### PR TITLE
feat(fleet): add `fleet add-worker` to bootstrap a provisioned host into a loom worker

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -450,6 +450,73 @@ untouched; only the in-memory tracking + reaper + watchdog go away, so the sweep
 finishes normally but its terminal state becomes unobservable via IPC after the
 deregister — an accepted consequence of an explicit operator `workspace remove`.
 
+## Fleet — operator-triggered multi-host worker fanout (`fleet`, #4340)
+
+The `fleet` subcommand family is the operator-triggered path for running loom
+across several hosts (epic #4340; architecture Option A — **federated daemons**,
+one full `loom-daemon` per host, coordination stays label-based through the
+forge, no new wire protocol). The **boundary decision** puts the fanout brain in
+`loom-daemon` (`loom-daemon/src/fleet/`): when to expand, what a worker is,
+dispatch/drain/teardown, fleet status. Generic VM provisioning stays in
+`repo:remote` (rjwalters/repo) — the seam `fleet` consumes is "a reachable Ubuntu
+box + an SSH alias", never a cloud CLI. v1 is operator-triggered, **not**
+auto-elastic (no queue-depth/cost-cap triggers — deferred until the manual
+command has mileage).
+
+### `fleet add-worker <ssh-host> --repo <owner/name> [--repo …]` (#4341)
+
+Takes a reachable, already-provisioned host to "daemon running, workspace
+registered, tokens ranked, dispatch verified" in one **idempotent** command over
+`ssh <ssh-host>`. The bootstrap is modeled as an ordered **plan** of named steps,
+each with a `check` (is it already done?) → `apply` → `verify` shape — Rust owns
+the plan/ordering/checklist; the per-phase shell is rendered in
+`fleet/add_worker.rs` (heredoc templates) and executed over a `CommandRunner`
+(the production `SshRunner`, or a mocked runner in tests). The steps encode the
+#3979 Phase-2 pilot's verified hand bootstrap:
+
+1. **base-deps** — build-essential, pkg-config, libssl-dev, **libsqlite3-dev**
+   (safehouse#38), git, gh, rustup.
+2. **machine-layout** — clone loom → `~/.local/share/loom`, `cargo build -p
+   loom-daemon --release`, install to `~/.local/bin` (Linux skips codesign).
+3. **claude-code** — install the Claude Code CLI.
+4. **forge-auth** — `gh auth login --with-token` with the operator's
+   fine-grained PAT fed over **ssh stdin** (never a command line).
+5. **token-accounts / token-pool / token-ranking** — install `accounts.env`
+   (0600, over stdin), `loom-daemon tokens bootstrap --shared`, then `tokens
+   check --ranking`. The **full** account pool ships (per #3979 — no pinned
+   subsets).
+6. **workspace-clone** — `gh repo clone` each `--repo` + `loom-daemon init`
+   (installs the `/loom:sweep` command, #4027).
+7. **workspace-register** — `loom-daemon workspace add` each repo at `--priority`.
+8. **daemon-unit** — a systemd `--user` unit (`Restart=on-failure`,
+   `loginctl enable-linger`). `WorkingDirectory=` is pinned to a workspace clone
+   as the **#4292** token-pool-cwd workaround — the rendered unit carries a
+   `#4292` marker so it is removed when that lands.
+9. **idle-shutdown** (optional, `--idle-shutdown-minutes N`) — a cron guard that
+   powers the host off after N idle minutes, skipping while claude / loom-daemon
+   are working.
+10. **safehouse** (optional, `--safehouse`) — **skip-with-notice** until #3998
+    (the safehoused provisioning fragment) lands.
+11. **verify** — `loom-daemon status` sane from the workspace cwd, ranking
+    fresh, workspace registered.
+
+Steps landed since the pilot are **deliberately absent**: no Python `loom_tools`
+/ `pip --break-system-packages` (native token selection landed #4228), no
+single-repo daemon-cwd pin for dispatch (registry-resolved dispatch landed #4299
+/ PR #4322).
+
+**Secrets** (`--pat-file`, `--accounts-env`) are read locally at **preflight**
+(a missing/empty file fails before any remote action) and travel to the worker
+only over ssh stdin — never a command line, never a logged rendered script. A
+supplied secret is `StepStdin { secret: true }`, redacted in dry-run output and
+`Debug`.
+
+`--dry-run` prints the full ordered plan without contacting the host. On a
+successful run each worker is recorded (dedup on the SSH alias) in a machine-level
+**fleet registry** at `~/.loom/fleet.json` (`LOOM_FLEET_PATH` override) — the
+inventory the siblings `fleet status` (#4342) and `fleet drain` (#4343) will
+enumerate. A re-run is idempotent: each step's `check` reports it `unchanged`.
+
 ## Token pool provisioning for managed repos (#3938)
 
 The multi-workspace work finder measures the token pool **once per tick from the

--- a/loom-daemon/src/fleet/add_worker.rs
+++ b/loom-daemon/src/fleet/add_worker.rs
@@ -1,0 +1,994 @@
+//! `fleet add-worker` — bootstrap a provisioned host into a working loom worker
+//! (issue #4341, epic #4340). This module renders the ordered bootstrap plan
+//! (the heredoc-style shell templates for each [`super::Step`]), the production
+//! SSH [`super::CommandRunner`], and the top-level [`run`] orchestration.
+//!
+//! The plan encodes the #3979 Phase-2 pilot's verified hand bootstrap (the
+//! 2026-07-28 pilot report on #3979 is ground truth). Deliberately **absent**,
+//! because the underlying gaps have since landed:
+//!
+//! - **No Python `loom_tools` / `pip --break-system-packages` step** — #4228
+//!   landed, so `spawn-claude.sh` execs the native `loom-daemon tokens select`;
+//!   a Rust-only worker spawns sweeps with zero Python on the token hot path.
+//! - **No single-repo daemon-cwd pin for dispatch** — #4299 landed (PR #4322):
+//!   dispatch resolves the target workspace from the registry, so a worker can
+//!   register several repos.
+//!
+//! The **only** remaining cwd coupling is the token pool (#4292, still open):
+//! the systemd unit pins `WorkingDirectory=` to a workspace clone so
+//! `.loom/tokens/` resolves. That workaround is marked with `#4292` in the
+//! rendered unit so it is removed when #4292 lands.
+
+use anyhow::{anyhow, bail, Context, Result};
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use super::{
+    all_succeeded, default_fleet_registry_path, execute_plan, render_checklist, CommandOutput,
+    CommandRunner, FleetRegistry, Plan, Step, StepStatus, StepStdin, VerifyResult, WorkerRecord,
+};
+
+/// Default upstream Loom repo cloned to the worker's machine-level layout.
+pub const DEFAULT_LOOM_REPO_URL: &str = "https://github.com/rjwalters/loom";
+
+/// Base directory (systemd `%h`-relative) under which workspace repos are
+/// cloned on the worker.
+const WORKSPACE_BASE: &str = "loom-workspaces";
+
+/// Operator inputs for a single `fleet add-worker` invocation.
+#[derive(Debug, Clone)]
+pub struct AddWorkerConfig {
+    /// SSH alias/host to reach the worker (from `repo:remote` or operator
+    /// supplied). Never embedded in a secret-carrying command.
+    pub ssh_host: String,
+    /// Workspace repos to clone + register on the worker (`owner/name`). At
+    /// least one is required.
+    pub repos: Vec<String>,
+    /// Cross-repo dispatch priority the workspaces are registered at (#3946;
+    /// lower = higher priority).
+    pub priority: u32,
+    /// Print the ordered plan without contacting the host.
+    pub dry_run: bool,
+    /// Upstream Loom repo URL to clone on the worker.
+    pub loom_repo_url: String,
+    /// Local path to the operator's fine-grained forge PAT (Contents+Issues+PRs
+    /// on the target repos). Transferred to the worker only via ssh stdin.
+    pub pat_file: Option<PathBuf>,
+    /// Local path to the operator's `accounts.env` (the full token pool).
+    /// Transferred to the worker only via ssh stdin.
+    pub accounts_env_file: Option<PathBuf>,
+    /// Whether to wire safehouse fleet-comms (config-gated; see [`build_plan`]).
+    pub safehouse_enabled: bool,
+    /// Idle-shutdown guard: power the host off after this many idle minutes.
+    /// `None` disables the guard.
+    pub idle_shutdown_minutes: Option<u32>,
+}
+
+/// Secret payloads read locally during preflight, then fed to the plan over
+/// stdin. Never logged, never placed on a command line.
+#[derive(Debug, Clone, Default)]
+pub struct Secrets {
+    /// Fine-grained forge PAT contents, if `--pat-file` was supplied.
+    pub pat: Option<String>,
+    /// `accounts.env` contents, if `--accounts-env` was supplied.
+    pub accounts_env: Option<String>,
+}
+
+/// The production [`CommandRunner`]: runs one rendered shell command per call
+/// over `ssh <host> <shell>`, feeding secrets via the child's stdin so they
+/// never appear on a command line (where `ps` on the worker would expose them).
+pub struct SshRunner {
+    /// The SSH alias/host.
+    pub host: String,
+}
+
+impl SshRunner {
+    /// A runner targeting `host`.
+    #[must_use]
+    pub fn new(host: &str) -> Self {
+        Self {
+            host: host.to_string(),
+        }
+    }
+}
+
+impl CommandRunner for SshRunner {
+    fn run(&self, shell: &str, stdin: Option<&str>) -> Result<CommandOutput> {
+        let mut cmd = Command::new("ssh");
+        // BatchMode: never block on an interactive password/passphrase prompt —
+        // an unreachable or auth-failing host fails fast instead of hanging.
+        cmd.arg("-o").arg("BatchMode=yes");
+        cmd.arg(&self.host);
+        cmd.arg(shell);
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        if stdin.is_some() {
+            cmd.stdin(Stdio::piped());
+        } else {
+            // Detach stdin so a remote command that reads stdin does not hang
+            // waiting on this process's terminal.
+            cmd.stdin(Stdio::null());
+        }
+
+        let mut child = cmd
+            .spawn()
+            .with_context(|| format!("failed to launch `ssh {}` (is ssh installed?)", self.host))?;
+
+        if let Some(payload) = stdin {
+            let mut sink = child
+                .stdin
+                .take()
+                .ok_or_else(|| anyhow!("ssh child stdin was not captured"))?;
+            sink.write_all(payload.as_bytes())
+                .context("writing payload to ssh stdin")?;
+            // Drop closes the pipe so the remote `cat`/`gh --with-token` sees EOF.
+            drop(sink);
+        }
+
+        let out = child.wait_with_output().context("waiting on ssh child")?;
+        Ok(CommandOutput {
+            code: out.status.code().unwrap_or(-1),
+            stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        })
+    }
+}
+
+/// A forge slug (`owner/name`) restricted to a safe character set, so it can be
+/// interpolated into rendered shell without an injection hazard.
+fn validate_repo(repo: &str) -> Result<()> {
+    if repo.is_empty() {
+        bail!("--repo must not be empty");
+    }
+    if !repo
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '/'))
+    {
+        bail!("--repo '{repo}' contains characters outside [A-Za-z0-9._/-]; refusing to render it into shell");
+    }
+    if !repo.contains('/') {
+        bail!("--repo '{repo}' should be a forge slug like owner/name");
+    }
+    Ok(())
+}
+
+/// Derive the on-worker clone directory name for a repo slug (`owner/name` →
+/// `name`). Validated by [`validate_repo`] first, so the result is shell-safe.
+fn repo_dir_name(repo: &str) -> &str {
+    repo.rsplit('/').next().unwrap_or(repo)
+}
+
+/// `%h`-relative workspace path for a repo (systemd expands `%h` to the user's
+/// home in a user unit; the shell steps use `"$HOME/..."` for the same path).
+fn workspace_rel(repo: &str) -> String {
+    format!("{WORKSPACE_BASE}/{}", repo_dir_name(repo))
+}
+
+/// Local preflight (AC 3): validate inputs and read the operator's secret files
+/// **before any remote action**. Fails with a clear message if a supplied
+/// secret file is missing/unreadable, or if inputs are malformed. Reading a
+/// local file does not "touch the host", so this runs in dry-run mode too.
+pub fn preflight(config: &AddWorkerConfig) -> Result<Secrets> {
+    if config.ssh_host.trim().is_empty() {
+        bail!("ssh-host must not be empty");
+    }
+    if config.repos.is_empty() {
+        bail!("at least one --repo is required");
+    }
+    for repo in &config.repos {
+        validate_repo(repo)?;
+    }
+
+    let mut secrets = Secrets::default();
+    if let Some(path) = &config.pat_file {
+        let contents = std::fs::read_to_string(path)
+            .with_context(|| format!("reading --pat-file {} (does it exist?)", path.display()))?;
+        let trimmed = contents.trim();
+        if trimmed.is_empty() {
+            bail!("--pat-file {} is empty", path.display());
+        }
+        secrets.pat = Some(trimmed.to_string());
+    }
+    if let Some(path) = &config.accounts_env_file {
+        let contents = std::fs::read_to_string(path).with_context(|| {
+            format!("reading --accounts-env {} (does it exist?)", path.display())
+        })?;
+        if contents.trim().is_empty() {
+            bail!("--accounts-env {} is empty", path.display());
+        }
+        secrets.accounts_env = Some(contents);
+    }
+    Ok(secrets)
+}
+
+/// Build the ordered bootstrap [`Plan`] from `config` + already-read `secrets`.
+///
+/// Pure (no I/O, no host contact) so the ordering, idempotency checks, secret
+/// placement, and skip-with-notice branches are all unit-testable. Each step's
+/// `check` phase is what makes a re-run idempotent (AC 2).
+#[must_use]
+pub fn build_plan(config: &AddWorkerConfig, secrets: &Secrets) -> Plan {
+    let mut plan = Plan::new();
+    let primary_rel = workspace_rel(&config.repos[0]);
+
+    // 1. Base deps (safehouse#38: libsqlite3-dev is required).
+    plan.push_step(Step::new(
+        "base-deps",
+        "install build-essential, pkg-config, libssl-dev, libsqlite3-dev, git, gh, rustup",
+        Some(
+            "dpkg -s build-essential pkg-config libssl-dev libsqlite3-dev git >/dev/null 2>&1 \
+             && command -v gh >/dev/null 2>&1 && command -v cargo >/dev/null 2>&1"
+                .to_string(),
+        ),
+        render_base_deps(),
+    ));
+
+    // 2. Machine-level layout: clone loom, build loom-daemon, install to ~/.local/bin.
+    plan.push_step(Step::new(
+        "machine-layout",
+        "clone loom to ~/.local/share/loom, cargo build -p loom-daemon --release, install to ~/.local/bin",
+        Some(r#"test -x "$HOME/.local/bin/loom-daemon""#.to_string()),
+        render_machine_layout(&config.loom_repo_url),
+    ));
+
+    // 3. Claude Code install.
+    plan.push_step(Step::new(
+        "claude-code",
+        "install Claude Code CLI",
+        Some("command -v claude >/dev/null 2>&1".to_string()),
+        render_claude_code(),
+    ));
+
+    // 4. Forge auth via operator-supplied fine-grained PAT (over stdin).
+    match &secrets.pat {
+        Some(pat) => plan.push_step(
+            Step::new(
+                "forge-auth",
+                "authenticate gh with the fine-grained PAT (via stdin) and set up git credential helper",
+                Some("gh auth status >/dev/null 2>&1".to_string()),
+                render_forge_auth(),
+            )
+            .with_stdin(StepStdin { content: pat.clone(), secret: true }),
+        ),
+        None => plan.push_skip(
+            "forge-auth",
+            "authenticate gh with the fine-grained PAT",
+            "no --pat-file supplied",
+        ),
+    }
+
+    // 5. Token pool: full account pool (#3979 decision — no pinned subsets).
+    //    5a. Install accounts.env (secret, over stdin, 0600).
+    match &secrets.accounts_env {
+        Some(env) => plan.push_step(
+            Step::new(
+                "token-accounts",
+                "install accounts.env to ~/.loom/accounts.env (0600, via stdin)",
+                None,
+                render_token_accounts(),
+            )
+            .with_stdin(StepStdin {
+                content: env.clone(),
+                secret: true,
+            }),
+        ),
+        None => {
+            plan.push_skip("token-accounts", "install accounts.env", "no --accounts-env supplied")
+        }
+    }
+    //    5b. Bootstrap the shared pool (idempotent — check for existing tokens).
+    if secrets.accounts_env.is_some() {
+        plan.push_step(Step::new(
+            "token-pool",
+            "loom-daemon tokens bootstrap (shared machine pool)",
+            Some(r#"ls "$HOME/.loom/tokens"/*.token >/dev/null 2>&1"#.to_string()),
+            render_token_pool(),
+        ));
+    } else {
+        plan.push_skip("token-pool", "bootstrap the token pool", "no --accounts-env supplied");
+    }
+    //    5c. Refresh the ranking (always — the verify AC wants a fresh ranking).
+    if secrets.accounts_env.is_some() {
+        plan.push_step(Step::new(
+            "token-ranking",
+            "loom-daemon tokens check --ranking (fresh availability probe)",
+            None,
+            render_token_ranking(),
+        ));
+    } else {
+        plan.push_skip("token-ranking", "refresh the token ranking", "no --accounts-env supplied");
+    }
+
+    // 6. Clone + init workspace repos (init installs the /loom:sweep command, #4027).
+    plan.push_step(Step::new(
+        "workspace-clone",
+        "clone workspace repo(s) and run loom-daemon init (installs /loom:sweep)",
+        Some(render_workspace_clone_check(&config.repos)),
+        render_workspace_clone(&config.repos),
+    ));
+
+    // 7. Register workspaces in the machine-level registry (idempotent).
+    plan.push_step(Step::new(
+        "workspace-register",
+        &format!("loom-daemon workspace add each repo (priority {})", config.priority),
+        Some(render_workspace_register_check(&config.repos)),
+        render_workspace_register(&config.repos, config.priority),
+    ));
+
+    // 8. Start the daemon under a systemd --user unit (Restart=on-failure, linger).
+    plan.push_step(Step::new(
+        "daemon-unit",
+        "install + enable the loom-daemon systemd --user unit (linger, Restart=on-failure)",
+        Some("systemctl --user is-enabled loom-daemon.service >/dev/null 2>&1".to_string()),
+        render_daemon_unit(&primary_rel),
+    ));
+
+    // 9. Idle-shutdown guard (optional).
+    match config.idle_shutdown_minutes {
+        Some(minutes) => plan.push_step(Step::new(
+            "idle-shutdown",
+            &format!("install idle-shutdown cron guard ({minutes} idle minutes)"),
+            Some(r#"crontab -l 2>/dev/null | grep -q loom-idle-shutdown"#.to_string()),
+            render_idle_shutdown(minutes),
+        )),
+        None => plan.push_skip(
+            "idle-shutdown",
+            "install idle-shutdown cron guard",
+            "no --idle-shutdown-minutes supplied",
+        ),
+    }
+
+    // 10. Optional safehouse wiring (#3998 not yet landed → skip-with-notice).
+    if config.safehouse_enabled {
+        plan.push_skip(
+            "safehouse",
+            "wire safehouse fleet-comms (tailnet join, account, LOOM_SAFEHOUSE_* env)",
+            "requires #3998 (safehoused provisioning fragment) which has not landed",
+        );
+    } else {
+        plan.push_skip(
+            "safehouse",
+            "wire safehouse fleet-comms",
+            "safehouse not requested (pass --safehouse to enable once #3998 lands)",
+        );
+    }
+
+    // 11. Verify: daemon reachable from the workspace cwd, ranking fresh, repos registered.
+    plan.push_step(Step::new(
+        "verify",
+        "verify: loom-daemon status sane from the workspace cwd, token ranking fresh, workspace registered",
+        None,
+        render_verify(&primary_rel, &config.repos),
+    ));
+
+    plan
+}
+
+/// Top-level orchestration for `loom-daemon fleet add-worker`.
+///
+/// Preflight → build plan → (dry-run: print + return) → execute over ssh →
+/// print the per-step checklist → on full success, upsert the fleet registry
+/// record. Returns an error if any step failed (so the CLI exits non-zero).
+pub fn run(config: &AddWorkerConfig) -> Result<()> {
+    let secrets = preflight(config)?;
+    let plan = build_plan(config, &secrets);
+
+    if config.dry_run {
+        print!("{}", plan.render_dry_run(&config.ssh_host));
+        println!(
+            "\n(dry run — no action taken on {}. Re-run without --dry-run to execute.)",
+            config.ssh_host
+        );
+        return Ok(());
+    }
+
+    let runner = SshRunner::new(&config.ssh_host);
+    let reports = execute_plan(&runner, &plan);
+    print!("{}", render_checklist(&config.ssh_host, &reports));
+
+    let verify_ok = reports
+        .iter()
+        .find(|r| r.name == "verify")
+        .map(|r| matches!(r.status, StepStatus::Changed));
+
+    if all_succeeded(&reports, &plan) {
+        let record = WorkerRecord {
+            ssh_host: config.ssh_host.clone(),
+            repos: config.repos.clone(),
+            priority: config.priority,
+            bootstrapped_at: chrono::Utc::now().to_rfc3339(),
+            last_verify: verify_ok.map(|ok| VerifyResult {
+                ok,
+                at: chrono::Utc::now().to_rfc3339(),
+                summary: if ok {
+                    "daemon reachable, ranking fresh, workspace registered".to_string()
+                } else {
+                    "verify step did not confirm".to_string()
+                },
+            }),
+        };
+        let path = default_fleet_registry_path()?;
+        let mut registry = FleetRegistry::load(&path)?;
+        let replaced = registry.upsert(record);
+        registry.save(&path)?;
+        println!(
+            "\nWorker {} {} in the fleet registry ({}).",
+            config.ssh_host,
+            if replaced { "updated" } else { "recorded" },
+            path.display()
+        );
+        println!("Bootstrap complete: daemon running, workspace registered, tokens ranked, dispatch verified.");
+        Ok(())
+    } else {
+        let failed = reports
+            .iter()
+            .find(|r| r.status.is_failure())
+            .map_or_else(|| "unknown".to_string(), |r| r.name.clone());
+        bail!(
+            "fleet add-worker halted at step '{failed}' on {} — see the checklist above. \
+             The run is idempotent: fix the cause and re-run to resume.",
+            config.ssh_host
+        )
+    }
+}
+
+// ===========================================================================
+// Shell templates (rendered on the daemon, executed on the worker over ssh)
+// ===========================================================================
+
+fn render_base_deps() -> String {
+    // NOTE: the rustup + gh installs are written as shell text here (never run
+    // through the daemon's own shell), so the curl-pipe idiom is safe.
+    r#"set -e
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get update -qq
+sudo apt-get install -y build-essential pkg-config libssl-dev libsqlite3-dev git curl ca-certificates
+if ! command -v gh >/dev/null 2>&1; then
+  sudo mkdir -p -m 755 /etc/apt/keyrings
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+  sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+  sudo apt-get update -qq
+  sudo apt-get install -y gh
+fi
+if ! command -v cargo >/dev/null 2>&1; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+fi
+"#
+    .to_string()
+}
+
+fn render_machine_layout(loom_repo_url: &str) -> String {
+    format!(
+        r#"set -e
+. "$HOME/.cargo/env" 2>/dev/null || true
+LOOM_SRC="$HOME/.local/share/loom"
+if [ -d "$LOOM_SRC/.git" ]; then
+  git -C "$LOOM_SRC" pull --ff-only
+else
+  mkdir -p "$(dirname "$LOOM_SRC")"
+  git clone {loom_repo_url} "$LOOM_SRC"
+fi
+cd "$LOOM_SRC"
+cargo build -p loom-daemon --release
+mkdir -p "$HOME/.local/bin"
+install -m 0755 "$LOOM_SRC/target/release/loom-daemon" "$HOME/.local/bin/loom-daemon"
+# Ensure ~/.local/bin is on PATH for future logins (Linux worker skips codesign).
+if ! echo "$PATH" | tr ':' '\n' | grep -qx "$HOME/.local/bin"; then
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.profile"
+fi
+"#
+    )
+}
+
+fn render_claude_code() -> String {
+    r#"set -e
+curl -fsSL https://claude.ai/install.sh | bash
+"#
+    .to_string()
+}
+
+fn render_forge_auth() -> String {
+    // The PAT arrives on stdin; pipe it straight into `gh auth login` so it
+    // never lands on a command line. `gh` stores it 0600 under ~/.config/gh.
+    r#"set -e
+export PATH="$HOME/.local/bin:$PATH"
+gh auth login --with-token
+gh auth setup-git
+"#
+    .to_string()
+}
+
+fn render_token_accounts() -> String {
+    // accounts.env arrives on stdin; umask 077 makes the written file 0600.
+    r#"set -e
+umask 077
+mkdir -p "$HOME/.loom"
+cat > "$HOME/.loom/accounts.env"
+chmod 600 "$HOME/.loom/accounts.env"
+"#
+    .to_string()
+}
+
+fn render_token_pool() -> String {
+    r#"set -e
+export PATH="$HOME/.local/bin:$PATH"
+LOOM_ACCOUNTS_ENV="$HOME/.loom/accounts.env" loom-daemon tokens bootstrap --shared --home-env "$HOME/.loom/accounts.env"
+"#
+    .to_string()
+}
+
+fn render_token_ranking() -> String {
+    r#"set -e
+export PATH="$HOME/.local/bin:$PATH"
+loom-daemon tokens check --ranking --shared 2>/dev/null || loom-daemon tokens check --ranking
+"#
+    .to_string()
+}
+
+fn render_workspace_clone_check(repos: &[String]) -> String {
+    let mut s = String::from("set -e\n");
+    for repo in repos {
+        let rel = workspace_rel(repo);
+        s.push_str(&format!("test -d \"$HOME/{rel}/.git\" || exit 1\n"));
+    }
+    s
+}
+
+fn render_workspace_clone(repos: &[String]) -> String {
+    let mut s = String::from(
+        r#"set -e
+export PATH="$HOME/.local/bin:$PATH"
+LOOM_SRC="$HOME/.local/share/loom"
+mkdir -p "$HOME/loom-workspaces"
+"#,
+    );
+    for repo in repos {
+        let rel = workspace_rel(repo);
+        s.push_str(&format!(
+            r#"if [ ! -d "$HOME/{rel}/.git" ]; then
+  gh repo clone {repo} "$HOME/{rel}"
+fi
+loom-daemon init "$HOME/{rel}" --defaults "$LOOM_SRC/defaults" || true
+"#
+        ));
+    }
+    s
+}
+
+fn render_workspace_register_check(repos: &[String]) -> String {
+    let mut s = String::from(
+        r#"set -e
+export PATH="$HOME/.local/bin:$PATH"
+LIST="$(loom-daemon workspace list --json 2>/dev/null || echo '{}')"
+"#,
+    );
+    for repo in repos {
+        let rel = workspace_rel(repo);
+        let name = repo_dir_name(repo);
+        s.push_str(&format!("echo \"$LIST\" | grep -q \"{name}\" || exit 1  # {rel}\n"));
+    }
+    s
+}
+
+fn render_workspace_register(repos: &[String], priority: u32) -> String {
+    let mut s = String::from(
+        r#"set -e
+export PATH="$HOME/.local/bin:$PATH"
+"#,
+    );
+    for repo in repos {
+        let rel = workspace_rel(repo);
+        s.push_str(&format!("loom-daemon workspace add \"$HOME/{rel}\" --priority {priority}\n"));
+    }
+    s
+}
+
+fn render_daemon_unit(primary_rel: &str) -> String {
+    // WorkingDirectory pinned to a workspace clone is the #4292 token-pool cwd
+    // workaround — REMOVE once #4292 lands (token pool no longer cwd-coupled).
+    format!(
+        r#"set -e
+export PATH="$HOME/.local/bin:$PATH"
+mkdir -p "$HOME/.config/systemd/user"
+cat > "$HOME/.config/systemd/user/loom-daemon.service" <<'UNIT'
+[Unit]
+Description=Loom daemon (fleet worker)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# WORKAROUND(#4292): the token pool resolves via the daemon's cwd, so pin the
+# working directory to a workspace clone whose .loom/tokens/ the daemon can
+# find. Remove this WorkingDirectory line once #4292 (cwd-decoupled token pool)
+# lands.
+WorkingDirectory=%h/{primary_rel}
+ExecStart=%h/.local/bin/loom-daemon
+Restart=on-failure
+RestartSec=5
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+
+[Install]
+WantedBy=default.target
+UNIT
+# Linger so the user manager (and the daemon) survive logout + reboot on an
+# SSH-only host.
+loginctl enable-linger "$USER" 2>/dev/null || true
+systemctl --user daemon-reload
+systemctl --user enable --now loom-daemon.service
+"#
+    )
+}
+
+fn render_idle_shutdown(minutes: u32) -> String {
+    // Guard: power off after N idle minutes, but never while a sweep child
+    // (claude) runs or the daemon reports in-flight sweeps. Pilot-equivalent.
+    format!(
+        r#"set -e
+mkdir -p "$HOME/.local/bin"
+cat > "$HOME/.local/bin/loom-idle-shutdown.sh" <<'GUARD'
+#!/usr/bin/env bash
+# loom-idle-shutdown (#4341): power off after {minutes} idle minutes, skipping
+# while claude or loom-daemon are actively working.
+set -euo pipefail
+export PATH="$HOME/.local/bin:$PATH"
+LIMIT={minutes}
+STAMP="$HOME/.loom/last-active"
+mkdir -p "$HOME/.loom"
+active=0
+if pgrep -x claude >/dev/null 2>&1; then active=1; fi
+if loom-daemon status --json 2>/dev/null | grep -Eq '"active_sweeps"[[:space:]]*:[[:space:]]*[1-9]'; then active=1; fi
+if [ "$active" = "1" ]; then
+  date +%s > "$STAMP"
+  exit 0
+fi
+now=$(date +%s)
+last=$(cat "$STAMP" 2>/dev/null || echo "$now")
+idle_min=$(( (now - last) / 60 ))
+if [ "$idle_min" -ge "$LIMIT" ]; then
+  sudo systemctl poweroff
+fi
+GUARD
+chmod 0755 "$HOME/.local/bin/loom-idle-shutdown.sh"
+# Run the guard every 5 minutes.
+( crontab -l 2>/dev/null | grep -v loom-idle-shutdown; echo "*/5 * * * * $HOME/.local/bin/loom-idle-shutdown.sh >/dev/null 2>&1" ) | crontab -
+"#
+    )
+}
+
+fn render_verify(primary_rel: &str, repos: &[String]) -> String {
+    let mut checks = String::new();
+    for repo in repos {
+        let name = repo_dir_name(repo);
+        checks.push_str(&format!(
+            "echo \"$LIST\" | grep -q \"{name}\" || {{ echo \"workspace {name} not registered\" >&2; exit 1; }}\n"
+        ));
+    }
+    format!(
+        r#"set -e
+export PATH="$HOME/.local/bin:$PATH"
+cd "$HOME/{primary_rel}" 2>/dev/null || true
+# Daemon reachable + status sane from the workspace cwd.
+loom-daemon status >/dev/null 2>&1 || {{ echo "loom-daemon status failed" >&2; exit 1; }}
+# Token ranking is present + fresh (bootstrap + check ran).
+test -f "$HOME/.loom/tokens/.ranking" || test -f "$HOME/{primary_rel}/.loom/tokens/.ranking" \
+  || {{ echo "no token ranking found" >&2; exit 1; }}
+# Workspace(s) registered — the dispatch target must resolve from the registry (#4299).
+LIST="$(loom-daemon workspace list --json 2>/dev/null || echo '{{}}')"
+{checks}"#
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn base_config() -> AddWorkerConfig {
+        AddWorkerConfig {
+            ssh_host: "worker-1".to_string(),
+            repos: vec!["rjwalters/anvil".to_string()],
+            priority: 50,
+            dry_run: false,
+            loom_repo_url: DEFAULT_LOOM_REPO_URL.to_string(),
+            pat_file: None,
+            accounts_env_file: None,
+            safehouse_enabled: false,
+            idle_shutdown_minutes: None,
+        }
+    }
+
+    // ---- validation / preflight ----------------------------------------
+
+    #[test]
+    fn validate_repo_accepts_slug_and_rejects_injection() {
+        assert!(validate_repo("rjwalters/anvil").is_ok());
+        assert!(validate_repo("owner/name.with-dots_and-dashes").is_ok());
+        assert!(validate_repo("no-slash").is_err());
+        assert!(validate_repo("owner/name; rm -rf /").is_err());
+        assert!(validate_repo("owner/$(whoami)").is_err());
+        assert!(validate_repo("").is_err());
+    }
+
+    #[test]
+    fn repo_dir_name_takes_last_segment() {
+        assert_eq!(repo_dir_name("rjwalters/anvil"), "anvil");
+        assert_eq!(repo_dir_name("a/b/c"), "c");
+    }
+
+    #[test]
+    fn preflight_requires_a_repo() {
+        let mut config = base_config();
+        config.repos.clear();
+        assert!(preflight(&config).is_err());
+    }
+
+    #[test]
+    fn preflight_rejects_empty_host() {
+        let mut config = base_config();
+        config.ssh_host = "   ".to_string();
+        assert!(preflight(&config).is_err());
+    }
+
+    #[test]
+    fn preflight_missing_pat_file_fails_before_remote() {
+        let mut config = base_config();
+        config.pat_file = Some(PathBuf::from("/nonexistent/pat-file-xyz"));
+        let err = preflight(&config).unwrap_err().to_string();
+        assert!(err.contains("pat-file"), "err: {err}");
+    }
+
+    #[test]
+    fn preflight_missing_accounts_env_fails_before_remote() {
+        let mut config = base_config();
+        config.accounts_env_file = Some(PathBuf::from("/nonexistent/accounts-xyz.env"));
+        assert!(preflight(&config).is_err());
+    }
+
+    #[test]
+    fn preflight_reads_secret_files_and_trims_pat() {
+        let dir = tempfile::tempdir().unwrap();
+        let pat = dir.path().join("pat");
+        let accounts = dir.path().join("accounts.env");
+        std::fs::write(&pat, "  github_pat_abc123\n").unwrap();
+        std::fs::write(&accounts, "ACCOUNT_EMAIL_1=a@b.c\n").unwrap();
+        let mut config = base_config();
+        config.pat_file = Some(pat);
+        config.accounts_env_file = Some(accounts);
+        let secrets = preflight(&config).unwrap();
+        assert_eq!(secrets.pat.as_deref(), Some("github_pat_abc123"));
+        assert!(secrets
+            .accounts_env
+            .as_deref()
+            .unwrap()
+            .contains("ACCOUNT_EMAIL_1"));
+    }
+
+    #[test]
+    fn preflight_empty_pat_file_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let pat = dir.path().join("pat");
+        std::fs::write(&pat, "   \n").unwrap();
+        let mut config = base_config();
+        config.pat_file = Some(pat);
+        assert!(preflight(&config).is_err());
+    }
+
+    // ---- plan shape ----------------------------------------------------
+
+    #[test]
+    fn plan_step_ordering_matches_the_eight_pilot_steps() {
+        let config = base_config();
+        // Full secrets so the token/forge steps are executable, not skipped.
+        let secrets = Secrets {
+            pat: Some("pat".to_string()),
+            accounts_env: Some("ACCOUNT_EMAIL_1=a@b.c".to_string()),
+        };
+        let plan = build_plan(&config, &secrets);
+        let names: Vec<&str> = plan
+            .entries
+            .iter()
+            .map(super::super::PlanEntry::name)
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                "base-deps",
+                "machine-layout",
+                "claude-code",
+                "forge-auth",
+                "token-accounts",
+                "token-pool",
+                "token-ranking",
+                "workspace-clone",
+                "workspace-register",
+                "daemon-unit",
+                "idle-shutdown",
+                "safehouse",
+                "verify",
+            ]
+        );
+    }
+
+    #[test]
+    fn base_deps_check_includes_libsqlite3_dev() {
+        // safehouse#38: libsqlite3-dev must be part of the base deps.
+        let plan = build_plan(&base_config(), &Secrets::default());
+        let base = plan
+            .entries
+            .iter()
+            .find_map(|e| match e {
+                super::super::PlanEntry::Step(s) if s.name == "base-deps" => Some(s),
+                _ => None,
+            })
+            .unwrap();
+        assert!(base.check.as_ref().unwrap().contains("libsqlite3-dev"));
+        assert!(base.apply.contains("libsqlite3-dev"));
+    }
+
+    #[test]
+    fn forge_auth_and_token_accounts_carry_secret_stdin() {
+        let config = base_config();
+        let secrets = Secrets {
+            pat: Some("the-pat".to_string()),
+            accounts_env: Some("ACCOUNT_EMAIL_1=a@b.c".to_string()),
+        };
+        let plan = build_plan(&config, &secrets);
+        for name in ["forge-auth", "token-accounts"] {
+            let step = plan
+                .entries
+                .iter()
+                .find_map(|e| match e {
+                    super::super::PlanEntry::Step(s) if s.name == name => Some(s),
+                    _ => None,
+                })
+                .unwrap();
+            let stdin = step.stdin.as_ref().expect("secret step must carry stdin");
+            assert!(stdin.secret, "{name} stdin must be marked secret");
+        }
+        // The apply strings must NOT embed the secret values (stdin only).
+        let dry = plan.render_dry_run("worker-1");
+        assert!(!dry.contains("the-pat"));
+    }
+
+    #[test]
+    fn missing_secrets_become_skips_not_failures() {
+        // No PAT, no accounts.env → those steps are skip-with-notice.
+        let plan = build_plan(&base_config(), &Secrets::default());
+        for name in [
+            "forge-auth",
+            "token-accounts",
+            "token-pool",
+            "token-ranking",
+        ] {
+            let entry = plan.entries.iter().find(|e| e.name() == name).unwrap();
+            assert!(
+                matches!(entry, super::super::PlanEntry::Skip { .. }),
+                "{name} should be a skip when its secret is absent"
+            );
+        }
+    }
+
+    #[test]
+    fn safehouse_is_skip_with_3998_notice_when_enabled() {
+        let mut config = base_config();
+        config.safehouse_enabled = true;
+        let plan = build_plan(&config, &Secrets::default());
+        let entry = plan
+            .entries
+            .iter()
+            .find(|e| e.name() == "safehouse")
+            .unwrap();
+        match entry {
+            super::super::PlanEntry::Skip { reason, .. } => assert!(reason.contains("#3998")),
+            other => panic!("expected safehouse skip, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn idle_shutdown_step_present_only_when_configured() {
+        // Absent → skip.
+        let plan = build_plan(&base_config(), &Secrets::default());
+        let entry = plan
+            .entries
+            .iter()
+            .find(|e| e.name() == "idle-shutdown")
+            .unwrap();
+        assert!(matches!(entry, super::super::PlanEntry::Skip { .. }));
+
+        // Present → executable step whose apply renders the minute limit.
+        let mut config = base_config();
+        config.idle_shutdown_minutes = Some(45);
+        let plan = build_plan(&config, &Secrets::default());
+        let step = plan
+            .entries
+            .iter()
+            .find_map(|e| match e {
+                super::super::PlanEntry::Step(s) if s.name == "idle-shutdown" => Some(s),
+                _ => None,
+            })
+            .unwrap();
+        assert!(step.apply.contains("LIMIT=45"));
+    }
+
+    #[test]
+    fn daemon_unit_pins_workingdirectory_with_4292_marker() {
+        // AC 4: the #4292 token-pool cwd workaround must be marked with its
+        // tracking issue so it is removed when #4292 lands.
+        let config = base_config();
+        let plan = build_plan(&config, &Secrets::default());
+        let step = plan
+            .entries
+            .iter()
+            .find_map(|e| match e {
+                super::super::PlanEntry::Step(s) if s.name == "daemon-unit" => Some(s),
+                _ => None,
+            })
+            .unwrap();
+        assert!(step
+            .apply
+            .contains("WorkingDirectory=%h/loom-workspaces/anvil"));
+        assert!(step.apply.contains("#4292"), "workaround must be marked with #4292");
+        assert!(step.apply.contains("Restart=on-failure"));
+        assert!(step.apply.contains("enable-linger"));
+    }
+
+    #[test]
+    fn no_python_loom_tools_or_pip_step_anywhere() {
+        // #4228 landed — no interim Python install may appear (AC 4).
+        let config = base_config();
+        let secrets = Secrets {
+            pat: Some("pat".to_string()),
+            accounts_env: Some("ACCOUNT_EMAIL_1=a@b.c".to_string()),
+        };
+        let plan = build_plan(&config, &secrets);
+        for entry in &plan.entries {
+            if let super::super::PlanEntry::Step(s) = entry {
+                let hay = format!("{}\n{}", s.apply, s.check.clone().unwrap_or_default());
+                assert!(!hay.contains("break-system-packages"), "step {} has pip step", s.name);
+                assert!(
+                    !hay.contains("loom_tools"),
+                    "step {} references python loom_tools",
+                    s.name
+                );
+                assert!(!hay.contains("pip install"), "step {} has pip install", s.name);
+            }
+        }
+    }
+
+    #[test]
+    fn workspace_register_uses_the_priority() {
+        let mut config = base_config();
+        config.priority = 7;
+        config.repos = vec!["a/anvil".to_string(), "b/repo2".to_string()];
+        let plan = build_plan(&config, &Secrets::default());
+        let step = plan
+            .entries
+            .iter()
+            .find_map(|e| match e {
+                super::super::PlanEntry::Step(s) if s.name == "workspace-register" => Some(s),
+                _ => None,
+            })
+            .unwrap();
+        assert!(step.apply.contains("--priority 7"));
+        assert!(step.apply.contains("loom-workspaces/anvil"));
+        assert!(step.apply.contains("loom-workspaces/repo2"));
+    }
+
+    #[test]
+    fn dry_run_render_is_stable_and_lists_all_steps() {
+        let config = base_config();
+        let secrets = Secrets {
+            pat: Some("pat".to_string()),
+            accounts_env: Some("env".to_string()),
+        };
+        let plan = build_plan(&config, &secrets);
+        let out = plan.render_dry_run(&config.ssh_host);
+        assert!(out.contains("13 steps"));
+        assert!(out.contains("base-deps"));
+        assert!(out.contains("verify"));
+        assert!(out.contains("feeds a secret via stdin"));
+    }
+}

--- a/loom-daemon/src/fleet/mod.rs
+++ b/loom-daemon/src/fleet/mod.rs
@@ -1,0 +1,995 @@
+//! Operator-triggered multi-host worker fanout (`loom-daemon fleet …`, epic
+//! #4340). This module owns the **fanout brain**: the boundary decision on
+//! #4340 puts "when to expand, what a worker is, dispatch/drain/teardown, fleet
+//! status" in `loom-daemon`, not in installed shell scripts — so the bootstrap
+//! is modeled as an ordered, idempotent plan the daemon owns, not a monolithic
+//! bash script under `defaults/scripts/`.
+//!
+//! # What this phase delivers (issue #4341 — `fleet add-worker`)
+//!
+//! `loom-daemon fleet add-worker <ssh-host> --repo <workspace-repo>` takes a
+//! reachable, already-provisioned Ubuntu host (an SSH alias from `repo:remote`
+//! or operator-supplied) to "daemon running, workspace registered, tokens
+//! ranked, dispatch verified" in one command. Generic VM provisioning stays in
+//! `repo:remote` (rjwalters/repo) per the epic's boundary decision — this
+//! command consumes "a reachable box + an SSH alias", it never wrangles a cloud
+//! CLI.
+//!
+//! ## Architecture — step planner + executor
+//!
+//! The bootstrap is an ordered [`Plan`] of named [`Step`]s. Each step has three
+//! phases:
+//!
+//! - **check** — shell that exits `0` when the step is already satisfied. This
+//!   is what makes a re-run idempotent (AC 2): an already-bootstrapped host
+//!   reports every step [`StepStatus::AlreadyDone`] and touches nothing.
+//! - **apply** — shell that performs the step (only run when `check` is absent
+//!   or fails).
+//! - **verify** — optional shell that confirms `apply` succeeded.
+//!
+//! Rust owns the plan, the ordering, and the per-step checklist report. The
+//! shell for each phase is rendered in [`add_worker`] (heredoc-style templates,
+//! the way `init::templates` renders scaffolding) and executed over a
+//! [`CommandRunner`] — the real one is an `ssh <host> <shell>` runner, but the
+//! trait lets the unit tests drive the whole plan through a mock without a live
+//! box. A `--dry-run` flag prints the ordered plan without contacting the host,
+//! which makes the verify AC testable in CI.
+//!
+//! ## Fleet registry
+//!
+//! [`add_worker`] writes one [`WorkerRecord`] per bootstrapped worker into a
+//! machine-level [`FleetRegistry`] at `~/.loom/fleet.json`, following the
+//! conventions of [`crate::workspace_registry`]. The sibling commands `fleet
+//! status` (#4342) and `fleet drain` (#4343) enumerate workers from this
+//! inventory — `add-worker` is where it gets written. The schema is kept
+//! deliberately minimal; the siblings can extend it.
+
+pub mod add_worker;
+
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+// ===========================================================================
+// Command runner (the SSH / mock seam)
+// ===========================================================================
+
+/// Captured result of running one shell command on the target host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandOutput {
+    /// Process exit code (`-1` when the child was killed by a signal / never
+    /// produced a code — treated as a failure by every caller).
+    pub code: i32,
+    /// Captured stdout (lossily UTF-8 decoded).
+    pub stdout: String,
+    /// Captured stderr (lossily UTF-8 decoded).
+    pub stderr: String,
+}
+
+impl CommandOutput {
+    /// Whether the command exited cleanly (`code == 0`).
+    #[must_use]
+    pub fn ok(&self) -> bool {
+        self.code == 0
+    }
+}
+
+/// The seam between the step executor and the host: a `run` that executes one
+/// rendered shell command against the target, optionally feeding `stdin`.
+///
+/// The production implementation ([`add_worker::SshRunner`]) runs `ssh <host>
+/// <shell>`; the tests supply a scripted mock so the whole plan can be
+/// exercised — including secrets-over-stdin and idempotent re-runs — without a
+/// live box or the network.
+pub trait CommandRunner {
+    /// Run `shell` on the target. When `stdin` is `Some`, its bytes are written
+    /// to the command's standard input (this is how secrets reach the host —
+    /// never on the command line, where `ps` would expose them).
+    ///
+    /// Returns the captured [`CommandOutput`]. An `Err` is reserved for a
+    /// failure to *launch* the transport at all (e.g. `ssh` missing) — a
+    /// non-zero remote exit is a successful launch and is reported via
+    /// [`CommandOutput::code`].
+    fn run(&self, shell: &str, stdin: Option<&str>) -> Result<CommandOutput>;
+}
+
+// ===========================================================================
+// Step / plan model
+// ===========================================================================
+
+/// A secret or plain payload fed to a step's `apply` command over stdin.
+#[derive(Clone)]
+pub struct StepStdin {
+    /// The bytes written to the command's stdin.
+    pub content: String,
+    /// When `true`, the content is a secret: it is never printed (dry-run and
+    /// logs show `<redacted>`), and it only ever travels over stdin.
+    pub secret: bool,
+}
+
+impl std::fmt::Debug for StepStdin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never render secret bytes through Debug (avoids accidental leakage in
+        // a `{:?}` log line).
+        if self.secret {
+            f.debug_struct("StepStdin")
+                .field("secret", &true)
+                .field("content", &"<redacted>")
+                .finish()
+        } else {
+            f.debug_struct("StepStdin")
+                .field("secret", &false)
+                .field("content", &self.content)
+                .finish()
+        }
+    }
+}
+
+/// One named unit of the bootstrap plan.
+#[derive(Debug, Clone)]
+pub struct Step {
+    /// Stable machine name (`base-deps`, `token-pool`, …) used in the checklist
+    /// and by callers matching on a specific step.
+    pub name: String,
+    /// One-line human summary shown in the dry-run plan and the checklist.
+    pub summary: String,
+    /// Shell that exits `0` when the step is already satisfied. `None` means the
+    /// step is always applied (e.g. a `check` + `--ranking` refresh we want to
+    /// re-run every time). A present `check` is what classifies a re-run as
+    /// [`StepStatus::AlreadyDone`].
+    pub check: Option<String>,
+    /// Shell that performs the step. Run only when `check` is `None` or fails.
+    pub apply: String,
+    /// Shell that confirms the step succeeded. `None` trusts `apply`'s exit
+    /// code.
+    pub verify: Option<String>,
+    /// Optional stdin payload for the `apply` command (how secrets reach the
+    /// host — see [`StepStdin`]).
+    pub stdin: Option<StepStdin>,
+}
+
+impl Step {
+    /// Convenience constructor for a check → apply step with no stdin/verify.
+    #[must_use]
+    pub fn new(name: &str, summary: &str, check: Option<String>, apply: String) -> Self {
+        Self {
+            name: name.to_string(),
+            summary: summary.to_string(),
+            check,
+            apply,
+            verify: None,
+            stdin: None,
+        }
+    }
+
+    /// Builder: attach a `verify` phase.
+    #[must_use]
+    pub fn with_verify(mut self, verify: String) -> Self {
+        self.verify = Some(verify);
+        self
+    }
+
+    /// Builder: attach an stdin payload for `apply`.
+    #[must_use]
+    pub fn with_stdin(mut self, stdin: StepStdin) -> Self {
+        self.stdin = Some(stdin);
+        self
+    }
+}
+
+/// An entry in the ordered plan: either an executable [`Step`] or a
+/// deliberately-skipped step (config-gated, e.g. safehouse when it is not
+/// enabled or its prerequisite has not landed).
+#[derive(Debug, Clone)]
+pub enum PlanEntry {
+    /// A step to execute (check → apply → verify).
+    Step(Step),
+    /// A step intentionally not run, with an operator-facing reason. Reported as
+    /// [`StepStatus::Skipped`] and shown in the dry-run plan so the omission is
+    /// never silent.
+    Skip {
+        /// Stable machine name.
+        name: String,
+        /// One-line human summary.
+        summary: String,
+        /// Why the step is skipped (e.g. `"safehouse.enabled is false"`).
+        reason: String,
+    },
+}
+
+impl PlanEntry {
+    /// The step's machine name, regardless of variant.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            PlanEntry::Step(s) => &s.name,
+            PlanEntry::Skip { name, .. } => name,
+        }
+    }
+
+    /// The step's one-line summary, regardless of variant.
+    #[must_use]
+    pub fn summary(&self) -> &str {
+        match self {
+            PlanEntry::Step(s) => &s.summary,
+            PlanEntry::Skip { summary, .. } => summary,
+        }
+    }
+}
+
+/// An ordered bootstrap plan.
+#[derive(Debug, Clone, Default)]
+pub struct Plan {
+    /// The plan entries, in execution order.
+    pub entries: Vec<PlanEntry>,
+}
+
+impl Plan {
+    /// A new, empty plan.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append an executable step.
+    pub fn push_step(&mut self, step: Step) {
+        self.entries.push(PlanEntry::Step(step));
+    }
+
+    /// Append a deliberately-skipped step.
+    pub fn push_skip(&mut self, name: &str, summary: &str, reason: &str) {
+        self.entries.push(PlanEntry::Skip {
+            name: name.to_string(),
+            summary: summary.to_string(),
+            reason: reason.to_string(),
+        });
+    }
+
+    /// Render the ordered plan for `--dry-run`: one numbered line per entry with
+    /// its status placeholder, plus a `[skip]` reason where applicable. Secrets
+    /// are never included (the rendered shell that carries them is not printed).
+    #[must_use]
+    pub fn render_dry_run(&self, host: &str) -> String {
+        let mut out = String::new();
+        out.push_str(&format!(
+            "fleet add-worker plan for {host} ({} steps):\n",
+            self.entries.len()
+        ));
+        for (i, entry) in self.entries.iter().enumerate() {
+            let n = i + 1;
+            match entry {
+                PlanEntry::Step(s) => {
+                    let secret_note = if s.stdin.as_ref().is_some_and(|p| p.secret) {
+                        "  (feeds a secret via stdin)"
+                    } else {
+                        ""
+                    };
+                    out.push_str(&format!("  {n:>2}. [{}] {}{}\n", s.name, s.summary, secret_note));
+                }
+                PlanEntry::Skip {
+                    name,
+                    summary,
+                    reason,
+                } => {
+                    out.push_str(&format!("  {n:>2}. [{name}] {summary}  — SKIP: {reason}\n"));
+                }
+            }
+        }
+        out
+    }
+}
+
+// ===========================================================================
+// Execution + checklist report
+// ===========================================================================
+
+/// Classification of a single step's outcome after execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StepStatus {
+    /// The `check` phase reported the step already satisfied — nothing applied
+    /// (the idempotent-re-run case, AC 2).
+    AlreadyDone,
+    /// The step was applied (and verified, if it had a `verify`) successfully.
+    Changed,
+    /// The step was deliberately not run; carries the reason.
+    Skipped(String),
+    /// The step failed; carries a human diagnostic (which phase, exit code, a
+    /// trailing slice of stderr).
+    Failed(String),
+}
+
+impl StepStatus {
+    /// A short tag for the checklist column.
+    #[must_use]
+    pub fn tag(&self) -> &'static str {
+        match self {
+            StepStatus::AlreadyDone => "unchanged",
+            StepStatus::Changed => "changed",
+            StepStatus::Skipped(_) => "skipped",
+            StepStatus::Failed(_) => "FAILED",
+        }
+    }
+
+    /// Whether this status halts the plan (only [`StepStatus::Failed`] does).
+    #[must_use]
+    pub fn is_failure(&self) -> bool {
+        matches!(self, StepStatus::Failed(_))
+    }
+}
+
+/// The result of one executed plan entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StepReport {
+    /// The step's machine name.
+    pub name: String,
+    /// The step's one-line summary.
+    pub summary: String,
+    /// The classified outcome.
+    pub status: StepStatus,
+}
+
+/// Execute a single [`Step`] against `runner`, returning its [`StepReport`].
+///
+/// Phase order: `check` (if present and exit 0 ⇒ [`StepStatus::AlreadyDone`]) →
+/// `apply` (feeding `stdin`) → `verify` (if present). Any phase that fails to
+/// launch, or exits non-zero on `apply`/`verify`, yields [`StepStatus::Failed`]
+/// with a diagnostic that never includes a secret payload.
+pub fn execute_step(runner: &dyn CommandRunner, step: &Step) -> StepReport {
+    let report = |status| StepReport {
+        name: step.name.clone(),
+        summary: step.summary.clone(),
+        status,
+    };
+
+    // 1. check — is it already done?
+    if let Some(check) = &step.check {
+        match runner.run(check, None) {
+            Ok(out) if out.ok() => return report(StepStatus::AlreadyDone),
+            Ok(_) => { /* not done — fall through to apply */ }
+            Err(e) => return report(StepStatus::Failed(format!("check phase could not run: {e}"))),
+        }
+    }
+
+    // 2. apply
+    let stdin = step.stdin.as_ref().map(|p| p.content.as_str());
+    match runner.run(&step.apply, stdin) {
+        Ok(out) if out.ok() => { /* applied — verify next */ }
+        Ok(out) => {
+            return report(StepStatus::Failed(format!(
+                "apply exited {}: {}",
+                out.code,
+                tail_stderr(&out.stderr)
+            )))
+        }
+        Err(e) => return report(StepStatus::Failed(format!("apply phase could not run: {e}"))),
+    }
+
+    // 3. verify
+    if let Some(verify) = &step.verify {
+        match runner.run(verify, None) {
+            Ok(out) if out.ok() => {}
+            Ok(out) => {
+                return report(StepStatus::Failed(format!(
+                    "verify exited {}: {}",
+                    out.code,
+                    tail_stderr(&out.stderr)
+                )))
+            }
+            Err(e) => {
+                return report(StepStatus::Failed(format!("verify phase could not run: {e}")))
+            }
+        }
+    }
+
+    report(StepStatus::Changed)
+}
+
+/// Execute a whole [`Plan`] against `runner`, halting at the first failed step
+/// (so a broken host does not cascade half-applied steps). Returns the reports
+/// gathered up to and including the halting step — every remaining entry is left
+/// unreported, and the caller surfaces the failure.
+pub fn execute_plan(runner: &dyn CommandRunner, plan: &Plan) -> Vec<StepReport> {
+    let mut reports = Vec::with_capacity(plan.entries.len());
+    for entry in &plan.entries {
+        match entry {
+            PlanEntry::Skip {
+                name,
+                summary,
+                reason,
+            } => {
+                reports.push(StepReport {
+                    name: name.clone(),
+                    summary: summary.clone(),
+                    status: StepStatus::Skipped(reason.clone()),
+                });
+            }
+            PlanEntry::Step(step) => {
+                let report = execute_step(runner, step);
+                let failed = report.status.is_failure();
+                reports.push(report);
+                if failed {
+                    break;
+                }
+            }
+        }
+    }
+    reports
+}
+
+/// Render the per-step checklist from a set of [`StepReport`]s (AC: a re-run
+/// "reports unchanged steps"). Human-readable, one line per step.
+#[must_use]
+pub fn render_checklist(host: &str, reports: &[StepReport]) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("fleet add-worker checklist for {host}:\n"));
+    for (i, r) in reports.iter().enumerate() {
+        let n = i + 1;
+        let mark = match r.status {
+            StepStatus::AlreadyDone => "=",
+            StepStatus::Changed => "+",
+            StepStatus::Skipped(_) => "-",
+            StepStatus::Failed(_) => "x",
+        };
+        out.push_str(&format!("  {mark} {n:>2}. [{}] {} ({})", r.name, r.summary, r.status.tag()));
+        match &r.status {
+            StepStatus::Skipped(reason) => out.push_str(&format!(" — {reason}")),
+            StepStatus::Failed(diag) => out.push_str(&format!(" — {diag}")),
+            _ => {}
+        }
+        out.push('\n');
+    }
+    out
+}
+
+/// Whether the reports represent a fully-successful run (no failed step, and
+/// every non-skip entry was reported — i.e. the plan did not halt early).
+#[must_use]
+pub fn all_succeeded(reports: &[StepReport], plan: &Plan) -> bool {
+    reports.len() == plan.entries.len() && !reports.iter().any(|r| r.status.is_failure())
+}
+
+/// Trim a stderr blob to its last non-empty line (bounded), so a diagnostic
+/// stays one line and never dumps a multi-KB build log into the checklist.
+fn tail_stderr(stderr: &str) -> String {
+    let line = stderr
+        .lines()
+        .rev()
+        .find(|l| !l.trim().is_empty())
+        .unwrap_or("")
+        .trim();
+    if line.len() > 200 {
+        format!("{}…", &line[..200])
+    } else {
+        line.to_string()
+    }
+}
+
+// ===========================================================================
+// Fleet registry (`~/.loom/fleet.json`)
+// ===========================================================================
+
+/// Environment override for the fleet-registry file location (mirrors
+/// [`crate::workspace_registry::REGISTRY_PATH_ENV`]). Primarily a test seam.
+pub const FLEET_REGISTRY_PATH_ENV: &str = "LOOM_FLEET_PATH";
+
+/// Current on-disk schema version for the fleet registry.
+pub const FLEET_REGISTRY_VERSION: u32 = 1;
+
+/// The outcome of the most recent `verify` step for a worker.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerifyResult {
+    /// Whether the verify phase passed.
+    pub ok: bool,
+    /// RFC3339 timestamp of the verification.
+    pub at: String,
+    /// One-line human summary (e.g. `"daemon running, 7 tokens ranked"`).
+    pub summary: String,
+}
+
+/// One bootstrapped worker's inventory record. Kept deliberately minimal — the
+/// sibling `fleet status`/`fleet drain` commands (#4342/#4343) can extend it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkerRecord {
+    /// The SSH alias/host used to reach the worker (the canonical key — two
+    /// records with the same `ssh_host` are deduplicated on upsert).
+    pub ssh_host: String,
+    /// The workspace repos registered on the worker (as passed to `--repo`).
+    #[serde(default)]
+    pub repos: Vec<String>,
+    /// The dispatch priority the workspaces were registered at.
+    #[serde(default = "crate::workspace_registry::default_priority")]
+    pub priority: u32,
+    /// RFC3339 timestamp of the most recent successful bootstrap.
+    pub bootstrapped_at: String,
+    /// Result of the last `verify` step, if one ran.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_verify: Option<VerifyResult>,
+}
+
+/// The machine-level set of bootstrapped workers, persisted at
+/// `~/.loom/fleet.json`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetRegistry {
+    /// On-disk schema version.
+    #[serde(default = "default_fleet_version")]
+    pub version: u32,
+    /// Bootstrapped workers, in insertion order.
+    #[serde(default)]
+    pub workers: Vec<WorkerRecord>,
+}
+
+fn default_fleet_version() -> u32 {
+    FLEET_REGISTRY_VERSION
+}
+
+impl Default for FleetRegistry {
+    fn default() -> Self {
+        Self {
+            version: FLEET_REGISTRY_VERSION,
+            workers: Vec::new(),
+        }
+    }
+}
+
+/// Resolve the fleet-registry file path: honour [`FLEET_REGISTRY_PATH_ENV`]
+/// first, else `~/.loom/fleet.json`.
+pub fn default_fleet_registry_path() -> Result<PathBuf> {
+    if let Ok(path) = std::env::var(FLEET_REGISTRY_PATH_ENV) {
+        if !path.is_empty() {
+            return Ok(PathBuf::from(path));
+        }
+    }
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("no home directory"))?;
+    Ok(home.join(".loom").join("fleet.json"))
+}
+
+impl FleetRegistry {
+    /// Load the registry from `path`. A missing or empty file yields an empty
+    /// registry; a present-but-unparseable file is an error so a corrupted
+    /// registry is loud rather than silently reset (mirrors
+    /// [`crate::workspace_registry::WorkspaceRegistry::load`]).
+    pub fn load(path: &Path) -> Result<Self> {
+        match std::fs::read_to_string(path) {
+            Ok(contents) => {
+                if contents.trim().is_empty() {
+                    return Ok(Self::default());
+                }
+                let registry: Self = serde_json::from_str(&contents)
+                    .with_context(|| format!("parsing fleet registry at {}", path.display()))?;
+                Ok(registry)
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => {
+                Err(e).with_context(|| format!("reading fleet registry at {}", path.display()))
+            }
+        }
+    }
+
+    /// Load from the default registry path ([`default_fleet_registry_path`]).
+    pub fn load_default() -> Result<Self> {
+        Self::load(&default_fleet_registry_path()?)
+    }
+
+    /// Persist the registry to `path` atomically (temp file + rename), creating
+    /// the parent directory if needed.
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating fleet registry dir {}", parent.display()))?;
+        }
+        let mut json = serde_json::to_string_pretty(self)?;
+        json.push('\n');
+        let tmp = path.with_extension(format!("json.tmp.{}", std::process::id()));
+        std::fs::write(&tmp, json.as_bytes())
+            .with_context(|| format!("writing temp fleet registry {}", tmp.display()))?;
+        std::fs::rename(&tmp, path)
+            .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))?;
+        Ok(())
+    }
+
+    /// Persist to the default registry path.
+    pub fn save_default(&self) -> Result<()> {
+        self.save(&default_fleet_registry_path()?)
+    }
+
+    /// Insert or replace the record for `record.ssh_host` (dedup on the SSH
+    /// alias — a re-bootstrap updates the existing record in place rather than
+    /// duplicating it). Returns `true` when an existing record was replaced,
+    /// `false` when a new one was inserted.
+    pub fn upsert(&mut self, record: WorkerRecord) -> bool {
+        if let Some(existing) = self
+            .workers
+            .iter_mut()
+            .find(|w| w.ssh_host == record.ssh_host)
+        {
+            *existing = record;
+            true
+        } else {
+            self.workers.push(record);
+            false
+        }
+    }
+
+    /// The record for `ssh_host`, if present.
+    #[must_use]
+    pub fn get(&self, ssh_host: &str) -> Option<&WorkerRecord> {
+        self.workers.iter().find(|w| w.ssh_host == ssh_host)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    // ---- Mock command runner -------------------------------------------
+
+    /// A scripted [`CommandRunner`]: each `run` pops the next canned
+    /// [`CommandOutput`] and records the `(shell, stdin)` it was asked to run,
+    /// so tests can assert on both ordering/idempotency and secret handling.
+    struct MockRunner {
+        responses: RefCell<Vec<CommandOutput>>,
+        calls: RefCell<Vec<(String, Option<String>)>>,
+    }
+
+    impl MockRunner {
+        fn new(responses: Vec<CommandOutput>) -> Self {
+            Self {
+                responses: RefCell::new(responses),
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn calls(&self) -> Vec<(String, Option<String>)> {
+            self.calls.borrow().clone()
+        }
+    }
+
+    impl CommandRunner for MockRunner {
+        fn run(&self, shell: &str, stdin: Option<&str>) -> Result<CommandOutput> {
+            self.calls
+                .borrow_mut()
+                .push((shell.to_string(), stdin.map(str::to_string)));
+            let mut r = self.responses.borrow_mut();
+            if r.is_empty() {
+                Ok(CommandOutput {
+                    code: 0,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                })
+            } else {
+                Ok(r.remove(0))
+            }
+        }
+    }
+
+    fn ok() -> CommandOutput {
+        CommandOutput {
+            code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        }
+    }
+    fn nonzero(code: i32, stderr: &str) -> CommandOutput {
+        CommandOutput {
+            code,
+            stdout: String::new(),
+            stderr: stderr.to_string(),
+        }
+    }
+
+    // ---- execute_step --------------------------------------------------
+
+    #[test]
+    fn check_pass_reports_already_done_without_applying() {
+        // check exits 0 → apply must NOT run.
+        let runner = MockRunner::new(vec![ok()]);
+        let step = Step::new("s", "summary", Some("check-cmd".into()), "apply-cmd".into());
+        let report = execute_step(&runner, &step);
+        assert_eq!(report.status, StepStatus::AlreadyDone);
+        // Only the check ran.
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "check-cmd");
+    }
+
+    #[test]
+    fn check_fail_then_apply_reports_changed() {
+        // check exits non-zero → apply runs and succeeds.
+        let runner = MockRunner::new(vec![nonzero(1, ""), ok()]);
+        let step = Step::new("s", "summary", Some("check-cmd".into()), "apply-cmd".into());
+        let report = execute_step(&runner, &step);
+        assert_eq!(report.status, StepStatus::Changed);
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[1].0, "apply-cmd");
+    }
+
+    #[test]
+    fn no_check_always_applies() {
+        let runner = MockRunner::new(vec![ok()]);
+        let step = Step::new("s", "summary", None, "apply-cmd".into());
+        let report = execute_step(&runner, &step);
+        assert_eq!(report.status, StepStatus::Changed);
+        assert_eq!(runner.calls().len(), 1);
+    }
+
+    #[test]
+    fn apply_nonzero_reports_failed_with_stderr_tail() {
+        let runner = MockRunner::new(vec![nonzero(2, "line one\nboom: the real error\n")]);
+        let step = Step::new("s", "summary", None, "apply-cmd".into());
+        let report = execute_step(&runner, &step);
+        match report.status {
+            StepStatus::Failed(diag) => {
+                assert!(diag.contains("exited 2"), "diag: {diag}");
+                assert!(diag.contains("boom: the real error"), "diag: {diag}");
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_failure_reports_failed() {
+        // check absent, apply ok, verify non-zero.
+        let runner = MockRunner::new(vec![ok(), nonzero(3, "verify said no")]);
+        let step = Step::new("s", "summary", None, "apply".into()).with_verify("verify".into());
+        let report = execute_step(&runner, &step);
+        assert!(report.status.is_failure());
+    }
+
+    #[test]
+    fn secret_stdin_is_fed_to_apply_only() {
+        let runner = MockRunner::new(vec![ok()]);
+        let step = Step::new("s", "secret step", None, "cat > dest".into()).with_stdin(StepStdin {
+            content: "super-secret-pat".into(),
+            secret: true,
+        });
+        let report = execute_step(&runner, &step);
+        assert_eq!(report.status, StepStatus::Changed);
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].1.as_deref(), Some("super-secret-pat"));
+    }
+
+    // ---- execute_plan / idempotency ------------------------------------
+
+    #[test]
+    fn plan_ordering_is_preserved() {
+        let mut plan = Plan::new();
+        plan.push_step(Step::new("first", "1", None, "a".into()));
+        plan.push_step(Step::new("second", "2", None, "b".into()));
+        plan.push_step(Step::new("third", "3", None, "c".into()));
+        let runner = MockRunner::new(vec![ok(), ok(), ok()]);
+        let reports = execute_plan(&runner, &plan);
+        let names: Vec<_> = reports.iter().map(|r| r.name.as_str()).collect();
+        assert_eq!(names, vec!["first", "second", "third"]);
+    }
+
+    #[test]
+    fn idempotent_rerun_reports_every_step_unchanged() {
+        // Every step has a check that passes → all AlreadyDone, nothing applied.
+        let mut plan = Plan::new();
+        for i in 0..3 {
+            plan.push_step(Step::new(
+                &format!("s{i}"),
+                "summary",
+                Some(format!("check-{i}")),
+                format!("apply-{i}"),
+            ));
+        }
+        let runner = MockRunner::new(vec![ok(), ok(), ok()]);
+        let reports = execute_plan(&runner, &plan);
+        assert!(reports.iter().all(|r| r.status == StepStatus::AlreadyDone));
+        assert!(all_succeeded(&reports, &plan));
+        // Only the 3 checks ran — zero applies.
+        assert_eq!(runner.calls().len(), 3);
+    }
+
+    #[test]
+    fn plan_halts_on_first_failure() {
+        let mut plan = Plan::new();
+        plan.push_step(Step::new("ok1", "1", None, "a".into()));
+        plan.push_step(Step::new("boom", "2", None, "b".into()));
+        plan.push_step(Step::new("never", "3", None, "c".into()));
+        // first ok, second fails, third should never run.
+        let runner = MockRunner::new(vec![ok(), nonzero(1, "nope")]);
+        let reports = execute_plan(&runner, &plan);
+        assert_eq!(reports.len(), 2, "halts after the failing step");
+        assert_eq!(reports[0].status, StepStatus::Changed);
+        assert!(reports[1].status.is_failure());
+        assert!(!all_succeeded(&reports, &plan));
+    }
+
+    #[test]
+    fn skip_entries_report_skipped_and_do_not_run() {
+        let mut plan = Plan::new();
+        plan.push_step(Step::new("real", "do it", None, "a".into()));
+        plan.push_skip("safehouse", "wire safehouse", "safehouse.enabled is false");
+        let runner = MockRunner::new(vec![ok()]);
+        let reports = execute_plan(&runner, &plan);
+        assert_eq!(reports.len(), 2);
+        assert_eq!(reports[0].status, StepStatus::Changed);
+        match &reports[1].status {
+            StepStatus::Skipped(reason) => assert_eq!(reason, "safehouse.enabled is false"),
+            other => panic!("expected Skipped, got {other:?}"),
+        }
+        // Only the one real step ran on the host.
+        assert_eq!(runner.calls().len(), 1);
+    }
+
+    // ---- rendering -----------------------------------------------------
+
+    #[test]
+    fn dry_run_render_lists_every_entry_and_redacts_secrets() {
+        let mut plan = Plan::new();
+        plan.push_step(
+            Step::new("token-accounts", "install accounts.env", None, "cat > x".into()).with_stdin(
+                StepStdin {
+                    content: "SECRET_TOKEN_VALUE".into(),
+                    secret: true,
+                },
+            ),
+        );
+        plan.push_skip("safehouse", "wire safehouse", "requires #3998");
+        let rendered = plan.render_dry_run("worker-1");
+        assert!(rendered.contains("worker-1"));
+        assert!(rendered.contains("token-accounts"));
+        assert!(rendered.contains("feeds a secret via stdin"));
+        assert!(rendered.contains("SKIP: requires #3998"));
+        // The secret value must never appear in the dry-run output.
+        assert!(!rendered.contains("SECRET_TOKEN_VALUE"));
+    }
+
+    #[test]
+    fn checklist_render_marks_each_status() {
+        let reports = vec![
+            StepReport {
+                name: "a".into(),
+                summary: "A".into(),
+                status: StepStatus::AlreadyDone,
+            },
+            StepReport {
+                name: "b".into(),
+                summary: "B".into(),
+                status: StepStatus::Changed,
+            },
+            StepReport {
+                name: "c".into(),
+                summary: "C".into(),
+                status: StepStatus::Skipped("requires #3998".into()),
+            },
+            StepReport {
+                name: "d".into(),
+                summary: "D".into(),
+                status: StepStatus::Failed("apply exited 1: boom".into()),
+            },
+        ];
+        let out = render_checklist("worker-1", &reports);
+        assert!(out.contains("(unchanged)"));
+        assert!(out.contains("(changed)"));
+        assert!(out.contains("(skipped) — requires #3998"));
+        assert!(out.contains("(FAILED) — apply exited 1: boom"));
+    }
+
+    #[test]
+    fn secret_stdin_debug_is_redacted() {
+        let s = StepStdin {
+            content: "hunter2".into(),
+            secret: true,
+        };
+        let dbg = format!("{s:?}");
+        assert!(!dbg.contains("hunter2"));
+        assert!(dbg.contains("<redacted>"));
+        // A non-secret payload is shown.
+        let plain = StepStdin {
+            content: "visible".into(),
+            secret: false,
+        };
+        assert!(format!("{plain:?}").contains("visible"));
+    }
+
+    // ---- fleet registry ------------------------------------------------
+
+    fn record(host: &str) -> WorkerRecord {
+        WorkerRecord {
+            ssh_host: host.to_string(),
+            repos: vec!["rjwalters/anvil".to_string()],
+            priority: 50,
+            bootstrapped_at: "2026-07-28T00:00:00Z".to_string(),
+            last_verify: None,
+        }
+    }
+
+    #[test]
+    fn registry_load_missing_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fleet.json");
+        let reg = FleetRegistry::load(&path).unwrap();
+        assert!(reg.workers.is_empty());
+        assert_eq!(reg.version, FLEET_REGISTRY_VERSION);
+    }
+
+    #[test]
+    fn registry_load_corrupt_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fleet.json");
+        std::fs::write(&path, "{ not json").unwrap();
+        assert!(FleetRegistry::load(&path).is_err());
+    }
+
+    #[test]
+    fn registry_upsert_dedups_on_ssh_host() {
+        let mut reg = FleetRegistry::default();
+        assert!(!reg.upsert(record("worker-1")), "first insert is new");
+        assert!(reg.upsert(record("worker-1")), "second is a replace");
+        assert_eq!(reg.workers.len(), 1);
+
+        assert!(!reg.upsert(record("worker-2")));
+        assert_eq!(reg.workers.len(), 2);
+    }
+
+    #[test]
+    fn registry_upsert_replaces_in_place() {
+        let mut reg = FleetRegistry::default();
+        reg.upsert(record("worker-1"));
+        let mut updated = record("worker-1");
+        updated.priority = 3;
+        updated.last_verify = Some(VerifyResult {
+            ok: true,
+            at: "2026-07-28T01:00:00Z".to_string(),
+            summary: "daemon running".to_string(),
+        });
+        reg.upsert(updated);
+        assert_eq!(reg.workers.len(), 1);
+        let got = reg.get("worker-1").unwrap();
+        assert_eq!(got.priority, 3);
+        assert!(got.last_verify.as_ref().unwrap().ok);
+    }
+
+    #[test]
+    fn registry_save_load_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("fleet.json");
+        let mut reg = FleetRegistry::default();
+        reg.upsert(record("worker-1"));
+        reg.save(&path).unwrap();
+        assert!(path.exists());
+
+        let loaded = FleetRegistry::load(&path).unwrap();
+        assert_eq!(loaded, reg);
+        // No stray temp file left behind.
+        let leftovers: Vec<_> = std::fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .filter_map(std::result::Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+            .collect();
+        assert!(leftovers.is_empty());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn default_registry_path_honours_env_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let custom = dir.path().join("custom-fleet.json");
+        std::env::set_var(FLEET_REGISTRY_PATH_ENV, &custom);
+        let resolved = default_fleet_registry_path().unwrap();
+        std::env::remove_var(FLEET_REGISTRY_PATH_ENV);
+        assert_eq!(resolved, custom);
+    }
+
+    #[test]
+    fn registry_legacy_record_without_priority_parses_as_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fleet.json");
+        std::fs::write(
+            &path,
+            r#"{ "version": 1, "workers": [ { "ssh_host": "w1", "bootstrapped_at": "t" } ] }"#,
+        )
+        .unwrap();
+        let reg = FleetRegistry::load(&path).unwrap();
+        assert_eq!(reg.workers.len(), 1);
+        assert_eq!(reg.workers[0].priority, crate::workspace_registry::DEFAULT_WORKSPACE_PRIORITY);
+        assert!(reg.workers[0].repos.is_empty());
+    }
+}

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -24,6 +24,7 @@ pub mod epic_state;
 pub mod epic_supervisor;
 pub mod errors;
 pub mod event_bus;
