### PR TITLE
feat(tokens): cut spawn-claude.sh + claude-wrapper.sh over to native loom-daemon tokens (epic #4081 phase 2)

### DIFF
--- a/.loom/docs/token-pool.md
+++ b/.loom/docs/token-pool.md
@@ -237,9 +237,14 @@ token hits its weekly limit.
    `claude` (or pass `--use-wrapper` to layer on top of `claude-wrapper.sh` for
    retry behavior).
 
-## Selection algorithm (`loom_tools.tokens.select`)
+## Selection algorithm (`loom-daemon tokens select`)
 
-Three tiers, falling through to the next when the current tier yields nothing:
+Three tiers, falling through to the next when the current tier yields nothing.
+Native Rust (`loom-daemon/src/tokens_pool/select.rs`), invoked directly by
+`spawn-claude.sh` / `claude-wrapper.sh` as of issue #4228 (epic #4081 Phase 2) —
+byte-compatible with the historical `loom_tools.tokens.select` implementation,
+which stays in-tree as reference/conformance material (`loom-tools/tests/tokens/`)
+but is no longer on the runtime path:
 
 1. **Ranking** — `.loom/tokens/.ranking` (pipe-delimited `name|status|5h_util`,
    refreshed every <10 min). A persistent rotation cursor spreads consecutive
@@ -250,6 +255,11 @@ Three tiers, falling through to the next when the current tier yields nothing:
 3. **Random** — uniform pick from all `*.token` files.
 
 Tokens marked bad in `.loom/tokens/.bad_tokens` are skipped at every tier.
+`loom-daemon tokens select --export` emits shell-evalable `export
+CLAUDE_CODE_OAUTH_TOKEN=...` / `export LOOM_TOKEN_NAME=...` lines (plus a
+non-exported `LOOM_TOKEN_MODE=...`) so callers `eval` the output directly
+instead of round-tripping through a JSON parser; `--auto-unpin` runs the
+pinned-account auto-recovery pre-flight (see below) before selecting.
 
 ### Ranking format: 5h-load field + soft gate (issue #4195)
 
@@ -274,13 +284,19 @@ the gpeyton-fork load-aware selection proposal (fork commits `283de8e3`,
 `20961dd9`) with upstream's existing rotation-cursor spread — a load-aware gate
 *layered on* #3909, not the fork's waterfall-fill replacement.
 
-## Bad-token tracking (`loom_tools.tokens.bad_tokens`)
+## Bad-token tracking (`loom-daemon tokens mark-bad`)
 
 When a token returns `TOKEN_EXPIRED` or `TOKEN_EXHAUSTED`, callers append an entry
-to `.loom/tokens/.bad_tokens`. Writes are guarded with a `mkdir`-based lock
-(POSIX-atomic, macOS-compatible — `flock` is **not** used because it isn't
-available on stock macOS). Reads use word-boundary regex so `agent-1` and
-`agent-10` don't collide.
+to `.loom/tokens/.bad_tokens` via `loom-daemon tokens mark-bad <name> --reason
+<text>` (native Rust, `loom-daemon/src/tokens_pool/bad_tokens.rs`, exposed as a
+CLI subcommand in #4228 — the historical Python `loom_tools.tokens.bad_tokens`
+module was library-only, with no CLI of its own). Writes are guarded with a
+`mkdir`-based lock (POSIX-atomic, macOS-compatible — `flock` is **not** used
+because it isn't available on stock macOS). Reads use word-boundary regex so
+`agent-1` and `agent-10` don't collide. The reason field's embedded
+newlines/carriage-returns are sanitized to spaces so every `.bad_tokens` record
+is exactly one line — byte-compatible with the Python implementation, and
+conformance-tested against it in `loom-tools/tests/tokens/test_rust_conformance.py`.
 
 ## Error classification (`.loom/scripts/lib/classify-error.sh`)
 
@@ -311,18 +327,17 @@ one truth). Provision the shared pool once per machine with `loom-tokens bootstr
 --shared`. See [daemon-reference.md → Token pool provisioning for managed
 repos](daemon-reference.md#token-pool-provisioning-for-managed-repos-3938).
 
-**Package-path fallback for consumer-repo dispatches (#3949)**: `#3938` fixed the
-pool *location*, but token *selection* still shells into `python3 -m
-loom_tools.tokens.select`, and `spawn-claude.sh` locates that Python package via
-(1) `LOOM_PACKAGE_PATH` env, (2) script-relative `../../loom-tools/src`, (3)
-`$WORKSPACE/loom-tools/src`. `loom-daemon`'s `spawn_child` now resolves and
-forwards `LOOM_PACKAGE_PATH` automatically on every dispatch: an ambient override
-on the daemon's own environment always wins, otherwise it derives
-`<loom-checkout>/loom-tools/src` from the source tree the running `loom-daemon`
-binary was compiled from (`CARGO_MANIFEST_DIR`, baked in at build time) when that
-directory still exists and contains `loom_tools/tokens`. A consumer repo with no
-loom checkout and no `LOOM_PACKAGE_PATH` env now selects a token successfully with
-zero manual configuration.
+**Native selection, zero Python package-path resolution needed (#4228)**: `#3938`
+fixed the pool *location*; as of #4228 (epic #4081 Phase 2) token *selection*
+itself is native too — `spawn-claude.sh` / `claude-wrapper.sh` shell out to
+`loom-daemon tokens select` (resolved via `$LOOM_DAEMON_BIN` -> `loom-daemon` on
+PATH -> build-output-relative candidates under the repo; see
+`.loom/scripts/lib/locate-daemon-bin.sh`) instead of `python3 -m
+loom_tools.tokens.select`. This retires the `LOOM_PACKAGE_PATH` bridge entirely
+(script-side resolution AND the daemon-side `spawn_child`/role-runner forwarding
+that used to derive it from the source tree the running binary was compiled
+from) — a consumer repo with no loom checkout now selects a token successfully
+with zero manual configuration and no Python package to locate at all.
 
 ## Hard-fail on missing pool
 

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1409,8 +1409,10 @@ the `.ranking` discrete status word (`exhausted` is already ≥ 0.95 utilization
 a finer sub-exhausted (≥ 0.90) bucket would read the richer `loom-tokens check
 --json` utilization and is a tracked follow-up. Even rotation/staggering of
 dispatches across the available account set (so 5h/7d windows reset in a
-staggered pattern) lives in the spawn-time selector (`loom_tools.tokens.select`),
-not the daemon, and is a separate follow-up.
+staggered pattern) lives in the spawn-time selector (native `loom-daemon tokens
+select`, `loom-daemon/src/tokens_pool/select.rs` — cut over from
+`loom_tools.tokens.select` in #4228), not the daemon's own dispatch loop, and is
+a separate follow-up.
 
 ## Operability — config, start/stop, E2E (Phase D, #3813)
 
@@ -1824,8 +1826,9 @@ for the full design.
 ### Prerequisite: a fresh token ranking (#3894, self-refreshed by the daemon since #3969)
 
 **When you run autonomous mode against a multi-account token pool, keep
-`.loom/tokens/.ranking` fresh.** The spawn-time selector (`loom_tools.tokens.select`)
-is 3-tier — ranking → allowlist → random — and the ranking file is only
+`.loom/tokens/.ranking` fresh.** The spawn-time selector (native `loom-daemon
+tokens select`, cut over from `loom_tools.tokens.select` in #4228) is 3-tier —
+ranking → allowlist → random — and the ranking file is only
 considered fresh for **10 minutes**. When it is absent or stale, tier-1 declines
 and selection falls to the lower tiers. The work finder dispatches in bursts, so
 a stale ranking means the daemon can steadily hand out accounts a recent probe

--- a/defaults/docs/runtime-adapters.md
+++ b/defaults/docs/runtime-adapters.md
@@ -63,10 +63,10 @@ token-rotating launcher that:
 1. Resolves the canonical repo root (worktree-aware, via
    `git rev-parse --git-common-dir`).
 2. Selects a Claude Code OAuth token from the effective `.loom/tokens/` pool
-   (per-repo pool, else the shared machine-level pool) via
-   `python3 -m loom_tools.tokens.select`, exports `CLAUDE_CODE_OAUTH_TOKEN`, and
-   exports `LOOM_TOKEN_NAME` so a downstream wrapper can mark exactly the right
-   account bad on a usage fault.
+   (per-repo pool, else the shared machine-level pool) via the native
+   `loom-daemon tokens select` CLI (issue #4228), exports
+   `CLAUDE_CODE_OAUTH_TOKEN`, and exports `LOOM_TOKEN_NAME` so a downstream
+   wrapper can mark exactly the right account bad on a usage fault.
 3. `exec`s the underlying CLI — `claude` by default, or
    `.loom/scripts/claude-wrapper.sh` when `--use-wrapper` is passed for
    retry/backoff/auth-cache behavior.
@@ -85,10 +85,12 @@ Claude-specific internals):
 | **Observability** | Emits exactly one structured `spawn-claude: model=<v>` line (and an effort line when resolved) to stderr on every spawn, changing no behavior. | Emit an equivalent single structured line so log scrapers can attribute the dispatch. |
 
 The daemon dispatch path (`loom-daemon`'s `spawn_child`) sets
-`LOOM_PACKAGE_PATH`, `LOOM_SWEEP_CLAIM_OWNED`, and per-sweep log redirection
-around this script; an adapter's spawn entry point is invoked the same way, so it
-must tolerate those env vars being present (Claude's script logs
-`LOOM_SWEEP_CLAIM_OWNED` on every spawn for dispatch diagnosability).
+`LOOM_SWEEP_CLAIM_OWNED` and per-sweep log redirection around this script; an
+adapter's spawn entry point is invoked the same way, so it must tolerate that
+env var being present (Claude's script logs `LOOM_SWEEP_CLAIM_OWNED` on every
+spawn for dispatch diagnosability). `LOOM_PACKAGE_PATH` forwarding — the
+bridge that let a dispatched `spawn-claude.sh` locate the Python `loom_tools`
+package — was retired end-to-end in #4228 once token selection went native.
 
 The runtime-neutral **dispatch seam** that realizes this contract point today —
 `spawn-worker.sh` plus the `runtimes` config block — is specified in

--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -77,7 +77,11 @@ TERMINAL_ID="${LOOM_TERMINAL_ID:-}"
 # Desktop/Documents/Downloads/Photos/Music/iCloud on an unsigned launchd binary.
 WORKSPACE="${LOOM_WORKSPACE:-$(pwd 2>/dev/null || echo "/tmp")}"
 
-# Python interpreter + active-account tracking for account rotation (#3738).
+# Python interpreter — still used by several NON-token helpers further down
+# this script (auth-status caching, MCP config parsing). The token-path
+# account-rotation calls (mark-bad / re-select, #3738) were cut over to the
+# native `loom-daemon tokens` CLI in issue #4228 (epic #4081 Phase 2) and no
+# longer consult this variable.
 LOOM_PYTHON="${LOOM_PYTHON:-python3}"
 # The account name whose OAuth token is currently exported. spawn-claude.sh
 # exports LOOM_TOKEN_NAME before exec'ing this wrapper; when the wrapper is
@@ -85,8 +89,9 @@ LOOM_PYTHON="${LOOM_PYTHON:-python3}"
 # content-matching the token against the pool at rotation time.
 ACTIVE_TOKEN_NAME="${LOOM_TOKEN_NAME:-}"
 
-# Directory of this script — used to source the shared error classifier and to
-# locate the loom_tools package for the mark-bad / re-select calls (#3738).
+# Directory of this script — used to source the shared error classifier and
+# to locate the native `loom-daemon` binary for the mark-bad / re-select
+# calls (#3738, cut over to `loom-daemon tokens` in #4228).
 _WRAPPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source the shared error classifier so the wrapper's account-exhaustion
@@ -99,6 +104,18 @@ if [[ -f "${_WRAPPER_DIR}/lib/classify-error.sh" ]]; then
     # shellcheck source=lib/classify-error.sh
     # shellcheck disable=SC1091
     source "${_WRAPPER_DIR}/lib/classify-error.sh"
+fi
+
+# Source the shared loom-daemon binary resolver (issue #4228) so account
+# rotation's mark-bad / re-select calls resolve the SAME binary
+# probe-tokens.sh / spawn-claude.sh do: $LOOM_DAEMON_BIN -> `loom-daemon` on
+# PATH -> build-output-relative candidates under the repo. If absent (older
+# install mid-resync), rotate_exhausted_account / reselect_account_no_mark
+# fail soft (return 1, same observable behavior as a Python selection error).
+if [[ -f "${_WRAPPER_DIR}/lib/locate-daemon-bin.sh" ]]; then
+    # shellcheck source=lib/locate-daemon-bin.sh
+    # shellcheck disable=SC1091
+    source "${_WRAPPER_DIR}/lib/locate-daemon-bin.sh"
 fi
 
 # Whether --dangerously-skip-permissions was passed (detected in main())
@@ -947,36 +964,41 @@ is_account_session_limit() {
 
 # Re-select a DIFFERENT rotation account WITHOUT marking the current one bad
 # (#3947). Used for concurrent-session-limit faults: the account isn't broken,
-# it just can't take another simultaneous session, so we spread to a sibling and
-# retry. Advances the rotation cursor (loom_tools.tokens.select) so a healthy
+# it just can't take another simultaneous session, so we spread to a sibling
+# and retry. Advances the rotation cursor (native `loom-daemon tokens select`,
+# cut over from `loom_tools.tokens.select` in issue #4228) so a healthy
 # sibling is preferred over re-picking the saturated account. Returns 0 when a
-# new token was exported, 1 when selection yielded nothing.
+# new token was exported, 1 when selection yielded nothing (including "no
+# loom-daemon binary resolved" — the same observable failure a broken Python
+# selector used to produce).
 reselect_account_no_mark() {
-    local ws pkg
+    local ws daemon_bin
     ws="$(_resolve_token_workspace)"
-    pkg="$(_resolve_package_path "${ws}")"
+    daemon_bin="$(declare -F loom_locate_daemon_bin >/dev/null 2>&1 && loom_locate_daemon_bin "${ws}" || true)"
+    if [[ -z "${daemon_bin}" ]]; then
+        log_warn "No loom-daemon binary resolved — cannot re-select an OAuth account"
+        return 1
+    fi
 
-    local sel_json _sel_rc
+    local sel_output _sel_rc
     set +e
-    sel_json="$(PYTHONPATH="${pkg}${PYTHONPATH:+:$PYTHONPATH}" \
-        "${LOOM_PYTHON}" -m loom_tools.tokens.select --workspace "${ws}" --json 2>/dev/null)"
+    sel_output="$("${daemon_bin}" tokens select --workspace "${ws}" --export 2>/dev/null)"
     _sel_rc=$?
     set -e
-    if [[ ${_sel_rc} -ne 0 || -z "${sel_json}" ]]; then
+    if [[ ${_sel_rc} -ne 0 || -z "${sel_output}" ]]; then
         return 1
     fi
 
-    local new_key new_name
-    new_key="$(printf '%s' "${sel_json}" | "${LOOM_PYTHON}" -c 'import json,sys; print(json.load(sys.stdin)["key"])' 2>/dev/null || echo "")"
-    new_name="$(printf '%s' "${sel_json}" | "${LOOM_PYTHON}" -c 'import json,sys; print(json.load(sys.stdin)["name"])' 2>/dev/null || echo "")"
-    if [[ -z "${new_key}" ]]; then
+    # `--export` emits shell-evalable `export CLAUDE_CODE_OAUTH_TOKEN=...` /
+    # `export LOOM_TOKEN_NAME=...` lines (issue #4228) — no more round-trip
+    # through `python3 -c 'import json...'` to pull the two fields back out.
+    eval "${sel_output}"
+    if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
         return 1
     fi
 
-    export CLAUDE_CODE_OAUTH_TOKEN="${new_key}"
-    ACTIVE_TOKEN_NAME="${new_name}"
-    export LOOM_TOKEN_NAME="${new_name}"
-    log_info "Re-selected OAuth account → '${new_name}' after concurrent-session limit (token NOT marked bad)"
+    ACTIVE_TOKEN_NAME="${LOOM_TOKEN_NAME:-}"
+    log_info "Re-selected OAuth account → '${ACTIVE_TOKEN_NAME}' after concurrent-session limit (token NOT marked bad)"
     return 0
 }
 
@@ -1010,23 +1032,6 @@ _resolve_token_workspace() {
     printf '%s\n' "${WORKSPACE}"
 }
 
-# Resolve the loom_tools package source (for the mark_bad / select calls).
-# Script-relative first (repo layout), then $WORKSPACE fallback.
-_resolve_package_path() {
-    local ws="$1"
-    if [[ -n "${LOOM_PACKAGE_PATH:-}" ]]; then
-        printf '%s\n' "${LOOM_PACKAGE_PATH}"
-        return
-    fi
-    local rel
-    rel="$(cd "${_WRAPPER_DIR}/../../loom-tools/src" 2>/dev/null && pwd || echo "")"
-    if [[ -n "${rel}" && -d "${rel}/loom_tools/tokens" ]]; then
-        printf '%s\n' "${rel}"
-        return
-    fi
-    printf '%s\n' "${ws}/loom-tools/src"
-}
-
 # Fallback identification of the active account when LOOM_TOKEN_NAME is unset:
 # content-match the exported token against .loom/tokens/*.token. Deterministic
 # (exact content compare) — deliberately avoids lean-genius's `ls -t | head -1`
@@ -1049,32 +1054,30 @@ _derive_token_name() {
 
 # Mark the active account exhausted in .loom/tokens/.bad_tokens, then re-run
 # Loom token selection (which now skips it) and re-export
-# CLAUDE_CODE_OAUTH_TOKEN. Reuses the existing Loom primitives
-# (loom_tools.tokens.bad_tokens.mark_bad + loom_tools.tokens.select) rather
-# than reimplementing lean-genius's raw file-glob. Returns 0 on success (a new
-# account is exported), 1 when the pool has no eligible account left.
+# CLAUDE_CODE_OAUTH_TOKEN. Reuses the existing Loom primitives via the native
+# `loom-daemon tokens mark-bad` / `tokens select` CLI (cut over from
+# `loom_tools.tokens.bad_tokens.mark_bad` + `loom_tools.tokens.select` in
+# issue #4228) rather than reimplementing lean-genius's raw file-glob.
+# Returns 0 on success (a new account is exported), 1 when the pool has no
+# eligible account left (or no loom-daemon binary resolves).
 rotate_exhausted_account() {
     local reason="$1"
-    local ws pkg
+    local ws daemon_bin
     ws="$(_resolve_token_workspace)"
-    pkg="$(_resolve_package_path "${ws}")"
+    daemon_bin="$(declare -F loom_locate_daemon_bin >/dev/null 2>&1 && loom_locate_daemon_bin "${ws}" || true)"
 
     if [[ -z "${ACTIVE_TOKEN_NAME}" ]]; then
         ACTIVE_TOKEN_NAME="$(_derive_token_name "${ws}" "${CLAUDE_CODE_OAUTH_TOKEN:-}" || true)"
     fi
 
+    if [[ -z "${daemon_bin}" ]]; then
+        log_warn "No loom-daemon binary resolved — cannot mark '${ACTIVE_TOKEN_NAME:-unknown}' bad or re-select"
+        return 1
+    fi
+
     if [[ -n "${ACTIVE_TOKEN_NAME}" ]]; then
-        local _mb
-        set +e
-        PYTHONPATH="${pkg}${PYTHONPATH:+:$PYTHONPATH}" "${LOOM_PYTHON}" - \
-            "${ws}" "${ACTIVE_TOKEN_NAME}" "exhausted: ${reason}" <<'PY' 2>/dev/null
-import sys
-from loom_tools.tokens.bad_tokens import mark_bad
-mark_bad(sys.argv[1], sys.argv[2], sys.argv[3])
-PY
-        _mb=$?
-        set -e
-        if [[ ${_mb} -eq 0 ]]; then
+        if "${daemon_bin}" tokens mark-bad "${ACTIVE_TOKEN_NAME}" \
+            --reason "exhausted: ${reason}" --workspace "${ws}" >/dev/null 2>&1; then
             log_info "Marked account '${ACTIVE_TOKEN_NAME}' exhausted in .bad_tokens (${reason})"
         else
             log_warn "Could not record '${ACTIVE_TOKEN_NAME}' in .bad_tokens (continuing to re-select)"
@@ -1083,27 +1086,22 @@ PY
         log_warn "Active account name unknown — cannot mark it bad; re-selecting anyway"
     fi
 
-    local sel_json _sel_rc
+    local sel_output _sel_rc
     set +e
-    sel_json="$(PYTHONPATH="${pkg}${PYTHONPATH:+:$PYTHONPATH}" \
-        "${LOOM_PYTHON}" -m loom_tools.tokens.select --workspace "${ws}" --json 2>/dev/null)"
+    sel_output="$("${daemon_bin}" tokens select --workspace "${ws}" --export 2>/dev/null)"
     _sel_rc=$?
     set -e
-    if [[ ${_sel_rc} -ne 0 || -z "${sel_json}" ]]; then
+    if [[ ${_sel_rc} -ne 0 || -z "${sel_output}" ]]; then
         return 1
     fi
 
-    local new_key new_name
-    new_key="$(printf '%s' "${sel_json}" | "${LOOM_PYTHON}" -c 'import json,sys; print(json.load(sys.stdin)["key"])' 2>/dev/null || echo "")"
-    new_name="$(printf '%s' "${sel_json}" | "${LOOM_PYTHON}" -c 'import json,sys; print(json.load(sys.stdin)["name"])' 2>/dev/null || echo "")"
-    if [[ -z "${new_key}" ]]; then
+    eval "${sel_output}"
+    if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
         return 1
     fi
 
-    export CLAUDE_CODE_OAUTH_TOKEN="${new_key}"
-    ACTIVE_TOKEN_NAME="${new_name}"
-    export LOOM_TOKEN_NAME="${new_name}"
-    log_info "Rotated OAuth account → '${new_name}' (token tail=…${new_key: -4})"
+    ACTIVE_TOKEN_NAME="${LOOM_TOKEN_NAME:-}"
+    log_info "Rotated OAuth account → '${ACTIVE_TOKEN_NAME}' (token tail=…${CLAUDE_CODE_OAUTH_TOKEN: -4})"
     return 0
 }
 

--- a/defaults/scripts/spawn-claude.sh
+++ b/defaults/scripts/spawn-claude.sh
@@ -2,8 +2,10 @@
 # spawn-claude.sh - Token-rotating launcher for Claude Code.
 #
 # This script is a thin layer that:
-#   1. Selects a Claude Code OAuth token from .loom/tokens/ via
-#      `python3 -m loom_tools.tokens.select`.
+#   1. Selects a Claude Code OAuth token from .loom/tokens/ via the native
+#      `loom-daemon tokens select` CLI (issue #4228, epic #4081 Phase 2 — the
+#      historical interpreted-language selector call has been retired from
+#      this path entirely; see loom-daemon/src/tokens_pool/select.rs).
 #   2. Exports CLAUDE_CODE_OAUTH_TOKEN.
 #   3. exec's the underlying CLI (`claude` by default, or
 #      `claude-wrapper.sh` if --use-wrapper is passed for retry behavior).
@@ -46,7 +48,11 @@
 #   LOOM_WORKSPACE         Override repo root detection.
 #   LOOM_SPAWN_NO_EXPORT   If set, skip selection (caller already exported a
 #                          token). Useful for testing the dispatch path.
-#   LOOM_PYTHON            Override the python interpreter (default: python3).
+#   LOOM_DAEMON_BIN        Override the `loom-daemon` binary used for native
+#                          token selection (see lib/locate-daemon-bin.sh for
+#                          the full resolution order: this env var ->
+#                          `loom-daemon` on PATH -> build-output-relative
+#                          candidates under the repo).
 #   LOOM_MODEL             Model to pass as `claude --model <value>` (issue
 #                          #3477). Lowest-priority tier: an explicit `--model`
 #                          in the passthrough args always wins. When neither
@@ -106,7 +112,13 @@ _resolve_workspace() {
 }
 
 WORKSPACE="$(_resolve_workspace)"
-PYTHON="${LOOM_PYTHON:-python3}"
+
+# --- Locate the loom-daemon binary (token selection, issue #4228) ---
+# Resolution precedence (see lib/locate-daemon-bin.sh): $LOOM_DAEMON_BIN ->
+# `loom-daemon` on PATH -> build-output-relative candidates under $WORKSPACE.
+_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/locate-daemon-bin.sh
+source "${_script_dir}/lib/locate-daemon-bin.sh"
 
 # --- Daemon self-claim marker visibility (Issue #3823, observability #3967) ---
 # `loom-daemon`'s `SweepRegistry::spawn_child` exports
@@ -240,71 +252,38 @@ elif [[ -n "${LOOM_EFFORT:-}" ]]; then
     log_info "spawn-claude: effort=$LOOM_EFFORT (from LOOM_EFFORT)"
 fi
 
-# --- Locate loom_tools package source ---
-# Search order:
-#   1. $LOOM_PACKAGE_PATH (env override).
-#   2. Script-relative: .loom/scripts/spawn-claude.sh -> ../../loom-tools/src
-#      (matches the loom repo layout regardless of WORKSPACE override).
-#   3. $WORKSPACE/loom-tools/src.
-#
-# Tiers 2/3 only resolve inside an actual loom checkout — a CONSUMER repo's
-# installed .loom/scripts/spawn-claude.sh has no loom-tools/ sibling, so
-# tier 1 is load-bearing there. Issue #3949: `loom-daemon`'s `spawn_child`
-# (loom-daemon/src/sweep_registry.rs::resolve_package_path_env) now sets
-# LOOM_PACKAGE_PATH automatically on every daemon-dispatched child — derived
-# from the loom checkout the running daemon binary was built from — so this
-# no longer needs to be exported manually before starting the daemon.
-_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-_script_relative_pkg="$(cd "$_script_dir/../../loom-tools/src" 2>/dev/null && pwd || echo "")"
-PACKAGE_PATH="${LOOM_PACKAGE_PATH:-$_script_relative_pkg}"
-if [[ -z "$PACKAGE_PATH" || ! -d "$PACKAGE_PATH/loom_tools/tokens" ]]; then
-    PACKAGE_PATH="${WORKSPACE}/loom-tools/src"
-fi
-
 # --- Token selection ---
 if [[ -z "${LOOM_SPAWN_NO_EXPORT:-}" && -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+    _daemon_bin="$(loom_locate_daemon_bin "$WORKSPACE")"
+    if [[ -z "$_daemon_bin" ]] || ! "$_daemon_bin" tokens select --help >/dev/null 2>&1; then
+        log_error "No loom-daemon binary supporting 'tokens select' was found."
+        log_error "(\$LOOM_DAEMON_BIN -> 'loom-daemon' on PATH -> build-output-relative"
+        log_error "candidates under the repo all came up empty or stale.)"
+        log_error "Build or start one, then retry:"
+        log_error "  ./.loom/scripts/cli/loom-daemon-start.sh"
+        log_error "  cargo build --release -p loom-daemon"
+        exit 78  # EX_CONFIG
+    fi
+
+    _select_args=(tokens select --workspace "$WORKSPACE" --export)
     # Pre-flight: auto-unpin if every allowlisted account has hit the
     # consecutive-failure threshold (default 5). Without this, an
     # operator-set pin can trap the spawner once all pinned accounts
     # exhaust their weekly quota. Empty-pool guard: we never silently
     # clear .bad_tokens — if that file blocks every account, the user
-    # must intervene (e.g. `loom-tokens unblock <name>`).
-    PYTHONPATH="${PACKAGE_PATH}${PYTHONPATH:+:$PYTHONPATH}" \
-        "$PYTHON" - "$WORKSPACE" <<'PY' || true
-import sys
-from pathlib import Path
-try:
-    from loom_tools.tokens import allowlist as a
-    from loom_tools.tokens import failure_counts as fc
-except Exception:
-    sys.exit(0)
-ws = Path(sys.argv[1])
-try:
-    pinned = a.read_allowlist(ws)
-    if not pinned:
-        sys.exit(0)
-    if all(fc.threshold_reached(ws, n) for n in pinned):
-        a.clear_allowlist(ws)
-        fc.reset_all(ws)
-        print(
-            f"[auto-unpin] All {len(pinned)} pinned account(s) hit "
-            f"{fc.DEFAULT_THRESHOLD} consecutive failures; "
-            f"cleared .allowlist.",
-            file=sys.stderr,
-        )
-except Exception as exc:  # noqa: BLE001
-    print(f"[auto-unpin] skipped ({exc!r})", file=sys.stderr)
-PY
+    # must intervene (e.g. `loom-tokens unblock <name>`). Capability-probed
+    # (issue #4228) so a daemon binary mid-roll that predates `--auto-unpin`
+    # degrades to plain selection instead of a hard argument-parse failure.
+    if "$_daemon_bin" tokens select --help 2>&1 | grep -q -- '--auto-unpin'; then
+        _select_args+=(--auto-unpin)
+    fi
 
-    # Capture stdout (JSON) and stderr (errors) separately so log output
-    # does not contaminate the JSON we feed to python -c.
+    # Capture stdout (shell-evalable export lines) and stderr (errors /
+    # advisories, e.g. a firing "[auto-unpin] ..." line) separately so log
+    # output never contaminates what we're about to `eval`.
     _selection_stderr_file="$(mktemp)"
-    _selection_json=""
-    if ! _selection_json="$(
-        PYTHONPATH="${PACKAGE_PATH}${PYTHONPATH:+:$PYTHONPATH}" \
-        "$PYTHON" -m loom_tools.tokens.select --workspace "$WORKSPACE" --json \
-        2>"$_selection_stderr_file"
-    )"; then
+    _selection_output=""
+    if ! _selection_output="$("$_daemon_bin" "${_select_args[@]}" 2>"$_selection_stderr_file")"; then
         log_error "Token selection failed:"
         cat "$_selection_stderr_file" >&2 || true
         rm -f "$_selection_stderr_file"
@@ -318,35 +297,26 @@ PY
         log_error "Set CLAUDE_CODE_OAUTH_TOKEN explicitly to bypass selection."
         exit 78  # EX_CONFIG
     fi
+    # Surface any advisory stderr (e.g. the auto-unpin line) without treating
+    # it as a failure — mirrors the historical Python pre-flight's `|| true`.
+    cat "$_selection_stderr_file" >&2 || true
     rm -f "$_selection_stderr_file"
 
-    # Parse JSON without jq (jq isn't guaranteed to be installed).
-    _token=$(
-        printf '%s' "$_selection_json" \
-        | "$PYTHON" -c 'import json,sys; print(json.load(sys.stdin)["key"])'
-    )
-    _name=$(
-        printf '%s' "$_selection_json" \
-        | "$PYTHON" -c 'import json,sys; print(json.load(sys.stdin)["name"])'
-    )
-    _mode=$(
-        printf '%s' "$_selection_json" \
-        | "$PYTHON" -c 'import json,sys; print(json.load(sys.stdin)["mode"])'
-    )
+    # `--export` emits `export CLAUDE_CODE_OAUTH_TOKEN=...` and
+    # `export LOOM_TOKEN_NAME=...` (both consumed by downstream processes,
+    # including a claude-wrapper.sh invoked via --use-wrapper) plus a local
+    # (non-exported) `LOOM_TOKEN_MODE=...` used only for the log line below.
+    # Tokens are base64/hex-like and never contain a single quote in
+    # practice — see `loom-daemon tokens select`'s own doc comment.
+    eval "$_selection_output"
 
-    if [[ -z "$_token" ]]; then
-        log_error "Token selection returned empty key for account '$_name'."
+    if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+        log_error "Token selection returned an empty key for account '${LOOM_TOKEN_NAME:-unknown}'."
         exit 78
     fi
 
-    export CLAUDE_CODE_OAUTH_TOKEN="$_token"
-    # Export the selected account name so a downstream claude-wrapper.sh knows
-    # which account the exported token belongs to. This is what lets the
-    # wrapper mark exactly the right account bad when it rotates on a
-    # usage/session-limit fault (issue #3738) instead of guessing from file
-    # mtimes. Harmless for the direct-`claude` dispatch path.
-    export LOOM_TOKEN_NAME="$_name"
-    log_info "spawn-claude: using OAuth account '$_name' (mode=$_mode)"
+    log_info "spawn-claude: using OAuth account '${LOOM_TOKEN_NAME:-unknown}' (mode=${LOOM_TOKEN_MODE:-unknown})"
+    unset LOOM_TOKEN_MODE
 fi
 
 # --- Print-mode background-task wait ceiling (issue #3943) ---

--- a/defaults/scripts/tests/test-probe-tokens-fallback.sh
+++ b/defaults/scripts/tests/test-probe-tokens-fallback.sh
@@ -1,15 +1,24 @@
 #!/usr/bin/env bash
-# test-probe-tokens-fallback.sh - Regression guard for #4079.
+# test-probe-tokens-fallback.sh - Regression guard for #4079, re-scoped in
+# #4228 (epic #4081 Phase 2).
 #
-# probe-tokens.sh falls back to a Python module invocation
-# (`python3 -m loom_tools.tokens.cli check`) when the `loom-tokens` console
-# script isn't on PATH. #4079 fixed a typo where the fallback invoked a
-# module that never existed (`loom_tools.cli.loom_tokens`, real module is
-# `loom_tools.tokens.cli`). This test asserts:
-#   1. probe-tokens.sh no longer references the stale module path.
-#   2. The fallback module path it does reference is actually importable.
-#   3. With no `loom-tokens` on PATH, probe-tokens.sh --json exits 0 and
-#      emits JSON (exercises the real fallback codepath end-to-end).
+# probe-tokens.sh delegates to the native `loom-daemon tokens check`
+# subcommand (issue #4080) and falls back to the `loom-tokens` console
+# script on PATH only when the resolved daemon binary predates the `tokens`
+# subcommand (a host mid-roll). The bare `python3 -m loom_tools.tokens.cli`
+# fallback tier that #4079 originally regression-tested no longer exists at
+# all — it was removed by #4080, well before this file's own cutover phase
+# (#4228). This test now asserts:
+#   1. probe-tokens.sh no longer references the stale module path (#4079).
+#   2. probe-tokens.sh contains NO python3/loom_tools reference whatsoever —
+#      the bare interpreter fallback tier is gone, not just fixed (#4228).
+#   3. With no capable `loom-daemon` binary resolvable and no `loom-tokens`
+#      on PATH, probe-tokens.sh fails loudly (exit 1, actionable message)
+#      rather than silently degrading — there is nothing left to fall back
+#      to.
+#   4. With `loom-tokens` on PATH but no capable daemon binary, probe-tokens.sh
+#      --json exits 0 and emits JSON via that fallback (exercises the real
+#      fallback codepath end-to-end).
 #
 # Usage:
 #   ./.loom/scripts/tests/test-probe-tokens-fallback.sh
@@ -18,8 +27,6 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-DEFAULTS_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
-REPO_ROOT="$(cd "$DEFAULTS_DIR/.." && pwd)"
 PROBE_SCRIPT="$SCRIPTS_DIR/probe-tokens.sh"
 
 RED='\033[0;31m'
@@ -60,35 +67,52 @@ else
     pass "probe-tokens.sh does not reference loom_tools.cli.loom_tokens"
 fi
 
-# -------- Test 3: the fallback module it references is importable --------
-echo "Test 3: fallback module path is importable"
-fallback_module="$(grep -oE 'loom_tools\.[a-zA-Z0-9_.]+' "$PROBE_SCRIPT" | grep -v '^loom_tools\.cli\.loom_tokens$' | head -n1 || true)"
-if [[ -z "$fallback_module" ]]; then
-    fail "could not extract a fallback module reference from probe-tokens.sh"
+# -------- Test 3: NO python3/loom_tools reference in CODE (issue #4228) --------
+# The bare interpreted-language fallback tier #4079 regression-tested is gone
+# entirely as of #4080 — the only remaining fallback is `loom-tokens` on PATH.
+# Deliberate comments explaining the history (e.g. "the bare python3 -m
+# fallback tier has been removed") are allowed — only non-comment lines count.
+echo "Test 3: no python3/loom_tools reference in probe-tokens.sh's executable code"
+code_hits="$(grep -vE '^\s*#' "$PROBE_SCRIPT" | grep -nE "python3|loom_tools" || true)"
+if [[ -n "$code_hits" ]]; then
+    fail "probe-tokens.sh's executable code still references python3/loom_tools: $code_hits"
 else
-    if PYTHONPATH="$REPO_ROOT/loom-tools/src${PYTHONPATH:+:$PYTHONPATH}" python3 -c \
-        "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('$fallback_module') else 1)" \
-        2>/dev/null; then
-        pass "fallback module '$fallback_module' is importable"
-    else
-        fail "fallback module '$fallback_module' is NOT importable"
-    fi
+    pass "probe-tokens.sh's executable code contains no python3/loom_tools reference"
 fi
 
-# -------- Test 4: with no loom-tokens on PATH, --json exits 0 and emits JSON --------
-echo "Test 4: --json fallback exits 0 and emits JSON with no loom-tokens on PATH"
-# Build a PATH with common system dirs but no loom-tokens console script, so
-# the script is forced down the python3 fallback branch.
-stripped_path="/usr/bin:/bin:/usr/sbin:/sbin"
-if command -v python3 >/dev/null 2>&1; then
-    python3_dir="$(dirname "$(command -v python3)")"
-    stripped_path="$python3_dir:$stripped_path"
-fi
-if command -v loom-tokens >/dev/null 2>&1; then
-    echo "  (skipping: loom-tokens is on PATH in this environment, cannot force fallback via PATH stripping)"
-    pass "skipped (loom-tokens present; not a failure)"
+# A hermetic "nothing resolves" workspace: no .git/.loom markers (so
+# probe-tokens.sh's own find_repo_root() falls back to $PWD) and no
+# target/{release,debug}/loom-daemon build-output-relative candidate
+# underneath it — required to truly defeat daemon-binary resolution rather
+# than accidentally finding THIS checkout's own freshly-built binary.
+NO_DAEMON_WS="$(mktemp -d)"
+trap 'rm -rf "$NO_DAEMON_WS"' EXIT
+STRIPPED_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+
+# -------- Test 4: neither a capable daemon binary nor loom-tokens on PATH
+#                   fails loudly (exit 1, actionable message) --------
+echo "Test 4: no capable daemon binary and no loom-tokens on PATH -> exit 1"
+out="$(cd "$NO_DAEMON_WS" && LOOM_DAEMON_BIN="/nonexistent/loom-daemon" \
+    PATH="$STRIPPED_PATH" "$PROBE_SCRIPT" --json 2>&1)"
+rc=$?
+if [[ "$rc" -eq 1 ]]; then
+    pass "no daemon binary + no loom-tokens on PATH exits 1"
 else
-    json_out="$(cd "$REPO_ROOT" && PATH="$stripped_path" PYTHONPATH="$REPO_ROOT/loom-tools/src${PYTHONPATH:+:$PYTHONPATH}" "$PROBE_SCRIPT" --json 2>/dev/null)"
+    fail "expected exit 1 with no daemon binary + no loom-tokens on PATH, got $rc"
+fi
+if [[ "$out" == *"no loom-daemon binary"* ]]; then
+    pass "failure message is actionable (names the missing daemon binary)"
+else
+    fail "failure message did not mention the missing daemon binary. Got: $out"
+fi
+
+# -------- Test 5: with loom-tokens on PATH (but no capable daemon binary),
+#                   --json exits 0 and emits JSON via that fallback --------
+echo "Test 5: --json fallback exits 0 and emits JSON via loom-tokens on PATH"
+if command -v loom-tokens >/dev/null 2>&1; then
+    loom_tokens_dir="$(dirname "$(command -v loom-tokens)")"
+    json_out="$(cd "$NO_DAEMON_WS" && LOOM_DAEMON_BIN="/nonexistent/loom-daemon" \
+        PATH="$loom_tokens_dir:$STRIPPED_PATH" "$PROBE_SCRIPT" --json 2>/dev/null)"
     rc=$?
     if [[ "$rc" -eq 0 ]]; then
         pass "fallback --json exit code is 0"
@@ -100,6 +124,9 @@ else
     else
         fail "fallback --json did not emit parseable JSON. Got: $json_out"
     fi
+else
+    echo "  (skipping: loom-tokens is not on PATH in this environment — cannot exercise the fallback codepath)"
+    pass "skipped (loom-tokens absent; not a failure)"
 fi
 
 # -------- Summary --------

--- a/defaults/scripts/tests/test-spawn-claude.sh
+++ b/defaults/scripts/tests/test-spawn-claude.sh
@@ -11,6 +11,25 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEFAULTS_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$DEFAULTS_DIR/.." && pwd)"
+
+# Resolve THIS checkout's own `loom-daemon` binary (issue #4228 — spawn-claude.sh
+# / claude-wrapper.sh now select/mark-bad tokens through it instead of Python).
+# Pin it explicitly into every spawn-claude.sh / claude-wrapper.sh invocation
+# below via LOOM_DAEMON_BIN so the assertions exercise THIS checkout's daemon,
+# never any host-level install / canary loom-daemon the dev environment may
+# have on PATH (mirrors the pre-existing LOOM_PACKAGE_PATH-pinning rationale
+# this file used for the Python selector).
+DAEMON_BIN=""
+for _candidate in \
+    "$REPO_ROOT/target/release/loom-daemon" \
+    "$REPO_ROOT/target/debug/loom-daemon"; do
+    if [[ -x "$_candidate" ]]; then
+        DAEMON_BIN="$_candidate"
+        break
+    fi
+done
 
 # Colors
 RED='\033[0;31m'
@@ -298,6 +317,17 @@ assert_eq "RECOVERABLE" "$result" "2-arg call under set -u with no LOOM_RUNTIME 
 echo ""
 echo "Testing spawn-claude.sh dispatch..."
 
+# spawn-claude.sh's token selection is now a hard dependency on the native
+# `loom-daemon` binary (issue #4228, epic #4081 Phase 2 — no Python fallback
+# exists to degrade to). Fail fast with a clear message rather than let every
+# subsequent test below fail opaquely on "No loom-daemon binary...".
+if [[ -z "$DAEMON_BIN" ]]; then
+    echo "FATAL: no loom-daemon binary found at $REPO_ROOT/target/{release,debug}/loom-daemon" >&2
+    echo "  Build one first: cd loom-daemon && cargo build --release" >&2
+    echo "  (spawn-claude.sh's token selection requires it as of issue #4228)" >&2
+    exit 1
+fi
+
 # Set up a fake workspace
 TEST_WS="$(mktemp -d)"
 trap 'rm -rf "$TEST_WS"' EXIT
@@ -320,7 +350,7 @@ STUB
 chmod +x "$STUB_DIR/claude"
 
 # Test: spawn-claude selects the only token and exec's the stub
-output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
 assert_contains "stub-claude got token=fake-token-alpha" "$output" \
     "spawn-claude exports selected token to claude"
@@ -337,7 +367,7 @@ assert_contains "stub-claude ceiling=0" "$output" \
 
 # Test: an operator-set CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS is PRESERVED
 # (the `:=` default-assignment idiom only fills an unset/empty value).
-output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS="120000" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
 assert_contains "stub-claude ceiling=120000" "$output" \
@@ -348,7 +378,7 @@ assert_contains "stub-claude ceiling=120000" "$output" \
 # Explicitly unset it first: this test suite may itself be running inside a
 # daemon-dispatched `/loom:sweep` session, which would otherwise leak an
 # ambient `LOOM_SWEEP_CLAIM_OWNED` into the subshell and false-fail this case.
-output=$(env -u LOOM_SWEEP_CLAIM_OWNED LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+output=$(env -u LOOM_SWEEP_CLAIM_OWNED LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
 assert_contains "spawn-claude: LOOM_SWEEP_CLAIM_OWNED=unset" "$output" \
     "spawn-claude logs LOOM_SWEEP_CLAIM_OWNED=unset when not daemon-dispatched (#3967)"
@@ -356,7 +386,7 @@ assert_contains "spawn-claude: LOOM_SWEEP_CLAIM_OWNED=unset" "$output" \
 # Test: with the var set (simulating a daemon-dispatched child, #3823), the
 # same log line echoes the exact issue number — the diagnostic this issue's
 # acceptance criteria calls for, straight from the per-sweep log.
-output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     LOOM_SWEEP_CLAIM_OWNED="3964" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
 assert_contains "spawn-claude: LOOM_SWEEP_CLAIM_OWNED=3964" "$output" \
@@ -374,7 +404,7 @@ assert_contains "spawn-claude: LOOM_SWEEP_CLAIM_OWNED=3964" "$output" \
 # `/loom:sweep` skill's own `$ARGUMENTS`. This test asserts the prompt (with the
 # embedded flag) is forwarded verbatim as a single `-p` argument, alongside the
 # env var (kept for backward compatibility, #3823/#3967).
-output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     LOOM_SWEEP_CLAIM_OWNED="4111" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "/loom:sweep 4111 --claim-owned 4111" \
         --dangerously-skip-permissions 2>&1 || true)
@@ -385,7 +415,7 @@ assert_contains "spawn-claude: LOOM_SWEEP_CLAIM_OWNED=4111" "$output" \
     "spawn-claude still logs the env var when the --claim-owned flag is also present (#4111 backward compat)"
 
 # Test: explicit CLAUDE_CODE_OAUTH_TOKEN bypasses selection
-output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     CLAUDE_CODE_OAUTH_TOKEN="caller-supplied" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
 assert_contains "stub-claude got token=caller-supplied" "$output" \
@@ -396,7 +426,7 @@ assert_contains "stub-claude got token=caller-supplied" "$output" \
 # case deterministically hard-fails regardless of the host's ~/.loom/tokens.
 EMPTY_WS="$(mktemp -d)"
 output=$(LOOM_WORKSPACE="$EMPTY_WS" LOOM_SHARED_TOKENS_DIR="" \
-    PATH="$STUB_DIR:$PATH" \
+    LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
 exit_code=$?
 assert_contains "loom-tokens bootstrap" "$output" \
@@ -405,7 +435,8 @@ rm -rf "$EMPTY_WS"
 
 # Test that spawn-claude.sh exits 78 on missing tokens (shared fallback off).
 set +e
-LOOM_WORKSPACE="$(mktemp -d)" LOOM_SHARED_TOKENS_DIR="" PATH="$STUB_DIR:$PATH" \
+LOOM_WORKSPACE="$(mktemp -d)" LOOM_SHARED_TOKENS_DIR="" \
+    LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" >/dev/null 2>&1
 exit_code=$?
 set -e
@@ -413,28 +444,22 @@ assert_eq "78" "$exit_code" "missing tokens exits 78 (EX_CONFIG)"
 
 # Test: consumer repo with NO per-repo pool falls back to the shared
 # machine-level pool (issue #3938) instead of hard-failing.
-#
-# Pin LOOM_PACKAGE_PATH at the repo-under-test's loom_tools so the assertion
-# exercises THIS checkout's selector, not any host-level editable install /
-# canary LOOM_PACKAGE_PATH the dev environment may export.
-REPO_PKG="$(cd "$SCRIPTS_DIR/../../loom-tools/src" 2>/dev/null && pwd || echo "")"
 CONSUMER_WS="$(mktemp -d)"
 SHARED_POOL="$(mktemp -d)"
 echo -n "fake-token-shared" > "$SHARED_POOL/shared-acct.token"
 chmod 600 "$SHARED_POOL/shared-acct.token"
 output=$(LOOM_WORKSPACE="$CONSUMER_WS" LOOM_SHARED_TOKENS_DIR="$SHARED_POOL" \
-    LOOM_PACKAGE_PATH="$REPO_PKG" PATH="$STUB_DIR:$PATH" \
+    LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
 assert_contains "stub-claude got token=fake-token-shared" "$output" \
     "spawn-claude falls back to shared pool for a repo with no pool (#3938)"
 assert_contains "OAuth account 'shared-acct'" "$output" \
     "spawn-claude logs the shared-pool account (#3938)"
 # State must land in the shared pool, never forked into the consumer repo.
-LOOM_SHARED_TOKENS_DIR="$SHARED_POOL" PYTHONPATH="$REPO_PKG" \
-    python3 -c "
-from loom_tools.tokens.bad_tokens import mark_bad
-mark_bad('$CONSUMER_WS', 'shared-acct', 'test')
-" 2>/dev/null || true
+# Uses the native `loom-daemon tokens mark-bad` CLI (issue #4228) instead of
+# the historical inline `loom_tools.tokens.bad_tokens.mark_bad` python call.
+LOOM_SHARED_TOKENS_DIR="$SHARED_POOL" "$DAEMON_BIN" tokens mark-bad shared-acct \
+    --reason test --workspace "$CONSUMER_WS" >/dev/null 2>&1 || true
 if [[ -f "$SHARED_POOL/.bad_tokens" && ! -f "$CONSUMER_WS/.loom/tokens/.bad_tokens" ]]; then
     assert_eq "ok" "ok" "shared-pool .bad_tokens written to shared dir, not consumer repo (#3938)"
 else
@@ -457,7 +482,7 @@ echo ""
 echo "Testing spawn-claude.sh model selection (#3477)..."
 
 # Case 3: LOOM_MODEL env produces --model in args
-output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     LOOM_MODEL="claude-sonnet-4-6" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
 assert_contains "stub-claude args=-p ping --model claude-sonnet-4-6" "$output" \
@@ -466,7 +491,7 @@ assert_contains "spawn-claude: model=claude-sonnet-4-6 (from LOOM_MODEL)" "$outp
     "structured model log line emitted for LOOM_MODEL case (#3482)"
 
 # Case 1: explicit --model arg wins over LOOM_MODEL env
-output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     LOOM_MODEL="claude-sonnet-4-6" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" --model claude-opus-4-8 2>&1 || true)
 assert_contains "stub-claude args=-p ping --model claude-opus-4-8" "$output" \
@@ -484,7 +509,7 @@ else
 fi
 
 # Case 2: --model=value form also suppresses LOOM_MODEL injection
-output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     LOOM_MODEL="claude-sonnet-4-6" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" --model=claude-opus-4-8 2>&1 || true)
 assert_contains "stub-claude args=-p ping --model=claude-opus-4-8" "$output" \
@@ -502,7 +527,7 @@ else
 fi
 
 # Case 4 (zero-behavior-change criterion): no env + no arg => no --model
-output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
 TESTS_RUN=$((TESTS_RUN + 1))
 if [[ "$output" == *"stub-claude args=-p ping"* && "$output" != *"--model"* ]]; then
@@ -517,7 +542,7 @@ assert_contains "spawn-claude: model=default" "$output" \
     "structured model=default log line emitted when nothing configured (#3482)"
 
 # Empty LOOM_MODEL is treated as unset — no --model emitted
-output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     LOOM_MODEL="" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
 TESTS_RUN=$((TESTS_RUN + 1))
@@ -549,7 +574,7 @@ echo ""
 echo "Testing spawn-claude.sh effort selection (#3705)..."
 
 # Case 1: LOOM_EFFORT env produces --effort in args
-output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     LOOM_EFFORT="xhigh" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
 assert_contains "stub-claude args=-p ping --effort xhigh" "$output" \
@@ -558,7 +583,7 @@ assert_contains "spawn-claude: effort=xhigh (from LOOM_EFFORT)" "$output" \
     "structured effort log line emitted for LOOM_EFFORT case (#3705)"
 
 # Case 2: explicit --effort arg wins over LOOM_EFFORT env
-output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     LOOM_EFFORT="xhigh" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" --effort high 2>&1 || true)
 assert_contains "stub-claude args=-p ping --effort high" "$output" \
@@ -576,7 +601,7 @@ else
 fi
 
 # Case 3: --effort=value form also suppresses LOOM_EFFORT injection
-output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     LOOM_EFFORT="xhigh" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" --effort=high 2>&1 || true)
 assert_contains "stub-claude args=-p ping --effort=high" "$output" \
@@ -594,7 +619,7 @@ else
 fi
 
 # Case 4 (zero-behavior-change criterion): no env + no arg => no --effort
-output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
 TESTS_RUN=$((TESTS_RUN + 1))
 if [[ "$output" == *"stub-claude args=-p ping"* && "$output" != *"--effort"* ]]; then
@@ -616,7 +641,7 @@ else
 fi
 
 # Case 5: empty LOOM_EFFORT is treated as unset — no --effort emitted
-output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
     LOOM_EFFORT="" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
 TESTS_RUN=$((TESTS_RUN + 1))
@@ -642,10 +667,9 @@ echo ""
 echo "Testing claude-wrapper.sh account rotation (#3738)..."
 
 WRAPPER="$SCRIPTS_DIR/claude-wrapper.sh"
-PKG_SRC="$(cd "$SCRIPTS_DIR/../../loom-tools/src" 2>/dev/null && pwd || echo "")"
 
-if [[ -z "$PKG_SRC" || ! -d "$PKG_SRC/loom_tools/tokens" ]]; then
-    echo "  (skipping rotation tests — loom_tools package not found)"
+if [[ -z "$DAEMON_BIN" ]]; then
+    echo "  (skipping rotation tests — loom-daemon binary not found)"
 else
   # --- Fixture: 2-account pool; stub exhausts alpha, succeeds on beta ---
   ROT_WS="$(mktemp -d)"
@@ -680,7 +704,7 @@ STUB
     LOOM_WORKSPACE="$ROT_WS" \
     LOOM_TOKEN_NAME="alpha" \
     CLAUDE_CODE_OAUTH_TOKEN="tok-alpha" \
-    LOOM_PACKAGE_PATH="$PKG_SRC" \
+    LOOM_DAEMON_BIN="$DAEMON_BIN" \
     LOOM_MAX_RETRIES=1 \
     LOOM_SHEPHERD_TASK_ID="test-rotation" \
     LOOM_STARTUP_MONITOR_WINDOW=1 \
@@ -731,7 +755,7 @@ STUB
     LOOM_WORKSPACE="$ROT_WS2" \
     LOOM_TOKEN_NAME="a" \
     CLAUDE_CODE_OAUTH_TOKEN="tok-a" \
-    LOOM_PACKAGE_PATH="$PKG_SRC" \
+    LOOM_DAEMON_BIN="$DAEMON_BIN" \
     LOOM_MAX_RETRIES=1 \
     LOOM_SHEPHERD_TASK_ID="test-rotation" \
     LOOM_STARTUP_MONITOR_WINDOW=1 \

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -226,9 +226,10 @@ enum Commands {
     /// self-refresh invoke natively. As of #4105 `bootstrap` is native too
     /// (multi-source `.env` merge + pool provisioning), and as of #4106
     /// `import-from-monitor` is native too (claude-monitor live SQLite
-    /// import); `spawn-claude.sh` (selection) remains Python-only (see
-    /// `loom-daemon/src/tokens_pool/mod.rs`). Purely file-based; does not
-    /// require a running daemon.
+    /// import). As of #4228 `select` and the new `mark-bad` are also what
+    /// `spawn-claude.sh` / `claude-wrapper.sh` invoke — zero Python left on
+    /// the token hot path (see `loom-daemon/src/tokens_pool/mod.rs`). Purely
+    /// file-based; does not require a running daemon.
     Tokens {
         #[command(subcommand)]
         action: TokensAction,
@@ -382,21 +383,35 @@ enum QuarantineAction {
 enum TokensAction {
     /// Select an OAuth token from the pool using the 3-tier algorithm
     /// (ranking -> allowlist -> random), skipping bad-marked tokens at every
-    /// tier. Mirrors `python3 -m loom_tools.tokens.select`.
+    /// tier. Native Rust port of `python3 -m loom_tools.tokens.select`,
+    /// invoked directly by `spawn-claude.sh` / `claude-wrapper.sh` as of
+    /// issue #4228 (epic #4081 Phase 2) — the Python selector is no longer on
+    /// the token hot path.
     Select {
         /// Repo root containing `.loom/tokens/` (the canonical main-checkout
         /// root when called from a worktree — no upward `.git` walk).
         #[arg(long, value_name = "PATH", default_value = ".")]
         workspace: String,
 
-        /// Emit `export CLAUDE_CODE_OAUTH_TOKEN=...` shell lines instead of
-        /// JSON.
+        /// Emit shell-evalable `export CLAUDE_CODE_OAUTH_TOKEN=...` /
+        /// `export LOOM_TOKEN_NAME=...` lines (plus a non-exported
+        /// `LOOM_TOKEN_MODE=...` assignment) instead of JSON — designed to be
+        /// consumed via `eval "$(loom-daemon tokens select --export ...)"`.
         #[arg(long)]
         export: bool,
 
         /// Omit the secret key from output (safe inspection).
         #[arg(long)]
         no_key: bool,
+
+        /// Pre-flight (issue #4228): if every allowlisted (pinned) account
+        /// has hit the consecutive-failure threshold, clear `.allowlist` and
+        /// reset `.failure_counts` before selecting, rather than trap the
+        /// spawner on exhausted pinned accounts. Mirrors the inline Python
+        /// heredoc `spawn-claude.sh` historically ran ahead of selection; a
+        /// firing auto-unpin logs an `[auto-unpin] ...` advisory to stderr.
+        #[arg(long)]
+        auto_unpin: bool,
     },
 
     /// Materialize `.loom/tokens/` from `ACCOUNT_*_N` triples, merging by email
@@ -565,6 +580,31 @@ enum TokensAction {
         all_reasons: bool,
 
         /// Emit JSON status.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Append a bad-token entry to `.bad_tokens` for `name`. Native Rust CLI
+    /// exposure of the existing `tokens_pool::bad_tokens::mark_bad` library
+    /// function (issue #4228, epic #4081 Phase 2) — closes the last gap that
+    /// kept `claude-wrapper.sh`'s account-rotation path on an inline Python
+    /// heredoc. Byte-compatible with the historical Python `mark_bad`: the
+    /// reason is newline-sanitized (embedded `\n`/`\r` collapsed to spaces)
+    /// so every `.bad_tokens` entry is exactly one line.
+    MarkBad {
+        /// Account name (token file stem, no extension) to mark bad.
+        #[arg(value_name = "NAME")]
+        name: String,
+
+        /// Free-form reason recorded alongside the timestamp + name.
+        #[arg(long, value_name = "TEXT", default_value = "")]
+        reason: String,
+
+        /// Repo root containing `.loom/tokens/`.
+        #[arg(long, value_name = "PATH", default_value = ".")]
+        workspace: String,
+
+        /// Emit a JSON status instead of a human message.
         #[arg(long)]
         json: bool,
     },
@@ -3841,10 +3881,11 @@ fn print_monitor_import(result: &loom_daemon::tokens_pool::monitor_db::MonitorIm
     }
 }
 
-/// Handle `loom-daemon tokens <select|pin|unpin|unblock>` (Issue #4082,
-/// Phase 1 of epic #4081). Purely file-based — does not require a running
-/// daemon. See `loom-daemon/src/tokens_pool/mod.rs` for the ported subset
-/// and what is deliberately deferred.
+/// Handle `loom-daemon tokens <select|pin|unpin|unblock|mark-bad>` (Issue
+/// #4082, Phase 1 of epic #4081; `mark-bad` added in #4228, Phase 2). Purely
+/// file-based — does not require a running daemon. See
+/// `loom-daemon/src/tokens_pool/mod.rs` for the ported subset and what is
+/// deliberately deferred.
 fn handle_tokens_command(action: TokensAction) -> Result<()> {
     use loom_daemon::tokens_pool::{allowlist, bad_tokens, failure_counts, select};
 
@@ -3853,8 +3894,14 @@ fn handle_tokens_command(action: TokensAction) -> Result<()> {
             workspace,
             export,
             no_key,
+            auto_unpin,
         } => {
             let ws = resolve_tokens_workspace(&workspace)?;
+            if auto_unpin {
+                if let Some(msg) = loom_daemon::tokens_pool::maybe_auto_unpin(&ws) {
+                    eprintln!("{msg}");
+                }
+            }
             match select::select_token(&ws, None) {
                 Ok(sel) => {
                     if export {
@@ -3868,10 +3915,14 @@ fn handle_tokens_command(action: TokensAction) -> Result<()> {
                         } else {
                             // Tokens are base64/hex-like and never contain a
                             // single quote in practice; this is a simple
-                            // wrap, not a full Python repr() escape (no
-                            // caller consumes --export in this phase — see
-                            // module docs).
+                            // wrap, not a full Python repr() escape.
                             println!("export CLAUDE_CODE_OAUTH_TOKEN='{}'", sel.key);
+                            // Shell-evalable (issue #4228): lets
+                            // spawn-claude.sh / claude-wrapper.sh `eval` this
+                            // output directly instead of round-tripping
+                            // through `python3 -c 'import json...'`.
+                            println!("export LOOM_TOKEN_NAME='{}'", sel.name);
+                            println!("LOOM_TOKEN_MODE='{}'", sel.mode);
                             println!(
                                 "# selected={} mode={} file={}",
                                 sel.name,
@@ -4236,6 +4287,29 @@ fn handle_tokens_command(action: TokensAction) -> Result<()> {
                 std::process::exit(3);
             }
             Ok(())
+        }
+
+        TokensAction::MarkBad {
+            name,
+            reason,
+            workspace,
+            json,
+        } => {
+            let ws = resolve_tokens_workspace(&workspace)?;
+            match bad_tokens::mark_bad(&ws, &name, &reason) {
+                Ok(()) => {
+                    if json {
+                        println!("{}", serde_json::json!({ "marked": true, "name": name }));
+                    } else {
+                        println!("Marked '{name}' bad ({reason}).");
+                    }
+                    Ok(())
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    std::process::exit(1);
+                }
+            }
         }
     }
 }

--- a/loom-daemon/src/role_runner.rs
+++ b/loom-daemon/src/role_runner.rs
@@ -356,13 +356,6 @@ fn run_role_with_timeout(
         .stdout(Stdio::from(out_file))
         .stderr(Stdio::from(stderr_file));
 
-    // Forward LOOM_PACKAGE_PATH so a consumer-repo dispatch can still locate
-    // the `loom_tools` Python package for token selection (issue #3949) —
-    // mirrors `sweep_registry::spawn_child`'s treatment exactly.
-    if let Some(pkg_path) = sweep_registry::resolve_package_path_env() {
-        cmd.env(sweep_registry::PACKAGE_PATH_ENV, pkg_path);
-    }
-
     // Run the child as its own process-group leader so a timeout can tear
     // down the whole subtree (the `claude` session's tool-call
     // subprocesses), not just the top-level `spawn-claude.sh` PID — mirrors

--- a/loom-daemon/src/self_update.rs
+++ b/loom-daemon/src/self_update.rs
@@ -29,8 +29,9 @@ use std::process::Command;
 pub const BUILT_COMMIT: &str = env!("LOOM_DAEMON_GIT_COMMIT");
 
 /// This crate's own directory in the source tree it was compiled from, baked
-/// in at compile time via `CARGO_MANIFEST_DIR` — the same technique
-/// `sweep_registry::BUILD_MANIFEST_DIR` uses for `LOOM_PACKAGE_PATH`
+/// in at compile time via `CARGO_MANIFEST_DIR` — the same
+/// compiled-from-source-tree technique the (retired in #4228)
+/// `sweep_registry::resolve_package_path_env` used for `LOOM_PACKAGE_PATH`
 /// resolution (issue #3949). This is a build-time constant, so it keeps
 /// pointing at the original checkout even after the compiled binary is
 /// copied elsewhere (e.g. `~/.local/bin/loom-daemon`, issue #3922) — as long

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -332,64 +332,6 @@ pub const EXPERIMENT_ENV_ALLOWLIST: &[&str] = &[
     "LOOM_TRANSCRIPT_ARCHIVE",
 ];
 
-/// Issue #3949: env var `spawn-claude.sh` checks FIRST when locating the
-/// `loom_tools` Python package source (before its own script-relative and
-/// `$WORKSPACE`-relative fallbacks). Those fallbacks only resolve inside an
-/// actual loom checkout, so a daemon dispatch into a **consumer repo** (one
-/// with no loom checkout of its own, e.g. the #3938 shared-pool scenario)
-/// hard-fails token selection with `ModuleNotFoundError: No module named
-/// 'loom_tools'` unless an operator manually exports this on the daemon's
-/// own environment before starting it (the pre-#3949 interim workaround).
-pub const PACKAGE_PATH_ENV: &str = "LOOM_PACKAGE_PATH";
-
-/// Issue #3949: the loom-daemon crate's own directory in the source tree it
-/// was COMPILED from, baked in at compile time via `CARGO_MANIFEST_DIR`. This
-/// is a build-time constant (not a runtime env lookup), so it survives the
-/// compiled binary being copied elsewhere (e.g. `~/.local/bin/loom-daemon`,
-/// issue #3922) as long as the source checkout it was built from is still
-/// present on the same machine — the normal case for an operator who built
-/// (or `install.sh`-installed) `loom-daemon` locally.
-const BUILD_MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
-
-/// Resolve the `LOOM_PACKAGE_PATH` value `spawn_child` should forward to a
-/// dispatched sweep child, in precedence order:
-///
-/// 1. `LOOM_PACKAGE_PATH` already set in the DAEMON's own ambient
-///    environment — an explicit operator override (mirrors the pre-#3949
-///    interim workaround of exporting it before `loom-daemon-start.sh`, and
-///    the general explicit-allowlist-forwarding pattern used for
-///    [`EXPERIMENT_ENV_ALLOWLIST`]). Always wins when non-empty.
-/// 2. Derived from the loom checkout this binary was compiled from
-///    (`<BUILD_MANIFEST_DIR>/../loom-tools/src`), but ONLY when that
-///    directory still exists on this machine AND actually contains
-///    `loom_tools/tokens` — the same validity check `spawn-claude.sh` itself
-///    applies to its own script-relative candidate. This is what lets a
-///    consumer-repo dispatch (#3938) resolve token selection with **zero**
-///    manual configuration.
-/// 3. `None` — `spawn_child` sets nothing, and the dispatched
-///    `spawn-claude.sh` falls back to its own pre-#3949 resolution order
-///    unchanged (a byte-for-byte no-op, e.g. for a daemon built from a
-///    stripped release tarball with no `loom-tools` sibling directory).
-#[must_use]
-pub fn resolve_package_path_env() -> Option<String> {
-    if let Ok(val) = std::env::var(PACKAGE_PATH_ENV) {
-        if !val.trim().is_empty() {
-            return Some(val);
-        }
-    }
-    let candidate = Path::new(BUILD_MANIFEST_DIR)
-        .join("..")
-        .join("loom-tools")
-        .join("src");
-    if !candidate.join("loom_tools").join("tokens").is_dir() {
-        return None;
-    }
-    // Best-effort canonicalize for a tidy absolute path; fall back to the
-    // (still-valid, just non-canonical) joined candidate on failure.
-    let resolved = candidate.canonicalize().unwrap_or(candidate);
-    Some(resolved.display().to_string())
-}
-
 /// Issue #3802: fallback `token_name` recorded when `spawn-claude.sh`'s
 /// account selection cannot be captured (e.g. the `LOOM_SPAWN_NO_EXPORT`
 /// bypass path, where the caller pre-exported `CLAUDE_CODE_OAUTH_TOKEN` and no
@@ -3344,19 +3286,6 @@ impl SweepRegistry {
             }
         }
 
-        // Issue #3949: resolve and forward LOOM_PACKAGE_PATH so a
-        // dispatched `spawn-claude.sh` can locate the `loom_tools` Python
-        // package even when the dispatch target is a consumer repo with no
-        // loom checkout of its own (the #3938 shared-pool scenario). A
-        // consumer repo's installed `.loom/scripts/spawn-claude.sh` has no
-        // `../../loom-tools/src` sibling to fall back on, so without this
-        // the child hard-fails token selection with `ModuleNotFoundError`
-        // unless an operator manually exported this var before starting the
-        // daemon. See `resolve_package_path_env` for the full precedence.
-        if let Some(pkg_path) = resolve_package_path_env() {
-            cmd.env(PACKAGE_PATH_ENV, pkg_path);
-        }
-
         let mut child = cmd
             .spawn()
             .with_context(|| format!("failed to spawn {} -p '{}'", spawn_bin.display(), prompt))?;
@@ -5516,7 +5445,6 @@ mod tests {
   printf 'LOOM_SWEEP_CLAIM_OWNED=%s\n' "${{LOOM_SWEEP_CLAIM_OWNED:-unset}}"
   printf 'LOOM_TERMINAL_ID=%s\n' "${{LOOM_TERMINAL_ID:-unset}}"
   printf 'CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=%s\n' "${{CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS:-unset}}"
-  printf 'LOOM_PACKAGE_PATH=%s\n' "${{LOOM_PACKAGE_PATH:-unset}}"
 }} >> "{rec}" 2>&1
 exit 0
 "#,
@@ -6013,85 +5941,6 @@ exit 0
         assert!(
             recorded.contains("CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0"),
             "expected print-mode bg-wait ceiling disabled (=0); got: {recorded}"
-        );
-    }
-
-    /// Issue #3949 unit coverage of the resolution order itself (does not go
-    /// through a full dispatch): with no ambient `LOOM_PACKAGE_PATH` set on
-    /// the test process, `resolve_package_path_env` must derive the real
-    /// monorepo's `loom-tools/src` from `CARGO_MANIFEST_DIR` — this is the
-    /// exact zero-config path that fixes a consumer-repo dispatch (#3938)
-    /// with no operator action required.
-    #[test]
-    #[serial]
-    fn resolve_package_path_env_derives_from_build_tree_when_unset() {
-        std::env::remove_var(PACKAGE_PATH_ENV);
-
-        let resolved = resolve_package_path_env()
-            .expect("expected a derived LOOM_PACKAGE_PATH in this monorepo checkout");
-        let resolved_path = Path::new(&resolved);
-        assert!(
-            resolved_path.join("loom_tools").join("tokens").is_dir(),
-            "derived path must contain loom_tools/tokens; got: {resolved}"
-        );
-        assert!(
-            resolved_path.ends_with(Path::new("loom-tools").join("src")),
-            "derived path should end in loom-tools/src; got: {resolved}"
-        );
-    }
-
-    /// Issue #3949: an operator-set `LOOM_PACKAGE_PATH` on the daemon's own
-    /// ambient environment always wins over the build-tree-derived fallback
-    /// — this is the highest-precedence tier, matching the pre-#3949 interim
-    /// workaround of exporting it before `loom-daemon-start.sh`.
-    #[test]
-    #[serial]
-    fn resolve_package_path_env_prefers_ambient_override() {
-        std::env::set_var(PACKAGE_PATH_ENV, "/tmp/custom-loom-tools-src-3949");
-
-        let resolved = resolve_package_path_env();
-
-        std::env::remove_var(PACKAGE_PATH_ENV);
-
-        assert_eq!(
-            resolved.as_deref(),
-            Some("/tmp/custom-loom-tools-src-3949"),
-            "an ambient LOOM_PACKAGE_PATH override must be forwarded verbatim"
-        );
-    }
-
-    /// Issue #3949 end-to-end: `spawn_child` forwards the derived
-    /// `LOOM_PACKAGE_PATH` to the dispatched child even when the daemon's own
-    /// environment never set it — the acceptance-criteria scenario (a
-    /// consumer repo with no loom checkout and no `LOOM_PACKAGE_PATH` env
-    /// still selects a token successfully, because the daemon fills in the
-    /// package path on its behalf).
-    #[test]
-    #[serial]
-    fn dispatch_forwards_derived_package_path_when_unset() {
-        std::env::remove_var(PACKAGE_PATH_ENV);
-
-        let dir = tempdir().unwrap();
-        let (mut registry, record_log) = fixture_registry(dir.path());
-
-        let outcome = registry
-            .dispatch(&SweepKind::Issue(4245), None, None, None, None)
-            .expect("dispatch should succeed");
-
-        let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
-        assert!(
-            // Generous budget (#3985): a busy host must not turn this red.
-            wait_for_contents(&record_log, &needle, FIXTURE_CHILD_WAIT_MS),
-            "fake spawn-claude.sh did not finish writing within the wait budget"
-        );
-        let recorded = std::fs::read_to_string(&record_log).unwrap();
-        assert!(
-            !recorded.contains("LOOM_PACKAGE_PATH=unset"),
-            "expected a derived LOOM_PACKAGE_PATH forwarded to the child; got: {recorded}"
-        );
-        assert!(
-            recorded.contains("LOOM_PACKAGE_PATH=") && recorded.contains("loom-tools/src"),
-            "expected LOOM_PACKAGE_PATH to point at loom-tools/src; got: {recorded}"
         );
     }
 

--- a/loom-daemon/src/tokens_pool/mod.rs
+++ b/loom-daemon/src/tokens_pool/mod.rs
@@ -4,15 +4,20 @@
 //! # Scope of this phase
 //!
 //! Phase 1 (issue #4082) was a **pure addition** with no caller cutover. Phase
-//! 2 (issue #4080, epic #4081) cut the check/probe path over: `loom-daemon
-//! tokens check` (issue #4108, this module's [`check`]) is invoked by
-//! `defaults/scripts/probe-tokens.sh` (native-binary resolution, `python3 -m`
-//! fallback removed), the daemon's own
+//! 2 landed in two increments: issue #4080 cut the check/probe path over
+//! (`loom-daemon tokens check`, issue #4108, this module's [`check`]) —
+//! invoked by `defaults/scripts/probe-tokens.sh` (native-binary resolution,
+//! `python3 -m` fallback removed), the daemon's own
 //! [`crate::token_ranking_refresh::ScriptRankingRefreshRunner`] (via
 //! `std::env::current_exe()`), and `loom-daemon status`'s
-//! `collect_token_usage()` (in-process). `spawn-claude.sh` (token *selection*,
-//! [`select`]) remains on the Python path — that cutover is a separate,
-//! file-disjoint follow-up.
+//! `collect_token_usage()` (in-process). Issue #4228 finished Phase 2: the
+//! token-*selection* path (`spawn-claude.sh` / `claude-wrapper.sh`, this
+//! module's [`select`]) and the bad-token-marking path
+//! (`claude-wrapper.sh`'s account rotation, this module's [`bad_tokens`], now
+//! exposed as `loom-daemon tokens mark-bad`) both cut over to the native CLI
+//! too — zero Python left on the token hot path, and the `LOOM_PACKAGE_PATH`
+//! bridge that used to locate the Python package for those two callers was
+//! retired end-to-end (scripts + `sweep_registry`/`role_runner` forwarding).
 //!
 //! Ported in this phase — the concurrency-critical "hot path" every sweep
 //! dispatch exercises, plus the operator-facing bookkeeping CLI:
@@ -70,3 +75,106 @@ pub mod rotation;
 pub mod select;
 
 pub use select::{EmptyTokenPoolError, SelectedToken, EX_CONFIG};
+
+/// Auto-unpin pre-flight (issue #4228, epic #4081 Phase 2): if the operator
+/// has pinned specific accounts (`.allowlist`) and EVERY pinned account has
+/// reached the consecutive-failure threshold ([`failure_counts::DEFAULT_THRESHOLD`]),
+/// clear the pin and reset the failure counters rather than trap the spawner
+/// on a set of exhausted pinned accounts forever. Mirrors the inline Python
+/// heredoc `spawn-claude.sh` historically ran ahead of every selection
+/// (never a standalone Python module — this is the first time the behavior
+/// gets a name in either language).
+///
+/// Empty-pool guard preserved: this NEVER touches `.bad_tokens` — if that
+/// file blocks every account, the operator must intervene (e.g. `loom-tokens
+/// unblock <name>`).
+///
+/// Returns `Some(message)` — already formatted like the historical Python
+/// advisory line — when the auto-unpin fired; `None` when there was nothing
+/// to do (no active pin, or not every pinned account is over threshold).
+#[must_use]
+pub fn maybe_auto_unpin(workspace: &std::path::Path) -> Option<String> {
+    let pinned = allowlist::read_allowlist(workspace);
+    if pinned.is_empty() {
+        return None;
+    }
+    let threshold = failure_counts::DEFAULT_THRESHOLD;
+    let all_over_threshold = pinned
+        .iter()
+        .all(|name| failure_counts::threshold_reached(workspace, name, threshold));
+    if !all_over_threshold {
+        return None;
+    }
+    let _ = allowlist::clear_allowlist(workspace);
+    let _ = failure_counts::reset_all(workspace);
+    Some(format!(
+        "[auto-unpin] All {} pinned account(s) hit {threshold} consecutive failures; cleared \
+         .allowlist.",
+        pinned.len()
+    ))
+}
+
+#[cfg(test)]
+mod auto_unpin_tests {
+    use super::*;
+    use std::fs;
+
+    fn make_pool(names: &[&str]) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join(".loom").join("tokens");
+        fs::create_dir_all(&dir).unwrap();
+        for n in names {
+            fs::write(dir.join(format!("{n}.token")), format!("key-{n}")).unwrap();
+        }
+        tmp
+    }
+
+    #[test]
+    fn no_allowlist_is_a_noop() {
+        let tmp = make_pool(&["a"]);
+        assert!(maybe_auto_unpin(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn allowlist_below_threshold_is_a_noop() {
+        let tmp = make_pool(&["a", "b"]);
+        allowlist::write_allowlist(tmp.path(), &["a".to_string()]).unwrap();
+        for _ in 0..failure_counts::DEFAULT_THRESHOLD - 1 {
+            failure_counts::record_failure(tmp.path(), "a", failure_counts::DEFAULT_THRESHOLD)
+                .unwrap();
+        }
+        assert!(maybe_auto_unpin(tmp.path()).is_none());
+        assert_eq!(allowlist::read_allowlist(tmp.path()), vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn all_pinned_over_threshold_clears_allowlist_and_counters() {
+        let tmp = make_pool(&["a", "b", "c"]);
+        allowlist::write_allowlist(tmp.path(), &["a".to_string(), "b".to_string()]).unwrap();
+        for name in ["a", "b"] {
+            for _ in 0..failure_counts::DEFAULT_THRESHOLD {
+                failure_counts::record_failure(tmp.path(), name, failure_counts::DEFAULT_THRESHOLD)
+                    .unwrap();
+            }
+        }
+        let msg = maybe_auto_unpin(tmp.path()).expect("expected auto-unpin to fire");
+        assert!(msg.contains("[auto-unpin]"));
+        assert!(msg.contains("2 pinned account"));
+        assert!(allowlist::read_allowlist(tmp.path()).is_empty());
+        assert_eq!(failure_counts::get_count(tmp.path(), "a"), 0);
+        assert_eq!(failure_counts::get_count(tmp.path(), "b"), 0);
+    }
+
+    #[test]
+    fn one_pinned_account_still_healthy_blocks_auto_unpin() {
+        let tmp = make_pool(&["a", "b"]);
+        allowlist::write_allowlist(tmp.path(), &["a".to_string(), "b".to_string()]).unwrap();
+        for _ in 0..failure_counts::DEFAULT_THRESHOLD {
+            failure_counts::record_failure(tmp.path(), "a", failure_counts::DEFAULT_THRESHOLD)
+                .unwrap();
+        }
+        // "b" never failed — the pin must survive.
+        assert!(maybe_auto_unpin(tmp.path()).is_none());
+        assert_eq!(allowlist::read_allowlist(tmp.path()), vec!["a".to_string(), "b".to_string()]);
+    }
+}

--- a/loom-tools/tests/tokens/test_rust_conformance.py
+++ b/loom-tools/tests/tokens/test_rust_conformance.py
@@ -382,6 +382,74 @@ def test_unblock_default_scope_excluded_exit3_identically(tmp_path):
     assert py_json == rust_json == {"removed": 1, "kept": 1, "excluded": ["b"]}
 
 
+# ---------------------------------------------------------------------------
+# mark-bad (issue #4228, epic #4081 Phase 2): the new `loom-daemon tokens
+# mark-bad` CLI exposure of the pre-existing `bad_tokens::mark_bad` library
+# fn — the gap that let `claude-wrapper.sh` drop its inline
+# `from loom_tools.tokens.bad_tokens import mark_bad` heredoc. Python's
+# `mark_bad` has no CLI of its own (library-only, exercised directly in
+# `loom-tools/tests/tokens/test_bad_tokens.py`), so the comparison here calls
+# the Python function directly rather than shelling to a Python CLI.
+# ---------------------------------------------------------------------------
+
+
+def test_mark_bad_appends_byte_compatible_entry(tmp_path):
+    py_ws = tmp_path / "py"
+    rust_ws = tmp_path / "rust"
+    _write_pool(py_ws, ["a"])
+    _write_pool(rust_ws, ["a"])
+
+    py_mark_bad(py_ws, "a", "exhausted: weekly limit")
+    rust_result = _run_rust("mark-bad", "a", "--reason", "exhausted: weekly limit", "--workspace", str(rust_ws))
+    assert rust_result.returncode == 0, rust_result.stderr
+
+    py_bad = (py_ws / ".loom" / "tokens" / ".bad_tokens").read_text(encoding="utf-8")
+    rust_bad = (rust_ws / ".loom" / "tokens" / ".bad_tokens").read_text(encoding="utf-8")
+    # Timestamps differ per-run; the record shape (name + reason text) must
+    # match exactly, and each is exactly one line.
+    assert py_bad.count("\n") == rust_bad.count("\n") == 1
+    assert "a exhausted: weekly limit" in py_bad
+    assert "a exhausted: weekly limit" in rust_bad
+
+
+def test_mark_bad_reason_newline_sanitization_agrees(tmp_path):
+    """Both implementations collapse an embedded newline/CR in the reason so
+    a `.bad_tokens` record is always exactly one line (parity guard named
+    explicitly in issue #4228)."""
+    py_ws = tmp_path / "py"
+    rust_ws = tmp_path / "rust"
+    _write_pool(py_ws, ["agent-1"])
+    _write_pool(rust_ws, ["agent-1"])
+
+    multiline_reason = "line one\nline two\rline three"
+    py_mark_bad(py_ws, "agent-1", multiline_reason)
+    rust_result = _run_rust(
+        "mark-bad", "agent-1", "--reason", multiline_reason, "--workspace", str(rust_ws)
+    )
+    assert rust_result.returncode == 0, rust_result.stderr
+
+    py_bad = (py_ws / ".loom" / "tokens" / ".bad_tokens").read_text(encoding="utf-8")
+    rust_bad = (rust_ws / ".loom" / "tokens" / ".bad_tokens").read_text(encoding="utf-8")
+    assert py_bad.count("\n") == rust_bad.count("\n") == 1
+    for record in (py_bad, rust_bad):
+        assert "line one" in record
+        assert "line two" in record
+        assert "line three" in record
+
+
+def test_mark_bad_missing_tokens_dir_both_fail(tmp_path):
+    py_ws = tmp_path / "py"
+    rust_ws = tmp_path / "rust"
+    py_ws.mkdir()
+    rust_ws.mkdir()
+
+    with pytest.raises(Exception):
+        py_mark_bad(py_ws, "agent-1", "no dir")
+
+    rust_result = _run_rust("mark-bad", "agent-1", "--reason", "no dir", "--workspace", str(rust_ws))
+    assert rust_result.returncode != 0
+
+
 def _loom_tools_src() -> str:
     root = _find_repo_root()
     assert root is not None


### PR DESCRIPTION
Closes #4228

Phase 2 of epic #4081 (Eliminate Python from Loom): cut the remaining Bash callers on the token hot path over to the native `loom-daemon tokens` CLI, retiring the last runtime Python from token selection and bad-token marking.

## What changed

**New Rust CLI surface (`loom-daemon/src/main.rs`)**
- `loom-daemon tokens mark-bad <name> --reason <text> [--workspace P] [--json]` — thin CLI exposure of the pre-existing `tokens_pool::bad_tokens::mark_bad` library fn (the gap `TokensAction` had). Byte-compatible with the Python `mark_bad`: the reason is newline/CR-sanitized so every `.bad_tokens` record is exactly one line.
- `tokens select --auto-unpin` — runs the pinned-account auto-recovery pre-flight (new `tokens_pool::maybe_auto_unpin`) before selecting, replacing spawn-claude.sh's inline Python heredoc. Fires only when EVERY allowlisted account is over the consecutive-failure threshold; never touches `.bad_tokens`.
- `tokens select --export` now also emits shell-evalable `export LOOM_TOKEN_NAME=...` + a local `LOOM_TOKEN_MODE=...` line, so callers `eval` the output instead of round-tripping the JSON through `python3 -c 'json.load(...)'`.

**Bash caller cutover**
- `spawn-claude.sh`: selects via `loom-daemon tokens select --export --auto-unpin` (capability-probed so a daemon mid-roll degrades to plain selection), resolves the binary through the shared `lib/locate-daemon-bin.sh`, and `eval`s the export lines. All `python3`/`PYTHON`/`loom_tools` and the inline auto-unpin heredoc are gone.
- `claude-wrapper.sh`: `rotate_exhausted_account` / `reselect_account_no_mark` now call `loom-daemon tokens mark-bad` / `tokens select --export`. The non-token Python helpers (auth-status caching, MCP config parsing, error-report JSON) are deliberately left untouched per the curator's AC correction.

**Bridge retirement (`LOOM_PACKAGE_PATH`)**
- Removed `PACKAGE_PATH_ENV` / `resolve_package_path_env` + forwarding from `sweep_registry.rs`, the forwarding from `role_runner.rs`, and `_resolve_package_path` from claude-wrapper.sh + the resolution block in spawn-claude.sh. No non-token consumer remained, so it is retired end-to-end (no follow-up needed).

**Docs**: `token-pool.md`, `daemon-reference.md`, `runtime-adapters.md` updated to name the native CLI and note the bridge retirement.

## Acceptance criteria

- [x] Corrected grep AC: `grep -n "loom_tools" spawn-claude.sh claude-wrapper.sh` → only two deliberate comment lines in claude-wrapper.sh; `grep -nE "python3|PYTHON" spawn-claude.sh` → empty.
- [x] `loom-daemon tokens mark-bad` exists, byte-compatible with Python `mark_bad`, conformance-tested against `loom-tools/tests/tokens/` fixtures (byte-compat + newline sanitization + missing-dir parity).
- [x] `LOOM_PACKAGE_PATH` forwarding removed end-to-end (scripts + sweep_registry + role_runner).
- [x] Docs updated; exit-code 78 (`EX_CONFIG`) missing-pool behavior preserved.
- [x] Python `loom_tools.tokens` implementation + tests left in-tree (callers-only cutover per scope guard).

## Tests

- `cargo test tokens` (release): 191 passed, incl. new `auto_unpin_tests::*` and `bad_tokens::tests::mark_bad_*`.
- `loom-tools/tests/tokens/test_rust_conformance.py`: 24 passed (incl. the 3 new mark-bad parity tests).
- Full `loom-tools/tests/tokens/`: 373 passed (Python implementation untouched, still green).
- `defaults/scripts/tests/test-spawn-claude.sh`: 107 passed.
- `defaults/scripts/tests/test-probe-tokens-fallback.sh`: 7/7 passed.

## Related

#4218 (runpy RuntimeWarning on spawn-time selection) is obsoleted by this phase — its warning came from the `python3 -m loom_tools.tokens.select` callers this PR retires. (Note: #4252 also independently addressed the warning on the Python side.) Whoever merges/champions this should verify-and-close #4218 as obsolete rather than build it. Not closing it here — that is Judge/Champion's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
