### PR TITLE
fix(scripts): delete the local branch on every merge-pr.sh cleanup path

### DIFF
--- a/defaults/docs/troubleshooting.md
+++ b/defaults/docs/troubleshooting.md
@@ -77,6 +77,24 @@ loom-clean --deep --dry-run  # Preview deep clean
 loom-clean --force  # Non-interactive, safe for automation
 ```
 
+**Backlog of pre-existing `[gone]` local branches (#4100)**: `merge-pr.sh` deletes
+the local feature branch for every PR it merges as of #4100, but repos that ran
+Loom before that fix accumulated one orphaned local branch per merged issue —
+each pointing at a remote ref the merge already deleted server-side, so `git
+branch -vv` shows them as `[gone]`. Reap the existing backlog with:
+
+```bash
+git fetch --prune   # drop stale remote-tracking refs first
+loom-clean --force  # clean_branches() deletes local branches whose remote is gone
+```
+
+`loom-clean`'s `clean_branches()` already handles this in two passes: a
+pattern-agnostic pass that deletes any local branch (other than the
+default/current/other-worktree-checked-out ones) whose `origin/<branch>` no
+longer exists, plus an issue-state pass that probes `feature/issue-*` branches
+still tracking a remote against the forge and deletes them once the issue is
+closed. No separate one-off backlog tool is needed.
+
 **Manual cleanup** (if needed, but use with caution):
 
 **WARNING**: Running `git worktree remove` while your shell is in the worktree directory will corrupt your shell state. Always ensure you've navigated out of the worktree first, or use `loom-clean` which handles this safely.

--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -9,7 +9,8 @@
 # (see forge-helpers.sh for details).
 #
 # Options:
-#   --no-cleanup-worktree  Skip local worktree cleanup after merge
+#   --no-cleanup-worktree  Skip local worktree AND local branch cleanup after
+#                          merge
 #   --cleanup-worktree     (no-op, worktree cleanup is now the default)
 #   --worktree-path <dir>  Explicit worktree path to clean up (bypasses
 #                          .loom-managed sentinel guard — caller asserts
@@ -28,14 +29,29 @@
 #                          stacked child PRs targeting it (operator asserts the
 #                          children are already reconciled). See #3747 item 2.
 #
-# By default, the local worktree is cleaned up after a successful merge.
-# Pass --no-cleanup-worktree to skip this (e.g., when other terminals may
-# have their CWD inside the worktree).
+# By default, the local worktree AND the local branch it held are cleaned up
+# after a successful merge (#4100). Pass --no-cleanup-worktree to skip both
+# (e.g., when other terminals may have their CWD inside the worktree, or the
+# branch has unpushed commits you want to keep).
 #
 # Cleanup is restricted to Loom-managed worktrees (those containing the
 # .loom-managed sentinel written by worktree.sh). Worktrees lacking the
 # sentinel are treated as user-owned and never removed. Set
 # LOOM_PRESERVE_WORKTREE=1 to disable cleanup unconditionally for a session.
+#
+# Local branch deletion (#4100): every cleanup path — the default
+# .loom/worktrees/issue-N convention, a discovered Loom-managed worktree at a
+# non-standard path, and even the case where no worktree exists at all —
+# attempts to delete the merged PR's local branch. Safety is determined by
+# whether the local branch tip equals the merged PR's head SHA (not by `git
+# branch --merged`, which is always false for a squash merge): a matching tip
+# uses `git branch -D` (every commit on the branch was part of the merged PR);
+# a non-matching tip (unpushed local work) falls back to `git branch -d`,
+# which keeps the branch and reports it instead of force-deleting. A branch
+# checked out as the current HEAD (or in another worktree) is never deleted —
+# git itself refuses, and the refusal is reported with a specific message
+# rather than the generic "unmerged commits" warning. The repo's default
+# branch is never a delete target.
 #
 # Override: pass --worktree-path <dir> to opt into removing a non-Loom
 # worktree (the sentinel guard is bypassed only when this flag is supplied).
@@ -76,7 +92,8 @@ Supports both GitHub and Gitea forges. Forge detection is automatic
 (see forge-helpers.sh for details).
 
 Options:
-  --no-cleanup-worktree  Skip local worktree cleanup after merge
+  --no-cleanup-worktree  Skip local worktree AND local branch cleanup
+                         after merge
   --cleanup-worktree     (no-op, worktree cleanup is now the default)
   --worktree-path <dir>  Explicit worktree path to clean up. Bypasses the
                          .loom-managed sentinel guard (caller asserts
@@ -103,15 +120,26 @@ Options:
                          responsibility, mirroring --worktree-path.
   -h, --help             Show this help and exit
 
-By default, the local worktree is cleaned up after a successful merge.
-Pass --no-cleanup-worktree to skip this (e.g., when other terminals may
-have their CWD inside the worktree).
+By default, the local worktree AND the local branch it held are cleaned up
+after a successful merge (#4100). Pass --no-cleanup-worktree to skip both
+(e.g., when other terminals may have their CWD inside the worktree, or you
+want to keep a branch with unpushed commits).
 
 Cleanup is restricted to Loom-managed worktrees (those under
 .loom/worktrees/issue-N that contain a .loom-managed sentinel file written
 by worktree.sh). User-provisioned worktrees at other paths are never
 removed by the default code path. Set LOOM_PRESERVE_WORKTREE=1 to disable
 cleanup unconditionally for a session.
+
+Local branch deletion (#4100): every cleanup path — including the case
+where no worktree exists at all — attempts to delete the merged PR's local
+branch. Safety is determined by comparing the local branch tip to the
+merged PR's head SHA (not 'git branch --merged', which is always false for
+a squash merge): a matching tip uses 'git branch -D'; a non-matching tip
+(unpushed local work) falls back to 'git branch -d', which keeps the
+branch and reports it instead of force-deleting. The branch currently
+checked out (main worktree or any other) is never deleted, and the repo's
+default branch is never a delete target.
 
 When --worktree-path <dir> is passed explicitly, the operator is taking
 responsibility for the cleanup decision: the sentinel guard is bypassed
@@ -198,6 +226,16 @@ source "$SCRIPT_DIR/lib/forge-helpers.sh"
 # overridden root, not just the default .loom/worktrees.
 # shellcheck source=lib/worktree-root.sh
 source "$SCRIPT_DIR/lib/worktree-root.sh"
+# Default-branch resolver (#4100) — the local-branch delete guard must never
+# target the repo's default branch. Sourced defensively: a repo where this
+# fails to resolve (e.g. no network + no origin/HEAD symref) still falls back
+# to the literal "main"/"master" check in _maybe_delete_local_branch below.
+DEFAULT_BRANCH_NAME=""
+if [[ -f "$SCRIPT_DIR/lib/default-branch.sh" ]]; then
+  # shellcheck source=lib/default-branch.sh
+  source "$SCRIPT_DIR/lib/default-branch.sh"
+  DEFAULT_BRANCH_NAME="$(cd "$REPO_ROOT" && loom_default_branch 2>/dev/null || true)"
+fi
 forge_detect
 
 # Use gh-cached for read-only queries to reduce API calls (see issue #1609)
@@ -292,6 +330,11 @@ PR_MERGED=$(echo "$PR_JSON" | jq -r '.merged')
 PR_BRANCH=$(echo "$PR_JSON" | jq -r '.head.ref')
 PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
 PR_MERGEABLE=$(echo "$PR_JSON" | jq -r '.mergeable')
+# Head SHA (#4100): the safety criterion for local-branch deletion. A local
+# branch whose tip equals this SHA carries no commits absent from the merged
+# PR, so it is safe to force-delete even though it will never satisfy
+# `git branch --merged` after a squash merge.
+PR_HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha // empty')
 
 # Check if already merged
 if [[ "$PR_MERGED" == "true" ]]; then
@@ -1171,8 +1214,15 @@ if [[ "$PR_MERGEABLE" == "false" ]]; then
 fi
 
 if [[ "$DRY_RUN" == "true" ]]; then
-  info "[dry-run] Would merge PR #$PR_NUMBER (squash) and delete branch '$PR_BRANCH'"
-  [[ "$CLEANUP_WORKTREE" == "true" ]] && info "[dry-run] Would clean up local worktree"
+  info "[dry-run] Would merge PR #$PR_NUMBER (squash) and delete remote branch '$PR_BRANCH'"
+  if [[ "$CLEANUP_WORKTREE" == "true" ]]; then
+    info "[dry-run] Would clean up local worktree"
+    if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$PR_BRANCH"; then
+      info "[dry-run] Would delete local branch '$PR_BRANCH'"
+    fi
+  else
+    info "[dry-run] --no-cleanup-worktree: would leave local worktree and local branch '$PR_BRANCH' in place"
+  fi
   exit 0
 fi
 
@@ -1289,12 +1339,12 @@ _auto_reconcile_stacked_children || true
 # Delete remote branch (skip if forge auto-deletes on merge)
 DELETE_BRANCH_ON_MERGE=$(forge_check_auto_delete "$REPO_NWO" "$GH")
 if [[ "$DELETE_BRANCH_ON_MERGE" == "true" ]]; then
-  info "Skipping branch deletion (auto-delete is enabled)"
+  info "Skipping remote branch deletion (auto-delete is enabled)"
 else
   info "Deleting remote branch: $PR_BRANCH"
   forge_delete_branch "$REPO_NWO" "$PR_BRANCH" && \
-    success "Branch '$PR_BRANCH' deleted" || \
-    warning "Could not delete branch '$PR_BRANCH' (may already be deleted)"
+    success "Remote branch '$PR_BRANCH' deleted" || \
+    warning "Could not delete remote branch '$PR_BRANCH' (may already be deleted)"
 fi
 
 # Cleanup worktree if requested.
@@ -1362,11 +1412,24 @@ _find_worktree_by_branch() {
     '
 }
 
-# Delete the matching local branch. Uses `git branch -d` (not -D) so unmerged
-# commits abort the delete — that's the right safety net. Never fails the
-# cleanup pipeline; warns on errors.
+# Delete the matching local branch (#4100).
+#
+# _maybe_delete_local_branch <branch> [expected_head_sha]
+#
+# `expected_head_sha` is optional — the merged PR's `head.sha` (already parsed
+# into $PR_HEAD_SHA at the top of this script). When it is supplied AND the
+# local branch tip equals it, every commit on the branch was part of the
+# merged PR, so `git branch -D` (force) is safe even though the branch will
+# never satisfy `git branch --merged` after a squash merge. When it is absent
+# (the pre-#4100 :1455-equivalent caller below) or the tip does not match
+# (unpushed local work), this falls back to the original `git branch -d`
+# behaviour: Git's own "not fully merged" safety net, which keeps the branch
+# and reports it rather than force-deleting.
+#
+# Never fails the cleanup pipeline — always returns 0, warns on errors.
 _maybe_delete_local_branch() {
   local branch="$1"
+  local expected_head_sha="${2:-}"
   if [[ -z "$branch" ]]; then
     return 0
   fi
@@ -1374,11 +1437,43 @@ _maybe_delete_local_branch() {
     info "Local branch '$branch' does not exist — skipping branch delete"
     return 0
   fi
-  if git -C "$REPO_ROOT" branch -d "$branch" 2>/dev/null; then
-    success "Local branch '$branch' deleted"
-  else
-    warning "Could not delete local branch '$branch' (may have unmerged commits — use 'git branch -D' if intentional)"
+  # Never delete the repo's default branch (cheap belt-and-suspenders; the
+  # merged PR's head branch should never legitimately BE the default branch,
+  # but a misdetected $PR_BRANCH must not take this out).
+  if [[ -n "$DEFAULT_BRANCH_NAME" && "$branch" == "$DEFAULT_BRANCH_NAME" ]] || \
+     [[ "$branch" == "main" ]] || [[ "$branch" == "master" ]]; then
+    warning "Refusing to delete local branch '$branch' — it is the repository's default branch"
+    return 0
   fi
+
+  local delete_flag="-d"
+  local safety_note=""
+  if [[ -n "$expected_head_sha" ]]; then
+    local local_tip
+    local_tip="$(git -C "$REPO_ROOT" rev-parse --verify -q "refs/heads/$branch" 2>/dev/null || echo "")"
+    if [[ -n "$local_tip" ]] && [[ "$local_tip" == "$expected_head_sha" ]]; then
+      delete_flag="-D"
+      safety_note=" (tip matches merged PR head SHA — safe force-delete)"
+    fi
+  fi
+
+  local delete_output
+  if delete_output="$(git -C "$REPO_ROOT" branch "$delete_flag" "$branch" 2>&1)"; then
+    success "Local branch '$branch' deleted$safety_note"
+    return 0
+  fi
+
+  # Distinguish "checked out somewhere" (current HEAD or another worktree)
+  # from a genuine "not fully merged" refusal — the former gets a specific
+  # message instead of the generic unmerged-commits warning (#4100 AC #4).
+  if echo "$delete_output" | grep -qiE "checked out at|is currently checked out|used by worktree"; then
+    warning "Could not delete local branch '$branch' — it is checked out (current HEAD or another worktree)"
+  elif [[ "$delete_flag" == "-d" ]]; then
+    warning "Could not delete local branch '$branch' (may have unpushed commits — use 'git branch -D $branch' if intentional)"
+  else
+    warning "Could not delete local branch '$branch': $delete_output"
+  fi
+  return 0
 }
 
 # _remove_loom_worktree <path> [allow_unmanaged]
@@ -1461,12 +1556,14 @@ _remove_loom_worktree() {
 
 if [[ "$CLEANUP_WORKTREE" == "true" ]]; then
   if [[ "${LOOM_PRESERVE_WORKTREE:-0}" == "1" ]]; then
-    info "Worktree cleanup skipped (LOOM_PRESERVE_WORKTREE=1)"
+    info "Worktree cleanup skipped (LOOM_PRESERVE_WORKTREE=1) — local branch left in place"
   elif [[ -n "$WORKTREE_PATH_OVERRIDE" ]]; then
     # Explicit operator opt-in: bypass the sentinel guard for THIS path only.
     # The path was already validated at parse time (exists + is a registered
     # worktree of this repo). _remove_loom_worktree will also delete the
-    # matching local branch via `git branch -d` (refuses on unmerged commits).
+    # matching local branch via `git branch -d` (refuses on unmerged commits)
+    # — this is the pre-#4100 caller, so no head-SHA safety check is passed;
+    # behaviour is unchanged from before #4100.
     info "Cleanup target overridden by --worktree-path: $WORKTREE_PATH_OVERRIDE"
     _remove_loom_worktree "$WORKTREE_PATH_OVERRIDE" "true"
   else
@@ -1509,7 +1606,21 @@ if [[ "$CLEANUP_WORKTREE" == "true" ]]; then
         info "No worktree found at $DEFAULT_WT_PATH (and none tracking '$PR_BRANCH' in 'git worktree list')"
       fi
     fi
+    # Local-branch delete (#4100): the default-convention path, the
+    # discovered-Loom-managed-non-standard-path, and the no-worktree-at-all
+    # case (rows 2-4 of the issue's path table) all funnel through here —
+    # none of them call _maybe_delete_local_branch internally the way the
+    # --worktree-path override does above. Passing $PR_HEAD_SHA lets the
+    # helper safely `-D` a branch whose tip matches the merged PR (the only
+    # criterion that is correct after a squash merge — `git branch --merged`
+    # is not). If the discovered worktree above was user-owned and left in
+    # place, its branch is still checked out there, so this call is a
+    # harmless no-op that reports the specific "checked out" refusal instead
+    # of attempting a real delete.
+    _maybe_delete_local_branch "$PR_BRANCH" "$PR_HEAD_SHA"
   fi
+else
+  info "Worktree cleanup skipped (--no-cleanup-worktree) — local branch left in place"
 fi
 
 success "Done"

--- a/defaults/scripts/tests/test-merge-pr-local-branch-cleanup.sh
+++ b/defaults/scripts/tests/test-merge-pr-local-branch-cleanup.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# test-merge-pr-local-branch-cleanup.sh - Tests for local-branch deletion (#4100)
+#
+# merge-pr.sh already cleaned up the remote branch and the worktree on a
+# successful merge but left the LOCAL branch behind on every path except the
+# --worktree-path explicit override. Every merged issue therefore leaked one
+# local `feature/issue-N` branch, all classifying as `[gone]` once
+# `git fetch --prune` runs.
+#
+# Root cause: `_maybe_delete_local_branch` existed but had exactly one call
+# site (:1455-era, the --worktree-path override), gated behind
+# allow_unmanaged=="true". The default `.loom/worktrees/issue-N` path, the
+# discovered-Loom-managed-non-standard-path, and the no-worktree-at-all case
+# never called it.
+#
+# The safety criterion is NOT `git branch --merged` (always false for a
+# squash merge) — it's whether the local branch tip equals the merged PR's
+# `head.sha` (already parsed by merge-pr.sh into $PR_HEAD_SHA). A matching
+# tip is safe to force-delete (`-D`); a non-matching tip (unpushed local
+# work) falls back to the original `git branch -d` behaviour, which keeps the
+# branch and reports it.
+#
+# Verifies:
+#   1. Source contains the extended helper signature, the wiring outside
+#      allow_unmanaged, the disambiguated remote-branch log line, the
+#      dry-run preview line, and the --no-cleanup-worktree / preserve-env
+#      skip messages.
+#   2. Behavioral tests of the REAL `_maybe_delete_local_branch` function
+#      body (extracted verbatim from merge-pr.sh, no drift) against real git
+#      repos:
+#      (a) head-sha tip match -> `-D` (safe force-delete), branch removed.
+#      (b) head-sha tip mismatch (unpushed commit) -> kept, warned with the
+#          literal `git branch -D <branch>` escape hatch.
+#      (c) branch checked out elsewhere (current HEAD or another worktree)
+#          -> specific "checked out" message, branch preserved, never
+#          force-deleted.
+#      (d) branch is the repo's default branch -> refused up front, never
+#          even attempts a git branch -d/-D.
+#      (e) branch does not exist locally -> quiet no-op info line, not a
+#          warning.
+#      (f) no expected_head_sha supplied (the pre-#4100 --worktree-path
+#          caller shape) -> falls back to plain `-d` behaviour unchanged.
+#
+# This is the companion to test-merge-pr-worktree-path.sh (wiring/discovery)
+# and test-merge-pr-primary-worktree-guard.sh (the extract-and-eval pattern
+# this test reuses for _maybe_delete_local_branch).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+MERGE_PR="$SCRIPTS_DIR/merge-pr.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_grep() {
+    local pattern="$1" file="$2" msg="$3"
+    if grep -qE "$pattern" "$file"; then pass "$msg"; else fail "$msg (pattern: $pattern)"; fi
+}
+
+refute_grep() {
+    local pattern="$1" file="$2" msg="$3"
+    if grep -qE "$pattern" "$file"; then fail "$msg (unexpectedly matched: $pattern)"; else pass "$msg"; fi
+}
+
+[[ -x "$MERGE_PR" ]] || { echo "ERROR: $MERGE_PR not executable" >&2; exit 1; }
+
+# --- Test 1: source contains the extended wiring ---
+echo "Test 1: merge-pr.sh source contains the #4100 local-branch cleanup wiring"
+
+assert_grep "PR_HEAD_SHA=\\\$\\(echo \"\\\$PR_JSON\" \\| jq -r '\\.head\\.sha" "$MERGE_PR" \
+    "merge-pr.sh parses PR_HEAD_SHA from the PR JSON"
+assert_grep 'expected_head_sha="\$\{2:-\}"' "$MERGE_PR" \
+    "_maybe_delete_local_branch accepts an optional expected_head_sha second arg"
+assert_grep '_maybe_delete_local_branch "\$PR_BRANCH" "\$PR_HEAD_SHA"' "$MERGE_PR" \
+    "the unified branch-delete call passes PR_HEAD_SHA (reachable outside allow_unmanaged)"
+assert_grep 'delete_flag="-D"' "$MERGE_PR" \
+    "helper switches to -D (force) when the tip-match safety check passes"
+assert_grep "success \"Remote branch '\\\$PR_BRANCH' deleted\"" "$MERGE_PR" \
+    "remote-branch success line is disambiguated as 'Remote branch' (was 'Branch')"
+refute_grep "success \"Branch '\\\$PR_BRANCH' deleted\"" "$MERGE_PR" \
+    "the old ambiguous 'Branch ... deleted' (without Remote/Local) line is gone"
+assert_grep "Would delete local branch '\\\$PR_BRANCH'" "$MERGE_PR" \
+    "--dry-run previews the local branch it would delete"
+assert_grep "no-cleanup-worktree.*local branch left in place" "$MERGE_PR" \
+    "--no-cleanup-worktree emits an explicit skip message covering the local branch"
+assert_grep "LOOM_PRESERVE_WORKTREE=1.*local branch left in place" "$MERGE_PR" \
+    "LOOM_PRESERVE_WORKTREE=1 emits an explicit skip message covering the local branch"
+assert_grep "checked out \\(current HEAD or another worktree\\)" "$MERGE_PR" \
+    "checked-out refusal gets a specific message, not the generic unmerged-commits warning"
+assert_grep "it is the repository's default branch" "$MERGE_PR" \
+    "helper refuses to delete the repo's default branch"
+
+# --- Extract the ACTUAL function body from the live source (no drift) ---
+extract_fn() {
+    local name="$1" file="$2"
+    awk -v fn="$name" '
+      $0 ~ "^"fn"\\(\\) \\{" { grab=1 }
+      grab { print }
+      grab && /^}/ { exit }
+    ' "$file"
+}
+
+# Harness: stub the logging helpers, then eval the real function body.
+info()    { echo "INFO: $*"; }
+warning() { echo "WARN: $*"; }
+success() { echo "OK: $*"; }
+error()   { echo "ERROR: $*" >&2; return 1; }
+
+eval "$(extract_fn _maybe_delete_local_branch "$MERGE_PR")"
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/loom-merge-local-branch.XXXXXX")"
+TMP_ROOT="$(cd "$TMP_ROOT" && pwd -P)"
+cleanup() { rm -rf "$TMP_ROOT" 2>/dev/null || true; }
+trap cleanup EXIT
+
+REPO="$TMP_ROOT/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+git -C "$REPO" config user.email "test@example.com"
+git -C "$REPO" config user.name "Test"
+echo "hello" > "$REPO/README.md"
+git -C "$REPO" add -A
+git -C "$REPO" commit -q -m "initial"
+git -C "$REPO" branch -M main
+BASE_SHA="$(git -C "$REPO" rev-parse HEAD)"
+
+# shellcheck disable=SC2034
+REPO_ROOT="$REPO"
+# shellcheck disable=SC2034
+DEFAULT_BRANCH_NAME="main"
+
+echo ""
+echo "Test 2: behavioral tests of the real _maybe_delete_local_branch body"
+
+# --- (a) tip matches expected_head_sha -> safe force-delete (-D) ---
+git -C "$REPO" checkout -q -b feature/issue-100
+echo "change" >> "$REPO/README.md"
+git -C "$REPO" commit -q -am "issue 100 work"
+MATCH_SHA="$(git -C "$REPO" rev-parse feature/issue-100)"
+git -C "$REPO" checkout -q main
+
+out_a="$(_maybe_delete_local_branch "feature/issue-100" "$MATCH_SHA" 2>&1)"
+if [[ "$out_a" == *"OK: Local branch 'feature/issue-100' deleted"* ]] \
+   && [[ "$out_a" == *"safe force-delete"* ]] \
+   && ! git -C "$REPO" show-ref --verify --quiet refs/heads/feature/issue-100; then
+    pass "(a) tip matching the merged PR head SHA force-deletes the branch"
+else
+    fail "(a) expected safe force-delete; got: $out_a"
+fi
+
+# --- (b) tip does NOT match expected_head_sha (unpushed extra commit) -> kept ---
+git -C "$REPO" checkout -q -b feature/issue-200
+echo "change" >> "$REPO/README.md"
+git -C "$REPO" commit -q -am "merged part"
+MERGED_SHA="$(git -C "$REPO" rev-parse feature/issue-200)"
+echo "more" >> "$REPO/README.md"
+git -C "$REPO" commit -q -am "extra unpushed work"
+git -C "$REPO" checkout -q main
+
+out_b="$(_maybe_delete_local_branch "feature/issue-200" "$MERGED_SHA" 2>&1)"
+if [[ "$out_b" == *"WARN:"* ]] \
+   && [[ "$out_b" == *"git branch -D feature/issue-200"* ]] \
+   && git -C "$REPO" show-ref --verify --quiet refs/heads/feature/issue-200; then
+    pass "(b) tip mismatch keeps the branch and reports the -D escape hatch"
+else
+    fail "(b) expected kept-and-warned with -D escape hatch; got: $out_b"
+fi
+git -C "$REPO" branch -D feature/issue-200 >/dev/null 2>&1 || true
+
+# --- (c) branch checked out in another worktree -> specific message, kept ---
+git -C "$REPO" branch feature/issue-300
+WT2="$TMP_ROOT/wt2"
+git -C "$REPO" worktree add -q "$WT2" feature/issue-300 >/dev/null 2>&1
+
+out_c="$(_maybe_delete_local_branch "feature/issue-300" "" 2>&1)"
+if [[ "$out_c" == *"WARN:"* ]] \
+   && [[ "$out_c" == *"checked out (current HEAD or another worktree)"* ]] \
+   && git -C "$REPO" show-ref --verify --quiet refs/heads/feature/issue-300; then
+    pass "(c) branch checked out in another worktree gets the specific checked-out message"
+else
+    fail "(c) expected checked-out-specific warning; got: $out_c"
+fi
+git -C "$REPO" worktree remove "$WT2" --force >/dev/null 2>&1 || true
+git -C "$REPO" branch -D feature/issue-300 >/dev/null 2>&1 || true
+
+# --- (c2) branch IS the current HEAD (primary checkout) -> also refused ---
+git -C "$REPO" checkout -q -b feature/issue-301
+out_c2="$(_maybe_delete_local_branch "feature/issue-301" "" 2>&1)"
+if [[ "$out_c2" == *"checked out (current HEAD or another worktree)"* ]] \
+   && git -C "$REPO" show-ref --verify --quiet refs/heads/feature/issue-301; then
+    pass "(c2) branch that is the current HEAD is never deleted"
+else
+    fail "(c2) expected current-HEAD refusal; got: $out_c2"
+fi
+git -C "$REPO" checkout -q main
+git -C "$REPO" branch -D feature/issue-301 >/dev/null 2>&1 || true
+
+# --- (d) default branch is never a delete target ---
+out_d="$(_maybe_delete_local_branch "main" "$BASE_SHA" 2>&1)"
+if [[ "$out_d" == *"WARN:"* ]] \
+   && [[ "$out_d" == *"it is the repository's default branch"* ]] \
+   && git -C "$REPO" show-ref --verify --quiet refs/heads/main; then
+    pass "(d) refuses to delete the repo's default branch, even with a matching tip"
+else
+    fail "(d) expected default-branch refusal; got: $out_d"
+fi
+
+# --- (e) branch does not exist locally -> quiet info no-op ---
+out_e="$(_maybe_delete_local_branch "feature/issue-999-does-not-exist" "deadbeef" 2>&1)"
+if [[ "$out_e" == *"INFO:"* ]] \
+   && [[ "$out_e" == *"does not exist"* ]] \
+   && [[ "$out_e" != *"WARN:"* ]]; then
+    pass "(e) nonexistent local branch is a quiet info no-op, not a warning"
+else
+    fail "(e) expected quiet info no-op; got: $out_e"
+fi
+
+# --- (f) no expected_head_sha (pre-#4100 caller shape) -> plain -d behaviour ---
+git -C "$REPO" checkout -q -b feature/issue-400
+echo "clean work" >> "$REPO/README.md"
+git -C "$REPO" commit -q -am "clean, mergeable"
+git -C "$REPO" checkout -q main
+git -C "$REPO" merge -q --no-ff feature/issue-400 -m "merge for -d test"
+
+out_f="$(_maybe_delete_local_branch "feature/issue-400" 2>&1)"
+if [[ "$out_f" == *"OK: Local branch 'feature/issue-400' deleted"* ]] \
+   && [[ "$out_f" != *"safe force-delete"* ]] \
+   && ! git -C "$REPO" show-ref --verify --quiet refs/heads/feature/issue-400; then
+    pass "(f) omitting expected_head_sha preserves the original plain -d behaviour"
+else
+    fail "(f) expected plain -d delete with no safety-note; got: $out_f"
+fi
+
+# --- Summary ---
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+[[ $TESTS_FAILED -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

- `merge-pr.sh` cleaned up the remote branch and the worktree on a merged PR but left the local `feature/issue-N` branch behind on every path except the explicit `--worktree-path` override, so every merged issue leaked one local branch — invisible to `git branch --merged` after a squash merge (the branch is never an ancestor of `main`), showing as `[gone]` once `git fetch --prune` runs.
- Wires local-branch deletion into the default `.loom/worktrees/issue-N` path, the discovered-Loom-managed-non-standard-path case, and the no-worktree-at-all case — the three rows the pre-existing `_maybe_delete_local_branch` helper never reached.
- Adds a head-SHA safety criterion so the delete is correct under squash merges: the local branch tip is compared to the merged PR's `head.sha` (already parsed by the script). A matching tip is safe to `git branch -D`; a mismatched tip (unpushed local work) falls back to `git branch -d`, which keeps the branch and reports it.

## Changes

- `defaults/scripts/merge-pr.sh`:
  - Parses `PR_HEAD_SHA` from the PR JSON and resolves `DEFAULT_BRANCH_NAME` via `lib/default-branch.sh`.
  - Extends `_maybe_delete_local_branch(branch, [expected_head_sha])`: never targets the repo's default branch; uses `-D` only when the local tip matches `expected_head_sha`, otherwise falls back to `-d`; distinguishes a "checked out elsewhere" refusal (current HEAD or another worktree) from a generic "not fully merged" refusal with a specific message; the pre-existing `--worktree-path` caller is unchanged (still calls with no SHA, so its behavior is byte-for-byte preserved).
  - Wires a single unified `_maybe_delete_local_branch "$PR_BRANCH" "$PR_HEAD_SHA"` call after the worktree-cleanup dispatch resolves, inside the `CLEANUP_WORKTREE` guard, so it covers the default path, the discovery path, and the no-worktree case without running under `--no-cleanup-worktree` / `LOOM_PRESERVE_WORKTREE=1`.
  - Disambiguates the remote-branch log line (`"Branch 'X' deleted"` → `"Remote branch 'X' deleted"`), and adds explicit skip messages naming the local branch for both `--no-cleanup-worktree` and `LOOM_PRESERVE_WORKTREE=1`.
  - Previews the local-branch delete under `--dry-run` without mutating anything.
  - Updates the header comment block and `--help` text to describe the new default (local branch deletion is no longer `--worktree-path`-only).
- `defaults/scripts/tests/test-merge-pr-local-branch-cleanup.sh` (new): static source assertions for the wiring/log-line/dry-run/skip-message surface, plus behavioral tests of the real `_maybe_delete_local_branch` function body (extracted verbatim, same pattern as `test-merge-pr-primary-worktree-guard.sh`) against real git repos — tip-match force-delete, tip-mismatch keep-and-warn, checked-out-elsewhere refusal (both "another worktree" and "current HEAD"), default-branch refusal, nonexistent-branch no-op, and the no-SHA fallback preserving pre-#4100 behavior.
- `.loom/docs/troubleshooting.md` (via its `defaults/docs/troubleshooting.md` symlink target) — one-paragraph backlog remedy (`git fetch --prune` + `loom-clean --force`) pointing at the existing `clean_branches()` two-pass cleanup in `loom_tools/clean.py`, so pre-#4100 `[gone]` branches are reaped without new tooling.

## Acceptance Criteria Verification

- [x] After a successful `merge-pr.sh <N>`, the local branch is deleted when safe — verified via `--dry-run` against a real open PR (`feature/issue-4046` correctly identified for deletion) and behavioral test (a).
- [x] Safety uses the head-SHA tip comparison, not `git branch --merged` — test (a)/(b)/(f) exercise the tip-match vs. tip-mismatch branches directly.
- [x] A branch failing the safety check is kept and reported, never force-deleted unless the merged-PR check passed — test (b) verifies the branch survives with the `git branch -D <branch>` escape hatch in the warning.
- [x] The branch currently checked out is never deleted — tests (c) and (c2) cover "checked out in another worktree" and "is the current HEAD".
- [x] Log lines distinguish remote vs. local branch deletion — "Branch ... deleted" → "Remote branch ... deleted" / "Local branch ... deleted"; static assertion + the old ambiguous line is asserted gone.
- [x] Backlog remedy — documented in `.loom/docs/troubleshooting.md` (`git fetch --prune` + `loom-clean --force`, pointing at the existing `clean_branches()`).

## Test Plan

- [x] `bash defaults/scripts/tests/test-merge-pr-local-branch-cleanup.sh` — 18/18 pass (new).
- [x] `bash defaults/scripts/tests/test-merge-pr-help.sh` — 15/15 pass (regression).
- [x] `bash defaults/scripts/tests/test-merge-pr-worktree-path.sh` — 21/21 pass (regression).
- [x] All other `defaults/scripts/tests/test-merge-pr-*.sh` files — pass (auto-merge-disabled-fallback 30/30, auto-reconcile 20/20, merge-ordering-guard 25/25, partial-increment 19/19, primary-worktree-guard 14/14, unstable-fallback 68/68, worktree-awk 11/11).
- [x] `./.loom/scripts/merge-pr.sh <open-PR> --dry-run` against a real open PR: correctly previews `Would delete local branch 'feature/issue-4046'` and mutates nothing.
- [x] `./.loom/scripts/merge-pr.sh <open-PR> --dry-run --no-cleanup-worktree`: correctly previews "would leave local worktree and local branch ... in place" and mutates nothing.
- [x] `shellcheck --severity=warning` clean on `merge-pr.sh` and the new test file; full-repo `find defaults/scripts -name '*.sh' | xargs shellcheck` (matches the CI job) exits 0.
- [x] `check-phantom-labels.sh` / `check-labels-drift.sh` — unaffected, still pass.
- [x] `./.loom/scripts/check-main-clean.sh` — main worktree unaffected.

Note: the load-bearing manual verification from the issue ("merge a real PR, `git fetch --prune`, `git branch -vv` shows the branch absent") requires merging a live PR through this exact script and is covered by the automated tip-match test (a), which exercises the identical code path against a synthetic squash-merge-shaped repo (branch tip == merged head SHA, no ancestor relationship required).

Closes #4100