### PR TITLE
feat(fleet-comms): Bash socket helper so role subagents can reach safehouse (#4199)

### DIFF
--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -870,9 +870,12 @@ If the `safehouse_send` / `safehouse_read` MCP tools are present in this
 session, post sparingly to the fleet room: one line on claim ("starting issue
 #N: `<title>`"), one line on PR creation, and any *notable* mid-task finding
 (surprising discovery, a concern worth human eyes) — not routine progress. A
-genuine blocker gets `type: handoff`. If the tools are absent, proceed exactly
-as above — this is normal, not an error. Full etiquette (detection, threading,
-what NOT to do): `.loom/docs/fleet-comms.md`.
+genuine blocker gets `type: handoff`. If the MCP tools are absent (they are for
+this subagent's tool allowlist), fall back to
+`.loom/scripts/fleet-send.sh --task-id <repo>_<N> --type task --body "<line>"`,
+which exits 0 silently when the room is unreachable. If neither resolves,
+proceed exactly as above — this is normal, not an error. Full etiquette
+(detection, threading, what NOT to do): `.loom/docs/fleet-comms.md`.
 
 ## Terminal Probe Protocol
 

--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -815,8 +815,11 @@ Reviewer                    Fixer                     Reviewer
 
 If the `safehouse_send` / `safehouse_read` MCP tools are present in this
 session, post one line on what you fixed after pushing. A genuine blocker
-(e.g. feedback you cannot address) gets `type: handoff`. If the tools are
-absent, proceed exactly as above — this is normal, not an error. Full
+(e.g. feedback you cannot address) gets `type: handoff`. If the MCP tools are
+absent (they are for this subagent's tool allowlist), fall back to
+`.loom/scripts/fleet-send.sh --task-id <repo>_<N> --type task --body "<line>"`,
+which exits 0 silently when the room is unreachable. If neither resolves,
+proceed exactly as above — this is normal, not an error. Full
 etiquette: `.loom/docs/fleet-comms.md`.
 
 ## Terminal Probe Protocol

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -1353,8 +1353,11 @@ EOF
 If the `safehouse_send` / `safehouse_read` MCP tools are present in this
 session, post one line with your verdict summary (approve / changes-requested
 + one-line why) — not the full review comment, that's what `gh pr comment` is
-for. A genuine blocker gets `type: handoff`. If the tools are absent, proceed
-exactly as above — this is normal, not an error. Full etiquette: `.loom/docs/fleet-comms.md`.
+for. A genuine blocker gets `type: handoff`. If the MCP tools are absent (they
+are for this subagent's tool allowlist), fall back to
+`.loom/scripts/fleet-send.sh --task-id <repo>_<N> --type task --body "<line>"`,
+which exits 0 silently when the room is unreachable. If neither resolves,
+proceed exactly as above — this is normal, not an error. Full etiquette: `.loom/docs/fleet-comms.md`.
 
 ## Terminal Probe Protocol
 

--- a/defaults/docs/fleet-comms.md
+++ b/defaults/docs/fleet-comms.md
@@ -14,20 +14,34 @@ remains the sole source of truth (see "What NOT to do" below).
 > `defaults/.loom/docs/`) — see `defaults/docs/runtime-adapters.md` for the same
 > convention spelled out in detail.
 
-## 1. Detection — the tools are optional, always
+## 1. Detection — the room is optional, always
 
-Safehouse MCP injection is conditional (config-gated, host-dependent). A role
-session may or may not have `safehouse_send` / `safehouse_read` available —
-**do not assume either way**. This is the same degradation contract documented
-in `safehouse.md`, extended to worker behavior:
+Safehouse posting is conditional (config-gated, host-dependent). A role session
+may or may not be able to reach the room — **do not assume either way**. There
+are two delivery paths, tried in order; the same degradation contract from
+`safehouse.md` applies to both:
 
-- **If the tools are present**: use them per the guidance below.
-- **If the tools are absent**: proceed exactly as you do today. This is the
-  normal case for most sessions, not an error condition.
-- **Never fail, retry, stall, or comment on their absence.** No tool-presence
-  check should ever block, slow, or change the outcome of a role's normal
-  work. Treat a missing `safehouse_send` the same way you'd treat a missing
-  optional dependency — silently unavailable, nothing to fix.
+1. **MCP tools (`safehouse_send` / `safehouse_read`)** — present when
+   `spawn-claude.sh` injected the safehouse MCP server *and* your runtime/role
+   exposes MCP tools. Prefer these when available.
+2. **Bash helper (`.loom/scripts/fleet-send.sh`)** — the fallback for roles
+   whose tool allowlists exclude MCP tools. Lifecycle role subagents
+   (`loom-builder` / `loom-judge` / `loom-doctor`) pin their tools to
+   Read/Glob/Grep/Bash(/Write/Edit) with no MCP tools, so the injected
+   `safehouse_send` is invisible to them — but they all have Bash. The helper
+   resolves the socket/persona from `$SAFEHOUSED_SOCKET` + `$SAFEHOUSE_PERSONA`
+   (exported into the session by `spawn-claude.sh`) and is a thin JSON-lines
+   client for the same wire protocol. It posts only (no read op yet).
+
+- **If a path is available**: use it per the guidance below (MCP first, then the
+  helper).
+- **If neither resolves**: proceed exactly as you do today. This is the normal
+  case for most sessions, not an error condition. `fleet-send.sh` itself exits 0
+  silently when no socket/persona is set, so an unconditional call is safe.
+- **Never fail, retry, stall, or comment on the room's absence.** No presence
+  check should ever block, slow, or change the outcome of a role's normal work.
+  Treat an unreachable room the same way you'd treat a missing optional
+  dependency — silently unavailable, nothing to fix.
 
 ## 2. When to post (sparingly)
 
@@ -51,18 +65,30 @@ separate issue.
 
 ## 3. How to post
 
+Via the MCP tool (when present):
+
 ```
 safehouse_send(
-  task_id: "<issue number>",   # threads with the daemon's own narration for the same issue
+  task_id: "<repo>_<issue>",   # threads with the daemon's own narration for the same issue
   to: "*",                      # broadcast
   type: "task" | "handoff" | "chat",
   body: "<one concise line>"
 )
 ```
 
-- **`task_id`**: always the bare issue number as a string, so your message
-  threads alongside the daemon's phase narration for that issue (see the
-  envelope table in `safehouse.md`).
+Via the Bash helper (the fallback for roles without MCP tools):
+
+```
+.loom/scripts/fleet-send.sh --task-id "<repo>_<issue>" --type task --body "<one concise line>"
+```
+
+The helper defaults `to` to `"*"`, reads persona/socket from the session env,
+and exits 0 silently when the room is unreachable — call it unconditionally.
+
+- **`task_id`**: the repo-qualified `<repo>_<issue>` form the daemon narrates on
+  (post-#4224 — e.g. `loom_4199`, the workspace-root basename plus the issue
+  number), so your message threads alongside the daemon's phase narration for
+  that issue (see the envelope table in `safehouse.md`).
 - **`to`**: `"*"` (broadcast) — this is a shared room, not a DM.
 - **`type`**:
   - `task` — routine, in-band progress (claim / PR-created lines).

--- a/defaults/scripts/fleet-send.sh
+++ b/defaults/scripts/fleet-send.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# fleet-send.sh — post ONE safehouse envelope over the AF_UNIX socket, for
+# lifecycle role subagents (Builder / Judge / Doctor) whose Claude-Code tool
+# allowlists exclude MCP tools and therefore can't reach the session-injected
+# `safehouse_send` MCP tool (issue #4199, phase 2 of #4196 / #3997).
+#
+# It is a thin JSON-lines client mirroring the daemon's reference implementation
+# (loom-daemon/src/safehouse.rs: `hello`, `build_send_request`): connect, send
+# the mandatory `hello` handshake, then one `send` request.
+#
+# HARD degradation contract — this helper MUST NEVER block, stall, or fail a
+# role. Absent env vars, an unresolvable socket, an invalid argument, or any
+# connect/hello/send failure ⇒ **exit 0 SILENTLY** (no stdout, no stderr).
+# Treat "posted" as best-effort; the room is optional, the role's work is not.
+#
+# Usage:
+#   fleet-send.sh --task-id <id> --type chat|task|handoff|ack \
+#                 --body <text> [--to <persona|*>] [--room <name>]
+#
+# Resolution:
+#   socket  = $SAFEHOUSED_SOCKET  (fallback $LOOM_SAFEHOUSE_SOCKET)
+#   persona = $SAFEHOUSE_PERSONA
+#
+# Both are exported into the worker session by spawn-claude.sh alongside the
+# safehouse MCP injection; a plain shell without them is the common case and
+# exits 0. `task_id` should be the repo-qualified form the daemon narrates on
+# (`<repo>_<issue>`, e.g. `loom_4199`, post-#4224) so role posts thread with the
+# daemon's dispatch narration; the helper only enforces the `[A-Za-z0-9_]`
+# charset.
+
+# Deliberately NOT `set -e` — every failure path must fall through to exit 0.
+set -u
+
+# Any unexpected error, signal, or EXIT ⇒ silent success. Belt-and-suspenders
+# on top of the explicit `exit 0`s below.
+trap 'exit 0' ERR
+trap 'exit 0' EXIT
+
+# --- Parse args -------------------------------------------------------------
+_task_id=""
+_type=""
+_body=""
+_to="*"
+_room=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --task-id) _task_id="${2:-}"; shift 2 || exit 0 ;;
+        --task-id=*) _task_id="${1#*=}"; shift ;;
+        --type) _type="${2:-}"; shift 2 || exit 0 ;;
+        --type=*) _type="${1#*=}"; shift ;;
+        --body) _body="${2:-}"; shift 2 || exit 0 ;;
+        --body=*) _body="${1#*=}"; shift ;;
+        --to) _to="${2:-}"; shift 2 || exit 0 ;;
+        --to=*) _to="${1#*=}"; shift ;;
+        --room) _room="${2:-}"; shift 2 || exit 0 ;;
+        --room=*) _room="${1#*=}"; shift ;;
+        *) shift ;; # ignore unknown args — never fail a role over a typo
+    esac
+done
+
+# --- Resolve socket + persona (silent no-op when absent) --------------------
+_socket="${SAFEHOUSED_SOCKET:-${LOOM_SAFEHOUSE_SOCKET:-}}"
+_persona="${SAFEHOUSE_PERSONA:-}"
+
+[[ -z "$_socket" || -z "$_persona" ]] && exit 0
+[[ -z "$_body" ]] && exit 0
+
+# --- Validate BEFORE opening the socket (matches safehouse.rs) --------------
+# `type` must be one of the closed envelope-v1 enum.
+case "$_type" in
+    chat | task | handoff | ack) ;;
+    *) exit 0 ;; # invalid type ⇒ reject locally, no socket write
+esac
+
+# `task_id`, when present, must be [A-Za-z0-9_].
+if [[ -n "$_task_id" && "$_task_id" =~ [^A-Za-z0-9_] ]]; then
+    exit 0
+fi
+
+# --- Send over the socket (best-effort; python does the AF_UNIX I/O) --------
+SAFEHOUSE_FS_SOCKET="$_socket" \
+    SAFEHOUSE_FS_PERSONA="$_persona" \
+    SAFEHOUSE_FS_TASK_ID="$_task_id" \
+    SAFEHOUSE_FS_TYPE="$_type" \
+    SAFEHOUSE_FS_BODY="$_body" \
+    SAFEHOUSE_FS_TO="$_to" \
+    SAFEHOUSE_FS_ROOM="$_room" \
+    "${LOOM_PYTHON:-python3}" - <<'PY' 2>/dev/null || exit 0
+import json, os, socket, sys
+
+sock_path = os.environ.get("SAFEHOUSE_FS_SOCKET", "")
+persona = os.environ.get("SAFEHOUSE_FS_PERSONA", "")
+task_id = os.environ.get("SAFEHOUSE_FS_TASK_ID", "")
+kind = os.environ.get("SAFEHOUSE_FS_TYPE", "")
+body = os.environ.get("SAFEHOUSE_FS_BODY", "")
+to = os.environ.get("SAFEHOUSE_FS_TO", "*") or "*"
+room = os.environ.get("SAFEHOUSE_FS_ROOM", "")
+
+ENVELOPE_VERSION = 1
+
+
+def normalize_to(value):
+    # "*" and @matrix-ids pass through; a persona is lowercased and hyphens
+    # folded to underscores (the wire form), mirroring safehouse.rs.
+    if value == "*" or value.startswith("@"):
+        return value
+    return value.lower().replace("-", "_")
+
+
+def read_reply(reader):
+    # Skip interleaved async push lines (they carry an `event` key and no `id`)
+    # and return the first genuine reply object, or None on EOF/timeout.
+    for line in reader:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except Exception:
+            continue
+        if isinstance(msg, dict) and "event" in msg and "id" not in msg:
+            continue
+        return msg
+    return None
+
+
+try:
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.settimeout(5.0)
+    s.connect(sock_path)
+except Exception:
+    sys.exit(0)
+
+try:
+    reader = s.makefile("r", encoding="utf-8")
+
+    def write_line(obj):
+        s.sendall((json.dumps(obj) + "\n").encode("utf-8"))
+
+    # Mandatory hello handshake.
+    write_line({"id": 0, "op": "hello", "persona": persona})
+    reply = read_reply(reader)
+    if not (isinstance(reply, dict) and reply.get("ok") is True):
+        sys.exit(0)
+
+    # send request (id=1). Emit `v:1` and omit task_id/room when absent, exactly
+    # like build_send_request.
+    req = {
+        "id": 1,
+        "op": "send",
+        "v": ENVELOPE_VERSION,
+        "to": normalize_to(to),
+        "type": kind,
+        "body": body,
+    }
+    if task_id:
+        req["task_id"] = task_id
+    if room:
+        req["room"] = room
+    write_line(req)
+    # Best-effort: read the send reply so safehoused processes the line before
+    # we close, but never fail the role on its content.
+    read_reply(reader)
+except Exception:
+    sys.exit(0)
+finally:
+    try:
+        s.close()
+    except Exception:
+        pass
+
+sys.exit(0)
+PY
+
+exit 0