+pub mod fleet;
 pub mod forge_parser;
 pub mod git_parser;
 pub mod git_utils;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -146,6 +146,18 @@ enum Commands {
         action: WorkspaceAction,
     },
 
+    /// Operator-triggered multi-host worker fanout (epic #4340). `fleet
+    /// add-worker <ssh-host> --repo <repo>` takes a reachable, already-provisioned
+    /// Ubuntu host to "daemon running, workspace registered, tokens ranked,
+    /// dispatch verified" in one idempotent command, over ssh. Generic VM
+    /// provisioning stays in `repo:remote` — this consumes a reachable box + an
+    /// SSH alias, it never wrangles a cloud CLI. The bootstrap is an ordered,
+    /// idempotent plan; `--dry-run` prints it without touching the host.
+    Fleet {
+        #[command(subcommand)]
+        action: FleetAction,
+    },
+
     /// Manage insta-crash quarantines (Issue #3939): the in-memory pauses the
     /// daemon applies to issues whose sweeps insta-crash repeatedly. Connects to
     /// the running daemon over its Unix socket, since the quarantine state lives
@@ -317,6 +329,63 @@ enum WorkspaceAction {
         /// Emit machine-readable JSON instead of the human-readable table.
         #[arg(long)]
         json: bool,
+    },
+}
+
+/// Sub-actions for `loom-daemon fleet` (epic #4340).
+#[derive(Subcommand)]
+enum FleetAction {
+    /// Bootstrap a provisioned host into a working loom worker (issue #4341).
+    /// Runs an ordered, idempotent plan over `ssh <ssh-host>`: base deps, the
+    /// machine-level loom-daemon build, Claude Code, forge auth, the full token
+    /// pool, workspace clone + registration, a systemd --user daemon unit, an
+    /// optional idle-shutdown guard, and a verify step. Secrets (PAT,
+    /// accounts.env) travel only over ssh stdin, never a command line.
+    AddWorker {
+        /// SSH alias/host to reach the worker (from `repo:remote` or operator
+        /// supplied).
+        #[arg(value_name = "SSH_HOST")]
+        ssh_host: String,
+
+        /// Workspace repo(s) to clone + register on the worker (`owner/name`).
+        /// Repeat for several repos. At least one is required.
+        #[arg(long, value_name = "OWNER/NAME", required = true)]
+        repo: Vec<String>,
+
+        /// Cross-repo dispatch priority the workspaces are registered at (#3946;
+        /// lower = higher priority). Defaults to 100.
+        #[arg(long, value_name = "N", default_value_t = loom_daemon::workspace_registry::DEFAULT_WORKSPACE_PRIORITY)]
+        priority: u32,
+
+        /// Local path to the operator's fine-grained forge PAT (Contents+Issues+PRs
+        /// on the target repos). Read locally at preflight; transferred to the
+        /// worker only via ssh stdin. Omit to skip forge auth (skip-with-notice).
+        #[arg(long, value_name = "PATH")]
+        pat_file: Option<String>,
+
+        /// Local path to the operator's `accounts.env` (the full token pool).
+        /// Read locally at preflight; transferred to the worker only via ssh
+        /// stdin. Omit to skip token-pool provisioning (skip-with-notice).
+        #[arg(long, value_name = "PATH")]
+        accounts_env: Option<String>,
+
+        /// Upstream Loom repo URL cloned to the worker's machine-level layout.
+        #[arg(long, value_name = "URL", default_value = loom_daemon::fleet::add_worker::DEFAULT_LOOM_REPO_URL)]
+        loom_repo: String,
+
+        /// Wire safehouse fleet-comms on the worker. Config-gated: skip-with-notice
+        /// until #3998 (the safehoused provisioning fragment) lands.
+        #[arg(long)]
+        safehouse: bool,
+
+        /// Install an idle-shutdown cron guard that powers the host off after
+        /// this many idle minutes (skipping while claude / loom-daemon work).
+        #[arg(long, value_name = "MINUTES")]
+        idle_shutdown_minutes: Option<u32>,
+
+        /// Print the ordered plan without contacting the host.
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -1750,6 +1819,7 @@ fn handle_cli_command(command: Commands) -> Result<()> {
             format,
         } => handle_stats_command(role.as_deref(), issue, weekly, &format),
         Commands::Workspace { action } => handle_workspace_command(action),
+        Commands::Fleet { action } => handle_fleet_command(action),
         Commands::Tokens { action } => handle_tokens_command(action),
         Commands::UpdateGitignore { workspace } => handle_update_gitignore_command(&workspace),
         Commands::Status { .. } => {
@@ -3996,6 +4066,40 @@ fn print_agent_effectiveness(agent: &activity::AgentEffectiveness) {
 /// This runs whether or not the daemon is up; a running daemon re-reads the
 /// same file on its next tick (hot-apply), and its `RegisterWorkspace` /
 /// `DeregisterWorkspace` / `ListWorkspaces` IPC handlers touch the same file.
+/// Handle `loom-daemon fleet …` (epic #4340). Thin clap→module wiring: all
+/// bootstrap logic (the step planner/executor, shell templates, fleet registry)
+/// lives in [`loom_daemon::fleet`].
+fn handle_fleet_command(action: FleetAction) -> Result<()> {
+    use loom_daemon::fleet::add_worker::{self, AddWorkerConfig};
+
+    match action {
+        FleetAction::AddWorker {
+            ssh_host,
+            repo,
+            priority,
+            pat_file,
+            accounts_env,
+            loom_repo,
+            safehouse,
+            idle_shutdown_minutes,
+            dry_run,
+        } => {
+            let config = AddWorkerConfig {
+                ssh_host,
+                repos: repo,
+                priority,
+                dry_run,
+                loom_repo_url: loom_repo,
+                pat_file: pat_file.map(PathBuf::from),
+                accounts_env_file: accounts_env.map(PathBuf::from),
+                safehouse_enabled: safehouse,
+                idle_shutdown_minutes,
+            };
+            add_worker::run(&config)
+        }
+    }
+}
+
 fn handle_workspace_command(action: WorkspaceAction) -> Result<()> {
     use loom_daemon::workspace_registry::{AddOutcome, WorkspaceRegistry};
 


### PR DESCRIPTION
## Summary

Adds `loom-daemon fleet add-worker <ssh-host> --repo <owner/name> [--repo …]` — the first child of epic #4340. It takes a reachable, already-provisioned Ubuntu host to "daemon running, workspace registered, tokens ranked, dispatch verified" in one **idempotent** command over `ssh`. Generic VM provisioning stays in `repo:remote` per the epic's boundary decision; this consumes "a reachable box + an SSH alias".

The bootstrap is modeled as an ordered **plan** of named steps, each with a `check` (already done?) → `apply` → `verify` shape. Rust owns the plan/ordering/checklist; the per-phase shell is rendered as heredoc templates and executed over a `CommandRunner` trait — the production `SshRunner`, or a mocked runner in tests (no live box needed). `--dry-run` prints the full plan without contacting the host.

## Changes

- **`loom-daemon/src/fleet/mod.rs`** (new) — module root: the `CommandRunner` seam, the `Step`/`Plan`/`PlanEntry` model, `execute_step`/`execute_plan` (halt-on-first-failure), checklist + dry-run rendering, and the machine-level `FleetRegistry` (`~/.loom/fleet.json`, `LOOM_FLEET_PATH` override, atomic save, dedup-on-ssh-host upsert) following `workspace_registry.rs` conventions.
- **`loom-daemon/src/fleet/add_worker.rs`** (new) — `SshRunner`, `AddWorkerConfig`, local secrets preflight, the pure `build_plan`, the heredoc shell templates for each step, and the `run` orchestration (preflight → plan → dry-run/execute → checklist → fleet-registry upsert).
- **`loom-daemon/src/main.rs`** — thin clap wiring: a `Fleet` command + `FleetAction::AddWorker` subcommand and a `handle_fleet_command` dispatch arm (all logic stays in the module).
- **`loom-daemon/src/lib.rs`** — register the `fleet` module.
- **`defaults/docs/daemon-reference.md`** — document the `fleet add-worker` surface (new "Fleet" section; no CLAUDE.md change, budget check passes at 312/320).

The 8 pilot steps are encoded as 13 plan entries (base-deps incl. **libsqlite3-dev** per safehouse#38, machine-layout, claude-code, forge-auth, token-accounts/pool/ranking, workspace-clone, workspace-register, daemon-unit, idle-shutdown, safehouse, verify).

## Acceptance Criteria Verification

- [x] **One command takes a fresh Ubuntu box to "daemon running, workspace registered, tokens ranked, dispatch verified"** — the ordered plan does exactly this; the `verify` step confirms status/ranking/registration from the workspace cwd.
- [x] **Idempotent re-run** — each step's `check` phase reports `unchanged` (test: `idempotent_rerun_reports_every_step_unchanged`).
- [x] **Secrets only as 0600 files on the host, never in images/command lines** — PAT + accounts.env read at local preflight, transferred only over ssh stdin (`StepStdin { secret: true }`, redacted in dry-run/Debug); `token-accounts` writes with `umask 077` + `chmod 600`. Missing/empty secret files fail preflight before any remote action. Nothing auto-provisions cloud resources.
- [x] **Known-workaround marked with its tracking issue** — the systemd unit `WorkingDirectory=` pin carries a `#4292` marker (test: `daemon_unit_pins_workingdirectory_with_4292_marker`). No interim #4228 (Python/pip) or #4299 (single-repo cwd) steps appear (test: `no_python_loom_tools_or_pip_step_anywhere`).

## Test Plan

- [x] **Automated** — 38 unit tests in the `fleet` module (mocked command runner) cover step ordering, idempotency classification (done/changed/failed), secrets-over-stdin + preflight failure, skip-with-notice branches, the #4292 marker, and dry-run/checklist rendering. `cargo test -p loom-daemon --lib fleet::` → 38 passed. `cargo clippy --all-targets` and `cargo fmt --check` clean.
- [x] **Manual** — `loom-daemon fleet add-worker loom-worker-1 --repo rjwalters/anvil --repo rjwalters/kicad-tools --priority 20 --idle-shutdown-minutes 30 --dry-run` prints the full ordered 13-step plan (secret-less steps shown as skip-with-notice) without contacting the host.
- [ ] **Live** — full run against a fresh Ubuntu 24.04 box (operator-run, matches the pilot) — not runnable in CI without a live SSH host.

Part of #4340
Closes #4341

🤖 Generated with [Claude Code](https://claude.com/claude-code)