### PR TITLE
feat(daemon): autonomy-loss detector — intent marker + heartbeat + host-side watchdog (#4011)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -1375,6 +1375,10 @@ concurrency ceiling 5" and share it with the team:
       "intervalSecs": 120,
       "expirySecs": 86400
     },
+    "heartbeat": {
+      "enabled": true,
+      "intervalSecs": 60
+    },
     "dispatchStaggerMs": 2000,
     "watchdog": {
       "enabled": true,
@@ -1882,6 +1886,89 @@ depending on `bootout` timing. `loom-daemon-stop.sh` also re-verifies (scoped to
 its launchd label) that no daemon is still alive after the stop and exits non-zero
 if one is, closing the silent-success hole where a failed bootout could leave a
 relaunched daemon dispatching.
+
+### Autonomy-loss watchdog + heartbeat (#4011)
+
+**The failure this closes.** On 2026-07-26 the `loom-daemon` launchd job took a
+SIGTERM two seconds after starting and was left `bootout`-ed (unloaded) from
+launchd. Autonomous dispatch silently stopped, and **nothing surfaced it** — no
+log line, no forge signal, no notification. It was discovered hours later only
+because someone happened to run `loom-daemon status` by hand. `loom-daemon
+status` is a *pull*, and that pull is exactly the thing that didn't happen.
+
+The fix is a *host-side* detector that lives **outside** the daemon process — a
+dead daemon cannot report its own death (which is why #3971's in-daemon watch
+loop is not reusable as the reporter). It has three cooperating parts:
+
+1. **Durable autonomy-desired marker** (`<loom_dir>/autonomy-desired`).
+   `loom-daemon-start.sh` writes it on a successful start; **only** an
+   operator-initiated `loom-daemon-stop.sh` removes it. Its lifetime is
+   **operator intent**, not process liveness — deliberately, because both of the
+   "obvious" markers (the pid file, the loaded launchd job) are destroyed by the
+   very stop path that causes an outage, so a detector built on them could not
+   tell a deliberately-stopped daemon from a silently-dead one. The marker
+   records the paths + label the watchdog needs (heartbeat file, cadence,
+   pid file, launchd label, `use_launchd`).
+
+2. **Declared-cadence heartbeat** (`<loom_dir>/daemon.heartbeat`, `loom-daemon/src/daemon_heartbeat.rs`).
+   The running daemon rewrites it every `intervalSecs` (default 60s). This is an
+   *explicit* liveness contract, chosen over piggybacking on the token-ranking
+   `.ranking` mtime (#3969) — that is a config-disableable side effect, so a
+   detector keyed to it would silently stop working when someone turned that loop
+   off. Default-on (read-only, no dispatch side effect); opt out with
+   `LOOM_DAEMON_HEARTBEAT=0` / `autonomous.heartbeat.enabled=false`.
+
+3. **Host-side watchdog** (`loom-daemon-watchdog.sh`), the payload of a **second
+   launchd job** (`<daemon-label>-watchdog`) that `loom-daemon-start.sh`
+   provisions on macOS with a `StartInterval` cadence (default 300s). Each run
+   compares intent (marker present?) against reality (daemon loaded + alive?
+   heartbeat fresh?) and, on divergence, appends a loud line to
+   `<loom_dir>/logs/daemon-watchdog.log` and stderr (which launchd captures).
+
+| File | Env override | Config key | Default |
+|------|--------------|-----------|---------|
+| heartbeat cadence | `LOOM_DAEMON_HEARTBEAT_INTERVAL_SECS` | `autonomous.heartbeat.intervalSecs` | `60` |
+| heartbeat on/off | `LOOM_DAEMON_HEARTBEAT` | `autonomous.heartbeat.enabled` | `true` (on) |
+| watchdog interval | `LOOM_WATCHDOG_INTERVAL_SECS` | — | `300` |
+| staleness threshold | `LOOM_DAEMON_HEARTBEAT_STALE_SECS` | — | `max(5 × cadence, 300)` |
+
+**Why `StartInterval`, not a resident process or `KeepAlive`.** The reporter must
+itself be supervised, but a long-lived resident watchdog just moves the
+who-watches-the-watchdog problem up a level (it too can crash and stay dead). A
+`StartInterval` job owns no long-lived process: launchd re-runs it every interval
+regardless of how the last run exited, so it structurally cannot
+crash-and-stay-dead. `KeepAlive` is deliberately **not** set — it would busy-loop
+a short-lived job. The watchdog exit code (`0` healthy / no daemon expected, `1`
+divergence) is for testability + a human running it by hand; a `StartInterval`
+job's exit code does not affect relaunch.
+
+**Decision matrix** (marker present ⇒ a daemon is expected):
+
+| Reality | Watchdog |
+|---------|----------|
+| daemon alive, heartbeat fresh | silent (OK) |
+| daemon alive, heartbeat **stale** | **report** — daemon may be wedged |
+| daemon alive, no heartbeat file | silent (liveness-only; heartbeat disabled or not yet written) |
+| daemon **not loaded/alive** | **report** — the #4011 outage |
+| marker **absent** | silent — deliberate stop, no false page |
+
+**Marker lifetime across a self-update.** `loom-daemon-update.sh` performs an
+internal stop→start, which is a **restart**, not operator intent to stop — so it
+passes `loom-daemon-stop.sh --restarting` (equivalently
+`LOOM_DAEMON_STOP_KEEP_INTENT=1`), which **preserves** the marker + watchdog. This
+is load-bearing: inferring restart-vs-stop would mean every self-update silently
+disarms the detector — the exact bug class #4011 fixes — so it is an explicit
+signal, never an inference. The subsequent start re-writes the marker and
+re-provisions the watchdog.
+
+**Platform + isolation.** The scheduled watchdog is a launchd job, so on Linux /
+the `--no-launchd` nohup path there is no host-side checker provisioned — the
+marker + heartbeat are still written, and `loom-daemon-watchdog.sh` can be run by
+hand or wired to a cron / systemd timer to consume them. `<loom_dir>` is the
+parent of `LOOM_SOCKET_PATH` (else `~/.loom`), so pointing `LOOM_SOCKET_PATH` at a
+tempdir isolates the marker + heartbeat there too — which is how the lifecycle
+tests avoid ever touching the operator's real `~/.loom`. A forge-side reporting
+channel is an explicit follow-up (out of scope for #4011).
 
 ### macOS session-bootstrap hazard (#3972)
 

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -219,6 +219,121 @@ render_launchd_plist() {
     printf '</dict>\n</plist>\n'
 }
 
+# ---------- autonomy-desired intent marker (#4011) ----------
+# Write the durable "a daemon is EXPECTED to be running on this host" marker on a
+# successful start. Its LIFETIME is operator intent, NOT process liveness: only
+# an operator-initiated loom-daemon-stop.sh removes it, and it is deliberately
+# PRESERVED across the internal stop loom-daemon-update.sh performs (via
+# LOOM_DAEMON_STOP_KEEP_INTENT). The host-side watchdog (loom-daemon-watchdog.sh)
+# reads it to decide whether a missing daemon is a silent failure (marker present
+# ⇒ report) or a deliberate stop (marker absent ⇒ stay silent). Records the paths
+# and label the watchdog needs so it can probe reality without re-deriving them.
+# Args: <use_launchd true|false> <launchd_label>
+write_intent_marker() {
+    local use_launchd="$1" label="$2"
+    mkdir -p "$LOOM_DIR" 2>/dev/null || true
+    (
+        umask 077
+        cat > "$INTENT_MARKER" <<EOF
+# loom autonomy-desired marker (issue #4011)
+# Presence ⇒ a loom-daemon is EXPECTED to be running on this host. Written by
+# loom-daemon-start.sh on a successful start; removed ONLY by an
+# operator-initiated loom-daemon-stop.sh (preserved across update.sh restarts).
+# Do not hand-edit — delete via loom-daemon-stop.sh so the watchdog stays quiet.
+started_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+repo_root=$REPO_ROOT
+pid_file=$PID_FILE
+heartbeat_file=$HEARTBEAT_FILE
+heartbeat_interval_secs=$HEARTBEAT_INTERVAL_SECS
+use_launchd=$use_launchd
+launchd_label=$label
+socket_path=$SOCKET_PATH
+EOF
+    )
+}
+
+# ---------- watchdog LaunchAgent (#4011) ----------
+# The watchdog is the payload of a SECOND launchd job that runs on a
+# StartInterval cadence, SEPARATE from the daemon job, and reports when intent
+# (the marker above) diverges from reality (daemon not loaded/alive, or heartbeat
+# stale). It uses StartInterval and NOT KeepAlive: a KeepAlive'd short-lived job
+# would busy-loop, whereas StartInterval already re-runs it every interval
+# regardless of how the last run exited — which is exactly what makes an interval
+# job unable to "crash and stay dead" (the who-watches-the-watchdog resolution).
+resolve_watchdog_label() {
+    echo "${LOOM_WATCHDOG_LABEL:-$(resolve_launchd_label)-watchdog}"
+}
+
+# Locate the installed watchdog script (installed copy first, then the defaults/
+# copy for a Loom source checkout that has not yet synced), mirroring the daemon
+# binary/script resolution elsewhere.
+locate_watchdog_script() {
+    local candidate
+    for candidate in \
+        "$REPO_ROOT/.loom/scripts/cli/loom-daemon-watchdog.sh" \
+        "$REPO_ROOT/defaults/scripts/cli/loom-daemon-watchdog.sh"; do
+        if [[ -f "$candidate" ]]; then echo "$candidate"; return 0; fi
+    done
+    echo ""
+}
+
+# render_watchdog_plist <label> <watchdog_script> <workdir> <log_path> <interval_secs>
+render_watchdog_plist() {
+    local label="$1" script="$2" workdir="$3" log_path="$4" interval="$5"
+    local plist_path_value="${PATH}:${HOME}/.local/bin:${HOME}/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    printf '<?xml version="1.0" encoding="UTF-8"?>\n'
+    printf '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
+    printf '<plist version="1.0">\n<dict>\n'
+    printf '    <key>Label</key>\n    <string>%s</string>\n' "$(xml_escape "$label")"
+    printf '    <key>ProgramArguments</key>\n    <array>\n        <string>/bin/bash</string>\n        <string>%s</string>\n    </array>\n' "$(xml_escape "$script")"
+    printf '    <key>WorkingDirectory</key>\n    <string>%s</string>\n' "$(xml_escape "$workdir")"
+    printf '    <key>EnvironmentVariables</key>\n    <dict>\n'
+    printf '        <key>PATH</key>\n        <string>%s</string>\n' "$(xml_escape "$plist_path_value")"
+    printf '        <key>HOME</key>\n        <string>%s</string>\n' "$(xml_escape "$HOME")"
+    printf '        <key>LOOM_AUTONOMY_MARKER</key>\n        <string>%s</string>\n' "$(xml_escape "$INTENT_MARKER")"
+    printf '        <key>LOOM_SOCKET_PATH</key>\n        <string>%s</string>\n' "$(xml_escape "$SOCKET_PATH")"
+    printf '        <key>LOOM_LAUNCHD_LABEL</key>\n        <string>%s</string>\n' "$(xml_escape "$(resolve_launchd_label)")"
+    printf '    </dict>\n'
+    printf '    <key>RunAtLoad</key>\n    <true/>\n'
+    printf '    <key>StartInterval</key>\n    <integer>%s</integer>\n' "$interval"
+    printf '    <key>ProcessType</key>\n    <string>Background</string>\n'
+    printf '    <key>StandardOutPath</key>\n    <string>%s</string>\n' "$(xml_escape "$log_path")"
+    printf '    <key>StandardErrorPath</key>\n    <string>%s</string>\n' "$(xml_escape "$log_path")"
+    printf '</dict>\n</plist>\n'
+}
+
+# Provision + (re)load the watchdog LaunchAgent. Best-effort and NON-FATAL: a
+# watchdog that fails to install must never fail the daemon start (the daemon
+# running without a watchdog is strictly better than no daemon at all).
+provision_watchdog_job() {
+    [[ "$IS_DARWIN" == "true" ]] || { warn "watchdog: not Darwin — skipping (marker+heartbeat still active; no scheduled checker on this platform)."; return 0; }
+    command -v launchctl >/dev/null 2>&1 || { warn "watchdog: launchctl not found — skipping."; return 0; }
+    local script; script="$(locate_watchdog_script)"
+    if [[ -z "$script" ]]; then
+        warn "watchdog: loom-daemon-watchdog.sh not found — skipping (autonomy-loss detection disabled)."
+        return 0
+    fi
+    local wd_label wd_service wd_plist wd_interval wd_log
+    wd_label="$(resolve_watchdog_label)"
+    wd_service="gui/$(id -u)/${wd_label}"
+    wd_plist="$HOME/Library/LaunchAgents/${wd_label}.plist"
+    wd_interval="${LOOM_WATCHDOG_INTERVAL_SECS:-300}"
+    wd_log="$LOOM_DIR/logs/daemon-watchdog.log"
+    mkdir -p "$HOME/Library/LaunchAgents" "$LOOM_DIR/logs" 2>/dev/null || true
+    if ! render_watchdog_plist "$wd_label" "$script" "$REPO_ROOT" "$wd_log" "$wd_interval" > "$wd_plist" 2>/dev/null; then
+        warn "watchdog: could not write $wd_plist — skipping."
+        return 0
+    fi
+    if launchctl print "$wd_service" >/dev/null 2>&1; then
+        launchctl bootout "$wd_service" >/dev/null 2>&1 || true
+    fi
+    if launchctl bootstrap "gui/$(id -u)" "$wd_plist" >/dev/null 2>&1; then
+        echo "Watchdog:       $wd_label (StartInterval ${wd_interval}s) → $wd_log"
+    else
+        warn "watchdog: launchctl bootstrap failed for $wd_service — autonomy-loss detection not active (non-fatal)."
+    fi
+}
+
 # ---------- args ----------
 # Capture the raw invocation args before the parsing loop consumes "$@" — used
 # below to persist exactly what was passed (Issue #3968: `loom-daemon-update.sh`
@@ -267,6 +382,19 @@ PID_FILE="$REPO_ROOT/.loom/.daemon.pid"
 SOCKET_PATH="${LOOM_SOCKET_PATH:-$HOME/.loom/loom-daemon.sock}"
 START_LOG="$REPO_ROOT/.loom/logs/daemon-start.log"
 mkdir -p "$REPO_ROOT/.loom/logs"
+
+# ---------- autonomy-desired marker + heartbeat paths (#4011) ----------
+# LOOM_DIR is the machine-level dir the daemon uses for its socket/log/heartbeat
+# — the parent of SOCKET_PATH, matching the daemon's own resolve_loom_dir()
+# (LOOM_SOCKET_PATH parent, else ~/.loom). Pointing SOCKET_PATH at a tempdir (as
+# the lifecycle tests do) therefore isolates the marker + heartbeat there too,
+# never touching the operator's real ~/.loom.
+LOOM_DIR="$(dirname "$SOCKET_PATH")"
+INTENT_MARKER="${LOOM_AUTONOMY_MARKER:-$LOOM_DIR/autonomy-desired}"
+HEARTBEAT_FILE="$LOOM_DIR/daemon.heartbeat"
+# Kept in sync with the daemon-side default (daemon_heartbeat.rs) so the
+# watchdog's derived staleness threshold matches the real cadence.
+HEARTBEAT_INTERVAL_SECS="${LOOM_DAEMON_HEARTBEAT_INTERVAL_SECS:-60}"
 
 # ---------- already-running guard (PID file) ----------
 if [[ -f "$PID_FILE" ]]; then
@@ -469,8 +597,12 @@ if [[ "$USE_LAUNCHD" == "true" ]]; then
     fi
 
     echo "$daemon_pid" > "$PID_FILE"
+    # Record operator intent + arm the host-side autonomy-loss watchdog (#4011).
+    write_intent_marker "true" "$LAUNCHD_LABEL"
+    provision_watchdog_job
     ok "loom-daemon started under launchd (pid $daemon_pid, label $LAUNCHD_LABEL)."
     echo "PID file: $PID_FILE"
+    echo "Intent marker: $INTENT_MARKER"
     echo "Stop with: ./.loom/scripts/cli/loom-daemon-stop.sh"
     exit 0
 fi
@@ -495,6 +627,13 @@ if ! kill -0 "$daemon_pid" 2>/dev/null; then
 fi
 
 echo "$daemon_pid" > "$PID_FILE"
+# Record operator intent (#4011). The scheduled watchdog is a launchd job, so on
+# Linux / the nohup path there is no host-side checker to provision — the marker
+# + heartbeat are still written, and `loom-daemon-watchdog.sh` can be run by hand
+# or wired to a cron/systemd timer to consume them.
+write_intent_marker "false" ""
+provision_watchdog_job
 ok "loom-daemon started (pid $daemon_pid). PID file: $PID_FILE"
+echo "Intent marker: $INTENT_MARKER"
 echo "Stop with: ./.loom/scripts/cli/loom-daemon-stop.sh"
 exit 0

--- a/defaults/scripts/cli/loom-daemon-stop.sh
+++ b/defaults/scripts/cli/loom-daemon-stop.sh
@@ -40,13 +40,25 @@
 # the inverted-#4011 silent-success hole where a failed bootout could leave a
 # relaunched daemon dispatching while the script reported success.
 #
+# Autonomy-desired marker (#4011): a normal operator stop is INTENT to stop, so
+# it removes the durable `autonomy-desired` marker loom-daemon-start.sh wrote and
+# boots out the watchdog LaunchAgent — after that the watchdog correctly stays
+# silent (no daemon is expected). But the internal stop that
+# loom-daemon-update.sh performs is NOT operator intent to stop; it is a restart,
+# so update.sh passes --restarting (or LOOM_DAEMON_STOP_KEEP_INTENT=1) and this
+# script PRESERVES the marker + watchdog. Inferring restart-vs-stop would be
+# wrong (every self-update would silently disarm the detector — the exact bug
+# class #4011 fixes), so it must be an explicit signal.
+#
 # Usage:
-#   ./.loom/scripts/cli/loom-daemon-stop.sh            Graceful stop (SIGTERM -> SIGKILL)
-#   ./.loom/scripts/cli/loom-daemon-stop.sh --force    Skip the grace window (SIGKILL)
+#   ./.loom/scripts/cli/loom-daemon-stop.sh              Graceful stop (SIGTERM -> SIGKILL); clears the autonomy-desired marker
+#   ./.loom/scripts/cli/loom-daemon-stop.sh --force      Skip the grace window (SIGKILL)
+#   ./.loom/scripts/cli/loom-daemon-stop.sh --restarting Restart (update.sh): PRESERVE the marker + watchdog
 #   ./.loom/scripts/cli/loom-daemon-stop.sh --help
 #
 # Environment:
 #   LOOM_DAEMON_STOP_GRACE_SECS   Grace window before SIGKILL (default 10)
+#   LOOM_DAEMON_STOP_KEEP_INTENT  1/true/yes: preserve the autonomy-desired marker + watchdog (same as --restarting)
 #   LOOM_LAUNCHD_LABEL            macOS only: the LaunchAgent label to bootout (default com.rjwalters.loom-daemon)
 #   LOOM_DAEMON_LAUNCHD           macOS only: 0/false/no disables ALL launchd interaction
 #                                 (lookup + bootout), symmetric with loom-daemon-start.sh.
@@ -92,10 +104,17 @@ find_repo_root() {
 }
 
 FORCE=false
+# Preserve the autonomy-desired marker + watchdog across this stop? True for a
+# restart (update.sh), false for an operator stop. Env or --restarting.
+KEEP_INTENT=false
+if [[ "${LOOM_DAEMON_STOP_KEEP_INTENT:-}" =~ ^(1|true|yes|on)$ ]]; then
+    KEEP_INTENT=true
+fi
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --help|-h) show_help; exit 0 ;;
         --force|-f) FORCE=true; shift ;;
+        --restarting) KEEP_INTENT=true; shift ;;
         *) err "Unknown option '$1'"; echo "Use --help for usage" >&2; exit 1 ;;
     esac
 done
