### PR TITLE
feat(scripts): add blame-issue.sh attribution command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,7 +303,8 @@ map, downstream-consumer guidance —
   [build-gate](.loom/docs/build-gate.md) ·
   [forge-auth](.loom/docs/forge-authentication.md) /
   [github-auth](.loom/docs/github-authentication.md) ·
-  [safehouse](.loom/docs/safehouse.md)
+  [safehouse](.loom/docs/safehouse.md) ·
+  [blame-issue](.loom/docs/blame-issue.md)
 
 ---
 

--- a/defaults/docs/blame-issue.md
+++ b/defaults/docs/blame-issue.md
@@ -1,0 +1,69 @@
+# Blame-Issue Attribution
+
+Reference detail for `.loom/scripts/blame-issue.sh` (#4338, codecast evaluation
+borrow item 1 — [`docs/research/codecast-evaluation.md`](../../docs/research/codecast-evaluation.md)).
+
+## Why
+
+codecast's `cast blame` answers "which agent session wrote this line" by joining
+`git blame` against a transcript session database. Loom does not have — or need —
+a transcript database for this: every Builder/Doctor commit is created inside a
+labeled issue's worktree, the PR is squash-merged with a `(#PR)` subject suffix
+(this repo's merge style, see CLAUDE.md "Merging PRs"), and the PR body carries
+`Closes #N`. That is already an in-band, durable join key from a line of code
+back to the issue that produced it — `blame-issue.sh` is a small **read-only**
+reporting wrapper that walks it for a human.
+
+## Usage
+
+```bash
+./.loom/scripts/blame-issue.sh <path>                  # whole-file blame, one row per hunk
+./.loom/scripts/blame-issue.sh <path> -L 10,40          # restrict to a line range (git-blame -L syntax)
+./.loom/scripts/blame-issue.sh --pattern STRING <path>  # `git log --follow -S<pattern>` mode instead of blame
+./.loom/scripts/blame-issue.sh --no-role <path>         # skip the role lookup (fewer gh calls, faster)
+./.loom/scripts/blame-issue.sh --format json <path>     # newline-delimited JSON instead of the table
+./.loom/scripts/blame-issue.sh --help
+```
+
+Output is a tab-separated table, one row per contiguous hunk (or per matching
+commit in `--pattern` mode):
+
+```
+PATH  LINES  COMMIT  PR  ISSUES  ROLE  SUBJECT
+```
+
+## Resolution chain
+
+1. `git blame --porcelain` (or `git log --follow -S<pattern>` in pattern mode)
+   finds the commit that last touched each line/hunk.
+2. The commit resolves to a PR number **offline first**: a squash-merge commit
+   subject's trailing `(#1234)` is a reliable join key with no network call. If a
+   commit has no such suffix (a direct-to-main commit, or a non-squash merge),
+   it falls back to the GitHub REST "commit → associated pulls" endpoint
+   (`gh api repos/{owner}/{repo}/commits/<sha>/pulls`).
+3. The PR resolves to its closing issue number(s) via `closingIssuesReferences`
+   (GitHub's own computed field from `gh pr view --json closingIssuesReferences`),
+   falling back to regexing `Closes/Fixes/Resolves/Part of #N` out of the PR body
+   when that field is empty.
+4. **Role is best-effort.** A squash commit collapses every commit in the PR
+   (Builder's original push, any Doctor fix-up pushes) into one commit on
+   `main`, so per-line Builder-vs-Doctor attribution below the PR level is not
+   recoverable. `blame-issue.sh` instead reports at the PR level: if
+   `loom:changes-requested` was **ever** applied to the PR (per its label
+   timeline, `gh api repos/{owner}/{repo}/issues/<PR>/timeline`), the PR went
+   through at least one Doctor cycle — reported as `builder+doctor` (mixed).
+   Otherwise `builder`. `unknown` when the PR can't be resolved at all, or when
+   `--no-role`/no `gh` auth skips the lookup.
+
+## Guardrails
+
+Read-only: only `git blame`/`git log` (local) and `gh api`/`gh pr view` **GET**
+calls. No forge writes, no daemon involvement, no new state on disk — nothing to
+clean up, nothing to gitignore.
+
+## Tests
+
+`defaults/scripts/tests/test-blame-issue.sh` exercises the resolution chain
+against a throwaway synthetic git fixture with a stubbed `gh` binary on `PATH`
+(no network access needed) — mirrors the `test-check-main-freshness.sh` /
+`test-disk-headroom.sh` fixture-repo pattern.

--- a/defaults/scripts/blame-issue.sh
+++ b/defaults/scripts/blame-issue.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# blame-issue.sh - Which issue/PR produced this line? (#4338, codecast borrow item 1)
+#
+# codecast's `cast blame` answers "which agent session wrote this line" by
+# joining git blame against transcript session records -- a database Loom does
+# not have. Loom does not need one: every Builder/Doctor commit is created in a
+# labeled issue's worktree, its PR is squash-merged with a `(#PR)` subject
+# suffix, and the PR body carries `Closes #N`. That is already an in-band,
+# durable join key from a line of code back to the issue that produced it. This
+# script is a small READ-ONLY reporting wrapper around `git blame` /
+# `git log -S` that walks that chain for a human.
+#
+# What it does, per hunk (a contiguous run of lines attributed to one commit):
+#   1. `git blame --porcelain` to find the commit that last touched each line.
+#   2. Resolve that commit to a PR number -- first offline, by matching the
+#      squash-merge commit subject's trailing `(#1234)` (this repo's merge
+#      style, see CLAUDE.md "Merging PRs"); falls back to the GitHub REST
+#      "commit -> associated pulls" endpoint for any commit that doesn't carry
+#      that suffix (direct-to-main commits, non-squash merges).
+#   3. Resolve the PR to its closing issue number(s) via
+#      `closingIssuesReferences` (GitHub's own computed field), falling back to
+#      regexing `Closes/Fixes/Resolves/Part of #N` out of the PR body.
+#   4. Best-effort role: if `loom:changes-requested` was EVER applied to the PR
+#      (per its label timeline), the PR went through a Doctor cycle at least
+#      once -- reported as `builder+doctor` (mixed; a squash commit collapses
+#      per-commit authorship so no finer attribution is possible). Otherwise
+#      `builder`. `unknown` if the PR can't be resolved.
+#
+# Read-only: only `git blame`/`git log` (local) and `gh api`/`gh pr view` GET
+# calls. No forge writes, no new state on disk, no daemon involvement.
+#
+# Usage:
+#   blame-issue.sh <path>                       # whole-file blame, one row per hunk
+#   blame-issue.sh <path> -L START,END           # restrict to a line range (git-blame -L syntax)
+#   blame-issue.sh --pattern STRING <path>       # `git log --follow -S<pattern>` mode instead of blame
+#   blame-issue.sh --no-role <path>              # skip the role lookup (fewer gh calls, faster)
+#   blame-issue.sh --format json <path>          # newline-delimited JSON instead of the table
+#   blame-issue.sh --help
+#
+# Output (table format, tab-separated, greppable):
+#   PATH  LINES  COMMIT  PR  ISSUES  ROLE  SUBJECT
+#
+# Exit codes:
+#   0 - completed (rows printed; a row with unresolved PR/issue/role is not a
+#       failure -- best-effort fields are marked "-"/"unknown")
+#   2 - usage error (bad args, path not found, not in a git repo)
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+
+usage() {
+    sed -n '2,42p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+# ---- Argument parsing ------------------------------------------------------
+PATTERN=""
+LINE_RANGE=""
+DO_ROLE=1
+FORMAT="table"
+TARGET_PATH=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --pattern)
+            [[ -n "${2:-}" ]] || { echo "$SCRIPT_NAME: --pattern requires an argument" >&2; exit 2; }
+            PATTERN="$2"
+            shift 2
+            ;;
+        -L)
+            [[ -n "${2:-}" ]] || { echo "$SCRIPT_NAME: -L requires an argument (START,END)" >&2; exit 2; }
+            LINE_RANGE="$2"
+            shift 2
+            ;;
+        --no-role)
+            DO_ROLE=0
+            shift
+            ;;
+        --format)
+            [[ -n "${2:-}" ]] || { echo "$SCRIPT_NAME: --format requires an argument (table|json)" >&2; exit 2; }
+            FORMAT="$2"
+            shift 2
+            ;;
+        -*)
+            echo "$SCRIPT_NAME: unknown option: $1" >&2
+            echo "Run with --help for usage." >&2
+            exit 2
+            ;;
+        *)
+            if [[ -n "$TARGET_PATH" ]]; then
+                echo "$SCRIPT_NAME: unexpected extra argument: $1" >&2
+                exit 2
+            fi
+            TARGET_PATH="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$TARGET_PATH" ]]; then
+    echo "$SCRIPT_NAME: missing <path>" >&2
+    echo "Run with --help for usage." >&2
+    exit 2
+fi
+
+if [[ "$FORMAT" != "table" && "$FORMAT" != "json" ]]; then
+    echo "$SCRIPT_NAME: --format must be 'table' or 'json' (got '$FORMAT')" >&2
+    exit 2
+fi
+
+# ---- Resolve repo root + gh availability -----------------------------------
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "$SCRIPT_NAME: not inside a git repository" >&2
+    exit 2
+}
+
+HAVE_GH=0
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    HAVE_GH=1
+else
+    echo "$SCRIPT_NAME: WARNING: gh CLI not available/authenticated -- PR/issue/role columns will be '-'/'unknown'" >&2
+fi
+
+# git blame/log need a path relative to the repo (or CWD); resolve to a path
+# git accepts, working whether invoked from repo root or a subdirectory, and
+# whether the caller passed a path through a per-file symlink (e.g. the
+# installed .loom/scripts/<name>.sh -> defaults/scripts/<name>.sh layout) --
+# git blame refuses a path outside the repo, so resolve through the symlink to
+# the tracked file's real location before handing it to git.
+if [[ ! -e "$TARGET_PATH" ]]; then
+    echo "$SCRIPT_NAME: path not found: $TARGET_PATH" >&2
+    exit 2
+fi
+REAL_PATH="$(cd "$(dirname "$TARGET_PATH")" 2>/dev/null && pwd -P)/$(basename "$TARGET_PATH")"
+GIT_PATH="${REAL_PATH#"$REPO_ROOT"/}"
+if [[ "$GIT_PATH" == "$REAL_PATH" ]]; then
+    echo "$SCRIPT_NAME: path is not inside repo $REPO_ROOT: $TARGET_PATH" >&2
+    exit 2
+fi
+
+# ---- Small caches (plain arrays -- macOS ships bash 3.2, no associative arrays) ---
+CACHE_SHA=()
+CACHE_PR=()
+CACHE_ISSUES=()
+CACHE_ROLE=()
+
+cache_lookup() {
+    # cache_lookup <sha> -> sets CACHED_PR/CACHED_ISSUES/CACHED_ROLE, returns 0 if found
+    local sha="$1" i
+    for i in "${!CACHE_SHA[@]}"; do
+        if [[ "${CACHE_SHA[$i]}" == "$sha" ]]; then
+            CACHED_PR="${CACHE_PR[$i]}"
+            CACHED_ISSUES="${CACHE_ISSUES[$i]}"
+            CACHED_ROLE="${CACHE_ROLE[$i]}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+cache_store() {
+    local sha="$1" pr="$2" issues="$3" role="$4"
+    CACHE_SHA+=("$sha")
+    CACHE_PR+=("$pr")
+    CACHE_ISSUES+=("$issues")
+    CACHE_ROLE+=("$role")
+}
+
+# resolve_pr_from_subject <subject> -> PR number on stdout, or empty
+resolve_pr_from_subject() {
+    local subject="$1"
+    if [[ "$subject" =~ \(#([0-9]+)\)[[:space:]]*$ ]]; then
+        printf '%s' "${BASH_REMATCH[1]}"
+    fi
+}
+
+# resolve_pr_from_gh <sha> -> PR number on stdout, or empty. Fallback for
+# commits whose subject has no trailing "(#N)" (direct-to-main, non-squash).
+resolve_pr_from_gh() {
+    local sha="$1"
+    [[ "$HAVE_GH" == 1 ]] || return 0
+    gh api "repos/{owner}/{repo}/commits/$sha/pulls" --jq '.[0].number // empty' 2>/dev/null || true
+}
+
+# resolve_issues <pr> -> comma-separated issue numbers on stdout (may be empty)
+resolve_issues() {
+    local pr="$1" issues=""
+    [[ "$HAVE_GH" == 1 && -n "$pr" ]] || { printf ''; return; }
+    issues="$(gh pr view "$pr" --json closingIssuesReferences \
+        -q '[.closingIssuesReferences[].number] | join(",")' 2>/dev/null || true)"
+    if [[ -z "$issues" ]]; then
+        # Fallback: regex the PR body for Closes/Fixes/Resolves/Part of #N.
+        local body
+        body="$(gh pr view "$pr" --json body -q '.body // ""' 2>/dev/null || true)"
+        issues="$(printf '%s' "$body" \
+            | grep -Eio '(clos(e|es|ed)|fix(es|ed)?|resolv(e|es|ed)|part of)[[:space:]]+#[0-9]+' \
+            | grep -Eo '[0-9]+' \
+            | awk '!seen[$0]++' \
+            | paste -sd, - 2>/dev/null || true)"
+    fi
+    printf '%s' "$issues"
+}
+
+# resolve_role <pr> -> "builder" | "builder+doctor" | "unknown"
+resolve_role() {
+    local pr="$1"
+    [[ "$DO_ROLE" == 1 && "$HAVE_GH" == 1 && -n "$pr" ]] || { printf 'unknown'; return; }
+    local labels
+    labels="$(gh api "repos/{owner}/{repo}/issues/$pr/timeline" --paginate \
+        -q '.[] | select(.event=="labeled") | .label.name' 2>/dev/null || true)"
+    if [[ -z "$labels" ]]; then
+        printf 'unknown'
+    elif printf '%s\n' "$labels" | grep -qx 'loom:changes-requested'; then
+        printf 'builder+doctor'
+    else
+        printf 'builder'
+    fi
+}
+
+# resolve_commit <sha> -> populates RESOLVED_PR / RESOLVED_ISSUES / RESOLVED_ROLE
+# / RESOLVED_SUBJECT, using the cache when possible.
+resolve_commit() {
+    local sha="$1" subject pr issues role
+    subject="$(git -C "$REPO_ROOT" log -1 --format=%s "$sha" 2>/dev/null || echo "")"
+    RESOLVED_SUBJECT="$subject"
+
+    if cache_lookup "$sha"; then
+        RESOLVED_PR="$CACHED_PR"
+        RESOLVED_ISSUES="$CACHED_ISSUES"
+        RESOLVED_ROLE="$CACHED_ROLE"
+        return
+    fi
+
+    pr="$(resolve_pr_from_subject "$subject")"
+    if [[ -z "$pr" ]]; then
+        pr="$(resolve_pr_from_gh "$sha")"
+    fi
+
+    issues=""
+    role="unknown"
+    if [[ -n "$pr" ]]; then
+        issues="$(resolve_issues "$pr")"
+        role="$(resolve_role "$pr")"
+    fi
+
+    RESOLVED_PR="${pr:--}"
+    RESOLVED_ISSUES="${issues:--}"
+    RESOLVED_ROLE="$role"
+    cache_store "$sha" "$RESOLVED_PR" "$RESOLVED_ISSUES" "$RESOLVED_ROLE"
+}
+
+emit_row() {
+    local lines="$1" sha="$2" pr="$3" issues="$4" role="$5" subject="$6"
+    local short_sha="${sha:0:9}"
+    if [[ "$FORMAT" == "json" ]]; then
+        # Minimal hand-rolled JSON (no jq dependency for output); subject is
+        # escaped for backslashes/quotes only, adequate for commit subjects.
+        local esc_subject="${subject//\\/\\\\}"
+        esc_subject="${esc_subject//\"/\\\"}"
+        printf '{"path":"%s","lines":"%s","commit":"%s","pr":"%s","issues":"%s","role":"%s","subject":"%s"}\n' \
+            "$GIT_PATH" "$lines" "$sha" "$pr" "$issues" "$role" "$esc_subject"
+    else
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$GIT_PATH" "$lines" "$short_sha" "$pr" "$issues" "$role" "$subject"
+    fi
+}
+
+if [[ "$FORMAT" == "table" ]]; then
+    printf 'PATH\tLINES\tCOMMIT\tPR\tISSUES\tROLE\tSUBJECT\n'
+fi
+
+if [[ -n "$PATTERN" ]]; then
+    # ---- Pattern mode: git log --follow -S<pattern> ------------------------
+    while IFS= read -r sha; do
+        [[ -n "$sha" ]] || continue
+        resolve_commit "$sha"
+        emit_row "-" "$sha" "$RESOLVED_PR" "$RESOLVED_ISSUES" "$RESOLVED_ROLE" "$RESOLVED_SUBJECT"
+    done < <(git -C "$REPO_ROOT" log --follow --format=%H -S"$PATTERN" -- "$GIT_PATH" 2>/dev/null)
+else
+    # ---- Blame mode: one row per contiguous hunk ---------------------------
+    blame_args=(--porcelain -e)
+    if [[ -n "$LINE_RANGE" ]]; then
+        blame_args+=(-L "$LINE_RANGE")
+    fi
+    while IFS= read -r header; do
+        # Only lines with exactly 4 fields (sha, orig-line, final-line, group-size)
+        # mark the START of a new hunk in porcelain output; that group-size is
+        # the count of consecutive lines this commit owns starting at final-line.
+        sha="${header%% *}"
+        rest="${header#* }"
+        final_line="${rest#* }"
+        final_line="${final_line%% *}"
+        group_size="${rest##* }"
+        end_line=$(( final_line + group_size - 1 ))
+        line_range="$final_line"
+        [[ "$group_size" -gt 1 ]] && line_range="${final_line}-${end_line}"
+
+        resolve_commit "$sha"
+        emit_row "$line_range" "$sha" "$RESOLVED_PR" "$RESOLVED_ISSUES" "$RESOLVED_ROLE" "$RESOLVED_SUBJECT"
+    done < <(git -C "$REPO_ROOT" blame "${blame_args[@]}" -- "$GIT_PATH" 2>/dev/null \
+        | grep -E '^[0-9a-f]{40} [0-9]+ [0-9]+ [0-9]+$')
+fi

--- a/defaults/scripts/tests/test-blame-issue.sh
+++ b/defaults/scripts/tests/test-blame-issue.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# test-blame-issue.sh - Tests for blame-issue.sh (#4338, codecast borrow item 1)
+#
+# Style matches test-check-main-freshness.sh / test-disk-headroom.sh: a
+# throwaway `mktemp -d` synthetic git repo fixture, hand-rolled assertions, no
+# bats. blame-issue.sh's PR/issue/role resolution shells out to `gh`, so this
+# harness stubs a fake `gh` binary on PATH that answers the exact `gh pr view`
+# / `gh api .../pulls` / `gh api .../timeline` invocations the script makes,
+# keyed off a synthetic PR number embedded in each fixture commit's subject
+# (the "(#NNN)" squash-merge suffix this repo's merge style produces) --
+# no network access required.
+#
+# Usage:
+#   ./defaults/scripts/tests/test-blame-issue.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BLAME_SCRIPT="$SCRIPTS_DIR/blame-issue.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_contains() {
+    local needle="$1" haystack="$2" msg="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        pass "$msg"
+    else
+        fail "$msg (expected substring '$needle' in: $haystack)"
+    fi
+}
+
+assert_not_contains() {
+    local needle="$1" haystack="$2" msg="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        pass "$msg"
+    else
+        fail "$msg (unexpected substring '$needle' in: $haystack)"
+    fi
+}
+
+assert_eq() {
+    if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 (expected '$2', got '$1')"; fi
+}
+
+if [[ ! -x "$BLAME_SCRIPT" ]]; then
+    echo -e "${RED}FATAL${NC}: $BLAME_SCRIPT not found or not executable" >&2
+    exit 1
+fi
+
+# Scratch area for fixtures + fake gh -- cleaned on exit.
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/test-blame-issue.XXXXXX")"
+# shellcheck disable=SC2329  # invoked indirectly via the EXIT trap below
+cleanup() { rm -rf "$WORKDIR" 2>/dev/null || true; }
+trap cleanup EXIT
+
+export GIT_AUTHOR_NAME="test" GIT_AUTHOR_EMAIL="test@example.com"
+export GIT_COMMITTER_NAME="test" GIT_COMMITTER_EMAIL="test@example.com"
+
+# ---- Fake `gh` stub ---------------------------------------------------------
+# Answers exactly the invocations blame-issue.sh makes, keyed off a synthetic
+# PR number: PR 101 = builder-only cycle (issue 5001, no changes-requested);
+# PR 102 = builder+doctor cycle (issue 5002, changes-requested was applied).
+FAKE_BIN="$WORKDIR/bin"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/gh" <<'FAKEGH'
+#!/usr/bin/env bash
+case "$1" in
+    auth)
+        exit 0
+        ;;
+    pr)
+        if [[ "$2" == "view" ]]; then
+            pr="$3"
+            case "$pr" in
+                101) echo "5001" ;;
+                102) echo "5002" ;;
+                *) echo "" ;;
+            esac
+        fi
+        ;;
+    api)
+        path="$2"
+        if [[ "$path" == *"/timeline" ]]; then
+            pr="${path#*/issues/}"
+            pr="${pr%/timeline}"
+            case "$pr" in
+                101) printf 'loom:review-requested\nloom:pr\n' ;;
+                102) printf 'loom:review-requested\nloom:changes-requested\nloom:pr\n' ;;
+            esac
+        elif [[ "$path" == *"/pulls" ]]; then
+            # commit -> associated PRs fallback; unused in this fixture since
+            # every fixture commit's subject already carries "(#NNN)".
+            echo ""
+        fi
+        ;;
+esac
+exit 0
+FAKEGH
+chmod +x "$FAKE_BIN/gh"
+
+# ---- Fixture repo -----------------------------------------------------------
+REPO="$WORKDIR/repo"
+git init --quiet "$REPO"
+{
+    echo "line one"
+} > "$REPO/file.txt"
+git -C "$REPO" add file.txt
+git -C "$REPO" commit --quiet -m "feat: add line one (#101)"
+
+{
+    echo "line one"
+    echo "line two"
+} > "$REPO/file.txt"
+git -C "$REPO" add file.txt
+git -C "$REPO" commit --quiet -m "fix: add line two (#102)"
+
+{
+    echo "line one"
+    echo "line two"
+    echo "line three (no PR suffix)"
+} > "$REPO/file.txt"
+git -C "$REPO" add file.txt
+git -C "$REPO" commit --quiet -m "direct commit, no PR reference"
+
+run_blame() {
+    ( cd "$REPO" && PATH="$FAKE_BIN:$PATH" "$BLAME_SCRIPT" "$@" )
+}
+
+# -------- Test 1: script exists and is executable --------
+echo "Test 1: script exists and is executable"
+if [[ -x "$BLAME_SCRIPT" ]]; then
+    pass "blame-issue.sh is executable"
+else
+    fail "blame-issue.sh is missing or not executable"
+fi
+
+# -------- Test 2: --help prints usage and exits 0 --------
+echo "Test 2: --help prints usage and exits 0"
+help_out="$("$BLAME_SCRIPT" --help 2>&1)"
+rc=$?
+assert_eq "$rc" "0" "--help exits 0"
+assert_contains "Usage" "$help_out" "--help mentions Usage"
+
+# -------- Test 3: blame mode resolves PR/issue/role from commit subject --------
+echo "Test 3: blame mode resolves PR 101 (builder-only)"
+out="$(run_blame file.txt)"
+rc=$?
+assert_eq "$rc" "0" "blame mode exits 0"
+assert_contains "101" "$out" "resolves PR 101 from commit subject suffix"
+assert_contains "5001" "$out" "resolves issue 5001 for PR 101"
+assert_contains "builder" "$out" "reports builder role for PR 101 (no changes-requested)"
+
+echo "Test 4: blame mode resolves PR 102 (builder+doctor)"
+assert_contains "102" "$out" "resolves PR 102 from commit subject suffix"
+assert_contains "5002" "$out" "resolves issue 5002 for PR 102"
+assert_contains "builder+doctor" "$out" "reports builder+doctor role for PR 102 (changes-requested applied)"
+
+echo "Test 5: direct commit with no PR suffix falls back gracefully"
+assert_contains "direct commit, no PR reference" "$out" "direct commit subject is present in output"
+
+# -------- Test 6: --no-role skips role lookup --------
+echo "Test 6: --no-role marks role unknown without querying gh"
+out_norole="$(run_blame --no-role file.txt)"
+assert_contains "unknown" "$out_norole" "--no-role reports role=unknown"
+assert_not_contains "builder+doctor" "$out_norole" "--no-role never resolves builder+doctor"
+
+# -------- Test 7: --pattern mode uses git log -S --------
+echo "Test 7: --pattern mode finds commits touching a string"
+out_pattern="$(run_blame --pattern "line two" file.txt)"
+assert_contains "102" "$out_pattern" "--pattern mode finds the commit that introduced 'line two'"
+
+# -------- Test 8: --format json emits parseable-looking JSON --------
+echo "Test 8: --format json emits JSON lines"
+out_json="$(run_blame --format json -L 1,1 file.txt)"
+assert_contains '"pr":"101"' "$out_json" "--format json includes pr field"
+assert_contains '"commit":"' "$out_json" "--format json includes commit field"
+
+# -------- Test 9: missing path -> exit 2 --------
+echo "Test 9: missing path exits 2 with an error"
+rc=0
+err_out="$( (cd "$REPO" && "$BLAME_SCRIPT" does-not-exist.txt) 2>&1 )" || rc=$?
+assert_eq "$rc" "2" "missing path exits 2"
+assert_contains "not found" "$err_out" "missing path prints a 'not found' error"
+
+# -------- Test 10: outside a git repo -> exit 2 --------
+echo "Test 10: outside a git repo exits 2"
+NONREPO="$WORKDIR/not-a-repo"
+mkdir -p "$NONREPO"
+touch "$NONREPO/f.txt"
+rc=0
+( cd "$NONREPO" && "$BLAME_SCRIPT" f.txt ) >/dev/null 2>&1 || rc=$?
+assert_eq "$rc" "2" "non-git dir exits 2"
+
+# -------- Test 11: bad --format value -> exit 2 --------
+echo "Test 11: bad --format value exits 2"
+rc=0
+( cd "$REPO" && "$BLAME_SCRIPT" --format xml file.txt ) >/dev/null 2>&1 || rc=$?
+assert_eq "$rc" "2" "bad --format exits 2"
+
+# -------- Test 12: read-only -- no forge writes, no new state on disk --------
+echo "Test 12: read-only -- fixture repo has no new untracked files after running"
+status_before="$(git -C "$REPO" status --porcelain)"
+run_blame file.txt >/dev/null
+status_after="$(git -C "$REPO" status --porcelain)"
+assert_eq "$status_after" "$status_before" "repo working tree unchanged after blame-issue.sh runs"
+
+# -------- Summary --------
+echo ""
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo -e "${RED}FAILED${NC}: $TESTS_FAILED test(s) failed"
+    exit 1
+fi
+echo -e "${GREEN}OK${NC}: all tests passed"
+exit 0


