### PR TITLE
fix(scripts): default loom-daemon-update.sh to ff-first sync before building

### DIFF
--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -14,11 +14,22 @@
 # `loom-daemon --version`) against the LOCAL source tree's current HEAD short
 # commit. This answers the directly actionable question — "would rebuilding
 # right now produce a different binary?" — without touching the network.
-# Secondary (advisory only, never gates the rebuild): a bounded, best-effort
-# check of how far local HEAD is behind origin/<default-branch>, mirroring
-# check-main-freshness.sh's pattern, so an operator running this cron-style
-# learns "you're up to date with local HEAD, but HEAD itself is behind
-# origin" instead of being told nothing needs doing.
+#
+# Checkout freshness (default, ff-first — #4330): the whole point of running
+# this script is to get the daemon onto the LATEST code, so before resolving
+# the local HEAD used for the staleness comparison above, this script attempts
+# a bounded, best-effort `git fetch` of origin/<default-branch> and, if local
+# HEAD is behind, a `git merge --ff-only`. On success the rebuild below builds
+# the freshly-synced HEAD. If the ff-merge cannot apply (diverged local
+# commits, or a dirty tracked file conflicts with the incoming change) the
+# script ABORTS (exit 1) rather than guessing or hard-resetting — a stale
+# rebuild silently missing merged commits (the 2026-07-29 incident this issue
+# closes) is worse than a loud abort asking the operator to resolve it by
+# hand. A fetch failure/timeout (offline, network degraded) is NOT treated as
+# "behind" — the script warns and proceeds with local HEAD as-is, so this
+# check never makes the script hard-network-dependent. `--allow-stale`
+# restores the pre-#4330 build-what's-here behavior (skips the fetch+merge
+# entirely) for deliberate use (bisecting, testing a local patch) — see below.
 #
 # It:
 #   - detects whether the resolved binary is stale vs. the local source tree,
@@ -90,6 +101,7 @@
 #   ./.loom/scripts/cli/loom-daemon-update.sh --force       Rebuild + provision + restart even if already up to date
 #   ./.loom/scripts/cli/loom-daemon-update.sh --no-restart  Rebuild + provision only; leave the running daemon untouched
 #   ./.loom/scripts/cli/loom-daemon-update.sh --relaunch    Launchd/systemd only: after a refused restart, re-render the plist/unit and relaunch under supervision (SIGTERMs the daemon so sweep children reparent; preserves the live LOOM_* env)
+#   ./.loom/scripts/cli/loom-daemon-update.sh --allow-stale Skip the default ff-first sync with origin/<default-branch> and build the current (possibly stale) checkout as-is (#4330) — for deliberate use: bisecting, testing a local patch
 #   ./.loom/scripts/cli/loom-daemon-update.sh --help
 #
 # Environment:
@@ -144,7 +156,12 @@
 #
 # Exit codes:
 #   0  up to date (no-op) OR rebuild+provision+restart succeeded
-#   1  usage error / not a source checkout / build or provision failure
+#   1  usage error / not a source checkout / build or provision failure /
+#      the default ff-first sync with origin/<default-branch> could not apply
+#      (diverged local commits, a dirty tracked file conflicting with the
+#      incoming change, or HEAD is not on <default-branch>) — the script
+#      NEVER guesses or hard-resets; resolve manually or pass --allow-stale
+#      (#4330)
 #   3  (--check only) update available
 #   4  build verification FAILED: the freshly-built binary's embedded commit
 #      does not match the source HEAD it was built from. This is a BUILD-SYSTEM
@@ -276,6 +293,7 @@ FORCE=false
 CHECK_ONLY=false
 NO_RESTART=false
 RELAUNCH=false
+ALLOW_STALE=false
 [[ "${LOOM_DAEMON_UPDATE_RELAUNCH:-}" =~ ^(1|true|yes)$ ]] && RELAUNCH=true
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -285,6 +303,7 @@ while [[ $# -gt 0 ]]; do
         --check) CHECK_ONLY=true; shift ;;
         --no-restart) NO_RESTART=true; shift ;;
         --relaunch) RELAUNCH=true; shift ;;
+        --allow-stale) ALLOW_STALE=true; shift ;;
         *) err "Unknown option '$1'"; echo "Use --help for usage" >&2; exit 1 ;;
     esac
 done
@@ -350,6 +369,99 @@ if [[ -z "$START_SCRIPT" || -z "$STOP_SCRIPT" ]]; then
     exit 1
 fi
 
