### PR TITLE
fix(daemon): unify ranking-file resolution and fix the honest-status headline for token capacity

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1235,7 +1235,7 @@ daemon restart:
 
 | Input | Source | Bound it enforces |
 |-------|--------|-------------------|
-| **healthy-token count** | `available` accounts in `{workspace}/.loom/tokens/.ranking` (`capacity::token_axis_limit`), falling back to the `*.token` count (`tokens::token_pool_size`) when no ranking exists | the count of accounts safe to dispatch to — never dispatch to an exhausted/blocked one (#3902) |
+| **healthy-token count** | `available` accounts in `.ranking` in the pool directory `tokens_pool::paths::resolve_tokens_dir` resolves for the workspace — per-repo `{workspace}/.loom/tokens/` when it holds `*.token` files, else the shared machine-level pool (#3938) (`capacity::read_ranking` / `token_axis_limit`, unified with the writer in #4344 — pre-#4344 this hardcoded the per-repo path even on a shared-pool host, which could pin the dispatch cap at 0 against an orphaned per-repo `.ranking` indefinitely), falling back to the `*.token` count (`tokens::token_pool_size`) when no ranking exists | the count of accounts safe to dispatch to — never dispatch to an exhausted/blocked one (#3902) |
 | **per-token concurrency** | `LOOM_PER_TOKEN_CONCURRENCY` / `autonomous.perTokenConcurrency`, default **2** (#3947) | how many concurrent sweeps to allow **per healthy account**. A plan limit is a utilization-window token bucket, not a session count, so one healthy account can run several concurrent sessions. Before #3947 the implicit factor was `1` (one sweep per account), which collapsed the whole fleet to cap 1 when 6/7 accounts were at their weekly ceiling even though the single healthy account had ample session-window headroom |
 | **disk headroom** | `floor(free_gb / LOOM_PER_WORKTREE_GB)` on the worktree-root volume (`disk_headroom::disk_headroom_limit`, a Rust port of `disk-headroom.sh` that shells to `df -Pk`) | never provision more worktrees than the scratch volume can hold |
 | **cpu headroom** (#3978, measured-idle signal #4031) | `max(1, floor((logical_cpus × LOOM_CPU_UTILIZATION_TARGET − consumed_cores) / LOOM_EST_CORES_PER_SWEEP))`, where `consumed_cores = logical_cpus × (1 − idle_fraction)` from the measured idle fraction (loadavg fallback) (`cpu_headroom::cpu_headroom_limit`) | never start more concurrent sweeps than the host's CPU headroom can currently absorb |
@@ -1433,6 +1433,30 @@ diagnosis line; at or above the cap it names the binding term as before. The
 `= min(…)` breakdown line is untouched — those genuinely are ceilings. The JSON
 status carries the same `capacity_bound` boolean so scripted consumers aren't
 misled at low occupancy either.
+
+**Honest headline when the daemon's own read disagrees with a fresh probe
+(#4344).** `resolve_capacity` prefers a fresh client-side `loom-tokens check
+--json` probe over the daemon's own ranking read when one succeeds — useful for
+showing current numbers, but that probe's cap is **not** what the running
+daemon actually used to gate dispatch this tick. The pretty-printed `Dynamic
+concurrency cap:` headline and the `= min(healthy N × per-token M …)`
+breakdown always name the daemon's own numbers (`report.dynamic_cap` /
+`report.capacity.token_axis_limit`) — the probe's cap is shown only as a
+labeled secondary `fresh probe suggests: …` line when it differs. The
+`capacity_bound` gate above is likewise computed against the daemon's own cap,
+not the probe's, so "not capacity-bound" can never print while the daemon's
+real (lower) cap is already saturated. When the daemon's own ranking read
+shows **0 healthy accounts** while the probe (or raw pool) disagrees — the
+#4344 incident: dispatch pinned at a token term of `0 × per-token = 0` for
+~40 minutes because the ranking directory it read had diverged from the one
+`loom-tokens check --ranking` / the #4080 self-refresher actually wrote — the
+status view promotes this from the old small-print `note: daemon dispatch cap
+still uses a stale .ranking (...)` line to a headline `⚠ DISPATCH IS
+TOKEN-STARVED: …` line and suppresses "the limiter is work availability"
+underneath it, since the real limiter is unambiguously the token term. The
+root fix for the divergence itself is unifying which `.ranking` file
+[`capacity::read_ranking`] consults — see the healthy-token-count row of the
+input table above.
 
 **Session-limit fault handling (#3947).** Stacking can occasionally trip a
 **concurrent-session-limit** fault on a token (the account is healthy but cannot

--- a/loom-daemon/src/capacity.rs
+++ b/loom-daemon/src/capacity.rs
@@ -157,29 +157,44 @@ impl RankingSnapshot {
 /// files, so callers that have their own resolved directory (or want to probe
 /// a specific one directly, e.g. in tests) can bypass re-resolution.
 ///
-/// The file is the pipe-delimited `name|status` format written by
-/// `loom-tokens check --ranking` (one account per line). Returns `None` when the
-/// file is absent, unreadable, or contains no parseable rows — the signal that
-/// no probe data exists, in which case callers fall back to the raw token-pool
-/// size (byte-for-byte the pre-#3902 behavior). Blank lines and malformed rows
-/// (no `|`) are skipped; a row's status is parsed via [`AccountHealth::parse`].
+/// The file is the pipe-delimited `name|status|5h_util` format written by
+/// `loom-tokens check --ranking` (one account per line, issue #4195), where the
+/// status is the **second** field and the trailing 5h-utilization field is
+/// optional (legacy `name|status` lines omit it). Returns `None` when the file
+/// is absent, unreadable, or contains no parseable rows — the signal that no
+/// probe data exists, in which case callers fall back to the raw token-pool size
+/// (byte-for-byte the pre-#3902 behavior). Blank lines, `#` comments, and
+/// malformed rows (no `|`, so no status field) are skipped; a row's status is
+/// parsed via [`AccountHealth::parse`].
+///
+/// Parsing goes through [`crate::tokens_pool::select::parse_ranking_line`] — the
+/// **same** triple parser the spawn-time selector uses — so this reader and the
+/// selector can never de-sync on the field layout (the #4243/#4344 drift, where
+/// this function took the *last* field as the status and mis-read every 3-field
+/// row's `5h_util` — e.g. `agent3-2amlogic|available|0.09` → `"0.09"` →
+/// [`AccountHealth::Unknown`] — pinning the token axis at 0 on a fully healthy
+/// pool). A malformed no-`|` row is still skipped here (rather than counted with
+/// an empty/unknown status) so an unparseable ranking is treated as absent, not
+/// as a genuine 0-healthy snapshot.
 #[must_use]
 pub fn read_ranking_at(pool_dir: &Path) -> Option<RankingSnapshot> {
     let ranking_path = pool_dir.join(".ranking");
     let contents = std::fs::read_to_string(&ranking_path).ok()?;
     let mut snap = RankingSnapshot::default();
     for line in contents.lines() {
-        let line = line.trim();
-        if line.is_empty() {
+        // A row must carry a `|` (a status field). A no-`|` row is genuinely
+        // malformed and is skipped, not counted as an empty-status account —
+        // preserving the "unparseable ranking ⇒ absent, not 0-healthy"
+        // fallback (see the module doc + `read_ranking_malformed_*` tests).
+        if !line.contains('|') {
             continue;
         }
-        // `name|status` — the status is the last pipe-delimited field so a name
-        // containing a stray pipe (there are none in practice) still parses.
-        let Some((_name, status)) = line.rsplit_once('|') else {
+        let Some((_name, status, _util_5h)) = crate::tokens_pool::select::parse_ranking_line(line)
+        else {
             continue;
         };
         snap.total += 1;
-        match AccountHealth::parse(status) {
+        match AccountHealth::parse(&status) {
             AccountHealth::Available => snap.available += 1,
             AccountHealth::Exhausted => snap.exhausted += 1,
             AccountHealth::RateLimited => snap.rate_limited += 1,
@@ -607,6 +622,155 @@ mod tests {
         assert_eq!(snap.total, 2, "the pipe-less row is skipped");
         assert_eq!(snap.available, 1);
         assert_eq!(snap.exhausted, 1);
+    }
+
+    #[test]
+    fn read_ranking_at_parses_three_field_format() {
+        // #4243/#4344 primary bug: writers emit `name|status|5h_util` whenever
+        // 5h utilization is known (which on the live host is always). The
+        // status is the SECOND field — the reader must NOT take the trailing
+        // util as the status. This is the exact live-host layout from the
+        // #4344 incident: 7 three-field rows, 6 available.
+        let tmp = tempfile::tempdir().unwrap();
+        write_ranking_at(
+            tmp.path(),
+            "agent3-2amlogic|available|0.09\n\
+             robb-2amlogic|available|0.18\n\
+             rjwalters-gmail|available|0.22\n\
+             agent2-2amlogic|available|0.31\n\
+             agent4-2amlogic|available|0.05\n\
+             agent5-2amlogic|available|0.44\n\
+             old-account|exhausted|0.00\n",
+        );
+        let snap = read_ranking_at(tmp.path()).unwrap();
+        assert_eq!(snap.total, 7);
+        assert_eq!(snap.available, 6, "3-field rows: the status is the SECOND field, not the last");
+        assert_eq!(snap.exhausted, 1);
+        assert_eq!(
+            snap.unknown, 0,
+            "the 5h_util field must never be parsed as a status word (the #4243 drift)"
+        );
+    }
+
+    #[test]
+    fn read_ranking_at_curator_fixture_three_field() {
+        // The exact fixture the judge required to pass:
+        //   total=3, available=2, exhausted=1.
+        let tmp = tempfile::tempdir().unwrap();
+        write_ranking_at(
+            tmp.path(),
+            "agent3-2amlogic|available|0.09\n\
+             robb-2amlogic|available|0.18\n\
+             rjwalters-gmail|exhausted|0.00\n",
+        );
+        let snap = read_ranking_at(tmp.path()).unwrap();
+        assert_eq!(snap.total, 3);
+        assert_eq!(snap.available, 2);
+        assert_eq!(snap.exhausted, 1);
+    }
+
+    #[test]
+    fn read_ranking_at_mixed_two_and_three_field() {
+        // A file mixing legacy 2-field lines and new 3-field lines — the state
+        // during a rolling format migration — must parse both correctly.
+        let tmp = tempfile::tempdir().unwrap();
+        write_ranking_at(
+            tmp.path(),
+            "legacy-a|available\n\
+             new-b|available|0.12\n\
+             legacy-c|exhausted\n\
+             new-d|blocked|0.00\n\
+             new-e|rate_limited|0.88\n",
+        );
+        let snap = read_ranking_at(tmp.path()).unwrap();
+        assert_eq!(snap.total, 5);
+        assert_eq!(snap.available, 2);
+        assert_eq!(snap.exhausted, 1);
+        assert_eq!(snap.blocked, 1);
+        assert_eq!(snap.rate_limited, 1);
+        assert_eq!(snap.unknown, 0);
+    }
+
+    #[test]
+    fn read_ranking_at_comment_lines_are_skipped() {
+        // `#` comments (stripped by the shared selector parser) are not rows.
+        let tmp = tempfile::tempdir().unwrap();
+        write_ranking_at(
+            tmp.path(),
+            "# probed 2026-07-29\na|available|0.10\nb|exhausted # near ceiling\n",
+        );
+        let snap = read_ranking_at(tmp.path()).unwrap();
+        assert_eq!(snap.total, 2, "the leading comment line is not a row");
+        assert_eq!(snap.available, 1);
+        assert_eq!(snap.exhausted, 1);
+    }
+
+    #[test]
+    fn ranking_format_drift_conformance_writer_reader_selector_agree() {
+        // Format-drift guard (#4344 AC 3): the single test that would have
+        // caught #4243's partial migration. It binds THREE parties to the same
+        // fixture lines and fails if any one drifts:
+        //   (1) the WRITER — `tokens_pool::check::ranking_line` (what is
+        //       actually written to `.ranking`),
+        //   (2) capacity's READER — `read_ranking_at` (this module),
+        //   (3) the spawn-time SELECTOR's parser —
+        //       `tokens_pool::select::parse_ranking_line`.
+        // If a future format change moves the status field, at least one of
+        // these assertions breaks, so no reader can silently miss the
+        // migration again.
+        use crate::tokens_pool::check::ranking_line;
+        use crate::tokens_pool::select::parse_ranking_line;
+
+        // (name, status, util) fixtures spanning every health class plus the
+        // optional / absent util field.
+        let accounts: [(&str, &str, Option<f64>); 5] = [
+            ("agent3-2amlogic", "available", Some(0.09)),
+            ("robb-2amlogic", "available", None), // legacy 2-field line
+            ("rjwalters-gmail", "exhausted", Some(0.00)),
+            ("agent2", "rate_limited", Some(0.88)),
+            ("agent4", "blocked", None),
+        ];
+
+        // Render the file exactly as the writer would.
+        let body: String = accounts
+            .iter()
+            .map(|(name, status, util)| ranking_line(name, status, *util) + "\n")
+            .collect();
+
+        // (2) vs (3): the selector's parser must recover the same name/status
+        // the writer put in, from the writer's own output.
+        for ((name, status, util), line) in accounts.iter().zip(body.lines()) {
+            let (pname, pstatus, putil) =
+                parse_ranking_line(line).expect("writer output must be parseable by the selector");
+            assert_eq!(&pname, name);
+            assert_eq!(
+                &pstatus, status,
+                "selector parser must recover the writer's status field, not the util"
+            );
+            match util {
+                Some(u) => {
+                    let p = putil.expect("a 3-field line must yield a util");
+                    assert_eq!(format!("{p:.2}"), format!("{u:.2}"));
+                }
+                None => assert_eq!(putil, None, "a 2-field line must yield no util"),
+            }
+        }
+
+        // (1) → (2): capacity's reader must classify that same file into the
+        // writer's intended statuses — 2 available, 1 exhausted, 1
+        // rate_limited, 1 blocked, and crucially 0 unknown.
+        let tmp = tempfile::tempdir().unwrap();
+        write_ranking_at(tmp.path(), &body);
+        let snap = read_ranking_at(tmp.path()).unwrap();
+        assert_eq!(snap.total, 5);
+        assert_eq!(snap.available, 2);
+        assert_eq!(snap.exhausted, 1);
+        assert_eq!(snap.rate_limited, 1);
+        assert_eq!(snap.blocked, 1);
+        assert_eq!(
+            snap.unknown, 0,
+            "no writer-produced line may parse to Unknown — that is the #4243 drift signature"
+        );
     }
 
     // ------------------------------------------------------------------

--- a/loom-daemon/src/capacity.rs
+++ b/loom-daemon/src/capacity.rs
@@ -12,10 +12,13 @@
 //!
 //! 1. **Slow down** — [`token_axis_limit`] backs the token axis off from the
 //!    raw pool size toward the count of *healthy* (`available`) accounts, read
-//!    from the rotation ranking file (`.loom/tokens/.ranking`). When every
-//!    account is exhausted the limit drops to 0 and the finder defers (never
-//!    hammers an exhausted account). A single healthy account is the throughput
-//!    floor, never a halt (operator refinement on #3902).
+//!    from the rotation ranking file (`.ranking`, resolved via
+//!    [`read_ranking`] to whichever pool directory — per-repo or shared
+//!    machine-level (#3938) — actually holds the tokens, kept in lock-step
+//!    with the writer since #4344). When every account is exhausted the limit
+//!    drops to 0 and the finder defers (never hammers an exhausted account). A
+//!    single healthy account is the throughput floor, never a halt (operator
+//!    refinement on #3902).
 //! 2. **Alert** — [`assess_pressure`] derives whether the token axis is the
 //!    binding constraint *and* work is queued behind it, and
 //!    [`CapacityAdvisory::message`] builds an operator advisory naming the
@@ -34,11 +37,14 @@
 //! # Why the ranking file (not a network probe)
 //!
 //! The daemon never performs the slow per-account rate-limit probe itself — that
-//! is `loom-tokens check`'s job, run out-of-band (cron / `probe-tokens.sh`),
-//! which writes the discrete status into `.loom/tokens/.ranking` (the
-//! format-of-record the spawn-time selector already consumes). Reading that file
-//! keeps this module a fast, non-blocking, filesystem-only read that matches the
-//! footing of [`crate::tokens::token_pool_size`] and
+//! is `loom-tokens check`'s job, run out-of-band (cron / `probe-tokens.sh` /
+//! the #4080 self-refresh), which writes the discrete status into
+//! `<resolved-pool-dir>/.ranking` (the format-of-record the spawn-time
+//! selector already consumes). [`read_ranking`] resolves the **same**
+//! directory the writer targets (#3938 per-repo-then-shared precedence,
+//! #4344) so the reader and writer can never diverge onto different files.
+//! Reading that file keeps this module a fast, non-blocking, filesystem-only
+//! read that matches the footing of [`crate::tokens::token_pool_size`] and
 //! [`crate::disk_headroom::disk_headroom_limit`].
 //!
 //! # Near-ceiling granularity
@@ -142,7 +148,14 @@ impl RankingSnapshot {
     }
 }
 
-/// Parse the rotation ranking file at `{workspace_root}/.loom/tokens/.ranking`.
+/// Parse the rotation ranking file directly at `{pool_dir}/.ranking`.
+///
+/// This is the resolved-dir-aware core of [`read_ranking`] (issue #4344):
+/// `pool_dir` is already resolved (e.g. via
+/// [`crate::tokens_pool::paths::resolve_tokens_dir`]) to whichever pool —
+/// per-repo or shared machine-level (#3938) — actually holds the `*.token`
+/// files, so callers that have their own resolved directory (or want to probe
+/// a specific one directly, e.g. in tests) can bypass re-resolution.
 ///
 /// The file is the pipe-delimited `name|status` format written by
 /// `loom-tokens check --ranking` (one account per line). Returns `None` when the
@@ -151,8 +164,8 @@ impl RankingSnapshot {
 /// size (byte-for-byte the pre-#3902 behavior). Blank lines and malformed rows
 /// (no `|`) are skipped; a row's status is parsed via [`AccountHealth::parse`].
 #[must_use]
-pub fn read_ranking(workspace_root: &Path) -> Option<RankingSnapshot> {
-    let ranking_path = workspace_root.join(".loom").join("tokens").join(".ranking");
+pub fn read_ranking_at(pool_dir: &Path) -> Option<RankingSnapshot> {
+    let ranking_path = pool_dir.join(".ranking");
     let contents = std::fs::read_to_string(&ranking_path).ok()?;
     let mut snap = RankingSnapshot::default();
     for line in contents.lines() {
@@ -179,6 +192,32 @@ pub fn read_ranking(workspace_root: &Path) -> Option<RankingSnapshot> {
     } else {
         Some(snap)
     }
+}
+
+/// Parse the rotation ranking file for `workspace_root`, resolving the
+/// effective pool directory the **same way** [`crate::tokens::token_pool_size`]
+/// and [`crate::tokens_pool::paths::resolve_tokens_dir`] do: the per-repo pool
+/// (`{workspace_root}/.loom/tokens/`) when it holds `*.token` files, else the
+/// shared machine-level pool (`~/.loom/tokens`, override
+/// `LOOM_SHARED_TOKENS_DIR`, issue #3938), else the per-repo path unchanged.
+///
+/// # Why this matters (issue #4344)
+///
+/// Before this fix, this function hardcoded the per-repo path regardless of
+/// where the pool (and the ranking the writer refreshes) actually lived. On a
+/// host where the pool resolves to the shared machine-level directory (the
+/// per-repo dir has no `*.token` files), every ranking refresh — manual or the
+/// #4080 self-refresh — landed in the shared `.ranking`, while this reader kept
+/// consulting a stale, orphaned per-repo `.ranking` left over from a prior
+/// storm. If that orphaned file had 0 `available` rows, the token axis was
+/// pinned at 0 **forever** — re-read every tick, always from the wrong file,
+/// surviving even a daemon restart (the orphaned file itself never changes).
+/// Resolving the same directory the writer targets closes that gap; the
+/// fallback semantics (absent/unparseable ranking anywhere ⇒ `None`, callers
+/// fall back to the raw pool size) are unchanged.
+#[must_use]
+pub fn read_ranking(workspace_root: &Path) -> Option<RankingSnapshot> {
+    read_ranking_at(&crate::tokens_pool::paths::resolve_tokens_dir(workspace_root))
 }
 
 // ============================================================================
@@ -479,13 +518,31 @@ pub fn format_minutes(mins: u64) -> String {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use crate::tokens_pool::paths::SHARED_TOKENS_DIR_ENV;
+    use serial_test::serial;
     use std::fs;
     use std::path::Path;
 
+    /// Write a `.ranking` file directly into `pool_dir` (no `.loom/tokens`
+    /// nesting) — the fixture for [`read_ranking_at`], which is
+    /// resolution-agnostic.
+    fn write_ranking_at(pool_dir: &Path, body: &str) {
+        fs::create_dir_all(pool_dir).unwrap();
+        fs::write(pool_dir.join(".ranking"), body).unwrap();
+    }
+
+    /// Write a `.ranking` file at the legacy per-repo location
+    /// (`{workspace}/.loom/tokens/.ranking`) — the fixture for [`read_ranking`]
+    /// resolution tests.
     fn write_ranking(workspace: &Path, body: &str) {
-        let dir = workspace.join(".loom").join("tokens");
-        fs::create_dir_all(&dir).unwrap();
-        fs::write(dir.join(".ranking"), body).unwrap();
+        write_ranking_at(&workspace.join(".loom").join("tokens"), body);
+    }
+
+    /// Write a `.token` file into `dir` so [`crate::tokens_pool::paths::
+    /// resolve_tokens_dir`] treats it as a populated pool.
+    fn write_token_file(dir: &Path, name: &str) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(dir.join(name), "sk-ant-oat01-fake").unwrap();
     }
 
     // ------------------------------------------------------------------
@@ -509,30 +566,30 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // read_ranking
+    // read_ranking_at (pure parsing — no directory resolution, no env)
     // ------------------------------------------------------------------
 
     #[test]
-    fn read_ranking_missing_is_none() {
+    fn read_ranking_at_missing_is_none() {
         let tmp = tempfile::tempdir().unwrap();
-        assert_eq!(read_ranking(tmp.path()), None);
+        assert_eq!(read_ranking_at(tmp.path()), None);
     }
 
     #[test]
-    fn read_ranking_empty_is_none() {
+    fn read_ranking_at_empty_is_none() {
         let tmp = tempfile::tempdir().unwrap();
-        write_ranking(tmp.path(), "\n  \n");
-        assert_eq!(read_ranking(tmp.path()), None);
+        write_ranking_at(tmp.path(), "\n  \n");
+        assert_eq!(read_ranking_at(tmp.path()), None);
     }
 
     #[test]
-    fn read_ranking_counts_statuses() {
+    fn read_ranking_at_counts_statuses() {
         let tmp = tempfile::tempdir().unwrap();
-        write_ranking(
+        write_ranking_at(
             tmp.path(),
             "a|available\nb|available\nc|exhausted\nd|rate_limited\ne|blocked\nf|weird\n",
         );
-        let snap = read_ranking(tmp.path()).unwrap();
+        let snap = read_ranking_at(tmp.path()).unwrap();
         assert_eq!(snap.total, 6);
         assert_eq!(snap.available, 2);
         assert_eq!(snap.exhausted, 1);
@@ -543,13 +600,164 @@ mod tests {
     }
 
     #[test]
-    fn read_ranking_skips_malformed_rows() {
+    fn read_ranking_at_skips_malformed_rows() {
         let tmp = tempfile::tempdir().unwrap();
-        write_ranking(tmp.path(), "a|available\nno-pipe-here\n\nb|exhausted\n");
-        let snap = read_ranking(tmp.path()).unwrap();
+        write_ranking_at(tmp.path(), "a|available\nno-pipe-here\n\nb|exhausted\n");
+        let snap = read_ranking_at(tmp.path()).unwrap();
         assert_eq!(snap.total, 2, "the pipe-less row is skipped");
         assert_eq!(snap.available, 1);
         assert_eq!(snap.exhausted, 1);
+    }
+
+    // ------------------------------------------------------------------
+    // read_ranking (resolved-dir-aware) — issue #4344
+    //
+    // These tests exercise directory *resolution*, which reads
+    // `LOOM_SHARED_TOKENS_DIR` (a process-global env var). Serialized against
+    // every other `#[serial]` test in the crate (unkeyed group, matching
+    // `tokens_pool::paths`' own tests) and always pinned to an explicit value
+    // — never left ambient — so a real `~/.loom/tokens` on the host running
+    // the test suite can never leak in.
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn read_ranking_per_repo_pool_unchanged() {
+        // Per-repo tokens + per-repo ranking: resolution must still pick the
+        // per-repo pool, matching pre-#4344 behavior byte-for-byte.
+        std::env::set_var(SHARED_TOKENS_DIR_ENV, "");
+        let repo = tempfile::tempdir().unwrap();
+        write_token_file(&repo.path().join(".loom").join("tokens"), "a.token");
+        write_ranking(repo.path(), "a|available\nb|exhausted\n");
+
+        let snap = read_ranking(repo.path()).unwrap();
+        assert_eq!(snap.total, 2);
+        assert_eq!(snap.available, 1);
+        std::env::remove_var(SHARED_TOKENS_DIR_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn read_ranking_resolves_shared_pool_over_stale_per_repo_ranking() {
+        // The exact #4344 regression fixture: a shared-pool layout (per-repo
+        // dir has NO `*.token` files, so it never wins resolution) with a
+        // stale, orphaned per-repo `.ranking` reporting 0 healthy, and a
+        // fresh shared `.ranking` reporting N healthy. Reading via the
+        // per-repo path alone (pre-#4344) would return the stale 0-healthy
+        // snapshot forever; resolution must instead follow the pool the
+        // refresher actually writes to.
+        let repo = tempfile::tempdir().unwrap();
+        let shared = tempfile::tempdir().unwrap();
+        write_token_file(shared.path(), "s.token");
+        write_ranking_at(shared.path(), "s1|available\ns2|available\ns3|available\n");
+        // Orphaned per-repo ranking: 0 healthy, would starve dispatch forever
+        // if it were the one actually consulted.
+        write_ranking(repo.path(), "orphan|exhausted\n");
+        std::env::set_var(SHARED_TOKENS_DIR_ENV, shared.path().to_str().unwrap());
+
+        let snap = read_ranking(repo.path()).unwrap();
+        assert_eq!(
+            snap.available, 3,
+            "must read the shared pool's fresh ranking, not the stale per-repo one"
+        );
+        assert_eq!(snap.total, 3);
+        assert_eq!(token_axis_limit(repo.path(), 3), 3);
+        std::env::remove_var(SHARED_TOKENS_DIR_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn dispatch_resumes_after_ranking_refresh_without_restart() {
+        // Filed AC 4 (regression test), sharpened by the curator analysis:
+        // simulates the exact incident timeline — the daemon "starts" (first
+        // tick) with a 0-healthy ranking present, then the ranking file is
+        // refreshed to N-healthy minutes later (no daemon restart in
+        // between). Each `token_axis_limit` call below stands in for one
+        // work-finder tick — there is no in-memory cache to invalidate, so
+        // the very next tick after the refresh must observe the new count.
+        std::env::set_var(SHARED_TOKENS_DIR_ENV, "");
+        let repo = tempfile::tempdir().unwrap();
+        let per_repo = repo.path().join(".loom").join("tokens");
+        write_token_file(&per_repo, "a.token");
+        write_token_file(&per_repo, "b.token");
+        write_token_file(&per_repo, "c.token");
+
+        // "Startup" tick: a storm-era ranking present with 0 healthy accounts.
+        write_ranking_at(&per_repo, "a|exhausted\nb|exhausted\nc|blocked\n");
+        assert_eq!(
+            token_axis_limit(repo.path(), 3),
+            0,
+            "tick 1 (at 'startup'): dispatch correctly sees 0 healthy — matches the incident's \
+             initial wedge"
+        );
+
+        // Minutes later, the ranking is refreshed to 2 healthy — no restart,
+        // just an on-disk file change (mirrors a manual `loom-tokens check
+        // --ranking` or the #4080 self-refresh).
+        write_ranking_at(&per_repo, "a|available\nb|available\nc|exhausted\n");
+        assert_eq!(
+            token_axis_limit(repo.path(), 3),
+            2,
+            "tick 2 (next tick after the refresh): dispatch resumes at the new healthy count \
+             within one tick, with no restart"
+        );
+        std::env::remove_var(SHARED_TOKENS_DIR_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn read_ranking_absent_everywhere_falls_back_to_none() {
+        // Neither pool holds `*.token` files nor a `.ranking` — resolution
+        // lands on the per-repo path (resolve_tokens_dir's own fallback), and
+        // no ranking exists there either. Preserves the absent-ranking
+        // fallback policy: callers see `None` and fall back to raw pool size.
+        std::env::set_var(SHARED_TOKENS_DIR_ENV, "");
+        let repo = tempfile::tempdir().unwrap();
+        assert_eq!(read_ranking(repo.path()), None);
+        assert_eq!(
+            token_axis_limit(repo.path(), 5),
+            5,
+            "no ranking ⇒ raw pool size (pre-#3902 fallback)"
+        );
+        std::env::remove_var(SHARED_TOKENS_DIR_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn read_ranking_both_pools_have_ranking_per_repo_wins() {
+        // Both the per-repo and shared pools hold token files (and a
+        // ranking); resolution must prefer the per-repo pool, matching
+        // `resolve_tokens_dir`'s precedence.
+        let repo = tempfile::tempdir().unwrap();
+        let shared = tempfile::tempdir().unwrap();
+        let per_repo = repo.path().join(".loom").join("tokens");
+        write_token_file(&per_repo, "a.token");
+        write_ranking_at(&per_repo, "a|available\n");
+        write_token_file(shared.path(), "s.token");
+        write_ranking_at(shared.path(), "s1|available\ns2|available\ns3|available\n");
+        std::env::set_var(SHARED_TOKENS_DIR_ENV, shared.path().to_str().unwrap());
+
+        let snap = read_ranking(repo.path()).unwrap();
+        assert_eq!(
+            snap.total, 1,
+            "per-repo pool wins when it has tokens, even if shared also has some"
+        );
+        assert_eq!(snap.available, 1);
+        std::env::remove_var(SHARED_TOKENS_DIR_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn read_ranking_malformed_ranking_is_absent_not_zero() {
+        // A ranking file with no parseable rows is treated as absent (`None`)
+        // rather than a genuine 0-healthy snapshot, so token_axis_limit falls
+        // back to the raw pool size instead of wrongly pinning to 0.
+        std::env::set_var(SHARED_TOKENS_DIR_ENV, "");
+        let repo = tempfile::tempdir().unwrap();
+        write_ranking(repo.path(), "\n  \nno-pipe-here\n");
+        assert_eq!(read_ranking(repo.path()), None);
+        assert_eq!(token_axis_limit(repo.path(), 4), 4);
+        std::env::remove_var(SHARED_TOKENS_DIR_ENV);
     }
 
     // ------------------------------------------------------------------
@@ -557,25 +765,41 @@ mod tests {
     // ------------------------------------------------------------------
 
     #[test]
+    #[serial]
     fn token_axis_limit_uses_available_when_ranking_present() {
+        std::env::set_var(SHARED_TOKENS_DIR_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
-        write_ranking(tmp.path(), "a|available\nb|available\nc|exhausted\n");
+        let per_repo = tmp.path().join(".loom").join("tokens");
+        write_token_file(&per_repo, "a.token");
+        write_token_file(&per_repo, "b.token");
+        write_token_file(&per_repo, "c.token");
+        write_ranking_at(&per_repo, "a|available\nb|available\nc|exhausted\n");
         // 3 token files present, but only 2 available → limit 2.
         assert_eq!(token_axis_limit(tmp.path(), 3), 2);
+        std::env::remove_var(SHARED_TOKENS_DIR_ENV);
     }
 
     #[test]
+    #[serial]
     fn token_axis_limit_falls_back_to_pool_when_no_ranking() {
+        std::env::set_var(SHARED_TOKENS_DIR_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         // No ranking file → fall back to raw pool size (pre-#3902 behavior).
         assert_eq!(token_axis_limit(tmp.path(), 5), 5);
+        std::env::remove_var(SHARED_TOKENS_DIR_ENV);
     }
 
     #[test]
+    #[serial]
     fn token_axis_limit_zero_when_all_exhausted() {
+        std::env::set_var(SHARED_TOKENS_DIR_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
-        write_ranking(tmp.path(), "a|exhausted\nb|blocked\n");
+        let per_repo = tmp.path().join(".loom").join("tokens");
+        write_token_file(&per_repo, "a.token");
+        write_token_file(&per_repo, "b.token");
+        write_ranking_at(&per_repo, "a|exhausted\nb|blocked\n");
         assert_eq!(token_axis_limit(tmp.path(), 2), 0, "never dispatch to exhausted");
+        std::env::remove_var(SHARED_TOKENS_DIR_ENV);
     }
 
     // ------------------------------------------------------------------

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -3400,17 +3400,36 @@ fn print_status_human(
     let rc = resolve_capacity(report, token_usage);
 
     let factor = report.per_token_concurrency.max(1);
-    println!("\nDynamic concurrency cap: {}", rc.effective_cap);
+    // #4344: `rc` prefers a fresh client-side probe when one succeeded, which
+    // can legitimately show a *different* (usually fresher) number than what
+    // the running daemon actually used for its own dispatch decision this
+    // tick. `report.dynamic_cap` / `report.capacity.token_axis_limit` are that
+    // daemon-side truth — the number dispatch decisions are actually gated
+    // on — so the headline always names the daemon's own cap; the probe's
+    // number is shown as a labeled secondary line only when it disagrees.
+    let dispatch_cap = report.dynamic_cap;
+    let dispatch_token_axis = report.capacity.token_axis_limit;
+    println!("\nDynamic concurrency cap: {dispatch_cap}  (the number dispatch uses)");
     println!(
         "  = min(healthy {} × per-token {} = {}, disk headroom {}, cpu headroom {}, \
          configured max {})",
-        rc.token_axis_limit,
+        dispatch_token_axis,
         factor,
-        rc.token_axis_limit.saturating_mul(factor),
+        dispatch_token_axis.saturating_mul(factor),
         report.disk_headroom,
         report.cpu_headroom,
         report.configured_max
     );
+    if rc.source == "probe" && rc.effective_cap != dispatch_cap {
+        println!(
+            "  fresh probe suggests: {} (healthy {} × per-token {} = {}) — not yet reflected in \
+             dispatch; if this persists, refresh with `loom-tokens check --ranking`.",
+            rc.effective_cap,
+            rc.token_axis_limit,
+            factor,
+            rc.token_axis_limit.saturating_mul(factor)
+        );
+    }
     // CPU headroom detail (#3978 AC4; measured-idle signal #4031). The signal
     // chain is measured idle → loadavg → static capacity, so the line names
     // which signal actually fed the term. `logical_cpus == 0` means an older
@@ -3457,7 +3476,22 @@ fn print_status_human(
     // minimum of several ceilings, but a ceiling only *binds* once in-flight
     // occupancy reaches it. Below the cap the limiter is work availability, not
     // any resource term — so the token-bound diagnosis below is gated on this.
-    let capacity_bound = report.in_flight.len() >= rc.effective_cap;
+    // #4344: this must be checked against the daemon's *actual* dispatch cap
+    // (`dispatch_cap`), not `rc.effective_cap` — the latter is recomputed from
+    // a fresh client-side probe when one succeeds and can disagree with what
+    // the daemon itself used, which previously let "not capacity-bound" print
+    // even while the daemon's real (lower) cap was already saturated.
+    let capacity_bound = report.in_flight.len() >= dispatch_cap;
+    // #4344: the daemon's own dispatch decision reads 0 healthy accounts while
+    // a fresher probe (or the raw pool) shows real capacity — the exact
+    // wedge this issue exists for. When this holds, promote the diagnosis to
+    // the headline and suppress the misleading "limiter is work availability"
+    // line below (the limiter is unmistakably the token term: `0 × per-token
+    // = 0`).
+    let dispatch_starved_but_disagrees = report.capacity.ranking_present
+        && report.capacity.healthy_accounts == 0
+        && rc.ranking_present
+        && rc.healthy > 0;
     if rc.ranking_present {
         let src = if rc.source == "probe" {
             "live probe: loom-tokens check --json"
@@ -3468,45 +3502,71 @@ fn print_status_human(
             "  {}/{} accounts healthy, {} exhausted/near-ceiling ({src})",
             rc.healthy, rc.total, rc.exhausted
         );
-        // When a fresh probe disagrees with the daemon's ranking-based cap, the
-        // ranking is stale — the daemon may still be dispatching against the old
-        // (higher) count. Surface it so the operator re-probes (#3936).
-        if rc.source == "probe"
+        if dispatch_starved_but_disagrees {
+            // Headline promotion (#4344, was a small-print "note" pre-fix):
+            // the daemon's own dispatch decision is starved at 0 healthy
+            // accounts while the number above disagrees — dispatch will not
+            // resume until the ranking the daemon actually reads is fresh.
+            let pool_display = report
+                .token_pool_dir
+                .as_ref()
+                .map_or_else(|| "(unknown pool dir)".to_string(), |d| d.display().to_string());
+            println!(
+                "  \u{26a0} DISPATCH IS TOKEN-STARVED: the daemon's own ranking read shows \
+                 0/{} healthy (dispatch cap {dispatch_cap}), disagreeing with the {} healthy \
+                 shown above from {pool_display}. The token term is the limiter — refresh the \
+                 ranking with `loom-tokens check --ranking` (or wait for the next self-refresh).",
+                report.capacity.total_accounts, rc.healthy,
+            );
+        } else if rc.source == "probe"
             && report.capacity.ranking_present
             && report.capacity.healthy_accounts != rc.healthy
         {
+            // Non-zero disagreement (the daemon still has *some* healthy
+            // accounts, just a different count than the fresh probe) stays a
+            // small-print note — dispatch is not silently starved here, just
+            // running on slightly stale data.
             println!(
                 "  note: daemon dispatch cap still uses a stale .ranking ({} healthy); \
                  refresh it with `loom-tokens check --ranking`.",
                 report.capacity.healthy_accounts
             );
         }
-        if !capacity_bound {
-            // In-flight is below the cap: nothing is binding. Naming tokens (or
-            // any resource) as "the bottleneck" here is the #4031 defect — at,
-            // say, 1 in-flight against a cap of 7 the limiter is simply how much
-            // ready work exists. Suppress the token-bound diagnosis.
-            println!(
-                "  not capacity-bound ({} in flight, cap {} — the limiter is work availability, \
-                 not tokens/disk/CPU)",
-                report.in_flight.len(),
-                rc.effective_cap
-            );
-        } else if rc.token_bound {
-            if rc.healthy == 0 {
+        // #4344: when the daemon's own dispatch decision is unambiguously
+        // token-starved (see above), never print "the limiter is work
+        // availability" — the headline diagnosis already named the real
+        // limiter, and running the generic capacity_bound/token_bound chain
+        // underneath it would contradict it (e.g. `capacity_bound` is
+        // trivially true against a dispatch cap of 0).
+        if !dispatch_starved_but_disagrees {
+            if !capacity_bound {
+                // In-flight is below the cap: nothing is binding. Naming tokens
+                // (or any resource) as "the bottleneck" here is the #4031
+                // defect — at, say, 1 in-flight against a cap of 7 the limiter
+                // is simply how much ready work exists. Suppress the
+                // token-bound diagnosis.
                 println!(
-                    "  token-bound: NO healthy accounts — new dispatch deferred until capacity \
-                     returns. Add accounts (~/.claude-monitor/accounts.env + `loom-tokens \
-                     bootstrap`) or buy API credits, then `loom-tokens check --ranking`."
+                    "  not capacity-bound ({} in flight, cap {dispatch_cap} — the limiter is \
+                     work availability, not tokens/disk/CPU)",
+                    report.in_flight.len(),
                 );
+            } else if rc.token_bound {
+                if rc.healthy == 0 {
+                    println!(
+                        "  token-bound: NO healthy accounts — new dispatch deferred until \
+                         capacity returns. Add accounts (~/.claude-monitor/accounts.env + \
+                         `loom-tokens bootstrap`) or buy API credits, then `loom-tokens check \
+                         --ranking`."
+                    );
+                } else {
+                    println!(
+                        "  token-bound: tokens are the binding constraint on throughput. Add \
+                         accounts or API credits to dispatch more concurrently."
+                    );
+                }
             } else {
-                println!(
-                    "  token-bound: tokens are the binding constraint on throughput. Add accounts \
-                     or API credits to dispatch more concurrently."
-                );
+                println!("  not token-bound (tokens are not the current bottleneck)");
             }
-        } else {
-            println!("  not token-bound (tokens are not the current bottleneck)");
         }
     } else {
         println!(
@@ -3516,10 +3576,9 @@ fn print_status_human(
         );
         if !capacity_bound {
             println!(
-                "  not capacity-bound ({} in flight, cap {} — the limiter is work availability, \
-                 not tokens/disk/CPU)",
+                "  not capacity-bound ({} in flight, cap {dispatch_cap} — the limiter is work \
+                 availability, not tokens/disk/CPU)",
                 report.in_flight.len(),
-                rc.effective_cap
             );
         }
     }

--- a/loom-daemon/src/tokens_pool/select.rs
+++ b/loom-daemon/src/tokens_pool/select.rs
@@ -140,7 +140,38 @@ fn parse_util(field: &str) -> Option<f64> {
     field.parse::<f64>().ok()
 }
 
-/// Yield `(name, status, util_5h)` triples from the ranking file. Format:
+/// Parse a single `.ranking` line into a `(name, status, util_5h)` triple.
+///
+/// This is the **shared** triple parser for the `name|status|5h_util` format
+/// (issue #4195): `status` is the *second* pipe-delimited field and the third
+/// (5h utilization) is optional, so a legacy `name|status` line yields
+/// `util_5h = None` (backward compatible). `#` comments are stripped; a
+/// blank/comment-only line, or one whose name is empty, yields `None`.
+///
+/// Both the selector ([`read_ranking`]) and the daemon's capacity reader
+/// ([`crate::capacity::read_ranking_at`]) consume the ranking through this one
+/// function so the two readers can never de-sync on field positions again —
+/// the #4243/#4344 drift where capacity treated the *last* field as the status
+/// and mis-read every 3-field row's `5h_util` as the status word. A
+/// format-drift conformance test (`capacity::tests`) pins them together.
+#[must_use]
+pub(crate) fn parse_ranking_line(line: &str) -> Option<(String, String, Option<f64>)> {
+    let stripped = strip_comment(line);
+    if stripped.is_empty() {
+        return None;
+    }
+    let mut parts = stripped.splitn(3, '|');
+    let name = parts.next().unwrap_or("").trim().to_string();
+    let status = parts.next().unwrap_or("").trim().to_string();
+    let util = parts.next().and_then(parse_util);
+    if name.is_empty() {
+        return None;
+    }
+    Some((name, status, util))
+}
+
+/// Yield `(name, status, util_5h)` triples from the ranking file, one per
+/// parseable line via the shared [`parse_ranking_line`] parser. Format:
 /// `name|status|5h_util` per line (issue #4195); the third field is optional,
 /// so a legacy `name|status` line yields `util_5h = None` (backward
 /// compatible). Malformed/empty lines are skipped; `status` defaults to `""`.
@@ -148,21 +179,7 @@ fn read_ranking(ranking_file: &Path) -> Vec<(String, String, Option<f64>)> {
     let Ok(text) = std::fs::read_to_string(ranking_file) else {
         return Vec::new();
     };
-    let mut out = Vec::new();
-    for raw in text.lines() {
-        let stripped = strip_comment(raw);
-        if stripped.is_empty() {
-            continue;
-        }
-        let mut parts = stripped.splitn(3, '|');
-        let name = parts.next().unwrap_or("").trim().to_string();
-        let status = parts.next().unwrap_or("").trim().to_string();
-        let util = parts.next().and_then(parse_util);
-        if !name.is_empty() {
-            out.push((name, status, util));
-        }
-    }
-    out
+    text.lines().filter_map(parse_ranking_line).collect()
 }
 
 fn read_allowlist_lines(allowlist_file: &Path) -> Vec<String> {

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -1355,6 +1355,14 @@ where
         // move (e.g. the token axis jumping from a batch of account resets)
         // without a steady-state stream of identical lines every interval.
         let mut was_max_concurrent: Option<usize> = None;
+        // Healthy-account transition state (#4344): log the count of healthy
+        // (`available`) token accounts once when it *changes* tick-to-tick —
+        // never every tick — so an operator sees the token axis move (a batch
+        // of accounts resetting from `exhausted`, or the whole pool going
+        // token-starved) without a steady-state stream. Distinct from the cap
+        // line: the healthy count can change while the cap does not (another
+        // axis binds), and vice versa.
+        let mut was_healthy_tokens: Option<usize> = None;
         loop {
             ticker.tick().await;
             // Reactive main-health backstop (Phase C, #3812): skip all dispatch
@@ -1383,6 +1391,7 @@ where
             let pool_size = token_pool_size(&workspace_root);
             let ranking = capacity::read_ranking(&workspace_root);
             let token_limit = ranking.as_ref().map_or(pool_size, |r| r.available);
+            log_healthy_token_transition(&mut was_healthy_tokens, token_limit, ranking.as_ref());
             let disk = disk_headroom_limit(&workspace_root);
             // CPU headroom (#3978; measured-idle signal #4031): the term the
             // pre-#3978 formula lacked. `cpu_headroom_limit()` refreshes the
@@ -1563,6 +1572,9 @@ pub fn spawn_multi_work_finder_task(
         // Axis-visibility state (#4234) — see the single-workspace loop above
         // for the full rationale.
         let mut was_max_concurrent: Option<usize> = None;
+        // Healthy-account transition state (#4344) — see the single-workspace
+        // loop above for the full rationale.
+        let mut was_healthy_tokens: Option<usize> = None;
         // Missing-root hygiene (#4326): tracks which registered roots are
         // currently missing so `filter_missing_roots` logs a warning once per
         // transition rather than once per tick.
@@ -1575,6 +1587,7 @@ pub fn spawn_multi_work_finder_task(
             let pool_size = token_pool_size(&fallback_root);
             let ranking = capacity::read_ranking(&fallback_root);
             let token_limit = ranking.as_ref().map_or(pool_size, |r| r.available);
+            log_healthy_token_transition(&mut was_healthy_tokens, token_limit, ranking.as_ref());
             let disk = disk_headroom_limit(&fallback_root);
             // CPU headroom (#3978; measured-idle signal #4031) — also a
             // machine-level resource, probed once per tick and shared across
@@ -1790,6 +1803,43 @@ fn filter_missing_roots(roots: Vec<PathBuf>, warned: &mut HashSet<PathBuf>) -> V
     }
     *warned = still_missing;
     existing
+}
+
+/// Log the count of healthy (`available`) token accounts once, on a **state
+/// change** — never every tick (#4344 AC).
+///
+/// `prev` is the last logged healthy count (carried across ticks); it is
+/// updated in place. The very first observation seeds `prev` silently (no
+/// startup line); every subsequent change logs a single `info!` edge naming the
+/// old → new healthy count and the ranking total, so an operator can see the
+/// token axis move — an account batch resetting, or the pool going
+/// token-starved (`… -> 0 …`) — without a steady-state stream. Mirrors the
+/// state-change-dedup discipline the cap line (`was_max_concurrent`) and the
+/// capacity advisory (`was_pressured`) already use.
+fn log_healthy_token_transition(
+    prev: &mut Option<usize>,
+    healthy: usize,
+    ranking: Option<&capacity::RankingSnapshot>,
+) {
+    if *prev == Some(healthy) {
+        return;
+    }
+    if let Some(old) = *prev {
+        let total = ranking
+            .map_or_else(|| "n/a (no ranking; raw pool)".to_string(), |r| r.total.to_string());
+        if healthy == 0 {
+            log::warn!(
+                "work_finder: healthy token accounts {old} -> 0 (of {total}) — dispatch is \
+                 token-starved until an account resets or is added (`loom-tokens check --ranking`)"
+            );
+        } else {
+            log::info!(
+                "work_finder: healthy token accounts {old} -> {healthy} (of {total}) — \
+                 dynamic-cap token axis follows"
+            );
+        }
+    }
+    *prev = Some(healthy);
 }
 
 /// Emit the add-capacity advisory / recovery on a token-pressure **state
@@ -2102,6 +2152,48 @@ pub use forge::{GhWorkSource, RegistryDispatcher};
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    // ===================================================================
+    // Healthy-account transition tracking (#4344)
+    // ===================================================================
+
+    fn snap(total: usize, available: usize) -> capacity::RankingSnapshot {
+        capacity::RankingSnapshot {
+            total,
+            available,
+            exhausted: total - available,
+            ..capacity::RankingSnapshot::default()
+        }
+    }
+
+    #[test]
+    fn healthy_token_transition_dedups_by_state() {
+        // The tracker only advances `prev` when the healthy count changes —
+        // repeated identical ticks are no-ops (the once-per-transition contract
+        // the AC requires). We assert on the carried state, since the log line
+        // itself is a side effect.
+        let mut prev: Option<usize> = None;
+
+        // First observation seeds silently.
+        log_healthy_token_transition(&mut prev, 6, Some(&snap(7, 6)));
+        assert_eq!(prev, Some(6));
+
+        // Stable ticks: no change.
+        log_healthy_token_transition(&mut prev, 6, Some(&snap(7, 6)));
+        assert_eq!(prev, Some(6));
+
+        // Drop to token-starved (0 healthy) — a transition.
+        log_healthy_token_transition(&mut prev, 0, Some(&snap(7, 0)));
+        assert_eq!(prev, Some(0));
+
+        // Recovery to a new count — another transition.
+        log_healthy_token_transition(&mut prev, 4, Some(&snap(7, 4)));
+        assert_eq!(prev, Some(4));
+
+        // No-ranking fallback path (raw pool size) still tracks the count.
+        log_healthy_token_transition(&mut prev, 3, None);
+        assert_eq!(prev, Some(3));
+    }
 
     // ===================================================================
     // Mock source + dispatcher


### PR DESCRIPTION
## Summary

Two related fixes to the daemon's token-capacity accounting and status
reporting (issue #4344):

- **Ranking-file resolution divergence (the starvation bug)**: `capacity::read_ranking` hardcoded the per-repo `{workspace_root}/.loom/tokens/.ranking` path regardless of where the token pool (and its writer) actually resolved to (`tokens_pool::paths::resolve_tokens_dir` — per-repo pool when it holds `*.token` files, else the shared machine-level pool, #3938). On a host where the pool lives in the shared directory, every ranking refresh (manual or the #4080 self-refresh) landed in the shared `.ranking`, while dispatch kept reading a stale, orphaned per-repo `.ranking` from a prior storm. If that orphaned file had 0 healthy rows, the token axis was pinned at `0 × per-token = 0` indefinitely — re-read every tick, always from the wrong file, surviving even a daemon restart.
- **Honest status headline (the misdiagnosis)**: `loom-daemon status`'s pretty-printed "Token capacity" block computed its "currently binding" (`capacity_bound`) diagnosis against a CLI-side fresh-probe recomputation (`rc.effective_cap`) instead of the daemon's own dispatch cap (`report.dynamic_cap`). This could print `not capacity-bound (... the limiter is work availability, not tokens/disk/CPU)` even while the daemon's real, lower cap was already starved at 0 healthy accounts — exactly the observed incident where `status` said "no work available" while 14 ready issues sat undispatched.

## Changes

- `loom-daemon/src/capacity.rs`:
  - Added `read_ranking_at(pool_dir: &Path)` — the resolution-agnostic parsing core.
  - Reimplemented `read_ranking(workspace_root)` as `read_ranking_at(&tokens_pool::paths::resolve_tokens_dir(workspace_root))`, so all four existing call sites (`work_finder.rs` ×2, `ipc.rs` ×2) automatically read the same directory the writer targets — no call-site changes needed, since the public signature is unchanged. Absent/unparseable-ranking fallback semantics (token term = raw pool size) are preserved byte-for-byte.
  - Updated module docs to describe the unified resolution.
  - Added a regression test suite: shared-pool-over-stale-per-repo-ranking (the exact incident fixture), per-repo-pool-unchanged, absent-ranking fallback, both-pools-have-ranking (per-repo wins), malformed-ranking-is-absent-not-zero, and a dedicated "dispatch resumes after ranking refresh without restart" test simulating the incident timeline across two ticks.
- `loom-daemon/src/main.rs` (`print_status_human`'s "Token capacity" block):
  - The "Dynamic concurrency cap" headline and its `= min(healthy N × per-token M …)` breakdown now always show the daemon's own numbers (`report.dynamic_cap` / `report.capacity.token_axis_limit`) — the number dispatch actually used — with a labeled `fresh probe suggests: …` secondary line only when a client-side probe disagrees.
  - `capacity_bound` (used to gate the "not capacity-bound ... limiter is work availability" line) is now computed against the daemon's own cap, not the CLI-recomputed one.
  - When the daemon's own ranking read shows 0 healthy accounts while a fresh probe (or the raw pool) disagrees, the diagnosis is promoted from a small-print `note: ...` to a headline `⚠ DISPATCH IS TOKEN-STARVED: ...` line, and "the limiter is work availability" is suppressed underneath it (the limiter is unambiguously the token term).
- `defaults/docs/daemon-reference.md`: documented the unified ranking resolution (dynamic-cap input table) and the new honest-headline status behavior.

## Acceptance Criteria Verification

- [x] The daemon re-reads/refreshes its healthy-account count on a bounded interval **from the correct file**: the existing per-tick re-read (no caching) is unchanged; the fix is *which* directory is consulted, matching the writer's resolution (`tokens_pool::paths::resolve_tokens_dir`). Verified by `dispatch_resumes_after_ranking_refresh_without_restart` (two simulated ticks, same process, no restart).
- [x] `status` promotes the daemon-internal-healthy-is-0-but-probe-disagrees case from small print to the headline, and suppresses "the limiter is work availability" in that case (`dispatch_starved_but_disagrees` branch in `print_status_human`).
- [x] The cap-breakdown line shows the number the dispatch decision actually uses (`report.dynamic_cap` / `report.capacity.token_axis_limit`), with the CLI probe's number labeled separately when it disagrees.
- [x] Regression test: daemon starts with a 0-healthy ranking, ranking file refreshed to N-healthy → dispatch resumes within one refresh interval without a restart (`dispatch_resumes_after_ranking_refresh_without_restart`, plus `read_ranking_resolves_shared_pool_over_stale_per_repo_ranking` for the exact shared-pool fixture from the curator's sharpened AC).

## Test Plan

- `cargo fmt` — clean.
- `cargo clippy --all-targets --all-features` — clean, no new warnings.
- `cargo check --lib` / `cargo check --bin loom-daemon` — clean.
- `cargo test --lib` (loom-daemon crate): 1558 passed, 0 failed.
- `cargo test --bin loom-daemon`: 30 passed, 0 failed.
- Targeted reruns: `capacity::`, `ipc::`, `work_finder::`, `tokens::`, `tokens_pool::` modules all green.
- `cargo test --workspace --lib --bins` (the `buildGate.command` invocation): passed on the first run (1558/1558); a second run on this shared dogfooding host showed 2 unrelated flaky failures (`tokens_pool::bootstrap::tests::bootstrap_no_source_errors`, `terminal::claude_config::tests::test_setup_creates_fallback_state_when_no_home_state`) in files this PR does not touch — both pass individually in isolation, confirming a pre-existing cross-test env-var race unrelated to this change (this host has a real `~/.claude-monitor/accounts.env` that some unrelated tests leak against under parallel execution).

Closes #4344