--- a/defaults/scripts/spawn-claude.sh
+++ b/defaults/scripts/spawn-claude.sh
@@ -405,6 +405,21 @@ if [[ -f "$_mcp_config_lib" ]]; then
         _sh_persona="$(loom_mcp_pick_persona \
             "${LOOM_SWEEP_CLAIM_OWNED:-}" "$_sh_pool" "$_sh_fallback")"
 
+        # Export persona + socket into the SESSION process environment — not
+        # only into the injected MCP config file's server env — so Bash-tool
+        # helpers can reach safehoused. Lifecycle role subagents (loom-builder /
+        # loom-judge / loom-doctor) pin their tool allowlists to Read/Glob/Grep/
+        # Bash(/Write/Edit) with no MCP tools, so the injected `safehouse_send`
+        # tool is invisible to them; `fleet-send.sh` (Bash) is their path to the
+        # room and it resolves the socket/persona from these env vars (#4199).
+        # Only the socket path is exported (no token or key). Guard on a
+        # resolvable socket — with none there is nothing to connect to, and this
+        # is independent of whether the safehouse-mcp launch command is present.
+        if [[ -n "$_sh_socket" ]]; then
+            export SAFEHOUSE_PERSONA="$_sh_persona"
+            export SAFEHOUSED_SOCKET="$_sh_socket"
+        fi
+
         if [[ -z "$_sh_socket" ]]; then
             log_warn "spawn-claude: safehouse enabled but no socket resolves (safehouse.socket / \$LOOM_SAFEHOUSE_SOCKET / \$SAFEHOUSED_SOCKET); skipping safehouse MCP injection (loom MCP unaffected)."
         elif ! command -v "$_sh_command" >/dev/null 2>&1; then

