### PR TITLE
feat(safehouse): surface live connection state in loom-daemon status (#4345)

### DIFF
--- a/.loom/docs/safehouse.md
+++ b/.loom/docs/safehouse.md
@@ -92,6 +92,108 @@ personas (`loom_builder_42`) are blocked upstream until safehoused grows prefix
 support and are tracked in #3999 — do not attempt to register personas at
 dispatch time; there is no such path.
 
+## Connection status: not configured / unreachable / connected (#4345)
+
+Before #4345, `safehouse.enabled` false/absent, enabled-but-unreachable, and
+enabled-and-connected all looked identical to an operator — silence. Two
+surfaces now report the live state:
+
+- **`loom-daemon status`** (and `status --json`) prints a `Safehouse:` line
+  (a `safehouse` object in JSON) with one of three states, self-reported by
+  the daemon's own live connection — never a second, status-time connection
+  attempt (a CLI-side probe could not know "room joined" the way the daemon's
+  own connection can):
+  - `not configured` — no `safehouse` block, `enabled: false`/absent, or
+    enabled with no socket path resolving at all (nothing to even try). No
+    connection has been attempted.
+  - `configured, unreachable` — enabled, a socket path resolved, but the most
+    recent connect attempt failed, was refused, or dropped. The resolved
+    socket path is included.
+  - `connected` — the most recent connect attempt completed the `hello`
+    handshake. The configured room name is included when one was configured
+    (`safehouse.room` unset is valid only when safehoused joined exactly one
+    room, resolved server-side — the daemon is never told that resolved name,
+    so the line omits it rather than guessing).
+- **`loom-daemon-start.sh`** prints a cheaper, **static**, pre-connect check at
+  start time (`ok`/`warn` colored, one line): it runs *before* the daemon
+  connects, so it can only distinguish "not configured" from "configured" —
+  proving "connected" needs the daemon's own live socket, which is what
+  `loom-daemon status` is for. Concretely: no `safehouse` block/disabled ⇒
+  `not configured`; enabled with no socket resolving ⇒ `configured,
+  unreachable`; enabled with a socket path that exists as a socket on disk ⇒
+  `configured (socket present)`; enabled with a socket path that does not
+  exist yet ⇒ `configured, unreachable` (the path is included either way).
+
+Implementation: `loom-daemon/src/safehouse.rs`'s `SafehouseState` is a shared
+`Arc<Mutex<..>>` cell (the same injection shape [`PeerClaimView`] already
+uses) updated by both the narration sink ([`run_sink`]) and the peer-claim
+coordination task ([`run_coordination`]) on every connect/disconnect
+transition; `workspace_pool.rs`'s `WorkspacePool` owns one cell per daemon and
+`ipc.rs`'s `build_daemon_status` reads it into a new optional
+`DaemonStatusReport.safehouse` field (`#[serde(default)]`, so an older
+daemon's wire payload — missing the field entirely — still parses).
+`loom-daemon-start.sh`'s static check reuses the same env>config>default
+resolvers `lib/mcp-config.sh` already defines for the safehouse-mcp worker
+injection (phase 2, below) rather than re-deriving them.
+
+## New-host onboarding (#4345)
+
+The manual path from a fresh interactive host (no `safehoused`, no
+`safehouse` config block anywhere) to `loom-daemon status` reading
+`connected`. **An automated service-wrapper + install-step path is tracked as
+a follow-up (#4359)** — this section is the documented fallback until that
+lands, and stays valid afterward as the manual/debug path.
+
+1. **Bot account + credentials.** Provision (or reuse) a Matrix account for
+   the `loom_daemon` persona in the target safehouse deployment — this is an
+   operator-side step in the external `rjwalters/safehouse` repo/deployment,
+   not something this repo automates. Note the account's credentials and the
+   room the fleet uses.
+2. **Build/install `safehoused`.** Build from the `rjwalters/safehouse`
+   checkout per that repo's own instructions. Confirm the `personas` allowlist
+   in its config includes `loom_daemon` (or whichever persona you assign this
+   host, per "Operator setup" above) — the allowlist is boot-time and
+   restart-only, no hot reload.
+3. **Run `safehoused`.** Until #4359 ships a supervised service wrapper
+   (launchd LaunchAgent / `systemd --user`, mirroring
+   `loom-daemon-start.sh`'s own pattern), start it manually or under your own
+   supervisor of choice — `nohup safehoused &`, a personal launchd plist, a
+   tmux pane, etc. Note the socket path it binds (safehoused's own config
+   controls this).
+4. **Socket env or config.** Either export `SAFEHOUSED_SOCKET=<path>` (the
+   convention safehoused's own clients read) machine-wide, or set
+   `safehouse.socket` explicitly in this host's `.loom/config.json` — see
+   [Socket resolution](#configuration) above for the full precedence.
+5. **Enable the `safehouse` config block** in `.loom/config.json` (per
+   workspace, since it lives in the per-repo config tier) or export
+   `LOOM_SAFEHOUSE_ENABLED=1` machine-wide:
+   ```jsonc
+   "safehouse": {
+     "enabled": true,
+     "socket": null,      // omit to rely on $SAFEHOUSED_SOCKET
+     "room": null,         // omit only if safehoused joined exactly one room
+     "persona": "loom_daemon"
+   }
+   ```
+6. **Start/restart `loom-daemon`** (`loom-daemon-start.sh`). Its startup
+   banner prints the static `Safehouse:` line described above — confirm it
+   reads `configured (socket present ...)`, not `not configured` or
+   `configured, unreachable`, before moving on.
+7. **Verify with `loom-daemon status`.** Give it a few seconds for the
+   narration sink / peer-coordination task to complete their first connect
+   (the sink connects lazily on the first narrated bus event; the
+   peer-coordination task connects eagerly at daemon startup, so it is
+   usually first to show `connected`). Confirm the `Safehouse:` line reads
+   `connected` with the expected room, then run a sweep and confirm the room
+   shows the `loom-daemon → everyone · task` dispatch line.
+
+If the line sticks at `configured, unreachable`: confirm `safehoused` is
+actually running and bound to the exact path `loom-daemon status` reports,
+that the persona is in safehoused's allowlist (a rejected `hello` also
+degrades to `unreachable` — check the daemon log for `safehoused rejected
+persona`), and that the daemon process can reach the socket path (permissions,
+same-host, no stale socket file from a crashed prior run).
+
 ## What gets narrated
 
 The sink maps the **existing frozen event taxonomy** (`event_bus.rs`,
@@ -183,6 +285,20 @@ network, unauthenticated, timeout) degrades to narrating the dispatch line
 - `loom-daemon/src/workspace_pool.rs` — `start_safehouse_narration()` and
   `start_peer_coordination()` subscribe/attach the shared `Arc<EventBus>` /
   `PeerClaimView` and spawn on the daemon runtime; both no-ops when disabled.
+  Also (#4345) owns the `SharedSafehouseState` cell and exposes
+  `safehouse_status()` for `ipc::build_daemon_status`.
+- `loom-daemon/src/types.rs` — `DaemonStatusReport.safehouse` /
+  `SafehouseStatus` (#4345), the wire shape for the connection-state line.
+- `loom-daemon/src/ipc.rs` / `loom-daemon/src/main.rs` — (#4345)
+  `build_daemon_status` reads the pool's `safehouse_status()`; `main.rs`
+  renders the `Safehouse:` human line and the `safehouse` JSON object.
+- `defaults/scripts/cli/loom-daemon-start.sh` — (#4345) the static
+  pre-connect `Safehouse:` line, via `lib/mcp-config.sh`'s existing
+  `loom_mcp_safehouse_enabled`/`loom_mcp_safehouse_socket` resolvers.
+- Tests: `safehouse.rs`'s `mod tests` (state-cell + wire-rendering cases),
+  `workspace_pool.rs`'s `mod tests` (pool wiring), `ipc.rs`'s
+  `test_build_daemon_status_reports_halt_and_in_flight` (report field),
+  `defaults/scripts/tests/test-loom-daemon-start.sh` (start-wrapper line).
 
 ## Peer-claim coordination: cross-host soft claim (#4028)
 

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -454,6 +454,41 @@ EOF
     )
 }
 
+# ---------- safehouse fleet-comms status (#4345) ----------
+# Reuses the same env>config>default resolvers `mcp-config.sh` already defines
+# for the safehouse-mcp worker injection (phase 2, #3999) — this is a purely
+# static, PRE-CONNECT check: "would the daemon even try?" It can only report
+# "not configured" vs "configured", never "connected" (proving a live
+# connection needs the daemon's own socket, surfaced instead by
+# `loom-daemon status` --- see .loom/docs/safehouse.md "New-host onboarding").
+_LOOM_MCP_CONFIG_LIB="$_LOOM_LAUNCHD_LIB_DIR/mcp-config.sh"
+if [[ -r "$_LOOM_MCP_CONFIG_LIB" ]]; then
+    # shellcheck source=../lib/mcp-config.sh
+    source "$_LOOM_MCP_CONFIG_LIB"
+fi
+print_safehouse_status() {
+    if ! command -v loom_mcp_safehouse_enabled >/dev/null 2>&1; then
+        return 0 # mcp-config.sh missing (stale/partial install) — skip silently
+    fi
+    local enabled socket
+    enabled=$(loom_mcp_safehouse_enabled "$REPO_ROOT")
+    if [[ "$enabled" != "true" ]]; then
+        echo "Safehouse:     not configured (safehouse.enabled is false/absent)"
+        return 0
+    fi
+    socket=$(loom_mcp_safehouse_socket "$REPO_ROOT")
+    if [[ -z "$socket" ]]; then
+        warn "Safehouse:     configured, unreachable (enabled but no socket path resolved -- set" \
+             "safehouse.socket, \$LOOM_SAFEHOUSE_SOCKET, or \$SAFEHOUSED_SOCKET)"
+        return 0
+    fi
+    if [[ -S "$socket" ]]; then
+        ok "Safehouse:     configured (socket present at $socket) -- see 'loom-daemon status' for live connection state"
+    else
+        warn "Safehouse:     configured, unreachable (socket $socket does not exist -- is safehoused running?)"
+    fi
+}
+
 # ---------- watchdog LaunchAgent / systemd timer (#4011, #4260 sub-issue D) ----------
 # The watchdog is the payload of a SECOND, SEPARATE scheduled job from the
 # daemon job/unit itself, and reports when intent (the marker above) diverges
@@ -1030,6 +1065,7 @@ if [[ "$USE_LAUNCHD" == "true" ]]; then
     ok "loom-daemon started under launchd (pid $daemon_pid, label $LAUNCHD_LABEL)."
     echo "PID file: $PID_FILE"
     echo "Intent marker: $INTENT_MARKER"
+    print_safehouse_status
     if [[ "$MACHINE_MODE" == "true" ]]; then
         echo "Stop with: loom stop"
     else
@@ -1103,6 +1139,7 @@ if [[ "$IS_LINUX_SYSTEMD" == "true" ]]; then
     ok "loom-daemon started under systemd (pid $daemon_pid, unit $SYSTEMD_UNIT)."
     echo "PID file: $PID_FILE"
     echo "Intent marker: $INTENT_MARKER"
+    print_safehouse_status
     warn "Reboot survival requires lingering: run 'loginctl enable-linger \"\$USER\"' once (SSH-only / headless hosts)."
     if [[ "$MACHINE_MODE" == "true" ]]; then
         echo "Stop with: loom stop"
@@ -1140,6 +1177,7 @@ write_intent_marker "false" ""
 provision_watchdog_job_none
 ok "loom-daemon started (pid $daemon_pid). PID file: $PID_FILE"
 echo "Intent marker: $INTENT_MARKER"
+print_safehouse_status
 if [[ "$MACHINE_MODE" == "true" ]]; then
     echo "Stop with: loom stop"
 else

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -563,6 +563,113 @@ out=$( LOOM_LAUNCHD_DOMAIN="gui/${UID_NOW}" PATH="$DOMAIN_STUB_DIR/nogui:$PATH" 
     bash -c "source '$LAUNCHD_DOMAIN_LIB'; resolve_launchd_domain" )
 assert_eq "gui/${UID_NOW}" "$out" "override to a non-resolving domain is honored verbatim (no silent fallback)"
 
+# ---------- safehouse fleet-comms status surfacing (#4345) ----------
+# One-line static visibility check at start time: `loom-daemon-start.sh` can
+# only tell "configured" from "not configured" (a live connection needs the
+# daemon's own socket -- `loom-daemon status` covers that, see
+# .loom/docs/safehouse.md "New-host onboarding"). Uses the nohup fallback path
+# (--no-launchd --no-systemd) so this never touches real launchd/systemd, and a
+# background daemon fake bin that stays alive long enough for the "started"
+# banner (which the safehouse line is printed alongside) to run.
+SH_BG_FAKE_BIN="$WORKDIR/fake-loom-daemon-safehouse-bg"
+cat > "$SH_BG_FAKE_BIN" <<'EOF'
+#!/usr/bin/env bash
+sleep 5
+EOF
+chmod +x "$SH_BG_FAKE_BIN"
+
+# SH1. No `safehouse` block at all -> "not configured".
+SH1_HOME="$(mktemp -d)"
+mkdir -p "$SH1_HOME/.loom"
+sh1_out=$( ( cd "$SH1_HOME" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    -u LOOM_SAFEHOUSE_ENABLED -u LOOM_SAFEHOUSE_SOCKET -u SAFEHOUSED_SOCKET \
+    LOOM_DAEMON_BIN="$SH_BG_FAKE_BIN" \
+    LOOM_SOCKET_PATH="$SH1_HOME/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$SH1_HOME/.loom/autonomy-desired" \
+    LOOM_WATCHDOG_LABEL="com.example.loom-sandbox-$$-sh1-watchdog" \
+    bash "$START_SCRIPT" --no-launchd --no-systemd 2>&1 ) )
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$sh1_out" | grep -q '^Safehouse:.*not configured'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} safehouse: no config block -> 'not configured' (#4345)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} safehouse: no config block -> 'not configured' (#4345)"
+    echo "  output: $sh1_out"
+fi
+if [[ -f "$SH1_HOME/.loom/.daemon.pid" ]]; then
+    kill "$(cat "$SH1_HOME/.loom/.daemon.pid" 2>/dev/null)" 2>/dev/null || true
+fi
+rm -rf "$SH1_HOME"
+
+# SH2. safehouse.enabled=true + socket configured but the path does not exist
+#      -> "configured, unreachable" (stderr warn -- captured via 2>&1).
+SH2_HOME="$(mktemp -d)"
+mkdir -p "$SH2_HOME/.loom"
+cat > "$SH2_HOME/.loom/config.json" <<EOF
+{"safehouse": {"enabled": true, "socket": "$SH2_HOME/.loom/does-not-exist.sock"}}
+EOF
+sh2_out=$( ( cd "$SH2_HOME" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    -u LOOM_SAFEHOUSE_ENABLED -u LOOM_SAFEHOUSE_SOCKET -u SAFEHOUSED_SOCKET \
+    LOOM_DAEMON_BIN="$SH_BG_FAKE_BIN" \
+    LOOM_SOCKET_PATH="$SH2_HOME/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$SH2_HOME/.loom/autonomy-desired" \
+    LOOM_WATCHDOG_LABEL="com.example.loom-sandbox-$$-sh2-watchdog" \
+    bash "$START_SCRIPT" --no-launchd --no-systemd 2>&1 ) )
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$sh2_out" | grep -q '^Safehouse:.*configured, unreachable' \
+    && echo "$sh2_out" | grep -q 'does-not-exist.sock'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} safehouse: enabled + missing socket -> 'configured, unreachable' with the resolved path (#4345)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} safehouse: enabled + missing socket -> 'configured, unreachable' with the resolved path (#4345)"
+    echo "  output: $sh2_out"
+fi
+if [[ -f "$SH2_HOME/.loom/.daemon.pid" ]]; then
+    kill "$(cat "$SH2_HOME/.loom/.daemon.pid" 2>/dev/null)" 2>/dev/null || true
+fi
+rm -rf "$SH2_HOME"
+
+# SH3. safehouse.enabled=true + socket path IS a real bound AF_UNIX socket file
+#      -> "configured (socket present ...)". Only `bind()`s (no accept loop
+#      needed -- the start wrapper only stat()s the path, it never connects).
+SH3_HOME="$(mktemp -d)"
+mkdir -p "$SH3_HOME/.loom"
+SH3_SOCK="$SH3_HOME/.loom/safehoused.sock"
+if command -v python3 >/dev/null 2>&1 \
+    && python3 -c "
+import socket
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.bind('$SH3_SOCK')
+" 2>/dev/null; then
+    cat > "$SH3_HOME/.loom/config.json" <<EOF
+{"safehouse": {"enabled": true, "socket": "$SH3_SOCK"}}
+EOF
+    sh3_out=$( ( cd "$SH3_HOME" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+        -u LOOM_SAFEHOUSE_ENABLED -u LOOM_SAFEHOUSE_SOCKET -u SAFEHOUSED_SOCKET \
+        LOOM_DAEMON_BIN="$SH_BG_FAKE_BIN" \
+        LOOM_SOCKET_PATH="$SH3_HOME/.loom/loom-daemon.sock" \
+        LOOM_AUTONOMY_MARKER="$SH3_HOME/.loom/autonomy-desired" \
+        LOOM_WATCHDOG_LABEL="com.example.loom-sandbox-$$-sh3-watchdog" \
+        bash "$START_SCRIPT" --no-launchd --no-systemd 2>&1 ) )
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if echo "$sh3_out" | grep -q '^Safehouse:.*configured (socket present'; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} safehouse: enabled + socket file present -> 'configured (socket present ...)' (#4345)"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} safehouse: enabled + socket file present -> 'configured (socket present ...)' (#4345)"
+        echo "  output: $sh3_out"
+    fi
+    if [[ -f "$SH3_HOME/.loom/.daemon.pid" ]]; then
+        kill "$(cat "$SH3_HOME/.loom/.daemon.pid" 2>/dev/null)" 2>/dev/null || true
+    fi
+else
+    echo "  (skipping SH3: python3 AF_UNIX bind unavailable on this host)"
+fi
+rm -rf "$SH3_HOME"
+
 # ---------- summary ----------
 echo
 echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1389,6 +1389,11 @@ pub fn build_daemon_status(
         host_breaker: crate::host_breaker::global_snapshot()
             .map(crate::host_breaker::BreakerSnapshot::into_status)
             .map(Box::new),
+        // Live safehouse connection state (#4345) — the pool's shared cell is
+        // updated by the narration sink / peer-coordination tasks
+        // `start_safehouse_narration`/`start_peer_coordination` spawn, and
+        // read back here on every status call (no second connection).
+        safehouse: Some(workspace_pool.safehouse_status()),
     }
 }
 
@@ -4522,6 +4527,11 @@ exit 0
             auto_update_terminal_reason: None,
             auto_update_note: Some("within settle window".to_string()),
             host_breaker: None,
+            safehouse: Some(crate::types::SafehouseStatus {
+                state: "connected".to_string(),
+                socket: Some(std::path::PathBuf::from("/tmp/safehoused.sock")),
+                room: Some("fleet".to_string()),
+            }),
         };
         let resp = Response::DaemonStatus(Box::new(report));
         let json = serde_json::to_string(&resp).expect("serialize response");
@@ -4865,6 +4875,15 @@ exit 0
         // The tempdir has no `.loom/tokens/`, so the pool + dynamic cap are 0.
         assert_eq!(report.token_pool_size, 0);
         assert_eq!(report.dynamic_cap, 0);
+        // #4345: a pool that never called start_safehouse_narration /
+        // start_peer_coordination still reports a live safehouse state — the
+        // cell's own default, not a missing/`None` field.
+        let safehouse = report
+            .safehouse
+            .as_ref()
+            .expect("safehouse status always present");
+        assert_eq!(safehouse.state, "not_configured");
+        assert!(safehouse.socket.is_none());
         // Per-repo breakdown: exactly one entry for the single workspace.
         assert_eq!(report.per_repo.len(), 1);
         assert_eq!(report.per_repo[0].root, root);

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -3195,6 +3195,14 @@ fn print_status_json(
             "sustain_ticks": h.sustain_ticks,
             "cooldown_secs": h.cooldown_secs,
         })),
+        // Live safehouse fleet-comms connection state (#4345) — `null` only
+        // from a pre-#4345 daemon binary that never computed one. `state` is
+        // one of "not_configured" / "unreachable" / "connected".
+        "safehouse": report.safehouse.as_ref().map(|s| serde_json::json!({
+            "state": s.state,
+            "socket": s.socket,
+            "room": s.room,
+        })),
     });
     println!("{}", serde_json::to_string_pretty(&combined)?);
     Ok(())
@@ -3557,6 +3565,33 @@ fn print_status_human(
         Some(c) => println!("Forge credential: DEGRADED — {}", c.message),
         None => {
             println!("Forge credential: unknown (older daemon binary — restart to pick up #4005)")
+        }
+    }
+
+    // Live safehouse fleet-comms connection state (#4345): before this,
+    // "not configured", "configured but unreachable", and "connected" all
+    // looked identical — silence. See `.loom/docs/safehouse.md`.
+    match &report.safehouse {
+        Some(s) if s.state == "connected" => {
+            println!(
+                "Safehouse:     connected (room: {}, socket: {})",
+                s.room.as_deref().unwrap_or("(default — sole joined room)"),
+                s.socket
+                    .as_ref()
+                    .map_or_else(|| "?".to_string(), |p| p.display().to_string())
+            );
+        }
+        Some(s) if s.state == "unreachable" => {
+            println!(
+                "Safehouse:     configured, unreachable (socket: {})",
+                s.socket
+                    .as_ref()
+                    .map_or_else(|| "unresolved".to_string(), |p| p.display().to_string())
+            );
+        }
+        Some(_) => println!("Safehouse:     not configured"),
+        None => {
+            println!("Safehouse:     unknown (older daemon binary — restart to pick up #4345)")
         }
     }
 
@@ -5532,6 +5567,7 @@ mod status_client_tests {
             auto_update_terminal_reason: None,
             auto_update_note: None,
             host_breaker: None,
+            safehouse: None,
         }
     }
 

