### PR TITLE
feat(merge-pr): preserve worktrees for still-open partial-increment issues

### DIFF
--- a/defaults/scripts/lib/forge-helpers.sh
+++ b/defaults/scripts/lib/forge-helpers.sh
@@ -379,6 +379,44 @@ forge_get_pr_nocache() {
   fi
 }
 
+# Get an issue's open/closed state.
+# Usage: forge_get_issue_state NWO ISSUE_NUMBER [GH_CMD]
+# Returns on stdout: "OPEN" or "CLOSED". On any lookup failure or an
+# unrecognized/empty state value, prints nothing and returns exit code 1.
+#
+# Fail-unsafe-to-preserve contract (#4186): this is used to gate destructive
+# cleanup (e.g. merge-pr.sh's worktree removal), so callers MUST treat a
+# non-zero return (empty stdout) as "assume the issue might still be open"
+# and preserve whatever resource the check gates — never assume CLOSED on a
+# lookup failure. This function only ever reports CLOSED when the forge
+# unambiguously says so.
+forge_get_issue_state() {
+  local nwo="$1"
+  local issue_number="$2"
+  local gh_cmd="${3:-gh}"
+  local raw_state=""
+
+  if [[ "$FORGE_TYPE" == "gitea" ]]; then
+    forge_split_nwo "$nwo"
+    raw_state=$(gitea_api GET "repos/$FORGE_OWNER/$FORGE_REPO/issues/$issue_number" 2>/dev/null \
+      | jq -r '.state // empty' 2>/dev/null) || true
+  else
+    raw_state=$("$gh_cmd" api "repos/$nwo/issues/$issue_number" --jq '.state // empty' 2>/dev/null) || true
+  fi
+
+  case "$(echo "$raw_state" | tr '[:lower:]' '[:upper:]')" in
+    OPEN)
+      echo "OPEN"
+      ;;
+    CLOSED)
+      echo "CLOSED"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 # Check if repo auto-deletes branches on merge.
 # Usage: forge_check_auto_delete NWO
 # Returns: "true" or "false" on stdout

--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -1554,6 +1554,50 @@ _remove_loom_worktree() {
   fi
 }
 
+# _issue_is_closed_for_cleanup <issue_number>
+#
+# Async-close-race adaptation (#4186, adapted from fork PR #77's open-issue
+# worktree guard).
+#
+# Removing a worktree unconditionally after merge breaks the partial-
+# increment lifecycle (#3667): a `Part of #N` / `Contributes to #N` PR merges
+# while issue N stays open, and the next Builder increment (or an agent still
+# inside it) needs that worktree. But naively querying the issue's LIVE state
+# right after merge has a race: GitHub closes `Closes #N` issues
+# ASYNCHRONOUSLY, after the merge webhook fires — so a lookup taken here
+# would see "open" for essentially every normal merge and silently defeat
+# cleanup entirely. Gate the live lookup on whether this PR is actually a
+# close target of the issue:
+#
+#   - $issue_number IS a close target of $PR_NUMBER -> the merge itself
+#     closes it; clean up exactly as before this change (no lookup, no
+#     race).
+#   - $issue_number is NOT a close target (partial increment, or no closing
+#     keyword at all) -> query live state via forge_get_issue_state and
+#     preserve the worktree unless that state is CLOSED.
+#
+# Fail-unsafe-to-preserve: any lookup failure (forge_pr_close_targets
+# returning nothing, forge_get_issue_state failing / returning an unknown
+# state) is treated as "preserve" — cleanup must never destroy a worktree it
+# isn't certain is safe to remove. A skipped cleanup here is always
+# recoverable later (loom-clean, or a future merge that actually closes the
+# issue).
+#
+# Returns 0 (true — safe to clean up) or 1 (false — preserve the worktree).
+_issue_is_closed_for_cleanup() {
+  local issue_number="$1"
+
+  local close_targets
+  close_targets="$(forge_pr_close_targets "$PR_NUMBER" "$GH" 2>/dev/null || true)"
+  if echo "$close_targets" | grep -qx "$issue_number"; then
+    return 0
+  fi
+
+  local state
+  state="$(forge_get_issue_state "$REPO_NWO" "$issue_number" "$GH" 2>/dev/null || true)"
+  [[ "$state" == "CLOSED" ]]
+}
+
 if [[ "$CLEANUP_WORKTREE" == "true" ]]; then
   if [[ "${LOOM_PRESERVE_WORKTREE:-0}" == "1" ]]; then
     info "Worktree cleanup skipped (LOOM_PRESERVE_WORKTREE=1) — local branch left in place"