+# ---------- sync with origin/<default-branch> (ff-first default, #4330) ----------
+# Runs BEFORE the staleness detection below resolves SOURCE_COMMIT, so a
+# successful ff-sync is reflected in the rebuild decision (rebuilding the
+# freshly-synced HEAD, not the pre-merge one). Never touches the network or
+# the tree in --check / --dry-run (both are documented "no writes" contracts)
+# or under --allow-stale (today's build-what's-here behavior) — those paths
+# fall through to the read-only advisory branch below instead.
+#
+# Globals set for downstream consumers (staleness echo + the final
+# "installed" summary, AC4):
+#   DEFAULT_BRANCH        resolved default branch name, or "" if unresolvable
+#   ORIGIN_COMMIT         short commit of origin/<DEFAULT_BRANCH> at fetch
+#                         time, or "unknown" if unreachable/unresolvable
+#   ORIGIN_BEHIND_COUNT   commits local <DEFAULT_BRANCH> was behind origin
+#                         BEFORE any sync (0 if unknown or already current)
+#   FF_SYNCED             true if this run fast-forwarded local HEAD
+DEFAULT_BRANCH=""
+ORIGIN_COMMIT="unknown"
+ORIGIN_BEHIND_COUNT=0
+FF_SYNCED=false
+
+sync_with_origin() {
+    local repo_root="$1"
+    # shellcheck disable=SC1091
+    if [[ -r "$SCRIPT_DIR/../lib/default-branch.sh" ]]; then
+        source "$SCRIPT_DIR/../lib/default-branch.sh" 2>/dev/null || return 0
+    else
+        return 0
+    fi
+    declare -F loom_default_branch >/dev/null 2>&1 || return 0
+    DEFAULT_BRANCH="$(cd "$repo_root" && loom_default_branch origin 2>/dev/null)" || { DEFAULT_BRANCH=""; return 0; }
+    [[ -z "$DEFAULT_BRANCH" ]] && return 0
+
+    # Bounded, best-effort fetch — a fetch failure/timeout must NOT make this
+    # script network-dependent: warn and proceed with local HEAD as-is (behind
+    # count stays unknown, not "known stale").
+    local fetch_ok=true
+    if command -v timeout >/dev/null 2>&1; then
+        (cd "$repo_root" && timeout 5 git fetch origin "$DEFAULT_BRANCH" --quiet >/dev/null 2>&1) || fetch_ok=false
+    else
+        (cd "$repo_root" && git fetch origin "$DEFAULT_BRANCH" --quiet >/dev/null 2>&1) || fetch_ok=false
+    fi
+    if [[ "$fetch_ok" == "false" ]]; then
+        warn "note: could not reach origin to check ${DEFAULT_BRANCH} for updates (fetch failed or timed out) — proceeding with local HEAD as-is."
+        return 0
+    fi
+
+    ORIGIN_COMMIT="$(cd "$repo_root" && git rev-parse --short "origin/${DEFAULT_BRANCH}" 2>/dev/null || echo "unknown")"
+
+    local n
+    n="$(cd "$repo_root" && git rev-list --count "${DEFAULT_BRANCH}..origin/${DEFAULT_BRANCH}" 2>/dev/null || echo 0)"
+    [[ "$n" =~ ^[0-9]+$ ]] || n=0
+    ORIGIN_BEHIND_COUNT="$n"
+    [[ "$n" -eq 0 ]] && return 0
+
+    # Read-only modes and --allow-stale never write — just advise, mirroring
+    # the pre-#4330 advisory-only behavior.
+    if [[ "$CHECK_ONLY" == "true" || "$DRY_RUN" == "true" ]]; then
+        warn "note: local ${DEFAULT_BRANCH} is ${n} commit(s) behind origin/${DEFAULT_BRANCH}."
+        return 0
+    fi
+    if [[ "$ALLOW_STALE" == "true" ]]; then
+        warn "note: local ${DEFAULT_BRANCH} is ${n} commit(s) behind origin/${DEFAULT_BRANCH} — building the current (stale) checkout as-is per --allow-stale."
+        return 0
+    fi
+
+    # Default: attempt the ff-sync. Only well-defined when HEAD IS the default
+    # branch — on a feature branch or detached HEAD, `git merge --ff-only
+    # origin/<default>` would merge into the WRONG ref, so refuse instead of
+    # guessing (an operator deliberately elsewhere, e.g. bisecting, is exactly
+    # the --allow-stale use case).
+    local current_branch
+    current_branch="$(cd "$repo_root" && git symbolic-ref --short HEAD 2>/dev/null || true)"
+    if [[ "$current_branch" != "$DEFAULT_BRANCH" ]]; then
+        err "Local ${DEFAULT_BRANCH} is ${n} commit(s) behind origin/${DEFAULT_BRANCH}, but the checkout HEAD is on '${current_branch:-<detached HEAD>}', not '${DEFAULT_BRANCH}' — refusing to guess which branch to sync."
+        err "Check out ${DEFAULT_BRANCH} and re-run, or pass --allow-stale to build the current checkout as-is (e.g. bisecting, testing a local patch)."
+        return 1
+    fi
+
+    echo "Local ${DEFAULT_BRANCH} is ${n} commit(s) behind origin/${DEFAULT_BRANCH} — fast-forwarding before building (default; pass --allow-stale to build the current checkout as-is)..."
+    if ! (cd "$repo_root" && git merge --ff-only "origin/${DEFAULT_BRANCH}" --quiet); then
+        err "Fast-forward merge from origin/${DEFAULT_BRANCH} did not apply — local commits have diverged, or a dirty tracked file conflicts with the incoming change."
+        err "Refusing to guess or hard-reset: resolve manually (rebase/merge by hand), or pass --allow-stale to build the current (stale) checkout as-is."
+        return 1
+    fi
+    ok "Fast-forwarded local ${DEFAULT_BRANCH} to origin/${DEFAULT_BRANCH} (${n} commit(s))."
+    FF_SYNCED=true
+    return 0
+}
+if ! sync_with_origin "$REPO_ROOT"; then
+    exit 1
+fi
+
 # ---------- staleness detection ----------
 DAEMON_BIN=$(locate_daemon_bin "$REPO_ROOT")
 