@@ -108,6 +127,27 @@ fi
 
 PID_FILE="$REPO_ROOT/.loom/.daemon.pid"
 GRACE_SECS="${LOOM_DAEMON_STOP_GRACE_SECS:-10}"
+
+# ---------- autonomy-desired marker + watchdog (#4011) ----------
+SOCKET_PATH="${LOOM_SOCKET_PATH:-$HOME/.loom/loom-daemon.sock}"
+LOOM_DIR="$(dirname "$SOCKET_PATH")"
+INTENT_MARKER="${LOOM_AUTONOMY_MARKER:-$LOOM_DIR/autonomy-desired}"
+
+# Remove the operator-intent marker and bump out the watchdog LaunchAgent. Only
+# called on an operator-initiated stop (NOT a --restarting update.sh stop). After
+# this the watchdog sees no marker and correctly stays silent — no false page on
+# a deliberate stop. Best-effort; failures never change the stop's exit status.
+teardown_autonomy_intent() {
+    rm -f "$INTENT_MARKER" 2>/dev/null || true
+    local wd_label wd_service
+    wd_label="${LOOM_WATCHDOG_LABEL:-${LAUNCHD_LABEL}-watchdog}"
+    wd_service="gui/$(id -u)/${wd_label}"
+    if [[ "$USE_LAUNCHD" == "true" ]] && command -v launchctl >/dev/null 2>&1; then
+        if launchctl print "$wd_service" >/dev/null 2>&1; then
+            launchctl bootout "$wd_service" >/dev/null 2>&1 || true
+        fi
+    fi
+}
 
 # ---------- launchd plumbing (macOS, #3972) ----------
 IS_DARWIN=false
