### PR TITLE
fix(daemon): durably release insta-crash quarantine labels

### DIFF
--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -32,6 +32,7 @@ pub mod main_health_gate;
 pub mod metrics_collector;
 pub mod phase_join;
 pub mod pipeline_snapshot;
+pub mod quarantine_reconciliation;
 pub mod role_runner;
 pub mod role_validation;
 pub mod self_update;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -7,6 +7,7 @@ use loom_daemon::health_monitor;
 use loom_daemon::ipc::IpcServer;
 use loom_daemon::main_health_gate;
 use loom_daemon::metrics_collector;
+use loom_daemon::quarantine_reconciliation;
 use loom_daemon::role_runner;
 use loom_daemon::role_validation;
 use loom_daemon::self_update;
@@ -661,6 +662,50 @@ async fn main() -> Result<()> {
         log::info!(
             "claim_reconciliation: startup pass disabled ({}=0)",
             claim_reconciliation::RECONCILE_ENABLED_ENV
+        );
+    }
+
+    // Stranded-quarantine reconciliation across every managed workspace
+    // (Issue #4110). The insta-crash quarantine (#3939) is memory-only, so a
+    // restart drops the in-memory pause while the `loom:blocked` label it
+    // applied survives on the forge — with nothing left to release it, the
+    // issue is permanently invisible to the work finder. This pass scans
+    // every registered workspace's open `loom:blocked` issues and releases
+    // the ones carrying a daemon-authored quarantine comment back to
+    // `loom:issue`; a human's manual `loom:blocked` (no such comment) is
+    // never touched. Reuses the same `workspace_registry` roots resolved
+    // above for claim reconciliation.
+    if quarantine_reconciliation::reconciliation_enabled() {
+        let workspace_registry =
+            loom_daemon::workspace_registry::WorkspaceRegistry::load_default().unwrap_or_default();
+        let roots = workspace_registry.effective_roots(&sweep_workspace);
+        let gh_bin = std::path::PathBuf::from("gh");
+        let mut total_checked = 0usize;
+        let mut total_released = 0usize;
+        for root in &roots {
+            let (checked, released) =
+                quarantine_reconciliation::forge::reconcile_workspace(&gh_bin, root);
+            total_checked += checked;
+            total_released += released;
+        }
+        if total_released > 0 {
+            log::info!(
+                "quarantine_reconciliation: startup pass checked {total_checked} loom:blocked \
+                 issue(s) across {} workspace(s), released {total_released} stranded \
+                 quarantine(s) (#4110)",
+                roots.len()
+            );
+        } else {
+            log::debug!(
+                "quarantine_reconciliation: startup pass checked {total_checked} loom:blocked \
+                 issue(s) across {} workspace(s), nothing to release",
+                roots.len()
+            );
+        }
+    } else {
+        log::info!(
+            "quarantine_reconciliation: startup pass disabled ({}=0)",
+            quarantine_reconciliation::RECONCILE_ENABLED_ENV
         );
     }
 

