### PR TITLE
feat(daemon): stateful host-distress circuit breaker for dispatch

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1548,6 +1548,12 @@ concurrency ceiling 5" and share it with the team:
         "instaCrashSecs": 60
       }
     },
+    "hostBreaker": {
+      "enabled": true,
+      "loadPerCoreTrip": 2.5,
+      "sustainTicks": 3,
+      "cooldownSecs": 300
+    },
     "mainHealthGate": {
       "enabled": true
     },
@@ -1596,6 +1602,10 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.workFinder.quarantine.threshold` | `LOOM_WORK_FINDER_QUARANTINE_THRESHOLD` | `3` | Consecutive insta-crashes before an issue is quarantined. Zero/invalid → default |
 | `autonomous.workFinder.quarantine.ttlSecs` | `LOOM_WORK_FINDER_QUARANTINE_TTL_SECS` | `3600` | How long a quarantine entry persists before auto-release. Zero/invalid → default |
 | `autonomous.workFinder.quarantine.instaCrashSecs` | `LOOM_WORK_FINDER_QUARANTINE_INSTA_CRASH_SECS` | `60` | Checkpoint-less death within this window of dispatch counts as an insta-crash. Zero/invalid → default |
+| `autonomous.hostBreaker.enabled` | `LOOM_HOST_BREAKER` | `true` | Host-distress circuit breaker on/off (#4235). A safety backstop — **defaults on**. Env truthy (`1`/`true`/`yes`/`on`) enables, any other value disables; wins over config. See [Host-distress circuit breaker](#host-distress-circuit-breaker-4235) below |
+| `autonomous.hostBreaker.loadPerCoreTrip` | `LOOM_HOST_BREAKER_LOAD_PER_CORE` | `2.5` | Load-per-core at/over which a tick counts toward tripping. `<= 0`/invalid → default |
+| `autonomous.hostBreaker.sustainTicks` | `LOOM_HOST_BREAKER_SUSTAIN_TICKS` | `3` | Consecutive over-threshold work-finder ticks required to trip (a single spike never trips). Zero/invalid → default |
+| `autonomous.hostBreaker.cooldownSecs` | `LOOM_HOST_BREAKER_COOLDOWN_SECS` | `300` | Cool-down window held after distress subsides before dispatch resumes. Zero/invalid → default |
 | `autonomous.perTokenConcurrency` | `LOOM_PER_TOKEN_CONCURRENCY` | `2` | Concurrent sweeps **per healthy token** in the cap (#3947). Zero/invalid → default; clamped to a floor of 1 |
 | `autonomous.cpuUtilizationTarget` | `LOOM_CPU_UTILIZATION_TARGET` | `0.75` | Fraction of logical CPUs the CPU headroom term is willing to dedicate to sweep work (#3978, config surface #4032). Outside `(0, 1]` or wrong JSON type → default; single-root, resolved once at startup (not per-workspace) |
 | `autonomous.estCoresPerSweep` | `LOOM_EST_CORES_PER_SWEEP` | `2.0` | Estimated CPU cores one concurrent sweep consumes while building/testing (#3978, config surface #4032). `<= 0` or wrong JSON type → default; integer JSON (`2`) and float JSON (`2.0`) both accepted; single-root, resolved once at startup |
@@ -1786,6 +1796,75 @@ candidate is dropped **before** the global slot-fill pass, so a workspace whose
 only candidates are quarantined never reserves a shared dispatch slot — healthy
 sibling work in other repos gets it instead. Defaults **on**; disable with
 `LOOM_WORK_FINDER_QUARANTINE=0` or `autonomous.workFinder.quarantine.enabled = false`.
+
+### Host-distress circuit breaker (#4235)
+
+The insta-crash quarantine above protects the shared **queue** from one broken
+issue; the host circuit breaker protects the **host itself** from a sustained
+overload. It was added after the 2026-07-27→28 meltdown (#4231): a 6-way sweep
+fan-out drove load to 118 on 28 cores, the window server was watchdog-killed five
+times, and the daemon itself crashed — and then a *second* wave re-spiked the host
+two hours later because nothing remembered the first incident. The point-in-time
+admission checks (CPU headroom #3978, the per-tick load-admission ramp cap #4234)
+each make a *fresh* decision every tick, so the instant load dipped they
+re-admitted a full wave.
+
+The breaker is the **stateful** layer those checks lack. It samples
+**load-per-core** (`loadavg_1m / logical_cpus`) once per work-finder tick and runs
+a three-phase state machine:
+
+- **Closed** (normal) → **Open** once load-per-core has been at/over
+  `loadPerCoreTrip` for `sustainTicks` *consecutive* ticks. A single spike resets
+  the counter, so a transient burst never trips.
+- **Open** (tripped) — new dispatch is **suppressed** in every repo while running
+  sweeps **drain untouched** (the breaker never kills a running sweep). Stays Open
+  while the host is still hot.
+- **CoolDown** — once load drops back below the threshold, dispatch stays
+  suppressed for a further `cooldownSecs` so a transient dip can't re-admit a full
+  wave (exactly the #4231 01:41 re-spike). A re-spike over the threshold during
+  cool-down sends it straight back to Open; otherwise the cool-down elapses and it
+  returns to Closed.
+
+The breaker's suppression composes with the existing dispatch suppressors at the
+same choke point — it is OR'd onto the main-health-gate halt and the scheduled
+drain, and works alongside (never bypassing) the `maxAdmissionsPerTick` ramp cap.
+
+**Default-ON rationale.** Unlike the work-finder loop itself (opt-in,
+default-off), the breaker **defaults on** — the same call the insta-crash
+quarantine made. It only ever acts under genuinely severe *sustained* load, it
+never aborts running work, and it is only ever *sampled* from inside the
+work-finder loop, so a daemon that never enables the work-finder sees zero
+behavior change. A backstop that defaulted off would not have prevented #4231's
+second wave, which is the whole point.
+
+**Explicit `dispatch_sweep` is hard-blocked by default (with a `force`
+override).** This differs deliberately from the sibling headroom advisory (#4234),
+which only *advises* an explicit dispatch that would exceed the point-in-time
+dynamic cap and never blocks it. A *tripped* breaker represents **sustained,
+already-observed** distress — a materially stronger signal than a single-tick
+headroom reading — so `dispatch_sweep` (CLI `loom-daemon dispatch <N>` / the
+`mcp__loom__dispatch_sweep` tool) is **refused** while the breaker is Open or
+CoolDown. An operator who knows the host is distressed and wants to dispatch anyway
+passes `--force` (CLI) / `force: true` (IPC).
+
+**Observability.** The breaker is surfaced three ways: a log line on every phase
+change; a state-change-deduped `daemon.host_breaker.state` event-bus event
+(payload: `transition`, `state`, `reason`, `tripped_at`, `releases_at`); and
+`loom-daemon status`, which prints `Host breaker: OK/OPEN/COOLING DOWN` with the
+reason, the tripped-at time, and the cool-down release time (also in
+`--json → host_breaker`).
+
+**Clearing it manually.** The breaker auto-clears when the cool-down elapses on a
+recovered host — no operator action is needed in the normal case. To clear it
+sooner, either resolve the load (it releases on the next below-threshold tick plus
+the cool-down) or restart the daemon (the state is in-memory, like the
+quarantine). To disable it entirely, set `LOOM_HOST_BREAKER=0` or
+`autonomous.hostBreaker.enabled = false`.
+
+**Follow-ups deliberately deferred** (kept out of the first version to stay
+minimal, per #4235): macOS-only trip signals (`.ips` crash reports, `syspolicyd`
+CPU-ratio amplification, daemon self-restart detection) and durable trip/release
+telemetry (coordinate with #4137 rather than building a parallel store).
 
 ### Cross-host dispatch-collision baseline (#4085, Phase 0 of #4028)
 

--- a/loom-daemon/src/cpu_headroom.rs
+++ b/loom-daemon/src/cpu_headroom.rs
@@ -304,6 +304,30 @@ pub fn read_loadavg_1m() -> Option<f64> {
     None
 }
 
+/// Pure: load-per-core = `loadavg_1m / ncpu`, or `None` when the load average
+/// is unavailable or the CPU count is zero. The host-distress circuit breaker
+/// (#4235) trips on this normalized ratio so its threshold is portable across
+/// hosts of different core counts (a raw load of 100 is catastrophic on 8 cores
+/// but routine on 128).
+#[must_use]
+pub fn load_per_core_from(loadavg_1m: Option<f64>, ncpu: usize) -> Option<f64> {
+    let load = loadavg_1m?;
+    if ncpu == 0 {
+        return None;
+    }
+    Some(load / ncpu as f64)
+}
+
+/// Sample the current load-per-core from live host inputs for the host-distress
+/// circuit breaker (#4235). Uses the **fast**, non-sleeping load-average read
+/// ([`read_loadavg_1m`] — a `/proc/loadavg` read on Linux, a quick `sysctl` on
+/// macOS), never the ~1s `iostat` idle sample, so it is safe to call inline from
+/// the work-finder loop each tick. `None` when no load-average source exists.
+#[must_use]
+pub fn load_per_core() -> Option<f64> {
+    load_per_core_from(read_loadavg_1m(), logical_cpu_count())
+}
+
 // ============================================================================
 // CPU utilization — measured idle fraction (#4031), OS-specific read, pure parse
 // ============================================================================

--- a/loom-daemon/src/host_breaker.rs
+++ b/loom-daemon/src/host_breaker.rs
@@ -473,7 +473,7 @@ pub fn step(
                     }),
                     next,
                 }
-            } else if prev.releases_at.map_or(true, |r| now >= r) {
+            } else if prev.releases_at.is_none_or(|r| now >= r) {
                 // Cool-down elapsed (or, defensively, no deadline recorded) —
                 // resume normal dispatch.
                 let reason = "cool-down elapsed; dispatch resumed".to_string();

--- a/loom-daemon/src/host_breaker.rs
+++ b/loom-daemon/src/host_breaker.rs
@@ -1,0 +1,984 @@
+//! Host-distress circuit breaker (Issue #4235 — item 4 of the #4231 meltdown
+//! decomposition).
+//!
+//! # Why this exists
+//!
+//! The 2026-07-27→28 host meltdown (#4231) was a 6-way sweep fan-out driving
+//! load to 118 on 28 cores; `WindowServer` was watchdog-killed five times and
+//! `loom_daemon` itself crashed at 23:52 — a clear distress signal ~2 hours
+//! before the GUI finally died. A *second* wave re-spiked the host at 01:41
+//! because nothing remembered the first incident: the point-in-time admission
+//! checks (CPU headroom #3978, the per-tick load-admission gate #4234) each
+//! made a *fresh* decision every tick, so the moment load dipped they re-admitted
+//! a full wave.
+//!
+//! This module is the **stateful** adaptive layer the point-in-time checks
+//! lack. When the host shows *sustained* distress it **trips**, stops launching
+//! new work, lets the running work drain (it never kills a running sweep), and
+//! only resumes after a **cool-down** — so a transient load dip cannot
+//! immediately re-admit a full wave.
+//!
+//! # Distinction from the admission gate (#4234)
+//!
+//! The headroom/ramp checks in #4234 are *point-in-time admission* decisions.
+//! The breaker is *stateful*: it trips only on sustained over-threshold load,
+//! stays open across ticks, and releases on a cool-down TTL. It is consulted as
+//! a **second dispatch suppressor** alongside the existing main-health halt flag
+//! and the ramp cap — never a parallel mechanism.
+//!
+//! # State machine
+//!
+//! ```text
+//!            load-per-core ≥ threshold                load < threshold
+//!            for `sustain_ticks` ticks
+//!   Closed ───────────────────────────▶  Open  ───────────────────────▶ CoolDown
+//!     ▲                                    ▲                                 │
+//!     │ cool-down elapsed                  │ re-spike (load ≥ threshold)     │
+//!     └────────────────────────────────── CoolDown ◀────────────────────────┘
+//! ```
+//!
+//! - **Closed** — normal; new dispatch allowed. A per-tick counter tracks how
+//!   many *consecutive* ticks load-per-core has been at/over the trip
+//!   threshold; reaching `sustain_ticks` trips to **Open**. A single spike
+//!   resets the counter, so a transient burst never trips.
+//! - **Open** — tripped; new dispatch is suppressed (running work drains). Stays
+//!   Open while the host is still hot; once load drops back below the threshold
+//!   it moves to **CoolDown**.
+//! - **CoolDown** — distress subsided but dispatch stays suppressed for
+//!   `cooldown` seconds so a transient dip cannot re-admit a full wave. A
+//!   re-spike over the threshold sends it straight back to **Open**; otherwise
+//!   the cool-down elapses and it returns to **Closed**.
+//!
+//! # Testability
+//!
+//! The decision logic is a pure [`step`] function over an immutable
+//! [`BreakerRuntime`] + an observation + a `now` timestamp, mirroring
+//! [`crate::quarantine_reconciliation`]'s decide/plan split — it is unit-tested
+//! without a forge, a host, or a runtime. [`SharedHostBreaker`] is the thin
+//! interior-mutable runtime handle the work-finder loop updates each tick and
+//! the IPC status/dispatch paths read; it delegates every decision to [`step`].
+//!
+//! # Default-ON rationale
+//!
+//! Unlike the autonomous work-finder itself (default-OFF, opt-in), the breaker
+//! **defaults on** — it is a safety backstop, the same call the insta-crash
+//! quarantine (#3939, `QuarantineConfig::enabled = true`) made. It only ever
+//! acts under genuinely severe *sustained* load, it never kills running work,
+//! and it is only ever *sampled* from inside the work-finder loop — which itself
+//! only runs when an operator has opted into autonomy. So a repo that never
+//! enables the work-finder sees zero behavior change, and a repo that does gets
+//! the meltdown backstop for free. The whole lesson of #4231 was that nothing
+//! remembered the first incident; a backstop that defaulted off would not have
+//! helped.
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+use chrono::{DateTime, Utc};
+
+// ============================================================================
+// Config surface (env > config > default, mirroring work_finder + quarantine)
+// ============================================================================
+
+/// Env var toggling the host circuit breaker. `0`/`false`/`no`/`off` disables;
+/// anything else truthy (`1`/`true`/`yes`/`on`) forces on. Overrides config.
+/// Defaults ON — a safety backstop, mirroring
+/// [`crate::sweep_registry::QUARANTINE_ENABLE_ENV`].
+pub const HOST_BREAKER_ENABLE_ENV: &str = "LOOM_HOST_BREAKER";
+
+/// Env var overriding the load-per-core trip threshold. A `<= 0`/invalid value
+/// falls through to config/default.
+pub const HOST_BREAKER_LOAD_PER_CORE_ENV: &str = "LOOM_HOST_BREAKER_LOAD_PER_CORE";
+
+/// Env var overriding the number of consecutive over-threshold ticks required
+/// to trip. A zero/invalid value falls through to config/default.
+pub const HOST_BREAKER_SUSTAIN_TICKS_ENV: &str = "LOOM_HOST_BREAKER_SUSTAIN_TICKS";
+
+/// Env var overriding the cool-down window, in seconds. A zero/invalid value
+/// falls through to config/default.
+pub const HOST_BREAKER_COOLDOWN_SECS_ENV: &str = "LOOM_HOST_BREAKER_COOLDOWN_SECS";
+
+/// Default: the breaker is enabled (a safety backstop, like the insta-crash
+/// quarantine).
+pub const DEFAULT_HOST_BREAKER_ENABLED: bool = true;
+
+/// Default load-per-core trip threshold. Normal healthy hosts sit well below
+/// `1.0` load-per-core; sustained `2.5×` oversubscription is clear distress
+/// (the #4231 meltdown peaked at ~4.2 load-per-core) while leaving bursty
+/// build spikes below the line. Deliberately well above the CPU-headroom
+/// utilization target (`cpuUtilizationTarget`, default ~0.85) — the breaker is
+/// for *distress*, not for the routine headroom throttling #3978/#4234 already
+/// handle.
+pub const DEFAULT_HOST_BREAKER_LOAD_PER_CORE: f64 = 2.5;
+
+/// Default consecutive over-threshold ticks before tripping. At the default
+/// 60s work-finder interval this is ~3 minutes of *sustained* distress, so a
+/// single noisy tick can never trip. Mirrors the quarantine's
+/// `DEFAULT_QUARANTINE_THRESHOLD = 3` "N strikes" shape.
+pub const DEFAULT_HOST_BREAKER_SUSTAIN_TICKS: u32 = 3;
+
+/// Default cool-down window: once distress subsides, hold new dispatch for this
+/// long so a transient load dip cannot re-admit a full wave (the #4231 01:41
+/// re-spike). 5 minutes — long enough to outlast the load-average's own 1-minute
+/// smoothing window several times over.
+pub const DEFAULT_HOST_BREAKER_COOLDOWN_SECS: u64 = 300;
+
+/// Resolved host-breaker parameters (env > config > default), captured once at
+/// daemon startup and held by [`SharedHostBreaker`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HostBreakerConfig {
+    /// Whether the breaker is active. When `false` the breaker is permanently
+    /// Closed and never suppresses dispatch (byte-for-byte the pre-#4235 path).
+    pub enabled: bool,
+    /// Load-per-core at/over which a tick counts toward tripping.
+    pub load_per_core_threshold: f64,
+    /// Consecutive over-threshold ticks required to trip.
+    pub sustain_ticks: u32,
+    /// How long the cool-down holds dispatch after distress subsides.
+    pub cooldown_secs: u64,
+}
+
+impl Default for HostBreakerConfig {
+    fn default() -> Self {
+        Self {
+            enabled: DEFAULT_HOST_BREAKER_ENABLED,
+            load_per_core_threshold: DEFAULT_HOST_BREAKER_LOAD_PER_CORE,
+            sustain_ticks: DEFAULT_HOST_BREAKER_SUSTAIN_TICKS,
+            cooldown_secs: DEFAULT_HOST_BREAKER_COOLDOWN_SECS,
+        }
+    }
+}
+
+/// The raw config half read from `.loom/config.json → autonomous.hostBreaker`
+/// (each field `None` when absent/malformed), before env/default resolution.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct HostBreakerConfigFile {
+    pub enabled: Option<bool>,
+    pub load_per_core_threshold: Option<f64>,
+    pub sustain_ticks: Option<u32>,
+    pub cooldown_secs: Option<u64>,
+}
+
+/// Read `.loom/config.json → autonomous.hostBreaker`, soft-failing every field
+/// to `None` (env/default resolution) on a missing file, malformed JSON, or a
+/// missing `autonomous` / `hostBreaker` block. Mirrors the soft-fail contract of
+/// [`crate::work_finder::read_work_finder_config`].
+#[must_use]
+pub fn read_host_breaker_config(repo_root: &std::path::Path) -> HostBreakerConfigFile {
+    let effective = crate::config_resolver::resolve_effective_config(repo_root);
+    let Some(autonomous) = crate::config_resolver::get_path(&effective, "autonomous") else {
+        return HostBreakerConfigFile::default();
+    };
+    let hb = autonomous.get("hostBreaker");
+    HostBreakerConfigFile {
+        enabled: hb
+            .and_then(|h| h.get("enabled"))
+            .and_then(serde_json::Value::as_bool),
+        load_per_core_threshold: hb
+            .and_then(|h| h.get("loadPerCoreTrip"))
+            .and_then(serde_json::Value::as_f64)
+            .filter(|&f| f > 0.0),
+        sustain_ticks: hb
+            .and_then(|h| h.get("sustainTicks"))
+            .and_then(serde_json::Value::as_u64)
+            .filter(|&n| n > 0)
+            .and_then(|n| u32::try_from(n).ok()),
+        cooldown_secs: hb
+            .and_then(|h| h.get("cooldownSecs"))
+            .and_then(serde_json::Value::as_u64)
+            .filter(|&n| n > 0),
+    }
+}
+
+/// Env override for [`HOST_BREAKER_ENABLE_ENV`] — `Some(true/false)` when set to
+/// a recognized truthy/falsy value, `None` when unset (config/default decides).
+fn env_enabled() -> Option<bool> {
+    match std::env::var(HOST_BREAKER_ENABLE_ENV) {
+        Ok(v) => {
+            Some(matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        }
+        Err(_) => None,
+    }
+}
+
+fn env_load_per_core() -> Option<f64> {
+    std::env::var(HOST_BREAKER_LOAD_PER_CORE_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<f64>().ok())
+        .filter(|&f| f > 0.0)
+}
+
+fn env_sustain_ticks() -> Option<u32> {
+    std::env::var(HOST_BREAKER_SUSTAIN_TICKS_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .filter(|&n| n > 0)
+}
+
+fn env_cooldown_secs() -> Option<u64> {
+    std::env::var(HOST_BREAKER_COOLDOWN_SECS_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&n| n > 0)
+}
+
+/// Resolve the full [`HostBreakerConfig`] with precedence **env > config >
+/// default** for every field independently.
+#[must_use]
+pub fn resolve_config(file: &HostBreakerConfigFile) -> HostBreakerConfig {
+    HostBreakerConfig {
+        enabled: env_enabled()
+            .or(file.enabled)
+            .unwrap_or(DEFAULT_HOST_BREAKER_ENABLED),
+        load_per_core_threshold: env_load_per_core()
+            .or(file.load_per_core_threshold)
+            .unwrap_or(DEFAULT_HOST_BREAKER_LOAD_PER_CORE),
+        sustain_ticks: env_sustain_ticks()
+            .or(file.sustain_ticks)
+            .unwrap_or(DEFAULT_HOST_BREAKER_SUSTAIN_TICKS),
+        cooldown_secs: env_cooldown_secs()
+            .or(file.cooldown_secs)
+            .unwrap_or(DEFAULT_HOST_BREAKER_COOLDOWN_SECS),
+    }
+}
+
+/// Convenience: read `repo_root`'s config and resolve it end-to-end.
+#[must_use]
+pub fn resolve_config_for(repo_root: &std::path::Path) -> HostBreakerConfig {
+    resolve_config(&read_host_breaker_config(repo_root))
+}
+
+// ============================================================================
+// Pure state machine
+// ============================================================================
+
+/// The three breaker phases (see the module docs for the transition diagram).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BreakerPhase {
+    /// Normal — new dispatch allowed.
+    Closed,
+    /// Tripped on sustained distress — new dispatch suppressed, running work
+    /// drains.
+    Open,
+    /// Distress subsided but still holding dispatch for the cool-down window.
+    CoolDown,
+}
+
+impl BreakerPhase {
+    /// A stable lowercase wire/render tag.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BreakerPhase::Closed => "closed",
+            BreakerPhase::Open => "open",
+            BreakerPhase::CoolDown => "cooldown",
+        }
+    }
+
+    /// Whether this phase suppresses new dispatch (Open or CoolDown).
+    #[must_use]
+    pub fn suppresses_dispatch(self) -> bool {
+        !matches!(self, BreakerPhase::Closed)
+    }
+}
+
+/// The evolving breaker state. Immutable input / owned output of [`step`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct BreakerRuntime {
+    pub phase: BreakerPhase,
+    /// Consecutive over-threshold ticks observed while Closed (the trip counter).
+    pub consecutive_over: u32,
+    /// When the breaker last tripped to Open (`None` while Closed).
+    pub tripped_at: Option<DateTime<Utc>>,
+    /// When a CoolDown completes and the breaker returns to Closed (`None`
+    /// outside CoolDown).
+    pub releases_at: Option<DateTime<Utc>>,
+    /// Human-readable reason for the current non-Closed state (`None` while
+    /// Closed).
+    pub reason: Option<String>,
+    /// The most recent load-per-core sample observed (for the status surface).
+    pub last_load_per_core: Option<f64>,
+}
+
+impl Default for BreakerRuntime {
+    fn default() -> Self {
+        Self {
+            phase: BreakerPhase::Closed,
+            consecutive_over: 0,
+            tripped_at: None,
+            releases_at: None,
+            reason: None,
+            last_load_per_core: None,
+        }
+    }
+}
+
+/// Which edge a [`Transition`] represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransitionKind {
+    /// Closed → Open (sustained distress reached the trip threshold).
+    Tripped,
+    /// Open → CoolDown (distress subsided; cool-down begins).
+    CoolingDown,
+    /// CoolDown → Closed (cool-down elapsed; normal dispatch resumes).
+    Released,
+    /// CoolDown → Open (host re-spiked during cool-down).
+    ReTripped,
+}
+
+impl TransitionKind {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TransitionKind::Tripped => "tripped",
+            TransitionKind::CoolingDown => "cooling_down",
+            TransitionKind::Released => "released",
+            TransitionKind::ReTripped => "re_tripped",
+        }
+    }
+}
+
+/// A recorded phase transition — the payload for the `daemon.host_breaker.state`
+/// event and the operator log line.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Transition {
+    pub kind: TransitionKind,
+    /// The phase entered.
+    pub phase: BreakerPhase,
+    pub reason: String,
+    pub tripped_at: Option<DateTime<Utc>>,
+    pub releases_at: Option<DateTime<Utc>>,
+}
+
+/// The result of one [`step`]: the next runtime plus an optional transition
+/// (present only on a phase change).
+#[derive(Debug, Clone, PartialEq)]
+pub struct StepResult {
+    pub next: BreakerRuntime,
+    pub transition: Option<Transition>,
+}
+
+/// The pure breaker state machine: fold one observation (`load_per_core` at
+/// `now`) into `prev`, returning the next runtime and any phase transition.
+///
+/// A `load_per_core` of `None` (no load-average source available) is treated as
+/// **not over threshold** — it never trips a Closed breaker, and it lets an Open
+/// breaker begin cooling down rather than latching forever on missing data
+/// (fail-toward-recovery, matching the CPU-headroom module's fail-open chain).
+#[must_use]
+pub fn step(
+    prev: &BreakerRuntime,
+    config: &HostBreakerConfig,
+    load_per_core: Option<f64>,
+    now: DateTime<Utc>,
+) -> StepResult {
+    // Disabled: permanently Closed, no suppression, no transitions — but still
+    // record the last sample so the status surface stays honest.
+    if !config.enabled {
+        return StepResult {
+            next: BreakerRuntime {
+                last_load_per_core: load_per_core,
+                ..BreakerRuntime::default()
+            },
+            transition: None,
+        };
+    }
+
+    let over = load_per_core.is_some_and(|l| l >= config.load_per_core_threshold);
+    let load_str = load_per_core.map_or_else(|| "n/a".to_string(), |l| format!("{l:.2}"));
+    let mut next = prev.clone();
+    next.last_load_per_core = load_per_core;
+
+    match prev.phase {
+        BreakerPhase::Closed => {
+            if over {
+                let count = prev.consecutive_over.saturating_add(1);
+                next.consecutive_over = count;
+                if count >= config.sustain_ticks {
+                    let reason = format!(
+                        "load-per-core {load_str} ≥ {:.2} sustained for {count} consecutive tick(s)",
+                        config.load_per_core_threshold
+                    );
+                    next.phase = BreakerPhase::Open;
+                    next.tripped_at = Some(now);
+                    next.releases_at = None;
+                    next.reason = Some(reason.clone());
+                    return StepResult {
+                        transition: Some(Transition {
+                            kind: TransitionKind::Tripped,
+                            phase: BreakerPhase::Open,
+                            reason,
+                            tripped_at: Some(now),
+                            releases_at: None,
+                        }),
+                        next,
+                    };
+                }
+            } else {
+                next.consecutive_over = 0;
+            }
+            StepResult {
+                next,
+                transition: None,
+            }
+        }
+        BreakerPhase::Open => {
+            if over {
+                // Still hot — stay Open. (The trip counter is unused in Open.)
+                StepResult {
+                    next,
+                    transition: None,
+                }
+            } else {
+                let releases_at = now + chrono::Duration::seconds(config.cooldown_secs as i64);
+                let reason = format!(
+                    "load-per-core {load_str} < {:.2}; cooling down for {}s",
+                    config.load_per_core_threshold, config.cooldown_secs
+                );
+                next.phase = BreakerPhase::CoolDown;
+                next.consecutive_over = 0;
+                next.releases_at = Some(releases_at);
+                next.reason = Some(reason.clone());
+                StepResult {
+                    transition: Some(Transition {
+                        kind: TransitionKind::CoolingDown,
+                        phase: BreakerPhase::CoolDown,
+                        reason,
+                        tripped_at: prev.tripped_at,
+                        releases_at: Some(releases_at),
+                    }),
+                    next,
+                }
+            }
+        }
+        BreakerPhase::CoolDown => {
+            if over {
+                // Re-spike during cool-down — straight back to Open. This is the
+                // #4231 01:41 second wave the breaker exists to stop.
+                let reason = format!(
+                    "host re-spiked (load-per-core {load_str} ≥ {:.2}) during cool-down",
+                    config.load_per_core_threshold
+                );
+                next.phase = BreakerPhase::Open;
+                next.consecutive_over = 0;
+                next.tripped_at = Some(now);
+                next.releases_at = None;
+                next.reason = Some(reason.clone());
+                StepResult {
+                    transition: Some(Transition {
+                        kind: TransitionKind::ReTripped,
+                        phase: BreakerPhase::Open,
+                        reason,
+                        tripped_at: Some(now),
+                        releases_at: None,
+                    }),
+                    next,
+                }
+            } else if prev.releases_at.map_or(true, |r| now >= r) {
+                // Cool-down elapsed (or, defensively, no deadline recorded) —
+                // resume normal dispatch.
+                let reason = "cool-down elapsed; dispatch resumed".to_string();
+                next.phase = BreakerPhase::Closed;
+                next.consecutive_over = 0;
+                next.tripped_at = None;
+                next.releases_at = None;
+                next.reason = None;
+                StepResult {
+                    transition: Some(Transition {
+                        kind: TransitionKind::Released,
+                        phase: BreakerPhase::Closed,
+                        reason,
+                        tripped_at: None,
+                        releases_at: None,
+                    }),
+                    next,
+                }
+            } else {
+                // Still cooling.
+                StepResult {
+                    next,
+                    transition: None,
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// A serializable snapshot for the status surface
+// ============================================================================
+
+/// A point-in-time snapshot of the breaker for `loom-daemon status` and the
+/// transition event payload. Maps to [`crate::types::HostBreakerStatus`] via
+/// [`Self::into_status`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct BreakerSnapshot {
+    pub enabled: bool,
+    pub phase: BreakerPhase,
+    pub suppressed: bool,
+    pub reason: Option<String>,
+    pub tripped_at: Option<DateTime<Utc>>,
+    pub releases_at: Option<DateTime<Utc>>,
+    pub last_load_per_core: Option<f64>,
+    pub load_per_core_threshold: f64,
+    pub sustain_ticks: u32,
+    pub cooldown_secs: u64,
+    pub consecutive_over: u32,
+}
+
+impl BreakerSnapshot {
+    /// Convert to the wire/status type in [`crate::types`].
+    #[must_use]
+    pub fn into_status(self) -> crate::types::HostBreakerStatus {
+        crate::types::HostBreakerStatus {
+            enabled: self.enabled,
+            phase: self.phase.as_str().to_string(),
+            suppressed: self.suppressed,
+            reason: self.reason,
+            tripped_at: self.tripped_at,
+            releases_at: self.releases_at,
+            last_load_per_core: self.last_load_per_core,
+            load_per_core_threshold: self.load_per_core_threshold,
+            sustain_ticks: self.sustain_ticks,
+            cooldown_secs: self.cooldown_secs,
+        }
+    }
+}
+
+// ============================================================================
+// Shared runtime handle + process-global registration
+// ============================================================================
+
+/// Thread-safe breaker handle: the work-finder loop [`observe`](Self::observe)s
+/// a fresh load sample into it each tick; the IPC status/dispatch paths read
+/// [`is_suppressed`](Self::is_suppressed) / [`snapshot`](Self::snapshot). All
+/// decisions delegate to the pure [`step`].
+#[derive(Debug)]
+pub struct SharedHostBreaker {
+    config: HostBreakerConfig,
+    inner: Mutex<BreakerRuntime>,
+}
+
+// Allow expect_used: a poisoned breaker mutex means another thread panicked
+// while holding it — unrecoverable, matching the crash-on-poison policy used
+// across ipc.rs / auto_update.rs / the drain state.
+#[allow(clippy::expect_used)]
+impl SharedHostBreaker {
+    #[must_use]
+    pub fn new(config: HostBreakerConfig) -> Self {
+        Self {
+            config,
+            inner: Mutex::new(BreakerRuntime::default()),
+        }
+    }
+
+    #[must_use]
+    pub fn config(&self) -> HostBreakerConfig {
+        self.config
+    }
+
+    /// Fold one load-per-core sample into the breaker, returning any phase
+    /// transition (the caller emits the log line + event on `Some`).
+    pub fn observe(&self, load_per_core: Option<f64>, now: DateTime<Utc>) -> Option<Transition> {
+        let mut guard = self.inner.lock().expect("host breaker mutex poisoned");
+        let result = step(&guard, &self.config, load_per_core, now);
+        *guard = result.next;
+        result.transition
+    }
+
+    /// Whether the breaker is currently suppressing new dispatch.
+    #[must_use]
+    pub fn is_suppressed(&self) -> bool {
+        if !self.config.enabled {
+            return false;
+        }
+        let guard = self.inner.lock().expect("host breaker mutex poisoned");
+        guard.phase.suppresses_dispatch()
+    }
+
+    /// A snapshot for the status surface.
+    #[must_use]
+    pub fn snapshot(&self) -> BreakerSnapshot {
+        let guard = self.inner.lock().expect("host breaker mutex poisoned");
+        let suppressed = self.config.enabled && guard.phase.suppresses_dispatch();
+        BreakerSnapshot {
+            enabled: self.config.enabled,
+            phase: guard.phase,
+            suppressed,
+            reason: guard.reason.clone(),
+            tripped_at: guard.tripped_at,
+            releases_at: guard.releases_at,
+            last_load_per_core: guard.last_load_per_core,
+            load_per_core_threshold: self.config.load_per_core_threshold,
+            sustain_ticks: self.config.sustain_ticks,
+            cooldown_secs: self.config.cooldown_secs,
+            consecutive_over: guard.consecutive_over,
+        }
+    }
+}
+
+/// Process-global breaker handle. The single work-finder loop registers its
+/// handle here so [`crate::ipc::build_daemon_status`] and the `dispatch_sweep`
+/// handler can read/consult it without threading an `Arc` through the whole IPC
+/// server (mirrors [`crate::auto_update`]'s process-global status handle). Unset
+/// (breaker never enabled / work-finder never spawned) reads as "not
+/// suppressed", i.e. zero behavior change.
+static GLOBAL: OnceLock<Arc<SharedHostBreaker>> = OnceLock::new();
+
+/// Register the process-global breaker handle. Idempotent: only the first
+/// registration wins (there is exactly one breaker per daemon process).
+pub fn register_global(breaker: Arc<SharedHostBreaker>) {
+    let _ = GLOBAL.set(breaker);
+}
+
+/// The process-global breaker handle, if one has been registered.
+#[must_use]
+pub fn global() -> Option<Arc<SharedHostBreaker>> {
+    GLOBAL.get().cloned()
+}
+
+/// Whether the process-global breaker is currently suppressing dispatch.
+/// `false` when no breaker is registered (zero behavior change).
+#[must_use]
+pub fn global_is_suppressed() -> bool {
+    GLOBAL.get().is_some_and(|b| b.is_suppressed())
+}
+
+/// A snapshot of the process-global breaker, or `None` when none is registered.
+#[must_use]
+pub fn global_snapshot() -> Option<BreakerSnapshot> {
+    GLOBAL.get().map(|b| b.snapshot())
+}
+
+/// Emit the operator log line + the state-change-deduped
+/// `daemon.host_breaker.state` [`Generic`](crate::types::Event::Generic) event
+/// for a breaker transition. Called by the work-finder loop on every `Some`
+/// transition returned by [`SharedHostBreaker::observe`]; the transition itself
+/// is already de-duplicated (it fires only on a real phase change), so this is
+/// never a per-tick stream. Fire-and-forget: a `NoSubscribers` publish result is
+/// logged at debug and ignored (matching the daemon's other publish sites).
+pub fn emit_transition_event(event_bus: &Arc<crate::event_bus::EventBus>, transition: &Transition) {
+    match transition.kind {
+        TransitionKind::Tripped | TransitionKind::ReTripped => {
+            log::warn!(
+                "host_breaker: {} → {} — {}",
+                transition.kind.as_str(),
+                transition.phase.as_str(),
+                transition.reason
+            );
+        }
+        TransitionKind::CoolingDown | TransitionKind::Released => {
+            log::info!(
+                "host_breaker: {} → {} — {}",
+                transition.kind.as_str(),
+                transition.phase.as_str(),
+                transition.reason
+            );
+        }
+    }
+    if let Err(e) = event_bus.publish_generic(
+        "daemon.host_breaker.state",
+        serde_json::json!({
+            "transition": transition.kind.as_str(),
+            "state": transition.phase.as_str(),
+            "reason": transition.reason,
+            "tripped_at": transition.tripped_at,
+            "releases_at": transition.releases_at,
+        }),
+    ) {
+        log::debug!("host_breaker: state event not delivered: {e}");
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::float_cmp)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> HostBreakerConfig {
+        HostBreakerConfig {
+            enabled: true,
+            load_per_core_threshold: 2.5,
+            sustain_ticks: 3,
+            cooldown_secs: 300,
+        }
+    }
+
+    fn t0() -> DateTime<Utc> {
+        "2026-07-28T00:00:00Z".parse().unwrap()
+    }
+
+    /// Drive a sequence of samples through `step`, returning the final runtime
+    /// and every transition observed.
+    fn drive(
+        config: &HostBreakerConfig,
+        start: BreakerRuntime,
+        samples: &[(Option<f64>, DateTime<Utc>)],
+    ) -> (BreakerRuntime, Vec<Transition>) {
+        let mut state = start;
+        let mut transitions = Vec::new();
+        for &(load, now) in samples {
+            let result = step(&state, config, load, now);
+            if let Some(t) = result.transition.clone() {
+                transitions.push(t);
+            }
+            state = result.next;
+        }
+        (state, transitions)
+    }
+
+    // --- Trip only after N sustained ticks -------------------------------
+
+    #[test]
+    fn single_spike_does_not_trip() {
+        let config = cfg();
+        let (state, transitions) = drive(
+            &config,
+            BreakerRuntime::default(),
+            &[
+                (Some(5.0), t0()), // over, count=1
+                (Some(0.1), t0()), // under, resets
+                (Some(5.0), t0()), // over, count=1 again
+                (Some(0.1), t0()), // under, resets
+            ],
+        );
+        assert_eq!(state.phase, BreakerPhase::Closed);
+        assert!(transitions.is_empty(), "a single spike must never trip");
+        assert_eq!(state.consecutive_over, 0);
+    }
+
+    #[test]
+    fn trips_after_sustain_ticks() {
+        let config = cfg();
+        let (state, transitions) = drive(
+            &config,
+            BreakerRuntime::default(),
+            &[(Some(3.0), t0()), (Some(3.0), t0()), (Some(3.0), t0())],
+        );
+        assert_eq!(state.phase, BreakerPhase::Open);
+        assert_eq!(transitions.len(), 1);
+        assert_eq!(transitions[0].kind, TransitionKind::Tripped);
+        assert!(state.tripped_at.is_some());
+        assert!(state.reason.as_deref().unwrap().contains("sustained"));
+    }
+
+    #[test]
+    fn does_not_trip_one_tick_early() {
+        let config = cfg();
+        let (state, transitions) = drive(
+            &config,
+            BreakerRuntime::default(),
+            &[(Some(3.0), t0()), (Some(3.0), t0())], // only 2 of 3
+        );
+        assert_eq!(state.phase, BreakerPhase::Closed);
+        assert!(transitions.is_empty());
+        assert_eq!(state.consecutive_over, 2);
+    }
+
+    #[test]
+    fn exactly_at_threshold_counts_as_over() {
+        let config = cfg();
+        let (state, _) = drive(
+            &config,
+            BreakerRuntime::default(),
+            &[(Some(2.5), t0()), (Some(2.5), t0()), (Some(2.5), t0())],
+        );
+        assert_eq!(state.phase, BreakerPhase::Open);
+    }
+
+    // --- Open → CoolDown → Closed ----------------------------------------
+
+    #[test]
+    fn open_stays_open_while_hot_then_cools_down() {
+        let config = cfg();
+        let tripped = drive(
+            &config,
+            BreakerRuntime::default(),
+            &[(Some(3.0), t0()), (Some(3.0), t0()), (Some(3.0), t0())],
+        )
+        .0;
+        assert_eq!(tripped.phase, BreakerPhase::Open);
+
+        // Still hot: stays Open, no transition.
+        let (still_open, tr) = drive(&config, tripped.clone(), &[(Some(4.0), t0())]);
+        assert_eq!(still_open.phase, BreakerPhase::Open);
+        assert!(tr.is_empty());
+
+        // Load drops: enters CoolDown with a releases_at.
+        let (cooling, tr) = drive(&config, still_open, &[(Some(0.5), t0())]);
+        assert_eq!(cooling.phase, BreakerPhase::CoolDown);
+        assert_eq!(tr.len(), 1);
+        assert_eq!(tr[0].kind, TransitionKind::CoolingDown);
+        assert_eq!(cooling.releases_at, Some(t0() + chrono::Duration::seconds(300)));
+    }
+
+    #[test]
+    fn cooldown_releases_after_window() {
+        let config = cfg();
+        let cooling = BreakerRuntime {
+            phase: BreakerPhase::CoolDown,
+            releases_at: Some(t0() + chrono::Duration::seconds(300)),
+            tripped_at: Some(t0()),
+            reason: Some("cooling".to_string()),
+            ..BreakerRuntime::default()
+        };
+        // Before the window elapses: still cooling.
+        let (still, tr) =
+            drive(&config, cooling.clone(), &[(Some(0.1), t0() + chrono::Duration::seconds(299))]);
+        assert_eq!(still.phase, BreakerPhase::CoolDown);
+        assert!(tr.is_empty());
+
+        // At/after the deadline with an acceptable load: released to Closed.
+        let (released, tr) =
+            drive(&config, cooling, &[(Some(0.1), t0() + chrono::Duration::seconds(300))]);
+        assert_eq!(released.phase, BreakerPhase::Closed);
+        assert_eq!(tr.len(), 1);
+        assert_eq!(tr[0].kind, TransitionKind::Released);
+        assert!(released.tripped_at.is_none());
+        assert!(released.releases_at.is_none());
+    }
+
+    #[test]
+    fn still_hot_host_re_trips_during_cooldown() {
+        let config = cfg();
+        let cooling = BreakerRuntime {
+            phase: BreakerPhase::CoolDown,
+            releases_at: Some(t0() + chrono::Duration::seconds(300)),
+            tripped_at: Some(t0()),
+            reason: Some("cooling".to_string()),
+            ..BreakerRuntime::default()
+        };
+        // A re-spike inside the cool-down window immediately re-trips to Open.
+        let (reopened, tr) =
+            drive(&config, cooling, &[(Some(3.0), t0() + chrono::Duration::seconds(60))]);
+        assert_eq!(reopened.phase, BreakerPhase::Open);
+        assert_eq!(tr.len(), 1);
+        assert_eq!(tr[0].kind, TransitionKind::ReTripped);
+        assert!(reopened.releases_at.is_none());
+    }
+
+    #[test]
+    fn missing_load_sample_never_trips_and_lets_open_cool() {
+        let config = cfg();
+        // None samples never trip a Closed breaker.
+        let (state, tr) = drive(
+            &config,
+            BreakerRuntime::default(),
+            &[(None, t0()), (None, t0()), (None, t0()), (None, t0())],
+        );
+        assert_eq!(state.phase, BreakerPhase::Closed);
+        assert!(tr.is_empty());
+
+        // An Open breaker with no load data begins cooling (fail-toward-recovery).
+        let open = BreakerRuntime {
+            phase: BreakerPhase::Open,
+            tripped_at: Some(t0()),
+            ..BreakerRuntime::default()
+        };
+        let (cooling, tr) = drive(&config, open, &[(None, t0())]);
+        assert_eq!(cooling.phase, BreakerPhase::CoolDown);
+        assert_eq!(tr[0].kind, TransitionKind::CoolingDown);
+    }
+
+    // --- Disabled ---------------------------------------------------------
+
+    #[test]
+    fn disabled_never_trips_or_suppresses() {
+        let config = HostBreakerConfig {
+            enabled: false,
+            ..cfg()
+        };
+        let (state, tr) = drive(
+            &config,
+            BreakerRuntime::default(),
+            &[
+                (Some(99.0), t0()),
+                (Some(99.0), t0()),
+                (Some(99.0), t0()),
+                (Some(99.0), t0()),
+            ],
+        );
+        assert_eq!(state.phase, BreakerPhase::Closed);
+        assert!(tr.is_empty());
+        assert_eq!(state.last_load_per_core, Some(99.0));
+    }
+
+    // --- SharedHostBreaker handle ----------------------------------------
+
+    #[test]
+    fn shared_handle_suppresses_only_when_open_or_cooldown() {
+        let breaker = SharedHostBreaker::new(cfg());
+        assert!(!breaker.is_suppressed(), "fresh breaker is Closed");
+
+        // Three sustained over-threshold observations trip it.
+        assert!(breaker.observe(Some(3.0), t0()).is_none());
+        assert!(breaker.observe(Some(3.0), t0()).is_none());
+        let trip = breaker.observe(Some(3.0), t0());
+        assert_eq!(trip.unwrap().kind, TransitionKind::Tripped);
+        assert!(breaker.is_suppressed(), "Open suppresses dispatch");
+
+        let snap = breaker.snapshot();
+        assert_eq!(snap.phase, BreakerPhase::Open);
+        assert!(snap.suppressed);
+        assert!(snap.tripped_at.is_some());
+        assert_eq!(snap.load_per_core_threshold, 2.5);
+
+        // Drop the load: CoolDown still suppresses.
+        breaker.observe(Some(0.1), t0());
+        assert!(breaker.is_suppressed(), "CoolDown still suppresses dispatch");
+        assert_eq!(breaker.snapshot().phase, BreakerPhase::CoolDown);
+    }
+
+    #[test]
+    fn disabled_shared_handle_reports_not_suppressed() {
+        let breaker = SharedHostBreaker::new(HostBreakerConfig {
+            enabled: false,
+            ..cfg()
+        });
+        for _ in 0..5 {
+            breaker.observe(Some(50.0), t0());
+        }
+        assert!(!breaker.is_suppressed());
+        assert!(!breaker.snapshot().suppressed);
+        assert_eq!(breaker.snapshot().phase, BreakerPhase::Closed);
+    }
+
+    #[test]
+    fn into_status_maps_fields() {
+        let breaker = SharedHostBreaker::new(cfg());
+        breaker.observe(Some(3.0), t0());
+        breaker.observe(Some(3.0), t0());
+        breaker.observe(Some(3.0), t0());
+        let status = breaker.snapshot().into_status();
+        assert_eq!(status.phase, "open");
+        assert!(status.suppressed);
+        assert!(status.enabled);
+        assert_eq!(status.load_per_core_threshold, 2.5);
+        assert_eq!(status.sustain_ticks, 3);
+        assert_eq!(status.cooldown_secs, 300);
+        assert!(status.reason.is_some());
+    }
+
+    // --- Config resolution ------------------------------------------------
+
+    #[test]
+    fn resolve_config_defaults_when_empty() {
+        let resolved = resolve_config(&HostBreakerConfigFile::default());
+        assert_eq!(resolved, HostBreakerConfig::default());
+        assert!(resolved.enabled, "breaker defaults ON (safety backstop)");
+    }
+
+    #[test]
+    fn resolve_config_uses_file_over_default() {
+        let file = HostBreakerConfigFile {
+            enabled: Some(false),
+            load_per_core_threshold: Some(4.0),
+            sustain_ticks: Some(5),
+            cooldown_secs: Some(600),
+        };
+        let resolved = resolve_config(&file);
+        assert!(!resolved.enabled);
+        assert_eq!(resolved.load_per_core_threshold, 4.0);
+        assert_eq!(resolved.sustain_ticks, 5);
+        assert_eq!(resolved.cooldown_secs, 600);
+    }
+}

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1328,7 +1328,8 @@ pub fn build_daemon_status(
         // auto-update global-snapshot pattern above. `None` (no breaker
         // registered — work-finder off or breaker disabled) reads as "inactive".
         host_breaker: crate::host_breaker::global_snapshot()
-            .map(crate::host_breaker::BreakerSnapshot::into_status),
+            .map(crate::host_breaker::BreakerSnapshot::into_status)
+            .map(Box::new),
     }
 }
 

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -2196,7 +2196,7 @@ fn handle_request(
                                 "dispatch_sweep refused: host circuit breaker is {} ({}).{releases} \
                                  Running work is draining and new dispatch is paused (#4235). \
                                  Re-run with force to override.",
-                                snap.phase,
+                                snap.phase.as_str(),
                                 snap.reason.as_deref().unwrap_or("sustained host distress"),
                             ),
                         };

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1323,6 +1323,12 @@ pub fn build_daemon_status(
         auto_update_backoff_secs: au.backoff_secs,
         auto_update_terminal_reason: au.terminal_reason,
         auto_update_note: au.note,
+        // Host-distress circuit breaker (#4235) — read from the process-global
+        // handle the work-finder loop registers/updates each tick, mirroring the
+        // auto-update global-snapshot pattern above. `None` (no breaker
+        // registered — work-finder off or breaker disabled) reads as "inactive".
+        host_breaker: crate::host_breaker::global_snapshot()
+            .map(crate::host_breaker::BreakerSnapshot::into_status),
     }
 }
 
@@ -2158,7 +2164,45 @@ fn handle_request(
             effort,
             depends_on,
             workspace_root,
+            force,
         } => {
+            // Host-distress circuit breaker (#4235): a *tripped* breaker
+            // represents SUSTAINED, already-observed host distress across
+            // multiple ticks — a materially stronger signal than the
+            // point-in-time headroom advisory below (which by #4234's deliberate
+            // design only *advises*, never blocks). Because the breaker's signal
+            // is stronger and stateful, it **hard-blocks** an explicit
+            // `dispatch_sweep` by default; an operator who truly wants to
+            // dispatch into a distressed host passes `force: true` to override.
+            // This is the one-sentence reconciliation the issue asks for: the
+            // breaker blocks where the headroom check advises *because* it fires
+            // only on proven, sustained distress, not a single-tick reading.
+            if !force {
+                if let Some(snap) = crate::host_breaker::global_snapshot() {
+                    if snap.suppressed {
+                        let releases = snap.releases_at.map_or_else(
+                            || " (host still hot — cool-down not yet started)".to_string(),
+                            |r| format!(" (cool-down releases at {r})"),
+                        );
+                        log::warn!(
+                            "dispatch_sweep: refused {kind:?} — host circuit breaker is {} \
+                             ({}){releases}; running work drains, new dispatch paused. \
+                             Re-run with force to override.",
+                            snap.phase.as_str(),
+                            snap.reason.as_deref().unwrap_or("sustained host distress"),
+                        );
+                        return Response::Error {
+                            message: format!(
+                                "dispatch_sweep refused: host circuit breaker is {} ({}).{releases} \
+                                 Running work is draining and new dispatch is paused (#4235). \
+                                 Re-run with force to override.",
+                                snap.phase,
+                                snap.reason.as_deref().unwrap_or("sustained host distress"),
+                            ),
+                        };
+                    }
+                }
+            }
             let target =
                 resolve_registry(sweep_registry, workspace_pool, workspace_root.as_deref());
             let mut sr = target.lock().expect("Sweep registry mutex poisoned");
@@ -3066,6 +3110,7 @@ exit 0
                     effort: None,
                     depends_on: None,
                     workspace_root: None,
+                    force: false,
                 },
                 &tm,
                 &db,
@@ -3149,6 +3194,7 @@ exit 0
                 effort: None,
                 depends_on: None,
                 workspace_root: Some(dir_b.path().to_string_lossy().into_owned()),
+                force: false,
             },
             &tm,
             &db,