--- a/loom-daemon/src/safehouse.rs
+++ b/loom-daemon/src/safehouse.rs
@@ -221,6 +221,116 @@ fn env_nonempty(key: &str) -> Option<String> {
 }
 
 // ============================================================================
+// Connection state (issue #4345 — new-host onboarding visibility)
+// ============================================================================
+//
+// Before #4345, `safehouse.enabled` false/absent, enabled-but-unreachable, and
+// enabled-and-connected all looked identical to an operator: silence. The
+// narration sink and peer-claim coordination task both already know their own
+// live connection state; this cell is how that knowledge reaches
+// `loom-daemon status` without a second, status-time connection attempt (a
+// CLI-side probe can't know "room joined" the way the daemon's own live
+// connection can).
+
+/// Live safehouse connection state, shared between the narration sink
+/// ([`run_sink`]) and the peer-claim coordination task ([`run_coordination`])
+/// via a [`SharedSafehouseState`] cell — the same "shared `Arc<Mutex<..>>`
+/// updated by the task that owns the connection" shape [`PeerClaimView`]
+/// already uses. Both tasks connect to the same `safehoused` peer off the same
+/// resolved config, so in steady state they agree; a transient disagreement
+/// (one connection drops, the other has not yet) resolves to whichever task
+/// transitions last, which self-heals on the next reconnect attempt.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum SafehouseState {
+    /// `safehouse.enabled` is false/absent (the byte-for-byte no-op path), or
+    /// enabled with no socket resolving at all. No connection has ever been
+    /// attempted for this transition.
+    #[default]
+    NotConfigured,
+    /// Enabled with a socket resolved, but the most recent connect attempt
+    /// failed, refused, or dropped. `socket` carries the path that was tried.
+    Unreachable { socket: PathBuf },
+    /// The most recent connect attempt completed the `hello` handshake
+    /// successfully. `room` is the configured room name — `None` when
+    /// [`SafehouseConfig::room`] is unset, which is only valid when safehoused
+    /// joined exactly one room (resolved server-side; this client is never
+    /// told the resolved name in that case).
+    Connected {
+        socket: PathBuf,
+        room: Option<String>,
+    },
+}
+
+impl SafehouseState {
+    /// Render into the wire [`crate::types::SafehouseStatus`] shape consumed by
+    /// `DaemonStatusReport` (#4345).
+    #[must_use]
+    pub fn to_status(&self) -> crate::types::SafehouseStatus {
+        match self {
+            Self::NotConfigured => crate::types::SafehouseStatus {
+                state: "not_configured".to_owned(),
+                socket: None,
+                room: None,
+            },
+            Self::Unreachable { socket } => crate::types::SafehouseStatus {
+                state: "unreachable".to_owned(),
+                socket: Some(socket.clone()),
+                room: None,
+            },
+            Self::Connected { socket, room } => crate::types::SafehouseStatus {
+                state: "connected".to_owned(),
+                socket: Some(socket.clone()),
+                room: room.clone(),
+            },
+        }
+    }
+}
+
+/// A shared, `Arc`-wrapped connection-state cell, injected into
+/// [`spawn_sink`]/[`spawn_peer_coordination`] (and their `run_*` loops) so
+/// [`WorkspacePool`](crate::workspace_pool::WorkspacePool) can hold one cell
+/// per daemon and read it back for `loom-daemon status` without a second
+/// connection. Mirrors [`PeerClaimView`]'s `Arc<Mutex<..>>` injection shape.
+pub type SharedSafehouseState = Arc<Mutex<SafehouseState>>;
+
+/// Construct a fresh cell defaulted to [`SafehouseState::NotConfigured`] — the
+/// correct starting value for a daemon that has not yet called
+/// [`spawn_sink`]/[`spawn_peer_coordination`] for this cell.
+#[must_use]
+pub fn new_shared_state() -> SharedSafehouseState {
+    Arc::new(Mutex::new(SafehouseState::default()))
+}
+
+/// Overwrite `cell` with `state`. Recovers a poisoned mutex (a panic on some
+/// other thread while holding the lock must never permanently blind `status`
+/// to connection state) rather than propagating the poison.
+fn set_state(cell: &SharedSafehouseState, state: SafehouseState) {
+    match cell.lock() {
+        Ok(mut guard) => *guard = state,
+        Err(poisoned) => *poisoned.into_inner() = state,
+    }
+}
+
+/// Snapshot the current connection state out of `cell`.
+#[must_use]
+pub fn snapshot_state(cell: &SharedSafehouseState) -> SafehouseState {
+    match cell.lock() {
+        Ok(guard) => guard.clone(),
+        Err(poisoned) => poisoned.into_inner().clone(),
+    }
+}
+
+/// Set `cell` to [`SafehouseState::NotConfigured`] (#4345). Exposed (unlike
+/// [`set_state`]) for `workspace_pool.rs`'s disabled-config fast path in
+/// `start_peer_coordination`, which returns before ever calling
+/// [`spawn_peer_coordination`] — the one caller outside this module that needs
+/// to report a transition directly rather than through a `spawn_*`/`run_*`
+/// entry point.
+pub fn set_not_configured(cell: &SharedSafehouseState) {
+    set_state(cell, SafehouseState::NotConfigured);
+}
+
+// ============================================================================
 // Envelope
 // ============================================================================
 
