### PR TITLE
feat(daemon): add loom-daemon quarantine list read path

### DIFF
--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -2049,6 +2049,50 @@ fn handle_request(
             }
         }
 
+        Request::ListQuarantines { workspace_root } => {
+            // Operator-reachable insta-crash-quarantine read path (Issue
+            // #4215) — the authority for "which issues are quarantined right
+            // now", distinct from a forge `loom:blocked` query. Unlike every
+            // other `workspace_root: Option<String>` request, `None` here
+            // means "every registered workspace" (see the doc comment on
+            // `Request::ListQuarantines`), not just the default one, so a
+            // `Some(root)` scopes to a single registry via the same
+            // `resolve_registry` path `ClearQuarantine` uses, while `None`
+            // enumerates roots the way `build_daemon_status` does.
+            let now = Utc::now();
+            let entries = match workspace_root.as_deref() {
+                Some(root) if !root.trim().is_empty() => {
+                    let target = resolve_registry(sweep_registry, workspace_pool, Some(root));
+                    let sr = target.lock().expect("Sweep registry mutex poisoned");
+                    sr.quarantine_entries(now)
+                }
+                _ => {
+                    // No `fallback_root` is threaded into this synchronous
+                    // dispatcher (unlike `build_daemon_status`), but the
+                    // default registry's own config already carries it —
+                    // it's the same root `resolve_registry`'s `None` arm
+                    // would have targeted.
+                    let fallback_root = {
+                        let sr = sweep_registry
+                            .lock()
+                            .expect("Sweep registry mutex poisoned");
+                        sr.config().workspace_root.clone()
+                    };
+                    let workspace_registry = WorkspaceRegistry::load_default().unwrap_or_default();
+                    let roots = workspace_registry.effective_roots(&fallback_root);
+                    let mut entries = Vec::new();
+                    for root in &roots {
+                        let registry = workspace_pool.get_or_provision(root);
+                        let sr = registry.lock().expect("Sweep registry mutex poisoned");
+                        entries.extend(sr.quarantine_entries(now));
+                    }
+                    entries.sort_unstable_by_key(|e| e.issue);
+                    entries
+                }
+            };
+            Response::QuarantineList { entries }
+        }
+
         // ====================================================================
         // Event Bus Handlers (Issue #3453 — Phase B of #3449)
         // ====================================================================
@@ -3256,6 +3300,145 @@ exit 0
             other => panic!("Expected QuarantineCleared, got: {other:?}"),
         }
         assert!(!sr.lock().unwrap().is_quarantined(808));
