### PR TITLE
fix(tokens): eliminate runpy RuntimeWarning from spawn-time token selection

### DIFF
--- a/loom-tools/src/loom_tools/tokens/__init__.py
+++ b/loom-tools/src/loom_tools/tokens/__init__.py
@@ -51,12 +51,28 @@ from loom_tools.tokens.failure_counts import (
     reset_all,
     threshold_reached,
 )
-from loom_tools.tokens.select import (
-    EmptyTokenPoolError,
-    SelectedToken,
-    TokenSelectionError,
-    select_token,
-)
+# NOTE: `select` is intentionally *not* imported eagerly here. Doing so would
+# put `loom_tools.tokens.select` into `sys.modules` before `runpy` executes it
+# as `__main__` for `python3 -m loom_tools.tokens.select` invocations (used by
+# `defaults/scripts/spawn-claude.sh` and `claude-wrapper.sh`), which triggers a
+# `RuntimeWarning: found in sys.modules after import ... this may result in
+# unpredictable behaviour` on every spawn. Instead, re-export the names lazily
+# via PEP 562 module `__getattr__` so the public API (`select_token`, etc.) is
+# still importable from the package, just not eagerly.
+
+
+def __getattr__(name: str):
+    if name in {
+        "EmptyTokenPoolError",
+        "SelectedToken",
+        "TokenSelectionError",
+        "select_token",
+    }:
+        from loom_tools.tokens import select as _select
+
+        return getattr(_select, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "DEFAULT_THRESHOLD",

--- a/loom-tools/tests/tokens/test_select.py
+++ b/loom-tools/tests/tokens/test_select.py
@@ -722,6 +722,44 @@ def test_cli_empty_pool_exits_78(tmp_path):
     assert "loom-tokens bootstrap" in result.stderr
 
 
+def test_cli_no_runpy_import_order_warning(tmp_path):
+    """`python -m loom_tools.tokens.select` must not print the runpy
+    RuntimeWarning caused by the package `__init__` eagerly importing the
+    `select` submodule before runpy executes it as `__main__` (issue #4218).
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loom_tools.tokens.select",
+            "--workspace",
+            str(tmp_path),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_cli_env(),
+    )
+    assert result.returncode == EX_CONFIG
+    assert "RuntimeWarning" not in result.stderr
+    assert "found in sys.modules" not in result.stderr
+
+
+def test_package_lazy_reexport_identity():
+    """The package-level API (`select_token`, `EmptyTokenPoolError`, etc.) must
+    still resolve, lazily, to the exact objects defined in the `select`
+    submodule (PEP 562 `__getattr__`, not an eager import) — see #4218.
+    """
+    import loom_tools.tokens as tokens_pkg
+    import loom_tools.tokens.select as select_mod
+
+    assert tokens_pkg.select_token is select_mod.select_token
+    assert tokens_pkg.EmptyTokenPoolError is select_mod.EmptyTokenPoolError
+    assert tokens_pkg.SelectedToken is select_mod.SelectedToken
+    assert tokens_pkg.TokenSelectionError is select_mod.TokenSelectionError
+
+
 # ---------- shared machine-level pool fallback (issue #3938) ----------
 
 


### PR DESCRIPTION
## Summary

Fixes the Python `RuntimeWarning` that `spawn-claude.sh` (and
`claude-wrapper.sh`) prints on every token selection run:

```
<frozen runpy>:130: RuntimeWarning: 'loom_tools.tokens.select' found in sys.modules after import of package 'loom_tools.tokens', but prior to execution of 'loom_tools.tokens.select'; this may result in unpredictable behaviour
```

Root cause: `loom_tools/tokens/__init__.py` eagerly imported the `select`
submodule at package-init time to re-export `select_token` and friends. That
put `loom_tools.tokens.select` into `sys.modules` before `runpy` executed it
as `__main__` for `python3 -m loom_tools.tokens.select` — the classic
`python -m package.module` import-order wart.

## Fix

Replaced the eager `from loom_tools.tokens.select import (...)` block with a
PEP 562 module-level `__getattr__` that lazily imports and re-exports the four
names (`EmptyTokenPoolError`, `SelectedToken`, `TokenSelectionError`,
`select_token`) on first attribute access. `__all__` is unchanged, so the
documented package-level public API still works identically for any caller —
just without importing `select` eagerly at package-init time.

No shell script changes needed — `spawn-claude.sh` / `claude-wrapper.sh`'s
`-m loom_tools.tokens.select` invocations are unchanged (that's #4228's scope,
per the issue's own cross-reference; verified #4228 has not landed on main
yet, so this fix is still needed).

## Testing

- Added `test_cli_no_runpy_import_order_warning` — runs `python3 -m
  loom_tools.tokens.select --workspace <empty tmp>` via subprocess and asserts
  stderr contains no `RuntimeWarning` / `found in sys.modules`, while still
  pinning the existing `EX_CONFIG` (78) exit-code contract for an empty pool.
- Added `test_package_lazy_reexport_identity` — confirms
  `loom_tools.tokens.select_token` (and the other three re-exports) resolve,
  lazily, to the exact same objects as `loom_tools.tokens.select.select_token`.
- `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/test_select.py -v` — 55 passed.
- `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -v` (excluding the two slow/integration files unrelated to this change) — 324 passed.
- Manual: ran the exact invocation `spawn-claude.sh` uses
  (`python3 -m loom_tools.tokens.select --workspace <dir> --json`) directly and
  confirmed stderr is clean (no warning) both on a real token pool and an
  empty one.
- `ruff check` on the two changed files: all checks passed.

Closes #4218
