### PR TITLE
fix(hooks): confine Bash-tool writes to a builder's worktree, closing the #4063 escape

### DIFF
--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -663,6 +663,86 @@ resolve_worktree_root() {
 }
 
 # =============================================================================
+# worktree-isolation toggle — Bash-tool write confinement (issue #4178).
+#
+# guard-worktree-paths.sh confines the Edit/Write TOOL matcher to a builder's
+# issue worktree, but nothing confined the Bash tool: `>`/`>>` redirection,
+# `tee`, `sed -i`, `cp`/`mv` all write files without ever going through
+# Edit/Write, so a session denied on Edit/Write could fall back to Bash and
+# land the same write in the main checkout. Sweep #4063 used exactly this
+# escape to edit live guard hooks in the main checkout while its own worktree
+# stayed clean (see the issue's root-cause writeup / hook-error-log timeline).
+#
+# This reuses the SAME toggle guard-worktree-paths.sh already exposes
+# (guards.worktreeIsolation / LOOM_GUARD_WORKTREE_ISOLATION) — one switch, not
+# two — so a repo/session that already opted out of Edit/Write confinement
+# gets the identical Bash-write confinement decision, and the documented
+# escape hatch (a human/driver session that must edit the main checkout while
+# worktrees exist) keeps working here too.
+#
+# Resolution order (highest precedence first), mirroring every other guard
+# toggle in this file:
+#   1. LOOM_GUARD_WORKTREE_ISOLATION env var (0/false/no disables, 1/true/yes
+#      forces on). Overrides config.
+#   2. .loom/config.json -> guards.worktreeIsolation (default true when absent)
+#   3. Default: true (guard on)
+#
+# The config read is best-effort: any parse failure falls through to guard-ON
+# and never trips the ERR trap.
+# =============================================================================
+_WORKTREE_ISOLATION_CACHE=""
+worktree_isolation_guard_enabled() {
+    if [[ -z "$_WORKTREE_ISOLATION_CACHE" ]]; then
+        local enabled=true
+        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
+            enabled=$(jq -r 'if .guards.worktreeIsolation == false then "false" else "true" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=true
+            [[ -n "$enabled" ]] || enabled=true
+        fi
+        case "${LOOM_GUARD_WORKTREE_ISOLATION:-}" in
+            0|false|no)  enabled=false ;;
+            1|true|yes)  enabled=true ;;
+        esac
+        _WORKTREE_ISOLATION_CACHE="$enabled"
+    fi
+    [[ "$_WORKTREE_ISOLATION_CACHE" == "true" ]]
+}
+
+# True if $1 (an absolute, lexically-normalized path) sits inside ANY managed
+# worktree — walks up looking for the `.loom-managed` sentinel worktree.sh
+# writes at every worktree root. Inline copy of walk_up_for_sentinel() in
+# guard-worktree-paths.sh: kept separate rather than sourced, same rationale
+# as resolve_worktree_root() mirroring worktree-root.sh above — this hook is a
+# distinct process with its own self-contained fail-open contract.
+_in_any_managed_worktree() {
+    local dir="$1"
+    [[ -n "$dir" ]] || return 1
+    if [[ ! -d "$dir" ]]; then
+        dir="${dir%/*}"
+        [[ -z "$dir" ]] && dir="/"
+    fi
+    local i=0
+    while [[ $i -lt 64 ]]; do
+        [[ -f "$dir/.loom-managed" ]] && return 0
+        [[ "$dir" == "/" ]] && break
+        dir="${dir%/*}"
+        [[ -z "$dir" ]] && dir="/"
+        i=$((i + 1))
+    done
+    return 1
+}
+
+# True if at least one managed worktree currently exists under $1
+# (<base>/<name>/.loom-managed, depth 2 — matches worktree.sh's layout).
+# Mirrors any_managed_worktree_exists() in guard-worktree-paths.sh.
+_any_managed_worktree_exists() {
+    local base="$1"
+    [[ -n "$base" && -d "$base" ]] || return 1
+    local hit
+    hit=$(find "$base" -mindepth 2 -maxdepth 2 -name '.loom-managed' -print -quit 2>/dev/null) || hit=""
+    [[ -n "$hit" ]]
+}
+
+# =============================================================================
 # force-op branch-scope toggle — default ALL (preserve current behaviour).
 #
 # The three generic force-op ASK patterns (git push --force / -f /
@@ -1342,6 +1422,128 @@ extract_rm_targets() {
     }'
 }
 
