### PR TITLE
fix(daemon): resolve dispatch's target workspace from the registry, not cwd (#4299)

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -195,11 +195,37 @@ Inputs:
   field is `#[serde(default)]` on the wire, so pre-#3729 clients remain
   compatible.
 - `workspace_root` (optional, issue #3929) — target managed-workspace root.
-  When omitted, the sweep is dispatched into the daemon's **default** workspace
-  (byte-for-byte unchanged). When set to a registered repo root, the daemon
-  resolves that repo's sweep registry via the `WorkspacePool` and dispatches into
-  its working tree — the way to dispatch into a managed repo other than the
-  default when two repos share issue numbers. `#[serde(default)]` on the wire.
+  When set to a registered repo root, the daemon resolves that repo's sweep
+  registry via the `WorkspacePool` and dispatches into its working tree — the
+  way to dispatch into a managed repo other than the default when two repos
+  share issue numbers. `#[serde(default)]` on the wire.
+
+  **When omitted (issue #4299):** the daemon no longer blindly targets its own
+  seeded default (cwd at startup / `LOOM_WORKSPACE`) — it consults the
+  on-disk `~/.loom/workspaces.json` registry (`WorkspaceRegistry::resolve_dispatch_root`,
+  `workspace_registry.rs`) in this order:
+  1. **Registry empty** -> the seeded default (byte-for-byte pre-#4299 / pre-registry
+     behavior).
+  2. **Seeded default is itself registered** -> the seeded default. This is the
+     back-compat floor: every existing multi-workspace host runs the daemon
+     from a registered repo, so a bare dispatch with no `workspace_root` keeps
+     working with no new flags.
+  3. **Seeded default is NOT registered, exactly one workspace is registered**
+     -> that workspace. This is the case a single-repo worker host (daemon cwd
+     = the machine checkout, one product repo registered) needs: the sole
+     registration is the only sane target.
+  4. **Seeded default is NOT registered, multiple workspaces are registered**
+     -> a structured `CONFIG_WORKSPACE_AMBIGUOUS` error naming every
+     registered root. Issue numbers are per-repo, so guessing which repo
+     "owns" issue N by probing the forge is ill-defined — an explicit
+     `workspace_root`/`--workspace` is required instead. Never a silent cwd
+     fallback.
+
+  This resolution applies to the **dispatch path only**. `list_sweeps`,
+  `get_sweep_status`, and quarantine requests keep their unconditional
+  default-registry fallback for an absent `workspace_root` — read-path default
+  behavior is unchanged (a deliberate scope limit; see the #4299 issue for the
+  follow-up if that also needs to change).
 
 #### `loom-daemon dispatch <issue>` — operator CLI (Issue #3952)
 
@@ -224,6 +250,15 @@ loom-daemon dispatch 3952 --depends-on 3945        # stacked-PR child (#3729)
 | `--model <M>` | `model` | omit to let the daemon resolve `autonomous.model` / the shipped default (#3944) |
 | `--effort <E>` | `effort` | reasoning-effort override (#3716) |
 | `--depends-on <P>` | `depends_on` | single parent issue; child branches off `feature/issue-<P>` (#3729) |
+
+**`--workspace` client-side cwd default (issue #4299).** When `--workspace` is
+omitted, the CLI itself (not the daemon — it cannot see the client's cwd)
+checks whether its own working directory falls under a registered workspace
+root and, if so, populates `workspace_root` with that root before sending the
+request (`resolve_cli_dispatch_workspace` in `main.rs`). This is what makes
+`cd ~/GitHub/anvil && loom-daemon dispatch 758` target anvil even when the
+daemon's own seeded default points elsewhere. A cwd outside every registered
+root leaves `--workspace` unset, and the daemon-side resolution above applies.
 
 **Bounded ack timeout (never hangs).** The CLI waits at most **30s** for the
 daemon to ack the dispatch, then exits **nonzero** with a clear

--- a/defaults/docs/machine-dispatcher.md
+++ b/defaults/docs/machine-dispatcher.md
@@ -240,6 +240,24 @@ launchd-managed) or refused (not currently running, or a pre-#4077 binary), it
 falls back to a plain stop-then-start via the same checkout-resolved
 lifecycle-script delegates.
 
+### Sweep dispatch on a multi-repo worker host (#4299)
+
+The lifecycle hand-off above (`LOOM_MACHINE_CHECKOUT`) governs `start`/`stop`/
+`update`/`restart` — it does **not** apply to `loom-daemon dispatch <issue>` or
+the MCP `dispatch_sweep` tool, which target a **repo's working tree**, not the
+machine checkout. A worker host provisioned with the machine-level layout
+(checkout at `~/.local/share/loom`, one or more product repos registered via
+`loom-daemon workspace add`) used to require restarting the daemon with an
+explicit `WorkingDirectory=<repo>` override — collapsing the machine-level
+daemon back into a single-repo daemon — because `dispatch`/`dispatch_sweep`
+resolved an absent `--workspace`/`workspace_root` from the daemon's own cwd
+instead of the workspace registry. This is fixed: dispatch now consults
+`~/.loom/workspaces.json` for the explicit-param-absent case, so a daemon
+started with cwd = the machine checkout and exactly one registered workspace
+dispatches into that workspace with no `WorkingDirectory` override needed. See
+[`daemon-reference.md`](daemon-reference.md) → `dispatch_sweep` for the full
+resolution precedence.
+
 ### Supervision (reboot/crash) — macOS via launchd, Linux via systemd `--user`
 
 Reboot/crash supervision itself (as opposed to the workdir/pid-file relocation

--- a/loom-daemon/src/errors.rs
+++ b/loom-daemon/src/errors.rs
@@ -128,6 +128,7 @@ impl ErrorCode {
     pub const CONFIG_MISSING_FIELD: &'static str = "CONFIG_MISSING_FIELD";
     pub const CONFIG_INVALID_VALUE: &'static str = "CONFIG_INVALID_VALUE";
     pub const CONFIG_FILE_NOT_FOUND: &'static str = "CONFIG_FILE_NOT_FOUND";
+    pub const CONFIG_WORKSPACE_AMBIGUOUS: &'static str = "CONFIG_WORKSPACE_AMBIGUOUS";
 
     // Activity database error codes
     pub const ACTIVITY_DB_LOCKED: &'static str = "ACTIVITY_DB_LOCKED";
@@ -379,6 +380,36 @@ impl DaemonError {
         )
         .recoverable(false)
         .with_details(serde_json::json!({ "raw": raw }))
+    }
+
+    // Configuration errors
+    /// Creates a "dispatch workspace ambiguous" error (Issue #4299): raised by
+    /// `DispatchSweep` resolution when the daemon's seeded default workspace
+    /// (its cwd) is not itself registered and more than one workspace is
+    /// registered, so there is no safe default target — never resolved via a
+    /// silent cwd fallback. `registered` lists every currently-registered
+    /// workspace root so the caller/operator can supply one via
+    /// `--workspace`/`workspace_root`.
+    #[must_use]
+    pub fn workspace_ambiguous(registered: &[std::path::PathBuf]) -> Self {
+        let roots: Vec<String> = registered.iter().map(|p| p.display().to_string()).collect();
+        Self::new(
+            ErrorDomain::Configuration,
+            ErrorCode::CONFIG_WORKSPACE_AMBIGUOUS,
+            format!(
+                "dispatch target is ambiguous: the daemon's default workspace is not \
+                 registered and {} workspaces are registered ({}) — pass an explicit \
+                 --workspace/workspace_root",
+                roots.len(),
+                roots.join(", ")
+            ),
+        )
+        .recoverable(false)
+        .with_details(serde_json::json!({ "registered": roots }))
+        .with_recovery_hint(
+            "Specify the target repo explicitly: `loom-daemon dispatch <N> --workspace <path>` \
+             (CLI) or `workspace_root` (MCP dispatch_sweep).",
+        )
     }
 
     // Internal errors

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1380,6 +1380,73 @@ fn resolve_registry(
     }
 }
 
+/// Resolve which per-repo [`SweepRegistry`] a `DispatchSweep` request targets
+/// (Issue #4299). Unlike [`resolve_registry`] (used by every read path —
+/// `ListSweeps`, `GetSweepStatus`, quarantine requests — which keeps its
+/// unconditional cwd-registry fallback; changing those defaults is out of
+/// scope here), the **dispatch** path never silently trusts the daemon's own
+/// cwd for the explicit-param-absent case. It consults the on-disk
+/// [`WorkspaceRegistry`] instead:
+///
+/// - `workspace_root` `Some(non-empty)` -> unchanged: normalize and
+///   provision/return that repo's registry (explicit param always wins).
+/// - `workspace_root` `None`/empty -> [`WorkspaceRegistry::resolve_dispatch_root`]
+///   against the seeded default (`default`'s own `workspace_root`) decides:
+///   empty registry or seeded-default-is-registered both resolve back to
+///   `default` (byte-for-byte pre-#4299 behavior); a single non-cwd
+///   registration provisions that workspace; multiple non-cwd registrations
+///   with no seeded-default match returns a structured ambiguity error naming
+///   every registered root instead of guessing.
+///
+/// A `WorkspaceRegistry::load_default()` failure (e.g. a corrupt registry
+/// file) degrades to the empty-registry behavior (seeded default) rather than
+/// blocking dispatch entirely — mirroring the existing `unwrap_or_default()`
+/// precedent used elsewhere for registry reads (`main.rs`'s `workspace list`
+/// handlers).
+/// Returns `Err(Response::StructuredError(..))` (rather than a bare
+/// `DaemonError`) so the caller can propagate it directly as the arm's
+/// response. `Response` is the same "big enum" every other IPC handler
+/// returns directly (never via `Result`), so `clippy::result_large_err` fires
+/// here purely because of the `Result` wrapper — allowed rather than boxed to
+/// match the rest of this file's `Response`-as-return-value convention.
+#[allow(clippy::result_large_err)]
+fn resolve_dispatch_registry(
+    default: &Arc<Mutex<SweepRegistry>>,
+    workspace_pool: &Arc<WorkspacePool>,
+    workspace_root: Option<&str>,
+) -> Result<Arc<Mutex<SweepRegistry>>, Response> {
+    if let Some(root) = workspace_root {
+        if !root.trim().is_empty() {
+            let normalized = crate::workspace_registry::normalize_path(Path::new(root));
+            return Ok(workspace_pool.get_or_provision(&normalized));
+        }
+    }
+
+    let seeded_default = {
+        let sr = default.lock().expect("Sweep registry mutex poisoned");
+        sr.config().workspace_root.clone()
+    };
+    let registry = WorkspaceRegistry::load_default().unwrap_or_default();
+
+    match registry.resolve_dispatch_root(&seeded_default) {
+        // `SeededDefault` is a deliberate marker, not a path to re-derive and
+        // compare — see `resolve_dispatch_root`'s doc comment: reusing the
+        // literal `default` `Arc` (rather than re-provisioning via the pool
+        // from a normalized copy of `seeded_default`) is what guarantees this
+        // always resolves to the *same* registry instance `main` seeded the
+        // pool with, even when `seeded_default` contains an unresolved
+        // symlink component (e.g. a `/var` -> `/private/var` tempdir on
+        // macOS) that would otherwise make a path-equality check miss.
+        crate::workspace_registry::DispatchRootResolution::SeededDefault => Ok(default.clone()),
+        crate::workspace_registry::DispatchRootResolution::Registered(root) => {
+            Ok(workspace_pool.get_or_provision(&root))
+        }
+        crate::workspace_registry::DispatchRootResolution::Ambiguous { registered } => {
+            Err(Response::StructuredError(DaemonError::workspace_ambiguous(&registered)))
+        }
+    }
+}
+
 // ============================================================================
 // dispatch_sweep headroom advisory (#4234 — Gap 1 of the #4231 decomposition)
 // ============================================================================
@@ -2204,8 +2271,19 @@ fn handle_request(
                     }
                 }
             }
-            let target =
-                resolve_registry(sweep_registry, workspace_pool, workspace_root.as_deref());
+            // Dispatch-only resolution (Issue #4299): consults the workspace
+            // registry for the explicit-param-absent case instead of always
+            // trusting the daemon's own cwd. See `resolve_dispatch_registry`'s
+            // doc comment for the full precedence and why this differs from
+            // `resolve_registry` (used by the read paths below).
+            let target = match resolve_dispatch_registry(
+                sweep_registry,
+                workspace_pool,
+                workspace_root.as_deref(),
+            ) {
+                Ok(target) => target,
+                Err(response) => return response,
+            };
             let mut sr = target.lock().expect("Sweep registry mutex poisoned");
             // Model resolution (issue #3944): an explicit `model` param still
             // wins, but an ABSENT one falls back to `autonomous.model` in
@@ -3099,6 +3177,10 @@ exit 0
     fn test_dispatch_sweep_still_dispatches_under_synthetic_low_headroom() {
         let (tm, db, _, bus) = setup_test_context();
         let (sr, _dir, _rec) = setup_sweep_registry_in_tempdir();
+        // Absent `workspace_root` now consults the on-disk workspace registry
+        // (#4299) — pin it to an empty temp registry so this test's outcome
+        // never depends on the host's real `~/.loom/workspaces.json`.
+        let _registry_guard = seed_temp_registry(&[]);
 
         std::env::set_var(crate::work_finder::WORK_FINDER_MAX_CONCURRENT_ENV, "1");
 
@@ -3286,11 +3368,243 @@ exit 0
         );
     }
 
+    // ===== Dispatch-path workspace resolution (#4299) =====
+
+    /// Registers `path` as the sole workspace at a temp registry file (via
+    /// [`crate::workspace_registry::REGISTRY_PATH_ENV`]) and returns a guard
+    /// that clears the env var on drop, so `WorkspaceRegistry::load_default()`
+    /// inside `resolve_dispatch_registry` never touches the real
+    /// `~/.loom/workspaces.json`.
+    struct RegistryEnvGuard {
+        _dir: tempfile::TempDir,
+    }
+    impl Drop for RegistryEnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var(crate::workspace_registry::REGISTRY_PATH_ENV);
+        }
+    }
+    fn seed_temp_registry(roots: &[&Path]) -> RegistryEnvGuard {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("workspaces.json");
+        std::env::set_var(crate::workspace_registry::REGISTRY_PATH_ENV, &path);
+        let mut registry = WorkspaceRegistry::default();
+        for root in roots {
+            registry.add(root, None).unwrap();
+        }
+        registry.save(&path).unwrap();
+        RegistryEnvGuard { _dir: dir }
+    }
+
+    /// Issue #4299 — the Linux worker-host shape this issue exists to fix:
+    /// exactly one workspace is registered and it is NOT the daemon's seeded
+    /// default (its cwd). An absent `workspace_root` on `DispatchSweep` must
+    /// still target the single registration, not the unregistered default.
+    #[test]
+    #[serial_test::serial]
+    fn test_dispatch_sweep_absent_workspace_root_targets_single_registration() {
+        let (tm, db, _, bus) = setup_test_context();
+        let (sr_default, dir_a, _rec_a) = setup_sweep_registry_in_tempdir();
+        let (sr_b, dir_b, _rec_b) = setup_sweep_registry_in_tempdir();
+        let root_a = crate::workspace_registry::normalize_path(dir_a.path());
+        let root_b = crate::workspace_registry::normalize_path(dir_b.path());
+
+        let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
+        pool.seed(root_a, sr_default.clone());
+        pool.seed(root_b.clone(), sr_b.clone());
+
+        // Registry names ONLY repo B — repo A (the seeded default) is
+        // unregistered, mirroring a machine-checkout daemon cwd with one
+        // registered product repo.
+        let _guard = seed_temp_registry(&[dir_b.path()]);
+
+        let dispatched = handle_request(
+            Request::DispatchSweep {
+                kind: SweepKind::Issue(4299),
+                idempotency_key: None,
+                model: None,
+                effort: None,
+                depends_on: None,
+                workspace_root: None,
+                force: false,
+            },
+            &tm,
+            &db,
+            &sr_default,
+            &bus,
+            &pool,
+        );
+        assert!(
+            matches!(dispatched, Response::SweepDispatched { .. }),
+            "expected SweepDispatched, got: {dispatched:?}"
+        );
+
+        // Repo B's registry sees the dispatched sweep...
+        let listed_b = handle_request(
+            Request::ListSweeps {
+                state_filter: None,
+                workspace_root: Some(dir_b.path().to_string_lossy().into_owned()),
+            },
+            &tm,
+            &db,
+            &sr_default,
+            &bus,
+            &pool,
+        );
+        match listed_b {
+            Response::SweepList { sweeps } => {
+                assert_eq!(
+                    sweeps.len(),
+                    1,
+                    "the single registered workspace must receive the sweep"
+                )
+            }
+            other => panic!("Expected SweepList, got: {other:?}"),
+        }
+
+        // ...and the unregistered default (repo A / daemon cwd) does NOT.
+        let listed_default = handle_request(
+            Request::ListSweeps {
+                state_filter: None,
+                workspace_root: None,
+            },
+            &tm,
+            &db,
+            &sr_default,
+            &bus,
+            &pool,
+        );
+        match listed_default {
+            Response::SweepList { sweeps } => assert!(
+                sweeps.is_empty(),
+                "the daemon's own (unregistered) cwd must NOT receive the sweep"
+            ),
+            other => panic!("Expected SweepList, got: {other:?}"),
+        }
+    }
+
+    /// Issue #4299 — with multiple registered workspaces and a seeded default
+    /// that is itself unregistered, an absent `workspace_root` must return a
+    /// structured ambiguity error naming every registered root, never a silent
+    /// cwd fallback.
+    #[test]
+    #[serial_test::serial]
+    fn test_dispatch_sweep_ambiguous_registry_errors_without_explicit_param() {
+        let (tm, db, _, bus) = setup_test_context();
+        let (sr_default, dir_a, _rec_a) = setup_sweep_registry_in_tempdir();
+        let (sr_b, dir_b, _rec_b) = setup_sweep_registry_in_tempdir();
+        let (sr_c, dir_c, _rec_c) = setup_sweep_registry_in_tempdir();
+        let root_a = crate::workspace_registry::normalize_path(dir_a.path());
+        let root_b = crate::workspace_registry::normalize_path(dir_b.path());
+        let root_c = crate::workspace_registry::normalize_path(dir_c.path());
+
+        let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
+        pool.seed(root_a, sr_default.clone());
+        pool.seed(root_b.clone(), sr_b.clone());
+        pool.seed(root_c.clone(), sr_c.clone());
+
+        let _guard = seed_temp_registry(&[dir_b.path(), dir_c.path()]);
+
+        let dispatched = handle_request(
+            Request::DispatchSweep {
+                kind: SweepKind::Issue(4299),
+                idempotency_key: None,
+                model: None,
+                effort: None,
+                depends_on: None,
+                workspace_root: None,
+                force: false,
+            },
+            &tm,
+            &db,
+            &sr_default,
+            &bus,
+            &pool,
+        );
+        match dispatched {
+            Response::StructuredError(err) => {
+                assert_eq!(err.code.0, crate::errors::ErrorCode::CONFIG_WORKSPACE_AMBIGUOUS);
+                assert!(
+                    err.message.contains(&root_b.display().to_string())
+                        && err.message.contains(&root_c.display().to_string()),
+                    "ambiguity error must name every registered root, got: {}",
+                    err.message
+                );
+            }
+            other => panic!("Expected StructuredError, got: {other:?}"),
+        }
+    }
+
+    /// Issue #4299 — the #4027 wedge-loop guard must evaluate the *resolved*
+    /// workspace (the single registration), not the daemon's own unregistered
+    /// cwd: the error names repo B's root, not repo A's.
+    #[test]
+    #[serial_test::serial]
+    fn test_dispatch_sweep_wedge_guard_names_resolved_workspace_not_cwd() {
+        let (tm, db, _, bus) = setup_test_context();
+        let dir_a = tempdir().unwrap();
+        let dir_b = tempdir().unwrap();
+        // Neither workspace has `.claude/commands/loom/sweep.md`, and
+        // `skip_label_flip` is left at its default `false` so the #4027 guard
+        // is actually evaluated (unlike `setup_sweep_registry_in_tempdir`,
+        // which sets `skip_label_flip = true` for its other fixtures).
+        let sr_default = Arc::new(Mutex::new(SweepRegistry::new(SweepRegistryConfig::new(
+            dir_a.path().to_path_buf(),
+        ))));
+        let sr_b = Arc::new(Mutex::new(SweepRegistry::new(SweepRegistryConfig::new(
+            dir_b.path().to_path_buf(),
+        ))));
+        let root_a = crate::workspace_registry::normalize_path(dir_a.path());
+        let root_b = crate::workspace_registry::normalize_path(dir_b.path());
+
+        let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
+        pool.seed(root_a.clone(), sr_default.clone());
+        pool.seed(root_b.clone(), sr_b.clone());
+
+        let _guard = seed_temp_registry(&[dir_b.path()]);
+
+        let dispatched = handle_request(
+            Request::DispatchSweep {
+                kind: SweepKind::Issue(4299),
+                idempotency_key: None,
+                model: None,
+                effort: None,
+                depends_on: None,
+                workspace_root: None,
+                force: false,
+            },
+            &tm,
+            &db,
+            &sr_default,
+            &bus,
+            &pool,
+        );
+        match dispatched {
+            Response::Error { message } => {
+                // The guard message embeds `SweepRegistryConfig::workspace_root`
+                // verbatim, which here is the *raw* tempdir path each `sr_*` was
+                // constructed with (not the canonicalized `root_a`/`root_b` used
+                // as the pool's dedup key) — assert against that raw form.
+                assert!(
+                    message.contains(&dir_b.path().display().to_string()),
+                    "wedge-guard error must name the resolved workspace (repo B), got: {message}"
+                );
+                assert!(
+                    !message.contains(&dir_a.path().display().to_string()),
+                    "wedge-guard error must NOT name the daemon's own unregistered cwd, got: {message}"
+                );
+            }
+            other => panic!("Expected Error (wedge-guard refusal), got: {other:?}"),
+        }
+    }
+
     #[test]
     #[serial_test::serial]
     fn test_handle_request_dispatch_sweep_happy_path() {
         let (tm, db, _, bus) = setup_test_context();
         let (sr, _dir, _rec) = setup_sweep_registry_in_tempdir();
+        // #4299: pin the registry to empty so `workspace_root: None` resolution
+        // is deterministic regardless of the host's real registry.
+        let _registry_guard = seed_temp_registry(&[]);
 
         let response = handle_request(
             Request::DispatchSweep {
@@ -3370,6 +3684,9 @@ exit 0
     fn test_handle_request_dispatch_sweep_exports_claim_ownership_marker() {
         let (tm, db, _, bus) = setup_test_context();
         let (sr, _dir, record_log) = setup_sweep_registry_in_tempdir();
+        // #4299: pin the registry to empty so `workspace_root: None` resolution
+        // is deterministic regardless of the host's real registry.
+        let _registry_guard = seed_temp_registry(&[]);
 
         let response = handle_request(
             Request::DispatchSweep {
@@ -3420,9 +3737,13 @@ exit 0
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_handle_request_dispatch_sweep_rejects_prset_in_phase_a() {
         let (tm, db, _, bus) = setup_test_context();
         let (sr, _dir, _rec) = setup_sweep_registry_in_tempdir();
+        // #4299: pin the registry to empty so `workspace_root: None` resolution
+        // is deterministic regardless of the host's real registry.
+        let _registry_guard = seed_temp_registry(&[]);
 
         let response = handle_request(
             Request::DispatchSweep {
@@ -3954,6 +4275,9 @@ exit 0
     fn test_handle_request_get_sweep_status_returns_existing() {
         let (tm, db, _, bus) = setup_test_context();
         let (sr, _dir, _rec) = setup_sweep_registry_in_tempdir();
+        // #4299: pin the registry to empty so `workspace_root: None` resolution
+        // is deterministic regardless of the host's real registry.
+        let _registry_guard = seed_temp_registry(&[]);
 
         // Dispatch a sweep to get a real entry in the registry.
         let dispatched = handle_request(

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -797,6 +797,14 @@ async fn main() -> Result<()> {
     // recovery on restart relies on lock dirs + sweep checkpoints + the
     // forge (labels). The reaper task polls live PIDs on a configurable
     // interval (`LOOM_SWEEP_REAPER_INTERVAL_SECS`, default 30s).
+    //
+    // `sweep_workspace` seeds the *default* registry only. As of #4299, an
+    // explicit-`workspace_root`-absent `DispatchSweep`/`dispatch_sweep`
+    // request no longer blindly trusts this cwd-derived value as its target:
+    // `ipc::resolve_dispatch_registry` consults the on-disk workspace
+    // registry first and only falls back to this default when the registry
+    // is empty or this root is itself registered. See that function's doc
+    // comment for the full precedence.
     let sweep_workspace = workspace_from_env
         .as_ref()
         .map(std::path::PathBuf::from)
@@ -2452,11 +2460,41 @@ fn build_dispatch_request(
     }
 }
 
+/// Resolve the `dispatch` subcommand's effective `--workspace` (Issue #4299):
+/// an explicit `--workspace` always wins; when absent, defaults it from the
+/// CLI process's own `cwd` if `cwd` falls under a registered workspace root —
+/// the daemon cannot see the client's cwd, so if that resolution is going to
+/// happen at all it must happen client-side, before the `DispatchSweep`
+/// request is built. This is what fixes `loom-daemon dispatch <N>` run from
+/// inside a registered repo previously making no difference. A `cwd` outside
+/// every registered root (or an empty registry) leaves the result `None`, and
+/// the daemon's own registry-based resolution (`ipc::resolve_dispatch_registry`)
+/// then applies.
+///
+/// Pure and side-effect-free — takes the already-resolved `cwd` and
+/// already-loaded `registry` rather than performing I/O itself, so it is
+/// unit-testable without touching the real filesystem/env; `cwd`/`registry`
+/// are resolved once by [`handle_dispatch_command`] via `std::env::current_dir()`
+/// / `WorkspaceRegistry::load_default()`.
+fn resolve_cli_dispatch_workspace(
+    explicit: Option<String>,
+    cwd: &Path,
+    registry: &loom_daemon::workspace_registry::WorkspaceRegistry,
+) -> Option<String> {
+    explicit.or_else(|| {
+        loom_daemon::workspace_registry::resolve_client_workspace_default(cwd, registry)
+            .map(|root| root.to_string_lossy().into_owned())
+    })
+}
+
 /// Handle the `dispatch` subcommand (Issue #3952). Connects to the running
 /// daemon over its Unix socket and enqueues a sweep via the same `DispatchSweep`
 /// request the MCP `dispatch_sweep` tool uses — but with a bounded client-side
 /// ack timeout so a wedged daemon can never hang the CLI (the #3945 failure
 /// mode). On success prints the sweep id + per-sweep log path and exits 0.
+///
+/// See [`resolve_cli_dispatch_workspace`] for the `--workspace` default logic
+/// applied here (Issue #4299).
 async fn handle_dispatch_command(
     issue: u32,
     workspace: Option<String>,
@@ -2465,6 +2503,11 @@ async fn handle_dispatch_command(
     depends_on: Option<u32>,
     force: bool,
 ) -> Result<()> {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let registry =
+        loom_daemon::workspace_registry::WorkspaceRegistry::load_default().unwrap_or_default();
+    let workspace = resolve_cli_dispatch_workspace(workspace, &cwd, &registry);
+
     let socket_path = resolve_socket_path()?;
     let request = build_dispatch_request(issue, workspace, model, effort, depends_on, force);
     let ack_timeout = resolve_dispatch_ack_timeout();
@@ -4699,8 +4742,8 @@ mod dispatch_tests {
     //! deliberately-unresponsive socket (the #3945 wedge must never hang).
     use super::{
         build_dispatch_request, classify_gate_verdict, format_gate_status, gate_status_short_label,
-        query_daemon_bounded, resolve_dispatch_ack_timeout, GateVerdict, DAEMON_IPC_TIMEOUT_ENV,
-        DISPATCH_ACK_TIMEOUT,
+        query_daemon_bounded, resolve_cli_dispatch_workspace, resolve_dispatch_ack_timeout,
+        GateVerdict, DAEMON_IPC_TIMEOUT_ENV, DISPATCH_ACK_TIMEOUT,
     };
     use chrono::{DateTime, Utc};
     use loom_daemon::types::{Request, Response, SweepKind};
@@ -4767,6 +4810,47 @@ mod dispatch_tests {
             }
             other => panic!("expected DispatchSweep, got {other:?}"),
         }
+    }
+
+    // ===== `resolve_cli_dispatch_workspace` (Issue #4299) =====
+
+    /// An explicit `--workspace` always wins, regardless of cwd/registry state.
+    #[test]
+    fn resolve_cli_dispatch_workspace_explicit_always_wins() {
+        let registry = loom_daemon::workspace_registry::WorkspaceRegistry::default();
+        let resolved = resolve_cli_dispatch_workspace(
+            Some("/explicit/repo".to_string()),
+            std::path::Path::new("/somewhere/else"),
+            &registry,
+        );
+        assert_eq!(resolved.as_deref(), Some("/explicit/repo"));
+    }
+
+    /// Issue #4299's core CLI fix: running `loom-daemon dispatch <N>` from
+    /// inside a registered repo (no `--workspace` flag) must default
+    /// `workspace_root` to that repo's root.
+    #[test]
+    fn resolve_cli_dispatch_workspace_defaults_from_cwd_inside_registered_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+
+        let mut registry = loom_daemon::workspace_registry::WorkspaceRegistry::default();
+        registry.add(&repo, None).unwrap();
+
+        let canonical_repo = std::fs::canonicalize(&repo).unwrap();
+        let resolved = resolve_cli_dispatch_workspace(None, &repo, &registry);
+        assert_eq!(resolved, Some(canonical_repo.to_string_lossy().into_owned()));
+    }
+
+    /// A cwd outside every registered root (or an empty registry) leaves the
+    /// result `None` — the daemon's own registry-based resolution applies.
+    #[test]
+    fn resolve_cli_dispatch_workspace_none_when_cwd_unregistered() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = loom_daemon::workspace_registry::WorkspaceRegistry::default();
+        let resolved = resolve_cli_dispatch_workspace(None, dir.path(), &registry);
+        assert_eq!(resolved, None);
     }
 
     /// A fake daemon that accepts one connection, verifies the received request

--- a/loom-daemon/src/workspace_registry.rs
+++ b/loom-daemon/src/workspace_registry.rs
@@ -156,6 +156,37 @@ fn looks_like_workspace(root: &Path) -> bool {
     root.join(".git").exists() || root.join(".loom").exists()
 }
 
+/// Resolve the **client-side** `--workspace` default for the `loom-daemon
+/// dispatch` CLI (Issue #4299): if `cwd` falls under (or exactly at) a
+/// registered workspace root, return that root so `dispatch` run from inside a
+/// registered repo targets it — fixing the observed case where the client's
+/// own cwd made no difference to dispatch (the daemon cannot see the CLI's
+/// cwd, so this must be resolved client-side, before the request is built).
+///
+/// Pure and side-effect-free: takes the already-loaded `registry` and an
+/// already-resolved `cwd` rather than performing I/O itself, so it is
+/// unit-testable without touching the filesystem or environment. Returns
+/// `None` when `cwd` is not under any registered root — the daemon's own
+/// [`WorkspaceRegistry::resolve_dispatch_root`] then applies for the
+/// explicit-param-absent case.
+///
+/// When more than one registered root would match (nested workspaces), the
+/// **longest** (most specific) matching root wins.
+#[must_use]
+pub fn resolve_client_workspace_default(
+    cwd: &Path,
+    registry: &WorkspaceRegistry,
+) -> Option<PathBuf> {
+    let cwd = normalize_path(cwd);
+    registry
+        .workspaces
+        .iter()
+        .map(|w| &w.root)
+        .filter(|root| cwd.starts_with(root.as_path()))
+        .max_by_key(|root| root.as_os_str().len())
+        .cloned()
+}
+
 impl WorkspaceRegistry {
     /// Load the registry from `path`. A missing file yields an empty registry
     /// (the common first-run case). A present-but-unparseable file is an error
@@ -325,6 +356,82 @@ impl WorkspaceRegistry {
             self.roots()
         }
     }
+
+    /// Resolve the default target workspace for an **explicit-param-absent**
+    /// `DispatchSweep` request (Issue #4299) — deterministic local resolution
+    /// from registry state, never a forge probe (issue numbers are per-repo, so
+    /// "which repo owns issue N" is ill-defined without an explicit target).
+    ///
+    /// `seeded_default` is the daemon's seeded default workspace (its own cwd
+    /// at startup, or `LOOM_WORKSPACE`) — **not required to be pre-normalized**;
+    /// this normalizes it internally before comparing against registry entries
+    /// (which are always stored normalized).
+    ///
+    /// Deliberately returns [`DispatchRootResolution::SeededDefault`] as a
+    /// distinct marker rather than the seeded path itself: the daemon's real
+    /// default registry is keyed in the [`crate::workspace_pool::WorkspacePool`]
+    /// by the caller's own (possibly-unnormalized) `sweep_workspace` value, so a
+    /// caller that re-derives "is this the default?" via path *equality*
+    /// against a freshly-normalized copy can silently mismatch on a symlinked
+    /// tempdir/mount and re-provision a **second, distinct** registry instance
+    /// for the same logical directory — orphaning the real default's reaper,
+    /// journal, and in-memory dedup state. Returning a marker instead makes
+    /// "use the literal seeded default registry" structurally unambiguous.
+    ///
+    /// Precedence, in order:
+    /// 1. Registry **empty** -> the seeded default (byte-for-byte pre-registry
+    ///    behavior — mirrors [`effective_roots`](Self::effective_roots)).
+    /// 2. Seeded default **is registered** -> the seeded default. Back-compat is
+    ///    load-bearing here: existing multi-workspace hosts run the daemon from
+    ///    a registered workspace, and any other outcome would break every bare
+    ///    `loom-daemon dispatch <N>` on them.
+    /// 3. Seeded default **not registered**, exactly **one** registered
+    ///    workspace -> that workspace (the single-registration Linux-worker
+    ///    case this issue exists to fix).
+    /// 4. Seeded default **not registered**, **multiple** registered
+    ///    workspaces -> [`DispatchRootResolution::Ambiguous`], never a silent
+    ///    cwd fallback.
+    #[must_use]
+    pub fn resolve_dispatch_root(&self, seeded_default: &Path) -> DispatchRootResolution {
+        if self.workspaces.is_empty() {
+            return DispatchRootResolution::SeededDefault;
+        }
+
+        let normalized_default = normalize_path(seeded_default);
+        if self.contains(&normalized_default) {
+            return DispatchRootResolution::SeededDefault;
+        }
+
+        let roots = self.roots();
+        if roots.len() == 1 {
+            return DispatchRootResolution::Registered(
+                roots.into_iter().next().unwrap_or(normalized_default),
+            );
+        }
+
+        DispatchRootResolution::Ambiguous { registered: roots }
+    }
+}
+
+/// Outcome of [`WorkspaceRegistry::resolve_dispatch_root`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DispatchRootResolution {
+    /// Use the daemon's own seeded default registry as-is — either the
+    /// registry is empty (pre-registry back-compat) or the seeded default is
+    /// itself a registered workspace. The caller must dispatch through its
+    /// existing default registry instance, never re-provision one.
+    SeededDefault,
+    /// Use this other, specific registered workspace root (provisioned via the
+    /// workspace pool).
+    Registered(PathBuf),
+    /// The daemon's seeded default isn't registered and more than one
+    /// workspace is registered — no safe default; the caller must ask for an
+    /// explicit `--workspace`/`workspace_root`. Carries the full registered set
+    /// so the caller can list it in the error.
+    Ambiguous {
+        /// The currently-registered workspace roots, in registry order.
+        registered: Vec<PathBuf>,
+    },
 }
 
 #[cfg(test)]
@@ -653,5 +760,144 @@ mod tests {
             reg.workspaces[0].priority, DEFAULT_WORKSPACE_PRIORITY,
             "an entry with no `priority` parses as the default (backward compat)"
         );
+    }
+
+    // ===================================================================
+    // Dispatch-path workspace resolution (#4299)
+    // ===================================================================
+
+    #[test]
+    fn resolve_dispatch_root_empty_registry_uses_seeded_default() {
+        let reg = WorkspaceRegistry::default();
+        let seeded = PathBuf::from("/some/cwd/wherever");
+        assert_eq!(
+            reg.resolve_dispatch_root(&seeded),
+            DispatchRootResolution::SeededDefault,
+            "empty registry preserves byte-for-byte pre-registry (cwd) behavior"
+        );
+    }
+
+    #[test]
+    fn resolve_dispatch_root_seeded_default_registered_wins() {
+        let dir = tempdir().unwrap();
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::create_dir_all(&b).unwrap();
+
+        let mut reg = WorkspaceRegistry::default();
+        reg.add(&a, None).unwrap();
+        reg.add(&b, None).unwrap();
+
+        assert_eq!(
+            reg.resolve_dispatch_root(&a),
+            DispatchRootResolution::SeededDefault,
+            "existing multi-workspace hosts (daemon cwd == a registered root) keep the \
+             same default with no new flags"
+        );
+    }
+
+    #[test]
+    fn resolve_dispatch_root_single_unregistered_seed_targets_the_registration() {
+        // The Linux worker-host shape this issue exists to fix: daemon cwd is
+        // the machine checkout (unregistered), exactly one workspace (anvil) is
+        // registered.
+        let dir = tempdir().unwrap();
+        let machine_checkout = dir.path().join("machine-checkout");
+        let anvil = dir.path().join("anvil");
+        std::fs::create_dir_all(&machine_checkout).unwrap();
+        std::fs::create_dir_all(&anvil).unwrap();
+
+        let mut reg = WorkspaceRegistry::default();
+        reg.add(&anvil, None).unwrap();
+
+        let canonical_anvil = std::fs::canonicalize(&anvil).unwrap();
+        assert_eq!(
+            reg.resolve_dispatch_root(&machine_checkout),
+            DispatchRootResolution::Registered(canonical_anvil)
+        );
+    }
+
+    #[test]
+    fn resolve_dispatch_root_multiple_unregistered_seed_is_ambiguous() {
+        let dir = tempdir().unwrap();
+        let machine_checkout = dir.path().join("machine-checkout");
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        std::fs::create_dir_all(&machine_checkout).unwrap();
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::create_dir_all(&b).unwrap();
+
+        let mut reg = WorkspaceRegistry::default();
+        reg.add(&a, None).unwrap();
+        reg.add(&b, None).unwrap();
+
+        match reg.resolve_dispatch_root(&machine_checkout) {
+            DispatchRootResolution::Ambiguous { registered } => {
+                assert_eq!(registered.len(), 2, "ambiguity error names every registered root");
+                assert!(registered.contains(&std::fs::canonicalize(&a).unwrap()));
+                assert!(registered.contains(&std::fs::canonicalize(&b).unwrap()));
+            }
+            other => panic!("expected Ambiguous, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_client_workspace_default_matches_cwd_under_root() {
+        let dir = tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        let nested = repo.join("subdir");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let mut reg = WorkspaceRegistry::default();
+        reg.add(&repo, None).unwrap();
+
+        let canonical_repo = std::fs::canonicalize(&repo).unwrap();
+        assert_eq!(
+            resolve_client_workspace_default(&repo, &reg),
+            Some(canonical_repo.clone()),
+            "cwd exactly at the registered root matches"
+        );
+        assert_eq!(
+            resolve_client_workspace_default(&nested, &reg),
+            Some(canonical_repo),
+            "cwd nested under the registered root matches"
+        );
+    }
+
+    #[test]
+    fn resolve_client_workspace_default_no_match_outside_any_root() {
+        let dir = tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        let elsewhere = dir.path().join("elsewhere");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::fs::create_dir_all(&elsewhere).unwrap();
+
+        let mut reg = WorkspaceRegistry::default();
+        reg.add(&repo, None).unwrap();
+
+        assert_eq!(resolve_client_workspace_default(&elsewhere, &reg), None);
+    }
+
+    #[test]
+    fn resolve_client_workspace_default_empty_registry_is_none() {
+        let reg = WorkspaceRegistry::default();
+        let dir = tempdir().unwrap();
+        assert_eq!(resolve_client_workspace_default(dir.path(), &reg), None);
+    }
+
+    #[test]
+    fn resolve_client_workspace_default_prefers_most_specific_nested_match() {
+        let dir = tempdir().unwrap();
+        let outer = dir.path().join("outer");
+        let inner = outer.join("inner");
+        std::fs::create_dir_all(&inner).unwrap();
+
+        let mut reg = WorkspaceRegistry::default();
+        reg.add(&outer, None).unwrap();
+        reg.add(&inner, None).unwrap();
+
+        let canonical_inner = std::fs::canonicalize(&inner).unwrap();
+        assert_eq!(resolve_client_workspace_default(&inner, &reg), Some(canonical_inner));
     }
 }


### PR DESCRIPTION
## Summary

`loom-daemon dispatch <N>` and MCP `dispatch_sweep` resolved an absent `workspace_root` from the daemon's own seeded default (`LOOM_WORKSPACE` env → daemon process cwd → `"."`) instead of consulting the workspace registry. On a multi-workspace worker host whose daemon cwd is the machine checkout (not a registered repo), this made every dispatch of a registered repo's issue reject with the #4027 wedge-loop guard firing against the wrong workspace.

Dispatch-path resolution now consults `~/.loom/workspaces.json` (`WorkspaceRegistry::resolve_dispatch_root`, in `loom-daemon/src/workspace_registry.rs`) whenever `workspace_root` is absent/empty:

1. Registry empty → seeded default (byte-for-byte pre-#4299 behavior).
2. Seeded default is itself registered → seeded default (back-compat: existing multi-workspace hosts keep working with no new flags).
3. Seeded default not registered, exactly one registered workspace → that workspace (the Linux worker-host shape this issue exists to fix).
4. Seeded default not registered, multiple registered workspaces → a structured `CONFIG_WORKSPACE_AMBIGUOUS` error naming every registered root — never a silent cwd fallback.

The `loom-daemon dispatch` CLI additionally defaults `--workspace` client-side from its own cwd when run inside a registered repo (`resolve_cli_dispatch_workspace` in `main.rs`), since the daemon cannot see the client's cwd.

Read paths (`ListSweeps`, `GetSweepStatus`, quarantine requests) are unchanged by design — they already have their own unconditional cwd-registry fallback and `work_finder::tick_multi` / the role runner / epic supervisor / health gate were never affected (they already resolve per-workspace via `WorkspaceRegistry::effective_roots()`). No change to the #4027 wedge-loop guard itself — it evaluates whatever registry resolution now correctly picks.

## Changes

- `loom-daemon/src/workspace_registry.rs` — new `resolve_dispatch_root` (daemon-side precedence) and `resolve_client_workspace_default` (CLI cwd default) pure resolvers, with unit tests for all registry states.
- `loom-daemon/src/ipc.rs` — new `resolve_dispatch_registry` used only by the `DispatchSweep` arm of `handle_request` (read paths keep `resolve_registry` unchanged); IPC-level regression tests for single-registration targeting, ambiguity, and the wedge-guard naming the resolved workspace.
- `loom-daemon/src/main.rs` — `handle_dispatch_command` applies the client-side cwd default via `resolve_cli_dispatch_workspace` before building the `DispatchSweep` request; doc comments on `sweep_workspace` seeding.
- `loom-daemon/src/errors.rs` — new `CONFIG_WORKSPACE_AMBIGUOUS` error code + `DaemonError::workspace_ambiguous(...)` constructor.
- `defaults/docs/daemon-reference.md`, `defaults/docs/machine-dispatcher.md` — document the resolution precedence and retire the `WorkingDirectory=<repo>` workaround guidance for multi-workspace worker hosts.

## Test plan

- [x] `cd loom-daemon && cargo test` — full suite passes except 2 pre-existing `terminal::claude_config` tests that fail only under parallel execution (shared `$HOME/.claude` state) and pass individually and on main; unrelated to this change.
- [x] `cargo test --lib dispatch` — all 105 dispatch-related tests pass, including the new `#4299` resolver/IPC/wedge-guard tests.
- [x] `cargo clippy --all-targets` — clean.
- [x] Manual review: back-compat cases (empty registry, seeded-default-registered) preserve pre-#4299 behavior byte-for-byte per the new unit tests.

Closes #4299
