### PR TITLE
feat(scripts): migrate 9 config readers onto config-resolver.sh

### DIFF
--- a/defaults/scripts/archive-transcripts.sh
+++ b/defaults/scripts/archive-transcripts.sh
@@ -46,6 +46,10 @@
 
 set -uo pipefail
 
+_ARCHIVE_TRANSCRIPTS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/config-resolver.sh
+source "$_ARCHIVE_TRANSCRIPTS_SCRIPT_DIR/lib/config-resolver.sh"
+
 # ------------------------------------------------------------------ output ---
 RED='\033[0;31m'; GREEN='\033[0;32m'; BLUE='\033[0;34m'; YELLOW='\033[1;33m'
 CYAN='\033[0;36m'; NC='\033[0m'
@@ -101,14 +105,17 @@ PROJECTS_DIR="$CLAUDE_BASE/projects"
 # and for the config.json read).  A worktree resolves to the worktree root.
 REPO_ROOT="$(git -C "$SOURCE_CWD" rev-parse --show-toplevel 2>/dev/null || true)"
 REPO_LABEL="$(basename "${REPO_ROOT:-$SOURCE_CWD}")"
-CONFIG_JSON="${REPO_ROOT:+$REPO_ROOT/.loom/config.json}"
 
+# Config read via the config-resolver tier chain (#4062) instead of a single
+# hand-rolled `.loom/config.json` read — a `.loom-project/project.json` or
+# `.loom-local/local.json` override is picked up too. Only attempted when
+# REPO_ROOT resolved (best-effort, same as the historical CONFIG_JSON guard).
 CFG_ENABLED=false
 CFG_DIR=""
-if [[ -n "${CONFIG_JSON:-}" && -f "$CONFIG_JSON" ]] && command -v jq >/dev/null 2>&1; then
-  # Best-effort: malformed JSON -> jq fails -> disabled default preserved.
-  CFG_ENABLED="$(jq -r '.loom.transcriptArchive.enabled // false' "$CONFIG_JSON" 2>/dev/null || echo false)"
-  CFG_DIR="$(jq -r '.loom.transcriptArchive.dir // ""' "$CONFIG_JSON" 2>/dev/null || echo "")"
+if [[ -n "${REPO_ROOT:-}" ]] && command -v jq >/dev/null 2>&1; then
+  # Best-effort: a malformed tier soft-fails to {} -> disabled default preserved.
+  CFG_ENABLED="$(loom_config_get "$REPO_ROOT" "loom.transcriptArchive.enabled" "false")"
+  CFG_DIR="$(loom_config_get "$REPO_ROOT" "loom.transcriptArchive.dir" "")"
 fi
 
 ENABLED=false

--- a/defaults/scripts/archive-transcripts.sh
+++ b/defaults/scripts/archive-transcripts.sh
@@ -113,9 +113,13 @@ REPO_LABEL="$(basename "${REPO_ROOT:-$SOURCE_CWD}")"
 CFG_ENABLED=false
 CFG_DIR=""
 if [[ -n "${REPO_ROOT:-}" ]] && command -v jq >/dev/null 2>&1; then
+  # Resolve the merged effective config ONCE (config-resolver, #4062) — then
+  # extract both keys from that single resolved JSON via jq, rather than two
+  # loom_config_get calls that would each re-merge all four config tiers.
   # Best-effort: a malformed tier soft-fails to {} -> disabled default preserved.
-  CFG_ENABLED="$(loom_config_get "$REPO_ROOT" "loom.transcriptArchive.enabled" "false")"
-  CFG_DIR="$(loom_config_get "$REPO_ROOT" "loom.transcriptArchive.dir" "")"
+  _archive_cfg="$(loom_resolve_config "$REPO_ROOT")"
+  CFG_ENABLED="$(echo "$_archive_cfg" | jq -r '.loom.transcriptArchive.enabled // false' 2>/dev/null || echo false)"
+  CFG_DIR="$(echo "$_archive_cfg" | jq -r '.loom.transcriptArchive.dir // ""' 2>/dev/null || echo "")"
 fi
 
 ENABLED=false

--- a/defaults/scripts/cli/loom-start.sh
+++ b/defaults/scripts/cli/loom-start.sh
@@ -14,6 +14,10 @@
 
 set -euo pipefail
 
+_LOOM_START_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/config-resolver.sh
+source "$_LOOM_START_SCRIPT_DIR/../lib/config-resolver.sh"
+
 # Find repository root
 find_repo_root() {
     local dir="$PWD"
@@ -43,7 +47,6 @@ if [[ -z "$REPO_ROOT" ]]; then
     exit 1
 fi
 
-CONFIG_FILE="$REPO_ROOT/.loom/config.json"
 # shellcheck disable=SC2034  # LOG_DIR reserved for future logging enhancements
 LOG_DIR="/tmp"
 TMUX_SOCKET="loom"
@@ -112,7 +115,8 @@ ${YELLOW}CONFIGURATION:${NC}
 ${YELLOW}REQUIREMENTS:${NC}
     - tmux must be installed
     - claude CLI must be in PATH
-    - .loom/config.json must exist
+    - a resolved config with a non-empty terminals array must exist (.loom/config.json,
+      .loom-project/project.json, or .loom-local/local.json)
 EOF
 }
 
@@ -153,19 +157,62 @@ check_dependencies() {
     fi
 }
 