@@ -367,6 +479,9 @@ echo "Source tree HEAD:  ${SOURCE_COMMIT}"
 if [[ -n "$MACHINE_CHECKOUT" ]]; then
     echo "Source tree:       $REPO_ROOT (machine checkout, LOOM_MACHINE_CHECKOUT)"
 fi
+if [[ "$FF_SYNCED" == "true" ]]; then
+    echo "Source tree:       fast-forwarded to origin/${DEFAULT_BRANCH} before this run (#4330)."
+fi
 
 UPDATE_NEEDED=false
 if [[ -z "$DAEMON_BIN" ]]; then
@@ -379,34 +494,22 @@ elif [[ "$INSTALLED_COMMIT" != "$SOURCE_COMMIT" ]]; then
     UPDATE_NEEDED=true
 fi
 
-# ---------- advisory: local HEAD vs origin/<default-branch> (non-blocking) ----------
-# Never gates the rebuild decision above — purely informational, mirrors
-# check-main-freshness.sh's bounded-fetch pattern.
-advisory_behind_origin() {
-    local repo_root="$1"
-    # shellcheck disable=SC1091
-    if [[ -r "$SCRIPT_DIR/../lib/default-branch.sh" ]]; then
-        source "$SCRIPT_DIR/../lib/default-branch.sh" 2>/dev/null || return 0
+# print_final_installed_line <commit> — the AC4 "final installed line": states
+# the built/installed commit AND whether it matches origin/<default-branch> at
+# build time. Uses ORIGIN_COMMIT resolved by sync_with_origin above (no
+# re-fetch). Prints an honest "unknown" comparison when the default branch or
+# origin commit could not be resolved (offline, no origin remote, etc.) rather
+# than silently omitting the currency claim.
+print_final_installed_line() {
+    local commit="$1"
+    if [[ -z "$DEFAULT_BRANCH" || "$ORIGIN_COMMIT" == "unknown" ]]; then
+        echo "Installed: ${commit} (currency vs origin/<default-branch> unknown — unresolvable or unreachable)"
+    elif [[ "$commit" == "$ORIGIN_COMMIT" ]]; then
+        echo "Installed: ${commit} (matches origin/${DEFAULT_BRANCH})"
     else
-        return 0
-    fi
-    declare -F loom_default_branch >/dev/null 2>&1 || return 0
-    local branch
-    branch="$(cd "$repo_root" && loom_default_branch origin 2>/dev/null)" || return 0
-    [[ -z "$branch" ]] && return 0
-    if command -v timeout >/dev/null 2>&1; then
-        (cd "$repo_root" && timeout 5 git fetch origin "$branch" --quiet >/dev/null 2>&1) || true
-    else
-        (cd "$repo_root" && git fetch origin "$branch" --quiet >/dev/null 2>&1) || true
-    fi
-    local n
-    n="$(cd "$repo_root" && git rev-list --count "${branch}..origin/${branch}" 2>/dev/null || echo 0)"
-    [[ "$n" =~ ^[0-9]+$ ]] || n=0
-    if [[ "$n" -gt 0 ]]; then
-        warn "note: local ${branch} is ${n} commit(s) behind origin/${branch} — rebuilding now will NOT pick those up. Run 'git merge --ff-only origin/${branch}' first if you want them."
+        echo "Installed: ${commit} (origin/${DEFAULT_BRANCH} is at ${ORIGIN_COMMIT} — does NOT match; built from a checkout that was behind or diverged, e.g. --allow-stale)"
     fi
 }
-advisory_behind_origin "$REPO_ROOT"
 
 # ---------- launchd ownership detection (macOS, mirrors loom-daemon-stop.sh #4042) ----------
 # launchd is checked AHEAD of the .loom/.daemon.pid tier because the plist's
@@ -776,6 +879,7 @@ if [[ "$CHECK_ONLY" == "true" ]]; then
         exit 3
     fi
     ok "loom-daemon binary is already up to date with source HEAD (${SOURCE_COMMIT})."
+    print_final_installed_line "$SOURCE_COMMIT"
     exit 0
 fi
 
@@ -786,6 +890,7 @@ fi
 
 if [[ "$UPDATE_NEEDED" == "false" ]]; then
     ok "loom-daemon binary is already up to date with source HEAD (${SOURCE_COMMIT}). Nothing to do."
+    print_final_installed_line "$SOURCE_COMMIT"
     exit 0
 fi
 
@@ -808,6 +913,11 @@ PROVISION_TARGET="${LOOM_DAEMON_BIN:-$DEST_DIR/loom-daemon}"
 
 if [[ "$DRY_RUN" == "true" ]]; then
     echo
+    if [[ "$ALLOW_STALE" == "true" ]]; then
+        echo "[dry-run] --allow-stale given: would build the current checkout as-is (no fetch/ff-merge)."
+    elif [[ -n "$DEFAULT_BRANCH" && "$ORIGIN_BEHIND_COUNT" -gt 0 ]]; then
+        echo "[dry-run] Plan includes fast-forwarding local ${DEFAULT_BRANCH} to origin/${DEFAULT_BRANCH} (${ORIGIN_BEHIND_COUNT} commit(s) behind) before building; would abort instead of building stale if the ff-merge cannot apply."
+    fi
     echo "[dry-run] Would run: (cd $DAEMON_DIR && cargo build --release)"
     echo "[dry-run] Would provision the fresh binary to: $PROVISION_TARGET"
     if [[ "$NO_RESTART" == "true" ]]; then
@@ -955,12 +1065,14 @@ if [[ "$NO_RESTART" == "true" ]]; then
             echo "  $STOP_SCRIPT && $START_SCRIPT ${RESTART_ARGS[*]:-}"
         fi
     fi
+    print_final_installed_line "$BUILT_COMMIT"
     exit 0
 fi
 
 if [[ "$WAS_RUNNING" != "true" ]]; then
     ok "Rebuilt + provisioned. loom-daemon was not running — nothing to restart."
     echo "Start it with: $START_SCRIPT [flags]"
+    print_final_installed_line "$BUILT_COMMIT"
     exit 0
 fi
 
@@ -993,6 +1105,7 @@ if [[ "$DAEMON_MANAGER" == "launchd" ]]; then
 
         if NEW_PID="$(wait_for_new_launchd_pid "$PRE_RESTART_PID" "$RESTART_POLL_SECS" "$RESTART_POLL_INTERVAL")"; then
             ok "loom-daemon restart scheduled — launchd relaunched it onto the freshly-provisioned binary (new pid ${NEW_PID}, verified within ${RESTART_POLL_SECS}s)."
+            print_final_installed_line "$BUILT_COMMIT"
             exit 0
         fi
 
@@ -1003,6 +1116,7 @@ if [[ "$DAEMON_MANAGER" == "launchd" ]]; then
 
         if NEW_PID="$(wait_for_new_launchd_pid "$PRE_RESTART_PID" "$KICKSTART_POLL_SECS" "$RESTART_POLL_INTERVAL")"; then
             ok "loom-daemon restart scheduled — launchd's own relaunch did not occur within ${RESTART_POLL_SECS}s, but the 'launchctl kickstart' fallback relaunched it (new pid ${NEW_PID}, verified within ${KICKSTART_POLL_SECS}s). Remediation note: the kickstart fallback was required (#4232) — investigate why launchd did not relaunch the job on its own."
+            print_final_installed_line "$BUILT_COMMIT"
             exit 0
         fi
 
@@ -1058,6 +1172,7 @@ if [[ "$DAEMON_MANAGER" == "systemd" ]]; then
     echo "(.daemon.flags is NOT consulted — the unit's Environment= lines carry the equivalent config.)"
     if "$PROVISION_TARGET" restart; then
         ok "loom-daemon restart scheduled — systemd will relaunch it onto the freshly-provisioned binary."
+        print_final_installed_line "$BUILT_COMMIT"
         exit 0
     fi
     # The restart request is served by the RUNNING (old) binary. A pre-#4267
@@ -1122,3 +1237,8 @@ if [[ "${#RESTART_ARGS[@]}" -gt 0 ]]; then
 else
     "$START_SCRIPT"
 fi
+START_RC=$?
+if [[ "$START_RC" -eq 0 ]]; then
+    print_final_installed_line "$BUILT_COMMIT"
+fi
+exit "$START_RC"

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -120,6 +120,44 @@ EOF
     ( cd "$root" && git init -q && git -c user.email=test@test -c user.name=test commit -q --allow-empty -m init )
 }
 
