### PR TITLE
fix(daemon): verify launchd relaunch + bounded watchdog auto-kickstart (#4232)

### DIFF
--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -132,6 +132,15 @@
 #                          checkout. Direct invocation of this script (no
 #                          dispatcher -- the existing dev workflow) never sets
 #                          it and is unaffected.
+#   LOOM_DAEMON_RESTART_POLL_SECS  macOS/launchd only: seconds to poll for a
+#                          NEW, live pid after a `restart` ack before falling
+#                          back to `launchctl kickstart` (default 30, #4232).
+#   LOOM_DAEMON_RESTART_POLL_INTERVAL  Poll interval in seconds between pid
+#                          checks (default 1; may be fractional, e.g. 0.5).
+#   LOOM_DAEMON_RESTART_KICKSTART_POLL_SECS  macOS/launchd only: seconds to
+#                          re-poll for a new, live pid after the `launchctl
+#                          kickstart` fallback before giving up (default 15,
+#                          #4232).
 #
 # Exit codes:
 #   0  up to date (no-op) OR rebuild+provision+restart succeeded
@@ -155,6 +164,14 @@
 #      with --relaunch (or LOOM_DAEMON_UPDATE_RELAUNCH=1) it performs that
 #      re-render+relaunch itself, propagating loom-daemon-start.sh's exit code
 #      (#4042, #4118, #4260 sub-issue C).
+#   7  launchd restart ACK'd but never took effect (#4232): the running (old)
+#      binary accepted the `restart` IPC request (exit 0), but launchd never
+#      relaunched the job onto a NEW, live pid within the poll window, AND the
+#      `launchctl kickstart` fallback (plain, never -k) also failed to bring it
+#      up within its own poll window. The fresh binary IS provisioned, but the
+#      daemon's live status is NOT confirmed — this is the "restart scheduled
+#      but launchd silently never relaunched" outage this issue closes; the
+#      script refuses to report success on the ack alone.
 #
 # See also: loom-daemon-start.sh (writes .loom/.daemon.flags), loom-daemon-stop.sh
 # (SIGTERM -> grace -> SIGKILL; in-flight sweeps survive by design — this
@@ -475,6 +492,54 @@ systemd_unit_loaded() {
 }
 systemd_unit_pid() {
     systemctl --user show -p MainPID --value "$SYSTEMD_UNIT" 2>/dev/null
+}
+
+# ---------- verify a launchd restart actually relaunched the job (#4232) ----------
+# THE PROBLEM: the launchd branch below used to treat a successful `restart`
+# ack (the RUNNING binary accepting the IPC request, exit 0) as success and
+# exit 0 immediately — fire-and-forget. On 2026-07-28 that ack was honest (the
+# supervised daemon exited 0 per its #4054 contract) but launchd's own
+# KeepAlive:SuccessfulExit relaunch never fired, so the script reported success
+# while the daemon silently stayed down for ~4 minutes until an operator ran
+# `launchctl kickstart` by hand. This closes that gap: verify a NEW pid before
+# reporting success, and self-heal via `kickstart` when launchd doesn't.
+#
+# wait_for_new_launchd_pid <pre_pid> <timeout_secs> <interval_secs> — poll
+# `launchd_job_pid` until it reports a pid that is BOTH different from
+# <pre_pid> AND alive (`kill -0`), for up to <timeout_secs>. A pid that merely
+# differs but is already dead (a race artifact) — or that still equals
+# <pre_pid> (the old process lingering mid-teardown during the poll window) —
+# must NEVER be mistaken for a successful relaunch. On success, echoes the new
+# pid on stdout and returns 0; on timeout, returns 1 with no output.
+# <interval_secs> may be fractional (e.g. 0.2), matching `sleep`'s own support.
+wait_for_new_launchd_pid() {
+    local pre_pid="$1" timeout_secs="$2" interval_secs="$3"
+    local deadline cur_pid
+    deadline=$(( $(date +%s) + timeout_secs ))
+    while true; do
+        cur_pid="$(launchd_job_pid)"
+        if [[ -n "$cur_pid" && "$cur_pid" != "$pre_pid" ]] && kill -0 "$cur_pid" 2>/dev/null; then
+            echo "$cur_pid"
+            return 0
+        fi
+        if (( $(date +%s) >= deadline )); then
+            return 1
+        fi
+        sleep "$interval_secs"
+    done
+}
+
+# log_launchd_diagnostics — dump `launchctl print`'s current state as a
+# diagnostic breadcrumb (state / last exit status) when a relaunch cannot be
+# verified, so an operator (or the PR/issue this failure is reported to) has
+# the exact evidence needed to tell "launchd never relaunched" apart from "the
+# daemon crashed immediately after relaunching" (#4232).
+log_launchd_diagnostics() {
+    warn "launchctl print $LAUNCHD_SERVICE diagnostic snapshot:"
+    local line
+    while IFS= read -r line; do
+        warn "  $line"
+    done < <(launchctl print "$LAUNCHD_SERVICE" 2>&1)
 }
 
 # ---------- re-render + relaunch on a refused restart (#4118) ----------
@@ -909,9 +974,43 @@ if [[ "$DAEMON_MANAGER" == "launchd" ]]; then
     echo "loom-daemon is launchd-managed (label ${LAUNCHD_LABEL})."
     echo "Restarting via the supervised restart primitive: $PROVISION_TARGET restart"
     echo "(.daemon.flags is NOT consulted — the plist's EnvironmentVariables carries the equivalent config.)"
+
+    # Capture the pre-restart pid BEFORE the request so the poll below can tell
+    # "launchd relaunched onto a new pid" apart from "the same job never moved".
+    PRE_RESTART_PID="$(launchd_job_pid)"
+
     if "$PROVISION_TARGET" restart; then
-        ok "loom-daemon restart scheduled — launchd will relaunch it onto the freshly-provisioned binary."
-        exit 0
+        # The RUNNING (old) binary accepted the request — but that ack is the
+        # daemon's promise, not proof launchd actually honored it (#4232: the
+        # daemon can exit 0 and launchd can still fail to relaunch it). Verify
+        # a NEW, live pid before reporting success; the success message below
+        # is intentionally the ONLY "restart scheduled"-style success line in
+        # this branch, and it is unreachable until verification passes.
+        RESTART_POLL_SECS="${LOOM_DAEMON_RESTART_POLL_SECS:-30}"
+        RESTART_POLL_INTERVAL="${LOOM_DAEMON_RESTART_POLL_INTERVAL:-1}"
+        KICKSTART_POLL_SECS="${LOOM_DAEMON_RESTART_KICKSTART_POLL_SECS:-15}"
+        echo "Restart request accepted (pre-restart pid: ${PRE_RESTART_PID:-<none>}). Verifying launchd relaunches onto a NEW, live pid within ${RESTART_POLL_SECS}s before reporting success (#4232)..."
+
+        if NEW_PID="$(wait_for_new_launchd_pid "$PRE_RESTART_PID" "$RESTART_POLL_SECS" "$RESTART_POLL_INTERVAL")"; then
+            ok "loom-daemon restart scheduled — launchd relaunched it onto the freshly-provisioned binary (new pid ${NEW_PID}, verified within ${RESTART_POLL_SECS}s)."
+            exit 0
+        fi
+
+        warn "launchd did NOT relaunch within ${RESTART_POLL_SECS}s of the restart ack — no new, live pid observed (pre-restart pid was ${PRE_RESTART_PID:-<none>})."
+        log_launchd_diagnostics
+        warn "Falling back to 'launchctl kickstart $LAUNCHD_SERVICE' (plain — NEVER -k — so a daemon that DID relaunch during the race window above is never killed)."
+        launchctl kickstart "$LAUNCHD_SERVICE" >/dev/null 2>&1
+
+        if NEW_PID="$(wait_for_new_launchd_pid "$PRE_RESTART_PID" "$KICKSTART_POLL_SECS" "$RESTART_POLL_INTERVAL")"; then
+            ok "loom-daemon restart scheduled — launchd's own relaunch did not occur within ${RESTART_POLL_SECS}s, but the 'launchctl kickstart' fallback relaunched it (new pid ${NEW_PID}, verified within ${KICKSTART_POLL_SECS}s). Remediation note: the kickstart fallback was required (#4232) — investigate why launchd did not relaunch the job on its own."
+            exit 0
+        fi
+
+        err "loom-daemon restart FAILED: no new, live pid was observed even after the 'launchctl kickstart' fallback."
+        log_launchd_diagnostics
+        err "The freshly-built binary IS provisioned, but the daemon's live status is NOT confirmed (pre-restart pid was ${PRE_RESTART_PID:-<none>})."
+        err "Investigate manually: launchctl print $LAUNCHD_SERVICE"
+        exit 7
     fi
     # The restart request is served by the RUNNING (old) binary. A pre-#4077
     # daemon has no RestartDaemon handler (and an unsupervised/dead socket also

--- a/defaults/scripts/cli/loom-daemon-watchdog.sh
+++ b/defaults/scripts/cli/loom-daemon-watchdog.sh
@@ -42,11 +42,31 @@
 #   OPERATOR INTENT: present ⇒ a daemon is expected; absent ⇒ it was
 #   deliberately stopped (or never started) ⇒ stay silent.
 #
+# BOUNDED AUTO-REMEDIATION (#4232)
+#   The watchdog was deliberately report-only until #4232: on 2026-07-28 a
+#   `loom-daemon restart` was ack'd (the running daemon exited 0, honoring its
+#   #4054/#4077 restart contract) but launchd never relaunched it — the
+#   watchdog could describe that outage but not fix it, which matters once
+#   #4055's unattended self-update path can hit the same race with no operator
+#   watching. This job now auto-runs `launchctl kickstart <label>` (PLAIN,
+#   NEVER `-k`) for EXACTLY ONE divergence signature: the launchd job is
+#   LOADED (launchctl still knows about it) + NOT running + its last exit
+#   status was 0. That signature can ONLY arise from a restart-primitive exit
+#   that launchd failed to honor — an operator SIGTERM stop exits 143/130
+#   (loom-daemon-stop.sh), a crash exits non-zero, and a booted-out/never-
+#   loaded job fails `launchctl print` outright. Every other divergence stays
+#   report-only, exactly as before: no crash-loop revival, no reviving a
+#   deliberate stop.
+#
 # EXIT CODES (a StartInterval job's exit code does not affect relaunch — these
 # exist for testability and for a human running it by hand):
-#   0  no divergence — daemon healthy, OR no daemon is expected (marker absent)
-#   1  DIVERGENCE reported — a daemon is expected but is not running, or is
-#      running but its heartbeat is stale (possibly wedged)
+#   0  no divergence — daemon healthy, no daemon expected (marker absent), OR
+#      the #4232 bounded auto-remediation (see above) successfully relaunched
+#      it via 'launchctl kickstart'
+#   1  DIVERGENCE reported — a daemon is expected but is not running (and
+#      either the #4232 remediation gate did not apply, or it fired but the
+#      daemon is still not confirmed running), or is running but its
+#      heartbeat is stale (possibly wedged)
 #   2  usage error
 #
 # Usage:
@@ -65,6 +85,11 @@
 #   LOOM_LAUNCHD_DOMAIN          macOS: pin the launchd domain (gui/<uid> or user/<uid>);
 #                                else auto-resolved gui→user (#4130), matching the start
 #   LOOM_DAEMON_LAUNCHD          0/false/no: treat as a non-launchd (nohup) daemon; check the pid file only
+#   LOOM_WATCHDOG_KICKSTART_RECHECK_ATTEMPTS  #4232: how many times to re-check
+#                                for a live pid after the auto-kickstart fallback
+#                                (default 3).
+#   LOOM_WATCHDOG_KICKSTART_RECHECK_INTERVAL  #4232: seconds between re-checks
+#                                (default 1; may be fractional).
 
 set -uo pipefail
 
@@ -158,17 +183,29 @@ LABEL="${LOOM_LAUNCHD_LABEL:-${MARKER_LABEL:-com.rjwalters.loom-daemon}}"
 # ---------- 2. reality: is the expected daemon actually alive? ----------
 daemon_alive=false
 liveness_detail=""
+# job_loaded / launchd_service feed the #4232 bounded auto-remediation gate
+# below: job_loaded=true means `launchctl print` succeeded (the job IS in
+# launchd's table) even though no live pid was found — distinct from "not
+# loaded at all" (a booted-out job, or a non-launchd host), which stays
+# report-only no matter what.
+job_loaded=false
+launchd_service=""
 if [[ "$USE_LAUNCHD" == "true" ]] && command -v launchctl >/dev/null 2>&1; then
     # Resolve the domain (gui/<uid> ↦ user/<uid>, #4130) the same way the start
     # did, so a headless daemon in user/<uid> is probed correctly rather than
     # always looked up under gui/<uid> (which would false-report divergence).
-    service="$(resolve_launchd_domain)/${LABEL}"
-    launchd_pid="$(launchctl print "$service" 2>/dev/null | awk -F'= ' '/^[[:space:]]*pid = /{gsub(/[^0-9]/, "", $2); print $2; exit}')"
+    launchd_service="$(resolve_launchd_domain)/${LABEL}"
+    launchd_print_output="$(launchctl print "$launchd_service" 2>/dev/null)"
+    launchd_print_rc=$?
+    launchd_pid="$(printf '%s\n' "$launchd_print_output" | awk -F'= ' '/^[[:space:]]*pid = /{gsub(/[^0-9]/, "", $2); print $2; exit}')"
     if [[ -n "$launchd_pid" ]] && kill -0 "$launchd_pid" 2>/dev/null; then
         daemon_alive=true
-        liveness_detail="launchd job $service alive (pid $launchd_pid)"
+        liveness_detail="launchd job $launchd_service alive (pid $launchd_pid)"
+    elif [[ "$launchd_print_rc" -eq 0 ]]; then
+        job_loaded=true
+        liveness_detail="launchd job $launchd_service is LOADED but NOT running (no live pid)"
     else
-        liveness_detail="launchd job $service is not loaded/alive"
+        liveness_detail="launchd job $launchd_service is not loaded/alive"
     fi
 else
     # Non-launchd (nohup / Linux) path: the pid file is the only liveness signal.
@@ -186,6 +223,56 @@ else
 fi
 
 if [[ "$daemon_alive" != "true" ]]; then
+    # ---------- bounded auto-remediation (#4232) ----------
+    # THE PROBLEM: the restart primitive's contract (#4054/#4077) is "the
+    # supervised daemon exits 0 -> KeepAlive:SuccessfulExit relaunches it". On
+    # 2026-07-28 that contract's exit-0 half held but launchd's relaunch half
+    # silently didn't, and this watchdog (a report-only detector) could only
+    # describe the outage, not fix it — exactly the unattended-#4055-rollout
+    # risk this narrow gate closes.
+    #
+    # THE GATE IS NARROW BY CONSTRUCTION: auto-`kickstart` fires ONLY for the
+    # exact signature "job LOADED (launchctl still knows about it) + NOT
+    # running + last exit status 0". An operator-initiated SIGTERM stop exits
+    # 143/130 (loom-daemon-stop.sh); a genuine crash exits non-zero; a booted-
+    # out/never-loaded job fails `launchctl print` outright (job_loaded=false).
+    # NONE of those can produce "loaded, down, exit 0" — only a restart-
+    # primitive exit that launchd failed to honor can. So every OTHER
+    # divergence (stop, crash, bootout) falls through to the report-only path
+    # below unchanged: no crash-loop revival, no reviving a deliberate stop.
+    if [[ "$job_loaded" == "true" && -n "$launchd_service" ]]; then
+        last_exit_status="$(launchctl print "$launchd_service" 2>/dev/null \
+            | grep -oE 'last exit (code|status)[[:space:]]*=[[:space:]]*[-0-9]+' \
+            | head -n1 | grep -oE '[-0-9]+$')"
+        if [[ "$last_exit_status" == "0" ]]; then
+            report DIVERGENCE \
+                "A daemon is EXPECTED (autonomy-desired marker present, started $(marker_get started_at)) but is NOT running: ${liveness_detail}. Last exit status was 0 — the restart-primitive's own exit-0 contract (#4054/#4077) — which launchd failed to honor. Auto-remediating with 'launchctl kickstart ${launchd_service}' (PLAIN, never -k, so a daemon that is mid-relaunch is never killed) (#4232)."
+            launchctl kickstart "$launchd_service" >/dev/null 2>&1
+            # Brief, bounded re-check — this is a StartInterval job (re-run
+            # every cadence regardless), so a failure here is NOT the last
+            # chance; it just means this pass still reports divergence and the
+            # next pass tries again.
+            RECHECK_ATTEMPTS="${LOOM_WATCHDOG_KICKSTART_RECHECK_ATTEMPTS:-3}"
+            RECHECK_INTERVAL="${LOOM_WATCHDOG_KICKSTART_RECHECK_INTERVAL:-1}"
+            recheck_pid=""
+            for _ in $(seq 1 "$RECHECK_ATTEMPTS"); do
+                recheck_pid="$(launchctl print "$launchd_service" 2>/dev/null | awk -F'= ' '/^[[:space:]]*pid = /{gsub(/[^0-9]/, "", $2); print $2; exit}')"
+                if [[ -n "$recheck_pid" ]] && kill -0 "$recheck_pid" 2>/dev/null; then
+                    break
+                fi
+                recheck_pid=""
+                sleep "$RECHECK_INTERVAL"
+            done
+            if [[ -n "$recheck_pid" ]]; then
+                report OK "auto-remediation succeeded: 'launchctl kickstart' relaunched ${launchd_service} (new pid ${recheck_pid})."
+                exit 0
+            fi
+            report DIVERGENCE \
+                "Auto-remediation attempted ('launchctl kickstart ${launchd_service}') but the daemon is STILL not confirmed running. Escalate manually: launchctl print ${launchd_service}  (or ./.loom/scripts/cli/loom-daemon-start.sh [flags])."
+            exit 1
+        fi
+    fi
+
     report DIVERGENCE \
         "A daemon is EXPECTED (autonomy-desired marker present, started $(marker_get started_at)) but is NOT running: ${liveness_detail}. Autonomous dispatch has stopped. Recover with: ./.loom/scripts/cli/loom-daemon-start.sh [flags]  (or 'loom-daemon status' to inspect)."
     exit 1

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -165,16 +165,73 @@ EOF
 # simulating a launchd-managed loom-daemon for the #4042 ownership-detection
 # tests. Paired with a fake `uname`->Darwin so the update script's Darwin-gated
 # launchd path fires deterministically on any host.
+#
+# Optional $3/$4 (#4232): when a <post_restart_marker> file path is given,
+# `print` reports pid 4242 until that file EXISTS, at which point it reports
+# <post_restart_pid> instead — simulating "launchd relaunched the job onto a
+# new (real, live) pid the instant the restart request was accepted". Tests
+# that don't pass $3/$4 keep the old static-4242-forever behavior (they never
+# exercise the #4232 pid-verification poll).
 write_fake_launchd_loaded_bin() {
-    local bin_dir="$1" log="$2"
+    local bin_dir="$1" log="$2" post_restart_marker="${3:-}" post_restart_pid="${4:-}"
     mkdir -p "$bin_dir"
     : > "$log"
     cat > "$bin_dir/launchctl" <<EOF
 #!/usr/bin/env bash
 echo "\$*" >> "${log}"
 case "\${1:-}" in
-  print) echo "	pid = 4242" ; exit 0 ;;
+  print)
+    if [[ -n "${post_restart_marker}" && -e "${post_restart_marker}" ]]; then
+      echo "	pid = ${post_restart_pid}"
+    else
+      echo "	pid = 4242"
+    fi
+    exit 0 ;;
   *)     exit 0 ;;
