### PR TITLE
feat(safehouse): inject safehouse-mcp into workers via a pre-registered persona pool (#3999)

### DIFF
--- a/.loom/docs/safehouse.md
+++ b/.loom/docs/safehouse.md
@@ -122,3 +122,100 @@ by the bare issue number (`task_id`):
 - `loom-daemon/src/workspace_pool.rs` — `start_safehouse_narration()` subscribes
   the shared `Arc<EventBus>` (the single place it is owned) and spawns the sink
   on the daemon runtime; a no-op when disabled.
+
+# Phase 2 — worker-side `safehouse-mcp` injection (#3999)
+
+Phase 1 lets the daemon *narrate*. Phase 2 gives each **worker** session a
+two-way handle: when the `safehouse` block is enabled, Loom injects the
+`safehouse-mcp` stdio MCP server (`rjwalters/safehouse`, tools `safehouse_send` /
+`safehouse_read` / `safehouse_create_room` / `safehouse_list_rooms`; env
+`SAFEHOUSED_SOCKET` + `SAFEHOUSE_PERSONA`) into the worker's MCP config, so a
+Builder can ask a question in the room mid-task and read the human's answer
+instead of only signalling through labels. The MCP server holds no keys — the
+socket path is the only credential-adjacent value written.
+
+## Per-worker persona: a bounded pre-registered pool (design decision)
+
+safehoused's persona allowlist is a **static boot-time TOML array** with no
+runtime registration, no glob/prefix matching, and no SIGHUP reload (see phase-1
+note above). So a literal per-issue name like `loom_builder_42` **cannot** be
+minted at dispatch time — safehoused would reject the `hello` for a name not in
+its boot allowlist, and it cannot restart per worker.
+
+Loom therefore assigns each worker a persona from a **bounded pool the operator
+pre-registers** in safehoused's allowlist ahead of time — the same "fixed pool,
+rotate per slot" shape as the token pool. Configure the pool in the `safehouse`
+block and add the identical names to safehoused's `personas`:
+
+```jsonc
+"safehouse": {
+  "enabled": true,
+  "socket": "/run/safehoused.sock",
+  "persona": "loom_daemon",                     // scalar fallback (daemon + no-pool workers)
+  "workerPersonas": ["loom_builder_1",          // the pre-registered worker pool
+                     "loom_builder_2",
+                     "loom_builder_3",
+                     "loom_builder_4"],
+  "mcpCommand": "safehouse-mcp"                  // launcher for the stdio MCP server
+}
+```
+
+```toml
+# safehoused config — restart required after editing (allowlist read once at boot)
+personas = ["loom_daemon", "loom_builder_1", "loom_builder_2", "loom_builder_3", "loom_builder_4"]
+```
+
+Each worker is assigned `workerPersonas[issue_number % pool_size]` (round-robin
+by worktree slot — the issue number comes from `LOOM_SWEEP_CLAIM_OWNED`). Two
+**concurrently-running** workers (distinct issue numbers) get distinct personas
+whenever the pool is at least as large as the concurrency level and the numbers
+do not collide mod N — so size the pool to your max concurrent workers. With **no
+`workerPersonas`** configured, every worker falls back to the scalar `persona`
+(workspace-wide, no per-worker attribution) — the feature degrades, never fails.
+
+Env overrides (each wins over config): `LOOM_SAFEHOUSE_WORKER_PERSONAS`
+(comma-separated pool), `LOOM_SAFEHOUSE_MCP_COMMAND`, plus the phase-1
+`LOOM_SAFEHOUSE_ENABLED` / `LOOM_SAFEHOUSE_SOCKET` / `LOOM_SAFEHOUSE_PERSONA`.
+
+## Delivery: session-scoped `--mcp-config` at spawn time
+
+Injection happens in `spawn-claude.sh` (the mandatory agent spawn path), not by
+rewriting the workspace `.mcp.json`. Concurrent sweeps **share** the workspace
+root, so a per-worker persona cannot live in that shared file; instead
+spawn-claude generates a **session-scoped** MCP config (persona substituted for
+this worker) and passes it via `claude --mcp-config <file>`. The file lists the
+`loom` server FIRST (so it is self-contained even when the session cwd has no
+project `.mcp.json`) and appends `safehouse` second.
+
+`scripts/setup-mcp.sh` (the workspace-root generator, reached inside worktrees
+via the `.mcp.json` symlink `worktree.sh` creates) **also** learns to append the
+`safehouse` server when enabled — but with the scalar `persona`, since it is not
+per-worker. Both writers keep `loom` first and unchanged so
+`claude-wrapper.sh`'s MCP pre-flight (which keys off the first server with args)
+still resolves the loom entry point.
+
+## Degradation contract (unchanged from phase 1)
+
+- `safehouse.enabled` false/absent ⇒ **byte-for-byte no-op**: spawn-claude
+  appends no `--mcp-config`, and setup-mcp emits the identical loom-only file.
+- Enabled but the launch command is missing, or no socket resolves ⇒ one
+  `warn`, **injection skipped**, the `loom` MCP server unaffected and the worker
+  starts normally.
+- Socket configured but not yet present at spawn ⇒ one `warn`, injected anyway
+  (best-effort — `safehouse-mcp` connects lazily and never blocks the worker).
+- A persona absent from safehoused's boot allowlist is rejected by safehoused at
+  `hello` with a clear message — provision the whole pool before enabling.
+
+## Implementation (phase 2)
+
+- `defaults/scripts/lib/mcp-config.sh` — shared resolvers (env > config >
+  default, mirroring `safehouse.rs`), the pool round-robin persona picker, and
+  the `loom`-first `.mcp.json` emitter.
+- `defaults/scripts/spawn-claude.sh` — per-worker injection via `--mcp-config`.
+- `scripts/setup-mcp.sh` — workspace-root two-server generation when enabled.
+- Tests: `defaults/scripts/tests/test-mcp-config.sh`.
+
+> The exact `safehouse-mcp` binary/protocol lives in the external
+> `rjwalters/safehouse` repo and is not verifiable from this repo, so the
+> launcher is configurable (`safehouse.mcpCommand`) and a missing command
+> degrades to a logged skip rather than a broken server entry.

--- a/defaults/config.json
+++ b/defaults/config.json
@@ -12,7 +12,9 @@
     "enabled": false,
     "socket": null,
     "room": null,
-    "persona": "loom_daemon"
+    "persona": "loom_daemon",
+    "workerPersonas": [],
+    "mcpCommand": "safehouse-mcp"
   },
   "health_monitoring": {
     "enabled": true,

--- a/defaults/scripts/lib/mcp-config.sh
+++ b/defaults/scripts/lib/mcp-config.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# mcp-config.sh — shared resolution for the optional safehouse MCP server
+# injected into worker sessions (issue #3999, phase 2 of the safehouse
+# fleet-comms layer #3997).
+#
+# Source this file (do not exec). It defines resolvers that mirror the daemon's
+# `safehouse` config-block precedence (env > config > default) from
+# loom-daemon/src/safehouse.rs, plus a per-worker persona picker and a
+# `.mcp.json` emitter that always lists the `loom` server FIRST.
+#
+# The daemon narrates as ONE static operator-provisioned persona
+# (`safehouse.persona`, default `loom_daemon`). safehoused reads its persona
+# allowlist once at boot with no runtime registration and no prefix matching,
+# so literal per-issue names (`loom_builder_42`) cannot be registered at
+# dispatch time. Instead, workers draw from a BOUNDED, PRE-REGISTERED pool
+# (`safehouse.workerPersonas`) an operator adds to safehoused's allowlist
+# ahead of time; each concurrent worker is assigned one pool entry (round-robin
+# by its issue/worktree slot). When no pool is configured, every worker falls
+# back to the scalar `safehouse.persona` (workspace-wide, no per-worker
+# attribution) — the feature degrades, it never fails.
+#
+# Every resolver soft-degrades: a missing/malformed config, a missing `jq`, or
+# a disabled block yields the safe default and never aborts the caller.
+
+_LOOM_MCP_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./config-resolver.sh
+source "$_LOOM_MCP_LIB_DIR/config-resolver.sh"
+
+# _loom_mcp_truthy <value> -> exit 0 when truthy, 1 otherwise.
+# Matches loom-daemon/src/safehouse.rs `env_bool`: 1/true/yes/on ⇒ true.
+_loom_mcp_truthy() {
+    case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
+        1 | true | yes | on) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# loom_mcp_safehouse_enabled <repo_root> -> echoes "true" or "false".
+# Precedence: LOOM_SAFEHOUSE_ENABLED (env) > safehouse.enabled (config) >
+# false (default). An explicitly-empty env value ("") disables (matches the
+# daemon's env_bool, which maps "" ⇒ false).
+loom_mcp_safehouse_enabled() {
+    local repo_root="$1"
+    if [[ -n "${LOOM_SAFEHOUSE_ENABLED+set}" ]]; then
+        if _loom_mcp_truthy "$LOOM_SAFEHOUSE_ENABLED"; then echo true; else echo false; fi
+        return 0
+    fi
+    local v
+    v="$(loom_config_get "$repo_root" "safehouse.enabled" "false")"
+    if _loom_mcp_truthy "$v"; then echo true; else echo false; fi
+}
+
+# loom_mcp_safehouse_socket <repo_root> -> echoes the resolved socket path, or
+# empty when none resolves. Precedence mirrors safehouse.rs `resolve_socket`
+# combined with the config layer: safehouse.socket (config) >
+# LOOM_SAFEHOUSE_SOCKET (env) > SAFEHOUSED_SOCKET (env). Config wins here
+# because the daemon reads the configured socket before falling back to the
+# conventional env var.
+loom_mcp_safehouse_socket() {
+    local repo_root="$1"
+    local cfg
+    cfg="$(loom_config_get "$repo_root" "safehouse.socket" "")"
+    if [[ -n "$cfg" && "$cfg" != "null" ]]; then
+        printf '%s\n' "$cfg"
+        return 0
+    fi
+    if [[ -n "${LOOM_SAFEHOUSE_SOCKET:-}" ]]; then
+        printf '%s\n' "$LOOM_SAFEHOUSE_SOCKET"
+        return 0
+    fi
+    if [[ -n "${SAFEHOUSED_SOCKET:-}" ]]; then
+        printf '%s\n' "$SAFEHOUSED_SOCKET"
+        return 0
+    fi
+    printf '\n'
+}
+
+# loom_mcp_safehouse_persona_fallback <repo_root> -> echoes the scalar persona.
+# Precedence: LOOM_SAFEHOUSE_PERSONA (env) > safehouse.persona (config) >
+# loom_daemon (default). Used when no worker pool is configured.
+loom_mcp_safehouse_persona_fallback() {
+    local repo_root="$1"
+    if [[ -n "${LOOM_SAFEHOUSE_PERSONA:-}" ]]; then
+        printf '%s\n' "$LOOM_SAFEHOUSE_PERSONA"
+        return 0
+    fi
+    loom_config_get "$repo_root" "safehouse.persona" "loom_daemon"
+}
+
+# loom_mcp_worker_personas <repo_root> -> echoes a comma-separated pool, or
+# empty when none is configured. Precedence: LOOM_SAFEHOUSE_WORKER_PERSONAS
+# (env, comma-separated) > safehouse.workerPersonas (config array).
+loom_mcp_worker_personas() {
+    local repo_root="$1"
+    if [[ -n "${LOOM_SAFEHOUSE_WORKER_PERSONAS:-}" ]]; then
+        printf '%s\n' "$LOOM_SAFEHOUSE_WORKER_PERSONAS"
+        return 0
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        printf '\n'
+        return 0
+    fi
+    local effective
+    effective="$(loom_resolve_config "$repo_root")"
+    printf '%s' "$effective" | jq -r '
+        (.safehouse.workerPersonas // [])
+        | if type == "array"
+          then (map(select(type == "string" and (. | length) > 0)) | join(","))
+          else "" end
+    ' 2>/dev/null || printf '\n'
+}
+
+# loom_mcp_safehouse_command <repo_root> -> echoes the safehouse-mcp launcher
+# command. Precedence: LOOM_SAFEHOUSE_MCP_COMMAND (env) > safehouse.mcpCommand
+# (config) > safehouse-mcp (default). The exact binary lives in the external
+# rjwalters/safehouse repo and cannot be verified here, so it is configurable.
+loom_mcp_safehouse_command() {
+    local repo_root="$1"
+    if [[ -n "${LOOM_SAFEHOUSE_MCP_COMMAND:-}" ]]; then
+        printf '%s\n' "$LOOM_SAFEHOUSE_MCP_COMMAND"
+        return 0
+    fi
+    loom_config_get "$repo_root" "safehouse.mcpCommand" "safehouse-mcp"
+}
+
+# loom_mcp_pick_persona <issue> <pool_csv> <fallback> -> echoes the persona for
+# this worker. Round-robins the pool by `issue % pool_size` so two concurrent
+# workers (distinct issue numbers) get distinct personas whenever the pool is
+# at least as large as the concurrent-worker count and their numbers do not
+# collide mod N. Falls back to `fallback` when the pool is empty; falls back to
+# the first pool entry when the issue slot is unknown (deterministic).
+loom_mcp_pick_persona() {
+    local issue="$1" pool_csv="$2" fallback="$3"
+    if [[ -z "$pool_csv" ]]; then
+        printf '%s\n' "$fallback"
+        return 0
+    fi
+    local -a pool
+    IFS=',' read -r -a pool <<<"$pool_csv"
+    local n=${#pool[@]}
+    if [[ "$n" -eq 0 ]]; then
+        printf '%s\n' "$fallback"
+        return 0
+    fi
+    if [[ -z "$issue" || ! "$issue" =~ ^[0-9]+$ ]]; then
+        printf '%s\n' "${pool[0]}"
+        return 0
+    fi
+    local idx=$((issue % n))
+    printf '%s\n' "${pool[$idx]}"
+}
+
+# loom_mcp_emit_config <workspace_root> [socket] [persona] [command]
+# Echoes a full .mcp.json document. The `loom` server is ALWAYS emitted first
+# (claude-wrapper.sh's MCP pre-flight extracts its staleness entry point from
+# the first server with args, so order is load-bearing). A `safehouse` server
+# is appended SECOND only when socket, persona, AND command are all non-empty.
+# The socket path is the only credential-adjacent value written — no token or
+# key is ever emitted.
+loom_mcp_emit_config() {
+    LOOM_MCP_WS="$1" \
+        LOOM_MCP_SH_SOCKET="${2:-}" \
+        LOOM_MCP_SH_PERSONA="${3:-}" \
+        LOOM_MCP_SH_COMMAND="${4:-}" \
+        "${LOOM_PYTHON:-python3}" - <<'PY'
+import json, os, collections
+
+ws = os.environ["LOOM_MCP_WS"]
+socket = os.environ.get("LOOM_MCP_SH_SOCKET", "").strip()
+persona = os.environ.get("LOOM_MCP_SH_PERSONA", "").strip()
+command = os.environ.get("LOOM_MCP_SH_COMMAND", "").strip()
+
+servers = collections.OrderedDict()
+# loom MUST be first — claude-wrapper.sh's pre-flight keys off the first
+# server with args.
+servers["loom"] = {
+    "command": "node",
+    "args": [os.path.join(ws, "mcp-loom", "dist", "index.js")],
+    "env": {"LOOM_WORKSPACE": ws},
+}
+if socket and persona and command:
+    servers["safehouse"] = {
+        "command": command,
+        "args": [],
+        "env": {
+            "SAFEHOUSED_SOCKET": socket,
+            "SAFEHOUSE_PERSONA": persona,
+        },
+    }
+print(json.dumps({"mcpServers": servers}, indent=2))
+PY
+}

--- a/defaults/scripts/spawn-claude.sh
+++ b/defaults/scripts/spawn-claude.sh
@@ -362,6 +362,69 @@ fi
 : "${CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS:=0}"
 export CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS
 
+# --- Optional safehouse MCP server injection (issue #3999) ---
+# When the `safehouse` config block is enabled and a socket + launch command
+# resolve, inject a session-scoped MCP config that adds the `safehouse` stdio
+# server alongside `loom`, with a PER-WORKER persona so two concurrent workers
+# in the same workspace get distinct `SAFEHOUSE_PERSONA` values. The persona is
+# drawn from a bounded, operator-pre-registered pool (`safehouse.workerPersonas`)
+# round-robined by this worker's issue slot (`LOOM_SWEEP_CLAIM_OWNED`), because
+# safehoused's allowlist is a static boot-time TOML array with no runtime/prefix
+# registration — literal per-issue names cannot be minted at dispatch time.
+#
+# Delivery shape: a session-scoped `--mcp-config <file>` (not a rewrite of the
+# workspace `.mcp.json`). Concurrent sweeps SHARE the workspace root, so a
+# per-worker persona cannot live in the shared file; a session-scoped config is
+# the only correct per-worker surface. The file lists `loom` FIRST so it is
+# self-contained even if the session's cwd has no project `.mcp.json`.
+#
+# Degradation contract (mirrors #3997): disabled/absent ⇒ byte-for-byte no-op
+# (no --mcp-config appended). Enabled but the launch command is missing, or no
+# socket resolves ⇒ log a warning and SKIP injection — the `loom` MCP server is
+# never affected and the worker always starts. Only the socket path (no token or
+# key) is ever written into the injected config.
+_mcp_config_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/mcp-config.sh"
+if [[ -f "$_mcp_config_lib" ]]; then
+    # shellcheck source=./lib/mcp-config.sh
+    source "$_mcp_config_lib"
+
+    # Respect an explicit operator-supplied --mcp-config (do not clobber).
+    _has_mcp_config_arg=false
+    for _arg in ${PASSTHROUGH_ARGS[@]+"${PASSTHROUGH_ARGS[@]}"}; do
+        case "$_arg" in
+            --mcp-config | --mcp-config=*) _has_mcp_config_arg=true; break ;;
+        esac
+    done
+
+    if [[ "$_has_mcp_config_arg" == "false" \
+        && "$(loom_mcp_safehouse_enabled "$WORKSPACE")" == "true" ]]; then
+        _sh_socket="$(loom_mcp_safehouse_socket "$WORKSPACE")"
+        _sh_command="$(loom_mcp_safehouse_command "$WORKSPACE")"
+        _sh_pool="$(loom_mcp_worker_personas "$WORKSPACE")"
+        _sh_fallback="$(loom_mcp_safehouse_persona_fallback "$WORKSPACE")"
+        _sh_persona="$(loom_mcp_pick_persona \
+            "${LOOM_SWEEP_CLAIM_OWNED:-}" "$_sh_pool" "$_sh_fallback")"
+
+        if [[ -z "$_sh_socket" ]]; then
+            log_warn "spawn-claude: safehouse enabled but no socket resolves (safehouse.socket / \$LOOM_SAFEHOUSE_SOCKET / \$SAFEHOUSED_SOCKET); skipping safehouse MCP injection (loom MCP unaffected)."
+        elif ! command -v "$_sh_command" >/dev/null 2>&1; then
+            log_warn "spawn-claude: safehouse launch command '$_sh_command' not found in PATH; skipping safehouse MCP injection (loom MCP unaffected)."
+        else
+            if [[ ! -S "$_sh_socket" && ! -e "$_sh_socket" ]]; then
+                log_warn "spawn-claude: safehouse socket '$_sh_socket' not present at spawn; injecting anyway (best-effort — safehouse-mcp connects lazily and never blocks the worker)."
+            fi
+            _mcp_session_config="$(mktemp -t loom-mcp-config.XXXXXX 2>/dev/null || mktemp)"
+            if loom_mcp_emit_config "$WORKSPACE" "$_sh_socket" "$_sh_persona" "$_sh_command" >"$_mcp_session_config" 2>/dev/null; then
+                PASSTHROUGH_ARGS+=(--mcp-config "$_mcp_session_config")
+                log_info "spawn-claude: injected safehouse MCP server (persona=$_sh_persona, socket=$_sh_socket, config=$_mcp_session_config)"
+            else
+                rm -f "$_mcp_session_config"
+                log_warn "spawn-claude: failed to generate safehouse MCP config; skipping injection (loom MCP unaffected)."
+            fi
+        fi
+    fi
+fi
+
 # --- Dispatch ---
 if [[ "$USE_WRAPPER" == "true" ]]; then
     _wrapper="${WORKSPACE}/.loom/scripts/claude-wrapper.sh"

--- a/defaults/scripts/tests/test-mcp-config.sh
+++ b/defaults/scripts/tests/test-mcp-config.sh
@@ -1,0 +1,360 @@
+#!/usr/bin/env bash
+# test-mcp-config.sh — Tests for the safehouse MCP injection layer (issue #3999).
+#
+# Covers:
+#   1. Resolver precedence (env > config > default) for enabled/socket/persona.
+#   2. Per-worker persona pool round-robin (distinct per concurrent worker).
+#   3. loom_mcp_emit_config emits `loom` FIRST and appends `safehouse` only when
+#      socket + persona + command are all present; no token/key is emitted.
+#   4. Byte-identical regression: with safehouse disabled, scripts/setup-mcp.sh
+#      produces the exact pre-#3999 loom-only .mcp.json.
+#   5. claude-wrapper.sh's MCP pre-flight still resolves the `loom` entry point
+#      with two servers present.
+#
+# Style matches test-spawn-claude.sh — plain bash, hand-rolled assertions.
+# Bats is NOT used in this repository.
+#
+# Usage:
+#   ./.loom/scripts/tests/test-mcp-config.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Repo root: defaults/scripts/tests -> defaults/scripts -> defaults -> repo
+REPO_ROOT="$(cd "$SCRIPTS_DIR/../.." && pwd)"
+LIB="$SCRIPTS_DIR/lib/mcp-config.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected: '$expected'"
+        echo "    Actual:   '$actual'"
+    fi
+}
+
+assert_contains() {
+    local needle="$1" haystack="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" == *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+assert_not_contains() {
+    local needle="$1" haystack="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" != *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Unexpected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+# Isolate every resolver call from the ambient operator environment.
+unset LOOM_SAFEHOUSE_ENABLED LOOM_SAFEHOUSE_SOCKET LOOM_SAFEHOUSE_PERSONA \
+    LOOM_SAFEHOUSE_WORKER_PERSONAS LOOM_SAFEHOUSE_MCP_COMMAND SAFEHOUSED_SOCKET \
+    2>/dev/null || true
+
+# shellcheck source=../lib/mcp-config.sh
+source "$LIB"
+
+HAVE_JQ=false
+command -v jq >/dev/null 2>&1 && HAVE_JQ=true
+
+# ============================================================
+# Section 1: enabled resolution (env > config > default)
+# ============================================================
+echo "Testing loom_mcp_safehouse_enabled..."
+
+_empty_repo="$(mktemp -d)"
+assert_eq "false" "$(loom_mcp_safehouse_enabled "$_empty_repo")" \
+    "default is false when no config and no env"
+
+LOOM_SAFEHOUSE_ENABLED=1 \
+    assert_eq "true" "$(LOOM_SAFEHOUSE_ENABLED=1 loom_mcp_safehouse_enabled "$_empty_repo")" \
+    "env LOOM_SAFEHOUSE_ENABLED=1 forces true"
+
+assert_eq "false" "$(LOOM_SAFEHOUSE_ENABLED=off loom_mcp_safehouse_enabled "$_empty_repo")" \
+    "env LOOM_SAFEHOUSE_ENABLED=off forces false"
+
+assert_eq "false" "$(LOOM_SAFEHOUSE_ENABLED='' loom_mcp_safehouse_enabled "$_empty_repo")" \
+    "env LOOM_SAFEHOUSE_ENABLED='' forces false (matches daemon env_bool)"
+
+if $HAVE_JQ; then
+    _cfg_repo="$(mktemp -d)"
+    mkdir -p "$_cfg_repo/.loom"
+    cat >"$_cfg_repo/.loom/config.json" <<'JSON'
+{ "safehouse": { "enabled": true } }
+JSON
+    assert_eq "true" "$(loom_mcp_safehouse_enabled "$_cfg_repo")" \
+        "config safehouse.enabled=true resolves true"
+    assert_eq "false" "$(LOOM_SAFEHOUSE_ENABLED=0 loom_mcp_safehouse_enabled "$_cfg_repo")" \
+        "env overrides config (0 beats config true)"
+    rm -rf "$_cfg_repo"
+else
+    echo -e "  ${YELLOW}SKIP${NC}: config-layer enabled tests (jq not installed)"
+fi
+
+# ============================================================
+# Section 2: socket resolution (config > LOOM_SAFEHOUSE_SOCKET > SAFEHOUSED_SOCKET)
+# ============================================================
+echo "Testing loom_mcp_safehouse_socket..."
+
+assert_eq "" "$(loom_mcp_safehouse_socket "$_empty_repo")" \
+    "empty when nothing resolves"
+assert_eq "/tmp/a.sock" \
+    "$(LOOM_SAFEHOUSE_SOCKET=/tmp/a.sock loom_mcp_safehouse_socket "$_empty_repo")" \
+    "LOOM_SAFEHOUSE_SOCKET is used"
+assert_eq "/tmp/b.sock" \
+    "$(SAFEHOUSED_SOCKET=/tmp/b.sock loom_mcp_safehouse_socket "$_empty_repo")" \
+    "SAFEHOUSED_SOCKET fallback is used"
+assert_eq "/tmp/a.sock" \
+    "$(LOOM_SAFEHOUSE_SOCKET=/tmp/a.sock SAFEHOUSED_SOCKET=/tmp/b.sock loom_mcp_safehouse_socket "$_empty_repo")" \
+    "LOOM_SAFEHOUSE_SOCKET wins over SAFEHOUSED_SOCKET"
+
+if $HAVE_JQ; then
+    _sock_repo="$(mktemp -d)"
+    mkdir -p "$_sock_repo/.loom"
+    cat >"$_sock_repo/.loom/config.json" <<'JSON'
+{ "safehouse": { "socket": "/run/cfg.sock" } }
+JSON
+    assert_eq "/run/cfg.sock" \
+        "$(LOOM_SAFEHOUSE_SOCKET=/tmp/env.sock loom_mcp_safehouse_socket "$_sock_repo")" \
+        "config safehouse.socket wins over env (matches daemon resolve order)"
+    rm -rf "$_sock_repo"
+fi
+
+# ============================================================
+# Section 3: persona fallback + worker pool round-robin
+# ============================================================
+echo "Testing persona resolution..."
+
+assert_eq "loom_daemon" "$(loom_mcp_safehouse_persona_fallback "$_empty_repo")" \
+    "persona fallback default is loom_daemon"
+assert_eq "loom_x" \
+    "$(LOOM_SAFEHOUSE_PERSONA=loom_x loom_mcp_safehouse_persona_fallback "$_empty_repo")" \
+    "LOOM_SAFEHOUSE_PERSONA overrides fallback"
+
+# pick_persona with empty pool -> fallback
+assert_eq "loom_daemon" "$(loom_mcp_pick_persona 42 "" loom_daemon)" \
+    "empty pool falls back to scalar persona"
+
+# pick_persona round-robin: distinct concurrent issues -> distinct personas
+pool="loom_b1,loom_b2,loom_b3,loom_b4"
+p10="$(loom_mcp_pick_persona 10 "$pool" loom_daemon)"
+p11="$(loom_mcp_pick_persona 11 "$pool" loom_daemon)"
+p12="$(loom_mcp_pick_persona 12 "$pool" loom_daemon)"
+assert_eq "loom_b3" "$p10" "issue 10 -> pool[10%4]=pool[2]"
+assert_eq "loom_b4" "$p11" "issue 11 -> pool[11%4]=pool[3]"
+assert_eq "loom_b1" "$p12" "issue 12 -> pool[12%4]=pool[0]"
+# The acceptance-critical property: two concurrent workers differ.
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$p10" != "$p11" && "$p11" != "$p12" && "$p10" != "$p12" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: three concurrent issues (10,11,12) get three distinct personas"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: concurrent personas not distinct ($p10/$p11/$p12)"
+fi
+
+# unknown issue slot -> deterministic first pool entry
+assert_eq "loom_b1" "$(loom_mcp_pick_persona "" "$pool" loom_daemon)" \
+    "unknown issue slot -> first pool entry"
+assert_eq "loom_b1" "$(loom_mcp_pick_persona "not-a-number" "$pool" loom_daemon)" \
+    "non-numeric issue slot -> first pool entry"
+
+# worker personas from env
+assert_eq "a,b,c" \
+    "$(LOOM_SAFEHOUSE_WORKER_PERSONAS=a,b,c loom_mcp_worker_personas "$_empty_repo")" \
+    "LOOM_SAFEHOUSE_WORKER_PERSONAS env pool is read"
+
+if $HAVE_JQ; then
+    _pool_repo="$(mktemp -d)"
+    mkdir -p "$_pool_repo/.loom"
+    cat >"$_pool_repo/.loom/config.json" <<'JSON'
+{ "safehouse": { "workerPersonas": ["loom_builder_1", "loom_builder_2"] } }
+JSON
+    assert_eq "loom_builder_1,loom_builder_2" \
+        "$(loom_mcp_worker_personas "$_pool_repo")" \
+        "config safehouse.workerPersonas array is joined to CSV"
+    rm -rf "$_pool_repo"
+fi
+
+# ============================================================
+# Section 4: emit config — loom first, safehouse additive, no secrets
+# ============================================================
+echo "Testing loom_mcp_emit_config..."
+
+loom_only="$(loom_mcp_emit_config /ws/root)"
+assert_contains '"loom"' "$loom_only" "loom-only config contains loom server"
+assert_not_contains '"safehouse"' "$loom_only" \
+    "loom-only config has NO safehouse entry (no socket/persona/command)"
+assert_contains '/ws/root/mcp-loom/dist/index.js' "$loom_only" \
+    "loom-only config points at mcp-loom entry"
+
+two_server="$(loom_mcp_emit_config /ws/root /run/sh.sock loom_builder_1 safehouse-mcp)"
+assert_contains '"safehouse"' "$two_server" "two-server config contains safehouse"
+assert_contains '"SAFEHOUSED_SOCKET": "/run/sh.sock"' "$two_server" \
+    "safehouse env carries the socket path"
+assert_contains '"SAFEHOUSE_PERSONA": "loom_builder_1"' "$two_server" \
+    "safehouse env carries the per-worker persona"
+
+# loom MUST appear before safehouse in iteration order.
+loom_pos="$(printf '%s' "$two_server" | grep -n '"loom"' | head -1 | cut -d: -f1)"
+sh_pos="$(printf '%s' "$two_server" | grep -n '"safehouse"' | head -1 | cut -d: -f1)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -n "$loom_pos" && -n "$sh_pos" && "$loom_pos" -lt "$sh_pos" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: loom server appears before safehouse (line $loom_pos < $sh_pos)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: loom must precede safehouse (loom@$loom_pos safehouse@$sh_pos)"
+fi
+
+# Security: no token/key/secret words in the emitted config.
+for word in token TOKEN api_key API_KEY secret SECRET password OAUTH oauth; do
+    assert_not_contains "$word" "$two_server" "emitted config contains no '$word'"
+done
+
+# ============================================================
+# Section 5: claude-wrapper.sh MCP pre-flight resolves loom with 2 servers
+# ============================================================
+echo "Testing claude-wrapper.sh MCP pre-flight extraction with two servers..."
+
+_pf_dir="$(mktemp -d)"
+loom_mcp_emit_config /ws/root /run/sh.sock loom_builder_1 safehouse-mcp \
+    >"$_pf_dir/.mcp.json"
+
+# This is the EXACT extraction logic from defaults/scripts/claude-wrapper.sh
+# check_mcp_server(): the first server with args wins.
+_entry="$(python3 -c "
+import json, sys
+with open('$_pf_dir/.mcp.json') as f:
+    cfg = json.load(f)
+servers = cfg.get('mcpServers', {})
+for name, srv in servers.items():
+    args = srv.get('args', [])
+    if args:
+        print(args[-1])
+        sys.exit(0)
+")"
+assert_eq "/ws/root/mcp-loom/dist/index.js" "$_entry" \
+    "pre-flight extracts the loom entry point (first server with args) with safehouse present"
+rm -rf "$_pf_dir"
+
+# ============================================================
+# Section 6: byte-identical setup-mcp.sh output when safehouse disabled
+# ============================================================
+echo "Testing setup-mcp.sh byte-identical loom-only output (safehouse disabled)..."
+
+_run_setup_mcp() {
+    # Build an isolated workspace with a pre-built (fake) mcp bundle so
+    # setup-mcp.sh skips the npm build, then run it and echo the produced JSON.
+    local ws="$1"
+    mkdir -p "$ws/scripts" "$ws/mcp-loom/dist" \
+        "$ws/defaults/scripts/lib"
+    # Fake, non-stale bundle (no src/ dir -> no staleness rebuild).
+    : >"$ws/mcp-loom/dist/index.js"
+    cp "$REPO_ROOT/scripts/setup-mcp.sh" "$ws/scripts/setup-mcp.sh"
+    cp "$SCRIPTS_DIR/lib/mcp-config.sh" "$ws/defaults/scripts/lib/mcp-config.sh"
+    cp "$SCRIPTS_DIR/lib/config-resolver.sh" "$ws/defaults/scripts/lib/config-resolver.sh"
+    ( bash "$ws/scripts/setup-mcp.sh" >/dev/null 2>&1 )
+    cat "$ws/.mcp.json"
+}
+
+_disabled_ws="$(mktemp -d)"
+actual_disabled="$(_run_setup_mcp "$_disabled_ws")"
+read -r -d '' expected_disabled <<EOF || true
+{
+  "mcpServers": {
+    "loom": {
+      "command": "node",
+      "args": ["$_disabled_ws/mcp-loom/dist/index.js"],
+      "env": {
+        "LOOM_WORKSPACE": "$_disabled_ws"
+      }
+    }
+  }
+}
+EOF
+assert_eq "$expected_disabled" "$actual_disabled" \
+    "setup-mcp.sh with no safehouse block is byte-identical to pre-#3999 output"
+rm -rf "$_disabled_ws"
+
+# setup-mcp.sh with safehouse enabled emits a two-server file, loom first.
+if $HAVE_JQ; then
+    _enabled_ws="$(mktemp -d)"
+    mkdir -p "$_enabled_ws/scripts" "$_enabled_ws/mcp-loom/dist" \
+        "$_enabled_ws/defaults/scripts/lib" "$_enabled_ws/.loom"
+    : >"$_enabled_ws/mcp-loom/dist/index.js"
+    : >"$_enabled_ws/sh.sock" # a resolvable socket path
+    cp "$REPO_ROOT/scripts/setup-mcp.sh" "$_enabled_ws/scripts/setup-mcp.sh"
+    cp "$SCRIPTS_DIR/lib/mcp-config.sh" "$_enabled_ws/defaults/scripts/lib/mcp-config.sh"
+    cp "$SCRIPTS_DIR/lib/config-resolver.sh" "$_enabled_ws/defaults/scripts/lib/config-resolver.sh"
+    cat >"$_enabled_ws/.loom/config.json" <<JSON
+{ "safehouse": { "enabled": true, "socket": "$_enabled_ws/sh.sock",
+  "persona": "loom_daemon", "mcpCommand": "cat" } }
+JSON
+    ( bash "$_enabled_ws/scripts/setup-mcp.sh" >/dev/null 2>&1 )
+    enabled_out="$(cat "$_enabled_ws/.mcp.json")"
+    assert_contains '"safehouse"' "$enabled_out" \
+        "setup-mcp.sh with safehouse enabled emits a safehouse server"
+    assert_contains "$_enabled_ws/sh.sock" "$enabled_out" \
+        "setup-mcp.sh safehouse entry carries the socket path"
+    # loom still first
+    e_loom="$(printf '%s' "$enabled_out" | grep -n '"loom"' | head -1 | cut -d: -f1)"
+    e_sh="$(printf '%s' "$enabled_out" | grep -n '"safehouse"' | head -1 | cut -d: -f1)"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ -n "$e_loom" && -n "$e_sh" && "$e_loom" -lt "$e_sh" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: setup-mcp.sh keeps loom before safehouse"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: setup-mcp.sh loom must precede safehouse"
+    fi
+    rm -rf "$_enabled_ws"
+else
+    echo -e "  ${YELLOW}SKIP${NC}: setup-mcp.sh enabled test (jq not installed)"
+fi
+
+rm -rf "$_empty_repo"
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo "========================================"
+echo "Test Results:"
+echo "  Total:  $TESTS_RUN"
+echo -e "  ${GREEN}Passed: $TESTS_PASSED${NC}"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo -e "  ${RED}Failed: $TESTS_FAILED${NC}"
+    exit 1
+fi
+echo -e "  ${GREEN}All tests passed!${NC}"

--- a/scripts/setup-mcp.sh
+++ b/scripts/setup-mcp.sh
@@ -14,6 +14,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Get the workspace root (parent of scripts/)
 WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# Optional safehouse MCP server injection (#3999). Sourcing the shared resolver
+# is best-effort: when the lib is absent (e.g. an older installed tree) or the
+# safehouse block is disabled, generation falls through to the loom-only heredoc
+# below, byte-for-byte identical to the pre-#3999 output.
+MCP_CONFIG_LIB="$WORKSPACE_ROOT/defaults/scripts/lib/mcp-config.sh"
+# shellcheck source=../defaults/scripts/lib/mcp-config.sh
+[[ -f "$MCP_CONFIG_LIB" ]] && source "$MCP_CONFIG_LIB"
+
 MCP_DIR="$WORKSPACE_ROOT/mcp-loom"
 MCP_SRC="$MCP_DIR/src"
 MCP_ENTRY="$MCP_DIR/dist/index.js"
@@ -48,8 +56,63 @@ if [[ "$NEEDS_BUILD" -eq 1 ]]; then
   fi
 fi
 
-# Generate .mcp.json with unified loom server
-cat > "$WORKSPACE_ROOT/.mcp.json" <<EOF
+# Resolve the optional safehouse server (#3999). When the block is enabled and
+# a socket + launch command resolve, emit a second `safehouse` server AFTER the
+# unchanged `loom` entry. This workspace-root file uses the scalar
+# `safehouse.persona` (workspace-wide); per-worker personas are injected at
+# spawn time by spawn-claude.sh via --mcp-config. When disabled/unresolved, the
+# loom-only heredoc below is byte-for-byte identical to the pre-#3999 output.
+SAFEHOUSE_ENABLED="false"
+SH_SOCKET=""
+SH_PERSONA=""
+SH_COMMAND=""
+if declare -F loom_mcp_safehouse_enabled >/dev/null 2>&1; then
+  SAFEHOUSE_ENABLED="$(loom_mcp_safehouse_enabled "$WORKSPACE_ROOT")"
+fi
+if [[ "$SAFEHOUSE_ENABLED" == "true" ]]; then
+  SH_SOCKET="$(loom_mcp_safehouse_socket "$WORKSPACE_ROOT")"
+  SH_PERSONA="$(loom_mcp_safehouse_persona_fallback "$WORKSPACE_ROOT")"
+  SH_COMMAND="$(loom_mcp_safehouse_command "$WORKSPACE_ROOT")"
+  if [[ -z "$SH_SOCKET" ]]; then
+    echo "Warning: safehouse enabled but no socket resolves (safehouse.socket / \$LOOM_SAFEHOUSE_SOCKET / \$SAFEHOUSED_SOCKET); omitting safehouse server." >&2
+    SH_SOCKET=""
+  elif ! command -v "$SH_COMMAND" >/dev/null 2>&1; then
+    echo "Warning: safehouse launch command '$SH_COMMAND' not found in PATH; omitting safehouse server (loom MCP unaffected)." >&2
+    SH_SOCKET=""
+  fi
+fi
+
+if [[ "$SAFEHOUSE_ENABLED" == "true" && -n "$SH_SOCKET" ]]; then
+  # Two-server config. `loom` stays FIRST (claude-wrapper.sh's pre-flight keys
+  # off the first server with args) and byte-identical to the loom-only block;
+  # `safehouse` is appended second. Only the socket path is credential-adjacent.
+  cat > "$WORKSPACE_ROOT/.mcp.json" <<EOF
+{
+  "mcpServers": {
+    "loom": {
+      "command": "node",
+      "args": ["$WORKSPACE_ROOT/mcp-loom/dist/index.js"],
+      "env": {
+        "LOOM_WORKSPACE": "$WORKSPACE_ROOT"
+      }
+    },
+    "safehouse": {
+      "command": "$SH_COMMAND",
+      "args": [],
+      "env": {
+        "SAFEHOUSED_SOCKET": "$SH_SOCKET",
+        "SAFEHOUSE_PERSONA": "$SH_PERSONA"
+      }
+    }
+  }
+}
+EOF
+  echo "Generated .mcp.json with loom + safehouse MCP servers"
+  echo "  Workspace: $WORKSPACE_ROOT"
+  echo "  Safehouse persona: $SH_PERSONA (socket: $SH_SOCKET)"
+else
+  # Generate .mcp.json with unified loom server
+  cat > "$WORKSPACE_ROOT/.mcp.json" <<EOF
 {
   "mcpServers": {
     "loom": {
@@ -63,6 +126,7 @@ cat > "$WORKSPACE_ROOT/.mcp.json" <<EOF
 }
 EOF
 
-echo "Generated .mcp.json with unified loom MCP server"
-echo "  Workspace: $WORKSPACE_ROOT"
-echo "  Server: mcp-loom/dist/index.js"
+  echo "Generated .mcp.json with unified loom MCP server"
+  echo "  Workspace: $WORKSPACE_ROOT"
+  echo "  Server: mcp-loom/dist/index.js"
+fi


### PR DESCRIPTION
Closes #3999

## What this does

Phase 2 of the safehouse fleet-comms layer (#3997 shipped the daemon-side, emit-only phase 1). When the `safehouse` config block is enabled, worker sessions now get the keyless `safehouse-mcp` stdio server injected into their MCP config with `SAFEHOUSED_SOCKET` + a **per-worker** `SAFEHOUSE_PERSONA`, so a Builder can `safehouse_send`/`safehouse_read` in the room mid-task instead of being label-only.

## Design decisions (please read — deliberate scope choices)

### 1. Per-worker persona = bounded, pre-registered POOL (not literal `loom_builder_<issue>`)

The issue's literal criterion asks for "the worker's assigned persona … `loom_builder_42`". That exact dynamic-naming path is **genuinely blocked externally**: `.loom/docs/safehouse.md` (and `loom-daemon/src/safehouse.rs:30-34`) confirm safehoused reads its persona allowlist **once at boot** from a static TOML array — no runtime registration, no glob/prefix matching, no SIGHUP reload. A name minted at dispatch time would be rejected at `hello`, and safehoused cannot restart per worker.

So this PR implements the acceptance *criterion* ("two workers running concurrently in the same workspace get different values") via a **bounded pool the operator pre-registers** in safehoused's allowlist, exactly the shape of the existing token pool: configure `safehouse.workerPersonas: ["loom_builder_1", …]`, add the same names to safehoused's `personas`, and each worker is assigned `workerPersonas[issue_number % pool_size]` (round-robin by worktree slot, issue number from `LOOM_SWEEP_CLAIM_OWNED`). With no pool configured it falls back to the scalar `safehouse.persona` (workspace-wide) — degrade, never fail. This needs **zero** safehoused-side change.

### 2. Injection shape = session-scoped `--mcp-config` at spawn time (Option 1)

Chosen over "extend setup-mcp per-worktree" because **concurrent sweeps share the workspace root** — a per-worker persona cannot live in the shared `.mcp.json`. `spawn-claude.sh` (the mandatory spawn path, where the persona is known) generates a session-scoped config with the persona substituted and passes `claude --mcp-config <file>`. The file lists `loom` FIRST so it is self-contained even when the session cwd has no project `.mcp.json`.

`scripts/setup-mcp.sh` *also* learns to append the safehouse server (with the **scalar** persona, since it is not per-worker) to the workspace-root `.mcp.json` — this covers direct/human `claude` sessions and reaches worktree sessions via the `.mcp.json` symlink `worktree.sh` already creates. Both writers keep `loom` first and byte-for-byte unchanged.

### 3. "Can't verify safehouse-mcp's binary/protocol" gap → configurable + graceful

The `safehouse-mcp` command, tool names, and env vars live in the external `rjwalters/safehouse` repo and are not verifiable here. So the launcher is configurable (`safehouse.mcpCommand`, default `safehouse-mcp`) and follows #3997's degradation contract: a **missing launch command or unresolvable socket → one `warn` + skip injection**, `loom` MCP unaffected, worker always starts. A socket that is configured but not yet present is injected best-effort (safehouse-mcp connects lazily). No token/key is ever written — the socket path is the only credential-adjacent value.

## Acceptance criteria

- [x] Enabled → worker MCP config has a `safehouse` server with `SAFEHOUSED_SOCKET` + per-worker `SAFEHOUSE_PERSONA` (pool, distinct per concurrent worker).
- [x] Disabled/absent → generated config byte-identical to today (automated regression test: `setup-mcp.sh` output compared byte-for-byte; spawn-claude appends no `--mcp-config`).
- [x] Socket configured but absent/unconnectable → worker starts, loom MCP works, logged not fatal.
- [x] Injection reaches worktree sessions (spawn-claude injects on the top-level sweep session inherited by Task subagents; setup-mcp's file reaches worktrees via the existing `.mcp.json` symlink).
- [x] No token/key in the injected config (security grep test — zero hits).
- [x] `loom` entry unchanged and first — test exercises `claude-wrapper.sh`'s exact pre-flight extraction with two servers present and asserts it still returns the loom entry point.

## Testing

`defaults/scripts/tests/test-mcp-config.sh` — 43 assertions (resolver precedence env>config>default, pool round-robin distinctness, loom-first emit, no-secrets grep, claude-wrapper two-server pre-flight, byte-identical setup-mcp regression). Verified `shellcheck -x` clean on all four changed shell files and the existing `test-spawn-claude.sh` (80 assertions) still passes. Manually smoke-tested spawn-claude's three paths (disabled → no `--mcp-config`; enabled → `--mcp-config` with correct per-issue persona, loom first; missing command → skip + warn).

## Notes for reviewer

- `defaults/config.json` gains `safehouse.workerPersonas` + `safehouse.mcpCommand`; `loom-daemon/src/safehouse.rs` reads only known keys (no `deny_unknown_fields`) so the daemon ignores them.
- `.loom/scripts` is a symlink to `defaults/scripts`, so the spawn-claude/lib edits land in `defaults/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
