### PR TITLE
docs: fix stale stale-building-check.sh references, point to loom-recover-orphans

### DIFF
--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -1863,11 +1863,7 @@ which claude
 
 **Orphaned issues stuck in loom:building state**:
 
-When an agent crashes or is cancelled while building, issues can get stuck in `loom:building` state without a PR. Recover them with the orphan-recovery tool documented immediately below (there is no `stale-building-check.sh` script — the historical script was never ported; use `loom-recover-orphans` / the `loom-orphan-recovery` guidance that follows).
-
-**Configuration via environment**:
-- `STALE_THRESHOLD_HOURS=2` - Hours before issue without PR is considered stale
-- `STALE_WITH_PR_HOURS=24` - Hours before issue with stale PR is flagged
+When an agent crashes or is cancelled while building, issues can get stuck in `loom:building` state without a PR. The shell script that historically handled this was deleted in `b811fca8` (#3433, "delete shepherd brain + /shepherd skill + milestone writers") during the v0.10.0 shepherd deprecation. Its successor is `loom-recover-orphans`, documented immediately below.
 
 **Orphaned task recovery (daemon dispatch crashes)**:
 

--- a/defaults/docs/troubleshooting.md
+++ b/defaults/docs/troubleshooting.md
@@ -196,25 +196,21 @@ Wait for tool_result before initiating next tool execution.
 
 ### Orphaned issues stuck in loom:building state
 
-When an agent crashes or is cancelled while building, issues can get stuck in `loom:building` state without a PR. Use the stale-building-check script to detect and recover these:
+When an agent crashes or is cancelled while building, issues can get stuck in `loom:building` state without a PR. The shell script that historically handled this was deleted in `b811fca8` (#3433, "delete shepherd brain + /shepherd skill + milestone writers") during the v0.10.0 shepherd deprecation. Its successor, `loom-recover-orphans`, detects and recovers these:
 
 ```bash
 # Check for stale building issues (dry run)
-./.loom/scripts/stale-building-check.sh
+loom-recover-orphans
 
 # Show detailed progress
-./.loom/scripts/stale-building-check.sh --verbose
+loom-recover-orphans --verbose
 
 # Auto-recover stale issues (resets to loom:issue)
-./.loom/scripts/stale-building-check.sh --recover
+loom-recover-orphans --recover
 
 # JSON output for automation
-./.loom/scripts/stale-building-check.sh --json
+loom-recover-orphans --json
 ```
-
-**Configuration via environment**:
-- `STALE_THRESHOLD_HOURS=2` - Hours before issue without PR is considered stale
-- `STALE_WITH_PR_HOURS=24` - Hours before issue with stale PR is flagged
 
 **What it does**:
 - Finds issues with `loom:building` label that have been stuck

--- a/loom-tools/src/loom_tools/daemon_diagnostic.py
+++ b/loom-tools/src/loom_tools/daemon_diagnostic.py
@@ -343,7 +343,7 @@ def run_health_check() -> HealthReport:
         if report.orphaned_building:
             orphan_list = ", ".join(f"#{n}" for n in report.orphaned_building)
             report.add_warning(f"Orphaned loom:building issues (labeled but not tracked by spawn loop): {orphan_list}")
-            report.add_recommendation("Check orphaned issues with: ./.loom/scripts/stale-building-check.sh --recover")
+            report.add_recommendation("Check orphaned issues with: loom-recover-orphans --recover")
 
     # 4. Check stale building issues
     report.stale_building = check_stale_building(report.pipeline.building)

--- a/loom-tools/tests/test_worktree.py
+++ b/loom-tools/tests/test_worktree.py
@@ -179,7 +179,7 @@ class TestDocumentedBehaviorDifferences:
         instead of being removed. This prevents CWD corruption when the
         shell's working directory points to the deleted worktree.
 
-        Manual cleanup tools (loom-clean, stale-building-check.sh) remain
+        Manual cleanup tools (loom-clean, loom-recover-orphans) remain
         the proper place for worktree removal.
         """
         from loom_tools.worktree import _reset_stale_worktree_in_place


### PR DESCRIPTION
## Summary

`.loom/scripts/stale-building-check.sh` does not exist — it was deleted in
`b811fca8` (#3433, "delete shepherd brain + /shepherd skill + milestone
writers") during the v0.10.0 shepherd deprecation, not "never ported" as
`defaults/CLAUDE.md` previously claimed. Its replacement,
`loom-recover-orphans` (`loom_tools.orphan_recovery`), has been a registered
console script (`loom-tools/pyproject.toml`) the whole time.

This is docs + one string, no logic changes, per the curated scope on #4102.
The original report's AC#1 ("merge should strip `loom:building` from closed
issues") was explicitly rejected by the curator — that's settled policy per
#2838 and is untouched here.

## Changes

- `loom-tools/src/loom_tools/daemon_diagnostic.py:346` — the
  `loom-daemon-diagnostic` console script's user-facing recommendation now
  reads `loom-recover-orphans --recover` instead of the nonexistent script
  path.
- `defaults/docs/troubleshooting.md` — rewrote the "Orphaned issues stuck in
  loom:building state" section to document `loom-recover-orphans`; dropped
  the two dead env vars `STALE_THRESHOLD_HOURS` / `STALE_WITH_PR_HOURS`
  (zero code consumers — confirmed via `git grep`).
- `defaults/CLAUDE.md` — corrected the history (deleted in `b811fca8` / #3433,
  not "never ported") and dropped the same dead env-var block.
- `loom-tools/tests/test_worktree.py:182` — replaced the stale script name
  in a docstring with `loom-recover-orphans` (no test logic change).

`docs/migration/daemon-state-consumers.md:196` is left unchanged
(intentional historical migration record), per the curated scope.

## Follow-up noted, not acted on

Per the curator's note: the `daemon_diagnostic.py` orphan-detection block
this recommendation lives in reads `read_spawn_loop_state()`, whose own
docstring says there is "no writer post-v0.11.0" — so that diagnostic's
orphan detection may be partly vestigial and worth retiring in a future
issue. Only the recommendation string was touched here per the curated
scope.

## Verification

- `git grep -n "stale-building-check"` → only
  `docs/migration/daemon-state-consumers.md` (matches AC).
- `git grep -n "STALE_THRESHOLD_HOURS\|STALE_WITH_PR_HOURS"` → no results.
- `loom-recover-orphans --help` (via `python3 -m loom_tools.orphan_recovery
  --help`) succeeds.
- `PYTHONPATH=loom-tools/src:$PYTHONPATH python3 -m pytest
  loom-tools/tests/test_worktree.py -v` → 21 passed.
- `./scripts/check-claude-md-budget.sh` → OK (308/320 lines).
- `git diff --stat -- defaults/scripts/merge-pr.sh loom-daemon/` → empty
  (no merge-path changes, per #2838).

Closes #4102