### PR DESCRIPTION
## Summary

Implements #4338 (codecast-evaluation borrow-list item 1): a small **read-only**
`.loom/scripts/blame-issue.sh` that answers "which issue/PR produced this
line?" without a transcript database. codecast's `cast blame` joins git blame
against session records; Loom already carries this attribution in-band —
every Builder/Doctor commit lives in a labeled issue's worktree, and this
repo's squash-merge PRs carry a `(#PR)` subject suffix plus a `Closes #N`
body trailer.

## Resolution chain

1. `git blame --porcelain` (or `git log --follow -S<pattern>` in `--pattern`
   mode) to find the commit per line/hunk.
2. Commit -> PR number: first offline via the squash-merge subject's trailing
   `(#1234)`; falls back to `gh api repos/{owner}/{repo}/commits/<sha>/pulls`
   for commits without that suffix.
3. PR -> issue number(s): `closingIssuesReferences` (GitHub's computed
   field), falling back to regexing `Closes/Fixes/Resolves/Part of #N` out of
   the PR body.
4. PR -> best-effort role: `builder` if `loom:changes-requested` was never
   applied to the PR (per its label timeline); `builder+doctor` if it was
   (a squash commit collapses per-commit authorship, so finer-grained
   attribution isn't recoverable — reported at the PR level, honestly
   labeled as mixed rather than falsely attributed to one role).

