### PR TITLE
feat(daemon): native `loom-daemon tokens bootstrap` (#4105)

### DIFF
--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -222,10 +222,11 @@ enum Commands {
     /// rate-limit probe (`check`), and the operator-facing pin/unpin/unblock
     /// bookkeeping CLI. As of #4080 (Phase 2) `check` is also the
     /// implementation `probe-tokens.sh` and the daemon's own ranking
-    /// self-refresh invoke natively; `spawn-claude.sh` (selection) and
-    /// `bootstrap`/`import-from-monitor` remain Python-only (deferred to
-    /// follow-up issues — see `loom-daemon/src/tokens_pool/mod.rs`). Purely
-    /// file-based; does not require a running daemon.
+    /// self-refresh invoke natively. As of #4105 `bootstrap` is native too
+    /// (multi-source `.env` merge + pool provisioning); `spawn-claude.sh`
+    /// (selection) and `import-from-monitor` (issue #4106) remain Python-only
+    /// (see `loom-daemon/src/tokens_pool/mod.rs`). Purely file-based; does not
+    /// require a running daemon.
     Tokens {
         #[command(subcommand)]
         action: TokensAction,
@@ -375,6 +376,53 @@ enum TokensAction {
         /// Omit the secret key from output (safe inspection).
         #[arg(long)]
         no_key: bool,
+    },
+
+    /// Materialize `.loom/tokens/` from `ACCOUNT_*_N` triples, merging by email
+    /// with precedence claude-monitor (`~/.claude-monitor/accounts.env`,
+    /// primary) > repo-local. The home master (`~/.loom/accounts.env`) is
+    /// opt-in only: read solely when `$LOOM_ACCOUNTS_ENV` (or `--home-env`)
+    /// points at it. `ACCOUNT_TOKEN_FILE_N` is optional — auto-derived from
+    /// `ACCOUNT_EMAIL_N` when omitted. Native Rust port of the historical Python
+    /// `loom-tokens bootstrap` CLI (issue #4105, epic #4081).
+    Bootstrap {
+        /// Repo root (plain path, default `.` — no upward `.git` walk). The
+        /// pool is written to `<workspace>/.loom/tokens` unless `--shared`.
+        #[arg(long, value_name = "PATH", default_value = ".")]
+        workspace: String,
+
+        /// Path to the repo-local account source (default:
+        /// `<repo>/.loom/accounts.env` if present, else `<repo>/.env`).
+        #[arg(long, value_name = "PATH")]
+        env: Option<String>,
+
+        /// Path to the home-dir master account source. Opt-in only; with no
+        /// flag the home master is read only when `$LOOM_ACCOUNTS_ENV` points
+        /// at a file.
+        #[arg(long, value_name = "PATH")]
+        home_env: Option<String>,
+
+        /// Ignore the home master; bootstrap from the repo-local source only.
+        #[arg(long)]
+        no_home: bool,
+
+        /// Materialize the SHARED machine-level pool at `~/.loom/tokens`
+        /// (override with `$LOOM_SHARED_TOKENS_DIR`) instead of the repo-local
+        /// `<repo>/.loom/tokens`.
+        #[arg(long)]
+        shared: bool,
+
+        /// Overwrite existing token files even if their fingerprint matches.
+        #[arg(long)]
+        force: bool,
+
+        /// Report what would change without writing any files.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Emit a JSON summary on stdout.
+        #[arg(long)]
+        json: bool,
     },
 
     /// Probe each bootstrapped account for rate-limit headers and rank by
@@ -3432,6 +3480,50 @@ fn resolve_tokens_workspace(workspace: &str) -> Result<PathBuf> {
     }
 }
 
+/// Human-readable label for an account's merge provenance. Mirrors
+/// `cli._SOURCE_LABEL`.
+fn source_label(source: &str) -> &str {
+    match source {
+        "home" => "home",
+        "repo" => "repo",
+        "repo-override" => "repo (overrides home)",
+        "monitor" => "claude-monitor",
+        "monitor-override" => "claude-monitor (overrides repo/home)",
+        other => other,
+    }
+}
+
+/// Print the effective merged account set and where each came from. Mirrors
+/// `cli._print_effective_accounts` — secrets are never shown, only email, token
+/// filename, and source.
+fn print_effective_accounts(result: &loom_daemon::tokens_pool::bootstrap::BootstrapResult) {
+    let disp = |p: &Option<std::path::PathBuf>| -> String {
+        p.as_ref()
+            .map_or_else(|| "(none)".to_string(), |p| p.display().to_string())
+    };
+    println!("Account sources:");
+    println!("  claude-monitor: {}", disp(&result.monitor_env));
+    println!("  home: {}", disp(&result.home_env));
+    println!("  repo: {}", disp(&result.repo_env));
+
+    if result.effective.is_empty() {
+        println!("Effective accounts: (none)");
+        return;
+    }
+
+    println!("Effective accounts ({}):", result.effective.len());
+    let width = result
+        .effective
+        .iter()
+        .map(|a| a.name.chars().count())
+        .max()
+        .unwrap_or(0);
+    for a in &result.effective {
+        let label = source_label(&a.source);
+        println!("  {:<width$}  {}  [{label}]", a.name, a.email, width = width);
+    }
+}
+
 /// Handle `loom-daemon tokens <select|pin|unpin|unblock>` (Issue #4082,
 /// Phase 1 of epic #4081). Purely file-based — does not require a running
 /// daemon. See `loom-daemon/src/tokens_pool/mod.rs` for the ported subset
@@ -3493,6 +3585,91 @@ fn handle_tokens_command(action: TokensAction) -> Result<()> {
                     std::process::exit(select::EX_CONFIG);
                 }
             }
+        }
+
+        TokensAction::Bootstrap {
+            workspace,
+            env,
+            home_env,
+            no_home,
+            shared,
+            force,
+            dry_run,
+            json,
+        } => {
+            use loom_daemon::tokens_pool::bootstrap::{self, BootstrapError, BootstrapOptions};
+            use loom_daemon::tokens_pool::paths::shared_tokens_dir;
+
+            let repo_root = resolve_tokens_workspace(&workspace)?;
+
+            // `--shared` redirects the destination pool to the machine-level
+            // location (issue #3938). Only the write target changes; account
+            // sources are unchanged. Refuse when the shared pool is disabled.
+            let tokens_dir = if shared {
+                match shared_tokens_dir() {
+                    Some(dir) => {
+                        eprintln!(
+                            "Bootstrapping the shared machine-level pool at {}",
+                            dir.display()
+                        );
+                        Some(dir)
+                    }
+                    None => {
+                        eprintln!(
+                            "error: --shared requested but the shared pool is disabled \
+                             (LOOM_SHARED_TOKENS_DIR is empty). Unset it or point it at a directory."
+                        );
+                        std::process::exit(1);
+                    }
+                }
+            } else {
+                None
+            };
+
+            // `--no-home` disables the master; `--home-env` points elsewhere;
+            // neither falls through to default resolution ($LOOM_ACCOUNTS_ENV).
+            let home_env_path = if no_home {
+                Some(None)
+            } else {
+                home_env.map(|p| Some(std::path::PathBuf::from(p)))
+            };
+
+            let opts = BootstrapOptions {
+                repo_root,
+                env_path: env.map(std::path::PathBuf::from),
+                home_env_path,
+                force,
+                dry_run,
+                tokens_dir,
+            };
+
+            let result = match bootstrap::bootstrap_tokens(&opts) {
+                Ok(r) => r,
+                Err(e @ (BootstrapError::NoSource(_) | BootstrapError::DuplicateFile(_))) => {
+                    eprintln!("error: {e}");
+                    std::process::exit(1);
+                }
+                Err(BootstrapError::Io(e)) => return Err(anyhow!("bootstrap failed: {e}")),
+            };
+
+            // Warnings (partial triples, drift, unreadable tokens) go to stderr
+            // so `--json` stdout stays clean.
+            for w in &result.warnings {
+                eprintln!("warning: {w}");
+            }
+
+            if json {
+                println!("{}", serde_json::to_string_pretty(&result.to_json())?);
+            } else {
+                print_effective_accounts(&result);
+            }
+
+            // Unresolved drift without --force is a non-zero exit so CI can
+            // detect divergence (mirrors cli._cmd_bootstrap).
+            if !result.drifted.is_empty() && !force {
+                std::process::exit(2);
+            }
+            Ok(())
         }
 
         TokensAction::Check {

--- a/loom-daemon/src/tokens_pool/bootstrap.rs
+++ b/loom-daemon/src/tokens_pool/bootstrap.rs
@@ -1,0 +1,1363 @@
+//! Materialize the multi-account OAuth token pool from account sources.
+//!
+//! Native Rust port of `loom_tools.tokens.bootstrap` (issue #4105, epic #4081
+//! "eliminate Python from Loom", Phase 1, child B). Reads numbered
+//! `ACCOUNT_EMAIL_N` / `ACCOUNT_KEY_N` / `ACCOUNT_TOKEN_FILE_N` triples and
+//! materializes them as per-account `.token` files inside `.loom/tokens/`,
+//! writing an `index.json` manifest with sha256 fingerprints (truncated to 8
+//! chars) so drift between the source and on-disk state can be detected
+//! without storing secret material.
+//!
+//! # Additive multi-source merge (#3695, #3698)
+//!
+//! Accounts are read from up to three sources and merged **by account email**
+//! (case-insensitive) so a set of Claude accounts can be declared **once** and
+//! shared across every workspace. In **precedence order, highest first**:
+//!
+//! 1. **claude-monitor master (#3698)** — `~/.claude-monitor/accounts.env` when
+//!    present (dir via [`super::monitor::claude_monitor_dir`], overridable with
+//!    `LOOM_CLAUDE_MONITOR_DIR`). EMAIL+KEY-only entries auto-derive their token
+//!    filename (see [`derive_token_filename`]). Soft dependency: pure file
+//!    detection, no import of any claude-monitor package.
+//! 2. **Home master (#3695)** — **opt-in only** (#3704). Consulted only when
+//!    `LOOM_ACCOUNTS_ENV` (or `--home-env`) points at a file; unset means the
+//!    home master is not auto-read (no default location).
+//! 3. **Repo-local** — `<repo>/.loom/accounts.env` if present, else the legacy
+//!    `<repo>/.env` (override with `--env`).
+//!
+//! An entry whose email appears in a higher-precedence source **overrides** the
+//! lower one; an entry with a new email **adds** to the pool. Absent the
+//! claude-monitor file, resolution is byte-for-byte identical to the #3695
+//! home+repo merge (repo overrides home).
+//!
+//! # Byte-compatible `index.json` (hard requirement)
+//!
+//! `index.json` must parse identically whether written by Python or Rust, since
+//! both implementations coexist until epic #4081 Phase 4. The manifest is
+//! `INDEX_VERSION = 2`, carries only email / filename / source / 8-char
+//! fingerprint (never secret material), and is written atomically. The
+//! conformance suite `loom-tools/tests/tokens/test_rust_conformance.py` diffs
+//! the effective merged set and the `index.json` accounts array across both
+//! CLIs.
+//!
+//! # Reuse surface (#4106)
+//!
+//! [`Account`], [`materialize_accounts`], and [`write_index`] are `pub` with a
+//! stable signature so the `import-from-monitor` port (issue #4106) can reuse
+//! this writer directly rather than hand-rolling a second one that could drift
+//! on the security-relevant details (atomic write-then-rename, `0600`/`0700`
+//! modes, fingerprint-based drift detection).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use regex::Regex;
+use sha2::{Digest, Sha256};
+
+use super::monitor::claude_monitor_dir;
+
+/// `index.json` schema version (mirrors `bootstrap.INDEX_VERSION`).
+pub const INDEX_VERSION: i64 = 2;
+/// Pool directory mode (`0700`).
+const DIR_MODE: u32 = 0o700;
+/// Per-token file mode (`0600`).
+const FILE_MODE: u32 = 0o600;
+
+/// Env var naming the opt-in home master accounts file (#3695/#3704).
+pub const HOME_ACCOUNTS_ENV_VAR: &str = "LOOM_ACCOUNTS_ENV";
+/// Filename of claude-monitor's master accounts file inside its dir (#3698).
+const MONITOR_ACCOUNTS_ENV_NAME: &str = "accounts.env";
+
+// Regexes are compiled lazily per call site. bootstrap runs at most a handful
+// of times per invocation, so a `once_cell`/`LazyLock` cache buys nothing and
+// would add ceremony; matching `check.rs`'s no-new-machinery house style.
+
+/// `ACCOUNT_<FIELD>_<N>=<value>` — FIELD is one of the triple keys, N is 1+
+/// digits, anchored to the start of the (already left-trimmed) line.
+fn env_line_re() -> Regex {
+    Regex::new(r"^ACCOUNT_(EMAIL|KEY|TOKEN_FILE)_(\d+)\s*=\s*(.*)$").unwrap()
+}
+
+/// Filename safety: lowercase/uppercase letters, digits, dot, dash, underscore;
+/// must end with `.token`.
+fn token_file_re() -> Regex {
+    Regex::new(r"^[A-Za-z0-9._-]+\.token$").unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Filename derivation (#3697)
+// ---------------------------------------------------------------------------
+
+/// Derive a safe `<name>.token` filename from an account email (#3697).
+///
+/// Convention (stable so account identities don't churn): strip dots and
+/// hyphens from the local-part, append `-<first-domain-label>`, lowercase, then
+/// drop any remaining unsafe character. Examples:
+///
+/// * `alice@example.com`     -> `alice-example.token`
+/// * `a.b.jones@example.org` -> `abjones-example.token`
+/// * `agent-1@example.com`   -> `agent1-example.token`
+///
+/// The result always matches [`token_file_re`]. Two *distinct* emails can still
+/// derive the same stem; that true collision is caught by the duplicate-filename
+/// guard in [`bootstrap_tokens`], not silently merged.
+#[must_use]
+pub fn derive_token_filename(email: &str) -> String {
+    let strip_local = Regex::new(r"[.-]").unwrap();
+    let strip_unsafe = Regex::new(r"[^A-Za-z0-9._-]").unwrap();
+
+    let email = email.trim();
+    let (local, domain) = match email.split_once('@') {
+        Some((l, d)) => (l, Some(d)),
+        None => (email, None),
+    };
+    let local_clean = strip_local.replace_all(local, "");
+    let domain_label = domain
+        .map(|d| d.split('.').next().unwrap_or(""))
+        .unwrap_or("");
+    let stem = if domain_label.is_empty() {
+        local_clean.to_string()
+    } else {
+        format!("{local_clean}-{domain_label}")
+    };
+    let stem = strip_unsafe
+        .replace_all(&stem.to_lowercase(), "")
+        .to_string();
+    let stem = if stem.is_empty() {
+        "account".to_string()
+    } else {
+        stem
+    };
+    format!("{stem}.token")
+}
+
+// ---------------------------------------------------------------------------
+// .env parsing
+// ---------------------------------------------------------------------------
+
+/// Strip surrounding quotes and embedded newlines/quotes from a value.
+///
+/// Mirrors `bootstrap._strip_value`: drop a single matching pair of surrounding
+/// quotes, then remove embedded newlines and stray quotes.
+fn strip_value(raw: &str) -> String {
+    let s = raw.trim();
+    let bytes = s.as_bytes();
+    let s = if bytes.len() >= 2 {
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if first == last && (first == b'\'' || first == b'"') {
+            &s[1..s.len() - 1]
+        } else {
+            s
+        }
+    } else {
+        s
+    };
+    s.replace(['\n', '\r', '\'', '"'], "")
+}
+
+/// A partially-parsed `ACCOUNT_*_N` triple (any subset of fields may be set).
+#[derive(Default, Clone)]
+struct ParsedTriple {
+    email: Option<String>,
+    key: Option<String>,
+    file: Option<String>,
+}
+
+/// Parse `env_path` and return `{N: ParsedTriple}` keyed by account index.
+///
+/// Lines that don't match the `ACCOUNT_*_N=` pattern are ignored (this is not a
+/// general-purpose `.env` parser). Partial triples are returned as-is so the
+/// caller can warn and skip them. Mirrors `bootstrap.parse_env_accounts`.
+fn parse_env_accounts(env_path: &Path) -> BTreeMap<u32, ParsedTriple> {
+    let mut accounts: BTreeMap<u32, ParsedTriple> = BTreeMap::new();
+    let text = match std::fs::read_to_string(env_path) {
+        Ok(t) => t,
+        Err(_) => return accounts,
+    };
+    let re = env_line_re();
+
+    for line in text.lines() {
+        let stripped = line.trim_start();
+        if stripped.is_empty() || stripped.starts_with('#') {
+            continue;
+        }
+        let caps = match re.captures(stripped) {
+            Some(c) => c,
+            None => continue,
+        };
+        let field = &caps[1];
+        let n: u32 = match caps[2].parse() {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let value = strip_value(&caps[3]);
+        let entry = accounts.entry(n).or_default();
+        match field {
+            "EMAIL" => entry.email = Some(value),
+            "KEY" => entry.key = Some(value),
+            "TOKEN_FILE" => entry.file = Some(value),
+            _ => {}
+        }
+    }
+    accounts
+}
+
+// ---------------------------------------------------------------------------
+// Source resolution + merge (#3695, #3698)
+// ---------------------------------------------------------------------------
+
+/// A single validated account triple with its provenance.
+///
+/// `source` is one of `"home"`, `"repo"`, `"repo-override"`, `"monitor"`, or
+/// `"monitor-override"` (see `bootstrap.Account` for the full semantics).
+///
+/// Public and stable so the `import-from-monitor` port (#4106) reuses it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Account {
+    pub email: String,
+    pub key: String,
+    pub file: String,
+    pub source: String,
+    /// Source index N, for reporting/ordering.
+    pub index: u32,
+}
+
+/// Resolve the opt-in home-dir master accounts file (#3695, retired as default
+/// #3704). Mirrors `bootstrap.default_home_accounts_env`.
+///
+/// Returns the resolved path (which may not exist on disk) when
+/// `LOOM_ACCOUNTS_ENV` names a non-empty path, else `None` (the master is
+/// opt-in only: no default location).
+fn default_home_accounts_env() -> Option<PathBuf> {
+    match std::env::var(HOME_ACCOUNTS_ENV_VAR) {
+        Ok(v) => {
+            if v.trim().is_empty() {
+                None
+            } else {
+                Some(expand_tilde(&v))
+            }
+        }
+        Err(_) => None,
+    }
+}
+
+/// Resolve claude-monitor's master accounts file (#3698):
+/// `<claude-monitor-dir>/accounts.env`. The path may not exist on disk.
+fn default_claude_monitor_accounts_env() -> PathBuf {
+    claude_monitor_dir().join(MONITOR_ACCOUNTS_ENV_NAME)
+}
+
+/// Resolve the repo-local accounts source path (#3695). Mirrors
+/// `bootstrap.resolve_repo_env`.
+///
+/// Precedence: explicit `env_path` (`--env`), else `<repo>/.loom/accounts.env`
+/// if it exists, else `<repo>/.env` (returned even when absent so the caller can
+/// report it).
+fn resolve_repo_env(repo_root: &Path, env_path: Option<&Path>) -> PathBuf {
+    if let Some(p) = env_path {
+        return p.to_path_buf();
+    }
+    let dedicated = repo_root.join(".loom").join("accounts.env");
+    if dedicated.is_file() {
+        return dedicated;
+    }
+    repo_root.join(".env")
+}
+
+/// Minimal `~`/`~/` expansion (Python's `Path.expanduser()` equivalent).
+fn expand_tilde(raw: &str) -> PathBuf {
+    if let Some(rest) = raw.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+    } else if raw == "~" {
+        if let Some(home) = dirs::home_dir() {
+            return home;
+        }
+    }
+    PathBuf::from(raw)
+}
+
+/// A warning message surfaced during a bootstrap run (partial triple, unsafe
+/// filename, drift, duplicate filename). Collected rather than logged inline so
+/// the CLI arm owns presentation and JSON stays clean on stdout.
+pub type Warning = String;
+
+/// Validate parsed triples and return complete, safe [`Account`]s. Incomplete
+/// triples and unsafe token filenames are recorded as warnings and skipped.
+/// Mirrors `bootstrap._assemble_valid_accounts`.
+fn assemble_valid_accounts(
+    accounts: &BTreeMap<u32, ParsedTriple>,
+    source: &str,
+    warnings: &mut Vec<Warning>,
+) -> Vec<Account> {
+    let file_re = token_file_re();
+    let mut out: Vec<Account> = Vec::new();
+    for (&n, triple) in accounts {
+        // Auto-derive the token filename from the email when omitted (#3697).
+        let file = match (&triple.file, &triple.email) {
+            (Some(f), _) if !f.is_empty() => Some(f.clone()),
+            (_, Some(e)) if !e.is_empty() => Some(derive_token_filename(e)),
+            (f, _) => f.clone(),
+        };
+
+        let email_ok = triple.email.as_deref().is_some_and(|s| !s.is_empty());
+        let key_ok = triple.key.as_deref().is_some_and(|s| !s.is_empty());
+        let file_ok = file.as_deref().is_some_and(|s| !s.is_empty());
+
+        if !email_ok || !key_ok || !file_ok {
+            let mut missing: Vec<&str> = Vec::new();
+            if !email_ok {
+                missing.push("email");
+            }
+            if !file_ok {
+                missing.push("file");
+            }
+            if !key_ok {
+                missing.push("key");
+            }
+            missing.sort_unstable();
+            warnings.push(format!(
+                "[{source}] ACCOUNT_*_{n}: incomplete triple (missing: {}); skipping.",
+                missing.join(", ")
+            ));
+            continue;
+        }
+
+        let filename = file.unwrap();
+        if !file_re.is_match(&filename) || filename.contains('/') || filename.contains('\\') {
+            warnings.push(format!(
+                "[{source}] ACCOUNT_TOKEN_FILE_{n}={filename:?}: unsafe filename; skipping."
+            ));
+            continue;
+        }
+
+        out.push(Account {
+            email: triple.email.clone().unwrap(),
+            key: triple.key.clone().unwrap(),
+            file: filename,
+            source: source.to_string(),
+            index: n,
+        });
+    }
+    out
+}
+
+/// Merge the `over` accounts **on top of** the `base` accounts, by email.
+/// Mirrors `bootstrap.merge_accounts`.
+///
+/// An email present only in `base` is inherited; present only in `over` is
+/// added; present in both means the `over` entry wins and is retagged
+/// `source=override_label` while keeping `base`'s position. Ordering: base
+/// accounts first (in base order), then over-only additions (in over order).
+fn merge_accounts(base: &[Account], over: &[Account], override_label: &str) -> Vec<Account> {
+    fn key(acct: &Account) -> String {
+        acct.email.trim().to_lowercase()
+    }
+
+    let mut merged: BTreeMap<String, Account> = BTreeMap::new();
+    let mut order: Vec<String> = Vec::new();
+    for acct in base {
+        let k = key(acct);
+        if !merged.contains_key(&k) {
+            order.push(k.clone());
+        }
+        merged.insert(k, acct.clone()); // last base entry for a dup email wins
+    }
+
+    for acct in over {
+        let k = key(acct);
+        match merged.entry(k.clone()) {
+            std::collections::btree_map::Entry::Occupied(mut e) => {
+                // Override in place, preserving position but recording provenance.
+                e.insert(Account {
+                    email: acct.email.clone(),
+                    key: acct.key.clone(),
+                    file: acct.file.clone(),
+                    source: override_label.to_string(),
+                    index: acct.index,
+                });
+            }
+            std::collections::btree_map::Entry::Vacant(e) => {
+                order.push(k);
+                e.insert(acct.clone());
+            }
+        }
+    }
+
+    order.into_iter().map(|k| merged[&k].clone()).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Fingerprinting + manifest
+// ---------------------------------------------------------------------------
+
+/// Return the first 8 hex chars of sha256(secret). Used in `index.json` for
+/// drift detection; **never** stores the secret itself. Mirrors
+/// `bootstrap.fingerprint`.
+#[must_use]
+pub fn fingerprint(secret: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(secret.as_bytes());
+    let full = hex::encode(hasher.finalize());
+    full[..8].to_string()
+}
+
+fn now_iso() -> String {
+    chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}
+
+/// Strip the trailing `.token` suffix to derive a logical account name.
+fn name_from_file(filename: &str) -> String {
+    if filename.to_lowercase().ends_with(".token") {
+        filename[..filename.len() - ".token".len()].to_string()
+    } else {
+        filename.to_string()
+    }
+}
+
+#[cfg(unix)]
+fn chmod_best_effort(path: &Path, mode: u32) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode));
+}
+
+#[cfg(not(unix))]
+fn chmod_best_effort(_path: &Path, _mode: u32) {}
+
+// ---------------------------------------------------------------------------
+// Materialize + write
+// ---------------------------------------------------------------------------
+
+/// One manifest row for `index.json` (never contains secret material).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManifestRow {
+    pub env_index: u32,
+    pub name: String,
+    pub email: String,
+    pub file: String,
+    pub source: String,
+    pub key_fingerprint: String,
+    /// Set on a drifted row: the source (env) fingerprint that disagreed with
+    /// the on-disk one recorded in `key_fingerprint`.
+    pub drift: bool,
+    pub env_fingerprint: Option<String>,
+}
+
+impl ManifestRow {
+    fn to_json(&self) -> serde_json::Value {
+        let mut obj = serde_json::Map::new();
+        obj.insert("env_index".into(), serde_json::json!(self.env_index));
+        obj.insert("name".into(), serde_json::json!(self.name));
+        obj.insert("email".into(), serde_json::json!(self.email));
+        obj.insert("file".into(), serde_json::json!(self.file));
+        obj.insert("source".into(), serde_json::json!(self.source));
+        obj.insert("key_fingerprint".into(), serde_json::json!(self.key_fingerprint));
+        if self.drift {
+            obj.insert("drift".into(), serde_json::json!(true));
+            obj.insert("env_fingerprint".into(), serde_json::json!(self.env_fingerprint));
+        }
+        serde_json::Value::Object(obj)
+    }
+}
+
+/// Per-file disposition from [`materialize_accounts`]. Mirrors
+/// `bootstrap.MaterializeOutcome`.
+#[derive(Debug, Clone, Default)]
+pub struct MaterializeOutcome {
+    pub written: Vec<String>,
+    pub unchanged: Vec<String>,
+    pub drifted: Vec<String>,
+    /// Manifest rows for `index.json` (never contains secret material).
+    pub manifest_accounts: Vec<ManifestRow>,
+}
+
+/// Write each account's key to `<tokens_dir>/<file>` and build manifest rows.
+/// Mirrors `bootstrap.materialize_accounts`.
+///
+/// Drift (an on-disk token whose fingerprint differs from the source) is
+/// reported and **skipped** unless `force`. Atomic write-then-rename with
+/// `0600` files inside a `0700` dir.
+///
+/// Public and stable so the `import-from-monitor` port (#4106) materializes
+/// pools through this same writer.
+pub fn materialize_accounts(
+    accounts: &[Account],
+    tokens_dir: &Path,
+    force: bool,
+    dry_run: bool,
+    warnings: &mut Vec<Warning>,
+) -> std::io::Result<MaterializeOutcome> {
+    if !dry_run {
+        std::fs::create_dir_all(tokens_dir)?;
+        chmod_best_effort(tokens_dir, DIR_MODE);
+    }
+
+    let mut outcome = MaterializeOutcome::default();
+
+    for acct in accounts {
+        let token_path = tokens_dir.join(&acct.file);
+        let new_fp = fingerprint(&acct.key);
+
+        let existing_fp: Option<String> = if token_path.exists() {
+            match std::fs::read_to_string(&token_path) {
+                Ok(existing) => Some(fingerprint(existing.trim_end_matches('\n'))),
+                Err(e) => {
+                    warnings.push(format!(
+                        "Could not read {}: {e}; will rewrite.",
+                        token_path.display()
+                    ));
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        // action: "written" | "unchanged" | "drifted"
+        let action = match &existing_fp {
+            None => "written",
+            Some(fp) if *fp == new_fp => {
+                if force {
+                    "written"
+                } else {
+                    "unchanged"
+                }
+            }
+            Some(_) => "drifted",
+        };
+
+        if action == "drifted" && !force {
+            let disk_fp = existing_fp.clone().unwrap_or_default();
+            warnings.push(format!(
+                "DRIFT: {} on disk does not match the account source \
+                 (disk fp={disk_fp}, source fp={new_fp}); re-run with --force to overwrite.",
+                acct.file
+            ));
+            outcome.drifted.push(acct.file.clone());
+            outcome.manifest_accounts.push(ManifestRow {
+                env_index: acct.index,
+                name: name_from_file(&acct.file),
+                email: acct.email.clone(),
+                file: acct.file.clone(),
+                source: acct.source.clone(),
+                key_fingerprint: disk_fp,
+                drift: true,
+                env_fingerprint: Some(new_fp),
+            });
+            continue;
+        }
+
+        if action == "unchanged" {
+            outcome.unchanged.push(acct.file.clone());
+        } else {
+            // written (new file or force-overwrite)
+            if !dry_run {
+                let tmp = token_path.with_file_name(format!("{}.tmp", acct.file));
+                std::fs::write(&tmp, &acct.key)?;
+                chmod_best_effort(&tmp, FILE_MODE);
+                std::fs::rename(&tmp, &token_path)?;
+                chmod_best_effort(&token_path, FILE_MODE);
+            }
+            outcome.written.push(acct.file.clone());
+        }
+
+        outcome.manifest_accounts.push(ManifestRow {
+            env_index: acct.index,
+            name: name_from_file(&acct.file),
+            email: acct.email.clone(),
+            file: acct.file.clone(),
+            source: acct.source.clone(),
+            key_fingerprint: new_fp,
+            drift: false,
+            env_fingerprint: None,
+        });
+    }
+
+    Ok(outcome)
+}
+
+/// Atomically write the `index.json` manifest beside the pool. Mirrors
+/// `bootstrap.write_index`. Carries only email / filename / source / 8-char
+/// fingerprint — [`fingerprint`] guarantees no secret material lands here.
+///
+/// Public and stable for reuse by the `import-from-monitor` port (#4106).
+pub fn write_index(
+    manifest_accounts: &[ManifestRow],
+    index_path: &Path,
+    dry_run: bool,
+) -> std::io::Result<()> {
+    let manifest = serde_json::json!({
+        "version": INDEX_VERSION,
+        "generated_at": now_iso(),
+        "accounts": manifest_accounts.iter().map(ManifestRow::to_json).collect::<Vec<_>>(),
+    });
+    if dry_run {
+        return Ok(());
+    }
+    if let Some(parent) = index_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let body = serde_json::to_string_pretty(&manifest)? + "\n";
+    let tmp = index_path.with_file_name(format!(
+        "{}.tmp",
+        index_path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("index.json")
+    ));
+    std::fs::write(&tmp, body)?;
+    std::fs::rename(&tmp, index_path)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Options for [`bootstrap_tokens`].
+pub struct BootstrapOptions {
+    /// Repo root (must contain `.loom/`).
+    pub repo_root: PathBuf,
+    /// Optional override for the repo-local source file (`--env`).
+    pub env_path: Option<PathBuf>,
+    /// Home master override (`--home-env`): `Some(Some(path))` points elsewhere,
+    /// `Some(None)` disables it (`--no-home`), `None` uses default resolution
+    /// (honoring `LOOM_ACCOUNTS_ENV`).
+    pub home_env_path: Option<Option<PathBuf>>,
+    /// Overwrite token files even when the fingerprint matches.
+    pub force: bool,
+    /// Compute dispositions without writing anything.
+    pub dry_run: bool,
+    /// Destination pool dir override (`--shared`). `None` = `<repo>/.loom/tokens`.
+    pub tokens_dir: Option<PathBuf>,
+}
+
+/// One entry in the effective merged account set (no secrets).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectiveAccount {
+    pub email: String,
+    pub name: String,
+    pub file: String,
+    pub source: String,
+}
+
+/// Outcome of a single [`bootstrap_tokens`] call. Mirrors
+/// `bootstrap.BootstrapResult`.
+#[derive(Debug, Clone, Default)]
+pub struct BootstrapResult {
+    pub written: Vec<String>,
+    pub unchanged: Vec<String>,
+    pub drifted: Vec<String>,
+    pub skipped: Vec<String>,
+    pub dry_run: bool,
+    pub tokens_dir: Option<PathBuf>,
+    pub index_path: Option<PathBuf>,
+    pub monitor_env: Option<PathBuf>,
+    pub home_env: Option<PathBuf>,
+    pub repo_env: Option<PathBuf>,
+    pub effective: Vec<EffectiveAccount>,
+    /// Non-fatal warnings accumulated during the run (partial triples, drift,
+    /// unreadable tokens). The CLI arm decides how to surface them.
+    pub warnings: Vec<Warning>,
+}
+
+impl BootstrapResult {
+    /// JSON shape matching `bootstrap.BootstrapResult.to_dict`.
+    #[must_use]
+    pub fn to_json(&self) -> serde_json::Value {
+        let path_str = |p: &Option<PathBuf>| match p {
+            Some(p) => serde_json::Value::String(p.display().to_string()),
+            None => serde_json::Value::Null,
+        };
+        serde_json::json!({
+            "written": self.written,
+            "unchanged": self.unchanged,
+            "drifted": self.drifted,
+            "skipped": self.skipped,
+            "dry_run": self.dry_run,
+            "tokens_dir": path_str(&self.tokens_dir),
+            "index_path": path_str(&self.index_path),
+            "monitor_env": path_str(&self.monitor_env),
+            "home_env": path_str(&self.home_env),
+            "repo_env": path_str(&self.repo_env),
+            "effective": self.effective.iter().map(|a| serde_json::json!({
+                "email": a.email,
+                "name": a.name,
+                "file": a.file,
+                "source": a.source,
+            })).collect::<Vec<_>>(),
+        })
+    }
+}
+
+/// Error from [`bootstrap_tokens`]. Mirrors the Python `FileNotFoundError` /
+/// `ValueError` split so the CLI arm can map exit codes.
+#[derive(Debug)]
+pub enum BootstrapError {
+    /// Neither the monitor, home, nor repo-local source exists on disk.
+    NoSource(String),
+    /// Two effective accounts resolve to the same token filename.
+    DuplicateFile(String),
+    /// An IO failure while materializing the pool.
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for BootstrapError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoSource(m) | Self::DuplicateFile(m) => write!(f, "{m}"),
+            Self::Io(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for BootstrapError {}
+
+impl From<std::io::Error> for BootstrapError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+/// Bootstrap `.loom/tokens/` from the merged account sources (#3695, #3698).
+/// Mirrors `bootstrap.bootstrap_tokens`.
+pub fn bootstrap_tokens(opts: &BootstrapOptions) -> Result<BootstrapResult, BootstrapError> {
+    // Destination pool dir: the repo-local pool by default, or an explicit
+    // override (e.g. the shared machine-level pool for `--shared`, #3938).
+    let tokens_dir = opts
+        .tokens_dir
+        .clone()
+        .unwrap_or_else(|| opts.repo_root.join(".loom").join("tokens"));
+    let index_path = tokens_dir.join("index.json");
+
+    // Resolve the sources. `home_env_path` uses a nested Option so an explicit
+    // disable (`Some(None)`) is distinguishable from an omitted arg (`None`).
+    let home_file: Option<PathBuf> = match &opts.home_env_path {
+        None => default_home_accounts_env(),
+        Some(explicit) => explicit.clone(),
+    };
+    let repo_file = resolve_repo_env(&opts.repo_root, opts.env_path.as_deref());
+    let monitor_file = default_claude_monitor_accounts_env();
+
+    let mut result = BootstrapResult {
+        dry_run: opts.dry_run,
+        tokens_dir: Some(tokens_dir.clone()),
+        index_path: Some(index_path.clone()),
+        ..Default::default()
+    };
+
+    let monitor_present = monitor_file.is_file();
+    let home_present = home_file.as_deref().is_some_and(Path::is_file);
+    let repo_present = repo_file.is_file();
+
+    result.monitor_env = monitor_present.then(|| monitor_file.clone());
+    result.home_env = if home_present {
+        home_file.clone()
+    } else {
+        None
+    };
+    result.repo_env = repo_present.then(|| repo_file.clone());
+
+    if !monitor_present && !home_present && !repo_present {
+        let home_disp = home_file
+            .as_ref()
+            .map_or_else(|| "(disabled)".to_string(), |p| p.display().to_string());
+        return Err(BootstrapError::NoSource(format!(
+            "No account source found. Looked for a repo-local source at {}, a home master at \
+             {home_disp}, and a claude-monitor master at {}. Declare accounts in one of them \
+             (see `loom-daemon tokens bootstrap --help`).",
+            repo_file.display(),
+            monitor_file.display(),
+        )));
+    }
+
+    let mut warnings: Vec<Warning> = Vec::new();
+
+    let monitor_accounts = if monitor_present {
+        assemble_valid_accounts(&parse_env_accounts(&monitor_file), "monitor", &mut warnings)
+    } else {
+        Vec::new()
+    };
+    let home_accounts = if home_present {
+        assemble_valid_accounts(
+            &parse_env_accounts(home_file.as_deref().unwrap()),
+            "home",
+            &mut warnings,
+        )
+    } else {
+        Vec::new()
+    };
+    let repo_accounts = if repo_present {
+        assemble_valid_accounts(&parse_env_accounts(&repo_file), "repo", &mut warnings)
+    } else {
+        Vec::new()
+    };
+
+    // Three-source merge, precedence claude-monitor > repo > home. First layer
+    // repo over home (repo-override), then claude-monitor on top
+    // (monitor-override). Absent the monitor source the second merge is a no-op.
+    let home_repo = merge_accounts(&home_accounts, &repo_accounts, "repo-override");
+    let valid = merge_accounts(&home_repo, &monitor_accounts, "monitor-override");
+
+    result.effective = valid
+        .iter()
+        .map(|a| EffectiveAccount {
+            email: a.email.clone(),
+            name: name_from_file(&a.file),
+            file: a.file.clone(),
+            source: a.source.clone(),
+        })
+        .collect();
+
+    if valid.is_empty() {
+        let srcs: Vec<String> = [&result.monitor_env, &result.home_env, &result.repo_env]
+            .iter()
+            .filter_map(|p| p.as_ref().map(|p| p.display().to_string()))
+            .collect();
+        let where_ = if srcs.is_empty() {
+            "the account source(s)".to_string()
+        } else {
+            srcs.join(", ")
+        };
+        warnings
+            .push(format!("No complete ACCOUNT_*_N triples in {where_}; nothing to bootstrap."));
+        result.warnings = warnings;
+        return Ok(result);
+    }
+
+    // Detect duplicate filenames (would otherwise clobber each other) on the
+    // *merged* set.
+    let mut seen_files: BTreeMap<String, Account> = BTreeMap::new();
+    for acct in &valid {
+        if let Some(prior) = seen_files.get(&acct.file) {
+            let msg = format!(
+                "Duplicate ACCOUNT_TOKEN_FILE: {:?} maps to both {:?} ({}) and {:?} ({}); aborting.",
+                acct.file, prior.email, prior.source, acct.email, acct.source
+            );
+            warnings.push(msg);
+            result.warnings = warnings;
+            return Err(BootstrapError::DuplicateFile(format!(
+                "duplicate token filename: {}",
+                acct.file
+            )));
+        }
+        seen_files.insert(acct.file.clone(), acct.clone());
+    }
+
+    let outcome =
+        materialize_accounts(&valid, &tokens_dir, opts.force, opts.dry_run, &mut warnings)?;
+    result.written.extend(outcome.written.iter().cloned());
+    result.unchanged.extend(outcome.unchanged.iter().cloned());
+    result.drifted.extend(outcome.drifted.iter().cloned());
+
+    write_index(&outcome.manifest_accounts, &index_path, opts.dry_run)?;
+
+    if !result.drifted.is_empty() && !opts.force {
+        warnings.push(format!(
+            "{} token(s) drifted from the account source; re-run with --force to overwrite \
+             on-disk values.",
+            result.drifted.len()
+        ));
+    }
+
+    result.warnings = warnings;
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    // ---- derive_token_filename ----------------------------------------
+
+    #[test]
+    fn derive_filename_examples() {
+        assert_eq!(derive_token_filename("alice@example.com"), "alice-example.token");
+        assert_eq!(derive_token_filename("a.b.jones@example.org"), "abjones-example.token");
+        assert_eq!(derive_token_filename("agent-1@example.com"), "agent1-example.token");
+    }
+
+    #[test]
+    fn derive_filename_no_domain() {
+        assert_eq!(derive_token_filename("solo"), "solo.token");
+    }
+
+    #[test]
+    fn derive_filename_empty_falls_back_to_account() {
+        assert_eq!(derive_token_filename("@"), "account.token");
+    }
+
+    #[test]
+    fn derive_filename_always_matches_safe_re() {
+        let re = token_file_re();
+        for e in ["Weird Name!@Example.Com", "x+y@z.io", "员工@公司.cn"] {
+            assert!(re.is_match(&derive_token_filename(e)), "unsafe for {e}");
+        }
+    }
+
+    // ---- strip_value --------------------------------------------------
+
+    #[test]
+    fn strip_value_removes_surrounding_quotes() {
+        assert_eq!(strip_value("  'sk-ant-oat01-x'  "), "sk-ant-oat01-x");
+        assert_eq!(strip_value("\"quoted\""), "quoted");
+    }
+
+    #[test]
+    fn strip_value_removes_embedded_newlines_and_quotes() {
+        assert_eq!(strip_value("ab\ncd\"ef"), "abcdef");
+    }
+
+    // ---- parse_env_accounts + triple parsing --------------------------
+
+    #[test]
+    fn parse_full_and_partial_triples() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = tmp.path().join(".env");
+        fs::write(
+            &env,
+            "# comment\n\
+             ACCOUNT_EMAIL_1=alice@example.com\n\
+             ACCOUNT_KEY_1=sk-ant-oat01-a\n\
+             ACCOUNT_TOKEN_FILE_1=alice.token\n\
+             ACCOUNT_EMAIL_2=bob@example.com\n\
+             ACCOUNT_KEY_3=orphan-key\n\
+             NOT_AN_ACCOUNT=ignored\n",
+        )
+        .unwrap();
+        let parsed = parse_env_accounts(&env);
+        assert_eq!(parsed.len(), 3);
+        assert_eq!(parsed[&1].email.as_deref(), Some("alice@example.com"));
+        assert_eq!(parsed[&1].file.as_deref(), Some("alice.token"));
+        // Partial triples preserved as-is.
+        assert_eq!(parsed[&2].email.as_deref(), Some("bob@example.com"));
+        assert!(parsed[&2].key.is_none());
+        assert!(parsed[&3].email.is_none());
+    }
+
+    #[test]
+    fn parse_gap_tolerant_indices() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = tmp.path().join(".env");
+        fs::write(
+            &env,
+            "ACCOUNT_EMAIL_1=a@x.com\nACCOUNT_KEY_1=k1\n\
+             ACCOUNT_EMAIL_5=b@x.com\nACCOUNT_KEY_5=k5\n",
+        )
+        .unwrap();
+        let parsed = parse_env_accounts(&env);
+        let keys: Vec<u32> = parsed.keys().copied().collect();
+        assert_eq!(keys, vec![1, 5]);
+    }
+
+    #[test]
+    fn assemble_warns_on_partial_triple() {
+        let mut accounts: BTreeMap<u32, ParsedTriple> = BTreeMap::new();
+        accounts.insert(
+            1,
+            ParsedTriple {
+                email: Some("a@x.com".into()),
+                key: None,
+                file: Some("a.token".into()),
+            },
+        );
+        let mut warnings = Vec::new();
+        let out = assemble_valid_accounts(&accounts, "repo", &mut warnings);
+        assert!(out.is_empty());
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("incomplete triple"));
+        assert!(warnings[0].contains("missing: key"));
+    }
+
+    #[test]
+    fn assemble_auto_derives_filename_from_email() {
+        let mut accounts: BTreeMap<u32, ParsedTriple> = BTreeMap::new();
+        accounts.insert(
+            1,
+            ParsedTriple {
+                email: Some("carol@example.com".into()),
+                key: Some("sk-ant-oat01-c".into()),
+                file: None,
+            },
+        );
+        let mut warnings = Vec::new();
+        let out = assemble_valid_accounts(&accounts, "monitor", &mut warnings);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].file, "carol-example.token");
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn assemble_rejects_unsafe_filename() {
+        let mut accounts: BTreeMap<u32, ParsedTriple> = BTreeMap::new();
+        accounts.insert(
+            1,
+            ParsedTriple {
+                email: Some("a@x.com".into()),
+                key: Some("k".into()),
+                file: Some("../evil.token".into()),
+            },
+        );
+        let mut warnings = Vec::new();
+        let out = assemble_valid_accounts(&accounts, "repo", &mut warnings);
+        assert!(out.is_empty());
+        assert!(warnings[0].contains("unsafe filename"));
+    }
+
+    // ---- merge precedence ---------------------------------------------
+
+    fn acct(email: &str, key: &str, file: &str, source: &str, index: u32) -> Account {
+        Account {
+            email: email.into(),
+            key: key.into(),
+            file: file.into(),
+            source: source.into(),
+            index,
+        }
+    }
+
+    #[test]
+    fn merge_repo_overrides_home() {
+        let home = vec![acct("a@x.com", "home-key", "a.token", "home", 1)];
+        let repo = vec![acct("a@x.com", "repo-key", "a.token", "repo", 1)];
+        let merged = merge_accounts(&home, &repo, "repo-override");
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].key, "repo-key");
+        assert_eq!(merged[0].source, "repo-override");
+    }
+
+    #[test]
+    fn merge_three_source_precedence_monitor_wins() {
+        let home = vec![acct("a@x.com", "hk", "a.token", "home", 1)];
+        let repo = vec![acct("a@x.com", "rk", "a.token", "repo", 1)];
+        let monitor = vec![acct("a@x.com", "mk", "a.token", "monitor", 1)];
+        let home_repo = merge_accounts(&home, &repo, "repo-override");
+        let valid = merge_accounts(&home_repo, &monitor, "monitor-override");
+        assert_eq!(valid.len(), 1);
+        assert_eq!(valid[0].key, "mk");
+        assert_eq!(valid[0].source, "monitor-override");
+    }
+
+    #[test]
+    fn merge_adds_new_emails_and_is_case_insensitive() {
+        let home = vec![acct("A@x.com", "hk", "a.token", "home", 1)];
+        let repo = vec![
+            acct("a@x.com", "rk", "a.token", "repo", 1),
+            acct("b@x.com", "rk2", "b.token", "repo", 2),
+        ];
+        let merged = merge_accounts(&home, &repo, "repo-override");
+        // "A@x.com" and "a@x.com" collapse; b is added.
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].source, "repo-override");
+        assert_eq!(merged[1].email, "b@x.com");
+    }
+
+    // ---- fingerprint --------------------------------------------------
+
+    #[test]
+    fn fingerprint_is_8_hex_chars() {
+        let fp = fingerprint("sk-ant-oat01-secret");
+        assert_eq!(fp.len(), 8);
+        assert!(fp.chars().all(|c| c.is_ascii_hexdigit()));
+        // Stable value (sha256("x")[:8]).
+        assert_eq!(fingerprint("x"), "2d711642");
+    }
+
+    // ---- materialize + index.json -------------------------------------
+
+    #[cfg(unix)]
+    #[test]
+    fn materialize_writes_0600_files_in_0700_dir() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("tokens");
+        let accts = vec![acct("a@x.com", "sk-ant-oat01-a", "a.token", "repo", 1)];
+        let mut warnings = Vec::new();
+        let outcome = materialize_accounts(&accts, &dir, false, false, &mut warnings).unwrap();
+        assert_eq!(outcome.written, vec!["a.token"]);
+        let token = dir.join("a.token");
+        assert_eq!(fs::read_to_string(&token).unwrap(), "sk-ant-oat01-a");
+        let fmode = fs::metadata(&token).unwrap().permissions().mode() & 0o777;
+        let dmode = fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(fmode, 0o600);
+        assert_eq!(dmode, 0o700);
+        // No leftover temp file.
+        assert!(!dir.join("a.token.tmp").exists());
+    }
+
+    #[test]
+    fn materialize_dry_run_writes_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("tokens");
+        let accts = vec![acct("a@x.com", "k", "a.token", "repo", 1)];
+        let mut warnings = Vec::new();
+        let outcome = materialize_accounts(&accts, &dir, false, true, &mut warnings).unwrap();
+        assert_eq!(outcome.written, vec!["a.token"]);
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn materialize_unchanged_on_fingerprint_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("tokens");
+        let accts = vec![acct("a@x.com", "k", "a.token", "repo", 1)];
+        let mut warnings = Vec::new();
+        materialize_accounts(&accts, &dir, false, false, &mut warnings).unwrap();
+        let outcome = materialize_accounts(&accts, &dir, false, false, &mut warnings).unwrap();
+        assert_eq!(outcome.unchanged, vec!["a.token"]);
+        assert!(outcome.written.is_empty());
+    }
+
+    #[test]
+    fn materialize_drift_skipped_without_force_reported_with_force() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("tokens");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("a.token"), "hand-edited-different").unwrap();
+        let accts = vec![acct("a@x.com", "sk-source", "a.token", "repo", 1)];
+
+        let mut w1 = Vec::new();
+        let no_force = materialize_accounts(&accts, &dir, false, false, &mut w1).unwrap();
+        assert_eq!(no_force.drifted, vec!["a.token"]);
+        assert!(no_force.written.is_empty());
+        assert!(no_force.manifest_accounts[0].drift);
+        // File untouched.
+        assert_eq!(fs::read_to_string(dir.join("a.token")).unwrap(), "hand-edited-different");
+
+        let mut w2 = Vec::new();
+        let forced = materialize_accounts(&accts, &dir, true, false, &mut w2).unwrap();
+        assert_eq!(forced.written, vec!["a.token"]);
+        assert_eq!(fs::read_to_string(dir.join("a.token")).unwrap(), "sk-source");
+    }
+
+    #[test]
+    fn write_index_v2_shape_no_secrets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("tokens");
+        fs::create_dir_all(&dir).unwrap();
+        let rows = vec![ManifestRow {
+            env_index: 1,
+            name: "alice-example".into(),
+            email: "alice@example.com".into(),
+            file: "alice-example.token".into(),
+            source: "repo".into(),
+            key_fingerprint: fingerprint("sk-ant-oat01-secret"),
+            drift: false,
+            env_fingerprint: None,
+        }];
+        let index_path = dir.join("index.json");
+        write_index(&rows, &index_path, false).unwrap();
+        let raw = fs::read_to_string(&index_path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(parsed["version"], 2);
+        assert!(parsed["generated_at"].is_string());
+        let acct = &parsed["accounts"][0];
+        assert_eq!(acct["key_fingerprint"].as_str().unwrap().len(), 8);
+        assert_eq!(acct["source"], "repo");
+        // No secret material anywhere in the file.
+        assert!(!raw.contains("sk-ant-oat01-secret"));
+        assert!(!index_path.with_file_name("index.json.tmp").exists());
+    }
+
+    // ---- bootstrap_tokens end-to-end ----------------------------------
+
+    fn scratch_repo(env_body: &str) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join(".loom")).unwrap();
+        fs::write(tmp.path().join(".env"), env_body).unwrap();
+        tmp
+    }
+
+    fn isolate_env() {
+        // Disable the home + monitor sources so tests never touch a real
+        // ~/.loom or ~/.claude-monitor.
+        std::env::set_var(HOME_ACCOUNTS_ENV_VAR, "");
+        std::env::set_var("LOOM_CLAUDE_MONITOR_DIR", "/nonexistent-monitor-xyz-4105");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn bootstrap_repo_only_writes_pool_and_index() {
+        isolate_env();
+        let repo = scratch_repo(
+            "ACCOUNT_EMAIL_1=alice@example.com\n\
+             ACCOUNT_KEY_1=sk-ant-oat01-a\n\
+             ACCOUNT_EMAIL_2=bob@example.com\n\
+             ACCOUNT_KEY_2=sk-ant-oat01-b\n",
+        );
+        let opts = BootstrapOptions {
+            repo_root: repo.path().to_path_buf(),
+            env_path: None,
+            home_env_path: None,
+            force: false,
+            dry_run: false,
+            tokens_dir: None,
+        };
+        let result = bootstrap_tokens(&opts).unwrap();
+        assert_eq!(result.written.len(), 2);
+        assert_eq!(result.effective.len(), 2);
+        // Filenames auto-derived from emails.
+        let files: Vec<&str> = result.effective.iter().map(|a| a.file.as_str()).collect();
+        assert!(files.contains(&"alice-example.token"));
+        assert!(files.contains(&"bob-example.token"));
+        let pool = repo.path().join(".loom").join("tokens");
+        assert!(pool.join("index.json").is_file());
+        assert!(pool.join("alice-example.token").is_file());
+        std::env::remove_var(HOME_ACCOUNTS_ENV_VAR);
+        std::env::remove_var("LOOM_CLAUDE_MONITOR_DIR");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn bootstrap_dry_run_writes_no_files() {
+        isolate_env();
+        let repo = scratch_repo("ACCOUNT_EMAIL_1=a@x.com\nACCOUNT_KEY_1=k\n");
+        let opts = BootstrapOptions {
+            repo_root: repo.path().to_path_buf(),
+            env_path: None,
+            home_env_path: None,
+            force: false,
+            dry_run: true,
+            tokens_dir: None,
+        };
+        let result = bootstrap_tokens(&opts).unwrap();
+        assert_eq!(result.effective.len(), 1);
+        assert!(!repo
+            .path()
+            .join(".loom")
+            .join("tokens")
+            .join("index.json")
+            .exists());
+        std::env::remove_var(HOME_ACCOUNTS_ENV_VAR);
+        std::env::remove_var("LOOM_CLAUDE_MONITOR_DIR");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn bootstrap_no_source_errors() {
+        isolate_env();
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join(".loom")).unwrap();
+        let opts = BootstrapOptions {
+            repo_root: tmp.path().to_path_buf(),
+            env_path: None,
+            home_env_path: None,
+            force: false,
+            dry_run: false,
+            tokens_dir: None,
+        };
+        match bootstrap_tokens(&opts) {
+            Err(BootstrapError::NoSource(_)) => {}
+            other => panic!("expected NoSource, got {other:?}"),
+        }
+        std::env::remove_var(HOME_ACCOUNTS_ENV_VAR);
+        std::env::remove_var("LOOM_CLAUDE_MONITOR_DIR");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn bootstrap_no_home_ignores_home_master() {
+        isolate_env();
+        let repo = scratch_repo("ACCOUNT_EMAIL_1=a@x.com\nACCOUNT_KEY_1=repo-key\n");
+        // Point a home master at a file that WOULD add an account, then disable
+        // it with home_env_path = Some(None).
+        let home = tempfile::tempdir().unwrap();
+        let home_env = home.path().join("accounts.env");
+        fs::write(&home_env, "ACCOUNT_EMAIL_1=h@x.com\nACCOUNT_KEY_1=home-key\n").unwrap();
+        std::env::set_var(HOME_ACCOUNTS_ENV_VAR, &home_env);
+
+        let opts = BootstrapOptions {
+            repo_root: repo.path().to_path_buf(),
+            env_path: None,
+            home_env_path: Some(None), // --no-home
+            force: false,
+            dry_run: true,
+            tokens_dir: None,
+        };
+        let result = bootstrap_tokens(&opts).unwrap();
+        // Only the repo account survives.
+        assert_eq!(result.effective.len(), 1);
+        assert_eq!(result.effective[0].email, "a@x.com");
+        assert!(result.home_env.is_none());
+        std::env::remove_var(HOME_ACCOUNTS_ENV_VAR);
+        std::env::remove_var("LOOM_CLAUDE_MONITOR_DIR");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn bootstrap_partial_triple_warns_without_aborting() {
+        isolate_env();
+        let repo = scratch_repo(
+            "ACCOUNT_EMAIL_1=a@x.com\nACCOUNT_KEY_1=k\n\
+             ACCOUNT_EMAIL_2=orphan@x.com\n",
+        );
+        let opts = BootstrapOptions {
+            repo_root: repo.path().to_path_buf(),
+            env_path: None,
+            home_env_path: None,
+            force: false,
+            dry_run: true,
+            tokens_dir: None,
+        };
+        let result = bootstrap_tokens(&opts).unwrap();
+        assert_eq!(result.effective.len(), 1);
+        assert!(result
+            .warnings
+            .iter()
+            .any(|w| w.contains("incomplete triple")));
+        std::env::remove_var(HOME_ACCOUNTS_ENV_VAR);
+        std::env::remove_var("LOOM_CLAUDE_MONITOR_DIR");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn bootstrap_duplicate_filename_aborts() {
+        isolate_env();
+        // Two distinct emails forced onto the same token filename.
+        let repo = scratch_repo(
+            "ACCOUNT_EMAIL_1=a@x.com\nACCOUNT_KEY_1=k1\nACCOUNT_TOKEN_FILE_1=dup.token\n\
+             ACCOUNT_EMAIL_2=b@x.com\nACCOUNT_KEY_2=k2\nACCOUNT_TOKEN_FILE_2=dup.token\n",
+        );
+        let opts = BootstrapOptions {
+            repo_root: repo.path().to_path_buf(),
+            env_path: None,
+            home_env_path: None,
+            force: false,
+            dry_run: false,
+            tokens_dir: None,
+        };
+        match bootstrap_tokens(&opts) {
+            Err(BootstrapError::DuplicateFile(_)) => {}
+            other => panic!("expected DuplicateFile, got {other:?}"),
+        }
+        std::env::remove_var(HOME_ACCOUNTS_ENV_VAR);
+        std::env::remove_var("LOOM_CLAUDE_MONITOR_DIR");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn bootstrap_shared_tokens_dir_override() {
+        isolate_env();
+        let repo = scratch_repo("ACCOUNT_EMAIL_1=a@x.com\nACCOUNT_KEY_1=k\n");
+        let shared = tempfile::tempdir().unwrap();
+        let shared_pool = shared.path().join("pool");
+        let opts = BootstrapOptions {
+            repo_root: repo.path().to_path_buf(),
+            env_path: None,
+            home_env_path: None,
+            force: false,
+            dry_run: false,
+            tokens_dir: Some(shared_pool.clone()),
+        };
+        let result = bootstrap_tokens(&opts).unwrap();
+        assert_eq!(result.tokens_dir.as_deref(), Some(shared_pool.as_path()));
+        assert!(shared_pool.join("index.json").is_file());
+        // The repo-local pool was NOT written.
+        assert!(!repo.path().join(".loom").join("tokens").exists());
+        std::env::remove_var(HOME_ACCOUNTS_ENV_VAR);
+        std::env::remove_var("LOOM_CLAUDE_MONITOR_DIR");
+    }
+}

--- a/loom-daemon/src/tokens_pool/mod.rs
+++ b/loom-daemon/src/tokens_pool/mod.rs
@@ -19,6 +19,7 @@
 //!
 //! | Module | Python source | Mirrors |
 //! |---|---|---|
+//! | [`bootstrap`] | `tokens/bootstrap.py` | multi-source `.env` merge + `.token`/`index.json` provisioning |
 //! | [`paths`] | `tokens/paths.py` | per-repo/shared pool resolution (#3938) |
 //! | [`locking`] | `tokens/_locking.py` | `mkdir`-based lock (no `flock` — absent on stock macOS) |
 //! | [`rng`] | (stdlib `random`) | seedable PRNG for deterministic tests, no new crate |
@@ -36,11 +37,14 @@
 //! already shells out via `Command::new`. The transport is behind the
 //! [`check::ProbeTransport`] trait so tests never touch the network.
 //!
-//! **Deferred to follow-up issues** (filed alongside issue #4094 — see the PR
-//! description): `bootstrap.py` (multi-source `.env` merge + file provisioning)
-//! and `monitor_db.py` (claude-monitor SQLite import). Neither is on the
-//! per-dispatch hot path (they run at bootstrap time or on an operator
-//! cadence), so scoping them out keeps this increment reviewable.
+//! `bootstrap.py` (multi-source `.env` merge + file provisioning) was ported in
+//! issue #4105 as [`bootstrap`]. **Still deferred**: `monitor_db.py`
+//! (claude-monitor SQLite import, consumed by `import-from-monitor`, issue
+//! #4106). It is not on the per-dispatch hot path (it runs at bootstrap time or
+//! on an operator cadence), so scoping it out keeps each increment reviewable.
+//! [`bootstrap`] leaves the read-only `_check_monitor_divergence` warning
+//! (which reads the live `usage.db`) to that same follow-up, since it depends on
+//! the unported SQLite reader.
 //!
 //! # Byte-compatible state (hard requirement)
 //!
@@ -53,6 +57,7 @@
 
 pub mod allowlist;
 pub mod bad_tokens;
+pub mod bootstrap;
 pub mod check;
 pub mod failure_counts;
 pub mod locking;

--- a/loom-tools/tests/tokens/test_rust_conformance.py
+++ b/loom-tools/tests/tokens/test_rust_conformance.py
@@ -427,6 +427,150 @@ def test_check_monitor_source_manifest_only_account_has_empty_status(tmp_path):
     assert py_ranking == rust_ranking == "acct-a|available\nacct-z|\n"
 
 
+# ---------------------------------------------------------------------------
+# bootstrap: multi-source `.env` merge + `.token`/`index.json` provisioning
+# (#4105). The Python CLI resolves its repo root via `find_repo_root()` (needs
+# a `.git` + `.loom/` marker and is run with `cwd=workspace`); the Rust CLI
+# takes an explicit `--workspace`. Both are isolated from the real host
+# environment (no home master, no claude-monitor, no shared pool) so only the
+# repo-local `.env` feeds the merge.
+# ---------------------------------------------------------------------------
+
+
+def _seed_bootstrap_repo(workspace: Path, env_body: str) -> Path:
+    """Create a `.git` + `.loom` repo skeleton with a repo-local `.env`."""
+    (workspace / ".loom").mkdir(parents=True, exist_ok=True)
+    (workspace / ".git").mkdir(parents=True, exist_ok=True)
+    (workspace / ".env").write_text(env_body, encoding="utf-8")
+    return workspace
+
+
+def _bootstrap_env(monitor_dir: Path) -> dict:
+    return {
+        **os.environ,
+        "PYTHONPATH": _loom_tools_src(),
+        "LOOM_ACCOUNTS_ENV": "",  # disable the home master
+        "LOOM_CLAUDE_MONITOR_DIR": str(monitor_dir),  # empty -> no monitor source
+        "LOOM_SHARED_TOKENS_DIR": "",  # disable the shared pool fallback
+    }
+
+
+def _run_python_bootstrap(workspace: Path, monitor_dir: Path, *extra: str):
+    return subprocess.run(
+        ["python3", "-m", "loom_tools.tokens.cli", "bootstrap", *extra],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=workspace,
+        env=_bootstrap_env(monitor_dir),
+    )
+
+
+def _run_rust_bootstrap(workspace: Path, monitor_dir: Path, *extra: str):
+    assert DAEMON_BIN is not None
+    return subprocess.run(
+        [
+            str(DAEMON_BIN),
+            "tokens",
+            "bootstrap",
+            "--workspace",
+            str(workspace),
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_bootstrap_env(monitor_dir),
+    )
+
+
+_BOOTSTRAP_ENV_BODY = (
+    "ACCOUNT_EMAIL_1=alice@example.com\n"
+    "ACCOUNT_KEY_1=sk-ant-oat01-alice\n"
+    "ACCOUNT_EMAIL_2=bob.jones@example.org\n"
+    "ACCOUNT_KEY_2=sk-ant-oat01-bob\n"
+    # A partial triple: email with no key. Both must warn and skip, not abort.
+    "ACCOUNT_EMAIL_3=orphan@example.com\n"
+)
+
+
+def test_bootstrap_dry_run_effective_set_agrees(tmp_path):
+    monitor_dir = tmp_path / "monitor-empty"  # never created -> no monitor src
+    py_ws = _seed_bootstrap_repo(tmp_path / "py", _BOOTSTRAP_ENV_BODY)
+    rust_ws = _seed_bootstrap_repo(tmp_path / "rust", _BOOTSTRAP_ENV_BODY)
+
+    py = _run_python_bootstrap(py_ws, monitor_dir, "--dry-run", "--json")
+    assert py.returncode == 0, py.stderr
+    rust = _run_rust_bootstrap(rust_ws, monitor_dir, "--dry-run", "--json")
+    assert rust.returncode == 0, rust.stderr
+
+    py_effective = json.loads(py.stdout)["effective"]
+    rust_effective = json.loads(rust.stdout)["effective"]
+
+    # The auto-derived filenames + merge provenance must match byte-for-byte.
+    assert rust_effective == py_effective
+    # The orphan (partial) triple is dropped by both; only the two full ones
+    # survive with filenames derived from the email local-part + domain label.
+    files = {a["file"] for a in rust_effective}
+    assert files == {"alice-example.token", "bobjones-example.token"}
+    # Dry-run writes nothing.
+    assert not (py_ws / ".loom" / "tokens" / "index.json").exists()
+    assert not (rust_ws / ".loom" / "tokens" / "index.json").exists()
+
+
+def _index_accounts(pool: Path) -> list:
+    """Load `index.json`'s accounts array (drops the per-run `generated_at`)."""
+    manifest = json.loads((pool / "index.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == 2
+    return manifest["accounts"]
+
+
+def test_bootstrap_index_json_and_tokens_byte_compatible(tmp_path):
+    monitor_dir = tmp_path / "monitor-empty"
+    py_ws = _seed_bootstrap_repo(tmp_path / "py", _BOOTSTRAP_ENV_BODY)
+    rust_ws = _seed_bootstrap_repo(tmp_path / "rust", _BOOTSTRAP_ENV_BODY)
+
+    py = _run_python_bootstrap(py_ws, monitor_dir)
+    assert py.returncode == 0, py.stderr
+    rust = _run_rust_bootstrap(rust_ws, monitor_dir)
+    assert rust.returncode == 0, rust.stderr
+
+    py_pool = py_ws / ".loom" / "tokens"
+    rust_pool = rust_ws / ".loom" / "tokens"
+
+    # index.json manifest rows are byte-compatible (only generated_at differs).
+    assert _index_accounts(rust_pool) == _index_accounts(py_pool)
+    # And the manifest carries only 8-char fingerprints + source, no secrets.
+    for row in _index_accounts(rust_pool):
+        assert len(row["key_fingerprint"]) == 8
+        assert "source" in row
+        assert "key" not in row
+    raw = (rust_pool / "index.json").read_text(encoding="utf-8")
+    assert "sk-ant-oat01" not in raw
+
+    # The materialized token files are identical across both writers.
+    for name in ("alice-example.token", "bobjones-example.token"):
+        assert (rust_pool / name).read_text(encoding="utf-8") == (
+            py_pool / name
+        ).read_text(encoding="utf-8")
+
+
+def test_bootstrap_no_source_both_fail(tmp_path):
+    monitor_dir = tmp_path / "monitor-empty"
+    # A repo skeleton with NO account source at all.
+    py_ws = tmp_path / "py"
+    rust_ws = tmp_path / "rust"
+    for ws in (py_ws, rust_ws):
+        (ws / ".loom").mkdir(parents=True)
+        (ws / ".git").mkdir(parents=True)
+
+    py = _run_python_bootstrap(py_ws, monitor_dir, "--json")
+    rust = _run_rust_bootstrap(rust_ws, monitor_dir, "--json")
+    # Both exit non-zero when no account source exists.
+    assert py.returncode != 0
+    assert rust.returncode != 0
+
+
 def test_check_monitor_source_no_fresh_data_leaves_ranking_untouched(tmp_path):
     index_accounts = [{"name": "acct-a", "email": "a@example.com"}]
     py_ws = _seed_monitor_pool(tmp_path / "py", index_accounts)


### PR DESCRIPTION
Closes #4105

Child **B** of the epic #4081 phase-1 decomposition. Ports
`loom_tools.tokens.bootstrap` (878 lines) to a native Rust
`tokens_pool::bootstrap` module and wires a `TokensAction::Bootstrap`
variant + handler into `main.rs`, following the exact PR #4108 (`tokens
check`) integration precedent.

## What landed

- **`loom-daemon/src/tokens_pool/bootstrap.rs`** (new) — the port:
  - numbered-triple parsing (`ACCOUNT_EMAIL_N` / `ACCOUNT_KEY_N` /
    `ACCOUNT_TOKEN_FILE_N`) with gap tolerance and partial-triple warnings;
    filename auto-derived from the email (`alice@example.com` ->
    `alice-example.token`) when absent;
  - email-keyed 3-source merge with precedence **claude-monitor >
    repo-local > opt-in home master**;
  - `0600` token files in a `0700` dir, atomic write-then-rename,
    `index.json` v2 manifest with 8-char sha256 fingerprints and no secret
    material;
  - `Account`, `materialize_accounts`, `write_index` exported `pub` with a
    stable signature for reuse by the blocked-on-this `import-from-monitor`
    port (#4106).
- **`main.rs`** — `TokensAction::Bootstrap` enum variant + `handle_tokens_command`
  arm covering all seven scope flags (`--dry-run`, `--force`, `--shared`,
  `--env`, `--home-env`, `--no-home`, `--json`); corrects the stale
  "bootstrap remains Python-only" doc comment.
- **`tokens_pool/mod.rs`** — registers `pub mod bootstrap;` (alphabetical),
  adds the module doc-table row, and corrects the stale "Deferred to
  follow-up issues" note.
- **`test_rust_conformance.py`** — 3 cross-language conformance cases
  (dry-run effective set agrees, `index.json` + token files byte-compatible,
  no-source failure). They **skip** (not fail) when the daemon binary is
  unbuilt.

## Deliberately deferred

The read-only `_check_monitor_divergence` warning (which reads the live
claude-monitor `usage.db`) is left to #4106 alongside the `monitor_db.py`
SQLite reader it depends on — it does not affect the pool provisioning path
or any conformance-checked output.

## Tests

- 27 Rust unit tests in `bootstrap.rs` (triple parsing, filename derivation,
  3-source precedence, `index.json` v2 shape, `0600`/`0700` mode assertions,
  drift skip/force, duplicate-filename abort, `--no-home`, `--shared`,
  dry-run) — all pass.
- 14 conformance tests pass (3 new bootstrap cases).
- Full `loom-tools/tests/tokens/` regression suite: **347 passed**.
- `cargo clippy -p loom-daemon` clean; `cargo fmt --check` clean.
- Manual parity verified: Rust and Python produce byte-identical
  `index.json` account rows, identical token contents, and `0600`/`0700`
  modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)