### PR TITLE
feat(cli): systemd timer unit for the loom-daemon autonomy watchdog on Linux

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -2282,29 +2282,42 @@ loop is not reusable as the reporter). It has three cooperating parts:
    off. Default-on (read-only, no dispatch side effect); opt out with
    `LOOM_DAEMON_HEARTBEAT=0` / `autonomous.heartbeat.enabled=false`.
 
-3. **Host-side watchdog** (`loom-daemon-watchdog.sh`), the payload of a **second
-   launchd job** (`<daemon-label>-watchdog`) that `loom-daemon-start.sh`
-   provisions on macOS with a `StartInterval` cadence (default 300s). Each run
-   compares intent (marker present?) against reality (daemon loaded + alive?
-   heartbeat fresh?) and, on divergence, appends a loud line to
-   `<loom_dir>/logs/daemon-watchdog.log` and stderr (which launchd captures).
+3. **Host-side watchdog** (`loom-daemon-watchdog.sh`), the payload of a
+   **second, separate scheduled job** from the daemon job/unit itself, that
+   `loom-daemon-start.sh` provisions on a recurring cadence (default 300s):
+   - **Darwin**: a second **launchd job** (`<daemon-label>-watchdog`) on a
+     `StartInterval` cadence.
+   - **systemd Linux** (#4260 sub-issue D): a `Type=oneshot`
+     `<daemon-unit>-watchdog.service` driven by a paired
+     `<daemon-unit>-watchdog.timer` (`OnUnitActiveSec` + `OnBootSec`,
+     `Persistent=false`), `enable --now`'d on the **timer** (mirroring
+     `loom-daemon.service` itself — #4268).
+
+   Each run compares intent (marker present?) against reality (daemon loaded +
+   alive? heartbeat fresh?) and, on divergence, appends a loud line to
+   `<loom_dir>/logs/daemon-watchdog.log` and stderr (which launchd/systemd both
+   capture into the same log via the rendered job/unit's stdout/stderr redirect).
 
 | File | Env override | Config key | Default |
 |------|--------------|-----------|---------|
 | heartbeat cadence | `LOOM_DAEMON_HEARTBEAT_INTERVAL_SECS` | `autonomous.heartbeat.intervalSecs` | `60` |
 | heartbeat on/off | `LOOM_DAEMON_HEARTBEAT` | `autonomous.heartbeat.enabled` | `true` (on) |
-| watchdog interval | `LOOM_WATCHDOG_INTERVAL_SECS` | — | `300` |
+| watchdog interval | `LOOM_WATCHDOG_INTERVAL_SECS` | — | `300` (launchd `StartInterval` / systemd `OnUnitActiveSec`+`OnBootSec`) |
+| watchdog job/unit basename override | `LOOM_WATCHDOG_LABEL` | — | `<daemon label/unit>-watchdog` |
 | staleness threshold | `LOOM_DAEMON_HEARTBEAT_STALE_SECS` | — | `max(5 × cadence, 300)` |
 
-**Why `StartInterval`, not a resident process or `KeepAlive`.** The reporter must
-itself be supervised, but a long-lived resident watchdog just moves the
-who-watches-the-watchdog problem up a level (it too can crash and stay dead). A
-`StartInterval` job owns no long-lived process: launchd re-runs it every interval
-regardless of how the last run exited, so it structurally cannot
-crash-and-stay-dead. `KeepAlive` is deliberately **not** set — it would busy-loop
-a short-lived job. The watchdog exit code (`0` healthy / no daemon expected, `1`
-divergence) is for testability + a human running it by hand; a `StartInterval`
-job's exit code does not affect relaunch.
+**Why an interval timer, not a resident process or `KeepAlive`/`Restart=`.** The
+reporter must itself be supervised, but a long-lived resident watchdog just moves
+the who-watches-the-watchdog problem up a level (it too can crash and stay dead).
+Both scheduling mechanisms own **no long-lived process**: launchd re-runs a
+`StartInterval` job every interval regardless of how the last run exited, and
+systemd's `.timer` re-fires its paired `Type=oneshot` service the same way — so
+neither can crash-and-stay-dead. `KeepAlive`/`Restart=` are deliberately **not**
+set on the watchdog job/service — that would busy-loop a short-lived job/oneshot
+service instead of driving it off a fixed interval clock. The watchdog exit code
+(`0` healthy / no daemon expected, `1` divergence) is for testability + a human
+running it by hand; neither a `StartInterval` job's nor a timer-fired oneshot
+service's exit code affects the next scheduled run.
 
 **Decision matrix** (marker present ⇒ a daemon is expected):
 
@@ -2325,10 +2338,12 @@ disarms the detector — the exact bug class #4011 fixes — so it is an explici
 signal, never an inference. The subsequent start re-writes the marker and
 re-provisions the watchdog.
 
-**Platform + isolation.** The scheduled watchdog is a launchd job, so on Linux /
-the `--no-launchd` nohup path there is no host-side checker provisioned — the
-marker + heartbeat are still written, and `loom-daemon-watchdog.sh` can be run by
-hand or wired to a cron / systemd timer to consume them. `<loom_dir>` is the
+**Platform + isolation.** Darwin and systemd Linux hosts both get a provisioned,
+scheduled watchdog (see the two bullets above). Only the **nohup fallback tier**
+— a non-systemd Linux host, or an explicit `--no-launchd`/`--no-systemd` /
+`LOOM_DAEMON_LAUNCHD=0`/`LOOM_DAEMON_SYSTEMD=0` escape hatch — has no host-side
+checker provisioned: the marker + heartbeat are still written, and
+`loom-daemon-watchdog.sh` can be run by hand or wired to cron. `<loom_dir>` is the
 parent of `LOOM_SOCKET_PATH` (else `~/.loom`), so pointing `LOOM_SOCKET_PATH` at a
 tempdir isolates the marker + heartbeat there too — which is how the lifecycle
 tests avoid ever touching the operator's real `~/.loom`. A forge-side reporting
@@ -2566,9 +2581,11 @@ disable-on-stop. The contract mirrors launchd point-for-point:
   interaction symmetrically, so a `--no-systemd` (nohup) start gets a stop that
   never touches the user manager.
 - **Crash relaunch is out of scope.** `Restart=on-success` deliberately does
-  **not** relaunch a crashed daemon (a non-zero exit) — that is watchdog territory,
-  tracked as sub-issue D of #4260, mirroring the macOS `StartInterval` autonomy-loss
-  watchdog (#4011), which remains launchd-only for now.
+  **not** relaunch a crashed daemon (a non-zero exit) — that is watchdog territory.
+  On a systemd host it is delivered by the `<unit>-watchdog.timer` +
+  `Type=oneshot` `.service` pair (#4260 sub-issue D, "Autonomy-loss watchdog +
+  heartbeat" above), mirroring the macOS `StartInterval` autonomy-loss watchdog
+  (#4011) — the watchdog *reports* divergence, it does not restart the daemon.
 
 ### macOS TCC hygiene under launchd (#3980)
 

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -26,6 +26,11 @@
 #     disable-on-stop, LOOM_DAEMON_SUPERVISOR=systemd) — see --no-systemd for the
 #     escape hatch; on a non-systemd Linux host (or with --no-systemd) it stays a
 #     plain nohup background job,
+#   - arms the autonomy-loss watchdog (#4011): on Darwin a SECOND launchd
+#     StartInterval job, on a systemd Linux host a `<unit>-watchdog.timer` +
+#     `.service` pair (#4260 sub-issue D) — both drive the SAME
+#     loom-daemon-watchdog.sh payload on a recurring interval, independent of
+#     the daemon job/unit, so a wedged or dead daemon still gets checked,
 #   - backgrounds the daemon and writes a PID file (.loom/.daemon.pid),
 #   - persists the resolved invocation flags to .loom/.daemon.flags so
 #     `loom-daemon-update.sh` (#3968) can restart with EXACTLY the same
@@ -77,6 +82,11 @@
 #   LOOM_DAEMON_LAUNCHD  macOS only: 0/false/no forces the legacy nohup path (same as --no-launchd)
 #   LOOM_DAEMON_SYSTEMD  Linux only: 0/false/no forces the legacy nohup path (same as --no-systemd)
 #   LOOM_SYSTEMD_UNIT    Linux only: override the systemd --user unit name (default loom-daemon.service)
+#   LOOM_WATCHDOG_LABEL  Override the watchdog job identifier (macOS: LaunchAgent
+#                        label, default <daemon label>-watchdog; systemd Linux:
+#                        service/timer unit basename, default <daemon unit>-watchdog)
+#   LOOM_WATCHDOG_INTERVAL_SECS  Watchdog check cadence in seconds (default 300) —
+#                        macOS StartInterval / systemd OnUnitActiveSec+OnBootSec
 #   LOOM_LAUNCHD_LABEL   macOS only: override the LaunchAgent label (default com.rjwalters.loom-daemon)
 #   LOOM_LAUNCHD_DOMAIN  macOS only: pin the launchd domain (e.g. gui/$(id -u) or
 #                        user/$(id -u)); honored verbatim, else auto-resolved
@@ -444,14 +454,21 @@ EOF
     )
 }
 
-# ---------- watchdog LaunchAgent (#4011) ----------
-# The watchdog is the payload of a SECOND launchd job that runs on a
-# StartInterval cadence, SEPARATE from the daemon job, and reports when intent
-# (the marker above) diverges from reality (daemon not loaded/alive, or heartbeat
-# stale). It uses StartInterval and NOT KeepAlive: a KeepAlive'd short-lived job
-# would busy-loop, whereas StartInterval already re-runs it every interval
-# regardless of how the last run exited — which is exactly what makes an interval
-# job unable to "crash and stay dead" (the who-watches-the-watchdog resolution).
+# ---------- watchdog LaunchAgent / systemd timer (#4011, #4260 sub-issue D) ----------
+# The watchdog is the payload of a SECOND, SEPARATE scheduled job from the
+# daemon job/unit itself, and reports when intent (the marker above) diverges
+# from reality (daemon not loaded/alive, or heartbeat stale):
+#   - Darwin: a launchd job on a StartInterval cadence. StartInterval, NOT
+#     KeepAlive: a KeepAlive'd short-lived job would busy-loop, whereas
+#     StartInterval already re-runs it every interval regardless of how the
+#     last run exited.
+#   - systemd Linux: a `Type=oneshot` service driven by a `.timer` unit
+#     (`OnUnitActiveSec`). The systemd equivalent of StartInterval — a timer
+#     re-fires the oneshot service every interval independent of the last run's
+#     exit status.
+# Both mechanisms share the same property: the watchdog job owns NO long-lived
+# process, so it structurally cannot crash-and-stay-dead (the
+# who-watches-the-watchdog resolution).
 resolve_watchdog_label() {
     echo "${LOOM_WATCHDOG_LABEL:-$(resolve_launchd_label)-watchdog}"
 }
@@ -499,8 +516,7 @@ render_watchdog_plist() {
 # Provision + (re)load the watchdog LaunchAgent. Best-effort and NON-FATAL: a
 # watchdog that fails to install must never fail the daemon start (the daemon
 # running without a watchdog is strictly better than no daemon at all).
-provision_watchdog_job() {
-    [[ "$IS_DARWIN" == "true" ]] || { warn "watchdog: not Darwin — skipping (marker+heartbeat still active; no scheduled checker on this platform)."; return 0; }
+provision_watchdog_job_launchd() {
     command -v launchctl >/dev/null 2>&1 || { warn "watchdog: launchctl not found — skipping."; return 0; }
     local script; script="$(locate_watchdog_script)"
     if [[ -z "$script" ]]; then
@@ -530,6 +546,110 @@ provision_watchdog_job() {
     else
         warn "watchdog: launchctl bootstrap failed for $wd_service — autonomy-loss detection not active (non-fatal)."
     fi
+}
+
+# ---------- watchdog systemd --user timer (#4260 sub-issue D) ----------
+# resolve_systemd_watchdog_unit — the watchdog service/timer basename (no
+# `.service`/`.timer` suffix), mirroring resolve_watchdog_label's Darwin
+# `<daemon label>-watchdog` pattern: `<daemon unit>-watchdog`, with the same
+# LOOM_WATCHDOG_LABEL override.
+resolve_systemd_watchdog_unit() {
+    local daemon_unit; daemon_unit="$(resolve_systemd_unit)"
+    echo "${LOOM_WATCHDOG_LABEL:-${daemon_unit%.service}-watchdog}"
+}
+
+# render_systemd_watchdog_service <watchdog_script> <workdir> <log_path>
+# Type=oneshot: the unit owns no long-lived process (the ExecStart runs the
+# watchdog's single check-and-exit pass) -- the timer unit below re-fires it,
+# not a Restart= directive.
+render_systemd_watchdog_service() {
+    local script="$1" workdir="$2" log_path="$3"
+    printf '[Unit]\n'
+    printf 'Description=Loom daemon autonomy-loss watchdog (loom-daemon-watchdog)\n'
+    printf '\n'
+    printf '[Service]\n'
+    printf 'Type=oneshot\n'
+    printf 'WorkingDirectory=%s\n' "$workdir"
+    printf 'ExecStart=/bin/bash %s\n' "$script"
+    printf 'Environment=PATH=%s\n' "$PLIST_PATH_VALUE"
+    printf 'Environment=HOME=%s\n' "$HOME"
+    printf 'Environment=LOOM_AUTONOMY_MARKER=%s\n' "$INTENT_MARKER"
+    printf 'Environment=LOOM_SOCKET_PATH=%s\n' "$SOCKET_PATH"
+    printf 'Environment=LOOM_DAEMON_LAUNCHD=0\n'
+    printf 'StandardOutput=append:%s\n' "$log_path"
+    printf 'StandardError=append:%s\n' "$log_path"
+}
+
+# render_systemd_watchdog_timer <service_unit_name> <interval_secs>
+# OnUnitActiveSec is the systemd analog of launchd's StartInterval (re-fires
+# every <interval>s regardless of the last run's exit status). OnBootSec gives
+# the RunAtLoad-equivalent "run shortly after the user session starts" —
+# though `enable --now` on a timer already triggers an immediate first run, so
+# this only matters across reboots. Persistent=false: a watchdog tick missed
+# while the session was down should NOT fire a catch-up run the moment the
+# session resumes -- the next regular tick is soon enough.
+render_systemd_watchdog_timer() {
+    local service_unit="$1" interval="$2"
+    printf '[Unit]\n'
+    printf 'Description=Loom daemon autonomy-loss watchdog timer (loom-daemon-watchdog)\n'
+    printf '\n'
+    printf '[Timer]\n'
+    printf 'OnBootSec=%s\n' "$interval"
+    printf 'OnUnitActiveSec=%s\n' "$interval"
+    printf 'Unit=%s\n' "$service_unit"
+    printf 'Persistent=false\n'
+    printf '\n'
+    printf '[Install]\n'
+    printf 'WantedBy=timers.target\n'
+}
+
+# Provision + enable the watchdog service+timer pair under `systemd --user`.
+# Best-effort and NON-FATAL, same contract as the launchd path.
+provision_watchdog_job_systemd() {
+    command -v systemctl >/dev/null 2>&1 || { warn "watchdog: systemctl not found — skipping."; return 0; }
+    local script; script="$(locate_watchdog_script)"
+    if [[ -z "$script" ]]; then
+        warn "watchdog: loom-daemon-watchdog.sh not found — skipping (autonomy-loss detection disabled)."
+        return 0
+    fi
+    local wd_unit svc_unit timer_unit unit_dir svc_path timer_path wd_interval wd_log
+    wd_unit="$(resolve_systemd_watchdog_unit)"
+    svc_unit="${wd_unit}.service"
+    timer_unit="${wd_unit}.timer"
+    unit_dir="$(resolve_systemd_unit_dir)"
+    svc_path="${unit_dir}/${svc_unit}"
+    timer_path="${unit_dir}/${timer_unit}"
+    wd_interval="${LOOM_WATCHDOG_INTERVAL_SECS:-300}"
+    wd_log="$LOOM_DIR/logs/daemon-watchdog.log"
+    mkdir -p "$unit_dir" "$LOOM_DIR/logs" 2>/dev/null || true
+    if ! render_systemd_watchdog_service "$script" "$REPO_ROOT" "$wd_log" > "$svc_path" 2>/dev/null; then
+        warn "watchdog: could not write $svc_path — skipping."
+        return 0
+    fi
+    if ! render_systemd_watchdog_timer "$svc_unit" "$wd_interval" > "$timer_path" 2>/dev/null; then
+        warn "watchdog: could not write $timer_path — skipping."
+        return 0
+    fi
+    systemctl --user daemon-reload >/dev/null 2>&1 || true
+    if systemctl --user enable --now "$timer_unit" >/dev/null 2>&1; then
+        echo "Watchdog:       $timer_unit (OnUnitActiveSec ${wd_interval}s) → $wd_log"
+    else
+        warn "watchdog: systemctl --user enable --now failed for $timer_unit — autonomy-loss detection not active (non-fatal)."
+    fi
+}
+
+# Called from the nohup fallback tier (non-systemd Linux host, or
+# --no-launchd/--no-systemd): no scheduled watchdog job/timer to provision.
+# Deliberately NOT re-derived from $IS_DARWIN/$IS_LINUX_SYSTEMD -- each of the
+# three call sites below already knows definitively which supervisor tier it
+# is in (that is what selected this code path), so it calls the matching
+# provision_watchdog_job_{launchd,systemd} directly instead of re-detecting.
+# Re-detecting here would be redundant AND actively wrong under the
+# LOOM_SYSTEMD_FORCE=1 test seam, where a Darwin test runner can have both
+# $IS_DARWIN and $IS_LINUX_SYSTEMD true simultaneously.
+provision_watchdog_job_none() {
+    warn "watchdog: no scheduled checker on this platform (nohup-fallback Linux / non-systemd host) — skipping (marker+heartbeat still active). Run loom-daemon-watchdog.sh by hand or wire it to cron."
+    return 0
 }
 
 # ---------- args ----------
@@ -906,7 +1026,7 @@ if [[ "$USE_LAUNCHD" == "true" ]]; then
     echo "$daemon_pid" > "$PID_FILE"
     # Record operator intent + arm the host-side autonomy-loss watchdog (#4011).
     write_intent_marker "true" "$LAUNCHD_LABEL"
-    provision_watchdog_job
+    provision_watchdog_job_launchd
     ok "loom-daemon started under launchd (pid $daemon_pid, label $LAUNCHD_LABEL)."
     echo "PID file: $PID_FILE"
     echo "Intent marker: $INTENT_MARKER"
@@ -976,11 +1096,10 @@ if [[ "$IS_LINUX_SYSTEMD" == "true" ]]; then
     fi
 
     echo "$daemon_pid" > "$PID_FILE"
-    # Record operator intent (#4011). The scheduled watchdog is a launchd job, so
-    # on Linux there is no host-side checker to provision -- the marker + heartbeat
-    # are still written (the systemd-side watchdog is sub-issue D of #4260).
+    # Record operator intent + arm the systemd-timer autonomy-loss watchdog
+    # (#4011, #4260 sub-issue D).
     write_intent_marker "false" ""
-    provision_watchdog_job
+    provision_watchdog_job_systemd
     ok "loom-daemon started under systemd (pid $daemon_pid, unit $SYSTEMD_UNIT)."
     echo "PID file: $PID_FILE"
     echo "Intent marker: $INTENT_MARKER"
@@ -1013,12 +1132,12 @@ if ! kill -0 "$daemon_pid" 2>/dev/null; then
 fi
 
 echo "$daemon_pid" > "$PID_FILE"
-# Record operator intent (#4011). The scheduled watchdog is a launchd job, so on
-# Linux / the nohup path there is no host-side checker to provision — the marker
-# + heartbeat are still written, and `loom-daemon-watchdog.sh` can be run by hand
-# or wired to a cron/systemd timer to consume them.
+# Record operator intent (#4011). This is the nohup fallback tier (non-systemd
+# Linux host, or --no-launchd/--no-systemd), so there is no scheduled checker to
+# provision here — the marker + heartbeat are still written, and
+# `loom-daemon-watchdog.sh` can be run by hand or wired to cron.
 write_intent_marker "false" ""
-provision_watchdog_job
+provision_watchdog_job_none
 ok "loom-daemon started (pid $daemon_pid). PID file: $PID_FILE"
 echo "Intent marker: $INTENT_MARKER"
 if [[ "$MACHINE_MODE" == "true" ]]; then

--- a/defaults/scripts/cli/loom-daemon-stop.sh
+++ b/defaults/scripts/cli/loom-daemon-stop.sh
@@ -53,8 +53,11 @@
 #
 # Autonomy-desired marker (#4011): a normal operator stop is INTENT to stop, so
 # it removes the durable `autonomy-desired` marker loom-daemon-start.sh wrote and
-# boots out the watchdog LaunchAgent — after that the watchdog correctly stays
-# silent (no daemon is expected). But the internal stop that
+# tears down the watchdog scheduler — the launchd LaunchAgent on Darwin
+# (`launchctl bootout`), or the `<unit>-watchdog.timer` + `.service` pair on a
+# systemd Linux host (`systemctl --user disable --now`, #4260 sub-issue D) —
+# after that the watchdog correctly stays silent (no daemon is expected). But
+# the internal stop that
 # loom-daemon-update.sh performs is NOT operator intent to stop; it is a restart,
 # so update.sh passes --restarting (or LOOM_DAEMON_STOP_KEEP_INTENT=1) and this
 # script PRESERVES the marker + watchdog. Inferring restart-vs-stop would be
@@ -176,10 +179,11 @@ SOCKET_PATH="${LOOM_SOCKET_PATH:-$HOME/.loom/loom-daemon.sock}"
 LOOM_DIR="$(dirname "$SOCKET_PATH")"
 INTENT_MARKER="${LOOM_AUTONOMY_MARKER:-$LOOM_DIR/autonomy-desired}"
 
-# Remove the operator-intent marker and bump out the watchdog LaunchAgent. Only
-# called on an operator-initiated stop (NOT a --restarting update.sh stop). After
-# this the watchdog sees no marker and correctly stays silent — no false page on
-# a deliberate stop. Best-effort; failures never change the stop's exit status.
+# Remove the operator-intent marker and tear down the watchdog LaunchAgent /
+# systemd timer+service. Only called on an operator-initiated stop (NOT a
+# --restarting update.sh stop). After this the watchdog sees no marker and
+# correctly stays silent — no false page on a deliberate stop. Best-effort;
+# failures never change the stop's exit status.
 teardown_autonomy_intent() {
     rm -f "$INTENT_MARKER" 2>/dev/null || true
     local wd_label wd_service
@@ -191,6 +195,19 @@ teardown_autonomy_intent() {
         if launchctl print "$wd_service" >/dev/null 2>&1; then
             launchctl bootout "$wd_service" >/dev/null 2>&1 || true
         fi
+    fi
+    # systemd --user watchdog timer+service teardown (#4260 sub-issue D),
+    # symmetric with the launchd bootout above. $IS_LINUX_SYSTEMD is resolved
+    # below (before any call to this function); mirrors loom-daemon-start.sh's
+    # resolve_systemd_watchdog_unit() naming (<daemon unit>-watchdog, same
+    # LOOM_WATCHDOG_LABEL override) so stop always targets the SAME unit pair
+    # start provisioned.
+    if [[ "$IS_LINUX_SYSTEMD" == "true" ]] && command -v systemctl >/dev/null 2>&1; then
+        local sd_daemon_unit sd_wd_unit
+        sd_daemon_unit="$(resolve_systemd_unit)"
+        sd_wd_unit="${LOOM_WATCHDOG_LABEL:-${sd_daemon_unit%.service}-watchdog}"
+        systemctl --user disable --now "${sd_wd_unit}.timer" >/dev/null 2>&1 || true
+        systemctl --user disable --now "${sd_wd_unit}.service" >/dev/null 2>&1 || true
     fi
 }
 

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -327,8 +327,133 @@ else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "${RED}✗${NC} systemd path: prints the loginctl enable-linger reboot-survival reminder"
 fi
+# S2 uses $WORKDIR as REPO_ROOT, which has no loom-daemon-watchdog.sh fixture
+# (a scratch tmpdir, not a real checkout) -- so the watchdog provisioning
+# tier degrades to its missing-script skip. Confirm that degrade is a WARNING,
+# never a failed start (parity with the launchd branch, #4260 sub-issue D AC).
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$sd_out" | grep -qi 'watchdog.*loom-daemon-watchdog.sh not found'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} systemd path: missing watchdog script degrades to a warning (start already asserted exit 0 above)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} systemd path: missing watchdog script degrades to a warning"
+    echo "  output: $sd_out"
+fi
 kill "$SD_MAIN_SLEEP_PID" 2>/dev/null || true
 rm -rf "$SD_HOME"
+
+# ---------- systemd --user watchdog timer (#4260 sub-issue D) ----------
+# A repo-like scratch checkout with the REAL loom-daemon-watchdog.sh installed
+# (S2's $WORKDIR deliberately has none) so provision_watchdog_job_systemd's
+# happy path is actually exercised, not just its missing-script skip above.
+WD_REPO="$(mktemp -d)"
+mkdir -p "$WD_REPO/.loom/scripts/cli" "$WD_REPO/.loom/logs"
+cp "$SCRIPT_DIR/../cli/loom-daemon-watchdog.sh" "$WD_REPO/.loom/scripts/cli/loom-daemon-watchdog.sh"
+
+make_sd_stub_wd() {
+    local log="$1" mainpid="$2" fail_wd="$3"
+    cat > "$SD_BIN/systemctl" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$log"
+if [[ "\${1:-}" == "--user" ]]; then shift; fi
+case "\${1:-}" in
+  show) echo "${mainpid}" ;;
+  enable)
+    if [[ "$fail_wd" == "1" && "\$*" == *"-watchdog.timer"* ]]; then exit 1; fi
+    exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+    chmod +x "$SD_BIN/systemctl"
+}
+
+# WD1. Happy path: timer + service rendered with the correct fields, the timer
+#      (not the service) is enable --now'd, and LOOM_WATCHDOG_INTERVAL_SECS
+#      drives BOTH OnUnitActiveSec and OnBootSec.
+sleep 30 & WD_MAIN_SLEEP_PID=$!
+WD_LOG="$WORKDIR/sd-watchdog.log"; : > "$WD_LOG"
+make_sd_stub_wd "$WD_LOG" "$WD_MAIN_SLEEP_PID" "0"
+WD_HOME="$(mktemp -d)"; mkdir -p "$WD_HOME/.loom/logs"
+WD_UNIT="loom-daemon-wd-test-$$.service"
+wd_out=$( cd "$WD_REPO" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    PATH="$SD_BIN:$PATH" HOME="$WD_HOME" \
+    LOOM_SYSTEMD_FORCE=1 LOOM_SYSTEMD_UNIT="$WD_UNIT" LOOM_WATCHDOG_INTERVAL_SECS=42 \
+    LOOM_DAEMON_BIN="$FAKE_BIN" \
+    LOOM_SOCKET_PATH="$WD_HOME/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$WD_HOME/.loom/autonomy-desired" \
+    bash "$START_SCRIPT" --no-launchd 2>&1 )
+wd_rc=$?
+assert_eq "0" "$wd_rc" "systemd watchdog: start exits 0 with a real watchdog script present"
+WD_TIMER_UNIT="loom-daemon-wd-test-$$-watchdog.timer"
+WD_SVC_UNIT="loom-daemon-wd-test-$$-watchdog.service"
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q -- "--user enable --now $WD_TIMER_UNIT" "$WD_LOG" \
+    && ! grep -q -- "--user enable --now $WD_SVC_UNIT" "$WD_LOG"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} systemd watchdog: enable --now targets the TIMER unit, not the service"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} systemd watchdog: enable --now targets the TIMER unit, not the service"
+    echo "  systemctl calls: $(cat "$WD_LOG")"
+fi
+WD_TIMER_PATH="$WD_HOME/.config/systemd/user/$WD_TIMER_UNIT"
+WD_SVC_PATH="$WD_HOME/.config/systemd/user/$WD_SVC_UNIT"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -f "$WD_TIMER_PATH" ]] \
+    && grep -qx 'OnUnitActiveSec=42' "$WD_TIMER_PATH" \
+    && grep -qx 'OnBootSec=42' "$WD_TIMER_PATH" \
+    && grep -qx "Unit=$WD_SVC_UNIT" "$WD_TIMER_PATH" \
+    && grep -qx 'Persistent=false' "$WD_TIMER_PATH"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} systemd watchdog: timer renders OnUnitActiveSec/OnBootSec from LOOM_WATCHDOG_INTERVAL_SECS, Unit=<service>, Persistent=false"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} systemd watchdog: timer renders the expected fields"
+    cat "$WD_TIMER_PATH" 2>/dev/null | sed 's/^/    /'
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -f "$WD_SVC_PATH" ]] \
+    && grep -qx 'Type=oneshot' "$WD_SVC_PATH" \
+    && grep -q "^ExecStart=/bin/bash $WD_REPO/.loom/scripts/cli/loom-daemon-watchdog.sh$" "$WD_SVC_PATH"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} systemd watchdog: service renders Type=oneshot and ExecStart=<watchdog script path>"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} systemd watchdog: service renders Type=oneshot and ExecStart=<watchdog script path>"
+    cat "$WD_SVC_PATH" 2>/dev/null | sed 's/^/    /'
+fi
+kill "$WD_MAIN_SLEEP_PID" 2>/dev/null || true
+rm -rf "$WD_HOME"
+
+# WD2. Provisioning failure (stub enable --now on the timer exits 1) is a
+#      WARNING, never a failed daemon start.
+sleep 30 & WD2_MAIN_SLEEP_PID=$!
+WD2_LOG="$WORKDIR/sd-watchdog-fail.log"; : > "$WD2_LOG"
+make_sd_stub_wd "$WD2_LOG" "$WD2_MAIN_SLEEP_PID" "1"
+WD2_HOME="$(mktemp -d)"; mkdir -p "$WD2_HOME/.loom/logs"
+WD2_UNIT="loom-daemon-wd2-test-$$.service"
+wd2_out=$( cd "$WD_REPO" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    PATH="$SD_BIN:$PATH" HOME="$WD2_HOME" \
+    LOOM_SYSTEMD_FORCE=1 LOOM_SYSTEMD_UNIT="$WD2_UNIT" \
+    LOOM_DAEMON_BIN="$FAKE_BIN" \
+    LOOM_SOCKET_PATH="$WD2_HOME/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$WD2_HOME/.loom/autonomy-desired" \
+    bash "$START_SCRIPT" --no-launchd 2>&1 )
+wd2_rc=$?
+assert_eq "0" "$wd2_rc" "systemd watchdog: a failed 'enable --now' on the timer does not fail the daemon start"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$wd2_out" | grep -qi 'watchdog.*enable --now failed'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} systemd watchdog: install failure is reported as a warning"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} systemd watchdog: install failure is reported as a warning"
+    echo "  output: $wd2_out"
+fi
+kill "$WD2_MAIN_SLEEP_PID" 2>/dev/null || true
+rm -rf "$WD2_HOME"
+rm -rf "$WD_REPO"
 
 # S3. Escape hatch: --no-systemd falls back to the nohup path byte-compatibly —
 #     the stub systemctl is on PATH and detection is FORCED, yet no systemctl

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -385,6 +385,7 @@ wd_out=$( cd "$WD_REPO" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
     bash "$START_SCRIPT" --no-launchd 2>&1 )
 wd_rc=$?
 assert_eq "0" "$wd_rc" "systemd watchdog: start exits 0 with a real watchdog script present"
