### PR TITLE
feat(daemon): resolve launchd domain gui→user so the daemon starts headlessly over SSH

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -2010,9 +2010,11 @@ process:
   default),
 - locates the `loom-daemon` binary (`LOOM_DAEMON_BIN` → `PATH` → `target/{release,debug}`),
 - runs the **advisory** host-sleep check (`check-host-sleep.sh`, #3350) — never blocks the start,
-- **on macOS, backgrounds the daemon as a `gui/<uid>` LaunchAgent** instead of a
-  plain `nohup … &` (#3972 — see "macOS session-bootstrap hazard" below); on
-  Linux it stays a plain nohup background job,
+- **on macOS, backgrounds the daemon as a launchd LaunchAgent** in the resolved
+  per-user domain (`gui/<uid>` with an active GUI login, else the SSH-reachable
+  `user/<uid>` background domain — #4130) instead of a plain `nohup … &` (#3972 —
+  see "macOS session-bootstrap hazard" below); on Linux it stays a plain nohup
+  background job,
 - backgrounds the daemon and writes a PID file at `.loom/.daemon.pid` (gitignored),
 - refuses a second start when the PID file points at a live process, and surfaces
   the daemon's own **singleton-guard** refusal (#3806) — if the backgrounded
@@ -2198,17 +2200,57 @@ Linux does not have this failure mode — a systemd user session (or a plain
 identity to the shell that spawned it.
 
 **Fix.** `loom-daemon-start.sh` now generates a `launchd` LaunchAgent plist and
-loads it with `launchctl bootstrap gui/<uid>` instead of `nohup`-backgrounding
-in-process (Darwin only — Linux is unaffected and keeps the plain nohup path).
-This was validated during the incident itself: relaunching the identical
-binary as a launchd agent immediately restored `gh`/`git` — the first tick
-after migration reported `13 seen, 3 dispatched, 0 error(s)`.
+loads it with `launchctl bootstrap <domain>` (the resolved per-user domain — see
+"launchd domain resolution" below) instead of `nohup`-backgrounding in-process
+(Darwin only — Linux is unaffected and keeps the plain nohup path). This was
+validated during the incident itself: relaunching the identical binary as a
+launchd agent immediately restored `gh`/`git` — the first tick after migration
+reported `13 seen, 3 dispatched, 0 error(s)`.
+
+**launchd domain resolution (#4130) — gui/<uid> ↦ user/<uid>.** The daemon was
+originally loaded into the hardcoded `gui/<uid>` domain — the per-GUI-login
+(Aqua) domain owned by `loginwindow`. Over SSH with **no active GUI login
+session** that domain does not exist, so `launchctl bootstrap gui/<uid> …` fails
+with `error 125: Domain does not support specified action`, and the daemon could
+not be (re)started remotely on a headless Mac. The shared resolver
+`resolve_launchd_domain()` (`defaults/scripts/lib/launchd-domain.sh`, consumed by
+`loom-daemon-start.sh` / `-stop.sh` / `-update.sh` / `-watchdog.sh` so the whole
+lifecycle agrees on one domain) resolves in this order:
+
+1. an explicit `LOOM_LAUNCHD_DOMAIN` override, honored **verbatim** (a pinned
+   domain that does not resolve fails loudly at `bootstrap`, never falls back
+   further — the override is honored, not advisory);
+2. `gui/<uid>` when `launchctl print gui/<uid>` resolves (a live GUI login) —
+   **byte-for-byte the pre-#4130 default** on a host with an Aqua session;
+3. `user/<uid>` — the **background per-user** domain that `sshd` itself
+   instantiates: present over SSH with no GUI, running as the *user* (not root),
+   and `gui/<uid>` already forwards to it (`endpoint destination =
+   …domain.user.<uid>`).
+
+**Rejected alternatives** (documented, deliberately not implemented):
+
+| Mechanism | Runs as | Needs GUI session? | Needs sudo? | Why rejected |
+|---|---|---|---|---|
+| `gui/<uid>` (pre-#4130 default) | user | **yes** | no | Fails over SSH — the defect this fixes. Kept as the preferred domain **when it resolves**. |
+| **`user/<uid>` (chosen fallback)** | user | no | no (own uid) | Background session ⇒ TCC prompts can't be answered interactively (see #3980) and the login keychain may be locked (see #4005). Smallest change, closest privilege match. |
+| `launchctl asuser <uid>` | user | effectively yes (targets a session) | yes | Still needs a target session to impersonate. |
+| system `LaunchDaemon` | **root** by default | no | yes | Wrong privilege model and **no login-keychain session** — re-opens the #4005 headless-credential problem in a new place instead of closing one. |
+
+**Consequences of a non-Aqua (`user/<uid>`) domain.** A background domain cannot
+surface an interactive TCC prompt, so any touch of a protected folder by the
+daemon or a sweep child fails silently rather than prompting — see
+`### macOS TCC hygiene under launchd (#3980)` below (the daemon's legitimate
+working set never needs a protected folder, so this is a diagnostic signal, not a
+blocker). The operator's **login keychain** may also be locked in a headless
+session, so export a `GH_TOKEN` for forge auth rather than relying on the keychain
+(the #4005 credential preflight reports this loudly). Both are inherent to running
+without an Aqua session, not regressions introduced here.
 
 - **Plist location & label**: `~/Library/LaunchAgents/com.rjwalters.loom-daemon.plist`
-  (override the label with `LOOM_LAUNCHD_LABEL`). Regenerated and reloaded
-  (`bootout` the old definition, then a fresh `bootstrap` + `kickstart -k`) on
-  **every** start, so a later invocation's flags/env always win over a stale
-  loaded definition.
+  (override the label with `LOOM_LAUNCHD_LABEL`; override the domain with
+  `LOOM_LAUNCHD_DOMAIN`). Regenerated and reloaded (`bootout` the old definition,
+  then a fresh `bootstrap` + `kickstart -k`) on **every** start, so a later
+  invocation's flags/env always win over a stale loaded definition.
 - **Environment forwarding**: the plist's `PATH` is the current `PATH` plus a
   fallback set (`~/.local/bin`, `~/.cargo/bin`, Homebrew, standard bin dirs) so
   `gh`, `git`, `cargo`, and `python3` resolve even inside launchd's minimal
@@ -2247,8 +2289,12 @@ after migration reported `13 seen, 3 dispatched, 0 error(s)`.
   during the stop window. See [Supervised restart primitive](#supervised-restart-primitive-4054)
   below and `docs/design/supervised-restart-primitive.md`.
 - **Escape hatch**: `--no-launchd` (or `LOOM_DAEMON_LAUNCHD=0`) forces the
-  legacy nohup path even on Darwin — e.g. for a sandboxed/headless macOS runner
-  with no GUI login session where `gui/<uid>` may not resolve.
+  legacy nohup path even on Darwin — e.g. for a sandboxed macOS runner where no
+  launchd domain is usable at all. Note that a headless/SSH-only session **no
+  longer requires** this escape hatch just to start: `resolve_launchd_domain()`
+  falls back to `user/<uid>` (above), so the durable launchd path (and its #3972
+  Mach-bootstrap-namespace protection) is available over SSH too — nohup remains
+  only the last-resort opt-out, not the headless default.
 - **Inspection without side effects**: `--print-plist` renders the exact plist
   XML this invocation would install and exits — no `launchctl` call, no file
   write to `~/Library/LaunchAgents`. Useful for auditing exactly what
@@ -2267,8 +2313,9 @@ after migration reported `13 seen, 3 dispatched, 0 error(s)`.
 **Why launchd changed the TCC picture.** Under the pre-#3972 nohup model, the
 daemon inherited whatever TCC (Transparency, Consent, and Control) grants the
 launching terminal app already had — so folder-access prompts, if any, belonged
-to Terminal.app/iTerm/Claude Code, not to `loom-daemon`. As a `gui/<uid>`
-LaunchAgent (see above), the daemon is its **own** TCC-responsible process:
+to Terminal.app/iTerm/Claude Code, not to `loom-daemon`. As a launchd LaunchAgent
+(see above — `gui/<uid>` under a GUI login, else `user/<uid>` over SSH, #4130),
+the daemon is its **own** TCC-responsible process:
 any touch of a protected location (`~/Desktop`, `~/Documents`, `~/Downloads`,
 `~/Pictures` (Photos), `~/Music` (Media & Apple Music),
 `~/Library/Mobile Documents` (iCloud Drive), network/removable volumes, …) by
@@ -2278,6 +2325,16 @@ including Photos / Media & Apple Music / iCloud — evidence of something
 enumerating the top level of `$HOME` itself rather than touching those folders
 individually (macOS bundles the per-category checks into one burst when a
 process lists `$HOME`'s immediate contents).
+
+**Under the `user/<uid>` (headless/SSH) domain (#4130) there is no prompt at
+all.** A background domain cannot surface an interactive TCC dialog, so the same
+out-of-bounds access **fails silently** (permission-denied) instead of prompting.
+That does not change the contract below — the daemon's and sweep children's
+legitimate working set still contains no protected folder — it only changes the
+symptom (a silent file-not-found rather than a popup). The remedy is identical:
+fix the offending script/tool to stay within the working-set contract, never a
+broad grant. This is one of the documented consequences of the non-Aqua fallback
+domain (see "launchd domain resolution" under #3972 above).
 
 **The daemon's legitimate working set never needs a protected folder.** Audited
 surfaces — the daemon core (Rust) and `.loom/scripts/*` — only ever touch

--- a/defaults/docs/github-authentication.md
+++ b/defaults/docs/github-authentication.md
@@ -142,14 +142,22 @@ file to mode `0600` whenever it carries a `GH_TOKEN`/`GITEA_TOKEN`/
 `FORGE_TOKEN`, so a local user other than the daemon's owner cannot read the
 PAT out of `~/Library/LaunchAgents`.
 
-**Out of scope**: `launchctl bootstrap gui/$UID` (the launchd domain
-`loom-daemon-start.sh` uses on macOS) fails over SSH — `gui/$UID` is a
-per-GUI-session domain that does not exist in an SSH session — so a daemon
-that isn't already running cannot be *started* remotely on macOS today even
-with a valid token exported. That is a supervision-model gap (a `LaunchDaemon`
-or `launchctl asuser` mechanism), not a credential problem; restarting an
-*already-running* daemon (`loom-daemon-update.sh`) and running fully headless
-on Linux (`--no-launchd` / nohup path) both work with an exported token today.
+**Starting the daemon headlessly over SSH (#4130 — resolved).** Earlier this
+section noted that `launchctl bootstrap gui/$UID` (the domain
+`loom-daemon-start.sh` originally hardcoded on macOS) fails over SSH with
+`error 125: Domain does not support specified action`, because `gui/$UID` is a
+per-GUI-login domain that does not exist in an SSH session — so a not-yet-running
+daemon could not be *started* remotely on macOS. That gap is now closed: the
+shared resolver `resolve_launchd_domain()` prefers `gui/<uid>` when a GUI login
+is active and otherwise falls back to the background per-user `user/<uid>` domain
+that `sshd` instantiates (running as the user, not root). So a headless / SSH-only
+`loom-daemon-start.sh` now completes, and stop/update find the resulting job. Pin
+the domain with `LOOM_LAUNCHD_DOMAIN` if needed; the rejected alternatives
+(a root system `LaunchDaemon`, `launchctl asuser`) and the login-keychain / TCC
+consequences of the non-Aqua domain are covered in
+[`daemon-reference.md` → "launchd domain resolution (#4130)"](daemon-reference.md).
+As before, export a `GH_TOKEN` for forge auth in a headless session (the login
+keychain may be locked) — the #4005 credential preflight reports this loudly.
 
 ## Troubleshooting
 

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -17,8 +17,10 @@
 #     LOOM_WORK_FINDER unset => off, LOOM_MAIN_HEALTH_GATE unset => off). Opt in
 #     explicitly with --work-finder / --health-gate, or hand control to
 #     .loom/config.json -> autonomous with --from-config (#3911),
-#   - on macOS, backgrounds the daemon as a `gui/<uid>` LaunchAgent (#3972) so
-#     it survives the launching session's death instead of a plain `nohup ...
+#   - on macOS, backgrounds the daemon as a launchd LaunchAgent (#3972) in the
+#     resolved per-user domain (`gui/<uid>` when a GUI login is active, else
+#     `user/<uid>` — #4130, so it can also be (re)started headlessly over SSH)
+#     so it survives the launching session's death instead of a plain `nohup ...
 #     &`; on Linux it stays a plain nohup background job,
 #   - backgrounds the daemon and writes a PID file (.loom/.daemon.pid),
 #   - persists the resolved invocation flags to .loom/.daemon.flags so
@@ -42,6 +44,13 @@
 # specifically to avoid that failure mode; see --no-launchd below for the
 # escape hatch and daemon-reference.md Operability for the incident writeup.
 #
+# launchd domain (#4130): the LaunchAgent is loaded into the domain
+# resolve_launchd_domain() (lib/launchd-domain.sh) picks — `gui/<uid>` when a
+# GUI (Aqua) login session is active (byte-for-byte the pre-#4130 behavior),
+# else the background per-user `user/<uid>` domain that sshd instantiates, so a
+# headless / SSH-only start no longer fails with `error 125: Domain does not
+# support specified action`. Override with LOOM_LAUNCHD_DOMAIN.
+#
 # Usage:
 #   ./.loom/scripts/cli/loom-daemon-start.sh                 Reliability daemon (both loops OFF)
 #   ./.loom/scripts/cli/loom-daemon-start.sh --work-finder   Enable the autonomous work finder
@@ -61,6 +70,10 @@
 #   LOOM_WORK_FINDER / LOOM_MAIN_HEALTH_GATE  Respected when already exported
 #   LOOM_DAEMON_LAUNCHD  macOS only: 0/false/no forces the legacy nohup path (same as --no-launchd)
 #   LOOM_LAUNCHD_LABEL   macOS only: override the LaunchAgent label (default com.rjwalters.loom-daemon)
+#   LOOM_LAUNCHD_DOMAIN  macOS only: pin the launchd domain (e.g. gui/$(id -u) or
+#                        user/$(id -u)); honored verbatim, else auto-resolved
+#                        gui→user (#4130). A pinned domain that does not resolve
+#                        fails loudly at bootstrap rather than falling back.
 #
 # Exit codes:
 #   0  daemon started (or already running)
@@ -135,6 +148,17 @@ xml_escape() {
 resolve_launchd_label() {
     echo "${LOOM_LAUNCHD_LABEL:-com.rjwalters.loom-daemon}"
 }
+
+# resolve_launchd_domain() — the launchd domain (gui/<uid> ↦ user/<uid>) the
+# LaunchAgent is loaded/inspected/booted-out under (#4130). Shared verbatim with
+# loom-daemon-stop.sh / -update.sh / -watchdog.sh via lib/launchd-domain.sh so
+# all four lifecycle scripts always agree on the domain. Sourced here (all four
+# scripts source the same one definition).
+_LOOM_LAUNCHD_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" 2>/dev/null && pwd)"
+if [[ -r "$_LOOM_LAUNCHD_LIB_DIR/launchd-domain.sh" ]]; then
+    # shellcheck source=../lib/launchd-domain.sh
+    source "$_LOOM_LAUNCHD_LIB_DIR/launchd-domain.sh"
+fi
 
 # render_launchd_plist <label> <daemon_bin> <workdir> <log_path>
 # Prints the LaunchAgent plist XML to stdout. Mirrors the hand-written plist
@@ -313,9 +337,13 @@ provision_watchdog_job() {
         warn "watchdog: loom-daemon-watchdog.sh not found — skipping (autonomy-loss detection disabled)."
         return 0
     fi
-    local wd_label wd_service wd_plist wd_interval wd_log
+    local wd_label wd_domain wd_service wd_plist wd_interval wd_log
     wd_label="$(resolve_watchdog_label)"
-    wd_service="gui/$(id -u)/${wd_label}"
+    # Same resolved domain the daemon job uses (#4130) so the watchdog is
+    # bootstrapped where stop.sh will later look for it — gui/<uid> with a GUI
+    # login, else the SSH-reachable user/<uid> domain.
+    wd_domain="$(resolve_launchd_domain)"
+    wd_service="${wd_domain}/${wd_label}"
     wd_plist="$HOME/Library/LaunchAgents/${wd_label}.plist"
     wd_interval="${LOOM_WATCHDOG_INTERVAL_SECS:-300}"
     wd_log="$LOOM_DIR/logs/daemon-watchdog.log"
@@ -327,7 +355,7 @@ provision_watchdog_job() {
     if launchctl print "$wd_service" >/dev/null 2>&1; then
         launchctl bootout "$wd_service" >/dev/null 2>&1 || true
     fi
-    if launchctl bootstrap "gui/$(id -u)" "$wd_plist" >/dev/null 2>&1; then
+    if launchctl bootstrap "$wd_domain" "$wd_plist" >/dev/null 2>&1; then
         echo "Watchdog:       $wd_label (StartInterval ${wd_interval}s) → $wd_log"
     else
         warn "watchdog: launchctl bootstrap failed for $wd_service — autonomy-loss detection not active (non-fatal)."
@@ -533,13 +561,15 @@ if [[ "$USE_LAUNCHD" == "true" ]]; then
     # namespace; when that session dies, trustd/opendirectoryd XPC lookups
     # start failing for the daemon and every child it spawns (gh TLS errors,
     # "No user exists for uid N" from git) with no crash and no obvious log
-    # signal. Loading as a `gui/<uid>` LaunchAgent keeps the daemon in the
-    # user's durable GUI bootstrap domain instead, independent of whichever
+    # signal. Loading as a launchd LaunchAgent keeps the daemon in a durable
+    # per-user bootstrap domain instead, independent of whichever
     # terminal/session launched it. See daemon-reference.md Operability for
     # the incident writeup. Escape hatch: --no-launchd / LOOM_DAEMON_LAUNCHD=0.
+    # The domain is resolve_launchd_domain()'s pick (#4130): gui/<uid> with a
+    # live GUI login (unchanged from before), else the SSH-reachable user/<uid>
+    # background domain so a headless start no longer fails `error 125`.
     LAUNCHD_LABEL=$(resolve_launchd_label)
-    LAUNCHD_UID=$(id -u)
-    LAUNCHD_DOMAIN="gui/${LAUNCHD_UID}"
+    LAUNCHD_DOMAIN="$(resolve_launchd_domain)"
     LAUNCHD_SERVICE="${LAUNCHD_DOMAIN}/${LAUNCHD_LABEL}"
     PLIST_DIR="$HOME/Library/LaunchAgents"
     PLIST_FILE="$PLIST_DIR/${LAUNCHD_LABEL}.plist"

--- a/defaults/scripts/cli/loom-daemon-stop.sh
+++ b/defaults/scripts/cli/loom-daemon-stop.sh
@@ -19,7 +19,8 @@
 #   sweep, use `mcp__loom__cancel_sweep` against a running daemon before stopping.
 #
 # macOS launchd counterpart (#3972): when loom-daemon-start.sh loaded the
-# daemon as a `gui/<uid>` LaunchAgent, this script ALSO unloads the launchd
+# daemon as a launchd LaunchAgent (in the resolve_launchd_domain() domain —
+# gui/<uid> or user/<uid>, #4130), this script ALSO unloads the launchd
 # job definition (`launchctl bootout`) after the process is confirmed dead —
 # not just kills the pid. This matters because the generated plist sets
 # RunAtLoad=true (mirroring the validated incident-fix plist), so leaving the
@@ -60,6 +61,10 @@
 #   LOOM_DAEMON_STOP_GRACE_SECS   Grace window before SIGKILL (default 10)
 #   LOOM_DAEMON_STOP_KEEP_INTENT  1/true/yes: preserve the autonomy-desired marker + watchdog (same as --restarting)
 #   LOOM_LAUNCHD_LABEL            macOS only: the LaunchAgent label to bootout (default com.rjwalters.loom-daemon)
+#   LOOM_LAUNCHD_DOMAIN           macOS only: pin the launchd domain (gui/<uid> or
+#                                 user/<uid>); else auto-resolved gui→user (#4130).
+#                                 Must match the domain the start used so the
+#                                 bootout targets the right service.
 #   LOOM_DAEMON_LAUNCHD           macOS only: 0/false/no disables ALL launchd interaction
 #                                 (lookup + bootout), symmetric with loom-daemon-start.sh.
 #                                 A start done with --no-launchd / LOOM_DAEMON_LAUNCHD=0
@@ -141,7 +146,9 @@ teardown_autonomy_intent() {
     rm -f "$INTENT_MARKER" 2>/dev/null || true
     local wd_label wd_service
     wd_label="${LOOM_WATCHDOG_LABEL:-${LAUNCHD_LABEL}-watchdog}"
-    wd_service="gui/$(id -u)/${wd_label}"
+    # $LAUNCHD_DOMAIN is resolved below (gui/<uid> ↦ user/<uid>, #4130) before any
+    # call to this function; the launchctl calls here are gated on USE_LAUNCHD.
+    wd_service="${LAUNCHD_DOMAIN}/${wd_label}"
     if [[ "$USE_LAUNCHD" == "true" ]] && command -v launchctl >/dev/null 2>&1; then
         if launchctl print "$wd_service" >/dev/null 2>&1; then
             launchctl bootout "$wd_service" >/dev/null 2>&1 || true
@@ -150,6 +157,14 @@ teardown_autonomy_intent() {
 }
 
 # ---------- launchd plumbing (macOS, #3972) ----------
+# Shared domain resolver (#4130): gui/<uid> ↦ user/<uid>, sourced verbatim so
+# stop agrees with the domain the start put the job in.
+_LOOM_LAUNCHD_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" 2>/dev/null && pwd)"
+if [[ -r "$_LOOM_LAUNCHD_LIB_DIR/launchd-domain.sh" ]]; then
+    # shellcheck source=../lib/launchd-domain.sh
+    source "$_LOOM_LAUNCHD_LIB_DIR/launchd-domain.sh"
+fi
+
 IS_DARWIN=false
 [[ "$(uname -s)" == "Darwin" ]] && IS_DARWIN=true
 
@@ -167,7 +182,17 @@ fi
 
 DEFAULT_LAUNCHD_LABEL="com.rjwalters.loom-daemon"
 LAUNCHD_LABEL="${LOOM_LAUNCHD_LABEL:-$DEFAULT_LAUNCHD_LABEL}"
-LAUNCHD_SERVICE="gui/$(id -u)/${LAUNCHD_LABEL}"
+# Resolve the domain ONLY when launchd interaction is on (#4130): probing
+# `launchctl print gui/<uid>` when LOOM_DAEMON_LAUNCHD=0 would reach the
+# machine-global launchd domain the disabled path must never touch (#4078). The
+# placeholder below is inert — every launchd function short-circuits on
+# USE_LAUNCHD, so it is never consumed when launchd is off.
+if [[ "$USE_LAUNCHD" == "true" ]]; then
+    LAUNCHD_DOMAIN="$(resolve_launchd_domain)"
+else
+    LAUNCHD_DOMAIN=""
+fi
+LAUNCHD_SERVICE="${LAUNCHD_DOMAIN}/${LAUNCHD_LABEL}"
 
 launchd_job_loaded() {
     [[ "$USE_LAUNCHD" == "true" ]] || return 1

--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -38,8 +38,10 @@
 # nor .loom/.daemon.flags reliably reflects "is it running" — the pid file goes
 # stale after any KeepAlive:SuccessfulExit relaunch, and a hand-bootstrapped
 # daemon has no state files at all. This script therefore checks the launchd job
-# state (`launchctl print gui/<uid>/<label>`, mirroring loom-daemon-stop.sh)
-# AHEAD of the pid-file tier when resolving whether/how the daemon is running.
+# state (`launchctl print <domain>/<label>`, where <domain> is
+# resolve_launchd_domain()'s gui/<uid> ↦ user/<uid> pick — #4130 — mirroring
+# loom-daemon-stop.sh) AHEAD of the pid-file tier when resolving whether/how the
+# daemon is running.
 # When launchd-managed, it restarts via the `loom-daemon restart` primitive
 # (#4077 — sends Request::RestartDaemon over the IPC socket; the supervised
 # daemon exits 0 and launchd relaunches it onto the fresh binary with the
@@ -82,6 +84,9 @@
 #                          domain and follows the PID-file/nohup restart path.
 #   LOOM_LAUNCHD_LABEL     macOS only: the LaunchAgent label to inspect/restart
 #                          (default com.rjwalters.loom-daemon).
+#   LOOM_LAUNCHD_DOMAIN    macOS only: pin the launchd domain (gui/<uid> or
+#                          user/<uid>); else auto-resolved gui→user (#4130),
+#                          matching loom-daemon-start.sh / -stop.sh.
 #   LOOM_DAEMON_UPDATE_RELAUNCH  macOS/launchd only: 1/true/yes is equivalent to
 #                          passing --relaunch (opt in to the re-render + relaunch
 #                          on a refused restart).
@@ -304,6 +309,14 @@ advisory_behind_origin "$REPO_ROOT"
 # loom-daemon-start.sh itself started; a hand-bootstrapped daemon has no state
 # files at all. Honors LOOM_DAEMON_LAUNCHD symmetrically with start/stop.sh so a
 # --no-launchd install never reaches into the machine-global launchd domain.
+# Shared domain resolver (#4130): gui/<uid> ↦ user/<uid>, sourced verbatim so
+# update agrees with the domain the start put the job in.
+_LOOM_LAUNCHD_LIB_DIR="$(cd "$SCRIPT_DIR/../lib" 2>/dev/null && pwd)"
+if [[ -r "$_LOOM_LAUNCHD_LIB_DIR/launchd-domain.sh" ]]; then
+    # shellcheck source=../lib/launchd-domain.sh
+    source "$_LOOM_LAUNCHD_LIB_DIR/launchd-domain.sh"
+fi
+
 IS_DARWIN=false
 [[ "$(uname -s)" == "Darwin" ]] && IS_DARWIN=true
 USE_LAUNCHD="$IS_DARWIN"
@@ -312,7 +325,16 @@ if [[ "${LOOM_DAEMON_LAUNCHD:-}" =~ ^(0|false|no)$ ]]; then
 fi
 DEFAULT_LAUNCHD_LABEL="com.rjwalters.loom-daemon"
 LAUNCHD_LABEL="${LOOM_LAUNCHD_LABEL:-$DEFAULT_LAUNCHD_LABEL}"
-LAUNCHD_SERVICE="gui/$(id -u)/${LAUNCHD_LABEL}"
+# Resolve the domain ONLY when launchd interaction is on (#4130): probing
+# `launchctl print gui/<uid>` when LOOM_DAEMON_LAUNCHD=0 would reach the
+# machine-global launchd domain the disabled path must never touch (#4078). The
+# placeholder is inert — launchd_job_loaded and the launchd restart path all
+# short-circuit on USE_LAUNCHD, so it is never consumed when launchd is off.
+if [[ "$USE_LAUNCHD" == "true" ]]; then
+    LAUNCHD_SERVICE="$(resolve_launchd_domain)/${LAUNCHD_LABEL}"
+else
+    LAUNCHD_SERVICE="/${LAUNCHD_LABEL}"
+fi
 LAUNCHD_PLIST="$HOME/Library/LaunchAgents/${LAUNCHD_LABEL}.plist"
 
 launchd_job_loaded() {

--- a/defaults/scripts/cli/loom-daemon-watchdog.sh
+++ b/defaults/scripts/cli/loom-daemon-watchdog.sh
@@ -62,6 +62,8 @@
 #                                  max(5 × heartbeat cadence, 300))
 #   LOOM_SOCKET_PATH              Override the daemon socket (its dir is the loom dir)
 #   LOOM_LAUNCHD_LABEL            macOS: the DAEMON label to probe (default com.rjwalters.loom-daemon)
+#   LOOM_LAUNCHD_DOMAIN          macOS: pin the launchd domain (gui/<uid> or user/<uid>);
+#                                else auto-resolved gui→user (#4130), matching the start
 #   LOOM_DAEMON_LAUNCHD          0/false/no: treat as a non-launchd (nohup) daemon; check the pid file only
 
 set -uo pipefail
@@ -76,6 +78,14 @@ fi
 show_help() {
     awk 'NR>=2 { if ($0 !~ /^#/) exit; sub(/^# ?/, ""); print }' "$0"
 }
+
+# Shared domain resolver (#4130): gui/<uid> ↦ user/<uid>, sourced verbatim so the
+# watchdog probes the daemon in the same domain the start put it in.
+_LOOM_LAUNCHD_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" 2>/dev/null && pwd)"
+if [[ -r "$_LOOM_LAUNCHD_LIB_DIR/launchd-domain.sh" ]]; then
+    # shellcheck source=../lib/launchd-domain.sh
+    source "$_LOOM_LAUNCHD_LIB_DIR/launchd-domain.sh"
+fi
 
 VERBOSE=false
 while [[ $# -gt 0 ]]; do
@@ -149,7 +159,10 @@ LABEL="${LOOM_LAUNCHD_LABEL:-${MARKER_LABEL:-com.rjwalters.loom-daemon}}"
 daemon_alive=false
 liveness_detail=""
 if [[ "$USE_LAUNCHD" == "true" ]] && command -v launchctl >/dev/null 2>&1; then
-    service="gui/$(id -u)/${LABEL}"
+    # Resolve the domain (gui/<uid> ↦ user/<uid>, #4130) the same way the start
+    # did, so a headless daemon in user/<uid> is probed correctly rather than
+    # always looked up under gui/<uid> (which would false-report divergence).
+    service="$(resolve_launchd_domain)/${LABEL}"
     launchd_pid="$(launchctl print "$service" 2>/dev/null | awk -F'= ' '/^[[:space:]]*pid = /{gsub(/[^0-9]/, "", $2); print $2; exit}')"
     if [[ -n "$launchd_pid" ]] && kill -0 "$launchd_pid" 2>/dev/null; then
         daemon_alive=true

--- a/defaults/scripts/lib/launchd-domain.sh
+++ b/defaults/scripts/lib/launchd-domain.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# launchd-domain.sh — shared launchd-domain resolver for the loom-daemon
+# lifecycle scripts (issue #4130).
+#
+# Source this file (do not exec). Defines a single function:
+#
+#   resolve_launchd_domain -> echoes the launchd domain target
+#     ("gui/<uid>", "user/<uid>", or an explicit LOOM_LAUNCHD_DOMAIN override)
+#     that the loom-daemon LaunchAgent is loaded / inspected / booted out under.
+#
+# WHY THIS EXISTS (#4130). loom-daemon-start.sh historically hardcoded
+# `gui/<uid>` — the per-GUI-login (Aqua) launchd domain owned by loginwindow.
+# Over SSH with no active GUI login session that domain does not exist, so
+# `launchctl bootstrap gui/<uid> …` fails with `error 125: Domain does not
+# support specified action`, and the daemon cannot be (re)started remotely on a
+# headless Mac. `user/<uid>` is the BACKGROUND per-user domain that sshd itself
+# instantiates: it is present over SSH with no GUI at all, runs as the *user*
+# (not root, unlike a system LaunchDaemon), and `gui/<uid>` already forwards to
+# it (`endpoint destination = …domain.user.<uid>`). So we PREFER `gui/<uid>`
+# when it resolves — byte-for-byte the pre-#4130 behavior on a host with a live
+# GUI login — and fall back to `user/<uid>` only when it does not.
+#
+# REJECTED ALTERNATIVES (documented, deliberately NOT implemented):
+#   * a system-domain LaunchDaemon — runs as root by default and has NO
+#     login-keychain session, so it re-opens the #4005 headless-credential
+#     problem in a new place instead of closing one; and
+#   * `launchctl asuser <uid> launchctl bootstrap gui/<uid> …` — still needs a
+#     target session to impersonate and needs sudo.
+# `user/<uid>` is the smallest change and the closest privilege match to
+# today's behavior. See daemon-reference.md "macOS session-bootstrap hazard
+# (#3972)" for the trade-off table and the login-keychain (#4005) / TCC (#3980)
+# consequences of a non-Aqua domain.
+#
+# Resolution precedence (first match wins):
+#   1. $LOOM_LAUNCHD_DOMAIN — an explicit operator override, honored VERBATIM.
+#      No probe, no further fallback: a domain pinned here that does not resolve
+#      fails loudly at the launchctl call site (e.g. `launchctl bootstrap` in
+#      loom-daemon-start.sh) rather than silently falling back to another
+#      domain. The override is honored, not advisory.
+#   2. gui/<uid> — when `launchctl print gui/<uid>` resolves (a live GUI login).
+#   3. user/<uid> — the background per-user domain (headless / SSH-only).
+#
+# All four lifecycle scripts (start / stop / update / watchdog) source this ONE
+# definition so they always agree on the domain — a per-script domain string is
+# exactly how stop/update/watchdog would end up looking a service up in a
+# domain the start put it somewhere else.
+resolve_launchd_domain() {
+    local uid
+    uid="$(id -u)"
+    if [[ -n "${LOOM_LAUNCHD_DOMAIN:-}" ]]; then
+        printf '%s\n' "${LOOM_LAUNCHD_DOMAIN}"
+        return 0
+    fi
+    if command -v launchctl >/dev/null 2>&1 && launchctl print "gui/${uid}" >/dev/null 2>&1; then
+        printf '%s\n' "gui/${uid}"
+        return 0
+    fi
+    printf '%s\n' "user/${uid}"
+    return 0
+}

--- a/defaults/scripts/tests/lib/launchd-sandbox.sh
+++ b/defaults/scripts/tests/lib/launchd-sandbox.sh
@@ -44,7 +44,13 @@ launchd_sandbox_new_label() {
 #     (one line per call) so a test can assert what was attempted, and
 #   - are STRUCTURALLY UNABLE to touch a real launchd job or process:
 #       * launchctl: `print` always exits 1 (job "not loaded"); everything else
-#         is a harmless no-op exit 0.
+#         is a harmless no-op exit 0. This is domain-AGNOSTIC (#4130): `print`
+#         fails for BOTH gui/<uid> and user/<uid>, so it correctly stubs a job
+#         under whichever domain resolve_launchd_domain() picks, and the failing
+#         gui/<uid> probe drives the resolver to the user/<uid> fallback — so a
+#         sandboxed test never depends on the host having (or lacking) a GUI
+#         login. launchd_sandbox_assert_no_production_label scopes on the LABEL
+#         (com.rjwalters.*), independent of the domain, so it still holds.
 #       * pgrep: always exits 1 with no output (never matches a real process),
 #         so a label-blind `pgrep -f loom-daemon` in the stop script can never
 #         return the production daemon's (or a decoy's) PID.

--- a/defaults/scripts/tests/test-loom-daemon-launchd-plist.sh
+++ b/defaults/scripts/tests/test-loom-daemon-launchd-plist.sh
@@ -171,6 +171,16 @@ else
     echo -e "${RED}✗${NC} --help documents --no-launchd and --print-plist"
 fi
 
+# 9. Domain resolution (#4130) does not leak into the DEFAULT rendered plist:
+#    the launchd domain (gui/<uid> vs user/<uid>) is a LOAD-time concern, not a
+#    plist field. render_launchd_plist is untouched by #4130, so a plain
+#    --print-plist (no LOOM_LAUNCHD_DOMAIN pin) carries neither a gui/<uid> nor a
+#    user/<uid> domain token — the GUI-path plist is byte-for-byte what it was.
+default_plist=$( cd "$WORKDIR" && env -u LOOM_LAUNCHD_DOMAIN -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --print-plist 2>/dev/null )
+assert_not_contains "$default_plist" "gui/$(id -u)" "default plist carries no gui/<uid> domain token (#4130 — domain is load-time, GUI path unchanged)"
+assert_not_contains "$default_plist" "user/$(id -u)" "default plist carries no user/<uid> domain token (#4130 — domain is load-time)"
+
 # ---------- summary ----------
 echo
 echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -156,6 +156,49 @@ if [[ -f "$WORKDIR/.loom/.daemon.pid" ]]; then
     kill "$(cat "$WORKDIR/.loom/.daemon.pid" 2>/dev/null)" 2>/dev/null || true
 fi
 
+# ---------- launchd domain resolution (#4130) ----------
+# resolve_launchd_domain() (lib/launchd-domain.sh) picks gui/<uid> when the GUI
+# (Aqua) domain resolves — byte-for-byte the pre-#4130 default — else the
+# SSH-reachable user/<uid> background domain, and honors an explicit
+# LOOM_LAUNCHD_DOMAIN override verbatim. Driven through a stub launchctl so both
+# the GUI-present and headless (SSH-only) cases are deterministic on any host.
+LAUNCHD_DOMAIN_LIB="$(cd "$SCRIPT_DIR/../lib" && pwd)/launchd-domain.sh"
+UID_NOW="$(id -u)"
+DOMAIN_STUB_DIR="$WORKDIR/domain-stub"
+mkdir -p "$DOMAIN_STUB_DIR/gui" "$DOMAIN_STUB_DIR/nogui"
+# GUI-present: `launchctl print gui/<uid>` succeeds.
+cat > "$DOMAIN_STUB_DIR/gui/launchctl" <<'EOF'
+#!/usr/bin/env bash
+[[ "$1" == "print" && "$2" == gui/* ]] && exit 0
+exit 1
+EOF
+# Headless (no GUI login): every `launchctl print` fails (the gui/<uid> domain
+# does not exist — the `error 125` this issue fixes).
+cat > "$DOMAIN_STUB_DIR/nogui/launchctl" <<'EOF'
+#!/usr/bin/env bash
+[[ "$1" == "print" ]] && exit 1
+exit 0
+EOF
+chmod +x "$DOMAIN_STUB_DIR"/*/launchctl
+
+out=$( env -u LOOM_LAUNCHD_DOMAIN PATH="$DOMAIN_STUB_DIR/gui:$PATH" \
+    bash -c "source '$LAUNCHD_DOMAIN_LIB'; resolve_launchd_domain" )
+assert_eq "gui/${UID_NOW}" "$out" "resolver picks gui/<uid> when the GUI domain resolves (default path unchanged)"
+
+out=$( env -u LOOM_LAUNCHD_DOMAIN PATH="$DOMAIN_STUB_DIR/nogui:$PATH" \
+    bash -c "source '$LAUNCHD_DOMAIN_LIB'; resolve_launchd_domain" )
+assert_eq "user/${UID_NOW}" "$out" "resolver falls back to user/<uid> when gui/<uid> does not resolve (headless/SSH)"
+
+out=$( LOOM_LAUNCHD_DOMAIN="user/${UID_NOW}" PATH="$DOMAIN_STUB_DIR/gui:$PATH" \
+    bash -c "source '$LAUNCHD_DOMAIN_LIB'; resolve_launchd_domain" )
+assert_eq "user/${UID_NOW}" "$out" "LOOM_LAUNCHD_DOMAIN override is honored verbatim (wins over the gui probe)"
+
+# A pinned domain that does NOT resolve is still honored verbatim — it must fail
+# loudly downstream (at launchctl bootstrap), never silently fall back further.
+out=$( LOOM_LAUNCHD_DOMAIN="gui/${UID_NOW}" PATH="$DOMAIN_STUB_DIR/nogui:$PATH" \
+    bash -c "source '$LAUNCHD_DOMAIN_LIB'; resolve_launchd_domain" )
+assert_eq "gui/${UID_NOW}" "$out" "override to a non-resolving domain is honored verbatim (no silent fallback)"
+
 # ---------- summary ----------
 echo
 echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -97,10 +97,15 @@ LOOM_REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 # installed on the dev machine can never leak into a test).
 new_fixture() {
     local root="$1"
-    mkdir -p "$root/.loom/logs" "$root/.loom/scripts/cli" "$root/loom-daemon" "$root/scripts/install"
+    mkdir -p "$root/.loom/logs" "$root/.loom/scripts/cli" "$root/.loom/scripts/lib" "$root/loom-daemon" "$root/scripts/install"
     cp "$CLI_DIR/loom-daemon-start.sh" "$root/.loom/scripts/cli/loom-daemon-start.sh"
     cp "$CLI_DIR/loom-daemon-stop.sh" "$root/.loom/scripts/cli/loom-daemon-stop.sh"
     chmod +x "$root/.loom/scripts/cli/"*.sh
+    # The fixture start/stop scripts source ../lib/launchd-domain.sh for the
+    # shared gui/<uid> ↦ user/<uid> resolver (#4130), so it must exist alongside
+    # them in the throwaway tree — else a launchd-mode restart path would find no
+    # resolve_launchd_domain. Mirrors the real defaults/scripts/lib layout.
+    cp "$CLI_DIR/../lib/launchd-domain.sh" "$root/.loom/scripts/lib/launchd-domain.sh"
     cp "$LOOM_REPO_ROOT/scripts/install/provision-daemon.sh" "$root/scripts/install/provision-daemon.sh"
     cat > "$root/loom-daemon/Cargo.toml" <<'EOF'
 [package]


### PR DESCRIPTION
## Summary

`loom-daemon-start.sh` hardcoded the per-GUI-login `gui/<uid>` launchd domain, so `launchctl bootstrap gui/<uid> …` failed over SSH with no active GUI session (`error 125: Domain does not support specified action`), blocking a remote (re)start of the daemon on macOS. This adds a shared domain resolver that prefers `gui/<uid>` when it resolves (unchanged GUI behavior) and otherwise falls back to the SSH-reachable background per-user `user/<uid>` domain that `sshd` instantiates. All four lifecycle scripts consume the one shared definition so they always agree on the domain.

## Changes

- **New `defaults/scripts/lib/launchd-domain.sh`** — `resolve_launchd_domain()` with precedence: `LOOM_LAUNCHD_DOMAIN` override (honored verbatim) → probe `gui/<uid>` → fall back to `user/<uid>`. Documents the rejected alternatives (system `LaunchDaemon`, `launchctl asuser`).
- **`loom-daemon-start.sh`** — sources the resolver; replaces the hardcoded domain at the daemon bootstrap and the #4011 watchdog service lookup + bootstrap; header/help/env docs.
- **`loom-daemon-stop.sh` / `-update.sh` / `-watchdog.sh`** — source the same resolver at their service-lookup / bootout sites; resolution is gated on `USE_LAUNCHD` so a `LOOM_DAEMON_LAUNCHD=0` path never probes the machine-global launchd domain (#4078 symmetry).
- **Docs** — `daemon-reference.md` #3972 section gains a "launchd domain resolution (#4130)" subsection + trade-off table + login-keychain/TCC cross-references; #3980 gains a "no prompt under `user/<uid>`" note; `github-authentication.md` "out of scope" note refreshed (the gap is now closed).
- **Tests** — resolver unit tests (gui-present / headless fallback / override honored / non-resolving override honored verbatim) in `test-loom-daemon-start.sh`; a plist regression guard in `test-loom-daemon-launchd-plist.sh`; the update-test fixture copies the lib; sandbox-lib comment documents domain-agnostic stubbing.

## Acceptance Criteria Verification

1. **Single shared resolver consumed by all four scripts** — `resolve_launchd_domain()` in `lib/launchd-domain.sh`, sourced by all four. `grep -n 'gui/' defaults/scripts/cli/*.sh` returns only comment lines (0 hardcoded consumer sites). ✅
2. **Both launchd jobs (daemon + watchdog) use the resolved domain** — `provision_watchdog_job` now resolves and bootstraps into the same domain. ✅
3. **GUI host unchanged** — resolver picks `gui/<uid>`; the rendered plist carries no domain token (domain is load-time). Verified with a live scratch-labeled `gui/<uid>` start→stop cycle (job resolved under `gui/501`, cleanly booted out). ✅
4. **Headless (SSH) start completes; stop/update act on it** — resolver falls back to `user/<uid>` (verified via sandboxed launchctl-stub tests; a real headless-host cycle is a manual operator test-plan item — see below). ✅ (unit-tested)
5. **Docs cover mechanism, order, rejected alternatives, keychain/TCC consequences** — daemon-reference.md updated. ✅
6. **`--no-launchd` / Linux unchanged; #3972 not reintroduced** — still a launchd domain, never session-inherited nohup; Linux untouched. ✅
7. **`LOOM_LAUNCHD_DOMAIN` override exists, takes precedence, fails loud if it doesn't resolve** — honored verbatim with no further fallback; verified live (pinning `user/501` on this GUI host failed loudly at bootstrap rather than silently falling back to gui). ✅

## Test Plan

- Automated: `test-loom-daemon-{start,stop,update,watchdog,launchd-plist}.sh` — all pass (15 / 22 / 51 / 12 / 28).
- `shellcheck -S warning` clean on the lib + four scripts.
- **Live GUI regression cycle** (scratch label, isolated socket/marker, fake sleeper binary): start bootstrapped into `gui/501`, job resolved, stop cleanly booted it out; no scratch plist/job leaked; production `com.rjwalters.loom-daemon` untouched.
- **Live override validation**: `LOOM_LAUNCHD_DOMAIN=user/501` on this GUI-active host fails loudly at bootstrap (I/O error — the gui session owns the domain), confirming both that the override is honored (no silent fallback) and *why* the resolver prefers gui when present rather than blanket-switching to user.
- **Not validated on this machine**: the real headless / no-GUI-session `user/<uid>` bootstrap path (this dev host has an active Aqua session). Covered by the sandboxed launchctl-stub tests; a real SSH-only-host cycle remains a manual operator test-plan item.

Closes #4130

🤖 Generated with [Claude Code](https://claude.com/claude-code)