### PR TITLE
fix(tests): sanitize ambient guard-behavior env vars in guard test hermeticity

### DIFF
--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -19,6 +19,15 @@
 
 set -euo pipefail
 
+# Hermetic baseline: ambient guard-behavior overrides must not leak into tests
+# (#4325). Tests that exercise env-driven behavior deliberately inject their
+# vars explicitly per invocation (run_guard_env / assert_ask_env / assert_allow_env),
+# or via run_guard_in_worktree, so they are unaffected by this unset.
+unset LOOM_FORCE_SCOPE LOOM_DEFAULT_BRANCH LOOM_GUARD_SQL LOOM_GUARD_CLOUD \
+      LOOM_GUARD_REVERSIBLE_GH LOOM_RM_SCOPE LOOM_GUARD_READONLY_FASTPATH \
+      LOOM_GUARD_WORKTREE_ISOLATION LOOM_WORKTREE_PATH LOOM_WORKTREE_ROOT \
+      LOOM_GUARD_DECISION_LOG LOOM_GUARD_DECISION_LOG_FILE
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 GUARD="$REPO_ROOT/defaults/hooks/guard-destructive-generic.sh"

--- a/tests/hooks/test-guard-loom-workflow.sh
+++ b/tests/hooks/test-guard-loom-workflow.sh
@@ -13,6 +13,15 @@
 
 set -euo pipefail
 
+# Hermetic baseline: ambient guard-behavior overrides must not leak into tests
+# (#4325). Tests that exercise env-driven behavior deliberately inject their
+# vars explicitly per invocation, or via run_guard_in_worktree, so they are
+# unaffected by this unset.
+unset LOOM_FORCE_SCOPE LOOM_DEFAULT_BRANCH LOOM_GUARD_SQL LOOM_GUARD_CLOUD \
+      LOOM_GUARD_REVERSIBLE_GH LOOM_RM_SCOPE LOOM_GUARD_READONLY_FASTPATH \
+      LOOM_GUARD_WORKTREE_ISOLATION LOOM_WORKTREE_PATH LOOM_WORKTREE_ROOT \
+      LOOM_GUARD_DECISION_LOG LOOM_GUARD_DECISION_LOG_FILE
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 GUARD="$REPO_ROOT/defaults/hooks/guard-loom-workflow.sh"


### PR DESCRIPTION
## Summary

`tests/hooks/test-guard-destructive.sh` and `tests/hooks/test-guard-loom-workflow.sh` piped input straight into the guard under test without sanitizing inherited environment variables. An ambient `LOOM_FORCE_SCOPE=protected` in the invoking shell (a legitimate operator setting, #3674) leaked into the suites' "baseline" (ambient-mode) assertions, causing two tests to fail:

- `Ask for git push --force (non-main)` — expected `ask`, got `allow`
- `Ask for git reset --hard` — expected `ask`, got `allow`

Root-caused and confirmed during Judge review of PR #4289 (see #4325 for the full investigation): the guard's own force-op scope logic (`force_scope_mode()`) is correct and behaves per spec in both `all` and `protected` modes — the defect is purely in the test harness's non-hermetic baseline.

## Changes

Added an `unset` block right after `set -euo pipefail` in both suites, sanitizing every `LOOM_*` var `guard-destructive-generic.sh` reads:

```bash
unset LOOM_FORCE_SCOPE LOOM_DEFAULT_BRANCH LOOM_GUARD_SQL LOOM_GUARD_CLOUD \
      LOOM_GUARD_REVERSIBLE_GH LOOM_RM_SCOPE LOOM_GUARD_READONLY_FASTPATH \
      LOOM_GUARD_WORKTREE_ISOLATION LOOM_WORKTREE_PATH LOOM_WORKTREE_ROOT \
      LOOM_GUARD_DECISION_LOG LOOM_GUARD_DECISION_LOG_FILE
```

Tests that exercise env-driven behavior deliberately (`run_guard_env` / `assert_ask_env` / `assert_allow_env`, and `run_guard_in_worktree`) inject their vars explicitly per invocation, so they're unaffected by this unset — verified below.

No changes to `defaults/hooks/guard-destructive-generic.sh` or `guard-loom-workflow.sh` — the guards' behavior is correct as-is.

## Test plan

- [x] `LOOM_FORCE_SCOPE=protected ./tests/hooks/test-guard-destructive.sh` — 467/467 pass (was 2 failures before the fix)
- [x] `./tests/hooks/test-guard-destructive.sh` with no ambient overrides — 467/467 pass (no regression)
- [x] `LOOM_FORCE_SCOPE=protected ./tests/hooks/test-guard-loom-workflow.sh` — 27/27 pass
- [x] All existing env-injection tests (`assert_ask_env`/`assert_allow_env`, worktree cases) still pass, confirming the unset doesn't break explicit per-test env plumbing

Closes #4325
