### PR TITLE
docs(judge): stale loom:reviewing claim reclaim rule

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -50,7 +50,7 @@
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:reviewing
-  description: "Judge is actively reviewing this PR. Applied by: Judge only (claim label)."
+  description: "Judge is actively reviewing this PR. Applied by: Judge only (claim label). Stale after LOOM_STALE_REVIEWING_MINUTES (default 30) with no follow-up comment — may be reclaimed by a new Judge."
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:review-requested

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -220,7 +220,7 @@ fi
 ### Primary Queue (Priority)
 
 1. **Find work**: `gh pr list --label="loom:review-requested" --state=open`
-2. **Claim PR**: `gh pr edit <number> --add-label "loom:reviewing"` to signal you're working on it
+2. **Claim PR** (staleness-aware — see "Stale `loom:reviewing` Claim Check" immediately below before running this): `gh pr edit <number> --add-label "loom:reviewing"` to signal you're working on it
 3. **Check merge state**: Check for conflicts and attempt automated rebase if DIRTY (see Automated Rebase for DIRTY PRs below)
    ```bash
    MERGE_STATE=$(gh pr view <number> --json mergeStateStatus --jq '.mergeStateStatus')
@@ -243,6 +243,63 @@ fi
 11. **Update labels** (⚠️ NEVER use `gh pr review` - see warning at top of file). **The label update is the PRIMARY deliverable — always run it immediately after the comment using `&&`:**
    - If approved: `gh pr comment ... && gh pr edit <number> --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:pr"` (blue badge - ready for Champion auto-merge)
    - If changes needed: `gh pr comment ... && gh pr edit <number> --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:changes-requested"` (amber badge - Doctor will address)
+
+### Stale `loom:reviewing` Claim Check (Step 2)
+
+Run this **before** claiming a PR in step 2 above. `gh pr list
+--label="loom:review-requested"` can surface a PR that another Judge already
+claimed (`loom:review-requested` and `loom:reviewing` coexist while a review
+is in progress) — including one whose claiming Judge's process died mid-review
+(parent sweep crash). Without this check, that dead claim blocks the PR from
+ever being reviewed again. This is the minutes-scale analog of the
+`loom:building` staleness convention (`LOOM_STALE_BUILDING_HOURS`,
+`loom-daemon/src/claim_reconciliation.rs`) — reviews run 5–15 minutes in
+practice, not hours, so the grace period is minutes, not hours.
+
+**If the PR does NOT carry `loom:reviewing`:** proceed to claim as today — no
+behavior change: `gh pr edit <number> --add-label "loom:reviewing"`.
+
+**If the PR DOES carry `loom:reviewing`:** determine the claim's age and
+whether anyone has commented since the claim was made:
+
+```bash
+N=<pr-number>
+CLAIMED_AT=$(gh api "repos/{owner}/{repo}/issues/$N/timeline" --paginate \
+  --jq '[.[] | select(.event=="labeled" and .label.name=="loom:reviewing")] | last | .created_at')
+COMMENTS_AFTER=$(gh api "repos/{owner}/{repo}/issues/$N/comments" \
+  --jq --arg t "$CLAIMED_AT" '[.[] | select(.created_at > $t)] | length')
+```
+
+Then decide:
+
+| Condition | Verdict | Action |
+|-----------|---------|--------|
+| Claim age < `LOOM_STALE_REVIEWING_MINUTES` (default **30**), OR `COMMENTS_AFTER > 0` | **Fresh** — a Judge is actively working this PR | **Do not stomp the claim.** Skip this PR and continue the batch to the next candidate PR. |
+| Claim age ≥ `LOOM_STALE_REVIEWING_MINUTES` AND `COMMENTS_AFTER == 0` | **Stale** — the claiming Judge's process almost certainly died mid-review | Reclaim (see below), then proceed with the normal review from step 3. |
+| Timeline API call fails or returns empty (`CLAIMED_AT` unset) | **Unknown — fail safe** | Treat as **fresh**. Never stomp a claim on API failure or missing data. |
+
+**Reclaiming a stale claim:**
+
+```bash
+gh pr edit $N --remove-label "loom:reviewing"
+gh pr comment $N --body "Reclaiming stale loom:reviewing claim (age > ${LOOM_STALE_REVIEWING_MINUTES:-30}m, no follow-up comment) — a prior Judge's parent sweep likely died mid-review."
+gh pr edit $N --add-label "loom:reviewing"
+# Continue to step 3 (Check merge state) and evaluate normally
+```
+
+**Env var**: `LOOM_STALE_REVIEWING_MINUTES` (default **30**) — named to
+mirror `LOOM_STALE_BUILDING_HOURS` (`loom-daemon/src/claim_reconciliation.rs`,
+the analogous no-record staleness threshold for `loom:building` claims), but
+on a **minutes**, not hours, scale, since review turnaround (5–15 minutes) is
+two orders of magnitude faster than a build.
+
+**Applies everywhere a Judge claims a PR from a multi-PR pass** — not just
+this single-PR narrative. This same check-then-claim rule governs the batch
+loop in "Autonomous mode (configured with targetInterval)" under Completion
+below, and any cron-invoked pass over `loom:review-requested` PRs: a
+cron-invoked Judge and a `/loom:sweep`-dispatched Judge must apply the
+identical rule so neither stomps the other's fresh claim nor stalls behind a
+dead one.
 
 **Pre-approval checklist** (verify before executing approval commands):
 - [ ] I am using `gh pr comment`, NOT `gh pr review`
