### PR TITLE
docs: fix stale bare /<role> slash-command references to /loom:<role>

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -101,21 +101,21 @@ The `commands/` directory contains slash commands that invoke Loom roles. Each c
 
 | Command | Role | Purpose |
 |---------|------|---------|
-| `/builder` | Builder | Implements features for `loom:issue` issues and creates PRs |
-| `/judge` | Judge | Reviews PRs with `loom:review-requested` label |
-| `/curator` | Curator | Enhances issues and marks them as `loom:curated` |
-| `/architect` | Architect | Creates architectural proposals with `loom:architect` |
-| `/hermit` | Hermit | Identifies bloat and creates simplification issues |
-| `/doctor` | Doctor | Addresses PR feedback and resolves conflicts |
-| `/guide` | Guide | Triages issues and applies `loom:urgent` to top 3 |
-| `/champion` | Champion | Auto-merges approved PRs with `loom:pr` label |
+| `/loom:builder` | Builder | Implements features for `loom:issue` issues and creates PRs |
+| `/loom:judge` | Judge | Reviews PRs with `loom:review-requested` label |
+| `/loom:curator` | Curator | Enhances issues and marks them as `loom:curated` |
+| `/loom:architect` | Architect | Creates architectural proposals with `loom:architect` |
+| `/loom:hermit` | Hermit | Identifies bloat and creates simplification issues |
+| `/loom:doctor` | Doctor | Addresses PR feedback and resolves conflicts |
+| `/loom:guide` | Guide | Triages issues and applies `loom:urgent` to top 3 |
+| `/loom:champion` | Champion | Auto-merges approved PRs with `loom:pr` label |
 
 ### How Slash Commands Work
 
 **Manual Invocation**: Use slash commands to assume a role:
 ```bash
-/builder    # Assume Builder role, find and implement a loom:issue
-/judge      # Assume Judge role, review a PR with loom:review-requested
+/loom:builder    # Assume Builder role, find and implement a loom:issue
+/loom:judge      # Assume Judge role, review a PR with loom:review-requested
 ```
 
 Each slash command tells Claude to:

--- a/.loom/docs/troubleshooting.md
+++ b/.loom/docs/troubleshooting.md
@@ -374,8 +374,8 @@ Note: by default the daemon does not poll the forge for `loom:issue` items — d
 For now, trigger them manually when the queue is empty:
 
 ```bash
-claude -p "/architect" --dangerously-skip-permissions
-claude -p "/hermit"    --dangerously-skip-permissions
+claude -p "/loom:architect" --dangerously-skip-permissions
+claude -p "/loom:hermit"    --dangerously-skip-permissions
 ```
 
 ## Overnight / long-running orchestration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,14 +31,14 @@ Loom decomposes development into three coordination tiers, with the forge (GitHu
 | Tier 3 | Human | Oversight — approve proposals, handle edge cases | Observer |
 | Tier 2 | `loom-daemon` (MCP) + GH Actions cron | Multi-issue dispatch + scheduled support roles | Continuous / cron |
 | Tier 1 | `/loom:sweep <issue>` | Single-issue lifecycle (Curator → Merge) | Per-issue |
-| Tier 0 | `/builder`, `/judge`, etc. | Task execution — single focused work units | Per-task |
+| Tier 0 | `/loom:builder`, `/loom:judge`, etc. | Task execution — single focused work units | Per-task |
 
 ## Usage Modes
 
 ### 1. Manual Orchestration Mode (MOM)
 
-Open Claude Code in this repo and use slash commands (`/builder`, `/judge`,
-`/curator`, …) — each terminal acts as a specialized agent.
+Open Claude Code in this repo and use slash commands (`/loom:builder`,
+`/loom:judge`, `/loom:curator`, …) — each terminal acts as a specialized agent.
 
 ### 2. Single-issue lifecycle: `/loom:sweep <issue>`
 

--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ stateDiagram-v2
 
 **Quality Gates**
 - Acceptance criteria verification before PR creation
-- Automated code review with `/judge`
-- PR conflict resolution with `/doctor`
-- Main branch validation with `/auditor`
+- Automated code review with `/loom:judge`
+- PR conflict resolution with `/loom:doctor`
+- Main branch validation with `/loom:auditor`
 
 **Forge-Agnostic**
 - Works with GitHub and Gitea out of the box
