### PR TITLE
feat(install): converge consumer .gitignore at resync via update-gitignore subcommand (#4280)

### DIFF
--- a/defaults/scripts/resync-installed.sh
+++ b/defaults/scripts/resync-installed.sh
@@ -30,6 +30,14 @@
 # last_resync date into .loom/install-metadata.json (requires jq or python3;
 # skipped with a warning if neither is present — the file sync still succeeds).
 #
+# It also refreshes the marker-delimited Loom-managed `.gitignore` block via the
+# daemon's `update-gitignore` subcommand (#4280) — the ephemeral-pattern list is
+# single-sourced in loom-daemon, so existing installs converge on newly-ignored
+# runtime paths (e.g. .loom/sweep-checkpoint/, .loom/worktrees-local/) at resync
+# time. A missing daemon binary is a loud warning, not a silent skip. Any path
+# still untracked-and-unignored under .loom/ afterward is reported as an audit
+# warning so the pattern list can be extended.
+#
 # EXPLICITLY OUT OF SCOPE (never touched by resync — updated by other mechanisms):
 #   .loom/config.json       - operator-owned; needs merge-semantics design
 #   CLAUDE.md               - repo-customized at install; needs managed-section markers
@@ -94,7 +102,7 @@ for arg in "$@"; do
         --dry-run|-n) DRY_RUN=1 ;;
         --quiet|-q)   QUIET=1 ;;
         --help|-h)
-            sed -n '2,61p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '2,69p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)
@@ -440,6 +448,82 @@ PY
 if [[ "$DRY_RUN" -ne 1 ]]; then
     restamp_metadata
 fi
+
+# ---------- refresh the Loom-managed .gitignore block (#4280) ----------
+#
+# The marker-delimited managed block in the consumer's .gitignore is written by
+# `loom-daemon init` at install time and was NEVER refreshed by resync — so a
+# repo installed by a stale binary (or before a pattern was added) keeps ignoring
+# the old set forever, leaving newer runtime dirs (e.g. .loom/sweep-checkpoint/,
+# .loom/worktrees-local/) untracked-and-unignored. The ephemeral-pattern list is
+# single-sourced in the daemon (EPHEMERAL_PATTERNS), so we invoke the daemon's
+# `update-gitignore` subcommand rather than duplicating the list in shell. A
+# missing/too-old binary is a LOUD stderr warning, never a silent skip.
+
+refresh_gitignore_block() {
+    local locate_lib bin
+    locate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/locate-daemon-bin.sh"
+    if [[ ! -f "$locate_lib" ]]; then
+        warn ".gitignore refresh skipped: locate-daemon-bin.sh not found next to resync-installed.sh."
+        warn "  Newer runtime paths may stay untracked-and-unignored until the next full install."
+        return 0
+    fi
+    # shellcheck source=lib/locate-daemon-bin.sh
+    # shellcheck disable=SC1091
+    source "$locate_lib"
+    # Prefer a binary in the source checkout (matches the version being synced);
+    # the resolver falls back to $LOOM_DAEMON_BIN / `loom-daemon` on PATH.
+    bin="$(loom_locate_daemon_bin "$SOURCE_ROOT")"
+    if [[ -z "$bin" ]]; then
+        warn "Could not refresh the Loom-managed .gitignore block: no loom-daemon binary resolved"
+        warn "  (\$LOOM_DAEMON_BIN -> 'loom-daemon' on PATH -> build-output under $SOURCE_ROOT)."
+        warn "  Newer runtime paths (e.g. .loom/sweep-checkpoint/, .loom/worktrees-local/) may stay untracked-and-unignored."
+        return 0
+    fi
+    # `update-gitignore` has no dedicated --dry-run; on a dry run we only probe
+    # that the subcommand exists (never writing), so the preview neither mutates
+    # nor claims a refresh a pre-#4280 binary cannot perform.
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        if "$bin" update-gitignore --help >/dev/null 2>&1; then
+            note "  ${BOLD}would refresh${NC} .gitignore (loom-managed block, via $bin)"
+        else
+            warn ".gitignore refresh unavailable: '$bin' has no 'update-gitignore' subcommand (rebuild the daemon)."
+        fi
+        return 0
+    fi
+    if "$bin" update-gitignore "$REPO_ROOT" >/dev/null 2>&1; then
+        note "  ${GREEN}refreshed${NC} .gitignore (loom-managed block, via $bin)"
+    else
+        warn ".gitignore refresh failed: '$bin update-gitignore' errored"
+        warn "  (a pre-#4280 daemon lacks this subcommand — rebuild loom-daemon)."
+    fi
+}
+refresh_gitignore_block
+
+# ---------- audit: untracked-and-unignored paths under .loom/ (#4280) ----------
+#
+# After the block refresh, anything STILL surfacing as untracked-and-unignored
+# under .loom/ is a Loom-owned runtime path the pattern list does not yet cover
+# (an enumerated list always trails reality). Surface it as a warning so it can
+# be added to EPHEMERAL_PATTERNS, instead of silently dirtying the consumer's
+# `git status` (or being swept into a commit by `git add -A`). `git status
+# --porcelain` already excludes ignored files, so every `??` entry here is by
+# definition untracked-and-unignored; tracked install-owned files never appear.
+
+audit_untracked_loom_paths() {
+    [[ -d "$REPO_ROOT/.loom" ]] || return 0
+    local out
+    out="$(git -C "$REPO_ROOT" status --porcelain -- .loom/ 2>/dev/null | sed -n 's/^?? //p')"
+    [[ -z "$out" ]] && return 0
+    warn "Untracked-and-unignored path(s) under .loom/ (not covered by the managed .gitignore block):"
+    local p
+    while IFS= read -r p; do
+        [[ -z "$p" ]] && continue
+        printf '%b\n' "${YELLOW}    $p${NC}" >&2
+    done <<< "$out"
+    warn "If these are Loom runtime state, add them to EPHEMERAL_PATTERNS (loom-daemon/src/init/post_init.rs)."
+}
+audit_untracked_loom_paths
 
 # ---------- summary ----------
 