+    }
+
+    // ===== ListQuarantines (Issue #4215) =====
+    //
+    // `workspace_root: None` enumerates every registered workspace (unlike
+    // `ClearQuarantine`'s `None` == default-workspace-only), so these tests
+    // seed the pool with the default registry at its own workspace root —
+    // exactly the way `main.rs` wires `workspace_pool.seed(sweep_workspace,
+    // sweep_registry)` in production — and pin `REGISTRY_PATH_ENV` to an empty
+    // file so `effective_roots` resolves to exactly `[root]` regardless of any
+    // real `~/.loom/workspaces.json` on the host running the test.
+
+    #[test]
+    #[serial_test::serial]
+    fn test_handle_request_list_quarantines_empty_registry() {
+        use crate::workspace_registry::REGISTRY_PATH_ENV;
+
+        let (tm, db, _, bus) = setup_test_context();
+        let (sr, dir, _rec) = setup_sweep_registry_in_tempdir();
+        let root = dir.path().to_path_buf();
+        let empty_reg = dir.path().join("no-such-workspaces.json");
+        std::env::set_var(REGISTRY_PATH_ENV, &empty_reg);
+
+        let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
+        pool.seed(root, sr.clone());
+
+        let response = handle_request(
+            Request::ListQuarantines {
+                workspace_root: None,
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+            &pool,
+        );
+        std::env::remove_var(REGISTRY_PATH_ENV);
+
+        match response {
+            Response::QuarantineList { entries } => {
+                assert!(entries.is_empty(), "no quarantines seeded -> empty list");
+            }
+            other => panic!("Expected QuarantineList, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_handle_request_list_quarantines_seeded_entries() {
+        use crate::workspace_registry::REGISTRY_PATH_ENV;
+
+        let (tm, db, _, bus) = setup_test_context();
+        let (sr, dir, _rec) = setup_sweep_registry_in_tempdir();
+        let root = dir.path().to_path_buf();
+        let empty_reg = dir.path().join("no-such-workspaces.json");
+        std::env::set_var(REGISTRY_PATH_ENV, &empty_reg);
+
+        let applied_at = Utc::now();
+        {
+            let mut reg = sr.lock().unwrap();
+            reg.seed_quarantine_with_details_for_test(4215, applied_at, 2);
+        }
+
+        let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
+        pool.seed(root.clone(), sr.clone());
+
+        let response = handle_request(
+            Request::ListQuarantines {
+                workspace_root: None,
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+            &pool,
+        );
+        std::env::remove_var(REGISTRY_PATH_ENV);
+
+        match response {
+            Response::QuarantineList { entries } => {
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].issue, 4215);
+                assert_eq!(entries[0].workspace_root, root);
+                assert_eq!(entries[0].insta_crash_count, 2);
+                assert_eq!(entries[0].quarantined_at, applied_at);
+                assert!(
+                    entries[0].ttl_remaining_secs > 0,
+                    "freshly-applied quarantine should have TTL remaining"
+                );
+            }
+            other => panic!("Expected QuarantineList, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_handle_request_list_quarantines_ttl_clamps_to_zero() {
+        use crate::workspace_registry::REGISTRY_PATH_ENV;
+
+        let (tm, db, _, bus) = setup_test_context();
+        let (sr, dir, _rec) = setup_sweep_registry_in_tempdir();
+        let root = dir.path().to_path_buf();
+        let empty_reg = dir.path().join("no-such-workspaces.json");
+        std::env::set_var(REGISTRY_PATH_ENV, &empty_reg);
+
+        // Default TTL is 3600s (Issue #3939) — quarantine this issue as though
+        // it were applied 2 hours ago, well past TTL. `reap_once` (the actual
+        // expiry sweep) never runs in this test, so the stale entry survives in
+        // memory; `ttl_remaining_secs` must still clamp to 0 rather than
+        // reporting a nonsensical negative remainder.
+        let long_ago = Utc::now() - chrono::Duration::seconds(7200);
+        {
+            let mut reg = sr.lock().unwrap();
+            reg.seed_quarantine_with_details_for_test(9001, long_ago, 5);
+        }
+
+        let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
+        pool.seed(root, sr.clone());
+
+        let response = handle_request(
+            Request::ListQuarantines {
+                workspace_root: None,
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+            &pool,
+        );
+        std::env::remove_var(REGISTRY_PATH_ENV);
+
+        match response {
+            Response::QuarantineList { entries } => {
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].issue, 9001);
+                assert_eq!(entries[0].ttl_remaining_secs, 0, "past-TTL entry must clamp to 0");
+            }
+            other => panic!("Expected QuarantineList, got: {other:?}"),
+        }
     }
 
     #[test]

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -17,7 +17,7 @@ use loom_daemon::self_update;
 use loom_daemon::sweep_registry::{self, SweepRegistry, SweepRegistryConfig};
 use loom_daemon::terminal::TerminalManager;
 use loom_daemon::token_ranking_refresh;
-use loom_daemon::types::{DaemonStatusReport, Request, Response, SweepKind};
+use loom_daemon::types::{DaemonStatusReport, QuarantineEntry, Request, Response, SweepKind};
 use loom_daemon::watch_registry;
 use loom_daemon::work_finder;
 use loom_daemon::workspace_pool::WorkspacePool;
@@ -353,6 +353,25 @@ enum QuarantineAction {
 
         /// Target managed-workspace root (Issue #3929). Omit to use the daemon's
         /// default workspace.
+        #[arg(long, value_name = "PATH")]
+        workspace_root: Option<String>,
+    },
+
+    /// List active insta-crash quarantines (Issue #4215): issue, workspace,
+    /// insta-crash tally vs threshold, applied-at, and TTL remaining.
+    ///
+    /// This is the authority for "which issues are quarantined right now" — a
+    /// forge `loom:blocked` query is NOT equivalent, because
+    /// `apply_quarantine_label` reuses that same label for genuine
+    /// dependency-blocked issues, and (since #4206) a TTL-expired quarantine
+    /// can leave `loom:blocked` in place after a manual re-park. Prefer this
+    /// command over grepping `loom:blocked` when triaging a quarantine wave.
+    List {
+        /// Target managed-workspace root (Issue #3929). Omit to list
+        /// quarantines across EVERY registered workspace — unlike `clear`,
+        /// whose omitted `--workspace-root` targets only the daemon's default
+        /// workspace (see the `Request::ListQuarantines` doc comment for why
+        /// the default differs).
         #[arg(long, value_name = "PATH")]
         workspace_root: Option<String>,
     },
@@ -1902,7 +1921,74 @@ async fn handle_quarantine_command(action: QuarantineAction) -> Result<()> {
                 }
             }
         }
+
+        QuarantineAction::List { workspace_root } => {
+            let request = Request::ListQuarantines { workspace_root };
+            match query_daemon(&socket_path, &request).await {
+                Ok(Response::QuarantineList { entries }) => {
+                    render_quarantine_list(&entries);
+                    Ok(())
+                }
+                Ok(Response::Error { message }) => {
+                    eprintln!("Daemon error: {message}");
+                    std::process::exit(1);
+                }
+                Ok(other) => {
+                    eprintln!("Unexpected response from daemon: {other:?}");
+                    std::process::exit(1);
+                }
+                Err(e) => {
+                    eprintln!("Could not reach loom-daemon at {}: {e}", socket_path.display());
+                    eprintln!();
+                    eprintln!("Is the daemon running? Start it with:");
+                    eprintln!("  ./.loom/scripts/cli/loom-daemon-start.sh");
+                    std::process::exit(1);
+                }
+            }
+        }
     }
