### PR TITLE
fix(daemon): quarantine automation no longer overrides a deliberate operator loom:blocked park

### DIFF
--- a/loom-daemon/src/quarantine_reconciliation.rs
+++ b/loom-daemon/src/quarantine_reconciliation.rs
@@ -23,6 +23,29 @@
 //! fresh daemon's quarantine memory is *always* empty at startup, so the sole
 //! question is "did the daemon itself apply this `loom:blocked` label", which
 //! the comment marker answers directly.
+//!
+//! ## Recency comparison (Issue #4206)
+//!
+//! The marker-comment-presence heuristic above is wrong once an issue has
+//! ever been quarantined: the comment is permanent, so it stays on the
+//! thread forever. That means EVERY later manual park an operator applies to
+//! that same issue — including one applied long after the daemon released
+//! its own quarantine — is misclassified as daemon-owned and auto-flipped
+//! right back to `loom:issue`, silently overriding a deliberate human
+//! decision. This is the "crash-loop on previously-quarantined issues"
+//! defect the issue describes.
+//!
+//! [`decide`] now additionally compares two timestamps when both are
+//! available: the most recent `labeled loom:blocked` timeline event, and the
+//! most recent quarantine-marker comment. A `loom:blocked` label is only
+//! treated as daemon-owned (and thus releasable) when its labeling event is
+//! contemporaneous with — not meaningfully newer than — the daemon's own
+//! comment (see [`RECENCY_TOLERANCE_SECS`]). When either timestamp is
+//! unavailable this falls back to the pre-#4206 behavior (marker presence
+//! alone), so a partial/older API response never strands a genuine daemon
+//! quarantine.
+
+use chrono::{DateTime, Utc};
 
 /// Env var to disable the startup quarantine reconciliation pass entirely
 /// (kill switch, not a feature gate — this is corrective crash recovery in
@@ -37,6 +60,14 @@ pub const RECONCILE_ENABLED_ENV: &str = "LOOM_QUARANTINE_RECONCILE";
 /// [`crate::claim_reconciliation::MAX_ISSUES_PER_WORKSPACE`].
 pub const MAX_ISSUES_PER_WORKSPACE: u32 = 100;
 
+/// How close the most recent `labeled loom:blocked` timeline event must be
+/// to the most recent quarantine-marker comment for the two to be treated as
+/// the SAME daemon-applied mutation (Issue #4206). `gh`'s label-flip and
+/// comment-post are two separate API calls a few hundred milliseconds apart
+/// at most; a few seconds of slack absorbs API latency without opening a
+/// window a human's manual re-park could land inside.
+pub const RECENCY_TOLERANCE_SECS: i64 = 5;
+
 /// Resolve whether the startup quarantine reconciliation pass is enabled.
 #[must_use]
 pub fn reconciliation_enabled() -> bool {
@@ -48,35 +79,64 @@ pub fn reconciliation_enabled() -> bool {
 
 /// A `loom:blocked` issue reported by the forge, trimmed to the fields the
 /// reconciliation decision needs.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BlockedIssue {
     pub number: u32,
     /// Whether any comment on the issue contains
     /// [`crate::sweep_registry::QUARANTINE_COMMENT_MARKER`].
     pub has_quarantine_comment: bool,
+    /// Timestamp of the most recent quarantine-marker comment on the issue
+    /// thread (Issue #4206). `None` when there is no marker comment, or its
+    /// timestamp could not be resolved.
+    pub last_quarantine_comment_at: Option<DateTime<Utc>>,
+    /// Timestamp of the most recent `labeled loom:blocked` timeline event
+    /// (Issue #4206). `None` when unresolvable — callers must treat this as
+    /// "no recency signal available", not "never labeled".
+    pub last_blocked_labeled_at: Option<DateTime<Utc>>,
 }
 
 /// The reconciliation decision for one issue.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReconcileAction {
-    /// No daemon quarantine comment found — leave the claim alone. This is
-    /// the fail-safe branch: a human's manual `loom:blocked` is never
-    /// touched.
+    /// Leave the claim alone. This is the fail-safe branch: a human's
+    /// manual `loom:blocked` — including a LATER manual re-park on an issue
+    /// the daemon once quarantined (Issue #4206) — is never touched.
     Keep,
     /// Flip `loom:blocked` back to `loom:issue`: the label was applied by a
-    /// daemon quarantine that could not have survived to this restart.
+    /// daemon quarantine that could not have survived to this restart (or,
+    /// for the TTL path, has now aged out).
     Release,
 }
 
 /// Pure decision function — no I/O, fully unit-testable. See the module docs
 /// for the decision rule.
