### PR TITLE
feat(install): user-scope skills/agents resolve from the machine checkout (Epic #3835 Phase 4)

### DIFF
--- a/defaults/docs/machine-dispatcher.md
+++ b/defaults/docs/machine-dispatcher.md
@@ -252,6 +252,65 @@ writeup. **Linux has no equivalent** — the non-Darwin path is a plain `nohup �
 &` with no reboot/crash recovery and no watchdog. This is tracked as a named
 follow-up, #4260, rather than designed inline here.
 
+## User-scope skills + agents (Epic #3835 Phase 4, #4261)
+
+The `/loom:*` slash-command skills and the `loom-*` subagents also resolve from
+the machine-level checkout, provisioned by
+`scripts/install/provision-skills.sh` (sibling of `provision-dispatcher.sh`)
+next to the dispatcher install:
+
+```
+~/.claude/commands/loom      -> <checkout>/defaults/.claude/commands/loom   (whole-directory symlink)
+~/.claude/agents/loom-<role>.md -> <checkout>/defaults/.claude/agents/loom-<role>.md  (per-file symlinks)
+```
+
+Why the two shapes differ:
+
+- **Commands are one whole-directory symlink.** `.claude/commands/loom/` is a
+  Loom-owned namespace, so a single link is the minimal surface, keeps
+  `.claude/commands/` itself a real directory (a co-installed tool can still
+  write sibling namespaces into it), and preserves the relative cross-references
+  between skill files (e.g. one skill `@`-including `probe-protocol.md`).
+- **Agents are per-file symlinks.** `~/.claude/agents/` is **shared** with the
+  operator's own agents, so it cannot be wholesale-symlinked; each
+  `loom-<role>.md` is linked individually and non-Loom agents are untouched.
+
+Both link **through the checkout path** (`<checkout>/defaults/...`, default
+checkout `~/.local/share/loom`), never the installer's transient source root.
+Because `~/.local/share/loom` is itself a symlink to the source checkout, the
+links stay valid even if the machine checkout is later re-provisioned, and
+**`loom update` (refreshing the checkout) updates the skills/agents seen by
+every repo at once** — they cannot drift per-repo.
+
+Provisioning is additive and best-effort (never fatal). It:
+
+- **Never clobbers a real destination.** An operator's hand-tuned
+  `~/.claude/agents/loom-judge.md`, or a real `~/.claude/commands/loom/`
+  directory, is left as-is with a warning.
+- **Repoints a stale symlink** (e.g. one left by an older checkout location) to
+  the current checkout.
+- **Prunes a dangling `loom-*` agent link** whose target no longer exists in the
+  checkout (a renamed/removed role) — but only when the broken link points into
+  a checkout's `defaults/.claude/agents/` tree, never an operator's own link.
+
+### Transition precedence (not a bug)
+
+Until Phase 6 (#4254) strips the committed per-repo copies, an already-installed
+consumer repo keeps its `.claude/commands/loom/*` files, and Claude Code
+resolves a **project-level** definition over a **user-level** one when names
+collide. Those repos therefore keep resolving their (possibly stale) copies
+until migration; this provisioning only changes what **fresh installs and
+post-migration repos** resolve. The coexistence is expected and does not error —
+provisioning does not try to force user scope to win.
+
+> **Scope boundary (Phase 4 vs Phase 6).** This phase adds the user-scope
+> resolution *mechanism* (the replacement Phase 6 depends on). Ceasing the
+> per-repo copy on a fresh install is coupled to `loom-daemon init` (Rust),
+> which materializes `.claude/commands/loom/` + `.claude/agents/` and whose own
+> post-init validation (and the installer's `EXPECTED_FILES` check) currently
+> requires those trees present. That cutover lands with Phase 6's
+> `git rm --cached` migration, not here.
+
 ## Uninstall semantics
 
 A per-repo `uninstall-loom.sh` removes only the per-repo `./.loom/bin/loom` pool
@@ -259,3 +318,10 @@ manager. The machine-level `~/.local/bin/loom` dispatcher and the
 `~/.local/share/loom` checkout link are **not** removed by a per-repo uninstall —
 same semantics as the shared `~/.local/bin/loom-daemon` binary, which outlives any
 single repo's uninstall.
+
+The user-scope skill + agent links follow the **same** shared-resource rule:
+they are one set resolved by every repo on the machine, so a per-repo uninstall
+does not remove them (that would break `/loom:*` for every other consumer repo).
+A machine-level teardown removes them via `deprovision_loom_skills` in
+`scripts/install/provision-skills.sh`, which deletes a link only when it points
+into the machine checkout and never touches an operator's real files.

--- a/defaults/scripts/tests/test-provision-skills.sh
+++ b/defaults/scripts/tests/test-provision-skills.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# test-provision-skills.sh — tests for user-scope Loom skills + agents
+# provisioning (Epic #3835 Phase 4, #4261).
+#
+# Covers scripts/install/provision-skills.sh:
+#   - fresh provision creates the whole-dir commands link + all agent links,
+#     all pointing THROUGH the machine checkout (#4261 design decision 3)
+#   - the verifiable-globals contract (PROVISIONED_SKILLS_LINK /
+#     PROVISIONED_AGENT_LINKS, mirroring provision-dispatcher.sh #4053)
+#   - idempotent re-provision
+#   - a pre-existing REAL file/dir at a destination is left untouched + warned
+#     (never clobber an operator's hand-tuned agent or a real commands dir)
+#   - a stale symlink (into an old checkout) is repointed
+#   - a dangling loom-* agent link (renamed/removed role) is pruned
+#   - soft failure (missing source) returns 1 without aborting the caller
+#   - deprovision removes links iff they point into the checkout, never real files
+#
+# Sandboxed $HOME per case via mktemp -d, matching test-loom-dispatcher.sh.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# defaults/scripts/tests -> defaults/scripts/tests/../../.. -> repo root
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PROVISION_LIB="$REPO_ROOT/scripts/install/provision-skills.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_eq() {
+    if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 (expected '$2', got '$1')"; fi
+}
+assert_contains() {
+    if [[ "$1" == *"$2"* ]]; then pass "$3"; else fail "$3 (missing substring: '$2' in: $1)"; fi
+}
+
+[[ -f "$PROVISION_LIB" ]] || { echo "provisioning lib not found at $PROVISION_LIB"; exit 1; }
+
+# shellcheck source=/dev/null
+source "$PROVISION_LIB"
+
+# Build a fake machine-level checkout carrying the shipped skill + agent trees.
+# Echoes the checkout path. Optionally wrap it in a symlink (as the real
+# install does: ~/.local/share/loom -> source checkout) via make_linked_checkout.
+make_real_checkout() {
+    local c; c="$(mktemp -d)"
+    mkdir -p "$c/defaults/.claude/commands/loom" "$c/defaults/.claude/agents"
+    # A handful of representative skill files + a cross-referenced include.
+    for s in builder judge sweep probe-protocol; do
+        echo "# $s skill" > "$c/defaults/.claude/commands/loom/$s.md"
+    done
+    for a in builder judge doctor curator champion; do
+        echo "# loom-$a agent" > "$c/defaults/.claude/agents/loom-$a.md"
+    done
+    printf '%s\n' "$c"
+}
+
+# ── Test 1: fresh provision creates all links, pointing through the checkout ──
+echo "Test 1: fresh provision links the commands dir + every agent (AC1/AC2)"
+CHK=$(make_real_checkout)
+HOME_T=$(mktemp -d)
+# Run in the CURRENT shell (not $(...) which would subshell the globals away),
+# capturing output via a temp file — matches how test-loom-dispatcher.sh asserts
+# on provisioning globals after a direct call.
+OUT_FILE=$(mktemp)
+set +e
+provision_loom_skills "$CHK" "$HOME_T/.claude" >"$OUT_FILE" 2>&1
+rc=$?
+set -e 2>/dev/null || true
+out=$(cat "$OUT_FILE")
+assert_eq "$rc" "0" "fresh provision returns 0"
+
+DEST_CMD="$HOME_T/.claude/commands/loom"
+if [[ -L "$DEST_CMD" ]]; then
+    tgt="$(readlink "$DEST_CMD")"
+    assert_eq "$tgt" "$CHK/defaults/.claude/commands/loom" "commands is a whole-dir symlink through the checkout"
+else
+    fail "commands destination was not created as a symlink"
+fi
+# The link resolves — a skill file is readable through it.
+[[ -f "$DEST_CMD/builder.md" ]] && pass "a skill file resolves through the commands link" || fail "skill file does not resolve through the commands link"
+
+agent_ok=true
+for a in builder judge doctor curator champion; do
+    d="$HOME_T/.claude/agents/loom-$a.md"
+    [[ -L "$d" && "$(readlink "$d")" == "$CHK/defaults/.claude/agents/loom-$a.md" ]] || agent_ok=false
+done
+$agent_ok && pass "every loom-* agent is a per-file symlink through the checkout" || fail "not all agent links point through the checkout"
+
+# ── Test 2: verifiable-globals contract (#4053) ──────────────────────────────
+echo "Test 2: provisioning exposes verifiable globals (#4053)"
+assert_eq "$PROVISIONED_SKILLS_LINK" "$DEST_CMD" "PROVISIONED_SKILLS_LINK points at the commands link"
+agent_count=$(printf '%s\n' "$PROVISIONED_AGENT_LINKS" | grep -c 'loom-' || true)
+assert_eq "$agent_count" "5" "PROVISIONED_AGENT_LINKS enumerates all 5 agent links"
+
+# ── Test 3: idempotent re-provision ──────────────────────────────────────────
+echo "Test 3: re-provision is idempotent (second run returns 0, no changes)"
+before=$(cd "$HOME_T/.claude" && find . | sort)
+set +e
+provision_loom_skills "$CHK" "$HOME_T/.claude" >/dev/null 2>&1
+rc=$?
+set -e 2>/dev/null || true
+after=$(cd "$HOME_T/.claude" && find . | sort)
+assert_eq "$rc" "0" "second provision returns 0"
+assert_eq "$after" "$before" "tree is byte-identical after a second provision"
+
+# ── Test 4: pre-existing REAL file/dir is left untouched + warned ────────────
+echo "Test 4: a real destination file/dir is preserved, never clobbered (design decision 4)"
+CHK2=$(make_real_checkout)
+HOME2=$(mktemp -d)
+mkdir -p "$HOME2/.claude/commands/loom" "$HOME2/.claude/agents"
+echo "OPERATOR REAL COMMANDS" > "$HOME2/.claude/commands/loom/mine.md"
+echo "OPERATOR REAL AGENT" > "$HOME2/.claude/agents/loom-judge.md"
+set +e
+out=$(provision_loom_skills "$CHK2" "$HOME2/.claude" 2>&1)
+set -e 2>/dev/null || true
+# Real commands dir preserved (still a dir with the operator's file, not a link).
+if [[ -L "$HOME2/.claude/commands/loom" ]]; then
+    fail "clobbered the operator's real commands directory with a symlink"
+else
+    assert_eq "$(cat "$HOME2/.claude/commands/loom/mine.md")" "OPERATOR REAL COMMANDS" "operator's real commands dir is preserved"
+fi
+assert_contains "$out" "leaving as-is" "provisioning warns it left the real commands dir alone"
+# Real operator agent preserved (real file, not a link).
+[[ -L "$HOME2/.claude/agents/loom-judge.md" ]] && fail "clobbered operator's real loom-judge.md" \
+    || assert_eq "$(cat "$HOME2/.claude/agents/loom-judge.md")" "OPERATOR REAL AGENT" "operator's real loom-judge.md is preserved"
+# Other agents still linked despite the one preserved real file.
+[[ -L "$HOME2/.claude/agents/loom-builder.md" ]] && pass "sibling agents still linked when one is a real file" || fail "sibling agents were not linked"
+
+# ── Test 5: a stale symlink into an old checkout is repointed ─────────────────
+echo "Test 5: a symlink into an OLD checkout is repointed to the current one (design decision 4)"
+OLD=$(make_real_checkout)
+NEW=$(make_real_checkout)
+HOME3=$(mktemp -d)
+mkdir -p "$HOME3/.claude/commands" "$HOME3/.claude/agents"
+ln -s "$OLD/defaults/.claude/commands/loom" "$HOME3/.claude/commands/loom"
+ln -s "$OLD/defaults/.claude/agents/loom-builder.md" "$HOME3/.claude/agents/loom-builder.md"
+set +e
+provision_loom_skills "$NEW" "$HOME3/.claude" >/dev/null 2>&1
+set -e 2>/dev/null || true
+assert_eq "$(readlink "$HOME3/.claude/commands/loom")" "$NEW/defaults/.claude/commands/loom" "stale commands link repointed to the new checkout"
+assert_eq "$(readlink "$HOME3/.claude/agents/loom-builder.md")" "$NEW/defaults/.claude/agents/loom-builder.md" "stale agent link repointed to the new checkout"
+
+# ── Test 6: a dangling loom-* agent link is pruned ───────────────────────────
+echo "Test 6: a dangling loom-* agent link (removed role) is pruned (design decision 5)"
+CHK6=$(make_real_checkout)
+HOME6=$(mktemp -d)
+mkdir -p "$HOME6/.claude/agents"
+# Simulate a role that used to exist in the checkout but was removed upstream:
+# the link points into the checkout's agents tree but the target is gone.
+ln -s "$CHK6/defaults/.claude/agents/loom-removed.md" "$HOME6/.claude/agents/loom-removed.md"
+# A dangling link that points OUTSIDE the checkout must NOT be pruned.
+ln -s "/nonexistent/operator/place/loom-mine.md" "$HOME6/.claude/agents/loom-mine.md"
+set +e
+provision_loom_skills "$CHK6" "$HOME6/.claude" >/dev/null 2>&1
+set -e 2>/dev/null || true
+[[ -e "$HOME6/.claude/agents/loom-removed.md" || -L "$HOME6/.claude/agents/loom-removed.md" ]] \
+    && fail "dangling in-checkout agent link was not pruned" \
+    || pass "dangling in-checkout agent link pruned"
+[[ -L "$HOME6/.claude/agents/loom-mine.md" ]] \
+    && pass "a dangling link OUTSIDE the checkout is left alone (not Loom's to prune)" \
+    || fail "wrongly pruned an operator link pointing outside the checkout"
+
+# ── Test 7: soft failure (missing source) returns 1, does not abort ──────────
+echo "Test 7: a missing skills source returns 1 (soft failure) without aborting the caller"
+HOME7=$(mktemp -d)
+OUT7=$(mktemp)
+set +e
+provision_loom_skills "/nonexistent/checkout/xyz" "$HOME7/.claude" >"$OUT7" 2>&1
+rc=$?
+set -e 2>/dev/null || true
+out=$(cat "$OUT7")
+assert_eq "$rc" "1" "missing source returns 1"
+assert_contains "$out" "skills source not found" "explains the missing source"
+assert_eq "$PROVISIONED_SKILLS_LINK" "$HOME7/.claude/commands/loom" "globals still published on the soft-fail path"
+
+# Prove non-abort: a caller with 'set -e' semantics can note the failure and go on.
+caller_reached_end=false
+run_caller() {
+    provision_loom_skills "/nonexistent/checkout/xyz" "$HOME7/.claude" >/dev/null 2>&1 || true
+    caller_reached_end=true
+}
+run_caller
+$caller_reached_end && pass "caller continues past a soft failure" || fail "soft failure aborted the caller"
+
+# ── Test 8: deprovision removes checkout links but never real files ──────────
+echo "Test 8: deprovision removes links into the checkout, preserves real operator files (design decision 9)"
+CHK8=$(make_real_checkout)
+HOME8=$(mktemp -d)
+provision_loom_skills "$CHK8" "$HOME8/.claude" >/dev/null 2>&1
+# Add a real operator agent alongside the links.
+echo "OPERATOR" > "$HOME8/.claude/agents/loom-mine.md"  # not from the checkout
+set +e
+deprovision_loom_skills "$CHK8" "$HOME8/.claude" >/dev/null 2>&1
+set -e 2>/dev/null || true
+[[ -e "$HOME8/.claude/commands/loom" || -L "$HOME8/.claude/commands/loom" ]] \
+    && fail "deprovision did not remove the commands link" \
+    || pass "deprovision removed the commands link"
+[[ -L "$HOME8/.claude/agents/loom-builder.md" ]] \
+    && fail "deprovision did not remove an agent link" \
+    || pass "deprovision removed the agent links"
+assert_eq "$(cat "$HOME8/.claude/agents/loom-mine.md" 2>/dev/null)" "OPERATOR" "deprovision preserved the operator's real agent file"
+
+# ── Test 9: deprovision leaves a REAL commands dir alone ─────────────────────
+echo "Test 9: deprovision never removes a real (non-link) destination"
+CHK9=$(make_real_checkout)
+HOME9=$(mktemp -d)
+mkdir -p "$HOME9/.claude/commands/loom"
+echo "REAL" > "$HOME9/.claude/commands/loom/keep.md"
+set +e
+deprovision_loom_skills "$CHK9" "$HOME9/.claude" >/dev/null 2>&1
+set -e 2>/dev/null || true
+assert_eq "$(cat "$HOME9/.claude/commands/loom/keep.md" 2>/dev/null)" "REAL" "deprovision preserved a real commands directory"
+
+echo ""
+echo "======================================"
+echo "test-provision-skills.sh: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+echo "======================================"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -201,6 +201,14 @@ source "$LOOM_ROOT/scripts/install/provision-daemon.sh"
 # shellcheck source=scripts/install/provision-dispatcher.sh
 source "$LOOM_ROOT/scripts/install/provision-dispatcher.sh"
 
+# User-scope skills + agents provisioning (Epic #3835 Phase 4, #4261). Sibling
+# of provision-dispatcher.sh; links ~/.claude/commands/loom and
+# ~/.claude/agents/loom-*.md into the machine checkout so `/loom:*` skills and
+# `loom-*` subagents resolve from the single machine-level checkout and update
+# with `loom update`. Own file so the test suite can exercise it standalone.
+# shellcheck source=scripts/install/provision-skills.sh
+source "$LOOM_ROOT/scripts/install/provision-skills.sh"
+
 # Dogfood command-dir linker (issue #3682) — extracted so the test suite can
 # exercise the scoped-symlink logic without running the full installer.
 # shellcheck source=scripts/install/dogfood-commands.sh
@@ -1087,6 +1095,18 @@ provision_machine_daemon "$LOOM_ROOT/target/release/loom-daemon" || \
 info "Provisioning machine-level loom dispatcher..."
 provision_loom_dispatcher "$LOOM_ROOT" || \
   warning "Machine-level loom dispatcher not fully provisioned (see note above); use ./.loom/bin/loom in-repo, or set LOOM_HOME."
+
+# Provision user-scope skills + agents (Epic #3835 Phase 4, #4261). Links
+# ~/.claude/commands/loom (whole dir) and ~/.claude/agents/loom-*.md (per file)
+# THROUGH the machine checkout established just above (PROVISIONED_LOOM_CHECKOUT),
+# so `/loom:*` skills and `loom-*` subagents resolve from the single machine-level
+# checkout and update with `loom update`, instead of drifting per-repo. Additive
+# and best-effort: it never clobbers an operator's real files, and a soft failure
+# is logged but never aborts the install. (Existing per-repo copies are NOT
+# removed here — that is Phase 6 migration territory, #4254.)
+info "Provisioning user-scope loom skills + agents..."
+provision_loom_skills "${PROVISIONED_LOOM_CHECKOUT:-}" || \
+  warning "User-scope loom skills/agents not fully provisioned; /loom:* skills still resolve from any per-repo copy."
 
 # Run loom-daemon init in the worktree
 cd "$TARGET_PATH/$WORKTREE_PATH"

--- a/scripts/install/provision-skills.sh
+++ b/scripts/install/provision-skills.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# scripts/install/provision-skills.sh — user-scope Loom skills + agents
+# provisioning (Epic #3835 Phase 4, #4261).
+#
+# Sibling of provision-dispatcher.sh. Where that installs the machine-level
+# `loom` dispatcher (~/.local/bin/loom + ~/.local/share/loom), this establishes
+# the user-scope resolution of the `/loom:*` slash-command skills and the
+# `loom-*` subagents, so they resolve from the SINGLE machine-level checkout
+# instead of a per-repo copy that can drift stale:
+#
+#     ~/.claude/commands/loom  -> <checkout>/defaults/.claude/commands/loom
+#     ~/.claude/agents/loom-*.md -> <checkout>/defaults/.claude/agents/loom-*.md
+#
+# Source this file with:
+#     source "$LOOM_ROOT/scripts/install/provision-skills.sh"
+# then call `provision_loom_skills [checkout_dir] [claude_dir]`.
+#
+# Deliberately self-contained (defines its own output helpers) so the test suite
+# can source it without pulling in the full installer.
+#
+# ── Why a whole-directory link for commands, per-file links for agents ────────
+# `.claude/commands/loom/` is a Loom-owned namespace: one whole-directory symlink
+# (`~/.claude/commands/loom`) is the minimal surface, keeps `.claude/commands/`
+# itself a real directory that a co-installed tool can write siblings into, and
+# preserves the relative cross-references between skill files (e.g. one skill
+# `@`-including `probe-protocol.md`). `~/.claude/agents/`, by contrast, is SHARED
+# with the operator's own agents, so it cannot be wholesale-symlinked — each
+# `loom-<role>.md` is linked individually and non-Loom agents are left untouched.
+#
+# ── Why link THROUGH the checkout path, not $LOOM_ROOT ────────────────────────
+# The links target `<checkout>/defaults/...` (default checkout
+# `${LOOM_HOME:-$HOME/.local/share/loom}`), NOT the installer's transient
+# $LOOM_ROOT. `~/.local/share/loom` is itself a symlink to the source checkout
+# (provisioned by provision-dispatcher.sh), so the links stay valid even if the
+# machine checkout is later re-provisioned from a different source tree, and
+# `loom update` (which refreshes the checkout) updates the skills/agents seen by
+# every repo at once.
+#
+# ── Clobber avoidance (mirrors provision-dispatcher.sh's semantics) ───────────
+# A real file/dir at a destination (an operator's hand-tuned
+# `~/.claude/agents/loom-judge.md`, or a real `~/.claude/commands/loom/`
+# directory) is LEFT AS-IS and warned — never clobbered. A SYMLINK that points
+# somewhere other than the current checkout may be repointed (e.g. a link left
+# behind by an older checkout location). Dangling `loom-*` agent links whose
+# target no longer exists in the checkout are pruned so a renamed/removed role
+# does not leave a broken agent behind forever.
+#
+# ── Transition precedence (NOT a bug) ─────────────────────────────────────────
+# Until Phase 6 (#4254) strips the committed per-repo copies, an already-
+# installed consumer repo keeps its `.claude/commands/loom/*` files, and Claude
+# Code resolves a project-level definition over a user-level one when names
+# collide. Those repos therefore keep resolving their (possibly stale) copies
+# until migration; this provisioning only changes what FRESH installs and
+# POST-migration repos resolve. Coexistence is expected and does not error.
+
+# Emit a skills-provision status line (plain text so sourcing tests can assert).
+_pskill_ok()   { echo "  [loom-skills] $*"; }
+_pskill_warn() { echo "  [loom-skills] WARNING: $*" >&2; }
+
+# Set on every return (success or soft-failure) so the caller can VERIFY the
+# destinations it wrote rather than trust a success message (the #4053
+# "expose enough for the caller to verify" contract, matching
+# provision-dispatcher.sh's PROVISIONED_DISPATCHER_BIN). Assigned as GLOBALS
+# (no `local`) so they survive the function return.
+# shellcheck disable=SC2034
+PROVISIONED_SKILLS_LINK=""
+# shellcheck disable=SC2034
+PROVISIONED_AGENT_LINKS=""
+
+# provision_loom_skills [checkout_dir] [claude_dir]
+#
+# Best-effort — never fatal. Returns 1 on a soft failure so the caller can note
+# it, but the installer must NOT abort on a non-zero return.
+provision_loom_skills() {
+    local checkout_dir="${1:-${LOOM_HOME:-$HOME/.local/share/loom}}"
+    local claude_dir="${2:-$HOME/.claude}"
+
+    local commands_src="$checkout_dir/defaults/.claude/commands/loom"
+    local agents_src="$checkout_dir/defaults/.claude/agents"
+    local commands_dest="$claude_dir/commands/loom"
+    local agents_dest_dir="$claude_dir/agents"
+
+    # Publish resolved destinations up front so EVERY return path communicates
+    # where things live (the caller gates on the return code). Consumed by
+    # callers/tests, not this file — hence the SC2034 suppressions.
+    # shellcheck disable=SC2034
+    PROVISIONED_SKILLS_LINK="$commands_dest"
+    # shellcheck disable=SC2034
+    PROVISIONED_AGENT_LINKS=""
+
+    # -L follows the checkout symlink to the real defaults/ tree.
+    if [[ ! -d "$commands_src" ]]; then
+        _pskill_warn "skills source not found at '$commands_src'; skipping (is the machine checkout provisioned?)."
+        return 1
+    fi
+
+    local soft_fail=0
+
+    # ── 1. whole-directory commands link ──────────────────────────────────────
+    if ! mkdir -p "$claude_dir/commands" 2>/dev/null; then
+        _pskill_warn "could not create $claude_dir/commands; skipping skills link."
+        soft_fail=1
+    else
+        _pskill_link_dir "$commands_src" "$commands_dest" || soft_fail=1
+    fi
+
+    # ── 2. per-file agent links ───────────────────────────────────────────────
+    if [[ ! -d "$agents_src" ]]; then
+        _pskill_warn "agents source not found at '$agents_src'; skipping agent links."
+        soft_fail=1
+    elif ! mkdir -p "$agents_dest_dir" 2>/dev/null; then
+        _pskill_warn "could not create $agents_dest_dir; skipping agent links."
+        soft_fail=1
+    else
+        local agent_src agent_base agent_dest links=""
+        shopt -s nullglob
+        for agent_src in "$agents_src"/loom-*.md; do
+            agent_base="$(basename "$agent_src")"
+            agent_dest="$agents_dest_dir/$agent_base"
+            if _pskill_link_file "$agent_src" "$agent_dest"; then
+                links="${links}${agent_dest}"$'\n'
+            else
+                soft_fail=1
+            fi
+        done
+        shopt -u nullglob
+        # shellcheck disable=SC2034
+        PROVISIONED_AGENT_LINKS="${links%$'\n'}"
+
+        # ── 3. prune dangling loom-* agent links (renamed/removed roles) ──────
+        _pskill_prune_dangling_agents "$agents_dest_dir"
+    fi
+
+    return "$soft_fail"
+}
+
+# deprovision_loom_skills [checkout_dir] [claude_dir]
+#
+# Remove the user-scope links, but ONLY when they point into the given machine
+# checkout — an operator's real files/dirs, or symlinks that point elsewhere,
+# are left untouched. Best-effort; never fatal.
+deprovision_loom_skills() {
+    local checkout_dir="${1:-${LOOM_HOME:-$HOME/.local/share/loom}}"
+    local claude_dir="${2:-$HOME/.claude}"
+
+    local commands_src="$checkout_dir/defaults/.claude/commands/loom"
+    local agents_src="$checkout_dir/defaults/.claude/agents"
+    local commands_dest="$claude_dir/commands/loom"
+    local agents_dest_dir="$claude_dir/agents"
+
+    if _pskill_link_points_into "$commands_dest" "$commands_src"; then
+        rm -f "$commands_dest" 2>/dev/null \
+            && _pskill_ok "removed skills link $commands_dest"
+    elif [[ -e "$commands_dest" ]]; then
+        _pskill_ok "left $commands_dest as-is (not a link into the checkout)"
+    fi
+
+    local agent_src agent_dest
+    shopt -s nullglob
+    for agent_src in "$agents_src"/loom-*.md; do
+        agent_dest="$agents_dest_dir/$(basename "$agent_src")"
+        if _pskill_link_points_into "$agent_dest" "$agent_src"; then
+            rm -f "$agent_dest" 2>/dev/null \
+                && _pskill_ok "removed agent link $agent_dest"
+        fi
+    done
+    shopt -u nullglob
+    return 0
+}
+
+# ── internal helpers ─────────────────────────────────────────────────────────
+
+# Establish <dest> as a symlink -> <src> (whole directory). Preserves a real
+# file/dir; repoints a stale symlink; idempotent when already correct.
+_pskill_link_dir() {
+    local src="$1" dest="$2"
+    if [[ -L "$dest" ]]; then
+        local cur
+        cur="$(readlink "$dest" 2>/dev/null || true)"
+        if [[ "$cur" == "$src" ]]; then
+            _pskill_ok "skills already linked: $dest -> $src"
+            return 0
+        fi
+        _pskill_ok "repointing stale skills link: $dest ($cur -> $src)"
+        rm -f "$dest" 2>/dev/null || true
+    elif [[ -e "$dest" ]]; then
+        _pskill_warn "$dest already exists (not a symlink); leaving as-is."
+        return 0
+    fi
+    if ln -s "$src" "$dest" 2>/dev/null; then
+        _pskill_ok "linked skills: $dest -> $src"
+        return 0
+    fi
+    _pskill_warn "could not create skills link at $dest"
+    return 1
+}
+
+# Establish <dest> as a symlink -> <src> (single file). Preserves a real file;
+# repoints a stale symlink; idempotent when already correct.
+_pskill_link_file() {
+    local src="$1" dest="$2"
+    if [[ -L "$dest" ]]; then
+        local cur
+        cur="$(readlink "$dest" 2>/dev/null || true)"
+        if [[ "$cur" == "$src" ]]; then
+            return 0
+        fi
+        rm -f "$dest" 2>/dev/null || true
+    elif [[ -e "$dest" ]]; then
+        _pskill_warn "$dest already exists (not a symlink); leaving operator file as-is."
+        return 0
+    fi
+    if ln -s "$src" "$dest" 2>/dev/null; then
+        _pskill_ok "linked agent: $(basename "$dest")"
+        return 0
+    fi
+    _pskill_warn "could not create agent link at $dest"
+    return 1
+}
+
+# Remove `loom-*.md` symlinks under <agents_dir> that are dangling AND point
+# into a checkout's `defaults/.claude/agents/` tree (a role that was renamed or
+# removed upstream). A broken link to something OUTSIDE the checkout is left
+# alone — it is not Loom's to prune.
+_pskill_prune_dangling_agents() {
+    local agents_dir="$1" link tgt
+    shopt -s nullglob
+    for link in "$agents_dir"/loom-*.md; do
+        [[ -L "$link" ]] || continue
+        # -e follows the link; a true target still present is kept.
+        [[ -e "$link" ]] && continue
+        tgt="$(readlink "$link" 2>/dev/null || true)"
+        if [[ "$tgt" == *"/defaults/.claude/agents/"* ]]; then
+            rm -f "$link" 2>/dev/null \
+                && _pskill_ok "pruned dangling agent link: $(basename "$link")"
+        fi
+    done
+    shopt -u nullglob
+}
+
+# True iff <path> is a symlink whose readlink target equals <expected_src>.
+_pskill_link_points_into() {
+    local path="$1" expected="$2"
+    [[ -L "$path" ]] || return 1
+    local cur
+    cur="$(readlink "$path" 2>/dev/null || true)"
+    [[ "$cur" == "$expected" ]]
+}

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -2995,6 +2995,37 @@ fi
 echo ""
 
 # ==========================================================================
+# User-scope skills + agents provisioning (Epic #3835 Phase 4, #4261)
+# ==========================================================================
+# Its own unit suite lives at defaults/scripts/tests/test-provision-skills.sh
+# (whole-dir commands link + per-file agent links through the machine checkout,
+# clobber avoidance, stale-link repoint, dangling-link prune, soft-fail, and
+# the checkout-only deprovision). Fold its result into the installer suite so it
+# runs in CI + the build gate rather than dev-only.
+echo "Test: user-scope skills+agents provisioning suite (test-provision-skills.sh)"
+SKILLS_TEST="$DEFAULTS_DIR/scripts/tests/test-provision-skills.sh"
+if [[ -f "$SKILLS_TEST" ]]; then
+  set +e
+  SKILLS_TEST_OUT=$(bash "$SKILLS_TEST" 2>&1)
+  SKILLS_TEST_RC=$?
+  set -e
+  if [[ $SKILLS_TEST_RC -eq 0 ]]; then
+    pass "test-provision-skills.sh: all cases passed"
+  else
+    fail "test-provision-skills.sh failed (rc=$SKILLS_TEST_RC)"
+    echo "$SKILLS_TEST_OUT" | tail -20
+  fi
+else
+  fail "test-provision-skills.sh not found at $SKILLS_TEST"
+fi
+if [[ -f "$LOOM_ROOT/scripts/install/provision-skills.sh" ]]; then
+  pass "scripts/install/provision-skills.sh present"
+else
+  fail "scripts/install/provision-skills.sh missing"
+fi
+echo ""
+
+# ==========================================================================
 # Summary
 # ==========================================================================
 echo "======================================"

--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -601,6 +601,16 @@ else
     REMOVE_FILES+=(".loom/bin/loom")
   fi
 
+  # NOTE (Epic #3835 Phase 4, #4261): the user-scope skill + agent links
+  # (~/.claude/commands/loom and ~/.claude/agents/loom-*.md) are machine-level
+  # SHARED resources — one set, resolved by every repo Loom is installed into,
+  # exactly like the ~/.local/bin/loom dispatcher above. A per-repo uninstall
+  # therefore does NOT remove them: doing so would break `/loom:*` skills and
+  # `loom-*` subagents for every OTHER consumer repo on the machine. A
+  # machine-level teardown can remove them safely via `deprovision_loom_skills`
+  # in scripts/install/provision-skills.sh, which deletes a link ONLY when it
+  # points into the machine checkout and never touches an operator's real files.
+
   # Backward compatibility: also check old location (repo root)
   if [[ -f "$TARGET_PATH/loom" ]] && [[ -x "$TARGET_PATH/loom" ]]; then
     REMOVE_FILES+=("loom")


### PR DESCRIPTION
Part of #4261 (Epic #3835 Phase 4).

## What this delivers

The user-scope **resolution mechanism** that makes the `/loom:*` skills and
`loom-*` subagents resolve from the single machine-level checkout (the
replacement Phase 6, #4254, depends on), plus its wiring, uninstall semantics,
docs, and an automated test suite.

New `scripts/install/provision-skills.sh` (sibling of `provision-dispatcher.sh`)
establishes, next to the dispatcher install:

```
~/.claude/commands/loom      -> <checkout>/defaults/.claude/commands/loom   (one whole-dir symlink)
~/.claude/agents/loom-<role>.md -> <checkout>/defaults/.claude/agents/loom-<role>.md (per-file symlinks)
```

- **Whole-dir link for commands** (Loom-owned namespace; keeps `.claude/commands/`
  a real dir; preserves relative cross-references between skill files).
- **Per-file links for agents** (`~/.claude/agents/` is shared with the operator's
  own agents, so it cannot be wholesale-symlinked).
- Links target the **checkout path** (`<checkout>/defaults/...`), not the
  transient `$LOOM_ROOT`, so `loom update` updates what every repo resolves at
  once and links cannot drift per-repo.
- Best-effort / never-fatal, with verifiable globals (`PROVISIONED_SKILLS_LINK`,
  `PROVISIONED_AGENT_LINKS`, matching the `PROVISIONED_DISPATCHER_BIN` pattern).
- **Never clobbers a real destination** (an operator's hand-tuned
  `loom-judge.md`, or a real `commands/loom/` dir) — leaves it + warns.
- **Repoints a stale symlink** (older checkout location) to the current checkout.
- **Prunes a dangling `loom-*` agent link** whose target is gone from the
  checkout — but only when the broken link points into a checkout's agents tree,
  never an operator's own link.
- `deprovision_loom_skills` removes links **only** when they point into the
  machine checkout, never real files.

Wired into `scripts/install-loom.sh` right after `provision_loom_dispatcher`
(using the resolved `PROVISIONED_LOOM_CHECKOUT`).

## Acceptance criteria

- [x] Skills and agents resolve from the machine-level checkout (whole-dir +
  per-file symlinks — mechanism decided and implemented)
- [x] `loom update` (refreshing the checkout) updates the skills/agents seen by
  every repo at once (links point through the checkout path)
- [x] Existing per-repo copies are NOT removed by this phase (Phase 6 territory)
- [~] "no freshly-installed consumer repo carries its own copies" / installer
  copy-skip (AC1/AC4 second half) — see scope boundary below

## Scope boundary (deviation from the curator's AC4, with rationale)

The curator's design assumed `scripts/install-loom.sh` performs the per-repo copy
of the two trees. It does **not** — `loom-daemon init` (Rust) materializes
`.claude/commands/loom/` + `.claude/agents/`, and **three** validation points
hard-require those trees present post-init: Rust `init/git.rs` (asserts the dirs
exist with >=5 subagents), the installer's `EXPECTED_FILES` check
(`install-loom.sh:1653-1654`), and `manifest.sh` bookkeeping. Making the shell
installer "skip the copy" while Rust still copies would either be a no-op or break
these validations. Ceasing the copy is a coupled Rust + validation change that
naturally belongs with **Phase 6's `git rm --cached` migration** (#4254). I
therefore delivered the additive user-scope mechanism (which is exactly what
Phase 6 needs) and did **not** touch `manifest.sh` or the Rust init. This is
documented inline in `machine-dispatcher.md` ("Scope boundary (Phase 4 vs Phase
6)"). `install.sh`'s reference to the slash-command surface is summary text, not a
copy op, and remains accurate for fresh installs until Phase 6.

**Uninstall** follows the existing in-file dispatcher precedent
(`uninstall-loom.sh:593-599`): the user-scope links are machine-level SHARED
resources (one set, every repo), so a per-repo uninstall does not remove them
(that would break `/loom:*` for every other repo). `deprovision_loom_skills` is
provided + tested for a machine-level teardown.

## Testing

- New `defaults/scripts/tests/test-provision-skills.sh` (sandboxed `$HOME`):
  **24/24 pass** — fresh provision links commands dir + all agents through the
  checkout; verifiable globals; idempotent re-provision; real file/dir preserved
  + warned; stale symlink repointed; dangling in-checkout link pruned (out-of-
  checkout link left alone); soft-fail returns 1 without aborting the caller;
  deprovision removes checkout links but preserves real files. Folded into
  `scripts/test-installer.sh` so it runs in CI + the build gate.
- Existing `test-loom-dispatcher.sh`: **60/60 pass** (no regression).
- `shellcheck --severity=warning`: clean on all new/modified scripts (the 3
  SC2115 warnings in install/uninstall are pre-existing, not on touched lines).

### Manual verification (needs a live Claude Code session)

- **AC2** — after a fresh install with no per-repo copy, open a session in a
  consumer repo and confirm `/loom:builder`, `/loom:judge`, `/loom:sweep` still
  resolve (through `~/.claude/commands/loom`) and `loom-builder`/`loom-judge`
  subagents dispatch (through `~/.claude/agents/loom-*.md`).
- **AC3** — run `loom update` to refresh the checkout, edit a skill in the
  checkout, and confirm the change is visible in every repo's session without
  reinstalling.
- **Transition** — in a repo that still carries committed `.claude/commands/loom/*`,
  confirm the project-level copy wins and coexists with the user-level link
  without error.

Part of #4261
