### PR TITLE
feat(install): harden reinstall safety, target-aware setup-mcp.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,5 @@ jobs:
         run: bash defaults/scripts/check-labels-drift.sh
       - name: Run installer tests
         run: bash scripts/test-installer.sh
+      - name: Run installer reinstall-safety tests (#4188)
+        run: bash defaults/scripts/tests/test-install-reinstall-safety.sh

--- a/defaults/scripts/tests/test-install-reinstall-safety.sh
+++ b/defaults/scripts/tests/test-install-reinstall-safety.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# test-install-reinstall-safety.sh - Regression tests for issue #4188
+# ("Harvest (fork #55): harden installer reinstall safety + target-aware
+# setup-mcp.sh"), ported from gpeyton/loom commit f064aeef.
+#
+# Covers the installer-safety findings that remain in scope on this repo's
+# restructured installer (see issue #4188 for the full harvest triage):
+#   1. --quick / --yes / --full must not silently bypass the
+#      destructive-reinstall acknowledgement gate -- a non-interactive
+#      reinstall over an existing .loom/ install now requires
+#      --confirm-reinstall (install.sh).
+#   2. Quick Install must rebuild the loom-daemon binary when the source
+#      tree is newer than the binary on disk, not just when it's absent
+#      (install.sh::loom_daemon_binary_stale).
+#   3. `scripts/uninstall-loom.sh --local`'s staging step must only stage
+#      Loom-managed paths, not unrelated untracked/staged consumer files
+#      sitting in the working tree (already landed via the #3545 work --
+#      this group is a regression guard, not new behavior).
+#
+# Two groups present in the original fork commit are intentionally NOT
+# ported here:
+#   - is_legacy_rjwalters_install() metadata-first detection: the function
+#     does not exist on this repo's restructured installer;
+#     install-metadata.json is already written and consumed as authoritative
+#     (install.sh's TARGET_PATH/.loom detection), so there is nothing left to
+#     regression-test under that name.
+#   - Hook-dedup quote-normalization (scaffolding.rs): split out to #4200,
+#     tracked as a Rust unit test there.
+#
+# Strategy: install.sh's loom_daemon_binary_stale() is pure and side-effect
+# free, so it is extracted via awk (same pattern as
+# test-install-source-guard.sh) and exercised in an isolated harness rather
+# than running the full installer end-to-end. The --confirm-reinstall gate
+# and the uninstall staging scope are tested by actually invoking
+# install.sh / uninstall-loom.sh against throwaway temp git repos.
+#
+# Usage:
+#   bash defaults/scripts/tests/test-install-reinstall-safety.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+UNINSTALL_SH="$REPO_ROOT/scripts/uninstall-loom.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" == *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Looking for: '$needle'"
+        echo "    In output:"
+        echo "$haystack" | sed 's/^/      /'
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" != *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Should NOT contain: '$needle'"
+    fi
+}
+
+assert_zero_exit() {
+    local actual="$1" msg="$2"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$actual" -eq 0 ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg (exit=$actual)"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg (expected 0, got $actual)"
+    fi
+}
+
+assert_nonzero_exit() {
+    local actual="$1" msg="$2"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$actual" -ne 0 ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg (exit=$actual)"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg (expected non-zero, got $actual)"
+    fi
+}
+
+if [[ ! -f "$INSTALL_SH" ]]; then
+    echo "ERROR: $INSTALL_SH not found" >&2
+    exit 1
+fi
+if [[ ! -f "$UNINSTALL_SH" ]]; then
+    echo "ERROR: $UNINSTALL_SH not found" >&2
+    exit 1
+fi
+
+# Extract a single top-level function body ("name() {" ... "}") from a file.
+extract_function() {
+    local func_name="$1" file="$2"
+    awk -v fn="${func_name}() {" '
+        $0 == fn { capture=1 }
+        capture { print }
+        capture && /^\}$/ { exit }
+    ' "$file"
+}
+
+echo "================================================================"
+echo "Group 1: --confirm-reinstall gate (issue #4188)"
+echo "================================================================"
+echo ""
+
+# install.sh's dependency-check step (git/node/pnpm/cargo) runs BEFORE the
+# reinstall gate this group tests, and prompts interactively if any are
+# missing. Rather than risk a false failure (or a hang) on a runner missing
+# one of these, skip this group with a clear message when the full
+# dependency set isn't available -- Groups 2/3 don't need it.
+MISSING_FOR_GROUP1=()
+for dep in git node pnpm cargo; do
+    command -v "$dep" &> /dev/null || MISSING_FOR_GROUP1+=("$dep")
+done
+
+if [[ ${#MISSING_FOR_GROUP1[@]} -gt 0 ]]; then
+    echo -e "${YELLOW}SKIP${NC}: missing ${MISSING_FOR_GROUP1[*]} -- install.sh's dependency-check step runs before the reinstall gate"
+else
+    # Build a throwaway "existing install" target: any dir with a .loom/
+    # subdirectory is enough to hit the reinstall gate in install.sh, since
+    # the gate itself runs before any uninstall/build work happens.
+    T1=$(mktemp -d /tmp/loom-confirm-reinstall-test.XXXXXX)
+    mkdir -p "$T1/.loom"
+    echo "sentinel" > "$T1/.loom/sentinel-marker"
+    git -C "$T1" init --quiet 2>/dev/null || true
+
+    # Case 1: --quick without --confirm-reinstall must refuse (non-zero
+    # exit), print guidance mentioning --confirm-reinstall, and leave the
+    # existing .loom/ untouched (no uninstall attempted). Stdin redirected
+    # from /dev/null so any latent interactive prompt fails fast (EOF)
+    # instead of hanging.
+    OUTPUT1=$("$INSTALL_SH" --quick "$T1" < /dev/null 2>&1)
+    EXIT1=$?
+    assert_nonzero_exit "$EXIT1" "Case 1: --quick without --confirm-reinstall refuses"
+    assert_contains "$OUTPUT1" "--confirm-reinstall" "Case 1: guidance mentions --confirm-reinstall"
+    if [[ -f "$T1/.loom/sentinel-marker" ]]; then
+        TESTS_RUN=$((TESTS_RUN + 1))
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: Case 1: existing .loom/ left untouched (no destructive uninstall ran)"
+    else
+        TESTS_RUN=$((TESTS_RUN + 1))
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: Case 1: existing .loom/ was modified/removed -- gate did not block in time"
+    fi
+
+    # Case 2: -y (--yes) without --quick/--confirm-reinstall must ALSO
+    # refuse -- -y alone still implies NON_INTERACTIVE=true, so it must hit
+    # the same gate (regression guard for "any non-interactive flag
+    # combination bypasses the warning", not just --quick specifically).
+    OUTPUT2=$("$INSTALL_SH" -y "$T1" < /dev/null 2>&1)
+    EXIT2=$?
+    assert_nonzero_exit "$EXIT2" "Case 2: -y without --confirm-reinstall refuses"
+    assert_contains "$OUTPUT2" "--confirm-reinstall" "Case 2: guidance mentions --confirm-reinstall"
+
+    # Case 3: --full without --confirm-reinstall must ALSO refuse.
+    OUTPUT3=$("$INSTALL_SH" --full "$T1" < /dev/null 2>&1)
+    EXIT3=$?
+    assert_nonzero_exit "$EXIT3" "Case 3: --full without --confirm-reinstall refuses"
+    assert_contains "$OUTPUT3" "--confirm-reinstall" "Case 3: guidance mentions --confirm-reinstall"
+
+    rm -rf "$T1"
+fi
+echo ""
+
+echo "================================================================"
+echo "Group 2: loom-daemon binary staleness (issue #4188)"
+echo "================================================================"
+echo ""
+
+STALE_FN=$(extract_function "loom_daemon_binary_stale" "$INSTALL_SH")
+if [[ -z "$STALE_FN" ]]; then
+    echo "ERROR: could not extract loom_daemon_binary_stale() from $INSTALL_SH" >&2
+    exit 1
+fi
+
+HARNESS=$(mktemp /tmp/loom-stale-binary-harness.XXXXXX.sh)
+{
+    echo '#!/usr/bin/env bash'
+    echo 'set -uo pipefail'
+    printf '%s\n' "$STALE_FN"
+    echo 'loom_daemon_binary_stale "$1"'
+    echo 'exit $?'
+} > "$HARNESS"
+chmod +x "$HARNESS"
+
+T2=$(mktemp -d /tmp/loom-stale-binary-test.XXXXXX)
+mkdir -p "$T2/loom-daemon/src" "$T2/loom-api/src" "$T2/target/release"
+echo 'fn main() {}' > "$T2/loom-daemon/src/main.rs"
+touch "$T2/Cargo.toml" "$T2/Cargo.lock"
+
+# Case 1: binary absent -> stale.
+"$HARNESS" "$T2"
+assert_zero_exit "$?" "Case 1: missing binary is stale"
+
+# Case 2: binary present and newer than all source files -> not stale.
+touch "$T2/target/release/loom-daemon"
+sleep 1.1
+touch "$T2/target/release/loom-daemon"
+"$HARNESS" "$T2"
+assert_nonzero_exit "$?" "Case 2: binary newer than source is NOT stale"
+
+# Case 3: source file touched after the binary (simulating `git pull`
+# landing a newer commit) -> stale again.
+sleep 1.1
+echo '// updated' >> "$T2/loom-daemon/src/main.rs"
+"$HARNESS" "$T2"
+assert_zero_exit "$?" "Case 3: source newer than binary IS stale (issue #4188 regression)"
+
+rm -rf "$T2" "$HARNESS"
+echo ""
+
+echo "================================================================"
+echo "Group 3: uninstall-loom.sh --local stages only Loom-managed paths"
+echo "================================================================"
+echo ""
+
+T3=$(mktemp -d /tmp/loom-uninstall-scope-test.XXXXXX)
+git -C "$T3" init --quiet
+git -C "$T3" config user.email "test@test.com"
+git -C "$T3" config user.name "Test"
+
+# Minimal Loom footprint (heuristic/legacy removal path -- no
+# install-metadata.json manifest, so uninstall-loom.sh walks defaults/).
+mkdir -p "$T3/.loom/roles" "$T3/.loom/scripts"
+echo '{}' > "$T3/.loom/config.json"
+cat > "$T3/CLAUDE.md" <<'EOF'
+# Loom Orchestration - Repository Guide
+
+Generated by Loom Installation Process
+EOF
+git -C "$T3" add -A
+git -C "$T3" commit -m "Initial commit with Loom installed" --quiet
+
+# Unrelated consumer state that must NOT be touched by the uninstall's
+# staging step: an untracked file, a staged-but-uncommitted new file, and a
+# modification to an existing tracked (non-Loom) file.
+echo "unrelated" > "$T3/unrelated-untracked.txt"
+echo "console.log('hi')" > "$T3/app.js"
+git -C "$T3" add app.js
+echo "# My Project" > "$T3/README.md"
+git -C "$T3" add README.md
+git -C "$T3" commit -m "Add app.js and README.md" --quiet
+echo "# My Project (locally modified, not staged)" >> "$T3/README.md"
+echo "another unrelated untracked file" > "$T3/scratch-notes.txt"
+
+"$UNINSTALL_SH" --yes --local "$T3" > /tmp/loom-uninstall-scope-test.log 2>&1
+UNINSTALL_EXIT=$?
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ $UNINSTALL_EXIT -eq 0 ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: uninstall-loom.sh --local exited 0"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: uninstall-loom.sh --local exited $UNINSTALL_EXIT"
+    sed 's/^/    /' /tmp/loom-uninstall-scope-test.log
+fi
+
+STAGED_AFTER=$(git -C "$T3" diff --cached --name-only)
+
+# The unrelated untracked files must remain untracked (NOT staged).
+assert_not_contains "$STAGED_AFTER" "unrelated-untracked.txt" \
+    "unrelated untracked file was not staged by uninstall"
+assert_not_contains "$STAGED_AFTER" "scratch-notes.txt" \
+    "second unrelated untracked file was not staged by uninstall"
+
+# The locally-modified-but-unstaged README.md change must remain unstaged
+# (git add -A would have staged it as part of the "everything" sweep).
+README_STAGED_DIFF=$(git -C "$T3" diff --cached -- README.md)
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -z "$README_STAGED_DIFF" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: unrelated unstaged README.md edit was not swept into the index"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: unrelated unstaged README.md edit was staged by uninstall"
+fi
+
+# Loom-managed removals (e.g. .loom/config.json) SHOULD be staged as
+# deletions -- the fix must not become "stage nothing".
+assert_contains "$STAGED_AFTER" ".loom/config.json" \
+    "Loom-managed file removal WAS staged (fix doesn't over-correct to no-op)"
+
+rm -rf "$T3" /tmp/loom-uninstall-scope-test.log
+echo ""
+
+echo "================================================================"
+echo "Tests run:    $TESTS_RUN"
+echo -e "Tests passed: ${GREEN}$TESTS_PASSED${NC}"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo -e "Tests failed: ${RED}$TESTS_FAILED${NC}"
+    exit 1
+fi
+echo "================================================================"
+echo "All tests passed."

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,12 @@
 #   -y, --yes                  Non-interactive mode (skip confirmation prompts)
 #   --quick                    Quick Install - direct install without GitHub workflow
 #   --full                     Full Install - creates issue, worktree, and PR
+#   --confirm-reinstall        Acknowledge a destructive reinstall over an existing
+#                              .loom/ install. Required alongside --quick/--yes/--full
+#                              when the target already has Loom installed -- without
+#                              it, non-interactive runs stop and ask you to inventory
+#                              customizations first (interactive runs still get a
+#                              y/N prompt instead).
 #   --allow-non-main-source    Permit installing from a non-main / detached-HEAD Loom source
 #                              (forwarded to scripts/install-loom.sh)
 #   --allow-stale-target       Permit installing over a target whose Loom is newer/stale
@@ -16,6 +22,7 @@
 #   ./install.sh --quick ~/projects/my-app
 #   ./install.sh --full /path/to/team-project
 #   ./install.sh -y ~/projects/my-app  # Non-interactive, defaults to quick
+#   ./install.sh --quick --confirm-reinstall ~/projects/my-app  # Reinstall over an existing install
 
 set -euo pipefail
 
@@ -270,6 +277,26 @@ verify_install() {
   fi
 }
 
+# Returns 0 (true / stale) if the loom-daemon release binary is missing, OR
+# if the source tree it would be built from is newer than the binary on
+# disk (e.g. `git pull` landed a newer commit since the binary was last
+# built). A bare "does it exist" check lets `install.sh --quick` silently
+# reuse a stale binary built from an older commit after a source update --
+# issue #4188. `find -newer` catches both "never built" (the -f check below)
+# and "built from a prior commit" in one pass.
+loom_daemon_binary_stale() {
+  local loom_root="$1"
+  local binary="$loom_root/target/release/loom-daemon"
+
+  [[ -f "$binary" ]] || return 0
+
+  local newer_file
+  newer_file="$(find "$loom_root/loom-daemon" "$loom_root/loom-api" \
+      "$loom_root/Cargo.toml" "$loom_root/Cargo.lock" \
+      -type f -newer "$binary" 2>/dev/null | head -n1)"
+  [[ -n "$newer_file" ]]
+}
+
 # Issue #3588: re-append the current Loom ephemeral .gitignore patterns after a
 # --quick reinstall stash pop that was performed against a HEAD-reset .gitignore.
 #
@@ -406,6 +433,11 @@ echo ""
 # Parse flags
 NON_INTERACTIVE=false
 INSTALL_TYPE=""
+# Explicit acknowledgement that a reinstall over an existing (or legacy)
+# .loom/ installation is destructive (it uninstalls before reinstalling).
+# Required in addition to --quick/--yes/--full when an existing install is
+# detected -- see the reinstall gate below and issue #4188.
+CONFIRM_REINSTALL=false
 # Source/target override flags accepted by scripts/install-loom.sh. The top-level
 # wrapper does not act on them (its source guard runs only in the delegated
 # installer), but it must accept and forward them so the flags it suggests
@@ -435,6 +467,10 @@ while [[ "${1:-}" == -* ]]; do
       NON_INTERACTIVE=true  # --full implies non-interactive
       shift
       ;;
+    --confirm-reinstall)
+      CONFIRM_REINSTALL=true
+      shift
+      ;;
     --allow-non-main-source|--allow-stale-target)
       # Pass-through: accepted here so the wrapper's own suggestion works, then
       # forwarded to scripts/install-loom.sh at the Full-Install delegation execs.
@@ -448,6 +484,12 @@ while [[ "${1:-}" == -* ]]; do
       echo "  -y, --yes                  Non-interactive mode (skip confirmation prompts)"
       echo "  --quick                    Quick Install - direct install without GitHub workflow"
       echo "  --full                     Full Install - creates issue, worktree, and PR"
+      echo "  --confirm-reinstall        Acknowledge a destructive reinstall over an existing"
+      echo "                             .loom/ install. Required alongside --quick/--yes/--full"
+      echo "                             when the target already has Loom installed -- without"
+      echo "                             it, non-interactive runs stop and ask you to inventory"
+      echo "                             customizations first (interactive runs still get a"
+      echo "                             y/N prompt instead)."
       echo "  --allow-non-main-source    Permit installing from a non-main / detached-HEAD"
       echo "                             Loom source (forwarded to scripts/install-loom.sh)"
       echo "  --allow-stale-target       Permit installing over a newer/stale target"
@@ -458,6 +500,7 @@ while [[ "${1:-}" == -* ]]; do
       echo "  ./install.sh --quick ~/projects/my-app"
       echo "  ./install.sh --full /path/to/team-project"
       echo "  ./install.sh -y ~/projects/my-app  # Non-interactive, defaults to quick install"
+      echo "  ./install.sh --quick --confirm-reinstall ~/projects/my-app  # Reinstall over an existing install"
       echo "  ./install.sh --yes --allow-non-main-source /path/to/target  # Install from a non-main source"
       exit 0
       ;;
@@ -756,8 +799,16 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
       info "Installation cancelled"
       exit 0
     fi
+  elif [[ "$CONFIRM_REINSTALL" == true ]]; then
+    info "Non-interactive mode: proceeding with reinstall (--confirm-reinstall acknowledged)"
   else
-    info "Non-interactive mode: proceeding with reinstall"
+    # Issue #4188: --quick / --yes / --full previously set NON_INTERACTIVE=true
+    # and fell straight through the reinstall warning above into a destructive
+    # uninstall-then-reinstall. A non-interactive run over an existing (or
+    # legacy) install now MUST pass --confirm-reinstall explicitly -- it
+    # cannot silently cross this boundary just because it also passed
+    # --quick/--yes/--full.
+    error "Existing Loom installation detected at $TARGET_PATH/.loom -- refusing to run a non-interactive reinstall without explicit acknowledgement.\n       Reinstalling uninstalls the existing Loom payload before writing the new version; inventory and back up any project-owned Loom hooks, scripts, and agent configuration first.\n       Re-run with --confirm-reinstall once you have done so, or omit --quick/--yes/--full to get an interactive y/N prompt instead."
   fi
 
   # Issue #3545: for a --quick reinstall, guard uncommitted user changes across
@@ -830,9 +881,15 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
     info "Running fresh Quick Install..."
     echo ""
 
-    # Check if loom-daemon is built
-    if [[ ! -f "$LOOM_ROOT/target/release/loom-daemon" ]]; then
-      warning "loom-daemon binary not found"
+    # Check if loom-daemon is built AND up to date with the current source
+    # tree (issue #4188 -- a bare existence check reuses a binary built from
+    # an older commit after `git pull` landed a newer one).
+    if loom_daemon_binary_stale "$LOOM_ROOT"; then
+      if [[ -f "$LOOM_ROOT/target/release/loom-daemon" ]]; then
+        warning "loom-daemon binary is stale (source tree updated since last build)"
+      else
+        warning "loom-daemon binary not found"
+      fi
       info "Building loom-daemon (this may take a minute)..."
       cd "$LOOM_ROOT"
       pnpm daemon:build || error "Failed to build loom-daemon"
@@ -1199,9 +1256,15 @@ case "$METHOD" in
     info "Running Quick Install..."
     echo ""
 
-    # Check if loom-daemon is built
-    if [[ ! -f "$LOOM_ROOT/target/release/loom-daemon" ]]; then
-      warning "loom-daemon binary not found"
+    # Check if loom-daemon is built AND up to date with the current source
+    # tree (issue #4188 -- a bare existence check reuses a binary built from
+    # an older commit after `git pull` landed a newer one).
+    if loom_daemon_binary_stale "$LOOM_ROOT"; then
+      if [[ -f "$LOOM_ROOT/target/release/loom-daemon" ]]; then
+        warning "loom-daemon binary is stale (source tree updated since last build)"
+      else
+        warning "loom-daemon binary not found"
+      fi
       info "Building loom-daemon (this may take a minute)..."
       cd "$LOOM_ROOT"
       pnpm daemon:build || error "Failed to build loom-daemon"

--- a/scripts/setup-mcp.sh
+++ b/scripts/setup-mcp.sh
@@ -6,23 +6,87 @@
 # e.g. new sweep-dispatch tools added to src/tools/sweeps.ts never showing
 # up in dist/index.js because the artifact merely *exists* (see #3803, same
 # failure shape as the installed-copy drift fixed in #3777).
+#
+# Usage:
+#   ./scripts/setup-mcp.sh                          # Generate .mcp.json in this checkout
+#   ./scripts/setup-mcp.sh --target /path/to/consumer-repo
+#                                                     # Write .mcp.json into a consumer
+#                                                     # repository instead of this Loom
+#                                                     # source checkout, with LOOM_WORKSPACE
+#                                                     # (and safehouse config resolution)
+#                                                     # pointed at the consumer. --workspace
+#                                                     # is accepted as an alias.
+#
+# `mcp-loom` itself only ever lives in the Loom SOURCE checkout (it is not
+# installed into consumer repos), so the generated `loom` server entry always
+# points at this checkout's mcp-loom/dist/index.js regardless of --target.
+# Only the OUTPUT location (where .mcp.json gets written), LOOM_WORKSPACE (the
+# env var mcp-loom uses to find the repo it operates on), and safehouse config
+# resolution (read from the target's own .loom/config.json) move to the target
+# when --target/--workspace is given. See issue #4188.
 
 set -euo pipefail
 
+TARGET_ARG=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target|--workspace)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: $1 requires a path argument" >&2
+        exit 2
+      fi
+      TARGET_ARG="$2"
+      shift 2
+      ;;
+    --target=*|--workspace=*)
+      TARGET_ARG="${1#*=}"
+      shift
+      ;;
+    -h|--help)
+      sed -n '2,23p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1 (supported: --target/--workspace <path>)" >&2
+      exit 2
+      ;;
+  esac
+done
+
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Get the workspace root (parent of scripts/)
-WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# The Loom SOURCE checkout root (parent of scripts/) -- mcp-loom and the
+# shared mcp-config.sh resolver lib always live here, regardless of --target.
+LOOM_SOURCE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# OUTPUT_TARGET is where .mcp.json gets written, what LOOM_WORKSPACE gets set
+# to, and which repo's .loom/config.json safehouse resolution reads from.
+# Defaults to the Loom source checkout itself (unchanged, self-targeting
+# behavior) unless --target/--workspace names a consumer repository.
+if [[ -n "$TARGET_ARG" ]]; then
+  # Expand tilde and resolve to an absolute path; must already exist.
+  TARGET_ARG="${TARGET_ARG/#\~/$HOME}"
+  if [[ ! -d "$TARGET_ARG" ]]; then
+    echo "Error: --target/--workspace directory does not exist: $TARGET_ARG" >&2
+    exit 2
+  fi
+  OUTPUT_TARGET="$(cd "$TARGET_ARG" && pwd)"
+else
+  OUTPUT_TARGET="$LOOM_SOURCE_ROOT"
+fi
 
 # Optional safehouse MCP server injection (#3999). Sourcing the shared resolver
 # is best-effort: when the lib is absent (e.g. an older installed tree) or the
 # safehouse block is disabled, generation falls through to the loom-only heredoc
