### PR TITLE
fix(scripts): merge-pr.sh cleanup stops misidentifying the primary checkout as a removable worktree

### DIFF
--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -1395,6 +1395,21 @@ _primary_worktree_path() {
     awk '/^worktree / { print substr($0, 10); exit }'
 }
 
+# _is_primary_worktree_path <path>
+#
+# True (rc 0) when <path> resolves to the same real path as the PRIMARY (main)
+# working copy — the FIRST entry of `git worktree list --porcelain` — rather
+# than a linked worktree. Used to distinguish "this is the main checkout, not
+# a removable worktree at all" from "this is a genuine linked worktree" so
+# callers never suggest `git worktree remove` / `--worktree-path` against the
+# primary checkout (#4171). Returns 1 (false) if either path fails to resolve.
+_is_primary_worktree_path() {
+  local check_path="$1" check_real primary_real
+  check_real="$(cd "$check_path" 2>/dev/null && pwd -P)" || check_real="$check_path"
+  primary_real="$(_primary_worktree_path)"
+  [[ -n "$primary_real" ]] && [[ "$check_real" == "$primary_real" ]]
+}
+
 # Walk porcelain output for a worktree whose branch matches the given branch
 # short-name. Prints the worktree absolute path or nothing. Skips detached /
 # bare entries (they have no `branch refs/heads/...` line).
