### PR TITLE
feat: add startup forge-credential preflight + plist hardening to daemon

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -2088,6 +2088,19 @@ after migration reported `13 seen, 3 dispatched, 0 error(s)`.
   `--health-gate` / `--from-config` semantics are preserved exactly — the
   launchd job never sees a wider or narrower autonomy configuration than a
   plain nohup start would have resolved.
+- **Token hardening + startup credential preflight (#4005)**: because a
+  forwarded `GH_TOKEN`/`GITEA_TOKEN`/`FORGE_TOKEN` is embedded verbatim in the
+  plist, `loom-daemon-start.sh` writes the file mode `0600` whenever it
+  carries one of those vars (otherwise it inherits the process umask —
+  typically world-readable `0644`). Separately, the daemon resolves its own
+  forge credential once at boot — before its first `gh` consumer — and logs
+  the outcome loudly (`info!`/`error!`, never the token value); the result is
+  also surfaced in `loom-daemon status` (`credential_preflight` in `--json`,
+  a "Forge credential: OK/DEGRADED" line in the human view). See
+  [`github-authentication.md` § Headless and SSH-only daemon operation](github-authentication.md#headless-and-ssh-only-daemon-operation-4005)
+  for the operator-facing walkthrough — this is the fix for the
+  keychain-unlock-dependency failure mode: a daemon started over SSH with no
+  exported token used to boot clean and then 401 silently on every forge call.
 - **`RunAtLoad=true` / `KeepAlive={SuccessfulExit:true}`** (#4054): `RunAtLoad=true`
   means the daemon survives a reboot/re-login, not just the death of one particular
   session — strictly *more* durable than the pre-#3972 nohup contract (which didn't

--- a/.loom/docs/github-authentication.md
+++ b/.loom/docs/github-authentication.md
@@ -80,6 +80,77 @@ gh pr list --repo <owner>/<repo> --limit 1
 
 If `gh auth status` shows the default credential instead of `GH_TOKEN`, verify the variable is exported in the same shell session.
 
+## Headless and SSH-only daemon operation (#4005)
+
+`loom-daemon`'s own forge calls (claim reconciliation, the main-health gate,
+metrics collection, the work finder, …) all shell out to `gh`, which resolves
+credentials the same way an interactive shell does: `GH_TOKEN` env var →
+`GITHUB_TOKEN` env var → `gh`'s own credential store (the macOS login
+**keychain**, or `~/.config/gh/hosts.yml` on Linux). The keychain only unlocks
+for processes running in the user's **GUI login session** — a daemon started
+over SSH with a clean environment, or from a headless server with no
+interactive login, cannot unlock it. Without an env-var token, every `gh` call
+the daemon makes will `401`.
+
+**The fix is an exported token, not a new credential store.** Loom does not
+provision a separate daemon-managed PAT file — `export GH_TOKEN` (or
+`GITHUB_TOKEN`) before starting the daemon, and the existing forwarding
+mechanism carries it the rest of the way:
+
+```bash
+# On the headless / SSH-only host, before starting the daemon:
+export GH_TOKEN=github_pat_xxxxxxxxxxxxxxxxxxxx
+./.loom/scripts/cli/loom-daemon-start.sh
+```
+
+`loom-daemon-start.sh` forwards any exported `GH_TOKEN` / `GITHUB_TOKEN` /
+`GITEA_TOKEN` / `FORGE_TOKEN` into the launchd plist's `EnvironmentVariables`
+(macOS) or the backgrounded process's inherited environment (`--no-launchd` /
+Linux) — so the daemon **and every sweep child it dispatches** see the token,
+with no per-sweep configuration needed. The daemon inherits its environment
+**from the shell that started it** — export the token *before* invoking
+`loom-daemon-start.sh`, not after. A later `loom-daemon-update.sh` restart
+re-renders the plist from the *current* shell's environment, so an
+already-running daemon does not silently lose a token that was exported only
+in a now-closed session (the same footgun `LOOM_WORK_FINDER` / autonomy-flag
+env replay has — see [`daemon-reference.md`](daemon-reference.md)).
+
+**Startup credential preflight.** The daemon resolves its forge credential
+once at boot, immediately before its first `gh` consumer (the claim
+reconciliation startup pass), and reports the outcome — `info!` naming which
+mechanism won (`GH_TOKEN`, `GITHUB_TOKEN`, or `gh`'s own credential store) plus
+a non-secret fingerprint (never the token itself), or `error!` naming both
+remedies (export a token, or unlock the login keychain from a GUI session)
+when nothing resolves. This turns the pre-#4005 failure mode — a daemon that
+boots clean and then 401s silently on every forge call for the life of the
+process — into a single loud, actionable line. The result is also visible
+without reading logs via `loom-daemon status` ("Forge credential: OK/DEGRADED
+— …"); see [`daemon-reference.md`](daemon-reference.md) for the field shape.
+The preflight is read-only, bounded (never blocks daemon startup), and never
+logs, prints, or serializes a token value.
+
+**GitHub only.** The preflight covers `GH_TOKEN`/`GITHUB_TOKEN` because the
+daemon's own forge calls are exclusively `gh`-CLI-based. `GITEA_TOKEN` /
+`FORGE_TOKEN` forwarding still happens (for dispatched sweep children targeting
+a Gitea-backed repo — see [`forge-authentication.md`](forge-authentication.md))
+but the daemon process itself never calls a Gitea API, so there is nothing to
+preflight for it.
+
+**Plist permissions.** Because the rendered launchd plist embeds the token
+value verbatim in `EnvironmentVariables`, `loom-daemon-start.sh` hardens the
+file to mode `0600` whenever it carries a `GH_TOKEN`/`GITEA_TOKEN`/
+`FORGE_TOKEN`, so a local user other than the daemon's owner cannot read the
+PAT out of `~/Library/LaunchAgents`.
+
+**Out of scope**: `launchctl bootstrap gui/$UID` (the launchd domain
+`loom-daemon-start.sh` uses on macOS) fails over SSH — `gui/$UID` is a
+per-GUI-session domain that does not exist in an SSH session — so a daemon
+that isn't already running cannot be *started* remotely on macOS today even
+with a valid token exported. That is a supervision-model gap (a `LaunchDaemon`
+or `launchctl asuser` mechanism), not a credential problem; restarting an
+*already-running* daemon (`loom-daemon-update.sh`) and running fully headless
+on Linux (`--no-launchd` / nohup path) both work with an exported token today.
+
 ## Troubleshooting
 
 ### Token not being picked up

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -547,6 +547,18 @@ if [[ "$USE_LAUNCHD" == "true" ]]; then
 
     render_launchd_plist "$LAUNCHD_LABEL" "$DAEMON_BIN" "$REPO_ROOT" "$START_LOG" > "$PLIST_FILE"
 
+    # Harden the rendered plist when it carries a forwarded credential
+    # (#4005): the token-forwarding loop in render_launchd_plist writes any
+    # exported GH_TOKEN/GITEA_TOKEN/FORGE_TOKEN straight into
+    # EnvironmentVariables above, and the plain `>` redirect otherwise leaves
+    # the file at the process's umask (typically world-readable, 0644) --
+    # any local user could read the PAT straight out of
+    # ~/Library/LaunchAgents. Match the same env pattern the forwarding loop
+    # reads from.
+    if env | grep -qE '^(GH_TOKEN|GITEA_TOKEN|FORGE_TOKEN)=' 2>/dev/null; then
+        chmod 600 "$PLIST_FILE"
+    fi
+
     echo "Launchd label:  $LAUNCHD_LABEL"
     echo "Launchd plist:  $PLIST_FILE"
 

--- a/loom-daemon/src/credential_preflight.rs
+++ b/loom-daemon/src/credential_preflight.rs
@@ -1,0 +1,375 @@
+//! Startup forge-credential preflight (#4005).
+//!
+//! # Problem
+//!
+//! Every daemon-issued `gh` call (`claim_reconciliation`, `main_health_gate`,
+//! `metrics_collector`, the work finder, …) is a plain `Command::new("gh")`
+//! with no `env_clear` — so it authenticates however `gh` itself resolves
+//! credentials in the daemon's process environment: `GH_TOKEN` /
+//! `GITHUB_TOKEN`, falling back to `gh`'s own credential store (the macOS
+//! login keychain, or `~/.config/gh/hosts.yml` on Linux). That plumbing
+//! already works headlessly *if* a token happens to be exported before
+//! `loom-daemon-start.sh` runs — the actual defect is that nothing checks at
+//! startup, so a daemon started with neither an exported token nor an
+//! unlocked keychain (e.g. over SSH, clean environment) boots clean and then
+//! 401s on every forge call for the life of the process, with nothing but
+//! silent per-tick noise to show for it.
+//!
+//! # What this module does
+//!
+//! [`run`] resolves the credential state **once**, at daemon startup —
+//! immediately before the claim-reconciliation startup pass
+//! (`main.rs`, the daemon's first `gh` consumer) — and reports the outcome:
+//!
+//! - `info!` on success, naming which mechanism won and a non-secret
+//!   fingerprint (last 4 chars of an env token, or the authenticated login).
+//! - `error!` on failure, naming both remedies (export `GH_TOKEN` before
+//!   starting the daemon, or unlock the login keychain from a GUI session).
+//!
+//! The result is also carried in [`crate::types::DaemonStatusReport`] so an
+//! operator can see it via `loom-daemon status` without reading logs.
+//!
+//! # Non-goals
+//!
+//! - **No new credential store.** This reads the credential `gh` would
+//!   already use (env vars it inherits, or its own store) — it never
+//!   provisions, writes, or manages a loom-specific PAT file. The existing
+//!   plist env-forwarding mechanism (`loom-daemon-start.sh`) already reaches
+//!   the daemon and every dispatched sweep child; a second secret-at-rest
+//!   surface would add attack surface for no capability gain.
+//! - **GitHub only.** The daemon's own forge calls all shell out to `gh`,
+//!   which only ever resolves GitHub credentials. `GITEA_TOKEN`/
+//!   `FORGE_TOKEN` forwarding exists solely for dispatched sweep children
+//!   targeting a Gitea-backed repo — the daemon process itself never calls a
+//!   Gitea API, so there is nothing to preflight for it here. See
+//!   `.loom/docs/github-authentication.md` § "Headless and SSH-only daemon operation".
+//! - **Never blocks or hangs.** Bounded by [`PREFLIGHT_TIMEOUT`] via the
+//!   reused [`crate::main_health_gate::run_capture_with_timeout`] helper — an
+//!   unlocked-keychain prompt or a hung `gh` is exactly the failure mode this
+//!   preflight must survive, not itself trigger.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use chrono::Utc;
+
+use crate::main_health_gate::run_capture_with_timeout;
+use crate::types::CredentialPreflightReport;
+
+/// Bound on the `gh auth status` probe. `gh auth status --json` documents an
+/// exit code of `0` regardless of authentication outcome (state is carried in
+/// the JSON body), so a non-zero exit or a hang here means the probe itself
+/// could not complete — never treated as "not authenticated".
+pub const PREFLIGHT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Injectable probe seam so the resolution logic is unit-testable without a
+/// real `gh` binary — mirrors [`crate::main_health_gate::ForgeCiStatus`].
+pub trait GhAuthProbe {
+    /// Returns raw `gh auth status --json hosts` stdout, or a non-secret
+    /// error string when the probe itself could not complete.
+    fn probe(&self) -> Result<String, String>;
+}
+
+/// The concrete probe: `gh auth status --json hosts`, bounded by
+/// [`PREFLIGHT_TIMEOUT`] via the reused bounded-subprocess helper.
+pub struct RealGhAuthProbe {
+    /// The `gh` binary to invoke — plain `"gh"` in production, overridable in
+    /// tests to point at a stub script on `PATH`.
+    pub gh_bin: String,
+    /// Working directory for the subprocess. `gh auth status` is host-level
+    /// (not repo-scoped), so any existing directory works; the daemon passes
+    /// its primary workspace root for consistency with its other `gh` calls.
+    pub cwd: PathBuf,
+}
+
+impl GhAuthProbe for RealGhAuthProbe {
+    fn probe(&self) -> Result<String, String> {
+        run_capture_with_timeout(
+            &self.gh_bin,
+            &["auth", "status", "--json", "hosts"],
+            &self.cwd,
+            PREFLIGHT_TIMEOUT,
+        )
+    }
+}
+
+/// Non-secret fingerprint for an env-sourced token: the last 4 characters.
+/// Tokens shorter than 4 characters (should not occur in practice) fingerprint
+/// as `"***"` rather than echoing the whole value.
+fn env_fingerprint(value: &str) -> String {
+    let tail: String = value
+        .chars()
+        .rev()
+        .take(4)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+    if tail.chars().count() < 4 {
+        "***".to_string()
+    } else {
+        tail
+    }
+}
+
+/// Pure reducer: given the daemon's own `GH_TOKEN`/`GITHUB_TOKEN` env lookups
+/// and the raw probe outcome, decide the report. Split out from I/O so it is
+/// unit-testable without a real `gh` binary or process environment — mirrors
+/// `main_health_gate::parse_gh_run_list`.
+fn resolve(
+    gh_token_env: Option<&str>,
+    github_token_env: Option<&str>,
+    probe: Result<String, String>,
+) -> CredentialPreflightReport {
+    let checked_at = Utc::now();
+    let stdout = match probe {
+        Ok(stdout) => stdout,
+        Err(e) => {
+            return CredentialPreflightReport {
+                ok: false,
+                mechanism: "unknown".to_string(),
+                fingerprint: None,
+                message: format!(
+                    "could not determine gh authentication state ({e}) — forge calls may fail \
+                     silently. Export GH_TOKEN before starting the daemon (see \
+                     loom-daemon-start.sh), or unlock the login keychain from a GUI session."
+                ),
+                checked_at,
+            };
+        }
+    };
+
+    let parsed: serde_json::Value = match serde_json::from_str(&stdout) {
+        Ok(v) => v,
+        Err(e) => {
+            return CredentialPreflightReport {
+                ok: false,
+                mechanism: "unknown".to_string(),
+                fingerprint: None,
+                message: format!("could not parse `gh auth status --json hosts` output ({e})"),
+                checked_at,
+            };
+        }
+    };
+
+    // The active entry per host is the one `gh` will actually use — `gh auth
+    // status --json hosts` returns every known account per host, with
+    // exactly one `active: true` entry per host that has one.
+    let active = parsed
+        .get("hosts")
+        .and_then(serde_json::Value::as_object)
+        .into_iter()
+        .flat_map(|hosts| hosts.values())
+        .filter_map(serde_json::Value::as_array)
+        .flatten()
+        .find(|entry| entry.get("active").and_then(serde_json::Value::as_bool) == Some(true));
+
+    let Some(active) = active else {
+        return CredentialPreflightReport {
+            ok: false,
+            mechanism: "none".to_string(),
+            fingerprint: None,
+            message: "no usable gh credential found — not logged into any GitHub host. Export \
+                      GH_TOKEN before starting the daemon (see loom-daemon-start.sh), or run \
+                      `gh auth login` / unlock the login keychain from a GUI session."
+                .to_string(),
+            checked_at,
+        };
+    };
+
+    let token_source = active
+        .get("tokenSource")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown");
+    let state = active
+        .get("state")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown");
+    let login = active
+        .get("login")
+        .and_then(serde_json::Value::as_str)
+        .filter(|s| !s.is_empty());
+
+    if state != "success" {
+        return CredentialPreflightReport {
+            ok: false,
+            mechanism: token_source.to_string(),
+            fingerprint: None,
+            message: format!(
+                "gh reports the active credential ({token_source}) as unusable — forge calls \
+                 will 401. Export a valid GH_TOKEN before starting the daemon, or unlock the \
+                 login keychain from a GUI session."
+            ),
+            checked_at,
+        };
+    }
+
+    let fingerprint = match token_source {
+        "GH_TOKEN" => gh_token_env.map(env_fingerprint),
+        "GITHUB_TOKEN" => github_token_env.map(env_fingerprint),
+        _ => login.map(str::to_string),
+    };
+
+    CredentialPreflightReport {
+        ok: true,
+        mechanism: token_source.to_string(),
+        fingerprint,
+        message: match login {
+            Some(l) => format!("authenticated via {token_source} (account {l})"),
+            None => format!("authenticated via {token_source}"),
+        },
+        checked_at,
+    }
+}
+
+/// Run the startup preflight and log the outcome (#4005 AC1/AC2): `info!` on
+/// success naming the mechanism + fingerprint, `error!` on failure naming
+/// both remedies. Never panics; bounded by [`PREFLIGHT_TIMEOUT`] (via
+/// `probe`), so it cannot hang daemon startup.
+#[must_use]
+pub fn run(probe: &dyn GhAuthProbe) -> CredentialPreflightReport {
+    let gh_token = std::env::var("GH_TOKEN").ok().filter(|s| !s.is_empty());
+    let github_token = std::env::var("GITHUB_TOKEN").ok().filter(|s| !s.is_empty());
+    let report = resolve(gh_token.as_deref(), github_token.as_deref(), probe.probe());
+    if report.ok {
+        log::info!(
+            "credential_preflight: forge credential resolved via {} ({}) — #4005",
+            report.mechanism,
+            report.fingerprint.as_deref().unwrap_or("no fingerprint")
+        );
+    } else {
+        log::error!("credential_preflight: {} — #4005", report.message);
+    }
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FixedProbe(Result<String, String>);
+    impl GhAuthProbe for FixedProbe {
+        fn probe(&self) -> Result<String, String> {
+            self.0.clone()
+        }
+    }
+
+    fn json_active(token_source: &str, state: &str, login: &str) -> String {
+        format!(
+            r#"{{"hosts":{{"github.com":[{{"state":"{state}","active":true,"host":"github.com","login":"{login}","tokenSource":"{token_source}"}}]}}}}"#
+        )
+    }
+
+    #[test]
+    fn env_gh_token_present_and_valid_reports_ok_with_env_mechanism() {
+        let stdout = json_active("GH_TOKEN", "success", "");
+        let report = resolve(Some("ghp_abcd1234wxyz"), None, Ok(stdout));
+        assert!(report.ok);
+        assert_eq!(report.mechanism, "GH_TOKEN");
+        assert_eq!(report.fingerprint.as_deref(), Some("wxyz"));
+        assert!(!report.message.contains("ghp_abcd1234wxyz"));
+    }
+
+    #[test]
+    fn env_github_token_present_and_valid_reports_ok_with_env_mechanism() {
+        let stdout = json_active("GITHUB_TOKEN", "success", "");
+        let report = resolve(None, Some("ghp_zzzz9999abcd"), Ok(stdout));
+        assert!(report.ok);
+        assert_eq!(report.mechanism, "GITHUB_TOKEN");
+        assert_eq!(report.fingerprint.as_deref(), Some("abcd"));
+    }
+
+    #[test]
+    fn no_env_token_credential_store_success_reports_ok_with_login_fingerprint() {
+        let stdout = json_active("keyring", "success", "octocat");
+        let report = resolve(None, None, Ok(stdout));
+        assert!(report.ok);
+        assert_eq!(report.mechanism, "keyring");
+        assert_eq!(report.fingerprint.as_deref(), Some("octocat"));
+    }
+
+    #[test]
+    fn no_active_host_reports_degraded_none_mechanism() {
+        let report = resolve(None, None, Ok(r#"{"hosts":{}}"#.to_string()));
+        assert!(!report.ok);
+        assert_eq!(report.mechanism, "none");
+        assert!(report.message.contains("gh auth login") || report.message.contains("GH_TOKEN"));
+    }
+
+    #[test]
+    fn active_host_with_error_state_reports_degraded() {
+        let stdout = json_active("GH_TOKEN", "error", "");
+        let report = resolve(Some("ghp_invalidinvalid"), None, Ok(stdout));
+        assert!(!report.ok);
+        assert_eq!(report.mechanism, "GH_TOKEN");
+        assert!(report.fingerprint.is_none());
+        assert!(!report.message.contains("ghp_invalidinvalid"));
+    }
+
+    #[test]
+    fn probe_error_reports_unknown_mechanism_never_panics() {
+        let report =
+            resolve(None, None, Err("could not spawn `gh`: No such file or directory".to_string()));
+        assert!(!report.ok);
+        assert_eq!(report.mechanism, "unknown");
+    }
+
+    #[test]
+    fn unparseable_probe_output_reports_unknown_mechanism_never_panics() {
+        let report = resolve(None, None, Ok("not json at all".to_string()));
+        assert!(!report.ok);
+        assert_eq!(report.mechanism, "unknown");
+    }
+
+    #[test]
+    fn env_fingerprint_never_leaks_full_token() {
+        let token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+        let fp = env_fingerprint(token);
+        assert_eq!(fp.len(), 4);
+        assert_ne!(fp, token);
+        assert!(!fp.contains("ghp_"));
+    }
+
+    #[test]
+    fn env_fingerprint_short_value_never_panics() {
+        assert_eq!(env_fingerprint(""), "***");
+        assert_eq!(env_fingerprint("ab"), "***");
+    }
+
+    #[test]
+    fn run_with_missing_gh_binary_never_panics_and_reports_degraded() {
+        // A `FixedProbe` standing in for "gh missing from PATH" — exercises
+        // the same code path `RealGhAuthProbe` would hit via
+        // `run_capture_with_timeout`'s spawn-failure branch, without
+        // depending on the test host's actual PATH contents.
+        let probe = FixedProbe(Err(
+            "could not spawn `gh`: No such file or directory (os error 2)".to_string()
+        ));
+        let report = run(&probe);
+        assert!(!report.ok);
+        assert_eq!(report.mechanism, "unknown");
+    }
+
+    #[test]
+    fn run_never_includes_a_token_looking_value_in_message() {
+        let stdout = json_active("GH_TOKEN", "success", "");
+        let probe = FixedProbe(Ok(stdout));
+        // Test-only env mutation of a var no other test in this module reads
+        // or writes; restored immediately after.
+        std::env::set_var("GH_TOKEN", "ghp_supersecrettoken1234567890");
+        let report = run(&probe);
+        std::env::remove_var("GH_TOKEN");
+        assert!(report.ok);
+        assert!(!report.message.contains("ghp_supersecrettoken1234567890"));
+        assert!(report.fingerprint.as_deref() != Some("ghp_supersecrettoken1234567890"));
+    }
+
+    #[test]
+    fn real_probe_with_missing_gh_binary_never_panics() {
+        let probe = RealGhAuthProbe {
+            gh_bin: "loom-test-nonexistent-gh-binary-4005".to_string(),
+            cwd: std::env::temp_dir(),
+        };
+        assert!(probe.probe().is_err());
+    }
+}

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -7,7 +7,7 @@ use crate::git_utils;
 use crate::main_health_gate::WorkspaceHealthStates;
 use crate::sweep_registry::{BeginCancel, SweepRegistry};
 use crate::terminal::TerminalManager;
-use crate::types::{DaemonStatusReport, Event, Request, Response};
+use crate::types::{CredentialPreflightReport, DaemonStatusReport, Event, Request, Response};
 use crate::workspace_pool::WorkspacePool;
 use crate::workspace_registry::WorkspaceRegistry;
 use anyhow::Result;
@@ -211,6 +211,11 @@ pub struct IpcServer {
     /// empty (#3930). In the common single-workspace case this is the only root
     /// the `DaemonStatus` per-repo breakdown enumerates.
     fallback_root: PathBuf,
+    /// Startup forge-credential preflight snapshot (#4005), resolved once at
+    /// daemon boot (`main.rs`, before the claim-reconciliation startup pass)
+    /// and threaded in read-only so `DaemonStatus` can report it without a
+    /// re-probe on every status query.
+    credential_preflight: Arc<CredentialPreflightReport>,
 }
 
 impl IpcServer {
@@ -224,6 +229,7 @@ impl IpcServer {
         health_states: Arc<WorkspaceHealthStates>,
         workspace_pool: Arc<WorkspacePool>,
         fallback_root: PathBuf,
+        credential_preflight: CredentialPreflightReport,
     ) -> Self {
         Self {
             socket_path,
@@ -234,6 +240,7 @@ impl IpcServer {
             health_states,
             workspace_pool,
             fallback_root,
+            credential_preflight: Arc::new(credential_preflight),
         }
     }
 
@@ -270,9 +277,20 @@ impl IpcServer {
                     let health = self.health_states.clone();
                     let pool = self.workspace_pool.clone();
                     let fallback = self.fallback_root.clone();
+                    let credential_preflight = self.credential_preflight.clone();
                     tokio::spawn(async move {
-                        if let Err(e) =
-                            handle_client(stream, tm, db, sr, bus, health, pool, fallback).await
+                        if let Err(e) = handle_client(
+                            stream,
+                            tm,
+                            db,
+                            sr,
+                            bus,
+                            health,
+                            pool,
+                            fallback,
+                            credential_preflight,
+                        )
+                        .await
                         {
                             log::error!("Client error: {e}");
                         }
@@ -296,6 +314,7 @@ async fn handle_client(
     health_states: Arc<WorkspaceHealthStates>,
     workspace_pool: Arc<WorkspacePool>,
     fallback_root: PathBuf,
+    credential_preflight: Arc<CredentialPreflightReport>,
 ) -> Result<()> {
     let (reader, mut writer) = stream.into_split();
     let mut lines = BufReader::new(reader).lines();
@@ -368,7 +387,12 @@ async fn handle_client(
             // (within the TTL) makes this a no-op. `spawn_blocking` join errors
             // are non-fatal — the status falls back to the last cached value.
             let _ = tokio::task::spawn_blocking(crate::cpu_headroom::refresh_cpu_util_cache).await;
-            let report = build_daemon_status(&workspace_pool, &health_states, &fallback_root);
+            let report = build_daemon_status(
+                &workspace_pool,
+                &health_states,
+                &fallback_root,
+                &credential_preflight,
+            );
             let response = Response::DaemonStatus(report);
             let response_json = serde_json::to_string(&response)?;
             writer.write_all(response_json.as_bytes()).await?;
@@ -581,6 +605,7 @@ pub fn build_daemon_status(
     workspace_pool: &Arc<WorkspacePool>,
     health_states: &WorkspaceHealthStates,
     fallback_root: &Path,
+    credential_preflight: &CredentialPreflightReport,
 ) -> DaemonStatusReport {
     // Enumerate every registered managed workspace (Issue #3930). An empty
     // registry yields `[fallback_root]`, so the common single-workspace case is
@@ -724,6 +749,9 @@ pub fn build_daemon_status(
         main_health_gate_verdict_at: health_states.last_verdict_at(fallback_root),
         capacity,
         per_repo,
+        // Resolved once at daemon startup (#4005), threaded in read-only —
+        // never re-probed per status query.
+        credential_preflight: Some(credential_preflight.clone()),
     }
 }
 
@@ -1814,6 +1842,19 @@ mod tests {
             .clone()
     }
 
+    /// A fixture credential-preflight snapshot for `build_daemon_status` tests
+    /// (#4005) — these tests exercise the dynamic-cap/health-gate machinery,
+    /// not credential resolution, so a fixed `Ok` snapshot keeps them focused.
+    fn test_credential_preflight() -> CredentialPreflightReport {
+        CredentialPreflightReport {
+            ok: true,
+            mechanism: "test-fixture".to_string(),
+            fingerprint: None,
+            message: "test fixture — not a real preflight".to_string(),
+            checked_at: Utc::now(),
+        }
+    }
+
     /// A [`WorkspacePool`] for `handle_request` tests (Issue #3929). The
     /// default-workspace (`workspace_root: None`) paths these tests exercise
     /// never provision, so no task is actually spawned.
@@ -2838,6 +2879,7 @@ exit 0
                 health_gate_enabled: Some(true),
                 health_gate_verdict_at: Some(chrono::Utc::now()),
             }],
+            credential_preflight: Some(test_credential_preflight()),
         };
         let resp = Response::DaemonStatus(report);
         let json = serde_json::to_string(&resp).expect("serialize response");
@@ -2869,6 +2911,12 @@ exit 0
                 assert!(r.main_health_gate_verdict_at.is_some());
                 assert_eq!(r.per_repo[0].health_gate_enabled, Some(true));
                 assert!(r.per_repo[0].health_gate_verdict_at.is_some());
+                assert_eq!(
+                    r.credential_preflight
+                        .as_ref()
+                        .map(|c| c.mechanism.as_str()),
+                    Some("test-fixture")
+                );
             }
             other => panic!("Expected DaemonStatus, got: {other:?}"),
         }
@@ -3056,7 +3104,7 @@ exit 0
         let health = WorkspaceHealthStates::new();
 
         // No sweeps in flight, cap > 0 ⇒ the cap is a ceiling but NOT binding.
-        let report = build_daemon_status(&pool, &health, &root);
+        let report = build_daemon_status(&pool, &health, &root, &test_credential_preflight());
         assert!(report.dynamic_cap > 0, "two tokens should yield a positive cap");
         assert!(report.in_flight.is_empty());
         assert!(
@@ -3080,7 +3128,7 @@ exit 0
                 .expect("dispatch");
             }
         }
-        let report = build_daemon_status(&pool, &health, &root);
+        let report = build_daemon_status(&pool, &health, &root, &test_credential_preflight());
         assert_eq!(report.in_flight.len(), cap);
         assert!(
             report.capacity_bound,
@@ -3124,7 +3172,7 @@ exit 0
         let health = WorkspaceHealthStates::new();
 
         // Fresh state: not halted, no sweeps.
-        let report = build_daemon_status(&pool, &health, &root);
+        let report = build_daemon_status(&pool, &health, &root, &test_credential_preflight());
         assert!(!report.main_health_gate_halted);
         assert!(report.in_flight.is_empty());
         // The tempdir has no `.loom/tokens/`, so the pool + dynamic cap are 0.
@@ -3155,7 +3203,7 @@ exit 0
             r#"{"autonomous": {"mainHealthGate": {"enabled": true}}, "buildGate": {"enabled": true, "command": "true"}}"#,
         )
         .unwrap();
-        let report = build_daemon_status(&pool, &health, &root);
+        let report = build_daemon_status(&pool, &health, &root, &test_credential_preflight());
         assert_eq!(
             report.main_health_gate_enabled,
             Some(true),
@@ -3173,7 +3221,7 @@ exit 0
             reg.dispatch(&crate::types::SweepKind::Issue(3891), None, None, None, None)
                 .expect("dispatch");
         }
-        let report = build_daemon_status(&pool, &health, &root);
+        let report = build_daemon_status(&pool, &health, &root, &test_credential_preflight());
         assert_eq!(report.in_flight.len(), 1);
         assert!(matches!(report.in_flight[0].kind, crate::types::SweepKind::Issue(3891)));
         assert_eq!(report.per_repo[0].in_flight_count, 1);
@@ -3181,7 +3229,7 @@ exit 0
         // Flip the halt flag for this root -> the report tracks it (top-level and
         // per-repo).
         health.set_halted(&root, true);
-        let report = build_daemon_status(&pool, &health, &root);
+        let report = build_daemon_status(&pool, &health, &root, &test_credential_preflight());
         assert!(report.main_health_gate_halted);
         assert!(report.per_repo[0].health_gate_halted);
         assert!(!report.main_health_gate_not_evaluated, "no skip has happened yet");
@@ -3198,7 +3246,7 @@ exit 0
             )),
             std::time::Duration::from_secs(3600),
         );
-        let report = build_daemon_status(&pool, &health, &root);
+        let report = build_daemon_status(&pool, &health, &root, &test_credential_preflight());
         assert!(report.main_health_gate_halted, "prior halt persists through a skip");
         assert!(report.main_health_gate_not_evaluated, "skip surfaces as not-evaluated");
         assert!(report.per_repo[0].health_gate_halted);
@@ -3267,7 +3315,7 @@ exit 0
                 .expect("dispatch");
         }
 
-        let report = build_daemon_status(&pool, &health, &root_a);
+        let report = build_daemon_status(&pool, &health, &root_a, &test_credential_preflight());
         assert_eq!(report.per_repo.len(), 2, "both managed repos are listed");
         // Union of in-flight across repos = repo A's single sweep.
         assert_eq!(report.in_flight.len(), 1);

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -15,6 +15,7 @@ pub mod capacity;
 pub mod claim_reconciliation;
 pub mod config_resolver;
 pub mod cpu_headroom;
+pub mod credential_preflight;
 pub mod daemon_heartbeat;
 pub mod disk_headroom;
 pub mod epic_state;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -1,5 +1,6 @@
 use loom_daemon::activity::{self, ActivityDb, StatsQueries};
 use loom_daemon::claim_reconciliation;
+use loom_daemon::credential_preflight;
 use loom_daemon::daemon_heartbeat;
 use loom_daemon::epic_supervisor;
 use loom_daemon::event_bus::EventBus;
@@ -616,6 +617,19 @@ async fn main() -> Result<()> {
         Err(e) => log::warn!("sweep_registry: reconstruction failed: {e}"),
     }
 
+    // Startup forge-credential preflight (Issue #4005). Resolved once, here —
+    // immediately before the claim-reconciliation pass below, the daemon's
+    // first `gh` consumer — so a headless/SSH-only start with neither an
+    // exported GH_TOKEN/GITHUB_TOKEN nor an unlockable GUI login keychain is
+    // diagnosed loudly at boot instead of surfacing as silent per-tick 401s
+    // for the life of the process. Non-fatal and bounded (same posture as the
+    // reconciliation pass itself): a `gh` hiccup here never blocks startup.
+    let credential_preflight_probe = credential_preflight::RealGhAuthProbe {
+        gh_bin: "gh".to_string(),
+        cwd: sweep_workspace.clone(),
+    };
+    let credential_preflight = credential_preflight::run(&credential_preflight_probe);
+
     // Stale-`loom:building`-claim reconciliation across every managed
     // workspace (Issue #3953). `sweep.reconstruct()` above only recovers
     // entries this registry itself owns evidence for (locks/checkpoints); it
@@ -1096,7 +1110,9 @@ async fn main() -> Result<()> {
     // `DaemonStatus` request can report each registered repo's own halt state
     // (#3930), and `sweep_workspace` is the `effective_roots` fallback for the
     // per-repo status breakdown — the same values the work-finder and gate loop
-    // share above.
+    // share above. `credential_preflight` (#4005) is threaded in so
+    // `DaemonStatus` can report the startup credential resolution computed
+    // once above, without reading logs.
     let server = IpcServer::new(
         socket_path.clone(),
         tm,
@@ -1106,6 +1122,7 @@ async fn main() -> Result<()> {
         workspace_health_states.clone(),
         workspace_pool.clone(),
         sweep_workspace.clone(),
+        credential_preflight,
     );
 
     // Setup signal handler for graceful shutdown. We listen for BOTH SIGINT
@@ -2255,6 +2272,17 @@ fn print_status_json(
             "enabled": report.main_health_gate_enabled,
             "verdict_at": report.main_health_gate_verdict_at,
         },
+        // Startup forge-credential preflight (#4005) — resolved once at
+        // daemon boot, before the daemon's first `gh` consumer. Never
+        // contains a token value; `null` only from a pre-#4005 daemon binary
+        // that never computed one.
+        "credential_preflight": report.credential_preflight.as_ref().map(|c| serde_json::json!({
+            "ok": c.ok,
+            "mechanism": c.mechanism,
+            "fingerprint": c.fingerprint,
+            "message": c.message,
+            "checked_at": c.checked_at,
+        })),
         // Per-repo breakdown across every registered managed workspace (#3930).
         "per_repo": report.per_repo.iter().map(|r| serde_json::json!({
             "root": r.root,
@@ -2607,6 +2635,25 @@ fn print_status_human(
     );
     let gate = format_gate_status(&verdict);
     println!("\nMain-health gate: {gate}");
+
+    // Startup forge-credential preflight (#4005) — resolved once at daemon
+    // boot, before the daemon's first `gh` consumer, so a headless/SSH-only
+    // start with no usable credential is visible here rather than only as
+    // silent per-tick 401s in the logs. `None` only from a pre-#4005 daemon
+    // binary that never computed one.
+    match &report.credential_preflight {
+        Some(c) if c.ok => {
+            println!(
+                "Forge credential: OK — {} ({})",
+                c.mechanism,
+                c.fingerprint.as_deref().unwrap_or("no fingerprint")
+            );
+        }
+        Some(c) => println!("Forge credential: DEGRADED — {}", c.message),
+        None => {
+            println!("Forge credential: unknown (older daemon binary — restart to pick up #4005)")
+        }
+    }
 
     // Per-repo breakdown across every registered managed workspace (#3930). In
     // the common single-workspace case this is one line for the daemon's own

--- a/loom-daemon/src/main_health_gate.rs
+++ b/loom-daemon/src/main_health_gate.rs
@@ -1071,7 +1071,11 @@ fn parse_gh_run_list(stdout: &str, sha: &str, ci_workflow: Option<&str>) -> CiVe
 ///
 /// stdout goes to a temp file rather than a pipe for the same reason the gate
 /// command's does (no pipe-buffer deadlock while polling); stderr is discarded.
-fn run_capture_with_timeout(
+///
+/// `pub(crate)` (rather than private) so [`crate::credential_preflight`] can
+/// reuse the same bounded-subprocess helper for its `gh auth status` probe
+/// (#4005) instead of reimplementing timeout/kill handling.
+pub(crate) fn run_capture_with_timeout(
     program: &str,
     args: &[&str],
     cwd: &Path,

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -889,6 +889,14 @@ pub struct DaemonStatusReport {
     /// pre-#3930 wire data / older clients compatible (an empty vec).
     #[serde(default)]
     pub per_repo: Vec<RepoStatus>,
+    /// Startup forge-credential preflight snapshot (#4005): resolved once at
+    /// daemon boot, before the claim-reconciliation startup pass (the
+    /// daemon's first `gh` consumer) — see
+    /// [`crate::credential_preflight::run`]. `None` only for a pre-#4005 wire
+    /// payload from an older daemon binary that never computed one.
+    /// `#[serde(default)]` keeps that wire data compatible.
+    #[serde(default)]
+    pub credential_preflight: Option<CredentialPreflightReport>,
 }
 
 /// One registered managed-workspace's status line in [`DaemonStatusReport`]
@@ -974,6 +982,47 @@ pub struct CapacityReport {
     /// Whether the token axis is the binding (minimum) constraint on the dynamic
     /// cap — i.e. tokens, not disk or the operator ceiling, are the bottleneck.
     pub token_bound: bool,
+}
+
+/// Startup forge-credential preflight snapshot (#4005) — see
+/// [`crate::credential_preflight`] for the resolution logic. Resolved exactly
+/// once, before the daemon's first `gh` consumer, so headless/SSH-only
+/// operation (no unlockable GUI login keychain) is diagnosed loudly at boot
+/// instead of surfacing as an unexplained per-tick `401` on every forge call.
+///
+/// GitHub-only: the daemon's own forge calls all shell out to `gh`, which
+/// resolves GitHub credentials exclusively. `GITEA_TOKEN`/`FORGE_TOKEN`
+/// forwarding (`loom-daemon-start.sh`) exists only for dispatched sweep
+/// children targeting a Gitea-backed repo — the daemon process itself never
+/// calls a Gitea API, so there is nothing here to preflight for it.
+///
+/// **Never carries a token value** — only a resolution-mechanism label and a
+/// non-secret fingerprint (last 4 chars of an env-sourced token, or the
+/// authenticated `gh` login for a credential-store resolution).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CredentialPreflightReport {
+    /// `true` when a usable GitHub credential was resolved; `false` when
+    /// none was found, or the probe itself could not complete within its
+    /// bound (`gh` missing from `PATH`, timed out, spawn failure, …) — see
+    /// [`Self::mechanism`] `"unknown"` for that latter case.
+    pub ok: bool,
+    /// Which mechanism resolved the credential: `"GH_TOKEN"` / `"GITHUB_TOKEN"`
+    /// (the daemon's own process environment) or `gh`'s own `tokenSource`
+    /// (e.g. `"keyring"`, `"oauth_token"`) reported by `gh auth status`.
+    /// `"none"` when nothing resolved; `"unknown"` when the probe itself
+    /// failed to run. NEVER a token value.
+    pub mechanism: String,
+    /// A non-secret fingerprint: the last 4 characters of an env-sourced
+    /// token, or the authenticated `gh` login for a credential-store
+    /// resolution. `None` when no credential resolved.
+    pub fingerprint: Option<String>,
+    /// Human-readable, log/print-safe summary — never contains a token.
+    /// Names both remediations (export `GH_TOKEN` before starting the
+    /// daemon, or unlock the login keychain from a GUI session) when `ok` is
+    /// `false`.
+    pub message: String,
+    /// Wall-clock time this snapshot was taken (daemon startup).
+    pub checked_at: DateTime<Utc>,
 }
 
 // ========================================================================


### PR DESCRIPTION
## Summary

The daemon's `gh` calls (claim reconciliation, main-health gate, metrics collection, work finder, …) have never had a startup credential check. A headless/SSH start with no exported `GH_TOKEN`/`GITHUB_TOKEN` and no unlockable GUI login keychain boots clean and then 401s silently on every forge call for the life of the process. Separately, the launchd plist that carries a forwarded token was written world-readable. This PR adds a bounded, once-at-boot credential preflight with loud logging + `loom-daemon status` visibility, and hardens the plist to `0600` when it carries a token.

## Changes

- **`loom-daemon/src/credential_preflight.rs`** (new): resolves the daemon's GitHub credential via a single bounded `gh auth status --json hosts` probe (reuses `main_health_gate::run_capture_with_timeout`, 10s bound). Reports which mechanism won (`GH_TOKEN`/`GITHUB_TOKEN`/`gh`'s own credential store) with a non-secret fingerprint (last-4 of an env token, or the authenticated login) — never the token itself. Logs `info!` on success, `error!` naming both remedies on failure. 12 unit tests cover env-token/store/none/error/timeout-style failures and assert no token value ever appears in a log message.
- **`loom-daemon/src/main.rs`**: runs the preflight once, immediately before the claim-reconciliation startup pass (the daemon's first `gh` consumer); threads the result into `IpcServer::new`; renders it in both `--json` (`credential_preflight` key) and human `loom-daemon status` output ("Forge credential: OK/DEGRADED — …").
- **`loom-daemon/src/types.rs`**: new `CredentialPreflightReport` wire type + `DaemonStatusReport.credential_preflight: Option<...>` (`#[serde(default)]`, backward-compatible with older daemon payloads).
- **`loom-daemon/src/ipc.rs`**: threads the preflight snapshot through `IpcServer` → `handle_client` → `build_daemon_status` (mirrors how `health_states`/`fallback_root` are already threaded); updates the 9 existing `build_daemon_status`/`DaemonStatusReport` test call sites with a fixture.
- **`loom-daemon/src/main_health_gate.rs`**: `run_capture_with_timeout` bumped from private to `pub(crate)` so the preflight can reuse it instead of reimplementing timeout/kill handling.
- **`defaults/scripts/cli/loom-daemon-start.sh`**: `chmod 600` the rendered launchd plist whenever it carries a forwarded `GH_TOKEN`/`GITEA_TOKEN`/`FORGE_TOKEN` (previously left at the process umask, typically world-readable `0644`).
- **`.loom/docs/github-authentication.md`**: new "Headless and SSH-only daemon operation" section covering the env-inheritance footgun, the preflight, plist hardening, and the GitHub-only scope decision (Gitea forwarding is for sweep children only — the daemon itself never calls a Gitea API).
- **`.loom/docs/daemon-reference.md`**: cross-links the new section from the existing launchd-plist writeup.

**Deliberately not done** (per the curated issue's explicit scope decision): no new loom-managed PAT file — the existing plist env-forwarding mechanism already reaches the daemon and every dispatched sweep child, so a second credential store would be new attack surface for no capability gain. The `launchctl bootstrap gui/$UID` SSH-start failure (`error 125`) is a separate supervision-model problem, not a credential problem — filed as a follow-up: #4130.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Startup credential preflight, resolved once before claim reconciliation, `info!`/non-secret fingerprint | ✅ | `credential_preflight::run()` called in `main.rs` before the `claim_reconciliation::reconciliation_enabled()` block; `run_never_includes_a_token_looking_value_in_message` + `env_fingerprint_never_leaks_full_token` tests |
| Loud, actionable `error!` naming both remedies when no credential resolves; non-fatal/bounded | ✅ | `resolve()`'s `None`/error branches always name "export GH_TOKEN... or unlock the login keychain"; bounded by `PREFLIGHT_TIMEOUT` (10s) via reused `run_capture_with_timeout`; `run_with_missing_gh_binary_never_panics_and_reports_degraded` + `real_probe_with_missing_gh_binary_never_panics` |
| Preflight result visible in `loom-daemon status` | ✅ | `credential_preflight` field in `--json` output; "Forge credential: OK/DEGRADED — …" line in human output; `test_daemon_status_request_response_round_trip` asserts the field round-trips |
| Plist hardened to 0600 when it carries a `*_TOKEN` | ✅ | `chmod 600 "$PLIST_FILE"` gated on `env | grep -qE '^(GH_TOKEN|GITEA_TOKEN|FORGE_TOKEN)='`, matching the same pattern the forwarding loop reads |
| Docs: headless/daemon operation section + cross-link | ✅ | `.loom/docs/github-authentication.md` § "Headless and SSH-only daemon operation"; cross-linked from `.loom/docs/daemon-reference.md` |
| Gitea parity: covered or explicitly GitHub-only | ✅ | Documented GitHub-only (the daemon's own forge calls are exclusively `gh`-CLI-based; `GITEA_TOKEN`/`FORGE_TOKEN` forwarding remains for sweep children only) — no code change needed |
| No secret ever appears in logs/status/event payloads | ✅ | `run_never_includes_a_token_looking_value_in_message` asserts the exported token value never appears in `report.message`/`fingerprint`; fingerprint is always a 4-char slice computed locally, never `gh`'s own `--show-token` output (never invoked) |
| No new loom-managed PAT file | ✅ | Not implemented — reuses the existing plist env-forwarding mechanism (see "Deliberately not done" above) |

## Test Plan

- `cargo test --lib credential_preflight` — 12/12 pass (env-token present/absent/neither-usable, probe error, unparseable output, fingerprint never leaks, `run()` never panics on a missing `gh` binary)
- `cargo test --lib` (full `loom-daemon` suite) — 1230/1230 pass, including the updated `ipc::tests::test_build_daemon_status_*` and `test_daemon_status_*` round-trip/backward-compat tests
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt -- --check` — clean
- `bash defaults/scripts/tests/test-loom-daemon-start.sh` — 11/11 pass (no regression from the plist-hardening change)
- `bash -n defaults/scripts/cli/loom-daemon-start.sh` — syntax OK
- Manual `ls -l ~/Library/LaunchAgents/<label>.plist` / wedged-`gh` / invalid-`GH_TOKEN` verification (from the curated test plan) were not re-run in this sandbox (no real launchd session here) — the automated coverage above exercises the same code paths (probe error handling, degraded-credential branch, plist chmod condition) without touching the operator's real LaunchAgents.

Closes #4005