### PR TITLE
feat(tokens): add 5h load-aware eligibility gate to ranked token selection

### DIFF
--- a/.loom/docs/token-pool.md
+++ b/.loom/docs/token-pool.md
@@ -241,13 +241,38 @@ token hits its weekly limit.
 
 Three tiers, falling through to the next when the current tier yields nothing:
 
-1. **Ranking** — `.loom/tokens/.ranking` (pipe-delimited `name|status`, refreshed
-   every <10 min). Picks the first non-`exhausted`/non-`blocked` token.
+1. **Ranking** — `.loom/tokens/.ranking` (pipe-delimited `name|status|5h_util`,
+   refreshed every <10 min). A persistent rotation cursor spreads consecutive
+   dispatches one-per-account across the eligible accounts (#3909;
+   `LOOM_TOKEN_SPREAD_TOP_N` / `tokens.spreadTopN` optionally caps the window).
 2. **Allowlist** — `.loom/tokens/.allowlist` (one name per line). Random pick from
    allowed accounts.
 3. **Random** — uniform pick from all `*.token` files.
 
 Tokens marked bad in `.loom/tokens/.bad_tokens` are skipped at every tier.
+
+### Ranking format: 5h-load field + soft gate (issue #4195)
+
+The `.ranking` line format is `name|status|5h_util`, where the **third field**
+is the account's 5h-window utilization (a fraction `0.0`–`1.0`, fixed at 2
+decimals). It is **optional**: a legacy 2-field `name|status` line still parses,
+and an account with no measured 5h utilization is written in the 2-field form
+(the value is left off, never faked as `0.0`). All four ranking writers emit it
+— the Python probe (`check.py`) and monitor (`monitor.py`) paths and their
+byte-identical Rust ports (`tokens_pool::check` / `tokens_pool::monitor`).
+
+The ranked tier layers a **soft load gate** on top of the rotation cursor: in
+the preferred pass an account **at/above** the 5h threshold is excluded (so the
+cursor rotates only across the lightly-loaded accounts), and the fallback pass
+readmits them — the pool never hard-fails on load alone. A **missing or
+unparseable** utilization is treated as *unknown* → never gated. The threshold
+defaults to `0.70` and is overridable via the `LOOM_TOKEN_5H_LOAD_GATE` env var
+(a value `> 1.0` disables the gate); it follows the `LOOM_TOKEN_SPREAD_TOP_N`
+precedent and is honored identically by the Python selector (`select.py`) and
+the Rust port (`tokens_pool::select`). This is the Option-A reconciliation of
+the gpeyton-fork load-aware selection proposal (fork commits `283de8e3`,
+`20961dd9`) with upstream's existing rotation-cursor spread — a load-aware gate
+*layered on* #3909, not the fork's waterfall-fill replacement.
 
 ## Bad-token tracking (`loom_tools.tokens.bad_tokens`)
 

--- a/loom-daemon/src/tokens_pool/check.rs
+++ b/loom-daemon/src/tokens_pool/check.rs
@@ -534,8 +534,23 @@ fn now_iso() -> String {
     chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
 }
 
