### PR TITLE
feat(mcp-loom): add force param to dispatch_sweep for host-breaker override

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1845,7 +1845,7 @@ already-observed** distress — a materially stronger signal than a single-tick
 headroom reading — so `dispatch_sweep` (CLI `loom-daemon dispatch <N>` / the
 `mcp__loom__dispatch_sweep` tool) is **refused** while the breaker is Open or
 CoolDown. An operator who knows the host is distressed and wants to dispatch anyway
-passes `--force` (CLI) / `force: true` (IPC).
+passes `--force` (CLI) / `force: true` (IPC / `mcp__loom__dispatch_sweep`).
 
 **Observability.** The breaker is surfaced three ways: a log line on every phase
 change; a state-change-deduped `daemon.host_breaker.state` event-bus event

--- a/mcp-loom/src/tools/sweeps.ts
+++ b/mcp-loom/src/tools/sweeps.ts
@@ -349,6 +349,7 @@ async function dispatchSweep(args: {
   effort?: string;
   depends_on?: number;
   workspace_root?: string;
+  force?: boolean;
 }): Promise<{ success: true; result: DispatchResponse["payload"] } | { success: false; error: string }> {
   try {
     const response = (await sendDaemonRequest({
@@ -373,6 +374,12 @@ async function dispatchSweep(args: {
         // default) dispatches into the daemon's default workspace, exactly as
         // before; a value routes the sweep into that managed repo's registry.
         workspace_root: args.workspace_root ?? null,
+        // Issue #4317: operator override for the host-distress circuit
+        // breaker (#4235/#4316). Unlike the other optional params above, the
+        // Rust-side field is a bare `bool` (not `Option<bool>`) — sending
+        // `null` here would fail serde deserialization on every dispatch, so
+        // this MUST default to `false`, never `null`/omitted.
+        force: args.force ?? false,
       },
     }, Math.max(DISPATCH_TIMEOUT_MS, resolveDaemonIpcTimeoutMs()))) as DaemonResponse;
 
@@ -711,6 +718,18 @@ export const sweepTools: Tool[] = [
             "repo's working tree / sweep registry — required to address a " +
             "managed repo other than the default when two repos share issue " +
             "numbers.",
+        },
+        force: {
+          type: "boolean",
+          description:
+            "Optional operator override for the host-distress circuit " +
+            "breaker (issue #4235). A tripped breaker represents sustained, " +
+            "already-observed host distress, so it hard-blocks an explicit " +
+            "dispatch_sweep by default. Set to `true` to say \"I know the " +
+            "host is distressed, dispatch anyway\" and bypass that block. " +
+            "Omit (or pass `false`) to preserve the default refuse-when-" +
+            "tripped behavior — mirrors the CLI's `loom-daemon dispatch <N> " +
+            "--force`.",
         },
       },
       required: ["kind"],
@@ -1116,6 +1135,9 @@ export async function handleSweepTool(
         args.depends_on > 0
           ? (args.depends_on as number)
           : undefined;
+      // Issue #4317: defensive extraction — only a literal boolean `true`
+      // forwards as `true` (e.g. the string `"true"` or `1` must NOT).
+      const force = args?.force === true;
 
       const result = await dispatchSweep({
         kind: normalized,
@@ -1124,6 +1146,7 @@ export async function handleSweepTool(
         effort,
         depends_on: dependsOn,
         workspace_root: extractWorkspaceRoot(args),
+        force,
       });
       if (!result.success) {
         return [


### PR DESCRIPTION
## Summary

`dispatch_sweep`'s Rust wire protocol (`DispatchSweep`) and the CLI
(`loom-daemon dispatch <N> --force`) both support overriding a tripped
#4235 host-distress circuit breaker via `force: bool` — but the
`mcp__loom__dispatch_sweep` MCP tool had no way to reach it, so an
MCP-driven dispatch could never override a tripped/cooling breaker (it
always sent the implicit default `false`).

## Changes

- `mcp-loom/src/tools/sweeps.ts`:
  - `dispatchSweep()` args + payload: add optional `force?: boolean`,
    forwarded as `args.force ?? false` (never `null` — the Rust-side field
    is a bare `bool`, not `Option<bool>`, so `null` would fail serde
    deserialization on every dispatch).
  - `dispatch_sweep`'s `inputSchema`: document the new optional `force`
    boolean property (not in `required`), describing the #4235 breaker
    semantics and mirroring the CLI's `--force`.
  - Tool handler: extract defensively (`args?.force === true`) so only a
    literal boolean `true` forwards as `true` — a stray string `"true"` or
    `1` does not.
- `defaults/docs/daemon-reference.md`: one-line update noting the MCP tool
  (`mcp__loom__dispatch_sweep`) now also reaches the override, alongside
  the existing CLI/IPC mentions.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `inputSchema` exposes optional `force` boolean with #4235-semantics description | ✅ | Added `force` property to `dispatch_sweep`'s `inputSchema.properties`, not in `required` |
| `dispatchSweep()` accepts `force?: boolean` and forwards it in the `DispatchSweep` payload | ✅ | Added to args type + payload |
| Absent `force` serializes as `false`, never `null` | ✅ | Payload uses `force: args.force ?? false` (all other optional params here use `?? null` deliberately, since their Rust fields are `Option<T>`; `force` is a bare `bool`) |
| Handler extracts defensively — only literal `true` forwards | ✅ | `const force = args?.force === true;` |
| Dispatch without `force` remains behavior-identical | ✅ | `npm test` (36/36 passing) + manual trace: omitted arg → `force: false` on the wire, matching pre-change behavior |

## Test Plan

- `cd mcp-loom && npm run typecheck` — passes (`tsc --noEmit`, 0 errors)
- `cd mcp-loom && npm run build` — passes (typecheck + esbuild bundle)
- `cd mcp-loom && npm test` — 36/36 tests passing (no existing test file
  covers `dispatchSweep`/`sweeps.ts` specifically; the two existing suites
  cover `config-resolver`/`config` and are unaffected)
- Manual read-through: verified `force: args.force ?? false` (not `?? null`)
  matches the curator's called-out serde constraint, and that the handler's
  `args?.force === true` rejects non-boolean truthy values (`"true"`, `1`)

Closes #4317
