### PR TITLE
docs(fleet-comms): role guidance for worker safehouse posting

### DIFF
--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -848,6 +848,16 @@ After PR creation:
 - [ ] STOP - do not touch any PR labels
 - [ ] Move to next issue
 
+## Fleet-Comms Etiquette (optional)
+
+If the `safehouse_send` / `safehouse_read` MCP tools are present in this
+session, post sparingly to the fleet room: one line on claim ("starting issue
+#N: `<title>`"), one line on PR creation, and any *notable* mid-task finding
+(surprising discovery, a concern worth human eyes) — not routine progress. A
+genuine blocker gets `type: handoff`. If the tools are absent, proceed exactly
+as above — this is normal, not an error. Full etiquette (detection, threading,
+what NOT to do): `.loom/docs/fleet-comms.md`.
+
 ## Terminal Probe Protocol
 
 When you receive a probe command, respond with: `AGENT:Builder:<brief-task>` — e.g. `AGENT:Builder:implementing-issue-456`.

--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -811,6 +811,14 @@ Reviewer                    Fixer                     Reviewer
 - **Fixer**: Address feedback, resolve conflicts, signal completion (→ `loom:review-requested`)
 - **Handoff**: Fixer transitions `loom:changes-requested` → `loom:review-requested` after fixing
 
+## Fleet-Comms Etiquette (optional)
+
+If the `safehouse_send` / `safehouse_read` MCP tools are present in this
+session, post one line on what you fixed after pushing. A genuine blocker
+(e.g. feedback you cannot address) gets `type: handoff`. If the tools are
+absent, proceed exactly as above — this is normal, not an error. Full
+etiquette: `.loom/docs/fleet-comms.md`.
+
 ## Terminal Probe Protocol
 
 When you receive a probe command, respond with: `AGENT:Doctor:<brief-task>` — e.g. `AGENT:Doctor:fixing-changes-requested-789`.

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -1348,6 +1348,14 @@ EOF
 # Note: PR now has loom:pr (blue badge) - ready for Champion auto-merge
 ```
 
+## Fleet-Comms Etiquette (optional)
+
+If the `safehouse_send` / `safehouse_read` MCP tools are present in this
+session, post one line with your verdict summary (approve / changes-requested
++ one-line why) — not the full review comment, that's what `gh pr comment` is
+for. A genuine blocker gets `type: handoff`. If the tools are absent, proceed
+exactly as above — this is normal, not an error. Full etiquette: `.loom/docs/fleet-comms.md`.
+
 ## Terminal Probe Protocol
 
 When you receive a probe command, respond with: `AGENT:Judge:<brief-task>` — e.g. `AGENT:Judge:evaluating-PR-123`.

--- a/defaults/docs/fleet-comms.md
+++ b/defaults/docs/fleet-comms.md
@@ -1,0 +1,99 @@
+# Fleet-comms etiquette (safehouse posting for worker roles)
+
+Phase 3 of the safehouse interface roadmap (#4196, phase 2 of #3999/#3997). The
+plumbing already exists and is documented in
+[`safehouse.md`](safehouse.md): when the `safehouse` config block is enabled,
+`spawn-claude.sh` injects a session-scoped MCP config that gives the worker the
+`safehouse_send` / `safehouse_read` (and room-admin) tools alongside `loom`.
+This document is the **behavioral layer** — when and how a role uses those
+tools once they're present. It does not change label-based coordination, which
+remains the sole source of truth (see "What NOT to do" below).
+
+> **Path note**: this file lives at `defaults/docs/fleet-comms.md` in the Loom
+> source repo. A consumer install maps it to `.loom/docs/fleet-comms.md` (not
+> `defaults/.loom/docs/`) — see `defaults/docs/runtime-adapters.md` for the same
+> convention spelled out in detail.
+
+## 1. Detection — the tools are optional, always
+
+Safehouse MCP injection is conditional (config-gated, host-dependent). A role
+session may or may not have `safehouse_send` / `safehouse_read` available —
+**do not assume either way**. This is the same degradation contract documented
+in `safehouse.md`, extended to worker behavior:
+
+- **If the tools are present**: use them per the guidance below.
+- **If the tools are absent**: proceed exactly as you do today. This is the
+  normal case for most sessions, not an error condition.
+- **Never fail, retry, stall, or comment on their absence.** No tool-presence
+  check should ever block, slow, or change the outcome of a role's normal
+  work. Treat a missing `safehouse_send` the same way you'd treat a missing
+  optional dependency — silently unavailable, nothing to fix.
+
+## 2. When to post (sparingly)
+
+**The room is a human's phone, not a log file.** A message should be something
+a person watching Element would actually want to see arrive as a notification.
+Routine progress narration is already covered by the daemon's own event-bus
+narration (`safehouse.md` phase 1) — a worker posting the same information a
+second time is noise, not signal.
+
+| Role | Post on | Do NOT post |
+|------|---------|-------------|
+| **Builder** | One line on claim ("starting issue #N: `<title>`"); one line on PR creation; a *notable* mid-task finding (surprising discovery, a concern worth human eyes, a decision the human might want to veto) | Routine progress ("wrote the function", "running tests now", file-by-file narration) |
+| **Judge** | Verdict summary — approve or changes-requested, one-line why | The full review comment (that's what `gh pr comment` is for) |
+| **Doctor** | One line on what was fixed | Step-by-step fix narration |
+| **All roles** | A genuine blocker — post with `type: handoff` (the "a human must act" signal) | A concern you're already handling yourself (that's not a blocker) |
+
+Curator, Champion, and Guide are label-machine roles — out of scope for now
+(their throughput is high and their output is mechanical; the noise risk
+outweighs the value). Do not add fleet-comms posting to those roles without a
+separate issue.
+
+## 3. How to post
+
+```
+safehouse_send(
+  task_id: "<issue number>",   # threads with the daemon's own narration for the same issue
+  to: "*",                      # broadcast
+  type: "task" | "handoff" | "chat",
+  body: "<one concise line>"
+)
+```
+
+- **`task_id`**: always the bare issue number as a string, so your message
+  threads alongside the daemon's phase narration for that issue (see the
+  envelope table in `safehouse.md`).
+- **`to`**: `"*"` (broadcast) — this is a shared room, not a DM.
+- **`type`**:
+  - `task` — routine, in-band progress (claim / PR-created lines).
+  - `handoff` — a genuine blocker; this is the signal that a human must act.
+  - `chat` — free-form conversation (rare for automated posts; mostly for
+    replying to an operator's directed message).
+
+## 4. What NOT to do
+
+- **Labels remain the sole coordination mechanism.** Never treat the room as
+  state — no role should read the room to decide what to do next (with the one
+  exception in §5 below), and no role should skip or substitute a label
+  transition because it "already said so in the room."
+- **Never post secrets, tokens, or keys.** The same rule as every other
+  Loom-side channel (logs, PR comments, issue comments) applies here.
+- **Never block on `safehouse_read`.** Poll it only at natural pause points
+  (e.g., right after pushing a PR, right after claiming an issue) — never as a
+  wait loop, and never as a precondition for continuing your normal work.
+
+## 5. Read-back: operator guidance is advisory input
+
+At the natural checkpoints where you do poll the room, you may see an
+operator's `@`-directed message. Treat it exactly like an issue comment: fold
+it in as advisory input to your current task. It does **not** override role
+guardrails (scope discipline, label discipline, the "issues are suggestions"
+guardrails, etc.) — it's a hint from a human watching the fleet, not a
+privilege escalation. If it conflicts with your role's mandatory rules, follow
+your role's rules and, if useful, say why in a reply.
+
+## Summary for role authors
+
+If you're adding a fleet-comms pointer to a new role file, keep it short (a
+handful of lines) and link back here rather than restating the etiquette
+inline — see `builder.md`, `judge.md`, `doctor.md` for the pattern.


### PR DESCRIPTION
## Summary

Adds the behavioral layer for worker safehouse posting (phase 2 of the
safehouse interface roadmap, #4196) — role-prompt guidance for when and how
Builder/Judge/Doctor use the `safehouse_send` / `safehouse_read` MCP tools that
`spawn-claude.sh` already injects conditionally. All plumbing (injection,
resolvers, persona pool, host provisioning) was already on main; this issue was
purely the missing "roles know these tools exist and when to use them" piece.

## Changes

- **`defaults/docs/fleet-comms.md`** (new) — the shared fleet-comms etiquette:
  detection/degradation contract (tools are optional, absence is normal),
  when to post (sparingly — the room is a human's phone, not a log file),
  how to post (`safehouse_send` with `task_id`/`to`/`type`), what NOT to do
  (labels remain the sole coordination mechanism, no secrets, never block on
  `safehouse_read`), and read-back (operator `@`-messages are advisory input,
  never override role guardrails).
- **`defaults/.claude/commands/loom/builder.md`** — short "Fleet-Comms
  Etiquette (optional)" pointer section (claim + PR-creation lines, notable
  findings only, `handoff` for blockers).
- **`defaults/.claude/commands/loom/judge.md`** — pointer section (verdict
  summary one-liner).
- **`defaults/.claude/commands/loom/doctor.md`** — pointer section (what-was-fixed
  one-liner).

`defaults/roles/{builder,judge,doctor}.md` are symlinks to these files, so the
symlinked view reflects the same changes automatically (verified with `diff`).

Docs + role prompts only. No changes to `spawn-claude.sh`, `mcp-config.sh`, or
any lifecycle/label behavior. Root `CLAUDE.md` is untouched (budget check
still passes: 311/320 lines).

## Acceptance Criteria Verification

- [x] `defaults/docs/fleet-comms.md` exists with the etiquette (detection,
      when/how/what-not, threading convention via `task_id`)
- [x] builder.md, judge.md, doctor.md each gain a short fleet-comms pointer
      section (10 / 8 / 8 added lines respectively — all well under ~10 lines)
- [x] Guidance explicitly states the tools are optional and absence is normal
      (both in `fleet-comms.md` §1 and in each role's pointer section)
- [x] No changes to spawn/injection code, `mcp-config.sh`, or any
      lifecycle/label behavior (docs + role prompts only — `git diff --stat`
      confirms only the 4 files above changed)
- [x] Root CLAUDE.md unchanged — `scripts/check-claude-md-budget.sh` passes
      (311/320 lines, unchanged from before this PR)

## Live verification (bonus, not blocking)

**Skipped — no safehouse MCP tools available in this Builder session.** This
Builder ran as a Task-tool-dispatched subagent inside a parent Claude Code
session, not as a `spawn-claude.sh`-launched process, so the conditional
`--mcp-config` injection that adds `safehouse_send` / `safehouse_read` never
applied here (confirmed: no `mcp__safehouse__*` tools were present in this
session's tool list). This host does have safehouse enabled
(`LOOM_SAFEHOUSE_ENABLED=1`, socket resolved) for daemon-dispatched sweeps —
just not for this particular manually-orchestrated Builder invocation. This is
itself a live demonstration of the degradation contract this PR documents: no
tools present → proceed exactly as normal, no failure, no stall.

## Test Plan

- [x] Read `defaults/docs/safehouse.md` to confirm actual tool names
      (`safehouse_send` / `safehouse_read` / `safehouse_create_room` /
      `safehouse_list_rooms`) and injection mechanism before writing guidance.
- [x] Confirmed `defaults/roles/{builder,judge,doctor}.md` are symlinks to the
      edited files and `diff` shows the symlinked view matches.
- [x] Ran `./scripts/check-claude-md-budget.sh` — passes (311/320, CLAUDE.md
      untouched by this PR).
- [x] `git diff --stat` — confirms only the 4 intended docs/role files changed
      (no spawn/injection code touched).
- [ ] Not executed (observation-only): whether a live worker actually posts to
      `loom-fleet` per this new guidance — requires a real sweep dispatch with
      safehouse injection active, out of scope for a docs-only PR to verify.

Closes #4197