+[[ "$wd_rc" == "0" ]] || echo "  output: $wd_out"
 WD_TIMER_UNIT="loom-daemon-wd-test-$$-watchdog.timer"
 WD_SVC_UNIT="loom-daemon-wd-test-$$-watchdog.service"
 TESTS_RUN=$((TESTS_RUN + 1))

--- a/defaults/scripts/tests/test-loom-daemon-stop.sh
+++ b/defaults/scripts/tests/test-loom-daemon-stop.sh
@@ -396,6 +396,21 @@ else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "${RED}✗${NC} systemd tier: operator stop clears the autonomy-desired marker"
 fi
+# SD1b (#4260 sub-issue D): the same operator stop also tears down the
+# watchdog timer + service pair, symmetric with the launchd bootout tier.
+# Naming mirrors loom-daemon-start.sh's resolve_systemd_watchdog_unit():
+# <daemon unit>-watchdog(.timer|.service).
+SD_WD_UNIT="${LOOM_SYSTEMD_UNIT%.service}-watchdog"
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q -- "--user disable --now ${SD_WD_UNIT}.timer" "$SD_LOG" \
+    && grep -q -- "--user disable --now ${SD_WD_UNIT}.service" "$SD_LOG"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} systemd tier: operator stop disables the watchdog timer + service"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} systemd tier: operator stop disables the watchdog timer + service"
+    echo "  systemctl calls: $(cat "$SD_LOG")"
+fi
 
 # SD2. Post-disable verification: if the unit is STILL active after disable --now
 #      (a disable that did not stick — the inverted-#4011 silent-success hole),


