### PR TITLE
fix(daemon): manage launchd-installed daemon in loom-daemon-update.sh

### DIFF
--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -33,6 +33,23 @@
 #     stopped (this script never widens FLAGS-OFF by starting autonomy that
 #     wasn't already running).
 #
+# Launchd-managed daemons (#4042): on Darwin the daemon is commonly launchd-
+# managed (default since #3972/#4054), in which case NEITHER .loom/.daemon.pid
+# nor .loom/.daemon.flags reliably reflects "is it running" — the pid file goes
+# stale after any KeepAlive:SuccessfulExit relaunch, and a hand-bootstrapped
+# daemon has no state files at all. This script therefore checks the launchd job
+# state (`launchctl print gui/<uid>/<label>`, mirroring loom-daemon-stop.sh)
+# AHEAD of the pid-file tier when resolving whether/how the daemon is running.
+# When launchd-managed, it restarts via the `loom-daemon restart` primitive
+# (#4077 — sends Request::RestartDaemon over the IPC socket; the supervised
+# daemon exits 0 and launchd relaunches it onto the fresh binary with the
+# plist's persisted ProgramArguments/EnvironmentVariables). .daemon.flags is NOT
+# consulted in this mode (the plist's EnvironmentVariables IS the durable flag
+# source), and no "restarting FLAGS-OFF" warning fires. If the running (old)
+# binary predates #4077 and refuses the request, this script REFUSES LOUDLY
+# (exit 6) with the manual bootout/bootstrap fallback rather than reporting a
+# half-update — the exact #4011 silent-autonomy-loss class this closes.
+#
 # Usage:
 #   ./.loom/scripts/cli/loom-daemon-update.sh              Detect, rebuild if stale, provision, restart (preserving flags)
 #   ./.loom/scripts/cli/loom-daemon-update.sh --check       Detect only; exit 0 (up to date) or 3 (update available); no writes
@@ -48,6 +65,14 @@
 #                          exact path instead of the machine-level default.
 #   LOOM_DAEMON_BIN_DIR   Machine-level install dir (default ~/.local/bin),
 #                          forwarded to provision-daemon.sh.
+#   LOOM_DAEMON_LAUNCHD    macOS only: 0/false/no disables ALL launchd interaction
+#                          (ownership detection + launchd restart), symmetric with
+#                          loom-daemon-start.sh / loom-daemon-stop.sh. A daemon
+#                          started with --no-launchd / LOOM_DAEMON_LAUNCHD=0 gets
+#                          an update that never reads the machine-global launchd
+#                          domain and follows the PID-file/nohup restart path.
+#   LOOM_LAUNCHD_LABEL     macOS only: the LaunchAgent label to inspect/restart
+#                          (default com.rjwalters.loom-daemon).
 #
 # Exit codes:
 #   0  up to date (no-op) OR rebuild+provision+restart succeeded
@@ -62,6 +87,11 @@
 #      claimed-successful provision is not the expected build (a silent no-op
 #      roll — "reports success while shipping nothing"). Distinct from both a
 #      compile failure and a provisioning soft-failure (#4053).
+#   6  launchd restart FAILED: the daemon is launchd-managed but the running
+#      (old) binary refused the `loom-daemon restart` IPC request (a pre-#4077
+#      binary with no RestartDaemon handler, or a dead socket). The fresh binary
+#      IS provisioned but the OLD one is still running; the script refuses to
+#      report success and prints the manual bootout/bootstrap fallback (#4042).
 #
 # See also: loom-daemon-start.sh (writes .loom/.daemon.flags), loom-daemon-stop.sh
 # (SIGTERM -> grace -> SIGKILL; in-flight sweeps survive by design — this
@@ -249,8 +279,60 @@ advisory_behind_origin() {
 }
 advisory_behind_origin "$REPO_ROOT"
 
