### PR TITLE
feat(spawn): spawn-worker.sh runtime dispatcher + runtimes config block (claude-only, zero behavior change)

### DIFF
--- a/.loom/docs/runtime-adapters.md
+++ b/.loom/docs/runtime-adapters.md
@@ -1,0 +1,1 @@
+../../defaults/docs/runtime-adapters.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,9 @@ Configuration lives in `.loom/config.json` (committed for team sharing): a
   self-update, epic supervisor: [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md)
   §Operability (precedence **env > config > default**; daemon defaults FLAGS-OFF).
 - **Post-Builder quality gate (`buildGate`)** — [`.loom/docs/build-gate.md`](.loom/docs/build-gate.md).
+- **Runtime dispatch (`runtimes`)** — `spawn-worker.sh` selects the worker runtime
+  (`LOOM_RUNTIME` env > `runtimes.default` > `"claude"`), execing `spawn-<runtime>.sh`:
+  [`.loom/docs/runtime-adapters.md`](.loom/docs/runtime-adapters.md).
 - **Custom roles** — add `.loom/roles/<name>.md` (and optional `<name>.json`).
 - **Branch rulesets & repository settings** — set at install time or via
   `./scripts/install/setup-branch-protection.sh` / `setup-repository-settings.sh`.
@@ -299,8 +302,7 @@ map, downstream-consumer guidance —
   [build-gate](.loom/docs/build-gate.md) ·
   [forge-auth](.loom/docs/forge-authentication.md) /
   [github-auth](.loom/docs/github-authentication.md) ·
-  [safehouse](.loom/docs/safehouse.md) ·
-  [runtime-adapters](.loom/docs/runtime-adapters.md)
+  [safehouse](.loom/docs/safehouse.md)
 
 ---
 

--- a/defaults/config.json
+++ b/defaults/config.json
@@ -8,6 +8,9 @@
       "known_hosts": []
     }
   },
