### PR TITLE
feat(daemon): observe cross-host dispatch collisions at label-flip time

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -1426,6 +1426,8 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.watchdog.intervalSecs` | `LOOM_SWEEP_WATCHDOG_INTERVAL_SECS` | `30` | Watchdog probe cadence (shared by all three backstops) |
 | `autonomous.watchdog.reviewStall` | `LOOM_SWEEP_REVIEW_STALL` | `true` | Review-phase stall watchdog on/off (#3910) |
 | `autonomous.watchdog.reviewStallTimeoutSecs` | `LOOM_SWEEP_REVIEW_STALL_TIMEOUT_SECS` | `2700` | Log-silence window before a hung Judge/Doctor sweep is re-dispatched |
+| `autonomous.collisionDetection.enabled` | `LOOM_DETECT_COLLISIONS` | `false` | Cross-host dispatch-collision baseline (#4085). Off by default — adds one extra `gh issue view --json labels` round-trip per dispatch. Detection only: a collision is logged/counted, never acted on |
+| *(host identity, records only)* | `LOOM_HOST_ID` | `$HOSTNAME` → `hostname` → `unknown-host` | Overrides this host's identity string in collision log records (#4085); set it where the daemon runs without `$HOSTNAME` exported |
 
 ### Daemon log path override (`LOOM_DAEMON_LOG`, #4010)
 
@@ -1574,6 +1576,52 @@ candidate is dropped **before** the global slot-fill pass, so a workspace whose
 only candidates are quarantined never reserves a shared dispatch slot — healthy
 sibling work in other repos gets it instead. Defaults **on**; disable with
 `LOOM_WORK_FINDER_QUARANTINE=0` or `autonomous.workFinder.quarantine.enabled = false`.
+
+### Cross-host dispatch-collision baseline (#4085, Phase 0 of #4028)
+
+When two `loom-daemon` hosts share one repo backlog, both can dispatch the same
+issue: the `mkdir` claim lock (`.loom/locks/issue-<N>/`) is filesystem-local, so
+a peer host's lock is invisible, and the `loom:issue → loom:building` flip
+succeeds whether or not the label was still there — the losing host is never
+told it lost. This makes the cross-host collision rate **unobservable**, which is
+the prerequisite gap #4028's coordination layer has to justify closing.
+
+Collision detection makes that rate **measurable** (detection only — no
+coordination, no backoff, behavior is otherwise unchanged). When enabled, just
+before the label flip the registry reads the issue's **pre-flip** label state
+(`gh issue view <N> --json labels`) and classifies it:
+
+- `loom:issue` already gone **or** `loom:building` already present → **collision**
+  (a peer host claimed it first). A diagnostic record is logged at `warn` — issue
+  number, repo/workspace, this host's identity (`LOOM_HOST_ID` → `$HOSTNAME` →
+  `hostname` → `unknown-host`), timestamp, and the observed pre-flip label set —
+  and a per-registry cumulative counter is incremented.
+- `loom:issue` present and `loom:building` absent → **clean** (this host is first).
+- gh timeout / non-zero exit / unparseable JSON → **unknown**. **Fail-closed:**
+  an unverifiable read is never counted as a collision, so the baseline is never
+  inflated.
+
+**How to read the count.** The running total is surfaced on the work-finder's
+per-tick summary line as the trailing `N cross-host-collision(s)` field, e.g.:
+
+```
+work_finder: tick — cap 3 (...); 5 seen, 2 dispatched, 1 labeled-skip,
+0 in-flight-skip, 0 quarantine-skip, 0 deferred, 0 error(s), 3 cross-host-collision(s)
+```
+
+Unlike the other (per-tick) counters, this one is a **monotonic cumulative
+total** read from the dispatcher(s) at tick end (summed across workspaces in the
+multi-repo tick), so successive lines show the baseline accumulate. It is `0`
+whenever detection is disabled. The existing fields (`labeled-skip` /
+`in-flight-skip` / `quarantine-skip` …) keep their names and semantics unchanged.
+
+**Cost / default.** Enabling detection adds exactly one `gh issue view --json
+labels` round-trip per dispatch (measured ~0.4s against GitHub), bounded by the
+same `LOOM_REAP_GH_TIMEOUT_SECS` ceiling as the other best-effort `gh` calls.
+Because that is a real per-dispatch API cost it is **off by default**; enable it
+per the config/env row above (`LOOM_DETECT_COLLISIONS=1` or
+`autonomous.collisionDetection.enabled = true`, precedence **env > config >
+default**) on the hosts sharing a backlog while you take the measurement.
 
 ### Prerequisite: a fresh token ranking (#3894, self-refreshed by the daemon since #3969)
 

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -688,6 +688,21 @@ async fn main() -> Result<()> {
         quarantine_config.insta_crash_secs
     );
 
+    // Cross-host collision detection (#4085, Phase 0 of #4028): resolve env >
+    // config > default(off) for the default workspace so a shared-backlog
+    // deployment can measure the baseline duplicate-dispatch rate. Detection
+    // only — a detected collision is logged/counted, never acted on.
+    let detect_collisions = sweep_registry::resolve_collision_detection(&sweep_workspace);
+    sweep.set_collision_detection(detect_collisions);
+    log::info!(
+        "sweep_registry: cross-host collision detection {} (#4085)",
+        if detect_collisions {
+            "enabled"
+        } else {
+            "disabled"
+        }
+    );
+
     let sweep_registry = Arc::new(Mutex::new(sweep));
     let _reaper_handle = sweep_registry::spawn_reaper_task(sweep_registry.clone());
 

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -482,6 +482,21 @@ pub const REVIEW_STALL_ENABLE_ENV: &str = "LOOM_SWEEP_REVIEW_STALL";
 /// seconds.
 pub const REVIEW_STALL_TIMEOUT_ENV: &str = "LOOM_SWEEP_REVIEW_STALL_TIMEOUT_SECS";
 
+/// Env var toggling cross-host dispatch-collision detection (Issue #4085,
+/// Phase 0 of #4028). Precedence **env > config > default**; default **off**
+/// because the probe adds one extra `gh issue view` round-trip per dispatch.
+/// `1`/`true`/`yes`/`on` enable; anything else disables. When enabled, the
+/// daemon does a pre-flip label read and records — but never acts on — the
+/// case where a peer host already claimed the issue. Detection only.
+pub const COLLISION_DETECT_ENV: &str = "LOOM_DETECT_COLLISIONS";
+
+/// Env var overriding this host's identity string in collision records (Issue
+/// #4085). Falls back to `$HOSTNAME`, then the `hostname` binary, then
+/// `"unknown-host"`. Set it when the daemon runs somewhere `$HOSTNAME` is not
+/// exported (a non-interactive service unit) so cross-host collision logs stay
+/// attributable.
+pub const HOST_ID_ENV: &str = "LOOM_HOST_ID";
+
 /// Default review-phase stall timeout (45 min of zero log output). A sweep that
 /// has already made startup progress (worktree/checkpoint exists) but whose log
 /// file has not been appended to within this window is treated as wedged in a
@@ -1095,6 +1110,64 @@ pub struct SweepRegistry {
     /// releases it. Keyed by issue number; since each registry is scoped to one
     /// workspace root, this is effectively a `(workspace, issue)` key.
     quarantined: HashMap<u32, DateTime<Utc>>,
+    /// Whether cross-host dispatch-collision detection is enabled (Issue #4085,
+    /// Phase 0 of #4028). When `true`, [`dispatch`](Self::dispatch) issues a
+    /// pre-flip `gh issue view --json labels` read and classifies whether a peer
+    /// host already flipped `loom:issue → loom:building`. Off by default (the
+    /// probe adds one extra API round-trip); `main.rs` / [`WorkspacePool`] set
+    /// the resolved env > config > default value. Detection only — a detected
+    /// collision never changes dispatch behavior.
+    ///
+    /// [`WorkspacePool`]: crate::workspace_pool::WorkspacePool
+    detect_collisions: bool,
+    /// Cumulative count of cross-host dispatch collisions this registry has
+    /// observed (Issue #4085). Incremented once per dispatch whose pre-flip
+    /// label read showed `loom:issue` already gone (or `loom:building` already
+    /// present) — i.e. another host claimed the issue first. Surfaced to
+    /// operators via the work-finder's per-tick summary line. Always `0` when
+    /// `detect_collisions` is `false`. Monotonic for the life of the process.
+    collision_count: u64,
+}
+
+/// Classification of a pre-flip label read (Issue #4085). Detection only — the
+/// caller records the outcome but never changes dispatch behavior on it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CollisionClass {
+    /// `loom:issue` was still present and `loom:building` absent — this host is
+    /// the first claimant, no collision.
+    Clean,
+    /// `loom:issue` was already gone, or `loom:building` already present, before
+    /// this host flipped the labels — a peer host claimed it first. Carries the
+    /// observed pre-flip label set for the diagnostic log record.
+    Collision { labels: Vec<String> },
+    /// The label state could not be read (gh timeout / non-zero exit /
+    /// unparseable JSON). **Fail-closed**: never counted as a collision, so the
+    /// baseline is never inflated by an unverifiable flip.
+    Unknown,
+}
+
+/// Resolve this host's identity string for collision records (Issue #4085),
+/// precedence `LOOM_HOST_ID` env > `$HOSTNAME` env > the `hostname` binary >
+/// `"unknown-host"`. Only invoked when a collision is actually recorded (rare),
+/// so the one-shot `hostname` subprocess is not on the hot dispatch path.
+fn host_identity() -> String {
+    for var in [HOST_ID_ENV, "HOSTNAME"] {
+        if let Ok(v) = std::env::var(var) {
+            let t = v.trim();
+            if !t.is_empty() {
+                return t.to_string();
+            }
+        }
+    }
+    if let Ok(out) = Command::new("hostname").output() {
+        if out.status.success() {
+            let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !s.is_empty() {
+                return s;
+            }
+        }
+    }
+    "unknown-host".to_string()
 }
 
 impl SweepRegistry {
@@ -1120,6 +1193,8 @@ impl SweepRegistry {
             quarantine_config: QuarantineConfig::default(),
             insta_crash_counts: HashMap::new(),
             quarantined: HashMap::new(),
+            detect_collisions: false,
+            collision_count: 0,
         }
     }
 
@@ -1142,6 +1217,8 @@ impl SweepRegistry {
             quarantine_config: QuarantineConfig::default(),
             insta_crash_counts: HashMap::new(),
             quarantined: HashMap::new(),
+            detect_collisions: false,
+            collision_count: 0,
         }
     }
 
@@ -1176,6 +1253,29 @@ impl SweepRegistry {
     #[must_use]
     pub fn quarantine_config(&self) -> QuarantineConfig {
         self.quarantine_config
+    }
+
+    /// Enable or disable cross-host dispatch-collision detection (Issue #4085).
+    /// `main.rs` and the workspace pool call this once at provision time with
+    /// the resolved env > config > default value (see
+    /// [`resolve_collision_detection`]).
+    pub fn set_collision_detection(&mut self, enabled: bool) {
+        self.detect_collisions = enabled;
+    }
+
+    /// Read-only accessor for whether collision detection is enabled (Issue
+    /// #4085).
+    #[must_use]
+    pub fn collision_detection_enabled(&self) -> bool {
+        self.detect_collisions
+    }
+
+    /// Cumulative count of cross-host dispatch collisions observed by this
+    /// registry (Issue #4085). Always `0` when detection is disabled. Read by
+    /// the work-finder to surface the running baseline on its per-tick line.
+    #[must_use]
+    pub fn collision_count(&self) -> u64 {
+        self.collision_count
     }
 
     /// The set of issue numbers currently quarantined for insta-crashing (Issue
@@ -1353,6 +1453,14 @@ impl SweepRegistry {
         //    when the dispatcher has gh credentials; tests opt out via
         //    `skip_label_flip`).
         if !self.config.skip_label_flip {
+            // 4a. Cross-host collision baseline (Issue #4085, Phase 0 of #4028):
+            //     read the pre-flip label state and record — but never act on —
+            //     the case where a peer host already claimed this issue. A no-op
+            //     when detection is disabled (default), so the flip path below is
+            //     byte-for-byte unchanged. Must run BEFORE the flip: once this
+            //     host flips, a collided issue is indistinguishable from a clean
+            //     one.
+            self.detect_and_record_collision(issue_number);
             if let Err(e) = self.flip_label_to_building(issue_number) {
                 log::warn!(
                     "label flip for issue #{issue_number} failed (continuing dispatch): {e}"
@@ -1583,6 +1691,103 @@ impl SweepRegistry {
             issue,
         ) {
             log::debug!("sweep_journal: failed to remove entry for #{issue}: {e}");
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // Cross-host collision detection (Issue #4085, Phase 0 of #4028)
+    // ------------------------------------------------------------------------
+
+    /// Read the issue's **current** forge labels and classify whether a peer
+    /// host already claimed it (Issue #4085). Called by [`dispatch`](Self::dispatch)
+    /// immediately *before* the label flip, when detection is enabled — a
+    /// post-flip read cannot distinguish a collided issue from a clean one (both
+    /// end up `loom:building`), so the observation must happen pre-flip.
+    ///
+    /// Uses a bounded `gh issue view <N> --json labels`. **Fail-closed**: any
+    /// timeout, non-zero exit, or unparseable payload resolves to
+    /// [`CollisionClass::Unknown`], never `Collision`, so the baseline is never
+    /// inflated by an unverifiable read. The `gh issue edit` flip itself is left
+    /// byte-for-byte unchanged.
+    fn classify_preflip_labels(&self, issue: u32) -> CollisionClass {
+        let gh = self
+            .config
+            .gh_bin
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("gh"));
+        let mut cmd = Command::new(&gh);
+        cmd.arg("issue")
+            .arg("view")
+            .arg(issue.to_string())
+            .arg("--json")
+            .arg("labels");
+        // Same workspace/repo scoping as the flip (#3937): resolve the issue
+        // against *this* registry's repo, not the daemon's cwd repo.
+        cmd.current_dir(&self.config.workspace_root);
+        if let Ok(repo) = std::env::var("LOOM_REPO") {
+            cmd.arg("--repo").arg(repo);
+        }
+        let timeout = reap_gh_timeout();
+        let output = match output_with_timeout(cmd, timeout) {
+            Ok(Some(o)) if o.status.success() => o,
+            Ok(Some(_)) => return CollisionClass::Unknown, // non-zero exit
+            Ok(None) => return CollisionClass::Unknown,    // timed out + killed
+            Err(_) => return CollisionClass::Unknown,      // spawn failure
+        };
+        // `gh issue view --json labels` emits `{"labels":[{"name":"..."},...]}`.
+        let parsed: serde_json::Value = match serde_json::from_slice(&output.stdout) {
+            Ok(v) => v,
+            Err(_) => return CollisionClass::Unknown,
+        };
+        let Some(arr) = parsed.get("labels").and_then(|l| l.as_array()) else {
+            return CollisionClass::Unknown;
+        };
+        let labels: Vec<String> = arr
+            .iter()
+            .filter_map(|l| l.get("name").and_then(|n| n.as_str()).map(String::from))
+            .collect();
+        let has_issue = labels.iter().any(|l| l == "loom:issue");
+        let has_building = labels.iter().any(|l| l == "loom:building");
+        if !has_issue || has_building {
+            CollisionClass::Collision { labels }
+        } else {
+            CollisionClass::Clean
+        }
+    }
+
+    /// When detection is enabled, probe the pre-flip label state and record —
+    /// but never act on — a cross-host collision (Issue #4085). A no-op (no `gh`
+    /// call at all) when detection is disabled, so the disabled dispatch path is
+    /// byte-for-byte unchanged. Increments [`collision_count`](Self::collision_count)
+    /// and logs a diagnostic record (issue, repo/workspace, host, timestamp,
+    /// observed pre-flip labels) on a confirmed collision.
+    fn detect_and_record_collision(&mut self, issue: u32) {
+        if !self.detect_collisions {
+            return;
+        }
+        match self.classify_preflip_labels(issue) {
+            CollisionClass::Collision { labels } => {
+                self.collision_count += 1;
+                log::warn!(
+                    "sweep_registry: cross-host dispatch collision (#4085) — issue #{issue} in \
+                     {repo} was already claimed by another host before host {host} flipped it at \
+                     {ts}; observed pre-flip labels=[{labels}]; running collision count={count} \
+                     (detection only — dispatch continues unchanged)",
+                    repo = self.config.workspace_root.display(),
+                    host = host_identity(),
+                    ts = Utc::now().to_rfc3339(),
+                    labels = labels.join(", "),
+                    count = self.collision_count,
+                );
+            }
+            CollisionClass::Unknown => {
+                // Fail-closed: an unverifiable read is never a collision.
+                log::debug!(
+                    "sweep_registry: collision probe for issue #{issue} inconclusive \
+                     (fail-closed, not counted) (#4085)"
+                );
+            }
+            CollisionClass::Clean => {}
         }
     }
 
@@ -3760,6 +3965,25 @@ pub fn resolve_review_stall_timeout(config: &StartupRaceConfig) -> Duration {
     Duration::from_secs(secs)
 }
 
+/// Resolve whether cross-host dispatch-collision detection runs (Issue #4085,
+/// Phase 0 of #4028), precedence **env > config > default(false)**. Reads
+/// `LOOM_DETECT_COLLISIONS` first, then `autonomous.collisionDetection.enabled`
+/// from the effective config, then defaults **off** (the probe adds one extra
+/// `gh issue view` round-trip per dispatch, so it is opt-in until a baseline
+/// justifies it).
+#[must_use]
+pub fn resolve_collision_detection(repo_root: &Path) -> bool {
+    if let Ok(v) = std::env::var(COLLISION_DETECT_ENV) {
+        return matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on");
+    }
+    let effective = crate::config_resolver::resolve_effective_config(repo_root);
+    crate::config_resolver::get_path(&effective, "autonomous")
+        .and_then(|a| a.get("collisionDetection"))
+        .and_then(|c| c.get("enabled"))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
 // ============================================================================
 // Insta-crash quarantine config resolution (Issue #3939)
 // ============================================================================
@@ -5758,6 +5982,188 @@ exit 0
             gh_calls.is_empty(),
             "expected no forge call for a no-op clear; got: {gh_calls:?}"
         );
+    }
+
+    // ====================================================================
+    // Cross-host collision detection (Issue #4085, Phase 0 of #4028)
+    // ====================================================================
+
+    /// Install a fake `gh` that logs its argv to `gh_log`, emits `stdout` on
+    /// stdout, and exits with `exit_code`. Returns the fake binary path. Reuses
+    /// the established bash-stub pattern (the `--json labels` payload is the one
+    /// addition the collision tests need over the flip/restore stubs).
+    fn install_fake_gh(dir: &Path, gh_log: &Path, stdout: &str, exit_code: i32) -> PathBuf {
+        let fake_gh = dir.join("fake-gh.sh");
+        let script = format!(
+            "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"{log}\"\nprintf '%s' '{out}'\nexit {code}\n",
+            log = gh_log.display(),
+            out = stdout.replace('\'', "'\\''"),
+            code = exit_code,
+        );
+        std::fs::write(&fake_gh, &script).unwrap();
+        let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_gh, perms).unwrap();
+        if let Ok(f) = std::fs::File::open(&fake_gh) {
+            let _ = f.sync_all();
+        }
+        fake_gh
+    }
+
+    fn collision_registry(
+        dir: &Path,
+        gh_log: &Path,
+        stdout: &str,
+        exit_code: i32,
+    ) -> SweepRegistry {
+        let fake_gh = install_fake_gh(dir, gh_log, stdout, exit_code);
+        let mut config = SweepRegistryConfig::new(dir.to_path_buf());
+        config.gh_bin = Some(fake_gh);
+        SweepRegistry::new(config)
+    }
+
+    /// A pre-flip read showing `loom:building` already present is a collision.
+    #[test]
+    fn classify_preflip_labels_flags_prior_building_claim() {
+        let dir = tempdir().unwrap();
+        let gh_log = dir.path().join("gh.log");
+        let registry = collision_registry(
+            dir.path(),
+            &gh_log,
+            r#"{"labels":[{"name":"loom:building"},{"name":"loom:curated"}]}"#,
+            0,
+        );
+        match registry.classify_preflip_labels(42) {
+            CollisionClass::Collision { labels } => {
+                assert!(labels.iter().any(|l| l == "loom:building"));
+            }
+            other => panic!("expected Collision, got {other:?}"),
+        }
+    }
+
+    /// A pre-flip read with `loom:issue` already gone is a collision even if
+    /// `loom:building` is not (yet) visible.
+    #[test]
+    fn classify_preflip_labels_flags_missing_issue_label() {
+        let dir = tempdir().unwrap();
+        let gh_log = dir.path().join("gh.log");
+        let registry = collision_registry(
+            dir.path(),
+            &gh_log,
+            r#"{"labels":[{"name":"tier:goal-supporting"}]}"#,
+            0,
+        );
+        assert!(matches!(registry.classify_preflip_labels(42), CollisionClass::Collision { .. }));
+    }
+
+    /// `loom:issue` still present and `loom:building` absent ⇒ this host is the
+    /// first claimant: Clean, not a collision.
+    #[test]
+    fn classify_preflip_labels_clean_when_issue_label_present() {
+        let dir = tempdir().unwrap();
+        let gh_log = dir.path().join("gh.log");
+        let registry = collision_registry(
+            dir.path(),
+            &gh_log,
+            r#"{"labels":[{"name":"loom:issue"},{"name":"loom:curated"}]}"#,
+            0,
+        );
+        assert_eq!(registry.classify_preflip_labels(42), CollisionClass::Clean);
+    }
+
+    /// Fail-closed: a non-zero `gh` exit is `Unknown`, never a collision — an
+    /// unverifiable read must not inflate the baseline.
+    #[test]
+    fn classify_preflip_labels_fail_closed_on_gh_error() {
+        let dir = tempdir().unwrap();
+        let gh_log = dir.path().join("gh.log");
+        let registry = collision_registry(dir.path(), &gh_log, "", 1);
+        assert_eq!(registry.classify_preflip_labels(42), CollisionClass::Unknown);
+    }
+
+    /// Fail-closed: unparseable stdout (exit 0 but not the expected JSON) is
+    /// `Unknown`, never a collision.
+    #[test]
+    fn classify_preflip_labels_fail_closed_on_unparseable() {
+        let dir = tempdir().unwrap();
+        let gh_log = dir.path().join("gh.log");
+        let registry = collision_registry(dir.path(), &gh_log, "not json at all", 0);
+        assert_eq!(registry.classify_preflip_labels(42), CollisionClass::Unknown);
+    }
+
+    /// With detection enabled, a collision increments the counter once per call;
+    /// an Unknown/Clean read does not.
+    #[test]
+    fn detect_and_record_collision_increments_counter() {
+        let dir = tempdir().unwrap();
+        let gh_log = dir.path().join("gh.log");
+        let mut registry =
+            collision_registry(dir.path(), &gh_log, r#"{"labels":[{"name":"loom:building"}]}"#, 0);
+        registry.set_collision_detection(true);
+        assert_eq!(registry.collision_count(), 0);
+        registry.detect_and_record_collision(42);
+        assert_eq!(registry.collision_count(), 1);
+        registry.detect_and_record_collision(43);
+        assert_eq!(registry.collision_count(), 2);
+    }
+
+    /// With detection DISABLED, `detect_and_record_collision` is a pure no-op:
+    /// no `gh` call at all (the disabled dispatch path is byte-for-byte
+    /// unchanged) and the counter stays zero.
+    #[test]
+    fn detect_and_record_collision_disabled_is_noop() {
+        let dir = tempdir().unwrap();
+        let gh_log = dir.path().join("gh.log");
+        let mut registry =
+            collision_registry(dir.path(), &gh_log, r#"{"labels":[{"name":"loom:building"}]}"#, 0);
+        // detection left at its default (false)
+        assert!(!registry.collision_detection_enabled());
+        registry.detect_and_record_collision(42);
+        assert_eq!(registry.collision_count(), 0);
+        let gh_calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            gh_calls.is_empty(),
+            "disabled detection must not invoke gh at all; got: {gh_calls:?}"
+        );
+    }
+
+    /// A fail-closed Unknown read never increments the counter even with
+    /// detection enabled.
+    #[test]
+    fn detect_and_record_collision_unknown_not_counted() {
+        let dir = tempdir().unwrap();
+        let gh_log = dir.path().join("gh.log");
+        let mut registry = collision_registry(dir.path(), &gh_log, "", 1);
+        registry.set_collision_detection(true);
+        registry.detect_and_record_collision(42);
+        assert_eq!(registry.collision_count(), 0, "Unknown must not count");
+    }
+
+    /// Config resolution honors precedence env > config > default(off) (#4085).
+    #[test]
+    #[serial]
+    fn resolve_collision_detection_env_overrides() {
+        std::env::remove_var(COLLISION_DETECT_ENV);
+        let dir = tempdir().unwrap();
+        // No file, no env → default off.
+        assert!(!resolve_collision_detection(dir.path()));
+
+        // Config file enables it.
+        let loom = dir.path().join(".loom");
+        std::fs::create_dir_all(&loom).unwrap();
+        std::fs::write(
+            loom.join("config.json"),
+            r#"{"autonomous":{"collisionDetection":{"enabled":true}}}"#,
+        )
+        .unwrap();
+        assert!(resolve_collision_detection(dir.path()), "config enables");
+
+        // Env overrides config (off wins over config-on).
+        std::env::set_var(COLLISION_DETECT_ENV, "off");
+        assert!(!resolve_collision_detection(dir.path()), "env off overrides config on");
+        std::env::set_var(COLLISION_DETECT_ENV, "1");
+        assert!(resolve_collision_detection(dir.path()), "env on");
+        std::env::remove_var(COLLISION_DETECT_ENV);
     }
 
     /// Config resolution honors precedence env > config > default (#3939).

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -325,6 +325,17 @@ pub trait WorkDispatcher {
         HashSet::new()
     }
 
+    /// Cumulative count of cross-host dispatch collisions this dispatcher's
+    /// registry has observed (Issue #4085, Phase 0 of #4028) — dispatches whose
+    /// pre-flip label read showed a peer host claimed the issue first. Read once
+    /// per tick and surfaced on the per-tick summary line so an operator can
+    /// watch the baseline collision rate. Defaults to `0` so a dispatcher that
+    /// does not model collision detection (e.g. a test fake, or a registry with
+    /// detection disabled) opts out with zero boilerplate.
+    fn collisions(&self) -> u64 {
+        0
+    }
+
     /// Dispatch a build sweep for `issue`. Returns `true` when a **new** sweep
     /// was started, `false` when the dispatch was an idempotency no-op (a sweep
     /// with the same key was already running).
@@ -360,6 +371,13 @@ pub struct TickReport {
     pub skipped_quarantined: usize,
     /// Dispatch attempts that returned an error (logged, non-fatal).
     pub errors: usize,
+    /// Cumulative cross-host dispatch collisions observed (Issue #4085, Phase 0
+    /// of #4028). Unlike the other counters — which are per-tick tallies — this
+    /// is a **monotonic total** read from the dispatcher(s) at tick end, so an
+    /// operator watching successive summary lines sees the baseline collision
+    /// rate accumulate. Always `0` unless collision detection is enabled
+    /// (`LOOM_DETECT_COLLISIONS` / `autonomous.collisionDetection.enabled`).
+    pub collisions: u64,
     /// True when at least one workspace was gated this tick because the
     /// main-health gate (Phase C, #3812) had halted its dispatch (`main` was
     /// **verified** red — see [`crate::main_health_gate::GateOutcome`]). `seen`
@@ -408,6 +426,9 @@ pub fn tick(
     // Reactive backstop: a red `main` halts all new dispatch this tick.
     if halted {
         report.halted = true;
+        // Surface the running collision baseline even on a halted tick (#4085) —
+        // no dispatch happens, so the total is just carried forward.
+        report.collisions = dispatcher.collisions();
         return Ok(report);
     }
 
@@ -457,6 +478,10 @@ pub fn tick(
             }
         }
     }
+
+    // Read the cumulative cross-host collision total AFTER the dispatch loop so
+    // any collision recorded during this tick's dispatches is included (#4085).
+    report.collisions = dispatcher.collisions();
 
     Ok(report)
 }
@@ -640,6 +665,9 @@ pub fn tick_multi<S: WorkSource, D: WorkDispatcher>(
     }
 
     report.halted = any_halted;
+    // Sum the cumulative cross-host collision totals across every workspace's
+    // dispatcher (#4085), read after pass 2 so this tick's collisions count.
+    report.collisions = workspaces.iter().map(|(_, d)| d.collisions()).sum();
     report
 }
 
@@ -1043,14 +1071,16 @@ where
                              healthy={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
                              cpu={cpu}, ceiling={configured_max}); \
                              {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, \
-                             {} quarantine-skip, {} deferred, {} error(s)",
+                             {} quarantine-skip, {} deferred, {} error(s), \
+                             {} cross-host-collision(s)",
                             report.seen,
                             report.dispatched,
                             report.skipped_labeled,
                             report.skipped_in_flight,
                             report.skipped_quarantined,
                             report.deferred_capacity,
-                            report.errors
+                            report.errors,
+                            report.collisions
                         );
                     }
                     // Token-capacity advisory (#3902) — surface on state change.
@@ -1222,7 +1252,8 @@ pub fn spawn_multi_work_finder_task(
                      healthy={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
                      cpu={cpu}, ceiling={configured_max}); {} workspace(s), \
                      {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, \
-                     {} quarantine-skip, {} deferred, {} error(s)",
+                     {} quarantine-skip, {} deferred, {} error(s), \
+                     {} cross-host-collision(s)",
                     pairs.len(),
                     report.seen,
                     report.dispatched,
@@ -1230,7 +1261,8 @@ pub fn spawn_multi_work_finder_task(
                     report.skipped_in_flight,
                     report.skipped_quarantined,
                     report.deferred_capacity,
-                    report.errors
+                    report.errors,
+                    report.collisions
                 );
             }
 
@@ -1487,6 +1519,16 @@ pub mod forge {
             }
         }
 
+        fn collisions(&self) -> u64 {
+            match self.registry.lock() {
+                Ok(reg) => reg.collision_count(),
+                Err(poisoned) => {
+                    log::error!("work_finder: sweep registry mutex poisoned ({poisoned:?})");
+                    0
+                }
+            }
+        }
+
         fn dispatch(&mut self, issue: u32) -> Result<bool> {
             let mut reg = self
                 .registry
@@ -1559,6 +1601,8 @@ mod tests {
         fail_issues: HashSet<u32>,
         /// Issue numbers this dispatcher reports as quarantined (Issue #3939).
         quarantined: HashSet<u32>,
+        /// Cumulative cross-host collision count this dispatcher reports (#4085).
+        collisions: u64,
     }
 
     impl WorkDispatcher for RecordingDispatcher {
@@ -1567,6 +1611,9 @@ mod tests {
         }
         fn quarantined(&self) -> HashSet<u32> {
             self.quarantined.clone()
+        }
+        fn collisions(&self) -> u64 {
+            self.collisions
         }
         fn dispatch(&mut self, issue: u32) -> Result<bool> {
             if self.fail_issues.contains(&issue) {
@@ -1816,6 +1863,60 @@ exit 0
         assert_eq!(report.skipped_in_flight, 1, "#1 was an idempotency no-op");
         assert_eq!(report.deferred_capacity, 0);
         assert_eq!(disp.dispatched, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_tick_surfaces_collision_total() {
+        // The dispatcher reports a cumulative cross-host collision count (#4085);
+        // the tick surfaces it on the report so the per-tick summary line can log
+        // the running baseline.
+        let mut source = FakeSource::once(vec![issue(1)]);
+        let mut disp = RecordingDispatcher {
+            collisions: 3,
+            ..Default::default()
+        };
+        let report = tick(&mut source, &mut disp, 5, false).unwrap();
+        assert_eq!(report.collisions, 3, "collision total surfaced from dispatcher");
+        assert_eq!(report.dispatched, 1);
+    }
+
+    #[test]
+    fn test_tick_collision_total_surfaced_when_halted() {
+        // Even on a halted tick (no dispatch), the running collision baseline is
+        // carried forward onto the report.
+        let mut source = FakeSource::once(vec![issue(1)]);
+        let mut disp = RecordingDispatcher {
+            collisions: 2,
+            ..Default::default()
+        };
+        let report = tick(&mut source, &mut disp, 5, true).unwrap();
+        assert!(report.halted);
+        assert_eq!(report.dispatched, 0);
+        assert_eq!(report.collisions, 2);
+    }
+
+    #[test]
+    fn test_tick_multi_sums_collision_totals() {
+        // tick_multi sums the collision totals across every workspace's
+        // dispatcher (#4085).
+        let mut multi = vec![
+            (
+                FakeSource::once(vec![issue(1)]),
+                RecordingDispatcher {
+                    collisions: 2,
+                    ..Default::default()
+                },
+            ),
+            (
+                FakeSource::once(vec![issue(2)]),
+                RecordingDispatcher {
+                    collisions: 5,
+                    ..Default::default()
+                },
+            ),
+        ];
+        let report = tick_multi(&mut multi, &[0, 0], 10, &[false, false]);
+        assert_eq!(report.collisions, 7, "collision totals summed across workspaces");
     }
 
     #[test]

--- a/loom-daemon/src/workspace_pool.rs
+++ b/loom-daemon/src/workspace_pool.rs
@@ -135,6 +135,10 @@ impl WorkspacePool {
         // workspace so the reaper quarantines a repeatedly-insta-crashing issue
         // instead of letting it be re-dispatched every tick.
         registry.set_quarantine_config(sweep_registry::resolve_quarantine_config(root));
+        // Cross-host collision detection (#4085): resolve env > config >
+        // default(off) so a shared-backlog deployment measures the baseline
+        // duplicate-dispatch rate. Detection only — never changes dispatch.
+        registry.set_collision_detection(sweep_registry::resolve_collision_detection(root));
 
         let arc = Arc::new(Mutex::new(registry));
         // Spawn the reaper on the shared daemon runtime regardless of which


### PR DESCRIPTION
## Summary

Makes cross-host duplicate `loom-daemon` dispatch of the same issue **observable** (Phase 0 of #4028). When two hosts share one repo backlog, both can flip `loom:issue -> loom:building` for the same issue and neither is told it lost — so the collision rate is currently unmeasurable, and any claim that #4028's coordination layer improves it is unfalsifiable. This adds an opt-in detection-only baseline. No coordination, no backoff, no behavior change on a detected collision.

## Implementation option chosen: **Option A (pre-flip read)**

Option A per the issue: before `flip_label_to_building`, when detection is enabled, issue `gh issue view <N> --json labels` and inspect the set. Chosen over Option B (REST `DELETE` label status code) because it leaves the existing `gh issue edit` flip **byte-for-byte intact**, is trivially unit-testable with the existing fake-`gh` harness, and directly yields the observed pre-flip label state the acceptance criteria ask for. Option B rewrites a load-bearing path (a second call to add `loom:building`, its own error taxonomy) for an accuracy gain the baseline does not need — the TOCTOU window in Option A under-counts rather than inflates, which is the safe direction for a baseline estimate. Option A's added latency (below) measured fine, so Option B's "only if A measures badly" condition was not triggered.

## Measured latency cost

The extra `gh issue view <N> --json labels` round-trip measured **~0.37-0.40s** against GitHub (3 samples: 0.37s, 0.40s, 0.38s). It is bounded by the same `LOOM_REAP_GH_TIMEOUT_SECS` ceiling as the daemon's other best-effort `gh` calls, and only runs when detection is explicitly enabled. Because it is a real per-dispatch API cost, detection is **off by default** and opt-in (see AC table). This does not meaningfully lengthen the dispatch path relative to the existing flip (itself a `gh` round-trip).

## Changes

- `loom-daemon/src/sweep_registry.rs`:
  - `classify_preflip_labels` — bounded `gh issue view --json labels`, returns `Collision { labels }` / `Clean` / `Unknown`; fail-closed on timeout/non-zero/unparseable.
  - `detect_and_record_collision` — called from `dispatch` just before the flip (no-op + zero `gh` calls when disabled); logs the diagnostic record and increments the counter on a confirmed collision.
  - `host_identity()` helper (`LOOM_HOST_ID` -> `$HOSTNAME` -> `hostname` -> `unknown-host`), `collision_count()` accessor, `set_collision_detection` setter, and `resolve_collision_detection` (env > config > default(off)).
- `loom-daemon/src/work_finder.rs`: `WorkDispatcher::collisions()` (default 0), `TickReport.collisions`, populated in `tick` (incl. halted path) and summed across workspaces in `tick_multi`, and appended to **both** per-tick summary log call sites as `N cross-host-collision(s)`. Existing fields unchanged.
- `loom-daemon/src/main.rs` + `workspace_pool.rs`: wire the resolved flag onto the seed registry and every pooled workspace registry.
- `.loom/docs/daemon-reference.md`: config rows + a dedicated section documenting the counter and how to read it.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Detects at dispatch time that another claimant flipped first; distinct collision counter (not folded into a skip counter) | Done | `detect_and_record_collision` runs pre-flip in `dispatch`; new `collision_count`, separate from `skipped_*`. `detect_and_record_collision_increments_counter` |
| Record carries issue #, repo/workspace, host identity, timestamp, observed pre-flip labels | Done | `log::warn!` record in `detect_and_record_collision` includes all five |
| Count surfaced via an existing read-only path (per-tick log line) | Done | `N cross-host-collision(s)` on both work-finder call sites; `test_tick_surfaces_collision_total`, `test_tick_multi_sums_collision_totals` |
| Detection only — dispatch behavior unchanged | Done | Detection precedes the untouched flip; nothing branches on the result |
| Default-on only if bounded+measured, else gated (env > config > default) | Done | Gated off by default; `resolve_collision_detection`, `resolve_collision_detection_env_overrides` |
| Zero behavior change single-host beyond the counter | Done | `detect_and_record_collision_disabled_is_noop` asserts no `gh` call when disabled |
| Per-tick log line existing fields not renamed/repurposed | Done | New field appended only; `labeled-skip` / `in-flight-skip` / `quarantine-skip` unchanged |
| Fail-closed on ambiguity (timeout/error/unparseable = unknown, not collision) | Done | `classify_preflip_labels_fail_closed_on_gh_error`, `_on_unparseable`, `detect_and_record_collision_unknown_not_counted` |

## Test Plan

- `cd loom-daemon && cargo test` — **green** (1197 lib + integration tests pass). Two `integration_security` terminal-ID-validation tests flaked once under concurrent test-binary load (machine-wide `cleanup_all_loom_sessions` race); both pass in isolation (`cargo test --test integration_security` → 14/14) and are unrelated to this change.
- New unit tests reuse the existing fake-`gh` bash-stub harness (stdout now also emits a `--json labels` payload). No fixed `sleep` added (per #4044).
- `cargo clippy --all-targets` clean; `cargo fmt` applied.

Closes #4085