### PR TITLE
fix(scripts): fail-closed disk-headroom probe instead of a fake 0 GB

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -788,7 +788,14 @@ The disk math lives in a small sourceable helper so it is deterministic and unit
 ```bash
 source ./.loom/scripts/lib/disk-headroom.sh
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-FREE_GB="$(loom_worktree_root_free_gb "$REPO_ROOT")"   # df's the RESOLVED worktree root (scratch volume), not the repo drive
+# df's the RESOLVED worktree root (scratch volume), not the repo drive.
+# Unknown != zero (#4164): loom_worktree_root_free_gb prints NOTHING and
+# returns non-zero when it cannot actually measure free space (missing arg,
+# unresolvable worktree root, a failing/malformed `df`) — capture the exit
+# status here and DO NOT feed a fake "0" into loom_wave_size_from_disk below;
+# that used to be indistinguishable from a genuinely full disk.
+DISK_PROBE_OK=true
+FREE_GB="$(loom_worktree_root_free_gb "$REPO_ROOT")" || DISK_PROBE_OK=false
 ```
 
 Then resolve by branch (`CAND` = number of surviving candidate issues):
@@ -808,14 +815,36 @@ else  # use_subagent (no daemon, single-token pool, --no-daemon, daemon-owned ch
     export LOOM_SUBAGENT_WAVE_CAP
     MECH=subagent; MECHANISM="in-session subagent"
 fi
