### PR TITLE
fix(daemon): guard dispatch against issues with an open linked PR (#4123)

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1682,14 +1682,34 @@ per-tick summary line as the trailing `N cross-host-collision(s)` field, e.g.:
 
 ```
 work_finder: tick — cap 3 (...); 5 seen, 2 dispatched, 1 labeled-skip,
-0 in-flight-skip, 0 quarantine-skip, 0 deferred, 0 error(s), 3 cross-host-collision(s)
+0 in-flight-skip, 0 quarantine-skip, 0 pr-open-skip, 0 deferred, 0 error(s), 3 cross-host-collision(s)
 ```
 
 Unlike the other (per-tick) counters, this one is a **monotonic cumulative
 total** read from the dispatcher(s) at tick end (summed across workspaces in the
 multi-repo tick), so successive lines show the baseline accumulate. It is `0`
 whenever detection is disabled. The existing fields (`labeled-skip` /
-`in-flight-skip` / `quarantine-skip` …) keep their names and semantics unchanged.
+`in-flight-skip` / `quarantine-skip` / `pr-open-skip` …) keep their names and
+semantics unchanged.
+
+**`pr-open-skip` (open-PR dispatch guard, #4123).** A per-tick counter (like the
+other `*-skip` fields, not cumulative) for issues the finder declined to dispatch
+because they **already have an open linked PR**. The guard lives in
+`SweepRegistry::dispatch()` (step 2.6, right after the #4088 closed-issue guard),
+so it covers *every* dispatch caller — the work finder, the epic supervisor, the
+IPC/CLI `dispatch_sweep`, and all three watchdogs — with one forge check. Every
+in-memory dedup signal (idempotency key, in-flight set, `loom:building` label)
+dies with the parent sweep, so without this guard an issue whose approved PR is
+still open would be re-dispatched the moment its sweep exits, redoing finished
+work against the token pool. `dispatch()` refuses these with a typed
+`OpenPrDispatchError`; the finder attributes that refusal to `pr-open-skip`
+(never to `error(s)`), and a tick whose only outcome is a `pr-open-skip` **still
+logs** its summary line (the counter is part of the log gate). The guard keys on
+PR *openness* only — never on review labels — and is **fail-open**: any forge
+error, timeout, or unparseable output lets dispatch proceed, so a `gh` outage can
+never wedge the daemon. It is GitHub-only (uses the `closedByPullRequestsReferences`
+closes-graph, filtered to `state == "OPEN"`); a Gitea workspace fails open and
+keeps today's behavior.
 
 **Cost / default.** Enabling detection adds exactly one `gh issue view --json
 labels` round-trip per dispatch (measured ~0.4s against GitHub), bounded by the

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -119,6 +119,44 @@ pub const TERMINAL_RETENTION_SECS: i64 = 3600;
 /// `dispatch_sweep` `model` param.
 pub const DEFAULT_DISPATCH_MODEL: &str = "sonnet";
 
+/// Typed, matchable error returned by [`SweepRegistry::dispatch`] when the
+/// open-PR guard (Issue #4123, step 2.6) refuses a dispatch because the target
+/// issue already has an **open** linked pull request.
+///
+/// Every in-memory dedup signal (idempotency key, in-flight set, the
+/// `loom:building` label) clears when the parent sweep exits, so an issue whose
+/// approved PR is still open looks identical to fresh work the moment its sweep
+/// dies — and the work-finder re-dispatches it, redoing finished work against a
+/// scarce token pool. The forge's closes-graph is the one durable signal that
+/// survives process death and daemon restarts, so this guard consults it.
+///
+/// This is a **distinct, downcast-matchable** type (not a string-matched
+/// `anyhow` message) so the work-finder can attribute the refusal to its own
+/// `pr-open-skip` counter rather than a generic dispatch failure. It is created
+/// via `.into()` so `anyhow::Error` preserves the concrete type for
+/// `downcast_ref::<OpenPrDispatchError>()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OpenPrDispatchError {
+    /// The issue whose dispatch was refused.
+    pub issue: u32,
+    /// The open linked PR that triggered the refusal.
+    pub pr: u32,
+}
+
+impl std::fmt::Display for OpenPrDispatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "refusing to dispatch issue #{}: it already has an open linked PR #{} \
+             (#4123 open-PR guard). A fresh issue sweep would duplicate work already \
+             in review.",
+            self.issue, self.pr
+        )
+    }
+}
+
+impl std::error::Error for OpenPrDispatchError {}
+
 /// Issue #3944: which tier of the dispatch-model precedence chain supplied the
 /// resolved model. Surfaced in the daemon dispatch log line so an operator can
 /// tell *why* a child is running a given model.
