### PR TITLE
docs: extract guard/model/health/hooks reference content to defaults/docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,7 @@ Configuration lives in `.loom/config.json` (committed for team sharing): a
   confine Edit/Write to a builder's worktree; category toggles (`guards.sqlDdl`,
   `cloudCli`, `reversibleGh`, `rmScope`, `forceScope`, `readOnlyFastPath`,
   `decisionLog`, `worktreeIsolation`, each with an `LOOM_*` env override) let a
-  repo opt out. Catalog: [`defaults/CLAUDE.md` → "Custom Guard Hooks"](defaults/CLAUDE.md).
+  repo opt out. Catalog: [`defaults/docs/guard-hooks.md`](defaults/docs/guard-hooks.md).
 - **MCP hooks** — the unified `mcp-loom` server; run `./scripts/setup-mcp.sh` to
   generate `.mcp.json`. See the mcp-loom README.
 

--- a/defaults/.loom/CLAUDE.md
+++ b/defaults/.loom/CLAUDE.md
@@ -283,8 +283,16 @@ Configuration lives in `.loom/config.json` (committed for team sharing): a
   /path/to/repo` (squash-only merges, auto-delete branches, auto-merge enabled).
 - **Guard hooks** — `PreToolUse` guards block/ask on destructive commands and
   confine Edit/Write to a builder's worktree; toggle categories via
-  `.loom/config.json` → `guards.*` (each with an `LOOM_*` env override). See the
+  `.loom/config.json` → `guards.*` (each with an `LOOM_*` env override). Full
+  catalog: [`.loom/docs/guard-hooks.md`](.loom/docs/guard-hooks.md); see also the
   `guard-destructive.sh` / `guard-worktree-paths.sh` scripts under `.loom/hooks/`.
+- **Model selection** — worker model resolution, the escalation ladder, and the
+  suggested-model-by-role defaults: [`.loom/docs/model-selection.md`](.loom/docs/model-selection.md);
+  the opt-in model-cost A/B experiment: [`.loom/docs/model-cost-experiment.md`](.loom/docs/model-cost-experiment.md).
+- **Health monitoring & advanced hooks** — proactive health monitoring for
+  unattended runs: [`.loom/docs/health-monitoring.md`](.loom/docs/health-monitoring.md);
+  opt-in `UserPromptSubmit` context injection + transcript archival:
+  [`.loom/docs/advanced-hooks.md`](.loom/docs/advanced-hooks.md).
 - **MCP hooks** — the unified `mcp-loom` server; run `./scripts/setup-mcp.sh` to
   generate `.mcp.json`.
 
@@ -337,7 +345,12 @@ concurrency errors are covered in
   [github-auth](.loom/docs/github-authentication.md) /
   [forge-auth](.loom/docs/forge-authentication.md) ·
   [ci-integration](.loom/docs/ci-integration.md) ·
-  [tool-use-concurrency-errors](.loom/docs/tool-use-concurrency-errors.md)
+  [tool-use-concurrency-errors](.loom/docs/tool-use-concurrency-errors.md) ·
+  [guard-hooks](.loom/docs/guard-hooks.md) ·
+  [model-selection](.loom/docs/model-selection.md) ·
+  [model-cost-experiment](.loom/docs/model-cost-experiment.md) ·
+  [health-monitoring](.loom/docs/health-monitoring.md) ·
+  [advanced-hooks](.loom/docs/advanced-hooks.md)
 
 ## Support
 

--- a/defaults/docs/advanced-hooks.md
+++ b/defaults/docs/advanced-hooks.md
@@ -1,0 +1,189 @@
+# Advanced Hooks
+
+Opt-in `UserPromptSubmit` context injection (the Methodology Injection Framework)
+and durable session-transcript archival — reference-tier detail an agent looks up
+on demand.
+
+## Methodology Injection Framework
+
+Loom provides an opt-in methodology injection hook that automatically injects project-specific context into every agent session. This is useful for domain knowledge, coding conventions, design rules, or any context that agents need to do their job well.
+
+### Quick Start
+
+1. Create the context directory in your repository:
+   ```bash
+   mkdir -p .loom/context/roles .loom/context/topics
+   ```
+
+2. Add a universal context file (injected once per session by default):
+   ```bash
+   cat > .loom/context/universal.md << 'EOF'
+   # Project Rules
+   - Use TypeScript strict mode
+   - All functions must have JSDoc comments
+   - Run tests before creating PRs
+   EOF
+   ```
+
+3. The hook is already registered in `.claude/settings.json`. It activates automatically when `.loom/context/` exists and silently does nothing when the directory is absent.
+
+### Context File Structure
+
+```
+.loom/context/
+├── config.json              # Optional configuration
+├── universal.md             # Injected once per session by default
+├── roles/
+│   ├── builder.md           # Injected when LOOM_ROLE=builder
+│   ├── judge.md             # Injected when LOOM_ROLE=judge
+│   └── ...
+└── topics/
+    ├── security.md          # Injected when prompt matches "security"
+    ├── security.pattern     # Optional: custom regex pattern for matching
+    ├── database.md          # Injected when prompt matches "database"
+    └── ...
+```
+
+**Universal context** (`universal.md`): Injected when the context directory exists — **once per session by default** (`universal_frequency: "session"`), so the project-wide rules ride along on the first prompt of a session and are deduped on subsequent turns. Set `universal_frequency: "always"` to restore per-prompt injection. Use for project-wide rules and conventions.
+
+**Role context** (`roles/<role>.md`): Injected when the `LOOM_ROLE` environment variable matches the filename, or when a slash command (e.g., `/builder`) is detected in the prompt. Role names are case-insensitive.
+
+**Topic context** (`topics/<name>.md`): Injected when the prompt matches the topic keyword. By default the filename is matched as an **anchored** token — the topic name must appear either as a slash command (`/loom:<name>` or `/repo:<name>`) or as a standalone word that is not part of a flag or path segment. So `security.md` injects on "check the security model" or `/loom:security`, but a "release" topic does **not** inject on `cargo build --release` or `target/release`. For custom matching, create a sidecar `.pattern` file with a regex (e.g., `security.pattern` containing `security|auth|token|credential`); the sidecar overrides the filename fallback entirely.
+
+### Configuration
+
+Create `.loom/context/config.json` to customize behavior:
+
+```json
+{
+  "max_context_chars": 8000,
+  "enabled": true,
+  "inject_universal": true,
+  "universal_frequency": "session",
+  "inject_role": true,
+  "inject_topics": true
+}
+```
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `max_context_chars` | 8000 | Maximum total characters injected (prevents overwhelming the context window) |
+| `enabled` | true | Set to false to disable injection without removing files |
+| `inject_universal` | true | Whether to inject `universal.md` at all (on/off master switch) |
+| `universal_frequency` | `"session"` | How often `universal.md` is injected: `"session"` (once per session — default) or `"always"` (every matching prompt, legacy behavior). Any missing/malformed value falls back to `"session"`. |
+| `inject_role` | true | Whether to inject role-specific context |
+| `inject_topics` | true | Whether to inject topic-matched context |
+
+> **Behavior-change note (#3758)**: `universal_frequency` defaults to `"session"`,
+> a deliberate flip from the historical always-inject behavior. Any repo that
+> already opted into `.loom/context/` **without** setting this key now gets
+> `universal.md` **once per session** instead of on every prompt. This mirrors the
+> precedent set by #3609 for `skill-router.sh` (which likewise dropped per-prompt
+> injection with no back-compat shim). To keep the old every-prompt behavior, set
+> `"universal_frequency": "always"`. The once-per-session dedup uses a session-keyed
+> marker at `.loom/logs/methodology-inject-seen/<sanitized-session-id>` (its own
+> namespace, parallel to `skill-router.sh`'s `skill-router-seen/`); a missing/empty
+> `session_id` on stdin degrades gracefully to per-turn injection. Role and topic
+> injection are unaffected — they still fire on every matching turn.
+
+### How It Works
+
+The `methodology-inject.sh` hook runs as a `UserPromptSubmit` hook alongside `skill-router.sh`. On each prompt:
+
+1. Checks for `.loom/context/` directory -- exits silently if absent
+2. Reads `universal.md` if present, **once per session** by default (`universal_frequency`) — deduped via a session-keyed marker, exactly like `skill-router.sh`'s #3609 routing-table dedup
+3. Detects the active role via `LOOM_ROLE` env var or prompt slash command
+4. Scans `topics/` files, matching prompt against filename or sidecar `.pattern` regex
+5. Concatenates matching content, capped at `max_context_chars`
+6. Returns the collected context as `additionalContext`
+
+The hook follows the same error-handling patterns as other Loom hooks: it never exits non-zero, logs errors to `.loom/logs/hook-errors.log`, and fails silently on any unexpected error.
+
+### UserPromptSubmit Hooks: Opt-In Triggers and Disabling
+
+Both `UserPromptSubmit` hooks are **opt-in by config presence** and do nothing until you add their config. Each has a one-line off switch:
+
+| Hook | Opt-in trigger | One-line disable |
+|------|----------------|------------------|
+| `methodology-inject.sh` | Presence of the `.loom/context/` directory | Delete/rename `.loom/context/`, or set `"enabled": false` in `.loom/context/config.json`, or remove the hook's entry from the `UserPromptSubmit` array in `.claude/settings.json` |
+| `skill-router.sh` | Presence of `.loom/config/skill-routes.json` | Delete `.loom/config/skill-routes.json`, or remove the hook's entry from the `UserPromptSubmit` array in `.claude/settings.json` |
+
+`skill-router.sh` is already conservative (issue #3609): it emits nothing on non-matching turns, and appends its agent routing table at most once per session (session-keyed dedup, degrading gracefully when `session_id` is missing). `methodology-inject.sh` now mirrors that once-per-session discipline for `universal.md` (see `universal_frequency` above). Neither hook blocks a prompt or exits non-zero; both fail silently on any error.
+
+### Example Context Files
+
+Example context files are provided in `defaults/hooks/example-context/` to guide setup. Copy them to your `.loom/context/` directory and customize:
+
+```bash
+cp -r defaults/hooks/example-context/* .loom/context/
+```
+
+### Session Transcript Archival (opt-in, #3726)
+
+Claude Code writes a full JSONL transcript for every session — and a per-subagent
+transcript for every Builder / Judge / Doctor Task — under
+`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/<cwd-slug>/`. These are the
+ground-truth record of what each agent did and what it cost (per-message `usage`
++ `model`), but they live only on the local box and are subject to Claude Code's
+own pruning. `archive-transcripts.sh` copies them to a durable location so a
+multi-day canary run can be audited / cost-harvested after the fact (serves the
+#3725 per-role cost harvest — the archived index is its `agent-<id>` join key).
+
+**Off by default. Zero behavior change unless you turn it on.** Enable via env or
+config (env-over-config precedence, matching the `guards.rmScope` string pattern):
+
+```bash
+# env wins over config; a path enables, ""/off/0/no/disabled forces off:
+LOOM_TRANSCRIPT_ARCHIVE=/Volumes/scratch/loom-transcripts \
+  ./.loom/scripts/archive-transcripts.sh
+```
+
+```json
+// .loom/config.json — new top-level "loom" block:
+{ "loom": { "transcriptArchive": { "enabled": true, "dir": "/Volumes/scratch/loom-transcripts" } } }
+```
+
+**Layout at destination** — `<dir>/<repo>/<date>/<session-uuid>/`:
+
+```
+<session-uuid>.jsonl                       the session's own transcript
+<session-uuid>/subagents/agent-*.jsonl     per-subagent transcripts
+<session-uuid>/subagents/agent-*.meta.json role+issue sidecars (copied verbatim)
+<session-uuid>/tool-results/…              large tool outputs
+index.json                                 agent-id-keyed join index (schema loom.transcript-index/v1)
+```
+
+The `index.json` is keyed by `agent-<id>` with one row per subagent; **role and
+issue are read from the existing `agent-*.meta.json` sidecars** (not re-derived),
+and the archiver adds only the loom-side context the sidecar lacks (repo, sweep
+issue, model, start/end ts, and `arm`/`attempt` when a model experiment is active).
+
+**Base path is `CLAUDE_CONFIG_DIR`-aware** — the archiver never hard-codes
+`~/.claude`. Per-agent isolated config dirs (`.loom/claude-config/<agent>/`) get a
+fresh `projects/`, so the copier resolves its source through
+`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects` (mirrors
+`loom_tools.common.claude_config.resolve_projects_dir()`).
+
+**When it runs**: cron-friendly periodic sync (the durability backstop — the
+session's own top-level `<uuid>.jsonl` is still being appended while the session
+runs, so only a periodic + at-exit sync reliably captures the tail), plus a
+completion-time invocation from `/loom:sweep`. Idempotent (size + mtime skip), so
+re-runs copy nothing new. Cron example:
+
+```cron
+*/15 * * * * cd /path/to/repo && ./.loom/scripts/archive-transcripts.sh >> .loom/logs/archive-transcripts.log 2>&1
+```
+
+> **Guardrails — transcripts can contain secrets.** A transcript is full tool I/O
+> and may include `.env` contents or token values that scrolled through a shell.
+> The archiver treats the destination as sensitive, exactly like `.loom/tokens/`
+> and `accounts.env`: created **mode `0700`**, files **`0600`**; if the destination
+> is **inside a git repo it MUST be gitignored** or the archiver **refuses** (it
+> will not copy secret-bearing transcripts into a tracked tree); and it prints a
+> **loud one-line banner naming the destination** whenever archival is enabled.
+> As with the token pool, **you (the operator) own the security of the archive
+> location** — put it outside any repo, or gitignore it.
+
+**Out of scope (v1)**: remote / object-storage backends (`s3://`, `gcs://`,
+rsync-to-remote) are an explicit follow-on — v1 is a local filesystem destination
+only.

