### PR TITLE
feat(daemon): reaper-driven resume for crashed post-Builder sweeps

### DIFF
--- a/.loom/config.json
+++ b/.loom/config.json
@@ -4,7 +4,7 @@
   "autonomous": {
     "roleRunner": {
       "enabled": true,
-      "roles": ["curator", "champion"]
+      "roles": ["curator", "champion", "judge"]
     },
     "collisionDetection": {
       "enabled": true

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -107,6 +107,7 @@ issue** — the v0.10.0 set is intentionally frozen.
 | `sweep.issue.{N}.blocker` | Sweep child                     | `{reason, label_added, repo?}` |
 | `sweep.issue.{N}.exited`  | Daemon reaper (or `cancel_sweep`) | `{exit_code, duration_sec, repo?}` |
 | `sweep.issue.{N}.crashed` | Daemon reaper                   | `{checkpoint_phase, repo?}` |
+| `sweep.issue.{N}.resume_dispatched` | Daemon reaper (#4256) | `{pr, checkpoint_phase?, dispatched, repo?}` |
 | `sweep.global.dispatch`   | Daemon                          | `{sweep_id, kind}` |
 | `sweep.global.completed`  | Daemon                          | `{sweep_id, outcome}` |
 | `epic.issue.{N}.decompose` | Epic supervisor (#3842)        | `{epic, action, state}` |
@@ -2005,6 +2006,30 @@ Because that is a real per-dispatch API cost it is **off by default**; enable it
 per the config/env row above (`LOOM_DETECT_COLLISIONS=1` or
 `autonomous.collisionDetection.enabled = true`, precedence **env > config >
 default**) on the hosts sharing a backlog while you take the measurement.
+
+**Reaper-driven resume (#4256): the guard's own escape valve.** A sweep that
+dies **after** its Builder opened a PR would otherwise strand that PR at
+`loom:review-requested` forever — the #4123 guard above correctly refuses
+every *ordinary* re-dispatch of the issue (an open PR looks identical to
+fresh work the instant the sweep exits), but nothing else ever re-dispatches
+it, so the checkpoint-resume machinery (#3373, which would skip straight to
+Judge) never gets a chance to run. `SweepRegistry::reap_once()` closes this
+gap directly: when a crashed sweep's checkpoint reads `builder-done`,
+`judge-rejected`, `judge-done`, or `doctor-done` (Builder-or-later — a
+pre-Builder `curator-done` crash gets ordinary crash handling only) **and**
+the issue still has an open linked PR, the reaper re-dispatches the *same*
+issue through a private bypass (`dispatch_resume_after_crash`) that is
+reachable **only** from the reaper — not from the work finder, the epic
+supervisor, the IPC/CLI `dispatch_sweep`, or any watchdog — and only exempts
+step 2.6 when the PR it names matches the one the guard itself would find.
+Every other dispatch path still refuses via `OpenPrDispatchError`, so
+#4123's anti-duplicate property is unchanged. The attempt is never silent:
+a `sweep.issue.{N}.resume_dispatched` event (`{pr, checkpoint_phase?,
+dispatched, repo?}`) is published — with `dispatched: false` on the rare
+case the resume dispatch call itself fails — and narrated over Safehouse
+(when enabled) as a `handoff`. The `restore_label_to_ready` operator-park
+guard (#4206) still applies: an issue carrying `loom:blocked` is never
+resume-dispatched.
 
 ### Cross-host soft claim over safehouse (#4028, Phase 1 of #4028)
 

--- a/loom-daemon/src/safehouse.rs
+++ b/loom-daemon/src/safehouse.rs
@@ -402,6 +402,7 @@ fn decode_exit_code_annotation(code: i32) -> &'static str {
 /// | `SweepBlocker` | `handoff` | `<repo>#n · BLOCKED — <reason>` |
 /// | `SweepExited` | `ack` | `<repo>#n · done ✓ · <dur>` or `<repo>#n · failed ✗ · exit <code>[ (decoded)] · <dur>` |
 /// | `SweepCrashed` | `handoff` | `<repo>#n · crashed ✗ at <checkpoint_phase> — resumable (checkpoint kept)` |
+/// | `SweepResumeDispatched` (#4256) | `handoff` | `<repo>#n · reaper resumed crashed sweep at <phase> (open PR #m) — resuming without operator intervention` (or a "still stranded" variant when the resume dispatch itself failed) |
 ///
 /// `SweepGlobalCompleted` is intentionally **not** narrated: it carries only a
 /// `sweep_id` (no issue number), and `SweepExited` already emits the completion
@@ -485,6 +486,33 @@ pub fn event_to_envelope(event: &Event) -> Option<Envelope> {
                     "{} · crashed ✗ at {phase} — resumable (checkpoint kept)",
                     repo_issue_prefix(repo.as_deref(), *issue)
                 ),
+            })
+        }
+        Event::SweepResumeDispatched {
+            issue,
+            pr,
+            checkpoint_phase,
+            dispatched,
+            repo,
+        } => {
+            let phase = checkpoint_phase.as_deref().unwrap_or("unknown");
+            let prefix = repo_issue_prefix(repo.as_deref(), *issue);
+            let body = if *dispatched {
+                format!(
+                    "{prefix} · reaper resumed crashed sweep at {phase} (open PR #{pr}) — \
+                     resuming without operator intervention"
+                )
+            } else {
+                format!(
+                    "{prefix} · reaper attempted resume at {phase} (open PR #{pr}) but the \
+                     dispatch itself failed — still stranded, needs a look"
+                )
+            };
+            Some(Envelope {
+                to: "*".to_owned(),
+                kind: "handoff".to_owned(),
+                task_id: Some(qualify_task_id(repo.as_deref(), *issue)),
+                body,
             })
         }
         // SweepGlobalCompleted (no issue number — SweepExited covers it),
@@ -1276,7 +1304,7 @@ mod tests {
     // ---- event → envelope mapping ----
 
     #[test]
-    fn maps_the_five_narrated_events() {
+    fn maps_the_narrated_events() {
         let dispatch = Event::SweepGlobalDispatch {
             sweep_id: "sweep-issue-42-1".to_owned() as SweepId,
             kind: SweepKind::Issue(42),
@@ -1338,6 +1366,36 @@ mod tests {
         let env = event_to_envelope(&crashed).unwrap();
         assert_eq!(env.kind, "handoff");
         assert_eq!(env.body, "vibesql#42 · crashed ✗ at judge — resumable (checkpoint kept)");
+
+        // Issue #4256: a successful reaper-driven resume narrates as a
+        // `handoff` naming the phase + PR, so an operator watching chat sees
+        // recovery happen without having to run `/loom:sweep --prs` by hand.
+        let resumed = Event::SweepResumeDispatched {
+            issue: 42,
+            pr: 4300,
+            checkpoint_phase: Some("builder-done".to_owned()),
+            dispatched: true,
+            repo: Some("/repos/vibesql".to_owned()),
+        };
+        let env = event_to_envelope(&resumed).unwrap();
+        assert_eq!(env.kind, "handoff");
+        assert_eq!(
+            env.body,
+            "vibesql#42 · reaper resumed crashed sweep at builder-done (open PR #4300) — \
+             resuming without operator intervention"
+        );
+
+        // A resume ATTEMPT whose own dispatch call failed still narrates —
+        // the recovery attempt must never be silent even on failure.
+        let resume_failed = Event::SweepResumeDispatched {
+            issue: 42,
+            pr: 4300,
+            checkpoint_phase: Some("builder-done".to_owned()),
+            dispatched: false,
+            repo: Some("/repos/vibesql".to_owned()),
+        };
+        let env = event_to_envelope(&resume_failed).unwrap();
+        assert!(env.body.contains("still stranded"), "got: {}", env.body);
     }
 
     #[test]

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -180,6 +180,26 @@ const RESUMABLE_CHECKPOINT_PHASES: [&str; 4] = [
     "doctor-done",
 ];
 
+/// Issue #4256 (Judge residual-risk backstop): the maximum number of
+/// consecutive reaper-driven resume dispatches for a single issue before the
+/// reaper stops resuming and leaves the PR for the periodic Judge role /
+/// operator.
+///
+/// The #4123 open-PR guard used to backstop infinite re-dispatch once a PR
+/// existed, but the resume path (`dispatch_resume_after_crash`) deliberately
+/// bypasses it. A sweep that reliably dies in the **~2s..stall window** — too
+/// slow for the sub-`insta_crash_secs` quarantine tally (#3939), too fast to
+/// ever rewrite the checkpoint or reach Judge — would otherwise reset every
+/// backstop each tick and resume forever. This small constant caps the
+/// consecutive *checkpoint-less* resume attempts per issue: any resume run
+/// that actually advances the checkpoint (real progress) resets the tally (see
+/// [`SweepRegistry::reap_once`]'s `checkpoint_written_by_run` branch), so only
+/// a genuine crash→resume→crash loop accrues toward the cap. On exhaustion the
+/// reaper stops resuming, emits a failure-visible `SweepResumeDispatched`
+/// (`dispatched: false`) event, and adds NO labels — the PR is picked up by the
+/// periodic Judge role (repo-config backstop (c)) or an operator.
+const MAX_RESUME_ATTEMPTS: u32 = 3;
+
 /// Issue #3944: which tier of the dispatch-model precedence chain supplied the
 /// resolved model. Surfaced in the daemon dispatch log line so an operator can
 /// tell *why* a child is running a given model.
@@ -1340,6 +1360,16 @@ pub struct SweepRegistry {
     /// reaper on a checkpoint-less death inside the insta-crash window; reset to
     /// zero on any terminal outcome that made real progress or exited cleanly.
     insta_crash_counts: HashMap<u32, u32>,
+    /// Consecutive reaper-driven resume dispatches per issue (Issue #4256, Judge
+    /// residual-risk backstop). Incremented each time [`reap_once`](Self::reap_once)
+    /// resume-dispatches a crashed post-Builder sweep; reset to zero when a run
+    /// advances the checkpoint (real progress — the `checkpoint_written_by_run`
+    /// branch). Once an issue reaches [`MAX_RESUME_ATTEMPTS`] consecutive
+    /// checkpoint-less resume crashes the reaper stops resuming it, replacing the
+    /// #4123 open-PR backstop that the resume path deliberately bypasses so an
+    /// issue that reliably dies in the ~2s..stall window cannot resume forever.
+    /// Keyed by issue like [`insta_crash_counts`](Self::insta_crash_counts).
+    resume_attempt_counts: HashMap<u32, u32>,
     /// Currently-quarantined issues → the instant they were quarantined (Issue
     /// #3939). The work finder skips these until the entry ages past
     /// [`QuarantineConfig::ttl`], at which point [`reap_once`](Self::reap_once)
@@ -1458,6 +1488,7 @@ impl SweepRegistry {
             review_stall_gaveup: HashSet::new(),
             quarantine_config: QuarantineConfig::default(),
             insta_crash_counts: HashMap::new(),
+            resume_attempt_counts: HashMap::new(),
             quarantined: HashMap::new(),
             pending_quarantine_release: HashSet::new(),
             detect_collisions: false,
@@ -1487,6 +1518,7 @@ impl SweepRegistry {
             review_stall_gaveup: HashSet::new(),
             quarantine_config: QuarantineConfig::default(),
             insta_crash_counts: HashMap::new(),
+            resume_attempt_counts: HashMap::new(),
             quarantined: HashMap::new(),
             pending_quarantine_release: HashSet::new(),
             detect_collisions: false,
@@ -3860,6 +3892,16 @@ impl SweepRegistry {
                             // non-clean death still counts toward quarantine.
                             if checkpoint_written_by_run(&checkpoint, started_at) {
                                 self.record_terminal_outcome(issue, false);
+                                // #4256: a run that advanced the checkpoint made
+                                // real progress (reached Judge/Doctor and wrote a
+                                // fresh phase), so it is a HEALTHY resume — clear
+                                // the resume-attempt runway. Only *consecutive*
+                                // checkpoint-less resume crashes (the ~2s..stall
+                                // pathology) accrue toward `MAX_RESUME_ATTEMPTS`;
+                                // a productively-progressing resume chain is never
+                                // capped. Mirrors `record_terminal_outcome`'s
+                                // reset of `insta_crash_counts` on progress.
+                                self.resume_attempt_counts.remove(&issue);
                             } else {
                                 let insta_crash = duration_sec
                                     < self.quarantine_config.insta_crash_secs
@@ -3900,34 +3942,84 @@ impl SweepRegistry {
                                 && !self.issue_has_blocked_label(issue)
                             {
                                 if let Some(pr) = self.first_open_linked_pr(issue) {
-                                    let dispatched =
-                                        match self.dispatch_resume_after_crash(issue, pr) {
-                                            Ok(_) => {
-                                                log::info!(
-                                                    "issue #{issue}: reaper-driven resume \
-                                                     dispatched (crashed at checkpoint phase \
-                                                     {resume_phase_check:?}, open PR #{pr}) \
-                                                     — #4256"
-                                                );
-                                                true
-                                            }
-                                            Err(e) => {
-                                                log::warn!(
-                                                    "issue #{issue}: reaper-driven resume \
-                                                     dispatch failed (crashed at checkpoint \
-                                                     phase {resume_phase_check:?}, open PR \
-                                                     #{pr}): {e} — #4256"
-                                                );
-                                                false
-                                            }
-                                        };
-                                    events_to_emit.push(Event::SweepResumeDispatched {
-                                        issue,
-                                        pr,
-                                        checkpoint_phase: resume_phase_check.clone(),
-                                        dispatched,
-                                        repo: None, // stamped by emit_event (#3929)
-                                    });
+                                    // Bounded resume attempts (#4256, Judge
+                                    // residual-risk backstop): the resume path
+                                    // bypasses the #4123 open-PR guard, so a sweep
+                                    // stuck in the ~2s..stall crash window (never
+                                    // rewrites the checkpoint, never trips the
+                                    // sub-`insta_crash_secs` quarantine tally)
+                                    // would otherwise resume forever. Once an
+                                    // issue has accumulated `MAX_RESUME_ATTEMPTS`
+                                    // consecutive checkpoint-less resume crashes,
+                                    // stop resuming: emit the failure-visible
+                                    // event (`dispatched: false`) once and leave
+                                    // the PR for the periodic Judge role /
+                                    // operator. No labels are added beyond the
+                                    // ones already present.
+                                    let attempts = self
+                                        .resume_attempt_counts
+                                        .get(&issue)
+                                        .copied()
+                                        .unwrap_or(0);
+                                    if attempts >= MAX_RESUME_ATTEMPTS {
+                                        log::warn!(
+                                            "issue #{issue}: reaper-driven resume attempts \
+                                             exhausted ({attempts}/{MAX_RESUME_ATTEMPTS} \
+                                             consecutive checkpoint-less resume crashes, open \
+                                             PR #{pr}, checkpoint phase {resume_phase_check:?}) \
+                                             — NOT resuming again; leaving the PR for the \
+                                             periodic Judge role / operator (#4256)"
+                                        );
+                                        events_to_emit.push(Event::SweepResumeDispatched {
+                                            issue,
+                                            pr,
+                                            checkpoint_phase: resume_phase_check.clone(),
+                                            dispatched: false,
+                                            repo: None, // stamped by emit_event (#3929)
+                                        });
+                                    } else {
+                                        // Count the attempt regardless of whether
+                                        // the dispatch call itself succeeds, so a
+                                        // persistently-failing resume dispatch is
+                                        // bounded too.
+                                        let attempt_no = *self
+                                            .resume_attempt_counts
+                                            .entry(issue)
+                                            .and_modify(|c| *c += 1)
+                                            .or_insert(1);
+                                        let dispatched =
+                                            match self.dispatch_resume_after_crash(issue, pr) {
+                                                Ok(_) => {
+                                                    log::info!(
+                                                        "issue #{issue}: reaper-driven resume \
+                                                         dispatched (attempt \
+                                                         {attempt_no}/{MAX_RESUME_ATTEMPTS}, \
+                                                         crashed at checkpoint phase \
+                                                         {resume_phase_check:?}, open PR #{pr}) \
+                                                         — #4256"
+                                                    );
+                                                    true
+                                                }
+                                                Err(e) => {
+                                                    log::warn!(
+                                                        "issue #{issue}: reaper-driven resume \
+                                                         dispatch failed (attempt \
+                                                         {attempt_no}/{MAX_RESUME_ATTEMPTS}, \
+                                                         crashed at checkpoint phase \
+                                                         {resume_phase_check:?}, open PR #{pr}): \
+                                                         {e} — #4256"
+                                                    );
+                                                    false
+                                                }
+                                            };
+                                        events_to_emit.push(Event::SweepResumeDispatched {
+                                            issue,
+                                            pr,
+                                            checkpoint_phase: resume_phase_check.clone(),
+                                            dispatched,
+                                            repo: None, // stamped by emit_event (#3929)
+                                        });
+                                    }
                                 }
                             }
                         } else {
@@ -11685,6 +11777,153 @@ exit 0\n";
         assert!(
             err.downcast_ref::<OpenPrDispatchError>().is_some(),
             "must be the typed OpenPrDispatchError, not some other failure; got: {err}"
+        );
+        std::env::remove_var("LOOM_REPO");
+    }
+
+    /// Bounded resume attempts (#4256, Judge residual-risk backstop): once an
+    /// issue has accumulated `MAX_RESUME_ATTEMPTS` consecutive checkpoint-less
+    /// resume crashes, the reaper stops resuming it — it emits a
+    /// failure-visible `SweepResumeDispatched { dispatched: false }` event,
+    /// creates NO fresh Running entry, and adds NO labels beyond the ones
+    /// already present. This is the replacement for the #4123 open-PR backstop
+    /// that the resume path deliberately bypasses, closing the ~2s..stall
+    /// infinite-resume window. The checkpoint is deliberately made STALE
+    /// (mtime before this run's `started_at`) so the reset-on-progress branch
+    /// does not clear the seeded tally — the exact pathology the cap bounds.
+    #[tokio::test]
+    #[serial]
+    async fn reaper_stops_resuming_after_attempt_cap() {
+        use crate::event_bus::EventBus;
+
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        let (mut reg, gh_log) = open_pr_guard_registry(ws, "4310", 0, false);
+        let bus = Arc::new(EventBus::new());
+        reg.set_event_bus(bus.clone());
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        write_checkpoint(&reg, 4260, "builder-done");
+        insert_dead_running_entry(&mut reg, 4260, "sweep-issue-4260-crashed");
+        // Stale inherited checkpoint: `started_at` AFTER the checkpoint mtime,
+        // so `checkpoint_written_by_run` is false and the reset-on-progress
+        // branch never clears the seeded tally.
+        reg.entries
+            .get_mut("sweep-issue-4260-crashed")
+            .unwrap()
+            .started_at = Utc::now() + chrono::Duration::seconds(30);
+        // Pre-seed the issue exactly AT the cap — the next resume is refused.
+        reg.resume_attempt_counts.insert(4260, MAX_RESUME_ATTEMPTS);
+
+        let changed = reg.reap_once();
+        assert!(changed >= 1);
+
+        let mut saw_resume_false = false;
+        for _ in 0..8 {
+            let Ok(ev) = tokio::time::timeout(Duration::from_secs(5), sub.recv()).await else {
+                break;
+            };
+            if let Event::SweepResumeDispatched {
+                issue,
+                pr,
+                dispatched,
+                ..
+            } = ev.unwrap()
+            {
+                assert_eq!(issue, 4260);
+                assert_eq!(pr, 4310);
+                assert!(
+                    !dispatched,
+                    "at the attempt cap the reaper must NOT resume (dispatched:false)"
+                );
+                saw_resume_false = true;
+            }
+        }
+        assert!(
+            saw_resume_false,
+            "exhaustion must still emit a failure-visible resume_dispatched event (not silent)"
+        );
+
+        // No resume dispatch ⇒ no fresh Running entry for the issue.
+        assert!(
+            running_issue_sweep_id(&reg, 4260).is_none(),
+            "no resume dispatch at the cap means no fresh Running entry"
+        );
+        // The cap is not exceeded.
+        assert_eq!(
+            reg.resume_attempt_counts.get(&4260).copied(),
+            Some(MAX_RESUME_ATTEMPTS),
+            "an exhausted issue's counter stays pinned at the cap, never grows"
+        );
+        // No extra label was applied on exhaustion (the PR is left as-is for
+        // the periodic Judge role / operator).
+        // No NEW label is applied on exhaustion. `restore_label_to_ready`
+        // still flips loom:building→loom:issue (existing behavior, not a new
+        // label), and `issue_has_blocked_label` mentions "loom:blocked" only
+        // inside its read-only `--jq` query — so assert specifically that no
+        // `--add-label loom:blocked` (quarantine) edit was issued.
+        let calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            !calls.contains("add-label loom:blocked"),
+            "exhaustion must NOT add labels beyond the existing ones; got: {calls:?}"
+        );
+        std::env::remove_var("LOOM_REPO");
+    }
+
+    /// Boundary companion to `reaper_stops_resuming_after_attempt_cap`: one
+    /// below the cap the resume still fires and ticks the per-issue counter up
+    /// to exactly `MAX_RESUME_ATTEMPTS`, so the cap value itself is locked (the
+    /// Nth attempt succeeds; only the (N+1)th is refused). Uses the same stale
+    /// checkpoint so the seeded tally survives into the resume decision.
+    #[tokio::test]
+    #[serial]
+    async fn reaper_still_resumes_one_below_attempt_cap() {
+        use crate::event_bus::EventBus;
+
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        let (mut reg, _gh_log) = open_pr_guard_registry(ws, "4311", 0, false);
+        let bus = Arc::new(EventBus::new());
+        reg.set_event_bus(bus.clone());
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        write_checkpoint(&reg, 4261, "judge-rejected");
+        insert_dead_running_entry(&mut reg, 4261, "sweep-issue-4261-crashed");
+        reg.entries
+            .get_mut("sweep-issue-4261-crashed")
+            .unwrap()
+            .started_at = Utc::now() + chrono::Duration::seconds(30);
+        reg.resume_attempt_counts
+            .insert(4261, MAX_RESUME_ATTEMPTS - 1);
+
+        let changed = reg.reap_once();
+        assert!(changed >= 1);
+
+        let mut saw_resume_true = false;
+        for _ in 0..8 {
+            let Ok(ev) = tokio::time::timeout(Duration::from_secs(5), sub.recv()).await else {
+                break;
+            };
+            if let Event::SweepResumeDispatched {
+                issue, dispatched, ..
+            } = ev.unwrap()
+            {
+                assert_eq!(issue, 4261);
+                assert!(dispatched, "one below the cap the resume must still fire");
+                saw_resume_true = true;
+            }
+        }
+        assert!(saw_resume_true, "expected a successful resume dispatch below the cap");
+        assert!(
+            running_issue_sweep_id(&reg, 4261).is_some(),
+            "a below-cap resume must create a fresh Running entry"
+        );
+        assert_eq!(
+            reg.resume_attempt_counts.get(&4261).copied(),
+            Some(MAX_RESUME_ATTEMPTS),
+            "the resume attempt must tick the per-issue counter up to the cap"
         );
         std::env::remove_var("LOOM_REPO");
     }

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -159,6 +159,27 @@ impl std::fmt::Display for OpenPrDispatchError {
 
 impl std::error::Error for OpenPrDispatchError {}
 
+/// Issue #4256: checkpoint phases at/after Builder completion. A crash whose
+/// checkpoint reads one of these means a PR was opened for the issue, so
+/// [`SweepRegistry::reap_once`]'s reaper-driven resume is eligible to
+/// re-dispatch straight past the #4123 open-PR guard — the checkpoint-resume
+/// machinery (#3373) then skips back to the correct phase (typically Judge)
+/// rather than redoing the Builder.
+///
+/// Mirrors `VALID_PHASES` in `defaults/scripts/sweep-checkpoint.sh` (the
+/// daemon only *reads* checkpoint phases; the sweep skill is the sole writer
+/// and validator, so this is a read-side allowlist, not the canonical
+/// source). `curator-done` is excluded (no PR exists yet — an ordinary
+/// re-dispatch is exactly right). `merge-done` is excluded too: a merge
+/// closes the issue, so the 2.5 closed-issue guard already refuses a
+/// re-dispatch there and a resume would be a wasted forge round trip.
+const RESUMABLE_CHECKPOINT_PHASES: [&str; 4] = [
+    "builder-done",
+    "judge-rejected",
+    "judge-done",
+    "doctor-done",
+];
+
 /// Issue #3944: which tier of the dispatch-model precedence chain supplied the
 /// resolved model. Surfaced in the daemon dispatch log line so an operator can
 /// tell *why* a child is running a given model.
@@ -1890,6 +1911,43 @@ impl SweepRegistry {
         effort: Option<&str>,
         depends_on: Option<u32>,
     ) -> Result<DispatchOutcome> {
+        self.dispatch_inner(kind, idempotency_key, model, effort, depends_on, None)
+    }
+
+    /// Issue #4256: reaper-driven resume. When [`Self::reap_once`] observes a
+    /// crashed sweep whose checkpoint shows real Builder-or-later progress
+    /// (`RESUMABLE_CHECKPOINT_PHASES`) AND whose issue still has an open
+    /// linked PR, it is not fresh work — it is the exact scenario the #4123
+    /// open-PR guard exists to protect (an ordinary re-dispatch would
+    /// double-build), but here the open PR *is* this crashed sweep's own PR
+    /// and the checkpoint-resume machinery (#3373) exists precisely to pick
+    /// back up at the correct phase (typically Judge) instead of redoing the
+    /// Builder.
+    ///
+    /// This bypasses guard step 2.6 for exactly this one issue/PR pair —
+    /// `resume_pr` must equal the PR the guard would itself find, so a stale
+    /// or mismatched caller can never silently disable the guard. It is
+    /// **only** reachable from [`Self::reap_once`]; no other call site
+    /// (work-finder, IPC/CLI dispatch, epic supervisor, watchdogs) can pass a
+    /// bypass, so the anti-duplicate property of #4123 is unchanged for
+    /// every other dispatch path.
+    fn dispatch_resume_after_crash(
+        &mut self,
+        issue: u32,
+        resume_pr: u32,
+    ) -> Result<DispatchOutcome> {
+        self.dispatch_inner(&SweepKind::Issue(issue), None, None, None, None, Some(resume_pr))
+    }
+
+    fn dispatch_inner(
+        &mut self,
+        kind: &SweepKind,
+        idempotency_key: Option<String>,
+        model: Option<&str>,
+        effort: Option<&str>,
+        depends_on: Option<u32>,
+        resume_bypass_pr: Option<u32>,
+    ) -> Result<DispatchOutcome> {
         // 1. Idempotency dedup against Running entries.
         if let Some(ref key) = idempotency_key {
             if let Some(existing) = self.find_running_by_key(key) {
@@ -1982,13 +2040,26 @@ impl SweepRegistry {
         //     a Gitea workspace — this is GitHub-only, like `issue_is_closed`)
         //     can never wedge the daemon. Skipped when label flips are disabled
         //     (test fixtures without `gh` credentials), mirroring 2.5.
+        //
+        //     Issue #4256: `resume_bypass_pr` — set only by
+        //     `dispatch_resume_after_crash`, itself only reachable from
+        //     `reap_once` — exempts a resume of THIS issue's own crashed sweep
+        //     from the guard, but only when it names the exact PR the guard
+        //     would find; any other PR (or none) still refuses normally, so a
+        //     stale/mismatched resume can never widen into a blanket bypass.
         if !self.config.skip_label_flip {
             if let Some(pr) = self.first_open_linked_pr(issue_number) {
-                return Err(OpenPrDispatchError {
-                    issue: issue_number,
-                    pr,
+                if resume_bypass_pr != Some(pr) {
+                    return Err(OpenPrDispatchError {
+                        issue: issue_number,
+                        pr,
+                    }
+                    .into());
                 }
-                .into());
+                log::info!(
+                    "issue #{issue_number}: reaper-driven resume dispatch bypassing the #4123 \
+                     open-PR guard for its own PR #{pr} (#4256)"
+                );
             }
         }
 
@@ -3752,6 +3823,10 @@ impl SweepRegistry {
                                 .and_then(|p| tail_lines(p, EXHAUSTION_LOG_TAIL_LINES).ok())
                                 .map(|lines| lines.join("\n"))
                                 .and_then(|tail| classify_crash(&tail, exit_code));
+                            // Captured before `checkpoint_phase` moves into the
+                            // `SweepCrashed` event below — needed for the
+                            // reaper-driven resume check further down (#4256).
+                            let resume_phase_check = checkpoint_phase.clone();
                             if let Some(info) = self.entries.get_mut(&sweep_id) {
                                 info.state = SweepState::Crashed { at: now };
                                 if info.latest_phase.is_none() {
@@ -3792,6 +3867,68 @@ impl SweepRegistry {
                                 // #4122: re-attribute account-exhaustion deaths
                                 // to the spawn account instead of the issue.
                                 self.record_insta_crash_outcome(&sweep_id, issue, insta_crash);
+                            }
+                            // Reaper-driven resume (Issue #4256): a crash whose
+                            // checkpoint shows real Builder-or-later progress
+                            // AND whose issue still has an open linked PR is
+                            // not fresh work — it is exactly the case the
+                            // #4123 open-PR guard exists to protect (an
+                            // ordinary re-dispatch would double-build). But
+                            // here the open PR *is* this crashed sweep's own
+                            // PR, and the checkpoint-resume machinery (#3373)
+                            // exists precisely to skip back to the correct
+                            // phase (typically Judge) instead of redoing the
+                            // Builder. Without this, the guard and the resume
+                            // machinery contradict each other: the guard
+                            // correctly refuses every ordinary re-dispatch,
+                            // and nothing else ever re-dispatches the issue —
+                            // stranding the PR at `loom:review-requested`
+                            // forever. Gated on `skip_label_flip` like the
+                            // guard itself (test fixtures without `gh`
+                            // credentials never attempt a real forge probe
+                            // here) and only checked for phases at/after
+                            // Builder completion, so a pre-PR crash never
+                            // pays for the extra forge round trip. Also
+                            // respects the #4206 operator-park guard: never
+                            // resume-dispatch an issue `restore_label_to_ready`
+                            // just deliberately left without `loom:issue`
+                            // because it carries `loom:blocked`.
+                            if !self.config.skip_label_flip
+                                && resume_phase_check
+                                    .as_deref()
+                                    .is_some_and(|p| RESUMABLE_CHECKPOINT_PHASES.contains(&p))
+                                && !self.issue_has_blocked_label(issue)
+                            {
+                                if let Some(pr) = self.first_open_linked_pr(issue) {
+                                    let dispatched =
+                                        match self.dispatch_resume_after_crash(issue, pr) {
+                                            Ok(_) => {
+                                                log::info!(
+                                                    "issue #{issue}: reaper-driven resume \
+                                                     dispatched (crashed at checkpoint phase \
+                                                     {resume_phase_check:?}, open PR #{pr}) \
+                                                     — #4256"
+                                                );
+                                                true
+                                            }
+                                            Err(e) => {
+                                                log::warn!(
+                                                    "issue #{issue}: reaper-driven resume \
+                                                     dispatch failed (crashed at checkpoint \
+                                                     phase {resume_phase_check:?}, open PR \
+                                                     #{pr}): {e} — #4256"
+                                                );
+                                                false
+                                            }
+                                        };
+                                    events_to_emit.push(Event::SweepResumeDispatched {
+                                        issue,
+                                        pr,
+                                        checkpoint_phase: resume_phase_check.clone(),
+                                        dispatched,
+                                        repo: None, // stamped by emit_event (#3929)
+                                    });
+                                }
                             }
                         } else {
                             // Orphaned-claim recovery (issue #3823b): a
@@ -11314,6 +11451,242 @@ exit 0\n";
             !calls.contains("api graphql"),
             "the open-PR (2.6) probe must never run once 2.5 refuses; got: {calls:?}"
         );
+    }
+
+    // --- reaper-driven resume (Issue #4256) ---
+
+    /// Write a `sweep-checkpoint.sh`-style checkpoint file for `issue` with
+    /// `phase`, matching the on-disk shape `read_checkpoint_phase` parses.
+    fn write_checkpoint(reg: &SweepRegistry, issue: u32, phase: &str) {
+        let dir = reg.config.checkpoint_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join(format!("issue-{issue}.json")),
+            format!(r#"{{"phase":"{phase}","issue":{issue}}}"#),
+        )
+        .unwrap();
+    }
+
+    /// Insert a `Running` entry with a guaranteed-dead PID (Issue #4256 test
+    /// fixture), mirroring `reaper_emits_crashed_event_with_checkpoint_phase`'s
+    /// pattern: no retained `Child` handle, so `poll_liveness` falls back to
+    /// the `kill(pid, 0)` probe, which reports dead for this bogus PID.
+    fn insert_dead_running_entry(reg: &mut SweepRegistry, issue: u32, sweep_id: &str) {
+        reg.entries.insert(
+            sweep_id.to_string(),
+            SweepInfo {
+                sweep_id: sweep_id.to_string(),
+                kind: SweepKind::Issue(issue),
+                pid: 2_147_483_641,
+                token_name: "unknown".into(),
+                log_path: reg.compute_log_path(issue),
+                idempotency_key: None,
+                started_at: Utc::now() - chrono::Duration::seconds(5),
+                state: SweepState::Running,
+                latest_phase: None,
+                pr_number: None,
+                model: None,
+                effort: None,
+                depends_on: None,
+                repo: None,
+            },
+        );
+    }
+
+    /// AC (Test Plan item 1): a crashed sweep whose checkpoint reads
+    /// `builder-done` AND whose issue has an open linked PR is resumed by the
+    /// reaper — the resume dispatch bypasses the #4123 open-PR guard (a
+    /// second `issue edit ... loom:building` shows up in the gh log for a
+    /// FRESH sweep entry), and a `SweepResumeDispatched` event is published so
+    /// the recovery attempt is visible on the event bus (AC: "not silent").
+    #[tokio::test]
+    #[serial]
+    async fn reaper_resumes_crashed_sweep_at_builder_done_with_open_pr() {
+        use crate::event_bus::EventBus;
+
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        let (mut reg, gh_log) = open_pr_guard_registry(ws, "4300", 0, false);
+        let bus = Arc::new(EventBus::new());
+        reg.set_event_bus(bus.clone());
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        write_checkpoint(&reg, 4256, "builder-done");
+        insert_dead_running_entry(&mut reg, 4256, "sweep-issue-4256-crashed");
+
+        let changed = reg.reap_once();
+        assert!(changed >= 1);
+
+        let mut saw_resume = false;
+        let mut saw_crashed = false;
+        // Crashed, GlobalCompleted, GlobalDispatch (resume spawn), plus our
+        // ResumeDispatched — drain generously and match by variant.
+        for _ in 0..8 {
+            let Ok(ev) = tokio::time::timeout(Duration::from_secs(5), sub.recv()).await else {
+                break;
+            };
+            match ev.unwrap() {
+                Event::SweepResumeDispatched {
+                    issue,
+                    pr,
+                    checkpoint_phase,
+                    dispatched,
+                    ..
+                } => {
+                    assert_eq!(issue, 4256);
+                    assert_eq!(pr, 4300);
+                    assert_eq!(checkpoint_phase.as_deref(), Some("builder-done"));
+                    assert!(dispatched, "the resume dispatch itself must have succeeded");
+                    saw_resume = true;
+                }
+                Event::SweepCrashed { issue, .. } => {
+                    assert_eq!(issue, 4256);
+                    saw_crashed = true;
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_crashed, "expected the normal sweep.issue.4256.crashed event too");
+        assert!(saw_resume, "expected a sweep.issue.4256.resume_dispatched event");
+
+        // A fresh Running entry exists for issue 4256 under a NEW sweep_id
+        // (the original crashed one is retained, terminal).
+        let resumed_id = running_issue_sweep_id(&reg, 4256);
+        assert!(resumed_id.is_some(), "resume dispatch must have created a new Running entry");
+        assert_ne!(resumed_id.unwrap(), "sweep-issue-4256-crashed");
+
+        let calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            calls.contains("issue edit 4256") && calls.contains("loom:building"),
+            "the resume dispatch must flip the label like an ordinary dispatch; got: {calls:?}"
+        );
+        std::env::remove_var("LOOM_REPO");
+    }
+
+    /// AC (Test Plan item 3): a crashed sweep whose checkpoint is
+    /// `curator-done` (pre-PR) is NOT resumed even though `first_open_linked_pr`
+    /// would report one — resume is gated on a Builder-or-later checkpoint
+    /// phase, and a pre-PR crash gets ONLY the normal crash handling.
+    #[tokio::test]
+    #[serial]
+    async fn reaper_does_not_resume_pre_builder_checkpoint() {
+        use crate::event_bus::EventBus;
+
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        let (mut reg, gh_log) = open_pr_guard_registry(ws, "4301", 0, false);
+        let bus = Arc::new(EventBus::new());
+        reg.set_event_bus(bus.clone());
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        write_checkpoint(&reg, 4257, "curator-done");
+        insert_dead_running_entry(&mut reg, 4257, "sweep-issue-4257-crashed");
+
+        let changed = reg.reap_once();
+        assert!(changed >= 1);
+
+        for _ in 0..2 {
+            let ev = sub.recv().await.unwrap();
+            assert!(
+                !matches!(ev, Event::SweepResumeDispatched { .. }),
+                "a pre-Builder checkpoint must never trigger a resume dispatch"
+            );
+        }
+
+        assert!(
+            running_issue_sweep_id(&reg, 4257).is_none(),
+            "no resume dispatch means no fresh Running entry for the issue"
+        );
+        let calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            !calls.contains("api graphql"),
+            "resume-eligibility check must not even probe the closes-graph for a \
+             pre-Builder checkpoint phase; got: {calls:?}"
+        );
+        std::env::remove_var("LOOM_REPO");
+    }
+
+    /// Edge case (Test Plan item 4): the crashed sweep's PR already
+    /// merged/closed by the time the reaper ticks — `first_open_linked_pr`
+    /// returns `None` (empty post-`--jq` output), so no resume is attempted
+    /// and no error surfaces; only the normal crash handling fires.
+    #[tokio::test]
+    #[serial]
+    async fn reaper_skips_resume_when_pr_already_closed() {
+        use crate::event_bus::EventBus;
+
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        // Empty graphql stdout ⇒ no OPEN-state linked PR.
+        let (mut reg, gh_log) = open_pr_guard_registry(ws, "", 0, false);
+        let bus = Arc::new(EventBus::new());
+        reg.set_event_bus(bus.clone());
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        write_checkpoint(&reg, 4258, "judge-done");
+        insert_dead_running_entry(&mut reg, 4258, "sweep-issue-4258-crashed");
+
+        let changed = reg.reap_once();
+        assert!(changed >= 1);
+
+        for _ in 0..2 {
+            let ev = sub.recv().await.unwrap();
+            assert!(
+                !matches!(ev, Event::SweepResumeDispatched { .. }),
+                "no open PR means no resume dispatch, even at a resumable phase"
+            );
+        }
+
+        assert!(
+            running_issue_sweep_id(&reg, 4258).is_none(),
+            "no resume dispatch means no fresh Running entry for the issue"
+        );
+        let calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            calls.contains("api graphql"),
+            "the resume-eligibility check DID probe the closes-graph; got: {calls:?}"
+        );
+        std::env::remove_var("LOOM_REPO");
+    }
+
+    /// AC (Test Plan item 2, regression): the recovery path must NOT weaken
+    /// the #4123 guard for ordinary dispatches. After a reaper-driven resume
+    /// has fired for an issue (so it now has a fresh Running sweep AND an
+    /// open PR), a plain `dispatch()` call for the SAME issue — simulating an
+    /// unrelated later work-finder tick — is still refused with the typed
+    /// `OpenPrDispatchError`. The resume bypass is unreachable from the
+    /// public `dispatch()` entry point.
+    #[tokio::test]
+    #[serial]
+    async fn ordinary_dispatch_still_refused_after_a_resume() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        let (mut reg, _gh_log) = open_pr_guard_registry(ws, "4302", 0, false);
+
+        write_checkpoint(&reg, 4259, "doctor-done");
+        insert_dead_running_entry(&mut reg, 4259, "sweep-issue-4259-crashed");
+        let changed = reg.reap_once();
+        assert!(changed >= 1);
+        assert!(
+            running_issue_sweep_id(&reg, 4259).is_some(),
+            "the resume dispatch must have created a fresh Running entry first"
+        );
+
+        // A later, ordinary re-dispatch attempt for the same issue (e.g. a
+        // stray work-finder tick, or a watchdog) must still be refused — the
+        // open PR is still open, and this call carries no resume exemption.
+        let err = reg
+            .dispatch(&SweepKind::Issue(4259), None, None, None, None)
+            .expect_err("an ordinary dispatch must still be refused by the #4123 guard");
+        assert!(
+            err.downcast_ref::<OpenPrDispatchError>().is_some(),
+            "must be the typed OpenPrDispatchError, not some other failure; got: {err}"
+        );
+        std::env::remove_var("LOOM_REPO");
     }
 
     // --- workspace-commands dispatch guard (Issue #4027) ---

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -1377,6 +1377,31 @@ pub enum Event {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         repo: Option<String>,
     },
+    /// `sweep.issue.{N}.resume_dispatched` — reaper-driven resume (Issue
+    /// #4256). A crashed sweep's issue had an open linked PR plus a
+    /// Builder-or-later checkpoint, so the reaper re-dispatched the SAME
+    /// issue with the #4123 open-PR guard bypassed for that one resume — the
+    /// checkpoint-resume machinery (#3373) then picks back up at the correct
+    /// phase (typically Judge) instead of redoing the Builder. This is the
+    /// one dispatch path that proceeds despite an open PR; every other
+    /// dispatch caller still refuses via `OpenPrDispatchError`, so #4123's
+    /// anti-duplicate property is unchanged.
+    SweepResumeDispatched {
+        issue: u32,
+        /// The open linked PR the resume targets.
+        pr: u32,
+        /// The checkpoint phase the crashed sweep last recorded.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        checkpoint_phase: Option<String>,
+        /// Whether the resume dispatch itself succeeded (spawned a child).
+        /// `false` means the reaper attempted recovery but the dispatch call
+        /// failed (e.g. a spawn error) — still emitted so the attempt is
+        /// visible on the event bus even when the retry itself fails.
+        dispatched: bool,
+        /// Owning managed-workspace root (Issue #3929). See [`Self::SweepPhase`].
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        repo: Option<String>,
+    },
     /// `sweep.global.dispatch` — daemon dispatched a new sweep.
     SweepGlobalDispatch {
         sweep_id: SweepId,
@@ -1454,6 +1479,7 @@ impl Event {
     /// | `SweepBlocker {issue, ..}` | `sweep.issue.{issue}.blocker` |
     /// | `SweepExited {issue, ..}` | `sweep.issue.{issue}.exited` |
     /// | `SweepCrashed {issue, ..}` | `sweep.issue.{issue}.crashed` |
+    /// | `SweepResumeDispatched {issue, ..}` | `sweep.issue.{issue}.resume_dispatched` |
     /// | `SweepGlobalDispatch {..}` | `sweep.global.dispatch` |
     /// | `SweepGlobalCompleted {..}` | `sweep.global.completed` |
     /// | `EpicAction {epic, action, ..}` | `epic.issue.{epic}.{action}` |
@@ -1474,6 +1500,9 @@ impl Event {
             Self::SweepBlocker { issue, .. } => format!("sweep.issue.{issue}.blocker"),
             Self::SweepExited { issue, .. } => format!("sweep.issue.{issue}.exited"),
             Self::SweepCrashed { issue, .. } => format!("sweep.issue.{issue}.crashed"),
+            Self::SweepResumeDispatched { issue, .. } => {
+                format!("sweep.issue.{issue}.resume_dispatched")
+            }
             Self::SweepGlobalDispatch { .. } => "sweep.global.dispatch".to_string(),
             Self::SweepGlobalCompleted { .. } => "sweep.global.completed".to_string(),
             Self::EpicAction { epic, action, .. } => {
@@ -1502,6 +1531,7 @@ impl Event {
             | Self::SweepBlocker { repo, .. }
             | Self::SweepExited { repo, .. }
             | Self::SweepCrashed { repo, .. }
+            | Self::SweepResumeDispatched { repo, .. }
             | Self::SweepGlobalDispatch { repo, .. } => repo,
             _ => return,
         };


### PR DESCRIPTION
## Summary

A sweep that crashes **after** its Builder opened a PR used to strand that PR at `loom:review-requested` forever: the #4123 open-PR guard correctly refuses every *ordinary* re-dispatch of the issue (an open PR looks identical to fresh work the instant the sweep exits), but nothing else ever re-dispatches it, so the checkpoint-resume machinery (#3373) never gets a chance to skip back to the Judge phase.

This implements the curator-recommended **(a) reaper-driven resume**, primary, plus **(c) repo-config backstop**.

### (a) Reaper-driven resume

`SweepRegistry::reap_once()` now detects the exact stranding scenario: a crashed sweep whose checkpoint reads `builder-done` / `judge-rejected` / `judge-done` / `doctor-done` (Builder-or-later — a pre-Builder `curator-done` crash still gets ordinary crash handling only) **and** whose issue still has an open linked PR. In that case it re-dispatches the *same* issue through a new private path (`dispatch_resume_after_crash` → `dispatch_inner(..., resume_bypass_pr)`) that:

- is reachable **only** from the reaper — not from the work-finder, epic supervisor, IPC/CLI `dispatch_sweep`, or any watchdog
- only bypasses the #4123 open-PR guard (step 2.6) when the PR it names matches the PR the guard's own `first_open_linked_pr` check finds — a stale/mismatched resume can never widen into a blanket bypass
- still respects the #4206 operator-park guard: an issue carrying `loom:blocked` is never resume-dispatched

Every other dispatch caller is byte-for-byte unchanged, so #4123's anti-duplicate property is preserved for all non-resume dispatches (covered by a regression test).

The recovery attempt is never silent: a new `sweep.issue.{N}.resume_dispatched` event (`{issue, pr, checkpoint_phase?, dispatched, repo?}`) is published on the event bus — with `dispatched: false` on the rare case the resume dispatch call itself fails — and narrated over Safehouse (when enabled) as a `handoff`.

### (c) Repo-config backstop

Added `"judge"` to this repo's `.loom/config.json` → `autonomous.roleRunner.roles` (was `["curator", "champion"]`) so a stranded PR still gets picked up by the periodic judge role even in the rare case (a) misses (e.g. `gh` outage during the reaper tick, or the PR closing/merging out from under the resume between checks).

### Docs

`defaults/docs/daemon-reference.md`: new `sweep.issue.{N}.resume_dispatched` event-taxonomy row + a "Reaper-driven resume" subsection under the #4123 open-PR guard writeup.

## Acceptance criteria (from #4256)

- [x] A sweep killed after PR creation results in that PR being judged and (on approval) merged without operator intervention, within one recovery cycle — the reaper resumes the same issue at the next 30s tick (default), and checkpoint-resume machinery picks up at Judge.
- [x] The recovery path does not double-build: the open-PR guard's anti-duplicate property is preserved for all non-resume dispatches — covered by `ordinary_dispatch_still_refused_after_a_resume`.
- [x] A recovery attempt is visible in the event bus / status output (not silent) — `sweep.issue.{N}.resume_dispatched` event + Safehouse narration + log lines.

## Test plan

New Rust tests in `loom-daemon/src/sweep_registry.rs`:
- `reaper_resumes_crashed_sweep_at_builder_done_with_open_pr` — checkpoint `builder-done` + open PR → resume dispatch fires, bypasses the guard, emits the event, flips the label like an ordinary dispatch.
- `reaper_does_not_resume_pre_builder_checkpoint` — checkpoint `curator-done` → no resume, no forge probe at all.
- `reaper_skips_resume_when_pr_already_closed` — checkpoint `judge-done` but PR already merged/closed → no resume, no error.
- `ordinary_dispatch_still_refused_after_a_resume` — regression: after a resume fires, a plain `dispatch()` call for the same issue is still refused with the typed `OpenPrDispatchError`.

New tests in `loom-daemon/src/safehouse.rs` covering the `SweepResumeDispatched` → `Envelope` narration (success and failure bodies).

All existing #4123/#4088/#4027 guard tests pass unmodified. Full `cargo test --lib` run: 1493 passed (one unrelated pre-existing flake, `disk_headroom::tests::test_worktree_root_free_gb_returns_a_value`, a `df -Pk` hiccup under heavy concurrent-worktree host load — passes in isolation, unrelated to this change).

Closes #4256