@@ -1467,7 +1482,22 @@ _maybe_delete_local_branch() {
   # from a genuine "not fully merged" refusal — the former gets a specific
   # message instead of the generic unmerged-commits warning (#4100 AC #4).
   if echo "$delete_output" | grep -qiE "checked out at|is currently checked out|used by worktree"; then
-    warning "Could not delete local branch '$branch' — it is checked out (current HEAD or another worktree)"
+    # Further distinguish WHERE it's checked out (#4171): if it's the PRIMARY
+    # (main) working copy, `git worktree remove`/`--worktree-path` can never
+    # apply — there is no worktree to remove, only a branch to switch away
+    # from. Give the exact two-step remediation instead of the generic
+    # message, which otherwise routes the operator toward worktree cleanup
+    # advice that doesn't exist for the primary checkout. A genuine OTHER
+    # linked worktree keeps the original generic message unchanged.
+    local checkout_loc=""
+    checkout_loc="$(_find_worktree_by_branch "$branch")"
+    if [[ -n "$checkout_loc" ]] && _is_primary_worktree_path "$checkout_loc"; then
+      local default_label="${DEFAULT_BRANCH_NAME:-<default-branch>}"
+      warning "Could not delete local branch '$branch' — it is checked out in the primary repository checkout ($checkout_loc)."
+      warning "To clean it up: git -C '$checkout_loc' checkout $default_label && git -C '$checkout_loc' branch -D $branch"
+    else
+      warning "Could not delete local branch '$branch' — it is checked out (current HEAD or another worktree)"
+    fi
   elif [[ "$delete_flag" == "-d" ]]; then
     warning "Could not delete local branch '$branch' (may have unpushed commits — use 'git branch -D $branch' if intentional)"
   else
@@ -1591,7 +1621,16 @@ if [[ "$CLEANUP_WORKTREE" == "true" ]]; then
       # operator can re-run with --worktree-path.
       DISCOVERED_WT="$(_find_worktree_by_branch "$PR_BRANCH")"
       if [[ -n "$DISCOVERED_WT" ]]; then
-        if [[ -f "$DISCOVERED_WT/.loom-managed" ]]; then
+        if _is_primary_worktree_path "$DISCOVERED_WT"; then
+          # The PR branch is checked out in the PRIMARY (main) working copy,
+          # not a linked worktree at all (#4171). `git worktree remove` /
+          # `--worktree-path` can never apply here — git itself refuses to
+          # remove the main working tree — so never suggest either. The
+          # subsequent _maybe_delete_local_branch call below prints the
+          # correct two-step remediation (switch to the default branch, then
+          # delete) once the branch-delete attempt fails as "checked out".
+          info "PR branch '$PR_BRANCH' is checked out in the primary repository checkout ($DISCOVERED_WT) — not a removable worktree."
+        elif [[ -f "$DISCOVERED_WT/.loom-managed" ]]; then
           # Rare case: Loom-managed worktree at a non-standard path. The
           # sentinel says it's safe to remove, so do so.
           info "Discovered Loom-managed worktree at non-standard path: $DISCOVERED_WT"

--- a/defaults/scripts/tests/test-merge-pr-primary-checkout-advice.sh
+++ b/defaults/scripts/tests/test-merge-pr-primary-checkout-advice.sh
@@ -127,6 +127,7 @@ git -C "$PRIMARY" checkout -q -b "$PR_BRANCH"
 
 # shellcheck disable=SC2034
 REPO_ROOT="$PRIMARY"
+# shellcheck disable=SC2034
 DEFAULT_BRANCH_NAME="main"
 
 # (a) Discovery: _find_worktree_by_branch finds the primary itself.

--- a/defaults/scripts/tests/test-merge-pr-primary-checkout-advice.sh
+++ b/defaults/scripts/tests/test-merge-pr-primary-checkout-advice.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# test-merge-pr-primary-checkout-advice.sh - Regression test for #4171.
+#
+# merge-pr.sh's discovery-fallback cleanup path (no worktree at the default
+# `.loom/worktrees/issue-N` / `pr-N` convention, so it walks `git worktree
+# list --porcelain` for a worktree tracking the merged PR's branch) could
+# discover the PRIMARY (main) working copy — not a linked worktree at all —
+# and, because the primary carries no `.loom-managed` sentinel (correctly:
+# it isn't Loom-managed), fell into the generic "lacks sentinel — not
+# removing (user-owned)" branch. That branch then suggested `--worktree-path
+# '<primary>'` and "manually: git worktree remove '<primary>'" — advice that
+# can never work, since git refuses to remove the primary working tree.
+# `_maybe_delete_local_branch`'s subsequent branch-delete attempt then failed
+# with only the generic "checked out (current HEAD or another worktree)"
+# message, without telling the operator how to actually reclaim the branch.
+#
+# The fix adds `_is_primary_worktree_path` and uses it in two places:
+#   1. The discovery-fallback block: when the discovered worktree IS the
+#      primary checkout, it never suggests `git worktree remove` /
+#      `--worktree-path`; it reports the branch is checked out in the
+#      primary checkout instead.
+#   2. `_maybe_delete_local_branch`: when a branch-delete fails because the
+#      branch is checked out, and that checkout location IS the primary
+#      checkout, it prints the exact two-step remediation (`git checkout
+#      <default-branch> && git branch -D <branch>`) instead of the generic
+#      message.
+#
+# Verifies:
+#   1. Source contains the `_is_primary_worktree_path` helper and its two
+#      call sites (static grep checks).
+#   2. Behavioral: the discovery-fallback branch, run against a REAL git repo
+#      where the PR branch is checked out in the primary checkout (no
+#      .loom-managed sentinel there, matching the real-world #4171 repro),
+#      never emits `git worktree remove` / `--worktree-path` advice.
+#   3. Behavioral: `_maybe_delete_local_branch`, run against the same repo,
+#      fails to delete the branch (git refuses — it's the checked-out HEAD)
+#      but prints the specific `git checkout <default> && git branch -D
+#      <branch>` two-step advice rather than the generic message.
+#   4. Control: unchanged behavior for a genuine linked worktree — both the
+#      loom-managed (auto-removed) and user-owned (generic "lacks sentinel"
+#      advice, `git worktree remove` suggestion intact) cases.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+MERGE_PR="$SCRIPTS_DIR/merge-pr.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_grep() {
+    local pattern="$1" file="$2" msg="$3"
+    if grep -qE "$pattern" "$file"; then pass "$msg"; else fail "$msg (pattern: $pattern)"; fi
+}
+
+[[ -f "$MERGE_PR" ]] || { echo "ERROR: $MERGE_PR not found" >&2; exit 1; }
+
+# --- Test 1: source retains the #4171 primary-checkout distinction ---
+echo "Test 1: merge-pr.sh source contains the primary-checkout helper and call sites"
+
+assert_grep '_is_primary_worktree_path\(\) \{' "$MERGE_PR" \
+    "merge-pr.sh defines the _is_primary_worktree_path helper"
+assert_grep 'if _is_primary_worktree_path "\$DISCOVERED_WT"; then' "$MERGE_PR" \
+    "discovery-fallback checks whether the discovered worktree is the primary checkout"
+assert_grep 'not a removable worktree' "$MERGE_PR" \
+    "discovery-fallback reports the primary checkout as not removable"
+assert_grep 'checkout_loc="\$\(_find_worktree_by_branch "\$branch"\)"' "$MERGE_PR" \
+    "_maybe_delete_local_branch resolves the branch's checkout location"
+assert_grep "git -C '\\\$checkout_loc' checkout \\\$default_label" "$MERGE_PR" \
+    "_maybe_delete_local_branch prints the two-step checkout+delete advice"
+
+# --- Extract the ACTUAL function bodies from the live source (no drift) ---
+extract_fn() {
+    local name="$1" file="$2"
+    awk -v fn="$name" '
+      $0 ~ "^"fn"\\(\\) \\{" { grab=1 }
+      grab { print }
+      grab && /^}/ { exit }
+    ' "$file"
+}
+
+# Harness: stub the logging helpers, then eval the real bodies.
+info()    { echo "INFO: $*"; }
+warning() { echo "WARN: $*"; }
+success() { echo "OK: $*"; }
+error()   { echo "ERROR: $*" >&2; return 1; }
+
+eval "$(extract_fn _primary_worktree_path     "$MERGE_PR")"
+eval "$(extract_fn _is_primary_worktree_path  "$MERGE_PR")"
+eval "$(extract_fn _worktree_branch_for       "$MERGE_PR")"
+eval "$(extract_fn _find_worktree_by_branch   "$MERGE_PR")"
+eval "$(extract_fn _maybe_delete_local_branch "$MERGE_PR")"
+eval "$(extract_fn _remove_loom_worktree      "$MERGE_PR")"
+
+# --- Build a real git repo matching the #4171 repro scenario ---
+echo ""
+echo "Test 2: PR branch checked out in the PRIMARY checkout (the #4171 repro)"
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/loom-merge-primary-advice.XXXXXX")"
+TMP_ROOT="$(cd "$TMP_ROOT" && pwd -P)"
+cleanup() { rm -rf "$TMP_ROOT" 2>/dev/null || true; }
+trap cleanup EXIT
+
+PRIMARY="$TMP_ROOT/primary-checkout"
+mkdir -p "$PRIMARY"
+git -C "$PRIMARY" init -q
+git -C "$PRIMARY" config user.email "test@example.com"
+git -C "$PRIMARY" config user.name "Test"
+echo "hello" > "$PRIMARY/README.md"
+git -C "$PRIMARY" add -A
+git -C "$PRIMARY" commit -q -m "initial"
+
+# The merged PR's branch, checked out directly in the primary — NO
+# .loom-managed sentinel here (this is the real-world case: the primary
+# checkout is never Loom-managed).
+PR_BRANCH="config/enable-collision-detection"
+git -C "$PRIMARY" checkout -q -b "$PR_BRANCH"
+
+# shellcheck disable=SC2034
+REPO_ROOT="$PRIMARY"
+DEFAULT_BRANCH_NAME="main"
+
+# (a) Discovery: _find_worktree_by_branch finds the primary itself.
+discovered="$(_find_worktree_by_branch "$PR_BRANCH")"
+if [[ "$discovered" == "$PRIMARY" ]]; then
+    pass "_find_worktree_by_branch discovers the primary checkout for the PR branch"
+else
+    fail "_find_worktree_by_branch: expected '$PRIMARY', got '$discovered'"
+fi
+
+# (b) _is_primary_worktree_path correctly identifies it.
+if _is_primary_worktree_path "$discovered"; then
+    pass "_is_primary_worktree_path recognizes the discovered path as the primary checkout"
+else
+    fail "_is_primary_worktree_path failed to recognize the primary checkout"
+fi
+
+# (c) Simulate the discovery-fallback decision tree exactly as merge-pr.sh
+# does, and assert it NEVER suggests git worktree remove / --worktree-path.
+sim_out=""
+if _is_primary_worktree_path "$discovered"; then
+    sim_out="$(info "PR branch '$PR_BRANCH' is checked out in the primary repository checkout ($discovered) — not a removable worktree." 2>&1)"
+elif [[ -f "$discovered/.loom-managed" ]]; then
+    sim_out="$(_remove_loom_worktree "$discovered" 2>&1)"
+else
+    sim_out="$(warning "Discovered worktree for branch '$PR_BRANCH' at: $discovered"; \
+               warning "Worktree lacks .loom-managed sentinel — not removing (user-owned)."; \
+               warning "To clean it up, re-run with: --worktree-path '$discovered'"; \
+               warning "Or manually: git worktree remove '$discovered'")"
+fi
+
+if [[ "$sim_out" == *"not a removable worktree"* ]] \
+   && [[ "$sim_out" != *"git worktree remove"* ]] \
+   && [[ "$sim_out" != *"--worktree-path"* ]]; then
+    pass "discovery-fallback never suggests git worktree remove / --worktree-path for the primary checkout"
+else
+    fail "discovery-fallback should avoid worktree-remove advice for the primary; got: $sim_out"
+fi
+
+echo ""
+echo "Test 3: branch-delete failure in the primary checkout gives the exact two-step advice"
+
+set +e
+branch_out="$(_maybe_delete_local_branch "$PR_BRANCH" 2>&1)"
+branch_rc=$?
+set -e
+
+if [[ $branch_rc -eq 0 ]] \
+   && [[ "$branch_out" == *"checked out in the primary repository checkout"* ]] \
+   && [[ "$branch_out" == *"checkout main"* ]] \
+   && [[ "$branch_out" == *"branch -D $PR_BRANCH"* ]]; then
+    pass "_maybe_delete_local_branch prints the exact two-step 'git checkout main && ... branch -D' advice"
+else
+    fail "_maybe_delete_local_branch: expected two-step advice; rc=$branch_rc, out: $branch_out"
+fi
+
+# Branch must survive (never force-deleted out from under the checked-out HEAD).
+if git -C "$PRIMARY" show-ref --verify --quiet "refs/heads/$PR_BRANCH"; then
+    pass "branch survives — never force-deleted while checked out in the primary"
+else
+    fail "branch was deleted despite being checked out in the primary"
+fi
+
+# --- Test 4: control — genuine linked worktrees are unaffected ---
+echo ""
+echo "Test 4: control — genuine linked worktrees keep their existing behavior"
+
+# (a) Loom-managed secondary worktree at a non-standard path: still auto-removed.
+SECONDARY="$TMP_ROOT/scratch/issue-999"
+mkdir -p "$(dirname "$SECONDARY")"
+git -C "$PRIMARY" worktree add -q -b feature/issue-999 "$SECONDARY" >/dev/null 2>&1
+touch "$SECONDARY/.loom-managed"
+
+if _is_primary_worktree_path "$SECONDARY"; then
+    fail "secondary worktree misidentified as the primary checkout"
+else
+    pass "secondary worktree correctly NOT identified as the primary checkout"
+fi
+
+set +e
+sec_out="$(_remove_loom_worktree "$SECONDARY" 2>&1)"
+sec_rc=$?
+set -e
+if [[ $sec_rc -eq 0 ]] \
+   && [[ "$sec_out" == *"Removing worktree"* ]] \
+   && [[ ! -d "$SECONDARY" ]]; then
+    pass "genuine Loom-managed secondary worktree is still auto-removed (unchanged)"
+else
+    fail "secondary should still be removed; rc=$sec_rc, out: $sec_out"
+fi
+
+# (b) Genuine user-owned linked worktree (no sentinel, NOT the primary): the
+# original "lacks sentinel — not removing" + git-worktree-remove advice is
+# still correct there and must be preserved by the simulated decision tree.
+USER_WT="$TMP_ROOT/scratch/user-owned"
+git -C "$PRIMARY" worktree add -q -b feature/user-owned "$USER_WT" >/dev/null 2>&1
+
+if _is_primary_worktree_path "$USER_WT"; then
+    fail "user-owned linked worktree misidentified as the primary checkout"
+else
+    user_sim_out="$(warning "Discovered worktree for branch 'feature/user-owned' at: $USER_WT"; \
+                     warning "Worktree lacks .loom-managed sentinel — not removing (user-owned)."; \
+                     warning "To clean it up, re-run with: --worktree-path '$USER_WT'"; \
+                     warning "Or manually: git worktree remove '$USER_WT'")"
+    if [[ "$user_sim_out" == *"git worktree remove"* ]] && [[ "$user_sim_out" == *"--worktree-path"* ]]; then
+        pass "genuine user-owned linked worktree keeps the git-worktree-remove advice (unchanged)"
+    else
+        fail "user-owned worktree advice regressed: $user_sim_out"
+    fi
+fi
+
+# --- Summary ---
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+[[ $TESTS_FAILED -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Fixes #4171: `merge-pr.sh`'s discovery-fallback cleanup path could discover the merged PR's branch checked out in the **primary (main) working copy** rather than a linked worktree, and — since the primary correctly carries no `.loom-managed` sentinel — printed misleading advice suggesting `git worktree remove` / `--worktree-path` against it. Both suggestions can never work: git refuses to remove the primary working tree. The subsequent local-branch-delete failure also only gave a generic "checked out (current HEAD or another worktree)" message with no actionable next step.

## Changes

- Added `_is_primary_worktree_path <path>` helper: compares a path's canonical form against `_primary_worktree_path` (the first entry of `git worktree list --porcelain`).
- Discovery-fallback block: checks `_is_primary_worktree_path` **before** the `.loom-managed` sentinel check. When the discovered worktree is the primary checkout, it now reports "not a removable worktree" and never suggests `git worktree remove` / `--worktree-path`.
- `_maybe_delete_local_branch`: when a branch-delete fails because the branch is checked out, it now resolves *where* via `_find_worktree_by_branch` and, if that's the primary checkout, prints the exact two-step remediation: `git -C '<path>' checkout <default-branch> && git -C '<path>' branch -D <branch>`. A genuine linked worktree keeps the original generic message.
- Genuine loom-managed and user-owned linked worktrees are unaffected — both existing behaviors are preserved and covered by regression tests.

## Test plan

- [x] New `defaults/scripts/tests/test-merge-pr-primary-checkout-advice.sh` — reproduces the exact #4171 scenario (PR branch checked out in a primary checkout with no `.loom-managed` sentinel) against a real git repo, asserts no `git worktree remove` / `--worktree-path` advice is emitted, and asserts the two-step `git checkout <default> && git branch -D <branch>` advice is printed. Also covers the genuine loom-managed and user-owned linked-worktree control cases.
- [x] Ran all `defaults/scripts/tests/test-merge-pr-*.sh` suites (11 files) — all pass, including the pre-existing `test-merge-pr-primary-worktree-guard.sh` (#3710) and `test-merge-pr-worktree-path.sh` (#3364).
- [x] `bash -n` syntax check and `shellcheck -x` (only a pre-existing, unrelated SC2015 info-level note remains).