@@ -1680,6 +1718,37 @@ impl SweepRegistry {
             ));
         }
 
+        // 2.6 Open-PR guard (Issue #4123). Every in-memory dedup signal — the
+        //     idempotency key, the in-flight set, the `loom:building` label —
+        //     is scoped to the running sweep's lifetime and clears when the
+        //     parent exits (`reconstruct()` even drops the idempotency key on a
+        //     daemon restart). So an issue whose approved PR is still open looks
+        //     identical to fresh work the moment its sweep dies, and every
+        //     caller that routes through `dispatch()` — the work-finder, the
+        //     epic supervisor, the IPC/CLI dispatch, and all three watchdogs
+        //     (startup #3887, mid-build-death #3895, review-stall #3910) — would
+        //     re-dispatch it, redoing finished work against a scarce token pool.
+        //     The forge's closes-graph is the one durable signal that survives
+        //     process death and restarts, so this guard consults it, right after
+        //     the closed-issue guard and before the lock/label flip so a single
+        //     check covers all six call sites. Keys on PR *openness* only, never
+        //     on review labels — driving an open PR forward is the
+        //     Judge/Champion/Doctor path's job, not the issue work-finder's.
+        //     Best-effort and fail-open: any forge error/timeout/unparseable
+        //     output returns `None` and dispatch proceeds, so a `gh` outage (or
+        //     a Gitea workspace — this is GitHub-only, like `issue_is_closed`)
+        //     can never wedge the daemon. Skipped when label flips are disabled
+        //     (test fixtures without `gh` credentials), mirroring 2.5.
+        if !self.config.skip_label_flip {
+            if let Some(pr) = self.first_open_linked_pr(issue_number) {
+                return Err(OpenPrDispatchError {
+                    issue: issue_number,
+                    pr,
+                }
+                .into());
+            }
+        }
+
         // 3. Acquire the claim lock atomically.
         let sweep_id = generate_sweep_id(kind);
         self.acquire_lock(issue_number, &sweep_id)?;
@@ -2070,6 +2139,107 @@ impl SweepRegistry {
             "OPEN" => Some(false),
             _ => None,
         }
