### PR TITLE
feat(mcp-loom): resolve .loom config across tiers, refuse write-flattening

### DIFF
--- a/mcp-loom/package-lock.json
+++ b/mcp-loom/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loom/mcp",
-  "version": "0.9.1",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loom/mcp",
-      "version": "0.9.1",
+      "version": "0.15.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "strip-ansi": "^7.1.2"
@@ -17,7 +17,8 @@
       "devDependencies": {
         "@types/node": "^22.18.10",
         "esbuild": "^0.27.3",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -474,6 +475,13 @@
         "hono": "^4"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -514,6 +522,402 @@
         }
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
@@ -522,6 +926,119 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -582,6 +1099,16 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -615,6 +1142,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -642,6 +1179,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/content-disposition": {
@@ -732,6 +1296,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -787,6 +1361,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -848,6 +1429,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -876,6 +1467,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -998,6 +1599,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1184,6 +1800,23 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1244,6 +1877,25 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -1324,6 +1976,30 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -1331,6 +2007,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/proxy-addr": {
@@ -1392,6 +2097,51 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
+      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.3",
+        "@rollup/rollup-android-arm64": "4.62.3",
+        "@rollup/rollup-darwin-arm64": "4.62.3",
+        "@rollup/rollup-darwin-x64": "4.62.3",
+        "@rollup/rollup-freebsd-arm64": "4.62.3",
+        "@rollup/rollup-freebsd-x64": "4.62.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
+        "@rollup/rollup-linux-arm64-musl": "4.62.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
+        "@rollup/rollup-linux-loong64-musl": "4.62.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-musl": "4.62.3",
+        "@rollup/rollup-openbsd-x64": "4.62.3",
+        "@rollup/rollup-openharmony-arm64": "4.62.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
+        "@rollup/rollup-win32-x64-gnu": "4.62.3",
+        "@rollup/rollup-win32-x64-msvc": "4.62.3",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/router": {
@@ -1560,6 +2310,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1568,6 +2342,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-ansi": {
       "version": "7.1.2",
@@ -1582,6 +2363,50 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -1646,6 +2471,585 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1659,6 +3063,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/mcp-loom/package.json
+++ b/mcp-loom/package.json
@@ -10,6 +10,7 @@
     "build": "tsc --noEmit && rm -rf dist && node esbuild.config.js",
     "build:bundle": "rm -rf dist && node esbuild.config.js",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "verify:daemon-timeout": "node scripts/verify-daemon-timeout.mjs",
     "watch": "tsc --watch --noEmit"
   },