--- a/defaults/scripts/tests/test-fleet-send.sh
+++ b/defaults/scripts/tests/test-fleet-send.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# test-fleet-send.sh — Tests for the safehouse Bash fleet-comms client
+# (issue #4199, phase 2 of #4196 / #3997).
+#
+# fleet-send.sh is the Bash fallback that lifecycle role subagents (Builder /
+# Judge / Doctor) use to post to the safehouse room, since their tool allowlists
+# exclude the injected `safehouse_send` MCP tool. Its contract is HARD
+# degradation: never block or fail a role.
+#
+# Covers:
+#   a. No SAFEHOUSED_SOCKET / SAFEHOUSE_PERSONA env ⇒ exit 0, zero output.
+#   b. Env set but the socket path is absent (connect fails) ⇒ exit 0.
+#   c. Happy path against a mock AF_UNIX server: the server receives `hello`
+#      (with the right persona) then `send` (with the right type/task_id/to/body).
+#   d. Invalid `--type` ⇒ rejected locally with NO socket write, exit 0.
+#
+# Style matches test-mcp-config.sh — plain bash, hand-rolled assertions.
+# Bats is NOT used in this repository.
+#
+# Usage:
+#   ./.loom/scripts/tests/test-fleet-send.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FLEET_SEND="$SCRIPTS_DIR/fleet-send.sh"
+PY="${LOOM_PYTHON:-python3}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: $1"
+}
+fail() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: $1"
+    [[ -n "${2:-}" ]] && echo "    $2"
+}
+
+assert_eq() {
+    if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3" "expected '$1', got '$2'"; fi
+}
+assert_contains() {
+    if [[ "$2" == *"$1"* ]]; then pass "$3"; else fail "$3" "expected substring '$1' in '$2'"; fi
+}
+assert_not_contains() {
+    if [[ "$2" != *"$1"* ]]; then pass "$3"; else fail "$3" "unexpected substring '$1' in '$2'"; fi
+}
+
+# Isolate every invocation from the ambient operator environment.
+unset SAFEHOUSED_SOCKET LOOM_SAFEHOUSE_SOCKET SAFEHOUSE_PERSONA 2>/dev/null || true
+
+if ! command -v "$PY" >/dev/null 2>&1; then
+    echo -e "  ${YELLOW}SKIP${NC}: python3 not available; fleet-send.sh tests need it"
+    exit 0
+fi
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# Mock AF_UNIX safehoused: accept one connection, reply ok to hello + send, and
+# record every received line to $2. Times out (writing an empty record) if no
+# client ever connects — used to prove the "no socket write" path in test (d).
+MOCK_PY="$TMPDIR_TEST/mock-safehoused.py"
+cat >"$MOCK_PY" <<'PY'
+import json, os, socket, sys
+
+sock_path = sys.argv[1]
+record = sys.argv[2]
+accept_timeout = float(os.environ.get("MOCK_ACCEPT_TIMEOUT", "3"))
+
+if os.path.exists(sock_path):
+    os.unlink(sock_path)
+
+srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+srv.bind(sock_path)
+srv.listen(1)
+srv.settimeout(accept_timeout)
+
+received = []
+try:
+    conn, _ = srv.accept()
+except socket.timeout:
+    with open(record, "w") as f:
+        pass  # empty record: no client connected
+    srv.close()
+    sys.exit(0)
+
+conn.settimeout(3.0)
+reader = conn.makefile("r", encoding="utf-8")
+try:
+    for line in reader:
+        line = line.strip()
+        if not line:
+            continue
+        received.append(line)
+        try:
+            msg = json.loads(line)
+        except Exception:
+            continue
+        op = msg.get("op")
+        if op == "hello":
+            conn.sendall((json.dumps({"id": 0, "ok": True}) + "\n").encode("utf-8"))
+        elif op == "send":
+            conn.sendall(
+                (json.dumps({"id": msg.get("id", 1), "ok": True}) + "\n").encode("utf-8")
+            )
+            break
+finally:
+    with open(record, "w") as f:
+        f.write("\n".join(received))
+    conn.close()
+    srv.close()
+    if os.path.exists(sock_path):
+        try:
+            os.unlink(sock_path)
+        except OSError:
+            pass
+PY
+
+# start_mock <sockpath> <recordfile> — launch the mock, wait for it to bind.
+MOCK_PID=""
+start_mock() {
+    local sock="$1" rec="$2"
+    "$PY" "$MOCK_PY" "$sock" "$rec" &
+    MOCK_PID=$!
+    local i=0
+    while [[ ! -S "$sock" && $i -lt 50 ]]; do
+        sleep 0.05
+        i=$((i + 1))
+    done
+}
+
+echo "============================================================"
+echo "fleet-send.sh degradation + wire tests"
+echo "============================================================"
+
+# ---------------------------------------------------------------------------
+# (a) No env at all ⇒ exit 0, zero output.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- (a) no SAFEHOUSED_SOCKET / SAFEHOUSE_PERSONA --"
+out_a="$(env -u SAFEHOUSED_SOCKET -u LOOM_SAFEHOUSE_SOCKET -u SAFEHOUSE_PERSONA \
+    bash "$FLEET_SEND" --task-id loom_4199 --type task --body "hi" 2>&1)"
+rc_a=$?
+assert_eq "0" "$rc_a" "(a) exits 0 with no env"
+assert_eq "" "$out_a" "(a) produces zero output with no env"
+
+# ---------------------------------------------------------------------------
+# (b) Env set but the socket path does not exist ⇒ exit 0, zero output.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- (b) env set, socket path absent --"
+missing_sock="$TMPDIR_TEST/does-not-exist.sock"
+out_b="$(SAFEHOUSED_SOCKET="$missing_sock" SAFEHOUSE_PERSONA="loom_builder_1" \
+    bash "$FLEET_SEND" --task-id loom_4199 --type task --body "hi" 2>&1)"
+rc_b=$?
+assert_eq "0" "$rc_b" "(b) exits 0 when socket path is absent"
+assert_eq "" "$out_b" "(b) produces zero output when socket is absent"
+
+# ---------------------------------------------------------------------------
+# (c) Happy path against a mock AF_UNIX server.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- (c) mock server receives hello then send --"
+sock_c="$TMPDIR_TEST/c.sock"
+rec_c="$TMPDIR_TEST/c.record"
+start_mock "$sock_c" "$rec_c"
+if [[ -S "$sock_c" ]]; then
+    SAFEHOUSED_SOCKET="$sock_c" SAFEHOUSE_PERSONA="loom_builder_5" \
+        bash "$FLEET_SEND" --task-id loom_4199 --type handoff \
+        --body "starting issue 4199" --to "*"
+    rc_c=$?
+    wait "$MOCK_PID" 2>/dev/null || true
+    record_c="$(cat "$rec_c" 2>/dev/null || true)"
+    assert_eq "0" "$rc_c" "(c) exits 0 on success"
+    assert_contains '"op"' "$record_c" "(c) server received at least one request"
+    assert_contains 'hello' "$record_c" "(c) server received a hello request"
+    assert_contains 'loom_builder_5' "$record_c" "(c) hello carries the resolved persona"
+    assert_contains 'send' "$record_c" "(c) server received a send request"
+    assert_contains 'handoff' "$record_c" "(c) send carries the requested type"
+    assert_contains 'loom_4199' "$record_c" "(c) send carries the task_id"
+    assert_contains 'starting issue 4199' "$record_c" "(c) send carries the body"
+    assert_contains '"to": "*"' "$record_c" "(c) send carries to=* (broadcast)"
+    # Ensure hello precedes send on the wire.
+    hello_idx="$(printf '%s\n' "$record_c" | grep -n hello | head -1 | cut -d: -f1)"
+    send_idx="$(printf '%s\n' "$record_c" | grep -n '"op": "send"' | head -1 | cut -d: -f1)"
+    if [[ -n "$hello_idx" && -n "$send_idx" && "$hello_idx" -lt "$send_idx" ]]; then
+        pass "(c) hello precedes send"
+    else
+        fail "(c) hello must precede send" "hello@$hello_idx send@$send_idx"
+    fi
+else
+    fail "(c) mock server failed to bind its socket"
+fi
+
+# ---------------------------------------------------------------------------
+# (d) Invalid --type ⇒ rejected locally, NO socket write, exit 0.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- (d) invalid type rejected without a socket write --"
+sock_d="$TMPDIR_TEST/d.sock"
+rec_d="$TMPDIR_TEST/d.record"
+MOCK_ACCEPT_TIMEOUT=1 start_mock "$sock_d" "$rec_d"
+if [[ -S "$sock_d" ]]; then
+    out_d="$(SAFEHOUSED_SOCKET="$sock_d" SAFEHOUSE_PERSONA="loom_builder_5" \
+        bash "$FLEET_SEND" --task-id loom_4199 --type bogus --body "nope" 2>&1)"
+    rc_d=$?
+    wait "$MOCK_PID" 2>/dev/null || true
+    record_d="$(cat "$rec_d" 2>/dev/null || true)"
+    assert_eq "0" "$rc_d" "(d) exits 0 on invalid type"
+    assert_eq "" "$out_d" "(d) produces zero output on invalid type"
+    assert_not_contains "hello" "$record_d" "(d) no hello reached the socket (no write)"
+    assert_eq "" "$record_d" "(d) mock recorded nothing (no connection)"
+else
+    fail "(d) mock server failed to bind its socket"
+fi
+
+# ---------------------------------------------------------------------------
+# (d2) Invalid task_id (charset) ⇒ rejected locally, exit 0.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- (d2) invalid task_id charset rejected without a socket write --"
+sock_e="$TMPDIR_TEST/e.sock"
+rec_e="$TMPDIR_TEST/e.record"
+MOCK_ACCEPT_TIMEOUT=1 start_mock "$sock_e" "$rec_e"
+if [[ -S "$sock_e" ]]; then
+    out_e="$(SAFEHOUSED_SOCKET="$sock_e" SAFEHOUSE_PERSONA="loom_builder_5" \
+        bash "$FLEET_SEND" --task-id "loom/4199 bad" --type task --body "nope" 2>&1)"
+    rc_e=$?
+    wait "$MOCK_PID" 2>/dev/null || true
+    record_e="$(cat "$rec_e" 2>/dev/null || true)"
+    assert_eq "0" "$rc_e" "(d2) exits 0 on invalid task_id"
+    assert_eq "" "$out_e" "(d2) produces zero output on invalid task_id"
+    assert_eq "" "$record_e" "(d2) mock recorded nothing (no connection)"
+else
+    fail "(d2) mock server failed to bind its socket"
+fi
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo "========================================"
+echo "Test Results:"
+echo "  Total:  $TESTS_RUN"
+echo -e "  ${GREEN}Passed: $TESTS_PASSED${NC}"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo -e "  ${RED}Failed: $TESTS_FAILED${NC}"
+    exit 1
+fi
+echo -e "  ${GREEN}All tests passed!${NC}"


