### PR TITLE
feat(tokens): cut probe/check path over to native loom-daemon tokens check

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -1688,13 +1688,16 @@ already owns dispatch cadence and consumes the ranking (via `spawn-claude.sh`
 selection) on every sweep it spawns.
 
 **What it does.** On a configurable cadence (default 10 minutes) the loop
-shells out to each registered repo's `probe-tokens.sh --ranking` (the same
-script an operator cron would have called), which probes every bootstrapped
-account for its current rate-limit headers and atomically rewrites `.ranking`
-in whichever pool `loom_tools.tokens` resolves for that repo — the per-repo
-`.loom/tokens/`, or the shared machine-level pool (#3938) when the per-repo pool
-is absent/empty. Pool-location resolution is left entirely to the existing
-Python selector; the daemon-side loop never reimplements it.
+invokes **its own binary** (`std::env::current_exe()`) with `tokens check
+--ranking --workspace <repo_root>` for each registered repo — as of #4080 this
+is a direct daemon-to-daemon subcommand invocation rather than a shell out to
+`probe-tokens.sh`, which sidesteps the "stale binary predates the `tokens`
+subcommand" hazard entirely (the running daemon by construction supports its
+own subcommands) and drops a process layer (daemon → bash → daemon). It probes
+every bootstrapped account for its current rate-limit headers and atomically
+rewrites `.ranking` in whichever pool [`tokens_pool::paths`] resolves for that
+repo — the per-repo `.loom/tokens/`, or the shared machine-level pool (#3938)
+when the per-repo pool is absent/empty.
 
 **Default-on, unlike the work finder / main-health gate.** Those two loops are
 opt-in because they have dispatch-affecting side effects (spawning sweeps,

--- a/.loom/docs/token-pool.md
+++ b/.loom/docs/token-pool.md
@@ -153,8 +153,20 @@ consume:
 loom-tokens check                  # Probe + print human table
 loom-tokens check --ranking        # Probe + write .loom/tokens/.ranking atomically
 loom-tokens check --json           # Emit full JSON report to stdout
+loom-daemon tokens check --json    # Native Rust equivalent (issue #4108)
 ./.loom/scripts/probe-tokens.sh    # Cron-friendly wrapper for periodic invocation
 ```
+
+**`probe-tokens.sh` delegates to `loom-daemon tokens check`, not Python (#4080).**
+It resolves a `loom-daemon` binary (`$LOOM_DAEMON_BIN` → `loom-daemon` on PATH →
+build-output-relative candidates under the repo), capability-probes it with
+`tokens check --help` to detect a stale pre-#4108 binary, and `exec`s `tokens
+check "$@"` on success — the flags and exit codes above are unchanged either
+way. It falls back to `loom-tokens` on PATH (with a stderr warning) only when
+the resolved daemon binary predates the `tokens` subcommand, and exits `1` with
+an actionable message (naming `loom-daemon-start.sh` / `cargo build`) when
+neither is available. The historical `python3 -m loom_tools.tokens.cli`
+fallback tier has been removed entirely.
 
 The probe sends a minimal `POST /v1/messages` request (1 input, 1 output token)
 and parses rate-limit response headers. The header parser matches by **suffix**
@@ -170,11 +182,14 @@ are logged and skipped — one bad account does not abort the run.
 OAuth tokens shaped `sk-ant-oat01-*` are sent with `Authorization: Bearer` +
 `anthropic-beta: oauth-2025-04-20`; plain API keys use `x-api-key`.
 
-**The running `loom-daemon` self-refreshes `.ranking` (#3969)** — it runs the
-equivalent of `probe-tokens.sh --ranking` on its own periodic loop (default every
-10 minutes, `autonomous.tokenRankingRefresh` / `LOOM_TOKEN_RANKING_REFRESH*`, on
-by default since it is read-only probing with no dispatch side effect), so a
-standing cron for this is no longer required when the daemon is running. See
+**The running `loom-daemon` self-refreshes `.ranking` (#3969)** — it invokes
+**its own binary** (`std::env::current_exe()`) with `tokens check --ranking
+--workspace <repo_root>` on its own periodic loop (default every 10 minutes,
+`autonomous.tokenRankingRefresh` / `LOOM_TOKEN_RANKING_REFRESH*`, on by default
+since it is read-only probing with no dispatch side effect) — as of #4080 this
+is a direct daemon-to-daemon subcommand invocation, not a shell out to
+`probe-tokens.sh`, so a standing cron for this is no longer required when the
+daemon is running. See
 [Token-ranking self-refresh](daemon-reference.md#token-ranking-self-refresh-3969)
 for the config knobs.
 

--- a/defaults/scripts/lib/locate-daemon-bin.sh
+++ b/defaults/scripts/lib/locate-daemon-bin.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# locate-daemon-bin.sh — Resolve the loom-daemon binary to invoke.
+#
+# Source this file (do not exec). Defines a single function:
+#
+#   loom_locate_daemon_bin <repo_root> -> echoes the absolute path to a
+#   loom-daemon binary on stdout, or an empty string if none could be
+#   resolved.
+#
+# Resolution precedence (first match wins):
+#   1. $LOOM_DAEMON_BIN — must be executable.
+#   2. `loom-daemon` on PATH.
+#   3. Build-output-relative candidates under <repo_root>:
+#        loom-daemon/target/release/loom-daemon
+#        loom-daemon/target/debug/loom-daemon
+#        target/release/loom-daemon
+#        target/debug/loom-daemon
+#
+# Extracted (issue #4080) from the identical inline copies in
+# loom-daemon-start.sh and loom-daemon-update.sh so probe-tokens.sh's
+# daemon-binary resolution does not add a fourth copy of this logic.
+
+loom_locate_daemon_bin() {
+    local root="$1"
+    if [[ -n "${LOOM_DAEMON_BIN:-}" && -x "${LOOM_DAEMON_BIN}" ]]; then
+        echo "${LOOM_DAEMON_BIN}"; return 0
+    fi
+    if command -v loom-daemon >/dev/null 2>&1; then
+        command -v loom-daemon; return 0
+    fi
+    local candidate
+    for candidate in \
+        "$root/loom-daemon/target/release/loom-daemon" \
+        "$root/loom-daemon/target/debug/loom-daemon" \
+        "$root/target/release/loom-daemon" \
+        "$root/target/debug/loom-daemon"; do
+        if [[ -x "$candidate" ]]; then echo "$candidate"; return 0; fi
+    done
+    echo ""
+}

--- a/defaults/scripts/probe-tokens.sh
+++ b/defaults/scripts/probe-tokens.sh
@@ -8,18 +8,63 @@
 #
 # Exit codes:
 #   0 - At least one account was probed (results may be mixed)
-#   1 - Every probe failed, or the tokens directory is missing
+#   1 - Every probe failed, or the tokens directory is missing, or no daemon
+#       binary/loom-tokens fallback could be resolved
 #
 # Cron example (every 10 minutes):
 #   */10 * * * * cd /path/to/repo && ./.loom/scripts/probe-tokens.sh --ranking >> .loom/logs/probe-tokens.log 2>&1
 #
-# Thin wrapper around the loom-tokens Python CLI.  Modeled on
-# .loom/scripts/check-usage.sh — keeps the bash surface tiny so the real
-# logic lives in loom-tools.
+# Delegates to the native `loom-daemon tokens check` subcommand (issue #4080,
+# epic #4081 Phase 2 — a byte-compatible Rust port of the historical Python
+# `loom-tokens check` CLI). Falls back to `loom-tokens` on PATH when the
+# resolved daemon binary predates the `tokens` subcommand (a host mid-roll —
+# #4108 landed in commit 51389917). The bare `python3 -m` fallback tier has
+# been removed entirely.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/locate-daemon-bin.sh
+source "$SCRIPT_DIR/lib/locate-daemon-bin.sh"
+
+# ---------- repo root (mirrors loom-daemon-start.sh's find_repo_root) ----------
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.loom" ]]; then echo "$dir"; return 0; fi
+        if [[ -f "$dir/.git" ]]; then
+            local gitdir main_repo
+            gitdir=$(sed 's/^gitdir: //' "$dir/.git")
+            main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+            if [[ -d "$main_repo/.loom" ]]; then echo "$main_repo"; return 0; fi
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "$PWD"
+}
+
+REPO_ROOT="$(find_repo_root)"
+DAEMON_BIN="$(loom_locate_daemon_bin "$REPO_ROOT")"
+
+# Capability-probe before committing to the native path: a host mid-roll can
+# have a `loom-daemon` binary predating commit 51389917 (#4108), which would
+# fail with "unrecognized subcommand `tokens`". `tokens check --help` is a
+# cheap, side-effect-free way to detect that ahead of time.
+if [[ -n "$DAEMON_BIN" ]] && "$DAEMON_BIN" tokens check --help >/dev/null 2>&1; then
+    exec "$DAEMON_BIN" tokens check "$@"
+fi
+
+if [[ -n "$DAEMON_BIN" ]]; then
+    echo "WARNING probe-tokens.sh: $DAEMON_BIN does not support 'tokens check' (stale build); falling back to loom-tokens on PATH" >&2
+fi
 
 if command -v loom-tokens &>/dev/null; then
     loom-tokens check "$@"
     exit $?
 fi
 
-python3 -m loom_tools.tokens.cli check "$@"
+echo "ERROR probe-tokens.sh: no loom-daemon binary supporting 'tokens check' and no loom-tokens on PATH." >&2
+echo "  Build or start a daemon binary, then retry:" >&2
+echo "    ./.loom/scripts/cli/loom-daemon-start.sh" >&2
+echo "    cargo build --release -p loom-daemon" >&2
+exit 1

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -193,15 +193,15 @@ enum Commands {
     Restart,
 
     /// Manage the multi-account OAuth token pool at `.loom/tokens/` (Issue
-    /// #4082, Phase 1 of epic #4081 "eliminate Python from Loom"). Native
-    /// Rust port of the hot-path subset of `loom_tools.tokens` — the 3-tier
-    /// selection algorithm and the operator-facing pin/unpin/unblock
-    /// bookkeeping CLI. This is a pure addition in this phase: no existing
-    /// caller (`spawn-claude.sh`, `probe-tokens.sh`) has been switched over
-    /// yet, and `bootstrap`/`check`/`import-from-monitor` remain
-    /// Python-only (deferred to a follow-up issue — see
-    /// `loom-daemon/src/tokens_pool/mod.rs`). Purely file-based; does not
-    /// require a running daemon.
+    /// #4082/#4108, epic #4081 "eliminate Python from Loom"). Native Rust
+    /// port of the token pool: the 3-tier selection algorithm, the HTTP
+    /// rate-limit probe (`check`), and the operator-facing pin/unpin/unblock
+    /// bookkeeping CLI. As of #4080 (Phase 2) `check` is also the
+    /// implementation `probe-tokens.sh` and the daemon's own ranking
+    /// self-refresh invoke natively; `spawn-claude.sh` (selection) and
+    /// `bootstrap`/`import-from-monitor` remain Python-only (deferred to
+    /// follow-up issues — see `loom-daemon/src/tokens_pool/mod.rs`). Purely
+    /// file-based; does not require a running daemon.
     Tokens {
         #[command(subcommand)]
         action: TokensAction,
@@ -354,9 +354,11 @@ enum TokensAction {
     },
 
     /// Probe each bootstrapped account for rate-limit headers and rank by
-    /// available quota, optionally writing `.loom/tokens/.ranking`. Mirrors
-    /// `python3 -m loom_tools.tokens.cli check`. The HTTP probe shells to
-    /// `curl` (no HTTP-client crate — see `tokens_pool::check`).
+    /// available quota, optionally writing `.loom/tokens/.ranking`. A
+    /// byte-compatible port of the historical Python `loom-tokens check` CLI
+    /// (issue #4108) — as of #4080 this is also what `probe-tokens.sh` and
+    /// the daemon's own ranking self-refresh invoke natively. The HTTP probe
+    /// shells to `curl` (no HTTP-client crate — see `tokens_pool::check`).
     Check {
         /// Repo root containing `.loom/tokens/` (plain path, default `.` — no
         /// upward `.git` walk).
@@ -1994,28 +1996,33 @@ async fn handle_dispatch_command(
     }
 }
 
-/// Collect per-token usage by shelling out to `loom-tokens check --json`,
-/// mirroring `probe-tokens.sh`: prefer the `loom-tokens` binary on PATH, else
-/// fall back to `python3 -m loom_tools.tokens.cli`. Best-effort — returns
-/// `None` on any failure (binary absent, non-zero exit, unparseable output) so
-/// the status view still renders without the usage table.
+/// Collect per-token usage via an in-process call to
+/// [`loom_daemon::tokens_pool::check::run_check`] — the same native probe
+/// `loom-daemon tokens check --json` (`TokensAction::Check`) runs, called
+/// directly rather than shelled out to (issue #4080, epic #4081 Phase 2).
+/// `loom-daemon status` runs client-side with no supervision requirement, and
+/// the probe code is already linked into this binary, so there is no reason
+/// to pay a subprocess round-trip the way the historical `loom-tokens` /
+/// `python3 -m` two-tier shell-out did. Best-effort — never panics, never
+/// propagates an error, and returns `None` when the workspace can't be
+/// resolved so the status view still renders without the usage table.
 fn collect_token_usage() -> Option<serde_json::Value> {
-    let attempts: [(&str, &[&str]); 2] = [
-        ("loom-tokens", &["check", "--json"]),
-        ("python3", &["-m", "loom_tools.tokens.cli", "check", "--json"]),
-    ];
-    for (bin, args) in attempts {
-        let Ok(output) = Command::new(bin).args(args).output() else {
-            continue;
-        };
-        if !output.status.success() {
-            continue;
-        }
-        if let Ok(value) = serde_json::from_slice::<serde_json::Value>(&output.stdout) {
-            return Some(value);
-        }
-    }
-    None
+    use loom_daemon::tokens_pool::check::{
+        self, CheckOptions, CurlTransport, DEFAULT_PROBE_MODEL, DEFAULT_PROBE_PROMPT,
+    };
+
+    let ws = resolve_tokens_workspace(".").ok()?;
+    let tokens_dir = loom_daemon::tokens_pool::paths::resolve_tokens_dir(&ws);
+
+    let opts = CheckOptions {
+        source: check::resolve_source(None),
+        write_ranking: false,
+        probe_prompt: DEFAULT_PROBE_PROMPT,
+        model: DEFAULT_PROBE_MODEL,
+        stagger: true,
+    };
+    let report = check::run_check(&tokens_dir, &opts, &CurlTransport);
+    Some(report.to_json())
 }
 
 /// Handle the `status` subcommand — render the running daemon's autonomous-mode

--- a/loom-daemon/src/token_ranking_refresh.rs
+++ b/loom-daemon/src/token_ranking_refresh.rs
@@ -15,28 +15,31 @@
 //!
 //! # What it does
 //!
-//! On a configurable cadence (default 10 minutes) the daemon shells out to the
-//! repo's installed `probe-tokens.sh --ranking` (falling back to
-//! `defaults/scripts/probe-tokens.sh` for a Loom checkout that has not yet
-//! synced the installed copy — see [`ScriptRankingRefreshRunner::resolve_script_bin`]),
-//! which probes every bootstrapped account for its current rate-limit headers
-//! and atomically rewrites `.ranking` in whichever pool `loom_tools.tokens`
-//! resolves for that repo (per-repo `.loom/tokens/`, or the shared
-//! machine-level pool per #3938 when the per-repo pool is absent/empty — pool
-//! *location* resolution is left entirely to the existing Python selector so
-//! this module never has to duplicate it).
+//! On a configurable cadence (default 10 minutes) the daemon shells out to
+//! **its own binary** (`std::env::current_exe()`) with `tokens check
+//! --ranking --workspace <repo_root>` (issue #4080, epic #4081 Phase 2 —
+//! historically this shelled out to `probe-tokens.sh --ranking`; see
+//! [`ScriptRankingRefreshRunner::resolve_bin`]). Invoking `current_exe()`
+//! rather than re-resolving a script sidesteps the "stale binary predates the
+//! `tokens` subcommand" hazard entirely — the running daemon by construction
+//! supports its own subcommands — and drops a process layer (daemon → bash →
+//! daemon). The subcommand probes every bootstrapped account for its current
+//! rate-limit headers and atomically rewrites `.ranking` in whichever pool
+//! [`crate::tokens_pool::paths`] resolves for that repo (per-repo
+//! `.loom/tokens/`, or the shared machine-level pool per #3938 when the
+//! per-repo pool is absent/empty).
 //!
 //! # Never fatal, never double-writes unsafely
 //!
-//! A probe failure (network hiccup, `gh`/`python3` missing, every account
-//! exhausted, no tokens bootstrapped at all) is logged and skipped — it never
-//! panics the loop or the daemon. Because `loom-tokens check --ranking` writes
-//! `.ranking` atomically (temp file + rename, matching every other Loom
-//! bookkeeping writer), an operator's cron running the identical script
-//! concurrently is harmless: the two refreshers can race to *schedule* a
-//! write but never to a *torn* file, and whichever write lands last simply
-//! wins — both are measuring the same live rate-limit state, so there is no
-//! correctness cost to the redundancy, only (rare) duplicated API calls.
+//! A probe failure (network hiccup, every account exhausted, no tokens
+//! bootstrapped at all) is logged and skipped — it never panics the loop or
+//! the daemon. Because `tokens check --ranking` writes `.ranking` atomically
+//! (temp file + rename, matching every other Loom bookkeeping writer), an
+//! operator's cron running `probe-tokens.sh --ranking` concurrently is
+//! harmless: the two refreshers can race to *schedule* a write but never to a
+//! *torn* file, and whichever write lands last simply wins — both are
+//! measuring the same live rate-limit state, so there is no correctness cost
+//! to the redundancy, only (rare) duplicated API calls.
 //!
 //! # Default-on (unlike the work-finder / main-health-gate loops)
 //!
@@ -65,8 +68,8 @@
 //!   pool, exactly like [`crate::main_health_gate::spawn_multi_main_health_gate_task`].
 //!   An empty registry reduces to the single `fallback_root`.
 //! - The probe runs on a blocking thread via `tokio::task::spawn_blocking` (it
-//!   shells out to Python + a network call) so it never parks a runtime
-//!   worker, mirroring the main-health gate's command execution.
+//!   shells out to a subprocess and makes network calls) so it never parks a
+//!   runtime worker, mirroring the main-health gate's command execution.
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -114,8 +117,8 @@ const MAX_OUTPUT_TAIL_BYTES: usize = 2048;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RefreshOutcome {
     /// The probe ran to completion and reported success (`.ranking` rewritten,
-    /// or at least one account was probed — see `probe-tokens.sh`'s own exit
-    /// code contract).
+    /// or at least one account was probed — see `loom-daemon tokens check`'s
+    /// own exit code contract, mirrored from `probe-tokens.sh`).
     Success,
     /// The probe could not be run, or ran and reported failure. `reason`
     /// explains what happened. Never fatal to the daemon — logged and skipped.
@@ -140,20 +143,24 @@ pub trait RankingRefreshRunner {
     fn refresh(&mut self) -> RefreshOutcome;
 }
 
-/// The concrete [`RankingRefreshRunner`]: shells out to the repo's
-/// `probe-tokens.sh --ranking` in `repo_root`.
+/// The concrete [`RankingRefreshRunner`]: shells out to **its own binary**
+/// (`std::env::current_exe()`) with `tokens check --ranking --workspace
+/// <repo_root>` (issue #4080). Historically this resolved and spawned
+/// `probe-tokens.sh --ranking`; invoking `current_exe()` instead sidesteps the
+/// "stale binary predates the `tokens` subcommand" hazard entirely (the
+/// running daemon by construction supports its own subcommands) and drops a
+/// process layer (daemon → bash → daemon).
 ///
 /// Pool-location resolution (per-repo vs. the #3938 shared machine-level pool)
-/// is deliberately **not** reimplemented here — `probe-tokens.sh` delegates to
-/// `loom_tools.tokens.check`, which already owns that resolution and the
-/// atomic `.ranking` write. This runner's only job is finding the script and
-/// running it with a timeout.
+/// is deliberately **not** reimplemented here — `tokens check` delegates to
+/// [`crate::tokens_pool::paths`], which already owns that resolution and the
+/// atomic `.ranking` write. This runner's only job is resolving the binary to
+/// invoke and running it with a timeout.
 pub struct ScriptRankingRefreshRunner {
     repo_root: PathBuf,
-    /// Explicit script override (tests point this at a fake executable).
-    /// Production leaves this `None` and resolves via
-    /// [`Self::resolve_script_bin`].
-    script_bin: Option<PathBuf>,
+    /// Explicit binary override (tests point this at a fake executable).
+    /// Production leaves this `None` and resolves via [`Self::resolve_bin`].
+    bin: Option<PathBuf>,
     timeout: Duration,
 }
 
@@ -163,16 +170,16 @@ impl ScriptRankingRefreshRunner {
     pub fn new(repo_root: PathBuf) -> Self {
         Self {
             repo_root,
-            script_bin: None,
+            bin: None,
             timeout: DEFAULT_PROBE_TIMEOUT,
         }
     }
 
-    /// Override the script binary (tests only — production always resolves via
-    /// [`Self::resolve_script_bin`]).
+    /// Override the daemon binary to invoke (tests only — production always
+    /// resolves via [`Self::resolve_bin`] to `std::env::current_exe()`).
     #[must_use]
-    pub fn with_script_bin(mut self, bin: PathBuf) -> Self {
-        self.script_bin = Some(bin);
+    pub fn with_bin(mut self, bin: PathBuf) -> Self {
+        self.bin = Some(bin);
         self
     }
 
@@ -183,54 +190,32 @@ impl ScriptRankingRefreshRunner {
         self
     }
 
-    /// Resolve `probe-tokens.sh`, preferring (in order):
-    /// 1. [`Self::script_bin`] explicit override (tests).
-    /// 2. `<repo_root>/.loom/scripts/probe-tokens.sh` (the installed copy).
-    /// 3. `<repo_root>/defaults/scripts/probe-tokens.sh` (a Loom checkout that
-    ///    has not yet synced the installed copy — mirrors
-    ///    [`crate::sweep_registry::SweepRegistryConfig::resolve_spawn_bin`]'s
-    ///    fallback order for `spawn-claude.sh`).
-    fn resolve_script_bin(&self) -> Result<PathBuf, String> {
-        if let Some(p) = &self.script_bin {
+    /// Resolve the binary to invoke: [`Self::bin`] explicit override (tests),
+    /// else `std::env::current_exe()` — the currently-running `loom-daemon`
+    /// binary, which by construction supports the `tokens check` subcommand.
+    fn resolve_bin(&self) -> Result<PathBuf, String> {
+        if let Some(p) = &self.bin {
             return Ok(p.clone());
         }
-        let installed = self
-            .repo_root
-            .join(".loom")
-            .join("scripts")
-            .join("probe-tokens.sh");
-        if installed.exists() {
-            return Ok(installed);
-        }
-        let defaults = self
-            .repo_root
-            .join("defaults")
-            .join("scripts")
-            .join("probe-tokens.sh");
-        if defaults.exists() {
-            return Ok(defaults);
-        }
-        Err(format!(
-            "probe-tokens.sh not found under {} (looked in .loom/scripts and defaults/scripts)",
-            self.repo_root.display()
-        ))
+        std::env::current_exe().map_err(|e| format!("could not resolve current_exe(): {e}"))
     }
 }
 
 impl RankingRefreshRunner for ScriptRankingRefreshRunner {
     fn refresh(&mut self) -> RefreshOutcome {
-        let script = match self.resolve_script_bin() {
+        let bin = match self.resolve_bin() {
             Ok(p) => p,
             Err(e) => return RefreshOutcome::Failure(e),
         };
-        run_probe_with_timeout(&script, &self.repo_root, self.timeout)
+        run_probe_with_timeout(&bin, &self.repo_root, self.timeout)
     }
 }
 
-/// Run `script --ranking` in `cwd`, capturing combined output to a temp file
-/// (never a pipe — avoids the pipe-buffer deadlock the health gate's
-/// equivalent helper documents) and killing it after `timeout`.
-fn run_probe_with_timeout(script: &Path, cwd: &Path, timeout: Duration) -> RefreshOutcome {
+/// Run `bin tokens check --ranking --workspace <repo_root>` with `repo_root`
+/// as both the `--workspace` argument and the child's cwd, capturing combined
+/// output to a temp file (never a pipe — avoids the pipe-buffer deadlock the
+/// health gate's equivalent helper documents) and killing it after `timeout`.
+fn run_probe_with_timeout(bin: &Path, repo_root: &Path, timeout: Duration) -> RefreshOutcome {
     let log_path = std::env::temp_dir()
         .join(format!("loom-token-ranking-refresh-{}.log", uuid::Uuid::new_v4()));
     let out_file = match std::fs::File::create(&log_path) {
@@ -247,9 +232,13 @@ fn run_probe_with_timeout(script: &Path, cwd: &Path, timeout: Duration) -> Refre
         }
     };
 
-    let mut child = match Command::new(script)
+    let mut child = match Command::new(bin)
+        .arg("tokens")
+        .arg("check")
         .arg("--ranking")
-        .current_dir(cwd)
+        .arg("--workspace")
+        .arg(repo_root)
+        .current_dir(repo_root)
         .stdin(Stdio::null())
         .stdout(Stdio::from(out_file))
         .stderr(Stdio::from(stderr_file))
@@ -258,7 +247,7 @@ fn run_probe_with_timeout(script: &Path, cwd: &Path, timeout: Duration) -> Refre
         Ok(c) => c,
         Err(e) => {
             let _ = std::fs::remove_file(&log_path);
-            return RefreshOutcome::Failure(format!("could not spawn `{}`: {e}", script.display()));
+            return RefreshOutcome::Failure(format!("could not spawn `{}`: {e}", bin.display()));
         }
     };
 
@@ -270,7 +259,7 @@ fn run_probe_with_timeout(script: &Path, cwd: &Path, timeout: Duration) -> Refre
                 let tail = std::fs::read_to_string(&log_path).unwrap_or_default();
                 break RefreshOutcome::Failure(format!(
                     "`{}` exited with {status}: {}",
-                    script.display(),
+                    bin.display(),
                     truncate_tail(&tail)
                 ));
             }
@@ -280,17 +269,14 @@ fn run_probe_with_timeout(script: &Path, cwd: &Path, timeout: Duration) -> Refre
                     let _ = child.wait();
                     break RefreshOutcome::Failure(format!(
                         "`{}` timed out after {}s",
-                        script.display(),
+                        bin.display(),
                         timeout.as_secs()
                     ));
                 }
                 std::thread::sleep(PROBE_POLL_INTERVAL);
             }
             Err(e) => {
-                break RefreshOutcome::Failure(format!(
-                    "could not poll `{}`: {e}",
-                    script.display()
-                ))
+                break RefreshOutcome::Failure(format!("could not poll `{}`: {e}", bin.display()))
             }
         }
     };
@@ -535,9 +521,9 @@ mod tests {
         fs::write(root.join(".loom").join("config.json"), contents).unwrap();
     }
 
-    /// A fake script that just exits with a fixed code, optionally writing to
+    /// A fake binary that just exits with a fixed code, optionally writing to
     /// stdout/stderr first. Written with a shebang so it's directly executable.
-    fn write_fake_script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    fn write_fake_bin(dir: &Path, name: &str, body: &str) -> PathBuf {
         fs::create_dir_all(dir).unwrap();
         let path = dir.join(name);
         fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
@@ -552,76 +538,40 @@ mod tests {
     }
 
     // ===================================================================
-    // ScriptRankingRefreshRunner — script resolution + execution
+    // ScriptRankingRefreshRunner — binary resolution + execution
     // ===================================================================
 
     #[test]
-    fn test_resolve_script_bin_missing_is_failure() {
+    fn test_resolve_bin_defaults_to_current_exe() {
         let tmp = tempfile::tempdir().unwrap();
-        let mut runner = ScriptRankingRefreshRunner::new(tmp.path().to_path_buf());
-        let outcome = runner.refresh();
-        assert!(!outcome.is_success());
-        let RefreshOutcome::Failure(reason) = outcome else {
-            panic!("expected Failure");
-        };
-        assert!(reason.contains("probe-tokens.sh not found"), "{reason}");
+        let runner = ScriptRankingRefreshRunner::new(tmp.path().to_path_buf());
+        let resolved = runner.resolve_bin().unwrap();
+        assert_eq!(resolved, std::env::current_exe().unwrap());
     }
 
     #[test]
-    fn test_resolve_script_bin_prefers_installed_over_defaults() {
+    fn test_resolve_bin_honors_override() {
         let tmp = tempfile::tempdir().unwrap();
-        write_fake_script(&tmp.path().join(".loom").join("scripts"), "probe-tokens.sh", "exit 0");
-        write_fake_script(
-            &tmp.path().join("defaults").join("scripts"),
-            "probe-tokens.sh",
-            "exit 1",
-        );
-        let runner = ScriptRankingRefreshRunner::new(tmp.path().to_path_buf());
-        let resolved = runner.resolve_script_bin().unwrap();
-        assert_eq!(
-            resolved,
-            tmp.path()
-                .join(".loom")
-                .join("scripts")
-                .join("probe-tokens.sh")
-        );
-    }
-
-    #[test]
-    fn test_resolve_script_bin_falls_back_to_defaults() {
-        let tmp = tempfile::tempdir().unwrap();
-        write_fake_script(
-            &tmp.path().join("defaults").join("scripts"),
-            "probe-tokens.sh",
-            "exit 0",
-        );
-        let runner = ScriptRankingRefreshRunner::new(tmp.path().to_path_buf());
-        let resolved = runner.resolve_script_bin().unwrap();
-        assert_eq!(
-            resolved,
-            tmp.path()
-                .join("defaults")
-                .join("scripts")
-                .join("probe-tokens.sh")
-        );
+        let fake = write_fake_bin(tmp.path(), "fake-daemon.sh", "exit 0");
+        let runner =
+            ScriptRankingRefreshRunner::new(tmp.path().to_path_buf()).with_bin(fake.clone());
+        assert_eq!(runner.resolve_bin().unwrap(), fake);
     }
 
     #[test]
     fn test_refresh_success_on_zero_exit() {
         let tmp = tempfile::tempdir().unwrap();
-        let script = write_fake_script(tmp.path(), "fake-probe.sh", "echo ok; exit 0");
-        let mut runner =
-            ScriptRankingRefreshRunner::new(tmp.path().to_path_buf()).with_script_bin(script);
+        let bin = write_fake_bin(tmp.path(), "fake-daemon.sh", "echo ok; exit 0");
+        let mut runner = ScriptRankingRefreshRunner::new(tmp.path().to_path_buf()).with_bin(bin);
         assert_eq!(runner.refresh(), RefreshOutcome::Success);
     }
 
     #[test]
     fn test_refresh_failure_on_nonzero_exit_includes_output_tail() {
         let tmp = tempfile::tempdir().unwrap();
-        let script =
-            write_fake_script(tmp.path(), "fake-probe.sh", "echo tokens directory missing; exit 1");
-        let mut runner =
-            ScriptRankingRefreshRunner::new(tmp.path().to_path_buf()).with_script_bin(script);
+        let bin =
+            write_fake_bin(tmp.path(), "fake-daemon.sh", "echo tokens directory missing; exit 1");
+        let mut runner = ScriptRankingRefreshRunner::new(tmp.path().to_path_buf()).with_bin(bin);
         let outcome = runner.refresh();
         let RefreshOutcome::Failure(reason) = outcome else {
             panic!("expected Failure");
@@ -630,26 +580,28 @@ mod tests {
     }
 
     #[test]
-    fn test_refresh_receives_ranking_flag() {
+    fn test_refresh_invokes_tokens_check_ranking_argv() {
         let tmp = tempfile::tempdir().unwrap();
-        // Fail unless invoked with --ranking as $1, so this also proves the
-        // runner passes the flag the CLAUDE.md contract documents.
-        let script = write_fake_script(
-            tmp.path(),
-            "fake-probe.sh",
-            "[ \"$1\" = \"--ranking\" ] && exit 0 || exit 1",
+        let repo_root = tmp.path().to_path_buf();
+        let expected_workspace = repo_root.display().to_string();
+        // Fail unless invoked with the exact `tokens check --ranking
+        // --workspace <repo_root>` argv, proving the runner passes the
+        // arguments the module docs promise (issue #4080).
+        let body = format!(
+            "[ \"$1\" = tokens ] && [ \"$2\" = check ] && [ \"$3\" = --ranking ] && \
+             [ \"$4\" = --workspace ] && [ \"$5\" = \"{expected_workspace}\" ] && exit 0 || exit 1"
         );
-        let mut runner =
-            ScriptRankingRefreshRunner::new(tmp.path().to_path_buf()).with_script_bin(script);
+        let bin = write_fake_bin(tmp.path(), "fake-daemon.sh", &body);
+        let mut runner = ScriptRankingRefreshRunner::new(repo_root).with_bin(bin);
         assert_eq!(runner.refresh(), RefreshOutcome::Success);
     }
 
     #[test]
-    fn test_refresh_times_out_on_hung_script() {
+    fn test_refresh_times_out_on_hung_bin() {
         let tmp = tempfile::tempdir().unwrap();
-        let script = write_fake_script(tmp.path(), "fake-probe.sh", "sleep 30");
+        let bin = write_fake_bin(tmp.path(), "fake-daemon.sh", "sleep 30");
         let mut runner = ScriptRankingRefreshRunner::new(tmp.path().to_path_buf())
-            .with_script_bin(script)
+            .with_bin(bin)
             .with_timeout(Duration::from_millis(300));
         let outcome = runner.refresh();
         let RefreshOutcome::Failure(reason) = outcome else {
@@ -661,11 +613,10 @@ mod tests {
     #[test]
     fn test_refresh_spawn_failure_is_reported() {
         let tmp = tempfile::tempdir().unwrap();
-        // A script path that does not exist and was never `.exists()`-checked
+        // A binary path that does not exist and was never `.exists()`-checked
         // because it's an explicit override — spawn itself must fail cleanly.
         let bogus = tmp.path().join("does-not-exist.sh");
-        let mut runner =
-            ScriptRankingRefreshRunner::new(tmp.path().to_path_buf()).with_script_bin(bogus);
+        let mut runner = ScriptRankingRefreshRunner::new(tmp.path().to_path_buf()).with_bin(bogus);
         let outcome = runner.refresh();
         assert!(!outcome.is_success());
     }

--- a/loom-daemon/src/tokens_pool/mod.rs
+++ b/loom-daemon/src/tokens_pool/mod.rs
@@ -3,10 +3,16 @@
 //!
 //! # Scope of this phase
 //!
-//! This is a **pure addition** — nothing in the repo calls into this module
-//! yet (`spawn-claude.sh`, `probe-tokens.sh`, and the daemon's own
-//! [`crate::token_ranking_refresh`] / [`crate::tokens`] remain on the Python
-//! path). The caller cutover is epic #4081 Phase 2.
+//! Phase 1 (issue #4082) was a **pure addition** with no caller cutover. Phase
+//! 2 (issue #4080, epic #4081) cut the check/probe path over: `loom-daemon
+//! tokens check` (issue #4108, this module's [`check`]) is invoked by
+//! `defaults/scripts/probe-tokens.sh` (native-binary resolution, `python3 -m`
+//! fallback removed), the daemon's own
+//! [`crate::token_ranking_refresh::ScriptRankingRefreshRunner`] (via
+//! `std::env::current_exe()`), and `loom-daemon status`'s
+//! `collect_token_usage()` (in-process). `spawn-claude.sh` (token *selection*,
+//! [`select`]) remains on the Python path — that cutover is a separate,
+//! file-disjoint follow-up.
 //!
 //! Ported in this phase — the concurrency-critical "hot path" every sweep
 //! dispatch exercises, plus the operator-facing bookkeeping CLI:


### PR DESCRIPTION
## Summary

Epic #4081 Phase 2, check-path slice. Cuts three call sites over to the native `loom-daemon tokens check` subcommand (PR #4108, commit 51389917) and removes the Python `python3 -m` fallback tier entirely.

- **`defaults/scripts/probe-tokens.sh`** — replaced the `loom-tokens` / `python3 -m` resolution tiers with daemon-binary resolution: `$LOOM_DAEMON_BIN` → `loom-daemon` on PATH → build-output-relative candidates (extracted to a new shared helper, `defaults/scripts/lib/locate-daemon-bin.sh`, also usable by `loom-daemon-start.sh`/`loom-daemon-update.sh` in a future cleanup). Capability-probes the resolved binary with `tokens check --help` before committing to the native path (transitional-staleness guard for a host mid-roll), falls back to `loom-tokens` on PATH with a stderr warning when the binary is stale, and exits 1 with an actionable message when neither is available. Script name, flags, and exit codes are unchanged.
- **`loom-daemon/src/token_ranking_refresh.rs`** — `ScriptRankingRefreshRunner` now invokes `std::env::current_exe()` with `tokens check --ranking --workspace <repo_root>` instead of resolving and spawning `probe-tokens.sh`. This sidesteps the staleness hazard entirely (the running daemon by construction supports its own subcommands) and drops a process layer (daemon → bash → daemon). Timeout/kill supervision machinery is unchanged. The `script_bin` test override was migrated to `bin`; the script-resolution tests (which no longer apply) were replaced with tests asserting the exact `tokens check --ranking --workspace <root>` argv, plus a non-zero-exit case and a timeout-kill case (both already existed, now bin-based).
- **`loom-daemon/src/main.rs`** — `collect_token_usage()` (used by `loom-daemon status`) now calls `check::run_check()` in-process instead of shelling out twice, mirroring `TokensAction::Check`'s handler with `write_ranking: false`. `print_token_usage_table()` is unchanged (JSON shape is identical).
- **Docs** — updated `.loom/docs/token-pool.md`, `.loom/docs/daemon-reference.md`, and the relevant doc comments in `main.rs`/`tokens_pool/mod.rs` to describe the native invocation path.

## Scope guards honored

- `spawn-claude.sh` / `claude-wrapper.sh` untouched (separate, file-disjoint issues).
- No changes to `loom-tools/` Python code — the conformance suite passes unmodified.
- No new crates.
- `.loom/scripts/probe-tokens.sh` (the installed, untracked copy generated from `defaults/`) is not part of this PR, per the issue's note — operators pick up the change via `resync-installed.sh`.

## Test plan

- [x] `cd loom-daemon && cargo test token_ranking_refresh` — 21 passed, including the new argv-assertion, non-zero-exit, and timeout-kill cases.
- [x] `cargo test --lib -p loom-daemon` — 1246 passed, 0 failed.
- [x] `cargo clippy --package loom-daemon -- -D warnings <CI allow-list>` — clean.
- [x] `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -q` — 344 passed (Python side untouched).
- [x] `git grep -n "loom_tools" -- defaults/scripts/probe-tokens.sh loom-daemon/src/` — only select-path references remain (`main.rs:339`'s `Select` doc, `token_ranking_refresh.rs:7`'s module doc referencing `tokens.select`), as called out as out-of-scope by the acceptance criteria.
- [x] Manual: `LOOM_DAEMON_BIN=<release bin> probe-tokens.sh --json` — succeeds via the native path, emits `{ranked_at, accounts[]}`.
- [x] Manual: consumer-repo simulation (`env -u PYTHONPATH PATH="/tmp/bin-only:/usr/bin:/bin" probe-tokens.sh --json` with only `loom-daemon` on PATH, no loom checkout, no `loom-tokens`, no `python3` module) — succeeds.
- [x] Manual: stale-binary fallback (`LOOM_DAEMON_BIN` pointed at a stub that fails `tokens check --help`) — warns to stderr and falls back to `loom-tokens` on PATH.
- [x] Manual: no daemon binary + no `loom-tokens` on PATH — exits 1 with an actionable message naming `loom-daemon-start.sh` / `cargo build`.
- [ ] Not exercised in this sandbox: `cargo test -p loom-daemon` integration tests (`tests/integration_basic.rs`) fail in this environment on **unmodified `main`** too (`TestDaemon::start()` times out waiting for the socket) — confirmed pre-existing via `git stash`, unrelated to this change.

Closes #4080