### PR TITLE
fix(daemon): re-render supervised plist on refused-restart fallback instead of bootstrapping the stale one

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -2262,7 +2262,26 @@ manually rebuilt the Rust binary, reprovisioned it, and restarted the process.
 ./.loom/scripts/cli/loom-daemon-update.sh --dry-run     # print the plan without building/provisioning/restarting
 ./.loom/scripts/cli/loom-daemon-update.sh --force       # rebuild + provision + restart even if already up to date
 ./.loom/scripts/cli/loom-daemon-update.sh --no-restart  # rebuild + provision only; leave the running daemon untouched
+./.loom/scripts/cli/loom-daemon-update.sh --relaunch    # launchd only: after a refused restart, re-render the plist + relaunch under supervision (preserves the live plist's LOOM_* env)
 ```
+
+**Launchd refused-restart fallback (`--relaunch`, exit 6, #4118)**: on the
+FIRST roll onto a #4077-capable binary the *running* (old) daemon has no
+`RestartDaemon` handler and refuses the `loom-daemon restart` IPC, so the script
+exits **6** rather than reporting a half-update. It does **not** tell you to
+`launchctl bootstrap` the existing plist — that plist is stale by construction
+(no `KeepAlive:{SuccessfulExit:true}`, no `LOOM_DAEMON_SUPERVISOR`), so
+bootstrapping it relaunches *unsupervised* and every subsequent roll refuses
+identically forever, and its `launchctl bootout` tears down the whole job tree
+(in-flight sweep children are direct children of the launchd job, so they are
+killed). Instead, `--relaunch` (or `LOOM_DAEMON_UPDATE_RELAUNCH=1`) re-renders
+the plist via `loom-daemon-start.sh` — installing both supervised keys — while
+**preserving the live plist's `LOOM_*`/token `EnvironmentVariables`** (read with
+`plutil` + `jq`, `PATH`/`HOME`/`LOOM_DAEMON_SUPERVISOR` excluded so autonomy
+flags never silently narrow to FLAGS-OFF, #4011), and stops the old daemon
+**gracefully with `SIGTERM`** so sweep children reparent and keep working. The
+default path stays exit-6 (no `--relaunch`) so the sweep-disrupting relaunch is
+always a consented action.
 
 **Staleness detection** is primary-local, zero-network: it compares the git
 commit **baked into** the currently-resolved `loom-daemon` binary (embedded at

--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -47,8 +47,16 @@
 # consulted in this mode (the plist's EnvironmentVariables IS the durable flag
 # source), and no "restarting FLAGS-OFF" warning fires. If the running (old)
 # binary predates #4077 and refuses the request, this script REFUSES LOUDLY
-# (exit 6) with the manual bootout/bootstrap fallback rather than reporting a
-# half-update — the exact #4011 silent-autonomy-loss class this closes.
+# (exit 6) and prints how to re-render the plist + relaunch under supervision
+# (loom-daemon-update.sh --relaunch), rather than reporting a half-update — the
+# exact #4011 silent-autonomy-loss class this closes. The old advice to bootstrap
+# the EXISTING plist was itself a bug (#4118): it relaunched under the STALE plist
+# (no KeepAlive:SuccessfulExit, no LOOM_DAEMON_SUPERVISOR), so every subsequent
+# roll hit the same exit 6 forever, and its bootout killed in-flight sweeps
+# (sweep children are direct children of the launchd job). --relaunch re-renders
+# via loom-daemon-start.sh (installing the supervised keys) while preserving the
+# live plist's LOOM_* autonomy env, and SIGTERMs the daemon so sweep children
+# reparent instead of being torn down with the job.
 #
 # Usage:
 #   ./.loom/scripts/cli/loom-daemon-update.sh              Detect, rebuild if stale, provision, restart (preserving flags)
@@ -56,6 +64,7 @@
 #   ./.loom/scripts/cli/loom-daemon-update.sh --dry-run     Print the plan without building/provisioning/restarting
 #   ./.loom/scripts/cli/loom-daemon-update.sh --force       Rebuild + provision + restart even if already up to date
 #   ./.loom/scripts/cli/loom-daemon-update.sh --no-restart  Rebuild + provision only; leave the running daemon untouched
+#   ./.loom/scripts/cli/loom-daemon-update.sh --relaunch    Launchd only: after a refused restart, re-render the plist and relaunch under supervision (SIGTERMs the daemon so sweep children reparent; preserves the live plist's LOOM_* env)
 #   ./.loom/scripts/cli/loom-daemon-update.sh --help
 #
 # Environment:
@@ -73,6 +82,9 @@
 #                          domain and follows the PID-file/nohup restart path.
 #   LOOM_LAUNCHD_LABEL     macOS only: the LaunchAgent label to inspect/restart
 #                          (default com.rjwalters.loom-daemon).
+#   LOOM_DAEMON_UPDATE_RELAUNCH  macOS/launchd only: 1/true/yes is equivalent to
+#                          passing --relaunch (opt in to the re-render + relaunch
+#                          on a refused restart).
 #
 # Exit codes:
 #   0  up to date (no-op) OR rebuild+provision+restart succeeded
@@ -91,7 +103,10 @@
 #      (old) binary refused the `loom-daemon restart` IPC request (a pre-#4077
 #      binary with no RestartDaemon handler, or a dead socket). The fresh binary
 #      IS provisioned but the OLD one is still running; the script refuses to
-#      report success and prints the manual bootout/bootstrap fallback (#4042).
+#      report success. Without --relaunch it prints how to re-render the plist and
+#      relaunch under supervision, then exits 6; with --relaunch (or
+#      LOOM_DAEMON_UPDATE_RELAUNCH=1) it performs that re-render+relaunch itself,
+#      propagating loom-daemon-start.sh's exit code (#4042, #4118).
 #
 # See also: loom-daemon-start.sh (writes .loom/.daemon.flags), loom-daemon-stop.sh
 # (SIGTERM -> grace -> SIGKILL; in-flight sweeps survive by design — this
@@ -195,6 +210,8 @@ DRY_RUN=false
 FORCE=false
 CHECK_ONLY=false
 NO_RESTART=false
+RELAUNCH=false
+[[ "${LOOM_DAEMON_UPDATE_RELAUNCH:-}" =~ ^(1|true|yes)$ ]] && RELAUNCH=true
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --help|-h) show_help; exit 0 ;;
@@ -202,6 +219,7 @@ while [[ $# -gt 0 ]]; do
         --force) FORCE=true; shift ;;
         --check) CHECK_ONLY=true; shift ;;
         --no-restart) NO_RESTART=true; shift ;;
+        --relaunch) RELAUNCH=true; shift ;;
         *) err "Unknown option '$1'"; echo "Use --help for usage" >&2; exit 1 ;;
     esac
 done
@@ -304,6 +322,105 @@ launchd_job_loaded() {
 }
 launchd_job_pid() {
     launchctl print "$LAUNCHD_SERVICE" 2>/dev/null | awk -F'= ' '/^[[:space:]]*pid = /{gsub(/[^0-9]/, "", $2); print $2; exit}'
+}
+
+# ---------- re-render + relaunch on a refused restart (#4118) ----------
+# The exit-6 fallback USED to tell the operator to `launchctl bootstrap` the
+# EXISTING plist. That plist is stale by construction (it is the pre-#4077 file
+# that caused the refused restart) — bootstrapping it relaunches WITHOUT
+# KeepAlive:SuccessfulExit and WITHOUT LOOM_DAEMON_SUPERVISOR, so the next roll
+# refuses identically, forever; and its `launchctl bootout` tears down the whole
+# job tree, killing in-flight sweeps (they are direct children of the launchd
+# job). The correct fix is to RE-RENDER the plist via loom-daemon-start.sh (which
+# hardcodes the two supervised keys), preserving the live plist's autonomy/auth
+# env, and to stop the old daemon gracefully so sweep children reparent.
+
+# harvest_plist_env <plist> — echo the live plist's EnvironmentVariables,
+# restricted to exactly the keys render_launchd_plist itself forwards (LOOM_*,
+# GH_TOKEN, GITEA_TOKEN, FORGE_TOKEN) and EXCLUDING:
+#   - PATH / HOME     (start.sh rebuilds PATH from the live shell; round-tripping
+#                      the plist's already-extended PATH would grow it each roll),
+#   - LOOM_DAEMON_SUPERVISOR (start.sh hardcodes it; re-exporting is pointless).
+# Emits one "<key>\t<base64(value)>" line per key so values containing spaces or
+# newlines survive. Fails loudly (return 2) when the plist is absent or
+# unparseable — it must NEVER silently return an empty set, which would let the
+# re-render narrow the autonomy flags to FLAGS-OFF defaults (the #4011 class).
+harvest_plist_env() {
+    local plist="$1"
+    if [[ ! -f "$plist" ]]; then
+        err "Cannot harvest launchd env: plist not found at $plist"
+        return 2
+    fi
+    if ! command -v plutil >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+        err "Cannot harvest launchd env: plutil and jq are both required on the macOS launchd path."
+        return 2
+    fi
+    local json
+    json=$(plutil -convert json -o - "$plist" 2>/dev/null) || {
+        err "Cannot harvest launchd env: plist at $plist is not parseable by plutil."
+        return 2
+    }
+    printf '%s' "$json" | jq -r '
+        .EnvironmentVariables // {}
+        | to_entries[]
+        | select(.key | test("^(LOOM_[A-Za-z0-9_]*|GH_TOKEN|GITEA_TOKEN|FORGE_TOKEN)$"))
+        | select(.key != "LOOM_DAEMON_SUPERVISOR")
+        | .key + "\t" + (.value | @base64)
+    ' 2>/dev/null || {
+        err "Cannot harvest launchd env: failed to extract EnvironmentVariables from $plist."
+        return 2
+    }
+}
+
+# perform_relaunch <plist> <service> — re-render the LaunchAgent and relaunch it
+# under launchd supervision, preserving the live plist's autonomy/auth env.
+# Invoked ONLY from the exit-6 fallback when the operator opted in (--relaunch /
+# LOOM_DAEMON_UPDATE_RELAUNCH=1), so the sweep-disrupting relaunch is a consented
+# action, never silent. Returns loom-daemon-start.sh's exit code (or 6 if the env
+# harvest fails — refusing to relaunch into a silently-narrowed env).
+perform_relaunch() {
+    local plist="$1"
+    echo "--relaunch: re-rendering the LaunchAgent and relaunching under launchd supervision."
+
+    # 1. Preserve the live plist's autonomy/auth env across the re-render.
+    local harvested
+    if ! harvested=$(harvest_plist_env "$plist"); then
+        err "Refusing to relaunch: could not read the live plist's EnvironmentVariables."
+        err "Relaunching now would silently narrow the autonomy flags to FLAGS-OFF defaults (#4011) — aborting."
+        return 6
+    fi
+    local k v64 count=0
+    while IFS=$'\t' read -r k v64; do
+        [[ -z "$k" ]] && continue
+        export "$k=$(printf '%s' "$v64" | base64 --decode)"
+        count=$((count + 1))
+    done <<< "$harvested"
+    echo "Preserved ${count} LOOM_*/token env var(s) from the live plist across the re-render (PATH/HOME/LOOM_DAEMON_SUPERVISOR excluded by design)."
+
+    # 2. Stop the old daemon GRACEFULLY so its sweep children reparent and keep
+    #    working, instead of `launchctl bootout` tearing down the whole job tree.
+    #    kill -TERM makes the daemon exit non-zero, so the stale plist's
+    #    KeepAlive=false does not relaunch it — start.sh below installs the fresh,
+    #    supervised plist and bootstraps the new process.
+    local daemon_pid
+    daemon_pid=$(launchd_job_pid)
+    if [[ -n "$daemon_pid" ]] && kill -0 "$daemon_pid" 2>/dev/null; then
+        echo "Sending SIGTERM to the running daemon (pid ${daemon_pid}) — sweep children reparent and keep working (NOT bootout, which would kill them)."
+        kill -TERM "$daemon_pid" 2>/dev/null || true
+        local _waited
+        for _waited in 1 2 3 4 5; do
+            kill -0 "$daemon_pid" 2>/dev/null || break
+            sleep 1
+        done
+    fi
+
+    # 3. Re-render + bootstrap via loom-daemon-start.sh. It hardcodes
+    #    KeepAlive:{SuccessfulExit:true} + LOOM_DAEMON_SUPERVISOR=launchd, and
+    #    harvests the LOOM_* env we just re-exported. In launchd mode the plist's
+    #    EnvironmentVariables — not .daemon.flags — is the durable config, so no
+    #    flags are passed here.
+    echo "Invoking ${START_SCRIPT} to re-render the supervised plist and relaunch."
+    "$START_SCRIPT"
 }
 
 # Resolve which manager owns the running daemon: launchd (checked first), the
@@ -500,8 +617,10 @@ if [[ "$NO_RESTART" == "true" ]]; then
     if [[ "$WAS_RUNNING" == "true" ]]; then
         if [[ "$DAEMON_MANAGER" == "launchd" ]]; then
             echo "The running (launchd-managed) daemon is still the PRE-update binary. Restart it with:"
-            echo "  $PROVISION_TARGET restart"
-            echo "or manually: launchctl bootout $LAUNCHD_SERVICE && launchctl bootstrap gui/$(id -u) $LAUNCHD_PLIST"
+            echo "  $PROVISION_TARGET restart      (graceful: supervised in-place relaunch, in-flight sweeps preserved)"
+            echo "If that binary predates #4077 and refuses the restart, re-render + relaunch under supervision:"
+            echo "  loom-daemon-update.sh --relaunch   (preserves the live plist's LOOM_* env; SIGTERMs the daemon so sweep children reparent)"
+            echo "Do NOT 'launchctl bootout $LAUNCHD_SERVICE' by hand — bootout tears down the whole job tree and KILLS in-flight sweeps (they are direct children of the launchd job)."
         else
             echo "The running daemon is still the PRE-update binary. Restart manually with:"
             echo "  $STOP_SCRIPT && $START_SCRIPT ${RESTART_ARGS[*]:-}"
@@ -537,9 +656,29 @@ if [[ "$DAEMON_MANAGER" == "launchd" ]]; then
     # still running (the #4011 silent-autonomy-loss class this issue closes).
     err "loom-daemon restart FAILED: the running daemon did not accept the restart request."
     err "This is expected on the FIRST roll onto a #4077-capable binary — the currently-running binary predates the 'restart' IPC command (or its socket is dead)."
-    err "The freshly-built binary IS provisioned, but the OLD binary is still running. Restart it manually to pick up the update:"
-    err "  launchctl bootout   $LAUNCHD_SERVICE"
-    err "  launchctl bootstrap gui/$(id -u) $LAUNCHD_PLIST"
+    err "The freshly-built binary IS provisioned, but the OLD (unsupervised) binary is still running."
+
+    if [[ "$RELAUNCH" == "true" ]]; then
+        perform_relaunch "$LAUNCHD_PLIST"
+        exit $?
+    fi
+
+    daemon_pid_hint=$(launchd_job_pid)
+    err ""
+    err "To finish the roll, re-render the plist and relaunch under launchd supervision"
+    err "(this installs KeepAlive:{SuccessfulExit:true} + LOOM_DAEMON_SUPERVISOR=launchd so"
+    err "the NEXT roll can use the supervised path) while preserving the live plist's LOOM_*"
+    err "autonomy env — run:"
+    err "  loom-daemon-update.sh --relaunch      (or: LOOM_DAEMON_UPDATE_RELAUNCH=1 loom-daemon-update.sh)"
+    err ""
+    err "WARNING: do NOT 'launchctl bootout $LAUNCHD_SERVICE' by hand to force this."
+    err "bootout tears down the whole job tree, and in-flight sweep children are DIRECT"
+    err "children of the launchd job, so it TERMINATES every running sweep — stranding"
+    err "loom:building labels and leaving worktrees behind. --relaunch above instead stops"
+    err "the daemon gracefully (SIGTERM) so sweep children reparent and keep working."
+    err "If you must relaunch by hand, prefer the graceful sequence over bootout+bootstrap:"
+    err "  kill -TERM ${daemon_pid_hint:-<daemon-pid>}   # daemon exits non-zero; children reparent; not relaunched (stale plist KeepAlive=false)"
+    err "  $START_SCRIPT                                  # re-render + bootstrap the supervised plist"
     exit 6
 fi
 

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -175,6 +175,57 @@ EOF
     chmod +x "$bin_dir/uname"
 }
 
+# Writes a stale, PRE-#4077 LaunchAgent plist at $1 (the exact state that causes
+# the refused-restart exit-6 fallback): KeepAlive=false, NO LOOM_DAEMON_SUPERVISOR
+# key, and four autonomy env keys plus a SENTINEL PATH. The re-render on the
+# --relaunch path (#4118) must (a) install KeepAlive:{SuccessfulExit:true} +
+# LOOM_DAEMON_SUPERVISOR=launchd, (b) carry all four autonomy keys through
+# unchanged, and (c) NOT round-trip the sentinel PATH (start.sh rebuilds PATH).
+# Args: <plist_path> <label> <bin> <homedir>.
+write_fixture_plist_pre4077() {
+    local plist="$1" label="$2" bin="$3" homedir="$4"
+    mkdir -p "$(dirname "$plist")"
+    cat > "$plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${label}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${bin}</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/sentinel-oldpath-4118/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>${homedir}</string>
+        <key>LOOM_WORK_FINDER</key>
+        <string>1</string>
+        <key>LOOM_MAIN_HEALTH_GATE</key>
+        <string>1</string>
+        <key>LOOM_WORK_FINDER_MAX_CONCURRENT</key>
+        <string>10</string>
+        <key>LOOM_PER_TOKEN_CONCURRENCY</key>
+        <string>5</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>StandardOutPath</key>
+    <string>${homedir}/daemon.log</string>
+    <key>StandardErrorPath</key>
+    <string>${homedir}/daemon.log</string>
+</dict>
+</plist>
+EOF
+}
+
 # Writes a fake `cargo` that, on `cargo build --release` (cwd = loom-daemon/),
 # copies $NEW_FAKE_BIN_SRC into target/release/loom-daemon instead of
 # compiling. Tests export NEW_FAKE_BIN_SRC before invoking loom-daemon-update.sh.
@@ -800,10 +851,13 @@ else
 fi
 
 # ============================================================
-# 16. Launchd restart REFUSED (#4042): a launchd job is loaded but the running
-#     (old) binary rejects the restart request (pre-#4077 binary / dead socket).
-#     The updater must exit NON-ZERO (6) and print the manual bootout/bootstrap
-#     fallback — never report success while silently skipping the restart.
+# 16. Launchd restart REFUSED (#4042/#4118): a launchd job is loaded but the
+#     running (old) binary rejects the restart request (pre-#4077 binary / dead
+#     socket). Without --relaunch the updater must exit NON-ZERO (6) and print
+#     the CORRECTED fallback: it names the `--relaunch` re-render path (NOT a
+#     bare `launchctl bootstrap` of the stale plist, which was the #4118 bug),
+#     warns that `launchctl bootout` terminates in-flight sweeps (AC4), and
+#     prefers a graceful `kill -TERM`.
 # ============================================================
 W16="$BASE_WORKDIR/w16"
 new_fixture "$W16"
@@ -823,13 +877,26 @@ out16=$( cd "$W16" && PATH="$LD_BIN16:$TEST_PATH" LOOM_DAEMON_LAUNCHD=1 \
     bash "$UPDATE_SCRIPT" 2>&1 )
 rc16=$?
 assert_eq "6" "$rc16" "launchd restart refused -> exit 6 (never a silent half-update)"
+# (a) Names the --relaunch re-render path and does NOT recommend a bare
+#     `launchctl bootstrap` of the stale plist (the #4118 self-perpetuating bug).
 TESTS_RUN=$((TESTS_RUN + 1))
-if echo "$out16" | grep -qi 'launchctl bootout' && echo "$out16" | grep -qi 'launchctl bootstrap'; then
+if echo "$out16" | grep -q -- '--relaunch' && ! echo "$out16" | grep -qi 'launchctl bootstrap'; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
-    echo -e "${GREEN}✓${NC} refused launchd restart prints the manual bootout/bootstrap fallback"
+    echo -e "${GREEN}✓${NC} refused restart names --relaunch, never a bare bootstrap of the stale plist"
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))
-    echo -e "${RED}✗${NC} refused launchd restart prints the manual bootout/bootstrap fallback"
+    echo -e "${RED}✗${NC} refused restart names --relaunch, never a bare bootstrap of the stale plist"
+    echo "  output: $out16"
+fi
+# (b) AC4: warns that bootout terminates in-flight sweeps + prefers kill -TERM.
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out16" | grep -qi 'bootout' && echo "$out16" | grep -qi 'sweep' \
+    && echo "$out16" | grep -q 'kill -TERM'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} refused restart warns bootout kills in-flight sweeps + prefers kill -TERM (AC4)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} refused restart warns bootout kills in-flight sweeps + prefers kill -TERM (AC4)"
     echo "  output: $out16"
 fi
 
@@ -947,7 +1014,152 @@ else
 fi
 
 # ============================================================
-# 20. Launchd-sandbox guards (#4078): the whole suite exercises the REAL
+# 21. --relaunch re-renders the plist with the SUPERVISED keys (#4118 AC1):
+#     after a refused restart, `--relaunch` re-renders via loom-daemon-start.sh,
+#     installing KeepAlive:{SuccessfulExit:true} + LOOM_DAEMON_SUPERVISOR=launchd
+#     into the plist — the two keys the stale pre-#4077 fixture plist LACKS, so a
+#     passing assertion proves the re-render actually happened (not a leftover).
+#     HOME is sandboxed so LAUNCHD_PLIST resolves inside the test tree, never the
+#     operator's real ~/Library/LaunchAgents (#4078).
+# ============================================================
+W21="$BASE_WORKDIR/w21"
+new_fixture "$W21"
+INSTALLED21="$W21/installed/loom-daemon"
+mkdir -p "$W21/installed"
+RESTART_MARKER21="$W21/restart-invoked"
+# Running (old) + fresh binaries both REFUSE restart (pre-#4077) -> exit-6 path.
+write_fake_daemon_restart "$INSTALLED21" "deadbee" "$RESTART_MARKER21" 1
+NEW_FAKE21="$W21/new-fake-daemon"
+HEAD21="$(cd "$W21" && git rev-parse --short HEAD)"
+write_fake_daemon_restart "$NEW_FAKE21" "$HEAD21" "$RESTART_MARKER21" 1
+LD_BIN21="$W21/launchd-bin"
+write_fake_launchd_loaded_bin "$LD_BIN21" "$W21/launchctl.log"
+HOME21="$W21/home"
+PLIST21="$HOME21/Library/LaunchAgents/${LOOM_LAUNCHD_LABEL}.plist"
+write_fixture_plist_pre4077 "$PLIST21" "$LOOM_LAUNCHD_LABEL" "$INSTALLED21" "$HOME21"
+( cd "$W21" && PATH="$LD_BIN21:$TEST_PATH" HOME="$HOME21" LOOM_DAEMON_LAUNCHD=1 \
+    LOOM_DAEMON_BIN="$INSTALLED21" NEW_FAKE_BIN_SRC="$NEW_FAKE21" \
+    bash "$UPDATE_SCRIPT" --relaunch >/dev/null 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q 'LOOM_DAEMON_SUPERVISOR' "$PLIST21" 2>/dev/null \
+    && grep -q 'SuccessfulExit' "$PLIST21" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --relaunch re-renders the plist with KeepAlive:SuccessfulExit + LOOM_DAEMON_SUPERVISOR (AC1)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --relaunch re-renders the plist with KeepAlive:SuccessfulExit + LOOM_DAEMON_SUPERVISOR (AC1)"
+    echo "  plist: $(cat "$PLIST21" 2>/dev/null)"
+fi
+
+# ============================================================
+# 22. --relaunch PRESERVES the live plist's autonomy env across the re-render
+#     (#4118 AC3): the four autonomy keys carry through byte-for-byte, and the
+#     stale PATH is NOT round-tripped (start.sh rebuilds PATH; harvesting it would
+#     grow the string every roll — Curator trap #1).
+# ============================================================
+W22="$BASE_WORKDIR/w22"
+new_fixture "$W22"
+INSTALLED22="$W22/installed/loom-daemon"
+mkdir -p "$W22/installed"
+RESTART_MARKER22="$W22/restart-invoked"
+write_fake_daemon_restart "$INSTALLED22" "deadbee" "$RESTART_MARKER22" 1
+NEW_FAKE22="$W22/new-fake-daemon"
+HEAD22="$(cd "$W22" && git rev-parse --short HEAD)"
+write_fake_daemon_restart "$NEW_FAKE22" "$HEAD22" "$RESTART_MARKER22" 1
+LD_BIN22="$W22/launchd-bin"
+write_fake_launchd_loaded_bin "$LD_BIN22" "$W22/launchctl.log"
+HOME22="$W22/home"
+PLIST22="$HOME22/Library/LaunchAgents/${LOOM_LAUNCHD_LABEL}.plist"
+write_fixture_plist_pre4077 "$PLIST22" "$LOOM_LAUNCHD_LABEL" "$INSTALLED22" "$HOME22"
+( cd "$W22" && PATH="$LD_BIN22:$TEST_PATH" HOME="$HOME22" LOOM_DAEMON_LAUNCHD=1 \
+    LOOM_DAEMON_BIN="$INSTALLED22" NEW_FAKE_BIN_SRC="$NEW_FAKE22" \
+    bash "$UPDATE_SCRIPT" --relaunch >/dev/null 2>&1 )
+wf22=$(plutil -extract EnvironmentVariables.LOOM_WORK_FINDER raw -o - "$PLIST22" 2>/dev/null)
+hg22=$(plutil -extract EnvironmentVariables.LOOM_MAIN_HEALTH_GATE raw -o - "$PLIST22" 2>/dev/null)
+mc22=$(plutil -extract EnvironmentVariables.LOOM_WORK_FINDER_MAX_CONCURRENT raw -o - "$PLIST22" 2>/dev/null)
+pt22=$(plutil -extract EnvironmentVariables.LOOM_PER_TOKEN_CONCURRENCY raw -o - "$PLIST22" 2>/dev/null)
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$wf22" == "1" && "$hg22" == "1" && "$mc22" == "10" && "$pt22" == "5" ]] \
+    && ! grep -q 'sentinel-oldpath-4118' "$PLIST22" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --relaunch preserves all 4 autonomy env keys and does NOT round-trip the stale PATH (AC3)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --relaunch preserves all 4 autonomy env keys and does NOT round-trip the stale PATH (AC3)"
+    echo "  WF=[$wf22] HG=[$hg22] MAXC=[$mc22] PERTOK=[$pt22]"
+    echo "  plist: $(cat "$PLIST22" 2>/dev/null)"
+fi
+
+# ============================================================
+# 23. --no-restart on a launchd host does NOT print a bare `launchctl bootstrap`
+#     of the stale plist (the second #4118 stale-advice site): it names the
+#     --relaunch re-render path and warns that bootout kills in-flight sweeps.
+# ============================================================
+W23="$BASE_WORKDIR/w23"
+new_fixture "$W23"
+INSTALLED23="$W23/installed/loom-daemon"
+mkdir -p "$W23/installed"
+RESTART_MARKER23="$W23/restart-invoked"
+write_fake_daemon_restart "$INSTALLED23" "deadbee" "$RESTART_MARKER23" 0
+NEW_FAKE23="$W23/new-fake-daemon"
+HEAD23="$(cd "$W23" && git rev-parse --short HEAD)"
+write_fake_daemon_restart "$NEW_FAKE23" "$HEAD23" "$RESTART_MARKER23" 0
+LD_BIN23="$W23/launchd-bin"
+write_fake_launchd_loaded_bin "$LD_BIN23" "$W23/launchctl.log"
+out23=$( cd "$W23" && PATH="$LD_BIN23:$TEST_PATH" LOOM_DAEMON_LAUNCHD=1 \
+    LOOM_DAEMON_BIN="$INSTALLED23" NEW_FAKE_BIN_SRC="$NEW_FAKE23" \
+    bash "$UPDATE_SCRIPT" --no-restart 2>&1 )
+rc23=$?
+assert_eq "0" "$rc23" "--no-restart on a launchd host exits 0"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out23" | grep -q -- '--relaunch' \
+    && ! echo "$out23" | grep -qi 'launchctl bootstrap' \
+    && echo "$out23" | grep -qi 'bootout' && echo "$out23" | grep -qi 'sweep'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --no-restart names --relaunch, no bare bootstrap, warns bootout kills sweeps"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --no-restart names --relaunch, no bare bootstrap, warns bootout kills sweeps"
+    echo "  output: $out23"
+fi
+
+# ============================================================
+# 24. --relaunch with the live plist ABSENT fails loudly (names the missing path)
+#     and refuses to relaunch — it must NEVER silently render FLAGS-OFF defaults
+#     (the #4011 class this whole line of work closes). No plist is written.
+# ============================================================
+W24="$BASE_WORKDIR/w24"
+new_fixture "$W24"
+INSTALLED24="$W24/installed/loom-daemon"
+mkdir -p "$W24/installed"
+RESTART_MARKER24="$W24/restart-invoked"
+write_fake_daemon_restart "$INSTALLED24" "deadbee" "$RESTART_MARKER24" 1
+NEW_FAKE24="$W24/new-fake-daemon"
+HEAD24="$(cd "$W24" && git rev-parse --short HEAD)"
+write_fake_daemon_restart "$NEW_FAKE24" "$HEAD24" "$RESTART_MARKER24" 1
+LD_BIN24="$W24/launchd-bin"
+write_fake_launchd_loaded_bin "$LD_BIN24" "$W24/launchctl.log"
+HOME24="$W24/home"
+mkdir -p "$HOME24/Library/LaunchAgents"   # dir exists, plist deliberately absent
+PLIST24="$HOME24/Library/LaunchAgents/${LOOM_LAUNCHD_LABEL}.plist"
+out24=$( cd "$W24" && PATH="$LD_BIN24:$TEST_PATH" HOME="$HOME24" LOOM_DAEMON_LAUNCHD=1 \
+    LOOM_DAEMON_BIN="$INSTALLED24" NEW_FAKE_BIN_SRC="$NEW_FAKE24" \
+    bash "$UPDATE_SCRIPT" --relaunch 2>&1 )
+rc24=$?
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$rc24" -ne 0 ]] && echo "$out24" | grep -qi 'not found' \
+    && echo "$out24" | grep -qF "$PLIST24" && [[ ! -e "$PLIST24" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --relaunch with an absent plist fails loudly (names the path) and renders nothing"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --relaunch with an absent plist fails loudly (names the path) and renders nothing"
+    echo "  rc=$rc24 plist-exists=$([[ -e "$PLIST24" ]] && echo yes || echo no)"
+    echo "  output: $out24"
+fi
+
+# ============================================================
+# 25. Launchd-sandbox guards (#4078): the whole suite exercises the REAL
 #     start/stop scripts, so prove it never reached the operator's live daemon.
 #     (a) The suite-level decoy loom-daemon is still alive — no by-name kill
 #         fired anywhere in the suite.


### PR DESCRIPTION
## Summary

`loom-daemon-update.sh`'s launchd refused-restart fallback (exit 6) told the operator to `launchctl bootout && launchctl bootstrap` the **existing** plist. That plist is stale by construction — it is the pre-#4077 file that caused the refused restart, so it lacks `KeepAlive:{SuccessfulExit:true}` and `LOOM_DAEMON_SUPERVISOR=launchd`. Bootstrapping it relaunches the daemon **unsupervised**, so `loom-daemon restart` keeps failing and every subsequent roll hits the same exit 6 forever (self-perpetuating). Separately, `launchctl bootout` tears down the whole job tree, and in-flight sweep children are direct children of the launchd job — so the printed advice silently killed running sweeps.

This adds an opt-in re-render + relaunch path and corrects both stale-advice sites.

## Changes

- **`defaults/scripts/cli/loom-daemon-update.sh`**
  - New `--relaunch` flag (and `LOOM_DAEMON_UPDATE_RELAUNCH=1` env). On a refused restart it re-renders the plist via `loom-daemon-start.sh` (which hardcodes both supervised keys), rather than bootstrapping the stale file.
  - `harvest_plist_env()` reads the live plist's `EnvironmentVariables` with `plutil` + `jq`, restricted to `LOOM_*`/`GH_TOKEN`/`GITEA_TOKEN`/`FORGE_TOKEN` and **excluding** `PATH`/`HOME` (start.sh rebuilds PATH — round-tripping would grow it each roll) and `LOOM_DAEMON_SUPERVISOR` (hardcoded). Fails loudly if the plist is absent/unparseable — never silently narrows autonomy flags to FLAGS-OFF (#4011).
  - `perform_relaunch()` re-exports the harvested env, `SIGTERM`s the old daemon (children reparent and keep working, unlike `bootout`), then invokes `loom-daemon-start.sh` to re-render + relaunch under supervision.
  - Default exit-6 path now names `--relaunch`, warns that `bootout` terminates in-flight sweeps, and prefers `kill -TERM <daemon-pid>`. The `--no-restart` launchd site (the second stale-advice location) is corrected the same way. Header/usage/exit-code comments updated.
- **`defaults/scripts/tests/test-loom-daemon-update.sh`** — rewrote case 16 to the new contract (names `--relaunch`, no bare `bootstrap`, AC4 sweep-kill warning + `kill -TERM`); added cases for the re-render (AC1), env preservation without PATH round-tripping (AC3), the `--no-restart` site, and the loud-failure edge case when the live plist is absent. All new cases sandbox `HOME` and reuse the #4078 launchd-sandbox guards.
- **`.loom/docs/daemon-reference.md`** — documented `--relaunch` and the exit-6 fallback under Self-update.

## Acceptance Criteria Verification

1. **Installed plist has `KeepAlive:{SuccessfulExit:true}` + `LOOM_DAEMON_SUPERVISOR=launchd` after the fallback** — verified by new test case 21 (re-render into a pre-#4077 fixture plist that lacks both keys; the assertion only passes if the re-render happened).
2. **A second run takes the supervised path and does not exit 6** — the re-render installs `LOOM_DAEMON_SUPERVISOR`, so the restarted #4077-capable daemon accepts `loom-daemon restart`; existing case (launchd restart accepted → exit 0) exercises that supervised path.
3. **Re-rendered `EnvironmentVariables` match the previous plist's for all `LOOM_*` autonomy keys** — case 22 asserts `LOOM_WORK_FINDER=1`, `LOOM_MAIN_HEALTH_GATE=1`, `LOOM_WORK_FINDER_MAX_CONCURRENT=10`, `LOOM_PER_TOKEN_CONCURRENCY=5` all survive (via `plutil -extract`), and the stale sentinel PATH is NOT round-tripped.
4. **Fallback text states `bootout` terminates in-flight sweeps** — cases 16 and 23 assert the warning text plus the `kill -TERM` graceful alternative.

## Test Plan

- [x] `bash defaults/scripts/tests/test-loom-daemon-update.sh` — 51/51 pass (case 16 rewritten; 4 new cases).
- [x] `bash defaults/scripts/tests/test-loom-daemon-launchd-plist.sh` — 26/26 pass (no `render_launchd_plist` regression).
- [x] `bash defaults/scripts/tests/test-loom-daemon-start.sh` — 11/11 pass.
- [x] `shellcheck -x` clean on the modified script.
- [x] Sandbox safety: the suite's #4078 decoy survives and no `launchctl` invocation named a `com.rjwalters.*` label; new cases sandbox `HOME` so no real `~/Library/LaunchAgents` write.

Closes #4118

🤖 Generated with [Claude Code](https://claude.com/claude-code)