@@ -1388,5 +1445,7 @@ If no work was found (no PRs with `loom:review-requested`), report that and stop
 4. Once the queue is empty, execute `/clear` to reset context for the next interval
 
 This batch processing prevents PRs from waiting unnecessarily when multiple are queued. Under the wave-parallel sweep model, several sweeps can land PRs at once, so the judge must drain the queue efficiently rather than processing one PR per interval.
+
+**Apply the "Stale `loom:reviewing` Claim Check" (see Primary Queue, step 2) to every PR in this loop, not just the first.** A `loom:review-requested` PR already carrying a fresh `loom:reviewing` claim from a concurrently-running Judge must be skipped (continue to the next PR in the batch); one carrying a stale claim is reclaimed then reviewed. This keeps a cron-invoked batch pass and a `/loom:sweep`-dispatched pass consistent with each other.
 
 If no work is available at the start of an iteration, execute `/clear` and wait for the next trigger.

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -267,7 +267,7 @@ N=<pr-number>
 CLAIMED_AT=$(gh api "repos/{owner}/{repo}/issues/$N/timeline" --paginate \
   --jq '[.[] | select(.event=="labeled" and .label.name=="loom:reviewing")] | last | .created_at')
 COMMENTS_AFTER=$(gh api "repos/{owner}/{repo}/issues/$N/comments" \
-  --jq --arg t "$CLAIMED_AT" '[.[] | select(.created_at > $t)] | length')
+  | jq --arg t "$CLAIMED_AT" '[.[] | select(.created_at > $t)] | length')
 ```
 
 Then decide:

--- a/defaults/.github/labels.yml
+++ b/defaults/.github/labels.yml
@@ -50,7 +50,7 @@
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:reviewing
-  description: "Judge is actively reviewing this PR. Applied by: Judge only (claim label)."
+  description: "Judge is actively reviewing this PR. Applied by: Judge only (claim label). Stale after LOOM_STALE_REVIEWING_MINUTES (default 30) with no follow-up comment — may be reclaimed by a new Judge."
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:review-requested


### PR DESCRIPTION
Closes #4258

## Summary

`loom:reviewing` is a Judge claim label with no staleness rule. When a Judge's
process dies mid-review (parent sweep crash), the claim survives indefinitely
and blocks all future review of that PR. `loom:building` already has a
staleness convention (`LOOM_STALE_BUILDING_HOURS`); this delivers the
analogous **minutes-scale** convention for `loom:reviewing` as a documented
skill/label convention (option 1 from the curator enhancement) — no new Rust
reaper code. Rust reaper-side reconciliation is out of scope here, deferred to
the companion issue #4256.

## Changes

- **`defaults/.claude/commands/loom/judge.md`** (also covers `defaults/roles/judge.md`,
  a symlink to the same file):
  - Primary Queue step 2 ("Claim PR") now points to a new "Stale `loom:reviewing`
    Claim Check" subsection that runs *before* claiming.
  - New subsection specifies the exact algorithm:
    - Not currently claimed → claim as today, no change.
    - Currently claimed → compute claim age via the labeling timeline event and
      whether any comment postdates the claim.
    - Fresh (age < `LOOM_STALE_REVIEWING_MINUTES`, default 30, OR a follow-up
      comment exists) → skip, do not stomp, continue the batch.
    - Stale (age ≥ threshold AND no follow-up comment) → remove
      `loom:reviewing`, post a one-line reclaim note, re-add `loom:reviewing`,
      then review normally.
    - Timeline API failure/empty result → fail safe to "fresh" (never stomp on
      API failure).
  - Documents `LOOM_STALE_REVIEWING_MINUTES` (default 30) alongside the naming
    parity with `LOOM_STALE_BUILDING_HOURS`
    (`loom-daemon/src/claim_reconciliation.rs`).
  - Mirrors the rule into the "Autonomous mode (batch)" completion section so a
    cron-invoked Judge and a `/loom:sweep`-dispatched Judge apply the same
    rule when draining a multi-PR queue.
- **`.github/labels.yml`** and **`defaults/.github/labels.yml`** (kept in sync):
  extended the `loom:reviewing` label description to mention the staleness
  rule and default threshold.
- **`.github/CONFIGURATION.md` / `defaults/.github/CONFIGURATION.md`**: checked —
  these only have a short table summary ("Judge is actively reviewing"), not a
  verbatim restatement of the label description, so left unchanged per scope.
- **`loom-tools/src/loom_tools/forge_cli.py`**: checked — the `loom:reviewing`
  references there are generic `pr edit` CLI usage examples, unrelated to the
  staleness rule; no change needed.

## Out of scope (deferred to #4256)

- No changes to `loom-daemon/src/sweep_registry.rs` or any Rust reaper code —
  this issue is documentation/convention only.

## Test plan

- This is a markdown + YAML label-description change; no code compiles.
- `python3 -c "import yaml; yaml.safe_load(open('.github/labels.yml')); yaml.safe_load(open('defaults/.github/labels.yml'))"` — both parse cleanly.
- Confirmed `.github/labels.yml` and `defaults/.github/labels.yml` remain byte-identical after the edit.
- Read through the full updated `judge.md` to confirm the new step reads
  unambiguously and matches the surrounding structure/tone/step-numbering
  (inserted as a non-renumbering subsection so no existing "step N" reference
  elsewhere in the doc shifts).