### PR TITLE
feat(curator): surface open cross-referencing issues before curation

### DIFF
--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -428,17 +428,19 @@ gh issue close <number> --reason "not planned"
 
 ### Duplicate Detection
 
-**Check for potential duplicates during curation** using the duplicate detection script. Use `--include-merged-prs` to also catch issues that overlap with recently merged PRs or recently closed issues:
+**Check for potential duplicates during curation** using the duplicate detection script. Use `--include-merged-prs` to also catch issues that overlap with recently merged PRs or recently closed issues, and pass `--issue <number>` so the script also probes for **related open work** — see "Related Open Work (Cross-References)" immediately below, a different question from duplication:
 
 ```bash
 # Get issue title and body
 TITLE=$(gh issue view <number> --json title --jq .title)
 BODY=$(gh issue view <number> --json body --jq .body)
 
-# Check for similar existing issues, merged PRs, and closed issues
-if ! ./.loom/scripts/check-duplicate.sh --include-merged-prs "$TITLE" "$BODY"; then
-    # Potential duplicate found - investigate before marking curated
-    echo "Potential duplicate detected - review similar issues"
+# Check for similar existing issues, merged PRs, closed issues, AND open
+# issues/PRs that cross-reference this one (--issue, issue #4162)
+if ! ./.loom/scripts/check-duplicate.sh --include-merged-prs --issue "<number>" "$TITLE" "$BODY"; then
+    # DUPLICATE_FOUND and/or RELATED_OPEN_WORK found - read the full output
+    # before marking curated
+    echo "Potential duplicate or related open work detected - review before curating"
 fi
 ```
 
@@ -475,6 +477,31 @@ fi
    ```
 
 **Why this matters**: closing on a **clear, stated rationale** keeps the backlog healthy and — because the work-finder only polls *open* issues — removes the item from the queue without a loop. But an **unverified** guess should be flagged, not closed, and never close an issue that is being actively built (`loom:building`) by another agent (see issue #2084 where a curator closed #1981 mid-processing, requiring manual intervention — coordinate via a comment when an issue is in flight).
+
+### Related Open Work (Cross-References, issue #4162)
+
+Duplicate detection answers "has this been reported before?" — it does **not** catch open issues that argue for a **different or changed spec** for the one you're curating. A real incident: an open issue explicitly named the target issue's number in its body (a critique of the target's acceptance criteria), was never surfaced because it wasn't a *duplicate*, and the target got curated — and later built — against a spec that other open work had already argued was wrong.
+
+`check-duplicate.sh --issue <number>` (see the invocation above) closes this gap by probing GitHub's timeline API for **open** issues/PRs whose body or comments cross-reference `<number>` (a `#<number>` mention — a structural signal GitHub already computes, not a similarity heuristic). When present, they appear in a `RELATED_OPEN_WORK` block, **distinct from** any `DUPLICATE_FOUND` block:
+
+```
+RELATED_OPEN_WORK
+#87: Rework the retry policy this issue assumes (open issue, cross-references #42)
+PR #90: Implement alternate approach (open PR, cross-references #42)
+```
+
+**This is required reading, not optional context — silence is not a valid outcome.** For **every** issue listed under `RELATED_OPEN_WORK`, your enhancement comment must explicitly state one of:
+
+- **Absorbed** — you read it and changed the acceptance criteria/spec accordingly. Say what changed and cite the cross-referencing issue.
+- **Disregarded** — you read it and it does not apply (wrong scope, superseded, already resolved). State the reason, not just "not applicable."
+
+```bash
+gh issue comment <number> --body "Related open work: #87 argues the retry policy should be event-driven rather than polling. Absorbed — updated the AC to require an event-driven retry, see revised Acceptance Criteria above."
+# or:
+gh issue comment <number> --body "Related open work: #87 discusses a different subsystem (auth, not this issue's caching layer) — disregarded as out of scope for this issue."
+```
+
+A `RELATED_OPEN_WORK` hit is **not** grounds for closing or auto-rescoping on its own — it is a signal to actively reconcile the spec (or explicitly reject the reconciliation) before marking `loom:curated`, since the whole point is preventing a Builder from shipping against a spec another open issue has already argued is wrong. GitHub-specific: on a non-GitHub forge (or an API failure) the probe degrades gracefully (stderr warning, empty result) rather than failing the duplicate check.
 
 ### Planning
 - Document multiple implementation approaches

