### PR TITLE
fix(daemon): route dispatched sweeps + role spawns through claude-wrapper.sh with Execution-error retry

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -899,6 +899,15 @@ is_transient_error() {
         "MCP.*failed"
         "plugins failed"
         "plugin.*failed to install"
+        # Issue #4255: the Claude CLI's bare `Execution error` fatal. This is the
+        # single most common unattended-death signature — 21% of daemon sweep
+        # logs terminated on it — yet it matched NONE of the patterns above, and
+        # because the CLI prints it (non-empty output) the empty-output-with-
+        # exit-1 heuristic below never fired either, so the wrapper died on
+        # attempt 1 without a single retry. Treat it as transient/retryable
+        # (bounded by MAX_RETRIES): it is an opaque transport/harness fault, not
+        # a deterministic build failure, so a retry frequently succeeds.
+        "Execution error"
     )
 
     for pattern in "${patterns[@]}"; do
@@ -915,6 +924,41 @@ is_transient_error() {
     fi
 
     return 1
+}
+
+# Issue #4255: emit a structured, self-diagnosing block when the wrapper gives
+# up on a child PERMANENTLY (a non-transient error, or the retry budget
+# exhausted). Before this, a daemon-dispatched sweep that died left only the
+# child's raw output — often the single opaque line `Execution error` — in
+# `.loom/logs/sweep-issue-<N>.log`, with no exit code, no error classification,
+# and no stderr context, so every forensic pass had to guess. This records the
+# exit code, the `classify-error.sh` verdict, and the tail of the captured
+# stdout+stderr so a permanent death is diagnosable straight from the sweep log.
+#
+#   log_permanent_death <exit_code> <output> [reason]
+LOOM_DEATH_TAIL_LINES="${LOOM_DEATH_TAIL_LINES:-20}"
+log_permanent_death() {
+    local exit_code="$1"
+    local output="$2"
+    local reason="${3:-permanent failure}"
+
+    local classification="UNCLASSIFIED"
+    if declare -F classify_error >/dev/null 2>&1; then
+        classification="$(classify_error "${output}" "${exit_code}" 2>/dev/null || echo "UNCLASSIFIED")"
+    fi
+
+    local tail_text
+    tail_text="$(printf '%s\n' "${output}" | tail -n "${LOOM_DEATH_TAIL_LINES}")"
+
+    log_error "=== claude-wrapper: permanent death (${reason}) ==="
+    log_error "exit_code=${exit_code} classification=${classification}"
+    log_error "stderr/stdout tail (last ${LOOM_DEATH_TAIL_LINES} lines):"
+    # Emit the tail as discrete log lines so timestamps and the [ERROR] prefix
+    # bracket the captured block in the sweep log.
+    while IFS= read -r _line; do
+        log_error "  | ${_line}"
+    done <<< "${tail_text}"
+    log_error "=== end permanent-death diagnostics ==="
 }
 
 # --- Account rotation on usage/session-limit exhaustion (issue #3738) ---
