### PR TITLE
fix: widen fixture-child spawn waits to FIXTURE_CHILD_WAIT_MS

### DIFF
--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -4199,6 +4199,26 @@ exit 0
         false
     }
 
+    /// Wait (up to `FIXTURE_CHILD_WAIT_MS`, #4044) for the fixture's fake
+    /// `spawn-claude.sh` to write `needle` into `record_log`, then return the
+    /// file's full contents for the caller's own content assertions.
+    ///
+    /// Panics with a message that distinguishes "the child never started /
+    /// never wrote anything" from "the child started but wrote the wrong
+    /// thing" — the third acceptance criterion of #4044 — rather than the
+    /// old bare "did not finish writing within 10s".
+    fn assert_child_wrote(record_log: &Path, needle: &str) -> String {
+        let wrote = wait_for_contents(record_log, needle, FIXTURE_CHILD_WAIT_MS);
+        let recorded = std::fs::read_to_string(record_log).unwrap_or_default();
+        assert!(
+            wrote,
+            "fake spawn-claude.sh did not write expected contents within {}ms\n  needle: {needle}\n  record_log exists: {}\n  record_log contents: {recorded}",
+            FIXTURE_CHILD_WAIT_MS,
+            record_log.exists(),
+        );
+        recorded
+    }
+
     /// Poll `.loom/scripts/spawn-claude.sh` fixture installation: write a
     /// custom script body + exec bit into `workspace` and return a registry
     /// configured to spawn it. Used by the child-process-lifecycle tests
