### PR TITLE
feat(dispatch): machine-level loom dispatcher + ~/.local/share/loom checkout

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1414,6 +1414,14 @@ not the daemon, and is a separate follow-up.
 
 ## Operability — config, start/stop, E2E (Phase D, #3813)
 
+> **Machine-level `loom` dispatcher (Epic #3835 Phase 3a, #4157).** A machine-level
+> `loom` entry point at `~/.local/bin/loom` (sibling of `~/.local/bin/loom-daemon`)
+> resolves the `~/.local/share/loom` checkout and exec's into it —
+> `loom start|stop|status|sweep|update`. It is distinct from the per-repo tmux
+> agent-pool manager `./.loom/bin/loom`; the name-collision resolution, checkout
+> layout, and the thin-`update` boundary are documented in
+> [`machine-dispatcher.md`](machine-dispatcher.md).
+
 Phases A–C built the autonomous *engine* (work finder, dynamic concurrency,
 main-health gate) as env-var-only surfaces. Phase D (#3813) adds the
 operator-facing layer: a committed config surface, safe start/stop wrappers for

--- a/defaults/docs/machine-dispatcher.md
+++ b/defaults/docs/machine-dispatcher.md
@@ -1,0 +1,109 @@
+# Machine-level `loom` dispatcher
+
+Epic #3835 Phase 3a (#4157). The `loom` dispatcher is a machine-level entry
+point installed to `~/.local/bin/loom`. It resolves the machine-level Loom
+checkout at `~/.local/share/loom` and exec's into it. It is a sibling of the
+`~/.local/bin/loom-daemon` binary — one install per machine, shared across every
+repo Loom is installed into.
+
+```
+loom <command> [options]
+```
+
+| Command | What it does |
+|---------|--------------|
+| `start` | Start the machine-level `loom-daemon` (delegates to `loom-daemon-start.sh`) |
+| `stop`  | Stop the machine-level `loom-daemon` (delegates to `loom-daemon-stop.sh`) |
+| `status`| Show machine-level + current-repo status (read-only) |
+| `sweep <issue>` | Dispatch `/loom:sweep <issue>` for the current repo |
+| `update`| Thin delegate to `loom-daemon-update.sh` (no rebuild logic of its own) |
+
+Environment: `LOOM_HOME` overrides the machine-level checkout location (default
+`~/.local/share/loom`).
+
+## Checkout resolution — link, not a second clone (AC1)
+
+The installer always runs **from** a Loom source checkout (`$LOOM_ROOT`). Rather
+than cloning a *second* copy into `~/.local/share/loom` — which a developer
+running Loom *on* the Loom repo could then let drift out of sync — provisioning
+establishes the machine checkout as a **symlink**:
+
+```
+~/.local/share/loom -> $LOOM_ROOT
+```
+
+A symlink cannot diverge, so the hard AC1 constraint ("a developer running Loom
+on the Loom repo must not end up with two divergent copies") holds by
+construction. If `~/.local/share/loom` already exists as a **real directory**
+(an operator's pre-existing standalone clone), provisioning leaves it untouched
+— that is the supported "fresh clone" resolution. The `loom` dispatcher resolves
+the checkout at runtime and works with either shape.
+
+## The name collision with `./.loom/bin/loom`, and how it is resolved (AC3)
+
+There are two different Loom surfaces that both answer to the name `loom`:
+
+| Surface | What it is | Verbs |
+|---------|-----------|-------|
+| `~/.local/bin/loom` (this dispatcher) | Machine-level runtime driver | `start stop status sweep update` |
+| `./.loom/bin/loom` | Per-repo **tmux agent-pool** manager | `start status health stop attach send scale logs` |
+
+Three verbs collide by name — `start`, `stop`, `status` — and mean *different
+things* in each surface.
+
+**Why there is no PATH-shadowing.** `.loom/bin` is **never** added to `PATH`
+anywhere in the tree, and every in-repo invocation of the pool manager is
+path-qualified (`./.loom/bin/loom …`). A path-qualified call never resolves
+through `PATH`, and a bare `loom …` on `PATH` never resolves to `./.loom/bin/loom`.
+So the two invocation forms are **disjoint by construction** — adding
+`~/.local/bin/loom` cannot shadow the pool manager, and the pool manager cannot
+shadow the dispatcher. This is the `#4079` failure mode (a stale entry shadowing
+another on `PATH`) *not* recurring; it is asserted by a regression test, not
+patched with a compatibility shim.
+
+**The residual, human-facing risk** is narrower: an operator typing a bare
+`loom start` *while inside a consumer repo* might mean the tmux pool but get the
+machine dispatcher. The dispatcher resolves this by **detecting** a nearby
+`./.loom/bin/loom` (walking up from `$PWD`) and, for the three colliding verbs:
+
+- **`start` / `stop`** (they mutate process state): the dispatcher **refuses**
+  and prints a disambiguation naming *both* surfaces, then exits non-zero — it
+  never silently runs the wrong one. Force the machine surface with
+  `loom start --machine`, or run the pool with `./.loom/bin/loom start`.
+- **`status`** (read-only, and required by AC7 to produce output from inside a
+  repo): the dispatcher prints machine-level status and a clearly-labelled line
+  pointing at the per-repo pool manager (`… run: ./.loom/bin/loom status`). It
+  is never silent about the other surface.
+
+## `status` output across contexts (AC7)
+
+`loom status` reports a `repo:` line that distinguishes the three contexts:
+
+- **consumer repo root** → `repo: consumer-repo (root: …)`
+- **git worktree** (under `.loom/worktrees/…`) → `repo: git-worktree (main checkout: …)`
+- **non-repo directory** (e.g. `/tmp`) → `repo: non-repo (no .loom/ found from cwd)`
+
+## Config resolution (AC5)
+
+`loom status` resolves configuration through the Phase 2 tier resolver
+(`defaults/scripts/lib/config-resolver.sh`: private defaults → `.loom/config.json`
+→ `.loom-project/project.json` → `.loom-local/local.json`) rather than reading
+`.loom/config.json` directly, so a value overridden in `.loom-local/local.json`
+wins. In a **non-repo** directory only the private-defaults tier contributes
+(graceful degradation, not an error). When `jq` is unavailable the dispatcher
+says so explicitly — it does **not** present a `jq`-less host as "no config".
+
+## `update` is a thin verb (scope guard, Finding 3)
+
+`loom update` only resolves the machine checkout and delegates to the **existing**
+`loom-daemon-update.sh` (built by #3968, extended by the shipped #4055 self-update
+loop). It implements **no** rebuild / reprovision / restart logic itself, so it
+neither pre-empts #4017 (auto-rebuild-when-stale) nor duplicates #4055.
+
+## Uninstall semantics
+
+A per-repo `uninstall-loom.sh` removes only the per-repo `./.loom/bin/loom` pool
+manager. The machine-level `~/.local/bin/loom` dispatcher and the
+`~/.local/share/loom` checkout link are **not** removed by a per-repo uninstall —
+same semantics as the shared `~/.local/bin/loom-daemon` binary, which outlives any
+single repo's uninstall.

--- a/defaults/scripts/tests/test-loom-dispatcher.sh
+++ b/defaults/scripts/tests/test-loom-dispatcher.sh
@@ -98,12 +98,17 @@ out=$(cd "$CONSUMER" && LOOM_HOME="$CHK" bash "$DISPATCHER" status 2>&1)
 assert_contains "$out" "consumer-repo" "consumer repo context labelled consumer-repo"
 assert_contains "$out" "pool manager:  present" "consumer repo notes the pool manager"
 
-# (2) git worktree
-WT=$(mktemp -d)
+# (2) git worktree — a real Loom worktree of a repo that commits .loom/ carries
+# its own checked-out .loom/ directory, so $WT gets one too. This exercises the
+# ordering fix: the linked-worktree (.git file) check must win over the
+# consumer-repo (.loom/ dir) check, else the worktree is misclassified as a
+# consumer-repo rooted at itself instead of at the main checkout.
+WT=$(mktemp -d); mkdir -p "$WT/.loom"
 MAIN=$(mktemp -d); mkdir -p "$MAIN/.loom"
 printf 'gitdir: %s/.git/worktrees/wt\n' "$MAIN" > "$WT/.git"
 out=$(cd "$WT" && LOOM_HOME="$CHK" bash "$DISPATCHER" status 2>&1)
 assert_contains "$out" "git-worktree" "worktree context labelled git-worktree"
+assert_contains "$out" "$MAIN" "worktree resolves LOOM_CTX_ROOT to the main checkout, not the worktree"
 
 # (3) non-repo directory
 NR=$(mktemp -d)

--- a/defaults/scripts/tests/test-loom-dispatcher.sh
+++ b/defaults/scripts/tests/test-loom-dispatcher.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# test-loom-dispatcher.sh — tests for the machine-level `loom` dispatcher and its
+# provisioning (Epic #3835 Phase 3a, #4157).
+#
+# Covers:
+#   - scripts/loom — checkout resolution (AC1), collision resolution (AC3),
+#     the three status contexts (AC7), config resolution via the Phase 2 tier
+#     resolver incl. the jq-absent case (AC5), and the thin `update` boundary
+#     (Finding 3).
+#   - scripts/install/provision-dispatcher.sh — the verifiable-globals contract
+#     (#4053), the symlink checkout (AC1), and the console-script invariant (AC6).
+#   - the no-shadow regression proving the two `loom` invocation forms stay
+#     disjoint (AC4).
+#
+# Throwaway `mktemp -d` scratch per case, matching test-config-resolver.sh.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# defaults/scripts/tests -> defaults/scripts/tests/../../.. -> repo root
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+DISPATCHER="$REPO_ROOT/scripts/loom"
+PROVISION_LIB="$REPO_ROOT/scripts/install/provision-dispatcher.sh"
+REAL_RESOLVER="$REPO_ROOT/defaults/scripts/lib/config-resolver.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_contains() {
+    if [[ "$1" == *"$2"* ]]; then pass "$3"; else fail "$3 (missing substring: '$2' in: $1)"; fi
+}
+assert_not_contains() {
+    if [[ "$1" != *"$2"* ]]; then pass "$3"; else fail "$3 (unexpected substring: '$2')"; fi
+}
+assert_eq() {
+    if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 (expected '$2', got '$1')"; fi
+}
+
+[[ -f "$DISPATCHER" ]]    || { echo "dispatcher not found at $DISPATCHER"; exit 1; }
+[[ -f "$PROVISION_LIB" ]] || { echo "provisioning lib not found at $PROVISION_LIB"; exit 1; }
+
+# Build a fake machine-level checkout with stub daemon-lifecycle scripts and a
+# real copy of the config resolver. Echoes the checkout path.
+make_checkout() {
+    local c; c="$(mktemp -d)"
+    mkdir -p "$c/defaults/scripts/cli" "$c/defaults/scripts/lib"
+    cat > "$c/defaults/scripts/cli/loom-daemon-start.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "STUB_START args=[$*]"
+EOF
+    cat > "$c/defaults/scripts/cli/loom-daemon-stop.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "STUB_STOP args=[$*]"
+EOF
+    cat > "$c/defaults/scripts/cli/loom-daemon-update.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "STUB_UPDATE args=[$*]"
+EOF
+    chmod +x "$c/defaults/scripts/cli/"*.sh
+    cp "$REAL_RESOLVER" "$c/defaults/scripts/lib/config-resolver.sh"
+    printf '%s\n' "$c"
+}
+
+# Build a fake consumer repo with a pool-manager stub + config tiers.
+make_consumer_repo() {
+    local r; r="$(mktemp -d)"
+    mkdir -p "$r/.loom/bin"
+    cat > "$r/.loom/bin/loom" <<'EOF'
+#!/usr/bin/env bash
+echo "POOL_MANAGER args=[$*]"
+EOF
+    chmod +x "$r/.loom/bin/loom"
+    printf '%s\n' "$r"
+}
+
+# ── AC1 / AC7: checkout resolution + status ABSENT checkout ───────────────────
+echo "Test 1: status reports an ABSENT machine checkout (AC1 resolution)"
+out=$(LOOM_HOME="/nonexistent/loom/checkout/xyz" bash "$DISPATCHER" status 2>&1)
+assert_contains "$out" "ABSENT" "status shows ABSENT when checkout missing"
+assert_contains "$out" "machine-level dispatcher" "status self-identifies as machine-level"
+
+# ── AC7: three distinguishable status contexts ───────────────────────────────
+echo "Test 2: status contexts are correct and distinguishable (AC7)"
+CHK=$(make_checkout)
+CONSUMER=$(make_consumer_repo)
+
+# (1) consumer repo root
+out=$(cd "$CONSUMER" && LOOM_HOME="$CHK" bash "$DISPATCHER" status 2>&1)
+assert_contains "$out" "consumer-repo" "consumer repo context labelled consumer-repo"
+assert_contains "$out" "pool manager:  present" "consumer repo notes the pool manager"
+
+# (2) git worktree
+WT=$(mktemp -d)
+MAIN=$(mktemp -d); mkdir -p "$MAIN/.loom"
+printf 'gitdir: %s/.git/worktrees/wt\n' "$MAIN" > "$WT/.git"
+out=$(cd "$WT" && LOOM_HOME="$CHK" bash "$DISPATCHER" status 2>&1)
+assert_contains "$out" "git-worktree" "worktree context labelled git-worktree"
+
+# (3) non-repo directory
+NR=$(mktemp -d)
+out=$(cd "$NR" && LOOM_HOME="$CHK" bash "$DISPATCHER" status 2>&1)
+assert_contains "$out" "non-repo" "non-repo context labelled non-repo"
+
+# ── AC3: collision resolution for the overlapping verbs ──────────────────────
+echo "Test 3: bare 'start' inside a consumer repo disambiguates, never runs silently (AC3)"
+set +e
+out=$(cd "$CONSUMER" && LOOM_HOME="$CHK" bash "$DISPATCHER" start 2>&1)
+rc=$?
+set -e 2>/dev/null || true
+assert_eq "$rc" "3" "bare 'loom start' in a repo exits 3 (disambiguating non-zero)"
+assert_contains "$out" ".loom/bin/loom start" "disambiguation names the per-repo pool surface"
+assert_contains "$out" "loom start --machine" "disambiguation names the machine surface"
+assert_not_contains "$out" "STUB_START" "bare 'loom start' did NOT run the daemon start (no silent surface)"
+
+echo "Test 4: 'start --machine' bypasses the guard and delegates (strips --machine)"
+set +e
+out=$(cd "$CONSUMER" && LOOM_HOME="$CHK" bash "$DISPATCHER" start --machine 2>&1)
+rc=$?
+set -e 2>/dev/null || true
+assert_eq "$rc" "0" "'loom start --machine' exits 0"
+assert_contains "$out" "STUB_START" "'--machine' delegates to loom-daemon-start.sh"
+assert_contains "$out" "args=[]" "the --machine selector is stripped before delegating"
+
+# ── Finding 3: thin update verb ──────────────────────────────────────────────
+echo "Test 5: 'update' is a thin delegator with no rebuild logic of its own (Finding 3)"
+set +e
+out=$(LOOM_HOME="$CHK" bash "$DISPATCHER" update --check 2>&1)
+rc=$?
+set -e 2>/dev/null || true
+assert_eq "$rc" "0" "'loom update' exits 0 via delegation"
+assert_contains "$out" "STUB_UPDATE args=[--check]" "'update' delegates to loom-daemon-update.sh, passing args"
+# Structural: the dispatcher must not itself implement rebuild/restart.
+src="$(cat "$DISPATCHER")"
+assert_not_contains "$src" "cargo build" "dispatcher source contains no 'cargo build' (thin boundary)"
+assert_not_contains "$src" "launchctl" "dispatcher source contains no 'launchctl' (thin boundary)"
+assert_not_contains "$src" "git pull" "dispatcher source contains no 'git pull' (thin boundary)"
+
+# ── AC5: config resolution through the Phase 2 tier resolver ─────────────────
+if command -v jq >/dev/null 2>&1; then
+    echo "Test 6: status resolves config through the tier chain — local tier wins (AC5)"
+    RTIER=$(make_consumer_repo)
+    mkdir -p "$RTIER/.loom" "$RTIER/.loom-local"
+    echo '{"autonomous":{"workFinder":{"enabled":false}}}' > "$RTIER/.loom/config.json"
+    echo '{"autonomous":{"workFinder":{"enabled":true}}}'  > "$RTIER/.loom-local/local.json"
+    out=$(cd "$RTIER" && LOOM_CONFIG_DEFAULTS_FILE="" LOOM_HOME="$CHK" bash "$DISPATCHER" status 2>&1)
+    assert_contains "$out" "autonomous.workFinder.enabled = true" ".loom-local/local.json overrides .loom/config.json (resolver, not direct read)"
+else
+    echo "Test 6: SKIP (jq not on PATH)"
+fi
+
+echo "Test 7: status is explicit when jq is unavailable — not masqueraded as 'no config' (AC5)"
+JQLESS_BIN=$(mktemp -d)
+for t in sed dirname readlink; do
+    p="$(command -v "$t" 2>/dev/null || true)"
+    [[ -n "$p" ]] && ln -s "$p" "$JQLESS_BIN/$t"
+done
+REAL_BASH="$(command -v bash)"
+set +e
+out=$(cd "$NR" && PATH="$JQLESS_BIN" HOME="$NR" LOOM_HOME="$CHK" "$REAL_BASH" "$DISPATCHER" status 2>&1)
+set -e 2>/dev/null || true
+assert_contains "$out" "jq not available" "jq-absent status says so explicitly"
+
+# ── AC4: no-shadow regression — the two invocation forms stay disjoint ───────
+echo "Test 8: bare 'loom' and './.loom/bin/loom' resolve to different surfaces in the same shell (AC4)"
+# Provision the dispatcher into a temp bin dir and put ONLY that dir on PATH.
+BIN=$(mktemp -d)
+HOME_T=$(mktemp -d)
+# shellcheck source=/dev/null
+source "$PROVISION_LIB"
+provision_loom_dispatcher "$REPO_ROOT" "$BIN" "$HOME_T/.local/share/loom" >/dev/null 2>&1 || true
+# Same shell: PATH has the dispatcher's bin dir but NOT any repo's .loom/bin.
+run_path="$BIN:/usr/bin:/bin"
+assert_not_contains ":$run_path:" "/.loom/bin:" "'.loom/bin' is absent from the test PATH"
+# bare 'loom status' -> the machine dispatcher
+set +e
+bare_out=$(cd "$CONSUMER" && PATH="$run_path" HOME="$HOME_T" LOOM_HOME="$CHK" loom status 2>&1)
+set -e 2>/dev/null || true
+assert_contains "$bare_out" "machine-level dispatcher" "bare 'loom status' resolves to the machine dispatcher"
+# path-qualified './.loom/bin/loom status' -> the pool manager
+pool_out=$(cd "$CONSUMER" && PATH="$run_path" ./.loom/bin/loom status 2>&1)
+assert_contains "$pool_out" "POOL_MANAGER" "'./.loom/bin/loom status' resolves to the pool manager"
+assert_not_contains "$pool_out" "machine-level dispatcher" "the two forms are disjoint (no shadowing)"
+
+# ── #4053 contract + AC1 symlink + AC6 console-script invariant ──────────────
+echo "Test 9: provisioning exposes verifiable globals and links the checkout (AC1, #4053)"
+assert_eq "$PROVISIONED_DISPATCHER_BIN" "$BIN/loom" "PROVISIONED_DISPATCHER_BIN points at the installed dispatcher"
+assert_eq "$PROVISIONED_LOOM_CHECKOUT" "$HOME_T/.local/share/loom" "PROVISIONED_LOOM_CHECKOUT points at the checkout"
+[[ -x "$BIN/loom" ]] && pass "dispatcher installed and executable" || fail "dispatcher not installed/executable"
+if [[ -L "$HOME_T/.local/share/loom" ]]; then
+    tgt="$(readlink "$HOME_T/.local/share/loom")"
+    assert_eq "$tgt" "$REPO_ROOT" "checkout is a symlink to the source checkout (cannot diverge)"
+else
+    fail "checkout was not established as a symlink"
+fi
+# Idempotent second run.
+set +e
+provision_loom_dispatcher "$REPO_ROOT" "$BIN" "$HOME_T/.local/share/loom" >/dev/null 2>&1
+rc=$?
+set -e 2>/dev/null || true
+assert_eq "$rc" "0" "provisioning is idempotent (second run returns 0)"
+
+echo "Test 10: provisioning never touches the 23 loom-* console-script symlinks (AC6)"
+BIN2=$(mktemp -d)
+HOME2=$(mktemp -d)
+# Seed 23 dummy console-script files, snapshot their checksums.
+for i in $(seq 1 23); do echo "console-script-$i" > "$BIN2/loom-fake$i"; done
+before=$(cd "$BIN2" && for f in loom-fake*; do printf '%s:%s\n' "$f" "$(cksum < "$f")"; done | sort)
+source "$PROVISION_LIB"
+provision_loom_dispatcher "$REPO_ROOT" "$BIN2" "$HOME2/.local/share/loom" >/dev/null 2>&1 || true
+after=$(cd "$BIN2" && for f in loom-fake*; do printf '%s:%s\n' "$f" "$(cksum < "$f")"; done | sort)
+assert_eq "$after" "$before" "all 23 loom-* entries are byte-identical before/after provisioning"
+[[ -f "$BIN2/loom" ]] && pass "only the 'loom' dispatcher was added" || fail "dispatcher not added to bin dir"
+count=$(cd "$BIN2" && ls loom-fake* 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "$count" "23" "console-script count unchanged (23)"
+
+echo ""
+echo "======================================"
+echo "test-loom-dispatcher.sh: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+echo "======================================"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -194,6 +194,13 @@ source "$LOOM_ROOT/scripts/install/manifest.sh"
 # shellcheck source=scripts/install/provision-daemon.sh
 source "$LOOM_ROOT/scripts/install/provision-daemon.sh"
 
+# Source the machine-level `loom` dispatcher provisioning helper (Epic #3835
+# Phase 3a, #4157). Sibling of provision-daemon.sh; installs ~/.local/bin/loom
+# and establishes the ~/.local/share/loom checkout link. Own file so the test
+# suite can exercise it without sourcing the full installer.
+# shellcheck source=scripts/install/provision-dispatcher.sh
+source "$LOOM_ROOT/scripts/install/provision-dispatcher.sh"
+
 # Dogfood command-dir linker (issue #3682) — extracted so the test suite can
 # exercise the scoped-symlink logic without running the full installer.
 # shellcheck source=scripts/install/dogfood-commands.sh
@@ -1070,6 +1077,16 @@ info "loom-daemon binary: $DAEMON_VERSION"
 info "Provisioning machine-level loom-daemon binary..."
 provision_machine_daemon "$LOOM_ROOT/target/release/loom-daemon" || \
   warning "Machine-level loom-daemon not provisioned (see note above); autonomous daemon mode needs LOOM_DAEMON_BIN or a binary on PATH."
+
+# Provision the machine-level `loom` dispatcher (Epic #3835 Phase 3a, #4157).
+# Installs ~/.local/bin/loom and links ~/.local/share/loom -> this Loom source
+# checkout so `loom start|stop|status|sweep|update` resolves a machine-level
+# runtime with no per-repo copy. Best-effort: a soft failure is logged but never
+# aborts the install. It writes ONLY those two paths — it never touches the
+# ~/.local/bin/loom-* Python console-script symlinks (Epic #4081's scope).
+info "Provisioning machine-level loom dispatcher..."
+provision_loom_dispatcher "$LOOM_ROOT" || \
+  warning "Machine-level loom dispatcher not fully provisioned (see note above); use ./.loom/bin/loom in-repo, or set LOOM_HOME."
 
 # Run loom-daemon init in the worktree
 cd "$TARGET_PATH/$WORKTREE_PATH"

--- a/scripts/install/provision-dispatcher.sh
+++ b/scripts/install/provision-dispatcher.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# scripts/install/provision-dispatcher.sh — machine-level `loom` dispatcher
+# provisioning (Epic #3835 Phase 3a, #4157).
+#
+# Sibling of provision-daemon.sh. Where that installs the loom-daemon *binary*
+# to ~/.local/bin/loom-daemon, this installs the `loom` *dispatcher* to
+# ~/.local/bin/loom AND establishes the machine-level Loom checkout at
+# ~/.local/share/loom that the dispatcher resolves into.
+#
+# Source this file with:
+#     source "$LOOM_ROOT/scripts/install/provision-dispatcher.sh"
+# then call `provision_loom_dispatcher "$LOOM_ROOT" [bin_dir] [checkout_dir]`.
+#
+# Deliberately self-contained (defines its own output helpers) so the test suite
+# can source it without pulling in the full installer.
+#
+# ── AC1: checkout resolution (fresh clone vs link to an existing dev checkout) ──
+# The installer always runs FROM a Loom source checkout ($LOOM_ROOT). Rather than
+# cloning a *second* copy — which a developer running Loom on the Loom repo could
+# then let drift out of sync with their working tree — this provisions the machine
+# checkout as a SYMLINK ~/.local/share/loom -> $LOOM_ROOT. A symlink cannot
+# diverge, so AC1's hard constraint ("must not end up with two divergent copies")
+# holds by construction. If ~/.local/share/loom already exists as a real
+# directory (an operator's pre-existing standalone clone), it is LEFT AS-IS and
+# never clobbered — that is the supported "fresh clone" resolution.
+#
+# ── AC6: this provisioning writes EXACTLY two machine-level paths ──────────────
+# ~/.local/bin/loom (the dispatcher) and ~/.local/share/loom (the checkout link).
+# It never adds, removes, or repoints any of the ~/.local/bin/loom-* Python
+# console-script symlinks (Epic #4081's scope).
+
+# Emit a dispatcher-provision status line (plain text so sourcing tests can
+# assert on it).
+_pdisp_ok()   { echo "  [loom-dispatcher] $*"; }
+_pdisp_warn() { echo "  [loom-dispatcher] WARNING: $*" >&2; }
+
+# Set on every return (success or soft-failure) so the caller can VERIFY the
+# destinations it wrote rather than trust a success message (the #4053
+# "expose enough for the caller to verify" contract, matching
+# provision-daemon.sh's PROVISIONED_DAEMON_BIN). Assigned as GLOBALS (no `local`)
+# so they survive the function return. Consumed by callers/tests, not this file.
+# shellcheck disable=SC2034
+PROVISIONED_DISPATCHER_BIN=""
+# shellcheck disable=SC2034
+PROVISIONED_LOOM_CHECKOUT=""
+
+# provision_loom_dispatcher <loom_root> [bin_dir] [checkout_dir]
+#
+# Best-effort — never fatal. Returns 1 on a soft failure so the caller can note
+# it, but the installer must NOT abort on a non-zero return.
+provision_loom_dispatcher() {
+    local loom_root="${1:-}"
+    local bin_dir="${2:-${LOOM_DAEMON_BIN_DIR:-$HOME/.local/bin}}"
+    local checkout_dir="${3:-$HOME/.local/share/loom}"
+    local src="$loom_root/scripts/loom"
+    local dest_bin="$bin_dir/loom"
+
+    # Publish resolved destinations up front so EVERY return path communicates
+    # where things live (the caller gates on the return code).
+    PROVISIONED_DISPATCHER_BIN="$dest_bin"
+    PROVISIONED_LOOM_CHECKOUT="$checkout_dir"
+
+    if [[ -z "$loom_root" || ! -f "$src" ]]; then
+        _pdisp_warn "dispatcher source not found at '${src:-<unset>}'; skipping."
+        return 1
+    fi
+
+    local soft_fail=0
+
+    # ── 1. establish the machine-level checkout (AC1) ─────────────────────────
+    if [[ -L "$checkout_dir" ]]; then
+        local cur
+        cur="$(readlink "$checkout_dir" 2>/dev/null || true)"
+        if [[ "$cur" == "$loom_root" ]]; then
+            _pdisp_ok "checkout already linked: $checkout_dir -> $loom_root"
+        else
+            _pdisp_warn "checkout $checkout_dir already links elsewhere ($cur); leaving as-is."
+        fi
+    elif [[ -e "$checkout_dir" ]]; then
+        # A real directory (or file) already there — an operator's standalone
+        # clone is the supported "fresh clone" resolution; never clobber it.
+        _pdisp_warn "checkout $checkout_dir already exists (not a symlink); leaving as-is."
+    else
+        if mkdir -p "$(dirname "$checkout_dir")" 2>/dev/null \
+            && ln -s "$loom_root" "$checkout_dir" 2>/dev/null; then
+            _pdisp_ok "linked machine checkout: $checkout_dir -> $loom_root"
+        else
+            _pdisp_warn "could not create checkout link at $checkout_dir"
+            soft_fail=1
+        fi
+    fi
+
+    # ── 2. install the dispatcher to ~/.local/bin/loom (AC2) ──────────────────
+    if ! mkdir -p "$bin_dir" 2>/dev/null; then
+        _pdisp_warn "could not create $bin_dir; skipping dispatcher install."
+        return 1
+    fi
+    if install -m 755 "$src" "$dest_bin" 2>/dev/null \
+        || { cp -f "$src" "$dest_bin" 2>/dev/null && chmod 755 "$dest_bin" 2>/dev/null; }; then
+        _pdisp_ok "installed loom dispatcher -> $dest_bin"
+    else
+        _pdisp_warn "failed to install dispatcher to $dest_bin"
+        return 1
+    fi
+
+    _pdisp_check_path "$bin_dir"
+    return "$soft_fail"
+}
+
+# Warn (one clear line, never fatal) when <dir> is not on PATH.
+_pdisp_check_path() {
+    local dir="$1"
+    case ":${PATH:-}:" in
+        *":$dir:"*) return 0 ;;
+        *)
+            _pdisp_warn "$dir is not on your PATH — add it so 'loom' resolves:"
+            _pdisp_warn "    export PATH=\"$dir:\$PATH\"   # add to ~/.zshrc or ~/.bashrc"
+            return 0
+            ;;
+    esac
+}

--- a/scripts/loom
+++ b/scripts/loom
@@ -82,11 +82,13 @@ loom_detect_context() {
         if [[ -f "$dir/.loom/bin/loom" && -z "$LOOM_CTX_POOL" ]]; then
             LOOM_CTX_POOL="$dir/.loom/bin/loom"
         fi
-        if [[ -d "$dir/.loom" ]]; then
-            LOOM_CTX_ROOT="$dir"
-            LOOM_CTX_KIND="consumer-repo"
-            return 0
-        fi
+        # Linked-worktree detection MUST precede the consumer-repo (.loom/) check:
+        # a repo that commits .loom/ (config.json, roles/, scripts/ — the norm per
+        # CLAUDE.md) carries a real .loom/ directory inside every worktree checkout
+        # too, so testing -d "$dir/.loom" first would misclassify every worktree of
+        # such a repo as a consumer-repo and resolve LOOM_CTX_ROOT to the worktree
+        # instead of the main checkout. A linked worktree's .git is a *file*
+        # ("gitdir: <path>"), so -f "$dir/.git" distinguishes it cleanly.
         if [[ -f "$dir/.git" ]]; then
             # Linked git worktree: .git is a file "gitdir: <path>".
             local gitdir main_repo
@@ -100,6 +102,11 @@ loom_detect_context() {
                 fi
                 return 0
             fi
+        fi
+        if [[ -d "$dir/.loom" ]]; then
+            LOOM_CTX_ROOT="$dir"
+            LOOM_CTX_KIND="consumer-repo"
+            return 0
         fi
         dir="$(dirname "$dir")"
     done

--- a/scripts/loom
+++ b/scripts/loom
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# scripts/loom — machine-level Loom dispatcher (Epic #3835 Phase 3a, #4157).
+#
+# Installed to ~/.local/bin/loom by scripts/install/provision-dispatcher.sh as a
+# machine-level, install-once-per-machine entry point (a sibling of the
+# ~/.local/bin/loom-daemon binary that provision-daemon.sh installs). It resolves
+# the machine-level Loom checkout (~/.local/share/loom) and exec's into it.
+#
+# Verbs (at minimum): start | stop | status | sweep | update.
+#
+# ── NOT the same surface as ./.loom/bin/loom ────────────────────────────────
+# ./.loom/bin/loom is the PER-REPO tmux agent-pool manager (verbs: start status
+# health stop attach send scale logs). This dispatcher is the MACHINE-LEVEL
+# runtime driver. Three verbs collide by name — start / stop / status — and mean
+# different things in each surface. `.loom/bin` is never on PATH, and every
+# in-repo call to the pool manager is path-qualified (`./.loom/bin/loom …`), so
+# a bare `loom …` on PATH can never resolve to the pool manager and vice-versa —
+# the two invocation forms are disjoint by construction (that is why AC4 is a
+# regression test, not a compatibility shim). For the three colliding verbs this
+# dispatcher additionally detects a nearby per-repo pool manager and refuses to
+# guess (start/stop) or clearly labels itself (status) rather than silently
+# running the wrong surface. See defaults/docs/machine-dispatcher.md.
+#
+# Environment:
+#   LOOM_HOME   Override the machine-level checkout location
+#               (default: ~/.local/share/loom).
+
+set -euo pipefail
+
+DISPATCHER_VERSION="1"
+
+# ── output helpers (plain text so sourcing tests can assert on them) ──────────
+if [[ -t 2 ]]; then
+    _C_RED=$'\033[0;31m'; _C_YEL=$'\033[1;33m'; _C_NC=$'\033[0m'
+else
+    _C_RED=''; _C_YEL=''; _C_NC=''
+fi
+_err()  { printf '%sloom:%s %s\n' "$_C_RED" "$_C_NC" "$*" >&2; }
+_warn() { printf '%sloom:%s %s\n' "$_C_YEL" "$_C_NC" "$*" >&2; }
+
+# ── machine-level checkout resolution (AC1) ──────────────────────────────────
+# The provisioning step (provision-dispatcher.sh) establishes ~/.local/share/loom
+# as a symlink to the Loom source checkout the installer ran from — the
+# "link to an existing dev checkout" resolution — so a developer running Loom on
+# the Loom repo never ends up with two divergent copies (AC1's hard constraint).
+# At runtime the dispatcher only needs to *resolve* that location, honoring an
+# explicit LOOM_HOME override first.
+loom_resolve_checkout() {
+    if [[ -n "${LOOM_HOME:-}" ]]; then
+        printf '%s\n' "${LOOM_HOME%/}"
+        return 0
+    fi
+    printf '%s\n' "$HOME/.local/share/loom"
+}
+
+# Echo the canonical scripts subtree inside a resolved checkout. A Loom *source*
+# checkout ships defaults/scripts/…; a checkout that is itself an installed
+# consumer repo ships .loom/scripts/…. Prefer the source layout, fall back.
+loom_checkout_scripts_dir() {
+    local checkout="$1"
+    if [[ -d "$checkout/defaults/scripts" ]]; then
+        printf '%s\n' "$checkout/defaults/scripts"
+    elif [[ -d "$checkout/.loom/scripts" ]]; then
+        printf '%s\n' "$checkout/.loom/scripts"
+    else
+        return 1
+    fi
+}
+
+# ── repo-context resolution (AC7) ────────────────────────────────────────────
+# Walk up from $PWD. Sets three globals:
+#   LOOM_CTX_KIND  = consumer-repo | git-worktree | non-repo
+#   LOOM_CTX_ROOT  = resolved repo root (main checkout for a worktree), or ""
+#   LOOM_CTX_POOL  = path to a nearby ./.loom/bin/loom pool manager, or ""
+loom_detect_context() {
+    LOOM_CTX_KIND="non-repo"
+    LOOM_CTX_ROOT=""
+    LOOM_CTX_POOL=""
+
+    local dir="$PWD"
+    while [[ "$dir" != "/" && -n "$dir" ]]; do
+        if [[ -f "$dir/.loom/bin/loom" && -z "$LOOM_CTX_POOL" ]]; then
+            LOOM_CTX_POOL="$dir/.loom/bin/loom"
+        fi
+        if [[ -d "$dir/.loom" ]]; then
+            LOOM_CTX_ROOT="$dir"
+            LOOM_CTX_KIND="consumer-repo"
+            return 0
+        fi
+        if [[ -f "$dir/.git" ]]; then
+            # Linked git worktree: .git is a file "gitdir: <path>".
+            local gitdir main_repo
+            gitdir=$(sed 's/^gitdir: //' "$dir/.git" 2>/dev/null || true)
+            if [[ -n "$gitdir" ]]; then
+                main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+                LOOM_CTX_ROOT="$main_repo"
+                LOOM_CTX_KIND="git-worktree"
+                if [[ -z "$LOOM_CTX_POOL" && -f "$main_repo/.loom/bin/loom" ]]; then
+                    LOOM_CTX_POOL="$main_repo/.loom/bin/loom"
+                fi
+                return 0
+            fi
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 0
+}
+
+# ── collision guard for the three overlapping verbs (AC3) ────────────────────
+# start/stop mutate process state, so on a detected pool-manager collision we
+# refuse and disambiguate (never silently run the wrong surface). An explicit
+# --machine anywhere in the args opts out of the guard.
+loom_has_flag() {
+    local want="$1"; shift
+    local a
+    for a in "$@"; do [[ "$a" == "$want" ]] && return 0; done
+    return 1
+}
+
+loom_collision_guard() {
+    local verb="$1"; shift
+    loom_has_flag "--machine" "$@" && return 0
+    [[ -n "$LOOM_CTX_POOL" ]] || return 0
+    _err "'$verb' is ambiguous here — two different Loom surfaces both define it."
+    _err "  per-repo tmux agent pool:  ${LOOM_CTX_POOL} $verb"
+    _err "  machine-level loom-daemon: loom $verb --machine"
+    _err "Re-run with one of the above (see 'loom help')."
+    exit 3
+}
+
+# Resolve + exec a daemon lifecycle script from the machine checkout, dropping
+# the leading --machine selector (the delegated script does not know that flag).
+loom_exec_checkout_script() {
+    local rel="$1"; shift
+    local checkout scripts_dir target
+    checkout="$(loom_resolve_checkout)"
+    if [[ ! -e "$checkout" ]]; then
+        _err "machine-level checkout not found at: $checkout"
+        _err "install it (run the Loom installer) or set LOOM_HOME to a Loom checkout."
+        exit 1
+    fi
+    if ! scripts_dir="$(loom_checkout_scripts_dir "$checkout")"; then
+        _err "no scripts/ tree under the machine checkout: $checkout"
+        exit 1
+    fi
+    target="$scripts_dir/$rel"
+    if [[ ! -x "$target" ]]; then
+        _err "expected script not found or not executable: $target"
+        exit 1
+    fi
+    local passthrough=()
+    local a
+    for a in "$@"; do [[ "$a" == "--machine" ]] && continue; passthrough+=("$a"); done
+    # `${arr[@]+…}` guard: expand to nothing (not an empty arg) when the array is
+    # empty, so this is safe under `set -u` on bash 3.2 (macOS default).
+    exec "$target" ${passthrough[@]+"${passthrough[@]}"}
+}
+
+# ── verbs ────────────────────────────────────────────────────────────────────
+loom_cmd_start() { loom_detect_context; loom_collision_guard start "$@"; loom_exec_checkout_script "cli/loom-daemon-start.sh" "$@"; }
+loom_cmd_stop()  { loom_detect_context; loom_collision_guard stop  "$@"; loom_exec_checkout_script "cli/loom-daemon-stop.sh"  "$@"; }
+
+# `update` is a THIN verb (Epic #3835 Phase 3a scope guard, Finding 3): it only
+# resolves the machine checkout and delegates to the EXISTING update surface
+# (loom-daemon-update.sh, built by #3968 and extended by the shipped #4055
+# self-update loop). It implements NO rebuild/reprovision/restart logic itself,
+# so it neither pre-empts #4017 (auto-rebuild-when-stale) nor duplicates #4055.
+loom_cmd_update() {
+    local checkout scripts_dir target
+    checkout="$(loom_resolve_checkout)"
+    if [[ ! -e "$checkout" ]] || ! scripts_dir="$(loom_checkout_scripts_dir "$checkout")"; then
+        _err "machine-level checkout not found at: ${checkout}"
+        _err "'loom update' only delegates to loom-daemon-update.sh in the checkout; install Loom or set LOOM_HOME."
+        exit 1
+    fi
+    target="$scripts_dir/cli/loom-daemon-update.sh"
+    if [[ ! -x "$target" ]]; then
+        _err "update delegate not found or not executable: $target"
+        _err "'loom update' is a thin delegator; it does not rebuild/restart on its own."
+        exit 1
+    fi
+    exec "$target" "$@"
+}
+
+# `sweep <issue>` dispatches a single-issue lifecycle for the CURRENT repo.
+loom_cmd_sweep() {
+    loom_detect_context
+    if [[ -z "$LOOM_CTX_ROOT" ]]; then
+        _err "'sweep' must run inside a Loom repo (no .loom/ found from $PWD)."
+        exit 1
+    fi
+    if ! command -v claude >/dev/null 2>&1; then
+        _err "'claude' CLI not found on PATH; cannot dispatch a sweep."
+        exit 1
+    fi
+    if [[ $# -eq 0 ]]; then
+        _err "usage: loom sweep <issue-number> [more issues|flags]"
+        exit 1
+    fi
+    cd "$LOOM_CTX_ROOT"
+    exec claude -p "/loom:sweep $*" --dangerously-skip-permissions
+}
+
+# `status` is read-only and AC7 requires it to produce correct, distinguishable
+# output from a consumer repo, a git worktree, and a non-repo directory. So on a
+# pool-manager collision it does NOT error — it prints machine-level status and a
+# clearly-labelled pointer to the per-repo pool manager (never a silent
+# wrong-surface run).
+loom_cmd_status() {
+    loom_detect_context
+    local checkout checkout_state target
+    checkout="$(loom_resolve_checkout)"
+    if [[ -L "$checkout" ]]; then
+        target="$(readlink "$checkout" 2>/dev/null || true)"
+        checkout_state="symlink -> ${target:-?}"
+    elif [[ -d "$checkout" ]]; then
+        checkout_state="directory (clone)"
+    else
+        checkout_state="ABSENT"
+    fi
+
+    echo "Loom (machine-level dispatcher)"
+    echo "  dispatcher:    ${BASH_SOURCE[0]}"
+    echo "  checkout:      ${checkout} [${checkout_state}]"
+    if command -v loom-daemon >/dev/null 2>&1; then
+        echo "  loom-daemon:   $(loom-daemon --version 2>/dev/null || echo '(version unavailable)')"
+    else
+        echo "  loom-daemon:   not on PATH"
+    fi
+
+    echo "Context"
+    echo "  cwd:           ${PWD}"
+    case "$LOOM_CTX_KIND" in
+        consumer-repo) echo "  repo:          consumer-repo (root: ${LOOM_CTX_ROOT})" ;;
+        git-worktree)  echo "  repo:          git-worktree (main checkout: ${LOOM_CTX_ROOT})" ;;
+        non-repo)      echo "  repo:          non-repo (no .loom/ found from cwd)" ;;
+    esac
+    if [[ -n "$LOOM_CTX_POOL" ]]; then
+        echo "  pool manager:  present — for the per-repo tmux pool run: ${LOOM_CTX_POOL} status"
+    else
+        echo "  pool manager:  none"
+    fi
+
+    # AC5: resolve config through the Phase 2 tier resolver, not by reading
+    # .loom/config.json directly. AC4-note: the jq-absent case must be explicit,
+    # not masqueraded as "no config".
+    echo "Config (resolved via the Phase 2 tier chain)"
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "  (jq not available — config tiers cannot be resolved on this host)"
+        return 0
+    fi
+    local resolver
+    if resolver="$(loom_checkout_scripts_dir "$checkout" 2>/dev/null)/lib/config-resolver.sh" \
+        && [[ -f "$resolver" ]]; then
+        # shellcheck source=/dev/null
+        source "$resolver"
+        local wf
+        wf="$(loom_config_get "${LOOM_CTX_ROOT:-$PWD}" "autonomous.workFinder.enabled" "(unset)")"
+        echo "  autonomous.workFinder.enabled = ${wf}   (repo_root: ${LOOM_CTX_ROOT:-<none>})"
+    else
+        echo "  (config resolver not found in checkout; cannot resolve tiers)"
+    fi
+}
+
+loom_print_help() {
+    cat <<EOF
+loom — machine-level Loom dispatcher (Epic #3835 Phase 3a)
+
+USAGE:
+    loom <command> [options]
+
+COMMANDS:
+    start     Start the machine-level loom-daemon (delegates to loom-daemon-start.sh)
+    stop      Stop the machine-level loom-daemon  (delegates to loom-daemon-stop.sh)
+    status    Show machine-level + current-repo status (read-only)
+    sweep     Dispatch /loom:sweep <issue> for the current repo
+    update    Thin delegate to loom-daemon-update.sh (no rebuild logic of its own)
+    help      Show this help
+    version   Show dispatcher version
+
+NOTE:
+    This is NOT ./.loom/bin/loom (the per-repo tmux agent-pool manager). For the
+    three overlapping verbs (start/stop/status) run inside a repo that has a pool
+    manager, use './.loom/bin/loom <verb>' for the tmux pool, or 'loom <verb>
+    --machine' to force the machine-level surface. See
+    defaults/docs/machine-dispatcher.md.
+
+ENVIRONMENT:
+    LOOM_HOME   Override the machine-level checkout (default: ~/.local/share/loom)
+EOF
+}
+
+main() {
+    local cmd="${1:-help}"
+    shift || true
+    case "$cmd" in
+        start)              loom_cmd_start "$@" ;;
+        stop)               loom_cmd_stop "$@" ;;
+        status)             loom_cmd_status "$@" ;;
+        sweep)              loom_cmd_sweep "$@" ;;
+        update)             loom_cmd_update "$@" ;;
+        help|--help|-h)     loom_print_help ;;
+        version|--version|-v) echo "loom dispatcher v${DISPATCHER_VERSION} (machine-level)" ;;
+        *)
+            _err "unknown command '$cmd'"
+            _err "run 'loom help' for available commands"
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -2879,6 +2879,46 @@ fi
 echo ""
 
 # ==========================================================================
