### PR TITLE
feat(daemon): machine-mode lifecycle scripts + loom restart verb (#4229)

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1414,13 +1414,21 @@ not the daemon, and is a separate follow-up.
 
 ## Operability — config, start/stop, E2E (Phase D, #3813)
 
-> **Machine-level `loom` dispatcher (Epic #3835 Phase 3a, #4157).** A machine-level
-> `loom` entry point at `~/.local/bin/loom` (sibling of `~/.local/bin/loom-daemon`)
-> resolves the `~/.local/share/loom` checkout and exec's into it —
-> `loom start|stop|status|sweep|update`. It is distinct from the per-repo tmux
-> agent-pool manager `./.loom/bin/loom`; the name-collision resolution, checkout
-> layout, and the thin-`update` boundary are documented in
-> [`machine-dispatcher.md`](machine-dispatcher.md).
+> **Machine-level `loom` dispatcher (Epic #3835 Phase 3a #4157, Phase 3b #4229).**
+> A machine-level `loom` entry point at `~/.local/bin/loom` (sibling of
+> `~/.local/bin/loom-daemon`) resolves the `~/.local/share/loom` checkout and
+> exec's into it — `loom start|stop|restart|status|sweep|update`. It is distinct
+> from the per-repo tmux agent-pool manager `./.loom/bin/loom`; the
+> name-collision resolution, checkout layout, and the thin-`update` boundary
+> are documented in [`machine-dispatcher.md`](machine-dispatcher.md). Every
+> delegating verb hands its lifecycle-script delegate
+> (`loom-daemon-start.sh`/`-stop.sh`/`-update.sh`) the resolved checkout via
+> `LOOM_MACHINE_CHECKOUT`, so the plist `WorkingDirectory` and the
+> `.daemon.pid`/`.daemon.flags`/startup-log home resolve consistently —
+> `$HOME/.loom`, not a `$PWD`-derived repo — regardless of which directory
+> `loom` was invoked from (#4229). Direct invocation of a lifecycle script (no
+> dispatcher) is unaffected: the pre-#4229 `$PWD`-based `find_repo_root()`
+> contract remains the fallback, unchanged.
 
 Phases A–C built the autonomous *engine* (work finder, dynamic concurrency,
 main-health gate) as env-var-only surfaces. Phase D (#3813) adds the
@@ -2099,8 +2107,12 @@ process:
   per-user domain (`gui/<uid>` with an active GUI login, else the SSH-reachable
   `user/<uid>` background domain — #4130) instead of a plain `nohup … &` (#3972 —
   see "macOS session-bootstrap hazard" below); on Linux it stays a plain nohup
-  background job,
-- backgrounds the daemon and writes a PID file at `.loom/.daemon.pid` (gitignored),
+  background job with no reboot/crash supervision (deferred to #4260),
+- backgrounds the daemon and writes a PID file at `.loom/.daemon.pid` (gitignored)
+  — or, in **machine mode** (dispatcher-driven, `LOOM_MACHINE_CHECKOUT` set,
+  #4229), at `$HOME/.loom/.daemon.pid` so the same machine-wide launchd
+  singleton is tracked consistently no matter which repo `loom start` ran
+  from; see [`machine-dispatcher.md`](machine-dispatcher.md#the-pidflags-relocation-decision),
 - refuses a second start when the PID file points at a live process, and surfaces
   the daemon's own **singleton-guard** refusal (#3806) — if the backgrounded
   process exits immediately it prints the startup-log tail instead of leaving a

--- a/defaults/docs/machine-dispatcher.md
+++ b/defaults/docs/machine-dispatcher.md
@@ -1,10 +1,10 @@
 # Machine-level `loom` dispatcher
 
-Epic #3835 Phase 3a (#4157). The `loom` dispatcher is a machine-level entry
-point installed to `~/.local/bin/loom`. It resolves the machine-level Loom
-checkout at `~/.local/share/loom` and exec's into it. It is a sibling of the
-`~/.local/bin/loom-daemon` binary — one install per machine, shared across every
-repo Loom is installed into.
+Epic #3835 Phase 3a (#4157) + Phase 3b (#4229). The `loom` dispatcher is a
+machine-level entry point installed to `~/.local/bin/loom`. It resolves the
+machine-level Loom checkout at `~/.local/share/loom` and exec's into it. It is a
+sibling of the `~/.local/bin/loom-daemon` binary — one install per machine,
+shared across every repo Loom is installed into.
 
 ```
 loom <command> [options]
@@ -14,6 +14,7 @@ loom <command> [options]
 |---------|--------------|
 | `start` | Start the machine-level `loom-daemon` (delegates to `loom-daemon-start.sh`) |
 | `stop`  | Stop the machine-level `loom-daemon` (delegates to `loom-daemon-stop.sh`) |
+| `restart` | Restart the machine-level `loom-daemon` (drain-and-roll; falls back to stop+start) |
 | `status`| Show machine-level + current-repo status (read-only) |
 | `sweep <issue>` | Dispatch `/loom:sweep <issue>` for the current repo |
 | `update`| Thin delegate to `loom-daemon-update.sh` (no rebuild logic of its own) |
@@ -45,7 +46,7 @@ There are two different Loom surfaces that both answer to the name `loom`:
 
 | Surface | What it is | Verbs |
 |---------|-----------|-------|
-| `~/.local/bin/loom` (this dispatcher) | Machine-level runtime driver | `start stop status sweep update` |
+| `~/.local/bin/loom` (this dispatcher) | Machine-level runtime driver | `start stop restart status sweep update` |
 | `./.loom/bin/loom` | Per-repo **tmux agent-pool** manager | `start status health stop attach send scale logs` |
 
 Three verbs collide by name — `start`, `stop`, `status` — and mean *different
@@ -70,6 +71,10 @@ machine dispatcher. The dispatcher resolves this by **detecting** a nearby
   and prints a disambiguation naming *both* surfaces, then exits non-zero — it
   never silently runs the wrong one. Force the machine surface with
   `loom start --machine`, or run the pool with `./.loom/bin/loom start`.
+  `restart` (#4229) gets the **same guard**, even though the per-repo pool
+  manager has no `restart` verb of its own — guard consistency across the
+  three process-mutating verbs is cheaper than explaining why `restart` is the
+  odd one out.
 - **`status`** (read-only, and required by AC7 to produce output from inside a
   repo): the dispatcher prints machine-level status and a clearly-labelled line
   pointing at the per-repo pool manager (`… run: ./.loom/bin/loom status`). It
@@ -99,6 +104,85 @@ says so explicitly — it does **not** present a `jq`-less host as "no config".
 `loom-daemon-update.sh` (built by #3968, extended by the shipped #4055 self-update
 loop). It implements **no** rebuild / reprovision / restart logic itself, so it
 neither pre-empts #4017 (auto-rebuild-when-stale) nor duplicates #4055.
+
+## Machine mode: LOOM_MACHINE_CHECKOUT hand-off (Phase 3b, #4229)
+
+Phase 3a shipped `start`/`stop`/`update` as delegates, but each of the three
+lifecycle scripts (`loom-daemon-start.sh`, `-stop.sh`, `-update.sh`) still
+resolved its own operating root by walking up from `$PWD`
+(`find_repo_root()`), independent of what this dispatcher had already
+resolved. That produced two concrete gaps, closed here:
+
+1. **`loom update` failed outside a Loom source checkout.** From a consumer
+   repo, `find_repo_root()` found the consumer repo (no
+   `loom-daemon/Cargo.toml` there) and refused; from a non-repo directory it
+   found nothing at all and refused with "Not in a Loom workspace" — even
+   though this dispatcher had *already* resolved and validated the machine
+   checkout.
+2. **`loom start`/`stop` bound machine-global daemon state to whichever repo
+   they were invoked from.** The launchd label (`com.rjwalters.loom-daemon`)
+   is a machine-wide singleton, but the rendered plist's `WorkingDirectory`
+   and the `.daemon.pid`/`.daemon.flags` files were `$REPO_ROOT`-relative — so
+   `loom start` from repo A and `loom update` from repo B could read/write two
+   different pid/flags files against the same launchd job.
+
+**The fix**: every verb that delegates into the checkout (`start`, `stop`,
+`update`, `restart`) exports `LOOM_MACHINE_CHECKOUT=<resolved checkout>` before
+exec'ing/invoking its lifecycle-script delegate. Each lifecycle script now
+checks this variable *first*, ahead of its `$PWD`-based `find_repo_root()`
+fallback:
+
+- **Set** (machine mode — always true for a dispatcher-driven invocation): the
+  checkout is used as the operating root (plist `WorkingDirectory`, the
+  `loom-daemon/Cargo.toml` rebuild target for `update`) **regardless of
+  `$PWD`**, and runtime artifacts — `.daemon.pid`, `.daemon.flags`, the
+  startup log — resolve under `$HOME/.loom` (the pid/flags decision below),
+  not under the checkout or the invoking directory.
+- **Unset** (direct invocation of a lifecycle script, no dispatcher — the
+  pre-#4229 dev workflow): every script behaves **byte-for-byte** as before,
+  `$PWD`-based `find_repo_root()` included. Machine mode is strictly additive.
+
+### The pid/flags relocation decision
+
+`#4042` already established that a `.loom/.daemon.pid` file is an unreliable
+running-state source under launchd (`KeepAlive:{SuccessfulExit:true}` assigns
+a fresh pid on every supervised relaunch) — which argued for dropping pid
+files entirely under launchd and treating `launchctl print` as the sole
+source of truth. This unit takes the **narrower, lower-risk option** instead:
+relocate `.daemon.pid`/`.daemon.flags`/the startup log from
+`$REPO_ROOT/.loom/` to `$HOME/.loom/` in machine mode, rather than removing
+pid-file tracking altogether. `$HOME/.loom/` is not new state — it is the
+**existing** machine-level state home (socket, token pool, `activity.db`,
+`daemon.log` already live there); this only adds a few more files to a
+directory that was already the machine-level source of truth, and the
+pid-file/nohup fallback tier every lifecycle script's own ownership-detection
+logic already has (see `loom-daemon-update.sh`'s `DAEMON_MANAGER` resolution)
+keeps working unchanged. No existing state (socket, tokens, `activity.db`,
+logs) moves. Dropping pid files entirely under launchd remains available as a
+future, more invasive follow-up if the pid-file tier ever proves more
+confusing than useful in machine mode.
+
+### `restart` verb (Gap 3)
+
+`loom restart` mirrors `start`/`stop` — same collision guard — and prefers a
+**drain-and-roll** restart: it first tries the daemon's own supervised restart
+IPC (`loom-daemon restart`, #4077), which never tears down in-flight sweep
+children (unlike a `launchctl bootout`). If that is unavailable (not
+launchd-managed) or refused (not currently running, or a pre-#4077 binary), it
+falls back to a plain stop-then-start via the same checkout-resolved
+lifecycle-script delegates.
+
+### Supervision (reboot/crash) — macOS done, Linux deferred
+
+Reboot/crash supervision itself (as opposed to the workdir/pid-file relocation
+above) is already implemented and documented for macOS via launchd —
+`RunAtLoad` (#3972), `KeepAlive:{SuccessfulExit:true}` restart-only relaunch
+(#4054), and a `StartInterval` autonomy-loss watchdog (#4011), all resolved
+through the `gui/<uid>` ↦ `user/<uid>` domain fallback (#4130). See
+[`daemon-reference.md`](daemon-reference.md) → Operability for the full
+writeup. **Linux has no equivalent** — the non-Darwin path is a plain `nohup …
+&` with no reboot/crash recovery and no watchdog. This is tracked as a named
+follow-up, #4260, rather than designed inline here.
 
 ## Uninstall semantics
 

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -82,6 +82,17 @@
 #                        a host that needs one or two additional dirs (e.g. a
 #                        project-local toolchain) without inheriting the WHOLE
 #                        invoking shell's interactive PATH.
+#   LOOM_MACHINE_CHECKOUT  Machine mode (Epic #3835 Phase 3b, #4229): set by
+#                        the `scripts/loom` dispatcher to the resolved
+#                        ~/.local/share/loom checkout before it execs this
+#                        script. When set, the plist's WorkingDirectory and the
+#                        pid/flags home resolve from THIS path -- not from
+#                        $PWD -- so `loom start` manages the SAME machine-wide
+#                        singleton daemon no matter which repo it is run from.
+#                        Direct invocation of this script (the existing dev
+#                        workflow) never sets it and is unaffected: $PWD-based
+#                        find_repo_root() stays the fallback. See
+#                        defaults/docs/machine-dispatcher.md.
 #
 # Exit codes:
 #   0  daemon started (or already running)
@@ -468,7 +479,35 @@ while [[ $# -gt 0 ]]; do
 done
 
 REPO_ROOT=$(find_repo_root)
-if [[ -z "$REPO_ROOT" ]]; then
+
+# ---------- machine-mode resolution (Epic #3835 Phase 3b, #4229) ----------
+# LOOM_MACHINE_CHECKOUT (set by the `scripts/loom` dispatcher before it execs
+# this script) is authoritative regardless of $PWD: the launchd label this
+# script drives (com.rjwalters.loom-daemon) is a machine-wide singleton, so
+# `loom start` run from repo A and again from repo B must resolve the SAME
+# workdir + pid/flags home -- not two different ones keyed to whichever repo
+# happened to be $PWD when it was invoked. Direct invocation of this script
+# (no dispatcher -- the existing dev workflow) leaves this var unset and falls
+# through to the pre-#4229 $PWD-based contract below, byte-for-byte unchanged.
+MACHINE_CHECKOUT="${LOOM_MACHINE_CHECKOUT:-}"
+MACHINE_MODE=false
+if [[ -n "$MACHINE_CHECKOUT" ]]; then
+    MACHINE_MODE=true
+    if [[ ! -d "$MACHINE_CHECKOUT" ]]; then
+        err "LOOM_MACHINE_CHECKOUT does not exist: $MACHINE_CHECKOUT"
+        exit 1
+    fi
+    REPO_ROOT="$MACHINE_CHECKOUT"
+    # Runtime artifacts (pid file, persisted flags, startup log) live under the
+    # EXISTING machine-level state home (~/.loom -- socket, token pool,
+    # activity.db, and the daemon's own log already live there; see
+    # machine-dispatcher.md's "pid/flags relocation" note) rather than under
+    # the checkout itself, which may be a symlink to a developer's working
+    # clone and is not otherwise treated as writable runtime state.
+    DAEMON_STATE_HOME="$HOME/.loom"
+elif [[ -n "$REPO_ROOT" ]]; then
+    DAEMON_STATE_HOME="$REPO_ROOT/.loom"
+else
     err "Not in a Loom workspace (.loom directory not found)"
     exit 1
 fi
@@ -486,10 +525,10 @@ fi
 # stderr exactly once per run rather than once per plist rendered.
 PLIST_PATH_VALUE="$(resolve_plist_path)"
 
-PID_FILE="$REPO_ROOT/.loom/.daemon.pid"
+PID_FILE="$DAEMON_STATE_HOME/.daemon.pid"
 SOCKET_PATH="${LOOM_SOCKET_PATH:-$HOME/.loom/loom-daemon.sock}"
-START_LOG="$REPO_ROOT/.loom/logs/daemon-start.log"
-mkdir -p "$REPO_ROOT/.loom/logs"
+START_LOG="$DAEMON_STATE_HOME/logs/daemon-start.log"
+mkdir -p "$DAEMON_STATE_HOME/logs"
 
 # ---------- autonomy-desired marker + heartbeat paths (#4011) ----------
 # LOOM_DIR is the machine-level dir the daemon uses for its socket/log/heartbeat
@@ -509,7 +548,11 @@ if [[ -f "$PID_FILE" ]]; then
     existing_pid=$(cat "$PID_FILE" 2>/dev/null || true)
     if [[ -n "$existing_pid" ]] && kill -0 "$existing_pid" 2>/dev/null; then
         warn "loom-daemon already running (pid $existing_pid, per $PID_FILE)."
-        echo "To restart: ./.loom/scripts/cli/loom-daemon-stop.sh && $0" >&2
+        if [[ "$MACHINE_MODE" == "true" ]]; then
+            echo "To restart: loom restart  (or: loom stop && loom start)" >&2
+        else
+            echo "To restart: ./.loom/scripts/cli/loom-daemon-stop.sh && $0" >&2
+        fi
         exit 0
     fi
     # Stale PID file — clean it up and continue.
@@ -582,7 +625,7 @@ fi
 # --no-health-gate) is preserved verbatim, one per line. Written on every
 # start attempt (success or failure) so the record always reflects the most
 # recent invocation.
-FLAGS_FILE="$REPO_ROOT/.loom/.daemon.flags"
+FLAGS_FILE="$DAEMON_STATE_HOME/.daemon.flags"
 : > "$FLAGS_FILE"
 # Guard the array expansion: a bare invocation (the common case) leaves
 # ORIGINAL_ARGS empty, and "${arr[@]}" on a zero-element array is an unbound
@@ -601,6 +644,11 @@ fi
 echo "Daemon binary: $DAEMON_BIN"
 echo "Socket:        $SOCKET_PATH"
 echo "Daemon log:    ${HOME}/.loom/daemon.log"
+if [[ "$MACHINE_MODE" == "true" ]]; then
+    echo "Mode:          machine (workdir: $REPO_ROOT, state: $DAEMON_STATE_HOME)"
+else
+    echo "Mode:          dev (repo: $REPO_ROOT)"
+fi
 
 # ---------- foreground mode ----------
 if [[ "$FOREGROUND" == "true" ]]; then
@@ -742,7 +790,11 @@ if [[ "$USE_LAUNCHD" == "true" ]]; then
     ok "loom-daemon started under launchd (pid $daemon_pid, label $LAUNCHD_LABEL)."
     echo "PID file: $PID_FILE"
     echo "Intent marker: $INTENT_MARKER"
-    echo "Stop with: ./.loom/scripts/cli/loom-daemon-stop.sh"
+    if [[ "$MACHINE_MODE" == "true" ]]; then
+        echo "Stop with: loom stop"
+    else
+        echo "Stop with: ./.loom/scripts/cli/loom-daemon-stop.sh"
+    fi
     exit 0
 fi
 
@@ -774,5 +826,9 @@ write_intent_marker "false" ""
 provision_watchdog_job
 ok "loom-daemon started (pid $daemon_pid). PID file: $PID_FILE"
 echo "Intent marker: $INTENT_MARKER"
-echo "Stop with: ./.loom/scripts/cli/loom-daemon-stop.sh"
+if [[ "$MACHINE_MODE" == "true" ]]; then
+    echo "Stop with: loom stop"
+else
+    echo "Stop with: ./.loom/scripts/cli/loom-daemon-stop.sh"
+fi
 exit 0

--- a/defaults/scripts/cli/loom-daemon-stop.sh
+++ b/defaults/scripts/cli/loom-daemon-stop.sh
@@ -70,6 +70,14 @@
 #                                 A start done with --no-launchd / LOOM_DAEMON_LAUNCHD=0
 #                                 must get a stop that never reads or mutates the
 #                                 machine-global launchd domain (issue #4078).
+#   LOOM_MACHINE_CHECKOUT         Machine mode (Epic #3835 Phase 3b, #4229): set
+#                                 by the `scripts/loom` dispatcher before it execs
+#                                 this script. When set, the pid file is read from
+#                                 the machine-level state home (~/.loom) instead of
+#                                 $PWD's repo -- matching loom-daemon-start.sh, so
+#                                 `loom stop` always targets the same machine-wide
+#                                 daemon regardless of the invoking directory.
+#                                 Direct invocation (no dispatcher) never sets it.
 #
 # Exit codes:
 #   0  daemon stopped (or was not running)
@@ -125,12 +133,27 @@ while [[ $# -gt 0 ]]; do
 done
 
 REPO_ROOT=$(find_repo_root)
-if [[ -z "$REPO_ROOT" ]]; then
+
+# ---------- machine-mode resolution (Epic #3835 Phase 3b, #4229) ----------
+# Mirrors loom-daemon-start.sh: LOOM_MACHINE_CHECKOUT (set by the dispatcher)
+# is authoritative regardless of $PWD, so `loom stop` always resolves the SAME
+# pid file loom-daemon-start.sh wrote for the machine-wide singleton daemon --
+# not a different $PWD-derived one. Direct invocation is unaffected.
+MACHINE_CHECKOUT="${LOOM_MACHINE_CHECKOUT:-}"
+if [[ -n "$MACHINE_CHECKOUT" ]]; then
+    if [[ ! -d "$MACHINE_CHECKOUT" ]]; then
+        err "LOOM_MACHINE_CHECKOUT does not exist: $MACHINE_CHECKOUT"
+        exit 1
+    fi
+    DAEMON_STATE_HOME="$HOME/.loom"
+elif [[ -n "$REPO_ROOT" ]]; then
+    DAEMON_STATE_HOME="$REPO_ROOT/.loom"
+else
     err "Not in a Loom workspace (.loom directory not found)"
     exit 1
 fi
 
-PID_FILE="$REPO_ROOT/.loom/.daemon.pid"
+PID_FILE="$DAEMON_STATE_HOME/.daemon.pid"
 GRACE_SECS="${LOOM_DAEMON_STOP_GRACE_SECS:-10}"
 
 # ---------- autonomy-desired marker + watchdog (#4011) ----------

--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -90,6 +90,17 @@
 #   LOOM_DAEMON_UPDATE_RELAUNCH  macOS/launchd only: 1/true/yes is equivalent to
 #                          passing --relaunch (opt in to the re-render + relaunch
 #                          on a refused restart).
+#   LOOM_MACHINE_CHECKOUT  Machine mode (Epic #3835 Phase 3b, #4229): set by the
+#                          `scripts/loom` dispatcher to the resolved
+#                          ~/.local/share/loom checkout before it execs this
+#                          script. When set, THIS is the source tree rebuilt
+#                          from (overriding the $PWD-based find_repo_root()
+#                          below), so `loom update` works from any directory --
+#                          a consumer repo, or no repo at all -- instead of
+#                          requiring $PWD to already be inside a Loom source
+#                          checkout. Direct invocation of this script (no
+#                          dispatcher -- the existing dev workflow) never sets
+#                          it and is unaffected.
 #
 # Exit codes:
 #   0  up to date (no-op) OR rebuild+provision+restart succeeded
@@ -230,7 +241,29 @@ while [[ $# -gt 0 ]]; do
 done
 
 REPO_ROOT=$(find_repo_root)
-if [[ -z "$REPO_ROOT" ]]; then
+
+# ---------- machine-mode source-tree override (Epic #3835 Phase 3b, #4229) --
+# Gap 1: this script rebuilds FROM SOURCE and used to resolve that source tree
+# by walking up from $PWD -- so from a consumer repo (find_repo_root() finds
+# the consumer repo, which has no loom-daemon/Cargo.toml) or a non-repo
+# directory (find_repo_root() finds nothing) it refused with "only works
+# inside a Loom source checkout", even though the `scripts/loom` dispatcher
+# had ALREADY resolved+validated the machine checkout before exec'ing here.
+# LOOM_MACHINE_CHECKOUT overrides the $PWD-derived REPO_ROOT with that
+# checkout, so `loom update` rebuilds it from any directory. Direct invocation
+# of this script (no dispatcher) never sets it and is unaffected -- the
+# pre-#4229 $PWD-based contract is the fallback below.
+MACHINE_CHECKOUT="${LOOM_MACHINE_CHECKOUT:-}"
+if [[ -n "$MACHINE_CHECKOUT" ]]; then
+    if [[ ! -d "$MACHINE_CHECKOUT" ]]; then
+        err "LOOM_MACHINE_CHECKOUT does not exist: $MACHINE_CHECKOUT"
+        exit 1
+    fi
+    REPO_ROOT="$MACHINE_CHECKOUT"
+    DAEMON_STATE_HOME="$HOME/.loom"
+elif [[ -n "$REPO_ROOT" ]]; then
+    DAEMON_STATE_HOME="$REPO_ROOT/.loom"
+else
     err "Not in a Loom workspace (.loom directory not found)"
     exit 1
 fi
@@ -242,10 +275,31 @@ if [[ ! -f "$DAEMON_DIR/Cargo.toml" ]]; then
     exit 1
 fi
 
-PID_FILE="$REPO_ROOT/.loom/.daemon.pid"
-FLAGS_FILE="$REPO_ROOT/.loom/.daemon.flags"
-START_SCRIPT="$REPO_ROOT/.loom/scripts/cli/loom-daemon-start.sh"
-STOP_SCRIPT="$REPO_ROOT/.loom/scripts/cli/loom-daemon-stop.sh"
+# Resolve a lifecycle script under REPO_ROOT: the INSTALLED copy first (a
+# self-hosted checkout's own .loom/scripts/cli/, kept in sync by
+# resync-installed.sh), falling back to defaults/scripts/cli/ -- the shipped
+# source of truth every Loom source checkout has, including a fresh clone that
+# has never been "installed" onto itself (machine mode may point at exactly
+# that). Direct (non-machine) invocation almost always resolves the first
+# candidate, matching pre-#4229 behavior byte-for-byte.
+resolve_lifecycle_script() {
+    local rel="$1" candidate
+    for candidate in \
+        "$REPO_ROOT/.loom/scripts/cli/$rel" \
+        "$REPO_ROOT/defaults/scripts/cli/$rel"; do
+        if [[ -x "$candidate" ]]; then echo "$candidate"; return 0; fi
+    done
+    echo ""
+}
+
+PID_FILE="$DAEMON_STATE_HOME/.daemon.pid"
+FLAGS_FILE="$DAEMON_STATE_HOME/.daemon.flags"
+START_SCRIPT="$(resolve_lifecycle_script loom-daemon-start.sh)"
+STOP_SCRIPT="$(resolve_lifecycle_script loom-daemon-stop.sh)"
+if [[ -z "$START_SCRIPT" || -z "$STOP_SCRIPT" ]]; then
+    err "Could not resolve loom-daemon-start.sh / loom-daemon-stop.sh under $REPO_ROOT (.loom/scripts/cli or defaults/scripts/cli)."
+    exit 1
+fi
 
 # ---------- staleness detection ----------
 DAEMON_BIN=$(locate_daemon_bin "$REPO_ROOT")
@@ -261,6 +315,9 @@ SOURCE_COMMIT=$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo "
 
 echo "Installed binary: ${DAEMON_BIN:-<none found>} (commit ${INSTALLED_COMMIT})"
 echo "Source tree HEAD:  ${SOURCE_COMMIT}"
+if [[ -n "$MACHINE_CHECKOUT" ]]; then
+    echo "Source tree:       $REPO_ROOT (machine checkout, LOOM_MACHINE_CHECKOUT)"
+fi
 
 UPDATE_NEEDED=false
 if [[ -z "$DAEMON_BIN" ]]; then

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -156,6 +156,72 @@ if [[ -f "$WORKDIR/.loom/.daemon.pid" ]]; then
     kill "$(cat "$WORKDIR/.loom/.daemon.pid" 2>/dev/null)" 2>/dev/null || true
 fi
 
+# ---------- machine mode (Epic #3835 Phase 3b, #4229) ----------
+# LOOM_MACHINE_CHECKOUT (set by the `scripts/loom` dispatcher, never by a
+# direct invocation) overrides BOTH the resolved workdir (the checkout, not
+# $PWD) and the pid/flags/startup-log home ($HOME/.loom, not $REPO_ROOT/.loom)
+# -- and must work from a directory that has NO .loom/ at all, unlike the
+# dev-mode fallback below. Every write targets a SCRATCH $HOME, never the real
+# operator ~/.loom.
+MACHINE_HOME="$(mktemp -d)"
+MACHINE_CHECKOUT="$(mktemp -d)"
+NON_REPO_DIR="$(mktemp -d)"
+
+out=$( ( cd "$NON_REPO_DIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    HOME="$MACHINE_HOME" \
+    LOOM_MACHINE_CHECKOUT="$MACHINE_CHECKOUT" \
+    LOOM_DAEMON_BIN="$FAKE_BIN" \
+    bash "$START_SCRIPT" --foreground 2>&1 ) )
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out" | grep -q '^FAKE_DAEMON'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} machine mode: start succeeds from a NON-REPO directory (no dev-mode '.loom directory not found' refusal)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} machine mode: start succeeds from a NON-REPO directory"
+    echo "  output: $out"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out" | grep -q "Mode:.*machine (workdir: $MACHINE_CHECKOUT"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} machine mode: plist workdir resolves to the checkout, not \$PWD"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} machine mode: plist workdir resolves to the checkout, not \$PWD"
+    echo "  output: $out"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -f "$MACHINE_HOME/.loom/.daemon.flags" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} machine mode: persisted flags land under \$HOME/.loom (existing machine-level state home)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} machine mode: persisted flags land under \$HOME/.loom (existing machine-level state home)"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ ! -d "$NON_REPO_DIR/.loom" && ! -d "$MACHINE_CHECKOUT/.loom" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} machine mode: no runtime state leaks into \$PWD or the checkout"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} machine mode: no runtime state leaks into \$PWD or the checkout"
+fi
+
+# Dev-mode fallback (scope guard, filed AC5): direct invocation with NO
+# LOOM_MACHINE_CHECKOUT from that SAME non-repo directory still refuses exactly
+# as before #4229 -- machine mode is additive, not a replacement.
+out_dev=$( cd "$NON_REPO_DIR" && LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --foreground 2>&1 )
+rc_dev=$?
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$rc_dev" -ne 0 ]] && echo "$out_dev" | grep -qi "Not in a Loom workspace"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} dev-mode fallback unchanged: refuses from a non-repo dir with no dispatcher (#4229 scope guard)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} dev-mode fallback unchanged: refuses from a non-repo dir with no dispatcher (#4229 scope guard)"
+fi
+rm -rf "$MACHINE_HOME" "$MACHINE_CHECKOUT" "$NON_REPO_DIR"
+
 # ---------- launchd domain resolution (#4130) ----------
 # resolve_launchd_domain() (lib/launchd-domain.sh) picks gui/<uid> when the GUI
 # (Aqua) domain resolves — byte-for-byte the pre-#4130 default — else the

--- a/defaults/scripts/tests/test-loom-daemon-stop.sh
+++ b/defaults/scripts/tests/test-loom-daemon-stop.sh
@@ -335,6 +335,63 @@ else
     echo -e "${RED}✗${NC} --help documents --restarting and the autonomy-desired marker"
 fi
 
+# ---------- machine mode (Epic #3835 Phase 3b, #4229) ----------
+# LOOM_MACHINE_CHECKOUT makes the pid-file home resolve from $HOME/.loom
+# instead of $PWD's repo -- and must work even from a directory with NO
+# .loom/ at all (unlike the dev-mode fallback, which requires one). Every
+# write below targets a SCRATCH $HOME, never the real operator ~/.loom.
+MACHINE_HOME="$(mktemp -d)"
+mkdir -p "$MACHINE_HOME/.loom"
+MACHINE_CHECKOUT="$(mktemp -d)"
+NON_REPO_DIR="$(mktemp -d)"
+
+( sleep 30 & echo $! > "$MACHINE_HOME/.loom/.daemon.pid" )
+machine_pid=$(cat "$MACHINE_HOME/.loom/.daemon.pid")
+out_machine=$( cd "$NON_REPO_DIR" && HOME="$MACHINE_HOME" LOOM_MACHINE_CHECKOUT="$MACHINE_CHECKOUT" \
+    LOOM_LAUNCHD_LABEL="$FAKE_LABEL" LOOM_DAEMON_STOP_GRACE_SECS=2 bash "$STOP_SCRIPT" 2>&1 )
+rc_machine=$?
+assert_eq "0" "$rc_machine" "machine mode: stop from a non-repo dir exits 0"
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! echo "$out_machine" | grep -qi "Not in a Loom workspace"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} machine mode: never hits the dev-mode 'Not in a Loom workspace' refusal"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} machine mode: never hits the dev-mode 'Not in a Loom workspace' refusal"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! kill -0 "$machine_pid" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} machine mode: stop resolves the pid file under \$HOME/.loom (not \$PWD) and kills it"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    kill -9 "$machine_pid" 2>/dev/null || true
+    echo -e "${RED}✗${NC} machine mode: stop resolves the pid file under \$HOME/.loom (not \$PWD) and kills it"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ ! -d "$NON_REPO_DIR/.loom" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} machine mode: stop does not require (or create) .loom/ at \$PWD"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} machine mode: stop does not require (or create) .loom/ at \$PWD"
+fi
+
+# Dev-mode fallback (scope guard): direct invocation with NO LOOM_MACHINE_CHECKOUT
+# from a non-repo directory still refuses exactly as before #4229.
+out_dev=$( cd "$NON_REPO_DIR" && LOOM_LAUNCHD_LABEL="$FAKE_LABEL" bash "$STOP_SCRIPT" 2>&1 )
+rc_dev=$?
+assert_eq "1" "$rc_dev" "dev-mode fallback unchanged: stop from a non-repo dir (no dispatcher) still exits 1"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out_dev" | grep -qi "Not in a Loom workspace"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} dev-mode fallback unchanged: reports 'Not in a Loom workspace'"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} dev-mode fallback unchanged: reports 'Not in a Loom workspace'"
+fi
+rm -rf "$MACHINE_HOME" "$MACHINE_CHECKOUT" "$NON_REPO_DIR"
+
 # ---------- summary ----------
 # Final suite-level decoy guard (#4078): nothing above should have killed the
 # by-name-matchable decoy spawned at suite start.

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -1164,6 +1164,62 @@ else
 fi
 
 # ============================================================
+# M1. Machine mode (Epic #3835 Phase 3b, #4229): LOOM_MACHINE_CHECKOUT lets
+#     `--check` rebuild-detect against the CHECKOUT's source tree even when
+#     $PWD is a totally unrelated non-Loom directory -- the concrete Gap 1
+#     regression this issue closes ("only works inside a Loom source
+#     checkout"). HOME is overridden to a scratch dir so DAEMON_STATE_HOME
+#     ($HOME/.loom in machine mode) never touches the real operator ~/.loom,
+#     matching the rest of this suite's isolation discipline.
+# ============================================================
+WM1="$BASE_WORKDIR/wm1-checkout"
+new_fixture "$WM1"
+HEADM1="$(cd "$WM1" && git rev-parse --short HEAD)"
+write_fake_daemon "$WM1/installed-loom-daemon" "$HEADM1" "$WM1/marker"
+NON_LOOM_DIR="$BASE_WORKDIR/wm1-non-loom-cwd"
+mkdir -p "$NON_LOOM_DIR"
+HOME_WM1="$BASE_WORKDIR/wm1-home"
+mkdir -p "$HOME_WM1"
+out=$( cd "$NON_LOOM_DIR" && PATH="$TEST_PATH" HOME="$HOME_WM1" LOOM_MACHINE_CHECKOUT="$WM1" \
+    LOOM_DAEMON_BIN="$WM1/installed-loom-daemon" \
+    bash "$UPDATE_SCRIPT" --check; echo "EXIT=$?" )
+rc=$(echo "$out" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "0" "$rc" "machine mode: --check from an unrelated non-Loom \$PWD resolves the checkout as source tree (Gap 1)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out" | grep -q "only works inside a Loom source checkout"; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} machine mode: never refuses with the dev-mode 'source checkout' error"
+    echo "  output: $out"
+else
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} machine mode: never refuses with the dev-mode 'source checkout' error"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out" | grep -qF "$WM1"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} machine mode: reports the machine checkout as the resolved source tree"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} machine mode: reports the machine checkout as the resolved source tree"
+    echo "  output: $out"
+fi
+
+# Dev-mode fallback (scope guard, filed AC5): the SAME non-Loom directory,
+# invoked directly (no LOOM_MACHINE_CHECKOUT -- no dispatcher), still refuses
+# exactly as before #4229. Machine mode is additive, never a replacement.
+out_dev=$( cd "$NON_LOOM_DIR" && PATH="$TEST_PATH" HOME="$HOME_WM1" bash "$UPDATE_SCRIPT" --check 2>&1 )
+rc_dev=$?
+assert_eq "1" "$rc_dev" "dev-mode fallback unchanged: --check from a non-Loom \$PWD (no dispatcher) still exits 1"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out_dev" | grep -qi "Not in a Loom workspace"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} dev-mode fallback unchanged: reports 'Not in a Loom workspace'"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} dev-mode fallback unchanged: reports 'Not in a Loom workspace'"
+fi
+
+# ============================================================
 # 25. Launchd-sandbox guards (#4078): the whole suite exercises the REAL
 #     start/stop scripts, so prove it never reached the operator's live daemon.
 #     (a) The suite-level decoy loom-daemon is still alive — no by-name kill

--- a/defaults/scripts/tests/test-loom-dispatcher.sh
+++ b/defaults/scripts/tests/test-loom-dispatcher.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # test-loom-dispatcher.sh — tests for the machine-level `loom` dispatcher and its
-# provisioning (Epic #3835 Phase 3a, #4157).
+# provisioning (Epic #3835 Phase 3a #4157, Phase 3b #4229).
 #
 # Covers:
 #   - scripts/loom — checkout resolution (AC1), collision resolution (AC3),
@@ -11,6 +11,11 @@
 #     (#4053), the symlink checkout (AC1), and the console-script invariant (AC6).
 #   - the no-shadow regression proving the two `loom` invocation forms stay
 #     disjoint (AC4).
+#   - Phase 3b (#4229): the `restart` verb (collision guard, supervised-IPC
+#     drain-and-roll, stop+start fallback) and the LOOM_MACHINE_CHECKOUT
+#     hand-off every delegating verb (start/stop/update/restart) gives its
+#     lifecycle-script delegate, INCLUDING from a non-repo directory (the
+#     concrete "loom update works outside a Loom source checkout" regression).
 #
 # Throwaway `mktemp -d` scratch per case, matching test-config-resolver.sh.
 
@@ -53,17 +58,20 @@ assert_eq() {
 make_checkout() {
     local c; c="$(mktemp -d)"
     mkdir -p "$c/defaults/scripts/cli" "$c/defaults/scripts/lib"
+    # Each stub also echoes the LOOM_MACHINE_CHECKOUT it inherited (empty
+    # string if unset) so tests can assert on the machine-mode hand-off
+    # (#4229) without changing any existing substring assertion below.
     cat > "$c/defaults/scripts/cli/loom-daemon-start.sh" <<'EOF'
 #!/usr/bin/env bash
-echo "STUB_START args=[$*]"
+echo "STUB_START args=[$*] machine_checkout=[${LOOM_MACHINE_CHECKOUT:-}]"
 EOF
     cat > "$c/defaults/scripts/cli/loom-daemon-stop.sh" <<'EOF'
 #!/usr/bin/env bash
-echo "STUB_STOP args=[$*]"
+echo "STUB_STOP args=[$*] machine_checkout=[${LOOM_MACHINE_CHECKOUT:-}]"
 EOF
     cat > "$c/defaults/scripts/cli/loom-daemon-update.sh" <<'EOF'
 #!/usr/bin/env bash
-echo "STUB_UPDATE args=[$*]"
+echo "STUB_UPDATE args=[$*] machine_checkout=[${LOOM_MACHINE_CHECKOUT:-}]"
 EOF
     chmod +x "$c/defaults/scripts/cli/"*.sh
     cp "$REAL_RESOLVER" "$c/defaults/scripts/lib/config-resolver.sh"
@@ -226,6 +234,80 @@ assert_eq "$after" "$before" "all 23 loom-* entries are byte-identical before/af
 [[ -f "$BIN2/loom" ]] && pass "only the 'loom' dispatcher was added" || fail "dispatcher not added to bin dir"
 count=$(cd "$BIN2" && ls loom-fake* 2>/dev/null | wc -l | tr -d ' ')
 assert_eq "$count" "23" "console-script count unchanged (23)"
+
+# ── Phase 3b (#4229): LOOM_MACHINE_CHECKOUT hand-off ─────────────────────────
+echo "Test 11: start/stop/update all hand LOOM_MACHINE_CHECKOUT to their delegates"
+out=$(cd "$CONSUMER" && LOOM_HOME="$CHK" bash "$DISPATCHER" start --machine 2>&1)
+assert_contains "$out" "machine_checkout=[$CHK]" "'start --machine' hands the resolved checkout to loom-daemon-start.sh"
+
+out=$(cd "$CONSUMER" && LOOM_HOME="$CHK" bash "$DISPATCHER" stop --machine 2>&1)
+assert_contains "$out" "machine_checkout=[$CHK]" "'stop --machine' hands the resolved checkout to loom-daemon-stop.sh"
+
+out=$(LOOM_HOME="$CHK" bash "$DISPATCHER" update --check 2>&1)
+assert_contains "$out" "machine_checkout=[$CHK]" "'update' hands the resolved checkout to loom-daemon-update.sh (Gap 1)"
+
+echo "Test 12: 'loom update' hands off the checkout from a NON-REPO directory too (Gap 1 regression)"
+out=$(cd "$NR" && LOOM_HOME="$CHK" bash "$DISPATCHER" update --check 2>&1)
+assert_contains "$out" "machine_checkout=[$CHK]" "'update' from a non-repo dir still resolves+hands off the machine checkout"
+rc_check=0
+(cd "$NR" && LOOM_HOME="$CHK" bash "$DISPATCHER" update --check >/dev/null 2>&1) || rc_check=$?
+assert_eq "0" "$rc_check" "'update --check' from a non-repo dir does not refuse (no 'only works inside a Loom source checkout')"
+
+# ── Phase 3b (#4229): the `restart` verb ─────────────────────────────────────
+echo "Test 13: bare 'loom restart' inside a consumer repo disambiguates like start/stop (same collision guard)"
+set +e
+out=$(cd "$CONSUMER" && LOOM_HOME="$CHK" bash "$DISPATCHER" restart 2>&1)
+rc=$?
+set -e 2>/dev/null || true
+assert_eq "$rc" "3" "bare 'loom restart' in a repo exits 3 (disambiguating non-zero)"
+assert_contains "$out" "loom restart --machine" "disambiguation names the machine surface for restart"
+assert_not_contains "$out" "STUB_STOP" "bare 'loom restart' did NOT run any delegate (no silent surface)"
+assert_not_contains "$out" "STUB_START" "bare 'loom restart' did NOT run any delegate (no silent surface)"
+
+echo "Test 14: 'loom restart --machine' prefers the supervised drain-and-roll IPC when loom-daemon accepts it"
+RESTART_BIN_OK=$(mktemp -d)
+cat > "$RESTART_BIN_OK/loom-daemon" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "restart" ]] && exit 0
+exit 1
+EOF
+chmod +x "$RESTART_BIN_OK/loom-daemon"
+set +e
+out=$(cd "$CONSUMER" && PATH="$RESTART_BIN_OK:/usr/bin:/bin" LOOM_HOME="$CHK" bash "$DISPATCHER" restart --machine 2>&1)
+rc=$?
+set -e 2>/dev/null || true
+assert_eq "$rc" "0" "'loom restart --machine' exits 0 when the supervised restart IPC succeeds"
+assert_contains "$out" "restart scheduled" "reports the supervised drain-and-roll path"
+assert_not_contains "$out" "STUB_STOP" "supervised restart path never falls back to stop"
+assert_not_contains "$out" "STUB_START" "supervised restart path never falls back to start"
+
+echo "Test 15: 'loom restart --machine' falls back to stop-then-start when the supervised IPC refuses"
+RESTART_BIN_REFUSE=$(mktemp -d)
+cat > "$RESTART_BIN_REFUSE/loom-daemon" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$RESTART_BIN_REFUSE/loom-daemon"
+set +e
+out=$(cd "$CONSUMER" && PATH="$RESTART_BIN_REFUSE:/usr/bin:/bin" LOOM_HOME="$CHK" bash "$DISPATCHER" restart --machine 2>&1)
+rc=$?
+set -e 2>/dev/null || true
+assert_eq "$rc" "0" "'loom restart --machine' falls back to stop+start and still exits 0"
+assert_contains "$out" "STUB_STOP" "fallback invokes the stop delegate"
+assert_contains "$out" "STUB_START" "fallback invokes the start delegate"
+
+echo "Test 16: 'loom restart --machine' falls back to stop-then-start when loom-daemon isn't on PATH at all"
+set +e
+out=$(cd "$CONSUMER" && PATH="/usr/bin:/bin" LOOM_HOME="$CHK" bash "$DISPATCHER" restart --machine 2>&1)
+rc=$?
+set -e 2>/dev/null || true
+assert_eq "$rc" "0" "'loom restart --machine' with no loom-daemon on PATH falls back to stop+start"
+assert_contains "$out" "STUB_STOP" "fallback invokes the stop delegate (no loom-daemon on PATH)"
+assert_contains "$out" "STUB_START" "fallback invokes the start delegate (no loom-daemon on PATH)"
+
+echo "Test 17: 'restart' is documented in help output"
+help_out=$(LOOM_HOME="$CHK" bash "$DISPATCHER" help 2>&1)
+assert_contains "$help_out" "restart" "'loom help' documents the restart verb"
 
 echo ""
 echo "======================================"

--- a/scripts/loom
+++ b/scripts/loom
@@ -6,7 +6,15 @@
 # ~/.local/bin/loom-daemon binary that provision-daemon.sh installs). It resolves
 # the machine-level Loom checkout (~/.local/share/loom) and exec's into it.
 #
-# Verbs (at minimum): start | stop | status | sweep | update.
+# Verbs (at minimum): start | stop | status | sweep | update | restart.
+#
+# Machine mode (Epic #3835 Phase 3b, #4229): every delegate this dispatcher
+# execs into (start/stop/update/restart) is handed the resolved checkout via
+# LOOM_MACHINE_CHECKOUT so the lifecycle scripts operate against the SAME
+# machine-level workdir/pid/flags home no matter what directory the operator
+# happened to invoke `loom` from — the launchd label they all drive
+# (com.rjwalters.loom-daemon) is a machine-wide singleton, not a per-repo one.
+# See defaults/docs/machine-dispatcher.md.
 #
 # ── NOT the same surface as ./.loom/bin/loom ────────────────────────────────
 # ./.loom/bin/loom is the PER-REPO tmux agent-pool manager (verbs: start status
@@ -135,21 +143,37 @@ loom_collision_guard() {
     exit 3
 }
 
-# Resolve + exec a daemon lifecycle script from the machine checkout, dropping
-# the leading --machine selector (the delegated script does not know that flag).
-loom_exec_checkout_script() {
-    local rel="$1"; shift
-    local checkout scripts_dir target
+# Resolve the machine checkout + its scripts/ tree, or die with a legible
+# error. Echoes "<checkout>\n<scripts_dir>" (two lines) on success. Shared by
+# every verb that delegates into the checkout (start/stop/update/restart) so
+# the "checkout missing" / "no scripts/ tree" messages stay identical across
+# all of them.
+loom_resolve_checkout_scripts() {
+    local checkout scripts_dir
     checkout="$(loom_resolve_checkout)"
     if [[ ! -e "$checkout" ]]; then
         _err "machine-level checkout not found at: $checkout"
         _err "install it (run the Loom installer) or set LOOM_HOME to a Loom checkout."
-        exit 1
+        return 1
     fi
     if ! scripts_dir="$(loom_checkout_scripts_dir "$checkout")"; then
         _err "no scripts/ tree under the machine checkout: $checkout"
-        exit 1
+        return 1
     fi
+    printf '%s\n%s\n' "$checkout" "$scripts_dir"
+}
+
+# Resolve + exec a daemon lifecycle script from the machine checkout, dropping
+# the leading --machine selector (the delegated script does not know that
+# flag). Exports LOOM_MACHINE_CHECKOUT so the delegate resolves its
+# workdir/pid/flags home from the checkout rather than $PWD (machine mode,
+# #4229) — see the file-header comment above.
+loom_exec_checkout_script() {
+    local rel="$1"; shift
+    local resolved checkout scripts_dir target
+    resolved="$(loom_resolve_checkout_scripts)" || exit 1
+    checkout="$(sed -n '1p' <<<"$resolved")"
+    scripts_dir="$(sed -n '2p' <<<"$resolved")"
     target="$scripts_dir/$rel"
     if [[ ! -x "$target" ]]; then
         _err "expected script not found or not executable: $target"
@@ -158,6 +182,7 @@ loom_exec_checkout_script() {
     local passthrough=()
     local a
     for a in "$@"; do [[ "$a" == "--machine" ]] && continue; passthrough+=("$a"); done
+    export LOOM_MACHINE_CHECKOUT="$checkout"
     # `${arr[@]+…}` guard: expand to nothing (not an empty arg) when the array is
     # empty, so this is safe under `set -u` on bash 3.2 (macOS default).
     exec "$target" ${passthrough[@]+"${passthrough[@]}"}
@@ -172,21 +197,69 @@ loom_cmd_stop()  { loom_detect_context; loom_collision_guard stop  "$@"; loom_ex
 # (loom-daemon-update.sh, built by #3968 and extended by the shipped #4055
 # self-update loop). It implements NO rebuild/reprovision/restart logic itself,
 # so it neither pre-empts #4017 (auto-rebuild-when-stale) nor duplicates #4055.
+#
+# Gap 1 fix (#4229): loom-daemon-update.sh rebuilds FROM SOURCE and used to
+# resolve its source tree by walking up from $PWD — which fails outside a Loom
+# source checkout even though THIS dispatcher already resolved+validated the
+# machine checkout above. Exporting LOOM_MACHINE_CHECKOUT hands that resolution
+# to the delegate as an explicit override, so `loom update` rebuilds the
+# checkout from any directory (a consumer repo, or no repo at all).
 loom_cmd_update() {
-    local checkout scripts_dir target
-    checkout="$(loom_resolve_checkout)"
-    if [[ ! -e "$checkout" ]] || ! scripts_dir="$(loom_checkout_scripts_dir "$checkout")"; then
-        _err "machine-level checkout not found at: ${checkout}"
-        _err "'loom update' only delegates to loom-daemon-update.sh in the checkout; install Loom or set LOOM_HOME."
-        exit 1
-    fi
+    local resolved checkout scripts_dir target
+    resolved="$(loom_resolve_checkout_scripts)" || exit 1
+    checkout="$(sed -n '1p' <<<"$resolved")"
+    scripts_dir="$(sed -n '2p' <<<"$resolved")"
     target="$scripts_dir/cli/loom-daemon-update.sh"
     if [[ ! -x "$target" ]]; then
         _err "update delegate not found or not executable: $target"
         _err "'loom update' is a thin delegator; it does not rebuild/restart on its own."
         exit 1
     fi
+    export LOOM_MACHINE_CHECKOUT="$checkout"
     exec "$target" "$@"
+}
+
+# `restart` (Gap 3, #4229): the filed scope lists start|stop|status|restart, but
+# only the first three shipped in #4157/#4208. Thin delegate mirroring
+# start/stop — same collision guard (the per-repo pool manager has no
+# `restart`, but guard consistency is cheaper than explaining an asymmetry) —
+# preferring drain-and-roll semantics: try the daemon's own supervised restart
+# IPC first (`loom-daemon restart`, #4077 — never tears down in-flight sweep
+# children, unlike a bootout), falling back to a plain stop-then-start when the
+# daemon isn't launchd-managed (or isn't running at all yet).
+loom_cmd_restart() {
+    loom_detect_context
+    loom_collision_guard restart "$@"
+
+    local resolved checkout scripts_dir stop_target start_target
+    resolved="$(loom_resolve_checkout_scripts)" || exit 1
+    checkout="$(sed -n '1p' <<<"$resolved")"
+    scripts_dir="$(sed -n '2p' <<<"$resolved")"
+    stop_target="$scripts_dir/cli/loom-daemon-stop.sh"
+    start_target="$scripts_dir/cli/loom-daemon-start.sh"
+    if [[ ! -x "$stop_target" || ! -x "$start_target" ]]; then
+        _err "expected lifecycle script(s) not found or not executable under: $scripts_dir/cli"
+        exit 1
+    fi
+
+    local passthrough=()
+    local a
+    for a in "$@"; do [[ "$a" == "--machine" ]] && continue; passthrough+=("$a"); done
+
+    export LOOM_MACHINE_CHECKOUT="$checkout"
+
+    if command -v loom-daemon >/dev/null 2>&1 && loom-daemon restart >/dev/null 2>&1; then
+        echo "loom-daemon restart scheduled (supervised drain-and-roll; in-flight sweeps preserved)."
+        exit 0
+    fi
+
+    _warn "supervised 'loom-daemon restart' unavailable or refused (not launchd-managed, or not currently running) — falling back to stop-then-start."
+    if ! "$stop_target" --restarting; then
+        _err "loom-daemon-stop.sh failed — not starting a new binary on top of a possibly-still-running old one."
+        exit 1
+    fi
+    # `${arr[@]+…}` guard: see loom_exec_checkout_script above.
+    exec "$start_target" ${passthrough[@]+"${passthrough[@]}"}
 }
 
 # `sweep <issue>` dispatches a single-issue lifecycle for the CURRENT repo.
@@ -271,7 +344,7 @@ loom_cmd_status() {
 
 loom_print_help() {
     cat <<EOF
-loom — machine-level Loom dispatcher (Epic #3835 Phase 3a)
+loom — machine-level Loom dispatcher (Epic #3835 Phase 3a/3b)
 
 USAGE:
     loom <command> [options]
@@ -279,6 +352,7 @@ USAGE:
 COMMANDS:
     start     Start the machine-level loom-daemon (delegates to loom-daemon-start.sh)
     stop      Stop the machine-level loom-daemon  (delegates to loom-daemon-stop.sh)
+    restart   Restart the machine-level loom-daemon (drain-and-roll; falls back to stop+start)
     status    Show machine-level + current-repo status (read-only)
     sweep     Dispatch /loom:sweep <issue> for the current repo
     update    Thin delegate to loom-daemon-update.sh (no rebuild logic of its own)
@@ -301,12 +375,13 @@ main() {
     local cmd="${1:-help}"
     shift || true
     case "$cmd" in
-        start)              loom_cmd_start "$@" ;;
-        stop)               loom_cmd_stop "$@" ;;
-        status)             loom_cmd_status "$@" ;;
-        sweep)              loom_cmd_sweep "$@" ;;
-        update)             loom_cmd_update "$@" ;;
-        help|--help|-h)     loom_print_help ;;
+        start)               loom_cmd_start "$@" ;;
+        stop)                loom_cmd_stop "$@" ;;
+        restart)             loom_cmd_restart "$@" ;;
+        status)              loom_cmd_status "$@" ;;
+        sweep)               loom_cmd_sweep "$@" ;;
+        update)              loom_cmd_update "$@" ;;
+        help|--help|-h)      loom_print_help ;;
         version|--version|-v) echo "loom dispatcher v${DISPATCHER_VERSION} (machine-level)" ;;
         *)
             _err "unknown command '$cmd'"


### PR DESCRIPTION
## Summary

Epic #3835 Phase 3b. The Curator's review of #4229 found that the dispatcher
verbs, machine-level binary install, and launchd supervision (RunAtLoad +
KeepAlive:SuccessfulExit + StartInterval watchdog) were already delivered by
#4157/PR #4208 — the remaining gaps were narrower than the filed scope:

1. **`loom update` failed outside a Loom source checkout.** All three
   lifecycle scripts (`loom-daemon-start.sh`, `-stop.sh`, `-update.sh`)
   resolved their operating root by walking up from `$PWD`
   (`find_repo_root()`), so `update` refused with "only works inside a Loom
   source checkout" from a consumer repo or a non-repo directory — even
   though the dispatcher had already resolved and validated the machine
   checkout.
2. **`loom start`/`stop` bound machine-global daemon state to whichever repo
   invoked them.** The launchd label (`com.rjwalters.loom-daemon`) is a
   machine-wide singleton, but the rendered plist's `WorkingDirectory` and the
   `.daemon.pid`/`.daemon.flags` files were `$REPO_ROOT`-relative.
3. **No `restart` dispatcher verb**, though the filed scope listed
   `start|stop|status|restart`.

## What changed

- `scripts/loom`: every delegating verb (`start`/`stop`/`update`/`restart`)
  now exports `LOOM_MACHINE_CHECKOUT=<resolved checkout>` before invoking its
  lifecycle-script delegate. Added the `restart` verb — same collision guard
  as start/stop, prefers the supervised drain-and-roll IPC
  (`loom-daemon restart`, #4077), falling back to stop-then-start.
- `defaults/scripts/cli/loom-daemon-{start,stop,update}.sh`: each now checks
  `LOOM_MACHINE_CHECKOUT` **first**, ahead of the `$PWD`-based
  `find_repo_root()` fallback. When set (machine mode), the checkout is the
  operating root regardless of `$PWD`, and runtime artifacts
  (`.daemon.pid`/`.daemon.flags`/startup log) resolve under `$HOME/.loom` —
  the **existing** machine-level state home (socket, token pool,
  `activity.db`, `daemon.log` already live there) — rather than a
  `$REPO_ROOT/.loom` keyed to the invoking directory. When unset (direct
  invocation, no dispatcher), every script behaves byte-for-byte as before —
  machine mode is strictly additive, never a replacement for the dev-mode
  workflow.
- Linux `systemd` supervision remains genuinely undecided (the launchd
  supervision story is already implemented + documented); deferred to a named
  follow-up, #4260, per the scope guard.
- Tests: extended `test-loom-dispatcher.sh` (restart verb, collision guard,
  supervised-IPC + fallback paths, LOOM_MACHINE_CHECKOUT hand-off including
  from a non-repo directory) and added focused machine-mode regression cases
  to the three existing lifecycle test files
  (`test-loom-daemon-{start,stop,update}.sh`), all isolated to scratch
  `$HOME`/checkout/PWD dirs so nothing touches the real operator `~/.loom` or
  the real production launchd job.
- Docs: `machine-dispatcher.md` gets a new "Machine mode" section (the two
  gaps, the pid/flags relocation decision, the `restart` verb, and the
  macOS-done/Linux-deferred supervision note); `daemon-reference.md`'s
  Operability section header + lifecycle bullet list updated accordingly.

## Test plan

- [x] `defaults/scripts/tests/test-loom-dispatcher.sh` — 53/53 passed
- [x] `defaults/scripts/tests/test-loom-daemon-start.sh` — 20/20 passed
- [x] `defaults/scripts/tests/test-loom-daemon-stop.sh` — 28/28 passed
- [x] `defaults/scripts/tests/test-loom-daemon-update.sh` — 56/56 passed
- [x] `defaults/scripts/tests/test-loom-daemon-launchd-plist.sh` — 42/42 passed (no regression)
- [x] `shellcheck --severity=warning` clean on all five changed scripts
- [x] Manual: `bash scripts/loom help` documents `restart`

## Follow-up filed

- #4260 — Linux systemd supervision for the machine-level loom-daemon (scope guard)

Closes #4229