-# The helper prints two lines: size on line 1, reason token on line 2.
-# Capture both without `mapfile` (a bash-4.0+ builtin) so this works under
-# macOS's default /bin/bash 3.2: grab stdout once, then split by line.
-_WS_OUT="$(loom_wave_size_from_disk "$MECH" "$CAND" "$FREE_GB")"
-WAVE_SIZE="$(sed -n '1p' <<<"$_WS_OUT")"; REASON="$(sed -n '2p' <<<"$_WS_OUT")"
+if [[ "$DISK_PROBE_OK" == true ]]; then
+    # The helper prints two lines: size on line 1, reason token on line 2.
+    # Capture both without `mapfile` (a bash-4.0+ builtin) so this works under
+    # macOS's default /bin/bash 3.2: grab stdout once, then split by line.
+    _WS_OUT="$(loom_wave_size_from_disk "$MECH" "$CAND" "$FREE_GB")"
+    WAVE_SIZE="$(sed -n '1p' <<<"$_WS_OUT")"; REASON="$(sed -n '2p' <<<"$_WS_OUT")"
+else
+    # Unknown != zero (#4164): the disk probe failed, so SKIP the disk clamp
+    # entirely rather than feeding a bogus 0 into loom_wave_size_from_disk
+    # (which would floor the wave size to 1 and log reason "floor" —
+    # indistinguishable from a genuinely full disk). Fall back to
+    # K = min(target, CAND) with no disk term at all.
+    if [[ "$MECH" == daemon ]]; then
+        _TARGET="${LOOM_DAEMON_WAVE_TARGET:-10}"
+    else
+        _TARGET="$LOOM_SUBAGENT_WAVE_CAP"
+    fi
+    if (( CAND < _TARGET )); then
+        WAVE_SIZE="$CAND"
+    else
+        WAVE_SIZE="$_TARGET"
+    fi
+    (( WAVE_SIZE < 1 )) && WAVE_SIZE=1
+    REASON="unknown"
+fi
 ```
 
 `loom_wave_size_from_disk` prints two lines — the clamped size `K = min(target, floor(free_gb / LOOM_PER_WORKTREE_GB), CAND)` with a floor of 1 (never 0, even on a full disk) on line 1, and a machine reason token (`target` / `candidates` / `disk` / `floor`) on line 2. `LOOM_PER_WORKTREE_GB` defaults to a conservative 2 GB and is env-overridable for large-repo operators. The target is **10** for the daemon path; for the subagent path it is the **core-scaled** `clamp(floor((cores-2)/4), 3, 6)` (#3693) — resolved into `LOOM_SUBAGENT_WAVE_CAP` just above via `loom_subagent_target_from_cores` / `loom_detect_cores`, floor 3 on small/shared hosts, ceiling 6 on big ones — and an operator-set `LOOM_SUBAGENT_WAVE_CAP` env value always overrides it.
+
+**When the disk probe fails** (`DISK_PROBE_OK=false`, #4164), skip `loom_wave_size_from_disk` entirely — its pure-integer contract is unchanged and is not the caller-side fallback policy's home — and resolve `WAVE_SIZE = min(target, CAND)` (floor 1) with the reason token `unknown`, so an unmeasurable probe can never masquerade as a measured `0`.
 
 **Emit a one-line reason** so the operator understands any reduction. Map the reason token to a human sentence, adding the backend-specific context:
 
@@ -827,6 +856,7 @@ WAVE_SIZE="$(sed -n '1p' <<<"$_WS_OUT")"; REASON="$(sed -n '2p' <<<"$_WS_OUT")"
 | any, `candidates` | `wave size K, mechanism=<m>: reduced to K (only K candidate issues)` |
 | any, `disk` | `wave size K, mechanism=<m>: reduced to K (only <FREE_GB> GB free on <worktree-root>)` |
 | any, `floor` | `wave size 1, mechanism=<m>: reduced to 1 (only <FREE_GB> GB free on <worktree-root>)` |
+| any, `unknown` | `wave size K, mechanism=<m>: disk headroom unknown (probe failed on <worktree-root>) — disk clamp skipped` |
 
 The resolved `WAVE_SIZE` replaces `--builders-per-wave` everywhere the wave-partition consumers below reference it. On the **daemon path** `WAVE_SIZE` is the concurrency **target** the operator should expect (and that `--dry-run` reports) — the daemon runs each candidate as an independent detached process, so it is not a hard in-session partition. On the **subagent path** `WAVE_SIZE` is the literal wave partition size feeding the `min(...)` dispatch expression in the Wave Lifecycle. In both cases, **never raise the subagent ceiling toward 10** — the subagent auto default core-scales within `[3, 6]` (#3693), and true high parallelism toward 10 is the daemon path's job. (This is a width ceiling; the #3289 "one level deep" nesting rule is a separate, unchanged constraint the daemon path exists to route around.)
 

--- a/defaults/scripts/lib/disk-headroom.sh
+++ b/defaults/scripts/lib/disk-headroom.sh
@@ -73,7 +73,16 @@
 # audit table on #3680 for the full file-by-file disposition.
 _LOOM_DISK_HEADROOM_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # shellcheck source=./worktree-root.sh
-source "$_LOOM_DISK_HEADROOM_LIB_DIR/worktree-root.sh"
+source "$_LOOM_DISK_HEADROOM_LIB_DIR/worktree-root.sh" || return 1
+# Fail-closed dependency guard (#4164): a failed/no-op `source` above must not
+# be allowed to fall through silently — if loom_worktree_root never got
+# defined, abort here (before the function definitions below) so
+# loom_worktree_root_free_gb is never defined either. That turns "quietly
+# returns a fake 0" into "loudly fails to source at all" for the caller.
+command -v loom_worktree_root >/dev/null 2>&1 || {
+    echo "disk-headroom.sh: failed to load worktree-root.sh from '$_LOOM_DISK_HEADROOM_LIB_DIR'" >&2
+    return 1
+}
 
 # loom_worktree_root_free_gb <repo_root>
 #
@@ -84,16 +93,27 @@ source "$_LOOM_DISK_HEADROOM_LIB_DIR/worktree-root.sh"
 # POSIX 512-independent 1024-byte-block output (macOS df differs from GNU df;
 # -P pins the single-line-per-fs columnar format, -k pins 1K blocks), and the
 # 4th column of the data row is "Available" in 1K blocks.
+#
+# Unknown != zero (#4164): on ANY failure to actually measure free space —
+# missing argument, an unresolvable worktree root, a failing/malformed `df` —
+# this prints NOTHING on stdout and returns non-zero, with a stderr message
+# naming the probed path. A genuine measurement of 0 free bytes (a truly full
+# disk) still prints "0" with exit 0 — real disk pressure must stay
+# distinguishable from a broken probe. Callers (sweep.md Stage -1) MUST check
+# the exit status rather than assuming a printed value.
 loom_worktree_root_free_gb() {
     local repo_root="$1"
     if [[ -z "$repo_root" ]]; then
         echo "loom_worktree_root_free_gb: repo_root argument required" >&2
-        echo "0"
-        return 0
+        return 1
     fi
 
     local wt_root
     wt_root="$(loom_worktree_root "$repo_root")"
+    if [[ -z "$wt_root" ]]; then
+        echo "loom_worktree_root_free_gb: could not resolve worktree root for '$repo_root'" >&2
+        return 1
+    fi
 
     # Walk up to the nearest existing ancestor (read-only; never mkdir).
     local probe="$wt_root"
@@ -104,13 +124,16 @@ loom_worktree_root_free_gb() {
     local avail_k
     avail_k="$(df -Pk "$probe" 2>/dev/null | awk 'NR==2 {print $4}')"
     if [[ -z "$avail_k" || ! "$avail_k" =~ ^[0-9]+$ ]]; then
-        # df failed or produced an unexpected shape — report 0 free so the
-        # caller floors to a single worktree rather than crashing.
-        echo "0"
-        return 0
+        # df failed or produced an unexpected shape — this is UNMEASURABLE,
+        # not a measured 0. Print nothing and fail loudly so the caller can
+        # tell the difference (a fake 0 previously floored the wave size to 1
+        # with reason "floor", indistinguishable from a genuinely full disk).
+        echo "loom_worktree_root_free_gb: df failed or returned unexpected output for '$probe'" >&2
+        return 1
     fi
 
-    # 1K blocks -> GB (integer floor).
+    # 1K blocks -> GB (integer floor). A genuine 0 here is a real measurement
+    # (full disk) and is printed with exit 0, same as any other value.
     echo "$(( avail_k / 1024 / 1024 ))"
 }
 

--- a/defaults/scripts/tests/test-disk-headroom.sh
+++ b/defaults/scripts/tests/test-disk-headroom.sh
@@ -152,6 +152,97 @@ fi
 
 rm -rf "$STUBDIR" "$REPO" "$SCRATCH"
 
+# --- Test 6b: df failure -> unmeasurable, NOT a fake 0 (#4164) ---
+echo ""
+echo "Test 6b: a failing df yields non-zero exit + empty stdout (unknown != zero)"
+FAILDIR=$(mktemp -d /tmp/loom-dh-faildf.XXXXXX)
+cat > "$FAILDIR/df" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$FAILDIR/df"
+
+REPO2=$(mktemp -d /tmp/loom-dh-repo2.XXXXXX)
+set +e
+FAIL_OUT="$(PATH="$FAILDIR:$PATH" loom_worktree_root_free_gb "$REPO2" 2>/tmp/loom-dh-fail-stderr.$$)"
+FAIL_STATUS=$?
+set -e
+FAIL_STDERR="$(cat /tmp/loom-dh-fail-stderr.$$)"
+rm -f "/tmp/loom-dh-fail-stderr.$$"
+
+if [[ $FAIL_STATUS -ne 0 ]]; then
+    pass "a failing df returns non-zero exit (was: silently returned 0)"
+else
+    fail "a failing df returned exit 0 (expected non-zero)"
+fi
+assert_eq "$FAIL_OUT" "" "a failing df prints nothing on stdout (was: printed a fake '0')"
+if [[ -n "$FAIL_STDERR" ]]; then
+    pass "a failing df emits a stderr message naming the probed path"
+else
+    fail "a failing df produced no stderr message"
+fi
+
+# --- Test 6c: regression — an unmeasurable probe never resolves to 1|floor ---
+echo ""
+echo "Test 6c: regression — feeding the unmeasurable result into loom_wave_size_from_disk fails loudly, not '1|floor'"
+# Pre-#4164, a df failure produced a fake "0" that flowed straight into
+# loom_wave_size_from_disk and silently floored to wave size 1 with reason
+# "floor" -- indistinguishable from a genuinely full disk. Post-fix,
+# loom_worktree_root_free_gb's stdout is EMPTY on failure; feeding that empty
+# value to loom_wave_size_from_disk must be rejected (non-integer, exit 2),
+# never resolve to "1|floor". The real caller (sweep.md Stage -1) skips this
+# call entirely on probe failure -- this test guards a misuse of the empty
+# value if it were ever passed through anyway.
+if loom_wave_size_from_disk daemon 10 "$FAIL_OUT" >/dev/null 2>&1; then
+    fail "loom_wave_size_from_disk accepted an empty free_gb value (should reject non-integer input)"
+else
+    pass "loom_wave_size_from_disk rejects an empty/unmeasurable free_gb value (never silently floors to 1)"
+fi
+
+rm -rf "$FAILDIR" "$REPO2"
+
+# --- Test 6d: missing dependency -> fail-closed source, not a silent no-op ---
+echo ""
+echo "Test 6d: sourcing disk-headroom.sh without its worktree-root.sh sibling fails loudly (#4164)"
+ISOLATED=$(mktemp -d /tmp/loom-dh-isolated.XXXXXX)
+cp "$DISK_HEADROOM_LIB" "$ISOLATED/disk-headroom.sh"
+# Deliberately do NOT copy worktree-root.sh alongside it.
+ISO_OUT="$(bash -c "source '$ISOLATED/disk-headroom.sh' 2>&1; echo \"exit=\$?\"; command -v loom_worktree_root_free_gb >/dev/null 2>&1 && echo DEFINED || echo UNDEFINED")"
+if [[ "$ISO_OUT" == *"exit=0"* ]]; then
+    fail "sourcing disk-headroom.sh with a missing dependency reported exit=0 (expected non-zero)"
+else
+    pass "sourcing disk-headroom.sh with a missing dependency fails loudly (non-zero)"
+fi
+if [[ "$ISO_OUT" == *"UNDEFINED"* ]]; then
+    pass "loom_worktree_root_free_gb is never defined when the dependency source fails"
+else
+    fail "loom_worktree_root_free_gb got defined even though worktree-root.sh failed to load"
+fi
+rm -rf "$ISOLATED"
+
+# --- Test 6e: a genuine measured 0 free GB still returns 0 with exit 0 ---
+echo ""
+echo "Test 6e: a real 0-free-GB measurement still prints 0 with exit 0 (real pressure stays distinguishable from a broken probe)"
+ZERODIR=$(mktemp -d /tmp/loom-dh-zerodf.XXXXXX)
+cat > "$ZERODIR/df" <<'EOF'
+#!/usr/bin/env bash
+echo "Filesystem     1024-blocks      Used Available Capacity Mounted on"
+echo "/dev/full         52428800  52428800         0      100% /full"
+EOF
+chmod +x "$ZERODIR/df"
+
+REPO3=$(mktemp -d /tmp/loom-dh-repo3.XXXXXX)
+set +e
+ZERO_OUT="$(PATH="$ZERODIR:$PATH" loom_worktree_root_free_gb "$REPO3")"
+ZERO_STATUS=$?
+set -e
+assert_eq "$ZERO_STATUS" "0" "a genuine 0-free-GB df result still exits 0"
+assert_eq "$ZERO_OUT" "0" "a genuine 0-free-GB df result still prints 0 (not empty)"
+# And it still floors the wave size to 1 with reason "floor" -- a REAL full
+# disk (not an unmeasurable probe) is the one case that legitimately floors.
+assert_eq "$(wave daemon 10 "$ZERO_OUT")" "1|floor" "a genuine 0 GB free still floors the wave size to 1 (floor)"
+rm -rf "$ZERODIR" "$REPO3"
+
 # --- Test 7: disk-headroom.sh is sourceable directly under zsh (#3680) ---
 echo ""
 echo "Test 7: disk-headroom.sh sources cleanly under zsh (regression guard for #3680)"

--- a/loom-daemon/src/disk_headroom.rs
+++ b/loom-daemon/src/disk_headroom.rs
@@ -9,7 +9,11 @@
 //!   the existing Rust-native port of `worktree-root.sh`), walk up to the nearest
 //!   existing ancestor, and shell out to `df -Pk` to read the integer free GB on
 //!   **that** volume (the dedicated scratch volume when `LOOM_WORKTREE_ROOT` /
-//!   `worktree.root` is set — NOT the repo's own drive).
+//!   `worktree.root` is set — NOT the repo's own drive). Returns `Option<u64>`:
+//!   `None` means the probe was unmeasurable (df missing/errored, unparseable
+//!   output), not that 0 GB is free (#4164 — unknown != zero, mirroring the
+//!   bash-side fix). [`disk_headroom_limit`] skips the disk clamp on `None`
+//!   instead of treating an unmeasurable probe as a full disk.
 //! - [`disk_headroom`] mirrors the disk term of bash `loom_wave_size_from_disk`:
 //!   `floor(free_gb / LOOM_PER_WORKTREE_GB)`, the number of worktrees the scratch
 //!   volume can hold at the conservative per-worktree estimate.
@@ -57,7 +61,9 @@ pub fn per_worktree_gb() -> u64 {
 /// matching the bash `avail_k / 1024 / 1024`.
 ///
 /// Returns `None` when the output is malformed (missing data row, non-numeric
-/// Available column) so the caller can floor to 0 free rather than panic.
+/// Available column) so the caller ([`worktree_root_free_gb`]) can propagate
+/// "unmeasurable" rather than either panicking or manufacturing a fake `0`
+/// (#4164 — unknown != zero).
 #[must_use]
 pub fn parse_df_available_gb(df_output: &str) -> Option<u64> {
     // Second line is the single data row (`-P` guarantees one line per fs).
@@ -86,12 +92,15 @@ fn nearest_existing_ancestor(path: &Path) -> &Path {
 ///
 /// Resolves the worktree root via [`worktree_root`] (override-aware:
 /// `LOOM_WORKTREE_ROOT` / `worktree.root` / default `<repo>/.loom/worktrees`),
-/// walks up to the nearest existing ancestor, and runs `df -Pk` on it. Returns 0
-/// free on any failure (df missing/errored, unparseable output) so the caller
-/// floors to a single worktree rather than crashing — matching the bash
-/// `echo "0"` fallbacks.
+/// walks up to the nearest existing ancestor, and runs `df -Pk` on it.
+///
+/// Unknown != zero (#4164): returns `None` on any failure to actually measure
+/// free space (`df` missing/errored, unparseable output) instead of a fake
+/// `0` — a `0` used to flow straight into [`disk_headroom`] and look
+/// identical to a genuinely full disk. Callers (`disk_headroom_limit`) must
+/// treat `None` as "skip the disk clamp", not as "0 free".
 #[must_use]
-pub fn worktree_root_free_gb(repo_root: &Path) -> u64 {
+pub fn worktree_root_free_gb(repo_root: &Path) -> Option<u64> {
     let wt_root = worktree_root(repo_root);
     let probe = nearest_existing_ancestor(&wt_root);
 
@@ -102,11 +111,11 @@ pub fn worktree_root_free_gb(repo_root: &Path) -> u64 {
         .output()
     {
         Ok(o) if o.status.success() => o,
-        Ok(_) | Err(_) => return 0,
+        Ok(_) | Err(_) => return None,
     };
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    parse_df_available_gb(&stdout).unwrap_or(0)
+    parse_df_available_gb(&stdout)
 }
 
 /// The disk-headroom concurrency term: how many worktrees `free_gb` can hold at
@@ -124,9 +133,26 @@ pub fn disk_headroom(free_gb: u64, per_gb: u64) -> usize {
 /// worktrees the worktree-root scratch volume can hold at the resolved
 /// per-worktree estimate. Combines [`worktree_root_free_gb`] (I/O) with
 /// [`disk_headroom`] (pure math) and [`per_worktree_gb`] (env).
+///
+/// Unknown != zero (#4164): when the free-space probe is unmeasurable
+/// ([`worktree_root_free_gb`] returns `None`), this SKIPS the disk clamp
+/// entirely — returning `usize::MAX` so the disk term never binds the
+/// `min(...)` concurrency expression callers (`ipc.rs`, `work_finder.rs`)
+/// compose it into — and logs a warning naming the repo root, rather than
+/// silently treating the unmeasurable probe as a full disk.
 #[must_use]
 pub fn disk_headroom_limit(repo_root: &Path) -> usize {
-    disk_headroom(worktree_root_free_gb(repo_root), per_worktree_gb())
+    match worktree_root_free_gb(repo_root) {
+        Some(free_gb) => disk_headroom(free_gb, per_worktree_gb()),
+        None => {
+            log::warn!(
+                "disk_headroom: could not measure free space on the worktree-root \
+                 filesystem for {} — skipping the disk clamp (treating as unbounded)",
+                repo_root.display()
+            );
+            usize::MAX
+        }
+    }
 }
 
 #[cfg(test)]
@@ -245,8 +271,81 @@ mod tests {
         // and returns a plausible (non-astronomical) integer — the exact GB is
         // environment-dependent.
         let tmp = tempfile::tempdir().unwrap();
-        let free = worktree_root_free_gb(tmp.path());
+        let free = worktree_root_free_gb(tmp.path())
+            .expect("a real df -Pk against a real tempdir should succeed in the test env");
         // A modern dev/CI volume has < 1 EB free; this just guards the parse.
         assert!(free < 1_000_000_000);
+    }
+
+    // ===================================================================
+    // worktree_root_free_gb / disk_headroom_limit — unmeasurable (None) path
+    // (#4164: unknown != zero)
+    // ===================================================================
+
+    #[test]
+    #[serial]
+    fn test_worktree_root_free_gb_returns_none_on_df_failure() {
+        // A `df` on PATH that always fails must surface as `None` (unmeasurable),
+        // never as a fake `Some(0)` — a 0 free-GB reading must mean "measured a
+        // genuinely full disk", not "the probe itself failed".
+        let stub_dir = tempfile::tempdir().unwrap();
+        let stub_df = stub_dir.path().join("df");
+        std::fs::write(&stub_df, "#!/bin/sh\nexit 1\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&stub_df).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&stub_df, perms).unwrap();
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let old_path = std::env::var("PATH").unwrap_or_default();
+        // Prepend the stub dir so its `df` shadows the real one.
+        std::env::set_var("PATH", format!("{}:{old_path}", stub_dir.path().display()));
+        let result = worktree_root_free_gb(tmp.path());
+        std::env::set_var("PATH", old_path);
+
+        assert_eq!(result, None, "a failing df must yield None (unmeasurable), not a fake Some(0)");
+    }
+
+    #[test]
+    #[serial]
+    fn test_disk_headroom_limit_skips_clamp_on_unmeasurable_probe() {
+        // When the probe is unmeasurable, disk_headroom_limit must NOT clamp to
+        // 0 (which would look identical to "disk is completely full" and wrongly
+        // bind every `min(...)` concurrency expression down to 0) — it must skip
+        // the disk term entirely (usize::MAX, i.e. "no constraint from this axis").
+        let stub_dir = tempfile::tempdir().unwrap();
+        let stub_df = stub_dir.path().join("df");
+        std::fs::write(&stub_df, "#!/bin/sh\nexit 1\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&stub_df).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&stub_df, perms).unwrap();
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let old_path = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", format!("{}:{old_path}", stub_dir.path().display()));
+        let limit = disk_headroom_limit(tmp.path());
+        std::env::set_var("PATH", old_path);
+
+        assert_eq!(
+            limit,
+            usize::MAX,
+            "an unmeasurable disk probe must skip the clamp (usize::MAX), not silently become 0"
+        );
+    }
+
+    #[test]
+    fn test_disk_headroom_limit_measured_zero_still_clamps() {
+        // Regression: a REAL 0-free-GB measurement (genuinely full disk) is a
+        // legitimate, non-unmeasurable result and must still clamp to 0 via
+        // disk_headroom's normal floor-division math. This guards against
+        // over-correcting #4164 into "None and Some(0) behave the same".
+        assert_eq!(disk_headroom(0, per_worktree_gb().max(1)), 0);
     }
 }


### PR DESCRIPTION
## Summary

`loom_worktree_root_free_gb` (bash) and `worktree_root_free_gb` (Rust) previously
returned a plausible `0` on any measurement failure — a missing bash-only
dependency, a missing `repo_root` argument, or a `df` failure/malformed
output — indistinguishable from a genuine full-disk reading of `0`. That fake
`0` flowed into the wave-size math and floored `/loom:sweep`'s auto wave size
to 1 with reason `floor`, silently masquerading a broken probe as real disk
pressure. This PR makes "unmeasurable" a distinct, loud outcome from "measured
zero" in both the bash and Rust implementations.

## Changes

- `defaults/scripts/lib/disk-headroom.sh`
  - `loom_worktree_root_free_gb` now prints nothing and returns non-zero (with
    a stderr message naming the probed path) on any failure to measure: missing
    `repo_root` argument, unresolvable worktree root, or a failing/malformed
    `df`. A genuine measured `0` free GB (a truly full disk) still prints `0`
    with exit 0.
  - The `source .../worktree-root.sh` dependency load is now fail-closed: if
    the sibling library doesn't load (so `loom_worktree_root` never gets
    defined), the file aborts via `return 1` *before* defining
    `loom_worktree_root_free_gb` — turning "quietly proceeds with an unset
    dependency" into "loudly fails to source at all". (The library stays
    zsh-sourceable per #3680 — no `$BASH_VERSION` gate was added, since that
    would break the intentional zsh-sourcing design `sweep.md` Stage -1 relies
    on.)
- `defaults/.claude/commands/loom/sweep.md` (Stage -1, "Resolve auto wave
  size")
  - Captures the probe's exit status as `DISK_PROBE_OK`. On success, behavior
    is unchanged (feeds `FREE_GB` into `loom_wave_size_from_disk`). On
    failure, **skips `loom_wave_size_from_disk` entirely** — `loom_wave_size_from_disk`'s
    pure-integer contract is untouched — and falls back to
    `WAVE_SIZE = min(target, candidates)` (floor 1) with a new `unknown`
    reason token, so an unmeasurable probe can never resolve to the same
    output as `floor`.
  - Added the `unknown` row to the reason -> one-line-log mapping table:
    `wave size K, mechanism=<m>: disk headroom unknown (probe failed on
    <worktree-root>) — disk clamp skipped`.
- `loom-daemon/src/disk_headroom.rs` (Rust parity, per curator guidance)
  - `worktree_root_free_gb` now returns `Option<u64>` instead of a plain `u64`
    with a fake-`0` fallback — `None` means unmeasurable.
  - `disk_headroom_limit` skips the disk clamp entirely (`usize::MAX`, i.e. no
    constraint from the disk axis) and logs a warning naming the repo root
    when the probe is unmeasurable, instead of silently clamping every
    concurrency expression to 0.
  - A genuine 0-free-GB measurement is unaffected — it still clamps normally
    via `disk_headroom`'s ordinary floor division.
- `defaults/scripts/tests/test-disk-headroom.sh` — new cases: a failing `df`
  yields non-zero exit + empty stdout with a stderr message (Test 6b); feeding
  that unmeasurable result into `loom_wave_size_from_disk` is rejected rather
  than resolving to `1|floor` (Test 6c); sourcing `disk-headroom.sh` without
  its `worktree-root.sh` sibling fails loudly and never defines
  `loom_worktree_root_free_gb` (Test 6d); a genuine 0-free-GB `df` result
  still prints `0` with exit 0 and still floors the wave size to `1|floor`
  (Test 6e — the real-full-disk case stays distinguishable from a broken
  probe).
- New Rust unit tests in `disk_headroom.rs`: a stubbed failing `df` on `PATH`
  yields `None` from `worktree_root_free_gb`; `disk_headroom_limit` returns
  `usize::MAX` (not `0`) on that same unmeasurable probe; a genuine
  `disk_headroom(0, per)` measurement still clamps to `0` (regression guard
  against over-correcting into "`None` and `Some(0)` behave the same").

## Acceptance Criteria Verification

- [x] `loom_worktree_root_free_gb` distinguishes "measured 0 GB" from "could
      not measure" — empty stdout + non-zero exit on failure; `0`/exit-0 on a
      genuine full-disk measurement. Verified by Test 6b/6e.
- [x] `loom_wave_size_from_disk` / the caller treat an unmeasurable value as
      unknown, not zero — `sweep.md` Stage -1 now skips the call entirely on
      probe failure and falls back to `min(target, candidates)` rather than
      clamping through the disk term. `loom_wave_size_from_disk`'s own
      pure-integer contract is unchanged (still rejects non-integer/empty
      input, per Test 6c).
- [x] The library fails closed on a broken dependency load rather than
      proceeding with an unset `_LOOM_DISK_HEADROOM_LIB_DIR`/`loom_worktree_root`
      — implemented as a fail-closed `source ... || return 1` +
      `command -v loom_worktree_root` guard (not a `$BASH_VERSION` gate, per
      the curator's correction: the library is intentionally zsh-sourceable,
      #3680). Verified by Test 6d.
- [x] Sourcing with an unresolvable lib dir is an error, not a silent no-op —
      same fail-closed guard as above; `loom_worktree_root_free_gb` is never
      defined when the dependency fails to load.
- [x] Unit test added asserting the unmeasurable branch does NOT resolve to
      wave size 1 via a fake 0 — Test 6c (`loom_wave_size_from_disk` rejects
      the empty value outright) plus the `sweep.md` caller-side skip
      documented above.
- [x] The skill's one-line reason now distinguishes `unknown` from `0`/`floor`
      — new `unknown` reason-token row in the log-message table.
- [x] Rust parity (curator-added scope item) — `worktree_root_free_gb` /
      `disk_headroom_limit` now mirror the `Option<u64>` / skip-the-clamp
      contract instead of diverging with their own `0`-on-failure fallback.

## Test Plan

- [x] `bash defaults/scripts/tests/test-disk-headroom.sh` — 42/42 pass
      (existing matrix + all new unmeasurable-branch cases).
- [x] `cd loom-daemon && cargo test disk_headroom` — 15/15 pass, including the
      new `None`/`usize::MAX` unmeasurable-probe cases and the
      measured-0-still-clamps regression guard.
- [x] `cd loom-daemon && cargo test --test sweep_md_stage_minus_one_doc_lint`
      — 11/11 pass (Stage -1 structural doc-lint unaffected).
- [x] `cargo build` / `cargo clippy --all-targets` — clean, no warnings.
- [x] Manual (zsh regression, #3680): `zsh -c 'source
      ./.loom/scripts/lib/disk-headroom.sh && loom_worktree_root_free_gb
      "$(git rev-parse --show-toplevel)"'` still resolves the real free-GB
      figure — zsh sourcing is unaffected by the fail-closed dependency guard
      (verified via the existing Test 7 zsh-sourcing regression case, which
      still passes).
- [x] Edge case (Test 6e / Rust `test_disk_headroom_limit_measured_zero_still_clamps`):
      a genuine 0-free-GB measurement still clamps to wave size 1 / a disk
      limit of 0 — real disk pressure stays distinguishable from a broken
      probe, it is not conflated away by this fix.

Closes #4164