### PR TITLE
fix(daemon): render a deterministic PATH into the launchd plist

### DIFF
--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -74,6 +74,14 @@
 #                        user/$(id -u)); honored verbatim, else auto-resolved
 #                        gui→user (#4130). A pinned domain that does not resolve
 #                        fails loudly at bootstrap rather than falling back.
+#   LOOM_DAEMON_PATH        Full override for the rendered plist's PATH (#4172).
+#                        Used verbatim -- no canonical fallback is appended. For
+#                        a host that needs a wholly custom PATH.
+#   LOOM_DAEMON_PATH_EXTRA  Extra dir(s) to prepend onto the canonical minimal
+#                        PATH (#4172) instead of overriding it entirely -- for
+#                        a host that needs one or two additional dirs (e.g. a
+#                        project-local toolchain) without inheriting the WHOLE
+#                        invoking shell's interactive PATH.
 #
 # Exit codes:
 #   0  daemon started (or already running)
@@ -160,6 +168,59 @@ if [[ -r "$_LOOM_LAUNCHD_LIB_DIR/launchd-domain.sh" ]]; then
     source "$_LOOM_LAUNCHD_LIB_DIR/launchd-domain.sh"
 fi
 
+# resolve_plist_path() — the deterministic PATH baked into every rendered
+# plist (daemon + watchdog), issue #4172. Previously the rendered PATH was
+# "$PATH:<canonical fallback>" -- the INVOKING SHELL's entire interactive
+# PATH prefixed onto the fallback set -- which made a re-render non-hermetic:
+# whoever's shell happened to run `loom-daemon-start.sh` (or
+# `loom-daemon-update.sh --relaunch`) determined the daemon's tool
+# resolution, and an unrelated project-specific toolchain earlier in that
+# PATH could shadow the binaries the daemon and its sweep children expect.
+# Resolution order (highest precedence first), always logged to STDERR (never
+# stdout, so `--print-plist`'s XML output stays pipeable/diffable):
+#   1. LOOM_DAEMON_PATH      -- full override, used verbatim (no fallback
+#                               appended). For a host that needs a wholly
+#                               custom PATH.
+#   2. LOOM_DAEMON_PATH_EXTRA -- prepended onto the canonical minimal PATH,
+#                               for a host that needs one or two additional
+#                               dirs without inheriting the whole invoking
+#                               shell's interactive PATH.
+#   3. Default: the canonical minimal PATH -- exactly the pre-#4172 fallback
+#      set (~/.local/bin, ~/.cargo/bin, Homebrew, standard bin dirs, already
+#      sufficient for gh/git/cargo/python3), with NO shell-PATH prefix. This
+#      makes a bare re-render byte-for-byte reproducible across hosts/sessions.
+resolve_plist_path() {
+    local canonical="${HOME}/.local/bin:${HOME}/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    if [[ -n "${LOOM_DAEMON_PATH:-}" ]]; then
+        echo "Rendered plist PATH: full override via LOOM_DAEMON_PATH -> ${LOOM_DAEMON_PATH}" >&2
+        printf '%s' "${LOOM_DAEMON_PATH}"
+        return 0
+    fi
+    if [[ -n "${LOOM_DAEMON_PATH_EXTRA:-}" ]]; then
+        echo "Rendered plist PATH: canonical minimal PATH + LOOM_DAEMON_PATH_EXTRA -> ${LOOM_DAEMON_PATH_EXTRA}:${canonical}" >&2
+        printf '%s' "${LOOM_DAEMON_PATH_EXTRA}:${canonical}"
+        return 0
+    fi
+    echo "Rendered plist PATH: canonical minimal PATH (deterministic default) -> ${canonical}" >&2
+    printf '%s' "$canonical"
+}
+
+# extract_plist_path_value <plist_file> — best-effort textual extraction of
+# the <key>PATH</key>\n<string>VALUE</string> pair from a rendered launchd
+# plist. Deliberately NOT a general plist parser (no plutil/jq dependency) --
+# every plist this script renders follows that exact two-line shape, so a
+# simple awk match is sufficient. Used only by the --print-plist drift check
+# below; returns empty (and exit 1) when the key is absent or the file is
+# missing.
+extract_plist_path_value() {
+    local plist_file="$1"
+    [[ -f "$plist_file" ]] || return 1
+    awk '
+        /<key>PATH<\/key>/ { want=1; next }
+        want { sub(/^[ \t]*<string>/, ""); sub(/<\/string>[ \t]*$/, ""); print; exit }
+    ' "$plist_file"
+}
+
 # render_launchd_plist <label> <daemon_bin> <workdir> <log_path>
 # Prints the LaunchAgent plist XML to stdout. Mirrors the hand-written plist
 # that validated the #3972 fix during the incident