+esac
+EOF
+    chmod +x "$bin_dir/launchctl"
+    cat > "$bin_dir/uname" <<'EOF'
+#!/usr/bin/env bash
+echo "Darwin"
+EOF
+    chmod +x "$bin_dir/uname"
+}
+
+# Writes a fake `launchctl` at $1 for the #4232 restart-VERIFICATION tests: the
+# reported pid lives in a state file ($3) rather than being hardcoded, so a
+# test can hold it "stuck" on the pre-restart pid to simulate launchd failing
+# to relaunch on its own. `print` reports whatever pid (if any) is currently in
+# the state file plus a "last exit status" line (diagnostic breadcrumb,
+# #4232). `kickstart` is recorded VERBATIM to $2 (so a test can assert it was
+# never invoked with `-k`) and, only when $4 (<kickstart_new_pid>) is given,
+# overwrites the state file with it — simulating a kickstart-triggered
+# relaunch; when $4 is omitted, `kickstart` is a no-op (a kickstart that also
+# fails to bring the job up).
+write_fake_launchd_pid_bin() {
+    local bin_dir="$1" log="$2" state_file="$3" kickstart_new_pid="${4:-}"
+    mkdir -p "$bin_dir"
+    : > "$log"
+    cat > "$bin_dir/launchctl" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "${log}"
+case "\${1:-}" in
+  print)
+    pid="\$(cat "${state_file}" 2>/dev/null)"
+    if [[ -n "\$pid" ]]; then
+      echo "	state = running"
+      echo "	pid = \$pid"
+    else
+      echo "	state = not running"
+    fi
+    echo "	last exit status = 0"
+    exit 0 ;;
+  kickstart)
+    if [[ -n "${kickstart_new_pid}" ]]; then
+      echo "${kickstart_new_pid}" > "${state_file}"
+    fi
+    exit 0 ;;
+  *) exit 0 ;;
 esac
 EOF
     chmod +x "$bin_dir/launchctl"