@@ -184,6 +224,9 @@ if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
     warn "No running loom-daemon found (nothing to stop)."
     rm -f "$PID_FILE"
     launchd_bootout_if_loaded
+    if [[ "$KEEP_INTENT" != "true" ]]; then
+        teardown_autonomy_intent
+    fi
     exit 0
 fi
 
@@ -236,6 +279,14 @@ if launchd_job_loaded; then
 fi
 
 rm -f "$PID_FILE"
-ok "loom-daemon stopped (pid $pid)."
+# Operator stop ⇒ clear the autonomy-desired marker + watchdog so the detector
+# stays silent (no daemon is expected). A --restarting stop (update.sh) preserves
+# both so a self-update never silently disarms the detector (#4011).
+if [[ "$KEEP_INTENT" != "true" ]]; then
+    teardown_autonomy_intent
+    ok "loom-daemon stopped (pid $pid). Autonomy-desired marker cleared."
+else
+    ok "loom-daemon stopped (pid $pid). Autonomy-desired marker preserved (restart in progress)."
+fi
 echo "In-flight sweeps (if any) were left running by design; the next start reconciles them."
 exit 0

--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -438,7 +438,12 @@ else
 fi
 
 echo "Stopping loom-daemon..."
-if ! "$STOP_SCRIPT"; then
+# --restarting preserves the autonomy-desired marker + watchdog across this
+# internal stop (#4011): a self-update is NOT operator intent to stop, so the
+# detector must NOT be disarmed — otherwise every self-update would silently turn
+# off the very autonomy-loss detection this issue adds (the exact bug class it
+# fixes). The subsequent start re-writes the marker and re-provisions the watchdog.
+if ! "$STOP_SCRIPT" --restarting; then
     err "loom-daemon-stop.sh failed — NOT starting the new binary on top of a still-running old one."
     exit 1
 fi

