### PR TITLE
fix(gate): classify installed-surface resync output as ignorable dirt

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -660,6 +660,46 @@ The discriminator is deliberately narrow so a genuinely failing build still halt
 **any other non-zero exit is trusted as VERIFIED_RED** — `cargo test`'s 101 for a
 failing test still halts dispatch.
 
+### Dirty-tree ignore classes (#3950, #4332)
+
+`dirty-tree` only fires on **non-ignorable** local changes — `is_ignorable_dirt`
+(`loom-daemon/src/main_health_gate.rs`) excludes several known-safe classes before
+deciding the workspace needs a `Skip`:
+
+| Class | What it covers |
+|-------|-----------------|
+| Loom-owned transient paths (#3778/#3950) | `.loom/sweep-checkpoint/`, `.loom/tokens/`, `.loom/logs/`, `.loom/worktrees/`, … — the daemon's own runtime bookkeeping |
+| Regenerable lockfiles (#3950) | `package-lock.json`, `Cargo.lock`, `pnpm-lock.yaml`, `yarn.lock`, `uv.lock` (matched by basename anywhere in the tree) |
+| Re-stamped install manifest (#4239, #4332) | `.loom/install-metadata.json` exactly — generated + re-stamped by every `resync-installed.sh` run, no `defaults/` source to byte-match against |
+| Installed-surface byte-match (#4332) | `.loom/hooks/`, `.loom/scripts/`, `.loom/roles/`, `.loom/docs/`, `.loom/bin/`, `.claude/commands/loom/` — ignorable **iff** the dirty file's content byte-matches its tracked `defaults/` counterpart in the same worktree (loom-repo-scoped; a consumer repo has no local `defaults/` tree, so this class never applies there) |
+
+The installed-surface class exists because this repo dogfoods its own install:
+`resync-installed.sh` (`.loom/docs/troubleshooting.md` → *Overnight / long-running
+orchestration*) refreshes the tracked `.loom/…` / `.claude/commands/loom/` copies
+from `defaults/…` whenever they drift, and that refresh itself leaves the tree
+dirty until committed. Without this class, every resync produced tracked-file dirt
+the gate could not distinguish from an operator hand-edit, so it skipped every
+cycle as `dirty-tree` — a permanently blinded gate, not a one-off. Byte-matching
+against `defaults/` is the safety property: an operator hand-edit to an installed
+copy cannot byte-match content it was never copied from, so it still reports
+`dirty-tree` as before; only provable resync output is ignored. A `defaults/…`
+SOURCE-side edit is never in this class's domain either way (only the *installed*
+copy maps to its source, not the reverse), so editing `defaults/docs/x.md`
+directly and then resyncing still correctly skips the gate on that edit.
+
+`resync-installed.sh` also prints the exact `git add … && git commit` command in
+its summary when a run leaves the tree dirty with nothing but this kind of resync
+output — worth running so the dirt doesn't linger indefinitely (ignorable ≠
+committed; the gate proceeds either way, but an uncommitted resync is still a
+correctness gap in the repo's history).
+
+`defaults/scripts/check-main-clean.sh` (the sweep-lifecycle backstop for builder
+contamination on `main`, #2802/#3513) deliberately does **not** adopt this
+byte-match class — see the divergence note in its header and in
+`INSTALLED_SURFACE_PREFIXES`'s doc comment. That script protects a different
+property (a builder wrote into the main worktree by mistake) where a byte-match
+could mask a real, if rare, contamination bug.
+
 ### Forge-CI corroboration of a local red
 
 A local run can also fail *because of the host it runs on*: on the incident host

--- a/defaults/scripts/check-main-clean.sh
+++ b/defaults/scripts/check-main-clean.sh
@@ -52,6 +52,18 @@
 #     correctly in its own worktree leaves the main worktree pristine.
 #   - Issue worktrees live under <main>/.loom/worktrees/ which is gitignored, so
 #     their existence does NOT make the main worktree dirty.
+#   - Does NOT adopt the installed-surface byte-match ignore class added to
+#     `main_health_gate.rs`'s `is_ignorable_dirt` (#4332) — a deliberate
+#     divergence, not an oversight. That class exists to protect a *different*
+#     property: "this dirt is provably `resync-installed.sh` output, not an
+#     operator hand-edit worth halting the dispatch gate over." This script's
+#     job is the opposite kind of check — catching a *builder* accidentally
+#     writing into the MAIN worktree instead of its issue worktree (#2802 /
+#     #3513) — and a builder-written file that happens to byte-match
+#     `defaults/` is still a real out-of-worktree write bug the backstop must
+#     not mask. It would also be a no-op in the common case anyway: this
+#     script is the manual/consumer-repo backstop and most consumer installs
+#     have no local `defaults/` tree to byte-match against.
 
 set -euo pipefail
 

--- a/defaults/scripts/resync-installed.sh
+++ b/defaults/scripts/resync-installed.sh
@@ -46,6 +46,15 @@
 # still untracked-and-unignored under .loom/ afterward is reported as an audit
 # warning so the pattern list can be extended.
 #
+# In the loom source repo itself (tracked installed surfaces + a local
+# defaults/ tree), a non-dry-run that updates a file leaves the tree dirty
+# until that resync output is committed. If the only remaining dirt is resync
+# output, the summary block prints the exact `git add … && git commit`
+# command to run (#4332) — worth doing, since `main_health_gate.rs`'s
+# dirty-tree check treats byte-identical installed-surface dirt as ignorable
+# (never a reason to skip the gate) but does not commit on the operator's
+# behalf.
+#
 # EXPLICITLY OUT OF SCOPE (never touched by resync — updated by other mechanisms):
 #   .loom/config.json       - operator-owned; needs merge-semantics design
 #   CLAUDE.md               - repo-customized at install; needs managed-section markers
@@ -590,6 +599,51 @@ audit_untracked_loom_paths() {
     warn "If these are Loom runtime state, add them to EPHEMERAL_PATTERNS (loom-daemon/src/init/post_init.rs)."
 }
 audit_untracked_loom_paths
+
+# ---------- hint: stage + commit resync-only dirt (#4332) ----------
+#
+# In the loom source repo itself (DEFAULTS_DIR resolved locally, i.e. this
+# repo tracks its own installed surfaces under git), a resync that changed
+# tracked files leaves the tree dirty until that dirt is committed — and
+# `main_health_gate.rs`'s dirty-tree check (#4332) only recognizes it as safe
+# *resync* dirt (ignorable, not an operator edit worth halting the gate for),
+# it never commits on the operator's behalf. Print the exact command so this
+# doesn't linger as a standing "not evaluated (dirty-tree)" skip. Cheap and
+# best-effort: only fires when every dirty/untracked path is one this run's
+# surfaces cover (or the re-stamped install-metadata.json); any other dirt
+# (a genuine operator edit) suppresses the hint entirely.
+suggest_commit_if_resync_only_dirt() {
+    [[ "$REPO_ROOT/defaults" == "$DEFAULTS_DIR" ]] || return 0
+    local status
+    status="$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null)"
+    [[ -z "$status" ]] && return 0
+
+    local line path
+    local -a resync_paths=()
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        path="${line:3}"
+        [[ "$path" == *" -> "* ]] && path="${path##* -> }"
+        path="${path%\"}"
+        path="${path#\"}"
+        case "$path" in
+            .loom/hooks/*|.loom/scripts/*|.loom/roles/*|.loom/docs/*|.loom/bin/*|.claude/commands/loom/*|.loom/install-metadata.json)
+                resync_paths+=("$path")
+                ;;
+            *)
+                # Non-resync dirt present — do not suggest a commit that would
+                # also stage an unrelated (possibly operator) change.
+                return 0
+                ;;
+        esac
+    done <<< "$status"
+    [[ "${#resync_paths[@]}" -eq 0 ]] && return 0
+
+    echo ""
+    note "${BLUE}[resync] The tree is dirty with only resync output above — stage and commit it so the main-health gate doesn't skip on it:${NC}"
+    printf '%b\n' "    ${BOLD}git add ${resync_paths[*]} && git commit -m 'chore: resync installed Loom surfaces'${NC}"
+}
+[[ "$DRY_RUN" -eq 1 ]] || suggest_commit_if_resync_only_dirt
 
 # ---------- summary ----------
 

--- a/loom-daemon/src/main_health_gate.rs
+++ b/loom-daemon/src/main_health_gate.rs
@@ -1607,14 +1607,75 @@ const BUILD_ARTIFACT_LOCKFILE_BASENAMES: &[&str] = &[
     "uv.lock",
 ];
 
-/// Whether `path` (a repo-relative path from `git status --porcelain`) is
-/// ignorable dirt for the gate's dirty-tree check — either a Loom-owned
-/// transient path ([`LOOM_OWNED_PREFIXES`]) or a common regenerable lockfile
-/// ([`BUILD_ARTIFACT_LOCKFILE_BASENAMES`]). Ignorable dirt is dirt a hard
-/// reset to `origin/main` safely discards (it is either untracked Loom
-/// runtime state or a tracked file whose content the reset will overwrite
-/// anyway) — never a reason to skip the sync step.
-fn is_ignorable_dirt(path: &str) -> bool {
+/// The daemon's own re-stamped install-manifest (#4239): rewritten by every
+/// `resync-installed.sh` run and has no `defaults/` source counterpart (it is
+/// generated, not copied), so it cannot be classified by the byte-match rule
+/// below — it is ignorable by exact path instead. A hard reset merely reverts
+/// its stamps, which the next resync rewrites anyway.
+const INSTALL_METADATA_PATH: &str = ".loom/install-metadata.json";
+
+/// Installed↔source surface mapping (#4332) for the loom repo's own
+/// dogfooded install: each installed prefix's tracked, edited-upstream
+/// counterpart lives under `defaults/`. Mirrors the exact surface table
+/// `resync-installed.sh` walks (`defaults/scripts/resync-installed.sh`,
+/// search `widened pure-copy surfaces`) — **not** a uniform prefix rewrite:
+/// `.loom/bin/` and `.claude/commands/loom/` map into
+/// `defaults/.loom/bin/` and `defaults/.claude/commands/loom/`
+/// respectively, while the others map straight into `defaults/<name>/`.
+/// Only meaningful in a repo that carries a local `defaults/` tree (the loom
+/// repo itself); a consumer install has no `defaults/` dir so the byte-match
+/// lookup below always misses and classification is unchanged (#4332 is
+/// loom-repo-scoped by construction).
+///
+/// This class is intentionally **not** mirrored into
+/// `defaults/scripts/check-main-clean.sh`'s `LOOM_OWNED_PREFIXES` — see the
+/// divergence note in that script's header (#4332). That script protects a
+/// different property (catching a *builder* writing into the main worktree
+/// by mistake, not classifying resync output for the dispatch gate), so a
+/// byte-match there could mask real contamination instead of only ignoring
+/// safe, known-regenerable dirt.
+const INSTALLED_SURFACE_PREFIXES: &[(&str, &str)] = &[
+    (".loom/hooks/", "defaults/hooks/"),
+    (".loom/scripts/", "defaults/scripts/"),
+    (".loom/roles/", "defaults/roles/"),
+    (".loom/docs/", "defaults/docs/"),
+    (".loom/bin/", "defaults/.loom/bin/"),
+    (".claude/commands/loom/", "defaults/.claude/commands/loom/"),
+];
+
+/// If `path` falls under one of [`INSTALLED_SURFACE_PREFIXES`], return its
+/// `defaults/`-relative source counterpart path. `defaults/` source paths
+/// themselves are deliberately **not** in the mapping's domain — this only
+/// ever maps *installed* copies to their source, never the reverse, so a
+/// dirty `defaults/docs/x.md` (an operator editing the source directly)
+/// never matches here and stays non-ignorable.
+fn installed_surface_defaults_counterpart(path: &str) -> Option<String> {
+    INSTALLED_SURFACE_PREFIXES
+        .iter()
+        .find_map(|(installed, defaults)| {
+            path.strip_prefix(installed)
+                .map(|rest| format!("{defaults}{rest}"))
+        })
+}
+
+/// Whether `path` (a repo-relative path from `git status --porcelain`, rooted
+/// at `repo_root`) is ignorable dirt for the gate's dirty-tree check:
+///
+/// - a Loom-owned transient path ([`LOOM_OWNED_PREFIXES`]),
+/// - a common regenerable lockfile ([`BUILD_ARTIFACT_LOCKFILE_BASENAMES`]),
+/// - the re-stamped install manifest ([`INSTALL_METADATA_PATH`]), or
+/// - an installed-surface path (#4332,
+///   [`installed_surface_defaults_counterpart`]) whose content byte-matches
+///   its `defaults/` source counterpart — i.e. provably `resync-installed.sh`
+///   output, not an operator hand-edit (a hand-edit cannot byte-match the
+///   source it was never copied from).
+///
+/// Ignorable dirt is dirt a hard reset to `origin/main` safely discards (it
+/// is either untracked Loom runtime state or a tracked file whose content the
+/// reset will overwrite anyway, or — for the byte-match class — content
+/// identical to what's already committed under `defaults/`) — never a reason
+/// to skip the sync step.
+fn is_ignorable_dirt(path: &str, repo_root: &Path) -> bool {
     let loom_owned = LOOM_OWNED_PREFIXES.iter().any(|prefix| {
         if prefix.ends_with('/') {
             path.starts_with(prefix)
@@ -1626,15 +1687,30 @@ fn is_ignorable_dirt(path: &str) -> bool {
         return true;
     }
     let basename = path.rsplit('/').next().unwrap_or(path);
-    BUILD_ARTIFACT_LOCKFILE_BASENAMES.contains(&basename)
+    if BUILD_ARTIFACT_LOCKFILE_BASENAMES.contains(&basename) {
+        return true;
+    }
+    if path == INSTALL_METADATA_PATH {
+        return true;
+    }
+    if let Some(counterpart) = installed_surface_defaults_counterpart(path) {
+        if let (Ok(dirty_bytes), Ok(source_bytes)) =
+            (std::fs::read(repo_root.join(path)), std::fs::read(repo_root.join(&counterpart)))
+        {
+            return dirty_bytes == source_bytes;
+        }
+    }
+    false
 }
 
 /// Parse `git status --porcelain` v1 `output` and return the lines that are
 /// **not** ignorable dirt ([`is_ignorable_dirt`]) — the lines that must still
 /// be treated as "the workspace is dirty" for the gate's sync-before-run
 /// check. Rename lines (`R  old -> new`) are keyed on the new path. Empty
-/// lines are dropped.
-fn non_ignorable_dirt(output: &str) -> Vec<&str> {
+/// lines are dropped. `repo_root` backs the installed-surface byte-match
+/// check (#4332), which reads both the dirty path and its `defaults/`
+/// counterpart off disk.
+fn non_ignorable_dirt<'a>(output: &'a str, repo_root: &Path) -> Vec<&'a str> {
     output
         .lines()
         .filter(|line| !line.is_empty())
@@ -1642,7 +1718,7 @@ fn non_ignorable_dirt(output: &str) -> Vec<&str> {
             let path = line.get(3..).unwrap_or("");
             let path = path.rsplit(" -> ").next().unwrap_or(path);
             let path = path.trim_matches('"');
-            !is_ignorable_dirt(path)
+            !is_ignorable_dirt(path, repo_root)
         })
         .collect()
 }
@@ -1788,7 +1864,7 @@ pub fn prepare_workspace_to_origin_main(repo_root: &Path) -> PrepOutcome {
     // discards, not operator edits worth protecting.
     match git_status_porcelain(repo_root) {
         Ok(out) => {
-            let unexpected = non_ignorable_dirt(&out);
+            let unexpected = non_ignorable_dirt(&out, repo_root);
             if !unexpected.is_empty() {
                 // Name the exact `git status --porcelain` lines, and the root
                 // they were read from, so the claim is checkable against
@@ -3983,44 +4059,147 @@ mod tests {
 
     #[test]
     fn test_is_ignorable_dirt_loom_owned_prefixes() {
-        assert!(is_ignorable_dirt(".loom/logs/sweep-issue-1.log"));
-        assert!(is_ignorable_dirt(".loom/worktrees/issue-42/foo.rs"));
-        assert!(is_ignorable_dirt(".loom/tokens/agent-1.token"));
-        assert!(is_ignorable_dirt(".loom/sweep-checkpoint/issue-1.json"));
-        assert!(is_ignorable_dirt(".loom/accounts.env"));
-        assert!(is_ignorable_dirt(".loom-managed"));
+        let repo_root = tempfile::tempdir().unwrap();
+        let repo_root = repo_root.path();
+        assert!(is_ignorable_dirt(".loom/logs/sweep-issue-1.log", repo_root));
+        assert!(is_ignorable_dirt(".loom/worktrees/issue-42/foo.rs", repo_root));
+        assert!(is_ignorable_dirt(".loom/tokens/agent-1.token", repo_root));
+        assert!(is_ignorable_dirt(".loom/sweep-checkpoint/issue-1.json", repo_root));
+        assert!(is_ignorable_dirt(".loom/accounts.env", repo_root));
+        assert!(is_ignorable_dirt(".loom-managed", repo_root));
     }
 
     #[test]
     fn test_is_ignorable_dirt_lockfile_basenames() {
-        assert!(is_ignorable_dirt("mcp-loom/package-lock.json"));
-        assert!(is_ignorable_dirt("package-lock.json"));
-        assert!(is_ignorable_dirt("some/nested/dir/Cargo.lock"));
-        assert!(is_ignorable_dirt("pnpm-lock.yaml"));
+        let repo_root = tempfile::tempdir().unwrap();
+        let repo_root = repo_root.path();
+        assert!(is_ignorable_dirt("mcp-loom/package-lock.json", repo_root));
+        assert!(is_ignorable_dirt("package-lock.json", repo_root));
+        assert!(is_ignorable_dirt("some/nested/dir/Cargo.lock", repo_root));
+        assert!(is_ignorable_dirt("pnpm-lock.yaml", repo_root));
     }
 
     #[test]
     fn test_is_ignorable_dirt_rejects_unknown_paths() {
+        let repo_root = tempfile::tempdir().unwrap();
+        let repo_root = repo_root.path();
         // A genuine operator edit outside both lists must never be ignored.
-        assert!(!is_ignorable_dirt("src/main.rs"));
-        assert!(!is_ignorable_dirt("scratch.tmp"));
+        assert!(!is_ignorable_dirt("src/main.rs", repo_root));
+        assert!(!is_ignorable_dirt("scratch.tmp", repo_root));
         // A path that merely starts with ".loom" but isn't one of the listed
         // transient subtrees (e.g. a hypothetical ".loom/config.json" edit)
         // must NOT be ignored — only the explicitly listed prefixes count.
-        assert!(!is_ignorable_dirt(".loom/config.json"));
+        assert!(!is_ignorable_dirt(".loom/config.json", repo_root));
     }
 
     #[test]
     fn test_non_ignorable_dirt_filters_porcelain_lines() {
+        let repo_root = tempfile::tempdir().unwrap();
         let status = "?? .loom/logs/foo.log\n M mcp-loom/package-lock.json\n M src/main.rs\n";
-        let remaining = non_ignorable_dirt(status);
+        let remaining = non_ignorable_dirt(status, repo_root.path());
         assert_eq!(remaining, vec![" M src/main.rs"]);
     }
 
     #[test]
     fn test_non_ignorable_dirt_empty_when_all_ignorable() {
+        let repo_root = tempfile::tempdir().unwrap();
         let status = "?? .loom/logs/foo.log\n M package-lock.json\n";
-        assert!(non_ignorable_dirt(status).is_empty());
+        assert!(non_ignorable_dirt(status, repo_root.path()).is_empty());
+    }
+
+    // ===================================================================
+    // Installed-surface byte-match class (#4332) — a dirty installed-surface
+    // path (`.loom/hooks/`, `.loom/scripts/`, `.loom/roles/`, `.loom/docs/`,
+    // `.loom/bin/`, `.claude/commands/loom/`) is ignorable IFF its
+    // `defaults/` counterpart exists and byte-matches: provably
+    // `resync-installed.sh` output, never an operator hand-edit.
+    // ===================================================================
+
+    /// Write `content` to `repo_root`-relative `rel`, creating parent dirs.
+    fn write_rel(repo_root: &Path, rel: &str, content: &str) {
+        let path = repo_root.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn test_is_ignorable_dirt_installed_surface_byte_match() {
+        let repo = tempfile::tempdir().unwrap();
+        let repo_root = repo.path();
+        write_rel(repo_root, "defaults/docs/foo.md", "resynced content\n");
+        write_rel(repo_root, ".loom/docs/foo.md", "resynced content\n");
+        assert!(
+            is_ignorable_dirt(".loom/docs/foo.md", repo_root),
+            "byte-identical installed copy of a tracked defaults/ source is provably resync output"
+        );
+    }
+
+    /// AC4 pin: an installed-surface path whose content DIFFERS from its
+    /// `defaults/` counterpart is a genuine operator edit (or an
+    /// out-of-sync tree) and must never be ignored.
+    #[test]
+    fn test_is_ignorable_dirt_installed_surface_content_mismatch_stays_non_ignorable() {
+        let repo = tempfile::tempdir().unwrap();
+        let repo_root = repo.path();
+        write_rel(repo_root, "defaults/docs/foo.md", "source content\n");
+        write_rel(repo_root, ".loom/docs/foo.md", "operator edit\n");
+        assert!(
+            !is_ignorable_dirt(".loom/docs/foo.md", repo_root),
+            "content that diverges from defaults/ must not be assumed to be resync output"
+        );
+    }
+
+    #[test]
+    fn test_is_ignorable_dirt_install_metadata_exact_path() {
+        let repo = tempfile::tempdir().unwrap();
+        let repo_root = repo.path();
+        // No defaults/ counterpart needed — install-metadata.json is
+        // generated + re-stamped, not copied.
+        assert!(is_ignorable_dirt(".loom/install-metadata.json", repo_root));
+    }
+
+    /// Consumer-repo no-op: a repo with no local `defaults/` dir at all
+    /// cannot resolve the installed-surface mapping, so classification of an
+    /// installed-surface path is unchanged (non-ignorable) — this fix is
+    /// loom-repo-scoped by construction.
+    #[test]
+    fn test_is_ignorable_dirt_no_defaults_dir_leaves_classification_unchanged() {
+        let repo = tempfile::tempdir().unwrap();
+        let repo_root = repo.path();
+        write_rel(repo_root, ".loom/docs/foo.md", "some content\n");
+        // Deliberately no defaults/docs/foo.md.
+        assert!(!is_ignorable_dirt(".loom/docs/foo.md", repo_root));
+    }
+
+    /// Safety property: a `defaults/` SOURCE-side edit must remain
+    /// non-ignorable even when the installed copy it produced still
+    /// byte-matches — the installed-surface mapping only ever maps installed
+    /// paths to their source, never the reverse, so an operator editing
+    /// `defaults/docs/x.md` directly and then running resync still shows the
+    /// gate a real, unignorable change (the `defaults/` file itself).
+    #[test]
+    fn test_is_ignorable_dirt_defaults_source_edit_stays_non_ignorable() {
+        let repo = tempfile::tempdir().unwrap();
+        let repo_root = repo.path();
+        write_rel(repo_root, "defaults/docs/x.md", "operator's new content\n");
+        write_rel(repo_root, ".loom/docs/x.md", "operator's new content\n");
+        assert!(
+            !is_ignorable_dirt("defaults/docs/x.md", repo_root),
+            "the defaults/ source file itself is never in the installed-surface mapping's domain"
+        );
+    }
+
+    /// Edge case: an UNTRACKED installed file (e.g. a brand-new doc synced by
+    /// resync but not yet `git add`-ed) that byte-matches a tracked
+    /// `defaults/` counterpart is ignorable the same as a modified one.
+    #[test]
+    fn test_non_ignorable_dirt_untracked_installed_surface_byte_match() {
+        let repo = tempfile::tempdir().unwrap();
+        let repo_root = repo.path();
+        write_rel(repo_root, "defaults/docs/new.md", "new doc\n");
+        write_rel(repo_root, ".loom/docs/new.md", "new doc\n");
+        let status = "?? .loom/docs/new.md\n";
+        assert!(non_ignorable_dirt(status, repo_root).is_empty());
     }
 
     /// AC1(a): a workspace with ONLY Loom-owned transient paths dirty must NOT
@@ -4097,6 +4276,66 @@ mod tests {
             outcome,
             PrepOutcome::Ready,
             "a lone modified lockfile must not block the gate, got {outcome:?}"
+        );
+    }
+
+    /// AC (#4332): after a `resync-installed.sh`-shaped change — a tracked
+    /// installed-surface file rewritten to byte-match its `defaults/`
+    /// source, with no other edits — the gate must proceed to `Ready`
+    /// instead of `Skip { class: DirtyTree, .. }`.
+    #[test]
+    fn test_prepare_ignores_resync_shaped_installed_surface_dirt() {
+        let (_origin, clone) = make_origin_and_clone();
+        std::fs::create_dir_all(clone.path().join("defaults/docs")).unwrap();
+        std::fs::create_dir_all(clone.path().join(".loom/docs")).unwrap();
+        std::fs::write(clone.path().join("defaults/docs/foo.md"), "old content\n").unwrap();
+        std::fs::write(clone.path().join(".loom/docs/foo.md"), "old content\n").unwrap();
+        Command::new("git")
+            .args(["add", "defaults/docs/foo.md", ".loom/docs/foo.md"])
+            .current_dir(clone.path())
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", "seed installed surface"])
+            .current_dir(clone.path())
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["push", "origin", "main"])
+            .current_dir(clone.path())
+            .status()
+            .unwrap();
+
+        // Simulate a resync: the source under `defaults/` changed upstream
+        // (already committed) and the installed copy is refreshed to match —
+        // exactly what `resync-installed.sh` does, and exactly the dirt this
+        // issue is about.
+        std::fs::write(clone.path().join("defaults/docs/foo.md"), "new content\n").unwrap();
+        Command::new("git")
+            .args(["add", "defaults/docs/foo.md"])
+            .current_dir(clone.path())
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", "update defaults/docs/foo.md"])
+            .current_dir(clone.path())
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["push", "origin", "main"])
+            .current_dir(clone.path())
+            .status()
+            .unwrap();
+        // The installed copy is now stale relative to the freshly-committed
+        // source — resync rewrites it to match, leaving it dirty (tracked,
+        // modified) but byte-identical to `defaults/docs/foo.md`.
+        std::fs::write(clone.path().join(".loom/docs/foo.md"), "new content\n").unwrap();
+
+        let outcome = prepare_workspace_to_origin_main(clone.path());
+        assert_eq!(
+            outcome,
+            PrepOutcome::Ready,
+            "resync-shaped installed-surface dirt (byte-identical to its defaults/ source) must not block the gate, got {outcome:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

`is_ignorable_dirt` in `loom-daemon/src/main_health_gate.rs` classified dirt as ignorable only via `LOOM_OWNED_PREFIXES` (transient runtime state) and `BUILD_ARTIFACT_LOCKFILE_BASENAMES`. Installed-surface paths (`.loom/hooks/`, `.loom/scripts/`, `.loom/roles/`, `.loom/docs/`, `.loom/bin/`, `.claude/commands/loom/`, `.loom/install-metadata.json`) appeared in neither list, and in the loom repo they are tracked — so `resync-installed.sh` output (which refreshes these tracked installed copies from `defaults/`) was classified as non-ignorable dirt, and the main-health gate skipped every cycle with "not evaluated (dirty-tree)".

- Added an installed↔source surface mapping (mirrors `resync-installed.sh`'s own surface table, not a uniform prefix rewrite — `.loom/bin/` and `.claude/commands/loom/` map into `defaults/.loom/bin/` / `defaults/.claude/commands/loom/`, the rest map straight into `defaults/<name>/`).
- A dirty installed-surface path is now ignorable **iff** its `defaults/` counterpart exists in the worktree and byte-matches the dirty file's content — provably resync output, since an operator hand-edit cannot byte-match content it was never copied from.
- `.loom/install-metadata.json` is ignorable by exact path (no `defaults/` counterpart — it's generated + re-stamped, #4239).
- A dirty `defaults/docs/x.md` (source-side edit) is **never** in this mapping's domain — only installed copies map to source, never the reverse — so the gate still correctly skips on a real operator edit to the source.
- Repos with no local `defaults/` dir (consumer installs) are unaffected: the mapping lookup always misses, so classification is unchanged. This fix is loom-repo-scoped by construction.
- Explicitly decided (and documented) that `defaults/scripts/check-main-clean.sh`'s bash-mirrored `LOOM_OWNED_PREFIXES` does **not** adopt the byte-match class — its purpose (catching a *builder* writing into the main worktree by mistake) differs from the gate's (classifying resync output as safe), and byte-matching there could mask real contamination.
- `resync-installed.sh` now prints the exact `git add … && git commit` command in its summary when a run leaves the tree dirty with only resync output, so it doesn't linger uncommitted.

## Changes

- `loom-daemon/src/main_health_gate.rs` — `INSTALL_METADATA_PATH`, `INSTALLED_SURFACE_PREFIXES`, `installed_surface_defaults_counterpart`, extended `is_ignorable_dirt`/`non_ignorable_dirt` to take `repo_root` for the byte-match read; 12 new unit/integration tests.
- `defaults/scripts/check-main-clean.sh` — documented divergence decision (does not adopt the byte-match class).
- `defaults/scripts/resync-installed.sh` — optional `git add … && git commit` hint in the summary block when only resync output remains dirty.
- `defaults/docs/daemon-reference.md` — new "Dirty-tree ignore classes (#3950, #4332)" section documenting all four ignore classes and the check-main-clean.sh divergence.

## Test plan

- [x] `test_is_ignorable_dirt_installed_surface_byte_match` — byte-identical installed copy is ignorable
- [x] `test_is_ignorable_dirt_installed_surface_content_mismatch_stays_non_ignorable` — differing content stays non-ignorable (operator-edit pin, AC 4)
- [x] `test_is_ignorable_dirt_install_metadata_exact_path` — `.loom/install-metadata.json` ignorable with no counterpart needed
- [x] `test_is_ignorable_dirt_no_defaults_dir_leaves_classification_unchanged` — consumer-repo no-op
- [x] `test_is_ignorable_dirt_defaults_source_edit_stays_non_ignorable` — dirty `defaults/docs/x.md` source-side edit remains non-ignorable even when the installed copy byte-matches
- [x] `test_non_ignorable_dirt_untracked_installed_surface_byte_match` — untracked installed file byte-matching a tracked `defaults/` counterpart is ignorable
- [x] `test_prepare_ignores_resync_shaped_installed_surface_dirt` — end-to-end: `prepare_workspace_to_origin_main` reaches `Ready` (not `Skip`) after a resync-shaped change (AC 1)
- [x] `test_prepare_skips_dirty_workspace` (existing, pin) — a modified tracked non-Loom file still skips the gate (AC 4 regression pin)
- [x] All existing `is_ignorable_dirt`/`non_ignorable_dirt` tests updated for the new `repo_root` parameter and still pass
- [x] `cargo test --lib main_health_gate` — 118 passed, 0 failed
- [x] `cargo test --lib` (full workspace, parallel) — 1558 passed, 1 failed (`terminal::claude_config::tests::test_setup_creates_fallback_state_when_no_home_state`) — pre-existing, unrelated test-order/env-hermeticity flake (passes standalone in isolation; does not touch any file this PR changes)
- [x] `cargo fmt --check` / `cargo clippy --lib -- -D warnings` clean
- [x] Manually verified `resync-installed.sh`'s new git-add/commit hint fires only when all dirt is resync output, and is suppressed by any other dirt (e.g. a scratch file)

Closes #4332