-# Check if config file exists
+# List of config tier paths (lowest to highest precedence), for diagnostics.
+_loom_start_config_tiers() {
+    local repo_root="$1"
+    local defaults_path
+    defaults_path="$(_loom_config_private_defaults_path)"
+    [[ -n "$defaults_path" ]] && echo "$defaults_path"
+    echo "$repo_root/$LOOM_CONFIG_LEGACY_REL"
+    echo "$repo_root/$LOOM_CONFIG_PROJECT_REL"
+    echo "$repo_root/$LOOM_CONFIG_LOCAL_REL"
+}
+
+# Check that a valid, non-empty effective config resolves for this workspace.
+#
+# Migrated onto the config-resolver tier chain (#4062). Two distinct failure
+# modes are preserved, matching loom-daemon's handle_validate_command /
+# role_validation.rs `has_terminals` precondition (#4059) so the Bash and Rust
+# entry points agree:
+#
+#   1. MALFORMED TIER (regression guard): loom_resolve_config soft-fails a
+#      malformed tier file to `{}` silently -- appropriate for the resolver's
+#      general contract, but NOT here. A typo'd config must still fail loudly
+#      (non-zero, explicit message) rather than silently degrading to "no
+#      terminals configured" -- so every EXISTING tier file is validated as
+#      parseable JSON before the merge is trusted.
+#   2. NO TERMINALS ANYWHERE: retargeted from "the legacy .loom/config.json
+#      file exists" to "the resolved config has a non-empty `terminals`
+#      array" -- absence of the legacy file no longer implies absence of
+#      config under tiering (terminals may come from
+#      .loom-project/project.json alone). The exit behavior (non-zero) is
+#      preserved; only the condition is retargeted.
+#
+# Sets EFFECTIVE_CONFIG (compact JSON) as a side effect for reuse by callers
+# (Trap 2 -- resolve once, don't re-merge per key).
 check_config() {
-    if [[ ! -f "$CONFIG_FILE" ]]; then
-        echo -e "${RED}Error: Configuration file not found: $CONFIG_FILE${NC}" >&2
+    local tier_path
+    while IFS= read -r tier_path; do
+        if [[ -f "$tier_path" ]] && ! jq empty "$tier_path" 2>/dev/null; then
+            echo -e "${RED}Error: Invalid JSON in $tier_path${NC}" >&2
+            exit 1
+        fi
+    done < <(_loom_start_config_tiers "$REPO_ROOT")
+
+    EFFECTIVE_CONFIG="$(loom_resolve_config "$REPO_ROOT")"
+
+    local has_terminals
+    has_terminals=$(echo "$EFFECTIVE_CONFIG" | jq '(.terminals // []) | length > 0' 2>/dev/null || echo false)
+    if [[ "$has_terminals" != "true" ]]; then
+        echo -e "${RED}Error: No Loom config with a non-empty \`terminals\` array found in any tier.${NC}" >&2
+        echo "" >&2
+        echo "Searched (lowest to highest precedence):" >&2
+        while IFS= read -r tier_path; do
+            echo "  - $tier_path" >&2
+        done < <(_loom_start_config_tiers "$REPO_ROOT")
         echo "" >&2
         echo "Have you initialized Loom in this repository?" >&2
         echo "Run: ./scripts/install-loom.sh" >&2
-        exit 1
-    fi
-
-    # Validate JSON
-    if ! jq empty "$CONFIG_FILE" 2>/dev/null; then
-        echo -e "${RED}Error: Invalid JSON in $CONFIG_FILE${NC}" >&2
         exit 1
     fi
 }