--- a/defaults/scripts/cli/loom-daemon-watchdog.sh
+++ b/defaults/scripts/cli/loom-daemon-watchdog.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# loom-daemon-watchdog.sh - Host-side autonomy-loss detector for the RAW
+# loom-daemon process (Issue #4011).
+#
+# THE PROBLEM IT SOLVES
+#   On 2026-07-26 the loom-daemon launchd job took a SIGTERM two seconds after
+#   starting and was left `bootout`-ed (unloaded) from launchd. Autonomous
+#   dispatch (work finder, role runner) silently stopped. NOTHING surfaced it —
+#   no log line, no forge signal, no notification. It was discovered hours later
+#   only because someone happened to run `loom-daemon status` by hand. A pull
+#   nobody performed for hours is not a detector.
+#
+# WHAT THIS IS
+#   The payload of a SECOND launchd job (`<daemon-label>-watchdog`) that runs on
+#   a `StartInterval` cadence, SEPARATE from the daemon job. It compares two
+#   things:
+#     (1) operator INTENT — the durable `autonomy-desired` marker that
+#         loom-daemon-start.sh writes on a successful start and only an
+#         operator-initiated loom-daemon-stop.sh removes; and
+#     (2) REALITY — whether a daemon for the expected launchd label is actually
+#         loaded and alive, and whether its declared-cadence heartbeat file
+#         (written by the daemon, #4011) is fresh.
+#   When intent says "a daemon should be running" but reality disagrees, it
+#   REPORTS loudly (a timestamped line to the watchdog log + stderr, which
+#   launchd captures) instead of staying silent.
+#
+# WHY A SECOND LAUNCHD JOB, NOT A RESIDENT PROCESS
+#   The reporter must live OUTSIDE the daemon process: a dead daemon cannot
+#   report its own death (which is why #3971's in-daemon watch loop is not
+#   reusable here). And it must itself be supervised — but a long-lived resident
+#   watchdog just moves the "who watches the watchdog" problem up one level (it
+#   too can crash and stay dead). A `StartInterval` job owns NO long-lived
+#   process: launchd re-runs it every interval regardless of how the last run
+#   exited, so it structurally cannot crash-and-stay-dead. That is what resolves
+#   the recursion.
+#
+# WHY THE MARKER, NOT "is the pid file / launchd job present"
+#   loom-daemon-stop.sh boots out the job AND deletes the pid file, so after ANY
+#   stop those would be gone — making a deliberately-stopped daemon and a
+#   silently-dead one byte-identical. A detector built on them would page on
+#   every intentional stop or never page at all. The marker's lifetime is
+#   OPERATOR INTENT: present ⇒ a daemon is expected; absent ⇒ it was
+#   deliberately stopped (or never started) ⇒ stay silent.
+#
+# EXIT CODES (a StartInterval job's exit code does not affect relaunch — these
+# exist for testability and for a human running it by hand):
+#   0  no divergence — daemon healthy, OR no daemon is expected (marker absent)
+#   1  DIVERGENCE reported — a daemon is expected but is not running, or is
+#      running but its heartbeat is stale (possibly wedged)
+#   2  usage error
+#
+# Usage:
+#   ./.loom/scripts/cli/loom-daemon-watchdog.sh            Check once, report on divergence
+#   ./.loom/scripts/cli/loom-daemon-watchdog.sh --verbose  Also log the healthy/idle no-op cases
+#   ./.loom/scripts/cli/loom-daemon-watchdog.sh --help
+#
+# Environment:
+#   LOOM_AUTONOMY_MARKER           Path to the intent marker (default: derived
+#                                  from LOOM_SOCKET_PATH's dir, else ~/.loom/autonomy-desired)
+#   LOOM_WATCHDOG_LOG              Report log path (default: <loom dir>/logs/daemon-watchdog.log)
+#   LOOM_DAEMON_HEARTBEAT_STALE_SECS  Staleness threshold in seconds (default:
+#                                  max(5 × heartbeat cadence, 300))
+#   LOOM_SOCKET_PATH              Override the daemon socket (its dir is the loom dir)
+#   LOOM_LAUNCHD_LABEL            macOS: the DAEMON label to probe (default com.rjwalters.loom-daemon)
+#   LOOM_DAEMON_LAUNCHD          0/false/no: treat as a non-launchd (nohup) daemon; check the pid file only
+
+set -uo pipefail
+
+# ---------- output helpers ----------
+if [[ -t 2 ]]; then
+    RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+else
+    RED=''; GREEN=''; YELLOW=''; NC=''
+fi
+
+show_help() {
+    awk 'NR>=2 { if ($0 !~ /^#/) exit; sub(/^# ?/, ""); print }' "$0"
+}
+
+VERBOSE=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h) show_help; exit 0 ;;
+        --verbose|-v) VERBOSE=true; shift ;;
+        *) echo "Unknown option '$1' (use --help)" >&2; exit 2 ;;
+    esac
+done
+
+# ---------- path resolution (mirrors loom-daemon-start.sh / resolve_loom_dir) ----------
+SOCKET_PATH="${LOOM_SOCKET_PATH:-$HOME/.loom/loom-daemon.sock}"
+LOOM_DIR="$(dirname "$SOCKET_PATH")"
+MARKER="${LOOM_AUTONOMY_MARKER:-$LOOM_DIR/autonomy-desired}"
+WATCHDOG_LOG="${LOOM_WATCHDOG_LOG:-$LOOM_DIR/logs/daemon-watchdog.log}"
+
+# Append a timestamped line to the watchdog log (best-effort) and echo to
+# stderr, which launchd captures to the job's StandardErrorPath. This IS the
+# report — the durable, operator-visible signal that a pull never surfaced.
+report() {
+    local level="$1"; shift
+    local msg="$*"
+    local ts
+    ts="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    mkdir -p "$(dirname "$WATCHDOG_LOG")" 2>/dev/null || true
+    echo "$ts [$level] $msg" >> "$WATCHDOG_LOG" 2>/dev/null || true
+    case "$level" in
+        DIVERGENCE) echo -e "${RED}$ts [$level] $msg${NC}" >&2 ;;
+        OK)         [[ "$VERBOSE" == "true" ]] && echo -e "${GREEN}$ts [$level] $msg${NC}" >&2 ;;
+        *)          echo -e "${YELLOW}$ts [$level] $msg${NC}" >&2 ;;
+    esac
+}
+
+# ---------- 1. intent: is a daemon expected at all? ----------
+if [[ ! -f "$MARKER" ]]; then
+    # No marker ⇒ the daemon was deliberately stopped (or never started). This
+    # is the load-bearing quiet case: a detector that pages on an intentional
+    # stop gets muted by the operator and is worthless.
+    report OK "no autonomy-desired marker at $MARKER — no daemon expected; nothing to check."
+    exit 0
+fi
+
+# ---------- parse the marker (key=value; ignore comments/blanks) ----------
+marker_get() {
+    local key="$1"
+    # First matching `key=value` line; strip the key= prefix. Comments start '#'.
+    grep -E "^${key}=" "$MARKER" 2>/dev/null | head -n1 | cut -d= -f2-
+}
+
+HEARTBEAT_FILE="$(marker_get heartbeat_file)"
+HEARTBEAT_INTERVAL_SECS="$(marker_get heartbeat_interval_secs)"
+MARKER_USE_LAUNCHD="$(marker_get use_launchd)"
+MARKER_LABEL="$(marker_get launchd_label)"
+PID_FILE="$(marker_get pid_file)"
+
+# Fallbacks when the marker predates a field or the value is empty.
+[[ -z "$HEARTBEAT_FILE" ]] && HEARTBEAT_FILE="$LOOM_DIR/daemon.heartbeat"
+[[ "$HEARTBEAT_INTERVAL_SECS" =~ ^[0-9]+$ ]] || HEARTBEAT_INTERVAL_SECS=60
+[[ -z "$PID_FILE" ]] && PID_FILE=""
+
+# Env overrides win over the marker (a stop/start under a different label should
+# be probed with the current env, not a stale marker value).
+USE_LAUNCHD="${MARKER_USE_LAUNCHD:-true}"
+if [[ "${LOOM_DAEMON_LAUNCHD:-}" =~ ^(0|false|no)$ ]]; then
+    USE_LAUNCHD=false
+fi
+[[ "$(uname -s)" == "Darwin" ]] || USE_LAUNCHD=false
+LABEL="${LOOM_LAUNCHD_LABEL:-${MARKER_LABEL:-com.rjwalters.loom-daemon}}"
+
+# ---------- 2. reality: is the expected daemon actually alive? ----------
+daemon_alive=false
+liveness_detail=""
+if [[ "$USE_LAUNCHD" == "true" ]] && command -v launchctl >/dev/null 2>&1; then
+    service="gui/$(id -u)/${LABEL}"
+    launchd_pid="$(launchctl print "$service" 2>/dev/null | awk -F'= ' '/^[[:space:]]*pid = /{gsub(/[^0-9]/, "", $2); print $2; exit}')"
+    if [[ -n "$launchd_pid" ]] && kill -0 "$launchd_pid" 2>/dev/null; then
+        daemon_alive=true
+        liveness_detail="launchd job $service alive (pid $launchd_pid)"
+    else
+        liveness_detail="launchd job $service is not loaded/alive"
+    fi
+else
+    # Non-launchd (nohup / Linux) path: the pid file is the only liveness signal.
+    if [[ -n "$PID_FILE" && -f "$PID_FILE" ]]; then
+        pid="$(cat "$PID_FILE" 2>/dev/null || true)"
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+            daemon_alive=true
+            liveness_detail="pid $pid (from $PID_FILE) alive"
+        else
+            liveness_detail="pid file $PID_FILE present but pid not alive"
+        fi
+    else
+        liveness_detail="no live pid file at ${PID_FILE:-<none>}"
+    fi
+fi
+
+if [[ "$daemon_alive" != "true" ]]; then
+    report DIVERGENCE \
+        "A daemon is EXPECTED (autonomy-desired marker present, started $(marker_get started_at)) but is NOT running: ${liveness_detail}. Autonomous dispatch has stopped. Recover with: ./.loom/scripts/cli/loom-daemon-start.sh [flags]  (or 'loom-daemon status' to inspect)."
+    exit 1
+fi
+
+# ---------- 3. reality: is the heartbeat fresh? ----------
+# The daemon writes HEARTBEAT_FILE on a declared cadence (#4011). A live daemon
+# whose heartbeat has gone stale is likely wedged — still a process, but not
+# doing its periodic work. The threshold is a comfortable multiple of the
+# cadence so a single missed write never false-positives.
+STALE_SECS="${LOOM_DAEMON_HEARTBEAT_STALE_SECS:-}"
+if [[ ! "$STALE_SECS" =~ ^[0-9]+$ ]]; then
+    STALE_SECS=$(( HEARTBEAT_INTERVAL_SECS * 5 ))
+    (( STALE_SECS < 300 )) && STALE_SECS=300
+fi
+
+file_mtime() {
+    # Portable mtime (epoch secs): GNU `stat -c` vs BSD/macOS `stat -f`.
+    stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null
+}
+
+if [[ -f "$HEARTBEAT_FILE" ]]; then
+    mtime="$(file_mtime "$HEARTBEAT_FILE")"
+    if [[ "$mtime" =~ ^[0-9]+$ ]]; then
+        now="$(date -u +%s)"
+        age=$(( now - mtime ))
+        if (( age > STALE_SECS )); then
+            report DIVERGENCE \
+                "Daemon process is alive (${liveness_detail}) but its heartbeat ${HEARTBEAT_FILE} is STALE (${age}s old > ${STALE_SECS}s threshold) — the daemon may be wedged. Inspect with 'loom-daemon status'; consider ./.loom/scripts/cli/loom-daemon-stop.sh && ...start.sh."
+            exit 1
+        fi
+        report OK "daemon healthy (${liveness_detail}); heartbeat fresh (${age}s ≤ ${STALE_SECS}s)."
+        exit 0
+    fi
+    # Unreadable mtime — degrade to liveness-only rather than false-report.
+    report OK "daemon alive (${liveness_detail}); heartbeat mtime unreadable — liveness-only OK."
+    exit 0
+fi
+
+# No heartbeat file but the daemon is alive: either the heartbeat loop is
+# disabled (LOOM_DAEMON_HEARTBEAT=0) or the daemon just started and has not
+# written yet. Degrade to liveness-only — do NOT false-report, since the daemon
+# clearly IS running.
+report OK "daemon alive (${liveness_detail}); no heartbeat file at ${HEARTBEAT_FILE} (heartbeat disabled or not yet written) — liveness-only OK."
+exit 0

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -117,7 +117,17 @@ cat > "$BG_FAKE_BIN" <<'EOF'
 sleep 5
 EOF
 chmod +x "$BG_FAKE_BIN"
-( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$BG_FAKE_BIN" bash "$START_SCRIPT" --no-launchd >/dev/null 2>&1 )
+# LOOM_AUTONOMY_MARKER + LOOM_SOCKET_PATH pin the #4011 autonomy-desired marker
+# and heartbeat path into WORKDIR so a real start never writes the operator's
+# real ~/.loom/autonomy-desired. LOOM_WATCHDOG_LABEL is a scratch label so even
+# if the watchdog script were resolvable here, provisioning could not touch the
+# real com.rjwalters.loom-daemon-watchdog LaunchAgent.
+( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    LOOM_DAEMON_BIN="$BG_FAKE_BIN" \
+    LOOM_SOCKET_PATH="$WORKDIR/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$WORKDIR/.loom/autonomy-desired" \
+    LOOM_WATCHDOG_LABEL="com.example.loom-sandbox-$$-watchdog" \
+    bash "$START_SCRIPT" --no-launchd >/dev/null 2>&1 )
 bg_rc=$?
 assert_eq "0" "$bg_rc" "bare (zero-arg) background start exits 0 (no unbound-variable crash, #3968)"
 TESTS_RUN=$((TESTS_RUN + 1))
@@ -128,6 +138,19 @@ else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "${RED}✗${NC} bare start persists an EMPTY .loom/.daemon.flags (no autonomy flags to record)"
 fi
+# #4011: a successful start writes the durable autonomy-desired intent marker
+# (into the isolated WORKDIR location pinned above — never the real ~/.loom).
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -f "$WORKDIR/.loom/autonomy-desired" ]] \
+    && grep -q '^heartbeat_file=' "$WORKDIR/.loom/autonomy-desired" \
+    && grep -q '^use_launchd=false' "$WORKDIR/.loom/autonomy-desired"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} bare start writes the autonomy-desired marker with heartbeat + liveness fields (#4011)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} bare start writes the autonomy-desired marker with heartbeat + liveness fields (#4011)"
+fi
+
 # Clean up the background daemon this test started.
 if [[ -f "$WORKDIR/.loom/.daemon.pid" ]]; then
     kill "$(cat "$WORKDIR/.loom/.daemon.pid" 2>/dev/null)" 2>/dev/null || true

--- a/defaults/scripts/tests/test-loom-daemon-stop.sh
+++ b/defaults/scripts/tests/test-loom-daemon-stop.sh
@@ -263,6 +263,78 @@ else
     echo "  (skipping LOOM_DAEMON_LAUNCHD symmetry test — not Darwin)"
 fi
 
+# ---------- autonomy-desired marker lifecycle (#4011) ----------
+# Every case pins LOOM_AUTONOMY_MARKER into WORKDIR so it can NEVER touch the
+# operator's real ~/.loom/autonomy-desired.
+MARKER="$WORKDIR/.loom/autonomy-desired"
+
+# 4011-a. Operator stop on the "nothing to stop" path REMOVES the marker.
+mkdir -p "$WORKDIR/.loom"
+printf 'started_at=x\nlaunchd_label=%s\n' "$FAKE_LABEL" > "$MARKER"
+( cd "$WORKDIR" && LOOM_LAUNCHD_LABEL="$FAKE_LABEL" LOOM_AUTONOMY_MARKER="$MARKER" \
+    bash "$STOP_SCRIPT" >/dev/null 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ ! -f "$MARKER" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} operator stop removes the autonomy-desired marker (nothing-to-stop path)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} operator stop removes the autonomy-desired marker (nothing-to-stop path)"
+fi
+
+# 4011-b. --restarting PRESERVES the marker (the update.sh self-update path).
+printf 'started_at=x\nlaunchd_label=%s\n' "$FAKE_LABEL" > "$MARKER"
+( cd "$WORKDIR" && LOOM_LAUNCHD_LABEL="$FAKE_LABEL" LOOM_AUTONOMY_MARKER="$MARKER" \
+    bash "$STOP_SCRIPT" --restarting >/dev/null 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -f "$MARKER" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --restarting preserves the marker (self-update never disarms the detector)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --restarting preserves the marker (self-update never disarms the detector)"
+fi
+
+# 4011-c. LOOM_DAEMON_STOP_KEEP_INTENT=1 is the env equivalent of --restarting.
+printf 'started_at=x\n' > "$MARKER"
+( cd "$WORKDIR" && LOOM_LAUNCHD_LABEL="$FAKE_LABEL" LOOM_AUTONOMY_MARKER="$MARKER" \
+    LOOM_DAEMON_STOP_KEEP_INTENT=1 bash "$STOP_SCRIPT" >/dev/null 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -f "$MARKER" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} LOOM_DAEMON_STOP_KEEP_INTENT=1 preserves the marker"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} LOOM_DAEMON_STOP_KEEP_INTENT=1 preserves the marker"
+fi
+
+# 4011-d. Operator stop of a LIVE pid also removes the marker (SIGTERM path).
+printf 'started_at=x\n' > "$MARKER"
+( sleep 30 & echo $! > "$WORKDIR/.loom/.daemon.pid" )
+live_pid=$(cat "$WORKDIR/.loom/.daemon.pid")
+( cd "$WORKDIR" && LOOM_LAUNCHD_LABEL="$FAKE_LABEL" LOOM_AUTONOMY_MARKER="$MARKER" \
+    LOOM_DAEMON_STOP_GRACE_SECS=2 bash "$STOP_SCRIPT" >/dev/null 2>&1 )
+kill -9 "$live_pid" 2>/dev/null || true
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ ! -f "$MARKER" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} operator stop of a live daemon also clears the marker"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} operator stop of a live daemon also clears the marker"
+fi
+
+# 4011-e. --help documents the marker + --restarting.
+help_out2=$(bash "$STOP_SCRIPT" --help 2>/dev/null)
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$help_out2" | grep -q 'restarting' && echo "$help_out2" | grep -qi 'autonomy-desired'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --help documents --restarting and the autonomy-desired marker"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --help documents --restarting and the autonomy-desired marker"
+fi
+
 # ---------- summary ----------
 # Final suite-level decoy guard (#4078): nothing above should have killed the
 # by-name-matchable decoy spawned at suite start.

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -151,6 +151,14 @@ MINIMAL_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
 BASE_WORKDIR="$(mktemp -d)"
 