--- a/defaults/docs/guard-hooks.md
+++ b/defaults/docs/guard-hooks.md
@@ -1,0 +1,474 @@
+# Guard Hooks Reference
+
+Loom's `PreToolUse` guard hooks and their per-repo toggles. Each toggle resolves
+with **env > `.loom/config.json` > default** precedence; the operating-core guides
+(`CLAUDE.md` and `.loom/CLAUDE.md`, "Configuration → Guard hooks") point here for
+the full catalog.
+
+## Custom Guard Hooks
+
+Loom ships with several built-in `PreToolUse` guard hooks, registered independently under the `Bash` or `Edit|Write` matcher as noted below:
+
+- **`guard-destructive.sh`** (`Bash` matcher) — the generic repository-hygiene guard (catastrophic denies like `rm -rf /`, force-push to `main`, `gh repo delete`, fork bombs, curl-pipe-to-shell, cloud/SQL destruction; the segment-parsed lifecycle/cloud-CLI checks; and the `guards.sqlDdl` / `guards.cloudCli` / `guards.reversibleGh` / `guards.rmScope` / `guards.forceScope` toggle machinery documented below). Nothing about this guard is Loom-specific, so as of **#4041 its canonical home is [Repo Skills](https://github.com/rjwalters/repo)** (installed at `.claude/skills/repo/hooks/guard-destructive.sh`, carrying the rjwalters/repo#29 curl-pipe fix). In Loom, `guard-destructive.sh` is now a thin **dispatcher**: when the canonical Repo Skills guard is present it defers to it at runtime (and the installer does not install a second generic guard); otherwise it falls back to a clearly-marked **vendored copy** (`guard-destructive-generic.sh`) that Loom ships so standalone-Loom repos — those without Repo Skills — keep full coverage. Exactly one generic guard ever runs; the behavior and all the toggles below are unchanged either way. The pattern list itself is maintained upstream in Repo Skills, not forked in Loom.
+- **`guard-loom-workflow.sh`** (`Bash` matcher) — the thin, Loom-workflow-specific guard (issue #3604): the `gh pr merge` → `merge-pr.sh` redirect and the `pip install -e` worktree block (keyed on `LOOM_WORKTREE_PATH`, issue #2495). This guard and `guard-worktree-paths.sh` below are specific to the Loom worktree/merge workflow and stay Loom-owned.
+- **`guard-worktree-paths.sh`** (`Edit|Write` matcher, issue #2441 / #4007) — confines Edit/Write tool calls to a builder's issue worktree, denying writes that resolve into the main checkout. Two mechanisms: the `LOOM_WORKTREE_PATH` env fast path (tmux/manual sessions pinned to one worktree) and, when that env var is absent, a **path-derived fallback** — it walks up from the target path looking for the `.loom-managed` sentinel `worktree.sh` writes at every worktree root, and denies a write that lands in the main checkout while at least one managed worktree exists. The fallback exists because a daemon-dispatched sweep hosts multiple Task-subagent builders in one shared process env, so a single process-wide `LOOM_WORKTREE_PATH` cannot cover that path (#3719). Toggle: `guards.worktreeIsolation` / `LOOM_GUARD_WORKTREE_ISOLATION`, documented alongside the other guard toggles below.
+
+You can also add project-specific guards to protect read-only directories from accidental edits (see below).
+
+### SQL DDL/DML Guard Opt-Out (`guards.sqlDdl` / `LOOM_GUARD_SQL`)
+
+`guard-destructive.sh` blocks SQL DDL/DML patterns — `DROP DATABASE`, `DROP TABLE`, `DROP SCHEMA`, `TRUNCATE TABLE`, and `DELETE FROM` without a `WHERE` clause. For most repos this is a useful safety net, but for a project that is **itself a database engine** (e.g. a SQLite-compatible engine running a SQL conformance suite) those statements are the product's own dev/test vocabulary and the guard is a category error — the match is a case-insensitive substring, so it even fires when the words appear in a comment or a `--description` label.
+
+Such repos can opt out of the SQL guard while keeping every other guard (`rm -rf /`, force-push to `main`, `gh repo delete`, `aws s3 rb`, `aws iam delete`, etc.) fully active.
+
+The SQL guard is **on by default**. It is resolved in this order (highest precedence first):
+
+1. **`LOOM_GUARD_SQL` env var** — `0`/`false`/`no` disables the SQL guard; `1`/`true`/`yes` forces it on. Overrides the config value.
+2. **`.loom/config.json`** — `guards.sqlDdl` (default `true` when absent). Set it to `false` to disable:
+   ```json
+   {
+     "guards": {
+       "sqlDdl": false
+     }
+   }
+   ```
+3. **Default** — `true` (guard on).
+
+The config read is best-effort: a missing, empty, or malformed `.loom/config.json` falls through to guard-ON and never causes the hook to exit non-zero. Only the SQL DDL/DML blocks are affected — disabling the SQL guard does not weaken any other guard.
+
+**Examples**:
+
+```bash
+# Disable the SQL guard for a single command (e.g. a one-off dev query)
+LOOM_GUARD_SQL=0 vibesql -c "DROP TABLE t"
+
+# Persist the opt-out for the whole repo
+#   .loom/config.json  ->  { "guards": { "sqlDdl": false } }
+
+# Force the SQL guard on for one command even when the repo opts out
+LOOM_GUARD_SQL=1 psql -c "DROP TABLE users"
+```
+
+### Cloud CLI Guard Opt-Out (`guards.cloudCli` / `LOOM_GUARD_CLOUD`)
+
+`guard-destructive.sh` asks for confirmation on **mutating** cloud/container CLI calls — `aws ec2 run-instances`/`create-*`/`stop-instances`/`start-instances`/`terminate-instances`, `aws s3 rm`/`rb`/`cp`/`mv`/`sync`, other mutating `aws <service> <verb>` forms, and `docker rm`/`rmi`/`stop`/`kill`/`restart`. Read-only calls (`aws ec2 describe-instances`, `aws s3 ls`, `aws lambda list-functions`, `docker ps`, `docker logs`, etc.) are **not** prompted. For a repo whose *purpose* is managing cloud infrastructure (launch/stop/terminate dev VMs, build/tear-down containers), even the mutating asks are workflow friction rather than a safety win.
+
+Such repos can opt out of the cloud/docker ASK category while keeping every other guard active — including the genuinely catastrophic cloud denies (`aws s3 rm ... --recursive`, `aws s3 rb`, `aws iam delete-*`, `aws cloudformation delete-stack`, `docker system prune`), which are **never** gated by this toggle and stay hard denies even with the cloud guard off.
+
+The cloud guard is **on by default**. It is resolved in this order (highest precedence first):
+
+1. **`LOOM_GUARD_CLOUD` env var** — `0`/`false`/`no` disables the cloud/docker ASK category; `1`/`true`/`yes` forces it on. Overrides the config value.
+2. **`.loom/config.json`** — `guards.cloudCli` (default `true` when absent). Set it to `false` to disable:
+   ```json
+   {
+     "guards": {
+       "cloudCli": false
+     }
+   }
+   ```
+3. **Default** — `true` (guard on).
+
+The config read is best-effort: a missing, empty, or malformed `.loom/config.json` falls through to guard-ON and never causes the hook to exit non-zero. Only the cloud/docker ASK patterns are affected — disabling the cloud guard does not weaken the catastrophic cloud denies or any other guard.
+
+Note: `aws ec2 terminate-instances` is an **ask** (not a hard deny) so a legitimate VM-teardown workflow is possible; with `guards.cloudCli:false` / `LOOM_GUARD_CLOUD=0` it passes through without prompting.
+
+**Examples**:
+
+```bash
+# Tear down a dev VM without a prompt for a single command
+LOOM_GUARD_CLOUD=0 aws ec2 terminate-instances --instance-ids i-1234
+
+# Persist the opt-out for a cloud-management repo
+#   .loom/config.json  ->  { "guards": { "cloudCli": false } }
+
+# Force the cloud guard on for one command even when the repo opts out
+LOOM_GUARD_CLOUD=1 aws ec2 terminate-instances --instance-ids i-1234
+```
+
+### Reversible-GitHub Ask Opt-In (`guards.reversibleGh` / `LOOM_GUARD_REVERSIBLE_GH`)
+
+`guard-destructive.sh` scopes its ask tier to **irreversibility** (#3757): a guard whose purpose is preventing catastrophic, hard-to-undo mistakes should not add confirmation friction to operations that are trivially reversed. The **reversible** GitHub state changes — `gh pr close` (undo: `gh pr reopen`), `gh issue close` (undo: `gh issue reopen`), and `gh label delete` (undo: recreate, or one `gh label sync` in a repo with `labels.yml`) — therefore **do not prompt by default**. An autonomous agent that closes its own issue/PR as part of a normal lifecycle no longer stalls on a confirmation prompt (or, in a headless run with no approver, blocks entirely).
+
+The genuinely hard-to-reverse operations stay in the ungated ask tier and are **not** affected by this toggle: `gh release delete` (deletes published artifacts/tags), and `git clean -fd` / `git checkout .` / `git restore .` (untracked / uncommitted loss). The full catastrophic deny suite (`rm -rf /`, force-push to `main`, `gh repo delete`, …) is likewise unaffected.
+
+A repo that *wants* the confirmation back on the reversible GitHub ops can **opt in**. Unlike `guards.sqlDdl` / `guards.cloudCli` (which default **on** and are opted **out**), this toggle has **inverse polarity**: it defaults **off** and is opted **in**, because enabling it *adds* friction rather than removing it.
+
+The reversible-GitHub ask is **off by default**. It is resolved in this order (highest precedence first):
+
+1. **`LOOM_GUARD_REVERSIBLE_GH` env var** — `1`/`true`/`yes` enables the ask on `gh pr close` / `gh issue close` / `gh label delete`; `0`/`false`/`no` forces it off. Overrides the config value.
+2. **`.loom/config.json`** — `guards.reversibleGh` (default `false` when absent). Set it to `true` to opt in:
+   ```json
+   {
+     "guards": {
+       "reversibleGh": true
+     }
+   }
+   ```
+3. **Default** — `false` (no ask; the reversible GitHub ops pass through).
+
+The config read is best-effort: a missing, empty, or malformed `.loom/config.json` falls through to guard-**off** (the default) and never causes the hook to exit non-zero. Only the three reversible GitHub ASK patterns are affected — opting in does not touch `gh release delete`, the `git clean`/`checkout`/`restore` asks, or any deny.
+
+**Examples**:
+
+```bash
+# Default (off) — reversible GitHub ops pass through without a prompt:
+gh pr close 42          # allowed (undo: gh pr reopen 42)
+gh issue close 100      # allowed (undo: gh issue reopen 100)
+gh label delete stale   # allowed (undo: recreate the label)
+gh release delete v1.0  # STILL asks (not gated — deletes published artifacts)
+
+# Opt in to the confirmation for a whole repo:
+#   .loom/config.json  ->  { "guards": { "reversibleGh": true } }
+gh issue close 100      # ASK
+
+# Opt in for a single command:
+LOOM_GUARD_REVERSIBLE_GH=1 gh pr close 42       # ASK
+
+# Force off for one command even when the repo opts in:
+LOOM_GUARD_REVERSIBLE_GH=0 gh issue close 100   # allowed
+```
+
+### Worktree Isolation Guard Opt-Out (`guards.worktreeIsolation` / `LOOM_GUARD_WORKTREE_ISOLATION`)
+
+`guard-worktree-paths.sh` (issue #4007) denies Edit/Write tool calls whose target resolves into the **main** repository checkout while a Loom-managed worktree exists (path-derived — see the guard inventory bullet above for the mechanism). This is the mechanical enforcement behind "never work on main branch": a builder that used a repo-relative path after a cwd reset, or that otherwise escaped its issue worktree, is denied instead of silently corrupting the main checkout.
+
+The guard is **on by default**. It is resolved in this order (highest precedence first):
+
+1. **`LOOM_GUARD_WORKTREE_ISOLATION` env var** — `0`/`false`/`no` disables the guard; `1`/`true`/`yes` forces it on. Overrides the config value.
+2. **`.loom/config.json`** — `guards.worktreeIsolation` (default `true` when absent). Set it to `false` to disable:
+   ```json
+   {
+     "guards": {
+       "worktreeIsolation": false
+     }
+   }
+   ```
+3. **Default** — `true` (guard on).
+
+The config read is best-effort: a missing, empty, or malformed `.loom/config.json` falls through to guard-ON and never causes the hook to exit non-zero. Disabling this guard does not weaken any other guard. The toggle governs the guard as a whole — disabling it skips **both** mechanisms, including the `LOOM_WORKTREE_PATH` fast path's own containment check.
+
+### Repo-Scoped rm Guard (`guards.rmScope` / `LOOM_RM_SCOPE`)
+
+By default (as of #3628), `guard-destructive.sh` runs in **`repo` mode**: it blocks the **catastrophic** `rm -rf` targets — root (`/`), the user's `$HOME`, and any bare top-level directory (`/tmp`, `/var`, `/etc`, …) — **and** additionally denies any `rm -rf` target that is neither inside the repo/worktree areas nor on a built-in **ephemeral allowlist**. So an outside-repo deep path like `rm -rf /Users/someone/important` is **denied** out of the box. This is the safe-by-default behaviour (ADR Option B); it is a **behaviour change** from the pre-#3628 permissive default.
+
+Repos that need the old permissive behaviour — block only catastrophic targets and **allow** every deeper subpath, including subpaths outside the repository — can **opt out** to `off` (a.k.a. `permissive`) mode. The catastrophic top-level deny stays active in both modes, so bare `/tmp` and `/` are always blocked regardless.
+
+The rm-scope guard is **repo (on) by default**. It is resolved in this order (highest precedence first):
+
+1. **`LOOM_RM_SCOPE` env var** — `repo` forces repo mode; `off`/`0`/`no`/`permissive` forces the permissive opt-out; unset falls through to the config/default. Overrides the config value.
+2. **`.loom/config.json`** — `guards.rmScope`. An explicit `"off"` (or its synonym `"permissive"`) opts out to permissive mode; an absent key, any other value, or malformed JSON resolves to `"repo"` (the safe default):
+   ```json
+   {
+     "guards": {
+       "rmScope": "off"
+     }
+   }
+   ```
+3. **Default** — repo (safe-by-default, outside-repo deep `rm` denied).
+
+The config read is best-effort: a missing, empty, or malformed `.loom/config.json` falls through to **repo** (the safe default) and never causes the hook to exit non-zero. The permissive opt-out does not weaken any other guard — the catastrophic denies stay active.
+
+**In-scope targets** (allowed under `repo` mode):
+
+- Anything under the **repo root** (resolved from the command's `cwd`).
+- Anything under the **worktree root** — resolved with the same precedence as `loom_worktree_root()`: `LOOM_WORKTREE_ROOT` env → `.loom/config.json → worktree.root` → the default `<repo>/.loom/worktrees`. This admits an external scratch volume (e.g. `worktree.root: "/Volumes/scratch/wt"`).
+- The **ephemeral allowlist**: system temp roots and the Claude scratchpad.
+
+**Ephemeral allowlist prefixes**. `normalize_abs_path()` is **lexical only** — it does **not** resolve symlinks — so on macOS each temp root is listed in **both** its symlink form and its `/private` target:
+
+| Symlink form | `/private` target |
+|--------------|-------------------|
+| `/tmp/…` | `/private/tmp/…` |
+| `/var/tmp/…` | `/private/var/tmp/…` |
+| `/var/folders/…` (`$TMPDIR`) | `/private/var/folders/…` |
+
+Plus the Claude scratchpad glob `*/claude-*/*/scratchpad/*`. A **bare** temp root (`/tmp`, `/private/tmp`, …) is never admitted here — bare `/tmp` is already caught by the catastrophic top-level deny, and prefix matches carry a trailing `/` so a name-prefix sibling like `/tmpfoo/x` is **not** admitted by the `/tmp/` entry.
+
+**Examples**:
+
+```bash
+# Default (repo mode) — no config needed:
+rm -rf /Users/someone/important   # DENIED (outside repo, safe default)
+rm -rf /tmp/build-cache/x         # allowed (ephemeral allowlist)
+rm -rf ./dist                     # allowed (under repo)
+
+# Opt out to the old permissive behaviour for a whole repo:
+#   .loom/config.json  ->  { "guards": { "rmScope": "off" } }        # or "permissive"
+
+# One-off env opt-out — force permissive for a single command:
+LOOM_RM_SCOPE=off rm -rf /Users/someone/scratch       # allowed (permissive)
+
+# Force repo mode for one command even when the repo opts out:
+LOOM_RM_SCOPE=repo rm -rf /Users/someone/important    # DENIED (outside repo)
+```
+
+### Force-Op Branch Scope Guard (`guards.forceScope` / `LOOM_FORCE_SCOPE`)
+
+By default `guard-destructive.sh` **asks** for confirmation on every `git push
+--force` / `-f` / `--force-with-lease` and `git reset --hard`, regardless of
+which branch is targeted. For an autonomous/background agent that cannot answer
+an interactive prompt, that stalls the agent on *routine* work — force-pushing or
+hard-resetting its own single-owner working branch is a normal part of the
+rebase/amend/reset workflow. The genuinely dangerous case is a force op against a
+**protected/shared branch** (`main`/`master` or the repo's default branch).
+
+`guards.forceScope` makes the ask branch-aware (symmetric to `guards.rmScope`):
+
+| `guards.forceScope` | Behavior |
+|---------------------|----------|
+| `"all"` (**default**) | Ask on every force op regardless of branch — current behaviour, preserved byte-for-byte. |
+| `"protected"` | Ask only when the resolved target is a **protected** branch (the repo default branch plus `main`/`master`), or the branch identity is ambiguous (detached HEAD). Force ops on the agent's own working branches pass through. Solves the autonomous-agent stall. |
+| `"off"` | Never ask/deny on force ops. |
+
+The shipped default is **`"all"`** — a zero-config install sees **no behaviour
+change**. Consumers who want the autonomous-friendly behaviour opt in explicitly
+(`guards.forceScope: "protected"` in `.loom/config.json`).
+
+**Protected set & branch resolution**:
+- Protected branches = the repo default branch (detected offline via
+  `refs/remotes/origin/HEAD`, mirroring `loom_default_branch()`, with a
+  `LOOM_DEFAULT_BRANCH` override) plus the literals `main` and `master`.
+- The target branch is resolved from the push refspec — `<src>:<dst>` → `<dst>`,
+  a bare ref → the ref with a leading `+` stripped, and `HEAD` / no refspec → the
+  **checked-out branch**. `git reset --hard` always resolves to the checked-out
+  branch. The checked-out branch is read at the command's effective cwd, honoring
+  a `git -C <path>` prefix, else the hook's `cwd`.
+- **Detached HEAD** (or any unresolved branch identity) is treated as ambiguous
+  and **asks** — it is never silently allowed.
+
+**Always-on hard denies are unaffected**. The unconditional force-push-to-main /
+force-push-to-master denies (the `ALWAYS_BLOCK` patterns) fire **in every mode,
+including `"off"`** — `forceScope` only ever downgrades the generic force-op
+*ask*, it never weakens a hard deny.
+
+The force-op guard is resolved in this order (highest precedence first):
+
+1. **`LOOM_FORCE_SCOPE` env var** (`all`/`protected`/`off`). Overrides config.
+2. **`.loom/config.json`** — `guards.forceScope`: `"protected"`/`"off"`; an
+   absent key, any other value, or malformed JSON resolves to `"all"`:
+   ```json
+   {
+     "guards": {
+       "forceScope": "protected"
+     }
+   }
+   ```
+3. **Default** — `"all"` (preserve current behaviour).
+
+The config read is best-effort: a missing, empty, or malformed `.loom/config.json`
+falls through to `"all"` and never causes the hook to exit non-zero.
+
+**Examples**:
+
+```bash
+# Default (all) — every force op asks, no config needed:
+git reset --hard HEAD~1                       # ASK
+git push --force origin feature/my-branch     # ASK
+
+# Opt in to branch-aware force ops for a whole repo:
+#   .loom/config.json  ->  { "guards": { "forceScope": "protected" } }
+git reset --hard HEAD~1                        # allowed (own working branch)
+git push --force origin feature/my-branch      # allowed (working branch)
+git push --force origin main                   # DENIED (ALWAYS_BLOCK, unaffected)
+
+# One-off env override — force branch-aware mode for a single command:
+LOOM_FORCE_SCOPE=protected git push --force origin feature/x   # allowed
+
+# Force the old always-ask behaviour even when the repo opts into protected:
+LOOM_FORCE_SCOPE=all git reset --hard HEAD~1   # ASK
+```
+
+### Read-Only Fast-Path Guard Toggle (`guards.readOnlyFastPath` / `LOOM_GUARD_READONLY_FASTPATH`)
+
+`guard-destructive.sh` is a `PreToolUse`/`Bash` hook, so it fires before **every** Bash tool call. In Bash-dense sessions (remote ops, benchmark drivers) nearly every call is obviously read-only — `git status`, `ls`, `grep`, `aws … describe*`, `gh … list` — yet each one otherwise runs the full deny/ask gauntlet (~37 `grep`/`awk`/`sed` forks plus a `git rev-parse`, ~179ms measured) before falling through to `allow`.
+
+The read-only fast path (issue #3687) short-circuits that overwhelmingly-common case to a **silent** `allow` (exit 0, zero stdout/stderr, no logging) using a single bash-builtin structural test — zero forks — plus, only when that test passes, one lazy `jq` config read. It runs first, before the `git rev-parse` repo-root resolution and before any deny/ask array.
+
+The fast path is **on by default**. It is resolved in this order (highest precedence first):
+
+1. **`LOOM_GUARD_READONLY_FASTPATH` env var** — `0`/`false`/`no` disables the fast path (every command takes the full deny/ask path, byte-for-byte as before); `1`/`true`/`yes` forces it on. Overrides the config value.
+2. **`.loom/config.json`** — `guards.readOnlyFastPath` (default `true` when absent). Set it to `false` to disable:
+   ```json
+   {
+     "guards": {
+       "readOnlyFastPath": false
+     }
+   }
+   ```
+3. **Default** — `true` (fast path active).
+
+**Security — the fast path is a guard bypass by construction**, so admission is purely **structural** and conservative, never content-sensitive. A command is fast-pathed only when **all** of these hold (otherwise it falls through to the full path unchanged):
+
+- The raw command contains **none** of `;` `&` `|` `<` `>` backtick `$(` or a newline — this excludes all chaining, piping, redirection, and command substitution. So `git status && git push --force origin main`, `git status; rm -rf /`, and `git status $(rm -rf /)` all take the full path and are still denied.
+- The **first token** is an exact allowlist match (never a wrapper — `bash -c`, `sh -c`, `eval`, `xargs`, `env … git status`, `sudo git status` are all excluded because their first token isn't allowlisted):
+
+| First token | Admitted form |
+|-------------|---------------|
+| `git` | `git status` / `git log` / `git diff` / `git show` — **bare** subcommand only (so `git -C /path status` is not admitted) |
+| `ls`, `grep`, `rg` | any arguments |
+| `jq`, `wc`, `head`, `tail` | any arguments (pure read-only text/JSON filters — none has an in-place-mutation flag) |
+| `test`, `[`, `[[` | any arguments (boolean file/string test builtins — no mutation surface) |
+| `find` | any arguments **except** those containing a dangerous action-primary — `-delete`, `-exec`, `-execdir`, `-ok`, `-okdir`, `-fls`, `-fprint`, `-fprint0`, `-fprintf` — which structurally disqualify the command and route it to the full path |
+| `gh` | `gh <noun> view` / `gh <noun> list` (never `delete`/`close`/`archive`/…) |
+| `aws` | `aws <service> describe*` / `get*` / `list*`, and `aws s3 ls` |
+
+**`cat` and `ssh` are deliberately EXCLUDED** from the built-in list, even though they are read-only in spirit:
+
+- `cat` has a narrow existing `ASK` carve-out (`cat …/.ssh/…`, `cat …/.aws/credentials`); a blanket `cat` fast-path would silently skip it.
+- `ssh <host> '<cmd>'` wraps an **opaque remote command string** that the raw `ALWAYS_BLOCK` catastrophic scan still covers today; fast-pathing any `ssh …` would drop that coverage.
+
+**Optional extend-only escape hatch** — `guards.readOnlyFastPathExtra` is an array of **literal first-word commands** to add to the built-in list without hand-editing the Loom-managed `.claude/settings.json` (which the installer may overwrite). This directly answers "give operators a supported way to scope the matcher":
+
+```json
+{
+  "guards": {
+    "readOnlyFastPath": true,
+    "readOnlyFastPathExtra": ["psql"]
+  }
+}
+```
+
+> **Note**: `jq` and `wc` used to be the canonical example entries here, but as of #3772 they are part of the **built-in default** allowlist above — adding them via `readOnlyFastPathExtra` is now redundant. Use this escape hatch only for a genuinely-custom bare read-only command word (e.g. a site-specific query tool).
+
+> **Warning**: each word added here is a **guard bypass for that command word in full generality** (all arguments). Only add bare, argument-independent read-only utilities — never your own scripts or anything that could wrap a mutating call. Entries are matched as the literal first token only; no subcommand/verb parsing is applied to custom entries.
+
+The config read is best-effort and lazy: it happens only after a command has already passed the structural test, and any missing/empty/malformed `.loom/config.json` falls through to fast-path-ON. Disabling the fast path never weakens any deny/ask rule — it only makes the guard do its full work on every command again.
+
+**Examples**:
+
+```bash
+# Default: read-only commands are near-free and silent
+git status                     # fast-pathed (silent allow)
+aws ec2 describe-instances     # fast-pathed
+gh pr list                     # fast-pathed
+git status && git push --force origin main   # NOT fast-pathed → full path → DENIED
+
+# Disable the fast path for one command (restore full-path checking)
+LOOM_GUARD_READONLY_FASTPATH=0 git status
+
+# Persist the opt-out for a whole repo
+#   .loom/config.json  ->  { "guards": { "readOnlyFastPath": false } }
+
+# Extend the allowlist with a bare read-only utility (jq/wc/head/tail/find/test
+# are already built-in as of #3772 — use this for a genuinely-custom word):
+#   .loom/config.json  ->  { "guards": { "readOnlyFastPathExtra": ["psql"] } }
+```
+
+### Decision Telemetry Log (`guards.decisionLog` / `LOOM_GUARD_DECISION_LOG`)
+
+`guard-destructive.sh` **and** `guard-loom-workflow.sh` can record every **deny** and **ask** decision to a JSONL decision log (issue #3771, extended to the Loom-workflow guard in #3898), separate from `hook-errors.log`, so guard-hook friction becomes **measurable** — which patterns fire, how often, and whether a precision fix (#3755/#3756/#3757/#3898) actually cut the false-positive rate. Without it, "we keep hitting the hooks" is unquantifiable. Both guards share the **same log file, schema, and stable rule tags**, so a single reader aggregates fires across both (`guard-loom-workflow.sh`'s two denies carry the tags `loom:gh-pr-merge-redirect` and `loom:pip-install-editable-worktree`).
+
+The log is **off by default** — enabling it writes a new persistent, cross-session artifact, so like the other opt-in data-collection features (transcript archival #3726, the model-cost experiment #3725) a zero-config install sees no new file and no behaviour change. It is resolved in this order (highest precedence first):
+
+1. **`LOOM_GUARD_DECISION_LOG` env var** — `1`/`true`/`yes`/`on` enables; `0`/`false`/`no`/`off` disables. Overrides the config value.
+2. **`.loom/config.json`** — `guards.decisionLog` (default `false` when absent). Set it to `true` to enable:
+   ```json
+   {
+     "guards": {
+       "decisionLog": true
+     }
+   }
+   ```
+3. **Default** — `false` (no decision log written).
+
+When enabled, each deny/ask appends **one JSON object per line** to `.loom/logs/guard-decisions.log` (`SCRIPT_DIR`-relative, mirroring `hook-errors.log`; override the path with `LOOM_GUARD_DECISION_LOG_FILE`). **Stable schema** (the contract downstream reader tooling in #3772 depends on — field names are load-bearing):
+
+```json
+{"ts":"2026-07-22T23:17:13Z","decision":"deny","pattern":"sql-ddl","tier":"catastrophic","command":"<redacted>"}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `ts` | UTC timestamp (`date -u '+%Y-%m-%dT%H:%M:%SZ'`, same as `hook-errors.log`) |
+| `decision` | `deny` or `ask` |
+| `pattern` | a short, stable rule tag (e.g. `sql-ddl`, `rm-protected-path`, `force-op:protected`, `cloud-cli:<pattern>`) — **not** the full free-text reason |
+| `tier` | `catastrophic` for a deny, `ask` for an ask |
+| `command` | the command string, **redacted** via `strip_literal_text()` so no raw `--body`/`-m`/`--title`/`--notes`/`--comment` secret value is persisted |
+
+**`allow` decisions are never logged** — the #3687 read-only fast path's zero-overhead silent-allow stays silent, and allow-logging would swamp the log with the ~99% common case. Logging is **best-effort / fail-open**: the toggle is resolved lazily (only once a deny/ask is about to fire, so it never touches the fast path's hot path), and a log-write failure (permission denied, disk full, missing dir) never changes the deny/ask decision and never causes the hook to exit non-zero. `.loom/logs/` is gitignored.
+
+Summarize fires by rule (a fuller reader/aggregation CLI is #3772's scope):
+
+```bash
+jq -r '.pattern' .loom/logs/guard-decisions.log | sort | uniq -c | sort -rn
+```
+
+**Examples**:
+
+```bash
+# Enable for a single command (e.g. to capture one session's fires)
+LOOM_GUARD_DECISION_LOG=1 claude -p "/loom:builder" --dangerously-skip-permissions
+
+# Persist for a whole repo
+#   .loom/config.json  ->  { "guards": { "decisionLog": true } }
+
+# Force off for one command even when the repo opts in
+LOOM_GUARD_DECISION_LOG=0 <command>
+```
+
+### Autonomous Guard Defaults + Standing Per-Trigger Review Policy (#3898)
+
+A headless sweep runs under `--dangerously-skip-permissions`, where the guard `PreToolUse` hooks **fire** but an **ASK decision has no human to answer it — so it blocks**, functionally a silent deny. Every guard ASK therefore stalls autonomous work. To converge the guard toward *dangerous-only* without ever weakening a genuine safety rule, autonomous mode combines two guard defaults with a standing feedback loop.
+
+**Autonomous guard defaults** — set by `./.loom/scripts/cli/loom-daemon-start.sh` (each env-overridable; an already-exported value always wins), inherited by every dispatched `/loom:sweep` child:
+
+| Env var | Autonomous default | Why |
+|---------|--------------------|-----|
+| `LOOM_GUARD_DECISION_LOG` | `1` (on) | Capture every DENY/ASK so the review loop below has data. |
+| `LOOM_FORCE_SCOPE` | `protected` | Let an agent force-push / hard-reset its **own** working branch without a stall; force-push to `main`/`master`/default stays a **hard DENY** via `ALWAYS_BLOCK_PATTERNS`. |
+
+`guards.forceScope: "protected"` is the **Loom-recommended default for autonomous repos** — set it in committed `.loom/config.json` for repos that run the daemon, or rely on the start-script env default. The shipped hook default remains `"all"` (byte-for-byte unchanged for non-autonomous installs).
+
+**Standing per-trigger review policy** — a periodic support role (the **Auditor**, see `.loom/roles/auditor.md`) tails `.loom/logs/guard-decisions.log`, dedups by `pattern`, and files **one issue per distinct trigger** observed in autonomous runs, proposing to either (a) **allowlist / refine** the guard for the in-scope op or (b) **confirm it stays flagged**. Over time this converges the guard to dangerous-only. The dedup + summarize one-liner:
+
+```bash
+jq -r '.pattern' .loom/logs/guard-decisions.log | sort | uniq -c | sort -rn
+```
+
+New issues from this policy enter through normal intake (`loom:triage` → Curator → Champion/human approval); the review role never self-applies `loom:issue`.
+
+**First refinement pass (#3898):**
+- `guards.forceScope:"protected"` recommended for autonomous repos (above).
+- The catastrophic scan no longer false-positives on **documentation text** — a dangerous command merely *mentioned* inside a multi-line `--body`/`-m`/`--title`/`--notes`/`--comment` value (e.g. `gh issue create --body "…"`) is redacted as a single span and does **not** deny, while a genuinely dangerous command, or a command-substitution `$(…)` smuggled inside such a value, still DENIES.
+- `git checkout .` / `git restore .` / `git clean -fd` **stay ASK** (evaluated, kept flagged): they irreversibly discard uncommitted/untracked work, so the standing policy files a per-trigger issue rather than blanket-allowlisting them. A repo that wants them to pass headless can add the command word to an allowlist per its own risk decision.
+
+### Protecting Read-Only Directories
+
+Many projects have directories that should never be modified by agents (vendor code, generated files, external SDKs, process design kits). Loom provides a template hook for this.
+
+**Setup**:
+
+1. Copy the template to your hooks directory:
+   ```bash
+   cp defaults/hooks/guard-readonly-dirs.sh.template .loom/hooks/guard-readonly-dirs.sh
+   chmod +x .loom/hooks/guard-readonly-dirs.sh
+   ```
+
+2. Edit `.loom/hooks/guard-readonly-dirs.sh` and add your protected directories:
+   ```bash
+   PROTECTED_DIRS=(
+       "vendor/"
+       "third_party/"
+       "generated/"
+   )
+   ```
+
+3. Register the hook in `.claude/settings.json`:
+   ```json
+   {
+     "hooks": {
+       "PreToolUse": [
+         {
+           "matcher": "Edit|Write",
+           "hooks": [{ "type": "command", "command": ".loom/hooks/guard-readonly-dirs.sh" }]
+         }
+       ]
+     }
+   }
+   ```
+
+**How it works**: The hook intercepts Edit and Write tool calls, resolves the target file path to an absolute path, and checks whether it falls within any of the listed directories (relative to the repository root). If it does, the edit is blocked with a clear error message. The hook follows the same error-handling patterns as `guard-destructive.sh` (ERR trap, jq fallback, never exits non-zero).
+
+**Interaction with other hooks**: This hook uses the `Edit|Write` matcher, while `guard-destructive.sh` uses the `Bash` matcher, so they do not conflict. If `guard-worktree-paths.sh` is also active (same `Edit|Write` matcher), both hooks run in sequence -- if either denies, the action is blocked.
+
+**Template location**: `defaults/hooks/guard-readonly-dirs.sh.template`

--- a/defaults/docs/health-monitoring.md
+++ b/defaults/docs/health-monitoring.md
@@ -1,0 +1,118 @@
+# Health Monitoring
+
+Proactive health monitoring for extended unattended autonomous operation — health
+score, CLI, alert types, files, configuration, MCP tools, and the UI dashboard.
+
+## Health Monitoring
+
+Loom provides proactive health monitoring for extended unattended autonomous operation. The health system tracks throughput, latency, error rates, and resource usage to detect degradation patterns before they become critical.
+
+### Health Score
+
+The health score (0-100) is computed from multiple factors:
+- **Throughput trend** - Declining throughput reduces score
+- **Queue depth trend** - Growing queues reduce score
+- **Error rate** - Increasing errors reduce score
+- **Resource availability** - Near capacity limits reduce score
+- **Stuck agents** - Agents without heartbeats reduce score
+
+Score ranges:
+| Range | Status | Description |
+|-------|--------|-------------|
+| 90-100 | Excellent | System operating optimally |
+| 70-89 | Good | Normal operation, minor issues |
+| 50-69 | Fair | Some degradation detected |
+| 30-49 | Warning | Significant issues, attention needed |
+| 0-29 | Critical | Immediate intervention required |
+
+### Health Monitoring CLI
+
+```bash
+# View current health status
+./.loom/scripts/health-check.sh
+
+# JSON output for automation
+./.loom/scripts/health-check.sh --json
+
+# Collect and store metrics (called by daemon)
+./.loom/scripts/health-check.sh --collect
+
+# View alerts
+./.loom/scripts/health-check.sh --alerts
+
+# Acknowledge an alert
+./.loom/scripts/health-check.sh --acknowledge <alert-id>
+
+# View metric history (last 4 hours)
+./.loom/scripts/health-check.sh --history 4
+```
+
+### Alert Types
+
+| Alert Type | Description | Severity |
+|------------|-------------|----------|
+| `stuck_agents` | Agents without recent heartbeats | warning/critical |
+| `high_error_rate` | Consecutive iteration failures | warning/critical |
+| `resource_exhaustion` | Session budget near limits | warning/critical |
+| `queue_growth` | Ready queue growing without progress | warning |
+| `throughput_decline` | Significant throughput drop | warning |
+
+### Health Files
+
+| File | Purpose |
+|------|---------|
+| `.loom/health-metrics.json` | Historical health metrics (24-hour retention) |
+| `.loom/alerts.json` | Active and acknowledged alerts |
+
+### Configuration
+
+Health monitoring thresholds can be configured via environment variables:
+
+```bash
+LOOM_HEALTH_RETENTION_HOURS=24       # Metric retention period
+LOOM_THROUGHPUT_DECLINE_THRESHOLD=50 # % decline to trigger alert
+LOOM_QUEUE_GROWTH_THRESHOLD=5        # Queue growth count threshold
+LOOM_STUCK_AGENT_THRESHOLD=10        # Minutes without heartbeat
+LOOM_ERROR_RATE_THRESHOLD=20         # % error rate threshold
+```
+
+Or via `.loom/config.json`:
+
+```json
+{
+  "health_monitoring": {
+    "enabled": true,
+    "collect_interval_minutes": 5,
+    "retention_hours": 24,
+    "thresholds": {
+      "throughput_decline_percent": 50,
+      "queue_growth_count": 5,
+      "stuck_agent_minutes": 10,
+      "error_rate_percent": 20
+    }
+  }
+}
+```
+
+### MCP Health Tools
+
+The following MCP tools are available for health monitoring:
+
+| Tool | Description |
+|------|-------------|
+| `get_health_metrics` | Get current health score and latest metrics |
+| `get_health_history` | Get historical metrics for trend analysis |
+| `get_active_alerts` | Get unacknowledged alerts |
+| `acknowledge_alert` | Acknowledge an alert by ID |
+
+### UI Health Dashboard
+
+Access the Health Dashboard via:
+- Menu: View > Health Dashboard
+- Keyboard: Cmd+H (macOS) / Ctrl+H (Windows/Linux)
+
+The dashboard displays:
+- Health score gauge with status indicator
+- Current metrics grid (throughput, queues, errors, resources)
+- Active alerts with acknowledge button
+- Historical trends with sparkline visualizations

--- a/defaults/docs/model-cost-experiment.md
+++ b/defaults/docs/model-cost-experiment.md
@@ -1,0 +1,78 @@
+# Model-Cost Experiment
+
+Reference detail for the `/loom:sweep` model-cost A/B experiment (#3725). Treated
+as the authoritative behavior contract by
+[`docs/model-selection-retune.md`](https://github.com/rjwalters/loom/blob/main/docs/model-selection-retune.md).
+
+### Model-Cost Experiment (canary A/B, #3725)
+
+`/loom:sweep` can instrument a run to produce the balanced A/B evidence the
+measurement-gated Builder `opus → sonnet` retune (#3718) needs — you cannot
+generate it by observation alone, since passive collection only ever measures
+whatever the current Builder default is. **Off by default; zero behavior change
+unless you turn it on.** Tri-state `sweep.modelExperiment` /
+`LOOM_MODEL_EXPERIMENT` (env-over-config, string-valued like `guards.rmScope`):
+
+| Mode | Behavior |
+|------|----------|
+| `off` (default) | No instrumentation. No `.loom/stats/` file. Byte-for-byte unchanged. |
+| `observe` | Passive: one JSONL record per phase to `.loom/stats/sweep-model-stats.jsonl`. No model forcing. Safe anywhere. |
+| `experiment` | Active A/B: Builder forced to the per-issue arm's model. **Canary-only.** |
+
+```bash
+# Observe on any sweep (no behavior change, just records the outcome-chain):
+LOOM_MODEL_EXPERIMENT=observe claude -p "/loom:sweep 123" --dangerously-skip-permissions
+
+# Experiment on a canary (must confirm the canary — else it downgrades to observe):
+LOOM_MODEL_EXPERIMENT=experiment LOOM_MODEL_EXPERIMENT_CANARY=1 \
+  claude -p "/loom:sweep 123" --dangerously-skip-permissions
+```
+
+**Two arms** map onto #3718's inequality: **Arm A = opus-first** (Builder→opus),
+**Arm B = sonnet-first + escalate-on-Judge-rejection** (Builder→sonnet, escalating
+via the `sweep.escalation` ladder). Arm assignment is a **deterministic,
+resume-safe** function of the issue number, **stratified by the Curator complexity
+marker** (#3702) so both arms see a comparable difficulty mix — a killed-and-resumed
+sweep re-lands the same arm. In `experiment` mode the tier-2.5 complexity bump is
+**suppressed** (the marker is used only as the stratification key), so a
+`complex`-marked issue on Arm B stays sonnet and the A/B is not confounded.
+
+**Guardrails:** off by default; `observe` safe anywhere; `experiment` refuses to
+run on a non-canary target and loudly downgrades to `observe` unless an
+**uncommitted** signal confirms a canary — the `LOOM_MODEL_EXPERIMENT_CANARY=1`
+env var or the gitignored `.loom/CANARY` sentinel file. The confirmation must be
+uncommitted **by design** (#3731): the committed `sweep.modelExperimentCanary`
+config flag is **no longer** an accepted confirmation (it would propagate with a
+copied config via `defaults/`, firing experiment on production). A git-tracked
+`.loom/CANARY` is likewise refused. The `sweep.modelExperiment` *mode* may still
+live in committed config — it is inert without the uncommitted confirmation. A
+loud startup banner names the active mode, the canary confirmation source, and,
+in `experiment`, the arm assigned to each issue. `.loom/stats/` and `.loom/CANARY`
+are gitignored.
+
+**Harvesting the evidence:**
+
+```bash
+./.loom/scripts/agent-metrics.sh --model-experiment --archive-dir "$LOOM_TRANSCRIPT_ARCHIVE"
+```
+
+The load-bearing signal is the **deterministic outcome-chain** (arm / model /
+attempt / Judge verdict / Doctor-cycle count / complexity) — that alone answers
+#3718's inequality (first-attempt Judge-pass rate + mean Doctor cycles × model
+price), and it is stamped into the durable store per phase.
+
+**On token fidelity — read this before trusting a cost number.** There is **no
+per-phase real-token split at the Task-result boundary** (the harness does not
+surface per-subagent `usage` when a Task returns). Instead, **exact per-role cost
+is recovered at harvest time** by parsing each role subagent's durable
+`agent-<id>.jsonl` transcript — each Builder / Judge / Doctor invocation is its own
+transcript with full per-message `usage` (input/output + cache read/creation
+split + model), so this is true per-role granularity, not a whole-process
+aggregate. Cost uses the same cache-aware per-model pricing as `loom-daemon`'s
+`resource_usage.rs`. Harvest locates transcripts through the #3726 transcript
+archive's `agent-<id>`-keyed index (`--archive-dir` = `LOOM_TRANSCRIPT_ARCHIVE`),
+joined on the agent-id stamped in each stats record. Over a **multi-day canary**,
+run harvest periodically (cron) so usage is extracted before `~/.claude/projects`
+is pruned — or rely on the #3726 archive as the durable backstop. Each record
+carries a `token_fidelity` tag (`transcript` | `sweep-aggregate-log` | `none`) so
+you know exactly what a cost figure came from.

--- a/defaults/docs/model-selection.md
+++ b/defaults/docs/model-selection.md
@@ -1,0 +1,105 @@
+# Model Selection Strategy
+
+How Loom resolves each worker's model, the Judge-rejection escalation ladder, and
+the suggested-model defaults by role. Retuning these defaults is measurement-gated
+— see [`docs/model-selection-retune.md`](https://github.com/rjwalters/loom/blob/main/docs/model-selection-retune.md).
+
+### Model Selection Strategy
+
+Model selection is a first-class orchestration concern (issue #3477, Phase 1). Each worker's model is resolved through a fixed precedence chain — highest first:
+
+1. **Explicit dispatch param** — `mcp__loom__dispatch_sweep`'s optional `model` argument (daemon path), an explicit `--model` flag passed to `spawn-claude.sh` / `claude-wrapper.sh`, or an operator-requested model for an in-session sweep.
+2. **Workspace override** — `.loom/config.json` → `terminals[].roleConfig.model` (optional). Pin exact IDs here (e.g., `claude-sonnet-4-6`) when your workspace needs deterministic cost/behavior.
+3. **Role default** — `.loom/roles/<role>.json` → `suggestedModel` (ships as an alias). The `/loom:sweep` skill passes the resolved model to role subagents via the Task tool's `model` parameter.
+4. **Session default** — when nothing above resolves, NO `--model` flag (and no Task `model` param) is emitted at all, and the worker inherits the parent session/CLI default. This is the zero-config behavior: nothing configured means nothing changes.
+
+The spawn plumbing also honors a `LOOM_MODEL` environment variable (`spawn-claude.sh`, `claude-wrapper.sh`): it is injected as `--model <value>` unless an explicit `--model` is already present in the args. Retries inside `claude-wrapper.sh` always reuse the same model — transport-level failures (token exhaustion, crashes, 5xx) are not quality signals and never change the model.
+
+**Escalation on Judge rejection (`sweep.escalation`, Phase 2, issue #3481)**:
+
+The `/loom:sweep` orchestrator escalates one rung up a capability ladder when the Judge rejects a PR (`loom:changes-requested`) and a Doctor is dispatched to address the feedback. The escalation decision is made by the sweep orchestrator at Doctor-dispatch time — never by `claude-wrapper.sh` retries, never by worker self-assessment. Mode C (`--prs`) inherits the same rule for its Doctor phase (step C1b).
+
+The ladder is configured in `.loom/config.json`:
+
+```json
+{
+  "sweep": {
+    "escalation": ["sonnet", "opus"]
+  }
+}
+```
+
+| Value | Behavior |
+|-------|----------|
+| Key absent | Default ladder `["sonnet", "opus"]` applies |
+| `[]` or `false` | Escalation disabled entirely (pure Phase 1 behavior) |
+| Non-empty array | As configured; rungs accept aliases or pinned IDs |
+
+**Precedence interaction**: escalation replaces only tier 3 (`suggestedModel`) / tier 4 (session default) resolution for the rejection-triggered Doctor. Tier 1 (explicit dispatch param) and tier 2 (`roleConfig.model` workspace pin) always win — pins are never overridden. `ladder[0]` never overrides anything either: first attempts of every role use the unmodified precedence chain, and the ladder only fires on rejection (the rejection-triggered Doctor gets `ladder[1]`).
+
+**Cap interaction**: escalation composes with — and does not extend — the configurable Doctor→Judge cycle cap (`sweep.max_doctor_cycles`, default 1; issue #3668). The ladder is consumed as `ladder[min(attempt - 1, len - 1)]`, so raising the cap above 1 (or granting the default-cap distinct-defect grace cycle) activates deeper rungs automatically. At the default cap of 1, a second Judge rejection blocks the PR rather than dispatching another Doctor — unless that second rejection is a demonstrably distinct defect from the first, in which case the orchestrator may grant one logged, single-use grace cycle (never on an operator-raised cap). The sweep checkpoint's optional `attempt` field (`sweep-checkpoint.sh write N doctor-done --attempt 2`) records the cycle count (2 = first Doctor cycle, 3 = second, …); absent means attempt 1, and legacy checkpoints without the field read cleanly.
+
+**Suggested models by role** (`suggestedModel`, live as the role-default tier):
+
+| Role | Model | Rationale |
+|------|-------|-----------|
+| Builder | `opus` | Complex implementation requires deep reasoning |
+| Judge | `opus` | Code review needs thorough understanding |
+| Curator | `sonnet` | Issue enhancement is structured |
+| Doctor | `sonnet` | PR fixes are usually targeted and scoped |
+| Architect | `opus` | System design requires sophisticated thinking |
+| Hermit | `sonnet` | Code removal analysis is pattern-based |
+| Champion | `sonnet` | Proposal evaluation has clear criteria |
+| Guide | `sonnet` | Triage is systematic |
+| Driver | `sonnet` | General-purpose default |
+
+> **Retuning these defaults is measurement-gated.** Whether to flip a role's
+> default `opus → sonnet` ("cheap-first") is decided by measured data, not edited
+> blind — see [`docs/model-selection-retune.md`](https://github.com/rjwalters/loom/blob/main/docs/model-selection-retune.md)
+> (upstream Loom repo) for the decision inequality and the `agent-metrics.sh
+> --by-model` (#3482) gating procedure. Builder is the only real candidate; no
+> default has been flipped.
+
+**Valid model values**: aliases (`haiku`, `sonnet`, `opus`) or pinned model IDs (e.g., `claude-sonnet-4-6`).
+
+- **haiku**: Fast, cheap - for simple status checks and monitoring
+- **sonnet**: Balanced - for structured tasks with clear criteria
+- **opus**: Most capable - for complex reasoning and implementation
+
+**Aliases vs pinned IDs**: shipped role JSONs use aliases so defaults stay sensible across model releases with zero maintenance. The GitHub Actions cron workflows (`.github/workflows/loom-*.yml`) are the exception — they pin exact IDs because scheduled support roles are predictable, cost-sensitive load and a stale pin is visible and cheap to bump in the consuming repo.
+
+> **Logical-tier resolution (`sweep.modelAliases`, issue #3982).** A logical alias
+> is not always current on the wire: the bare `opus` alias still resolves to a
+> **previous-generation** model (`claude-opus-4-8`) while `sonnet`/`fable` resolve
+> to the current generation, which would make the escalation ladder
+> `sonnet → sonnet@xhigh → opus → fable` step *down* a generation at the `opus`
+> rung. So every consumer keeps naming `opus` and a **single indirection point**
+> maps the logical tier to the concrete ID the dispatch should use — the
+> `/loom:sweep` skill via `./.loom/scripts/resolve-model.sh`, `loom_tools` via
+> `model_tiers`, and `loom-daemon` via `resolve_dispatch_model`. The shipped map
+> pins only the stale tier (`opus → claude-opus-5`); `sonnet`/`fable` and pinned
+> IDs pass through unchanged. Repoint or drop a pin per-repo with an additive
+> `.loom/config.json` → `sweep.modelAliases` object (no code change):
+>
+> ```json
+> { "sweep": { "modelAliases": { "opus": "claude-opus-5" } } }
+> ```
+
+**Workspace override example** (`.loom/config.json`):
+
+```json
+{
+  "terminals": [
+    {
+      "id": "terminal-1",
+      "name": "Builder",
+      "role": "claude-code-worker",
+      "roleConfig": {
+        "workerType": "claude",
+        "roleFile": "builder.md",
+        "model": "claude-sonnet-4-6"
+      }
+    }
+  ]
+}
+```

--- a/docs/model-selection-retune.md
+++ b/docs/model-selection-retune.md
@@ -13,7 +13,7 @@ shipped), #3482 / PR #3485 (the `--by-model` measurement plumbing — already
 shipped), #3706 (this document).
 
 > **Hard rule.** Do **not** edit any `suggestedModel` value in
-> `defaults/roles/*.json`, nor the model values in the `defaults/CLAUDE.md`
+> `defaults/roles/*.json`, nor the model values in the `defaults/docs/model-selection.md`
 > "Suggested models by role" table, until the inequality below is demonstrated
 > **for that specific role** over a representative sample. The flip is a separate,
 > data-gated follow-up PR. This document changes no default.
@@ -164,7 +164,7 @@ parallel, purpose-built collector — the `/loom:sweep` model-cost experiment
 `.loom/stats/sweep-model-stats.jsonl` (arm / model / attempt / Judge verdict /
 Doctor-cycle count / complexity) and harvests it into exactly the per-arm §2
 inequality inputs. This runbook is the copy-pasteable procedure for accruing that
-sample. See `defaults/CLAUDE.md` § "Model-Cost Experiment (canary A/B, #3725)" for
+sample. See [`defaults/docs/model-cost-experiment.md`](../defaults/docs/model-cost-experiment.md) for
 the full behavior contract.
 
 > **This runbook is the *tooling*. The multi-day accrual run itself — turning on a
@@ -337,7 +337,7 @@ here changes a default** unless it also cites a qualifying sample per Section 3.
   **Decision:** `defaults/roles/builder.json` `suggestedModel` remains `opus`. No
   default changed, preserving the Hard Rule at the top of this document. Accruing the
   sample is out-of-band, over-time work (a multi-day `LOOM_MODEL_EXPERIMENT=observe`
-  or canary `experiment` campaign per `defaults/CLAUDE.md` § "Model-Cost Experiment"),
+  or canary `experiment` campaign per [`defaults/docs/model-cost-experiment.md`](../defaults/docs/model-cost-experiment.md)),
   not a Builder code change. `observe` mode is the suggested follow-up mechanism for
   generating the `sonnet` vs `opus` data points a passive `opus`-only default can
   never produce on its own.
@@ -406,7 +406,7 @@ When — and only when — conditions (1) and (2) both hold for a specific role 
 sample meeting Section 3's prerequisites:
 
 1. Open a **separate** PR that flips *only that one role's* `suggestedModel`
-   (Builder first), and updates the corresponding row in the `defaults/CLAUDE.md`
+   (Builder first), and updates the corresponding row in the `defaults/docs/model-selection.md`
    "Suggested models by role" table.
 2. Cite the measured `cost(sonnet_first)`, `cost(opus_first)`,
    `merge_rate` values and the sample size in the PR body.

--- a/loom-daemon/src/init/mod.rs
+++ b/loom-daemon/src/init/mod.rs
@@ -1527,6 +1527,24 @@ mod tests {
              report it MISSING on every install (#3476)"
         );
 
+        // Reference docs extracted from defaults/CLAUDE.md in #4143 (Phase 2 of
+        // #4052). They must ship from defaults/docs/ so live cross-references
+        // (CLAUDE.md guard catalog, docs/model-selection-retune.md) do not orphan
+        // when Phase 3 deletes defaults/CLAUDE.md.
+        for doc in &[
+            "guard-hooks.md",
+            "model-selection.md",
+            "model-cost-experiment.md",
+            "health-monitoring.md",
+            "advanced-hooks.md",
+        ] {
+            assert!(
+                defaults.join("docs").join(doc).is_file(),
+                "defaults/docs/{doc} missing — the #4143 reference-doc extraction \
+                 must ship it to <target>/.loom/docs/ or its cross-reference dangles"
+            );
+        }
+
         // The old nested location must stay gone: a file reappearing at
         // defaults/.loom/docs/ would be manifest-listed (via the `.loom/*`
         // literal rule in scripts/install/manifest.sh) but never copied by


### PR DESCRIPTION
## Summary

Phase 2 of 3 of parent #4052. Migrates the **reference-tier** content that
currently lives only in `defaults/CLAUDE.md` into shipped `defaults/docs/*.md`
files, and repoints every *live* cross-reference at the new home — so Phase 3
(#4144) can delete `defaults/CLAUDE.md` without orphaning a live pointer.
`defaults/CLAUDE.md` is intentionally **left in place** this phase.

Docs are authored at **`defaults/docs/`** (NOT `defaults/.loom/docs/`), so
`sync_managed_dir` copies them to `<target>/.loom/docs/` on install. No installer
code change was required — only content extraction, link repointing, and an added
test assertion.

## Changes

New reference docs (content byte-identical to the source sections):

- `defaults/docs/guard-hooks.md` — Custom Guard Hooks catalog + all eight
  `guards.*` toggles, Autonomous Guard Defaults, Protecting Read-Only Directories
- `defaults/docs/model-selection.md` — Model Selection Strategy (resolution chain,
  escalation ladder, "Suggested models by role" table)
- `defaults/docs/model-cost-experiment.md` — the `/loom:sweep` model-cost A/B
  experiment (#3725)
- `defaults/docs/health-monitoring.md` — health score, CLI, alert types, files,
  MCP tools, UI dashboard
- `defaults/docs/advanced-hooks.md` — Methodology Injection Framework + Session
  Transcript Archival

Repointed cross-references (all `defaults/CLAUDE.md` mentions removed from these):

- `CLAUDE.md` guard-catalog pointer → `defaults/docs/guard-hooks.md`
- `docs/model-selection-retune.md` ×4 → `model-selection.md` (:16, :409, the
  "Suggested models by role" table) / `model-cost-experiment.md` (:167, :340)
- `defaults/.loom/CLAUDE.md` — added consumer-relative `.loom/docs/*.md` links to
  all five new docs (Configuration bullets + Docs resource list)
- `loom-daemon/src/init/mod.rs` — extended `test_real_defaults_tree_ships_docs_at_top_level`
  to assert the five new docs ship

## Acceptance Criteria Verification

- [x] Guard-toggle catalog and Model-Cost Experiment content exist under
  `defaults/docs/`, reachable from `defaults/.loom/CLAUDE.md`
- [x] `git ls-files 'defaults/.loom/docs/*'` returns nothing (forbidden nested
  location not reintroduced)
- [x] `git grep -nE 'defaults/CLAUDE\.md' -- CLAUDE.md docs/model-selection-retune.md`
  returns **zero hits**; each repointed reference resolves to an existing file with
  the referenced content
- [x] Fresh install writes every new `defaults/docs/*.md` into `<target>/.loom/docs/`
  (verified manually + by the extended tripwire test)
- [x] `defaults/CLAUDE.md` still exists; migrated sections are **byte-comparable**
  to the new docs (verified via `diff`); all eight guard toggles survive
- [x] Both test suites pass

## Test Plan

- [x] `cargo test -p loom-daemon init` — 127 passed, incl.
  `test_real_defaults_tree_ships_docs_at_top_level`,
  `test_docs_subdirectory_copied_on_fresh_install`,
  `test_docs_subdirectory_restored_on_reinstall`
- [x] `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/test_installation_verification.py` — 27 passed, 22 skipped
- [x] Manual: `loom-daemon init` into a scratch repo → all five docs present at
  `.loom/docs/` alongside `ci-integration.md`; `--force` reinstall shows no
  duplication
- [x] Manual: `verify-install.sh check-links` on the installed scratch repo → "All
  intra-repo links resolve (76 files checked)", including the five new links

Part of #4052
Closes #4143