### PR TITLE
config: enable autonomous.collisionDetection (observe-only, #4146)

### DIFF
--- a/.loom/config.json
+++ b/.loom/config.json
@@ -5,6 +5,9 @@
     "roleRunner": {
       "enabled": true,
       "roles": ["curator", "champion"]
+    },
+    "collisionDetection": {
+      "enabled": true
     }
   },
   "buildGate": {


### PR DESCRIPTION
Enables `autonomous.collisionDetection.enabled` in `.loom/config.json`, folded into today's daemon roll onto `a7ab8ba0` per #4146 (operator-approved). Observe-only by construction — a detected collision is logged and counted, never acted on — and fails closed.

Verified live post-roll: `sweep_registry: cross-host collision detection enabled (#4085)` in `~/.loom/daemon.log`.

Part of #4146 (baseline observation window now open; reporting back to #4028/#3979 remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)