### PR TITLE
fix(hooks): migrate cold-path guard config readers to config-resolver (Option A)

### DIFF
--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -223,6 +223,28 @@ fi
 # commands (each entry is a full-generality bypass for that command word).
 # =============================================================================
 
+# CARVE-OUT (#4063): the three fast-path readers below — fastpath_config_file,
+# fastpath_enabled, fastpath_extra_admits — are deliberately NOT migrated to the
+# shared config-resolver.sh (loom_config_get / loom_resolve_config) that the
+# cold-path toggles use. This is intentional and preserves issue #3687's fork
+# budget:
+#   * This block can `exit 0` (silent allow) BEFORE REPO_ROOT is resolved — the
+#     `git -C "$CWD" rev-parse --show-toplevel` fork lives strictly below the
+#     fast-path dispatch. loom_resolve_config REQUIRES a repo_root as its first
+#     argument, so routing these through it would force hoisting that git
+#     rev-parse above the fast-path exit, directly regressing #3687 (which
+#     removed it from the pre-admission path).
+#   * fastpath_config_file is a fork-free bash-builtin upward directory walk;
+#     fastpath_enabled / fastpath_extra_admits each cost exactly one CACHED jq.
+#     loom_config_get is uncached and forks jq once per existing tier file plus a
+#     merge (~3 forks today, more as Epic #3835 lands upper tiers) on EVERY call —
+#     a 3x+ regression on a hook that fires before every Bash tool call. Caching
+#     the merge (Option B) still needs a repo_root, and teaching the resolver a
+#     fork-free upward-walk root discovery (Option C) would break the documented
+#     three-language (Rust/Python/Bash) conformance-fixture contract in
+#     config-resolver.sh's header. So the fast path keeps its direct single-jq
+#     read of the nearest .loom/config.json. See #4063 for the full analysis.
+#
 # Locate the nearest .loom/config.json by walking up from CWD, fork-free (no
 # git rev-parse). Cached. Best-effort: empty when none is found.
 _FASTPATH_CFG_FILE=""
@@ -393,6 +415,25 @@ elif [[ -n "$CWD" ]]; then
     log_hook_error "cwd does not exist: $CWD — skipping repo root resolution"
 fi
 
