### PR TITLE
feat(daemon): support LOOM_CODESIGN_IDENTITY for stable TCC-surviving codesigning

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -2525,11 +2525,18 @@ All this change actually buys is a **legible, stable identifier string**: the
 `codesign -dv` / System Settings → Privacy & Security / crash-diagnostic
 surfaces show `com.rjwalters.loom-daemon` instead of the rustc `-C metadata`
 hash (`loom_daemon-<hash>`, which itself changes on every version bump). It is
-also the necessary first step *if* the project ever adopts real signing — a
-self-signed certificate in a login keychain (breaks hermetic/headless builds)
-or Developer ID + notarization (requires a paid account) — but adopting
-either is unevaluated speculative infrastructure, not something this change
-does. No new TCC grant is requested or needed for this.
+also the necessary first step for real signing, which #4244 turns from
+speculative into an opt-in capability: set `LOOM_CODESIGN_IDENTITY` (or the
+`codesign.identity` config key, env > config > default) to a certificate
+already in the keychain and `sign_daemon_binary` signs with that certificate
+chain instead of ad-hoc — a certificate-anchored DR survives a rebuild, so a
+TCC grant to the daemon identity does too. Unset (or an identity the keychain
+doesn't have) falls back to the ad-hoc path above, unchanged, and no new TCC
+grant is requested by default. One-time self-signed cert setup (Certificate
+Assistant or openssl + `security import`, including the OpenSSL 3 PKCS12
+`-legacy` quirk and the `-T /usr/bin/codesign` trust-anchor requirement for
+unattended signing) and why grants should target the daemon identity, not
+Terminal: [`macos-tcc-codesign.md`](macos-tcc-codesign.md).
 
 ### Supervised restart primitive (#4054)
 

--- a/defaults/docs/macos-tcc-codesign.md
+++ b/defaults/docs/macos-tcc-codesign.md
@@ -1,0 +1,112 @@
+# macOS TCC + a stable codesign identity (#4244)
+
+Ad-hoc signing (the `loom-daemon` default, #4016) pins a legible
+`--identifier`, but TCC (Transparency, Consent, and Control — the Privacy &
+Security prompts) anchors a grant to the binary's **designated requirement**,
+which for an ad-hoc signature is a **cdhash-only** DR. Every
+`loom-daemon-update.sh` self-update roll rebuilds the binary (build.rs embeds
+the git commit and build time), producing a new cdhash — so any TCC grant
+made to the previous build silently evaporates and the operator is
+re-prompted. See [`daemon-reference.md` → "Why Full Disk Access is never the
+right answer"](daemon-reference.md) for the full measured writeup.
+
+`LOOM_CODESIGN_IDENTITY` (env, or the `codesign.identity` config key — the
+repo's standard env > config > default precedence) is the opt-in fix: point
+it at a certificate already in the keychain and `provision-daemon.sh` signs
+the daemon binary with THAT certificate's chain instead of ad-hoc. A
+certificate-anchored DR (`identifier "X" and certificate leaf = H"…"`)
+survives a rebuild — the identity, not the per-build hash, is what's pinned.
+Unset (or an identity `security find-identity -v -p codesigning` doesn't
+list) falls back to the ad-hoc path unchanged — this is entirely opt-in and
+every non-Darwin / no-`codesign` host is unaffected.
+
+## One-time setup: a self-signed "Code Signing" certificate
+
+You only need a certificate that satisfies the macOS `codeSign` policy — a
+paid Developer ID is not required for this local, single-machine use case.
+
+### Option A — Certificate Assistant (GUI)
+
+1. **Keychain Access → Certificate Assistant → Create a Certificate…**
+2. Name it something recognizable (e.g. `Loom Local Signing`).
+3. **Identity Type**: Self Signed Root. **Certificate Type**: **Code Signing**.
+4. Let it install into the login keychain.
+5. Verify it resolves: `security find-identity -v -p codesigning` should list it.
+
+### Option B — openssl + `security import` (scriptable)
+
+```bash
+# 1. Generate a self-signed cert + key.
+openssl req -x509 -newkey rsa:2048 -keyout loom-signing.key \
+  -out loom-signing.crt -days 3650 -nodes \
+  -subj "/CN=Loom Local Signing" \
+  -addext "extendedKeyUsage=codeSigning"
+
+# 2. Package as PKCS#12. OpenSSL 3's default export format fails
+#    `security import`'s MAC verification ("MAC verification failed") --
+#    the `-legacy` flag is required for a keychain-compatible export.
+openssl pkcs12 -export -legacy -in loom-signing.crt -inkey loom-signing.key \
+  -out loom-signing.p12 -passout pass:changeit
+
+# 3. Import into the login keychain, trusting codesign(1) as an anchor so
+#    later signing is NON-INTERACTIVE (no GUI trust prompt) -- required for
+#    the #4055 self-update loop to sign unattended.
+security import loom-signing.p12 -k ~/Library/Keychains/login.keychain-db \
+  -P changeit -T /usr/bin/codesign
+
+# 4. Trust the cert for the codeSign policy specifically (also avoids an
+#    interactive prompt on first use).
+security add-trusted-cert -p codeSign -k ~/Library/Keychains/login.keychain-db \
+  loom-signing.crt
+
+rm -f loom-signing.p12 loom-signing.key   # keep the .crt if you want a record
+```
+
+Both quirks above were hit and confirmed on a real host (2026-07-28):
+`openssl pkcs12 -export` without `-legacy` fails `security import` with "MAC
+verification failed", and `-T /usr/bin/codesign` at import time is what lets
+`codesign` sign later without prompting — provided the login keychain is
+unlocked in the user session (true for any interactive login; a headless/CI
+context should keep using the ad-hoc default instead).
+
+## Using it
+
+```bash
+export LOOM_CODESIGN_IDENTITY="Loom Local Signing"
+./.loom/scripts/cli/loom-daemon-update.sh     # or any provision-daemon.sh caller
+codesign -dvv ~/.local/bin/loom-daemon        # Authority=Loom Local Signing, no adhoc flag
+```
+
+Or persist it in `.loom/config.json` (or `.loom-local/local.json` for a
+machine-local, ungitted override):
+
+```json
+{
+  "codesign": { "identity": "Loom Local Signing" }
+}
+```
+
+## Grant the daemon identity, not Terminal
+
+Work spawned from an interactive terminal shell — in-session
+`spawn-claude.sh`, a hand-run `nohup loom-daemon …`, a debug daemon started
+from a worktree — attributes its TCC requests to the **terminal app**, not to
+`loom-daemon`. Granting broad file access there extends that grant to
+*everything ever run in that terminal*, forever, which is both a bigger
+attack surface than intended and does nothing to fix the actual rebuild
+churn.
+
+Prefer dispatching through the daemon itself — `loom-daemon dispatch` /
+`mcp__loom__dispatch_sweep` — so any TCC prompt a sweep child triggers is
+attributed to the `loom-daemon` binary (launchd already attributes children
+of a supervised job to the parent binary; no plist change is needed for
+this). If a grant is ever genuinely needed, add it to the `loom-daemon` row
+specifically (`~/.local/bin/loom-daemon`) rather than to Terminal — and, per
+the daemon-reference writeup, first double check the access really needs to
+be there at all, since the daemon's legitimate working set is scoped and
+FDA/broad grants are rarely the right fix.
+
+If you re-sign the binary with a stable identity after previously granting
+Terminal (or a stale ad-hoc `loom-daemon` row), remove the stale row from the
+relevant Privacy & Security pane and re-add the current binary path — the
+grant will then persist across rolls instead of silently evaporating.

--- a/scripts/install/provision-daemon.sh
+++ b/scripts/install/provision-daemon.sh
@@ -40,6 +40,55 @@ _pmd_warn()    { echo "  [loom-daemon] WARNING: $*" >&2; }
 # path under suspicion, so it must NOT be the one that leaves it unset).
 PROVISIONED_DAEMON_BIN=""
 
+# _pmd_resolve_codesign_identity
+#
+# Issue #4244: resolve an optional STABLE codesign identity (env > config >
+# default, the repo's standard precedence — see spawn-worker.sh's RUNTIME
+# resolution for the same shape) so a self-signed certificate can be used in
+# place of ad-hoc signing, letting macOS TCC anchor a designated requirement
+# to the certificate rather than a per-build cdhash (see sign_daemon_binary's
+# doc comment below for why that distinction matters).
+#
+#   1. $LOOM_CODESIGN_IDENTITY (env) — highest precedence.
+#   2. `codesign.identity` in the resolved config (.loom/config.json /
+#      .loom-project/project.json / .loom-local/local.json), read via the
+#      shared config-resolver.sh when it can be located and `jq` is present.
+#      Resolved relative to $LOOM_ROOT (if the caller exported it) else the
+#      git toplevel of $PWD; soft-skipped when neither resolves.
+#   3. Empty (default) — the caller falls back to ad-hoc signing.
+#
+# Echoes the resolved identity (possibly empty). Never fails the caller: any
+# missing piece (no repo root, no config-resolver.sh, no jq) soft-skips to
+# the next tier, exactly like loom_config_get's own soft-fail contract.
+_pmd_resolve_codesign_identity() {
+  if [[ -n "${LOOM_CODESIGN_IDENTITY:-}" ]]; then
+    printf '%s' "$LOOM_CODESIGN_IDENTITY"
+    return 0
+  fi
+
+  local repo_root="${LOOM_ROOT:-}"
+  if [[ -z "$repo_root" ]]; then
+    repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  fi
+  [[ -n "$repo_root" ]] || return 0
+
+  local lib candidate
+  for candidate in \
+    "$repo_root/.loom/scripts/lib/config-resolver.sh" \
+    "$repo_root/defaults/scripts/lib/config-resolver.sh"; do
+    if [[ -r "$candidate" ]]; then
+      lib="$candidate"
+      break
+    fi
+  done
+  [[ -n "${lib:-}" ]] || return 0
+
+  # shellcheck source=/dev/null
+  source "$lib"
+  declare -F loom_config_get >/dev/null 2>&1 || return 0
+  loom_config_get "$repo_root" "codesign.identity" ""
+}
+
 # sign_daemon_binary <bin>
 #
 # Issue #4016: ad-hoc-sign a freshly built/installed `loom-daemon` binary with
@@ -50,15 +99,24 @@ PROVISIONED_DAEMON_BIN=""
 # Security entries, and in any future crash/signing diagnostic — pinning a
 # human-legible identifier there is cheap and hermetic.
 #
-# IMPORTANT — this does NOT make a TCC grant survive a rebuild. An ad-hoc
-# signature has no certificate chain for codesign to anchor a designated
-# requirement to, so it falls back to a cdhash-only DR regardless of what
-# --identifier is passed; a rebuild that changes any byte of the binary
-# (which a self-update roll always does, since build.rs embeds the git commit
-# and build time) produces a new cdhash and orphans any grant just as an
-# unsigned binary would. See .loom/docs/daemon-reference.md's "Ad-hoc code
-# signing" section for the measured proof. This function only makes the
-# identifier legible; it is not a TCC-durability fix.
+# IMPORTANT — plain ad-hoc signing does NOT make a TCC grant survive a
+# rebuild. An ad-hoc signature has no certificate chain for codesign to
+# anchor a designated requirement to, so it falls back to a cdhash-only DR
+# regardless of what --identifier is passed; a rebuild that changes any byte
+# of the binary (which a self-update roll always does, since build.rs embeds
+# the git commit and build time) produces a new cdhash and orphans any grant
+# just as an unsigned binary would. See .loom/docs/daemon-reference.md's
+# "Ad-hoc code signing" section for the measured proof.
+#
+# Issue #4244: when $LOOM_CODESIGN_IDENTITY (or the `codesign.identity`
+# config key) names an identity present in the keychain
+# (`security find-identity -v -p codesigning`), sign with THAT identity
+# instead — a real certificate chain gives codesign a stable designated
+# requirement, so a TCC grant made to the resulting binary survives a
+# rebuild/reprovision (the identity, not the cdhash, is what's pinned). See
+# defaults/docs/macos-tcc-codesign.md for the one-time cert setup. This is
+# opt-in only: unset (or an identity the keychain doesn't have) falls back to
+# the ad-hoc path below, unchanged.
 #
 # Darwin-only, best-effort, and NEVER fatal: the linker-signed ad-hoc
 # signature the binary already carries (from `cargo build`) is sufficient to
@@ -71,6 +129,20 @@ sign_daemon_binary() {
   [[ -n "$bin" && -x "$bin" ]] || return 0
   [[ "$(uname -s 2>/dev/null)" == "Darwin" ]] || return 0
   command -v codesign >/dev/null 2>&1 || return 0
+
+  local identity
+  identity="$(_pmd_resolve_codesign_identity)"
+
+  if [[ -n "$identity" ]] && command -v security >/dev/null 2>&1 \
+      && security find-identity -v -p codesigning 2>/dev/null | grep -qF "$identity"; then
+    if codesign -f -s "$identity" --identifier com.rjwalters.loom-daemon "$bin" 2>/dev/null; then
+      _pmd_ok "signed $bin with identity '$identity' (identifier=com.rjwalters.loom-daemon) — TCC grants survive rebuilds"
+      return 0
+    fi
+    _pmd_warn "codesign with identity '$identity' failed for $bin; falling back to ad-hoc signing"
+  elif [[ -n "$identity" ]]; then
+    _pmd_warn "LOOM_CODESIGN_IDENTITY '$identity' not found via 'security find-identity -v -p codesigning'; falling back to ad-hoc signing (see defaults/docs/macos-tcc-codesign.md)"
+  fi
 
   if codesign -f -s - --identifier com.rjwalters.loom-daemon "$bin" 2>/dev/null; then
     _pmd_ok "ad-hoc signed $bin (identifier=com.rjwalters.loom-daemon)"

--- a/tests/install/test-provision-daemon.sh
+++ b/tests/install/test-provision-daemon.sh
@@ -254,6 +254,131 @@ codesign_args="$(cat "$CODESIGN_ARGS_FILE" 2>/dev/null || echo "<missing>")"
 assert_contains "codesign success: invoked with the stable identifier" "$codesign_args" "--identifier com.rjwalters.loom-daemon"
 assert_contains "codesign success: signs the installed DEST binary, not the source" "$codesign_args" "$DEST10/loom-daemon"
 
+# ---------- test 11: LOOM_CODESIGN_IDENTITY (#4244) — identity found in the
+# keychain -> codesign is invoked WITH that identity (not "-s -"). Fakes
+# `uname` (Darwin), `security find-identity` (reports the identity as a valid
+# codesigning identity), and `codesign` (records its argv instead of actually
+# signing, since the fake binary is a plain shell script, not a Mach-O).
+# ---------------------------------------------------------------------------
+FAKE_IDENTITY_DIR="$WORKDIR/fake-identity-bin"
+mkdir -p "$FAKE_IDENTITY_DIR"
+cat > "$FAKE_IDENTITY_DIR/uname" <<'EOF'
+#!/usr/bin/env bash
+echo "Darwin"
+EOF
+chmod +x "$FAKE_IDENTITY_DIR/uname"
+cat > "$FAKE_IDENTITY_DIR/security" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "find-identity" ]]; then
+  echo '  1) ABCDEF1234567890ABCDEF1234567890ABCDEF12 "Loom Local Signing"'
+  echo '     1 valid identities found'
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$FAKE_IDENTITY_DIR/security"
+CODESIGN_ARGS_ID_FILE="$WORKDIR/codesign-args-identity.txt"
+cat > "$FAKE_IDENTITY_DIR/codesign" <<EOF
+#!/usr/bin/env bash
+echo "\$@" > "$CODESIGN_ARGS_ID_FILE"
+exit 0
+EOF
+chmod +x "$FAKE_IDENTITY_DIR/codesign"
+
+SRC11="$WORKDIR/src11/loom-daemon"
+mkdir -p "$WORKDIR/src11"
+make_fake_bin "$SRC11" "0.15.5"
+DEST11="$WORKDIR/dest11"
+out11=$(PATH="$FAKE_IDENTITY_DIR:$PATH" LOOM_DAEMON_BIN_DIR="$DEST11" \
+  LOOM_CODESIGN_IDENTITY="Loom Local Signing" provision_machine_daemon "$SRC11" 2>&1)
+rc11=$?
+assert_eq "LOOM_CODESIGN_IDENTITY set + found: provision returns 0" "0" "$rc11"
+codesign_args_id="$(cat "$CODESIGN_ARGS_ID_FILE" 2>/dev/null || echo "<missing>")"
+assert_contains "LOOM_CODESIGN_IDENTITY set + found: codesign invoked WITH the identity" \
+  "$codesign_args_id" "-s Loom Local Signing"
+TOTAL=$((TOTAL + 1))
+if [[ "$codesign_args_id" != *"-s -"* ]]; then
+  echo -e "${GREEN}PASS${NC}: LOOM_CODESIGN_IDENTITY set + found: does NOT fall back to ad-hoc (-s -)"
+  PASS=$((PASS + 1))
+else
+  echo -e "${RED}FAIL${NC}: LOOM_CODESIGN_IDENTITY set + found: does NOT fall back to ad-hoc (-s -)"
+  echo "  actual: '$codesign_args_id'"
+  FAIL=$((FAIL + 1))
+fi
+assert_contains "LOOM_CODESIGN_IDENTITY set + found: still uses the stable --identifier" \
+  "$codesign_args_id" "--identifier com.rjwalters.loom-daemon"
+
+# ---------- test 12: LOOM_CODESIGN_IDENTITY (#4244) — identity NOT found in
+# the keychain -> falls back to the ad-hoc path unchanged, with a warning.
+# ---------------------------------------------------------------------------
+FAKE_NO_IDENTITY_DIR="$WORKDIR/fake-no-identity-bin"
+mkdir -p "$FAKE_NO_IDENTITY_DIR"
+cat > "$FAKE_NO_IDENTITY_DIR/uname" <<'EOF'
+#!/usr/bin/env bash
+echo "Darwin"
+EOF
+chmod +x "$FAKE_NO_IDENTITY_DIR/uname"
+cat > "$FAKE_NO_IDENTITY_DIR/security" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "find-identity" ]]; then
+  echo '     0 valid identities found'
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$FAKE_NO_IDENTITY_DIR/security"
+CODESIGN_ARGS_NOID_FILE="$WORKDIR/codesign-args-no-identity.txt"
+cat > "$FAKE_NO_IDENTITY_DIR/codesign" <<EOF
+#!/usr/bin/env bash
+echo "\$@" > "$CODESIGN_ARGS_NOID_FILE"
+exit 0
+EOF
+chmod +x "$FAKE_NO_IDENTITY_DIR/codesign"
+
+SRC12="$WORKDIR/src12/loom-daemon"
+mkdir -p "$WORKDIR/src12"
+make_fake_bin "$SRC12" "0.15.6"
+DEST12="$WORKDIR/dest12"
+out12=$(PATH="$FAKE_NO_IDENTITY_DIR:$PATH" LOOM_DAEMON_BIN_DIR="$DEST12" \
+  LOOM_CODESIGN_IDENTITY="Nonexistent Cert" provision_machine_daemon "$SRC12" 2>&1)
+rc12=$?
+assert_eq "LOOM_CODESIGN_IDENTITY set but missing: provision returns 0" "0" "$rc12"
+codesign_args_noid="$(cat "$CODESIGN_ARGS_NOID_FILE" 2>/dev/null || echo "<missing>")"
+assert_contains "LOOM_CODESIGN_IDENTITY missing: falls back to ad-hoc (-s -)" \
+  "$codesign_args_noid" "-s -"
+assert_contains "LOOM_CODESIGN_IDENTITY missing: warns non-fatally" "$out12" "not found"
+
+# ---------- test 13: LOOM_CODESIGN_IDENTITY unset — byte-identical to the
+# pre-#4244 ad-hoc path (regression guard for test 10's assertions, isolated
+# from any repo-level codesign.identity config that might exist).
+# ---------------------------------------------------------------------------
+SRC13="$WORKDIR/src13/loom-daemon"
+mkdir -p "$WORKDIR/src13"
+make_fake_bin "$SRC13" "0.15.7"
+DEST13="$WORKDIR/dest13"
+CODESIGN_ARGS_UNSET_FILE="$WORKDIR/codesign-args-unset.txt"
+FAKE_UNSET_DIR="$WORKDIR/fake-unset-bin"
+mkdir -p "$FAKE_UNSET_DIR"
+cat > "$FAKE_UNSET_DIR/uname" <<'EOF'
+#!/usr/bin/env bash
+echo "Darwin"
+EOF
+chmod +x "$FAKE_UNSET_DIR/uname"
+cat > "$FAKE_UNSET_DIR/codesign" <<EOF
+#!/usr/bin/env bash
+echo "\$@" > "$CODESIGN_ARGS_UNSET_FILE"
+exit 0
+EOF
+chmod +x "$FAKE_UNSET_DIR/codesign"
+out13=$(cd "$WORKDIR" && PATH="$FAKE_UNSET_DIR:$PATH" LOOM_DAEMON_BIN_DIR="$DEST13" \
+  env -u LOOM_CODESIGN_IDENTITY -u LOOM_ROOT \
+  bash -c 'source "'"$REPO_ROOT"'/scripts/install/provision-daemon.sh"; provision_machine_daemon "'"$SRC13"'"' 2>&1)
+rc13=$?
+assert_eq "LOOM_CODESIGN_IDENTITY unset: provision returns 0" "0" "$rc13"
+codesign_args_unset="$(cat "$CODESIGN_ARGS_UNSET_FILE" 2>/dev/null || echo "<missing>")"
+assert_contains "LOOM_CODESIGN_IDENTITY unset: ad-hoc path is unchanged (-s -)" \
+  "$codesign_args_unset" "-s -"
+
 # ---------- summary ----------
 echo ""
 echo "-----------------------------------------"


### PR DESCRIPTION
Closes #4244

## Summary

`provision-daemon.sh`'s existing ad-hoc signing (#4016) pins a legible
`--identifier` but has no certificate chain, so macOS TCC anchors any grant
to a per-build cdhash — every `loom-daemon-update.sh` self-update roll
rebuilds the binary, produces a new cdhash, and silently invalidates every
previously-granted permission.

This adds an **opt-in** `LOOM_CODESIGN_IDENTITY` (env, or a `codesign.identity`
config key — the repo's standard env > config > default precedence, same
shape as `spawn-worker.sh`'s runtime resolution):

- **Set + found in the keychain** (`security find-identity -v -p codesigning`):
  `sign_daemon_binary` signs with that certificate's chain
  (`codesign -f -s "$identity" --identifier com.rjwalters.loom-daemon`). A
  certificate-anchored designated requirement survives a rebuild, so a TCC
  grant made to the daemon binary persists across future rolls.
- **Unset, or an identity the keychain doesn't have**: falls back to the
  existing ad-hoc path (`codesign -f -s - --identifier com.rjwalters.loom-daemon`)
  **byte-identical to today**, including the non-fatal warn-on-failure
  contract.
- **Non-Darwin hosts / no `codesign` on PATH**: unaffected — the existing
  early-return guards are untouched and now sit ahead of the new identity
  resolution, so no extra work happens on those hosts either.

Also adds `defaults/docs/macos-tcc-codesign.md`: one-time self-signed
"Code Signing" certificate setup (Certificate Assistant GUI, or
openssl + `security import`), covering two macOS quirks confirmed on a real
host — OpenSSL 3's default PKCS12 export needs the `-legacy` flag for
`security import` to accept it, and `-T /usr/bin/codesign` at import time is
what makes later signing non-interactive (needed for the #4055 self-update
loop) — plus why TCC grants should target the `loom-daemon` identity rather
than the terminal app that happens to have spawned a sweep. Linked from
`daemon-reference.md`'s existing ad-hoc-signing section (which previously
called real signing "unevaluated speculative infrastructure" — updated to
describe this as the now-shipped opt-in path).

## Test plan

- [x] `bash tests/install/test-provision-daemon.sh` — 35/35 pass, including
      3 new cases: identity found → signed with that identity (not `-s -`),
      identity set but missing from the keychain → falls back to ad-hoc with
      a warning, and identity unset → ad-hoc path byte-identical to before.
- [x] `bash defaults/scripts/tests/test-loom-daemon-update.sh` — 56/56 pass
      (unchanged; exercises the pre-existing ad-hoc-path regressions this
      change must not break).
- [x] `bash scripts/check-claude-md-budget.sh` — OK, CLAUDE.md untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
