### PR TITLE
feat(fleet-comms): add fleet-check.sh read/check counterpart to fleet-send.sh

### DIFF
--- a/defaults/docs/fleet-comms.md
+++ b/defaults/docs/fleet-comms.md
@@ -24,14 +24,15 @@ are two delivery paths, tried in order; the same degradation contract from
 1. **MCP tools (`safehouse_send` / `safehouse_read`)** — present when
    `spawn-claude.sh` injected the safehouse MCP server *and* your runtime/role
    exposes MCP tools. Prefer these when available.
-2. **Bash helper (`.loom/scripts/fleet-send.sh`)** — the fallback for roles
-   whose tool allowlists exclude MCP tools. Lifecycle role subagents
-   (`loom-builder` / `loom-judge` / `loom-doctor`) pin their tools to
-   Read/Glob/Grep/Bash(/Write/Edit) with no MCP tools, so the injected
-   `safehouse_send` is invisible to them — but they all have Bash. The helper
-   resolves the socket/persona from `$SAFEHOUSED_SOCKET` + `$SAFEHOUSE_PERSONA`
-   (exported into the session by `spawn-claude.sh`) and is a thin JSON-lines
-   client for the same wire protocol. It posts only (no read op yet).
+2. **Bash helpers (`.loom/scripts/fleet-send.sh` / `.loom/scripts/fleet-check.sh`)**
+   — the fallback for roles whose tool allowlists exclude MCP tools. Lifecycle
+   role subagents (`loom-builder` / `loom-judge` / `loom-doctor`) pin their
+   tools to Read/Glob/Grep/Bash(/Write/Edit) with no MCP tools, so the
+   injected `safehouse_send` / `safehouse_read` are invisible to them — but
+   they all have Bash. Both helpers resolve the socket/persona from
+   `$SAFEHOUSED_SOCKET` + `$SAFEHOUSE_PERSONA` (exported into the session by
+   `spawn-claude.sh`) and speak the same JSON-lines wire protocol:
+   `fleet-send.sh` posts (`send` op), `fleet-check.sh` reads (`check` op).
 
 - **If a path is available**: use it per the guidance below (MCP first, then the
   helper).
@@ -85,6 +86,19 @@ Via the Bash helper (the fallback for roles without MCP tools):
 The helper defaults `to` to `"*"`, reads persona/socket from the session env,
 and exits 0 silently when the room is unreachable — call it unconditionally.
 
+To read back pending mail without MCP tools, use the read/check counterpart:
+
+```
+.loom/scripts/fleet-check.sh [--peek] [--limit <n>]
+```
+
+`fleet-check.sh` reads persona/socket from the same session env, prints each
+pending message as one JSON object per line to stdout on success, and prints
+nothing (exit 0) on any failure or an empty mailbox — treat empty output as
+"no mail" uniformly. By default a `check` **advances the persona's read
+cursor** (mail is consumed once read); pass `--peek` to read without
+consuming. `--limit <n>` caps how many messages come back in one call.
+
 - **`task_id`**: the repo-qualified `<repo>_<issue>` form the daemon narrates on
   (post-#4224 — e.g. `loom_4199`, the workspace-root basename plus the issue
   number), so your message threads alongside the daemon's phase narration for
@@ -117,6 +131,18 @@ guardrails (scope discipline, label discipline, the "issues are suggestions"
 guardrails, etc.) — it's a hint from a human watching the fleet, not a
 privilege escalation. If it conflicts with your role's mandatory rules, follow
 your role's rules and, if useful, say why in a reply.
+
+For roles without MCP tools, `.loom/scripts/fleet-check.sh` is the non-MCP
+path to this read-back (`safehouse_read`'s Bash-fallback counterpart to
+`safehouse_send`/`fleet-send.sh`) — poll it at the same natural checkpoints,
+never as a wait loop.
+
+**Shared-cursor caveat**: a persona's mailbox cursor is shared by every
+process using that persona. A default (advancing) `check` consumes mail for
+*all* consumers sharing the persona, not just the caller — if another process
+(or a later checkpoint in your own role) expected to see that mail, it won't.
+Use `--peek` when you're not sure you're the sole consumer of the persona's
+mailbox at that checkpoint.
 
 ## Summary for role authors
 