+# new_fixture_with_origin <root> <bare_dir> (#4330) — builds on new_fixture(),
+# adding a local BARE repo as `origin` so the ff-first sync path (which
+# resolves the default branch via refs/remotes/origin/HEAD, then fetches and
+# compares against origin/<branch>) has a real remote to talk to — entirely
+# offline (a plain filesystem path, no network). Forces the branch name to
+# `main` (deterministic regardless of the test host's init.defaultBranch) and
+# sets refs/remotes/origin/HEAD via `git remote set-head origin -a` so
+# loom_default_branch() resolves it the same way a real clone would.
+new_fixture_with_origin() {
+    local root="$1" bare="$2"
+    new_fixture "$root"
+    ( cd "$root" && git branch -q -M main )
+    git init -q --bare "$bare"
+    ( cd "$root" && git remote add origin "$bare" && git push -q origin HEAD:refs/heads/main )
+    git -C "$bare" symbolic-ref HEAD refs/heads/main
+    ( cd "$root" && git remote set-head origin -a >/dev/null 2>&1 )
+}
+
+# push_extra_commits_to_origin <bare_dir> <n> — advances the bare `origin`
+# repo `n` commits ahead of whatever a fixture repo's `main` currently is, by
+# cloning it into a throwaway dir, committing there, and pushing back. Echoes
+# the new origin tip's short commit on stdout. The fixture repo passed to
+# new_fixture_with_origin is left untouched (still behind by exactly <n>).
+push_extra_commits_to_origin() {
+    local bare="$1" n="$2" tmpclone
+    tmpclone="$(mktemp -d)"
+    git clone -q "$bare" "$tmpclone"
+    local i
+    for i in $(seq 1 "$n"); do
+        ( cd "$tmpclone" && git -c user.email=test@test -c user.name=test commit -q --allow-empty -m "extra ${i}" )
+    done
+    ( cd "$tmpclone" && git push -q origin HEAD:refs/heads/main )
+    local tip
+    tip="$(cd "$tmpclone" && git rev-parse --short HEAD)"
+    rm -rf "$tmpclone"
+    echo "$tip"
+}
+
 # Writes a fake daemon binary at $1 that reports commit $2 on --version and,
 # on a normal run, appends its inherited LOOM_WORK_FINDER / LOOM_MAIN_HEALTH_GATE
 # to marker file $3 before looping forever (so it stays alive for kill -0).