-# below, byte-for-byte identical to the pre-#3999 output.
-MCP_CONFIG_LIB="$WORKSPACE_ROOT/defaults/scripts/lib/mcp-config.sh"
+# below, byte-for-byte identical to the pre-#3999 output. The lib itself always
+# resolves from the source checkout (mirrors mcp-loom); the repo_root argument
+# passed to its resolvers below is OUTPUT_TARGET, so safehouse settings are
+# read from the target repo's own .loom/config.json.
+MCP_CONFIG_LIB="$LOOM_SOURCE_ROOT/defaults/scripts/lib/mcp-config.sh"
 # shellcheck source=../defaults/scripts/lib/mcp-config.sh
 [[ -f "$MCP_CONFIG_LIB" ]] && source "$MCP_CONFIG_LIB"
 
-MCP_DIR="$WORKSPACE_ROOT/mcp-loom"
+MCP_DIR="$LOOM_SOURCE_ROOT/mcp-loom"
 MCP_SRC="$MCP_DIR/src"
 MCP_ENTRY="$MCP_DIR/dist/index.js"
 
@@ -67,12 +131,12 @@ SH_SOCKET=""
 SH_PERSONA=""
 SH_COMMAND=""
 if declare -F loom_mcp_safehouse_enabled >/dev/null 2>&1; then
