### PR TITLE
fix(daemon): write install-metadata + real version on direct `loom-daemon init` (#4050)

### DIFF
--- a/loom-daemon/src/init/mod.rs
+++ b/loom-daemon/src/init/mod.rs
@@ -35,7 +35,9 @@ use std::path::Path;
 use serde_json::Value;
 
 use file_ops::{clean_managed_dir, copy_dir_with_report, verify_copied_files, TemplateContext};
-use post_init::{find_overbroad_loom_patterns, generate_manifest, update_gitignore};
+use post_init::{
+    find_overbroad_loom_patterns, generate_manifest, update_gitignore, write_install_metadata,
+};
 use retired::cleanup_retired_files;
 use scaffolding::setup_repository_scaffolding;
 
@@ -216,6 +218,14 @@ pub fn initialize_workspace(
     // (returns at ~line 147 before scaffolding) means this never runs on the
     // Loom source repo — it must not mutate the source tree.
     cleanup_retired_files(workspace, &mut report);
+
+    // Write .loom/install-metadata.json (and the gitignored loom-source-path
+    // sidecar) BEFORE generate_manifest so verify-install.sh reads the fresh
+    // loom_commit when it builds manifest.json (#4050). A direct `loom-daemon
+    // init` sets no LOOM_* env, so from_env() supplies the binary's compiled-in
+    // version/commit rather than the literal "unknown". The shell wrappers run
+    // finalize_quick_install after init and overwrite this with richer data.
+    write_install_metadata(workspace, &templates::LoomMetadata::from_env(), &defaults);
 
     // Generate installation manifest (.loom/manifest.json)
     generate_manifest(workspace);
@@ -557,6 +567,64 @@ fn verify_all_copied_files(
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn test_direct_init_writes_install_metadata_and_substitutes_version() {
+        // #4050: a direct `loom-daemon init` (no LOOM_* env exported by any
+        // shell wrapper) must still write `.loom/install-metadata.json` with a
+        // real version, and must substitute a real version into `.loom/CLAUDE.md`
+        // rather than leaking the literal "unknown".
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = temp_dir.path();
+        // The defaults dir MUST be named `defaults` so loom_source is derivable.
+        let defaults = temp_dir.path().join("defaults");
+
+        fs::create_dir(workspace.join(".git")).unwrap();
+        fs::create_dir_all(defaults.join("roles")).unwrap();
+        fs::create_dir_all(defaults.join(".loom")).unwrap();
+        fs::write(defaults.join("config.json"), "{}").unwrap();
+        fs::write(defaults.join("roles").join("builder.md"), "builder").unwrap();
+        // A CLAUDE.md template carrying the version placeholder.
+        fs::write(
+            defaults.join(".loom").join("CLAUDE.md"),
+            "# Loom\n\n**Loom Version**: {{LOOM_VERSION}}\n**Loom Commit**: {{LOOM_COMMIT}}\n",
+        )
+        .unwrap();
+
+        let result =
+            initialize_workspace(workspace.to_str().unwrap(), defaults.to_str().unwrap(), false);
+        assert!(result.is_ok(), "init failed: {result:?}");
+
+        // 1. install-metadata.json exists with a non-"unknown" version/commit.
+        let meta_raw =
+            fs::read_to_string(workspace.join(".loom").join("install-metadata.json")).unwrap();
+        let meta: serde_json::Value = serde_json::from_str(&meta_raw).unwrap();
+        let version = meta["loom_version"].as_str().unwrap();
+        assert!(!version.is_empty(), "loom_version must not be empty");
+        assert_ne!(version, "unknown", "loom_version must not be the literal unknown");
+        assert!(!version.contains("{{"), "loom_version must not be an unsubstituted placeholder");
+        // loom_source points at the defaults' parent (this temp dir).
+        let src = meta["loom_source"].as_str().unwrap();
+        assert!(!src.is_empty());
+
+        // 2. .loom/CLAUDE.md has no leftover placeholder and no "unknown" version.
+        let claude = fs::read_to_string(workspace.join(".loom").join("CLAUDE.md")).unwrap();
+        assert!(!claude.contains("{{"), "CLAUDE.md must have no unsubstituted placeholder");
+        assert!(
+            !claude.contains("**Loom Version**: unknown"),
+            "CLAUDE.md must not render the unknown version: {claude}"
+        );
+
+        // 3. Re-running init is idempotent — the metadata file still parses and
+        //    carries the same schema (no duplicate/garbled JSON).
+        let result2 =
+            initialize_workspace(workspace.to_str().unwrap(), defaults.to_str().unwrap(), true);
+        assert!(result2.is_ok(), "reinstall failed: {result2:?}");
+        let meta_raw2 =
+            fs::read_to_string(workspace.join(".loom").join("install-metadata.json")).unwrap();
+        let meta2: serde_json::Value = serde_json::from_str(&meta_raw2).unwrap();
+        assert_eq!(meta2["loom_version"].as_str().unwrap(), version);
+    }
 
     #[test]
     fn test_is_loom_source_repo_marker_file() {

--- a/loom-daemon/src/init/post_init.rs
+++ b/loom-daemon/src/init/post_init.rs
@@ -6,6 +6,10 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
+use serde_json::json;
+
+use super::templates::LoomMetadata;
+
 /// Gitignore patterns that would shadow installed Loom files like
 /// `.loom/scripts/lib/*.sh`. If a user's gitignore contains any of these, the
 /// installer must fail loudly: the files will exist on disk after install but
@@ -162,6 +166,89 @@ fn managed_gitignore_block() -> String {
     block
 }
 
+/// Derive the Loom source-checkout root from the resolved defaults directory.
+///
+/// The wrappers and daemon both point `init` at a `<root>/defaults` directory,
+/// so the source root is that directory's parent. Returns `None` when the
+/// directory is not named `defaults` (a bundled/embedded layout) or has no
+/// parent — the caller then omits `loom_source` rather than recording a wrong
+/// path. The result is canonicalized to an absolute path when possible so the
+/// gitignored `.loom/loom-source-path` sidecar and `loom_source` key match what
+/// the shell installer writes.
+fn derive_loom_source(defaults_dir: &Path) -> Option<String> {
+    if defaults_dir.file_name().and_then(|n| n.to_str()) != Some("defaults") {
+        return None;
+    }
+    let root = defaults_dir.parent()?;
+    // Prefer an absolute, symlink-resolved path (matches install.sh's
+    // `loom_root`); fall back to the lexical parent if canonicalization fails
+    // (e.g. the directory was removed between resolve and write).
+    let resolved = fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    Some(resolved.to_string_lossy().into_owned())
+}
+
+/// Write `.loom/install-metadata.json` (and, when derivable, the gitignored
+/// `.loom/loom-source-path` sidecar) so a direct `loom-daemon init` produces the
+/// same version metadata the shell installers do (#4050).
+///
+/// Before this, only `install.sh`/`install-loom.sh` wrote these artifacts, so a
+/// consumer that ran `loom-daemon init` directly (a supported entry point since
+/// the machine-level binary of #3922) got a `.loom/` with no version metadata:
+/// `/repo:update-tools` reported UNKNOWN and `manifest.json` carried empty
+/// `loom_version`/`loom_commit`.
+///
+/// Schema-compatible with `finalize_quick_install` (at least `loom_version`,
+/// `loom_commit`, `install_date`; `installed_files` may be empty —
+/// `verify-install.sh` warns-and-falls-back on an empty list). The wrappers run
+/// `finalize_quick_install` *after* `init`, overwriting this file with the
+/// richer version (populated `loom_source` + `installed_files`), so both paths
+/// converge and this write never regresses a wrapper install.
+///
+/// Non-fatal: a write failure warns but does not abort the install (mirrors
+/// [`generate_manifest`]).
+pub fn write_install_metadata(workspace_path: &Path, metadata: &LoomMetadata, defaults_dir: &Path) {
+    let loom_path = workspace_path.join(".loom");
+    if !loom_path.exists() {
+        return;
+    }
+
+    let version = metadata.version.as_deref().unwrap_or("unknown");
+    let commit = metadata.commit.as_deref().unwrap_or("unknown");
+    let source = derive_loom_source(defaults_dir);
+
+    let mut obj = json!({
+        "loom_version": version,
+        "loom_commit": commit,
+        "install_date": metadata.install_date,
+        "installed_files": [],
+    });
+    // Only record loom_source when it can be derived — never a wrong path.
+    if let Some(src) = source.as_deref() {
+        obj["loom_source"] = json!(src);
+    }
+
+    match serde_json::to_string_pretty(&obj) {
+        Ok(mut contents) => {
+            contents.push('\n');
+            if let Err(e) = fs::write(loom_path.join("install-metadata.json"), contents) {
+                eprintln!("Warning: Could not write .loom/install-metadata.json: {e}");
+            }
+        }
+        Err(e) => {
+            eprintln!("Warning: Could not serialize install metadata: {e}");
+        }
+    }
+
+    // Machine-local source sidecar (gitignored via EPHEMERAL_PATTERNS). Only
+    // written when the source root is known; consumers have a fallback chain
+    // that recreates it from `install-metadata.json`'s `loom_source` otherwise.
+    if let Some(src) = source {
+        if let Err(e) = fs::write(loom_path.join("loom-source-path"), format!("{src}\n")) {
+            eprintln!("Warning: Could not write .loom/loom-source-path: {e}");
+        }
+    }
+}
+
 /// Generate installation manifest by running verify-install.sh
 ///
 /// Attempts to run `.loom/scripts/verify-install.sh generate --quiet` to create
@@ -314,6 +401,120 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    fn metadata(version: &str, commit: &str) -> LoomMetadata {
+        LoomMetadata {
+            version: Some(version.to_string()),
+            commit: Some(commit.to_string()),
+            install_date: "2026-07-27".to_string(),
+        }
+    }
+
+    #[test]
+    fn write_install_metadata_writes_version_and_commit() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path();
+        fs::create_dir(workspace.join(".loom")).unwrap();
+        // A `<root>/defaults` dir so loom_source is derivable.
+        let defaults = workspace.join("srcroot").join("defaults");
+        fs::create_dir_all(&defaults).unwrap();
+
+        write_install_metadata(workspace, &metadata("0.15.0", "ebf4fc55"), &defaults);
+
+        let raw =
+            fs::read_to_string(workspace.join(".loom").join("install-metadata.json")).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(v["loom_version"], "0.15.0");
+        assert_eq!(v["loom_commit"], "ebf4fc55");
+        assert_eq!(v["install_date"], "2026-07-27");
+        assert!(v["installed_files"].is_array());
+        // loom_source is the parent of the `defaults` dir, canonicalized.
+        let src = v["loom_source"].as_str().unwrap();
+        assert!(src.ends_with("srcroot"), "loom_source should be the defaults parent, got {src}");
+
+        // The gitignored sidecar mirrors loom_source.
+        let sidecar = fs::read_to_string(workspace.join(".loom").join("loom-source-path")).unwrap();
+        assert_eq!(sidecar.trim(), src);
+    }
+
+    #[test]
+    fn write_install_metadata_omits_source_when_not_defaults() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path();
+        fs::create_dir(workspace.join(".loom")).unwrap();
+        // Not named `defaults` → loom_source cannot be derived and must be omitted.
+        let bundled = workspace.join("resources");
+        fs::create_dir_all(&bundled).unwrap();
+
+        write_install_metadata(workspace, &metadata("0.15.0", "abc1234"), &bundled);
+
+        let raw =
+            fs::read_to_string(workspace.join(".loom").join("install-metadata.json")).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(v["loom_version"], "0.15.0");
+        assert!(v.get("loom_source").is_none(), "loom_source must be omitted, not wrong");
+        // No sidecar written when the source root is unknown.
+        assert!(!workspace.join(".loom").join("loom-source-path").exists());
+    }
+
+    #[test]
+    fn write_install_metadata_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path();
+        fs::create_dir(workspace.join(".loom")).unwrap();
+        let defaults = workspace.join("srcroot").join("defaults");
+        fs::create_dir_all(&defaults).unwrap();
+
+        write_install_metadata(workspace, &metadata("0.15.0", "abc1234"), &defaults);
+        let first =
+            fs::read_to_string(workspace.join(".loom").join("install-metadata.json")).unwrap();
+        write_install_metadata(workspace, &metadata("0.15.0", "abc1234"), &defaults);
+        let second =
+            fs::read_to_string(workspace.join(".loom").join("install-metadata.json")).unwrap();
+
+        assert_eq!(first, second, "re-running init must not garble the JSON");
+        // Parses cleanly (no duplicate/concatenated objects).
+        serde_json::from_str::<serde_json::Value>(&second).unwrap();
+    }
+
+    #[test]
+    fn write_install_metadata_falls_back_to_unknown_when_absent() {
+        // A LoomMetadata with no version/commit (both env AND compiled empty)
+        // still produces valid JSON with the "unknown" placeholder rather than
+        // panicking or writing null.
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path();
+        fs::create_dir(workspace.join(".loom")).unwrap();
+        let defaults = workspace.join("srcroot").join("defaults");
+        fs::create_dir_all(&defaults).unwrap();
+
+        let meta = LoomMetadata {
+            version: None,
+            commit: None,
+            install_date: "2026-07-27".to_string(),
+        };
+        write_install_metadata(workspace, &meta, &defaults);
+
+        let raw =
+            fs::read_to_string(workspace.join(".loom").join("install-metadata.json")).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(v["loom_version"], "unknown");
+        assert_eq!(v["loom_commit"], "unknown");
+    }
+
+    #[test]
+    fn derive_loom_source_handles_defaults_and_non_defaults() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("checkout");
+        let defaults = root.join("defaults");
+        fs::create_dir_all(&defaults).unwrap();
+
+        let src = derive_loom_source(&defaults).unwrap();
+        assert!(src.ends_with("checkout"));
+
+        // A directory not named `defaults` yields None.
+        assert!(derive_loom_source(&root).is_none());
+    }
 
     #[test]
     fn creates_gitignore_with_all_patterns_when_none_exists() {

--- a/loom-daemon/src/init/templates.rs
+++ b/loom-daemon/src/init/templates.rs
@@ -16,12 +16,42 @@ pub struct LoomMetadata {
 }
 
 impl LoomMetadata {
-    /// Create metadata by reading from environment variables
+    /// Create metadata by reading from environment variables, falling back to
+    /// the values compiled into this binary.
+    ///
+    /// The shell installers (`install.sh`, `scripts/install-loom.sh`) export
+    /// `LOOM_VERSION`/`LOOM_COMMIT` describing the source tree being installed
+    /// *from*, so a non-empty env value always wins — the machine-level
+    /// `~/.local/bin/loom-daemon` binary (#3922) can be older than that source
+    /// tree. When the env vars are unset or empty (the direct `loom-daemon
+    /// init` path, which no wrapper sets them on), fall back to the binary's
+    /// own compiled-in version/commit rather than the literal `"unknown"` that
+    /// previously leaked into `.loom/CLAUDE.md` and `install-metadata.json`
+    /// (#4050).
     pub fn from_env() -> Self {
         Self {
-            version: std::env::var("LOOM_VERSION").ok(),
-            commit: std::env::var("LOOM_COMMIT").ok(),
+            version: env_or_compiled("LOOM_VERSION", env!("CARGO_PKG_VERSION")),
+            commit: env_or_compiled("LOOM_COMMIT", crate::self_update::BUILT_COMMIT),
             install_date: Local::now().format("%Y-%m-%d").to_string(),
+        }
+    }
+}
+
+/// Resolve a template value from `$var`, falling back to a compiled-in constant.
+///
+/// A non-empty env value wins (the installer's source-tree description). An
+/// unset or empty env var falls back to `compiled`, and if that itself is empty
+/// or the literal `"unknown"` (e.g. a tarball build with no `.git`) the result
+/// is `None` so the caller's own `"unknown"` fallback applies.
+fn env_or_compiled(var: &str, compiled: &str) -> Option<String> {
+    match std::env::var(var) {
+        Ok(v) if !v.is_empty() => Some(v),
+        _ => {
+            if compiled.is_empty() || compiled == "unknown" {
+                None
+            } else {
+                Some(compiled.to_string())
+            }
         }
     }
 }
@@ -171,7 +201,9 @@ mod tests {
 
     #[test]
     fn test_loom_metadata_from_env() {
-        // Test with environment variables set
+        // Test with environment variables set — a non-empty env value wins over
+        // the compiled-in constant (the installer's source-tree description,
+        // which may be newer than this binary; see #4050).
         std::env::set_var("LOOM_VERSION", "0.5.0");
         std::env::set_var("LOOM_COMMIT", "def5678");
 
@@ -183,8 +215,54 @@ mod tests {
         assert!(metadata.install_date.len() == 10);
         assert!(metadata.install_date.contains('-'));
 
-        // Clean up
+        // With the env vars unset, from_env() falls back to the binary's own
+        // compiled-in version (never the literal "unknown"). This is the
+        // direct `loom-daemon init` path the #4050 fix repairs. Done in the
+        // SAME test as the env-set case so the two never race under parallel
+        // test execution (the templates.rs env-mutation caveat).
         std::env::remove_var("LOOM_VERSION");
         std::env::remove_var("LOOM_COMMIT");
+
+        let fallback = LoomMetadata::from_env();
+        assert_eq!(
+            fallback.version.as_deref(),
+            Some(env!("CARGO_PKG_VERSION")),
+            "unset LOOM_VERSION must fall back to the compiled crate version"
+        );
+        assert_ne!(fallback.version.as_deref(), Some("unknown"));
+        // Commit is present unless this binary was built without git metadata
+        // (a tarball build ⇒ BUILT_COMMIT == "unknown" ⇒ None here).
+        if crate::self_update::BUILT_COMMIT != "unknown" {
+            assert_eq!(fallback.commit.as_deref(), Some(crate::self_update::BUILT_COMMIT));
+        }
+    }
+
+    #[test]
+    fn test_env_or_compiled_prefers_nonempty_env() {
+        // Use a unique var name so this never races with LOOM_VERSION/COMMIT.
+        let var = "LOOM_TEST_ENV_OR_COMPILED_A";
+        std::env::set_var(var, "from-env");
+        assert_eq!(env_or_compiled(var, "compiled"), Some("from-env".to_string()));
+        std::env::remove_var(var);
+    }
+
+    #[test]
+    fn test_env_or_compiled_empty_env_falls_back() {
+        let var = "LOOM_TEST_ENV_OR_COMPILED_B";
+        // An empty env value must NOT win — it falls through to the compiled value.
+        std::env::set_var(var, "");
+        assert_eq!(env_or_compiled(var, "compiled"), Some("compiled".to_string()));
+        std::env::remove_var(var);
+    }
+
+    #[test]
+    fn test_env_or_compiled_unset_uses_compiled() {
+        let var = "LOOM_TEST_ENV_OR_COMPILED_UNSET";
+        std::env::remove_var(var);
+        assert_eq!(env_or_compiled(var, "0.15.0"), Some("0.15.0".to_string()));
+        // A compiled value of "unknown" or "" degrades to None so the caller's
+        // own "unknown" placeholder applies rather than double-substituting.
+        assert_eq!(env_or_compiled(var, "unknown"), None);
+        assert_eq!(env_or_compiled(var, ""), None);
     }
 }

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -2025,6 +2025,42 @@ else
     else
       fail "AC1 (#3468): .claude/commands/loom/bump.md missing from consumer install"
     fi
+
+    # #4050: a direct `loom-daemon init` (no LOOM_VERSION/LOOM_COMMIT exported —
+    # this test does NOT set them, unlike install.sh's prepare_loom_metadata_env)
+    # must still write .loom/install-metadata.json with a real version, and must
+    # substitute a real version into .loom/CLAUDE.md rather than "unknown".
+    META_52="$INTERNAL_REPO/.loom/install-metadata.json"
+    if [[ -f "$META_52" ]] && jq empty "$META_52" >/dev/null 2>&1; then
+      meta_version="$(jq -r '.loom_version // ""' "$META_52")"
+      meta_commit="$(jq -r '.loom_commit // ""' "$META_52")"
+      if [[ -n "$meta_version" && "$meta_version" != "unknown" ]]; then
+        pass "#4050: daemon-direct init wrote install-metadata.json with loom_version=$meta_version"
+      else
+        fail "#4050: install-metadata.json loom_version is empty/unknown ('$meta_version')"
+      fi
+      if [[ -n "$meta_commit" ]]; then
+        pass "#4050: install-metadata.json carries a non-empty loom_commit"
+      else
+        fail "#4050: install-metadata.json loom_commit is empty"
+      fi
+    else
+      fail "#4050: daemon-direct init did not write a parseable .loom/install-metadata.json"
+    fi
+
+    CLAUDE_52="$INTERNAL_REPO/.loom/CLAUDE.md"
+    if [[ -f "$CLAUDE_52" ]]; then
+      # Only the five Loom template placeholders must be substituted; unrelated
+      # `{{...}}` in example content (e.g. `{{workspace}}`) is intentional, so
+      # match the exact placeholder set (mirrors Rust TEMPLATE_PLACEHOLDERS).
+      if grep -Eq '\{\{(LOOM_VERSION|LOOM_COMMIT|INSTALL_DATE|REPO_OWNER|REPO_NAME)\}\}' "$CLAUDE_52"; then
+        fail "#4050: .loom/CLAUDE.md still contains an unsubstituted Loom template placeholder"
+      elif grep -q '\*\*Loom Version\*\*: unknown' "$CLAUDE_52"; then
+        fail "#4050: .loom/CLAUDE.md renders 'Loom Version: unknown' on daemon-direct init"
+      else
+        pass "#4050: .loom/CLAUDE.md has a substituted version and no leftover placeholder"
+      fi
+    fi
   else
     fail "loom-daemon init failed against fresh consumer repo $INTERNAL_REPO"
   fi


### PR DESCRIPTION
Closes #4050

## Problem

Running `loom-daemon init` directly — the machine-level binary path added in #3922, as opposed to the `install.sh` / `scripts/install-loom.sh` shell wrappers — never wrote `.loom/install-metadata.json` and rendered `**Loom Version**: unknown` in `.loom/CLAUDE.md`. `LoomMetadata::from_env()` read only the `LOOM_VERSION`/`LOOM_COMMIT` env vars (which only the wrappers export), falling back to the literal `"unknown"`. This cascaded into empty `loom_version`/`loom_commit` in `manifest.json`, so `/repo:update-tools` reported UNKNOWN and could not compare the installed version against upstream (observed in rjwalters/safehouse).

## Fix (Option A — make the daemon self-sufficient, leave the shell wrappers as-is)

1. **`loom-daemon/src/init/templates.rs`** — `LoomMetadata::from_env()` now falls back to the binary's compiled-in `env!("CARGO_PKG_VERSION")` and `self_update::BUILT_COMMIT` when the env vars are unset or empty. A non-empty env value still wins, so the wrappers' source-tree description (which can be newer than a stale machine-level binary, per #3922) is preserved. A compiled value that is itself empty or `"unknown"` (a tarball build with no `.git`) degrades to `None` so the existing `"unknown"` placeholder still applies.
2. **`loom-daemon/src/init/post_init.rs`** — new `write_install_metadata()` writes `.loom/install-metadata.json` (schema-compatible with `finalize_quick_install`: `loom_version`, `loom_commit`, `install_date`, empty `installed_files`, and `loom_source` when derivable) plus the gitignored `.loom/loom-source-path` sidecar. `loom_source` is derived from the `--defaults` argument's parent only when that directory is named `defaults`; otherwise the key is omitted rather than recording a wrong path.
3. **`loom-daemon/src/init/mod.rs`** — calls `write_install_metadata(...)` immediately before `generate_manifest(workspace)` so `verify-install.sh` reads the fresh commit when building `manifest.json`.

The shell wrappers run `finalize_quick_install` *after* `init` and overwrite the file with richer data (populated `loom_source` + `installed_files`), so both install paths converge. `install.sh` / `scripts/install-loom.sh` are unchanged, and the `install-metadata.json` schema / key names are untouched (consumed by `/repo:update-tools`, `uninstall-loom.sh`, `resync-installed.sh`, `verify-install.sh`).

## Tests

- Unit: env-vs-compiled precedence (`env_or_compiled` prefers a non-empty env value, falls back on unset/empty, degrades `unknown`/empty compiled to `None`); `from_env()` compiled fallback covered in the same test as the env-wins case to avoid parallel env-mutation races.
- Unit: `write_install_metadata` writes version/commit/source, omits `loom_source` for a non-`defaults` dir, is idempotent, and degrades to `"unknown"` when metadata is absent; `derive_loom_source` for defaults vs non-defaults.
- Integration: `initialize_workspace` end-to-end asserts a real (non-`unknown`, non-placeholder) `loom_version` in the metadata file and no leftover Loom placeholder / `unknown` version in `.loom/CLAUDE.md`, and that re-running init is idempotent.
- Shell: `scripts/test-installer.sh` Test 52 (real `loom-daemon init`, no `LOOM_*` env) now also asserts `install-metadata.json` exists/parses with a non-`unknown` version + non-empty commit and that `.loom/CLAUDE.md` has no unsubstituted Loom placeholder. Full suite: 141/141 pass. `cargo test` (init module) and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)