@@ -1841,6 +1879,242 @@ if grep -q -- '-k' "$W36/launchctl.log" 2>/dev/null; then
 else
     TESTS_PASSED=$((TESTS_PASSED + 1))
     echo -e "${GREEN}✓${NC} exhausted kickstart fallback was still never invoked with -k"
+fi
+
+# ============================================================
+# 37. ff-first default (#4330): local main is behind origin/main with a
+#     CLEAN tree -> the ff-merge applies, and the rebuild below builds the
+#     freshly-synced (post-merge) HEAD, not the stale pre-merge one.
+# ============================================================
+W37="$BASE_WORKDIR/w37"
+BARE37="$BASE_WORKDIR/w37-origin.git"
+new_fixture_with_origin "$W37" "$BARE37"
+ORIGIN_TIP37="$(push_extra_commits_to_origin "$BARE37" 2)"
+NEW_FAKE37="$W37/new-fake-daemon"
+write_fake_daemon "$NEW_FAKE37" "$ORIGIN_TIP37" "$W37/new-marker"
+out37=$( cd "$W37" && PATH="$TEST_PATH" NEW_FAKE_BIN_SRC="$NEW_FAKE37" \
+    bash "$UPDATE_SCRIPT" 2>&1 )
+rc37=$?
+assert_eq "0" "$rc37" "ff-first: behind origin + clean tree -> update succeeds (ff-merge applied)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out37" | grep -qi 'Fast-forwarded'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} ff-first: reports the fast-forward sync"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} ff-first: reports the fast-forward sync"
+    echo "  output: $out37"
+fi
+HEAD_AFTER37="$(cd "$W37" && git rev-parse --short HEAD)"
+assert_eq "$ORIGIN_TIP37" "$HEAD_AFTER37" "ff-first: local HEAD now equals origin tip after the sync"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out37" | grep -qi "Build verification: freshly-built binary embeds source HEAD commit (${ORIGIN_TIP37})"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} ff-first: the rebuild is verified against the POST-merge HEAD, not the stale pre-merge one"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} ff-first: the rebuild is verified against the POST-merge HEAD, not the stale pre-merge one"
+    echo "  output: $out37"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out37" | grep -qE "Installed: ${ORIGIN_TIP37} \(matches origin/main\)"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} final installed line states the built commit AND that it matches origin/main (AC4)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} final installed line states the built commit AND that it matches origin/main (AC4)"
+    echo "  output: $out37"
+fi
+
+# ============================================================
+# 38. ff-first default: local main is behind origin/main AND has a DIVERGED
+#     local commit -> the ff-merge cannot apply -> abort exit 1, no merge, no
+#     build, working tree untouched. Never guesses or hard-resets.
+# ============================================================
+W38="$BASE_WORKDIR/w38"
+BARE38="$BASE_WORKDIR/w38-origin.git"
+new_fixture_with_origin "$W38" "$BARE38"
+push_extra_commits_to_origin "$BARE38" 2 >/dev/null
+# Diverge: a local commit that is NOT on origin (so the merge is not a plain
+# fast-forward — `git merge --ff-only` must refuse).
+( cd "$W38" && git -c user.email=test@test -c user.name=test commit -q --allow-empty -m "local diverged commit" )
+HEAD_BEFORE38="$(cd "$W38" && git rev-parse --short HEAD)"
+out38=$( cd "$W38" && PATH="$TEST_PATH" bash "$UPDATE_SCRIPT" 2>&1 )
+rc38=$?
+assert_eq "1" "$rc38" "ff-first: diverged local commit -> abort exit 1 (never guess or hard-reset)"
+HEAD_AFTER38="$(cd "$W38" && git rev-parse --short HEAD)"
+assert_eq "$HEAD_BEFORE38" "$HEAD_AFTER38" "ff-first: diverged case leaves local HEAD completely untouched"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out38" | grep -qi 'Refusing to guess or hard-reset'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} ff-first: diverged case reports the abort rationale"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} ff-first: diverged case reports the abort rationale"
+    echo "  output: $out38"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -e "$W38/loom-daemon/target/release/loom-daemon" ]]; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} ff-first: diverged case performs no build"
+else
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} ff-first: diverged case performs no build"
+fi
+
+# ============================================================
+# 39. --allow-stale restores the pre-#4330 build-what's-here behavior: the
+#     ff-merge is skipped entirely, the current (stale) checkout is built,
+#     and the behind-origin advisory warning is still printed.
+# ============================================================
+W39="$BASE_WORKDIR/w39"
+BARE39="$BASE_WORKDIR/w39-origin.git"
+new_fixture_with_origin "$W39" "$BARE39"
+push_extra_commits_to_origin "$BARE39" 3 >/dev/null
+HEAD_BEFORE39="$(cd "$W39" && git rev-parse --short HEAD)"
+NEW_FAKE39="$W39/new-fake-daemon"
+write_fake_daemon "$NEW_FAKE39" "$HEAD_BEFORE39" "$W39/new-marker"
+out39=$( cd "$W39" && PATH="$TEST_PATH" NEW_FAKE_BIN_SRC="$NEW_FAKE39" \
+    bash "$UPDATE_SCRIPT" --allow-stale 2>&1 )
+rc39=$?
+assert_eq "0" "$rc39" "--allow-stale: builds the current (stale) checkout, exits 0"
+HEAD_AFTER39="$(cd "$W39" && git rev-parse --short HEAD)"
+assert_eq "$HEAD_BEFORE39" "$HEAD_AFTER39" "--allow-stale: local HEAD is never merged/advanced"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out39" | grep -qi 'behind origin/main.*--allow-stale'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --allow-stale: the behind-origin advisory warning is still printed"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --allow-stale: the behind-origin advisory warning is still printed"
+    echo "  output: $out39"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out39" | grep -qE "Installed: ${HEAD_BEFORE39} \(origin/main is at .* does NOT match"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --allow-stale: final installed line reports the built commit does NOT match origin/main (AC4)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --allow-stale: final installed line reports the built commit does NOT match origin/main (AC4)"
+    echo "  output: $out39"
+fi
+
+# ============================================================
+# 40. --check / --dry-run stay read-only even when behind origin: no fetch
+#     result may write to the tree — HEAD is unchanged after either mode, and
+#     --check reports the behind-origin status informationally while
+#     --dry-run's printed plan mentions the ff-sync.
+# ============================================================
+W40="$BASE_WORKDIR/w40"
+BARE40="$BASE_WORKDIR/w40-origin.git"
+new_fixture_with_origin "$W40" "$BARE40"
+push_extra_commits_to_origin "$BARE40" 1 >/dev/null
+HEAD_BEFORE40="$(cd "$W40" && git rev-parse --short HEAD)"
+out40_check=$( cd "$W40" && PATH="$TEST_PATH" bash "$UPDATE_SCRIPT" --check 2>&1 )
+HEAD_AFTER40_CHECK="$(cd "$W40" && git rev-parse --short HEAD)"
+assert_eq "$HEAD_BEFORE40" "$HEAD_AFTER40_CHECK" "--check while behind origin: HEAD unchanged (no writes contract holds)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out40_check" | grep -qi 'behind origin/main'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --check reports the behind-origin status informationally"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --check reports the behind-origin status informationally"
+    echo "  output: $out40_check"
+fi
+out40_dry=$( cd "$W40" && PATH="$TEST_PATH" bash "$UPDATE_SCRIPT" --dry-run 2>&1 )
+HEAD_AFTER40_DRY="$(cd "$W40" && git rev-parse --short HEAD)"
+assert_eq "$HEAD_BEFORE40" "$HEAD_AFTER40_DRY" "--dry-run while behind origin: HEAD unchanged (no writes contract holds)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out40_dry" | grep -qi 'fast-forward.*origin/main'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --dry-run's printed plan mentions the ff-sync"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --dry-run's printed plan mentions the ff-sync"
+    echo "  output: $out40_dry"
+fi
+
+# ============================================================
+# 41. HEAD on a non-default branch while behind origin -> abort, naming
+#     --allow-stale (an operator deliberately elsewhere — e.g. bisecting — is
+#     exactly the --allow-stale use case, never a guess-which-branch merge).
+# ============================================================
+W41="$BASE_WORKDIR/w41"
+BARE41="$BASE_WORKDIR/w41-origin.git"
+new_fixture_with_origin "$W41" "$BARE41"
+push_extra_commits_to_origin "$BARE41" 1 >/dev/null
+( cd "$W41" && git checkout -q -b feature-branch )
+HEAD_BEFORE41="$(cd "$W41" && git rev-parse --short HEAD)"
+out41=$( cd "$W41" && PATH="$TEST_PATH" bash "$UPDATE_SCRIPT" 2>&1 )
+rc41=$?
+assert_eq "1" "$rc41" "non-default branch while behind -> abort exit 1"
+HEAD_AFTER41="$(cd "$W41" && git rev-parse --short HEAD)"
+assert_eq "$HEAD_BEFORE41" "$HEAD_AFTER41" "non-default branch while behind: HEAD untouched"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out41" | grep -q -- '--allow-stale'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} abort message names --allow-stale as the deliberate escape hatch"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} abort message names --allow-stale as the deliberate escape hatch"
+    echo "  output: $out41"
+fi
+
+# ============================================================
+# 42. Fetch failure (origin unreachable) must NOT make the script
+#     network-dependent: warn and proceed with local HEAD as-is, exactly like
+#     today's behavior — never abort, never hang past the bounded fetch.
+# ============================================================
+W42="$BASE_WORKDIR/w42"
+BARE42="$BASE_WORKDIR/w42-origin.git"
+new_fixture_with_origin "$W42" "$BARE42"
+# refs/remotes/origin/HEAD is now cached locally (set by new_fixture_with_origin
+# above), so loom_default_branch() can still name "main" via its offline,
+# no-network tier even though the URL below makes the ACTUAL fetch fail —
+# isolating "fetch failed" from "branch unresolvable" (test 43 covers the latter).
+( cd "$W42" && git remote set-url origin "$BASE_WORKDIR/does-not-exist-w42.git" )
+HEAD42="$(cd "$W42" && git rev-parse --short HEAD)"
+INSTALLED42="$W42/installed/loom-daemon"
+mkdir -p "$W42/installed"
+write_fake_daemon "$INSTALLED42" "$HEAD42" "$W42/old-marker"
+out42=$( cd "$W42" && PATH="$TEST_PATH" LOOM_DAEMON_BIN="$INSTALLED42" \
+    bash "$UPDATE_SCRIPT" --check 2>&1 )
+rc42=$?
+assert_eq "0" "$rc42" "fetch failure: proceeds as today (installed already matches local HEAD) -> exit 0"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out42" | grep -qi 'could not reach origin'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} fetch failure surfaces a warning instead of aborting"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} fetch failure surfaces a warning instead of aborting"
+    echo "  output: $out42"
+fi
+
+# ============================================================
+# 43. Signaling "unknown currency" honestly: a fixture with NO origin remote
+#     at all (loom_default_branch cannot resolve a default branch) still
+#     completes normally, and the final installed line says so explicitly
+#     rather than silently omitting the currency claim.
+# ============================================================
+W43="$BASE_WORKDIR/w43"
+new_fixture "$W43"
+HEAD43="$(cd "$W43" && git rev-parse --short HEAD)"
+NEW_FAKE43="$W43/new-fake-daemon"
+write_fake_daemon "$NEW_FAKE43" "$HEAD43" "$W43/new-marker"
+out43=$( cd "$W43" && PATH="$TEST_PATH" NEW_FAKE_BIN_SRC="$NEW_FAKE43" \
+    bash "$UPDATE_SCRIPT" 2>&1 )
+rc43=$?
+assert_eq "0" "$rc43" "no origin remote at all: update still succeeds"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out43" | grep -qi 'currency vs origin/<default-branch> unknown'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} final installed line honestly reports unknown currency when origin is unresolvable"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} final installed line honestly reports unknown currency when origin is unresolvable"
+    echo "  output: $out43"
 fi
 
 # ============================================================