### PR DESCRIPTION
## Summary

- `provision_watchdog_job()` in `loom-daemon-start.sh` gains a systemd branch: on a systemd Linux host it renders + installs a `Type=oneshot` `<unit>-watchdog.service` (runs the existing platform-agnostic `loom-daemon-watchdog.sh` payload) plus a paired `<unit>-watchdog.timer` (`OnUnitActiveSec`/`OnBootSec` = `LOOM_WATCHDOG_INTERVAL_SECS`, default 300s, `Persistent=false`), then `daemon-reload` + `enable --now` the **timer** — the systemd analog of the Darwin `StartInterval` LaunchAgent job.
- `loom-daemon-stop.sh`'s `teardown_autonomy_intent()` gains the symmetric systemd path: on an operator-initiated stop it `systemctl --user disable --now`s both the watchdog timer and service, alongside the existing launchd bootout.
- Both directions keep the existing best-effort / NON-FATAL contract: a watchdog install/teardown failure only warns, never fails the daemon start/stop.
- `defaults/docs/daemon-reference.md`'s watchdog section is updated: the "Linux… can be run by hand or wired to a cron / systemd timer" caveat is replaced with the now-provisioned timer, plus the new `LOOM_WATCHDOG_LABEL`/`LOOM_WATCHDOG_INTERVAL_SECS` env docs (also added to `loom-daemon-start.sh`'s own `--help` banner).
- **Structural note**: since a Darwin CI runner exercising the systemd branch via the `LOOM_SYSTEMD_FORCE=1` test seam can have `IS_DARWIN` and `IS_LINUX_SYSTEMD` both true at once, the three daemon-start call sites now call the specific `provision_watchdog_job_{launchd,systemd,none}` function they already know they need, rather than routing through a platform-autodetecting dispatcher that would always pick launchd in that scenario.
- Out of scope (per issue): no changes to `loom-daemon-watchdog.sh` itself (already platform-agnostic — it already resolves liveness from the PID file on any non-launchd path, which the rendered systemd service also forces via `Environment=LOOM_DAEMON_LAUNCHD=0`), the Darwin watchdog job, or heartbeat semantics.

