### PR TITLE
feat(cli): systemd --user service path in loom-daemon-start/stop (#4268)

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -2197,8 +2197,12 @@ process:
 - **on macOS, backgrounds the daemon as a launchd LaunchAgent** in the resolved
   per-user domain (`gui/<uid>` with an active GUI login, else the SSH-reachable
   `user/<uid>` background domain — #4130) instead of a plain `nohup … &` (#3972 —
-  see "macOS session-bootstrap hazard" below); on Linux it stays a plain nohup
-  background job with no reboot/crash supervision (deferred to #4260),
+  see "macOS session-bootstrap hazard" below); **on a systemd Linux host,
+  installs + enables a `systemd --user` service** (#4268 — see "systemd user unit
+  (Linux)" below) that mirrors the launchd supervision contract
+  (`Restart=on-success`, disable-on-stop, `LOOM_DAEMON_SUPERVISOR=systemd`); on a
+  non-systemd Linux host (or with `--no-systemd` / `LOOM_DAEMON_SYSTEMD=0`) it
+  stays a plain nohup background job,
 - backgrounds the daemon and writes a PID file at `.loom/.daemon.pid` (gitignored)
   — or, in **machine mode** (dispatcher-driven, `LOOM_MACHINE_CHECKOUT` set,
   #4229), at `$HOME/.loom/.daemon.pid` so the same machine-wide launchd
@@ -2212,7 +2216,11 @@ process:
 `loom-daemon-stop.sh` sends **SIGTERM** (not just Ctrl-C/SIGINT — the daemon now
 handles both, #3813), waits `LOOM_DAEMON_STOP_GRACE_SECS` (default 10s), then
 escalates to SIGKILL. On macOS it additionally `launchctl bootout`s the
-LaunchAgent job definition once the process is confirmed dead (see below).
+LaunchAgent job definition once the process is confirmed dead (see below). On a
+systemd Linux host it detects the `systemd --user` ownership
+(`systemctl --user is-active`/`is-enabled`) and instead stops + **disables** the
+unit (`systemctl --user disable --now`), so a subsequent reboot does not
+resurrect it (#4268 — see "systemd user unit (Linux)" below).
 
 **Shutdown decision — sweeps survive, they are not drained.** A clean daemon stop
 removes the Unix socket and exits, but **does not cancel in-flight `/loom:sweep`
@@ -2500,14 +2508,67 @@ without an Aqua session, not regressions introduced here.
   XML this invocation would install and exits — no `launchctl` call, no file
   write to `~/Library/LaunchAgents`. Useful for auditing exactly what
   environment/flags a given invocation would forward.
-- **Linux**: unaffected — `nohup` stays the mechanism, since a systemd user
-  session doesn't tie process identity to the spawning shell the way macOS's
-  Mach bootstrap does. Operators who want equivalent extra hardening on Linux
-  (e.g. surviving a `systemd --user` session teardown in an unusual setup) can
-  optionally wrap the start in `systemd-run --user --scope
-  ./.loom/scripts/cli/loom-daemon-start.sh` — not required for the documented
-  failure mode, since it doesn't reproduce on Linux, but available as a
-  belt-and-suspenders option.
+- **Linux**: on a systemd host the daemon is supervised as a `systemd --user`
+  service (#4268), not a bare `nohup` — see "systemd user unit (Linux)" directly
+  below. On a non-systemd host (or with `--no-systemd` / `LOOM_DAEMON_SYSTEMD=0`)
+  `nohup` remains the mechanism, which is safe on Linux because a background
+  process's identity is not tied to the spawning shell the way macOS's Mach
+  bootstrap is (so the #3972 failure mode does not reproduce there — the systemd
+  path is about reboot survival + supervised restart, not that incident).
+
+### systemd user unit (Linux, #4268)
+
+On a systemd Linux host, `loom-daemon-start.sh` installs a `systemd --user`
+service and `systemctl --user enable --now`s it, the Linux mirror of the launchd
+LaunchAgent path above (sub-issue B of #4260). This replaces the pre-#4268 bare
+`nohup … &`, which had no reboot survival, no supervised restart, and no
+disable-on-stop. The contract mirrors launchd point-for-point:
+
+| launchd (Darwin) | systemd `--user` (Linux) |
+|---|---|
+| `RunAtLoad=true` + `launchctl enable` (#3972) | `[Install] WantedBy=default.target` + `systemctl --user enable` |
+| `KeepAlive:{SuccessfulExit:true}` — relaunch only on a clean exit `0` (#4054) | `Restart=on-success` — relaunch only on a clean exit `0` (exact analog; a crash / operator SIGTERM/SIGINT exits non-zero and stays down) |
+| `launchctl bootout` on operator stop | `systemctl --user disable --now <unit>` |
+| plist `EnvironmentVariables` (`LOOM_DAEMON_SUPERVISOR=launchd`, forwarded `LOOM_*`/tokens, deterministic PATH #4172) | `Environment=` lines (`LOOM_DAEMON_SUPERVISOR=systemd`, same forwarded env + PATH) |
+| `WorkingDirectory` = checkout in machine mode (#4229), else repo root | `WorkingDirectory=` — same resolution |
+| `--no-launchd` / `LOOM_DAEMON_LAUNCHD=0` escape hatch (#4078) | `--no-systemd` / `LOOM_DAEMON_SYSTEMD=0` escape hatch |
+| `--print-plist` inspection (no side effects) | `--print-unit` inspection (no side effects) |
+
+- **Unit location & name**: `~/.config/systemd/user/loom-daemon.service` (override
+  the name with `LOOM_SYSTEMD_UNIT`). Regenerated and `daemon-reload`ed on every
+  start, so a later invocation's flags/env always win over a stale unit. Written
+  `0600` when it carries a forwarded `GH_TOKEN`/`GITEA_TOKEN`/`FORGE_TOKEN`.
+- **`LOOM_DAEMON_SUPERVISOR=systemd`** is baked into the unit so the daemon can
+  prove it is supervised before it exits for a supervised restart — recognized
+  daemon-side by `detect_supervisor()` (PR #4298 / #4267). It is hardcoded into the
+  rendered unit (never harvested from the caller's env), so it is present on every
+  supervised start and absent from the nohup path.
+- **Reboot survival requires lingering.** A `systemd --user` manager only runs
+  while the user has a session; the service comes back after a reboot (or an SSH
+  logout) **only** when the user has lingering enabled. Run **`loginctl
+  enable-linger "$USER"`** once on a headless / SSH-only host. Without it the unit
+  is still installed + supervised for the life of the login session, but does not
+  survive a reboot; `loom-daemon-start.sh` prints this reminder on every systemd
+  start.
+- **User-manager reachability fallback.** If `systemctl` is present but the
+  per-user manager is unreachable — a bare SSH login with no lingering and no
+  active user session, so `XDG_RUNTIME_DIR` is unset / `systemctl --user
+  is-system-running` reports `offline` — the start script warns clearly (with the
+  `enable-linger` remedy) and falls back to the nohup path, rather than failing
+  with a cryptic `Failed to connect to bus` error. Detection lives in
+  `is_linux_systemd()` / `systemd_user_manager_reachable()`
+  (`defaults/scripts/lib/systemd-user.sh`, the Linux counterpart to
+  `lib/launchd-domain.sh`, shared by start + stop).
+- **Stop disables the unit.** `loom-daemon-stop.sh` detects the `systemd --user`
+  ownership and runs `systemctl --user disable --now`, then re-verifies the unit is
+  inactive and exits non-zero if it is not (the systemd analog of the launchd
+  bootout-did-not-stick check). `LOOM_DAEMON_SYSTEMD=0` disables all systemd
+  interaction symmetrically, so a `--no-systemd` (nohup) start gets a stop that
+  never touches the user manager.
+- **Crash relaunch is out of scope.** `Restart=on-success` deliberately does
+  **not** relaunch a crashed daemon (a non-zero exit) — that is watchdog territory,
+  tracked as sub-issue D of #4260, mirroring the macOS `StartInterval` autonomy-loss
+  watchdog (#4011), which remains launchd-only for now.
 
 ### macOS TCC hygiene under launchd (#3980)
 

--- a/defaults/docs/machine-dispatcher.md
+++ b/defaults/docs/machine-dispatcher.md
@@ -240,17 +240,27 @@ launchd-managed) or refused (not currently running, or a pre-#4077 binary), it
 falls back to a plain stop-then-start via the same checkout-resolved
 lifecycle-script delegates.
 
-### Supervision (reboot/crash) — macOS done, Linux deferred
+### Supervision (reboot/crash) — macOS via launchd, Linux via systemd `--user`
 
 Reboot/crash supervision itself (as opposed to the workdir/pid-file relocation
-above) is already implemented and documented for macOS via launchd —
-`RunAtLoad` (#3972), `KeepAlive:{SuccessfulExit:true}` restart-only relaunch
-(#4054), and a `StartInterval` autonomy-loss watchdog (#4011), all resolved
-through the `gui/<uid>` ↦ `user/<uid>` domain fallback (#4130). See
-[`daemon-reference.md`](daemon-reference.md) → Operability for the full
-writeup. **Linux has no equivalent** — the non-Darwin path is a plain `nohup …
-&` with no reboot/crash recovery and no watchdog. This is tracked as a named
-follow-up, #4260, rather than designed inline here.
+above) is implemented for macOS via launchd — `RunAtLoad` (#3972),
+`KeepAlive:{SuccessfulExit:true}` restart-only relaunch (#4054), and a
+`StartInterval` autonomy-loss watchdog (#4011), all resolved through the
+`gui/<uid>` ↦ `user/<uid>` domain fallback (#4130).
+
+On a **systemd Linux host** the same reboot survival + supervised-restart contract
+is provided by a `systemd --user` service (#4268, sub-issue B of #4260): `loom
+start` installs `~/.config/systemd/user/loom-daemon.service` and `systemctl --user
+enable --now`s it (`Restart=on-success` == the launchd restart-only relaunch;
+`WantedBy=default.target` == `RunAtLoad`), and `loom stop` runs `systemctl --user
+disable --now` so a reboot does not resurrect it. **Reboot survival on a
+headless / SSH-only host requires lingering** — run `loginctl enable-linger
+"$USER"` once. A non-systemd host (or `--no-systemd` / `LOOM_DAEMON_SYSTEMD=0`)
+falls back to the plain `nohup` path. See [`daemon-reference.md`](daemon-reference.md)
+→ Operability → "systemd user unit (Linux)" for the full writeup. Crash relaunch
+(as opposed to restart-on-success) and a systemd-side autonomy-loss watchdog
+remain follow-ups (sub-issue D of #4260), mirroring the still-launchd-only #4011
+watchdog.
 
 ## User-scope skills + agents (Epic #3835 Phase 4, #4261)
 

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -21,7 +21,11 @@
 #     resolved per-user domain (`gui/<uid>` when a GUI login is active, else
 #     `user/<uid>` — #4130, so it can also be (re)started headlessly over SSH)
 #     so it survives the launching session's death instead of a plain `nohup ...
-#     &`; on Linux it stays a plain nohup background job,
+#     &`; on a systemd Linux host, installs + enables a `systemd --user` service
+#     (#4268) that mirrors the launchd contract (Restart=on-success,
+#     disable-on-stop, LOOM_DAEMON_SUPERVISOR=systemd) — see --no-systemd for the
+#     escape hatch; on a non-systemd Linux host (or with --no-systemd) it stays a
+#     plain nohup background job,
 #   - backgrounds the daemon and writes a PID file (.loom/.daemon.pid),
 #   - persists the resolved invocation flags to .loom/.daemon.flags so
 #     `loom-daemon-update.sh` (#3968) can restart with EXACTLY the same
@@ -61,7 +65,9 @@
 #   ./.loom/scripts/cli/loom-daemon-start.sh --no-health-gate    Force health gate OFF (explicit)
 #   ./.loom/scripts/cli/loom-daemon-start.sh --foreground    Run in the foreground (no PID file)
 #   ./.loom/scripts/cli/loom-daemon-start.sh --no-launchd    macOS only: use legacy nohup instead of a LaunchAgent
+#   ./.loom/scripts/cli/loom-daemon-start.sh --no-systemd    Linux only: use legacy nohup instead of a systemd --user service
 #   ./.loom/scripts/cli/loom-daemon-start.sh --print-plist   Print the LaunchAgent plist that WOULD be installed and exit (no side effects)
+#   ./.loom/scripts/cli/loom-daemon-start.sh --print-unit    Print the systemd --user unit that WOULD be installed and exit (no side effects)
 #   ./.loom/scripts/cli/loom-daemon-start.sh --help
 #
 # Environment:
@@ -69,6 +75,8 @@
 #   LOOM_SOCKET_PATH    Override the daemon socket (default ~/.loom/loom-daemon.sock)
 #   LOOM_WORK_FINDER / LOOM_MAIN_HEALTH_GATE  Respected when already exported
 #   LOOM_DAEMON_LAUNCHD  macOS only: 0/false/no forces the legacy nohup path (same as --no-launchd)
+#   LOOM_DAEMON_SYSTEMD  Linux only: 0/false/no forces the legacy nohup path (same as --no-systemd)
+#   LOOM_SYSTEMD_UNIT    Linux only: override the systemd --user unit name (default loom-daemon.service)
 #   LOOM_LAUNCHD_LABEL   macOS only: override the LaunchAgent label (default com.rjwalters.loom-daemon)
 #   LOOM_LAUNCHD_DOMAIN  macOS only: pin the launchd domain (e.g. gui/$(id -u) or
 #                        user/$(id -u)); honored verbatim, else auto-resolved
@@ -177,6 +185,13 @@ _LOOM_LAUNCHD_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" 2>/dev/null 
 if [[ -r "$_LOOM_LAUNCHD_LIB_DIR/launchd-domain.sh" ]]; then
     # shellcheck source=../lib/launchd-domain.sh
     source "$_LOOM_LAUNCHD_LIB_DIR/launchd-domain.sh"
+fi
+# systemd --user resolver (#4268) — the Linux counterpart to launchd-domain.sh
+# (is_linux_systemd / resolve_systemd_unit* / systemd_user_manager_reachable),
+# sourced by start/stop so both agree on unit name + path + detection.
+if [[ -r "$_LOOM_LAUNCHD_LIB_DIR/systemd-user.sh" ]]; then
+    # shellcheck source=../lib/systemd-user.sh
+    source "$_LOOM_LAUNCHD_LIB_DIR/systemd-user.sh"
 fi
 
 # resolve_plist_path() — the deterministic PATH baked into every rendered
@@ -326,6 +341,76 @@ render_launchd_plist() {
     printf '</dict>\n</plist>\n'
 }
 
+# ---------- systemd --user unit rendering (#4268) ----------
+# render_systemd_unit <daemon_bin> <workdir> <log_path>
+# Prints the `systemd --user` service unit to stdout. Pure string rendering --
+# safe to call on ANY platform (used by --print-unit for inspection/testing); the
+# `systemctl --user` invocation that consumes it is gated to a systemd Linux host
+# separately, below. This is the Linux mirror of render_launchd_plist:
+#
+#   * Restart=on-success is the exact analog of the launchd
+#     KeepAlive:{SuccessfulExit:true} contract (#4054): systemd relaunches the
+#     service ONLY when it exits with status 0 (the RestartDaemon primitive), and
+#     leaves it down on any non-zero exit -- a crash/panic, a SIGTERM operator
+#     stop (143), a SIGINT/Ctrl-C (130) -- so it preserves the no-crash-loop
+#     semantics while making the one deliberate clean exit the only relaunch
+#     trigger. Crash relaunch (Restart=always/on-failure) is deliberately NOT set
+#     here -- that is watchdog territory (sub-issue D of #4260).
+#   * [Install] WantedBy=default.target + `systemctl --user enable` is the
+#     RunAtLoad=true analog: the service comes up on login (and, with
+#     `loginctl enable-linger`, after a reboot).
+#   * LOOM_DAEMON_SUPERVISOR=systemd is baked in (hardcoded, not env-harvested) so
+#     the daemon can PROVE it is supervised before it exits for a restart (#4054,
+#     recognized daemon-side by detect_supervisor() since PR #4298 / #4267) -- and,
+#     conversely, is ABSENT from the nohup path, so an unsupervised daemon
+#     correctly refuses to exit on a restart request.
+#   * The PATH baked in is the SAME deterministic value as the launchd plist
+#     (#4172, $PLIST_PATH_VALUE), not the invoking shell's PATH; every already-
+#     exported LOOM_* / GH_TOKEN / GITEA_TOKEN / FORGE_TOKEN var is forwarded
+#     verbatim so the service sees EXACTLY the autonomy flags + auth this
+#     invocation resolved -- never wider, never narrower.
+render_systemd_unit() {
+    local bin="$1" workdir="$2" log_path="$3"
+    local unit_path_value="$PLIST_PATH_VALUE"
+
+    local env_lines=""
+    env_lines+="Environment=PATH=${unit_path_value}\n"
+    env_lines+="Environment=HOME=${HOME}\n"
+    # Mark the daemon as systemd-supervised so its RestartDaemon handler (#4054)
+    # will exit 0 for a supervised relaunch. Hardcoded (not env-harvested) so it
+    # is present in every rendered unit and never leaks to the nohup path.
+    env_lines+="Environment=LOOM_DAEMON_SUPERVISOR=systemd\n"
+
+    local line key
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        key="${line%%=*}"
+        # Never duplicate the supervisor key hardcoded above.
+        [[ "$key" == "LOOM_DAEMON_SUPERVISOR" ]] && continue
+        env_lines+="Environment=${line}\n"
+    done < <(env | grep -E '^(LOOM_[A-Za-z0-9_]*|GH_TOKEN|GITEA_TOKEN|FORGE_TOKEN)=' || true)
+
+    printf '[Unit]\n'
+    printf 'Description=Loom autonomous daemon (loom-daemon)\n'
+    printf 'After=network-online.target\n'
+    printf 'Wants=network-online.target\n'
+    printf '\n'
+    printf '[Service]\n'
+    printf 'Type=simple\n'
+    printf 'WorkingDirectory=%s\n' "$workdir"
+    printf 'ExecStart=%s\n' "$bin"
+    # Restart=on-success == launchd KeepAlive:{SuccessfulExit:true} (#4054): only a
+    # clean exit 0 (the RestartDaemon primitive) trips a relaunch; a crash / an
+    # operator SIGTERM/SIGINT exits non-zero and stays down.
+    printf 'Restart=on-success\n'
+    printf '%b' "$env_lines"
+    printf 'StandardOutput=append:%s\n' "$log_path"
+    printf 'StandardError=append:%s\n' "$log_path"
+    printf '\n'
+    printf '[Install]\n'
+    printf 'WantedBy=default.target\n'
+}
+
 # ---------- autonomy-desired intent marker (#4011) ----------
 # Write the durable "a daemon is EXPECTED to be running on this host" marker on a
 # successful start. Its LIFETIME is operator intent, NOT process liveness: only
@@ -462,7 +547,9 @@ FOREGROUND=false
 WANT_WORK_FINDER=false
 WANT_HEALTH_GATE=false
 NO_LAUNCHD=false
+NO_SYSTEMD=false
 PRINT_PLIST=false
+PRINT_UNIT=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --help|-h) show_help; exit 0 ;;
@@ -473,7 +560,9 @@ while [[ $# -gt 0 ]]; do
         --no-work-finder) WANT_WORK_FINDER=false; shift ;;
         --no-health-gate) WANT_HEALTH_GATE=false; shift ;;
         --no-launchd) NO_LAUNCHD=true; shift ;;
+        --no-systemd) NO_SYSTEMD=true; shift ;;
         --print-plist) PRINT_PLIST=true; shift ;;
+        --print-unit) PRINT_UNIT=true; shift ;;
         *) err "Unknown option '$1'"; echo "Use --help for usage" >&2; exit 1 ;;
     esac
 done
@@ -634,7 +723,7 @@ FLAGS_FILE="$DAEMON_STATE_HOME/.daemon.flags"
 if [[ "${#ORIGINAL_ARGS[@]}" -gt 0 ]]; then
     for _flag_arg in "${ORIGINAL_ARGS[@]}"; do
         case "$_flag_arg" in
-            --foreground|--fg|--help|-h|--no-launchd|--print-plist) continue ;;
+            --foreground|--fg|--help|-h|--no-launchd|--no-systemd|--print-plist|--print-unit) continue ;;
             *) echo "$_flag_arg" >> "$FLAGS_FILE" ;;
         esac
     done
@@ -669,6 +758,31 @@ if [[ "$IS_DARWIN" == "true" ]]; then
 fi
 [[ "$NO_LAUNCHD" == "true" ]] && USE_LAUNCHD=false
 
+# ---------- Linux systemd --user detection (#4268) ----------
+# On a systemd Linux host, supervise the daemon as a `systemd --user` service
+# instead of a plain nohup background job (the launchd analog, #3972). The
+# escape hatch --no-systemd / LOOM_DAEMON_SYSTEMD=0 forces the legacy nohup path,
+# symmetric with --no-launchd / LOOM_DAEMON_LAUNCHD=0 on Darwin (#4078 analog).
+# is_linux_systemd() (lib/systemd-user.sh) is false on a non-systemd Linux host,
+# in a container without a user manager, or on Darwin -- all of which fall
+# through to the nohup path byte-compatibly.
+IS_LINUX_SYSTEMD=false
+if [[ "$USE_LAUNCHD" != "true" ]] \
+    && ! [[ "${LOOM_DAEMON_SYSTEMD:-}" =~ ^(0|false|no)$ ]] \
+    && [[ "$NO_SYSTEMD" != "true" ]]; then
+    if declare -f is_linux_systemd >/dev/null 2>&1 && is_linux_systemd; then
+        IS_LINUX_SYSTEMD=true
+    elif [[ "$IS_DARWIN" != "true" ]] && command -v systemctl >/dev/null 2>&1 \
+        && declare -f systemd_user_manager_reachable >/dev/null 2>&1 \
+        && ! systemd_user_manager_reachable; then
+        # systemctl is present but the per-user manager is unreachable (a bare
+        # SSH login with no lingering / no active user session). Warn clearly and
+        # fall back to nohup rather than failing with a cryptic bus error.
+        warn "systemd --user manager unreachable (no XDG_RUNTIME_DIR / offline) — falling back to nohup."
+        warn "For a supervised, reboot-surviving daemon, run: loginctl enable-linger \"\$USER\" and retry."
+    fi
+fi
+
 # ---------- --print-plist: pure inspection, no side effects ----------
 if [[ "$PRINT_PLIST" == "true" ]]; then
     render_launchd_plist "$(resolve_launchd_label)" "$DAEMON_BIN" "$REPO_ROOT" "$START_LOG"
@@ -689,6 +803,12 @@ if [[ "$PRINT_PLIST" == "true" ]]; then
             } >&2
         fi
     fi
+    exit 0
+fi
+
+# ---------- --print-unit: pure inspection, no side effects (#4268) ----------
+if [[ "$PRINT_UNIT" == "true" ]]; then
+    render_systemd_unit "$DAEMON_BIN" "$REPO_ROOT" "$START_LOG"
     exit 0
 fi
 
@@ -798,7 +918,82 @@ if [[ "$USE_LAUNCHD" == "true" ]]; then
     exit 0
 fi
 
-# ---------- Linux (or --no-launchd): plain nohup background job ----------
+# ---------- Linux: systemd --user service (#4268) ----------
+# The Linux mirror of the launchd path above: install a `systemd --user` unit and
+# `enable --now` it so the daemon survives the launching shell's death and comes
+# back on login (and, with `loginctl enable-linger`, after a reboot). Restart=
+# on-success (rendered above) relaunches ONLY on a clean exit 0 -- the exact
+# analog of KeepAlive:{SuccessfulExit:true} (#4054). Escape hatch: --no-systemd /
+# LOOM_DAEMON_SYSTEMD=0 falls through to the nohup path below.
+if [[ "$IS_LINUX_SYSTEMD" == "true" ]]; then
+    SYSTEMD_UNIT="$(resolve_systemd_unit)"
+    SYSTEMD_UNIT_DIR="$(resolve_systemd_unit_dir)"
+    SYSTEMD_UNIT_PATH="$(resolve_systemd_unit_path)"
+    mkdir -p "$SYSTEMD_UNIT_DIR"
+
+    render_systemd_unit "$DAEMON_BIN" "$REPO_ROOT" "$START_LOG" > "$SYSTEMD_UNIT_PATH"
+
+    # Harden the rendered unit when it carries a forwarded credential (#4005
+    # analog): the env-forwarding loop in render_systemd_unit writes any exported
+    # GH_TOKEN/GITEA_TOKEN/FORGE_TOKEN straight into Environment= lines, and the
+    # plain `>` redirect otherwise leaves the file world-readable (0644).
+    if env | grep -qE '^(GH_TOKEN|GITEA_TOKEN|FORGE_TOKEN)=' 2>/dev/null; then
+        chmod 600 "$SYSTEMD_UNIT_PATH"
+    fi
+
+    echo "Systemd unit:   $SYSTEMD_UNIT"
+    echo "Unit file:      $SYSTEMD_UNIT_PATH"
+
+    # Reload so systemd picks up the freshly-rendered unit (a unit left from a
+    # prior invocation, possibly with different flags/env, must not keep running
+    # its OLD definition), then enable --now to install into default.target AND
+    # start it in one step.
+    systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+    ENABLE_ERR="$START_LOG.enable-err"
+    if ! systemctl --user enable --now "$SYSTEMD_UNIT" 2>"$ENABLE_ERR"; then
+        err "systemctl --user enable --now failed for $SYSTEMD_UNIT:"
+        cat "$ENABLE_ERR" >&2 2>/dev/null || true
+        rm -f "$ENABLE_ERR"
+        exit 1
+    fi
+    rm -f "$ENABLE_ERR"
+
+    # Give it a moment to either bind the socket or trip the singleton guard.
+    sleep 2
+
+    daemon_pid="$(systemctl --user show -p MainPID --value "$SYSTEMD_UNIT" 2>/dev/null)"
+    if [[ -z "$daemon_pid" || "$daemon_pid" == "0" ]] || ! kill -0 "$daemon_pid" 2>/dev/null; then
+        err "loom-daemon did not stay running under systemd ($SYSTEMD_UNIT)."
+        if [[ -s "$START_LOG" ]]; then
+            echo "----- startup output ($START_LOG) -----" >&2
+            tail -n 20 "$START_LOG" >&2
+            echo "---------------------------------------" >&2
+        fi
+        warn "If another daemon is already listening on the socket, stop it first"
+        warn "(./.loom/scripts/cli/loom-daemon-stop.sh) and retry."
+        exit 1
+    fi
+
+    echo "$daemon_pid" > "$PID_FILE"
+    # Record operator intent (#4011). The scheduled watchdog is a launchd job, so
+    # on Linux there is no host-side checker to provision -- the marker + heartbeat
+    # are still written (the systemd-side watchdog is sub-issue D of #4260).
+    write_intent_marker "false" ""
+    provision_watchdog_job
+    ok "loom-daemon started under systemd (pid $daemon_pid, unit $SYSTEMD_UNIT)."
+    echo "PID file: $PID_FILE"
+    echo "Intent marker: $INTENT_MARKER"
+    warn "Reboot survival requires lingering: run 'loginctl enable-linger \"\$USER\"' once (SSH-only / headless hosts)."
+    if [[ "$MACHINE_MODE" == "true" ]]; then
+        echo "Stop with: loom stop"
+    else
+        echo "Stop with: ./.loom/scripts/cli/loom-daemon-stop.sh"
+    fi
+    exit 0
+fi
+
+# ---------- Linux (non-systemd, or --no-launchd/--no-systemd): plain nohup ----------
 nohup "$DAEMON_BIN" >> "$START_LOG" 2>&1 &
 daemon_pid=$!
 

--- a/defaults/scripts/cli/loom-daemon-stop.sh
+++ b/defaults/scripts/cli/loom-daemon-stop.sh
@@ -18,6 +18,16 @@
 #   the reaper reconciles their state on the next start. To actively cancel a
 #   sweep, use `mcp__loom__cancel_sweep` against a running daemon before stopping.
 #
+# Linux systemd --user counterpart (#4268): when loom-daemon-start.sh installed
+# the daemon as a `systemd --user` service, this script detects that ownership
+# (`systemctl --user is-active`/`is-enabled <unit>`) and stops + DISABLES the unit
+# (`systemctl --user disable --now <unit>`) instead of a raw pid kill — the systemd
+# analog of the launchd bootout below. Disabling is what keeps a subsequent reboot
+# from resurrecting the daemon (the unit sets [Install] WantedBy=default.target).
+# The escape hatch LOOM_DAEMON_SYSTEMD=0 disables ALL systemd interaction
+# symmetrically with loom-daemon-start.sh --no-systemd (#4078 analog), falling back
+# to the pid-file/nohup tier.
+#
 # macOS launchd counterpart (#3972): when loom-daemon-start.sh loaded the
 # daemon as a launchd LaunchAgent (in the resolve_launchd_domain() domain —
 # gui/<uid> or user/<uid>, #4130), this script ALSO unloads the launchd
@@ -70,6 +80,11 @@
 #                                 A start done with --no-launchd / LOOM_DAEMON_LAUNCHD=0
 #                                 must get a stop that never reads or mutates the
 #                                 machine-global launchd domain (issue #4078).
+#   LOOM_DAEMON_SYSTEMD           Linux only: 0/false/no disables ALL systemd interaction
+#                                 (is-active/is-enabled lookup + disable --now),
+#                                 symmetric with loom-daemon-start.sh --no-systemd (#4268).
+#   LOOM_SYSTEMD_UNIT             Linux only: the systemd --user unit to stop + disable
+#                                 (default loom-daemon.service); must match the start's.
 #   LOOM_MACHINE_CHECKOUT         Machine mode (Epic #3835 Phase 3b, #4229): set
 #                                 by the `scripts/loom` dispatcher before it execs
 #                                 this script. When set, the pid file is read from
@@ -187,6 +202,12 @@ if [[ -r "$_LOOM_LAUNCHD_LIB_DIR/launchd-domain.sh" ]]; then
     # shellcheck source=../lib/launchd-domain.sh
     source "$_LOOM_LAUNCHD_LIB_DIR/launchd-domain.sh"
 fi
+# systemd --user resolver (#4268) — is_linux_systemd / resolve_systemd_unit,
+# shared with loom-daemon-start.sh so stop agrees on the unit the start installed.
+if [[ -r "$_LOOM_LAUNCHD_LIB_DIR/systemd-user.sh" ]]; then
+    # shellcheck source=../lib/systemd-user.sh
+    source "$_LOOM_LAUNCHD_LIB_DIR/systemd-user.sh"
+fi
 
 IS_DARWIN=false
 [[ "$(uname -s)" == "Darwin" ]] && IS_DARWIN=true
@@ -235,6 +256,49 @@ launchd_bootout_if_loaded() {
         launchctl bootout "$LAUNCHD_SERVICE" >/dev/null 2>&1 || true
     fi
 }
+
+# ---------- systemd --user ownership tier (Linux, #4268) ----------
+# When the daemon was started as a `systemd --user` service, stop + DISABLE the
+# unit rather than raw-killing the pid: disabling is what keeps a reboot from
+# resurrecting it (the unit sets WantedBy=default.target). This is the systemd
+# analog of the launchd bootout tier. Honors LOOM_DAEMON_SYSTEMD=0 symmetrically
+# with loom-daemon-start.sh --no-systemd (#4078 analog): a start done with
+# --no-systemd was a plain nohup job, so the stop must never reach into the
+# systemd user manager to look it up. When systemd is off, absent, or the unit
+# is not this daemon's, fall through to the pid-file/nohup tier below.
+IS_LINUX_SYSTEMD=false
+if ! [[ "${LOOM_DAEMON_SYSTEMD:-}" =~ ^(0|false|no)$ ]] \
+    && declare -f is_linux_systemd >/dev/null 2>&1 && is_linux_systemd; then
+    IS_LINUX_SYSTEMD=true
+fi
+if [[ "$IS_LINUX_SYSTEMD" == "true" ]]; then
+    SYSTEMD_UNIT="$(resolve_systemd_unit)"
+    # Only adopt the systemd tier when a unit under THIS name is actually loaded
+    # (active or enabled) — otherwise a --no-systemd / nohup start (or a stale
+    # scratch unit) should route to the pid-file tier, not a no-op disable.
+    if systemctl --user is-active --quiet "$SYSTEMD_UNIT" 2>/dev/null \
+        || systemctl --user is-enabled --quiet "$SYSTEMD_UNIT" 2>/dev/null; then
+        echo "Stopping loom-daemon via systemd (systemctl --user disable --now $SYSTEMD_UNIT)..."
+        systemctl --user disable --now "$SYSTEMD_UNIT" >/dev/null 2>&1 || true
+        # Verify the unit is actually down — a disable --now that did not stop the
+        # service is the systemd analog of a bootout that did not stick (the
+        # inverted-#4011 silent-success hole): fail loudly instead of reporting success.
+        if systemctl --user is-active --quiet "$SYSTEMD_UNIT" 2>/dev/null; then
+            err "loom-daemon is still active under systemd ($SYSTEMD_UNIT) after disable --now."
+            err "Retry the stop, or disable manually: systemctl --user disable --now $SYSTEMD_UNIT"
+            exit 1
+        fi
+        rm -f "$PID_FILE"
+        if [[ "$KEEP_INTENT" != "true" ]]; then
+            teardown_autonomy_intent
+            ok "loom-daemon stopped + disabled (systemd unit $SYSTEMD_UNIT). Autonomy-desired marker cleared."
+        else
+            ok "loom-daemon stopped + disabled (systemd unit $SYSTEMD_UNIT). Autonomy-desired marker preserved (restart in progress)."
+        fi
+        echo "In-flight sweeps (if any) were left running by design; the next start reconciles them."
+        exit 0
+    fi
+fi
 
 # Resolve the target pid: prefer the PID file, else a launchd lookup (Darwin),
 # else best-effort pgrep.

--- a/defaults/scripts/lib/systemd-user.sh
+++ b/defaults/scripts/lib/systemd-user.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# systemd-user.sh — shared systemd --user resolver for the loom-daemon lifecycle
+# scripts (issue #4268, sub-issue B of #4260).
+#
+# Source this file (do not exec). It is the Linux counterpart to
+# lib/launchd-domain.sh: where launchd-domain.sh resolves the per-user launchd
+# DOMAIN a macOS LaunchAgent loads under, this file answers the three questions
+# the Linux systemd --user service path needs:
+#
+#   is_linux_systemd            -> return 0 when the systemd --user path should be
+#                                  used (Linux + `systemctl` on PATH + a reachable
+#                                  per-user manager), non-zero to fall back to the
+#                                  legacy nohup path.
+#   resolve_systemd_unit        -> echoes the unit name (default loom-daemon.service,
+#                                  override via LOOM_SYSTEMD_UNIT).
+#   resolve_systemd_unit_dir    -> echoes the user-unit directory (~/.config/systemd/user).
+#   resolve_systemd_unit_path   -> echoes the full unit-file path (<dir>/<unit>).
+#   systemd_user_manager_reachable -> return 0 when `systemctl --user` can talk to
+#                                  the per-user manager (see the headless caveat).
+#
+# WHY THIS EXISTS (#4260/#4268). The pre-#4268 non-Darwin path in
+# loom-daemon-start.sh was a plain `nohup "$DAEMON_BIN" &` — no reboot survival,
+# no supervised restart, no bootout-on-stop. A `systemd --user` service mirrors
+# the Darwin launchd contract (#3972/#4054/#4130/#4229) on Linux:
+#
+#   launchd (Darwin)                        systemd --user (Linux)
+#   RunAtLoad=true + `launchctl enable`  ->  [Install] WantedBy=default.target
+#                                            + `systemctl --user enable`
+#   KeepAlive:{SuccessfulExit:true}      ->  Restart=on-success  (relaunch ONLY on
+#     (relaunch only on clean exit 0)         a clean exit 0 — exact match; an
+#                                             operator stop is never a clean exit,
+#                                             so it is not auto-restarted)
+#   `launchctl bootout` on operator stop ->  `systemctl --user disable --now <unit>`
+#   plist EnvironmentVariables           ->  Environment= lines in the rendered unit
+#   WorkingDirectory                     ->  WorkingDirectory=
+#   --no-launchd / LOOM_DAEMON_LAUNCHD=0 ->  --no-systemd / LOOM_DAEMON_SYSTEMD=0
+#     escape hatch to the nohup path          escape hatch to the nohup path
+#
+# HEADLESS / SSH CAVEAT (loginctl enable-linger). A `systemd --user` manager only
+# runs while the user has a session, and the service only survives a reboot / a
+# logout when the user has LINGERING enabled. Reboot survival and SSH-only hosts
+# therefore require `loginctl enable-linger "$USER"` once; without it the unit is
+# still installed + supervised for the life of the login session, but does not
+# come back after a reboot. systemd_user_manager_reachable() below is the
+# per-user-manager reachability probe (is XDG_RUNTIME_DIR present and does the
+# manager answer): when it is false — a bare SSH login with no lingering and no
+# active graphical/systemd user session — the start script warns and falls back
+# to the nohup path rather than failing with a cryptic bus/bootstrap error.
+
+# is_linux_systemd — return 0 when the systemd --user service path should drive
+# the daemon lifecycle. Requires Linux, `systemctl` on PATH, and a reachable
+# per-user manager.
+#
+# LOOM_SYSTEMD_FORCE=1 is a TEST-ONLY seam: it forces the platform + manager
+# checks to pass (so the lifecycle tests can exercise the systemd branch on a
+# Darwin CI runner behind a stub `systemctl` on PATH), while still requiring
+# `systemctl` to be resolvable — so a test that forgets to install its stub does
+# not silently take the branch.
+is_linux_systemd() {
+    if [[ "${LOOM_SYSTEMD_FORCE:-}" == "1" ]]; then
+        command -v systemctl >/dev/null 2>&1
+        return
+    fi
+    [[ "$(uname -s)" == "Linux" ]] || return 1
+    command -v systemctl >/dev/null 2>&1 || return 1
+    systemd_user_manager_reachable
+}
+
+# systemd_user_manager_reachable — return 0 when `systemctl --user` can reach the
+# per-user manager. A bare SSH login with no lingering and no active user session
+# has no user manager to bootstrap into: XDG_RUNTIME_DIR is unset and
+# `systemctl --user is-system-running` reports "offline" (or fails to connect to
+# the bus). Both cases return non-zero here so the caller can warn + fall back to
+# nohup instead of surfacing a cryptic "Failed to connect to bus" error.
+systemd_user_manager_reachable() {
+    [[ "${LOOM_SYSTEMD_FORCE:-}" == "1" ]] && return 0
+    [[ -n "${XDG_RUNTIME_DIR:-}" ]] || return 1
+    local state
+    state="$(systemctl --user is-system-running 2>/dev/null)"
+    # is-system-running exits non-zero when "degraded", but the manager is still
+    # reachable then — key on the reported STATE, not the exit code. Only
+    # "offline" (or an empty answer = no bus) means unreachable.
+    case "$state" in
+        offline|"") return 1 ;;
+        *)          return 0 ;;
+    esac
+}
+
+# resolve_systemd_unit — the unit name the loom-daemon service is installed under.
+# Default loom-daemon.service; override with LOOM_SYSTEMD_UNIT (e.g. a test's
+# scratch unit, or an operator managing a specifically-named daemon). A value
+# without a `.service` suffix is left verbatim — systemctl treats a bare name as a
+# .service unit, and the tests pin an explicit name, so no suffix normalization is
+# imposed here.
+resolve_systemd_unit() {
+    echo "${LOOM_SYSTEMD_UNIT:-loom-daemon.service}"
+}
+
+# resolve_systemd_unit_dir — the per-user unit directory systemd reads from.
+resolve_systemd_unit_dir() {
+    echo "${HOME}/.config/systemd/user"
+}
+
+# resolve_systemd_unit_path — the full path of the rendered unit file.
+resolve_systemd_unit_path() {
+    echo "$(resolve_systemd_unit_dir)/$(resolve_systemd_unit)"
+}

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -111,6 +111,9 @@ fi
 #    --no-launchd forces the legacy nohup path even on a Darwin test runner —
 #    this test exercises the flags-persistence array guard, not launchd
 #    (#3972), and must never mutate the real machine's LaunchAgents.
+#    --no-systemd is the Linux-runner analog (#4268): it forces the nohup path so
+#    running this suite on a real systemd host never installs/enables a real
+#    `systemd --user` unit.
 BG_FAKE_BIN="$WORKDIR/fake-loom-daemon-bg"
 cat > "$BG_FAKE_BIN" <<'EOF'
 #!/usr/bin/env bash
@@ -127,7 +130,7 @@ chmod +x "$BG_FAKE_BIN"
     LOOM_SOCKET_PATH="$WORKDIR/.loom/loom-daemon.sock" \
     LOOM_AUTONOMY_MARKER="$WORKDIR/.loom/autonomy-desired" \
     LOOM_WATCHDOG_LABEL="com.example.loom-sandbox-$$-watchdog" \
-    bash "$START_SCRIPT" --no-launchd >/dev/null 2>&1 )
+    bash "$START_SCRIPT" --no-launchd --no-systemd >/dev/null 2>&1 )
 bg_rc=$?
 assert_eq "0" "$bg_rc" "bare (zero-arg) background start exits 0 (no unbound-variable crash, #3968)"
 TESTS_RUN=$((TESTS_RUN + 1))
@@ -221,6 +224,175 @@ else
     echo -e "${RED}✗${NC} dev-mode fallback unchanged: refuses from a non-repo dir with no dispatcher (#4229 scope guard)"
 fi
 rm -rf "$MACHINE_HOME" "$MACHINE_CHECKOUT" "$NON_REPO_DIR"
+
+# ---------- systemd --user service path (#4268) ----------
+# The Linux mirror of the launchd path. The suite runs on Darwin runners, so
+# detection uses the test-only LOOM_SYSTEMD_FORCE=1 seam in lib/systemd-user.sh
+# plus a stub `systemctl` on PATH (mirroring the stub `launchctl` below). Every
+# invocation also passes --no-launchd so the systemd branch is reachable on a
+# Darwin runner (launchd wins over systemd by platform) and never touches real
+# launchd, and pins a scratch LOOM_SYSTEMD_UNIT so a stray real user manager is
+# never enabled/disabled.
+SD_UNIT="loom-daemon-test-$$.service"
+
+# S1. --print-unit renders the unit with NO side effects (no systemctl, no file
+#     write). Assert the four load-bearing fields from the issue's test plan:
+#     Restart=on-success, WantedBy=default.target, the baked
+#     Environment=LOOM_DAEMON_SUPERVISOR=systemd, and WorkingDirectory=<repo>.
+unit_out=$( ( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --print-unit 2>/dev/null ) )
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$unit_out" | grep -qx 'Restart=on-success' \
+    && echo "$unit_out" | grep -qx 'WantedBy=default.target' \
+    && echo "$unit_out" | grep -qx 'Environment=LOOM_DAEMON_SUPERVISOR=systemd' \
+    && echo "$unit_out" | grep -qx "WorkingDirectory=$WORKDIR"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --print-unit renders Restart=on-success, WantedBy=default.target, LOOM_DAEMON_SUPERVISOR=systemd, WorkingDirectory=<repo>"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --print-unit renders the expected unit fields"
+    echo "$unit_out" | sed 's/^/    /'
+fi
+
+# Shared stub systemctl: records every call, answers daemon-reload/enable as
+# success and `show -p MainPID --value` with a live pid we control. Structurally
+# unable to touch a real unit.
+SD_BIN="$WORKDIR/sd-bin"; mkdir -p "$SD_BIN"
+SD_MAIN_SLEEP_PID=""
+make_sd_stub() {
+    local log="$1" mainpid="$2"
+    cat > "$SD_BIN/systemctl" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$log"
+if [[ "\${1:-}" == "--user" ]]; then shift; fi
+case "\${1:-}" in
+  show) echo "${mainpid}" ;;
+  *)    exit 0 ;;
+esac
+EOF
+    chmod +x "$SD_BIN/systemctl"
+}
+
+# S2. Forced systemd path installs + enables the unit and writes the PID file
+#     from `systemctl --user show -p MainPID`. A real sleeper stands in for the
+#     daemon MainPID so the liveness check (kill -0) passes.
+sleep 30 & SD_MAIN_SLEEP_PID=$!
+SD_LOG="$WORKDIR/sd-enable.log"; : > "$SD_LOG"
+make_sd_stub "$SD_LOG" "$SD_MAIN_SLEEP_PID"
+SD_HOME="$(mktemp -d)"; mkdir -p "$SD_HOME/.loom/logs"
+sd_out=$( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    PATH="$SD_BIN:$PATH" HOME="$SD_HOME" \
+    LOOM_SYSTEMD_FORCE=1 LOOM_SYSTEMD_UNIT="$SD_UNIT" \
+    LOOM_DAEMON_BIN="$FAKE_BIN" \
+    LOOM_SOCKET_PATH="$SD_HOME/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$SD_HOME/.loom/autonomy-desired" \
+    bash "$START_SCRIPT" --no-launchd 2>&1 )
+sd_rc=$?
+assert_eq "0" "$sd_rc" "systemd path: start exits 0"
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q -- "--user enable --now $SD_UNIT" "$SD_LOG" && grep -q -- '--user daemon-reload' "$SD_LOG"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} systemd path: runs daemon-reload + enable --now on the unit"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} systemd path: runs daemon-reload + enable --now on the unit"
+    echo "  systemctl calls: $(cat "$SD_LOG")"
+fi
+# The PID file lands under the repo-root state home ($WORKDIR/.loom in dev mode),
+# not under the pinned scratch $HOME (which only relocates the socket/marker).
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$(cat "$WORKDIR/.loom/.daemon.pid" 2>/dev/null)" == "$SD_MAIN_SLEEP_PID" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} systemd path: PID file written from systemctl show -p MainPID"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} systemd path: PID file written from systemctl show -p MainPID"
+    echo "  pid file: [$(cat "$WORKDIR/.loom/.daemon.pid" 2>/dev/null)] expected [$SD_MAIN_SLEEP_PID]"
+fi
+rm -f "$WORKDIR/.loom/.daemon.pid"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -f "$SD_HOME/.config/systemd/user/$SD_UNIT" ]] \
+    && grep -qx 'Restart=on-success' "$SD_HOME/.config/systemd/user/$SD_UNIT"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} systemd path: renders the unit file under ~/.config/systemd/user with Restart=on-success"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} systemd path: renders the unit file under ~/.config/systemd/user with Restart=on-success"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$sd_out" | grep -qi 'enable-linger'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} systemd path: prints the loginctl enable-linger reboot-survival reminder"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} systemd path: prints the loginctl enable-linger reboot-survival reminder"
+fi
+kill "$SD_MAIN_SLEEP_PID" 2>/dev/null || true
+rm -rf "$SD_HOME"
+
+# S3. Escape hatch: --no-systemd falls back to the nohup path byte-compatibly —
+#     the stub systemctl is on PATH and detection is FORCED, yet no systemctl
+#     call is made (the whole systemd branch is skipped).
+SD_LOG2="$WORKDIR/sd-nohatch.log"; : > "$SD_LOG2"
+make_sd_stub "$SD_LOG2" "0"
+SD_HOME2="$(mktemp -d)"; mkdir -p "$SD_HOME2/.loom/logs"
+( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    PATH="$SD_BIN:$PATH" HOME="$SD_HOME2" \
+    LOOM_SYSTEMD_FORCE=1 LOOM_SYSTEMD_UNIT="$SD_UNIT" \
+    LOOM_DAEMON_BIN="$BG_FAKE_BIN" \
+    LOOM_SOCKET_PATH="$SD_HOME2/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$SD_HOME2/.loom/autonomy-desired" \
+    bash "$START_SCRIPT" --no-launchd --no-systemd >/dev/null 2>&1 )
+nohatch_rc=$?
+assert_eq "0" "$nohatch_rc" "--no-systemd: start exits 0 (nohup fallback)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ ! -s "$SD_LOG2" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --no-systemd: performs no systemctl call at all (byte-compatible nohup path)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --no-systemd: performs no systemctl call at all"
+    echo "  systemctl calls: $(cat "$SD_LOG2")"
+fi
+if [[ -f "$SD_HOME2/.loom/.daemon.pid" ]]; then
+    kill "$(cat "$SD_HOME2/.loom/.daemon.pid" 2>/dev/null)" 2>/dev/null || true
+fi
+rm -rf "$SD_HOME2"
+
+# S4. LOOM_DAEMON_SYSTEMD=0 is the env equivalent of --no-systemd (same skip).
+SD_LOG3="$WORKDIR/sd-envoff.log"; : > "$SD_LOG3"
+make_sd_stub "$SD_LOG3" "0"
+SD_HOME3="$(mktemp -d)"; mkdir -p "$SD_HOME3/.loom/logs"
+( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    PATH="$SD_BIN:$PATH" HOME="$SD_HOME3" \
+    LOOM_SYSTEMD_FORCE=1 LOOM_SYSTEMD_UNIT="$SD_UNIT" LOOM_DAEMON_SYSTEMD=0 \
+    LOOM_DAEMON_BIN="$BG_FAKE_BIN" \
+    LOOM_SOCKET_PATH="$SD_HOME3/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$SD_HOME3/.loom/autonomy-desired" \
+    bash "$START_SCRIPT" --no-launchd >/dev/null 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ ! -s "$SD_LOG3" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} LOOM_DAEMON_SYSTEMD=0: performs no systemctl call (env escape hatch, symmetric with --no-systemd)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} LOOM_DAEMON_SYSTEMD=0: performs no systemctl call"
+    echo "  systemctl calls: $(cat "$SD_LOG3")"
+fi
+if [[ -f "$SD_HOME3/.loom/.daemon.pid" ]]; then
+    kill "$(cat "$SD_HOME3/.loom/.daemon.pid" 2>/dev/null)" 2>/dev/null || true
+fi
+rm -rf "$SD_HOME3"
+
+# S5. --help documents the systemd escape hatch + --print-unit.
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$help_out" | grep -q -- '--no-systemd' && echo "$help_out" | grep -q -- '--print-unit'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --help documents --no-systemd and --print-unit"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --help documents --no-systemd and --print-unit"
+fi
 
 # ---------- launchd domain resolution (#4130) ----------
 # resolve_launchd_domain() (lib/launchd-domain.sh) picks gui/<uid> when the GUI

