### PR TITLE
fix(defaults): Write(/tmp/**) permission rule is invalid — use Edit(...) and cover /private/tmp

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -97,7 +97,9 @@
       "Bash(shuf:*)",
       "WebSearch",
       "Read(/tmp/**)",
-      "Edit(/tmp/**)"
+      "Read(/private/tmp/**)",
+      "Edit(/tmp/**)",
+      "Edit(/private/tmp/**)"
     ]
   }
 }

--- a/defaults/.claude/settings.json
+++ b/defaults/.claude/settings.json
@@ -92,7 +92,9 @@
       "Bash(shuf:*)",
       "WebSearch",
       "Read(/tmp/**)",
-      "Write(/tmp/**)"
+      "Read(/private/tmp/**)",
+      "Edit(/tmp/**)",
+      "Edit(/private/tmp/**)"
     ]
   }
 }

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -375,6 +375,33 @@ else
   fail "Cannot verify hook command prefixes (settings.json or jq missing)"
 fi
 
+# Test 12c: No invalid Write(...) path rule in permissions.allow (issue #4072)
+# Claude Code's permission engine only matches Edit(...) rules for file-editing
+# tools (Write/Edit/NotebookEdit all route through Edit checks) -- a
+# Write(...) path rule prints a startup warning and is a silent no-op. Also
+# assert the four temp-path entries the fix introduces are all present.
+echo "Test 12c: settings.json has no invalid Write(...) path rule"
+if [[ -f "$SETTINGS_FILE" ]] && command -v jq &> /dev/null; then
+  if jq -e '.permissions.allow[] | select(startswith("Write("))' "$SETTINGS_FILE" > /dev/null 2>&1; then
+    fail "settings.json contains an invalid Write(...) path rule -- use Edit(...)"
+  else
+    pass "no invalid Write(...) path rules in settings.json"
+  fi
+
+  TEMP_PATH_FAIL=0
+  for entry in "Read(/tmp/**)" "Read(/private/tmp/**)" "Edit(/tmp/**)" "Edit(/private/tmp/**)"; do
+    if ! jq -e --arg entry "$entry" '.permissions.allow[] | select(. == $entry)' "$SETTINGS_FILE" > /dev/null 2>&1; then
+      fail "settings.json missing expected temp-path rule: $entry"
+      TEMP_PATH_FAIL=1
+    fi
+  done
+  if [[ $TEMP_PATH_FAIL -eq 0 ]]; then
+    pass "settings.json has all four temp-path permission entries"
+  fi
+else
+  fail "Cannot verify settings.json permissions (settings.json or jq missing)"
+fi
+
 # Test 13: .github/labels.yml
 echo "Test 13: Install creates .github/labels.yml"
 if [[ -f "$INSTALL_REPO/.github/labels.yml" ]]; then


### PR DESCRIPTION
## Summary

The shipped default permission list in `defaults/.claude/settings.json` contained an invalid `Write(/tmp/**)` rule. Claude Code's permission engine only matches `Edit(...)` rules for file-editing tools (Write/Edit/NotebookEdit all route through Edit checks), so the rule both printed a startup warning on every launch AND was a no-op — temp-file writes still triggered permission prompts.

## Changes

1. **`defaults/.claude/settings.json`** — replaced `Read(/tmp/**)` + `Write(/tmp/**)` with four entries: `Read(/tmp/**)`, `Read(/private/tmp/**)`, `Edit(/tmp/**)`, `Edit(/private/tmp/**)`. This is the propagation source every fresh install copies from.
2. **`.claude/settings.json`** (this repo's own project settings, already partially fixed by `c4b6f677`) — added the two missing `/private/tmp/**` entries so it now matches the template's block byte-for-byte.
3. **`scripts/test-installer.sh`** — added Test 12c, a regression guard: asserts the installed `settings.json` has no `Write(`-prefixed path rule, and asserts all four temp-path entries are present.

Verified `git grep 'Write(' -- '*settings*.json'` returns nothing after this change, and `scripts/test-installer.sh` passes in full (140/140, including the new Test 12c).

Out of scope, per the issue's curator-verified scoping decision: `merge_permissions` (`loom-daemon/src/init/scaffolding.rs:356-385`) and `.loom/scripts/resync-installed.sh` were **not** touched.

## Known limitation (flagged, not fixed here)

`merge_permissions` is a pure union of `permissions.allow` — it never removes a rule, only appends missing ones. So an **existing** installed project that re-runs install will get `Edit(/tmp/**)` appended but will retain the stale `Write(/tmp/**)` forever; the startup warning persists for those installs until they manually edit their `.claude/settings.json`. This is a deliberate, documented limitation of this fix — building a deprecated-rules pruning mechanism into `merge_permissions` is a separate design question. Filing that follow-up issue is deferred to Champion/human per the issue body, not done here.

## Test plan

- [x] `git grep 'Write(' -- '*settings*.json'` returns nothing
- [x] `scripts/test-installer.sh` passes in full (140 passed, 0 failed), including new Test 12c
- [x] Both `defaults/.claude/settings.json` and `.claude/settings.json` temp-path rule blocks are byte-for-byte identical (verified via diff)
- [x] `loom-daemon/src/init/scaffolding.rs` untouched (confirmed via `git diff --stat`)

Closes #4072