### PR TITLE
fix(tokens): heal stale exhausted markers, neutral rate-limit label, unblock no-op fails loud (#4212)

### DIFF
--- a/.loom/docs/token-pool.md
+++ b/.loom/docs/token-pool.md
@@ -321,17 +321,33 @@ loom-tokens pin remove agent-3    # Remove
 loom-tokens pin status            # Show current allowlist
 loom-tokens unpin                 # Delete allowlist (back to full pool)
 
-loom-tokens unblock agent-1       # Remove one entry from .bad_tokens
-loom-tokens unblock --all         # Clear .bad_tokens entirely
+loom-tokens unblock agent-1              # Drop agent-1's AUTH entries only
+loom-tokens unblock agent-1 --all-reasons  # Also drop its exhausted/rate-limited entries
 ```
 
 **Validation**: `pin` accepts only exact bootstrapped account names —
 substring/fuzzy matches are rejected. The allowlist is sorted, deduplicated, and
 `mkdir`-lock guarded so concurrent operator commands don't drop entries.
 
-**Reason-aware bad-token TTL**: bad-tokens entries with reason `auth` (401) ignore
-`LOOM_TOKENS_BAD_TTL` (default 21600s = 6h) and persist until `loom-tokens
-unblock`. Other reasons expire automatically.
+**`unblock` default scope fails loudly on left-behind entries (#4212)**: the
+default scope removes only `auth` entries (a broken credential); transient
+`exhausted`/`rate-limited` entries clear themselves. When the named account has
+*only* a non-auth entry, the default scope leaves it in place — and rather than
+print "No matching entries removed" and exit `0` (the pre-#4212 silent no-op that
+let an operator dispatch onto a still-poisoned pool), `unblock` now **names the
+still-blocked accounts and exits `3`**. Re-run with `--all-reasons` to drop them,
+or wait for the cooldown to expire them automatically.
+
+**Reason-aware bad-token TTL**: bad-tokens entries whose reason is `auth` (401 /
+OAuth / expired / blocked) persist until `loom-tokens unblock`. Non-auth
+("exhausted"/"rate-limited") entries stop blocking selection once they age past
+the exhaustion cooldown (`LOOM_TOKEN_EXHAUSTION_COOLDOWN_SECS`, default 21600s =
+6h) — enforced at selection time in **both** the Rust daemon and the live Python
+spawn path (`is_bad`), so a recovered account re-enters the pool with no operator
+action even before `cleanup_bad_tokens` prunes the line from disk. Before #4212
+only the Rust path honored the cooldown, so on the live Python spawn path a stale
+`exhausted` marker outlived its rate-limit reset and wedged the account until a
+manual `unblock`.
 
 **Auto-unpin** (`failure_counts`): the wrapper tracks consecutive
 `TOKEN_EXHAUSTED` failures per account in `.loom/tokens/.failure_counts` (JSON).

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -4047,22 +4047,56 @@ fn handle_tokens_command(action: TokensAction) -> Result<()> {
                 std::process::exit(1);
             }
 
-            let (removed, kept) =
+            let outcome =
                 bad_tokens::unblock(&ws, &validated, all_reasons).map_err(|e| anyhow!(e))?;
+            let removed = outcome.removed;
+            let kept = outcome.kept;
+            let excluded = outcome.excluded;
             for name in &validated {
                 let _ = failure_counts::record_success(&ws, name);
             }
 
             if json {
-                println!("{}", serde_json::json!({ "removed": removed, "kept": kept }));
-            } else if removed > 0 {
-                let plural = if removed == 1 { "y" } else { "ies" };
-                println!("Removed {removed} bad-token entr{plural} for: {}", validated.join(", "));
-            } else {
                 println!(
-                    "No matching entries removed (use --all-reasons to drop non-auth entries \
-                     too)."
+                    "{}",
+                    serde_json::json!({
+                        "removed": removed,
+                        "kept": kept,
+                        "excluded": excluded,
+                    })
                 );
+            } else {
+                if removed > 0 {
+                    let plural = if removed == 1 { "y" } else { "ies" };
+                    println!(
+                        "Removed {removed} bad-token entr{plural} for: {}",
+                        validated.join(", ")
+                    );
+                }
+                if !excluded.is_empty() {
+                    // #4212: a no-op that looks like success is the failure
+                    // mode. Name the still-blocked accounts and fail below.
+                    let plural = if excluded.len() == 1 { "y" } else { "ies" };
+                    eprintln!(
+                        "Left {} non-auth (exhausted/rate-limited) entr{plural} in place for: \
+                         {}. These are still blocking selection — re-run with --all-reasons to \
+                         drop them (or wait for the exhaustion cooldown to expire them \
+                         automatically).",
+                        excluded.len(),
+                        excluded.join(", ")
+                    );
+                } else if removed == 0 {
+                    println!(
+                        "No matching entries removed (use --all-reasons to drop non-auth entries \
+                         too)."
+                    );
+                }
+            }
+
+            // Non-zero when the default scope left the named accounts still
+            // blocked — the operator's intent ("unblock X") was not achieved.
+            if !excluded.is_empty() {
+                std::process::exit(3);
             }
             Ok(())
         }

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -1018,7 +1018,14 @@ fn exhaustion_signatures() -> &'static [(&'static str, Regex)] {
     SIGS.get_or_init(|| {
         vec![
             (
-                "weekly-limit",
+                // Neutral label (#4212): this banner matches 5h-window ("hit
+                // your limit"), session, weekly, AND monthly signals — we
+                // cannot tell which window from the text, so labeling it
+                // "weekly-limit" materially misleads recovery decisions (a real
+                // weekly limit justifies waiting days; a 5h event, hours). The
+                // reason is transient exhaustion regardless, so use a neutral
+                // "rate-limited" that does not overclaim the window.
+                "rate-limited",
                 Regex::new(
                     r"(?i)hit your (limit|session limit|weekly limit)|hit\.your\.limit|monthly usage limit|out of extra usage",
                 )
@@ -7055,11 +7062,11 @@ exit 0
     fn classify_account_exhaustion_matches_signatures() {
         assert_eq!(
             classify_account_exhaustion("Claude: hit your weekly limit — try again later"),
-            Some("weekly-limit")
+            Some("rate-limited")
         );
         assert_eq!(
             classify_account_exhaustion("you are out of extra usage this month"),
-            Some("weekly-limit")
+            Some("rate-limited")
         );
         assert_eq!(
             classify_account_exhaustion("monitor emitted RATE_LIMIT_ABORT and exited"),

--- a/loom-daemon/src/tokens_pool/bad_tokens.rs
+++ b/loom-daemon/src/tokens_pool/bad_tokens.rs
@@ -195,13 +195,30 @@ pub fn cleanup_bad_tokens(workspace: &Path, max_age_seconds: i64) -> Result<usiz
     Ok(kept.len())
 }
 
+/// Outcome of [`unblock`]. `excluded` names the accounts that still have a
+/// non-auth ("exhausted") entry left in place because the default scope (no
+/// `all_reasons`) does not drop them (#4212). First-seen file order,
+/// de-duplicated, so the daemon CLI and the Python `cli.py::_cmd_unblock`
+/// emit a byte-identical `excluded` list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnblockOutcome {
+    pub removed: usize,
+    pub kept: usize,
+    pub excluded: Vec<String>,
+}
+
 /// Remove entries for `names` from `.bad_tokens` (operator `unblock`, ported
 /// from `cli.py::_cmd_unblock`). By default only entries whose reason field
 /// matches [`auth_reason_regex`] are dropped ("TTL entries clear
 /// themselves" — non-auth reasons are left for [`cleanup_bad_tokens`] /
 /// natural expiry); `all_reasons` also drops non-auth entries for the given
 /// names. Malformed lines (fewer than 2 whitespace-separated fields) are
-/// always kept so we never silently lose data. Returns `(removed, kept)`.
+/// always kept so we never silently lose data.
+///
+/// Returns an [`UnblockOutcome`]. `excluded` lists the named accounts whose
+/// non-auth entries the default scope left in place — the caller surfaces
+/// these and exits non-zero (#4212) so a no-op `unblock` can no longer look
+/// like success on a still-poisoned pool.
 ///
 /// # Errors
 /// Returns an error if the lock cannot be acquired or the file cannot be
@@ -210,11 +227,15 @@ pub fn unblock(
     workspace: &Path,
     names: &[String],
     all_reasons: bool,
-) -> Result<(usize, usize), String> {
+) -> Result<UnblockOutcome, String> {
     let dir = tokens_dir(workspace);
     let bad_file = bad_tokens_path(&dir);
     if !bad_file.is_file() {
-        return Ok((0, 0));
+        return Ok(UnblockOutcome {
+            removed: 0,
+            kept: 0,
+            excluded: Vec::new(),
+        });
     }
 
     let target: std::collections::HashSet<&str> = names.iter().map(String::as_str).collect();
@@ -223,6 +244,8 @@ pub fn unblock(
     let text = std::fs::read_to_string(&bad_file).map_err(|e| e.to_string())?;
     let mut removed = 0usize;
     let mut kept: Vec<String> = Vec::new();
+    let mut excluded: Vec<String> = Vec::new();
+    let mut excluded_seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     for line in text.lines() {
         let stripped = line.trim();
         if stripped.is_empty() {
@@ -233,9 +256,16 @@ pub fn unblock(
         let entry_name = parts.next();
         let reason = parts.next().unwrap_or("");
         if let Some(name) = entry_name {
-            if target.contains(name) && (all_reasons || auth_reason_regex().is_match(reason)) {
-                removed += 1;
-                continue;
+            if target.contains(name) {
+                if all_reasons || auth_reason_regex().is_match(reason) {
+                    removed += 1;
+                    continue;
+                }
+                // A named account with a non-auth entry that the DEFAULT scope
+                // leaves behind — record it so the caller can name it and fail.
+                if excluded_seen.insert(name.to_string()) {
+                    excluded.push(name.to_string());
+                }
             }
         }
         kept.push(line.to_string());
@@ -250,7 +280,11 @@ pub fn unblock(
     std::fs::write(&tmp, body).map_err(|e| e.to_string())?;
     std::fs::rename(&tmp, &bad_file).map_err(|e| e.to_string())?;
 
-    Ok((removed, kept.len()))
+    Ok(UnblockOutcome {
+        removed,
+        kept: kept.len(),
+        excluded,
+    })
 }
 
 #[cfg(test)]
@@ -415,7 +449,10 @@ mod tests {
     #[test]
     fn unblock_no_file_is_noop() {
         let tmp = make_pool();
-        assert_eq!(unblock(tmp.path(), &["a".to_string()], false).unwrap(), (0, 0));
+        let out = unblock(tmp.path(), &["a".to_string()], false).unwrap();
+        assert_eq!(out.removed, 0);
+        assert_eq!(out.kept, 0);
+        assert!(out.excluded.is_empty());
     }
 
     #[test]
@@ -423,21 +460,38 @@ mod tests {
         let tmp = make_pool();
         mark_bad(tmp.path(), "a", "401 unauthorized").unwrap();
         mark_bad(tmp.path(), "b", "exhausted: 429").unwrap();
-        let (removed, kept) =
-            unblock(tmp.path(), &["a".to_string(), "b".to_string()], false).unwrap();
-        assert_eq!(removed, 1);
-        assert_eq!(kept, 1);
+        // Only "a" is targeted, so "b" is not excluded (it was never asked for).
+        let out = unblock(tmp.path(), &["a".to_string()], false).unwrap();
+        assert_eq!(out.removed, 1);
+        assert_eq!(out.kept, 1);
+        assert!(out.excluded.is_empty());
         assert!(!is_bad(tmp.path(), "a"));
         assert!(is_bad(tmp.path(), "b"));
+    }
+
+    /// #4212: a named account whose only entry is non-auth ("exhausted") is
+    /// reported as `excluded` under the default scope — the caller fails
+    /// instead of silently no-op'ing.
+    #[test]
+    fn unblock_default_scope_reports_excluded_non_auth() {
+        let tmp = make_pool();
+        mark_bad(tmp.path(), "a", "401 unauthorized").unwrap();
+        mark_bad(tmp.path(), "b", "exhausted: weekly-limit").unwrap();
+        let out = unblock(tmp.path(), &["a".to_string(), "b".to_string()], false).unwrap();
+        assert_eq!(out.removed, 1); // a's auth entry
+        assert_eq!(out.kept, 1); // b's exhausted entry stays
+        assert_eq!(out.excluded, vec!["b".to_string()]);
     }
 
     #[test]
     fn unblock_all_reasons_drops_non_auth_too() {
         let tmp = make_pool();
         mark_bad(tmp.path(), "b", "exhausted: 429").unwrap();
-        let (removed, kept) = unblock(tmp.path(), &["b".to_string()], true).unwrap();
-        assert_eq!(removed, 1);
-        assert_eq!(kept, 0);
+        let out = unblock(tmp.path(), &["b".to_string()], true).unwrap();
+        assert_eq!(out.removed, 1);
+        assert_eq!(out.kept, 0);
+        // --all-reasons never excludes anything.
+        assert!(out.excluded.is_empty());
         assert!(!is_bad(tmp.path(), "b"));
     }
 
@@ -445,9 +499,10 @@ mod tests {
     fn unblock_ignores_unrelated_names() {
         let tmp = make_pool();
         mark_bad(tmp.path(), "a", "auth failure").unwrap();
-        let (removed, kept) = unblock(tmp.path(), &["c".to_string()], false).unwrap();
-        assert_eq!(removed, 0);
-        assert_eq!(kept, 1);
+        let out = unblock(tmp.path(), &["c".to_string()], false).unwrap();
+        assert_eq!(out.removed, 0);
+        assert_eq!(out.kept, 1);
+        assert!(out.excluded.is_empty());
         assert!(is_bad(tmp.path(), "a"));
     }
 
@@ -456,9 +511,10 @@ mod tests {
         let tmp = make_pool();
         let dir = pool_dir(tmp.path());
         fs::write(dir.join(".bad_tokens"), "onlyoneword\n").unwrap();
-        let (removed, kept) = unblock(tmp.path(), &["onlyoneword".to_string()], true).unwrap();
-        assert_eq!(removed, 0);
-        assert_eq!(kept, 1);
+        let out = unblock(tmp.path(), &["onlyoneword".to_string()], true).unwrap();
+        assert_eq!(out.removed, 0);
+        assert_eq!(out.kept, 1);
+        assert!(out.excluded.is_empty());
     }
 
     #[test]

--- a/loom-tools/src/loom_tools/tokens/bad_tokens.py
+++ b/loom-tools/src/loom_tools/tokens/bad_tokens.py
@@ -18,12 +18,75 @@ collide.
 
 from __future__ import annotations
 
+import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
 
 from loom_tools.tokens._locking import MkdirLock as _MkdirLock
 from loom_tools.tokens.paths import resolve_tokens_dir
+
+# Default cooldown (seconds) after which a non-auth (exhaustion) bad-token
+# entry stops blocking selection (#4122 / #4212). Weekly/session/5h-limit
+# exhaustion is transient — the account recovers on its own within a rate-limit
+# window — so those entries expire while auth-reason entries (a broken
+# credential) stay permanent. Mirrors the Rust reference
+# (``tokens_pool::bad_tokens::DEFAULT_EXHAUSTION_COOLDOWN_SECS``) so the two
+# implementations stay byte-for-byte in lockstep (the live spawn path is this
+# Python one — issue #4212).
+DEFAULT_EXHAUSTION_COOLDOWN_SECS = 6 * 3600
+
+# Env override (whole seconds, must parse to ``> 0``) for
+# ``DEFAULT_EXHAUSTION_COOLDOWN_SECS``. Same name as the Rust side.
+EXHAUSTION_COOLDOWN_ENV = "LOOM_TOKEN_EXHAUSTION_COOLDOWN_SECS"
+
+# Reasons treated as "auth" (a broken credential) rather than transient
+# exhaustion. Auth entries block selection permanently and are the default
+# scope of ``loom-tokens unblock``; exhaustion entries expire on their own
+# (cooldown / cleanup). Canonical definition lives here so ``is_bad`` (this
+# module) and ``cli.py``'s ``unblock`` share ONE regex — a drift between the
+# two is exactly the lockstep bug #4212 guards against. Mirrors the Rust
+# ``tokens_pool::bad_tokens::auth_reason_regex``.
+AUTH_REASON_RE = re.compile(
+    r"\b("
+    r"401|"
+    r"oauth|"
+    r"auth(entication)?|"
+    r"unauthorized|"
+    r"token[_\s]?expired|"
+    r"expired|"
+    r"blocked"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def exhaustion_cooldown_secs() -> int:
+    """Resolve the exhaustion-entry cooldown in seconds.
+
+    Precedence: ``EXHAUSTION_COOLDOWN_ENV`` (whole seconds, ``> 0``) else
+    ``DEFAULT_EXHAUSTION_COOLDOWN_SECS``. Mirrors the Rust
+    ``exhaustion_cooldown_secs`` resolver.
+    """
+    raw = os.environ.get(EXHAUSTION_COOLDOWN_ENV)
+    if raw is not None:
+        try:
+            n = int(raw.strip())
+        except (ValueError, AttributeError):
+            n = 0
+        if n > 0:
+            return n
+    return DEFAULT_EXHAUSTION_COOLDOWN_SECS
+
+
+def is_auth_reason(reason: str) -> bool:
+    """Return True when ``reason`` names an auth failure (permanent block).
+
+    A broken credential (401 / OAuth / expired / blocked) never self-heals, so
+    such entries block until an explicit ``unblock``. Anything else is treated
+    as transient exhaustion, subject to the cooldown in ``is_bad``.
+    """
+    return bool(AUTH_REASON_RE.search(reason))
 
 
 def _tokens_dir(workspace_path: Path | str) -> Path:
@@ -83,11 +146,24 @@ def mark_bad(workspace_path: Path | str, token_name: str, reason: str) -> None:
 
 
 def is_bad(workspace_path: Path | str, token_name: str) -> bool:
-    """Return True if ``token_name`` appears in the bad_tokens file.
+    """Return True if ``token_name`` is currently bad-marked.
 
     Uses a word-boundary regex so ``agent-1`` does not match ``agent-10``.
     Reads are unsynchronized — readers see a consistent file because writers
     only ever append whole lines.
+
+    Reason-aware expiry (#4122 / #4212): auth-reason entries (a broken
+    credential — matched by ``AUTH_REASON_RE``) block permanently. Non-auth
+    ("exhaustion") entries block only until they age past
+    ``exhaustion_cooldown_secs``: weekly/session/5h-limit exhaustion is
+    transient, so a stale exhaustion line no longer keeps an otherwise-healthy
+    account out of rotation even before ``cleanup_bad_tokens`` prunes it from
+    disk — the account re-enters the pool with no operator action. A line whose
+    timestamp cannot be parsed is treated as permanent (fail-closed — we never
+    silently un-block a token on a malformed entry). This mirrors the Rust
+    ``tokens_pool::bad_tokens::is_bad`` byte-for-byte; the live spawn path is
+    this Python one, so without it a recovered account stays blocked until a
+    manual ``unblock`` (the 2026-07-28 incident, #4212).
 
     Args:
         workspace_path: Repo root.
@@ -101,7 +177,33 @@ def is_bad(workspace_path: Path | str, token_name: str) -> bool:
         text = bad_file.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return False
-    return bool(_name_pattern(token_name).search(text))
+
+    pattern = _name_pattern(token_name)
+    cooldown = exhaustion_cooldown_secs()
+    now = datetime.now(timezone.utc).timestamp()
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or not pattern.search(stripped):
+            continue
+        # Parse `<ts> <name> <reason...>` from this matching line.
+        parts = stripped.split(" ", 2)
+        ts_str = parts[0] if parts else ""
+        reason = parts[2] if len(parts) >= 3 else ""
+        # Auth entries never expire.
+        if is_auth_reason(reason):
+            return True
+        # Non-auth (exhaustion) entries expire after the cooldown. A
+        # malformed/missing timestamp fails closed (permanent). An expired
+        # entry does NOT short-circuit — a later line may still block.
+        try:
+            ts_epoch = datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=timezone.utc,
+            ).timestamp()
+        except ValueError:
+            return True
+        if now - ts_epoch < cooldown:
+            return True
+    return False
 
 
 def cleanup_bad_tokens(

--- a/loom-tools/src/loom_tools/tokens/cli.py
+++ b/loom-tools/src/loom_tools/tokens/cli.py
@@ -26,13 +26,13 @@ import argparse
 import json
 import logging
 import os
-import re
 import sys
 from pathlib import Path
 
 from loom_tools.common.logging import log_error, log_info, log_success, log_warning
 from loom_tools.common.repo import find_repo_root
 from loom_tools.tokens import allowlist as allowlist_mod
+from loom_tools.tokens import bad_tokens as bad_tokens_mod
 from loom_tools.tokens import failure_counts
 from loom_tools.tokens.bootstrap import bootstrap_tokens
 from loom_tools.tokens.monitor_db import (
@@ -746,25 +746,19 @@ def _cmd_unpin(args: argparse.Namespace) -> int:
     return 0
 
 
-# Reasons we treat as "auth" for the unblock command. Match
-# case-insensitively against the free-form reason field of bad_tokens
-# entries. We do NOT match TOKEN_EXHAUSTED — those expire on their own.
-_AUTH_REASON_RE = re.compile(
-    r"\b("
-    r"401|"
-    r"oauth|"
-    r"auth(entication)?|"
-    r"unauthorized|"
-    r"token[_\s]?expired|"
-    r"expired|"
-    r"blocked"
-    r")\b",
-    re.IGNORECASE,
-)
-
-
 def _cmd_unblock(args: argparse.Namespace) -> int:
-    """Handle ``loom-tokens unblock <names...> [--all-reasons]``."""
+    """Handle ``loom-tokens unblock <names...> [--all-reasons]``.
+
+    Exit codes:
+        0 — entries removed, or nothing matched the named accounts at all.
+        2 — an unknown account name was given.
+        3 — default scope (no ``--all-reasons``) left non-auth ("exhausted")
+            entries in place for the named accounts. This is a *deliberate*
+            non-zero: the pre-#4212 behavior printed "No matching entries
+            removed" and exited 0, so an operator saw success while the pool
+            stayed poisoned and the next dispatches insta-crashed. We now name
+            the still-blocked accounts and fail so a script/operator notices.
+    """
     workspace = _resolve_workspace()
     if workspace is None:
         return 1
@@ -808,6 +802,12 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
     target_set = set(names)
     removed = 0
     kept_lines: list[str] = []
+    # Named accounts that still have a non-auth ("exhausted") entry left in
+    # place because the operator did not pass --all-reasons (#4212). Tracked in
+    # first-seen file order, de-duplicated, so the daemon Rust port can emit a
+    # byte-identical `excluded` list.
+    excluded: list[str] = []
+    excluded_seen: set[str] = set()
     with _MkdirLock(lock_path):
         try:
             lines = bad_file.read_text(encoding="utf-8").splitlines()
@@ -826,9 +826,14 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
             entry_name = parts[1]
             reason = parts[2] if len(parts) >= 3 else ""
             if entry_name in target_set:
-                if args.all_reasons or _AUTH_REASON_RE.search(reason):
+                if args.all_reasons or bad_tokens_mod.is_auth_reason(reason):
                     removed += 1
                     continue
+                # A named account with a non-auth entry that the DEFAULT scope
+                # leaves behind — record it so we can name it and fail.
+                if entry_name not in excluded_seen:
+                    excluded_seen.add(entry_name)
+                    excluded.append(entry_name)
             kept_lines.append(line)
 
         # Atomic rewrite via temp file (matches cleanup_bad_tokens).
@@ -850,7 +855,7 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
     if getattr(args, "emit_json", False):
         print(
             json.dumps(
-                {"removed": removed, "kept": len(kept_lines)},
+                {"removed": removed, "kept": len(kept_lines), "excluded": excluded},
                 indent=2,
             ),
         )
@@ -860,11 +865,27 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
                 f"Removed {removed} bad-token entr{'y' if removed == 1 else 'ies'}"
                 f" for: {', '.join(names)}",
             )
-        else:
+        if excluded:
+            # AC #4212: a no-op that looks like success is the failure mode.
+            # Name the still-blocked accounts and fail so the operator does not
+            # dispatch onto a still-poisoned pool.
+            log_warning(
+                f"Left {len(excluded)} non-auth (exhausted/rate-limited) "
+                f"entr{'y' if len(excluded) == 1 else 'ies'} in place for: "
+                f"{', '.join(excluded)}. These are still blocking selection — "
+                f"re-run with --all-reasons to drop them (or wait for the "
+                f"exhaustion cooldown to expire them automatically).",
+            )
+        elif not removed:
             log_info(
                 "No matching entries removed (use --all-reasons to drop "
                 "non-auth entries too).",
             )
+
+    # Non-zero when the default scope left the named accounts still blocked —
+    # the operator's intent ("unblock X") was not achieved.
+    if excluded:
+        return 3
     return 0
 
 

--- a/loom-tools/tests/tokens/test_bad_tokens.py
+++ b/loom-tools/tests/tokens/test_bad_tokens.py
@@ -8,9 +8,15 @@ from pathlib import Path
 
 import pytest
 
+from datetime import datetime, timedelta, timezone
+
 from loom_tools.tokens import bad_tokens
 from loom_tools.tokens.bad_tokens import (
+    DEFAULT_EXHAUSTION_COOLDOWN_SECS,
+    EXHAUSTION_COOLDOWN_ENV,
     cleanup_bad_tokens,
+    exhaustion_cooldown_secs,
+    is_auth_reason,
     is_bad,
     mark_bad,
 )
@@ -20,6 +26,10 @@ def _make_tokens_dir(tmp_path: Path) -> Path:
     d = tmp_path / ".loom" / "tokens"
     d.mkdir(parents=True)
     return tmp_path
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def test_mark_then_is_bad(tmp_path):
@@ -98,6 +108,75 @@ def test_cleanup_keeps_malformed_lines(tmp_path):
     contents = bad_file.read_text()
     assert "garbage" in contents
     assert "fresh" in contents
+
+
+# ---------- reason-aware cooldown (#4122 / #4212) ----------
+
+
+def test_exhaustion_entry_expires_after_cooldown_auth_stays(tmp_path):
+    """#4212: a stale exhaustion (non-auth) entry no longer blocks selection
+    even before cleanup prunes it, while an auth entry of the same age stays
+    permanent — the live Python spawn path must self-heal like the Rust one."""
+    workspace = _make_tokens_dir(tmp_path)
+    bad_file = workspace / ".loom" / "tokens" / ".bad_tokens"
+    old = _iso(datetime.now(timezone.utc) - timedelta(seconds=7 * 3600))
+    bad_file.write_text(
+        f"{old} agent-exh exhausted: weekly-limit\n"
+        f"{old} agent-auth 401 unauthorized\n",
+        encoding="utf-8",
+    )
+    # Exhaustion entry has aged out — selectable again (line still on disk).
+    assert is_bad(workspace, "agent-exh") is False
+    # Auth entry is permanent — unaffected by the TTL.
+    assert is_bad(workspace, "agent-auth") is True
+
+
+def test_fresh_exhaustion_entry_still_blocks(tmp_path):
+    """A just-written exhaustion entry blocks until the cooldown elapses."""
+    workspace = _make_tokens_dir(tmp_path)
+    mark_bad(workspace, "agent-1", "exhausted: weekly-limit")
+    assert is_bad(workspace, "agent-1") is True
+
+
+def test_malformed_timestamp_fails_closed(tmp_path):
+    """A matching line with an unparseable timestamp stays bad (fail-closed)."""
+    workspace = _make_tokens_dir(tmp_path)
+    bad_file = workspace / ".loom" / "tokens" / ".bad_tokens"
+    bad_file.write_text("not-a-timestamp agent-1 exhausted\n", encoding="utf-8")
+    assert is_bad(workspace, "agent-1") is True
+
+
+def test_expired_entry_does_not_shortcircuit_later_blocking_line(tmp_path):
+    """An aged-out exhaustion line must not mask a later still-blocking one."""
+    workspace = _make_tokens_dir(tmp_path)
+    bad_file = workspace / ".loom" / "tokens" / ".bad_tokens"
+    old = _iso(datetime.now(timezone.utc) - timedelta(seconds=7 * 3600))
+    fresh = _iso(datetime.now(timezone.utc))
+    bad_file.write_text(
+        f"{old} agent-1 exhausted: weekly-limit\n"
+        f"{fresh} agent-1 exhausted: 429\n",
+        encoding="utf-8",
+    )
+    assert is_bad(workspace, "agent-1") is True
+
+
+def test_exhaustion_cooldown_env_override(monkeypatch):
+    monkeypatch.setenv(EXHAUSTION_COOLDOWN_ENV, "100")
+    assert exhaustion_cooldown_secs() == 100
+    monkeypatch.setenv(EXHAUSTION_COOLDOWN_ENV, "0")
+    assert exhaustion_cooldown_secs() == DEFAULT_EXHAUSTION_COOLDOWN_SECS
+    monkeypatch.setenv(EXHAUSTION_COOLDOWN_ENV, "garbage")
+    assert exhaustion_cooldown_secs() == DEFAULT_EXHAUSTION_COOLDOWN_SECS
+    monkeypatch.delenv(EXHAUSTION_COOLDOWN_ENV, raising=False)
+    assert exhaustion_cooldown_secs() == DEFAULT_EXHAUSTION_COOLDOWN_SECS
+
+
+def test_is_auth_reason_matches_expected():
+    assert is_auth_reason("401 Unauthorized") is True
+    assert is_auth_reason("oauth token expired") is True
+    assert is_auth_reason("blocked") is True
+    assert is_auth_reason("exhausted: weekly-limit") is False
+    assert is_auth_reason("exhausted: rate-limited") is False
 
 
 # ---------- locking ----------

--- a/loom-tools/tests/tokens/test_rust_conformance.py
+++ b/loom-tools/tests/tokens/test_rust_conformance.py
@@ -255,7 +255,9 @@ def test_unblock_auth_reason_removed_identically(tmp_path):
     assert rust_result.returncode == 0, rust_result.stderr
     rust_json = json.loads(rust_result.stdout)
 
-    assert py_json == rust_json == {"removed": 1, "kept": 1}
+    # "a" (auth) is removed; "b" (exhausted) is not a target here, so nothing
+    # is excluded and both exit 0 (#4212 adds the `excluded` field).
+    assert py_json == rust_json == {"removed": 1, "kept": 1, "excluded": []}
 
     py_bad = (py_ws / ".loom" / "tokens" / ".bad_tokens").read_text(encoding="utf-8")
     rust_bad = (rust_ws / ".loom" / "tokens" / ".bad_tokens").read_text(encoding="utf-8")
@@ -265,6 +267,47 @@ def test_unblock_auth_reason_removed_identically(tmp_path):
     assert "a" not in rust_bad.split()
     assert "b" in py_bad
     assert "b" in rust_bad
+
+
+def test_unblock_default_scope_excluded_exit3_identically(tmp_path):
+    """#4212: a named account whose only entry is non-auth ("exhausted") is
+    left in place under the default scope — both implementations name it in
+    `excluded` and exit 3 (not a silent success)."""
+    py_ws = tmp_path / "py"
+    rust_ws = tmp_path / "rust"
+    _write_pool(py_ws, ["a", "b"])
+    _write_pool(rust_ws, ["a", "b"])
+    py_mark_bad(py_ws, "a", "401 unauthorized")
+    py_mark_bad(py_ws, "b", "exhausted: weekly-limit")
+    py_mark_bad(rust_ws, "a", "401 unauthorized")
+    py_mark_bad(rust_ws, "b", "exhausted: weekly-limit")
+
+    py_result = subprocess.run(
+        [
+            "python3",
+            "-m",
+            "loom_tools.tokens.cli",
+            "unblock",
+            "a",
+            "b",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=py_ws,
+        env={**os.environ, "LOOM_WORKSPACE": str(py_ws), "PYTHONPATH": _loom_tools_src()},
+    )
+    rust_result = _run_rust("unblock", "a", "b", "--workspace", str(rust_ws), "--json")
+
+    # Both exit 3 (default scope left a named account still blocked).
+    assert py_result.returncode == 3, py_result.stderr
+    assert rust_result.returncode == 3, rust_result.stderr
+
+    py_json = json.loads(py_result.stdout)
+    rust_json = json.loads(rust_result.stdout)
+    # "a"'s auth entry is dropped; "b"'s exhausted entry stays and is named.
+    assert py_json == rust_json == {"removed": 1, "kept": 1, "excluded": ["b"]}
 
 
 def _loom_tools_src() -> str:


### PR DESCRIPTION
Closes #4212

## Problem

The 2026-07-28 rate-limit storm exposed three compounding token-pool defects. All fixes land in **both** the Python (live spawn path) and Rust implementations, keeping the byte-for-byte conformance pair intact.

## Fixes

### 1. Stale `exhausted` markers outlived the reset (AC1 + AC4)
The Rust `is_bad` already expired non-auth ("exhausted") entries after a cooldown (#4122), but the **Python `is_bad` — which the live spawn path (`spawn-claude.sh`) actually calls — had no reason-aware cooldown at all**: it blocked permanently until `cleanup_bad_tokens` pruned the line. So a recovered account stayed out of the pool until a manual `unblock` per account. This is exactly the Python/Rust lockstep gap #4195 warned about.

Ported the exact reason-aware cooldown to Python `is_bad`:
- auth entries (401 / OAuth / expired / blocked) block permanently;
- exhaustion entries stop blocking past `LOOM_TOKEN_EXHAUSTION_COOLDOWN_SECS` (default 6h);
- a malformed/missing timestamp fails **closed** (never silently un-blocks).

Shared the auth-reason regex + added `exhaustion_cooldown_secs()`/`is_auth_reason()` in `bad_tokens.py` (previously duplicated in `cli.py`). The check runs at selection time against whichever pool `resolve_tokens_dir` picks, so per-repo and shared pools both self-heal with no second manual round (AC4).

### 2. Misclassification: 5h window labeled "weekly-limit" (AC2)
The daemon reaper's exhaustion classifier labeled every banner match `weekly-limit`, even a 5h-window "hit your limit" death. A `weekly-limit` label on a 5h event materially misleads recovery (weekly = wait days; 5h = wait hours). The window is unknowable from the banner, so the signature now uses a neutral **`rate-limited`** label (`sweep_registry.rs`).

### 3. `unblock` default scope silently no-op'd (AC3)
`unblock <name>` on an account whose only entry was non-auth printed "No matching entries removed" and exited **0** — the operator saw success and dispatched three sweeps onto the still-poisoned pool, all insta-crashing. Both CLIs now track the left-behind accounts, name them, add an `excluded` field to the JSON output, and **exit `3`**.

## Tests
- Python units: cooldown expiry vs. permanent auth, fresh-entry still blocks, malformed-ts fails closed, expired line doesn't mask a later blocking line, env override, `is_auth_reason`.
- Rust unit: `unblock_default_scope_reports_excluded_non_auth`; updated existing unblock tests to the `UnblockOutcome` struct.
- Cross-language conformance: new `excluded` JSON field asserted identical; new `test_unblock_default_scope_excluded_exit3_identically` (both exit 3, both name the account).
- `cargo test` (bad_tokens + all 184 sweep_registry tests) and the full conformance suite pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