@@ -3253,6 +3299,7 @@ exit 0
                 effort: None,
                 depends_on: None,
                 workspace_root: None,
+                force: false,
             },
             &tm,
             &db,
@@ -3331,6 +3378,7 @@ exit 0
                 effort: None,
                 depends_on: None,
                 workspace_root: None,
+                force: false,
             },
             &tm,
             &db,
@@ -3383,6 +3431,7 @@ exit 0
                 effort: None,
                 depends_on: None,
                 workspace_root: None,
+                force: false,
             },
             &tm,
             &db,
@@ -3418,6 +3467,7 @@ exit 0
                 effort,
                 depends_on: _,
                 workspace_root: _,
+                force: _,
             } => {
                 assert!(matches!(kind, SweepKind::Issue(42)));
                 assert!(idempotency_key.is_none());
@@ -3437,6 +3487,7 @@ exit 0
             effort: None,
             depends_on: None,
             workspace_root: None,
+            force: false,
         };
         let json = serde_json::to_string(&request).expect("serialize");
         let back: Request = serde_json::from_str(&json).expect("deserialize");
@@ -3448,6 +3499,7 @@ exit 0
                 effort,
                 depends_on: _,
                 workspace_root: _,
+                force: _,
             } => {
                 assert!(matches!(kind, SweepKind::Issue(7)));
                 assert_eq!(idempotency_key.as_deref(), Some("key-B"));
@@ -3467,6 +3519,7 @@ exit 0
             effort: None,
             depends_on: None,
             workspace_root: None,
+            force: false,
         };
         let json = serde_json::to_string(&request).expect("serialize");
         let back: Request = serde_json::from_str(&json).expect("deserialize");
