### PR TITLE
fix(mcp): settle unary daemon request on first newline frame, not on connection close

### DIFF
--- a/.loom/docs/troubleshooting.md
+++ b/.loom/docs/troubleshooting.md
@@ -281,6 +281,30 @@ grep -c dispatch_sweep dist/index.js   # should now be > 0
 
 `scripts/setup-mcp.sh` now auto-rebuilds when `dist/index.js` is missing **or** older than any file under `mcp-loom/src/` (#3803), so `./scripts/setup-mcp.sh` is the safe one-shot path. Rebuilding the bundle does **not** refresh an already-running session — an MCP client caches its tool list at connect time, so you must **restart the Claude Code session** (or respawn the `loom` MCP subprocess) for the new tools to appear. See [`mcp-loom/README.md`](../../mcp-loom/README.md#rebuilding-after-source-changes-reconnect-required) for the full rebuild + reconnect procedure and a raw `tools/list` verification snippet.
 
+### MCP tools hang with no response (~1800s), then abort
+
+**Symptom**: `mcp__loom__dispatch_sweep`, `mcp__loom__get_sweep_status`, `mcp__loom__list_sweeps`, or `mcp__loom__cancel_sweep` return **no response and no progress**, and are eventually aborted by the client (`sent no response or progress for 1800s; aborting`) — even though the underlying operation **succeeded** (the sweep child spawned, the PR opened, etc.). The CLI path (`loom-daemon status` / `dispatch`) stays fast throughout, which isolates the fault to the MCP/IPC response path, not a wedged daemon.
+
+**Cause** (#4043): the MCP bridge's unary request transport (`mcp-loom/src/shared/daemon.ts` `sendDaemonRequest`) historically settled its promise only in the socket's `end` handler. The real `loom-daemon` holds each connection **open by design** (a persistent per-connection read loop, `loom-daemon/src/ipc.rs` `handle_client`): it writes one newline-delimited JSON response frame per request and never closes after answering. So the response sat complete-but-unparsed in the client buffer while the promise waited forever for an `end` that never came. A **stale bundle** (`mcp-loom/dist/` older than `mcp-loom/src/`) compounds it by discarding the per-call timeout, turning a diagnosable failure into the full ~1800s idle hang.
+
+**Diagnose** — probe the raw socket (bypassing the MCP layer) and check the bundle for the timeout string:
+
+```bash
+# Does the bundle even carry the bounded-timeout fix? 0 => stale, pre-timeout bundle
+grep -c "did not respond within" mcp-loom/dist/index.js
+
+# Is dist/ older than src/? (any output => stale, rebuild needed)
+find mcp-loom/src -type f -newer mcp-loom/dist/index.js
+```
+
+**Fix** — the transport now settles on the **first newline-delimited response frame** (in the `data` handler) and closes the socket after settling, so it no longer depends on the daemon closing the connection. If you are on a pre-fix bundle, rebuild and reconnect:
+
+```bash
+cd mcp-loom && npm install && npm run build   # then restart the Claude Code session
+```
+
+The `claude-wrapper.sh` MCP pre-flight (`check_mcp_server`) now rebuilds a stale bundle before the smoke test, so a fresh session on an up-to-date checkout self-heals; the regression is guarded by `mcp-loom/scripts/verify-daemon-timeout.mjs`'s respond-without-close stub case (`npm run verify:daemon-timeout`).
+
 ### Inspect running sweeps
 
 ```bash

--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -359,8 +359,9 @@ resolve_mcp_workspace() {
 
 # Pre-flight check: verify MCP server can start
 # Attempts to launch the mcp-loom Node.js server and checks for the startup
-# message on stderr. If the dist/ directory is missing or stale, attempts
-# a rebuild before retrying.
+# message on stderr. If the built bundle is missing, or is stale (older than
+# any file under the sibling src/ tree), it rebuilds before the smoke test; a
+# smoke-test failure also triggers a rebuild-and-retry.
 check_mcp_server() {
     local mcp_workspace
     mcp_workspace=$(resolve_mcp_workspace)
@@ -396,6 +397,25 @@ for name, srv in servers.items():
         log_warn "MCP entry point missing: ${mcp_entry}"
         _try_mcp_rebuild "${mcp_entry}"
         return $?
+    fi
+
+    # Staleness check: a bundle older than any file under the sibling src/ tree
+    # is startable but lacks recent fixes (a smoke test passes on it silently).
+    # Rebuild before the smoke test. This mirrors the predicate in
+    # scripts/setup-mcp.sh (the one-shot .mcp.json generator) exactly so the two
+    # gates cannot drift (issue #4043). Rebuild failure on an otherwise-startable
+    # bundle is non-fatal — fall through to the smoke test below.
+    local mcp_src
+    mcp_src="$(dirname "$(dirname "${mcp_entry}")")/src"
+    if [[ -d "${mcp_src}" ]] && \
+       [[ -n "$(find "${mcp_src}" -type f -newer "${mcp_entry}" -print -quit 2>/dev/null)" ]]; then
+        log_warn "MCP bundle is stale (src newer than dist) - rebuilding: ${mcp_entry}"
+        if ! _try_mcp_rebuild "${mcp_entry}"; then
+            log_warn "MCP rebuild for stale bundle failed - continuing with existing bundle"
+        else
+            # Rebuild succeeded and already re-verified the smoke test.
+            return 0
+        fi
     fi
 
     # Smoke test: start MCP server and verify it emits the startup message

--- a/mcp-loom/scripts/verify-daemon-timeout.mjs
+++ b/mcp-loom/scripts/verify-daemon-timeout.mjs
@@ -12,6 +12,11 @@
  *   2. Happy case — server writes a JSON response frame then ends. Assert the
  *      call RESOLVES quickly and the timer was cleared (no regression to the
  *      fast path used by dispatch_sweep / list_sweeps / publish_event).
+ *   3. Real-daemon case — server writes a newline-delimited JSON response frame
+ *      and then KEEPS THE CONNECTION OPEN (never calls end/destroy), modeling
+ *      the real loom-daemon's persistent per-connection read loop. Assert the
+ *      call RESOLVES on the first frame without depending on connection close.
+ *      This case fails against a transport that settles only on `end` (#4043).
  *
  * Run: node scripts/verify-daemon-timeout.mjs   (from the mcp-loom dir)
  *
@@ -173,6 +178,49 @@ async function main() {
   check("resolved with expected payload", !!okResp && okResp.type === "EventPublished");
   check("resolved fast (timer cleared, no hang)", okElapsed < 1000, `elapsed=${okElapsed}ms`);
   await closeServer(okServer);
+
+  // ---- Case 3: real-daemon path (respond with a frame, never close) ----
+  // Models loom-daemon/src/ipc.rs `handle_client`: one `\n`-delimited response
+  // frame per request line, then the connection stays open for reuse. This is
+  // the regression guard for #4043 — a transport that settles only on the
+  // socket's `end` event hangs here (the server never ends) and this case
+  // FAILS, exactly reproducing the reported 1800s hang.
+  console.log("real-daemon path (respond then keep open)");
+  const heldReplySockets = [];
+  const persistentServer = await startStubServer(sockPath, (sock) => {
+    heldReplySockets.push(sock);
+    sock.on("data", () => {
+      // Answer with a newline-delimited frame, then deliberately do NOT
+      // end/destroy — the real daemon holds the connection open.
+      sock.write(JSON.stringify({ type: "SweepList", payload: { sweeps: [] } }));
+      sock.write("\n");
+    });
+  });
+
+  const persistentStart = Date.now();
+  let persistentResp = null;
+  let persistentErr = null;
+  try {
+    // A generous timeout so a FAILURE here is a genuine hang (settle-on-end
+    // regression), not a too-tight bound.
+    persistentResp = await sendDaemonRequest({ type: "ListSweeps", payload: { state_filter: null } }, 2000);
+  } catch (e) {
+    persistentErr = e;
+  }
+  const persistentElapsed = Date.now() - persistentStart;
+  check("resolved without waiting for close", persistentErr === null, persistentErr && persistentErr.message);
+  check(
+    "resolved with expected payload (first frame)",
+    !!persistentResp && persistentResp.type === "SweepList",
+    persistentResp && JSON.stringify(persistentResp)
+  );
+  check(
+    "resolved fast against a never-closing peer",
+    persistentElapsed < 1000,
+    `elapsed=${persistentElapsed}ms`
+  );
+  for (const s of heldReplySockets) s.destroy();
+  await closeServer(persistentServer);
 
   // Give the process a beat to confirm no lingering timer keeps it alive
   // (a leaked setTimeout would delay exit by the full timeout window).

--- a/mcp-loom/src/shared/daemon.ts
+++ b/mcp-loom/src/shared/daemon.ts
@@ -131,6 +131,12 @@ export async function sendDaemonRequest(
       if (settled) return;
       settled = true;
       clearTimer();
+      // Close the socket once we have our answer. The real daemon holds the
+      // connection open by design (a persistent per-connection read loop, see
+      // loom-daemon/src/ipc.rs `handle_client`), so we must send EOF ourselves
+      // for the daemon's `next_line()` to reap the connection — otherwise a
+      // half-open connection accumulates on the daemon per unary call.
+      if (!socket.destroyed) socket.destroy();
       resolve(value);
     };
     const settleReject = (error: Error) => {
@@ -141,11 +147,31 @@ export async function sendDaemonRequest(
       reject(error);
     };
 
+    // Settle on the FIRST complete newline-delimited response frame, mirroring
+    // the framing `sendDaemonStreamRequest` and the Rust CLI (main.rs:1477)
+    // already use. The daemon writes one `\n`-terminated JSON response per
+    // request line and then keeps the socket open for reuse — it never closes
+    // after answering — so waiting for `end` here would hang forever against
+    // the real daemon even though the response is already in `buffer` (#4043).
     socket.on("data", (data) => {
+      if (settled) return;
       buffer += data.toString();
+      const nl = buffer.indexOf("\n");
+      if (nl === -1) return; // frame not complete yet
+      const line = buffer.slice(0, nl);
+      try {
+        const response = JSON.parse(line);
+        settleResolve(response);
+      } catch (error) {
+        settleReject(new Error(`Failed to parse daemon response: ${error}`));
+      }
     });
 
+    // Fallback for a peer that closes after responding without a trailing
+    // newline (e.g. a close-after-respond stub server). The real daemon never
+    // reaches here; the `data` handler settles first.
     socket.on("end", () => {
+      if (settled) return;
       try {
         const response = JSON.parse(buffer);
         settleResolve(response);


### PR DESCRIPTION
## Summary

Fixes the ~1800s hang where `mcp__loom__dispatch_sweep` / `get_sweep_status` (and the other unary MCP tools) returned no response even though the daemon operation succeeded. The MCP bridge's unary transport (`sendDaemonRequest`) settled its promise **only** in the socket's `end` handler, but the real `loom-daemon` holds each connection open by design (a persistent per-connection read loop, `loom-daemon/src/ipc.rs` `handle_client`) and never closes after writing its one newline-delimited response frame. The response therefore sat complete-but-unparsed in the client buffer while the promise waited forever for an `end` that never came. A stale `dist/` bundle compounded it by discarding the per-call timeout, extending the failure to the client's full ~1800s idle abort.

## Changes

- **`mcp-loom/src/shared/daemon.ts`** (primary fix): `sendDaemonRequest` now settles on the **first complete `\n`-delimited frame** in the `data` handler — mirroring `sendDaemonStreamRequest` and the Rust CLI (`main.rs:1477`) — then closes the socket so the daemon's `next_line()` reaps the connection (no accumulating half-open connections). The `end` handler is retained as a close-after-respond fallback; the timeout remains as a genuine error-signal safety net. No daemon-side framing changes.
- **`mcp-loom/scripts/verify-daemon-timeout.mjs`**: adds a third stub case whose server responds with a newline-delimited frame and **does NOT close** (modeling the real daemon). Verified to **fail** against the pre-fix transport (hangs to the 2000ms bound) and **pass** after — the regression guard against a fourth recurrence.
- **`defaults/scripts/claude-wrapper.sh`**: `check_mcp_server()` gains a staleness branch before the smoke test that rebuilds when `dist/index.js` is older than any file under the sibling `src/` (mirroring `scripts/setup-mcp.sh:29-32`'s predicate exactly), invoking the existing `_try_mcp_rebuild()`. Non-fatal if rebuild fails but the bundle still starts. The `check_mcp_server` header comment is corrected to match. `.loom/scripts/claude-wrapper.sh` (gitignored installed copy) is deliberately untouched.
- **`.loom/docs/troubleshooting.md`**: new "MCP tools hang with no response (~1800s)" entry with the raw-socket / `grep -c "did not respond within"` diagnosis and the rebuild remedy.

## Acceptance Criteria Verification

- [x] `sendDaemonRequest` resolves on the first newline-delimited frame; does not depend on connection close (verified by the new respond-without-close harness case resolving in <1s).
- [x] Client closes the socket after settling (`socket.destroy()` in `settleResolve`).
- [x] Timeout still fires with the greppable "did not respond within" message against a never-responding server (existing hang cases pass).
- [x] `verify-daemon-timeout.mjs` gains a respond-without-close case that **fails** against the pre-fix transport (proven by stashing the fix: 3 checks failed) and passes after.
- [x] `check_mcp_server()` detects a bundle older than any file under `src/` and rebuilds before the smoke test with a greppable warning; rebuild failure on a startable bundle warns and continues (staleness predicate tested in isolation: fresh=no-op, stale=rebuild, no-src=no-op).
- [x] The `claude-wrapper.sh` comment matches implemented behavior.
- [x] No changes to `loom-daemon/src/` framing.

## Test Plan

- [x] `cd mcp-loom && npm run build` (tsc --noEmit + esbuild) passes.
- [x] `npm run verify:daemon-timeout` — all cases pass (hang → bounded rejection; respond-then-end → resolves; **respond-without-close → resolves**).
- [x] Regression proof: stashing the `daemon.ts` fix makes the new case fail (3 checks failed, hangs to the 2000ms bound), confirming it covers the defect.
- [x] `bash -n defaults/scripts/claude-wrapper.sh` passes; staleness predicate verified in isolation (fresh / stale / src-absent).

Live end-to-end checks (dispatch/cancel against a running daemon, connection-hygiene `lsof` sweep) require a live daemon + token pool and are left for the Judge/operator environment.

Closes #4043