### PR TITLE
fix(install): scope labels.yml install/uninstall to a BEGIN/END LOOM LABELS block (#4187)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,3 +1,12 @@
+# BEGIN LOOM LABELS
+# ============================================================================
+# LOOM-MANAGED BLOCK — everything between the BEGIN/END LOOM LABELS markers is
+# owned by Loom and is refreshed wholesale on every install/upgrade; edits made
+# in here WILL be lost. To add your repo's own labels, put them OUTSIDE this
+# block (above the BEGIN marker or below the END marker) — the installer and
+# uninstaller only ever touch the marked range, so your labels are preserved
+# across install, upgrade, and uninstall. See #4187.
+# ============================================================================
 # Loom Workflow Labels
 # These labels coordinate the Loom AI agent workflow
 # Sync with: .loom/scripts/sync-labels.sh (from the installed repo root)
@@ -140,3 +149,4 @@
 - name: external
   description: "Submitted by a non-collaborator; requires maintainer approval before Curator/Builder process it. Applied by: humans only."
   color: "E5E7EB"  # gray-200 - external/hold marker
+# END LOOM LABELS

--- a/defaults/.github/labels.yml
+++ b/defaults/.github/labels.yml
@@ -1,3 +1,12 @@
+# BEGIN LOOM LABELS
+# ============================================================================
+# LOOM-MANAGED BLOCK — everything between the BEGIN/END LOOM LABELS markers is
+# owned by Loom and is refreshed wholesale on every install/upgrade; edits made
+# in here WILL be lost. To add your repo's own labels, put them OUTSIDE this
+# block (above the BEGIN marker or below the END marker) — the installer and
+# uninstaller only ever touch the marked range, so your labels are preserved
+# across install, upgrade, and uninstall. See #4187.
+# ============================================================================
 # Loom Workflow Labels
 # These labels coordinate the Loom AI agent workflow
 # Sync with: .loom/scripts/sync-labels.sh (from the installed repo root)
@@ -140,3 +149,4 @@
 - name: external
   description: "Submitted by a non-collaborator; requires maintainer approval before Curator/Builder process it. Applied by: humans only."
   color: "E5E7EB"  # gray-200 - external/hold marker
+# END LOOM LABELS

--- a/loom-daemon/src/init/mod.rs
+++ b/loom-daemon/src/init/mod.rs
@@ -1609,10 +1609,12 @@ mod tests {
 
     #[test]
     fn test_preserved_files_excluded_from_verification_failures_end_to_end() {
-        // End-to-end: a customized .github/labels.yml (preserved by merge_dir_with_report
-        // on reinstall) should not appear as a verification failure after init, even
-        // though its bytes differ from the source defaults. This is the regression case
-        // from issue #3218.
+        // End-to-end: a consumer .github/labels.yml is block-merged on reinstall
+        // (issue #4187) — its Loom BEGIN/END LOOM LABELS block is refreshed while
+        // consumer-authored labels outside the block survive. The resulting file
+        // differs from the shipped source, so it must be recorded as `preserved`
+        // and must NOT surface as a verification failure. This also covers the
+        // original issue #3218 regression (preserved file leaking into failures).
         let temp_dir = TempDir::new().unwrap();
         let workspace = temp_dir.path();
         let defaults = temp_dir.path().join("defaults");
@@ -1624,16 +1626,20 @@ mod tests {
         fs::write(defaults.join("config.json"), "{}").unwrap();
         fs::write(defaults.join("roles").join("builder.md"), "builder").unwrap();
 
-        // .github scaffolding default with content X
+        // Shipped .github/labels.yml with a Loom-managed marker block.
         fs::create_dir_all(defaults.join(".github")).unwrap();
-        fs::write(defaults.join(".github").join("labels.yml"), "- name: default\n  color: ffffff")
-            .unwrap();
+        fs::write(
+            defaults.join(".github").join("labels.yml"),
+            "# BEGIN LOOM LABELS\n- name: loom:issue\n  color: ffffff\n# END LOOM LABELS\n",
+        )
+        .unwrap();
 
-        // Pre-existing customized .github/labels.yml with content Y (different bytes)
+        // Pre-existing consumer .github/labels.yml: a stale Loom block plus a
+        // consumer-authored label OUTSIDE the block.
         fs::create_dir_all(workspace.join(".github")).unwrap();
         fs::write(
             workspace.join(".github").join("labels.yml"),
-            "- name: customized\n  color: 000000\n  description: user edit",
+            "# BEGIN LOOM LABELS\n- name: loom:issue\n  color: 000000\n# END LOOM LABELS\n\n- name: team:frontend\n  color: 00ff00\n  description: consumer label\n",
         )
         .unwrap();
 
@@ -1642,14 +1648,26 @@ mod tests {
         assert!(result.is_ok());
         let report = result.unwrap();
 
-        // The customized file must be reported as preserved
+        // The block-merged file must be reported as preserved (consumer-owned).
         assert!(
             report.preserved.contains(&".github/labels.yml".to_string()),
             "preserved should contain .github/labels.yml, got: {:?}",
             report.preserved
         );
 
-        // And it must NOT appear as a verification failure (the bug we're fixing)
+        // The Loom block was refreshed to the shipped color; the consumer label
+        // outside the block survived untouched.
+        let installed = fs::read_to_string(workspace.join(".github").join("labels.yml")).unwrap();
+        assert!(
+            installed.contains("color: ffffff"),
+            "Loom block should be refreshed: {installed}"
+        );
+        assert!(
+            installed.contains("- name: team:frontend"),
+            "consumer label must survive: {installed}"
+        );
+
+        // And it must NOT appear as a verification failure (issue #3218).
         let leaked: Vec<&String> = report
             .verification_failures
             .iter()

--- a/loom-daemon/src/init/scaffolding.rs
+++ b/loom-daemon/src/init/scaffolding.rs
@@ -46,6 +46,134 @@ fn is_loom_hook_command(cmd: &str) -> bool {
 pub const LOOM_SECTION_START: &str = "<!-- BEGIN LOOM ORCHESTRATION -->";
 pub const LOOM_SECTION_END: &str = "<!-- END LOOM ORCHESTRATION -->";
 
+/// Loom-managed block markers for `.github/labels.yml` (issue #4187).
+///
+/// `.github/labels.yml` is the one scaffolding file a consumer legitimately
+/// co-owns: Loom ships its 27 workflow labels, but a consumer may add their own
+/// labels to the same file. Wrapping Loom's entries in these YAML-comment
+/// markers lets install/upgrade/uninstall touch **only** Loom's range and never
+/// clobber or orphan consumer-authored labels — the same marker-delimited
+/// managed-section pattern already used for root `CLAUDE.md`
+/// ([`LOOM_SECTION_START`]) and the `.gitignore` block.
+///
+/// The markers occupy their own comment lines in the shipped file; the line-
+/// oriented `sync-labels.sh` parser treats them (like every `#` line) as inert.
+pub const LOOM_LABELS_START: &str = "# BEGIN LOOM LABELS";
+pub const LOOM_LABELS_END: &str = "# END LOOM LABELS";
+
+/// The `.github`-relative path of the label registry, special-cased in the
+/// scaffolding copy so its Loom-managed block is merged rather than the whole
+/// file being clobbered (force) or frozen (merge). See [`install_labels_block`].
+const LABELS_YML_REL: &str = ".github/labels.yml";
+
+/// Extract the inclusive `# BEGIN LOOM LABELS` … `# END LOOM LABELS` block from
+/// `content`, returning the byte range `[start, end)` that spans from the first
+/// character of the BEGIN marker through the last character of the END marker
+/// (the trailing newline after END, if any, is **not** included).
+///
+/// Returns `None` when the markers are absent or malformed (END before BEGIN),
+/// so callers can fall back to append/preserve semantics rather than splicing a
+/// nonsensical range.
+fn labels_block_range(content: &str) -> Option<(usize, usize)> {
+    let start = content.find(LOOM_LABELS_START)?;
+    // Search for END only after BEGIN so a stray END above BEGIN can't invert
+    // the range.
+    let end_marker = content[start..].find(LOOM_LABELS_END)? + start;
+    let end = end_marker + LOOM_LABELS_END.len();
+    Some((start, end))
+}
+
+/// Compute the correct `.github/labels.yml` content for an install, preserving
+/// all consumer-owned entries outside the Loom-managed marker block.
+///
+/// - **`existing` has a well-formed block** → replace only the marked range with
+///   the shipped block; everything before/after is preserved byte-for-byte.
+/// - **`existing` is markerless** (a legacy install, or a consumer file Loom has
+///   never touched) → append the shipped block, preserving every existing entry.
+/// - **`source` has no block** (defensive; the shipped file always does) →
+///   return `existing` unchanged rather than risk clobbering consumer content.
+///
+/// The result is `None` when no change is needed (`existing` already equals the
+/// computed content), letting the caller record the file as `preserved`.
+fn merge_labels_block(existing: &str, source: &str) -> Option<String> {
+    let Some((src_start, src_end)) = labels_block_range(source) else {
+        // Shipped file unexpectedly lacks markers — never clobber the consumer.
+        return None;
+    };
+    let source_block = &source[src_start..src_end];
+
+    let merged = if let Some((dst_start, dst_end)) = labels_block_range(existing) {
+        // Splice the shipped block over the consumer's marked range.
+        format!("{}{}{}", &existing[..dst_start], source_block, &existing[dst_end..])
+    } else {
+        // Markerless consumer file: append the block, preserving all entries.
+        let head = existing.trim_end_matches('\n');
+        if head.is_empty() {
+            format!("{source_block}\n")
+        } else {
+            format!("{head}\n\n{source_block}\n")
+        }
+    };
+
+    if merged == existing {
+        None
+    } else {
+        Some(merged)
+    }
+}
+
+/// Install `.github/labels.yml` with Loom-block merge semantics (issue #4187).
+///
+/// `pre_existing` is the destination's content **before** the enclosing
+/// `.github` directory copy ran (that copy may have clobbered it under `--force`
+/// or left it frozen under merge — either way this function re-derives and writes
+/// the authoritative content). Any label-registry entry the directory copy left
+/// in the report is dropped and replaced with the correct one here.
+fn install_labels_block(
+    src: &Path,
+    dst: &Path,
+    pre_existing: Option<&str>,
+    report: &mut InitReport,
+) -> Result<(), String> {
+    let source =
+        fs::read_to_string(src).map_err(|e| format!("Failed to read labels.yml template: {e}"))?;
+
+    // The directory copy above already recorded labels.yml somewhere — drop that
+    // entry; this function is authoritative for the file.
+    report.added.retain(|f| f != LABELS_YML_REL);
+    report.updated.retain(|f| f != LABELS_YML_REL);
+    report.preserved.retain(|f| f != LABELS_YML_REL);
+
+    match pre_existing {
+        None => {
+            // Fresh install: ship the file verbatim (markers included), so the
+            // two registry copies stay byte-identical (#3896).
+            fs::write(dst, &source).map_err(|e| format!("Failed to write labels.yml: {e}"))?;
+            report.added.push(LABELS_YML_REL.to_string());
+        }
+        Some(existing) => {
+            match merge_labels_block(existing, &source) {
+                Some(merged) => {
+                    fs::write(dst, &merged)
+                        .map_err(|e| format!("Failed to write labels.yml: {e}"))?;
+                }
+                None => {
+                    // Content unchanged — but a `--force` directory copy may have
+                    // overwritten the file, so restore the consumer's version.
+                    fs::write(dst, existing)
+                        .map_err(|e| format!("Failed to write labels.yml: {e}"))?;
+                }
+            }
+            // Consumer-owned file: record as preserved so the post-install byte
+            // verification (which expects installed == source) does not flag the
+            // intentional divergence. See filter_preserved_from_verification_failures.
+            report.preserved.push(LABELS_YML_REL.to_string());
+        }
+    }
+
+    Ok(())
+}
+
 /// The short pointer injected into root CLAUDE.md (between section markers).
 ///
 /// This block is committed to the consumer repo, so its authoritative reference
@@ -762,13 +890,27 @@ pub fn setup_repository_scaffolding(
         report,
     )?;
 
-    // Copy .github/ directory
+    // Copy .github/ directory.
+    //
+    // `.github/labels.yml` is special-cased (issue #4187): capture its
+    // destination content BEFORE the directory copy (which clobbers it under
+    // --force / freezes it under merge), then re-derive the authoritative
+    // content via install_labels_block so only Loom's BEGIN/END LOOM LABELS
+    // block is (re)written and consumer-authored labels outside it survive.
+    let labels_src = defaults_path.join(LABELS_YML_REL);
+    let labels_dst = workspace_path.join(LABELS_YML_REL);
+    let pre_existing_labels = fs::read_to_string(&labels_dst).ok();
+
     copy_directory(
         &defaults_path.join(".github"),
         &workspace_path.join(".github"),
         ".github",
         report,
     )?;
+
+    if labels_src.exists() {
+        install_labels_block(&labels_src, &labels_dst, pre_existing_labels.as_deref(), report)?;
+    }
 
     // Note: The label-external-issues.yml workflow is no longer installed by default.
     // It generated spammy "No jobs were run" emails in single-contributor repos.
@@ -2639,5 +2781,123 @@ Run `cargo run` to start.";
         // must pass.
         let clean = wrap_loom_content(LOOM_ROOT_POINTER);
         assert!(assert_no_placeholders(&clean, "CLAUDE.md").is_ok());
+    }
+
+    // ── .github/labels.yml Loom-block merge (issue #4187) ──────────────────
+
+    const SHIPPED_LABELS: &str = "# BEGIN LOOM LABELS\n# managed by Loom\n- name: loom:issue\n  color: \"3B82F6\"\n- name: loom:building\n  color: \"F59E0B\"\n# END LOOM LABELS\n";
+
+    #[test]
+    fn test_labels_block_range_well_formed() {
+        let (start, end) = labels_block_range(SHIPPED_LABELS).unwrap();
+        assert_eq!(&SHIPPED_LABELS[start..start + LOOM_LABELS_START.len()], LOOM_LABELS_START);
+        assert!(SHIPPED_LABELS[..end].ends_with(LOOM_LABELS_END));
+    }
+
+    #[test]
+    fn test_labels_block_range_absent_or_malformed() {
+        // No markers at all.
+        assert!(labels_block_range("- name: team:foo\n  color: abcdef\n").is_none());
+        // END before BEGIN is not a valid block.
+        let inverted = "# END LOOM LABELS\n- name: x\n# BEGIN LOOM LABELS\n";
+        // BEGIN is found, but END only searched after BEGIN -> none.
+        assert!(labels_block_range(inverted).is_none());
+    }
+
+    #[test]
+    fn test_merge_labels_block_replaces_marked_range_preserving_outside() {
+        // Consumer file: labels above and below a stale Loom block.
+        let existing = "- name: team:above\n  color: \"111111\"\n\n# BEGIN LOOM LABELS\n- name: loom:issue\n  color: \"000000\"\n# END LOOM LABELS\n\n- name: team:below\n  color: \"222222\"\n";
+        let merged = merge_labels_block(existing, SHIPPED_LABELS).unwrap();
+
+        // Consumer entries outside the block are byte-preserved.
+        assert!(merged.contains("- name: team:above"));
+        assert!(merged.contains("- name: team:below"));
+        // The Loom block is refreshed to the shipped content.
+        assert!(merged.contains("color: \"3B82F6\""));
+        assert!(merged.contains("- name: loom:building"));
+        assert!(!merged.contains("color: \"000000\""), "stale Loom color must be gone");
+        // Exactly one marker pair.
+        assert_eq!(merged.matches(LOOM_LABELS_START).count(), 1);
+        assert_eq!(merged.matches(LOOM_LABELS_END).count(), 1);
+    }
+
+    #[test]
+    fn test_merge_labels_block_appends_to_markerless_file() {
+        let existing =
+            "- name: team:frontend\n  color: \"00ff00\"\n  description: consumer label\n";
+        let merged = merge_labels_block(existing, SHIPPED_LABELS).unwrap();
+
+        // Every existing entry survives.
+        assert!(merged.contains("- name: team:frontend"));
+        assert!(merged.contains("description: consumer label"));
+        // The Loom block is appended.
+        assert!(merged.contains(LOOM_LABELS_START));
+        assert!(merged.contains("- name: loom:issue"));
+        // Consumer content precedes the appended block.
+        assert!(merged.find("team:frontend").unwrap() < merged.find(LOOM_LABELS_START).unwrap());
+    }
+
+    #[test]
+    fn test_merge_labels_block_noop_when_block_matches() {
+        // A file that already equals a plain copy of the shipped file needs no change.
+        assert!(merge_labels_block(SHIPPED_LABELS, SHIPPED_LABELS).is_none());
+    }
+
+    #[test]
+    fn test_merge_labels_block_preserves_when_source_markerless() {
+        // Defensive: a shipped file without markers must never clobber consumer content.
+        let existing = "- name: team:only\n  color: \"abcdef\"\n";
+        assert!(merge_labels_block(existing, "- name: loom:issue\n  color: fff\n").is_none());
+    }
+
+    #[test]
+    fn test_install_labels_block_fresh_install_is_verbatim_copy() {
+        let temp = TempDir::new().unwrap();
+        let src = temp.path().join("labels.src.yml");
+        let dst = temp.path().join("labels.yml");
+        fs::write(&src, SHIPPED_LABELS).unwrap();
+
+        let mut report = InitReport::default();
+        install_labels_block(&src, &dst, None, &mut report).unwrap();
+
+        // Fresh install ships the file byte-for-byte (keeps registry parity).
+        assert_eq!(fs::read_to_string(&dst).unwrap(), SHIPPED_LABELS);
+        assert!(report.added.contains(&LABELS_YML_REL.to_string()));
+        assert!(!report.preserved.contains(&LABELS_YML_REL.to_string()));
+    }
+
+    #[test]
+    fn test_install_labels_block_force_restores_consumer_content() {
+        // Simulate a --force directory copy having clobbered the dst with the
+        // shipped file, while pre_existing captured the consumer's real content.
+        let temp = TempDir::new().unwrap();
+        let src = temp.path().join("labels.src.yml");
+        let dst = temp.path().join("labels.yml");
+        fs::write(&src, SHIPPED_LABELS).unwrap();
+        // Post-clobber on-disk state.
+        fs::write(&dst, SHIPPED_LABELS).unwrap();
+
+        let pre_existing = "# BEGIN LOOM LABELS\n- name: loom:issue\n  color: \"000000\"\n# END LOOM LABELS\n\n- name: team:below\n  color: \"222222\"\n";
+
+        let mut report = InitReport::default();
+        install_labels_block(&src, &dst, Some(pre_existing), &mut report).unwrap();
+
+        let result = fs::read_to_string(&dst).unwrap();
+        // Consumer label survives the force reinstall.
+        assert!(result.contains("- name: team:below"));
+        // Loom block refreshed.
+        assert!(result.contains("color: \"3B82F6\""));
+        // Recorded as preserved (consumer-owned) — dropped any copy-side entry.
+        assert!(report.preserved.contains(&LABELS_YML_REL.to_string()));
+        assert_eq!(report.added.iter().filter(|f| *f == LABELS_YML_REL).count(), 0);
+        assert_eq!(
+            report
+                .updated
+                .iter()
+                .filter(|f| *f == LABELS_YML_REL)
+                .count(),
+            0
+        );
     }
 }

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -1316,7 +1316,12 @@ if [[ -f "$TARGET_PATH/.loom/install-metadata.json" ]] && command -v jq >/dev/nu
         continue
         ;;
       .github/labels.yml|.github/CONFIGURATION.md|.github/ISSUE_TEMPLATE/config.yml|.github/ISSUE_TEMPLATE/task.yml)
-        # Loom-shipped — fall through to the sweep.
+        # Loom-shipped — fall through to the sweep. Note (#4187): labels.yml is
+        # co-owned — Loom manages only its BEGIN/END LOOM LABELS block. This
+        # sweep only fires if Loom STOPS shipping the file entirely; while it is
+        # shipped the block-merge in loom-daemon init owns updates. If labels.yml
+        # is ever retired, a whole-file git rm here would still take consumer
+        # labels with it — prefer a marker-block strip (see uninstall-loom.sh).
         ;;
       .github/*)
         # Consumer-owned by default.

--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -281,6 +281,12 @@ if [[ "$USE_MANIFEST" == "true" ]]; then
       # Loom patterns. See issue #3450.
       continue
     fi
+    if [[ "$file_path" == ".github/labels.yml" ]]; then
+      # labels.yml gets smart removal (step 6): strip only the Loom-owned
+      # BEGIN/END LOOM LABELS block, preserving consumer-authored labels in the
+      # same file. Hard-deleting it would destroy a consumer's own labels. #4187.
+      continue
+    fi
     # Defense in depth (issues #3450, #3480): .github/ is an ALLOWLIST —
     # only the files Loom actually ships into targets (source of truth:
     # defaults/.github/ as walked by scripts/install/manifest.sh) may be
@@ -453,6 +459,11 @@ else
       if [[ "$target_file" == "CLAUDE.md" ]]; then
         continue
       fi
+      # labels.yml gets smart removal (step 6): strip only the Loom marker
+      # block, preserving consumer-authored labels. See issue #4187.
+      if [[ "$target_file" == ".github/labels.yml" ]]; then
+        continue
+      fi
 
       if [[ -f "$TARGET_PATH/$target_file" ]]; then
         REMOVE_FILES+=("$target_file")
@@ -611,6 +622,12 @@ if [[ -f "$TARGET_PATH/.claude/settings.json" ]]; then
   SMART_REMOVE_FILES+=(".claude/settings.json")
 fi
 
+# .github/labels.yml needs marker-block removal (strip only the Loom labels
+# block; delete the file only when nothing meaningful remains). Issue #4187.
+if [[ -f "$TARGET_PATH/.github/labels.yml" ]]; then
+  SMART_REMOVE_FILES+=(".github/labels.yml")
+fi
+
 
 # Track directories to check for emptiness after removal
 REMOVE_DIRS=(
@@ -668,6 +685,9 @@ if [[ ${#SMART_REMOVE_FILES[@]} -gt 0 ]]; then
         ;;
       .claude/settings.json)
         echo "  - .claude/settings.json (remove Loom hooks and permissions only)"
+        ;;
+      .github/labels.yml)
+        echo "  - .github/labels.yml (remove Loom label block only, or entire file if Loom-generated)"
         ;;
     esac
   done
@@ -1003,6 +1023,66 @@ if [[ -f "$WORKTREE_ABS/.loom/CLAUDE.md" ]]; then
   rm -f "$WORKTREE_ABS/.loom/CLAUDE.md"
   REMOVED_LIST+=(".loom/CLAUDE.md")
   success ".loom/CLAUDE.md removed"
+fi
+
+# Handle .github/labels.yml — strip only the Loom-managed label block (#4187)
+#
+# labels.yml is the one scaffolding file a consumer legitimately co-owns: Loom
+# ships its workflow labels wrapped in `# BEGIN LOOM LABELS` / `# END LOOM
+# LABELS` markers, but a consumer may add their own labels to the same file.
+# Uninstall therefore removes ONLY the marked range, deleting the whole file
+# only when nothing meaningful remains outside it. A legacy markerless file is
+# deleted only when it is byte-identical to a shipped Loom template — otherwise
+# it is preserved with a warning, since it may hold consumer-authored labels.
+if [[ -f "$WORKTREE_ABS/.github/labels.yml" ]]; then
+  LABELS_YML="$WORKTREE_ABS/.github/labels.yml"
+
+  # Malformed-marker guard (mirrors CLAUDE.md / .gitignore): require exactly one
+  # BEGIN and one END marker, with BEGIN strictly before END, before we splice.
+  LABELS_BEGIN_COUNT=$(grep -c '^[[:space:]]*# BEGIN LOOM LABELS[[:space:]]*$' "$LABELS_YML" 2>/dev/null || true)
+  LABELS_END_COUNT=$(grep -c '^[[:space:]]*# END LOOM LABELS[[:space:]]*$' "$LABELS_YML" 2>/dev/null || true)
+
+  if [[ "$LABELS_BEGIN_COUNT" == "1" && "$LABELS_END_COUNT" == "1" ]] && \
+     awk '/^[[:space:]]*# BEGIN LOOM LABELS[[:space:]]*$/ { b = NR }
+          /^[[:space:]]*# END LOOM LABELS[[:space:]]*$/   { e = NR }
+          END { exit !(b > 0 && e > 0 && b < e) }' "$LABELS_YML"; then
+    info "Removing Loom label block from .github/labels.yml (marker-based)..."
+
+    # Delete BEGIN..END inclusive; leave every other line byte-for-byte intact.
+    sed '/^[[:space:]]*# BEGIN LOOM LABELS[[:space:]]*$/,/^[[:space:]]*# END LOOM LABELS[[:space:]]*$/d' \
+      "$LABELS_YML" > "${LABELS_YML}.tmp" && mv "${LABELS_YML}.tmp" "$LABELS_YML"
+
+    # Trim now-trailing blank lines (same idiom as the CLAUDE.md handler).
+    awk 'NF || prev_blank++ < 1 { print; if (NF) prev_blank=0 }' "$LABELS_YML" > "${LABELS_YML}.tmp" && mv "${LABELS_YML}.tmp" "$LABELS_YML"
+
+    # Delete the file only when nothing meaningful remains outside the block —
+    # i.e. it is empty, whitespace-only, or comments-only (no `- name:` entries).
+    if [[ ! -s "$LABELS_YML" ]] || ! grep -qE '^[[:space:]]*-[[:space:]]*name:' "$LABELS_YML" 2>/dev/null; then
+      rm -f "$LABELS_YML"
+      REMOVED_LIST+=(".github/labels.yml")
+      success ".github/labels.yml removed (only Loom labels remained)"
+    else
+      REMOVED_LIST+=(".github/labels.yml (Loom label block removed)")
+      success ".github/labels.yml Loom label block removed, consumer labels preserved"
+    fi
+  else
+    if [[ "$LABELS_BEGIN_COUNT" != "0" || "$LABELS_END_COUNT" != "0" ]]; then
+      warning ".github/labels.yml has malformed Loom markers — preserving file to avoid data loss"
+    fi
+    # Markerless file: delete ONLY if byte-identical to a shipped Loom template
+    # (a pristine pre-marker install). Otherwise preserve — it may hold
+    # consumer-authored labels.
+    SHIPPED_LABELS_TEMPLATE="$LOOM_ROOT/defaults/.github/labels.yml"
+    if [[ "$LABELS_BEGIN_COUNT" == "0" && "$LABELS_END_COUNT" == "0" ]] && \
+       [[ -f "$SHIPPED_LABELS_TEMPLATE" ]] && \
+       cmp -s "$LABELS_YML" "$SHIPPED_LABELS_TEMPLATE"; then
+      rm -f "$LABELS_YML"
+      REMOVED_LIST+=(".github/labels.yml")
+      success ".github/labels.yml removed (byte-identical to shipped Loom template)"
+    else
+      info ".github/labels.yml has no Loom markers and differs from the shipped template — preserving (may contain consumer labels)"
+    fi
+  fi
 fi
 
 # Handle .gitignore - remove the Loom-managed block

--- a/tests/install/test-uninstall-labels-block.sh
+++ b/tests/install/test-uninstall-labels-block.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Test suite for uninstall-loom.sh Step 6 ".github/labels.yml" smart removal (#4187).
+#
+# Usage: ./tests/install/test-uninstall-labels-block.sh
+#
+# labels.yml is co-owned: Loom ships its workflow labels wrapped in
+# `# BEGIN LOOM LABELS` / `# END LOOM LABELS` markers, while a consumer may add
+# their own labels to the same file. Uninstall must:
+#
+#   1. Mixed file      -> strip ONLY the marked range; consumer labels survive.
+#   2. Pure-Loom file  -> nothing meaningful remains outside the block -> delete.
+#   3. Markerless file -> delete ONLY if byte-identical to the shipped template;
+#                         otherwise preserve (it may hold consumer labels).
+#   4. Malformed markers -> preserve (never guess a splice range).
+#
+# The functional cases below replay the EXACT sed/awk/predicate pipeline the
+# script uses (extracted here) on fixtures, and source-anchor asserts pin that
+# the script (a) no longer hard-deletes labels.yml and (b) routes it to smart
+# removal. Exit 0 = all pass, 1 = failures.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+UNINSTALL_SH="$REPO_ROOT/scripts/uninstall-loom.sh"
+SHIPPED_TEMPLATE="$REPO_ROOT/defaults/.github/labels.yml"
+
+PASS=0
+FAIL=0
+TOTAL=0
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "${GREEN}PASS${NC}: $desc"; PASS=$((PASS + 1))
+  else
+    echo -e "${RED}FAIL${NC}: $desc"; echo "  expected: '$expected'"; echo "  actual:   '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Exact marker-strip pipeline mirrored from uninstall-loom.sh Step 6. Given a
+# labels.yml path, either strips the Loom block (deleting the file when nothing
+# meaningful remains) or preserves it, and echoes the outcome:
+#   "removed" | "block-stripped" | "preserved"
+strip_labels_block() {
+  local f="$1"
+  local begin end
+  begin=$(grep -c '^[[:space:]]*# BEGIN LOOM LABELS[[:space:]]*$' "$f" 2>/dev/null || true)
+  end=$(grep -c '^[[:space:]]*# END LOOM LABELS[[:space:]]*$' "$f" 2>/dev/null || true)
+
+  if [[ "$begin" == "1" && "$end" == "1" ]] && \
+     awk '/^[[:space:]]*# BEGIN LOOM LABELS[[:space:]]*$/ { b = NR }
+          /^[[:space:]]*# END LOOM LABELS[[:space:]]*$/   { e = NR }
+          END { exit !(b > 0 && e > 0 && b < e) }' "$f"; then
+    sed '/^[[:space:]]*# BEGIN LOOM LABELS[[:space:]]*$/,/^[[:space:]]*# END LOOM LABELS[[:space:]]*$/d' \
+      "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
+    awk 'NF || prev_blank++ < 1 { print; if (NF) prev_blank=0 }' "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
+    if [[ ! -s "$f" ]] || ! grep -qE '^[[:space:]]*-[[:space:]]*name:' "$f" 2>/dev/null; then
+      rm -f "$f"; echo "removed"
+    else
+      echo "block-stripped"
+    fi
+  else
+    if [[ "$begin" == "0" && "$end" == "0" ]] && cmp -s "$f" "$SHIPPED_TEMPLATE"; then
+      rm -f "$f"; echo "removed"
+    else
+      echo "preserved"
+    fi
+  fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo ""
+echo "=== Functional: labels.yml marker-block smart removal ==="
+
+# Case 1: mixed file — Loom block plus a consumer label outside it.
+MIXED="$TMP/mixed.yml"
+printf '# BEGIN LOOM LABELS\n- name: loom:issue\n  color: "3B82F6"\n# END LOOM LABELS\n\n- name: team:frontend\n  color: "00ff00"\n' > "$MIXED"
+OUT="$(strip_labels_block "$MIXED")"
+assert_eq "mixed file: block stripped, file kept" "block-stripped" "$OUT"
+assert_eq "mixed file: consumer label survives" "yes" \
+  "$([[ -f "$MIXED" ]] && grep -q 'team:frontend' "$MIXED" && echo yes || echo no)"
+assert_eq "mixed file: Loom label gone" "yes" \
+  "$([[ -f "$MIXED" ]] && ! grep -q 'loom:issue' "$MIXED" && echo yes || echo no)"
+
+# Case 2: pure-Loom file — only the block, nothing outside.
+PURE="$TMP/pure.yml"
+printf '# BEGIN LOOM LABELS\n- name: loom:issue\n  color: "3B82F6"\n# END LOOM LABELS\n' > "$PURE"
+OUT="$(strip_labels_block "$PURE")"
+assert_eq "pure-Loom file: deleted" "removed" "$OUT"
+assert_eq "pure-Loom file: no longer exists" "gone" "$([[ -f "$PURE" ]] && echo present || echo gone)"
+
+# Case 3a: markerless file byte-identical to a shipped template -> deleted.
+# Point SHIPPED_TEMPLATE at a deterministic markerless template equal to the
+# fixture so the cmp -s byte-match branch fires (the real defaults file has
+# markers, so it would never byte-match a legacy markerless snapshot).
+LEGACY_MATCH="$TMP/legacy-match.yml"
+printf -- '- name: loom:issue\n  color: "3B82F6"\n' > "$LEGACY_MATCH"
+LEGACY_TEMPLATE_BAK="$SHIPPED_TEMPLATE"
+SHIPPED_TEMPLATE="$TMP/tpl.yml"; cp "$LEGACY_MATCH" "$SHIPPED_TEMPLATE"
+OUT="$(strip_labels_block "$LEGACY_MATCH")"
+assert_eq "markerless byte-identical-to-template: deleted" "removed" "$OUT"
+SHIPPED_TEMPLATE="$LEGACY_TEMPLATE_BAK"
+
+# Case 3b: markerless file that differs from the template -> preserved.
+LEGACY_DIVERGED="$TMP/legacy-diverged.yml"
+printf -- '- name: team:only\n  color: "abcdef"\n  description: consumer-authored\n' > "$LEGACY_DIVERGED"
+OUT="$(strip_labels_block "$LEGACY_DIVERGED")"
+assert_eq "markerless diverged file: preserved" "preserved" "$OUT"
+assert_eq "markerless diverged file: still present with consumer label" "yes" \
+  "$([[ -f "$LEGACY_DIVERGED" ]] && grep -q 'team:only' "$LEGACY_DIVERGED" && echo yes || echo no)"
+
+# Case 4: malformed markers (two BEGINs) -> preserved (never guess a range).
+MALFORMED="$TMP/malformed.yml"
+printf '# BEGIN LOOM LABELS\n# BEGIN LOOM LABELS\n- name: loom:issue\n# END LOOM LABELS\n' > "$MALFORMED"
+OUT="$(strip_labels_block "$MALFORMED")"
+assert_eq "malformed markers: preserved" "preserved" "$OUT"
+assert_eq "malformed markers: file untouched" "yes" \
+  "$([[ -f "$MALFORMED" ]] && grep -q 'loom:issue' "$MALFORMED" && echo yes || echo no)"
+
+echo ""
+echo "=== Source anchors: uninstall-loom.sh routes labels.yml to smart removal ==="
+
+assert_eq "registers .github/labels.yml for smart removal" "yes" \
+  "$(grep -q 'SMART_REMOVE_FILES+=(".github/labels.yml")' "$UNINSTALL_SH" && echo yes || echo no)"
+assert_eq "manifest path skips labels.yml hard-delete" "yes" \
+  "$(grep -q 'file_path" == ".github/labels.yml"' "$UNINSTALL_SH" && echo yes || echo no)"
+assert_eq "Step 6 strips BEGIN..END LOOM LABELS range" "yes" \
+  "$(grep -q 'BEGIN LOOM LABELS\[\[:space:\]\]\*\$/,/\^\[\[:space:\]\]\*# END LOOM LABELS' "$UNINSTALL_SH" && echo yes || echo no)"
+
+echo ""
+echo "=== Shipped template ships the markers (parity) ==="
+assert_eq "defaults template has BEGIN marker" "yes" \
+  "$(grep -qx '# BEGIN LOOM LABELS' "$SHIPPED_TEMPLATE" && echo yes || echo no)"
+assert_eq "defaults template has END marker" "yes" \
+  "$(grep -qx '# END LOOM LABELS' "$SHIPPED_TEMPLATE" && echo yes || echo no)"
+assert_eq "root registry has BEGIN marker" "yes" \
+  "$(grep -qx '# BEGIN LOOM LABELS' "$REPO_ROOT/.github/labels.yml" && echo yes || echo no)"
+
+echo ""
+echo "==================================================="
+echo "Results: $PASS/$TOTAL passed, $FAIL failed"
+echo "==================================================="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #4187

## Summary

`.github/labels.yml` was the one shared scaffolding file Loom replaced wholesale. Both failure modes were live on `main`:

- **`--force` reinstall** (what Quick Install always passes) overwrote the file wholesale, silently deleting consumer-authored labels.
- **Non-force reinstall** preserved it forever, so a customized file never received Loom's own label updates.
- **Uninstall** hard-deleted the whole file, destroying any consumer labels merged into it.

Loom now owns only the range between `# BEGIN LOOM LABELS` and `# END LOOM LABELS`, extending the established CLAUDE.md / `.gitignore` marker-delimited managed-section pattern. Everything outside the markers is consumer-owned across install, upgrade, and uninstall.

Re-derived against main's `init/{scaffolding,mod}.rs` structure — **not** ported from the gpeyton fork's 726-line `labels.rs` (which does not exist on main).

## Changes

- `defaults/.github/labels.yml` + `.github/labels.yml` — wrap the 27 shipped labels in BEGIN/END markers with a "managed by Loom" note; kept **byte-identical** (parity contract #3896).
- `loom-daemon/src/init/scaffolding.rs` — special-case `labels.yml` in the `.github` copy: fresh → verbatim copy; marker-bearing dst → replace only the marked range (both merge **and** force modes); markerless dst → append the block, preserve all existing entries. Captured pre-copy so a force clobber is repaired. Recorded as `preserved` so post-install byte verification does not flag the intentional divergence.
- `loom-daemon/src/init/mod.rs` — the "customized labels.yml preserved" e2e test now asserts block-merge semantics (Loom block refreshed, consumer label outside survives).
- `scripts/uninstall-loom.sh` — route `labels.yml` to Step 6 smart removal: strip only the marker block; delete the file only when nothing meaningful remains outside it; a markerless file is deleted only when byte-identical to the shipped template, else preserved with a warning; malformed markers preserved.
- `scripts/install-loom.sh` — comment note on labels.yml co-ownership in the stale-sweep allowlist.
- `tests/install/test-uninstall-labels-block.sh` — new shell coverage (mixed / pure-Loom / markerless-match / markerless-diverged / malformed).

## Acceptance criteria

- [x] Fresh install ships `labels.yml` with BEGIN/END markers; both registry copies byte-identical (`check-labels-drift.sh` green)
- [x] Reinstall (with and without `--force`) updates only the marker block; consumer entries outside are never modified
- [x] Install onto a markerless `labels.yml` appends the Loom block and preserves every existing entry
- [x] Uninstall removes only the marker block; deletes the file only when nothing meaningful remains; markerless files deleted only when byte-identical to a shipped template
- [x] `sync-labels.sh` still parses all 27 Loom labels from the marked file (comment markers are inert to its line-oriented parser)
- [x] No label-lifecycle or forge-side behavior change beyond file handling

## Test results

- `cargo test --lib init::` — 129 passed (8 new label-merge unit tests + updated e2e test)
- `cargo fmt` clean; `cargo clippy --lib` clean
- `tests/install/test-uninstall-labels-block.sh` — 16/16 passed
- `defaults/scripts/check-labels-drift.sh` — OK (byte-identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)