--- a/defaults/scripts/tests/test-resync-installed.sh
+++ b/defaults/scripts/tests/test-resync-installed.sh
@@ -52,6 +52,13 @@ fail() {
     echo -e "  ${RED}FAIL${NC}: $1"
 }
 
+# Not counted toward pass/fail: used when a test's precondition (e.g. a
+# `update-gitignore`-capable loom-daemon binary) is unavailable in this
+# environment, so CI without a built daemon does not spuriously fail.
+skip() {
+    echo -e "  SKIP: $1"
+}
+
 WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/test-resync.XXXXXX")"
 # shellcheck disable=SC2329  # invoked indirectly via the EXIT trap below
 cleanup() { rm -rf "$WORKDIR" 2>/dev/null || true; }
@@ -362,6 +369,112 @@ if grep -q '"loom_version": *"0.0.0"' "$REPO/.loom/install-metadata.json"; then
     pass "(n) --dry-run leaves install-metadata.json unstamped"
 else
     fail "(n) --dry-run re-stamped metadata (should be preview-only)"
+fi
+
+# --- (#4280) .gitignore managed-block refresh + audit ------------------------
+echo "Test group 12b: resync refreshes the Loom-managed .gitignore block (#4280)"
+# Resolve a loom-daemon binary that supports `update-gitignore` (this feature).
+# Prefer $LOOM_DAEMON_BIN, then `loom-daemon` on PATH, then build-output under
+# the real Loom checkout the script lives in. Skip the group (do not fail) when
+# none is available — CI may run these shell tests without a built daemon.
+resolve_capable_daemon_bin() {
+    local candidate loom_root
+    loom_root="$(cd "$HELPERS_DIR/../.." && pwd)"   # defaults/scripts -> repo root
+    for candidate in \
+        "${LOOM_DAEMON_BIN:-}" \
+        "$(command -v loom-daemon 2>/dev/null || true)" \
+        "$loom_root/loom-daemon/target/debug/loom-daemon" \
+        "$loom_root/loom-daemon/target/release/loom-daemon" \
+        "$loom_root/target/debug/loom-daemon" \
+        "$loom_root/target/release/loom-daemon"; do
+        [[ -n "$candidate" && -x "$candidate" ]] || continue
+        if "$candidate" update-gitignore --help >/dev/null 2>&1; then
+            echo "$candidate"; return 0
+        fi
+    done
+    echo ""; return 0
+}
+GI_BIN="$(resolve_capable_daemon_bin)"
+if [[ -z "$GI_BIN" ]]; then
+    skip "(#4280) no update-gitignore-capable loom-daemon binary resolved — set LOOM_DAEMON_BIN to run"
+else
+    REPO="$(make_fixture)"
+    # Seed a stale pre-#3642 managed block: well-formed markers, but missing the
+    # runtime patterns added since (.loom/sweep-checkpoint/, .loom/worktrees-local/).
+    cat > "$REPO/.gitignore" <<'GIEOF'
+node_modules/
+# >>> loom-managed (do not edit) >>>
+# Loom runtime state (don't commit these)
+.loom-in-use
+.loom/state.json
+.loom/worktrees/
+.loom/logs/
+# <<< loom-managed <<<
+dist/
+GIEOF
+    OUT="$(cd "$REPO" && LOOM_DAEMON_BIN="$GI_BIN" bash "$SCRIPT" 2>&1)"
+    RC=$?
+    if [[ $RC -eq 0 ]]; then pass "(#4280) apply with a stale block exits 0"; else fail "(#4280) apply exits 0 (got $RC)"; fi
+    # Exactly one managed block, markers preserved.
+    if [[ "$(grep -c '>>> loom-managed' "$REPO/.gitignore")" -eq 1 && \
+          "$(grep -c '<<< loom-managed' "$REPO/.gitignore")" -eq 1 ]]; then
+        pass "(#4280) exactly one managed block, markers preserved"
+    else
+        fail "(#4280) managed block markers not exactly-one each"
+    fi
+    # The previously-absent runtime paths are now ignored.
+    if (cd "$REPO" && git check-ignore .loom/sweep-checkpoint/issue-1.json >/dev/null 2>&1); then
+        pass "(#4280) .loom/sweep-checkpoint/issue-1.json is now ignored"
+    else
+        fail "(#4280) .loom/sweep-checkpoint/ still not ignored after resync"
+    fi
+    if (cd "$REPO" && git check-ignore .loom/worktrees-local/x >/dev/null 2>&1); then
+        pass "(#4280) .loom/worktrees-local/ is now ignored"
+    else
+        fail "(#4280) .loom/worktrees-local/ still not ignored after resync"
+    fi
+    # User content on both sides of the block survived.
+    if grep -q '^node_modules/$' "$REPO/.gitignore" && grep -q '^dist/$' "$REPO/.gitignore"; then
+        pass "(#4280) user content around the block preserved"
+    else
+        fail "(#4280) user content around the block was lost"
+    fi
+    # Idempotent: a second resync leaves the .gitignore byte-identical.
+    cp "$REPO/.gitignore" "$WORKDIR/gi-before-2nd"
+    (cd "$REPO" && LOOM_DAEMON_BIN="$GI_BIN" bash "$SCRIPT" >/dev/null 2>&1)
+    if diff -q "$WORKDIR/gi-before-2nd" "$REPO/.gitignore" >/dev/null 2>&1; then
+        pass "(#4280) second resync is byte-identical (idempotent block refresh)"
+    else
+        fail "(#4280) second resync mutated the .gitignore"
+    fi
+
+    # Audit: an untracked-and-unignored path under .loom/ is surfaced as a warning.
+    REPO="$(make_fixture)"
+    printf 'RUNTIME\n' > "$REPO/.loom/some-new-runtime-dir-marker"   # untracked, unignored
+    OUT="$(cd "$REPO" && LOOM_DAEMON_BIN="$GI_BIN" bash "$SCRIPT" 2>&1)"
+    if grep -qi "untracked-and-unignored" <<<"$OUT"; then
+        pass "(#4280) audit reports an untracked-and-unignored .loom/ path"
+    else
+        fail "(#4280) audit did not report the untracked-and-unignored path"
+    fi
+fi
+
+# --- (#4280) missing binary degrades to a loud warning, never a silent skip --
+echo "Test group 12c: absent daemon binary -> loud warning, apply still exits 0 (#4280)"
+REPO="$(make_fixture)"
+# Force the resolver to find nothing: no LOOM_DAEMON_BIN, no PATH loom-daemon,
+# no build-output under the fixture's SOURCE_ROOT (the fixture repo).
+OUT="$(cd "$REPO" && env -u LOOM_DAEMON_BIN PATH="/usr/bin:/bin" bash "$SCRIPT" 2>&1)"
+RC=$?
+if [[ $RC -eq 0 ]]; then
+    pass "(#4280) apply still exits 0 when no daemon binary resolves"
+else
+    fail "(#4280) apply did not exit 0 with no daemon binary (got $RC)"
+fi
+if grep -qi "could not refresh the loom-managed .gitignore block\|no loom-daemon binary resolved" <<<"$OUT"; then
+    pass "(#4280) missing binary produces a loud warning (not a silent skip)"
+else
+    fail "(#4280) missing binary did not produce the expected warning"
 fi
 
 # --- contract checks ---------------------------------------------------------