+}
+
+/// Render `loom-daemon quarantine list` output (Issue #4215): one line per
+/// entry, grouped by workspace root (in the all-workspaces case there may be
+/// several), with a disambiguation footer whenever there is at least one
+/// entry to show. Entries within a group are already issue-sorted by
+/// [`SweepRegistry::quarantine_entries`]; `BTreeMap` keeps groups themselves
+/// ordered (by path) for deterministic output across runs.
+fn render_quarantine_list(entries: &[QuarantineEntry]) {
+    if entries.is_empty() {
+        println!("no active quarantines");
+        return;
+    }
+
+    let mut by_root: std::collections::BTreeMap<&Path, Vec<&QuarantineEntry>> =
+        std::collections::BTreeMap::new();
+    for entry in entries {
+        by_root
+            .entry(entry.workspace_root.as_path())
+            .or_default()
+            .push(entry);
+    }
+
+    for (root, group) in &by_root {
+        println!("{}:", root.display());
+        for e in group {
+            println!(
+                "  #{}  insta-crash {}/{}  applied {}  ttl remaining {}s",
+                e.issue,
+                e.insta_crash_count,
+                e.insta_crash_threshold,
+                e.quarantined_at.to_rfc3339(),
+                e.ttl_remaining_secs
+            );
+        }
+    }
+
+    println!();
+    println!(
+        "Note: `loom:blocked` on the forge may be a quarantine or a real dependency — this \
+         command is the authority for quarantines."
+    );
 }
 
 /// Handle the `restart` subcommand (Issue #4054 — the supervised restart

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -1667,6 +1667,40 @@ impl SweepRegistry {
         was_quarantined
     }
 
+    /// Read-only view of every currently-quarantined issue in this registry
+    /// (Issue #4215), joining `quarantined` (applied-at), `insta_crash_counts`
+    /// (tally), and `quarantine_config.ttl` into one row per issue — the data
+    /// backing `loom-daemon quarantine list` / [`crate::types::Request::ListQuarantines`].
+    /// Sorted by issue number, like [`Self::quarantined_issues_sorted`].
+    ///
+    /// `ttl_remaining_secs` is computed against `now` (passed in rather than
+    /// read internally so callers — and tests — can pin the clock) and clamped
+    /// to `0` for an entry already past its TTL; the actual expiry sweep only
+    /// runs from [`Self::reap_once`], so a stale-but-not-yet-reaped entry is
+    /// expected, not a bug.
+    #[must_use]
+    pub fn quarantine_entries(&self, now: DateTime<Utc>) -> Vec<crate::types::QuarantineEntry> {
+        let ttl = self.quarantine_config.ttl;
+        let mut entries: Vec<crate::types::QuarantineEntry> = self
+            .quarantined
+            .iter()
+            .map(|(&issue, &quarantined_at)| {
+                let elapsed = (now - quarantined_at).to_std().unwrap_or_default();
+                let ttl_remaining_secs = ttl.saturating_sub(elapsed).as_secs();
+                crate::types::QuarantineEntry {
+                    issue,
+                    workspace_root: self.config.workspace_root.clone(),
+                    quarantined_at,
+                    insta_crash_count: self.insta_crash_count(issue),
+                    insta_crash_threshold: self.quarantine_config.threshold,
+                    ttl_remaining_secs,
+                }
+            })
+            .collect();
+        entries.sort_unstable_by_key(|e| e.issue);
+        entries
+    }
+
     /// Test-only helper: seed an in-memory quarantine entry for `issue` so
     /// cross-module tests (e.g. the IPC dispatcher in `ipc.rs`) can exercise the
     /// `ClearQuarantine` path without driving the full insta-crash accrual.