@@ -3503,6 +3556,7 @@ exit 0
             effort: Some("xhigh".to_string()),
             depends_on: None,
             workspace_root: None,
+            force: false,
         };
         let json = serde_json::to_string(&request).expect("serialize");
         let back: Request = serde_json::from_str(&json).expect("deserialize");
@@ -3524,6 +3578,7 @@ exit 0
             effort: Some(String::new()),
             depends_on: None,
             workspace_root: None,
+            force: false,
         };
         let json = serde_json::to_string(&request).expect("serialize");
         let back: Request = serde_json::from_str(&json).expect("deserialize");
@@ -3563,6 +3618,7 @@ exit 0
             effort: None,
             depends_on: Some(3726),
             workspace_root: None,
+            force: false,
         };
         let json = serde_json::to_string(&request).expect("serialize");
         let back: Request = serde_json::from_str(&json).expect("deserialize");
@@ -3907,6 +3963,7 @@ exit 0
                 effort: None,
                 depends_on: None,
                 workspace_root: None,
+                force: false,
             },
             &tm,
             &db,
@@ -4062,6 +4119,7 @@ exit 0
             auto_update_backoff_secs: Some(120),
             auto_update_terminal_reason: None,
             auto_update_note: Some("within settle window".to_string()),
+            host_breaker: None,
         };
         let resp = Response::DaemonStatus(report);
         let json = serde_json::to_string(&resp).expect("serialize response");

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -28,6 +28,7 @@ pub mod forge_parser;
 pub mod git_parser;
 pub mod git_utils;
 pub mod health_monitor;