--- a/loom-daemon/src/init/mod.rs
+++ b/loom-daemon/src/init/mod.rs
@@ -35,14 +35,16 @@ use std::path::Path;
 use serde_json::Value;
 
 use file_ops::{clean_managed_dir, copy_dir_with_report, verify_copied_files, TemplateContext};
-use post_init::{
-    find_overbroad_loom_patterns, generate_manifest, update_gitignore, write_install_metadata,
-};
+use post_init::{find_overbroad_loom_patterns, generate_manifest, write_install_metadata};
 use retired::cleanup_retired_files;
 use scaffolding::setup_repository_scaffolding;
 
 // Re-export public types and functions
 pub use git::is_loom_source_repo;
+// Re-exported so the `loom-daemon update-gitignore` subcommand (#4280) can
+// rewrite the marker-delimited managed block on its own, without running a full
+// `init`. The pattern list stays single-sourced in `post_init::EPHEMERAL_PATTERNS`.
+pub use post_init::update_gitignore;
 
 // Import the rest for internal use
 use git::{resolve_defaults_path, validate_git_repository, validate_loom_source_repo};

--- a/loom-daemon/src/init/post_init.rs
+++ b/loom-daemon/src/init/post_init.rs
@@ -100,6 +100,12 @@ const GITIGNORE_BLOCK_HEADER: &str = "# Loom runtime state (don't commit these)"
 /// `.loom/exit-codes/`, `.loom/sweep-run/`, `.loom/stats/`, `.loom/spawn-loop.pid`,
 /// and `.loom/stop-spawn-loop`. The marker-delimited block is refreshed in place
 /// on every `update_gitignore`, so re-running the installer re-syncs consumers.
