### PR TITLE
feat(scripts): split classify-error.sh into engine + per-provider pattern tables

### DIFF
--- a/defaults/scripts/lib/classify-error.sh
+++ b/defaults/scripts/lib/classify-error.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# classify-error.sh — Classify a (output, exit_code) pair into an error category.
+# classify-error.sh — Classify a (output, exit_code, [provider]) triple into
+# an error category.
 #
-# Source this file (do not exec). Defines a single function:
+# Source this file (do not exec). Defines a single public function:
 #
-#   classify_error <output> <exit_code> -> echoes one of:
+#   classify_error <output> <exit_code> [provider] -> echoes one of:
 #       SUCCESS         — exit 0 (regardless of output content)
 #       TIMEOUT         — exit 124/137 (productive cycle, not a failure)
 #       CWD_DELETED     — working directory was removed
@@ -28,37 +29,74 @@
 #       FATAL           — non-recoverable (currently never returned;
 #                         reserved for future explicit FATAL signals)
 #
-# Design — exit-code-first ordering:
+# Design — engine vs. provider pattern tables (issue #4190):
+#   classify_error() is a two-layer design: a shared CLASSIFICATION ENGINE
+#   (exit-code-first ordering, the category enum, and the generic-transient
+#   fallthrough) plus provider-scoped PATTERN TABLES that hold the actual
+#   failure-signature regexes. This keeps a future non-Claude runtime adapter
+#   (Codex, Amp, ... — see #4167) additive: register a new provider table
+#   instead of editing the shared engine. Today only the `claude` table is
+#   populated; a `codex` stub exists for the future adapter to fill in.
+#
+#   Provider selector precedence (highest first): optional 3rd positional
+#   arg > `$LOOM_RUNTIME` (the same env var `spawn-worker.sh` uses for
+#   runtime dispatch, see `.loom/docs/runtime-adapters.md`) > default
+#   `"claude"`. Two-arg calls (e.g. `claude-wrapper.sh`, which sources this
+#   file and calls `classify_error "$1" "$2"`) are therefore unaffected and
+#   classify bit-identically to before this split — this file intentionally
+#   does NOT introduce a `LOOM_WORKER` selector (that name belongs to an
+#   older fork design; upstream's convention is `LOOM_RUNTIME`).
+#
+#   An unrecognized provider (or no table for a recognized-but-unimplemented
+#   provider, e.g. `codex` today) never errors — it simply has no
+#   provider-specific matches and falls straight through to the shared
+#   generic-transient table below. Provider tables are ordered case dispatch
+#   (sequential pattern checks), NOT associative-array iteration, so match
+#   order is always deterministic — bash does not guarantee iteration order
+#   for associative arrays.
+#
+#   Within the `claude` table, match order is significant and preserved from
+#   the pre-split implementation: CWD_DELETED -> MODEL_REFUSAL ->
+#   TOKEN_EXPIRED -> SESSION_LIMIT -> TOKEN_EXHAUSTED -> the "No messages
+#   returned" RECOVERABLE case. SESSION_LIMIT must precede TOKEN_EXHAUSTED
+#   because "concurrent session limit" contains the substring "session limit"
+#   that the exhaustion regex also matches (#3947). MODEL_REFUSAL is matched
+#   only when exit_code != 0, preserving the #3233 exit-code-first guarantee
+#   (a clean exit whose output merely mentions "refusal" stays SUCCESS).
+#
+#   Generic transients — rate-limit/429, 5xx, network errors, and the
+#   catch-all RECOVERABLE — are provider-INDEPENDENT and apply to every
+#   provider, including unknown ones. An unknown provider never produces an
+#   error; it always resolves through the generic table.
+#
+# Design — exit-code-first ordering (issue #3233, preserved by the split
+# above):
 #   The original lean-genius implementation grepped output BEFORE checking
 #   the exit code, which caused false positives on clean exits whose stdout
 #   legitimately contained substrings like "500" or "rate limit" (issue
 #   #3233). This rewrite checks the exit code first and only inspects output
-#   for genuine failures (exit_code != 0).
+#   for genuine failures (exit_code != 0). This ordering lives in the shared
+#   engine and applies identically regardless of provider.
 #
