### PR TITLE
feat(daemon): native `loom-daemon tokens import-from-monitor` (#4106)

### DIFF
--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -224,9 +224,10 @@ enum Commands {
     /// bookkeeping CLI. As of #4080 (Phase 2) `check` is also the
     /// implementation `probe-tokens.sh` and the daemon's own ranking
     /// self-refresh invoke natively. As of #4105 `bootstrap` is native too
-    /// (multi-source `.env` merge + pool provisioning); `spawn-claude.sh`
-    /// (selection) and `import-from-monitor` (issue #4106) remain Python-only
-    /// (see `loom-daemon/src/tokens_pool/mod.rs`). Purely file-based; does not
+    /// (multi-source `.env` merge + pool provisioning), and as of #4106
+    /// `import-from-monitor` is native too (claude-monitor live SQLite
+    /// import); `spawn-claude.sh` (selection) remains Python-only (see
+    /// `loom-daemon/src/tokens_pool/mod.rs`). Purely file-based; does not
     /// require a running daemon.
     Tokens {
         #[command(subcommand)]
@@ -416,6 +417,48 @@ enum TokensAction {
         /// Overwrite existing token files even if their fingerprint matches.
         #[arg(long)]
         force: bool,
+
+        /// Report what would change without writing any files.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Emit a JSON summary on stdout.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Materialize `.loom/tokens/` from claude-monitor's LIVE credential store
+    /// (`~/.claude-monitor/usage.db`) instead of the `accounts.env` snapshot.
+    /// Use this after rolling accounts: the snapshot keeps the old (now
+    /// revoked) tokens, so `bootstrap --force` would rewrite them unchanged.
+    /// Native Rust port of the historical Python `loom-tokens
+    /// import-from-monitor` CLI (issue #4106, epic #4081).
+    ImportFromMonitor {
+        /// Repo root (plain path, default `.` — no upward `.git` walk). The
+        /// pool is written to `<workspace>/.loom/tokens` unless `--shared`.
+        #[arg(long, value_name = "PATH", default_value = ".")]
+        workspace: String,
+
+        /// Import into the SHARED machine-level pool at `~/.loom/tokens`
+        /// (override with `$LOOM_SHARED_TOKENS_DIR`) instead of the
+        /// repo-local `<repo>/.loom/tokens`.
+        #[arg(long)]
+        shared: bool,
+
+        /// Path to claude-monitor's `usage.db` (default: `<claude-monitor
+        /// dir>/usage.db`, honoring `$LOOM_CLAUDE_MONITOR_DIR`).
+        #[arg(long, value_name = "PATH")]
+        db: Option<String>,
+
+        /// Overwrite on-disk tokens that differ from the store. Required to
+        /// apply rolled tokens, since every rolled token differs by design.
+        #[arg(long)]
+        force: bool,
+
+        /// Delete `*.token` files for accounts claude-monitor no longer
+        /// reports active (pool state files are never touched).
+        #[arg(long)]
+        prune: bool,
 
         /// Report what would change without writing any files.
         #[arg(long)]
@@ -3605,6 +3648,47 @@ fn print_effective_accounts(result: &loom_daemon::tokens_pool::bootstrap::Bootst
     }
 }
 
+/// Print the imported account set from `import-from-monitor`. Secrets are
+/// never shown. Mirrors `cli._print_monitor_import`.
+fn print_monitor_import(result: &loom_daemon::tokens_pool::monitor_db::MonitorImportResult) {
+    let disp = |p: &Option<std::path::PathBuf>| -> String {
+        p.as_ref()
+            .map_or_else(|| "(none)".to_string(), |p| p.display().to_string())
+    };
+    println!("claude-monitor store: {}", disp(&result.db_path));
+    println!("Destination pool: {}", disp(&result.tokens_dir));
+
+    if result.effective.is_empty() {
+        println!("Active accounts: (none)");
+        return;
+    }
+
+    let written: std::collections::HashSet<&str> =
+        result.written.iter().map(String::as_str).collect();
+    let unchanged: std::collections::HashSet<&str> =
+        result.unchanged.iter().map(String::as_str).collect();
+    let drifted: std::collections::HashSet<&str> =
+        result.drifted.iter().map(String::as_str).collect();
+
+    println!("Active accounts ({}):", result.effective.len());
+    for a in &result.effective {
+        let disposition = if written.contains(a.file.as_str()) {
+            "written"
+        } else if unchanged.contains(a.file.as_str()) {
+            "unchanged"
+        } else if drifted.contains(a.file.as_str()) {
+            "DRIFT (use --force)"
+        } else {
+            "-"
+        };
+        println!("  {}  {}  [{disposition}]", a.name, a.email);
+    }
+
+    if !result.pruned.is_empty() {
+        println!("Pruned ({}): {}", result.pruned.len(), result.pruned.join(", "));
+    }
+}
+
 /// Handle `loom-daemon tokens <select|pin|unpin|unblock>` (Issue #4082,
 /// Phase 1 of epic #4081). Purely file-based — does not require a running
 /// daemon. See `loom-daemon/src/tokens_pool/mod.rs` for the ported subset
@@ -3747,6 +3831,91 @@ fn handle_tokens_command(action: TokensAction) -> Result<()> {
 
             // Unresolved drift without --force is a non-zero exit so CI can
             // detect divergence (mirrors cli._cmd_bootstrap).
+            if !result.drifted.is_empty() && !force {
+                std::process::exit(2);
+            }
+            Ok(())
+        }
+
+        TokensAction::ImportFromMonitor {
+            workspace,
+            shared,
+            db,
+            force,
+            prune,
+            dry_run,
+            json,
+        } => {
+            use loom_daemon::tokens_pool::monitor_db::{
+                import_from_monitor, ImportOptions, MonitorImportError,
+            };
+            use loom_daemon::tokens_pool::paths::shared_tokens_dir;
+
+            // Destination: the shared machine-level pool, or this repo's pool
+            // (mirrors cli._cmd_import_from_monitor). `--workspace` is a
+            // plain path here (no upward `.git` walk), matching the sibling
+            // `bootstrap` / `check` / `select` CLI arms.
+            let tokens_dir = if shared {
+                match shared_tokens_dir() {
+                    Some(dir) => {
+                        eprintln!(
+                            "Importing into the shared machine-level pool at {}",
+                            dir.display()
+                        );
+                        dir
+                    }
+                    None => {
+                        eprintln!(
+                            "error: --shared requested but the shared pool is disabled \
+                             (LOOM_SHARED_TOKENS_DIR is empty). Unset it or point it at a directory."
+                        );
+                        std::process::exit(1);
+                    }
+                }
+            } else {
+                let ws = resolve_tokens_workspace(&workspace)?;
+                ws.join(".loom").join("tokens")
+            };
+
+            let db_path = db.map(std::path::PathBuf::from);
+            let opts = ImportOptions {
+                tokens_dir: &tokens_dir,
+                db_path: db_path.as_deref(),
+                monitor_dir: None,
+                force,
+                dry_run,
+                prune,
+            };
+
+            let result = match import_from_monitor(&opts) {
+                Ok(r) => r,
+                Err(
+                    e @ (MonitorImportError::DbUnavailable(_)
+                    | MonitorImportError::DuplicateFile(_)),
+                ) => {
+                    eprintln!("error: {e}");
+                    std::process::exit(1);
+                }
+                Err(MonitorImportError::Io(e)) => {
+                    return Err(anyhow!("import-from-monitor failed: {e}"))
+                }
+            };
+
+            // Warnings (no active credentials, unreadable tokens, prune
+            // failures, drift) go to stderr so `--json` stdout stays clean.
+            for w in &result.warnings {
+                eprintln!("warning: {w}");
+            }
+
+            if json {
+                println!("{}", serde_json::to_string_pretty(&result.to_json())?);
+            } else {
+                print_monitor_import(&result);
+            }
+
+            // Unresolved drift without --force is the "rolled tokens not
+            // applied" case; exit non-zero so a script notices the pool is
+            // still stale (mirrors cli._cmd_import_from_monitor).
             if !result.drifted.is_empty() && !force {
                 std::process::exit(2);
             }

--- a/loom-daemon/src/tokens_pool/mod.rs
+++ b/loom-daemon/src/tokens_pool/mod.rs
@@ -30,6 +30,7 @@
 //! | [`select`] | `tokens/select.py` | 3-tier selection algorithm |
 //! | [`check`] | `tokens/check.py` | HTTP rate-limit probe (curl transport) + `.ranking` writer |
 //! | [`monitor`] | `tokens/monitor.py` | claude-monitor `ranking.json` consumer (`--source auto\|monitor`) |
+//! | [`monitor_db`] | `tokens/monitor_db.py` | claude-monitor live SQLite (`usage.db`) import, `import-from-monitor` |
 //!
 //! The probe path ([`check`] + [`monitor`], issue #4094) shells to `curl`
 //! rather than take an HTTP-client crate — following the [`rng`] precedent of
@@ -38,13 +39,13 @@
 //! [`check::ProbeTransport`] trait so tests never touch the network.
 //!
 //! `bootstrap.py` (multi-source `.env` merge + file provisioning) was ported in
-//! issue #4105 as [`bootstrap`]. **Still deferred**: `monitor_db.py`
-//! (claude-monitor SQLite import, consumed by `import-from-monitor`, issue
-//! #4106). It is not on the per-dispatch hot path (it runs at bootstrap time or
-//! on an operator cadence), so scoping it out keeps each increment reviewable.
-//! [`bootstrap`] leaves the read-only `_check_monitor_divergence` warning
-//! (which reads the live `usage.db`) to that same follow-up, since it depends on
-//! the unported SQLite reader.
+//! issue #4105 as [`bootstrap`]. `monitor_db.py` (claude-monitor SQLite import,
+//! consumed by `import-from-monitor`) was ported in issue #4106 as
+//! [`monitor_db`], reusing [`bootstrap::materialize_accounts`] /
+//! [`bootstrap::write_index`] so the writer stays identical by construction.
+//! [`bootstrap`] still leaves the read-only `_check_monitor_divergence` warning
+//! (which reads the live `usage.db`) to a future follow-up, since it is a
+//! bootstrap-time advisory rather than the import path itself.
 //!
 //! # Byte-compatible state (hard requirement)
 //!
@@ -62,6 +63,7 @@ pub mod check;
 pub mod failure_counts;
 pub mod locking;
 pub mod monitor;
+pub mod monitor_db;
 pub mod paths;
 pub mod rng;
 pub mod rotation;

--- a/loom-daemon/src/tokens_pool/monitor_db.rs
+++ b/loom-daemon/src/tokens_pool/monitor_db.rs
@@ -1,0 +1,949 @@
+//! Import **live** account OAuth tokens from claude-monitor's SQLite store.
+//!
+//! Native Rust port of `loom_tools.tokens.monitor_db` (issue #4106, epic #4081
+//! "eliminate Python from Loom", Phase 1, child C). Depends on child B (#4105):
+//! it materializes the pool through the *same* writer `bootstrap` uses
+//! ([`super::bootstrap::materialize_accounts`] / [`super::bootstrap::write_index`]),
+//! so atomic write-then-rename, `0600` file / `0700` directory modes,
+//! fingerprint drift detection, and the `index.json` manifest are identical by
+//! construction rather than by convention.
+//!
+//! # Why a live-store import at all
+//!
+//! Loom treats claude-monitor as its primary account source, but through
+//! `~/.claude-monitor/accounts.env` — a **static snapshot** an operator wrote by
+//! hand at some point. claude-monitor keeps the *live* credentials in its SQLite
+//! store (`usage.db` → `oauth_credentials`) and refreshes them as accounts are
+//! re-authenticated. The two surfaces drift silently: after an account roll the
+//! snapshot still holds the old (now revoked) tokens, so `bootstrap --force`
+//! faithfully rewrites the same dead tokens. This command reads the live store
+//! directly so `--force` applies the freshly-rolled tokens.
+//!
+//! # Read-only, soft dependency
+//!
+//! The database is opened `file:…?mode=ro` (never written, never migrated — it
+//! belongs to another tool) with a bounded busy timeout, and every failure mode
+//! is a clean typed [`MonitorImportError::DbUnavailable`] rather than a crash:
+//! claude-monitor absent, `usage.db` absent, or a schema without
+//! `oauth_credentials` (an older claude-monitor). `LOOM_CLAUDE_MONITOR_DIR`
+//! relocates the directory, so tests never touch a real `~/.claude-monitor`.
+//!
+//! # Secrets
+//!
+//! `oauth_credentials.access_token` is raw secret material. It is carried in
+//! memory only, written solely to `0600` token files, and never logged — logs
+//! and the manifest carry email, filename, and the 8-char fingerprint only.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use regex::Regex;
+use rusqlite::{Connection, OpenFlags};
+
+use super::bootstrap::{
+    derive_token_filename, materialize_accounts, write_index, Account, Warning,
+};
+use super::monitor::claude_monitor_dir;
+
+/// claude-monitor's SQLite store, alongside `ranking.json` / `accounts.env` in
+/// the directory resolved by [`claude_monitor_dir`].
+const MONITOR_DB_NAME: &str = "usage.db";
+
+/// Provenance tag recorded in `index.json` for accounts sourced from the live
+/// DB. Deliberately distinct from `"monitor"` (the `accounts.env` snapshot) so
+/// an operator reading the manifest can tell which surface a token came from.
+const SOURCE_MONITOR_DB: &str = "monitor-db";
+
+/// Opening the DB should be instant; a bounded timeout means a lock held by
+/// claude-monitor surfaces as an error instead of hanging a sweep dispatch.
+const SQLITE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// claude-monitor labels an account either by bare email or as
+/// `"<email>'s Organization"`. This pattern recovers the email from the
+/// organization form. Compiled lazily per call site (matching the house style
+/// in `bootstrap.rs` / `check.rs`; this runs at most once per import).
+fn org_label_re() -> Regex {
+    Regex::new(r"^(?P<email>.+?)'s Organization$").unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Error from [`import_from_monitor`]. Mirrors the Python
+/// `MonitorDbUnavailable` / `ValueError` split so the CLI arm can map exit
+/// codes.
+#[derive(Debug)]
+pub enum MonitorImportError {
+    /// The directory, database file, or `oauth_credentials` table is missing
+    /// (or otherwise unreadable). The message names the path that was tried.
+    DbUnavailable(String),
+    /// Two accounts derive the same token filename (they would clobber each
+    /// other on disk).
+    DuplicateFile(String),
+    /// An IO failure while materializing the pool.
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for MonitorImportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DbUnavailable(m) | Self::DuplicateFile(m) => write!(f, "{m}"),
+            Self::Io(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for MonitorImportError {}
+
+impl From<std::io::Error> for MonitorImportError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DB path + read-only URI
+// ---------------------------------------------------------------------------
+
+/// Return the path to claude-monitor's `usage.db`.
+///
+/// Honors `LOOM_CLAUDE_MONITOR_DIR` via [`claude_monitor_dir`].
+#[must_use]
+pub fn monitor_db_path(monitor_dir: Option<&Path>) -> PathBuf {
+    let base = match monitor_dir {
+        Some(d) => d.to_path_buf(),
+        None => claude_monitor_dir(),
+    };
+    base.join(MONITOR_DB_NAME)
+}
+
+/// Percent-encode a path the way Python's `urllib.parse.quote(s)` (default
+/// `safe='/'`) does: leave `A-Z a-z 0-9 _ . - ~` and `/` intact, `%XX` the
+/// rest (each UTF-8 byte).
+fn percent_encode_path(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    for &b in path.as_bytes() {
+        if b.is_ascii_alphanumeric() || matches!(b, b'_' | b'.' | b'-' | b'~' | b'/') {
+            out.push(b as char);
+        } else {
+            out.push('%');
+            out.push_str(&format!("{b:02X}"));
+        }
+    }
+    out
+}
+
+/// Build the `mode=ro` SQLite URI for `path`.
+///
+/// The path is percent-encoded before interpolation. Without this, a `?` or
+/// `#` anywhere in the path would terminate the URI early and the `mode=ro`
+/// query parameter would be silently dropped — the connection could then open
+/// **read-write** against claude-monitor's live database (#4095). `%` fares
+/// even worse: the unencoded form fails to open a database that is present and
+/// readable.
+fn read_only_uri(path: &Path) -> String {
+    format!("file:{}?mode=ro", percent_encode_path(&path.to_string_lossy()))
+}
+
+// ---------------------------------------------------------------------------
+// Credential reading
+// ---------------------------------------------------------------------------
+
+/// One raw `oauth_credentials` row: `(id, label, access_token, joined_email)`.
+/// The three text columns are nullable in the source schema.
+type CredentialRow = (i64, Option<String>, Option<String>, Option<String>);
+
+/// One active credential row resolved to an email.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MonitorCredential {
+    pub email: String,
+    pub token: String,
+    pub label: String,
+}
+
+/// Recover an email from a credential label, or `None` if it isn't one.
+///
+/// claude-monitor uses either the bare email or `"<email>'s Organization"`.
+/// Anything without an `@` is a display name we cannot join on.
+fn email_from_label(label: &str) -> Option<String> {
+    let text = label.trim();
+    if text.is_empty() {
+        return None;
+    }
+    let text = match org_label_re().captures(text) {
+        Some(caps) => caps.name("email").map_or(text, |m| m.as_str()).trim(),
+        None => text,
+    };
+    if text.contains('@') {
+        Some(text.to_string())
+    } else {
+        None
+    }
+}
+
+/// Read active credentials from claude-monitor's store.
+///
+/// Only `is_active = 1` rows with a non-empty `access_token` are returned:
+/// claude-monitor deactivates rows for accounts an operator has removed, and
+/// importing those would repopulate the pool with retired accounts.
+///
+/// `expires_at` is deliberately **not** used as a filter — observed rows carry
+/// stale timestamps while the token still authenticates; health is established
+/// by probing (`loom-daemon tokens check`), which is authoritative.
+///
+/// When one email has several active rows, the highest `id` wins (rows are
+/// append-ordered, so that is the most recently stored credential). Returns
+/// credentials de-duplicated by email, in first-seen order.
+fn read_monitor_credentials(
+    db_path: &Path,
+    warnings: &mut Vec<Warning>,
+) -> Result<Vec<MonitorCredential>, MonitorImportError> {
+    if !db_path.is_file() {
+        return Err(MonitorImportError::DbUnavailable(format!(
+            "claude-monitor database not found at {}. Is claude-monitor installed on this \
+             host? (Set LOOM_CLAUDE_MONITOR_DIR to point elsewhere.)",
+            db_path.display()
+        )));
+    }
+
+    // Read-only URI: this database belongs to claude-monitor. We never write,
+    // migrate, or take a write lock on it. SQLITE_OPEN_READ_ONLY is belt-and-
+    // suspenders with the `?mode=ro` in the URI; SQLITE_OPEN_URI makes SQLite
+    // parse the string as a URI at all. The path is percent-encoded so a `?`
+    // or `#` in it cannot silently void the read-only guarantee (#4095).
+    let uri = read_only_uri(db_path);
+    let conn = Connection::open_with_flags(
+        &uri,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
+    )
+    .map_err(|e| {
+        MonitorImportError::DbUnavailable(format!("Could not open {}: {e}", db_path.display()))
+    })?;
+    // A lock held by claude-monitor surfaces as an error after the timeout,
+    // rather than hanging a sweep dispatch indefinitely.
+    conn.busy_timeout(SQLITE_TIMEOUT).map_err(|e| {
+        MonitorImportError::DbUnavailable(format!("Could not open {}: {e}", db_path.display()))
+    })?;
+
+    // LEFT JOIN so a credential whose account row is missing still comes back —
+    // its email is then recovered from the label.
+    let query = "SELECT c.id, c.label, c.access_token, a.email \
+                   FROM oauth_credentials c \
+                   LEFT JOIN accounts a ON a.id = c.account_id \
+                  WHERE c.is_active = 1 \
+                  ORDER BY c.id";
+
+    let rows: Vec<CredentialRow> = (|| {
+        let mut stmt = conn.prepare(query)?;
+        let mapped = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+            ))
+        })?;
+        mapped.collect::<rusqlite::Result<Vec<_>>>()
+    })()
+    .map_err(|e: rusqlite::Error| {
+        // A missing oauth_credentials table (older claude-monitor) surfaces as
+        // a "no such table" message — only then is the "predates the credential
+        // store" hint correct. Any other error (a hot WAL missing its -shm
+        // sidecar, a corrupt file) reaches the same branch, and attributing it
+        // to a missing table would send the reader down the wrong path.
+        let msg = e.to_string();
+        let hint = if msg.contains("no such table") {
+            " This claude-monitor may predate the credential store."
+        } else {
+            ""
+        };
+        MonitorImportError::DbUnavailable(format!(
+            "Could not read oauth_credentials from {}: {e}.{hint}",
+            db_path.display()
+        ))
+    })?;
+
+    // De-dup by lowercased email, keeping first-seen order but the latest
+    // (highest-id) credential value — mirrors Python's dict-of-email-lower.
+    let mut order: Vec<String> = Vec::new();
+    let mut by_email: std::collections::BTreeMap<String, MonitorCredential> =
+        std::collections::BTreeMap::new();
+    for (_id, label, access_token, joined_email) in rows {
+        let token = access_token.unwrap_or_default().trim().to_string();
+        if token.is_empty() {
+            continue;
+        }
+        let label = label.unwrap_or_default();
+        let email = {
+            let joined = joined_email.unwrap_or_default();
+            let joined = joined.trim();
+            if joined.is_empty() {
+                match email_from_label(&label) {
+                    Some(e) => e,
+                    None => {
+                        warnings.push(format!(
+                            "claude-monitor credential {label:?} has no resolvable email; \
+                             skipping (cannot derive a stable token filename)."
+                        ));
+                        continue;
+                    }
+                }
+            } else {
+                joined.to_string()
+            }
+        };
+        let key = email.to_lowercase();
+        let display_label = if label.is_empty() {
+            email.clone()
+        } else {
+            label
+        };
+        if !by_email.contains_key(&key) {
+            order.push(key.clone());
+        }
+        by_email.insert(
+            key,
+            MonitorCredential {
+                email,
+                token,
+                label: display_label,
+            },
+        );
+    }
+
+    Ok(order.into_iter().map(|k| by_email[&k].clone()).collect())
+}
+
+/// Convert credentials to [`Account`]s with derived token filenames.
+///
+/// Filenames come from [`derive_token_filename`], the same derivation
+/// `bootstrap` uses, so an account keeps one stable identity across both import
+/// paths and re-importing overwrites in place instead of creating a parallel
+/// file.
+fn credentials_to_accounts(creds: &[MonitorCredential]) -> Vec<Account> {
+    creds
+        .iter()
+        .enumerate()
+        .map(|(i, c)| Account {
+            email: c.email.clone(),
+            key: c.token.clone(),
+            file: derive_token_filename(&c.email),
+            source: SOURCE_MONITOR_DB.to_string(),
+            index: (i + 1) as u32,
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Result
+// ---------------------------------------------------------------------------
+
+/// One entry in the imported account set (no secrets). Mirrors the dicts in
+/// `MonitorImportResult.effective`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectiveAccount {
+    pub email: String,
+    pub name: String,
+    pub file: String,
+    pub source: String,
+}
+
+/// Outcome of a single [`import_from_monitor`] call. Mirrors
+/// `monitor_db.MonitorImportResult`.
+#[derive(Debug, Clone, Default)]
+pub struct MonitorImportResult {
+    pub written: Vec<String>,
+    pub unchanged: Vec<String>,
+    pub drifted: Vec<String>,
+    pub pruned: Vec<String>,
+    pub dry_run: bool,
+    pub tokens_dir: Option<PathBuf>,
+    pub index_path: Option<PathBuf>,
+    pub db_path: Option<PathBuf>,
+    pub effective: Vec<EffectiveAccount>,
+    /// Non-fatal warnings accumulated during the run (no active credentials,
+    /// unresolvable emails, prune failures, drift). The CLI arm decides how to
+    /// surface them; JSON stdout stays clean.
+    pub warnings: Vec<Warning>,
+}
+
+impl MonitorImportResult {
+    /// JSON shape matching `monitor_db.MonitorImportResult.to_dict` (warnings
+    /// are intentionally excluded — Python surfaces them via the logger).
+    #[must_use]
+    pub fn to_json(&self) -> serde_json::Value {
+        let path_str = |p: &Option<PathBuf>| match p {
+            Some(p) => serde_json::Value::String(p.display().to_string()),
+            None => serde_json::Value::Null,
+        };
+        serde_json::json!({
+            "written": self.written,
+            "unchanged": self.unchanged,
+            "drifted": self.drifted,
+            "pruned": self.pruned,
+            "dry_run": self.dry_run,
+            "tokens_dir": path_str(&self.tokens_dir),
+            "index_path": path_str(&self.index_path),
+            "db_path": path_str(&self.db_path),
+            "effective": self.effective.iter().map(|a| serde_json::json!({
+                "email": a.email,
+                "name": a.name,
+                "file": a.file,
+                "source": a.source,
+            })).collect::<Vec<_>>(),
+        })
+    }
+}
+
+/// Options for [`import_from_monitor`].
+pub struct ImportOptions<'a> {
+    /// Destination pool (per-repo `<repo>/.loom/tokens` or the shared
+    /// machine-level pool — the caller resolves which).
+    pub tokens_dir: &'a Path,
+    /// Override the database location (`--db`, tests). When `None`, resolved
+    /// from `monitor_dir`.
+    pub db_path: Option<&'a Path>,
+    /// Override the claude-monitor directory (tests). Ignored when `db_path`
+    /// is set.
+    pub monitor_dir: Option<&'a Path>,
+    /// Overwrite tokens that differ from the store.
+    pub force: bool,
+    /// Report what would change; write nothing.
+    pub dry_run: bool,
+    /// Delete `*.token` files for accounts the store no longer reports active.
+    pub prune: bool,
+}
+
+/// Strip a trailing `.token` suffix to derive a logical account name.
+fn name_from_file(filename: &str) -> String {
+    filename
+        .strip_suffix(".token")
+        .map_or_else(|| filename.to_string(), str::to_string)
+}
+
+/// Materialize `tokens_dir` from claude-monitor's live credential store.
+///
+/// Idempotent: a token whose on-disk fingerprint already matches the store is
+/// left untouched and reported `unchanged`. A token that differs is reported
+/// `drifted` and skipped unless `force` — so a hand-pinned token is never
+/// silently replaced. **After an account roll, `force=true` is the flag that
+/// actually updates the pool**, since every rolled token legitimately differs
+/// from what is on disk.
+///
+/// Mirrors `monitor_db.import_from_monitor`.
+pub fn import_from_monitor(
+    opts: &ImportOptions,
+) -> Result<MonitorImportResult, MonitorImportError> {
+    let resolved_db = match opts.db_path {
+        Some(p) => p.to_path_buf(),
+        None => monitor_db_path(opts.monitor_dir),
+    };
+
+    let mut result = MonitorImportResult {
+        dry_run: opts.dry_run,
+        tokens_dir: Some(opts.tokens_dir.to_path_buf()),
+        index_path: Some(opts.tokens_dir.join("index.json")),
+        db_path: Some(resolved_db.clone()),
+        ..Default::default()
+    };
+
+    let creds = read_monitor_credentials(&resolved_db, &mut result.warnings)?;
+    let accounts = credentials_to_accounts(&creds);
+
+    result.effective = accounts
+        .iter()
+        .map(|a| EffectiveAccount {
+            email: a.email.clone(),
+            name: name_from_file(&a.file),
+            file: a.file.clone(),
+            source: a.source.clone(),
+        })
+        .collect();
+
+    if accounts.is_empty() {
+        result.warnings.push(format!(
+            "No active credentials in {}; nothing to import. Check that claude-monitor has \
+             accounts configured.",
+            resolved_db.display()
+        ));
+        return Ok(result);
+    }
+
+    // Two distinct emails can derive the same stem (e.g. a.jones@x.com and
+    // ajones@x.com). Fail loudly rather than let one clobber the other.
+    let mut seen: std::collections::BTreeMap<String, &Account> = std::collections::BTreeMap::new();
+    for acct in &accounts {
+        if let Some(prior) = seen.get(&acct.file) {
+            return Err(MonitorImportError::DuplicateFile(format!(
+                "duplicate token filename: {} maps to both {:?} and {:?}",
+                acct.file, prior.email, acct.email
+            )));
+        }
+        seen.insert(acct.file.clone(), acct);
+    }
+
+    let outcome = materialize_accounts(
+        &accounts,
+        opts.tokens_dir,
+        opts.force,
+        opts.dry_run,
+        &mut result.warnings,
+    )?;
+    result.written = outcome.written.clone();
+    result.unchanged = outcome.unchanged.clone();
+    result.drifted = outcome.drifted.clone();
+
+    if opts.prune {
+        let keep: BTreeSet<String> = accounts.iter().map(|a| a.file.clone()).collect();
+        result.pruned =
+            prune_stale_tokens(opts.tokens_dir, &keep, opts.dry_run, &mut result.warnings);
+    }
+
+    write_index(&outcome.manifest_accounts, result.index_path.as_ref().unwrap(), opts.dry_run)?;
+
+    if !result.drifted.is_empty() && !opts.force {
+        result.warnings.push(format!(
+            "{} token(s) differ from claude-monitor's store and were left as-is; re-run with \
+             --force to overwrite. After rolling accounts this is expected — --force is what \
+             applies the new tokens.",
+            result.drifted.len()
+        ));
+    }
+
+    Ok(result)
+}
+
+/// Delete `*.token` files not in `keep`; return the filenames removed.
+///
+/// Globbing `*.token` deliberately excludes the pool's state files
+/// (`.ranking`, `.bad_tokens`, `.failure_counts`, `.allowlist`) and
+/// `index.json`, none of which carry that suffix — pruning never disturbs
+/// rotation state.
+fn prune_stale_tokens(
+    tokens_dir: &Path,
+    keep: &BTreeSet<String>,
+    dry_run: bool,
+    warnings: &mut Vec<Warning>,
+) -> Vec<String> {
+    if !tokens_dir.is_dir() {
+        return Vec::new();
+    }
+    // Collect + sort for deterministic ordering (Python sorts the glob).
+    let mut candidates: Vec<(String, PathBuf)> = Vec::new();
+    let entries = match std::fs::read_dir(tokens_dir) {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.ends_with(".token") && !keep.contains(&name) {
+            candidates.push((name, entry.path()));
+        }
+    }
+    candidates.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut pruned: Vec<String> = Vec::new();
+    for (name, path) in candidates {
+        if dry_run {
+            pruned.push(name);
+            continue;
+        }
+        match std::fs::remove_file(&path) {
+            Ok(()) => pruned.push(name),
+            Err(e) => warnings.push(format!("Could not prune {}: {e}", path.display())),
+        }
+    }
+    pruned
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// Seed a fixture `usage.db` with the `accounts` + `oauth_credentials`
+    /// schema the reader queries. `creds` rows are
+    /// `(label, access_token, account_email, is_active)`.
+    fn seed_usage_db(db_path: &Path, creds: &[(&str, &str, Option<&str>, i64)]) {
+        let conn = Connection::open(db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE accounts (id INTEGER PRIMARY KEY, email TEXT);
+             CREATE TABLE oauth_credentials (
+                 id INTEGER PRIMARY KEY,
+                 label TEXT,
+                 access_token TEXT,
+                 account_id INTEGER,
+                 is_active INTEGER
+             );",
+        )
+        .unwrap();
+        let mut next_account_id = 1i64;
+        for (label, token, account_email, is_active) in creds {
+            let account_id = match account_email {
+                Some(email) => {
+                    let id = next_account_id;
+                    next_account_id += 1;
+                    conn.execute(
+                        "INSERT INTO accounts (id, email) VALUES (?1, ?2)",
+                        rusqlite::params![id, email],
+                    )
+                    .unwrap();
+                    Some(id)
+                }
+                None => None,
+            };
+            conn.execute(
+                "INSERT INTO oauth_credentials (label, access_token, account_id, is_active) \
+                 VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![label, token, account_id, is_active],
+            )
+            .unwrap();
+        }
+    }
+
+    // ---- email_from_label / org regex ---------------------------------
+
+    #[test]
+    fn email_from_label_bare_email() {
+        assert_eq!(email_from_label("alice@example.com").as_deref(), Some("alice@example.com"));
+    }
+
+    #[test]
+    fn email_from_label_org_form() {
+        assert_eq!(
+            email_from_label("bob@example.com's Organization").as_deref(),
+            Some("bob@example.com")
+        );
+    }
+
+    #[test]
+    fn email_from_label_non_email_is_none() {
+        assert!(email_from_label("Acme Inc").is_none());
+        assert!(email_from_label("").is_none());
+        assert!(email_from_label("   ").is_none());
+    }
+
+    // ---- percent-encoding / read-only URI -----------------------------
+
+    #[test]
+    fn read_only_uri_percent_encodes_special_chars() {
+        let uri = read_only_uri(Path::new("/tmp/we?rd#dir/usage.db"));
+        assert_eq!(uri, "file:/tmp/we%3Frd%23dir/usage.db?mode=ro");
+        // The literal ?mode=ro delimiter is the only unencoded '?'.
+        assert!(uri.ends_with("?mode=ro"));
+    }
+
+    // ---- read_monitor_credentials -------------------------------------
+
+    #[test]
+    fn reads_active_credentials_and_filters_inactive() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("usage.db");
+        seed_usage_db(
+            &db,
+            &[
+                ("alice@example.com", "sk-live-alice", Some("alice@example.com"), 1),
+                ("bob@example.com", "sk-live-bob", Some("bob@example.com"), 1),
+                // Inactive -> filtered out.
+                ("carol@example.com", "sk-live-carol", Some("carol@example.com"), 0),
+            ],
+        );
+        let mut warnings = Vec::new();
+        let creds = read_monitor_credentials(&db, &mut warnings).unwrap();
+        let emails: Vec<&str> = creds.iter().map(|c| c.email.as_str()).collect();
+        assert_eq!(emails, ["alice@example.com", "bob@example.com"]);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn recovers_email_from_org_label_when_join_is_null() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("usage.db");
+        // No accounts row (account_email = None) -> email recovered from label.
+        seed_usage_db(&db, &[("dave@example.com's Organization", "sk-dave", None, 1)]);
+        let mut warnings = Vec::new();
+        let creds = read_monitor_credentials(&db, &mut warnings).unwrap();
+        assert_eq!(creds.len(), 1);
+        assert_eq!(creds[0].email, "dave@example.com");
+    }
+
+    #[test]
+    fn skips_rows_with_unresolvable_email_and_warns() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("usage.db");
+        seed_usage_db(&db, &[("Some Display Name", "sk-x", None, 1)]);
+        let mut warnings = Vec::new();
+        let creds = read_monitor_credentials(&db, &mut warnings).unwrap();
+        assert!(creds.is_empty());
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("no resolvable email"));
+    }
+
+    #[test]
+    fn skips_rows_with_empty_token() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("usage.db");
+        seed_usage_db(&db, &[("a@x.com", "", Some("a@x.com"), 1)]);
+        let mut warnings = Vec::new();
+        let creds = read_monitor_credentials(&db, &mut warnings).unwrap();
+        assert!(creds.is_empty());
+    }
+
+    #[test]
+    fn highest_id_wins_for_duplicate_email() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("usage.db");
+        seed_usage_db(
+            &db,
+            &[
+                ("a@x.com", "old-token", Some("a@x.com"), 1),
+                ("a@x.com", "new-token", Some("a@x.com"), 1),
+            ],
+        );
+        let mut warnings = Vec::new();
+        let creds = read_monitor_credentials(&db, &mut warnings).unwrap();
+        assert_eq!(creds.len(), 1);
+        assert_eq!(creds[0].token, "new-token");
+    }
+
+    #[test]
+    fn db_absent_is_db_unavailable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("does-not-exist.db");
+        let mut warnings = Vec::new();
+        match read_monitor_credentials(&db, &mut warnings) {
+            Err(MonitorImportError::DbUnavailable(m)) => assert!(m.contains("not found")),
+            other => panic!("expected DbUnavailable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_oauth_credentials_table_hints_old_monitor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("usage.db");
+        // A db that exists but has no oauth_credentials table.
+        let conn = Connection::open(&db).unwrap();
+        conn.execute_batch("CREATE TABLE unrelated (id INTEGER);")
+            .unwrap();
+        drop(conn);
+        let mut warnings = Vec::new();
+        match read_monitor_credentials(&db, &mut warnings) {
+            Err(MonitorImportError::DbUnavailable(m)) => {
+                assert!(m.contains("no such table") || m.contains("oauth_credentials"));
+                assert!(m.contains("predate the credential store"));
+            }
+            other => panic!("expected DbUnavailable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_survives_question_mark_in_path() {
+        // Regression guard for #4095: a '?' in the DB path must not void the
+        // read-only URI. Create the db in a directory whose name contains '?'.
+        let tmp = tempfile::tempdir().unwrap();
+        let weird = tmp.path().join("we?rd#dir");
+        fs::create_dir_all(&weird).unwrap();
+        let db = weird.join("usage.db");
+        seed_usage_db(&db, &[("a@x.com", "sk-a", Some("a@x.com"), 1)]);
+        let mut warnings = Vec::new();
+        let creds = read_monitor_credentials(&db, &mut warnings).unwrap();
+        assert_eq!(creds.len(), 1);
+        assert_eq!(creds[0].email, "a@x.com");
+    }
+
+    // ---- import_from_monitor end-to-end -------------------------------
+
+    fn import_opts<'a>(tokens_dir: &'a Path, db: &'a Path) -> ImportOptions<'a> {
+        ImportOptions {
+            tokens_dir,
+            db_path: Some(db),
+            monitor_dir: None,
+            force: false,
+            dry_run: false,
+            prune: false,
+        }
+    }
+
+    #[test]
+    fn import_writes_pool_and_index() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("usage.db");
+        seed_usage_db(
+            &db,
+            &[
+                ("alice@example.com", "sk-alice", Some("alice@example.com"), 1),
+                ("bob@example.com", "sk-bob", Some("bob@example.com"), 1),
+            ],
+        );
+        let pool = tmp.path().join("tokens");
+        let result = import_from_monitor(&import_opts(&pool, &db)).unwrap();
+        assert_eq!(result.written.len(), 2);
+        assert_eq!(result.effective.len(), 2);
+        assert!(pool.join("index.json").is_file());
+        assert!(pool.join("alice-example.token").is_file());
+        assert_eq!(fs::read_to_string(pool.join("alice-example.token")).unwrap(), "sk-alice");
+        // Source provenance is monitor-db, not monitor.
+        assert!(result.effective.iter().all(|a| a.source == "monitor-db"));
+    }
+
+    #[test]
+    fn import_dry_run_writes_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("usage.db");
+        seed_usage_db(&db, &[("a@x.com", "sk-a", Some("a@x.com"), 1)]);
+        let pool = tmp.path().join("tokens");
+        let mut opts = import_opts(&pool, &db);
+        opts.dry_run = true;
+        let result = import_from_monitor(&opts).unwrap();
+        assert_eq!(result.written, vec!["a-x.token"]);
+        assert!(!pool.exists());
+    }
+
+    #[test]
+    fn import_idempotent_then_drift_needs_force() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("usage.db");
+        seed_usage_db(&db, &[("a@x.com", "sk-a", Some("a@x.com"), 1)]);
+        let pool = tmp.path().join("tokens");
+
+        // First import writes.
+        import_from_monitor(&import_opts(&pool, &db)).unwrap();
+        // Second import is unchanged (fingerprint matches).
+        let again = import_from_monitor(&import_opts(&pool, &db)).unwrap();
+        assert_eq!(again.unchanged, vec!["a-x.token"]);
+        assert!(again.written.is_empty());
+
+        // Simulate a rolled token in the store.
+        let db2 = tmp.path().join("usage2.db");
+        seed_usage_db(&db2, &[("a@x.com", "sk-a-ROLLED", Some("a@x.com"), 1)]);
+
+        // Without force: reported drifted, on-disk token untouched.
+        let drift = import_from_monitor(&import_opts(&pool, &db2)).unwrap();
+        assert_eq!(drift.drifted, vec!["a-x.token"]);
+        assert_eq!(fs::read_to_string(pool.join("a-x.token")).unwrap(), "sk-a");
+        assert!(drift.warnings.iter().any(|w| w.contains("--force")));
+
+        // With force: the rolled token is applied.
+        let mut forced = import_opts(&pool, &db2);
+        forced.force = true;
+        let applied = import_from_monitor(&forced).unwrap();
+        assert_eq!(applied.written, vec!["a-x.token"]);
+        assert_eq!(fs::read_to_string(pool.join("a-x.token")).unwrap(), "sk-a-ROLLED");
+    }
+
+    #[test]
+    fn import_no_active_credentials_warns() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("usage.db");
+        seed_usage_db(&db, &[("a@x.com", "sk-a", Some("a@x.com"), 0)]); // inactive
+        let pool = tmp.path().join("tokens");
+        let result = import_from_monitor(&import_opts(&pool, &db)).unwrap();
+        assert!(result.effective.is_empty());
+        assert!(result
+            .warnings
+            .iter()
+            .any(|w| w.contains("No active credentials")));
+        assert!(!pool.exists());
+    }
+
+    #[test]
+    fn prune_removes_stale_tokens_but_leaves_state_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("usage.db");
+        seed_usage_db(&db, &[("a@x.com", "sk-a", Some("a@x.com"), 1)]);
+        let pool = tmp.path().join("tokens");
+        fs::create_dir_all(&pool).unwrap();
+
+        // A stale token for an account no longer active, plus every pool state
+        // file — none of which must be pruned.
+        fs::write(pool.join("stale-old.token"), "sk-stale").unwrap();
+        for state in [".ranking", ".bad_tokens", ".allowlist", ".failure_counts"] {
+            fs::write(pool.join(state), "sentinel").unwrap();
+        }
+
+        let mut opts = import_opts(&pool, &db);
+        opts.prune = true;
+        let result = import_from_monitor(&opts).unwrap();
+
+        assert_eq!(result.pruned, vec!["stale-old.token"]);
+        assert!(!pool.join("stale-old.token").exists());
+        // The active account's token is present.
+        assert!(pool.join("a-x.token").is_file());
+        // State files are untouched.
+        for state in [".ranking", ".bad_tokens", ".allowlist", ".failure_counts"] {
+            assert_eq!(fs::read_to_string(pool.join(state)).unwrap(), "sentinel");
+        }
+        // index.json is not pruned either.
+        assert!(pool.join("index.json").is_file());
+    }
+
+    #[test]
+    fn prune_dry_run_reports_without_deleting() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("usage.db");
+        seed_usage_db(&db, &[("a@x.com", "sk-a", Some("a@x.com"), 1)]);
+        let pool = tmp.path().join("tokens");
+        fs::create_dir_all(&pool).unwrap();
+        fs::write(pool.join("stale.token"), "sk-stale").unwrap();
+
+        let mut opts = import_opts(&pool, &db);
+        opts.prune = true;
+        opts.dry_run = true;
+        let result = import_from_monitor(&opts).unwrap();
+        assert_eq!(result.pruned, vec!["stale.token"]);
+        // Dry-run leaves the file in place.
+        assert!(pool.join("stale.token").exists());
+    }
+
+    #[test]
+    fn duplicate_derived_filename_aborts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("usage.db");
+        // "a.b@x.com" and "ab@x.com" both derive "ab-x.token".
+        seed_usage_db(
+            &db,
+            &[
+                ("a.b@x.com", "sk-1", Some("a.b@x.com"), 1),
+                ("ab@x.com", "sk-2", Some("ab@x.com"), 1),
+            ],
+        );
+        let pool = tmp.path().join("tokens");
+        match import_from_monitor(&import_opts(&pool, &db)) {
+            Err(MonitorImportError::DuplicateFile(m)) => {
+                assert!(m.contains("duplicate token filename"))
+            }
+            other => panic!("expected DuplicateFile, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn to_json_shape_matches_python_to_dict() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("usage.db");
+        seed_usage_db(&db, &[("a@x.com", "sk-a", Some("a@x.com"), 1)]);
+        let pool = tmp.path().join("tokens");
+        let result = import_from_monitor(&import_opts(&pool, &db)).unwrap();
+        let json = result.to_json();
+        for key in [
+            "written",
+            "unchanged",
+            "drifted",
+            "pruned",
+            "dry_run",
+            "tokens_dir",
+            "index_path",
+            "db_path",
+            "effective",
+        ] {
+            assert!(json.get(key).is_some(), "missing key {key}");
+        }
+        // No secret material in the JSON.
+        assert!(!json.to_string().contains("sk-a"));
+        let eff = &json["effective"][0];
+        assert_eq!(eff["source"], "monitor-db");
+        assert_eq!(eff["name"], "a-x");
+        assert_eq!(eff["file"], "a-x.token");
+    }
+}