@@ -1829,7 +1873,9 @@ run_with_retry() {
         # Check if this is a transient error worth retrying
         if ! is_transient_error "${output}" "${exit_code}"; then
             log_error "Non-transient error detected - not retrying"
-            log_error "Output: ${output}"
+            # Issue #4255: structured permanent-death diagnostics (exit code +
+            # classification + stderr tail) in place of a bare `Output: ...`.
+            log_permanent_death "${exit_code}" "${output}" "non-transient error"
             clear_retry_state
             return "${exit_code}"
         fi
@@ -1873,7 +1919,10 @@ run_with_retry() {
     done
 
     log_error "Max retries (${MAX_RETRIES}) exceeded"
-    log_error "Last error: ${output}"
+    # Issue #4255: structured permanent-death diagnostics (exit code +
+    # classification + stderr tail) so an exhausted-retry death is diagnosable
+    # from the sweep log instead of only a bare `Last error: ...` line.
+    log_permanent_death "${exit_code}" "${output}" "max retries (${MAX_RETRIES}) exceeded"
     clear_retry_state
 
     # When the last failure was MCP-related, exit with code 7 so the

--- a/defaults/scripts/tests/test-spawn-claude.sh
+++ b/defaults/scripts/tests/test-spawn-claude.sh
@@ -1096,6 +1096,122 @@ fi
 rm -rf "$PRIO_DIR"
 
 # ============================================================
+# Section 8: claude-wrapper.sh `Execution error` retry + permanent-death
+#            diagnostics (issue #4255)
+#
+# The Claude CLI's bare `Execution error` fatal was the single most common
+# unattended-death signature (21% of daemon sweep logs) yet matched none of
+# is_transient_error()'s patterns, so the wrapper died on attempt 1 without a
+# retry. It is now recognized as transient (bounded by LOOM_MAX_RETRIES), and a
+# permanent death emits a structured diagnostics block (exit code + classification
+# + stderr tail) instead of only the bare string. Both are unit-tested by sourcing
+# the wrapper with CLAUDE_WRAPPER_SOURCE_ONLY=1 (suppresses `main "$@"`).
+# ============================================================
+
+echo ""
+echo "Testing claude-wrapper.sh Execution-error handling (#4255)..."
+
+EE_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_WS" "$STUB_DIR" "$EE_DIR"' EXIT
+
+# --- Unit: is_transient_error() now recognizes the bare `Execution error` ---
+cat > "$EE_DIR/transient-driver.sh" <<'DRIVER'
+#!/usr/bin/env bash
+CLAUDE_WRAPPER_SOURCE_ONLY=1 source "$WRAPPER"
+set +e
+if is_transient_error "Execution error" 1; then echo "TRANSIENT=yes"; else echo "TRANSIENT=no"; fi
+# A genuinely deterministic non-transient failure must still be non-transient.
+if is_transient_error "error: unknown option '--frobnicate'" 1; then
+    echo "UNKNOWN=transient"
+else
+    echo "UNKNOWN=fatal"
+fi
+DRIVER
+ee_transient=$(WRAPPER="$WRAPPER" bash "$EE_DIR/transient-driver.sh" 2>&1)
+assert_contains "TRANSIENT=yes" "$ee_transient" \
+    "is_transient_error treats bare 'Execution error' as transient (#4255)"
+assert_contains "UNKNOWN=fatal" "$ee_transient" \
+    "is_transient_error still treats an unrelated deterministic error as non-transient (#4255)"
+
+# --- Unit: log_permanent_death() emits exit code + classification + tail ---
+cat > "$EE_DIR/death-driver.sh" <<'DRIVER'
+#!/usr/bin/env bash
+CLAUDE_WRAPPER_SOURCE_ONLY=1 source "$WRAPPER"
+set +e
+log_permanent_death 42 "line one
+line two
+Execution error" "max retries (2) exceeded" 2>&1
+DRIVER
+ee_death=$(WRAPPER="$WRAPPER" bash "$EE_DIR/death-driver.sh" 2>&1)
+assert_contains "permanent death (max retries (2) exceeded)" "$ee_death" \
+    "log_permanent_death labels the reason (#4255)"
+assert_contains "exit_code=42" "$ee_death" \
+    "log_permanent_death records the exit code (#4255)"
+assert_contains "classification=" "$ee_death" \
+    "log_permanent_death records the classify-error verdict (#4255)"
+assert_contains "Execution error" "$ee_death" \
+    "log_permanent_death includes the stderr/stdout tail (#4255)"
+
+# --- Integration: a stub that always prints `Execution error` retries up to
+#     LOOM_MAX_RETRIES, then dies permanently with the diagnostics block. ---
+if [[ -z "$DAEMON_BIN" ]]; then
+    echo "  (skipping Execution-error retry integration test — loom-daemon binary not found)"
+else
+  EE_WS="$(mktemp -d)"
+  mkdir -p "$EE_WS/.loom/tokens"
+  chmod 700 "$EE_WS/.loom/tokens"
+  printf '%s' "tok-solo" > "$EE_WS/.loom/tokens/solo.token"
+  chmod 600 "$EE_WS/.loom/tokens/solo.token"
+
+  EE_STUB="$(mktemp -d)"
+  cat > "$EE_STUB/claude" <<'STUB'
+#!/usr/bin/env bash
+case " $* " in
+  *" -p "*) ;;
+  *) exit 0 ;;
+esac
+echo "Execution error"
+exit 1
+STUB
+  chmod +x "$EE_STUB/claude"
+
+  set +e
+  ee_out=$(
+    LOOM_WORKSPACE="$EE_WS" \
+    LOOM_TOKEN_NAME="solo" \
+    CLAUDE_CODE_OAUTH_TOKEN="tok-solo" \
+    LOOM_DAEMON_BIN="$DAEMON_BIN" \
+    LOOM_MAX_RETRIES=2 \
+    LOOM_INITIAL_WAIT=0 \
+    LOOM_SHEPHERD_TASK_ID="test-execution-error" \
+    LOOM_STARTUP_MONITOR_WINDOW=1 \
+    PATH="$EE_STUB:$PATH" \
+    bash "$WRAPPER" -p "ping" 2>&1
+  )
+  ee_rc=$?
+  set -e
+
+  assert_contains "Detected transient error pattern: Execution error" "$ee_out" \
+      "wrapper retries on the bare 'Execution error' output (#4255)"
+  assert_contains "Max retries (2) exceeded" "$ee_out" \
+      "wrapper stops after LOOM_MAX_RETRIES attempts (#4255)"
+  assert_contains "permanent death" "$ee_out" \
+      "wrapper emits the permanent-death diagnostics block on final failure (#4255)"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  if [[ "$ee_rc" -ne 0 ]]; then
+      TESTS_PASSED=$((TESTS_PASSED + 1))
+      echo -e "  ${GREEN}PASS${NC}: wrapper exits non-zero after exhausting retries on Execution error"
+  else
+      TESTS_FAILED=$((TESTS_FAILED + 1))
+      echo -e "  ${RED}FAIL${NC}: wrapper exits non-zero after exhausting retries on Execution error"
+  fi
+
+  rm -rf "$EE_WS" "$EE_STUB"
+fi
+
+rm -rf "$EE_DIR"
+
+# ============================================================
 # Summary
 # ============================================================
 