@@ -613,15 +723,20 @@ impl SafehouseClient {
 
 /// Spawn the narration sink on `runtime` when enabled. Returns the task handle,
 /// or `None` (a byte-for-byte no-op: no bus subscription, no socket) when
-/// disabled or when no socket path can be resolved.
+/// disabled or when no socket path can be resolved. `state` (#4345) is updated
+/// with the resolved config-only state immediately (before any connection
+/// attempt) and further updated by [`run_sink`] as connect/disconnect
+/// transitions happen — see [`SafehouseState`].
 #[must_use]
 pub fn spawn_sink(
     config: SafehouseConfig,
     bus: &EventBus,
     runtime: &tokio::runtime::Handle,
+    state: SharedSafehouseState,
 ) -> Option<tokio::task::JoinHandle<()>> {
     if !config.enabled {
         // Disabled ⇒ do not even subscribe. No syscalls, no behavior change.
+        set_state(&state, SafehouseState::NotConfigured);
         return None;
     }
     let Some(socket) = resolve_socket(&config) else {
@@ -629,6 +744,10 @@ pub fn spawn_sink(
             "safehouse: enabled but no socket path resolved \
              (set safehouse.socket, $LOOM_SAFEHOUSE_SOCKET, or $SAFEHOUSED_SOCKET) — narration off"
         );
+        // No socket ⇒ nothing to report as "unreachable at <path>"; the
+        // degradation contract's "not configured" bucket also covers this
+        // (AC: "not configured (no safehouse block / disabled)").
+        set_state(&state, SafehouseState::NotConfigured);
         return None;
     };
     log::info!(
@@ -639,7 +758,8 @@ pub fn spawn_sink(
     // Empty topic set ⇒ receive every event; we filter in `event_to_envelope`.
     let subscription = bus.subscribe(Vec::<String>::new());
     Some(runtime.spawn(async move {
-        run_sink(config, socket, subscription, DEFAULT_MIN_BACKOFF, DEFAULT_MAX_BACKOFF).await;
+        run_sink(config, socket, subscription, DEFAULT_MIN_BACKOFF, DEFAULT_MAX_BACKOFF, state)
+            .await;
     }))
 }
 
@@ -709,7 +829,19 @@ async fn run_sink(
     mut subscription: crate::event_bus::Subscription,
     min_backoff: Duration,
     max_backoff: Duration,
+    state: SharedSafehouseState,
 ) {
+    // Report "configured, not yet connected" immediately — the sink connects
+    // lazily on the first narrated event (below), so without this a daemon
+    // that starts before any sweep activity would keep reading whatever the
+    // cell held before this task existed (#4345 edge case: "daemon starts
+    // before safehoused").
+    set_state(
+        &state,
+        SafehouseState::Unreachable {
+            socket: socket.clone(),
+        },
+    );
     let mut client: Option<SafehouseClient> = None;
     // Next instant a reconnect may be attempted, and the current backoff.
     let mut next_attempt = Instant::now();
@@ -764,6 +896,13 @@ async fn run_sink(
                     client = Some(connected);
                     backoff = min_backoff;
                     warned = false;
+                    set_state(
+                        &state,
+                        SafehouseState::Connected {
+                            socket: socket.clone(),
+                            room: config.room.clone(),
+                        },
+                    );
                 }
                 Err(err) => {
                     if !warned {
@@ -774,6 +913,12 @@ async fn run_sink(
                         );
                         warned = true;
                     }
+                    set_state(
+                        &state,
+                        SafehouseState::Unreachable {
+                            socket: socket.clone(),
+                        },
+                    );
                     next_attempt = Instant::now() + backoff;
                     backoff = (backoff * 2).min(max_backoff);
                     continue;
@@ -787,6 +932,12 @@ async fn run_sink(
                     "safehouse: narration send failed ({err:#}); will reconnect, sweep unaffected"
                 );
                 client = None;
+                set_state(
+                    &state,
+                    SafehouseState::Unreachable {
+                        socket: socket.clone(),
+                    },
+                );
                 next_attempt = Instant::now() + backoff;
                 backoff = (backoff * 2).min(max_backoff);
                 warned = true;
@@ -877,14 +1028,23 @@ pub fn claim_ad_to_envelope(ad: &ClaimAd) -> Envelope {
 /// drains the socket continuously via `select!`, so an idle daemon that emits no
 /// narration still observes peer claims promptly (the narration sink's
 /// `read_reply` only drains while it is emitting).
+///
+/// `state` (#4345) is updated with the resolved config-only state immediately
+/// (before any connection attempt) and further updated by [`run_coordination`]
+/// as connect/disconnect transitions happen — see [`SafehouseState`]. This
+/// task connects **eagerly** (unlike the narration sink's lazy first-event
+/// connect), so it is usually the first to observe a fresh daemon's true
+/// connection state.
 #[must_use]
 pub fn spawn_peer_coordination(
     config: SafehouseConfig,
     sink: Arc<dyn InboundEventSink>,
     outbound: tokio::sync::mpsc::Receiver<ClaimAd>,
     runtime: &tokio::runtime::Handle,
+    state: SharedSafehouseState,
 ) -> Option<tokio::task::JoinHandle<()>> {
     if !config.enabled {
+        set_state(&state, SafehouseState::NotConfigured);
         return None; // disabled ⇒ no socket, no task, no syscalls
     }
     let Some(socket) = resolve_socket(&config) else {
@@ -893,6 +1053,9 @@ pub fn spawn_peer_coordination(
              (set safehouse.socket, $LOOM_SAFEHOUSE_SOCKET, or $SAFEHOUSED_SOCKET) — \
              soft-claim coordination off"
         );
+        // See spawn_sink's identical fallback: no socket resolved groups under
+        // "not configured", the AC's bucket for "nothing to even try".
+        set_state(&state, SafehouseState::NotConfigured);
         return None;
     };
     log::info!(
@@ -901,8 +1064,16 @@ pub fn spawn_peer_coordination(
         socket.display()
     );
     Some(runtime.spawn(async move {
-        run_coordination(config, socket, sink, outbound, DEFAULT_MIN_BACKOFF, DEFAULT_MAX_BACKOFF)
-            .await;
+        run_coordination(
+            config,
+            socket,
+            sink,
+            outbound,
+            DEFAULT_MIN_BACKOFF,
+            DEFAULT_MAX_BACKOFF,
+            state,
+        )
+        .await;
     }))
 }
 
@@ -917,10 +1088,17 @@ async fn run_coordination(
     mut outbound: tokio::sync::mpsc::Receiver<ClaimAd>,
     min_backoff: Duration,
     max_backoff: Duration,
+    state: SharedSafehouseState,
 ) {
     let mut backoff = min_backoff;
     let mut warned = false;
     loop {
+        set_state(
+            &state,
+            SafehouseState::Unreachable {
+                socket: socket.clone(),
+            },
+        );
         let client = match SafehouseClient::connect(&socket, &config.persona, config.room.clone())
             .await
         {
@@ -930,6 +1108,13 @@ async fn run_coordination(
                 }
                 backoff = min_backoff;
                 warned = false;
+                set_state(
+                    &state,
+                    SafehouseState::Connected {
+                        socket: socket.clone(),
+                        room: config.room.clone(),
+                    },
+                );
                 client
             }
             Err(err) => {
@@ -1042,6 +1227,64 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
     use std::sync::{Arc, Mutex};
     use tokio::net::UnixListener;
+
+    // ---- connection-state cell + wire rendering (#4345) ----
+
+    #[test]
+    fn new_shared_state_defaults_to_not_configured() {
+        let state = new_shared_state();
+        assert_eq!(snapshot_state(&state), SafehouseState::NotConfigured);
+    }
+
+    #[test]
+    fn set_not_configured_overwrites_any_prior_state() {
+        let state = new_shared_state();
+        set_state(
+            &state,
+            SafehouseState::Connected {
+                socket: PathBuf::from("/tmp/x.sock"),
+                room: None,
+            },
+        );
+        set_not_configured(&state);
+        assert_eq!(snapshot_state(&state), SafehouseState::NotConfigured);
+    }
+
+    #[test]
+    fn state_to_status_maps_all_three_states() {
+        let not_configured = SafehouseState::NotConfigured.to_status();
+        assert_eq!(not_configured.state, "not_configured");
+        assert!(not_configured.socket.is_none());
+        assert!(not_configured.room.is_none());
+
+        let unreachable = SafehouseState::Unreachable {
+            socket: PathBuf::from("/tmp/x.sock"),
+        }
+        .to_status();
+        assert_eq!(unreachable.state, "unreachable");
+        assert_eq!(unreachable.socket, Some(PathBuf::from("/tmp/x.sock")));
+        assert!(unreachable.room.is_none());
+
+        let connected = SafehouseState::Connected {
+            socket: PathBuf::from("/tmp/x.sock"),
+            room: Some("fleet".to_owned()),
+        }
+        .to_status();
+        assert_eq!(connected.state, "connected");
+        assert_eq!(connected.socket, Some(PathBuf::from("/tmp/x.sock")));
+        assert_eq!(connected.room.as_deref(), Some("fleet"));
+
+        // A connected state with no configured room (safehoused resolved the
+        // sole joined room server-side) still reports "connected" — `room`
+        // just stays `None` rather than inventing a name.
+        let connected_no_room = SafehouseState::Connected {
+            socket: PathBuf::from("/tmp/x.sock"),
+            room: None,
+        }
+        .to_status();
+        assert_eq!(connected_no_room.state, "connected");
+        assert!(connected_no_room.room.is_none());
+    }
 
     // ---- config resolution (config > default, no env) ----
 
@@ -1469,6 +1712,7 @@ mod tests {
             subscription,
             Duration::from_millis(20),
             Duration::from_millis(80),
+            new_shared_state(),
         ));
 
         bus.publish(Event::SweepGlobalDispatch {
@@ -1577,14 +1821,18 @@ mod tests {
     async fn disabled_config_does_not_subscribe() {
         let bus = EventBus::new();
         assert_eq!(bus.receiver_count(), 0);
+        let state = new_shared_state();
         let handle = spawn_sink(
             SafehouseConfig::default(), // disabled
             &bus,
             &tokio::runtime::Handle::current(),
+            state.clone(),
         );
         assert!(handle.is_none(), "disabled ⇒ no sink task");
         // The load-bearing no-op assertion: no subscription was created.
         assert_eq!(bus.receiver_count(), 0, "disabled ⇒ no bus subscription");
+        // #4345: disabled must report as "not configured", never silence.
+        assert_eq!(snapshot_state(&state), SafehouseState::NotConfigured);
     }
 
     #[tokio::test]
@@ -1596,6 +1844,7 @@ mod tests {
         let bus = Arc::new(EventBus::new());
         let subscription = bus.subscribe(Vec::<String>::new());
 
+        let state = new_shared_state();
         let sink = tokio::spawn(run_sink(
             SafehouseConfig {
                 enabled: true,
@@ -1606,6 +1855,7 @@ mod tests {
             subscription,
             Duration::from_millis(50),
             Duration::from_millis(200),
+            state.clone(),
         ));
 
         // Publish a burst; the sink must consume them all without wedging.
@@ -1619,6 +1869,14 @@ mod tests {
         }
         // Give the sink a moment to drain, then drop the bus to close the sub.
         tokio::time::sleep(Duration::from_millis(100)).await;
+        // #4345: an absent peer must report "unreachable" (with the resolved
+        // socket path), never silence and never a stale "not configured".
+        match snapshot_state(&state) {
+            SafehouseState::Unreachable { socket } => {
+                assert_eq!(socket, PathBuf::from("/nonexistent/safehoused.sock"));
+            }
+            other => panic!("expected Unreachable, got {other:?}"),
+        }
         drop(bus);
         // The sink must exit cleanly once the bus closes (it never blocked).
         tokio::time::timeout(Duration::from_secs(2), sink)
@@ -1638,6 +1896,7 @@ mod tests {
 
         let bus = Arc::new(EventBus::new());
         let subscription = bus.subscribe(Vec::<String>::new());
+        let state = new_shared_state();
         let sink = tokio::spawn(run_sink(
             SafehouseConfig {
                 enabled: true,
@@ -1648,6 +1907,7 @@ mod tests {
             subscription,
             Duration::from_millis(20),
             Duration::from_millis(80),
+            state.clone(),
         ));
 
         // First event: delivered over listener1.
@@ -1691,6 +1951,12 @@ mod tests {
             .expect("sink must reconnect and deliver to the second server")
             .unwrap();
         assert!(!second.is_empty(), "a narration must land post-reconnect");
+        // #4345: the reconnect must be visible as Connected again, not stuck
+        // reporting the mid-outage Unreachable value.
+        match snapshot_state(&state) {
+            SafehouseState::Connected { socket: s, .. } => assert_eq!(s, socket),
+            other => panic!("expected Connected after reconnect, got {other:?}"),
+        }
 
         sink_done.await.unwrap();
         let _ = tokio::time::timeout(Duration::from_secs(2), sink).await;
@@ -1725,13 +1991,17 @@ mod tests {
         let view = Arc::new(Mutex::new(PeerClaimView::new("me".into(), Duration::from_secs(1))));
         let sink: Arc<dyn InboundEventSink> = Arc::new(PeerClaimSink::new(view));
         let (_tx, rx) = tokio::sync::mpsc::channel::<ClaimAd>(1);
+        let state = new_shared_state();
         let handle = spawn_peer_coordination(
             SafehouseConfig::default(), // disabled
             sink,
             rx,
             &tokio::runtime::Handle::current(),
+            state.clone(),
         );
         assert!(handle.is_none(), "disabled ⇒ no coordination task");
+        // #4345: disabled must report as "not configured".
+        assert_eq!(snapshot_state(&state), SafehouseState::NotConfigured);
     }
 
     #[tokio::test]
@@ -1771,6 +2041,7 @@ mod tests {
         let sink: Arc<dyn InboundEventSink> = Arc::new(PeerClaimSink::new(view.clone()));
         let (_tx, rx) = tokio::sync::mpsc::channel::<ClaimAd>(8); // held → task stays alive; never send (idle)
 
+        let state = new_shared_state();
         let task = tokio::spawn(run_coordination(
             SafehouseConfig {
                 enabled: true,
@@ -1782,6 +2053,7 @@ mod tests {
             rx,
             Duration::from_millis(20),
             Duration::from_millis(80),
+            state.clone(),
         ));
 
         // Poll the view for the claim (bounded condition-poll, not a fixed
@@ -1799,6 +2071,11 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
         assert!(seen, "an idle daemon must still observe the inbound peer claim (Gap 1a)");
+        // #4345: a live, idle coordination connection must report Connected.
+        match snapshot_state(&state) {
+            SafehouseState::Connected { socket: s, .. } => assert_eq!(s, socket),
+            other => panic!("expected Connected, got {other:?}"),
+        }
         server.await.unwrap();
         task.abort();
     }
@@ -1812,6 +2089,7 @@ mod tests {
         let view = Arc::new(Mutex::new(PeerClaimView::new("me".into(), Duration::from_secs(1))));
         let sink: Arc<dyn InboundEventSink> = Arc::new(PeerClaimSink::new(view));
         let (tx, rx) = tokio::sync::mpsc::channel::<ClaimAd>(4);
+        let state = new_shared_state();
 
         let task = tokio::spawn(run_coordination(
             SafehouseConfig {
@@ -1819,11 +2097,12 @@ mod tests {
                 socket: Some(socket.clone()),
                 ..SafehouseConfig::default()
             },
-            socket,
+            socket.clone(),
             sink,
             rx,
             Duration::from_millis(10),
             Duration::from_millis(30),
+            state.clone(),
         ));
 
         // Drop the only sender: the connect-fail drain loop must observe
@@ -1833,5 +2112,11 @@ mod tests {
             .await
             .expect("coordination task must terminate after its senders drop")
             .unwrap();
+        // #4345: a socket that never accepts must report Unreachable, never a
+        // stale "not configured" (the config here IS enabled).
+        match snapshot_state(&state) {
+            SafehouseState::Unreachable { socket: s } => assert_eq!(s, socket),
+            other => panic!("expected Unreachable, got {other:?}"),
+        }
     }
 }

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -1088,6 +1088,39 @@ pub struct DaemonStatusReport {
     /// heap alloc on an already-rare, human-latency status round-trip).
     #[serde(default)]
     pub host_breaker: Option<Box<HostBreakerStatus>>,
+    /// Live safehouse fleet-comms connection state (Issue #4345): distinguishes
+    /// `not_configured` (no `safehouse` block / disabled) from `unreachable`
+    /// (enabled, socket resolved, but the daemon's own connection attempt
+    /// failed/dropped) from `connected` (room joined) — before this the three
+    /// looked identical to an operator (silence). Rendered from
+    /// [`crate::safehouse::SafehouseState`] via
+    /// [`crate::workspace_pool::WorkspacePool::safehouse_status`]. `None` only
+    /// for a pre-#4345 wire payload from an older daemon binary that never
+    /// computed one. `#[serde(default)]` keeps that wire data compatible.
+    #[serde(default)]
+    pub safehouse: Option<SafehouseStatus>,
+}
+
+/// Live safehouse connection status for `loom-daemon status` (Issue #4345).
+/// See [`DaemonStatusReport::safehouse`] and `.loom/docs/safehouse.md`
+/// "New-host onboarding" for the operator story.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SafehouseStatus {
+    /// One of `"not_configured"`, `"unreachable"`, `"connected"`.
+    pub state: String,
+    /// The resolved socket path the daemon last tried/uses, when known.
+    /// `None` for `"not_configured"` (including the "enabled but no socket
+    /// resolves at all" sub-case, which also reports as `"not_configured"` —
+    /// there is nothing to name a path against).
+    #[serde(default)]
+    pub socket: Option<PathBuf>,
+    /// The configured room name, present only when `state == "connected"`.
+    /// `None` even when connected if no `safehouse.room` was configured
+    /// (valid only when safehoused joined exactly one room, resolved
+    /// server-side — this client is never told the resolved name in that
+    /// case).
+    #[serde(default)]
+    pub room: Option<String>,
 }
 
 /// Host-distress circuit-breaker snapshot for `loom-daemon status` (Issue

--- a/loom-daemon/src/workspace_pool.rs
+++ b/loom-daemon/src/workspace_pool.rs
@@ -106,6 +106,12 @@ pub struct WorkspacePool {
     /// [`start_peer_coordination`](Self::start_peer_coordination); injected into
     /// every registry [`get_or_provision`](Self::get_or_provision) builds.
     peer_coord: Mutex<Option<PeerCoordination>>,
+    /// The daemon-wide live safehouse connection-state cell (Issue #4345),
+    /// updated by both [`start_safehouse_narration`](Self::start_safehouse_narration)'s
+    /// sink and [`start_peer_coordination`](Self::start_peer_coordination)'s
+    /// coordination task. Read back by [`safehouse_status`](Self::safehouse_status)
+    /// for `loom-daemon status` — see `crate::safehouse::SafehouseState`.
+    safehouse_state: safehouse::SharedSafehouseState,
 }
 
 impl WorkspacePool {
@@ -118,6 +124,7 @@ impl WorkspacePool {
             runtime,
             inner: Mutex::new(HashMap::new()),
             peer_coord: Mutex::new(None),
+            safehouse_state: safehouse::new_shared_state(),
         }
     }
 
@@ -132,7 +139,21 @@ impl WorkspacePool {
     /// failure. The handle is detached (daemon-lifetime).
     pub fn start_safehouse_narration(&self, repo_root: &Path) {
         let config = crate::safehouse::resolve_config(repo_root);
-        let _ = crate::safehouse::spawn_sink(config, &self.event_bus, &self.runtime);
+        let _ = crate::safehouse::spawn_sink(
+            config,
+            &self.event_bus,
+            &self.runtime,
+            self.safehouse_state.clone(),
+        );
+    }
+
+    /// Snapshot the live safehouse connection state (Issue #4345) for
+    /// `loom-daemon status`: `not_configured` / `unreachable` / `connected`,
+    /// replacing the pre-#4345 silence all three states shared. See
+    /// `.loom/docs/safehouse.md` "New-host onboarding".
+    #[must_use]
+    pub fn safehouse_status(&self) -> crate::types::SafehouseStatus {
+        safehouse::snapshot_state(&self.safehouse_state).to_status()
     }
 
     /// Start the daemon-wide safehouse **peer-claim coordination** (Issue #4028)
@@ -149,6 +170,10 @@ impl WorkspacePool {
     pub fn start_peer_coordination(&self, repo_root: &Path) {
         let config = safehouse::resolve_config(repo_root);
         if !config.enabled {
+            // Mirrors spawn_sink's own disabled handling — set here too since
+            // this early return means spawn_peer_coordination (which would
+            // otherwise set it) is never reached (#4345).
+            safehouse::set_not_configured(&self.safehouse_state);
             return; // disabled ⇒ no coordination, byte-for-byte no-op
         }
         let mut slot = self
@@ -162,7 +187,13 @@ impl WorkspacePool {
         let view = Arc::new(Mutex::new(PeerClaimView::new(host_identity(), ttl)));
         let (tx, rx) = tokio::sync::mpsc::channel::<ClaimAd>(safehouse::PEER_CLAIM_CHANNEL_CAP);
         let sink: Arc<dyn InboundEventSink> = Arc::new(PeerClaimSink::new(view.clone()));
-        let task = safehouse::spawn_peer_coordination(config, sink, rx, &self.runtime);
+        let task = safehouse::spawn_peer_coordination(
+            config,
+            sink,
+            rx,
+            &self.runtime,
+            self.safehouse_state.clone(),
+        );
         if task.is_none() {
             // Enabled but no socket resolved: leave coordination unestablished so
             // registries stay in the no-op path (the outbound sender would have
@@ -465,6 +496,79 @@ mod tests {
         let pool = pool();
         assert!(pool.is_empty());
         assert_eq!(pool.len(), 0);
+    }
+
+    // ---- safehouse connection-state wiring (#4345) ----
+
+    #[tokio::test]
+    async fn safehouse_status_defaults_to_not_configured_before_any_start_call() {
+        let pool = pool();
+        assert_eq!(pool.safehouse_status().state, "not_configured");
+    }
+
+    #[tokio::test]
+    async fn start_safehouse_narration_surfaces_unreachable_for_enabled_unresolved_socket() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let socket = dir.path().join("nope.sock"); // never bound
+        write_config(
+            &root,
+            &format!(
+                r#"{{"safehouse": {{"enabled": true, "socket": {:?}}}}}"#,
+                socket.display().to_string()
+            ),
+        );
+        let pool = pool();
+
+        pool.start_safehouse_narration(&root);
+        // The sink reports "configured, not yet connected" immediately on
+        // spawn (before any connect attempt) — poll briefly rather than
+        // assuming the spawned task has already run once.
+        let mut status = pool.safehouse_status();
+        for _ in 0..50 {
+            if status.state != "not_configured" {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            status = pool.safehouse_status();
+        }
+        assert_eq!(status.state, "unreachable");
+        assert_eq!(status.socket, Some(socket));
+    }
+
+    #[tokio::test]
+    async fn start_peer_coordination_disabled_reports_not_configured_even_after_prior_state() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let socket = dir.path().join("nope.sock");
+        write_config(
+            &root,
+            &format!(
+                r#"{{"safehouse": {{"enabled": true, "socket": {:?}}}}}"#,
+                socket.display().to_string()
+            ),
+        );
+        let pool = pool();
+
+        // Drive the cell to a non-default state first via the narration sink.
+        pool.start_safehouse_narration(&root);
+        let mut status = pool.safehouse_status();
+        for _ in 0..50 {
+            if status.state != "not_configured" {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            status = pool.safehouse_status();
+        }
+        assert_eq!(status.state, "unreachable", "precondition: cell must be non-default");
+
+        // Now disable and re-resolve via the peer-coordination entry point's
+        // own disabled fast path (which returns before ever calling
+        // spawn_peer_coordination — the code path #4345 had to patch
+        // explicitly).
+        write_config(&root, r#"{"safehouse": {"enabled": false}}"#);
+        pool.start_peer_coordination(&root);
+        assert_eq!(pool.safehouse_status().state, "not_configured");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Implements the **visibility + docs** half of #4345 ("new-host onboarding:
safehoused is neither provisioned nor surfaced when loom-daemon starts on a
fresh host"). Before this, `safehouse.enabled` false/absent, enabled-but-
unreachable, and enabled-and-connected all looked identical to an operator —
silence. This PR gives an operator a way to actually see which of the three a
host is in, without requiring a change in runtime behavior.

- **State cell**: `loom-daemon/src/safehouse.rs` gets a `SafehouseState` enum
  (`NotConfigured` / `Unreachable { socket }` / `Connected { socket, room }`)
  and a `SharedSafehouseState = Arc<Mutex<SafehouseState>>` cell — the same
  injection shape `PeerClaimView` already uses. Both the narration sink
  (`run_sink`) and the peer-claim coordination task (`run_coordination`)
  update it on every connect/disconnect transition.
- **Pool wiring**: `WorkspacePool` (`workspace_pool.rs`) owns one cell per
  daemon and exposes `safehouse_status()`; `start_safehouse_narration` /
  `start_peer_coordination` both thread the cell through.
- **Status report**: a new optional `DaemonStatusReport.safehouse` field
  (`SafehouseStatus` in `types.rs`, `#[serde(default)]` for wire compat with
  older daemons) is populated in `ipc::build_daemon_status` and rendered by
  both `loom-daemon status` (human `Safehouse:` line) and `status --json`
  (`safehouse` object) in `main.rs`.
- **Start wrapper**: `loom-daemon-start.sh` prints a cheaper, static,
  pre-connect `Safehouse:` line at every successful start path (launchd,
  systemd, nohup fallback), reusing `lib/mcp-config.sh`'s existing
  `loom_mcp_safehouse_enabled`/`loom_mcp_safehouse_socket` resolvers rather
  than re-deriving the env>config>default precedence.
- **Docs**: `.loom/docs/safehouse.md` gains a "Connection status" section
  documenting the three states/two surfaces, and a "New-host onboarding"
  runbook (bot account, build/install safehoused, socket env, config block,
  start/verify) covering the *manual* path end to end.
- **Degradation contract preserved**: with no `safehouse` block, the state
  cell defaults to (and the disabled fast paths explicitly set)
  `NotConfigured`, but nothing about the byte-for-byte no-op runtime
  behavior changed — zero connection attempts, zero syscalls.

### Scope: visibility ships now, provisioning is a follow-up

The issue's own curator enhancement flagged that visibility+docs and
provisioning together exceed single-PR scope (>8 files) and recommended a
2-way split, visibility first since it's what makes provisioning verifiable.
Provisioning (a supervised `safehoused` service wrapper — launchd/systemd,
mirroring `loom-daemon-start.sh`'s own pattern — plus an install step) also
carries a cross-repo design decision (whether the service wrapper lives in
this repo or the `rjwalters/safehouse` repo) the issue explicitly leaves for
the Builder to settle. Rather than default that decision under this PR's
scope pressure, I filed it as a clearly-scoped follow-up: **#4359**.

### Acceptance criteria from #4345

- [x] Visibility: `loom-daemon status` (+ `--json`) distinguishes `not
      configured` / `configured, unreachable` (with resolved socket path) /
      `connected` (with room).
- [x] Start wrapper: `loom-daemon-start.sh` surfaces the same states (minus
      "connected", which needs a live daemon connection — documented).
- [x] Degradation contract preserved (no `safehouse` block ⇒ byte-for-byte
      no-op, confirmed by existing + new tests).
- [x] Docs: "New-host onboarding" runbook section.
- [ ] Provisioning path (supervised service + install step) — deferred to
      #4359 per the scope split above.

## Test plan

- `cargo test -p loom-daemon` — full `--lib` suite passes (1558 tests),
  including new/updated cases in `safehouse.rs` (state-cell transitions +
  wire rendering), `workspace_pool.rs` (pool wiring, disabled fast path),
  and `ipc.rs` (`build_daemon_status` report field, JSON round-trip).
- `defaults/scripts/tests/test-loom-daemon-start.sh` — 40/40 pass, including
  3 new cases: no config block → `not configured`; enabled + missing socket
  → `configured, unreachable` (with the resolved path); enabled + a real
  bound `AF_UNIX` socket file present → `configured (socket present ...)`.
- `cargo fmt --check` and `cargo clippy -p loom-daemon --all-targets` are
  clean.

Closes #4345