+# Machine-level `loom` dispatcher (Epic #3835 Phase 3a, #4157)
+# ==========================================================================
+# The dispatcher's own unit suite lives at
+# defaults/scripts/tests/test-loom-dispatcher.sh (checkout resolution, collision
+# resolution, config tiers, the AC7 status contexts, the AC4 no-shadow
+# regression, and the AC6 console-script invariant). Fold its result into the
+# installer suite so it runs in CI + the build gate rather than dev-only.
+echo "Test: machine-level loom dispatcher suite (test-loom-dispatcher.sh)"
+DISPATCHER_TEST="$DEFAULTS_DIR/scripts/tests/test-loom-dispatcher.sh"
+if [[ -f "$DISPATCHER_TEST" ]]; then
+  set +e
+  DISPATCHER_TEST_OUT=$(bash "$DISPATCHER_TEST" 2>&1)
+  DISPATCHER_TEST_RC=$?
+  set -e
+  if [[ $DISPATCHER_TEST_RC -eq 0 ]]; then
+    pass "test-loom-dispatcher.sh: all cases passed"
+  else
+    fail "test-loom-dispatcher.sh failed (rc=$DISPATCHER_TEST_RC)"
+    echo "$DISPATCHER_TEST_OUT" | tail -20
+  fi
+else
+  fail "test-loom-dispatcher.sh not found at $DISPATCHER_TEST"
+fi
+echo ""
+
+# The dispatcher source and its provisioning helper must ship.
+echo "Test: dispatcher + provisioning artifacts are present"
+if [[ -f "$LOOM_ROOT/scripts/loom" ]]; then
+  pass "scripts/loom dispatcher source present"
+else
+  fail "scripts/loom dispatcher source missing"
+fi
+if [[ -f "$LOOM_ROOT/scripts/install/provision-dispatcher.sh" ]]; then
+  pass "scripts/install/provision-dispatcher.sh present"
+else
+  fail "scripts/install/provision-dispatcher.sh missing"
+fi
+echo ""
+
+# ==========================================================================
 # Summary
 # ==========================================================================
 echo "======================================"