+///
+/// #4280: added `.loom/worktrees-local/` (machine-local worktree state observed
+/// untracked-and-unignored in a consumer repo). Existing consumer installs
+/// converge on this list via the new `loom-daemon update-gitignore` subcommand,
+/// which `resync-installed.sh` invokes — the block was previously refreshed only
+/// during a full `init`, so a fix here never reached repos between installs.
 pub const EPHEMERAL_PATTERNS: &[&str] = &[
     ".loom-in-use",
     ".loom-checkpoint",
@@ -118,6 +124,10 @@ pub const EPHEMERAL_PATTERNS: &[&str] = &[
     ".loom/issue-failures.json",
     ".loom/interventions/",
     ".loom/worktrees/",
+    // Local-mode / machine-local worktree state observed untracked-and-unignored
+    // in a consumer repo (anvil, 2026-07-28): `.loom/worktrees-local/<repo>/issue-N`
+    // (#4280). Runtime worktree state, same class as `.loom/worktrees/`.
+    ".loom/worktrees-local/",
     ".loom/state.json",
     ".loom/mcp-command.json",
     ".loom/activity.db",
@@ -539,6 +549,9 @@ mod tests {
         assert_eq!(contents.matches(".loom/locks/").count(), 1);
         assert!(contents.contains("# Loom runtime state"));
 
+        // #4280: machine-local worktree state must be ignored and appear once.
+        assert_eq!(contents.matches(".loom/worktrees-local/").count(), 1);
+
         // #3778: patterns that had drifted out of this installer-managed list
         // relative to the source .gitignore — a consumer re-sync must now emit
         // them so Loom-owned transient state never surfaces as untracked dirt.
@@ -600,6 +613,8 @@ mod tests {
         assert_eq!(contents.matches(".loom/worktrees/").count(), 1);
         assert_eq!(contents.matches(".loom/sweep-checkpoint/").count(), 1);
         assert_eq!(contents.matches(".loom/locks/").count(), 1);
+        // #4280: `.loom/worktrees-local/` must not duplicate across runs.
+        assert_eq!(contents.matches(".loom/worktrees-local/").count(), 1);
     }
 
     #[test]
@@ -628,6 +643,7 @@ mod tests {
             ".loom/issue-failures.json",
             ".loom/interventions/",
             ".loom/worktrees/",
+            ".loom/worktrees-local/",
             ".loom/state.json",
             ".loom/mcp-command.json",
             ".loom/activity.db",
@@ -1011,6 +1027,46 @@ mod tests {
         update_gitignore(tmp.path()).unwrap();
         let again = fs::read_to_string(&gitignore).unwrap();
         assert_eq!(contents, again, "second migration run must be a byte-identical no-op");
+    }
+
+    #[test]
+    fn refreshes_stale_marked_block_to_include_new_runtime_patterns() {
+        // #4280: a consumer whose marker-delimited block was written by a
+        // pre-#3642 binary lacks `.loom/sweep-checkpoint/` (and `.loom/worktrees-local/`).
+        // A single `update_gitignore` must refresh the block in place so those
+        // runtime paths become ignored — this is what the resync entry point drives.
+        let tmp = TempDir::new().unwrap();
+        let gitignore = tmp.path().join(".gitignore");
+
+        // Seed a well-formed but stale managed block (a realistic pre-#3642 subset),
+        // flanked by user content on both sides.
+        let stale_block = format!(
+            "{begin}\n{header}\n.loom-in-use\n.loom/state.json\n.loom/worktrees/\n.loom/logs/\n{end}",
+            begin = GITIGNORE_BEGIN_MARKER,
+            header = GITIGNORE_BLOCK_HEADER,
+            end = GITIGNORE_END_MARKER,
+        );
+        fs::write(&gitignore, format!("node_modules/\n{stale_block}\ndist/\n")).unwrap();
+
+        update_gitignore(tmp.path()).unwrap();
+        let contents = fs::read_to_string(&gitignore).unwrap();
+
+        // Exactly one block, markers preserved.
+        assert_eq!(contents.matches(GITIGNORE_BEGIN_MARKER).count(), 1);
+        assert_eq!(contents.matches(GITIGNORE_END_MARKER).count(), 1);
+        // The previously-absent runtime patterns are now present exactly once.
+        assert_eq!(contents.matches(".loom/sweep-checkpoint/").count(), 1);
+        assert_eq!(contents.matches(".loom/worktrees-local/").count(), 1);
+        // User content on both sides survived and kept its ordering.
+        let begin_pos = contents.find(GITIGNORE_BEGIN_MARKER).unwrap();
+        let end_pos = contents.find(GITIGNORE_END_MARKER).unwrap();
+        assert!(contents.find("node_modules/").unwrap() < begin_pos);
+        assert!(contents.find("dist/").unwrap() > end_pos);
+
+        // Idempotent: a second run is a byte-identical no-op.
+        update_gitignore(tmp.path()).unwrap();
+        let again = fs::read_to_string(&gitignore).unwrap();
+        assert_eq!(contents, again, "second refresh must be a byte-identical no-op");
     }
 
     #[test]

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -80,6 +80,21 @@ enum Commands {
         dry_run: bool,
     },
 
+    /// Rewrite only the marker-delimited Loom-managed `.gitignore` block in a
+    /// workspace, converging it on the current `EPHEMERAL_PATTERNS` set without
+    /// running a full `init` (Issue #4280). This is the standalone entry point
+    /// `defaults/scripts/resync-installed.sh` invokes so existing consumer
+    /// installs pick up newly-ignored runtime paths (e.g. `.loom/sweep-checkpoint/`,
+    /// `.loom/worktrees-local/`) at resync time — the pattern list stays
+    /// single-sourced in the daemon, never copied into shell. Idempotent: a
+    /// workspace already carrying the current block is a byte-for-byte no-op.
+    UpdateGitignore {
+        /// Target workspace directory (the repo root whose `.gitignore` to
+        /// refresh). Defaults to the current directory.
+        #[arg(value_name = "PATH", default_value = ".")]
+        workspace: String,
+    },
+
     /// Display agent effectiveness and activity metrics
     Stats {
         /// Filter by agent role (builder, judge, curator, etc.)
@@ -1658,6 +1673,31 @@ mod resolve_paths_tests {
 }
 
 /// Handle CLI commands (init, stats, validate modes)
+/// Handle `loom-daemon update-gitignore [PATH]` (Issue #4280).
+///
+/// Rewrites only the marker-delimited Loom-managed `.gitignore` block, converging
+/// it on the current `EPHEMERAL_PATTERNS` set. This is the standalone refresh
+/// entry point `resync-installed.sh` calls so existing consumer installs pick up
+/// newly-ignored runtime paths without a full `init`. Idempotent: a workspace
+/// already carrying the current block is a byte-for-byte no-op.
+fn handle_update_gitignore_command(workspace: &str) -> Result<()> {
+    let workspace_path = std::path::Path::new(workspace);
+    let absolute_workspace = if workspace_path.is_absolute() {
+        workspace_path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(workspace_path)
+    };
+
+    loom_daemon::init::update_gitignore(&absolute_workspace)
+        .map_err(|e| anyhow!("Failed to update .gitignore: {e}"))?;
+
+    println!(
+        "Refreshed the Loom-managed .gitignore block in {}",
+        absolute_workspace.display()
+    );
+    Ok(())
+}
+
 #[allow(clippy::too_many_lines)]
 fn handle_cli_command(command: Commands) -> Result<()> {
     match command {
@@ -1675,6 +1715,7 @@ fn handle_cli_command(command: Commands) -> Result<()> {
         } => handle_stats_command(role.as_deref(), issue, weekly, &format),
         Commands::Workspace { action } => handle_workspace_command(action),
         Commands::Tokens { action } => handle_tokens_command(action),
+        Commands::UpdateGitignore { workspace } => handle_update_gitignore_command(&workspace),
         Commands::Status { .. } => {
             // Routed directly in `main()` (it needs the async runtime for the
             // socket round-trip), never dispatched through this sync handler.


### PR DESCRIPTION
## Summary

Fixes the convergence failure behind `?? .loom/sweep-checkpoint/` in consumer repos (#4280). The Loom-managed `.gitignore` block was only ever (re)written during a full `loom-daemon init`, so existing installs never picked up runtime paths added to `EPHEMERAL_PATTERNS` after their install — `.loom/sweep-checkpoint/` (present since #3642) still surfaced untracked-and-unignored on repos installed by a stale binary.

## What changed

- **New `loom-daemon update-gitignore [PATH]` subcommand** (`loom-daemon/src/main.rs`) — a thin wrapper over the existing idempotent `update_gitignore(workspace_path)`, re-exported from `init` (`loom-daemon/src/init/mod.rs`). Rewrites only the marker-delimited managed block; the pattern list stays single-sourced in `EPHEMERAL_PATTERNS` (Option B — no shell-side copy).
- **`resync-installed.sh` invokes it** so existing consumer installs converge at resync time. A missing/too-old daemon binary degrades to a **loud stderr warning, never a silent skip** (resolves the binary via the shared `locate-daemon-bin.sh`). It also **audits** `git status --porcelain -- .loom/` and warns about any path still untracked-and-unignored, so future runtime dirs surface instead of silently dirtying consumer repos.
- **`.loom/worktrees-local/` added to `EPHEMERAL_PATTERNS`** (`loom-daemon/src/init/post_init.rs`) — observed untracked-and-unignored runtime worktree state in a consumer repo — with idempotency tests extended to cover it.

Explicitly not implemented: the shell port of the pattern list (Option A, rejected — would duplicate `EPHEMERAL_PATTERNS`) and wholesale `/.loom/` ignore (Option C, deferred to the #3835/#4254 migration).

## Testing

- `cargo test --lib post_init` — 26 pass, including the new `refreshes_stale_marked_block_to_include_new_runtime_patterns` and `.loom/worktrees-local/` idempotency assertions.
- `cargo clippy --bin loom-daemon` — clean.
- `defaults/scripts/tests/test-resync-installed.sh` — 48 pass. New groups: a stale pre-#3642 block converges in place (exactly one block, markers preserved, user content around it survives, idempotent second run, `git check-ignore .loom/sweep-checkpoint/issue-1.json` succeeds); the untracked-`.loom/` audit fires; an absent daemon binary warns loudly while apply still exits 0. The #4280 group skips gracefully (no fail) when no `update-gitignore`-capable binary is resolvable.
- `shellcheck` clean on both scripts.
- Manual: `loom-daemon update-gitignore` on a seeded stale-block repo — block refreshed in place, idempotent, `git check-ignore` now succeeds for `.loom/sweep-checkpoint/`, `.loom/worktrees-local/`, and `.loom/tokens/`.

Closes #4280

🤖 Generated with [Claude Code](https://claude.com/claude-code)