@@ -861,11 +918,13 @@ else
 fi
 
 # ============================================================
-# 15. Launchd ownership + restart (#4042): a launchd-managed daemon (stub
+# 15. Launchd ownership + restart (#4042/#4232): a launchd-managed daemon (stub
 #     launchctl reports a LOADED job + pid) with NO .loom/.daemon.pid file ->
 #     the updater plans/executes a RESTART (not "was not running"), drives it
 #     through the `restart` subcommand (stub records the invocation), does NOT
-#     consult .daemon.flags, and exits 0.
+#     consult .daemon.flags, and exits 0. The stub relaunches onto a NEW, real,
+#     live pid the instant the restart is accepted (#4232 case (a): relaunch
+#     observed -> success, no kickstart fallback ever invoked).
 # ============================================================
 W15="$BASE_WORKDIR/w15"
 new_fixture "$W15"
@@ -881,13 +940,18 @@ write_fake_daemon_restart "$NEW_FAKE15" "$HEAD15" "$RESTART_MARKER15" 0
 # A .daemon.flags that MUST NOT be consulted in launchd mode (would otherwise
 # add --work-finder to a stop+start path).
 echo "--work-finder" > "$W15/.loom/.daemon.flags"
+# A real, live process standing in for "the relaunched job's new pid" — the
+# #4232 poll requires a live pid (kill -0), not just a differing number.
+sleep 60 >/dev/null 2>&1 &
+RELAUNCHED_PID15=$!
 LD_BIN15="$W15/launchd-bin"