### PR DESCRIPTION
## Summary

`loom-daemon-update.sh` used to detect that the local checkout was behind
`origin/<default-branch>`, print an advisory warning, and then build/provision/
restart the daemon from that stale checkout anyway — the exact bug that shipped
a binary missing 5 merged commits (#4322's fix among them) on 2026-07-29. This
PR defaults the script to fast-forwarding the checkout before building, aborts
instead of guessing when the fast-forward can't apply, adds `--allow-stale` to
restore the previous behavior for deliberate use, and makes the final
"installed" summary line state currency against origin explicitly.

## Changes

- `defaults/scripts/cli/loom-daemon-update.sh`:
  - Added `sync_with_origin()`, run **before** `SOURCE_COMMIT` is resolved (so
    a successful sync is reflected in the staleness/rebuild decision, not
    computed against the pre-merge HEAD). Replaces the old advisory-only
    `advisory_behind_origin()`.
  - Default behavior when local `<default-branch>` is behind
    `origin/<default-branch>`: attempt `git merge --ff-only
    origin/<default-branch>`. On success, build the fast-forwarded HEAD.
  - Abort with exit 1 (never guess, never reset/stash) when: the merge can't
    apply as a pure fast-forward (diverged local commits, or a dirty tracked
    file conflicts with the incoming change), or HEAD is on a branch other
    than `<default-branch>` (refuses to guess which branch to sync).
  - A fetch failure/timeout (offline, unreachable origin) is NOT treated as
    "behind" — warns and proceeds with local HEAD as-is, so the script never
    becomes hard-network-dependent.
  - New `--allow-stale` flag: skips the fetch+merge entirely and restores the
    pre-existing build-what's-here behavior (for bisecting / testing a local
    patch), while still printing the behind-origin advisory warning.
  - `--check` reports behind-origin status informationally (no writes);
    `--dry-run`'s printed plan now mentions the ff-sync step (no writes).
  - New `print_final_installed_line()`, called at every success exit path
    (up-to-date no-op, `--no-restart`, not-running, launchd/systemd restart
    success incl. the kickstart fallback, and the PID-file/nohup restart):
    states the built/installed commit and whether it matches
    `origin/<default-branch>` at build time (using the fetch already
    performed — no re-fetch).
  - Updated the leading usage/doc comment banner (`--help` prints it) and the
    exit-code table to document `--allow-stale` and the new abort case.
