### PR TITLE
feat(config-resolver): migrate tokens.spreadTopN + heartbeat readers, carve out worktree-isolation guard reads

### DIFF
--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -737,19 +737,30 @@ resolve_worktree_root() {
 # toggle in this file:
 #   1. LOOM_GUARD_WORKTREE_ISOLATION env var (0/false/no disables, 1/true/yes
 #      forces on). Overrides config.
-#   2. .loom/config.json -> guards.worktreeIsolation (default true when absent)
+#   2. .loom/config.json (or a higher config-resolver tier) -> guards.worktreeIsolation
+#      (default true when absent)
 #   3. Default: true (guard on)
 #
 # The config read is best-effort: any parse failure falls through to guard-ON
 # and never trips the ERR trap.
+#
+# Migrated to the shared tier resolver (#4241; this reader postdated #4063's
+# migration pass, see issue #4241). Same polarity contract as every other
+# cold-path toggle in this file (sql_guard_enabled() et al.): loom_config_get
+# collapses null/missing to the "true" default, so only an explicit boolean
+# `false` disables — a missing/null key, a non-boolean value, or malformed
+# JSON/config-resolver.sh failing to source all stay guard-ON via `|| raw=true`.
+# This runs on the Bash write-scope path (after REPO_ROOT is already resolved
+# for the cold-path toggles above), not the #3687 read-only fast path, so the
+# extra jq forks loom_config_get costs are not a hot-path regression.
 # =============================================================================
 _WORKTREE_ISOLATION_CACHE=""
 worktree_isolation_guard_enabled() {
     if [[ -z "$_WORKTREE_ISOLATION_CACHE" ]]; then
-        local enabled=true
-        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
-            enabled=$(jq -r 'if .guards.worktreeIsolation == false then "false" else "true" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=true
-            [[ -n "$enabled" ]] || enabled=true
+        local enabled=true raw
+        if [[ -n "$REPO_ROOT" ]]; then
+            raw=$(loom_config_get "$REPO_ROOT" "guards.worktreeIsolation" "true" 2>/dev/null) || raw=true
+            [[ "$raw" == "false" ]] && enabled=false
         fi
         case "${LOOM_GUARD_WORKTREE_ISOLATION:-}" in
             0|false|no)  enabled=false ;;

--- a/.loom/hooks/guard-worktree-paths.sh
+++ b/.loom/hooks/guard-worktree-paths.sh
@@ -69,6 +69,25 @@ trap 'log_hook_error "Unexpected error on line ${LINENO}: ${BASH_COMMAND:-unknow
 #
 # The config read is best-effort: any parse failure falls through to
 # guard-ON and never trips the ERR trap or produces a non-zero exit.
+#
+# CARVE-OUT (#4241, same class as #4063): this read is deliberately NOT routed
+# through the shared config-resolver.sh (loom_config_get / loom_resolve_config)
+# that the cold-path guards.* toggles in guard-destructive-generic.sh use.
+# worktree_isolation_guard_enabled() is called UNCONDITIONALLY as the very
+# first thing this hook does, on EVERY Edit/Write PreToolUse -- there is no
+# cheaper structural pre-check upstream of it (unlike
+# guard-destructive-generic.sh's cold-path toggles, which only read config
+# lazily after a specific pattern has already matched). loom_resolve_config
+# soft-reads all four tier files plus a merge (up to 5 jq forks) on every
+# call; this direct single-jq read of the nearest .loom/config.json costs
+# exactly one. Fanning that out to 5x on the single hottest guard invocation
+# in the whole system is the #3687 fork-budget regression this repo has
+# already decided against once (see guard-destructive-generic.sh's own
+# CARVE-OUT for the read-only fast path). If Epic #3835's `.loom-project/`
+# tier needs to reach this toggle, prefer caching a repo-scoped
+# loom_resolve_config() result once per process (mirroring
+# guard-destructive-generic.sh's per-invocation caches) rather than paying
+# the full resolve on every Edit/Write.
 # =============================================================================
 worktree_isolation_guard_enabled() {
     local enabled=true
@@ -124,6 +143,20 @@ walk_up_for_sentinel() {
 # (LOOM_WORKTREE_ROOT env > .loom/config.json worktree.root > default). Kept
 # as a small inline duplicate rather than sourcing the library, so this
 # guard's fail-open contract does not depend on another script's behavior.
+#
+# CARVE-OUT (#4241, same class as #4063): the `worktree.root` read below is
+# deliberately NOT routed through config-resolver.sh either, for a different
+# reason than the toggle above -- this function is only reached on the rare
+# deny-candidate path (target resolves inside the main checkout and outside
+# every worktree, see path_derived_allow() above), so fork cost is not the
+# concern here. The concern is the SAME self-containment rationale already
+# documented on this function: sourcing config-resolver.sh would make this
+# guard's fail-open contract depend on that library's own behavior (and
+# transitively on jq's `*` deep-merge across up to four tier files) instead
+# of one direct, independently-auditable jq read. If/when a repo actually
+# populates `.loom-project/project.json` -> worktree.root (Epic #3835 Phase
+# 6+), migrate this read (and worktree-root.sh's own resolution) together so
+# the two stay in lockstep -- not this hook alone.
 resolve_worktree_base() {
     if [[ -n "${LOOM_WORKTREE_ROOT:-}" && "${LOOM_WORKTREE_ROOT}" == /* ]]; then
         printf '%s' "${LOOM_WORKTREE_ROOT%/}/$(basename "$MAIN_ROOT")"

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -737,19 +737,30 @@ resolve_worktree_root() {
 # toggle in this file:
 #   1. LOOM_GUARD_WORKTREE_ISOLATION env var (0/false/no disables, 1/true/yes
 #      forces on). Overrides config.
-#   2. .loom/config.json -> guards.worktreeIsolation (default true when absent)
+#   2. .loom/config.json (or a higher config-resolver tier) -> guards.worktreeIsolation
+#      (default true when absent)
 #   3. Default: true (guard on)
 #
 # The config read is best-effort: any parse failure falls through to guard-ON
 # and never trips the ERR trap.
+#
+# Migrated to the shared tier resolver (#4241; this reader postdated #4063's
+# migration pass, see issue #4241). Same polarity contract as every other
+# cold-path toggle in this file (sql_guard_enabled() et al.): loom_config_get
+# collapses null/missing to the "true" default, so only an explicit boolean
+# `false` disables — a missing/null key, a non-boolean value, or malformed
+# JSON/config-resolver.sh failing to source all stay guard-ON via `|| raw=true`.
+# This runs on the Bash write-scope path (after REPO_ROOT is already resolved
+# for the cold-path toggles above), not the #3687 read-only fast path, so the
+# extra jq forks loom_config_get costs are not a hot-path regression.
 # =============================================================================
 _WORKTREE_ISOLATION_CACHE=""
 worktree_isolation_guard_enabled() {
     if [[ -z "$_WORKTREE_ISOLATION_CACHE" ]]; then
-        local enabled=true
-        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
-            enabled=$(jq -r 'if .guards.worktreeIsolation == false then "false" else "true" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=true
-            [[ -n "$enabled" ]] || enabled=true
+        local enabled=true raw
+        if [[ -n "$REPO_ROOT" ]]; then
+            raw=$(loom_config_get "$REPO_ROOT" "guards.worktreeIsolation" "true" 2>/dev/null) || raw=true
+            [[ "$raw" == "false" ]] && enabled=false
         fi
         case "${LOOM_GUARD_WORKTREE_ISOLATION:-}" in
             0|false|no)  enabled=false ;;

--- a/defaults/hooks/guard-worktree-paths.sh
+++ b/defaults/hooks/guard-worktree-paths.sh
@@ -69,6 +69,25 @@ trap 'log_hook_error "Unexpected error on line ${LINENO}: ${BASH_COMMAND:-unknow
 #
 # The config read is best-effort: any parse failure falls through to
 # guard-ON and never trips the ERR trap or produces a non-zero exit.
+#
+# CARVE-OUT (#4241, same class as #4063): this read is deliberately NOT routed
+# through the shared config-resolver.sh (loom_config_get / loom_resolve_config)
+# that the cold-path guards.* toggles in guard-destructive-generic.sh use.
+# worktree_isolation_guard_enabled() is called UNCONDITIONALLY as the very
+# first thing this hook does, on EVERY Edit/Write PreToolUse -- there is no
+# cheaper structural pre-check upstream of it (unlike
+# guard-destructive-generic.sh's cold-path toggles, which only read config
+# lazily after a specific pattern has already matched). loom_resolve_config
+# soft-reads all four tier files plus a merge (up to 5 jq forks) on every
+# call; this direct single-jq read of the nearest .loom/config.json costs
+# exactly one. Fanning that out to 5x on the single hottest guard invocation
+# in the whole system is the #3687 fork-budget regression this repo has
+# already decided against once (see guard-destructive-generic.sh's own
+# CARVE-OUT for the read-only fast path). If Epic #3835's `.loom-project/`
+# tier needs to reach this toggle, prefer caching a repo-scoped
+# loom_resolve_config() result once per process (mirroring
+# guard-destructive-generic.sh's per-invocation caches) rather than paying
+# the full resolve on every Edit/Write.
 # =============================================================================
 worktree_isolation_guard_enabled() {
     local enabled=true
@@ -124,6 +143,20 @@ walk_up_for_sentinel() {
 # (LOOM_WORKTREE_ROOT env > .loom/config.json worktree.root > default). Kept
 # as a small inline duplicate rather than sourcing the library, so this
 # guard's fail-open contract does not depend on another script's behavior.
+#
+# CARVE-OUT (#4241, same class as #4063): the `worktree.root` read below is
+# deliberately NOT routed through config-resolver.sh either, for a different
+# reason than the toggle above -- this function is only reached on the rare
+# deny-candidate path (target resolves inside the main checkout and outside
+# every worktree, see path_derived_allow() above), so fork cost is not the
+# concern here. The concern is the SAME self-containment rationale already
+# documented on this function: sourcing config-resolver.sh would make this
+# guard's fail-open contract depend on that library's own behavior (and
+# transitively on jq's `*` deep-merge across up to four tier files) instead
+# of one direct, independently-auditable jq read. If/when a repo actually
+# populates `.loom-project/project.json` -> worktree.root (Epic #3835 Phase
+# 6+), migrate this read (and worktree-root.sh's own resolution) together so
+# the two stay in lockstep -- not this hook alone.
 resolve_worktree_base() {
     if [[ -n "${LOOM_WORKTREE_ROOT:-}" && "${LOOM_WORKTREE_ROOT}" == /* ]]; then
         printf '%s' "${LOOM_WORKTREE_ROOT%/}/$(basename "$MAIN_ROOT")"

--- a/loom-daemon/src/daemon_heartbeat.rs
+++ b/loom-daemon/src/daemon_heartbeat.rs
@@ -142,37 +142,17 @@ pub struct HeartbeatConfig {
     pub interval_secs: Option<u64>,
 }
 
-/// Read `.loom/config.json → autonomous.heartbeat`, soft-failing every field to
-/// `None` (env/default resolution) on any of: missing file, malformed JSON, or
-/// a missing `autonomous` / `heartbeat` block. Mirrors the soft-fail contract of
-/// [`crate::token_ranking_refresh::read_token_ranking_refresh_config`].
+/// Read `.loom/config.json → autonomous.heartbeat` through
+/// [`crate::config_resolver`] (so the `.loom-project/` tier is honored like
+/// every other migrated `autonomous.*` block, #4058/#4241), soft-failing every
+/// field to `None` (env/default resolution) on a missing file, malformed
+/// JSON, or a missing `autonomous` / `heartbeat` block. Shape copied from
+/// [`crate::token_ranking_refresh::read_token_ranking_refresh_config`] (which
+/// this module's doc comment already claimed to mirror).
 #[must_use]
 pub fn read_heartbeat_config(repo_root: &Path) -> HeartbeatConfig {
-    let config_path = repo_root.join(".loom").join("config.json");
-
-    let config_str = match std::fs::read_to_string(&config_path) {
-        Ok(s) => s,
-        Err(e) => {
-            log::debug!(
-                "daemon_heartbeat: could not read config at {}: {e}",
-                config_path.display()
-            );
-            return HeartbeatConfig::default();
-        }
-    };
-
-    let config: serde_json::Value = match serde_json::from_str(&config_str) {
-        Ok(v) => v,
-        Err(e) => {
-            log::warn!(
-                "daemon_heartbeat: could not parse config at {}: {e}",
-                config_path.display()
-            );
-            return HeartbeatConfig::default();
-        }
-    };
-
-    let Some(block) = config.get("autonomous").and_then(|a| a.get("heartbeat")) else {
+    let effective = crate::config_resolver::resolve_effective_config(repo_root);
+    let Some(block) = crate::config_resolver::get_path(&effective, "autonomous.heartbeat") else {
         return HeartbeatConfig::default();
     };
 
@@ -375,6 +355,54 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), r#"{"autonomous": {"heartbeat": {"intervalSecs": 0}}}"#);
         assert_eq!(read_heartbeat_config(tmp.path()).interval_secs, None);
+    }
+
+    // ===================================================================
+    // config_resolver migration (#4241) — tier precedence
+    // ===================================================================
+
+    fn write_project_config(root: &Path, contents: &str) {
+        let full = root.join(crate::config_resolver::PROJECT_CONFIG_REL);
+        fs::create_dir_all(full.parent().unwrap()).unwrap();
+        fs::write(full, contents).unwrap();
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn test_config_project_tier_only_is_honored_like_legacy() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        write_project_config(
+            tmp.path(),
+            r#"{"autonomous": {"heartbeat": {"enabled": false, "intervalSecs": 45}}}"#,
+        );
+        let cfg = read_heartbeat_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(
+            cfg,
+            HeartbeatConfig {
+                enabled: Some(false),
+                interval_secs: Some(45),
+            }
+        );
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn test_config_project_tier_overrides_legacy_overlap_and_supplies_non_overlap() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(
+            tmp.path(),
+            r#"{"autonomous": {"heartbeat": {"enabled": true, "intervalSecs": 60}}}"#,
+        );
+        write_project_config(tmp.path(), r#"{"autonomous": {"heartbeat": {"intervalSecs": 30}}}"#);
+        let cfg = read_heartbeat_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        // Overlapping `intervalSecs` -> project tier wins.
+        assert_eq!(cfg.interval_secs, Some(30));
+        // Non-overlapping `enabled` still supplied by legacy tier.
+        assert_eq!(cfg.enabled, Some(true));
     }
 
     // ===================================================================

--- a/loom-daemon/src/tokens_pool/select.rs
+++ b/loom-daemon/src/tokens_pool/select.rs
@@ -175,14 +175,14 @@ fn read_allowlist_lines(allowlist_file: &Path) -> Vec<String> {
         .collect()
 }
 
-/// Soft-fail read of `.loom/config.json` -> `tokens.spreadTopN`. Missing
-/// file, parse error, missing key, non-int, or bool all resolve to `None`.
+/// Soft-fail read of `.loom/config.json` -> `tokens.spreadTopN` through
+/// [`crate::config_resolver`] (so the `.loom-project/` tier is honored like
+/// every other migrated config surface, #4058/#4241). Missing file, parse
+/// error, missing key, non-int, or bool all resolve to `None`. Shape copied
+/// from [`crate::token_ranking_refresh::read_token_ranking_refresh_config`].
 fn read_config_spread_top_n(workspace: &Path) -> Option<i64> {
-    let config_path = workspace.join(".loom").join("config.json");
-    let text = std::fs::read_to_string(config_path).ok()?;
-    let value: serde_json::Value = serde_json::from_str(&text).ok()?;
-    let tokens_cfg = value.get("tokens")?;
-    let spread = tokens_cfg.get("spreadTopN")?;
+    let effective = crate::config_resolver::resolve_effective_config(workspace);
+    let spread = crate::config_resolver::get_path(&effective, "tokens.spreadTopN")?;
     // Reject bool (serde_json's Value::Bool is distinct from Number, so this
     // is naturally excluded) and non-integers.
     spread.as_i64()
@@ -639,6 +639,64 @@ mod tests {
         std::env::remove_var("LOOM_TOKEN_SPREAD_TOP_N");
         // N=1 == greedy first-eligible: always "a".
         assert_eq!(sel.name, "a");
+    }
+
+    // ---- config_resolver migration (#4241) — tier precedence ---------
+
+    fn write_legacy_config(root: &Path, contents: &str) {
+        let dir = root.join(".loom");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("config.json"), contents).unwrap();
+    }
+
+    fn write_project_config(root: &Path, contents: &str) {
+        let full = root.join(crate::config_resolver::PROJECT_CONFIG_REL);
+        fs::create_dir_all(full.parent().unwrap()).unwrap();
+        fs::write(full, contents).unwrap();
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn read_config_spread_top_n_legacy_tier_only() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        write_legacy_config(tmp.path(), r#"{"tokens": {"spreadTopN": 3}}"#);
+        let n = read_config_spread_top_n(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(n, Some(3));
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn read_config_spread_top_n_project_tier_only_is_honored() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        write_project_config(tmp.path(), r#"{"tokens": {"spreadTopN": 5}}"#);
+        let n = read_config_spread_top_n(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(n, Some(5));
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn read_config_spread_top_n_project_tier_overrides_legacy() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        write_legacy_config(tmp.path(), r#"{"tokens": {"spreadTopN": 2}}"#);
+        write_project_config(tmp.path(), r#"{"tokens": {"spreadTopN": 7}}"#);
+        let n = read_config_spread_top_n(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(n, Some(7));
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn read_config_spread_top_n_missing_everywhere_is_none() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        let n = read_config_spread_top_n(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(n, None);
     }
 
     #[test]

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -2179,6 +2179,18 @@ assert_allow_env "write-confinement: LOOM_GUARD_WORKTREE_ISOLATION=0 -> allow at
 assert_deny_env "write-confinement: LOOM_GUARD_WORKTREE_ISOLATION=1 overrides config-off -> deny" \
     "LOOM_GUARD_WORKTREE_ISOLATION=1" "echo x > $WT_REPO_OFF/defaults/hooks/f.sh" "$WT_REPO_OFF"
 
+# config_resolver migration (#4241): a `guards.worktreeIsolation:false` set
+# ONLY in the .loom-project/project.json tier (no legacy .loom/config.json)
+# must be honored the same as the legacy-tier test above -- proves
+# worktree_isolation_guard_enabled() actually resolves through
+# loom_config_get()/config-resolver.sh rather than reading .loom/config.json
+# directly.
+WT_REPO_PROJECT_OFF=$(make_wt_repo)
+mkdir -p "$WT_REPO_PROJECT_OFF/.loom-project"
+printf '%s' '{"guards":{"worktreeIsolation":false}}' > "$WT_REPO_PROJECT_OFF/.loom-project/project.json"
+assert_allow "write-confinement: guards.worktreeIsolation:false in .loom-project/ tier only -> allow at main root" \
+    "echo x > $WT_REPO_PROJECT_OFF/defaults/hooks/f.sh" "$WT_REPO_PROJECT_OFF"
+
 # False-positive guard: a `>` quoted inside a -m/--body value must NOT be
 # read as a redirection target (COMMAND_ASK_SCAN redaction, mirrors #3679).
 assert_allow "write-confinement: '>' inside a quoted -m value is not a target" \


### PR DESCRIPTION
## Summary

Four readers of `.loom/config.json` post-dated #4047's config-resolver call-site
migration and were still bypassing the tiered resolver: `select.rs`'s
`spreadTopN` reader, `daemon_heartbeat.rs`'s heartbeat-config reader, and two
bespoke `jq` reads in `guard-destructive-generic.sh` / `guard-worktree-paths.sh`.
This closes that drift by migrating what's safe to migrate and adding an
explicit `CARVE-OUT` decision, matching #4063's pattern, for the read that
should stay bespoke.

## Changes

- `loom-daemon/src/tokens_pool/select.rs::read_config_spread_top_n` — now
  resolves `tokens.spreadTopN` through `config_resolver::resolve_effective_config`
  / `get_path` instead of a direct `serde_json` read of `.loom/config.json`.
- `loom-daemon/src/daemon_heartbeat.rs::read_heartbeat_config` — now resolves
  `autonomous.heartbeat` through the same resolver, mirroring the shape of the
  already-migrated `token_ranking_refresh.rs` / `auto_update.rs` readers (the
  function's own doc comment claimed to mirror `read_token_ranking_refresh_config`,
  which was already migrated — this brings it back in sync).
- `defaults/hooks/guard-destructive-generic.sh` + `.loom/hooks/` copy —
  `worktree_isolation_guard_enabled()` now reads `guards.worktreeIsolation` via
  `loom_config_get()` (config-resolver.sh) instead of a bespoke `jq` read of the
  legacy file only. Runs on the Bash write-scope cold path (after `REPO_ROOT` is
  already resolved), so the extra resolver forks are not a hot-path cost.
  Explicit-`false`-vs-absent polarity is preserved (`raw == "false"` check, not
  `//`).
- `defaults/hooks/guard-worktree-paths.sh` + `.loom/hooks/` copy — added
  explicit `CARVE-OUT (#4241, same class as #4063)` doc comments on both reads
  (`guards.worktreeIsolation`, `worktree.root`) instead of migrating: this
  guard's `worktree_isolation_guard_enabled()` runs unconditionally on *every*
  Edit/Write PreToolUse with no cheaper structural pre-check upstream, so fanning
  a single jq read out to the resolver's up-to-5-fork tier merge is the exact
  #3687 fork-budget regression this repo already decided against once; the
  `worktree.root` read stays inline for the same self-containment rationale the
  function already documented (fail-open contract independent of another
  library's behavior).
- New regression tests: Rust tier-precedence tests for both migrated readers
  (project-tier-only, project-overrides-legacy, missing-everywhere), and a new
  hook test proving `guards.worktreeIsolation:false` set *only* in
  `.loom-project/project.json` is honored by the migrated guard.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `tokens.spreadTopN` resolves through the Rust config resolver | ✅ | `select.rs::read_config_spread_top_n` now calls `config_resolver::resolve_effective_config` / `get_path`; new tests `read_config_spread_top_n_project_tier_only_is_honored` / `_project_tier_overrides_legacy` |
| `autonomous.heartbeat` resolves through the Rust config resolver, matching migrated `auto_update.rs` shape | ✅ | `daemon_heartbeat.rs::read_heartbeat_config` now calls `config_resolver`; new tests `test_config_project_tier_only_is_honored_like_legacy` / `_project_tier_overrides_legacy_overlap_and_supplies_non_overlap` |
| Each of the three hook reads is either migrated or carries an explicit CARVE-OUT | ✅ | `guard-destructive-generic.sh`'s `worktree_isolation_guard_enabled` migrated to `loom_config_get`; `guard-worktree-paths.sh`'s two reads (`guards.worktreeIsolation`, `worktree.root`) both carry `CARVE-OUT (#4241)` comments with rationale |
| Guard default-on/fail-open behavior is regression-tested | ✅ | New hook test: `.loom-project/`-only `guards.worktreeIsolation:false` → allow; existing tests still cover explicit-false-in-legacy-tier and absent-key-stays-on |
| `defaults/hooks/` and `.loom/hooks/` updated in lockstep | ✅ | Both `guard-destructive-generic.sh` and `guard-worktree-paths.sh` diffs are identical between `defaults/hooks/` and `.loom/hooks/` |

## Test Plan

- `cd loom-daemon && cargo test tokens_pool` — 178 passed, 0 failed
- `cd loom-daemon && cargo test daemon_heartbeat` — 16 passed, 0 failed
- `cargo check` (loom-daemon) — clean
- `bash tests/hooks/test-guard-destructive.sh` — 447/459 passed. The 12
  failures (`git push --force`/`git reset --hard` ask-detection, `forceScope`
  truth-table x2/x5, `decisionLog` truth-table x2) are pre-existing and
  unrelated to this change — verified identical on `origin/main` before this
  PR's commit (458 total baseline tests, same 12 failures, same names), and
  none touch `worktreeIsolation`/`worktree.root`/the migrated readers.
- Manual: with no `.loom-project/`, both migrated readers and the migrated
  guard fall back to the legacy `.loom/config.json` tier exactly as before
  (existing legacy-tier-only tests still pass).

Closes #4241