--- a/defaults/scripts/fleet-check.sh
+++ b/defaults/scripts/fleet-check.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# fleet-check.sh — read/check ONE safehouse mailbox over the AF_UNIX socket,
+# for lifecycle role subagents (Builder / Judge / Doctor) whose Claude-Code
+# tool allowlists exclude MCP tools and therefore can't reach the
+# session-injected `safehouse_read` MCP tool. Read/check counterpart to
+# `fleet-send.sh` (issue #4248, follow-on from #4199 / phase 2 of #4196 /
+# #3997).
+#
+# It is a thin JSON-lines client speaking the same wire protocol as
+# `fleet-send.sh`: connect, send the mandatory `hello` handshake, then one
+# `check` request. The `check` contract is confirmed against
+# `rjwalters/safehouse` (commit 803f35b, `safehoused/src/rpc.rs` "check"
+# branch + `safehoused/src/mailbox.rs::check`):
+#
+#   {"id": 1, "op": "check"}                 # default: advances the read cursor
+#   {"id": 1, "op": "check", "peek": true}   # peek: does NOT advance the cursor
+#   {"id": 1, "op": "check", "limit": 2}     # cap returned count (server clamps)
+#
+#   {"ok": true, "advanced": true, "messages": [ {...envelope...}, ... ]}
+#
+# `check` returns unread envelopes for the authenticated persona, oldest
+# first. Default (advance=true) moves the persona's read cursor past
+# everything returned — an immediate second `check` returns `[]`. `peek: true`
+# leaves the cursor untouched. With `limit`, the cursor only advances past
+# what was actually returned.
+#
+# CAVEAT — shared cursor: spawned lifecycle roles share the persona's mailbox
+# cursor with any other process using the same persona. An advancing `check`
+# from one consumer consumes mail another consumer expected to see. Use
+# `--peek` when you don't want to consume mail meant for someone else sharing
+# your persona.
+#
+# HARD degradation contract — this helper MUST NEVER block, stall, or fail a
+# role. Absent env vars, an unresolvable socket, or any connect/hello/check
+# failure ⇒ **exit 0 SILENTLY** (no stdout, no stderr). An empty mailbox is
+# ALSO silent (zero output, exit 0) — a caller can treat empty output as "no
+# mail / no room" uniformly.
+#
+# UNLIKE fleet-send.sh (which never prints to stdout on any path): on
+# success, this helper prints each message in the `messages` array as one
+# JSON object per line to stdout.
+#
+# Usage:
+#   fleet-check.sh [--peek] [--limit <n>]
+#
+# Resolution:
+#   socket  = $SAFEHOUSED_SOCKET  (fallback $LOOM_SAFEHOUSE_SOCKET)
+#   persona = $SAFEHOUSE_PERSONA
+#
+# Both are exported into the worker session by spawn-claude.sh alongside the
+# safehouse MCP injection; a plain shell without them is the common case and
+# exits 0.
+
+# Deliberately NOT `set -e` — every failure path must fall through to exit 0.
+set -u
+
+# Any unexpected error, signal, or EXIT ⇒ silent success. Belt-and-suspenders
+# on top of the explicit `exit 0`s below.
+trap 'exit 0' ERR
+trap 'exit 0' EXIT
+
+# --- Parse args -------------------------------------------------------------
+_peek="false"
+_limit=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --peek) _peek="true"; shift ;;
+        --limit) _limit="${2:-}"; shift 2 || exit 0 ;;
+        --limit=*) _limit="${1#*=}"; shift ;;
+        *) shift ;; # ignore unknown args — never fail a role over a typo
+    esac
+done
+
+# --- Resolve socket + persona (silent no-op when absent) --------------------
+_socket="${SAFEHOUSED_SOCKET:-${LOOM_SAFEHOUSE_SOCKET:-}}"
+_persona="${SAFEHOUSE_PERSONA:-}"
+
+[[ -z "$_socket" || -z "$_persona" ]] && exit 0
+
+# `limit`, when present, must be a non-negative integer (else ignore it —
+# never fail a role over a typo).
+if [[ -n "$_limit" && ! "$_limit" =~ ^[0-9]+$ ]]; then
+    _limit=""
+fi
+
+# --- Check over the socket (best-effort; python does the AF_UNIX I/O) -------
+SAFEHOUSE_FC_SOCKET="$_socket" \
+    SAFEHOUSE_FC_PERSONA="$_persona" \
+    SAFEHOUSE_FC_PEEK="$_peek" \
+    SAFEHOUSE_FC_LIMIT="$_limit" \
+    "${LOOM_PYTHON:-python3}" - <<'PY' 2>/dev/null || exit 0
+import json, os, socket, sys
+
+sock_path = os.environ.get("SAFEHOUSE_FC_SOCKET", "")
+persona = os.environ.get("SAFEHOUSE_FC_PERSONA", "")
+peek = os.environ.get("SAFEHOUSE_FC_PEEK", "false") == "true"
+limit_raw = os.environ.get("SAFEHOUSE_FC_LIMIT", "")
+
+
+def read_reply(reader):
+    # Skip interleaved async push lines (they carry an `event` key and no `id`)
+    # and return the first genuine reply object, or None on EOF/timeout.
+    for line in reader:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except Exception:
+            continue
+        if isinstance(msg, dict) and "event" in msg and "id" not in msg:
+            continue
+        return msg
+    return None
+
+
+try:
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.settimeout(5.0)
+    s.connect(sock_path)
+except Exception:
+    sys.exit(0)
+
+try:
+    reader = s.makefile("r", encoding="utf-8")
+
+    def write_line(obj):
+        s.sendall((json.dumps(obj) + "\n").encode("utf-8"))
+
+    # Mandatory hello handshake.
+    write_line({"id": 0, "op": "hello", "persona": persona})
+    reply = read_reply(reader)
+    if not (isinstance(reply, dict) and reply.get("ok") is True):
+        sys.exit(0)
+
+    # check request (id=1).
+    req = {"id": 1, "op": "check"}
+    if peek:
+        req["peek"] = True
+    if limit_raw:
+        req["limit"] = int(limit_raw)
+    write_line(req)
+
+    reply = read_reply(reader)
+    if not (isinstance(reply, dict) and reply.get("ok") is True):
+        sys.exit(0)
+
+    messages = reply.get("messages")
+    if not isinstance(messages, list) or not messages:
+        sys.exit(0)
+
+    for msg in messages:
+        sys.stdout.write(json.dumps(msg) + "\n")
+except Exception:
+    sys.exit(0)
+finally:
+    try:
+        s.close()
+    except Exception:
+        pass
+
+sys.exit(0)
+PY
+
+exit 0