Read-only throughout: `git blame`/`git log` locally, `gh api`/`gh pr view`
**GET** calls only. No forge writes, no daemon change, no new state on disk.

## Usage

```bash
./.loom/scripts/blame-issue.sh <path>                  # whole-file, one row per hunk
./.loom/scripts/blame-issue.sh <path> -L 10,40          # restrict to a line range
./.loom/scripts/blame-issue.sh --pattern STRING <path>  # git log -S mode
./.loom/scripts/blame-issue.sh --no-role <path>         # skip role lookup (fewer gh calls)
./.loom/scripts/blame-issue.sh --format json <path>
./.loom/scripts/blame-issue.sh --help
```

## Testing

- `defaults/scripts/tests/test-blame-issue.sh`: 21 assertions against a
  throwaway synthetic git repo fixture with a stubbed `gh` binary on `PATH`
  (no network access needed), mirroring the `test-check-main-freshness.sh` /
  `test-disk-headroom.sh` fixture-repo pattern. All pass.
- Manually verified against this repo's own history (offline subject-suffix
  path and the `gh api commits/.../pulls` fallback both exercised), e.g.:

  ```
  ./.loom/scripts/blame-issue.sh defaults/scripts/check-main-clean.sh
  ./.loom/scripts/blame-issue.sh --pattern "LOOM_OWNED_PREFIXES" defaults/scripts/check-main-clean.sh
  ```

  correctly resolves multi-hop cases like a subject carrying two `(#N)`
  references (`... (#4162) (#4202)` correctly resolves to PR 4202, not the
  earlier issue mention) and the `Issue #2000: Auto-recovered PR (#2013)`
  auto-recovery commit style.
- `shellcheck` clean on both the script and its test.
- `scripts/check-claude-md-budget.sh` passes (313/320 lines after the
  one-line Resources pointer).

## Docs

`defaults/docs/blame-issue.md` carries the reference detail per this repo's
"new subsystem detail goes to `.loom/docs/`, not inline in CLAUDE.md" rule;
CLAUDE.md gets only a one-line Resources pointer.

Closes #4338