### PR TITLE
feat(daemon): advertise cross-host soft claims over safehouse (#4028, Phase 1)

### DIFF
--- a/.loom/docs/safehouse.md
+++ b/.loom/docs/safehouse.md
@@ -6,15 +6,22 @@ adds an optional, additive **narration** side-channel: an end-to-end-encrypted
 Matrix room a human watches in Element to follow a multi-host agent fleet in
 real time, instead of polling `gh` or tailing daemon logs.
 
-Phase 1 is **daemon-side, emit-only**. The `loom-daemon` subscribes its existing
-in-process event bus and narrates sweep-lifecycle transitions into the room. It
-adds no new event topics and no new publish call sites.
+Phase 1 **narration** is daemon-side and emit-only: the `loom-daemon` subscribes
+its existing in-process event bus and narrates sweep-lifecycle transitions into
+the room, adding no new event topics and no new publish call sites. On top of
+that, **peer-claim coordination (#4028) makes the room bidirectional** — a
+dedicated read task consumes inbound peer advertisements so daemons on a shared
+backlog back off before the non-atomic `loom:building` label flip would let them
+race. See [Peer-claim coordination](#peer-claim-coordination-cross-host-soft-claim-4028)
+below.
 
-> **Out of scope for phase 1** (tracked separately): per-worker personas
-> (`loom_builder_42`) and `SAFEHOUSE_PERSONA` forwarding to workers → **#3999**;
-> inbound human steering (reading `@`-mentions back to agents) → follow-up;
-> cloud-host provisioning of `safehoused` → **#3998**; carrying the judge verdict
-> value in an event payload (needs a frozen-taxonomy amendment) → follow-up.
+> **Out of scope** (tracked separately): per-worker personas (`loom_builder_42`)
+> and `SAFEHOUSE_PERSONA` forwarding to workers → **#3999**; inbound **human**
+> steering (reading `@`-mentions back to agents) → follow-up (it reuses the same
+> inbound read task #4028 adds); cloud-host provisioning of `safehoused` →
+> **#3998**; carrying the judge verdict value in an event payload (needs a
+> frozen-taxonomy amendment) → follow-up; the **atomic cross-host claim
+> authority** (a real CAS behind the soft claim) → Phase 2 of #4028.
 
 ## The degradation contract (read this first)
 
@@ -112,16 +119,78 @@ by the bare issue number (`task_id`):
   identity — the client never sends one (no impersonation).
 - Replies echo the request `id`. **Async push lines are interleaved on the same
   connection, carry an `event` key, and have no `id`** — the client
-  demultiplexes by skipping any line with an `event` key. Phase 1 is emit-only,
-  so pushes are read off the wire and discarded.
+  demultiplexes by skipping any line with an `event` key. The **narration**
+  connection is emit-only and discards inbound pushes; the **peer-claim
+  coordination** connection (#4028) instead routes each inbound `event` line to a
+  handler (see below).
 
 ## Implementation
 
 - `loom-daemon/src/safehouse.rs` — config resolver, envelope-v1 client, the
-  event→envelope mapping, and the reconnecting bus-subscriber sink.
-- `loom-daemon/src/workspace_pool.rs` — `start_safehouse_narration()` subscribes
-  the shared `Arc<EventBus>` (the single place it is owned) and spawns the sink
-  on the daemon runtime; a no-op when disabled.
+  event→envelope mapping, the reconnecting bus-subscriber narration sink, and
+  (#4028) the peer-claim coordination task + `InboundEventSink`.
+- `loom-daemon/src/peer_claims.rs` — the pure, socket-free peer-claim view
+  (TTL expiry, self-claim recognition, retraction, `ClaimAd` parse/serialize).
+- `loom-daemon/src/workspace_pool.rs` — `start_safehouse_narration()` and
+  `start_peer_coordination()` subscribe/attach the shared `Arc<EventBus>` /
+  `PeerClaimView` and spawn on the daemon runtime; both no-ops when disabled.
+
+## Peer-claim coordination: cross-host soft claim (#4028)
+
+On a multi-host deployment the only cross-host claim signal is the forge label,
+whose `loom:issue → loom:building` flip is **not** compare-and-swap
+(`SweepRegistry::flip_label_to_building` is an unconditional
+`--remove-label`/`--add-label`) — two hosts can both read `loom:issue` and
+dispatch before either flip propagates, producing duplicate sweeps. Peer-claim
+coordination shrinks that window:
+
+- **Advertise.** At the dispatch decision point — right after the local claim
+  lock, **before** the label flip — the daemon publishes a claim advertisement
+  over the room: issue number, [repo slug](#), host identity, PID, and a
+  wall-clock timestamp, carried as a **`task`** envelope (the `type` enum is
+  closed and owned by the safehouse repo, so a claim rides `task` with the bare
+  issue number as `task_id` — **no fifth type is invented**) whose `body` is the
+  structured JSON payload (marked `loom_claim`).
+- **Consume.** A **dedicated inbound read task** — separate from the narration
+  sink — drains the socket continuously via `select!`, so an **idle** daemon that
+  emits no narration still observes peer claims promptly (the narration
+  connection only reads while it is emitting). Each inbound claim is folded into a
+  shared `PeerClaimView`.
+- **Back off.** The work-finder skips any issue with a live peer claim, counted
+  under its **own** distinct `peer-claim-skip` reason on the per-tick summary line
+  (never folded into #4085's collision count).
+- **TTL.** Every peer claim expires after **`safehouse.peerClaimTtlSecs`
+  (default 120s = 2× the 60s work-finder interval)**, so a crashed peer cannot
+  permanently starve an issue. The TTL clock is the **local receipt `Instant`**,
+  never the advertiser's wall clock (clock skew is not comparable across hosts).
+  A peer also **retracts** its claim early when its sweep exits/crashes (a
+  `retract`-kind ad emitted from the reaper), freeing the issue before the TTL.
+- **Host identity.** loom's single, explicit host-identity concept is
+  `sweep_registry::host_identity()` (`LOOM_HOST_ID` > `$HOSTNAME` > the `hostname`
+  binary > `unknown-host`) — derived, not a new config block, and stable across
+  restarts. safehoused stamps the socket `from` from the *persona* (all daemons
+  share `loom_daemon`), which cannot distinguish hosts, so the identity travels in
+  the claim body and is what powers self-claim recognition: **a daemon never backs
+  off on its own advertisement.**
+- **Event taxonomy.** The internal pub/sub topic taxonomy is frozen; peer claims
+  add **no new bus topic** — they travel entirely over the safehouse room.
+
+### Soft claim, NOT a mutex (the load-bearing caveat)
+
+A room broadcast is eventually consistent, so this is a **fast backoff, not a
+lock**: two hosts advertising near-simultaneously still race. Advertisement
+*shrinks* the collision window; it does not close it. The atomic authority for
+the final claim — a real cross-host CAS (e.g. a `git push` to a claim ref) — is
+**Phase 2 of #4028**, deliberately out of scope here.
+
+### Fail-open (never a liveness dependency)
+
+Coordination is best-effort end to end: an unreachable/refusing/timing-out
+`safehoused` socket, a malformed inbound envelope, or a full outbound channel is
+logged (once) and **dispatch proceeds normally**. The outbound advertisement is a
+bounded, non-blocking `try_send` off the dispatch path; a `Full`/`Closed` channel
+drops the ad. `safehouse.enabled` false/absent is a **byte-for-byte no-op**: no
+view, no channel, no coordination task, no socket.
 
 # Phase 2 — worker-side `safehouse-mcp` injection (#3999)
 

--- a/defaults/config.json
+++ b/defaults/config.json
@@ -17,7 +17,8 @@
     "room": null,
     "persona": "loom_daemon",
     "workerPersonas": [],
-    "mcpCommand": "safehouse-mcp"
+    "mcpCommand": "safehouse-mcp",
+    "peerClaimTtlSecs": 120
   },
   "health_monitoring": {
     "enabled": true,

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1509,7 +1509,9 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.watchdog.reviewStall` | `LOOM_SWEEP_REVIEW_STALL` | `true` | Review-phase stall watchdog on/off (#3910) |
 | `autonomous.watchdog.reviewStallTimeoutSecs` | `LOOM_SWEEP_REVIEW_STALL_TIMEOUT_SECS` | `2700` | Log-silence window before a hung Judge/Doctor sweep is re-dispatched |
 | `autonomous.collisionDetection.enabled` | `LOOM_DETECT_COLLISIONS` | `false` | Cross-host dispatch-collision baseline (#4085). Off by default — adds one extra `gh issue view --json labels` round-trip per dispatch. Detection only: a collision is logged/counted, never acted on |
-| *(host identity, records only)* | `LOOM_HOST_ID` | `$HOSTNAME` → `hostname` → `unknown-host` | Overrides this host's identity string in collision log records (#4085); set it where the daemon runs without `$HOSTNAME` exported |
+| `safehouse.enabled` | `LOOM_SAFEHOUSE_ENABLED` | `false` | Enables safehouse fleet-comms (#3997) **and** cross-host soft-claim coordination (#4028). Off by default — a byte-for-byte no-op (no socket, no coordination task) when unset |
+| `safehouse.peerClaimTtlSecs` | `LOOM_PEER_CLAIM_TTL_SECS` | `120` | Peer-claim TTL, in seconds (#4028) — how long a peer's soft claim suppresses local dispatch (measured against local receipt, not the advertiser's clock). Default = 2× the 60s work-finder tick |
+| *(host identity)* | `LOOM_HOST_ID` | `$HOSTNAME` → `hostname` → `unknown-host` | This host's identity string, used in collision log records (#4085) **and** peer-claim self-recognition (#4028); set it where the daemon runs without `$HOSTNAME` exported |
 | `autonomous.autoUpdate.enabled` | `LOOM_AUTO_UPDATE` | `false` | Autonomous self-update loop on/off (#4055). **Opt-in** (it rebuilds + restarts the daemon process). Exactly one loop per daemon, not a per-workspace fan-out. See [Autonomous self-update loop](#autonomous-self-update-loop-4055) below |
 | `autonomous.autoUpdate.intervalSecs` | `LOOM_AUTO_UPDATE_INTERVAL_SECS` | `900` | Cadence between staleness checks. Zero/invalid → default |
 | `autonomous.autoUpdate.settleSecs` | `LOOM_AUTO_UPDATE_SETTLE_SECS` | `600` | Settle window: wait this long after first observing a stale commit — resetting on every further commit — before rolling, so a burst of merges collapses into one roll. Zero/invalid → default |
@@ -1744,6 +1746,64 @@ Because that is a real per-dispatch API cost it is **off by default**; enable it
 per the config/env row above (`LOOM_DETECT_COLLISIONS=1` or
 `autonomous.collisionDetection.enabled = true`, precedence **env > config >
 default**) on the hosts sharing a backlog while you take the measurement.
+
+### Cross-host soft claim over safehouse (#4028, Phase 1 of #4028)
+
+Where collision detection (above) only *measures* the race, the soft claim
+*shrinks* it. When `safehouse.enabled` is true, each daemon advertises its
+dispatch claims into the shared safehouse room and consumes peer advertisements,
+so a peer daemon backs off before the non-atomic `loom:building` label flip would
+let it race. This is Phase 1 of #4028 — see
+[`.loom/docs/safehouse.md` → Peer-claim coordination](safehouse.md#peer-claim-coordination-cross-host-soft-claim-4028)
+for the full design.
+
+- **Advertise before the flip.** In `SweepRegistry::dispatch()`, right after the
+  local claim lock and **before** `flip_label_to_building`, the daemon publishes a
+  claim advertisement (issue, cross-host-stable repo slug, host identity, PID,
+  timestamp) over the room. It rides a **`task`** envelope — the envelope `type`
+  enum is closed and owned by the safehouse repo, so **no fifth type is invented**
+  — with the bare issue number as `task_id` and the structured payload
+  (`loom_claim`-marked JSON) in the `body`.
+- **Dedicated inbound read task.** A coordination task on its own safehouse
+  connection drains the socket continuously (`select!` over read + outbound), so
+  an **idle** daemon that emits no narration still sees peer claims promptly — the
+  narration sink only reads while it is emitting, so peer-claim consumption cannot
+  piggyback on it. Inbound claims fold into a shared `PeerClaimView`
+  (`loom-daemon/src/peer_claims.rs`, pure/socket-free).
+- **Back off with a distinct counter.** The work-finder skips any issue with a
+  live peer claim, counted as **`peer-claim-skip`** on the per-tick summary line —
+  its **own** reason, never folded into `cross-host-collision(s)` (a post-hoc
+  count) or the label/in-flight skips:
+
+  ```
+  work_finder: tick — cap 3 (...); 5 seen, 1 dispatched, 0 labeled-skip,
+  0 in-flight-skip, 0 quarantine-skip, 0 pr-open-skip, 1 peer-claim-skip,
+  0 deferred, 0 error(s), 0 cross-host-collision(s)
+  ```
+
+- **TTL + retraction.** Peer claims expire after **`safehouse.peerClaimTtlSecs`
+  (env `LOOM_PEER_CLAIM_TTL_SECS`; default 120s = 2× the 60s work-finder tick)**,
+  measured against **local receipt time** (never the advertiser's wall clock —
+  clock skew is not comparable across hosts), so a crashed peer cannot
+  permanently starve an issue. A peer also emits a `retract` ad from its reaper on
+  a terminal sweep outcome, freeing the issue before the TTL.
+- **Self-claim recognition.** A daemon never backs off on its own advertisement:
+  the claim body carries the host identity (`host_identity()`:
+  `LOOM_HOST_ID` > `$HOSTNAME` > `hostname` > `unknown-host` — loom's single,
+  derived, restart-stable host concept), and the view ignores ads from this host.
+  safehoused's socket `from` is stamped from the *persona* (all daemons share
+  `loom_daemon`) and cannot distinguish hosts, hence the body-carried identity.
+- **Fail-open, no-op when off.** An unreachable/refusing/timing-out socket, a
+  malformed envelope, or a full outbound channel is logged once and **dispatch
+  proceeds** — the outbound ad is a bounded non-blocking `try_send` off the
+  dispatch path. `safehouse.enabled` false/absent is a **byte-for-byte no-op**: no
+  view, no channel, no coordination task, no socket. No new event-bus topic is
+  added (the frozen taxonomy is untouched — claims travel entirely over the room).
+
+> **Soft claim, NOT a mutex.** A room broadcast is eventually consistent, so this
+> is a fast backoff, not a lock — two hosts advertising near-simultaneously still
+> race. The **atomic** cross-host claim authority (a real CAS, e.g. a `git push`
+> to a claim ref) is **Phase 2 of #4028**, filed separately.
 
 ### Prerequisite: a fresh token ranking (#3894, self-refreshed by the daemon since #3969)
 

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -33,6 +33,7 @@ pub mod ipc;
 pub mod issue_creation_mutex;
 pub mod main_health_gate;
 pub mod metrics_collector;
+pub mod peer_claims;
 pub mod phase_join;
 pub mod pipeline_snapshot;
 pub mod quarantine_reconciliation;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -875,6 +875,21 @@ async fn main() -> Result<()> {
     // Byte-for-byte no-op when `safehouse.enabled` is false/absent.
     workspace_pool.start_safehouse_narration(&sweep_workspace);
 
+    // Optional cross-host soft-claim coordination (#4028): a dedicated safehouse
+    // connection that advertises this daemon's dispatch claims and consumes peer
+    // advertisements into a shared TTL-bounded view, so peer daemons back off
+    // before the non-atomic `loom:building` label flip would let them race.
+    // Byte-for-byte no-op when `safehouse.enabled` is false/absent. Injected into
+    // the seeded default registry here (the IPC `DispatchSweep` path); every other
+    // provisioned registry is injected in `get_or_provision`.
+    workspace_pool.start_peer_coordination(&sweep_workspace);
+    {
+        let mut reg = sweep_registry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        workspace_pool.inject_peer_coordination(&mut reg);
+    }
+
     // Startup watchdog (Issue #3887): auto-cancel + re-dispatch (once, bounded)
     // any daemon-dispatched sweep that hangs at startup with no progress. On by
     // default; disable with LOOM_SWEEP_WATCHDOG=0 or

--- a/loom-daemon/src/peer_claims.rs
+++ b/loom-daemon/src/peer_claims.rs
@@ -1,0 +1,608 @@
+//! Pure cross-host peer-claim view + TTL expiry (Issue #4028, Phase 1 — soft
+//! claim advertisement over the safehouse room).
+//!
+//! # What this is
+//!
+//! On a multi-host deployment (one daemon per machine, shared repo backlog) the
+//! only cross-host coordination for claiming an issue is the forge label
+//! (`loom:issue → loom:building`), whose flip is **non-atomic** — two hosts can
+//! both read `loom:issue` and dispatch before either flip propagates
+//! ([`crate::sweep_registry::SweepRegistry::flip_label_to_building`] is an
+//! unconditional `--remove-label`/`--add-label`, no CAS). This module implements
+//! the **soft claim**: each daemon advertises "claiming issue #N on host H" into
+//! the shared safehouse room the moment it decides to dispatch, and every peer
+//! keeps a **peer-claim view** so it can back off on an issue a peer is already
+//! building — far faster than the label propagates.
+//!
+//! # Soft claim, not a mutex (read this)
+//!
+//! A room broadcast is eventually consistent, so this is a **fast backoff**, not
+//! a lock: two hosts advertising near-simultaneously still race. Advertisement
+//! *shrinks* the collision window; it does not close it. The atomic authority for
+//! the final claim (a real cross-host CAS) is **Phase 2**, out of scope here — see
+//! #4028's "Design options for the atomic authority" section.
+//!
+//! # TTL is measured against LOCAL receipt, never the advertiser's clock
+//!
+//! A crashed peer must not starve an issue forever, so every peer claim expires
+//! after a bounded TTL ([`DEFAULT_PEER_CLAIM_TTL`], overridable). The expiry
+//! clock is the **local [`Instant`] at which this daemon observed the ad**, not
+//! the advertiser's wall-clock timestamp — wall clocks are not comparable across
+//! hosts (clock skew), so the advertised `ts` is carried for diagnostics only and
+//! is **never** used for TTL math. A peer can also retract its claim early (on
+//! its sweep exiting/crashing) so the issue frees before the TTL lapses.
+//!
+//! # Purity
+//!
+//! [`PeerClaimView`] and [`ClaimAd`] have **no socket dependency** — the decide
+//! logic (observe / retract / expire) is fully unit-testable with an injected
+//! [`Instant`], mirroring the `decide`/`plan` split in
+//! [`crate::claim_reconciliation`]. The socket transport lives entirely in
+//! [`crate::safehouse`].
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use serde_json::{json, Value};
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/// Marker key present in every claim-advertisement body payload, so an inbound
+/// room event that is a human chat message (or any non-claim `task` envelope) is
+/// cheaply distinguished from a claim and ignored.
+pub const PEER_CLAIM_MARKER: &str = "loom_claim";
+
+/// The single claim-payload schema version this daemon speaks. A body carrying a
+/// different version is rejected (treated as not-a-claim) rather than
+/// mis-parsed.
+pub const CLAIM_SCHEMA_VERSION: u64 = 1;
+
+/// Env var overriding the peer-claim TTL, in seconds. Precedence
+/// **env > config (`safehouse.peerClaimTtlSecs`) > default**.
+pub const PEER_CLAIM_TTL_ENV: &str = "LOOM_PEER_CLAIM_TTL_SECS";
+
+/// Default peer-claim TTL. Chosen at **2×** the default work-finder tick
+/// interval ([`crate::work_finder::DEFAULT_WORK_FINDER_INTERVAL_SECS`] = 60s) so
+/// a peer's soft claim survives at least one full tick — long enough for the
+/// peer's forge label flip to propagate and take over as the durable signal —
+/// while still freeing a crashed peer's issue promptly.
+pub const DEFAULT_PEER_CLAIM_TTL: Duration = Duration::from_secs(120);
+
+// ============================================================================
+// Claim advertisement
+// ============================================================================
+
+/// Whether an advertisement asserts a claim or retracts one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClaimKind {
+    /// "I am dispatching issue #N" — record a peer claim.
+    Advertise,
+    /// "My sweep for issue #N exited/crashed" — retract my earlier claim early
+    /// (before its TTL would lapse).
+    Retract,
+}
+
+impl ClaimKind {
+    #[must_use]
+    fn as_str(self) -> &'static str {
+        match self {
+            ClaimKind::Advertise => "advertise",
+            ClaimKind::Retract => "retract",
+        }
+    }
+
+    #[must_use]
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "advertise" => Some(ClaimKind::Advertise),
+            "retract" => Some(ClaimKind::Retract),
+            _ => None,
+        }
+    }
+}
+
+/// One claim advertisement, carried in the `body` of a `task`-typed safehouse
+/// envelope (Gap 2 of #4028: the envelope `type` enum is closed and owned by the
+/// safehouse repo, so a claim rides a `task` envelope with the issue number as
+/// `task_id` rather than inventing a fifth type).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaimAd {
+    pub kind: ClaimKind,
+    /// The issue being claimed / retracted.
+    pub issue: u32,
+    /// A **cross-host-stable** repo identity (see [`repo_slug`]) — NOT a local
+    /// absolute path, which differs per host for the same logical repo.
+    pub repo: String,
+    /// The advertising host's identity (see
+    /// [`crate::sweep_registry::host_identity`]). Used for self-claim
+    /// recognition (a daemon ignores its own ads) and to scope a retraction (a
+    /// host may only retract its own claim).
+    pub host: String,
+    /// The advertising daemon's PID (diagnostic).
+    pub pid: u32,
+    /// The advertiser's RFC3339 wall-clock timestamp. **Diagnostic only** — TTL
+    /// is measured against local receipt time, never this (clock skew).
+    pub ts: String,
+}
+
+impl ClaimAd {
+    #[must_use]
+    pub fn advertise(issue: u32, repo: String, host: String, pid: u32, ts: String) -> Self {
+        Self {
+            kind: ClaimKind::Advertise,
+            issue,
+            repo,
+            host,
+            pid,
+            ts,
+        }
+    }
+
+    #[must_use]
+    pub fn retract(issue: u32, repo: String, host: String, pid: u32, ts: String) -> Self {
+        Self {
+            kind: ClaimKind::Retract,
+            issue,
+            repo,
+            host,
+            pid,
+            ts,
+        }
+    }
+
+    /// Serialize to the JSON string carried in the envelope `body`.
+    #[must_use]
+    pub fn to_body_json(&self) -> String {
+        json!({
+            PEER_CLAIM_MARKER: CLAIM_SCHEMA_VERSION,
+            "kind": self.kind.as_str(),
+            "issue": self.issue,
+            "repo": self.repo,
+            "host": self.host,
+            "pid": self.pid,
+            "ts": self.ts,
+        })
+        .to_string()
+    }
+
+    /// Parse a claim from an already-decoded `body` JSON value. Returns `None`
+    /// for any non-claim or malformed payload (missing marker, wrong version,
+    /// missing/ill-typed fields) — this is the **malformed-envelope rejection**
+    /// AC: a bad payload is dropped, never panics, never mis-claims.
+    #[must_use]
+    pub fn from_body_value(v: &Value) -> Option<Self> {
+        let obj = v.as_object()?;
+        // Marker + version gate: anything without the exact marker/version is
+        // "not a claim" (e.g. a human chat message on the same room).
+        if obj.get(PEER_CLAIM_MARKER).and_then(Value::as_u64)? != CLAIM_SCHEMA_VERSION {
+            return None;
+        }
+        let kind = ClaimKind::from_str(obj.get("kind").and_then(Value::as_str)?)?;
+        let issue = u32::try_from(obj.get("issue").and_then(Value::as_u64)?).ok()?;
+        let repo = obj.get("repo").and_then(Value::as_str)?.to_owned();
+        let host = obj.get("host").and_then(Value::as_str)?.to_owned();
+        // `pid` and `ts` are diagnostic; tolerate their absence rather than
+        // rejecting an otherwise-valid claim.
+        let pid = obj
+            .get("pid")
+            .and_then(Value::as_u64)
+            .and_then(|p| u32::try_from(p).ok())
+            .unwrap_or(0);
+        let ts = obj
+            .get("ts")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+        if repo.is_empty() || host.is_empty() {
+            return None;
+        }
+        Some(Self {
+            kind,
+            issue,
+            repo,
+            host,
+            pid,
+            ts,
+        })
+    }
+
+    /// Parse a claim from the raw `body` string of an inbound room event.
+    #[must_use]
+    pub fn from_body_str(body: &str) -> Option<Self> {
+        let v: Value = serde_json::from_str(body).ok()?;
+        Self::from_body_value(&v)
+    }
+}
+
+// ============================================================================
+// Repo identity + TTL resolution
+// ============================================================================
+
+/// A **cross-host-stable** repo identity for keying peer claims.
+///
+/// A local absolute `workspace_root` differs per host for the same logical repo
+/// (`/Users/a/loom` vs `/home/b/loom`), so it cannot key claims across hosts.
+/// This resolves, in order: `$LOOM_REPO` (the forge `owner/repo` slug the daemon
+/// already threads through `gh --repo`), else the final path component
+/// (directory basename — two clones of `loom` share `"loom"`), else the full
+/// path as a last resort.
+///
+/// # Known limitation (documented, matches the frozen-taxonomy phase-b tradeoff)
+///
+/// Two *different* repos that share a directory basename **and** are backed by
+/// the same shared room could cross-suppress issue #N. This is the same
+/// issue-number-keying limitation already accepted for the `sweep.issue.{N}.*`
+/// narration taxonomy (#3929); set `$LOOM_REPO` to the `owner/repo` slug to make
+/// the key precise. Because the claim is a soft, TTL-bounded, fail-open backoff
+/// (never a hard lock), a false suppression self-heals within one TTL.
+#[must_use]
+pub fn repo_slug(workspace_root: &Path) -> String {
+    if let Ok(v) = std::env::var("LOOM_REPO") {
+        let t = v.trim();
+        if !t.is_empty() {
+            return t.to_owned();
+        }
+    }
+    workspace_root
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| workspace_root.display().to_string())
+}
+
+/// Resolve the peer-claim TTL with precedence **env > config
+/// (`safehouse.peerClaimTtlSecs`) > default([`DEFAULT_PEER_CLAIM_TTL`])**. A
+/// zero/unparseable value at any layer falls through (a zero TTL would make every
+/// claim expire instantly, defeating the backoff).
+#[must_use]
+pub fn resolve_peer_claim_ttl(repo_root: &Path) -> Duration {
+    if let Some(secs) = std::env::var(PEER_CLAIM_TTL_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&s| s > 0)
+    {
+        return Duration::from_secs(secs);
+    }
+    let effective = crate::config_resolver::resolve_effective_config(repo_root);
+    let from_config = crate::config_resolver::get_path(&effective, "safehouse")
+        .and_then(|s| s.get("peerClaimTtlSecs"))
+        .and_then(Value::as_u64)
+        .filter(|&s| s > 0);
+    from_config.map_or(DEFAULT_PEER_CLAIM_TTL, Duration::from_secs)
+}
+
+// ============================================================================
+// Peer-claim view
+// ============================================================================
+
+/// One live peer claim on an issue.
+#[derive(Debug, Clone)]
+struct ClaimEntry {
+    /// Which host holds the claim (for retraction scoping + diagnostics).
+    host: String,
+    /// Advertising daemon PID (diagnostic).
+    #[allow(dead_code)]
+    pid: u32,
+    /// **Local** [`Instant`] at which this daemon observed the ad — the TTL
+    /// clock. Never the advertiser's wall clock.
+    received_at: Instant,
+}
+
+/// The set of issues peer hosts have advertised as in-flight, with per-entry TTL
+/// expiry. Pure and socket-free: [`crate::safehouse`]'s inbound read task feeds
+/// it via [`observe_at`](Self::observe_at); the work-finder queries it via
+/// [`claimed_issues_at`](Self::claimed_issues_at).
+#[derive(Debug)]
+pub struct PeerClaimView {
+    /// This daemon's own host identity — ads from this host are ignored
+    /// (self-claim recognition, mirroring the `LOOM_SWEEP_CLAIM_OWNED` self-skip
+    /// so a daemon never backs off on its own advertisement).
+    self_host: String,
+    ttl: Duration,
+    /// Keyed by `(repo_slug, issue)` so two managed repos' issue #N never
+    /// collide.
+    claims: HashMap<(String, u32), ClaimEntry>,
+}
+
+impl PeerClaimView {
+    #[must_use]
+    pub fn new(self_host: String, ttl: Duration) -> Self {
+        Self {
+            self_host,
+            ttl,
+            claims: HashMap::new(),
+        }
+    }
+
+    /// This daemon's own host identity (self-claim recognition key).
+    #[must_use]
+    pub fn self_host(&self) -> &str {
+        &self.self_host
+    }
+
+    /// The configured TTL.
+    #[must_use]
+    pub fn ttl(&self) -> Duration {
+        self.ttl
+    }
+
+    /// Observe an inbound advertisement at local time `now`.
+    ///
+    /// Returns `true` when the ad was applied (a peer's), `false` when it was
+    /// ignored because it originated from **this** host (self-claim
+    /// recognition). A [`ClaimKind::Retract`] removes the peer's claim only when
+    /// the recorded holder matches the retracting host (a host may not retract
+    /// another host's claim).
+    pub fn observe_at(&mut self, ad: &ClaimAd, now: Instant) -> bool {
+        if ad.host == self.self_host {
+            return false; // never back off on our own advertisement
+        }
+        let key = (ad.repo.clone(), ad.issue);
+        match ad.kind {
+            ClaimKind::Advertise => {
+                self.claims.insert(
+                    key,
+                    ClaimEntry {
+                        host: ad.host.clone(),
+                        pid: ad.pid,
+                        received_at: now,
+                    },
+                );
+            }
+            ClaimKind::Retract => {
+                if self.claims.get(&key).is_some_and(|e| e.host == ad.host) {
+                    self.claims.remove(&key);
+                }
+            }
+        }
+        true
+    }
+
+    /// Whether `issue` in `repo` currently has a **live** (non-expired) peer
+    /// claim at local time `now`.
+    #[must_use]
+    pub fn is_claimed_at(&self, repo: &str, issue: u32, now: Instant) -> bool {
+        self.claims
+            .get(&(repo.to_owned(), issue))
+            .is_some_and(|e| now.saturating_duration_since(e.received_at) < self.ttl)
+    }
+
+    /// The set of issues in `repo` with a live peer claim at local time `now` —
+    /// the work-finder's per-tick skip set.
+    #[must_use]
+    pub fn claimed_issues_at(&self, repo: &str, now: Instant) -> HashSet<u32> {
+        self.claims
+            .iter()
+            .filter(|((r, _), e)| {
+                r == repo && now.saturating_duration_since(e.received_at) < self.ttl
+            })
+            .map(|((_, issue), _)| *issue)
+            .collect()
+    }
+
+    /// Drop every expired entry at local time `now`. Called opportunistically so
+    /// the map does not grow without bound from crashed peers.
+    pub fn prune_expired(&mut self, now: Instant) {
+        let ttl = self.ttl;
+        self.claims
+            .retain(|_, e| now.saturating_duration_since(e.received_at) < ttl);
+    }
+
+    /// Number of tracked claims (test/observability aid; includes not-yet-pruned
+    /// expired entries).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.claims.len()
+    }
+
+    /// Whether the view tracks no claims.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.claims.is_empty()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn ad(kind: ClaimKind, issue: u32, repo: &str, host: &str) -> ClaimAd {
+        ClaimAd {
+            kind,
+            issue,
+            repo: repo.to_owned(),
+            host: host.to_owned(),
+            pid: 42,
+            ts: "2026-07-28T00:00:00Z".to_owned(),
+        }
+    }
+
+    // ---- ClaimAd JSON round-trip + malformed rejection ----
+
+    #[test]
+    fn body_json_round_trips() {
+        let a = ClaimAd::advertise(4028, "loom".into(), "maple".into(), 123, "ts".into());
+        let parsed = ClaimAd::from_body_str(&a.to_body_json()).unwrap();
+        assert_eq!(parsed, a);
+
+        let r = ClaimAd::retract(7, "loom".into(), "birch".into(), 9, "ts".into());
+        let parsed = ClaimAd::from_body_str(&r.to_body_json()).unwrap();
+        assert_eq!(parsed, r);
+    }
+
+    #[test]
+    fn malformed_bodies_are_rejected_not_panicked() {
+        // Not JSON.
+        assert!(ClaimAd::from_body_str("not json").is_none());
+        // JSON but no marker (e.g. a human chat message sharing the room).
+        assert!(ClaimAd::from_body_str(r#"{"body":"hello human"}"#).is_none());
+        // Marker present but wrong version.
+        assert!(ClaimAd::from_body_str(
+            r#"{"loom_claim":999,"kind":"advertise","issue":1,"repo":"r","host":"h"}"#
+        )
+        .is_none());
+        // Marker + version but missing required field (repo).
+        assert!(ClaimAd::from_body_str(
+            r#"{"loom_claim":1,"kind":"advertise","issue":1,"host":"h"}"#
+        )
+        .is_none());
+        // Empty host is rejected.
+        assert!(ClaimAd::from_body_str(
+            r#"{"loom_claim":1,"kind":"advertise","issue":1,"repo":"r","host":""}"#
+        )
+        .is_none());
+        // Unknown kind.
+        assert!(ClaimAd::from_body_str(
+            r#"{"loom_claim":1,"kind":"steal","issue":1,"repo":"r","host":"h"}"#
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn pid_and_ts_are_optional_diagnostics() {
+        let a = ClaimAd::from_body_str(
+            r#"{"loom_claim":1,"kind":"advertise","issue":5,"repo":"r","host":"h"}"#,
+        )
+        .unwrap();
+        assert_eq!(a.pid, 0);
+        assert_eq!(a.ts, "");
+        assert_eq!(a.issue, 5);
+    }
+
+    // ---- TTL expiry ----
+
+    #[test]
+    fn claim_expires_after_ttl_measured_from_local_receipt() {
+        let ttl = Duration::from_secs(100);
+        let mut view = PeerClaimView::new("me".into(), ttl);
+        let base = Instant::now();
+        assert!(view.observe_at(&ad(ClaimKind::Advertise, 1, "loom", "peer"), base));
+
+        // Within the window: still claimed.
+        assert!(view.is_claimed_at("loom", 1, base + Duration::from_secs(99)));
+        // At/after the TTL: expired.
+        assert!(!view.is_claimed_at("loom", 1, base + Duration::from_secs(100)));
+        assert!(!view.is_claimed_at("loom", 1, base + Duration::from_secs(101)));
+    }
+
+    #[test]
+    fn claimed_issues_set_drops_expired_and_scopes_by_repo() {
+        let ttl = Duration::from_secs(100);
+        let mut view = PeerClaimView::new("me".into(), ttl);
+        let base = Instant::now();
+        view.observe_at(&ad(ClaimKind::Advertise, 1, "loom", "peer"), base);
+        view.observe_at(
+            &ad(ClaimKind::Advertise, 2, "loom", "peer"),
+            base + Duration::from_secs(50),
+        );
+        view.observe_at(&ad(ClaimKind::Advertise, 9, "other", "peer"), base);
+
+        // At base+60: #1 (age 60) live, #2 (age 10) live, but scoped to "loom".
+        let at = base + Duration::from_secs(60);
+        let set = view.claimed_issues_at("loom", at);
+        assert_eq!(set, HashSet::from([1, 2]));
+        // The "other" repo's claim never appears under "loom".
+        assert_eq!(view.claimed_issues_at("other", at), HashSet::from([9]));
+
+        // At base+120: #1 (age 120) expired, #2 (age 70) live.
+        let later = base + Duration::from_secs(120);
+        assert_eq!(view.claimed_issues_at("loom", later), HashSet::from([2]));
+    }
+
+    #[test]
+    fn prune_expired_reclaims_map_space() {
+        let ttl = Duration::from_secs(10);
+        let mut view = PeerClaimView::new("me".into(), ttl);
+        let base = Instant::now();
+        view.observe_at(&ad(ClaimKind::Advertise, 1, "loom", "peer"), base);
+        assert_eq!(view.len(), 1);
+        view.prune_expired(base + Duration::from_secs(11));
+        assert_eq!(view.len(), 0);
+        assert!(view.is_empty());
+    }
+
+    // ---- self-claim recognition ----
+
+    #[test]
+    fn own_advertisement_is_never_backed_off_on() {
+        let mut view = PeerClaimView::new("me".into(), Duration::from_secs(100));
+        let now = Instant::now();
+        // An ad from our own host is ignored.
+        assert!(!view.observe_at(&ad(ClaimKind::Advertise, 1, "loom", "me"), now));
+        assert!(!view.is_claimed_at("loom", 1, now));
+        assert!(view.is_empty());
+
+        // A peer's ad for the same issue IS recorded.
+        assert!(view.observe_at(&ad(ClaimKind::Advertise, 1, "loom", "peer"), now));
+        assert!(view.is_claimed_at("loom", 1, now));
+    }
+
+    // ---- retraction ----
+
+    #[test]
+    fn peer_retract_frees_the_issue_early() {
+        let mut view = PeerClaimView::new("me".into(), Duration::from_secs(1000));
+        let now = Instant::now();
+        view.observe_at(&ad(ClaimKind::Advertise, 1, "loom", "peer"), now);
+        assert!(view.is_claimed_at("loom", 1, now));
+
+        // The same peer retracting (its sweep exited/crashed) frees it well
+        // before the long TTL would.
+        view.observe_at(&ad(ClaimKind::Retract, 1, "loom", "peer"), now);
+        assert!(!view.is_claimed_at("loom", 1, now));
+    }
+
+    #[test]
+    fn a_host_cannot_retract_another_hosts_claim() {
+        let mut view = PeerClaimView::new("me".into(), Duration::from_secs(1000));
+        let now = Instant::now();
+        view.observe_at(&ad(ClaimKind::Advertise, 1, "loom", "peerA"), now);
+        // A different host's retract must not remove peerA's claim.
+        view.observe_at(&ad(ClaimKind::Retract, 1, "loom", "peerB"), now);
+        assert!(view.is_claimed_at("loom", 1, now));
+        // peerA's own retract does.
+        view.observe_at(&ad(ClaimKind::Retract, 1, "loom", "peerA"), now);
+        assert!(!view.is_claimed_at("loom", 1, now));
+    }
+
+    // ---- repo_slug ----
+
+    #[test]
+    fn repo_slug_prefers_env_then_basename() {
+        // Env override wins.
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        assert_eq!(repo_slug(Path::new("/anything/here")), "rjwalters/loom");
+        std::env::remove_var("LOOM_REPO");
+        // Basename fallback is cross-host-stable for the same repo.
+        assert_eq!(repo_slug(Path::new("/Users/a/loom")), "loom");
+        assert_eq!(repo_slug(Path::new("/home/b/loom")), "loom");
+    }
+
+    // ---- integration-shaped: two hosts, one issue, exactly one proceeds ----
+
+    #[test]
+    fn two_hosts_one_issue_second_host_backs_off_deterministically() {
+        // Host A dispatches issue 100 and advertises. Host B, before dispatching
+        // its own, observes A's ad and must treat 100 as in-flight — so only A
+        // proceeds. Deterministic injected ordering, NO sleeps (#4044).
+        let mut host_b = PeerClaimView::new("B".into(), Duration::from_secs(120));
+        let t = Instant::now();
+
+        // A's advertisement arrives on B's inbound read task.
+        let a_ad = ClaimAd::advertise(100, "loom".into(), "A".into(), 111, "ts".into());
+        host_b.observe_at(&a_ad, t);
+
+        // B's work-finder tick: 100 is peer-claimed, so B skips it.
+        assert!(host_b.is_claimed_at("loom", 100, t));
+        assert!(host_b.claimed_issues_at("loom", t).contains(&100));
+
+        // Once A's sweep exits and A retracts (or the TTL lapses), B is free to
+        // pick it up if A never landed a durable label.
+        host_b.observe_at(&ClaimAd::retract(100, "loom".into(), "A".into(), 111, "ts".into()), t);
+        assert!(!host_b.is_claimed_at("loom", 100, t));
+    }
+}

--- a/loom-daemon/src/safehouse.rs
+++ b/loom-daemon/src/safehouse.rs
@@ -39,6 +39,7 @@
 //!   demultiplexes by skipping any line with an `event` key.
 
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
@@ -46,8 +47,10 @@ use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::UnixStream;
+use tokio::sync::mpsc::error::TryRecvError;
 
 use crate::event_bus::{EventBus, RecvError};
+use crate::peer_claims::{ClaimAd, PeerClaimView};
 use crate::types::{Event, SweepKind};
 
 // ============================================================================
@@ -452,11 +455,24 @@ impl SafehouseClient {
                 serde_json::from_str(trimmed).context("bad reply from safehoused")?;
             if value.get("event").is_some() {
                 // Interleaved async push (inbound room event) — demultiplex it
-                // out; phase 1 is emit-only and does not consume inbound.
+                // out. The **narration** connection is emit-only and discards
+                // inbound; peer-claim consumption (#4028) runs on a *dedicated*
+                // read task ([`run_coordination`]) on its own connection, so an
+                // idle daemon that emits no narration still observes peer
+                // advertisements promptly (Gap 1a).
                 continue;
             }
             return Ok(value);
         }
+    }
+
+    /// Consume `self` into its raw halves so a caller (the peer-coordination
+    /// task) can read inbound room events and write outbound claim ads
+    /// **concurrently** on one connection — the narration [`send`](Self::send)
+    /// path reads its own reply inline and cannot be driven by a `select!` loop.
+    #[must_use]
+    pub fn into_parts(self) -> (BufReader<OwnedReadHalf>, OwnedWriteHalf, u64, Option<String>) {
+        (self.reader, self.writer, self.next_id, self.room)
     }
 }
 
@@ -575,6 +591,239 @@ async fn run_sink(
 }
 
 // ============================================================================
+// Peer-claim coordination (Issue #4028, Phase 1)
+// ============================================================================
+
+/// Bounded outbound claim-ad channel capacity. Ads are tiny and rare (one per
+/// dispatch / terminal outcome); the bound only matters during a safehoused
+/// outage, where [`SweepRegistry`](crate::sweep_registry::SweepRegistry)'s
+/// `try_send` drops on `Full` (fail-open) rather than blocking the dispatch path.
+pub const PEER_CLAIM_CHANNEL_CAP: usize = 256;
+
+/// A generic sink for inbound room events. Kept intentionally generic (rather
+/// than hard-wiring peer-claims) so the shared inbound read task can later fan an
+/// event out to additional consumers — e.g. inbound human steering (the
+/// follow-up noted at `.loom/docs/safehouse.md`) — without another connection.
+pub trait InboundEventSink: Send + Sync {
+    /// Handle one inbound room-event push line (a JSON object carrying an
+    /// `event` key). Best-effort: an implementation must never panic or block.
+    fn on_event(&self, event: &Value);
+}
+
+/// The peer-claim consumer: parses claim ads out of inbound room events and
+/// folds them into a shared [`PeerClaimView`] (self-claim recognition + TTL live
+/// in the view). A non-claim event (a human chat message, a narration line) is
+/// silently ignored.
+pub struct PeerClaimSink {
+    view: Arc<Mutex<PeerClaimView>>,
+}
+
+impl PeerClaimSink {
+    #[must_use]
+    pub fn new(view: Arc<Mutex<PeerClaimView>>) -> Self {
+        Self { view }
+    }
+}
+
+impl InboundEventSink for PeerClaimSink {
+    fn on_event(&self, event: &Value) {
+        let Some(body) = event.get("body").and_then(Value::as_str) else {
+            return;
+        };
+        let Some(ad) = ClaimAd::from_body_str(body) else {
+            return; // not a claim (human chat, narration, malformed) — ignore
+        };
+        match self.view.lock() {
+            Ok(mut view) => {
+                let now = Instant::now();
+                view.observe_at(&ad, now);
+                // Opportunistically prune so a crashed peer's entries do not
+                // accumulate between work-finder queries.
+                view.prune_expired(now);
+            }
+            Err(poisoned) => {
+                log::error!("safehouse: peer-claim view mutex poisoned ({poisoned:?})");
+            }
+        }
+    }
+}
+
+/// Build the `task`-typed advertisement envelope for a claim ad (Gap 2 of
+/// #4028): the envelope `type` enum is closed and owned by the safehouse repo, so
+/// a claim rides a `task` envelope with the bare issue number as `task_id` and
+/// the structured payload in `body`.
+#[must_use]
+pub fn claim_ad_to_envelope(ad: &ClaimAd) -> Envelope {
+    Envelope {
+        to: "*".to_owned(),
+        kind: "task".to_owned(),
+        task_id: Some(ad.issue.to_string()),
+        body: ad.to_body_json(),
+    }
+}
+
+/// Spawn the peer-claim coordination task: one dedicated safehouse connection
+/// that **reads** inbound peer advertisements into `sink` and **writes** this
+/// daemon's outbound claim ads drained from `outbound`. Returns `None` — a
+/// byte-for-byte no-op (no socket, no task) — when safehouse is disabled or no
+/// socket resolves, mirroring [`spawn_sink`]'s contract.
+///
+/// This is the **dedicated inbound read task** the issue's Gap 1a requires: it
+/// drains the socket continuously via `select!`, so an idle daemon that emits no
+/// narration still observes peer claims promptly (the narration sink's
+/// `read_reply` only drains while it is emitting).
+#[must_use]
+pub fn spawn_peer_coordination(
+    config: SafehouseConfig,
+    sink: Arc<dyn InboundEventSink>,
+    outbound: tokio::sync::mpsc::Receiver<ClaimAd>,
+    runtime: &tokio::runtime::Handle,
+) -> Option<tokio::task::JoinHandle<()>> {
+    if !config.enabled {
+        return None; // disabled ⇒ no socket, no task, no syscalls
+    }
+    let Some(socket) = resolve_socket(&config) else {
+        log::warn!(
+            "safehouse: peer coordination enabled but no socket path resolved \
+             (set safehouse.socket, $LOOM_SAFEHOUSE_SOCKET, or $SAFEHOUSED_SOCKET) — \
+             soft-claim coordination off"
+        );
+        return None;
+    };
+    log::info!(
+        "safehouse: peer-claim coordination enabled (persona={}, socket={})",
+        config.persona,
+        socket.display()
+    );
+    Some(runtime.spawn(async move {
+        run_coordination(config, socket, sink, outbound, DEFAULT_MIN_BACKOFF, DEFAULT_MAX_BACKOFF)
+            .await;
+    }))
+}
+
+/// The coordination loop. Reconnects lazily with capped backoff; on each live
+/// connection it concurrently reads inbound room events (→ `sink`) and drains
+/// outbound claim ads (→ socket). Any I/O failure degrades to a reconnect — it
+/// never blocks or fails a dispatch. Returns when all outbound senders drop.
+async fn run_coordination(
+    config: SafehouseConfig,
+    socket: PathBuf,
+    sink: Arc<dyn InboundEventSink>,
+    mut outbound: tokio::sync::mpsc::Receiver<ClaimAd>,
+    min_backoff: Duration,
+    max_backoff: Duration,
+) {
+    let mut backoff = min_backoff;
+    let mut warned = false;
+    loop {
+        let client = match SafehouseClient::connect(&socket, &config.persona, config.room.clone())
+            .await
+        {
+            Ok(client) => {
+                if warned {
+                    log::info!("safehouse: peer coordination reconnected to {}", socket.display());
+                }
+                backoff = min_backoff;
+                warned = false;
+                client
+            }
+            Err(err) => {
+                if !warned {
+                    log::warn!(
+                        "safehouse: cannot reach safehoused for peer coordination at {} \
+                             ({err:#}); coordination paused, dispatch unaffected",
+                        socket.display()
+                    );
+                    warned = true;
+                }
+                // Drain-and-drop queued ads during the outage so the bounded
+                // channel does not wedge; exit if all senders are gone.
+                loop {
+                    match outbound.try_recv() {
+                        Ok(_) => continue,
+                        Err(TryRecvError::Empty) => break,
+                        Err(TryRecvError::Disconnected) => return,
+                    }
+                }
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(max_backoff);
+                continue;
+            }
+        };
+
+        let (reader, mut writer, mut next_id, room) = client.into_parts();
+        let mut lines = reader.lines();
+        let reconnect = loop {
+            tokio::select! {
+                line = lines.next_line() => {
+                    match line {
+                        Ok(Some(l)) => {
+                            let trimmed = l.trim();
+                            if trimmed.is_empty() {
+                                continue;
+                            }
+                            let Ok(value) = serde_json::from_str::<Value>(trimmed) else {
+                                continue; // malformed line — fail-open, skip
+                            };
+                            if value.get("event").is_some() {
+                                sink.on_event(&value);
+                            }
+                            // A reply echo (has `id`, no `event`) to one of our
+                            // own sends: nothing to do, drop it.
+                        }
+                        Ok(None) => break true,          // peer closed → reconnect
+                        Err(e) => {
+                            log::debug!("safehouse: coordination read error ({e}); reconnecting");
+                            break true;
+                        }
+                    }
+                }
+                ad = outbound.recv() => {
+                    match ad {
+                        Some(ad) => {
+                            let env = claim_ad_to_envelope(&ad);
+                            let id = next_id;
+                            next_id = next_id.wrapping_add(1);
+                            match build_send_request(&env, id, room.as_deref()) {
+                                Ok(req) => {
+                                    let mut line = match serde_json::to_string(&req) {
+                                        Ok(s) => s,
+                                        Err(e) => {
+                                            log::warn!("safehouse: cannot serialize claim ad ({e})");
+                                            continue;
+                                        }
+                                    };
+                                    line.push('\n');
+                                    if writer.write_all(line.as_bytes()).await.is_err()
+                                        || writer.flush().await.is_err()
+                                    {
+                                        log::debug!(
+                                            "safehouse: coordination write failed; reconnecting"
+                                        );
+                                        break true;
+                                    }
+                                }
+                                // A claim ad that would be rejected by safehoused
+                                // (bad type/task_id) is a bug, not a transport
+                                // failure — log and drop, do not reconnect.
+                                Err(e) => log::warn!(
+                                    "safehouse: refusing to send invalid claim ad ({e})"
+                                ),
+                            }
+                        }
+                        None => return, // all senders dropped → task done
+                    }
+                }
+            }
+        };
+        if reconnect {
+            tokio::time::sleep(backoff).await;
+            backoff = (backoff * 2).min(max_backoff);
+        }
+    }
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -585,7 +834,7 @@ mod tests {
     use crate::types::{SweepId, SweepKind};
     use serde_json::json;
     use serial_test::serial;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     use tokio::net::UnixListener;
 
     // ---- config resolution (config > default, no env) ----
@@ -1029,5 +1278,144 @@ mod tests {
 
         sink_done.await.unwrap();
         let _ = tokio::time::timeout(Duration::from_secs(2), sink).await;
+    }
+
+    // ---- peer-claim coordination (#4028) ----
+
+    #[test]
+    fn claim_ad_serializes_to_a_valid_task_envelope() {
+        // Envelope-validity AC: the advertisement must serialize to a `type`
+        // within KNOWN_TYPES and a `task_id` matching [A-Za-z0-9_], asserted
+        // against build_send_request so a rejected-by-safehoused envelope fails
+        // at test time, not runtime.
+        let ad = ClaimAd::advertise(4028, "loom".into(), "maple".into(), 7, "ts".into());
+        let env = claim_ad_to_envelope(&ad);
+        assert_eq!(env.kind, "task");
+        assert!(KNOWN_TYPES.contains(&env.kind.as_str()));
+        assert_eq!(env.task_id.as_deref(), Some("4028"));
+
+        let req = build_send_request(&env, 1, Some("fleet")).unwrap();
+        assert_eq!(req["type"], json!("task"));
+        assert_eq!(req["task_id"], json!("4028"));
+        // The body round-trips back to the same claim on the receive side.
+        let body = req["body"].as_str().unwrap();
+        assert_eq!(ClaimAd::from_body_str(body), Some(ad));
+    }
+
+    #[tokio::test]
+    async fn disabled_config_spawns_no_coordination_task() {
+        // Byte-for-byte no-op AC: safehouse.enabled=false ⇒ no coordination task
+        // and no socket.
+        let view = Arc::new(Mutex::new(PeerClaimView::new("me".into(), Duration::from_secs(1))));
+        let sink: Arc<dyn InboundEventSink> = Arc::new(PeerClaimSink::new(view));
+        let (_tx, rx) = tokio::sync::mpsc::channel::<ClaimAd>(1);
+        let handle = spawn_peer_coordination(
+            SafehouseConfig::default(), // disabled
+            sink,
+            rx,
+            &tokio::runtime::Handle::current(),
+        );
+        assert!(handle.is_none(), "disabled ⇒ no coordination task");
+    }
+
+    #[tokio::test]
+    async fn idle_daemon_still_reads_inbound_peer_ad() {
+        // The core regression Gap 1a exists to fix: a daemon that emits NOTHING
+        // must still observe an inbound peer advertisement. A read_reply-piggyback
+        // implementation only reads while sending, so it would never see this.
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("safehoused.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read_half, mut write_half) = stream.into_split();
+            let mut lines = BufReader::new(read_half).lines();
+            let hello: Value =
+                serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+            assert_eq!(hello["op"], json!("hello"));
+            write_half
+                .write_all(b"{\"ok\":true,\"id\":0}\n")
+                .await
+                .unwrap();
+            // Unprompted inbound room event carrying a peer claim — the client
+            // sends nothing.
+            let claim = ClaimAd::advertise(4028, "loom".into(), "peer".into(), 5, "ts".into());
+            let push =
+                json!({"event": "message", "from": "loom_daemon", "body": claim.to_body_json()});
+            write_half
+                .write_all(format!("{push}\n").as_bytes())
+                .await
+                .unwrap();
+            // Hold the connection open so the client can read the push.
+            tokio::time::sleep(Duration::from_millis(300)).await;
+        });
+
+        let view = Arc::new(Mutex::new(PeerClaimView::new("me".into(), Duration::from_secs(120))));
+        let sink: Arc<dyn InboundEventSink> = Arc::new(PeerClaimSink::new(view.clone()));
+        let (_tx, rx) = tokio::sync::mpsc::channel::<ClaimAd>(8); // held → task stays alive; never send (idle)
+
+        let task = tokio::spawn(run_coordination(
+            SafehouseConfig {
+                enabled: true,
+                socket: Some(socket.clone()),
+                ..SafehouseConfig::default()
+            },
+            socket.clone(),
+            sink,
+            rx,
+            Duration::from_millis(20),
+            Duration::from_millis(80),
+        ));
+
+        // Poll the view for the claim (bounded condition-poll, not a fixed
+        // ordering sleep).
+        let mut seen = false;
+        for _ in 0..50 {
+            if view
+                .lock()
+                .unwrap()
+                .is_claimed_at("loom", 4028, Instant::now())
+            {
+                seen = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(seen, "an idle daemon must still observe the inbound peer claim (Gap 1a)");
+        server.await.unwrap();
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn coordination_reconnects_when_socket_absent_and_exits_on_sender_drop() {
+        // Fail-open: an absent socket must never wedge — the task loops with
+        // backoff and exits cleanly once its senders drop.
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("nope.sock"); // never bound
+        let view = Arc::new(Mutex::new(PeerClaimView::new("me".into(), Duration::from_secs(1))));
+        let sink: Arc<dyn InboundEventSink> = Arc::new(PeerClaimSink::new(view));
+        let (tx, rx) = tokio::sync::mpsc::channel::<ClaimAd>(4);
+
+        let task = tokio::spawn(run_coordination(
+            SafehouseConfig {
+                enabled: true,
+                socket: Some(socket.clone()),
+                ..SafehouseConfig::default()
+            },
+            socket,
+            sink,
+            rx,
+            Duration::from_millis(10),
+            Duration::from_millis(30),
+        ));
+
+        // Drop the only sender: the connect-fail drain loop must observe
+        // Disconnected and return, so the task terminates rather than spinning.
+        drop(tx);
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("coordination task must terminate after its senders drop")
+            .unwrap();
     }
 }

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -52,6 +52,7 @@
 //! [`crate::claim_reconciliation`] for the startup consumer.
 
 use crate::event_bus::EventBus;
+use crate::peer_claims::{self, ClaimAd, PeerClaimView};
 use crate::sweep_journal;
 use crate::tokens_pool::bad_tokens;
 use crate::types::{Event, SweepId, SweepInfo, SweepKind, SweepOutcome, SweepState};
@@ -1353,6 +1354,19 @@ pub struct SweepRegistry {
     /// operators via the work-finder's per-tick summary line. Always `0` when
     /// `detect_collisions` is `false`. Monotonic for the life of the process.
     collision_count: u64,
+    /// Outbound peer-claim advertiser (Issue #4028). When present, [`dispatch`](Self::dispatch)
+    /// publishes an `advertise` ad **before** the (non-atomic) label flip and
+    /// [`emit_event`](Self::emit_event) publishes a `retract` ad on a terminal
+    /// sweep outcome, both over the shared safehouse room via a bounded
+    /// non-blocking `try_send`. `None` (the default) is a **byte-for-byte no-op**:
+    /// no channel, no ad, no syscalls — set only when `safehouse.enabled` is true.
+    peer_claim_publisher: Option<tokio::sync::mpsc::Sender<ClaimAd>>,
+    /// Inbound peer-claim view (Issue #4028), shared with the safehouse
+    /// coordination task that feeds it. When present, [`peer_claimed_issues`](Self::peer_claimed_issues)
+    /// returns the issues a peer host has advertised as in-flight (TTL-bounded),
+    /// which the work-finder skips. `None` (default) ⇒ the work-finder sees an
+    /// empty set (no behavior change).
+    peer_claims: Option<Arc<Mutex<PeerClaimView>>>,
 }
 
 /// Classification of a pre-flip label read (Issue #4085). Detection only — the
@@ -1372,11 +1386,16 @@ enum CollisionClass {
     Unknown,
 }
 
-/// Resolve this host's identity string for collision records (Issue #4085),
-/// precedence `LOOM_HOST_ID` env > `$HOSTNAME` env > the `hostname` binary >
-/// `"unknown-host"`. Only invoked when a collision is actually recorded (rare),
-/// so the one-shot `hostname` subprocess is not on the hot dispatch path.
-fn host_identity() -> String {
+/// Resolve this host's identity string for collision records (Issue #4085) and
+/// peer-claim advertisements (Issue #4028), precedence `LOOM_HOST_ID` env >
+/// `$HOSTNAME` env > the `hostname` binary > `"unknown-host"`. This is loom's
+/// single, explicit host-identity concept — derived (not a new config block) and
+/// stable across restarts (`$HOSTNAME` / the machine hostname do not change).
+/// safehoused stamps the socket `from` from the *persona* (all daemons share
+/// `loom_daemon`), which cannot distinguish hosts, so the claim payload carries
+/// this identity in its body for self-claim recognition.
+#[must_use]
+pub fn host_identity() -> String {
     for var in [HOST_ID_ENV, "HOSTNAME"] {
         if let Ok(v) = std::env::var(var) {
             let t = v.trim();
@@ -1424,6 +1443,8 @@ impl SweepRegistry {
             pending_quarantine_release: HashSet::new(),
             detect_collisions: false,
             collision_count: 0,
+            peer_claim_publisher: None,
+            peer_claims: None,
         }
     }
 
@@ -1451,6 +1472,8 @@ impl SweepRegistry {
             pending_quarantine_release: HashSet::new(),
             detect_collisions: false,
             collision_count: 0,
+            peer_claim_publisher: None,
+            peer_claims: None,
         }
     }
 
@@ -1523,6 +1546,70 @@ impl SweepRegistry {
     #[must_use]
     pub fn collision_count(&self) -> u64 {
         self.collision_count
+    }
+
+    /// Attach the outbound peer-claim advertiser (Issue #4028). The workspace
+    /// pool / `main.rs` call this once at provision time **only when
+    /// `safehouse.enabled`** — an unset publisher keeps dispatch byte-for-byte
+    /// unchanged.
+    pub fn set_peer_claim_publisher(&mut self, tx: tokio::sync::mpsc::Sender<ClaimAd>) {
+        self.peer_claim_publisher = Some(tx);
+    }
+
+    /// Attach the shared inbound peer-claim view (Issue #4028), fed by the
+    /// safehouse coordination task. Only set when `safehouse.enabled`.
+    pub fn set_peer_claims(&mut self, view: Arc<Mutex<PeerClaimView>>) {
+        self.peer_claims = Some(view);
+    }
+
+    /// The set of issues a **peer** host has advertised as in-flight and not yet
+    /// expired (Issue #4028) — the work-finder's peer-claim skip set. Empty when
+    /// no view is attached (`safehouse.enabled` false) or the mutex is poisoned
+    /// (fail-open: an unavailable view never blocks dispatch). Scoped to this
+    /// registry's repo via [`peer_claims::repo_slug`], so two managed repos'
+    /// issue #N never cross-suppress.
+    #[must_use]
+    pub fn peer_claimed_issues(&self) -> HashSet<u32> {
+        let Some(view) = &self.peer_claims else {
+            return HashSet::new();
+        };
+        let repo = peer_claims::repo_slug(&self.config.workspace_root);
+        match view.lock() {
+            Ok(v) => v.claimed_issues_at(&repo, Instant::now()),
+            Err(poisoned) => {
+                log::error!("sweep_registry: peer-claim view mutex poisoned ({poisoned:?})");
+                HashSet::new()
+            }
+        }
+    }
+
+    /// Publish a peer-claim advertisement/retraction over the safehouse room
+    /// (Issue #4028). Best-effort and **non-blocking** — a bounded `try_send` so
+    /// the dispatch path never waits on the coordination task, and a `Full`
+    /// (safehoused outage backlog) or `Closed` (task gone) channel is a
+    /// **fail-open** drop: logged once, dispatch proceeds. A no-op when no
+    /// publisher is attached (`safehouse.enabled` false).
+    fn publish_peer_claim(&self, kind: peer_claims::ClaimKind, issue: u32) {
+        let Some(tx) = &self.peer_claim_publisher else {
+            return;
+        };
+        let repo = peer_claims::repo_slug(&self.config.workspace_root);
+        let host = host_identity();
+        let pid = std::process::id();
+        let ts = Utc::now().to_rfc3339();
+        let ad = match kind {
+            peer_claims::ClaimKind::Advertise => ClaimAd::advertise(issue, repo, host, pid, ts),
+            peer_claims::ClaimKind::Retract => ClaimAd::retract(issue, repo, host, pid, ts),
+        };
+        if let Err(e) = tx.try_send(ad) {
+            // Fail-open: the soft claim is an optimization, never a liveness
+            // dependency. Debug (not warn) so a persistent safehoused outage
+            // does not spam the log once per dispatch.
+            log::debug!(
+                "sweep_registry: peer-claim advertisement for issue #{issue} dropped \
+                 ({e}); dispatch unaffected (#4028)"
+            );
+        }
     }
 
     /// The set of issue numbers currently quarantined for insta-crashing (Issue
@@ -1790,6 +1877,15 @@ impl SweepRegistry {
         let sweep_id = generate_sweep_id(kind);
         self.acquire_lock(issue_number, &sweep_id)?;
 
+        // 3a. Soft cross-host claim (Issue #4028): advertise this claim over the
+        //     shared safehouse room **before** the non-atomic label flip below,
+        //     so a peer daemon backs off far faster than the `loom:building`
+        //     label propagates. Best-effort, non-blocking, fail-open (a no-op
+        //     when `safehouse.enabled` is false) — the room broadcast is a soft
+        //     claim/fast backoff, NOT a mutex; the forge label remains the
+        //     human-visible claim signal and Phase 2 is the atomic authority.
+        self.publish_peer_claim(peer_claims::ClaimKind::Advertise, issue_number);
+
         // 4. Flip the forge label loom:issue -> loom:building (best-effort
         //    when the dispatcher has gh credentials; tests opt out via
         //    `skip_label_flip`).
@@ -1917,6 +2013,17 @@ impl SweepRegistry {
     /// repos' issue #N — the topic string is unchanged; `repo` lives in the
     /// payload only.
     fn emit_event(&self, mut event: Event) {
+        // Peer-claim early retraction (Issue #4028): a terminal outcome for one
+        // of THIS host's sweeps retracts its soft claim over the room so peers
+        // free the issue before its TTL would lapse. Centralized here so every
+        // Exited/Crashed emit site is covered by one insertion. Best-effort /
+        // non-blocking / fail-open (a no-op when no publisher is attached).
+        match &event {
+            Event::SweepExited { issue, .. } | Event::SweepCrashed { issue, .. } => {
+                self.publish_peer_claim(peer_claims::ClaimKind::Retract, *issue);
+            }
+            _ => {}
+        }
         event.set_repo_if_absent(&self.config.workspace_root.display().to_string());
         if let Some(ref bus) = self.bus {
             let topic = event.topic();
@@ -5419,6 +5526,52 @@ exit 0
             recorded.contains("--dangerously-skip-permissions"),
             "expected --dangerously-skip-permissions in argv; got: {recorded}"
         );
+    }
+
+    /// Issue #4028 fail-open: an unreachable safehouse coordination channel (its
+    /// receiver dropped ⇒ `try_send` returns `Closed`) must NEVER block or fail a
+    /// dispatch — the soft claim is an optimization, never a liveness dependency.
+    /// This is the single most important #4028 test.
+    #[test]
+    fn dispatch_proceeds_when_peer_claim_channel_is_closed_fail_open() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        // Attach a publisher whose receiver is immediately dropped, so every
+        // `try_send` fails — modeling an absent/refusing safehoused.
+        let (tx, rx) = tokio::sync::mpsc::channel::<ClaimAd>(1);
+        drop(rx);
+        registry.set_peer_claim_publisher(tx);
+
+        let outcome = registry
+            .dispatch(&SweepKind::Issue(77), None, None, None, None)
+            .expect("dispatch must proceed even when the safehouse channel is closed");
+        assert!(outcome.was_new, "the sweep still starts");
+        assert_eq!(registry.len(), 1);
+    }
+
+    /// Issue #4028: the work-finder's peer-claim skip set reflects the attached
+    /// shared view, scoped to this registry's repo, and is empty when no view is
+    /// attached (byte-for-byte no-op).
+    #[test]
+    fn peer_claimed_issues_reflects_the_attached_view() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        // No view attached ⇒ empty (the no-op default).
+        assert!(registry.peer_claimed_issues().is_empty());
+
+        let repo = peer_claims::repo_slug(&registry.config().workspace_root);
+        let view =
+            Arc::new(Mutex::new(PeerClaimView::new("self".into(), Duration::from_secs(120))));
+        {
+            let mut v = view.lock().unwrap();
+            let now = Instant::now();
+            v.observe_at(
+                &ClaimAd::advertise(500, repo.clone(), "peer".into(), 1, "ts".into()),
+                now,
+            );
+        }
+        registry.set_peer_claims(view);
+        assert!(registry.peer_claimed_issues().contains(&500));
     }
 
     /// Issue #3953: `dispatch` persists a liveness record to the sweep

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -337,6 +337,18 @@ pub trait WorkDispatcher {
         0
     }
 
+    /// The set of issue numbers a **peer host** has advertised as in-flight over
+    /// the shared safehouse room and not yet expired (Issue #4028, Phase 1 soft
+    /// claim). The finder skips these — treating a peer's soft claim as an
+    /// additional TTL-bounded skip reason alongside [`SKIP_LABELS`] — so two
+    /// daemons on a shared backlog collide far less than the non-atomic forge
+    /// label flip alone permits. Defaults to empty so a dispatcher that does not
+    /// model peer claims (a test fake, or a registry with `safehouse.enabled`
+    /// false) opts out with zero boilerplate and **zero behavior change**.
+    fn peer_claimed(&self) -> HashSet<u32> {
+        HashSet::new()
+    }
+
     /// Dispatch a build sweep for `issue`. Returns `true` when a **new** sweep
     /// was started, `false` when the dispatch was an idempotency no-op (a sweep
     /// with the same key was already running).
@@ -398,6 +410,14 @@ pub struct TickReport {
     /// with the parent sweep, so without this guard an issue whose approved PR is
     /// still open would be re-dispatched the moment its sweep exits.
     pub skipped_pr_open: usize,
+    /// Issues skipped because a **peer host** advertised a live soft claim over
+    /// the safehouse room (Issue #4028, Phase 1). Counted under its **own**
+    /// distinct reason — never folded into [`collisions`](Self::collisions)
+    /// (#4085's post-hoc collision *count*) or the label/in-flight skips — so an
+    /// operator can see how many dispatches the soft claim actively prevented,
+    /// separate from the collisions it did not. Always `0` when
+    /// `safehouse.enabled` is false (the dispatcher's `peer_claimed()` is empty).
+    pub skipped_peer_claim: usize,
     /// Dispatch attempts that returned an error (logged, non-fatal).
     pub errors: usize,
     /// Cumulative cross-host dispatch collisions observed (Issue #4085, Phase 0
@@ -463,6 +483,7 @@ pub fn tick(
 
     let in_flight = dispatcher.in_flight();
     let quarantined = dispatcher.quarantined();
+    let peer_claimed = dispatcher.peer_claimed();
     // Occupancy (Issue #4003) is a distinct, possibly-smaller count than
     // `in_flight.len()`: a dispatcher may discount a spawned-but-unproven
     // sweep past its startup-proof grace window. `in_flight` itself stays the
@@ -485,6 +506,18 @@ pub fn tick(
         //     capacity gate so a quarantined issue never consumes a slot.
         if quarantined.contains(&item.number) {
             report.skipped_quarantined += 1;
+            continue;
+        }
+        // 2c. Peer soft claim (#4028): a peer host advertised a live claim over
+        //     the safehouse room. Back off — treated like a skip label, before
+        //     the capacity gate so a peer-claimed issue never reserves a slot.
+        if peer_claimed.contains(&item.number) {
+            report.skipped_peer_claim += 1;
+            log::info!(
+                "work_finder: skipping issue #{} — a peer host advertised a soft claim \
+                 over safehouse (#4028)",
+                item.number
+            );
             continue;
         }
         // 3. Fixed concurrency cap — defer the rest to a future tick.
@@ -663,6 +696,13 @@ pub fn tick_multi<S: WorkSource, D: WorkDispatcher>(
     let quarantined_sets: Vec<HashSet<u32>> =
         workspaces.iter().map(|(_, d)| d.quarantined()).collect();
 
+    // Snapshot each workspace's peer-claim set (#4028) alongside its quarantined
+    // set. A peer's live soft claim drops the candidate in pass 1, before the
+    // global sort and slot fill, so a peer-claimed issue never reserves a shared
+    // dispatch slot.
+    let peer_claimed_sets: Vec<HashSet<u32>> =
+        workspaces.iter().map(|(_, d)| d.peer_claimed()).collect();
+
     // Whether any workspace was gated this tick, derived **directly from the
     // shared per-repo halt flags** rather than accumulated as a side effect of
     // the candidate-gathering loop (#3974 AC3).
@@ -723,6 +763,17 @@ pub fn tick_multi<S: WorkSource, D: WorkDispatcher>(
             // enters the global queue, so it consumes no shared slot.
             if quarantined_sets[idx].contains(&item.number) {
                 report.skipped_quarantined += 1;
+                continue;
+            }
+            // Peer soft claim (#4028): a peer host is already building it — drop
+            // before the global queue so it consumes no shared slot.
+            if peer_claimed_sets[idx].contains(&item.number) {
+                report.skipped_peer_claim += 1;
+                log::info!(
+                    "work_finder: skipping issue #{} — a peer host advertised a soft claim \
+                     over safehouse (#4028)",
+                    item.number
+                );
                 continue;
             }
             candidates.push(PriorityCandidate {
@@ -1186,20 +1237,22 @@ where
                         || report.errors > 0
                         || report.skipped_quarantined > 0
                         || report.skipped_pr_open > 0
+                        || report.skipped_peer_claim > 0
                     {
                         log::info!(
                             "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
                              healthy={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
                              cpu={cpu}, ceiling={configured_max}); \
                              {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, \
-                             {} quarantine-skip, {} pr-open-skip, {} deferred, {} error(s), \
-                             {} cross-host-collision(s)",
+                             {} quarantine-skip, {} pr-open-skip, {} peer-claim-skip, \
+                             {} deferred, {} error(s), {} cross-host-collision(s)",
                             report.seen,
                             report.dispatched,
                             report.skipped_labeled,
                             report.skipped_in_flight,
                             report.skipped_quarantined,
                             report.skipped_pr_open,
+                            report.skipped_peer_claim,
                             report.deferred_capacity,
                             report.errors,
                             report.collisions
@@ -1391,14 +1444,15 @@ pub fn spawn_multi_work_finder_task(
                 || report.errors > 0
                 || report.skipped_quarantined > 0
                 || report.skipped_pr_open > 0
+                || report.skipped_peer_claim > 0
             {
                 log::info!(
                     "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
                      healthy={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
                      cpu={cpu}, ceiling={configured_max}); {} workspace(s), \
                      {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, \
-                     {} quarantine-skip, {} pr-open-skip, {} deferred, {} error(s), \
-                     {} cross-host-collision(s)",
+                     {} quarantine-skip, {} pr-open-skip, {} peer-claim-skip, \
+                     {} deferred, {} error(s), {} cross-host-collision(s)",
                     pairs.len(),
                     report.seen,
                     report.dispatched,
@@ -1406,6 +1460,7 @@ pub fn spawn_multi_work_finder_task(
                     report.skipped_in_flight,
                     report.skipped_quarantined,
                     report.skipped_pr_open,
+                    report.skipped_peer_claim,
                     report.deferred_capacity,
                     report.errors,
                     report.collisions
@@ -1693,6 +1748,16 @@ pub mod forge {
             }
         }
 
+        fn peer_claimed(&self) -> HashSet<u32> {
+            match self.registry.lock() {
+                Ok(reg) => reg.peer_claimed_issues(),
+                Err(poisoned) => {
+                    log::error!("work_finder: sweep registry mutex poisoned ({poisoned:?})");
+                    HashSet::new()
+                }
+            }
+        }
+
         fn dispatch(&mut self, issue: u32) -> Result<bool> {
             let mut reg = self
                 .registry
@@ -1770,6 +1835,8 @@ mod tests {
         quarantined: HashSet<u32>,
         /// Cumulative cross-host collision count this dispatcher reports (#4085).
         collisions: u64,
+        /// Issue numbers a peer host has soft-claimed over safehouse (#4028).
+        peer_claimed: HashSet<u32>,
     }
 
     impl WorkDispatcher for RecordingDispatcher {
@@ -1781,6 +1848,9 @@ mod tests {
         }
         fn collisions(&self) -> u64 {
             self.collisions
+        }
+        fn peer_claimed(&self) -> HashSet<u32> {
+            self.peer_claimed.clone()
         }
         fn dispatch(&mut self, issue: u32) -> Result<bool> {
             if self.pr_open_issues.contains(&issue) {
@@ -2027,6 +2097,39 @@ exit 0
         assert_eq!(report.dispatched, 1);
         assert!(multi[0].1.dispatched.is_empty(), "quarantined workspace dispatches nothing");
         assert_eq!(multi[1].1.dispatched, vec![10], "healthy sibling gets the shared slot");
+    }
+
+    #[test]
+    fn test_tick_peer_claim_skipped_under_distinct_counter() {
+        // A peer host's live soft claim (#4028) skips the issue under its OWN
+        // distinct counter — never folded into labeled/in-flight/quarantine — and
+        // does not consume a capacity slot (checked before the cap gate), so the
+        // healthy sibling issue takes the slot.
+        let mut source = FakeSource::once(vec![issue(1), issue(2)]);
+        let mut disp = RecordingDispatcher {
+            peer_claimed: HashSet::from([1]),
+            ..Default::default()
+        };
+        let report = tick(&mut source, &mut disp, 1, false).unwrap();
+
+        assert_eq!(report.skipped_peer_claim, 1, "#1 is peer-claimed");
+        assert_eq!(report.skipped_labeled, 0, "peer-claim is NOT a label skip");
+        assert_eq!(report.skipped_in_flight, 0, "peer-claim is NOT an in-flight skip");
+        assert_eq!(report.dispatched, 1);
+        assert_eq!(disp.dispatched, vec![2], "the slot goes to the un-claimed #2");
+    }
+
+    #[test]
+    fn test_tick_stops_skipping_once_peer_claim_clears() {
+        // Once the peer claim lapses (empty peer_claimed set, mirroring a TTL
+        // expiry / retraction), the previously-skipped issue dispatches normally.
+        let mut source = FakeSource::once(vec![issue(1)]);
+        let mut disp = RecordingDispatcher::default(); // no peer claims now
+        let report = tick(&mut source, &mut disp, 5, false).unwrap();
+
+        assert_eq!(report.skipped_peer_claim, 0);
+        assert_eq!(report.dispatched, 1);
+        assert_eq!(disp.dispatched, vec![1]);
     }
 
     #[test]

--- a/loom-daemon/src/workspace_pool.rs
+++ b/loom-daemon/src/workspace_pool.rs
@@ -53,7 +53,26 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use crate::event_bus::EventBus;
-use crate::sweep_registry::{self, SweepRegistry, SweepRegistryConfig};
+use crate::peer_claims::{self, ClaimAd, PeerClaimView};
+use crate::safehouse::{self, InboundEventSink, PeerClaimSink};
+use crate::sweep_registry::{self, host_identity, SweepRegistry, SweepRegistryConfig};
+
+/// The daemon-wide safehouse peer-claim coordination context (Issue #4028): one
+/// shared inbound view + one outbound publisher + the single coordination task
+/// that bridges them to the room. Created lazily by
+/// [`WorkspacePool::start_peer_coordination`] when `safehouse.enabled` is true;
+/// every provisioned registry gets clones of the publisher + view so a soft
+/// claim advertised by any repo's dispatch reaches the room and every repo's
+/// work-finder sees peer claims. `None` ⇒ byte-for-byte no-op.
+struct PeerCoordination {
+    /// Bounded, non-blocking outbound channel to the coordination task.
+    publisher: tokio::sync::mpsc::Sender<ClaimAd>,
+    /// The shared inbound view the coordination task feeds and every
+    /// dispatcher queries.
+    view: Arc<Mutex<PeerClaimView>>,
+    /// The coordination task handle, kept alive for the daemon's lifetime.
+    _task: Option<tokio::task::JoinHandle<()>>,
+}
 
 /// One cached per-workspace registry plus the background tasks keeping it
 /// reconciled and self-healing.
@@ -82,6 +101,11 @@ pub struct WorkspacePool {
     /// dedicated OS thread.
     runtime: tokio::runtime::Handle,
     inner: Mutex<HashMap<PathBuf, PooledRegistry>>,
+    /// The daemon-wide safehouse peer-claim coordination context (Issue #4028),
+    /// or `None` when `safehouse.enabled` is false. Set once by
+    /// [`start_peer_coordination`](Self::start_peer_coordination); injected into
+    /// every registry [`get_or_provision`](Self::get_or_provision) builds.
+    peer_coord: Mutex<Option<PeerCoordination>>,
 }
 
 impl WorkspacePool {
@@ -93,6 +117,7 @@ impl WorkspacePool {
             event_bus,
             runtime,
             inner: Mutex::new(HashMap::new()),
+            peer_coord: Mutex::new(None),
         }
     }
 
@@ -108,6 +133,67 @@ impl WorkspacePool {
     pub fn start_safehouse_narration(&self, repo_root: &Path) {
         let config = crate::safehouse::resolve_config(repo_root);
         let _ = crate::safehouse::spawn_sink(config, &self.event_bus, &self.runtime);
+    }
+
+    /// Start the daemon-wide safehouse **peer-claim coordination** (Issue #4028)
+    /// keyed off `repo_root`'s config. Creates the shared inbound
+    /// [`PeerClaimView`], the bounded outbound advertiser channel, and the single
+    /// coordination task that bridges them to the room, then stores them so every
+    /// registry [`get_or_provision`](Self::get_or_provision) builds — and the
+    /// seeded default registry via [`inject_peer_coordination`](Self::inject_peer_coordination)
+    /// — advertises and consumes soft claims.
+    ///
+    /// **Byte-for-byte no-op** when `safehouse.enabled` is false/absent: no view,
+    /// no channel, no task, no socket. Idempotent — a second call is a no-op once
+    /// coordination is established.
+    pub fn start_peer_coordination(&self, repo_root: &Path) {
+        let config = safehouse::resolve_config(repo_root);
+        if !config.enabled {
+            return; // disabled ⇒ no coordination, byte-for-byte no-op
+        }
+        let mut slot = self
+            .peer_coord
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if slot.is_some() {
+            return; // already established
+        }
+        let ttl = peer_claims::resolve_peer_claim_ttl(repo_root);
+        let view = Arc::new(Mutex::new(PeerClaimView::new(host_identity(), ttl)));
+        let (tx, rx) = tokio::sync::mpsc::channel::<ClaimAd>(safehouse::PEER_CLAIM_CHANNEL_CAP);
+        let sink: Arc<dyn InboundEventSink> = Arc::new(PeerClaimSink::new(view.clone()));
+        let task = safehouse::spawn_peer_coordination(config, sink, rx, &self.runtime);
+        if task.is_none() {
+            // Enabled but no socket resolved: leave coordination unestablished so
+            // registries stay in the no-op path (the outbound sender would have
+            // no consumer). spawn_peer_coordination already logged the reason.
+            return;
+        }
+        log::info!(
+            "workspace_pool: safehouse peer-claim coordination started (ttl={}s)",
+            ttl.as_secs()
+        );
+        *slot = Some(PeerCoordination {
+            publisher: tx,
+            view,
+            _task: task,
+        });
+    }
+
+    /// Inject the peer-claim publisher + view into `registry` when coordination
+    /// is established (Issue #4028). A no-op when `safehouse.enabled` is false, so
+    /// a registry with no coordination behaves byte-for-byte as before. Called by
+    /// [`get_or_provision`](Self::get_or_provision) and by `main.rs` for the
+    /// seeded default registry.
+    pub fn inject_peer_coordination(&self, registry: &mut SweepRegistry) {
+        let slot = self
+            .peer_coord
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(coord) = slot.as_ref() {
+            registry.set_peer_claim_publisher(coord.publisher.clone());
+            registry.set_peer_claims(coord.view.clone());
+        }
     }
 
     /// Seed the pool with a pre-built registry for `root` — used for the default
@@ -171,6 +257,9 @@ impl WorkspacePool {
         // default(off) so a shared-backlog deployment measures the baseline
         // duplicate-dispatch rate. Detection only — never changes dispatch.
         registry.set_collision_detection(sweep_registry::resolve_collision_detection(root));
+        // Cross-host soft claim (#4028): attach the shared peer-claim publisher +
+        // view when safehouse coordination is established. A no-op otherwise.
+        self.inject_peer_coordination(&mut registry);
 
         let arc = Arc::new(Mutex::new(registry));
         // Spawn the reaper and watchdog on the shared daemon runtime


### PR DESCRIPTION
Closes #4028

## What this does

Phase 1 of #4028: each daemon **advertises** a work-in-progress soft claim into
the shared safehouse room the moment it decides to dispatch, and **consumes**
peer advertisements so a peer daemon backs off before the non-atomic
`loom:issue → loom:building` label flip would otherwise let it race. This shrinks
the cross-host collision window; it is a **soft claim / fast backoff, NOT a
mutex**. Phase 2 (an atomic cross-host claim authority) is explicitly out of
scope and should be filed separately.

## Design (addresses the two curator-identified gaps)

- **Gap 1a — dedicated inbound read task.** A new coordination task on its *own*
  safehouse connection drains the socket continuously via `select!`, so an
  **idle** daemon that emits no narration still observes peer claims promptly. It
  is NOT piggybacked on `read_reply` (which only reads while emitting). Inbound
  events route through a generic `InboundEventSink` (kept generic so future
  inbound human-steering can reuse the same read task).
- **Gap 2 — no fifth envelope type.** Claim ads ride a **`task`** envelope (the
  `type` enum is closed and owned by the safehouse repo) with the bare issue
  number as `task_id` and a structured `loom_claim`-marked JSON `body`.

New pure module `loom-daemon/src/peer_claims.rs` (socket-free, unit-testable):
`PeerClaimView` with TTL expiry, self-claim recognition, retraction, and
`ClaimAd` parse/serialize — mirroring the `decide`/`plan` split in
`claim_reconciliation.rs`.

## Acceptance criteria — all implemented

- [x] Inbound consumption via a **dedicated** read task (Gap 1a), not `read_reply`.
- [x] Advertisement `type` is `task` (Gap 2); carries issue, repo, host, PID, ts.
- [x] Gating on `safehouse::resolve_config(repo_root).enabled` (not block presence).
- [x] `safehouse.enabled` false/absent ⇒ byte-for-byte no-op (no view, channel, task, socket).
- [x] Advertise at the dispatch decision point, **before** the label flip.
- [x] Peer-claim view + TTL; skip in `tick`/`tick_multi` under its **own** distinct
      `peer-claim-skip` counter (never folded into #4085's collision count), on the summary line.
- [x] TTL expiry (default **120s** = 2× the 60s work-finder tick), measured against
      **local receipt** not the advertiser's clock; peer `exited`/`crashed` retracts early.
- [x] Fail-open: unreachable socket / malformed envelope / full channel → logged once, dispatch proceeds.
- [x] Advertisement is best-effort/non-blocking (bounded `try_send` off the dispatch path).
- [x] Self-claim recognition — a daemon never backs off on its own ad (host-identity match).
- [x] Explicit host identity: `host_identity()` (`LOOM_HOST_ID` > `$HOSTNAME` > `hostname`),
      derived, restart-stable; carried in the body since safehoused's `from` is persona-scoped.
- [x] No new bus topic — claims travel entirely over the safehouse room.
- [x] Docs: `.loom/docs/safehouse.md` (fixed the emit-only statements + new section) and
      `defaults/docs/daemon-reference.md` (new section) — TTL, fail-open, envelope type, soft-claim caveat.

## Phase-0 (#4085) collision counters — NOT measured (stated explicitly per the AC)

I **could not** capture a real before/after collision delta: this is a single-host
environment with no second daemon and no genuinely shared multi-host backlog, so
there is no cross-host race to observe and `#4085`'s `collisions` counter stays 0
regardless of this change. Per the issue's non-negotiable, I am stating this
rather than claiming an unmeasured win. The soft-claim mechanism is instead
validated by the deterministic unit/integration tests below (two-registries /
one-room, idle-daemon read, TTL, self-recognition, fail-open). A real two-host
measurement remains an operator follow-up.

## Tests (all pure/deterministic — no sleeps for ordering, per #4044)

- `peer_claims`: TTL expiry (local-clock), self-claim recognition, retraction (+ host scoping),
  malformed-envelope rejection, JSON round-trip, repo scoping, and the **two-hosts/one-issue**
  integration shape (exactly one proceeds) via injected ordering.
- `safehouse`: **idle-daemon still reads an inbound peer ad** (the Gap 1a regression guard —
  fails against a `read_reply`-piggyback impl), envelope-validity against `build_send_request`,
  disabled no-op (no task/socket), fail-open reconnect + clean exit on sender drop.
- `work_finder`: `tick` skips a peer-claimed issue under the distinct counter and stops once
  it clears; slot not consumed.
- `sweep_registry`: **dispatch proceeds when the safehouse channel is closed (fail-open)** — the
  single most important test — and the peer-claim skip set reflects the attached view.

`cd loom-daemon && cargo test --lib` → **1346 passed; 0 failed**. `cargo clippy --all-targets`
clean, `cargo build` clean.

### Note on `tests/integration_basic.rs`

The 9 `integration_basic` tests fail on this host with "Daemon failed to create
socket within 5s" — a **pre-existing, environmental** flake, not caused by this
change. The harness spawns the debug daemon and fails if its IPC socket (bound
last, at `main.rs` ~:1250, after gh-calling startup reconciliation) is not up
within 5s. Verified directly: the **baseline `main` binary** takes **8.9s** to
bind the socket under current host load vs this branch's **7.7s** — so the
timeout is exceeded on both, and this branch is marginally faster (my
peer-coordination insertion is a no-op when safehouse is disabled). The affected
code paths (terminal IPC / socket creation) are untouched by this PR.

## Files
`loom-daemon/src/peer_claims.rs` (new), `safehouse.rs`, `sweep_registry.rs`,
`work_finder.rs`, `workspace_pool.rs`, `main.rs`, `lib.rs`; `defaults/config.json`
(`peerClaimTtlSecs`); `.loom/docs/safehouse.md`; `defaults/docs/daemon-reference.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