## Changes

- `defaults/scripts/cli/loom-daemon-start.sh`: `render_systemd_watchdog_service()` / `render_systemd_watchdog_timer()` / `resolve_systemd_watchdog_unit()` / `provision_watchdog_job_systemd()`; split the pre-existing launchd body into `provision_watchdog_job_launchd()`; added `provision_watchdog_job_none()` for the nohup-fallback tier; updated header/env docs.
- `defaults/scripts/cli/loom-daemon-stop.sh`: `teardown_autonomy_intent()` now also disables the watchdog timer + service when `IS_LINUX_SYSTEMD` is true; updated header comment.
- `defaults/docs/daemon-reference.md`: watchdog section rewritten to describe both platforms; "Platform + isolation" paragraph corrected (only the nohup-fallback tier now lacks a scheduled checker); the `Restart=on-success` write-up's "remains launchd-only for now" TODO is resolved.
- `defaults/scripts/tests/test-loom-daemon-start.sh`: new systemd-watchdog block — happy path (timer/service rendered with the correct fields, `enable --now` targets the timer not the service, `LOOM_WATCHDOG_INTERVAL_SECS` drives `OnUnitActiveSec`/`OnBootSec`), a provisioning-failure case (stub `enable --now` on the timer exits 1 → daemon start still exits 0, warning printed), plus an assertion that a missing watchdog script degrades to a warning without failing the (pre-existing) systemd-path start test.
- `defaults/scripts/tests/test-loom-daemon-stop.sh`: new assertion on the existing systemd-tier stop test that the watchdog timer + service are both `disable --now`'d.