@@ -1675,6 +1709,21 @@ impl SweepRegistry {
         self.quarantined.insert(issue, Utc::now());
         self.insta_crash_counts
             .insert(issue, self.quarantine_config.threshold);
+    }
+
+    /// Test-only helper (Issue #4215): like [`Self::seed_quarantine_for_test`]
+    /// but with an explicit `quarantined_at` and `insta_crash_count`, so tests
+    /// of `quarantine_entries` can pin a past-TTL `quarantined_at` (to exercise
+    /// the `ttl_remaining_secs` clamp) or a distinct tally.
+    #[cfg(test)]
+    pub fn seed_quarantine_with_details_for_test(
+        &mut self,
+        issue: u32,
+        quarantined_at: DateTime<Utc>,
+        insta_crash_count: u32,
+    ) {
+        self.quarantined.insert(issue, quarantined_at);
+        self.insta_crash_counts.insert(issue, insta_crash_count);
     }
 
     /// Issues currently awaiting a retried `loom:blocked` -> `loom:issue` label
@@ -7286,6 +7335,62 @@ exit 0
         assert!(!registry.is_quarantined(46));
         assert_eq!(registry.insta_crash_count(46), 0);
         assert!(!registry.clear_quarantine(46), "idempotent: false when nothing to clear");
+    }
+
+    /// `quarantine_entries` (Issue #4215) joins `quarantined`, `insta_crash_counts`,
+    /// and `quarantine_config` into one row per issue, sorted by issue number
+    /// like `quarantined_issues_sorted`, and reflects each issue's own tally.
+    #[test]
+    fn quarantine_entries_sorted_and_reflects_insta_crash_count() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+
+        let now = Utc::now();
+        // Insert out of order to verify the accessor sorts, not just echoes
+        // insertion order.
+        registry.quarantined.insert(200, now);
+        registry.insta_crash_counts.insert(200, 3);
+        registry.quarantined.insert(100, now);
+        registry.insta_crash_counts.insert(100, 7);
+
+        let entries = registry.quarantine_entries(now);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].issue, 100, "sorted ascending by issue number");
+        assert_eq!(entries[0].insta_crash_count, 7);
+        assert_eq!(entries[0].workspace_root, dir.path());
+        assert_eq!(entries[0].insta_crash_threshold, registry.quarantine_config().threshold);
+        assert_eq!(entries[1].issue, 200);
+        assert_eq!(entries[1].insta_crash_count, 3);
+    }
+
+    /// `ttl_remaining_secs` is computed against the `now` passed in, not a
+    /// fresh `Utc::now()` read internally — an issue quarantined `ttl / 2`
+    /// seconds ago should show roughly half its TTL remaining, and an issue
+    /// quarantined `2 * ttl` seconds ago (past-TTL, awaiting the next reaper
+    /// tick) must clamp to 0 rather than go negative.
+    #[test]
+    fn quarantine_entries_ttl_remaining_reflects_elapsed_time() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        let ttl_secs = registry.quarantine_config().ttl.as_secs();
+
+        let now = Utc::now();
+        let half_ttl_ago = now - chrono::Duration::seconds((ttl_secs / 2) as i64);
+        let past_ttl = now - chrono::Duration::seconds((ttl_secs * 2) as i64);
+        registry.quarantined.insert(1, half_ttl_ago);
+        registry.insta_crash_counts.insert(1, 3);
+        registry.quarantined.insert(2, past_ttl);
+        registry.insta_crash_counts.insert(2, 3);
+
+        let entries = registry.quarantine_entries(now);
+        let e1 = entries.iter().find(|e| e.issue == 1).unwrap();
+        let e2 = entries.iter().find(|e| e.issue == 2).unwrap();
+        assert!(
+            e1.ttl_remaining_secs > 0 && e1.ttl_remaining_secs <= ttl_secs,
+            "half-elapsed entry should have a positive, bounded remainder; got {}",
+            e1.ttl_remaining_secs
+        );
+        assert_eq!(e2.ttl_remaining_secs, 0, "past-TTL entry must clamp to 0");
     }
 
     /// The operator-action release path (`clear_quarantine`) must restore

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -280,6 +280,24 @@ pub enum Request {
         #[serde(default)]
         workspace_root: Option<String>,
     },