--- a/defaults/scripts/tests/test-fleet-check.sh
+++ b/defaults/scripts/tests/test-fleet-check.sh
@@ -1,0 +1,360 @@
+#!/usr/bin/env bash
+# test-fleet-check.sh — Tests for the safehouse Bash fleet-comms read/check
+# client (issue #4248, follow-on from #4199 / phase 2 of #4196 / #3997).
+#
+# fleet-check.sh is the read/check counterpart to fleet-send.sh — the Bash
+# fallback that lifecycle role subagents (Builder / Judge / Doctor) use to
+# read from the safehouse mailbox, since their tool allowlists exclude the
+# injected `safehouse_read` MCP tool. Its contract is HARD degradation: never
+# block or fail a role. UNLIKE fleet-send.sh, on success it prints each
+# message to stdout (one JSON object per line).
+#
+# Covers:
+#   a. No SAFEHOUSED_SOCKET / SAFEHOUSE_PERSONA env ⇒ exit 0, zero output.
+#   b. Env set but the socket path is absent (connect fails) ⇒ exit 0.
+#   c. Happy path against a mock AF_UNIX server: hello sent before check,
+#      messages from the reply are printed to stdout (one per line).
+#   d. Empty mailbox (`messages: []`) ⇒ zero output, exit 0.
+#   e. --peek and --limit flags appear in the wire request.
+#   f. Async push lines (object with `event`, no `id`) interleaved before the
+#      genuine reply are skipped.
+#   g. Malformed reply / early-closed connection ⇒ exit 0, no output.
+#
+# Style matches test-fleet-send.sh — plain bash, hand-rolled assertions.
+# Bats is NOT used in this repository.
+#
+# Usage:
+#   ./.loom/scripts/tests/test-fleet-check.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FLEET_CHECK="$SCRIPTS_DIR/fleet-check.sh"
+PY="${LOOM_PYTHON:-python3}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: $1"
+}
+fail() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: $1"
+    [[ -n "${2:-}" ]] && echo "    $2"
+}
+
+assert_eq() {
+    if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3" "expected '$1', got '$2'"; fi
+}
+assert_contains() {
+    if [[ "$2" == *"$1"* ]]; then pass "$3"; else fail "$3" "expected substring '$1' in '$2'"; fi
+}
+assert_not_contains() {
+    if [[ "$2" != *"$1"* ]]; then pass "$3"; else fail "$3" "unexpected substring '$1' in '$2'"; fi
+}
+
+# Isolate every invocation from the ambient operator environment.
+unset SAFEHOUSED_SOCKET LOOM_SAFEHOUSE_SOCKET SAFEHOUSE_PERSONA 2>/dev/null || true
+
+if ! command -v "$PY" >/dev/null 2>&1; then
+    echo -e "  ${YELLOW}SKIP${NC}: python3 not available; fleet-check.sh tests need it"
+    exit 0
+fi
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# Mock AF_UNIX safehoused: accept one connection, reply ok to hello, then
+# reply to `check` per the scripted behavior for this record, and record
+# every received line to $2. Times out (writing an empty record) if no
+# client ever connects.
+#
+# Behavior is selected via env vars read by the mock itself:
+#   MOCK_MESSAGES        - JSON array string to return as "messages" (default "[]")
+#   MOCK_PUSH_LINES      - integer count of async push lines to emit before the
+#                          check reply (default 0)
+#   MOCK_MALFORMED_CHECK - if "1", write a malformed (non-JSON) line instead of
+#                          a check reply, then close.
+#   MOCK_CLOSE_EARLY     - if "1", close the connection right after hello,
+#                          before any check request is even read.
+MOCK_PY="$TMPDIR_TEST/mock-safehoused.py"
+cat >"$MOCK_PY" <<'PY'
+import json, os, socket, sys
+
+sock_path = sys.argv[1]
+record = sys.argv[2]
+accept_timeout = float(os.environ.get("MOCK_ACCEPT_TIMEOUT", "3"))
+messages = json.loads(os.environ.get("MOCK_MESSAGES", "[]"))
+push_lines = int(os.environ.get("MOCK_PUSH_LINES", "0"))
+malformed_check = os.environ.get("MOCK_MALFORMED_CHECK", "0") == "1"
+close_early = os.environ.get("MOCK_CLOSE_EARLY", "0") == "1"
+
+if os.path.exists(sock_path):
+    os.unlink(sock_path)
+
+srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+srv.bind(sock_path)
+srv.listen(1)
+srv.settimeout(accept_timeout)
+
+received = []
+try:
+    conn, _ = srv.accept()
+except socket.timeout:
+    with open(record, "w") as f:
+        pass  # empty record: no client connected
+    srv.close()
+    sys.exit(0)
+
+conn.settimeout(3.0)
+reader = conn.makefile("r", encoding="utf-8")
+try:
+    for line in reader:
+        line = line.strip()
+        if not line:
+            continue
+        received.append(line)
+        try:
+            msg = json.loads(line)
+        except Exception:
+            continue
+        op = msg.get("op")
+        if op == "hello":
+            conn.sendall((json.dumps({"id": 0, "ok": True}) + "\n").encode("utf-8"))
+            if close_early:
+                break
+        elif op == "check":
+            for i in range(push_lines):
+                conn.sendall(
+                    (json.dumps({"event": "ping", "seq": i}) + "\n").encode("utf-8")
+                )
+            if malformed_check:
+                conn.sendall(b"{not json\n")
+            else:
+                conn.sendall(
+                    (
+                        json.dumps(
+                            {
+                                "id": msg.get("id", 1),
+                                "ok": True,
+                                "advanced": not msg.get("peek", False),
+                                "messages": messages,
+                            }
+                        )
+                        + "\n"
+                    ).encode("utf-8")
+                )
+            break
+finally:
+    with open(record, "w") as f:
+        f.write("\n".join(received))
+    conn.close()
+    srv.close()
+    if os.path.exists(sock_path):
+        try:
+            os.unlink(sock_path)
+        except OSError:
+            pass
+PY
+
+# start_mock <sockpath> <recordfile> — launch the mock, wait for it to bind.
+MOCK_PID=""
+start_mock() {
+    local sock="$1" rec="$2"
+    "$PY" "$MOCK_PY" "$sock" "$rec" &
+    MOCK_PID=$!
+    local i=0
+    while [[ ! -S "$sock" && $i -lt 50 ]]; do
+        sleep 0.05
+        i=$((i + 1))
+    done
+}
+
+echo "============================================================"
+echo "fleet-check.sh degradation + wire tests"
+echo "============================================================"
+
+# ---------------------------------------------------------------------------
+# (a) No env at all ⇒ exit 0, zero output.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- (a) no SAFEHOUSED_SOCKET / SAFEHOUSE_PERSONA --"
+out_a="$(env -u SAFEHOUSED_SOCKET -u LOOM_SAFEHOUSE_SOCKET -u SAFEHOUSE_PERSONA \
+    bash "$FLEET_CHECK" 2>&1)"
+rc_a=$?
+assert_eq "0" "$rc_a" "(a) exits 0 with no env"
+assert_eq "" "$out_a" "(a) produces zero output with no env"
+
+# ---------------------------------------------------------------------------
+# (b) Env set but the socket path does not exist ⇒ exit 0, zero output.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- (b) env set, socket path absent --"
+missing_sock="$TMPDIR_TEST/does-not-exist.sock"
+out_b="$(SAFEHOUSED_SOCKET="$missing_sock" SAFEHOUSE_PERSONA="loom_builder_1" \
+    bash "$FLEET_CHECK" 2>&1)"
+rc_b=$?
+assert_eq "0" "$rc_b" "(b) exits 0 when socket path is absent"
+assert_eq "" "$out_b" "(b) produces zero output when socket is absent"
+
+# ---------------------------------------------------------------------------
+# (c) Happy path against a mock AF_UNIX server: hello before check, messages
+#     printed to stdout.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- (c) mock server: hello before check, messages printed --"
+sock_c="$TMPDIR_TEST/c.sock"
+rec_c="$TMPDIR_TEST/c.record"
+msgs_c='[{"room_id": "r1", "event_id": "e1", "sender": "alice", "envelope": {"v": 1, "from": "alice", "to": "*", "type": "chat", "body": "hello there"}}, {"room_id": "r1", "event_id": "e2", "sender": "bob", "envelope": {"v": 1, "from": "bob", "to": "*", "type": "chat", "body": "second message"}}]'
+MOCK_MESSAGES="$msgs_c" start_mock "$sock_c" "$rec_c"
+if [[ -S "$sock_c" ]]; then
+    out_c="$(SAFEHOUSED_SOCKET="$sock_c" SAFEHOUSE_PERSONA="loom_builder_5" \
+        MOCK_MESSAGES="$msgs_c" bash "$FLEET_CHECK")"
+    rc_c=$?
+    wait "$MOCK_PID" 2>/dev/null || true
+    record_c="$(cat "$rec_c" 2>/dev/null || true)"
+    assert_eq "0" "$rc_c" "(c) exits 0 on success"
+    assert_contains "hello" "$record_c" "(c) server received a hello request"
+    assert_contains 'loom_builder_5' "$record_c" "(c) hello carries the resolved persona"
+    assert_contains '"op": "check"' "$record_c" "(c) server received a check request"
+    # Ensure hello precedes check on the wire.
+    hello_idx="$(printf '%s\n' "$record_c" | grep -n hello | head -1 | cut -d: -f1)"
+    check_idx="$(printf '%s\n' "$record_c" | grep -n '"op": "check"' | head -1 | cut -d: -f1)"
+    if [[ -n "$hello_idx" && -n "$check_idx" && "$hello_idx" -lt "$check_idx" ]]; then
+        pass "(c) hello precedes check"
+    else
+        fail "(c) hello must precede check" "hello@$hello_idx check@$check_idx"
+    fi
+    line_count_c="$(printf '%s' "$out_c" | grep -c '.' || true)"
+    assert_eq "2" "$line_count_c" "(c) prints one line per message (2 messages)"
+    assert_contains "hello there" "$out_c" "(c) stdout contains first message body"
+    assert_contains "second message" "$out_c" "(c) stdout contains second message body"
+else
+    fail "(c) mock server failed to bind its socket"
+fi
+
+# ---------------------------------------------------------------------------
+# (d) Empty mailbox ⇒ zero output, exit 0.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- (d) empty mailbox produces zero output --"
+sock_d="$TMPDIR_TEST/d.sock"
+rec_d="$TMPDIR_TEST/d.record"
+MOCK_MESSAGES='[]' start_mock "$sock_d" "$rec_d"
+if [[ -S "$sock_d" ]]; then
+    out_d="$(SAFEHOUSED_SOCKET="$sock_d" SAFEHOUSE_PERSONA="loom_builder_5" \
+        MOCK_MESSAGES='[]' bash "$FLEET_CHECK" 2>&1)"
+    rc_d=$?
+    wait "$MOCK_PID" 2>/dev/null || true
+    assert_eq "0" "$rc_d" "(d) exits 0 on empty mailbox"
+    assert_eq "" "$out_d" "(d) produces zero output on empty mailbox"
+else
+    fail "(d) mock server failed to bind its socket"
+fi
+
+# ---------------------------------------------------------------------------
+# (e) --peek and --limit flags appear in the wire request.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- (e) --peek and --limit appear in the check request --"
+sock_e="$TMPDIR_TEST/e.sock"
+rec_e="$TMPDIR_TEST/e.record"
+MOCK_MESSAGES='[]' start_mock "$sock_e" "$rec_e"
+if [[ -S "$sock_e" ]]; then
+    SAFEHOUSED_SOCKET="$sock_e" SAFEHOUSE_PERSONA="loom_builder_5" \
+        MOCK_MESSAGES='[]' bash "$FLEET_CHECK" --peek --limit 2 >/dev/null 2>&1
+    rc_e=$?
+    wait "$MOCK_PID" 2>/dev/null || true
+    record_e="$(cat "$rec_e" 2>/dev/null || true)"
+    assert_eq "0" "$rc_e" "(e) exits 0"
+    assert_contains '"peek": true' "$record_e" "(e) request carries peek: true"
+    assert_contains '"limit": 2' "$record_e" "(e) request carries limit: 2"
+else
+    fail "(e) mock server failed to bind its socket"
+fi
+
+# ---------------------------------------------------------------------------
+# (f) Async push lines (event, no id) interleaved before the reply are
+#     skipped; the genuine reply's messages still surface.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- (f) interleaved async push lines are skipped --"
+sock_f="$TMPDIR_TEST/f.sock"
+rec_f="$TMPDIR_TEST/f.record"
+msgs_f='[{"room_id": "r1", "event_id": "e9", "sender": "carol", "envelope": {"v": 1, "from": "carol", "to": "*", "type": "chat", "body": "after the pushes"}}]'
+MOCK_MESSAGES="$msgs_f" MOCK_PUSH_LINES=3 start_mock "$sock_f" "$rec_f"
+if [[ -S "$sock_f" ]]; then
+    out_f="$(SAFEHOUSED_SOCKET="$sock_f" SAFEHOUSE_PERSONA="loom_builder_5" \
+        MOCK_MESSAGES="$msgs_f" MOCK_PUSH_LINES=3 bash "$FLEET_CHECK")"
+    rc_f=$?
+    wait "$MOCK_PID" 2>/dev/null || true
+    assert_eq "0" "$rc_f" "(f) exits 0 despite interleaved push lines"
+    assert_contains "after the pushes" "$out_f" "(f) genuine reply message still surfaces"
+    assert_not_contains '"event": "ping"' "$out_f" "(f) push lines are not echoed to stdout"
+else
+    fail "(f) mock server failed to bind its socket"
+fi
+
+# ---------------------------------------------------------------------------
+# (g) Malformed reply ⇒ exit 0, no output.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- (g) malformed check reply produces no output --"
+sock_g="$TMPDIR_TEST/g.sock"
+rec_g="$TMPDIR_TEST/g.record"
+MOCK_MALFORMED_CHECK=1 start_mock "$sock_g" "$rec_g"
+if [[ -S "$sock_g" ]]; then
+    out_g="$(SAFEHOUSED_SOCKET="$sock_g" SAFEHOUSE_PERSONA="loom_builder_5" \
+        MOCK_MALFORMED_CHECK=1 bash "$FLEET_CHECK" 2>&1)"
+    rc_g=$?
+    wait "$MOCK_PID" 2>/dev/null || true
+    assert_eq "0" "$rc_g" "(g) exits 0 on malformed reply"
+    assert_eq "" "$out_g" "(g) produces zero output on malformed reply"
+else
+    fail "(g) mock server failed to bind its socket"
+fi
+
+# ---------------------------------------------------------------------------
+# (h) Connection closes right after hello, before any check reply ⇒ exit 0,
+#     no output (early-close / EOF path).
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- (h) server closes early (right after hello) ⇒ no output --"
+sock_h="$TMPDIR_TEST/h.sock"
+rec_h="$TMPDIR_TEST/h.record"
+MOCK_CLOSE_EARLY=1 start_mock "$sock_h" "$rec_h"
+if [[ -S "$sock_h" ]]; then
+    out_h="$(SAFEHOUSED_SOCKET="$sock_h" SAFEHOUSE_PERSONA="loom_builder_5" \
+        MOCK_CLOSE_EARLY=1 bash "$FLEET_CHECK" 2>&1)"
+    rc_h=$?
+    wait "$MOCK_PID" 2>/dev/null || true
+    assert_eq "0" "$rc_h" "(h) exits 0 when server closes early"
+    assert_eq "" "$out_h" "(h) produces zero output when server closes early"
+else
+    fail "(h) mock server failed to bind its socket"
+fi
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo "========================================"
+echo "Test Results:"
+echo "  Total:  $TESTS_RUN"
+echo -e "  ${GREEN}Passed: $TESTS_PASSED${NC}"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo -e "  ${RED}Failed: $TESTS_FAILED${NC}"
+    exit 1
+fi
+echo -e "  ${GREEN}All tests passed!${NC}"