### PR DESCRIPTION
Closes #4199

## What & why

The safehouse MCP injection in `spawn-claude.sh` works at the session level, but lifecycle role subagents (`loom-builder`, `loom-judge`, `loom-doctor`) pin their Claude-Code tool allowlists to Read/Glob/Grep/Bash(/Write/Edit) with **no MCP tools** — so the injected `safehouse_send` tool is invisible to exactly the roles fleet-comms (#4197) targets. This implements the curated **Option B**: a Bash socket helper, so every current and future role/runtime reaches the room without widening any tool allowlist.

## Changes

- **`defaults/scripts/fleet-send.sh`** (new): thin JSON-lines client over the AF_UNIX socket at `$SAFEHOUSED_SOCKET` (fallback `$LOOM_SAFEHOUSE_SOCKET`), persona from `$SAFEHOUSE_PERSONA`. Sends the mandatory `hello` handshake then a `send` request, mirroring `loom-daemon/src/safehouse.rs` (`hello`, `build_send_request`). Validates the closed type enum `{chat,task,handoff,ack}` and the `[A-Za-z0-9_]` `task_id` charset **before** any socket write. Hard degradation contract: absent env, unresolvable socket, invalid arg, or any connect/hello/send failure ⇒ **exit 0 silently**. Uses a `python3` stdlib heredoc (matching `lib/mcp-config.sh`'s `${LOOM_PYTHON:-python3}` convention) with a 5s socket timeout so it can never hang.
- **`defaults/scripts/spawn-claude.sh`**: export `SAFEHOUSE_PERSONA` + `SAFEHOUSED_SOCKET` into the session **process env** (previously only written into the injected MCP config file's server env), gated on a resolvable socket. Bash tool calls — including inside subagents — inherit session env, so this is what lets `fleet-send.sh` find them.
- **`defaults/docs/fleet-comms.md`**: §1 Detection rewritten to document two delivery paths (MCP tools first, Bash helper fallback, silent when neither resolves); §3 adds the helper invocation form and corrects the `task_id` guidance to the post-#4224 repo-qualified `<repo>_<issue>` form.
- **`defaults/.claude/commands/loom/{builder,judge,doctor}.md`** (the symlink targets of `defaults/roles/*.md`): one terse line each pointing at the helper fallback; full etiquette stays in fleet-comms.md.
- **`defaults/scripts/tests/test-fleet-send.sh`** (new): 21 assertions — (a) no env ⇒ exit 0, zero output; (b) env set but socket absent ⇒ exit 0; (c) mock AF_UNIX server receives `hello` (correct persona) then `send` (correct type/task_id/to/body), hello-before-send ordering asserted; (d) invalid `type` and (d2) invalid `task_id` rejected locally with **no socket write**, exit 0.

## Deferred

`fleet-check.sh` is deferred — the `check`/read op is undocumented in this repo (it lives in external `rjwalters/safehouse`) and the acceptance criteria only require posting via `fleet-send.sh`.

## Out of scope (unchanged)

`defaults/.claude/agents/loom-*.md` tool allowlists (Option A, rejected); any label/lifecycle behavior; the external safehouse repo.

## Testing

- `defaults/scripts/tests/test-fleet-send.sh` — 21/21 pass.
- `shellcheck -x` clean on `fleet-send.sh`, `test-fleet-send.sh`, and `spawn-claude.sh`.
- `test-spawn-claude.sh` has a **pre-existing** environmental hang (reproduced identically on the unmodified `main` copy via a SIGALRM harness; all assertions PASS up to the hang, zero FAILs on both) — unrelated to this change, which is a guarded additive env export inside the safehouse-enabled block.
- AC 1 (live post from a Builder inside a daemon-dispatched sweep on a provisioned host) is a manual/runtime check that can't run in CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