--- a/loom-tools/tests/tokens/test_rust_conformance.py
+++ b/loom-tools/tests/tokens/test_rust_conformance.py
@@ -571,6 +571,187 @@ def test_bootstrap_no_source_both_fail(tmp_path):
     assert rust.returncode != 0
 
 
+# ---------------------------------------------------------------------------
+# import-from-monitor: claude-monitor live SQLite (usage.db) import (#4106).
+# A fixture usage.db is driven through both CLIs (via --db) and the resulting
+# materialized pool + index.json must match byte-for-byte. Both are isolated
+# from the real host (no shared pool) and target their own repo-local pool.
+# ---------------------------------------------------------------------------
+
+import sqlite3  # noqa: E402
+
+
+def _seed_usage_db(db_path: Path, creds: list[dict]) -> Path:
+    """Create a fixture claude-monitor usage.db with the accounts +
+    oauth_credentials schema the importer queries. Each cred dict carries
+    `label`, `access_token`, `email` (None -> no accounts row) and `is_active`."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE accounts (id INTEGER PRIMARY KEY, email TEXT);
+            CREATE TABLE oauth_credentials (
+                id INTEGER PRIMARY KEY,
+                label TEXT,
+                access_token TEXT,
+                account_id INTEGER,
+                is_active INTEGER
+            );
+            """
+        )
+        next_account_id = 1
+        for c in creds:
+            account_id = None
+            if c.get("email") is not None:
+                account_id = next_account_id
+                next_account_id += 1
+                conn.execute(
+                    "INSERT INTO accounts (id, email) VALUES (?, ?)",
+                    (account_id, c["email"]),
+                )
+            conn.execute(
+                "INSERT INTO oauth_credentials "
+                "(label, access_token, account_id, is_active) VALUES (?, ?, ?, ?)",
+                (c["label"], c["access_token"], account_id, c["is_active"]),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    return db_path
+
+
+def _seed_import_repo(workspace: Path) -> Path:
+    """A `.git` + `.loom` repo skeleton so the Python CLI's find_repo_root()
+    resolves the repo-local pool at `<workspace>/.loom/tokens`."""
+    (workspace / ".loom").mkdir(parents=True, exist_ok=True)
+    (workspace / ".git").mkdir(parents=True, exist_ok=True)
+    return workspace
+
+
+def _import_env() -> dict:
+    return {
+        **os.environ,
+        "PYTHONPATH": _loom_tools_src(),
+        "LOOM_SHARED_TOKENS_DIR": "",  # disable the shared pool fallback
+    }
+
+
+def _run_python_import(workspace: Path, db: Path, *extra: str):
+    return subprocess.run(
+        [
+            "python3",
+            "-m",
+            "loom_tools.tokens.cli",
+            "import-from-monitor",
+            "--db",
+            str(db),
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=workspace,
+        env=_import_env(),
+    )
+
+
+def _run_rust_import(workspace: Path, db: Path, *extra: str):
+    assert DAEMON_BIN is not None
+    return subprocess.run(
+        [
+            str(DAEMON_BIN),
+            "tokens",
+            "import-from-monitor",
+            "--workspace",
+            str(workspace),
+            "--db",
+            str(db),
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_import_env(),
+    )
+
+
+_IMPORT_CREDS = [
+    {"label": "alice@example.com", "access_token": "sk-live-alice",
+     "email": "alice@example.com", "is_active": 1},
+    # Org-label form, joined account row absent -> email recovered from label.
+    {"label": "bob@example.com's Organization", "access_token": "sk-live-bob",
+     "email": None, "is_active": 1},
+    # Inactive -> filtered by both.
+    {"label": "carol@example.com", "access_token": "sk-live-carol",
+     "email": "carol@example.com", "is_active": 0},
+]
+
+
+def test_import_from_monitor_dry_run_effective_agrees(tmp_path):
+    db = _seed_usage_db(tmp_path / "monitor" / "usage.db", _IMPORT_CREDS)
+    py_ws = _seed_import_repo(tmp_path / "py")
+    rust_ws = _seed_import_repo(tmp_path / "rust")
+
+    py = _run_python_import(py_ws, db, "--dry-run", "--json")
+    assert py.returncode == 0, py.stderr
+    rust = _run_rust_import(rust_ws, db, "--dry-run", "--json")
+    assert rust.returncode == 0, rust.stderr
+
+    py_effective = json.loads(py.stdout)["effective"]
+    rust_effective = json.loads(rust.stdout)["effective"]
+
+    assert rust_effective == py_effective
+    # The two active accounts survive; the inactive carol is filtered out.
+    files = {a["file"] for a in rust_effective}
+    assert files == {"alice-example.token", "bob-example.token"}
+    assert all(a["source"] == "monitor-db" for a in rust_effective)
+    # Dry-run writes nothing.
+    assert not (py_ws / ".loom" / "tokens" / "index.json").exists()
+    assert not (rust_ws / ".loom" / "tokens" / "index.json").exists()
+
+
+def test_import_from_monitor_pool_and_index_byte_compatible(tmp_path):
+    db = _seed_usage_db(tmp_path / "monitor" / "usage.db", _IMPORT_CREDS)
+    py_ws = _seed_import_repo(tmp_path / "py")
+    rust_ws = _seed_import_repo(tmp_path / "rust")
+
+    py = _run_python_import(py_ws, db)
+    assert py.returncode == 0, py.stderr
+    rust = _run_rust_import(rust_ws, db)
+    assert rust.returncode == 0, rust.stderr
+
+    py_pool = py_ws / ".loom" / "tokens"
+    rust_pool = rust_ws / ".loom" / "tokens"
+
+    # index.json manifest rows are byte-compatible (only generated_at differs).
+    assert _index_accounts(rust_pool) == _index_accounts(py_pool)
+    for row in _index_accounts(rust_pool):
+        assert len(row["key_fingerprint"]) == 8
+        assert row["source"] == "monitor-db"
+        assert "key" not in row
+    raw = (rust_pool / "index.json").read_text(encoding="utf-8")
+    assert "sk-live" not in raw
+
+    # The materialized token files are identical across both writers.
+    for name in ("alice-example.token", "bob-example.token"):
+        assert (rust_pool / name).read_text(encoding="utf-8") == (
+            py_pool / name
+        ).read_text(encoding="utf-8")
+
+
+def test_import_from_monitor_db_absent_both_fail(tmp_path):
+    missing_db = tmp_path / "monitor" / "usage.db"  # never created
+    py_ws = _seed_import_repo(tmp_path / "py")
+    rust_ws = _seed_import_repo(tmp_path / "rust")
+
+    py = _run_python_import(py_ws, missing_db, "--json")
+    rust = _run_rust_import(rust_ws, missing_db, "--json")
+    # Both exit non-zero when the store is unavailable.
+    assert py.returncode != 0
+    assert rust.returncode != 0
+
+
 def test_check_monitor_source_no_fresh_data_leaves_ranking_untouched(tmp_path):
     index_accounts = [{"name": "acct-a", "email": "a@example.com"}]
     py_ws = _seed_monitor_pool(tmp_path / "py", index_accounts)


### PR DESCRIPTION
Native Rust port of `loom_tools.tokens.monitor_db` — child **C** of the #4094 decomposition (epic #4081 Phase 1). Reuses `Account` / `materialize_accounts` / `write_index` from the sibling `bootstrap` module (#4105, merged) so the pool writer, `0600`/`0700` modes, atomic write-then-rename, fingerprint drift detection, and the `index.json` manifest are identical by construction.

## What this adds

- **`loom-daemon/src/tokens_pool/monitor_db.rs`** (new) — read-only import from claude-monitor's live SQLite store (`usage.db` → `oauth_credentials`).
- **`TokensAction::ImportFromMonitor`** variant + handler in `main.rs`, following the `Bootstrap` wiring: `import-from-monitor [--workspace PATH] [--shared] [--db PATH] [--force] [--prune] [--dry-run] [--json]`.
- **`mod.rs`** — registers the module and updates the "still deferred" doc.

## Behavior (mirrors the Python original)

- SQLite via `rusqlite` (`bundled`, already a dep — no new crate, no shelling to `sqlite3`). Opened `SQLITE_OPEN_READ_ONLY | SQLITE_OPEN_URI` with a **percent-encoded** `file:…?mode=ro` URI (so `?`/`#`/`%` in the path can't void `mode=ro` — regression guard for #4095) and a 5s busy timeout so a lock surfaces as an error instead of hanging a dispatch.
- `is_active=1` filtering; email recovered from the `^(?P<email>.+?)'s Organization$` label when the `accounts` join is null; highest-`id` row wins per email; `source` recorded as `monitor-db` (distinct from the `accounts.env` snapshot's `monitor`).
- `--force` applies rolled tokens (every rolled token differs by design); `--prune` deletes `*.token` files for accounts no longer active while **never** touching `.ranking`/`.bad_tokens`/`.allowlist`/`.failure_counts` or `index.json`.
- Distinct `MonitorImportError::DbUnavailable` when the directory, `usage.db`, or `oauth_credentials` table is absent (with the "predates the credential store" hint only on an actual missing-table error).
- `--shared` targets `~/.loom/tokens/` (`$LOOM_SHARED_TOKENS_DIR`); `--workspace` is a plain path defaulting to `.`. Unresolved drift without `--force` exits `2`; DB-unavailable / duplicate-filename exit `1`.

## Tests

- **20 Rust unit tests** in `monitor_db.rs`: org-label regex, `is_active` filtering, empty-token skip, highest-id-wins dedup, unresolvable-email warn+skip, DB-absent / missing-table / `?`-in-path handling, `force`/`prune`/`dry-run` semantics, prune leaving state files untouched, duplicate derived filename abort, and `to_json` shape/no-secrets.
- **3 conformance cases** in `test_rust_conformance.py` drive a fixture `usage.db` through both the Python CLI and the Rust binary and assert the `effective` set, materialized token files, and `index.json` accounts are byte-compatible (plus a DB-absent both-fail case).
- Full `loom-tools/tests/tokens/` suite: **350 passed**. `cargo clippy` clean (lib + bin).

Closes #4106