### PR DESCRIPTION
## Summary

Adds `fleet-check.sh`, the read/check counterpart to the existing
`fleet-send.sh` fleet-comms Bash fallback. Lifecycle role subagents
(Builder/Judge/Doctor) whose tool allowlists exclude MCP tools could post to
the safehouse room but had no way to read replies over the Bash path. This
closes that gap per the CONFIRMED wire protocol spec added by Curator (against
`rjwalters/safehouse` commit `803f35b`).

## Changes

- `defaults/scripts/fleet-check.sh` (new): mirrors `fleet-send.sh`'s structure
  (`set -u`, no `set -e`, `trap 'exit 0' ERR EXIT`, same env resolution:
  `$SAFEHOUSED_SOCKET`/`$LOOM_SAFEHOUSE_SOCKET` + `$SAFEHOUSE_PERSONA`).
  Speaks the same JSON-lines AF_UNIX protocol: `hello` handshake, then a
  `check` op with optional `peek`/`limit`. Unlike `fleet-send.sh` (never
  prints to stdout), on success it prints each pending message as one JSON
  object per line; on any failure or empty mailbox it stays silent and exits
  0. Reuses the embedded Python `read_reply()` skip-async-push-lines pattern
  (objects with an `event` key and no `id`) from `fleet-send.sh`.
