### PR TITLE
feat(ci): add fork-drift monitoring workflow + harvest guide

### DIFF
--- a/.github/workflows/fork-drift.yml
+++ b/.github/workflows/fork-drift.yml
@@ -1,0 +1,143 @@
+name: Fork Drift Monitor
+
+# Daily check comparing each tracked fork's `main` against this repo's `main`
+# (ahead/behind commit counts), reported from upstream's perspective. On
+# detecting fork-ahead commits (harvestable work not yet landed here), opens
+# (or updates) a single deduplicated `loom:operator-only` issue per fork
+# pointing at the harvest procedure in docs/guides/fork-drift.md.
+#
+# This repo IS the upstream -- gpeyton/loom (tracked in #4165) diverged by
+# 115 commits before anyone noticed, forcing a large one-shot harvest
+# triage (#4190-#4200). This workflow closes that gap with a recurring,
+# cheap (pure git + gh, no Claude tokens, no extra secrets) drift signal so
+# future divergence is caught incrementally instead of discovered cold.
+#
+# Direction note: this is the reverse of the fork's own upstream-drift
+# workflow (gpeyton/loom#45, commit 3c80bec9), which watches *us* from the
+# fork's side. Adapting that workflow here means swapping every
+# ahead/behind arrow: "fork-ahead" (commits on fork/main not in our main) is
+# the harvestable-work signal that opens an issue; "fork-behind" (our
+# commits the fork hasn't synced) is reported only as divergence-risk
+# context in the job summary -- syncing that direction is the fork's own
+# workflow's job, not ours. See ADR-0012 for the fork-collaboration model
+# this workflow supports (PRs from the fork onto runtime-neutral surfaces;
+# everything else gets triaged into per-commit harvest issues here).
+#
+# The fork's workflow also runs `npm run test:codex` (a parity suite that
+# does not exist in this repo's package.json) alongside the drift check.
+# That step and its continue-on-error/final-fail-step machinery are dropped
+# entirely here -- drift observation needs no test leg.
+#
+# Disabled by default (cron commented out) -- matches the existing
+# "don't burn Actions minutes without an operator opt-in" convention used by
+# the .github/workflows/loom-*.yml support-role workflows. workflow_dispatch
+# is always available for manual smoke testing.
+
+on:
+  # schedule:
+  #   # Uncomment to enable daily drift checks. Pick a low-traffic UTC hour.
+  #   - cron: "23 6 * * *"
+  workflow_dispatch:  # Allow manual runs for smoke testing.
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  # Tracked forks to compare against, one per line ("owner/repo"). Seeded
+  # with the one known active fork from #4165. mattcproctor/loom is a known
+  # second fork -- uncomment to track it too once it warrants recurring
+  # drift observation.
+  TRACKED_FORKS: |
+    gpeyton/loom
+    # mattcproctor/loom
+
+jobs:
+  check-drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Measure and report fork drift
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          summary="## Fork Drift Report"$'\n\n'
+          summary+="| Fork | Fork-ahead (harvestable) | Fork-behind (sync risk) |"$'\n'
+          summary+="|------|---------------------------|--------------------------|"$'\n'
+
+          # Read the non-comment, non-blank lines of TRACKED_FORKS into an array.
+          forks=()
+          while IFS= read -r line; do
+            line="${line%%#*}"                # strip trailing comments
+            line="$(echo -n "$line" | xargs)"  # trim whitespace
+            [[ -n "$line" ]] && forks+=("$line")
+          done <<< "${TRACKED_FORKS}"
+
+          if [[ ${#forks[@]} -eq 0 ]]; then
+            echo "No tracked forks configured; nothing to check." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          for fork in "${forks[@]}"; do
+            remote_name="fork-$(echo "$fork" | tr '/' '-')"
+
+            echo "::group::Checking ${fork}"
+
+            # Fail closed with a clear error if the fork repo is unreachable,
+            # rather than silently reporting zero drift.
+            if ! git remote add "$remote_name" "https://github.com/${fork}.git" 2>/dev/null; then
+              git remote set-url "$remote_name" "https://github.com/${fork}.git"
+            fi
+
+            if ! git fetch --quiet "$remote_name" main; then
+              echo "::endgroup::"
+              echo "::error::Failed to fetch ${fork}:main -- fork repo unreachable or renamed default branch. Skipping drift report for this fork rather than filing a bogus one." >&2
+              summary+="| \`${fork}\` | **fetch failed** | **fetch failed** |"$'\n'
+              continue
+            fi
+
+            fork_ahead="$(git rev-list --count "main..${remote_name}/main")"
+            fork_behind="$(git rev-list --count "${remote_name}/main..main")"
+            echo "::endgroup::"
+
+            summary+="| \`${fork}\` | ${fork_ahead} commit(s) | ${fork_behind} commit(s) |"$'\n'
+
+            if [[ "$fork_ahead" == "0" ]]; then
+              continue
+            fi
+
+            title="chore: review ${fork} fork drift"
+            sync_doc_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/main/docs/guides/fork-drift.md"
+
+            existing_number="$(gh issue list --state open --search "\"$title\" in:title" \
+              --json number,title --jq ".[] | select(.title == \"$title\") | .number" | head -1)"
+
+            body=$(cat <<EOF
+          Fork drift check found **${fork_ahead}** commit(s) on \`${fork}:main\` not yet harvested into this repo (upstream). This repo is currently **${fork_behind}** commit(s) ahead of what \`${fork}\` has synced from us.
+
+          Follow [\`docs/guides/fork-drift.md\`](${sync_doc_url}) to fetch the fork, review \`main..${remote_name}/main\`, and either file per-commit/per-bucket harvest issues at \`loom:triage\`, or (for runtime-neutral surfaces) invite a PR from the fork per ADR-0012.
+
+          _Last checked: $(date -u +"%Y-%m-%dT%H:%M:%SZ") (workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})_
+          EOF
+            )
+
+            if [[ -n "$existing_number" ]]; then
+              gh issue comment "$existing_number" --body "$body"
+              echo "Updated existing fork-drift issue #$existing_number for ${fork}"
+            else
+              label_args=()
+              if gh label list --limit 200 --json name --jq '.[].name' | grep -Fxq 'loom:operator-only'; then
+                label_args=(--label "loom:operator-only")
+              fi
+              gh issue create --title "$title" "${label_args[@]}" --body "$body"
+            fi
+          done
+
+          echo "$summary" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/guides/fork-drift.md
+++ b/docs/guides/fork-drift.md
@@ -1,0 +1,139 @@
+# Fork Drift Guide
+
+This repository (`rjwalters/loom`) is the upstream that other repos fork —
+most notably [`gpeyton/loom`](https://github.com/gpeyton/loom), which diverged
+by 115 commits before anyone noticed (**#4165**), forcing a large one-shot
+harvest triage (**#4190**–**#4200**). ADR-0012
+(`docs/adr/0012-runtime-adapter-contract.md`) commits us to ongoing
+collaboration with that fork — and likely future ones, e.g.
+`mattcproctor/loom`, the origin of the fork's own port of this workflow — so
+divergence will keep accruing. This guide explains the automated
+drift-monitoring workflow and the manual procedure for harvesting fork-only
+work back into this repo.
+
+## The drift-monitoring workflow
+
+`.github/workflows/fork-drift.yml` runs a daily check (disabled by default —
+see below) that, for each tracked fork:
+
+1. Fetches the fork's `main` branch and computes commit counts in both
+   directions (`git rev-list --count`):
+   - **fork-ahead** (`main..fork/main`) — fork-only commits not yet in this
+     repo. This is the **harvestable work** signal.
+   - **fork-behind** (`fork/main..main`) — commits this repo has that the
+     fork hasn't synced. Reported as divergence-risk context only; syncing
+     that direction is the *fork's own* drift workflow's job, not ours.
+2. Writes both counts, per tracked fork, to the GitHub Actions job summary
+   (`$GITHUB_STEP_SUMMARY`) for every run, whether or not drift was detected.
+3. If a fork is ahead (fork-ahead > 0), opens **one** deduplicated
+   operator-facing issue titled `chore: review <fork> fork drift`. If that
+   issue is already open, the workflow adds a comment with refreshed counts
+   instead of opening a duplicate — re-running the workflow while drift
+   persists never spams new issues, it just updates the existing one.
+4. If a tracked fork is unreachable (renamed, deleted, network failure), the
+   step fails loudly for that fork with a clear `::error::` annotation rather
+   than silently reporting zero drift or filing a bogus report.
+
+### Tracked forks
+
+The `TRACKED_FORKS` env var in the workflow is a newline-delimited list of
+`owner/repo` entries. It is currently seeded with `gpeyton/loom` only.
+`mattcproctor/loom` is a known second fork, listed commented-out in the
+workflow as an example — uncomment it there if it starts to warrant recurring
+drift observation.
+
+### Enabling the schedule
+
+Like the other `.github/workflows/loom-*.yml` support-role workflows, the
+daily cron trigger ships **commented out** so Actions minutes aren't burned
+without an explicit opt-in. To enable it:
+
+1. Open `.github/workflows/fork-drift.yml` and uncomment the `schedule:` /
+   `- cron:` lines.
+2. Commit the change.
+
+No additional secrets are required — the workflow uses the default
+`GITHUB_TOKEN` (`issues: write`, `contents: read`), no `CLAUDE_API_KEY`.
+
+### Manual smoke test
+
+Trigger a one-off run at any time via the Actions UI ("Run workflow" on the
+"Fork Drift Monitor" workflow) or:
+
+```bash
+gh workflow run fork-drift.yml
+```
+
+This is safe to run repeatedly — the dedup logic (exact title match, not
+substring) means a second run while drift is still present updates the
+existing issue rather than creating a new one.
+
+## Interpreting the report
+
+When the workflow opens (or updates) a `chore: review <fork> fork drift`
+issue, the body/comment reports:
+
+- **Fork-ahead** — how many fork-only commits are not yet harvested into this
+  repo. This is the number to act on.
+- **Fork-behind** — how many commits this repo has that the fork hasn't
+  synced (context only; not actionable from this side).
+
+The issue is labeled `loom:operator-only` when that label exists on the repo
+(see `.github/labels.yml`: "Requires human action outside automation") —
+deciding *what* to harvest and *how* (cherry-pick vs. invite a fork PR) is a
+human/triage call, and the label keeps this recurring report out of the
+autonomous work-finder's queue.
+
+## Harvest procedure
+
+1. **Fetch the fork:**
+   ```bash
+   git remote add fork-gpeyton-loom https://github.com/gpeyton/loom.git 2>/dev/null || \
+     git remote set-url fork-gpeyton-loom https://github.com/gpeyton/loom.git
+   git fetch fork-gpeyton-loom main
+   ```
+
+2. **Review the diff** before triaging anything:
+   ```bash
+   git log --oneline main..fork-gpeyton-loom/main   # fork-only commits
+   git show <sha>                                   # inspect a specific commit
+   ```
+
+3. **Triage each commit or logical bucket** into one of two paths, following
+   the pattern used by the original #4165 triage (its output was the
+   #4190–#4200 sibling harvest issues):
+   - **Cherry-pick candidate**: file a `loom:triage` issue describing the
+     commit(s), the adaptation needed (if any — direction reversals, this
+     repo's naming/labels, etc.), and a link to the source commit. Let the
+     issue lifecycle (`loom:triage` → Curator → `loom:issue` → Builder) pick
+     it up normally.
+   - **Runtime-neutral surface**: per ADR-0012, prefer inviting a PR *from*
+     the fork rather than cherry-picking — comment on the dedup issue (or a
+     new issue) asking the fork maintainer to open the PR upstream. This
+     preserves attribution and reduces re-divergence for shared-contract work
+     (spawn dispatcher, error-classification tables, runtime adapters, etc.).
+   - It is also fine to **explicitly decline** a commit (fork-specific
+     design decision that doesn't apply upstream) — note the reasoning in a
+     comment rather than leaving it silently unaddressed.
+
+4. **Close the dedup issue** with a comment once the fork-ahead drift for
+   that fork has been fully triaged (harvested via issues/PRs, or explicitly
+   declined). The next drift check will reopen a fresh dedup issue if new
+   fork-ahead commits accumulate afterward.
+
+## See also
+
+- `.github/workflows/fork-drift.yml` — the workflow itself
+- **#4165** — the fork-divergence triage this workflow follows up on
+  (closed; this workflow is its drift-containment follow-up)
+- ADR-0012 (`docs/adr/0012-runtime-adapter-contract.md`) — the fork
+  collaboration model; scopes the PR-over-cherry-pick rule to runtime-neutral
+  work
+- **#4190**–**#4200** — sibling harvest issues from the #4165 triage; the
+  pattern step 3 above follows
+- Fork PR `gpeyton/loom#45` / commit `3c80bec9` — source material this
+  workflow and guide were adapted from (direction reversed: that workflow
+  watches upstream from the fork's side; this one watches forks from
+  upstream's side)
+- `docs/guides/development.md` — general contribution setup
+- `docs/guides/testing.md` — running the full test matrix


### PR DESCRIPTION
## Summary

Harvests gpeyton/loom#45 (commit `3c80bec9`, "feat: add upstream drift monitoring workflow and sync guide") with the comparison direction reversed — this repo is the upstream, so instead of watching upstream from the fork's side, this workflow watches tracked forks from upstream's side.

- `.github/workflows/fork-drift.yml` (new): daily check (disabled by default, `workflow_dispatch`-triggerable) that, for each tracked fork (seeded with `gpeyton/loom`; `mattcproctor/loom` listed commented-out as a known second fork):
  - computes **fork-ahead** (`main..fork/main`, harvestable work — triggers the report) and **fork-behind** (`fork/main..main`, divergence-risk context only) commit counts
  - writes a job-summary table for every run
  - opens/updates one deduplicated `loom:operator-only` issue per fork (exact-title dedup) only when fork-ahead > 0
  - fails loudly per-fork if the fork repo is unreachable, rather than filing a bogus zero-drift report
- `docs/guides/fork-drift.md` (new): explains the workflow, how to enable the schedule, how to interpret the report, and the harvest procedure (triage into `loom:triage` issues per the #4190-#4200 pattern, or invite a fork PR per ADR-0012 for runtime-neutral surfaces).

### Design decisions (per curated scope)
- Direction reversed throughout: fork-ahead (not upstream-behind) is the actionable signal.
- Dropped the fork's `npm run test:codex` parity step entirely — that script does not exist in this repo's `package.json` (verified). No replacement test leg; drift observation needs none.
- Dedup issue title: `chore: review <fork> fork drift`, labeled `loom:operator-only` (existing label, none created).
- Schedule ships commented out; `workflow_dispatch` always available. Permissions are exactly `contents: read` + `issues: write`, no new secrets.
- Guide named `docs/guides/fork-drift.md` (not `upstream-sync.md`) since we are the upstream.
- Both new files cross-reference each other, ADR-0012, and #4165.

## Test plan

- [x] Extracted the embedded bash step from the workflow YAML and ran `bash -n` + `shellcheck --severity=warning` — clean (no `actionlint` binary available in this environment).
- [x] Verified `test:codex` does not exist anywhere in `package.json` (grep confirms).
- [x] Ran the fork-list parsing logic (comment-stripping + trim) standalone against the real `TRACKED_FORKS` env value — correctly yields only `gpeyton/loom`, excludes the commented `mattcproctor/loom` example.
- [x] Ran the real `git rev-list --count` commands against a live fetch of `gpeyton/loom:main` from this worktree: fork-ahead=119, fork-behind=38 — confirms the ahead/behind logic and direction produce sensible, real numbers today.
- [x] No existing workflow files were modified; `git status` confirms only the two new files are added.
- [ ] Not run live via `gh workflow run fork-drift.yml` (not required per issue's test plan — YAML syntax + logic soundness is the bar for this PR).

Closes #4191