@@ -20,7 +21,8 @@
   "devDependencies": {
     "@types/node": "^22.18.10",
     "esbuild": "^0.27.3",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.9"
   },
   "allowScripts": {
     "esbuild@0.27.3": true

--- a/mcp-loom/src/shared/config-resolver.test.ts
+++ b/mcp-loom/src/shared/config-resolver.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Tests for the mcp-loom config resolver (issue #4064).
+ *
+ * Two responsibilities:
+ *   1. Byte-parity with `loom-daemon/src/config_resolver.rs` — the tier
+ *      precedence, `deepMerge` semantics, and soft-skip behavior must match
+ *      the Rust reference, proven both by mirrored unit cases and by the
+ *      shared cross-language conformance fixture.
+ *   2. The #4064 write-policy (option 3) — `configure_terminal` must refuse to
+ *      flatten a non-legacy tier into the legacy `.loom/config.json`.
+ */
+
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { handleTerminalTool } from "../tools/terminals.js";
+import {
+  deepMerge,
+  getPath,
+  hasNonLegacyTier,
+  LEGACY_CONFIG_REL,
+  LOCAL_CONFIG_REL,
+  privateDefaultsPath,
+  PRIVATE_DEFAULTS_ENV,
+  PROJECT_CONFIG_REL,
+  resolveEffectiveConfig,
+  softReadJsonObject,
+} from "./config-resolver.js";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+
+// The shared conformance fixture tree, four levels up from src/shared/.
+const CONFORMANCE_FIXTURE_DIR = join(
+  testDir,
+  "..",
+  "..",
+  "..",
+  "loom-tools",
+  "tests",
+  "fixtures",
+  "config_resolver"
+);
+
+// ---- env isolation --------------------------------------------------------
+
+const ORIGINAL_ENV = {
+  defaults: process.env[PRIVATE_DEFAULTS_ENV],
+  workspace: process.env.LOOM_WORKSPACE,
+};
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  restoreEnv(PRIVATE_DEFAULTS_ENV, ORIGINAL_ENV.defaults);
+  restoreEnv("LOOM_WORKSPACE", ORIGINAL_ENV.workspace);
+  await Promise.all(tempRoots.splice(0).map((p) => rm(p, { recursive: true, force: true })));
+});
+
+/** Disable the private-defaults tier for deterministic, host-independent output. */
+function disableDefaultsTier(): void {
+  process.env[PRIVATE_DEFAULTS_ENV] = "";
+}
+
+/** Create a temp repo root and write the requested tier files into it. */
+async function makeRepo(tiers: {
+  legacy?: string;
+  project?: string;
+  local?: string;
+}): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "loom-cfg-"));
+  tempRoots.push(root);
+  if (tiers.legacy !== undefined) {
+    await mkdir(join(root, ".loom"), { recursive: true });
+    await writeFile(join(root, LEGACY_CONFIG_REL), tiers.legacy);
+  }
+  if (tiers.project !== undefined) {
+    await mkdir(join(root, ".loom-project"), { recursive: true });
+    await writeFile(join(root, PROJECT_CONFIG_REL), tiers.project);
+  }
+  if (tiers.local !== undefined) {
+    await mkdir(join(root, ".loom-local"), { recursive: true });
+    await writeFile(join(root, LOCAL_CONFIG_REL), tiers.local);
+  }
+  return root;
+}
+
+// ===== deepMerge (mirrors config_resolver.rs) =====
+
+describe("deepMerge", () => {
+  it("unions disjoint keys", () => {
+    expect(deepMerge({ a: 1 }, { b: 2 })).toEqual({ a: 1, b: 2 });
+  });
+
+  it("merges nested objects recursively", () => {
+    expect(deepMerge({ a: { x: 1 } }, { a: { y: 2 } })).toEqual({ a: { x: 1, y: 2 } });
+  });
+
+  it("lets a scalar overlay replace the base", () => {
+    expect(deepMerge({ a: 1 }, { a: 2 })).toEqual({ a: 2 });
+  });
+
+  it("lets an explicit null overlay clear the key", () => {
+    expect(deepMerge({ a: 1 }, { a: null })).toEqual({ a: null });
+  });
+
+  it("treats an empty overlay as a no-op", () => {
+    const base = { a: { x: 1 }, b: [1, 2] };
+    expect(deepMerge(base, {})).toEqual(base);
+  });
+
+  it("replaces arrays rather than concatenating them", () => {
+    expect(deepMerge({ a: [1, 2] }, { a: [3] })).toEqual({ a: [3] });
+  });
+});
+
+// ===== softReadJsonObject (mirrors config_resolver.rs) =====
+
+describe("softReadJsonObject", () => {
+  it("returns {} for a missing file", async () => {
+    const root = await mkdtemp(join(tmpdir(), "loom-cfg-"));
+    tempRoots.push(root);
+    expect(await softReadJsonObject(join(root, "nope.json"))).toEqual({});
+  });
+
+  it("returns {} for malformed JSON", async () => {
+    const root = await mkdtemp(join(tmpdir(), "loom-cfg-"));
+    tempRoots.push(root);
+    const p = join(root, "bad.json");
+    await writeFile(p, "not valid json");
+    expect(await softReadJsonObject(p)).toEqual({});
+  });
+
+  it("returns {} for a non-object top-level value", async () => {
+    const root = await mkdtemp(join(tmpdir(), "loom-cfg-"));
+    tempRoots.push(root);
+    const p = join(root, "array.json");
+    await writeFile(p, "[1, 2, 3]");
+    expect(await softReadJsonObject(p)).toEqual({});
+  });
+
+  it("passes a valid object through unchanged", async () => {
+    const root = await mkdtemp(join(tmpdir(), "loom-cfg-"));
+    tempRoots.push(root);
+    const p = join(root, "ok.json");
+    await writeFile(p, '{"a": 1}');
+    expect(await softReadJsonObject(p)).toEqual({ a: 1 });
+  });
+});
+
+// ===== privateDefaultsPath =====
+
+describe("privateDefaultsPath", () => {
+  it("honors a non-empty env override", () => {
+    process.env[PRIVATE_DEFAULTS_ENV] = "/tmp/custom-defaults.json";
+    expect(privateDefaultsPath()).toBe("/tmp/custom-defaults.json");
+  });
+
+  it("disables the tier when the env var is set to empty", () => {
+    process.env[PRIVATE_DEFAULTS_ENV] = "";
+    expect(privateDefaultsPath()).toBeNull();
+  });
+});
+
+// ===== resolveEffectiveConfig: behavior preservation =====
+
+describe("resolveEffectiveConfig", () => {
+  it("matches the legacy file content exactly when only that tier is present", async () => {
+    disableDefaultsTier();
+    const root = await makeRepo({
+      legacy: '{"nextAgentNumber": 3, "autonomous": {"perTokenConcurrency": 2}}',
+    });
+    expect(await resolveEffectiveConfig(root)).toEqual({
+      nextAgentNumber: 3,
+      autonomous: { perTokenConcurrency: 2 },
+    });
+  });
+
+  it("returns {} when no files are present", async () => {
+    disableDefaultsTier();
+    const root = await makeRepo({});
+    expect(await resolveEffectiveConfig(root)).toEqual({});
+  });
+
+  it("soft-fails a malformed legacy tier without aborting the others", async () => {
+    disableDefaultsTier();
+    const root = await makeRepo({
+      legacy: "{not json",
+      project: '{"buildGate": {"enabled": true}}',
+    });
+    expect(await resolveEffectiveConfig(root)).toEqual({ buildGate: { enabled: true } });
+  });
+
+  it("applies precedence local > project > legacy", async () => {
+    disableDefaultsTier();
+    const root = await makeRepo({
+      legacy: '{"a": "legacy", "shared": 1}',
+      project: '{"a": "project", "shared": 2}',
+      local: '{"a": "local"}',
+    });
+    const effective = await resolveEffectiveConfig(root);
+    expect(effective.a).toBe("local");
+    expect(effective.shared).toBe(2);
+  });
+
+  it("unions disjoint keys across tiers", async () => {
+    disableDefaultsTier();
+    const root = await makeRepo({
+      legacy: '{"legacyOnly": 1}',
+      project: '{"projectOnly": 2}',
+      local: '{"localOnly": 3}',
+    });
+    expect(await resolveEffectiveConfig(root)).toEqual({
+      legacyOnly: 1,
+      projectOnly: 2,
+      localOnly: 3,
+    });
+  });
+
+  it("merges a nested autonomous block across tiers", async () => {
+    disableDefaultsTier();
+    const root = await makeRepo({
+      legacy: '{"autonomous": {"workFinder": {"enabled": true}}}',
+      local: '{"autonomous": {"perTokenConcurrency": 4}}',
+    });
+    expect(await resolveEffectiveConfig(root)).toEqual({
+      autonomous: { workFinder: { enabled: true }, perTokenConcurrency: 4 },
+    });
+  });
+});
+
+// ===== getPath =====
+
+describe("getPath", () => {
+  it("resolves a nested dotted key", () => {
+    expect(getPath({ autonomous: { workFinder: { enabled: true } } }, "autonomous.workFinder.enabled")).toBe(
+      true
+    );
+  });
+
+  it("returns undefined for a missing segment", () => {
+    expect(getPath({ autonomous: {} }, "autonomous.workFinder.enabled")).toBeUndefined();
+  });
+
+  it("returns undefined when indexing through a scalar", () => {
+    expect(getPath({ a: 1 }, "a.b")).toBeUndefined();
+  });
+
+  it("resolves a top-level key", () => {
+    expect(getPath({ nextAgentNumber: 3 }, "nextAgentNumber")).toBe(3);
+  });
+});
+
+// ===== Cross-language conformance fixture (#4039 / #4064 parity) =====
+
+describe("cross-language conformance", () => {
+  it("resolves the shared fixture identically to the Rust reference's expected.json", async () => {
+    disableDefaultsTier();
+    const effective = await resolveEffectiveConfig(CONFORMANCE_FIXTURE_DIR);
+    const expectedText = await readFile(join(CONFORMANCE_FIXTURE_DIR, "expected.json"), "utf-8");
+    expect(effective).toEqual(JSON.parse(expectedText));
+  });
+});
+
+// ===== Write-policy (option 3): no flattening of non-legacy tiers =====
+
+describe("configure_terminal write policy", () => {
+  it("refuses to flatten a non-legacy tier into .loom/config.json", async () => {
+    disableDefaultsTier();
+    const legacy = JSON.stringify(
+      { version: "1.0", offlineMode: false, terminals: [{ id: "terminal-1", name: "Old" }] },
+      null,
+      2
+    );
+    const project = JSON.stringify(
+      { projectOnly: "leaked-if-flattened", autonomous: { perTokenConcurrency: 9 } },
+      null,
+      2
+    );
+    const root = await makeRepo({ legacy, project });
+    process.env.LOOM_WORKSPACE = root;
+
+    const result = await handleTerminalTool("configure_terminal", {
+      terminal_id: "terminal-1",
+      name: "New",
+    });
+    const text = result[0]?.text ?? "";
+
+    // (0) The write was refused with an actionable error.
+    expect(text).toContain("Failed");
+    expect(text).toContain("non-legacy config tier");
+
+    // (a) The tier file is byte-unchanged.
+    expect(await readFile(join(root, PROJECT_CONFIG_REL), "utf-8")).toBe(project);
+
+    // (b) The legacy file gained no keys sourced from the project tier (in
+    //     fact it is byte-unchanged — the refuse path never writes).
+    const legacyAfter = await readFile(join(root, LEGACY_CONFIG_REL), "utf-8");
+    expect(legacyAfter).toBe(legacy);
+    expect(legacyAfter).not.toContain("projectOnly");
+    expect(legacyAfter).not.toContain("perTokenConcurrency");
+  });
+
+  it("hasNonLegacyTier is true with a project tier and false without", async () => {
+    disableDefaultsTier();
+    const withProject = await makeRepo({ legacy: "{}", project: '{"a": 1}' });
+    const legacyOnly = await makeRepo({ legacy: '{"a": 1}' });
+    expect(await hasNonLegacyTier(withProject)).toBe(true);
+    expect(await hasNonLegacyTier(legacyOnly)).toBe(false);
+  });
+
+  it("still edits the legacy file when it is the only tier present", async () => {
+    disableDefaultsTier();
+    const legacy = JSON.stringify(
+      { version: "1.0", terminals: [{ id: "terminal-1", name: "Old" }] },
+      null,
+      2
+    );
+    const root = await makeRepo({ legacy });
+    process.env.LOOM_WORKSPACE = root;
+
+    const result = await handleTerminalTool("configure_terminal", {
+      terminal_id: "terminal-1",
+      name: "New",
+    });
+    expect(result[0]?.text ?? "").toContain("Success");
+
+    const after = JSON.parse(await readFile(join(root, LEGACY_CONFIG_REL), "utf-8"));
+    expect(after.terminals[0].name).toBe("New");
+  });
+});