--- a/defaults/scripts/check-duplicate.sh
+++ b/defaults/scripts/check-duplicate.sh
@@ -75,12 +75,20 @@ USAGE:
     check-duplicate.sh --title "Issue title" [--body "Issue body"]
     check-duplicate.sh --threshold 50 --title "Title"
     check-duplicate.sh --include-merged-prs --title "Title"
+    check-duplicate.sh --issue 42 --title "Title"
 
 OPTIONS:
     --title TEXT            The title of the issue to check
     --body TEXT             The body/description of the issue (optional)
     --threshold NUM         Similarity threshold percentage (default: 60)
     --include-merged-prs    Also check recently merged PRs and closed issues
+    --issue N               Also probe for OPEN issues/PRs that cross-reference
+                             issue N (GitHub timeline API). Curator use --
+                             surfaces "related open work" distinct from
+                             duplicates: open items that may already argue for
+                             a different spec for N. GitHub-only; a non-GitHub
+                             forge or API failure skips the probe with a
+                             warning rather than failing the whole check.
     --json                  Output results as JSON
     --help                  Show this help message
 
@@ -97,9 +105,12 @@ EXAMPLES:
     # Also check recently merged PRs and closed issues
     check-duplicate.sh --include-merged-prs "Refactor authentication module"
 
+    # Also surface open work that cross-references issue #42
+    check-duplicate.sh --issue 42 --title "Refactor authentication module"
+
 EXIT CODES:
-    0  No duplicates found, safe to create issue
-    1  Potential duplicates found (listed to stdout)
+    0  No duplicates (and, with --issue, no related open work) found
+    1  Potential duplicates (or related open work) found (listed to stdout)
     2  Error (invalid arguments, gh command failed, etc.)
 
 INTEGRATION:
@@ -115,6 +126,14 @@ INTEGRATION:
 
     if ! ./.loom/scripts/check-duplicate.sh --include-merged-prs "$TITLE" "$BODY"; then
         echo "Potential overlap with merged PR or closed issue"
+    fi
+
+    Use with --issue N in the Curator role, before enriching issue N, to
+    surface open cross-referencing work that may already argue for a
+    different spec (issue #4162):
+
+    if ! ./.loom/scripts/check-duplicate.sh --include-merged-prs --issue "$N" "$TITLE" "$BODY"; then
+        echo "Read the DUPLICATE_FOUND / RELATED_OPEN_WORK output before curating"
     fi
 EOF
 }
@@ -337,6 +356,71 @@ search_closed_issues() {
     fi
 }
 