@@ -191,17 +252,28 @@ fi
 # (nothing would bring it back). Because it survives in the plist, the relaunched
 # daemon still sees it.
 #
-# The PATH is the CURRENT PATH plus a fallback set (~/.local/bin, ~/.cargo/bin,
-# Homebrew, standard bin dirs) so `gh`, `git`, `cargo`, and `python3` resolve
-# inside the LaunchAgent's minimal launchd environment even if the interactive
-# shell's PATH customizations aren't present there. Every already-exported
-# LOOM_* / GH_TOKEN / GITEA_TOKEN / FORGE_TOKEN var is forwarded verbatim so
-# the launchd job sees EXACTLY the autonomy flags and auth this invocation
-# resolved -- never wider, never narrower (#3972 AC: "preserves the current
-# flag semantics").
+# The PATH baked into the plist is DETERMINISTIC (#4172), not derived from the
+# invoking shell's PATH. It used to be "$PATH:<fallback>" -- the invoking
+# shell/session's ENTIRE interactive PATH prefixed onto a fallback set -- so a
+# re-render (e.g. a `loom-daemon-update.sh --relaunch` run from an interactive
+# terminal with a large project-specific PATH) silently replaced whatever PATH
+# the live plist carried with whoever's shell happened to run the roll:
+# non-hermetic, non-reproducible across hosts/sessions, and able to let an
+# unrelated toolchain earlier in that PATH shadow the binaries the daemon and
+# its sweep children expect (gh/git/cargo/python3). resolve_plist_path() (see
+# above) instead resolves, in order: an explicit LOOM_DAEMON_PATH override
+# (verbatim), LOOM_DAEMON_PATH_EXTRA prepended onto the canonical minimal PATH,
+# or the canonical minimal PATH alone (~/.local/bin, ~/.cargo/bin, Homebrew,
+# standard bin dirs -- the same fallback set this always carried, just no
+# longer prefixed with the invoking shell's PATH). It is computed exactly once
+# per script invocation into $PLIST_PATH_VALUE and logs its choice to stderr.
+# Every already-exported LOOM_* / GH_TOKEN / GITEA_TOKEN / FORGE_TOKEN var is
+# still forwarded verbatim so the launchd job sees EXACTLY the autonomy flags
+# and auth this invocation resolved -- never wider, never narrower (#3972 AC:
+# "preserves the current flag semantics").
 render_launchd_plist() {
     local label="$1" bin="$2" workdir="$3" log_path="$4"
-    local plist_path_value="${PATH}:${HOME}/.local/bin:${HOME}/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    local plist_path_value="$PLIST_PATH_VALUE"
 
     local env_entries=""
     env_entries+="        <key>PATH</key>\n        <string>$(xml_escape "$plist_path_value")</string>\n"
@@ -302,9 +374,11 @@ locate_watchdog_script() {
 }
 
 # render_watchdog_plist <label> <watchdog_script> <workdir> <log_path> <interval_secs>
+# Uses the SAME deterministic PATH as render_launchd_plist (#4172) -- see the
+# resolve_plist_path() comment above render_launchd_plist for the rationale.
 render_watchdog_plist() {
     local label="$1" script="$2" workdir="$3" log_path="$4" interval="$5"
-    local plist_path_value="${PATH}:${HOME}/.local/bin:${HOME}/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    local plist_path_value="$PLIST_PATH_VALUE"
     printf '<?xml version="1.0" encoding="UTF-8"?>\n'
     printf '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
     printf '<plist version="1.0">\n<dict>\n'
@@ -405,6 +479,12 @@ if [[ -z "$DAEMON_BIN" ]]; then
     echo "Build it (cargo build --release -p loom-daemon) or set LOOM_DAEMON_BIN=/path/to/loom-daemon" >&2
     exit 1
 fi
+
+# ---------- deterministic plist PATH (#4172) ----------
+# Resolved ONCE per invocation so both the daemon plist and the watchdog
+# plist (below) render the identical PATH, and so the choice is logged to
+# stderr exactly once per run rather than once per plist rendered.
+PLIST_PATH_VALUE="$(resolve_plist_path)"
 
 PID_FILE="$REPO_ROOT/.loom/.daemon.pid"
 SOCKET_PATH="${LOOM_SOCKET_PATH:-$HOME/.loom/loom-daemon.sock}"
@@ -544,6 +624,23 @@ fi
 # ---------- --print-plist: pure inspection, no side effects ----------
 if [[ "$PRINT_PLIST" == "true" ]]; then
     render_launchd_plist "$(resolve_launchd_label)" "$DAEMON_BIN" "$REPO_ROOT" "$START_LOG"
+    # PATH-drift check (#4172): if a live plist is already installed for this
+    # label, compare its PATH against the one just rendered and warn (stderr
+    # only -- READ-ONLY, no side effect) when they differ. This is what makes
+    # a PATH change from the live plist visible at inspection/roll time
+    # instead of silently swapping it out on the next real start/relaunch.
+    _live_plist="$HOME/Library/LaunchAgents/$(resolve_launchd_label).plist"
+    if [[ -f "$_live_plist" ]]; then
+        _live_path="$(extract_plist_path_value "$_live_plist" 2>/dev/null || true)"
+        if [[ -n "$_live_path" && "$_live_path" != "$PLIST_PATH_VALUE" ]]; then
+            {
+                echo ""
+                echo "PATH DRIFT DETECTED vs the installed plist ($_live_plist):"
+                echo "- live: $_live_path"
+                echo "+ new:  $PLIST_PATH_VALUE"
+            } >&2
+        fi
+    fi
     exit 0
 fi
 

--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -360,8 +360,11 @@ launchd_job_pid() {
 # harvest_plist_env <plist> — echo the live plist's EnvironmentVariables,
 # restricted to exactly the keys render_launchd_plist itself forwards (LOOM_*,
 # GH_TOKEN, GITEA_TOKEN, FORGE_TOKEN) and EXCLUDING:
-#   - PATH / HOME     (start.sh rebuilds PATH from the live shell; round-tripping
-#                      the plist's already-extended PATH would grow it each roll),
+#   - PATH / HOME     (start.sh resolves PATH deterministically -- a pinned
+#                      canonical minimal PATH by default, or an explicit
+#                      LOOM_DAEMON_PATH / LOOM_DAEMON_PATH_EXTRA override,
+#                      #4172; round-tripping the plist's PATH here would
+#                      re-introduce the non-deterministic-render bug),
 #   - LOOM_DAEMON_SUPERVISOR (start.sh hardcodes it; re-exporting is pointless).
 # Emits one "<key>\t<base64(value)>" line per key so values containing spaces or
 # newlines survive. Fails loudly (return 2) when the plist is absent or

--- a/defaults/scripts/tests/test-loom-daemon-launchd-plist.sh
+++ b/defaults/scripts/tests/test-loom-daemon-launchd-plist.sh
@@ -181,6 +181,84 @@ default_plist=$( cd "$WORKDIR" && env -u LOOM_LAUNCHD_DOMAIN -u LOOM_WORK_FINDER
 assert_not_contains "$default_plist" "gui/$(id -u)" "default plist carries no gui/<uid> domain token (#4130 — domain is load-time, GUI path unchanged)"
 assert_not_contains "$default_plist" "user/$(id -u)" "default plist carries no user/<uid> domain token (#4130 — domain is load-time)"
 
+# ---------- #4172: deterministic plist PATH ----------
+# Root cause under test: the rendered plist's PATH used to be "$PATH:<canonical
+# fallback>" -- the INVOKING SHELL's entire interactive PATH prefixed onto the
+# fallback set -- so a re-render (e.g. `loom-daemon-update.sh --relaunch`)
+# silently replaced whatever PATH the live plist carried with whoever's shell
+# happened to run the roll. Tests 10-14 below cover the fix: a deterministic
+# canonical-by-default PATH, an explicit full-override / extend-only escape
+# hatch, and a diff-friendly drift check against a previously-installed plist.
+
+# 10. Default (no LOOM_DAEMON_PATH / LOOM_DAEMON_PATH_EXTRA): the invoking
+#     shell's PATH is NOT prefixed onto the rendered plist -- a marker dir
+#     injected into PATH must not leak through, while the canonical fallback
+#     set is still present (unchanged from before #4172).
+MARKER_DIR="/tmp/loom-test-marker-4172-$$"
+det_out=$( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE -u LOOM_DAEMON_PATH -u LOOM_DAEMON_PATH_EXTRA \
+    PATH="${MARKER_DIR}:${PATH}" LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --print-plist 2>/dev/null )
+assert_not_contains "$det_out" "$MARKER_DIR" "default plist PATH does NOT leak the invoking shell's PATH (#4172 — deterministic, not shell-derived)"
+assert_contains "$det_out" "/.local/bin" "default plist PATH still includes the canonical ~/.local/bin fallback"
+assert_contains "$det_out" "/opt/homebrew/bin" "default plist PATH still includes the canonical Homebrew fallback"
+
+# 11. LOOM_DAEMON_PATH is a FULL override -- used verbatim, no canonical
+#     fallback appended.
+override_out=$( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE -u LOOM_DAEMON_PATH_EXTRA \
+    LOOM_DAEMON_PATH="/custom/override/bin:/custom/override/sbin" \
+    LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --print-plist 2>/dev/null )
+assert_contains "$override_out" $'<key>PATH</key>\n        <string>/custom/override/bin:/custom/override/sbin</string>' "LOOM_DAEMON_PATH is used verbatim as the plist PATH"
+assert_not_contains "$override_out" "/opt/homebrew/bin" "LOOM_DAEMON_PATH override does NOT append the canonical fallback"
+
+# 12. LOOM_DAEMON_PATH_EXTRA prepends onto the canonical minimal PATH instead
+#     of replacing it entirely.
+extra_out=$( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE -u LOOM_DAEMON_PATH \
+    LOOM_DAEMON_PATH_EXTRA="/extra/project/bin" \
+    LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --print-plist 2>/dev/null )
+assert_contains "$extra_out" "/extra/project/bin:" "LOOM_DAEMON_PATH_EXTRA is prepended onto the plist PATH"
+assert_contains "$extra_out" "/opt/homebrew/bin" "LOOM_DAEMON_PATH_EXTRA still carries the canonical Homebrew fallback"
+
+# 13. The chosen PATH is always logged (stderr) -- visible at every render,
+#     not just on inspection.
+log_out=$( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE -u LOOM_DAEMON_PATH -u LOOM_DAEMON_PATH_EXTRA \
+    LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --print-plist 2>&1 >/dev/null )
+assert_contains "$log_out" "Rendered plist PATH: canonical minimal PATH (deterministic default)" "default render logs its PATH choice to stderr"
+log_override_out=$( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE -u LOOM_DAEMON_PATH_EXTRA \
+    LOOM_DAEMON_PATH="/custom/override/bin" LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --print-plist 2>&1 >/dev/null )
+assert_contains "$log_override_out" "Rendered plist PATH: full override via LOOM_DAEMON_PATH" "LOOM_DAEMON_PATH override logs its source to stderr"
+
+# 14. --print-plist PATH-drift check: a change from a previously-installed
+#     live plist is visible (diff-friendly), not silently swapped out.
+#     Isolated via a scratch HOME so this never touches the operator's real
+#     ~/Library/LaunchAgents.
+NODRIFT_HOME="$WORKDIR/fakehome-nodrift"
+NODRIFT_LABEL="com.rjwalters.loom-daemon-nodrift-test"
+mkdir -p "$NODRIFT_HOME/Library/LaunchAgents"
+HOME="$NODRIFT_HOME" LOOM_LAUNCHD_LABEL="$NODRIFT_LABEL" LOOM_DAEMON_BIN="$FAKE_BIN" \
+    env -u LOOM_DAEMON_PATH -u LOOM_DAEMON_PATH_EXTRA -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    bash "$START_SCRIPT" --print-plist > "$NODRIFT_HOME/Library/LaunchAgents/${NODRIFT_LABEL}.plist" 2>/dev/null
+nodrift_out=$( HOME="$NODRIFT_HOME" LOOM_LAUNCHD_LABEL="$NODRIFT_LABEL" LOOM_DAEMON_BIN="$FAKE_BIN" \
+    env -u LOOM_DAEMON_PATH -u LOOM_DAEMON_PATH_EXTRA -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    bash "$START_SCRIPT" --print-plist 2>&1 >/dev/null )
+assert_not_contains "$nodrift_out" "PATH DRIFT DETECTED" "no drift warning when the live plist's PATH already matches the freshly-rendered one"
+
+DRIFT_HOME="$WORKDIR/fakehome-drift"
+DRIFT_LABEL="com.rjwalters.loom-daemon-drift-test"
+mkdir -p "$DRIFT_HOME/Library/LaunchAgents"
+cat > "$DRIFT_HOME/Library/LaunchAgents/${DRIFT_LABEL}.plist" <<'PLISTEOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+<key>PATH</key>
+<string>/old/stale/shell/path:/usr/bin</string>
+</dict></plist>
+PLISTEOF
+drift_out=$( HOME="$DRIFT_HOME" LOOM_LAUNCHD_LABEL="$DRIFT_LABEL" LOOM_DAEMON_BIN="$FAKE_BIN" \
+    env -u LOOM_DAEMON_PATH -u LOOM_DAEMON_PATH_EXTRA -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    bash "$START_SCRIPT" --print-plist 2>&1 >/dev/null )
+assert_contains "$drift_out" "PATH DRIFT DETECTED" "a PATH change from the live plist is flagged at --print-plist time"
+assert_contains "$drift_out" "/old/stale/shell/path:/usr/bin" "drift warning shows the OLD (live) PATH value"
+assert_contains "$drift_out" "- live:" "drift warning is diff-friendly (- live / + new lines)"
+assert_contains "$drift_out" "+ new:" "drift warning is diff-friendly (- live / + new lines)"
+
 # ---------- summary ----------
 echo
 echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"


### PR DESCRIPTION
## Summary

`loom-daemon-start.sh` baked `"$PATH:<fallback>"` into the rendered launchd
plist — the invoking shell's entire interactive PATH prefixed onto a
canonical fallback set — so every re-render (e.g. `loom-daemon-update.sh
--relaunch`) silently replaced whatever PATH the live plist carried with
whoever's shell happened to run the roll. This makes the fix deterministic:
the rendered PATH is now a pinned canonical minimal set by default, with an
explicit opt-in override for hosts that genuinely need more, and
`--print-plist` flags a PATH change from the previously installed plist.

## Changes

- Added `resolve_plist_path()` to `defaults/scripts/cli/loom-daemon-start.sh`:
  resolves, in priority order, `LOOM_DAEMON_PATH` (full override, used
  verbatim), `LOOM_DAEMON_PATH_EXTRA` (prepended onto the canonical minimal
  PATH), or the canonical minimal PATH alone (`~/.local/bin`, `~/.cargo/bin`,
  Homebrew, standard bin dirs — the same fallback set as before, just no
  longer prefixed with the invoking shell's PATH). Computed once per
  invocation into `$PLIST_PATH_VALUE` and always logged to stderr.
- Both `render_launchd_plist()` (the daemon job) and `render_watchdog_plist()`
  (the watchdog job) now consume the same `$PLIST_PATH_VALUE` instead of each
  independently prefixing `$PATH`.
- `--print-plist` now also diffs the freshly-rendered PATH against any
  previously installed live plist for the same label
  (`~/Library/LaunchAgents/<label>.plist`) and prints a diff-friendly `- live`
  / `+ new` "PATH DRIFT DETECTED" warning to stderr when they differ — purely
  read-only, no side effects, so drift is visible at roll/inspect time instead
  of being silently swapped in.
- Updated the stale rationale comment in `loom-daemon-update.sh`'s
  `harvest_plist_env()` (it previously said "start.sh rebuilds PATH from the
  live shell", which is no longer accurate).
- Added new documentation for `LOOM_DAEMON_PATH` / `LOOM_DAEMON_PATH_EXTRA` to
  the script's usage/env header comment.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Rendered plist's PATH is deterministic (pinned canonical minimal PATH, or the previous live plist's PATH preserved like `LOOM_*`) | ✅ | Default now resolves to the canonical 8-entry minimal PATH with no shell-PATH prefix (`resolve_plist_path()`); new test confirms a marker directory injected into the invoking shell's `PATH` does NOT leak into the rendered plist |
| Explicit override (env var or flag) exists for hosts that need extra PATH entries, and the render logs the PATH it chose | ✅ | `LOOM_DAEMON_PATH` (full override) and `LOOM_DAEMON_PATH_EXTRA` (extend canonical) env vars added; every render logs its chosen PATH (and which case produced it) to stderr — covered by new tests |
| `--print-plist` output makes a PATH change from the live plist visible (diff-friendly), so drift is noticed at roll time | ✅ | `--print-plist` now compares against `~/Library/LaunchAgents/<label>.plist` when present and prints a `- live` / `+ new` warning on mismatch, silent when they match — covered by new tests using an isolated scratch `HOME` |

## Test Plan

- `./defaults/scripts/tests/test-loom-daemon-launchd-plist.sh` — 42/42 passing (28 pre-existing + 14 new, covering default determinism, `LOOM_DAEMON_PATH`, `LOOM_DAEMON_PATH_EXTRA`, stderr logging, and the drift check both with and without a live plist)
- `./defaults/scripts/tests/test-loom-daemon-start.sh` — 15/15 passing (no regression)
- `./defaults/scripts/tests/test-loom-daemon-update.sh` — 51/51 passing, including the pre-existing `--relaunch ... does NOT round-trip the stale PATH` regression test
- `./defaults/scripts/tests/test-loom-daemon-watchdog.sh` — 12/12 passing
- `./defaults/scripts/tests/test-loom-daemon-stop.sh` — 22/22 passing
- `shellcheck` clean on all three modified files
- `bash -n` syntax check clean

Closes #4172