+pub mod host_breaker;
 pub mod init;
 pub mod ipc;
 pub mod issue_creation_mutex;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -7,6 +7,7 @@ use loom_daemon::daemon_install_state::{self, InstallStateReport};
 use loom_daemon::epic_supervisor;
 use loom_daemon::event_bus::EventBus;
 use loom_daemon::health_monitor;
+use loom_daemon::host_breaker;
 use loom_daemon::ipc::IpcServer;
 use loom_daemon::main_health_gate;
 use loom_daemon::metrics_collector;
@@ -188,6 +189,12 @@ enum Commands {
         /// branch.
         #[arg(long, value_name = "P")]
         depends_on: Option<u32>,
+
+        /// Override the host-distress circuit breaker (Issue #4235). By default a
+        /// *tripped* breaker (sustained host distress) refuses an explicit
+        /// dispatch; pass `--force` to dispatch anyway.
+        #[arg(long)]
+        force: bool,
     },
 
     /// Manage durable operator watches on issue/PR terminal state (Issue #3971).
@@ -672,7 +679,8 @@ async fn main() -> Result<()> {
                 model,
                 effort,
                 depends_on,
-            } => handle_dispatch_command(issue, workspace, model, effort, depends_on).await,
+                force,
+            } => handle_dispatch_command(issue, workspace, model, effort, depends_on, force).await,
             // `watch` connects to the running daemon over its Unix socket to
             // register/list/remove durable watches (Issue #3971).
             Commands::Watch { action } => handle_watch_command(action).await,
