### PR TITLE
fix(tokens): anchor loom-daemon status to the daemon's own resolved pool dir

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -476,6 +476,45 @@ instead; without `--force` a rolled token is reported as drift and left alone,
 and the command exits `2`. See "Importing live tokens from claude-monitor" in
 the root `CLAUDE.md` for the full behavior.
 
+### `status` reports the resolved pool directory, not a cwd-derived guess (#4292)
+
+Every surface that reads or writes the token pool — `loom-daemon status`, `tokens
+select` / `check` / `pin` / `unpin` / `unblock` / `mark-bad`, and the daemon's own
+token-ranking self-refresh loop (`autonomous.tokenRankingRefresh`, above) —
+resolves through the **same** precedence (env override `LOOM_SHARED_TOKENS_DIR`
+disables/redirects the shared fallback; otherwise per-repo
+`<workspace>/.loom/tokens/` wins when it holds `*.token` files, else the shared
+`~/.loom/tokens/`). Before #4292, `loom-daemon status` computed its per-token usage
+table **client-side** from the invoking process's own `cwd`
+(`resolve_tokens_workspace(".")`), independently of the pool directory the
+*daemon* itself resolved for `token_pool_size` / the dynamic-cap accounting.
+Running `status` from a different repo checkout than the daemon's own primary
+workspace could therefore report a false token picture (e.g. `0/0 healthy`) even
+though the daemon's own pool was perfectly healthy.
+
+The `DaemonStatusReport` now carries `token_pool_dir` — the exact directory the
+daemon resolved server-side — and `status` prints it (`pool: <dir>` in the human
+view, `dynamic_cap.token_pool_dir` in `--json`) and probes per-token usage against
+*that* directory instead of re-deriving one from the CLI's own cwd. The net effect:
+**`loom-daemon status` reports the same token picture no matter which directory it
+is run from** — it always describes the daemon's actual pool, never a client-side
+guess. `token_pool_dir` is `null` only when talking to a pre-#4292 daemon binary.
+
+**systemd note.** `loom-daemon-start.sh`'s generated unit (#4260/#4268) always sets
+`WorkingDirectory=` to a real resolved repo root (`LOOM_MACHINE_CHECKOUT` in
+machine mode, else `find_repo_root()`), so the daemon's primary workspace is never
+an incidental cwd when started that way. A **hand-rolled** unit that omits
+`WorkingDirectory=` starts with whatever cwd the service manager happens to use
+(often `~`) as the primary workspace instead. Since the per-repo pool for that
+workspace is `<cwd>/.loom/tokens/`, an operator who then bootstraps the
+machine-level pool via plain `loom-tokens bootstrap` from an **arbitrary**
+directory (not `~`, not a real repo checkout) will *not* populate the location the
+daemon resolves to by default. Always provision with `loom-tokens bootstrap
+--shared` (or `import-from-monitor --shared`) — which always targets
+`~/.loom/tokens/` regardless of cwd — so the daemon's default (cwd-anchored,
+falling back to shared) and the provisioning step agree, whether or not the unit
+that starts the daemon sets `WorkingDirectory=`.
+
 ## Per-repo status breakdown + per-repo main-health gate (#3930 — phase d)
 
 Phase d is the final phase of the multi-repo daemon (#3926/#3835). Phases b/c

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -864,7 +864,7 @@ async fn handle_client(
                 &credential_preflight,
                 &drain_state,
             );
-            let response = Response::DaemonStatus(report);
+            let response = Response::DaemonStatus(Box::new(report));
             let response_json = serde_json::to_string(&response)?;
             writer.write_all(response_json.as_bytes()).await?;
             writer.write_all(b"\n").await?;
@@ -1218,6 +1218,11 @@ pub fn build_daemon_status(
     // `workspace_root`, i.e. `fallback_root`).
     let workspace_root = fallback_root;
     let token_pool_size = crate::tokens::token_pool_size(workspace_root);
+    // Same precedence as `token_pool_size` (per-repo first, else the #3938
+    // shared machine-level pool), exposed on the report (#4292) so a client
+    // reading `status` from any cwd sees exactly which directory the daemon
+    // used rather than silently re-resolving a possibly-different one.
+    let token_pool_dir = Some(crate::tokens_pool::paths::resolve_tokens_dir(workspace_root));
     let disk_headroom = crate::disk_headroom::disk_headroom_limit(workspace_root);
     // Hoisted above the CPU snapshot (#4032) so the resolved
     // `cpuUtilizationTarget` / `estCoresPerSweep` knobs can feed it — this read
@@ -1282,6 +1287,7 @@ pub fn build_daemon_status(
         in_flight,
         unregistered_locked,
         token_pool_size,
+        token_pool_dir,
         disk_headroom,
         cpu_headroom,
         logical_cpus,
@@ -4018,6 +4024,7 @@ exit 0
             in_flight: vec![],
             unregistered_locked: vec![],
             token_pool_size: 4,
+            token_pool_dir: Some(std::path::PathBuf::from("/repo/a/.loom/tokens")),
             disk_headroom: 10,
             cpu_headroom: 6,
             logical_cpus: 8,
@@ -4063,12 +4070,16 @@ exit 0
             auto_update_terminal_reason: None,
             auto_update_note: Some("within settle window".to_string()),
         };
-        let resp = Response::DaemonStatus(report);
+        let resp = Response::DaemonStatus(Box::new(report));
         let json = serde_json::to_string(&resp).expect("serialize response");
         let back: Response = serde_json::from_str(&json).expect("deserialize response");
         match back {
             Response::DaemonStatus(r) => {
                 assert_eq!(r.token_pool_size, 4);
+                assert_eq!(
+                    r.token_pool_dir,
+                    Some(std::path::PathBuf::from("/repo/a/.loom/tokens"))
+                );
                 assert_eq!(r.disk_headroom, 10);
                 assert_eq!(r.cpu_headroom, 6);
                 assert_eq!(r.logical_cpus, 8);

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -1955,7 +1955,10 @@ async fn query_daemon_status(socket_path: &Path) -> Result<DaemonStatusReport> {
             .ok_or_else(|| anyhow!("daemon closed the connection without responding"))?;
         let response: Response = serde_json::from_str(&line)?;
         match response {
-            Response::DaemonStatus(report) => Ok(report),
+            // `Response::DaemonStatus` is boxed (issue #4292); unbox here so
+            // this function's `Result<DaemonStatusReport>` signature (and its
+            // one caller's field accesses) stays unchanged.
+            Response::DaemonStatus(report) => Ok(*report),
             Response::Error { message } => Err(anyhow!("daemon error: {message}")),
             other => Err(anyhow!("unexpected response: {other:?}")),
         }
@@ -2494,15 +2497,30 @@ async fn handle_dispatch_command(
 /// the probe code is already linked into this binary, so there is no reason
 /// to pay a subprocess round-trip the way the historical `loom-tokens` /
 /// `python3 -m` two-tier shell-out did. Best-effort — never panics, never
-/// propagates an error, and returns `None` when the workspace can't be
-/// resolved so the status view still renders without the usage table.
-fn collect_token_usage() -> Option<serde_json::Value> {
+/// propagates an error.
+///
+/// `tokens_dir` is the pool directory to probe — pass the daemon's own
+/// [`DaemonStatusReport::token_pool_dir`] (issue #4292), not a directory
+/// re-resolved from this *client* process's own cwd. Before #4292 this probed
+/// `resolve_tokens_workspace(".")` independently, so `loom-daemon status` run
+/// from a directory other than the daemon's own workspace could report a
+/// stale/false (e.g. 0/0 healthy) token picture even though the *daemon*
+/// itself had a perfectly healthy pool — the CLI and the daemon disagreed on
+/// which pool "the" pool was. Falling back to `None` only when the daemon
+/// report predates #4292 keeps the pre-existing cwd-based behavior for that
+/// one legacy case (an old daemon binary talking to a newer CLI).
+fn collect_token_usage(tokens_dir: Option<&Path>) -> Option<serde_json::Value> {
     use loom_daemon::tokens_pool::check::{
         self, CheckOptions, CurlTransport, DEFAULT_PROBE_MODEL, DEFAULT_PROBE_PROMPT,
     };
 
-    let ws = resolve_tokens_workspace(".").ok()?;
-    let tokens_dir = loom_daemon::tokens_pool::paths::resolve_tokens_dir(&ws);
+    let tokens_dir = match tokens_dir {
+        Some(dir) => dir.to_path_buf(),
+        None => {
+            let ws = resolve_tokens_workspace(".").ok()?;
+            loom_daemon::tokens_pool::paths::resolve_tokens_dir(&ws)
+        }
+    };
 
     let opts = CheckOptions {
         source: check::resolve_source(None),
@@ -2552,8 +2570,10 @@ async fn handle_status_command(json: bool, pipeline: bool) -> Result<()> {
     };
 
     // Per-token usage is a slow per-account network probe the daemon deliberately
-    // does NOT perform inside the IPC handler; collect it client-side here.
-    let token_usage = collect_token_usage();
+    // does NOT perform inside the IPC handler; collect it client-side here —
+    // but against the SAME pool directory the daemon itself resolved (#4292),
+    // not one independently re-derived from this CLI invocation's own cwd.
+    let token_usage = collect_token_usage(report.token_pool_dir.as_deref());
 
     // Self-update staleness (#3968): purely local, read-only — compares the
     // commit baked into THIS `loom-daemon status` binary against the source
@@ -2871,6 +2891,12 @@ fn print_status_json(
         "capacity_bound": report.capacity_bound,
         "dynamic_cap": {
             "token_pool_size": report.token_pool_size,
+            // The directory the daemon resolved for the pool above (#4292) —
+            // `null` only from a pre-#4292 daemon binary that never computed
+            // one. Lets an operator confirm at a glance which of the
+            // per-repo/shared pools is actually in effect, independent of
+            // whatever cwd `loom-daemon status` itself was run from.
+            "token_pool_dir": report.token_pool_dir,
             "disk_headroom": report.disk_headroom,
             // CPU headroom term (#3978; measured-idle signal #4031) — see the
             // field docs on `DaemonStatusReport::cpu_headroom` for the pre-#3978
@@ -3224,6 +3250,14 @@ fn print_status_human(
 
     // Token-capacity backpressure section (#3902, source-unified in #3936).
     println!("\nToken capacity:");
+    // Name the resolved pool directory (#4292) — the same one the per-token
+    // usage table below was probed against — so a mismatch between "where I
+    // ran this command from" and "where the daemon's pool actually lives" is
+    // visible instead of silent. `None` only from a pre-#4292 daemon binary.
+    match &report.token_pool_dir {
+        Some(dir) => println!("  pool: {}", dir.display()),
+        None => println!("  pool: (unknown — daemon predates #4292)"),
+    }
     // "Currently binding" vs "smallest ceiling" (#4031): the dynamic cap is the
     // minimum of several ceilings, but a ceiling only *binds* once in-flight
     // occupancy reaches it. Below the cap the limiter is work availability, not
@@ -3843,8 +3877,58 @@ fn resolve_tokens_workspace(workspace: &str) -> Result<PathBuf> {
     let p = Path::new(workspace);
     if p.is_absolute() {
         Ok(p.to_path_buf())
+    } else if p == Path::new(".") {
+        // The common case (every `--workspace` flag defaults to `"."`): return
+        // the cwd itself rather than `cwd.join(".")`, which `PathBuf::join`
+        // does not normalize away — it appends a literal trailing `Component::
+        // CurDir`, producing paths like `/home/ubuntu/./.loom/tokens` in
+        // "no tokens found" warnings (issue #4292). Functionally identical
+        // either way; this just keeps resolved/printed paths readable.
+        std::env::current_dir().map_err(Into::into)
     } else {
         Ok(std::env::current_dir()?.join(p))
+    }
+}
+
+#[cfg(test)]
+mod resolve_tokens_workspace_tests {
+    //! Tests for [`resolve_tokens_workspace`] (issue #4292). No test here
+    //! `chdir`s the process (unsafe to do in a parallel test binary) — the
+    //! `"."` case is instead verified against a live `current_dir()` read,
+    //! and the absolute-path case needs no cwd at all.
+    use super::resolve_tokens_workspace;
+    use std::path::Path;
+
+    #[test]
+    fn absolute_workspace_is_returned_unchanged() {
+        let resolved = resolve_tokens_workspace("/some/repo").expect("resolve");
+        assert_eq!(resolved, Path::new("/some/repo"));
+    }
+
+    /// The clap default value for every `--workspace` flag is exactly `"."`.
+    /// Resolving it must equal the cwd itself — no literal trailing `.`
+    /// component (the #4292 cosmetic bug: `cwd.join(".")` produces
+    /// `<cwd>/.`, which then reads as `<cwd>/./.loom/tokens` in "no tokens
+    /// found" warnings).
+    #[test]
+    fn dot_workspace_resolves_to_bare_cwd() {
+        let resolved = resolve_tokens_workspace(".").expect("resolve");
+        let cwd = std::env::current_dir().expect("current_dir");
+        assert_eq!(resolved, cwd);
+        assert!(
+            !resolved.to_string_lossy().contains("/./"),
+            "resolved path must not carry a literal './' component: {}",
+            resolved.display()
+        );
+    }
+
+    #[test]
+    fn other_relative_workspace_is_joined_to_cwd() {
+        let resolved = resolve_tokens_workspace("some/relative/repo").expect("resolve");
+        let expected = std::env::current_dir()
+            .expect("current_dir")
+            .join("some/relative/repo");
+        assert_eq!(resolved, expected);
     }
 }
 

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -562,8 +562,12 @@ pub enum Response {
     // Autonomous Daemon Status (Issue #3891 — follow-up to #3813 Phase D)
     // ========================================================================
     /// Result of a `DaemonStatus` request — the autonomous-mode operability
-    /// snapshot rendered by `loom-daemon status`.
-    DaemonStatus(DaemonStatusReport),
+    /// snapshot rendered by `loom-daemon status`. Boxed (issue #4292, when
+    /// `token_pool_dir` pushed `DaemonStatusReport` far enough past the next-
+    /// largest `Response` variant to trip `clippy::large_enum_variant`) so this
+    /// one large, infrequent (once per status poll) payload does not force
+    /// every other `Response` variant to reserve its stack space.
+    DaemonStatus(Box<DaemonStatusReport>),
     /// Result of a `RestartDaemon` request (Issue #4054).
     ///
     /// `scheduled` is `true` when the daemon is supervised and is about to exit
@@ -833,6 +837,22 @@ pub struct DaemonStatusReport {
     /// (`.loom/tokens/*.token`), the hard ceiling on concurrent sweeps
     /// (never over-subscribe an OAuth account). Via [`crate::tokens::token_pool_size`].
     pub token_pool_size: usize,
+    /// The tokens-pool directory the daemon actually resolved for
+    /// [`Self::token_pool_size`] / [`Self::capacity`] (issue #4292): the
+    /// primary workspace's per-repo pool (`<workspace>/.loom/tokens`) when it
+    /// holds `*.token` files, else the shared machine-level pool
+    /// (`~/.loom/tokens`, override `LOOM_SHARED_TOKENS_DIR`) — the same
+    /// precedence [`crate::tokens_pool::paths::resolve_tokens_dir`] applies
+    /// everywhere else. Surfaced so `loom-daemon status` can print *which*
+    /// pool it used no matter which directory it was invoked from, and so the
+    /// CLI's client-side per-token usage probe (`collect_token_usage`) can
+    /// target this exact directory instead of independently re-deriving one
+    /// from its own cwd — the mismatch that let `status` report a false
+    /// token picture when run from a directory other than the daemon's own
+    /// workspace. `#[serde(default)]` keeps pre-#4292 wire data / older
+    /// daemon binaries compatible (an absent field parses as `None`).
+    #[serde(default)]
+    pub token_pool_dir: Option<PathBuf>,
     /// Dynamic-cap input 2: how many worktrees the scratch volume can hold at
     /// `LOOM_PER_WORKTREE_GB` each. Via [`crate::disk_headroom::disk_headroom_limit`].
     pub disk_headroom: usize,


### PR DESCRIPTION
## Summary

`loom-daemon status` computed its per-token usage table **client-side** from
the invoking process's own cwd (`resolve_tokens_workspace(".")`),
independently of the pool directory the *daemon* itself resolved for
`token_pool_size` / dynamic-cap accounting. Running `status` from a different
repo checkout than the daemon's own primary workspace could therefore report a
false token picture (e.g. `0/0 healthy`) even though the daemon's own pool was
perfectly healthy — the CLI and the daemon disagreed on which pool "the" pool
was.

- `DaemonStatusReport` now carries `token_pool_dir`: the exact directory the
  daemon resolved server-side (via the existing #3938 per-repo-first /
  shared-fallback precedence — unchanged, not reordered).
- `status` prints it (`pool: <dir>` human view, `dynamic_cap.token_pool_dir`
  in `--json`) and probes per-token usage against **that** directory instead
  of re-deriving one from the CLI's own cwd.
- Net effect: `loom-daemon status` reports the same token picture no matter
  which directory it is run from.
- Fixed a cosmetic bug in `resolve_tokens_workspace`: the `"."` default (every
  `--workspace` flag's default) produced a literal trailing `.` path
  component via `cwd.join(".")`, surfacing as `/home/ubuntu/./.loom/tokens`
  in "no tokens found" warnings — now resolves to the bare cwd.
- Boxed `Response::DaemonStatus` (`Box<DaemonStatusReport>`) since the new
  field pushed the variant past `clippy::large_enum_variant`'s threshold.
- Docs: `defaults/docs/daemon-reference.md` documents the precedence chain
  and a systemd note (the just-landed #4260/#4268 generated unit already sets
  `WorkingDirectory=` to a real resolved repo root; a hand-rolled unit that
  omits it is the scenario that needs `loom-tokens bootstrap --shared`).

Investigated but deliberately **not** changed (see code-read notes on the
issue): `resolve_tokens_dir`'s per-repo-first precedence (#3938, Option C
explicitly rejected by the curator), `tokens_pool::paths` semantics in
general (so no Python `loom_tools.tokens.paths` mirror change needed — this
PR only touches Rust-daemon-only status/CLI plumbing, not the shared
resolution primitives), and capacity/backpressure accounting beyond reading
the already-computed workspace root.

## Test plan

- [x] `cargo build --lib --bin loom-daemon` (loom-daemon)
- [x] `cargo clippy --lib --bin loom-daemon --tests -- -D warnings` (clean)
- [x] `cargo fmt -- --check` (clean)
- [x] `cargo test --lib` (1515 passed)
- [x] `cargo test --bin loom-daemon` (24 passed, incl. new
      `resolve_tokens_workspace_tests` covering the `"."` cosmetic fix)
- [x] `ipc::tests::test_daemon_status_request_response_round_trip` extended to
      assert `token_pool_dir` round-trips
- [x] `ipc::tests::test_daemon_status_backward_compat_*` still pass (confirms
      `#[serde(default)]` keeps pre-#4292 wire data compatible)

Part of #4292 (trip-wire 2 of 3)

This PR delivers the status-reporting complement (trip-wire 2: `loom-daemon
status` now anchors its token picture to the daemon's server-side resolved
pool dir, so it reports consistently from any cwd). It intentionally does
**not** close #4292 — the Champion-approved Option A (registry-anchored
default-workspace pool resolution, reusing #4322's
`resolve_client_workspace_default()` / `resolve_dispatch_root()`) still owns:

- **Trip-wire 1** — daemon-startup machine-level pool anchor (the surface
  that strands a systemd/machine-level daemon's dispatch cap).
- **Trip-wire 3** — `tokens check --ranking` writing beside the pool the
  daemon reads.

Those remain tracked on #4292, which stays open. Uses "Part of" (not
"Closes") per the partial-increment convention so the remaining anchoring
work is not silently dropped during the active #4344 incident.