+# #4011: isolate the autonomy-desired marker + watchdog label suite-wide so a
+# restart path that reaches the real loom-daemon-start.sh can never write the
+# operator's real ~/.loom/autonomy-desired or provision the real
+# com.rjwalters.loom-daemon-watchdog LaunchAgent. Both are exported so every
+# sub-invocation (each cd'd into its own W* dir) inherits them.
+export LOOM_AUTONOMY_MARKER="$BASE_WORKDIR/autonomy-desired"
+export LOOM_WATCHDOG_LABEL="${LOOM_LAUNCHD_LABEL}-watchdog"
+
 # Suite-level decoy (#4078): a process whose argv ends in `/loom-daemon`, which
 # the stop script's label-blind `pgrep -f '(^|/)loom-daemon$'` fallback would
 # match. The whole update suite runs under a scratch LOOM_LAUNCHD_LABEL and

--- a/defaults/scripts/tests/test-loom-daemon-watchdog.sh
+++ b/defaults/scripts/tests/test-loom-daemon-watchdog.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# test-loom-daemon-watchdog.sh — Tests for loom-daemon-watchdog.sh, the host-side
+# autonomy-loss detector (issue #4011).
+#
+# The watchdog compares operator INTENT (the autonomy-desired marker) against
+# REALITY (daemon liveness + heartbeat freshness) and reports on divergence. This
+# suite drives it entirely from files it creates in a tempdir — a real daemon is
+# never started, and no invocation ever touches ~/.loom or the operator's real
+# launchd jobs (liveness is exercised through the pid-file path with
+# LOOM_DAEMON_LAUNCHD=0, plus one stubbed-launchctl case).
+#
+# Style matches the other daemon lifecycle tests — plain bash, hand-rolled
+# assertions. Bats is NOT used in this repository.
+#
+# Exit-code contract under test:
+#   0  no divergence (healthy, or no daemon expected)
+#   1  DIVERGENCE reported (expected-but-not-running, or wedged/stale heartbeat)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHDOG="$(cd "$SCRIPT_DIR/../cli" && pwd)/loom-daemon-watchdog.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "${GREEN}✓${NC} $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "${RED}✗${NC} $1"; }
+
+assert_rc() { # <expected> <actual> <msg>
+    if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 (expected rc=$1, got rc=$2)"; fi
+}
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+MARKER="$WORKDIR/autonomy-desired"
+HEARTBEAT="$WORKDIR/daemon.heartbeat"
+WDLOG="$WORKDIR/watchdog.log"      # the watchdog's own report log (LOOM_WATCHDOG_LOG)
+OUT="$WORKDIR/out.txt"             # captured stdout+stderr of each run (separate file)
+
+# Write a marker describing a non-launchd (pid-file) daemon so liveness is probed
+# via the pid file — deterministic and platform-independent.
+write_marker() { # <pid_file> <heartbeat_interval_secs>
+    cat > "$MARKER" <<EOF
+started_at=2026-07-27T00:00:00Z
+repo_root=$WORKDIR
+pid_file=$1
+heartbeat_file=$HEARTBEAT
+heartbeat_interval_secs=$2
+use_launchd=false
+launchd_label=com.example.test
+socket_path=$WORKDIR/loom-daemon.sock
+EOF
+}
+
+# Portable mtime back-dating (macOS `date -v`, GNU `date -d`).
+back_date_file() { # <file> <seconds_ago>
+    local f="$1" secs="$2" ts
+    ts=$(date -v-"${secs}"S '+%Y%m%d%H%M.%S' 2>/dev/null) \
+        || ts=$(date -d "@$(( $(date +%s) - secs ))" '+%Y%m%d%H%M.%S' 2>/dev/null)
+    [[ -n "$ts" ]] && touch -t "$ts" "$f" 2>/dev/null
+}
+
+# Run the watchdog on the pid-file path (LOOM_DAEMON_LAUNCHD=0). Extra env
+# assignments may be passed as KEY=VAL positional args. Sets global RC.
+run_watchdog() {
+    : > "$OUT"
+    env "$@" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
+        LOOM_DAEMON_LAUNCHD=0 bash "$WATCHDOG" > "$OUT" 2>&1
+    RC=$?
+}
+
+log_has()  { grep -q "$1" "$WDLOG" 2>/dev/null; }
+log_hasi() { grep -qi "$1" "$WDLOG" 2>/dev/null; }
+
+# A live pid we own for the "daemon alive" cases. The sleeper's stdio is
+# redirected to /dev/null so it does NOT hold open the `$(sleeper)` command
+# substitution pipe (which would otherwise block the caller for the full sleep).
+sleeper() { sleep 60 >/dev/null 2>&1 & echo $!; }
+
+# ===================================================================
+# 1. Marker ABSENT ⇒ no daemon expected ⇒ silent OK (exit 0).
+# ===================================================================
+rm -f "$MARKER" "$HEARTBEAT" "$WDLOG"
+run_watchdog
+assert_rc 0 "$RC" "marker absent: exits 0 (no daemon expected)"
+if log_has DIVERGENCE; then fail "marker absent: unexpected DIVERGENCE"; else pass "marker absent: no DIVERGENCE reported"; fi
+
+# ===================================================================
+# 2. Intent present, daemon ALIVE, heartbeat FRESH ⇒ silent OK.
+# ===================================================================
+live_pid=$(sleeper)
+echo "$live_pid" > "$WORKDIR/pidA"
+write_marker "$WORKDIR/pidA" 60
+printf '%s pid=%s ts=now\n' "$(date +%s)" "$live_pid" > "$HEARTBEAT"
+: > "$WDLOG"
+run_watchdog
+kill "$live_pid" 2>/dev/null || true
+assert_rc 0 "$RC" "alive + fresh heartbeat: exits 0"
+
+# ===================================================================
+# 3. Intent present, daemon ALIVE, heartbeat STALE ⇒ DIVERGENCE (wedged).
+# ===================================================================
+live_pid=$(sleeper)
+echo "$live_pid" > "$WORKDIR/pidB"
+write_marker "$WORKDIR/pidB" 60
+printf 'old\n' > "$HEARTBEAT"
+back_date_file "$HEARTBEAT" 3600   # 1h old, well past the 300s default threshold
+: > "$WDLOG"
+run_watchdog
+kill "$live_pid" 2>/dev/null || true
+assert_rc 1 "$RC" "alive + STALE heartbeat: exits 1 (divergence)"
+if log_has STALE; then pass "alive + stale heartbeat: reports it as wedged/stale"; else fail "alive + stale heartbeat: no STALE report"; fi
+
+# ===================================================================
+# 4. Intent present, daemon DEAD ⇒ DIVERGENCE (expected but not running).
+#    This IS the #4011 outage, reproduced.
+# ===================================================================
+dead_pid=$(sleeper); kill "$dead_pid" 2>/dev/null; wait "$dead_pid" 2>/dev/null
+echo "$dead_pid" > "$WORKDIR/pidC"
+write_marker "$WORKDIR/pidC" 60
+printf 'x\n' > "$HEARTBEAT"
+: > "$WDLOG"
+run_watchdog
+assert_rc 1 "$RC" "daemon DEAD but expected: exits 1 (the #4011 outage)"
+if log_has EXPECTED && log_hasi "not"; then
+    pass "daemon dead: reports 'expected but not running'"
+else
+    fail "daemon dead: missing the expected-but-not-running report"
+fi
+
+# ===================================================================
+# 5. Intent present, daemon ALIVE, NO heartbeat file ⇒ liveness-only OK.
+#    (heartbeat disabled or not yet written — do NOT false-report.)
+# ===================================================================
+live_pid=$(sleeper)
+echo "$live_pid" > "$WORKDIR/pidD"
+write_marker "$WORKDIR/pidD" 60
+rm -f "$HEARTBEAT"
+: > "$WDLOG"
+run_watchdog
+kill "$live_pid" 2>/dev/null || true
+assert_rc 0 "$RC" "alive + no heartbeat file: exits 0 (liveness-only, no false page)"
+
+# ===================================================================
+# 6. Staleness threshold is a comfortable multiple of the cadence: a heartbeat
+#    just under the default 300s threshold is NOT reported (no flapping).
+# ===================================================================
+live_pid=$(sleeper)
+echo "$live_pid" > "$WORKDIR/pidE"
+write_marker "$WORKDIR/pidE" 60
+printf 'x\n' > "$HEARTBEAT"
+back_date_file "$HEARTBEAT" 120   # 2min old < 300s threshold ⇒ still fresh
+: > "$WDLOG"
+run_watchdog
+kill "$live_pid" 2>/dev/null || true
+assert_rc 0 "$RC" "heartbeat 120s old < 300s threshold: not flagged (no flapping)"
+
+# ===================================================================
+# 7. LOOM_DAEMON_HEARTBEAT_STALE_SECS override is honored.
+# ===================================================================
+live_pid=$(sleeper)
+echo "$live_pid" > "$WORKDIR/pidF"
+write_marker "$WORKDIR/pidF" 60
+printf 'x\n' > "$HEARTBEAT"
+back_date_file "$HEARTBEAT" 10
+: > "$WDLOG"
+run_watchdog LOOM_DAEMON_HEARTBEAT_STALE_SECS=5
+kill "$live_pid" 2>/dev/null || true
+assert_rc 1 "$RC" "STALE_SECS override: 10s-old heartbeat with 5s threshold is flagged"
+
+# ===================================================================
+# 8. launchd path via a stubbed launchctl reporting the job is NOT loaded ⇒
+#    DIVERGENCE (mirrors a booted-out daemon).
+# ===================================================================
+STUB_BIN="$WORKDIR/stubbin"
+mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/launchctl" <<'EOF'
+#!/usr/bin/env bash
+# Stub: `print` always reports the job is not loaded (exit 1); no real job touched.
+case "${1:-}" in
+  print) exit 1 ;;
+  *)     exit 0 ;;
+esac
+EOF
+chmod +x "$STUB_BIN/launchctl"
+cat > "$MARKER" <<EOF
+started_at=2026-07-27T00:00:00Z
+heartbeat_file=$HEARTBEAT
+heartbeat_interval_secs=60
+use_launchd=true
+launchd_label=com.example.loom-sandbox-$$
+socket_path=$WORKDIR/loom-daemon.sock
+EOF
+: > "$WDLOG" "$OUT"
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    env PATH="$STUB_BIN:$PATH" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
+        bash "$WATCHDOG" > "$OUT" 2>&1
+    assert_rc 1 "$?" "launchd path: booted-out job (stub print exit 1) ⇒ divergence"
+else
+    # On non-Darwin the watchdog forces the pid-file path; with no pid_file in the
+    # marker that resolves to "no live pid" ⇒ divergence, which is still correct.
+    env LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" bash "$WATCHDOG" > "$OUT" 2>&1
+    assert_rc 1 "$?" "non-Darwin: expected daemon with no live pid ⇒ divergence"
+fi
+
+# ===================================================================
+# 9. --help works and documents the marker + StartInterval design.
+# ===================================================================
+help_out=$(bash "$WATCHDOG" --help 2>/dev/null)
+if echo "$help_out" | grep -qi 'autonomy-desired' && echo "$help_out" | grep -qi 'StartInterval'; then
+    pass "--help documents the marker + StartInterval rationale"
+else
+    fail "--help missing marker/StartInterval documentation"
+fi
+
+echo
+echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/loom-daemon/src/daemon_heartbeat.rs
+++ b/loom-daemon/src/daemon_heartbeat.rs
@@ -1,0 +1,493 @@
+//! Declared-cadence daemon liveness heartbeat (issue #4011).
+//!
+//! # Why
+//!
+//! On 2026-07-26 the `loom-daemon` launchd job took a SIGTERM two seconds after
+//! starting and was left `bootout`-ed (unloaded) from launchd. Autonomous
+//! dispatch silently stopped, and **nothing surfaced it** — no log line, no
+//! forge signal, no notification. It was discovered hours later only because
+//! someone happened to run `loom-daemon status` by hand.
+//!
+//! The fix (this issue's AC #1 / AC #2) is a *host-side* detector that lives
+//! **outside** the daemon process — a dead daemon cannot report its own death,
+//! which is why #3971's in-daemon watch loop is not reusable as the reporter.
+//! That detector (`loom-daemon-watchdog.sh`, run as a second `StartInterval`
+//! launchd job) needs a liveness signal it can read without talking to the
+//! daemon. This module emits it: a heartbeat file the running daemon touches on
+//! a **declared cadence**.
+//!
+//! # Why an explicit heartbeat, not an existing mtime
+//!
+//! The token-ranking refresh loop (#3969) already rewrites
+//! `.loom/tokens/.ranking` on a ~10-minute cadence, so its mtime is an
+//! *accidental* liveness signal. We deliberately do **not** build on it: it is a
+//! side effect rather than a contract, and it is config-disableable
+//! (`autonomous.tokenRankingRefresh`), so a detector keyed to it would silently
+//! stop working when an operator turned that loop off. This module writes a file
+//! whose *only* purpose is liveness, with a documented cadence the watchdog's
+//! staleness threshold is derived from.
+//!
+//! # Where
+//!
+//! The heartbeat lives at `<loom_dir>/daemon.heartbeat`, where `<loom_dir>` is
+//! resolved exactly like the daemon's socket/log paths: the parent of
+//! `LOOM_SOCKET_PATH` when set (so a test daemon pointed at a tempdir socket
+//! writes its heartbeat into that tempdir, never the operator's real
+//! `~/.loom/daemon.heartbeat`), else `~/.loom`. This mirrors `resolve_loom_dir`
+//! / `resolve_log_path` in `main.rs` (#4010).
+//!
+//! # Default-on
+//!
+//! Like the token-ranking refresh (#3969) and watch-monitor (#3971) loops, and
+//! unlike the dispatch-affecting work-finder / main-health-gate loops, this loop
+//! is **default-on**: it only ever writes a small bookkeeping file with no
+//! dispatch side effect, and an absent heartbeat is precisely the signal the
+//! watchdog needs. An operator can still opt out
+//! (`LOOM_DAEMON_HEARTBEAT=0` / `autonomous.heartbeat.enabled=false`); the
+//! watchdog degrades to a liveness-only check when no heartbeat is present.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/// Environment variable controlling the heartbeat loop. Default-on (see module
+/// docs): set to `0`/`false`/`no`/`off` (case-insensitive) to disable;
+/// `1`/`true`/`yes`/`on` to force-enable even when config disables it.
+pub const HEARTBEAT_ENABLE_ENV: &str = "LOOM_DAEMON_HEARTBEAT";
+
+/// Environment variable overriding the heartbeat cadence (seconds).
+pub const HEARTBEAT_INTERVAL_ENV: &str = "LOOM_DAEMON_HEARTBEAT_INTERVAL_SECS";
+
+/// Default heartbeat cadence. The watchdog's default staleness threshold
+/// (`loom-daemon-watchdog.sh`) is a comfortable multiple of this (5×), so a
+/// single missed write never trips a false report.
+pub const DEFAULT_HEARTBEAT_INTERVAL_SECS: u64 = 60;
+
+/// Basename of the heartbeat file under the resolved loom dir.
+pub const HEARTBEAT_FILENAME: &str = "daemon.heartbeat";
+
+// ============================================================================
+// Path resolution
+// ============================================================================
+
+/// Resolve `<loom_dir>` the same way `main.rs::resolve_loom_dir` does: the
+/// parent of `LOOM_SOCKET_PATH` when set, else `~/.loom`. Kept in sync with
+/// `main.rs` deliberately (both are tiny) rather than exported from `main`,
+/// which is a binary, not a library.
+fn resolve_loom_dir() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("LOOM_SOCKET_PATH") {
+        return PathBuf::from(path).parent().map(Path::to_path_buf);
+    }
+    dirs::home_dir().map(|h| h.join(".loom"))
+}
+
+/// Resolve the heartbeat file path (`<loom_dir>/daemon.heartbeat`), or `None`
+/// when no loom dir can be resolved (no home directory and no
+/// `LOOM_SOCKET_PATH`).
+#[must_use]
+pub fn resolve_heartbeat_path() -> Option<PathBuf> {
+    resolve_loom_dir().map(|d| d.join(HEARTBEAT_FILENAME))
+}
+
+// ============================================================================
+// Writing
+// ============================================================================
+
+/// Write one heartbeat record to `path` atomically (temp file + rename), so a
+/// concurrent watchdog read never sees a torn line. The record is a single line
+/// of `<unix_secs> pid=<pid> ts=<iso8601>` — the watchdog keys off the file's
+/// **mtime** for staleness, but the content is human-legible for diagnostics.
+///
+/// Returns `Err` with a human-readable reason on any I/O failure; the caller
+/// logs and continues (a failed heartbeat write is never fatal).
+pub fn write_heartbeat(path: &Path) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            return Err(format!("could not create {}: {e}", parent.display()));
+        }
+    }
+    let now = chrono::Utc::now();
+    let contents =
+        format!("{} pid={} ts={}\n", now.timestamp(), std::process::id(), now.to_rfc3339());
+    // Temp file in the same dir so the rename is atomic (same filesystem).
+    let tmp = path.with_extension(format!("heartbeat.tmp.{}", uuid::Uuid::new_v4()));
+    if let Err(e) = std::fs::write(&tmp, &contents) {
+        return Err(format!("could not write temp heartbeat {}: {e}", tmp.display()));
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!("could not rename heartbeat into place {}: {e}", path.display()));
+    }
+    Ok(())
+}
+
+// ============================================================================
+// Config (.loom/config.json → autonomous.heartbeat)
+// ============================================================================
+
+/// The subset of `.loom/config.json → autonomous.heartbeat` this module
+/// consumes. Each field is `Option` so an absent key falls through to the
+/// env-var / built-in-default resolution — precedence **env > config >
+/// default**, matching every other `autonomous.*` surface.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct HeartbeatConfig {
+    /// `autonomous.heartbeat.enabled` — whether to run the loop. `None` when the
+    /// key is absent (falls through to env / default(**true**) — default-on).
+    pub enabled: Option<bool>,
+    /// `autonomous.heartbeat.intervalSecs` — cadence in seconds (a zero/invalid
+    /// value is dropped to `None`).
+    pub interval_secs: Option<u64>,
+}
+
+/// Read `.loom/config.json → autonomous.heartbeat`, soft-failing every field to
+/// `None` (env/default resolution) on any of: missing file, malformed JSON, or
+/// a missing `autonomous` / `heartbeat` block. Mirrors the soft-fail contract of
+/// [`crate::token_ranking_refresh::read_token_ranking_refresh_config`].
+#[must_use]
+pub fn read_heartbeat_config(repo_root: &Path) -> HeartbeatConfig {
+    let config_path = repo_root.join(".loom").join("config.json");
+
+    let config_str = match std::fs::read_to_string(&config_path) {
+        Ok(s) => s,
+        Err(e) => {
+            log::debug!(
+                "daemon_heartbeat: could not read config at {}: {e}",
+                config_path.display()
+            );
+            return HeartbeatConfig::default();
+        }
+    };
+
+    let config: serde_json::Value = match serde_json::from_str(&config_str) {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn!(
+                "daemon_heartbeat: could not parse config at {}: {e}",
+                config_path.display()
+            );
+            return HeartbeatConfig::default();
+        }
+    };
+
+    let Some(block) = config.get("autonomous").and_then(|a| a.get("heartbeat")) else {
+        return HeartbeatConfig::default();
+    };
+
+    HeartbeatConfig {
+        enabled: block.get("enabled").and_then(serde_json::Value::as_bool),
+        interval_secs: block
+            .get("intervalSecs")
+            .and_then(serde_json::Value::as_u64)
+            .filter(|&s| s > 0),
+    }
+}
+
+/// Resolve whether the loop is enabled with precedence **env > config >
+/// default(true)** — default-on (see module docs).
+#[must_use]
+pub fn resolve_enabled(config: &HeartbeatConfig) -> bool {
+    if let Ok(v) = std::env::var(HEARTBEAT_ENABLE_ENV) {
+        return matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on");
+    }
+    config.enabled.unwrap_or(true)
+}
+
+/// Resolve the heartbeat cadence with precedence **env > config > default**. A
+/// zero or unparseable env value falls through to `config`/the default rather
+/// than producing a busy loop.
+#[must_use]
+pub fn resolve_interval(config: &HeartbeatConfig) -> Duration {
+    std::env::var(HEARTBEAT_INTERVAL_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .or(config.interval_secs)
+        .map_or_else(|| Duration::from_secs(DEFAULT_HEARTBEAT_INTERVAL_SECS), Duration::from_secs)
+}
+
+// ============================================================================
+// Runtime wiring
+// ============================================================================
+
+/// Spawn the heartbeat loop on the shared daemon runtime. The **first tick is
+/// not skipped** — the heartbeat is written immediately at boot so the watchdog
+/// has fresh data within one cadence of the daemon coming up, then every
+/// `interval` thereafter. A write failure is logged and the loop continues (the
+/// next tick retries); it is never fatal to the daemon.
+///
+/// Returns `None` (and logs a warning) when no heartbeat path can be resolved —
+/// the daemon still runs, only without a heartbeat, and the watchdog degrades to
+/// a liveness-only check.
+#[must_use]
+pub fn spawn_heartbeat_task(interval: Duration) -> Option<tokio::task::JoinHandle<()>> {
+    let path = match resolve_heartbeat_path() {
+        Some(p) => p,
+        None => {
+            log::warn!(
+                "daemon_heartbeat: could not resolve a heartbeat path (no home dir / \
+                 LOOM_SOCKET_PATH) — heartbeat disabled for this run"
+            );
+            return None;
+        }
+    };
+    log::info!(
+        "daemon_heartbeat: starting loop (path={}, interval={}s)",
+        path.display(),
+        interval.as_secs()
+    );
+    Some(tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            ticker.tick().await;
+            match write_heartbeat(&path) {
+                Ok(()) => log::debug!("daemon_heartbeat: wrote {}", path.display()),
+                Err(reason) => log::warn!(
+                    "daemon_heartbeat: write failed (logged, never fatal; will retry next tick): {reason}"
+                ),
+            }
+        }
+    }))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::fs;
+    use std::time::Instant;
+
+    fn write_config(root: &Path, contents: &str) {
+        fs::create_dir_all(root.join(".loom")).unwrap();
+        fs::write(root.join(".loom").join("config.json"), contents).unwrap();
+    }
+
+    // ===================================================================
+    // write_heartbeat
+    // ===================================================================
+
+    #[test]
+    fn test_write_heartbeat_creates_file_with_expected_shape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("daemon.heartbeat");
+        write_heartbeat(&path).unwrap();
+        let contents = fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("pid="), "{contents:?}");
+        assert!(contents.contains("ts="), "{contents:?}");
+        // First token is a unix timestamp (all digits).
+        let first = contents.split_whitespace().next().unwrap();
+        assert!(first.chars().all(|c| c.is_ascii_digit()), "{first:?}");
+    }
+
+    #[test]
+    fn test_write_heartbeat_creates_parent_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("nested")
+            .join("dir")
+            .join("daemon.heartbeat");
+        write_heartbeat(&path).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn test_write_heartbeat_overwrites_in_place() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("daemon.heartbeat");
+        write_heartbeat(&path).unwrap();
+        let first = fs::read_to_string(&path).unwrap();
+        // Sleep a hair so the timestamp differs, then rewrite.
+        std::thread::sleep(Duration::from_millis(1100));
+        write_heartbeat(&path).unwrap();
+        let second = fs::read_to_string(&path).unwrap();
+        assert_ne!(first, second, "second write should carry a newer timestamp");
+        // No stray temp files left behind.
+        let leftovers: Vec<_> = fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files should be renamed away: {leftovers:?}");
+    }
+
+    // ===================================================================
+    // Path resolution
+    // ===================================================================
+
+    #[test]
+    #[serial]
+    fn test_resolve_heartbeat_path_honors_socket_path_env() {
+        let tmp = tempfile::tempdir().unwrap();
+        let socket = tmp.path().join("loom-daemon.sock");
+        std::env::set_var("LOOM_SOCKET_PATH", &socket);
+        let resolved = resolve_heartbeat_path().unwrap();
+        assert_eq!(resolved, tmp.path().join(HEARTBEAT_FILENAME));
+        std::env::remove_var("LOOM_SOCKET_PATH");
+    }
+
+    // ===================================================================
+    // Config surface — autonomous.heartbeat
+    // ===================================================================
+
+    #[test]
+    fn test_config_missing_file_is_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(read_heartbeat_config(tmp.path()), HeartbeatConfig::default());
+    }
+
+    #[test]
+    fn test_config_malformed_json_is_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), "{not valid json");
+        assert_eq!(read_heartbeat_config(tmp.path()), HeartbeatConfig::default());
+    }
+
+    #[test]
+    fn test_config_missing_block_is_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"autonomous": {"workFinder": {"enabled": true}}}"#);
+        assert_eq!(read_heartbeat_config(tmp.path()), HeartbeatConfig::default());
+    }
+
+    #[test]
+    fn test_config_reads_enabled_and_interval() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(
+            tmp.path(),
+            r#"{"autonomous": {"heartbeat": {"enabled": false, "intervalSecs": 30}}}"#,
+        );
+        assert_eq!(
+            read_heartbeat_config(tmp.path()),
+            HeartbeatConfig {
+                enabled: Some(false),
+                interval_secs: Some(30)
+            }
+        );
+    }
+
+    #[test]
+    fn test_config_zero_interval_is_dropped_to_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"autonomous": {"heartbeat": {"intervalSecs": 0}}}"#);
+        assert_eq!(read_heartbeat_config(tmp.path()).interval_secs, None);
+    }
+
+    // ===================================================================
+    // Precedence — env > config > default
+    // ===================================================================
+
+    #[test]
+    #[serial]
+    fn test_resolve_enabled_default_is_true() {
+        std::env::remove_var(HEARTBEAT_ENABLE_ENV);
+        assert!(
+            resolve_enabled(&HeartbeatConfig::default()),
+            "absent config + unset env ⇒ default ON (default-on loop)"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_enabled_config_can_disable() {
+        std::env::remove_var(HEARTBEAT_ENABLE_ENV);
+        assert!(!resolve_enabled(&HeartbeatConfig {
+            enabled: Some(false),
+            interval_secs: None
+        }));
+        assert!(resolve_enabled(&HeartbeatConfig {
+            enabled: Some(true),
+            interval_secs: None
+        }));
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_enabled_env_overrides_config() {
+        std::env::set_var(HEARTBEAT_ENABLE_ENV, "0");
+        assert!(!resolve_enabled(&HeartbeatConfig {
+            enabled: Some(true),
+            interval_secs: None
+        }));
+        std::env::set_var(HEARTBEAT_ENABLE_ENV, "1");
+        assert!(resolve_enabled(&HeartbeatConfig {
+            enabled: Some(false),
+            interval_secs: None
+        }));
+        std::env::remove_var(HEARTBEAT_ENABLE_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_interval_default_config_and_env_precedence() {
+        std::env::remove_var(HEARTBEAT_INTERVAL_ENV);
+        assert_eq!(
+            resolve_interval(&HeartbeatConfig::default()),
+            Duration::from_secs(DEFAULT_HEARTBEAT_INTERVAL_SECS)
+        );
+        assert_eq!(
+            resolve_interval(&HeartbeatConfig {
+                enabled: None,
+                interval_secs: Some(30)
+            }),
+            Duration::from_secs(30)
+        );
+        std::env::set_var(HEARTBEAT_INTERVAL_ENV, "15");
+        assert_eq!(
+            resolve_interval(&HeartbeatConfig {
+                enabled: None,
+                interval_secs: Some(30)
+            }),
+            Duration::from_secs(15)
+        );
+        std::env::set_var(HEARTBEAT_INTERVAL_ENV, "0");
+        assert_eq!(
+            resolve_interval(&HeartbeatConfig {
+                enabled: None,
+                interval_secs: Some(30)
+            }),
+            Duration::from_secs(30)
+        );
+        std::env::remove_var(HEARTBEAT_INTERVAL_ENV);
+    }
+
+    // ===================================================================
+    // Loop wiring
+    // ===================================================================
+
+    #[tokio::test]
+    async fn test_loop_writes_immediately_and_refreshes_mtime() {
+        let tmp = tempfile::tempdir().unwrap();
+        let socket = tmp.path().join("loom-daemon.sock");
+        std::env::set_var("LOOM_SOCKET_PATH", &socket);
+        let path = tmp.path().join(HEARTBEAT_FILENAME);
+
+        let handle = spawn_heartbeat_task(Duration::from_millis(30)).unwrap();
+
+        // Written within one interval (first tick is immediate).
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !path.exists() {
+            assert!(Instant::now() < deadline, "heartbeat file never appeared");
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        let first = fs::metadata(&path).unwrap().modified().unwrap();
+
+        // A later tick refreshes the mtime.
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let now = fs::metadata(&path).unwrap().modified().unwrap();
+            if now > first {
+                break;
+            }
+            assert!(Instant::now() < deadline, "heartbeat mtime never advanced");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        handle.abort();
+        std::env::remove_var("LOOM_SOCKET_PATH");
+    }
+}

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -15,6 +15,7 @@ pub mod capacity;
 pub mod claim_reconciliation;
 pub mod config_resolver;
 pub mod cpu_headroom;
+pub mod daemon_heartbeat;
 pub mod disk_headroom;
 pub mod epic_state;
 pub mod epic_supervisor;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -1,5 +1,6 @@
 use loom_daemon::activity::{self, ActivityDb, StatsQueries};
 use loom_daemon::claim_reconciliation;
+use loom_daemon::daemon_heartbeat;
 use loom_daemon::epic_supervisor;
 use loom_daemon::event_bus::EventBus;
 use loom_daemon::health_monitor;
@@ -787,6 +788,31 @@ async fn main() -> Result<()> {
             );
             None
         };
+
+    // Declared-cadence liveness heartbeat (Issue #4011): the daemon touches
+    // `<loom_dir>/daemon.heartbeat` on a fixed cadence so a host-side watchdog
+    // (`loom-daemon-watchdog.sh`, a second StartInterval launchd job) can detect
+    // "a daemon should be running but isn't" WITHOUT talking to the daemon — a
+    // dead daemon cannot report its own death, so the reporter must live outside
+    // this process. Default-ON like the token-ranking refresh / watch-monitor
+    // loops (it only writes a small bookkeeping file with no dispatch side
+    // effect); opt out with `LOOM_DAEMON_HEARTBEAT=0` /
+    // `autonomous.heartbeat.enabled=false`. We deliberately do NOT reuse the
+    // token-ranking `.ranking` mtime as an accidental heartbeat: that is a
+    // config-disableable side effect, so a detector keyed to it would silently
+    // stop working when that loop is turned off.
+    let heartbeat_config = daemon_heartbeat::read_heartbeat_config(&sweep_workspace);
+    let _heartbeat_handle = if daemon_heartbeat::resolve_enabled(&heartbeat_config) {
+        let interval = daemon_heartbeat::resolve_interval(&heartbeat_config);
+        log::info!("daemon_heartbeat: enabled (interval={}s)", interval.as_secs());
+        daemon_heartbeat::spawn_heartbeat_task(interval)
+    } else {
+        log::debug!(
+            "daemon_heartbeat: disabled (set LOOM_DAEMON_HEARTBEAT=1 or \
+             autonomous.heartbeat.enabled=true to opt in)"
+        );
+        None
+    };
 
     // Autonomous periodic support-role runner (Issue #4015): dispatches the
     // standalone support roles (Champion, Curator, Judge, Auditor, Guide)


### PR DESCRIPTION
Closes #4011

## Problem

On 2026-07-26 the `loom-daemon` launchd job took a SIGTERM two seconds after starting and was left `bootout`-ed (unloaded) from launchd. Autonomous dispatch silently stopped, and **nothing surfaced it** — no log line, no forge signal, no notification. It was found hours later only because someone happened to run `loom-daemon status` by hand. That pull is exactly the thing that didn't happen.

## Scope (Champion-approved AC1 + AC2 only)

Per the pinned scope on the issue: **AC1 (detect "a daemon should be running but isn't") + AC2 (report without an operator thinking to look)**. AC3 (status disambiguation) is excised to #4069; AC4 (self-modification guard) shipped as #4054/#4077; flipping `KeepAlive` and a forge-side channel are explicit out-of-scope follow-ups.

## Mechanism — three cooperating parts, reporter lives OUTSIDE the daemon

A dead daemon cannot report its own death (which is why #3971's in-daemon watch loop is not reusable as the reporter).

1. **Durable autonomy-desired marker** (`<loom_dir>/autonomy-desired`). Written by `loom-daemon-start.sh` on a successful start; removed **only** by an operator-initiated `loom-daemon-stop.sh`. Its lifetime is **operator intent**, not process liveness — the pid file and loaded launchd job are both destroyed by the very stop path that causes an outage, so a detector built on them couldn't tell a deliberate stop from a silent death. `loom-daemon-update.sh` passes `stop --restarting` (`LOOM_DAEMON_STOP_KEEP_INTENT=1`) so a self-update never silently disarms the detector — an **explicit** signal, never inferred.

2. **Declared-cadence heartbeat** (`<loom_dir>/daemon.heartbeat`, new `loom-daemon/src/daemon_heartbeat.rs`). The daemon rewrites it every `intervalSecs` (default 60, default-on, `autonomous.heartbeat` / `LOOM_DAEMON_HEARTBEAT*`). Deliberately an **explicit** liveness contract, not the config-disableable `.ranking` mtime (#3969).

3. **Host-side watchdog** (`loom-daemon-watchdog.sh`), the payload of a **second** launchd job (`<label>-watchdog`) that `start.sh` provisions on macOS with `StartInterval` (default 300s). It compares intent vs reality (daemon loaded + alive? heartbeat fresh?) and reports divergence to `<loom_dir>/logs/daemon-watchdog.log` + stderr. `StartInterval` (not `KeepAlive`/resident) resolves who-watches-the-watchdog: an interval job owns no long-lived process, so it structurally cannot crash-and-stay-dead.

### Decision matrix (marker present ⇒ a daemon is expected)

| Reality | Watchdog |
|---|---|
| alive, heartbeat fresh | silent |
| alive, heartbeat **stale** | **report** (wedged) |
| alive, no heartbeat file | silent (liveness-only) |
| **not loaded/alive** | **report** (the #4011 outage) |
| marker **absent** | silent (deliberate stop — no false page) |

## Tests

- **14 Rust unit tests** (`daemon_heartbeat`): write/atomic-rename, path resolution, config soft-fail, env>config>default precedence, loop writes-immediately-and-refreshes-mtime.
- **12-case watchdog divergence matrix** (`test-loom-daemon-watchdog.sh`): dead / stale / fresh / no-heartbeat / marker-absent / under-threshold-no-flap / `STALE_SECS` override / launchd-stub / help.
- **Marker lifecycle** across start/stop (`test-loom-daemon-{start,stop}.sh`): written on start; removed on operator stop; **preserved** on `--restarting` and `LOOM_DAEMON_STOP_KEEP_INTENT=1`.
- All five daemon lifecycle suites pass (start 11, stop 22, update 33, launchd-plist 26, watchdog 12) + full daemon lib suite (1044). `render_launchd_plist`'s `KeepAlive`/`RunAtLoad` are untouched (Correction 1 honored). Every test pins `LOOM_AUTONOMY_MARKER`/`LOOM_SOCKET_PATH` into a tempdir so none can touch the operator's real `~/.loom`; `shellcheck --severity=warning` and `cargo clippy`/`cargo fmt --check` are clean.

## Docs

`.loom/docs/daemon-reference.md` gains an "Autonomy-loss watchdog + heartbeat (#4011)" section (mechanism, config table, decision matrix, the `--restarting` self-update contract, Linux/`--no-launchd` degradation) plus the `autonomous.heartbeat` config block.

## Meta-risk

This edits the very scripts whose failure caused the outage. Correctness is covered by the automated suites above; a real host stop/start/update cycle against an isolated `LOOM_LAUNCHD_LABEL` is the recommended manual verification before enabling in production (never against the live `com.rjwalters.loom-daemon`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)