+# ---------- launchd ownership detection (macOS, mirrors loom-daemon-stop.sh #4042) ----------
+# launchd is checked AHEAD of the .loom/.daemon.pid tier because the plist's
+# KeepAlive:SuccessfulExit assigns a FRESH pid on every supervised relaunch, so
+# the pid file goes stale after the first relaunch even for a launchd job that
+# loom-daemon-start.sh itself started; a hand-bootstrapped daemon has no state
+# files at all. Honors LOOM_DAEMON_LAUNCHD symmetrically with start/stop.sh so a
+# --no-launchd install never reaches into the machine-global launchd domain.
+IS_DARWIN=false
+[[ "$(uname -s)" == "Darwin" ]] && IS_DARWIN=true
+USE_LAUNCHD="$IS_DARWIN"
+if [[ "${LOOM_DAEMON_LAUNCHD:-}" =~ ^(0|false|no)$ ]]; then
+    USE_LAUNCHD=false
+fi
+DEFAULT_LAUNCHD_LABEL="com.rjwalters.loom-daemon"
+LAUNCHD_LABEL="${LOOM_LAUNCHD_LABEL:-$DEFAULT_LAUNCHD_LABEL}"
+LAUNCHD_SERVICE="gui/$(id -u)/${LAUNCHD_LABEL}"
+LAUNCHD_PLIST="$HOME/Library/LaunchAgents/${LAUNCHD_LABEL}.plist"
+
+launchd_job_loaded() {
+    [[ "$USE_LAUNCHD" == "true" ]] || return 1
+    command -v launchctl >/dev/null 2>&1 || return 1
+    launchctl print "$LAUNCHD_SERVICE" >/dev/null 2>&1
+}
+launchd_job_pid() {
+    launchctl print "$LAUNCHD_SERVICE" 2>/dev/null | awk -F'= ' '/^[[:space:]]*pid = /{gsub(/[^0-9]/, "", $2); print $2; exit}'
+}
+
+# Resolve which manager owns the running daemon: launchd (checked first), the
+# .loom/.daemon.pid file (nohup/script-managed), or none. WAS_RUNNING is derived
+# from this — a launchd-loaded job counts as running regardless of pid-file state.
+DAEMON_MANAGER="none"
+WAS_RUNNING=false
+if launchd_job_loaded; then
+    DAEMON_MANAGER="launchd"
+    WAS_RUNNING=true
+elif [[ -f "$PID_FILE" ]]; then
+    existing_pid=$(cat "$PID_FILE" 2>/dev/null || true)
+    if [[ -n "$existing_pid" ]] && kill -0 "$existing_pid" 2>/dev/null; then
+        DAEMON_MANAGER="pidfile"
+        WAS_RUNNING=true
+    fi
+fi
+
+describe_manager() {
+    case "$DAEMON_MANAGER" in
+        launchd) echo "Running daemon manager: launchd (label ${LAUNCHD_LABEL})." ;;
+        pidfile) echo "Running daemon manager: PID-file/nohup (.loom/.daemon.pid)." ;;
+        *)       echo "Running daemon manager: not running." ;;
+    esac
+}
+
 # ---------- --check: report only, no writes ----------
 if [[ "$CHECK_ONLY" == "true" ]]; then
+    describe_manager
     if [[ "$UPDATE_NEEDED" == "true" ]]; then
         warn "Update available (installed=${INSTALLED_COMMIT}, source=${SOURCE_COMMIT})."
         exit 3
@@ -270,14 +352,9 @@ if [[ "$UPDATE_NEEDED" == "false" ]]; then
 fi
 
 # ---------- resolve the restart plan up front (read-only; safe for --dry-run) ----------
-WAS_RUNNING=false
-if [[ -f "$PID_FILE" ]]; then
-    existing_pid=$(cat "$PID_FILE" 2>/dev/null || true)
-    if [[ -n "$existing_pid" ]] && kill -0 "$existing_pid" 2>/dev/null; then
-        WAS_RUNNING=true
-    fi
-fi
-
+# WAS_RUNNING + DAEMON_MANAGER were resolved above (launchd checked ahead of the
+# pid file). The flags below are only consulted for the pid-file/nohup restart
+# path — a launchd-managed restart replays flags from the plist, not this file.
 RESTART_ARGS=()
 FLAGS_SOURCE="none (defaulting to FLAGS-OFF bare restart)"
 if [[ -f "$FLAGS_FILE" ]]; then
@@ -297,6 +374,8 @@ if [[ "$DRY_RUN" == "true" ]]; then
     echo "[dry-run] Would provision the fresh binary to: $PROVISION_TARGET"
     if [[ "$NO_RESTART" == "true" ]]; then
         echo "[dry-run] --no-restart given: would leave the running daemon (if any) untouched."