+    }
+
+    /// Best-effort probe for an **open** pull request linked to `issue` via
+    /// GitHub's authoritative closes-graph (`closedByPullRequestsReferences`),
+    /// used by the #4123 open-PR dispatch guard. Returns `Some(pr_number)` when
+    /// at least one *open* linked PR exists, and `None` otherwise — where `None`
+    /// covers BOTH "no open PR" and any failure (missing/failed/timed-out `gh`,
+    /// unresolvable repo, unparseable output).
+    ///
+    /// Callers MUST treat `None` as **fail-open** — a forge outage or a wedged
+    /// `gh` must never wedge dispatch. This mirrors [`issue_is_closed`]'s `None`
+    /// contract and is bounded by [`reap_gh_timeout`] exactly like the label
+    /// flips so it cannot block the dispatch path.
+    ///
+    /// Filtering is on the node `state == "OPEN"` in the `--jq`, NOT on the
+    /// GraphQL `includeClosedPrs:false` flag alone: live testing showed a
+    /// *merged* PR still returns from the closes-graph even with
+    /// `includeClosedPrs:false` (it comes back with `state: MERGED`), so relying
+    /// on the flag would false-positive forever on every issue whose PR ever
+    /// merged. The `state == "OPEN"` filter is the load-bearing one; the flag is
+    /// kept only to trim the payload. This uses the forge's closes-link graph,
+    /// not `Closes #N` body-parsing. GitHub-only, like the helper above it.
+    fn first_open_linked_pr(&self, issue: u32) -> Option<u32> {
+        let (owner, repo) = self.resolve_owner_repo()?;
+        let gh = self
+            .config
+            .gh_bin
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("gh"));
+        let query = "query($owner:String!,$repo:String!,$num:Int!){\
+             repository(owner:$owner,name:$repo){\
+             issue(number:$num){\
+             closedByPullRequestsReferences(first:20,includeClosedPrs:false){\
+             nodes{ number state } } } } }";
+        let mut cmd = Command::new(&gh);
+        cmd.arg("api")
+            .arg("graphql")
+            .arg("-f")
+            .arg(format!("query={query}"))
+            .arg("-F")
+            .arg(format!("owner={owner}"))
+            .arg("-F")
+            .arg(format!("repo={repo}"))
+            .arg("-F")
+            .arg(format!("num={issue}"))
+            .arg("--jq")
+            .arg(
+                ".data.repository.issue.closedByPullRequestsReferences.nodes[] \
+                 | select(.state == \"OPEN\") | .number",
+            );
+        // Resolve against this registry's own workspace, matching the label-flip
+        // helpers and `issue_is_closed` (#3937).
+        cmd.current_dir(&self.config.workspace_root);
+        let output = output_with_timeout(cmd, reap_gh_timeout()).ok()??;
+        if !output.status.success() {
+            return None;
+        }
+        // The `--jq` emits one open PR number per line; take the first.
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .find_map(|l| l.trim().parse::<u32>().ok())
+    }
+
+    /// Resolve `(owner, repo)` for the registry's workspace, needed because
+    /// `gh api graphql` (unlike `gh issue view`) cannot infer the repo from the
+    /// working directory. Prefers the process-global `LOOM_REPO` override
+    /// (`owner/repo`) when set, else asks `gh repo view` in the workspace root.
+    /// Returns `None` on any failure so the open-PR guard fails open.
+    fn resolve_owner_repo(&self) -> Option<(String, String)> {
+        if let Ok(repo) = std::env::var("LOOM_REPO") {
+            if let Some((o, r)) = repo.split_once('/') {
+                if !o.is_empty() && !r.is_empty() {
+                    return Some((o.to_string(), r.to_string()));
+                }
+            }
+        }
+        let gh = self
+            .config
+            .gh_bin
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("gh"));
+        let mut cmd = Command::new(&gh);
+        cmd.arg("repo")
+            .arg("view")
+            .arg("--json")
+            .arg("owner,name")
+            .arg("--jq")
+            .arg(".owner.login + \"/\" + .name");
+        cmd.current_dir(&self.config.workspace_root);
+        let output = output_with_timeout(cmd, reap_gh_timeout()).ok()??;
+        if !output.status.success() {
+            return None;
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        stdout.trim().split_once('/').and_then(|(o, r)| {
+            if o.is_empty() || r.is_empty() {
+                None
+            } else {
+                Some((o.to_string(), r.to_string()))
+            }
+        })
     }
 
     fn flip_label_to_building(&self, issue: u32) -> Result<()> {
@@ -10009,6 +10179,207 @@ exit 0\n";
         if let Some(id) = running_issue_sweep_id(&reg, 4079) {
             let _ = reg.cancel(&id, Duration::from_secs(2));
         }
+    }
+
+    // --- open-PR dispatch guard (Issue #4123) ---
+
+    /// Install a fake `gh` for the open-PR guard: `issue view` always reports
+    /// `OPEN` (so the 2.5 closed-issue guard passes and the 2.6 open-PR guard is
+    /// reached), `api graphql` prints `graphql_stdout` (the post-`--jq` open-PR
+    /// numbers, one per line) and exits `graphql_exit`, and `repo view` resolves
+    /// the owner/repo. Every invocation is logged. `spawn-claude.sh` is a benign
+    /// echo-and-exit so a dispatch that passes the guard still spawns.
+    fn open_pr_guard_registry(
+        ws: &Path,
+        graphql_stdout: &str,
+        graphql_exit: i32,
+        skip_label_flip: bool,
+    ) -> (SweepRegistry, PathBuf) {
+        let gh_log = ws.join("gh-invocations.log");
+        let fake_gh = ws.join("fake-gh.sh");
+        let script = format!(
+            "#!/usr/bin/env bash\n\
+             printf '%s\\n' \"$*\" >> \"{log}\"\n\
+             if [[ \"$1\" == \"issue\" && \"$2\" == \"view\" ]]; then\n\
+             printf 'OPEN\\n'\n\
+             exit 0\n\
+             fi\n\
+             if [[ \"$1\" == \"api\" && \"$2\" == \"graphql\" ]]; then\n\
+             printf '%s\\n' \"{gql}\"\n\
+             exit {exit}\n\
+             fi\n\
+             if [[ \"$1\" == \"repo\" && \"$2\" == \"view\" ]]; then\n\
+             printf 'rjwalters/loom\\n'\n\
+             exit 0\n\
+             fi\n\
+             exit 0\n",
+            log = gh_log.display(),
+            gql = graphql_stdout,
+            exit = graphql_exit,
+        );
+        std::fs::write(&fake_gh, &script).unwrap();
+        let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_gh, perms).unwrap();
+        if let Ok(f) = std::fs::File::open(&fake_gh) {
+            let _ = f.sync_all();
+        }
+
+        let scripts_dir = ws.join(".loom").join("scripts");
+        std::fs::create_dir_all(&scripts_dir).unwrap();
+        let spawn = scripts_dir.join("spawn-claude.sh");
+        std::fs::write(&spawn, "#!/usr/bin/env bash\necho spawned\nexit 0\n").unwrap();
+        let mut sperms = std::fs::metadata(&spawn).unwrap().permissions();
+        sperms.set_mode(0o755);
+        std::fs::set_permissions(&spawn, sperms).unwrap();
+        if let Ok(f) = std::fs::File::open(&spawn) {
+            let _ = f.sync_all();
+        }
+        touch_sweep_command(ws);
+
+        let mut config = SweepRegistryConfig::new(ws.to_path_buf());
+        config.spawn_bin = Some(spawn);
+        config.gh_bin = Some(fake_gh);
+        config.skip_label_flip = skip_label_flip;
+        config.journal_path = Some(ws.join("test-sweeps-journal.json"));
+        (SweepRegistry::new(config), gh_log)
+    }
+
+    /// `dispatch` for an open issue that already has an open linked PR is refused
+    /// with the typed [`OpenPrDispatchError`] (downcast-matchable, not string
+    /// matching), and it must NOT acquire the claim lock or flip any labels — a
+    /// re-dispatch of already-in-review work would duplicate it.
+    #[test]
+    #[serial]
+    fn dispatch_refuses_open_pr_without_flipping_labels() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        let (mut reg, gh_log) = open_pr_guard_registry(ws, "4200", 0, false);
+
+        let err = reg
+            .dispatch(&SweepKind::Issue(4123), None, None, None, None)
+            .expect_err("an issue with an open linked PR must be refused");
+        let typed = err
+            .downcast_ref::<OpenPrDispatchError>()
+            .expect("refusal must carry the typed OpenPrDispatchError");
+        assert_eq!(typed.issue, 4123);
+        assert_eq!(typed.pr, 4200);
+
+        let calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(calls.contains("api graphql"), "the guard queried the closes-graph");
+        assert!(
+            !calls.contains("issue edit"),
+            "no label flip on a refused dispatch; got: {calls:?}"
+        );
+        // No lock acquired, no entry recorded.
+        assert!(running_issue_sweep_id(&reg, 4123).is_none());
+        std::env::remove_var("LOOM_REPO");
+    }
+
+    /// Fail-open (the single most safety-critical property): a forge error on the
+    /// open-PR probe (non-zero `gh api graphql`) must NOT wedge dispatch — the
+    /// guard returns `None` and dispatch proceeds to spawn + label flip.
+    #[test]
+    #[serial]
+    fn dispatch_fails_open_when_open_pr_lookup_errors() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        // `api graphql` exits non-zero ⇒ open-PR state unknown ⇒ fail open.
+        let (mut reg, gh_log) = open_pr_guard_registry(ws, "", 1, false);
+
+        let out = reg
+            .dispatch(&SweepKind::Issue(4124), None, None, None, None)
+            .expect("a forge error on the open-PR probe must not wedge dispatch (fail-open)");
+        assert!(wait_until_dead(out.pid, FIXTURE_CHILD_WAIT_MS));
+
+        let calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(calls.contains("api graphql"), "the guard attempted the closes-graph query");
+        assert!(
+            calls.contains("issue edit 4124"),
+            "dispatch proceeded to the label flip after failing open; got: {calls:?}"
+        );
+        if let Some(id) = running_issue_sweep_id(&reg, 4124) {
+            let _ = reg.cancel(&id, Duration::from_secs(2));
+        }
+        std::env::remove_var("LOOM_REPO");
+    }
+
+    /// An issue whose only linked PR is merged/closed is NOT blocked: the
+    /// `state == "OPEN"` `--jq` filter yields no PR number, so the probe returns
+    /// nothing and dispatch proceeds. Regression guard against an
+    /// `includeClosedPrs` misconfiguration that would strand every issue whose
+    /// PR ever merged.
+    #[test]
+    #[serial]
+    fn dispatch_open_pr_guard_ignores_merged_only_pr() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        // Empty post-`--jq` output = no OPEN-state PR (only merged/closed ones).
+        let (mut reg, _gh_log) = open_pr_guard_registry(ws, "", 0, false);
+
+        let out = reg
+            .dispatch(&SweepKind::Issue(4125), None, None, None, None)
+            .expect("an issue whose only linked PR is merged/closed must not be blocked");
+        assert!(wait_until_dead(out.pid, FIXTURE_CHILD_WAIT_MS));
+        if let Some(id) = running_issue_sweep_id(&reg, 4125) {
+            let _ = reg.cancel(&id, Duration::from_secs(2));
+        }
+        std::env::remove_var("LOOM_REPO");
+    }
+
+    /// `skip_label_flip = true` bypasses the open-PR guard entirely (test-fixture
+    /// path): even a fake `gh` that WOULD report an open PR is never consulted,
+    /// and dispatch proceeds.
+    #[test]
+    #[serial]
+    fn dispatch_skip_label_flip_bypasses_open_pr_guard() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        let (mut reg, gh_log) = open_pr_guard_registry(ws, "4200", 0, true);
+
+        let out = reg
+            .dispatch(&SweepKind::Issue(4126), None, None, None, None)
+            .expect("skip_label_flip must bypass the open-PR guard entirely");
+        assert!(wait_until_dead(out.pid, FIXTURE_CHILD_WAIT_MS));
+
+        let calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            !calls.contains("api graphql"),
+            "no forge call at all when label flips are disabled; got: {calls:?}"
+        );
+        if let Some(id) = running_issue_sweep_id(&reg, 4126) {
+            let _ = reg.cancel(&id, Duration::from_secs(2));
+        }
+        std::env::remove_var("LOOM_REPO");
+    }
+
+    /// The 2.5 closed-issue guard (#4088) fires BEFORE the 2.6 open-PR guard: a
+    /// closed issue (with a merged PR) is refused by 2.5 and the open-PR probe
+    /// never runs — no regression to the existing closed-issue path.
+    #[test]
+    #[serial]
+    fn closed_issue_guard_fires_before_open_pr_guard() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::remove_var("LOOM_REPO");
+        let (mut reg, gh_log) = closed_guard_registry(ws, "CLOSED", 0);
+
+        let err = reg
+            .dispatch(&SweepKind::Issue(4200), None, None, None, None)
+            .expect_err("a closed issue must still be refused by the 2.5 guard");
+        assert!(
+            err.to_string().contains("closed"),
+            "the 2.5 closed-issue guard wins; got: {err}"
+        );
+        let calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            !calls.contains("api graphql"),
+            "the open-PR (2.6) probe must never run once 2.5 refuses; got: {calls:?}"
+        );
     }
 
     // --- workspace-commands dispatch guard (Issue #4027) ---

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -91,6 +91,7 @@ use crate::cpu_headroom::{
 use crate::disk_headroom::disk_headroom_limit;
 use crate::event_bus::EventBus;
 use crate::main_health_gate::{MainHealthState, WorkspaceHealthStates};
+use crate::sweep_registry::OpenPrDispatchError;
 use crate::tokens::token_pool_size;
 use crate::types::Event;
 use crate::workspace_pool::WorkspacePool;
@@ -389,6 +390,14 @@ pub struct TickReport {
     /// (Issue #3939). Filtered out before the concurrency budget is allocated, so
     /// a quarantined candidate never consumes a shared dispatch slot.
     pub skipped_quarantined: usize,
+    /// Issues skipped because they already have an **open** linked PR (Issue
+    /// #4123 open-PR dispatch guard). `dispatch()` refuses these with the typed
+    /// [`OpenPrDispatchError`]; the finder attributes that refusal here rather
+    /// than to [`errors`](Self::errors) so a duplicate-work skip is visible and
+    /// distinct from a real dispatch failure. Every in-memory dedup signal dies
+    /// with the parent sweep, so without this guard an issue whose approved PR is
+    /// still open would be re-dispatched the moment its sweep exits.
+    pub skipped_pr_open: usize,
     /// Dispatch attempts that returned an error (logged, non-fatal).
     pub errors: usize,
     /// Cumulative cross-host dispatch collisions observed (Issue #4085, Phase 0
@@ -497,8 +506,21 @@ pub fn tick(
                 report.skipped_in_flight += 1;
             }
             Err(e) => {
-                report.errors += 1;
-                log::warn!("work_finder: dispatch for issue #{} failed: {e}", item.number);
+                // Open-PR guard refusal (#4123) is a *skip*, not a failure:
+                // attribute it to its own counter so it stays visible and
+                // distinct from a real dispatch error. Typed downcast, never a
+                // string match.
+                if e.downcast_ref::<OpenPrDispatchError>().is_some() {
+                    report.skipped_pr_open += 1;
+                    log::info!(
+                        "work_finder: skipping issue #{} — it already has an open linked PR \
+                         (#4123 open-PR guard)",
+                        item.number
+                    );
+                } else {
+                    report.errors += 1;
+                    log::warn!("work_finder: dispatch for issue #{} failed: {e}", item.number);
+                }
             }
         }
     }