--- a/mcp-loom/src/shared/config-resolver.ts
+++ b/mcp-loom/src/shared/config-resolver.ts
@@ -1,0 +1,184 @@
+/**
+ * Config resolution layer for mcp-loom (Epic #3835, issue #4064).
+ *
+ * A TypeScript port of `loom-daemon/src/config_resolver.rs` (the reference
+ * implementation). It resolves the effective config by deep-merging the tier
+ * chain, lowest to highest precedence:
+ *
+ *   1. Private/shared defaults (`$LOOM_CONFIG_DEFAULTS_FILE`, default
+ *      `~/.local/share/loom/config/defaults.json`) — a no-op tier on every
+ *      host until Epic #3835 Phase 3 ships.
+ *   2. Legacy `.loom/config.json` — the sole tier every existing repo has.
+ *   3. Tracked `.loom-project/project.json` — empty until a repo migrates.
+ *   4. Ignored `.loom-local/local.json` — host-local override.
+ *
+ * The tier order, `deepMerge` semantics (objects merge recursively, arrays
+ * replace, explicit `null` replaces), and soft-skip behavior (missing /
+ * unreadable / malformed / non-object files contribute nothing, never fatal)
+ * are kept byte-compatible with the Rust reference. The shared conformance
+ * fixture in `loom-tools/tests/fixtures/config_resolver/` must resolve
+ * identically here and in Rust/Python/Bash.
+ *
+ * NOTE: all existing resolvers (Rust/Python/Bash) are read-only. This module
+ * is likewise read-only — it never writes. The write-target policy for
+ * `configure_terminal` is enforced separately via `hasNonLegacyTier` (see
+ * issue #4064's write-policy decision): the writer refuses to flatten the
+ * merged view back into the legacy file when a non-legacy tier is present.
+ */
+
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Repo-relative path to the legacy, currently load-bearing config file. */
+export const LEGACY_CONFIG_REL = ".loom/config.json";
+
+/** Repo-relative path to the tracked, project-specific config file. */
+export const PROJECT_CONFIG_REL = ".loom-project/project.json";
+
+/** Repo-relative path to the ignored, host-local config override file. */
+export const LOCAL_CONFIG_REL = ".loom-local/local.json";
+
+/** Env var overriding the private/shared defaults file location. */
+export const PRIVATE_DEFAULTS_ENV = "LOOM_CONFIG_DEFAULTS_FILE";
+
+/** Home-relative default location of the private/shared defaults file. */
+const DEFAULT_PRIVATE_DEFAULTS_REL = ".local/share/loom/config/defaults.json";
+
+/** A JSON object (the shape every tier is normalized to before merging). */
+export type JsonObject = Record<string, unknown>;
+
+/**
+ * True for a plain JSON object — i.e. not `null`, not an array, not a scalar.
+ * Mirrors Rust's `Value::Object(_)` match arm.
+ */
+function isPlainObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Resolve the path to the private/shared defaults file, honoring
+ * {@link PRIVATE_DEFAULTS_ENV}. Returns `null` when the env var is explicitly
+ * set to an empty string (tier disabled). Mirrors Rust's
+ * `private_defaults_path`: an unset env var falls back to the home-relative
+ * default; a set-but-empty env var disables the tier.
+ */
+export function privateDefaultsPath(): string | null {
+  const env = process.env[PRIVATE_DEFAULTS_ENV];
+  if (env !== undefined) {
+    return env === "" ? null : env;
+  }
+  return join(homedir(), DEFAULT_PRIVATE_DEFAULTS_REL);
+}
+
+/**
+ * Soft-fail JSON-object read: a missing file, an unreadable file, malformed
+ * JSON, or a non-object top-level value all resolve to an empty object
+ * (`{}`) — that tier simply contributes nothing to the merge. Never throws.
+ * Mirrors Rust's `soft_read_json_object`.
+ */
+export async function softReadJsonObject(path: string): Promise<JsonObject> {
+  let text: string;
+  try {
+    text = await readFile(path, "utf-8");
+  } catch {
+    return {};
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return {};
+  }
+
+  return isPlainObject(parsed) ? parsed : {};
+}
+
+/**
+ * Deep-merge `overlay` onto `base`, returning the merged value.
+ *
+ * Semantics (identical to Rust's `deep_merge` and `jq`'s `*` operator):
+ * - When both sides are JSON objects, merge recursively key-by-key.
+ * - Otherwise `overlay` replaces `base` outright — including when `overlay`
+ *   is `null` (an explicit `null` in a higher tier clears the key) and when
+ *   either side is an array (arrays replace, never concatenate).
+ */
+export function deepMerge(base: unknown, overlay: unknown): unknown {
+  if (isPlainObject(base) && isPlainObject(overlay)) {
+    const merged: JsonObject = { ...base };
+    for (const key of Object.keys(overlay)) {
+      merged[key] = Object.prototype.hasOwnProperty.call(merged, key)
+        ? deepMerge(merged[key], overlay[key])
+        : overlay[key];
+    }
+    return merged;
+  }
+  return overlay;
+}
+
+/**
+ * Resolve the full effective config tree for `repoRoot` by deep-merging the
+ * tier chain lowest → highest. A missing or malformed file at any tier
+ * soft-fails to that tier contributing nothing. When only the legacy tier has
+ * content — the state of every repo today — the result is byte-for-byte the
+ * parsed content of `.loom/config.json`, preserving existing behavior.
+ */
+export async function resolveEffectiveConfig(repoRoot: string): Promise<JsonObject> {
+  let effective: JsonObject = {};
+
+  const defaultsPath = privateDefaultsPath();
+  if (defaultsPath !== null) {
+    effective = deepMerge(effective, await softReadJsonObject(defaultsPath)) as JsonObject;
+  }
+
+  effective = deepMerge(effective, await softReadJsonObject(join(repoRoot, LEGACY_CONFIG_REL))) as JsonObject;
+  effective = deepMerge(effective, await softReadJsonObject(join(repoRoot, PROJECT_CONFIG_REL))) as JsonObject;
+  effective = deepMerge(effective, await softReadJsonObject(join(repoRoot, LOCAL_CONFIG_REL))) as JsonObject;
+
+  return effective;
+}
+
+/**
+ * Look up a dotted key path (e.g. `"autonomous.workFinder.enabled"`) in an
+ * already-resolved effective config tree. Returns `undefined` on any missing
+ * segment or when a non-object value is indexed further. Mirrors Rust's
+ * `get_path`.
+ */
+export function getPath(config: unknown, dotted: string): unknown {
+  let cur: unknown = config;
+  for (const segment of dotted.split(".")) {
+    if (!isPlainObject(cur) || !Object.prototype.hasOwnProperty.call(cur, segment)) {
+      return undefined;
+    }
+    cur = cur[segment];
+  }
+  return cur;
+}
+
+/**
+ * True when a non-legacy tier (private defaults, `.loom-project/project.json`,
+ * or `.loom-local/local.json`) contributes any content for `repoRoot`.
+ *
+ * This is the guard behind the #4064 write-policy decision (option 3): when a
+ * non-legacy tier is present, `configure_terminal` must NOT write the merged
+ * view back to `.loom/config.json`, because doing so would flatten every
+ * higher-tier override into the legacy file and de-sync it from its source of
+ * truth. The writer refuses instead, directing the operator to edit the tier
+ * file directly.
+ */
+export async function hasNonLegacyTier(repoRoot: string): Promise<boolean> {
+  const defaultsPath = privateDefaultsPath();
+  if (defaultsPath !== null) {
+    if (Object.keys(await softReadJsonObject(defaultsPath)).length > 0) {
+      return true;
+    }
+  }
+  if (Object.keys(await softReadJsonObject(join(repoRoot, PROJECT_CONFIG_REL))).length > 0) {
+    return true;
+  }
+  if (Object.keys(await softReadJsonObject(join(repoRoot, LOCAL_CONFIG_REL))).length > 0) {
+    return true;
+  }
+  return false;
+}