+# Probe for OPEN issues/PRs whose bodies or comments cross-reference the given
+# issue number (issue #4162). This answers a different question than
+# duplicate detection above: not "is this the same issue" but "is there open
+# work that already argues for a different/changed spec for this issue" --
+# e.g. an open issue that critiques/rewrites #N's acceptance criteria via a
+# cross-reference in its body. Uses GitHub's timeline API (the same
+# `cross-referenced` event already used for PR detection in
+# .claude/commands/loom/sweep.md's existing-PR probe), which surfaces every
+# `#N` mention regardless of similarity -- no local text/keyword matching.
+#
+# GitHub-specific. Gracefully degrades (stderr warning, empty result, does
+# NOT fail the whole duplicate check) when `gh` is missing, the repo can't be
+# resolved (e.g. a Gitea remote `gh` doesn't recognize), or the API call
+# fails -- same pattern as search_merged_prs() above.
+#
+# Outputs a JSON array of {number, title, is_pr} for OPEN, same-repo,
+# non-self cross-references, deduped by number. Emits "[]" on any failure.
+search_cross_references() {
+    local issue_num="$1"
+
+    if ! command -v gh &>/dev/null; then
+        print_warning "gh CLI not found; skipping cross-reference probe for #${issue_num}"
+        echo "[]"
+        return 0
+    fi
+
+    local repo_nwo
+    if ! repo_nwo=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>&1); then
+        print_warning "Failed to resolve repository for cross-reference probe (non-GitHub forge?): $repo_nwo"
+        echo "[]"
+        return 0
+    fi
+
+    local timeline
+    if ! timeline=$(gh api "repos/${repo_nwo}/issues/${issue_num}/timeline" --paginate 2>&1); then
+        print_warning "Failed to fetch timeline for #${issue_num}: $timeline"
+        echo "[]"
+        return 0
+    fi
+
+    echo "$timeline" | jq -c --arg repo "$repo_nwo" --argjson self "$issue_num" '
+        [.[] | select(.event == "cross-referenced"
+                       and .source.issue != null
+                       and (.source.issue.repository.full_name // "") == $repo
+                       and .source.issue.number != $self
+                       and .source.issue.state == "open")
+         | {number: .source.issue.number,
+            title: .source.issue.title,
+            is_pr: (.source.issue.pull_request != null)}]
+        | unique_by(.number)
+    ' 2>/dev/null || echo "[]"
+}
+
+# Format a RELATED_OPEN_WORK JSON array (from search_cross_references) into
+# the human-readable lines used by the text-output mode.
+format_related_open_work() {
+    local issue_num="$1"
+    local json_array="$2"
+
+    echo "$json_array" | jq -r --arg n "$issue_num" '
+        .[] | (if .is_pr then "PR #" else "#" end) + (.number | tostring) + ": " + .title +
+              (if .is_pr then " (open PR, cross-references #" else " (open issue, cross-references #" end) + $n + ")"
+    '
+}
+
 # Main function
 main() {
     local title=""
@@ -344,6 +428,7 @@ main() {
     local threshold=60
     local json_output=false
     local include_merged_prs=false
+    local issue=""
 
     # Parse arguments
     while [[ $# -gt 0 ]]; do
@@ -366,6 +451,10 @@ main() {
                 ;;
             --include-merged-prs)
                 include_merged_prs=true
+                ;;
+            --issue)
+                shift
+                issue="$1"
                 ;;
             --json)
                 json_output=true
@@ -401,6 +490,12 @@ main() {
     # Validate threshold is a number
     if ! [[ "$threshold" =~ ^[0-9]+$ ]]; then
         print_error "Threshold must be a number"
+        exit 2
+    fi
+
+    # Validate --issue is a number, when given
+    if [[ -n "$issue" ]] && ! [[ "$issue" =~ ^[0-9]+$ ]]; then
+        print_error "--issue must be a number"
         exit 2
     fi
 
@@ -444,11 +539,27 @@ main() {
         fi
     fi
 
+    # Cross-reference probe (--issue N only, issue #4162). Distinct from
+    # duplicate detection above: surfaces OPEN issues/PRs that already
+    # cross-reference N, as "related open work" the Curator must read. Skip
+    # entirely when the base similarity check already hard-failed (exit 2) --
+    # no point probing on top of an already-broken forge call.
+    local related_json="[]"
+    local related_count=0
+    if [[ -n "$issue" && $exit_code -ne 2 ]]; then
+        related_json=$(search_cross_references "$issue")
+        related_count=$(echo "$related_json" | jq 'length' 2>/dev/null || echo 0)
+        if [[ "$related_count" -gt 0 ]]; then
+            exit_code=1
+        fi
+    fi
+
     if $json_output; then
-        if [[ $exit_code -eq 0 ]]; then
-            echo '{"duplicate_found": false, "matches": []}'
-        elif [[ $exit_code -eq 1 ]]; then
-            # Parse duplicates into JSON
+        if [[ $exit_code -eq 2 ]]; then
+            echo '{"error": "Failed to check duplicates"}'
+        else
+            # Parse duplicates into JSON (unconditional -- harmless no-op on
+            # an empty $result, e.g. exit_code 0 or "related work only")
             local matches="[]"
             while IFS= read -r line; do
                 [[ "$line" == "DUPLICATE_FOUND" ]] && continue
@@ -478,15 +589,27 @@ main() {
                 fi
             done <<< "$result"
 
-            echo "{\"duplicate_found\": true, \"matches\": $matches}"
-        else
-            echo '{"error": "Failed to check duplicates"}'
+            if [[ "$related_count" -gt 0 ]]; then
+                local cross_matches
+                cross_matches=$(echo "$related_json" | jq '[.[] | {number, title, similarity: 0, type: "cross_reference"}]')
+                matches=$(echo "$matches" | jq --argjson extra "$cross_matches" '. + $extra')
+            fi
+
+            if [[ "$matches" == "[]" ]]; then
+                echo '{"duplicate_found": false, "matches": []}'
+            else
+                echo "{\"duplicate_found\": true, \"matches\": $matches}"
+            fi
         fi
     else
         if [[ $exit_code -eq 0 ]]; then
             print_success "No duplicates found"
         else
             echo "$result"
+            if [[ "$related_count" -gt 0 ]]; then
+                echo "RELATED_OPEN_WORK"
+                format_related_open_work "$issue" "$related_json"
+            fi
         fi
     fi
 

--- a/defaults/scripts/tests/test-check-duplicate.sh
+++ b/defaults/scripts/tests/test-check-duplicate.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# test-check-duplicate.sh - Unit tests for check-duplicate.sh's --issue
+# cross-reference probe (issue #4162).
+#
+# check-duplicate.sh's existing keyword-similarity check answers "has this
+# been reported before?" -- it is structurally blind to an OPEN issue that
+# *critiques* the target's spec (a cross-reference in its body) without being
+# textually similar. This mirrors a real incident (rjwalters/repo #32/#33):
+# #33 named #32 three times in its body, arguing #32's acceptance criteria
+# were wrong, but was never surfaced because it wasn't a *duplicate* -- it
+# was a *related, spec-changing* piece of open work.
+#
+# `check-duplicate.sh --issue N` closes this gap by querying GitHub's
+# timeline API for open issues/PRs that cross-reference N, emitting a
+# RELATED_OPEN_WORK block distinct from DUPLICATE_FOUND. This is a
+# black-box test: check-duplicate.sh is a full CLI script (main "$@" at
+# EOF, not sourced functions), so we stub `gh` and `loom-forge` on PATH and
+# invoke the real script as a subprocess, asserting on stdout/exit code.
+#
+# Usage:
+#   ./.loom/scripts/tests/test-check-duplicate.sh
+
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)"
+CDS="$SCRIPTS_DIR/check-duplicate.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected: '$expected'"
+        echo "    Actual:   '$actual'"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if ! printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Unexpected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+if [[ ! -x "$CDS" ]]; then
+    echo -e "${RED}FATAL${NC}: $CDS not found or not executable" >&2
+    exit 2
+fi
+
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR" 2>/dev/null || true' EXIT
+
+# --- Stub loom-forge: present on PATH but deliberately non-functional, so
+# check-duplicate.sh's `loom-forge --version` probe fails and it falls back
+# to the `gh` stub below (byte-for-byte the documented fallback path,
+# defaults/scripts/check-duplicate.sh:35-42). Keeps this test independent of
+# whether a real loom-forge happens to be installed on the host. ---
+cat > "$STUB_DIR/loom-forge" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+chmod +x "$STUB_DIR/loom-forge"
+
+# --- Stub gh on PATH ---
+#   gh auth status                                     -> exit 0 (authenticated)
+#   gh repo view --json nameWithOwner --jq ...          -> "owner/repo" (or fail
+#                                                          if $STUB_DIR/repo-view-fail exists)
+#   gh issue list --state=open|closed ...               -> cat $STUB_DIR/issues-<state>.json (or [])
+#   gh pr list --state=merged ...                        -> cat $STUB_DIR/prs-merged.json (or [])
+#   gh api repos/OWNER/REPO/issues/N/timeline --paginate -> cat $STUB_DIR/timeline-N.json (or [];
+#                                                           fails if $STUB_DIR/timeline-fail exists)
+cat > "$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+STUB_DIR_FROM_ENV="${LOOM_TEST_STUB_DIR:?stub gh: LOOM_TEST_STUB_DIR not set}"
+
+case "$1" in
+  auth)
+    exit 0
+    ;;
+  repo)
+    if [[ -f "$STUB_DIR_FROM_ENV/repo-view-fail" ]]; then
+      echo "stub gh: repo view failed" >&2
+      exit 1
+    fi
+    echo "owner/repo"
+    exit 0
+    ;;
+  issue)
+    if [[ "$2" == "list" ]]; then
+      state="open"
+      shift 2
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --state=*) state="${1#--state=}" ;;
+        esac
+        shift
+      done
+      canned="$STUB_DIR_FROM_ENV/issues-$state.json"
+      if [[ -f "$canned" ]]; then cat "$canned"; else echo "[]"; fi
+      exit 0
+    fi
+    echo "stub gh: unhandled issue args: $*" >&2
+    exit 3
+    ;;
+  pr)
+    if [[ "$2" == "list" ]]; then
+      canned="$STUB_DIR_FROM_ENV/prs-merged.json"
+      if [[ -f "$canned" ]]; then cat "$canned"; else echo "[]"; fi
+      exit 0
+    fi
+    echo "stub gh: unhandled pr args: $*" >&2
+    exit 3
+    ;;
+  api)
+    if [[ -f "$STUB_DIR_FROM_ENV/timeline-fail" ]]; then
+      echo "stub gh: api call failed" >&2
+      exit 1
+    fi
+    path="$2"
+    num="${path%/timeline}"
+    num="${num##*/}"
+    canned="$STUB_DIR_FROM_ENV/timeline-$num.json"
+    if [[ -f "$canned" ]]; then cat "$canned"; else echo "[]"; fi
+    exit 0
+    ;;
+  *)
+    echo "stub gh: unhandled args: $*" >&2
+    exit 3
+    ;;
+esac
+STUB
+chmod +x "$STUB_DIR/gh"
+
+export LOOM_TEST_STUB_DIR="$STUB_DIR"
+export PATH="$STUB_DIR:$PATH"
+
+reset_state() {
+    rm -f "$STUB_DIR"/issues-*.json "$STUB_DIR"/prs-merged.json "$STUB_DIR"/timeline-*.json
+    rm -f "$STUB_DIR/timeline-fail" "$STUB_DIR/repo-view-fail"
+}
+
+run_cds() {
+    # Runs check-duplicate.sh, capturing stdout to $OUT, stderr to $ERR, exit to $RC.
+    OUT="$("$CDS" "$@" 2>"$STUB_DIR/stderr.log")"
+    RC=$?
+    ERR="$(cat "$STUB_DIR/stderr.log" 2>/dev/null || true)"
+}
+
+echo "Testing check-duplicate.sh --issue cross-reference probe..."
+
+# (a) Open cross-referencing issue -> RELATED_OPEN_WORK block, exit 1.
+# Mirrors the rjwalters/repo #32/#33 incident: querying #32 surfaces open #33.
+reset_state
+cat > "$STUB_DIR/timeline-32.json" <<'EOF'
+[
+  {"event": "labeled", "source": {}},
+  {"event": "cross-referenced", "source": {"type": "issue", "issue": {
+      "number": 33, "title": "Rework #32's acceptance criteria", "state": "open",
+      "repository": {"full_name": "owner/repo"}}}}
+]
+EOF
+run_cds --issue 32 --title "Some issue title" --body "Some issue body"
+assert_eq "1" "$RC" "(a) Open cross-reference present -> exit 1"
+assert_contains "$OUT" "RELATED_OPEN_WORK" "(a) RELATED_OPEN_WORK header present"
+assert_contains "$OUT" "#33: Rework #32's acceptance criteria (open issue, cross-references #32)" \
+  "(a) Cross-referencing issue #33 listed with correct format"
+assert_not_contains "$OUT" "DUPLICATE_FOUND" "(a) No keyword-similarity duplicates found separately"
+
+# (a2) Same fixture, but the cross-reference source is itself a PR.
+reset_state
+cat > "$STUB_DIR/timeline-32.json" <<'EOF'
+[
+  {"event": "cross-referenced", "source": {"type": "issue", "issue": {
+      "number": 40, "title": "Implement alternate approach", "state": "open",
+      "pull_request": {"url": "https://example.invalid"},
+      "repository": {"full_name": "owner/repo"}}}}
+]
+EOF
+run_cds --issue 32 --title "Some issue title"
+assert_eq "1" "$RC" "(a2) Open cross-referencing PR -> exit 1"
+assert_contains "$OUT" "PR #40: Implement alternate approach (open PR, cross-references #32)" \
+  "(a2) Cross-referencing PR #40 listed with PR-specific format"
+
+# (b) Closed cross-reference and self-reference are excluded.
+reset_state
+cat > "$STUB_DIR/timeline-50.json" <<'EOF'
+[
+  {"event": "cross-referenced", "source": {"type": "issue", "issue": {
+      "number": 51, "title": "Closed related work", "state": "closed",
+      "repository": {"full_name": "owner/repo"}}}},
+  {"event": "cross-referenced", "source": {"type": "issue", "issue": {
+      "number": 50, "title": "Self reference", "state": "open",
+      "repository": {"full_name": "owner/repo"}}}}
+]
+EOF
+run_cds --issue 50 --title "Some issue title"
+assert_eq "0" "$RC" "(b) Only closed/self cross-references -> exit 0 (nothing to surface)"
+assert_not_contains "$OUT" "RELATED_OPEN_WORK" "(b) No RELATED_OPEN_WORK block emitted"
+assert_not_contains "$OUT" "#51" "(b) Closed cross-reference #51 excluded"
+assert_not_contains "$OUT" "#50" "(b) Self-reference #50 excluded"
+
+# (c) No cross-references at all -> behavior identical to a plain run.
+reset_state
+run_cds --issue 60 --title "Some issue title"
+assert_eq "0" "$RC" "(c) No cross-references -> exit 0"
+assert_not_contains "$OUT" "RELATED_OPEN_WORK" "(c) No RELATED_OPEN_WORK block when timeline is empty"
+
+# (d) Invocation WITHOUT --issue is byte-identical to a --issue run with no
+# cross-references (Architect/Hermit/Auditor non-regression: they never pass
+# --issue, so their behavior must be untouched by this feature).
+reset_state
+run_cds --title "Some issue title"
+OUT_NO_ISSUE="$OUT"
+RC_NO_ISSUE="$RC"
+run_cds --issue 60 --title "Some issue title"
+assert_eq "$OUT_NO_ISSUE" "$OUT" "(d) --issue with no cross-refs -> output byte-identical to no --issue at all"
+assert_eq "$RC_NO_ISSUE" "$RC" "(d) --issue with no cross-refs -> exit code identical to no --issue at all"
+
+# (e) Timeline API failure -> probe skipped with a stderr warning, base
+# similarity check result (and its exit code) is unaffected by the failure.
+reset_state
+: > "$STUB_DIR/timeline-fail"
+run_cds --issue 70 --title "Some issue title"
+assert_eq "0" "$RC" "(e) Timeline API failure -> exit code driven by similarity check alone"
+assert_not_contains "$OUT" "RELATED_OPEN_WORK" "(e) Timeline API failure -> probe result skipped, not surfaced"
+assert_contains "$ERR" "Failed to fetch timeline" "(e) Timeline API failure -> stderr warning emitted"
+
+# (f) --json output includes a "cross_reference" typed entry.
+reset_state
+cat > "$STUB_DIR/timeline-32.json" <<'EOF'
+[
+  {"event": "cross-referenced", "source": {"type": "issue", "issue": {
+      "number": 33, "title": "Rework #32's acceptance criteria", "state": "open",
+      "repository": {"full_name": "owner/repo"}}}}
+]
+EOF
+run_cds --issue 32 --title "Some issue title" --json
+assert_eq "1" "$RC" "(f) --json with a cross-reference -> exit 1"
+assert_contains "$OUT" '"type": "cross_reference"' "(f) --json output tags the entry as type cross_reference"
+duplicate_found="$(echo "$OUT" | jq -r '.duplicate_found')"
+assert_eq "true" "$duplicate_found" "(f) --json duplicate_found is true when only related work is present"
+cross_num="$(echo "$OUT" | jq -r '.matches[] | select(.type == "cross_reference") | .number')"
+assert_eq "33" "$cross_num" "(f) --json cross_reference entry carries the correct issue number"
+
+# (g) Non-GitHub-forge-style failure (repo can't be resolved) degrades
+# gracefully: probe skipped, similarity check unaffected, no hard failure.
+reset_state
+: > "$STUB_DIR/repo-view-fail"
+run_cds --issue 80 --title "Some issue title"
+assert_eq "0" "$RC" "(g) repo view failure -> exit code driven by similarity check alone"
+assert_not_contains "$OUT" "RELATED_OPEN_WORK" "(g) repo view failure -> probe result skipped"
+assert_contains "$ERR" "Failed to resolve repository" "(g) repo view failure -> stderr warning emitted"
+
+# --- Summary ---
+echo ""
+echo "────────────────────────────────"
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

