### PR TITLE
feat: promote check-links to a hard install failure

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -82,7 +82,8 @@ which holds the connection open and streams one `EventStream` frame per
 event. Connection framing matches the existing terminal-management IPC
 surface; no new transport is introduced.
 
-Source of truth: [`loom-daemon/src/types.rs`](../../loom-daemon/src/types.rs).
+Source of truth: [`loom-daemon/src/types.rs`](https://github.com/rjwalters/loom/blob/main/loom-daemon/src/types.rs)
+(upstream Loom repo — not shipped to consumer installs).
 
 | Request | MCP tool | Response | Phase |
 |---------|----------|----------|-------|
@@ -156,7 +157,8 @@ In addition, the bus internally emits:
 
 Topic matching is **segment-aligned prefix** (`sweep.issue` matches
 `sweep.issue.123.phase` but not `sweep.issuetype.foo`). See
-[`event_bus::topic_matches`](../../loom-daemon/src/event_bus.rs) for the
+[`event_bus::topic_matches`](https://github.com/rjwalters/loom/blob/main/loom-daemon/src/event_bus.rs)
+(upstream Loom repo — not shipped to consumer installs) for the
 authoritative routing rule.
 
 ## MCP tool reference
@@ -1013,9 +1015,11 @@ the single `loom:epic` label and are **derived** — computed each tick from two
 already-visible facts: the number of `### Phase` sections in the epic body, and
 the open/closed status of the epic's `loom:epic-phase` children. The five states
 (implemented as `EpicState` in
-[`loom-daemon/src/epic_state.rs`](../../loom-daemon/src/epic_state.rs)) mirror
+[`loom-daemon/src/epic_state.rs`](https://github.com/rjwalters/loom/blob/main/loom-daemon/src/epic_state.rs)
+(upstream Loom repo — not shipped to consumer installs)) mirror
 the `derived=True` epic lane of the authoritative Python model
-([`loom-tools/src/loom_tools/state_machine.py`](../../loom-tools/src/loom_tools/state_machine.py),
+([`loom-tools/src/loom_tools/state_machine.py`](https://github.com/rjwalters/loom/blob/main/loom-tools/src/loom_tools/state_machine.py)
+(upstream Loom repo — not shipped to consumer installs),
 #3841):
 
 | Derived state | Condition | Enabled transition |
@@ -1041,7 +1045,8 @@ epic:phase_join   → epic:done        (Supervisor, barrier)        [close]
 
 Every edge touching `epic:phase_join` is a **phase-boundary edge** and declares
 a non-empty fork-join barrier
-([`loom-daemon/src/phase_join.rs`](../../loom-daemon/src/phase_join.rs)): the
+([`loom-daemon/src/phase_join.rs`](https://github.com/rjwalters/loom/blob/main/loom-daemon/src/phase_join.rs)
+(upstream Loom repo — not shipped to consumer installs)): the
 barrier holds — degrading the plan to a no-op — until every child of the current
 phase is closed, so phase N+1 (or epic close) never fires while a current-phase
 child is still open.
@@ -1052,7 +1057,8 @@ begins its lifecycle at `epic:needs_decomp`.
 
 **Conformance.** The Rust transition table is asserted faithful to the Python
 model by
-[`loom-daemon/tests/epic_conformance.rs`](../../loom-daemon/tests/epic_conformance.rs),
+[`loom-daemon/tests/epic_conformance.rs`](https://github.com/rjwalters/loom/blob/main/loom-daemon/tests/epic_conformance.rs)
+(upstream Loom repo — not shipped to consumer installs),
 which **derives** its expectation by invoking
 `python3 -m loom_tools.state_machine --json` and comparing the emitted epic
 sub-graph (states, edges, roles, barriers, `creates_issues`) against the Rust
@@ -1064,7 +1070,8 @@ test skips gracefully when `python3` is unavailable.
 The two issue-creating expand bursts (`decompose`'s downstream and both
 `expand`/`join` Champion dispatches that run `gh issue create`) are serialized
 through the global **#3707 issue-creation mutex**
-([`loom-daemon/src/issue_creation_mutex.rs`](../../loom-daemon/src/issue_creation_mutex.rs)).
+([`loom-daemon/src/issue_creation_mutex.rs`](https://github.com/rjwalters/loom/blob/main/loom-daemon/src/issue_creation_mutex.rs)
+(upstream Loom repo — not shipped to consumer installs)).
 The supervisor holds the async guard across the whole (spawn-and-wait) dispatch
 so a burst never interleaves with any other issue-creating burst anywhere in the
 daemon. All epic expands share the single `CHAMPION_EPIC_DECOMP` serialization
@@ -1093,7 +1100,8 @@ epic-supervisor action across all epics, or `epic.issue.{N}` for one epic
 ## Autonomous work finder (#3810)
 
 The **work finder** (Phase A of epic #3809,
-[`loom-daemon/src/work_finder.rs`](../../loom-daemon/src/work_finder.rs)) is the
+[`loom-daemon/src/work_finder.rs`](https://github.com/rjwalters/loom/blob/main/loom-daemon/src/work_finder.rs)
+(upstream Loom repo — not shipped to consumer installs)) is the
 daemon-native poller that turns a human-approved `loom:issue` into a dispatched
 build **without an operator** — restoring the one capability the deleted v0.10.0
 shepherd brain had that the daemon rebuild never replaced. It is **opt-in and
@@ -1217,7 +1225,8 @@ cost is judged worth paying.
 remaining constant — how many cores one concurrent sweep consumes during its
 build/test step — is a per-repo/host property. Its default (`2.0`) is **not**
 changed here absent a real multi-sweep measurement; a reproducible recipe lives
-at [`docs/measure-est-cores-per-sweep.md`](../../docs/measure-est-cores-per-sweep.md)
+at [`docs/measure-est-cores-per-sweep.md`](https://github.com/rjwalters/loom/blob/main/docs/measure-est-cores-per-sweep.md)
+(upstream Loom repo — not shipped to consumer installs)
 so an operator can calibrate it on a live fleet without re-opening the code.
 
 **Per-token concurrency factor (#3947).** The token axis is `healthy × factor`,
@@ -2525,7 +2534,8 @@ run against a binary-only / release-tarball install.
 
 The goal state — "file a `loom:triage` issue, watch it build" with zero operator
 dispatch — is validated by the E2E playbook at
-[`docs/autonomous-mode-e2e.md`](../../docs/autonomous-mode-e2e.md): it walks a
+[`docs/autonomous-mode-e2e.md`](https://github.com/rjwalters/loom/blob/main/docs/autonomous-mode-e2e.md)
+(upstream Loom repo — not shipped to consumer installs): it walks a
 throwaway issue from `loom:triage` → Curator → `loom:issue` → work-finder
 dispatch → PR → merge, with a scripted label-transition assertion, and confirms
 the operator only ever created the issue.
@@ -2572,17 +2582,19 @@ what Phase 3 deletes vs preserves".
 - **Phase B** (event bus): #3453 / PR #3460.
 - **Phase C** (monitoring + subscription tools): #3455.
 - **Migration guide**:
-  [`docs/migration/v0.10.0-shepherd-deprecation.md`](../../docs/migration/v0.10.0-shepherd-deprecation.md).
+  [`docs/migration/v0.10.0-shepherd-deprecation.md`](https://github.com/rjwalters/loom/blob/main/docs/migration/v0.10.0-shepherd-deprecation.md)
+  (upstream Loom repo — not shipped to consumer installs).
 - **Config resolution layer** (#4039, Epic #3835 Phase 2): a single resolver
   over private defaults + tracked `.loom-project/project.json` + ignored
   `.loom-local/local.json` + legacy `.loom/config.json`, additive-only (no
   existing call site — including this doc's `.loom/config.json` references
   above — has been migrated onto it yet; see follow-up #4047). Schema,
   precedence, and how it composes with `env > config > default`:
-  [`docs/design/config-resolution-tiers.md`](../../docs/design/config-resolution-tiers.md).
-- **Source**:
-  - [`loom-daemon/src/types.rs`](../../loom-daemon/src/types.rs) — IPC types.
-  - [`loom-daemon/src/sweep_registry.rs`](../../loom-daemon/src/sweep_registry.rs) — registry + reaper.
-  - [`loom-daemon/src/event_bus.rs`](../../loom-daemon/src/event_bus.rs) — pub/sub bus.
-  - [`loom-daemon/src/ipc.rs`](../../loom-daemon/src/ipc.rs) — request dispatcher.
-  - [`mcp-loom/src/tools/sweeps.ts`](../../mcp-loom/src/tools/sweeps.ts) — MCP tool definitions.
+  [`docs/design/config-resolution-tiers.md`](https://github.com/rjwalters/loom/blob/main/docs/design/config-resolution-tiers.md)
+  (upstream Loom repo — not shipped to consumer installs).
+- **Source** (upstream Loom repo — not shipped to consumer installs):
+  - [`loom-daemon/src/types.rs`](https://github.com/rjwalters/loom/blob/main/loom-daemon/src/types.rs) — IPC types.
+  - [`loom-daemon/src/sweep_registry.rs`](https://github.com/rjwalters/loom/blob/main/loom-daemon/src/sweep_registry.rs) — registry + reaper.
+  - [`loom-daemon/src/event_bus.rs`](https://github.com/rjwalters/loom/blob/main/loom-daemon/src/event_bus.rs) — pub/sub bus.
+  - [`loom-daemon/src/ipc.rs`](https://github.com/rjwalters/loom/blob/main/loom-daemon/src/ipc.rs) — request dispatcher.
+  - [`mcp-loom/src/tools/sweeps.ts`](https://github.com/rjwalters/loom/blob/main/mcp-loom/src/tools/sweeps.ts) — MCP tool definitions.

--- a/defaults/docs/troubleshooting.md
+++ b/defaults/docs/troubleshooting.md
@@ -306,7 +306,8 @@ exec-latency artifacts rather than contention. The narrative and its consequence
 for gate niceness live in [`build-gate.md`](build-gate.md) (the #4044 / #4046
 falsification passage). ADR-0011 also records this as a macOS-specific defect that
 is invisible to Linux CI by construction — see
-[`docs/adr/0011-ci-runner-platform.md`](../../docs/adr/0011-ci-runner-platform.md).
+[`docs/adr/0011-ci-runner-platform.md`](https://github.com/rjwalters/loom/blob/main/docs/adr/0011-ci-runner-platform.md)
+(upstream Loom repo — not shipped to consumer installs).
 
 > **Historical note on timeouts.** Contemporaneous incident writeups mention a
 > "600s" build-gate budget; that figure is **incident history only**. #4048 raised
@@ -339,7 +340,7 @@ loom-stuck-detection check-issue 123
 | `dead_pid` | (instant) | PID in the daemon sweep registry is no longer alive |
 | `error_spike` | 5 errors | Multiple errors in `.loom/logs/sweep-issue-N.log` |
 
-The pre-v0.10.0 indicators `missing_milestone:worktree_created` and `extended_work` were retired when the Python daemon brain (`daemon_v2/`) was removed — see [the migration guide § Per-CLI breaking changes](../../docs/migration/v0.10.0-shepherd-deprecation.md#per-cli-breaking-changes) for the field-level diff. The shell-level daemon surface (`./.loom/scripts/daemon.sh`) is preserved but does not write progress files, so milestone-based heuristics no longer apply.
+The pre-v0.10.0 indicators `missing_milestone:worktree_created` and `extended_work` were retired when the Python daemon brain (`daemon_v2/`) was removed — see [the migration guide § Per-CLI breaking changes](https://github.com/rjwalters/loom/blob/main/docs/migration/v0.10.0-shepherd-deprecation.md#per-cli-breaking-changes) (upstream Loom repo — not shipped to consumer installs) for the field-level diff. The shell-level daemon surface (`./.loom/scripts/daemon.sh`) is preserved but does not write progress files, so milestone-based heuristics no longer apply.
 
 ## Sweep Dispatch Troubleshooting
 
@@ -369,7 +370,7 @@ cd mcp-loom && npm install && npm run build
 grep -c dispatch_sweep dist/index.js   # should now be > 0
 ```
 
-`scripts/setup-mcp.sh` now auto-rebuilds when `dist/index.js` is missing **or** older than any file under `mcp-loom/src/` (#3803), so `./scripts/setup-mcp.sh` is the safe one-shot path. Rebuilding the bundle does **not** refresh an already-running session — an MCP client caches its tool list at connect time, so you must **restart the Claude Code session** (or respawn the `loom` MCP subprocess) for the new tools to appear. See [`mcp-loom/README.md`](../../mcp-loom/README.md#rebuilding-after-source-changes-reconnect-required) for the full rebuild + reconnect procedure and a raw `tools/list` verification snippet.
+`scripts/setup-mcp.sh` now auto-rebuilds when `dist/index.js` is missing **or** older than any file under `mcp-loom/src/` (#3803), so `./scripts/setup-mcp.sh` is the safe one-shot path. Rebuilding the bundle does **not** refresh an already-running session — an MCP client caches its tool list at connect time, so you must **restart the Claude Code session** (or respawn the `loom` MCP subprocess) for the new tools to appear. See [`mcp-loom/README.md`](https://github.com/rjwalters/loom/blob/main/mcp-loom/README.md#rebuilding-after-source-changes-reconnect-required) (upstream Loom repo — not shipped to consumer installs) for the full rebuild + reconnect procedure and a raw `tools/list` verification snippet.
 
 ### MCP tools hang with no response (~1800s), then abort
 

--- a/defaults/scripts/verify-install.sh
+++ b/defaults/scripts/verify-install.sh
@@ -365,8 +365,17 @@ extract_link_targets() {
     {
         # Markdown links: [text](target) — keep the ()-body only. A trailing
         # ` "title"` (rare in this repo, but cheap to strip) is dropped too.
+        # `|| true` guards each block independently: under `set -e -o
+        # pipefail` (active script-wide), a file with zero matches for one
+        # extraction form makes that grep exit 1, and pipefail propagates
+        # that non-zero status to the pipeline — which would abort this
+        # function (and skip the *other* extraction block entirely) for any
+        # file that has, say, backtick-only refs but no markdown-style
+        # links. A file legitimately having zero targets of one form is not
+        # an error (#4147).
         grep -oE '\]\([^)]+\)' "$file" 2>/dev/null \
-            | sed -E 's/^\]\(//; s/\)$//; s/ "[^"]*"$//'
+            | sed -E 's/^\]\(//; s/\)$//; s/ "[^"]*"$//' \
+            || true
         # Backtick-only install-rooted paths, e.g. `.loom/docs/build-gate.md`
         # or `.claude/roles/foo.md#anchor` — never wrapped in [...]().
         # The path-segment character class deliberately excludes glob (`*`)
@@ -378,7 +387,8 @@ extract_link_targets() {
         # (see e.g. `.loom-README.md`'s "Create `.loom/roles/my-role.md`:").
         grep -viE '\bcreate\b' "$file" 2>/dev/null \
             | grep -oE '`\.(loom|claude|codex|github)/[A-Za-z0-9_./-]+\.md(#[A-Za-z0-9_-]+)?`' \
-            | sed -E 's/^`//; s/`$//'
+            | sed -E 's/^`//; s/`$//' \
+            || true
     }
 }
 

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -1703,18 +1703,11 @@ if [[ -x ".loom/scripts/verify-install.sh" ]]; then
   # dangling target here means an installed file points at a sibling
   # Loom never shipped (a packaging gap, like #4097 itself) — surfacing it
   # here beats a downstream consumer audit finding it later.
-  #
-  # Non-fatal by design: some shipped reference docs (daemon-reference.md,
-  # troubleshooting.md) carry pre-existing links into the Loom SOURCE repo's
-  # own tree (source files, dev-only docs under docs/) that were authored
-  # assuming the doc lives only there — a known, tracked gap (see #4097's
-  # PR discussion) distinct from the packaging-boundary defects this check
-  # exists to catch. Promote to `error` once that cleanup lands (follow-up: #4147).
   info "Checking intra-repo links in installed files..."
   if ./.loom/scripts/verify-install.sh check-links --quiet; then
     success "All intra-repo links resolve"
   else
-    warning "Some intra-repo links in installed files are dangling (non-fatal) — run './.loom/scripts/verify-install.sh check-links' for details"
+    error "Some intra-repo links in installed files are dangling — run './.loom/scripts/verify-install.sh check-links' for details"
   fi
 fi
 echo ""

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -2732,6 +2732,153 @@ fi
 echo ""
 
 # ==========================================================================
+# Section 13: verify-install.sh check-links parsing coverage (#4147)
+#
+# install-loom.sh promotes a `check-links` failure to a hard installer error
+# (issue #4097's AC4). This section exercises cmd_check_links /
+# resolve_link_target / extract_link_targets directly (no full install run
+# needed — the parsing logic operates on any git repo with a
+# .loom/docs/*.md tree, which the legacy directory-walk fallback in
+# collect_tracked_files() picks up without an install-metadata.json).
+# ==========================================================================
+echo "--- Section 13: check-links parsing coverage (#4147) ---"
+echo ""
+
+VERIFY_INSTALL_SCRIPT="$DEFAULTS_DIR/scripts/verify-install.sh"
+
+# Minimal scratch git repo with a .loom/docs/ tree — enough for the legacy
+# directory-walk fallback in collect_tracked_files() to discover the fixture
+# .md files without needing an install-metadata.json.
+seed_check_links_repo() {
+  local repo="$1"
+  mkdir -p "$repo/.loom/docs"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email "test@test.com"
+  git -C "$repo" config user.name "Test"
+}
+
+echo "Test: check-links — clean fixture resolves (exit 0)"
+CL_OK="$TEST_DIR/check-links-ok"
+seed_check_links_repo "$CL_OK"
+mkdir -p "$CL_OK/.loom/docs/sub"
+echo "sibling content" > "$CL_OK/.loom/docs/b.md"
+echo "file in dir" > "$CL_OK/.loom/docs/sub/inner.md"
+cat > "$CL_OK/.loom/docs/a.md" <<'EOF'
+# Fixture
+
+Markdown link resolves: [x](b.md)
+Anchor stripped before resolution: [x](b.md#some-heading)
+Pure in-page anchor skipped: [x](#local)
+Directory target satisfied when non-empty: [x](sub/)
+External http(s) skipped: [ext](https://example.com/page)
+Mailto skipped: [m](mailto:a@b.c)
+Backtick-only install-rooted resolves: `.loom/docs/b.md`
+Glob placeholder is not a literal target: `.loom/roles/*.md`
+Name placeholder is not a literal target: `.loom/roles/<name>.md`
+Create `.loom/docs/tutorial-placeholder.md`: tutorial lines are excluded.
+EOF
+# Note: set -e is active throughout this file. check-links exits non-zero
+# (6) on a dangling link by design, so every invocation below is guarded
+# with `|| true` inside the capturing subshell and the real exit code is
+# captured separately via a `set +e` / `set -e` bracket — mirroring the
+# existing "set -e is active; capture ... via || true" convention used for
+# Test 45/46 above.
+set +e
+CL_OK_OUT=$(cd "$CL_OK" && bash "$VERIFY_INSTALL_SCRIPT" check-links 2>&1)
+CL_OK_RC=$?
+set -e
+if [[ $CL_OK_RC -eq 0 ]]; then
+  pass "check-links: markdown link, anchor-stripped link, in-page anchor, non-empty directory target, external/mailto skip, backtick-only install-rooted ref, glob/placeholder exclusion, and Create-tutorial-line exclusion all resolve (exit 0)"
+else
+  fail "check-links: clean fixture did not resolve (rc=$CL_OK_RC): $CL_OK_OUT"
+fi
+echo ""
+
+echo "Test: check-links — dangling markdown link (exit 6, target named)"
+CL_DANGLE_MD="$TEST_DIR/check-links-dangle-md"
+seed_check_links_repo "$CL_DANGLE_MD"
+cat > "$CL_DANGLE_MD/.loom/docs/a.md" <<'EOF'
+[x](nope.md)
+EOF
+set +e
+CL_DANGLE_MD_OUT=$(cd "$CL_DANGLE_MD" && bash "$VERIFY_INSTALL_SCRIPT" check-links 2>&1)
+CL_DANGLE_MD_RC=$?
+set -e
+if [[ $CL_DANGLE_MD_RC -eq 6 ]]; then
+  pass "check-links: dangling markdown link -> exit 6"
+else
+  fail "check-links: dangling markdown link -> expected exit 6, got $CL_DANGLE_MD_RC"
+fi
+if echo "$CL_DANGLE_MD_OUT" | grep -qF "nope.md"; then
+  pass "check-links: dangling markdown target named in output"
+else
+  fail "check-links: dangling markdown target not named in output: $CL_DANGLE_MD_OUT"
+fi
+echo ""
+
+echo "Test: check-links — dangling backtick-only install-rooted ref (exit 6)"
+CL_DANGLE_BT="$TEST_DIR/check-links-dangle-backtick"
+seed_check_links_repo "$CL_DANGLE_BT"
+cat > "$CL_DANGLE_BT/.loom/docs/a.md" <<'EOF'
+See `.loom/docs/gone.md` for details.
+EOF
+set +e
+CL_DANGLE_BT_OUT=$(cd "$CL_DANGLE_BT" && bash "$VERIFY_INSTALL_SCRIPT" check-links 2>&1)
+CL_DANGLE_BT_RC=$?
+set -e
+if [[ $CL_DANGLE_BT_RC -eq 6 ]]; then
+  pass "check-links: dangling backtick-only install-rooted ref -> exit 6"
+else
+  fail "check-links: dangling backtick-only ref -> expected exit 6, got $CL_DANGLE_BT_RC"
+fi
+if echo "$CL_DANGLE_BT_OUT" | grep -qF ".loom/docs/gone.md"; then
+  pass "check-links: dangling backtick-only target named in output"
+else
+  fail "check-links: dangling backtick-only target not named in output: $CL_DANGLE_BT_OUT"
+fi
+echo ""
+
+echo "Test: check-links — empty directory target dangles (exit 6)"
+CL_DANGLE_DIR="$TEST_DIR/check-links-dangle-dir"
+seed_check_links_repo "$CL_DANGLE_DIR"
+mkdir -p "$CL_DANGLE_DIR/.loom/docs/emptysub"
+cat > "$CL_DANGLE_DIR/.loom/docs/a.md" <<'EOF'
+[x](emptysub/)
+EOF
+set +e
+( cd "$CL_DANGLE_DIR" && bash "$VERIFY_INSTALL_SCRIPT" check-links >/dev/null 2>&1 )
+CL_DANGLE_DIR_RC=$?
+set -e
+if [[ $CL_DANGLE_DIR_RC -eq 6 ]]; then
+  pass "check-links: empty directory target -> exit 6"
+else
+  fail "check-links: empty directory target -> expected exit 6, got $CL_DANGLE_DIR_RC"
+fi
+echo ""
+
+echo "Test: check-links — --quiet suppresses stdout on a dangling link"
+CL_QUIET="$TEST_DIR/check-links-quiet"
+seed_check_links_repo "$CL_QUIET"
+cat > "$CL_QUIET/.loom/docs/a.md" <<'EOF'
+[x](nope.md)
+EOF
+set +e
+CL_QUIET_STDOUT=$(cd "$CL_QUIET" && bash "$VERIFY_INSTALL_SCRIPT" check-links --quiet 2>/dev/null)
+CL_QUIET_RC=$?
+set -e
+if [[ $CL_QUIET_RC -eq 6 ]]; then
+  pass "check-links --quiet: dangling link still exits 6"
+else
+  fail "check-links --quiet: expected exit 6, got $CL_QUIET_RC"
+fi
+if [[ -z "$CL_QUIET_STDOUT" ]]; then
+  pass "check-links --quiet: no stdout emitted"
+else
+  fail "check-links --quiet: unexpected stdout: $CL_QUIET_STDOUT"
+fi
+echo ""
+
+# ==========================================================================
 # Summary
 # ==========================================================================
 echo "======================================"


### PR DESCRIPTION
## Summary

Follow-up from PR #4145 (#4097), which added the `verify-install.sh check-links`
subcommand but wired it into `install-loom.sh` as a **non-fatal warning**. This
PR promotes it to a hard install failure now that the pre-existing dangling
upstream-source links it was deferring on are cleaned up, and adds CI-reachable
parsing test coverage.

## Changes

- **`scripts/install-loom.sh`**: deleted the "Non-fatal by design ... follow-up:
  #4147" comment block and changed the `check-links` failure branch from
  `warning` (non-fatal) to `error` (exits non-zero, hard install failure).
- **`defaults/docs/daemon-reference.md`** / **`defaults/docs/troubleshooting.md`**:
  absolutised the ~17 parent-escaping (`../../`) links that pointed into this
  repo's own source tree (`loom-daemon/src/*.rs`, dev-only `docs/*.md`, etc.) to
  `https://github.com/rjwalters/loom/blob/main/<path>` URLs marked "(upstream
  Loom repo — not shipped to consumer installs)" — the pattern already used in
  `defaults/CLAUDE.md`. No `../../`-escaping link remains under `defaults/docs/`.
  `.loom/docs/{daemon-reference,troubleshooting}.md` are symlinks into
  `defaults/docs/` in this (dogfooding) repo, so they update automatically —
  no separate resync needed.
- **`defaults/scripts/verify-install.sh`**: fixed a real bug in
  `extract_link_targets()` uncovered while writing the new tests — under the
  script's `set -e -o pipefail`, a doc file with **zero** matches for the
  markdown-link (`](...)`) extraction pipeline made that pipeline exit
  non-zero, which aborted the whole function *before* the backtick-only
  extraction block ever ran. Any doc whose only references were backtick-only
  (e.g. `` `.loom/docs/foo.md` ``, no `[text](...)` links at all) was silently
  never checked for dangling backtick refs. Guarded both extraction blocks
  with `|| true` — a file legitimately having zero targets of one form is not
  an error.
- **`scripts/test-installer.sh`** (Section 13, new): added parsing coverage
  for `check-links` reachable from the existing "Installer Integration Tests"
  CI job (`- run: bash scripts/test-installer.sh`) — no new CI wiring needed.
  Covers: markdown-link extraction/resolution, dangling markdown link (exit 6,
  target named in output), backtick-only install-rooted extraction/resolution
  (both clean and dangling — this is the case that caught the bug above),
  `#anchor` fragment stripping, pure in-page anchor skip, directory-target
  non-empty rule (both satisfied and empty/dangling), external `http(s)://`
  and `mailto:` skip, glob/placeholder exclusion (`*.md`, `<name>.md`), the
  `Create \`...\`` tutorial-line exclusion, and `--quiet` stdout suppression.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| AC1 — `check-links` exits 0 against a freshly-provisioned install root | ✅ | Built a scratch install root from `defaults/` (roles, scripts, hooks, docs, `.claude/`, `.github/`) and ran `verify-install.sh check-links` — `✓ All intra-repo links resolve (69 file(s) checked)`, exit 0. |
| AC2 — every remaining upstream-source reference in the two docs is absolutised or removed; no `../../` link survives under `defaults/docs/` | ✅ | `grep -rn '\](\.\./\.\./' defaults/docs/` returns empty after the edits. |
| AC3 — `install-loom.sh` treats a non-zero `check-links` exit as a hard error; the "Non-fatal by design" comment is deleted | ✅ | Diff shown above; standalone repro of the exact snippet confirms `error` fires and exits 1, "UNREACHED" never printed, on a dangling-link fixture. |
| AC4 — a fresh end-to-end install still succeeds | ✅ | Same scratch-root run as AC1 (0 dangling, exit 0); negative test (injected `[x](../../nope/gone.md)`) reproduces the dangling case and confirms `check-links` reports it (exit 6) and the installer's promoted wiring hard-fails on it. |
| AC5 — `check-links` parsing has automated coverage reachable from a CI job | ✅ | `scripts/test-installer.sh` Section 13 (12 new assertions, all passing); this file is already run by `.github/workflows/ci.yml`'s Installer Integration Tests job — no new CI wiring needed. `grep -rn 'check-links' scripts/test-installer.sh` returns hits. |
| AC6 — issue #4097's AC4 checklist row checked, closed if last open item | ✅ | #4097 was already closed. Checked the two matching checklist rows (`` `verify-install.sh` grows a link check... `` and `` `verify-install.sh` fails the install on an unresolved intra-repo link... ``) with a note referencing this PR. |
| AC7 — `test-verify-install-scope.sh` still passes | ✅ | `bash defaults/scripts/tests/test-verify-install-scope.sh` → 16/16 passed. |

## Test Plan

- `bash defaults/scripts/tests/test-verify-install-scope.sh` — 16/16 passed (no regression from touching `verify-install.sh`).
- `bash scripts/test-installer.sh` — 148 passed, 2 pre-existing failures unrelated to this PR (see below).
- Manual: scratch install root from `defaults/` → `verify-install.sh check-links` → clean (0 dangling, 69 files).
- Manual negative: injected `[x](../../nope/gone.md)` into the scratch root's `troubleshooting.md` → `check-links` reports it and exits 6; the exact `install-loom.sh` wiring snippet reproduces the hard failure (exit 1).
- Manual: standalone repro of the `set -e` bug against a fixture with a dangling backtick-only ref and no markdown links — failed before the `extract_link_targets` fix (silently reported "0 dangling"), passes after.
- Shellcheck: `find defaults/scripts -type f -name "*.sh" -print0 | xargs -0 shellcheck --severity=warning --format=gcc` (the exact command the Shellcheck CI job runs) — clean. (`scripts/install-loom.sh` / `scripts/test-installer.sh` are outside that job's `defaults/scripts/**` glob; a broader unscoped shellcheck pass surfaced only pre-existing info/style-level findings in those two files, none introduced by this change, one addressed anyway.)

### Pre-existing failures (not addressed here)

`bash scripts/test-installer.sh` has 2 pre-existing failures unrelated to this
PR's scope: `#4050: daemon-direct init did not write a parseable
.loom/install-metadata.json` and `#4050: .loom/CLAUDE.md renders 'Loom
Version: unknown' on daemon-direct init`. Root cause: this worktree's
`target/release/loom-daemon` binary predates PR #4149 (`fix(daemon): write
install-metadata + real version on direct loom-daemon init`, merged
2026-07-27 19:22), which already fixes this on `main` — the worktree's copied
binary is simply stale relative to that fix. Not caused by, or fixable within,
this PR's scope.

## Scope Guards Honored

- Did not touch `defaults/CLAUDE.md` (deletion target for a separate epic).
- Did not retro-wire `test-verify-install-scope.sh` into CI.
- Did not rewrite doc prose beyond what the link changes required.

Closes #4147