### PR TITLE
docs: honor commit.signoff / DCO in builder and doctor roles

### DIFF
--- a/defaults/.claude/commands/loom/builder-pr.md
+++ b/defaults/.claude/commands/loom/builder-pr.md
@@ -252,6 +252,7 @@ Root cause verification (for process/behavior issues):
 
 Local verification:
 - [ ] The project's check command passes (see `buildGate.command` in `.loom/config.json`, or the repo's documented CI command, e.g. `pnpm check:ci`)
+- [ ] Commits are signed off if required (`commit.signoff: true` in `.loom/config.json`, or a DCO/`sign-off` requirement — `git commit --signoff`; see "DCO sign-off" above)
 - [ ] Relevant tests pass
 - [ ] Each criterion has explicit verification (not "I think it works")
 ```
@@ -476,6 +477,22 @@ These patterns are **WRONG** — sweep phase validation will reject PRs with tit
 | `feat: implement feature from issue #N` | Generic — could be any feature |
 | `<copy of issue title>` | Issue titles describe problems; commits describe solutions |
 
+### DCO sign-off
+
+If `commit.signoff` is `true` in `.loom/config.json`, pass `--signoff` on **every**
+commit you author (including `git commit --amend`) so each carries a
+`Signed-off-by:` trailer — DCO-requiring repos gate PRs on it:
+
+```bash
+git commit --signoff -m "fix: validate PR title format in sweep phase validation"
+```
+
+If the knob is unset, do a one-time check before your first commit: if
+`CONTRIBUTING.md`/a `DCO` file mentions `Signed-off-by`/DCO **or** a required status
+check name matches `dco`/`sign-?off`, use `--signoff` too and note it in the PR
+body. `--signoff` is harmless when not required. See
+`defaults/docs/commit-signoff.md`.
+
 ---
 
 ## Creating Pull Requests: Label and Auto-Close Requirements