+    /// List active insta-crash quarantines (Issue #4215), the read-side
+    /// counterpart to [`Request::ClearQuarantine`] — the operator-reachable
+    /// authority for "which issues are quarantined right now", distinct from a
+    /// forge `loom:blocked` query (which conflates quarantines with genuine
+    /// dependency blocks, since `apply_quarantine_label` reuses that label).
+    ///
+    /// **`workspace_root` semantics deliberately differ from
+    /// [`Request::ClearQuarantine`]**: there, `None` means "the daemon's
+    /// default workspace" (you're targeting one specific repo you already
+    /// know). Here, `None` means "every registered workspace" — mirroring how
+    /// `DaemonStatus` enumerates `WorkspaceRegistry::load_default().
+    /// effective_roots(..)` — because "which issues are quarantined anywhere?"
+    /// is the operator's actual question during a quarantine wave.
+    /// `Some(root)` still scopes to that one repo's registry.
+    ListQuarantines {
+        #[serde(default)]
+        workspace_root: Option<String>,
+    },
     // ========================================================================
     // Autonomous Daemon Status (Issue #3891 — follow-up to #3813 Phase D)
     // ========================================================================
@@ -532,6 +550,13 @@ pub enum Response {
     QuarantineCleared {
         issue: u32,
         was_quarantined: bool,
+    },
+    /// Result of a `ListQuarantines` request (Issue #4215): the active
+    /// insta-crash quarantines, across one or every registered workspace
+    /// depending on the request's `workspace_root`. Empty when nothing is
+    /// currently quarantined.
+    QuarantineList {
+        entries: Vec<QuarantineEntry>,
     },
     // ========================================================================
     // Autonomous Daemon Status (Issue #3891 — follow-up to #3813 Phase D)
@@ -1066,6 +1091,35 @@ pub struct RepoStatus {
     /// keeps pre-#4012 wire data compatible.
     #[serde(default)]
     pub health_gate_verdict_at: Option<DateTime<Utc>>,
+}
+
+/// One active insta-crash quarantine (Issue #4215), as surfaced by
+/// `loom-daemon quarantine list` / [`Request::ListQuarantines`]. Joins the
+/// three pieces of quarantine state [`crate::sweep_registry::SweepRegistry`]
+/// already tracks in-memory (`quarantined`, `insta_crash_counts`,
+/// `quarantine_config.ttl`) into one read-only row.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct QuarantineEntry {
+    /// The quarantined issue number.
+    pub issue: u32,
+    /// The workspace whose registry this quarantine lives in — meaningful once
+    /// `ListQuarantines` enumerates across every registered workspace.
+    pub workspace_root: PathBuf,
+    /// When the quarantine was applied.
+    pub quarantined_at: DateTime<Utc>,
+    /// The consecutive-insta-crash tally that triggered (or is at) quarantine.
+    pub insta_crash_count: u32,
+    /// The consecutive-insta-crash threshold configured for this issue's
+    /// workspace, so the CLI can render "tally / threshold" instead of a bare
+    /// count. Read from the same per-workspace [`crate::sweep_registry::
+    /// QuarantineConfig`] the reaper enforces against — different managed
+    /// workspaces may configure different thresholds.
+    pub insta_crash_threshold: u32,
+    /// Seconds remaining before TTL auto-release, clamped to `0` — the TTL is
+    /// enforced only by [`crate::sweep_registry::SweepRegistry::reap_once`], so
+    /// an entry can be momentarily past-TTL between reaper ticks; a negative
+    /// remainder would be a confusing thing to render.
+    pub ttl_remaining_secs: u64,
 }
 
 /// The token-capacity section of [`DaemonStatusReport`] (#3902).


### PR DESCRIPTION
## Summary

`loom-daemon quarantine` previously had only a `clear` subcommand, so
"which issues are quarantined right now" was discoverable only by
probing `clear` per-issue or by querying the forge for `loom:blocked`
— which conflates auto-quarantined issues with genuine
dependency-blocked ones (`apply_quarantine_label` deliberately reuses
that label). This PR adds a read-only `quarantine list` subcommand,
mirroring the existing `quarantine clear` plumbing end to end.

