### PR TITLE
fix(spawn): pre-seed folder-trust flag for never-opened spawn targets

### DIFF
--- a/loom-tools/src/loom_tools/agent_spawn.py
+++ b/loom-tools/src/loom_tools/agent_spawn.py
@@ -34,6 +34,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
 from loom_tools.common.claude_config import (
+    _ensure_project_trusted,
+    _resolve_state_file,
     cleanup_agent_config_dir,
     setup_agent_config_dir,
     validate_agent_config_dir,
@@ -764,6 +766,16 @@ def spawn_agent(
     config_dir = setup_agent_config_dir(name, repo_root)
     _tmux("set-environment", "-t", session_name, "CLAUDE_CONFIG_DIR", str(config_dir))
     _tmux("set-environment", "-t", session_name, "TMPDIR", str(config_dir / "tmp"))
+
+    # Pre-seed the folder-trust flag for the actual spawn target (the
+    # worktree path when spawning into a worktree, not just repo_root — trust
+    # is keyed per-path) so a freshly-created repo/worktree that Claude Code
+    # has never opened doesn't stall the non-interactive session at the
+    # blocking "Is this a project you created or one you trust?" modal.
+    # Race-free alternative to detecting/dismissing the modal in the tmux
+    # pane.  Gated by LOOM_AUTO_TRUST (default on) inside the helper itself.
+    # See issue #4334.
+    _ensure_project_trusted(_resolve_state_file(), working_dir)
 
     # Set PYTHONPATH so pytest in worktrees resolves imports from the worktree's
     # source instead of the main repo's editable install (see issue #2358)

--- a/loom-tools/src/loom_tools/common/claude_config.py
+++ b/loom-tools/src/loom_tools/common/claude_config.py
@@ -230,6 +230,102 @@ def _ensure_onboarding_complete(state_path: Path) -> None:
     log.debug("Wrote merged .claude.json with onboarding-complete state")
 
 
+def _ensure_project_trusted(state_path: Path, project_dir: Path) -> None:
+    """Ensure .claude.json marks ``project_dir`` as trusted (skip the folder-trust modal).
+
+    Claude Code shows a blocking "Is this a project you created or one you
+    trust?" modal on first launch in any working directory that has no
+    ``projects[<abs-path>].hasTrustDialogAccepted: true`` entry in the state
+    file.  In a non-interactive agent spawn (``loom.sh`` pool,
+    ``agent-spawn.sh --role ...``) into a freshly-created repo/worktree that
+    Claude Code has never opened, the role command is delivered as keystrokes
+    into that modal instead of being run, stalling or killing the session.
+    See issue #4334.
+
+    This mirrors :func:`_ensure_onboarding_complete`'s two invariants:
+
+    - **Merge, never replace**: only the ``projects[<project_dir>]`` entry's
+      ``hasTrustDialogAccepted`` flag is set; any other fields on that entry
+      (or any other ``projects`` entries, or any other top-level fields) are
+      preserved unchanged.
+    - **Write through the symlink** (issue #2835): when ``state_path`` is a
+      healthy symlink (e.g. the per-agent ``CLAUDE_CONFIG_DIR/.claude.json``
+      pointing at the shared global state file), write to the resolved
+      target rather than unlinking the symlink and replacing it with a
+      standalone file, which would sever every future session from the
+      operator's global state.
+
+    Only the exact ``project_dir`` path is trusted — parents are never
+    walked and siblings are never globbed or trusted implicitly.
+
+    Gated by ``LOOM_AUTO_TRUST``.  Default is "1" (enabled); set to "0" to
+    disable, mirroring the ``LOOM_AUTO_ACCEPT_BYPASS`` pattern in
+    ``agent_spawn.py``.
+
+    Idempotent: if the target project already has
+    ``hasTrustDialogAccepted: true``, this is a no-op (no file rewrite).
+
+    Args:
+        state_path: Path to the ``.claude.json`` state file (or a per-agent
+            symlink to it).
+        project_dir: The exact spawn target directory to trust (the resolved
+            working directory — the worktree path when spawning into a
+            worktree, not just the repo root).
+    """
+    import json
+
+    if os.environ.get("LOOM_AUTO_TRUST", "1") == "0":
+        log.debug("Project trust auto-seed disabled via LOOM_AUTO_TRUST=0")
+        return
+
+    project_key = str(project_dir)
+
+    existing_data: dict = {}
+    try:
+        if state_path.exists():
+            existing_data = json.loads(state_path.read_text())
+            if not isinstance(existing_data, dict):
+                existing_data = {}
+    except (json.JSONDecodeError, OSError):
+        existing_data = {}
+
+    projects = existing_data.get("projects")
+    if not isinstance(projects, dict):
+        projects = {}
+
+    project_entry = projects.get(project_key)
+    if isinstance(project_entry, dict) and project_entry.get("hasTrustDialogAccepted") is True:
+        return  # Already trusted — idempotent no-op, no rewrite.
+
+    if not isinstance(project_entry, dict):
+        project_entry = {}
+    project_entry = {**project_entry, "hasTrustDialogAccepted": True}
+
+    merged = {**existing_data}
+    merged["projects"] = {**projects, project_key: project_entry}
+
+    # If state_path is a valid symlink, write directly to the symlink target
+    # rather than destroying the symlink and creating a standalone file.
+    # See issue #2835 (and _ensure_onboarding_complete above, same rationale).
+    if state_path.is_symlink():
+        target = state_path.resolve()
+        if target.exists():
+            target.write_text(json.dumps(merged))
+            log.debug("Updated symlink target .claude.json with trust for %s", project_key)
+            return
+        # Dangling symlink — fall through to unlink and recreate below.
+
+    # Remove whatever is there (dangling symlink, corrupt file, etc.)
+    # so we can write a standalone file.
+    try:
+        state_path.unlink()
+    except FileNotFoundError:
+        pass
+
+    state_path.write_text(json.dumps(merged))
+    log.debug("Wrote merged .claude.json with trust for %s", project_key)
+
+
 def _resolve_state_file() -> Path:
     """Resolve the Claude Code state file path.
 

--- a/loom-tools/tests/test_agent_spawn.py
+++ b/loom-tools/tests/test_agent_spawn.py
@@ -782,6 +782,86 @@ class TestGitWorktreePinning:
         assert len(git_env_calls) == 0
 
 
+class TestProjectTrustSeeding:
+    """Tests that spawn_agent seeds the folder-trust flag (#4334)."""
+
+    @patch("loom_tools.agent_spawn._ensure_project_trusted")
+    @patch("loom_tools.agent_spawn._resolve_state_file")
+    @patch("loom_tools.agent_spawn._tmux")
+    def test_seeds_trust_for_worktree_path_not_repo_root(
+        self,
+        mock_tmux: MagicMock,
+        mock_resolve_state_file: MagicMock,
+        mock_ensure_trusted: MagicMock,
+        mock_repo: pathlib.Path,
+    ) -> None:
+        """spawn_agent seeds the actual worktree path, not just repo_root."""
+        from loom_tools.agent_spawn import spawn_agent
+
+        worktree_dir = mock_repo / ".loom" / "worktrees" / "issue-4334"
+        worktree_dir.mkdir(parents=True)
+        (worktree_dir / ".git").write_text(
+            f"gitdir: {mock_repo}/.git/worktrees/issue-4334\n"
+        )
+
+        (mock_repo / ".loom" / "roles" / "builder.md").write_text("# Builder")
+        wrapper = mock_repo / ".loom" / "scripts" / "claude-wrapper.sh"
+        wrapper.write_text("#!/bin/bash\nclaude \"$@\"")
+        wrapper.chmod(0o755)
+
+        mock_tmux.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=""
+        )
+        fake_state_path = pathlib.Path("/fake/.claude.json")
+        mock_resolve_state_file.return_value = fake_state_path
+
+        spawn_agent(
+            role="builder",
+            name="builder-issue-4334",
+            args="4334",
+            worktree=str(worktree_dir),
+            repo_root=mock_repo,
+            verify_timeout=0,
+        )
+
+        mock_ensure_trusted.assert_called_once_with(fake_state_path, worktree_dir)
+
+    @patch("loom_tools.agent_spawn._ensure_project_trusted")
+    @patch("loom_tools.agent_spawn._resolve_state_file")
+    @patch("loom_tools.agent_spawn._tmux")
+    def test_seeds_trust_for_repo_root_when_no_worktree(
+        self,
+        mock_tmux: MagicMock,
+        mock_resolve_state_file: MagicMock,
+        mock_ensure_trusted: MagicMock,
+        mock_repo: pathlib.Path,
+    ) -> None:
+        """spawn_agent seeds repo_root when no worktree is given."""
+        from loom_tools.agent_spawn import spawn_agent
+
+        (mock_repo / ".loom" / "roles" / "builder.md").write_text("# Builder")
+        wrapper = mock_repo / ".loom" / "scripts" / "claude-wrapper.sh"
+        wrapper.write_text("#!/bin/bash\nclaude \"$@\"")
+        wrapper.chmod(0o755)
+
+        mock_tmux.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=""
+        )
+        fake_state_path = pathlib.Path("/fake/.claude.json")
+        mock_resolve_state_file.return_value = fake_state_path
+
+        spawn_agent(
+            role="builder",
+            name="test-builder",
+            args="",
+            worktree="",
+            repo_root=mock_repo,
+            verify_timeout=0,
+        )
+
+        mock_ensure_trusted.assert_called_once_with(fake_state_path, mock_repo)
+
+
 class TestAnsiStripping:
     """Tests for ANSI escape sequence stripping in log output."""
 

--- a/loom-tools/tests/test_claude_config.py
+++ b/loom-tools/tests/test_claude_config.py
@@ -13,6 +13,7 @@ from loom_tools.common.claude_config import (
     _SHARED_CONFIG_FILES,
     _copy_settings_without_plugins,
     _ensure_onboarding_complete,
+    _ensure_project_trusted,
     _keychain_service_name,
     _link_project_claude_dirs,
     _resolve_state_file,
@@ -562,6 +563,154 @@ class TestEnsureOnboardingComplete:
         # Full content must be preserved (not just the 4 required fields)
         assert data["userPref"] == "preserved"
         assert "projects" in data
+
+
+class TestEnsureProjectTrusted:
+    """Tests for _ensure_project_trusted (issue #4334)."""
+
+    def test_seeds_trust_into_empty_state_file(self, tmp_path: pathlib.Path) -> None:
+        import json
+
+        state = tmp_path / ".claude.json"
+        project_dir = tmp_path / "fresh-repo"
+
+        _ensure_project_trusted(state, project_dir)
+
+        assert state.exists()
+        data = json.loads(state.read_text())
+        assert data["projects"][str(project_dir)]["hasTrustDialogAccepted"] is True
+
+    def test_preserves_other_projects_entries(self, tmp_path: pathlib.Path) -> None:
+        import json
+
+        state = tmp_path / ".claude.json"
+        other_project = str(tmp_path / "other-repo")
+        state.write_text(json.dumps({
+            "projects": {
+                other_project: {"hasTrustDialogAccepted": True, "lastCost": 1.23},
+            },
+            "someOtherSetting": 42,
+        }))
+        project_dir = tmp_path / "fresh-repo"
+
+        _ensure_project_trusted(state, project_dir)
+
+        data = json.loads(state.read_text())
+        # New entry seeded.
+        assert data["projects"][str(project_dir)]["hasTrustDialogAccepted"] is True
+        # Existing entry and its other fields untouched.
+        assert data["projects"][other_project] == {
+            "hasTrustDialogAccepted": True,
+            "lastCost": 1.23,
+        }
+        # Unrelated top-level field untouched.
+        assert data["someOtherSetting"] == 42
+
+    def test_merges_flag_into_existing_entry_preserving_other_fields(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        import json
+
+        state = tmp_path / ".claude.json"
+        project_dir = tmp_path / "existing-repo"
+        state.write_text(json.dumps({
+            "projects": {
+                str(project_dir): {
+                    "hasTrustDialogAccepted": False,
+                    "history": ["a", "b"],
+                    "allowedTools": ["Bash"],
+                },
+            },
+        }))
+
+        _ensure_project_trusted(state, project_dir)
+
+        data = json.loads(state.read_text())
+        entry = data["projects"][str(project_dir)]
+        assert entry["hasTrustDialogAccepted"] is True
+        assert entry["history"] == ["a", "b"]
+        assert entry["allowedTools"] == ["Bash"]
+
+    def test_writes_through_valid_symlink(self, tmp_path: pathlib.Path) -> None:
+        import json
+
+        target = tmp_path / "home-claude.json"
+        target.write_text(json.dumps({"projects": {}, "userPref": "preserved"}))
+        state = tmp_path / ".claude.json"
+        state.symlink_to(target)
+        project_dir = tmp_path / "fresh-repo"
+
+        _ensure_project_trusted(state, project_dir)
+
+        # Symlink must be preserved — not replaced with a standalone file.
+        assert state.is_symlink()
+        data = json.loads(state.read_text())
+        assert data["projects"][str(project_dir)]["hasTrustDialogAccepted"] is True
+        assert data["userPref"] == "preserved"
+
+    def test_dangling_symlink_falls_back_to_standalone_file(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        import json
+
+        state = tmp_path / ".claude.json"
+        state.symlink_to(tmp_path / "nonexistent-target")
+        assert state.is_symlink()
+        assert not state.exists()  # dangling
+        project_dir = tmp_path / "fresh-repo"
+
+        _ensure_project_trusted(state, project_dir)
+
+        assert state.exists()
+        assert not state.is_symlink()  # replaced with real file
+        data = json.loads(state.read_text())
+        assert data["projects"][str(project_dir)]["hasTrustDialogAccepted"] is True
+
+    def test_disabled_via_loom_auto_trust_env(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LOOM_AUTO_TRUST", "0")
+        state = tmp_path / ".claude.json"
+        project_dir = tmp_path / "fresh-repo"
+
+        _ensure_project_trusted(state, project_dir)
+
+        assert not state.exists()
+
+    def test_idempotent_no_rewrite_when_already_trusted(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        import json
+
+        state = tmp_path / ".claude.json"
+        project_dir = tmp_path / "fresh-repo"
+        state.write_text(json.dumps({
+            "projects": {str(project_dir): {"hasTrustDialogAccepted": True}},
+        }))
+        before_mtime = state.stat().st_mtime_ns
+
+        _ensure_project_trusted(state, project_dir)
+
+        after_mtime = state.stat().st_mtime_ns
+        assert before_mtime == after_mtime  # no rewrite occurred
+
+    def test_only_seeds_exact_target_path_not_parent_or_siblings(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Only the exact spawn target is trusted — never parents or siblings."""
+        import json
+
+        state = tmp_path / ".claude.json"
+        project_dir = tmp_path / "repos" / "target-repo"
+        sibling_dir = tmp_path / "repos" / "sibling-repo"
+        parent_dir = tmp_path / "repos"
+
+        _ensure_project_trusted(state, project_dir)
+
+        data = json.loads(state.read_text())
+        assert str(project_dir) in data["projects"]
+        assert str(sibling_dir) not in data["projects"]
+        assert str(parent_dir) not in data["projects"]
 
 
 class TestCopySettingsWithoutPlugins:


### PR DESCRIPTION
## Summary

Non-interactive agent spawns (`loom.sh` pool, `agent-spawn.sh --role sweep`)
into a freshly-created repo/worktree that Claude Code has never opened hit
the interactive folder-trust modal ("Is this a project you created or one
you trust?"). The role command is delivered as keystrokes into the modal
instead of being run, so sessions stall or die. Root cause: `~/.claude.json`
has no `projects[<path>].hasTrustDialogAccepted: true` entry for the
never-opened folder.

## Changes

- `loom-tools/src/loom_tools/common/claude_config.py`: added
  `_ensure_project_trusted(state_path, project_dir)`, following
  `_ensure_onboarding_complete()`'s two invariants — merge-never-replace
  (only sets the one flag, preserving any richer existing entry's other
  fields and every other `projects` entry / top-level field) and
  write-through-the-symlink (never unlink-and-replace a healthy
  `.claude.json` symlink, per #2835). Gated by `LOOM_AUTO_TRUST` (default
  `"1"`/enabled; set to `"0"` to disable). Only the exact spawn target path
  is ever seeded — no parent-walking or sibling-globbing.
- `loom-tools/src/loom_tools/agent_spawn.py`: calls `_ensure_project_trusted`
  from `spawn_agent()` right after `setup_agent_config_dir(...)`, seeding the
  resolved `working_dir` (the actual worktree path when spawning into a
  worktree, not just `repo_root` — trust is keyed per-path).
- `loom-tools/tests/test_claude_config.py`: new `TestEnsureProjectTrusted`
  class (8 tests) covering empty state file, other-projects-present,
  existing-entry-with-extra-fields, valid-symlink-preserved,
  dangling-symlink-fallback, `LOOM_AUTO_TRUST=0` no-op, idempotency, and
  exact-path-only scoping.
- `loom-tools/tests/test_agent_spawn.py`: new `TestProjectTrustSeeding` class
  (2 tests) asserting `spawn_agent` invokes the seeding with the worktree
  path (not `repo_root`) when spawning into a worktree, and with `repo_root`
  when no worktree is given.

`defaults/scripts/spawn-claude.sh` is intentionally untouched — out of scope
per the issue (it execs the CLI in an already-interactive context).

## Acceptance Criteria Verification

- [x] Spawning into a folder with no `projects` entry results in
  `hasTrustDialogAccepted: true` for that folder before the CLI launches —
  verified via `test_seeds_trust_into_empty_state_file` and the
  `spawn_agent()` call-site tests.
- [x] Worktree spawns seed the worktree path, not only the repo root —
  verified via `test_seeds_trust_for_worktree_path_not_repo_root`.
- [x] Existing state-file content (other `projects` entries, other fields on
  an existing entry, other top-level fields) survives the merge — verified
  via `test_preserves_other_projects_entries` and
  `test_merges_flag_into_existing_entry_preserving_other_fields`.
- [x] A healthy `.claude.json` symlink is preserved (write-through); a
  dangling symlink falls back the same way `_ensure_onboarding_complete`
  does — verified via `test_writes_through_valid_symlink` and
  `test_dangling_symlink_falls_back_to_standalone_file`.
- [x] `LOOM_AUTO_TRUST=0` disables the seeding — verified via
  `test_disabled_via_loom_auto_trust_env`.
- [x] Idempotent: re-spawn into an already-trusted folder is a no-op (no file
  rewrite churn) — verified via `test_idempotent_no_rewrite_when_already_trusted`
  (asserts unchanged mtime).

## Test Plan

- `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/test_claude_config.py::TestEnsureProjectTrusted loom-tools/tests/test_agent_spawn.py::TestProjectTrustSeeding -v` — 10 passed.
- `ruff check` on all 4 changed files — clean (2 pre-existing findings in
  `agent_spawn.py`/`test_agent_spawn.py`, both outside the diff, unrelated to
  this change — confirmed present on unmodified `main` too).
- Note: the full `loom-tools/tests/test_claude_config.py` suite hangs on this
  particular macOS dev sandbox due to a pre-existing, unrelated issue —
  `setup_agent_config_dir()`'s `_clone_keychain_credentials()` calls the real
  `security` CLI, which can block on an interactive Keychain/TCC prompt in a
  headless sandbox (see `.loom/docs/macos-tcc-codesign.md`). Reproduced
  identically on unmodified `main` before any of this PR's changes, so it is
  not a regression; `_clone_keychain_credentials` is a no-op on non-Darwin,
  so CI (Linux) is unaffected.
- Manual verification (per the issue's repro) not performed in this sandbox;
  the merge/symlink/idempotency logic is covered by the automated tests
  above using the same code paths `setup_agent_config_dir` exercises for
  `_ensure_onboarding_complete`.

Closes #4334