-  SAFEHOUSE_ENABLED="$(loom_mcp_safehouse_enabled "$WORKSPACE_ROOT")"
+  SAFEHOUSE_ENABLED="$(loom_mcp_safehouse_enabled "$OUTPUT_TARGET")"
 fi
 if [[ "$SAFEHOUSE_ENABLED" == "true" ]]; then
-  SH_SOCKET="$(loom_mcp_safehouse_socket "$WORKSPACE_ROOT")"
-  SH_PERSONA="$(loom_mcp_safehouse_persona_fallback "$WORKSPACE_ROOT")"
-  SH_COMMAND="$(loom_mcp_safehouse_command "$WORKSPACE_ROOT")"
+  SH_SOCKET="$(loom_mcp_safehouse_socket "$OUTPUT_TARGET")"
+  SH_PERSONA="$(loom_mcp_safehouse_persona_fallback "$OUTPUT_TARGET")"
+  SH_COMMAND="$(loom_mcp_safehouse_command "$OUTPUT_TARGET")"
   if [[ -z "$SH_SOCKET" ]]; then
     echo "Warning: safehouse enabled but no socket resolves (safehouse.socket / \$LOOM_SAFEHOUSE_SOCKET / \$SAFEHOUSED_SOCKET); omitting safehouse server." >&2
     SH_SOCKET=""