+# Shared config-tier resolver (#4063). Source defaults/scripts/lib/config-resolver.sh
+# — deliberately sourced HERE, strictly below the #3687 fast-path dispatch and
+# REPO_ROOT resolution above, so a fast-pathed command pays ZERO added cost (not
+# even the `[[ -f ]]` stat below) — this is the cold path only. At runtime
+# SCRIPT_DIR is the installed hook dir (.loom/hooks/), and .loom/scripts is a
+# symlink to defaults/scripts, so ../scripts/lib resolves; in the test harness
+# SCRIPT_DIR is defaults/hooks/ and the sibling path resolves directly. The
+# COLD-PATH toggle readers below (sql/cloud/reversibleGh/decisionLog/rmScope/
+# forceScope + worktree.root) call loom_config_get through this so a single code
+# path reads the full tier chain (legacy .loom/config.json plus the #4039
+# project/local tiers) and stays byte-for-byte in lockstep with loom-daemon and
+# loom_tools. Best-effort: a missing/unsourceable lib leaves loom_config_get
+# undefined, and each reader's `|| <default>` fallback then preserves that
+# guard's safe default, so the guard never breaks.
+if [[ -f "$SCRIPT_DIR/../scripts/lib/config-resolver.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/../scripts/lib/config-resolver.sh" 2>/dev/null || true
+fi
+
 # =============================================================================
 # SQL DDL/DML guard toggle — default ON.
 #
@@ -417,14 +458,18 @@ fi
 _SQL_GUARD_CACHE=""
 sql_guard_enabled() {
     if [[ -z "$_SQL_GUARD_CACHE" ]]; then
-        local enabled=true
-        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
-            # jq // is alternative-on-null, not default-on-missing, so use
-            # if/then/else to treat only an explicit `false` as disabled (a
-            # missing guards.sqlDdl key stays on). On malformed JSON jq exits
-            # non-zero and the `||` fallback restores the guard-ON default.
-            enabled=$(jq -r 'if .guards.sqlDdl == false then "false" else "true" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=true
-            [[ -n "$enabled" ]] || enabled=true
+        local enabled=true raw
+        if [[ -n "$REPO_ROOT" ]]; then
+            # Migrated to the shared tier resolver (#4063). loom_config_get
+            # collapses null and missing to the default, so we KEEP the exact
+            # polarity in bash: only an explicit boolean `false` disables — a
+            # missing/null key OR a non-boolean value (e.g. "yes") stays guard-ON,
+            # matching the old `.guards.sqlDdl == false` test. `|| raw=true` also
+            # covers config-resolver.sh failing to source (loom_config_get unset)
+            # and malformed JSON (the resolver soft-reads a bad tier as {} → the
+            # key resolves absent → default "true").
+            raw=$(loom_config_get "$REPO_ROOT" "guards.sqlDdl" "true" 2>/dev/null) || raw=true
+            [[ "$raw" == "false" ]] && enabled=false
         fi
         # Env override wins over config.
         case "${LOOM_GUARD_SQL:-}" in
@@ -460,14 +505,14 @@ sql_guard_enabled() {
 _CLOUD_GUARD_CACHE=""
 cloud_guard_enabled() {
     if [[ -z "$_CLOUD_GUARD_CACHE" ]]; then
-        local enabled=true
-        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
-            # jq // is alternative-on-null, not default-on-missing, so use
-            # if/then/else to treat only an explicit `false` as disabled (a
-            # missing guards.cloudCli key stays on). On malformed JSON jq exits
-            # non-zero and the `||` fallback restores the guard-ON default.
-            enabled=$(jq -r 'if .guards.cloudCli == false then "false" else "true" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=true
-            [[ -n "$enabled" ]] || enabled=true
+        local enabled=true raw
+        if [[ -n "$REPO_ROOT" ]]; then
+            # Migrated to the shared tier resolver (#4063), same polarity as
+            # sql_guard_enabled(): only an explicit boolean `false` disables; a
+            # missing/null key, a non-boolean value, or malformed JSON stays
+            # guard-ON via the "true" default and the `|| raw=true` fallback.
+            raw=$(loom_config_get "$REPO_ROOT" "guards.cloudCli" "true" 2>/dev/null) || raw=true
+            [[ "$raw" == "false" ]] && enabled=false
         fi
         # Env override wins over config.
         case "${LOOM_GUARD_CLOUD:-}" in
@@ -514,14 +559,14 @@ cloud_guard_enabled() {
 _REVERSIBLE_GH_GUARD_CACHE=""
 reversible_gh_guard_enabled() {
     if [[ -z "$_REVERSIBLE_GH_GUARD_CACHE" ]]; then
-        local enabled=false
-        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
-            # jq // is alternative-on-null, not default-on-missing, so use
-            # if/then/else to treat only an explicit `true` as enabled (a
-            # missing guards.reversibleGh key stays off). On malformed JSON jq
-            # exits non-zero and the `||` fallback restores the guard-OFF default.
-            enabled=$(jq -r 'if .guards.reversibleGh == true then "true" else "false" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=false
-            [[ -n "$enabled" ]] || enabled=false
+        local enabled=false raw
+        if [[ -n "$REPO_ROOT" ]]; then
+            # Migrated to the shared tier resolver (#4063). INVERSE polarity of
+            # sql/cloud: only an explicit boolean `true` enables the ask; a
+            # missing/null key, a non-boolean value, or malformed JSON stays
+            # guard-OFF via the "false" default and the `|| raw=false` fallback.
+            raw=$(loom_config_get "$REPO_ROOT" "guards.reversibleGh" "false" 2>/dev/null) || raw=false
+            [[ "$raw" == "true" ]] && enabled=true
         fi
         # Env override wins over config.
         case "${LOOM_GUARD_REVERSIBLE_GH:-}" in
@@ -563,12 +608,14 @@ reversible_gh_guard_enabled() {
 _DECISION_LOG_CACHE=""
 decision_log_enabled() {
     if [[ -z "$_DECISION_LOG_CACHE" ]]; then
-        local enabled=false
-        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
-            # Only an explicit `true` enables; a missing key or malformed JSON
-            # (jq non-zero, caught by ||) stays OFF — inverse of sql_guard_enabled().
-            enabled=$(jq -r 'if .guards.decisionLog == true then "true" else "false" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=false
-            [[ -n "$enabled" ]] || enabled=false
+        local enabled=false raw
+        if [[ -n "$REPO_ROOT" ]]; then
+            # Migrated to the shared tier resolver (#4063). INVERSE polarity like
+            # reversible_gh_guard_enabled(): only an explicit boolean `true`
+            # enables; a missing/null key, a non-boolean value, or malformed JSON
+            # stays OFF via the "false" default and the `|| raw=false` fallback.
+            raw=$(loom_config_get "$REPO_ROOT" "guards.decisionLog" "false" 2>/dev/null) || raw=false
+            [[ "$raw" == "true" ]] && enabled=true
         fi
         # Env override wins over config.
         case "${LOOM_GUARD_DECISION_LOG:-}" in
@@ -615,15 +662,18 @@ decision_log_enabled() {
 _RM_SCOPE_CACHE=""
 rm_scope_repo_enabled() {
     if [[ -z "$_RM_SCOPE_CACHE" ]]; then
-        local mode=repo
-        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
-            # Only an explicit guards.rmScope of "off" or "permissive" opts out
-            # to the legacy permissive behaviour; any other value, a missing
-            # key, or malformed JSON resolves to "repo" (the safe default — the
-            # jq non-zero exit on malformed JSON is caught by the `||`
-            # fallback, which also resolves to repo).
-            mode=$(jq -r 'if (.guards.rmScope == "off" or .guards.rmScope == "permissive") then "off" else "repo" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || mode=repo
-            [[ -n "$mode" ]] || mode=repo
+        local mode=repo raw
+        if [[ -n "$REPO_ROOT" ]]; then
+            # Migrated to the shared tier resolver (#4063). This is a string
+            # value, not a boolean, so we read the raw string and keep the
+            # branching in bash: only an explicit "off"/"permissive" opts out;
+            # a missing/null key (→ default "repo"), any other string, or
+            # malformed JSON (→ `|| raw=repo`) resolves to the safe "repo".
+            raw=$(loom_config_get "$REPO_ROOT" "guards.rmScope" "repo" 2>/dev/null) || raw=repo
+            case "$raw" in
+                off|permissive)  mode=off ;;
+                *)               mode=repo ;;
+            esac
         fi
         # Env override wins over config.
         case "${LOOM_RM_SCOPE:-}" in
@@ -648,15 +698,18 @@ resolve_worktree_root() {
         printf '%s/%s' "${LOOM_WORKTREE_ROOT%/}" "$(basename "$repo_root")"
         return 0
     fi
-    # 2. Config key .loom/config.json -> worktree.root (absolute only).
-    local config_file="$repo_root/.loom/config.json"
-    if [[ -f "$config_file" ]]; then
-        local cfg_root
-        cfg_root=$(jq -r '.worktree.root? // empty' "$config_file" 2>/dev/null) || cfg_root=""
-        if [[ -n "$cfg_root" && "$cfg_root" == /* ]]; then
-            printf '%s/%s' "${cfg_root%/}" "$(basename "$repo_root")"
-            return 0
-        fi
+    # 2. Config key worktree.root (absolute only), via the shared tier resolver
+    #    (#4063). Only the config READ is routed through loom_config_get — the
+    #    env/default precedence and the absolute-path gate stay inline so the
+    #    function keeps its self-contained fallback shape. loom_config_get's
+    #    default "" collapses a missing/null key to empty (matching the old
+    #    `.worktree.root? // empty`), and a non-absolute value fails the `== /*`
+    #    gate and falls through to the in-repo default, exactly as before.
+    local cfg_root
+    cfg_root=$(loom_config_get "$repo_root" "worktree.root" "" 2>/dev/null) || cfg_root=""
+    if [[ -n "$cfg_root" && "$cfg_root" == /* ]]; then
+        printf '%s/%s' "${cfg_root%/}" "$(basename "$repo_root")"
+        return 0
     fi
     # 3. Default — in-repo worktrees dir.
     printf '%s/.loom/worktrees' "$repo_root"
@@ -778,14 +831,19 @@ _any_managed_worktree_exists() {
 _FORCE_SCOPE_CACHE=""
 force_scope_mode() {
     if [[ -z "$_FORCE_SCOPE_CACHE" ]]; then
-        local mode=all
-        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
-            # jq // is alternative-on-null, not default-on-missing, so use an
-            # explicit if/elif/else: only "protected"/"off" opt away from the
-            # default. A missing key, any other value, or malformed JSON (jq
-            # exits non-zero, caught by ||) resolves to "all".
-            mode=$(jq -r 'if (.guards.forceScope == "protected") then "protected" elif (.guards.forceScope == "off") then "off" else "all" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || mode=all
-            [[ -n "$mode" ]] || mode=all
+        local mode=all raw
+        if [[ -n "$REPO_ROOT" ]]; then
+            # Migrated to the shared tier resolver (#4063). String value like
+            # guards.rmScope, so read the raw string and branch in bash: only
+            # "protected"/"off" opt away from the default; a missing/null key
+            # (→ default "all"), any other value, or malformed JSON (→ `|| raw=all`)
+            # resolves to "all".
+            raw=$(loom_config_get "$REPO_ROOT" "guards.forceScope" "all" 2>/dev/null) || raw=all
+            case "$raw" in
+                protected)  mode=protected ;;
+                off)        mode=off ;;
+                *)          mode=all ;;
+            esac
         fi
         # Env override wins over config.
         case "${LOOM_FORCE_SCOPE:-}" in

--- a/.loom/hooks/guard-loom-workflow.sh
+++ b/.loom/hooks/guard-loom-workflow.sh
@@ -47,6 +47,18 @@ HOOK_ERROR_LOG="${SCRIPT_DIR}/../logs/hook-errors.log"
 # decision_log_enabled() below.
 DECISION_LOG="${LOOM_GUARD_DECISION_LOG_FILE:-${SCRIPT_DIR}/../logs/guard-decisions.log}"
 
+# Shared config-tier resolver (#4063). Source defaults/scripts/lib/config-resolver.sh
+# so decision_log_enabled() below reads the full config tier chain through the
+# same code path as guard-destructive-generic.sh (kept consistent between the two
+# guards). At runtime SCRIPT_DIR is .loom/hooks/ and .loom/scripts is a symlink to
+# defaults/scripts, so ../scripts/lib resolves. Best-effort: a missing/unsourceable
+# lib leaves loom_config_get undefined and the reader's `|| raw=false` fallback
+# preserves the guard-OFF default.
+if [[ -f "$SCRIPT_DIR/../scripts/lib/config-resolver.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/../scripts/lib/config-resolver.sh" 2>/dev/null || true
+fi
+
 # Log a diagnostic error message (best-effort, never fails the script)
 log_hook_error() {
     local msg="$1"
@@ -110,12 +122,15 @@ strip_literal_text() {
 _DECISION_LOG_CACHE=""
 decision_log_enabled() {
     if [[ -z "$_DECISION_LOG_CACHE" ]]; then
-        local enabled=false
-        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
-            # Only an explicit `true` enables; a missing key or malformed JSON
-            # (jq non-zero, caught by ||) stays OFF.
-            enabled=$(jq -r 'if .guards.decisionLog == true then "true" else "false" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=false
-            [[ -n "$enabled" ]] || enabled=false
+        local enabled=false raw
+        if [[ -n "$REPO_ROOT" ]]; then
+            # Migrated to the shared tier resolver (#4063), kept consistent with
+            # guard-destructive-generic.sh's decision_log_enabled(). INVERSE
+            # polarity: only an explicit boolean `true` enables; a missing/null
+            # key, a non-boolean value, or malformed JSON stays OFF via the
+            # "false" default and the `|| raw=false` fallback.
+            raw=$(loom_config_get "$REPO_ROOT" "guards.decisionLog" "false" 2>/dev/null) || raw=false
+            [[ "$raw" == "true" ]] && enabled=true
         fi
         # Env override wins over config.
         case "${LOOM_GUARD_DECISION_LOG:-}" in

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -223,6 +223,28 @@ fi
 # commands (each entry is a full-generality bypass for that command word).
 # =============================================================================
 
+# CARVE-OUT (#4063): the three fast-path readers below — fastpath_config_file,
+# fastpath_enabled, fastpath_extra_admits — are deliberately NOT migrated to the
+# shared config-resolver.sh (loom_config_get / loom_resolve_config) that the
+# cold-path toggles use. This is intentional and preserves issue #3687's fork
+# budget:
+#   * This block can `exit 0` (silent allow) BEFORE REPO_ROOT is resolved — the
+#     `git -C "$CWD" rev-parse --show-toplevel` fork lives strictly below the
+#     fast-path dispatch. loom_resolve_config REQUIRES a repo_root as its first
+#     argument, so routing these through it would force hoisting that git
+#     rev-parse above the fast-path exit, directly regressing #3687 (which
+#     removed it from the pre-admission path).
+#   * fastpath_config_file is a fork-free bash-builtin upward directory walk;
+#     fastpath_enabled / fastpath_extra_admits each cost exactly one CACHED jq.
+#     loom_config_get is uncached and forks jq once per existing tier file plus a
+#     merge (~3 forks today, more as Epic #3835 lands upper tiers) on EVERY call —
+#     a 3x+ regression on a hook that fires before every Bash tool call. Caching
+#     the merge (Option B) still needs a repo_root, and teaching the resolver a
+#     fork-free upward-walk root discovery (Option C) would break the documented
+#     three-language (Rust/Python/Bash) conformance-fixture contract in
+#     config-resolver.sh's header. So the fast path keeps its direct single-jq
+#     read of the nearest .loom/config.json. See #4063 for the full analysis.
+#
 # Locate the nearest .loom/config.json by walking up from CWD, fork-free (no
 # git rev-parse). Cached. Best-effort: empty when none is found.
 _FASTPATH_CFG_FILE=""
@@ -393,6 +415,25 @@ elif [[ -n "$CWD" ]]; then
     log_hook_error "cwd does not exist: $CWD — skipping repo root resolution"
 fi
 
+# Shared config-tier resolver (#4063). Source defaults/scripts/lib/config-resolver.sh
+# — deliberately sourced HERE, strictly below the #3687 fast-path dispatch and
+# REPO_ROOT resolution above, so a fast-pathed command pays ZERO added cost (not
+# even the `[[ -f ]]` stat below) — this is the cold path only. At runtime
+# SCRIPT_DIR is the installed hook dir (.loom/hooks/), and .loom/scripts is a
+# symlink to defaults/scripts, so ../scripts/lib resolves; in the test harness
+# SCRIPT_DIR is defaults/hooks/ and the sibling path resolves directly. The
+# COLD-PATH toggle readers below (sql/cloud/reversibleGh/decisionLog/rmScope/
+# forceScope + worktree.root) call loom_config_get through this so a single code
+# path reads the full tier chain (legacy .loom/config.json plus the #4039
+# project/local tiers) and stays byte-for-byte in lockstep with loom-daemon and
+# loom_tools. Best-effort: a missing/unsourceable lib leaves loom_config_get
+# undefined, and each reader's `|| <default>` fallback then preserves that
+# guard's safe default, so the guard never breaks.
+if [[ -f "$SCRIPT_DIR/../scripts/lib/config-resolver.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/../scripts/lib/config-resolver.sh" 2>/dev/null || true
+fi
+
 # =============================================================================
 # SQL DDL/DML guard toggle — default ON.
 #
@@ -417,14 +458,18 @@ fi
 _SQL_GUARD_CACHE=""
 sql_guard_enabled() {
     if [[ -z "$_SQL_GUARD_CACHE" ]]; then
-        local enabled=true
-        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
-            # jq // is alternative-on-null, not default-on-missing, so use
-            # if/then/else to treat only an explicit `false` as disabled (a
-            # missing guards.sqlDdl key stays on). On malformed JSON jq exits
-            # non-zero and the `||` fallback restores the guard-ON default.
-            enabled=$(jq -r 'if .guards.sqlDdl == false then "false" else "true" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=true
-            [[ -n "$enabled" ]] || enabled=true
+        local enabled=true raw
+        if [[ -n "$REPO_ROOT" ]]; then
+            # Migrated to the shared tier resolver (#4063). loom_config_get
+            # collapses null and missing to the default, so we KEEP the exact
+            # polarity in bash: only an explicit boolean `false` disables — a
+            # missing/null key OR a non-boolean value (e.g. "yes") stays guard-ON,
+            # matching the old `.guards.sqlDdl == false` test. `|| raw=true` also
+            # covers config-resolver.sh failing to source (loom_config_get unset)
+            # and malformed JSON (the resolver soft-reads a bad tier as {} → the
+            # key resolves absent → default "true").
+            raw=$(loom_config_get "$REPO_ROOT" "guards.sqlDdl" "true" 2>/dev/null) || raw=true
+            [[ "$raw" == "false" ]] && enabled=false
         fi
         # Env override wins over config.
         case "${LOOM_GUARD_SQL:-}" in
@@ -460,14 +505,14 @@ sql_guard_enabled() {
 _CLOUD_GUARD_CACHE=""
 cloud_guard_enabled() {
     if [[ -z "$_CLOUD_GUARD_CACHE" ]]; then
-        local enabled=true
-        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
-            # jq // is alternative-on-null, not default-on-missing, so use
-            # if/then/else to treat only an explicit `false` as disabled (a
-            # missing guards.cloudCli key stays on). On malformed JSON jq exits
-            # non-zero and the `||` fallback restores the guard-ON default.
-            enabled=$(jq -r 'if .guards.cloudCli == false then "false" else "true" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=true
-            [[ -n "$enabled" ]] || enabled=true
+        local enabled=true raw
+        if [[ -n "$REPO_ROOT" ]]; then
+            # Migrated to the shared tier resolver (#4063), same polarity as
+            # sql_guard_enabled(): only an explicit boolean `false` disables; a
+            # missing/null key, a non-boolean value, or malformed JSON stays
+            # guard-ON via the "true" default and the `|| raw=true` fallback.
+            raw=$(loom_config_get "$REPO_ROOT" "guards.cloudCli" "true" 2>/dev/null) || raw=true
+            [[ "$raw" == "false" ]] && enabled=false
         fi
         # Env override wins over config.
         case "${LOOM_GUARD_CLOUD:-}" in
@@ -514,14 +559,14 @@ cloud_guard_enabled() {
 _REVERSIBLE_GH_GUARD_CACHE=""
 reversible_gh_guard_enabled() {
     if [[ -z "$_REVERSIBLE_GH_GUARD_CACHE" ]]; then
-        local enabled=false
-        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
-            # jq // is alternative-on-null, not default-on-missing, so use
-            # if/then/else to treat only an explicit `true` as enabled (a
-            # missing guards.reversibleGh key stays off). On malformed JSON jq
-            # exits non-zero and the `||` fallback restores the guard-OFF default.
-            enabled=$(jq -r 'if .guards.reversibleGh == true then "true" else "false" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=false
-            [[ -n "$enabled" ]] || enabled=false
+        local enabled=false raw
+        if [[ -n "$REPO_ROOT" ]]; then
+            # Migrated to the shared tier resolver (#4063). INVERSE polarity of
+            # sql/cloud: only an explicit boolean `true` enables the ask; a
+            # missing/null key, a non-boolean value, or malformed JSON stays
+            # guard-OFF via the "false" default and the `|| raw=false` fallback.
+            raw=$(loom_config_get "$REPO_ROOT" "guards.reversibleGh" "false" 2>/dev/null) || raw=false
+            [[ "$raw" == "true" ]] && enabled=true
         fi
         # Env override wins over config.
         case "${LOOM_GUARD_REVERSIBLE_GH:-}" in
@@ -563,12 +608,14 @@ reversible_gh_guard_enabled() {
 _DECISION_LOG_CACHE=""
 decision_log_enabled() {
     if [[ -z "$_DECISION_LOG_CACHE" ]]; then
-        local enabled=false
-        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
-            # Only an explicit `true` enables; a missing key or malformed JSON
-            # (jq non-zero, caught by ||) stays OFF — inverse of sql_guard_enabled().
-            enabled=$(jq -r 'if .guards.decisionLog == true then "true" else "false" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=false
-            [[ -n "$enabled" ]] || enabled=false
+        local enabled=false raw
+        if [[ -n "$REPO_ROOT" ]]; then
+            # Migrated to the shared tier resolver (#4063). INVERSE polarity like
+            # reversible_gh_guard_enabled(): only an explicit boolean `true`
+            # enables; a missing/null key, a non-boolean value, or malformed JSON
+            # stays OFF via the "false" default and the `|| raw=false` fallback.
+            raw=$(loom_config_get "$REPO_ROOT" "guards.decisionLog" "false" 2>/dev/null) || raw=false
+            [[ "$raw" == "true" ]] && enabled=true
         fi
         # Env override wins over config.
         case "${LOOM_GUARD_DECISION_LOG:-}" in
@@ -615,15 +662,18 @@ decision_log_enabled() {
 _RM_SCOPE_CACHE=""
 rm_scope_repo_enabled() {
     if [[ -z "$_RM_SCOPE_CACHE" ]]; then
-        local mode=repo
-        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
-            # Only an explicit guards.rmScope of "off" or "permissive" opts out
-            # to the legacy permissive behaviour; any other value, a missing
-            # key, or malformed JSON resolves to "repo" (the safe default — the
-            # jq non-zero exit on malformed JSON is caught by the `||`
-            # fallback, which also resolves to repo).
-            mode=$(jq -r 'if (.guards.rmScope == "off" or .guards.rmScope == "permissive") then "off" else "repo" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || mode=repo
-            [[ -n "$mode" ]] || mode=repo
+        local mode=repo raw
+        if [[ -n "$REPO_ROOT" ]]; then
+            # Migrated to the shared tier resolver (#4063). This is a string
+            # value, not a boolean, so we read the raw string and keep the
+            # branching in bash: only an explicit "off"/"permissive" opts out;
+            # a missing/null key (→ default "repo"), any other string, or
+            # malformed JSON (→ `|| raw=repo`) resolves to the safe "repo".
+            raw=$(loom_config_get "$REPO_ROOT" "guards.rmScope" "repo" 2>/dev/null) || raw=repo
+            case "$raw" in
+                off|permissive)  mode=off ;;
+                *)               mode=repo ;;
+            esac
         fi
         # Env override wins over config.
         case "${LOOM_RM_SCOPE:-}" in
@@ -648,15 +698,18 @@ resolve_worktree_root() {
         printf '%s/%s' "${LOOM_WORKTREE_ROOT%/}" "$(basename "$repo_root")"
         return 0
     fi
-    # 2. Config key .loom/config.json -> worktree.root (absolute only).
-    local config_file="$repo_root/.loom/config.json"
-    if [[ -f "$config_file" ]]; then
-        local cfg_root
-        cfg_root=$(jq -r '.worktree.root? // empty' "$config_file" 2>/dev/null) || cfg_root=""
-        if [[ -n "$cfg_root" && "$cfg_root" == /* ]]; then
-            printf '%s/%s' "${cfg_root%/}" "$(basename "$repo_root")"
-            return 0
-        fi
+    # 2. Config key worktree.root (absolute only), via the shared tier resolver
+    #    (#4063). Only the config READ is routed through loom_config_get — the
+    #    env/default precedence and the absolute-path gate stay inline so the
+    #    function keeps its self-contained fallback shape. loom_config_get's
+    #    default "" collapses a missing/null key to empty (matching the old
+    #    `.worktree.root? // empty`), and a non-absolute value fails the `== /*`
+    #    gate and falls through to the in-repo default, exactly as before.
+    local cfg_root
+    cfg_root=$(loom_config_get "$repo_root" "worktree.root" "" 2>/dev/null) || cfg_root=""
+    if [[ -n "$cfg_root" && "$cfg_root" == /* ]]; then
+        printf '%s/%s' "${cfg_root%/}" "$(basename "$repo_root")"
+        return 0
     fi
     # 3. Default — in-repo worktrees dir.
     printf '%s/.loom/worktrees' "$repo_root"
@@ -778,14 +831,19 @@ _any_managed_worktree_exists() {
 _FORCE_SCOPE_CACHE=""
 force_scope_mode() {
     if [[ -z "$_FORCE_SCOPE_CACHE" ]]; then
-        local mode=all
-        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
-            # jq // is alternative-on-null, not default-on-missing, so use an
-            # explicit if/elif/else: only "protected"/"off" opt away from the
-            # default. A missing key, any other value, or malformed JSON (jq
-            # exits non-zero, caught by ||) resolves to "all".
-            mode=$(jq -r 'if (.guards.forceScope == "protected") then "protected" elif (.guards.forceScope == "off") then "off" else "all" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || mode=all
-            [[ -n "$mode" ]] || mode=all
+        local mode=all raw
+        if [[ -n "$REPO_ROOT" ]]; then
+            # Migrated to the shared tier resolver (#4063). String value like
+            # guards.rmScope, so read the raw string and branch in bash: only
+            # "protected"/"off" opt away from the default; a missing/null key
+            # (→ default "all"), any other value, or malformed JSON (→ `|| raw=all`)
+            # resolves to "all".
+            raw=$(loom_config_get "$REPO_ROOT" "guards.forceScope" "all" 2>/dev/null) || raw=all
+            case "$raw" in
+                protected)  mode=protected ;;
+                off)        mode=off ;;
+                *)          mode=all ;;
+            esac
         fi
         # Env override wins over config.
         case "${LOOM_FORCE_SCOPE:-}" in

--- a/defaults/hooks/guard-loom-workflow.sh
+++ b/defaults/hooks/guard-loom-workflow.sh
@@ -47,6 +47,18 @@ HOOK_ERROR_LOG="${SCRIPT_DIR}/../logs/hook-errors.log"
 # decision_log_enabled() below.
 DECISION_LOG="${LOOM_GUARD_DECISION_LOG_FILE:-${SCRIPT_DIR}/../logs/guard-decisions.log}"
 
+# Shared config-tier resolver (#4063). Source defaults/scripts/lib/config-resolver.sh
+# so decision_log_enabled() below reads the full config tier chain through the
+# same code path as guard-destructive-generic.sh (kept consistent between the two
+# guards). At runtime SCRIPT_DIR is .loom/hooks/ and .loom/scripts is a symlink to
+# defaults/scripts, so ../scripts/lib resolves. Best-effort: a missing/unsourceable
+# lib leaves loom_config_get undefined and the reader's `|| raw=false` fallback
+# preserves the guard-OFF default.
+if [[ -f "$SCRIPT_DIR/../scripts/lib/config-resolver.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/../scripts/lib/config-resolver.sh" 2>/dev/null || true
+fi
+
 # Log a diagnostic error message (best-effort, never fails the script)
 log_hook_error() {
     local msg="$1"
@@ -110,12 +122,15 @@ strip_literal_text() {
 _DECISION_LOG_CACHE=""
 decision_log_enabled() {
     if [[ -z "$_DECISION_LOG_CACHE" ]]; then
-        local enabled=false
-        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
-            # Only an explicit `true` enables; a missing key or malformed JSON
-            # (jq non-zero, caught by ||) stays OFF.
-            enabled=$(jq -r 'if .guards.decisionLog == true then "true" else "false" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=false
-            [[ -n "$enabled" ]] || enabled=false
+        local enabled=false raw
+        if [[ -n "$REPO_ROOT" ]]; then
+            # Migrated to the shared tier resolver (#4063), kept consistent with
+            # guard-destructive-generic.sh's decision_log_enabled(). INVERSE
+            # polarity: only an explicit boolean `true` enables; a missing/null
+            # key, a non-boolean value, or malformed JSON stays OFF via the
+            # "false" default and the `|| raw=false` fallback.
+            raw=$(loom_config_get "$REPO_ROOT" "guards.decisionLog" "false" 2>/dev/null) || raw=false
+            [[ "$raw" == "true" ]] && enabled=true
         fi
         # Env override wins over config.
         case "${LOOM_GUARD_DECISION_LOG:-}" in

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -2174,6 +2174,105 @@ rm -rf "$WT_REPO" "$WT_REPO_NOWT" "$WT_REPO_OFF" "$WT_REPO_LINKED"
 echo ""
 
 # =========================================================================
+echo -e "${YELLOW}--- Truth table: config-resolver migration polarity (#4063) ---${NC}"
+# =========================================================================
+#
+# guards.sqlDdl / cloudCli / reversibleGh / decisionLog / rmScope / forceScope
+# and worktree.root were migrated from a bespoke per-guard jq read to the
+# shared loom_config_get() (defaults/scripts/lib/config-resolver.sh). Each
+# reader keeps its EXACT prior polarity in bash rather than trusting
+# loom_config_get's null-collapses-to-default behavior blindly (see the
+# migration comment at each function). This is the truth table the migration
+# issue's acceptance criteria asked for: key absent / explicit true / explicit
+# false / explicit null / malformed JSON / non-boolean value, each verified to
+# resolve to the SAME decision as pre-migration main. Absent / true / false /
+# malformed are already covered by each guard's own section above; this
+# section adds the two previously-untested shapes — explicit `null` and a
+# non-boolean/out-of-range value — for every migrated reader.
+
+TT_NULL_REPO=$(make_sql_repo '{"guards":{"sqlDdl":null,"cloudCli":null,"reversibleGh":null,"decisionLog":null,"rmScope":null,"forceScope":null},"worktree":{"root":null}}')
+TT_NONBOOL_REPO=$(make_sql_repo '{"guards":{"sqlDdl":"yes","cloudCli":"yes","reversibleGh":"yes","decisionLog":"yes","rmScope":"banana","forceScope":"banana"},"worktree":{"root":42}}')
+
+# --- sqlDdl: default-on (true); explicit null and a non-boolean value both
+# stay ON (only an explicit boolean `false` disables). ---
+assert_deny "truth-table sqlDdl=null: DROP TABLE still denied (default true)" \
+    "mysql -e 'DROP TABLE users;'" "$TT_NULL_REPO"
+assert_deny "truth-table sqlDdl=\"yes\" (non-boolean): DROP TABLE still denied (default true)" \
+    "mysql -e 'DROP TABLE users;'" "$TT_NONBOOL_REPO"
+
+# --- cloudCli: default-on (true); explicit null and a non-boolean value both
+# still ask (only an explicit boolean `false` disables). ---
+assert_ask "truth-table cloudCli=null: aws ec2 terminate-instances still asks (default true)" \
+    "aws ec2 terminate-instances --instance-ids i-1234" "$TT_NULL_REPO"
+assert_ask "truth-table cloudCli=\"yes\" (non-boolean): aws ec2 terminate-instances still asks (default true)" \
+    "aws ec2 terminate-instances --instance-ids i-1234" "$TT_NONBOOL_REPO"
+
+# --- reversibleGh: default-off (false, INVERSE polarity); explicit null and a
+# non-boolean value both stay OFF (only an explicit boolean `true` enables). ---
+assert_allow "truth-table reversibleGh=null: gh pr close allowed (default false)" \
+    "gh pr close 42" "$TT_NULL_REPO"
+assert_allow "truth-table reversibleGh=\"yes\" (non-boolean): gh pr close allowed (default false)" \
+    "gh pr close 42" "$TT_NONBOOL_REPO"
+
+# --- rmScope: default "repo" (only "off"/"permissive" opt out); explicit null
+# and an unrecognized string both fall through to the safe "repo" default. ---
+assert_deny "truth-table rmScope=null: outside-repo path still denied (default repo)" \
+    "rm -rf /opt/some-vendor/important" "$TT_NULL_REPO"
+assert_deny "truth-table rmScope=\"banana\" (out-of-range): outside-repo path still denied (default repo)" \
+    "rm -rf /opt/some-vendor/important" "$TT_NONBOOL_REPO"
+
+# --- forceScope: default "all" (only "protected"/"off" opt out); explicit
+# null and an unrecognized string both fall through to "all" (force-push to a
+# working branch still asks). ---
+assert_ask "truth-table forceScope=null: force-push to working branch still asks (default all)" \
+    "git push --force origin feature/x" "$TT_NULL_REPO"
+assert_ask "truth-table forceScope=\"banana\" (out-of-range): force-push to working branch still asks (default all)" \
+    "git push --force origin feature/x" "$TT_NONBOOL_REPO"
+
+# --- worktree.root: explicit null and a non-string (number) value both fall
+# through to the in-repo default worktrees dir — no external root is admitted,
+# so an outside-repo rm under the would-be configured path is still denied
+# under the default rmScope=repo. ---
+assert_deny "truth-table worktree.root=null: no external root admitted, outside path denied" \
+    "rm -rf /Volumes/scratch/loom-wt/some-worktree/issue-1/foo" "$TT_NULL_REPO"
+assert_deny "truth-table worktree.root=42 (non-string): no external root admitted, outside path denied" \
+    "rm -rf /Volumes/scratch/loom-wt/some-worktree/issue-1/foo" "$TT_NONBOOL_REPO"
+
+# --- decisionLog: default-off (false, INVERSE polarity); explicit null and a
+# non-boolean value both stay OFF (only an explicit boolean `true` enables). No
+# env var is set, so the config value alone drives the decision. ---
+TT_DL_LOG="$(mktemp -u)"
+rm -f "$TT_DL_LOG"
+make_input "rm -rf /" "$TT_NULL_REPO" | \
+    env LOOM_GUARD_DECISION_LOG_FILE="$TT_DL_LOG" "$GUARD" >/dev/null 2>&1 || true
+TOTAL=$((TOTAL + 1))
+if [[ ! -f "$TT_DL_LOG" ]]; then
+    PASS=$((PASS + 1))
+    echo -e "  ${GREEN}PASS${NC}: truth-table decisionLog=null: deny writes NO decision record (default false)"
+else
+    FAIL=$((FAIL + 1))
+    echo -e "  ${RED}FAIL${NC}: truth-table decisionLog=null: deny writes NO decision record (default false)"
+    echo -e "       unexpected: $(cat "$TT_DL_LOG")"
+fi
+
+rm -f "$TT_DL_LOG"
+make_input "rm -rf /" "$TT_NONBOOL_REPO" | \
+    env LOOM_GUARD_DECISION_LOG_FILE="$TT_DL_LOG" "$GUARD" >/dev/null 2>&1 || true
+TOTAL=$((TOTAL + 1))
+if [[ ! -f "$TT_DL_LOG" ]]; then
+    PASS=$((PASS + 1))
+    echo -e "  ${GREEN}PASS${NC}: truth-table decisionLog=\"yes\" (non-boolean): deny writes NO decision record (default false)"
+else
+    FAIL=$((FAIL + 1))
+    echo -e "  ${RED}FAIL${NC}: truth-table decisionLog=\"yes\" (non-boolean): deny writes NO decision record (default false)"
+    echo -e "       unexpected: $(cat "$TT_DL_LOG")"
+fi
+
+rm -rf "$TT_NULL_REPO" "$TT_NONBOOL_REPO"
+
+echo ""
+
+# =========================================================================
 echo -e "${YELLOW}--- Performance check ---${NC}"
 # =========================================================================
 


### PR DESCRIPTION
Closes #4063

## Decision: Option A (carve out the hot path, migrate only the cold path)

Per the issue's curator-recommended and champion-approved decision, this PR
migrates the **seven cold-path** config readers in
`guard-destructive-generic.sh` — `sqlDdl`, `cloudCli`, `reversibleGh`,
`decisionLog`, `rmScope`, `forceScope`, `worktree.root` — plus the
`decisionLog` reader in `guard-loom-workflow.sh`, onto the shared
`loom_config_get()` / `loom_resolve_config()` (`defaults/scripts/lib/config-resolver.sh`,
#4039). This gives those readers the full 4-tier config chain (legacy
`.loom/config.json` + the `.loom-project`/`.loom-local` tiers) in lockstep with
loom-daemon and loom_tools, instead of a bespoke single-file `jq` read.

The **three #3687 read-only fast-path readers** — `fastpath_config_file`,
`fastpath_enabled`, `fastpath_extra_admits` — are **explicitly NOT migrated**.
They keep their fork-free / single-cached-`jq` implementation, with an
in-code `CARVE-OUT (#4063)` comment explaining why (this was already true on
main and is unchanged by this PR — only a comment was added there).

Option B (cache the merge in config-resolver.sh) doesn't solve the problem —
a cached merge still needs a `repo_root`, and the fast path deliberately
exits *before* `REPO_ROOT` is resolved (see control-flow note below). Option C
(teach the resolver a fork-free upward-walk root) would break the documented
three-language (Rust/Python/Bash) conformance-fixture contract in
`config-resolver.sh`'s header. Option A is the only one that preserves both
#3687 and the conformance guarantee.

## Where the config-resolver source line lives (and why)

`config-resolver.sh` is `source`d **strictly below** the fast-path dispatch
and the `REPO_ROOT=$(git -C "$CWD" rev-parse --show-toplevel ...)` resolution
— i.e. only on the cold path. A fast-pathed command (e.g. `git status`) never
reaches that line, so it pays **zero added cost** — not even the `[[ -f ]]`
stat that guards the `source`. This was deliberately placed there (not at the
top of the file, which an earlier draft of this change had done) specifically
so the fast path's fork/latency budget is untouched.

## Fork-count analysis (the acceptance criterion's primary evidence)

This is a static, code-verifiable claim, not a measurement subject to host
noise:

- **Before and after, the fast path costs the same 0 forks for path
  discovery** (`fastpath_config_file`'s upward bash-builtin walk) **+ 1
  cached `jq` fork** for `fastpath_enabled` — unchanged by this PR. No `git
  rev-parse` and no additional fork was introduced above the fast-path exit
  points (verified by inspection: `fastpath_builtin_admits`/`fastpath_enabled`
  calls and the `exit 0` sites are untouched; the new `source` line is now
  positioned strictly after them).
- The **cold-path** readers went from 1 fork each (bespoke `jq -r` read of
  `.loom/config.json` only) to up to 3 forks each today via
  `loom_config_get()` (1 soft-read of the legacy tier + 1 `jq -n` merge + 1
  `getpath`), rising toward more as Epic #3835 lands the upper config tiers.
  This is the accepted, scoped-in cost of the migration — these readers only
  fire on catastrophic/ask-tier commands, not on every Bash call.

## Wall-clock measurement (best-effort; host was under heavy unrelated load)

Ran the existing 100x `git status` fast-path benchmark (and an interleaved
5-round before/after comparison) against the pre-migration
`guard-destructive-generic.sh` (from `main`) and the post-migration version.
**Caveat**: this measurement was taken on a shared dev host with `uptime`
load averages of 30–40 throughout (multiple unrelated concurrent Loom sweeps
running `cargo build` in a sibling repo), so absolute numbers are noisy in
both directions; the fork-count analysis above is the load-bearing evidence.
Interleaved rounds (ms/call, `n=50` each):

| round | before (main) | after (this PR) |
|---|---|---|
| 1 | 146 | 259 |
| 2 | 176 | 155 |
| 3 | 166 | 174 |
| 4 | 307 | 318 |
| 5 | 332 | 108 |
| **mean** | **225** | **203** |

No consistent before/after direction — the two are within the same noise
band, consistent with the fork-count argument (no new forks added to the fast
path). The in-repo test suite's own 10x-iteration performance check (informational,
not gating under load) also passed the same way before and after.

## Polarity truth table

Every migrated reader kept its **exact prior bash-side polarity check**
rather than trusting `loom_config_get`'s null-collapses-to-default behavior
blindly, per the issue's polarity-trap warning:

| Reader | Default | Only this flips it |
|---|---|---|
| `sqlDdl` | ON | explicit `false` |
| `cloudCli` | ON | explicit `false` |
| `reversibleGh` | OFF (inverse) | explicit `true` |
| `decisionLog` (both guards) | OFF (inverse) | explicit `true` |
| `rmScope` | `"repo"` | `"off"`/`"permissive"` |
| `forceScope` | `"all"` | `"protected"`/`"off"` |
| `worktree.root` | in-repo default | absolute-path string |

Added a truth-table test section to `tests/hooks/test-guard-destructive.sh`
covering the two shapes not already exercised by the existing suite (explicit
`null` and a non-boolean/out-of-range value) for every migrated reader — the
existing suite already covered absent/true/false/malformed-JSON.

## Testing

All run with `LOOM_FORCE_SCOPE` and `LOOM_GUARD_DECISION_LOG` explicitly
unset — this dev sandbox has both set in its ambient shell environment
(operator-configured env overrides for this specific repo's own
self-hosting), which otherwise masks the config-driven defaults these tests
verify. Confirmed via `git stash` that these two vars caused the same
apparent "failures" on pre-migration `main` — not a regression from this PR.

- `tests/hooks/test-guard-destructive.sh`: **453/453 passed** (442 existing +
  11 new truth-table assertions)
- `tests/hooks/test-guard-loom-workflow.sh`: **27/27 passed**
- `defaults/scripts/tests/test-config-resolver.sh`: **14/14 passed**
  (unaffected — config-resolver.sh itself was not modified)
- `defaults/scripts/tests/test-guard-hook-schema.sh`: **11/11 passed**
- `./.loom/scripts/resync-installed.sh --dry-run`: exits **0** — 150
  unchanged, 0 skipped; `defaults/hooks/*` and `.loom/hooks/*` stay
  byte-identical for both touched files
- `shellcheck -x` on both touched hook files: same finding count
  before/after (4 pre-existing informational SC2016 notices, no new
  findings)

## Affected files

- `defaults/hooks/guard-destructive-generic.sh` / `.loom/hooks/guard-destructive-generic.sh`
  (kept byte-identical)
- `defaults/hooks/guard-loom-workflow.sh` / `.loom/hooks/guard-loom-workflow.sh`
  (kept byte-identical)
- `tests/hooks/test-guard-destructive.sh` (new truth-table section)
- `defaults/hooks/guard-destructive.sh` (the dispatcher) — **untouched**, as
  expected (it holds zero config readers post-#4107)
- `defaults/scripts/lib/config-resolver.sh` — **untouched** (Option A doesn't
  need caching)
