### PR TITLE
fix(daemon): surface live-locked-but-unregistered sweeps in status

### DIFF
--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1122,9 +1122,18 @@ pub fn build_daemon_status(
     // exactly the same registry it did pre-#3930).
     let mut in_flight: Vec<crate::types::SweepInfo> = Vec::new();
     let mut per_repo: Vec<crate::types::RepoStatus> = Vec::with_capacity(roots.len());
+    // Issue #4214: live-locked-but-unregistered sweeps, unioned across every
+    // root exactly like `in_flight` — each root is cross-checked against its
+    // own `.loom/locks/issue-*/` independently (a PrSet sweep has no per-issue
+    // lock and is naturally never a candidate here).
+    let mut unregistered_locked: Vec<crate::types::UnregisteredLockedSweep> = Vec::new();
     for root in &roots {
         let registry = workspace_pool.get_or_provision(root);
-        let (live, quarantined_issues): (Vec<crate::types::SweepInfo>, Vec<u32>) = {
+        let (live, quarantined_issues, locked_unregistered): (
+            Vec<crate::types::SweepInfo>,
+            Vec<u32>,
+            Vec<(u32, u32)>,
+        ) = {
             let sr = registry.lock().expect("Sweep registry mutex poisoned");
             // In-flight = sweeps still live (Pending / Running). Terminal sweeps
             // (Exited / Crashed) linger in the registry but are not "in flight".
@@ -1136,7 +1145,7 @@ pub fn build_daemon_status(
             // Insta-crash quarantine (#3939): surface which issues this repo is
             // currently refusing to re-dispatch, so a repo with a visible backlog
             // that is dispatching nothing is explained.
-            (live, sr.quarantined_issues_sorted())
+            (live, sr.quarantined_issues_sorted(), sr.unregistered_locked_issues())
         };
         per_repo.push(crate::types::RepoStatus {
             root: root.clone(),
@@ -1154,6 +1163,13 @@ pub fn build_daemon_status(
             health_gate_verdict_at: health_states.last_verdict_at(root),
         });
         in_flight.extend(live);
+        unregistered_locked.extend(locked_unregistered.into_iter().map(|(issue, owner_pid)| {
+            crate::types::UnregisteredLockedSweep {
+                root: root.clone(),
+                issue,
+                owner_pid,
+            }
+        }));
     }
 
     // Present the per-repo breakdown in dispatch-priority order (#3946) — the
@@ -1233,6 +1249,7 @@ pub fn build_daemon_status(
 
     DaemonStatusReport {
         in_flight,
+        unregistered_locked,
         token_pool_size,
         disk_headroom,
         cpu_headroom,
@@ -3409,6 +3426,7 @@ exit 0
         // Response: carries the full report.
         let report = DaemonStatusReport {
             in_flight: vec![],
+            unregistered_locked: vec![],
             token_pool_size: 4,
             disk_headroom: 10,
             cpu_headroom: 6,
@@ -3843,6 +3861,95 @@ exit 0
                 .as_deref(),
             Some(reason)
         );
+
+        match prev_shared {
+            Some(v) => std::env::set_var("LOOM_SHARED_TOKENS_DIR", v),
+            None => std::env::remove_var("LOOM_SHARED_TOKENS_DIR"),
+        }
+        std::env::remove_var(REGISTRY_PATH_ENV);
+    }
+
+    /// Regression test for Issue #4214 (the "vanish window" incident): a sweep
+    /// whose per-issue lock is live (`owner_pid` alive) but which has **no**
+    /// matching in-flight registry entry — the exact shape of the observed
+    /// incident, where the in-memory union of live entries silently lost track
+    /// of a sweep the filesystem lock proves is still alive — must be surfaced
+    /// via `DaemonStatusReport::unregistered_locked`, not silently omitted from
+    /// `in_flight` with no trace at all. Also exercises the full JSON
+    /// round-trip so a client (CLI, monitor script) sees the same shape.
+    #[test]
+    #[serial_test::serial]
+    fn test_build_daemon_status_surfaces_unregistered_locked_sweep() {
+        use crate::main_health_gate::WorkspaceHealthStates;
+        use crate::workspace_registry::REGISTRY_PATH_ENV;
+
+        let (sr, dir, _rec) = setup_sweep_registry_in_tempdir();
+        let root = dir.path().to_path_buf();
+        let empty_reg = dir.path().join("no-such-workspaces.json");
+        std::env::set_var(REGISTRY_PATH_ENV, &empty_reg);
+        let prev_shared = std::env::var("LOOM_SHARED_TOKENS_DIR").ok();
+        std::env::set_var("LOOM_SHARED_TOKENS_DIR", "");
+
+        let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
+        pool.seed(root.clone(), sr.clone());
+        let health = WorkspaceHealthStates::new();
+
+        // Baseline: no lock, nothing in flight, nothing unregistered.
+        let report = build_daemon_status(&pool, &health, &root, &test_credential_preflight());
+        assert!(report.in_flight.is_empty());
+        assert!(report.unregistered_locked.is_empty());
+
+        // Simulate the observed incident: a live, locked sweep (owner_pid alive,
+        // lock dir valid) with NO corresponding registry entry — i.e. it never
+        // went through `reconstruct()` or `dispatch()` in this process's
+        // lifetime, exactly the read-path-gap shape the issue's forensics
+        // pointed to (a registry mutation would have shown up as a Crashed/
+        // Exited terminal entry instead, not a bare absence).
+        let locks_dir = root.join(".loom").join("locks").join("issue-4201");
+        std::fs::create_dir_all(&locks_dir).unwrap();
+        // `LockOwner` is private to `sweep_registry`; write its wire schema
+        // directly (mirrors what `acquire_lock` writes) rather than reaching
+        // across the module boundary.
+        let owner = serde_json::json!({
+            "issue": 4201,
+            "owner_pid": std::process::id(),
+            "acquired_at": chrono::Utc::now().to_rfc3339(),
+            "sweep_id": "sweep-issue-4201-1785221507",
+        });
+        std::fs::write(locks_dir.join("owner.json"), serde_json::to_string_pretty(&owner).unwrap())
+            .unwrap();
+
+        let report = build_daemon_status(&pool, &health, &root, &test_credential_preflight());
+        assert!(
+            report.in_flight.is_empty(),
+            "the sweep never went through dispatch/reconstruct in this test, so it \
+             is deliberately still absent from in_flight -- that's the omission \
+             this test targets"
+        );
+        assert_eq!(
+            report.unregistered_locked.len(),
+            1,
+            "a live-locked issue with no registry entry must surface as unregistered_locked, \
+             got: {:?}",
+            report.unregistered_locked
+        );
+        let entry = &report.unregistered_locked[0];
+        assert_eq!(entry.issue, 4201);
+        assert_eq!(entry.owner_pid, std::process::id());
+        assert_eq!(entry.root, root);
+
+        // JSON round-trip: the field survives serialize -> deserialize (the
+        // wire contract `loom-daemon status --json` and any monitor script rely
+        // on), and stays byte-identical to a re-parse of the legacy fixture
+        // from `test_daemon_status_backward_compat_missing_capacity` (an absent
+        // field there must still default to empty -- covered by that test; this
+        // one only asserts our populated case survives the round trip).
+        let json = serde_json::to_string(&report).expect("serialize DaemonStatusReport");
+        let back: DaemonStatusReport =
+            serde_json::from_str(&json).expect("deserialize DaemonStatusReport");
+        assert_eq!(back.unregistered_locked.len(), 1);
+        assert_eq!(back.unregistered_locked[0].issue, 4201);
+        assert_eq!(back.unregistered_locked[0].owner_pid, std::process::id());
 
         match prev_shared {
             Some(v) => std::env::set_var("LOOM_SHARED_TOKENS_DIR", v),

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -2652,6 +2652,18 @@ fn print_status_json(
     let combined = serde_json::json!({
         "in_flight_count": report.in_flight.len(),
         "in_flight": report.in_flight,
+        // Live-locked-but-unregistered sweeps (#4214): a live `owner_pid` lock
+        // with no matching `in_flight` entry. Non-empty here means a sweep is
+        // demonstrably alive (the lock proves it) but the in-memory registry
+        // union above has lost track of it — read these as **alive**, not
+        // dead, and reconcile rather than re-dispatching. Empty in the
+        // overwhelmingly common case.
+        "unregistered_locked_count": report.unregistered_locked.len(),
+        "unregistered_locked": report.unregistered_locked.iter().map(|u| serde_json::json!({
+            "root": u.root,
+            "issue": u.issue,
+            "owner_pid": u.owner_pid,
+        })).collect::<Vec<_>>(),
         // "Currently binding" vs "smallest ceiling" (#4031): the cap only binds
         // once in-flight reaches it. `false` ⇒ the limiter is work availability,
         // not any resource term, so scripted consumers don't misread the
@@ -2941,6 +2953,23 @@ fn print_status_human(
                 "  {:<30} {:>7} {:>8}  {:<20} {}",
                 s.sweep_id, issue, s.pid, s.token_name, phase
             );
+        }
+    }
+
+    // Live-locked-but-unregistered sweeps (#4214): a sweep whose per-issue lock
+    // has a live `owner_pid` but no matching in-flight entry above. Non-empty
+    // means the daemon's in-memory registry union has lost track of a sweep
+    // that is demonstrably still alive (the lock proves it) — a monitor should
+    // read this as ALIVE, not dead, and an operator should reconcile rather
+    // than re-dispatch (re-dispatch is blocked by the lock anyway, #4146).
+    if !report.unregistered_locked.is_empty() {
+        println!(
+            "\nWARNING: {} live-locked sweep(s) missing from the in-flight registry \
+             (alive, not dead — reconcile, don't re-dispatch):",
+            report.unregistered_locked.len()
+        );
+        for u in &report.unregistered_locked {
+            println!("  issue #{} (pid {}) in {}", u.issue, u.owner_pid, u.root.display());
         }
     }
 

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -1632,6 +1632,78 @@ impl SweepRegistry {
         v
     }
 
+    /// Cross-check `.loom/locks/issue-<N>/` against this registry's own
+    /// in-memory entries and surface any issue whose lock has a **live**
+    /// `owner_pid` but no matching non-terminal (`Pending`/`Running`) registry
+    /// entry (Issue #4214).
+    ///
+    /// This is the structural fix for the "vanish window" incident: the
+    /// in-flight union `loom-daemon status` reports is built solely from
+    /// in-memory registry entries, so any read-path gap that silently drops an
+    /// entry from that union (e.g. a torn/mid-write `workspaces.json`, or a
+    /// root-spelling mismatch in the workspace pool causing a registry to be
+    /// skipped for a query) makes a demonstrably-alive, locked sweep vanish
+    /// from `status` with no trace — exactly the failure a liveness monitor
+    /// misreads as "sweep is dead". The lock directory is independent,
+    /// filesystem-durable evidence that the in-memory union cannot lose track
+    /// of, so cross-checking it here makes that omission structurally
+    /// impossible: the caller can render these as "alive, but state
+    /// unreconciled" instead of omitting them.
+    ///
+    /// A **stale** lock (dead `owner_pid`) is deliberately excluded — that
+    /// remains [`reconstruct`](Self::reconstruct)'s cleanup remit. Reporting a
+    /// dead lock here would misrepresent a genuinely finished/crashed sweep as
+    /// still running, which is the opposite of what this diagnostic is for.
+    ///
+    /// Returns `(issue, owner_pid)` pairs, sorted ascending by issue number.
+    #[must_use]
+    pub fn unregistered_locked_issues(&self) -> Vec<(u32, u32)> {
+        let locks_dir = self.config.locks_dir();
+        let mut result = Vec::new();
+        let Ok(read_dir) = std::fs::read_dir(&locks_dir) else {
+            return result;
+        };
+        for entry in read_dir {
+            let Ok(entry) = entry else { continue };
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_default();
+            let Some(issue_str) = name.strip_prefix("issue-") else {
+                continue;
+            };
+            let Ok(issue): Result<u32, _> = issue_str.parse() else {
+                continue;
+            };
+            let owner_path = path.join("owner.json");
+            let owner: Option<LockOwner> = std::fs::read_to_string(&owner_path)
+                .ok()
+                .and_then(|s| serde_json::from_str(&s).ok());
+            let Some(owner) = owner else {
+                // No (or unparsable) owner.json: nothing durable to cross-check
+                // against — `reconstruct()`'s stale-lock cleanup owns this case.
+                continue;
+            };
+            if !is_pid_alive(owner.owner_pid) {
+                // Stale lock (dead owner): the sweep has actually finished or
+                // crashed, not "unregistered" — do not report it as alive.
+                continue;
+            }
+            let already_registered = self.entries.values().any(|info| {
+                !info.state.is_terminal() && matches!(info.kind, SweepKind::Issue(i) if i == issue)
+            });
+            if !already_registered {
+                result.push((issue, owner.owner_pid));
+            }
+        }
+        result.sort_unstable();
+        result
+    }
+
     /// Test/inspection helper: the current consecutive-insta-crash count for an
     /// issue (Issue #3939). `0` when the issue has no recorded insta-crashes.
     #[must_use]
@@ -8319,6 +8391,99 @@ exit 0
         let info = registry.get("sweep-issue-77-reconstruct").unwrap();
         assert_eq!(info.pid, std::process::id());
         assert!(matches!(info.state, SweepState::Running));
+    }
+
+    /// Issue #4214: a live-locked issue with **no** matching registry entry at
+    /// all (no `reconstruct()` has run, no dispatch entry exists) must surface
+    /// via `unregistered_locked_issues` — this is the "vanish window" case: the
+    /// lock (filesystem-durable) proves the sweep is alive even though nothing
+    /// in memory currently reflects it.
+    #[test]
+    fn unregistered_locked_issues_surfaces_live_lock_with_no_entry() {
+        let dir = tempdir().unwrap();
+        let (registry, _record_log) = fixture_registry(dir.path());
+
+        let locks = registry.config.locks_dir();
+        std::fs::create_dir_all(&locks).unwrap();
+        let lock = locks.join("issue-4201");
+        std::fs::create_dir(&lock).unwrap();
+        let owner = LockOwner {
+            issue: 4201,
+            owner_pid: std::process::id(), // guaranteed alive
+            acquired_at: Utc::now().to_rfc3339(),
+            sweep_id: "sweep-issue-4201-1785221507".to_string(),
+        };
+        std::fs::write(lock.join("owner.json"), serde_json::to_string_pretty(&owner).unwrap())
+            .unwrap();
+
+        let unregistered = registry.unregistered_locked_issues();
+        assert_eq!(
+            unregistered,
+            vec![(4201, std::process::id())],
+            "a live-locked issue with no in-memory entry must surface as unregistered_locked"
+        );
+    }
+
+    /// Issue #4214: once the registry has admitted the lock's sweep as a
+    /// non-terminal entry (e.g. via `reconstruct()`, or a normal `dispatch()`),
+    /// the same lock must NOT be reported as unregistered — it is registered.
+    #[test]
+    fn unregistered_locked_issues_excludes_registered_live_entry() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+
+        let locks = registry.config.locks_dir();
+        std::fs::create_dir_all(&locks).unwrap();
+        let lock = locks.join("issue-4202");
+        std::fs::create_dir(&lock).unwrap();
+        let owner = LockOwner {
+            issue: 4202,
+            owner_pid: std::process::id(),
+            acquired_at: Utc::now().to_rfc3339(),
+            sweep_id: "sweep-issue-4202-registered".to_string(),
+        };
+        std::fs::write(lock.join("owner.json"), serde_json::to_string_pretty(&owner).unwrap())
+            .unwrap();
+
+        // Reconstruct admits the lock's sweep as a `Running` entry.
+        let admitted = registry.reconstruct().unwrap();
+        assert!(admitted >= 1);
+
+        let unregistered = registry.unregistered_locked_issues();
+        assert!(
+            unregistered.is_empty(),
+            "a lock whose sweep is already a registered non-terminal entry must not be \
+             reported as unregistered_locked; got: {unregistered:?}"
+        );
+    }
+
+    /// Issue #4214: a **stale** lock (dead `owner_pid`) must NOT be reported as
+    /// `unregistered_locked` — that lock is `reconstruct()`'s cleanup remit, not
+    /// evidence the sweep is still alive.
+    #[test]
+    fn unregistered_locked_issues_excludes_stale_dead_pid_lock() {
+        let dir = tempdir().unwrap();
+        let (registry, _record_log) = fixture_registry(dir.path());
+
+        let locks = registry.config.locks_dir();
+        std::fs::create_dir_all(&locks).unwrap();
+        let lock = locks.join("issue-4203");
+        std::fs::create_dir(&lock).unwrap();
+        let owner = LockOwner {
+            issue: 4203,
+            owner_pid: 2_147_483_640, // dead
+            acquired_at: Utc::now().to_rfc3339(),
+            sweep_id: "sweep-issue-4203-stale".to_string(),
+        };
+        std::fs::write(lock.join("owner.json"), serde_json::to_string_pretty(&owner).unwrap())
+            .unwrap();
+
+        let unregistered = registry.unregistered_locked_issues();
+        assert!(
+            unregistered.is_empty(),
+            "a stale (dead-pid) lock must never surface as unregistered_locked; got: \
+             {unregistered:?}"
+        );
     }
 
     #[test]

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -790,6 +790,20 @@ pub struct DaemonStatusReport {
     /// The full `SweepInfo` is carried so the CLI can render issue numbers,
     /// PIDs, token account, and latest phase without a second round-trip.
     pub in_flight: Vec<SweepInfo>,
+    /// Issues whose per-issue lock (`.loom/locks/issue-<N>/owner.json`) has a
+    /// **live** `owner_pid` but no matching entry in [`Self::in_flight`]
+    /// (Issue #4214) — a live, locked sweep that the in-memory registry union
+    /// has (transiently or otherwise) lost track of. `build_daemon_status`
+    /// cross-checks every root's lock directory against its own registry so
+    /// this class can never be silently empty when the underlying condition is
+    /// real: a liveness monitor should read entries here as **alive** (a
+    /// reconciliation gap, not a dead sweep), never as absence. A stale lock
+    /// (dead `owner_pid`) is deliberately excluded — that remains
+    /// `reconstruct()`'s cleanup remit. Empty in the overwhelmingly common
+    /// case. `#[serde(default)]` keeps pre-#4214 wire data / older clients
+    /// compatible (an absent field parses as an empty vec).
+    #[serde(default)]
+    pub unregistered_locked: Vec<UnregisteredLockedSweep>,
     /// Dynamic-cap input 1: size of the multi-account token pool
     /// (`.loom/tokens/*.token`), the hard ceiling on concurrent sweeps
     /// (never over-subscribe an OAuth account). Via [`crate::tokens::token_pool_size`].
@@ -1007,6 +1021,24 @@ pub struct DaemonStatusReport {
     /// `#[serde(default)]` keeps pre-#4055 wire data compatible.
     #[serde(default)]
     pub auto_update_note: Option<String>,
+}
+
+/// A live-locked sweep with no matching [`DaemonStatusReport::in_flight`] entry
+/// (Issue #4214). See the field doc on
+/// [`DaemonStatusReport::unregistered_locked`] for the full rationale; this is
+/// the per-entry shape, carrying enough to locate and reconcile it manually
+/// (which root, which issue, which PID is holding the lock).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UnregisteredLockedSweep {
+    /// The workspace root whose `.loom/locks/issue-<N>/` directory this lock
+    /// lives under.
+    pub root: PathBuf,
+    /// The issue number the lock is for (parsed from the `issue-<N>` dir name).
+    pub issue: u32,
+    /// The lock's `owner_pid`, confirmed alive (`kill(pid, 0)` succeeds) at
+    /// snapshot time — a dead-owner lock is stale-lock cleanup territory
+    /// (`reconstruct()`), not this diagnostic.
+    pub owner_pid: u32,
 }
 
 /// One registered managed-workspace's status line in [`DaemonStatusReport`]


### PR DESCRIPTION
## Summary

A live, locked sweep (owner_pid alive, lock dir valid) could transiently vanish
from `loom-daemon status`'s in-flight list, making a liveness monitor conclude
the sweep is dead. This makes that omission structurally impossible: any
issue whose per-issue lock has a live `owner_pid` but no matching in-flight
registry entry is now surfaced in a distinct `unregistered_locked` class, in
both human and `--json` `status` output.

## Root cause analysis

Per the curator's daemon-log forensics (see issue body/comments for the full
UTC timeline), no #4201-specific registry mutation is logged inside the
07:07–07:23Z vanish window, and the lock survived the window intact. A reaper
false-dead transition (`Crashed` ⇒ `release_lock` + label restore) would have
left a trace and released the lock — it did neither. That rules out a
**registry mutation** as the cause.

That leaves a **read-path omission**: `build_daemon_status` builds its
in-flight union purely from in-memory registry state reachable via
`WorkspacePool::get_or_provision(root)` for each
`WorkspaceRegistry::effective_roots()` root. Two read-path candidates were
identified (ranked in the curator's comment):

1. A transient `workspaces.json` read/parse failure (concurrent rewrite) or a
   root-spelling mismatch between the canonicalized registered root and the
   raw `LOOM_WORKSPACE` fallback root could cause a repo's registry to be
   skipped for one query tick.
2. The observed 07:23:40Z broken-pipe line (a known live #4043 MCP-bridge
   defect) suggests the *monitor's read itself* may have errored/timed out
   and been misread as "sweep absent" — no daemon-side bug required.

I could not conclusively pin which of (1) or (2) fired in the original
incident (the daemon has since rolled past that build), but both share the
same defect: **the in-memory union has no independent check**, so any gap in
it is silently indistinguishable from "the sweep is dead." This PR closes
that gap structurally rather than chasing the exact transient trigger: the
per-issue lock directory (`.loom/locks/issue-<N>/owner.json`) is
filesystem-durable, independent evidence of liveness that a status read can
always cross-check regardless of *why* the in-memory union momentarily missed
an entry.

The "reappearance" in the original incident is separately explained (per the
curator's comment) as the review-stall watchdog (#3910) auto-cancelling and
re-dispatching the sweep under a **new** sweep id for the same issue — not the
original entry returning. That is a distinct, already-tracked concern (see
"Follow-up" below).

## Changes

- `loom-daemon/src/sweep_registry.rs`: new `SweepRegistry::unregistered_locked_issues()` —
  enumerates `.loom/locks/issue-*/owner.json`, and for each lock with a
  **live** `owner_pid` and no matching non-terminal registry entry, returns
  `(issue, owner_pid)`. A **stale** lock (dead `owner_pid`) is deliberately
  excluded — that stays `reconstruct()`'s cleanup remit.
- `loom-daemon/src/types.rs`: new `UnregisteredLockedSweep { root, issue, owner_pid }`
  struct and a `#[serde(default)]` `DaemonStatusReport::unregistered_locked: Vec<UnregisteredLockedSweep>`
  field (backward-compat: absent on older wire payloads defaults to empty).
- `loom-daemon/src/ipc.rs`: `build_daemon_status()` calls the new registry
  method for every root (same loop that builds the per-repo `in_flight`
  union) and populates the new field.
- `loom-daemon/src/main.rs`: `print_status_human()` prints a `WARNING: N
  live-locked sweep(s) missing from the in-flight registry` block when
  non-empty; `print_status_json()` adds `unregistered_locked_count` /
  `unregistered_locked` to the JSON payload.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Root cause identified, distinguishing read-path omission from registry mutation | ✅ | See "Root cause analysis" above — event/lock evidence rules out a registry mutation; two read-path hypotheses remain plausible and are documented |
| `status` never silently omits a live-locked sweep — surfaced as `unregistered_locked` (new serde-defaulted field, human + JSON output) | ✅ | `unregistered_locked_issues()` + `DaemonStatusReport::unregistered_locked`, rendered in both `print_status_human` and `print_status_json`; `#[serde(default)]` keeps `test_daemon_status_backward_compat_missing_capacity` green |
| Stale (dead-pid) lock NOT reported as `unregistered_locked` | ✅ | `unregistered_locked_issues_excludes_stale_dead_pid_lock` |
| Regression test for the observed sequence + unit tests for live/stale lock cases | ✅ | `test_build_daemon_status_surfaces_unregistered_locked_sweep` (full `build_daemon_status` path + JSON round-trip) + the two `unregistered_locked_issues_*` unit tests |
| Watchdog log-idle-only cancellation noted as a candidate follow-up, not scope-crept here | ✅ | See "Follow-up" below |

## Test Plan

- `cargo test --lib unregistered_locked_issues` — 3/3 pass (live lock w/ no
  entry surfaces; registered live entry excluded; stale dead-pid lock
  excluded).
- `cargo test --lib test_build_daemon_status_surfaces_unregistered_locked_sweep` —
  passes; reproduces the observed shape (live lock, no registry entry) end to
  end through `build_daemon_status`, asserts `in_flight` stays empty while
  `unregistered_locked` surfaces the issue, and round-trips the report through
  `serde_json` to confirm the wire contract.
- `cargo test --lib` — full suite, 1467 passed, 0 failed.
- `cargo clippy --lib --tests -- -D warnings` — clean.
- `cargo build` — clean.
- `cargo fmt -- --check` — clean.
- Edge cases: PrSet sweeps have no per-issue lock dir, so they are naturally
  never candidates for `unregistered_locked`; multi-repo roots are
  cross-checked independently inside the same per-root loop that builds
  `in_flight`/`per_repo`.

## Follow-up (not in scope here)

Per the issue's explicit fencing: if the review-stall watchdog (#3910)
cancelling a checkpoint-progressing sweep on log-idle-only (ignoring
checkpoint mtime as a liveness signal) is a contributing cause to *why* a
sweep gets re-dispatched under a new id, that is a separate concern worth its
own issue — not addressed here.

Closes #4214