--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -578,7 +578,14 @@ else
     done < <(find "$TARGET_PATH/$loom_dir" -type f -print0 2>/dev/null | sort -z)
   done
 
-  # Also add the CLI wrapper if it exists (new location: .loom/bin/loom)
+  # Also add the CLI wrapper if it exists (new location: .loom/bin/loom).
+  # NOTE (Epic #3835 Phase 3a, #4157): this removes ONLY the per-repo tmux
+  # agent-pool manager. The machine-level dispatcher at ~/.local/bin/loom (and
+  # the ~/.local/share/loom checkout link) is deliberately NOT removed by a
+  # per-repo uninstall — same semantics as the machine-level ~/.local/bin/loom-daemon
+  # binary, which is shared across every repo Loom is installed into and outlives
+  # any single repo's uninstall. Removing it here would break `loom` for every
+  # other consumer repo on the machine.
   if [[ -f "$TARGET_PATH/.loom/bin/loom" ]] && [[ -x "$TARGET_PATH/.loom/bin/loom" ]]; then
     REMOVE_FILES+=(".loom/bin/loom")
   fi


### PR DESCRIPTION
## Summary

Epic #3835 Phase 3a (first of three units). Establishes the machine-level Loom
runtime: a `~/.local/share/loom` checkout and a `loom` dispatcher on `PATH`
(`~/.local/bin/loom`) that resolves it and exec's into it, with verbs
`start | stop | status | sweep | update`. Phase 3b (user daemon) and 3c
(user-scoped MCP) build on this install location and are out of scope here.

