### PR TITLE
feat(hooks): execute guard hooks from the machine checkout via user-scope wiring

### DIFF
--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -212,10 +212,11 @@ fi
 # rev-parse subprocess below), on purpose — the structural test never needs the
 # repo root. Only the toggle/extra-list config read needs a config file, and it
 # is resolved LAZILY (only after structural admission already passed) by walking
-# up from CWD to the nearest .loom/config.json WITHOUT forking git
-# (fastpath_config_file). So a fast-pathed command pays: 1 bash-builtin test +
-# (only if eligible) 1 stat-walk + 1 jq read — never the git rev-parse, never a
-# deny/ask array, never a log write.
+# up from CWD to the nearest Loom config root WITHOUT forking git
+# (fastpath_config_root). So a fast-pathed command pays: 1 bash-builtin test +
+# (only if eligible) 1 stat-walk + up to 2 bounded jq reads (project tier, then
+# legacy tier only if the key is absent from project) — never the git
+# rev-parse, never a deny/ask array, never a log write.
 #
 # Toggle: guards.readOnlyFastPath (default true) / LOOM_GUARD_READONLY_FASTPATH
 # env (0/false/no disables, 1/true/yes forces on; env wins). Optional
@@ -223,40 +224,57 @@ fi
 # commands (each entry is a full-generality bypass for that command word).
 # =============================================================================
 
-# CARVE-OUT (#4063): the three fast-path readers below — fastpath_config_file,
-# fastpath_enabled, fastpath_extra_admits — are deliberately NOT migrated to the
-# shared config-resolver.sh (loom_config_get / loom_resolve_config) that the
-# cold-path toggles use. This is intentional and preserves issue #3687's fork
-# budget:
+# CARVE-OUT (#4063, UPDATED for Epic #3835 Phase 5, #4262): the fast-path
+# config readers below — fastpath_config_root, _fastpath_tiered_get,
+# _fastpath_tiered_get_array, fastpath_enabled, fastpath_extra_admits — are
+# deliberately NOT migrated to the shared config-resolver.sh (loom_config_get /
+# loom_resolve_config) that the cold-path toggles use. This is intentional and
+# preserves issue #3687's fork budget:
 #   * This block can `exit 0` (silent allow) BEFORE REPO_ROOT is resolved — the
 #     `git -C "$CWD" rev-parse --show-toplevel` fork lives strictly below the
 #     fast-path dispatch. loom_resolve_config REQUIRES a repo_root as its first
 #     argument, so routing these through it would force hoisting that git
 #     rev-parse above the fast-path exit, directly regressing #3687 (which
 #     removed it from the pre-admission path).
-#   * fastpath_config_file is a fork-free bash-builtin upward directory walk;
-#     fastpath_enabled / fastpath_extra_admits each cost exactly one CACHED jq.
-#     loom_config_get is uncached and forks jq once per existing tier file plus a
-#     merge (~3 forks today, more as Epic #3835 lands upper tiers) on EVERY call —
-#     a 3x+ regression on a hook that fires before every Bash tool call. Caching
-#     the merge (Option B) still needs a repo_root, and teaching the resolver a
-#     fork-free upward-walk root discovery (Option C) would break the documented
-#     three-language (Rust/Python/Bash) conformance-fixture contract in
-#     config-resolver.sh's header. So the fast path keeps its direct single-jq
-#     read of the nearest .loom/config.json. See #4063 for the full analysis.
+#   * fastpath_config_root is a fork-free bash-builtin upward directory walk
+#     (now stat-ing for EITHER `.loom-project/project.json` or
+#     `.loom/config.json`, so a `.loom-project/`-only repo is still found);
+#     fastpath_enabled / fastpath_extra_admits each cost AT MOST two CACHED,
+#     file-scoped jq reads (project tier, then legacy tier ONLY when the key
+#     is absent from the project tier — #4262's Epic #3835 `.loom-project/`
+#     tier reaching this toggle without forking the full merge).
+#     loom_resolve_config is uncached and soft-reads every tier file plus a
+#     merge (4+ forks today) on EVERY call — a 4x+ regression on a hook that
+#     fires before every Bash tool call. Caching the merge (Option B) still
+#     needs a repo_root, and teaching the resolver a fork-free upward-walk
+#     root discovery (Option C) would break the documented three-language
+#     (Rust/Python/Bash) conformance-fixture contract in config-resolver.sh's
+#     header. So the fast path keeps its direct, bounded (<=2 fork) reads
+#     instead. See #4063 for the original analysis and #4262 for the tier
+#     widening.
 #
