### PR TITLE
feat(daemon): heal absent autonomy-desired marker at startup + watchdog state-mismatch WARN

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -2474,13 +2474,25 @@ service's exit code affects the next scheduled run.
 
 **Decision matrix** (marker present ⇒ a daemon is expected):
 
-| Reality | Watchdog |
-|---------|----------|
-| daemon alive, heartbeat fresh | silent (OK) |
-| daemon alive, heartbeat **stale** | **report** — daemon may be wedged |
-| daemon alive, no heartbeat file | silent (liveness-only; heartbeat disabled or not yet written) |
-| daemon **not loaded/alive** | **report** — the #4011 outage |
-| marker **absent** | silent — deliberate stop, no false page |
+| Marker | Reality | Watchdog |
+|--------|---------|----------|
+| present | daemon alive, heartbeat fresh | silent (OK) |
+| present | daemon alive, heartbeat **stale** | **report** — daemon may be wedged |
+| present | daemon alive, no heartbeat file | silent (liveness-only; heartbeat disabled or not yet written) |
+| present | daemon **not loaded/alive** | **report** — the #4011 outage |
+| **absent** | **nothing running** | silent — deliberate stop, no false page |
+| **absent** | **daemon IS running** | **report (WARN)** — state mismatch, crash protection disarmed (#4331) |
+
+The last row is the #4331 fix. Before it, a missing marker short-circuited to a
+bare `[OK] … nothing to check` **without probing reality at all** — so a
+supervised daemon running with its marker gone (see "Marker ownership" below) was
+reported healthy while the watchdog would in fact never revive it. The no-marker
+branch now runs the *same* liveness probe as the marker-present path (env-derived
+defaults: `LOOM_LAUNCHD_LABEL` or the default label; `<loom_dir>/.daemon.pid` on
+the non-launchd path) and, only when a daemon **is** demonstrably alive, WARNs +
+exits `1`. The load-bearing quiet case — marker absent *and* nothing alive, i.e. a
+deliberate `loom-daemon-stop.sh` (which also boots the daemon job out, so nothing
+is found) — stays exactly as silent as before.
 
 **Marker lifetime across a self-update.** `loom-daemon-update.sh` performs an
 internal stop→start, which is a **restart**, not operator intent to stop — so it
@@ -2490,6 +2502,41 @@ is load-bearing: inferring restart-vs-stop would mean every self-update silently
 disarms the detector — the exact bug class #4011 fixes — so it is an explicit
 signal, never an inference. The subsequent start re-writes the marker and
 re-provisions the watchdog.
+
+**Marker ownership (create / preserve / remove per surface).** The marker's
+lifetime is operator intent, spread across several surfaces — this table is the
+contract the healing + detection below implement:
+
+| Surface | Marker behavior | Reference |
+|---------|-----------------|-----------|
+| `loom-daemon-start.sh` | **Creates** it (`write_intent_marker`) on every successful start (launchd, systemd, nohup) | `loom-daemon-start.sh` (`write_intent_marker`) |
+| `loom-daemon-stop.sh` | **Removes** it + tears down the watchdog — unless `--restarting` / `LOOM_DAEMON_STOP_KEEP_INTENT=1`, which **preserves** both | `loom-daemon-stop.sh` |
+| `loom-daemon-update.sh` (full roll) | **Preserves + re-creates**: `stop --restarting` (preserve) then `start.sh` (re-write) | `loom-daemon-update.sh` |
+| `loom-daemon restart` (#4054 primitive) | **Preserved if present** (the daemon exits `EXIT_RESTART`; the supervisor relaunches, marker untouched). An **absent** marker is **healed at startup** — see below | `ipc.rs`, `autonomy_marker.rs` |
+| in-daemon self-update loop | Uses `update.sh --no-restart` + the restart primitive — bypasses the stop/start rewrite; relies on **startup healing** | `main.rs`, `autonomy_marker.rs` |
+| bare launchd `KeepAlive` / systemd `Restart=on-success` relaunch | Never runs the start script — relies on **startup healing** | `autonomy_marker.rs` |
+
+**Startup marker healing (#4331).** The restart primitive, the self-update loop,
+and a bare supervisor relaunch all bring up a fresh daemon **without** re-running
+`write_intent_marker`, so before #4331 an *absent* marker was never re-created
+while a supervised daemon kept running — the daemon ran with crash protection
+silently disarmed, forever. Rather than patch each restart path, the daemon heals
+the marker at **one startup choke point** (`autonomy_marker::heal_on_startup`,
+wired in `main.rs` right after the heartbeat loop): if it detects it is supervised
+([`ipc::detect_supervisor`] ⇒ `Some`, from the `LOOM_DAEMON_SUPERVISOR` env the
+plist/unit bake in) **and** the marker is absent, it re-writes it. That single
+point covers the primitive, the self-update loop, and a bare relaunch. Deliberate
+constraints:
+
+- **Never for an unsupervised run.** A `--foreground` / nohup / debug start
+  (`detect_supervisor` ⇒ `None`) writes **no** marker — otherwise every dev run
+  would arm the host-side pager after the dev session exits.
+- **`LOOM_AUTONOMY_MARKER` respected.** The path is resolved with the same env
+  override the plist/unit export, so healing and the watchdog agree.
+- **Never overwrites a present marker** (it already encodes start-time intent);
+  and a failed write is logged, never fatal. The healed marker mirrors
+  `write_intent_marker`'s fields byte-for-byte (with a `# HEALED …` provenance
+  comment) so the watchdog and `daemon_install_state` parse it identically.
 
 **Platform + isolation.** Darwin and systemd Linux hosts both get a provisioned,
 scheduled watchdog (see the two bullets above). Only the **nohup fallback tier**

--- a/defaults/scripts/cli/loom-daemon-watchdog.sh
+++ b/defaults/scripts/cli/loom-daemon-watchdog.sh
@@ -60,13 +60,14 @@
 #
 # EXIT CODES (a StartInterval job's exit code does not affect relaunch — these
 # exist for testability and for a human running it by hand):
-#   0  no divergence — daemon healthy, no daemon expected (marker absent), OR
-#      the #4232 bounded auto-remediation (see above) successfully relaunched
-#      it via 'launchctl kickstart'
-#   1  DIVERGENCE reported — a daemon is expected but is not running (and
-#      either the #4232 remediation gate did not apply, or it fired but the
-#      daemon is still not confirmed running), or is running but its
-#      heartbeat is stale (possibly wedged)
+#   0  no divergence — daemon healthy, OR no daemon expected AND none running
+#      (marker absent + nothing alive), OR the #4232 bounded auto-remediation
+#      (see above) successfully relaunched it via 'launchctl kickstart'
+#   1  DIVERGENCE / state mismatch reported — a daemon is expected but is not
+#      running (and either the #4232 remediation gate did not apply, or it fired
+#      but the daemon is still not confirmed running), or is running but its
+#      heartbeat is stale (possibly wedged), OR (#4331) a daemon IS running while
+#      the marker is ABSENT (crash protection disarmed — a WARN state mismatch)
 #   2  usage error
 #
 # Usage:
@@ -144,11 +145,80 @@ report() {
     esac
 }
 
+# ---------- reality probe (shared) ----------
+# Determine whether the expected daemon is actually alive. Reads the resolved
+# USE_LAUNCHD / LABEL / PID_FILE and sets four globals the callers branch on:
+#   daemon_alive     true|false
+#   liveness_detail  human-readable string (mirrored into status/log messages)
+#   job_loaded       true|false — launchd job in the table but with no live pid
+#                    (feeds the #4232 bounded auto-remediation gate)
+#   launchd_service  <domain>/<label> for the launchd path (else empty)
+# Factored out (#4331) so the no-marker state-mismatch check below and the
+# marker-present path below run the IDENTICAL liveness logic — they can never
+# diverge on what "alive" means.
+detect_daemon_liveness() {
+    daemon_alive=false
+    liveness_detail=""
+    job_loaded=false
+    launchd_service=""
+    if [[ "$USE_LAUNCHD" == "true" ]] && command -v launchctl >/dev/null 2>&1; then
+        # Resolve the domain (gui/<uid> ↦ user/<uid>, #4130) the same way the
+        # start did, so a headless daemon in user/<uid> is probed correctly.
+        launchd_service="$(resolve_launchd_domain)/${LABEL}"
+        launchd_print_output="$(launchctl print "$launchd_service" 2>/dev/null)"
+        launchd_print_rc=$?
+        launchd_pid="$(printf '%s\n' "$launchd_print_output" | awk -F'= ' '/^[[:space:]]*pid = /{gsub(/[^0-9]/, "", $2); print $2; exit}')"
+        if [[ -n "$launchd_pid" ]] && kill -0 "$launchd_pid" 2>/dev/null; then
+            daemon_alive=true
+            liveness_detail="launchd job $launchd_service alive (pid $launchd_pid)"
+        elif [[ "$launchd_print_rc" -eq 0 ]]; then
+            job_loaded=true
+            liveness_detail="launchd job $launchd_service is LOADED but NOT running (no live pid)"
+        else
+            liveness_detail="launchd job $launchd_service is not loaded/alive"
+        fi
+    else
+        # Non-launchd (nohup / Linux) path: the pid file is the only signal.
+        if [[ -n "$PID_FILE" && -f "$PID_FILE" ]]; then
+            pid="$(cat "$PID_FILE" 2>/dev/null || true)"
+            if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+                daemon_alive=true
+                liveness_detail="pid $pid (from $PID_FILE) alive"
+            else
+                liveness_detail="pid file $PID_FILE present but pid not alive"
+            fi
+        else
+            liveness_detail="no live pid file at ${PID_FILE:-<none>}"
+        fi
+    fi
+}
+
 # ---------- 1. intent: is a daemon expected at all? ----------
 if [[ ! -f "$MARKER" ]]; then
-    # No marker ⇒ the daemon was deliberately stopped (or never started). This
-    # is the load-bearing quiet case: a detector that pages on an intentional
-    # stop gets muted by the operator and is worthless.
+    # A missing marker is SUPPOSED to mean "deliberately stopped (or never
+    # started) — nothing to check". But the marker can go absent while a
+    # supervised daemon is very much alive: an out-of-band delete, a failed
+    # marker write, or a daemon rolled ONLY via `loom-daemon restart` / the
+    # self-update loop (neither re-writes the marker — #4331). In that state the
+    # daemon runs with crash protection DISARMED, and a bare `[OK] nothing to
+    # check` hides exactly the gap the watchdog exists to surface. So before
+    # staying quiet, cheaply probe reality with env-derived defaults.
+    USE_LAUNCHD=true
+    if [[ "${LOOM_DAEMON_LAUNCHD:-}" =~ ^(0|false|no)$ ]]; then
+        USE_LAUNCHD=false
+    fi
+    [[ "$(uname -s)" == "Darwin" ]] || USE_LAUNCHD=false
+    LABEL="${LOOM_LAUNCHD_LABEL:-com.rjwalters.loom-daemon}"
+    PID_FILE="$LOOM_DIR/.daemon.pid"
+    detect_daemon_liveness
+    if [[ "$daemon_alive" == "true" ]]; then
+        report WARN \
+            "STATE MISMATCH: no autonomy-desired marker at $MARKER, but a daemon IS running (${liveness_detail}). Crash protection is DISARMED — if this daemon dies the watchdog will NOT revive it. Heal it by restarting the daemon (it self-heals the marker at startup, #4331) or re-running ./.loom/scripts/cli/loom-daemon-start.sh; if the daemon should NOT be running, stop it with ./.loom/scripts/cli/loom-daemon-stop.sh."
+        exit 1
+    fi
+    # Nothing alive ⇒ the load-bearing quiet case: a deliberate stop (which also
+    # boots out the daemon job, so nothing is found here) must never page.
+    # Preserve the silent OK exactly as before.
     report OK "no autonomy-desired marker at $MARKER — no daemon expected; nothing to check."
     exit 0
 fi
@@ -181,46 +251,14 @@ fi
 LABEL="${LOOM_LAUNCHD_LABEL:-${MARKER_LABEL:-com.rjwalters.loom-daemon}}"
 
 # ---------- 2. reality: is the expected daemon actually alive? ----------
-daemon_alive=false
-liveness_detail=""
-# job_loaded / launchd_service feed the #4232 bounded auto-remediation gate
-# below: job_loaded=true means `launchctl print` succeeded (the job IS in
-# launchd's table) even though no live pid was found — distinct from "not
-# loaded at all" (a booted-out job, or a non-launchd host), which stays
-# report-only no matter what.
-job_loaded=false
-launchd_service=""
-if [[ "$USE_LAUNCHD" == "true" ]] && command -v launchctl >/dev/null 2>&1; then
-    # Resolve the domain (gui/<uid> ↦ user/<uid>, #4130) the same way the start
-    # did, so a headless daemon in user/<uid> is probed correctly rather than
-    # always looked up under gui/<uid> (which would false-report divergence).
-    launchd_service="$(resolve_launchd_domain)/${LABEL}"
-    launchd_print_output="$(launchctl print "$launchd_service" 2>/dev/null)"
-    launchd_print_rc=$?
-    launchd_pid="$(printf '%s\n' "$launchd_print_output" | awk -F'= ' '/^[[:space:]]*pid = /{gsub(/[^0-9]/, "", $2); print $2; exit}')"
-    if [[ -n "$launchd_pid" ]] && kill -0 "$launchd_pid" 2>/dev/null; then
-        daemon_alive=true
-        liveness_detail="launchd job $launchd_service alive (pid $launchd_pid)"
-    elif [[ "$launchd_print_rc" -eq 0 ]]; then
-        job_loaded=true
-        liveness_detail="launchd job $launchd_service is LOADED but NOT running (no live pid)"
-    else
-        liveness_detail="launchd job $launchd_service is not loaded/alive"
-    fi
-else
-    # Non-launchd (nohup / Linux) path: the pid file is the only liveness signal.
-    if [[ -n "$PID_FILE" && -f "$PID_FILE" ]]; then
-        pid="$(cat "$PID_FILE" 2>/dev/null || true)"
-        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
-            daemon_alive=true
-            liveness_detail="pid $pid (from $PID_FILE) alive"
-        else
-            liveness_detail="pid file $PID_FILE present but pid not alive"
-        fi
-    else
-        liveness_detail="no live pid file at ${PID_FILE:-<none>}"
-    fi
-fi
+# Shared probe (#4331): sets daemon_alive / liveness_detail / job_loaded /
+# launchd_service from the resolved USE_LAUNCHD / LABEL / PID_FILE. job_loaded /
+# launchd_service feed the #4232 bounded auto-remediation gate below:
+# job_loaded=true means `launchctl print` succeeded (the job IS in launchd's
+# table) even though no live pid was found — distinct from "not loaded at all"
+# (a booted-out job, or a non-launchd host), which stays report-only no matter
+# what.
+detect_daemon_liveness
 
 if [[ "$daemon_alive" != "true" ]]; then
     # ---------- bounded auto-remediation (#4232) ----------

--- a/defaults/scripts/tests/test-loom-daemon-watchdog.sh
+++ b/defaults/scripts/tests/test-loom-daemon-watchdog.sh
@@ -69,9 +69,16 @@ back_date_file() { # <file> <seconds_ago>
 
 # Run the watchdog on the pid-file path (LOOM_DAEMON_LAUNCHD=0). Extra env
 # assignments may be passed as KEY=VAL positional args. Sets global RC.
+#
+# LOOM_SOCKET_PATH is pinned into the tempdir so the resolved <loom_dir> is
+# $WORKDIR — this matters for the marker-ABSENT reality probe (#4331), whose
+# default pid file is `<loom_dir>/.daemon.pid`: without this the probe would look
+# at the operator's real ~/.loom/.daemon.pid and a live host daemon could break
+# the "nothing alive" cases.
 run_watchdog() {
     : > "$OUT"
     env "$@" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
+        LOOM_SOCKET_PATH="$WORKDIR/loom-daemon.sock" \
         LOOM_DAEMON_LAUNCHD=0 bash "$WATCHDOG" > "$OUT" 2>&1
     RC=$?
 }
@@ -87,10 +94,36 @@ sleeper() { sleep 60 >/dev/null 2>&1 & echo $!; }
 # ===================================================================
 # 1. Marker ABSENT ⇒ no daemon expected ⇒ silent OK (exit 0).
 # ===================================================================
-rm -f "$MARKER" "$HEARTBEAT" "$WDLOG"
+rm -f "$MARKER" "$HEARTBEAT" "$WDLOG" "$WORKDIR/.daemon.pid"
 run_watchdog
-assert_rc 0 "$RC" "marker absent: exits 0 (no daemon expected)"
-if log_has DIVERGENCE; then fail "marker absent: unexpected DIVERGENCE"; else pass "marker absent: no DIVERGENCE reported"; fi
+assert_rc 0 "$RC" "marker absent + nothing alive: exits 0 (no daemon expected)"
+if log_has DIVERGENCE || log_hasi "mismatch"; then fail "marker absent + nothing alive: unexpected report"; else pass "marker absent + nothing alive: no DIVERGENCE/MISMATCH reported"; fi
+
+# ===================================================================
+# 1b. Marker ABSENT but a daemon IS running ⇒ STATE MISMATCH (#4331): crash
+#     protection is disarmed, so the watchdog WARNs loudly + exits 1 instead of
+#     the old silent `[OK] nothing to check`. Reproduces the observed bug — a
+#     daemon rolled via the restart primitive / self-update, neither of which
+#     re-writes the marker. Liveness is probed via the default pid file
+#     (<loom_dir>/.daemon.pid) on the LOOM_DAEMON_LAUNCHD=0 path.
+# ===================================================================
+rm -f "$MARKER" "$HEARTBEAT" "$WDLOG"
+live_pid=$(sleeper)
+echo "$live_pid" > "$WORKDIR/.daemon.pid"
+run_watchdog
+kill "$live_pid" 2>/dev/null || true
+assert_rc 1 "$RC" "marker absent + daemon alive: exits 1 (state mismatch, crash protection disarmed)"
+if log_hasi "mismatch"; then
+    pass "marker absent + daemon alive: WARN reports the state mismatch"
+else
+    fail "marker absent + daemon alive: missing the state-mismatch WARN"
+fi
+if log_has DIVERGENCE; then
+    fail "marker absent + daemon alive: should be a WARN, not a DIVERGENCE"
+else
+    pass "marker absent + daemon alive: reported as WARN, not DIVERGENCE"
+fi
+rm -f "$WORKDIR/.daemon.pid"
 
 # ===================================================================
 # 2. Intent present, daemon ALIVE, heartbeat FRESH ⇒ silent OK.

--- a/loom-daemon/src/autonomy_marker.rs
+++ b/loom-daemon/src/autonomy_marker.rs
@@ -1,0 +1,420 @@
+//! Startup autonomy-desired marker **healing** (issue #4331).
+//!
+//! # Why
+//!
+//! The autonomy-desired marker (`<loom_dir>/autonomy-desired`, issue #4011) is
+//! the durable "a daemon is EXPECTED to be running on this host" signal that the
+//! host-side watchdog (`loom-daemon-watchdog.sh`) and `loom-daemon status`
+//! (`daemon_install_state.rs`) both key off. `loom-daemon-start.sh` writes it on
+//! a successful start and `loom-daemon-stop.sh` removes it on a deliberate stop —
+//! so far so good. The gap #4331 closes is that **no code path re-creates an
+//! ABSENT marker while a supervised daemon keeps running**:
+//!
+//! - `loom-daemon restart` (the #4054 supervised-restart primitive) exits
+//!   `EXIT_RESTART`; launchd/systemd relaunch the daemon but nothing touches the
+//!   marker — a present marker survives, an **absent** one is never healed.
+//! - The in-daemon self-update loop uses `loom-daemon-update.sh --no-restart` +
+//!   the restart primitive, bypassing the stop/start marker rewrite entirely.
+//! - A bare launchd `KeepAlive:SuccessfulExit` / systemd `Restart=on-success`
+//!   relaunch likewise never runs the start script.
+//!
+//! Once the marker is absent while a launchd/systemd-supervised daemon runs
+//! (however that state arose — an out-of-band delete, a failed write, or a daemon
+//! that predates a marker-writing start and has only rolled via the primitive
+//! since), the watchdog logs a misleading `[OK] … nothing to check` and provides
+//! **no crash protection** during exactly the unattended windows it exists for.
+//!
+//! # The fix: heal at ONE startup choke point
+//!
+//! Rather than patch each restart path, the daemon heals the marker **at
+//! startup**: if it detects it is supervised ([`crate::ipc::detect_supervisor`]
+//! returns `Some`) and the marker is absent, it re-writes it. That single choke
+//! point covers the restart primitive, the self-update loop, AND a bare
+//! supervisor relaunch, because all of them end in a fresh daemon process
+//! starting up.
+//!
+//! # Constraints (deliberate)
+//!
+//! - **Never create a marker for an unsupervised run.** A `--foreground` / debug
+//!   / nohup start ([`crate::ipc::detect_supervisor`] ⇒ `None`) must NOT arm the
+//!   host-side detector — otherwise every dev run would leave a marker that pages
+//!   the operator after the dev exits. Unsupervised ⇒ [`HealOutcome::UnsupervisedSkip`].
+//! - **Respect `LOOM_AUTONOMY_MARKER`.** The marker path is resolved with the same
+//!   env override the launchd plist / systemd unit export
+//!   (`loom-daemon-start.sh`), so healing and the watchdog agree on the path.
+//! - **Never overwrite an existing marker.** A present marker already encodes the
+//!   operator's start-time intent (its `started_at`, recorded paths); healing
+//!   only fills the *absent* case ⇒ [`HealOutcome::AlreadyPresent`] is a no-op.
+//! - **Never fatal.** A failed write is logged and the daemon keeps running
+//!   ([`HealOutcome::WriteFailed`]) — a daemon without a marker is strictly better
+//!   than no daemon.
+//!
+//! The written marker mirrors `loom-daemon-start.sh`'s `write_intent_marker`
+//! field-for-field (`started_at`, `repo_root`, `pid_file`, `heartbeat_file`,
+//! `heartbeat_interval_secs`, `use_launchd`, `launchd_label`, `socket_path`) so a
+//! healed marker is byte-compatible with a start-script-written one for both the
+//! watchdog and `daemon_install_state`'s parsers.
+
+use std::path::{Path, PathBuf};
+
+use crate::daemon_heartbeat::HEARTBEAT_FILENAME;
+use crate::daemon_install_state::{DEFAULT_LAUNCHD_LABEL, MARKER_FILENAME};
+
+/// Basename of the daemon pid file under `<loom_dir>`, matching
+/// `loom-daemon-start.sh`'s `PID_FILE="$DAEMON_STATE_HOME/.daemon.pid"`.
+pub const PID_FILENAME: &str = ".daemon.pid";
+
+/// The outcome of a startup healing attempt — one variant per branch of the
+/// "supervised? marker present?" decision, so `main.rs` can log precisely and
+/// tests can assert on the decision without inspecting the filesystem twice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HealOutcome {
+    /// Not supervised ([`crate::ipc::detect_supervisor`] ⇒ `None`): a
+    /// `--foreground` / nohup / debug run. NO marker written — arming the
+    /// host-side detector for a run nothing will relaunch would page the
+    /// operator after a dev session exits.
+    UnsupervisedSkip,
+    /// Supervised, but the marker already exists: left untouched (it already
+    /// encodes the operator's start-time intent).
+    AlreadyPresent,
+    /// Supervised and the marker was absent: wrote a fresh healing marker at the
+    /// contained path.
+    Healed(PathBuf),
+    /// Supervised, marker absent, but the write failed. Non-fatal — logged and
+    /// the daemon keeps running.
+    WriteFailed { path: PathBuf, error: String },
+}
+
+/// The fields a healing marker records — the exact set
+/// `loom-daemon-start.sh`'s `write_intent_marker` emits, so the watchdog and
+/// `daemon_install_state` parsers read a healed marker identically to a
+/// start-script-written one.
+#[derive(Debug, Clone)]
+pub struct MarkerFields {
+    /// ISO-8601 UTC start timestamp (`%Y-%m-%dT%H:%M:%SZ`, matching the shell's
+    /// `date -u`). For a healed marker this is the *heal* time — the best
+    /// approximation the daemon has of "expected since" when the original
+    /// start-time value was lost.
+    pub started_at: String,
+    /// The managed repo root, when resolvable (advisory only — not consumed by
+    /// the watchdog or `daemon_install_state`, but present in the start marker).
+    pub repo_root: Option<PathBuf>,
+    /// Pid file path (`<loom_dir>/.daemon.pid`) — the non-launchd liveness signal.
+    pub pid_file: PathBuf,
+    /// Heartbeat file path (`<loom_dir>/daemon.heartbeat`).
+    pub heartbeat_file: PathBuf,
+    /// Heartbeat cadence in seconds — the watchdog derives its staleness
+    /// threshold from this.
+    pub heartbeat_interval_secs: u64,
+    /// Whether liveness is probed via launchd (`true`) or the pid file (`false`).
+    pub use_launchd: bool,
+    /// The launchd label to probe when `use_launchd` (ignored otherwise).
+    pub launchd_label: String,
+    /// The daemon socket path.
+    pub socket_path: PathBuf,
+}
+
+/// Resolve `<loom_dir>` the same way `main.rs::resolve_loom_dir` /
+/// `daemon_heartbeat` / `daemon_install_state` do: the parent of
+/// `LOOM_SOCKET_PATH` when set (so a test daemon pointed at a tempdir socket
+/// heals into that tempdir, never the operator's real `~/.loom`), else `~/.loom`.
+fn resolve_loom_dir() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("LOOM_SOCKET_PATH") {
+        return PathBuf::from(path).parent().map(Path::to_path_buf);
+    }
+    dirs::home_dir().map(|h| h.join(".loom"))
+}
+
+/// Resolve the marker path: `LOOM_AUTONOMY_MARKER` env override first (matching
+/// `loom-daemon-start.sh`'s `INTENT_MARKER` and `daemon_install_state`), else
+/// `<loom_dir>/autonomy-desired`.
+#[must_use]
+pub fn resolve_marker_path(loom_dir: &Path) -> PathBuf {
+    std::env::var("LOOM_AUTONOMY_MARKER")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| loom_dir.join(MARKER_FILENAME))
+}
+
+/// Render the marker file contents — mirrors `loom-daemon-start.sh`'s
+/// `write_intent_marker` heredoc so a healed marker parses identically.
+#[must_use]
+pub fn render_marker(fields: &MarkerFields) -> String {
+    let repo_root = fields
+        .repo_root
+        .as_ref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+    format!(
+        "# loom autonomy-desired marker (issue #4011)\n\
+         # HEALED at daemon startup by loom-daemon (issue #4331): a supervised\n\
+         # daemon started while this marker was absent, so crash protection was\n\
+         # disarmed. Re-written here so the watchdog / `loom-daemon status` see\n\
+         # the running daemon as EXPECTED again. Removed ONLY by an operator-\n\
+         # initiated loom-daemon-stop.sh. Do not hand-edit.\n\
+         started_at={started_at}\n\
+         repo_root={repo_root}\n\
+         pid_file={pid_file}\n\
+         heartbeat_file={heartbeat_file}\n\
+         heartbeat_interval_secs={heartbeat_interval_secs}\n\
+         use_launchd={use_launchd}\n\
+         launchd_label={launchd_label}\n\
+         socket_path={socket_path}\n",
+        started_at = fields.started_at,
+        repo_root = repo_root,
+        pid_file = fields.pid_file.display(),
+        heartbeat_file = fields.heartbeat_file.display(),
+        heartbeat_interval_secs = fields.heartbeat_interval_secs,
+        use_launchd = fields.use_launchd,
+        launchd_label = fields.launchd_label,
+        socket_path = fields.socket_path.display(),
+    )
+}
+
+/// Write the marker owner-only (`0o600`, matching the shell's `umask 077`) via a
+/// temp file + atomic rename, so a concurrent watchdog read never sees a torn
+/// file. Returns a human-readable reason on any I/O failure (never fatal).
+fn write_marker_atomic(path: &Path, contents: &str) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            return Err(format!("could not create {}: {e}", parent.display()));
+        }
+    }
+    let tmp = path.with_extension(format!("autonomy.tmp.{}", uuid::Uuid::new_v4()));
+
+    let write_result = {
+        #[cfg(unix)]
+        {
+            use std::io::Write as _;
+            use std::os::unix::fs::OpenOptionsExt as _;
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(&tmp)
+                .and_then(|mut f| f.write_all(contents.as_bytes()))
+        }
+        #[cfg(not(unix))]
+        {
+            std::fs::write(&tmp, contents.as_bytes())
+        }
+    };
+    if let Err(e) = write_result {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!("could not write temp marker {}: {e}", tmp.display()));
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!("could not rename marker into place {}: {e}", path.display()));
+    }
+    Ok(())
+}
+
+/// Core, side-effect-scoped healing decision: given the resolved supervisor, the
+/// marker path, and the fields to write, decide-and-do. Split from [`heal_on_startup`]
+/// so tests drive every branch against tempdir fixtures without touching real env
+/// vars or `~/.loom`.
+///
+/// - `supervisor == None` ⇒ [`HealOutcome::UnsupervisedSkip`] (no write).
+/// - marker already exists ⇒ [`HealOutcome::AlreadyPresent`] (no write).
+/// - marker absent ⇒ write it: [`HealOutcome::Healed`] on success, else
+///   [`HealOutcome::WriteFailed`].
+#[must_use]
+pub fn heal_marker(
+    supervisor: Option<&str>,
+    marker_path: &Path,
+    fields: &MarkerFields,
+) -> HealOutcome {
+    if supervisor.is_none() {
+        return HealOutcome::UnsupervisedSkip;
+    }
+    if marker_path.exists() {
+        return HealOutcome::AlreadyPresent;
+    }
+    match write_marker_atomic(marker_path, &render_marker(fields)) {
+        Ok(()) => HealOutcome::Healed(marker_path.to_path_buf()),
+        Err(error) => HealOutcome::WriteFailed {
+            path: marker_path.to_path_buf(),
+            error,
+        },
+    }
+}
+
+/// Production entry point: resolve the marker path + fields from the process
+/// environment (mirroring `loom-daemon-start.sh` / `daemon_install_state`) and
+/// heal if supervised. `heartbeat_interval_secs` is the already-resolved cadence
+/// (main hoists it so the marker and the running heartbeat loop agree).
+///
+/// Returns `None` only when no loom dir can be resolved at all (no
+/// `LOOM_SOCKET_PATH` and no home directory); otherwise the [`HealOutcome`].
+#[must_use]
+pub fn heal_on_startup(heartbeat_interval_secs: u64) -> Option<HealOutcome> {
+    let supervisor = crate::ipc::detect_supervisor();
+    // Short-circuit before touching the filesystem: an unsupervised run must not
+    // even resolve/create the loom dir for the sake of a marker it won't write.
+    if supervisor.is_none() {
+        return Some(HealOutcome::UnsupervisedSkip);
+    }
+
+    let loom_dir = resolve_loom_dir()?;
+    let marker_path = resolve_marker_path(&loom_dir);
+
+    let use_launchd = supervisor.as_deref() == Some("launchd");
+    let launchd_label = std::env::var("LOOM_LAUNCHD_LABEL")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_LAUNCHD_LABEL.to_string());
+    let repo_root = std::env::var("LOOM_WORKSPACE")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from);
+    let socket_path = std::env::var("LOOM_SOCKET_PATH")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| loom_dir.join("loom-daemon.sock"));
+
+    let fields = MarkerFields {
+        started_at: chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+        repo_root,
+        pid_file: loom_dir.join(PID_FILENAME),
+        heartbeat_file: loom_dir.join(HEARTBEAT_FILENAME),
+        heartbeat_interval_secs,
+        use_launchd,
+        launchd_label,
+        socket_path,
+    };
+
+    Some(heal_marker(supervisor.as_deref(), &marker_path, &fields))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn sample_fields(dir: &Path) -> MarkerFields {
+        MarkerFields {
+            started_at: "2026-07-28T00:00:00Z".to_string(),
+            repo_root: Some(dir.to_path_buf()),
+            pid_file: dir.join(PID_FILENAME),
+            heartbeat_file: dir.join(HEARTBEAT_FILENAME),
+            heartbeat_interval_secs: 60,
+            use_launchd: true,
+            launchd_label: "com.example.loom-test".to_string(),
+            socket_path: dir.join("loom-daemon.sock"),
+        }
+    }
+
+    #[test]
+    fn unsupervised_never_writes_a_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join(MARKER_FILENAME);
+        let outcome = heal_marker(None, &marker, &sample_fields(dir.path()));
+        assert_eq!(outcome, HealOutcome::UnsupervisedSkip);
+        assert!(!marker.exists(), "unsupervised run must NOT arm the detector");
+    }
+
+    #[test]
+    fn supervised_absent_marker_is_healed() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join(MARKER_FILENAME);
+        assert!(!marker.exists());
+        let outcome = heal_marker(Some("launchd"), &marker, &sample_fields(dir.path()));
+        assert_eq!(outcome, HealOutcome::Healed(marker.clone()));
+        assert!(marker.exists(), "supervised + absent marker ⇒ healed");
+    }
+
+    #[test]
+    fn supervised_present_marker_is_left_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join(MARKER_FILENAME);
+        fs::write(&marker, "started_at=ORIGINAL\n").unwrap();
+        let outcome = heal_marker(Some("systemd"), &marker, &sample_fields(dir.path()));
+        assert_eq!(outcome, HealOutcome::AlreadyPresent);
+        // The original content — including its start-time intent — survives.
+        assert_eq!(fs::read_to_string(&marker).unwrap(), "started_at=ORIGINAL\n");
+    }
+
+    #[test]
+    fn healed_marker_is_parseable_by_the_install_state_probe() {
+        // The healed marker must be byte-compatible with what
+        // `daemon_install_state` parses — classify it and confirm the fields the
+        // watchdog/status care about round-trip.
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join(MARKER_FILENAME);
+        // Point at a pid we own so the probe resolves a live process, and force
+        // the pid-file path (use_launchd=false) so the test is host-independent.
+        let pid = std::process::id();
+        let pid_file = dir.path().join(PID_FILENAME);
+        fs::write(&pid_file, pid.to_string()).unwrap();
+        let mut fields = sample_fields(dir.path());
+        fields.use_launchd = false;
+        assert_eq!(
+            heal_marker(Some("systemd"), &marker, &fields),
+            HealOutcome::Healed(marker.clone())
+        );
+
+        let env = crate::daemon_install_state::EnvOverrides {
+            launchd_override: Some(false),
+            launchd_label_override: None,
+            heartbeat_stale_secs_override: None,
+            startup_grace_secs_override: Some(0),
+            is_darwin: false,
+        };
+        let report = crate::daemon_install_state::classify(dir.path(), &marker, &env);
+        // Marker present + our own live pid ⇒ NOT the not-expected/dead states.
+        assert_eq!(report.state, crate::daemon_install_state::InstallState::AliveButUnresponsive,);
+        assert_eq!(report.started_at.as_deref(), Some("2026-07-28T00:00:00Z"));
+        assert_eq!(report.pid, Some(pid));
+    }
+
+    #[test]
+    fn healed_marker_has_owner_only_permissions() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let dir = tempfile::tempdir().unwrap();
+            let marker = dir.path().join(MARKER_FILENAME);
+            let _ = heal_marker(Some("launchd"), &marker, &sample_fields(dir.path()));
+            let mode = fs::metadata(&marker).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "marker must be owner-only (umask 077 parity)");
+        }
+    }
+
+    #[test]
+    fn render_marker_emits_all_watchdog_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let rendered = render_marker(&sample_fields(dir.path()));
+        for key in [
+            "started_at=",
+            "pid_file=",
+            "heartbeat_file=",
+            "heartbeat_interval_secs=60",
+            "use_launchd=true",
+            "launchd_label=com.example.loom-test",
+            "socket_path=",
+        ] {
+            assert!(rendered.contains(key), "rendered marker missing {key:?}:\n{rendered}");
+        }
+        // The heal provenance comment is present so an operator can tell a healed
+        // marker from a start-script-written one.
+        assert!(rendered.contains("HEALED at daemon startup"));
+    }
+
+    #[test]
+    fn no_stray_temp_files_after_a_heal() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join(MARKER_FILENAME);
+        let _ = heal_marker(Some("launchd"), &marker, &sample_fields(dir.path()));
+        let leftovers: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files should be renamed away: {leftovers:?}");
+    }
+}

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod activity;
 pub mod auto_update;