@@ -284,17 +331,17 @@ main() {
     # Check config
     check_config
 
-    # Parse terminals from config
+    # Parse terminals from the effective config (EFFECTIVE_CONFIG was resolved
+    # once by check_config() above via loom_resolve_config -- Trap 1/2: array
+    # sites resolve once and reuse the merged JSON, never per-field
+    # loom_config_get). check_config() already guarantees a non-empty
+    # terminals array here (the hard-fail precondition it enforces), so no
+    # redundant zero-count check is needed at this point.
     local terminals
-    terminals=$(jq -c '.terminals // []' "$CONFIG_FILE")
+    terminals=$(echo "$EFFECTIVE_CONFIG" | jq -c '.terminals // []')
 
     local terminal_count
     terminal_count=$(echo "$terminals" | jq 'length')
-
-    if [[ "$terminal_count" -eq 0 ]]; then
-        echo -e "${YELLOW}No terminals configured in $CONFIG_FILE${NC}"
-        exit 0
-    fi
 
     # Filter by role if specified
     if [[ -n "$only_role" ]]; then
@@ -307,11 +354,22 @@ main() {
         fi
     fi
 
-    # Display summary
+    # Display summary. Under tiering, "Config:" names every tier that
+    # actually exists on disk rather than a single legacy path -- naming only
+    # .loom/config.json would be misleading (or falsely read as "none") once
+    # a higher tier supplies the effective config (#4062).
+    local config_tiers_present
+    # `|| true`: under `set -o pipefail`, a while-loop's exit status is that
+    # of the last command run in its final iteration -- if the LAST tier path
+    # tested happens to not exist (the common case for .loom-local/local.json
+    # and the private-defaults tier), `[[ -f "$t" ]]` is the last thing that
+    # ran and its nonzero status would otherwise propagate through the
+    # pipeline and trip `set -e`, aborting the script (#4062 regression).
+    config_tiers_present=$(_loom_start_config_tiers "$REPO_ROOT" | while IFS= read -r t; do [[ -f "$t" ]] && echo "$t"; done | paste -sd ', ' - || true)
     echo -e "${BOLD}Loom Agent Pool${NC}"
     echo ""
     echo -e "  Workspace: ${CYAN}$REPO_ROOT${NC}"
-    echo -e "  Config: ${CYAN}$CONFIG_FILE${NC}"
+    echo -e "  Config: ${CYAN}${config_tiers_present:-none found}${NC}"
     echo -e "  Agents: ${CYAN}$terminal_count${NC}"
     if [[ -n "$only_role" ]]; then
         echo -e "  Filter: ${CYAN}$only_role${NC}"

--- a/defaults/scripts/cli/loom-status.sh
+++ b/defaults/scripts/cli/loom-status.sh
@@ -22,6 +22,10 @@
 
 set -euo pipefail
 
+_LOOM_STATUS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/config-resolver.sh
+source "$_LOOM_STATUS_SCRIPT_DIR/../lib/config-resolver.sh"
+
 # Find repository root
 find_repo_root() {
     local dir="$PWD"
@@ -51,8 +55,38 @@ if [[ -z "$REPO_ROOT" ]]; then
     exit 1
 fi
 
-CONFIG_FILE="$REPO_ROOT/.loom/config.json"
 TMUX_SOCKET="loom"
+
+# List of config tier paths that exist on disk (lowest to highest precedence).
+# Used only for the human "Config:" display line -- naming every present tier
+# instead of a single legacy path (#4062).
+_loom_status_config_tiers_present() {
+    local dp
+    dp="$(_loom_config_private_defaults_path)"
+    [[ -n "$dp" && -f "$dp" ]] && echo "$dp"
+    [[ -f "$REPO_ROOT/$LOOM_CONFIG_LEGACY_REL" ]] && echo "$REPO_ROOT/$LOOM_CONFIG_LEGACY_REL"
+    [[ -f "$REPO_ROOT/$LOOM_CONFIG_PROJECT_REL" ]] && echo "$REPO_ROOT/$LOOM_CONFIG_PROJECT_REL"
+    [[ -f "$REPO_ROOT/$LOOM_CONFIG_LOCAL_REL" ]] && echo "$REPO_ROOT/$LOOM_CONFIG_LOCAL_REL"
+    # Explicit trailing success: under `set -o pipefail`, this function's exit
+    # status is whatever its last statement returned. The common case (no
+    # local/private-defaults tier present) makes the last `[[ -f ]] && echo`
+    # above false -- without this, callers piping this function's output
+    # (e.g. `_loom_status_config_tiers_present | paste ...`) would see the
+    # pipeline fail and, combined with `set -e`, abort the whole script
+    # (#4062 regression).
+    return 0
+}
+
+# Resolve the effective config ONCE per invocation (config-resolver, #4062)
+# and memoize it -- read_terminals() may be called from both emit_json and
+# emit_human, and must not re-merge the tier chain on every call.
+_LOOM_STATUS_EFFECTIVE_CONFIG=""
+_loom_status_effective_config() {
+    if [[ -z "$_LOOM_STATUS_EFFECTIVE_CONFIG" ]]; then
+        _LOOM_STATUS_EFFECTIVE_CONFIG="$(loom_resolve_config "$REPO_ROOT")"
+    fi
+    echo "$_LOOM_STATUS_EFFECTIVE_CONFIG"
+}
 
 # ANSI colors
 if [[ -t 1 ]]; then
@@ -184,10 +218,13 @@ work_queue_json() {
         '{"loom:issue":$issue, "loom:review-requested":$review_requested, "loom:pr":$pr}'
 }
 
-# Read the configured terminals as compact JSON array (or "[]")
+# Read the configured terminals as compact JSON array (or "[]"), resolved
+# through the config-resolver tier chain (#4062) rather than a single-tier
+# .loom/config.json read -- a workspace may supply terminals entirely from
+# .loom-project/project.json.
 read_terminals() {
-    if [[ -f "$CONFIG_FILE" ]] && command -v jq &>/dev/null; then
-        jq -c '.terminals // []' "$CONFIG_FILE" 2>/dev/null || echo "[]"
+    if command -v jq &>/dev/null; then
+        _loom_status_effective_config | jq -c '.terminals // []' 2>/dev/null || echo "[]"
     else
         echo "[]"
     fi
@@ -268,10 +305,16 @@ emit_human() {
     echo -e "${BOLD}Loom Agent Pool${NC}"
     echo ""
     echo -e "  Workspace: ${CYAN}$REPO_ROOT${NC}"
-    if [[ -f "$CONFIG_FILE" ]]; then
-        echo -e "  Config:    ${CYAN}$CONFIG_FILE${NC}"
+    # Names every config tier present on disk instead of a single legacy path
+    # -- naming only .loom/config.json would misreport "(none)" once a higher
+    # tier (e.g. .loom-project/project.json alone) supplies the effective
+    # config (#4062).
+    local config_tiers_present
+    config_tiers_present="$(_loom_status_config_tiers_present | paste -sd ', ' - 2>/dev/null)"
+    if [[ -n "$config_tiers_present" ]]; then
+        echo -e "  Config:    ${CYAN}$config_tiers_present${NC}"
     else
-        echo -e "  Config:    ${GRAY}(none — $CONFIG_FILE not found)${NC}"
+        echo -e "  Config:    ${GRAY}(none found — checked .loom/config.json, .loom-project/project.json, .loom-local/local.json)${NC}"
     fi
     echo -e "  Socket:    ${CYAN}tmux -L $TMUX_SOCKET${NC}"
     echo ""

--- a/defaults/scripts/lib/forge-helpers.sh
+++ b/defaults/scripts/lib/forge-helpers.sh
@@ -21,11 +21,29 @@
 #
 # Forge detection priority:
 #   1. LOOM_FORGE_TYPE env var
-#   2. .loom/config.json forge.type (if not "auto")
+#   2. Resolved config (config-resolver tier chain) forge.type (if not "auto")
 #   3. Auto-detect from git remote origin URL
 #   4. Default to "github"
+#
+# Config root resolution (#4062, decision recorded in epic #4081): the
+# resolved-config root is $REPO_ROOT (env) > $WORKSPACE_ROOT (env) > the
+# CANONICAL repo root via `git rev-parse --git-common-dir` — never the
+# worktree CWD. This mirrors spawn-claude.sh's #3938 precedent: forge auth is
+# exactly the kind of thing that must not silently resolve against the wrong
+# (worktree-local) directory.
 
 set -euo pipefail
+
+# ${BASH_SOURCE[0]:-$0} (not bare ${BASH_SOURCE[0]}) -- the bash+zsh-portable
+# self-path idiom from #3680. Slash commands (champion-reference.md,
+# champion-pr-merge.md) `source` this file DIRECTLY into the invoking shell
+# via an absolute path, which on macOS is often zsh (the Bash tool's default
+# shell). Under zsh, BASH_SOURCE is unset, so a bare ${BASH_SOURCE[0]}
+# resolves to the shell's CWD instead of this lib dir and the source below
+# fails (zsh sets $0 to the sourced file's own path, which recovers it).
+_LOOM_FORGE_HELPERS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=./config-resolver.sh
+source "$_LOOM_FORGE_HELPERS_LIB_DIR/config-resolver.sh"
 
 # --- Forge Detection ---
 
@@ -34,6 +52,33 @@ FORGE_TYPE=""
 _GITEA_BASE_URL=""
 _GITEA_TOKEN=""
 _GITEA_USERNAME=""
+
+# _forge_config_root -> echoes the root to resolve config from.
+# Precedence: $REPO_ROOT (env) > $WORKSPACE_ROOT (env) > canonical repo root
+# via `git rev-parse --git-common-dir` (parent of the common .git dir — works
+# identically from the main checkout or any linked worktree) > "." as a last
+# resort when git itself is unavailable (e.g. not inside a git repo).
+_forge_config_root() {
+  if [[ -n "${REPO_ROOT:-}" ]]; then
+    echo "$REPO_ROOT"
+    return 0
+  fi
+  if [[ -n "${WORKSPACE_ROOT:-}" ]]; then
+    echo "$WORKSPACE_ROOT"
+    return 0
+  fi
+
+  local git_common_dir
+  if git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null)"; then
+    if [[ "$git_common_dir" != /* ]]; then
+      git_common_dir="$(cd "$git_common_dir" && pwd)"
+    fi
+    dirname "$git_common_dir"
+    return 0
+  fi
+
+  echo "."
+}
 
 # Detect forge type from environment, config, or remote URL.
 # Sets FORGE_TYPE to "github" or "gitea".
@@ -55,19 +100,18 @@ forge_detect() {
     esac
   fi
 
-  # 2. Config file
-  local config_file
-  if [[ -n "${REPO_ROOT:-}" ]]; then
-    config_file="$REPO_ROOT/.loom/config.json"
-  elif [[ -n "${WORKSPACE_ROOT:-}" ]]; then
-    config_file="$WORKSPACE_ROOT/.loom/config.json"
-  else
-    config_file=".loom/config.json"
-  fi
+  # Resolve the merged effective config ONCE per invocation (config-resolver,
+  # #4062) and reuse it below for both the forge.type check and the
+  # forge.gitea.url autodetect fallback — never re-merge the tier chain per
+  # key within a single call.
+  local _forge_root _forge_cfg
+  _forge_root=$(_forge_config_root)
+  _forge_cfg=$(loom_resolve_config "$_forge_root")
 
-  if [[ -f "$config_file" ]] && command -v jq &>/dev/null; then
+  # 2. Resolved config — forge.type (if not "auto")
+  if command -v jq >/dev/null 2>&1; then
     local config_type
-    config_type=$(jq -r '.forge.type // "auto"' "$config_file" 2>/dev/null || echo "auto")
+    config_type=$(echo "$_forge_cfg" | jq -r '.forge.type // "auto"' 2>/dev/null || echo "auto")
     local config_lower
     config_lower=$(echo "$config_type" | tr '[:upper:]' '[:lower:]')
     case "$config_lower" in
@@ -87,9 +131,9 @@ forge_detect() {
       return 0
     fi
     # Check if host matches configured Gitea URL
-    if [[ -f "$config_file" ]] && command -v jq &>/dev/null; then
+    if command -v jq >/dev/null 2>&1; then
       local gitea_url
-      gitea_url=$(jq -r '.forge.gitea.url // ""' "$config_file" 2>/dev/null || echo "")
+      gitea_url=$(echo "$_forge_cfg" | jq -r '.forge.gitea.url // ""' 2>/dev/null || echo "")
       if [[ -n "$gitea_url" ]]; then
         local gitea_host
         gitea_host=$(_extract_host "$gitea_url")
@@ -133,24 +177,22 @@ _load_gitea_config() {
   # Username: env var first, then config. When set, switches to HTTP Basic Auth.
   _GITEA_USERNAME="${GITEA_USERNAME:-}"
 
-  local config_file
-  if [[ -n "${REPO_ROOT:-}" ]]; then
-    config_file="$REPO_ROOT/.loom/config.json"
-  elif [[ -n "${WORKSPACE_ROOT:-}" ]]; then
-    config_file="$WORKSPACE_ROOT/.loom/config.json"
-  else
-    config_file=".loom/config.json"
-  fi
+  # Resolve the merged effective config ONCE (config-resolver, #4062) — only
+  # when at least one of the three env vars above didn't already win, and
+  # only once regardless of how many of the three keys are still missing.
+  if [[ -z "$_GITEA_TOKEN" || -z "$_GITEA_BASE_URL" || -z "$_GITEA_USERNAME" ]] && command -v jq >/dev/null 2>&1; then
+    local _forge_root _forge_cfg
+    _forge_root=$(_forge_config_root)
+    _forge_cfg=$(loom_resolve_config "$_forge_root")
 
-  if [[ -f "$config_file" ]] && command -v jq &>/dev/null; then
     if [[ -z "$_GITEA_TOKEN" ]]; then
-      _GITEA_TOKEN=$(jq -r '.forge.gitea.token // ""' "$config_file" 2>/dev/null || echo "")
+      _GITEA_TOKEN=$(echo "$_forge_cfg" | jq -r '.forge.gitea.token // ""' 2>/dev/null || echo "")
     fi
     if [[ -z "$_GITEA_BASE_URL" ]]; then
-      _GITEA_BASE_URL=$(jq -r '.forge.gitea.url // ""' "$config_file" 2>/dev/null || echo "")
+      _GITEA_BASE_URL=$(echo "$_forge_cfg" | jq -r '.forge.gitea.url // ""' 2>/dev/null || echo "")
     fi
     if [[ -z "$_GITEA_USERNAME" ]]; then
-      _GITEA_USERNAME=$(jq -r '.forge.gitea.username // ""' "$config_file" 2>/dev/null || echo "")
+      _GITEA_USERNAME=$(echo "$_forge_cfg" | jq -r '.forge.gitea.username // ""' 2>/dev/null || echo "")
     fi
   fi
 

--- a/defaults/scripts/lib/worktree-root.sh
+++ b/defaults/scripts/lib/worktree-root.sh
@@ -39,6 +39,25 @@
 #     documented v1 limitation (see the issue), not a bug this helper guards.
 #   - This helper never creates directories; callers `mkdir -p` the parent as
 #     needed (git worktree add creates only the leaf).
+#
+# Config resolution (#4062): the `worktree.root` key is read through the
+# config-resolver tier chain (loom_config_get) instead of a hand-rolled
+# single-tier `.loom/config.json` read, so an override in
+# `.loom-project/project.json` / `.loom-local/local.json` is honored too.
+# `worktree.root` is a plain string, so a single loom_config_get call is
+# correct here (no array/object multi-field re-merge concern — see
+# config-resolver.sh's docstring on non-scalar values).
+#
+# ${BASH_SOURCE[0]:-$0} (not bare ${BASH_SOURCE[0]}) -- the bash+zsh-portable
+# self-path idiom from #3680: disk-headroom.sh sources this file, and
+# disk-headroom.sh is itself sourced DIRECTLY into the invoking shell by
+# sweep.md's Stage -1, which on macOS is often zsh. Under zsh, BASH_SOURCE is
+# unset, so a bare ${BASH_SOURCE[0]} resolves to the shell's CWD instead of
+# this lib dir and the source below fails (zsh sets $0 to the sourced file's
+# own path, which recovers it).
+_LOOM_WORKTREE_ROOT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=./config-resolver.sh
+source "$_LOOM_WORKTREE_ROOT_LIB_DIR/config-resolver.sh"
 
 # loom_worktree_root <repo_root>
 #
@@ -58,21 +77,19 @@ loom_worktree_root() {
         return 0
     fi
 
-    # 2. Config key override — .loom/config.json → worktree.root.
-    #    Same jq guard pattern as worktree.linkPaths (worktree.sh).
-    local config_file="$repo_root/.loom/config.json"
-    if command -v jq >/dev/null 2>&1 && [[ -f "$config_file" ]]; then
-        local cfg_root
-        cfg_root=$(jq -r '.worktree.root? // empty' "$config_file" 2>/dev/null)
-        if [[ -n "$cfg_root" ]]; then
-            if [[ "$cfg_root" == /* ]]; then
-                echo "${cfg_root%/}/$(basename "$repo_root")"
-                return 0
-            fi
-            echo "loom_worktree_root: worktree.root in .loom/config.json must be an absolute path (got: '$cfg_root'); falling back to default" >&2
-            echo "$repo_root/.loom/worktrees"
+    # 2. Config key override — worktree.root, resolved through the config
+    #    tier chain (legacy .loom/config.json, .loom-project/project.json,
+    #    .loom-local/local.json, private defaults).
+    local cfg_root
+    cfg_root=$(loom_config_get "$repo_root" "worktree.root" "")
+    if [[ -n "$cfg_root" ]]; then
+        if [[ "$cfg_root" == /* ]]; then
+            echo "${cfg_root%/}/$(basename "$repo_root")"
             return 0
         fi
+        echo "loom_worktree_root: worktree.root in the resolved config must be an absolute path (got: '$cfg_root'); falling back to default" >&2
+        echo "$repo_root/.loom/worktrees"
+        return 0
     fi
 
     # 3. Default — unchanged historical behavior.

--- a/defaults/scripts/tests/test-config-tiers-cli-migration.sh
+++ b/defaults/scripts/tests/test-config-tiers-cli-migration.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# test-config-tiers-cli-migration.sh — Tests for issue #4062: migrating the
+# nine Bash config readers under defaults/scripts/ onto config-resolver.sh.
+#
+# Covers the CLI/script call sites NOT already covered by
+# test-config-resolver.sh, test-worktree-root-override.sh,
+# test-worktree-nested-symlinks.sh, or test-forge-helpers.sh:
+#
+#   1. loom-status.sh picks up terminals[] supplied ONLY via
+#      .loom-project/project.json (no legacy .loom/config.json at all).
+#   2. validate-roles.sh picks up terminals[] / roleFile values from the
+#      project tier alone, and its `--json` machine-readable output reflects
+#      them.
+#   3. validate-roles.sh hard-fails (both --json and human branches) when NO
+#      tier supplies a non-empty terminals array — the Trap 3 retargeted
+#      precondition ("no terminals in the effective config" replacing "the
+#      legacy file is missing").
+#   4. loom-start.sh hard-fails, loudly and non-zero, when an EXISTING tier
+#      file is malformed JSON — the regression guard called out in the issue:
+#      loom_resolve_config soft-fails a malformed tier to `{}` silently, which
+#      would otherwise make a typo'd config silently start zero terminals.
+#   5. loom-start.sh hard-fails when no tier supplies terminals, and
+#      succeeds (--dry-run) when terminals come from the project tier alone.
+#   6. forge-helpers.sh's forge_detect / _load_gitea_config resolve config
+#      from the CANONICAL repo root when invoked from inside a linked git
+#      worktree, never the worktree's own (possibly divergent) checkout --
+#      the root-resolution decision recorded in epic #4081 (canonical repo
+#      root via `git rev-parse --git-common-dir`, mirroring the #3938
+#      spawn-claude.sh precedent).
+#
+# IMPORTANT: these are #!/usr/bin/env bash scripts. Run this file (and any
+# individual assertion) via `bash`, never sourced from an interactive zsh
+# shell -- under zsh, _loom_config_soft_read silently returns {} for a valid
+# config (looks exactly like a resolver bug; it isn't). See config-resolver.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+LOOM_STATUS_SH="$SCRIPTS_DIR/cli/loom-status.sh"
+LOOM_START_SH="$SCRIPTS_DIR/cli/loom-start.sh"
+VALIDATE_ROLES_SH="$SCRIPTS_DIR/validate-roles.sh"
+FORGE_HELPERS_LIB="$SCRIPTS_DIR/lib/forge-helpers.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq not found on PATH -- skipping test-config-tiers-cli-migration.sh"
+    exit 0
+fi
+
+# A plain workspace anchor: find_repo_root()/find_workspace_root() in these
+# scripts only require a `.loom` directory to exist -- no git repo needed
+# unless a test specifically exercises worktree/canonical-root resolution.
+new_workspace() {
+    local dir
+    dir=$(mktemp -d)
+    mkdir -p "$dir/.loom"
+    echo "$dir"
+}
+
+# --- Test 1: loom-status.sh --json picks up terminals from the project tier alone ---
+echo "Test 1: loom-status.sh --json -- terminals from .loom-project/project.json alone"
+ws=$(new_workspace)
+mkdir -p "$ws/.loom-project"
+cat > "$ws/.loom-project/project.json" <<'JSON'
+{"terminals": [{"id": "cfgtier-t1", "name": "Builder", "roleConfig": {"roleFile": "builder.md"}}]}
+JSON
+out=$(cd "$ws" && "$LOOM_STATUS_SH" --json 2>&1) || true
+if echo "$out" | jq -e '(.stopped + .running) | map(select(.id == "cfgtier-t1")) | length == 1' >/dev/null 2>&1; then
+    pass "loom-status.sh --json lists a terminal sourced only from the project tier"
+else
+    fail "loom-status.sh --json did not surface the project-tier-only terminal (got: $out)"
+fi
+rm -rf "$ws"
+
+# --- Test 2: validate-roles.sh picks up roles from the project tier alone ---
+echo ""
+echo "Test 2: validate-roles.sh --json -- roles from .loom-project/project.json alone"
+ws=$(new_workspace)
+mkdir -p "$ws/.loom-project"
+cat > "$ws/.loom-project/project.json" <<'JSON'
+{"terminals": [{"roleConfig": {"roleFile": "judge.md"}}, {"roleConfig": {"roleFile": "champion.md"}}]}
+JSON
+out=$(cd "$ws" && "$VALIDATE_ROLES_SH" --json 2>&1) || true
+if echo "$out" | jq -e '.configured_roles | index("judge") != null and index("champion") != null' >/dev/null 2>&1; then
+    pass "validate-roles.sh --json resolves configured_roles from the project tier alone"
+else
+    fail "validate-roles.sh --json did not resolve project-tier roles (got: $out)"
+fi
+rm -rf "$ws"
+
+# --- Test 3: validate-roles.sh hard-fails when no tier supplies terminals ---
+echo ""
+echo "Test 3: validate-roles.sh hard-fails when no tier supplies a non-empty terminals array"
+ws=$(new_workspace)  # .loom/ exists, but no config.json anywhere in any tier
+
+set +e
+out_human=$(cd "$ws" && "$VALIDATE_ROLES_SH" 2>&1)
+status_human=$?
+out_json=$(cd "$ws" && "$VALIDATE_ROLES_SH" --json 2>&1)
+status_json=$?
+set -e
+
+if [[ "$status_human" -ne 0 ]]; then
+    pass "validate-roles.sh (human) exits non-zero with no terminals in any tier"
+else
+    fail "validate-roles.sh (human) exited 0 with no terminals anywhere"
+fi
+if echo "$out_human" | grep -qi "terminals"; then
+    pass "validate-roles.sh (human) error names terminals, not a single legacy path"
+else
+    fail "validate-roles.sh (human) error message unexpected: $out_human"
+fi
+if [[ "$status_json" -ne 0 ]]; then
+    pass "validate-roles.sh --json exits non-zero with no terminals in any tier"
+else
+    fail "validate-roles.sh --json exited 0 with no terminals anywhere"
+fi
+if echo "$out_json" | jq -e '.error' >/dev/null 2>&1; then
+    pass "validate-roles.sh --json still emits a JSON object with .error on the retargeted failure"
+else
+    fail "validate-roles.sh --json did not emit valid JSON with .error (got: $out_json)"
+fi
+rm -rf "$ws"
+
+# --- Test 4: validate-roles.sh hard-fails on a PRESENT-but-empty terminals array too ---
+echo ""
+echo "Test 4: validate-roles.sh hard-fails when the only tier's terminals array is empty"
+ws=$(new_workspace)
+echo '{"terminals": []}' > "$ws/.loom/config.json"
+set +e
+out=$(cd "$ws" && "$VALIDATE_ROLES_SH" 2>&1)
+status=$?
+set -e
+if [[ "$status" -ne 0 ]]; then
+    pass "validate-roles.sh treats a present-but-empty terminals array as absent (matches Rust has_terminals)"
+else
+    fail "validate-roles.sh exited 0 for an empty terminals array"
+fi
+rm -rf "$ws"
+
+# The remaining tests exercise loom-start.sh, which additionally requires
+# tmux + claude on PATH (check_dependencies runs before config resolution).
+# Skip gracefully rather than falsely reporting a config-resolution failure
+# when the real blocker is a missing unrelated dependency.
+if ! command -v tmux >/dev/null 2>&1 || ! command -v claude >/dev/null 2>&1; then
+    echo ""
+    echo "tmux and/or claude not found on PATH -- skipping loom-start.sh tests (5-7)"
+else
+    # --- Test 5: loom-start.sh malformed tier JSON -> loud non-zero failure ---
+    echo ""
+    echo "Test 5: loom-start.sh fails loudly on a malformed EXISTING tier file (regression guard)"
+    ws=$(new_workspace)
+    printf '{ "terminals": [ invalid json' > "$ws/.loom/config.json"
+    set +e
+    out=$(cd "$ws" && "$LOOM_START_SH" --dry-run 2>&1)
+    status=$?
+    set -e
+    if [[ "$status" -ne 0 ]]; then
+        pass "loom-start.sh exits non-zero on a malformed tier file"
+    else
+        fail "loom-start.sh exited 0 despite malformed .loom/config.json (silent-degrade regression)"
+    fi
+    if echo "$out" | grep -qi "Invalid JSON"; then
+        pass "loom-start.sh names the malformed file explicitly (does not silently report 'no terminals')"
+    else
+        fail "loom-start.sh malformed-JSON error message unexpected: $out"
+    fi
+    rm -rf "$ws"
+
+    # --- Test 6: loom-start.sh hard-fails when no tier supplies terminals ---
+    echo ""
+    echo "Test 6: loom-start.sh hard-fails when no tier supplies a non-empty terminals array"
+    ws=$(new_workspace)
+    set +e
+    out=$(cd "$ws" && "$LOOM_START_SH" --dry-run 2>&1)
+    status=$?
+    set -e
+    if [[ "$status" -ne 0 ]]; then
+        pass "loom-start.sh exits non-zero with no terminals in any tier"
+    else
+        fail "loom-start.sh exited 0 with no terminals anywhere"
+    fi
+    if echo "$out" | grep -qi "terminals"; then
+        pass "loom-start.sh error names terminals, not a single legacy path"
+    else
+        fail "loom-start.sh error message unexpected: $out"
+    fi
+    rm -rf "$ws"
+
+    # --- Test 7: loom-start.sh --dry-run picks up terminals from the project tier alone ---
+    echo ""
+    echo "Test 7: loom-start.sh --dry-run -- terminals from .loom-project/project.json alone"
+    ws=$(new_workspace)
+    mkdir -p "$ws/.loom-project"
+    cat > "$ws/.loom-project/project.json" <<'JSON'
+{"terminals": [{"id": "cfgtier-start-t1", "name": "Builder", "roleConfig": {"roleFile": "builder.md"}}]}
+JSON
+    set +e
+    out=$(cd "$ws" && "$LOOM_START_SH" --dry-run 2>&1)
+    status=$?
+    set -e
+    if [[ "$status" -eq 0 ]]; then
+        pass "loom-start.sh --dry-run succeeds with terminals from the project tier alone"
+    else
+        fail "loom-start.sh --dry-run failed with project-tier-only terminals (exit $status): $out"
+    fi
+    if echo "$out" | grep -q "cfgtier-start-t1"; then
+        pass "loom-start.sh --dry-run lists the project-tier-only terminal"
+    else
+        fail "loom-start.sh --dry-run did not list the project-tier terminal: $out"
+    fi
+    rm -rf "$ws"
+fi
+
+# --- Test 8: forge-helpers.sh resolves from the CANONICAL repo root, never
+#     the worktree's own (possibly divergent) checkout, per the #4081
+#     decision record (git rev-parse --git-common-dir, mirroring the #3938
+#     spawn-claude.sh precedent). ---
+echo ""
+echo "Test 8: forge_detect / _load_gitea_config resolve from canonical repo root inside a worktree"
+if ! command -v git >/dev/null 2>&1; then
+    echo "git not found on PATH -- skipping Test 8"
+else
+    main_repo=$(mktemp -d)
+    git init -q -b main "$main_repo"
+    (
+        cd "$main_repo"
+        git config user.email t@t
+        git config user.name t
+        mkdir -p .loom
+        cat > .loom/config.json <<'JSON'
+{"forge": {"type": "gitea", "gitea": {"url": "https://gitea.example.com", "token": "tok-main-root", "username": "main-user"}}}
+JSON
+        git add .loom/config.json
+        git commit -q -m "add gitea config"
+    )
+
+    worktree_dir="${main_repo}-wt"
+    (cd "$main_repo" && git worktree add -q "$worktree_dir" -b wt-branch)
+
+    # Diverge: delete the WORKTREE-LOCAL copy of .loom/config.json (git
+    # checks it out into every worktree since it's tracked). If forge_detect
+    # wrongly resolved against the worktree's own CWD instead of the
+    # canonical repo root, this file would now be absent there and detection
+    # would fall through to the git-remote autodetect / github default --
+    # exposing exactly the regression this test guards against.
+    rm -f "$worktree_dir/.loom/config.json"
+
+    result=$(
+        cd "$worktree_dir"
+        unset REPO_ROOT WORKSPACE_ROOT LOOM_FORGE_TYPE 2>/dev/null || true
+        # shellcheck source=../lib/forge-helpers.sh
+        source "$FORGE_HELPERS_LIB"
+        forge_detect
+        echo "TYPE=$FORGE_TYPE"
+        echo "TOKEN=$_GITEA_TOKEN"
+        echo "URL=$_GITEA_BASE_URL"
+    )
+
+    if echo "$result" | grep -q "^TYPE=gitea$"; then
+        pass "forge_detect resolves forge.type from the canonical repo root inside a worktree"
+    else
+        fail "forge_detect did not resolve gitea from canonical root (got: $result)"
+    fi
+    if echo "$result" | grep -q "^TOKEN=tok-main-root$"; then
+        pass "_load_gitea_config resolves the token from the canonical repo root, not worktree CWD"
+    else
+        fail "_load_gitea_config did not resolve the main-repo token (got: $result)"
+    fi
+
+    rm -rf "$main_repo" "$worktree_dir"
+fi
+
+# --- Summary ---
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+[[ $TESTS_FAILED -eq 0 ]] || exit 1

--- a/defaults/scripts/validate-roles.sh
+++ b/defaults/scripts/validate-roles.sh
@@ -82,21 +82,40 @@ WORKSPACE_ROOT=$(find_workspace_root) || {
     exit 1
 }
 
-CONFIG_FILE="$WORKSPACE_ROOT/.loom/config.json"
+# Resolved through the config-resolver tier chain (#4062) rather than a
+# hand-rolled single-tier .loom/config.json read -- a workspace may supply
+# terminals entirely from .loom-project/project.json or .loom-local/local.json.
+# Resolved ONCE and reused below by get_configured_roles (Trap 2 -- never
+# re-merge the tier chain per key).
+_LOOM_VALIDATE_ROLES_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/config-resolver.sh
+source "$_LOOM_VALIDATE_ROLES_LIB_DIR/lib/config-resolver.sh"
 
-if [[ ! -f "$CONFIG_FILE" ]]; then
+EFFECTIVE_CONFIG=$(loom_resolve_config "$WORKSPACE_ROOT")
+
+# Retargeted hard-fail precondition (#4059/#4062): "no tier supplies a
+# non-empty terminals array" replaces "the legacy .loom/config.json file is
+# missing" -- mirrors loom-daemon's handle_validate_command / role_validation.rs
+# `has_terminals` check so the Bash and Rust validators agree. Both the --json
+# and human output branches are preserved, and the message names every tier
+# searched instead of a single legacy path.
+TERMINAL_COUNT=$(echo "$EFFECTIVE_CONFIG" | jq '(.terminals // []) | length' 2>/dev/null || echo 0)
+if [[ "$TERMINAL_COUNT" -eq 0 ]]; then
     if [[ "$JSON_OUTPUT" == "true" ]]; then
-        echo '{"error": "Config file not found: '"$CONFIG_FILE"'"}'
+        echo '{"error": "No Loom config with a non-empty terminals array found in any tier", "searched": ["'"$WORKSPACE_ROOT/$LOOM_CONFIG_LEGACY_REL"'", "'"$WORKSPACE_ROOT/$LOOM_CONFIG_PROJECT_REL"'", "'"$WORKSPACE_ROOT/$LOOM_CONFIG_LOCAL_REL"'"]}'
     else
-        echo -e "${RED}Error: Config file not found: $CONFIG_FILE${NC}" >&2
+        echo -e "${RED}Error: No Loom config with a non-empty \`terminals\` array found in any tier.${NC}" >&2
+        echo "Searched (lowest to highest precedence):" >&2
+        echo "  - $WORKSPACE_ROOT/$LOOM_CONFIG_LEGACY_REL" >&2
+        echo "  - $WORKSPACE_ROOT/$LOOM_CONFIG_PROJECT_REL" >&2
+        echo "  - $WORKSPACE_ROOT/$LOOM_CONFIG_LOCAL_REL" >&2
     fi
     exit 1
 fi
 
-# Extract configured roles from config.json
-# Uses jq to parse terminals and extract roleFile names
+# Extract configured roles from the resolved effective config.
 get_configured_roles() {
-    jq -r '.terminals[]?.roleConfig?.roleFile // empty' "$CONFIG_FILE" 2>/dev/null | \
+    echo "$EFFECTIVE_CONFIG" | jq -r '.terminals[]?.roleConfig?.roleFile // empty' 2>/dev/null | \
         sed 's/\.md$//' | \
         sort -u
 }

--- a/defaults/scripts/worktree.sh
+++ b/defaults/scripts/worktree.sh
@@ -1584,13 +1584,19 @@ if _try_worktree_add; then
                     -name node_modules -not -path "*/node_modules/*" -print0 2>/dev/null)
     fi
 
-    # Symlink additional gitignored paths configured in .loom/config.json under
-    # worktree.linkPaths (e.g. generated wasm-pack bindings that are expensive
-    # to rebuild per worktree). Best-effort: missing config, missing jq, malformed
-    # JSON, or an empty/absent key all silently skip this step (#3528). Mirrors
-    # the inline-jq-with-guard pattern from validate-roles.sh.
-    LOOM_CONFIG_FILE="$MAIN_WORKSPACE_DIR/.loom/config.json"
-    if command -v jq >/dev/null 2>&1 && [[ -f "$LOOM_CONFIG_FILE" ]]; then
+    # Symlink additional gitignored paths configured for worktree.linkPaths
+    # (e.g. generated wasm-pack bindings that are expensive to rebuild per
+    # worktree). Best-effort: missing config, missing jq, malformed JSON, or
+    # an empty/absent key all silently skip this step (#3528).
+    #
+    # Resolved through the config-resolver tier chain (#4062, lib/worktree-root.sh
+    # already sources lib/config-resolver.sh) ONCE, then queried locally via jq
+    # — worktree.linkPaths is an array, so loom_config_get's pretty-printed
+    # multi-line-JSON return for non-scalars must not be used here (see
+    # config-resolver.sh's docstring); resolve the merged JSON and pipe it
+    # through the existing jq expression instead.
+    if command -v jq >/dev/null 2>&1; then
+        LOOM_WORKTREE_LINKPATHS_CFG="$(loom_resolve_config "$MAIN_WORKSPACE_DIR")"
         while IFS= read -r link_path; do
             if [[ -z "$link_path" ]]; then
                 continue
@@ -1610,7 +1616,7 @@ if _try_worktree_add; then
                     fi
                 fi
             fi
-        done < <(jq -r '.worktree.linkPaths[]? // empty' "$LOOM_CONFIG_FILE" 2>/dev/null)
+        done < <(echo "$LOOM_WORKTREE_LINKPATHS_CFG" | jq -r '.worktree.linkPaths[]? // empty' 2>/dev/null)
     fi
 
     # Symlink .mcp.json from main workspace if available


### PR DESCRIPTION
## Summary

Migrates the nine `.loom/config.json` readers under `defaults/scripts/` (8 functions across 7 files — `forge_detect` appears twice, reading two different keys on two branches) onto `lib/config-resolver.sh`'s tier chain, per issue #4062 (parent #4047, epic #3835).

**Adopted decisions** (as required by the issue):
- **Malformed-JSON diagnostic mechanism**: `loom-start.sh`'s `check_config()` (and `validate-roles.sh`'s equivalent) explicitly validates every *existing* config tier file as parseable JSON (`jq empty <tier>`) before trusting the resolver's merge — `loom_resolve_config` itself soft-fails a malformed tier to `{}` silently (correct for its general contract), but that would otherwise regress `loom-start.sh` from "loud non-zero error" to "silently starts zero terminals" for a typo'd config. A new regression test (`test-config-tiers-cli-migration.sh` Test 5) locks this in.
- **Forge root-resolution answer**: `forge_detect` / `_load_gitea_config` resolve from `$REPO_ROOT` (env) → `$WORKSPACE_ROOT` (env) → the **canonical repo root** via `git rev-parse --git-common-dir` (never the worktree CWD) — the decision recorded in epic #4081 (mirrors the `spawn-claude.sh` #3938 precedent). A new test exercises this from inside a linked git worktree with the worktree's own `.loom/config.json` deliberately deleted, to prove resolution isn't happening against worktree-local CWD.

## Changes

- **`lib/worktree-root.sh`** (`loom_worktree_root`): `worktree.root` now read via `loom_config_get` (single scalar key) instead of a hand-rolled single-tier `jq` read.
- **`lib/forge-helpers.sh`** (`forge_detect`, `_load_gitea_config`): both resolve the merged effective config **once per invocation** (Trap 2) via the new `_forge_config_root` helper + `loom_resolve_config`, then query the cached JSON locally with `jq`.
- **`archive-transcripts.sh`**: `loom.transcriptArchive.{enabled,dir}` read via `loom_config_get`; the `${LOOM_TRANSCRIPT_ARCHIVE+set}` presence-check semantics are untouched.
- **`worktree.sh`** (`worktree.linkPaths[]`): resolves `loom_resolve_config` **once**, then pipes the merged JSON through the existing `jq -r '.worktree.linkPaths[]? // empty'` expression (Trap 1 — never per-field `loom_config_get` on an array key, since that returns pretty-printed multi-line JSON for non-scalars).
- **`cli/loom-start.sh`**: `check_config()` retargeted from "the legacy file exists" to "the resolved config has a non-empty `terminals` array" (mirrors loom-daemon's `#4059` `has_terminals` precondition), while preserving the malformed-JSON hard-fail as a distinct diagnostic. The `.terminals` read (L289) and the `Config:` display line (L314) both reuse the once-resolved `EFFECTIVE_CONFIG`.
- **`cli/loom-status.sh`**: `read_terminals()` resolves the effective config once (memoized across `emit_json`/`emit_human` calls); the `Config:` display line lists every tier present on disk instead of a single legacy path.
- **`validate-roles.sh`**: same hard-fail retarget as `loom-start.sh`, preserving **both** the `--json` and human error branches per the issue's trap; `get_configured_roles()` reuses the once-resolved config.
- **Zsh-safe sourcing** (`worktree-root.sh`, `forge-helpers.sh`): both are sourced directly into a possibly-zsh top-level shell (`disk-headroom.sh`'s Stage -1 chain; `champion-reference.md` / `champion-pr-merge.md` slash commands), so their new `source .../config-resolver.sh` lines use the `${BASH_SOURCE[0]:-$0}` idiom from #3680 rather than a bare `${BASH_SOURCE[0]}`.
- **Bug found and fixed while writing tests**: a `[[ -f "$tier" ]] && echo "$tier"` conditional as the *last* statement of a tier-listing helper (or the last iteration of a loop consuming one) can make that command exit non-zero in the common case (no local/private-defaults tier present) — combined with `set -o pipefail` + `set -e`, this silently aborted `loom-start.sh`/`loom-status.sh`'s new "Config:" display line. Fixed with an explicit trailing `return 0` / `|| true`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| All nine sites source `lib/config-resolver.sh` and resolve through `loom_resolve_config` / `loom_config_get`; no inline `.loom/config.json` path construction remains (excl. `config-resolver.sh`, `tests/`) | ✅ | `grep -rn '\.loom/config\.json' defaults/scripts/**/*.sh` (excl. tests/) shows only literal doc/help-text mentions in `verify-install.sh`, `loom-help.sh`, `loom-daemon-start.sh` (explicitly out of scope) plus prose comments |
| Array/object sites resolve ONCE and reuse the merged JSON; no per-field `loom_config_get` in a loop | ✅ | `worktree.sh` linkPaths and all three `terminals[]` sites (`loom-start.sh`, `loom-status.sh`, `validate-roles.sh`) call `loom_resolve_config` once and query locally via `jq` |
| The two hard-fail preconditions retargeted to "no terminals in the effective config"; both `validate-roles.sh` output branches preserved | ✅ | `test-config-tiers-cli-migration.sh` Tests 3 (validate-roles, human + `--json`), 6 (loom-start.sh) |
| Malformed-config diagnostics survive (`loom-start.sh` still fails loudly, non-zero) | ✅ | `test-config-tiers-cli-migration.sh` Test 5 (regression guard) |
| Status/display output does not report `(none)` or name a single legacy path when a higher tier supplied config | ✅ | `loom-start.sh`/`loom-status.sh` `Config:` lines now list every present tier; manual smoke-test below |
| `jq` absent ⇒ every site degrades exactly as it does today | ✅ | Verified per-site: `loom_config_get`/`loom_resolve_config` internally guard `command -v jq`; `test-worktree-nested-symlinks.sh` Test 5 (missing-jq case) still passes unmodified |
| A repo with only `.loom/config.json` produces byte-identical behavior at all nine sites | ✅ | `diff` against `main`'s `loom-status.sh`, `loom-start.sh --dry-run`, `validate-roles.sh` output in this repo's own `.loom/config.json` — **byte-identical** (see Test Plan) |
| `terminals[]` supplied only via `.loom-project/project.json` is picked up by `loom-start.sh`, `loom-status.sh`, `validate-roles.sh` | ✅ | `test-config-tiers-cli-migration.sh` Tests 1, 2, 7 |
| Forge root-resolution matches the adopted decision; PR body states which was adopted | ✅ | See "Adopted decisions" above; `test-config-tiers-cli-migration.sh` Test 8 (from inside a linked worktree) |

## Test Plan

Ran existing suites (all pass, `bash -c '<test>.sh'` per the issue's zsh-trap note):

```
test-config-resolver.sh                14/14
test-worktree-root-override.sh         18/18
test-archive-transcripts.sh            23/23
test-worktree-nested-symlinks.sh       11/11
test-verify-install-scope.sh           16/16
test-forge-helpers.sh                  36/36
test-disk-headroom.sh                  33/33 (regression caught+fixed: worktree-root.sh's
                                                new config-resolver.sh source needs the
                                                zsh-safe BASH_SOURCE idiom)
test-mcp-config.sh                     43/43
test-worktree-{base-override,concurrency,hookspath,json-purity,remove,
  sentinel,sentinel-reinvoke}.sh, test-pr-worktree-isolation.sh,
  test-gitignore-guard.sh, test-default-branch.sh,
  test-merge-pr-*.sh, test-rebase-stacked-children.sh,
  test-spawn-claude.sh, test-sweep-auto-stack.sh    all green
```

Added `defaults/scripts/tests/test-config-tiers-cli-migration.sh` (15 assertions, all passing):
1. `loom-status.sh --json` — terminals from `.loom-project/project.json` alone
2. `validate-roles.sh --json` — roles from the project tier alone
3. `validate-roles.sh` hard-fails (human **and** `--json`) with no terminals in any tier
4. `validate-roles.sh` hard-fails on a present-but-empty `terminals: []` too (matches Rust `has_terminals`)
5. `loom-start.sh` fails loudly (non-zero, "Invalid JSON" message) on a malformed existing tier file
6. `loom-start.sh` hard-fails with no terminals anywhere
7. `loom-start.sh --dry-run` succeeds and lists a terminal sourced only from the project tier
8. `forge_detect` / `_load_gitea_config` resolve `gitea`+token from the **canonical repo root** when run from inside a linked worktree whose own `.loom/config.json` was deliberately deleted (proves canonical-root resolution, not worktree-CWD)

Manual smoke test — byte-identical to `main` for the common single-tier case:
```bash
diff <(bash main-loom-status.sh) <(bash loom-status.sh)              # identical
diff <(bash main-loom-start.sh --dry-run) <(bash loom-start.sh --dry-run)  # identical
diff <(bash main-validate-roles.sh) <(bash validate-roles.sh)        # identical
```

## Out of Scope (per issue)

- `defaults/hooks/*` guard readers (sibling issue #4063)
- `defaults/scripts/resolve-model.sh`, `cli/loom-daemon-start.sh`, `verify-install.sh`, `cli/loom-help.sh` — unchanged per the issue

Closes #4062