### PR TITLE
feat(daemon): scheduled drain-and-restart primitive

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -113,6 +113,10 @@ issue** — the v0.10.0 set is intentionally frozen.
 | `epic.issue.{N}.join`      | Epic supervisor (#3842)        | `{epic, action, state}` |
 | `epic.issue.{N}.close`     | Epic supervisor (#3842)        | `{epic, action, state}` |
 | `daemon.capacity.advisory` | Work finder (#3902)            | `{pressured, queued, healthy_accounts, exhausted_accounts, total_accounts, estimated_drain_minutes?, message}` |
+| `daemon.drain.started`     | Drain supervisor (#4090)       | `{in_flight, timeout_secs, force_after_timeout, deadline}` |
+| `daemon.drain.completed`   | Drain supervisor (#4090)       | `{in_flight}` (always `0`) |
+| `daemon.drain.aborted`     | Daemon IPC (#4090)             | `{was_draining}` |
+| `daemon.drain.timeout`     | Drain supervisor (#4090)       | `{in_flight, forced, cancelled?}` |
 
 The four `epic.issue.{N}.*` topics were authorized by **#3873** (epic #3842
 Phase 4) and are documented in full under [Epic supervisor](#epic-supervisor-3842)
@@ -121,6 +125,12 @@ below. The `daemon.capacity.advisory` topic was authorized by **#3902** (epic
 state change** (entered/left the token-bound state), never every tick, so the
 operator gets one add-capacity advisory on the way in and one recovery on the way
 out. See [Token-capacity backpressure](#token-capacity-backpressure-3902) below.
+The four `daemon.drain.*` topics were authorized by **#4090** for the scheduled
+drain-and-restart primitive — `started` when a drain is accepted, `completed`
+when the last in-flight sweep finishes (right before the supervised relaunch),
+`aborted` when an operator cancels a drain, and `timeout` when the deadline is
+reached (`forced` distinguishes a refusal from a force-cancel restart). See
+[Supervised restart primitive](#supervised-restart-primitive-4054) below.
 They ride the same in-memory bus as the sweep topics and are tailable via
 `subscribe_to_events` / `tail_event_bus`.
 
@@ -1948,6 +1958,16 @@ the registry reconciles their state on the next start (`SweepRegistry::reconstru
 re-admits live-lock owners). To actively cancel a sweep, use
 `mcp__loom__cancel_sweep` against a running daemon *before* stopping it.
 
+> **Amended by #4090 (scheduled drain-and-restart).** The above describes the
+> *plain* stop/restart: sweeps survive the process boundary but the relaunched
+> daemon's in-memory registry starts empty, so a plain `RestartDaemon` leaves the
+> surviving children as **orphans** — invisible to `list_sweeps`, the concurrency
+> cap, the watchdog, and the reaper, and still holding `loom:building` for a
+> `claim_reconciliation` pass to re-dispatch as duplicates. When you want "finish
+> what you started, then roll" instead, use `loom-daemon restart --drain` (below):
+> it stops admitting new work and waits for the registry to empty before exiting,
+> so no sweep is killed and no orphan is left behind.
+
 **Exit code carries shutdown intent (#4054).** The daemon encodes *why* it is
 shutting down in its exit code, because the launchd `KeepAlive:{SuccessfulExit:true}`
 plist (below) relaunches only on a clean exit `0`: the `RestartDaemon` primitive
@@ -2267,6 +2287,47 @@ loom-daemon restart          # send RestartDaemon over the IPC socket
   the `exec` (Option 2) and detached-helper (Option 3) alternatives were rejected,
   and the Curator's exit-code-race finding — is in
   `docs/design/supervised-restart-primitive.md`.
+
+#### Scheduled drain-and-restart (`--drain`, #4090)
+
+A plain `loom-daemon restart` exits immediately: in-flight sweeps survive the
+process boundary but become **orphans** (absent from the relaunched daemon's
+in-memory registry — see the "sweeps survive, they are not drained" amendment
+above). `--drain` closes that gap by finishing in-flight work *before* rolling:
+
+```bash
+loom-daemon restart --drain                       # finish in-flight sweeps, then restart
+loom-daemon restart --drain --timeout 600         # bound the wait (default 1800s)
+loom-daemon restart --drain --force-after-timeout # at the deadline, cancel stragglers and restart anyway
+loom-daemon restart --abort-drain                 # cancel an in-progress drain, resume dispatch (no restart)
+```
+
+- **What a drain does:** it sets a daemon-global drain flag that is OR'd into the
+  same halt checks the main-health gate uses (#3812) — the work finder stops
+  dispatching, the epic supervisor stops scheduling phases, and (newly, #4090) the
+  role runner stops **starting** new role ticks. Already-running work is left
+  alone. A supervisor task then polls the cross-root in-flight sweep count (every
+  managed workspace, not just the primary) and exits `EXIT_RESTART` for the launchd
+  relaunch only once it reaches **zero** — so `list_sweeps` after the relaunch is
+  consistent with reality and there are **no orphans**.
+- **Fail-safe timeout:** reaching `--timeout` without `--force-after-timeout`
+  **refuses** the restart (clears the drain flag, resumes dispatch, stays up) and
+  reports the reason via `loom-daemon status` — it never silently restarts or
+  silently gives up. `--force-after-timeout` opts into cancelling the stragglers
+  via the existing `cancel_sweep` path, then restarts.
+- **Supervision proof is checked up front (AC5):** on an unsupervised host the
+  request is refused **before** dispatch is paused (`accepted: false`), so a caller
+  can detect nothing happened and no silent outage is introduced.
+- **Residual (documented, bounded):** role ticks have no sweep-registry entry to
+  poll, so a drain stops them *starting* but cannot *await* one already running —
+  a drain can complete while a role tick is still mid-flight, bounded by the role
+  timeout (`DEFAULT_ROLE_TIMEOUT`, 1800s). Awaiting role ticks is deliberately out
+  of scope (it would require a role registry, #4090's stop-and-split boundary).
+- **Observability:** `loom-daemon status` renders `DRAINING (n sweep(s) remaining,
+  deadline …)` while active and the last transition (timeout refusal / abort)
+  afterward; the four `daemon.drain.*` events (above) narrate the transitions on
+  the event bus. **Cannot be used for its own first roll** — see the rollout note
+  below.
 
 ### Self-update (rebuild + provision + restart, #3968)
 

--- a/loom-daemon/src/epic_supervisor.rs
+++ b/loom-daemon/src/epic_supervisor.rs
@@ -473,6 +473,11 @@ pub struct EpicSupervisor<S: EpicSource, D: EpicDispatcher> {
     /// **nothing** — a red `main` stops epic-child dispatch too (#3885). Absent
     /// (the default / test path) means the supervisor is never gated.
     health_state: Option<Arc<MainHealthState>>,
+    /// Optional daemon-global drain flag (#4090) shared with the work-finder and
+    /// role-runner. When set, [`tick`](Self::tick) dispatches **nothing** — a
+    /// scheduled drain pauses new epic-child dispatch just like a red `main`.
+    /// Absent (the default / test path) means the supervisor is never drained.
+    drain_flag: Option<Arc<AtomicBool>>,
 }
 
 impl<S: EpicSource, D: EpicDispatcher> EpicSupervisor<S, D> {
@@ -489,6 +494,7 @@ impl<S: EpicSource, D: EpicDispatcher> EpicSupervisor<S, D> {
             inflight_ttl: resolve_inflight_ttl(),
             bus: None,
             health_state: None,
+            drain_flag: None,
         }
     }
 
@@ -505,6 +511,15 @@ impl<S: EpicSource, D: EpicDispatcher> EpicSupervisor<S, D> {
     #[must_use]
     pub fn with_health_gate(mut self, health_state: Arc<MainHealthState>) -> Self {
         self.health_state = Some(health_state);
+        self
+    }
+
+    /// Attach the daemon-global drain flag (#4090) so that while a scheduled
+    /// drain is in progress the supervisor dispatches nothing. Builder-style;
+    /// returns `self`.
+    #[must_use]
+    pub fn with_drain_flag(mut self, drain_flag: Arc<AtomicBool>) -> Self {
+        self.drain_flag = Some(drain_flag);
         self
     }
 
@@ -529,9 +544,21 @@ impl<S: EpicSource, D: EpicDispatcher> EpicSupervisor<S, D> {
         // Existing in-flight sweeps are untouched (halting only stops making a
         // red `main` worse); a green run clears the flag and the next tick
         // resumes normally.
-        if self.health_state.as_ref().is_some_and(|s| s.is_halted()) {
+        let health_halted = self.health_state.as_ref().is_some_and(|s| s.is_halted());
+        // Scheduled drain (#4090): a daemon-global drain pauses new epic-child
+        // dispatch exactly like a red `main`, so it is OR'd into the same gate.
+        let drained = self
+            .drain_flag
+            .as_ref()
+            .is_some_and(|f| f.load(Ordering::Relaxed));
+        if health_halted || drained {
             log::warn!(
-                "epic_supervisor: main-health gate halted — skipping tick (no epic dispatch while main is red)"
+                "epic_supervisor: {} — skipping tick (no epic dispatch)",
+                if drained {
+                    "drain in progress"
+                } else {
+                    "main-health gate halted (main is red)"
+                }
             );
             return Ok(TickReport {
                 halted: true,
@@ -1010,6 +1037,7 @@ pub fn spawn_multi_supervisor_thread(
     event_bus: Arc<EventBus>,
     health_states: Arc<WorkspaceHealthStates>,
     interval: Duration,
+    drain_flag: Arc<AtomicBool>,
 ) -> Result<SupervisorHandle> {
     let shutdown = Arc::new(AtomicBool::new(false));
     let shutdown_thread = shutdown.clone();
@@ -1078,7 +1106,8 @@ pub fn spawn_multi_supervisor_thread(
                             let supervisor =
                                 EpicSupervisor::new(source, dispatcher, IssueCreationMutex::new())
                                     .with_event_bus(event_bus.clone())
-                                    .with_health_gate(health_states.get_or_create(root));
+                                    .with_health_gate(health_states.get_or_create(root))
+                                    .with_drain_flag(drain_flag.clone());
                             roots.push(root.clone());
                             supervisors.push(supervisor);
                             log::info!("epic_supervisor: watching workspace {}", root.display());
@@ -1672,6 +1701,27 @@ mod tests {
         assert!(!r2.halted);
         assert_eq!(r2.roles_dispatched, 1);
         assert_eq!(sup.dispatcher.roles.len(), 1);
+    }
+
+    /// A scheduled drain (#4090) halts epic dispatch exactly like a red `main`
+    /// (AC1): with the drain flag set, the tick dispatches nothing; clearing it
+    /// resumes normal dispatch. Mirrors the main-health halt tests above.
+    #[tokio::test]
+    async fn test_tick_skips_dispatch_while_draining() {
+        let drain = Arc::new(AtomicBool::new(true));
+        let mut sup = supervisor(vec![EpicSnapshot::new(1, "flat body", vec![], vec![])])
+            .with_drain_flag(drain.clone());
+
+        let report = sup.tick().await.unwrap();
+        assert!(report.halted, "a drain halts the tick");
+        assert_eq!(report.roles_dispatched, 0);
+        assert!(sup.dispatcher.roles.is_empty(), "no epic dispatch while draining");
+
+        // Clear the drain ⇒ the next tick dispatches normally.
+        drain.store(false, Ordering::Relaxed);
+        let r2 = sup.tick().await.unwrap();
+        assert!(!r2.halted);
+        assert_eq!(r2.roles_dispatched, 1);
     }
 
     #[tokio::test]

--- a/loom-daemon/src/event_bus.rs
+++ b/loom-daemon/src/event_bus.rs
@@ -32,6 +32,10 @@
 //! | `epic.issue.{N}.join`      | Epic supervisor | `{epic, action, state}` |
 //! | `epic.issue.{N}.close`     | Epic supervisor | `{epic, action, state}` |
 //! | `daemon.capacity.advisory` | Work finder | `{pressured, queued, healthy_accounts, exhausted_accounts, total_accounts, estimated_drain_minutes?, message}` |
+//! | `daemon.drain.started`   | Drain supervisor | `{in_flight, timeout_secs, force_after_timeout, deadline}` |
+//! | `daemon.drain.completed` | Drain supervisor | `{in_flight}` (always 0) |
+//! | `daemon.drain.aborted`   | Daemon (IPC) | `{was_draining}` |
+//! | `daemon.drain.timeout`   | Drain supervisor | `{in_flight, forced, cancelled?}` |
 //!
 //! New topics require a follow-up issue — the taxonomy is intentionally
 //! pinned. The four `epic.issue.{N}.*` topics were authorized by **#3873**
@@ -39,6 +43,8 @@
 //! (decompose / expand / join / close). The `daemon.capacity.advisory` topic
 //! was authorized by **#3902** (epic #3809) for the work finder's
 //! token-capacity backpressure advisory (fired on pressure state change). The
+//! four `daemon.drain.*` topics were authorized by **#4090** for the scheduled
+//! drain-and-restart primitive (started / completed / aborted / timeout). The
 //! bus accepts arbitrary topic
 //! strings (`publish` does not reject unknown topics) so the publisher side
 //! stays open for future extension, but the documented taxonomy is the

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -14,6 +14,7 @@ use anyhow::Result;
 use chrono::Utc;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::fs;
@@ -113,6 +114,436 @@ pub fn build_restart_decision() -> (Response, bool) {
             },
             false,
         ),
+    }
+}
+
+// ============================================================================
+// Scheduled drain-and-restart (Issue #4090)
+// ============================================================================
+
+/// Default bound on how long a drain waits for the sweep registry to empty
+/// before it either refuses (fail-safe) or force-cancels the stragglers. A
+/// sweep is ~10–20 min, so the default is generous.
+pub const DEFAULT_DRAIN_TIMEOUT_SECS: u64 = 1800;
+
+/// How often the drain supervisor re-counts the cross-root in-flight sweeps.
+/// Small enough that a drain that finishes exits promptly; the zero-in-flight
+/// case is handled on the very first poll (no full-interval wait).
+pub const DRAIN_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Shared drain-and-restart coordination state (Issue #4090).
+///
+/// Owns the daemon-global drain flag OR'd into the producers' halt checks (work
+/// finder, epic supervisor, role runner) and the descriptor the `DaemonStatus`
+/// snapshot renders. Exactly one drain-supervisor task may be live at a time; a
+/// monotonic `generation` lets a running supervisor detect it has been
+/// superseded (a fresh drain) or aborted, and stop **without** exiting the
+/// process.
+#[derive(Debug)]
+pub struct DrainState {
+    /// The flag consulted by the dispatch producers. `true` ⇒ new dispatch is
+    /// paused pending a supervised restart. Cloned out to each producer via
+    /// [`Self::flag`].
+    flag: Arc<AtomicBool>,
+    /// Bumped on every accepted drain start AND on abort/timeout-resume, so a
+    /// running drain-supervisor task can tell it is still the current one.
+    generation: AtomicU64,
+    /// Mutable descriptor of the active/last drain, for status rendering.
+    inner: Mutex<DrainDescriptor>,
+}
+
+/// The rendered view of the current (or most recent) drain (Issue #4090).
+#[derive(Debug, Default, Clone)]
+pub struct DrainDescriptor {
+    /// Whether a drain is currently in progress.
+    pub active: bool,
+    /// Deadline after which the drain gives up waiting.
+    pub deadline: Option<chrono::DateTime<Utc>>,
+    /// Whether the deadline path force-cancels stragglers (vs. refusing).
+    pub force_after_timeout: bool,
+    /// A short human-readable note about the last transition (timeout refusal,
+    /// abort) surfaced in `loom-daemon status`.
+    pub note: Option<String>,
+}
+
+/// Outcome of [`DrainState::begin`].
+#[derive(Debug)]
+pub enum DrainBegin {
+    /// A new drain was started; the caller must spawn the supervisor task with
+    /// this generation.
+    Started {
+        generation: u64,
+        deadline: chrono::DateTime<Utc>,
+    },
+    /// A drain was already in progress; the request is an idempotent ack and no
+    /// second supervisor should be spawned (the deadline/generation are
+    /// unchanged).
+    AlreadyDraining,
+}
+
+impl Default for DrainState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// Allow expect_used: a poisoned drain mutex means another thread panicked while
+// holding it — unrecoverable, same crash-on-poison policy as the rest of ipc.rs.
+#[allow(clippy::expect_used)]
+impl DrainState {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            flag: Arc::new(AtomicBool::new(false)),
+            generation: AtomicU64::new(0),
+            inner: Mutex::new(DrainDescriptor::default()),
+        }
+    }
+
+    /// A clone of the drain flag to hand to a dispatch producer.
+    #[must_use]
+    pub fn flag(&self) -> Arc<AtomicBool> {
+        self.flag.clone()
+    }
+
+    /// Whether new dispatch is currently paused for a drain.
+    #[must_use]
+    pub fn is_draining(&self) -> bool {
+        self.flag.load(Ordering::Relaxed)
+    }
+
+    /// The current generation — the token a supervisor compares against to
+    /// detect it has been superseded/aborted.
+    #[must_use]
+    pub fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Relaxed)
+    }
+
+    /// A snapshot of the descriptor for status rendering.
+    #[must_use]
+    pub fn snapshot(&self) -> DrainDescriptor {
+        self.inner.lock().expect("Drain mutex poisoned").clone()
+    }
+
+    /// Start a drain, or ack an already-running one (idempotent — a second drain
+    /// request while DRAINING neither stacks a supervisor nor moves the
+    /// deadline). Sets the drain flag on a fresh start.
+    pub fn begin(&self, timeout: Duration, force_after_timeout: bool) -> DrainBegin {
+        let mut inner = self.inner.lock().expect("Drain mutex poisoned");
+        if inner.active {
+            return DrainBegin::AlreadyDraining;
+        }
+        let deadline = Utc::now()
+            + chrono::Duration::from_std(timeout).unwrap_or_else(|_| chrono::Duration::seconds(0));
+        inner.active = true;
+        inner.deadline = Some(deadline);
+        inner.force_after_timeout = force_after_timeout;
+        inner.note = None;
+        // Set the flag while holding the descriptor lock so status can never
+        // observe `flag=true` with `active=false`.
+        self.flag.store(true, Ordering::Relaxed);
+        let generation = self.generation.fetch_add(1, Ordering::Relaxed) + 1;
+        DrainBegin::Started {
+            generation,
+            deadline,
+        }
+    }
+
+    /// Abort an in-progress drain: clear the flag, bump the generation (so the
+    /// running supervisor stops without exiting), and record a note. Returns
+    /// `true` when a drain was actually in progress.
+    pub fn abort(&self) -> bool {
+        let mut inner = self.inner.lock().expect("Drain mutex poisoned");
+        if !inner.active {
+            return false;
+        }
+        self.flag.store(false, Ordering::Relaxed);
+        self.generation.fetch_add(1, Ordering::Relaxed);
+        inner.active = false;
+        inner.deadline = None;
+        inner.note = Some("drain aborted by operator — dispatch resumed".to_string());
+        true
+    }
+
+    /// The supervisor's fail-safe timeout path: clear the flag, bump the
+    /// generation, and record the refusal note so status explains why the
+    /// daemon stayed up.
+    fn resolve_timeout(&self, note: String) {
+        let mut inner = self.inner.lock().expect("Drain mutex poisoned");
+        self.flag.store(false, Ordering::Relaxed);
+        self.generation.fetch_add(1, Ordering::Relaxed);
+        inner.active = false;
+        inner.deadline = None;
+        inner.note = Some(note);
+    }
+}
+
+/// The three terminal/continue decisions a drain-supervisor poll can reach
+/// (Issue #4090). Extracted as a pure function so the "2 → 1 → 0" and
+/// timeout-vs-force logic is unit-testable without spawning a task or calling
+/// `std::process::exit`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum DrainTick {
+    /// Sweeps still in flight and the deadline has not passed — keep waiting.
+    Continue,
+    /// Zero in-flight — restart now (exit `EXIT_RESTART`).
+    Complete,
+    /// Deadline passed with sweeps still in flight and no force — refuse the
+    /// restart, resume dispatch, stay up.
+    TimedOutRefuse,
+    /// Deadline passed with sweeps still in flight and `--force-after-timeout` —
+    /// cancel the stragglers, then restart.
+    TimedOutForce,
+}
+
+/// Decide a single drain-supervisor poll (Issue #4090). Zero in-flight always
+/// wins (even at/after the deadline: everything drained, so restart), otherwise
+/// a passed deadline is refused (fail-safe) or forced.
+#[must_use]
+pub fn evaluate_drain_tick(in_flight: usize, past_deadline: bool, force: bool) -> DrainTick {
+    if in_flight == 0 {
+        DrainTick::Complete
+    } else if past_deadline {
+        if force {
+            DrainTick::TimedOutForce
+        } else {
+            DrainTick::TimedOutRefuse
+        }
+    } else {
+        DrainTick::Continue
+    }
+}
+
+/// Count non-terminal (`Pending` / `Running`) sweeps across **every** managed
+/// root (Issue #4090, Finding 5). Mirrors [`build_daemon_status`]'s cross-root
+/// accounting so a drain never reads only the primary registry and restarts
+/// while a secondary managed repo still has live sweeps.
+// Allow expect_used: poisoned registry mutex ⇒ crash, same policy as elsewhere.
+#[allow(clippy::expect_used)]
+#[must_use]
+pub fn count_in_flight_sweeps(workspace_pool: &Arc<WorkspacePool>, fallback_root: &Path) -> usize {
+    let workspace_registry = WorkspaceRegistry::load_default().unwrap_or_default();
+    let roots = workspace_registry.effective_roots(fallback_root);
+    let mut count = 0;
+    for root in &roots {
+        let registry = workspace_pool.get_or_provision(root);
+        let sr = registry.lock().expect("Sweep registry mutex poisoned");
+        count += sr
+            .list(None)
+            .into_iter()
+            .filter(|info| !info.state.is_terminal())
+            .count();
+    }
+    count
+}
+
+/// Cancel every in-flight sweep across all managed roots via the existing
+/// [`SweepRegistry::cancel`] path (Issue #4090, `--force-after-timeout`).
+/// Returns the number cancelled. Blocking cancel is acceptable here: this runs
+/// only on the rare force-timeout path, moments before the process exits.
+// Allow expect_used: poisoned registry mutex ⇒ crash, same policy as elsewhere.
+#[allow(clippy::expect_used)]
+fn cancel_all_in_flight(workspace_pool: &Arc<WorkspacePool>, fallback_root: &Path) -> usize {
+    let workspace_registry = WorkspaceRegistry::load_default().unwrap_or_default();
+    let roots = workspace_registry.effective_roots(fallback_root);
+    let mut cancelled = 0;
+    for root in &roots {
+        let registry = workspace_pool.get_or_provision(root);
+        let ids: Vec<String> = {
+            let sr = registry.lock().expect("Sweep registry mutex poisoned");
+            sr.list(None)
+                .into_iter()
+                .filter(|info| !info.state.is_terminal())
+                .map(|info| info.sweep_id)
+                .collect()
+        };
+        for id in ids {
+            let mut sr = registry.lock().expect("Sweep registry mutex poisoned");
+            if sr.cancel(&id, Duration::from_secs(5)).is_ok() {
+                cancelled += 1;
+            }
+        }
+    }
+    cancelled
+}
+
+/// Handle a `DrainAndRestartDaemon` request (Issue #4090): check supervision up
+/// front (AC5 — refuse *before* pausing dispatch), then start the drain and
+/// spawn its supervisor task. Returns the `DaemonDrain` response to send back.
+///
+/// Must be called from within a tokio runtime context (the connection handler
+/// is) so it can spawn the supervisor.
+fn handle_drain_request(
+    drain: &Arc<DrainState>,
+    workspace_pool: &Arc<WorkspacePool>,
+    fallback_root: &Path,
+    event_bus: &Arc<EventBus>,
+    timeout_secs: Option<u64>,
+    force_after_timeout: bool,
+) -> Response {
+    // AC5 / Finding 4: prove supervision BEFORE entering DRAINING. Draining for
+    // 20 minutes and only then discovering there is no supervisor to relaunch
+    // into is the worst possible ordering — and pausing dispatch then refusing
+    // would be a silent outage.
+    let supervisor = match detect_supervisor() {
+        Some(s) => s,
+        None => {
+            return Response::DaemonDrain {
+                accepted: false,
+                supervisor: None,
+                in_flight: count_in_flight_sweeps(workspace_pool, fallback_root),
+                message: "refusing to drain: no supervisor detected \
+                    (LOOM_DAEMON_SUPERVISOR unset). This daemon was not started under \
+                    launchd, so nothing would relaunch it after a drain. Dispatch was \
+                    NOT paused. Restart manually with loom-daemon-stop.sh && \
+                    loom-daemon-start.sh."
+                    .to_string(),
+            };
+        }
+    };
+
+    let in_flight = count_in_flight_sweeps(workspace_pool, fallback_root);
+    let timeout = Duration::from_secs(timeout_secs.unwrap_or(DEFAULT_DRAIN_TIMEOUT_SECS));
+
+    match drain.begin(timeout, force_after_timeout) {
+        DrainBegin::Started {
+            generation,
+            deadline,
+        } => {
+            let _ = event_bus.publish_generic(
+                "daemon.drain.started",
+                serde_json::json!({
+                    "in_flight": in_flight,
+                    "timeout_secs": timeout.as_secs(),
+                    "force_after_timeout": force_after_timeout,
+                    "deadline": deadline,
+                }),
+            );
+            let drain_task = drain.clone();
+            let pool_task = workspace_pool.clone();
+            let root_task = fallback_root.to_path_buf();
+            let bus_task = event_bus.clone();
+            tokio::spawn(async move {
+                run_drain_supervisor(
+                    drain_task,
+                    pool_task,
+                    root_task,
+                    bus_task,
+                    generation,
+                    DRAIN_POLL_INTERVAL,
+                )
+                .await;
+            });
+            let msg = if in_flight == 0 {
+                format!("drain scheduled ({supervisor}-supervised): 0 in-flight — restarting now.")
+            } else {
+                format!(
+                    "drain scheduled ({supervisor}-supervised): {in_flight} in-flight sweep(s); \
+                     new dispatch paused. Will restart when drained, or {} at the deadline.",
+                    if force_after_timeout {
+                        "cancel stragglers and restart"
+                    } else {
+                        "refuse and resume dispatch"
+                    }
+                )
+            };
+            Response::DaemonDrain {
+                accepted: true,
+                supervisor: Some(supervisor),
+                in_flight,
+                message: msg,
+            }
+        }
+        DrainBegin::AlreadyDraining => Response::DaemonDrain {
+            accepted: true,
+            supervisor: Some(supervisor),
+            in_flight,
+            message: format!(
+                "already draining (idempotent): {in_flight} in-flight sweep(s); the existing \
+                 deadline is unchanged. Use `loom-daemon restart --abort-drain` to cancel."
+            ),
+        },
+    }
+}
+
+/// The drain-supervisor loop (Issue #4090). Polls the cross-root in-flight count
+/// and owns the eventual `std::process::exit(EXIT_RESTART)`; on a fail-safe
+/// timeout it clears the drain flag and stays up. Stops without exiting if it
+/// has been superseded (a new drain) or aborted (generation moved on).
+async fn run_drain_supervisor(
+    drain: Arc<DrainState>,
+    workspace_pool: Arc<WorkspacePool>,
+    fallback_root: PathBuf,
+    event_bus: Arc<EventBus>,
+    my_generation: u64,
+    poll_interval: Duration,
+) {
+    loop {
+        // Superseded / aborted: a newer drain or an abort bumped the generation,
+        // so this supervisor is stale — stop WITHOUT ending the process. This is
+        // the "abort then the queue empties anyway" guard (AC6): a stale
+        // supervisor must never fire a restart.
+        if drain.generation() != my_generation {
+            log::info!(
+                "drain supervisor (gen {my_generation}) superseded/aborted (current gen {}) — \
+                 stopping without restart",
+                drain.generation()
+            );
+            return;
+        }
+
+        let in_flight = count_in_flight_sweeps(&workspace_pool, &fallback_root);
+        let (past_deadline, force) = {
+            let snap = drain.snapshot();
+            let past = snap.deadline.is_some_and(|d| Utc::now() >= d);
+            (past, snap.force_after_timeout)
+        };
+
+        match evaluate_drain_tick(in_flight, past_deadline, force) {
+            DrainTick::Continue => {
+                tokio::time::sleep(poll_interval).await;
+            }
+            DrainTick::Complete => {
+                let _ = event_bus.publish_generic(
+                    "daemon.drain.completed",
+                    serde_json::json!({ "in_flight": 0 }),
+                );
+                log::warn!(
+                    "drain complete — 0 in-flight sweeps; exiting {EXIT_RESTART} for a launchd \
+                     KeepAlive:SuccessfulExit relaunch. No sweep was killed; no orphan left behind."
+                );
+                std::process::exit(EXIT_RESTART);
+            }
+            DrainTick::TimedOutRefuse => {
+                let note = format!(
+                    "drain timed out with {in_flight} sweep(s) still in flight — refused restart \
+                     (no --force-after-timeout); dispatch resumed, daemon stays up"
+                );
+                let _ = event_bus.publish_generic(
+                    "daemon.drain.timeout",
+                    serde_json::json!({ "in_flight": in_flight, "forced": false }),
+                );
+                log::warn!("{note}");
+                drain.resolve_timeout(note);
+                return;
+            }
+            DrainTick::TimedOutForce => {
+                let cancelled = cancel_all_in_flight(&workspace_pool, &fallback_root);
+                let _ = event_bus.publish_generic(
+                    "daemon.drain.timeout",
+                    serde_json::json!({
+                        "in_flight": in_flight,
+                        "forced": true,
+                        "cancelled": cancelled,
+                    }),
+                );
+                log::warn!(
+                    "drain timed out with {in_flight} in-flight; --force-after-timeout cancelled \
+                     {cancelled} sweep(s); exiting {EXIT_RESTART} for a supervised relaunch"
+                );
+                std::process::exit(EXIT_RESTART);
+            }
+        }
     }
 }
 
@@ -216,6 +647,10 @@ pub struct IpcServer {
     /// and threaded in read-only so `DaemonStatus` can report it without a
     /// re-probe on every status query.
     credential_preflight: Arc<CredentialPreflightReport>,
+    /// Shared drain-and-restart coordination state (#4090). The same `Arc` whose
+    /// flag is OR'd into the dispatch producers' halt checks; the IPC handler
+    /// sets/aborts it and the `DaemonStatus` snapshot renders it.
+    drain_state: Arc<DrainState>,
 }
 
 impl IpcServer {
@@ -230,6 +665,7 @@ impl IpcServer {
         workspace_pool: Arc<WorkspacePool>,
         fallback_root: PathBuf,
         credential_preflight: CredentialPreflightReport,
+        drain_state: Arc<DrainState>,
     ) -> Self {
         Self {
             socket_path,
@@ -241,6 +677,7 @@ impl IpcServer {
             workspace_pool,
             fallback_root,
             credential_preflight: Arc::new(credential_preflight),
+            drain_state,
         }
     }
 
@@ -278,6 +715,7 @@ impl IpcServer {
                     let pool = self.workspace_pool.clone();
                     let fallback = self.fallback_root.clone();
                     let credential_preflight = self.credential_preflight.clone();
+                    let drain = self.drain_state.clone();
                     tokio::spawn(async move {
                         if let Err(e) = handle_client(
                             stream,
@@ -289,6 +727,7 @@ impl IpcServer {
                             pool,
                             fallback,
                             credential_preflight,
+                            drain,
                         )
                         .await
                         {
@@ -315,6 +754,7 @@ async fn handle_client(
     workspace_pool: Arc<WorkspacePool>,
     fallback_root: PathBuf,
     credential_preflight: Arc<CredentialPreflightReport>,
+    drain_state: Arc<DrainState>,
 ) -> Result<()> {
     let (reader, mut writer) = stream.into_split();
     let mut lines = BufReader::new(reader).lines();
@@ -387,13 +827,64 @@ async fn handle_client(
             // (within the TTL) makes this a no-op. `spawn_blocking` join errors
             // are non-fatal — the status falls back to the last cached value.
             let _ = tokio::task::spawn_blocking(crate::cpu_headroom::refresh_cpu_util_cache).await;
-            let report = build_daemon_status(
+            let report = build_daemon_status_with_drain(
                 &workspace_pool,
                 &health_states,
                 &fallback_root,
                 &credential_preflight,
+                &drain_state,
             );
             let response = Response::DaemonStatus(report);
+            let response_json = serde_json::to_string(&response)?;
+            writer.write_all(response_json.as_bytes()).await?;
+            writer.write_all(b"\n").await?;
+            continue;
+        }
+
+        // DrainAndRestartDaemon / AbortDrain (Issue #4090). Handled here — like
+        // RestartDaemon — because the drain must ack immediately and then exit
+        // *minutes* later from a background supervisor task, which the inline
+        // per-connection handler cannot do. The supervisor is spawned inside
+        // `handle_drain_request`; this handler just acks and moves on.
+        if let Request::DrainAndRestartDaemon {
+            timeout_secs,
+            force_after_timeout,
+        } = request
+        {
+            let response = handle_drain_request(
+                &drain_state,
+                &workspace_pool,
+                &fallback_root,
+                &event_bus,
+                timeout_secs,
+                force_after_timeout,
+            );
+            let response_json = serde_json::to_string(&response)?;
+            writer.write_all(response_json.as_bytes()).await?;
+            writer.write_all(b"\n").await?;
+            writer.flush().await?;
+            continue;
+        }
+
+        if let Request::AbortDrain = request {
+            let was_draining = drain_state.abort();
+            let _ = event_bus.publish_generic(
+                "daemon.drain.aborted",
+                serde_json::json!({ "was_draining": was_draining }),
+            );
+            let message = if was_draining {
+                "drain aborted — dispatch resumed; no restart will fire (even if in-flight \
+                 later reaches zero)."
+                    .to_string()
+            } else {
+                "no drain in progress — nothing to abort (no-op).".to_string()
+            };
+            let response = Response::DaemonDrain {
+                accepted: was_draining,
+                supervisor: detect_supervisor(),
+                in_flight: count_in_flight_sweeps(&workspace_pool, &fallback_root),
+                message,
+            };
             let response_json = serde_json::to_string(&response)?;
             writer.write_all(response_json.as_bytes()).await?;
             writer.write_all(b"\n").await?;
@@ -752,7 +1243,35 @@ pub fn build_daemon_status(
         // Resolved once at daemon startup (#4005), threaded in read-only —
         // never re-probed per status query.
         credential_preflight: Some(credential_preflight.clone()),
+        // Drain fields default to "not draining" here; the drain-aware wrapper
+        // [`build_daemon_status_with_drain`] overlays live drain state (#4090).
+        // Keeping the base builder drain-agnostic preserves its many existing
+        // unit-test call sites unchanged.
+        draining: false,
+        drain_deadline: None,
+        drain_note: None,
     }
+}
+
+/// Like [`build_daemon_status`] but overlays the live drain-and-restart state
+/// (Issue #4090) so `loom-daemon status` can surface `DRAINING (n remaining,
+/// deadline …)`. The IPC `DaemonStatus` handler calls this; the base builder
+/// stays drain-agnostic for its existing tests.
+#[must_use]
+pub fn build_daemon_status_with_drain(
+    workspace_pool: &Arc<WorkspacePool>,
+    health_states: &WorkspaceHealthStates,
+    fallback_root: &Path,
+    credential_preflight: &CredentialPreflightReport,
+    drain: &DrainState,
+) -> DaemonStatusReport {
+    let mut report =
+        build_daemon_status(workspace_pool, health_states, fallback_root, credential_preflight);
+    let snap = drain.snapshot();
+    report.draining = drain.is_draining();
+    report.drain_deadline = snap.deadline;
+    report.drain_note = snap.note;
+    report
 }
 
 // Allow expect_used because mutex poisoning is a panic-level error that indicates
@@ -1595,6 +2114,17 @@ fn handle_request(
             // caller — do NOT exit here, only `handle_client` may end the
             // process for a supervised relaunch.
             build_restart_decision().0
+        }
+        Request::DrainAndRestartDaemon { .. } | Request::AbortDrain => {
+            // Structurally unreachable: `handle_client` intercepts both drain
+            // requests (#4090) before dispatching here, because a drain must ack
+            // immediately and exit from a background supervisor task minutes
+            // later — state the connection-scoped `handle_request` cannot own.
+            Response::Error {
+                message: "internal: drain requests must be handled by handle_client, not \
+                          handle_request"
+                    .to_string(),
+            }
         }
     }
 }
@@ -2889,6 +3419,9 @@ exit 0
                 health_gate_verdict_at: Some(chrono::Utc::now()),
             }],
             credential_preflight: Some(test_credential_preflight()),
+            draining: false,
+            drain_deadline: None,
+            drain_note: None,
         };
         let resp = Response::DaemonStatus(report);
         let json = serde_json::to_string(&resp).expect("serialize response");
@@ -3622,5 +4155,337 @@ exit 0
         }
 
         std::env::remove_var(crate::watch_registry::WATCHES_PATH_ENV);
+    }
+
+    // ===== Scheduled drain-and-restart (Issue #4090) =====
+
+    /// The pure drain-decision function (AC2 / AC3): zero in-flight always
+    /// completes (restart), even at/after the deadline; a passed deadline with
+    /// sweeps still in flight refuses (fail-safe) or forces per the flag; before
+    /// the deadline it keeps waiting.
+    #[test]
+    fn test_evaluate_drain_tick_decisions() {
+        // Still in flight, deadline not reached ⇒ keep waiting.
+        assert_eq!(evaluate_drain_tick(2, false, false), DrainTick::Continue);
+        assert_eq!(evaluate_drain_tick(1, false, true), DrainTick::Continue);
+        // Zero in-flight ⇒ complete regardless of deadline/force.
+        assert_eq!(evaluate_drain_tick(0, false, false), DrainTick::Complete);
+        assert_eq!(evaluate_drain_tick(0, true, false), DrainTick::Complete);
+        assert_eq!(evaluate_drain_tick(0, true, true), DrainTick::Complete);
+        // Deadline passed with work left: refuse (fail-safe) vs. force.
+        assert_eq!(evaluate_drain_tick(3, true, false), DrainTick::TimedOutRefuse);
+        assert_eq!(evaluate_drain_tick(3, true, true), DrainTick::TimedOutForce);
+    }
+
+    /// The "2 → 1 → 0" completion sequence (AC2): a supervisor stepping through
+    /// a decreasing in-flight count keeps waiting until it hits exactly zero,
+    /// then completes exactly once. Driven through the pure decision function so
+    /// no process actually exits.
+    #[test]
+    fn test_drain_tick_completes_only_at_zero() {
+        let mut completed = 0;
+        for n in [2usize, 1, 0] {
+            match evaluate_drain_tick(n, false, false) {
+                DrainTick::Continue => assert!(n > 0, "must still be waiting while n>0"),
+                DrainTick::Complete => {
+                    assert_eq!(n, 0, "must only complete at zero");
+                    completed += 1;
+                }
+                other => panic!("unexpected: {other:?}"),
+            }
+        }
+        assert_eq!(completed, 1, "completes exactly once, at n==0");
+    }
+
+    /// The `DrainState` machine: begin sets the flag and a deadline, a second
+    /// begin is idempotent (does not stack / move the deadline), abort clears
+    /// the flag and bumps the generation, and the timeout path clears + notes.
+    #[test]
+    fn test_drain_state_lifecycle() {
+        let drain = DrainState::new();
+        assert!(!drain.is_draining());
+        assert_eq!(drain.generation(), 0);
+
+        // begin ⇒ Started, flag set, deadline recorded, generation bumped.
+        let (gen1, deadline) = match drain.begin(Duration::from_secs(120), false) {
+            DrainBegin::Started {
+                generation,
+                deadline,
+            } => (generation, deadline),
+            other => panic!("expected Started, got {other:?}"),
+        };
+        assert!(drain.is_draining());
+        assert_eq!(gen1, 1);
+        assert_eq!(drain.snapshot().deadline, Some(deadline));
+        assert!(!drain.snapshot().force_after_timeout);
+
+        // A second begin while already draining is idempotent: same generation,
+        // same deadline, flag still set (AC edge: second drain does not stack).
+        match drain.begin(Duration::from_secs(9999), true) {
+            DrainBegin::AlreadyDraining => {}
+            other => panic!("expected AlreadyDraining, got {other:?}"),
+        }
+        assert_eq!(drain.generation(), gen1, "idempotent begin does not bump gen");
+        assert_eq!(
+            drain.snapshot().deadline,
+            Some(deadline),
+            "idempotent begin does not move the deadline"
+        );
+
+        // abort ⇒ flag cleared, generation bumped (so a live supervisor stops),
+        // note recorded.
+        assert!(drain.abort());
+        assert!(!drain.is_draining());
+        assert_eq!(drain.generation(), gen1 + 1);
+        assert!(drain.snapshot().note.unwrap().contains("aborted"));
+        // abort again ⇒ no-op.
+        assert!(!drain.abort());
+
+        // timeout resolution clears + notes + bumps generation.
+        let gen_before = drain.generation();
+        let _ = drain.begin(Duration::from_secs(1), false);
+        drain.resolve_timeout("timed out".to_string());
+        assert!(!drain.is_draining());
+        assert_eq!(drain.snapshot().note.as_deref(), Some("timed out"));
+        assert!(drain.generation() > gen_before);
+    }
+
+    /// AC5 (immediate unsupervised refusal): with no supervisor, a drain request
+    /// is refused with `accepted: false` **and the drain flag is never set** —
+    /// pausing dispatch then refusing would be a silent outage.
+    ///
+    /// NOTE: shares the `LOOM_DAEMON_SUPERVISOR` env with
+    /// `test_build_restart_decision_supervisor_gated`; `#[serial]` keeps them
+    /// from racing the process-global env var.
+    #[test]
+    #[serial_test::serial]
+    fn test_drain_request_unsupervised_refuses_without_pausing() {
+        std::env::remove_var("LOOM_DAEMON_SUPERVISOR");
+        let (sr, dir, _rec) = setup_sweep_registry_in_tempdir();
+        let root = dir.path().to_path_buf();
+        let empty_reg = dir.path().join("no-such-workspaces.json");
+        std::env::set_var(crate::workspace_registry::REGISTRY_PATH_ENV, &empty_reg);
+        let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
+        pool.seed(root.clone(), sr);
+        let bus = Arc::new(EventBus::new());
+        let drain = Arc::new(DrainState::new());
+
+        let resp = handle_drain_request(&drain, &pool, &root, &bus, Some(60), false);
+        match resp {
+            Response::DaemonDrain {
+                accepted,
+                supervisor,
+                ..
+            } => {
+                assert!(!accepted, "unsupervised host must refuse the drain");
+                assert!(supervisor.is_none());
+            }
+            other => panic!("expected DaemonDrain, got {other:?}"),
+        }
+        assert!(!drain.is_draining(), "refused drain must NOT pause dispatch");
+        assert_eq!(drain.generation(), 0, "refused drain must not bump generation");
+
+        std::env::remove_var(crate::workspace_registry::REGISTRY_PATH_ENV);
+    }
+
+    /// Cross-root in-flight counting (Finding 5): sweeps live in the SECONDARY
+    /// managed repo only must still be counted, so a drain that reads them does
+    /// not restart while that repo has live work. Also asserts terminal sweeps
+    /// are excluded.
+    #[test]
+    #[serial_test::serial]
+    fn test_count_in_flight_sweeps_cross_root() {
+        use crate::workspace_registry::{normalize_path, WorkspaceRegistry, REGISTRY_PATH_ENV};
+
+        let (sr_a, dir_a, _rec_a) = setup_sweep_registry_in_tempdir();
+        let (sr_b, dir_b, _rec_b) = setup_sweep_registry_in_tempdir();
+        let root_a = dir_a.path().to_path_buf();
+        let root_b = dir_b.path().to_path_buf();
+
+        let reg_path = dir_a.path().join("workspaces.json");
+        let mut reg = WorkspaceRegistry::default();
+        reg.add(&root_a, None).unwrap();
+        reg.add(&root_b, None).unwrap();
+        reg.save(&reg_path).unwrap();
+        std::env::set_var(REGISTRY_PATH_ENV, &reg_path);
+
+        let canon_a = normalize_path(&root_a);
+        let canon_b = normalize_path(&root_b);
+        let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
+        pool.seed(canon_a.clone(), sr_a);
+        pool.seed(canon_b.clone(), sr_b.clone());
+
+        // No sweeps anywhere ⇒ zero.
+        assert_eq!(count_in_flight_sweeps(&pool, &canon_a), 0);
+
+        // Dispatch a live sweep into the SECONDARY repo only.
+        {
+            let mut reg_b = sr_b.lock().unwrap();
+            reg_b
+                .dispatch(&crate::types::SweepKind::Issue(4090), None, None, None, None)
+                .expect("dispatch");
+        }
+        // Counted even though the primary (root_a) registry is empty — a drain
+        // reading only the primary would wrongly see zero and restart.
+        assert_eq!(
+            count_in_flight_sweeps(&pool, &canon_a),
+            1,
+            "a live sweep in the secondary repo must be counted"
+        );
+
+        std::env::remove_var(REGISTRY_PATH_ENV);
+    }
+
+    /// A pre-#4090 `DaemonStatus` JSON payload (no `drain` fields) still
+    /// deserializes — `#[serde(default)]` fills `draining: false` and leaves the
+    /// deadline/note `None` (mirrors the `capacity_bound` compat rationale).
+    #[test]
+    fn test_daemon_status_backward_compat_missing_drain_fields() {
+        let legacy = r#"{"in_flight":[],"token_pool_size":2,"disk_headroom":9,"configured_max":3,"dynamic_cap":2,"main_health_gate_halted":false}"#;
+        let report: DaemonStatusReport =
+            serde_json::from_str(legacy).expect("legacy payload deserializes");
+        assert!(!report.draining, "absent draining (#4090) defaults to false");
+        assert_eq!(report.drain_deadline, None);
+        assert_eq!(report.drain_note, None);
+    }
+
+    /// The new drain fields round-trip through serde, and
+    /// `build_daemon_status_with_drain` overlays the live drain state onto the
+    /// base report (AC4).
+    #[test]
+    #[serial_test::serial]
+    fn test_build_daemon_status_with_drain_overlays_state() {
+        let (sr, dir, _rec) = setup_sweep_registry_in_tempdir();
+        let root = dir.path().to_path_buf();
+        let empty_reg = dir.path().join("no-such-workspaces.json");
+        std::env::set_var(crate::workspace_registry::REGISTRY_PATH_ENV, &empty_reg);
+        let prev_shared = std::env::var("LOOM_SHARED_TOKENS_DIR").ok();
+        std::env::set_var("LOOM_SHARED_TOKENS_DIR", "");
+
+        let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
+        pool.seed(root.clone(), sr);
+        let health = WorkspaceHealthStates::new();
+        let drain = DrainState::new();
+
+        // No drain ⇒ overlay is a no-op.
+        let report = build_daemon_status_with_drain(
+            &pool,
+            &health,
+            &root,
+            &test_credential_preflight(),
+            &drain,
+        );
+        assert!(!report.draining);
+        assert_eq!(report.drain_deadline, None);
+
+        // Begin a drain ⇒ overlay reports draining + deadline.
+        let deadline = match drain.begin(Duration::from_secs(300), false) {
+            DrainBegin::Started { deadline, .. } => deadline,
+            other => panic!("expected Started, got {other:?}"),
+        };
+        let report = build_daemon_status_with_drain(
+            &pool,
+            &health,
+            &root,
+            &test_credential_preflight(),
+            &drain,
+        );
+        assert!(report.draining);
+        assert_eq!(report.drain_deadline, Some(deadline));
+
+        // Round-trips over the wire.
+        let json = serde_json::to_string(&report).unwrap();
+        let back: DaemonStatusReport = serde_json::from_str(&json).unwrap();
+        assert!(back.draining);
+        assert_eq!(back.drain_deadline, Some(deadline));
+
+        match prev_shared {
+            Some(v) => std::env::set_var("LOOM_SHARED_TOKENS_DIR", v),
+            None => std::env::remove_var("LOOM_SHARED_TOKENS_DIR"),
+        }
+        std::env::remove_var(crate::workspace_registry::REGISTRY_PATH_ENV);
+    }
+
+    /// Wire-compat (Finding 3): the new `DrainAndRestartDaemon` variant
+    /// round-trips, and the untouched `RestartDaemon` unit variant STILL
+    /// serializes to exactly `{"type":"RestartDaemon"}`. The
+    /// `test_restart_daemon_request_response_round_trip` assertion above must
+    /// also keep passing unmodified.
+    #[test]
+    fn test_drain_request_wire_compat() {
+        // RestartDaemon is unchanged — byte-for-byte the pre-#4090 shape.
+        assert_eq!(
+            serde_json::to_string(&Request::RestartDaemon).unwrap(),
+            r#"{"type":"RestartDaemon"}"#
+        );
+
+        // The new variant round-trips with its payload.
+        let req = Request::DrainAndRestartDaemon {
+            timeout_secs: Some(600),
+            force_after_timeout: true,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let back: Request = serde_json::from_str(&json).unwrap();
+        match back {
+            Request::DrainAndRestartDaemon {
+                timeout_secs,
+                force_after_timeout,
+            } => {
+                assert_eq!(timeout_secs, Some(600));
+                assert!(force_after_timeout);
+            }
+            other => panic!("expected DrainAndRestartDaemon, got {other:?}"),
+        }
+
+        // AbortDrain round-trips (unit-with-payload-none shape).
+        let json = serde_json::to_string(&Request::AbortDrain).unwrap();
+        assert_eq!(json, r#"{"type":"AbortDrain"}"#);
+        let back: Request = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, Request::AbortDrain));
+
+        // The DaemonDrain response round-trips.
+        let resp = Response::DaemonDrain {
+            accepted: true,
+            supervisor: Some("launchd".to_string()),
+            in_flight: 3,
+            message: "draining".to_string(),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let back: Response = serde_json::from_str(&json).unwrap();
+        match back {
+            Response::DaemonDrain {
+                accepted,
+                supervisor,
+                in_flight,
+                ..
+            } => {
+                assert!(accepted);
+                assert_eq!(supervisor.as_deref(), Some("launchd"));
+                assert_eq!(in_flight, 3);
+            }
+            other => panic!("expected DaemonDrain, got {other:?}"),
+        }
+    }
+
+    /// Abort clears the flag and bumps the generation, so a supervisor holding
+    /// the old generation stops without exiting — even if in-flight later
+    /// reaches zero (AC6, the "abort then the queue empties anyway" race). We
+    /// assert the generation contract the async supervisor relies on rather than
+    /// spawning it (its Complete branch calls `process::exit`).
+    #[test]
+    fn test_abort_supersedes_running_supervisor_generation() {
+        let drain = DrainState::new();
+        let gen = match drain.begin(Duration::from_secs(300), false) {
+            DrainBegin::Started { generation, .. } => generation,
+            other => panic!("expected Started, got {other:?}"),
+        };
+        // A supervisor captured `gen`; abort moves the generation on.
+        assert!(drain.abort());
+        assert_ne!(
+            drain.generation(),
+            gen,
+            "abort must bump the generation so the running supervisor detects supersession"
+        );
+        assert!(!drain.is_draining(), "abort resumes dispatch");
     }
 }

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -191,7 +191,29 @@ enum Commands {
     /// `--foreground`) the daemon refuses and stays running, and this command
     /// prints the refusal and exits non-zero. This is the primitive #4017 Phase
     /// 3 will call after a rebuild — it does nothing on its own.
-    Restart,
+    ///
+    /// With `--drain` (Issue #4090) the daemon instead stops admitting new work
+    /// immediately and waits for every in-flight sweep to finish before
+    /// restarting — no sweep killed, no orphan left behind. `--abort-drain`
+    /// cancels an in-progress drain and resumes normal dispatch.
+    Restart {
+        /// Finish all in-flight sweeps before restarting, instead of restarting
+        /// immediately (#4090). New dispatch is paused for the duration.
+        #[arg(long)]
+        drain: bool,
+        /// Max seconds to wait for in-flight sweeps to drain (with `--drain`).
+        /// Defaults to the daemon's built-in timeout (tens of minutes).
+        #[arg(long)]
+        timeout: Option<u64>,
+        /// On drain timeout, cancel the remaining sweeps and restart anyway
+        /// (with `--drain`). Without this, a timeout refuses the restart and
+        /// keeps the daemon running (fail-safe).
+        #[arg(long)]
+        force_after_timeout: bool,
+        /// Abort an in-progress drain and resume normal dispatch (no restart).
+        #[arg(long)]
+        abort_drain: bool,
+    },
 
     /// Manage the multi-account OAuth token pool at `.loom/tokens/` (Issue
     /// #4082/#4108, epic #4081 "eliminate Python from Loom"). Native Rust
@@ -488,8 +510,14 @@ async fn main() -> Result<()> {
             // register/list/remove durable watches (Issue #3971).
             Commands::Watch { action } => handle_watch_command(action).await,
             // `restart` connects to the running daemon over its Unix socket to
-            // trigger the supervised restart primitive (Issue #4054).
-            Commands::Restart => handle_restart_command().await,
+            // trigger the supervised restart primitive (Issue #4054), or a
+            // scheduled drain-and-restart (Issue #4090).
+            Commands::Restart {
+                drain,
+                timeout,
+                force_after_timeout,
+                abort_drain,
+            } => handle_restart_command(drain, timeout, force_after_timeout, abort_drain).await,
             other => handle_cli_command(other),
         };
     }
@@ -827,6 +855,14 @@ async fn main() -> Result<()> {
     // pre-#3930 single-flag behavior byte-for-byte.
     let workspace_health_states = Arc::new(main_health_gate::WorkspaceHealthStates::new());
 
+    // Shared drain-and-restart state (Issue #4090). Constructed here — before the
+    // epic supervisor, work-finder, and role runner — so its flag can be threaded
+    // into all three dispatch producers AND into the IPC server (which sets/aborts
+    // it and renders it in `loom-daemon status`). With no drain requested the flag
+    // stays `false`, so every producer's halt check is byte-for-byte unchanged.
+    let drain_state = Arc::new(loom_daemon::ipc::DrainState::new());
+    let drain_flag = drain_state.flag();
+
     // Epic supervisor loop (Issue #3872 — Phase 4 of epic #3842). Opt-in via
     // `LOOM_EPIC_SUPERVISOR`. The loop drives every open `loom:epic` issue
     // through its fork-join lifecycle by dispatching the enabled role each tick.
@@ -851,6 +887,7 @@ async fn main() -> Result<()> {
             event_bus.clone(),
             workspace_health_states.clone(),
             interval,
+            drain_flag.clone(),
         ) {
             Ok(handle) => {
                 log::info!(
@@ -936,6 +973,7 @@ async fn main() -> Result<()> {
             cpu_est_cores_per_sweep,
             workspace_health_states.clone(),
             event_bus.clone(),
+            drain_flag.clone(),
         ))
     } else {
         log::debug!("work_finder: disabled (set LOOM_WORK_FINDER=1 to enable)");
@@ -1068,7 +1106,12 @@ async fn main() -> Result<()> {
             .map(|spec| {
                 let interval = role_runner::resolve_interval_for_role(spec, &role_runner_config);
                 log::info!("role_runner: {} interval={}s", spec.name, interval.as_secs());
-                role_runner::spawn_multi_role_task(*spec, sweep_workspace.clone(), interval)
+                role_runner::spawn_multi_role_task(
+                    *spec,
+                    sweep_workspace.clone(),
+                    interval,
+                    drain_flag.clone(),
+                )
             })
             .collect();
         Some(handles)
@@ -1130,6 +1173,7 @@ async fn main() -> Result<()> {
         workspace_pool.clone(),
         sweep_workspace.clone(),
         credential_preflight,
+        drain_state.clone(),
     );
 
     // Setup signal handler for graceful shutdown. We listen for BOTH SIGINT
@@ -1408,7 +1452,7 @@ fn handle_cli_command(command: Commands) -> Result<()> {
             // socket round-trip), never dispatched through this sync handler.
             unreachable!("Watch is handled in main() before handle_cli_command")
         }
-        Commands::Restart => {
+        Commands::Restart { .. } => {
             // Routed directly in `main()` (it needs the async runtime for the
             // socket round-trip), never dispatched through this sync handler.
             unreachable!("Restart is handled in main() before handle_cli_command")
@@ -1698,8 +1742,39 @@ async fn handle_quarantine_command(action: QuarantineAction) -> Result<()> {
 /// Linux / `--foreground`) it replies `DaemonRestart { scheduled: false }` and
 /// keeps running — we print the refusal and exit non-zero, so an operator or
 /// Phase 3 can detect that no restart happened rather than assuming it did.
-async fn handle_restart_command() -> Result<()> {
+async fn handle_restart_command(
+    drain: bool,
+    timeout: Option<u64>,
+    force_after_timeout: bool,
+    abort_drain: bool,
+) -> Result<()> {
     let socket_path = resolve_socket_path()?;
+
+    // Drain-mode variants (Issue #4090) speak `DrainAndRestartDaemon` /
+    // `AbortDrain` and expect a `DaemonDrain` reply; the plain restart keeps its
+    // #4054 `RestartDaemon` / `DaemonRestart` contract byte-for-byte.
+    if abort_drain {
+        return handle_drain_reply(
+            &socket_path,
+            &Request::AbortDrain,
+            "loom-daemon drain aborted",
+            "no drain was in progress",
+        )
+        .await;
+    }
+    if drain {
+        return handle_drain_reply(
+            &socket_path,
+            &Request::DrainAndRestartDaemon {
+                timeout_secs: timeout,
+                force_after_timeout,
+            },
+            "loom-daemon drain scheduled",
+            "loom-daemon did NOT drain",
+        )
+        .await;
+    }
+
     match query_daemon(&socket_path, &Request::RestartDaemon).await {
         Ok(Response::DaemonRestart {
             scheduled,
@@ -1715,6 +1790,53 @@ async fn handle_restart_command() -> Result<()> {
                 Ok(())
             } else {
                 eprintln!("loom-daemon did NOT restart: {message}");
+                std::process::exit(1);
+            }
+        }
+        Ok(Response::Error { message }) => {
+            eprintln!("Daemon error: {message}");
+            std::process::exit(1);
+        }
+        Ok(other) => {
+            eprintln!("Unexpected response from daemon: {other:?}");
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("Could not reach loom-daemon at {}: {e}", socket_path.display());
+            eprintln!();
+            eprintln!("Is the daemon running? Start it with:");
+            eprintln!("  ./.loom/scripts/cli/loom-daemon-start.sh");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Shared reply handler for the drain-mode restart variants (Issue #4090): both
+/// `DrainAndRestartDaemon` and `AbortDrain` answer with a `DaemonDrain` frame.
+/// A refused request (unsupervised host, or abort with no drain in progress)
+/// exits non-zero so a script can detect that nothing happened.
+async fn handle_drain_reply(
+    socket_path: &Path,
+    request: &Request,
+    accepted_prefix: &str,
+    refused_prefix: &str,
+) -> Result<()> {
+    match query_daemon(socket_path, request).await {
+        Ok(Response::DaemonDrain {
+            accepted,
+            supervisor,
+            in_flight,
+            message,
+        }) => {
+            if accepted {
+                println!(
+                    "{accepted_prefix} (supervisor: {}, {in_flight} in-flight).",
+                    supervisor.as_deref().unwrap_or("unknown")
+                );
+                println!("{message}");
+                Ok(())
+            } else {
+                eprintln!("{refused_prefix}: {message}");
                 std::process::exit(1);
             }
         }
@@ -2295,6 +2417,14 @@ fn print_status_json(
             "message": c.message,
             "checked_at": c.checked_at,
         })),
+        // Scheduled drain-and-restart state (#4090). `draining: false` in the
+        // common case; `note` carries the last transition (timeout refusal /
+        // abort) so a scripted consumer sees why a drain ended without a restart.
+        "drain": {
+            "draining": report.draining,
+            "deadline": report.drain_deadline,
+            "note": report.drain_note,
+        },
         // Per-repo breakdown across every registered managed workspace (#3930).
         "per_repo": report.per_repo.iter().map(|r| serde_json::json!({
             "root": r.root,
@@ -2665,6 +2795,27 @@ fn print_status_human(
         None => {
             println!("Forge credential: unknown (older daemon binary — restart to pick up #4005)")
         }
+    }
+
+    // Scheduled drain-and-restart (#4090): a drain that quietly hangs is worse
+    // than no drain, so surface DRAINING with the remaining count + deadline.
+    // A `drain_note` (timeout refusal / abort) persists after a drain ends so
+    // the operator sees WHY the daemon is still up rather than restarted.
+    if report.draining {
+        let deadline = report.drain_deadline.map_or_else(
+            || "no deadline".to_string(),
+            |d| {
+                let secs = (d - Utc::now()).num_seconds();
+                if secs >= 0 {
+                    format!("deadline in {secs}s ({d})")
+                } else {
+                    format!("deadline passed {}s ago ({d})", -secs)
+                }
+            },
+        );
+        println!("Drain: DRAINING ({} sweep(s) remaining, {deadline})", report.in_flight.len());
+    } else if let Some(note) = &report.drain_note {
+        println!("Drain: not draining (last: {note})");
     }
 
     // Per-repo breakdown across every registered managed workspace (#3930). In

--- a/loom-daemon/src/role_runner.rs
+++ b/loom-daemon/src/role_runner.rs
@@ -604,6 +604,7 @@ pub fn spawn_role_task<R>(
     mut runner: R,
     spec: RoleSpec,
     interval: Duration,
+    drain: std::sync::Arc<std::sync::atomic::AtomicBool>,
 ) -> tokio::task::JoinHandle<()>
 where
     R: RoleInvocationRunner + Send + 'static,
@@ -615,6 +616,17 @@ where
         ticker.tick().await; // skip immediate first tick (see module docs)
         loop {
             ticker.tick().await;
+            // Scheduled drain (#4090): role ticks have no sweep-registry entry to
+            // await, so a drain cannot wait for an in-flight tick — but it MUST
+            // stop new ticks from *starting* (e.g. a Champion mid-merge). Skip
+            // the whole tick while draining.
+            if drain.load(std::sync::atomic::Ordering::Relaxed) {
+                log::debug!(
+                    "role_runner: {} tick skipped — drain in progress (no new role dispatch)",
+                    spec.name
+                );
+                continue;
+            }
             let name = spec.name;
             let prompt = spec.prompt;
             let tick_start = Instant::now();
@@ -657,6 +669,7 @@ pub fn spawn_multi_role_task(
     spec: RoleSpec,
     fallback_root: PathBuf,
     interval: Duration,
+    drain: std::sync::Arc<std::sync::atomic::AtomicBool>,
 ) -> tokio::task::JoinHandle<()> {
     log::info!(
         "role_runner: starting {} multi-workspace loop (interval={}s)",
@@ -669,6 +682,18 @@ pub fn spawn_multi_role_task(
         ticker.tick().await; // skip immediate first tick (see module docs)
         loop {
             ticker.tick().await;
+
+            // Scheduled drain (#4090): stop starting new role ticks across every
+            // workspace while a drain is in progress (Finding 2 — role ticks are
+            // not in the sweep registry, so the drain cannot await them, but it
+            // must not let a fresh Champion/Curator tick start mid-roll).
+            if drain.load(std::sync::atomic::Ordering::Relaxed) {
+                log::debug!(
+                    "role_runner: {} multi-workspace tick skipped — drain in progress",
+                    spec.name
+                );
+                continue;
+            }
 
             let roots = WorkspaceRegistry::load_default()
                 .unwrap_or_else(|e| {
@@ -1179,10 +1204,47 @@ mod tests {
             prompt: "/loom:curator",
             default_interval_secs: 1,
         };
-        let handle = spawn_role_task(runner, spec, Duration::from_millis(20));
+        let drain = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let handle = spawn_role_task(runner, spec, Duration::from_millis(20), drain);
 
         wait_for_calls(&calls, 1, Duration::from_secs(2)).await;
         wait_for_calls(&calls, 3, Duration::from_secs(2)).await;
+
+        handle.abort();
+    }
+
+    /// A drain in progress (#4090) stops role ticks from *starting*: with the
+    /// drain flag set before the loop runs, `spawn_role_task` performs ZERO
+    /// `invoke` calls even after several tick intervals elapse. This is the
+    /// highest-value new role-runner coverage (Finding 2 — role ticks had no
+    /// halt gate at all before this).
+    #[tokio::test]
+    async fn test_drain_stops_role_ticks_from_starting() {
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let runner = FakeRunner {
+            outcomes: vec![RoleTickOutcome::Success; 3],
+            calls: calls.clone(),
+        };
+        let spec = RoleSpec {
+            name: "champion",
+            prompt: "/loom:champion",
+            default_interval_secs: 1,
+        };
+        // Drain already engaged before the loop starts.
+        let drain = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let handle = spawn_role_task(runner, spec, Duration::from_millis(20), drain.clone());
+
+        // Let several tick intervals elapse; not a single invoke may fire.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "no role tick may start while draining"
+        );
+
+        // Clearing the drain resumes dispatch — proving the gate, not a dead loop.
+        drain.store(false, std::sync::atomic::Ordering::SeqCst);
+        wait_for_calls(&calls, 1, Duration::from_secs(2)).await;
 
         handle.abort();
     }
@@ -1200,7 +1262,8 @@ mod tests {
             prompt: "/loom:curator",
             default_interval_secs: 1,
         };
-        let handle = spawn_role_task(PanicOnceRunner, spec, Duration::from_millis(20));
+        let drain = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let handle = spawn_role_task(PanicOnceRunner, spec, Duration::from_millis(20), drain);
         let result = tokio::time::timeout(Duration::from_secs(5), handle).await;
         assert!(result.is_ok(), "loop task should finish (not hang) after the runner panics");
     }

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -378,6 +378,35 @@ pub enum Request {
     ///
     /// It never fires on its own — nothing in the daemon issues this request.
     RestartDaemon,
+    /// Scheduled drain-and-restart (Issue #4090): stop admitting *new* work
+    /// immediately, wait for every in-flight sweep to finish, then exit
+    /// [`EXIT_RESTART`](crate::ipc::EXIT_RESTART) for a supervised relaunch —
+    /// no sweep killed, no orphan left behind.
+    ///
+    /// A deliberately **separate** variant from [`Request::RestartDaemon`] (a
+    /// unit variant) rather than fields on it: the wire window where an older
+    /// `loom-daemon restart` client and a newer daemon disagree is *precisely a
+    /// roll*, so `{"type":"RestartDaemon"}` must keep deserializing unchanged.
+    ///
+    /// - `timeout_secs`: bound on how long to wait for the registry to empty.
+    ///   `None` ⇒ the daemon's default (tens of minutes; a sweep is ~10–20 min).
+    /// - `force_after_timeout`: when the deadline passes with sweeps still in
+    ///   flight, `true` cancels the stragglers via the existing `cancel_sweep`
+    ///   path and restarts anyway; `false` (fail-safe) refuses the restart,
+    ///   resumes dispatch, and stays up.
+    ///
+    /// On an unsupervised host the daemon refuses immediately (before pausing
+    /// dispatch) with `DaemonDrain { accepted: false, .. }`, mirroring
+    /// [`Request::RestartDaemon`]'s refusal contract.
+    DrainAndRestartDaemon {
+        timeout_secs: Option<u64>,
+        force_after_timeout: bool,
+    },
+    /// Abort an in-progress drain (Issue #4090): clear the drain flag so new
+    /// dispatch resumes, and stop the drain-supervisor task so no later restart
+    /// fires — even if the in-flight count subsequently reaches zero on its own.
+    /// A no-op (idempotent) when no drain is in progress.
+    AbortDrain,
     Shutdown,
 }
 
@@ -521,6 +550,21 @@ pub enum Response {
     DaemonRestart {
         scheduled: bool,
         supervisor: Option<String>,
+        message: String,
+    },
+    /// Result of a `DrainAndRestartDaemon` / `AbortDrain` request (Issue #4090).
+    ///
+    /// `accepted` is `true` when the drain was scheduled (or the abort took
+    /// effect); `false` on an unsupervised host (a drain would have nowhere to
+    /// relaunch into) or an abort with no drain in progress. `supervisor` names
+    /// the detected supervisor (`Some("launchd")`) or `None` when unsupervised.
+    /// `in_flight` is the cross-root non-terminal sweep count at request time,
+    /// so the operator immediately sees how much work the drain must wait for.
+    /// `message` is a human-readable explanation for operator output.
+    DaemonDrain {
+        accepted: bool,
+        supervisor: Option<String>,
+        in_flight: usize,
         message: String,
     },
     // ========================================================================
@@ -897,6 +941,30 @@ pub struct DaemonStatusReport {
     /// `#[serde(default)]` keeps that wire data compatible.
     #[serde(default)]
     pub credential_preflight: Option<CredentialPreflightReport>,
+    /// Whether a scheduled drain-and-restart (Issue #4090) is currently in
+    /// progress: new dispatch is paused and the daemon is waiting for the
+    /// in-flight sweep count ([`Self::in_flight`]) to reach zero before exiting
+    /// for a supervised relaunch. `false` in the common no-drain case.
+    /// `#[serde(default)]` keeps pre-#4090 wire data / older clients compatible
+    /// (an absent field parses as `false` — "not draining"), mirroring the
+    /// `capacity_bound` forward-compat convention.
+    #[serde(default)]
+    pub draining: bool,
+    /// Wall-clock deadline at which an in-progress drain (Issue #4090) gives up
+    /// waiting: without `--force-after-timeout` it refuses the restart and
+    /// resumes dispatch; with it, the stragglers are cancelled and the daemon
+    /// restarts anyway. `None` when no drain is active. `#[serde(default)]`
+    /// keeps pre-#4090 wire data compatible.
+    #[serde(default)]
+    pub drain_deadline: Option<DateTime<Utc>>,
+    /// A short human-readable note about the most recent drain transition
+    /// (Issue #4090) — e.g. why a drain timed out and was refused, or that a
+    /// drain was aborted by the operator. Surfaced so `loom-daemon status`
+    /// never leaves a drain that quietly ended unexplained. `None` when no
+    /// drain has run this process. `#[serde(default)]` keeps pre-#4090 wire
+    /// data compatible.
+    #[serde(default)]
+    pub drain_note: Option<String>,
 }
 
 /// One registered managed-workspace's status line in [`DaemonStatusReport`]

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -1155,6 +1155,7 @@ pub fn spawn_multi_work_finder_task(
     cpu_est_cores_per_sweep: f64,
     health_states: Arc<WorkspaceHealthStates>,
     event_bus: Arc<EventBus>,
+    drain: Arc<std::sync::atomic::AtomicBool>,
 ) -> tokio::task::JoinHandle<()> {
     log::info!(
         "work_finder: starting multi-workspace loop (interval={}s, configured_max={configured_max}, \
@@ -1213,7 +1214,13 @@ pub fn spawn_multi_work_finder_task(
 
             // Per-repo main-health halt (#3930): look up each root's own gate
             // state, parallel to `pairs`. A red repo halts only its own dispatch.
-            let halted: Vec<bool> = roots.iter().map(|r| health_states.is_halted(r)).collect();
+            // A scheduled drain (#4090) is daemon-global: it pauses new dispatch
+            // in EVERY repo at once, so it is OR'd into every root's halt.
+            let draining = drain.load(std::sync::atomic::Ordering::Relaxed);
+            let halted: Vec<bool> = roots
+                .iter()
+                .map(|r| health_states.is_halted(r) || draining)
+                .collect();
             let any_halted = halted.iter().any(|&h| h);
 
             let mut pairs: Vec<(GhWorkSource, RegistryDispatcher)> = roots


### PR DESCRIPTION
## Summary

Adds a **scheduled drain-and-restart** to the supervised restart primitive (#4054/#4077): `loom-daemon restart --drain` stops admitting new work immediately, waits for every in-flight sweep to finish, then exits `EXIT_RESTART` for the launchd relaunch — **no sweep killed, no orphan left behind**. This is the safety property that makes auto-rolling (#4055) defensible.

Follows the curated scope precisely: the drain reuses the main-health gate's proven halt plumbing (Finding 1) rather than inventing new machinery, adds a **separate** IPC variant so the untouched `{"type":"RestartDaemon"}` wire shape keeps deserializing (Finding 3), threads a halt gate into the role runner which had none (Finding 2), counts in-flight across all managed roots (Finding 5), and checks supervision up front so an unsupervised host refuses *before* pausing dispatch (Finding 4 / AC5).

## Changes

- **`types.rs`** — new `Request::DrainAndRestartDaemon { timeout_secs, force_after_timeout }` and `Request::AbortDrain`; new `Response::DaemonDrain { accepted, supervisor, in_flight, message }`; `DaemonStatusReport` gains `draining` / `drain_deadline` / `drain_note`, all `#[serde(default)]` per the `capacity_bound` precedent. **`RestartDaemon` is untouched.**
- **`ipc.rs`** — `DrainState` (drain flag + generation + descriptor), the pure `evaluate_drain_tick` decision fn, `count_in_flight_sweeps` (cross-root, mirrors `build_daemon_status`), the drain-supervisor task that owns the eventual `std::process::exit(EXIT_RESTART)`, and `build_daemon_status_with_drain`. Drain requests are intercepted in `handle_client` (like `RestartDaemon`) since they must ack immediately and exit minutes later.
- **`work_finder.rs` / `epic_supervisor.rs` / `role_runner.rs`** — the drain flag is OR'd into the existing halt checks (work finder, epic supervisor) and newly gates role-tick starts (role runner had no halt gate — Finding 2's real gap).
- **`main.rs`** — constructs the shared `DrainState`, threads its flag into all three producers and the state into the IPC server; `restart` CLI gains `--drain` / `--timeout` / `--force-after-timeout` / `--abort-drain`; `loom-daemon status` renders `DRAINING (n remaining, deadline …)`.
- **`event_bus.rs` + `daemon-reference.md`** — `daemon.drain.{started,completed,aborted,timeout}` added to **both** taxonomy tables, authorized by this issue; the "sweeps survive, they are not drained" paragraph and the "Supervised restart primitive" section are amended with the drain extension.

## Acceptance Criteria Verification

- **AC1** — drain stops new dispatch immediately: drain flag OR'd into work-finder/epic halts; `test_tick_skips_dispatch_while_draining` (epic) + `test_drain_stops_role_ticks_from_starting` (role runner, zero invokes while draining).
- **AC2** — restart only after the last sweep completes: `evaluate_drain_tick` completes only at `in_flight == 0` (`test_drain_tick_completes_only_at_zero`), terminal entries excluded; cross-root counting proven by `test_count_in_flight_sweeps_cross_root` (live sweep in the secondary repo blocks completion).
- **AC3** — timeout without force refuses + resumes + reports; with force cancels via the existing `SweepRegistry::cancel` path (`evaluate_drain_tick` → `TimedOutRefuse`/`TimedOutForce`; `resolve_timeout` clears the flag + records the note).
- **AC4** — `loom-daemon status` surfaces DRAINING with remaining count + deadline (`build_daemon_status_with_drain`, `test_build_daemon_status_with_drain_overlays_state`, round-trip + pre-drain-JSON compat).
- **AC5** — unsupervised refusal is immediate and never pauses dispatch (`test_drain_request_unsupervised_refuses_without_pausing` asserts `accepted:false` **and** flag never set, generation not bumped).
- **AC6** — abort restores dispatch and bumps the generation so a stale supervisor never fires a later restart (`test_abort_supersedes_running_supervisor_generation`).
- **Wire-compat** — `{"type":"RestartDaemon"}` still serializes unchanged (`test_drain_request_wire_compat`, and the pre-existing `test_restart_daemon_request_response_round_trip` passes unmodified).
- **Edge cases** — zero in-flight exits on the first poll (no interval wait); a second drain while DRAINING is an idempotent ack (`DrainBegin::AlreadyDraining`, deadline unchanged); SIGTERM precedence is preserved (drain supervisor only ever exits `EXIT_RESTART`; the signal handler exits `143` independently); `roleRunner` disabled path unchanged.

## Test Plan

- `cargo test --lib`: **1258 passed, 0 failed** (includes all new drain tests).
- `cargo fmt` clean, `cargo clippy --lib --bins --tests` clean.
- Pre-existing `tests/integration_basic.rs` failures are **unrelated**: they spawn the real daemon and hard-code a 5s socket-bind timeout, but the daemon takes ~12s to bind under this host's build contention. Verified failing identically on the clean `origin/main` baseline (stash → rebuild → `test_ping_pong` FAILED) with none of this PR's changes.

## Scope guard

Target was **≤7 files, ≤450 LOC including tests**. Landed **8 files** — exactly the Affected-Files list (7 Rust + `daemon-reference.md`). The total added line count exceeds 450, driven by (a) this crate's mandatory heavy rustdoc convention (~298 added comment lines) and (b) a test suite covering every AC + wire-compat + no-regression + the enumerated edge cases per the curated Test Plan. **All three architectural stop-and-split boundaries were respected**: no role-tick registry was built, `claim_reconciliation.rs` was not touched, and `SweepRegistry::cancel`'s signature is unchanged (the force path only *calls* it). The functional core (drain state machine + decision fn + cross-root counter + handlers + flag threading) is modest; the size is documentation and tests, not misplaced architecture.

Closes #4090

🤖 Generated with [Claude Code](https://claude.com/claude-code)