-# Locate the nearest .loom/config.json by walking up from CWD, fork-free (no
-# git rev-parse). Cached. Best-effort: empty when none is found.
-_FASTPATH_CFG_FILE=""
-_FASTPATH_CFG_FILE_DONE=""
-fastpath_config_file() {
-    if [[ -z "$_FASTPATH_CFG_FILE_DONE" ]]; then
-        _FASTPATH_CFG_FILE_DONE=1
+# Locate the nearest Loom config ROOT by walking up from CWD, fork-free (no
+# git rev-parse) — a directory holding EITHER the tracked project tier
+# (.loom-project/project.json, Epic #3835) OR the legacy tier
+# (.loom/config.json). Cached. Best-effort: empty when neither is found.
+#
+# Epic #3835 Phase 5 (#4262): previously this walked looking for
+# .loom/config.json alone. Widening the stat to "either tier file" keeps the
+# walk itself fork-free (bash-builtin [[ -f ]] tests only) while letting the
+# two readers below (fastpath_enabled / fastpath_extra_admits) consult
+# .loom-project/project.json — see the CARVE-OUT comment above for why this
+# stays a direct, bounded-fork jq read instead of routing through
+# loom_resolve_config().
+_FASTPATH_CFG_ROOT=""
+_FASTPATH_CFG_ROOT_DONE=""
+fastpath_config_root() {
+    if [[ -z "$_FASTPATH_CFG_ROOT_DONE" ]]; then
+        _FASTPATH_CFG_ROOT_DONE=1
         local d="$CWD"
         if [[ -n "$d" && "$d" == /* ]]; then
             while :; do
-                if [[ -f "$d/.loom/config.json" ]]; then
-                    _FASTPATH_CFG_FILE="$d/.loom/config.json"
+                if [[ -f "$d/.loom-project/project.json" || -f "$d/.loom/config.json" ]]; then
+                    _FASTPATH_CFG_ROOT="$d"
                     break
                 fi
                 [[ "$d" == "/" ]] && break
@@ -266,7 +284,69 @@ fastpath_config_file() {
             done
         fi
     fi
-    printf '%s' "$_FASTPATH_CFG_FILE"
+    printf '%s' "$_FASTPATH_CFG_ROOT"
+}
+
+# Read a dotted-path boolean-ish scalar from the tiered fast-path config: try
+# the tracked project tier first (.loom-project/project.json), falling back to
+# the legacy tier (.loom/config.json) ONLY when the key is absent from the
+# project tier — this mirrors the resolver's whole-value tier precedence (a
+# higher tier that sets the key wins outright, it is not merged with a lower
+# tier). At most two jq forks, both file-scoped (no directory-file soft-read
+# fan-out, no merge) — the bounded-fork budget this CARVE-OUT preserves.
+# Echoes the resolved value, or empty when the key is absent from both tiers.
+_fastpath_tiered_get() {
+    local dotted="$1" root cfg value
+    root=$(fastpath_config_root)
+    [[ -n "$root" ]] || { printf ''; return 0; }
+
+    cfg="$root/.loom-project/project.json"
+    if [[ -f "$cfg" ]]; then
+        value=$(jq -r --arg p "$dotted" '
+            ($p | split(".")) as $path
+            | try getpath($path) catch null
+            | if . == null then empty else . end
+        ' "$cfg" 2>/dev/null) || value=""
+        [[ -n "$value" ]] && { printf '%s' "$value"; return 0; }
+    fi
+
+    cfg="$root/.loom/config.json"
+    if [[ -f "$cfg" ]]; then
+        value=$(jq -r --arg p "$dotted" '
+            ($p | split(".")) as $path
+            | try getpath($path) catch null
+            | if . == null then empty else . end
+        ' "$cfg" 2>/dev/null) || value=""
+        [[ -n "$value" ]] && { printf '%s' "$value"; return 0; }
+    fi
+
+    printf ''
+}
+
+# Same tier precedence as _fastpath_tiered_get, but for an array-valued key:
+# echoes the elements of guards.<name> one per line, from whichever tier's
+# file HAS the key first (project, else legacy) — an array value at a tier is
+# a whole-value override, never merged element-wise with a lower tier (this
+# matches the resolver's jq `*` deep-merge semantics for non-object values).
+# Echoes nothing when the key is absent from both tiers.
+_fastpath_tiered_get_array() {
+    local dotted="$1" root cfg has
+    root=$(fastpath_config_root)
+    [[ -n "$root" ]] || return 0
+
+    cfg="$root/.loom-project/project.json"
+    if [[ -f "$cfg" ]]; then
+        has=$(jq -r --arg p "$dotted" '($p | split(".")) as $path | try (getpath($path) != null) catch false' "$cfg" 2>/dev/null) || has=false
+        if [[ "$has" == "true" ]]; then
+            jq -r --arg p "$dotted" '($p | split(".")) as $path | getpath($path) | (. // [])[]' "$cfg" 2>/dev/null
+            return 0
+        fi
+    fi
+
+    cfg="$root/.loom/config.json"
+    if [[ -f "$cfg" ]]; then
+        jq -r --arg p "$dotted" '($p | split(".")) as $path | try (getpath($path) // []) catch [] | .[]' "$cfg" 2>/dev/null
+    fi
 }
 
 # Resolve the fast-path toggle (config + env), cached. Default true. Only ever
@@ -275,14 +355,11 @@ fastpath_config_file() {
 _FASTPATH_ENABLED_CACHE=""
 fastpath_enabled() {
     if [[ -z "$_FASTPATH_ENABLED_CACHE" ]]; then
-        local enabled=true cfg
-        cfg=$(fastpath_config_file)
-        if [[ -n "$cfg" ]]; then
-            # Only an explicit `false` disables; a missing key or malformed JSON
-            # (jq non-zero, caught by ||) stays ON — mirrors sql_guard_enabled().
-            enabled=$(jq -r 'if .guards.readOnlyFastPath == false then "false" else "true" end' "$cfg" 2>/dev/null) || enabled=true
-            [[ -n "$enabled" ]] || enabled=true
-        fi
+        local enabled=true raw
+        # Only an explicit `false` disables; an absent key on both tiers, or
+        # malformed JSON, stays ON — mirrors sql_guard_enabled().
+        raw=$(_fastpath_tiered_get "guards.readOnlyFastPath")
+        [[ "$raw" == "false" ]] && enabled=false
         # Env override wins over config.
         case "${LOOM_GUARD_READONLY_FASTPATH:-}" in
             0|false|no)  enabled=false ;;
@@ -380,11 +457,7 @@ fastpath_extra_admits() {
     local first="${t[0]}"
     if [[ -z "$_FASTPATH_EXTRA_DONE" ]]; then
         _FASTPATH_EXTRA_DONE=1
-        local cfg
-        cfg=$(fastpath_config_file)
-        if [[ -n "$cfg" ]]; then
-            _FASTPATH_EXTRA_CACHE=$(jq -r '(.guards.readOnlyFastPathExtra // []) | .[]' "$cfg" 2>/dev/null) || _FASTPATH_EXTRA_CACHE=""
-        fi
+        _FASTPATH_EXTRA_CACHE=$(_fastpath_tiered_get_array "guards.readOnlyFastPathExtra" 2>/dev/null) || _FASTPATH_EXTRA_CACHE=""
     fi
     [[ -n "$_FASTPATH_EXTRA_CACHE" ]] || return 1
     local w

--- a/.loom/hooks/guard-destructive.sh
+++ b/.loom/hooks/guard-destructive.sh
@@ -40,9 +40,26 @@ trap 'exit 0' ERR
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo ".")"
 
-# SCRIPT_DIR is <repo>/.loom/hooks at runtime (the settings entry resolves to the
-# main worktree's copy even from a linked worktree), so ../../ is the repo root.
-CANONICAL_GUARD="$SCRIPT_DIR/../../.claude/skills/repo/hooks/guard-destructive.sh"
+# Resolve the consuming repo's root, so CANONICAL_GUARD (below) points at the
+# right `.claude/skills/repo/hooks/...` regardless of WHERE this dispatcher
+# itself lives:
+#
+#   - Legacy/project-level wiring: SCRIPT_DIR is <repo>/.loom/hooks (the
+#     settings entry resolves to the main worktree's copy even from a linked
+#     worktree), so ../../ is the repo root. This is the historical behavior,
+#     preserved byte-for-byte when LOOM_PROJECT_ROOT is unset.
+#   - Machine-level wiring (Epic #3835 Phase 5, #4262): this file runs from
+#     the shared checkout (SCRIPT_DIR is <checkout>/defaults/hooks), where
+#     SCRIPT_DIR-relative resolution would point outside the consuming repo
+#     entirely. The user-scope command wrapper (provision-hooks.sh) resolves
+#     the worktree-aware repo root BEFORE exec'ing this dispatcher and passes
+#     it via LOOM_PROJECT_ROOT, so that root is preferred when set.
+#
+# VENDORED_GUARD is always a SCRIPT_DIR-relative sibling — correct in both
+# layouts, since guard-destructive-generic.sh ships alongside this dispatcher
+# either way.
+CANONICAL_ROOT="${LOOM_PROJECT_ROOT:-$SCRIPT_DIR/../..}"
+CANONICAL_GUARD="$CANONICAL_ROOT/.claude/skills/repo/hooks/guard-destructive.sh"
 # Vendored copy of the canonical guard, shipped by Loom for standalone repos.
 VENDORED_GUARD="$SCRIPT_DIR/guard-destructive-generic.sh"
 

--- a/.loom/hooks/guard-worktree-paths.sh
+++ b/.loom/hooks/guard-worktree-paths.sh
@@ -51,6 +51,23 @@ MAIN_ROOT="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null &
 MAIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd 2>/dev/null || echo ".")"
 HOOK_ERROR_LOG="${MAIN_ROOT}/.loom/logs/hook-errors.log"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo ".")"
+
+# Shared config-tier resolver (#4063 / Epic #3835 Phase 5, #4262). Source
+# defaults/scripts/lib/config-resolver.sh so the two reads below (the
+# guards.worktreeIsolation toggle and worktree.root) honor the full tier chain
+# — including .loom-project/project.json — instead of a direct single-file jq
+# read against legacy .loom/config.json only. At runtime SCRIPT_DIR is
+# .loom/hooks/ (project-level wiring) or defaults/hooks/ (machine-level
+# wiring, #4262); in both layouts .loom/scripts (a symlink to
+# defaults/scripts) or defaults/scripts sits alongside, so ../scripts/lib
+# resolves. Best-effort: a missing/unsourceable lib leaves loom_resolve_config
+# undefined and the readers below fall back to their documented defaults.
+if [[ -f "$SCRIPT_DIR/../scripts/lib/config-resolver.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/../scripts/lib/config-resolver.sh" 2>/dev/null || true
+fi
+
 log_hook_error() {
     mkdir -p "$(dirname "$HOOK_ERROR_LOG")" 2>/dev/null || true
     echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [guard-worktree-paths] $1" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
@@ -64,39 +81,52 @@ trap 'log_hook_error "Unexpected error on line ${LINENO}: ${BASH_COMMAND:-unknow
 #
 # Default ON. Resolution order (highest precedence first):
 #   1. LOOM_GUARD_WORKTREE_ISOLATION env var (0/false/no disables, 1/true/yes forces on)
-#   2. .loom/config.json  ->  guards.worktreeIsolation  (default true when absent)
+#   2. Tiered config (Epic #3835) -> guards.worktreeIsolation, honoring
+#      .loom-project/project.json over legacy .loom/config.json (default true
+#      when absent from every tier)
 #   3. Default: true (guard on)
 #
 # The config read is best-effort: any parse failure falls through to
 # guard-ON and never trips the ERR trap or produces a non-zero exit.
 #
-# CARVE-OUT (#4241, same class as #4063): this read is deliberately NOT routed
-# through the shared config-resolver.sh (loom_config_get / loom_resolve_config)
-# that the cold-path guards.* toggles in guard-destructive-generic.sh use.
-# worktree_isolation_guard_enabled() is called UNCONDITIONALLY as the very
-# first thing this hook does, on EVERY Edit/Write PreToolUse -- there is no
-# cheaper structural pre-check upstream of it (unlike
+# CARVE-OUT (#4241, same class as #4063), UPDATED for Epic #3835 Phase 5
+# (#4262): worktree_isolation_guard_enabled() is called UNCONDITIONALLY as the
+# very first thing this hook does, on EVERY Edit/Write PreToolUse -- there is
+# no cheaper structural pre-check upstream of it (unlike
 # guard-destructive-generic.sh's cold-path toggles, which only read config
 # lazily after a specific pattern has already matched). loom_resolve_config
-# soft-reads all four tier files plus a merge (up to 5 jq forks) on every
-# call; this direct single-jq read of the nearest .loom/config.json costs
-# exactly one. Fanning that out to 5x on the single hottest guard invocation
-# in the whole system is the #3687 fork-budget regression this repo has
-# already decided against once (see guard-destructive-generic.sh's own
-# CARVE-OUT for the read-only fast path). If Epic #3835's `.loom-project/`
-# tier needs to reach this toggle, prefer caching a repo-scoped
-# loom_resolve_config() result once per process (mirroring
-# guard-destructive-generic.sh's per-invocation caches) rather than paying
-# the full resolve on every Edit/Write.
+# soft-reads all tier files plus a merge on every call, so calling it directly
+# from BOTH readers below would double the fork cost. Instead,
+# resolved_config() (below) calls loom_resolve_config() at most ONCE per
+# invocation and caches the merged JSON string; both readers then run one
+# cheap in-memory `jq` filter against that cached string (no extra file I/O).
+# This is exactly the mitigation this carve-out originally called for --
+# "prefer caching a repo-scoped loom_resolve_config() result once per
+# process" -- so `.loom-project/project.json` (and every other tier) now
+# reaches both toggles without re-forking the merge per reader.
 # =============================================================================
+_WORKTREE_GUARD_CONFIG_CACHE=""
+_WORKTREE_GUARD_CONFIG_DONE=""
+resolved_config() {
+    if [[ -z "$_WORKTREE_GUARD_CONFIG_DONE" ]]; then
+        _WORKTREE_GUARD_CONFIG_DONE=1
+        if [[ -n "$MAIN_ROOT" ]] && command -v loom_resolve_config &>/dev/null; then
+            _WORKTREE_GUARD_CONFIG_CACHE=$(loom_resolve_config "$MAIN_ROOT" 2>/dev/null) || _WORKTREE_GUARD_CONFIG_CACHE='{}'
+        fi
+        [[ -n "$_WORKTREE_GUARD_CONFIG_CACHE" ]] || _WORKTREE_GUARD_CONFIG_CACHE='{}'
+    fi
+    printf '%s' "$_WORKTREE_GUARD_CONFIG_CACHE"
+}
+
 worktree_isolation_guard_enabled() {
     local enabled=true
-    if [[ -n "$MAIN_ROOT" && -f "$MAIN_ROOT/.loom/config.json" ]] && command -v jq &>/dev/null; then
+    if command -v jq &>/dev/null; then
         # jq // is alternative-on-null, not default-on-missing, so use
         # if/then/else to treat only an explicit `false` as disabled (a
         # missing guards.worktreeIsolation key stays on).
-        enabled=$(jq -r 'if .guards.worktreeIsolation == false then "false" else "true" end' "$MAIN_ROOT/.loom/config.json" 2>/dev/null) || enabled=true
-        [[ -n "$enabled" ]] || enabled=true
+        local raw
+        raw=$(resolved_config | jq -r 'if .guards.worktreeIsolation == false then "false" else "true" end' 2>/dev/null) || raw=true
+        [[ -n "$raw" ]] && enabled="$raw"
     fi
     case "${LOOM_GUARD_WORKTREE_ISOLATION:-}" in
         0|false|no)  enabled=false ;;
@@ -144,27 +174,26 @@ walk_up_for_sentinel() {
 # as a small inline duplicate rather than sourcing the library, so this
 # guard's fail-open contract does not depend on another script's behavior.
 #
-# CARVE-OUT (#4241, same class as #4063): the `worktree.root` read below is
-# deliberately NOT routed through config-resolver.sh either, for a different
-# reason than the toggle above -- this function is only reached on the rare
-# deny-candidate path (target resolves inside the main checkout and outside
-# every worktree, see path_derived_allow() above), so fork cost is not the
-# concern here. The concern is the SAME self-containment rationale already
-# documented on this function: sourcing config-resolver.sh would make this
-# guard's fail-open contract depend on that library's own behavior (and
-# transitively on jq's `*` deep-merge across up to four tier files) instead
-# of one direct, independently-auditable jq read. If/when a repo actually
-# populates `.loom-project/project.json` -> worktree.root (Epic #3835 Phase
-# 6+), migrate this read (and worktree-root.sh's own resolution) together so
-# the two stay in lockstep -- not this hook alone.
+# UPDATED for Epic #3835 Phase 5 (#4262): this function is only reached on the
+# rare deny-candidate path (target resolves inside the main checkout and
+# outside every worktree, see path_derived_allow() above), so per-call fork
+# cost was never the concern here -- the original CARVE-OUT (#4241) instead
+# worried about this guard's fail-open contract depending on
+# config-resolver.sh's own behavior. That concern is addressed the same way
+# as the toggle above: resolved_config() calls loom_resolve_config() (if
+# sourced) at most once per invocation and soft-fails to '{}' on any error,
+# so a resolver failure still degrades to the pre-#4262 "no config, fall back
+# to the default" behavior rather than propagating an error. This lets
+# `.loom-project/project.json -> worktree.root` (Epic #3835) reach this guard
+# without a second, independent read path to keep in lockstep.
 resolve_worktree_base() {
     if [[ -n "${LOOM_WORKTREE_ROOT:-}" && "${LOOM_WORKTREE_ROOT}" == /* ]]; then
         printf '%s' "${LOOM_WORKTREE_ROOT%/}/$(basename "$MAIN_ROOT")"
         return 0
     fi
-    if [[ -n "$MAIN_ROOT" && -f "$MAIN_ROOT/.loom/config.json" ]] && command -v jq &>/dev/null; then
+    if [[ -n "$MAIN_ROOT" ]] && command -v jq &>/dev/null; then
         local cfg_root
-        cfg_root=$(jq -r '.worktree.root? // empty' "$MAIN_ROOT/.loom/config.json" 2>/dev/null) || cfg_root=""
+        cfg_root=$(resolved_config | jq -r '.worktree.root? // empty' 2>/dev/null) || cfg_root=""
         if [[ -n "$cfg_root" && "$cfg_root" == /* ]]; then
             printf '%s' "${cfg_root%/}/$(basename "$MAIN_ROOT")"
             return 0

--- a/defaults/.claude/settings.json
+++ b/defaults/.claude/settings.json
@@ -1,46 +1,4 @@
 {
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-destructive.sh"
-          },
-          {
-            "type": "command",
-            "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-loom-workflow.sh"
-          }
-        ]
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/skill-router.sh"
-          },
-          {
-            "type": "command",
-            "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/methodology-inject.sh"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-background-subagents.sh"
-          }
-        ]
-      }
-    ]
-  },
   "permissions": {
     "allow": [
       "Bash(gh:*)",

--- a/defaults/docs/guard-hooks.md
+++ b/defaults/docs/guard-hooks.md
@@ -1,9 +1,61 @@
 # Guard Hooks Reference
 
 Loom's `PreToolUse` guard hooks and their per-repo toggles. Each toggle resolves
-with **env > `.loom/config.json` > default** precedence; the operating-core guides
-(`CLAUDE.md` and `.loom/CLAUDE.md`, "Configuration → Guard hooks") point here for
-the full catalog.
+through the tiered config resolver with **env > tracked `.loom-project/project.json`
+> legacy `.loom/config.json` > default** precedence (Epic #3835 Phase 2 / #4039;
+see "Config tiers" below); the operating-core guides (`CLAUDE.md` and
+`.loom/CLAUDE.md`, "Configuration → Guard hooks") point here for the full catalog.
+
+## Machine-Level Execution (Epic #3835 Phase 5, #4262)
+
+As of Phase 5, the hook **scripts** are no longer copied into each consumer repo's
+`.loom/hooks/`. They execute from the **single machine-level checkout**
+(`${LOOM_HOME:-~/.local/share/loom}/defaults/hooks/`), wired once into the
+operator's **user-scope** `~/.claude/settings.json` by
+`scripts/install/provision-hooks.sh` (a sibling of the Phase 4 skills provisioner).
+A freshly-installed consumer repo therefore carries **no** hook-script copies and
+they can never drift stale (the recurring `resync-installed.sh` pain). Hook
+**policy** — the `guards.*` toggles and `buildGate` — still lives per-repo, read
+from the tracked `.loom-project/project.json` (or legacy `.loom/config.json`)
+through the tiered resolver. Implementation vs. policy are split: scripts machine-
+level, config per-repo.
+
+Each user-scope entry is a **fail-open, self-gating** command wrapper, because a
+user-scope hook fires in *every* repo the operator opens:
+
+1. **Workspace gate** — it resolves the main repo root worktree-aware
+   (`git rev-parse --git-common-dir`/.., so guards still fire from inside
+   `.loom/worktrees/*`) and **exits 0 silently** unless that root holds
+   `.loom-project/project.json` or `.loom/config.json`. Non-Loom repos, and the
+   case where the machine checkout is absent, no-op cleanly.
+2. **Transition precedence** — if the repo still carries a per-repo
+   `.loom/hooks/<name>` copy (pre-Phase-6 / #4254), the wrapper **defers**: it
+   exits 0 and lets the project-level `.claude/settings.json` entry run that copy.
+   The project copy **wins** until Phase 6 strips it, so a transition repo runs
+   each guard exactly **once** (no double-fire, no duplicated `guards.decisionLog`
+   lines).
+3. **Machine exec** — otherwise it exec's the machine-checkout hook, passing the
+   resolved repo root through `LOOM_PROJECT_ROOT` so `guard-destructive.sh`'s
+   dispatcher resolves the *consuming* repo's canonical Repo-Skills guard from a
+   checkout-shaped `SCRIPT_DIR`.
+
+Existing per-repo `.loom/hooks/` copies on an already-installed repo are left in
+place by this phase; removing them is Phase 6 (#4254) migration territory. Daemon-
+spawned workers inherit the user-scope wiring because `loom-daemon` copies
+`~/.claude/settings.json` into each worker's isolated `CLAUDE_CONFIG_DIR`.
+
+### Config tiers
+
+The guard toggles below are documented against `.loom/config.json` for historical
+continuity, but every `guards.*` / `worktree.*` read now flows through the tiered
+resolver (`defaults/scripts/lib/config-resolver.sh` `loom_config_get`), so the same
+key set in the tracked `.loom-project/project.json` takes precedence over the legacy
+`.loom/config.json`, and an `LOOM_*` env override beats both. `buildGate` is read the
+same way by the daemon's main-health gate (`main_health_gate.rs`, already tiered).
+The `guard-worktree-paths.sh` toggle reads and the `guard-destructive-generic.sh`
+read-only fast-path toggles both consult `.loom-project/project.json` first, then the
+legacy file — the fast path stays a bounded, direct-`jq` read (never the full resolver
+merge) to preserve the #3687 fork budget on the hottest guard invocation.
 
 ## Custom Guard Hooks
 

--- a/defaults/docs/machine-dispatcher.md
+++ b/defaults/docs/machine-dispatcher.md
@@ -311,6 +311,38 @@ provisioning does not try to force user scope to win.
 > requires those trees present. That cutover lands with Phase 6's
 > `git rm --cached` migration, not here.
 
+## User-scope guard hooks (Epic #3835 Phase 5, #4262)
+
+The `PreToolUse` / `UserPromptSubmit` / `Stop` guard **hooks** also resolve from
+the machine-level checkout, provisioned by `scripts/install/provision-hooks.sh`
+(sibling of `provision-skills.sh`). Rather than a symlink, this performs a jq-based
+**idempotent merge** into the operator's user-scope `~/.claude/settings.json`:
+create-if-missing, back up before the first write, dedupe by the machine-level
+marker substring `defaults/hooks/<name>` (survives Claude Code requoting — the
+#4200 lesson), preserve every non-Loom entry, and soft-fail (no write) on invalid
+existing JSON.
+
+Each wired command is a **fail-open, self-gating** wrapper (full behavior in
+`defaults/docs/guard-hooks.md` → "Machine-Level Execution"): it no-ops outside a
+Loom workspace, defers to a still-present per-repo `.loom/hooks/<name>` copy
+(transition precedence — the project copy wins until Phase 6 / #4254 strips it, so
+guards never double-fire), and otherwise exec's the machine-checkout hook with the
+resolved repo root passed via `LOOM_PROJECT_ROOT`. `$HOME` / `$LOOM_HOME` expand
+per-user at hook-invocation time, so one wired command is correct for every
+operator. Daemon-spawned workers inherit the wiring via the `~/.claude/settings.json`
+copy each worker's isolated `CLAUDE_CONFIG_DIR` receives.
+
+`loom-daemon init`'s `.claude/settings.json` merge (`scaffolding.rs`) recognizes
+this machine-level command form (`MACHINE_HOOK_MARKER`) alongside the legacy /
+project-relative prefixes, so a reinstall never duplicates and an uninstall never
+orphans an entry that lands in a project-level settings file.
+
+> **Scope boundary (Phase 5 vs Phase 6).** This phase ships the machine-level hook
+> *execution* + user-scope wiring, and stops **copying** `defaults/hooks/*.sh` into
+> a fresh install's `.loom/hooks/`. It does **not** remove existing per-repo copies
+> or their project-level settings entries — that is Phase 6's `git rm --cached`
+> migration, which this replacement unblocks.
+
 ## Uninstall semantics
 
 A per-repo `uninstall-loom.sh` removes only the per-repo `./.loom/bin/loom` pool
@@ -325,3 +357,12 @@ does not remove them (that would break `/loom:*` for every other consumer repo).
 A machine-level teardown removes them via `deprovision_loom_skills` in
 `scripts/install/provision-skills.sh`, which deletes a link only when it points
 into the machine checkout and never touches an operator's real files.
+
+The user-scope **hook** entries follow the identical rule: they are one shared set
+resolved by every repo, so a per-repo uninstall does not strip them (that would
+disable the destructive-command / worktree guards for every other consumer repo). A
+machine-level teardown removes them via `deprovision_loom_hooks` in
+`scripts/install/provision-hooks.sh`, which removes only entries carrying the
+`/defaults/hooks/` marker and never touches an operator's own hooks. The per-repo
+**project-level** `.claude/settings.json` Loom hook entries, by contrast, *are*
+stripped by `uninstall-loom.sh`'s jq smart-removal on that file.

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -212,10 +212,11 @@ fi
 # rev-parse subprocess below), on purpose — the structural test never needs the
 # repo root. Only the toggle/extra-list config read needs a config file, and it
 # is resolved LAZILY (only after structural admission already passed) by walking
-# up from CWD to the nearest .loom/config.json WITHOUT forking git
-# (fastpath_config_file). So a fast-pathed command pays: 1 bash-builtin test +
-# (only if eligible) 1 stat-walk + 1 jq read — never the git rev-parse, never a
-# deny/ask array, never a log write.
+# up from CWD to the nearest Loom config root WITHOUT forking git
+# (fastpath_config_root). So a fast-pathed command pays: 1 bash-builtin test +
+# (only if eligible) 1 stat-walk + up to 2 bounded jq reads (project tier, then
+# legacy tier only if the key is absent from project) — never the git
+# rev-parse, never a deny/ask array, never a log write.
 #
 # Toggle: guards.readOnlyFastPath (default true) / LOOM_GUARD_READONLY_FASTPATH
 # env (0/false/no disables, 1/true/yes forces on; env wins). Optional
@@ -223,40 +224,57 @@ fi
 # commands (each entry is a full-generality bypass for that command word).
 # =============================================================================
 
-# CARVE-OUT (#4063): the three fast-path readers below — fastpath_config_file,
-# fastpath_enabled, fastpath_extra_admits — are deliberately NOT migrated to the
-# shared config-resolver.sh (loom_config_get / loom_resolve_config) that the
-# cold-path toggles use. This is intentional and preserves issue #3687's fork
-# budget:
+# CARVE-OUT (#4063, UPDATED for Epic #3835 Phase 5, #4262): the fast-path
+# config readers below — fastpath_config_root, _fastpath_tiered_get,
+# _fastpath_tiered_get_array, fastpath_enabled, fastpath_extra_admits — are
+# deliberately NOT migrated to the shared config-resolver.sh (loom_config_get /
+# loom_resolve_config) that the cold-path toggles use. This is intentional and
+# preserves issue #3687's fork budget:
 #   * This block can `exit 0` (silent allow) BEFORE REPO_ROOT is resolved — the
 #     `git -C "$CWD" rev-parse --show-toplevel` fork lives strictly below the
 #     fast-path dispatch. loom_resolve_config REQUIRES a repo_root as its first
 #     argument, so routing these through it would force hoisting that git
 #     rev-parse above the fast-path exit, directly regressing #3687 (which
 #     removed it from the pre-admission path).
-#   * fastpath_config_file is a fork-free bash-builtin upward directory walk;
-#     fastpath_enabled / fastpath_extra_admits each cost exactly one CACHED jq.
-#     loom_config_get is uncached and forks jq once per existing tier file plus a
-#     merge (~3 forks today, more as Epic #3835 lands upper tiers) on EVERY call —
-#     a 3x+ regression on a hook that fires before every Bash tool call. Caching
-#     the merge (Option B) still needs a repo_root, and teaching the resolver a
-#     fork-free upward-walk root discovery (Option C) would break the documented
-#     three-language (Rust/Python/Bash) conformance-fixture contract in
-#     config-resolver.sh's header. So the fast path keeps its direct single-jq
-#     read of the nearest .loom/config.json. See #4063 for the full analysis.
+#   * fastpath_config_root is a fork-free bash-builtin upward directory walk
+#     (now stat-ing for EITHER `.loom-project/project.json` or
+#     `.loom/config.json`, so a `.loom-project/`-only repo is still found);
+#     fastpath_enabled / fastpath_extra_admits each cost AT MOST two CACHED,
+#     file-scoped jq reads (project tier, then legacy tier ONLY when the key
+#     is absent from the project tier — #4262's Epic #3835 `.loom-project/`
+#     tier reaching this toggle without forking the full merge).
+#     loom_resolve_config is uncached and soft-reads every tier file plus a
+#     merge (4+ forks today) on EVERY call — a 4x+ regression on a hook that
+#     fires before every Bash tool call. Caching the merge (Option B) still
+#     needs a repo_root, and teaching the resolver a fork-free upward-walk
+#     root discovery (Option C) would break the documented three-language
+#     (Rust/Python/Bash) conformance-fixture contract in config-resolver.sh's
+#     header. So the fast path keeps its direct, bounded (<=2 fork) reads
+#     instead. See #4063 for the original analysis and #4262 for the tier
+#     widening.
 #
-# Locate the nearest .loom/config.json by walking up from CWD, fork-free (no
-# git rev-parse). Cached. Best-effort: empty when none is found.
-_FASTPATH_CFG_FILE=""
-_FASTPATH_CFG_FILE_DONE=""
-fastpath_config_file() {
-    if [[ -z "$_FASTPATH_CFG_FILE_DONE" ]]; then
-        _FASTPATH_CFG_FILE_DONE=1
+# Locate the nearest Loom config ROOT by walking up from CWD, fork-free (no
+# git rev-parse) — a directory holding EITHER the tracked project tier
+# (.loom-project/project.json, Epic #3835) OR the legacy tier
+# (.loom/config.json). Cached. Best-effort: empty when neither is found.
+#
+# Epic #3835 Phase 5 (#4262): previously this walked looking for
+# .loom/config.json alone. Widening the stat to "either tier file" keeps the
+# walk itself fork-free (bash-builtin [[ -f ]] tests only) while letting the
+# two readers below (fastpath_enabled / fastpath_extra_admits) consult
+# .loom-project/project.json — see the CARVE-OUT comment above for why this
+# stays a direct, bounded-fork jq read instead of routing through
+# loom_resolve_config().
+_FASTPATH_CFG_ROOT=""
+_FASTPATH_CFG_ROOT_DONE=""
+fastpath_config_root() {
+    if [[ -z "$_FASTPATH_CFG_ROOT_DONE" ]]; then
+        _FASTPATH_CFG_ROOT_DONE=1
         local d="$CWD"
         if [[ -n "$d" && "$d" == /* ]]; then
             while :; do
-                if [[ -f "$d/.loom/config.json" ]]; then
-                    _FASTPATH_CFG_FILE="$d/.loom/config.json"
+                if [[ -f "$d/.loom-project/project.json" || -f "$d/.loom/config.json" ]]; then
+                    _FASTPATH_CFG_ROOT="$d"
                     break
                 fi
                 [[ "$d" == "/" ]] && break
@@ -266,7 +284,69 @@ fastpath_config_file() {
             done
         fi
     fi
-    printf '%s' "$_FASTPATH_CFG_FILE"
+    printf '%s' "$_FASTPATH_CFG_ROOT"
+}
+
+# Read a dotted-path boolean-ish scalar from the tiered fast-path config: try
+# the tracked project tier first (.loom-project/project.json), falling back to
+# the legacy tier (.loom/config.json) ONLY when the key is absent from the
+# project tier — this mirrors the resolver's whole-value tier precedence (a
+# higher tier that sets the key wins outright, it is not merged with a lower
+# tier). At most two jq forks, both file-scoped (no directory-file soft-read
+# fan-out, no merge) — the bounded-fork budget this CARVE-OUT preserves.
+# Echoes the resolved value, or empty when the key is absent from both tiers.
+_fastpath_tiered_get() {
+    local dotted="$1" root cfg value
+    root=$(fastpath_config_root)
+    [[ -n "$root" ]] || { printf ''; return 0; }
+
+    cfg="$root/.loom-project/project.json"
+    if [[ -f "$cfg" ]]; then
+        value=$(jq -r --arg p "$dotted" '
+            ($p | split(".")) as $path
+            | try getpath($path) catch null
+            | if . == null then empty else . end
+        ' "$cfg" 2>/dev/null) || value=""
+        [[ -n "$value" ]] && { printf '%s' "$value"; return 0; }
+    fi
+
+    cfg="$root/.loom/config.json"
+    if [[ -f "$cfg" ]]; then
+        value=$(jq -r --arg p "$dotted" '
+            ($p | split(".")) as $path
+            | try getpath($path) catch null
+            | if . == null then empty else . end
+        ' "$cfg" 2>/dev/null) || value=""
+        [[ -n "$value" ]] && { printf '%s' "$value"; return 0; }
+    fi
+
+    printf ''
+}
+
+# Same tier precedence as _fastpath_tiered_get, but for an array-valued key:
+# echoes the elements of guards.<name> one per line, from whichever tier's
+# file HAS the key first (project, else legacy) — an array value at a tier is
+# a whole-value override, never merged element-wise with a lower tier (this
+# matches the resolver's jq `*` deep-merge semantics for non-object values).
+# Echoes nothing when the key is absent from both tiers.
+_fastpath_tiered_get_array() {
+    local dotted="$1" root cfg has
+    root=$(fastpath_config_root)
+    [[ -n "$root" ]] || return 0
+
+    cfg="$root/.loom-project/project.json"
+    if [[ -f "$cfg" ]]; then
+        has=$(jq -r --arg p "$dotted" '($p | split(".")) as $path | try (getpath($path) != null) catch false' "$cfg" 2>/dev/null) || has=false
+        if [[ "$has" == "true" ]]; then
+            jq -r --arg p "$dotted" '($p | split(".")) as $path | getpath($path) | (. // [])[]' "$cfg" 2>/dev/null
+            return 0
+        fi
+    fi
+
+    cfg="$root/.loom/config.json"
+    if [[ -f "$cfg" ]]; then
+        jq -r --arg p "$dotted" '($p | split(".")) as $path | try (getpath($path) // []) catch [] | .[]' "$cfg" 2>/dev/null
+    fi
 }
 
 # Resolve the fast-path toggle (config + env), cached. Default true. Only ever
@@ -275,14 +355,11 @@ fastpath_config_file() {
 _FASTPATH_ENABLED_CACHE=""
 fastpath_enabled() {
     if [[ -z "$_FASTPATH_ENABLED_CACHE" ]]; then
-        local enabled=true cfg
-        cfg=$(fastpath_config_file)
-        if [[ -n "$cfg" ]]; then
-            # Only an explicit `false` disables; a missing key or malformed JSON
-            # (jq non-zero, caught by ||) stays ON — mirrors sql_guard_enabled().
-            enabled=$(jq -r 'if .guards.readOnlyFastPath == false then "false" else "true" end' "$cfg" 2>/dev/null) || enabled=true
-            [[ -n "$enabled" ]] || enabled=true
-        fi
+        local enabled=true raw
+        # Only an explicit `false` disables; an absent key on both tiers, or
+        # malformed JSON, stays ON — mirrors sql_guard_enabled().
+        raw=$(_fastpath_tiered_get "guards.readOnlyFastPath")
+        [[ "$raw" == "false" ]] && enabled=false
         # Env override wins over config.
         case "${LOOM_GUARD_READONLY_FASTPATH:-}" in
             0|false|no)  enabled=false ;;
@@ -380,11 +457,7 @@ fastpath_extra_admits() {
     local first="${t[0]}"
     if [[ -z "$_FASTPATH_EXTRA_DONE" ]]; then
         _FASTPATH_EXTRA_DONE=1
-        local cfg
-        cfg=$(fastpath_config_file)
-        if [[ -n "$cfg" ]]; then
-            _FASTPATH_EXTRA_CACHE=$(jq -r '(.guards.readOnlyFastPathExtra // []) | .[]' "$cfg" 2>/dev/null) || _FASTPATH_EXTRA_CACHE=""
-        fi
+        _FASTPATH_EXTRA_CACHE=$(_fastpath_tiered_get_array "guards.readOnlyFastPathExtra" 2>/dev/null) || _FASTPATH_EXTRA_CACHE=""
     fi
     [[ -n "$_FASTPATH_EXTRA_CACHE" ]] || return 1
     local w

--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -40,9 +40,26 @@ trap 'exit 0' ERR
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo ".")"
 
-# SCRIPT_DIR is <repo>/.loom/hooks at runtime (the settings entry resolves to the
-# main worktree's copy even from a linked worktree), so ../../ is the repo root.
-CANONICAL_GUARD="$SCRIPT_DIR/../../.claude/skills/repo/hooks/guard-destructive.sh"
+# Resolve the consuming repo's root, so CANONICAL_GUARD (below) points at the
+# right `.claude/skills/repo/hooks/...` regardless of WHERE this dispatcher
+# itself lives:
+#
+#   - Legacy/project-level wiring: SCRIPT_DIR is <repo>/.loom/hooks (the
+#     settings entry resolves to the main worktree's copy even from a linked
+#     worktree), so ../../ is the repo root. This is the historical behavior,
+#     preserved byte-for-byte when LOOM_PROJECT_ROOT is unset.
+#   - Machine-level wiring (Epic #3835 Phase 5, #4262): this file runs from
+#     the shared checkout (SCRIPT_DIR is <checkout>/defaults/hooks), where
+#     SCRIPT_DIR-relative resolution would point outside the consuming repo
+#     entirely. The user-scope command wrapper (provision-hooks.sh) resolves
+#     the worktree-aware repo root BEFORE exec'ing this dispatcher and passes
+#     it via LOOM_PROJECT_ROOT, so that root is preferred when set.
+#
+# VENDORED_GUARD is always a SCRIPT_DIR-relative sibling — correct in both
+# layouts, since guard-destructive-generic.sh ships alongside this dispatcher
+# either way.
+CANONICAL_ROOT="${LOOM_PROJECT_ROOT:-$SCRIPT_DIR/../..}"
+CANONICAL_GUARD="$CANONICAL_ROOT/.claude/skills/repo/hooks/guard-destructive.sh"
 # Vendored copy of the canonical guard, shipped by Loom for standalone repos.
 VENDORED_GUARD="$SCRIPT_DIR/guard-destructive-generic.sh"
 

--- a/defaults/hooks/guard-worktree-paths.sh
+++ b/defaults/hooks/guard-worktree-paths.sh
@@ -51,6 +51,23 @@ MAIN_ROOT="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null &
 MAIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd 2>/dev/null || echo ".")"
 HOOK_ERROR_LOG="${MAIN_ROOT}/.loom/logs/hook-errors.log"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo ".")"
+
+# Shared config-tier resolver (#4063 / Epic #3835 Phase 5, #4262). Source
+# defaults/scripts/lib/config-resolver.sh so the two reads below (the
+# guards.worktreeIsolation toggle and worktree.root) honor the full tier chain
+# — including .loom-project/project.json — instead of a direct single-file jq
+# read against legacy .loom/config.json only. At runtime SCRIPT_DIR is
+# .loom/hooks/ (project-level wiring) or defaults/hooks/ (machine-level
+# wiring, #4262); in both layouts .loom/scripts (a symlink to
+# defaults/scripts) or defaults/scripts sits alongside, so ../scripts/lib
+# resolves. Best-effort: a missing/unsourceable lib leaves loom_resolve_config
+# undefined and the readers below fall back to their documented defaults.
+if [[ -f "$SCRIPT_DIR/../scripts/lib/config-resolver.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/../scripts/lib/config-resolver.sh" 2>/dev/null || true
+fi
+
 log_hook_error() {
     mkdir -p "$(dirname "$HOOK_ERROR_LOG")" 2>/dev/null || true
     echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [guard-worktree-paths] $1" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
@@ -64,39 +81,52 @@ trap 'log_hook_error "Unexpected error on line ${LINENO}: ${BASH_COMMAND:-unknow
 #
 # Default ON. Resolution order (highest precedence first):
 #   1. LOOM_GUARD_WORKTREE_ISOLATION env var (0/false/no disables, 1/true/yes forces on)
-#   2. .loom/config.json  ->  guards.worktreeIsolation  (default true when absent)
+#   2. Tiered config (Epic #3835) -> guards.worktreeIsolation, honoring
+#      .loom-project/project.json over legacy .loom/config.json (default true
+#      when absent from every tier)
 #   3. Default: true (guard on)
 #
 # The config read is best-effort: any parse failure falls through to
 # guard-ON and never trips the ERR trap or produces a non-zero exit.
 #
-# CARVE-OUT (#4241, same class as #4063): this read is deliberately NOT routed
-# through the shared config-resolver.sh (loom_config_get / loom_resolve_config)
-# that the cold-path guards.* toggles in guard-destructive-generic.sh use.
-# worktree_isolation_guard_enabled() is called UNCONDITIONALLY as the very
-# first thing this hook does, on EVERY Edit/Write PreToolUse -- there is no
-# cheaper structural pre-check upstream of it (unlike
+# CARVE-OUT (#4241, same class as #4063), UPDATED for Epic #3835 Phase 5
+# (#4262): worktree_isolation_guard_enabled() is called UNCONDITIONALLY as the
+# very first thing this hook does, on EVERY Edit/Write PreToolUse -- there is
+# no cheaper structural pre-check upstream of it (unlike
 # guard-destructive-generic.sh's cold-path toggles, which only read config
 # lazily after a specific pattern has already matched). loom_resolve_config
-# soft-reads all four tier files plus a merge (up to 5 jq forks) on every
-# call; this direct single-jq read of the nearest .loom/config.json costs
-# exactly one. Fanning that out to 5x on the single hottest guard invocation
-# in the whole system is the #3687 fork-budget regression this repo has
-# already decided against once (see guard-destructive-generic.sh's own
-# CARVE-OUT for the read-only fast path). If Epic #3835's `.loom-project/`
-# tier needs to reach this toggle, prefer caching a repo-scoped
-# loom_resolve_config() result once per process (mirroring
-# guard-destructive-generic.sh's per-invocation caches) rather than paying
-# the full resolve on every Edit/Write.
+# soft-reads all tier files plus a merge on every call, so calling it directly
+# from BOTH readers below would double the fork cost. Instead,
+# resolved_config() (below) calls loom_resolve_config() at most ONCE per
+# invocation and caches the merged JSON string; both readers then run one
+# cheap in-memory `jq` filter against that cached string (no extra file I/O).
+# This is exactly the mitigation this carve-out originally called for --
+# "prefer caching a repo-scoped loom_resolve_config() result once per
+# process" -- so `.loom-project/project.json` (and every other tier) now
+# reaches both toggles without re-forking the merge per reader.
 # =============================================================================
+_WORKTREE_GUARD_CONFIG_CACHE=""
+_WORKTREE_GUARD_CONFIG_DONE=""
+resolved_config() {
+    if [[ -z "$_WORKTREE_GUARD_CONFIG_DONE" ]]; then
+        _WORKTREE_GUARD_CONFIG_DONE=1
+        if [[ -n "$MAIN_ROOT" ]] && command -v loom_resolve_config &>/dev/null; then
+            _WORKTREE_GUARD_CONFIG_CACHE=$(loom_resolve_config "$MAIN_ROOT" 2>/dev/null) || _WORKTREE_GUARD_CONFIG_CACHE='{}'
+        fi
+        [[ -n "$_WORKTREE_GUARD_CONFIG_CACHE" ]] || _WORKTREE_GUARD_CONFIG_CACHE='{}'
+    fi
+    printf '%s' "$_WORKTREE_GUARD_CONFIG_CACHE"
+}
+
 worktree_isolation_guard_enabled() {
     local enabled=true
-    if [[ -n "$MAIN_ROOT" && -f "$MAIN_ROOT/.loom/config.json" ]] && command -v jq &>/dev/null; then
+    if command -v jq &>/dev/null; then
         # jq // is alternative-on-null, not default-on-missing, so use
         # if/then/else to treat only an explicit `false` as disabled (a
         # missing guards.worktreeIsolation key stays on).
-        enabled=$(jq -r 'if .guards.worktreeIsolation == false then "false" else "true" end' "$MAIN_ROOT/.loom/config.json" 2>/dev/null) || enabled=true
-        [[ -n "$enabled" ]] || enabled=true
+        local raw
+        raw=$(resolved_config | jq -r 'if .guards.worktreeIsolation == false then "false" else "true" end' 2>/dev/null) || raw=true
+        [[ -n "$raw" ]] && enabled="$raw"
     fi
     case "${LOOM_GUARD_WORKTREE_ISOLATION:-}" in
         0|false|no)  enabled=false ;;
@@ -144,27 +174,26 @@ walk_up_for_sentinel() {
 # as a small inline duplicate rather than sourcing the library, so this
 # guard's fail-open contract does not depend on another script's behavior.
 #
-# CARVE-OUT (#4241, same class as #4063): the `worktree.root` read below is
-# deliberately NOT routed through config-resolver.sh either, for a different
-# reason than the toggle above -- this function is only reached on the rare
-# deny-candidate path (target resolves inside the main checkout and outside
-# every worktree, see path_derived_allow() above), so fork cost is not the
-# concern here. The concern is the SAME self-containment rationale already
-# documented on this function: sourcing config-resolver.sh would make this
-# guard's fail-open contract depend on that library's own behavior (and
-# transitively on jq's `*` deep-merge across up to four tier files) instead
-# of one direct, independently-auditable jq read. If/when a repo actually
-# populates `.loom-project/project.json` -> worktree.root (Epic #3835 Phase
-# 6+), migrate this read (and worktree-root.sh's own resolution) together so
-# the two stay in lockstep -- not this hook alone.
+# UPDATED for Epic #3835 Phase 5 (#4262): this function is only reached on the
+# rare deny-candidate path (target resolves inside the main checkout and
+# outside every worktree, see path_derived_allow() above), so per-call fork
+# cost was never the concern here -- the original CARVE-OUT (#4241) instead
+# worried about this guard's fail-open contract depending on
+# config-resolver.sh's own behavior. That concern is addressed the same way
+# as the toggle above: resolved_config() calls loom_resolve_config() (if
+# sourced) at most once per invocation and soft-fails to '{}' on any error,
+# so a resolver failure still degrades to the pre-#4262 "no config, fall back
+# to the default" behavior rather than propagating an error. This lets
+# `.loom-project/project.json -> worktree.root` (Epic #3835) reach this guard
+# without a second, independent read path to keep in lockstep.
 resolve_worktree_base() {
     if [[ -n "${LOOM_WORKTREE_ROOT:-}" && "${LOOM_WORKTREE_ROOT}" == /* ]]; then
         printf '%s' "${LOOM_WORKTREE_ROOT%/}/$(basename "$MAIN_ROOT")"
         return 0
     fi
-    if [[ -n "$MAIN_ROOT" && -f "$MAIN_ROOT/.loom/config.json" ]] && command -v jq &>/dev/null; then
+    if [[ -n "$MAIN_ROOT" ]] && command -v jq &>/dev/null; then
         local cfg_root
-        cfg_root=$(jq -r '.worktree.root? // empty' "$MAIN_ROOT/.loom/config.json" 2>/dev/null) || cfg_root=""
+        cfg_root=$(resolved_config | jq -r '.worktree.root? // empty' 2>/dev/null) || cfg_root=""
         if [[ -n "$cfg_root" && "$cfg_root" == /* ]]; then
             printf '%s' "${cfg_root%/}/$(basename "$MAIN_ROOT")"
             return 0

--- a/defaults/hooks/tests/test-guard-worktree-paths.sh
+++ b/defaults/hooks/tests/test-guard-worktree-paths.sh
@@ -41,9 +41,14 @@ NC='\033[0m'
 TMPROOT="$(mktemp -d)"
 trap 'rm -rf "$TMPROOT"' EXIT
 git init -q "$TMPROOT"
-mkdir -p "$TMPROOT/.loom/hooks"
+mkdir -p "$TMPROOT/.loom/hooks" "$TMPROOT/.loom/scripts/lib"
 cp "$SRC_HOOK" "$TMPROOT/.loom/hooks/guard-worktree-paths.sh"
 chmod +x "$TMPROOT/.loom/hooks/guard-worktree-paths.sh"
+# The hook sources ../scripts/lib/config-resolver.sh (Epic #3835 Phase 5,
+# #4262) relative to its own SCRIPT_DIR — stage the real resolver at the
+# equivalent installed-layout path so the guards.worktreeIsolation /
+# worktree.root reads exercise the actual tiered resolution, not a stub.
+cp "$REPO_ROOT/defaults/scripts/lib/config-resolver.sh" "$TMPROOT/.loom/scripts/lib/config-resolver.sh"
 HOOK="$TMPROOT/.loom/hooks/guard-worktree-paths.sh"
 
 pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); printf "${GREEN}PASS${NC} %s\n" "$1"; }
@@ -193,6 +198,40 @@ assert_allow "toggle: env LOOM_GUARD_WORKTREE_ISOLATION=0 -> allow" "$result"
 
 result=$(run_hook "$TMPROOT/CLAUDE.md")
 assert_deny "toggle: default (no config, no env) is ON -> deny" "$result"
+
+# --- Tiered config (Epic #3835 Phase 5, #4262): .loom-project/project.json --
+mkdir -p "$TMPROOT/.loom-project"
+cat > "$TMPROOT/.loom-project/project.json" <<'EOF'
+{"guards": {"worktreeIsolation": false}}
+EOF
+result=$(run_hook "$TMPROOT/CLAUDE.md")
+assert_allow "tiered config: .loom-project/project.json guards.worktreeIsolation=false -> allow" "$result"
+
+# .loom-project (higher tier) overrides a conflicting legacy .loom/config.json
+cat > "$TMPROOT/.loom/config.json" <<'EOF'
+{"guards": {"worktreeIsolation": true}}
+EOF
+result=$(run_hook "$TMPROOT/CLAUDE.md")
+assert_allow "tiered config: .loom-project overrides conflicting legacy .loom/config.json" "$result"
+rm -f "$TMPROOT/.loom/config.json"
+
+# worktree.root also resolves from .loom-project/project.json: point it at an
+# alternate base holding the ONLY managed worktree, and confirm a target under
+# the (now-legacy) worktrees dir at the main root no longer counts as "inside
+# a managed worktree" for this guard.
+ALT_BASE="$(mktemp -d)"
+cat > "$TMPROOT/.loom-project/project.json" <<EOF
+{"worktree": {"root": "$ALT_BASE"}}
+EOF
+mkdir -p "$ALT_BASE/$(basename "$TMPROOT")/issue-9"
+cat > "$ALT_BASE/$(basename "$TMPROOT")/issue-9/.loom-managed" <<'EOF'
+# Loom-managed worktree marker
+EOF
+result=$(run_hook "$ALT_BASE/$(basename "$TMPROOT")/issue-9/src/foo.rs")
+assert_allow "tiered config: worktree.root from .loom-project resolves an alt worktree base -> allow" "$result"
+rm -rf "$ALT_BASE"
+rm -f "$TMPROOT/.loom-project/project.json"
+rmdir "$TMPROOT/.loom-project" 2>/dev/null || true
 
 # --- Contract checks: exit is always 0, deny emits well-formed JSON --------
 for r in \

--- a/defaults/scripts/tests/test-provision-hooks.sh
+++ b/defaults/scripts/tests/test-provision-hooks.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# test-provision-hooks.sh — tests for user-scope Loom guard-hook wiring
+# (Epic #3835 Phase 5, #4262).
+#
+# Covers scripts/install/provision-hooks.sh:
+#   - fresh provision merges the Loom hook entries into a missing / empty /
+#     populated ~/.claude/settings.json
+#   - the verifiable-globals contract (PROVISIONED_HOOKS_SETTINGS /
+#     PROVISIONED_HOOKS_BACKUP, mirroring provision-dispatcher.sh #4053)
+#   - idempotent re-provision (no duplicates, including a requoted pre-existing
+#     entry — the #4200 lesson)
+#   - pre-existing non-Loom hooks + permissions are preserved
+#   - invalid existing JSON -> soft-fail (return 1) with NO write
+#   - a backup file is written before the first mutation
+#   - the wired command WRAPPER behaves: no-ops outside a Loom workspace (AC3),
+#     execs the machine-checkout hook inside one (AC1), and defers to a present
+#     per-repo .loom/hooks/ copy (transition dedup, design decision 3)
+#   - deprovision removes ONLY Loom-owned entries, preserving operator hooks
+#
+# Sandboxed $HOME per case via mktemp -d, matching test-provision-skills.sh.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# defaults/scripts/tests -> defaults/scripts/tests/../../.. -> repo root
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PROVISION_LIB="$REPO_ROOT/scripts/install/provision-hooks.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_eq() {
+    if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 (expected '$2', got '$1')"; fi
+}
+assert_contains() {
+    if [[ "$1" == *"$2"* ]]; then pass "$3"; else fail "$3 (missing substring: '$2')"; fi
+}
+
+[[ -f "$PROVISION_LIB" ]] || { echo "provisioning lib not found at $PROVISION_LIB"; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "jq required for these tests"; exit 1; }
+
+# shellcheck source=/dev/null
+source "$PROVISION_LIB"
+
+# Count hook commands (across all types/matchers) whose command carries the
+# machine-level marker for a given hook script name.
+count_marker() {
+    local file="$1" name="$2"
+    jq --arg m "defaults/hooks/$name" '
+        [ (.hooks // {}) | to_entries[] | .value[]? | .hooks[]? | .command // "" | select(contains($m)) ] | length
+    ' "$file" 2>/dev/null
+}
+
+# ── Test 1: fresh provision into a MISSING settings.json ─────────────────────
+echo "Test 1: fresh provision creates settings.json and wires all Loom hooks"
+HOME1=$(mktemp -d)
+OUT1=$(mktemp)
+provision_loom_hooks "$HOME1/.claude" >"$OUT1" 2>&1
+rc=$?
+assert_eq "$rc" "0" "fresh provision returns 0"
+SET1="$HOME1/.claude/settings.json"
+[[ -f "$SET1" ]] && pass "settings.json was created" || fail "settings.json was not created"
+jq empty "$SET1" 2>/dev/null && pass "settings.json is valid JSON" || fail "settings.json is not valid JSON"
+assert_eq "$(count_marker "$SET1" guard-destructive.sh)" "1" "guard-destructive.sh wired once"
+assert_eq "$(count_marker "$SET1" guard-worktree-paths.sh)" "1" "guard-worktree-paths.sh (Edit|Write) wired once"
+assert_eq "$(count_marker "$SET1" guard-background-subagents.sh)" "1" "Stop hook wired once"
+# The Edit|Write matcher exists (design decision 4 — consumers never had it).
+assert_eq "$(jq -r '[.hooks.PreToolUse[]?.matcher] | index("Edit|Write") != null' "$SET1")" "true" "Edit|Write matcher is present"
+
+# ── Test 2: verifiable-globals contract (#4053) ──────────────────────────────
+echo "Test 2: provisioning exposes verifiable globals (#4053)"
+assert_eq "$PROVISIONED_HOOKS_SETTINGS" "$SET1" "PROVISIONED_HOOKS_SETTINGS points at the settings file"
+# No backup on a fresh (missing) file — nothing to preserve.
+assert_eq "$PROVISIONED_HOOKS_BACKUP" "" "no backup written when there was no pre-existing file"
+
+# ── Test 3: idempotent re-provision (no duplicates) ──────────────────────────
+echo "Test 3: re-provision is idempotent (no duplicate entries)"
+provision_loom_hooks "$HOME1/.claude" >/dev/null 2>&1
+assert_eq "$(count_marker "$SET1" guard-destructive.sh)" "1" "guard-destructive.sh still wired exactly once after re-run"
+assert_eq "$(count_marker "$SET1" skill-router.sh)" "1" "skill-router.sh still wired exactly once after re-run"
+
+# ── Test 4: dedup against a REQUOTED pre-existing entry (#4200 lesson) ────────
+echo "Test 4: dedup keys on the marker substring, so a requoted entry is not duplicated (#4200)"
+HOME4=$(mktemp -d); mkdir -p "$HOME4/.claude"
+# A pre-existing Loom entry with DIFFERENT quoting/wrapper but the SAME marker.
+cat > "$HOME4/.claude/settings.json" <<'EOF'
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [
+        { "type": "command", "command": "sh -c \"exec ${LOOM_HOME}/defaults/hooks/guard-destructive.sh\"" }
+      ] }
+    ]
+  }
+}
+EOF
+provision_loom_hooks "$HOME4/.claude" >/dev/null 2>&1
+assert_eq "$(count_marker "$HOME4/.claude/settings.json" guard-destructive.sh)" "1" "requoted guard-destructive.sh entry is not duplicated"
+
+# ── Test 5: pre-existing non-Loom hooks + permissions preserved ──────────────
+echo "Test 5: operator's non-Loom hooks and permissions are preserved"
+HOME5=$(mktemp -d); mkdir -p "$HOME5/.claude"
+cat > "$HOME5/.claude/settings.json" <<'EOF'
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [
+        { "type": "command", "command": ".claude/hooks/my-own-guard.sh" }
+      ] }
+    ]
+  },
+  "permissions": { "allow": ["Bash(mytool:*)"] }
+}
+EOF
+provision_loom_hooks "$HOME5/.claude" >/dev/null 2>&1
+S5="$HOME5/.claude/settings.json"
+assert_eq "$(jq -r '[.hooks.PreToolUse[] | .hooks[]? | .command | select(. == ".claude/hooks/my-own-guard.sh")] | length' "$S5")" "1" "operator's own hook preserved"
+assert_eq "$(jq -r '.permissions.allow[0]' "$S5")" "Bash(mytool:*)" "operator's permissions preserved"
+assert_eq "$(count_marker "$S5" guard-destructive.sh)" "1" "Loom hook added alongside the operator's Bash matcher"
+
+# ── Test 6: invalid existing JSON -> soft-fail, NO write ─────────────────────
+echo "Test 6: invalid existing JSON is left untouched (soft-fail)"
+HOME6=$(mktemp -d); mkdir -p "$HOME6/.claude"
+printf 'this is { not json' > "$HOME6/.claude/settings.json"
+before6=$(cat "$HOME6/.claude/settings.json")
+OUT6=$(mktemp)
+provision_loom_hooks "$HOME6/.claude" >"$OUT6" 2>&1
+rc=$?
+assert_eq "$rc" "1" "invalid JSON returns 1"
+assert_eq "$(cat "$HOME6/.claude/settings.json")" "$before6" "invalid JSON file left byte-identical (no write)"
+assert_contains "$(cat "$OUT6")" "not valid JSON" "explains the refusal"
+
+# ── Test 7: a backup is written before the first mutation ─────────────────────
+echo "Test 7: a backup file is written before mutating an existing settings.json"
+HOME7=$(mktemp -d); mkdir -p "$HOME7/.claude"
+echo '{"permissions":{"allow":["Bash(x:*)"]}}' > "$HOME7/.claude/settings.json"
+provision_loom_hooks "$HOME7/.claude" >/dev/null 2>&1
+backups=$(find "$HOME7/.claude" -maxdepth 1 -name 'settings.json.loom-backup-*' | wc -l | tr -d ' ')
+[[ "$backups" -ge 1 ]] && pass "a timestamped backup was written" || fail "no backup file found"
+# The backup holds the ORIGINAL content (pre-mutation).
+bfile=$(find "$HOME7/.claude" -maxdepth 1 -name 'settings.json.loom-backup-*' | head -1)
+assert_eq "$(jq -r '.permissions.allow[0]' "$bfile")" "Bash(x:*)" "backup preserves the pre-mutation content"
+
+# ── Test 8: the wired WRAPPER command behaves correctly ──────────────────────
+echo "Test 8: the wired command wrapper — workspace gate, machine exec, transition dedup"
+# Build a fake machine checkout whose guard-destructive.sh prints a sentinel.
+CHK=$(mktemp -d)
+mkdir -p "$CHK/defaults/hooks"
+printf '#!/usr/bin/env bash\necho "MACHINE-RAN:$LOOM_PROJECT_ROOT"\nexit 0\n' > "$CHK/defaults/hooks/guard-destructive.sh"
+chmod +x "$CHK/defaults/hooks/guard-destructive.sh"
+# Extract the actual wired command for guard-destructive.sh from a fresh provision.
+HOME8=$(mktemp -d)
+provision_loom_hooks "$HOME8/.claude" >/dev/null 2>&1
+CMD=$(jq -r '.hooks.PreToolUse[] | select(.matcher=="Bash") | .hooks[] | .command | select(contains("defaults/hooks/guard-destructive.sh"))' "$HOME8/.claude/settings.json" | head -1)
+[[ -n "$CMD" ]] && pass "extracted the wired guard-destructive.sh command" || fail "could not extract the wired command"
+
+WOUT=""; WRC=0
+run_wrapper() { # $1=cwd -> assigns globals WOUT + WRC in the CURRENT shell
+    WOUT=$(cd "$1" && LOOM_HOME="$CHK" bash -c "$CMD" </dev/null 2>/dev/null)
+    WRC=$?
+}
+
+# 8a: non-Loom repo -> no-op (AC3)
+NONLOOM=$(mktemp -d); git -C "$NONLOOM" init -q
+run_wrapper "$NONLOOM"
+[[ -z "$WOUT" && "$WRC" == "0" ]] && pass "AC3: non-Loom repo -> silent no-op (exit 0)" || fail "AC3: expected silent exit 0, got out='$WOUT' rc=$WRC"
+
+# 8b: Loom workspace (legacy .loom/config.json), no per-repo copy -> machine exec (AC1)
+LOOMREPO=$(mktemp -d); git -C "$LOOMREPO" init -q; mkdir -p "$LOOMREPO/.loom"; echo '{}' > "$LOOMREPO/.loom/config.json"
+run_wrapper "$LOOMREPO"
+assert_contains "$WOUT" "MACHINE-RAN:$LOOMREPO" "AC1: Loom workspace with no copy -> execs the machine hook, LOOM_PROJECT_ROOT set"
+
+# 8c: Loom workspace WITH a per-repo .loom/hooks/ copy -> defers (transition dedup)
+mkdir -p "$LOOMREPO/.loom/hooks"
+printf '#!/usr/bin/env bash\necho SHOULD-NOT-RUN\n' > "$LOOMREPO/.loom/hooks/guard-destructive.sh"
+chmod +x "$LOOMREPO/.loom/hooks/guard-destructive.sh"
+run_wrapper "$LOOMREPO"
+[[ -z "$WOUT" && "$WRC" == "0" ]] && pass "transition: defers to a present per-repo copy (machine hook does not run)" || fail "transition: expected silent defer, got out='$WOUT' rc=$WRC"
+
+# 8d: Loom workspace but machine checkout absent -> no-op (fail-open)
+out=$(cd "$LOOMREPO" && rm -rf "$LOOMREPO/.loom/hooks" && LOOM_HOME="/nonexistent/checkout" bash -c "$CMD" </dev/null 2>/dev/null); wrc=$?
+[[ -z "$out" && "$wrc" == "0" ]] && pass "machine checkout absent -> silent no-op (exit 0)" || fail "expected silent exit 0 when checkout absent, got out='$out' rc=$wrc"
+
+# ── Test 9: deprovision removes only Loom-owned entries ──────────────────────
+echo "Test 9: deprovision strips Loom-owned entries, preserves operator hooks"
+HOME9=$(mktemp -d); mkdir -p "$HOME9/.claude"
+cat > "$HOME9/.claude/settings.json" <<'EOF'
+{ "hooks": { "PreToolUse": [ { "matcher": "Bash", "hooks": [
+  { "type": "command", "command": ".claude/hooks/my-own-guard.sh" }
+] } ] }, "permissions": { "allow": ["Bash(x:*)"] } }
+EOF
+provision_loom_hooks "$HOME9/.claude" >/dev/null 2>&1
+deprovision_loom_hooks "$HOME9/.claude" >/dev/null 2>&1
+S9="$HOME9/.claude/settings.json"
+assert_eq "$(count_marker "$S9" guard-destructive.sh)" "0" "deprovision removed the Loom hook entries"
+assert_eq "$(jq -r '[.hooks.PreToolUse[]? | .hooks[]? | .command | select(. == ".claude/hooks/my-own-guard.sh")] | length' "$S9")" "1" "operator's own hook preserved after deprovision"
+assert_eq "$(jq -r '.permissions.allow[0]' "$S9")" "Bash(x:*)" "operator's permissions preserved after deprovision"
+
+echo ""
+echo "======================================"
+echo "test-provision-hooks.sh: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+echo "======================================"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/loom-daemon/src/init/scaffolding.rs
+++ b/loom-daemon/src/init/scaffolding.rs
@@ -36,6 +36,28 @@ pub const LOOM_HOOK_PREFIX: &str = "${CLAUDE_PROJECT_DIR}/.loom/hooks/";
 #[allow(dead_code)]
 pub const LEGACY_LOOM_HOOK_PREFIX: &str = ".loom/hooks/";
 
+/// Substring marker identifying Loom's **machine-level** hook command form
+/// (Epic #3835 Phase 5, #4262). Where [`LOOM_HOOK_PREFIX`] and
+/// [`LEGACY_LOOM_HOOK_PREFIX`] are project-relative paths that start the
+/// command, the machine-level form is a `bash -c '...'` wrapper (provisioned
+/// into the *user-scope* `~/.claude/settings.json` by
+/// `scripts/install/provision-hooks.sh`, not written by this scaffolding
+/// module) that resolves and execs a hook script from the shared machine
+/// checkout, e.g.:
+///
+/// ```text
+/// bash -c 'R=$(...) || exit 0; ...; H="${LOOM_HOME:-$HOME/.local/share/loom}/defaults/hooks/guard-destructive.sh"; [ -x "$H" ] && exec "$H" || exit 0'
+/// ```
+///
+/// The interesting path segment (`/defaults/hooks/`) appears mid-string, not
+/// at the start, so recognition uses substring containment rather than
+/// `starts_with`. Project-level `.claude/settings.json` never contains this
+/// form today (it is user-scope only), but [`is_loom_hook_command`] still
+/// recognizes it so a future merge/removal pass over project-level settings
+/// (or a hand-copied entry) is not silently treated as a foreign hook.
+#[allow(dead_code)]
+pub const MACHINE_HOOK_MARKER: &str = "/defaults/hooks/";
+
 /// Normalize a hook command string for semantic-duplicate comparison.
 ///
 /// Loom-generated hook commands are a single `${CLAUDE_PROJECT_DIR}`-prefixed
@@ -68,7 +90,9 @@ fn normalize_hook_command(cmd: &str) -> String {
 #[allow(dead_code)]
 fn is_loom_hook_command(cmd: &str) -> bool {
     let normalized = normalize_hook_command(cmd);
-    normalized.starts_with(LOOM_HOOK_PREFIX) || normalized.starts_with(LEGACY_LOOM_HOOK_PREFIX)
+    normalized.starts_with(LOOM_HOOK_PREFIX)
+        || normalized.starts_with(LEGACY_LOOM_HOOK_PREFIX)
+        || normalized.contains(MACHINE_HOOK_MARKER)
 }
 
 /// Loom section markers for CLAUDE.md content preservation
@@ -2348,6 +2372,75 @@ WARNING: Never run `lake build` inside Docker - causes memory corruption.
             hooks_arr.len(),
             1,
             "Quoted-form Loom hook should be removed, got: {hooks_arr:?}"
+        );
+        assert_eq!(hooks_arr[0]["command"], ".claude/hooks/custom-guard.sh");
+    }
+
+    #[test]
+    fn test_remove_loom_hooks_removes_machine_level_form() {
+        // Epic #3835 Phase 5 (#4262): the machine-level `bash -c '...'`
+        // wrapper command (provisioned at user-scope, but exercised here
+        // against a project-level settings.json to prove recognition is not
+        // scope-specific) must be recognized and removed alongside the
+        // legacy/current project-relative prefixes.
+        let mut settings: serde_json::Value = serde_json::from_str(
+            r#"{
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": "bash -c 'H=\"${LOOM_HOME:-$HOME/.local/share/loom}/defaults/hooks/guard-destructive.sh\"; [ -x \"$H\" ] && exec \"$H\" || exit 0'"},
+                        {"type": "command", "command": ".claude/hooks/custom-guard.sh"}
+                    ]
+                }]
+            }
+        }"#,
+        )
+        .unwrap();
+
+        remove_loom_hooks(&mut settings);
+
+        let bash_hooks = &settings["hooks"]["PreToolUse"][0]["hooks"];
+        let hooks_arr = bash_hooks.as_array().unwrap();
+        assert_eq!(
+            hooks_arr.len(),
+            1,
+            "machine-level hook command should be removed, got: {hooks_arr:?}"
+        );
+        assert_eq!(hooks_arr[0]["command"], ".claude/hooks/custom-guard.sh");
+    }
+
+    #[test]
+    fn test_is_loom_hook_command_recognizes_all_three_forms() {
+        // Exercised indirectly through remove_loom_hooks above (the function
+        // itself is private); this test locks in the three recognized
+        // command shapes side-by-side so a future edit to the marker/prefix
+        // constants can't silently narrow recognition.
+        let mut settings: serde_json::Value = serde_json::from_str(
+            r#"{
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-destructive.sh"},
+                        {"type": "command", "command": ".loom/hooks/guard-destructive.sh"},
+                        {"type": "command", "command": "bash -c 'H=\"${LOOM_HOME:-$HOME/.local/share/loom}/defaults/hooks/guard-loom-workflow.sh\"; [ -x \"$H\" ] && exec \"$H\" || exit 0'"},
+                        {"type": "command", "command": ".claude/hooks/custom-guard.sh"}
+                    ]
+                }]
+            }
+        }"#,
+        )
+        .unwrap();
+
+        remove_loom_hooks(&mut settings);
+
+        let bash_hooks = &settings["hooks"]["PreToolUse"][0]["hooks"];
+        let hooks_arr = bash_hooks.as_array().unwrap();
+        assert_eq!(
+            hooks_arr.len(),
+            1,
+            "only the non-Loom custom guard should remain, got: {hooks_arr:?}"
         );
         assert_eq!(hooks_arr[0]["command"], ".claude/hooks/custom-guard.sh");
     }

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -209,6 +209,14 @@ source "$LOOM_ROOT/scripts/install/provision-dispatcher.sh"
 # shellcheck source=scripts/install/provision-skills.sh
 source "$LOOM_ROOT/scripts/install/provision-skills.sh"
 
+# User-scope guard-hook wiring (Epic #3835 Phase 5, #4262). Sibling of
+# provision-skills.sh; wires the Loom PreToolUse/UserPromptSubmit/Stop guard
+# hooks into ~/.claude/settings.json so they execute from the machine checkout
+# instead of a per-repo .loom/hooks/ copy that drifts stale. Own file so the
+# test suite can exercise it standalone.
+# shellcheck source=scripts/install/provision-hooks.sh
+source "$LOOM_ROOT/scripts/install/provision-hooks.sh"
+
 # Dogfood command-dir linker (issue #3682) — extracted so the test suite can
 # exercise the scoped-symlink logic without running the full installer.
 # shellcheck source=scripts/install/dogfood-commands.sh
@@ -1108,6 +1116,18 @@ info "Provisioning user-scope loom skills + agents..."
 provision_loom_skills "${PROVISIONED_LOOM_CHECKOUT:-}" || \
   warning "User-scope loom skills/agents not fully provisioned; /loom:* skills still resolve from any per-repo copy."
 
+# Provision user-scope guard hooks (Epic #3835 Phase 5, #4262). Wires the Loom
+# guard hooks into ~/.claude/settings.json so they execute from the machine
+# checkout — a freshly-installed consumer repo needs NO per-repo .loom/hooks/
+# copy. Each wired command self-gates: it no-ops outside a Loom workspace and
+# defers to any still-present per-repo .loom/hooks/ copy (Phase 6 / #4254 strips
+# those; until then the project copy wins, so guards run exactly once). Additive
+# and best-effort — an operator's non-Loom hook entries are preserved and a soft
+# failure is logged but never aborts the install.
+info "Provisioning user-scope loom guard hooks..."
+provision_loom_hooks || \
+  warning "User-scope loom guard hooks not fully provisioned; guards still fire from any per-repo .loom/hooks/ copy + project-level settings entry."
+
 # Run loom-daemon init in the worktree
 cd "$TARGET_PATH/$WORKTREE_PATH"
 
@@ -1205,44 +1225,21 @@ git config core.hooksPath .githooks
 success "Set core.hooksPath to .githooks"
 echo ""
 
-# Copy hooks to target (settings.json references .loom/hooks/guard-destructive.sh,
-# a dispatcher that defers to the canonical Repo Skills guard when present — #4041)
-info "Installing hooks..."
-# Detect the canonical Repo Skills generic guard carrying the rjwalters/repo#29
-# fix. When present, Loom's vendored generic guard (guard-destructive-generic.sh)
-# is NOT installed and any stale copy is removed — the guard-destructive.sh
-# dispatcher defers to the canonical guard at runtime. Same marker probe the
-# dispatcher uses, so install-time and runtime always agree. (#4041)
-CANONICAL_GUARD_PRESENT=false
-if [[ -r ".claude/skills/repo/hooks/guard-destructive.sh" ]] && \
-   grep -q 'repo#29' ".claude/skills/repo/hooks/guard-destructive.sh" 2>/dev/null; then
-  CANONICAL_GUARD_PRESENT=true
-fi
-if [[ -d "$LOOM_ROOT/defaults/hooks" ]]; then
-  mkdir -p .loom/hooks
-  for hook_file in "$LOOM_ROOT/defaults/hooks/"*.sh; do
-    [[ -f "$hook_file" ]] || continue
-    hook_name=$(basename "$hook_file")
-    if [[ "$hook_name" == "guard-destructive-generic.sh" ]] && [[ "$CANONICAL_GUARD_PRESENT" == "true" ]]; then
-      if [[ -f ".loom/hooks/$hook_name" ]]; then
-        rm -f ".loom/hooks/$hook_name"
-        info "Canonical Repo Skills guard present — removed stale vendored $hook_name (dispatcher defers to canonical)"
-      else
-        info "Canonical Repo Skills guard present — skipping vendored $hook_name (dispatcher defers to canonical)"
-      fi
-      continue
-    fi
-    if [[ -f ".loom/hooks/$hook_name" ]] && [[ "$FORCE_OVERWRITE" != "true" ]] && [[ "$CLEAN_FIRST" != "true" ]]; then
-      info "Skipping existing hook: $hook_name (use --force to overwrite)"
-    else
-      cp "$hook_file" ".loom/hooks/$hook_name"
-      chmod +x ".loom/hooks/$hook_name"
-      success "Installed hook: $hook_name"
-    fi
-  done
-else
-  warning "No hooks directory found in defaults"
-fi
+# Hook SCRIPTS are no longer copied into the consumer's .loom/hooks/ (Epic #3835
+# Phase 5, #4262). They now execute from the machine-level checkout via the
+# user-scope ~/.claude/settings.json wiring provisioned above
+# (provision_loom_hooks), so a freshly-installed consumer repo carries no
+# hook-script copies and they can never drift stale. Hook POLICY (guards.*,
+# buildGate) is read from the tracked .loom-project/ project config through the
+# tiered resolver — it does NOT live alongside the scripts.
+#
+# Existing per-repo .loom/hooks/ copies on an ALREADY-installed repo are left
+# untouched here: removing them is Phase 6 (#4254) migration territory, and the
+# user-scope wrapper defers to a present copy so guards do not double-fire during
+# the transition. The #4041 canonical-Repo-Skills-guard preference logic lives in
+# the guard-destructive.sh dispatcher (path-relative; it moves with the script),
+# so no install-time canonical-guard probe is needed anymore.
+info "Hooks execute from the machine checkout (user-scope wiring) — not copied per-repo (#4262)"
 echo ""
 
 # Copy default config files (skill-routes.json template, etc.)
@@ -1666,8 +1663,9 @@ EXPECTED_FILES=(
   ".loom/scripts/lib/loom-tools.sh"
   ".loom/scripts/lib/forge-helpers.sh"
   ".loom/scripts/lib/pipe-pane-cmd.sh"
-  ".loom/hooks/guard-destructive.sh"
-  ".loom/hooks/skill-router.sh"
+  # NOTE (#4262): .loom/hooks/*.sh are intentionally NOT expected — hook scripts
+  # execute from the machine checkout via user-scope settings wiring, so a fresh
+  # install carries no per-repo hook copies.
   "CLAUDE.md"
   ".github/labels.yml"
   ".claude/commands/loom"

--- a/scripts/install/manifest.sh
+++ b/scripts/install/manifest.sh
@@ -183,7 +183,15 @@ _emit_installed_files_manifest() {
         target_path=".loom/${rel_path}"
         ;;
       hooks/*)
-        target_path=".loom/${rel_path}"
+        # Epic #3835 Phase 5 (#4262): hook scripts are no longer copied into the
+        # consumer's .loom/hooks/ — they execute from the machine-level checkout
+        # via user-scope ~/.claude/settings.json wiring
+        # (scripts/install/provision-hooks.sh). Drop them from the ownership
+        # manifest so the uninstall hard-delete loop and the upgrade stale-file
+        # sweep no longer chase per-repo copies that a fresh install never wrote.
+        # (The #4041 canonical-guard skip above is now unreachable for hooks/* but
+        # left in place — harmless.)
+        continue
         ;;
       docs/*)
         target_path=".loom/${rel_path}"

--- a/scripts/install/provision-hooks.sh
+++ b/scripts/install/provision-hooks.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# scripts/install/provision-hooks.sh — user-scope Loom guard-hook wiring
+# (Epic #3835 Phase 5, #4262).
+#
+# Sibling of provision-skills.sh / provision-dispatcher.sh. Where those establish
+# the machine-level `loom` dispatcher and the user-scope `/loom:*` skills, this
+# wires the Loom PreToolUse / UserPromptSubmit / Stop guard HOOKS into the
+# operator's user-scope `~/.claude/settings.json`, pointing at hook scripts that
+# execute from the SINGLE machine-level checkout instead of a per-repo
+# `.loom/hooks/` copy that drifts stale (the recurring resync-installed.sh pain).
+#
+# Source this file with:
+#     source "$LOOM_ROOT/scripts/install/provision-hooks.sh"
+# then call `provision_loom_hooks [claude_dir]`.
+#
+# Deliberately self-contained (defines its own output helpers) so the test suite
+# can source it without pulling in the full installer.
+#
+# ── Why user-scope (design decision 1) ────────────────────────────────────────
+# The epic's end state is "hook scripts machine-level". A user-scope entry in
+# ~/.claude/settings.json fires in every repo the operator opens, resolving the
+# hook script from the machine checkout — so a fresh consumer repo needs NO
+# per-repo `.loom/hooks/` copy and NO project-level settings.json hook entry to
+# get the guards. The project-level entries `loom-daemon init` used to write are
+# no longer added on fresh installs (the defaults settings.json drops its `hooks`
+# block); existing project-level entries on already-installed repos are left
+# untouched (Phase 6 / #4254 migration territory).
+#
+# ── The fail-open command wrapper (design decisions 2/3/4) ────────────────────
+# Because a user-scope hook fires in EVERY repo — including non-Loom ones — each
+# wired command is a self-gating one-liner (see [`_phook_cmd`]) that:
+#   1. Resolves the main repo root worktree-aware (`git rev-parse
+#      --git-common-dir`/..), so guards still fire from inside `.loom/worktrees/*`.
+#   2. WORKSPACE GATE (AC3): exit 0 (silent no-op) unless that root holds
+#      `.loom-project/project.json` OR `.loom/config.json` — i.e. is a Loom
+#      workspace (migrated or legacy). Non-Loom repos, and the case where the
+#      machine checkout is absent, no-op cleanly.
+#   3. TRANSITION DEDUP (design decision 3): if the repo still carries a per-repo
+#      `.loom/hooks/<name>` copy (pre-Phase-6), exit 0 and let the project-level
+#      entry run that copy — the project copy WINS until Phase 6 strips it, so a
+#      transition repo runs each guard exactly ONCE (no double-fire, no
+#      duplicated decision-log lines).
+#   4. Otherwise exec the machine-checkout hook
+#      `${LOOM_HOME:-$HOME/.local/share/loom}/defaults/hooks/<name>`, passing the
+#      resolved repo root through `LOOM_PROJECT_ROOT` (so guard-destructive.sh's
+#      dispatcher resolves the consuming repo's canonical Repo-Skills guard from
+#      a checkout-shaped SCRIPT_DIR), and fail open (exit 0) if it is missing.
+# `$HOME` / `$LOOM_HOME` are expanded per-user at hook-invocation time (the
+# command is shell-executed), so a single wired command is correct for every
+# operator — this is the dogfood repo's proven worktree-aware wrapper pattern.
+#
+# ── Ownership + idempotence (the #4200 lesson) ────────────────────────────────
+# Every wired command carries the substring `/defaults/hooks/<name>` — the same
+# machine-level marker `loom-daemon init`'s scaffolding.rs recognizes
+# (MACHINE_HOOK_MARKER). Dedup and removal both key on that substring, which
+# survives any requoting Claude Code applies to settings.json, so a re-run never
+# duplicates an entry and deprovision never orphans one.
+
+# Emit a hooks-provision status line (plain text so sourcing tests can assert).
+_phook_ok()   { echo "  [loom-hooks] $*"; }
+_phook_warn() { echo "  [loom-hooks] WARNING: $*" >&2; }
+
+# Set on every return (success or soft-failure) so the caller can VERIFY what was
+# written rather than trust a success message (the #4053 "expose enough for the
+# caller to verify" contract, matching provision-dispatcher.sh's
+# PROVISIONED_DISPATCHER_BIN). Assigned as GLOBALS (no `local`) so they survive
+# the function return. Consumed by callers/tests, not this file.
+# shellcheck disable=SC2034
+PROVISIONED_HOOKS_SETTINGS=""
+# shellcheck disable=SC2034
+PROVISIONED_HOOKS_BACKUP=""
+
+# The Loom guard-hook wiring set. Parallel arrays (matcher strings contain `|`,
+# so a delimited single array is unsafe). Order mirrors defaults/.claude/
+# settings.json, plus the Edit|Write worktree guard (design decision 4) that
+# fresh consumers never had wired before.
+_PHOOK_TYPES=(PreToolUse PreToolUse PreToolUse UserPromptSubmit UserPromptSubmit Stop)
+_PHOOK_MATCHERS=(Bash Bash "Edit|Write" "" "" "")
+_PHOOK_NAMES=(
+    guard-destructive.sh
+    guard-loom-workflow.sh
+    guard-worktree-paths.sh
+    skill-router.sh
+    methodology-inject.sh
+    guard-background-subagents.sh
+)
+
+# Emit the fail-open, workspace-gated, transition-deferring command wrapper for a
+# single hook script <name>. A single-quoted `bash -c '...'` body with NO
+# embedded single quotes (all internal quoting is double quotes) so it survives
+# JSON round-tripping cleanly. See the header for the four steps this encodes.
+_phook_cmd() {
+    local name="$1"
+    # shellcheck disable=SC2016  # literal $-expansions are intentional (per-user, at hook time)
+    printf '%s' "bash -c 'ROOT=\$(cd \"\$(git rev-parse --git-common-dir 2>/dev/null)/..\" 2>/dev/null && pwd); [ -n \"\$ROOT\" ] || exit 0; { [ -f \"\$ROOT/.loom-project/project.json\" ] || [ -f \"\$ROOT/.loom/config.json\" ]; } || exit 0; [ -x \"\$ROOT/.loom/hooks/${name}\" ] && exit 0; H=\"\${LOOM_HOME:-\$HOME/.local/share/loom}/defaults/hooks/${name}\"; [ -x \"\$H\" ] && LOOM_PROJECT_ROOT=\"\$ROOT\" exec \"\$H\" || exit 0'"
+}
+
+# provision_loom_hooks [claude_dir]
+#
+# Idempotently merge the Loom guard-hook wiring into the user-scope
+# ~/.claude/settings.json. Best-effort — never fatal. Returns 1 on a soft
+# failure (invalid existing JSON, jq missing, unwritable dir) so the caller can
+# note it, but the installer must NOT abort on a non-zero return.
+provision_loom_hooks() {
+    local claude_dir="${1:-$HOME/.claude}"
+    local settings="$claude_dir/settings.json"
+
+    # Publish the resolved destination up front so EVERY return path communicates
+    # where things live (the caller gates on the return code).
+    # shellcheck disable=SC2034
+    PROVISIONED_HOOKS_SETTINGS="$settings"
+    # shellcheck disable=SC2034
+    PROVISIONED_HOOKS_BACKUP=""
+
+    if ! command -v jq >/dev/null 2>&1; then
+        _phook_warn "jq not available; cannot wire user-scope hooks."
+        return 1
+    fi
+
+    if ! mkdir -p "$claude_dir" 2>/dev/null; then
+        _phook_warn "could not create $claude_dir; skipping hook wiring."
+        return 1
+    fi
+
+    # Refuse to touch an existing file that is not valid JSON — a blind write
+    # would clobber the operator's settings. A missing OR empty file is fine
+    # (we start from {}).
+    if [[ -s "$settings" ]]; then
+        if ! jq empty "$settings" >/dev/null 2>&1; then
+            _phook_warn "$settings is not valid JSON; leaving it untouched."
+            return 1
+        fi
+    fi
+
+    # Back up before the first mutation (only when there is existing content to
+    # preserve). Timestamped so repeated runs never clobber an earlier backup.
+    if [[ -s "$settings" ]]; then
+        local backup
+        backup="${settings}.loom-backup-$(date -u +%Y%m%dT%H%M%SZ)"
+        if cp "$settings" "$backup" 2>/dev/null; then
+            # shellcheck disable=SC2034
+            PROVISIONED_HOOKS_BACKUP="$backup"
+            _phook_ok "backed up existing settings -> $(basename "$backup")"
+        else
+            _phook_warn "could not back up $settings; refusing to mutate it."
+            return 1
+        fi
+    fi
+
+    # Seed a missing/empty file with an empty object so jq has a base document.
+    if [[ ! -s "$settings" ]]; then
+        printf '{}\n' > "$settings" 2>/dev/null || {
+            _phook_warn "could not initialize $settings."
+            return 1
+        }
+    fi
+
+    local soft_fail=0 i
+    for i in "${!_PHOOK_NAMES[@]}"; do
+        local htype="${_PHOOK_TYPES[$i]}"
+        local matcher="${_PHOOK_MATCHERS[$i]}"
+        local name="${_PHOOK_NAMES[$i]}"
+        local cmd
+        cmd="$(_phook_cmd "$name")"
+        if _phook_merge_one "$settings" "$htype" "$matcher" "$name" "$cmd"; then
+            _phook_ok "wired $htype/${matcher:-<all>} -> $name"
+        else
+            _phook_warn "failed to wire $name into $settings"
+            soft_fail=1
+        fi
+    done
+
+    return "$soft_fail"
+}
+
+# Merge a single hook entry into <settings_file>, deduplicating by the
+# machine-level marker substring `defaults/hooks/<name>` (survives requoting).
+#   $1 settings_file  $2 hook_type  $3 matcher  $4 name  $5 command
+_phook_merge_one() {
+    local f="$1" htype="$2" matcher="$3" name="$4" cmd="$5"
+    local marker="defaults/hooks/$name"
+    local tmp
+    tmp="$(mktemp 2>/dev/null)" || return 1
+    if jq \
+        --arg ht "$htype" \
+        --arg m "$matcher" \
+        --arg marker "$marker" \
+        --arg cmd "$cmd" '
+        .hooks = (.hooks // {})
+        | .hooks[$ht] = (.hooks[$ht] // [])
+        | (.hooks[$ht] | map(.matcher // "") | index($m)) as $idx
+        | if $idx == null then
+            .hooks[$ht] += [{matcher: $m, hooks: [{type: "command", command: $cmd}]}]
+          else
+            .hooks[$ht][$idx].hooks = (.hooks[$ht][$idx].hooks // [])
+            | if (.hooks[$ht][$idx].hooks | map(.command // "") | any(contains($marker)))
+              then .
+              else .hooks[$ht][$idx].hooks += [{type: "command", command: $cmd}]
+              end
+          end
+        ' "$f" > "$tmp" 2>/dev/null; then
+        mv "$tmp" "$f" 2>/dev/null || { rm -f "$tmp"; return 1; }
+        return 0
+    fi
+    rm -f "$tmp"
+    return 1
+}
+
+# deprovision_loom_hooks [claude_dir]
+#
+# Remove Loom-owned guard-hook entries from the user-scope ~/.claude/settings.json
+# — identified by the machine-level marker substring `/defaults/hooks/` in the
+# command (the same MACHINE_HOOK_MARKER scaffolding.rs uses). Never touches a
+# non-Loom hook. Backs up before mutating. Cleans up emptied matcher entries and
+# hook-type arrays. Best-effort; never fatal.
+#
+# NOTE: a per-repo Loom UNINSTALL does NOT call this — the user-scope wiring is a
+# single machine-level resource shared by every repo Loom is installed into
+# (exactly like the ~/.local/bin/loom dispatcher and the user-scope skills from
+# Phase 4 / #4261). A machine-level teardown is the correct caller.
+deprovision_loom_hooks() {
+    local claude_dir="${1:-$HOME/.claude}"
+    local settings="$claude_dir/settings.json"
+
+    command -v jq >/dev/null 2>&1 || return 0
+    [[ -s "$settings" ]] || return 0
+    jq empty "$settings" >/dev/null 2>&1 || {
+        _phook_warn "$settings is not valid JSON; leaving it untouched."
+        return 0
+    }
+
+    # Nothing Loom-owned to remove? Leave the file (and its mtime) alone.
+    if ! jq -e '
+        (.hooks // {}) | to_entries | any(.value[]?.hooks[]?.command // "" | contains("/defaults/hooks/"))
+        ' "$settings" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    local backup
+    backup="${settings}.loom-backup-$(date -u +%Y%m%dT%H%M%SZ)"
+    cp "$settings" "$backup" 2>/dev/null && _phook_ok "backed up settings -> $(basename "$backup")"
+
+    local tmp
+    tmp="$(mktemp 2>/dev/null)" || return 0
+    if jq '
+        if .hooks then
+            .hooks |= (
+                to_entries
+                | map(
+                    .value |= (
+                        map(
+                            .hooks |= map(select((.command // "") | contains("/defaults/hooks/") | not))
+                        )
+                        | map(select((.hooks | length) > 0))
+                    )
+                )
+                | map(select((.value | length) > 0))
+                | from_entries
+            )
+            | if (.hooks | length) == 0 then del(.hooks) else . end
+        else . end
+        ' "$settings" > "$tmp" 2>/dev/null; then
+        mv "$tmp" "$settings" 2>/dev/null \
+            && _phook_ok "removed Loom user-scope hook entries from $settings"
+    else
+        rm -f "$tmp"
+    fi
+    return 0
+}

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -155,6 +155,45 @@ ROOT_CLAUDE_EOF
     fi
   fi
 
+  # Inject the LEGACY project-level Loom hook entries into the simulated
+  # .claude/settings.json. As of Epic #3835 Phase 5 (#4262) a fresh install no
+  # longer wires project-level hooks (they execute machine-level via user-scope
+  # ~/.claude/settings.json, and defaults/.claude/settings.json dropped its
+  # `hooks` block), so the copy above yields a hook-less settings file. This
+  # simulator, however, stands in for an ALREADY-installed / transition repo —
+  # the shape Phase 5 explicitly preserves (existing project entries are NOT
+  # removed until Phase 6 / #4254) and the shape the uninstall + project-hook
+  # tests below validate. Re-add the historical `${CLAUDE_PROJECT_DIR}`-prefixed
+  # entries so those tests keep exercising the legacy layout.
+  if [[ -f "$target/.claude/settings.json" ]] && command -v jq >/dev/null 2>&1; then
+    _sim_tmp="$(mktemp)"
+    if jq '
+      .hooks = {
+        "PreToolUse": [
+          { "matcher": "Bash", "hooks": [
+            { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-destructive.sh" },
+            { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-loom-workflow.sh" }
+          ] }
+        ],
+        "UserPromptSubmit": [
+          { "matcher": "", "hooks": [
+            { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/skill-router.sh" },
+            { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/methodology-inject.sh" }
+          ] }
+        ],
+        "Stop": [
+          { "hooks": [
+            { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-background-subagents.sh" }
+          ] }
+        ]
+      }
+    ' "$target/.claude/settings.json" > "$_sim_tmp" 2>/dev/null; then
+      mv "$_sim_tmp" "$target/.claude/settings.json"
+    else
+      rm -f "$_sim_tmp"
+    fi
+  fi
+
   # Copy .github directory (labels.yml)
   if [[ -d "$DEFAULTS_DIR/.github" ]]; then
     mkdir -p "$target/.github"
@@ -3022,6 +3061,38 @@ if [[ -f "$LOOM_ROOT/scripts/install/provision-skills.sh" ]]; then
   pass "scripts/install/provision-skills.sh present"
 else
   fail "scripts/install/provision-skills.sh missing"
+fi
+echo ""
+
+# ==========================================================================
+# User-scope guard-hook wiring (Epic #3835 Phase 5, #4262)
+# ==========================================================================
+# Its own unit suite lives at defaults/scripts/tests/test-provision-hooks.sh
+# (missing/empty/populated settings merge, idempotence incl. #4200 requoted
+# dedup, operator-hook/permissions preservation, invalid-JSON soft-fail, pre-
+# mutation backup, the fail-open workspace-gated wrapper, and the checkout-only
+# deprovision). Fold its result into the installer suite so it runs in CI + the
+# build gate rather than dev-only.
+echo "Test: user-scope guard-hook provisioning suite (test-provision-hooks.sh)"
+HOOKS_TEST="$DEFAULTS_DIR/scripts/tests/test-provision-hooks.sh"
+if [[ -f "$HOOKS_TEST" ]]; then
+  set +e
+  HOOKS_TEST_OUT=$(bash "$HOOKS_TEST" 2>&1)
+  HOOKS_TEST_RC=$?
+  set -e
+  if [[ $HOOKS_TEST_RC -eq 0 ]]; then
+    pass "test-provision-hooks.sh: all cases passed"
+  else
+    fail "test-provision-hooks.sh failed (rc=$HOOKS_TEST_RC)"
+    echo "$HOOKS_TEST_OUT" | tail -20
+  fi
+else
+  fail "test-provision-hooks.sh not found at $HOOKS_TEST"
+fi
+if [[ -f "$LOOM_ROOT/scripts/install/provision-hooks.sh" ]]; then
+  pass "scripts/install/provision-hooks.sh present"
+else
+  fail "scripts/install/provision-hooks.sh missing"
 fi
 echo ""
 

--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -611,6 +611,18 @@ else
   # in scripts/install/provision-skills.sh, which deletes a link ONLY when it
   # points into the machine checkout and never touches an operator's real files.
 
+  # NOTE (Epic #3835 Phase 5, #4262): the user-scope guard-hook entries wired
+  # into ~/.claude/settings.json by provision_loom_hooks are ALSO a machine-level
+  # SHARED resource — one set of entries, resolved by every repo Loom is
+  # installed into, exactly like the skills above. A per-repo uninstall therefore
+  # does NOT strip them: doing so would disable the destructive-command / worktree
+  # guards for every OTHER consumer repo on the machine. A machine-level teardown
+  # can remove them safely via `deprovision_loom_hooks` in
+  # scripts/install/provision-hooks.sh, which removes ONLY entries carrying the
+  # machine-level `/defaults/hooks/` marker and never touches an operator's own
+  # hooks. (The per-repo PROJECT-level `.claude/settings.json` Loom hook entries
+  # ARE stripped below, via the jq smart-removal on that file.)
+
   # Backward compatibility: also check old location (repo root)
   if [[ -f "$TARGET_PATH/loom" ]] && [[ -x "$TARGET_PATH/loom" ]]; then
     REMOVE_FILES+=("loom")

--- a/tests/hooks/test-guard-destructive-dispatcher.sh
+++ b/tests/hooks/test-guard-destructive-dispatcher.sh
@@ -111,6 +111,31 @@ check "no guard → empty output" "" "$OUT"
 check "no guard → exit 0" "0" "$RC"
 rm -rf "$REPO"
 
+
+# --- Case 5: machine-level layout (Epic #3835 Phase 5, #4262) --------------
+# When the dispatcher runs from a checkout (SCRIPT_DIR does NOT sit at
+# <repo>/.loom/hooks), the SCRIPT_DIR-relative "../../" resolution would point
+# outside the consuming repo entirely. The user-scope command wrapper
+# resolves the repo root itself and passes it via LOOM_PROJECT_ROOT — confirm
+# the dispatcher prefers that over its SCRIPT_DIR-relative fallback.
+echo "Case 5: LOOM_PROJECT_ROOT env fallback resolves canonical guard from a checkout-shaped SCRIPT_DIR"
+CHECKOUT="$(mktemp -d)"
+mkdir -p "$CHECKOUT/defaults/hooks"
+cp "$DISPATCHER_SRC" "$CHECKOUT/defaults/hooks/guard-destructive.sh"
+cp "$GENERIC_SRC" "$CHECKOUT/defaults/hooks/guard-destructive-generic.sh"
+chmod +x "$CHECKOUT/defaults/hooks/"*.sh
+REPO="$(mktemp -d)"
+mkdir -p "$REPO/.claude/skills/repo/hooks"
+MARK="repo#""29"
+printf '#!/usr/bin/env bash\n# fixed per %s\necho CANON-RAN\nexit 0\n' "$MARK" \
+  > "$REPO/.claude/skills/repo/hooks/guard-destructive.sh"
+chmod +x "$REPO/.claude/skills/repo/hooks/guard-destructive.sh"
+OUT="$(printf '{"tool_input":{"command":"%s"},"cwd":"%s"}\n' "$DANGER" "$REPO" \
+  | LOOM_PROJECT_ROOT="$REPO" bash "$CHECKOUT/defaults/hooks/guard-destructive.sh" 2>/dev/null)"
+check "canonical guard resolved via LOOM_PROJECT_ROOT (checkout-shaped SCRIPT_DIR)" "CANON-RAN" \
+  "$(printf '%s' "$OUT" | grep -o 'CANON-RAN' | head -1)"
+rm -rf "$CHECKOUT" "$REPO"
+
 echo ""
 echo "========================================="
 echo -e "Results: ${PASS} passed, ${FAIL} failed"

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -1799,6 +1799,44 @@ for _fp_dir in "$FASTPATH_OFF_REPO" "$FASTPATH_EXTRA_REPO"; do
     [[ -n "$_fp_dir" && "$_fp_dir" != "/" && -d "$_fp_dir/.loom" ]] && rm -rf "$_fp_dir"
 done
 
+# --- Tiered config (Epic #3835 Phase 5, #4262): .loom-project/project.json --
+# Create a throwaway git repo whose .loom-project/project.json (the tracked
+# tier) holds the given JSON, optionally alongside a legacy .loom/config.json
+# to exercise tier precedence. Echoes the repo path.
+make_project_tier_repo() {
+    local project_json="$1" legacy_json="${2:-}"
+    local dir
+    dir=$(mktemp -d 2>/dev/null)
+    git -C "$dir" init -q >/dev/null 2>&1
+    mkdir -p "$dir/.loom-project"
+    printf '%s' "$project_json" > "$dir/.loom-project/project.json"
+    if [[ -n "$legacy_json" ]]; then
+        mkdir -p "$dir/.loom"
+        printf '%s' "$legacy_json" > "$dir/.loom/config.json"
+    fi
+    echo "$dir"
+}
+
+if [[ "$_FP_AMBIENT_ON" == "1" ]]; then
+    PROJECT_TIER_REPO=$(make_project_tier_repo '{"guards":{"readOnlyFastPath":false}}')
+    assert_deny "Fast path tiered config: .loom-project/project.json readOnlyFastPath=false disables fast path" \
+        "grep '$_FP_DDL' schema.sql" "$PROJECT_TIER_REPO"
+
+    # Project tier (higher precedence) overrides a conflicting legacy tier.
+    OVERRIDE_REPO=$(make_project_tier_repo '{"guards":{"readOnlyFastPath":false}}' '{"guards":{"readOnlyFastPath":true}}')
+    assert_deny "Fast path tiered config: project tier overrides conflicting legacy tier (project wins)" \
+        "grep '$_FP_DDL' schema.sql" "$OVERRIDE_REPO"
+
+    # readOnlyFastPathExtra also resolves from the project tier.
+    PROJECT_EXTRA_REPO=$(make_project_tier_repo '{"guards":{"readOnlyFastPathExtra":["psql"]}}')
+    assert_allow "Fast path tiered config: readOnlyFastPathExtra from .loom-project admits 'psql'" \
+        "psql -c '$_FP_DDL'" "$PROJECT_EXTRA_REPO"
+
+    for _fp_dir in "$PROJECT_TIER_REPO" "$OVERRIDE_REPO" "$PROJECT_EXTRA_REPO"; do
+        [[ -n "$_fp_dir" && "$_fp_dir" != "/" && -d "$_fp_dir/.loom-project" ]] && rm -rf "$_fp_dir"
+    done
+fi
+
 echo ""
 
 # =========================================================================


### PR DESCRIPTION
## Summary

Epic #3835 Phase 5: move guard-hook **script execution** to the shared machine-level checkout, wired once into the operator's user-scope `~/.claude/settings.json`, while keeping hook **policy** (`guards.*`, `buildGate`) per-repo, read from the tracked `.loom-project/` project config through the existing tiered resolver. A freshly-installed consumer repo now carries no per-repo `.loom/hooks/` copies (which drift stale — the recurring `resync-installed.sh` pain). This is the replacement Phase 6 (#4254) depends on before it can `git rm --cached` the per-repo hooks.

## Changes

- **New `scripts/install/provision-hooks.sh`** — sibling of the Phase 4 skills provisioner. jq-based idempotent merge into `~/.claude/settings.json`: create-if-missing, back up before the first write, dedup by the machine-level marker substring `defaults/hooks/<name>` (survives Claude Code requoting, the #4200 lesson), preserve every non-Loom entry, soft-fail (no write) on invalid existing JSON. Each wired command is a **fail-open, self-gating** wrapper (decisions 1–4):
  1. resolves the repo root worktree-aware (`git rev-parse --git-common-dir`/..);
  2. **workspace gate** — exits 0 unless the root holds `.loom-project/project.json` or `.loom/config.json` (AC3: no-op in non-Loom repos and when the checkout is absent);
  3. **transition precedence** — defers to a still-present per-repo `.loom/hooks/<name>` copy so guards run exactly once until Phase 6 strips them;
  4. otherwise exec's the machine hook with `LOOM_PROJECT_ROOT` set. Also wires the `Edit|Write` worktree guard consumers never had (decision 4), and exposes `deprovision_loom_hooks` for machine-level teardown.
- **`scripts/install-loom.sh`** — invoke `provision_loom_hooks`; stop copying `defaults/hooks/*.sh` into `.loom/hooks/`; drop `.loom/hooks/*` from `EXPECTED_FILES`. Existing per-repo copies on already-installed repos are left untouched (scope guard 1).
- **`defaults/.claude/settings.json`** — drop the `hooks` block (permissions unchanged). `merge_hooks` is additive, so existing consumer project-level entries are preserved on upgrade and fresh installs get none.
- **`loom-daemon/src/init/scaffolding.rs`** — add `MACHINE_HOOK_MARKER` and recognize the machine-level command form in `is_loom_hook_command`, so init merge-dedup and hook removal handle old and new forms (decision 6).
- **`scripts/install/manifest.sh`** — stop enumerating `.loom/hooks/*` as Loom-owned so uninstall/stale-sweep don't chase per-repo copies.
- **`scripts/uninstall-loom.sh`** — NOTE that the user-scope hook entries are a shared machine-level resource (like the Phase 4 skills), not stripped by a per-repo uninstall; project-level entries are still smart-removed.
- **Config-tier migration** — `guard-worktree-paths.sh` migrates its two direct-`jq` reads to the tiered resolver via a per-invocation cache (preserving the #4241 fork-budget carve-out); `guard-destructive-generic.sh` fast-path toggle reads become project-tier-aware bounded (<=2 fork) reads; `guard-destructive.sh` dispatcher honors `LOOM_PROJECT_ROOT` for a checkout-shaped `SCRIPT_DIR` (decision 5).
- **Docs** — `defaults/docs/guard-hooks.md` + `defaults/docs/machine-dispatcher.md`.
- **Dogfood sync** — the three modified hooks re-synced into the tracked `.loom/hooks/` copies (keeps the byte-identity test green; not a removal).

## Acceptance Criteria Verification

- **AC1 (guards execute from the checkout; fresh repo has no copies)** — installer stops copying `defaults/hooks/*.sh`; `test-provision-hooks.sh` Test 8b execs the machine hook via the user-scope entry alone.
- **AC2 (`guards.*`/`buildGate` read from `.loom-project/` via tiered resolvers)** — `guard-worktree-paths.sh` + fast-path reads now consult `.loom-project/project.json` first (new tier fixtures in the worktree + fast-path suites); `buildGate` was already tiered in `main_health_gate.rs` (verify + document only, scope guard 5).
- **AC3 (no-op in non-Loom workspaces / missing checkout)** — workspace gate; `test-provision-hooks.sh` Test 8a/8d.
- **AC4 (guard semantics unchanged in a migrated repo; Edit|Write confinement)** — the `Edit|Write` worktree guard is now wired at user level; transition precedence keeps existing behavior.
- **AC5 (existing per-repo copies NOT removed)** — installer only stops *copying*; `merge_hooks` stays additive; uninstall NOTE + manifest change avoid touching them.

## Test Plan

- `defaults/scripts/tests/test-provision-hooks.sh` — 28/28 (merge into missing/empty/populated settings, idempotence incl. #4200 requoted dedup, operator-hook/permissions preservation, invalid-JSON soft-fail, pre-mutation backup, fail-open wrapper for AC1/AC3/transition, checkout-only deprovision). Folded into `scripts/test-installer.sh`.
- `defaults/hooks/tests/test-guard-worktree-paths.sh` 23/23, `tests/hooks/test-guard-destructive-dispatcher.sh` 8/8 (incl. new `LOOM_PROJECT_ROOT` case), tiered fast-path cases in `tests/hooks/test-guard-destructive.sh` all pass.
- `cargo test --lib init::scaffolding` — 50/50 (incl. machine-level form dedupe/removal).
- `scripts/test-installer.sh` — all tests passed (simulator updated to inject legacy project-level hook entries representing the transition-repo shape).

Note: `tests/hooks/test-guard-destructive.sh` has 12 pre-existing failures on this host (forceScope / `git push --force` / decisionLog categories) reproduced identically on a clean `main` checkout — unrelated to this change (which only touches the fast-path readers, whose tiered tests pass).

Closes #4262
Part of #3835
