### PR TITLE
fix(installer): drop decoy version from workspace package.json stub

### DIFF
--- a/defaults/.claude/commands/loom/bump.md
+++ b/defaults/.claude/commands/loom/bump.md
@@ -20,7 +20,7 @@ Walk the current repository root **once** and record which version-bearing files
 
 1. **`scripts/version.sh`** (top-level): if this file already exists from a prior `/loom:bump` run, **short-circuit** the detection. Skip directly to Phase 5 ("Invoke the generated script"). The script is the source of truth on subsequent runs — the operator may have edited it.
 
-2. **`package.json`** (top-level): an npm project. Read `.version` via `jq -r .version`.
+2. **`package.json`** (top-level): an npm project. Read `.version` via `jq -r .version`. **Skip this source if `.name == "loom-workspace"`** — that's the Loom installer's own workspace-scaffolding stub (`defaults/package.json`, copied into any consumer repo that lacked a root `package.json`), not a real project version source. It carries no `version` field in current installs; if an older stub with a leftover `version` field is still present, treat it the same way — skip it and keep walking the remaining detection sources instead of reporting a false version.
 
 3. **`*/package.json`** (workspace packages): an npm workspace / monorepo. Glob the top-level for subdirectory `package.json` files and read `.version` from each. Common patterns: `packages/*/package.json`, `apps/*/package.json`, or simply `<name>/package.json` (Loom's `mcp-loom/package.json` shape).
 
@@ -423,4 +423,5 @@ Release v$NEW_VERSION complete
 - **`scripts/version.sh` is the source of truth on subsequent runs.** Phase 1's short-circuit step ensures the skill defers to the generated script after the first run.
 - **Multiple shapes can coexist.** An npm+cargo monorepo (Loom's own shape) needs updates across `package.json`, `Cargo.toml`, `Cargo.lock`, and possibly `CLAUDE.md`. Emit writers for every detected shape.
 - **The seven detection sources are**: `package.json`, `*/package.json` (workspace), `Cargo.toml` (+ workspace members + `Cargo.lock`), `pyproject.toml` (`[project]` or `[tool.poetry]`), `setup.py`/`setup.cfg` (legacy Python), top-level shell script with `VERSION="X.Y.Z"`, and `CLAUDE.md`/`README.md` with `**Version**: X.Y.Z`.
+- **The top-level `package.json` source is skipped when it's the Loom-installed `loom-workspace` stub** (`.name == "loom-workspace"`) — it's workspace scaffolding, not a real project version source, and must never be reported as a detected version even if an older install left a stale `version` field on it.
 - **Branch protection**: if the operator's repo enforces PR-only merges to `main`, a direct push of the bump commit will fail. In that case, push the bump commit to a feature branch and open a PR — the tag can be created after the PR merges.

--- a/defaults/package.json
+++ b/defaults/package.json
@@ -1,6 +1,5 @@
 {
   "name": "loom-workspace",
-  "version": "1.0.0",
   "description": "Loom-managed workspace with AI development orchestration",
   "private": true,
   "scripts": {

--- a/defaults/scripts/resync-installed.sh
+++ b/defaults/scripts/resync-installed.sh
@@ -26,6 +26,14 @@
 #   .loom/bin/              <- defaults/.loom/bin/        (recursive; live consumer CLI)
 #   .claude/commands/loom/  <- defaults/.claude/commands/loom/ (recursive)
 #
+# It also applies one targeted field edit outside the pure-copy model (#4285):
+# a root package.json whose "name" is exactly "loom-workspace" (the Loom
+# installer's workspace-scaffolding stub, `defaults/package.json`) has its
+# decoy "version" field deleted in place if present — this is a `jq
+# 'del(.version)'` field edit, NOT a whole-file resync, so a consumer's
+# customized "scripts" block in the stub is preserved. A consumer's OWN
+# package.json (any other "name") is never touched.
+#
 # On a successful non-dry-run it also re-stamps loom_version, loom_commit, and a
 # last_resync date into .loom/install-metadata.json (requires jq or python3;
 # skipped with a warning if neither is present — the file sync still succeeds).
@@ -48,10 +56,11 @@
 #   install-metadata.json's install_date + installed_files - owned by the installer
 #
 # Local-override convention: list a relative path (e.g. `hooks/guard-destructive.sh`,
-# `scripts/foo.sh`, `roles/custom-role.md`, `docs/notes.md`, `bin/loom`, or
-# `commands/loom/mine.md`) — one per line — in `.loom/resync-ignore` to pin an
-# intentional per-repo customization. Matching files are reported as `skipped`
-# and never overwritten. Blank lines and `#` comments are ignored.
+# `scripts/foo.sh`, `roles/custom-role.md`, `docs/notes.md`, `bin/loom`,
+# `commands/loom/mine.md`, or `package.json` to pin the #4285 stub version edit)
+# — one per line — in `.loom/resync-ignore` to pin an intentional per-repo
+# customization. Matching files are reported as `skipped` and never overwritten.
+# Blank lines and `#` comments are ignored.
 #
 # Usage:
 #   ./.loom/scripts/resync-installed.sh            # sync; report what changed
@@ -385,6 +394,63 @@ fi
 if [[ -d "$REPO_ROOT/.claude/commands/loom" ]]; then
     resync_tree "$DEFAULTS_DIR/.claude/commands/loom" "$REPO_ROOT/.claude/commands/loom" "commands/loom" ".claude/commands/loom"
 fi
+
+# ---------- targeted field edit: loom-workspace package.json version (#4285) ----------
+#
+# defaults/package.json ships without a "version" field — the field was a decoy
+# for version-detection tooling (npm-shape probes, /loom:bump) that mistook the
+# installer's workspace stub for a real project version source. Consumers who
+# installed the OLD stub (with "version": "1.0.0") still carry it on disk. A
+# whole-file resync (like the surfaces above) would clobber the consumer's
+# customized "scripts" block (check:ci, test, lint, ...), so this does a
+# targeted field deletion instead: strip ".version" from the root package.json
+# ONLY when ".name" is exactly "loom-workspace" and a "version" field is
+# present. A consumer's own package.json (any other name) is left untouched.
+resync_workspace_stub_version() {
+    local pj="$REPO_ROOT/package.json"
+    [[ -f "$pj" ]] || return 0
+
+    if is_ignored "package.json"; then
+        note "  ${YELLOW}skipped${NC}   package.json ${YELLOW}(pinned in .loom/resync-ignore)${NC}"
+        N_SKIPPED=$((N_SKIPPED + 1))
+        return 0
+    fi
+
+    if ! command -v jq >/dev/null 2>&1; then
+        warn "Skipped package.json version-stub check (need jq). Surface sync still applied."
+        return 0
+    fi
+
+    local name
+    name="$(jq -r '.name // empty' "$pj" 2>/dev/null)"
+    [[ "$name" == "loom-workspace" ]] || return 0
+
+    local has_version
+    has_version="$(jq -r 'has("version")' "$pj" 2>/dev/null)"
+    if [[ "$has_version" != "true" ]]; then
+        note "  ${GREEN}unchanged${NC} package.json (no decoy version field)"
+        N_UNCHANGED=$((N_UNCHANGED + 1))
+        return 0
+    fi
+
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        printf '%b\n' "  ${BOLD}would update${NC} package.json (remove decoy \"version\" field, #4285)"
+        N_UPDATED=$((N_UPDATED + 1))
+        return 0
+    fi
+
+    local tmp="${pj}.tmp.$$"
+    if jq 'del(.version)' "$pj" > "$tmp" 2>/dev/null && [[ -s "$tmp" ]]; then
+        mv "$tmp" "$pj"
+        printf '%b\n' "  ${GREEN}updated${NC}   package.json (removed decoy \"version\" field, #4285)"
+        N_UPDATED=$((N_UPDATED + 1))
+    else
+        rm -f "$tmp"
+        err "failed to update package.json (jq del(.version))"
+    fi
+}
+
+resync_workspace_stub_version
 
 # ---------- re-stamp install-metadata.json (#4239, non-dry-run only) ----------
 #

--- a/defaults/scripts/tests/test-resync-installed.sh
+++ b/defaults/scripts/tests/test-resync-installed.sh
@@ -477,6 +477,68 @@ else
     fail "(#4280) missing binary did not produce the expected warning"
 fi
 
+# --- (#4285) targeted loom-workspace package.json version field edit --------
+echo "Test group 12d: loom-workspace package.json decoy version field removal (#4285)"
+REPO="$(make_fixture)"
+printf '{\n  "name": "loom-workspace",\n  "version": "1.0.0",\n  "scripts": {"test": "my-custom-test"}\n}\n' \
+    > "$REPO/package.json"
+OUT="$(cd "$REPO" && bash "$SCRIPT" 2>&1)"
+RC=$?
+if [[ $RC -eq 0 ]]; then pass "(#4285) apply with a stub version field exits 0"; else fail "(#4285) apply exits 0 (got $RC)"; fi
+if ! grep -q '"version"' "$REPO/package.json"; then
+    pass "(#4285) loom-workspace package.json version field removed"
+else
+    fail "(#4285) loom-workspace package.json version field NOT removed"
+fi
+if grep -q '"name": *"loom-workspace"' "$REPO/package.json"; then
+    pass "(#4285) loom-workspace package.json name preserved"
+else
+    fail "(#4285) loom-workspace package.json name was altered/lost"
+fi
+if grep -q "my-custom-test" "$REPO/package.json"; then
+    pass "(#4285) consumer's customized scripts block preserved"
+else
+    fail "(#4285) consumer's customized scripts block was lost"
+fi
+if grep -q "package.json.*removed decoy" <<<"$OUT"; then
+    pass "(#4285) apply reports the package.json version removal"
+else
+    fail "(#4285) apply did not report the package.json version removal"
+fi
+# Idempotent rerun: second apply is a clean no-op for package.json.
+OUT="$(cd "$REPO" && bash "$SCRIPT" 2>&1)"
+if grep -q "package.json (no decoy version field)" <<<"$OUT"; then
+    pass "(#4285) second run reports package.json unchanged (idempotent)"
+else
+    fail "(#4285) second run did not report package.json as unchanged"
+fi
+
+echo "Test group 12e: a consumer's OWN package.json (not loom-workspace) is untouched"
+REPO="$(make_fixture)"
+printf '{\n  "name": "my-real-project",\n  "version": "2.3.4"\n}\n' > "$REPO/package.json"
+OUT="$(cd "$REPO" && bash "$SCRIPT" 2>&1)"
+if grep -q '"version": *"2.3.4"' "$REPO/package.json"; then
+    pass "(#4285) consumer's own package.json version left untouched"
+else
+    fail "(#4285) consumer's own package.json version was modified"
+fi
+
+echo "Test group 12f: .loom/resync-ignore pins package.json against the stub edit"
+REPO="$(make_fixture)"
+printf '{\n  "name": "loom-workspace",\n  "version": "1.0.0"\n}\n' > "$REPO/package.json"
+printf 'package.json  # keep my pinned stub version\n' > "$REPO/.loom/resync-ignore"
+OUT="$(cd "$REPO" && bash "$SCRIPT" 2>&1)"
+if grep -q '"version": *"1.0.0"' "$REPO/package.json"; then
+    pass "(#4285) pinned package.json version NOT removed"
+else
+    fail "(#4285) pinned package.json version was removed despite resync-ignore"
+fi
+if grep -q "skipped.*package.json" <<<"$OUT"; then
+    pass "(#4285) pinned package.json reported as skipped"
+else
+    fail "(#4285) pinned package.json not reported skipped"
+fi
+
 # --- contract checks ---------------------------------------------------------
 echo "Test group 13: flag/contract checks"
 if bash "$SCRIPT" --help 2>&1 | grep -q "resync-installed.sh"; then


### PR DESCRIPTION
## Summary

`defaults/package.json`'s workspace-scaffolding stub shipped `"version": "1.0.0"` — a decoy that confuses version-detection tooling in consumer repos (`/repo:release`'s npm-shape probe, `/loom:bump`'s detection source #2) when the repo's real version lives elsewhere (e.g. rjwalters/claude-monitor keeps its version in Swift source + a build script). This PR removes the decoy and teaches the detection/resync tooling to ignore it.

## Changes

- `defaults/package.json`: dropped the `"version": "1.0.0"` field entirely. npm/pnpm only require `version` for *publishing*; a `"private": true` package without it installs and runs its scripts fine. Omission was chosen over a `0.0.0-loom-workspace` sentinel per the curator's rationale — a sentinel still matches naive `jq -r .version` probes and just moves the confusion.
- `defaults/.claude/commands/loom/bump.md`: at detection source #2 (top-level `package.json`), added an explicit skip for a root `package.json` whose `.name == "loom-workspace"` — treated as workspace scaffolding, not a real project version source, even if an older install left a stale `version` field on it. Also updated the summary list near the end of the file.
- `defaults/scripts/resync-installed.sh`: added a targeted `jq 'del(.version)'` field edit (not a whole-file resync) for a root `package.json` whose `.name` is exactly `loom-workspace` and which still has a `version` field. This is how existing consumers who received the OLD stub lose the decoy on their next resync, without clobbering their customized `scripts` block (`check:ci`, `test`, `lint`, ...). Honors `.loom/resync-ignore` (entry: `package.json`) for anyone who wants to pin it, and guards on `jq` availability like the existing metadata re-stamp step.
- `defaults/scripts/tests/test-resync-installed.sh`: added 3 new test groups (12d/12e/12f) covering: stub version removal + idempotent rerun + scripts-block preservation, a consumer's own (non-`loom-workspace`) `package.json` being left untouched, and `.loom/resync-ignore` pinning the stub.

`loom-daemon/src/init/scaffolding.rs` (the copy site) needed no change — its tests fabricate their own `defaults/` fixture content and don't assert on `version`, so they're unaffected by the stub edit; verified by running `cargo test scaffolding`.

**Explicitly out of scope** (per curator guidance and the issue body):
- `/repo:release`'s npm detection lives in a different repo (rjwalters/repo) — can't be fixed here.
- No code change to "fix existing consumer repos" beyond making a resync of an existing consumer naturally pick up the fixed stub — that's the `resync-installed.sh` targeted field edit above, not a bespoke migration script.

## Acceptance Criteria Verification

- [x] Installer omits the `version` field from the stub — `defaults/package.json` no longer has a `version` key.
- [x] `/loom:bump` skips a root `package.json` whose `name` is `loom-workspace` — added at detection source #2 in `bump.md`, plus the summary-list note.
- [x] Existing consumer repos: reinstall/resync removes the stub version — `resync-installed.sh` now strips `.version` from a `loom-workspace`-named root `package.json` in place, preserving the rest of the file.

## Test Plan

- [x] `bash defaults/scripts/tests/test-resync-installed.sh` — 57/57 passed (including 9 new #4285 assertions across 3 new test groups; the jump from the pre-change 41 baseline includes group 12b's daemon-dependent subtests, which ran because a `loom-daemon` debug binary was already built in this environment).
- [x] `cd loom-daemon && cargo test --test bump_md_doc_lint` — 8/8 passed (doc-lint contract for `bump.md` unaffected by the added guard prose).
- [x] `cd loom-daemon && cargo test scaffolding` (informational, per curator) — 48/48 passed; confirms the copy-site tests (which fabricate their own defaults content) are unaffected by the stub's `version` field removal.
- [x] `bash -n` + `shellcheck` on both modified shell scripts — clean.
- [ ] Manual (new install): not run in this environment (`loom-daemon init` end-to-end) — covered indirectly by the `scaffolding.rs` copy tests above.

Closes #4285