-write_fake_launchd_loaded_bin "$LD_BIN15" "$W15/launchctl.log"
+write_fake_launchd_loaded_bin "$LD_BIN15" "$W15/launchctl.log" "$RESTART_MARKER15" "$RELAUNCHED_PID15"
 
 out15=$( cd "$W15" && PATH="$LD_BIN15:$TEST_PATH" LOOM_DAEMON_LAUNCHD=1 \
     LOOM_DAEMON_BIN="$INSTALLED15" NEW_FAKE_BIN_SRC="$NEW_FAKE15" \
     bash "$UPDATE_SCRIPT" 2>&1 )
 rc15=$?
+kill "$RELAUNCHED_PID15" 2>/dev/null || true
 assert_eq "0" "$rc15" "launchd-managed update (no pid file) exits 0"
 TESTS_RUN=$((TESTS_RUN + 1))
 if [[ -s "$RESTART_MARKER15" ]]; then
@@ -906,6 +970,24 @@ if echo "$out15" | grep -qi 'not running'; then
 else
     TESTS_PASSED=$((TESTS_PASSED + 1))
     echo -e "${GREEN}✓${NC} launchd-loaded job is NOT mistaken for 'was not running'"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q "^${RELAUNCHED_PID15}$\|new pid ${RELAUNCHED_PID15}" <<< "$out15" || echo "$out15" | grep -q "new pid ${RELAUNCHED_PID15}"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} success message reports the VERIFIED new pid (#4232)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} success message reports the VERIFIED new pid (#4232)"
+    echo "  output: $out15"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q '^kickstart ' "$W15/launchctl.log" 2>/dev/null; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} relaunch observed immediately -> kickstart fallback is NEVER invoked (#4232 case a)"
+    echo "  launchctl.log: $(cat "$W15/launchctl.log" 2>/dev/null)"
+else
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} relaunch observed immediately -> kickstart fallback is NEVER invoked (#4232 case a)"
 fi
 TESTS_RUN=$((TESTS_RUN + 1))
 if echo "$out15" | grep -qi 'FLAGS-OFF'; then
@@ -1637,6 +1719,128 @@ else
     echo -e "${RED}✗${NC} --relaunch with an absent unit fails loudly (names the path) and renders nothing"
     echo "  rc=$rc34 unit-exists=$([[ -e "$UNIT_PATH34" ]] && echo yes || echo no)"
     echo "  output: $out34"
+fi
+
+# ============================================================
+# 35. Restart ack'd but launchd never relaunches -> kickstart fallback DOES
+#     relaunch it (#4232 case (b)): the restart request is accepted (exit 0)
+#     but the reported pid never moves off the pre-restart pid on its own;
+#     the updater falls back to a PLAIN 'launchctl kickstart' (never -k),
+#     which (per the stub) IS what finally moves the pid — success, with a
+#     remediation note in the output. Poll windows are shrunk via env so the
+#     test runs fast without changing the production defaults.
+# ============================================================
+W35="$BASE_WORKDIR/w35"
+new_fixture "$W35"
+INSTALLED35="$W35/installed/loom-daemon"
+mkdir -p "$W35/installed"
+RESTART_MARKER35="$W35/restart-invoked"
+write_fake_daemon_restart "$INSTALLED35" "deadbee" "$RESTART_MARKER35" 0
+NEW_FAKE35="$W35/new-fake-daemon"
+HEAD35="$(cd "$W35" && git rev-parse --short HEAD)"
+write_fake_daemon_restart "$NEW_FAKE35" "$HEAD35" "$RESTART_MARKER35" 0
+
+sleep 60 >/dev/null 2>&1 &
+OLD_PID26=$!
+sleep 60 >/dev/null 2>&1 &
+KICKSTART_PID35=$!
+STATE35="$W35/launchd-pid-state"
+echo "$OLD_PID26" > "$STATE35"
+LD_BIN35="$W35/launchd-bin"
+write_fake_launchd_pid_bin "$LD_BIN35" "$W35/launchctl.log" "$STATE35" "$KICKSTART_PID35"
+
+out35=$( cd "$W35" && PATH="$LD_BIN35:$TEST_PATH" LOOM_DAEMON_LAUNCHD=1 \
+    LOOM_DAEMON_BIN="$INSTALLED35" NEW_FAKE_BIN_SRC="$NEW_FAKE35" \
+    LOOM_DAEMON_RESTART_POLL_SECS=1 LOOM_DAEMON_RESTART_POLL_INTERVAL=0.2 \
+    LOOM_DAEMON_RESTART_KICKSTART_POLL_SECS=3 \
+    bash "$UPDATE_SCRIPT" 2>&1 )
+rc26=$?
+kill "$OLD_PID26" "$KICKSTART_PID35" 2>/dev/null || true
+assert_eq "0" "$rc26" "no spontaneous relaunch -> kickstart fallback relaunches it -> exit 0 (#4232 case b)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out35" | grep -qi 'kickstart' && echo "$out35" | grep -qi 'remediation'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} success output names the kickstart fallback + a remediation note"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} success output names the kickstart fallback + a remediation note"
+    echo "  output: $out35"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -qE '^kickstart [^ ]+$' "$W35/launchctl.log" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} kickstart is invoked PLAIN — never with -k"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} kickstart is invoked PLAIN — never with -k"
+    echo "  launchctl.log: $(cat "$W35/launchctl.log" 2>/dev/null)"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q -- '-k' "$W35/launchctl.log" 2>/dev/null; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} kickstart is NEVER invoked with -k (would risk killing a daemon that relaunched during the race window)"
+    echo "  launchctl.log: $(cat "$W35/launchctl.log" 2>/dev/null)"
+else
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} kickstart is NEVER invoked with -k (would risk killing a daemon that relaunched during the race window)"
+fi
+
+# ============================================================
+# 36. Restart ack'd, launchd never relaunches, AND the kickstart fallback also
+#     never brings it up -> exit NON-ZERO (7), loudly, rather than a silent
+#     half-update success (#4232 case (c)).
+# ============================================================
+W36="$BASE_WORKDIR/w36"
+new_fixture "$W36"
+INSTALLED36="$W36/installed/loom-daemon"
+mkdir -p "$W36/installed"
+RESTART_MARKER36="$W36/restart-invoked"
+write_fake_daemon_restart "$INSTALLED36" "deadbee" "$RESTART_MARKER36" 0
+NEW_FAKE36="$W36/new-fake-daemon"
+HEAD36="$(cd "$W36" && git rev-parse --short HEAD)"
+write_fake_daemon_restart "$NEW_FAKE36" "$HEAD36" "$RESTART_MARKER36" 0
+
+sleep 60 >/dev/null 2>&1 &
+OLD_PID27=$!
+STATE36="$W36/launchd-pid-state"
+echo "$OLD_PID27" > "$STATE36"
+LD_BIN36="$W36/launchd-bin"
+# No kickstart_new_pid given -> kickstart is a no-op; the pid never moves.
+write_fake_launchd_pid_bin "$LD_BIN36" "$W36/launchctl.log" "$STATE36"
+
+out36=$( cd "$W36" && PATH="$LD_BIN36:$TEST_PATH" LOOM_DAEMON_LAUNCHD=1 \
+    LOOM_DAEMON_BIN="$INSTALLED36" NEW_FAKE_BIN_SRC="$NEW_FAKE36" \
+    LOOM_DAEMON_RESTART_POLL_SECS=1 LOOM_DAEMON_RESTART_POLL_INTERVAL=0.2 \
+    LOOM_DAEMON_RESTART_KICKSTART_POLL_SECS=1 \
+    bash "$UPDATE_SCRIPT" 2>&1 )
+rc27=$?
+kill "$OLD_PID27" 2>/dev/null || true
+assert_eq "7" "$rc27" "no relaunch even after kickstart -> exit 7 (never a silent half-update, #4232 case c)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out36" | grep -qi 'FAILED' && echo "$out36" | grep -qi 'kickstart'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} failure output loudly reports the exhausted kickstart fallback"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} failure output loudly reports the exhausted kickstart fallback"
+    echo "  output: $out36"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out36" | grep -qi 'last exit status'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} failure output includes launchctl print diagnostics (state/last exit status)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} failure output includes launchctl print diagnostics (state/last exit status)"
+    echo "  output: $out36"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q -- '-k' "$W36/launchctl.log" 2>/dev/null; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} exhausted kickstart fallback was still never invoked with -k"
+else
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} exhausted kickstart fallback was still never invoked with -k"
 fi
 
 # ============================================================

