### PR TITLE
feat(runtime): claude capability manifest + role runtimeRequirements + check script

### DIFF
--- a/defaults/docs/runtime-adapters.md
+++ b/defaults/docs/runtime-adapters.md
@@ -262,6 +262,28 @@ compatibility and refuses to dispatch a role onto a runtime that cannot meet its
 requirements, rather than letting the session fail partway. The declaration is
 per-runtime; the requirements are per-role; the match happens at dispatch time.
 
+**Landed today (#4170):** the declaration and requirement sides of this contract
+exist as data + a standalone checker, ahead of dispatch wiring:
+
+- **Declaration** — `defaults/runtimes/<name>.json` (e.g.
+  `defaults/runtimes/claude.json`), matching the sketch above exactly (tri-state
+  `"yes" | "no" | "partial"` string values, capability set `mcp`, `subagents`,
+  `hooks`, `skills`, `worktreeIsolation`).
+- **Requirements** — an optional `"runtimeRequirements"` array on a role sidecar
+  (`defaults/roles/<name>.json`), e.g. `"runtimeRequirements": ["worktreeIsolation",
+  "mcp"]` on `builder.json`. A role with no `runtimeRequirements` key has no
+  constraints (any runtime is compatible). This is a distinct field from the
+  pre-existing `suggestedWorkerType` (a dispatch *preference* hint) — the checker
+  reads only `runtimeRequirements`.
+- **Matcher** — `defaults/scripts/check-runtime-capabilities.sh --role <name>
+  --runtime <name>` loads both files and checks requirements ⊆ capabilities,
+  where a requirement is satisfied only by a declared `"yes"` (`"partial"` fails
+  closed). Exit 0 on match or no-requirements, exit 78 (`EX_CONFIG`) on mismatch
+  naming each unmet capability, non-zero with a distinct message on an
+  unknown/missing role or runtime file. It is intentionally **standalone** —
+  not yet wired into `spawn-worker.sh` or any dispatch path; that wiring is a
+  follow-up decision.
+
 ## Phase 1: the `spawn-worker.sh` runtime-dispatch seam
 
 Contract point 1 ([Spawn](#1-spawn)) is realized today by a concrete

--- a/defaults/roles/builder.json
+++ b/defaults/roles/builder.json
@@ -6,6 +6,7 @@
   "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Development Worker who implements `loom:issue` issues (human-approved work). Priority system: (1) Check `gh issue list --label=\"loom:issue\" --label=\"loom:urgent\"` for critical issues. (2) If none urgent, check `gh issue list --label=\"loom:issue\"` (oldest first, FIFO) and claim new work. After creating a PR with `loom:review-requested`, move on to the next issue - the Doctor agent will handle any review feedback. You can work on multiple issues concurrently using worktrees.",
   "autonomousRecommended": false,
   "suggestedWorkerType": "claude",
+  "runtimeRequirements": ["worktreeIsolation", "mcp"],
   "gitIdentity": {
     "name": "Loom Worker",
     "email": "loom-worker@users.noreply.github.com"

--- a/defaults/roles/judge.json
+++ b/defaults/roles/judge.json
@@ -6,6 +6,7 @@
   "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Code Review Specialist. Check `gh pr list --label=\"loom:review-requested\"` for PRs needing review. Process ALL PRs in the queue before exiting \u2014 evaluate each PR, post feedback with `gh pr comment`, and update labels (approve: add `loom:pr`, remove `loom:review-requested`; or add `loom:changes-requested`, remove `loom:review-requested`). Do NOT use `gh pr review --approve` (fails with self-review restriction). Do NOT call /clear between PRs \u2014 only clear after draining the full queue.",
   "autonomousRecommended": true,
   "suggestedWorkerType": "codex",
+  "runtimeRequirements": ["mcp"],
   "gitIdentity": {
     "name": "Loom Reviewer",
     "email": "loom-reviewer@users.noreply.github.com"

--- a/defaults/runtimes/claude.json
+++ b/defaults/runtimes/claude.json
@@ -1,0 +1,10 @@
+{
+  "runtime": "claude",
+  "capabilities": {
+    "mcp": "yes",
+    "subagents": "yes",
+    "hooks": "yes",
+    "skills": "yes",
+    "worktreeIsolation": "yes"
+  }
+}

--- a/defaults/scripts/check-runtime-capabilities.sh
+++ b/defaults/scripts/check-runtime-capabilities.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# check-runtime-capabilities.sh — Match a role's runtimeRequirements against a
+# runtime's capability manifest (epic #4167, design pillar 2; issue #4170).
+#
+# This is a STANDALONE checker. It is deliberately NOT wired into
+# spawn-worker.sh or any dispatch path -- enforcement is a follow-up decision
+# (see defaults/docs/runtime-adapters.md §7 "Capability declaration"). It also
+# does NOT read `.loom/config.json`'s `runtimes` block itself; the caller
+# resolves the runtime name and passes it via `--runtime`.
+#
+# Schema (tri-state capability values -- yes | no | partial):
+#
+#   Runtime manifest (defaults/runtimes/<name>.json):
+#     { "runtime": "claude", "capabilities": { "mcp": "yes", ... } }
+#
+#   Role sidecar (defaults/roles/<name>.json), optional key:
+#     { ..., "runtimeRequirements": ["worktreeIsolation", "mcp"] }
+#
+# A requirement is satisfied only when the runtime declares that capability
+# as exactly "yes". A declared "partial" fails closed (the mismatch message
+# names the capability and its declared value, same as "no" / missing).
+#
+# Exit codes:
+#   0  - all requirements satisfied (including the no-requirements case)
+#   78 - EX_CONFIG: one or more requirements unmet (capability mismatch)
+#   1  - unknown/missing role or runtime file, or other usage error (a
+#        message DISTINCT from the mismatch message, so callers/tests can
+#        tell "misconfigured" apart from "mismatched")
+#
+# Usage:
+#   check-runtime-capabilities.sh --role <name> --runtime <name>
+#   check-runtime-capabilities.sh --role <name> --runtime <name> \
+#       [--role-file <path>] [--runtime-file <path>] [--dir <defaults-root>]
+#
+# Resolution (when --role-file / --runtime-file are not given):
+#   <dir>/roles/<role>.json      (default <dir>: repo .loom/ falling back to
+#   <dir>/runtimes/<runtime>.json defaults/, see resolve_dir() below)
+
+set -euo pipefail
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[check-runtime-capabilities]${NC} $*" >&2; }
+log_warn() { echo -e "${YELLOW}[check-runtime-capabilities] WARN${NC} $*" >&2; }
+log_error() { echo -e "${RED}[check-runtime-capabilities] ERROR${NC} $*" >&2; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+    cat <<'EOF'
+Usage: check-runtime-capabilities.sh --role <name> --runtime <name> [options]
+
+Required:
+  --role <name>          Role name (sidecar file <dir>/roles/<name>.json)
+  --runtime <name>       Runtime name (manifest <dir>/runtimes/<name>.json)
+
+Options:
+  --role-file <path>     Explicit path to the role sidecar JSON (overrides
+                          role-name resolution)
+  --runtime-file <path>  Explicit path to the runtime manifest JSON (overrides
+                          runtime-name resolution)
+  --dir <path>           Root directory containing roles/ and runtimes/
+                          subdirectories (default: repo .loom/, falling back
+                          to defaults/ next to this script)
+  -h, --help             Show this help
+
+Exit codes:
+  0   All requirements satisfied (or role declares no runtimeRequirements)
+  78  Capability mismatch (EX_CONFIG) -- requirement not met
+  1   Usage error, or unknown/missing role or runtime file
+EOF
+}
+
+ROLE=""
+RUNTIME=""
+ROLE_FILE=""
+RUNTIME_FILE=""
+DIR_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --role)
+            ROLE="${2:-}"
+            shift 2
+            ;;
+        --runtime)
+            RUNTIME="${2:-}"
+            shift 2
+            ;;
+        --role-file)
+            ROLE_FILE="${2:-}"
+            shift 2
+            ;;
+        --runtime-file)
+            RUNTIME_FILE="${2:-}"
+            shift 2
+            ;;
+        --dir)
+            DIR_OVERRIDE="${2:-}"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            log_error "Unknown argument: $1"
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$ROLE" || -z "$RUNTIME" ]]; then
+    log_error "Both --role and --runtime are required."
+    usage >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    log_error "jq is required but not found on PATH."
+    exit 1
+fi
+
+# --- Resolve the roles/runtimes root directory ---
+# Precedence: --dir override > repo .loom/ (if present) > defaults/ next to
+# this script (so the check works standalone in this repo before install).
+resolve_dir() {
+    if [[ -n "$DIR_OVERRIDE" ]]; then
+        printf '%s\n' "$DIR_OVERRIDE"
+        return
+    fi
+
+    local git_common_dir repo_root
+    if git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null)"; then
+        if [[ ! "$git_common_dir" = /* ]]; then
+            git_common_dir="$(cd "$git_common_dir" && pwd)"
+        fi
+        repo_root="$(dirname "$git_common_dir")"
+        if [[ -d "$repo_root/.loom/roles" && -d "$repo_root/.loom/runtimes" ]]; then
+            printf '%s\n' "$repo_root/.loom"
+            return
+        fi
+    fi
+
+    # Fallback: defaults/ next to this script (defaults/scripts -> defaults/).
+    printf '%s\n' "$(cd "$SCRIPT_DIR/.." && pwd)"
+}
+
+BASE_DIR="$(resolve_dir)"
+
+if [[ -z "$ROLE_FILE" ]]; then
+    ROLE_FILE="$BASE_DIR/roles/$ROLE.json"
+fi
+if [[ -z "$RUNTIME_FILE" ]]; then
+    RUNTIME_FILE="$BASE_DIR/runtimes/$RUNTIME.json"
+fi
+
+# --- Load + validate files (distinct exit path from mismatch) ---
+if [[ ! -f "$ROLE_FILE" ]]; then
+    log_error "Unknown role: no sidecar file found at '$ROLE_FILE'."
+    exit 1
+fi
+if ! jq -e . "$ROLE_FILE" >/dev/null 2>&1; then
+    log_error "Role sidecar '$ROLE_FILE' is not valid JSON."
+    exit 1
+fi
+
+if [[ ! -f "$RUNTIME_FILE" ]]; then
+    log_error "Unknown runtime: no manifest file found at '$RUNTIME_FILE'."
+    exit 1
+fi
+if ! jq -e . "$RUNTIME_FILE" >/dev/null 2>&1; then
+    log_error "Runtime manifest '$RUNTIME_FILE' is not valid JSON."
+    exit 1
+fi
+
+# --- No requirements declared -> trivially satisfied ---
+has_requirements="$(jq -r 'has("runtimeRequirements")' "$ROLE_FILE")"
+if [[ "$has_requirements" != "true" ]]; then
+    log_info "Role '$ROLE' declares no runtimeRequirements -- any runtime is compatible."
+    exit 0
+fi
+
+# --- Compute mismatches: required capability not declared exactly "yes" ---
+mismatches=""
+while IFS= read -r cap; do
+    [[ -z "$cap" ]] && continue
+    value="$(jq -r --arg cap "$cap" '.capabilities[$cap] // "no"' "$RUNTIME_FILE")"
+    if [[ "$value" != "yes" ]]; then
+        mismatches+="  - $cap: runtime '$RUNTIME' declares '$value' (requires 'yes')"$'\n'
+    fi
+done < <(jq -r '.runtimeRequirements[]?' "$ROLE_FILE")
+
+if [[ -n "$mismatches" ]]; then
+    log_error "Role '$ROLE' is not compatible with runtime '$RUNTIME':"
+    printf '%s' "$mismatches" >&2
+    exit 78
+fi
+
+log_info "Role '$ROLE' is compatible with runtime '$RUNTIME' (all requirements met)."
+exit 0

--- a/defaults/scripts/tests/test-check-runtime-capabilities.sh
+++ b/defaults/scripts/tests/test-check-runtime-capabilities.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# test-check-runtime-capabilities.sh — Tests for
+# defaults/scripts/check-runtime-capabilities.sh (#4170, epic #4167).
+#
+# Covers:
+#   1. Match: a role's runtimeRequirements are all declared "yes" by the
+#      runtime manifest -> exit 0.
+#   2. Mismatch: a required capability is declared "no" or "partial" (or is
+#      simply absent) -> exit 78, message names EACH missing/partial
+#      capability and its declared value ("partial" fails closed, same as
+#      "no").
+#   3. Role without runtimeRequirements -> exit 0 with a no-requirements note
+#      (any runtime is trivially compatible).
+#   4. Unknown/missing role file and unknown/missing runtime file -> non-zero
+#      exit with a message DISTINCT from the mismatch message, so callers can
+#      tell "misconfigured" apart from "mismatched".
+#
+# Style matches test-config-resolver.sh / test-disk-headroom.sh: throwaway
+# `mktemp -d` fixture roots (via --dir), hand-rolled assertions, no bats.
+#
+# Usage:
+#   ./defaults/scripts/tests/test-check-runtime-capabilities.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+CHECK_SCRIPT="$SCRIPTS_DIR/check-runtime-capabilities.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_eq() {
+    if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 (expected '$2', got '$1')"; fi
+}
+
+assert_contains() {
+    local needle="$1" haystack="$2" msg="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        pass "$msg"
+    else
+        fail "$msg (expected substring '$needle' in: $haystack)"
+    fi
+}
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq not found on PATH -- skipping test-check-runtime-capabilities.sh"
+    exit 0
+fi
+
+if [[ ! -x "$CHECK_SCRIPT" ]]; then
+    fail "check-runtime-capabilities.sh is missing or not executable at $CHECK_SCRIPT"
+    echo ""
+    echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+    exit 1
+fi
+
+new_fixture_dir() {
+    local dir
+    dir=$(mktemp -d)
+    mkdir -p "$dir/roles" "$dir/runtimes"
+    printf '%s\n' "$dir"
+}
+
+# --- Test 1: match -> exit 0 ---
+echo "Test 1: role requirements fully satisfied by runtime -> exit 0"
+dir=$(new_fixture_dir)
+cat > "$dir/roles/builder.json" <<'JSON'
+{"name": "Development Worker", "runtimeRequirements": ["worktreeIsolation", "mcp"]}
+JSON
+cat > "$dir/runtimes/claude.json" <<'JSON'
+{"runtime": "claude", "capabilities": {"mcp": "yes", "subagents": "yes", "hooks": "yes", "skills": "yes", "worktreeIsolation": "yes"}}
+JSON
+
+set +e
+output=$("$CHECK_SCRIPT" --role builder --runtime claude --dir "$dir" 2>&1)
+code=$?
+set -e
+assert_eq "$code" "0" "match case exits 0"
+rm -rf "$dir"
+
+# --- Test 2: mismatch -> exit 78, each missing/partial capability named ---
+echo "Test 2: mismatch -- missing and partial capabilities both named, exit 78"
+dir=$(new_fixture_dir)
+cat > "$dir/roles/judge.json" <<'JSON'
+{"name": "Code Review Specialist", "runtimeRequirements": ["mcp", "worktreeIsolation", "subagents"]}
+JSON
+cat > "$dir/runtimes/codex.json" <<'JSON'
+{"runtime": "codex", "capabilities": {"mcp": "partial", "subagents": "no", "hooks": "no", "skills": "no", "worktreeIsolation": "yes"}}
+JSON
+
+set +e
+output=$("$CHECK_SCRIPT" --role judge --runtime codex --dir "$dir" 2>&1)
+code=$?
+set -e
+assert_eq "$code" "78" "mismatch case exits 78 (EX_CONFIG)"
+assert_contains "mcp" "$output" "mismatch output names the 'mcp' capability (declared 'partial', fails closed)"
+assert_contains "partial" "$output" "mismatch output shows the declared 'partial' value for mcp"
+assert_contains "subagents" "$output" "mismatch output names the 'subagents' capability (declared 'no')"
+if [[ "$output" == *"worktreeIsolation: runtime"* ]]; then
+    fail "satisfied requirement 'worktreeIsolation' should not appear as a mismatch line"
+else
+    pass "satisfied requirement 'worktreeIsolation' correctly excluded from mismatch list"
+fi
+rm -rf "$dir"
+
+# --- Test 3: role without runtimeRequirements -> exit 0 with a note ---
+echo "Test 3: role without runtimeRequirements -> exit 0, any runtime compatible"
+dir=$(new_fixture_dir)
+cat > "$dir/roles/driver.json" <<'JSON'
+{"name": "Direct Command Execution"}
+JSON
+cat > "$dir/runtimes/claude.json" <<'JSON'
+{"runtime": "claude", "capabilities": {}}
+JSON
+
+set +e
+output=$("$CHECK_SCRIPT" --role driver --runtime claude --dir "$dir" 2>&1)
+code=$?
+set -e
+assert_eq "$code" "0" "role without runtimeRequirements exits 0 even against an empty capability set"
+assert_contains "no runtimeRequirements" "$output" "output notes the role declares no runtimeRequirements"
+rm -rf "$dir"
+
+# --- Test 4a: unknown role file -> non-zero, distinct message from mismatch ---
+echo "Test 4a: unknown role -> non-zero exit with a message distinct from the mismatch message"
+dir=$(new_fixture_dir)
+cat > "$dir/runtimes/claude.json" <<'JSON'
+{"runtime": "claude", "capabilities": {"mcp": "yes"}}
+JSON
+
+set +e
+output=$("$CHECK_SCRIPT" --role does-not-exist --runtime claude --dir "$dir" 2>&1)
+code=$?
+set -e
+if [[ "$code" -ne 0 ]]; then pass "unknown role exits non-zero"; else fail "unknown role should not exit 0 (got $code)"; fi
+if [[ "$code" -ne 78 ]]; then pass "unknown role exit code ($code) is distinct from the mismatch exit code 78"; else fail "unknown role must not be conflated with the mismatch exit code 78"; fi
+assert_contains "Unknown role" "$output" "unknown role message names the failure distinctly (not the mismatch wording)"
+rm -rf "$dir"
+
+# --- Test 4b: unknown runtime file -> non-zero, distinct message from mismatch ---
+echo "Test 4b: unknown runtime -> non-zero exit with a message distinct from the mismatch message"
+dir=$(new_fixture_dir)
+cat > "$dir/roles/builder.json" <<'JSON'
+{"runtimeRequirements": ["mcp"]}
+JSON
+
+set +e
+output=$("$CHECK_SCRIPT" --role builder --runtime does-not-exist --dir "$dir" 2>&1)
+code=$?
+set -e
+if [[ "$code" -ne 0 ]]; then pass "unknown runtime exits non-zero"; else fail "unknown runtime should not exit 0 (got $code)"; fi
+if [[ "$code" -ne 78 ]]; then pass "unknown runtime exit code ($code) is distinct from the mismatch exit code 78"; else fail "unknown runtime must not be conflated with the mismatch exit code 78"; fi
+assert_contains "Unknown runtime" "$output" "unknown runtime message names the failure distinctly (not the mismatch wording)"
+rm -rf "$dir"
+
+# --- Test 5: explicit --role-file / --runtime-file overrides ---
+echo "Test 5: --role-file and --runtime-file overrides bypass name-based resolution"
+dir=$(new_fixture_dir)
+role_file="$dir/some-role.json"
+runtime_file="$dir/some-runtime.json"
+cat > "$role_file" <<'JSON'
+{"runtimeRequirements": ["hooks"]}
+JSON
+cat > "$runtime_file" <<'JSON'
+{"runtime": "claude", "capabilities": {"hooks": "yes"}}
+JSON
+
+set +e
+output=$("$CHECK_SCRIPT" --role-file "$role_file" --runtime-file "$runtime_file" --role ignored --runtime ignored 2>&1)
+code=$?
+set -e
+assert_eq "$code" "0" "explicit file overrides resolve and match correctly"
+rm -rf "$dir"
+
+# --- Test 6: verify against the real repo fixtures (builder + judge x claude) ---
+echo "Test 6: real defaults/ fixtures -- builder and judge are both compatible with claude"
+DEFAULTS_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
+if [[ -f "$DEFAULTS_DIR/runtimes/claude.json" ]]; then
+    set +e
+    "$CHECK_SCRIPT" --role builder --runtime claude --dir "$DEFAULTS_DIR" >/dev/null 2>&1
+    b_code=$?
+    "$CHECK_SCRIPT" --role judge --runtime claude --dir "$DEFAULTS_DIR" >/dev/null 2>&1
+    j_code=$?
+    set -e
+    assert_eq "$b_code" "0" "real builder.json requirements are met by real claude.json"
+    assert_eq "$j_code" "0" "real judge.json requirements are met by real claude.json"
+else
+    fail "defaults/runtimes/claude.json not found -- cannot verify real fixtures"
+fi
+
+# --- Summary ---
+echo ""
+echo "────────────────────────────────"
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/scripts/install/manifest.sh
+++ b/scripts/install/manifest.sh
@@ -179,6 +179,9 @@ _emit_installed_files_manifest() {
       scripts/*)
         target_path=".loom/${rel_path}"
         ;;
+      runtimes/*)
+        target_path=".loom/${rel_path}"
+        ;;
       hooks/*)
         target_path=".loom/${rel_path}"
         ;;


### PR DESCRIPTION
## Summary

Implements the declaration and requirement sides of the runtime-adapter
capability contract (`defaults/docs/runtime-adapters.md` §7 "Capability
declaration"), ahead of dispatch wiring (epic #4167, design pillar 2).

- **`defaults/runtimes/claude.json`** — capability manifest for the Claude
  Code runtime, using the doc's normative **tri-state string** schema
  (`"yes" | "no" | "partial"`, NOT booleans): `mcp`, `subagents`, `hooks`,
  `skills`, `worktreeIsolation`, all `"yes"`. No `instructionFiles` field
  (that's contract point 5, not a capability).
- **`defaults/roles/builder.json`** / **`judge.json`** — add an optional
  `"runtimeRequirements"` array (builder: `worktreeIsolation` + `mcp`; judge:
  `mcp`) as worked examples. This is a distinct field from the pre-existing
  `suggestedWorkerType` preference hint — the checker only reads
  `runtimeRequirements`.
- **`defaults/scripts/check-runtime-capabilities.sh`** — `--role <name>
  --runtime <name>` matcher (plus `--role-file`/`--runtime-file`/`--dir`
  overrides for testability). Requirements must be a subset of capabilities
  declared exactly `"yes"` — a declared `"partial"` fails closed, naming the
  capability and its declared value. Exit 0 on match, exit 78 (`EX_CONFIG`)
  on mismatch (each unmet capability named), exit 0 with a note when the
  role has no `runtimeRequirements`, non-zero with a message **distinct**
  from the mismatch wording on an unknown/missing role or runtime file.
- **`defaults/scripts/tests/test-check-runtime-capabilities.sh`** — 17
  assertions covering match, mismatch (missing + partial both named),
  no-requirements, unknown role file, unknown runtime file, explicit file
  overrides, and the real `defaults/` fixtures.
- **`scripts/install/manifest.sh`** — added the `runtimes/*) → .loom/runtimes/*`
  mapping case so `defaults/runtimes/claude.json` installs into consumer repos
  (previously any unmapped `defaults/` entry silently fell through the
  catch-all and was never installed).
- Small doc addition to `defaults/docs/runtime-adapters.md` §7 documenting
  the concrete implementation (file locations, field semantics).

## Scope guards (preserved)

- The checker is **standalone** — not wired into `spawn-worker.sh` or any
  dispatch path. That enforcement decision is a follow-up.
- No `codex.json`/`amp.json` — Claude manifest only.
- No changes under `loom-daemon/` or `loom-tools/`.
- `spawn-claude.sh` / `spawn-worker.sh` are byte-identical to `origin/main`.
- The checker does not read `.loom/config.json`'s `runtimes` block itself —
  `--runtime <name>` is always passed explicitly by the caller.

```
$ git diff origin/main --stat
 defaults/docs/runtime-adapters.md                  |  22 +++
 defaults/roles/builder.json                        |   1 +
 defaults/roles/judge.json                          |   1 +
 defaults/runtimes/claude.json                      |  10 +
 defaults/scripts/check-runtime-capabilities.sh     | 205 ++++++++++++++++++++
 .../tests/test-check-runtime-capabilities.sh       | 209 +++++++++++++++++++++
 scripts/install/manifest.sh                        |   3 +
 7 files changed, 451 insertions(+)
```

## Test plan

- [x] `bash defaults/scripts/tests/test-check-runtime-capabilities.sh` — 17/17 passed
- [x] `./defaults/scripts/check-runtime-capabilities.sh --role builder --runtime claude --dir defaults` exits 0
- [x] `./defaults/scripts/check-runtime-capabilities.sh --role driver --runtime claude --dir defaults` exits 0 with a no-requirements note
- [x] `git diff origin/main --stat` — no changes under `loom-daemon/`, `loom-tools/`; no diff to `spawn-claude.sh`/`spawn-worker.sh`
- [x] `bash defaults/scripts/tests/test-config-resolver.sh` still passes (unrelated regression check)

Closes #4170

🤖 Generated with [Claude Code](https://claude.com/claude-code)