### PR TITLE
feat(spawn): nice sweep/role-runner children so they no longer starve the host (#4233)

### DIFF
--- a/defaults/docs/build-gate.md
+++ b/defaults/docs/build-gate.md
@@ -218,9 +218,28 @@ real, non-zero, unprivileged-achievable gap in the achievable direction
 (gate `5` > sweeps `0`): the gate yields *slightly* under contention rather than
 starving the sweeps, without being drastically deprioritized as it was at 19.
 The alternative — niceing sweep *children* up in the spawn path to force a
-strict gate-below-sweep gap — is deliberately not done, since the issue directed
-the spawn path be left untouched and the contention it would brace against is
-the one the evidence above withdrew.
+strict gate-below-sweep gap — was deliberately not done here at the time, since
+the issue directed the spawn path be left untouched and the contention it would
+brace against is the one the evidence above withdrew.
+
+**Update (#4233): the inversion is now implemented, from the OTHER side.**
+Issue #4231 (a 2026-07-27→28 host meltdown under 6-way sweep fan-out) diagnosed
+*starvation*, not raw load, as the real failure — sweep worker processes (and
+every `cargo`/`rustc`/test binary they spawn) ran at default niceness (0),
+competing head-to-head with interactive/system processes. `spawn-claude.sh` now
+re-execs itself at a mild positive niceness (default `nice 10`, configurable via
+`LOOM_SWEEP_NICENESS` env / `autonomous.spawnNiceness` config, master disable
+`LOOM_SWEEP_NICE=0`) using the same re-exec-with-sentinel pattern documented
+above (`LOOM_SWEEP_NICED` mirrors `LOOM_BUILD_GATE_NICED`). An optional macOS
+`taskpolicy -c <class>` scheduling-class layer (`LOOM_SWEEP_TASKPOLICY_CLASS` /
+`autonomous.spawnTaskpolicyClass`, off by default) is available on top of nice.
+See `spawn-claude.sh`'s own header comment for the full precedence chain. With
+sweep children now at `nice 10` and the gate at `nice 5`, the gate has a real,
+measured, unprivileged-achievable *higher* priority than sweeps — the reverse of
+the `gate 5 > sweeps 0` relationship described above — so the gate now
+structurally wins CPU contention against concurrently-dispatched sweep builds,
+addressing the #4084 premise (below) as a side effect rather than requiring the
+dispatch-suppression workaround alone.
 
 The re-exec mechanism and its knobs are preserved: `LOOM_BUILD_GATE_NICENESS`
 overrides the value (e.g. `=0` for exact sweep parity, `=19` to restore the old

--- a/defaults/scripts/spawn-claude.sh
+++ b/defaults/scripts/spawn-claude.sh
@@ -67,6 +67,20 @@
 #                          the sweep escalation ladder's per-rung `@effort`
 #                          cannot be threaded here because the in-session Task
 #                          tool exposes no effort parameter (see sweep.md).
+#   LOOM_SWEEP_NICENESS    Scheduling niceness applied to this process (and
+#                          everything it execs/forks — claude, claude-wrapper,
+#                          cargo, rustc, test binaries) via a `nice -n N exec`
+#                          re-exec, mirroring build-gate.sh's niceness pattern
+#                          (issue #4233). Precedence: this env var ->
+#                          `autonomous.spawnNiceness` config -> default `10`.
+#   LOOM_SWEEP_NICE=0      Disables the ENTIRE priority mechanism (nice AND
+#                          taskpolicy below), restoring pre-#4233 behavior.
+#   LOOM_SWEEP_TASKPOLICY_CLASS  Optional macOS `taskpolicy -c <class>`
+#                          scheduling class applied in-place (e.g. "utility").
+#                          Precedence: this env var ->
+#                          `autonomous.spawnTaskpolicyClass` config -> unset
+#                          (off by default). No-op on non-macOS or when
+#                          `taskpolicy` is unavailable.
 
 set -euo pipefail
 
@@ -113,10 +127,97 @@ _resolve_workspace() {
 
 WORKSPACE="$(_resolve_workspace)"
 
+_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Sweep/role-runner spawn scheduling priority (issue #4233) ---
+#
+# Issue #4231 (host meltdown 2026-07-27→28: 6-way sweep fan-out, load 118/28
+# cores, WindowServer watchdog-killed 5×, loom-daemon crashed) diagnosed
+# STARVATION, not raw load, as the actual failure mode: sweep worker processes
+# — and every build they spawn (cargo, rustc, test binaries) — run at default
+# niceness (0), so under fan-out they compete head-to-head with WindowServer,
+# VNC, and other system daemons for CPU.
+#
+# #3985/#4020/#4073/#4084 (see build-gate.sh:32-82) already ran this
+# experiment from the OTHER side — nicing the build GATE up so it could never
+# starve sweeps. #4020 found the extreme gate=19 starved the gate itself into
+# UNEVALUATED and settled on gate=5 (a mild, measured, unprivileged-achievable
+# gap above sweeps' nice-0 default); its comment (build-gate.sh:63-70)
+# explicitly flagged the untried alternative — nicing sweep children UP in the
+# spawn path — as deliberately not done at the time. This block does that, so
+# the gap between gate and sweep niceness is now real in both directions.
+#
+# Applied here — the outermost point in the daemon's actual dispatch path.
+# `loom-daemon` invokes THIS script directly for both sweep dispatch
+# (SweepRegistryConfig::resolve_spawn_bin in
+# loom-daemon/src/sweep_registry.rs) and scheduled role-runner dispatch
+# (role_runner.rs) — both unattended/background paths; MOM's interactive
+# terminals run `claude` directly and never go through this script, so no
+# separate "interactive opt-out" is needed. spawn-worker.sh (a not-yet-wired
+# future multi-runtime seam, see its own header) execs into this script for
+# the "claude" runtime and is therefore covered transparently; it applies no
+# priority adjustment of its own so there is no double-apply risk.
+#
+# Mechanism: a `nice -n N exec "$0" "$@"` re-exec — mirroring build-gate.sh's
+# `LOOM_BUILD_GATE_NICED` sentinel pattern — applied before ANY child process
+# (token selection, `claude`, `claude-wrapper.sh`). Because `exec` preserves
+# the PID and nice/taskpolicy attributes survive exec, the whole subsequent
+# process tree (this script → claude/claude-wrapper → any cargo/rustc it
+# forks) inherits the adjustment with no separate handling required
+# downstream. The build gate has its own independent niceness policy
+# (build-gate.sh) and is never invoked through this script, so there is no
+# overlap with it either.
+#
+# Precedence (env > config > default), the tier order used throughout loom:
+#   LOOM_SWEEP_NICENESS         > autonomous.spawnNiceness         > 10
+#   LOOM_SWEEP_TASKPOLICY_CLASS > autonomous.spawnTaskpolicyClass  > (unset)
+#
+# LOOM_SWEEP_NICE=0 disables the ENTIRE mechanism (nice AND taskpolicy),
+# restoring byte-identical pre-#4233 behavior (nice 0, no taskpolicy class).
+#
+# Default is nice ONLY, at a moderate value (10) — deliberately above the
+# gate's 5, so sweeps now yield to the gate under contention, addressing the
+# #4084 CPU-contention premise as a structural side effect. `taskpolicy` is
+# opt-in and unset by default: on macOS, `-c utility` is the recommended class
+# if enabled — deliberately NOT `-b`/background (DARWIN_BG), which also
+# throttles disk I/O and network aggressively enough to risk *causing* the
+# very timeouts this issue is trying to prevent.
+if [[ -z "${LOOM_SWEEP_NICED:-}" && "${LOOM_SWEEP_NICE:-1}" != "0" ]]; then
+    _sweep_niceness="${LOOM_SWEEP_NICENESS:-}"
+    _sweep_taskpolicy_class="${LOOM_SWEEP_TASKPOLICY_CLASS:-}"
+    _sweep_config_lib="${_script_dir}/lib/config-resolver.sh"
+    if [[ ( -z "$_sweep_niceness" || -z "$_sweep_taskpolicy_class" ) \
+          && -f "$_sweep_config_lib" ]]; then
+        # shellcheck source=./lib/config-resolver.sh
+        source "$_sweep_config_lib"
+        [[ -z "$_sweep_niceness" ]] \
+            && _sweep_niceness="$(loom_config_get "$WORKSPACE" "autonomous.spawnNiceness" "")"
+        [[ -z "$_sweep_taskpolicy_class" ]] \
+            && _sweep_taskpolicy_class="$(loom_config_get "$WORKSPACE" "autonomous.spawnTaskpolicyClass" "")"
+    fi
+    : "${_sweep_niceness:=10}"
+
+    # taskpolicy sets the scheduling class on THIS running process (no
+    # re-exec needed) and, like nice, survives the exec below since exec
+    # preserves the PID. Best-effort: a failure here never blocks the spawn.
+    if [[ -n "$_sweep_taskpolicy_class" ]] && command -v taskpolicy >/dev/null 2>&1; then
+        if taskpolicy -c "$_sweep_taskpolicy_class" -p $$ >/dev/null 2>&1; then
+            log_info "spawn-claude: applied taskpolicy -c $_sweep_taskpolicy_class (issue #4233)"
+        else
+            log_warn "spawn-claude: taskpolicy -c $_sweep_taskpolicy_class failed (non-fatal, continuing at default policy class)"
+        fi
+    fi
+
+    if [[ "$_sweep_niceness" != "0" ]] && command -v nice >/dev/null 2>&1; then
+        export LOOM_SWEEP_NICED=1
+        log_info "spawn-claude: re-exec at nice -n $_sweep_niceness (issue #4233; LOOM_SWEEP_NICE=0 to disable)"
+        exec nice -n "$_sweep_niceness" "$0" "$@"
+    fi
+fi
+
 # --- Locate the loom-daemon binary (token selection, issue #4228) ---
 # Resolution precedence (see lib/locate-daemon-bin.sh): $LOOM_DAEMON_BIN ->
 # `loom-daemon` on PATH -> build-output-relative candidates under $WORKSPACE.
-_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/locate-daemon-bin.sh
 source "${_script_dir}/lib/locate-daemon-bin.sh"
 

--- a/defaults/scripts/spawn-worker.sh
+++ b/defaults/scripts/spawn-worker.sh
@@ -26,6 +26,15 @@
 # 78 (EX_CONFIG) with a message naming the resolved runtime, where it was
 # resolved from (env vs config vs default), and the runners actually present.
 #
+# Sweep/role-runner scheduling priority (issue #4233): applied inside
+# `spawn-<runtime>.sh` (currently only `spawn-claude.sh`), NOT here — this
+# dispatcher only ever `exec`s into a runner, which preserves the pid, so a
+# runner-level `nice`/`taskpolicy` re-exec still covers every process this
+# script itself would otherwise have spawned. Deliberately not duplicated at
+# this layer to avoid a double-apply; a future `spawn-<runtime>.sh` adopting a
+# new runtime should apply its own priority policy the same way
+# `spawn-claude.sh` does, not rely on this dispatcher for it.
+#
 # Usage:
 #   .loom/scripts/spawn-worker.sh -p "your prompt"
 #   LOOM_RUNTIME=claude .loom/scripts/spawn-worker.sh --use-wrapper -p "..."

--- a/defaults/scripts/tests/test-spawn-claude.sh
+++ b/defaults/scripts/tests/test-spawn-claude.sh
@@ -969,6 +969,133 @@ assert_contains "ARG<--dangerously-skip-permissions>" "$bsd_captured" \
 rm -rf "$CC_DIR"
 
 # ============================================================
+# Section 7: spawn scheduling priority (issue #4233)
+#
+# Sweep worker processes (and everything they exec/fork downstream) get
+# niced up so they no longer starve interactive/system processes under
+# fan-out. The niceness value is observable via `ps -o ni=` on the exec'd
+# `claude` stub's own pid — the re-exec preserves the pid, so this directly
+# proves the value the eventual `claude`/cargo/rustc process tree inherits.
+# ============================================================
+
+echo ""
+echo "Testing spawn-claude.sh scheduling priority (#4233)..."
+
+PRIO_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_WS" "$STUB_DIR" "$PRIO_DIR"' EXIT
+
+cat > "$PRIO_DIR/claude" <<'STUB'
+#!/usr/bin/env bash
+echo "nice=$(ps -o ni= -p $$ | tr -d ' ')"
+STUB
+chmod +x "$PRIO_DIR/claude"
+
+# Fake `taskpolicy` that records its invocation instead of requiring a real
+# macOS host — this is a plain PATH-resolved stub, so it exercises the
+# `command -v taskpolicy` branch deterministically on any OS.
+TASKPOLICY_LOG="$PRIO_DIR/taskpolicy.log"
+cat > "$PRIO_DIR/taskpolicy" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$TASKPOLICY_LOG"
+exit 0
+STUB
+chmod +x "$PRIO_DIR/taskpolicy"
+
+# Test: default niceness is 10 with no env/config set.
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$PRIO_DIR:$PATH" \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+assert_contains "nice=10" "$output" \
+    "spawn-claude defaults to nice 10 (#4233)"
+assert_contains "spawn-claude: re-exec at nice -n 10" "$output" \
+    "spawn-claude logs the re-exec niceness (#4233)"
+
+# Test: LOOM_SWEEP_NICE=0 disables the entire mechanism (nice AND taskpolicy).
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$PRIO_DIR:$PATH" \
+    LOOM_SWEEP_NICE=0 \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+assert_contains "nice=0" "$output" \
+    "LOOM_SWEEP_NICE=0 disables the priority mechanism, restoring nice 0 (#4233)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$output" != *"re-exec at nice"* ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: LOOM_SWEEP_NICE=0 suppresses the re-exec entirely (#4233)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: LOOM_SWEEP_NICE=0 suppresses the re-exec entirely (#4233)"
+    echo "    In: '$output'"
+fi
+
+# Test: LOOM_SWEEP_NICENESS overrides the default value.
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$PRIO_DIR:$PATH" \
+    LOOM_SWEEP_NICENESS=15 \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+assert_contains "nice=15" "$output" \
+    "LOOM_SWEEP_NICENESS env overrides the default niceness (#4233)"
+
+# Test: autonomous.spawnNiceness config knob is honored when no env is set
+# (env > config > default precedence).
+CFG_WS="$(mktemp -d)"
+mkdir -p "$CFG_WS/.loom/tokens"
+chmod 700 "$CFG_WS/.loom/tokens"
+echo -n "fake-token-cfg" > "$CFG_WS/.loom/tokens/alpha.token"
+chmod 600 "$CFG_WS/.loom/tokens/alpha.token"
+cat > "$CFG_WS/.loom/config.json" <<'EOF'
+{ "autonomous": { "spawnNiceness": 7 } }
+EOF
+output=$(LOOM_WORKSPACE="$CFG_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$PRIO_DIR:$PATH" \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+assert_contains "nice=7" "$output" \
+    "autonomous.spawnNiceness config knob is honored (#4233)"
+
+# Test: an explicit LOOM_SWEEP_NICENESS env still wins over the config knob.
+output=$(LOOM_WORKSPACE="$CFG_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$PRIO_DIR:$PATH" \
+    LOOM_SWEEP_NICENESS=3 \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+assert_contains "nice=3" "$output" \
+    "LOOM_SWEEP_NICENESS env wins over autonomous.spawnNiceness config (#4233)"
+
+# Test: LOOM_SWEEP_TASKPOLICY_CLASS invokes the (stubbed) taskpolicy command
+# with the expected class and this process's own pid, additive to nice.
+: > "$TASKPOLICY_LOG"
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$PRIO_DIR:$PATH" \
+    LOOM_SWEEP_TASKPOLICY_CLASS="utility" \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+assert_contains "-c utility" "$(cat "$TASKPOLICY_LOG")" \
+    "LOOM_SWEEP_TASKPOLICY_CLASS invokes taskpolicy -c <class> (#4233)"
+assert_contains "spawn-claude: applied taskpolicy -c utility" "$output" \
+    "spawn-claude logs the applied taskpolicy class (#4233)"
+assert_contains "nice=10" "$output" \
+    "taskpolicy and the default nice both apply together (#4233)"
+
+# Test: autonomous.spawnTaskpolicyClass config knob is honored.
+: > "$TASKPOLICY_LOG"
+cat > "$CFG_WS/.loom/config.json" <<'EOF'
+{ "autonomous": { "spawnNiceness": 7, "spawnTaskpolicyClass": "utility" } }
+EOF
+output=$(LOOM_WORKSPACE="$CFG_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$PRIO_DIR:$PATH" \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+assert_contains "-c utility" "$(cat "$TASKPOLICY_LOG")" \
+    "autonomous.spawnTaskpolicyClass config knob is honored (#4233)"
+rm -rf "$CFG_WS"
+
+# Test: a re-exec loop cannot happen — the LOOM_SWEEP_NICED sentinel, once
+# set, is never re-applied even if the caller passes a differing niceness.
+output=$(LOOM_WORKSPACE="$TEST_WS" LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$PRIO_DIR:$PATH" \
+    LOOM_SWEEP_NICED=1 LOOM_SWEEP_NICENESS=15 \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$output" != *"re-exec at nice"* ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: LOOM_SWEEP_NICED sentinel prevents a second re-exec (#4233)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: LOOM_SWEEP_NICED sentinel prevents a second re-exec (#4233)"
+    echo "    In: '$output'"
+fi
+
+rm -rf "$PRIO_DIR"
+
+# ============================================================
 # Summary
 # ============================================================
 


### PR DESCRIPTION
Closes #4233

## What

`spawn-claude.sh` — the outermost point in the daemon's actual dispatch path
for both sweep dispatch (`sweep_registry.rs`'s `resolve_spawn_bin`/`spawn_child`)
and scheduled role-runner dispatch (`role_runner.rs`) — now re-execs itself
once under a mild positive scheduling priority before spawning `claude`/
`claude-wrapper.sh` (and everything they in turn fork: cargo, rustc, test
binaries). The re-exec mirrors `build-gate.sh`'s existing
`LOOM_BUILD_GATE_NICED` sentinel pattern exactly, one layer further up the
tree, so nothing downstream needs separate handling — `nice`/`taskpolicy`
attributes survive `exec`.

- **Default**: `nice -n 10` (env `LOOM_SWEEP_NICENESS` > config
  `autonomous.spawnNiceness` > default `10`).
- **Master disable**: `LOOM_SWEEP_NICE=0` restores byte-identical pre-#4233
  behavior (nice 0, no taskpolicy).
- **Optional, off by default**: a macOS `taskpolicy -c <class>` QoS-class hint
  layers on top of nice (env `LOOM_SWEEP_TASKPOLICY_CLASS` > config
  `autonomous.spawnTaskpolicyClass` > unset). Deliberately never `-b`/
  `DARWIN_BG` — that also throttles disk I/O and network aggressively enough
  to risk causing the very timeouts this issue is trying to prevent (called
  out explicitly in the issue).
- **Scope**: applied only inside `spawn-claude.sh`, which is exclusively a
  headless/background dispatch entry point (daemon sweep dispatch, daemon
  role-runner dispatch, or ad hoc manual headless invocation) — MOM's
  interactive terminals run `claude` directly and never go through this
  script, so no separate "interactive opt-out" is needed. `spawn-worker.sh`
  only ever `exec`s into `spawn-claude.sh` (or a future runtime adapter),
  which preserves the pid, so the re-exec there still covers it transparently
  with no double-apply — documented in `spawn-worker.sh`'s own header. The
  build gate (`build-gate.sh`) has its own independent niceness policy and is
  never invoked through this script, so there's no overlap with it either.

## Why

Host meltdown #4231 (2026-07-27→28: 6-way sweep fan-out, load 118/28 cores,
WindowServer watchdog-killed 5×, `loom-daemon` crashed) diagnosed *starvation*,
not raw load, as the actual failure mode — sweep worker processes ran at
default niceness (0), competing head-to-head with WindowServer, VNC, and
system daemons for CPU under fan-out.

The build gate already ran the inverse experiment: #3985 originally niced the
*gate* itself to 19, #4020 walked that back to a milder `nice 5` after
#4044/#4046 found the original premise (CPU contention from sweeps) was a
`syspolicyd` exec-latency artifact, not real contention. But #4073/#4084
later showed the gate could still time out under genuine concurrent sweep
builds, because sweep children ran at nice 0 and out-competed the gate's
nice 5. `build-gate.sh`'s own comment (lines 63-70) flagged the alternative —
nicing sweep children *up* in the spawn path — as considered and deliberately
not done at the time.

This PR does that. With sweep children now at `nice 10` and the gate at
`nice 5`, the gate has a real, measured, unprivileged-achievable priority
edge over sweeps (the reverse of the previous `gate 5 > sweeps 0`
relationship) — so the gate should now structurally win CPU contention
against concurrently-dispatched sweep builds, addressing the #4084 premise
as a side effect rather than requiring dispatch-suppression alone.

## Testing

- `defaults/scripts/tests/test-spawn-claude.sh`: 119/119 pass, including 12
  new cases covering default niceness, `LOOM_SWEEP_NICE=0` disable, the
  `LOOM_SWEEP_NICENESS` env override, the `autonomous.spawnNiceness` /
  `autonomous.spawnTaskpolicyClass` config knobs (env > config > default
  precedence), taskpolicy invocation, and the re-exec-loop sentinel guard.
- `defaults/scripts/tests/test-spawn-worker.sh`: 26/26 pass (unaffected —
  doc-only change there).
- `cargo test --workspace --lib --bins`: 1489/1490 pass; the one failure
  (`terminal::claude_config::tests::test_setup_creates_fallback_state_when_no_home_state`)
  is a pre-existing order-dependent flake unrelated to this change — it
  passes cleanly in isolation.
- `shellcheck -x defaults/scripts/spawn-claude.sh`: clean.
- `defaults/docs/build-gate.md`'s niceness-history section updated to record
  the inversion as now implemented.

`scripts/test-installer.sh` (the bash installer suite the build gate also
runs) was still in flight at authoring time under heavy host contention from
several other concurrent sweeps on this machine — an unrelated, pre-existing
`syspolicyd`-style scheduling artifact (0% CPU stalls under parallel builds).
The gate will re-run it in CI.