- `defaults/scripts/tests/test-fleet-check.sh` (new): reuses
  `test-fleet-send.sh`'s mock AF_UNIX server harness, extended with a `check`
  reply path (messages array, async push-line injection, malformed-reply and
  early-close scenarios).
- `defaults/docs/fleet-comms.md`: §1 removes the "posts only (no read op
  yet)" caveat and documents the check path; §3 adds a usage snippet for
  `fleet-check.sh`; §5 names `fleet-check.sh` as the non-MCP read path and
  documents the shared-cursor caveat (an advancing `check` consumes mail from
  any other consumer using the same persona — use `--peek` when unsure you're
  the sole consumer).

## Acceptance Criteria Verification

- [x] `fleet-check.sh` implemented per the confirmed wire protocol spec
      (hello → check, `peek`/`limit` params, id-matched replies, async-push
      skip)
- [x] Output contract: prints messages on success, silent (exit 0, no output)
      on any failure or empty mailbox
- [x] Same failure posture as `fleet-send.sh`: `set -u`, no `set -e`,
      `trap 'exit 0' ERR EXIT`, silent exit-0 on missing env/connect/handshake
      failure
- [x] `--peek` and `--limit <n>` flags supported and verified on the wire
- [x] `fleet-comms.md` documents the read path (§1, §3, §5) including the
      shared-cursor caveat

## Test Plan

Ran `./defaults/scripts/tests/test-fleet-check.sh` — 24/24 assertions pass,
covering:
- (a) no env ⇒ exit 0, zero output
- (b) socket path absent ⇒ exit 0, zero output
- (c) mock server: hello precedes check, 2 messages printed one-per-line
- (d) empty mailbox ⇒ zero output, exit 0
- (e) `--peek`/`--limit` appear correctly in the wire request
- (f) interleaved async push lines (event, no id) are skipped
- (g) malformed check reply ⇒ exit 0, no output
- (h) server closes connection right after hello ⇒ exit 0, no output

Also re-ran `./defaults/scripts/tests/test-fleet-send.sh` (21/21 pass,
unaffected regression check) and `shellcheck` on both new scripts (clean, no
warnings).

Closes #4248