### PR TITLE
docs(labels): loom:operator-only also covers owner-gated decisions

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -111,13 +111,14 @@
   description: Signal to abort shepherd for this issue (returns to loom:issue)
   color: "F97316"  # orange-500 - warning/signal color
 
-# loom:operator-only vs loom:blocked: operator-only = a human must act OUTSIDE
-# automation (credentials, infra, hardware) and sweep/shepherd skip it entirely;
+# loom:operator-only vs loom:blocked: operator-only = a human must act or rule
+# OUTSIDE automation (credentials, infra, hardware, or an owner-gated decision
+# on owner-tracked code) and sweep/shepherd skip it entirely;
 # blocked = waiting on a dependency but otherwise automatable. Keep the
 # description at/under GitHub's 100-char label-description limit so sync-labels.sh
 # can create it (a longer description fails with HTTP 422 and the label never syncs).
 - name: loom:operator-only
-  description: "Requires human action outside automation (credentials, infra, hardware); sweep/shepherd skip"
+  description: "Requires human action or ruling outside automation (creds, infra, hardware); sweep/shepherd skip"
   color: "F97316"  # orange-500 - operator-action signal (matches loom:abort)
 
 # Epic Labels

--- a/defaults/.github/labels.yml
+++ b/defaults/.github/labels.yml
@@ -111,13 +111,14 @@
   description: Signal to abort shepherd for this issue (returns to loom:issue)
   color: "F97316"  # orange-500 - warning/signal color
 
-# loom:operator-only vs loom:blocked: operator-only = a human must act OUTSIDE
-# automation (credentials, infra, hardware) and sweep/shepherd skip it entirely;
+# loom:operator-only vs loom:blocked: operator-only = a human must act or rule
+# OUTSIDE automation (credentials, infra, hardware, or an owner-gated decision
+# on owner-tracked code) and sweep/shepherd skip it entirely;
 # blocked = waiting on a dependency but otherwise automatable. Keep the
 # description at/under GitHub's 100-char label-description limit so sync-labels.sh
 # can create it (a longer description fails with HTTP 422 and the label never syncs).
 - name: loom:operator-only
-  description: "Requires human action outside automation (credentials, infra, hardware); sweep/shepherd skip"
+  description: "Requires human action or ruling outside automation (creds, infra, hardware); sweep/shepherd skip"
   color: "F97316"  # orange-500 - operator-action signal (matches loom:abort)
 
 # Epic Labels

--- a/defaults/docs/troubleshooting.md
+++ b/defaults/docs/troubleshooting.md
@@ -129,7 +129,7 @@ Run the sync script — or create the one label directly — to reconcile:
 ```bash
 gh label list --search operator                      # empty => not provisioned
 gh label create "loom:operator-only" --color F97316 \
-  --description "Requires human action outside automation (credentials, infra, hardware); sweep/shepherd skip"
+  --description "Requires human action or ruling outside automation (creds, infra, hardware); sweep/shepherd skip"
 ```
 
 **GitHub caps label descriptions at 100 characters.** A `labels.yml` entry with a
@@ -143,8 +143,10 @@ These two status labels look similar but mean different things to the automation
 - **`loom:blocked`** — work is *automatable* but currently waiting on a dependency
   (another issue, an unmerged PR, missing context). The intent is "unblock it, then
   a Builder can proceed."
-- **`loom:operator-only`** — work requires a *human to act outside automation
-  entirely* (rotating credentials, infra changes, hardware access, manual deploys).
+- **`loom:operator-only`** — work requires a *human to act or rule outside
+  automation entirely* (rotating credentials, infra changes, hardware access,
+  manual deploys — or an owner-gated decision: an issue the code owner filed as a
+  TODO on owner-tracked code, where the design direction is the owner's call).
   Sweep/shepherd skip these in pre-flight rather than attempting them; a human must
   do the work off-automation before the issue can proceed.
 


### PR DESCRIPTION
## Summary

`loom:operator-only` is the one label every automation layer hard-skips — `work_finder::SKIP_LABELS`, `/loom:sweep` pre-flight (including the aggressive `all` sentinel, where it is "the one hard exclusion"), and Champion `--merge` refusal (#3360/#3362). But its description scopes it to mechanical off-automation work: *credentials, infra, hardware*.

There is a second class with identical skip semantics that the wording doesn't cover: **owner-gated decisions** — issues a code owner files as TODOs on owner-tracked code, where the design direction is the owner's call and a sweep implementing "a" fix is exactly the wrong outcome even when the fix is technically plausible.

Motivating incident (host repo running loom 0.10.10): a `/loom:sweep` backlog cleanup picked up three owner-tracked TODO issues, implemented and merged fixes to provenance-tracked vendored trees without owner review. All three merges were reverted and the issues reopened. They were exactly operator-only-shaped — but the credentials/infra/hardware framing meant nobody had reached for the label.

## Changes (docs/metadata only — no behavior change)

- `.github/labels.yml` + `defaults/.github/labels.yml` (kept byte-identical; `check-labels-drift.sh` passes): description becomes `"Requires human action or ruling outside automation (creds, infra, hardware); sweep/shepherd skip"` — 96 chars, under the 100-char GitHub cap (#3532). The comment block above the entry names the owner-gated-decision case.
- `defaults/docs/troubleshooting.md`: the `gh label create` example matches the new description; the `loom:blocked` vs `loom:operator-only` section describes the owner-gated class.

Enforcement code paths are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