--- a/defaults/scripts/tests/test-loom-daemon-watchdog.sh
+++ b/defaults/scripts/tests/test-loom-daemon-watchdog.sh
@@ -211,7 +211,140 @@ else
 fi
 
 # ===================================================================
-# 9. --help works and documents the marker + StartInterval design.
+# 9. Bounded auto-remediation (#4232): job LOADED + NOT running + last exit
+#    status 0 is EXACTLY the signature a restart-primitive exit that launchd
+#    failed to honor can produce — the watchdog auto-`launchctl kickstart`s
+#    (PLAIN, never -k) and, once that relaunches the job, exits 0 with an OK
+#    "remediation succeeded" report instead of a bare DIVERGENCE.
+# ===================================================================
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    STUB9="$WORKDIR/stub9"
+    mkdir -p "$STUB9"
+    STATE9="$WORKDIR/state9"
+    : > "$STATE9"   # empty -> "not running" at check time
+    sleep 60 >/dev/null 2>&1 &
+    NEW_PID9=$!
+    LOG9="$WORKDIR/launchctl9.log"
+    : > "$LOG9"
+    cat > "$STUB9/launchctl" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$LOG9"
+case "\${1:-}" in
+  print)
+    pid="\$(cat "$STATE9" 2>/dev/null)"
+    if [[ -n "\$pid" ]]; then
+      echo "	state = running"
+      echo "	pid = \$pid"
+    else
+      echo "	state = not running"
+    fi
+    echo "	last exit status = 0"
+    exit 0
+    ;;
+  kickstart)
+    echo "$NEW_PID9" > "$STATE9"
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+    chmod +x "$STUB9/launchctl"
+    cat > "$MARKER" <<EOF
+started_at=2026-07-27T00:00:00Z
+heartbeat_file=$HEARTBEAT
+heartbeat_interval_secs=60
+use_launchd=true
+launchd_label=com.example.loom-sandbox-remediate-$$
+socket_path=$WORKDIR/loom-daemon.sock
+EOF
+    : > "$WDLOG" "$OUT"
+    env PATH="$STUB9:$PATH" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
+        LOOM_WATCHDOG_KICKSTART_RECHECK_ATTEMPTS=5 LOOM_WATCHDOG_KICKSTART_RECHECK_INTERVAL=0.2 \
+        bash "$WATCHDOG" > "$OUT" 2>&1
+    rc9=$?
+    kill "$NEW_PID9" 2>/dev/null || true
+    assert_rc 0 "$rc9" "exit-0-and-down: auto-kickstart relaunches the job -> exits 0"
+    if grep -qE '^kickstart ' "$LOG9"; then
+        pass "exit-0-and-down: auto-remediation invokes 'launchctl kickstart'"
+    else
+        fail "exit-0-and-down: auto-remediation invokes 'launchctl kickstart' (log: $(cat "$LOG9" 2>/dev/null))"
+    fi
+    if grep -q -- '-k' "$LOG9"; then
+        fail "exit-0-and-down: kickstart is invoked PLAIN, never with -k"
+    else
+        pass "exit-0-and-down: kickstart is invoked PLAIN, never with -k"
+    fi
+    if log_hasi 'remediat'; then
+        pass "exit-0-and-down: watchdog log records the remediation"
+    else
+        fail "exit-0-and-down: watchdog log records the remediation"
+    fi
+else
+    pass "exit-0-and-down auto-remediation test skipped (non-Darwin host)"
+fi
+
+# ===================================================================
+# 10. Every OTHER divergence stays report-only: job LOADED + NOT running but
+#     last exit status 143 (a SIGTERM'd operator stop) must NEVER trigger the
+#     auto-kickstart — narrow-gate proof that this is not a crash-loop reviver.
+# ===================================================================
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    STUB10="$WORKDIR/stub10"
+    mkdir -p "$STUB10"
+    STATE10="$WORKDIR/state10"
+    : > "$STATE10"
+    LOG10="$WORKDIR/launchctl10.log"
+    : > "$LOG10"
+    cat > "$STUB10/launchctl" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$LOG10"
+case "\${1:-}" in
+  print)
+    pid="\$(cat "$STATE10" 2>/dev/null)"
+    if [[ -n "\$pid" ]]; then
+      echo "	state = running"
+      echo "	pid = \$pid"
+    else
+      echo "	state = not running"
+    fi
+    echo "	last exit status = 143"
+    exit 0
+    ;;
+  kickstart)
+    # If this were ever wrongly invoked it WOULD bring the job "up" (proving a
+    # false positive would be caught) — the assertion below is that it is
+    # simply never called.
+    echo "999999" > "$STATE10"
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+    chmod +x "$STUB10/launchctl"
+    cat > "$MARKER" <<EOF
+started_at=2026-07-27T00:00:00Z
+heartbeat_file=$HEARTBEAT
+heartbeat_interval_secs=60
+use_launchd=true
+launchd_label=com.example.loom-sandbox-noremediate-$$
+socket_path=$WORKDIR/loom-daemon.sock
+EOF
+    : > "$WDLOG" "$OUT"
+    env PATH="$STUB10:$PATH" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
+        bash "$WATCHDOG" > "$OUT" 2>&1
+    rc10=$?
+    assert_rc 1 "$rc10" "exit-143-and-down: stays report-only (no auto-kickstart) -> exits 1"
+    if grep -q 'kickstart' "$LOG10"; then
+        fail "exit-143-and-down: kickstart is NEVER invoked (no crash-loop revival of an operator stop)"
+    else
+        pass "exit-143-and-down: kickstart is NEVER invoked (no crash-loop revival of an operator stop)"
+    fi
+else
+    pass "exit-143-and-down report-only test skipped (non-Darwin host)"
+fi
+
+# ===================================================================
+# 11. --help works and documents the marker + StartInterval design.
 # ===================================================================
 help_out=$(bash "$WATCHDOG" --help 2>/dev/null)
 if echo "$help_out" | grep -qi 'autonomy-desired' && echo "$help_out" | grep -qi 'StartInterval'; then