+# =============================================================================
+# extract_write_targets() — Bash-tool write-idiom target extraction (#4178).
+#
+# Emits one "<cwd>\t<target>" line (TAB-separated, US separator 0x1f — mirrors
+# parse_force_ops' SEP convention) per recognized write idiom found in $1:
+#   - `>` / `>>` redirection, bare or fd-prefixed (`2>file`), attached
+#     (`>file`) or spaced (`> file`). A dup-to-fd form (`>&1`, `2>&1`) is
+#     recognized and EXCLUDED — it never writes a file.
+#   - `tee <file>...`            — every non-flag argument is a target.
+#   - `sed -i ... <script> <file>...` — only when an -i/-i* flag is present;
+#     the FIRST non-flag argument is assumed to be the sed script, the rest
+#     are file targets. Exactly one non-flag argument is genuinely ambiguous
+#     (could be an -f scriptfile with no positional file yet) and is SKIPPED
+#     rather than guessed — allow on uncertainty, never deny on uncertainty.
+#   - `cp` / `mv ... <dest>`     — the LAST non-flag argument (the common
+#     `cp/mv src... dest` shape).
+#
+# $2 seeds the starting cwd. A `cd <path>` segment updates cwd for LATER
+# segments of the SAME command (so `cd <worktree> && echo x > f` resolves the
+# relative target against the worktree, not the hook's cwd) — global awk
+# variable `curcwd`, threaded across the per-line pattern-action block exactly
+# like parse_force_ops threads `cpath` via `git -C`.
+#
+# NOT a full shell parser: like parse_force_ops / extract_rm_targets, splitting
+# a segment into tokens is plain whitespace splitting (not quote-aware), so a
+# quoted argument containing a literal space can be mis-split. The caller
+# feeds this the ASK-tier working copy (COMMAND_ASK_SCAN — comment-stripped
+# AND literal-text-redacted, i.e. --body/-m/--title/--notes/--comment values
+# are replaced with same-length placeholder text) specifically so a `>` that
+# merely appears INSIDE such a quoted value (e.g. `git commit -m "a > b"`)
+# cannot manufacture a phantom target. Any remaining false positive from an
+# unredacted quote resolves to, at worst, an extra deny on a target that isn't
+# really a write (safe direction) or a missed target (also safe — the fail-
+# open contract this file uses everywhere: ambiguity never widens a deny).
+# =============================================================================
+extract_write_targets() {
+    printf '%s' "$1" | awk -v startcwd="$2" "$_QSPLIT_AWK"'
+    BEGIN {
+        SEP = sprintf("%c", 31)
+        curcwd = startcwd
+    }
+    {
+        $0 = qsplit($0)   # quote-aware segmentation (#3755)
+        n = split($0, segs, "\n")
+        for (i = 1; i <= n; i++) {
+            seg = segs[i]
+            sub(/^[ \t]+/, "", seg)
+            sub(/^sudo[ \t]+/, "", seg)
+            sub(/^[ \t]+/, "", seg)
+            if (seg == "") continue
+
+            m = split(seg, toks, /[ \t]+/)
+            if (m < 1) continue
+
+            if (toks[1] == "cd") {
+                if (m >= 2 && toks[2] != "" && toks[2] != "-") {
+                    if (toks[2] ~ /^\//) {
+                        curcwd = toks[2]
+                    } else if (curcwd != "") {
+                        curcwd = curcwd "/" toks[2]
+                    }
+                }
+                continue
+            }
+
+            if (toks[1] == "tee") {
+                for (j = 2; j <= m; j++) {
+                    if (toks[j] == "" || toks[j] ~ /^-/) continue
+                    print curcwd SEP toks[j]
+                }
+            } else if (toks[1] == "sed") {
+                has_i = 0
+                nf = 0
+                delete nfargs
+                for (j = 2; j <= m; j++) {
+                    if (toks[j] ~ /^-i/) has_i = 1
+                    if (toks[j] ~ /^-/) continue
+                    if (toks[j] == "") continue
+                    nf++
+                    nfargs[nf] = toks[j]
+                }
+                if (has_i && nf >= 2) {
+                    for (j = 2; j <= nf; j++) print curcwd SEP nfargs[j]
+                }
+            } else if (toks[1] == "cp" || toks[1] == "mv") {
+                nf = 0
+                delete nfargs
+                for (j = 2; j <= m; j++) {
+                    if (toks[j] ~ /^-/) continue
+                    if (toks[j] == "") continue
+                    nf++
+                    nfargs[nf] = toks[j]
+                }
+                if (nf >= 2) print curcwd SEP nfargs[nf]
+            }
+
+            # >/>>  redirection — token-boundary detection only (never a
+            # mid-token char scan), so scanning stays anchored to whitespace
+            # boundaries rather than manufacturing a target out of a `>`
+            # sitting inside an already-multi-char token.
+            for (j = 1; j <= m; j++) {
+                t = toks[j]
+                if (t == "") continue
+                if (t ~ /^[0-9]*>>?$/) {
+                    # Bare operator token. Dup-to-fd (`> &1`) is recognized by
+                    # the NEXT token starting with `&` and excluded.
+                    if (j + 1 <= m && toks[j+1] != "" && toks[j+1] !~ /^&/) {
+                        print curcwd SEP toks[j+1]
+                    }
+                    continue
+                }
+                if (t ~ /^[0-9]*>>?[^ \t&]/) {
+                    # Attached form (`>file`, `2>file`, `>>file`).
+                    op = t
+                    sub(/^[0-9]*>>?/, "", op)
+                    if (op != "") print curcwd SEP op
+                }
+            }
+        }
+    }'
+}
+
 normalize_abs_path() {
     # Lexically normalize an ABSOLUTE path without touching the filesystem:
     #   - collapse duplicate slashes    (//etc        -> /etc)
@@ -1498,6 +1700,75 @@ if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
             fi
         fi
     done
+fi
+
+# =============================================================================
+# BASH-TOOL WRITE CONFINEMENT — worktree isolation for `>`/`>>`/tee/sed -i/
+# cp/mv (issue #4178)
+#
+# guard-worktree-paths.sh confines Edit/Write tool calls to a builder's issue
+# worktree, but the Bash tool has no equivalent confinement — a session denied
+# on Edit/Write could fall back to a Bash write and land the same edit in the
+# main checkout (the #4178 incident: sweep #4063 escaped this way and edited
+# live guard hooks in the main checkout while its own worktree stayed clean).
+#
+# Gated by the SAME toggle as guard-worktree-paths.sh
+# (guards.worktreeIsolation / LOOM_GUARD_WORKTREE_ISOLATION,
+# worktree_isolation_guard_enabled() above) and only denies when a managed
+# worktree actually exists somewhere for this repo — exactly the
+# path_derived_allow() logic in guard-worktree-paths.sh, reimplemented here
+# because this is a separate Bash-matcher hook with its own fail-open
+# contract. A cheap substring pre-check keeps the segmenter off the hot path
+# for the vast majority of Bash calls that contain none of the recognized
+# write idioms at all.
+# =============================================================================
+if worktree_isolation_guard_enabled && \
+   { [[ "$COMMAND_ASK_SCAN" == *">"* ]] || [[ "$COMMAND_ASK_SCAN" == *"tee"* ]] || \
+     [[ "$COMMAND_ASK_SCAN" == *"sed"* ]] || [[ "$COMMAND_ASK_SCAN" == *"cp "* ]] || \
+     [[ "$COMMAND_ASK_SCAN" == *"mv "* ]]; }; then
+    _WT_WRITE_BASE=""
+    _WT_WRITE_BASE_DONE=""
+    WRITE_TARGETS=$(extract_write_targets "$COMMAND_ASK_SCAN" "$CWD" | head -20)
+    while IFS=$'\037' read -r _wcwd _wtarget; do
+        [[ -z "$_wtarget" ]] && continue
+
+        # Resolve to absolute; a relative target with no resolvable cwd is
+        # ambiguous — skip it (allow on uncertainty, never deny on it).
+        _wabs=""
+        if [[ "$_wtarget" == /* ]]; then
+            _wabs="$_wtarget"
+        elif [[ -n "$_wcwd" ]]; then
+            _wabs="$_wcwd/$_wtarget"
+        else
+            continue
+        fi
+        _wabs=$(normalize_abs_path "$_wabs")
+
+        # (a) Already inside some managed worktree -> allow. This is exactly
+        # where a builder is supposed to write.
+        _in_any_managed_worktree "$_wabs" && continue
+
+        # Not under any worktree. If it's also not under the main checkout,
+        # there is nothing this guard protects (e.g. /tmp scratch) -> allow.
+        [[ -z "$REPO_ROOT" ]] && continue
+        case "$_wabs" in
+            "$REPO_ROOT"|"$REPO_ROOT"/*) : ;;
+            *) continue ;;
+        esac
+
+        # Target resolves inside the main checkout and outside every
+        # worktree. Deny only if worktree isolation is actually in play for
+        # this repo/session (a managed worktree exists somewhere); otherwise
+        # fail open — a repo/session that has never created a worktree is
+        # unaffected, mirroring guard-worktree-paths.sh exactly.
+        if [[ -z "$_WT_WRITE_BASE_DONE" ]]; then
+            _WT_WRITE_BASE=$(resolve_worktree_root "$REPO_ROOT")
+            _WT_WRITE_BASE_DONE=1
+        fi
+        if _any_managed_worktree_exists "$_WT_WRITE_BASE"; then
+            deny "BLOCKED: Bash-tool write to '${_wabs}' resolves to the main repository checkout ('${REPO_ROOT}'), but a Loom-managed worktree exists for this session. This is a worktree-isolation bypass via Bash redirection/tee/sed -i/cp/mv — do NOT retry the write through Bash. cd into your issue worktree (.loom/worktrees/issue-<N>) and write there instead. (#4178)" "worktree-write-confinement"
+        fi
+    done <<< "$WRITE_TARGETS"
 fi
 
 # =============================================================================

--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -1728,6 +1728,29 @@ if worktree_isolation_guard_enabled && \
      [[ "$COMMAND_ASK_SCAN" == *"mv "* ]]; }; then
     _WT_WRITE_BASE=""
     _WT_WRITE_BASE_DONE=""
+
+    # Derive the TRUE main-checkout root — NOT REPO_ROOT. REPO_ROOT is resolved
+    # via `git rev-parse --show-toplevel`, which returns the *worktree* root when
+    # CWD is a linked worktree (the canonical builder setup: `cd
+    # .loom/worktrees/issue-N`). Keying the "resolves inside the main checkout"
+    # test below on REPO_ROOT would therefore miss an absolute-path (or
+    # `cd $MAIN && …`) Bash write into the main checkout issued from a builder's
+    # own worktree — the exact "denied on Edit/Write → retry via Bash" escape
+    # this block exists to close (#4178). Mirror the sibling guard
+    # guard-worktree-paths.sh: `--git-common-dir/..` is always the main checkout,
+    # from a worktree or not. `pwd -P` resolves symlinks so it matches the
+    # git-resolved forms consistently (and sidesteps the macOS
+    # /tmp -> /private/tmp mismatch vs. normalize_abs_path's lexical-only form).
+    # Fail open to REPO_ROOT if the git resolution is unavailable.
+    _WT_MAIN_ROOT=""
+    if [[ -n "$CWD" && -d "$CWD" ]]; then
+        _wt_common=$(cd "$CWD" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null) || _wt_common=""
+        if [[ -n "$_wt_common" ]]; then
+            _WT_MAIN_ROOT=$(cd "$CWD" 2>/dev/null && cd "$_wt_common/.." 2>/dev/null && pwd -P) || _WT_MAIN_ROOT=""
+        fi
+    fi
+    [[ -n "$_WT_MAIN_ROOT" ]] || _WT_MAIN_ROOT="$REPO_ROOT"
+
     WRITE_TARGETS=$(extract_write_targets "$COMMAND_ASK_SCAN" "$CWD" | head -20)
     while IFS=$'\037' read -r _wcwd _wtarget; do
         [[ -z "$_wtarget" ]] && continue
@@ -1750,9 +1773,9 @@ if worktree_isolation_guard_enabled && \
 
         # Not under any worktree. If it's also not under the main checkout,
         # there is nothing this guard protects (e.g. /tmp scratch) -> allow.
-        [[ -z "$REPO_ROOT" ]] && continue
+        [[ -z "$_WT_MAIN_ROOT" ]] && continue
         case "$_wabs" in
-            "$REPO_ROOT"|"$REPO_ROOT"/*) : ;;
+            "$_WT_MAIN_ROOT"|"$_WT_MAIN_ROOT"/*) : ;;
             *) continue ;;
         esac
 
@@ -1760,13 +1783,15 @@ if worktree_isolation_guard_enabled && \
         # worktree. Deny only if worktree isolation is actually in play for
         # this repo/session (a managed worktree exists somewhere); otherwise
         # fail open — a repo/session that has never created a worktree is
-        # unaffected, mirroring guard-worktree-paths.sh exactly.
+        # unaffected, mirroring guard-worktree-paths.sh exactly. The worktree
+        # base is resolved off the same main-checkout root so the "a managed
+        # worktree exists" gate stays consistent with the containment test.
         if [[ -z "$_WT_WRITE_BASE_DONE" ]]; then
-            _WT_WRITE_BASE=$(resolve_worktree_root "$REPO_ROOT")
+            _WT_WRITE_BASE=$(resolve_worktree_root "$_WT_MAIN_ROOT")
             _WT_WRITE_BASE_DONE=1
         fi
         if _any_managed_worktree_exists "$_WT_WRITE_BASE"; then
-            deny "BLOCKED: Bash-tool write to '${_wabs}' resolves to the main repository checkout ('${REPO_ROOT}'), but a Loom-managed worktree exists for this session. This is a worktree-isolation bypass via Bash redirection/tee/sed -i/cp/mv — do NOT retry the write through Bash. cd into your issue worktree (.loom/worktrees/issue-<N>) and write there instead. (#4178)" "worktree-write-confinement"
+            deny "BLOCKED: Bash-tool write to '${_wabs}' resolves to the main repository checkout ('${_WT_MAIN_ROOT}'), but a Loom-managed worktree exists for this session. This is a worktree-isolation bypass via Bash redirection/tee/sed -i/cp/mv — do NOT retry the write through Bash. cd into your issue worktree (.loom/worktrees/issue-<N>) and write there instead. (#4178)" "worktree-write-confinement"
         fi
     done <<< "$WRITE_TARGETS"
 fi

--- a/.loom/hooks/guard-worktree-paths.sh
+++ b/.loom/hooks/guard-worktree-paths.sh
@@ -255,4 +255,4 @@ if path_derived_allow "$NORM_PATH"; then
     exit 0
 fi
 
-emit_deny "BLOCKED: Edit/Write path '${NORM_PATH}' resolves to the main repository checkout ('${MAIN_ROOT}'), but a Loom-managed worktree exists for this session. Builders must write inside their issue worktree (.loom/worktrees/issue-<N>), never the main checkout. (#4007)"
+emit_deny "BLOCKED: Edit/Write path '${NORM_PATH}' resolves to the main repository checkout ('${MAIN_ROOT}'), but a Loom-managed worktree exists for this session. Builders must write inside their issue worktree (.loom/worktrees/issue-<N>), never the main checkout. Do NOT retry this write via Bash redirection/tee/sed -i/cp/mv -- that is also confined (guard-destructive-generic.sh, #4178) and denied for the same reason. cd into your issue worktree and write there instead. (#4007)"

--- a/defaults/.claude/commands/loom/builder-worktree.md
+++ b/defaults/.claude/commands/loom/builder-worktree.md
@@ -45,6 +45,12 @@ gh issue edit 84 --remove-label "loom:issue" --add-label "loom:building"
 WORKTREE_ABS="$(cd .loom/worktrees/issue-84 && pwd)"
 # -> e.g. /Users/you/repo/.loom/worktrees/issue-84
 
+# 3a. Assert it's really a managed worktree BEFORE any edit — the same two
+#     checks guard-worktree-paths.sh applies to every Edit/Write/Bash write
+#     it confines (#4178):
+[[ -f "$WORKTREE_ABS/.loom-managed" ]] || echo "FATAL: no .loom-managed sentinel"
+[[ "$(git -C "$WORKTREE_ABS" rev-parse --show-toplevel)" == "$WORKTREE_ABS" ]] || echo "FATAL: toplevel mismatch"
+
 # 4. Do your work using ABSOLUTE paths (implement, test, commit)
 #    - Write/Edit: pass "$WORKTREE_ABS/<file>"
 #    - Bash:       git -C "$WORKTREE_ABS" ...  OR  cd "$WORKTREE_ABS" && <cmd>
@@ -84,6 +90,16 @@ silently contaminating main (#3513, recurrence of #2802).
    git -C "$WORKTREE_ABS" status        # changes should be HERE
    ./.loom/scripts/check-main-clean.sh  # backstop: exits 3 if main is dirty
    ```
+
+**A guard denial is not a signal to retry via a different tool.** Two
+independent PreToolUse guards confine writes to your worktree while any
+managed worktree exists: `guard-worktree-paths.sh` on the Edit/Write matcher,
+and `guard-destructive-generic.sh` on the Bash matcher for the common write
+idioms (`>`/`>>` redirection, `tee`, `sed -i`, `cp`/`mv`) (#4178). If one
+denies, the fix is always to re-derive `$WORKTREE_ABS` and use it — never to
+fall back from Edit/Write to a Bash write (or vice versa) for the same target.
+That fallback is exactly how sweep #4063 escaped worktree isolation and edited
+live guard hooks in the main checkout.
 
 ### Collision Detection
 

--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -293,6 +293,12 @@ echo "$WORKTREE_ABS"  # MUST end in /.loom/worktrees/issue-<number>
 
 # 3. Verify the worktree's branch (works from anywhere via -C)
 git -C "$WORKTREE_ABS" branch --show-current  # MUST show: feature/issue-<number>
+
+# 4. Assert $WORKTREE_ABS is actually a managed worktree (not the main
+#    checkout under a misleading variable name) BEFORE any edit — the same
+#    two checks guard-worktree-paths.sh uses to confine Edit/Write (#4178):
+[[ -f "$WORKTREE_ABS/.loom-managed" ]] || echo "FATAL: no .loom-managed sentinel at $WORKTREE_ABS"
+[[ "$(git -C "$WORKTREE_ABS" rev-parse --show-toplevel)" == "$WORKTREE_ABS" ]] || echo "FATAL: $WORKTREE_ABS is not its own git toplevel"
 ```
 
 ### CRITICAL: Absolute-Path Discipline (cwd does NOT persist across tool calls)
@@ -358,10 +364,20 @@ Before writing any code, confirm ALL of these:
 - [ ] Worktree exists at `.loom/worktrees/issue-<N>`
 - [ ] Captured the worktree ABSOLUTE path once (`WORKTREE_ABS="$(cd .loom/worktrees/issue-<N> && pwd)"`)
 - [ ] Branch is `feature/issue-<N>` (not `main`) — `git -C "$WORKTREE_ABS" branch --show-current`
+- [ ] `.loom-managed` sentinel is present at `$WORKTREE_ABS` AND `git -C "$WORKTREE_ABS" rev-parse --show-toplevel` equals `$WORKTREE_ABS` (#4178 — the same assertion the worktree-isolation guard applies to every Edit/Write and Bash write)
 - [ ] Will use absolute paths under `$WORKTREE_ABS` for every Write/Edit/Bash file operation (cwd does NOT persist across tool calls)
 - [ ] Issue is claimed with `loom:building` label
 
 **If any of these fail, STOP and fix the setup before proceeding.**
+
+**A denial is not a signal to retry via Bash.** `guard-worktree-paths.sh`
+confines the Edit/Write tools to your worktree; `guard-destructive-generic.sh`
+independently confines the common Bash write idioms (`>`/`>>` redirection,
+`tee`, `sed -i`, `cp`/`mv`) the same way (#4178). If either denies a write, the
+fix is always the same: re-run the assertions above and use `$WORKTREE_ABS`,
+never to fall back to the other tool for the same target path — that fallback
+is exactly how sweep #4063 escaped and edited live guard hooks in the main
+checkout.
 
 ### Working with gh CLI from a Worktree
 

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -1465,7 +1465,18 @@ Each builder is responsible for:
 
 **Await all builders in the wave** before proceeding to Judge. Collect each builder's PR number (or failure marker). This await is **mandatory and explicit** — block on every builder's `TaskOutput` / completion notification. The harness may launch each Task async regardless of `run_in_background: false`, so proceeding to Judge on a dispatch flag alone can start Judge before builders finish; the "await all builders before Judge" rule is enforced by this explicit block, not by any dispatch flag (see "Subagent dispatch is async-only", #3822).
 
-**Backstop: verify the main worktree is clean after the builders return (#3513).** A builder subagent runs without `LOOM_WORKTREE_PATH` injected, so the `guard-worktree-paths.sh` hook does not fire on this path. If a builder used repo-relative paths after a cwd reset, it may have written to the **main** worktree instead of its issue worktree. After the wave's builders return and before advancing any PR to Judge, run:
+**Assert the Builder's cwd before it edits anything.** Before the Builder
+subagent prompt does any Write/Edit/Bash file mutation, it MUST capture
+`WORKTREE_ABS="$(cd .loom/worktrees/issue-N && pwd)"` and verify both: the
+`.loom-managed` sentinel is present at `$WORKTREE_ABS`, and `git -C
+"$WORKTREE_ABS" rev-parse --show-toplevel` equals `$WORKTREE_ABS` — then use
+`$WORKTREE_ABS` (never a bare repo-relative path) for every subsequent
+file-mutating call, Write/Edit or Bash alike (see `builder.md` → "Pre-Work
+Validation" / "Validation Checklist", #4178). A denied write is never a signal
+to retry the same target through a different tool (Edit/Write vs. Bash) — see
+below.
+
+**Backstop: verify the main worktree is clean after the builders return (#3513).** A builder subagent is dispatched via the Task tool ("one level deep", step 4 above) and inherits the orchestrator's single shared process env, which has **no** `LOOM_WORKTREE_PATH` — the Task tool exposes no per-subagent env-injection parameter (#3719). `guard-worktree-paths.sh`'s path-derived fallback (#4007) DOES fire on this path regardless — it denies an Edit/Write target resolving into the main checkout while any managed worktree exists, with no env var required — and `guard-destructive-generic.sh` extends the identical confinement to the common Bash-tool write idioms (`>`/`>>` redirection, `tee`, `sed -i`, `cp`/`mv`, #4178, closing the escape sweep #4063 used: a write denied on Edit/Write retried through Bash instead). Despite that guard coverage, this `check-main-clean.sh` backstop stays load-bearing — it is a whole-tree status check, not an idiom scan, so it catches anything the guards' heuristics don't recognize (e.g. an interpreter one-liner like `python -c`, deliberately out of scope for #4178's pattern list) or a write that landed before any worktree existed. After the wave's builders return and before advancing any PR to Judge, run:
 
 ```bash
 ./.loom/scripts/check-main-clean.sh --baseline "$MAIN_CLEAN_BASELINE"   # exit 3 ⇒ NEW main dirt (builder contamination)
@@ -1473,7 +1484,7 @@ Each builder is responsible for:
 
 The `--baseline` argument points at the snapshot taken once at step 0 (before wave 1). With it, the check subtracts any dirt that predated the sweep and exits `3` **only** on changes that appeared after the snapshot — so pre-existing working-tree dirt (a regenerated lockfile, an operator scratch edit) no longer false-positives as contamination on every wave (#3648). If the baseline file is missing or unreadable, the check warns and falls back to the whole-status hard-fail (fail-safe).
 
-If it exits `3`, the main worktree carries **new** uncommitted changes a builder left behind. Surface this loudly in the wave summary — **quote the specific offending paths** the check printed under `Offending changes:` so the operator can see exactly which files escaped a worktree — and **hard-block the wave from advancing any PR to Judge** until the contamination is investigated and the stray changes reverted (move them into the owning issue worktree, then restore main). This is a backstop only — the builder guidance (capture the absolute worktree path once, use absolute paths everywhere) is the primary defense. Note the mechanical reason it is *only* a backstop: a builder subagent is dispatched via the Task tool ("one level deep", step 4 above) and inherits the orchestrator's single shared process env, which has **no** `LOOM_WORKTREE_PATH` — and the Task tool exposes no per-subagent env-injection parameter — so `guard-worktree-paths.sh` structurally cannot fire per builder on this path (#3719; same-shape harness limitation as #3705). Detection here plus the builder-side absolute-path contract are the achievable defenses.
+If it exits `3`, the main worktree carries **new** uncommitted changes a builder left behind. Surface this loudly in the wave summary — **quote the specific offending paths** the check printed under `Offending changes:` so the operator can see exactly which files escaped a worktree — and **hard-block the wave from advancing any PR to Judge** until the contamination is investigated and the stray changes reverted (move them into the owning issue worktree, then restore main). The guard-hook denials plus the cwd-assertion prompt discipline above are the primary defense; this status check is the backstop that catches whatever they miss.
 
 **On successful PR creation**, write the `builder-done` checkpoint for that issue (record the PR number):
 ```bash

--- a/defaults/docs/guard-hooks.md
+++ b/defaults/docs/guard-hooks.md
@@ -9,9 +9,9 @@ the full catalog.
 
 Loom ships with several built-in `PreToolUse` guard hooks, registered independently under the `Bash` or `Edit|Write` matcher as noted below:
 
-- **`guard-destructive.sh`** (`Bash` matcher) — the generic repository-hygiene guard (catastrophic denies like `rm -rf /`, force-push to `main`, `gh repo delete`, fork bombs, curl-pipe-to-shell, cloud/SQL destruction; the segment-parsed lifecycle/cloud-CLI checks; and the `guards.sqlDdl` / `guards.cloudCli` / `guards.reversibleGh` / `guards.rmScope` / `guards.forceScope` toggle machinery documented below). Nothing about this guard is Loom-specific, so as of **#4041 its canonical home is [Repo Skills](https://github.com/rjwalters/repo)** (installed at `.claude/skills/repo/hooks/guard-destructive.sh`, carrying the rjwalters/repo#29 curl-pipe fix). In Loom, `guard-destructive.sh` is now a thin **dispatcher**: when the canonical Repo Skills guard is present it defers to it at runtime (and the installer does not install a second generic guard); otherwise it falls back to a clearly-marked **vendored copy** (`guard-destructive-generic.sh`) that Loom ships so standalone-Loom repos — those without Repo Skills — keep full coverage. Exactly one generic guard ever runs; the behavior and all the toggles below are unchanged either way. The pattern list itself is maintained upstream in Repo Skills, not forked in Loom.
+- **`guard-destructive.sh`** (`Bash` matcher) — the generic repository-hygiene guard (catastrophic denies like `rm -rf /`, force-push to `main`, `gh repo delete`, fork bombs, curl-pipe-to-shell, cloud/SQL destruction; the segment-parsed lifecycle/cloud-CLI checks; and the `guards.sqlDdl` / `guards.cloudCli` / `guards.reversibleGh` / `guards.rmScope` / `guards.forceScope` toggle machinery documented below). Nothing about this guard is Loom-specific, so as of **#4041 its canonical home is [Repo Skills](https://github.com/rjwalters/repo)** (installed at `.claude/skills/repo/hooks/guard-destructive.sh`, carrying the rjwalters/repo#29 curl-pipe fix). In Loom, `guard-destructive.sh` is now a thin **dispatcher**: when the canonical Repo Skills guard is present it defers to it at runtime (and the installer does not install a second generic guard); otherwise it falls back to a clearly-marked **vendored copy** (`guard-destructive-generic.sh`) that Loom ships so standalone-Loom repos — those without Repo Skills — keep full coverage. Exactly one generic guard ever runs; the behavior and all the toggles below are unchanged either way. The pattern list itself is maintained upstream in Repo Skills, not forked in Loom. **One Loom-specific exception:** the vendored copy also carries the Bash-tool **write-confinement** category (`>`/`>>` redirection, `tee`, `sed -i`, `cp`/`mv`, issue #4178) — see `guards.worktreeIsolation` below; this stays Loom-owned even though the rest of the file mirrors upstream, the same way `resolve_worktree_root()`/`guards.rmScope` already do.
 - **`guard-loom-workflow.sh`** (`Bash` matcher) — the thin, Loom-workflow-specific guard (issue #3604): the `gh pr merge` → `merge-pr.sh` redirect and the `pip install -e` worktree block (keyed on `LOOM_WORKTREE_PATH`, issue #2495). This guard and `guard-worktree-paths.sh` below are specific to the Loom worktree/merge workflow and stay Loom-owned.
-- **`guard-worktree-paths.sh`** (`Edit|Write` matcher, issue #2441 / #4007) — confines Edit/Write tool calls to a builder's issue worktree, denying writes that resolve into the main checkout. Two mechanisms: the `LOOM_WORKTREE_PATH` env fast path (tmux/manual sessions pinned to one worktree) and, when that env var is absent, a **path-derived fallback** — it walks up from the target path looking for the `.loom-managed` sentinel `worktree.sh` writes at every worktree root, and denies a write that lands in the main checkout while at least one managed worktree exists. The fallback exists because a daemon-dispatched sweep hosts multiple Task-subagent builders in one shared process env, so a single process-wide `LOOM_WORKTREE_PATH` cannot cover that path (#3719). Toggle: `guards.worktreeIsolation` / `LOOM_GUARD_WORKTREE_ISOLATION`, documented alongside the other guard toggles below.
+- **`guard-worktree-paths.sh`** (`Edit|Write` matcher, issue #2441 / #4007) — confines Edit/Write tool calls to a builder's issue worktree, denying writes that resolve into the main checkout. Two mechanisms: the `LOOM_WORKTREE_PATH` env fast path (tmux/manual sessions pinned to one worktree) and, when that env var is absent, a **path-derived fallback** — it walks up from the target path looking for the `.loom-managed` sentinel `worktree.sh` writes at every worktree root, and denies a write that lands in the main checkout while at least one managed worktree exists. The fallback exists because a daemon-dispatched sweep hosts multiple Task-subagent builders in one shared process env, so a single process-wide `LOOM_WORKTREE_PATH` cannot cover that path (#3719). Toggle: `guards.worktreeIsolation` / `LOOM_GUARD_WORKTREE_ISOLATION`, documented alongside the other guard toggles below. **This confines the Edit/Write tool matcher only** — a session denied here could historically fall back to a Bash-tool write (`>`, `tee`, `sed -i`, `cp`/`mv`) targeting the same path with nothing to stop it (the #4178 incident: sweep #4063 used exactly this to edit live guard hooks in the main checkout). `guard-destructive-generic.sh`'s write-confinement category (bullet above) now closes that gap under the identical toggle.
 
 You can also add project-specific guards to protect read-only directories from accidental edits (see below).
 
@@ -132,6 +132,26 @@ LOOM_GUARD_REVERSIBLE_GH=0 gh issue close 100   # allowed
 
 `guard-worktree-paths.sh` (issue #4007) denies Edit/Write tool calls whose target resolves into the **main** repository checkout while a Loom-managed worktree exists (path-derived — see the guard inventory bullet above for the mechanism). This is the mechanical enforcement behind "never work on main branch": a builder that used a repo-relative path after a cwd reset, or that otherwise escaped its issue worktree, is denied instead of silently corrupting the main checkout.
 
+**Bash-tool write confinement (issue #4178).** The same toggle *also* gates a
+second, independent check inside `guard-destructive-generic.sh` (the `Bash`
+matcher): it denies the common Bash write idioms — `>`/`>>` redirection,
+`tee`, `sed -i`, `cp`/`mv` — when their target resolves into the main checkout
+while a managed worktree exists, using the identical path-derived logic
+(`.loom-managed` sentinel walk-up). This closes the exact escape a real
+incident used: sweep #4063 was denied repeatedly on the Edit/Write path
+(logged in `.loom/logs/hook-errors.log`), then fell back to a Bash write for
+the same target and landed uncaught — because nothing confined the Bash tool.
+One toggle now governs both surfaces; there is no separate config key for the
+Bash-side check. Like the Edit/Write guard, this is a best-effort heuristic,
+not a full shell parser — it recognizes the common write idioms and resolves
+ambiguity toward **allow**, never toward a spurious deny (see
+`guard-destructive-generic.sh`'s `extract_write_targets()` for the exact
+recognized forms and their documented limitations). It deliberately does not
+attempt to catch every conceivable write vector (an interpreter one-liner like
+`python -c` is unparseable from a shell hook) — the goal is removing the easy
+fallback an agent reaches for after an Edit/Write denial, not building a full
+security boundary.
+
 The guard is **on by default**. It is resolved in this order (highest precedence first):
 
 1. **`LOOM_GUARD_WORKTREE_ISOLATION` env var** — `0`/`false`/`no` disables the guard; `1`/`true`/`yes` forces it on. Overrides the config value.
@@ -145,7 +165,16 @@ The guard is **on by default**. It is resolved in this order (highest precedence
    ```
 3. **Default** — `true` (guard on).
 
-The config read is best-effort: a missing, empty, or malformed `.loom/config.json` falls through to guard-ON and never causes the hook to exit non-zero. Disabling this guard does not weaken any other guard. The toggle governs the guard as a whole — disabling it skips **both** mechanisms, including the `LOOM_WORKTREE_PATH` fast path's own containment check.
+The config read is best-effort: a missing, empty, or malformed `.loom/config.json` falls through to guard-ON and never causes the hook to exit non-zero. Disabling this guard does not weaken any other guard. The toggle governs the guard as a whole — disabling it skips **all three** mechanisms: the `LOOM_WORKTREE_PATH` fast path's own containment check, the Edit/Write path-derived fallback, and the Bash-tool write-confinement check.
+
+**Operator escape hatch.** A human or `driver` session that needs to edit the
+main checkout directly while worktrees exist (e.g. hand-fixing something
+outside the normal Builder flow) should set `guards.worktreeIsolation: false`
+in `.loom/config.json` for the session, or export
+`LOOM_GUARD_WORKTREE_ISOLATION=0` for a single command — both mechanisms are
+disabled together, so there is no need to separately silence the Bash-side
+check. Restore the guard (remove the override, or `LOOM_GUARD_WORKTREE_ISOLATION=1`)
+once the direct edit is done.
 
 ### Repo-Scoped rm Guard (`guards.rmScope` / `LOOM_RM_SCOPE`)
 

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -663,6 +663,86 @@ resolve_worktree_root() {
 }
 
 # =============================================================================
+# worktree-isolation toggle — Bash-tool write confinement (issue #4178).
+#
+# guard-worktree-paths.sh confines the Edit/Write TOOL matcher to a builder's
+# issue worktree, but nothing confined the Bash tool: `>`/`>>` redirection,
+# `tee`, `sed -i`, `cp`/`mv` all write files without ever going through
+# Edit/Write, so a session denied on Edit/Write could fall back to Bash and
+# land the same write in the main checkout. Sweep #4063 used exactly this
+# escape to edit live guard hooks in the main checkout while its own worktree
+# stayed clean (see the issue's root-cause writeup / hook-error-log timeline).
+#
+# This reuses the SAME toggle guard-worktree-paths.sh already exposes
+# (guards.worktreeIsolation / LOOM_GUARD_WORKTREE_ISOLATION) — one switch, not
+# two — so a repo/session that already opted out of Edit/Write confinement
+# gets the identical Bash-write confinement decision, and the documented
+# escape hatch (a human/driver session that must edit the main checkout while
+# worktrees exist) keeps working here too.
+#
+# Resolution order (highest precedence first), mirroring every other guard
+# toggle in this file:
+#   1. LOOM_GUARD_WORKTREE_ISOLATION env var (0/false/no disables, 1/true/yes
+#      forces on). Overrides config.
+#   2. .loom/config.json -> guards.worktreeIsolation (default true when absent)
+#   3. Default: true (guard on)
+#
+# The config read is best-effort: any parse failure falls through to guard-ON
+# and never trips the ERR trap.
+# =============================================================================
+_WORKTREE_ISOLATION_CACHE=""
+worktree_isolation_guard_enabled() {
+    if [[ -z "$_WORKTREE_ISOLATION_CACHE" ]]; then
+        local enabled=true
+        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
+            enabled=$(jq -r 'if .guards.worktreeIsolation == false then "false" else "true" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=true
+            [[ -n "$enabled" ]] || enabled=true
+        fi
+        case "${LOOM_GUARD_WORKTREE_ISOLATION:-}" in
+            0|false|no)  enabled=false ;;
+            1|true|yes)  enabled=true ;;
+        esac
+        _WORKTREE_ISOLATION_CACHE="$enabled"
+    fi
+    [[ "$_WORKTREE_ISOLATION_CACHE" == "true" ]]
+}
+
+# True if $1 (an absolute, lexically-normalized path) sits inside ANY managed
+# worktree — walks up looking for the `.loom-managed` sentinel worktree.sh
+# writes at every worktree root. Inline copy of walk_up_for_sentinel() in
+# guard-worktree-paths.sh: kept separate rather than sourced, same rationale
+# as resolve_worktree_root() mirroring worktree-root.sh above — this hook is a
+# distinct process with its own self-contained fail-open contract.
+_in_any_managed_worktree() {
+    local dir="$1"
+    [[ -n "$dir" ]] || return 1
+    if [[ ! -d "$dir" ]]; then
+        dir="${dir%/*}"
+        [[ -z "$dir" ]] && dir="/"
+    fi
+    local i=0
+    while [[ $i -lt 64 ]]; do
+        [[ -f "$dir/.loom-managed" ]] && return 0
+        [[ "$dir" == "/" ]] && break
+        dir="${dir%/*}"
+        [[ -z "$dir" ]] && dir="/"
+        i=$((i + 1))
+    done
+    return 1
+}
+
+# True if at least one managed worktree currently exists under $1
+# (<base>/<name>/.loom-managed, depth 2 — matches worktree.sh's layout).
+# Mirrors any_managed_worktree_exists() in guard-worktree-paths.sh.
+_any_managed_worktree_exists() {
+    local base="$1"
+    [[ -n "$base" && -d "$base" ]] || return 1
+    local hit
+    hit=$(find "$base" -mindepth 2 -maxdepth 2 -name '.loom-managed' -print -quit 2>/dev/null) || hit=""
+    [[ -n "$hit" ]]
+}
+
+# =============================================================================
 # force-op branch-scope toggle — default ALL (preserve current behaviour).
 #
 # The three generic force-op ASK patterns (git push --force / -f /
@@ -1342,6 +1422,128 @@ extract_rm_targets() {
     }'
 }
 
+# =============================================================================
+# extract_write_targets() — Bash-tool write-idiom target extraction (#4178).
+#
+# Emits one "<cwd>\t<target>" line (TAB-separated, US separator 0x1f — mirrors
+# parse_force_ops' SEP convention) per recognized write idiom found in $1:
+#   - `>` / `>>` redirection, bare or fd-prefixed (`2>file`), attached
+#     (`>file`) or spaced (`> file`). A dup-to-fd form (`>&1`, `2>&1`) is
+#     recognized and EXCLUDED — it never writes a file.
+#   - `tee <file>...`            — every non-flag argument is a target.
+#   - `sed -i ... <script> <file>...` — only when an -i/-i* flag is present;
+#     the FIRST non-flag argument is assumed to be the sed script, the rest
+#     are file targets. Exactly one non-flag argument is genuinely ambiguous
+#     (could be an -f scriptfile with no positional file yet) and is SKIPPED
+#     rather than guessed — allow on uncertainty, never deny on uncertainty.
+#   - `cp` / `mv ... <dest>`     — the LAST non-flag argument (the common
+#     `cp/mv src... dest` shape).
+#
+# $2 seeds the starting cwd. A `cd <path>` segment updates cwd for LATER
+# segments of the SAME command (so `cd <worktree> && echo x > f` resolves the
+# relative target against the worktree, not the hook's cwd) — global awk
+# variable `curcwd`, threaded across the per-line pattern-action block exactly
+# like parse_force_ops threads `cpath` via `git -C`.
+#
+# NOT a full shell parser: like parse_force_ops / extract_rm_targets, splitting
+# a segment into tokens is plain whitespace splitting (not quote-aware), so a
+# quoted argument containing a literal space can be mis-split. The caller
+# feeds this the ASK-tier working copy (COMMAND_ASK_SCAN — comment-stripped
+# AND literal-text-redacted, i.e. --body/-m/--title/--notes/--comment values
+# are replaced with same-length placeholder text) specifically so a `>` that
+# merely appears INSIDE such a quoted value (e.g. `git commit -m "a > b"`)
+# cannot manufacture a phantom target. Any remaining false positive from an
+# unredacted quote resolves to, at worst, an extra deny on a target that isn't
+# really a write (safe direction) or a missed target (also safe — the fail-
+# open contract this file uses everywhere: ambiguity never widens a deny).
+# =============================================================================
+extract_write_targets() {
+    printf '%s' "$1" | awk -v startcwd="$2" "$_QSPLIT_AWK"'
+    BEGIN {
+        SEP = sprintf("%c", 31)
+        curcwd = startcwd
+    }
+    {
+        $0 = qsplit($0)   # quote-aware segmentation (#3755)
+        n = split($0, segs, "\n")
+        for (i = 1; i <= n; i++) {
+            seg = segs[i]
+            sub(/^[ \t]+/, "", seg)
+            sub(/^sudo[ \t]+/, "", seg)
+            sub(/^[ \t]+/, "", seg)
+            if (seg == "") continue
+
+            m = split(seg, toks, /[ \t]+/)
+            if (m < 1) continue
+
+            if (toks[1] == "cd") {
+                if (m >= 2 && toks[2] != "" && toks[2] != "-") {
+                    if (toks[2] ~ /^\//) {
+                        curcwd = toks[2]
+                    } else if (curcwd != "") {
+                        curcwd = curcwd "/" toks[2]
+                    }
+                }
+                continue
+            }
+
+            if (toks[1] == "tee") {
+                for (j = 2; j <= m; j++) {
+                    if (toks[j] == "" || toks[j] ~ /^-/) continue
+                    print curcwd SEP toks[j]
+                }
+            } else if (toks[1] == "sed") {
+                has_i = 0
+                nf = 0
+                delete nfargs
+                for (j = 2; j <= m; j++) {
+                    if (toks[j] ~ /^-i/) has_i = 1
+                    if (toks[j] ~ /^-/) continue
+                    if (toks[j] == "") continue
+                    nf++
+                    nfargs[nf] = toks[j]
+                }
+                if (has_i && nf >= 2) {
+                    for (j = 2; j <= nf; j++) print curcwd SEP nfargs[j]
+                }
+            } else if (toks[1] == "cp" || toks[1] == "mv") {
+                nf = 0
+                delete nfargs
+                for (j = 2; j <= m; j++) {
+                    if (toks[j] ~ /^-/) continue
+                    if (toks[j] == "") continue
+                    nf++
+                    nfargs[nf] = toks[j]
+                }
+                if (nf >= 2) print curcwd SEP nfargs[nf]
+            }
+
+            # >/>>  redirection — token-boundary detection only (never a
+            # mid-token char scan), so scanning stays anchored to whitespace
+            # boundaries rather than manufacturing a target out of a `>`
+            # sitting inside an already-multi-char token.
+            for (j = 1; j <= m; j++) {
+                t = toks[j]
+                if (t == "") continue
+                if (t ~ /^[0-9]*>>?$/) {
+                    # Bare operator token. Dup-to-fd (`> &1`) is recognized by
+                    # the NEXT token starting with `&` and excluded.
+                    if (j + 1 <= m && toks[j+1] != "" && toks[j+1] !~ /^&/) {
+                        print curcwd SEP toks[j+1]
+                    }
+                    continue
+                }
+                if (t ~ /^[0-9]*>>?[^ \t&]/) {
+                    # Attached form (`>file`, `2>file`, `>>file`).
+                    op = t
+                    sub(/^[0-9]*>>?/, "", op)
+                    if (op != "") print curcwd SEP op
+                }
+            }
+        }
+    }'
+}
+
 normalize_abs_path() {
     # Lexically normalize an ABSOLUTE path without touching the filesystem:
     #   - collapse duplicate slashes    (//etc        -> /etc)
@@ -1498,6 +1700,75 @@ if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
             fi
         fi
     done
+fi
+
+# =============================================================================
+# BASH-TOOL WRITE CONFINEMENT — worktree isolation for `>`/`>>`/tee/sed -i/
+# cp/mv (issue #4178)
+#
+# guard-worktree-paths.sh confines Edit/Write tool calls to a builder's issue
+# worktree, but the Bash tool has no equivalent confinement — a session denied
+# on Edit/Write could fall back to a Bash write and land the same edit in the
+# main checkout (the #4178 incident: sweep #4063 escaped this way and edited
+# live guard hooks in the main checkout while its own worktree stayed clean).
+#
+# Gated by the SAME toggle as guard-worktree-paths.sh
+# (guards.worktreeIsolation / LOOM_GUARD_WORKTREE_ISOLATION,
+# worktree_isolation_guard_enabled() above) and only denies when a managed
+# worktree actually exists somewhere for this repo — exactly the
+# path_derived_allow() logic in guard-worktree-paths.sh, reimplemented here
+# because this is a separate Bash-matcher hook with its own fail-open
+# contract. A cheap substring pre-check keeps the segmenter off the hot path
+# for the vast majority of Bash calls that contain none of the recognized
+# write idioms at all.
+# =============================================================================
+if worktree_isolation_guard_enabled && \
+   { [[ "$COMMAND_ASK_SCAN" == *">"* ]] || [[ "$COMMAND_ASK_SCAN" == *"tee"* ]] || \
+     [[ "$COMMAND_ASK_SCAN" == *"sed"* ]] || [[ "$COMMAND_ASK_SCAN" == *"cp "* ]] || \
+     [[ "$COMMAND_ASK_SCAN" == *"mv "* ]]; }; then
+    _WT_WRITE_BASE=""
+    _WT_WRITE_BASE_DONE=""
+    WRITE_TARGETS=$(extract_write_targets "$COMMAND_ASK_SCAN" "$CWD" | head -20)
+    while IFS=$'\037' read -r _wcwd _wtarget; do
+        [[ -z "$_wtarget" ]] && continue
+
+        # Resolve to absolute; a relative target with no resolvable cwd is
+        # ambiguous — skip it (allow on uncertainty, never deny on it).
+        _wabs=""
+        if [[ "$_wtarget" == /* ]]; then
+            _wabs="$_wtarget"
+        elif [[ -n "$_wcwd" ]]; then
+            _wabs="$_wcwd/$_wtarget"
+        else
+            continue
+        fi
+        _wabs=$(normalize_abs_path "$_wabs")
+
+        # (a) Already inside some managed worktree -> allow. This is exactly
+        # where a builder is supposed to write.
+        _in_any_managed_worktree "$_wabs" && continue
+
+        # Not under any worktree. If it's also not under the main checkout,
+        # there is nothing this guard protects (e.g. /tmp scratch) -> allow.
+        [[ -z "$REPO_ROOT" ]] && continue
+        case "$_wabs" in
+            "$REPO_ROOT"|"$REPO_ROOT"/*) : ;;
+            *) continue ;;
+        esac
+
+        # Target resolves inside the main checkout and outside every
+        # worktree. Deny only if worktree isolation is actually in play for
+        # this repo/session (a managed worktree exists somewhere); otherwise
+        # fail open — a repo/session that has never created a worktree is
+        # unaffected, mirroring guard-worktree-paths.sh exactly.
+        if [[ -z "$_WT_WRITE_BASE_DONE" ]]; then
+            _WT_WRITE_BASE=$(resolve_worktree_root "$REPO_ROOT")
+            _WT_WRITE_BASE_DONE=1
+        fi
+        if _any_managed_worktree_exists "$_WT_WRITE_BASE"; then
+            deny "BLOCKED: Bash-tool write to '${_wabs}' resolves to the main repository checkout ('${REPO_ROOT}'), but a Loom-managed worktree exists for this session. This is a worktree-isolation bypass via Bash redirection/tee/sed -i/cp/mv — do NOT retry the write through Bash. cd into your issue worktree (.loom/worktrees/issue-<N>) and write there instead. (#4178)" "worktree-write-confinement"
+        fi
+    done <<< "$WRITE_TARGETS"
 fi
 
 # =============================================================================

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -1728,6 +1728,29 @@ if worktree_isolation_guard_enabled && \
      [[ "$COMMAND_ASK_SCAN" == *"mv "* ]]; }; then
     _WT_WRITE_BASE=""
     _WT_WRITE_BASE_DONE=""
+
+    # Derive the TRUE main-checkout root — NOT REPO_ROOT. REPO_ROOT is resolved
+    # via `git rev-parse --show-toplevel`, which returns the *worktree* root when
+    # CWD is a linked worktree (the canonical builder setup: `cd
+    # .loom/worktrees/issue-N`). Keying the "resolves inside the main checkout"
+    # test below on REPO_ROOT would therefore miss an absolute-path (or
+    # `cd $MAIN && …`) Bash write into the main checkout issued from a builder's
+    # own worktree — the exact "denied on Edit/Write → retry via Bash" escape
+    # this block exists to close (#4178). Mirror the sibling guard
+    # guard-worktree-paths.sh: `--git-common-dir/..` is always the main checkout,
+    # from a worktree or not. `pwd -P` resolves symlinks so it matches the
+    # git-resolved forms consistently (and sidesteps the macOS
+    # /tmp -> /private/tmp mismatch vs. normalize_abs_path's lexical-only form).
+    # Fail open to REPO_ROOT if the git resolution is unavailable.
+    _WT_MAIN_ROOT=""
+    if [[ -n "$CWD" && -d "$CWD" ]]; then
+        _wt_common=$(cd "$CWD" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null) || _wt_common=""
+        if [[ -n "$_wt_common" ]]; then
+            _WT_MAIN_ROOT=$(cd "$CWD" 2>/dev/null && cd "$_wt_common/.." 2>/dev/null && pwd -P) || _WT_MAIN_ROOT=""
+        fi
+    fi
+    [[ -n "$_WT_MAIN_ROOT" ]] || _WT_MAIN_ROOT="$REPO_ROOT"
+
     WRITE_TARGETS=$(extract_write_targets "$COMMAND_ASK_SCAN" "$CWD" | head -20)
     while IFS=$'\037' read -r _wcwd _wtarget; do
         [[ -z "$_wtarget" ]] && continue
@@ -1750,9 +1773,9 @@ if worktree_isolation_guard_enabled && \
 
         # Not under any worktree. If it's also not under the main checkout,
         # there is nothing this guard protects (e.g. /tmp scratch) -> allow.
-        [[ -z "$REPO_ROOT" ]] && continue
+        [[ -z "$_WT_MAIN_ROOT" ]] && continue
         case "$_wabs" in
-            "$REPO_ROOT"|"$REPO_ROOT"/*) : ;;
+            "$_WT_MAIN_ROOT"|"$_WT_MAIN_ROOT"/*) : ;;
             *) continue ;;
         esac
 
@@ -1760,13 +1783,15 @@ if worktree_isolation_guard_enabled && \
         # worktree. Deny only if worktree isolation is actually in play for
         # this repo/session (a managed worktree exists somewhere); otherwise
         # fail open — a repo/session that has never created a worktree is
-        # unaffected, mirroring guard-worktree-paths.sh exactly.
+        # unaffected, mirroring guard-worktree-paths.sh exactly. The worktree
+        # base is resolved off the same main-checkout root so the "a managed
+        # worktree exists" gate stays consistent with the containment test.
         if [[ -z "$_WT_WRITE_BASE_DONE" ]]; then
-            _WT_WRITE_BASE=$(resolve_worktree_root "$REPO_ROOT")
+            _WT_WRITE_BASE=$(resolve_worktree_root "$_WT_MAIN_ROOT")
             _WT_WRITE_BASE_DONE=1
         fi
         if _any_managed_worktree_exists "$_WT_WRITE_BASE"; then
-            deny "BLOCKED: Bash-tool write to '${_wabs}' resolves to the main repository checkout ('${REPO_ROOT}'), but a Loom-managed worktree exists for this session. This is a worktree-isolation bypass via Bash redirection/tee/sed -i/cp/mv — do NOT retry the write through Bash. cd into your issue worktree (.loom/worktrees/issue-<N>) and write there instead. (#4178)" "worktree-write-confinement"
+            deny "BLOCKED: Bash-tool write to '${_wabs}' resolves to the main repository checkout ('${_WT_MAIN_ROOT}'), but a Loom-managed worktree exists for this session. This is a worktree-isolation bypass via Bash redirection/tee/sed -i/cp/mv — do NOT retry the write through Bash. cd into your issue worktree (.loom/worktrees/issue-<N>) and write there instead. (#4178)" "worktree-write-confinement"
         fi
     done <<< "$WRITE_TARGETS"
 fi

--- a/defaults/hooks/guard-worktree-paths.sh
+++ b/defaults/hooks/guard-worktree-paths.sh
@@ -255,4 +255,4 @@ if path_derived_allow "$NORM_PATH"; then
     exit 0
 fi
 
-emit_deny "BLOCKED: Edit/Write path '${NORM_PATH}' resolves to the main repository checkout ('${MAIN_ROOT}'), but a Loom-managed worktree exists for this session. Builders must write inside their issue worktree (.loom/worktrees/issue-<N>), never the main checkout. (#4007)"
+emit_deny "BLOCKED: Edit/Write path '${NORM_PATH}' resolves to the main repository checkout ('${MAIN_ROOT}'), but a Loom-managed worktree exists for this session. Builders must write inside their issue worktree (.loom/worktrees/issue-<N>), never the main checkout. Do NOT retry this write via Bash redirection/tee/sed -i/cp/mv -- that is also confined (guard-destructive-generic.sh, #4178) and denied for the same reason. cd into your issue worktree and write there instead. (#4007)"

--- a/defaults/hooks/tests/test-guard-worktree-paths.sh
+++ b/defaults/hooks/tests/test-guard-worktree-paths.sh
@@ -127,6 +127,19 @@ else
     fail "deny reason explains main-checkout + worktree contract (got: $reason)"
 fi
 
+# --- deny reason warns against the Bash-redirection bypass (#4178) ---------
+# The reason must explicitly steer away from retrying via Bash (>, tee, sed -i,
+# cp/mv) -- that bypass is exactly what sweep #4063 used, and the same target
+# is independently confined by guard-destructive-generic.sh's write-
+# confinement category. Belt-and-suspenders: this asserts the Edit/Write
+# guard's message CARRIES the warning; the Bash-side confinement is covered by
+# tests/hooks/test-guard-destructive.sh.
+if [[ "$reason" == *"Bash"* ]]; then
+    pass "deny reason warns against retrying via Bash redirection (#4178)"
+else
+    fail "deny reason warns against retrying via Bash redirection (#4178) (got: $reason)"
+fi
+
 # --- fail-open: no sentinel anywhere -----------------------------------
 rm -rf "$TMPROOT/.loom/worktrees"
 result=$(run_hook "$TMPROOT/CLAUDE.md")

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -2070,6 +2070,27 @@ make_wt_repo() {
     echo "$dir"
 }
 
+# Create a throwaway git repo with a REAL linked git worktree (via `git
+# worktree add`) at <repo>/.loom/worktrees/issue-1, carrying a `.loom-managed`
+# sentinel. Unlike make_wt_repo (a plain subdirectory), a linked worktree
+# exercises the show-toplevel vs. git-common-dir divergence: from inside the
+# worktree, `git rev-parse --show-toplevel` returns the *worktree* root while
+# `--git-common-dir/..` returns the *main* checkout. Echoes the repo path.
+make_wt_repo_linked() {
+    local dir
+    dir=$(mktemp -d 2>/dev/null)
+    dir=$(cd "$dir" && pwd -P)
+    git -C "$dir" init -q >/dev/null 2>&1
+    git -C "$dir" -c user.email=loom@test -c user.name=loom \
+        commit -q --allow-empty -m init >/dev/null 2>&1
+    mkdir -p "$dir/defaults/hooks" "$dir/.loom/worktrees"
+    git -C "$dir" worktree add -q "$dir/.loom/worktrees/issue-1" \
+        -b feature/issue-1 >/dev/null 2>&1
+    mkdir -p "$dir/.loom/worktrees/issue-1/src"
+    : > "$dir/.loom/worktrees/issue-1/.loom-managed"
+    echo "$dir"
+}
+
 WT_REPO=$(make_wt_repo)
 WT_DIR="$WT_REPO/.loom/worktrees/issue-1"
 
@@ -2124,7 +2145,31 @@ assert_allow "write-confinement: '>' inside a quoted -m value is not a target" \
 assert_allow "write-confinement: fd-dup 2>&1 is not treated as a file write" \
     "echo x 2>&1 | tee /tmp/loom-test-$$-log" "$WT_REPO"
 
-rm -rf "$WT_REPO" "$WT_REPO_NOWT" "$WT_REPO_OFF"
+# -------------------------------------------------------------------------
+# Regression (#4210): CWD is the builder's own LINKED worktree, and the write
+# targets the MAIN checkout by absolute path (or via `cd $MAIN`). This is the
+# canonical builder setup (`cd .loom/worktrees/issue-N`). The guard must key
+# its "inside the main checkout" test on the true main root
+# (--git-common-dir/..), NOT on `git rev-parse --show-toplevel` (which returns
+# the worktree root from a linked worktree) — otherwise a main-checkout write
+# from a worktree CWD slips through as ALLOW, leaving the headline #4178
+# protection open in exactly the configuration it is meant to cover.
+WT_REPO_LINKED=$(make_wt_repo_linked)
+WT_LINKED_DIR="$WT_REPO_LINKED/.loom/worktrees/issue-1"
+assert_deny "write-confinement: CWD=linked worktree, abs main-checkout write denies (#4210)" \
+    "echo x > $WT_REPO_LINKED/defaults/hooks/f.sh" "$WT_LINKED_DIR"
+assert_deny "write-confinement: CWD=linked worktree, cd \$MAIN && relative main write denies (#4210)" \
+    "cd $WT_REPO_LINKED && echo x > defaults/hooks/f.sh" "$WT_LINKED_DIR"
+assert_deny "write-confinement: CWD=linked worktree, sed -i on abs main-checkout path denies (#4210)" \
+    "sed -i 's/a/b/' $WT_REPO_LINKED/defaults/hooks/f.sh" "$WT_LINKED_DIR"
+# Sibling-allow checks from the same worktree CWD: writing inside the worktree
+# and to /tmp must still be permitted (no over-blocking from the new main root).
+assert_allow "write-confinement: CWD=linked worktree, write inside the worktree allows (#4210)" \
+    "echo x > $WT_LINKED_DIR/src/f.sh" "$WT_LINKED_DIR"
+assert_allow "write-confinement: CWD=linked worktree, write to /tmp allows (#4210)" \
+    "echo x > /tmp/loom-test-$$-linked.sh" "$WT_LINKED_DIR"
+
+rm -rf "$WT_REPO" "$WT_REPO_NOWT" "$WT_REPO_OFF" "$WT_REPO_LINKED"
 
 echo ""
 

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -2029,6 +2029,106 @@ fi
 echo ""
 
 # =========================================================================
+echo -e "${YELLOW}--- Bash-tool write confinement (guards.worktreeIsolation / LOOM_GUARD_WORKTREE_ISOLATION, #4178) ---${NC}"
+# =========================================================================
+#
+# guard-worktree-paths.sh confines Edit/Write tool calls to a builder's issue
+# worktree, but the Bash tool had no equivalent -- `>`/`>>` redirection, `tee`,
+# `sed -i`, `cp`/`mv` all write files without going through Edit/Write. Sweep
+# #4063 used exactly this escape to edit live guard hooks in the main checkout
+# while its own worktree stayed clean (see issue #4178's root-cause writeup:
+# the guard denied 10x on the Edit/Write path, then the escaped edits landed
+# in the silent window that followed via a Bash write instead).
+#
+# Fixture: an isolated throwaway git repo (its own REPO_ROOT / MAIN_ROOT, so
+# these tests never touch the real Loom checkout) with a managed worktree at
+# <repo>/.loom/worktrees/issue-1 (the `.loom-managed` sentinel worktree.sh
+# writes at every worktree root).
+
+# Create a throwaway git repo with a fixture managed worktree
+# (<repo>/.loom/worktrees/issue-1/.loom-managed) and an optional
+# .loom/config.json. Echoes the repo path.
+make_wt_repo() {
+    local config_json="${1:-}"
+    local dir
+    dir=$(mktemp -d 2>/dev/null)
+    # Canonicalize: on macOS, mktemp -d returns a path under the /var/folders
+    # symlink whose real target is /private/var/folders. The guard resolves
+    # REPO_ROOT via `git rev-parse --show-toplevel`, which returns the
+    # SYMLINK-RESOLVED form — so comparing an unresolved dir against it would
+    # spuriously mismatch (the guard would see the write as "outside the main
+    # checkout" and allow it). `cd ... && pwd -P` resolves symlinks the same
+    # way the guard's own git-based resolution does.
+    dir=$(cd "$dir" && pwd -P)
+    git -C "$dir" init -q >/dev/null 2>&1
+    mkdir -p "$dir/.loom/worktrees/issue-1/src" "$dir/defaults/hooks"
+    : > "$dir/.loom/worktrees/issue-1/.loom-managed"
+    if [[ -n "$config_json" ]]; then
+        mkdir -p "$dir/.loom"
+        printf '%s' "$config_json" > "$dir/.loom/config.json"
+    fi
+    echo "$dir"
+}
+
+WT_REPO=$(make_wt_repo)
+WT_DIR="$WT_REPO/.loom/worktrees/issue-1"
+
+assert_deny "write-confinement: echo > main-checkout path denies" \
+    "echo x > $WT_REPO/defaults/hooks/f.sh" "$WT_REPO"
+assert_deny "write-confinement: echo >> (append) main-checkout path denies" \
+    "echo x >> $WT_REPO/defaults/hooks/f.sh" "$WT_REPO"
+assert_deny "write-confinement: tee main-checkout path denies" \
+    "echo x | tee $WT_REPO/f" "$WT_REPO"
+assert_deny "write-confinement: sed -i on main-checkout path denies" \
+    "sed -i 's/a/b/' $WT_REPO/f" "$WT_REPO"
+assert_deny "write-confinement: cp destination in main checkout denies" \
+    "cp /tmp/a.sh $WT_REPO/defaults/hooks/f.sh" "$WT_REPO"
+assert_deny "write-confinement: mv destination in main checkout denies" \
+    "mv /tmp/a.sh $WT_REPO/defaults/hooks/f.sh" "$WT_REPO"
+assert_deny "write-confinement: heredoc cat > main-checkout path denies" \
+    "cat > $WT_REPO/defaults/hooks/f.sh <<EOF
+hello
+EOF" "$WT_REPO"
+assert_deny "write-confinement: relative target + cwd at main root denies" \
+    "echo x > defaults/hooks/f.sh" "$WT_REPO"
+
+assert_allow "write-confinement: echo > target inside the managed worktree allows" \
+    "echo x > $WT_DIR/src/f.sh" "$WT_REPO"
+assert_allow "write-confinement: tee target inside the managed worktree allows" \
+    "echo x | tee $WT_DIR/src/f.sh" "$WT_REPO"
+assert_allow "write-confinement: echo > target in /tmp allows" \
+    "echo x > /tmp/loom-test-$$-f.sh" "$WT_REPO"
+assert_allow "write-confinement: cd <worktree> && echo > relative target allows" \
+    "cd $WT_DIR && echo x > f.sh" "$WT_REPO"
+
+# No managed worktree anywhere -> fail open (allow).
+WT_REPO_NOWT=$(make_wt_repo)
+rm -rf "$WT_REPO_NOWT/.loom/worktrees"
+assert_allow "write-confinement: no managed worktree anywhere -> allow (fail-open)" \
+    "echo x > $WT_REPO_NOWT/defaults/hooks/f.sh" "$WT_REPO_NOWT"
+
+# Toggle opt-out: guards.worktreeIsolation:false / LOOM_GUARD_WORKTREE_ISOLATION=0.
+WT_REPO_OFF=$(make_wt_repo '{"guards":{"worktreeIsolation":false}}')
+assert_allow "write-confinement: guards.worktreeIsolation:false -> allow at main root" \
+    "echo x > $WT_REPO_OFF/defaults/hooks/f.sh" "$WT_REPO_OFF"
+assert_allow_env "write-confinement: LOOM_GUARD_WORKTREE_ISOLATION=0 -> allow at main root" \
+    "LOOM_GUARD_WORKTREE_ISOLATION=0" "echo x > $WT_REPO/defaults/hooks/f.sh" "$WT_REPO"
+assert_deny_env "write-confinement: LOOM_GUARD_WORKTREE_ISOLATION=1 overrides config-off -> deny" \
+    "LOOM_GUARD_WORKTREE_ISOLATION=1" "echo x > $WT_REPO_OFF/defaults/hooks/f.sh" "$WT_REPO_OFF"
+
+# False-positive guard: a `>` quoted inside a -m/--body value must NOT be
+# read as a redirection target (COMMAND_ASK_SCAN redaction, mirrors #3679).
+assert_allow "write-confinement: '>' inside a quoted -m value is not a target" \
+    "git commit -m \"if (a > b) then something\"" "$WT_REPO"
+# fd-dup (2>&1) is not a file write and must not manufacture a phantom target.
+assert_allow "write-confinement: fd-dup 2>&1 is not treated as a file write" \
+    "echo x 2>&1 | tee /tmp/loom-test-$$-log" "$WT_REPO"
+
+rm -rf "$WT_REPO" "$WT_REPO_NOWT" "$WT_REPO_OFF"
+
+echo ""
+
+# =========================================================================
 echo -e "${YELLOW}--- Performance check ---${NC}"
 # =========================================================================
 


### PR DESCRIPTION
## Root cause (from the issue's curated findings, re-verified)

`.loom/logs/hook-errors.log` shows sweep #4063's Builder session was denied
**10x** on the Edit/Write path between 03:31:34Z and 03:33:02Z (targets:
`defaults/hooks/guard-destructive-generic.sh`, `defaults/hooks/guard-loom-workflow.sh`),
then went silent. The escaped edits to those files -- and to the `.loom/hooks/`
installed copies, which were **never denied at all** (zero log entries) --
landed in that silent window. There is no code path where repeated Edit/Write
denials start succeeding, and the `.loom-managed` worktree + config toggle were
unchanged throughout, so the edits necessarily went through a channel the
Edit/Write guard doesn't see.

`guard-worktree-paths.sh` only registers on the `Edit|Write` tool matcher. The
Bash matcher runs `guard-destructive.sh` -> `guard-destructive-generic.sh` +
`guard-loom-workflow.sh`, and **neither confined write targets to a worktree**
-- they detect destructive command *classes*, not out-of-worktree *writes*. So
a Bash-tool write (`>`, `tee`, `sed -i`, `cp`/`mv`) to the exact same path the
Edit/Write guard had just denied was never even inspected. That also explains
why the `.loom/hooks/` copies diverged from `defaults/hooks/`: they were
hand-written twice via Bash rather than produced by `resync-installed.sh`.

## Fix

- **`defaults/hooks/guard-destructive-generic.sh`** -- new Bash-tool
  write-confinement category. `extract_write_targets()` (a new awk-based
  extractor reusing the file's existing quote-aware `qsplit` segmenter)
  recognizes `>`/`>>` redirection (bare, attached, fd-prefixed; excludes
  fd-dup forms like `2>&1`), `tee <file>...`, `sed -i ... <file>` and
  `cp`/`mv ... <dest>`, threading a `cd <path>` segment's cwd across `&&`
  chains. Each resolved target is checked with the same allow/deny logic
  `guard-worktree-paths.sh` uses: allow if inside any `.loom-managed`
  worktree, allow if outside the main checkout entirely (e.g. `/tmp`), deny
  only if it resolves into the main checkout **and** a managed worktree
  exists somewhere (`resolve_worktree_root()`, already present in this file
  for the `guards.rmScope` check, is reused unchanged). Gated by the
  **existing** `guards.worktreeIsolation` / `LOOM_GUARD_WORKTREE_ISOLATION`
  toggle -- no new config key. Never a non-zero exit; any parse ambiguity
  resolves to allow. Scans the already comment-stripped and
  literal-text-redacted `COMMAND_ASK_SCAN` copy (not the raw command), so a
  `>` quoted inside a `--body`/`-m`/`--title`/`--notes`/`--comment` value
  (e.g. a commit message) can't manufacture a phantom target.
- **`defaults/hooks/guard-worktree-paths.sh`** -- hardened the deny message:
  explicitly tells the agent not to retry via Bash redirection/tee/sed -i/cp/mv
  and to `cd` into the issue worktree instead.
- **`defaults/.claude/commands/loom/builder.md`** /
  **`builder-worktree.md`** -- Builders now assert `.loom-managed` presence
  and `git rev-parse --show-toplevel` equality for `$WORKTREE_ABS` before any
  edit, and are told explicitly that a guard denial is never a signal to
  retry the same write through the other tool (Edit/Write vs. Bash).
- **`defaults/.claude/commands/loom/sweep.md`** -- documents the same
  cwd-assertion step for the dispatched Builder phase, and corrects a stale
  claim in the "verify main is clean" backstop section that
  `guard-worktree-paths.sh` "does not fire" for Task-subagent builders -- its
  #4007 path-derived fallback (`.loom-managed` walk-up, no env var needed)
  does fire on that path; the backstop remains valuable for what the guards'
  heuristics don't recognize (e.g. an interpreter one-liner).
- **`defaults/docs/guard-hooks.md`** -- documents the new category and
  confirms `guards.worktreeIsolation:false` / `LOOM_GUARD_WORKTREE_ISOLATION=0`
  remains the supported escape hatch for a human/driver session that needs to
  edit the main checkout directly -- one toggle now covers both mechanisms.
- **Installed `.loom/hooks/` copies** -- manually synced from `defaults/`
  (this repo's own installed copies are git-tracked for dogfooding;
  `resync-installed.sh` resolves `REPO_ROOT` via `git rev-parse
  --git-common-dir`, which points at the *main* checkout even from this
  worktree, so it can't be used to sync a worktree's own uncommitted
  `defaults/` changes into that same worktree's `.loom/hooks/`).

## Tests

- New cases in `tests/hooks/test-guard-destructive.sh`: fixture managed
  worktree + main-checkout target for `>`, `>>`, `tee`, `sed -i`, `cp`, `mv`,
  heredoc `cat > ... <<EOF`, relative target + cwd at main root (all deny);
  same idioms targeting the worktree or `/tmp` (allow); no managed worktree
  anywhere (fail-open allow); `cd <worktree> && echo x > f` (cwd-tracking,
  allow); `guards.worktreeIsolation:false` / `LOOM_GUARD_WORKTREE_ISOLATION=0`
  (allow) and `=1` overriding a config `false` (deny); a `>` quoted inside a
  `-m` value and an `fd-dup` (`2>&1`) don't manufacture phantom targets.
- `defaults/hooks/tests/test-guard-worktree-paths.sh`: added an assertion
  that the hardened deny message warns against retrying via Bash.
- Full suite run (env-isolated from this host's `LOOM_FORCE_SCOPE`/
  `LOOM_GUARD_DECISION_LOG` autonomous-mode exports, which otherwise leak
  into the test subprocess and alter unrelated force-op assertions):
  `tests/hooks/test-guard-destructive.sh` 434/434,
  `defaults/hooks/tests/test-guard-worktree-paths.sh` 20/20,
  `tests/hooks/test-guard-loom-workflow.sh` 27/27,
  `tests/hooks/test-guard-destructive-dispatcher.sh` 7/7. `shellcheck -S
  warning` clean on both edited hooks.

## Out of scope (per the curated issue)

Cross-issue worktree isolation (#3719); an auditor/monitor alert on the
"deny-cluster + dirty main checkout" signature; covering every conceivable
Bash write vector (an interpreter one-liner like `python -c` is unparseable
from a shell hook -- the goal is removing the easy fallback, not building a
full security boundary).

Closes #4178