-/// Serialize a report to the selector's `name|status` format (trailing newline,
-/// empty report -> empty string). Mirrors `check.format_ranking_lines`.
+/// Format one `.ranking` line, emitting the optional 5h-utilization field
+/// (issue #4195): `name|status|5h_util` when the 5h utilization is known, else
+/// the legacy `name|status` (backward compatible: a `None` utilization is left
+/// unwritten rather than faked as `0.0`). The float is fixed at 2 decimals so
+/// the probe and monitor writers stay byte-identical with the Python port
+/// (`check._ranking_line`). Shared with `monitor::format_ranking_lines`.
+pub(crate) fn ranking_line(name: &str, status: &str, util_5h: Option<f64>) -> String {
+    match util_5h {
+        Some(u) => format!("{name}|{status}|{u:.2}"),
+        None => format!("{name}|{status}"),
+    }
+}
+
+/// Serialize a report to the selector's `name|status|5h_util` format (trailing
+/// newline, empty report -> empty string). The 5h utilization is an optional
+/// third field, emitted when measured (issue #4195). Mirrors
+/// `check.format_ranking_lines`.
 #[must_use]
 pub fn format_ranking_lines(report: &ProbeReport) -> String {
     if report.accounts.is_empty() {
@@ -543,9 +558,7 @@ pub fn format_ranking_lines(report: &ProbeReport) -> String {
     }
     let mut out = String::new();
     for a in &report.accounts {
-        out.push_str(&a.name);
-        out.push('|');
-        out.push_str(&a.status);
+        out.push_str(&ranking_line(&a.name, &a.status, a.s5h_utilization));
         out.push('\n');
     }
     out
@@ -994,6 +1007,19 @@ mod tests {
             accounts: vec![AccountResult::new("a-1", "available")],
         };
         assert_eq!(format_ranking_lines(&report), "a-1|available\n");
+    }
+
+    #[test]
+    fn format_ranking_lines_emits_5h_util_third_field() {
+        // The 5h utilization is the optional third field (issue #4195), fixed
+        // at 2 decimals; an absent value keeps the legacy 2-field form.
+        let mut loaded = AccountResult::new("a-1", "available");
+        loaded.s5h_utilization = Some(0.42);
+        let report = ProbeReport {
+            ranked_at: "x".into(),
+            accounts: vec![loaded, AccountResult::new("b-2", "available")],
+        };
+        assert_eq!(format_ranking_lines(&report), "a-1|available|0.42\nb-2|available\n");
     }
 
     #[test]

--- a/loom-daemon/src/tokens_pool/monitor.rs
+++ b/loom-daemon/src/tokens_pool/monitor.rs
@@ -266,8 +266,10 @@ pub fn build_monitor_accounts(
     Some(accounts)
 }
 
-/// Serialize ordered accounts to the selector's `name|status` format (trailing
-/// newline; empty -> empty string). Mirrors `monitor.format_ranking_lines`.
+/// Serialize ordered accounts to the selector's `name|status|5h_util` format
+/// (trailing newline; empty -> empty string). The 5h utilization is an optional
+/// third field, emitted when known (issue #4195); byte-identical with the probe
+/// writer (`check::ranking_line`). Mirrors `monitor.format_ranking_lines`.
 #[must_use]
 pub fn format_ranking_lines(accounts: &[MonitorAccount]) -> String {
     if accounts.is_empty() {
@@ -275,9 +277,7 @@ pub fn format_ranking_lines(accounts: &[MonitorAccount]) -> String {
     }
     let mut out = String::new();
     for a in accounts {
-        out.push_str(&a.name);
-        out.push('|');
-        out.push_str(&a.status);
+        out.push_str(&super::check::ranking_line(&a.name, &a.status, a.util_5h));
         out.push('\n');
     }
     out
@@ -513,6 +513,27 @@ mod tests {
             util_5h: None,
         }];
         assert_eq!(format_ranking_lines(&accounts), "acct-z|\n");
+    }
+
+    #[test]
+    fn format_ranking_lines_emits_5h_util_third_field() {
+        // The 5h utilization is the optional third field (issue #4195), fixed
+        // at 2 decimals; an absent value keeps the legacy 2-field form.
+        let accounts = vec![
+            MonitorAccount {
+                name: "a".into(),
+                status: "available".into(),
+                util_7d: Some(0.20),
+                util_5h: Some(0.90),
+            },
+            MonitorAccount {
+                name: "b".into(),
+                status: "available".into(),
+                util_7d: Some(0.10),
+                util_5h: None,
+            },
+        ];
+        assert_eq!(format_ranking_lines(&accounts), "a|available|0.90\nb|available\n");
     }
 
     #[test]

--- a/loom-daemon/src/tokens_pool/select.rs
+++ b/loom-daemon/src/tokens_pool/select.rs
@@ -7,7 +7,12 @@
 //!      using the persistent rotation cursor ([`super::rotation`]) so a
 //!      burst of N concurrent dispatches spreads across `min(N, available)`
 //!      distinct accounts (#3909). `LOOM_TOKEN_SPREAD_TOP_N` /
-//!      `tokens.spreadTopN` optionally caps the rotation window.
+//!      `tokens.spreadTopN` optionally caps the rotation window. The preferred
+//!      pass additionally excludes accounts at/above the 5h-window load
+//!      threshold (`name|status|5h_util` third field, `LOOM_TOKEN_5H_LOAD_GATE`,
+//!      default 0.70) — a soft eligibility gate layered on the rotation cursor
+//!      (#4195); the fallback pass readmits them so the pool never hard-fails on
+//!      load alone.
 //!   2. Allowlist file (`.allowlist`): random pick from allowed accounts.
 //!   3. Random pick from all `.token` files.
 //!
@@ -30,6 +35,15 @@ const RANKING_FRESH_SECONDS: u64 = 600; // 10 min
 
 /// Exit code when no token is available (matches sysexits.h EX_CONFIG).
 pub const EX_CONFIG: i32 = 78;
+
+/// Default 5h-window load threshold for the tier-1 *preferred* pass (issue
+/// #4195). An account at/above this fraction of its 5h rate-limit window is
+/// excluded from the preferred pass (a soft eligibility gate layered on top of
+/// the #3909 rotation-cursor spread) and readmitted in the fallback pass, so a
+/// fully-loaded pool still dispatches. Overridable via `LOOM_TOKEN_5H_LOAD_GATE`
+/// (a value > 1.0 disables the gate). A missing/unparseable utilization is
+/// treated as unknown → never gated. Mirrors `select.py:_DEFAULT_5H_LOAD_GATE`.
+const DEFAULT_5H_LOAD_GATE: f64 = 0.70;
 
 /// Statuses considered positively healthy (issue #3991 — allowlist of
 /// known-good statuses, not a denylist of known-bad ones). The empty string
@@ -115,9 +129,22 @@ fn strip_comment(line: &str) -> String {
     line.split('#').next().unwrap_or("").trim().to_string()
 }
 
-/// Yield `(name, status)` pairs from the ranking file. Malformed/empty
-/// lines are skipped; `status` defaults to `""`.
-fn read_ranking(ranking_file: &Path) -> Vec<(String, String)> {
+/// Parse a ranking line's optional 5h-utilization field (issue #4195). An
+/// empty or unparseable field yields `None` ("unknown") — never coerced to
+/// `0.0`, so an unmeasured account is never load-gated (see #4164).
+fn parse_util(field: &str) -> Option<f64> {
+    let field = field.trim();
+    if field.is_empty() {
+        return None;
+    }
+    field.parse::<f64>().ok()
+}
+
+/// Yield `(name, status, util_5h)` triples from the ranking file. Format:
+/// `name|status|5h_util` per line (issue #4195); the third field is optional,
+/// so a legacy `name|status` line yields `util_5h = None` (backward
+/// compatible). Malformed/empty lines are skipped; `status` defaults to `""`.
+fn read_ranking(ranking_file: &Path) -> Vec<(String, String, Option<f64>)> {
     let Ok(text) = std::fs::read_to_string(ranking_file) else {
         return Vec::new();
     };
@@ -127,11 +154,12 @@ fn read_ranking(ranking_file: &Path) -> Vec<(String, String)> {
         if stripped.is_empty() {
             continue;
         }
-        let mut parts = stripped.splitn(2, '|');
+        let mut parts = stripped.splitn(3, '|');
         let name = parts.next().unwrap_or("").trim().to_string();
         let status = parts.next().unwrap_or("").trim().to_string();
+        let util = parts.next().and_then(parse_util);
         if !name.is_empty() {
-            out.push((name, status));
+            out.push((name, status, util));
         }
     }
     out
@@ -174,20 +202,47 @@ fn resolve_spread_top_n(workspace: &Path) -> Option<usize> {
     None
 }
 
+/// Resolve the tier-1 5h-load threshold (issue #4195): `LOOM_TOKEN_5H_LOAD_GATE`
+/// env var (parsed as a float) → the constant default [`DEFAULT_5H_LOAD_GATE`].
+/// An unset or unparseable env value falls back to the default. Mirrors
+/// `select.py:_resolve_load_gate` so both implementations gate identically.
+fn resolve_load_gate() -> f64 {
+    if let Ok(raw) = std::env::var("LOOM_TOKEN_5H_LOAD_GATE") {
+        if let Ok(v) = raw.trim().parse::<f64>() {
+            return v;
+        }
+    }
+    DEFAULT_5H_LOAD_GATE
+}
+
 fn collect_ranked_candidates(
     tokens_dir: &Path,
     ranking_file: &Path,
     workspace: &Path,
     cap: Option<usize>,
     healthy_only: bool,
+    load_gate: f64,
 ) -> Vec<SelectedToken> {
     let mut out = Vec::new();
-    for (name, status) in read_ranking(ranking_file) {
+    for (name, status, util) in read_ranking(ranking_file) {
         if is_hard_excluded_status(&status) {
             continue;
         }
         if healthy_only && !is_healthy_status(&status) {
             continue;
+        }
+        // Load gate (issue #4195): the preferred pass additionally excludes
+        // accounts at/above the 5h-window load threshold. An unknown
+        // (unmeasured) utilization is never gated. The fallback pass drops the
+        // gate so a fully-loaded pool still dispatches. The rotation cursor
+        // then rotates across the load-eligible set, so no per-spawn in-burst
+        // bump is needed — the cursor already prevents intra-burst stacking.
+        if healthy_only {
+            if let Some(u) = util {
+                if u >= load_gate {
+                    continue;
+                }
+            }
         }
         let token_file = tokens_dir.join(format!("{name}.token"));
         if !token_file.is_file() {
@@ -231,10 +286,13 @@ fn try_ranking(
     }
 
     let cap = resolve_spread_top_n(workspace);
+    let load_gate = resolve_load_gate();
 
-    let mut eligible = collect_ranked_candidates(tokens_dir, ranking_file, workspace, cap, true);
+    let mut eligible =
+        collect_ranked_candidates(tokens_dir, ranking_file, workspace, cap, true, load_gate);
     if eligible.is_empty() {
-        eligible = collect_ranked_candidates(tokens_dir, ranking_file, workspace, cap, false);
+        eligible =
+            collect_ranked_candidates(tokens_dir, ranking_file, workspace, cap, false, load_gate);
     }
     if eligible.is_empty() {
         return None;
@@ -248,8 +306,8 @@ fn stale_ranking_exclusions(ranking_file: &Path) -> HashSet<String> {
     match file_age_seconds(ranking_file) {
         Some(age) if age >= RANKING_FRESH_SECONDS => read_ranking(ranking_file)
             .into_iter()
-            .filter(|(_, status)| !is_healthy_status(status))
-            .map(|(name, _)| name)
+            .filter(|(_, status, _)| !is_healthy_status(status))
+            .map(|(name, _, _)| name)
             .collect(),
         _ => HashSet::new(),
     }
@@ -589,5 +647,119 @@ mod tests {
         fs::write(pool_dir(tmp.path()).join("a.token"), "  sk-ant\noat01\t-xyz  \n").unwrap();
         let key = read_token_file(&pool_dir(tmp.path()).join("a.token")).unwrap();
         assert_eq!(key, "sk-antoat01-xyz");
+    }
+
+    // ---- 5h load gate (issue #4195) ----------------------------------
+
+    #[test]
+    fn read_ranking_parses_optional_util_field() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ranking = tmp.path().join(".ranking");
+        // 3-field, legacy 2-field, and a malformed util (-> None, "unknown").
+        fs::write(&ranking, "a|available|0.70\nb|available\nc|available|bad\n").unwrap();
+        let rows = read_ranking(&ranking);
+        assert_eq!(rows[0], ("a".to_string(), "available".to_string(), Some(0.70)));
+        assert_eq!(rows[1], ("b".to_string(), "available".to_string(), None));
+        assert_eq!(rows[2], ("c".to_string(), "available".to_string(), None));
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_load_gate_env_and_default() {
+        std::env::remove_var("LOOM_TOKEN_5H_LOAD_GATE");
+        assert_eq!(resolve_load_gate(), DEFAULT_5H_LOAD_GATE);
+        std::env::set_var("LOOM_TOKEN_5H_LOAD_GATE", "0.5");
+        assert_eq!(resolve_load_gate(), 0.5);
+        // Unparseable -> default.
+        std::env::set_var("LOOM_TOKEN_5H_LOAD_GATE", "garbage");
+        assert_eq!(resolve_load_gate(), DEFAULT_5H_LOAD_GATE);
+        std::env::remove_var("LOOM_TOKEN_5H_LOAD_GATE");
+    }
+
+    #[test]
+    #[serial]
+    fn load_gate_excludes_loaded_account_in_preferred_pass() {
+        std::env::remove_var("LOOM_TOKEN_5H_LOAD_GATE");
+        std::env::remove_var("LOOM_TOKEN_SPREAD_TOP_N");
+        let tmp = make_pool(&["a", "b"]);
+        // `a` healthy but 90% 5h-loaded (>= 0.70 default gate); `b` light.
+        fs::write(pool_dir(tmp.path()).join(".ranking"), "a|available|0.90\nb|available|0.10\n")
+            .unwrap();
+        let mut rng = Rng::seeded(1);
+        for _ in 0..10 {
+            let sel = select_token(tmp.path(), Some(&mut rng)).unwrap();
+            assert_eq!(sel.name, "b");
+            assert_eq!(sel.mode, "ranked");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn load_gate_readmits_in_fallback_when_all_loaded() {
+        std::env::remove_var("LOOM_TOKEN_5H_LOAD_GATE");
+        std::env::remove_var("LOOM_TOKEN_SPREAD_TOP_N");
+        let tmp = make_pool(&["a", "b"]);
+        // Both over the gate -> fallback pass drops the gate; pool never
+        // hard-fails on load alone.
+        fs::write(pool_dir(tmp.path()).join(".ranking"), "a|available|0.95\nb|available|0.90\n")
+            .unwrap();
+        let mut rng = Rng::seeded(1);
+        let sel = select_token(tmp.path(), Some(&mut rng)).unwrap();
+        assert!(sel.name == "a" || sel.name == "b");
+        assert_eq!(sel.mode, "ranked");
+    }
+
+    #[test]
+    #[serial]
+    fn load_gate_unknown_util_is_never_gated() {
+        std::env::remove_var("LOOM_TOKEN_5H_LOAD_GATE");
+        std::env::remove_var("LOOM_TOKEN_SPREAD_TOP_N");
+        let tmp = make_pool(&["a", "b", "c"]);
+        // a: legacy 2-field (unknown); b: malformed util (unknown); c: loaded.
+        fs::write(
+            pool_dir(tmp.path()).join(".ranking"),
+            "a|available\nb|available|not-a-number\nc|available|0.99\n",
+        )
+        .unwrap();
+        let mut chosen = HashSet::new();
+        for _ in 0..10 {
+            let mut rng = Rng::seeded(1);
+            let sel = select_token(tmp.path(), Some(&mut rng)).unwrap();
+            assert_eq!(sel.mode, "ranked");
+            chosen.insert(sel.name);
+        }
+        // a and b (unknown) rotate; c (0.99 loaded) is excluded.
+        assert!(chosen.contains("a") && chosen.contains("b"));
+        assert!(!chosen.contains("c"));
+    }
+
+    #[test]
+    #[serial]
+    fn load_gate_env_override_lowers_threshold() {
+        std::env::remove_var("LOOM_TOKEN_SPREAD_TOP_N");
+        let tmp = make_pool(&["a", "b"]);
+        fs::write(pool_dir(tmp.path()).join(".ranking"), "a|available|0.50\nb|available|0.10\n")
+            .unwrap();
+        std::env::set_var("LOOM_TOKEN_5H_LOAD_GATE", "0.40");
+        let mut rng = Rng::seeded(1);
+        for _ in 0..10 {
+            let sel = select_token(tmp.path(), Some(&mut rng)).unwrap();
+            assert_eq!(sel.name, "b"); // `a` now over the lowered gate.
+        }
+        std::env::remove_var("LOOM_TOKEN_5H_LOAD_GATE");
+    }
+
+    #[test]
+    #[serial]
+    fn load_gate_backward_compatible_2field_ranking() {
+        std::env::remove_var("LOOM_TOKEN_5H_LOAD_GATE");
+        std::env::remove_var("LOOM_TOKEN_SPREAD_TOP_N");
+        let tmp = make_pool(&["a", "b"]);
+        // Pure legacy 2-field file still parses + selects unchanged.
+        fs::write(pool_dir(tmp.path()).join(".ranking"), "a|exhausted\nb|available\n").unwrap();
+        let mut rng = Rng::seeded(1);
+        let sel = select_token(tmp.path(), Some(&mut rng)).unwrap();
+        assert_eq!(sel.name, "b");
+        assert_eq!(sel.mode, "ranked");
     }
 }

--- a/loom-tools/src/loom_tools/tokens/check.py
+++ b/loom-tools/src/loom_tools/tokens/check.py
@@ -435,15 +435,31 @@ def build_report(results: Iterable[AccountResult]) -> ProbeReport:
     return ProbeReport(ranked_at=ranked_at, accounts=sorted_results)
 
 
-def format_ranking_lines(report: ProbeReport) -> str:
-    """Serialize a probe report to the selector's ``name|status`` format.
+def _ranking_line(name: str, status: str, util_5h: float | None) -> str:
+    """Format one ``.ranking`` line, emitting the optional 5h-utilization field.
 
-    This is the format ``select.py:_read_ranking`` consumes (pipe-delimited
-    ``name|status``, one account per line, already ordered by
-    :func:`build_report`). A trailing newline is included so the file ends
+    ``name|status|5h_util`` when the 5h utilization is known (issue #4195),
+    else the legacy ``name|status`` (backward compatible: a ``None`` utilization
+    is left unwritten rather than faked as ``0.0``). The float is fixed at 2
+    decimals so the ``check`` and ``monitor`` writers stay byte-identical with
+    the Rust port (``tokens_pool::check::ranking_line`` / ``monitor``).
+    """
+    if util_5h is None:
+        return f"{name}|{status}"
+    return f"{name}|{status}|{util_5h:.2f}"
+
+
+def format_ranking_lines(report: ProbeReport) -> str:
+    """Serialize a probe report to the selector's ``name|status|5h_util`` format.
+
+    This is the format ``select.py:_read_ranking`` consumes (pipe-delimited,
+    one account per line, already ordered by :func:`build_report`). The 5h
+    utilization is emitted as an optional third field when measured (issue
+    #4195); accounts without a measured 5h utilization keep the legacy 2-field
+    ``name|status`` form. A trailing newline is included so the file ends
     cleanly; an empty report yields an empty string.
     """
-    lines = [f"{a.name}|{a.status}" for a in report.accounts]
+    lines = [_ranking_line(a.name, a.status, a.s5h_utilization) for a in report.accounts]
     return "\n".join(lines) + ("\n" if lines else "")
 
 

--- a/loom-tools/src/loom_tools/tokens/monitor.py
+++ b/loom-tools/src/loom_tools/tokens/monitor.py
@@ -41,7 +41,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from loom_tools.tokens.check import _STATUS_RANK
+from loom_tools.tokens.check import _STATUS_RANK, _ranking_line
 
 logger = logging.getLogger(__name__)
 
@@ -287,12 +287,15 @@ def build_monitor_accounts(
 
 
 def format_ranking_lines(accounts: list[MonitorAccount]) -> str:
-    """Serialize ordered accounts to the selector's ``name|status`` format.
+    """Serialize ordered accounts to the selector's ``name|status|5h_util`` format.
 
-    This is the format ``select.py:_read_ranking`` consumes. A trailing
-    newline is included so the file ends cleanly.
+    This is the format ``select.py:_read_ranking`` consumes. The 5h utilization
+    is emitted as an optional third field when known (issue #4195); accounts
+    with no measured 5h utilization keep the legacy 2-field ``name|status``
+    form. Byte-identical with the probe writer (``check._ranking_line``) and the
+    Rust port. A trailing newline is included so the file ends cleanly.
     """
-    lines = [f"{a.name}|{a.status}" for a in accounts]
+    lines = [_ranking_line(a.name, a.status, a.util_5h) for a in accounts]
     return "\n".join(lines) + ("\n" if lines else "")
 
 

--- a/loom-tools/src/loom_tools/tokens/select.py
+++ b/loom-tools/src/loom_tools/tokens/select.py
@@ -68,6 +68,22 @@ EX_CONFIG = 78
 # historical behavior); a value <= 0 also means unbounded.
 _DEFAULT_SPREAD_TOP_N: int | None = None
 
+# Default 5h-window load threshold for the tier-1 *preferred* pass (issue #4195).
+# The account probe measures 5h-window utilization but upstream historically
+# discarded it at ranking-serialization time, so the load-blind rotation cursor
+# (#3909) happily dispatched into an account already near its 5h limit. We now
+# carry the 5h utilization as an optional third ranking field and add a soft
+# eligibility gate *on top of* the existing rotation-cursor spread: an account
+# at/above this fraction of its 5h window is excluded from the preferred pass and
+# readmitted in the fallback pass (so a fully-loaded pool still dispatches rather
+# than hard-failing on load alone). This is the fork-design reconciliation of
+# issue #4165 (Option A) — a load-aware gate layered on #3909, not the fork's
+# waterfall-fill replacement. Overridable via ``LOOM_TOKEN_5H_LOAD_GATE``
+# (following the ``LOOM_TOKEN_SPREAD_TOP_N`` precedent); a value > 1.0 disables
+# the gate. A missing/unparseable utilization is treated as *unknown* → never
+# gated (never coerced to 0.0-as-fact — see #4164 for that failure mode).
+_DEFAULT_5H_LOAD_GATE = 0.70
+
 # Ranking-status handling is an *allowlist of known-good statuses*, not a
 # denylist of known-bad ones (issue #3991). The account probe assigns one of
 # (see CLAUDE.md → token health probe): ``available`` (utilizations < 95%),
@@ -150,22 +166,42 @@ def _strip_comment(line: str) -> str:
     return line.strip()
 
 
-def _read_ranking(ranking_file: Path) -> Iterable[tuple[str, str]]:
-    """Yield (name, status) pairs from the ranking file.
+def _parse_util(field: str) -> float | None:
+    """Parse a ranking line's optional 5h-utilization field (issue #4195).
 
-    Format: ``name|status`` per line. Lines starting with ``#`` are skipped.
-    Malformed lines are skipped. ``status`` defaults to empty string.
+    An empty or unparseable field yields ``None`` ("unknown") — never coerced to
+    ``0.0``, so an unmeasured account is never load-gated (see #4164).
+    """
+    field = field.strip()
+    if not field:
+        return None
+    try:
+        return float(field)
+    except (TypeError, ValueError):
+        return None
+
+
+def _read_ranking(ranking_file: Path) -> Iterable[tuple[str, str, float | None]]:
+    """Yield (name, status, util_5h) triples from the ranking file.
+
+    Format: ``name|status|5h_util`` per line (issue #4195). The third field is
+    *optional* — a legacy ``name|status`` line yields ``util_5h=None``, so
+    existing 2-field ranking files parse unchanged (backward compatible). Lines
+    starting with ``#`` are skipped, as are malformed lines. ``status`` defaults
+    to empty string; an absent or unparseable utilization yields ``None``
+    ("unknown" — never load-gated).
     """
     try:
         for raw in ranking_file.read_text(encoding="utf-8").splitlines():
             stripped = _strip_comment(raw)
             if not stripped:
                 continue
-            parts = stripped.split("|", 1)
+            parts = stripped.split("|", 2)
             name = parts[0].strip()
             status = parts[1].strip() if len(parts) > 1 else ""
+            util = _parse_util(parts[2]) if len(parts) > 2 else None
             if name:
-                yield name, status
+                yield name, status, util
     except OSError:
         return
 
@@ -237,6 +273,24 @@ def _read_config_spread_top_n(workspace_path: Path) -> int | None:
     return value
 
 
+def _resolve_load_gate() -> float:
+    """Resolve the tier-1 5h-load threshold (issue #4195).
+
+    Precedence: ``LOOM_TOKEN_5H_LOAD_GATE`` env var (parsed as a float) → the
+    constant default ``_DEFAULT_5H_LOAD_GATE`` (0.70). An unset or unparseable
+    env value falls back to the default. Mirrors the ``select.rs``
+    ``resolve_load_gate`` so the two implementations gate identically. A
+    ``tokens.*`` config key can follow later if needed.
+    """
+    raw = os.environ.get("LOOM_TOKEN_5H_LOAD_GATE")
+    if raw is not None:
+        try:
+            return float(raw.strip())
+        except (TypeError, ValueError):
+            pass
+    return _DEFAULT_5H_LOAD_GATE
+
+
 def _try_ranking(
     tokens_dir: Path,
     ranking_file: Path,
@@ -276,16 +330,27 @@ def _try_ranking(
         return None
 
     cap = _resolve_spread_top_n(workspace_path)
+    load_gate = _resolve_load_gate()
 
     def _collect(*, healthy_only: bool) -> list[SelectedToken]:
         out: list[SelectedToken] = []
-        for name, status in _read_ranking(ranking_file):
+        for name, status, util in _read_ranking(ranking_file):
             # Hard-excluded in every pass: the probe flagged the account dead.
             if status in _TIER1_HARD_EXCLUDED:
                 continue
             # Preferred pass: allowlist — only positively-healthy statuses.
             # Fallback pass admits the rest (rate_limited / unknown statuses).
             if healthy_only and status not in _HEALTHY_STATUSES:
+                continue
+            # Load gate (issue #4195): the preferred pass additionally excludes
+            # accounts at/above the 5h-window load threshold, mirroring the
+            # rate_limited soft-exclusion. An unknown (unmeasured) utilization is
+            # never gated. The fallback pass drops the gate so a fully-loaded
+            # pool still dispatches rather than hard-failing on load alone. The
+            # rotation cursor then rotates across the load-eligible set, so no
+            # per-spawn "in-burst" bump is needed — the cursor already prevents
+            # intra-burst stacking by construction.
+            if healthy_only and util is not None and util >= load_gate:
                 continue
             token_file = tokens_dir / f"{name}.token"
             if not token_file.is_file():
@@ -342,7 +407,7 @@ def _stale_ranking_exclusions(ranking_file: Path) -> set[str]:
         return set()
     return {
         name
-        for name, status in _read_ranking(ranking_file)
+        for name, status, _util in _read_ranking(ranking_file)
         if status not in _HEALTHY_STATUSES
     }
 

--- a/loom-tools/tests/tokens/test_check.py
+++ b/loom-tools/tests/tokens/test_check.py
@@ -524,8 +524,9 @@ class TestSourceMonitor:
             )
         assert not post.called  # monitor path never probes
         text = (tokens_dir / ".ranking").read_text()
-        # pipe format, ordered by util_7d ascending (a before b)
-        assert text == "acct-a|available\nacct-b|available\n"
+        # pipe format, ordered by util_7d ascending (a before b); the 5h
+        # utilization is emitted as the optional third field (issue #4195).
+        assert text == "acct-a|available|0.10\nacct-b|available|0.10\n"
 
     def test_monitor_source_no_data_returns_empty_no_probe(
         self, tmp_path: Path, monkeypatch
@@ -622,9 +623,11 @@ class TestSourceMonitor:
                 tokens_dir, source="probe", write_ranking=True, stagger=False
             )
 
-        # Sanity: the probe wrote the selector's pipe format, not JSON.
+        # Sanity: the probe wrote the selector's pipe format, not JSON. The 5h
+        # utilization is the optional third field (issue #4195); _good_headers
+        # reports 5h=0.10 for both probes.
         assert (tokens_dir / ".ranking").read_text() == (
-            "acct-a|available\nacct-b|exhausted\n"
+            "acct-a|available|0.10\nacct-b|exhausted|0.10\n"
         )
 
         selected = select_token(workspace)

--- a/loom-tools/tests/tokens/test_monitor.py
+++ b/loom-tools/tests/tokens/test_monitor.py
@@ -328,7 +328,14 @@ class TestWriter:
             MonitorAccount("a", "available", 0.1, 0.2),
             MonitorAccount("b", "exhausted", 0.9, 0.9),
         ]
-        assert format_ranking_lines(accts) == "a|available\nb|exhausted\n"
+        # Third field is the 5h utilization (issue #4195), fixed at 2 decimals.
+        assert format_ranking_lines(accts) == "a|available|0.20\nb|exhausted|0.90\n"
+
+    def test_format_lines_omits_absent_5h_util(self) -> None:
+        # An unmeasured 5h utilization keeps the legacy 2-field form (issue
+        # #4195): never faked as 0.0, so the selector treats it as "unknown".
+        accts = [MonitorAccount("a", "available", 0.1, None)]
+        assert format_ranking_lines(accts) == "a|available\n"
 
     def test_empty_writes_empty(self) -> None:
         assert format_ranking_lines([]) == ""

--- a/loom-tools/tests/tokens/test_rust_conformance.py
+++ b/loom-tools/tests/tokens/test_rust_conformance.py
@@ -124,6 +124,78 @@ def test_select_ranked_tier_single_healthy_candidate_agrees(tmp_path):
     assert rust_sel["mode"] == py_sel.mode == "ranked"
 
 
+def test_select_ranked_tier_load_gate_agrees(tmp_path):
+    """Both selectors exclude a 5h-loaded account in the preferred pass (#4195).
+
+    A mixed-load 3-field ranking: `a` is healthy but 90% 5h-loaded (>= the 0.70
+    default gate), `b` is healthy and lightly loaded. The preferred pass leaves
+    exactly one eligible candidate (`b`), so the outcome is deterministic and
+    directly comparable across the two independent RNGs.
+    """
+    workspace = _write_pool(tmp_path, ["a", "b"])
+    (workspace / ".loom" / "tokens" / ".ranking").write_text(
+        "a|available|0.90\nb|available|0.10\n", encoding="utf-8"
+    )
+
+    py_sel = py_select_token(workspace)
+    result = _run_rust("select", "--workspace", str(workspace), "--no-key")
+    assert result.returncode == 0, result.stderr
+    rust_sel = json.loads(result.stdout)
+
+    assert rust_sel["name"] == py_sel.name == "b"
+    assert rust_sel["mode"] == py_sel.mode == "ranked"
+
+
+def test_select_ranked_tier_load_gate_fallback_agrees(tmp_path):
+    """When every account is over the gate, both readmit in the fallback (#4195).
+
+    Both accounts are 5h-loaded, so the fallback pass (gate dropped) is what
+    selects — the pool never hard-fails on load alone. Cap the rotation window
+    to N=1 (via the shared env both processes read) so both pick the first
+    eligible fallback candidate (`a`) deterministically.
+    """
+    workspace = _write_pool(tmp_path, ["a", "b"])
+    (workspace / ".loom" / "tokens" / ".ranking").write_text(
+        "a|available|0.95\nb|available|0.90\n", encoding="utf-8"
+    )
+    prev = os.environ.get("LOOM_TOKEN_SPREAD_TOP_N")
+    os.environ["LOOM_TOKEN_SPREAD_TOP_N"] = "1"
+    try:
+        py_sel = py_select_token(workspace)
+        result = _run_rust("select", "--workspace", str(workspace), "--no-key")
+    finally:
+        if prev is None:
+            os.environ.pop("LOOM_TOKEN_SPREAD_TOP_N", None)
+        else:
+            os.environ["LOOM_TOKEN_SPREAD_TOP_N"] = prev
+    assert result.returncode == 0, result.stderr
+    rust_sel = json.loads(result.stdout)
+
+    assert rust_sel["name"] == py_sel.name == "a"
+    assert rust_sel["mode"] == py_sel.mode == "ranked"
+
+
+def test_select_ranked_tier_unknown_util_not_gated_agrees(tmp_path):
+    """A legacy 2-field (unknown-util) line stays eligible in both (#4195).
+
+    `a` has no measured 5h utilization (2-field legacy line) -> unknown ->
+    never gated; `b` is 5h-loaded and excluded. The preferred pass leaves `a`
+    as the sole candidate, deterministic across both RNGs.
+    """
+    workspace = _write_pool(tmp_path, ["a", "b"])
+    (workspace / ".loom" / "tokens" / ".ranking").write_text(
+        "a|available\nb|available|0.99\n", encoding="utf-8"
+    )
+
+    py_sel = py_select_token(workspace)
+    result = _run_rust("select", "--workspace", str(workspace), "--no-key")
+    assert result.returncode == 0, result.stderr
+    rust_sel = json.loads(result.stdout)
+
+    assert rust_sel["name"] == py_sel.name == "a"
+    assert rust_sel["mode"] == py_sel.mode == "ranked"
+
+
 def test_select_bad_token_skipped_by_both(tmp_path):
     workspace = _write_pool(tmp_path, ["a", "b"])
     py_mark_bad(workspace, "a", "exhausted: 429")
@@ -385,7 +457,13 @@ def test_check_monitor_source_ranking_byte_identical(tmp_path):
         encoding="utf-8"
     )
     # Ordered by (status_rank, util_7d, util_5h): a (0.20) < b (0.80) < c (rl).
-    assert py_ranking == rust_ranking == "acct-a|available\nacct-b|available\nacct-c|rate_limited\n"
+    # The 5h utilization is emitted as the optional third field (issue #4195),
+    # byte-identical across both writers.
+    assert (
+        py_ranking
+        == rust_ranking
+        == "acct-a|available|0.10\nacct-b|available|0.10\nacct-c|rate_limited|0.90\n"
+    )
 
     # The Python selector consumes the Rust-written .ranking: it picks a
     # healthy (available) account, never the rate_limited one, via the ranked

--- a/loom-tools/tests/tokens/test_select.py
+++ b/loom-tools/tests/tokens/test_select.py
@@ -785,3 +785,121 @@ def test_shared_disabled_still_hard_fails(tmp_path, monkeypatch):
 
     with pytest.raises(EmptyTokenPoolError):
         select_token(repo)
+
+
+# ---------- 5h load gate (issue #4195) ----------
+
+
+def test_ranking_load_gate_excludes_loaded_account(tmp_path, monkeypatch):
+    """The preferred pass excludes an account at/above the 5h load threshold.
+
+    Issue #4195: `a` is healthy but 90% loaded on its 5h window (>= the 0.70
+    default gate), so it is skipped in favor of the lightly-loaded `b`.
+    """
+    monkeypatch.delenv("LOOM_TOKEN_5H_LOAD_GATE", raising=False)
+    monkeypatch.delenv("LOOM_TOKEN_SPREAD_TOP_N", raising=False)
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb"})
+    _write_ranking(workspace, ["a|available|0.90", "b|available|0.10"])
+    for seed in range(25):
+        sel = select_token(workspace, rng=random.Random(seed))
+        assert sel.name == "b"
+        assert sel.mode == "ranked"
+
+
+def test_ranking_load_gate_readmits_in_fallback_when_all_loaded(tmp_path, monkeypatch):
+    """When every account is 5h-loaded, the fallback pass readmits them.
+
+    The pool never hard-fails on load alone (issue #4195) — both accounts are
+    over the gate, so the fallback pass drops the gate and one is still chosen.
+    """
+    monkeypatch.delenv("LOOM_TOKEN_5H_LOAD_GATE", raising=False)
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb"})
+    _write_ranking(workspace, ["a|available|0.95", "b|available|0.90"])
+    sel = select_token(workspace, rng=random.Random(0))
+    assert sel.name in ("a", "b")
+    assert sel.mode == "ranked"
+
+
+def test_ranking_load_gate_unknown_util_never_gated(tmp_path, monkeypatch):
+    """A missing/unparseable 5h utilization is unknown -> never gated.
+
+    Issue #4195/#4164: an unmeasured account must not be treated as 0.0-loaded
+    *or* as over-threshold — a 2-field (legacy) line and a malformed util field
+    both parse to "unknown" and stay eligible in the preferred pass.
+    """
+    monkeypatch.delenv("LOOM_TOKEN_5H_LOAD_GATE", raising=False)
+    monkeypatch.delenv("LOOM_TOKEN_SPREAD_TOP_N", raising=False)
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb", "c": "kc"})
+    # a: legacy 2-field (unknown), b: malformed util (unknown), c: loaded.
+    _write_ranking(workspace, ["a|available", "b|available|not-a-number", "c|available|0.99"])
+    chosen: set[str] = set()
+    for seed in range(30):
+        sel = select_token(workspace, rng=random.Random(seed))
+        chosen.add(sel.name)
+        assert sel.mode == "ranked"
+    # a and b (unknown) are eligible; c (0.99 loaded) is excluded.
+    assert chosen == {"a", "b"}
+
+
+def test_ranking_load_gate_backward_compatible_2field(tmp_path, monkeypatch):
+    """Existing 2-field ranking files parse and select unchanged (issue #4195)."""
+    monkeypatch.delenv("LOOM_TOKEN_5H_LOAD_GATE", raising=False)
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb"})
+    _write_ranking(workspace, ["a|exhausted", "b|available"])
+    sel = select_token(workspace)
+    assert sel.name == "b"
+    assert sel.mode == "ranked"
+
+
+def test_ranking_load_gate_env_override_threshold(tmp_path, monkeypatch):
+    """LOOM_TOKEN_5H_LOAD_GATE overrides the default threshold (issue #4195)."""
+    monkeypatch.delenv("LOOM_TOKEN_SPREAD_TOP_N", raising=False)
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb"})
+    # a at 0.50: excluded only when the gate is lowered below 0.50.
+    _write_ranking(workspace, ["a|available|0.50", "b|available|0.10"])
+    monkeypatch.setenv("LOOM_TOKEN_5H_LOAD_GATE", "0.40")
+    for seed in range(25):
+        sel = select_token(workspace, rng=random.Random(seed))
+        assert sel.name == "b"  # a now over the lowered gate
+
+    # A gate above 1.0 disables gating entirely -> a is eligible again.
+    monkeypatch.setenv("LOOM_TOKEN_5H_LOAD_GATE", "2.0")
+    chosen = {
+        select_token(workspace, rng=random.Random(seed)).name for seed in range(50)
+    }
+    assert chosen == {"a", "b"}
+
+
+def test_ranking_load_gate_rotates_across_eligible_set(tmp_path, monkeypatch):
+    """The rotation cursor still spreads across the load-eligible set (issue #4195)."""
+    monkeypatch.delenv("LOOM_TOKEN_5H_LOAD_GATE", raising=False)
+    monkeypatch.delenv("LOOM_TOKEN_SPREAD_TOP_N", raising=False)
+    workspace = _make_workspace(
+        tmp_path, {"a": "ka", "b": "kb", "c": "kc", "d": "kd"},
+    )
+    # a and d are over the gate; b and c are the eligible set.
+    _write_ranking(
+        workspace,
+        ["a|available|0.80", "b|available|0.10", "c|available|0.20", "d|available|0.99"],
+    )
+    chosen: list[str] = []
+    for _ in range(10):
+        sel = select_token(workspace, rng=random.Random(0))
+        assert sel.mode == "ranked"
+        chosen.append(sel.name)
+    assert set(chosen) == {"b", "c"}
+
+
+def test_stale_ranking_load_gate_field_does_not_break_exclusions(tmp_path):
+    """A stale 3-field ranking still yields the #3894 advisory exclusions.
+
+    The load-gate third field must not disturb the stale-ranking exclusion path
+    (issue #4195 AC): the exhausted account is still excluded from lower tiers.
+    """
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb"})
+    _write_stale_ranking(
+        workspace, ["a|exhausted|0.99", "b|available|0.10"], age_secs=11 * 60
+    )
+    _write_allowlist(workspace, ["a", "b"])
+    sel = select_token(workspace, rng=random.Random(0))
+    assert sel.name == "b"  # stale exhausted `a` excluded from the allowlist tier


### PR DESCRIPTION
## Summary

Reconciles the gpeyton-fork's load-aware token selection proposal with upstream's existing rotation-cursor spread, per **Option A** of the curated decision in #4195: extend the `.ranking` format to carry each account's 5h-window utilization as an optional third field, and add a **soft eligibility gate** on top of the existing #3909 rotation cursor — *not* the fork's waterfall-fill replacement.

The account probe already measures 5h utilization but every ranking writer historically discarded it, so the load-blind rotation cursor happily dispatched into an account already near its 5h limit. This closes that gap while preserving #3909's even-drain rotation.

**Design source** (not cherry-picked — they patch a divergent JSON ranking format that does not exist upstream): fork commits `283de8e3` (waterfall fill) and `20961dd9` (5h-headroom spread). We deliberately take only the *load signal*, layered as a gate on the rotation cursor, because the cursor already prevents the intra-burst stacking that the fork's uncited "synthetic per-spawn bump" was needed to avoid.

Implemented in **both languages in the same PR** (required — the two are kept byte-identical by `test_rust_conformance.py`).

## Changes

- **Format**: `.ranking` lines are now `name|status|5h_util` (fraction, 2 decimals). The third field is optional — accounts with no measured 5h utilization keep the legacy 2-field form (never faked as `0.0`), and existing 2-field files parse unchanged.
- **Writers (all four)**: `check.py`/`monitor.py` and Rust `tokens_pool::check`/`tokens_pool::monitor` emit the field via a shared `ranking_line` helper.
- **Readers (both)**: `select.py:_read_ranking` and `select.rs:read_ranking` parse 2- or 3-field lines tolerantly; a missing/unparseable utilization → `None` ("unknown").
- **Gate**: the tier-1 preferred pass excludes accounts with `5h_util >= threshold`; the fallback pass drops the gate so a fully-loaded pool still dispatches. Threshold defaults to `0.70`, overridable via `LOOM_TOKEN_5H_LOAD_GATE` (`> 1.0` disables), mirrored in `select.py:_resolve_load_gate` / `select.rs:resolve_load_gate`.
- **Docs**: `.loom/docs/token-pool.md` documents the format extension, the gate, and the Option-A decision.

## Acceptance Criteria Verification

- [x] `.ranking` carries 5h utilization as an optional third field; all four writers emit it; existing 2-field files still parse (backward compatible) — verified by new writer round-trip tests + the conformance byte-identity assertion.
- [x] Tier-1 preferred pass excludes accounts at/above the threshold; fallback readmits them — identical in `select.py`/`select.rs` (behavior-agreement tests in the conformance suite).
- [x] Missing/unparseable utilization → unknown → NOT gated (never fake 0.0) — in both languages (`load_gate_unknown_util_*` tests).
- [x] Rotation-cursor semantics (#3909) unchanged for the eligible set; `spreadTopN` cap still applies — `load_gate_rotates_across_eligible_set` + existing spread tests green.
- [x] Stale-ranking advisory path (#3894) unaffected by the format change — `test_stale_ranking_load_gate_field_does_not_break_exclusions` + existing stale tests green.
- [x] `test_rust_conformance.py` fully green (20 passed): byte-identical writer output + mixed-load `test_select_*` behavior-agreement.
- [x] PR records the Option A decision and links the two fork commits as the design source (above).

## Test Plan

- `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/` — **341 passed**, plus `test_rust_conformance.py` **20 passed** (run against the built `loom-daemon` binary).
- `cargo test tokens_pool::` — all `tokens_pool::{select,check,monitor}` tests green, including the new `load_gate_*`, `read_ranking_parses_optional_util_field`, `resolve_load_gate_env_and_default`, and `format_ranking_lines_emits_5h_util_third_field` cases. `cargo clippy --lib` clean, `cargo fmt` applied.
- Note: `tokens_pool::bootstrap::tests` show a pre-existing env-race flake (the failing test name changes run-to-run; a clean run is 169 passed / 0 failed) in a module this PR does not touch.

Closes #4195

🤖 Generated with [Claude Code](https://claude.com/claude-code)