### PR TITLE
fix(labels): shorten 5 over-limit label descriptions + add CI lint (#4335)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -23,11 +23,11 @@
 
 # Core Workflow States
 - name: loom:triage
-  description: "New issue awaiting Curator enhancement. Applied by: humans or any agent filing a new issue (intake label)."
+  description: "New issue awaiting Curator enhancement. Applied by: humans or any agent filing an issue (intake)."
   color: "9CA3AF"  # gray-400 - neutral initial state
 
 - name: loom:issue
-  description: "Approved for work (ready for Builder to claim). Applied by: humans, Champion, or a /loom:sweep orchestrator's Approval gate — see .loom/roles/curator.md 'Who promotes loom:curated → loom:issue' for the authoritative rule."
+  description: "Approved for work. Applied by: humans, Champion, or sweep Approval gate — see curator.md for rule."
   color: "3B82F6"  # blue-500
 
 # DEPRECATED: loom:in-progress removed (use role-specific labels)
@@ -50,7 +50,7 @@
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:reviewing
-  description: "Judge is actively reviewing this PR. Applied by: Judge only (claim label). Stale after LOOM_STALE_REVIEWING_MINUTES (default 30) with no follow-up comment — may be reclaimed by a new Judge."
+  description: "Judge is reviewing this PR. Applied by: Judge only. Stale after LOOM_STALE_REVIEWING_MINUTES (30m)."
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:review-requested
@@ -95,7 +95,7 @@
   color: "6366F1"  # indigo-500 - indicates meta/tooling request
 
 - name: loom:curated
-  description: "Curator-enriched, awaiting human approval. Additive marker; coexists with loom:issue (highest-quality state for Builders). Applied by: Curator only."
+  description: "Curator-enriched, awaiting approval. Additive; coexists with loom:issue. Applied by: Curator only."
   color: "10B981"  # emerald-500
 
 # Status Labels
@@ -147,6 +147,6 @@
 # (see builder.md "Ignore External Issues") — a non-collaborator submission needs
 # maintainer approval before Curator/Builder process it.
 - name: external
-  description: "Submitted by a non-collaborator; requires maintainer approval before Curator/Builder process it. Applied by: humans only."
+  description: "Non-collaborator submission; needs maintainer approval before curation. Applied by: humans only."
   color: "E5E7EB"  # gray-200 - external/hold marker
 # END LOOM LABELS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,8 @@ jobs:
         run: bash defaults/scripts/check-phantom-labels.sh
       - name: Check labels.yml copies are in sync (#3896)
         run: bash defaults/scripts/check-labels-drift.sh
+      - name: Check label descriptions fit GitHub's 100-char limit (#4335)
+        run: bash defaults/scripts/check-label-descriptions.sh
       - name: Run installer tests
         run: bash scripts/test-installer.sh
       - name: Run installer reinstall-safety tests (#4188)

--- a/defaults/.github/labels.yml
+++ b/defaults/.github/labels.yml
@@ -23,11 +23,11 @@
 
 # Core Workflow States
 - name: loom:triage
-  description: "New issue awaiting Curator enhancement. Applied by: humans or any agent filing a new issue (intake label)."
+  description: "New issue awaiting Curator enhancement. Applied by: humans or any agent filing an issue (intake)."
   color: "9CA3AF"  # gray-400 - neutral initial state
 
 - name: loom:issue
-  description: "Approved for work (ready for Builder to claim). Applied by: humans, Champion, or a /loom:sweep orchestrator's Approval gate — see .loom/roles/curator.md 'Who promotes loom:curated → loom:issue' for the authoritative rule."
+  description: "Approved for work. Applied by: humans, Champion, or sweep Approval gate — see curator.md for rule."
   color: "3B82F6"  # blue-500
 
 # DEPRECATED: loom:in-progress removed (use role-specific labels)
@@ -50,7 +50,7 @@
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:reviewing
-  description: "Judge is actively reviewing this PR. Applied by: Judge only (claim label). Stale after LOOM_STALE_REVIEWING_MINUTES (default 30) with no follow-up comment — may be reclaimed by a new Judge."
+  description: "Judge is reviewing this PR. Applied by: Judge only. Stale after LOOM_STALE_REVIEWING_MINUTES (30m)."
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:review-requested
@@ -95,7 +95,7 @@
   color: "6366F1"  # indigo-500 - indicates meta/tooling request
 
 - name: loom:curated
-  description: "Curator-enriched, awaiting human approval. Additive marker; coexists with loom:issue (highest-quality state for Builders). Applied by: Curator only."
+  description: "Curator-enriched, awaiting approval. Additive; coexists with loom:issue. Applied by: Curator only."
   color: "10B981"  # emerald-500
 
 # Status Labels
@@ -147,6 +147,6 @@
 # (see builder.md "Ignore External Issues") — a non-collaborator submission needs
 # maintainer approval before Curator/Builder process it.
 - name: external
-  description: "Submitted by a non-collaborator; requires maintainer approval before Curator/Builder process it. Applied by: humans only."
+  description: "Non-collaborator submission; needs maintainer approval before curation. Applied by: humans only."
   color: "E5E7EB"  # gray-200 - external/hold marker
 # END LOOM LABELS

--- a/defaults/scripts/check-label-descriptions.sh
+++ b/defaults/scripts/check-label-descriptions.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# check-label-descriptions.sh - Fail if any label description in the registry
+# exceeds GitHub's 100-character limit.
+#
+# Why (#4335): sync-labels.sh pushes each label's `description` from
+# `labels.yml` verbatim to the GitHub API, which rejects descriptions over 100
+# characters with HTTP 422 on BOTH create and edit. Five descriptions had
+# silently drifted over the limit (`loom:issue`, `loom:reviewing`,
+# `loom:curated`, `external`, `loom:triage`), so every consumer sync left those
+# labels stale — the create path 422'd on fresh repos, and the edit path 422'd
+# everywhere else. There was no automated tie between the registry and the API
+# limit, so the drift accumulated until a consumer install surfaced it. This
+# lint is that tie: the registry is the enforced source of truth, and truncation
+# is deliberately NOT added to sync-labels.sh (silent truncation would hide
+# exactly the drift this check exists to catch).
+#
+# Registry format: the descriptions are one-line quoted YAML values, e.g.
+#   description: "Approved for work. Applied by: humans ..."
+# so a full YAML parser is unnecessary — a line regex over both registry copies
+# (kept byte-identical by check-labels-drift.sh) is sufficient, matching the
+# dependency-free bash approach of the sibling checks.
+#
+# GitHub counts CHARACTERS, not bytes (a multi-byte em-dash counts as one), so
+# the length is measured with `${#var}` on a UTF-8 locale rather than byte size.
+#
+# Usage:
+#   check-label-descriptions.sh [ROOT]
+#     ROOT  Repository root containing defaults/ and .github/labels.yml.
+#           Defaults to `git rev-parse --show-toplevel`, then the script's own
+#           repo root. If <ROOT>/defaults does not exist (e.g. an installed
+#           downstream repo with no source tree), it falls back to whatever
+#           labels.yml copies are present; if none exist it is a clean no-op.
+#
+# Exit codes: 0 = all descriptions within the limit (or nothing to check);
+# 1 = one or more descriptions exceed 100 characters (offenders named on stderr).
+
+set -euo pipefail
+
+readonly MAX_LEN=100
+
+# --- Resolve ROOT -----------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ $# -ge 1 && -n "${1:-}" ]]; then
+  ROOT="$1"
+else
+  if ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+  else
+    # defaults/scripts/ -> defaults/ -> repo root
+    ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+  fi
+fi
+
+# --- Collect the registry copies to check -----------------------------------
+LABELS_FILES=()
+[[ -f "$ROOT/.github/labels.yml" ]] && LABELS_FILES+=("$ROOT/.github/labels.yml")
+[[ -f "$ROOT/defaults/.github/labels.yml" ]] && LABELS_FILES+=("$ROOT/defaults/.github/labels.yml")
+
+if [[ ${#LABELS_FILES[@]} -eq 0 ]]; then
+  echo "check-label-descriptions: no labels.yml found under $ROOT — nothing to check (ok)."
+  exit 0
+fi
+
+# --- Scan every label block for an over-length description ------------------
+# labels.yml is a flat list of `- name: <label>` blocks, each followed by a
+# `description:` line. Track the most recent `name:` so an offending
+# description can be attributed to its label.
+too_long=0
+
+for file in "${LABELS_FILES[@]}"; do
+  current_label=""
+  lineno=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    lineno=$((lineno + 1))
+
+    # Capture the label name for the block we're in.
+    if [[ "$line" =~ ^-[[:space:]]+name:[[:space:]]*(.*)$ ]]; then
+      current_label="${BASH_REMATCH[1]}"
+      # Strip surrounding quotes and trailing inline comment/whitespace.
+      current_label="${current_label%%#*}"
+      current_label="${current_label#\"}"; current_label="${current_label%\"}"
+      current_label="${current_label#\'}"; current_label="${current_label%\'}"
+      # trim trailing whitespace
+      current_label="${current_label%"${current_label##*[![:space:]]}"}"
+      continue
+    fi
+
+    # Only description lines matter.
+    [[ "$line" =~ ^[[:space:]]*description:[[:space:]] ]] || continue
+
+    # Extract the description value after `description:`.
+    desc="${line#*description:}"
+    # trim leading whitespace
+    desc="${desc#"${desc%%[![:space:]]*}"}"
+    # Strip one layer of surrounding quotes if present.
+    if [[ "$desc" == \"*\" ]]; then
+      desc="${desc#\"}"; desc="${desc%\"}"
+    elif [[ "$desc" == \'*\' ]]; then
+      desc="${desc#\'}"; desc="${desc%\'}"
+    fi
+
+    if (( ${#desc} > MAX_LEN )); then
+      echo "OVER LIMIT (${#desc} > ${MAX_LEN}): ${current_label:-<unknown>}" >&2
+      echo "  at ${file#"$ROOT"/}:$lineno" >&2
+      echo "  description: $desc" >&2
+      too_long=1
+    fi
+  done < "$file"
+done
+
+if [[ "$too_long" -ne 0 ]]; then
+  echo "" >&2
+  echo "check-label-descriptions: FAIL — one or more label descriptions exceed" >&2
+  echo "GitHub's ${MAX_LEN}-character limit. sync-labels.sh will 422 on both create" >&2
+  echo "and edit for these labels, silently leaving them stale on every repo." >&2
+  echo "Shorten the description(s) above in BOTH .github/labels.yml and" >&2
+  echo "defaults/.github/labels.yml (they are kept byte-identical), preserving the" >&2
+  echo "'Applied by:' clause, then re-run this check." >&2
+  exit 1
+fi
+
+echo "check-label-descriptions: OK — all label descriptions are within ${MAX_LEN} characters."
+exit 0


### PR DESCRIPTION
Closes #4335

## Problem
Five label descriptions in `.github/labels.yml` (and its byte-identical mirror `defaults/.github/labels.yml`) exceeded GitHub's 100-character limit. `sync-labels.sh` pushes each description verbatim to the API, which 422s on **both** create and edit — so these five labels silently never synced anywhere (`external` failed to create on fresh consumer repos; the other four 422'd on edit and stayed stale everywhere):

| Label | Old length |
|---|---|
| loom:issue | 221 |
| loom:reviewing | 189 |
| loom:curated | 148 |
| external | 121 |
| loom:triage | 106 |

## Changes
- **`.github/labels.yml` + `defaults/.github/labels.yml`** — shortened all five descriptions to ≤100 chars (identical edits; byte-identical parity preserved). Each keeps its `Applied by:` clause; `loom:issue` keeps its pointer to curator.md's promotion rule.
- **`defaults/scripts/check-label-descriptions.sh`** (new) — dependency-free bash lint following the sibling `check-labels-drift.sh` / `check-phantom-labels.sh` pattern. Parses `description:` lines from both registry copies and fails, naming any label over 100 chars. Measures character length (not bytes) so multi-byte em-dashes count as one, matching GitHub.
- **`.github/workflows/ci.yml`** — wired the new lint into the existing labels job next to the drift and phantom checks.
- **`sync-labels.sh`** — intentionally NOT modified; adding truncation there would silently hide future drift.

## Test plan (all run, all pass)
- `bash defaults/scripts/check-label-descriptions.sh` → OK. Temporarily lengthening `loom:triage` past 100 chars → FAIL naming `loom:triage` (122 > 100); reverted → OK.
- `bash defaults/scripts/check-labels-drift.sh` → OK (both copies identical).
- `bash defaults/scripts/check-phantom-labels.sh` → OK (no label names changed).
- Python length sweep over both files → zero descriptions > 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)