### PR DESCRIPTION
## Summary

`loom-daemon-update.sh`'s launchd restart branch treated a successful
`restart` ack (the running binary accepting the IPC request, exit 0) as
success and exited immediately — fire-and-forget. On 2026-07-28 that ack
was honest (the daemon honored its #4054/#4077 restart contract) but
launchd's own `KeepAlive:SuccessfulExit` relaunch silently never fired, so
the roll reported success while autonomous dispatch stayed down for ~4
minutes until an operator ran `launchctl kickstart` by hand.

This PR:

1. **Updater verify + kickstart fallback** (`loom-daemon-update.sh`): capture
   the pre-restart pid, poll for a NEW, different, **live** pid (`kill -0`)
   for up to `LOOM_DAEMON_RESTART_POLL_SECS` (default 30s) after the restart
   ack. On timeout, log `launchctl print` diagnostics (state / last exit
   status), then run `launchctl kickstart "$LAUNCHD_SERVICE"` — **plain,
   never `-k`**, so a daemon that actually relaunched during the race window
   is never killed — and re-poll for `LOOM_DAEMON_RESTART_KICKSTART_POLL_SECS`
   (default 15s). Only after verification does it print the
   `restart scheduled`-style success line; on continued failure it exits
   non-zero (**new exit code 7**) with diagnostics.
2. **Watchdog bounded auto-remediation** (`loom-daemon-watchdog.sh`): when the
   launchd job is loaded + not running + its last exit status was `0` — the
   one signature a restart-primitive exit that launchd failed to honor can
   produce — the watchdog now auto-`launchctl kickstart`s (plain, never `-k`)
   and reports the remediation. Every other divergence (a SIGTERM'd stop
   exiting 143/130, a genuine crash, a booted-out job) stays report-only, as
   before — no crash-loop revival, no reviving a deliberate operator stop.
3. Deferred the optional Rust-side poll in `handle_restart_command`
   (`loom-daemon/src/main.rs`) per the issue's own scope guard — this PR is
   scoped to the two shell scripts + their tests.

Root-cause evidence: not reproduced in this scoped builder session (no live
launchd job available to instrument mid-incident); shipping the
defense-in-depth fix per the issue's own allowance ("effective regardless of
root cause").

## Acceptance criteria

- [x] `loom-daemon-update.sh` no longer reports success on the restart ack
      alone: verifies a new pid within ~30s, falls back to `launchctl
      kickstart`, exits non-zero with diagnostics if still down after the
      fallback.
- [x] The fallback uses plain `kickstart` (never `-k`) — verified in tests
      (`grep -q -- '-k'` asserts absence in both the updater and watchdog
      suites).
- [x] The watchdog auto-kickstarts exactly the "loaded + not running + last
      exit 0" divergence and continues to report-only every other divergence
      (simulated exit-143 stop is reported, not revived — new test case 10).
- [x] Structural check: the updater's success line is emitted only after pid
      verification (the `ok "...restart scheduled..."` calls are inside the
      `wait_for_new_launchd_pid` success branches, never immediately after
      the `restart` ack).
- [x] Root-cause evidence recorded above ("not reproducible in this scoped
      session; defense-in-depth shipped").

## Test plan

- `defaults/scripts/tests/test-loom-daemon-update.sh` — 61/61 passing,
  including 3 new/updated cases: (15) relaunch observed immediately →
  success, kickstart never invoked; (26) no spontaneous relaunch → kickstart
  fallback relaunches → success with a remediation note; (27) no relaunch
  even after kickstart → exit 7.
- `defaults/scripts/tests/test-loom-daemon-watchdog.sh` — 18/18 passing,
  including 2 new cases: (9) exit-0-and-down → auto-kickstart fires and
  succeeds; (10) exit-143-and-down → stays report-only, kickstart never
  invoked.
- `shellcheck -x` clean on both modified CLI scripts and both test files.
- Manual verification on a live launchd host is still recommended per the
  issue's test plan (not performed in this scoped session).

Closes #4232