+    elif [[ "$DAEMON_MANAGER" == "launchd" ]]; then
+        echo "[dry-run] loom-daemon is launchd-managed (label ${LAUNCHD_LABEL}) — would restart via '$PROVISION_TARGET restart' (the #4077 supervised primitive); .daemon.flags is NOT consulted (the plist's EnvironmentVariables carries the equivalent config)."
     elif [[ "$WAS_RUNNING" == "true" ]]; then
         echo "[dry-run] Would stop + restart loom-daemon with flags from ${FLAGS_SOURCE}: ${RESTART_ARGS[*]:-<none>}"
     else
@@ -419,8 +498,14 @@ fi
 if [[ "$NO_RESTART" == "true" ]]; then
     ok "Rebuilt + provisioned. Skipping restart (--no-restart)."
     if [[ "$WAS_RUNNING" == "true" ]]; then
-        echo "The running daemon is still the PRE-update binary. Restart manually with:"
-        echo "  $STOP_SCRIPT && $START_SCRIPT ${RESTART_ARGS[*]:-}"
+        if [[ "$DAEMON_MANAGER" == "launchd" ]]; then
+            echo "The running (launchd-managed) daemon is still the PRE-update binary. Restart it with:"
+            echo "  $PROVISION_TARGET restart"
+            echo "or manually: launchctl bootout $LAUNCHD_SERVICE && launchctl bootstrap gui/$(id -u) $LAUNCHD_PLIST"
+        else
+            echo "The running daemon is still the PRE-update binary. Restart manually with:"
+            echo "  $STOP_SCRIPT && $START_SCRIPT ${RESTART_ARGS[*]:-}"
+        fi
     fi
     exit 0
 fi
@@ -431,6 +516,34 @@ if [[ "$WAS_RUNNING" != "true" ]]; then
     exit 0
 fi
 
+# ---------- launchd-managed restart via the #4077 supervised primitive (#4042) ----------
+# The daemon is launchd-supervised, so NEITHER stop.sh+start.sh NOR .daemon.flags
+# apply: the plist's ProgramArguments + EnvironmentVariables are the durable
+# source of truth. `loom-daemon restart` sends Request::RestartDaemon over the
+# IPC socket; the supervised daemon exits 0 and KeepAlive:SuccessfulExit
+# relaunches it onto the freshly-provisioned binary with the plist's config.
+if [[ "$DAEMON_MANAGER" == "launchd" ]]; then
+    echo "loom-daemon is launchd-managed (label ${LAUNCHD_LABEL})."
+    echo "Restarting via the supervised restart primitive: $PROVISION_TARGET restart"
+    echo "(.daemon.flags is NOT consulted — the plist's EnvironmentVariables carries the equivalent config.)"
+    if "$PROVISION_TARGET" restart; then
+        ok "loom-daemon restart scheduled — launchd will relaunch it onto the freshly-provisioned binary."
+        exit 0
+    fi
+    # The restart request is served by the RUNNING (old) binary. A pre-#4077
+    # daemon has no RestartDaemon handler (and an unsupervised/dead socket also
+    # fails), so the request was refused. Refuse loudly rather than claim a
+    # half-update success: the fresh binary is provisioned but the OLD one is
+    # still running (the #4011 silent-autonomy-loss class this issue closes).
+    err "loom-daemon restart FAILED: the running daemon did not accept the restart request."
+    err "This is expected on the FIRST roll onto a #4077-capable binary — the currently-running binary predates the 'restart' IPC command (or its socket is dead)."
+    err "The freshly-built binary IS provisioned, but the OLD binary is still running. Restart it manually to pick up the update:"
+    err "  launchctl bootout   $LAUNCHD_SERVICE"
+    err "  launchctl bootstrap gui/$(id -u) $LAUNCHD_PLIST"
+    exit 6
+fi
+
+# ---------- PID-file/nohup-managed restart (preserve prior flags exactly) ----------
 if [[ "$FLAGS_SOURCE" == "$FLAGS_FILE" ]]; then
     echo "Restarting with the flags persisted at the last start ($FLAGS_FILE): ${RESTART_ARGS[*]:-<none>}"
 else

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -127,6 +127,54 @@ EOF
     chmod +x "$path"
 }
 