## Changes

- **`scripts/loom`** — the dispatcher. Resolves the checkout (`LOOM_HOME` override
  → default `~/.local/share/loom`), detects repo context, resolves config through
  the Phase 2 tier resolver, and handles the `./.loom/bin/loom` name collision.
- **`scripts/install/provision-dispatcher.sh`** — install-once provisioning that
  mirrors `provision-daemon.sh`'s verifiable-globals contract
  (`PROVISIONED_DISPATCHER_BIN` / `PROVISIONED_LOOM_CHECKOUT`, #4053). Links the
  checkout to the source tree; writes only `~/.local/bin/loom` + the checkout.
- **`scripts/install-loom.sh`** — calls the new provisioning next to the daemon
  step (`.loom/bin/loom` copy at :1684-1691 untouched).
- **`scripts/uninstall-loom.sh`** — documents that a per-repo uninstall leaves the
  machine dispatcher (same semantics as `loom-daemon`).
- **`defaults/scripts/tests/test-loom-dispatcher.sh`** — 32 cases; folded into
  `test-installer.sh` so it runs in CI + the build gate.
- **`defaults/docs/machine-dispatcher.md`** — documents the collision resolution
  and checkout layout; linked from `daemon-reference.md`.

## Design decisions left open by the issue

- **Dispatcher source location: `scripts/`** (not `defaults/scripts/cli/`). Per the
  Curator/Champion guidance: `scripts/install/provision-daemon.sh` is the existing
  precedent for machine-level provisioning into `~/.local/bin/`, and a machine-level
  artifact is not consumer-installed, so `defaults/scripts/cli/` (the consumer-CLI
  tier) is the wrong tier.
- **AC1 checkout resolution: symlink `~/.local/share/loom -> $LOOM_ROOT`** (link to
  the existing dev checkout), not a second clone. A symlink cannot diverge, so
  "a developer running Loom on the Loom repo must not end up with two divergent
  copies" holds by construction. A pre-existing real directory (standalone clone)
  is left untouched — the supported "fresh clone" shape. Both are tested.
- **`update` path (Finding 3): thin delegate to `loom-daemon-update.sh`**, the
  existing surface built by #3968 and extended by the shipped #4055 self-update
  loop. The dispatcher implements no rebuild/restart logic itself, so it neither
  pre-empts #4017 nor duplicates #4055 — asserted structurally + behaviourally.
- **Collision (AC3): detect-and-disambiguate**, not rename. `start`/`stop` refuse
  with a disambiguating non-zero exit naming both surfaces (bypass: `--machine`);
  `status` is read-only (AC7 needs output), so it labels itself machine-level and
  points at the pool manager. Renaming the pool manager was rejected as higher-risk
  (live install-critical surface + stale docs).
- **`verify-install.sh` intentionally not modified.** It verifies per-repo `.loom/`
  manifest files; the dispatcher is a machine-level artifact (like the `loom-daemon`
  binary) and does not belong to the per-repo manifest. Adding it there would be a
  category mismatch and risk failing a per-repo verify when the machine dispatcher
  is legitimately absent. Same reasoning for `manifest.sh` (not manifest-managed).
- **Drift between `defaults/.loom/bin/loom` and `.loom/bin/loom` (Finding 2) left
  out of scope**, as instructed.

## Acceptance Criteria Verification

- **AC1** checkout established, fresh-clone-vs-link answered + tested — symlink
  resolution, idempotent, no divergent copy. ✅ (Test 1, 9)
- **AC2** `loom` dispatcher with `start/stop/status/sweep/update`, resolving the
  checkout and exec'ing into it. ✅
- **AC3** collision explicitly resolved + documented; never a silent wrong-surface
  run. ✅ (Test 3, 4; machine-dispatcher.md)
- **AC4** existing `./.loom/bin/loom` consumers keep working — verified, not
  asserted: the two invocation forms resolve to different surfaces in one shell,
  `.loom/bin` absent from PATH. ✅ (Test 8)
- **AC5** config resolved through the Phase 2 tier resolver (local tier wins),
  jq-absent case explicit. ✅ (Test 6, 7)
- **AC6** provisioning does not add/remove/repoint any `loom-*` console-script
  symlink — 23 entries byte-identical before/after. ✅ (Test 10)
- **AC7** `loom status` from consumer repo / worktree / non-repo each correct and
  distinguishable. ✅ (Test 2; manual below)
- **AC8** tests cover checkout + collision resolution; manual steps recorded. ✅

## Test Plan

- **Automated**: `bash defaults/scripts/tests/test-loom-dispatcher.sh` → 32/32.
- **Automated**: `bash scripts/test-installer.sh` → 154 passed, 0 failed (includes
  the dispatcher suite + the unchanged :601 `.loom/bin` and :2710 guidance-path
  assertions).
- **Manual — AC7 three contexts** (`LOOM_HOME` pointed at a stub checkout):
  - consumer repo root → `repo: consumer-repo (root: …)` + `pool manager: present`
  - git worktree → `repo: git-worktree (main checkout: …)`
  - `/tmp` (non-repo) → `repo: non-repo (no .loom/ found from cwd)`
  All three distinguishable; captured in Test 2.
- **Manual — collision**: bare `loom start` in a consumer repo exits 3 with a
  message naming both `./.loom/bin/loom start` and `loom start --machine`; never
  runs the daemon start.

Closes #4157
