### PR TITLE
docs: troubleshooting entry for syspolicyd exec saturation

### DIFF
--- a/defaults/docs/build-gate.md
+++ b/defaults/docs/build-gate.md
@@ -187,7 +187,10 @@ Two concrete failure classes motivated the split (#3985):
   #4046 established the timing-test failures were macOS `syspolicyd`
   exec-latency artifacts, not contention (968/968 passed later with **no code
   change**). The generous bounds are still correct; the "sweeps starve the
-  gate's timing tests" story that motivated them is not.
+  gate's timing tests" story that motivated them is not. For the operator-facing
+  diagnostic — how to recognize `syspolicyd` saturation live and unwedge it — see
+  [`troubleshooting.md`](troubleshooting.md) → "Several unrelated things hang at
+  once (macOS Gatekeeper / `syspolicyd`)".
 
 **The gate runs at a mild throttle relative to sweeps (#4020, revises #3985).**
 `build-gate.sh` now defaults to `nice 5` — a mild positive niceness, a real but

--- a/defaults/docs/troubleshooting.md
+++ b/defaults/docs/troubleshooting.md
@@ -222,6 +222,82 @@ When an agent crashes or is cancelled while building, issues can get stuck in `l
 - Issues without PRs older than threshold are flagged/recovered
 - Issues with stale PRs are flagged but not auto-recovered (need manual review)
 
+## Several unrelated things hang at once (macOS Gatekeeper / `syspolicyd`)
+
+**Symptom:** several unrelated processes — a `cargo` build, a sweep child, a
+shell wrapper, a timing-sensitive test — appear to hang *simultaneously*, all
+sitting at **zero CPU time** even after minutes of wall-clock. It looks like
+host-wide CPU starvation, but the CPUs are idle.
+
+**Zero CPU means nothing on its own.** Before chasing any single victim,
+distinguish the two very different conditions that both present as "stuck at zero
+CPU":
+
+- *Many* unrelated processes at zero CPU, including short-lived `exec`s that never
+  make progress → **macOS Gatekeeper / `syspolicyd` saturation** (this section).
+- A *single sweep* at zero CPU with a flat log → almost certainly **healthy, not
+  wedged**. Sweeps are network-bound and accrue almost no CPU while awaiting API
+  responses; `%CPU`, cumulative `TIME`, a `sample <pid>` stack (which parks in
+  `CFRunLoopRun → mach_msg`, indistinguishable from a block), and sweep-log size
+  **cannot** tell a working sweep from a dead one. Verify liveness via the side
+  effects a sweep actually produces — `ls .loom/worktrees/`, `git log` in the
+  worktree, `git ls-remote --heads origin 'feature/issue-*'`, and the forge
+  (`gh pr list`) — before concluding anything. (See "Stuck Agent Detection" below.)
+
+### First diagnostic move
+
+```bash
+ps -axo %cpu,time,comm | sort -rn | head
+```
+
+If `syspolicyd` is at or near the **top** of that list, stop debugging the
+individual victims — they are symptoms, not the cause. Under parallel `cargo`
+builds, macOS's Gatekeeper daemon (`syspolicyd`) becomes the bottleneck: it
+serializes code-signature / notarization checks on every `exec`, and when
+saturated it stalls *every* new process launch host-wide.
+
+### The exec-stall signature
+
+A victim of `syspolicyd` saturation is a process caught mid-`exec` — launched, but
+its target binary has not yet cleared Gatekeeper. Its tell-tale signature:
+
+- **Zero CPU time** accumulated even after minutes of elapsed wall-clock.
+- **`STAT S`** (interruptible sleep) — blocked, not spinning.
+- **No child processes** — the wrapper never got far enough to fork its target.
+- `lsof -p <pid>` shows `txt = /usr/bin/env` (or another wrapper) that **never
+  exec'd its actual target** — the process is frozen inside the launch, waiting on
+  the signature check.
+
+### It is load-induced and self-recovering
+
+The condition is caused by launch load, not by any one process, and it clears on
+its own once the load is removed — **removing the build load (letting the parallel
+`cargo` builds finish, or throttling them) is normally sufficient.** If you need to
+unwedge it manually:
+
+```bash
+sudo killall syspolicyd
+```
+
+`syspolicyd` is a system daemon that `launchd` restarts immediately; killing it
+drops its saturated in-flight queue and lets the stalled `exec`s proceed.
+
+### Why this matters — a falsified contention story
+
+This signature was originally *misdiagnosed* as CPU contention. The build gate's
+timing-sensitive tests failed under host load and the failures were attributed to
+sweeps starving the gate; #4044 / #4046 falsified that — the same tests passed
+968/968 later with **no code change**, establishing the failures as `syspolicyd`
+exec-latency artifacts rather than contention. The narrative and its consequences
+for gate niceness live in [`build-gate.md`](build-gate.md) (the #4044 / #4046
+falsification passage). ADR-0011 also records this as a macOS-specific defect that
+is invisible to Linux CI by construction — see
+[`docs/adr/0011-ci-runner-platform.md`](../../docs/adr/0011-ci-runner-platform.md).
+
+> **Historical note on timeouts.** Contemporaneous incident writeups mention a
+> "600s" build-gate budget; that figure is **incident history only**. #4048 raised
+> the live budget to **1200s** — do not read 600s as the current value.
+
 ## Stuck Agent Detection
 
 `loom-stuck-detection` checks for stuck sweep children by reading the per-task heartbeats in `.loom/spawn-loop-state.json::running[].last_heartbeat`.


### PR DESCRIPTION
Closes #4046

## What changed

Docs-only. Two files, +80 lines.

### `defaults/docs/troubleshooting.md` (`.loom/docs/troubleshooting.md`)
New top-level section **"Several unrelated things hang at once (macOS Gatekeeper / `syspolicyd`)"**, inserted immediately before `## Stuck Agent Detection`. Covers:

- **First diagnostic move:** `ps -axo %cpu,time,comm | sort -rn | head` — if `syspolicyd` is at the top, stop debugging individual victims.
- **The exec-stall signature:** zero CPU time after minutes, `STAT S`, no children, `lsof -p <pid>` showing `txt = /usr/bin/env` on a wrapper that never exec'd its target.
- **Load-induced and self-recovering:** removing build load is normally sufficient; `sudo killall syspolicyd` is the manual unwedge (launchd restarts it).
- **Cross-links:** to [`build-gate.md`](../blob/main/defaults/docs/build-gate.md)'s #4044/#4046 falsification passage and to `docs/adr/0011-ci-runner-platform.md` (the ADR, which records the syspolicyd finding at lines 16 and 152–155). The closed issue #4038 is deliberately **not** referenced — ADR-0011 is the durable record.
- **Zero-CPU inverse reading:** incorporates the issue author's companion-lesson acceptance criterion — a lone sweep at zero CPU with a flat log is normally *healthy*; `ps`/CPU-time/`sample` stacks/log size cannot distinguish a wedged sweep from a working one, so verify via `.loom/worktrees/`, `git log`, `git ls-remote`, and the forge.
- **600s framed as historical only:** an explicit note that the live build-gate budget is **1200s** (#4048), not 600s.

### `defaults/docs/build-gate.md` (`.loom/docs/build-gate.md`)
One-line reciprocal pointer added to the existing #4044/#4046 falsification bullet, linking forward to the new troubleshooting section.

## Test plan (all verified)

- `ps -axo %cpu,time,comm | sort -rn | head` run on this host — real, working invocation as documented.
- Relative links resolve from the symlinked `.loom/docs/` location: `build-gate.md` (sibling), `../../docs/adr/0011-ci-runner-platform.md`, and the reciprocal `troubleshooting.md`.
- `git diff | grep 600` → both occurrences are inside the "Historical note on timeouts" block, clearly framed as incident history.
- `#4038` appears nowhere in the diff; ADR-0011 is used instead.
- `./scripts/check-claude-md-budget.sh` → OK (308/320 lines); CLAUDE.md untouched.

## Out of scope (follow-up note)

The Curator surfaced a real, pre-existing **docs propagation gap**: `defaults/docs/` ships only `ci-integration.md`, so `troubleshooting.md` (and six sibling `.loom/docs/*.md` files linked from the shipped `defaults/CLAUDE.md`) never reach consumer installs via `sync_managed_dir(..., "docs", ...)`. Explicitly out of scope for this issue; noted here for a future follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)