+pub mod autonomy_marker;
 pub mod capacity;
 pub mod claim_reconciliation;
 pub mod config_resolver;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -1,5 +1,6 @@
 use loom_daemon::activity::{self, ActivityDb, StatsQueries};
 use loom_daemon::auto_update;
+use loom_daemon::autonomy_marker;
 use loom_daemon::claim_reconciliation;
 use loom_daemon::credential_preflight;
 use loom_daemon::daemon_heartbeat;
@@ -1314,10 +1315,13 @@ async fn main() -> Result<()> {
     // config-disableable side effect, so a detector keyed to it would silently
     // stop working when that loop is turned off.
     let heartbeat_config = daemon_heartbeat::read_heartbeat_config(&sweep_workspace);
+    // Resolved once here so the healing marker below (#4331) and the running
+    // heartbeat loop agree on the cadence the watchdog derives its staleness
+    // threshold from — even if the loop itself is disabled.
+    let heartbeat_interval = daemon_heartbeat::resolve_interval(&heartbeat_config);
     let _heartbeat_handle = if daemon_heartbeat::resolve_enabled(&heartbeat_config) {
-        let interval = daemon_heartbeat::resolve_interval(&heartbeat_config);
-        log::info!("daemon_heartbeat: enabled (interval={}s)", interval.as_secs());
-        daemon_heartbeat::spawn_heartbeat_task(interval)
+        log::info!("daemon_heartbeat: enabled (interval={}s)", heartbeat_interval.as_secs());
+        daemon_heartbeat::spawn_heartbeat_task(heartbeat_interval)
     } else {
         log::debug!(
             "daemon_heartbeat: disabled (set LOOM_DAEMON_HEARTBEAT=1 or \
@@ -1325,6 +1329,42 @@ async fn main() -> Result<()> {
         );
         None
     };
+
+    // Startup autonomy-desired marker healing (Issue #4331). The marker is the
+    // durable "a daemon is EXPECTED on this host" signal the watchdog + status
+    // key off (#4011). `loom-daemon restart` (#4054), the in-daemon self-update
+    // loop, and a bare launchd/systemd relaunch all bring up a fresh daemon
+    // WITHOUT re-running the start script's `write_intent_marker` — so an ABSENT
+    // marker was never healed, leaving a supervised daemon running with crash
+    // protection silently disarmed. This single startup choke point covers all
+    // three paths: if the daemon is supervised and the marker is absent, re-write
+    // it. An unsupervised (`--foreground`/nohup/debug) run never writes one — it
+    // must not arm the host-side pager for a process nothing will relaunch.
+    match autonomy_marker::heal_on_startup(heartbeat_interval.as_secs()) {
+        Some(autonomy_marker::HealOutcome::Healed(path)) => log::warn!(
+            "autonomy_marker: HEALED an absent autonomy-desired marker at {} — a supervised \
+             daemon was running with crash protection disarmed (restart-primitive / self-update / \
+             bare relaunch never re-writes it). The watchdog and `loom-daemon status` now see this \
+             daemon as EXPECTED again (#4331).",
+            path.display()
+        ),
+        Some(autonomy_marker::HealOutcome::AlreadyPresent) => {
+            log::debug!("autonomy_marker: marker already present — no healing needed (#4331)")
+        }
+        Some(autonomy_marker::HealOutcome::UnsupervisedSkip) => log::debug!(
+            "autonomy_marker: unsupervised run (no LOOM_DAEMON_SUPERVISOR) — deliberately NOT \
+             writing an autonomy-desired marker (#4331)"
+        ),
+        Some(autonomy_marker::HealOutcome::WriteFailed { path, error }) => log::warn!(
+            "autonomy_marker: failed to heal the autonomy-desired marker at {} (logged, never \
+             fatal; the daemon keeps running): {error} (#4331)",
+            path.display()
+        ),
+        None => log::warn!(
+            "autonomy_marker: could not resolve a loom dir (no LOOM_SOCKET_PATH / home) — \
+             skipping marker healing for this run (#4331)"
+        ),
+    }
 
     // Autonomous periodic support-role runner (Issue #4015): dispatches the
     // standalone support roles (Champion, Curator, Judge, Auditor, Guide)


### PR DESCRIPTION
## Summary

The autonomy-desired marker (#4011) is the durable "a daemon is EXPECTED on this host" signal that both the host-side watchdog (`loom-daemon-watchdog.sh`) and `loom-daemon status` (`daemon_install_state.rs`) key off. The gap #4331 closes: **no code path re-created an ABSENT marker while a supervised daemon kept running**. `loom-daemon restart` (#4054), the in-daemon self-update loop, and a bare launchd/systemd relaunch all bring up a fresh daemon *without* re-running the start script's `write_intent_marker` — so once the marker went absent (out-of-band delete, failed write, or a daemon only ever rolled via the primitive/self-update), it stayed absent forever. The daemon ran with crash protection silently disarmed, and every watchdog tick logged a misleading `[OK] … nothing to check`.

This PR delivers the coherent core (ACs 1–3): **contract + healing + detection**. AC4 (surfacing protection state in `loom-daemon status` on the reachable path) is split to **#4354** per the issue's own Scope note.

## Changes

- **AC2 — startup healing** (`loom-daemon/src/autonomy_marker.rs`, new; wired in `main.rs` right after the heartbeat loop): one startup choke point that covers the restart primitive, the self-update loop, AND a bare supervisor relaunch. If `ipc::detect_supervisor()` is `Some` **and** the marker is absent, re-write it. Deliberately **never** writes for an unsupervised (`--foreground`/nohup/debug) run; respects `LOOM_AUTONOMY_MARKER`; never overwrites a present marker; never fatal (logged on write failure). The healed marker mirrors `write_intent_marker`'s fields byte-for-byte (with a `# HEALED …` provenance comment) so the watchdog and `daemon_install_state` parse it identically.
- **AC3 — watchdog WARN** (`defaults/scripts/cli/loom-daemon-watchdog.sh`): the no-marker branch now runs the *same* liveness probe as the marker-present path (factored into a shared `detect_daemon_liveness` function). A daemon demonstrably alive while the marker is absent is a loud **WARN + exit 1** (state mismatch: crash protection disarmed). The load-bearing quiet case — marker absent **and** nothing alive (a deliberate stop) — stays exactly as silent as before.
- **AC1 — docs** (`defaults/docs/daemon-reference.md`): marker-ownership table (create / preserve / remove per surface), the startup-healing contract, and a new decision-matrix row for the marker-absent-but-alive WARN.

## Acceptance Criteria Verification

| Criterion (from #4331) | Status | Verification |
|---|---|---|
| AC1: document marker ownership (create/preserve/remove) | ✅ | New "Marker ownership" table + "Startup marker healing" subsection in `daemon-reference.md` |
| AC2: heal an absent marker at startup when supervised; respect `LOOM_AUTONOMY_MARKER`; never for an unsupervised run | ✅ | `autonomy_marker::heal_on_startup` wired in `main.rs`; unit tests cover supervised-heals / unsupervised-skip / present-untouched / parseable-by-install-state / owner-only perms |
| AC3: watchdog treats "daemon running but marker absent" as a loud WARN, not `[OK]`; preserve silent-OK when nothing alive | ✅ | `test-loom-daemon-watchdog.sh` cases 1/1b/1c: alive+no-marker ⇒ WARN+exit1; nothing-alive+no-marker ⇒ silent exit0 |
| AC4: `loom-daemon status` surfaces protection state | ⏭️ Deferred | Split to **#4354** per the issue's Scope note (cleanly separable follow-up) |

## Test Plan

- `cargo test --lib autonomy_marker` — 7/7 pass (heals-when-supervised, never-when-unsupervised, present-untouched, healed-marker-is-parseable-by-`daemon_install_state`, owner-only `0o600` perms, renders-all-watchdog-fields, no-stray-temp-files).
- `bash defaults/scripts/tests/test-loom-daemon-watchdog.sh` — 21/21 pass, including the new marker-absent-but-alive WARN case and the regression guard that marker-absent + nothing-alive stays silent. The suite now pins `LOOM_SOCKET_PATH` into its tempdir so the no-marker probe's default pid path (`<loom_dir>/.daemon.pid`) never touches the operator's real `~/.loom`.
- `cargo check` / `cargo clippy --lib` / `cargo fmt --all -- --check` — clean.
- `bash -n` on the watchdog script — clean.

## Notes

- The healing is placed at startup (not in each restart path) so one choke point covers the primitive, self-update, and bare `KeepAlive`/`Restart=on-success` relaunches — as recommended in the curated implementation guidance.
- AC3's WARN branch lives in the shared `loom-daemon-watchdog.sh`, so it applies to both the launchd and systemd (#4321) hosts; the Linux path is exercised through the pid-file probe with `LOOM_DAEMON_LAUNCHD=0`.

Closes #4331