@@ -86,14 +150,14 @@ if [[ "$SAFEHOUSE_ENABLED" == "true" && -n "$SH_SOCKET" ]]; then
   # Two-server config. `loom` stays FIRST (claude-wrapper.sh's pre-flight keys
   # off the first server with args) and byte-identical to the loom-only block;
   # `safehouse` is appended second. Only the socket path is credential-adjacent.
-  cat > "$WORKSPACE_ROOT/.mcp.json" <<EOF
+  cat > "$OUTPUT_TARGET/.mcp.json" <<EOF
 {
   "mcpServers": {
     "loom": {
       "command": "node",
-      "args": ["$WORKSPACE_ROOT/mcp-loom/dist/index.js"],
+      "args": ["$LOOM_SOURCE_ROOT/mcp-loom/dist/index.js"],
       "env": {
-        "LOOM_WORKSPACE": "$WORKSPACE_ROOT"
+        "LOOM_WORKSPACE": "$OUTPUT_TARGET"
       }
     },
     "safehouse": {
@@ -108,18 +172,18 @@ if [[ "$SAFEHOUSE_ENABLED" == "true" && -n "$SH_SOCKET" ]]; then
 }
 EOF
   echo "Generated .mcp.json with loom + safehouse MCP servers"
-  echo "  Workspace: $WORKSPACE_ROOT"
+  echo "  Workspace: $OUTPUT_TARGET"
   echo "  Safehouse persona: $SH_PERSONA (socket: $SH_SOCKET)"
 else
   # Generate .mcp.json with unified loom server
-  cat > "$WORKSPACE_ROOT/.mcp.json" <<EOF
+  cat > "$OUTPUT_TARGET/.mcp.json" <<EOF
 {
   "mcpServers": {
     "loom": {
       "command": "node",
-      "args": ["$WORKSPACE_ROOT/mcp-loom/dist/index.js"],
+      "args": ["$LOOM_SOURCE_ROOT/mcp-loom/dist/index.js"],
       "env": {
-        "LOOM_WORKSPACE": "$WORKSPACE_ROOT"
+        "LOOM_WORKSPACE": "$OUTPUT_TARGET"
       }
     }
   }
@@ -127,6 +191,6 @@ else
 EOF
 
   echo "Generated .mcp.json with unified loom MCP server"
-  echo "  Workspace: $WORKSPACE_ROOT"
+  echo "  Workspace: $OUTPUT_TARGET"
   echo "  Server: mcp-loom/dist/index.js"
 fi


### PR DESCRIPTION
## Summary

Ports the shell-side half of gpeyton/loom fork commit `f064aeef` (harvest bucket a of #4165), re-derived against current main per the curator's scoping in #4188.

- `install.sh` — require `--confirm-reinstall` in addition to `--quick`/`--yes`/`--full` when reinstalling over an existing `.loom/` install; a non-interactive run without it now aborts with an actionable message instead of silently proceeding through the destructive uninstall→reinstall cycle. Interactive y/N behavior at the `Proceed with reinstall? [y/N]` prompt is unchanged.
- `install.sh` — rebuild `loom-daemon` when the source tree (`loom-daemon/`, `loom-api/`, `Cargo.toml`/`.lock`) is newer than `target/release/loom-daemon`, not only when the binary is entirely missing (`loom_daemon_binary_stale()`), at both Quick Install call sites.
- `scripts/setup-mcp.sh` — add `--target`/`--workspace <path>` so `.mcp.json` can be written into a consumer repository instead of always self-targeting the Loom source checkout. `mcp-loom` build/staleness resolution and the shared safehouse-config lib still resolve against the *source* tree (mcp-loom is never installed into consumer repos); only the output path, `LOOM_WORKSPACE`, and safehouse config lookup move to the target. Flagless output is byte-identical to today's — verified via a manual before/after diff and the existing `test-mcp-config.sh` suite (43/43 still pass).
- `defaults/scripts/tests/test-install-reinstall-safety.sh` — new regression harness (15 assertions) covering the `--confirm-reinstall` gate, the loom-daemon staleness check, and the already-landed `uninstall-loom.sh --local` scoped-staging behavior (kept as a regression guard). Wired into the "Installer Integration Tests" CI job in `.github/workflows/ci.yml`.

Two pieces of the original fork commit are intentionally **not** ported here, per the issue's curator triage:
- `is_legacy_rjwalters_install()` metadata-first detection — the function doesn't exist on main's restructured installer (`install-metadata.json` is already authoritative), so there's nothing left to port or test under that name.
- The `scaffolding.rs` hook-dedup quote-normalization — split out to #4200 (diverged ~659 lines since the fork base, needs its own re-derivation).

## Test plan

- [x] `bash defaults/scripts/tests/test-install-reinstall-safety.sh` — 15/15 pass locally
- [x] `bash scripts/test-installer.sh` — 151/151 pass (no regressions)
- [x] `bash defaults/scripts/tests/test-mcp-config.sh` — 43/43 pass (setup-mcp.sh byte-identical no-flag output confirmed)
- [x] Manual: `./install.sh --quick <target-with-existing-.loom>` → aborts with `--confirm-reinstall` guidance; rerun with `--confirm-reinstall` → proceeds through reinstall
- [x] Manual: `-y` and `--full` without `--confirm-reinstall` also refuse (not just `--quick`)
- [x] Manual: `loom_daemon_binary_stale()` extracted + exercised — missing binary is stale, binary newer than source is not stale, source touched after binary is stale again
- [x] Manual: `scripts/setup-mcp.sh --target /tmp/consumer-repo` writes `.mcp.json` under the target with correct absolute paths (source-tree `mcp-loom` args, target-tree `LOOM_WORKSPACE`); source checkout's own `.mcp.json` untouched
- [x] Manual: `--target` with a path containing spaces works correctly
- [x] Shellcheck (`--severity=warning`, matching the CI job) clean on all touched/new scripts

Closes #4188