`check-duplicate.sh`'s keyword-similarity check answers "has this been reported before?" — it is structurally blind to an **open issue that critiques/rewrites the target's spec** via a `#N` cross-reference in its body, since that's a *different open issue with low title/text similarity*, not a duplicate.

Real incident this closes: rjwalters/repo #33 named #32 three times in its body, arguing #32's acceptance criteria were wrong. It was never surfaced to the Curator (it isn't a duplicate — it's a critique), so #32 was curated and shipped against a spec that other open work had already argued would not work.

## Changes

- **`defaults/scripts/check-duplicate.sh`**: new `--issue N` flag. Probes GitHub's timeline API (`gh api repos/OWNER/REPO/issues/N/timeline --paginate`, same `cross-referenced` event pattern `/loom:sweep`'s existing-PR probe already uses) for **open** issues/PRs whose body/comments cross-reference `N`, excluding closed sources and self-references. Emits a `RELATED_OPEN_WORK` block **distinct from** `DUPLICATE_FOUND`, and a `"type": "cross_reference"` entry in `--json` output. GitHub-only — a non-GitHub forge or any API failure degrades gracefully (stderr warning, probe skipped, similarity results unaffected), same pattern as the existing `search_merged_prs()` degradation. **Additive/non-breaking**: Architect/Hermit/Auditor never pass `--issue` (no issue number exists pre-creation), so their behavior is byte-for-byte unchanged — verified by a test asserting output parity with/without `--issue` when there's nothing to surface.
- **`defaults/roles/curator.md`** (this repo self-hosts via a `.loom/roles` ⇄ `defaults/roles` symlink, and `defaults/roles/curator.md` ⇄ `defaults/.claude/commands/loom/curator.md` symlink, so this is genuinely one file, not two kept in sync by hand): the Duplicate Detection invocation now passes `--issue "<number>"`, and a new **"Related Open Work (Cross-References)"** section requires the curator's enhancement comment to explicitly acknowledge **every** `RELATED_OPEN_WORK` entry as either **absorbed** (AC changed, cite the cross-reference) or **disregarded** (reason stated) — silence is not a valid outcome, per the issue's acceptance criteria.
- **`defaults/scripts/tests/test-check-duplicate.sh`** (new): black-box tests that stub `gh`/`loom-forge` on `PATH` and invoke the real script as a subprocess (it's a full CLI script, not sourced functions — mirrors the invocation style of `test-rebase-stacked-children.sh` for the stub pattern). 24 assertions covering:
  - the #32/#33-shaped fixture (open cross-referencing issue → `RELATED_OPEN_WORK`, exit 1), including a PR-sourced variant
  - closed-cross-reference and self-reference exclusion
  - no-cross-reference behavior parity with a plain (no `--issue`) invocation
  - timeline-API-failure and repo-view-failure graceful degradation (stderr warning, base similarity check unaffected)
  - `--json` `"type": "cross_reference"` entries

## Out of scope (explicit follow-up, not this PR)

The issue's AC lists, as an optional "consider" (not a hard requirement): extending the same cross-reference probe to `/loom:sweep`'s per-issue pre-flight. I've kept that out of this PR to bound the diff to the Curator path the incident actually hit — the `--issue N` / `--json` `cross_reference` type is shaped so a follow-up can wire it into the sweep pre-flight without another script change, per the curator's original scoping guidance on this issue.

## Test plan

- [x] `bash defaults/scripts/tests/test-check-duplicate.sh` — 24/24 passed
- [x] `shellcheck` clean on both `check-duplicate.sh` and the new test
- [x] Live smoke test: `./.loom/scripts/check-duplicate.sh --issue 4162 --title "..."` against the real repo — runs cleanly, no crash, correct graceful output
- [x] Verified `defaults/roles/curator.md` and `defaults/.claude/commands/loom/curator.md` are symlinked (one file) so there's no byte-identical-copy drift risk

Closes #4162