### PR TITLE
feat(daemon): close the load-gate gaps — dispatch_sweep headroom advisory + per-tick admission ramp cap

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1243,6 +1243,92 @@ at [`docs/measure-est-cores-per-sweep.md`](https://github.com/rjwalters/loom/blo
 (upstream Loom repo — not shipped to consumer installs)
 so an operator can calibrate it on a live fleet without re-opening the code.
 
+**The release-build fan-out footgun (#4234, decomposed from #4231).** `2.0` is
+calibrated against `cargo check`/`clippy`/debug-build sweep phases (#4031), not
+a **release** build: `cargo build --release` parallelizes codegen units across
+essentially every logical core, so a release-build-heavy repo's real per-sweep
+consumption can run much closer to `logical_cpus` than `2.0`. The #4231 host
+meltdown (a 6-way sweep fan-out that drove load to 118 on a 28-core host) is
+the concrete failure mode: at the shipped default, six concurrent
+release-building sweeps look like `6 × 2 = 12` cores of demand to the cpu
+headroom term when the real demand is far higher. Raise
+`autonomous.estCoresPerSweep` well above `2.0` — plausibly toward
+`logical_cpu_count()` itself — for a repo whose sweeps spend meaningful wall
+clock in a release build. The knob is resolved **once at daemon startup**
+(env > config > default, #4032), the same startup-capture as every other
+dynamic-cap knob; a live re-tune takes effect on the next daemon restart, not
+mid-run. #4234 adds a second, independent backstop for exactly this
+under-estimate — see the next section.
+
+#### Per-tick admission (ramp) cap (#4234)
+
+`resolve_dynamic_max_concurrent` is a **live** ceiling, recomputed every tick,
+so it can *jump* tick-to-tick — e.g. several exhausted token accounts resetting
+at once raises the token axis from ~2 to ~14, or a miscalibrated
+`estCoresPerSweep` (previous section) makes the cpu axis look larger than the
+host can actually sustain. Before #4234, a jump like that let a **single tick**
+admit every newly-eligible candidate up to the new, larger cap in one shot.
+Load average / measured idle fraction is a **lagging** signal sampled at
+wave-*start*: a burst admitted together all ramp their builds minutes later,
+well after the tick that "safely" admitted them observed a still-quiet host.
+This is the exact failure mode of the #4231 incident's second wave — the host
+re-spiked at 01:41 after load had already dropped to 8, because the admission
+decision had already been made by the time load caught up.
+
+`autonomous.workFinder.maxAdmissionsPerTick` (`LOOM_WORK_FINDER_MAX_ADMISSIONS_PER_TICK`,
+default **3**, mirroring `maxConcurrent`'s default) bounds how many **new**
+sweeps a single tick may admit, **independent of** `max_concurrent` — the two
+caps are separate and both apply (`tick_report.deferred_capacity` counts
+candidates deferred by the concurrency ceiling, `tick_report.deferred_ramp_cap`
+counts candidates deferred by this ramp cap; either alone can defer a
+candidate, and both fire in the same tick when both bind). A large cap jump
+therefore ramps up over several ticks instead of bursting in one — each
+subsequent tick re-samples CPU/disk/token headroom fresh, so a ramp that turns
+out to be too aggressive self-corrects within one interval (default 60s)
+rather than in one uncontrolled burst. Resolved with the standard precedence
+**env > config > default**, single-root, at daemon startup — the same
+startup-capture pattern as `cpuUtilizationTarget`/`estCoresPerSweep`: the ramp
+cap's whole purpose is to smooth admission *within* the live per-tick
+re-computation of `max_concurrent`, so the knob itself does not need to be
+live; retuning it takes effect on the next daemon restart.
+
+#### `dispatch_sweep` headroom advisory (#4234)
+
+Before #4234, the dynamic cap above only gated the autonomous work finder's
+**own** dispatches — the `dispatch_sweep` IPC/MCP handler (the entry point for
+`mcp__loom__dispatch_sweep`, `loom-daemon dispatch`, and any other
+operator-driven fan-out) dispatched directly with **no** headroom consult at
+all. Any operator- or MCP-driven `dispatch_sweep` call was completely ungated;
+the #4231 6-way fan-out that triggered the host meltdown was dispatched through
+exactly this handler.
+
+The fix is **advisory-first**, matching `capacity.rs`'s token-backpressure
+"never a halt" precedent (#3902) rather than adding a hard-defer/`force`
+protocol change: `dispatch_sweep` **always dispatches** — an explicit
+operator/MCP request is a deliberate act, and the work finder's own dynamic
+cap remains the hard backstop for *its own* autonomous dispatches — but now
+computes the same `resolve_dynamic_max_concurrent` headroom the work finder
+uses (token/disk/cpu/configured-max, scoped to the target repo) and, on a
+**state change** into/out of "occupancy at or over that headroom" for that
+repo, logs a warning and publishes a `daemon.dispatch.headroom_advisory`
+event-bus event (state-change-deduped — never a per-call stream, keyed
+per-repo so a multi-workspace daemon's repos don't cross-suppress each
+other's advisories). This required **zero protocol change**: no new
+`Request::DispatchSweep` field, no new `Response` variant — the advisory is a
+side channel exactly like the token-capacity advisory. Every `dispatch_sweep`
+call's log line additionally always names the current occupancy/dynamic-cap
+axes (not just on the deduped transition), so `RUST_LOG=loom_daemon=info`
+shows the same headroom picture the work finder's own tick log shows, without
+duplicating the `cpu_headroom_snapshot`/`disk_headroom_limit` plumbing
+`loom-daemon status` (`build_daemon_status`) already exposes.
+
+The handler never calls the **refreshing** CPU probe
+(`cpu_headroom::cpu_headroom_limit`, which sleeps ~1s on macOS via `iostat`)
+while holding the sweep-registry mutex — doing so would stall every other IPC
+request scoped to the same registry for that second. It uses the
+**non-refreshing** `cpu_headroom::cpu_headroom_snapshot` (the memoized idle
+fraction; never blocks) instead, the same call `build_daemon_status` makes.
+
 **Per-token concurrency factor (#3947).** The token axis is `healthy × factor`,
 not `healthy × 1`. The factor is resolved with the standard precedence **env
 (`LOOM_PER_TOKEN_CONCURRENCY`) > config (`autonomous.perTokenConcurrency`) >
@@ -1454,6 +1540,7 @@ concurrency ceiling 5" and share it with the team:
       "enabled": true,
       "intervalSecs": 60,
       "maxConcurrent": 5,
+      "maxAdmissionsPerTick": 3,
       "quarantine": {
         "enabled": true,
         "threshold": 3,
@@ -1504,6 +1591,7 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.workFinder.enabled` | `LOOM_WORK_FINDER` | `false` | Master on/off for the finder loop |
 | `autonomous.workFinder.intervalSecs` | `LOOM_WORK_FINDER_INTERVAL_SECS` | `60` | Zero/invalid → default |
 | `autonomous.workFinder.maxConcurrent` | `LOOM_WORK_FINDER_MAX_CONCURRENT` | `3` | Operator **ceiling**, not a fixed target |
+| `autonomous.workFinder.maxAdmissionsPerTick` | `LOOM_WORK_FINDER_MAX_ADMISSIONS_PER_TICK` | `3` | Per-tick **ramp** cap (#4234) — bounds how many *new* sweeps one tick may admit, independent of `maxConcurrent`/the live dynamic cap. Zero/invalid → default; resolved once at startup, mirroring `estCoresPerSweep`. See [Per-tick admission (ramp) cap](#per-tick-admission-ramp-cap-4234) below |
 | `autonomous.workFinder.quarantine.enabled` | `LOOM_WORK_FINDER_QUARANTINE` | `true` | Insta-crash quarantine on/off (#3939). A safety backstop — defaults on |
 | `autonomous.workFinder.quarantine.threshold` | `LOOM_WORK_FINDER_QUARANTINE_THRESHOLD` | `3` | Consecutive insta-crashes before an issue is quarantined. Zero/invalid → default |
 | `autonomous.workFinder.quarantine.ttlSecs` | `LOOM_WORK_FINDER_QUARANTINE_TTL_SECS` | `3600` | How long a quarantine entry persists before auto-release. Zero/invalid → default |

--- a/loom-daemon/src/cpu_headroom.rs
+++ b/loom-daemon/src/cpu_headroom.rs
@@ -143,6 +143,33 @@ pub const EST_CORES_PER_SWEEP_ENV: &str = "LOOM_EST_CORES_PER_SWEEP";
 /// calibrated figure for the primary host rather than an un-measured guess —
 /// still tunable per repo/host via [`EST_CORES_PER_SWEEP_ENV`] or
 /// `autonomous.estCoresPerSweep`).
+///
+/// # The release-build fan-out footgun (#4234, Gap 2 of the #4231 decomposition)
+///
+/// `2.0` is calibrated against typical `cargo check`/`clippy`/debug-build
+/// sweep phases (#4031), **not** the release-build fan-out that triggered the
+/// #4231 host meltdown. `cargo build --release` parallelizes codegen units
+/// across every logical core rustc can grab — a single release build can
+/// legitimately consume close to `ncpu` cores on its own, not `2`. Six
+/// concurrent release-building sweeps on a 28-core host is demand-side closer
+/// to `6 × 28` than `6 × 2`; at the default `2.0` this term under-estimates
+/// consumption by roughly an order of magnitude during exactly the phase that
+/// matters most.
+///
+/// This is a **calibration** gap, not a formula bug: [`cpu_headroom`] and its
+/// floor-at-`1` "never a hard halt" policy are working as designed (#3902's
+/// precedent — CPU is a soft backoff term, not `disk_headroom`'s or the token
+/// axis's hard floor-at-zero). A repo whose sweeps spend meaningful time in a
+/// release build should raise `LOOM_EST_CORES_PER_SWEEP` /
+/// `autonomous.estCoresPerSweep` well above `2.0` — plausibly toward
+/// `logical_cpu_count()` itself for a repo where release builds dominate sweep
+/// wall-clock time — rather than relying on this default. #4234 adds a second,
+/// independent backstop for exactly this under-estimate: the work finder's
+/// per-tick admission (ramp) cap
+/// ([`crate::work_finder::WORK_FINDER_MAX_ADMISSIONS_PER_TICK_ENV`]) bounds how
+/// many *new* sweeps land in any single tick regardless of how (mis)calibrated
+/// this term is, so a wrong `estCoresPerSweep` no longer alone determines
+/// whether a whole wave lands in one tick.
 pub const DEFAULT_EST_CORES_PER_SWEEP: f64 = 2.0;
 
 /// Env override for [`UTILIZATION_TARGET_ENV`] — `None` when unset,

--- a/loom-daemon/src/event_bus.rs
+++ b/loom-daemon/src/event_bus.rs
@@ -36,6 +36,7 @@
 //! | `daemon.drain.completed` | Drain supervisor | `{in_flight}` (always 0) |
 //! | `daemon.drain.aborted`   | Daemon (IPC) | `{was_draining}` |
 //! | `daemon.drain.timeout`   | Drain supervisor | `{in_flight, forced, cancelled?}` |
+//! | `daemon.dispatch.headroom_advisory` | Daemon (IPC, `dispatch_sweep`) | `{repo_root, low_headroom, occupancy, dynamic_cap, cpu_headroom, disk_headroom, token_axis_limit, message}` |
 //!
 //! New topics require a follow-up issue — the taxonomy is intentionally
 //! pinned. The four `epic.issue.{N}.*` topics were authorized by **#3873**
@@ -45,7 +46,13 @@
 //! token-capacity backpressure advisory (fired on pressure state change). The
 //! four `daemon.drain.*` topics were authorized by **#4090** for the scheduled
 //! drain-and-restart primitive (started / completed / aborted / timeout). The
-//! bus accepts arbitrary topic
+//! `daemon.dispatch.headroom_advisory` topic was authorized by **#4234**
+//! (decomposed from #4231) for the `dispatch_sweep` IPC handler's
+//! advisory-first headroom consult — fired on a state change into/out of
+//! "occupancy at or over the dynamic concurrency cap," mirroring
+//! `daemon.capacity.advisory`'s dedup discipline but scoped to a single
+//! dispatch request rather than the work finder's periodic tick. The bus
+//! accepts arbitrary topic
 //! strings (`publish` does not reject unknown topics) so the publisher side
 //! stays open for future extension, but the documented taxonomy is the
 //! contract subscribers should rely on.

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -12,6 +12,7 @@ use crate::workspace_pool::WorkspacePool;
 use crate::workspace_registry::WorkspaceRegistry;
 use anyhow::Result;
 use chrono::Utc;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -1342,6 +1343,201 @@ fn resolve_registry(
     }
 }
 
+// ============================================================================
+// dispatch_sweep headroom advisory (#4234 — Gap 1 of the #4231 decomposition)
+// ============================================================================
+//
+// Before #4234, `dispatch_sweep` was the *only* remaining sweep-dispatch entry
+// point that never consulted the dynamic concurrency cap
+// (`resolve_dynamic_max_concurrent` — token/disk/cpu/configured-max) the
+// autonomous work finder has enforced on its own dispatches since
+// #3811/#3978/#4032. Any operator- or MCP-driven `dispatch_sweep` call was
+// completely ungated — the mechanism this closed a gap in, not a mechanism
+// built from scratch (the work finder's cap already existed and worked; this
+// handler alone bypassed it). The #4231 host-meltdown 6-way fan-out was
+// dispatched through exactly this handler.
+//
+// The policy, per the curator's #4234 guidance, is **advisory-first** —
+// matching the `capacity.rs` "never a halt" precedent for token backpressure
+// (#3902): `dispatch_sweep` always dispatches (an explicit operator/MCP
+// request is a deliberate act, and the autonomous loop's own cap remains the
+// hard backstop for *its* dispatches), but now computes the same headroom the
+// work finder uses and, on a **state change** into/out of "occupancy at or
+// over that headroom", logs a warning and publishes a
+// `daemon.dispatch.headroom_advisory` event — so an operator firing a manual
+// fan-out sees the same signal the autonomous loop already acts on. This
+// requires **zero protocol change**: no new `Request::DispatchSweep` field, no
+// new `Response` variant. The advisory is a side channel (log + event bus),
+// exactly like `capacity.rs`'s token-pressure advisory.
+//
+// # Never the blocking (~1s on macOS) headroom refresh under the registry lock
+//
+// The `DispatchSweep` arm holds the registry mutex from just after this
+// assessment through the dispatch call. `cpu_headroom::cpu_headroom_limit`
+// refreshes the memoized idle-fraction sample, which sleeps ~1s on macOS
+// (`iostat`) — calling it here would stall every other IPC request scoped to
+// the same registry (`ListSweeps` / `GetSweepStatus` / a concurrent
+// `DispatchSweep`) for that second. [`assess_dispatch_headroom`] therefore
+// uses the **non-refreshing** [`crate::cpu_headroom::cpu_headroom_snapshot`]
+// (reads the memoized cache; never blocks) — the exact same call
+// `build_daemon_status` makes, just without that function's own
+// `spawn_blocking` pre-warm (this handler is synchronous, not `async`, so it
+// cannot `.await` a `spawn_blocking` join; a same-generation `iostat` sample
+// from a recent `DaemonStatus` poll or the work-finder's own tick is
+// sufficient for an advisory signal, and a `None` idle fraction falls back
+// through `cpu_headroom`'s documented fail-open chain).
+
+/// Per-repo dynamic-cap headroom snapshot computed for a `dispatch_sweep`
+/// request (#4234). Mirrors the inputs `build_daemon_status` already exposes
+/// on the status surface — no new plumbing, just the same math consulted at
+/// dispatch time instead of only at status-poll time.
+struct DispatchHeadroom {
+    /// Live (non-terminal) sweep count already registered for this repo.
+    occupancy: usize,
+    /// `resolve_dynamic_max_concurrent` — min(token axis, disk, cpu, configured max).
+    dynamic_cap: usize,
+    cpu_headroom: usize,
+    disk_headroom: usize,
+    token_axis_limit: usize,
+}
+
+/// Compute [`DispatchHeadroom`] for `repo_root` against the **already-locked**
+/// registry `sr`. See the module docs above for why this never calls the
+/// refreshing CPU probe.
+fn assess_dispatch_headroom(sr: &mut SweepRegistry, repo_root: &Path) -> DispatchHeadroom {
+    // Reap-on-read (mirrors ListSweeps/GetSweepStatus, Issue #3893): a sweep
+    // whose child already exited must not inflate occupancy against a stale
+    // `Running` entry.
+    sr.reap_liveness();
+    let occupancy = sr
+        .list(None)
+        .into_iter()
+        .filter(|info| !info.state.is_terminal())
+        .count();
+
+    let wf_config = crate::work_finder::read_work_finder_config(repo_root);
+    let configured_max = crate::work_finder::resolve_max_concurrent_with_config(&wf_config);
+    let per_token_concurrency = crate::work_finder::resolve_per_token_concurrency(&wf_config);
+    let cpu_utilization_target = crate::work_finder::resolve_cpu_utilization_target(&wf_config);
+    let cpu_est_cores_per_sweep = crate::work_finder::resolve_cpu_est_cores_per_sweep(&wf_config);
+    let cpu_snapshot =
+        crate::cpu_headroom::cpu_headroom_snapshot(cpu_utilization_target, cpu_est_cores_per_sweep);
+    let disk_headroom = crate::disk_headroom::disk_headroom_limit(repo_root);
+    let token_pool_size = crate::tokens::token_pool_size(repo_root);
+    let ranking = crate::capacity::read_ranking(repo_root);
+    let token_axis_limit = ranking.as_ref().map_or(token_pool_size, |r| r.available);
+    let dynamic_cap = crate::work_finder::resolve_dynamic_max_concurrent(
+        token_axis_limit,
+        per_token_concurrency,
+        disk_headroom,
+        cpu_snapshot.cpu_headroom,
+        configured_max,
+    );
+
+    DispatchHeadroom {
+        occupancy,
+        dynamic_cap,
+        cpu_headroom: cpu_snapshot.cpu_headroom,
+        disk_headroom,
+        token_axis_limit,
+    }
+}
+
+/// Whether admitting one more sweep would meet or exceed the computed dynamic
+/// cap. `>=` (not `>`): dispatching this new sweep pushes occupancy to
+/// `occupancy + 1`, so `occupancy >= dynamic_cap` already means "no headroom
+/// left for it." Pure predicate — trivially unit-testable without touching the
+/// registry or the host.
+#[must_use]
+fn dispatch_would_meet_or_exceed_headroom(h: &DispatchHeadroom) -> bool {
+    h.occupancy >= h.dynamic_cap
+}
+
+/// Process-global, per-repo dedup state for the `daemon.dispatch.headroom_advisory`
+/// event (#4234) — mirrors the work finder's `was_pressured` state-change dedup
+/// (#3902), but keyed by normalized repo root (rather than a single loop-local
+/// `bool`) since `dispatch_sweep` is a request handler, not a per-workspace loop
+/// task, and a multi-workspace daemon must not let repo A's transition suppress
+/// or falsely flip repo B's advisory.
+static DISPATCH_HEADROOM_STATE: Mutex<BTreeMap<PathBuf, bool>> = Mutex::new(BTreeMap::new());
+
+/// Build the advisory/recovery message for a `dispatch_sweep` headroom
+/// transition. Split out from [`emit_dispatch_headroom_advisory_on_change`] so
+/// the message text itself is unit-testable without the global dedup state.
+fn dispatch_headroom_message(
+    repo_root: &Path,
+    low_headroom: bool,
+    h: &DispatchHeadroom,
+    kind: &crate::types::SweepKind,
+) -> String {
+    if low_headroom {
+        format!(
+            "dispatch_sweep: dispatching {kind:?} into {} while occupancy is at/over the \
+             computed dynamic-cap headroom (occupancy={} >= dynamic_cap={}; cpu_headroom={}, \
+             disk_headroom={}, token_axis_limit={}) — advisory only per #4234 (dispatch \
+             proceeds; the autonomous work finder's own cap is unaffected)",
+            repo_root.display(),
+            h.occupancy,
+            h.dynamic_cap,
+            h.cpu_headroom,
+            h.disk_headroom,
+            h.token_axis_limit
+        )
+    } else {
+        format!(
+            "dispatch_sweep: headroom recovered for {} (occupancy={} < dynamic_cap={})",
+            repo_root.display(),
+            h.occupancy,
+            h.dynamic_cap
+        )
+    }
+}
+
+/// Emit the `daemon.dispatch.headroom_advisory` log line + event **only on a
+/// state change** (never a per-call stream — mirrors `capacity.rs`'s
+/// `emit_capacity_transition`, #3902). A no-op when `low_headroom` matches the
+/// last-known state for `repo_root`.
+fn emit_dispatch_headroom_advisory_on_change(
+    event_bus: &Arc<EventBus>,
+    repo_root: &Path,
+    low_headroom: bool,
+    h: &DispatchHeadroom,
+    kind: &crate::types::SweepKind,
+) {
+    {
+        let mut state = DISPATCH_HEADROOM_STATE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let was_low = state.get(repo_root).copied().unwrap_or(false);
+        if low_headroom == was_low {
+            return;
+        }
+        state.insert(repo_root.to_path_buf(), low_headroom);
+    }
+
+    let message = dispatch_headroom_message(repo_root, low_headroom, h, kind);
+    if low_headroom {
+        log::warn!("{message}");
+    } else {
+        log::info!("{message}");
+    }
+    if let Err(e) = event_bus.publish_generic(
+        "daemon.dispatch.headroom_advisory",
+        serde_json::json!({
+            "repo_root": repo_root.display().to_string(),
+            "low_headroom": low_headroom,
+            "occupancy": h.occupancy,
+            "dynamic_cap": h.dynamic_cap,
+            "cpu_headroom": h.cpu_headroom,
+            "disk_headroom": h.disk_headroom,
+            "token_axis_limit": h.token_axis_limit,
+            "message": message,
+        }),
+    ) {
+        log::debug!("dispatch_sweep: headroom advisory not delivered: {e}");
+    }
+}
+
 #[allow(clippy::expect_used, clippy::too_many_lines)]
 fn handle_request(
     request: Request,
@@ -1943,12 +2139,35 @@ fn handle_request(
             // autonomous work-finder / epic-supervisor dispatch paths so every
             // daemon-dispatched child is pinned to an explicit model.
             let repo_root = sr.config().workspace_root.clone();
+
+            // Headroom advisory (#4234, Gap 1 of #4231's decomposition): consult
+            // the same dynamic concurrency cap the autonomous work finder
+            // applies to its own dispatches, and advise — never gate — an
+            // explicit `dispatch_sweep` call that would push occupancy at/over
+            // it. See the module docs above this arm for the full rationale and
+            // the "never the blocking refresh under this lock" hazard.
+            let headroom = assess_dispatch_headroom(&mut sr, &repo_root);
+            let low_headroom = dispatch_would_meet_or_exceed_headroom(&headroom);
+            emit_dispatch_headroom_advisory_on_change(
+                event_bus,
+                &repo_root,
+                low_headroom,
+                &headroom,
+                &kind,
+            );
+
             let (resolved_model, model_source) =
                 crate::sweep_registry::resolve_dispatch_model(&repo_root, model.as_deref());
             log::info!(
-                "dispatch_sweep: {:?} with model={resolved_model} (source={})",
+                "dispatch_sweep: {:?} with model={resolved_model} (source={}); headroom \
+                 occupancy={} dynamic_cap={} (cpu={} disk={} tokens={})",
                 kind,
-                model_source.as_str()
+                model_source.as_str(),
+                headroom.occupancy,
+                headroom.dynamic_cap,
+                headroom.cpu_headroom,
+                headroom.disk_headroom,
+                headroom.token_axis_limit
             );
             match sr.dispatch(
                 &kind,
@@ -2686,6 +2905,164 @@ exit 0
         config.journal_path = Some(dir.path().join("test-sweeps-journal.json"));
         let sr = Arc::new(Mutex::new(SweepRegistry::new(config)));
         (sr, dir, record_log)
+    }
+
+    // ========================================================================
+    // dispatch_sweep headroom advisory (#4234 — Gap 1 of #4231's decomposition)
+    // ========================================================================
+
+    fn fake_headroom(occupancy: usize, dynamic_cap: usize) -> DispatchHeadroom {
+        DispatchHeadroom {
+            occupancy,
+            dynamic_cap,
+            cpu_headroom: dynamic_cap,
+            disk_headroom: 10,
+            token_axis_limit: 5,
+        }
+    }
+
+    #[test]
+    fn dispatch_headroom_predicate_boundary() {
+        assert!(
+            !dispatch_would_meet_or_exceed_headroom(&fake_headroom(2, 3)),
+            "below cap: headroom remains"
+        );
+        assert!(
+            dispatch_would_meet_or_exceed_headroom(&fake_headroom(3, 3)),
+            "at cap: no headroom left for one more"
+        );
+        assert!(
+            dispatch_would_meet_or_exceed_headroom(&fake_headroom(5, 3)),
+            "over cap: definitely no headroom"
+        );
+    }
+
+    #[test]
+    fn dispatch_headroom_message_names_every_axis() {
+        let h = DispatchHeadroom {
+            occupancy: 4,
+            dynamic_cap: 3,
+            cpu_headroom: 2,
+            disk_headroom: 9,
+            token_axis_limit: 6,
+        };
+        let kind = SweepKind::Issue(123);
+        let repo = Path::new("/tmp/loom-test-repo");
+
+        let entered = dispatch_headroom_message(repo, true, &h, &kind);
+        assert!(entered.contains("occupancy=4"), "{entered}");
+        assert!(entered.contains("dynamic_cap=3"), "{entered}");
+        assert!(entered.contains("cpu_headroom=2"), "{entered}");
+        assert!(entered.contains("disk_headroom=9"), "{entered}");
+        assert!(entered.contains("token_axis_limit=6"), "{entered}");
+        assert!(entered.contains("123"), "{entered}");
+        assert!(entered.contains("advisory only"), "{entered}");
+
+        let recovered = dispatch_headroom_message(repo, false, &h, &kind);
+        assert!(recovered.contains("recovered"), "{recovered}");
+    }
+
+    #[test]
+    fn dispatch_headroom_advisory_dedups_on_state_change() {
+        let bus = Arc::new(EventBus::new());
+        let mut sub = bus.subscribe(["daemon.dispatch.headroom_advisory"]);
+        // A fresh, unique tempdir path keys the process-global dedup state
+        // independently of any other test (#4234's per-repo dedup design).
+        let repo_dir = tempdir().unwrap();
+        let repo_root = repo_dir.path().to_path_buf();
+        let kind = SweepKind::Issue(4234);
+        let low = fake_headroom(5, 3);
+        let ok = fake_headroom(1, 3);
+
+        // Entering low headroom fires the advisory.
+        emit_dispatch_headroom_advisory_on_change(&bus, &repo_root, true, &low, &kind);
+        match sub
+            .try_recv()
+            .expect("advisory published on entering low headroom")
+        {
+            Event::Generic { topic, payload } => {
+                assert_eq!(topic, "daemon.dispatch.headroom_advisory");
+                assert_eq!(payload["low_headroom"].as_bool(), Some(true));
+                assert_eq!(payload["occupancy"].as_u64(), Some(5));
+                assert_eq!(payload["dynamic_cap"].as_u64(), Some(3));
+            }
+            other => panic!("expected Generic advisory event, got {other:?}"),
+        }
+
+        // Still low on the next call — deduped, no second event.
+        emit_dispatch_headroom_advisory_on_change(&bus, &repo_root, true, &low, &kind);
+        assert!(
+            matches!(sub.try_recv(), Err(crate::event_bus::RecvError::Empty)),
+            "no duplicate advisory while headroom stays low"
+        );
+
+        // Recovers — symmetric recovery event.
+        emit_dispatch_headroom_advisory_on_change(&bus, &repo_root, false, &ok, &kind);
+        match sub.try_recv().expect("recovery event published") {
+            Event::Generic { topic, payload } => {
+                assert_eq!(topic, "daemon.dispatch.headroom_advisory");
+                assert_eq!(payload["low_headroom"].as_bool(), Some(false));
+            }
+            other => panic!("expected Generic recovery event, got {other:?}"),
+        }
+
+        // Staying recovered — deduped again.
+        emit_dispatch_headroom_advisory_on_change(&bus, &repo_root, false, &ok, &kind);
+        assert!(
+            matches!(sub.try_recv(), Err(crate::event_bus::RecvError::Empty)),
+            "no duplicate recovery event while headroom stays healthy"
+        );
+    }
+
+    /// End-to-end (#4234): `dispatch_sweep` must dispatch even when the
+    /// computed headroom is fully saturated — advisory-first, never a hard
+    /// gate. Forces `configured_max=1` via env (the smallest term always wins
+    /// the `min()` in `resolve_dynamic_max_concurrent`), which is deterministic
+    /// regardless of the real host's token/disk/cpu state.
+    #[test]
+    #[serial_test::serial]
+    fn test_dispatch_sweep_still_dispatches_under_synthetic_low_headroom() {
+        let (tm, db, _, bus) = setup_test_context();
+        let (sr, _dir, _rec) = setup_sweep_registry_in_tempdir();
+
+        std::env::set_var(crate::work_finder::WORK_FINDER_MAX_CONCURRENT_ENV, "1");
+
+        let dispatch_issue = |n: u32| {
+            handle_request(
+                Request::DispatchSweep {
+                    kind: SweepKind::Issue(n),
+                    idempotency_key: None,
+                    model: None,
+                    effort: None,
+                    depends_on: None,
+                    workspace_root: None,
+                },
+                &tm,
+                &db,
+                &sr,
+                &bus,
+                &test_pool(),
+            )
+        };
+
+        // First dispatch always succeeds regardless of computed headroom.
+        match dispatch_issue(90_001) {
+            Response::SweepDispatched { .. } => {}
+            other => panic!("Expected SweepDispatched, got: {other:?}"),
+        }
+
+        // Second dispatch: occupancy is now >= the forced ceiling of 1, so this
+        // call is guaranteed to be at/over the dynamic cap — and it STILL
+        // dispatches (advisory-only per #4234, never a hard gate).
+        match dispatch_issue(90_002) {
+            Response::SweepDispatched { .. } => {}
+            other => panic!(
+                "Expected SweepDispatched even at/over headroom (advisory-first policy), \
+                 got: {other:?}"
+            ),
+        }
+
+        std::env::remove_var(crate::work_finder::WORK_FINDER_MAX_CONCURRENT_ENV);
     }
 
     #[test]

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -1131,6 +1131,15 @@ async fn main() -> Result<()> {
             work_finder::resolve_cpu_utilization_target(&work_finder_config);
         let cpu_est_cores_per_sweep =
             work_finder::resolve_cpu_est_cores_per_sweep(&work_finder_config);
+        // Per-tick admission (ramp) cap (#4234): resolved once at startup from
+        // the same `work_finder_config`, precedence env > config > default —
+        // the same startup-capture pattern as the CPU knobs above. Bounds how
+        // many *new* sweeps a single tick may admit, independent of how large
+        // the dynamic cap computes to that tick — see
+        // `work_finder::WORK_FINDER_MAX_ADMISSIONS_PER_TICK_ENV` for the full
+        // ramp-lag rationale (#4231's second wave).
+        let max_admissions_per_tick =
+            work_finder::resolve_max_admissions_per_tick_with_config(&work_finder_config);
         // #4084: hold new dispatch off a root while its build-gate run is in
         // flight, so a fresh sweep build does not race the gate's own build for
         // cores (the contention that timed the gate out under #4073's mild
@@ -1143,6 +1152,7 @@ async fn main() -> Result<()> {
             "work_finder: enabled (multi-workspace, interval={}s, configured_max={configured_max}, \
              per_token_concurrency={per_token_concurrency}, cpu_utilization_target={cpu_utilization_target}, \
              cpu_est_cores_per_sweep={cpu_est_cores_per_sweep}, \
+             max_admissions_per_tick={max_admissions_per_tick}, \
              dynamic cap = min(healthy tokens × per-token, disk, cpu, configured_max), \
              global across workspaces)",
             interval.as_secs()
@@ -1158,6 +1168,7 @@ async fn main() -> Result<()> {
             per_token_concurrency,
             cpu_utilization_target,
             cpu_est_cores_per_sweep,
+            max_admissions_per_tick,
             workspace_health_states.clone(),
             suppress_dispatch_during_gate,
             event_bus.clone(),

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -150,6 +150,49 @@ pub const PER_TOKEN_CONCURRENCY_ENV: &str = "LOOM_PER_TOKEN_CONCURRENCY";
 /// kicks in when concurrency demand exceeds the healthy-account count.
 pub const DEFAULT_PER_TOKEN_CONCURRENCY: usize = 2;
 
+/// Environment variable setting the **per-tick admission cap** (#4234, Gap 3 of
+/// the #4231 decomposition).
+///
+/// [`resolve_dynamic_max_concurrent`] is a **live** ceiling — recomputed every
+/// tick from the token pool, disk, and CPU/load axes — so it can *jump*
+/// tick-to-tick (e.g. several exhausted token accounts resetting at once
+/// raises the token axis from ~2 to ~14). Before #4234 a jump like that let a
+/// single tick admit every newly-eligible candidate up to the new, larger cap
+/// in one shot: `loadavg`/idle-fraction is a **lagging** signal sampled at
+/// wave-*start*, so a burst admitted together all ramp their builds minutes
+/// later, well after the tick that "safely" admitted them observed a
+/// still-quiet host. This is the exact ramp-lag failure mode from the #4231
+/// incident's second wave (host re-spiked at 01:41 after load had already
+/// dropped to 8 — the admission had already happened by the time load caught
+/// up). This knob bounds **how many *new* sweeps one tick may admit**,
+/// independent of how large `max_concurrent` computes to that tick, forcing a
+/// large jump to ramp up over several ticks instead of one — each subsequent
+/// tick re-samples CPU/disk/token headroom fresh, so a ramp that turns out to
+/// be too aggressive self-corrects within one interval
+/// ([`DEFAULT_WORK_FINDER_INTERVAL_SECS`], default 60s) rather than in one
+/// uncontrolled burst.
+///
+/// Precedence is the standard **env > config
+/// (`autonomous.workFinder.maxAdmissionsPerTick`) > default**, resolved once at
+/// daemon startup via [`read_work_finder_config`] → `config_resolver` — the
+/// same startup-capture pattern as `cpuUtilizationTarget` / `estCoresPerSweep`
+/// (#4032): the *inputs* (occupancy, live headroom) are re-read every tick, but
+/// this *knob* takes effect only on daemon restart unless a future change
+/// moves knob resolution into the tick loop itself. A zero/unparseable value is
+/// dropped (falls through to config/default) — a zero cap would silently
+/// freeze the loop at its current occupancy forever, which is a footgun, not a
+/// deliberate "pause" (use the main-health-gate halt or a scheduled drain for
+/// that instead).
+pub const WORK_FINDER_MAX_ADMISSIONS_PER_TICK_ENV: &str =
+    "LOOM_WORK_FINDER_MAX_ADMISSIONS_PER_TICK";
+
+/// Default per-tick admission cap (#4234). `3` mirrors
+/// [`DEFAULT_WORK_FINDER_MAX_CONCURRENT`] — the same conservative magnitude
+/// that would have kept the #4231 6-way fan-out from admitting more than half
+/// its sweeps in a single tick even if every other axis (token/disk/cpu) had
+/// momentarily computed room for all six.
+pub const DEFAULT_MAX_ADMISSIONS_PER_TICK: usize = 3;
+
 /// Labels that disqualify an issue from dispatch even if it still appears in
 /// the `loom:issue`-filtered listing.
 ///
@@ -398,6 +441,13 @@ pub struct TickReport {
     pub skipped_in_flight: usize,
     /// Issues deferred to a future tick because the concurrency cap was reached.
     pub deferred_capacity: usize,
+    /// Issues deferred to a future tick because the **per-tick admission cap**
+    /// (#4234, `max_admissions_per_tick`) was reached, independent of
+    /// `deferred_capacity` — this fires even when `max_concurrent` computes
+    /// large enough to admit them (e.g. a token-axis jump), because the ramp
+    /// cap deliberately smooths *how fast* new sweeps are admitted rather than
+    /// how many may run concurrently. See [`WORK_FINDER_MAX_ADMISSIONS_PER_TICK_ENV`].
+    pub deferred_ramp_cap: usize,
     /// Issues skipped because they are quarantined for repeated insta-crashing
     /// (Issue #3939). Filtered out before the concurrency budget is allocated, so
     /// a quarantined candidate never consumes a shared dispatch slot.
@@ -460,11 +510,43 @@ pub struct TickReport {
 /// Propagates a source (`list_ready_issues`) error so the caller can log it and
 /// retry next tick. Individual dispatch errors are logged and counted in
 /// [`TickReport::errors`] rather than aborting the tick.
+///
+/// Unlimited-admission convenience wrapper over
+/// [`tick_with_admission_cap`] — callers that don't need the #4234 per-tick
+/// ramp cap (most existing tests, and any caller predating #4234) get
+/// byte-for-byte the pre-#4234 behavior.
 pub fn tick(
     source: &mut impl WorkSource,
     dispatcher: &mut impl WorkDispatcher,
     max_concurrent: usize,
     halted: bool,
+) -> Result<TickReport> {
+    tick_with_admission_cap(source, dispatcher, max_concurrent, halted, usize::MAX)
+}
+
+/// Like [`tick`], but additionally bounds how many **new** sweeps this single
+/// tick may admit to `max_admissions_per_tick`, independent of
+/// `max_concurrent` (#4234, Gap 3 of the #4231 decomposition — see
+/// [`WORK_FINDER_MAX_ADMISSIONS_PER_TICK_ENV`] for the full ramp-lag
+/// rationale). `usize::MAX` (what [`tick`] passes) disables the ramp cap
+/// entirely, reducing to the pre-#4234 behavior.
+///
+/// The two caps are independent and both apply: `occupancy >= max_concurrent`
+/// defers to [`TickReport::deferred_capacity`] (the existing concurrency
+/// ceiling); a *separate* `admitted_this_tick >= max_admissions_per_tick`
+/// defers to [`TickReport::deferred_ramp_cap`] (the new ramp limiter) even
+/// when `max_concurrent` still has room. Both checks run every candidate, so a
+/// tick can produce both kinds of deferral in the same pass.
+///
+/// # Errors
+///
+/// Same as [`tick`].
+pub fn tick_with_admission_cap(
+    source: &mut impl WorkSource,
+    dispatcher: &mut impl WorkDispatcher,
+    max_concurrent: usize,
+    halted: bool,
+    max_admissions_per_tick: usize,
 ) -> Result<TickReport> {
     let ready = source.list_ready_issues()?;
     let mut report = TickReport {
@@ -489,6 +571,10 @@ pub fn tick(
     // sweep past its startup-proof grace window. `in_flight` itself stays the
     // full dedup set for the `contains()` check below.
     let mut occupancy = dispatcher.occupancy();
+    // Ramp-admission counter (#4234): distinct from `occupancy` — this counts
+    // only sweeps admitted *this tick*, reset every call, whereas `occupancy`
+    // carries forward prior ticks' still-running sweeps.
+    let mut admitted_this_tick: usize = 0;
 
     for item in ready {
         // 1. Defensive skip-label filter (stale forge cache).
@@ -525,12 +611,22 @@ pub fn tick(
             report.deferred_capacity += 1;
             continue;
         }
+        // 3b. Per-tick admission (ramp) cap (#4234) — independent of the
+        //     concurrency cap above: even when `max_concurrent` has room, this
+        //     tick may not admit more than `max_admissions_per_tick` *new*
+        //     sweeps, so a sudden jump in the concurrency cap ramps up over
+        //     several ticks instead of bursting in one.
+        if admitted_this_tick >= max_admissions_per_tick {
+            report.deferred_ramp_cap += 1;
+            continue;
+        }
         // 4. Dispatch. The registry's idempotency key + claim lock make a
         //    double-dispatch of an already-running issue a no-op / loud error.
         match dispatcher.dispatch(item.number) {
             Ok(true) => {
                 report.dispatched += 1;
                 occupancy += 1;
+                admitted_this_tick += 1;
             }
             Ok(false) => {
                 // Idempotency no-op: a sweep with the same key was already
@@ -671,11 +767,31 @@ pub fn dispatch_held_per_root_with_drain(
         .collect()
 }
 
+/// Unlimited-admission convenience wrapper over
+/// [`tick_multi_with_admission_cap`] — see [`tick`] / [`tick_with_admission_cap`]
+/// for the single-workspace analogue and the #4234 rationale.
 pub fn tick_multi<S: WorkSource, D: WorkDispatcher>(
     workspaces: &mut [(S, D)],
     priorities: &[u32],
     max_concurrent: usize,
     halted: &[bool],
+) -> TickReport {
+    tick_multi_with_admission_cap(workspaces, priorities, max_concurrent, halted, usize::MAX)
+}
+
+/// Like [`tick_multi`], but additionally bounds how many **new** sweeps this
+/// single tick may admit — **across every workspace, one shared counter** —
+/// to `max_admissions_per_tick` (#4234). Mirrors
+/// [`tick_with_admission_cap`]'s two-independent-caps design: the existing
+/// shared `max_concurrent` budget and the new ramp cap both apply, and either
+/// alone can defer a candidate. `usize::MAX` (what [`tick_multi`] passes)
+/// disables the ramp cap, reducing to the pre-#4234 behavior.
+pub fn tick_multi_with_admission_cap<S: WorkSource, D: WorkDispatcher>(
+    workspaces: &mut [(S, D)],
+    priorities: &[u32],
+    max_concurrent: usize,
+    halted: &[bool],
+    max_admissions_per_tick: usize,
 ) -> TickReport {
     use crate::workspace_registry::DEFAULT_WORKSPACE_PRIORITY;
 
@@ -789,6 +905,11 @@ pub fn tick_multi<S: WorkSource, D: WorkDispatcher>(
     // Global priority sort (#3946): (workspace priority, urgent, age, number).
     candidates.sort_by(candidate_cmp);
 
+    // Ramp-admission counter (#4234), shared across every workspace exactly
+    // like `occupancy` — see `tick_with_admission_cap`'s single-workspace
+    // analogue for the full rationale.
+    let mut admitted_this_tick: usize = 0;
+
     // Pass 2 (mutable dispatcher calls): fill the single shared concurrency
     // budget in the sorted global order, routing each candidate back to its
     // owning workspace's dispatcher.
@@ -800,11 +921,18 @@ pub fn tick_multi<S: WorkSource, D: WorkDispatcher>(
             report.deferred_capacity += 1;
             continue;
         }
+        // Shared global ramp cap (#4234) — independent of the concurrency cap
+        // above; see `tick_with_admission_cap`.
+        if admitted_this_tick >= max_admissions_per_tick {
+            report.deferred_ramp_cap += 1;
+            continue;
+        }
         let dispatcher = &mut workspaces[cand.workspace_idx].1;
         match dispatcher.dispatch(cand.number) {
             Ok(true) => {
                 report.dispatched += 1;
                 occupancy += 1;
+                admitted_this_tick += 1;
             }
             Ok(false) => {
                 report.skipped_in_flight += 1;
@@ -905,6 +1033,10 @@ pub struct WorkFinderConfig {
     /// `autonomous.workFinder.maxConcurrent` — the operator concurrency ceiling
     /// (a zero/invalid value is dropped to `None`).
     pub max_concurrent: Option<usize>,
+    /// `autonomous.workFinder.maxAdmissionsPerTick` — the per-tick ramp
+    /// admission cap (#4234; a zero/invalid value is dropped to `None`). See
+    /// [`WORK_FINDER_MAX_ADMISSIONS_PER_TICK_ENV`] for the full rationale.
+    pub max_admissions_per_tick: Option<usize>,
     /// `autonomous.perTokenConcurrency` — how many concurrent sweeps to allow per
     /// *healthy* token in the dynamic cap (#3947). Note this lives at the
     /// `autonomous` level (not under `workFinder`), so it is read even when no
@@ -979,6 +1111,11 @@ pub fn read_work_finder_config(repo_root: &Path) -> WorkFinderConfig {
             .and_then(serde_json::Value::as_u64)
             .filter(|&n| n > 0)
             .and_then(|n| usize::try_from(n).ok()),
+        max_admissions_per_tick: wf
+            .and_then(|w| w.get("maxAdmissionsPerTick"))
+            .and_then(serde_json::Value::as_u64)
+            .filter(|&n| n > 0)
+            .and_then(|n| usize::try_from(n).ok()),
         per_token_concurrency,
         cpu_utilization_target,
         est_cores_per_sweep,
@@ -1013,6 +1150,35 @@ pub fn resolve_max_concurrent_with_config(config: &WorkFinderConfig) -> usize {
     env_max_concurrent()
         .or(config.max_concurrent)
         .unwrap_or(DEFAULT_WORK_FINDER_MAX_CONCURRENT)
+}
+
+/// Env override for the per-tick admission (ramp) cap — `None` when unset,
+/// zero, or unparseable (a zero cap would freeze the loop, see
+/// [`WORK_FINDER_MAX_ADMISSIONS_PER_TICK_ENV`]).
+fn env_max_admissions_per_tick() -> Option<usize> {
+    std::env::var(WORK_FINDER_MAX_ADMISSIONS_PER_TICK_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .filter(|&n| n > 0)
+}
+
+/// Resolve the per-tick admission (ramp) cap with precedence **env > config
+/// (`autonomous.workFinder.maxAdmissionsPerTick`) > default** (#4234).
+/// Resolved once at daemon startup — the same startup-capture pattern as
+/// [`resolve_cpu_utilization_target`] / [`resolve_cpu_est_cores_per_sweep`]
+/// (#4032) — and threaded through to [`spawn_work_finder_task`] /
+/// [`spawn_multi_work_finder_task`] as a plain `usize`, mirroring
+/// `per_token_concurrency`. See [`WORK_FINDER_MAX_ADMISSIONS_PER_TICK_ENV`] for
+/// why this is a deliberate startup-capture, not a per-tick re-read: the ramp
+/// cap's whole purpose is to smooth admission *within* the live per-tick
+/// re-computation of `max_concurrent`, so it does not itself need to be live —
+/// an operator retuning it takes effect on the next daemon restart, exactly
+/// like `configured_max` / `per_token_concurrency` today.
+#[must_use]
+pub fn resolve_max_admissions_per_tick_with_config(config: &WorkFinderConfig) -> usize {
+    env_max_admissions_per_tick()
+        .or(config.max_admissions_per_tick)
+        .unwrap_or(DEFAULT_MAX_ADMISSIONS_PER_TICK)
 }
 
 /// Env override for the per-token concurrency factor — `None` when unset, zero,
@@ -1150,6 +1316,7 @@ pub fn spawn_work_finder_task<S, D>(
     per_token_concurrency: usize,
     cpu_utilization_target: f64,
     cpu_est_cores_per_sweep: f64,
+    max_admissions_per_tick: usize,
     health_state: Arc<MainHealthState>,
     suppress_dispatch_during_gate: bool,
     event_bus: Arc<EventBus>,
@@ -1161,6 +1328,7 @@ where
     log::info!(
         "work_finder: starting loop (interval={}s, configured_max={configured_max}, \
          per_token_concurrency={per_token_concurrency}, \
+         max_admissions_per_tick={max_admissions_per_tick}, \
          dynamic cap = min(healthy tokens × per-token, disk, cpu, configured_max))",
         interval.as_secs()
     );
@@ -1179,6 +1347,14 @@ where
         // add-capacity advisory / recovery fires only on state change, never
         // every tick.
         let mut was_pressured = false;
+        // Axis-visibility state (#4234): promote the per-tick axis line from
+        // `debug!` to `info!` only when the computed cap actually **changes**
+        // value tick-to-tick — mirrors the state-change-dedup discipline
+        // `was_pressured` already applies to the capacity advisory, so an
+        // operator watching the log at default level sees every meaningful cap
+        // move (e.g. the token axis jumping from a batch of account resets)
+        // without a steady-state stream of identical lines every interval.
+        let mut was_max_concurrent: Option<usize> = None;
         loop {
             ticker.tick().await;
             // Reactive main-health backstop (Phase C, #3812): skip all dispatch
@@ -1203,7 +1379,16 @@ where
             // back to the policy floor of 1 (soft backoff, never a hard halt).
             // `cpu_utilization_target` / `cpu_est_cores_per_sweep` are resolved
             // once at startup (env > config > default, #4032) and captured by
-            // this task, mirroring `per_token_concurrency`.
+            // this task, mirroring `per_token_concurrency`. NOTE (#4234): a
+            // release-build-heavy repo should raise `estCoresPerSweep` well
+            // above the shipped default of 2.0 — a `cargo build --release`
+            // parallelizes across every core via rustc codegen units, so 6
+            // concurrent release builds demand far closer to `6 × ncpu` than
+            // `6 × 2`. The per-tick `max_admissions_per_tick` ramp cap below is
+            // a second, independent backstop for exactly this under-estimate:
+            // even if `estCoresPerSweep` is miscalibrated too low and the cpu
+            // axis over-admits, the ramp cap still bounds how many of those
+            // over-admitted sweeps land in any single tick.
             let cpu = tokio::task::spawn_blocking(move || {
                 cpu_headroom_limit(cpu_utilization_target, cpu_est_cores_per_sweep)
             })
@@ -1216,12 +1401,25 @@ where
                 cpu,
                 configured_max,
             );
-            log::debug!(
+            let axis_line = format!(
                 "work_finder: dynamic cap = {max_concurrent} (pool={pool_size}, \
                  healthy_tokens={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
-                 cpu={cpu}, configured_max={configured_max}, halted={halted})"
+                 cpu={cpu}, configured_max={configured_max}, \
+                 max_admissions_per_tick={max_admissions_per_tick}, halted={halted})"
             );
-            match tick(&mut source, &mut dispatcher, max_concurrent, halted) {
+            if was_max_concurrent != Some(max_concurrent) {
+                log::info!("{axis_line}");
+                was_max_concurrent = Some(max_concurrent);
+            } else {
+                log::debug!("{axis_line}");
+            }
+            match tick_with_admission_cap(
+                &mut source,
+                &mut dispatcher,
+                max_concurrent,
+                halted,
+                max_admissions_per_tick,
+            ) {
                 Ok(report) => {
                     if report.halted && !was_halted {
                         log::warn!(
@@ -1238,14 +1436,16 @@ where
                         || report.skipped_quarantined > 0
                         || report.skipped_pr_open > 0
                         || report.skipped_peer_claim > 0
+                        || report.deferred_ramp_cap > 0
                     {
                         log::info!(
                             "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
                              healthy={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
-                             cpu={cpu}, ceiling={configured_max}); \
+                             cpu={cpu}, ceiling={configured_max}, ramp_cap={max_admissions_per_tick}); \
                              {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, \
                              {} quarantine-skip, {} pr-open-skip, {} peer-claim-skip, \
-                             {} deferred, {} error(s), {} cross-host-collision(s)",
+                             {} deferred (capacity), {} deferred (ramp), {} error(s), \
+                             {} cross-host-collision(s)",
                             report.seen,
                             report.dispatched,
                             report.skipped_labeled,
@@ -1254,6 +1454,7 @@ where
                             report.skipped_pr_open,
                             report.skipped_peer_claim,
                             report.deferred_capacity,
+                            report.deferred_ramp_cap,
                             report.errors,
                             report.collisions
                         );
@@ -1328,6 +1529,7 @@ pub fn spawn_multi_work_finder_task(
     per_token_concurrency: usize,
     cpu_utilization_target: f64,
     cpu_est_cores_per_sweep: f64,
+    max_admissions_per_tick: usize,
     health_states: Arc<WorkspaceHealthStates>,
     suppress_dispatch_during_gate: bool,
     event_bus: Arc<EventBus>,
@@ -1335,7 +1537,7 @@ pub fn spawn_multi_work_finder_task(
 ) -> tokio::task::JoinHandle<()> {
     log::info!(
         "work_finder: starting multi-workspace loop (interval={}s, configured_max={configured_max}, \
-         per_token_concurrency={per_token_concurrency}, \
+         per_token_concurrency={per_token_concurrency}, max_admissions_per_tick={max_admissions_per_tick}, \
          dynamic cap = min(healthy tokens × per-token, disk, cpu, configured_max), global across workspaces)",
         interval.as_secs()
     );
@@ -1346,6 +1548,9 @@ pub fn spawn_multi_work_finder_task(
         ticker.tick().await;
         let mut was_halted = false;
         let mut was_pressured = false;
+        // Axis-visibility state (#4234) — see the single-workspace loop above
+        // for the full rationale.
+        let mut was_max_concurrent: Option<usize> = None;
         loop {
             ticker.tick().await;
 
@@ -1418,15 +1623,28 @@ pub fn spawn_multi_work_finder_task(
                 })
                 .collect();
 
-            log::debug!(
+            let axis_line = format!(
                 "work_finder: dynamic cap = {max_concurrent} (pool={pool_size}, \
                  healthy_tokens={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
-                 cpu={cpu}, configured_max={configured_max}, any_halted={any_halted}, \
+                 cpu={cpu}, configured_max={configured_max}, \
+                 max_admissions_per_tick={max_admissions_per_tick}, any_halted={any_halted}, \
                  workspaces={}, priorities={priorities:?})",
                 pairs.len()
             );
+            if was_max_concurrent != Some(max_concurrent) {
+                log::info!("{axis_line}");
+                was_max_concurrent = Some(max_concurrent);
+            } else {
+                log::debug!("{axis_line}");
+            }
 
-            let report = tick_multi(&mut pairs, &priorities, max_concurrent, &halted);
+            let report = tick_multi_with_admission_cap(
+                &mut pairs,
+                &priorities,
+                max_concurrent,
+                &halted,
+                max_admissions_per_tick,
+            );
 
             if report.halted && !was_halted {
                 log::warn!(
@@ -1445,14 +1663,17 @@ pub fn spawn_multi_work_finder_task(
                 || report.skipped_quarantined > 0
                 || report.skipped_pr_open > 0
                 || report.skipped_peer_claim > 0
+                || report.deferred_ramp_cap > 0
             {
                 log::info!(
                     "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
                      healthy={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
-                     cpu={cpu}, ceiling={configured_max}); {} workspace(s), \
+                     cpu={cpu}, ceiling={configured_max}, ramp_cap={max_admissions_per_tick}); \
+                     {} workspace(s), \
                      {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, \
                      {} quarantine-skip, {} pr-open-skip, {} peer-claim-skip, \
-                     {} deferred, {} error(s), {} cross-host-collision(s)",
+                     {} deferred (capacity), {} deferred (ramp), {} error(s), \
+                     {} cross-host-collision(s)",
                     pairs.len(),
                     report.seen,
                     report.dispatched,
@@ -1462,6 +1683,7 @@ pub fn spawn_multi_work_finder_task(
                     report.skipped_pr_open,
                     report.skipped_peer_claim,
                     report.deferred_capacity,
+                    report.deferred_ramp_cap,
                     report.errors,
                     report.collisions
                 );
@@ -1991,6 +2213,91 @@ exit 0
         assert_eq!(report.dispatched, 3);
         assert_eq!(report.deferred_capacity, 0);
         assert_eq!(disp.dispatched, vec![1, 2, 3]);
+    }
+
+    // ===================================================================
+    // tick_with_admission_cap — per-tick ramp cap (#4234, Gap 3 of #4231)
+    // ===================================================================
+
+    #[test]
+    fn test_tick_admission_cap_limits_new_dispatches_even_under_large_concurrency_cap() {
+        // 6 ready candidates, plenty of concurrency room (max_concurrent=10),
+        // but the ramp cap only allows 3 *new* admissions this tick — exactly
+        // the #4231 6-way-fan-out scenario: a token-axis jump could make
+        // max_concurrent look like it has room for all 6, but the ramp cap
+        // still bounds the burst.
+        let mut source = FakeSource::once((1..=6).map(issue).collect());
+        let mut disp = RecordingDispatcher::default();
+        let report = tick_with_admission_cap(&mut source, &mut disp, 10, false, 3).unwrap();
+
+        assert_eq!(report.seen, 6);
+        assert_eq!(report.dispatched, 3, "only the ramp cap's worth admitted");
+        assert_eq!(report.deferred_ramp_cap, 3, "the rest deferred to the ramp cap, not capacity");
+        assert_eq!(report.deferred_capacity, 0, "concurrency cap was never the binding constraint");
+        assert_eq!(disp.dispatched, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_tick_admission_cap_and_concurrency_cap_are_independent_and_both_apply() {
+        // Concurrency cap (2) is smaller than the ramp cap (5) here, so the
+        // concurrency cap is the one that actually binds — exercising that the
+        // two checks compose rather than one silently overriding the other.
+        let mut source = FakeSource::once((1..=6).map(issue).collect());
+        let mut disp = RecordingDispatcher::default();
+        let report = tick_with_admission_cap(&mut source, &mut disp, 2, false, 5).unwrap();
+
+        assert_eq!(report.dispatched, 2);
+        assert_eq!(report.deferred_capacity, 4, "concurrency cap bound first");
+        assert_eq!(report.deferred_ramp_cap, 0, "ramp cap never reached — occupancy hit 2 first");
+    }
+
+    #[test]
+    fn test_tick_admission_cap_unlimited_reduces_to_plain_tick() {
+        // `tick()` is a thin wrapper passing `usize::MAX` — byte-for-byte the
+        // pre-#4234 unlimited-admission behavior.
+        let mut source_capped = FakeSource::once((1..=4).map(issue).collect());
+        let mut disp_capped = RecordingDispatcher::default();
+        let capped =
+            tick_with_admission_cap(&mut source_capped, &mut disp_capped, 10, false, usize::MAX)
+                .unwrap();
+
+        let mut source_plain = FakeSource::once((1..=4).map(issue).collect());
+        let mut disp_plain = RecordingDispatcher::default();
+        let plain = tick(&mut source_plain, &mut disp_plain, 10, false).unwrap();
+
+        assert_eq!(capped, plain);
+        assert_eq!(disp_capped.dispatched, disp_plain.dispatched);
+    }
+
+    #[test]
+    fn test_tick_multi_admission_cap_shared_across_workspaces() {
+        // Two workspaces, 4 candidates total, ramp cap 2 — the cap is a single
+        // shared counter across both workspaces (mirrors the concurrency cap's
+        // existing shared-budget contract).
+        let source_a = FakeSource::once(vec![issue(1), issue(2)]);
+        let disp_a = RecordingDispatcher::default();
+        let source_b = FakeSource::once(vec![issue(3), issue(4)]);
+        let disp_b = RecordingDispatcher::default();
+        let mut multi = vec![(source_a, disp_a), (source_b, disp_b)];
+
+        let report = tick_multi_with_admission_cap(&mut multi, &[], 10, &[false, false], 2);
+
+        assert_eq!(report.dispatched, 2);
+        assert_eq!(report.deferred_ramp_cap, 2);
+        assert_eq!(report.deferred_capacity, 0);
+    }
+
+    #[test]
+    fn test_tick_admission_cap_zero_defers_everything() {
+        // A ramp cap of 0 admits nothing this tick (still distinct from
+        // `halted`: `seen` reflects the backlog, no main-health warning fires).
+        let mut source = FakeSource::once((1..=3).map(issue).collect());
+        let mut disp = RecordingDispatcher::default();
+        let report = tick_with_admission_cap(&mut source, &mut disp, 10, false, 0).unwrap();
+
+        assert_eq!(report.dispatched, 0);
+        assert_eq!(report.deferred_ramp_cap, 3);
+        assert!(disp.dispatched.is_empty());
     }
 
     #[test]
@@ -3017,7 +3324,7 @@ exit 0
         let tmp = tempfile::tempdir().unwrap();
         write_config(
             tmp.path(),
-            r#"{"autonomous": {"perTokenConcurrency": 4, "cpuUtilizationTarget": 0.6, "estCoresPerSweep": 3.5, "workFinder": {"enabled": true, "intervalSecs": 90, "maxConcurrent": 5}}}"#,
+            r#"{"autonomous": {"perTokenConcurrency": 4, "cpuUtilizationTarget": 0.6, "estCoresPerSweep": 3.5, "workFinder": {"enabled": true, "intervalSecs": 90, "maxConcurrent": 5, "maxAdmissionsPerTick": 4}}}"#,
         );
         assert_eq!(
             read_work_finder_config(tmp.path()),
@@ -3025,6 +3332,7 @@ exit 0
                 enabled: Some(true),
                 interval_secs: Some(90),
                 max_concurrent: Some(5),
+                max_admissions_per_tick: Some(4),
                 per_token_concurrency: Some(4),
                 cpu_utilization_target: Some(0.6),
                 est_cores_per_sweep: Some(3.5),
@@ -3312,6 +3620,57 @@ exit 0
         std::env::set_var(WORK_FINDER_MAX_CONCURRENT_ENV, "nope");
         assert_eq!(resolve_max_concurrent_with_config(&cfg), 8);
         std::env::remove_var(WORK_FINDER_MAX_CONCURRENT_ENV);
+    }
+
+    // ===================================================================
+    // resolve_max_admissions_per_tick_with_config — env > config > default
+    // (#4234)
+    // ===================================================================
+
+    #[test]
+    #[serial]
+    fn test_resolve_max_admissions_per_tick_with_config_precedence() {
+        std::env::remove_var(WORK_FINDER_MAX_ADMISSIONS_PER_TICK_ENV);
+
+        // Default when neither env nor config set.
+        assert_eq!(
+            resolve_max_admissions_per_tick_with_config(&WorkFinderConfig::default()),
+            DEFAULT_MAX_ADMISSIONS_PER_TICK
+        );
+
+        // Config used when env unset.
+        let cfg = WorkFinderConfig {
+            max_admissions_per_tick: Some(7),
+            ..Default::default()
+        };
+        assert_eq!(resolve_max_admissions_per_tick_with_config(&cfg), 7);
+
+        // Env overrides config.
+        std::env::set_var(WORK_FINDER_MAX_ADMISSIONS_PER_TICK_ENV, "1");
+        assert_eq!(resolve_max_admissions_per_tick_with_config(&cfg), 1);
+
+        // A zero/garbage env value is ignored; config still wins over default.
+        std::env::set_var(WORK_FINDER_MAX_ADMISSIONS_PER_TICK_ENV, "0");
+        assert_eq!(resolve_max_admissions_per_tick_with_config(&cfg), 7);
+        std::env::set_var(WORK_FINDER_MAX_ADMISSIONS_PER_TICK_ENV, "nope");
+        assert_eq!(resolve_max_admissions_per_tick_with_config(&cfg), 7);
+        std::env::remove_var(WORK_FINDER_MAX_ADMISSIONS_PER_TICK_ENV);
+    }
+
+    #[test]
+    fn test_read_work_finder_config_parses_max_admissions_per_tick() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"autonomous": {"workFinder": {"maxAdmissionsPerTick": 5}}}"#);
+        let cfg = read_work_finder_config(tmp.path());
+        assert_eq!(cfg.max_admissions_per_tick, Some(5));
+    }
+
+    #[test]
+    fn test_read_work_finder_config_drops_zero_max_admissions_per_tick() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"autonomous": {"workFinder": {"maxAdmissionsPerTick": 0}}}"#);
+        let cfg = read_work_finder_config(tmp.path());
+        assert_eq!(cfg.max_admissions_per_tick, None, "a zero cap is treated as absent");
     }
 
     #[test]


### PR DESCRIPTION
Closes #4234

## Summary

Closes the three gaps left in the existing work-finder concurrency cap (#3811/#3978/#4032) that let the #4231 host-meltdown 6-way fan-out escape it. The cap mechanism and load feedback already existed and worked as designed; this closes the specific holes rather than rebuilding the mechanism.

### Gap 1 — `dispatch_sweep` bypassed headroom entirely
`Request::DispatchSweep` (`loom-daemon/src/ipc.rs`) now consults the same `resolve_dynamic_max_concurrent` headroom (token/disk/cpu/configured-max) the autonomous work finder already applies to its own dispatches. Policy is **advisory-first**, matching `capacity.rs`'s token-backpressure "never a halt" precedent (#3902) — an explicit operator/MCP dispatch is a deliberate act, so it always proceeds, but on a state-change into/out of "occupancy at/over the computed headroom" it logs a warning and publishes a new `daemon.dispatch.headroom_advisory` event-bus event (state-change-deduped, per-repo). This required **zero protocol change** (no new `Request::DispatchSweep` field, no `force` param). Every `dispatch_sweep` call's log line now always names the current occupancy/dynamic-cap axes. Uses the non-refreshing `cpu_headroom_snapshot` (never blocks) rather than `cpu_headroom_limit` (which sleeps ~1s on macOS via `iostat`) to avoid stalling other IPC requests while holding the sweep-registry mutex.

### Gap 2 — `estCoresPerSweep` underestimates release builds
Documented the footgun in code comments (`cpu_headroom.rs`) and `defaults/docs/daemon-reference.md`: the default `2.0` is calibrated against debug/check/clippy phases, not `cargo build --release`, which can consume close to `logical_cpus` cores on its own. A release-build-heavy repo should raise `autonomous.estCoresPerSweep` accordingly. The per-tick admission cap (Gap 3) is the independent backstop for when this knob is still miscalibrated.

### Gap 3 — no ramp-aware admission
New `autonomous.workFinder.maxAdmissionsPerTick` knob (`LOOM_WORK_FINDER_MAX_ADMISSIONS_PER_TICK`, default `3`, env > config > default via `config_resolver`) bounds how many **new** sweeps a single tick may admit, independent of the live `max_concurrent` cap. This directly addresses the #4231 incident's second wave (host re-spiked minutes after admission, once builds actually ramped up, even though loadavg looked quiet at admission time). `TickReport::deferred_ramp_cap` tracks candidates deferred by this cap separately from `deferred_capacity`. Resolved once at daemon startup, same startup-capture pattern as the other dynamic-cap knobs.

### Axis visibility
The per-tick dynamic-cap axis log line (`work_finder.rs`) now promotes from `debug!` to `info!` on value change (state-change dedup, mirroring the capacity advisory), so an operator at default log level sees every meaningful cap move without a steady stream of identical lines. No new plumbing needed for the status surface — `build_daemon_status` already exposed the CPU axes.

## Test plan

- [x] Unit: `dispatch_sweep` with synthetic low headroom (forced `configured_max=1` via env) still dispatches — advisory-only, never a hard gate (`test_dispatch_sweep_still_dispatches_under_synthetic_low_headroom`)
- [x] Unit: headroom-advisory dedup fires only on state change, symmetric recovery event (`dispatch_headroom_advisory_dedups_on_state_change`)
- [x] Unit: per-tick admission cap limits a large candidate set to K per tick, independent of the concurrency cap, including the shared multi-workspace counter and the `usize::MAX`-reduces-to-plain-`tick()` invariant (`test_tick_admission_cap_*`, `test_tick_multi_admission_cap_shared_across_workspaces`)
- [x] Unit: `autonomous.workFinder.maxAdmissionsPerTick` config parsing + env>config>default precedence (`test_resolve_max_admissions_per_tick_with_config_precedence`, `test_read_work_finder_config_*`)
- [x] `cd loom-daemon && cargo test --lib` — 1502 passed, 0 failed
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --check` — clean

**Note on `cargo test` (full, including integration targets):** `loom-daemon/tests/integration_basic.rs` (9 tests) failed with "Daemon failed to create socket within 5s" on this dev host — pre-existing and unrelated to this change (no files in `loom-daemon/tests/` touched). These integration tests spawn a real daemon + tmux session and are explicitly excluded from the build gate (`.loom/docs/build-gate.md`: "the integration test **targets**... excluded"); CI runs them in a controlled runner with a guaranteed-live tmux. This dev host had concurrent cargo test/clippy activity from other worktrees at the time, consistent with the documented flakiness.

## Documentation

`defaults/docs/daemon-reference.md` (source for `.loom/docs/daemon-reference.md`, symlinked) gains:
- The release-build fan-out footgun writeup
- Per-tick admission (ramp) cap section
- `dispatch_sweep` headroom advisory section
- `maxAdmissionsPerTick` in the example config + knob-precedence table

🤖 Generated with [Claude Code](https://claude.com/claude-code)