--- a/defaults/scripts/tests/test-loom-daemon-stop.sh
+++ b/defaults/scripts/tests/test-loom-daemon-stop.sh
@@ -51,6 +51,14 @@ assert_eq() {
 # loaded job on the host machine, regardless of platform.
 FAKE_LABEL="$(launchd_sandbox_new_label)"
 
+# Scratch systemd unit (#4268), the systemd analog of FAKE_LABEL: exported so
+# EVERY stop invocation below (not just the new systemd-tier cases) resolves a
+# guaranteed-nonexistent unit. On a Darwin runner `systemctl` is absent so the
+# systemd tier is never taken; on a real systemd Linux host this ensures the
+# existing cases probe a scratch unit (is-active/is-enabled false → fall through
+# to the pid tier) and can NEVER disable the operator's real loom-daemon.service.
+export LOOM_SYSTEMD_UNIT="loom-daemon-test-$$.service"
+
 WORKDIR="$(mktemp -d)"
 
 # Suite-level safety guard (#4078): a decoy process whose argv ends in
@@ -333,6 +341,118 @@ if echo "$help_out2" | grep -q 'restarting' && echo "$help_out2" | grep -qi 'aut
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "${RED}✗${NC} --help documents --restarting and the autonomy-desired marker"
+fi
+
+# ---------- systemd --user ownership tier (#4268) ----------
+# The Linux mirror of the launchd bootout tier. Detection uses the test-only
+# LOOM_SYSTEMD_FORCE=1 seam plus a stub `systemctl` on PATH (mirroring the stub
+# launchctl above). The stub models unit state via a `down` marker file so the
+# post-disable is-active re-check flips to inactive.
+SD_BIN="$WORKDIR/sd-bin"; mkdir -p "$SD_BIN"
+SD_STATE="$WORKDIR/sd-state"; mkdir -p "$SD_STATE"
+SD_LOG="$WORKDIR/sd-stop.log"
+make_sd_stop_stub() {
+    : > "$SD_LOG"
+    rm -f "$SD_STATE/down"
+    cat > "$SD_BIN/systemctl" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$SD_LOG"
+if [[ "\${1:-}" == "--user" ]]; then shift; fi
+DOWN="$SD_STATE/down"
+case "\${1:-}" in
+  is-active)  [[ -f "\$DOWN" ]] && exit 3; exit 0 ;;   # exit 3 = inactive
+  is-enabled) [[ -f "\$DOWN" ]] && exit 1; exit 0 ;;
+  disable)    touch "\$DOWN"; exit 0 ;;                 # disable --now => now inactive
+  *) exit 0 ;;
+esac
+EOF
+    chmod +x "$SD_BIN/systemctl"
+}
+
+# SD1. Forced systemd tier: an active unit is stopped + DISABLED (disable --now),
+#      the stop exits 0, and the autonomy-desired marker is cleared.
+make_sd_stop_stub
+mkdir -p "$WORKDIR/.loom"
+printf 'started_at=x\n' > "$WORKDIR/.loom/autonomy-desired"
+sd_out=$( cd "$WORKDIR" && PATH="$SD_BIN:$PATH" LOOM_SYSTEMD_FORCE=1 \
+    LOOM_LAUNCHD_LABEL="$FAKE_LABEL" LOOM_AUTONOMY_MARKER="$WORKDIR/.loom/autonomy-desired" \
+    bash "$STOP_SCRIPT" 2>&1 )
+sd_rc=$?
+assert_eq "0" "$sd_rc" "systemd tier: stop of an active unit exits 0"
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q -- "--user disable --now $LOOM_SYSTEMD_UNIT" "$SD_LOG"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} systemd tier: runs 'systemctl --user disable --now <unit>' (stop + disable so reboot cannot resurrect)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} systemd tier: runs 'systemctl --user disable --now <unit>'"
+    echo "  systemctl calls: $(cat "$SD_LOG")"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ ! -f "$WORKDIR/.loom/autonomy-desired" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} systemd tier: operator stop clears the autonomy-desired marker"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} systemd tier: operator stop clears the autonomy-desired marker"
+fi
+
+# SD2. Post-disable verification: if the unit is STILL active after disable --now
+#      (a disable that did not stick — the inverted-#4011 silent-success hole),
+#      the stop exits non-zero instead of reporting success.
+: > "$SD_LOG"
+cat > "$SD_BIN/systemctl" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$SD_LOG"
+if [[ "\${1:-}" == "--user" ]]; then shift; fi
+case "\${1:-}" in
+  is-active)  exit 0 ;;   # ALWAYS active — disable did not stick
+  is-enabled) exit 0 ;;
+  disable)    exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$SD_BIN/systemctl"
+stuck_out=$( cd "$WORKDIR" && PATH="$SD_BIN:$PATH" LOOM_SYSTEMD_FORCE=1 \
+    LOOM_LAUNCHD_LABEL="$FAKE_LABEL" bash "$STOP_SCRIPT" 2>&1 )
+stuck_rc=$?
+assert_eq "1" "$stuck_rc" "systemd tier: unit still active after disable --now → stop exits non-zero"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$stuck_out" | grep -qi 'still active'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} systemd tier: reports the still-active unit instead of success"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} systemd tier: reports the still-active unit instead of success"
+fi
+
+# SD3. Symmetry (#4078 analog): LOOM_DAEMON_SYSTEMD=0 disables ALL systemd
+#      interaction, so NO systemctl call is made even with the stub on PATH and
+#      detection forced — the stop routes to the pid/nohup tier.
+make_sd_stop_stub
+sym_out=$( cd "$WORKDIR" && PATH="$SD_BIN:$PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEMON_SYSTEMD=0 \
+    LOOM_LAUNCHD_LABEL="$FAKE_LABEL" bash "$STOP_SCRIPT" 2>&1 )
+sym_rc=$?
+assert_eq "0" "$sym_rc" "LOOM_DAEMON_SYSTEMD=0: stop exits 0 (pid/nohup tier)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ ! -s "$SD_LOG" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} LOOM_DAEMON_SYSTEMD=0: stop performs no systemctl call at all (symmetric with --no-systemd)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} LOOM_DAEMON_SYSTEMD=0: stop performs no systemctl call at all"
+    echo "  systemctl calls: $(cat "$SD_LOG")"
+fi
+
+# SD4. --help documents the systemd disable counterpart + the LOOM_DAEMON_SYSTEMD
+#      escape hatch.
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$help_out" | grep -qi 'systemd' && echo "$help_out" | grep -q 'LOOM_DAEMON_SYSTEMD'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --help documents the systemd disable counterpart + LOOM_DAEMON_SYSTEMD"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --help documents the systemd disable counterpart + LOOM_DAEMON_SYSTEMD"
 fi
 
 # ---------- machine mode (Epic #3835 Phase 3b, #4229) ----------

--- a/defaults/scripts/tests/test-loom-daemon-stop.sh
+++ b/defaults/scripts/tests/test-loom-daemon-stop.sh
@@ -374,9 +374,9 @@ EOF
 make_sd_stop_stub
 mkdir -p "$WORKDIR/.loom"
 printf 'started_at=x\n' > "$WORKDIR/.loom/autonomy-desired"
-sd_out=$( cd "$WORKDIR" && PATH="$SD_BIN:$PATH" LOOM_SYSTEMD_FORCE=1 \
+( cd "$WORKDIR" && PATH="$SD_BIN:$PATH" LOOM_SYSTEMD_FORCE=1 \
     LOOM_LAUNCHD_LABEL="$FAKE_LABEL" LOOM_AUTONOMY_MARKER="$WORKDIR/.loom/autonomy-desired" \
-    bash "$STOP_SCRIPT" 2>&1 )
+    bash "$STOP_SCRIPT" >/dev/null 2>&1 )
 sd_rc=$?
 assert_eq "0" "$sd_rc" "systemd tier: stop of an active unit exits 0"
 TESTS_RUN=$((TESTS_RUN + 1))
@@ -430,8 +430,8 @@ fi
 #      interaction, so NO systemctl call is made even with the stub on PATH and
 #      detection forced — the stop routes to the pid/nohup tier.
 make_sd_stop_stub
-sym_out=$( cd "$WORKDIR" && PATH="$SD_BIN:$PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEMON_SYSTEMD=0 \
-    LOOM_LAUNCHD_LABEL="$FAKE_LABEL" bash "$STOP_SCRIPT" 2>&1 )
+( cd "$WORKDIR" && PATH="$SD_BIN:$PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEMON_SYSTEMD=0 \
+    LOOM_LAUNCHD_LABEL="$FAKE_LABEL" bash "$STOP_SCRIPT" >/dev/null 2>&1 )
 sym_rc=$?
 assert_eq "0" "$sym_rc" "LOOM_DAEMON_SYSTEMD=0: stop exits 0 (pid/nohup tier)"
 TESTS_RUN=$((TESTS_RUN + 1))


### PR DESCRIPTION
## Summary

Adds a `systemd --user` supervision path for the Linux `loom-daemon`, parallel to the existing Darwin launchd path (sub-issue **B** of #4260). Replaces the bare `nohup "$DAEMON_BIN" &` non-Darwin path, which had no reboot survival, no supervised restart, and no disable-on-stop.

## What changed

- **New shared lib `defaults/scripts/lib/systemd-user.sh`** — the Linux counterpart to `launchd-domain.sh`: `is_linux_systemd` / `systemd_user_manager_reachable` detection (with a test-only `LOOM_SYSTEMD_FORCE=1` seam), unit-name resolution (default `loom-daemon.service`, override via `LOOM_SYSTEMD_UNIT`), and unit-file path (`~/.config/systemd/user/`).
- **`loom-daemon-start.sh`** — an `IS_LINUX_SYSTEMD` branch beside the `IS_DARWIN` branch renders the unit (`render_systemd_unit`, mirroring `render_launchd_plist`), `daemon-reload`, `enable --now`, verifies aliveness, writes the PID file from `systemctl --user show -p MainPID`, and keeps the #4011 intent marker. The Darwin path is untouched. Adds `--print-unit` (parity with `--print-plist`) and the `--no-systemd` / `LOOM_DAEMON_SYSTEMD=0` escape hatch. A systemctl-present-but-manager-unreachable host warns (with `loginctl enable-linger` guidance) and falls back to nohup rather than a cryptic bus error.
- **`loom-daemon-stop.sh`** — a systemd ownership tier (`is-active`/`is-enabled`) runs `systemctl --user disable --now`, re-verifies the unit is inactive (the systemd analog of the launchd bootout-did-not-stick check), and honors `LOOM_DAEMON_SYSTEMD=0` symmetrically; the pid-file/nohup tier stays the fallback.
- **Docs** — `daemon-reference.md` gains a "systemd user unit (Linux)" section and the obsolete "Linux is unaffected — nohup stays the mechanism" paragraph is rewritten; `machine-dispatcher.md`'s supervision section now covers the Linux systemd path.
- **Tests** — both lifecycle suites gain systemd-path cases driven by a stub `systemctl` behind `LOOM_SYSTEMD_FORCE=1`, asserting the rendered unit's `Restart=on-success`, `WantedBy=default.target`, `Environment=LOOM_DAEMON_SUPERVISOR=systemd`, and `WorkingDirectory=`, plus the disable-on-stop tier, the still-active-after-disable failure, and both escape hatches.

## Contract (launchd → systemd `--user`)

| launchd (Darwin) | systemd `--user` (Linux) |
|---|---|
| `RunAtLoad=true` + `launchctl enable` | `[Install] WantedBy=default.target` + `systemctl --user enable` |
| `KeepAlive:{SuccessfulExit:true}` (#4054) | `Restart=on-success` (relaunch only on a clean exit 0) |
| `launchctl bootout` on stop | `systemctl --user disable --now` |
| `--no-launchd` / `LOOM_DAEMON_LAUNCHD=0` | `--no-systemd` / `LOOM_DAEMON_SYSTEMD=0` |
| `--print-plist` | `--print-unit` |

`LOOM_DAEMON_SUPERVISOR=systemd` is baked into the unit; the daemon-side recognition shipped in PR #4298 (`detect_supervisor()`), so that soft dependency is already satisfied.

## Scope

Crash relaunch (`Restart=always`/`on-failure`) and a systemd-side autonomy-loss watchdog are deliberately out of scope — sub-issue D of #4260.

## Test results (local, Darwin)

- `test-loom-daemon-start.sh`: **30 passed, 0 failed**
- `test-loom-daemon-stop.sh`: **36 passed, 0 failed**
- Unaffected siblings green: `test-loom-daemon-launchd-plist` (42), `test-loom-daemon-update` (56), `test-loom-daemon-watchdog` (12)
- `shellcheck -S warning` clean on the new lib + both cli scripts.

Closes #4268

🤖 Generated with [Claude Code](https://claude.com/claude-code)