@@ -1162,6 +1170,26 @@ async fn main() -> Result<()> {
         // config as the gate's master switch (env > config > default(on)).
         let suppress_dispatch_during_gate = main_health_gate::resolve_suppress_dispatch_during_gate(
             &main_health_gate::read_autonomous_gate_config(&sweep_workspace),
+        );
+        // Host-distress circuit breaker (#4235): resolve its config once at
+        // startup (env > config > default, default-ON) from the daemon's primary
+        // workspace and register the process-global handle. The work-finder loop
+        // (spawned just below) samples load-per-core into it each tick and
+        // consults it as a second dispatch suppressor; `loom-daemon status` and
+        // the `dispatch_sweep` IPC handler read it via the same global. Registered
+        // only when the work-finder is enabled, since the loop is the breaker's
+        // sole sampler — a daemon with no work-finder never trips it (and its
+        // dispatch_sweep sees a Closed/absent breaker: zero behavior change).
+        let host_breaker_config = host_breaker::resolve_config_for(&sweep_workspace);
+        host_breaker::register_global(std::sync::Arc::new(host_breaker::SharedHostBreaker::new(
+            host_breaker_config,
+        )));
+        log::info!(
+            "host_breaker: enabled={} (load_per_core_trip={:.2}, sustain_ticks={}, cooldown_secs={})",
+            host_breaker_config.enabled,
+            host_breaker_config.load_per_core_threshold,
+            host_breaker_config.sustain_ticks,
+            host_breaker_config.cooldown_secs,
         );
         log::info!(
             "work_finder: enabled (multi-workspace, interval={}s, configured_max={configured_max}, \
@@ -2407,6 +2435,7 @@ fn build_dispatch_request(
     model: Option<String>,
     effort: Option<String>,
     depends_on: Option<u32>,
+    force: bool,
 ) -> Request {
     Request::DispatchSweep {
         kind: SweepKind::Issue(issue),
@@ -2417,6 +2446,9 @@ fn build_dispatch_request(
         effort,
         depends_on,
         workspace_root: workspace,
+        // Host-distress circuit-breaker override (#4235): default false, so a
+        // tripped breaker refuses the dispatch unless the operator passes --force.
+        force,
     }
 }
 
@@ -2431,9 +2463,10 @@ async fn handle_dispatch_command(
     model: Option<String>,
     effort: Option<String>,
     depends_on: Option<u32>,
+    force: bool,
 ) -> Result<()> {
     let socket_path = resolve_socket_path()?;
-    let request = build_dispatch_request(issue, workspace, model, effort, depends_on);
+    let request = build_dispatch_request(issue, workspace, model, effort, depends_on, force);
     let ack_timeout = resolve_dispatch_ack_timeout();
 
     match query_daemon_bounded(&socket_path, &request, ack_timeout).await {
@@ -2974,6 +3007,22 @@ fn print_status_json(
             "terminal_reason": report.auto_update_terminal_reason,
             "note": report.auto_update_note,
         },
+        // Host-distress circuit breaker (#4235) — `null` when no breaker is
+        // registered (work-finder off / breaker disabled). Otherwise the current
+        // phase (closed/open/cooldown), why it tripped, and the cool-down
+        // release time so a scripted consumer sees a paused-dispatch host.
+        "host_breaker": report.host_breaker.as_ref().map(|h| serde_json::json!({
+            "enabled": h.enabled,
+            "phase": h.phase,
+            "suppressed": h.suppressed,
+            "reason": h.reason,
+            "tripped_at": h.tripped_at,
+            "releases_at": h.releases_at,
+            "last_load_per_core": h.last_load_per_core,
+            "load_per_core_threshold": h.load_per_core_threshold,
+            "sustain_ticks": h.sustain_ticks,
+            "cooldown_secs": h.cooldown_secs,
+        })),
     });
     println!("{}", serde_json::to_string_pretty(&combined)?);
     Ok(())
@@ -3350,6 +3399,55 @@ fn print_status_human(
         println!("Drain: DRAINING ({} sweep(s) remaining, {deadline})", report.in_flight.len());
     } else if let Some(note) = &report.drain_note {
         println!("Drain: not draining (last: {note})");
+    }
+
+    // Host-distress circuit breaker (#4235): surface the phase, why it tripped,
+    // and when the cool-down releases so an operator sees a paused-dispatch host
+    // and can tell it apart from a main-health halt or a drain. A Closed breaker
+    // prints a one-line "OK" with its configured thresholds; an absent breaker
+    // (work-finder off / disabled) prints nothing.
+    if let Some(hb) = &report.host_breaker {
+        let load = hb
+            .last_load_per_core
+            .map_or_else(|| "n/a".to_string(), |l| format!("{l:.2}"));
+        match hb.phase.as_str() {
+            "closed" => {
+                if hb.enabled {
+                    println!(
+                        "Host breaker: OK (closed; load/core {load}, trip ≥ {:.2} for {} tick(s), cooldown {}s)",
+                        hb.load_per_core_threshold, hb.sustain_ticks, hb.cooldown_secs
+                    );
+                } else {
+                    println!("Host breaker: disabled");
+                }
+            }
+            "open" => {
+                println!(
+                    "Host breaker: OPEN — new dispatch paused, running work draining ({})",
+                    hb.reason.as_deref().unwrap_or("sustained host distress")
+                );
+                if let Some(t) = hb.tripped_at {
+                    println!("  tripped at: {t}");
+                }
+            }
+            "cooldown" => {
+                let releases = hb.releases_at.map_or_else(
+                    || "unknown".to_string(),
+                    |r| {
+                        let secs = (r - Utc::now()).num_seconds();
+                        if secs >= 0 {
+                            format!("in {secs}s ({r})")
+                        } else {
+                            format!("overdue by {}s ({r})", -secs)
+                        }
+                    },
+                );
+                println!(
+                    "Host breaker: COOLING DOWN — dispatch paused, releases {releases} (load/core {load})"
+                );
+            }
+            other => println!("Host breaker: {other}"),
+        }
     }
 
     // Per-repo breakdown across every registered managed workspace (#3930). In
@@ -4621,6 +4719,7 @@ mod dispatch_tests {
             Some("sonnet".to_string()),
             Some("high".to_string()),
             Some(3945),
+            true,
         );
         match request {
             Request::DispatchSweep {
@@ -4630,6 +4729,7 @@ mod dispatch_tests {
                 effort,
                 depends_on,
                 workspace_root,
+                force,
             } => {
                 assert_eq!(kind, SweepKind::Issue(3952));
                 assert_eq!(idempotency_key, None);
@@ -4637,6 +4737,7 @@ mod dispatch_tests {
                 assert_eq!(effort.as_deref(), Some("high"));
                 assert_eq!(depends_on, Some(3945));
                 assert_eq!(workspace_root.as_deref(), Some("/some/repo"));
+                assert!(force, "--force must plumb through to the request");
             }
             other => panic!("expected DispatchSweep, got {other:?}"),
         }
@@ -4646,7 +4747,7 @@ mod dispatch_tests {
     /// every override `None`, so the daemon applies its own defaults.
     #[test]
     fn build_dispatch_request_defaults_are_none() {
-        let request = build_dispatch_request(42, None, None, None, None);
+        let request = build_dispatch_request(42, None, None, None, None, false);
         match request {
             Request::DispatchSweep {
                 kind,
@@ -4654,6 +4755,7 @@ mod dispatch_tests {
                 effort,
                 depends_on,
                 workspace_root,
+                force,
                 ..
             } => {
                 assert_eq!(kind, SweepKind::Issue(42));
@@ -4661,6 +4763,7 @@ mod dispatch_tests {
                 assert!(effort.is_none());
                 assert!(depends_on.is_none());
                 assert!(workspace_root.is_none());
+                assert!(!force, "force defaults to false");
             }
             other => panic!("expected DispatchSweep, got {other:?}"),
         }
@@ -4718,6 +4821,7 @@ mod dispatch_tests {
             Some("sonnet".to_string()),
             Some("high".to_string()),
             Some(3945),
+            false,
         );
         let response = query_daemon_bounded(&socket_path, &request, Duration::from_secs(5))
             .await
@@ -4757,7 +4861,7 @@ mod dispatch_tests {
             tokio::time::sleep(Duration::from_secs(30)).await;
         });
 
-        let request = build_dispatch_request(3952, None, None, None, None);
+        let request = build_dispatch_request(3952, None, None, None, None, false);
         let started = std::time::Instant::now();
         let result = query_daemon_bounded(&socket_path, &request, Duration::from_millis(200)).await;
         let elapsed = started.elapsed();
@@ -4778,7 +4882,7 @@ mod dispatch_tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let socket_path = dir.path().join("nonexistent.sock");
 
-        let request = build_dispatch_request(3952, None, None, None, None);
+        let request = build_dispatch_request(3952, None, None, None, None, false);
         let result = query_daemon_bounded(&socket_path, &request, Duration::from_millis(500)).await;
 
         assert!(result.is_err(), "expected a connect error, got {result:?}");
@@ -4824,7 +4928,7 @@ mod dispatch_tests {
             writer.flush().await.expect("flush");
         });
 
-        let request = build_dispatch_request(3952, None, None, None, None);
+        let request = build_dispatch_request(3952, None, None, None, None, false);
         let started = std::time::Instant::now();
         // Use the CLI's real default budget — the exact value a plain
         // `loom-daemon dispatch` resolves to with no env override.

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -1062,9 +1062,12 @@ pub struct DaemonStatusReport {
     /// breaker is enabled); `None` when no breaker is active — which the status
     /// renderer treats as "breaker inactive", the zero-behavior-change baseline.
     /// `#[serde(default)]` keeps pre-#4235 wire data / older clients compatible
-    /// (an absent field parses as `None`).
+    /// (an absent field parses as `None`). Boxed (`clippy::large_enum_variant`):
+    /// `HostBreakerStatus` is the field that tips `Response::DaemonStatus` past
+    /// the second-largest variant, and the indirection is the cheapest fix (one
+    /// heap alloc on an already-rare, human-latency status round-trip).
     #[serde(default)]
-    pub host_breaker: Option<HostBreakerStatus>,
+    pub host_breaker: Option<Box<HostBreakerStatus>>,
 }
 
 /// Host-distress circuit-breaker snapshot for `loom-daemon status` (Issue

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -181,6 +181,17 @@ pub enum Request {
         /// workspace registry is used, exactly as before.
         #[serde(default)]
         workspace_root: Option<String>,
+        /// Operator override for the host-distress circuit breaker (Issue
+        /// #4235). A *tripped* breaker represents **sustained**, already-observed
+        /// host distress — a stronger signal than the point-in-time headroom
+        /// advisory — so it **hard-blocks** an explicit `dispatch_sweep` by
+        /// default (distinct from the deliberately-advisory headroom check, which
+        /// never blocks). `force: true` is the operator saying "I know the host
+        /// is distressed, dispatch anyway" and bypasses that block. When `false`
+        /// (or absent on the wire — `#[serde(default)]` keeps existing clients
+        /// byte-for-byte compatible) a tripped breaker refuses the dispatch.
+        #[serde(default)]
+        force: bool,
     },
     /// List tracked sweeps, optionally filtered by state.
     ListSweeps {
@@ -1046,6 +1057,50 @@ pub struct DaemonStatusReport {
     /// `#[serde(default)]` keeps pre-#4055 wire data compatible.
     #[serde(default)]
     pub auto_update_note: Option<String>,
+    /// Host-distress circuit-breaker state (Issue #4235). `Some` when a breaker
+    /// has been registered this process (the work-finder loop is running and the
+    /// breaker is enabled); `None` when no breaker is active — which the status
+    /// renderer treats as "breaker inactive", the zero-behavior-change baseline.
+    /// `#[serde(default)]` keeps pre-#4235 wire data / older clients compatible
+    /// (an absent field parses as `None`).
+    #[serde(default)]
+    pub host_breaker: Option<HostBreakerStatus>,
+}
+
+/// Host-distress circuit-breaker snapshot for `loom-daemon status` (Issue
+/// #4235). Rendered from [`crate::host_breaker::BreakerSnapshot`]. The
+/// `daemon.host_breaker.state` event carries the same transition data on every
+/// phase change; this is the point-in-time status view.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HostBreakerStatus {
+    /// Whether the breaker is enabled (default ON — a safety backstop).
+    pub enabled: bool,
+    /// The current phase: `"closed"`, `"open"`, or `"cooldown"`.
+    pub phase: String,
+    /// Whether the breaker is currently suppressing new dispatch (Open or
+    /// CoolDown).
+    pub suppressed: bool,
+    /// Human-readable reason for the current non-Closed state; `None` while
+    /// Closed.
+    #[serde(default)]
+    pub reason: Option<String>,
+    /// When the breaker last tripped to Open; `None` while Closed.
+    #[serde(default)]
+    pub tripped_at: Option<DateTime<Utc>>,
+    /// When the current cool-down completes and normal dispatch resumes; `None`
+    /// outside CoolDown.
+    #[serde(default)]
+    pub releases_at: Option<DateTime<Utc>>,
+    /// The most recent load-per-core sample observed; `None` when no
+    /// load-average source is available.
+    #[serde(default)]
+    pub last_load_per_core: Option<f64>,
+    /// The configured load-per-core trip threshold.
+    pub load_per_core_threshold: f64,
+    /// The configured number of consecutive over-threshold ticks needed to trip.
+    pub sustain_ticks: u32,
+    /// The configured cool-down window, in seconds.
+    pub cooldown_secs: u64,
 }
 
 /// A live-locked sweep with no matching [`DaemonStatusReport::in_flight`] entry

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -1363,8 +1363,20 @@ where
             // dispatched into the same root the gate's own build is competing
             // with for cores — the `suppress_dispatch_during_gate` knob (default
             // on) gates this so the pre-#4084 behavior is exactly recoverable.
+            // Host-distress circuit breaker (#4235): sample load-per-core, fold
+            // it into the breaker, and consult it as a second dispatch
+            // suppressor alongside the main-health halt flag and the gate
+            // in-flight hold. See the multi-workspace loop for the full
+            // rationale; when no breaker is registered these are no-ops.
+            if let Some(breaker) = crate::host_breaker::global() {
+                let load_per_core = crate::cpu_headroom::load_per_core();
+                if let Some(transition) = breaker.observe(load_per_core, chrono::Utc::now()) {
+                    crate::host_breaker::emit_transition_event(&event_bus, &transition);
+                }
+            }
             let halted = health_state.is_halted()
-                || (suppress_dispatch_during_gate && health_state.is_gate_in_flight());
+                || (suppress_dispatch_during_gate && health_state.is_gate_in_flight())
+                || crate::host_breaker::global_is_suppressed();
             // Recompute the dynamic cap from live inputs every tick (Phase B),
             // now with token-capacity backpressure (#3902): the token axis is the
             // count of *healthy* accounts from the ranking, not the flat pool.
@@ -1607,12 +1619,30 @@ pub fn spawn_multi_work_finder_task(
             // regardless of gate state, and a gate in flight holds its own root
             // regardless of drain state.
             let draining = drain.load(std::sync::atomic::Ordering::Relaxed);
-            let halted = dispatch_held_per_root_with_drain(
+            // Host-distress circuit breaker (#4235): sample the current
+            // load-per-core and fold it into the breaker's state machine. A
+            // tripped/cooling breaker is a *daemon-global* dispatch suppressor
+            // (like the scheduled drain) — it holds new dispatch in EVERY repo
+            // while running work drains — so it is OR'd onto every root's hold
+            // below. The load sample uses the fast, non-sleeping loadavg read (no
+            // `iostat`), safe to call inline. When no breaker is registered the
+            // helpers are no-ops returning `false` (zero behavior change).
+            if let Some(breaker) = crate::host_breaker::global() {
+                let load_per_core = crate::cpu_headroom::load_per_core();
+                if let Some(transition) = breaker.observe(load_per_core, chrono::Utc::now()) {
+                    crate::host_breaker::emit_transition_event(&event_bus, &transition);
+                }
+            }
+            let breaker_suppressed = crate::host_breaker::global_is_suppressed();
+            let halted: Vec<bool> = dispatch_held_per_root_with_drain(
                 &health_states,
                 &roots,
                 suppress_dispatch_during_gate,
                 draining,
-            );
+            )
+            .into_iter()
+            .map(|h| h || breaker_suppressed)
+            .collect();
             let any_halted = halted.iter().any(|&h| h);
 
             let mut pairs: Vec<(GhWorkSource, RegistryDispatcher)> = roots

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -2664,6 +2664,85 @@ exit 0
     }
 
     #[test]
+    fn test_tripped_host_breaker_suppresses_tick_without_aborting_running_work() {
+        // The host-distress circuit breaker (#4235) is consulted at the tick
+        // choke point by folding its `is_suppressed()` into the same `halted`
+        // bool the main-health gate uses. This proves the two load-bearing
+        // properties end-to-end: a *tripped* breaker dispatches ZERO new sweeps,
+        // and the running (in-flight) sweeps are left untouched — drain, don't
+        // abort.
+        use crate::host_breaker::{BreakerPhase, HostBreakerConfig, SharedHostBreaker};
+        let now = chrono::Utc::now();
+        let breaker = SharedHostBreaker::new(HostBreakerConfig {
+            enabled: true,
+            load_per_core_threshold: 2.5,
+            sustain_ticks: 3,
+            cooldown_secs: 300,
+        });
+        // Not yet tripped: the breaker does not suppress, so a tick dispatches.
+        assert!(!breaker.is_suppressed());
+
+        // Three sustained over-threshold samples trip it to Open.
+        breaker.observe(Some(4.0), now);
+        breaker.observe(Some(4.0), now);
+        breaker.observe(Some(4.0), now);
+        assert_eq!(breaker.snapshot().phase, BreakerPhase::Open);
+        assert!(breaker.is_suppressed(), "tripped breaker suppresses dispatch");
+
+        // Feed the breaker's suppression into the tick's `halted` input, exactly
+        // as the work-finder loop does.
+        let mut source = FakeSource::once((1..=5).map(issue).collect());
+        let mut disp = RecordingDispatcher {
+            in_flight: HashSet::from([100, 101]),
+            ..Default::default()
+        };
+        let halted = breaker.is_suppressed();
+        let report = tick(&mut source, &mut disp, 10, halted).unwrap();
+
+        assert!(report.halted, "a tripped breaker halts the tick");
+        assert_eq!(report.seen, 5, "backlog is still observed");
+        assert_eq!(report.dispatched, 0, "zero new dispatch while the breaker is open");
+        assert!(disp.dispatched.is_empty(), "no new sweeps started");
+        // Drain, don't abort: the two running sweeps are untouched.
+        assert_eq!(disp.in_flight, HashSet::from([100, 101]));
+    }
+
+    #[test]
+    fn test_host_breaker_cooldown_release_resumes_dispatch() {
+        // After the breaker cools down and releases, the tick resumes dispatch —
+        // the "cool-down release" half of the Test Plan, driven through the same
+        // `halted`-composition path the loop uses.
+        use crate::host_breaker::{BreakerPhase, HostBreakerConfig, SharedHostBreaker};
+        let t0 = chrono::Utc::now();
+        let breaker = SharedHostBreaker::new(HostBreakerConfig {
+            enabled: true,
+            load_per_core_threshold: 2.5,
+            sustain_ticks: 3,
+            cooldown_secs: 300,
+        });
+        // Trip → Open.
+        for _ in 0..3 {
+            breaker.observe(Some(4.0), t0);
+        }
+        assert!(breaker.is_suppressed());
+        // Load drops → CoolDown (still suppressed).
+        breaker.observe(Some(0.1), t0 + chrono::Duration::seconds(10));
+        assert_eq!(breaker.snapshot().phase, BreakerPhase::CoolDown);
+        assert!(breaker.is_suppressed(), "cool-down still suppresses");
+        // Cool-down elapses with acceptable load → Closed, dispatch resumes.
+        breaker.observe(Some(0.1), t0 + chrono::Duration::seconds(400));
+        assert_eq!(breaker.snapshot().phase, BreakerPhase::Closed);
+        assert!(!breaker.is_suppressed());
+
+        let mut source = FakeSource::once((1..=3).map(issue).collect());
+        let mut disp = RecordingDispatcher::default();
+        let report = tick(&mut source, &mut disp, 10, breaker.is_suppressed()).unwrap();
+        assert!(!report.halted);
+        assert_eq!(report.dispatched, 3, "dispatch resumes once the breaker releases");
+        assert_eq!(disp.dispatched, vec![1, 2, 3]);
+    }
+
+    #[test]
     fn test_tick_resumes_dispatch_once_halt_cleared() {
         // Same source shape: halted ⇒ zero, then not halted ⇒ dispatches.
         let mut source = FakeSource::once((1..=3).map(issue).collect());


### PR DESCRIPTION
## Summary

Adds a stateful circuit breaker (`loom-daemon/src/host_breaker.rs`) that trips on
*sustained* host load-per-core, pauses new work-finder dispatch while draining
(never killing) running sweeps, and only resumes after a cool-down — the
adaptive layer identified as missing in the 2026-07-27→28 host meltdown (#4231
item 4). Point-in-time checks (CPU headroom #3978, per-tick admission gate
#4234) each re-evaluate fresh every tick, so a transient load dip immediately
re-admits a full wave; this breaker remembers the incident across ticks.

## Changes

- **`host_breaker.rs`** (new module): pure `step()` decide function over an
  immutable `BreakerRuntime` + observation + timestamp (mirrors
  `quarantine_reconciliation`'s decide/plan split for unit-testability),
  `Closed -> Open -> CoolDown -> Closed` state machine, `SharedHostBreaker`
  interior-mutable handle, config resolution (env > config > default) under
  `autonomous.hostBreaker` / `LOOM_HOST_BREAKER*`.
- **`work_finder.rs`**: consult the breaker as a second dispatch suppressor
  alongside the existing main-health halt flag and the #4286 admission ramp
  cap, at the same tick choke points; feed per-tick load samples; emit a
  state-change-deduped `daemon.host_breaker.state` `Event::Generic` on
  transitions (precedented by #4286's `headroom_advisory` event, so no new
  taxonomy topic needed).
- **`cpu_headroom.rs`**: expose the sampled load-per-core for the breaker to
  consume.
- **`ipc.rs`**: surface breaker state in `loom-daemon status`; explicit
  `dispatch_sweep` now **hard-blocks** while the breaker is Open/CoolDown
  (`force: true` overrides) — a deliberate reconciliation against #4286's
  headroom advisory, which only *advises* and never blocks: the breaker's
  signal is stronger because it is proven, *sustained* distress across
  multiple ticks, not a single-tick reading.
- **`types.rs`**: `DaemonStatusReport.host_breaker: Option<Box<HostBreakerStatus>>`
  (boxed — see fix commit below) plus the config knobs.
- **`defaults/docs/daemon-reference.md`**: documents the breaker, its knobs,
  and how to read/clear its state via `loom-daemon status`.

Config (env > config > default, mirroring the quarantine knobs' naming style):

| Knob | Env | Config | Default |
|---|---|---|---|
| Enabled | `LOOM_HOST_BREAKER` | `autonomous.hostBreaker.enabled` | `true` (default-**on** safety backstop, same call as the insta-crash quarantine) |
| Trip threshold | `LOOM_HOST_BREAKER_LOAD_PER_CORE` | `autonomous.hostBreaker.loadPerCore` | `2.5` |
| Sustain ticks | `LOOM_HOST_BREAKER_SUSTAIN_TICKS` | `autonomous.hostBreaker.sustainTicks` | `3` |
| Cool-down (s) | `LOOM_HOST_BREAKER_COOLDOWN_SECS` | `autonomous.hostBreaker.cooldownSecs` | `300` |

Default-on rationale (stated per the issue's request): unlike the work-finder
itself (default-off, opt-in), the breaker is only ever sampled from inside the
work-finder loop, so a repo that never enables autonomy sees zero behavior
change; a repo that does gets the meltdown backstop for free.

**Post-verification fix commit**: `cargo clippy` flagged
`clippy::large_enum_variant` — the new `host_breaker` field pushed
`Response::DaemonStatus` to 576 bytes vs. 272 for the next-largest variant.
Boxed just the new field (`Option<Box<HostBreakerStatus>>`) rather than the
whole `DaemonStatusReport` variant, keeping the fix local to this PR's own
surface.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Breaker trips only after N sustained over-threshold ticks (single spike doesn't trip) | Yes | `host_breaker::tests::single_spike_does_not_trip`, `trips_after_sustain_ticks`, `does_not_trip_one_tick_early` |
| Open breaker suppresses work-finder dispatch; running sweeps drain, not aborted | Yes | `host_breaker::tests::shared_handle_suppresses_only_when_open_or_cooldown`; `work_finder::tests::test_tripped_host_breaker_suppresses_tick_without_aborting_running_work` |
| Cool-down release; a still-hot host re-trips immediately | Yes | `host_breaker::tests::cooldown_releases_after_window`, `still_hot_host_re_trips_during_cooldown`, `open_stays_open_while_hot_then_cools_down`; `work_finder::tests::test_host_breaker_cooldown_release_resumes_dispatch` |
| Status output reflects closed/open/cool-down with reason and timestamps | Yes | `host_breaker::tests::into_status_maps_fields`; `loom-daemon status` renderer in `main.rs` |
| Manual: synthetic load trips the breaker on a dev host; release after cool-down | Deferred | Covered by the unit-level state-machine tests above (decide/plan split is host-independent by design); not re-verified with a live `yes` burner in this verification pass |

Local verification (this pass, after rebasing onto latest `origin/main`):
- `cargo build` — clean
- `cargo test --workspace --lib --bins` (the repo's actual local quality gate per `.loom/docs/build-gate.md`) — **1531 + 21 passed, 0 failed** (confirmed twice; one run hit an unrelated one-off flake in `disk_headroom::tests::test_worktree_root_free_gb_returns_a_value`, `df -Pk` on a busy host — passes standalone and on the immediate rerun, and the file is untouched by this branch)
- `cargo clippy --workspace --all-targets` — clean (after the boxing fix above)
- `cargo fmt --all -- --check` — clean
- `loom-daemon/tests/integration_basic.rs` (a different test target) fails with "Daemon failed to create socket within 5s" on this host — this is the documented environment-sensitive integration-test class excluded from the local gate (`.loom/docs/build-gate.md` → "Local gate vs. CI (#3985)"); CI's `cargo test --workspace` (all targets, controlled runner) still exercises it.

## Test Plan

- `cargo test --workspace --lib --bins` in `loom-daemon/`
- Targeted: `cargo test host_breaker` — 16 unit tests + 2 `work_finder` integration tests, all passing

Closes #4235