--- a/mcp-loom/src/shared/config.ts
+++ b/mcp-loom/src/shared/config.ts
@@ -9,6 +9,7 @@ import { access, readFile, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ConfigFile, StateFile } from "../types.js";
+import { resolveEffectiveConfig } from "./config-resolver.js";
 
 /** Global Loom directory in user's home */
 export const LOOM_DIR = join(homedir(), ".loom");
@@ -82,30 +83,39 @@ export async function writeStateFile(state: StateFile): Promise<void> {
 }
 
 /**
- * Read the workspace config file
+ * Read the effective workspace config.
+ *
+ * Resolves the full tier chain (private defaults → `.loom/config.json` →
+ * `.loom-project/project.json` → `.loom-local/local.json`) via
+ * {@link resolveEffectiveConfig}, so every read surface agrees with the
+ * daemon / Python / Bash resolvers about the effective config (issue #4064).
+ *
+ * Returns `null` when no tier contributes any content (an uninitialized
+ * workspace), preserving the previous "config file not found" contract. When
+ * only the legacy `.loom/config.json` is present — the state of every repo
+ * today — the merged result is byte-for-byte that file's parsed content.
+ *
+ * WRITE HAZARD: the result may be a merge across tiers. Callers must NOT write
+ * it back to `.loom/config.json` when a non-legacy tier is present, or they
+ * flatten higher-tier overrides into the legacy file. `configure_terminal`
+ * guards against this with `hasNonLegacyTier` (see config-resolver.ts).
  */
 export async function readConfigFile(): Promise<ConfigFile | null> {
-  try {
-    const workspacePath = getWorkspacePath();
-    const configPath = join(workspacePath, ".loom", "config.json");
-
-    const fileStats = await stat(configPath);
-    if (!fileStats.isFile()) {
-      return null;
-    }
-
-    const content = await readFile(configPath, "utf-8");
-    return JSON.parse(content) as ConfigFile;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return null;
-    }
-    throw error;
+  const effective = await resolveEffectiveConfig(getWorkspacePath());
+  if (Object.keys(effective).length === 0) {
+    return null;
   }
+  return effective as unknown as ConfigFile;
 }
 
 /**
- * Write the workspace config file
+ * Write the workspace config file.
+ *
+ * Always targets the legacy `.loom/config.json` and only that file — this
+ * resolver family is read-only across all four languages, so there is no
+ * tier-aware write path. Do not call this with a merged (multi-tier) config
+ * when a non-legacy tier is present; see `readConfigFile`'s WRITE HAZARD note
+ * and the `hasNonLegacyTier` guard in `configure_terminal`.
  */
 export async function writeConfigFile(config: ConfigFile): Promise<void> {
   const workspacePath = getWorkspacePath();
@@ -126,24 +136,6 @@ export async function readWorkspaceStateFile(): Promise<string> {
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return "State file not found. Workspace may not be initialized.";
-    }
-    throw error;
-  }
-}
-
-/**
- * Read the workspace config file (returns as string for compatibility)
- */
-export async function readWorkspaceConfigFile(): Promise<string> {
-  try {
-    const workspacePath = getWorkspacePath();
-    const configPath = join(workspacePath, ".loom", "config.json");
-
-    await access(configPath);
-    return await readFile(configPath, "utf-8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return "Config file not found. Workspace may not be initialized.";
     }
     throw error;
   }

--- a/mcp-loom/src/tools/terminals.ts
+++ b/mcp-loom/src/tools/terminals.ts
@@ -23,6 +23,11 @@ import {
   writeConfigFile,
   writeStateFile,
 } from "../shared/config.js";
+import {
+  LOCAL_CONFIG_REL,
+  PROJECT_CONFIG_REL,
+  hasNonLegacyTier,
+} from "../shared/config-resolver.js";
 import { sendDaemonRequest } from "../shared/daemon.js";
 import { formatTerminalOutput } from "../shared/formatting.js";
 import { writeMCPCommand } from "../shared/ipc.js";
@@ -347,6 +352,25 @@ async function configureTerminal(
       return {
         success: false,
         error: "Config file not found. Workspace may not be initialized.",
+      };
+    }
+
+    // Write-policy guard (issue #4064): `readConfigFile` now returns the merged
+    // view across config tiers. Writing that back to `.loom/config.json` when a
+    // non-legacy tier is present would flatten every `.loom-project/` and
+    // `.loom-local/` override into the legacy file, silently de-syncing it from
+    // its source of truth. Since this resolver family is read-only (there is no
+    // tier-aware write path), refuse the edit and direct the operator to the
+    // tier file instead.
+    if (await hasNonLegacyTier(getWorkspacePath())) {
+      return {
+        success: false,
+        error:
+          `Refusing to edit ${terminalId}: a non-legacy config tier is present ` +
+          `(${PROJECT_CONFIG_REL} or ${LOCAL_CONFIG_REL}). mcp-loom reads the merged ` +
+          `config across all tiers, but can only write the legacy .loom/config.json — ` +
+          `writing here would flatten your tier overrides into it and de-sync them. ` +
+          `Edit the terminal in the tier file that defines it directly.`,
       };
     }
 

--- a/mcp-loom/src/tools/ui.ts
+++ b/mcp-loom/src/tools/ui.ts
@@ -14,7 +14,7 @@
 import { access, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-import { CONSOLE_LOG_PATH, getWorkspacePath } from "../shared/config.js";
+import { CONSOLE_LOG_PATH, getWorkspacePath, readConfigFile } from "../shared/config.js";
 import { writeMCPCommand } from "../shared/ipc.js";
 
 /**
@@ -105,16 +105,11 @@ async function getUIState(): Promise<string> {
   try {
     const workspacePath = getWorkspacePath();
 
-    // Read config file
-    const configPath = join(workspacePath, ".loom", "config.json");
-    let config: { version: string; terminals: unknown[]; offlineMode?: boolean } | null = null;
-    try {
-      await access(configPath);
-      const configContent = await readFile(configPath, "utf-8");
-      config = JSON.parse(configContent);
-    } catch {
-      // Config doesn't exist or can't be read
-    }
+    // Read the effective config across all tiers (issue #4064) so get_ui_state
+    // agrees with the daemon / Python / Bash surfaces about the config, rather
+    // than reading only the legacy `.loom/config.json`.
+    const config: { version: string; terminals: unknown[]; offlineMode?: boolean } | null =
+      await readConfigFile();
 
     // Read state file
     const statePath = join(workspacePath, ".loom", "state.json");


### PR DESCRIPTION
## Summary

`mcp-loom` (TypeScript) was the fourth language reading `.loom/config.json` with no tier resolver (Rust/Python/Bash already have one via #4039). Once Epic #3835 relocates settings into `.loom-project/project.json` / `.loom-local/local.json`, the MCP server would silently disagree with every other surface about the effective config.

This implements **Option A** (the Curator/Champion recommendation) with **write-policy option 3**. Full decision rationale is recorded in an issue comment (AC #2).

## Changes

- **New `mcp-loom/src/shared/config-resolver.ts`** — a TS port of `loom-daemon/src/config_resolver.rs`, byte-compatible: tier order (private defaults → `.loom/config.json` → `.loom-project/project.json` → `.loom-local/local.json`), `deepMerge` (objects merge recursively, arrays replace, explicit `null` replaces), and soft-skip (missing/unreadable/malformed/non-object → contributes nothing, never fatal). Exports `resolveEffectiveConfig`, `deepMerge`, `getPath`, `softReadJsonObject`, `privateDefaultsPath`, `hasNonLegacyTier`.
- **Migrated the two live readers** — `readConfigFile()` (`shared/config.ts`) and `getUIState()` (`tools/ui.ts`) now resolve across tiers.
- **Deleted dead `readWorkspaceConfigFile()`** (zero callers repo-wide).
- **Write-policy (option 3)** — `configure_terminal` now calls `hasNonLegacyTier()` and refuses, with an actionable error, when a non-legacy tier is present, instead of flattening the merged view into the legacy file. When only the legacy tier exists (every repo today) the merged view is byte-identical, so the write path is unchanged.
- **Test infrastructure** — added vitest + a `test` script to `mcp-loom/package.json` (none existed).

## Acceptance Criteria Verification

- [x] Four sites audited (done by Curator); enumeration = 2 live readers + 1 writer + 1 dead reader.
- [x] Decision (A) recorded in a comment with an explicit `configure_terminal` write-target policy (option 3).
- [x] `readWorkspaceConfigFile` deleted as dead code.
- [x] TS resolver with tier precedence + `deepMerge` byte-compatible with `config_resolver.rs`; live read sites use it; parity demonstrated via the shared fixture.
- [x] `configure_terminal` cannot flatten `.loom-project/`/`.loom-local/` into `.loom/config.json` — proven by a regression test asserting tier files and the legacy file are byte-unchanged.
- [x] No surface silently disagrees with another about the effective config.

## Test Plan

- [x] `cd mcp-loom && npm run typecheck` — green
- [x] `npm test` — **26 passed**: tier-precedence/`deepMerge`/soft-skip cases mirroring the Rust tests (disjoint-key union, deep merge, array replacement, explicit-`null`, malformed/non-object soft-skip), cross-language parity against `loom-tools/tests/fixtures/config_resolver/expected.json`, and the write-flattening regression.
- [x] `npm run build` — green (bundle unaffected)
- [x] Regression: with only `.loom/config.json` present, `resolveEffectiveConfig` returns byte-identical content and `configure_terminal` still edits the legacy file (covered by tests).

Closes #4064