-# Test vectors live in `.loom/scripts/tests/test-spawn-claude.sh`.
+# Design source: this provider-table split is a re-implementation, not a
+# cherry-pick, of the engine/table split pioneered in gpeyton/loom@fd5d1da8
+# ("feat(errors): per-provider pattern tables in classify-error.sh"). That
+# commit predates upstream's SESSION_LIMIT (#3947) and MODEL_REFUSAL
+# categories, so it is used here only as a design reference for the
+# selector/table shape — all six Claude-specific categories, in their
+# current documented order, are carried into the `claude` table below.
+#
+# Test vectors live in `defaults/scripts/tests/test-spawn-claude.sh`.
 
 # shellcheck disable=SC2120  # OK that callers pass the args; we don't default.
 
-classify_error() {
+# --- Provider pattern tables -------------------------------------------
+
+# _classify_error_claude <output> -> echoes a category, or nothing if no
+# Claude-specific pattern matched (caller falls through to the generic
+# table). Only called when exit_code != 0.
+_classify_error_claude() {
     local output="$1"
-    local exit_code="$2"
-
-    # 1. Timeout from the `timeout(1)` command — productive cycle, not error
-    if [[ "$exit_code" -eq 124 || "$exit_code" -eq 137 ]]; then
-        echo "TIMEOUT"
-        return
-    fi
-
-    # 2. Exit-code-first: a clean exit is SUCCESS regardless of output content.
-    #    This is the critical fix for #3233 — the previous implementation
-    #    returned RECOVERABLE for clean exits whose stdout contained "500",
-    #    "rate limit", or "No messages returned".
-    if [[ "$exit_code" -eq 0 ]]; then
-        echo "SUCCESS"
-        return
-    fi
-
-    # --- Below here, exit_code != 0 (genuine failure). Inspect output. ---
 
     # Working directory deleted (worktree cleaned up while CLI ran)
     if echo "$output" | grep -qi "current working directory was deleted"; then
@@ -71,8 +109,9 @@ classify_error() {
     # transport failure or a quality signal: the sweep orchestrator responds
     # by dropping one ladder rung (e.g. fable→opus) WITHOUT consuming a Doctor
     # cycle (see sweep.md, "Refusal-aware fallback"). Matched only on a genuine
-    # failure (exit_code != 0) so the exit-code-first #3233 guarantee holds — a
-    # clean exit whose output merely mentions "refusal" stays SUCCESS above.
+    # failure (exit_code != 0, guaranteed by the caller) so the exit-code-first
+    # #3233 guarantee holds — a clean exit whose output merely mentions
+    # "refusal" stays SUCCESS in the shared engine above.
     if echo "$output" | grep -qiE '"?stop_reason"?[[:space:]]*[:=][[:space:]]*"?refusal'; then
         echo "MODEL_REFUSAL"
         return
@@ -104,11 +143,64 @@ classify_error() {
     # and "out of extra usage". A naive `hit.your.limit` pattern misses the
     # "session"/multi-word forms (there is filler between "your" and "limit").
     # This regex is kept in lockstep with claude-wrapper.sh, which sources this
-    # file rather than duplicating the pattern (issue #3738).
+    # file rather than duplicating the pattern (issue #3738) — moving the
+    # pattern into this table preserves that single-source property; the
+    # wrapper still reaches it only via `classify_error`, never a copy.
     if echo "$output" | grep -qiE "hit your (limit|session limit|weekly limit)|hit\.your\.limit|monthly usage limit|out of extra usage"; then
         echo "TOKEN_EXHAUSTED"
         return
     fi
+
+    # "No messages returned" — transient API issue specific to the Claude CLI's
+    # own wording (only reached when exit_code != 0, per the caller contract)
+    if echo "$output" | grep -q "No messages returned"; then
+        echo "RECOVERABLE"
+        return
+    fi
+
+    # No Claude-specific pattern matched — fall through to the generic table.
+}
+
+# _classify_error_codex <output> -> stub for the future Codex runtime adapter
+# (#4167). Intentionally empty: upstream has no Codex runner yet, so there are
+# no real failure signatures to encode. Every input falls through to the
+# shared generic table below (rate-limit/5xx/network/catch-all), which is
+# already correct default behavior for an as-yet-unimplemented provider.
+# TODO(#4167): populate with Codex-specific failure signatures (401/quota/
+# rate-limit wording) when the Codex adapter ships. Do not guess at wording.
+_classify_error_codex() {
+    :
+}
+
+# _classify_error_provider <output> <provider> -> dispatches to the matching
+# provider table via ordered case dispatch (deterministic; no associative-
+# array iteration). Unknown providers intentionally match nothing here and
+# fall through to the generic table in classify_error.
+_classify_error_provider() {
+    local output="$1"
+    local provider="$2"
+
+    case "$provider" in
+        claude)
+            _classify_error_claude "$output"
+            ;;
+        codex)
+            _classify_error_codex "$output"
+            ;;
+        *)
+            # Unknown provider: no provider-specific table, no error — the
+            # generic fallback in classify_error covers it.
+            ;;
+    esac
+}
+
+# --- Generic (provider-independent) transient table ---------------------
+
+# _classify_error_generic <output> -> always echoes a category (never empty).
+# Applies to every provider, including unknown ones, so an unrecognized
+# `provider` value never fails to classify.
+_classify_error_generic() {
+    local output="$1"
 
     # Rate limit (429) — transient, retry with backoff
     if echo "$output" | grep -qiE "rate.limit|too.many.requests|429"; then
@@ -128,14 +220,48 @@ classify_error() {
         return
     fi
 
-    # "No messages returned" — transient API issue (only if exit_code != 0)
-    if echo "$output" | grep -q "No messages returned"; then
-        echo "RECOVERABLE"
+    # Catch-all: unknown non-zero exit, treat as recoverable in daemon mode
+    echo "RECOVERABLE"
+}
+
+# --- Shared classification engine ----------------------------------------
+
+classify_error() {
+    local output="$1"
+    local exit_code="$2"
+    # Provider selector precedence: explicit 3rd arg > $LOOM_RUNTIME > "claude".
+    # Parameter-expansion defaults (not `${3:-}` followed by a separate check)
+    # so a 2-arg call (e.g. claude-wrapper.sh) never trips `set -u`.
+    local provider="${3:-${LOOM_RUNTIME:-claude}}"
+
+    # 1. Timeout from the `timeout(1)` command — productive cycle, not error.
+    #    Provider-independent: a timeout is a timeout regardless of runtime.
+    if [[ "$exit_code" -eq 124 || "$exit_code" -eq 137 ]]; then
+        echo "TIMEOUT"
         return
     fi
 
-    # Catch-all: unknown non-zero exit, treat as recoverable in daemon mode
-    echo "RECOVERABLE"
+    # 2. Exit-code-first: a clean exit is SUCCESS regardless of output content
+    #    or provider. This is the critical fix for #3233 — the previous
+    #    implementation returned RECOVERABLE for clean exits whose stdout
+    #    contained "500", "rate limit", or "No messages returned".
+    if [[ "$exit_code" -eq 0 ]]; then
+        echo "SUCCESS"
+        return
+    fi
+
+    # --- Below here, exit_code != 0 (genuine failure). Inspect output. ---
+
+    # 3. Provider-specific table first (e.g. the six Claude categories).
+    local provider_result
+    provider_result="$(_classify_error_provider "$output" "$provider")"
+    if [[ -n "$provider_result" ]]; then
+        echo "$provider_result"
+        return
+    fi
+
+    # 4. Generic, provider-independent transients (always resolves).
+    _classify_error_generic "$output"
 }
 
 # Convenience predicate matching legacy callers in claude-wrapper.sh.

--- a/defaults/scripts/tests/test-spawn-claude.sh
+++ b/defaults/scripts/tests/test-spawn-claude.sh
@@ -226,6 +226,71 @@ assert_eq "TOKEN_EXHAUSTED" "$result" "weekly 'session limit' stays TOKEN_EXHAUS
 result=$(classify_error "Note: agents pause on a concurrent session limit." 0)
 assert_eq "SUCCESS" "$result" "exit=0 mentioning 'concurrent session' is SUCCESS (#3233/#3947)"
 
+# --- Provider-selector vectors (issue #4190) ---
+# classify_error() now accepts an optional 3rd provider arg with precedence
+# 3rd arg > $LOOM_RUNTIME > "claude". These vectors prove the split into
+# engine + provider pattern tables preserves every prior behavior and adds
+# the new selector semantics correctly.
+
+# Vector #36: explicit 3rd arg "claude" behaves identically to the 2-arg
+# default (bit-identical proof, explicit form)
+result=$(classify_error "OAuth token has expired" 1 "claude")
+assert_eq "TOKEN_EXPIRED" "$result" "explicit 3rd arg 'claude' classifies like the 2-arg default (#4190)"
+
+# Vector #37: LOOM_RUNTIME=claude env selects the claude table (no 3rd arg)
+result=$(LOOM_RUNTIME=claude classify_error "You've hit your weekly limit" 1)
+assert_eq "TOKEN_EXHAUSTED" "$result" "LOOM_RUNTIME=claude selects the claude table (#4190)"
+
+# Vector #38: explicit 3rd arg overrides a conflicting LOOM_RUNTIME
+result=$(LOOM_RUNTIME=nosuch classify_error "OAuth token has expired" 1 "claude")
+assert_eq "TOKEN_EXPIRED" "$result" "3rd arg 'claude' overrides a conflicting LOOM_RUNTIME=nosuch (#4190)"
+
+# Vector #39: unknown provider (LOOM_RUNTIME=nosuch) hits the generic 429
+# fallback rather than erroring or matching a Claude-specific pattern
+result=$(LOOM_RUNTIME=nosuch classify_error "429 Too Many Requests" 1)
+assert_eq "RECOVERABLE" "$result" "unknown provider -> generic 429 fallback, no error (#4190)"
+
+# Vector #40: unknown provider hits the generic 5xx fallback
+result=$(LOOM_RUNTIME=nosuch classify_error "503 Service Unavailable" 1)
+assert_eq "RECOVERABLE" "$result" "unknown provider -> generic 5xx fallback, no error (#4190)"
+
+# Vector #41: unknown provider hits the generic network-error fallback
+result=$(LOOM_RUNTIME=nosuch classify_error "ECONNREFUSED" 1)
+assert_eq "RECOVERABLE" "$result" "unknown provider -> generic network fallback, no error (#4190)"
+
+# Vector #42: unknown provider does NOT match a Claude-specific pattern —
+# "OAuth token has expired" falls through to the generic catch-all instead of
+# TOKEN_EXPIRED, proving provider tables are genuinely provider-scoped.
+result=$(LOOM_RUNTIME=nosuch classify_error "OAuth token has expired" 1)
+assert_eq "RECOVERABLE" "$result" "unknown provider does not match the claude-only TOKEN_EXPIRED pattern (#4190)"
+
+# Vector #43: unknown provider + clean exit is still SUCCESS (engine layer is
+# provider-independent)
+result=$(LOOM_RUNTIME=nosuch classify_error "anything" 0)
+assert_eq "SUCCESS" "$result" "unknown provider + exit=0 is SUCCESS (#4190)"
+
+# Vector #44: SESSION_LIMIT still wins over TOKEN_EXHAUSTED under an explicit
+# claude provider selector (ordering invariant preserved post-split)
+result=$(classify_error "Error: you have reached your concurrent session limit" 1 "claude")
+assert_eq "SESSION_LIMIT" "$result" "SESSION_LIMIT beats TOKEN_EXHAUSTED under explicit claude provider (#4190)"
+
+# Vector #45: exit 124/137 -> TIMEOUT regardless of provider (engine layer)
+result=$(LOOM_RUNTIME=nosuch classify_error "anything" 124)
+assert_eq "TIMEOUT" "$result" "exit=124 is TIMEOUT regardless of provider (#4190)"
+result=$(classify_error "anything" 137 "claude")
+assert_eq "TIMEOUT" "$result" "exit=137 is TIMEOUT regardless of provider (#4190)"
+
+# Vector #46: a 2-arg call under `set -u` does not trip an unbound-variable
+# error — the provider default-expansion chain must be safe with no 3rd arg
+# and no LOOM_RUNTIME set.
+set -u
+result=$(env -u LOOM_RUNTIME bash -c '
+  source "'"$SCRIPTS_DIR"'/lib/classify-error.sh"
+  set -u
+  classify_error "anything" 1
+')
+assert_eq "RECOVERABLE" "$result" "2-arg call under set -u with no LOOM_RUNTIME does not error (#4190)"
+
 # ============================================================
 # Section 2: spawn-claude.sh dispatch (with stub `claude`)
 # ============================================================


### PR DESCRIPTION
## Summary

- Splits `classify_error()` in `defaults/scripts/lib/classify-error.sh` into a shared classification **engine** (exit-code-first ordering, category enum, generic-transient fallthrough) and provider-scoped **pattern tables**, so a future non-Claude runtime adapter (#4167) can register a new table instead of editing the shared engine.
- Adds an optional 3rd `provider` argument to `classify_error <output> <exit_code> [provider]`, with precedence: explicit 3rd arg > `$LOOM_RUNTIME` (matching `spawn-worker.sh`'s runtime-dispatch convention) > default `"claude"`.
- Carries all six Claude-specific categories — CWD_DELETED, MODEL_REFUSAL, TOKEN_EXPIRED, SESSION_LIMIT, TOKEN_EXHAUSTED, and the "No messages returned" RECOVERABLE case — into a `claude` pattern table, in their current documented order (SESSION_LIMIT before TOKEN_EXHAUSTED; MODEL_REFUSAL only matched on `exit_code != 0`).
- Keeps generic transients (429/5xx/network/catch-all RECOVERABLE) provider-independent so an unknown provider always falls through cleanly rather than erroring.
- Includes an intentionally empty, TODO-marked `codex` stub for the future #4167 adapter.
- `claude-wrapper.sh` is unchanged — its existing 2-arg `classify_error "$1" "$2"` calls resolve the provider via the default chain and classify bit-identically to before.

## Design source

Re-implements (not a cherry-pick of) the engine/table split pioneered in `gpeyton/loom@fd5d1da8` ("feat(errors): per-provider pattern tables in classify-error.sh"). That commit predates upstream's SESSION_LIMIT (#3947) and MODEL_REFUSAL categories, so it's used here only as a design reference for the selector/table shape — this PR re-implements against current `main` and carries all six Claude categories, in their current order, into the `claude` table.

## Changes

- `defaults/scripts/lib/classify-error.sh` — engine/table split, optional provider selector, header comment rewrite documenting the table structure and precedence.
- `defaults/scripts/tests/test-spawn-claude.sh` — added 11 new vectors covering explicit 3rd-arg selection, `LOOM_RUNTIME` precedence and override, unknown-provider generic fallback (429/5xx/network/catch-all), unknown-provider clean-exit SUCCESS, SESSION_LIMIT-before-TOKEN_EXHAUSTED under an explicit `claude` selector, TIMEOUT regardless of provider, and a `set -u` 2-arg-call safety check.

## Acceptance Criteria Verification

- [x] `classify_error <output> <exit_code> [provider]` accepts an optional provider selector with precedence 3rd arg > `$LOOM_RUNTIME` > `"claude"` — verified by vectors #36–38.
- [x] All six Claude-specific categories live in the `claude` pattern table; generic HTTP/network transients are provider-independent — verified by vectors #39–42.
- [x] Two-arg calls classify bit-identically to current main for all existing test vectors; `claude-wrapper.sh` itself is unchanged — verified: all 80 pre-existing vectors pass unmodified (`git diff` shows zero changes to `claude-wrapper.sh`).
- [x] SESSION_LIMIT-before-TOKEN_EXHAUSTED and MODEL_REFUSAL-only-on-failure ordering invariants are preserved, comments retained — verified by pre-existing vectors #30–35 plus new vector #44.
- [x] Unknown provider values fall through to the generic table without erroring; `is_recoverable_error` behavior unchanged — verified by vectors #39–43.
- [x] Header comment block updated to document table structure and selector precedence.
- [x] PR body credits fork commit `gpeyton/loom@fd5d1da8` as the design source (above).

## Test Plan

- [x] `bash defaults/scripts/tests/test-spawn-claude.sh` — all 92 vectors pass (80 pre-existing unmodified + 12 new), zero expectation edits to the pre-existing vectors (bit-identical proof).
- [x] `shellcheck defaults/scripts/lib/classify-error.sh` and `test-spawn-claude.sh` — zero warnings.
- [x] Manual: sourced `classify-error.sh` in a clean shell under `set -u` and ran a 2-arg call — no unbound-variable error (also covered by automated vector #46).
- [x] Edge cases: SESSION_LIMIT still wins over TOKEN_EXHAUSTED under the claude table (vector #44); `stop_reason: refusal` with exit 0 stays SUCCESS (pre-existing vector #21, unchanged); exit 124/137 → TIMEOUT regardless of provider (vector #45).

## Scope

Two files touched, as scoped: `defaults/scripts/lib/classify-error.sh` and `defaults/scripts/tests/test-spawn-claude.sh`. `claude-wrapper.sh` and `spawn-worker.sh` are untouched, per the issue's scope guard. No Codex/Amp runner work.

Closes #4190