@@ -596,6 +613,7 @@ When creating a PR, verify:
 6. All CI checks pass locally (the project's check command — `buildGate.command` in `.loom/config.json`, e.g. `pnpm check:ci`)
 7. PR description includes verification table for each criterion
 8. Tests added/updated as needed
+9. Commits carry a `Signed-off-by:` trailer if required (`commit.signoff: true` in `.loom/config.json`, or a DCO/`sign-off` check — see "DCO sign-off")
 
 ### Creating the PR
 

--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -813,6 +813,33 @@ git diff   # Read the actual changes
 
 **The PR title and commit message MUST describe what the code change does, not reference the issue.** See builder-pr.md for the full rules, anti-patterns, and examples.
 
+### Commit Conventions: DCO / sign-off
+
+Some repos require a DCO `Signed-off-by:` trailer on **every** commit (enforced by
+a required `sign-off`/`DCO` status check). Honor it so your PR passes on the first
+Judge pass instead of burning a Doctor cycle on `git commit --amend --signoff`:
+
+```bash
+# Load-bearing: if commit.signoff is true in .loom/config.json, pass --signoff
+# on EVERY commit you author (including --amend).
+if [ "$(jq -r '.commit.signoff // false' .loom/config.json 2>/dev/null)" = "true" ]; then
+  git commit --signoff -m "fix: ..."
+else
+  git commit -m "fix: ..."
+fi
+```
+
+- **Knob (deterministic)**: `commit.signoff: true` in `.loom/config.json` ⇒ always
+  `--signoff`. Read it the same way you read `buildGate.command`. Absent ⇒ behavior
+  unchanged, except:
+- **Heuristic (advisory fallback, knob unset)**: before your first commit, if
+  `CONTRIBUTING.md`/a `DCO` file mentions `Signed-off-by`/DCO, **or** a required
+  status check name matches `dco`/`sign-?off`, use `--signoff` too and note it in
+  the PR body.
+- `--signoff` is harmless when not required (only adds a trailer); git does not add
+  a duplicate trailer for an identity already present. Full reference:
+  `defaults/docs/commit-signoff.md`.
+
 ### Closing vs Partial Increments (family/epic issues)
 
 Decide whether this PR **fully** resolves the issue (`Closes #N`) or is only a

--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -203,6 +203,9 @@ if [ "$PRIORITY_1" -eq 0 ] && [ "$PRIORITY_2" -eq 0 ]; then
       git fetch origin main
       git rebase origin/main
       # ... resolve conflicts ...
+      # If commit.signoff is true (or the repo requires DCO), re-signed commits
+      # must keep their Signed-off-by: trailer — use `git commit --amend --signoff`
+      # when re-authoring a commit during the rebase. See defaults/docs/commit-signoff.md.
       git push --force-with-lease
 
       # Comment but don't add labels
@@ -320,6 +323,7 @@ gh pr edit 588 --remove-label "loom:treating" --add-label "loom:review-requested
    - Do NOT push until all local checks pass
    - This prevents multiple fix-push-fail cycles
 9. **Commit and push**: Push your fixes to the PR branch
+   - **DCO / sign-off**: if `commit.signoff` is `true` in `.loom/config.json` (read it the same way as `buildGate.command`), or the repo has a DCO / required `sign-off` check, add `--signoff` to **every** commit you author — including `git commit --amend --signoff` when re-authoring during a rebase — so each carries a `Signed-off-by:` trailer. Harmless when not required; git will not add a duplicate trailer. Reference: `defaults/docs/commit-signoff.md`.
    - **9a. Rebase any stacked children** (best-effort): if the just-pushed branch matches `feature/issue-<N>` (i.e. you amended a stacked *parent*), run:
      ```bash
      ./.loom/scripts/rebase-stacked-children.sh feature/issue-<N>
@@ -615,6 +619,10 @@ pnpm check:ci   # your repo's check command — see buildGate.command in .loom/c
 
 # Commit and push
 git add .
+# DCO / sign-off: if commit.signoff is true in .loom/config.json (or the repo has a
+# DCO / required sign-off check), add --signoff so the commit carries a
+# Signed-off-by: trailer — same rule the Builder follows. Applies to EVERY commit
+# you author, including --amend. See defaults/docs/commit-signoff.md.
 git commit -m "Address review feedback
 
 - Fix null handling in foo.ts:15

--- a/defaults/docs/commit-signoff.md
+++ b/defaults/docs/commit-signoff.md
@@ -1,0 +1,68 @@
+# Commit sign-off (DCO): the `commit.signoff` knob
+
+Some repositories require a [Developer Certificate of Origin](https://developercertificate.org/)
+(DCO) sign-off on **every** commit — a `Signed-off-by: Name <email>` trailer,
+produced by `git commit --signoff`. These repos typically enforce it with a
+required `sign-off` / `DCO` status check that fails any PR whose commits lack the
+trailer.
+
+Loom's Builder and Doctor roles author the commits that land in a PR, so a
+DCO-requiring repo will fail those PRs on the first Judge pass unless the roles
+sign off. This page documents the opt-in knob that makes them do so
+deterministically.
+
+## The knob
+
+Add to the repo's `.loom/config.json`:
+
+```json
+{
+  "commit": {
+    "signoff": true
+  }
+}
+```
+
+When `commit.signoff` is `true`, the Builder and Doctor roles pass `--signoff` on
+**every** commit they author, including `git commit --amend` and the rebase +
+force-push path. Each resulting commit carries a `Signed-off-by:` trailer for the
+committing identity.
+
+**The knob is the load-bearing guarantee.** It is read the same way roles already
+read `buildGate.command` — from `.loom/config.json`, by the role prompt. There is
+no git-native "always sign off `git commit`" setting (`format.signoff` affects
+`git format-patch` only), so the trailer must come from `--signoff` on each commit.
+
+### Absent by default
+
+`commit.signoff` is **opt-in and absent by default** — it is intentionally *not*
+present in `defaults/config.json`, and enabling it is a per-consuming-repo choice.
+When the knob is unset, commit behavior is unchanged (no trailer added), except for
+the advisory heuristic below.
+
+## Detection heuristic (advisory fallback)
+
+When the knob is **unset**, the roles do one bounded, best-effort check before the
+first commit and use `--signoff` if any of these fire (noting it in the PR body):
+
+- `CONTRIBUTING.md` (or a `DCO` / `DCO.txt` file) mentions `Signed-off-by` or DCO, or
+- the repo has a required status check whose name matches `dco` or `sign-?off`.
+
+The heuristic is **advisory, not load-bearing** — set the knob for a guarantee. A
+`--signoff` on a repo that does not require it is harmless: it only adds a trailer.
+
+## Edge cases
+
+- **No duplicate trailer**: `git commit --signoff` does not add a second identical
+  `Signed-off-by:` trailer when one for the same identity is already present.
+- **Amend / rebase**: the same rule applies to `git commit --amend --signoff` and
+  to any commit re-authored during a rebase + `git push --force-with-lease`.
+- **Existing trailer**: a commit that already carries the trailer is left as-is.
+
+## Optional hook backstop (not installed by default)
+
+A repo-local `prepare-commit-msg` hook that appends the trailer when missing would
+make the guarantee independent of prompt adherence. Loom does **not** install one:
+`worktree.sh` stays free of DCO-specific behavior, and the knob-driven prompt
+guidance is the mechanism. Repos that want a hard, prompt-independent guarantee can
+add such a hook themselves.


### PR DESCRIPTION
## Summary

Teach the Builder and Doctor roles about repo-level DCO / sign-off requirements so
sweeps against DCO-requiring repos pass the `sign-off` check on the first Judge
pass instead of burning a Doctor→Judge cycle on `git commit --amend --signoff`
(the failure was 3/3 PRs in a recent safehouse sweep).

## Changes

- **`defaults/.claude/commands/loom/builder.md`** — new "Commit Conventions: DCO /
  sign-off" step after the diff-review guidance: read `commit.signoff` from
  `.loom/config.json` (same pattern as `buildGate.command`) and pass `--signoff` on
  every commit when set; advisory heuristic fallback (CONTRIBUTING.md/DCO file or a
  `dco`/`sign-?off` status check) when unset.
- **`defaults/.claude/commands/loom/builder-pr.md`** — "DCO sign-off" subsection in
  the commit-message guidance, plus a sign-off item in the pre-PR checklist and the
  final pre-PR checklist.
- **`defaults/.claude/commands/loom/doctor.md`** — same rule at the commit/push
  step and the rebase + force-push path, explicitly covering `git commit --amend
  --signoff`.
- **`defaults/docs/commit-signoff.md`** — new reference page documenting the knob,
  the advisory heuristic, edge cases (no duplicate trailer, amend/rebase), and the
  documented decision **not** to install a `prepare-commit-msg` hook backstop
  (`worktree.sh` stays DCO-agnostic).

The `commit.signoff` knob is **opt-in and absent by default** — not added to this
repo's `.loom/config.json` or `defaults/config.json`. `worktree.sh` is untouched
(optional hook backstop declined, decision documented).

## Acceptance Criteria Verification

- [x] Builder detects a DCO requirement (config knob primary; CONTRIBUTING.md/DCO
  file or `dco`/`sign-off` status check as advisory fallback) and commits with
  `--signoff` — added to `builder.md`/`builder-pr.md`.
- [x] Doctor applies the same rule to its own commits, incl. `--amend --signoff`
  and the rebase path — added to `doctor.md`.
- [x] Config knob `commit.signoff: true` honored unconditionally so detection is
  not load-bearing — documented and wired into the role prompts.
- [x] Opt-in, absent-by-default (not in `defaults/config.json`) — verified `grep -c
  signoff defaults/config.json` = 0.

## Test Plan

- [x] Manual scratch-repo verification (absolute-path scratch, `git -C`): with
  `commit.signoff: true` the commit carries a `Signed-off-by:` trailer for the
  committer; `git commit --amend --signoff` keeps a single trailer (no duplicate);
  knob absent → no trailer (behavior unchanged).
- [x] `scripts/check-claude-md-budget.sh` passes (CLAUDE.md untouched; new content
  routed to `defaults/docs/`, not `defaults/CLAUDE.md`).
- N/A automated: prompt/doc change plus prompt-read config logic; the optional
  `prepare-commit-msg` backstop (which would warrant a shell test) was declined.

Closes #4337