### PR TITLE
feat(install): add `loom migrate` for historical consumer installs → daemon model

### DIFF
--- a/defaults/docs/machine-dispatcher.md
+++ b/defaults/docs/machine-dispatcher.md
@@ -440,7 +440,14 @@ boundary no matter where it is invoked. What one pass does:
    — **excluding `sweep.modelAliases`**. That key's Rust/Python resolvers diverge;
    migrating it would freeze the divergence into every consumer repo, so it is
    left in the (lower-precedence, on-disk) legacy tier and reported as excluded.
-   An existing `project.json` is left untouched (idempotency).
+   **Host-local keys** (`worktree.root` — a per-host scratch-disk path) are routed
+   to the **gitignored** `.loom-local/local.json` (the resolver's `LOCAL_CONFIG_REL`
+   tier), *not* the tracked, shared `project.json`: since this same pass
+   `git rm --cached`s the legacy config, `project.json` becomes the highest tier
+   every fresh clone / CI run picks up, so a stray `worktree.root` there would
+   silently propagate one operator's filesystem layout to the whole team. An
+   existing `project.json` is left untouched (idempotency); an existing
+   `local.json` override is preserved (only a missing `worktree.root` is filled in).
 3. **Untrack the committed implementation** per the manifest — `git rm --cached`
    (files stay on disk, just leave the index) + a gitignore block single-sourced
    with `install-loom.sh --local`. Only the machine-served namespaces (`/.loom/`,
@@ -458,7 +465,20 @@ boundary no matter where it is invoked. What one pass does:
    `.loom/sweep-checkpoint/`, `.loom/tokens/`) and the `loom.sh` / `.loom/bin/loom`
    shims are never touched, so `./loom.sh` and the per-repo pool manager keep
    working.