--- a/loom-daemon/src/quarantine_reconciliation.rs
+++ b/loom-daemon/src/quarantine_reconciliation.rs
@@ -1,0 +1,418 @@
+//! Daemon-startup reconciliation of stranded `loom:blocked` insta-crash
+//! quarantines across every managed workspace (Issue #4110).
+//!
+//! The insta-crash quarantine (#3939) is memory-only:
+//! [`crate::sweep_registry::SweepRegistry`]'s `quarantined` map never survives
+//! a daemon restart. The forge label (`loom:blocked`) it applied, however,
+//! does survive — so a restart drops the in-memory pause while leaving the
+//! label behind, and nothing scans for that afterward. The `loom:blocked`
+//! issue is then invisible to the work finder (which only polls open
+//! `loom:issue`) with no quarantine left anywhere to clear, forever.
+//!
+//! This module is the startup pass that closes that gap: for every registered
+//! workspace, list the open `loom:blocked` issues and release the ones that
+//! carry a daemon-authored quarantine comment (identified by
+//! [`crate::sweep_registry::QUARANTINE_COMMENT_MARKER`]) back to `loom:issue`.
+//! An issue a human deliberately blocked by hand carries no such comment and
+//! is never touched — this pass only ever undoes its own past mutation.
+//!
+//! Mirrors [`crate::claim_reconciliation`]'s conventions: a kill-switch env
+//! var, a per-workspace issue cap, and a pure `decide`/`plan` split that keeps
+//! the decision logic unit-testable without a forge. Unlike
+//! `claim_reconciliation`, there is no liveness question to answer here — a
+//! fresh daemon's quarantine memory is *always* empty at startup, so the sole
+//! question is "did the daemon itself apply this `loom:blocked` label", which
+//! the comment marker answers directly.
+
+/// Env var to disable the startup quarantine reconciliation pass entirely
+/// (kill switch, not a feature gate — this is corrective crash recovery in
+/// the same spirit as [`crate::claim_reconciliation::RECONCILE_ENABLED_ENV`],
+/// so it defaults to ON). `0`/`false`/`no`/`off` disables; anything else
+/// (including unset) leaves it enabled.
+pub const RECONCILE_ENABLED_ENV: &str = "LOOM_QUARANTINE_RECONCILE";
+
+/// Bound on how many `loom:blocked` issues one reconciliation pass inspects
+/// per workspace (defense in depth against an unexpectedly huge backlog
+/// turning startup into a `gh`-API storm), matching
+/// [`crate::claim_reconciliation::MAX_ISSUES_PER_WORKSPACE`].
+pub const MAX_ISSUES_PER_WORKSPACE: u32 = 100;
+
+/// Resolve whether the startup quarantine reconciliation pass is enabled.
+#[must_use]
+pub fn reconciliation_enabled() -> bool {
+    match std::env::var(RECONCILE_ENABLED_ENV) {
+        Ok(v) => !matches!(v.trim().to_ascii_lowercase().as_str(), "0" | "false" | "no" | "off"),
+        Err(_) => true,
+    }
+}
+
+/// A `loom:blocked` issue reported by the forge, trimmed to the fields the
+/// reconciliation decision needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockedIssue {
+    pub number: u32,
+    /// Whether any comment on the issue contains
+    /// [`crate::sweep_registry::QUARANTINE_COMMENT_MARKER`].
+    pub has_quarantine_comment: bool,
+}
+
+/// The reconciliation decision for one issue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReconcileAction {
+    /// No daemon quarantine comment found — leave the claim alone. This is
+    /// the fail-safe branch: a human's manual `loom:blocked` is never
+    /// touched.
+    Keep,
+    /// Flip `loom:blocked` back to `loom:issue`: the label was applied by a
+    /// daemon quarantine that could not have survived to this restart.
+    Release,
+}
+
+/// Pure decision function — no I/O, fully unit-testable. See the module docs
+/// for the decision rule.
+#[must_use]
+pub fn decide(issue: &BlockedIssue) -> ReconcileAction {
+    if issue.has_quarantine_comment {
+        ReconcileAction::Release
+    } else {
+        ReconcileAction::Keep
+    }
+}
+
+/// Plan reconciliation decisions for every issue in `issues`. Performs no
+/// I/O; `issues` is expected to already be capped to
+/// [`MAX_ISSUES_PER_WORKSPACE`] by the caller.
+#[must_use]
+pub fn plan(issues: &[BlockedIssue]) -> Vec<(u32, ReconcileAction)> {
+    issues
+        .iter()
+        .map(|issue| (issue.number, decide(issue)))
+        .collect()
+}
+
+/// `gh`/label-flip glue. Not unit-tested directly (mirrors
+/// [`crate::claim_reconciliation::forge`] / [`crate::work_finder::forge`]) —
+/// the decision logic above is the fully-covered surface; this module is a
+/// thin, best-effort `Command` wrapper.
+pub mod forge {
+    use super::{plan, BlockedIssue, ReconcileAction, MAX_ISSUES_PER_WORKSPACE};
+    use crate::sweep_registry::QUARANTINE_COMMENT_MARKER;
+    use anyhow::{anyhow, Context, Result};
+    use serde::Deserialize;
+    use std::path::Path;
+    use std::process::{Command, Stdio};
+
+    #[derive(Debug, Deserialize)]
+    struct GhComment {
+        #[serde(default)]
+        body: String,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct GhBlockedIssue {
+        number: u32,
+        #[serde(default)]
+        comments: Vec<GhComment>,
+    }
+
+    fn list_blocked_issues(gh_bin: &Path, root: &Path) -> Result<Vec<BlockedIssue>> {
+        let mut cmd = Command::new(gh_bin);
+        cmd.arg("issue")
+            .arg("list")
+            .arg("--label")
+            .arg("loom:blocked")
+            .arg("--state")
+            .arg("open")
+            .arg("--limit")
+            .arg(MAX_ISSUES_PER_WORKSPACE.to_string())
+            .arg("--json")
+            .arg("number,comments");
+        cmd.current_dir(root);
+        if let Ok(repo) = std::env::var("LOOM_REPO") {
+            cmd.arg("--repo").arg(repo);
+        }
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let out = cmd
+            .output()
+            .with_context(|| format!("failed to invoke {}", gh_bin.display()))?;
+        if !out.status.success() {
+            return Err(anyhow!(
+                "gh issue list --label loom:blocked failed in {}: {}",
+                root.display(),
+                String::from_utf8_lossy(&out.stderr).trim()
+            ));
+        }
+        let rows: Vec<GhBlockedIssue> =
+            serde_json::from_slice(&out.stdout).context("parse gh issue list JSON")?;
+        Ok(rows
+            .into_iter()
+            .map(|r| BlockedIssue {
+                number: r.number,
+                has_quarantine_comment: r
+                    .comments
+                    .iter()
+                    .any(|c| c.body.contains(QUARANTINE_COMMENT_MARKER)),
+            })
+            .collect())
+    }
+
+    fn release(gh_bin: &Path, root: &Path, issue: u32) -> Result<()> {
+        let mut cmd = Command::new(gh_bin);
+        cmd.arg("issue")
+            .arg("edit")
+            .arg(issue.to_string())
+            .arg("--remove-label")
+            .arg("loom:blocked")
+            .arg("--add-label")
+            .arg("loom:issue");
+        cmd.current_dir(root);
+        if let Ok(repo) = std::env::var("LOOM_REPO") {
+            cmd.arg("--repo").arg(repo);
+        }
+        cmd.stdout(Stdio::null()).stderr(Stdio::piped());
+        let out = cmd
+            .output()
+            .with_context(|| format!("failed to invoke {}", gh_bin.display()))?;
+        if !out.status.success() {
+            return Err(anyhow!(
+                "gh issue edit failed for #{issue} in {}: {}",
+                root.display(),
+                String::from_utf8_lossy(&out.stderr).trim()
+            ));
+        }
+        Ok(())
+    }
+
+    /// Reconcile stranded `loom:blocked` quarantines for one registered
+    /// workspace `root`. Best-effort and bounded: any `gh` failure is logged
+    /// at `warn` and this workspace's pass returns `(0, 0)` rather than
+    /// propagating an error (one repo's forge hiccup must never block the
+    /// daemon's startup, nor the other registered workspaces).
+    ///
+    /// Returns `(checked, released)` — the number of `loom:blocked` issues
+    /// inspected and the number actually released, for the caller's summary
+    /// log line.
+    pub fn reconcile_workspace(gh_bin: &Path, root: &Path) -> (usize, usize) {
+        let issues = match list_blocked_issues(gh_bin, root) {
+            Ok(v) => v,
+            Err(e) => {
+                log::warn!("quarantine_reconciliation: {}: {e}", root.display());
+                return (0, 0);
+            }
+        };
+        if issues.is_empty() {
+            return (0, 0);
+        }
+
+        let decisions = plan(&issues);
+        let checked = decisions.len();
+
+        let mut released = 0usize;
+        for (issue_number, action) in decisions {
+            let ReconcileAction::Release = action else {
+                continue;
+            };
+            match release(gh_bin, root, issue_number) {
+                Ok(()) => {
+                    released += 1;
+                    log::info!(
+                        "quarantine_reconciliation: released stranded quarantine \
+                         loom:blocked -> loom:issue for #{issue_number} in {} (#4110)",
+                        root.display()
+                    );
+                }
+                Err(e) => {
+                    log::warn!(
+                        "quarantine_reconciliation: failed to release #{issue_number} in {}: {e}",
+                        root.display()
+                    );
+                }
+            }
+        }
+
+        (checked, released)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::tempdir;
+
+    fn issue(number: u32, has_comment: bool) -> BlockedIssue {
+        BlockedIssue {
+            number,
+            has_quarantine_comment: has_comment,
+        }
+    }
+
+    #[test]
+    fn decide_releases_when_quarantine_comment_present() {
+        assert_eq!(decide(&issue(42, true)), ReconcileAction::Release);
+    }
+
+    #[test]
+    fn decide_keeps_manual_block_with_no_quarantine_comment() {
+        assert_eq!(
+            decide(&issue(42, false)),
+            ReconcileAction::Keep,
+            "a human's manual loom:blocked (no daemon comment) must never be auto-flipped"
+        );
+    }
+
+    #[test]
+    fn plan_maps_each_issue_independently() {
+        let issues = vec![issue(1, true), issue(2, false), issue(3, true)];
+        let decisions = plan(&issues);
+        assert_eq!(
+            decisions,
+            vec![
+                (1, ReconcileAction::Release),
+                (2, ReconcileAction::Keep),
+                (3, ReconcileAction::Release),
+            ]
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn reconciliation_enabled_resolves_env_precedence() {
+        std::env::remove_var(RECONCILE_ENABLED_ENV);
+        assert!(reconciliation_enabled(), "defaults to enabled");
+
+        for off in ["0", "false", "no", "off", "OFF", "False"] {
+            std::env::set_var(RECONCILE_ENABLED_ENV, off);
+            assert!(!reconciliation_enabled(), "{off} should disable");
+        }
+
+        std::env::set_var(RECONCILE_ENABLED_ENV, "1");
+        assert!(reconciliation_enabled());
+
+        std::env::remove_var(RECONCILE_ENABLED_ENV);
+    }
+
+    fn write_fake_gh(dir: &std::path::Path, script: &str) -> std::path::PathBuf {
+        let fake_gh = dir.join("fake-gh.sh");
+        std::fs::write(&fake_gh, script).unwrap();
+        #[cfg(unix)]
+        {
+            let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&fake_gh, perms).unwrap();
+        }
+        fake_gh
+    }
+
+    /// A `loom:blocked` issue carrying the daemon's quarantine comment is
+    /// released, and the recorded `gh` argv proves the real label-flip
+    /// command ran (not just the in-memory decision).
+    #[test]
+    fn reconcile_workspace_releases_issue_with_quarantine_comment() {
+        let dir = tempdir().unwrap();
+        let repo_root = dir.path().join("repo");
+        std::fs::create_dir_all(&repo_root).unwrap();
+        let gh_log = dir.path().join("gh-invocations.log");
+        let script = format!(
+            r#"#!/usr/bin/env bash
+printf '%s\n' "$*" >> "{log}"
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  echo '[{{"number":99,"comments":[{{"body":"Auto-quarantined by loom-daemon (#3939): insta-crashed 3 times"}}]}}]'
+  exit 0
+fi
+exit 0
+"#,
+            log = gh_log.display(),
+        );
+        let fake_gh = write_fake_gh(dir.path(), &script);
+
+        let (checked, released) = forge::reconcile_workspace(&fake_gh, &repo_root);
+        assert_eq!(checked, 1);
+        assert_eq!(released, 1);
+
+        let gh_calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            gh_calls.contains("issue edit 99 --remove-label loom:blocked --add-label loom:issue"),
+            "expected the real label-flip argv; got: {gh_calls:?}"
+        );
+    }
+
+    /// A `loom:blocked` issue with NO daemon quarantine comment (an
+    /// operator's manual block) is left untouched — no `gh issue edit` call
+    /// is ever made for it.
+    #[test]
+    fn reconcile_workspace_never_touches_manual_block() {
+        let dir = tempdir().unwrap();
+        let repo_root = dir.path().join("repo");
+        std::fs::create_dir_all(&repo_root).unwrap();
+        let gh_log = dir.path().join("gh-invocations.log");
+        let script = format!(
+            r#"#!/usr/bin/env bash
+printf '%s\n' "$*" >> "{log}"
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  echo '[{{"number":77,"comments":[{{"body":"Blocked manually pending a human decision"}}]}}]'
+  exit 0
+fi
+exit 0
+"#,
+            log = gh_log.display(),
+        );
+        let fake_gh = write_fake_gh(dir.path(), &script);
+
+        let (checked, released) = forge::reconcile_workspace(&fake_gh, &repo_root);
+        assert_eq!(checked, 1);
+        assert_eq!(released, 0, "no quarantine comment => never released");
+
+        let gh_calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            !gh_calls.contains("issue edit"),
+            "a manually-blocked issue must never be flipped; got: {gh_calls:?}"
+        );
+    }
+
+    /// The per-workspace cap is passed through to `gh issue list --limit`, so
+    /// an unexpectedly huge backlog cannot turn startup into an API storm.
+    #[test]
+    fn reconcile_workspace_passes_issue_cap_to_gh_list() {
+        let dir = tempdir().unwrap();
+        let repo_root = dir.path().join("repo");
+        std::fs::create_dir_all(&repo_root).unwrap();
+        let gh_log = dir.path().join("gh-invocations.log");
+        let script = format!(
+            r#"#!/usr/bin/env bash
+printf '%s\n' "$*" >> "{log}"
+echo '[]'
+exit 0
+"#,
+            log = gh_log.display(),
+        );
+        let fake_gh = write_fake_gh(dir.path(), &script);
+
+        let (checked, released) = forge::reconcile_workspace(&fake_gh, &repo_root);
+        assert_eq!(checked, 0);
+        assert_eq!(released, 0);
+
+        let gh_calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            gh_calls.contains(&format!("--limit {MAX_ISSUES_PER_WORKSPACE}")),
+            "expected the issue-cap limit in the gh invocation; got: {gh_calls:?}"
+        );
+    }
+
+    /// A `gh issue list` failure is absorbed (logged, not propagated) so one
+    /// repo's forge hiccup never blocks startup.
+    #[test]
+    fn reconcile_workspace_absorbs_gh_list_failure() {
+        let dir = tempdir().unwrap();
+        let repo_root = dir.path().join("repo");
+        std::fs::create_dir_all(&repo_root).unwrap();
+        let fake_gh = write_fake_gh(dir.path(), "#!/usr/bin/env bash\necho 'boom' >&2\nexit 1\n");
+
+        let (checked, released) = forge::reconcile_workspace(&fake_gh, &repo_root);
+        assert_eq!(checked, 0);
+        assert_eq!(released, 0);
+    }
+}

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -568,6 +568,13 @@ pub const DEFAULT_QUARANTINE_TTL_SECS: u64 = 3600;
 /// never counts here.
 pub const DEFAULT_QUARANTINE_INSTA_CRASH_SECS: i64 = 60;
 