@@ -4286,19 +4306,7 @@ exit 0
         // the final line (LOOM_TERMINAL_ID) so the assertion isn't racing
         // mid-write.
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
-        let sweep_log = dir
-            .path()
-            .join(".loom")
-            .join("logs")
-            .join("sweep-issue-42.log");
-        assert!(
-            wait_for_contents(&record_log, &needle, 10000),
-            "fake spawn-claude.sh did not finish writing within 10s\n  record_log: {}\n  record_log exists: {}\n  sweep_log: {}",
-            std::fs::read_to_string(&record_log).unwrap_or_default(),
-            record_log.exists(),
-            std::fs::read_to_string(&sweep_log).unwrap_or_default(),
-        );
-        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        let recorded = assert_child_wrote(&record_log, &needle);
         assert!(
             recorded.contains("argv: -p /loom:sweep 42"),
             "expected argv in recorded log; got: {recorded}"
@@ -4398,11 +4406,7 @@ exit 0
             .expect("dispatch should succeed");
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
-        assert!(
-            wait_for_contents(&record_log, &needle, 10000),
-            "fake spawn-claude.sh did not finish writing within 10s"
-        );
-        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        let recorded = assert_child_wrote(&record_log, &needle);
         assert!(
             recorded.contains("argv: -p /loom:sweep 4242 --dangerously-skip-permissions"),
             "expected --dangerously-skip-permissions appended after the prompt; got: {recorded}"
@@ -4425,11 +4429,7 @@ exit 0
             .expect("dispatch should succeed");
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
-        assert!(
-            wait_for_contents(&record_log, &needle, 10000),
-            "fake spawn-claude.sh did not finish writing within 10s"
-        );
-        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        let recorded = assert_child_wrote(&record_log, &needle);
         assert!(
             recorded.contains("LOOM_SWEEP_CLAIM_OWNED=4243"),
             "expected claim-ownership marker for issue 4243; got: {recorded}"
@@ -4453,11 +4453,7 @@ exit 0
             .expect("dispatch should succeed");
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
-        assert!(
-            wait_for_contents(&record_log, &needle, 10000),
-            "fake spawn-claude.sh did not finish writing within 10s"
-        );
-        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        let recorded = assert_child_wrote(&record_log, &needle);
         assert!(
             recorded.contains("CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0"),
             "expected print-mode bg-wait ceiling disabled (=0); got: {recorded}"
@@ -4556,11 +4552,7 @@ exit 0
             .expect("dispatch should succeed");
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
-        assert!(
-            wait_for_contents(&record_log, &needle, 10000),
-            "fake spawn-claude.sh did not finish writing within 10s"
-        );
-        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        let recorded = assert_child_wrote(&record_log, &needle);
         assert!(
             recorded.contains("argv: -p /loom:sweep 43 --model claude-sonnet-4-6"),
             "expected --model in argv; got: {recorded}"
@@ -4588,11 +4580,7 @@ exit 0
             .expect("dispatch should succeed");
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
-        assert!(
-            wait_for_contents(&record_log, &needle, 10000),
-            "fake spawn-claude.sh did not finish writing within 10s"
-        );
-        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        let recorded = assert_child_wrote(&record_log, &needle);
         assert!(
             !recorded.contains("--model"),
             "empty model must not emit --model; got: {recorded}"
@@ -4881,11 +4869,7 @@ exit 0
             .expect("dispatch should succeed");
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
-        assert!(
-            wait_for_contents(&record_log, &needle, 10000),
-            "fake spawn-claude.sh did not finish writing within 10s"
-        );
-        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        let recorded = assert_child_wrote(&record_log, &needle);
         assert!(
             recorded.contains("argv: -p /loom:sweep 45 --effort xhigh"),
             "expected --effort in argv; got: {recorded}"
@@ -4912,11 +4896,7 @@ exit 0
             .expect("dispatch should succeed");
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
-        assert!(
-            wait_for_contents(&record_log, &needle, 10000),
-            "fake spawn-claude.sh did not finish writing within 10s"
-        );
-        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        let recorded = assert_child_wrote(&record_log, &needle);
         assert!(
             recorded.contains("argv: -p /loom:sweep 46 --model claude-sonnet-4-6 --effort xhigh"),
             "expected --model then --effort in argv; got: {recorded}"
@@ -4939,11 +4919,7 @@ exit 0
             .expect("dispatch should succeed");
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
-        assert!(
-            wait_for_contents(&record_log, &needle, 10000),
-            "fake spawn-claude.sh did not finish writing within 10s"
-        );
-        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        let recorded = assert_child_wrote(&record_log, &needle);
         assert!(
             !recorded.contains("--effort"),
             "empty effort must not emit --effort; got: {recorded}"
@@ -4971,11 +4947,7 @@ exit 0
             .expect("dispatch should succeed");
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
-        assert!(
-            wait_for_contents(&record_log, &needle, 10000),
-            "fake spawn-claude.sh did not finish writing within 10s"
-        );
-        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        let recorded = assert_child_wrote(&record_log, &needle);
         assert!(
             recorded.contains("argv: -p /loom:sweep 50 --depends-on 49"),
             "expected --depends-on in argv; got: {recorded}"
@@ -5000,11 +4972,7 @@ exit 0
             .expect("dispatch should succeed");
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
-        assert!(
-            wait_for_contents(&record_log, &needle, 10000),
-            "fake spawn-claude.sh did not finish writing within 10s"
-        );
-        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        let recorded = assert_child_wrote(&record_log, &needle);
         assert!(
             !recorded.contains("--depends-on"),
             "depends_on=None must not emit --depends-on; got: {recorded}"
@@ -5152,11 +5120,7 @@ exit 0
         std::env::remove_var("LOOM_TRANSCRIPT_ARCHIVE");
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
-        assert!(
-            wait_for_contents(&record_log, &needle, 10000),
-            "fake spawn-claude.sh did not finish writing within 10s"
-        );
-        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        let recorded = assert_child_wrote(&record_log, &needle);
         assert!(
             recorded.contains("LOOM_MODEL_EXPERIMENT=canary"),
             "expected LOOM_MODEL_EXPERIMENT forwarded to child; got: {recorded}"
@@ -5198,11 +5162,7 @@ exit 0
             .expect("dispatch should succeed");
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
-        assert!(
-            wait_for_contents(&record_log, &needle, 10000),
-            "fake spawn-claude.sh did not finish writing within 10s"
-        );
-        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        let recorded = assert_child_wrote(&record_log, &needle);
         // The fixture prints `<VAR>=unset` when the child sees the var unset.
         assert!(
             recorded.contains("LOOM_MODEL_EXPERIMENT=unset"),
@@ -6465,12 +6425,7 @@ exit 0
         assert!(outcome.was_new);
 
         let needle = format!("CLAUDE_CODE_OAUTH_TOKEN={token_value}");
-        assert!(
-            wait_for_contents(&record_log, &needle, 10000),
-            "fake spawn did not record OAuth token within 10s; got: {}",
-            std::fs::read_to_string(&record_log).unwrap_or_default()
-        );
-        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        let recorded = assert_child_wrote(&record_log, &needle);
         assert!(
             recorded.contains(".loom/tokens/agent-1.token"),
             "expected TOKEN_SOURCE to point at .loom/tokens/; got: {recorded}"
@@ -7173,7 +7128,8 @@ exit 0\n";
         let leader_pid = outcome.pid;
         let sweep_id = outcome.sweep_id.clone();
 
-        let gc_pid = read_pid_file(&gc_pidfile, 5000).expect("grandchild pid should be recorded");
+        let gc_pid = read_pid_file(&gc_pidfile, FIXTURE_CHILD_WAIT_MS)
+            .expect("grandchild pid should be recorded");
         assert!(is_pid_alive(leader_pid), "leader should be running post-dispatch");
         assert!(is_pid_alive(gc_pid), "grandchild should be running post-dispatch");
         assert_ne!(leader_pid, gc_pid);
@@ -7188,9 +7144,12 @@ exit 0\n";
         // The ENTIRE tree must be gone. The grandchild assertion is the crux:
         // it proves the signal reached the whole process group (#3800), not
         // just the tracked leader PID.
-        assert!(wait_until_dead(leader_pid, 3000), "leader still alive after cancel");
         assert!(
-            wait_until_dead(gc_pid, 3000),
+            wait_until_dead(leader_pid, FIXTURE_CHILD_WAIT_MS),
+            "leader still alive after cancel"
+        );
+        assert!(
+            wait_until_dead(gc_pid, FIXTURE_CHILD_WAIT_MS),
             "grandchild survived cancel — group-kill did not reach it (single-PID regression)"
         );
 
@@ -7219,7 +7178,7 @@ exit 0\n";
         let sweep_id = outcome.sweep_id.clone();
 
         // Let the child start.
-        assert!(wait_until_alive(pid, 3000), "child should have started");
+        assert!(wait_until_alive(pid, FIXTURE_CHILD_WAIT_MS), "child should have started");
         assert!(matches!(registry.get(&sweep_id).unwrap().state, SweepState::Running));
 
         // Kill out of band: SIGKILL the leader PID directly (mimics an
@@ -7249,7 +7208,7 @@ exit 0\n";
         // No zombie: because try_wait() reaped the child, kill(pid, 0) now
         // fails (the PID is no longer in the process table).
         assert!(
-            wait_until_dead(pid, 2000),
+            wait_until_dead(pid, FIXTURE_CHILD_WAIT_MS),
             "killed child left a <defunct> zombie — reaper did not wait() it"
         );
     }
@@ -7275,10 +7234,25 @@ exit 0\n";
             .expect("dispatch should succeed");
         let sweep_id = outcome.sweep_id.clone();
 
-        // Reap-on-read reconciles liveness via the retained handle's
-        // `try_wait()`. Bound the loop to ~2s to prove "prompt" — a healthy
-        // implementation transitions on the first reconcile once the child has
-        // exited (`try_wait` reaps the zombie and yields the exit status).
+        // Phase 1 (#4044): wait generously for the fixture child to actually
+        // exit. Under host exec-latency pressure (syspolicyd, AV scanners),
+        // launching the child and running it to `exit 0` can itself take far
+        // longer than the promptness bound below — that latency is a host
+        // condition, not the property under test, so it gets the same
+        // generous ceiling as every other fixture-child wait.
+        assert!(
+            wait_until_dead(outcome.pid, FIXTURE_CHILD_WAIT_MS),
+            "fixture child did not exit within the wait budget"
+        );
+
+        // Phase 2: reap-on-read reconciles liveness via the retained handle's
+        // `try_wait()`. Bound THIS loop to ~2s to prove "prompt" — a healthy
+        // implementation transitions on the first reconcile once the child is
+        // confirmed dead (`try_wait` reaps the zombie and yields the exit
+        // status). Because Phase 1 already confirmed death, this bound now
+        // measures reap promptness from confirmed death, not from dispatch —
+        // it can no longer be falsely reddened by the child's own launch
+        // latency.
         let mut still_running = true;
         for _ in 0..80 {
             registry.reap_liveness();
@@ -7397,8 +7371,14 @@ exit 0\n";
             .expect("dispatch should succeed");
         let sweep_id = outcome.sweep_id.clone();
 
-        // Ensure the child has actually exited before we reap-on-read.
-        assert!(wait_until_dead(outcome.pid, 5000), "fake spawn child should exit promptly");
+        // Ensure the child has actually exited before we reap-on-read. This
+        // gate is generous (#4044) — it is not part of the bounded-gh
+        // property under test below, which starts timing only after this
+        // point.
+        assert!(
+            wait_until_dead(outcome.pid, FIXTURE_CHILD_WAIT_MS),
+            "fake spawn child did not exit within the wait budget"
+        );
 
         // The read-path reap must return well under the ~15-minute hang. It
         // kills the wedged gh at the 1s bound; generous headroom covers poll
@@ -7954,7 +7934,10 @@ exit 0\n";
         let out = reg
             .dispatch(&SweepKind::Issue(4242), None, None, None, None)
             .unwrap();
-        assert!(wait_until_alive(out.pid, 5000), "hung fixture child should start");
+        assert!(
+            wait_until_alive(out.pid, FIXTURE_CHILD_WAIT_MS),
+            "hung fixture child should start"
+        );
         let first_id = out.sweep_id.clone();
 
         // 2. Healthy while inside the timeout window.
@@ -8003,7 +7986,7 @@ exit 0\n";
         let out = reg
             .dispatch(&SweepKind::Issue(4343), None, None, None, None)
             .unwrap();
-        assert!(wait_until_alive(out.pid, 5000));
+        assert!(wait_until_alive(out.pid, FIXTURE_CHILD_WAIT_MS));
 
         // Simulate progress: create a worktree for the issue.
         let wt = ws.join(".loom").join("worktrees").join("issue-4343");
@@ -8348,7 +8331,7 @@ exit 0\n";
         let out = reg
             .dispatch(&SweepKind::Issue(5150), None, None, None, None)
             .unwrap();
-        assert!(wait_until_alive(out.pid, 5000));
+        assert!(wait_until_alive(out.pid, FIXTURE_CHILD_WAIT_MS));
 
         // No worktree/checkpoint yet ⇒ NOT past startup ⇒ the review-stall
         // watchdog leaves it entirely to the #3887 startup watchdog, even with a
@@ -8371,7 +8354,7 @@ exit 0\n";
         let out = reg
             .dispatch(&SweepKind::Issue(5252), None, None, None, None)
             .unwrap();
-        assert!(wait_until_alive(out.pid, 5000), "fixture child should start");
+        assert!(wait_until_alive(out.pid, FIXTURE_CHILD_WAIT_MS), "fixture child should start");
         let wt = ws.join(".loom").join("worktrees").join("issue-5252");
         std::fs::create_dir_all(&wt).unwrap();
 

--- a/loom-daemon/src/token_ranking_refresh.rs
+++ b/loom-daemon/src/token_ranking_refresh.rs
@@ -914,6 +914,13 @@ mod tests {
         }
     }
 
+    /// Issue #4044: these tests wait on a genuine `spawn_blocking` OS thread
+    /// (not process exec), but a saturated host scheduler can still starve
+    /// that thread past a short deadline — a false red, not a code fault.
+    /// The polling helpers below return the instant the condition is met, so
+    /// a generous ceiling costs nothing on a healthy host.
+    const SCHEDULER_WAIT: Duration = Duration::from_secs(90);
+
     /// Poll `calls` (real wall-clock time — `refresh()` runs on a genuine
     /// `spawn_blocking` OS thread, so a paused tokio clock can't stand in for
     /// waiting on it) until it reaches `target`, or panic after `timeout`.
@@ -948,8 +955,8 @@ mod tests {
         // OS thread completing).
         let handle = spawn_token_ranking_refresh_task(runner, Duration::from_millis(20));
 
-        wait_for_calls(&calls, 1, Duration::from_secs(2)).await;
-        wait_for_calls(&calls, 3, Duration::from_secs(2)).await;
+        wait_for_calls(&calls, 1, SCHEDULER_WAIT).await;
+        wait_for_calls(&calls, 3, SCHEDULER_WAIT).await;
 
         handle.abort();
     }
@@ -965,7 +972,7 @@ mod tests {
         let handle = spawn_token_ranking_refresh_task(PanicOnceRunner, Duration::from_millis(20));
         // The loop should observe the panicked blocking task and return
         // (rather than hang or propagate the panic to the caller).
-        let result = tokio::time::timeout(Duration::from_secs(5), handle).await;
+        let result = tokio::time::timeout(SCHEDULER_WAIT, handle).await;
         assert!(result.is_ok(), "loop task should finish (not hang) after the runner panics");
     }
 }

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -1633,6 +1633,15 @@ exit 0
     #[test]
     #[serial]
     fn test_registry_dispatcher_exports_claim_ownership_marker() {
+        // Issue #4044: mirrors `sweep_registry::tests::FIXTURE_CHILD_WAIT_MS`
+        // (that const is private to `sweep_registry`'s test module, so it
+        // can't be reused here directly). A short fixed poll bound falsely
+        // reddens this test under host exec-latency pressure (syspolicyd,
+        // AV scanners delaying the spawned child's launch) — the bound is a
+        // ceiling on a healthy-host-cheap poll, not a promptness assertion,
+        // so widening it is free.
+        const FIXTURE_CHILD_WAIT_MS: u128 = 120_000;
+
         let (mut dispatcher, _dir, record_log) = setup_registry_dispatcher_in_tempdir();
 
         let was_new = dispatcher.dispatch(3964).expect("dispatch should succeed");
@@ -1640,7 +1649,7 @@ exit 0
 
         let start = std::time::Instant::now();
         let mut recorded = String::new();
-        while start.elapsed().as_millis() < 5000 {
+        while start.elapsed().as_millis() < FIXTURE_CHILD_WAIT_MS {
             if let Ok(s) = std::fs::read_to_string(&record_log) {
                 if s.contains("LOOM_SWEEP_CLAIM_OWNED=") {
                     recorded = s;


### PR DESCRIPTION
## Summary

17 daemon test failures on 2026-07-27 were traced to host `exec`-latency pressure (`syspolicyd` saturation), not real bugs — the identical `cargo test --workspace --lib --bins` command passed green (968/968) a few hours later with no code change. This is a tests-only mechanical migration: replace the remaining hardcoded short waits for a fixture child process with the existing generous `FIXTURE_CHILD_WAIT_MS` (120s) ceiling, added by #4024 for exactly this hazard. Since every polling helper here returns the instant its condition is met, a generous ceiling costs nothing on a healthy host.

## Changes

- **`loom-daemon/src/sweep_registry.rs`**:
  - Migrated all 14 `wait_for_contents(&record_log, &needle, 10000)` call sites to `FIXTURE_CHILD_WAIT_MS`.
  - Widened ~10 sibling child-lifecycle waits with the same exposure: `read_pid_file(..., 5000)`, `wait_until_dead(..., 3000/2000/5000)`, `wait_until_alive(..., 3000/5000)`.
  - Added a shared `assert_child_wrote(record_log, needle) -> String` helper (folds the "distinguish never-started vs wrong-content" failure-message pattern already demonstrated at one call site into all 14 migrated sites), replacing per-site boilerplate.
  - Preserved the two intentional **promptness** assertions as properties under test, not blanket-widened:
    - `read_path_reaps_exited_child_out_of_running_promptly`: split into two phases — Phase 1 waits generously (`wait_until_dead(pid, FIXTURE_CHILD_WAIT_MS)`) for the child to actually exit; Phase 2 keeps its original ~2s bound but now measures reap-promptness from *confirmed death*, not from dispatch time.
    - `read_path_reap_is_bounded_when_gh_wedges`: its `elapsed < 15s` assertion (the bounded-`gh` property, #3973) is untouched; only the preceding `wait_until_dead(outcome.pid, 5000)` gate widened.
- **`loom-daemon/src/work_finder.rs`**: replaced the inline ~5000ms poll loop in `test_registry_dispatcher_exports_claim_ownership_marker` with a local `FIXTURE_CHILD_WAIT_MS` const (120s) — the test module can't see `sweep_registry`'s private const, so it's duplicated with a cross-reference comment (minimal option, no shared test-support module existed).
- **`loom-daemon/src/token_ranking_refresh.rs`**: widened the `wait_for_calls(&calls, N, Duration::from_secs(2))` deadlines and the `Duration::from_secs(5)` timeout in `test_loop_stops_cleanly_when_runner_panics` to a shared `SCHEDULER_WAIT = Duration::from_secs(90)` — these wait on a genuine `spawn_blocking` OS thread (no process exec), but a saturated host scheduler can still starve that thread past a short deadline.

No production code changed — tests only.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|---------------|
| Replace fixed 10s spawn waits with a generous bound | Done | All 14 sites in `sweep_registry.rs` now use `FIXTURE_CHILD_WAIT_MS` (120s) |
| Poll to a long ceiling where the test only needs "child eventually wrote X" | Done | ~10 sibling lifecycle waits (`read_pid_file`/`wait_until_dead`/`wait_until_alive`) widened the same way |
| Failure messages distinguish never-started vs wrong-content | Done | New `assert_child_wrote` helper reports needle, `record_log.exists()`, and full contents on timeout |
| Re-run under artificial exec-latency pressure and confirm green | Verified locally (not committed) | See Test Plan below |
| Preserve the two promptness assertions as properties, not widen blindly | Done | Phase-separated `read_path_reaps_exited_child_out_of_running_promptly`; `read_path_reap_is_bounded_when_gh_wedges`'s `elapsed < 15s` untouched |
| `rg -n '10000' loom-daemon/src/sweep_registry.rs` returns no remaining fixed spawn-wait bounds | Done | `rg -n '10000' loom-daemon/src/sweep_registry.rs` → no matches |

## Test Plan

- `cargo test --workspace --lib --bins` (from `loom-daemon/`): **1185 passed + 21 passed (main.rs bin tests), 0 failed**.
- `cargo test --lib sweep_registry::` / `work_finder::` / `token_ranking_refresh` individually: all green, including both promptness tests (`read_path_reaps_exited_child_out_of_running_promptly`, `read_path_reap_is_bounded_when_gh_wedges`).
- `cargo fmt --all -- --check` and `cargo clippy --lib --bins --tests`: clean.
- `rg -n '10000' loom-daemon/src/sweep_registry.rs`: no matches.
- Manual exec-latency simulation (local-only, not committed): temporarily prefixed the fixture's fake `spawn-claude.sh` body with `sleep 15` (exceeds the old 10s bound, sits far under the new 120s ceiling) and re-ran the `dispatch_*` tests — confirmed they failed under the old 10000ms literal and passed after the migration to `FIXTURE_CHILD_WAIT_MS`. No temporary change was committed.

Closes #4044