### PR TITLE
fix(daemon): embed --depends-on in the -p prompt, not as a sibling argv token

### DIFF
--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -1596,11 +1596,13 @@ impl SweepRegistry {
     /// effort is preserved end-to-end.
     ///
     /// `depends_on` (issue #3729, stacked-PR v1): when `Some(N)`, the spawned
-    /// child receives `--depends-on <N>` appended to the argv (immediately
-    /// after any `--model` / `--effort`), instructing `/loom:sweep` to branch
-    /// its worktree/PR off `feature/issue-<N>`. When `None`, no
-    /// `--depends-on` flag is emitted — byte-for-byte unchanged behavior. A
-    /// single optional parent (not a list) makes diamonds unrepresentable.
+    /// child receives `--depends-on <N>` embedded in the `-p` prompt string
+    /// (immediately after `--claim-owned`; issue #4121 — NOT a sibling argv
+    /// token, since `--depends-on` is not a real `claude` CLI flag),
+    /// instructing `/loom:sweep` to branch its worktree/PR off
+    /// `feature/issue-<N>`. When `None`, no `--depends-on` text is emitted —
+    /// byte-for-byte unchanged behavior. A single optional parent (not a
+    /// list) makes diamonds unrepresentable.
     pub fn dispatch(
         &mut self,
         kind: &SweepKind,
@@ -2704,7 +2706,18 @@ impl SweepRegistry {
         // pre-flight. The env var (`LOOM_SWEEP_CLAIM_OWNED`, set below) is kept
         // unchanged for backward compatibility (#3823/#3967). Unconditional on
         // every daemon dispatch — every dispatch claims exactly one issue.
-        let prompt = format!("/loom:sweep {issue} --claim-owned {issue}");
+        let mut prompt = format!("/loom:sweep {issue} --claim-owned {issue}");
+        // Stacked-PR dependency (issue #3729, v1; sibling-arg bug fixed in
+        // #4121): when a parent issue is declared, fold `--depends-on <N>`
+        // INTO the same `-p` prompt string as `--claim-owned` above, for the
+        // identical reason — `--depends-on` is not a `claude` CLI flag
+        // either, so a sibling `cmd.arg()` token makes `claude` exit 1
+        // (`error: unknown option '--depends-on'`) before any session
+        // starts. Absent the param, no text is appended (byte-for-byte
+        // unchanged). Mirrors the `--claim-owned` append-only contract.
+        if let Some(parent) = depends_on {
+            prompt.push_str(&format!(" --depends-on {parent}"));
+        }
         let mut cmd = Command::new(&spawn_bin);
         cmd.arg("-p").arg(&prompt);
         // Model selection (issue #3477, Phase 1): the dispatch-param tier of
@@ -2726,16 +2739,9 @@ impl SweepRegistry {
                 cmd.arg("--effort").arg(e);
             }
         }
-        // Stacked-PR dependency (issue #3729, v1): when a parent issue is
-        // declared, append `--depends-on <N>` so `/loom:sweep` branches the
-        // child worktree/PR off `feature/issue-<N>` instead of the default
-        // branch. Absent the param, no flag is emitted (byte-for-byte
-        // unchanged). Mirrors the `--model` / `--effort` append-only contract.
-        if let Some(parent) = depends_on {
-            cmd.arg("--depends-on").arg(parent.to_string());
-        }
-        // (Daemon self-claim marker `--claim-owned <N>` is embedded in the
-        // `-p` prompt text above, not appended as a sibling arg — see #4111.)
+        // (Daemon self-claim marker `--claim-owned <N>` and the stacked-PR
+        // `--depends-on <N>` marker are both embedded in the `-p` prompt text
+        // above, not appended as sibling args — see #4111 / #4121.)
         // Unattended-permissions flag (issue #3824): a daemon-dispatched child
         // is a detached, non-interactive `claude -p` process — there is no
         // human to answer a permission prompt, so any tool call needing
@@ -2747,8 +2753,8 @@ impl SweepRegistry {
         // `claude -p "/<role>" --dangerously-skip-permissions`). Scoped to this
         // daemon-only dispatch path; `spawn-claude.sh` stays a generic
         // pass-through and never adds a permission flag of its own. Appended
-        // AFTER `--model`/`--effort`/`--depends-on` (and the prompt-embedded
-        // `--claim-owned`) so the positional argv contract is unchanged.
+        // AFTER `--model`/`--effort` (and the prompt-embedded `--claim-owned`
+        // / `--depends-on`) so the positional argv contract is unchanged.
         cmd.arg("--dangerously-skip-permissions");
         cmd.env("LOOM_TERMINAL_ID", format!("daemon-{sweep_id}"))
             // Claim-ownership marker (issue #3823): `dispatch()` flips
@@ -5942,6 +5948,26 @@ exit 0
         assert!(
             recorded.contains("argv: -p /loom:sweep 50 --claim-owned 50 --depends-on 49"),
             "expected --depends-on in argv; got: {recorded}"
+        );
+        // Regression for #4121 (mirrors the #4120 `--claim-owned` review): the
+        // flattened `argv:` assertion above renders byte-identically whether
+        // `--depends-on 49` is embedded in the single `-p` prompt token or
+        // appended as its own sibling argv token — so it cannot distinguish
+        // the fixed and buggy forms. The real `claude` CLI rejects
+        // `--depends-on` as an unknown option if it ever arrives as a
+        // standalone token; only text inside the `-p "<prompt>"` value
+        // reaches the `/loom:sweep` skill's `$ARGUMENTS`. Use the per-token
+        // `arg: ` fixture lines (as `dispatch_appends_claim_owned_flag` does)
+        // to assert the flag is part of the prompt VALUE and NOT a
+        // standalone token.
+        assert!(
+            recorded.contains("arg: /loom:sweep 50 --claim-owned 50 --depends-on 49"),
+            "expected --depends-on inside the single -p prompt token; got: {recorded}"
+        );
+        assert!(
+            !recorded.contains("arg: --depends-on"),
+            "--depends-on must NOT be a standalone argv token (the real claude CLI \
+             rejects it as an unknown option); got: {recorded}"
         );
         assert_eq!(
             registry.get(&outcome.sweep_id).unwrap().depends_on,


### PR DESCRIPTION
## Summary
`SweepRegistry::spawn_child` (`loom-daemon/src/sweep_registry.rs`) appended `--depends-on <parent>` as a separate `cmd.arg()` sibling token after `-p "<prompt>"` when dispatching a stacked-PR child `claude` process. The real `claude` CLI does not recognize `--depends-on` as a flag — it's meant to be parsed by the `/loom:sweep` skill's own `$ARGUMENTS` handling from inside the prompt text — so the child process immediately exited 1 with `error: unknown option '--depends-on'`. This is the same class of bug PR #4120 already fixed for `--claim-owned`, but `--depends-on` was left untouched.

## Changes
- Build the full `-p` prompt string BEFORE calling `cmd.arg("-p")`, appending `--depends-on <parent>` to that prompt string when `depends_on` is `Some`, instead of appending it as a separate sibling argv token afterward — mirroring the existing `--claim-owned` fix pattern.
- Removed the now-dead sibling-arg append site and its stale comment; consolidated the "embedded in the prompt, not sibling args" note to cover both `--claim-owned` and `--depends-on`.
- Updated the stale doc comment on `dispatch()` that claimed `--depends-on` is "appended to the argv (immediately after any `--model` / `--effort`)" to reflect that it is now embedded in the `-p` prompt string, immediately after `--claim-owned`.
- Updated the `--dangerously-skip-permissions` ordering comment (no longer lists `--depends-on` among the sibling-arg flags it follows).
- Did **not** touch `--model` / `--effort` / `--dangerously-skip-permissions` (real `claude` CLI flags, correctly siblings) or `role_runner.rs` / `epic_supervisor.rs` (only pass real CLI flags) or `main.rs`'s own `loom-daemon dispatch --depends-on` clap CLI (the daemon's own CLI, unaffected).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--depends-on <parent>` is embedded in the `-p` prompt string, not a sibling argv token | ✅ | `cargo test dispatch_with_depends_on_appends_depends_on_arg` passes; new `arg: /loom:sweep 50 --claim-owned 50 --depends-on 49` assertion (single token) and `!recorded.contains("arg: --depends-on")` (no standalone token) both pass |
| Existing test hardened so it actually detects the bug | ✅ | Added per-token `arg:` assertions to `dispatch_with_depends_on_appends_depends_on_arg`; confirmed they **fail** against unfixed `main` (`error: unknown option` reproduced via the sibling-token assertion failing) before applying the fix, then confirmed they pass after |
| `dispatch_without_depends_on_emits_no_flag` stays green (no `--depends-on` when `depends_on` is `None`) | ✅ | `cargo test dispatch_without_depends_on_emits_no_flag` passes |
| `dispatch_appends_dangerously_skip_permissions` / `dispatch_appends_claim_owned_flag` stay green | ✅ | Both pass unchanged |
| Stale doc comment updated | ✅ | `dispatch()` doc comment and the `--dangerously-skip-permissions` ordering comment both updated |
| Scope: single-site fix in `sweep_registry.rs` | ✅ | `git diff --stat`: 1 file changed, 44 insertions(+), 18 deletions(-) |

## Test Plan
- `cargo test --lib` in `loom-daemon/`: 1319 passed, 0 failed.
- `cargo test --test integration_basic`: 9 pre-existing failures (`Daemon failed to create socket within 5s`), confirmed identical on unmodified code via `git stash` — unrelated to this change (daemon-startup socket integration tests, not `sweep_registry.rs`).
- `cargo fmt -- --check`: clean.
- `cargo clippy --lib -- -D warnings`: clean.
- Manually confirmed the regression guard is real: reverted the fix locally and re-ran `dispatch_with_depends_on_appends_depends_on_arg` — it failed with `expected --depends-on inside the single -p prompt token; got: ... arg: --depends-on / arg: 49 ...`, proving the new assertions actually catch the bug the old flattened-`argv:` assertion missed.

Closes #4121