+/// Marker substring embedded in every quarantine comment body posted by
+/// [`SweepRegistry::apply_quarantine_label`] (Issue #3939). Used by
+/// [`crate::quarantine_reconciliation`] (Issue #4110) to distinguish a
+/// daemon-applied `loom:blocked` from one a human deliberately applied by
+/// hand — only the former is safe to auto-release at startup.
+pub const QUARANTINE_COMMENT_MARKER: &str = "Auto-quarantined by loom-daemon (#3939)";
+
 /// Resolved insta-crash-quarantine parameters (Issue #3939), set on the registry
 /// at construction so [`SweepRegistry::reap_once`] can enforce them without a
 /// per-tick config read. Defaults mirror the shipped constants (enabled — it is a
@@ -1110,6 +1117,16 @@ pub struct SweepRegistry {
     /// releases it. Keyed by issue number; since each registry is scoped to one
     /// workspace root, this is effectively a `(workspace, issue)` key.
     quarantined: HashMap<u32, DateTime<Utc>>,
+    /// Issues whose `loom:blocked` -> `loom:issue` label restore failed at
+    /// least once (Issue #4110): [`release_quarantine_label`](Self::release_quarantine_label)
+    /// is a best-effort `gh` call, and a transient failure must not silently
+    /// strand the issue at `loom:blocked` forever — the in-memory quarantine
+    /// state is already gone by the time the label edit runs, so this set is
+    /// the only remaining record that a retry is owed. [`reap_once`](Self::reap_once)
+    /// retries every entry here on each tick until the flip succeeds (or the
+    /// operator fixes the forge state by hand, at which point the retried
+    /// `gh issue edit` is a harmless idempotent no-op).
+    pending_quarantine_release: HashSet<u32>,
     /// Whether cross-host dispatch-collision detection is enabled (Issue #4085,
     /// Phase 0 of #4028). When `true`, [`dispatch`](Self::dispatch) issues a
     /// pre-flip `gh issue view --json labels` read and classifies whether a peer
@@ -1193,6 +1210,7 @@ impl SweepRegistry {
             quarantine_config: QuarantineConfig::default(),
             insta_crash_counts: HashMap::new(),
             quarantined: HashMap::new(),
+            pending_quarantine_release: HashSet::new(),
             detect_collisions: false,
             collision_count: 0,
         }
@@ -1217,6 +1235,7 @@ impl SweepRegistry {
             quarantine_config: QuarantineConfig::default(),
             insta_crash_counts: HashMap::new(),
             quarantined: HashMap::new(),
+            pending_quarantine_release: HashSet::new(),
             detect_collisions: false,
             collision_count: 0,
         }
@@ -1317,11 +1336,17 @@ impl SweepRegistry {
     /// label restore re-arms `loom:issue` (mirroring [`expire_quarantine`]), so
     /// the operator command both releases the in-memory pause and re-enters the
     /// issue into the work-finder queue — the label flip alone never sufficed.
+    ///
+    /// A failed label restore (Issue #4110) does NOT make this return `false` —
+    /// the in-memory quarantine genuinely was cleared — but the issue is added
+    /// to [`pending_quarantine_release`](Self::pending_quarantine_release_issues)
+    /// so the background reaper keeps retrying the flip until it succeeds,
+    /// instead of leaving the issue permanently stranded at `loom:blocked`.
     pub fn clear_quarantine(&mut self, issue: u32) -> bool {
         self.insta_crash_counts.remove(&issue);
         let was_quarantined = self.quarantined.remove(&issue).is_some();
         if was_quarantined {
-            self.release_quarantine_label(issue);
+            self.attempt_quarantine_release(issue);
         }
         was_quarantined
     }
@@ -1334,6 +1359,14 @@ impl SweepRegistry {
         self.quarantined.insert(issue, Utc::now());
         self.insta_crash_counts
             .insert(issue, self.quarantine_config.threshold);
+    }
+
+    /// Issues currently awaiting a retried `loom:blocked` -> `loom:issue` label
+    /// restore after at least one failed attempt (Issue #4110). Exposed for
+    /// tests and `loom-daemon status`-style diagnostics.
+    #[must_use]
+    pub fn pending_quarantine_release_issues(&self) -> HashSet<u32> {
+        self.pending_quarantine_release.clone()
     }
 
     /// Read-only accessor for the event bus, if any. Exposed so external
@@ -1930,7 +1963,9 @@ impl SweepRegistry {
     /// Called at the top of each [`reap_once`](Self::reap_once). Cheap
     /// early-return when nothing is quarantined. On release the insta-crash tally
     /// is cleared too, so the issue re-qualifies with a fresh runway, and a
-    /// best-effort forge label restore re-arms `loom:issue`.
+    /// best-effort forge label restore re-arms `loom:issue` — retried on
+    /// subsequent ticks via [`pending_quarantine_release`](Self::pending_quarantine_release_issues)
+    /// if the first attempt fails (Issue #4110).
     fn expire_quarantine(&mut self) {
         if self.quarantined.is_empty() {
             return;
@@ -1950,8 +1985,76 @@ impl SweepRegistry {
                 "sweep_registry: issue #{issue} quarantine expired after {ttl_secs}s — eligible \
                  for re-dispatch again (#3939)"
             );
-            self.release_quarantine_label(issue);
+            self.attempt_quarantine_release(issue);
         }
+    }
+
+    /// Retry every issue in [`pending_quarantine_release`](Self::pending_quarantine_release_issues)
+    /// (Issue #4110). Called every [`reap_once`](Self::reap_once) tick, right
+    /// after [`expire_quarantine`](Self::expire_quarantine): a previously
+    /// failed `loom:blocked` -> `loom:issue` restore (transient `gh` failure or
+    /// timeout, #3973) is retried here until it succeeds, instead of leaving
+    /// the issue permanently stranded. Cheap early-return when nothing is
+    /// pending. Idempotent — re-running the flip on an issue that a human
+    /// already restored by hand is a harmless no-op `gh` call.
+    fn retry_pending_quarantine_releases(&mut self) {
+        if self.pending_quarantine_release.is_empty() {
+            return;
+        }
+        let pending: Vec<u32> = self.pending_quarantine_release.iter().copied().collect();
+        for issue in pending {
+            self.attempt_quarantine_release(issue);
+        }
+    }
+
+    /// Attempt the `loom:blocked` -> `loom:issue` label restore for `issue`
+    /// (Issue #4110). On success, clears any pending-retry record. On
+    /// failure, records `issue` in [`pending_quarantine_release`](Self::pending_quarantine_release_issues)
+    /// (if not already there) and logs at `warn` — a silent strand is the
+    /// defect this exists to prevent, so the failure must be visible above
+    /// the default log level.
+    fn attempt_quarantine_release(&mut self, issue: u32) {
+        if self.release_quarantine_label(issue) {
+            self.pending_quarantine_release.remove(&issue);
+        } else {
+            let first_attempt = self.pending_quarantine_release.insert(issue);
+            log::warn!(
+                "sweep_registry: quarantine release for #{issue} failed — `loom:blocked` may \
+                 remain stranded on the forge; retrying on the next reaper tick (#4110){}",
+                if first_attempt {
+                    ""
+                } else {
+                    " (repeated failure)"
+                }
+            );
+        }
+    }
+
+    /// Best-effort release of every currently-quarantined issue's
+    /// `loom:blocked` label before this registry is dropped (Issue #4110).
+    /// Workspace eviction ([`crate::workspace_pool::WorkspacePool::evict`])
+    /// discards this registry's in-memory state, including any live
+    /// quarantine and its reaper — so without this, an evicted workspace's
+    /// quarantined issues would sit at `loom:blocked` until the *next* full
+    /// daemon restart triggers the startup reconciliation pass
+    /// ([`crate::quarantine_reconciliation`]). Each release here is a single
+    /// best-effort attempt (no in-registry retry survives past eviction,
+    /// since the reaper that would drive it is gone); a failure is logged at
+    /// `warn` and left for the reconciliation pass to pick up at the next
+    /// restart. Returns the number of quarantines flushed (attempted).
+    pub fn flush_quarantines_for_eviction(&mut self) -> usize {
+        let issues: Vec<u32> = self.quarantined.keys().copied().collect();
+        for issue in &issues {
+            self.quarantined.remove(issue);
+            self.insta_crash_counts.remove(issue);
+            if !self.release_quarantine_label(*issue) {
+                log::warn!(
+                    "sweep_registry: eviction release for #{issue} failed — `loom:blocked` may \
+                     remain stranded until the next daemon-restart reconciliation pass (#4110)"
+                );
+            }
+        }
+        issues.len()
     }
 
     /// Best-effort forge mutation on quarantine (#3939): add `loom:blocked`,
@@ -1995,17 +2098,18 @@ impl SweepRegistry {
         }
 
         let body = format!(
-            "Auto-quarantined by loom-daemon (#3939): this issue's sweep insta-crashed {count} \
+            "{marker}: this issue's sweep insta-crashed {count} \
              times in a row — each child died within {secs}s of dispatch without writing a phase \
              checkpoint, which almost always means an environment/configuration failure (e.g. a \
              missing token pool, #3938) rather than a problem with the issue itself. Re-dispatch \
              is paused so it stops occupying a global concurrency slot and starving other work. \
              Once the underlying cause is fixed, clear the quarantine with `loom-daemon \
-             quarantine clear {issue}` (this releases the in-memory pause AND restores \
-             `loom:issue`), or simply wait for the {ttl}s TTL to auto-release it. Note: manually \
-             flipping `loom:blocked` -> `loom:issue` on the forge does NOT release the daemon's \
-             in-memory quarantine on its own — the work finder skips it until the CLI clear or the \
-             TTL fires.",
+             quarantine clear {issue}`, or simply wait for the {ttl}s TTL — both paths release the \
+             in-memory pause AND restore `loom:issue` (#4110). Note: manually flipping \
+             `loom:blocked` -> `loom:issue` on the forge does NOT release the daemon's in-memory \
+             quarantine on its own — the work finder skips it until the CLI clear or the TTL \
+             fires.",
+            marker = QUARANTINE_COMMENT_MARKER,
             secs = self.quarantine_config.insta_crash_secs,
             ttl = self.quarantine_config.ttl.as_secs(),
         );
@@ -2030,13 +2134,24 @@ impl SweepRegistry {
         }
     }
 
-    /// Best-effort forge mutation on quarantine expiry (#3939): remove
-    /// `loom:blocked` and re-add `loom:issue` so an auto-released issue re-enters
-    /// the work-finder queue. The mirror of [`apply_quarantine_label`]. Skipped
-    /// when label flips are disabled; a `gh` failure is logged at debug only.
-    fn release_quarantine_label(&self, issue: u32) {
+    /// Best-effort forge mutation on quarantine expiry/clear (#3939): remove
+    /// `loom:blocked` and re-add `loom:issue` so a released issue re-enters the
+    /// work-finder queue. The mirror of [`apply_quarantine_label`]. Skipped
+    /// (returns `true` — a no-op success) when label flips are disabled.
+    ///
+    /// Returns `true` on a confirmed successful flip, `false` otherwise
+    /// (Issue #4110: previously this returned `()` and treated a completed-but-
+    /// failed `gh` invocation — non-zero exit — identically to success, which is
+    /// the root cause of the observed strand: the in-memory quarantine was
+    /// already dropped by the caller before this ran, so a swallowed failure
+    /// left `loom:blocked` on the forge with nothing left to retry it). Callers
+    /// use the return value to decide whether to retry
+    /// ([`attempt_quarantine_release`](Self::attempt_quarantine_release)).
+    /// Every failure is logged at `warn` (was `debug`) — a silent strand is
+    /// exactly the defect this exists to prevent.
+    fn release_quarantine_label(&self, issue: u32) -> bool {
         if self.config.skip_label_flip {
-            return;
+            return true;
         }
         let gh = self
             .config
@@ -2059,16 +2174,28 @@ impl SweepRegistry {
         // `ListSweeps` / `GetSweepStatus` read path.
         let timeout = reap_gh_timeout();
         match output_with_timeout(edit, timeout) {
-            Ok(Some(_)) => {}
-            Ok(None) => log::debug!(
-                "sweep_registry: quarantine-release label edit for #{issue} exceeded {}s, \
-                 killed (#3973)",
-                timeout.as_secs()
-            ),
+            Ok(Some(output)) if output.status.success() => true,
+            Ok(Some(output)) => {
+                log::warn!(
+                    "sweep_registry: quarantine-release label edit for #{issue} exited {:?}: {}",
+                    output.status.code(),
+                    String::from_utf8_lossy(&output.stderr).trim()
+                );
+                false
+            }
+            Ok(None) => {
+                log::warn!(
+                    "sweep_registry: quarantine-release label edit for #{issue} exceeded {}s, \
+                     killed (#3973)",
+                    timeout.as_secs()
+                );
+                false
+            }
             Err(e) => {
-                log::debug!(
+                log::warn!(
                     "sweep_registry: quarantine-release label edit for #{issue} failed: {e}"
-                )
+                );
+                false
             }
         }
     }
@@ -2706,6 +2833,9 @@ impl SweepRegistry {
         // has aged past the configured window before this tick's work. Cheap
         // early-return when nothing is quarantined.
         self.expire_quarantine();
+        // Retry any previously-failed quarantine label restores (Issue #4110).
+        // Cheap early-return when nothing is pending.
+        self.retry_pending_quarantine_releases();
 
         // Snapshot keys + pids first so we can borrow mutably below.
         // Capture started_at so we can compute durations for Exited events.
@@ -5981,6 +6111,167 @@ exit 0
         assert!(
             gh_calls.is_empty(),
             "expected no forge call for a no-op clear; got: {gh_calls:?}"
+        );
+    }
+
+    // ------------------------------------------------------------------------
+    // Durable quarantine release (Issue #4110)
+    // ------------------------------------------------------------------------
+
+    /// TTL-driven release now performs the *real* `gh` label-flip argv.
+    /// Previously the quarantine test suite only ever exercised
+    /// `expire_quarantine` via `fixture_registry`, which sets
+    /// `skip_label_flip = true` — so no test asserted what argv the release
+    /// path actually sends to `gh`. Also confirms a subsequent tick with
+    /// nothing pending makes no further `gh` calls at all (idempotence: a
+    /// released issue is not repeatedly re-flipped).
+    #[test]
+    fn quarantine_expiry_flips_real_forge_label_via_argv() {
+        let dir = tempdir().unwrap();
+        let gh_log = dir.path().join("gh-invocations.log");
+        let fake_gh = install_fake_gh(dir.path(), &gh_log, "", 0);
+
+        let mut config = SweepRegistryConfig::new(dir.path().to_path_buf());
+        config.gh_bin = Some(fake_gh);
+        config.skip_label_flip = false; // exercise the real release path
+        let mut registry = SweepRegistry::new(config);
+        registry.set_quarantine_config(QuarantineConfig {
+            ttl: Duration::from_secs(3600),
+            ..QuarantineConfig::default()
+        });
+        registry
+            .quarantined
+            .insert(60, Utc::now() - chrono::Duration::seconds(7200));
+        registry.insta_crash_counts.insert(60, 3);
+
+        registry.reap_once();
+
+        assert!(!registry.is_quarantined(60));
+        assert!(
+            registry.pending_quarantine_release_issues().is_empty(),
+            "a successful flip leaves nothing pending"
+        );
+        let gh_calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            gh_calls.contains("issue edit 60 --remove-label loom:blocked --add-label loom:issue"),
+            "expected TTL expiry to send the real label-flip argv; got: {gh_calls:?}"
+        );
+
+        // A later tick with nothing quarantined/pending must not re-invoke gh.
+        registry.reap_once();
+        let gh_calls_after = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert_eq!(gh_calls, gh_calls_after, "no further gh calls once nothing is pending");
+    }
+
+    /// A `gh` failure during release must NOT permanently strand the issue:
+    /// the entry is retained in the pending-release set and retried until it
+    /// succeeds (Issue #4110). Previously `expire_quarantine` dropped the
+    /// in-memory entry unconditionally and `release_quarantine_label`
+    /// swallowed any failure at `debug`, so a single transient `gh` hiccup
+    /// permanently stranded `loom:blocked` with nothing left in memory to
+    /// retry it — reproducing the exact reported end state (`quarantine
+    /// clear` -> "was not quarantined", forge still `loom:blocked`).
+    ///
+    /// The fake `gh` fails its first two invocations (a counter file tracks
+    /// remaining failures) — enough to survive both the `expire_quarantine`
+    /// attempt AND the same-tick `retry_pending_quarantine_releases` pass —
+    /// so the first `reap_once` tick genuinely ends with the issue still
+    /// pending, and only the second tick's retry succeeds.
+    #[test]
+    fn quarantine_release_retries_after_gh_failure_then_succeeds() {
+        let dir = tempdir().unwrap();
+        let gh_log = dir.path().join("gh-invocations.log");
+        let fail_counter = dir.path().join("fails-remaining");
+        std::fs::write(&fail_counter, "2").unwrap();
+        let fake_gh = dir.path().join("fake-gh.sh");
+        let script = format!(
+            "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"{log}\"\ncount=$(cat \"{counter}\" \
+             2>/dev/null || echo 0)\nif [ \"$count\" -gt 0 ]; then\n  echo $((count - 1)) > \
+             \"{counter}\"\n  exit 1\nfi\nexit 0\n",
+            log = gh_log.display(),
+            counter = fail_counter.display(),
+        );
+        std::fs::write(&fake_gh, &script).unwrap();
+        let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_gh, perms).unwrap();
+        if let Ok(f) = std::fs::File::open(&fake_gh) {
+            let _ = f.sync_all();
+        }
+
+        let mut config = SweepRegistryConfig::new(dir.path().to_path_buf());
+        config.gh_bin = Some(fake_gh);
+        config.skip_label_flip = false;
+        let mut registry = SweepRegistry::new(config);
+        registry.set_quarantine_config(QuarantineConfig {
+            ttl: Duration::from_secs(3600),
+            ..QuarantineConfig::default()
+        });
+        registry
+            .quarantined
+            .insert(61, Utc::now() - chrono::Duration::seconds(7200));
+        registry.insta_crash_counts.insert(61, 3);
+
+        // First tick: both the `expire_quarantine` attempt and the same-tick
+        // `retry_pending_quarantine_releases` pass hit the fake gh's two
+        // scripted failures. The in-memory quarantine is still gone
+        // (`expire_quarantine` drops it before attempting the release), but
+        // the issue must NOT be silently stranded — it lands in the
+        // pending-retry set instead.
+        registry.reap_once();
+        assert!(
+            !registry.is_quarantined(61),
+            "quarantine memory clears regardless of flip outcome"
+        );
+        assert!(
+            registry.pending_quarantine_release_issues().contains(&61),
+            "a failed release must be retried, not dropped"
+        );
+
+        // Second tick: the fake gh's failure budget is exhausted, so the
+        // retry succeeds and clears the pending entry.
+        registry.reap_once();
+        assert!(
+            registry.pending_quarantine_release_issues().is_empty(),
+            "a successful retry clears the pending-release record"
+        );
+
+        let gh_calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert_eq!(
+            gh_calls
+                .matches("issue edit 61 --remove-label loom:blocked --add-label loom:issue")
+                .count(),
+            3,
+            "expected three attempts: two scripted failures then the successful retry; got: \
+             {gh_calls:?}"
+        );
+    }
+
+    /// Eviction (Issue #4110): a workspace's live quarantines are released
+    /// before the pool drops the registry, instead of silently vanishing with
+    /// the reaper that would otherwise have retried them.
+    #[test]
+    fn flush_quarantines_for_eviction_releases_and_clears_state() {
+        let dir = tempdir().unwrap();
+        let gh_log = dir.path().join("gh-invocations.log");
+        let fake_gh = install_fake_gh(dir.path(), &gh_log, "", 0);
+
+        let mut config = SweepRegistryConfig::new(dir.path().to_path_buf());
+        config.gh_bin = Some(fake_gh);
+        config.skip_label_flip = false;
+        let mut registry = SweepRegistry::new(config);
+        registry.quarantined.insert(62, Utc::now());
+        registry.insta_crash_counts.insert(62, 3);
+
+        let flushed = registry.flush_quarantines_for_eviction();
+        assert_eq!(flushed, 1);
+        assert!(!registry.is_quarantined(62));
+        assert_eq!(registry.insta_crash_count(62), 0);
+
+        let gh_calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            gh_calls.contains("issue edit 62 --remove-label loom:blocked --add-label loom:issue"),
+            "expected eviction to flush the real label-flip argv; got: {gh_calls:?}"
         );
     }
 

--- a/loom-daemon/src/workspace_pool.rs
+++ b/loom-daemon/src/workspace_pool.rs
@@ -193,6 +193,25 @@ impl WorkspacePool {
         }
         match map.remove(root) {
             Some(pooled) => {
+                // Release any outstanding quarantine labels before the
+                // registry's reaper (the only thing that would otherwise
+                // retry a failed release) is aborted (Issue #4110) — without
+                // this, an evicted workspace's quarantined issues sit at
+                // `loom:blocked` until the *next* full daemon restart's
+                // startup reconciliation pass
+                // ([`crate::quarantine_reconciliation`]).
+                let flushed = pooled
+                    .registry
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .flush_quarantines_for_eviction();
+                if flushed > 0 {
+                    log::info!(
+                        "workspace_pool: flushed {flushed} quarantine release(s) for {} before \
+                         eviction (#4110)",
+                        root.display()
+                    );
+                }
                 if let Some(reaper) = pooled._reaper {
                     reaper.abort();
                 }


### PR DESCRIPTION
## Summary

Implements the Curator's corrected root-cause analysis on #4110: the TTL
already restored `loom:issue` on current main, but two real, unfixed bugs
still strand `loom:blocked` issues forever — a best-effort release that drops
in-memory state before attempting (and never retries) the `gh` label flip,
and no startup reconciliation for a daemon restart (which always wipes the
memory-only quarantine map). A third gap — workspace eviction dropping a
live quarantine's only retry path — is fixed as well, since it was small and
directly analogous to the restart case.

## Changes

- `loom-daemon/src/sweep_registry.rs`
  - `release_quarantine_label` now checks `output.status.success()` instead
    of treating any completed `gh` invocation as success, returns a `bool`,
    and logs failures at `warn` (was `debug`) — the previous code silently
    treated a non-zero `gh` exit identically to success.
  - `expire_quarantine` / `clear_quarantine` now route through a new
    `attempt_quarantine_release` helper: on failure the issue is added to a
    new `pending_quarantine_release: HashSet<u32>` field instead of being
    dropped; `reap_once` retries every pending entry each tick
    (`retry_pending_quarantine_releases`) until the flip succeeds.
  - New `flush_quarantines_for_eviction` releases every live quarantine
    before a registry is discarded.
  - Extracted `QUARANTINE_COMMENT_MARKER` const and fixed the posted
    comment's wording: both the CLI clear **and** the TTL restore
    `loom:issue` (previously only the CLI path was described that way).
- `loom-daemon/src/quarantine_reconciliation.rs` (new) — startup
  reconciliation pass mirroring `claim_reconciliation`'s conventions (kill
  switch, per-workspace issue cap, pure `decide`/`plan` split). Scans open
  `loom:blocked` issues per workspace and releases the ones whose comments
  contain `QUARANTINE_COMMENT_MARKER` back to `loom:issue`; an issue with no
  such comment (an operator's manual block) is never touched. Unlike
  `claim_reconciliation` there's no PID-liveness question — a fresh daemon's
  quarantine memory is always empty at startup, so the marker alone decides.
- `loom-daemon/src/main.rs` — wires the new pass in beside the existing
  `claim_reconciliation` startup call.
- `loom-daemon/src/workspace_pool.rs` — `evict()` calls
  `flush_quarantines_for_eviction` before aborting the registry's reaper.
- `loom-daemon/src/lib.rs` — registers the new module.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| A `gh` failure/timeout during release does not permanently strand the issue; failure logged at `warn`+ | ✅ | `release_quarantine_label` returns `bool` on exit-status check, logs at `warn`; `quarantine_release_retries_after_gh_failure_then_succeeds` test drives a scripted 2-failure-then-success fake `gh` through two `reap_once` ticks and asserts the pending set + eventual success |
| A daemon restart does not permanently strand quarantined issues — startup pass reconciles `loom:blocked` issues with a quarantine comment but no live quarantine | ✅ | New `quarantine_reconciliation` module + `main.rs` wiring; `reconcile_workspace_releases_issue_with_quarantine_comment` asserts the real `gh issue edit --remove-label loom:blocked --add-label loom:issue` argv fires |
| Startup pass is bounded (issue cap) and has a kill-switch env var | ✅ | `MAX_ISSUES_PER_WORKSPACE` passed to `gh issue list --limit`; `LOOM_QUARANTINE_RECONCILE` kill switch — `reconcile_workspace_passes_issue_cap_to_gh_list`, `reconciliation_enabled_resolves_env_precedence` |
| Workspace eviction does not silently strand a quarantined issue | ✅ | `flush_quarantines_for_eviction` called from `WorkspacePool::evict`; `flush_quarantines_for_eviction_releases_and_clears_state` |
| Quarantine comment states both release paths restore `loom:issue` | ✅ | Comment body rewritten in `apply_quarantine_label`; read the updated format string |
| Idempotence preserved — releasing a non-quarantined issue is a no-op success; repeated flip is harmless | ✅ | Existing `clear_quarantine_noop_skips_forge_label` / `ipc.rs:test_handle_request_clear_quarantine_noop` still pass; `quarantine_expiry_flips_real_forge_label_via_argv` asserts a later tick with nothing pending makes no further `gh` calls |
| ~~TTL expiry restores `loom:issue`~~ (already true on `main`) — add the missing test | ✅ | `quarantine_expiry_flips_real_forge_label_via_argv` is the first test to exercise the real (non-`skip_label_flip`) TTL release argv |

## Test Plan

- `cargo test -p loom-daemon --lib quarantine` — 27 passed (0 failed)
- `cargo test -p loom-daemon --lib` (full crate) — 1212 passed, 0 failed
- `cargo test -p loom-daemon --lib workspace_pool` — 7 passed (existing eviction tests unaffected — an empty quarantine map short-circuits the new flush with zero `gh` calls)
- `cargo clippy -p loom-daemon --lib --tests -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## Scope note

The issue's implementation guidance set a soft ~400 LOC target and an
explicit escape hatch to defer the reconciliation pass if it alone would
blow that budget. The total diff (main.rs/workspace_pool.rs/lib.rs wiring +
sweep_registry.rs release-path fix + the new quarantine_reconciliation
module, tests included) came in over that number, but the reconciliation
module itself is much leaner than its `claim_reconciliation` sibling (no
PID-liveness question — a fresh daemon's quarantine memory is always empty
at startup, so the daemon-authored comment marker alone decides), and a
large share of the total is rustdoc matching this repo's existing
doc-per-function convention plus the real-argv test coverage the issue's own
Test Plan called out as a pre-existing gap. Given all four steps are small,
mutually reinforcing, and independently well-tested, I landed them together
rather than splitting step 2 into a follow-up.

Closes #4110