## Changes

- `loom-daemon/src/types.rs`: new `Request::ListQuarantines { workspace_root: Option<String> }`,
  `Response::QuarantineList { entries: Vec<QuarantineEntry> }`, and a
  `QuarantineEntry { issue, workspace_root, quarantined_at, insta_crash_count,
  insta_crash_threshold, ttl_remaining_secs }` struct (the threshold field was
  added beyond the original spec so the CLI can render "tally / threshold"
  rather than a bare count — different managed workspaces may configure
  different thresholds).
- `loom-daemon/src/sweep_registry.rs`: read-only `SweepRegistry::quarantine_entries(&self, now)`
  accessor joining `quarantined`, `insta_crash_counts`, and `quarantine_config`
  into one row per issue, sorted by issue number (like `quarantined_issues_sorted`).
  `ttl_remaining_secs` is computed against the passed-in `now` and clamped to 0
  for a past-TTL entry (TTL expiry only runs from `reap_once`, so a
  stale-but-not-yet-reaped entry is expected).
- `loom-daemon/src/ipc.rs`: handles `Request::ListQuarantines`. `Some(root)`
  resolves that single registry via the existing `resolve_registry` helper
  (like `ClearQuarantine`). `None` enumerates **every** registered workspace
  the way `build_daemon_status` does (`WorkspaceRegistry::load_default().effective_roots(..)`
  + `workspace_pool.get_or_provision`) — the doc comment on
  `Request::ListQuarantines` calls out that this default deliberately
  differs from `ClearQuarantine`'s `None` (default-workspace-only).
- `loom-daemon/src/main.rs`: new `QuarantineAction::List` variant +
  `handle_quarantine_command` arm (same socket-connect / "Is the daemon
  running?" error path as `Clear`), plus a `render_quarantine_list` helper
  that prints one line per entry grouped by workspace root, or
  `no active quarantines` (exit 0) when empty. Non-empty output and the
  `List` variant's `--help` doc comment both carry the disambiguation note:
  "`loom:blocked` on the forge may be a quarantine or a real dependency —
  this command is the authority for quarantines." (Per #4206, the marker
  comment alone is not described as sufficient — `quarantine_reconciliation::decide`
  compares timeline events, not just marker presence.)

## Acceptance Criteria Verification

- [x] `loom-daemon quarantine list` prints active quarantines: issue,
      workspace, insta-crash tally (vs threshold), applied-at, TTL remaining
      — verified via `--help` output and unit tests exercising the full
      IPC round trip.
- [x] Distinguishable-from-blocked guidance present in both `--help` and the
      non-empty-output footer — verified with `loom-daemon quarantine list --help`.
- [x] Empty state prints `no active quarantines` and exits 0 — covered by
      `render_quarantine_list`'s early return + unit test
      `test_handle_request_list_quarantines_empty_registry`.
- [x] Scope guard respected: only the 4 files listed above touched; no
      changes to quarantine apply/expire/clear semantics, no MCP tool
      exposure, no reconciliation changes.

## Test Plan

- `cargo check` / `cargo clippy --all-targets` / `cargo fmt --check`: clean.
- `cargo test --lib`: 1467 passed, 1 pre-existing unrelated failure
  (`disk_headroom::tests::test_worktree_root_free_gb_returns_a_value`, a
  real-`df` environment smoke test in a file this PR does not touch — passes
  in isolation, flakes under full-suite parallel load; confirmed unrelated).
- New unit tests (mirroring `test_handle_request_clear_quarantine_*`):
  - `ipc::tests::test_handle_request_list_quarantines_empty_registry`
  - `ipc::tests::test_handle_request_list_quarantines_seeded_entries`
  - `ipc::tests::test_handle_request_list_quarantines_ttl_clamps_to_zero`
  - `sweep_registry::tests::quarantine_entries_sorted_and_reflects_insta_crash_count`
  - `sweep_registry::tests::quarantine_entries_ttl_remaining_reflects_elapsed_time`
- Manual: `loom-daemon quarantine list --help` and `quarantine --help` render
  the disambiguation note and command listing correctly; `LOOM_SOCKET_PATH`
  pointed at a nonexistent socket reproduces the same friendly "Is the daemon
  running?" error path as `quarantine clear`. Full live-daemon smoke test
  (dispatch a real quarantine and list it) skipped per the issue's "optional/
  skippable" guidance — unit tests cover the read path end to end.

Closes #4215