+# Writes a fake daemon binary at $1 that reports commit $2 on --version, and on a
+# `restart` subcommand (the #4077 supervised primitive, #4042) appends a line to
+# marker file $3 and exits with code $4 — so a launchd-managed update test can
+# assert the update drove `restart` (NOT stop+start) and control whether the
+# request "succeeds" (0, supervised) or is "refused" (non-zero, pre-#4077 binary).
+# On a normal run it loops forever (kept alive for any liveness check).
+write_fake_daemon_restart() {
+    local path="$1" commit="$2" restart_marker="$3" restart_rc="$4"
+    cat > "$path" <<EOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "--version" ]]; then
+    echo "loom-daemon 0.15.0 (commit ${commit}, built 2026-07-26T00:00:00Z)"
+    exit 0
+fi
+if [[ "\${1:-}" == "restart" ]]; then
+    echo "restart" >> "${restart_marker}"
+    exit ${restart_rc}
+fi
+while true; do sleep 1; done
+EOF
+    chmod +x "$path"
+}
+
+# Writes a fake `launchctl` at $1 that logs invocations to $2 and, on
+# `launchctl print`, reports a LOADED job with a live-looking pid (exit 0) —
+# simulating a launchd-managed loom-daemon for the #4042 ownership-detection
+# tests. Paired with a fake `uname`->Darwin so the update script's Darwin-gated
+# launchd path fires deterministically on any host.
+write_fake_launchd_loaded_bin() {
+    local bin_dir="$1" log="$2"
+    mkdir -p "$bin_dir"
+    : > "$log"
+    cat > "$bin_dir/launchctl" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "${log}"
+case "\${1:-}" in
+  print) echo "	pid = 4242" ; exit 0 ;;
+  *)     exit 0 ;;
+esac
+EOF
+    chmod +x "$bin_dir/launchctl"
+    cat > "$bin_dir/uname" <<'EOF'
+#!/usr/bin/env bash
+echo "Darwin"
+EOF
+    chmod +x "$bin_dir/uname"
+}
+
 # Writes a fake `cargo` that, on `cargo build --release` (cwd = loom-daemon/),
 # copies $NEW_FAKE_BIN_SRC into target/release/loom-daemon instead of
 # compiling. Tests export NEW_FAKE_BIN_SRC before invoking loom-daemon-update.sh.
@@ -695,7 +743,211 @@ else
 fi
 
 # ============================================================
