### PR TITLE
fix(daemon): latch sweep progress per SweepId + 300s watchdog default + closed-issue dispatch guard

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -1382,7 +1382,7 @@ concurrency ceiling 5" and share it with the team:
     "dispatchStaggerMs": 2000,
     "watchdog": {
       "enabled": true,
-      "timeoutSecs": 120,
+      "timeoutSecs": 300,
       "intervalSecs": 30,
       "reviewStall": true,
       "reviewStallTimeoutSecs": 2700
@@ -1422,7 +1422,7 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.watchMonitor.expirySecs` | `LOOM_WATCH_MONITOR_EXPIRY_SECS` | `86400` | Give-up window for an unresolved watch; `0` disables expiry |
 | `autonomous.dispatchStaggerMs` | `LOOM_SWEEP_DISPATCH_STAGGER_MS` | `2000` | Min gap between consecutive child spawns (#3887). `0` disables |
 | `autonomous.watchdog.enabled` | `LOOM_SWEEP_WATCHDOG` | `true` | Startup watchdog on/off (#3887). Also the master switch for the tick — mid-build-death (#3895) + review-stall (#3910) run in the same task |
-| `autonomous.watchdog.timeoutSecs` | `LOOM_SWEEP_WATCHDOG_TIMEOUT_SECS` | `120` | No-progress window before auto-restart |
+| `autonomous.watchdog.timeoutSecs` | `LOOM_SWEEP_WATCHDOG_TIMEOUT_SECS` | `300` | No-progress window before auto-restart (raised from 120s in #4088 — the old default sat inside the observed 110–150s dispatch→worktree window and cancelled healthy sweeps) |
 | `autonomous.watchdog.intervalSecs` | `LOOM_SWEEP_WATCHDOG_INTERVAL_SECS` | `30` | Watchdog probe cadence (shared by all three backstops) |
 | `autonomous.watchdog.reviewStall` | `LOOM_SWEEP_REVIEW_STALL` | `true` | Review-phase stall watchdog on/off (#3910) |
 | `autonomous.watchdog.reviewStallTimeoutSecs` | `LOOM_SWEEP_REVIEW_STALL_TIMEOUT_SECS` | `2700` | Log-silence window before a hung Judge/Doctor sweep is re-dispatched |
@@ -1506,6 +1506,23 @@ written / log output past the spawn header) and auto-cancels + re-dispatches —
 frozen `sweep.issue.{N}.exited` / `sweep.global.completed` / `sweep.global.dispatch`
 topics (no new event topics). The watchdog defaults **on**; disable it with
 `LOOM_SWEEP_WATCHDOG=0` or `autonomous.watchdog.enabled = false`.
+
+**Progress is latched per sweep (#4088).** The progress probe reads only the
+*current* filesystem state (worktree / checkpoint / log), and **all three signals
+are torn down at successful completion** — `merge-pr.sh` removes the worktree,
+`/loom:sweep` deletes the checkpoint, and the log never grows past the spawn
+header. So a *finished* sweep is structurally indistinguishable from one that
+*never started*, and because the decision function is memoryless (`elapsed` is
+total runtime and only increases), a completed-then-cleaned-up sweep would be
+re-dispatched against its own — now closed — issue. To fix this the watchdog
+**latches progress per `SweepId`**: once a sweep is ever observed making progress
+it is left alone for the rest of its life (later crashes are delegated to the
+mid-build-death / review-stall backstops below). The latch is keyed by `SweepId`,
+not issue number, so a *re-dispatched* sweep that then genuinely hangs at startup
+is still rescued. Independently, **`dispatch` skips any issue that is closed on
+the forge** (best-effort, fail-open on a `gh` error) — this covers all three
+watchdogs, since each re-dispatches through the same method, so no self-heal path
+can ever re-claim a closed/merged issue.
 
 **Review-phase stall watchdog (#3910).** The startup watchdog rescues a sweep
 that shows *no* progress, and the mid-build-death watchdog (#3895) rescues one

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -443,7 +443,13 @@ pub const WATCHDOG_INTERVAL_ENV: &str = "LOOM_SWEEP_WATCHDOG_INTERVAL_SECS";
 /// written no checkpoint, and produced no log output past the spawn header
 /// within this window is treated as hung. Generous enough that a healthy sweep
 /// (which emits Curator-phase output well inside two minutes) never trips it.
-pub const DEFAULT_WATCHDOG_TIMEOUT_SECS: u64 = 120;
+///
+/// Raised from 120s to 300s (Issue #4088): under concurrency the normal
+/// dispatch→worktree latency was measured at 110–150s, so the old 120s default
+/// sat *inside* the healthy distribution and cancelled progressing sweeps. 300s
+/// clears that window with headroom while staying an order of magnitude below
+/// the review-stall timeout (2700s), keeping the three backstops well separated.
+pub const DEFAULT_WATCHDOG_TIMEOUT_SECS: u64 = 300;
 
 /// Default watchdog probe interval — matches the reaper cadence.
 pub const DEFAULT_WATCHDOG_INTERVAL_SECS: u64 = 30;
@@ -1065,6 +1071,22 @@ pub struct SweepRegistry {
     /// Issues the watchdog has already logged a give-up for, so the loud
     /// give-up warning fires once per issue rather than every tick.
     watchdog_gaveup: HashSet<u32>,
+    /// Sweeps the startup watchdog has ever observed making progress, latched so
+    /// the "has progressed" signal is monotonic (Issue #4088). `sweep_made_progress`
+    /// re-derives progress from mutable filesystem state (worktree / checkpoint /
+    /// log) every tick, all of which are torn down at successful completion — so a
+    /// *finished* sweep reads as *never started* and the memoryless
+    /// [`watchdog_decision`] re-dispatches it. Once a `SweepId` lands here the
+    /// startup watchdog leaves it alone forever, delegating any later crash to the
+    /// mid-build-death (#3895) / review-stall (#3910) backstops, which is the
+    /// division of labor the module doc already specifies.
+    ///
+    /// Keyed by `SweepId`, NOT issue: an issue-keyed latch would persist across
+    /// re-dispatch, so a re-dispatched sweep that then genuinely hangs at startup
+    /// would read as "already progressed" and never be rescued — silently
+    /// defanging the watchdog and violating AC2. Grows per dispatch, so it is
+    /// pruned alongside entry GC in [`reap_once`](Self::reap_once).
+    watchdog_progressed: HashSet<SweepId>,
     /// Issues the mid-build-death watchdog has already recovered once (Issue
     /// #3895). Distinct from `watchdog_retried` (startup-hang, no progress):
     /// this bounds the "made progress then the child died" recovery to a
@@ -1113,6 +1135,7 @@ impl SweepRegistry {
             last_spawn_at: None,
             watchdog_retried: HashSet::new(),
             watchdog_gaveup: HashSet::new(),
+            watchdog_progressed: HashSet::new(),
             midbuild_retried: HashSet::new(),
             midbuild_gaveup: HashSet::new(),
             review_stall_retried: HashSet::new(),
@@ -1135,6 +1158,7 @@ impl SweepRegistry {
             last_spawn_at: None,
             watchdog_retried: HashSet::new(),
             watchdog_gaveup: HashSet::new(),
+            watchdog_progressed: HashSet::new(),
             midbuild_retried: HashSet::new(),
             midbuild_gaveup: HashSet::new(),
             review_stall_retried: HashSet::new(),
@@ -1344,6 +1368,24 @@ impl SweepRegistry {
                 ));
             }
         };
+
+        // 2.5 Closed-issue guard (Issue #4088). All three watchdogs
+        //     (startup #3887, mid-build-death #3895, review-stall #3910)
+        //     re-dispatch through this method, and `gh issue edit` succeeds on a
+        //     closed issue, so nothing else stops a watchdog false-positive from
+        //     re-claiming an issue whose PR already merged. Placing the guard
+        //     here — before the lock/label flip — covers all three call sites
+        //     with one check. Best-effort and fail-open: a forge lookup error
+        //     returns `None` and dispatch proceeds, so a `gh` outage can never
+        //     wedge the daemon. Skipped when label flips are disabled (test
+        //     fixtures without `gh` credentials).
+        if !self.config.skip_label_flip && self.issue_is_closed(issue_number) == Some(true) {
+            return Err(anyhow!(
+                "refusing to dispatch issue #{issue_number}: it is closed on the forge \
+                 (#4088 closed-issue guard). A watchdog re-dispatch must not re-claim a \
+                 closed/merged issue."
+            ));
+        }
 
         // 3. Acquire the claim lock atomically.
         let sweep_id = generate_sweep_id(kind);
@@ -1589,6 +1631,48 @@ impl SweepRegistry {
     // ------------------------------------------------------------------------
     // Forge label flip
     // ------------------------------------------------------------------------
+
+    /// Best-effort probe of whether an issue is closed on the forge (Issue
+    /// #4088). Returns `Some(true)` when closed, `Some(false)` when open, and
+    /// `None` on any error (missing/failed/timed-out `gh`, unparseable output).
+    ///
+    /// Callers MUST treat `None` as **fail-open** — a forge outage or a wedged
+    /// `gh` must never wedge dispatch. The call is bounded by [`reap_gh_timeout`]
+    /// exactly like the label flips so it cannot block the dispatch path.
+    fn issue_is_closed(&self, issue: u32) -> Option<bool> {
+        let gh = self
+            .config
+            .gh_bin
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("gh"));
+        let mut cmd = Command::new(&gh);
+        cmd.arg("issue")
+            .arg("view")
+            .arg(issue.to_string())
+            .arg("--json")
+            .arg("state")
+            .arg("--jq")
+            .arg(".state");
+        // Resolve the issue against this registry's own workspace, matching the
+        // label-flip helpers (#3937). LOOM_REPO still overrides when set.
+        cmd.current_dir(&self.config.workspace_root);
+        if let Ok(repo) = std::env::var("LOOM_REPO") {
+            cmd.arg("--repo").arg(repo);
+        }
+        let output = output_with_timeout(cmd, reap_gh_timeout()).ok()??;
+        if !output.status.success() {
+            return None;
+        }
+        match String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .to_ascii_uppercase()
+            .as_str()
+        {
+            "CLOSED" => Some(true),
+            "OPEN" => Some(false),
+            _ => None,
+        }
+    }
 
     fn flip_label_to_building(&self, issue: u32) -> Result<()> {
         let gh = self
@@ -2712,6 +2796,11 @@ impl SweepRegistry {
             // `poll_liveness` already, but drop any lingering handle so a
             // GC'd sweep never leaks a `Child` (Issue #3801).
             let _ = self.children.remove(&id);
+            // Prune the per-SweepId progress latch so it cannot grow unbounded
+            // across many dispatches (Issue #4088). Safe because a GC'd entry is
+            // terminal — the watchdog only ever consults the latch for
+            // Running/Pending entries it still owns a Child handle for.
+            self.watchdog_progressed.remove(&id);
             changes += 1;
         }
         changes
@@ -2810,7 +2899,17 @@ impl SweepRegistry {
 
         let mut restarts = 0usize;
         for (sweep_id, issue, log_path, elapsed) in candidates {
-            let made_progress = self.sweep_made_progress(issue, &log_path);
+            // Latch progress per SweepId (Issue #4088): `sweep_made_progress`
+            // only reports the *current* filesystem state, and every signal it
+            // reads (worktree, checkpoint, log) is torn down at successful
+            // completion — so a finished sweep would otherwise read as
+            // never-started and be re-dispatched. Once observed true, the latch
+            // keeps `made_progress` true for this SweepId on every later tick.
+            let made_progress = self.watchdog_progressed.contains(&sweep_id)
+                || self.sweep_made_progress(issue, &log_path);
+            if made_progress {
+                self.watchdog_progressed.insert(sweep_id.clone());
+            }
             let already_retried = self.watchdog_retried.contains(&issue);
             match watchdog_decision(elapsed, timeout, made_progress, already_retried) {
                 WatchdogDecision::Healthy => {}
@@ -8002,6 +8101,308 @@ exit 0\n";
         let _ = reg.cancel(&out.sweep_id, Duration::from_secs(2));
     }
 
+    // --- progress latch (Issue #4088) ---
+
+    /// AC5 regression (the headline bug): a sweep that made progress (worktree
+    /// present), then had that worktree AND its checkpoint torn down at
+    /// completion while still `Running`, with `elapsed` far past the timeout,
+    /// must NOT be cancelled or re-dispatched. On `origin/main` the stateless
+    /// probe reads "no progress" after cleanup and re-dispatches against the
+    /// now-closed issue; the per-`SweepId` latch prevents that.
+    #[test]
+    fn watchdog_does_not_redispatch_completed_sweep_after_cleanup() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        let mut reg = hung_child_registry(ws);
+
+        let out = reg
+            .dispatch(&SweepKind::Issue(4078), None, None, None, None)
+            .unwrap();
+        assert!(wait_until_alive(out.pid, FIXTURE_CHILD_WAIT_MS));
+
+        // Progress appears (Builder created a worktree), and a tick observes +
+        // latches it.
+        let wt = ws.join(".loom").join("worktrees").join("issue-4078");
+        std::fs::create_dir_all(&wt).unwrap();
+        assert_eq!(reg.watchdog_once(Duration::from_secs(10)), 0);
+        assert!(
+            reg.watchdog_progressed.contains(&out.sweep_id),
+            "progress is latched for the sweep"
+        );
+
+        // Completion tears down every progress signal (merge-pr.sh removes the
+        // worktree; /loom:sweep deletes the checkpoint). The stateless probe now
+        // reads no-progress — the exact #4078 condition.
+        std::fs::remove_dir_all(&wt).unwrap();
+        assert!(
+            !reg.sweep_made_progress(4078, &out.log_path),
+            "stateless probe reads no-progress after cleanup (the bug's precondition)"
+        );
+
+        // Even backdated far past the timeout, the latched sweep is left alone.
+        backdate(&mut reg, &out.sweep_id, 9999);
+        assert_eq!(
+            reg.watchdog_once(Duration::from_secs(10)),
+            0,
+            "a completed-then-cleaned-up sweep is never re-dispatched (AC5)"
+        );
+        assert!(
+            !reg.watchdog_retried.contains(&4078),
+            "no retry recorded for the completed sweep"
+        );
+
+        let _ = reg.cancel(&out.sweep_id, Duration::from_secs(2));
+    }
+
+    /// AC2 on re-dispatch (the Finding 6 trap): the latch is keyed by `SweepId`,
+    /// not issue. A latch keyed by issue would make a *re-dispatched* sweep that
+    /// genuinely hangs read as "already progressed" and never be rescued —
+    /// silently defanging the watchdog for the very issues it already rescued
+    /// once. A prior sweep's latch (distinct `SweepId`) must not cover a new
+    /// hung sweep for the same issue.
+    #[test]
+    fn watchdog_latch_is_scoped_by_sweep_id_so_redispatch_is_still_rescued() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        let mut reg = hung_child_registry(ws);
+
+        let out = reg
+            .dispatch(&SweepKind::Issue(4060), None, None, None, None)
+            .unwrap();
+        assert!(wait_until_alive(out.pid, FIXTURE_CHILD_WAIT_MS));
+
+        // Simulate a PRIOR, now-gone sweep for the SAME issue having progressed:
+        // its distinct SweepId is latched. An issue-keyed latch would instead
+        // hold `4060` and wrongly cover the current sweep.
+        reg.watchdog_progressed
+            .insert("sweep-issue-4060-prior".to_string());
+        assert!(
+            !reg.watchdog_progressed.contains(&out.sweep_id),
+            "the current (hung) sweep is not itself latched"
+        );
+
+        // The current sweep never progressed; backdate it past the timeout.
+        backdate(&mut reg, &out.sweep_id, 600);
+        assert_eq!(
+            reg.watchdog_once(Duration::from_secs(60)),
+            1,
+            "a re-dispatched sweep that hangs at startup is still rescued (AC2)"
+        );
+        assert!(reg.watchdog_retried.contains(&4060));
+
+        if let Some(id) = running_issue_sweep_id(&reg, 4060) {
+            let _ = reg.cancel(&id, Duration::from_secs(2));
+        }
+    }
+
+    /// The latch is monotonic (stays true across ticks once observed) AND scoped
+    /// to a single `SweepId` — a sibling sweep that never progressed is
+    /// unaffected and still eligible for rescue.
+    #[test]
+    fn watchdog_latch_is_monotonic_and_per_sweep() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        let mut reg = hung_child_registry(ws);
+
+        let a = reg
+            .dispatch(&SweepKind::Issue(5001), None, None, None, None)
+            .unwrap();
+        assert!(wait_until_alive(a.pid, FIXTURE_CHILD_WAIT_MS));
+        let b = reg
+            .dispatch(&SweepKind::Issue(5002), None, None, None, None)
+            .unwrap();
+        assert!(wait_until_alive(b.pid, FIXTURE_CHILD_WAIT_MS));
+
+        // Only A makes progress.
+        let wt_a = ws.join(".loom").join("worktrees").join("issue-5001");
+        std::fs::create_dir_all(&wt_a).unwrap();
+        assert_eq!(reg.watchdog_once(Duration::from_secs(10)), 0);
+        assert!(reg.watchdog_progressed.contains(&a.sweep_id), "A latched");
+        assert!(
+            !reg.watchdog_progressed.contains(&b.sweep_id),
+            "B never progressed ⇒ not latched"
+        );
+
+        // Monotonic: remove A's worktree; a later tick keeps A latched.
+        std::fs::remove_dir_all(&wt_a).unwrap();
+        assert_eq!(reg.watchdog_once(Duration::from_secs(10)), 0);
+        assert!(
+            reg.watchdog_progressed.contains(&a.sweep_id),
+            "A stays latched across ticks even with its worktree gone"
+        );
+
+        // B, never progressing and backdated, is still restarted — A's latch is
+        // scoped to A and does not cover its sibling.
+        backdate(&mut reg, &b.sweep_id, 600);
+        assert_eq!(
+            reg.watchdog_once(Duration::from_secs(60)),
+            1,
+            "the un-latched sibling is rescued"
+        );
+        assert!(reg.watchdog_retried.contains(&5002));
+        assert!(!reg.watchdog_retried.contains(&5001));
+
+        for issue in [5001u32, 5002u32] {
+            if let Some(id) = running_issue_sweep_id(&reg, issue) {
+                let _ = reg.cancel(&id, Duration::from_secs(2));
+            }
+        }
+    }
+
+    /// Latch pruning: entries for sweeps GC'd from `entries` are dropped from
+    /// the latch, so the per-`SweepId` set cannot grow unbounded across many
+    /// dispatches.
+    #[test]
+    fn watchdog_latch_pruned_on_entry_gc() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        let (mut reg, _rec) = fixture_registry(ws);
+
+        // A terminal entry aged past the retention window, with its SweepId
+        // latched — exactly the state left behind by a completed sweep.
+        let sid = "sweep-issue-6001-done".to_string();
+        let old = Utc::now() - chrono::Duration::seconds(TERMINAL_RETENTION_SECS + 60);
+        reg.entries.insert(
+            sid.clone(),
+            SweepInfo {
+                sweep_id: sid.clone(),
+                kind: SweepKind::Issue(6001),
+                pid: 2_147_483_640,
+                token_name: "unknown".into(),
+                log_path: ws.join(".loom/logs/sweep-issue-6001.log"),
+                idempotency_key: None,
+                started_at: old,
+                state: SweepState::Exited {
+                    code: Some(0),
+                    at: old,
+                },
+                latest_phase: None,
+                pr_number: None,
+                model: None,
+                effort: None,
+                depends_on: None,
+                repo: None,
+            },
+        );
+        reg.watchdog_progressed.insert(sid.clone());
+
+        // GC drops the terminal entry and must prune its latch entry with it.
+        reg.reap_once();
+        assert!(!reg.entries.contains_key(&sid), "terminal entry is GC'd");
+        assert!(
+            !reg.watchdog_progressed.contains(&sid),
+            "the latch entry is pruned alongside the GC'd sweep"
+        );
+    }
+
+    // --- closed-issue dispatch guard (Issue #4088, AC6) ---
+
+    /// Install a fake `gh` that reports a fixed `issue view` state and records
+    /// every invocation, returning `(registry, gh_log)`. `spawn-claude.sh` is a
+    /// benign echo-and-exit so a dispatch that passes the guard still spawns.
+    fn closed_guard_registry(
+        ws: &Path,
+        view_stdout: &str,
+        view_exit: i32,
+    ) -> (SweepRegistry, PathBuf) {
+        let gh_log = ws.join("gh-invocations.log");
+        let fake_gh = ws.join("fake-gh.sh");
+        let script = format!(
+            "#!/usr/bin/env bash\n\
+             printf '%s\\n' \"$*\" >> \"{log}\"\n\
+             if [[ \"$1\" == \"issue\" && \"$2\" == \"view\" ]]; then\n\
+             printf '%s\\n' \"{state}\"\n\
+             exit {exit}\n\
+             fi\n\
+             exit 0\n",
+            log = gh_log.display(),
+            state = view_stdout,
+            exit = view_exit,
+        );
+        std::fs::write(&fake_gh, &script).unwrap();
+        let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_gh, perms).unwrap();
+        if let Ok(f) = std::fs::File::open(&fake_gh) {
+            let _ = f.sync_all();
+        }
+
+        let scripts_dir = ws.join(".loom").join("scripts");
+        std::fs::create_dir_all(&scripts_dir).unwrap();
+        let spawn = scripts_dir.join("spawn-claude.sh");
+        std::fs::write(&spawn, "#!/usr/bin/env bash\necho spawned\nexit 0\n").unwrap();
+        let mut sperms = std::fs::metadata(&spawn).unwrap().permissions();
+        sperms.set_mode(0o755);
+        std::fs::set_permissions(&spawn, sperms).unwrap();
+        if let Ok(f) = std::fs::File::open(&spawn) {
+            let _ = f.sync_all();
+        }
+
+        let mut config = SweepRegistryConfig::new(ws.to_path_buf());
+        config.spawn_bin = Some(spawn);
+        config.gh_bin = Some(fake_gh);
+        config.skip_label_flip = false; // exercise the real guard + flip path
+        config.journal_path = Some(ws.join("test-sweeps-journal.json"));
+        (SweepRegistry::new(config), gh_log)
+    }
+
+    /// AC6: `dispatch` for a closed issue is refused, and it must NOT flip any
+    /// labels (no `issue edit`) — a watchdog re-dispatch can never re-claim a
+    /// closed/merged issue.
+    #[test]
+    #[serial]
+    fn dispatch_refuses_closed_issue_without_flipping_labels() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::remove_var("LOOM_REPO");
+        let (mut reg, gh_log) = closed_guard_registry(ws, "CLOSED", 0);
+
+        let err = reg
+            .dispatch(&SweepKind::Issue(4078), None, None, None, None)
+            .expect_err("a closed issue must be refused");
+        assert!(
+            err.to_string().contains("closed"),
+            "error explains the closed-issue guard; got: {err}"
+        );
+
+        let calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(calls.contains("issue view 4078"), "the guard probed issue state");
+        assert!(
+            !calls.contains("issue edit"),
+            "no label flip on a refused dispatch; got: {calls:?}"
+        );
+        // No lock was acquired and no entry recorded.
+        assert!(running_issue_sweep_id(&reg, 4078).is_none());
+    }
+
+    /// AC6 fail-open: a forge lookup error (non-zero `gh`) must NOT wedge
+    /// dispatch — the guard returns `None` and dispatch proceeds normally.
+    #[test]
+    #[serial]
+    fn dispatch_fails_open_when_issue_state_lookup_errors() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::remove_var("LOOM_REPO");
+        // `issue view` exits non-zero ⇒ state unknown ⇒ fail open.
+        let (mut reg, gh_log) = closed_guard_registry(ws, "", 1);
+
+        let out = reg
+            .dispatch(&SweepKind::Issue(4079), None, None, None, None)
+            .expect("a gh outage must not wedge dispatch (fail-open)");
+        assert!(wait_until_dead(out.pid, FIXTURE_CHILD_WAIT_MS));
+
+        let calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(calls.contains("issue view 4079"), "the guard probed issue state");
+        assert!(
+            calls.contains("issue edit 4079"),
+            "dispatch proceeded to the label flip after failing open; got: {calls:?}"
+        );
+
+        if let Some(id) = running_issue_sweep_id(&reg, 4079) {
+            let _ = reg.cancel(&id, Duration::from_secs(2));
+        }
+    }
+
     // --- config resolution: env > config > default ---
 
     fn write_cfg(dir: &Path, body: &str) {
@@ -8190,6 +8591,13 @@ exit 0\n";
     fn resolve_watchdog_timeout_and_interval_precedence() {
         std::env::remove_var(WATCHDOG_TIMEOUT_ENV);
         std::env::remove_var(WATCHDOG_INTERVAL_ENV);
+        // AC1 (#4088): the default no-progress window is 300s — clear of the
+        // observed 110–150s healthy dispatch→worktree distribution.
+        assert_eq!(DEFAULT_WATCHDOG_TIMEOUT_SECS, 300);
+        assert_eq!(
+            resolve_watchdog_timeout(&StartupRaceConfig::default()),
+            Duration::from_secs(300)
+        );
         assert_eq!(
             resolve_watchdog_timeout(&StartupRaceConfig::default()),
             Duration::from_secs(DEFAULT_WATCHDOG_TIMEOUT_SECS)


### PR DESCRIPTION
## Summary

Fixes the #3887 startup watchdog cancelling **healthy** sweeps and re-dispatching **completed** ones. The Curator analysis identified two independent defects; both are fixed, plus the AC6 closed-issue guard.

1. **Threshold sat inside the healthy distribution.** Under concurrency the normal dispatch→worktree latency is 110–150s, but `DEFAULT_WATCHDOG_TIMEOUT_SECS` was `120`, so progressing sweeps were killed mid-Curator. Raised to `300` — clear of the observed window, still an order of magnitude below the 2700s review-stall timeout, so the three backstops stay well separated.
2. **Progress was not latched.** `sweep_made_progress` re-derives progress from mutable filesystem state (worktree / checkpoint / log) every tick, and **all three signals are torn down at successful completion** (`merge-pr.sh` removes the worktree, `/loom:sweep` deletes the checkpoint, the log never grows past the spawn header). So a *finished* sweep read as *never-started*, and the memoryless `watchdog_decision` re-dispatched it against its own — now closed — issue (the 1135s #4078 incident). Added a per-`SweepId` latch so "has progressed" is monotonic.
3. **Closed-issue guard.** `dispatch` now skips an issue that is closed on the forge (best-effort, **fail-open** on a `gh` error). Placed in `dispatch` so it covers all three watchdogs (#3887 / #3895 / #3910), which all re-dispatch through it.

## Changes

- `loom-daemon/src/sweep_registry.rs`
  - `DEFAULT_WATCHDOG_TIMEOUT_SECS` `120` → `300`.
  - New private `watchdog_progressed: HashSet<SweepId>` latch next to `watchdog_retried` / `watchdog_gaveup`; initialized in both constructors; consulted + populated in `watchdog_once` around the `sweep_made_progress` call; pruned in the `reap_once` GC loop.
  - **Keyed by `SweepId`, not issue** (Finding 6): an issue-keyed latch would make a re-dispatched sweep that hangs read as "already progressed" and never be rescued (defangs the watchdog, violates AC2).
  - New `issue_is_closed` helper + closed-issue pre-flight guard in `dispatch` (fail-open).
  - **Unchanged:** `watchdog_decision` (pure, four existing tests) and `sweep_made_progress`'s three probes — only the statelessness was the defect.
- `.loom/docs/daemon-reference.md` — updated the `timeoutSecs` default (config example + knob table) and the startup-watchdog prose to document the per-sweep latch and the closed-issue skip.

## Acceptance Criteria Verification

1. Healthy sweep not cancelled — 300s default clears the 110–150s window. ✅ (`resolve_watchdog_timeout_and_interval_precedence`)
2. Genuinely hung sweep still cancelled, **including on re-dispatch** — SweepId-scoped latch. ✅ (`watchdog_latch_is_scoped_by_sweep_id_so_redispatch_is_still_rescued`, `watchdog_restarts_hung_sweep_once_then_gives_up` unchanged)
3. Signal documented in `daemon-reference.md`. ✅
4. "Slow but healthy startup" covered. ✅ (raised default + latch tests)
5. Completed sweep (worktree + checkpoint gone) not re-dispatched. ✅ (`watchdog_does_not_redispatch_completed_sweep_after_cleanup` — reproduces the #4078 cleanup condition)
6. Re-dispatch skipped for a closed issue, all three watchdogs. ✅ (guard in shared `dispatch`; `dispatch_refuses_closed_issue_without_flipping_labels`, `dispatch_fails_open_when_issue_state_lookup_errors`)

## Test Plan

- `cargo test --lib` latch suite: AC5 regression, AC2 re-dispatch rescue, monotonicity + per-sweep scope, latch pruning — all pass.
- Closed-issue guard: refuse-without-flipping + fail-open — pass.
- Regression: `watchdog_decision` (4), `midbuild` (10), `review_stall` (7), `log_has_progress` (4), `sweep_made_progress` (1) all pass unmodified. `cargo clippy --lib` clean, `cargo fmt` applied.

## Notes

- **Scope:** 2 files. Test code is the bulk of the diff (the Test Plan mandated 5+ latch/guard tests plus a fake-`gh` helper); production change is ~100 lines localized to `sweep_registry.rs`. Touched none of the work-finder / quarantine (#3939) / `spawn-claude.sh` layers the scope guard warns about.
- **Rollout:** daemon-side Rust — needs a **rebuild + `loom-daemon-start.sh`** to take effect; a run against the stale binary is not evidence the fix failed.
- **#4110 / #4111** also touch `dispatch`; no code overlap expected (this adds one pre-flight guard at step 2.5), but flag for merge-conflict check.

Closes #4088

🤖 Generated with [Claude Code](https://claude.com/claude-code)