+///
+/// 1. No quarantine-marker comment anywhere on the thread ⇒ this `loom:blocked`
+///    was never touched by the daemon ⇒ [`ReconcileAction::Keep`].
+/// 2. A marker comment exists AND both recency timestamps are available ⇒
+///    compare them: a `labeled loom:blocked` event more than
+///    [`RECENCY_TOLERANCE_SECS`] newer than the marker comment is a later,
+///    independent manual park ⇒ [`ReconcileAction::Keep`]. Otherwise the
+///    labeling is either the daemon's own (contemporaneous) mutation or
+///    predates it ⇒ [`ReconcileAction::Release`].
+/// 3. A marker comment exists but either timestamp is unavailable (partial
+///    API response) ⇒ fall back to the pre-#4206 behavior: marker presence
+///    alone is enough ⇒ [`ReconcileAction::Release`]. This is the fail-open
+///    branch — favoring the pre-existing release behavior over stranding a
+///    genuine daemon quarantine on an unverifiable read.
 #[must_use]
 pub fn decide(issue: &BlockedIssue) -> ReconcileAction {
-    if issue.has_quarantine_comment {
-        ReconcileAction::Release
-    } else {
-        ReconcileAction::Keep
+    if !issue.has_quarantine_comment {
+        return ReconcileAction::Keep;
     }
+    if let (Some(labeled_at), Some(comment_at)) =
+        (issue.last_blocked_labeled_at, issue.last_quarantine_comment_at)
+    {
+        if (labeled_at - comment_at).num_seconds() > RECENCY_TOLERANCE_SECS {
+            return ReconcileAction::Keep;
+        }
+    }
+    ReconcileAction::Release
 }
 
 /// Plan reconciliation decisions for every issue in `issues`. Performs no
@@ -95,9 +155,10 @@ pub fn plan(issues: &[BlockedIssue]) -> Vec<(u32, ReconcileAction)> {
 /// the decision logic above is the fully-covered surface; this module is a
 /// thin, best-effort `Command` wrapper.
 pub mod forge {
-    use super::{plan, BlockedIssue, ReconcileAction, MAX_ISSUES_PER_WORKSPACE};
-    use crate::sweep_registry::QUARANTINE_COMMENT_MARKER;
+    use super::{decide, plan, BlockedIssue, ReconcileAction, MAX_ISSUES_PER_WORKSPACE};
+    use crate::sweep_registry::{output_with_timeout, reap_gh_timeout, QUARANTINE_COMMENT_MARKER};
     use anyhow::{anyhow, Context, Result};
+    use chrono::{DateTime, Utc};
     use serde::Deserialize;
     use std::path::Path;
     use std::process::{Command, Stdio};
@@ -106,6 +167,8 @@ pub mod forge {
     struct GhComment {
         #[serde(default)]
         body: String,
+        #[serde(default, rename = "createdAt")]
+        created_at: Option<DateTime<Utc>>,
     }
 
     #[derive(Debug, Deserialize)]
@@ -146,14 +209,136 @@ pub mod forge {
             serde_json::from_slice(&out.stdout).context("parse gh issue list JSON")?;
         Ok(rows
             .into_iter()
-            .map(|r| BlockedIssue {
-                number: r.number,
-                has_quarantine_comment: r
+            .map(|r| {
+                let marker_comments: Vec<&GhComment> = r
                     .comments
                     .iter()
-                    .any(|c| c.body.contains(QUARANTINE_COMMENT_MARKER)),
+                    .filter(|c| c.body.contains(QUARANTINE_COMMENT_MARKER))
+                    .collect();
+                BlockedIssue {
+                    number: r.number,
+                    has_quarantine_comment: !marker_comments.is_empty(),
+                    last_quarantine_comment_at: marker_comments
+                        .iter()
+                        .filter_map(|c| c.created_at)
+                        .max(),
+                    // Filled in by the caller (Issue #4206) only for
+                    // candidates that could actually be released — an issue
+                    // with no marker comment is `Keep` unconditionally and
+                    // never needs the extra `gh` round-trip.
+                    last_blocked_labeled_at: None,
+                }
             })
             .collect())
+    }
+
+    /// Best-effort fetch of the most recent `labeled loom:blocked` timeline
+    /// event for `issue` (Issue #4206), used to distinguish the daemon's own
+    /// (contemporaneous) label-flip from a later, independent manual park.
+    /// Returns `None` on any failure/timeout/unparseable-output — callers
+    /// must treat that as "no recency signal", which [`decide`] resolves by
+    /// falling back to the pre-#4206 marker-presence-only rule.
+    fn fetch_last_blocked_labeled_at(
+        gh_bin: &Path,
+        root: &Path,
+        issue: u32,
+    ) -> Option<DateTime<Utc>> {
+        let mut cmd = Command::new(gh_bin);
+        cmd.arg("api")
+            .arg(format!("repos/{{owner}}/{{repo}}/issues/{issue}/timeline"))
+            .arg("--paginate")
+            .arg("--jq")
+            .arg(
+                r#"[.[] | select(.event == "labeled" and .label.name == "loom:blocked") | .created_at] | max // empty"#,
+            );
+        cmd.current_dir(root);
+        if let Ok(repo) = std::env::var("LOOM_REPO") {
+            cmd.arg("--repo").arg(repo);
+        }
+        let out = output_with_timeout(cmd, reap_gh_timeout()).ok()??;
+        if !out.status.success() {
+            return None;
+        }
+        parse_timestamp(&out.stdout)
+    }
+
+    /// Best-effort fetch of the most recent quarantine-marker comment's
+    /// timestamp for `issue` (Issue #4206), independent of
+    /// [`list_blocked_issues`]'s bulk fetch — used by [`probe_manual_repark`],
+    /// which is called per-issue outside the startup listing pass (from the
+    /// TTL-expiry path). Returns `None` on any failure, OR when no comment on
+    /// the thread contains [`QUARANTINE_COMMENT_MARKER`].
+    fn fetch_last_quarantine_comment_at(
+        gh_bin: &Path,
+        root: &Path,
+        issue: u32,
+    ) -> Option<DateTime<Utc>> {
+        let mut cmd = Command::new(gh_bin);
+        cmd.arg("issue")
+            .arg("view")
+            .arg(issue.to_string())
+            .arg("--json")
+            .arg("comments")
+            .arg("--jq")
+            .arg(format!(
+                r#"[.comments[] | select(.body | contains("{QUARANTINE_COMMENT_MARKER}")) | .createdAt] | max // empty"#
+            ));
+        cmd.current_dir(root);
+        if let Ok(repo) = std::env::var("LOOM_REPO") {
+            cmd.arg("--repo").arg(repo);
+        }
+        let out = output_with_timeout(cmd, reap_gh_timeout()).ok()??;
+        if !out.status.success() {
+            return None;
+        }
+        parse_timestamp(&out.stdout)
+    }
+
+    /// Parse a `gh --jq` scalar result that is either a bare RFC-3339
+    /// timestamp or a JSON-quoted one, tolerating an empty/`null` result
+    /// (no match).
+    fn parse_timestamp(stdout: &[u8]) -> Option<DateTime<Utc>> {
+        let raw = String::from_utf8_lossy(stdout);
+        let trimmed = raw.trim();
+        if trimmed.is_empty() || trimmed == "null" {
+            return None;
+        }
+        let unquoted = trimmed.trim_matches('"');
+        DateTime::parse_from_rfc3339(unquoted)
+            .ok()
+            .map(|dt| dt.with_timezone(&Utc))
+    }
+
+    /// Best-effort, single-issue check of whether `issue`'s current
+    /// `loom:blocked` label is a manual park applied well AFTER the daemon's
+    /// own quarantine comment (Issue #4206) — used by
+    /// [`crate::sweep_registry::SweepRegistry`]'s TTL-expiry path (outside
+    /// the startup listing pass) to decide whether releasing would clobber a
+    /// deliberate later operator decision.
+    ///
+    /// Returns `true` only when [`decide`] resolves to
+    /// [`ReconcileAction::Keep`] on freshly-fetched data — i.e. a marker
+    /// comment DOES exist (this issue was genuinely quarantined at some
+    /// point) and a `loom:blocked` labeling event is confirmed to postdate
+    /// it by more than [`super::RECENCY_TOLERANCE_SECS`]. Any unresolvable
+    /// signal (no marker comment found, a `gh` failure/timeout, or missing
+    /// timeline data) returns `false` — fail-open, so a forge hiccup can
+    /// never permanently strand a genuine daemon quarantine at `loom:blocked`.
+    #[must_use]
+    pub fn probe_manual_repark(gh_bin: &Path, root: &Path, issue: u32) -> bool {
+        let Some(last_quarantine_comment_at) =
+            fetch_last_quarantine_comment_at(gh_bin, root, issue)
+        else {
+            return false;
+        };
+        let last_blocked_labeled_at = fetch_last_blocked_labeled_at(gh_bin, root, issue);
+        let state = BlockedIssue {
+            number: issue,
+            has_quarantine_comment: true,
+            last_quarantine_comment_at: Some(last_quarantine_comment_at),
+            last_blocked_labeled_at,
+        };
+        decide(&state) == ReconcileAction::Keep
     }
 
     fn release(gh_bin: &Path, root: &Path, issue: u32) -> Result<()> {
@@ -204,6 +389,21 @@ pub mod forge {
             return (0, 0);
         }
 
+        // Issue #4206: augment with the timeline recency signal, but only
+        // for candidates that might actually be released (a marker comment
+        // exists) — an issue with no marker comment is `Keep` unconditionally
+        // and never needs the extra `gh` round-trip.
+        let issues: Vec<BlockedIssue> = issues
+            .into_iter()
+            .map(|mut issue| {
+                if issue.has_quarantine_comment {
+                    issue.last_blocked_labeled_at =
+                        fetch_last_blocked_labeled_at(gh_bin, root, issue.number);
+                }
+                issue
+            })
+            .collect();
+
         let decisions = plan(&issues);
         let checked = decisions.len();
 
@@ -247,6 +447,8 @@ mod tests {
         BlockedIssue {
             number,
             has_quarantine_comment: has_comment,
+            last_quarantine_comment_at: None,
+            last_blocked_labeled_at: None,
         }
     }
 
@@ -276,6 +478,67 @@ mod tests {
                 (3, ReconcileAction::Release),
             ]
         );
+    }
+
+    /// Issue #4206 (Option 1, recency comparison): when both timestamps are
+    /// available and the `loom:blocked` labeling event is contemporaneous
+    /// with the daemon's own quarantine-marker comment (within
+    /// [`RECENCY_TOLERANCE_SECS`]), the label is still recognized as
+    /// daemon-owned and released — this is the normal quarantine-apply
+    /// sequence (label flip, then comment), not a manual park.
+    #[test]
+    fn decide_releases_when_labeled_event_contemporaneous_with_marker_comment() {
+        let comment_at = Utc::now();
+        let labeled_at = comment_at + chrono::Duration::seconds(2);
+        let issue = BlockedIssue {
+            number: 42,
+            has_quarantine_comment: true,
+            last_quarantine_comment_at: Some(comment_at),
+            last_blocked_labeled_at: Some(labeled_at),
+        };
+        assert_eq!(decide(&issue), ReconcileAction::Release);
+    }
+
+    /// Issue #4206 (Option 1, recency comparison) — the load-bearing
+    /// regression case: an issue the daemon quarantined LONG ago (its
+    /// marker comment is old), but whose `loom:blocked` label was applied by
+    /// a human much more recently (a deliberate later park unrelated to the
+    /// original daemon quarantine). The comment-presence-only heuristic
+    /// (pre-#4206) would misclassify this as daemon-owned and release it —
+    /// silently overriding the operator's park. The recency-aware decision
+    /// must Keep it.
+    #[test]
+    fn decide_keeps_manual_repark_long_after_daemon_quarantine_comment() {
+        let comment_at = Utc::now() - chrono::Duration::days(3);
+        let labeled_at = Utc::now(); // re-blocked by a human just now
+        let issue = BlockedIssue {
+            number: 4206,
+            has_quarantine_comment: true,
+            last_quarantine_comment_at: Some(comment_at),
+            last_blocked_labeled_at: Some(labeled_at),
+        };
+        assert_eq!(
+            decide(&issue),
+            ReconcileAction::Keep,
+            "a loom:blocked label applied well after the daemon's quarantine comment is a \
+             later, independent manual park and must never be auto-released"
+        );
+    }
+
+    /// Issue #4206: when a marker comment exists but the timeline recency
+    /// signal could not be resolved (partial/older API response, or the
+    /// timeline fetch failed), `decide` falls back to the pre-#4206
+    /// marker-presence-only rule rather than stranding a genuine daemon
+    /// quarantine on an unverifiable read.
+    #[test]
+    fn decide_releases_on_missing_timeline_signal_with_marker_comment_present() {
+        let issue = BlockedIssue {
+            number: 7,
+            has_quarantine_comment: true,
+            last_quarantine_comment_at: Some(Utc::now()),
+            last_blocked_labeled_at: None,
+        };
+        assert_eq!(decide(&issue), ReconcileAction::Release);
     }
 
     #[test]

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -53,6 +53,7 @@
 
 use crate::event_bus::EventBus;
 use crate::peer_claims::{self, ClaimAd, PeerClaimView};
+use crate::quarantine_reconciliation;
 use crate::sweep_journal;
 use crate::tokens_pool::bad_tokens;
 use crate::types::{Event, SweepId, SweepInfo, SweepKind, SweepOutcome, SweepState};
@@ -1047,7 +1048,7 @@ fn classify_account_exhaustion(log_tail: &str) -> Option<&'static str> {
 /// Resolve the per-call reaper `gh` timeout (Issue #3973): the
 /// [`REAP_GH_TIMEOUT_ENV`] override (whole seconds, must be > 0) or the
 /// [`REAP_GH_TIMEOUT`] default.
-fn reap_gh_timeout() -> Duration {
+pub(crate) fn reap_gh_timeout() -> Duration {
     std::env::var(REAP_GH_TIMEOUT_ENV)
         .ok()
         .and_then(|s| s.trim().parse::<u64>().ok())
@@ -1071,7 +1072,7 @@ fn reap_gh_timeout() -> Duration {
 /// an edit ack), so the `try_wait` poll loop never risks a full-pipe-buffer
 /// deadlock; the kill-on-timeout path drains the pipe via `wait()` after the
 /// signal.
-fn output_with_timeout(
+pub(crate) fn output_with_timeout(
     mut cmd: Command,
     timeout: Duration,
 ) -> std::io::Result<Option<std::process::Output>> {
@@ -2427,20 +2428,39 @@ impl SweepRegistry {
         }
     }
 
+    /// Restore a crashed/orphaned claim's `loom:building` back to
+    /// `loom:issue` — UNLESS the issue currently carries `loom:blocked`
+    /// (Issue #4206). A deliberate operator park (applied by hand, possibly
+    /// while the now-dead sweep was still `loom:building`) must never be
+    /// clobbered into the illegal `loom:blocked` + `loom:issue` combo by the
+    /// crash-recovery path. Re-reads the issue's current labels first (the
+    /// same probe pattern as [`Self::issue_has_blocked_label`], used
+    /// elsewhere on the reap path) — best-effort and fail-open: an
+    /// unverifiable read falls back to the pre-#4206 unconditional restore,
+    /// since a stranded `loom:building` claim is the more common failure
+    /// mode this path exists to fix.
     fn restore_label_to_ready(&self, issue: u32) -> Result<()> {
         let gh = self
             .config
             .gh_bin
             .clone()
             .unwrap_or_else(|| PathBuf::from("gh"));
+        let blocked = self.issue_has_blocked_label(issue);
         let mut cmd = Command::new(&gh);
         cmd.arg("issue")
             .arg("edit")
             .arg(issue.to_string())
             .arg("--remove-label")
-            .arg("loom:building")
-            .arg("--add-label")
-            .arg("loom:issue");
+            .arg("loom:building");
+        if blocked {
+            log::info!(
+                "sweep_registry: restore_label_to_ready for #{issue} found `loom:blocked` \
+                 already present — preserving the operator's park by removing the stale \
+                 `loom:building` claim only, NOT re-adding `loom:issue` (#4206)"
+            );
+        } else {
+            cmd.arg("--add-label").arg("loom:issue");
+        }
         // Scope the restore to the registry's workspace so the crash-path label
         // recovery resolves against the right repo in a multi-workspace daemon
         // (#3937). LOOM_REPO still overrides when set.
@@ -2615,12 +2635,53 @@ impl SweepRegistry {
         for issue in expired {
             self.quarantined.remove(&issue);
             self.insta_crash_counts.remove(&issue);
+
+            // Issue #4206: before restoring the forge label, check whether a
+            // human re-applied `loom:blocked` well AFTER the daemon's own
+            // quarantine comment — a deliberate later park, distinguishable
+            // from the daemon's own (older) quarantine by comparing the most
+            // recent `labeled loom:blocked` timeline event against the most
+            // recent quarantine-marker comment. If so, the in-memory entry
+            // above is still purged (this issue stops occupying quarantine
+            // bookkeeping/TTL churn), but the forge label is left completely
+            // untouched — TTL expiry becomes a no-op for it.
+            if !self.config.skip_label_flip && self.is_manually_reparked(issue) {
+                log::info!(
+                    "sweep_registry: issue #{issue} quarantine TTL expired, but the forge shows \
+                     `loom:blocked` was re-applied by a human after the daemon's quarantine \
+                     comment — purging the in-memory record WITHOUT touching the forge label \
+                     (#4206)"
+                );
+                continue;
+            }
+
             log::info!(
                 "sweep_registry: issue #{issue} quarantine expired after {ttl_secs}s — eligible \
                  for re-dispatch again (#3939)"
             );
             self.attempt_quarantine_release(issue);
         }
+    }
+
+    /// Best-effort probe (Issue #4206) for whether `issue`'s current
+    /// `loom:blocked` label was applied by a human well after the daemon's
+    /// last quarantine-marker comment — i.e. a deliberate LATER park that
+    /// happens to sit on an issue the daemon also quarantined at some point.
+    /// Bounded by [`reap_gh_timeout`] like every other reaper-path `gh` call
+    /// (Issue #3973). Fail-open (`false`) on any unresolvable signal so a
+    /// forge hiccup never permanently strands a genuine daemon quarantine —
+    /// see [`quarantine_reconciliation::forge::probe_manual_repark`].
+    fn is_manually_reparked(&self, issue: u32) -> bool {
+        let gh = self
+            .config
+            .gh_bin
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("gh"));
+        quarantine_reconciliation::forge::probe_manual_repark(
+            &gh,
+            &self.config.workspace_root,
+            issue,
+        )
     }
 
     /// Retry every issue in [`pending_quarantine_release`](Self::pending_quarantine_release_issues)
@@ -7339,6 +7400,82 @@ exit 0
         assert_eq!(gh_calls, gh_calls_after, "no further gh calls once nothing is pending");
     }
 
+    /// Issue #4206 (Option 1): TTL expiry must never release a `loom:blocked`
+    /// that the forge shows was RE-applied by a human well after the
+    /// daemon's own quarantine comment — a deliberate later park. The
+    /// in-memory quarantine entry is still purged (so it stops occupying TTL
+    /// bookkeeping and re-firing every tick), but the forge label must be
+    /// left completely untouched — this is exactly the reported crash-loop:
+    /// the daemon repeatedly overriding a human's park on a
+    /// previously-quarantined issue.
+    #[test]
+    fn quarantine_ttl_expiry_never_releases_a_later_manual_repark() {
+        let dir = tempdir().unwrap();
+        let gh_log = dir.path().join("gh-invocations.log");
+        let fake_gh = dir.path().join("fake-gh.sh");
+        // `gh issue view <n> --json comments --jq ...` (the marker-comment
+        // recency probe) reports an old daemon quarantine comment;
+        // `gh api repos/{owner}/{repo}/issues/<n>/timeline ...` (the
+        // labeled-event recency probe) reports a `loom:blocked` labeling
+        // event long AFTER that comment — the signature of a later manual
+        // re-park.
+        let script = format!(
+            r#"#!/usr/bin/env bash
+printf '%s\n' "$*" >> "{log}"
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  echo '"2020-01-01T00:00:00Z"'
+  exit 0
+fi
+if [ "$1" = "api" ]; then
+  echo '"2030-01-01T00:00:00Z"'
+  exit 0
+fi
+exit 0
+"#,
+            log = gh_log.display(),
+        );
+        std::fs::write(&fake_gh, &script).unwrap();
+        let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_gh, perms).unwrap();
+        if let Ok(f) = std::fs::File::open(&fake_gh) {
+            let _ = f.sync_all();
+        }
+
+        let mut config = SweepRegistryConfig::new(dir.path().to_path_buf());
+        config.gh_bin = Some(fake_gh);
+        config.skip_label_flip = false;
+        let mut registry = SweepRegistry::new(config);
+        registry.set_quarantine_config(QuarantineConfig {
+            ttl: Duration::from_secs(3600),
+            ..QuarantineConfig::default()
+        });
+        registry
+            .quarantined
+            .insert(4206, Utc::now() - chrono::Duration::seconds(7200));
+        registry.insta_crash_counts.insert(4206, 3);
+
+        registry.reap_once();
+
+        assert!(
+            !registry.is_quarantined(4206),
+            "the in-memory quarantine entry must still be purged so TTL bookkeeping doesn't \
+             keep re-firing on this issue every tick"
+        );
+        assert_eq!(registry.insta_crash_count(4206), 0);
+        assert!(
+            registry.pending_quarantine_release_issues().is_empty(),
+            "a detected manual repark is not a failed release — nothing should be pending retry"
+        );
+
+        let gh_calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            !gh_calls.contains("--remove-label loom:blocked"),
+            "a later manual park must never have its loom:blocked label touched by TTL \
+             expiry; got gh invocations: {gh_calls:?}"
+        );
+    }
+
     /// A `gh` failure during release must NOT permanently strand the issue:
     /// the entry is retained in the pending-release set and retried until it
     /// succeeds (Issue #4110). Previously `expire_quarantine` dropped the
@@ -7348,17 +7485,22 @@ exit 0
     /// retry it — reproducing the exact reported end state (`quarantine
     /// clear` -> "was not quarantined", forge still `loom:blocked`).
     ///
-    /// The fake `gh` fails its first two invocations (a counter file tracks
-    /// remaining failures) — enough to survive both the `expire_quarantine`
-    /// attempt AND the same-tick `retry_pending_quarantine_releases` pass —
-    /// so the first `reap_once` tick genuinely ends with the issue still
-    /// pending, and only the second tick's retry succeeds.
+    /// The fake `gh` fails its first three invocations (a counter file
+    /// tracks remaining failures) — enough to survive the Issue #4206
+    /// manual-repark probe `expire_quarantine` now runs first, the
+    /// `expire_quarantine` release attempt itself, AND the same-tick
+    /// `retry_pending_quarantine_releases` pass — so the first `reap_once`
+    /// tick genuinely ends with the issue still pending, and only the second
+    /// tick's retry succeeds. The probe call fails open (a failed/unparsable
+    /// read is never treated as a manual repark), so it does not change the
+    /// release-retry semantics under test here — it just adds one more `gh`
+    /// invocation ahead of the real release attempts.
     #[test]
     fn quarantine_release_retries_after_gh_failure_then_succeeds() {
         let dir = tempdir().unwrap();
         let gh_log = dir.path().join("gh-invocations.log");
         let fail_counter = dir.path().join("fails-remaining");
-        std::fs::write(&fail_counter, "2").unwrap();
+        std::fs::write(&fail_counter, "3").unwrap();
         let fake_gh = dir.path().join("fake-gh.sh");
         let script = format!(
             "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"{log}\"\ncount=$(cat \"{counter}\" \
@@ -7797,6 +7939,57 @@ exit 0
         );
     }
 
+    /// Issue #4206 (Option 2): the crash-path label restore must NEVER add
+    /// `loom:issue` while the issue currently carries `loom:blocked` on the
+    /// forge — that would produce the illegal `loom:blocked` + `loom:issue`
+    /// combo, silently overriding an operator's deliberate park. The stale
+    /// `loom:building` claim from the now-dead sweep is still cleared.
+    #[test]
+    fn restore_label_to_ready_does_not_add_loom_issue_when_blocked() {
+        let dir = tempdir().unwrap();
+        let gh_log = dir.path().join("gh-invocations.log");
+        let fake_gh = dir.path().join("fake-gh.sh");
+        // `gh issue view <n> --json labels --jq '...'` (the pre-check probe)
+        // reports the issue as currently `loom:blocked`; any `gh issue edit`
+        // call is recorded and always succeeds.
+        let script = format!(
+            r#"#!/usr/bin/env bash
+printf '%s\n' "$*" >> "{log}"
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  echo "true"
+  exit 0
+fi
+exit 0
+"#,
+            log = gh_log.display(),
+        );
+        std::fs::write(&fake_gh, &script).unwrap();
+        let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_gh, perms).unwrap();
+        if let Ok(f) = std::fs::File::open(&fake_gh) {
+            let _ = f.sync_all();
+        }
+
+        let mut config = SweepRegistryConfig::new(dir.path().to_path_buf());
+        config.gh_bin = Some(fake_gh);
+        config.skip_label_flip = false; // exercise the real restore path
+        let registry = SweepRegistry::new(config);
+
+        registry.restore_label_to_ready(4206).unwrap();
+
+        let gh_calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            gh_calls.contains("issue edit 4206 --remove-label loom:building"),
+            "expected the stale loom:building claim to still be removed; got: {gh_calls:?}"
+        );
+        assert!(
+            !gh_calls.contains("--add-label loom:issue"),
+            "must NOT re-add loom:issue while loom:blocked is present (illegal combo); got: \
+             {gh_calls:?}"
+        );
+    }
+
     /// Issue #3827: a cancelled daemon-owned Issue sweep that never opened a
     /// PR must have its pre-dispatch loom:building claim restored to loom:issue
     /// by `finish_cancel` — mirroring the reaper's clean-exit recovery (#3823b).
@@ -7913,8 +8106,9 @@ exit 0
         let cwds: Vec<_> = recorded.lines().filter(|l| !l.is_empty()).collect();
         assert_eq!(
             cwds.len(),
-            2,
-            "expected both flip + restore to invoke gh once each; got cwds: {cwds:?}"
+            3,
+            "expected the flip (1 call) + restore (Issue #4206's pre-check `loom:blocked` \
+             probe, then the edit — 2 calls) to invoke gh three times total; got cwds: {cwds:?}"
         );
         for cwd in &cwds {
             let got = std::fs::canonicalize(cwd).unwrap();


### PR DESCRIPTION
Closes #4206

## Summary

Two independent daemon automation paths could override a deliberate operator `loom:blocked` park, causing an hourly crash-loop on previously-quarantined issues:

1. **Crash-path label restore** (`SweepRegistry::restore_label_to_ready`, `loom-daemon/src/sweep_registry.rs`) flipped `loom:building` -> `loom:issue` on a dead sweep without checking whether `loom:blocked` was already present — producing the illegal `loom:blocked` + `loom:issue` combo. It now re-reads the issue's current labels first (reusing the existing `issue_has_blocked_label` probe) and, when `loom:blocked` is present, only removes the stale `loom:building` claim without re-adding `loom:issue`.

2. **Quarantine release** (TTL expiry and startup reconciliation, `loom-daemon/src/quarantine_reconciliation.rs`) previously treated ANY daemon quarantine-marker comment on the thread as proof the current `loom:blocked` label was daemon-owned. Since that marker comment is permanent, every LATER manual park an operator applied to a previously-quarantined issue was misclassified as daemon-owned and auto-released back to `loom:issue`. `decide()` now additionally compares two timestamps when both are resolvable: the most recent `labeled loom:blocked` timeline event vs. the most recent quarantine-marker comment. A labeling event meaningfully newer (> `RECENCY_TOLERANCE_SECS` = 5s) than the comment is recognized as an independent, later manual park and is never released. TTL expiry still purges the in-memory quarantine entry in this case (so it stops occupying dispatch bookkeeping and re-firing every tick), but leaves the forge label completely untouched.

Both new checks are fail-open on any unresolvable/partial `gh` read (timeout, missing timeline data, etc.), preserving the pre-existing recovery behavior when the new recency signal can't be obtained — a forge hiccup can never permanently strand a genuine daemon quarantine.

## Implementation notes

- `sweep_registry::{output_with_timeout, reap_gh_timeout}` bumped to `pub(crate)` so the new TTL-path probe (`quarantine_reconciliation::forge::probe_manual_repark`) can share the same bounded-`gh`-call machinery as the rest of the reaper path (Issue #3973 convention).
- The timeline recency fetch (`gh api repos/{owner}/{repo}/issues/<n>/timeline --jq ...`) is only attempted for candidates that already have a quarantine-marker comment — an issue with no marker comment is `Keep` unconditionally and never needs the extra round-trip.

## Test plan

All automated (per the issue's test plan):
- `decide_keeps_manual_repark_long_after_daemon_quarantine_comment` — the load-bearing regression case: an old marker comment + a much more recent `labeled loom:blocked` event ⇒ `Keep`.
- `decide_releases_when_labeled_event_contemporaneous_with_marker_comment` — the normal apply-quarantine sequence (label then comment) ⇒ `Release`.
- `decide_releases_on_missing_timeline_signal_with_marker_comment_present` — fallback to pre-#4206 behavior when the recency signal is unavailable.
- `decide_keeps_manual_block_with_no_quarantine_comment` (pre-existing) — still passes unchanged.
- `sweep_registry::tests::quarantine_ttl_expiry_never_releases_a_later_manual_repark` — end-to-end: TTL expiry purges the in-memory entry but never touches the forge label when a manual repark is detected.
- `sweep_registry::tests::restore_label_to_ready_does_not_add_loom_issue_when_blocked` — the crash-restore path clears `loom:building` but does not re-add `loom:issue` when `loom:blocked` is present.
- Updated 3 pre-existing tests (`label_flips_run_in_registry_workspace_root`'s gh-call count, `quarantine_release_retries_after_gh_failure_then_succeeds`'s fail-counter budget) to account for the new probe call the fix adds; both continue asserting the same underlying behavior.

Full suite: `cargo build --lib`, `cargo test --lib` (1405 passed), `cargo clippy --lib --all-targets -- -D warnings` (clean), `cargo fmt --check` (clean) — all green in `loom-daemon/`.