### PR TITLE
fix(guards): retier cloud credential/resource deletion to the ungated ask tier (#4216)

### DIFF
--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -1253,11 +1253,25 @@ ALWAYS_BLOCK_PATTERNS=(
     # scan. For a repo whose job is standing up and tearing down dev VMs the
     # teardown path (`terminate-instances`) is a first-class workflow, so it is
     # downgraded to an ask via the toggle-gated CLOUD_ASK_PATTERNS below (and
-    # fully bypassed when LOOM_GUARD_CLOUD=0 / guards.cloudCli:false). The other
-    # aws forms here stay ungated — they remain a hard safety floor (#3593).
+    # fully bypassed when LOOM_GUARD_CLOUD=0 / guards.cloudCli:false).
+    #
+    # NOTE: `aws iam delete` was likewise retiered OUT of this catastrophic
+    # scan — but to the UNGATED ask tier (ASK_PATTERNS below, alongside
+    # `gh release delete`), NOT to CLOUD_ASK_PATTERNS (#4216). Rationale:
+    # deleting an IAM credential is a legitimate, often security-POSITIVE step
+    # (revoking an exposed key whose replacement is already active) that a
+    # supervised operator must be able to run in-session — a hard block left
+    # only the undocumented script-file bypass. It stays UNGATED so a repo that
+    # set guards.cloudCli:false / LOOM_GUARD_CLOUD=0 for EC2-churn convenience
+    # would still ASK (never silently allow) on IAM deletion, and a headless
+    # sweep still effectively blocks (an ASK with no human to answer denies;
+    # see defaults/docs/guard-hooks.md). The remaining aws forms below stay
+    # ungated catastrophic denies — a hard safety floor (#3593): mass object /
+    # bucket deletion (`s3 rm --recursive`, `s3 rb`) and stack teardown
+    # (`cloudformation delete-stack`) were not part of the rotation incident and
+    # are deliberately kept as hard denies.
     'aws s3 rm.*--recursive'
     'aws s3 rb'
-    'aws iam delete'
     'aws cloudformation delete-stack'
 
     # Docker mass destruction
@@ -1411,9 +1425,22 @@ lifecycle_or_cloud_reason() {
     }'
 }
 
-_LIFECYCLE_REASON=$(lifecycle_or_cloud_reason "$COMMAND_NO_COMMENT" | head -1)
-if [[ -n "$_LIFECYCLE_REASON" ]]; then
-    deny "BLOCKED: $_LIFECYCLE_REASON" "lifecycle-or-cloud-delete"
+# Split the single deny call this used to share (#4216). System-lifecycle
+# commands (halt/reboot/poweroff/shutdown/init 0|6) are a hard safety floor and
+# stay DENY. The az/gcloud `… delete` cloud branch was retiered to the UNGATED
+# ask tier — mirroring the `aws iam delete` move above — so a supervised
+# operator is prompted rather than hard-blocked, while a headless sweep's
+# unanswered ASK still blocks (see defaults/docs/guard-hooks.md). A lifecycle
+# deny takes precedence over a cloud-delete ask in a compound command (e.g.
+# `az group delete …; halt`), so the hard floor is never downgraded.
+_LIFECYCLE_CLOUD_REASONS=$(lifecycle_or_cloud_reason "$COMMAND_NO_COMMENT")
+_LIFECYCLE_DENY=$(printf '%s\n' "$_LIFECYCLE_CLOUD_REASONS" | grep '^system lifecycle command:' | head -1)
+if [[ -n "$_LIFECYCLE_DENY" ]]; then
+    deny "BLOCKED: $_LIFECYCLE_DENY" "lifecycle"
+fi
+_CLOUD_DELETE_ASK=$(printf '%s\n' "$_LIFECYCLE_CLOUD_REASONS" | grep '^cloud resource deletion:' | head -1)
+if [[ -n "$_CLOUD_DELETE_ASK" ]]; then
+    ask "Command requires confirmation: $COMMAND ($_CLOUD_DELETE_ASK — retiered to the ungated ask tier in #4216; an interactive operator confirms, a headless session still blocks)" "cloud-delete-ask"
 fi
 
 # =============================================================================
@@ -1964,9 +1991,22 @@ ASK_PATTERNS=(
     # a repo opts IN via guards.reversibleGh (REVERSIBLE_GH_ASK_PATTERNS below).
     '(^|[;&|[:space:]])gh release delete'
 
-    # NOTE: cloud CLI (aws) + docker ASK patterns are NOT in this ungated array.
-    # They live in CLOUD_ASK_PATTERNS below, gated by cloud_guard_enabled() so
-    # cloud-dev repos can opt down (LOOM_GUARD_CLOUD=0 / guards.cloudCli:false).
+    # Cloud IAM credential deletion — retiered from the catastrophic ALWAYS_BLOCK
+    # list to this UNGATED ask tier (#4216). Kept OUT of CLOUD_ASK_PATTERNS on
+    # purpose: that array is gated by cloud_guard_enabled(), so a repo that set
+    # guards.cloudCli:false / LOOM_GUARD_CLOUD=0 for EC2-churn convenience would
+    # SILENTLY bypass IAM deletion too — an unacceptable weakening for credential
+    # deletion. Ungated here means: always prompt an interactive operator, never
+    # silently allow, and still block a headless sweep (an ASK with no human to
+    # answer denies, per defaults/docs/guard-hooks.md). The az/gcloud `… delete`
+    # peer is handled by the segment parser above, which splits its former deny
+    # into a lifecycle deny + this same cloud-delete ask.
+    '(^|[;&|[:space:]])aws iam delete'
+
+    # NOTE: the remaining cloud CLI (aws ec2/lambda) + docker ASK patterns are
+    # NOT in this ungated array. They live in CLOUD_ASK_PATTERNS below, gated by
+    # cloud_guard_enabled() so cloud-dev repos can opt down (LOOM_GUARD_CLOUD=0 /
+    # guards.cloudCli:false).
 
     # Service management
     '(^|[;&|[:space:]])systemctl restart'

--- a/defaults/docs/guard-hooks.md
+++ b/defaults/docs/guard-hooks.md
@@ -19,7 +19,7 @@ You can also add project-specific guards to protect read-only directories from a
 
 `guard-destructive.sh` blocks SQL DDL/DML patterns — `DROP DATABASE`, `DROP TABLE`, `DROP SCHEMA`, `TRUNCATE TABLE`, and `DELETE FROM` without a `WHERE` clause. For most repos this is a useful safety net, but for a project that is **itself a database engine** (e.g. a SQLite-compatible engine running a SQL conformance suite) those statements are the product's own dev/test vocabulary and the guard is a category error — the match is a case-insensitive substring, so it even fires when the words appear in a comment or a `--description` label.
 
-Such repos can opt out of the SQL guard while keeping every other guard (`rm -rf /`, force-push to `main`, `gh repo delete`, `aws s3 rb`, `aws iam delete`, etc.) fully active.
+Such repos can opt out of the SQL guard while keeping every other guard (`rm -rf /`, force-push to `main`, `gh repo delete`, `aws s3 rb`, `aws cloudformation delete-stack`, etc.) fully active.
 
 The SQL guard is **on by default**. It is resolved in this order (highest precedence first):
 
@@ -53,7 +53,9 @@ LOOM_GUARD_SQL=1 psql -c "DROP TABLE users"
 
 `guard-destructive.sh` asks for confirmation on **mutating** cloud/container CLI calls — `aws ec2 run-instances`/`create-*`/`stop-instances`/`start-instances`/`terminate-instances`, `aws s3 rm`/`rb`/`cp`/`mv`/`sync`, other mutating `aws <service> <verb>` forms, and `docker rm`/`rmi`/`stop`/`kill`/`restart`. Read-only calls (`aws ec2 describe-instances`, `aws s3 ls`, `aws lambda list-functions`, `docker ps`, `docker logs`, etc.) are **not** prompted. For a repo whose *purpose* is managing cloud infrastructure (launch/stop/terminate dev VMs, build/tear-down containers), even the mutating asks are workflow friction rather than a safety win.
 
-Such repos can opt out of the cloud/docker ASK category while keeping every other guard active — including the genuinely catastrophic cloud denies (`aws s3 rm ... --recursive`, `aws s3 rb`, `aws iam delete-*`, `aws cloudformation delete-stack`, `docker system prune`), which are **never** gated by this toggle and stay hard denies even with the cloud guard off.
+Such repos can opt out of the cloud/docker ASK category while keeping every other guard active — including the genuinely catastrophic cloud denies (`aws s3 rm ... --recursive`, `aws s3 rb`, `aws cloudformation delete-stack`, `docker system prune`), which are **never** gated by this toggle and stay hard denies even with the cloud guard off.
+
+Note (#4216): `aws iam delete-*` and `az`/`gcloud … delete` are **no longer** hard denies — they were retiered to the **ungated ask tier** (see below), because deleting a credential or a single cloud resource is a legitimate, often security-positive step (e.g. revoking an exposed key whose replacement is already active) that a hard block only left the undocumented script-file bypass to satisfy. Being **ungated** (not part of the `guards.cloudCli` ASK category) is deliberate: `guards.cloudCli:false` / `LOOM_GUARD_CLOUD=0` still **asks** on `aws iam delete-*` rather than silently allowing it, and a headless sweep still blocks it (an ASK with no human to answer denies — see the Autonomous section below). Only mass object/bucket deletion (`s3 rm --recursive`, `s3 rb`) and stack teardown (`cloudformation delete-stack`) stay hard denies.
 
 The cloud guard is **on by default**. It is resolved in this order (highest precedence first):
 
@@ -89,7 +91,7 @@ LOOM_GUARD_CLOUD=1 aws ec2 terminate-instances --instance-ids i-1234
 
 `guard-destructive.sh` scopes its ask tier to **irreversibility** (#3757): a guard whose purpose is preventing catastrophic, hard-to-undo mistakes should not add confirmation friction to operations that are trivially reversed. The **reversible** GitHub state changes — `gh pr close` (undo: `gh pr reopen`), `gh issue close` (undo: `gh issue reopen`), and `gh label delete` (undo: recreate, or one `gh label sync` in a repo with `labels.yml`) — therefore **do not prompt by default**. An autonomous agent that closes its own issue/PR as part of a normal lifecycle no longer stalls on a confirmation prompt (or, in a headless run with no approver, blocks entirely).
 
-The genuinely hard-to-reverse operations stay in the ungated ask tier and are **not** affected by this toggle: `gh release delete` (deletes published artifacts/tags), and `git clean -fd` / `git checkout .` / `git restore .` (untracked / uncommitted loss). The full catastrophic deny suite (`rm -rf /`, force-push to `main`, `gh repo delete`, …) is likewise unaffected.
+The genuinely hard-to-reverse operations stay in the ungated ask tier and are **not** affected by this toggle: `gh release delete` (deletes published artifacts/tags), `git clean -fd` / `git checkout .` / `git restore .` (untracked / uncommitted loss), and — since #4216 — `aws iam delete-*` and `az`/`gcloud … delete` (cloud credential / resource deletion, retiered here from the catastrophic deny list; ungated on purpose so `guards.cloudCli:false` cannot silently bypass them). The full catastrophic deny suite (`rm -rf /`, force-push to `main`, `gh repo delete`, `aws s3 rb`, `aws cloudformation delete-stack`, …) is likewise unaffected.
 
 A repo that *wants* the confirmation back on the reversible GitHub ops can **opt in**. Unlike `guards.sqlDdl` / `guards.cloudCli` (which default **on** and are opted **out**), this toggle has **inverse polarity**: it defaults **off** and is opted **in**, because enabling it *adds* friction rather than removing it.
 
@@ -460,6 +462,16 @@ New issues from this policy enter through normal intake (`loom:triage` → Curat
 - `guards.forceScope:"protected"` recommended for autonomous repos (above).
 - The catastrophic scan no longer false-positives on **documentation text** — a dangerous command merely *mentioned* inside a multi-line `--body`/`-m`/`--title`/`--notes`/`--comment` value (e.g. `gh issue create --body "…"`) is redacted as a single span and does **not** deny, while a genuinely dangerous command, or a command-substitution `$(…)` smuggled inside such a value, still DENIES.
 - `git checkout .` / `git restore .` / `git clean -fd` **stay ASK** (evaluated, kept flagged): they irreversibly discard uncommitted/untracked work, so the standing policy files a per-trigger issue rather than blanket-allowlisting them. A repo that wants them to pass headless can add the command word to an allowlist per its own risk decision.
+
+**Second refinement pass (#4216):** `aws iam delete-*` and `az`/`gcloud … delete` were retiered from the catastrophic deny list to the **ungated ask tier**. A hard block on credential/resource deletion was over-broad — deleting an IAM key is often the *security-positive* step — and left only the undocumented script-file bypass as recourse. The deny→ask move is safe for autonomous mode by construction: a headless sweep's unanswered ASK still blocks (per the paragraph above), so nothing that was denied headless now silently runs; only a supervised interactive operator gains a confirm prompt. The patterns stay **ungated** (not folded into `guards.cloudCli`) so a repo disabling the cloud ASK category for EC2-churn convenience cannot silently bypass IAM deletion.
+
+### When a Legitimate Operation Is Pattern-Blocked
+
+When a guard blocks (or asks about) an operation you believe is legitimate, the sanctioned recourse depends on the session:
+
+1. **Interactive session** — the **ask-tier prompt is the sanctioned path.** For a pattern in the ungated ask tier (`aws iam delete-*`, `az`/`gcloud … delete`, `gh release delete`, `git clean -fd`, …) the guard emits an ASK; confirm it in the session and the operation proceeds, with the decision recorded in the decision log (§ above). A pattern that is a **hard deny** (`rm -rf /`, force-push to `main`, `aws s3 rb`, `aws cloudformation delete-stack`, …) is not meant to be overridden ad hoc — if it is a genuine, recurring false positive, fix it with a pattern/tier-change PR (this doc + the guard + its tests), exactly as #4216 did for `aws iam delete`.
+2. **Headless / autonomous session** — by design, an ASK with no human to answer **blocks** (see above), and a hard deny blocks outright. The sanctioned path is to **re-run the specific operation in a supervised interactive session** so a human can answer the ASK. Do **not** try to make the daemon answer prompts; the block is the intended safety behavior for unattended runs.
+3. **The script-file workaround is UNSANCTIONED.** Writing the blocked command into a file and running `bash that-file` (or any equivalent that hides the command string from the `PreToolUse` scan) is a **generic guard bypass, not a policy** — it defeats *every* pattern, not just a false positive, and leaves no ask/deny record. (Note: #4178 / PR #4210 confines *where* the Bash tool may write, but does not close executing an already-written script inside a builder's own worktree — so this remains a real bypass, not a closed hole.) The honest fix for a recurring false positive is a pattern/tier-change PR like #4216, reviewed like any other change.
 
 ### Protecting Read-Only Directories
 

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -1253,11 +1253,25 @@ ALWAYS_BLOCK_PATTERNS=(
     # scan. For a repo whose job is standing up and tearing down dev VMs the
     # teardown path (`terminate-instances`) is a first-class workflow, so it is
     # downgraded to an ask via the toggle-gated CLOUD_ASK_PATTERNS below (and
-    # fully bypassed when LOOM_GUARD_CLOUD=0 / guards.cloudCli:false). The other
-    # aws forms here stay ungated — they remain a hard safety floor (#3593).
+    # fully bypassed when LOOM_GUARD_CLOUD=0 / guards.cloudCli:false).
+    #
+    # NOTE: `aws iam delete` was likewise retiered OUT of this catastrophic
+    # scan — but to the UNGATED ask tier (ASK_PATTERNS below, alongside
+    # `gh release delete`), NOT to CLOUD_ASK_PATTERNS (#4216). Rationale:
+    # deleting an IAM credential is a legitimate, often security-POSITIVE step
+    # (revoking an exposed key whose replacement is already active) that a
+    # supervised operator must be able to run in-session — a hard block left
+    # only the undocumented script-file bypass. It stays UNGATED so a repo that
+    # set guards.cloudCli:false / LOOM_GUARD_CLOUD=0 for EC2-churn convenience
+    # would still ASK (never silently allow) on IAM deletion, and a headless
+    # sweep still effectively blocks (an ASK with no human to answer denies;
+    # see defaults/docs/guard-hooks.md). The remaining aws forms below stay
+    # ungated catastrophic denies — a hard safety floor (#3593): mass object /
+    # bucket deletion (`s3 rm --recursive`, `s3 rb`) and stack teardown
+    # (`cloudformation delete-stack`) were not part of the rotation incident and
+    # are deliberately kept as hard denies.
     'aws s3 rm.*--recursive'
     'aws s3 rb'
-    'aws iam delete'
     'aws cloudformation delete-stack'
 
     # Docker mass destruction
@@ -1411,9 +1425,22 @@ lifecycle_or_cloud_reason() {
     }'
 }
 
-_LIFECYCLE_REASON=$(lifecycle_or_cloud_reason "$COMMAND_NO_COMMENT" | head -1)
-if [[ -n "$_LIFECYCLE_REASON" ]]; then
-    deny "BLOCKED: $_LIFECYCLE_REASON" "lifecycle-or-cloud-delete"
+# Split the single deny call this used to share (#4216). System-lifecycle
+# commands (halt/reboot/poweroff/shutdown/init 0|6) are a hard safety floor and
+# stay DENY. The az/gcloud `… delete` cloud branch was retiered to the UNGATED
+# ask tier — mirroring the `aws iam delete` move above — so a supervised
+# operator is prompted rather than hard-blocked, while a headless sweep's
+# unanswered ASK still blocks (see defaults/docs/guard-hooks.md). A lifecycle
+# deny takes precedence over a cloud-delete ask in a compound command (e.g.
+# `az group delete …; halt`), so the hard floor is never downgraded.
+_LIFECYCLE_CLOUD_REASONS=$(lifecycle_or_cloud_reason "$COMMAND_NO_COMMENT")
+_LIFECYCLE_DENY=$(printf '%s\n' "$_LIFECYCLE_CLOUD_REASONS" | grep '^system lifecycle command:' | head -1)
+if [[ -n "$_LIFECYCLE_DENY" ]]; then
+    deny "BLOCKED: $_LIFECYCLE_DENY" "lifecycle"
+fi
+_CLOUD_DELETE_ASK=$(printf '%s\n' "$_LIFECYCLE_CLOUD_REASONS" | grep '^cloud resource deletion:' | head -1)
+if [[ -n "$_CLOUD_DELETE_ASK" ]]; then
+    ask "Command requires confirmation: $COMMAND ($_CLOUD_DELETE_ASK — retiered to the ungated ask tier in #4216; an interactive operator confirms, a headless session still blocks)" "cloud-delete-ask"
 fi
 
 # =============================================================================
@@ -1964,9 +1991,22 @@ ASK_PATTERNS=(
     # a repo opts IN via guards.reversibleGh (REVERSIBLE_GH_ASK_PATTERNS below).
     '(^|[;&|[:space:]])gh release delete'
 
-    # NOTE: cloud CLI (aws) + docker ASK patterns are NOT in this ungated array.
-    # They live in CLOUD_ASK_PATTERNS below, gated by cloud_guard_enabled() so
-    # cloud-dev repos can opt down (LOOM_GUARD_CLOUD=0 / guards.cloudCli:false).
+    # Cloud IAM credential deletion — retiered from the catastrophic ALWAYS_BLOCK
+    # list to this UNGATED ask tier (#4216). Kept OUT of CLOUD_ASK_PATTERNS on
+    # purpose: that array is gated by cloud_guard_enabled(), so a repo that set
+    # guards.cloudCli:false / LOOM_GUARD_CLOUD=0 for EC2-churn convenience would
+    # SILENTLY bypass IAM deletion too — an unacceptable weakening for credential
+    # deletion. Ungated here means: always prompt an interactive operator, never
+    # silently allow, and still block a headless sweep (an ASK with no human to
+    # answer denies, per defaults/docs/guard-hooks.md). The az/gcloud `… delete`
+    # peer is handled by the segment parser above, which splits its former deny
+    # into a lifecycle deny + this same cloud-delete ask.
+    '(^|[;&|[:space:]])aws iam delete'
+
+    # NOTE: the remaining cloud CLI (aws ec2/lambda) + docker ASK patterns are
+    # NOT in this ungated array. They live in CLOUD_ASK_PATTERNS below, gated by
+    # cloud_guard_enabled() so cloud-dev repos can opt down (LOOM_GUARD_CLOUD=0 /
+    # guards.cloudCli:false).
 
     # Service management
     '(^|[;&|[:space:]])systemctl restart'

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -385,16 +385,32 @@ assert_deny "Block aws s3 rm recursive" \
 assert_deny "Block aws s3 rb" \
     "aws s3 rb s3://my-bucket --force"
 
+# Deliberately KEPT catastrophic in #4216 (only aws iam delete + az/gcloud delete
+# moved to ask) — mass object/bucket deletion and stack teardown stay hard denies.
+assert_deny "Block aws cloudformation delete-stack (kept catastrophic #4216)" \
+    "aws cloudformation delete-stack --stack-name prod"
+
 # aws ec2 terminate-instances is no longer an ALWAYS_BLOCK deny (#3593) — it is
 # a toggle-gated ask (see the cloud-toggle section below).
 assert_ask "Ask (not deny) for aws ec2 terminate-instances (#3593)" \
     "aws ec2 terminate-instances --instance-ids i-1234"
 
-assert_deny "Block gcloud delete" \
+# gcloud/az `… delete` are no longer ALWAYS_BLOCK denies (#4216) — they were
+# retiered to the ungated ask tier alongside `aws iam delete` (see the #4216
+# section below). A supervised operator confirms; a headless sweep still blocks.
+assert_ask "Ask (not deny) for gcloud ... delete (#4216)" \
     "gcloud compute instances delete my-instance"
 
 assert_deny "Block docker system prune" \
     "docker system prune -af"
+
+# aws iam delete-* was retiered from ALWAYS_BLOCK to the ungated ask tier (#4216)
+# — credential deletion is a legitimate security-positive step, so it now prompts
+# an interactive operator instead of hard-blocking (headless still blocks).
+assert_ask "Ask (not deny) for aws iam delete-user (#4216)" \
+    "aws iam delete-user --user-name bob"
+assert_ask "Ask (not deny) for aws iam delete-access-key (#4216)" \
+    "aws iam delete-access-key --access-key-id AKIA --user-name bob"
 
 assert_deny "Block DROP DATABASE" \
     "psql -c 'DROP DATABASE mydb;'"
@@ -898,7 +914,10 @@ assert_deny_env "Cloud toggle off does NOT weaken: aws s3 rb still denied" \
     "LOOM_GUARD_CLOUD=0" "aws s3 rb s3://prod-bucket --force" "$CLOUD_OFF_REPO"
 assert_deny_env "Cloud toggle off does NOT weaken: aws s3 rm --recursive still denied" \
     "LOOM_GUARD_CLOUD=0" "aws s3 rm s3://prod-bucket/data --recursive" "$CLOUD_OFF_REPO"
-assert_deny_env "Cloud toggle off does NOT weaken: aws iam delete-user still denied" \
+# aws iam delete moved to the UNGATED ask tier (#4216) — it is NOT gated by the
+# cloud toggle, so LOOM_GUARD_CLOUD=0 must still ASK (never silently allow). This
+# is the whole point of keeping it ungated rather than in CLOUD_ASK_PATTERNS.
+assert_ask_env "Cloud toggle off does NOT weaken: aws iam delete-user still ASKS (ungated #4216)" \
     "LOOM_GUARD_CLOUD=0" "aws iam delete-user --user-name bob" "$CLOUD_OFF_REPO"
 assert_deny_env "Cloud toggle off does NOT weaken: aws cloudformation delete-stack still denied" \
     "LOOM_GUARD_CLOUD=0" "aws cloudformation delete-stack --stack-name prod" "$CLOUD_OFF_REPO"
@@ -1373,10 +1392,13 @@ assert_allow "Allow 'hazard...delete' prose in a gh pr comment body (#3584)" \
 assert_ask "Ask (not deny) for 'shutdown' inside an aws ec2 flag name (#3584)" \
     "aws ec2 run-instances --instance-initiated-shutdown-behavior stop"
 
-# Regression: the lifecycle/cloud words as STANDALONE commands still DENY.
-assert_deny "Regression (#3584): 'az group delete' as command word still denied" \
+# Regression: the LIFECYCLE words as STANDALONE commands still DENY. The
+# az/gcloud cloud-delete branch was retiered to ask (#4216) — the segment parser
+# still classifies the command word, but the call site now splits lifecycle
+# (deny) from cloud-delete (ask), so these two now ASK rather than deny.
+assert_ask "Retier (#4216): 'az group delete' command word now ASKS" \
     "az group delete my-rg --yes"
-assert_deny "Regression (#3584): 'gcloud ... delete' as command word still denied" \
+assert_ask "Retier (#4216): 'gcloud ... delete' command word now ASKS" \
     "gcloud compute instances delete my-instance"
 assert_deny "Regression (#3584): standalone 'halt' still denied" \
     "halt"
@@ -1442,7 +1464,10 @@ assert_deny "#3755: 'env FOO=bar halt' still denied after quote-aware split" \
     "env FOO=bar halt"
 assert_deny "#3755: standalone 'halt' still denied" \
     "halt"
-assert_deny "#3755: 'az group delete' command word still denied" \
+# az/gcloud delete is still classified by command-word segmentation, but the
+# cloud-delete branch now ASKS instead of denying (#4216) — the quote-aware
+# split still resolves the command word correctly, which is what this pins.
+assert_ask "#3755: 'az group delete' command word still classified (now ASKS, #4216)" \
     "az group delete my-rg --yes"
 # Safety floor mirror of strip_literal_text() (#3679): a quoted span carrying a
 # command substitution keeps its separators ACTIVE, so a smuggled lifecycle word
@@ -1921,6 +1946,23 @@ if [[ -f "$DL_LOG" ]] && \
 else
     dl_assert "ask logs a JSONL record (decision=ask, tier=ask)" 1 "record: ${_dl_rec:-<none>}"
 fi
+
+# (b-#4216) The patterns retiered from catastrophic deny to the ungated ask tier
+# emit decision=ask, tier=ask in the decision log — the audit-trail AC. Pins both
+# the raw-pattern move (aws iam delete) and the segment-parser split (az delete).
+for _dl_retier in "aws iam delete-access-key --access-key-id AKIA --user-name bob" "az group delete my-rg --yes"; do
+    rm -f "$DL_LOG"
+    make_input "$_dl_retier" "$REPO_ROOT" | \
+        env LOOM_GUARD_DECISION_LOG=1 LOOM_GUARD_DECISION_LOG_FILE="$DL_LOG" "$GUARD" >/dev/null 2>&1 || true
+    _dl_rec="$(tail -1 "$DL_LOG" 2>/dev/null)"
+    if [[ -f "$DL_LOG" ]] && \
+       [[ "$(printf '%s' "$_dl_rec" | jq -r '.decision' 2>/dev/null)" == "ask" ]] && \
+       [[ "$(printf '%s' "$_dl_rec" | jq -r '.tier' 2>/dev/null)" == "ask" ]]; then
+        dl_assert "#4216 retiered pattern logs decision=ask, tier=ask ($_dl_retier)" 0
+    else
+        dl_assert "#4216 retiered pattern logs decision=ask, tier=ask ($_dl_retier)" 1 "record: ${_dl_rec:-<none>}"
+    fi
+done
 
 # (c) An allow-only command (full-path, non-matching) writes NO record even with
 # the toggle on. `cargo build` is not fast-pathed and matches no deny/ask rule.


### PR DESCRIPTION
Closes #4216

## What & why

During a 2026-07-28 credential rotation the cloud guard hard-BLOCKED
`aws iam delete-access-key` — the security-positive step (revoking an exposed
key whose verified replacement was already active). The pattern sat in the
catastrophic, ungated ALWAYS_BLOCK deny tier, so there was no in-session
recourse other than the undocumented script-file bypass.

This retiers selected cloud-destruction patterns from catastrophic deny to the
**ungated ask tier** (curator's Option A, the minimal set), splits the shared
lifecycle/cloud deny call site, updates the tier docs, and extends the guard
test suite. It does **not** weaken autonomous-mode protection.

## Per-pattern decisions (deliberate, mirroring #4063 discipline)

**Moved to the ungated ask tier** (always prompts an interactive operator, never
silently allowed, headless still blocks):
- `aws iam delete*` — moved out of the raw ALWAYS_BLOCK list into `ASK_PATTERNS`
  alongside `gh release delete`.
- `az ... delete` / `gcloud ... delete` — the segment parser still classifies
  them; the call site now splits lifecycle (deny) from cloud-delete (ask).

Kept **ungated** on purpose (NOT folded into the `guards.cloudCli` /
`CLOUD_ASK_PATTERNS` toggle): `guards.cloudCli:false` / `LOOM_GUARD_CLOUD=0`
would otherwise silently bypass IAM deletion entirely — an unacceptable
weakening for credential deletion (curator flag against Option B). A test pins
that `LOOM_GUARD_CLOUD=0` still ASKS on `aws iam delete-user`.

**Kept as catastrophic deny** (not part of the rotation incident):
`aws s3 rm --recursive`, `aws s3 rb`, `aws cloudformation delete-stack`,
`docker system prune`. Pinned with explicit deny tests.

**Call-site split**: system-lifecycle commands (`halt`, `reboot`, `poweroff`,
`shutdown`, `init 0|6`) remain HARD DENIES; only the cloud-delete branch moves
to ask. A lifecycle deny outranks a cloud-delete ask in a compound command, so
the hard floor is never downgraded.

## Headless / autonomous safety (no new code needed)

No interactivity detection was added. Under `--dangerously-skip-permissions`
(how every autonomous sweep runs) an ASK decision has no human to answer it and
therefore blocks — functionally a silent deny. So a deny to ask move preserves
autonomous-mode blocking automatically while giving interactive sessions a
prompt. This is documented at `defaults/docs/guard-hooks.md`, "Autonomous Guard
Defaults" section ("A headless sweep runs under `--dangerously-skip-permissions`
... an ASK decision has no human to answer it — so it blocks").

## Docs

- Corrected the cloud opt-out and reversible-gh tier prose so `aws iam delete*`
  and `az`/`gcloud delete` are listed in the ungated ask tier, not the
  catastrophic deny list.
- Added a "When a Legitimate Operation Is Pattern-Blocked" section: (1)
  interactive to the ask-tier prompt is the sanctioned path; (2) headless to
  re-run in a supervised interactive session by design; (3) the Write+`bash
  file` script workaround is explicitly UNSANCTIONED (a generic bypass that
  defeats every pattern and leaves no ask/deny record) — the correct fix for a
  recurring false positive is a pattern/tier-change PR like this one.

## Tests (all automated in tests/hooks/test-guard-destructive.sh)

- Retiered patterns emit `permissionDecision:"ask"` (raw `aws iam delete*` and
  the az/gcloud segment-parser split).
- Decision log records `{"decision":"ask","tier":"ask"}` for the retiered
  patterns.
- System-lifecycle commands (`halt`, `reboot`, `init 0`) still DENY after the
  split.
- Kept-catastrophic patterns (`s3 rm --recursive`, `s3 rb`,
  `cloudformation delete-stack`, `docker system prune`) still DENY.
- `LOOM_GUARD_CLOUD=0` still ASKS on `aws iam delete-user` (ungated).
- #3584 prose false-positive regression (hazard...delete near az/gcloud prose)
  still ALLOWS.

Full suite: 458/458 pass locally when run with a clean environment
(`env -u LOOM_FORCE_SCOPE -u LOOM_GUARD_DECISION_LOG`). Note: the autonomous
guard defaults `LOOM_FORCE_SCOPE=protected` and `LOOM_GUARD_DECISION_LOG=1`, if
exported in the runner's environment, leak into the force-scope and
decision-log-toggle tests and cause 12 unrelated failures — these are
pre-existing/environment-driven (confirmed identical against the unmodified
main guard) and untouched by this change.

## Manual verification of the interactive path

I cannot spawn a nested interactive session to literally prove the prompt
appears, so I verified the code path instead: running the guard on
`aws iam delete-user --user-name bob`, `aws iam delete-access-key ...`,
`az group delete ...`, and `gcloud compute instances delete ...` each produces a
JSON decision with `permissionDecision:"ask"` and a reason (the interactive
prompt Claude Code renders from that ASK). The headless-blocks behavior is not
newly implemented here; it is the documented meaning of an unanswered ASK under
`--dangerously-skip-permissions` (cited above).

## Lockstep

`.loom/hooks/guard-destructive-generic.sh` is kept byte-identical to
`defaults/hooks/guard-destructive-generic.sh` (verified with `cmp`; both were
byte-identical at HEAD and now carry the identical 58-line diff). Note:
`./.loom/scripts/resync-installed.sh --dry-run` resolves REPO_ROOT via
`git rev-parse --git-common-dir`, which from a worktree points at the primary
workspace rather than the worktree, so it reports the primary checkout as
unchanged (exit 0); the worktree lockstep was therefore verified directly with
`cmp` / `diff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
