### PR TITLE
fix(hooks): make Bash-write redirection detection quote-aware (#4245)

### DIFF
--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -969,6 +969,81 @@ function qsplit(s,   out, n, i, c, j, qc, ci, inner, SQ, DQ) {
 }
 '
 
+# =============================================================================
+# QUOTE-AWARE REDIRECTION MASKING (#4245)
+#
+# extract_write_targets() (below) recognizes `>`/`>>` redirection by splitting
+# a qsplit()-segmented command on whitespace and pattern-matching each token —
+# but that whitespace split is NOT quote-aware, so a `>` that is DATA inside a
+# quoted argument (e.g. `gh issue create --body "... env > config > default
+# ..."`) can land in its own whitespace-bounded "token" and be misread as a
+# real redirection operator, manufacturing a phantom write target and denying
+# a command that writes nothing to the filesystem (#4245; same failure class
+# as the #3755 qsplit()/#3679 strip_literal_text() quoting fixes above).
+#
+# mask_gt() walks the string tracking quote state (single-quoted,
+# double-quoted, unquoted) and replaces every `>` found INSIDE a quoted span
+# with SOH (0x01, a character that can never appear in a shell command and so
+# can never itself be mis-split into a phantom target). It otherwise returns
+# the input UNCHANGED byte-for-byte (same length, same whitespace positions),
+# so a caller can split both the original and the masked string on whitespace
+# and get IDENTICAL token boundaries — the masked tokens are used only to
+# DECIDE whether a token is a real (unquoted) redirection operator; the
+# ORIGINAL tokens are still used to extract the actual target text.
+#
+# Deliberately does NOT model backslash-escaped quotes -- same simplification
+# qsplit() (above) and strip_literal_text() already accept for this file's
+# other quote-tracking scans, and for good reason beyond just consistency: the
+# input mask_gt() actually receives (COMMAND_ASK_SCAN, see extract_write_targets()
+# below) has typically already been through strip_literal_text()'s OWN
+# escape-blind redaction, which can shift a quote's effective position (e.g. an
+# escaped `\"` inside a redacted --body value loses its backslash, since the
+# redaction's own quote-matching stops at the first bare `"` it finds). Layering
+# a stricter, escape-AWARE scan on top of that already-escape-blind text would
+# only desynchronize the two passes' quote parity -- worse, in the wrong
+# direction (masking too little). Matching qsplit()'s exact toggle-on-every-
+# quote-char behavior keeps both passes' parity in agreement. Same accepted
+# risk direction as qsplit(): pathological unbalanced-quote input could in
+# theory shift parity and mis-mask a genuine unquoted `>`, but that is the same
+# best-effort risk this file already accepts for `;|&` segmentation -- never a
+# NEW risk introduced here. An unterminated quote (no matching close before
+# end-of-string) just runs to the end of the string in that quote state --
+# never crashes, never mis-indexes.
+# =============================================================================
+_MASKGT_AWK='
+function mask_gt(s,   out, n, i, c, mode, SQ, DQ, MASK) {
+    SQ = sprintf("%c", 39)    # single quote
+    DQ = sprintf("%c", 34)    # double quote
+    MASK = sprintf("%c", 1)   # SOH -- placeholder for a quoted ">" (never a real char)
+    out = ""
+    n = length(s)
+    i = 1
+    mode = 0   # 0 = unquoted, 1 = single-quoted, 2 = double-quoted
+    while (i <= n) {
+        c = substr(s, i, 1)
+        if (mode == 0) {
+            if (c == SQ) { mode = 1; out = out c; i++; continue }
+            if (c == DQ) { mode = 2; out = out c; i++; continue }
+            out = out c
+            i++
+            continue
+        }
+        if (mode == 1) {
+            # Single-quoted: only the matching quote ends the span.
+            if (c == SQ) { mode = 0; out = out c; i++; continue }
+            out = out (c == ">" ? MASK : c)
+            i++
+            continue
+        }
+        # mode == 2 (double-quoted): only the matching quote ends the span.
+        if (c == DQ) { mode = 0; out = out c; i++; continue }
+        out = out (c == ">" ? MASK : c)
+        i++
+    }
+    return out
+}
+'
+
 # Parse force-op segments out of a command, emitting one TAB-separated
 # "<cpath>\t<target>" line per genuine git force-push / hard-reset. Portable awk
 # only (mirrors extract_rm_targets / lifecycle_or_cloud_reason segment parsing):
@@ -1532,18 +1607,25 @@ extract_rm_targets() {
 #
 # NOT a full shell parser: like parse_force_ops / extract_rm_targets, splitting
 # a segment into tokens is plain whitespace splitting (not quote-aware), so a
-# quoted argument containing a literal space can be mis-split. The caller
-# feeds this the ASK-tier working copy (COMMAND_ASK_SCAN — comment-stripped
-# AND literal-text-redacted, i.e. --body/-m/--title/--notes/--comment values
-# are replaced with same-length placeholder text) specifically so a `>` that
-# merely appears INSIDE such a quoted value (e.g. `git commit -m "a > b"`)
-# cannot manufacture a phantom target. Any remaining false positive from an
-# unredacted quote resolves to, at worst, an extra deny on a target that isn't
-# really a write (safe direction) or a missed target (also safe — the fail-
-# open contract this file uses everywhere: ambiguity never widens a deny).
+# quoted argument containing a literal space can be mis-split. The `>`/`>>`
+# redirection scan below is the one exception: it is quote-aware (#4245) via
+# mask_gt() — a `>` inside a quoted argument (e.g. `gh issue create --body
+# "... env > config > default ..."`) is never treated as a redirection
+# operator, regardless of whether the caller's literal-text redaction (next
+# paragraph) already removed it. The caller ALSO feeds this the ASK-tier
+# working copy (COMMAND_ASK_SCAN — comment-stripped AND literal-text-redacted,
+# i.e. --body/-m/--title/--notes/--comment values are replaced with
+# same-length placeholder text) as a second, independent narrowing so a `>`
+# that merely appears INSIDE such a quoted value (e.g. `git commit -m "a > b"`)
+# cannot manufacture a phantom target even in the (non-`>`) tee/sed/cp/mv
+# target-extraction paths below, which stay plain-whitespace-split. Any
+# remaining false positive resolves to, at worst, an extra deny on a target
+# that isn't really a write (safe direction) or a missed target (also safe —
+# the fail-open contract this file uses everywhere: ambiguity never widens a
+# deny).
 # =============================================================================
 extract_write_targets() {
-    printf '%s' "$1" | awk -v startcwd="$2" "$_QSPLIT_AWK"'
+    printf '%s' "$1" | awk -v startcwd="$2" "$_QSPLIT_AWK""$_MASKGT_AWK"'
     BEGIN {
         SEP = sprintf("%c", 31)
         curcwd = startcwd
@@ -1560,6 +1642,15 @@ extract_write_targets() {
 
             m = split(seg, toks, /[ \t]+/)
             if (m < 1) continue
+
+            # Quote-aware parallel tokenization (#4245): mseg is byte-for-byte
+            # identical to seg except a `>` inside a quoted span is replaced
+            # with an SOH placeholder, so whitespace splitting yields the SAME
+            # token boundaries (mm == m always) but mtoks[] can be tested for
+            # a REAL (unquoted) redirection operator without ever matching a
+            # `>` that was only quoted data.
+            mseg = mask_gt(seg)
+            mm = split(mseg, mtoks, /[ \t]+/)
 
             if (toks[1] == "cd") {
                 if (m >= 2 && toks[2] != "" && toks[2] != "-") {
@@ -1606,21 +1697,25 @@ extract_write_targets() {
             # >/>>  redirection — token-boundary detection only (never a
             # mid-token char scan), so scanning stays anchored to whitespace
             # boundaries rather than manufacturing a target out of a `>`
-            # sitting inside an already-multi-char token.
+            # sitting inside an already-multi-char token. The MATCH test reads
+            # mtoks[] (quote-masked, #4245) so a `>` that is only quoted DATA
+            # can never match as an operator; the actual target text is still
+            # read from the ORIGINAL toks[] (unmasked) once a real operator is
+            # confirmed.
             for (j = 1; j <= m; j++) {
-                t = toks[j]
-                if (t == "") continue
-                if (t ~ /^[0-9]*>>?$/) {
+                mt = mtoks[j]
+                if (mt == "") continue
+                if (mt ~ /^[0-9]*>>?$/) {
                     # Bare operator token. Dup-to-fd (`> &1`) is recognized by
                     # the NEXT token starting with `&` and excluded.
-                    if (j + 1 <= m && toks[j+1] != "" && toks[j+1] !~ /^&/) {
+                    if (j + 1 <= m && toks[j+1] != "" && mtoks[j+1] !~ /^&/) {
                         print curcwd SEP toks[j+1]
                     }
                     continue
                 }
-                if (t ~ /^[0-9]*>>?[^ \t&]/) {
+                if (mt ~ /^[0-9]*>>?[^ \t&]/) {
                     # Attached form (`>file`, `2>file`, `>>file`).
-                    op = t
+                    op = toks[j]
                     sub(/^[0-9]*>>?/, "", op)
                     if (op != "") print curcwd SEP op
                 }
@@ -1876,7 +1971,7 @@ if worktree_isolation_guard_enabled && \
             _WT_WRITE_BASE_DONE=1
         fi
         if _any_managed_worktree_exists "$_WT_WRITE_BASE"; then
-            deny "BLOCKED: Bash-tool write to '${_wabs}' resolves to the main repository checkout ('${_WT_MAIN_ROOT}'), but a Loom-managed worktree exists for this session. This is a worktree-isolation bypass via Bash redirection/tee/sed -i/cp/mv — do NOT retry the write through Bash. cd into your issue worktree (.loom/worktrees/issue-<N>) and write there instead. (#4178)" "worktree-write-confinement"
+            deny "BLOCKED: Bash-tool write to '${_wabs}' resolves to the main repository checkout ('${_WT_MAIN_ROOT}'), but a Loom-managed worktree exists elsewhere in this repository (this check cannot verify it belongs to the acting session — see #4245). This is a worktree-isolation bypass via Bash redirection/tee/sed -i/cp/mv — do NOT retry the write through Bash. cd into your issue worktree (.loom/worktrees/issue-<N>) and write there instead. (#4178)" "worktree-write-confinement"
         fi
     done <<< "$WRITE_TARGETS"
 fi

--- a/.loom/hooks/guard-worktree-paths.sh
+++ b/.loom/hooks/guard-worktree-paths.sh
@@ -255,4 +255,4 @@ if path_derived_allow "$NORM_PATH"; then
     exit 0
 fi
 
-emit_deny "BLOCKED: Edit/Write path '${NORM_PATH}' resolves to the main repository checkout ('${MAIN_ROOT}'), but a Loom-managed worktree exists for this session. Builders must write inside their issue worktree (.loom/worktrees/issue-<N>), never the main checkout. Do NOT retry this write via Bash redirection/tee/sed -i/cp/mv -- that is also confined (guard-destructive-generic.sh, #4178) and denied for the same reason. cd into your issue worktree and write there instead. (#4007)"
+emit_deny "BLOCKED: Edit/Write path '${NORM_PATH}' resolves to the main repository checkout ('${MAIN_ROOT}'), but a Loom-managed worktree exists elsewhere in this repository (this check cannot verify it belongs to the acting session — see #4245). Builders must write inside their issue worktree (.loom/worktrees/issue-<N>), never the main checkout. Do NOT retry this write via Bash redirection/tee/sed -i/cp/mv -- that is also confined (guard-destructive-generic.sh, #4178) and denied for the same reason. cd into your issue worktree and write there instead. (#4007)"

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -969,6 +969,81 @@ function qsplit(s,   out, n, i, c, j, qc, ci, inner, SQ, DQ) {
 }
 '
 
+# =============================================================================
+# QUOTE-AWARE REDIRECTION MASKING (#4245)
+#
+# extract_write_targets() (below) recognizes `>`/`>>` redirection by splitting
+# a qsplit()-segmented command on whitespace and pattern-matching each token —
+# but that whitespace split is NOT quote-aware, so a `>` that is DATA inside a
+# quoted argument (e.g. `gh issue create --body "... env > config > default
+# ..."`) can land in its own whitespace-bounded "token" and be misread as a
+# real redirection operator, manufacturing a phantom write target and denying
+# a command that writes nothing to the filesystem (#4245; same failure class
+# as the #3755 qsplit()/#3679 strip_literal_text() quoting fixes above).
+#
+# mask_gt() walks the string tracking quote state (single-quoted,
+# double-quoted, unquoted) and replaces every `>` found INSIDE a quoted span
+# with SOH (0x01, a character that can never appear in a shell command and so
+# can never itself be mis-split into a phantom target). It otherwise returns
+# the input UNCHANGED byte-for-byte (same length, same whitespace positions),
+# so a caller can split both the original and the masked string on whitespace
+# and get IDENTICAL token boundaries — the masked tokens are used only to
+# DECIDE whether a token is a real (unquoted) redirection operator; the
+# ORIGINAL tokens are still used to extract the actual target text.
+#
+# Deliberately does NOT model backslash-escaped quotes -- same simplification
+# qsplit() (above) and strip_literal_text() already accept for this file's
+# other quote-tracking scans, and for good reason beyond just consistency: the
+# input mask_gt() actually receives (COMMAND_ASK_SCAN, see extract_write_targets()
+# below) has typically already been through strip_literal_text()'s OWN
+# escape-blind redaction, which can shift a quote's effective position (e.g. an
+# escaped `\"` inside a redacted --body value loses its backslash, since the
+# redaction's own quote-matching stops at the first bare `"` it finds). Layering
+# a stricter, escape-AWARE scan on top of that already-escape-blind text would
+# only desynchronize the two passes' quote parity -- worse, in the wrong
+# direction (masking too little). Matching qsplit()'s exact toggle-on-every-
+# quote-char behavior keeps both passes' parity in agreement. Same accepted
+# risk direction as qsplit(): pathological unbalanced-quote input could in
+# theory shift parity and mis-mask a genuine unquoted `>`, but that is the same
+# best-effort risk this file already accepts for `;|&` segmentation -- never a
+# NEW risk introduced here. An unterminated quote (no matching close before
+# end-of-string) just runs to the end of the string in that quote state --
+# never crashes, never mis-indexes.
+# =============================================================================
+_MASKGT_AWK='
+function mask_gt(s,   out, n, i, c, mode, SQ, DQ, MASK) {
+    SQ = sprintf("%c", 39)    # single quote
+    DQ = sprintf("%c", 34)    # double quote
+    MASK = sprintf("%c", 1)   # SOH -- placeholder for a quoted ">" (never a real char)
+    out = ""
+    n = length(s)
+    i = 1
+    mode = 0   # 0 = unquoted, 1 = single-quoted, 2 = double-quoted
+    while (i <= n) {
+        c = substr(s, i, 1)
+        if (mode == 0) {
+            if (c == SQ) { mode = 1; out = out c; i++; continue }
+            if (c == DQ) { mode = 2; out = out c; i++; continue }
+            out = out c
+            i++
+            continue
+        }
+        if (mode == 1) {
+            # Single-quoted: only the matching quote ends the span.
+            if (c == SQ) { mode = 0; out = out c; i++; continue }
+            out = out (c == ">" ? MASK : c)
+            i++
+            continue
+        }
+        # mode == 2 (double-quoted): only the matching quote ends the span.
+        if (c == DQ) { mode = 0; out = out c; i++; continue }
+        out = out (c == ">" ? MASK : c)
+        i++
+    }
+    return out
+}
+'
+
 # Parse force-op segments out of a command, emitting one TAB-separated
 # "<cpath>\t<target>" line per genuine git force-push / hard-reset. Portable awk
 # only (mirrors extract_rm_targets / lifecycle_or_cloud_reason segment parsing):
@@ -1532,18 +1607,25 @@ extract_rm_targets() {
 #
 # NOT a full shell parser: like parse_force_ops / extract_rm_targets, splitting
 # a segment into tokens is plain whitespace splitting (not quote-aware), so a
-# quoted argument containing a literal space can be mis-split. The caller
-# feeds this the ASK-tier working copy (COMMAND_ASK_SCAN — comment-stripped
-# AND literal-text-redacted, i.e. --body/-m/--title/--notes/--comment values
-# are replaced with same-length placeholder text) specifically so a `>` that
-# merely appears INSIDE such a quoted value (e.g. `git commit -m "a > b"`)
-# cannot manufacture a phantom target. Any remaining false positive from an
-# unredacted quote resolves to, at worst, an extra deny on a target that isn't
-# really a write (safe direction) or a missed target (also safe — the fail-
-# open contract this file uses everywhere: ambiguity never widens a deny).
+# quoted argument containing a literal space can be mis-split. The `>`/`>>`
+# redirection scan below is the one exception: it is quote-aware (#4245) via
+# mask_gt() — a `>` inside a quoted argument (e.g. `gh issue create --body
+# "... env > config > default ..."`) is never treated as a redirection
+# operator, regardless of whether the caller's literal-text redaction (next
+# paragraph) already removed it. The caller ALSO feeds this the ASK-tier
+# working copy (COMMAND_ASK_SCAN — comment-stripped AND literal-text-redacted,
+# i.e. --body/-m/--title/--notes/--comment values are replaced with
+# same-length placeholder text) as a second, independent narrowing so a `>`
+# that merely appears INSIDE such a quoted value (e.g. `git commit -m "a > b"`)
+# cannot manufacture a phantom target even in the (non-`>`) tee/sed/cp/mv
+# target-extraction paths below, which stay plain-whitespace-split. Any
+# remaining false positive resolves to, at worst, an extra deny on a target
+# that isn't really a write (safe direction) or a missed target (also safe —
+# the fail-open contract this file uses everywhere: ambiguity never widens a
+# deny).
 # =============================================================================
 extract_write_targets() {
-    printf '%s' "$1" | awk -v startcwd="$2" "$_QSPLIT_AWK"'
+    printf '%s' "$1" | awk -v startcwd="$2" "$_QSPLIT_AWK""$_MASKGT_AWK"'
     BEGIN {
         SEP = sprintf("%c", 31)
         curcwd = startcwd
@@ -1560,6 +1642,15 @@ extract_write_targets() {
 
             m = split(seg, toks, /[ \t]+/)
             if (m < 1) continue
+
+            # Quote-aware parallel tokenization (#4245): mseg is byte-for-byte
+            # identical to seg except a `>` inside a quoted span is replaced
+            # with an SOH placeholder, so whitespace splitting yields the SAME
+            # token boundaries (mm == m always) but mtoks[] can be tested for
+            # a REAL (unquoted) redirection operator without ever matching a
+            # `>` that was only quoted data.
+            mseg = mask_gt(seg)
+            mm = split(mseg, mtoks, /[ \t]+/)
 
             if (toks[1] == "cd") {
                 if (m >= 2 && toks[2] != "" && toks[2] != "-") {
@@ -1606,21 +1697,25 @@ extract_write_targets() {
             # >/>>  redirection — token-boundary detection only (never a
             # mid-token char scan), so scanning stays anchored to whitespace
             # boundaries rather than manufacturing a target out of a `>`
-            # sitting inside an already-multi-char token.
+            # sitting inside an already-multi-char token. The MATCH test reads
+            # mtoks[] (quote-masked, #4245) so a `>` that is only quoted DATA
+            # can never match as an operator; the actual target text is still
+            # read from the ORIGINAL toks[] (unmasked) once a real operator is
+            # confirmed.
             for (j = 1; j <= m; j++) {
-                t = toks[j]
-                if (t == "") continue
-                if (t ~ /^[0-9]*>>?$/) {
+                mt = mtoks[j]
+                if (mt == "") continue
+                if (mt ~ /^[0-9]*>>?$/) {
                     # Bare operator token. Dup-to-fd (`> &1`) is recognized by
                     # the NEXT token starting with `&` and excluded.
-                    if (j + 1 <= m && toks[j+1] != "" && toks[j+1] !~ /^&/) {
+                    if (j + 1 <= m && toks[j+1] != "" && mtoks[j+1] !~ /^&/) {
                         print curcwd SEP toks[j+1]
                     }
                     continue
                 }
-                if (t ~ /^[0-9]*>>?[^ \t&]/) {
+                if (mt ~ /^[0-9]*>>?[^ \t&]/) {
                     # Attached form (`>file`, `2>file`, `>>file`).
-                    op = t
+                    op = toks[j]
                     sub(/^[0-9]*>>?/, "", op)
                     if (op != "") print curcwd SEP op
                 }
@@ -1876,7 +1971,7 @@ if worktree_isolation_guard_enabled && \
             _WT_WRITE_BASE_DONE=1
         fi
         if _any_managed_worktree_exists "$_WT_WRITE_BASE"; then
-            deny "BLOCKED: Bash-tool write to '${_wabs}' resolves to the main repository checkout ('${_WT_MAIN_ROOT}'), but a Loom-managed worktree exists for this session. This is a worktree-isolation bypass via Bash redirection/tee/sed -i/cp/mv — do NOT retry the write through Bash. cd into your issue worktree (.loom/worktrees/issue-<N>) and write there instead. (#4178)" "worktree-write-confinement"
+            deny "BLOCKED: Bash-tool write to '${_wabs}' resolves to the main repository checkout ('${_WT_MAIN_ROOT}'), but a Loom-managed worktree exists elsewhere in this repository (this check cannot verify it belongs to the acting session — see #4245). This is a worktree-isolation bypass via Bash redirection/tee/sed -i/cp/mv — do NOT retry the write through Bash. cd into your issue worktree (.loom/worktrees/issue-<N>) and write there instead. (#4178)" "worktree-write-confinement"
         fi
     done <<< "$WRITE_TARGETS"
 fi

--- a/defaults/hooks/guard-worktree-paths.sh
+++ b/defaults/hooks/guard-worktree-paths.sh
@@ -255,4 +255,4 @@ if path_derived_allow "$NORM_PATH"; then
     exit 0
 fi
 
-emit_deny "BLOCKED: Edit/Write path '${NORM_PATH}' resolves to the main repository checkout ('${MAIN_ROOT}'), but a Loom-managed worktree exists for this session. Builders must write inside their issue worktree (.loom/worktrees/issue-<N>), never the main checkout. Do NOT retry this write via Bash redirection/tee/sed -i/cp/mv -- that is also confined (guard-destructive-generic.sh, #4178) and denied for the same reason. cd into your issue worktree and write there instead. (#4007)"
+emit_deny "BLOCKED: Edit/Write path '${NORM_PATH}' resolves to the main repository checkout ('${MAIN_ROOT}'), but a Loom-managed worktree exists elsewhere in this repository (this check cannot verify it belongs to the acting session — see #4245). Builders must write inside their issue worktree (.loom/worktrees/issue-<N>), never the main checkout. Do NOT retry this write via Bash redirection/tee/sed -i/cp/mv -- that is also confined (guard-destructive-generic.sh, #4178) and denied for the same reason. cd into your issue worktree and write there instead. (#4007)"

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -2188,6 +2188,31 @@ assert_allow "write-confinement: fd-dup 2>&1 is not treated as a file write" \
     "echo x 2>&1 | tee /tmp/loom-test-$$-log" "$WT_REPO"
 
 # -------------------------------------------------------------------------
+# Quote-aware `>` masking (#4245) -- mask_gt() in extract_write_targets().
+#
+# A `>` that is only DATA inside a quoted --body/--title/... value (e.g. prose
+# describing the env > config > default precedence order) must never be
+# misread as a shell redirection operator, no matter how many such quoted `>`
+# characters the value contains. This is the exact false positive reported in
+# #4245: `gh issue create --body "... env > config > default ..."` was denied
+# as a "worktree-isolation bypass" even though `gh issue create` writes
+# nothing to the filesystem.
+assert_allow "write-confinement (#4245): gh issue create --body with a quoted '>' allows" \
+    "gh issue create --title \"Test\" --label \"loom:triage\" --body \"a > b\"" "$WT_REPO"
+assert_allow "write-confinement (#4245): multiple quoted '>' in one --body value allows" \
+    "gh issue create --title \"Test\" --body \"... following the env > config > default precedence ...\"" "$WT_REPO"
+assert_allow "write-confinement (#4245): quoted '>' inside a single-quoted value allows" \
+    "echo 'a > b'" "$WT_REPO"
+
+# Regression: a quote-aware mask must only NARROW detection, never widen it --
+# a REAL (unquoted) redirection into the main checkout must still deny even
+# when the same command also contains a quoted `>` elsewhere.
+assert_deny "write-confinement (#4245): quoted '>' alongside a real unquoted '>' still denies" \
+    "echo \"a > b\" > $WT_REPO/defaults/hooks/f.sh" "$WT_REPO"
+assert_deny "write-confinement (#4245): bare '>' redirection still denies (regression)" \
+    "echo x > $WT_REPO/defaults/hooks/g.sh" "$WT_REPO"
+
+# -------------------------------------------------------------------------
 # Regression (#4210): CWD is the builder's own LINKED worktree, and the write
 # targets the MAIN checkout by absolute path (or via `cd $MAIN`). This is the
 # canonical builder setup (`cd .loom/worktrees/issue-N`). The guard must key


### PR DESCRIPTION
Closes #4245

## Root cause

`guard-destructive-generic.sh`'s Bash-tool write-confinement check (#4178)
recognizes `>`/`>>` redirection in `extract_write_targets()` by splitting a
`qsplit()`-segmented command on whitespace and pattern-matching each token.
That whitespace split was **not quote-aware**: a `>` that is only prose DATA
inside a quoted flag value (e.g. `gh issue create --body "... following the
env > config > default precedence ..."`) could land in its own
whitespace-bounded "token" and be misread as a real redirection operator,
manufacturing a phantom write target and denying a command that writes
nothing to the filesystem.

The existing mitigation (`strip_literal_text()` redacting
`--body`/`-m`/`--title`/`--notes`/`--comment` values before the scan) narrows
most cases, but is not a structural fix — `extract_write_targets()` itself had
no notion of quoting for `>`.

## Fix

Added `mask_gt()`, a small quote-tracking awk state machine (single-quoted /
double-quoted / unquoted), that replaces any `>` found **inside** a quoted
span with a placeholder byte (SOH, 0x01 — a character that can never appear
in a real shell command and so can never itself be mis-split into a phantom
target). It returns the string byte-for-byte unchanged otherwise, so
whitespace-splitting the masked string yields IDENTICAL token boundaries to
the original — the masked tokens are used only to decide whether a token is a
*real* (unquoted) redirection operator, while the original (unmasked) tokens
are still used to extract the actual write target text.

`mask_gt()` deliberately does **not** model backslash-escaped quotes, matching
the existing simplification `qsplit()` and `strip_literal_text()` already use
elsewhere in this file. This isn't just for consistency: the text `mask_gt()`
receives has typically already been through `strip_literal_text()`'s own
escape-blind redaction, which can shift a quote's effective position (an
escaped `\"` inside a redacted `--body` value loses its backslash during
redaction). Layering a stricter, escape-aware scan on top of that
already-escape-blind text actually desynchronizes the two passes' quote
parity in the wrong direction (masking too little) — verified by hand-tracing
and testing both variants against an escaped-quote case. Matching `qsplit()`'s
exact toggle-on-every-quote-char behavior keeps the two passes' parity in
agreement.

Also (per the issue's third acceptance-criteria bullet, scoped to a
quick/safe wording fix rather than a full session-identity refactor): the
worktree-write-confinement and Edit/Write worktree-path deny messages no
longer claim "a Loom-managed worktree exists **for this session**" — that
claim was never actually verified (the check is repo-global: it fires whenever
ANY managed worktree exists anywhere in the repo, not necessarily one owned by
the acting session). The messages now say a worktree "exists elsewhere in
this repository" and note the check cannot verify session ownership. No
behavior change, wording only. A full session-scoped fix would need an ambient
session-identity signal that doesn't currently exist in the hook's input
(PreToolUse hooks receive no session/task ID) — that's a larger effort than
this issue's primary quoting bug and is left for separate follow-up if wanted.

## Tests

Added to `tests/hooks/test-guard-destructive.sh` (write-confinement section,
`#4245`):
- `gh issue create --body "a > b"` allows (the issue's own repro)
- multiple quoted `>` in one `--body` value (the exact reported phrase)
  allows
- quoted `>` inside a single-quoted value allows
- regression: a quoted `>` alongside a REAL unquoted `>` in the same command
  still denies (masking must narrow, never widen)
- regression: a bare unquoted `>` redirection still denies

All existing tests in `tests/hooks/test-guard-destructive.sh`,
`defaults/hooks/tests/test-guard-worktree-paths.sh` (20/20,
including the `.loom/` vs `defaults/` byte-identical sync check), and
`tests/hooks/test-guard-destructive-dispatcher.sh` (7/7) pass.

Updated `.loom/hooks/guard-destructive-generic.sh` and
`.loom/hooks/guard-worktree-paths.sh` (the tracked, installed copies of these
hooks in this self-hosting repo) to stay byte-identical to their
`defaults/hooks/` source, matching this repo's existing resync convention.