-# 15. Launchd-sandbox guards (#4078): the whole suite exercises the REAL
+# 15. Launchd ownership + restart (#4042): a launchd-managed daemon (stub
+#     launchctl reports a LOADED job + pid) with NO .loom/.daemon.pid file ->
+#     the updater plans/executes a RESTART (not "was not running"), drives it
+#     through the `restart` subcommand (stub records the invocation), does NOT
+#     consult .daemon.flags, and exits 0.
+# ============================================================
+W15="$BASE_WORKDIR/w15"
+new_fixture "$W15"
+HEAD15="$(cd "$W15" && git rev-parse --short HEAD)"
+INSTALLED15="$W15/installed/loom-daemon"
+mkdir -p "$W15/installed"
+# The provisioned (fresh) binary — invoked as `restart` after provisioning —
+# reports source HEAD and accepts the restart request (rc 0). No .daemon.pid.
+RESTART_MARKER15="$W15/restart-invoked"
+write_fake_daemon_restart "$INSTALLED15" "deadbee" "$RESTART_MARKER15" 0
+NEW_FAKE15="$W15/new-fake-daemon"
+write_fake_daemon_restart "$NEW_FAKE15" "$HEAD15" "$RESTART_MARKER15" 0
+# A .daemon.flags that MUST NOT be consulted in launchd mode (would otherwise
+# add --work-finder to a stop+start path).
+echo "--work-finder" > "$W15/.loom/.daemon.flags"
+LD_BIN15="$W15/launchd-bin"
+write_fake_launchd_loaded_bin "$LD_BIN15" "$W15/launchctl.log"
+
+out15=$( cd "$W15" && PATH="$LD_BIN15:$TEST_PATH" LOOM_DAEMON_LAUNCHD=1 \
+    LOOM_DAEMON_BIN="$INSTALLED15" NEW_FAKE_BIN_SRC="$NEW_FAKE15" \
+    bash "$UPDATE_SCRIPT" 2>&1 )
+rc15=$?
+assert_eq "0" "$rc15" "launchd-managed update (no pid file) exits 0"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -s "$RESTART_MARKER15" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} launchd restart driven through the 'restart' subcommand (not stop+start)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} launchd restart driven through the 'restart' subcommand (not stop+start)"
+    echo "  output: $out15"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out15" | grep -qi 'not running'; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} launchd-loaded job is NOT mistaken for 'was not running'"
+    echo "  output: $out15"
+else
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} launchd-loaded job is NOT mistaken for 'was not running'"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out15" | grep -qi 'FLAGS-OFF'; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} no 'restarting FLAGS-OFF' warning fires for a launchd restart"
+    echo "  output: $out15"
+else
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} no 'restarting FLAGS-OFF' warning fires for a launchd restart"
+fi
+
+# ============================================================
+# 16. Launchd restart REFUSED (#4042): a launchd job is loaded but the running
+#     (old) binary rejects the restart request (pre-#4077 binary / dead socket).
+#     The updater must exit NON-ZERO (6) and print the manual bootout/bootstrap
+#     fallback — never report success while silently skipping the restart.
+# ============================================================
+W16="$BASE_WORKDIR/w16"
+new_fixture "$W16"
+HEAD16="$(cd "$W16" && git rev-parse --short HEAD)"
+INSTALLED16="$W16/installed/loom-daemon"
+mkdir -p "$W16/installed"
+RESTART_MARKER16="$W16/restart-invoked"
+write_fake_daemon_restart "$INSTALLED16" "deadbee" "$RESTART_MARKER16" 1
+NEW_FAKE16="$W16/new-fake-daemon"
+# Fresh binary's `restart` returns non-zero (request refused by the running daemon).
+write_fake_daemon_restart "$NEW_FAKE16" "$HEAD16" "$RESTART_MARKER16" 1
+LD_BIN16="$W16/launchd-bin"
+write_fake_launchd_loaded_bin "$LD_BIN16" "$W16/launchctl.log"
+
+out16=$( cd "$W16" && PATH="$LD_BIN16:$TEST_PATH" LOOM_DAEMON_LAUNCHD=1 \
+    LOOM_DAEMON_BIN="$INSTALLED16" NEW_FAKE_BIN_SRC="$NEW_FAKE16" \
+    bash "$UPDATE_SCRIPT" 2>&1 )
+rc16=$?
+assert_eq "6" "$rc16" "launchd restart refused -> exit 6 (never a silent half-update)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out16" | grep -qi 'launchctl bootout' && echo "$out16" | grep -qi 'launchctl bootstrap'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} refused launchd restart prints the manual bootout/bootstrap fallback"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} refused launchd restart prints the manual bootout/bootstrap fallback"
+    echo "  output: $out16"
+fi
+
+# ============================================================
+# 17. --check names the owning manager (#4042): launchd (with label) when a
+#     job is loaded; PID-file/nohup when a live pid file exists; not running
+#     otherwise. All three are read-only (exit 3 here since the commit differs).
+# ============================================================
+W17="$BASE_WORKDIR/w17"
+new_fixture "$W17"
+INSTALLED17="$W17/installed/loom-daemon"
+mkdir -p "$W17/installed"
+write_fake_daemon "$INSTALLED17" "deadbee" "$W17/marker"
+LD_BIN17="$W17/launchd-bin"
+write_fake_launchd_loaded_bin "$LD_BIN17" "$W17/launchctl.log"
+# (a) launchd loaded -> manager: launchd (names the scratch label).
+check_ld_out=$( cd "$W17" && PATH="$LD_BIN17:$TEST_PATH" LOOM_DAEMON_LAUNCHD=1 \
+    LOOM_LAUNCHD_LABEL="com.example.scratch-4042" LOOM_DAEMON_BIN="$INSTALLED17" \
+    bash "$UPDATE_SCRIPT" --check 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$check_ld_out" | grep -qi 'manager: launchd' && echo "$check_ld_out" | grep -q 'com.example.scratch-4042'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --check names launchd (with label) as the owning manager"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --check names launchd (with label) as the owning manager"
+    echo "  output: $check_ld_out"
+fi
+# (b) LOOM_DAEMON_LAUNCHD=0 + live pid file -> manager: PID-file/nohup.
+"$INSTALLED17" >/dev/null 2>&1 &
+pid17=$!
+sleep 0.3
+echo "$pid17" > "$W17/.loom/.daemon.pid"
+check_pid_out=$( cd "$W17" && PATH="$TEST_PATH" LOOM_DAEMON_LAUNCHD=0 \
+    LOOM_DAEMON_BIN="$INSTALLED17" bash "$UPDATE_SCRIPT" --check 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$check_pid_out" | grep -qi 'manager: PID-file'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --check names PID-file/nohup as the owning manager"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --check names PID-file/nohup as the owning manager"
+    echo "  output: $check_pid_out"
+fi
+kill "$pid17" 2>/dev/null || true
+rm -f "$W17/.loom/.daemon.pid"
+# (c) nothing running -> manager: not running.
+check_none_out=$( cd "$W17" && PATH="$TEST_PATH" LOOM_DAEMON_LAUNCHD=0 \
+    LOOM_DAEMON_BIN="$INSTALLED17" bash "$UPDATE_SCRIPT" --check 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$check_none_out" | grep -qi 'manager: not running'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --check names 'not running' when no daemon is up"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --check names 'not running' when no daemon is up"
+    echo "  output: $check_none_out"
+fi
+
+# ============================================================
+# 18. --dry-run in launchd mode reports the launchd restart plan and makes no
+#     writes (no rebuild, no restart invocation).
+# ============================================================
+W18="$BASE_WORKDIR/w18"
+new_fixture "$W18"
+INSTALLED18="$W18/installed/loom-daemon"
+mkdir -p "$W18/installed"
+RESTART_MARKER18="$W18/restart-invoked"
+write_fake_daemon_restart "$INSTALLED18" "deadbee" "$RESTART_MARKER18" 0
+LD_BIN18="$W18/launchd-bin"
+write_fake_launchd_loaded_bin "$LD_BIN18" "$W18/launchctl.log"
+dry18_out=$( cd "$W18" && PATH="$LD_BIN18:$TEST_PATH" LOOM_DAEMON_LAUNCHD=1 \
+    LOOM_DAEMON_BIN="$INSTALLED18" bash "$UPDATE_SCRIPT" --dry-run 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$dry18_out" | grep -qi 'launchd-managed' && echo "$dry18_out" | grep -qi 'restart' \
+    && [[ ! -s "$RESTART_MARKER18" ]] && [[ ! -e "$W18/loom-daemon/target/release/loom-daemon" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --dry-run reports the launchd restart plan and makes no writes"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --dry-run reports the launchd restart plan and makes no writes"
+    echo "  output: $dry18_out"
+fi
+
+# ============================================================
+# 19. LOOM_DAEMON_LAUNCHD=0 skips all launchd tiers even on a (faked) Darwin
+#     host with a launchd job loaded: the daemon is treated as NOT launchd-
+#     managed, so with no pid file it is "not running" (no restart attempted).
+#     Guards the sandbox invariant that --no-launchd never reaches launchd.
+# ============================================================
+W19="$BASE_WORKDIR/w19"
+new_fixture "$W19"
+HEAD19="$(cd "$W19" && git rev-parse --short HEAD)"
+INSTALLED19="$W19/installed/loom-daemon"
+mkdir -p "$W19/installed"
+RESTART_MARKER19="$W19/restart-invoked"
+write_fake_daemon_restart "$INSTALLED19" "deadbee" "$RESTART_MARKER19" 0
+NEW_FAKE19="$W19/new-fake-daemon"
+write_fake_daemon_restart "$NEW_FAKE19" "$HEAD19" "$RESTART_MARKER19" 0
+LD_BIN19="$W19/launchd-bin"
+write_fake_launchd_loaded_bin "$LD_BIN19" "$W19/launchctl.log"
+out19=$( cd "$W19" && PATH="$LD_BIN19:$TEST_PATH" LOOM_DAEMON_LAUNCHD=0 \
+    LOOM_DAEMON_BIN="$INSTALLED19" NEW_FAKE_BIN_SRC="$NEW_FAKE19" \
+    bash "$UPDATE_SCRIPT" 2>&1 )
+rc19=$?
+assert_eq "0" "$rc19" "LOOM_DAEMON_LAUNCHD=0 update exits 0 (rebuild+provision, no launchd)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out19" | grep -qi 'not running' && [[ ! -s "$RESTART_MARKER19" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} LOOM_DAEMON_LAUNCHD=0 skips launchd tiers (no restart driven)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} LOOM_DAEMON_LAUNCHD=0 skips launchd tiers (no restart driven)"
+    echo "  output: $out19"
+fi
+
+# ============================================================
+# 20. Launchd-sandbox guards (#4078): the whole suite exercises the REAL
 #     start/stop scripts, so prove it never reached the operator's live daemon.
 #     (a) The suite-level decoy loom-daemon is still alive — no by-name kill
 #         fired anywhere in the suite.


### PR DESCRIPTION
## Summary

`loom-daemon-update.sh` (#3968) resolved "is the daemon running, and how do I restart it" solely from `.loom/.daemon.pid` / `.loom/.daemon.flags` — the nohup/script-managed style. On Darwin the daemon is commonly **launchd-managed** (default since #3972/#4054), where the pid file goes stale after any `KeepAlive:SuccessfulExit` relaunch and a hand-bootstrapped daemon has no state files at all. The updater therefore rebuilt + reprovisioned, then silently skipped the restart ("was not running — nothing to restart"), leaving the operator believing the fix was live while the old binary kept running — the #4011 silent-autonomy-loss class.

This teaches the updater to detect a launchd-managed daemon and restart it through the #4077 `loom-daemon restart` primitive, refusing loudly if that request cannot be served.

## Changes

- **Ownership detection** (`defaults/scripts/cli/loom-daemon-update.sh`): added the launchd plumbing mirrored from `loom-daemon-stop.sh` (`IS_DARWIN` / `USE_LAUNCHD` honoring `LOOM_DAEMON_LAUNCHD`, `LAUNCHD_SERVICE="gui/$(id -u)/${LOOM_LAUNCHD_LABEL:-com.rjwalters.loom-daemon}"`, `launchd_job_loaded()` / `launchd_job_pid()`). A new `DAEMON_MANAGER` (`launchd` / `pidfile` / `none`) is resolved with **launchd checked ahead of the pid-file tier**, driving `WAS_RUNNING`.
- **launchd-mode restart**: after provisioning, a launchd-managed daemon is restarted via `"$PROVISION_TARGET" restart` (the #4077 supervised primitive). `.daemon.flags` is **not** consulted and the "restarting FLAGS-OFF" warning does **not** fire — the plist's `EnvironmentVariables` is the durable flag source.
- **Refuse loudly on failure**: if the launchd job is loaded but the restart request fails (pre-#4077 binary / dead socket), the script exits **6** and prints the manual `launchctl bootout` / `bootstrap` fallback rather than reporting success. New exit code 6 documented in the header banner.
- **`--check` reports the owning manager**: launchd (naming the label), PID-file/nohup, or not running.
- **Non-launchd paths unchanged**: Linux and `--no-launchd`/`LOOM_DAEMON_LAUNCHD=0` follow the existing PID-file/nohup restart flow byte-for-byte.
- **Tests** (`defaults/scripts/tests/test-loom-daemon-update.sh`): 14 new assertions (tests 15–19) using the existing `lib/launchd-sandbox.sh` machinery plus a fake `launchctl`→loaded-job and a fake daemon with a `restart` subcommand.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Ownership detection: launchd checked ahead of pid-file tier | ✅ | `DAEMON_MANAGER` resolution; test 15 (launchd loaded + no pid file → restart planned/executed, not "was not running") |
| launchd restart via `loom-daemon restart`; `.daemon.flags` not consulted; no FLAGS-OFF warning | ✅ | Test 15 asserts the `restart` subcommand was recorded (not stop+start), a `.daemon.flags` present is ignored, and no `FLAGS-OFF` text is emitted |
| Refuse loudly on restart failure (exit non-zero + manual fallback) | ✅ | Test 16: refused restart → exit 6 + `launchctl bootout`/`bootstrap` printed |
| `--check` names the owning manager | ✅ | Test 17: launchd (with label) / PID-file/nohup / not running |
| Non-launchd paths behaviorally unchanged | ✅ | Tests 5/5b/6/7 (pre-existing) unchanged and green; test 19: `LOOM_DAEMON_LAUNCHD=0` skips all launchd tiers |

## Test Plan

- `bash defaults/scripts/tests/test-loom-daemon-update.sh` → **45 passed, 0 failed** (31 pre-existing unchanged + 14 new).
- `bash defaults/scripts/tests/test-loom-daemon-stop.sh` → 22 passed; `test-loom-daemon-watchdog.sh` → 12 passed (shared `launchd-sandbox.sh` unaffected).
- `shellcheck` clean on both modified files.

Closes #4042