+  "runtimes": {
+    "default": "claude"
+  },
   "safehouse": {
     "enabled": false,
     "socket": null,

--- a/defaults/docs/runtime-adapters.md
+++ b/defaults/docs/runtime-adapters.md
@@ -90,6 +90,11 @@ around this script; an adapter's spawn entry point is invoked the same way, so i
 must tolerate those env vars being present (Claude's script logs
 `LOOM_SWEEP_CLAIM_OWNED` on every spawn for dispatch diagnosability).
 
+The runtime-neutral **dispatch seam** that realizes this contract point today —
+`spawn-worker.sh` plus the `runtimes` config block — is specified in
+[Phase 1: the `spawn-worker.sh` runtime-dispatch seam](#phase-1-the-spawn-workersh-runtime-dispatch-seam)
+below.
+
 ### 2. Model mapping
 
 **Contract:** map Loom's **logical model tiers** (`opus`, `sonnet`,
@@ -256,6 +261,98 @@ Judge needs read-only + forge access). Dispatch computes role → runtime
 compatibility and refuses to dispatch a role onto a runtime that cannot meet its
 requirements, rather than letting the session fail partway. The declaration is
 per-runtime; the requirements are per-role; the match happens at dispatch time.
+
+## Phase 1: the `spawn-worker.sh` runtime-dispatch seam
+
+Contract point 1 ([Spawn](#1-spawn)) is realized today by a concrete
+**runtime-dispatch seam** so the underlying runtime is a swappable adapter rather
+than a hardwired path. Claude Code is adapter #1; a future Codex adapter
+(`spawn-codex.sh`) slots in behind the same seam with no caller change. This is
+**Phase 1** of epic **#4167** and is a **zero-behavior-change** extraction: with
+nothing configured, the seam execs the same `spawn-claude.sh` Loom always ran.
+(This upstreams the dispatch-seam shape the fork's PR #9 built — see the [fork
+mapping table](#fork-mapping-table) — as Loom's own Phase 1 implementation.)
+
+### The dispatcher: `spawn-worker.sh`
+
+`defaults/scripts/spawn-worker.sh` (installed to `.loom/scripts/spawn-worker.sh`)
+is a thin dispatcher that resolves a runtime name and execs the matching
+`spawn-<runtime>.sh` runner in the same directory, forwarding every argument
+verbatim. Because it uses `exec`, the runner's exit code is the dispatcher's exit
+code — so the [error classification](#3-error-classification) contract is
+unaffected by the extra hop.
+
+```bash
+.loom/scripts/spawn-worker.sh -p "your prompt"
+LOOM_RUNTIME=claude .loom/scripts/spawn-worker.sh --use-wrapper -p "..."
+```
+
+Callers migrate from `spawn-claude.sh` to `spawn-worker.sh` to gain runtime
+selection; until they do, `spawn-claude.sh` keeps working unchanged (existing
+daemon/tooling callers are intentionally left on the direct path in Phase 1).
+
+### Runtime resolution (precedence)
+
+The runtime is resolved with the standard Loom precedence chain
+(**env > config > default**):
+
+| Precedence | Source | Notes |
+|-----------|--------|-------|
+| 1 (highest) | `LOOM_RUNTIME` env var | A non-empty value wins. An **empty** value is treated as unset and falls through. |
+| 2 | `.loom/config.json` → `runtimes.default` | Read via the shared config-resolver (soft-fails silently). |
+| 3 (default) | built-in `"claude"` | Applies when neither of the above resolves. |
+
+The config read tolerates a missing config file, a missing `runtimes` block, and
+a missing `jq` — all of these degrade silently to the built-in `claude` default,
+so a bare install with no `runtimes` config sees no behavior change.
+
+### The `runtimes` config block
+
+Add to `.loom/config.json`:
+
+```json
+{
+  "runtimes": {
+    "default": "claude"
+  }
+}
+```
+
+`runtimes.default` names the runtime used when `LOOM_RUNTIME` is unset. The value
+must have a matching `spawn-<value>.sh` runner on disk (e.g. `"claude"` →
+`spawn-claude.sh`).
+
+### Adding a runtime adapter
+
+Drop a `spawn-<runtime>.sh` runner next to `spawn-claude.sh` (same directory,
+executable). It must satisfy the [Spawn interface](#1-spawn) above — accept the
+same passthrough-args contract and `exec` its underlying CLI. Then select it
+per-run with `LOOM_RUNTIME=<runtime>` or repo-wide with `runtimes.default`.
+
+### Unknown-runtime failure (exit 78)
+
+If the resolved runtime has no matching `spawn-<runtime>.sh` runner, the
+dispatcher exits **78** (`EX_CONFIG`) — the same distinct config-error code the
+Spawn contract's *missing-pool* facet uses — with an actionable message naming:
+
+- the resolved runtime,
+- where it was resolved from (env vs config vs default), and
+- the `spawn-*.sh` runners actually present on disk.
+
+```text
+ERROR Unknown runtime 'codex' (resolved from config (runtimes.default)):
+ERROR no runner found at /…/.loom/scripts/spawn-codex.sh.
+ERROR Available runtimes on disk: claude.
+```
+
+### Scope (Phase 1)
+
+- No capability-matrix enforcement in the dispatcher
+  ([contract point 7](#7-capability-declaration) is a separate issue) — the seam
+  only routes; it does not validate a runtime's feature set.
+- `spawn-claude.sh`, `claude-wrapper.sh`, the Rust `loom-daemon`, and the Python
+  `loom-tools` callers are unchanged; migrating callers onto `spawn-worker.sh`
+  is a follow-up once the seam has soaked.
 
 ## Fork mapping table
 

--- a/defaults/scripts/spawn-worker.sh
+++ b/defaults/scripts/spawn-worker.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# spawn-worker.sh - Runtime-dispatch seam in front of the worker spawn path.
+#
+# This thin dispatcher is the single indirection point that turns "the worker
+# is always Claude Code" into "the worker is whichever runtime adapter the
+# operator selected". Claude Code is adapter #1 (`spawn-claude.sh`); a future
+# Codex adapter slots in as `spawn-codex.sh` behind the same seam with no
+# caller change. It mirrors the multi-runtime fork's `spawn-worker.sh` so the
+# two trees converge (epic #4167, Phase 1).
+#
+# Zero behavior change: with no `LOOM_RUNTIME` env and no `runtimes.default`
+# in `.loom/config.json`, this execs `spawn-claude.sh` with the args
+# verbatim — byte-for-byte the same worker Loom spawned before this seam
+# existed. Existing callers that invoke `spawn-claude.sh` directly are
+# unaffected; migrating them to `spawn-worker.sh` is a follow-up.
+#
+# Runtime resolution (standard precedence, highest first):
+#   1. LOOM_RUNTIME env var (non-empty).
+#   2. `.loom/config.json` -> runtimes.default.
+#   3. Built-in default: "claude".
+#
+# Dispatch: exec "$SCRIPT_DIR/spawn-<runtime>.sh" "$@" — all args forwarded
+# verbatim, and the runner's exit code is passed through by exec.
+#
+# Failure: an unknown runtime (no matching `spawn-<runtime>.sh` on disk) exits
+# 78 (EX_CONFIG) with a message naming the resolved runtime, where it was
+# resolved from (env vs config vs default), and the runners actually present.
+#
+# Usage:
+#   .loom/scripts/spawn-worker.sh -p "your prompt"
+#   LOOM_RUNTIME=claude .loom/scripts/spawn-worker.sh --use-wrapper -p "..."
+#
+# Env vars:
+#   LOOM_RUNTIME     Selects the runtime adapter (highest precedence). An empty
+#                    value is treated as unset (falls through to config/default).
+#   LOOM_WORKSPACE   Override repo-root detection (used only to locate
+#                    `.loom/config.json`).
+
+set -euo pipefail
+
+# --- Logging helpers (match loom convention) ---
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')]${NC} $*" >&2; }
+log_warn() { echo -e "${YELLOW}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] WARN${NC} $*" >&2; }
+log_error() { echo -e "${RED}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] ERROR${NC} $*" >&2; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Repo root resolution (handles worktrees) ---
+# Only used to locate `.loom/config.json`. Mirrors spawn-claude.sh:
+#   1. Trust LOOM_WORKSPACE if set.
+#   2. Else derive from `git rev-parse --git-common-dir` (works in worktrees).
+#   3. Else fall back relative to this script (.loom/scripts -> repo root).
+_resolve_workspace() {
+    if [[ -n "${LOOM_WORKSPACE:-}" ]]; then
+        printf '%s\n' "$LOOM_WORKSPACE"
+        return
+    fi
+
+    local git_common_dir
+    if git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null)"; then
+        if [[ ! "$git_common_dir" = /* ]]; then
+            git_common_dir="$(cd "$git_common_dir" && pwd)"
+        fi
+        printf '%s\n' "$(dirname "$git_common_dir")"
+        return
+    fi
+
+    cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd
+}
+
+# --- List the spawn-<runtime>.sh runners present on disk (for messages) ---
+# Echoes a space-separated list of runtime names (the `<runtime>` slug), with
+# the dispatcher itself (`worker`) excluded.
+_available_runtimes() {
+    local f name
+    local found=()
+    for f in "$SCRIPT_DIR"/spawn-*.sh; do
+        [[ -e "$f" ]] || continue
+        name="$(basename "$f")"
+        name="${name#spawn-}"
+        name="${name%.sh}"
+        [[ "$name" == "worker" ]] && continue
+        found+=("$name")
+    done
+    printf '%s' "${found[*]:-<none>}"
+}
+
+# --- Resolve the runtime (env > config > default) ---
+RUNTIME=""
+RUNTIME_SOURCE=""
+
+if [[ -n "${LOOM_RUNTIME:-}" ]]; then
+    RUNTIME="$LOOM_RUNTIME"
+    RUNTIME_SOURCE="env (LOOM_RUNTIME)"
+else
+    _cfg_runtime=""
+    _resolver_lib="$SCRIPT_DIR/lib/config-resolver.sh"
+    if [[ -f "$_resolver_lib" ]]; then
+        # shellcheck source=./lib/config-resolver.sh
+        source "$_resolver_lib"
+        _workspace="$(_resolve_workspace)"
+        # loom_config_get soft-fails to the default (here "") on a missing
+        # config file, a missing `runtimes` block, or a missing `jq` — so a
+        # bare install with no runtimes config resolves to "claude" below.
+        _cfg_runtime="$(loom_config_get "$_workspace" "runtimes.default" "")"
+    fi
+
+    if [[ -n "$_cfg_runtime" ]]; then
+        RUNTIME="$_cfg_runtime"
+        RUNTIME_SOURCE="config (runtimes.default)"
+    else
+        RUNTIME="claude"
+        RUNTIME_SOURCE="default"
+    fi
+fi
+
+# --- Dispatch ---
+RUNNER="$SCRIPT_DIR/spawn-$RUNTIME.sh"
+if [[ ! -f "$RUNNER" ]]; then
+    log_error "Unknown runtime '$RUNTIME' (resolved from $RUNTIME_SOURCE):"
+    log_error "no runner found at $RUNNER."
+    log_error "Available runtimes on disk: $(_available_runtimes)."
+    log_error "Set LOOM_RUNTIME, or .loom/config.json -> runtimes.default, to a"
+    log_error "runtime that has a matching spawn-<runtime>.sh runner."
+    exit 78  # EX_CONFIG
+fi
+
+log_info "spawn-worker: runtime=$RUNTIME (from $RUNTIME_SOURCE) -> $(basename "$RUNNER")"
+exec "$RUNNER" "$@"

--- a/defaults/scripts/tests/test-spawn-worker.sh
+++ b/defaults/scripts/tests/test-spawn-worker.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# test-spawn-worker.sh — Tests for spawn-worker.sh (runtime dispatcher).
+#
+# Style matches test-spawn-claude.sh — plain bash, hand-rolled assertions.
+# Bats is NOT used in this repository.
+#
+# The dispatcher resolves its runner (`spawn-<runtime>.sh`) relative to its own
+# directory and exec's it. To exercise dispatch without triggering real token
+# selection or spawning a real `claude`, each test stages a temp scripts dir
+# holding a COPY of spawn-worker.sh, a copy of lib/config-resolver.sh, and
+# lightweight STUB runners (spawn-claude.sh / spawn-codex.sh) that just echo
+# their args. So no test ever reaches the real spawn-claude.sh token path.
+#
+# Usage:
+#   ./.loom/scripts/tests/test-spawn-worker.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected: '$expected'"
+        echo "    Actual:   '$actual'"
+    fi
+}
+
+assert_contains() {
+    local needle="$1"
+    local haystack="$2"
+    local msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" == *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+assert_not_contains() {
+    local needle="$1"
+    local haystack="$2"
+    local msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" != *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Unexpected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+# ============================================================
+# Stage a temp scripts dir with a copy of the dispatcher + stub runners.
+# ============================================================
+
+STAGE="$(mktemp -d)"
+WS="$(mktemp -d)"           # fake workspace holding .loom/config.json
+trap 'rm -rf "$STAGE" "$WS"' EXIT
+
+mkdir -p "$STAGE/lib" "$WS/.loom"
+cp "$SCRIPTS_DIR/spawn-worker.sh" "$STAGE/spawn-worker.sh"
+cp "$SCRIPTS_DIR/lib/config-resolver.sh" "$STAGE/lib/config-resolver.sh"
+chmod +x "$STAGE/spawn-worker.sh"
+
+# Stub runners: print each arg on its own bracketed line so args containing
+# spaces are observable verbatim (a plain `$*` would collapse them).
+_make_stub() {
+    local path="$1" label="$2" rc="${3:-0}"
+    cat > "$path" <<STUB
+#!/usr/bin/env bash
+echo "stub-$label reached"
+printf 'stub-$label arg=[%s]\n' "\$@"
+exit $rc
+STUB
+    chmod +x "$path"
+}
+_make_stub "$STAGE/spawn-claude.sh" "claude"
+_make_stub "$STAGE/spawn-codex.sh" "codex"
+
+WORKER="$STAGE/spawn-worker.sh"
+
+# LOOM_CONFIG_DEFAULTS_FILE="" disables the private-defaults config tier so a
+# stray ~/.local/share/loom/config/defaults.json on the host can't perturb
+# resolution. Every invocation below runs with a controlled workspace.
+run_worker() {
+    # usage: run_worker <ws> [env assignments as VAR=val ...] -- <args...>
+    local ws="$1"; shift
+    local -a envs=()
+    while [[ $# -gt 0 && "$1" != "--" ]]; do envs+=("$1"); shift; done
+    shift || true   # drop the --
+    env -u LOOM_RUNTIME \
+        LOOM_WORKSPACE="$ws" \
+        LOOM_CONFIG_DEFAULTS_FILE="" \
+        ${envs[@]+"${envs[@]}"} \
+        bash "$WORKER" "$@" 2>&1 || true
+}
+
+_have_jq=true
+command -v jq >/dev/null 2>&1 || _have_jq=false
+
+# ============================================================
+# Section 1: default resolution -> spawn-claude.sh
+# ============================================================
+
+echo "Testing spawn-worker.sh default resolution..."
+
+# No env, no config file at all -> built-in default "claude".
+output="$(run_worker "$WS" -- -p ping)"
+assert_contains "stub-claude reached" "$output" \
+    "no env + no config dispatches to spawn-claude.sh (zero behavior change)"
+assert_contains "runtime=claude (from default)" "$output" \
+    "default resolution logs source=default"
+assert_not_contains "stub-codex reached" "$output" \
+    "default resolution does NOT reach any other runner"
+
+# Args forwarded verbatim.
+assert_contains "stub-claude arg=[-p]" "$output" "args passthrough: -p"
+assert_contains "stub-claude arg=[ping]" "$output" "args passthrough: ping"
+
+# ============================================================
+# Section 2: LOOM_RUNTIME env override
+# ============================================================
+
+echo ""
+echo "Testing spawn-worker.sh LOOM_RUNTIME env override..."
+
+# Env selects codex even with no config.
+output="$(run_worker "$WS" LOOM_RUNTIME=codex -- -p ping)"
+assert_contains "stub-codex reached" "$output" \
+    "LOOM_RUNTIME=codex dispatches to spawn-codex.sh"
+assert_contains "runtime=codex (from env (LOOM_RUNTIME))" "$output" \
+    "env resolution logs source=env"
+assert_not_contains "stub-claude reached" "$output" \
+    "env override does NOT reach spawn-claude.sh"
+
+# Empty LOOM_RUNTIME is treated as unset (falls through to default).
+output="$(run_worker "$WS" LOOM_RUNTIME= -- -p ping)"
+assert_contains "stub-claude reached" "$output" \
+    "empty LOOM_RUNTIME falls through to the default (claude)"
+assert_contains "runtime=claude (from default)" "$output" \
+    "empty LOOM_RUNTIME resolves source=default"
+
+# ============================================================
+# Section 3: config runtimes.default resolution + precedence
+# ============================================================
+
+echo ""
+echo "Testing spawn-worker.sh config runtimes.default..."
+
+if [[ "$_have_jq" != "true" ]]; then
+    echo "  (skipping config-based tests — jq not installed)"
+else
+    # config runtimes.default=codex, no env -> codex.
+    printf '{ "runtimes": { "default": "codex" } }\n' > "$WS/.loom/config.json"
+    output="$(run_worker "$WS" -- -p ping)"
+    assert_contains "stub-codex reached" "$output" \
+        "config runtimes.default=codex dispatches to spawn-codex.sh"
+    assert_contains "runtime=codex (from config (runtimes.default))" "$output" \
+        "config resolution logs source=config"
+
+    # env beats config: config says codex, env says claude -> claude.
+    output="$(run_worker "$WS" LOOM_RUNTIME=claude -- -p ping)"
+    assert_contains "stub-claude reached" "$output" \
+        "LOOM_RUNTIME env overrides config runtimes.default"
+    assert_contains "runtime=claude (from env (LOOM_RUNTIME))" "$output" \
+        "env-over-config resolution logs source=env"
+
+    # A config with no runtimes block falls through to the built-in default.
+    printf '{ "champion": { "auto_merge_max_lines": 500 } }\n' > "$WS/.loom/config.json"
+    output="$(run_worker "$WS" -- -p ping)"
+    assert_contains "runtime=claude (from default)" "$output" \
+        "config present but no runtimes block resolves to default claude"
+
+    rm -f "$WS/.loom/config.json"
+fi
+
+# ============================================================
+# Section 4: unknown runtime -> exit 78 (EX_CONFIG)
+# ============================================================
+
+echo ""
+echo "Testing spawn-worker.sh unknown-runtime failure..."
+
+# Unknown from env: capture exit code and message.
+set +e
+out_unknown="$(env -u LOOM_RUNTIME \
+    LOOM_WORKSPACE="$WS" LOOM_CONFIG_DEFAULTS_FILE="" LOOM_RUNTIME=bogus \
+    bash "$WORKER" -p ping 2>&1)"
+rc_unknown=$?
+set -e
+assert_eq "78" "$rc_unknown" "unknown runtime exits 78 (EX_CONFIG)"
+assert_contains "Unknown runtime 'bogus'" "$out_unknown" \
+    "unknown-runtime message names the resolved runtime"
+assert_contains "env (LOOM_RUNTIME)" "$out_unknown" \
+    "unknown-runtime message names the source (env)"
+assert_contains "Available runtimes on disk:" "$out_unknown" \
+    "unknown-runtime message lists available runners"
+assert_contains "claude" "$out_unknown" \
+    "available-runtimes list includes the staged claude runner"
+
+# Unknown from config: message names the config source.
+if [[ "$_have_jq" == "true" ]]; then
+    printf '{ "runtimes": { "default": "nope" } }\n' > "$WS/.loom/config.json"
+    set +e
+    out_cfg_unknown="$(env -u LOOM_RUNTIME \
+        LOOM_WORKSPACE="$WS" LOOM_CONFIG_DEFAULTS_FILE="" \
+        bash "$WORKER" -p ping 2>&1)"
+    rc_cfg_unknown=$?
+    set -e
+    assert_eq "78" "$rc_cfg_unknown" "unknown runtime from config exits 78"
+    assert_contains "config (runtimes.default)" "$out_cfg_unknown" \
+        "unknown-from-config message names the config source"
+    rm -f "$WS/.loom/config.json"
+fi
+
+# ============================================================
+# Section 5: args pass through verbatim (incl. spaces) + exit passthrough
+# ============================================================
+
+echo ""
+echo "Testing spawn-worker.sh arg + exit-code passthrough..."
+
+# Args with embedded spaces survive as single arguments.
+output="$(run_worker "$WS" -- -p "hello world" --flag --model=x)"
+assert_contains "stub-claude arg=[hello world]" "$output" \
+    "an arg containing a space is forwarded as ONE argument"
+assert_contains "stub-claude arg=[--flag]" "$output" "bare flag forwarded verbatim"
+assert_contains "stub-claude arg=[--model=x]" "$output" "--key=value forwarded verbatim"
+
+# The runner's exit code is passed through via exec.
+_make_stub "$STAGE/spawn-claude.sh" "claude" 42
+set +e
+env -u LOOM_RUNTIME LOOM_WORKSPACE="$WS" LOOM_CONFIG_DEFAULTS_FILE="" \
+    bash "$WORKER" -p ping >/dev/null 2>&1
+rc_pass=$?
+set -e
+assert_eq "42" "$rc_pass" "runner exit code is passed through via exec"
+_make_stub "$STAGE/spawn-claude.sh" "claude" 0   # restore
+
+# ============================================================
+# Summary
+# ============================================================
+
+echo ""
+echo "==================================="
+echo "Tests run:    $TESTS_RUN"
+echo -e "Tests passed: ${GREEN}$TESTS_PASSED${NC}"
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    echo -e "Tests failed: ${RED}$TESTS_FAILED${NC}"
+    exit 1
+fi
+echo "All tests passed."


### PR DESCRIPTION
Part of #4167 (multi-runtime worker support), Phase 1.

Adds a runtime-dispatch seam in front of the Claude spawn path with **zero behavior change** — Claude Code becomes adapter #1 behind the seam instead of the hardwired only path. Mirrors the fork's `spawn-worker.sh` so a Codex adapter can slot in as `spawn-codex.sh` later.

## What landed

**`defaults/scripts/spawn-worker.sh`** — thin dispatcher, same dir as `spawn-claude.sh`:
- Resolves the runtime with standard precedence `LOOM_RUNTIME` env > `runtimes.default` config > `"claude"`.
- `exec "$SCRIPT_DIR/spawn-<runtime>.sh" "$@"` — args forwarded verbatim, exit code passthrough via exec.
- Unknown runtime / missing `spawn-<runtime>.sh` → exit **78** (`EX_CONFIG`) with a message naming the resolved runtime, its source (env vs config vs default), and the `spawn-*.sh` runners found on disk.
- Config read via the shared `lib/config-resolver.sh` (`loom_config_get`), soft-failing silently on a missing config file, a missing `runtimes` block, or a missing `jq` → default `claude`.

**`defaults/config.json`** — adds `"runtimes": { "default": "claude" }`.

**`defaults/docs/runtime-adapters.md`** — full dispatcher + `runtimes` config contract; a one-line pointer subsection added to CLAUDE.md's Configuration list. New docs install automatically via the daemon's recursive `sync_managed_dir(..., "docs", ...)`; the self-hosted `.loom/docs/` per-file symlink is mirrored so intra-repo link-check passes.

**`defaults/scripts/tests/test-spawn-worker.sh`** — 26 assertions, stub-runner staging (no real token selection / no real `claude`): default→`spawn-claude.sh`, `LOOM_RUNTIME` env + config `runtimes.default` precedence, unknown→78 with sourced message, and verbatim arg (incl. spaces) + exit-code passthrough.

## Verification

- `test-spawn-worker.sh`: 26/26 green.
- `test-spawn-claude.sh` (preserve-AC): 80/80 green, unchanged.
- shellcheck (severity=warning) clean on both new scripts.
- `verify-install.sh check-links`: all intra-repo links resolve.
- CLAUDE.md budget: 311/320 lines.

## Scope guards honored (zero behavior change)

- `spawn-claude.sh` byte-identical; existing callers unaffected (migration is a follow-up).
- No changes under `loom-daemon/` (Rust) or `loom-tools/` (Python).
- No capability-matrix enforcement in the dispatcher; no daemon changes; no new labels.

Closes #4169

🤖 Generated with [Claude Code](https://claude.com/claude-code)