@@ -1582,7 +1626,16 @@ if [[ "$CLEANUP_WORKTREE" == "true" ]]; then
       DEFAULT_WT_PATH="$WT_ROOT_DIR/pr-$PR_NUMBER"
     fi
     if [[ -d "$DEFAULT_WT_PATH" ]]; then
-      _remove_loom_worktree "$DEFAULT_WT_PATH"
+      # Close-target-aware gate (#4186): ISSUE_NUM is only set when
+      # PR_BRANCH matched the feature/issue-<N> convention above. When it's
+      # unset (the pr-<N> path) this check is skipped entirely — unchanged
+      # behavior.
+      if [[ -n "${ISSUE_NUM:-}" ]] && ! _issue_is_closed_for_cleanup "$ISSUE_NUM"; then
+        warning "Preserving worktree at $DEFAULT_WT_PATH — issue #$ISSUE_NUM is not a close target of PR #$PR_NUMBER and its live state is not CLOSED"
+        info "This is the partial-increment case (#3667) or an issue-state lookup failure; cleanup will be retried by a future merge that actually closes #$ISSUE_NUM, or run 'loom-clean' manually once it does"
+      else
+        _remove_loom_worktree "$DEFAULT_WT_PATH"
+      fi
     else
       # Discovery fallback (warn-only): the Loom-convention path is missing,
       # so walk porcelain looking for any worktree tracking $PR_BRANCH. We
@@ -1593,9 +1646,15 @@ if [[ "$CLEANUP_WORKTREE" == "true" ]]; then
       if [[ -n "$DISCOVERED_WT" ]]; then
         if [[ -f "$DISCOVERED_WT/.loom-managed" ]]; then
           # Rare case: Loom-managed worktree at a non-standard path. The
-          # sentinel says it's safe to remove, so do so.
-          info "Discovered Loom-managed worktree at non-standard path: $DISCOVERED_WT"
-          _remove_loom_worktree "$DISCOVERED_WT"
+          # sentinel says it's safe to remove — unless the close-target-aware
+          # gate (#4186) says preserve.
+          if [[ -n "${ISSUE_NUM:-}" ]] && ! _issue_is_closed_for_cleanup "$ISSUE_NUM"; then
+            warning "Preserving discovered worktree at $DISCOVERED_WT — issue #$ISSUE_NUM is not a close target of PR #$PR_NUMBER and its live state is not CLOSED"
+            info "This is the partial-increment case (#3667) or an issue-state lookup failure; cleanup will be retried by a future merge that actually closes #$ISSUE_NUM, or run 'loom-clean' manually once it does"
+          else
+            info "Discovered Loom-managed worktree at non-standard path: $DISCOVERED_WT"
+            _remove_loom_worktree "$DISCOVERED_WT"
+          fi
         else
           warning "Discovered worktree for branch '$PR_BRANCH' at: $DISCOVERED_WT"
           warning "Worktree lacks .loom-managed sentinel — not removing (user-owned)."

--- a/defaults/scripts/tests/test-merge-pr-worktree-path.sh
+++ b/defaults/scripts/tests/test-merge-pr-worktree-path.sh
@@ -23,6 +23,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 MERGE_PR="$SCRIPTS_DIR/merge-pr.sh"
+FORGE_HELPERS="$SCRIPTS_DIR/lib/forge-helpers.sh"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -101,6 +102,20 @@ assert_grep "Discovered worktree for branch" "$MERGE_PR" \
 assert_grep "re-run with: --worktree-path" "$MERGE_PR" \
     "discovery fallback suggests --worktree-path in the hint"
 