-6. **Register** the repo via `loom-daemon workspace add … --priority N` (skipped
+6. **Repair the MCP wiring** (#4386). A historical repo can carry a repo-scoped
+   `.mcp.json` whose `loom` server entry points into a long-dead worktree bundle
+   (e.g. `.loom/worktrees/issue-N/mcp-loom/dist/index.js`). Because Claude Code MCP
+   precedence is **local > project > user**, that repo-scoped entry silently
+   *shadows* the machine-level user-scope server — and when its path is a dead
+   worktree it kills every daemon-dispatched child at the claude-wrapper MCP
+   pre-flight (a fleet-wide spawn outage with no surfaced error). Migration strips
+   any repo-scoped `loom` entry from `.mcp.json` (deleting the file if `loom` was
+   its only server; other servers such as `safehouse` are kept — matching
+   `setup-mcp.sh`'s #4230 migration), then **verifies the user-scope `loom`
+   registration** exists and points at the machine checkout's
+   `mcp-loom/dist/index.js`, `claude mcp add --scope user`-ing it if absent or
+   mis-pointed (skipped with a clear note when the `claude` CLI is not on PATH).
+7. **Register** the repo via `loom-daemon workspace add … --priority N` (skipped
    with a clear note when `loom-daemon` is not on PATH), **re-stamp**
    `.loom/install-metadata.json` (`loom_version`, `loom_commit`,
    `migrated_to_machine_model`, `install_model`), and **refresh** the CLAUDE.md

--- a/defaults/docs/machine-dispatcher.md
+++ b/defaults/docs/machine-dispatcher.md
@@ -406,6 +406,81 @@ orphans an entry that lands in a project-level settings file.
 > or their project-level settings entries — that is Phase 6's `git rm --cached`
 > migration, which this replacement unblocks.
 
+## `loom migrate`: historical consumer install → daemon model (Epic #3835 Phase 6, #4254)
+
+`loom migrate` takes a repo carrying a **historical file-copy install** (a full
+committed copy of the Loom implementation under `.loom/`,
+`.claude/commands/loom/`, `.claude/agents/loom-*.md` plus a legacy
+`.loom/config.json` — the pre-daemon layout every consumer repo on ≤ 0.12 holds)
+to the machine-level daemon model in **one idempotent pass**. It is the final
+phase of Epic #3835: Phases 1–5 stood up the machine checkout, user-scope skills /
+agents / hooks / mcp, and the workspace registry; this phase retires the per-repo
+file copies that would otherwise shadow them and drift stale.
+
+Run it from inside the repo:
+
+```bash
+loom migrate --dry-run          # full file-by-file plan; makes no changes
+loom migrate                    # apply; prints a per-file report, stages the result
+loom migrate --priority 20      # workspace-registry priority (default 3)
+loom migrate --force            # proceed despite an uncommitted working tree
+```
+
+The dispatcher resolves the current repo root and delegates to
+`scripts/install/migrate-consumer.sh` in the machine checkout, exporting
+`LOOM_MACHINE_CHECKOUT` so the migration reads the current `defaults/` ownership
+boundary no matter where it is invoked. What one pass does:
+
+1. **Detect** the historical install from `.loom/install-metadata.json` + its
+   `installed_files` manifest. No metadata/manifest → a clean refusal, zero
+   changes. An uncommitted working tree → refuse unless `--force` (so the
+   migration's staged `git rm --cached` never entangles unrelated edits).
+2. **Extract project config** from the legacy `.loom/config.json` into the
+   **tracked** `.loom-project/project.json` (the Phase 2 resolver's project tier)
+   — **excluding `sweep.modelAliases`**. That key's Rust/Python resolvers diverge;
+   migrating it would freeze the divergence into every consumer repo, so it is
+   left in the (lower-precedence, on-disk) legacy tier and reported as excluded.
+   An existing `project.json` is left untouched (idempotency).
+3. **Untrack the committed implementation** per the manifest — `git rm --cached`
+   (files stay on disk, just leave the index) + a gitignore block single-sourced
+   with `install-loom.sh --local`. Only the machine-served namespaces (`/.loom/`,
+   `/.claude/commands/loom/`, `/.claude/agents/loom-*.md`) are untracked; genuinely
+   repo-level manifest entries (`.github/*`, `.codex/*`, `.gitignore`,
+   `package.json`) stay **tracked**. Nothing outside the manifest is ever touched
+   (the #3450 ownership rule).
+4. **Remove deprecated artifacts** — the `loom-iteration.md` / `loom-parent.md`
+   two-tier-daemon tombstones (removed as a subsystem in v0.10.0, #3372) and any
+   manifest entry under a Loom namespace no longer shipped by current `defaults/`
+   (shepherd-era scripts) are deleted from disk **and** index.
+5. **Preserve**: `.loom/resync-ignore` pins stay tracked and are reported;
+   locally-modified files are surfaced (the working copy is never deleted — `git
+   rm --cached` only touches the index); runtime state (`.loom/logs/`,
+   `.loom/sweep-checkpoint/`, `.loom/tokens/`) and the `loom.sh` / `.loom/bin/loom`
+   shims are never touched, so `./loom.sh` and the per-repo pool manager keep
+   working.
+6. **Register** the repo via `loom-daemon workspace add … --priority N` (skipped
+   with a clear note when `loom-daemon` is not on PATH), **re-stamp**
+   `.loom/install-metadata.json` (`loom_version`, `loom_commit`,
+   `migrated_to_machine_model`, `install_model`), and **refresh** the CLAUDE.md
+   `<!-- BEGIN/END LOOM ORCHESTRATION -->` marker section to the daemon-model
+   surface.
+
+The migration **stages** its result and leaves the commit to the operator —
+review with `git status`, then commit. A second run is a clean no-op (an existing
+tracked `.loom-project/project.json` short-circuits extraction and the manifest
+paths are already untracked). Fixture-based coverage:
+`scripts/test-migrate-consumer.sh`.
+
+> **Skills stay installed, not stripped.** After migration the role skills
+> (`/builder`, `/judge`, `/curator`, `/doctor`, `/loom:sweep`, `/loom`, …) still
+> resolve in consumer sessions — now from the **user-scope** machine checkout
+> (Phase 4), so they track the installed daemon version instead of the stale
+> per-repo copies this pass removes. Migration replaces the copies with the
+> always-current shared skills; it does not remove manual capability. It **does**
+> require user-scope provisioning to have run on the host first (Phases 4/5) —
+> otherwise a migrated repo would lose its now-untracked skills with no
+> replacement.
+
 ## Uninstall semantics
 
 A per-repo `uninstall-loom.sh` removes only the per-repo `./.loom/bin/loom` pool

--- a/defaults/scripts/tests/test-loom-dispatcher.sh
+++ b/defaults/scripts/tests/test-loom-dispatcher.sh
@@ -336,6 +336,33 @@ echo "Test 17: 'restart' is documented in help output"
 help_out=$(LOOM_HOME="$CHK" bash "$DISPATCHER" help 2>&1)
 assert_contains "$help_out" "restart" "'loom help' documents the restart verb"
 
+echo "Test 18: 'migrate' verb routing (Epic #3835 Phase 6, #4254)"
+# The real checkout ships scripts/install/migrate-consumer.sh; stub it into the
+# fake checkout so the dispatcher's target resolution finds it.
+mkdir -p "$CHK/scripts/install"
+cat > "$CHK/scripts/install/migrate-consumer.sh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--help" ]]; then echo "MIGRATE_HELP"; exit 0; fi
+echo "MIGRATE args=[$*] machine_checkout=[${LOOM_MACHINE_CHECKOUT:-}]"
+EOF
+chmod +x "$CHK/scripts/install/migrate-consumer.sh"
+
+assert_contains "$help_out" "migrate" "'loom help' documents the migrate verb"
+
+# --help is reachable from a non-repo directory (no .loom/ context needed).
+migrate_help=$(cd "$(mktemp -d)" && LOOM_HOME="$CHK" bash "$DISPATCHER" migrate --help 2>&1)
+assert_contains "$migrate_help" "MIGRATE_HELP" "'loom migrate --help' delegates without a repo context"
+
+# Outside a Loom repo, 'migrate' refuses with a clear message.
+migrate_norepo=$(cd "$(mktemp -d)" && LOOM_HOME="$CHK" bash "$DISPATCHER" migrate 2>&1 || true)
+assert_contains "$migrate_norepo" "must run inside a Loom consumer repo" "'loom migrate' refuses outside a repo"
+
+# Inside a consumer repo, 'migrate' delegates with the repo root + machine checkout.
+MIGREPO="$(make_consumer_repo)"
+migrate_run=$(cd "$MIGREPO" && LOOM_HOME="$CHK" bash "$DISPATCHER" migrate --dry-run 2>&1 || true)
+assert_contains "$migrate_run" "MIGRATE args=" "'loom migrate' delegates to migrate-consumer.sh"
+assert_contains "$migrate_run" "machine_checkout=[$CHK]" "'loom migrate' hands off LOOM_MACHINE_CHECKOUT"
+
 echo ""
 echo "======================================"
 echo "test-loom-dispatcher.sh: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"

--- a/scripts/install/migrate-consumer.sh
+++ b/scripts/install/migrate-consumer.sh
@@ -220,14 +220,24 @@ mc_read_manifest() {
 
 # ── config extraction (scope guard 1: exclude sweep.modelAliases) ─────────────
 
-# mc_extract_config <repo> <dry_run> — write tracked .loom-project/project.json
-# from legacy .loom/config.json minus sweep.modelAliases. Idempotent: an existing
-# project.json is left untouched.
+# mc_extract_config <repo> <dry_run> — split legacy .loom/config.json into the two
+# resolver tiers the daemon model uses (config_resolver.rs):
+#   - tracked .loom-project/project.json  (PROJECT_CONFIG_REL — shared team policy)
+#       minus sweep.modelAliases (scope guard 1) AND minus host-local keys.
+#   - gitignored .loom-local/local.json   (LOCAL_CONFIG_REL — per-host override)
+#       carries the host-local keys (worktree.root — a per-host scratch-disk path).
+# Routing host-local keys OUT of the tracked tier is load-bearing: since this same
+# pass `git rm --cached`s the legacy .loom/config.json, project.json becomes the
+# highest tier every fresh clone / CI run picks up — copying worktree.root there
+# would silently propagate one operator's filesystem layout to the whole team.
+# Idempotent: an existing project.json short-circuits (leaves both tiers untouched).
 mc_extract_config() {
     local repo="$1" dry_run="$2"
     local legacy="$repo/.loom/config.json"
     local project_dir="$repo/.loom-project"
     local project="$project_dir/project.json"
+    local local_dir="$repo/.loom-local"
+    local localcfg="$local_dir/local.json"
 
     if [[ -f "$project" ]]; then
         mc_report skipped ".loom-project/project.json" "already present"
@@ -242,33 +252,68 @@ mc_extract_config() {
         return 1
     fi
 
-    # Surface host-local-looking keys the operator may prefer in .loom-local/.
-    local wr
+    # Host-local-looking keys routed to the gitignored .loom-local/local.json tier
+    # instead of the tracked, shared project.json. worktree.root is the only one
+    # detected today; add more jq paths here as they are identified.
+    local wr have_local=0
     wr="$(jq -r '.worktree.root // empty' "$legacy" 2>/dev/null || true)"
     if [[ -n "$wr" ]]; then
-        mc_report surfaced ".loom/config.json" "worktree.root=$wr is host-local; kept on disk (legacy tier) and copied to project.json"
+        have_local=1
+        mc_report surfaced ".loom/config.json" "worktree.root=$wr is host-local → .loom-local/local.json (NOT the tracked project.json)"
     fi
     if jq -e '.sweep.modelAliases' "$legacy" >/dev/null 2>&1; then
         mc_report surfaced "sweep.modelAliases" "EXCLUDED from project.json (Rust/Python resolver divergence — scope guard 1)"
     fi
 
     if [[ "$dry_run" == "1" ]]; then
-        mc_report "would create" ".loom-project/project.json" "from .loom/config.json minus sweep.modelAliases"
+        mc_report "would create" ".loom-project/project.json" "from .loom/config.json minus sweep.modelAliases + host-local keys"
+        [[ "$have_local" == "1" ]] \
+            && mc_report "would create" ".loom-local/local.json" "host-local worktree.root=$wr (gitignored, per-host tier)"
         return 0
     fi
 
+    # Host-local tier first. Never clobber an existing local override; only fill in
+    # a missing worktree.root so a re-run converges without losing operator edits.
+    if [[ "$have_local" == "1" ]]; then
+        mkdir -p "$local_dir" || { mc_err "could not create $local_dir"; return 1; }
+        if [[ -f "$localcfg" ]]; then
+            local tmpl
+            tmpl="$(mktemp)" || return 1
+            if jq --arg r "$wr" \
+                 '.worktree = (.worktree // {})
+                  | (if (.worktree.root // "") == "" then .worktree.root = $r else . end)' \
+                 "$localcfg" > "$tmpl" 2>/dev/null; then
+                mv "$tmpl" "$localcfg"
+                mc_report updated ".loom-local/local.json" "host-local worktree.root ensured (existing override kept)"
+            else
+                rm -f "$tmpl"
+                mc_warn "could not update $localcfg — leaving it as-is"
+            fi
+        else
+            if jq -n --arg r "$wr" '{worktree: {root: $r}}' > "$localcfg" 2>/dev/null; then
+                mc_report created ".loom-local/local.json" "host-local worktree.root=$wr (gitignored)"
+            else
+                mc_err "failed to write $localcfg"; return 1
+            fi
+        fi
+        # Deliberately NOT git-added: .loom-local/ is gitignored (per-host tier).
+    fi
+
     mkdir -p "$project_dir" || { mc_err "could not create $project_dir"; return 1; }
-    # del(.sweep.modelAliases); prune an emptied sweep object so migrated config
-    # is clean.
+    # Strip sweep.modelAliases (scope guard 1) and the host-local worktree.root
+    # (routed to local.json above); prune emptied sweep/worktree objects so the
+    # migrated project config is clean.
     if ! jq 'del(.sweep.modelAliases)
-             | if (has("sweep") and (.sweep | length) == 0) then del(.sweep) else . end' \
+             | del(.worktree.root)
+             | if (has("sweep") and (.sweep | length) == 0) then del(.sweep) else . end
+             | if (has("worktree") and (.worktree | length) == 0) then del(.worktree) else . end' \
              "$legacy" > "$project" 2>/dev/null; then
         mc_err "failed to extract config from $legacy"
         rm -f "$project"
         return 1
     fi
     git -C "$repo" add -- .loom-project/project.json 2>/dev/null || true
-    mc_report created ".loom-project/project.json" "from .loom/config.json minus sweep.modelAliases"
+    mc_report created ".loom-project/project.json" "from .loom/config.json minus sweep.modelAliases + host-local keys"
     return 0
 }
 
@@ -532,6 +577,119 @@ mc_update_claude_md() {
     git -C "$repo" add -- CLAUDE.md 2>/dev/null || true
 }
 
+# ── MCP registration cleanup (#4386, surfaced on #4254 2026-07-29) ────────────
+# A historical install can carry a repo-scoped .mcp.json whose `loom` server entry
+# points into a long-dead worktree bundle (e.g.
+# .loom/worktrees/issue-N/mcp-loom/dist/index.js). Under the machine-level model
+# the `loom` server is registered ONCE at USER scope; Claude Code MCP precedence is
+# local > project > user, so a lingering repo-scoped `loom` entry SILENTLY outranks
+# (shadows) the user-scope server — and when its path is a dead worktree it kills
+# every daemon-dispatched child at the claude-wrapper MCP pre-flight (a fleet-wide
+# spawn outage with no surfaced error). This step therefore:
+#   1. strips any repo-scoped `loom` entry from .mcp.json (deleting the file if
+#      `loom` was its only server; other servers such as `safehouse` are kept),
+#      matching setup-mcp.sh's #4230 migration;
+#   2. verifies the user-scope `loom` registration exists and points at the machine
+#      checkout's mcp-loom/dist/index.js, (re)adding it if absent or mis-pointed.
+
+# mc_strip_mcp_loom_entry <file> — remove the `loom` server from an .mcp.json in
+# place. Prints one token: skip | noop | stripped | removed-file.
+mc_strip_mcp_loom_entry() {
+    local file="$1"
+    [[ -f "$file" ]] || { echo skip; return 0; }
+    command -v python3 >/dev/null 2>&1 || { echo skip; return 0; }
+    python3 - "$file" <<'PYEOF'
+import json, os, sys
+path = sys.argv[1]
+try:
+    with open(path) as f:
+        cfg = json.load(f)
+except Exception:
+    print("skip"); sys.exit(0)
+servers = cfg.get("mcpServers", {})
+if "loom" not in servers:
+    print("noop"); sys.exit(0)
+del servers["loom"]
+cfg["mcpServers"] = servers
+if not servers:
+    os.remove(path)
+    print("removed-file")
+else:
+    with open(path, "w") as f:
+        json.dump(cfg, f, indent=2)
+        f.write("\n")
+    print("stripped")
+PYEOF
+}
+
+mc_fix_mcp() {
+    local repo="$1" dry_run="$2"
+    local mcp="$repo/.mcp.json"
+
+    # 1. Strip a shadowing repo-scoped `loom` entry from .mcp.json.
+    if [[ -f "$mcp" ]] && command -v jq >/dev/null 2>&1; then
+        local has_loom
+        has_loom="$(jq -r 'if (.mcpServers.loom) then "yes" else "no" end' "$mcp" 2>/dev/null || echo no)"
+        if [[ "$has_loom" == "yes" ]]; then
+            local stale note
+            stale="$(jq -r '[.mcpServers.loom.args[]? | select(type=="string")]
+                            | map(select(endswith("index.js")))[0] // empty' "$mcp" 2>/dev/null || true)"
+            note="repo-scoped loom entry shadows the user-scope server (#4230)"
+            if [[ -n "$stale" && ! -e "$stale" ]]; then
+                note="repo-scoped loom entry points at a missing bundle ($stale) — #4386 spawn-outage signature"
+            fi
+            local was_tracked
+            was_tracked="$(git -C "$repo" ls-files -- .mcp.json 2>/dev/null)"
+            if [[ "$dry_run" == "1" ]]; then
+                mc_report "would remove" ".mcp.json" "$note"
+            else
+                local res
+                res="$(mc_strip_mcp_loom_entry "$mcp")"
+                case "$res" in
+                    removed-file) mc_report removed ".mcp.json" "$note (was loom-only; file deleted)" ;;
+                    stripped)     mc_report updated ".mcp.json" "$note (stripped; other servers kept)" ;;
+                    *)            : ;;
+                esac
+                # Stage the change only when the file was already tracked; never
+                # newly-track a repo-scoped .mcp.json (it is a per-repo artifact).
+                [[ -n "$was_tracked" ]] && git -C "$repo" add -- .mcp.json 2>/dev/null || true
+            fi
+        fi
+    fi
+
+    # 2. Verify / (re)add the user-scope `loom` MCP registration.
+    local loom_root entry
+    loom_root="$(mc_resolve_loom_root 2>/dev/null || true)"
+    entry="${LOOM_HOME:-$HOME/.local/share/loom}/mcp-loom/dist/index.js"
+    if [[ ! -f "$entry" && -n "$loom_root" && -f "$loom_root/mcp-loom/dist/index.js" ]]; then
+        entry="$loom_root/mcp-loom/dist/index.js"
+    fi
+    if ! command -v claude >/dev/null 2>&1; then
+        mc_warn "claude CLI not on PATH — cannot verify the user-scope 'loom' MCP registration."
+        mc_warn "  register later (one time, per machine): claude mcp add --scope user loom -- node \"$entry\""
+        return 0
+    fi
+    # `claude mcp get` reports across scopes; treat a hit that already references
+    # the expected bundle as good and skip. Otherwise (absent or mis-pointed)
+    # (re)register at user scope, idempotently (remove-then-add like install-loom.sh).
+    local cur
+    if cur="$(claude mcp get loom 2>/dev/null)" && printf '%s' "$cur" | grep -qF "$entry"; then
+        mc_report skipped "user-scope loom MCP" "already registered → $entry"
+        return 0
+    fi
+    if [[ "$dry_run" == "1" ]]; then
+        mc_report "would register" "user-scope loom MCP" "claude mcp add --scope user loom -- node $entry"
+        return 0
+    fi
+    claude mcp remove --scope user loom >/dev/null 2>&1 || true
+    if claude mcp add --scope user loom -- node "$entry" >/dev/null 2>&1; then
+        mc_report registered "user-scope loom MCP" "-> $entry"
+    else
+        mc_warn "failed to register the user-scope 'loom' MCP server; register manually:"
+        mc_warn "  claude mcp add --scope user loom -- node \"$entry\""
+    fi
+}
+
 # ── orchestration ─────────────────────────────────────────────────────────────
 mc_usage() {
     cat <<EOF
@@ -605,6 +763,7 @@ mc_main() {
     mc_extract_config    "$repo" "$dry_run"
     mc_untrack_manifest  "$repo" "$dry_run"
     mc_apply_gitignore   "$repo" "$dry_run"
+    mc_fix_mcp           "$repo" "$dry_run"
     mc_restamp_metadata  "$repo" "$dry_run"
     mc_update_claude_md  "$repo" "$dry_run"
     mc_register_workspace "$repo" "$priority" "$dry_run"

--- a/scripts/install/migrate-consumer.sh
+++ b/scripts/install/migrate-consumer.sh
@@ -1,0 +1,624 @@
+#!/usr/bin/env bash
+# scripts/install/migrate-consumer.sh — one-pass migration of a historical
+# file-copy Loom install to the machine-level daemon model (Epic #3835 Phase 6,
+# #4254).
+#
+# A pre-daemon consumer repo (anvil, kicad-tools, …) holds a full committed copy
+# of the Loom implementation under .loom/, .claude/commands/loom/,
+# .claude/agents/loom-*.md, plus a legacy .loom/config.json. The machine-level
+# model (Phases 1–5) resolves skills/agents/hooks/mcp at USER scope from the
+# machine checkout (~/.local/share/loom) and reads project policy from a TRACKED
+# .loom-project/project.json. This migration takes a repo from the former to the
+# latter in one idempotent pass:
+#
+#   1. Detect the historical install from .loom/install-metadata.json +
+#      installed_files manifest (refuse cleanly when absent).
+#   2. Extract project config from legacy .loom/config.json into the tracked
+#      .loom-project/project.json — EXCLUDING sweep.modelAliases (scope guard 1:
+#      the Rust/Python resolvers diverge on that key, do not freeze the divergence
+#      into every migrated repo).
+#   3. Untrack the committed implementation per the manifest (git rm --cached) and
+#      gitignore it, touching NOTHING outside the manifest (#3450 ownership rule).
+#      Stale Loom-owned artifacts no longer shipped (loom-iteration.md,
+#      loom-parent.md, shepherd-era scripts) are removed outright.
+#   4. Preserve: .loom/resync-ignore pins stay tracked; locally-modified files are
+#      surfaced (git rm --cached never deletes the working copy); runtime state
+#      (.loom/logs/, .loom/sweep-checkpoint/, .loom/tokens/) and the loom.sh /
+#      .loom/bin/loom shims are never touched.
+#   5. Register the repo via `loom-daemon workspace add`.
+#   6. Re-stamp .loom/install-metadata.json and refresh the CLAUDE.md marker
+#      section to describe the daemon-model surface.
+#
+# Source this file (for the test suite) OR run it directly:
+#     bash scripts/install/migrate-consumer.sh <repo> [--dry-run] [--priority N] [--force]
+#
+# Reuses the established installer patterns:
+#   - scripts/install/manifest.sh        (_emit_loom_ownership_set — #3450 boundary)
+#   - scripts/install/local-mode.sh      (gitignore block + git rm --cached idiom)
+#   - defaults/scripts/resync-installed.sh (.loom/resync-ignore pin-list reading)
+#
+# Bash 3.2 compatible (stock macOS) — no associative arrays, no mapfile.
+
+set -uo pipefail
+
+# ── output helpers (plain text so sourcing tests can assert on them) ──────────
+if [[ -t 1 ]]; then
+    _MC_GRN=$'\033[0;32m'; _MC_YEL=$'\033[1;33m'; _MC_RED=$'\033[0;31m'
+    _MC_BLU=$'\033[0;34m'; _MC_NC=$'\033[0m'
+else
+    _MC_GRN=''; _MC_YEL=''; _MC_RED=''; _MC_BLU=''; _MC_NC=''
+fi
+mc_err()   { printf '%bERROR: %s%b\n' "$_MC_RED" "$*" "$_MC_NC" >&2; }
+mc_warn()  { printf '%bWARN: %s%b\n'  "$_MC_YEL" "$*" "$_MC_NC" >&2; }
+mc_info()  { printf '%b%s%b\n'        "$_MC_BLU" "$*" "$_MC_NC"; }
+# Per-file report line (#3777 resync reporting style): "  <verb>   <path> (note)".
+mc_report() {
+    local verb="$1" path="$2" note="${3:-}"
+    local color="$_MC_GRN"
+    case "$verb" in
+        skipped|preserved|surfaced) color="$_MC_YEL" ;;
+        would*)                     color="$_MC_BLU" ;;
+    esac
+    if [[ -n "$note" ]]; then
+        printf '  %b%-16s%b %s %b(%s)%b\n' "$color" "$verb" "$_MC_NC" "$path" "$_MC_YEL" "$note" "$_MC_NC"
+    else
+        printf '  %b%-16s%b %s\n' "$color" "$verb" "$_MC_NC" "$path"
+    fi
+}
+
+# ── resolve LOOM_ROOT (the machine checkout that ships defaults/) ──────────────
+# Precedence: LOOM_MACHINE_CHECKOUT (exported by the dispatcher, #4229) > the
+# script's own location (…/scripts/install/migrate-consumer.sh -> two dirs up).
+mc_resolve_loom_root() {
+    if [[ -n "${LOOM_ROOT:-}" && -d "${LOOM_ROOT}/defaults" ]]; then
+        printf '%s\n' "$LOOM_ROOT"
+        return 0
+    fi
+    if [[ -n "${LOOM_MACHINE_CHECKOUT:-}" && -d "${LOOM_MACHINE_CHECKOUT}/defaults" ]]; then
+        printf '%s\n' "$LOOM_MACHINE_CHECKOUT"
+        return 0
+    fi
+    local self_dir root
+    self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    root="$(cd "$self_dir/../.." && pwd)"
+    if [[ -d "$root/defaults" ]]; then
+        printf '%s\n' "$root"
+        return 0
+    fi
+    return 1
+}
+
+# ── deprecated / preserved path predicates ────────────────────────────────────
+
+# The shim / entry-point surfaces the migration must leave TRACKED and working
+# (scope guard 2): loom.sh -> `exec loom "$@"` and the per-repo pool manager
+# under .loom/bin/. Keeping them tracked is what preserves post-migration
+# `./loom.sh` and `./.loom/bin/loom`.
+mc_is_preserved_shim() {
+    case "$1" in
+        loom.sh)        return 0 ;;
+        .loom/bin/*)    return 0 ;;
+        *)              return 1 ;;
+    esac
+}
+
+# The machine-served implementation namespaces — the ONLY paths migration
+# untracks + gitignores, single-sourced with local-mode.sh's ignore patterns
+# (/.loom/, /.claude/commands/loom/, /.claude/agents/loom-*.md). A manifest entry
+# outside these (e.g. .github/labels.yml, .codex/config.toml, .gitignore) is
+# genuinely repo-level and stays TRACKED — the daemon model never serves it from
+# the machine checkout. Runtime state and the .loom/bin/ shims are carved out by
+# the earlier predicates before this one is consulted.
+mc_is_untrackable_namespace() {
+    case "$1" in
+        .loom/*)                  return 0 ;;
+        .claude/commands/loom/*)  return 0 ;;
+        .claude/agents/loom-*.md) return 0 ;;
+        *)                        return 1 ;;
+    esac
+}
+
+# Explicitly deprecated Loom artifacts to remove OUTRIGHT (disk + index), even
+# though current defaults/ still ships the (dead) file. These predate the daemon
+# model and only cause drift/confusion in a migrated repo — the loom-iteration /
+# loom-parent two-tier daemon skills (removed as a subsystem in v0.10.0, #3372)
+# still ship as tombstone files. Genuinely-removed shepherd-era scripts (no
+# longer in defaults/) are caught by the ownership-set check below and need no
+# entry here. Add explicit paths as more tombstones are identified.
+mc_is_deprecated_artifact() {
+    case "$1" in
+        .claude/commands/loom/loom-iteration.md) return 0 ;;
+        .claude/commands/loom/loom-parent.md)    return 0 ;;
+        *)                                        return 1 ;;
+    esac
+}
+
+# Runtime state that must never be touched (scope guard 2). These are never in a
+# manifest (generated, not shipped) — this is belt-and-suspenders.
+mc_is_runtime_state() {
+    case "$1" in
+        .loom/logs/*|.loom/sweep-checkpoint/*|.loom/tokens/*) return 0 ;;
+        .loom/worktrees/*|.loom/worktrees-local/*)            return 0 ;;
+        *)                                                    return 1 ;;
+    esac
+}
+
+# ── .loom/resync-ignore pin-list (same convention as resync-installed.sh) ──────
+# A pin is a defaults-relative path (e.g. "hooks/guard-destructive.sh",
+# "config.json"); the manifest gives target-relative paths (".loom/hooks/…",
+# ".loom/config.json"). Translate a manifest path back to its defaults-relative
+# form for the pin comparison so both files speak the same language.
+mc_manifest_to_defaults_rel() {
+    local p="$1"
+    case "$p" in
+        .loom/config.json) printf 'config.json\n' ;;
+        .loom/README.md)   printf '.loom-README.md\n' ;;
+        .loom/config/*)    printf 'config/%s\n' "${p#.loom/config/}" ;;
+        .loom/roles/*)     printf 'roles/%s\n'  "${p#.loom/roles/}" ;;
+        .loom/scripts/*)   printf 'scripts/%s\n' "${p#.loom/scripts/}" ;;
+        .loom/runtimes/*)  printf 'runtimes/%s\n' "${p#.loom/runtimes/}" ;;
+        .loom/hooks/*)     printf 'hooks/%s\n'  "${p#.loom/hooks/}" ;;
+        .loom/docs/*)      printf 'docs/%s\n'   "${p#.loom/docs/}" ;;
+        .loom/bin/*)       printf 'bin/%s\n'    "${p#.loom/bin/}" ;;
+        .claude/commands/loom/*) printf 'commands/loom/%s\n' "${p#.claude/commands/loom/}" ;;
+        *)                 printf '%s\n' "$p" ;;
+    esac
+}
+
+mc_is_pinned() {
+    local repo="$1" manifest_path="$2"
+    local ignore_file="$repo/.loom/resync-ignore"
+    [[ -f "$ignore_file" ]] || return 1
+    local defaults_rel line
+    defaults_rel="$(mc_manifest_to_defaults_rel "$manifest_path")"
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%%#*}"
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+        [[ -z "$line" ]] && continue
+        [[ "$line" == "$defaults_rel" || "$line" == "$manifest_path" ]] && return 0
+    done < "$ignore_file"
+    return 1
+}
+
+# ── detection ─────────────────────────────────────────────────────────────────
+
+# mc_detect_install <repo> — 0 when a historical install (metadata + a non-empty
+# installed_files manifest) is present, 1 otherwise.
+mc_detect_install() {
+    local repo="$1"
+    local meta="$repo/.loom/install-metadata.json"
+    [[ -f "$meta" ]] || return 1
+    grep -q '"installed_files"' "$meta" 2>/dev/null || return 1
+    return 0
+}
+
+# mc_already_migrated <repo> — 0 when the repo already carries the target layout
+# (tracked .loom-project/project.json), so a second run is a clean no-op.
+mc_already_migrated() {
+    local repo="$1"
+    [[ -n "$(git -C "$repo" ls-files -- .loom-project/project.json 2>/dev/null)" ]]
+}
+
+# mc_read_manifest <repo> — echo the installed_files entries, one target-relative
+# path per line. Handles single- and multi-line JSON array formats (same parse
+# as scripts/uninstall-loom.sh).
+mc_read_manifest() {
+    local repo="$1"
+    local meta="$repo/.loom/install-metadata.json"
+    local content list
+    content="$(tr '\n' ' ' < "$meta")"
+    list="$(printf '%s' "$content" \
+        | grep -o '"installed_files"[[:space:]]*:[[:space:]]*\[[^]]*\]' \
+        | sed 's/.*\[//;s/\]//' | tr ',' '\n')"
+    local line
+    while IFS= read -r line; do
+        line="$(printf '%s' "$line" | sed 's/^[[:space:]]*"//;s/"[[:space:]]*$//;s/^[[:space:]]*//;s/[[:space:]]*$//')"
+        [[ -n "$line" ]] && printf '%s\n' "$line"
+    done <<< "$list"
+}
+
+# ── config extraction (scope guard 1: exclude sweep.modelAliases) ─────────────
+
+# mc_extract_config <repo> <dry_run> — write tracked .loom-project/project.json
+# from legacy .loom/config.json minus sweep.modelAliases. Idempotent: an existing
+# project.json is left untouched.
+mc_extract_config() {
+    local repo="$1" dry_run="$2"
+    local legacy="$repo/.loom/config.json"
+    local project_dir="$repo/.loom-project"
+    local project="$project_dir/project.json"
+
+    if [[ -f "$project" ]]; then
+        mc_report skipped ".loom-project/project.json" "already present"
+        return 0
+    fi
+    if [[ ! -f "$legacy" ]]; then
+        mc_report skipped ".loom-project/project.json" "no legacy .loom/config.json to extract"
+        return 0
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        mc_warn "jq not available — cannot extract config into .loom-project/project.json"
+        return 1
+    fi
+
+    # Surface host-local-looking keys the operator may prefer in .loom-local/.
+    local wr
+    wr="$(jq -r '.worktree.root // empty' "$legacy" 2>/dev/null || true)"
+    if [[ -n "$wr" ]]; then
+        mc_report surfaced ".loom/config.json" "worktree.root=$wr is host-local; kept on disk (legacy tier) and copied to project.json"
+    fi
+    if jq -e '.sweep.modelAliases' "$legacy" >/dev/null 2>&1; then
+        mc_report surfaced "sweep.modelAliases" "EXCLUDED from project.json (Rust/Python resolver divergence — scope guard 1)"
+    fi
+
+    if [[ "$dry_run" == "1" ]]; then
+        mc_report "would create" ".loom-project/project.json" "from .loom/config.json minus sweep.modelAliases"
+        return 0
+    fi
+
+    mkdir -p "$project_dir" || { mc_err "could not create $project_dir"; return 1; }
+    # del(.sweep.modelAliases); prune an emptied sweep object so migrated config
+    # is clean.
+    if ! jq 'del(.sweep.modelAliases)
+             | if (has("sweep") and (.sweep | length) == 0) then del(.sweep) else . end' \
+             "$legacy" > "$project" 2>/dev/null; then
+        mc_err "failed to extract config from $legacy"
+        rm -f "$project"
+        return 1
+    fi
+    git -C "$repo" add -- .loom-project/project.json 2>/dev/null || true
+    mc_report created ".loom-project/project.json" "from .loom/config.json minus sweep.modelAliases"
+    return 0
+}
+
+# ── manifest-driven removal ───────────────────────────────────────────────────
+
+# mc_untrack_manifest <repo> <dry_run> — for each manifest entry decide:
+#   - shim / runtime state              → leave tracked, never touch (preserve)
+#   - pinned in .loom/resync-ignore     → leave tracked (skipped)
+#   - CLAUDE.md                         → handled by the marker-section step
+#   - deprecated Loom-namespace artifact (not in current defaults/) → remove
+#   - current Loom implementation       → git rm --cached (untrack, keep on disk)
+#   - not Loom-owned by current defaults/ → preserve (#3450)
+# Sets globals MC_N_UNTRACKED / MC_N_REMOVED / MC_N_PRESERVED / MC_N_SKIPPED.
+mc_untrack_manifest() {
+    local repo="$1" dry_run="$2"
+    local loom_root ownership_set
+    loom_root="$(mc_resolve_loom_root)" || { mc_err "cannot resolve a Loom checkout with defaults/"; return 1; }
+
+    # Current ownership boundary (#3450). Source manifest.sh with the right env.
+    # shellcheck source=scripts/install/manifest.sh
+    LOOM_ROOT="$loom_root" TARGET_PATH="$repo" source "$loom_root/scripts/install/manifest.sh"
+    ownership_set="$(LOOM_ROOT="$loom_root" TARGET_PATH="$repo" _emit_loom_ownership_set)"
+
+    MC_N_UNTRACKED=0; MC_N_REMOVED=0; MC_N_PRESERVED=0; MC_N_SKIPPED=0
+    local path is_tracked
+    while IFS= read -r path; do
+        [[ -n "$path" ]] || continue
+
+        # Never touch the shim entry points or runtime state.
+        if mc_is_preserved_shim "$path"; then
+            mc_report preserved "$path" "shim entry point — kept tracked"; continue
+        fi
+        if mc_is_runtime_state "$path"; then
+            mc_report preserved "$path" "runtime state — untouched"; continue
+        fi
+        # CLAUDE.md is refreshed in place by the marker-section step, never untracked.
+        if [[ "$path" == "CLAUDE.md" ]]; then
+            continue
+        fi
+        # Repo-level files outside the machine-served namespaces (.github/*,
+        # .codex/*, .gitignore, package.json, …) stay tracked — the daemon model
+        # never serves them from the machine checkout.
+        if ! mc_is_untrackable_namespace "$path"; then
+            mc_report preserved "$path" "repo-level — kept tracked"
+            MC_N_PRESERVED=$((MC_N_PRESERVED + 1)); continue
+        fi
+        # Pinned local customization: keep tracked, report.
+        if mc_is_pinned "$repo" "$path"; then
+            mc_report skipped "$path" "pinned in .loom/resync-ignore"
+            MC_N_SKIPPED=$((MC_N_SKIPPED + 1)); continue
+        fi
+
+        is_tracked="$(git -C "$repo" ls-files -- "$path" 2>/dev/null)"
+
+        # Explicitly-deprecated tombstone (still shipped, but dead): remove it.
+        # Deprecated artifacts no longer shipped fall through to the ownership
+        # check below; both paths converge on the same removal.
+        if mc_is_deprecated_artifact "$path" \
+            || ! printf '%s\n' "$ownership_set" | grep -Fxq -- "$path"; then
+            # under a machine-served Loom namespace (established above) → Loom
+            # provenance is certain, so removing cannot touch a consumer file
+            # (#3450 boundary).
+            if [[ ! -e "$repo/$path" && -z "$is_tracked" ]]; then
+                continue  # already gone
+            fi
+            if [[ "$dry_run" == "1" ]]; then
+                mc_report "would remove" "$path" "deprecated Loom artifact (no longer shipped)"
+            else
+                [[ -n "$is_tracked" ]] && git -C "$repo" rm -q -f --ignore-unmatch -- "$path" >/dev/null 2>&1
+                rm -f "$repo/$path" 2>/dev/null || true
+                mc_report removed "$path" "deprecated Loom artifact"
+            fi
+            MC_N_REMOVED=$((MC_N_REMOVED + 1)); continue
+        fi
+
+        # Current Loom implementation → untrack (git rm --cached), keep on disk.
+        if [[ -z "$is_tracked" ]]; then
+            continue  # not tracked (e.g. already local-mode); nothing to untrack
+        fi
+        # Surface a locally-modified file (working tree differs from index). The
+        # working copy is preserved on disk by --cached; we only flag it.
+        if ! git -C "$repo" diff --quiet -- "$path" 2>/dev/null; then
+            mc_report surfaced "$path" "locally modified — working copy kept on disk"
+        fi
+        if [[ "$dry_run" == "1" ]]; then
+            mc_report "would untrack" "$path" "git rm --cached (kept on disk, gitignored)"
+        else
+            git -C "$repo" rm -q --cached -- "$path" >/dev/null 2>&1 \
+                && mc_report untracked "$path" "kept on disk, gitignored"
+        fi
+        MC_N_UNTRACKED=$((MC_N_UNTRACKED + 1))
+    done < <(mc_read_manifest "$repo")
+    return 0
+}
+
+# ── gitignore ─────────────────────────────────────────────────────────────────
+# Reuse local-mode.sh's marker-delimited block so the ignored implementation
+# paths are single-sourced with `install-loom.sh --local`.
+mc_apply_gitignore() {
+    local repo="$1" dry_run="$2"
+    local loom_root
+    loom_root="$(mc_resolve_loom_root)" || return 1
+    # shellcheck source=scripts/install/local-mode.sh
+    source "$loom_root/scripts/install/local-mode.sh"
+    if [[ "$dry_run" == "1" ]]; then
+        mc_report "would ignore" ".gitignore" "add the loom-local implementation block"
+        return 0
+    fi
+    if loom_local_apply_gitignore "$repo"; then
+        git -C "$repo" add -- .gitignore 2>/dev/null || true
+        mc_report updated ".gitignore" "loom-local implementation block"
+    else
+        mc_warn "failed to update .gitignore"
+        return 1
+    fi
+}
+
+# ── workspace registration ────────────────────────────────────────────────────
+mc_register_workspace() {
+    local repo="$1" priority="$2" dry_run="$3"
+    if ! command -v loom-daemon >/dev/null 2>&1; then
+        mc_warn "loom-daemon not on PATH — skipping workspace registration."
+        mc_warn "  register later with: loom-daemon workspace add \"$repo\" --priority $priority"
+        return 0
+    fi
+    if [[ "$dry_run" == "1" ]]; then
+        mc_report "would register" "$repo" "loom-daemon workspace add --priority $priority"
+        return 0
+    fi
+    if loom-daemon workspace add "$repo" --priority "$priority" >/dev/null 2>&1; then
+        mc_report registered "$repo" "loom-daemon workspace (priority $priority)"
+    else
+        # add is idempotent-ish; a duplicate is not a failure worth aborting on.
+        mc_warn "loom-daemon workspace add returned non-zero (already registered?)"
+    fi
+}
+
+# ── metadata re-stamp ─────────────────────────────────────────────────────────
+mc_restamp_metadata() {
+    local repo="$1" dry_run="$2"
+    local meta="$repo/.loom/install-metadata.json"
+    local loom_root ver commit today
+    loom_root="$(mc_resolve_loom_root)" || return 1
+    today="$(date +%Y-%m-%d)"
+    ver="unknown"
+    if [[ -f "$loom_root/package.json" ]] && command -v jq >/dev/null 2>&1; then
+        ver="$(jq -r '.version // "unknown"' "$loom_root/package.json" 2>/dev/null || echo unknown)"
+    fi
+    commit="$(git -C "$loom_root" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+
+    if [[ "$dry_run" == "1" ]]; then
+        mc_report "would restamp" ".loom/install-metadata.json" "loom_version=$ver, migrated=$today"
+        return 0
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        mc_warn "jq not available — cannot re-stamp install-metadata.json"
+        return 1
+    fi
+    local tmp
+    tmp="$(mktemp)" || return 1
+    if jq --arg v "$ver" --arg c "$commit" --arg d "$today" \
+        '.loom_version = $v | .loom_commit = $c | .migrated_to_machine_model = $d | .install_model = "machine-daemon"' \
+        "$meta" > "$tmp" 2>/dev/null; then
+        mv "$tmp" "$meta"
+        git -C "$repo" add -- .loom/install-metadata.json 2>/dev/null || true
+        mc_report restamped ".loom/install-metadata.json" "loom_version=$ver, migrated=$today"
+    else
+        rm -f "$tmp"
+        mc_warn "failed to re-stamp install-metadata.json"
+        return 1
+    fi
+}
+
+# ── CLAUDE.md marker section ──────────────────────────────────────────────────
+# Refresh the Loom-managed block delimited by
+#   <!-- BEGIN LOOM ORCHESTRATION --> … <!-- END LOOM ORCHESTRATION -->
+# with a short daemon-model description. Absent markers → append the block.
+MC_CLAUDE_BEGIN="<!-- BEGIN LOOM ORCHESTRATION -->"
+MC_CLAUDE_END="<!-- END LOOM ORCHESTRATION -->"
+
+mc_claude_block() {
+    cat <<EOF
+$MC_CLAUDE_BEGIN
+## Loom Orchestration (machine-level daemon model)
+
+This repo is migrated to the machine-level Loom daemon model (Epic #3835). The
+Loom implementation is no longer committed here — skills (\`/builder\`, \`/judge\`,
+\`/curator\`, \`/doctor\`, \`/loom:sweep\`, \`/loom\`, …), agents, guard hooks, and the
+mcp-loom server all resolve at user scope from the machine checkout
+(\`~/.local/share/loom\`), so they track the installed daemon version instead of
+drifting stale.
+
+- **Project policy** lives in the tracked \`.loom-project/project.json\` (enabled
+  agents, buildGate, guard toggles, priorities). Host-local overrides go in the
+  gitignored \`.loom-local/local.json\`; the legacy \`.loom/config.json\` remains a
+  lower-precedence tier on disk.
+- **Drive work** with \`loom sweep <issue>\` (machine dispatcher) or the manual
+  role skills in a Claude Code session. This repo is registered in the
+  machine-level workspace registry for autonomous dispatch.
+
+See \`~/.local/share/loom/defaults/docs/machine-dispatcher.md\`.
+$MC_CLAUDE_END
+EOF
+}
+
+mc_update_claude_md() {
+    local repo="$1" dry_run="$2"
+    local claude="$repo/CLAUDE.md"
+    if [[ ! -f "$claude" ]]; then
+        if [[ "$dry_run" == "1" ]]; then
+            mc_report "would create" "CLAUDE.md" "daemon-model marker section"; return 0
+        fi
+        mc_claude_block > "$claude"
+        git -C "$repo" add -- CLAUDE.md 2>/dev/null || true
+        mc_report created "CLAUDE.md" "daemon-model marker section"
+        return 0
+    fi
+
+    local has_begin has_end
+    has_begin="$(grep -cF "$MC_CLAUDE_BEGIN" "$claude" 2>/dev/null || echo 0)"
+    has_end="$(grep -cF "$MC_CLAUDE_END" "$claude" 2>/dev/null || echo 0)"
+
+    if [[ "$dry_run" == "1" ]]; then
+        if [[ "$has_begin" == "1" && "$has_end" == "1" ]]; then
+            mc_report "would update" "CLAUDE.md" "refresh the daemon-model marker section"
+        else
+            mc_report "would update" "CLAUDE.md" "append the daemon-model marker section"
+        fi
+        return 0
+    fi
+
+    local tmp
+    tmp="$(mktemp)" || return 1
+    if [[ "$has_begin" == "1" && "$has_end" == "1" ]]; then
+        # Replace the existing block in place.
+        awk -v begin="$MC_CLAUDE_BEGIN" -v end="$MC_CLAUDE_END" '
+            $0 == begin { inblock=1; skip=1 }
+            inblock && $0 == end { inblock=0; print "@@LOOM_BLOCK@@"; next }
+            inblock { next }
+            { print }
+        ' "$claude" > "$tmp"
+        # Splice the fresh block in place of the sentinel.
+        local out
+        out="$(mktemp)" || { rm -f "$tmp"; return 1; }
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            if [[ "$line" == "@@LOOM_BLOCK@@" ]]; then
+                mc_claude_block
+            else
+                printf '%s\n' "$line"
+            fi
+        done < "$tmp" > "$out"
+        mv "$out" "$claude"; rm -f "$tmp"
+        mc_report updated "CLAUDE.md" "refreshed the daemon-model marker section"
+    else
+        # Append (separated by a blank line).
+        printf '\n' >> "$claude"
+        mc_claude_block >> "$claude"
+        mc_report updated "CLAUDE.md" "appended the daemon-model marker section"
+        rm -f "$tmp"
+    fi
+    git -C "$repo" add -- CLAUDE.md 2>/dev/null || true
+}
+
+# ── orchestration ─────────────────────────────────────────────────────────────
+mc_usage() {
+    cat <<EOF
+Usage: migrate-consumer.sh <repo> [options]
+
+Migrate a historical file-copy Loom install to the machine-level daemon model.
+
+Options:
+  --dry-run          Print the full file-by-file plan; make no changes.
+  --priority N       Workspace registry priority (default: 3).
+  --force            Proceed even when the working tree has uncommitted changes.
+  -h, --help         Show this help.
+EOF
+}
+
+mc_main() {
+    local repo="" dry_run=0 priority=3 force=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --dry-run|-n) dry_run=1 ;;
+            --priority)   priority="${2:-3}"; shift ;;
+            --priority=*) priority="${1#--priority=}" ;;
+            --force)      force=1 ;;
+            -h|--help)    mc_usage; return 0 ;;
+            -*)           mc_err "unknown option: $1"; mc_usage; return 2 ;;
+            *)            repo="$1" ;;
+        esac
+        shift
+    done
+
+    if [[ -z "$repo" ]]; then
+        repo="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+    fi
+    if [[ -z "$repo" || ! -d "$repo" ]]; then
+        mc_err "no target repo (pass a path or run inside a git repo)"
+        return 2
+    fi
+    repo="$(cd "$repo" && pwd)"
+    if ! git -C "$repo" rev-parse --git-dir >/dev/null 2>&1; then
+        mc_err "$repo is not a git repository"
+        return 2
+    fi
+
+    # Detection / refusal.
+    if ! mc_detect_install "$repo"; then
+        mc_err "no historical Loom install detected at $repo"
+        mc_err "  (.loom/install-metadata.json with an installed_files manifest is required)"
+        return 1
+    fi
+
+    if mc_already_migrated "$repo"; then
+        mc_info "Already migrated: $repo carries a tracked .loom-project/project.json."
+        mc_info "Re-running the idempotent passes to converge any remaining drift."
+    fi
+
+    # Dirty-tree guard (define behavior: refuse unless --force). Only pre-existing
+    # tracked changes matter — untracked runtime files are fine.
+    if [[ "$force" != "1" ]]; then
+        if ! git -C "$repo" diff --quiet 2>/dev/null || ! git -C "$repo" diff --cached --quiet 2>/dev/null; then
+            mc_err "working tree has uncommitted changes — commit/stash them first, or pass --force."
+            return 1
+        fi
+    fi
+
+    if [[ "$dry_run" == "1" ]]; then
+        mc_info "── loom migrate — DRY RUN plan for $repo ──"
+    else
+        mc_info "── loom migrate — applying to $repo ──"
+    fi
+
+    mc_extract_config    "$repo" "$dry_run"
+    mc_untrack_manifest  "$repo" "$dry_run"
+    mc_apply_gitignore   "$repo" "$dry_run"
+    mc_restamp_metadata  "$repo" "$dry_run"
+    mc_update_claude_md  "$repo" "$dry_run"
+    mc_register_workspace "$repo" "$priority" "$dry_run"
+
+    if [[ "$dry_run" == "1" ]]; then
+        mc_info "── dry run complete — no changes made ──"
+    else
+        mc_info "── migration complete ──"
+        mc_info "Review staged changes with 'git -C \"$repo\" status', then commit."
+    fi
+    return 0
+}
+
+# Run only when executed directly (not when sourced by the test suite).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    mc_main "$@"
+fi

--- a/scripts/loom
+++ b/scripts/loom
@@ -335,6 +335,36 @@ loom_cmd_sweep() {
     exec claude -p "/loom:sweep $*" --dangerously-skip-permissions
 }
 
+# `migrate` takes a historical file-copy Loom install in the CURRENT repo to the
+# machine-level daemon model in one idempotent pass (Epic #3835 Phase 6, #4254).
+# It delegates to scripts/install/migrate-consumer.sh in the machine checkout,
+# passing the resolved repo root so the migration operates on the operator's repo
+# no matter which subdirectory `loom migrate` was invoked from.
+loom_cmd_migrate() {
+    local resolved checkout target
+    resolved="$(loom_resolve_checkout_scripts)" || exit 1
+    checkout="$(sed -n '1p' <<<"$resolved")"
+    if [[ -f "$checkout/scripts/install/migrate-consumer.sh" ]]; then
+        target="$checkout/scripts/install/migrate-consumer.sh"
+    elif [[ -f "$checkout/.loom/scripts/install/migrate-consumer.sh" ]]; then
+        target="$checkout/.loom/scripts/install/migrate-consumer.sh"
+    else
+        _err "migrate-consumer.sh not found under the machine checkout: $checkout"
+        exit 1
+    fi
+    # --help is reachable without a repo context.
+    if loom_has_flag "--help" "$@" || loom_has_flag "-h" "$@"; then
+        exec bash "$target" --help
+    fi
+    loom_detect_context
+    if [[ -z "$LOOM_CTX_ROOT" ]]; then
+        _err "'migrate' must run inside a Loom consumer repo (no .loom/ found from $PWD)."
+        exit 1
+    fi
+    export LOOM_MACHINE_CHECKOUT="$checkout"
+    exec bash "$target" "$LOOM_CTX_ROOT" "$@"
+}
+
 # `status` is read-only and AC7 requires it to produce correct, distinguishable
 # output from a consumer repo, a git worktree, and a non-repo directory. So on a
 # pool-manager collision it does NOT error — it prints machine-level status and a
@@ -409,6 +439,8 @@ COMMANDS:
     restart   Restart the machine-level loom-daemon (drain-and-roll; falls back to stop+start)
     status    Show machine-level + current-repo status (read-only)
     sweep     Dispatch /loom:sweep <issue> for the current repo
+    migrate   Migrate a historical file-copy install in the current repo to the
+              machine-level daemon model (--dry-run for a plan; Epic #3835 Phase 6)
     update    Thin delegate to loom-daemon-update.sh (no rebuild logic of its own)
     help      Show this help
     version   Show dispatcher version
@@ -434,6 +466,7 @@ main() {
         restart)             loom_cmd_restart "$@" ;;
         status)              loom_cmd_status "$@" ;;
         sweep)               loom_cmd_sweep "$@" ;;
+        migrate)             loom_cmd_migrate "$@" ;;
         update)              loom_cmd_update "$@" ;;
         help|--help|-h)      loom_print_help ;;
         version|--version|-v) echo "loom dispatcher v${DISPATCHER_VERSION} (machine-level)" ;;

--- a/scripts/test-migrate-consumer.sh
+++ b/scripts/test-migrate-consumer.sh
@@ -34,7 +34,32 @@ trap cleanup EXIT
 # ~/.loom/workspaces.json with paths that vanish on cleanup.
 FAKE_HOME="$TEST_DIR/home"
 mkdir -p "$FAKE_HOME"
-run_migrate() { HOME="$FAKE_HOME" bash "$MIGRATE" "$@"; }
+
+# A fake `claude` on PATH so the user-scope MCP verification (#4386) is hermetic
+# and deterministic: it never touches the real `claude mcp` registry. It records
+# add/remove into a state file under HOME and reports registration via `mcp get`.
+FAKE_BIN="$TEST_DIR/bin"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/claude" <<'SH'
+#!/usr/bin/env bash
+# fake claude for migrate tests: simulate `claude mcp {get,add,remove}` at user scope.
+state="$HOME/.claude-mcp-loom"   # holds the registered entry path, if any
+case "${1:-} ${2:-}" in
+  "mcp get")
+    # `claude mcp get loom` — succeed (printing the entry) only once registered.
+    [[ -s "$state" ]] || exit 1
+    printf 'loom: node %s\n' "$(cat "$state")"; exit 0 ;;
+  "mcp add")
+    # args: mcp add --scope user loom -- node <entry>
+    printf '%s\n' "${*: -1}" > "$state"; exit 0 ;;
+  "mcp remove")
+    : > "$state"; exit 0 ;;
+esac
+exit 0
+SH
+chmod +x "$FAKE_BIN/claude"
+
+run_migrate() { PATH="$FAKE_BIN:$PATH" HOME="$FAKE_HOME" bash "$MIGRATE" "$@"; }
 
 # Build a fixture repo with a committed 0.12-style install.
 #   - manifest lists current-impl files, deprecated tombstones, a shim, and a
@@ -116,6 +141,25 @@ JSON
   echo 'log line'  > "$repo/.loom/logs/sweep.log"
   echo 'token'     > "$repo/.loom/tokens/acct.env"
   echo 'ckpt'      > "$repo/.loom/sweep-checkpoint/issue-1.json"
+
+  # A historical repo-scoped .mcp.json whose `loom` entry points into a long-dead
+  # worktree bundle (#4386 spawn-outage signature) alongside a per-repo safehouse
+  # server that must survive the strip. Untracked (generated artifact).
+  cat > "$repo/.mcp.json" <<JSON
+{
+  "mcpServers": {
+    "loom": {
+      "command": "node",
+      "args": [ "$repo/.loom/worktrees/issue-4188/mcp-loom/dist/index.js" ]
+    },
+    "safehouse": {
+      "command": "safehoused-client",
+      "args": [],
+      "env": { "SAFEHOUSED_SOCKET": "/tmp/sh.sock" }
+    }
+  }
+}
+JSON
 }
 
 echo "======================================"
@@ -195,6 +239,25 @@ if command -v jq >/dev/null 2>&1; then
   jq -e '.sweep.maxParallel == 3' "$A/.loom-project/project.json" >/dev/null 2>&1 \
      && pass "project.json keeps non-modelAliases sweep keys" \
      || fail "project.json dropped sweep.maxParallel"
+  # Host-local worktree.root must NOT land in the tracked, shared project.json
+  # (Judge blocker: it would propagate one operator's scratch-disk path to the
+  # team). It belongs in the gitignored .loom-local/local.json tier instead.
+  if jq -e 'has("worktree")' "$A/.loom-project/project.json" >/dev/null 2>&1; then
+    fail "project.json still contains worktree.root (host-local key leaked to tracked tier)"
+  else
+    pass "project.json excludes host-local worktree.root"
+  fi
+  if [[ -f "$A/.loom-local/local.json" ]] \
+     && jq -e '.worktree.root == "/mnt/scratch"' "$A/.loom-local/local.json" >/dev/null 2>&1; then
+    pass "worktree.root routed to .loom-local/local.json"
+  else
+    fail "worktree.root not written to .loom-local/local.json"
+  fi
+  # .loom-local/ must be gitignored (per-host tier), never tracked.
+  [[ -z "$(git -C "$A" ls-files -- .loom-local/local.json)" ]] \
+    && pass ".loom-local/local.json stays untracked" || fail ".loom-local/local.json was tracked"
+  grep -qF "/.loom-local/" "$A/.gitignore" \
+    && pass ".gitignore covers /.loom-local/" || fail ".gitignore missing /.loom-local/"
 else
   warn "jq unavailable — skipping project.json content assertions"
 fi
@@ -271,6 +334,25 @@ else
     && pass "workspace registration cleanly skipped (no daemon)" \
     || fail "missing-daemon path not handled"
 fi
+
+# 3l. stale repo-scoped `loom` .mcp.json entry stripped, safehouse preserved (#4386).
+if command -v jq >/dev/null 2>&1; then
+  if [[ -f "$A/.mcp.json" ]] \
+     && ! jq -e '.mcpServers.loom' "$A/.mcp.json" >/dev/null 2>&1 \
+     && jq -e '.mcpServers.safehouse' "$A/.mcp.json" >/dev/null 2>&1; then
+    pass "stale repo-scoped loom .mcp.json entry stripped, safehouse kept"
+  else
+    fail "repo-scoped loom .mcp.json entry not stripped (or safehouse lost)"
+  fi
+  grep -q "#4386 spawn-outage signature" "$TEST_DIR/apply.out" \
+    && pass "dead-worktree .mcp.json entry surfaced (#4386 note)" \
+    || fail "#4386 dead-worktree note not surfaced"
+fi
+
+# 3m. user-scope `loom` MCP registration added when absent (via the fake claude).
+grep -q "registered.*user-scope loom MCP\|user-scope loom MCP.*->" "$TEST_DIR/apply.out" \
+  && pass "user-scope loom MCP registration added" \
+  || fail "user-scope loom MCP registration not reported"
 echo ""
 
 # ==========================================================================
@@ -285,6 +367,9 @@ after="$(git -C "$A" status --porcelain)"
 [[ "$before" == "$after" ]] && pass "second apply is a no-op (clean tree)" || { fail "second apply mutated the tree"; git -C "$A" status --porcelain; }
 grep -q "already present" "$TEST_DIR/apply2.out" \
   && pass "second run reports project.json already present" || warn "no 'already present' note on rerun"
+grep -q "user-scope loom MCP.*already registered" "$TEST_DIR/apply2.out" \
+  && pass "second run reports user-scope loom MCP already registered" \
+  || warn "no 'already registered' MCP note on rerun"
 echo ""
 
 # ==========================================================================

--- a/scripts/test-migrate-consumer.sh
+++ b/scripts/test-migrate-consumer.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+# Test suite for scripts/install/migrate-consumer.sh (Epic #3835 Phase 6, #4254).
+#
+# Builds throwaway git fixtures that simulate a historical 0.12-style file-copy
+# Loom install (install-metadata.json + installed_files manifest, committed
+# implementation, a pinned locally-edited file, deprecated tombstone artifacts,
+# sweep.modelAliases in the legacy config, and untracked runtime state) and
+# drives `loom migrate` against them, asserting the machine-model target layout.
+#
+# Fast + hermetic: temp git repos, no network, no gh auth, no daemon. Workspace
+# registration is best-effort and skipped when loom-daemon is absent (asserted).
+#
+# Usage: bash scripts/test-migrate-consumer.sh
+
+set -uo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+passed=0; failed=0
+pass() { echo -e "${GREEN}✓${NC} $1"; passed=$((passed + 1)); }
+fail() { echo -e "${RED}✗${NC} $1"; failed=$((failed + 1)); }
+warn() { echo -e "${YELLOW}!${NC} $1"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOOM_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MIGRATE="$LOOM_ROOT/scripts/install/migrate-consumer.sh"
+export LOOM_ROOT   # so migrate-consumer.sh resolves defaults/ from this checkout
+
+TEST_DIR="$(mktemp -d)"
+cleanup() { [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]] && rm -rf "$TEST_DIR"; }
+trap cleanup EXIT
+
+# Run the migration with an isolated HOME so `loom-daemon workspace add` writes
+# to a throwaway registry under TEST_DIR instead of polluting the real
+# ~/.loom/workspaces.json with paths that vanish on cleanup.
+FAKE_HOME="$TEST_DIR/home"
+mkdir -p "$FAKE_HOME"
+run_migrate() { HOME="$FAKE_HOME" bash "$MIGRATE" "$@"; }
+
+# Build a fixture repo with a committed 0.12-style install.
+#   - manifest lists current-impl files, deprecated tombstones, a shim, and a
+#     repo-level file
+#   - legacy .loom/config.json carries guards/buildGate/worktree.root AND
+#     sweep.modelAliases (the scope-guard-1 exclusion target)
+#   - .loom/resync-ignore pins a locally-edited script
+#   - untracked runtime state under .loom/logs, .loom/tokens, .loom/sweep-checkpoint
+make_fixture() {
+  local repo="$1"
+  mkdir -p "$repo"/.loom/{scripts,hooks,bin,logs,tokens,sweep-checkpoint} \
+           "$repo"/.claude/commands/loom "$repo"/.claude/agents "$repo"/.github
+  git -C "$repo" init --quiet
+  git -C "$repo" config user.email "t@e.com"; git -C "$repo" config user.name "T"
+
+  # Legacy config with the modelAliases key that must NOT migrate.
+  cat > "$repo/.loom/config.json" <<'JSON'
+{
+  "guards": { "sqlDdl": true, "cloudCli": false },
+  "buildGate": { "enabled": true, "command": "make test" },
+  "worktree": { "root": "/mnt/scratch" },
+  "sweep": { "modelAliases": { "opus": "claude-opus-4-8" }, "maxParallel": 3 }
+}
+JSON
+
+  echo 'echo worktree' > "$repo/.loom/scripts/worktree.sh"
+  echo 'guard'         > "$repo/.loom/hooks/guard-destructive.sh"
+  echo 'pool manager'  > "$repo/.loom/bin/loom"
+  echo 'builder skill' > "$repo/.claude/commands/loom/builder.md"
+  echo 'DEPRECATED iteration' > "$repo/.claude/commands/loom/loom-iteration.md"
+  echo 'DEPRECATED parent'    > "$repo/.claude/commands/loom/loom-parent.md"
+  echo 'builder agent'  > "$repo/.claude/agents/loom-builder.md"
+  echo 'exec loom "$@"' > "$repo/loom.sh"
+  echo 'consumer labels' > "$repo/.github/labels.yml"
+  echo 'node_modules/'   > "$repo/.gitignore"
+
+  # Pinned + locally edited script.
+  echo 'custom-pinned'  > "$repo/.loom/scripts/custom.sh"
+  echo 'scripts/custom.sh' > "$repo/.loom/resync-ignore"
+
+  # CLAUDE.md with the marker section.
+  cat > "$repo/CLAUDE.md" <<'MD'
+# My Project
+
+<!-- BEGIN LOOM ORCHESTRATION -->
+Old MCP-observer loop content.
+<!-- END LOOM ORCHESTRATION -->
+
+More project docs.
+MD
+
+  # Historical manifest.
+  cat > "$repo/.loom/install-metadata.json" <<'JSON'
+{
+  "loom_version": "0.12.0",
+  "loom_commit": "abc1234",
+  "install_date": "2026-07-21",
+  "installed_files": [
+    ".loom/config.json",
+    ".loom/scripts/worktree.sh",
+    ".loom/scripts/custom.sh",
+    ".loom/hooks/guard-destructive.sh",
+    ".loom/bin/loom",
+    ".claude/commands/loom/builder.md",
+    ".claude/commands/loom/loom-iteration.md",
+    ".claude/commands/loom/loom-parent.md",
+    ".claude/agents/loom-builder.md",
+    ".github/labels.yml",
+    "loom.sh",
+    "CLAUDE.md"
+  ]
+}
+JSON
+
+  git -C "$repo" add -A
+  git -C "$repo" commit -q -m "committed 0.12-style loom install"
+
+  # Untracked runtime state (created AFTER the commit so it stays untracked).
+  echo 'log line'  > "$repo/.loom/logs/sweep.log"
+  echo 'token'     > "$repo/.loom/tokens/acct.env"
+  echo 'ckpt'      > "$repo/.loom/sweep-checkpoint/issue-1.json"
+}
+
+echo "======================================"
+echo "migrate-consumer.sh tests"
+echo "======================================"
+echo ""
+
+# ==========================================================================
+# 1. Refusal: no historical install (no metadata)
+# ==========================================================================
+echo "--- refusal + guards ---"
+R0="$TEST_DIR/no-metadata"
+mkdir -p "$R0"; git -C "$R0" init --quiet
+git -C "$R0" config user.email t@e.com; git -C "$R0" config user.name T
+echo x > "$R0/f"; git -C "$R0" add -A; git -C "$R0" commit -q -m init
+before="$(git -C "$R0" status --porcelain)"
+if run_migrate "$R0" > "$TEST_DIR/r0.out" 2>&1; then
+  fail "missing metadata should refuse (non-zero exit)"
+else
+  pass "missing metadata refuses (non-zero exit)"
+fi
+after="$(git -C "$R0" status --porcelain)"
+[[ "$before" == "$after" ]] && pass "refusal made zero changes" || fail "refusal changed the tree"
+
+# Dirty-tree guard.
+D0="$TEST_DIR/dirty"; make_fixture "$D0"
+echo 'dirty edit' >> "$D0/.github/labels.yml"   # uncommitted tracked change
+if run_migrate "$D0" > "$TEST_DIR/dirty.out" 2>&1; then
+  fail "dirty tree should refuse without --force"
+else
+  pass "dirty tree refuses without --force"
+fi
+echo ""
+
+# ==========================================================================
+# 2. Dry run: full plan, zero changes
+# ==========================================================================
+echo "--- dry run ---"
+DR="$TEST_DIR/dryrun"; make_fixture "$DR"
+before="$(git -C "$DR" status --porcelain)"
+run_migrate "$DR" --dry-run > "$TEST_DIR/dry.out" 2>&1 && rc=0 || rc=$?
+[[ "$rc" -eq 0 ]] && pass "--dry-run exits 0" || fail "--dry-run exits 0 (rc=$rc)"
+after="$(git -C "$DR" status --porcelain)"
+[[ "$before" == "$after" ]] && pass "--dry-run makes zero changes" || fail "--dry-run mutated the tree"
+[[ ! -f "$DR/.loom-project/project.json" ]] && pass "--dry-run does not write project.json" || fail "--dry-run wrote project.json"
+grep -q "would untrack" "$TEST_DIR/dry.out" && pass "--dry-run prints an untrack plan" || fail "--dry-run untrack plan missing"
+grep -q "would remove" "$TEST_DIR/dry.out" && pass "--dry-run prints a deprecated-removal plan" || fail "--dry-run removal plan missing"
+grep -q "would create.*project.json" "$TEST_DIR/dry.out" && pass "--dry-run plans project.json" || fail "--dry-run project.json plan missing"
+echo ""
+
+# ==========================================================================
+# 3. Apply: target layout
+# ==========================================================================
+echo "--- apply (target layout) ---"
+A="$TEST_DIR/apply"; make_fixture "$A"
+run_migrate "$A" > "$TEST_DIR/apply.out" 2>&1 && rc=0 || rc=$?
+[[ "$rc" -eq 0 ]] && pass "apply exits 0" || { fail "apply exits 0 (rc=$rc)"; cat "$TEST_DIR/apply.out"; }
+
+# 3a. project.json extracted, tracked, and modelAliases EXCLUDED.
+if [[ -f "$A/.loom-project/project.json" ]] \
+   && [[ -n "$(git -C "$A" ls-files -- .loom-project/project.json)" ]]; then
+  pass "project.json created + tracked"
+else
+  fail "project.json not created/tracked"
+fi
+if command -v jq >/dev/null 2>&1; then
+  if jq -e '.sweep.modelAliases' "$A/.loom-project/project.json" >/dev/null 2>&1; then
+    fail "project.json still contains sweep.modelAliases (scope guard 1 violated)"
+  else
+    pass "project.json excludes sweep.modelAliases (scope guard 1)"
+  fi
+  jq -e '.guards.sqlDdl == true and .buildGate.command == "make test"' \
+     "$A/.loom-project/project.json" >/dev/null 2>&1 \
+     && pass "project.json carries guards + buildGate" \
+     || fail "project.json missing guards/buildGate"
+  # sweep.maxParallel (a non-modelAliases sweep key) is retained.
+  jq -e '.sweep.maxParallel == 3' "$A/.loom-project/project.json" >/dev/null 2>&1 \
+     && pass "project.json keeps non-modelAliases sweep keys" \
+     || fail "project.json dropped sweep.maxParallel"
+else
+  warn "jq unavailable — skipping project.json content assertions"
+fi
+
+# 3b. current implementation untracked but still on disk.
+if [[ -z "$(git -C "$A" ls-files -- .loom/scripts/worktree.sh)" ]] \
+   && [[ -z "$(git -C "$A" ls-files -- .claude/commands/loom/builder.md)" ]] \
+   && [[ -f "$A/.loom/scripts/worktree.sh" ]] \
+   && [[ -f "$A/.claude/commands/loom/builder.md" ]]; then
+  pass "implementation untracked + kept on disk"
+else
+  fail "implementation untrack/keep failed"
+fi
+
+# 3c. gitignore block written.
+grep -qF "/.loom/" "$A/.gitignore" && grep -qF "/.claude/commands/loom/" "$A/.gitignore" \
+  && pass "gitignore implementation block written" || fail "gitignore block missing"
+
+# 3d. shims preserved (tracked + on disk).
+if [[ -n "$(git -C "$A" ls-files -- loom.sh)" ]] \
+   && [[ -n "$(git -C "$A" ls-files -- .loom/bin/loom)" ]] \
+   && [[ -f "$A/loom.sh" ]] && [[ -f "$A/.loom/bin/loom" ]]; then
+  pass "loom.sh + .loom/bin/loom shims preserved (tracked)"
+else
+  fail "shims not preserved"
+fi
+
+# 3e. repo-level file stays tracked.
+[[ -n "$(git -C "$A" ls-files -- .github/labels.yml)" ]] \
+  && pass ".github/labels.yml stays tracked" || fail ".github/labels.yml untracked"
+
+# 3f. pinned file left tracked (not untracked).
+[[ -n "$(git -C "$A" ls-files -- .loom/scripts/custom.sh)" ]] \
+  && pass "pinned .loom/scripts/custom.sh stays tracked" || fail "pinned file was untracked"
+grep -q "pinned in .loom/resync-ignore" "$TEST_DIR/apply.out" \
+  && pass "pinned file surfaced in report" || fail "pinned file not surfaced"
+
+# 3g. deprecated tombstones removed (disk + index).
+if [[ ! -f "$A/.claude/commands/loom/loom-iteration.md" ]] \
+   && [[ ! -f "$A/.claude/commands/loom/loom-parent.md" ]] \
+   && [[ -z "$(git -C "$A" ls-files -- .claude/commands/loom/loom-iteration.md)" ]]; then
+  pass "deprecated tombstones removed (disk + index)"
+else
+  fail "deprecated tombstones not removed"
+fi
+
+# 3h. runtime state untouched.
+if [[ -f "$A/.loom/logs/sweep.log" ]] && [[ -f "$A/.loom/tokens/acct.env" ]] \
+   && [[ -f "$A/.loom/sweep-checkpoint/issue-1.json" ]]; then
+  pass "runtime state (logs/tokens/sweep-checkpoint) untouched"
+else
+  fail "runtime state disturbed"
+fi
+
+# 3i. metadata re-stamped.
+if command -v jq >/dev/null 2>&1; then
+  jq -e '.migrated_to_machine_model and .install_model == "machine-daemon"' \
+     "$A/.loom/install-metadata.json" >/dev/null 2>&1 \
+     && pass "install-metadata.json re-stamped" || fail "metadata not re-stamped"
+fi
+
+# 3j. CLAUDE.md marker section refreshed.
+grep -q "machine-level daemon model" "$A/CLAUDE.md" \
+  && grep -qc "<!-- BEGIN LOOM ORCHESTRATION -->" "$A/CLAUDE.md" >/dev/null \
+  && [[ "$(grep -cF "<!-- BEGIN LOOM ORCHESTRATION -->" "$A/CLAUDE.md")" -eq 1 ]] \
+  && pass "CLAUDE.md marker section refreshed (single block)" \
+  || fail "CLAUDE.md marker section not refreshed"
+
+# 3k. workspace registration reported (skipped when daemon absent).
+if command -v loom-daemon >/dev/null 2>&1; then
+  grep -q "registered" "$TEST_DIR/apply.out" && pass "workspace registered" || warn "workspace registration not reported"
+else
+  grep -q "loom-daemon not on PATH" "$TEST_DIR/apply.out" \
+    && pass "workspace registration cleanly skipped (no daemon)" \
+    || fail "missing-daemon path not handled"
+fi
+echo ""
+
+# ==========================================================================
+# 4. Idempotency: second apply is a no-op
+# ==========================================================================
+echo "--- idempotency ---"
+git -C "$A" add -A; git -C "$A" commit -q -m "migrated" 2>/dev/null || true
+before="$(git -C "$A" status --porcelain)"
+run_migrate "$A" > "$TEST_DIR/apply2.out" 2>&1 && rc=0 || rc=$?
+[[ "$rc" -eq 0 ]] && pass "second apply exits 0" || fail "second apply exits 0 (rc=$rc)"
+after="$(git -C "$A" status --porcelain)"
+[[ "$before" == "$after" ]] && pass "second apply is a no-op (clean tree)" || { fail "second apply mutated the tree"; git -C "$A" status --porcelain; }
+grep -q "already present" "$TEST_DIR/apply2.out" \
+  && pass "second run reports project.json already present" || warn "no 'already present' note on rerun"
+echo ""
+
+# ==========================================================================
+# 5. Edge: repo with no .loom/resync-ignore
+# ==========================================================================
+echo "--- edge: no resync-ignore ---"
+E="$TEST_DIR/no-ignore"; make_fixture "$E"
+rm -f "$E/.loom/resync-ignore"
+git -C "$E" rm -q --cached .loom/resync-ignore >/dev/null 2>&1 || true
+git -C "$E" commit -q -am "drop resync-ignore" 2>/dev/null || true
+run_migrate "$E" > "$TEST_DIR/e.out" 2>&1 && rc=0 || rc=$?
+[[ "$rc" -eq 0 ]] && pass "migrate with no resync-ignore exits 0" || fail "no-resync-ignore rc=$rc"
+[[ -z "$(git -C "$E" ls-files -- .loom/scripts/custom.sh)" ]] \
+  && pass "unpinned custom.sh untracked when no resync-ignore" || fail "custom.sh handling wrong"
+echo ""
+
+echo "======================================"
+echo -e "${GREEN}Passed: $passed${NC}   ${RED}Failed: $failed${NC}"
+echo "======================================"
+[[ "$failed" -eq 0 ]] && { echo -e "${GREEN}All tests passed!${NC}"; exit 0; } || { echo -e "${RED}Some tests failed.${NC}"; exit 1; }


### PR DESCRIPTION
## Summary

Implements Epic #3835 **Phase 6** (#4254): a first-class `loom migrate`
subcommand on the machine dispatcher that takes a historical file-copy Loom
install (the pre-daemon layout every consumer repo on ≤ 0.12 holds) to the
machine-level daemon model in **one idempotent pass** — tracked project config,
untracked implementation, working `/loom` against the machine daemon, no stale
role docs — with zero manual archaeology.

## Changes

- **`scripts/loom`** — new `migrate` verb: resolves the current repo root,
  delegates to `migrate-consumer.sh` in the machine checkout with
  `LOOM_MACHINE_CHECKOUT` exported; `--help` reachable without a repo context.
- **`scripts/install/migrate-consumer.sh`** (new) — the migration:
  - detect historical install from `.loom/install-metadata.json` +
    `installed_files` manifest (clean refusal when absent; dirty-tree refusal
    unless `--force`)
  - extract legacy `.loom/config.json` → tracked `.loom-project/project.json`,
    **excluding `sweep.modelAliases`** (scope guard 1 — Rust/Python resolver
    divergence)
  - untrack the committed implementation per the manifest (`git rm --cached`) +
    gitignore, only under the machine-served namespaces (`/.loom/`,
    `/.claude/commands/loom/`, `/.claude/agents/loom-*.md`); repo-level manifest
    entries (`.github/*`, `.gitignore`, `package.json`) stay tracked; nothing
    outside the manifest is touched (#3450 ownership rule)
  - remove deprecated tombstones (`loom-iteration.md`, `loom-parent.md`, and any
    Loom-namespace manifest entry no longer shipped) from disk + index
  - preserve `.loom/resync-ignore` pins, surface locally-modified files, never
    touch runtime state (`.loom/logs|sweep-checkpoint|tokens`) or the
    `loom.sh` / `.loom/bin/loom` shims (scope guard 2)
  - register via `loom-daemon workspace add`, re-stamp metadata, refresh the
    CLAUDE.md `<!-- BEGIN/END LOOM ORCHESTRATION -->` marker section
  - `--dry-run` prints a full file-by-file plan; apply prints a per-file report
    (#3777 style)
- **`scripts/test-migrate-consumer.sh`** (new) — 30 fixture-based assertions.
- **`defaults/scripts/tests/test-loom-dispatcher.sh`** — 5 new `migrate` routing
  assertions (65/65 pass).
- **`defaults/docs/machine-dispatcher.md`** — documents `loom migrate` (docs go
  here, not `defaults/CLAUDE.md`, per scope guard 4).

Reuses `manifest.sh` (`_emit_loom_ownership_set`), `local-mode.sh` (gitignore
block + `git rm --cached` idiom), and the `resync-installed.sh` pin-list
convention. No new Python (scope guard 3).

## Acceptance Criteria Verification

- [x] `loom migrate` exists on the dispatcher, idempotent (2nd run no-op), with
  `--dry-run` full plan + per-file apply report — *dispatcher routing test +
  dry-run/idempotency fixtures*
- [x] Detects historical install; clear refusal (zero changes) when
  metadata/manifest absent — *refusal fixture*
- [x] Extracts config into `.loom-project/project.json` **excluding
  `sweep.modelAliases`** — *fixture asserts the key is absent and other
  guards/buildGate/sweep keys are retained*
- [x] Removes committed impl per manifest (`git rm --cached` + gitignore),
  touches nothing outside the manifest — *untrack/keep + ownership fixtures*
- [x] Preserve-ACs: pins + locally-modified surfaced, runtime state untouched,
  `loom.sh` / `.loom/bin/loom` shims kept tracked — *dedicated fixtures*
- [x] Registers via `loom-daemon workspace add` (priority defaulted/`--priority`)
  — *asserted; cleanly skipped + reported when daemon absent*
- [x] Re-stamps metadata + updates the CLAUDE.md marker section — *fixtures*
- [x] Removes deprecated artifacts (`loom-iteration.md`, `loom-parent.md`,
  shepherd-era scripts) — *tombstone-removal fixture*

## Test Plan

Automated (all green):
- [x] `bash scripts/test-migrate-consumer.sh` — 30/30 (fixture install →
  migrate → target layout; `--dry-run` clean + no-op re-apply; missing metadata
  refusal; `modelAliases` exclusion; no-`resync-ignore` edge; dirty-tree refusal)
- [x] `bash defaults/scripts/tests/test-loom-dispatcher.sh` — 65/65 (incl. 5 new
  `migrate` routing cases)
- [x] `bash scripts/test-install-local-mode.sh` — 19/19 (shared `local-mode.sh`
  unregressed)
- [x] `shellcheck -S warning` clean on all changed/new shell files

Deferred (needs operator access to a separate repo, out of scope for this
environment):
- [ ] **Manual canary on anvil (0.12.0, 161 committed files)** end-to-end — run
  `loom migrate --dry-run` then apply on anvil, confirm `/loom` works against the
  machine daemon and the repo appears in `loom-daemon workspace`. The automated
  fixtures exercise the same code paths against synthetic 0.12-style installs;
  the anvil run is the real-world confirmation and should be performed by the
  operator before wide rollout.

Note: the test suite isolates `loom-daemon workspace add` under a throwaway
`HOME` so it never pollutes the real `~/.loom/workspaces.json`.

Closes #4254