- `defaults/scripts/tests/test-loom-daemon-update.sh`:
  - Added `new_fixture_with_origin()` / `push_extra_commits_to_origin()`
    fixture helpers (a real local bare-repo `origin`, entirely offline).
  - 23 new assertions (tests 37-43): behind + clean tree → ff-merge applied
    and the rebuild verifies against the post-merge HEAD; behind + diverged
    local commit → abort exit 1, no merge, no build, tree untouched;
    `--allow-stale` → builds the pre-merge HEAD, advisory still printed;
    `--check` / `--dry-run` while behind → HEAD unchanged, plan/status
    reported; HEAD on a non-default branch while behind → abort naming
    `--allow-stale`; fetch failure → warns and proceeds, never aborts; the
    final installed line's match/no-match/unknown-currency wording.

## Acceptance Criteria Verification

- [x] Defaults to bringing the checkout current before building via
      `git merge --ff-only origin/<default-branch>`; on success, builds the
      updated HEAD — verified by test 37 (rebuild verification message names
      the post-merge commit, and `Installed: ... (matches origin/main)`).
- [x] Aborts (never guesses or hard-resets) when the ff-merge cannot apply
      (diverged local commits, or a dirty tracked file conflict) — verified
      by test 38 (exit 1, HEAD byte-identical before/after, no build
      artifact produced).
- [x] `--allow-stale` restores today's build-what's-here behavior for
      deliberate use — verified by test 39 (HEAD never merged, still builds
      and restarts, advisory warning still printed).
- [x] The final "installed" line states the built commit AND whether it
      matches `origin/<default-branch>` at build time — verified by tests
      37/39/43 (match / no-match / unknown-currency wording) across every
      success exit path in the script.

## Test Plan

- [x] `bash defaults/scripts/tests/test-loom-daemon-update.sh` — 106/106
      tests pass (83 pre-existing regression tests + 23 new #4330 tests),
      0 failures.
- [x] `shellcheck` clean on both modified files.
- [x] `bash -n` syntax check passes on both modified files.

Closes #4330