@@ -737,8 +759,19 @@ pub fn tick_multi<S: WorkSource, D: WorkDispatcher>(
                 report.skipped_in_flight += 1;
             }
             Err(e) => {
-                report.errors += 1;
-                log::warn!("work_finder: dispatch for issue #{} failed: {e}", cand.number);
+                // Open-PR guard refusal (#4123) — see the single-workspace
+                // `tick` for the rationale. A skip, not a failure.
+                if e.downcast_ref::<OpenPrDispatchError>().is_some() {
+                    report.skipped_pr_open += 1;
+                    log::info!(
+                        "work_finder: skipping issue #{} — it already has an open linked PR \
+                         (#4123 open-PR guard)",
+                        cand.number
+                    );
+                } else {
+                    report.errors += 1;
+                    log::warn!("work_finder: dispatch for issue #{} failed: {e}", cand.number);
+                }
             }
         }
     }
@@ -1149,20 +1182,24 @@ where
                         log::info!("work_finder: main-health gate cleared — resuming dispatch");
                     }
                     was_halted = report.halted;
-                    if report.dispatched > 0 || report.errors > 0 || report.skipped_quarantined > 0
+                    if report.dispatched > 0
+                        || report.errors > 0
+                        || report.skipped_quarantined > 0
+                        || report.skipped_pr_open > 0
                     {
                         log::info!(
                             "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
                              healthy={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
                              cpu={cpu}, ceiling={configured_max}); \
                              {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, \
-                             {} quarantine-skip, {} deferred, {} error(s), \
+                             {} quarantine-skip, {} pr-open-skip, {} deferred, {} error(s), \
                              {} cross-host-collision(s)",
                             report.seen,
                             report.dispatched,
                             report.skipped_labeled,
                             report.skipped_in_flight,
                             report.skipped_quarantined,
+                            report.skipped_pr_open,
                             report.deferred_capacity,
                             report.errors,
                             report.collisions
@@ -1350,13 +1387,17 @@ pub fn spawn_multi_work_finder_task(
             }
             was_halted = report.halted;
 
-            if report.dispatched > 0 || report.errors > 0 || report.skipped_quarantined > 0 {
+            if report.dispatched > 0
+                || report.errors > 0
+                || report.skipped_quarantined > 0
+                || report.skipped_pr_open > 0
+            {
                 log::info!(
                     "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
                      healthy={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
                      cpu={cpu}, ceiling={configured_max}); {} workspace(s), \
                      {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, \
-                     {} quarantine-skip, {} deferred, {} error(s), \
+                     {} quarantine-skip, {} pr-open-skip, {} deferred, {} error(s), \
                      {} cross-host-collision(s)",
                     pairs.len(),
                     report.seen,
@@ -1364,6 +1405,7 @@ pub fn spawn_multi_work_finder_task(
                     report.skipped_labeled,
                     report.skipped_in_flight,
                     report.skipped_quarantined,
+                    report.skipped_pr_open,
                     report.deferred_capacity,
                     report.errors,
                     report.collisions
@@ -1721,6 +1763,9 @@ mod tests {
         noop_issues: HashSet<u32>,
         /// Issue numbers whose dispatch should error.
         fail_issues: HashSet<u32>,
+        /// Issue numbers whose dispatch should be refused by the open-PR guard
+        /// (#4123) — the dispatcher returns the typed [`OpenPrDispatchError`].
+        pr_open_issues: HashSet<u32>,
         /// Issue numbers this dispatcher reports as quarantined (Issue #3939).
         quarantined: HashSet<u32>,
         /// Cumulative cross-host collision count this dispatcher reports (#4085).
@@ -1738,6 +1783,11 @@ mod tests {
             self.collisions
         }
         fn dispatch(&mut self, issue: u32) -> Result<bool> {
+            if self.pr_open_issues.contains(&issue) {
+                // Mirror the production `SweepRegistry::dispatch` open-PR guard:
+                // refuse with the typed, downcast-matchable error (#4123).
+                return Err(OpenPrDispatchError { issue, pr: 9999 }.into());
+            }
             if self.fail_issues.contains(&issue) {
                 anyhow::bail!("forced dispatch failure for #{issue}");
             }
@@ -2064,6 +2114,63 @@ exit 0
         assert_eq!(report.dispatched, 2);
         assert_eq!(report.errors, 1);
         assert_eq!(disp.dispatched, vec![1, 3]);
+    }
+
+    #[test]
+    fn test_tick_open_pr_refusal_counts_as_pr_open_skip_not_error() {
+        // #2 has an open linked PR: `dispatch()` refuses with the typed
+        // OpenPrDispatchError, which the finder attributes to `skipped_pr_open`
+        // — NOT `errors` — while its siblings dispatch normally (#4123).
+        let mut source = FakeSource::once(vec![issue(1), issue(2), issue(3)]);
+        let mut disp = RecordingDispatcher {
+            pr_open_issues: HashSet::from([2]),
+            ..Default::default()
+        };
+        let report = tick(&mut source, &mut disp, 10, false).unwrap();
+
+        assert_eq!(report.skipped_pr_open, 1, "#2's open-PR refusal is a pr-open-skip");
+        assert_eq!(report.errors, 0, "an open-PR skip is never a dispatch error");
+        assert_eq!(report.dispatched, 2, "#1 and #3 still dispatch");
+        assert_eq!(disp.dispatched, vec![1, 3], "#2 never dispatched");
+    }
+
+    #[test]
+    fn test_tick_skip_only_pr_open_tick_is_reported() {
+        // A tick whose ONLY outcome is a pr-open-skip must still surface a
+        // non-empty report (dispatched == 0, errors == 0) — the counter carries
+        // the visibility, and the tick-log gate includes `skipped_pr_open` so
+        // such a tick is no longer silent (#4123).
+        let mut source = FakeSource::once(vec![issue(5)]);
+        let mut disp = RecordingDispatcher {
+            pr_open_issues: HashSet::from([5]),
+            ..Default::default()
+        };
+        let report = tick(&mut source, &mut disp, 10, false).unwrap();
+
+        assert_eq!(report.dispatched, 0);
+        assert_eq!(report.errors, 0);
+        assert_eq!(report.skipped_pr_open, 1);
+        assert!(disp.dispatched.is_empty(), "nothing dispatched on a skip-only tick");
+    }
+
+    #[test]
+    fn test_tick_multi_open_pr_refusal_counts_as_pr_open_skip() {
+        // The multi-workspace path attributes the open-PR refusal the same way
+        // as the single-workspace `tick` (#4123): the epic supervisor and
+        // watchdogs route through the same `dispatch()` seam, so this coverage
+        // matches the guard's placement.
+        let src_a = FakeSource::once(vec![issue(1), issue(2)]);
+        let disp_a = RecordingDispatcher {
+            pr_open_issues: HashSet::from([2]),
+            ..Default::default()
+        };
+        let mut pairs: Vec<(FakeSource, RecordingDispatcher)> = vec![(src_a, disp_a)];
+        let report = tick_multi(&mut pairs, &[], 10, &[false]);
+
+        assert_eq!(report.skipped_pr_open, 1);
+        assert_eq!(report.errors, 0);
+        assert_eq!(report.dispatched, 1);
+        assert_eq!(pairs[0].1.dispatched, vec![1]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds an **open-PR dispatch guard** (step 2.6) to `SweepRegistry::dispatch()`, immediately after the #4088 closed-issue guard. Every in-memory dedup signal (idempotency key, in-flight set, `loom:building` label) dies with the parent sweep, so an issue whose approved PR is still open looks identical to fresh work the moment its sweep exits — and every dispatch caller re-dispatches it, redoing finished work against a scarce token pool (the #4034 / PR #4036 recurrence).

## What changed

- **`sweep_registry.rs`**
  - New typed, downcast-matchable `OpenPrDispatchError` (not string matching).
  - Step 2.6 in `dispatch()`: refuse — without acquiring the claim lock or flipping labels — when the issue has an open linked PR. Placed in `dispatch()` so it covers all six callers (work finder, epic supervisor, IPC/CLI, and the three watchdogs) with one check.
  - `first_open_linked_pr()` helper: one `gh api graphql` call on `closedByPullRequestsReferences`, filtered to `state == "OPEN"` in the `--jq`. Mirrors `issue_is_closed()`'s fail-open `Option` contract, `current_dir`, and `reap_gh_timeout()` bounds. `resolve_owner_repo()` resolves owner/repo (LOOM_REPO override, else `gh repo view`) since GraphQL cannot infer the repo from cwd.
- **`work_finder.rs`**: new per-tick `skipped_pr_open` counter, attributed via `downcast_ref::<OpenPrDispatchError>()` (distinct from real dispatch errors), surfaced as `pr-open-skip` in both tick-log lines and added to both log-gate conditions so a skip-only tick still logs.
- **`defaults/docs/daemon-reference.md`**: documents the new counter beside the existing tick counters.

## Safety properties

- **Fail-open is mandatory** — any forge error/timeout/unparseable output lets dispatch proceed; a `gh` outage can never wedge the daemon. This is the most safety-critical test.
- **`state == "OPEN"` filter is load-bearing**, not `includeClosedPrs:false`: live testing confirmed a *merged* PR still returns from the closes-graph even with `includeClosedPrs:false` (state `MERGED`), so relying on the flag alone would strand every issue whose PR ever merged.
- Keys on PR openness only (never review labels); skipped under `skip_label_flip`; GitHub-only (Gitea fails open).

## Tests

`sweep_registry.rs`: open-PR refusal (no lock, no label flip, typed error); fail-open on forge error; merged-only PR not blocked; `skip_label_flip` bypass; 2.5-before-2.6 ordering. `work_finder.rs`: `pr-open-skip` attribution (single + multi workspace) and skip-only-tick visibility. Full `sweep_registry::tests` (177) and `work_finder::tests` (94) pass; `cargo clippy --lib --tests` clean.

Closes #4123

🤖 Generated with [Claude Code](https://claude.com/claude-code)