--- a/loom-daemon/src/role_runner.rs
+++ b/loom-daemon/src/role_runner.rs
@@ -349,8 +349,18 @@ fn run_role_with_timeout(
     let mut cmd = Command::new(script);
     cmd.arg("-p")
         .arg(prompt)
-        .arg("--dangerously-skip-permissions")
-        .current_dir(workspace_root)
+        .arg("--dangerously-skip-permissions");
+    // Transient-error recovery (issue #4255): scheduled role spawns are the
+    // same unattended class as daemon-dispatched sweeps, so route them through
+    // `claude-wrapper.sh` (retry/backoff/classification, bounded by
+    // `LOOM_MAX_RETRIES`) instead of running bare `claude` that dies on the
+    // first transient API failure. `spawn-claude.sh` consumes `--use-wrapper`
+    // (not forwarded to `claude`) and execs the wrapper. Operators can force
+    // the legacy single-shot path with `LOOM_USE_WRAPPER=0`.
+    if sweep_registry::wrapper_dispatch_enabled() {
+        cmd.arg("--use-wrapper");
+    }
+    cmd.current_dir(workspace_root)
         .env(sweep_registry::WORKSPACE_ENV, workspace_root)
         .stdin(Stdio::null())
         .stdout(Stdio::from(out_file))
@@ -884,6 +894,48 @@ mod tests {
         let mut runner =
             ScriptRoleInvocationRunner::new(tmp.path().to_path_buf()).with_spawn_bin(script);
         assert_eq!(runner.invoke("curator", "/curator"), RoleTickOutcome::Success);
+    }
+
+    /// Issue #4255: a scheduled role spawn routes through `claude-wrapper.sh` by
+    /// appending `--use-wrapper` after `--dangerously-skip-permissions`, so a
+    /// transient API death is retried instead of killing the unattended role run
+    /// on the first failure. Serialized on a named lock shared with the opt-out
+    /// test so the `LOOM_USE_WRAPPER` env mutation cannot race it.
+    #[test]
+    #[serial(loom_use_wrapper_env)]
+    fn test_invoke_appends_use_wrapper_flag() {
+        std::env::remove_var("LOOM_USE_WRAPPER");
+        let tmp = tempfile::tempdir().unwrap();
+        // Succeeds only when the 4th arg is exactly --use-wrapper.
+        let script = write_fake_script(
+            tmp.path(),
+            "fake-spawn.sh",
+            "[ \"$3\" = \"--dangerously-skip-permissions\" ] && [ \"$4\" = \"--use-wrapper\" ] && exit 0 || exit 1",
+        );
+        let mut runner =
+            ScriptRoleInvocationRunner::new(tmp.path().to_path_buf()).with_spawn_bin(script);
+        assert_eq!(runner.invoke("curator", "/curator"), RoleTickOutcome::Success);
+    }
+
+    /// Issue #4255: the `LOOM_USE_WRAPPER=0` debug opt-out restores the legacy
+    /// single-shot argv — argv ends at `--dangerously-skip-permissions` with no
+    /// `--use-wrapper` token.
+    #[test]
+    #[serial(loom_use_wrapper_env)]
+    fn test_invoke_opt_out_omits_use_wrapper_flag() {
+        std::env::set_var("LOOM_USE_WRAPPER", "0");
+        let tmp = tempfile::tempdir().unwrap();
+        // Succeeds only when there is NO 4th arg (argv ends at skip-permissions).
+        let script = write_fake_script(
+            tmp.path(),
+            "fake-spawn.sh",
+            "[ \"$3\" = \"--dangerously-skip-permissions\" ] && [ -z \"$4\" ] && exit 0 || exit 1",
+        );
+        let mut runner =
+            ScriptRoleInvocationRunner::new(tmp.path().to_path_buf()).with_spawn_bin(script);
+        let outcome = runner.invoke("curator", "/curator");
+        std::env::remove_var("LOOM_USE_WRAPPER");
+        assert_eq!(outcome, RoleTickOutcome::Success);
     }
 
     #[test]

--- a/loom-daemon/src/safehouse.rs
+++ b/loom-daemon/src/safehouse.rs
@@ -473,6 +473,7 @@ pub fn event_to_envelope(event: &Event) -> Option<Envelope> {
         Event::SweepCrashed {
             issue,
             checkpoint_phase,
+            classification: _,
             repo,
         } => {
             let phase = checkpoint_phase.as_deref().unwrap_or("unknown");
@@ -1331,6 +1332,7 @@ mod tests {
         let crashed = Event::SweepCrashed {
             issue: 42,
             checkpoint_phase: Some("judge".to_owned()),
+            classification: None,
             repo: Some("/repos/vibesql".to_owned()),
         };
         let env = event_to_envelope(&crashed).unwrap();

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -994,6 +994,54 @@ fn classify_account_exhaustion(log_tail: &str) -> Option<&'static str> {
         .map(|(label, _)| *label)
 }
 
+/// Best-effort crash classification for the `sweep.issue.{N}.crashed` payload
+/// (Issue #4255). Derives a short, stable label from the dead sweep's log tail
+/// plus its exit code so a subscriber (#4137 telemetry) can attribute WHY the
+/// sweep died rather than re-parsing free-form logs.
+///
+/// Precedence, most-specific first:
+/// 1. `account-exhausted:<signature>` — the account hit a usage/weekly/session
+///    limit (reuses the #4122 signature table so the daemon classifies
+///    exhaustion the same way the wrapper does).
+/// 2. `execution-error` — the CLI printed the bare `Execution error` string
+///    (the chronic transient-death mode this issue targets; the wrapper now
+///    retries it, so reaching the reaper means retries were exhausted).
+/// 3. `exit-<code>` — any other non-zero exit whose log yields no known
+///    signature. `None` when the exit was clean/unknown with no signature, so
+///    the field is omitted from the wire form rather than carrying noise.
+fn classify_crash(log_tail: &str, exit_code: Option<i32>) -> Option<String> {
+    if let Some(sig) = classify_account_exhaustion(log_tail) {
+        return Some(format!("account-exhausted:{sig}"));
+    }
+    // Literal `Execution error` (case-insensitive) — the unlogged transient
+    // death mode. Mirrors `claude-wrapper.sh::is_transient_error`'s new pattern
+    // so a death that survived the wrapper's retry loop is still labeled.
+    if log_tail.to_ascii_lowercase().contains("execution error") {
+        return Some("execution-error".to_string());
+    }
+    match exit_code {
+        Some(0) | None => None,
+        Some(code) => Some(format!("exit-{code}")),
+    }
+}
+
+/// Whether a daemon-dispatched child should route through `claude-wrapper.sh`'s
+/// retry/backoff/classification layer (Issue #4255).
+///
+/// Daemon dispatch and the role runner are the unattended paths that most need
+/// transient-error recovery, so the wrapper is the **default** — `spawn_child`
+/// and the role runner append `--use-wrapper` to the `spawn-claude.sh` argv.
+/// An operator can force the legacy single-shot path (bare `claude`, no retry)
+/// for debugging by exporting `LOOM_USE_WRAPPER` to a falsey value
+/// (`0`/`false`/`no`/`off`, case-insensitive). Any other value — or the var
+/// being unset — keeps the wrapper on.
+pub(crate) fn wrapper_dispatch_enabled() -> bool {
+    match std::env::var("LOOM_USE_WRAPPER") {
+        Ok(v) => !matches!(v.trim().to_ascii_lowercase().as_str(), "0" | "false" | "no" | "off"),
+        Err(_) => true,
+    }
+}
+
 /// Resolve the per-call reaper `gh` timeout (Issue #3973): the
 /// [`REAP_GH_TIMEOUT_ENV`] override (whole seconds, must be > 0) or the
 /// [`REAP_GH_TIMEOUT`] default.
@@ -3203,6 +3251,23 @@ impl SweepRegistry {
         // AFTER `--model`/`--effort` (and the prompt-embedded `--claim-owned`
         // / `--depends-on`) so the positional argv contract is unchanged.
         cmd.arg("--dangerously-skip-permissions");
+        // Transient-error recovery (issue #4255): route the child through
+        // `claude-wrapper.sh` so a transient API death (rate-limit storm, 5xx,
+        // overloaded, or the CLI's bare `Execution error`) is retried with
+        // exponential backoff per `LOOM_MAX_RETRIES` instead of killing the
+        // whole sweep on the first failure — the daemon dispatch path is the
+        // unattended path that most needs it (21% of sweep logs died this way
+        // before this flag). `spawn-claude.sh` consumes `--use-wrapper` (it is
+        // NOT forwarded to `claude`) and execs the wrapper, which forwards the
+        // daemon's `-p/--model/--effort/--dangerously-skip-permissions` argv
+        // verbatim. Appended AFTER `--dangerously-skip-permissions` so the
+        // positional prompt contract (#4111/#4121) is unchanged and existing
+        // argv-prefix assertions still hold. Operators can force the legacy
+        // single-shot path with `LOOM_USE_WRAPPER=0` (see
+        // `wrapper_dispatch_enabled`).
+        if wrapper_dispatch_enabled() {
+            cmd.arg("--use-wrapper");
+        }
         cmd.env("LOOM_TERMINAL_ID", format!("daemon-{sweep_id}"))
             // Claim-ownership marker (issue #3823): `dispatch()` flips
             // loom:issue -> loom:building on the forge BEFORE this child is
@@ -3675,6 +3740,18 @@ impl SweepRegistry {
                                 let _ = self.restore_label_to_ready(issue);
                             }
                             let checkpoint_phase = read_checkpoint_phase(&checkpoint);
+                            // Issue #4255: attribute WHY the sweep died by
+                            // classifying the tail of its log (account
+                            // exhaustion / `Execution error` / bare exit code)
+                            // and carrying that verdict on the crashed event
+                            // alongside the phase. Best-effort: an unreadable
+                            // log yields `None`, exactly like a clean exit.
+                            let log_path = self.entries.get(&sweep_id).map(|i| i.log_path.clone());
+                            let classification = log_path
+                                .as_deref()
+                                .and_then(|p| tail_lines(p, EXHAUSTION_LOG_TAIL_LINES).ok())
+                                .map(|lines| lines.join("\n"))
+                                .and_then(|tail| classify_crash(&tail, exit_code));
                             if let Some(info) = self.entries.get_mut(&sweep_id) {
                                 info.state = SweepState::Crashed { at: now };
                                 if info.latest_phase.is_none() {
@@ -3684,6 +3761,7 @@ impl SweepRegistry {
                             events_to_emit.push(Event::SweepCrashed {
                                 issue,
                                 checkpoint_phase,
+                                classification,
                                 repo: None, // stamped by emit_event (#3929)
                             });
                             events_to_emit.push(Event::SweepGlobalCompleted {
@@ -4297,6 +4375,7 @@ impl SweepRegistry {
                         self.emit_event(Event::SweepCrashed {
                             issue,
                             checkpoint_phase: None,
+                            classification: None,
                             repo: None, // stamped by emit_event (#3929)
                         });
                     }
@@ -4316,6 +4395,7 @@ impl SweepRegistry {
                             self.emit_event(Event::SweepCrashed {
                                 issue,
                                 checkpoint_phase: None,
+                                classification: None,
                                 repo: None, // stamped by emit_event (#3929)
                             });
                         }
@@ -4476,6 +4556,7 @@ impl SweepRegistry {
                         self.emit_event(Event::SweepCrashed {
                             issue,
                             checkpoint_phase: None,
+                            classification: None,
                             repo: None, // stamped by emit_event (#3929)
                         });
                     }
@@ -5772,6 +5853,89 @@ exit 0
         );
     }
 
+    /// Issue #4255: a daemon dispatch routes the child through
+    /// `claude-wrapper.sh` by appending `--use-wrapper` immediately AFTER
+    /// `--dangerously-skip-permissions`, so a transient API death (rate-limit /
+    /// 5xx / overloaded / bare `Execution error`) is retried instead of killing
+    /// the whole sweep on the first failure. Serialized on the named
+    /// `loom_use_wrapper_env` lock shared with every other test that reads or
+    /// mutates `LOOM_USE_WRAPPER` (this module + `role_runner`), so a concurrent
+    /// opt-out test cannot flip the flag mid-run.
+    #[test]
+    #[serial(loom_use_wrapper_env)]
+    fn dispatch_appends_use_wrapper_flag() {
+        std::env::remove_var("LOOM_USE_WRAPPER");
+        let dir = tempdir().unwrap();
+        let (mut registry, record_log) = fixture_registry(dir.path());
+
+        let outcome = registry
+            .dispatch(&SweepKind::Issue(4255), None, None, None, None)
+            .expect("dispatch should succeed");
+
+        let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
+        let recorded = assert_child_wrote(&record_log, &needle);
+        assert!(
+            recorded.contains("--dangerously-skip-permissions --use-wrapper"),
+            "expected --use-wrapper appended after --dangerously-skip-permissions; got: {recorded}"
+        );
+        // The flag must be its OWN argv token (spawn-claude.sh consumes it), not
+        // folded into the prompt like --claim-owned.
+        assert!(
+            recorded.contains("arg: --use-wrapper"),
+            "expected --use-wrapper as a standalone argv token; got: {recorded}"
+        );
+    }
+
+    /// Issue #4255: the `LOOM_USE_WRAPPER=0` debug opt-out restores the legacy
+    /// single-shot argv — no `--use-wrapper` token — so an operator can
+    /// reproduce a raw first-shot failure. Shares the named `loom_use_wrapper_env`
+    /// lock so it never races the presence tests that assume the wrapper-on default.
+    #[test]
+    #[serial(loom_use_wrapper_env)]
+    fn dispatch_opt_out_omits_use_wrapper_flag() {
+        std::env::set_var("LOOM_USE_WRAPPER", "0");
+        let dir = tempdir().unwrap();
+        let (mut registry, record_log) = fixture_registry(dir.path());
+
+        let outcome = registry
+            .dispatch(&SweepKind::Issue(4256), None, None, None, None)
+            .expect("dispatch should succeed");
+
+        let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
+        let recorded = assert_child_wrote(&record_log, &needle);
+        std::env::remove_var("LOOM_USE_WRAPPER");
+        assert!(
+            !recorded.contains("--use-wrapper"),
+            "LOOM_USE_WRAPPER=0 must suppress --use-wrapper; got: {recorded}"
+        );
+        // The rest of the argv contract is unchanged.
+        assert!(
+            recorded.contains("--dangerously-skip-permissions"),
+            "opt-out must not drop --dangerously-skip-permissions; got: {recorded}"
+        );
+    }
+
+    /// Issue #4255: `classify_crash` derives a stable label from a dead sweep's
+    /// log tail + exit code for the `sweep.issue.{N}.crashed` payload.
+    #[test]
+    fn classify_crash_labels_death_causes() {
+        // The chronic transient-death signature (case-insensitive).
+        assert_eq!(
+            classify_crash("spawn preamble\nExecution error\n", None).as_deref(),
+            Some("execution-error")
+        );
+        // Account exhaustion wins over everything else (reuses the #4122 table).
+        assert_eq!(
+            classify_crash("hit your weekly limit — try again later", Some(1)).as_deref(),
+            Some("account-exhausted:rate-limited")
+        );
+        // Any other non-zero exit with no known signature → bare exit label.
+        assert_eq!(classify_crash("some opaque build failure", Some(2)).as_deref(), Some("exit-2"));
+        // A clean/unknown exit with no signature carries no classification.
+        assert_eq!(classify_crash("", Some(0)), None);
+        assert_eq!(classify_crash("nothing notable", None), None);
+    }
+
     /// Issue #3823 (Option A): `spawn_child` exports the claim-ownership
     /// marker `LOOM_SWEEP_CLAIM_OWNED=<issue>` into the dispatched child so its
     /// `/loom:sweep` pre-flight recognises the daemon's own pre-dispatch
@@ -6768,6 +6932,77 @@ exit 0
         // production).
         let info = registry.get(&sweep_id).unwrap();
         assert!(matches!(info.state, SweepState::Crashed { .. }));
+    }
+
+    /// Issue #4255: the reaper's `sweep.issue.{N}.crashed` payload carries a
+    /// best-effort error classification derived from the dead sweep's log tail,
+    /// alongside `checkpoint_phase`. A log whose terminal output is the chronic
+    /// `Execution error` string is labeled `execution-error`.
+    #[tokio::test]
+    async fn reaper_crashed_event_carries_classification() {
+        use crate::event_bus::EventBus;
+
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        let bus = Arc::new(EventBus::new());
+        registry.set_event_bus(bus.clone());
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        let cp_dir = registry.config.checkpoint_dir();
+        std::fs::create_dir_all(&cp_dir).unwrap();
+        std::fs::write(cp_dir.join("issue-57.json"), r#"{"phase":"builder","issue":57}"#).unwrap();
+
+        // Write a sweep log whose terminal line is the bare `Execution error`
+        // fatal — the exact death mode this issue targets.
+        let log_path = registry.compute_log_path(57);
+        std::fs::create_dir_all(log_path.parent().unwrap()).unwrap();
+        std::fs::write(&log_path, "spawn-claude: preamble\nExecution error\n").unwrap();
+
+        let sweep_id = "sweep-issue-57-test".to_string();
+        registry.entries.insert(
+            sweep_id.clone(),
+            SweepInfo {
+                sweep_id: sweep_id.clone(),
+                kind: SweepKind::Issue(57),
+                pid: 2_147_483_641,
+                token_name: "unknown".into(),
+                log_path,
+                idempotency_key: None,
+                started_at: Utc::now(),
+                state: SweepState::Running,
+                latest_phase: None,
+                pr_number: None,
+                model: None,
+                effort: None,
+                depends_on: None,
+                repo: None,
+            },
+        );
+
+        let changed = registry.reap_once();
+        assert!(changed >= 1);
+
+        let mut saw_classified = false;
+        for _ in 0..2 {
+            let ev = sub.recv().await.unwrap();
+            if let Event::SweepCrashed {
+                issue,
+                checkpoint_phase,
+                classification,
+                ..
+            } = ev
+            {
+                assert_eq!(issue, 57);
+                assert_eq!(checkpoint_phase.as_deref(), Some("builder"));
+                assert_eq!(
+                    classification.as_deref(),
+                    Some("execution-error"),
+                    "expected the crashed event to carry the execution-error classification"
+                );
+                saw_classified = true;
+            }
+        }
+        assert!(saw_classified, "expected a classified sweep.issue.57.crashed event");
     }
 
     /// Clean-exit (no checkpoint) emits `sweep.issue.{N}.exited` plus

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -1276,6 +1276,14 @@ pub enum Event {
         issue: u32,
         #[serde(skip_serializing_if = "Option::is_none")]
         checkpoint_phase: Option<String>,
+        /// Issue #4255: the reaper's best-effort error classification derived
+        /// from the dead sweep's log tail + exit code (e.g. `execution-error`,
+        /// `account-exhausted:rate-limited`, `exit-<code>`). Carried alongside
+        /// `checkpoint_phase` so a subscriber (#4137 durable telemetry) can
+        /// attribute WHY a sweep died, not just which phase it reached. `None`
+        /// when the log yields no recognizable signature (or is unreadable).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        classification: Option<String>,
         /// Owning managed-workspace root (Issue #3929). See [`Self::SweepPhase`].
         #[serde(default, skip_serializing_if = "Option::is_none")]
         repo: Option<String>,
@@ -1516,6 +1524,7 @@ mod tests {
         let crashed = Event::SweepCrashed {
             issue: 7,
             checkpoint_phase: Some("doctor".to_string()),
+            classification: None,
             repo: Some("/repos/c".to_string()),
         };
         assert_eq!(crashed.topic(), "sweep.issue.7.crashed");


### PR DESCRIPTION
## Summary

Daemon-dispatched sweeps and daemon-native scheduled role spawns ran **bare `claude` with no retry** — `spawn_child` and the role runner built the `spawn-claude.sh` argv without `--use-wrapper`, so `claude-wrapper.sh`'s retry/backoff/classification layer never ran on the unattended path that most needs it. 21% of sweep logs on this host terminated on a single unlogged `Execution error` line.

Crucially, passing `--use-wrapper` alone would **not** have fixed it: the bare `Execution error` string matched none of `is_transient_error()`'s patterns, and because the CLI prints it (non-empty output) the empty-output-with-exit-1 heuristic never fired either — the wrapper would still have died on attempt 1. This PR does both halves.

## Changes

- **`loom-daemon/src/sweep_registry.rs`** — `spawn_child` appends `--use-wrapper` after `--dangerously-skip-permissions` (gated by `wrapper_dispatch_enabled()`, opt out with `LOOM_USE_WRAPPER=0`). New `classify_crash()` derives a stable label (`account-exhausted:<sig>` / `execution-error` / `exit-<code>`) from the dead sweep's log tail + exit code; the reaper attaches it to the `sweep.issue.{N}.crashed` event.
- **`loom-daemon/src/role_runner.rs`** — same one-line argv change for scheduled role spawns (the identical unattended class).
- **`loom-daemon/src/types.rs`** — `Event::SweepCrashed` gains a `classification: Option<String>` field (serde-optional, wire-compatible).
- **`loom-daemon/src/safehouse.rs`** — destructure updated for the new field.
- **`defaults/scripts/claude-wrapper.sh`** — `is_transient_error()` recognizes the bare `Execution error` as transient (bounded by `LOOM_MAX_RETRIES`); new `log_permanent_death()` emits exit code + `classify-error.sh` verdict + stderr/stdout tail at both permanent-death exit points.

## Acceptance Criteria Verification

- [x] A daemon-dispatched sweep **and a role-runner spawn** hitting a transient error retry per wrapper policy, including the bare `Execution error` output — verified by `dispatch_appends_use_wrapper_flag`, `test_invoke_appends_use_wrapper_flag`, and the shell retry integration test (`wrapper retries on the bare 'Execution error' output` + `Max retries (2) exceeded`).
- [x] Permanent death records exit code + stderr tail + classification, not just `Execution error` — `log_permanent_death` unit tests + reaper `classification` field test.
- [x] Single-shot opt-out remains available (`LOOM_USE_WRAPPER=0`) — `dispatch_opt_out_omits_use_wrapper_flag`, `test_invoke_opt_out_omits_use_wrapper_flag`.
- [x] Crashed-event payload carries the classification alongside `checkpoint_phase` — `reaper_crashed_event_carries_classification`.
- [x] Same-model invariant (#3477) preserved — no change to the wrapper's pre-loop `--model` handling.

## Test Plan

- `cd loom-daemon && cargo test --lib` — **1496 pre-existing + 6 new, all pass**; `cargo clippy` clean, `cargo fmt` applied.
- `bash defaults/scripts/tests/test-spawn-claude.sh` — **10 new `#4255` assertions pass**. 5 pre-existing failures (token-selection / `.bad_tokens` in Section 2/5) reproduce identically on the pristine base (verified via `git stash`) and are unrelated to this change — they involve `spawn-claude.sh` account logging, which this PR does not touch.

## Scope notes

Prevention + first-crash diagnostics only. Recovery of already-stranded post-Builder PRs (#4256), the background-Judge turn-end trap (#4257), and `loom:reviewing` staleness (#4258) are explicitly out of scope. Expect a textual rebase against #4228 (concurrent token-selection rewrite of the same files).

Closes #4255

🤖 Generated with [Claude Code](https://claude.com/claude-code)