+# --- Test 2b: async-close-race guard (#4186) source surface ---
+assert_grep "_issue_is_closed_for_cleanup" "$MERGE_PR" \
+    "merge-pr.sh defines the close-target-aware cleanup gate"
+assert_grep "forge_pr_close_targets" "$MERGE_PR" \
+    "merge-pr.sh's cleanup gate consults forge_pr_close_targets (async-close-race adaptation)"
+assert_grep "forge_get_issue_state" "$MERGE_PR" \
+    "merge-pr.sh's cleanup gate consults forge_get_issue_state for non-close-target issues"
+assert_grep "Preserving worktree at" "$MERGE_PR" \
+    "default-path preserved-worktree case logs a clear reason"
+assert_grep "Preserving discovered worktree at" "$MERGE_PR" \
+    "discovered-path preserved-worktree case logs a clear reason"
+assert_grep "forge_get_issue_state" "$FORGE_HELPERS" \
+    "forge-helpers.sh defines forge_get_issue_state"
+
 # --- Test 3: Precedence — --no-cleanup-worktree warns when combined ---
 echo ""
 echo "Test 3: --no-cleanup-worktree wins over --worktree-path"
@@ -146,8 +161,15 @@ simulate_cleanup() {
     #   $5 override_has_sentinel ("true" / "false") # does override path have .loom-managed
     #   $6 discovered          (string or "")     # discovered worktree path
     #   $7 discovered_has_sentinel ("true" / "false")
+    #   $8 issue_num           (string or "", default "") # set only on the
+    #      feature/issue-<N> path; empty models the unaffected pr-<N> path (#4186)
+    #   $9 is_close_target     ("true" / "false", default "false") # is
+    #      issue_num among forge_pr_close_targets for the just-merged PR?
+    #   $10 issue_state        ("OPEN" / "CLOSED" / "", default "") # live
+    #      forge_get_issue_state result; "" models a lookup failure
     local preserve="$1" cleanup="$2" override="$3" default_exists="$4" \
-          override_has_sentinel="$5" discovered="$6" discovered_has_sentinel="$7"
+          override_has_sentinel="$5" discovered="$6" discovered_has_sentinel="$7" \
+          issue_num="${8:-}" is_close_target="${9:-false}" issue_state="${10:-}"
 
     if [[ "$cleanup" != "true" ]]; then
         echo "skip:no-cleanup"; return 0
@@ -156,7 +178,8 @@ simulate_cleanup() {
         echo "skip:env"; return 0
     fi
     if [[ -n "$override" ]]; then
-        # --worktree-path bypasses sentinel
+        # --worktree-path bypasses sentinel (and the #4186 issue gate below —
+        # the operator explicitly took responsibility for this path).
         if [[ "$override_has_sentinel" == "true" ]]; then
             echo "remove:override-managed"
         else
@@ -164,14 +187,39 @@ simulate_cleanup() {
         fi
         return 0
     fi
+
+    # Close-target-aware issue gate (#4186), mirroring
+    # _issue_is_closed_for_cleanup: no issue_num (pr-<N> path) always allows
+    # removal; a close-target issue always allows removal (the merge itself
+    # closes it, no race); otherwise fall back to the live state lookup,
+    # where CLOSED allows and anything else (including a lookup failure,
+    # modeled by issue_state="") preserves.
+    _gate_allows_removal() {
+        if [[ -z "$issue_num" ]]; then
+            return 0
+        fi
+        if [[ "$is_close_target" == "true" ]]; then
+            return 0
+        fi
+        [[ "$issue_state" == "CLOSED" ]]
+    }
+
     if [[ "$default_exists" == "true" ]]; then
-        echo "remove:default"
+        if _gate_allows_removal; then
+            echo "remove:default"
+        else
+            echo "preserve:default-open-issue"
+        fi
         return 0
     fi
     # Fallback discovery
     if [[ -n "$discovered" ]]; then
         if [[ "$discovered_has_sentinel" == "true" ]]; then
-            echo "remove:discovered-managed"
+            if _gate_allows_removal; then
+                echo "remove:discovered-managed"
+            else
+                echo "preserve:discovered-open-issue"
+            fi
         else
             echo "warn:discovered-user-owned"
         fi
@@ -244,6 +292,65 @@ if [[ "$result" == "skip:nothing-to-do" ]]; then
     pass "case H: nothing-found is a quiet no-op"
 else
     fail "case H: expected 'skip:nothing-to-do', got '$result'"
+fi
+
+# --- Test 5: async-close-race issue gate (#4186) ---
+echo ""
+echo "Test 5: close-target-aware issue gate on the default and discovered paths"
+
+# Case I: default path, issue IS a close target of the merged PR — a normal
+# `Closes #N` merge must clean up exactly as before this change, no state
+# lookup consulted at all.
+result=$(simulate_cleanup 0 true "" true false "" false 42 true "")
+if [[ "$result" == "remove:default" ]]; then
+    pass "case I: Closes-target issue removes unconditionally (no regression)"
+else
+    fail "case I: expected 'remove:default', got '$result'"
+fi
+
+# Case J: default path, issue is NOT a close target and its live state is
+# OPEN — the partial-increment shape (#3667); preserve.
+result=$(simulate_cleanup 0 true "" true false "" false 42 false "OPEN")
+if [[ "$result" == "preserve:default-open-issue" ]]; then
+    pass "case J: non-target open issue preserves the worktree"
+else
+    fail "case J: expected 'preserve:default-open-issue', got '$result'"
+fi
+
+# Case K: default path, issue is NOT a close target and the state lookup
+# failed (modeled as an empty issue_state) — fail-unsafe-to-preserve.
+result=$(simulate_cleanup 0 true "" true false "" false 42 false "")
+if [[ "$result" == "preserve:default-open-issue" ]]; then
+    pass "case K: issue-state lookup failure preserves the worktree (fail-unsafe)"
+else
+    fail "case K: expected 'preserve:default-open-issue', got '$result'"
+fi
+
+# Case L: default path, issue is NOT a close target but its live state is
+# CLOSED (e.g. closed independently of this PR) — safe to remove.
+result=$(simulate_cleanup 0 true "" true false "" false 42 false "CLOSED")
+if [[ "$result" == "remove:default" ]]; then
+    pass "case L: non-target issue whose live state is CLOSED still removes"
+else
+    fail "case L: expected 'remove:default', got '$result'"
+fi
+
+# Case M: no issue_num at all (the pr-<N> worktree path) — gate is skipped
+# entirely; default-path removal is unaffected.
+result=$(simulate_cleanup 0 true "" true false "" false "" false "")
+if [[ "$result" == "remove:default" ]]; then
+    pass "case M: pr-<N> path (no ISSUE_NUM) is unaffected by the issue gate"
+else
+    fail "case M: expected 'remove:default', got '$result'"
+fi
+
+# Case N: discovered (non-standard-path) Loom-managed worktree, issue is NOT
+# a close target and is OPEN — preserve at the discovered-path call site too.
+result=$(simulate_cleanup 0 true "" false false "/found" true 42 false "OPEN")
+if [[ "$result" == "preserve:discovered-open-issue" ]]; then
+    pass "case N: discovered-path gate also preserves for a non-target open issue"
+else
+    fail "case N: expected 'preserve:discovered-open-issue', got '$result'"
 fi
 
 # --- Summary ---


### PR DESCRIPTION
## Summary

Harvest (fork #77), Part 1 only per curator rescope: `merge-pr.sh` unconditionally
removes an issue's worktree after merging its PR, but a partial-increment merge
(`Part of #N` / `Contributes to #N`, #3667) leaves the issue open — the next Builder
increment (or an agent still inside it) needs that worktree. This adds a
close-target-aware gate that preserves the worktree in that case, while a normal
`Closes #N` merge continues to clean up exactly as before (no regression, no
async-close-race).

`prune-merged-worktrees.sh` is deliberately **not** added — the curator rescope
found it duplicates `loom-clean` with strictly weaker safety (no `.loom-managed`
sentinel check, force-removes uncommitted changes, Linux-only liveness check that
no-ops on macOS, ignores `LOOM_PRESERVE_WORKTREE`).

## Changes

- `defaults/scripts/lib/forge-helpers.sh`: new `forge_get_issue_state NWO ISSUE_NUMBER [gh-cmd]`
  (both forge arms — `gh api` for GitHub, `gitea_api` for Gitea). Returns
  `OPEN`/`CLOSED` on success; on any lookup failure or unrecognized state it
  prints nothing and returns non-zero — callers must treat that as "preserve",
  never as "closed".
- `defaults/scripts/merge-pr.sh`: new `_issue_is_closed_for_cleanup <issue_number>`
  gate, applied at both worktree-removal call sites (the default `issue-<N>`
  path and the discovered Loom-managed non-standard path):
  - If `ISSUE_NUM` **is** a close target of the just-merged PR (via the
    existing `forge_pr_close_targets`, GraphQL `closingIssuesReferences`) —
    the merge itself closes the issue, so cleanup proceeds unconditionally,
    exactly as before this change. No state lookup, no async-close race.
  - If `ISSUE_NUM` is **not** a close target (partial increment, or no closing
    keyword) — query live state via `forge_get_issue_state` and preserve the
    worktree unless that state is `CLOSED`. A lookup failure preserves
    (fail-unsafe-to-preserve).
  - The `pr-<N>` worktree path (no `ISSUE_NUM` set at all) is untouched by
    this gate.
  - The preserved-worktree branch logs a clear `warning` + `info` explaining
    why cleanup was skipped and how to retry it later.
- `defaults/scripts/tests/test-merge-pr-worktree-path.sh`: static greps for the
  new symbols in both files, plus `simulate_cleanup` extended with the
  close-target-aware gate and 6 new cases (I–N): a `Closes`-target issue
  removes unconditionally, a non-target open issue preserves, an issue-state
  lookup failure preserves, a non-target issue whose state is independently
  `CLOSED` still removes, the `pr-<N>` (no `ISSUE_NUM`) path is unaffected,
  and the discovered-path call site applies the same gate.

## Acceptance Criteria Verification

- [x] `forge_get_issue_state` added with both forge arms, fail-unsafe-to-preserve
      contract documented in its header comment.
- [x] `merge-pr.sh` gates worktree removal at both call sites, close-target-aware
      via `forge_pr_close_targets` — verified by cases I/M (`Closes`-target and
      no-`ISSUE_NUM` paths both still `remove:default`, i.e. no regression).
- [x] Preserved-worktree path logs a clear `warning`/`info` (verified by the
      new static grep assertions).
- [x] `prune-merged-worktrees.sh` is **not** added (`git status` / `ls` confirm
      no new file; diff is scoped to the 3 files above).
- [x] `test-merge-pr-worktree-path.sh` passes with the new cases (33/33).

## Test Plan

- [x] `./defaults/scripts/tests/test-merge-pr-worktree-path.sh` — 33/33 passed
      (24 pre-existing + 9 new: 6 static-grep + 6 `simulate_cleanup` cases,
      renumbered as needed).
- [x] Ran the full adjacent merge-pr / forge-helpers test suite to confirm no
      regression: `test-forge-helpers.sh` (36/36), `test-merge-pr-help.sh`
      (15/15), `test-merge-pr-local-branch-cleanup.sh` (18/18),
      `test-merge-pr-partial-increment.sh` (19/19),
      `test-merge-pr-primary-worktree-guard.sh` (14/14),
      `test-merge-pr-worktree-awk.sh` (11/11),
      `test-merge-pr-auto-merge-disabled-fallback.sh` (30/30),
      `test-merge-pr-auto-reconcile.sh` (20/20),
      `test-merge-pr-merge-ordering-guard.sh` (25/25),
      `test-merge-pr-unstable-fallback.sh` (68/68) — all green.
  - Manual reasoning (dry-run not applicable without a live forge round-trip;
    covered instead by the inline `simulate_cleanup` cases I–N which mirror
    `_issue_is_closed_for_cleanup`'s exact branch structure):
    - A PR with `Closes #N` → case I: removes unconditionally, no lookup race.
    - Partial-increment shape (`feature/issue-<N>` branch, PR body only
      `Part of #N`) → case J: preserves and logs the reason.
    - `ISSUE_NUM` unset (`pr-<N>` path) → case M: unchanged, still removes.
    - Forge lookup failure → case K: preserves (merge itself is unaffected;
      the gate only governs the worktree-removal step, which already runs
      after the merge succeeds).
- `bash -n` syntax check on both modified scripts.
- `shellcheck` on both modified scripts: no new findings introduced by this
  diff (3 pre-existing informational SC2015/SC2016 notes, unrelated to the
  changed lines).

Closes #4186