## Acceptance Criteria Verification

- [x] On a systemd Linux host, daemon start provisions + starts the watchdog timer — verified via the `LOOM_SYSTEMD_FORCE=1` + stub-`systemctl` test seam (real Linux host not available in this environment); `killing the daemon with SIGKILL produces a divergence report within one interval` is unchanged behavior of the already-platform-agnostic `loom-daemon-watchdog.sh` (untouched in this PR) driven by the new timer.
- [x] Operator stop tears down timer + service — new `test-loom-daemon-stop.sh` assertion confirms both `disable --now` calls fire on an operator stop.
- [x] Watchdog install failure is a warning, never a failed daemon start — new `test-loom-daemon-start.sh` WD2 case: a failing `enable --now` on the timer still exits 0.
- [x] Darwin watchdog provisioning unchanged — the launchd body is moved verbatim into `provision_watchdog_job_launchd()`, byte-identical logic; nohup-fallback Linux hosts keep the existing warning via the new `provision_watchdog_job_none()`.

## Test Plan

- [x] `bash defaults/scripts/tests/test-loom-daemon-start.sh` — 37/37 passed (was 26/26 before this PR's additions)
- [x] `bash defaults/scripts/tests/test-loom-daemon-stop.sh` — 37/37 passed
- [x] `bash defaults/scripts/tests/test-loom-daemon-watchdog.sh` — 12/12 passed (unchanged, confirms no regression)
- [x] `bash defaults/scripts/tests/test-loom-daemon-update.sh` — 56/56 passed (unchanged, confirms no regression)
- [x] `shellcheck -x` clean on both modified scripts
- [x] `LOOM_WATCHDOG_INTERVAL_SECS` override verified end-to-end (manual smoke test + WD1 automated test)
- [x] Watchdog script missing ⇒ warn + skip, parity with the launchd branch — asserted against the pre-existing systemd-path start test (whose scratch `$WORKDIR` has no watchdog script fixture)

Closes #4270