@@ -301,14 +301,14 @@ gh pr create --label "loom:review-requested"
 |------|---------|------|
 | `/loom:sweep` | Single-issue lifecycle orchestration (Curator → Merge) | Per-issue |
 | `loom-daemon` + `mcp__loom__dispatch_sweep` | Multi-issue detached dispatch (Tier 2) | Continuous, opt-in |
-| `/builder` | Implement features and fixes | Manual |
-| `/judge` | Review pull requests | Cron via GH Actions |
-| `/curator` | Enhance and organize issues | Cron via GH Actions |
-| `/architect` | Create architectural proposals | Manual (cadence #3381) |
-| `/hermit` | Identify simplification opportunities | Manual (cadence #3381) |
-| `/doctor` | Fix PR feedback and conflicts | Manual |
-| `/champion` | Evaluate proposals, auto-merge PRs | Cron via GH Actions |
-| `/auditor` | Validate main branch builds | Cron via GH Actions |
+| `/loom:builder` | Implement features and fixes | Manual |
+| `/loom:judge` | Review pull requests | Cron via GH Actions |
+| `/loom:curator` | Enhance and organize issues | Cron via GH Actions |
+| `/loom:architect` | Create architectural proposals | Manual (cadence #3381) |
+| `/loom:hermit` | Identify simplification opportunities | Manual (cadence #3381) |
+| `/loom:doctor` | Fix PR feedback and conflicts | Manual |
+| `/loom:champion` | Evaluate proposals, auto-merge PRs | Cron via GH Actions |
+| `/loom:auditor` | Validate main branch builds | Cron via GH Actions |
 
 ## Development
 

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -1358,12 +1358,12 @@ When you receive a probe command, respond with: `AGENT:Judge:<brief-task>` — e
 
 **After completing an evaluation, stop or continue based on how you were invoked:**
 
-### Manual invocation (via `/judge` or `/judge <number>`)
+### Manual invocation (via `/loom:judge` or `/loom:judge <number>`)
 
 After completing **one** PR evaluation (PR labeled `loom:pr` or `loom:changes-requested`):
 - **Stop immediately** — do not search for additional PRs
 - Report a brief summary of what was evaluated and the outcome
-- The user can run `/judge` again if they want to evaluate another PR
+- The user can run `/loom:judge` again if they want to evaluate another PR
 
 If no work was found (no PRs with `loom:review-requested`), report that and stop.
 

--- a/defaults/.claude/commands/loom/loom.md
+++ b/defaults/.claude/commands/loom/loom.md
@@ -291,15 +291,15 @@ Loom has three layers of roles:
 
 | Command | Role | What it does |
 |---------|------|-------------|
-| `/builder` | Builder | Implements features/fixes from `loom:issue` issues, creates PRs |
-| `/judge` | Judge | Reviews PRs with `loom:review-requested`, approves or requests changes |
-| `/curator` | Curator | Enhances issues with implementation guidance, marks `loom:curated` |
-| `/doctor` | Doctor | Fixes PR feedback, resolves merge conflicts |
-| `/champion` | Champion | Evaluates proposals, auto-merges approved PRs |
-| `/architect` | Architect | Creates architectural proposals for new features |
-| `/hermit` | Hermit | Identifies code simplification opportunities |
-| `/guide` | Guide | Prioritizes and triages the issue backlog |
-| `/auditor` | Auditor | Validates main branch builds and catches regressions |
+| `/loom:builder` | Builder | Implements features/fixes from `loom:issue` issues, creates PRs |
+| `/loom:judge` | Judge | Reviews PRs with `loom:review-requested`, approves or requests changes |
+| `/loom:curator` | Curator | Enhances issues with implementation guidance, marks `loom:curated` |
+| `/loom:doctor` | Doctor | Fixes PR feedback, resolves merge conflicts |
+| `/loom:champion` | Champion | Evaluates proposals, auto-merges approved PRs |
+| `/loom:architect` | Architect | Creates architectural proposals for new features |
+| `/loom:hermit` | Hermit | Identifies code simplification opportunities |
+| `/loom:guide` | Guide | Prioritizes and triages the issue backlog |
+| `/loom:auditor` | Auditor | Validates main branch builds and catches regressions |
 | `/driver` | Driver | Plain shell for ad-hoc commands |
 | `/imagine` | Bootstrapper | Bootstrap new projects with Loom |
 

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -1139,7 +1139,7 @@ Apply exactly one of the three branches below, based on the PR's current label:
 #### C1a. `loom:review-requested` → Judge phase only
 
 - Load and follow the instructions in `.claude/commands/loom/judge.md` for this PR.
-- Dispatch `loom-judge` as a **single subagent Task** from this orchestrator session. Do **NOT** invoke `/loom:sweep` or `/judge` slash-commands as subagents — see "CRITICAL: One level deep" in the Execution Model.
+- Dispatch `loom-judge` as a **single subagent Task** from this orchestrator session. Do **NOT** invoke `/loom:sweep` or `/loom:judge` slash-commands as subagents — see "CRITICAL: One level deep" in the Execution Model.
 - If a previous Judge attempt for this PR died mid-flight without a fresh checkpoint (rate limit, crash), re-verify forge state and complete only the missing steps before re-dispatching — see "Mid-phase-death recovery" in the Wave Lifecycle (the rule is phase-generic; Mode C inherits it, same as the Doctor-cycle cap).
 - Expected exit states:
   - **Approve** → PR labeled `loom:pr` by Judge. If a closing-issue checkpoint is in scope, write `judge-done`:
@@ -1155,7 +1155,7 @@ Apply exactly one of the three branches below, based on the PR's current label:
 If the PR entered the wave already labeled `loom:changes-requested` (e.g., from a previous Judge run), or just transitioned there from C1a, run inline Doctor → Judge cycles for this PR — **up to `sweep.max_doctor_cycles`** (default 1; see "Doctor-cycle cap" in the Execution Model):
 
 - Load and follow the instructions in `.claude/commands/loom/doctor.md` for this PR.
-- Dispatch `loom-doctor` as a **single subagent Task** from this orchestrator session. Do **NOT** invoke `/loom:sweep` or `/doctor` slash-commands as subagents — see "CRITICAL: One level deep".
+- Dispatch `loom-doctor` as a **single subagent Task** from this orchestrator session. Do **NOT** invoke `/loom:sweep` or `/loom:doctor` slash-commands as subagents — see "CRITICAL: One level deep".
 - If a previous Doctor attempt for this PR died mid-flight without a fresh `doctor-done` checkpoint (rate limit, crash), re-verify forge state (pushed commit? already re-labeled `loom:review-requested`?) and complete only the missing steps rather than duplicating the pushed fix — see "Mid-phase-death recovery" in the Wave Lifecycle (inherited here, same as the Doctor-cycle cap).
 - **Model escalation (#3481)**: Mode C inherits the issue-side rule unchanged — this Doctor is dispatched because of a `loom:changes-requested` rejection, so resolve its model per "Model escalation on Judge rejection" in the Execution Model: pass `ladder[1]` from `sweep.escalation` (default ladder: `opus`, resolved through `resolve-model.sh` to `claude-opus-5` — #3982) via the Task tool's `model` parameter, **unless** a tier-1/tier-2 pin applies (pins win) or escalation is disabled (`[]`/`false`).
 - Doctor addresses the judge feedback, commits the fixes, pushes, and re-labels the PR `loom:review-requested`.
@@ -1762,7 +1762,7 @@ Do not auto-stop the daemon. Do not block on this warning — proceed with the s
 
 ## Constraints
 
-- **Wave model, one level deep.** When `--builders-per-wave > 1` (Modes A/B only), dispatch `loom-builder` / `loom-judge` / `loom-doctor` subagents **directly from this orchestrator session** in a single tool-call block. In Mode C, dispatch `loom-judge` and `loom-doctor` as **single subagent Tasks** per PR (size-1 waves). **Never invoke `/loom:sweep`, `/judge`, or `/doctor` as a subagent from `/loom:sweep`** — that is the two-levels-deep pattern that triggers the #3289 stall. See "CRITICAL: One level deep" in the Execution Model.
+- **Wave model, one level deep.** When `--builders-per-wave > 1` (Modes A/B only), dispatch `loom-builder` / `loom-judge` / `loom-doctor` subagents **directly from this orchestrator session** in a single tool-call block. In Mode C, dispatch `loom-judge` and `loom-doctor` as **single subagent Tasks** per PR (size-1 waves). **Never invoke `/loom:sweep`, `/loom:judge`, or `/loom:doctor` as a subagent from `/loom:sweep`** — that is the two-levels-deep pattern that triggers the #3289 stall. See "CRITICAL: One level deep" in the Execution Model.
 - **Per-PR Judge is sequential within a wave.** Builders parallelize (Modes A/B); judges do not. Mode C inherits this: PRs are processed one per size-1 wave. Don't parallelize judges or PRs without a separate design pass.
 - **Configurable Doctor→Judge cycle cap per PR (`sweep.max_doctor_cycles`, default 1).** Inline within the wave (Modes A/B issue-side and Mode C PR-side both enforce this). If Judge still requests changes after the configured number of Doctor passes, the PR is blocked — do not retry indefinitely. At the default cap of 1, the orchestrator may grant one extra bounded cycle when the second rejection is a demonstrably distinct defect (logged, single-use, never on an operator-raised cap) — see "Doctor-cycle cap".
 - **Mode C skips Curator, Approval gate, and Builder.** These phases already ran (the PR exists). Re-running them would be incorrect.

--- a/defaults/.loom/CLAUDE.md
+++ b/defaults/.loom/CLAUDE.md
@@ -23,7 +23,7 @@ Use Claude Code terminals with specialized roles for hands-on development coordi
 
 **Setup**:
 1. Open Claude Code in this repository
-2. Use slash commands to assume roles: `/builder`, `/judge`, `/curator`, etc.
+2. Use slash commands to assume roles: `/loom:builder`, `/loom:judge`, `/loom:curator`, etc.
 3. Each terminal acts as a specialized agent following role guidelines
 
 **When to use MOM**:

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -101,7 +101,7 @@ Loom decomposes development into three coordination tiers, with the forge (GitHu
 | Tier 3 | Human | Oversight — approve proposals, handle edge cases | Observer |
 | Tier 2 | `loom-daemon` (MCP) + GH Actions cron | Multi-issue dispatch + scheduled support roles | Continuous / cron |
 | Tier 1 | `/loom:sweep <issue>` | Issue lifecycle from creation to merge | Per-issue |
-| Tier 0 | `/builder`, `/judge`, etc. | Task execution — single focused work units | Per-task |
+| Tier 0 | `/loom:builder`, `/loom:judge`, etc. | Task execution — single focused work units | Per-task |
 
 ### Tier responsibilities
 
@@ -144,7 +144,7 @@ Use Claude Code terminals with specialized roles for hands-on development coordi
 
 **Setup**:
 1. Open Claude Code in this repository
-2. Use slash commands to assume roles: `/builder`, `/judge`, `/curator`, etc.
+2. Use slash commands to assume roles: `/loom:builder`, `/loom:judge`, `/loom:curator`, etc.
 3. Each terminal acts as a specialized agent following role guidelines
 
 **When to use MOM**:
@@ -234,11 +234,11 @@ For the full surface — IPC request/response variants, event-bus internals, reg
 
 | Workflow | Role | Schedule (commented) |
 |----------|------|----------------------|
-| `loom-champion.yml` | `/champion` | `*/10 * * * *` |
-| `loom-curator.yml`  | `/curator`  | `*/5 * * * *`  |
-| `loom-judge.yml`    | `/judge`    | `*/5 * * * *`  |
-| `loom-auditor.yml`  | `/auditor`  | `*/10 * * * *` |
-| `loom-guide.yml`    | `/guide`    | `*/15 * * * *` |
+| `loom-champion.yml` | `/loom:champion` | `*/10 * * * *` |
+| `loom-curator.yml`  | `/loom:curator`  | `*/5 * * * *`  |
+| `loom-judge.yml`    | `/loom:judge`    | `*/5 * * * *`  |
+| `loom-auditor.yml`  | `/loom:auditor`  | `*/10 * * * *` |
+| `loom-guide.yml`    | `/loom:guide`    | `*/15 * * * *` |
 
 **Disabled by default.** Every shipped workflow has its `schedule:` block commented out so forks don't burn Actions minutes accidentally. To opt in on a fork:
 
@@ -1522,7 +1522,7 @@ jq -r '.pattern' .loom/logs/guard-decisions.log | sort | uniq -c | sort -rn
 
 ```bash
 # Enable for a single command (e.g. to capture one session's fires)
-LOOM_GUARD_DECISION_LOG=1 claude -p "/builder" --dangerously-skip-permissions
+LOOM_GUARD_DECISION_LOG=1 claude -p "/loom:builder" --dangerously-skip-permissions
 
 # Persist for a whole repo
 #   .loom/config.json  ->  { "guards": { "decisionLog": true } }
@@ -1956,8 +1956,8 @@ See [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) for the f
 **This is by design post-v0.10.0.** Neither the daemon nor the GH Actions cron generates work for Architect / Hermit — that cadence is tracked under follow-up #3381. For now, trigger them manually when the queue is empty:
 
 ```bash
-claude -p "/architect" --dangerously-skip-permissions
-claude -p "/hermit"    --dangerously-skip-permissions
+claude -p "/loom:architect" --dangerously-skip-permissions
+claude -p "/loom:hermit"    --dangerously-skip-permissions
 ```
 
 ## Health Monitoring

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -399,11 +399,11 @@ daemon's historical intervals:
 
 | Workflow            | Role        | Schedule (commented) |
 |---------------------|-------------|----------------------|
-| `loom-judge.yml`    | `/judge`    | `*/5 * * * *`        |
-| `loom-curator.yml`  | `/curator`  | `*/5 * * * *`        |
-| `loom-champion.yml` | `/champion` | `*/10 * * * *`       |
-| `loom-auditor.yml`  | `/auditor`  | `*/10 * * * *`       |
-| `loom-guide.yml`    | `/guide`    | `*/15 * * * *`       |
+| `loom-judge.yml`    | `/loom:judge`    | `*/5 * * * *`        |
+| `loom-curator.yml`  | `/loom:curator`  | `*/5 * * * *`        |
+| `loom-champion.yml` | `/loom:champion` | `*/10 * * * *`       |
+| `loom-auditor.yml`  | `/loom:auditor`  | `*/10 * * * *`       |
+| `loom-guide.yml`    | `/loom:guide`    | `*/15 * * * *`       |
 
 Workflows ship with `schedule:` blocks **commented out** so forks
 don't accidentally burn Actions minutes. To opt in: add a

--- a/docs/autonomous-mode-e2e.md
+++ b/docs/autonomous-mode-e2e.md
@@ -93,9 +93,9 @@ If the crons are not enabled, trigger the roles manually (still zero
 issue-editing by you):
 
 ```bash
-claude -p "/curator"  --dangerously-skip-permissions
-claude -p "/champion" --dangerously-skip-permissions   # promotes loom:curated → loom:issue, later auto-merges
-claude -p "/judge"    --dangerously-skip-permissions
+claude -p "/loom:curator"  --dangerously-skip-permissions
+claude -p "/loom:champion" --dangerously-skip-permissions   # promotes loom:curated → loom:issue, later auto-merges
+claude -p "/loom:judge"    --dangerously-skip-permissions
 ```
 
 ## Step 5 — Scripted assertion: wait for the label sequence

--- a/docs/guides/quickstart-tutorial.md
+++ b/docs/guides/quickstart-tutorial.md
@@ -64,7 +64,7 @@ The Curator role enhances issues with implementation details, acceptance criteri
 Open a new terminal and start Claude Code with the Curator role:
 
 ```bash
-claude code "/curator"
+claude code "/loom:curator"
 ```
 
 **What this does:** Loads the Curator role definition from `.loom/roles/curator.md` and provides context about issue curation workflow.
@@ -123,7 +123,7 @@ Now we'll implement the feature as a Builder.
 In a new terminal (or the same one after exiting Curator):
 
 ```bash
-claude code "/builder"
+claude code "/loom:builder"
 ```
 
 ### Claim the Issue
@@ -209,7 +209,7 @@ The Judge role performs thorough code reviews.
 ### Launch Judge Terminal
 
 ```bash
-claude code "/judge"
+claude code "/loom:judge"
 ```
 
 ### Find and Review the PR
@@ -323,10 +323,10 @@ Congratulations! You've completed your first Loom workflow. You now know:
 
 Try these other roles:
 
-- **`/architect`** - Create architectural proposals and design documents
-- **`/hermit`** - Identify code bloat and suggest simplifications
-- **`/doctor`** - Fix bugs and maintain existing PRs
-- **`/guide`** - Prioritize and organize the issue backlog
+- **`/loom:architect`** - Create architectural proposals and design documents
+- **`/loom:hermit`** - Identify code bloat and suggest simplifications
+- **`/loom:doctor`** - Fix bugs and maintain existing PRs
+- **`/loom:guide`** - Prioritize and organize the issue backlog
 
 ### Customize Roles
 

--- a/docs/migration/v0.10.0-shepherd-deprecation.md
+++ b/docs/migration/v0.10.0-shepherd-deprecation.md
@@ -435,11 +435,11 @@ intervals.
 
 | Workflow | Role | Schedule (commented in-template) |
 |----------|------|----------------------------------|
-| `loom-champion.yml` | `/champion` | `*/10 * * * *` |
-| `loom-curator.yml`  | `/curator`  | `*/5 * * * *`  |
-| `loom-judge.yml`    | `/judge`    | `*/5 * * * *`  |
-| `loom-auditor.yml`  | `/auditor`  | `*/10 * * * *` |
-| `loom-guide.yml`    | `/guide`    | `*/15 * * * *` |
+| `loom-champion.yml` | `/loom:champion` | `*/10 * * * *` |
+| `loom-curator.yml`  | `/loom:curator`  | `*/5 * * * *`  |
+| `loom-judge.yml`    | `/loom:judge`    | `*/5 * * * *`  |
+| `loom-auditor.yml`  | `/loom:auditor`  | `*/10 * * * *` |
+| `loom-guide.yml`    | `/loom:guide`    | `*/15 * * * *` |
 
 **Workflows are disabled by default** — each shipped workflow has its
 `schedule:` block commented out. To opt in on a fork:


### PR DESCRIPTION
## Summary

PR #4036 switched the `loom-champion`/`curator`/`judge`/`auditor`/`guide` GitHub Actions workflows to invoke the namespaced `/loom:<role>` slash commands, but documentation referencing these commands was never updated. Since only namespaced commands exist under `.claude/commands/loom/` (confirmed — no bare-name command files anywhere in the tree), every bare `/<role>` invocation silently no-ops (`Unknown command: /<role>`, exit 0) — the same failure mode as #4034.

This is a mechanical find/replace at the enumerated sites from the curator-enhanced issue body: copy-pasteable command lines, GitHub Actions role-reference tables, and MOM/Tier-0 instructional prose. Generic `/<role>` placeholder shorthand and historical ADR-0010 prose are left unchanged, as directed by the issue.

## Files changed

- `CLAUDE.md` — Tier-0 row + MOM slash-command prose
- `defaults/CLAUDE.md` — Tier-0 row, MOM prose, GH Actions role table, decision-log example, architect/hermit manual-trigger example
- `defaults/.loom/CLAUDE.md` — MOM slash-command prose
- `README.md` — quality-gates bullets + Agent Roles table
- `.claude/README.md` — Available Commands table + manual-invocation example
- `docs/agents.md` — GH Actions role table
- `docs/autonomous-mode-e2e.md` — manual-trigger command lines
- `docs/guides/quickstart-tutorial.md` — Launch Curator/Builder/Judge terminal commands + Explore More Roles bullets
- `docs/migration/v0.10.0-shepherd-deprecation.md` — GH Actions role table
- `.loom/docs/troubleshooting.md` — architect/hermit manual-trigger example
- `defaults/.claude/commands/loom/judge.md`, `.../loom.md`, `.../sweep.md` — manual-invocation references and never-invoke-as-subagent warnings

## Verification

```
$ grep -rn '"/\(curator\|champion\|judge\|auditor\|guide\|builder\)"' --include='*.md' .
(no output)

$ grep -rn '`/\(curator\|champion\|judge\|auditor\|guide\|builder\|doctor\)`' --include='*.md' .
docs/adr/0010-daemon-rebuild.md:194        # historical ADR, left as-is
defaults/CLAUDE.md:1643                    # accurate placeholder-detection prose, left as-is
defaults/.claude/commands/loom/help.md:23  # deliberately documents both accepted parse forms, left as-is

$ ./scripts/check-claude-md-budget.sh
check-claude-md-budget: OK — CLAUDE.md is 313 lines (budget 320).

$ bash defaults/hooks/tests/test-methodology-inject.sh
=== 27/27 passed ===
```

`git diff --stat` shows 71 insertions / 71 deletions across 13 files — pure 1:1 substitutions, no line-count changes.

Closes #4037

## Test plan

- [x] Verification grep 1 (quoted command lines) returns nothing
- [x] Verification grep 2 (backticked bare commands) returns only the three documented leave-as-is sites
- [x] `./scripts/check-claude-md-budget.sh` passes (313/320 lines, unchanged from before)
- [x] `bash defaults/hooks/tests/test-methodology-inject.sh` still passes (27/27) — confirms bare-form role detection in the hook itself is untouched
- [x] Doc-only change — no code paths touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)