### PR TITLE
feat(loom-tools): local-only opt-in semantic search over sweep summaries + PR history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,10 @@ Thumbs.db
 .loom/usage-cache.json
 .loom/claude-config/
 .loom/tokens/
+# Local, opt-in semantic search index (#4339) — repo-local SQLite DB. Never
+# committed; runtime code also refuses to write here if this entry is ever
+# removed (see loom_tools.semantic_search.guard_index_dest_not_tracked).
+.loom/search-index/
 .loom/accounts.env
 .loom/sweep-checkpoint/
 .loom/sweep-run/

--- a/defaults/docs/semantic-search.md
+++ b/defaults/docs/semantic-search.md
@@ -1,0 +1,105 @@
+# Semantic Search Over Sweep History (`loom-search`)
+
+Local-only, **opt-in, off-by-default** search over past sweep summaries and
+merged-PR history. Filed as the codecast-evaluation borrow-list item 2
+(`docs/research/codecast-evaluation.md`, Question 4) — issue #4339.
+
+## Why
+
+Loom has no memory across past sweeps: `.loom/logs/sweep-issue-*.log` and
+merged PRs are grep-able and browsable, but not aggregated or ranked.
+"Did a past sweep already hit this failure?" is otherwise answered by manual
+log archaeology. `loom-search` gives a single ranked query surface over both.
+
+## Enablement
+
+Disabled by default. Enable one of:
+
+- `.loom/config.json`:
+
+  ```json
+  { "search": { "enabled": true } }
+  ```
+
+- Env override (wins over config in both directions):
+
+  ```bash
+  export LOOM_SEARCH_ENABLED=1   # or 0 to force-disable even if config says true
+  ```
+
+Resolution precedence is **env > config > default (off)** — the same
+convention as `autonomous.*` and `transcriptArchive`.
+
+## Usage
+
+```bash
+# Build/refresh the index (incremental — a second run with no new sweeps/PRs
+# indexes 0 new rows).
+loom-search index
+
+# Query (top 10 results by default).
+loom-search "token exhaustion"
+loom-search --top-k 20 "auth token exhaustion"
+```
+
+When search is **disabled**, `loom-search index` is a no-op (no
+`.loom/search-index/` directory is created) and `loom-search QUERY` degrades
+to a plain, case-insensitive grep over `.loom/logs/sweep-issue-*.log`,
+printing a note that the index is disabled and how to enable it.
+
+## What is indexed (v1)
+
+1. **Sweep final summaries** — the tail (~8 KB) of each
+   `.loom/logs/sweep-issue-<N>.log`, keyed by the issue number in the
+   filename. Full transcripts are **not** indexed (bounds cost; see
+   "Out of scope" below).
+2. **Merged PR titles/bodies** for the current repo, via
+   `gh pr list --state merged --json number,title,body,mergedAt,url --limit
+   500` (bounded to the 500 most recent).
+
+Issue-closing-comment ingest is a stretch goal only and is **not** built in
+v1 (doc note, not implemented).
+
+## Storage and ranking
+
+- SQLite database at `.loom/search-index/index.db` — repo-local, gitignored.
+- Ranking is SQLite **FTS5 + BM25** via the stdlib `sqlite3` module only —
+  zero new dependencies, no model download, fully local.
+- Indexing is incremental: each sweep log is keyed by its mtime, each PR by
+  its `mergedAt` timestamp; unchanged items are skipped on re-index.
+
+### Tier B (vector embeddings) — not built in v1
+
+The schema includes an `embeddings` table placeholder and an `Embedder`
+protocol stub so a follow-up can add local (e.g. an ONNX model behind a
+`loom-tools[search]` optional extra) or remote embeddings, each gated by its
+own separate opt-in (a future `search.embeddings.provider` config key,
+default none). **No heavyweight ML dependency ships in this v1.** See the
+follow-up issue linked from PR #4339's implementation for the Tier B design
+discussion.
+
+## Threat model
+
+- **What is indexed**: sweep-log tails (may reference issue numbers, error
+  messages, and file paths already local to this repo/host) and merged PR
+  titles/bodies (already public/forge-hosted content for this repo).
+- **Where it lives**: `.loom/search-index/index.db`, on this host only,
+  under the repo working tree. It is gitignored — a runtime
+  gitignore-or-refuse guard (mirroring
+  `defaults/scripts/archive-transcripts.sh`) additionally refuses to write
+  the index if that entry is ever removed from `.gitignore` and the
+  destination is not otherwise ignored.
+- **What leaves the host**: nothing, by default. The only network traffic is
+  the `gh pr list` forge read during `loom-search index` — the same
+  coordination-layer read every other Loom role already performs, not a sync
+  of local data off-host. If a future Tier B enables a remote embeddings
+  provider, that call (and its own opt-in) will be documented here at that
+  time; v1 makes no such call.
+
+## Out of scope (v1)
+
+- Vector embeddings / any model download (Tier B follow-up issue).
+- Raw-transcript indexing over the #3726 transcript archive.
+- Issue-closing-comment ingest.
+- Any daemon/MCP surface — `loom-search` is a plain CLI.
+- Any networked storage backend.

--- a/loom-tools/pyproject.toml
+++ b/loom-tools/pyproject.toml
@@ -51,6 +51,7 @@ loom-auto-merge = "loom_tools.auto_merge:main"
 loom-tokens = "loom_tools.tokens.cli:main"
 loom-state-machine = "loom_tools.state_machine:main"
 loom-resolve-model = "loom_tools.model_tiers:main"
+loom-search = "loom_tools.semantic_search:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/loom-tools/src/loom_tools/semantic_search.py
+++ b/loom-tools/src/loom_tools/semantic_search.py
@@ -1,0 +1,606 @@
+"""Local-only, opt-in semantic search over sweep summaries + PR history (#4339).
+
+Codecast-evaluation borrow-list item 2 (``docs/research/codecast-evaluation.md``,
+Question 4), constrained by that evaluation's Q3 verdict: **opt-in,
+off-by-default, local-only storage** — this module must never reproduce
+codecast's plaintext off-host sync inside Loom.
+
+**What is indexed (v1)**:
+
+1. Sweep final summaries — the tail (~8 KB) of each
+   ``.loom/logs/sweep-issue-<N>.log``, keyed by the issue number parsed from
+   the filename.
+2. Merged PR titles/bodies for the current repo, via
+   ``gh pr list --state merged --json number,title,body,mergedAt,url --limit
+   500`` (bounded; reading the forge is normal coordination-layer traffic,
+   not off-host sync of local data).
+
+Issue-closing-comment ingest and raw-transcript indexing (the #3726 archive)
+are explicitly out of scope for v1 — see the follow-up issue filed alongside
+this PR for the Tier B (vector embeddings) work.
+
+**Storage**: a SQLite database at ``.loom/search-index/index.db``
+(repo-local, gitignored). Ranking is SQLite FTS5 + BM25 — stdlib ``sqlite3``
+only, zero new dependencies. Tier B (pluggable embeddings) is designed in via
+the :class:`Embedder` protocol and the ``embeddings`` table, but not
+implemented in v1.
+
+**Enablement**: ``search.enabled`` in ``.loom/config.json`` (read via the
+canonical :mod:`loom_tools.common.config_resolver`), with env override
+``LOOM_SEARCH_ENABLED`` (via :func:`loom_tools.common.config.env_bool`).
+Default OFF. Precedence is **env > config > default**, matching the
+``autonomous.*`` / ``transcriptArchive`` convention elsewhere in this repo.
+When disabled, ``loom-search QUERY`` degrades to a plain grep over
+``.loom/logs/sweep-issue-*.log`` and indexing is a no-op.
+
+See ``defaults/docs/semantic-search.md`` for the full usage + threat-model
+doc.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from loom_tools.common.config import env_bool
+from loom_tools.common.config_resolver import get_path, resolve_effective_config
+
+logger = logging.getLogger(__name__)
+
+#: Env var overriding ``search.enabled`` in ``.loom/config.json``.
+SEARCH_ENABLED_ENV = "LOOM_SEARCH_ENABLED"
+
+#: Repo-relative directory the SQLite index lives under. Must stay gitignored
+#: (see ``.gitignore``) — a misconfigured/un-ignored destination refuses to
+#: write, mirroring ``defaults/scripts/archive-transcripts.sh``'s
+#: gitignore-or-refuse guard.
+INDEX_DIR_REL = ".loom/search-index"
+INDEX_DB_NAME = "index.db"
+
+#: Repo-relative glob of sweep log files to index / grep-fallback over.
+SWEEP_LOG_GLOB = ".loom/logs/sweep-issue-*.log"
+
+#: Bytes of log tail to index per sweep (bounds cost; full transcripts are
+#: explicitly out of scope for v1).
+LOG_TAIL_BYTES = 8192
+
+#: Bound on merged PRs fetched per index run.
+PR_FETCH_LIMIT = 500
+
+_SWEEP_LOG_RE = re.compile(r"sweep-issue-(\d+)\.log$")
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS items (
+    source_type TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    watermark TEXT NOT NULL,
+    fts_rowid INTEGER,
+    PRIMARY KEY (source_type, source_id)
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS documents USING fts5(
+    source_type UNINDEXED,
+    source_id UNINDEXED,
+    title,
+    body,
+    link UNINDEXED
+);
+
+-- Tier B placeholder (#4339 follow-up): not populated in v1. Kept here so a
+-- later PR can add local/remote embeddings without a schema migration dance.
+CREATE TABLE IF NOT EXISTS embeddings (
+    source_type TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    model TEXT NOT NULL,
+    vector BLOB NOT NULL,
+    PRIMARY KEY (source_type, source_id, model)
+);
+"""
+
+
+class Embedder(Protocol):
+    """Tier B stub (#4339 follow-up) — not implemented in v1.
+
+    A later, separately opt-in tier can implement this to populate the
+    ``embeddings`` table (local ONNX model or a remote API gated by its own
+    ``search.embeddings.provider`` config, default none).
+    """
+
+    def embed(self, text: str) -> list[float]:
+        """Return a vector embedding for ``text``."""
+        ...
+
+
+@dataclass
+class SearchResult:
+    """One ranked search hit."""
+
+    source_type: str  # "sweep" or "pr"
+    source_id: str
+    title: str
+    summary: str
+    link: str
+    rank: float
+
+
+# --------------------------------------------------------------------------
+# Enablement
+# --------------------------------------------------------------------------
+
+
+def is_search_enabled(repo_root: Path) -> bool:
+    """Resolve whether the semantic index is enabled for ``repo_root``.
+
+    Precedence: env (:data:`SEARCH_ENABLED_ENV`) > ``search.enabled`` in the
+    resolved ``.loom/config.json`` tree > default (``False``). The env var
+    wins in *both* directions when present — even ``LOOM_SEARCH_ENABLED=0``
+    overrides a ``true`` config value, matching the
+    ``transcriptArchive``/``autonomous.*`` convention.
+    """
+    if SEARCH_ENABLED_ENV in os.environ:
+        return env_bool(SEARCH_ENABLED_ENV, default=False)
+    effective = resolve_effective_config(repo_root)
+    return bool(get_path(effective, "search.enabled", False))
+
+
+# --------------------------------------------------------------------------
+# gitignore-or-refuse guard (mirrors archive-transcripts.sh)
+# --------------------------------------------------------------------------
+
+
+class IndexDestinationNotIgnoredError(RuntimeError):
+    """Raised when the index destination is tracked (or trackable) by git."""
+
+
+def _git_toplevel(path: Path) -> str | None:
+    probe = path
+    while not probe.exists() and probe != probe.parent:
+        probe = probe.parent
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(probe), "rev-parse", "--show-toplevel"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _is_gitignored(top: str, dest: Path) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "-C", top, "check-ignore", "-q", str(dest) + "/"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+def guard_index_dest_not_tracked(dest: Path) -> None:
+    """Refuse to proceed if ``dest`` is inside a git repo but not gitignored.
+
+    Mirrors ``archive-transcripts.sh``'s ``guard_dest_not_tracked``: a
+    misconfigured index destination must never become a tracked artifact.
+    Not inside any repo at all is fine (e.g. a destination outside the repo).
+    """
+    top = _git_toplevel(dest)
+    if not top:
+        return
+    if _is_gitignored(top, dest):
+        return
+    raise IndexDestinationNotIgnoredError(
+        f"Index destination '{dest}' is inside git repo '{top}' but is NOT "
+        "gitignored. Refusing to write the search index into a tracked "
+        "tree. Add the path to .gitignore, or point search.indexDir "
+        "elsewhere."
+    )
+
+
+def index_dir(repo_root: Path) -> Path:
+    """Resolve the index directory for ``repo_root`` (no side effects)."""
+    return repo_root / INDEX_DIR_REL
+
+
+def index_db_path(repo_root: Path) -> Path:
+    return index_dir(repo_root) / INDEX_DB_NAME
+
+
+# --------------------------------------------------------------------------
+# Storage
+# --------------------------------------------------------------------------
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_SCHEMA)
+    conn.commit()
+    return conn
+
+
+def _upsert_document(
+    conn: sqlite3.Connection,
+    *,
+    source_type: str,
+    source_id: str,
+    watermark: str,
+    title: str,
+    body: str,
+    link: str,
+) -> bool:
+    """Insert/refresh one document. Returns True if newly indexed/changed."""
+    row = conn.execute(
+        "SELECT watermark, fts_rowid FROM items WHERE source_type = ? AND source_id = ?",
+        (source_type, source_id),
+    ).fetchone()
+    if row is not None and row[0] == watermark:
+        return False  # unchanged -> skip (incremental no-op)
+
+    if row is not None and row[1] is not None:
+        conn.execute("DELETE FROM documents WHERE rowid = ?", (row[1],))
+
+    cur = conn.execute(
+        "INSERT INTO documents (source_type, source_id, title, body, link) VALUES (?, ?, ?, ?, ?)",
+        (source_type, source_id, title, body, link),
+    )
+    fts_rowid = cur.lastrowid
+    conn.execute(
+        """
+        INSERT INTO items (source_type, source_id, watermark, fts_rowid)
+        VALUES (?, ?, ?, ?)
+        ON CONFLICT(source_type, source_id)
+        DO UPDATE SET watermark = excluded.watermark, fts_rowid = excluded.fts_rowid
+        """,
+        (source_type, source_id, watermark, fts_rowid),
+    )
+    return True
+
+
+# --------------------------------------------------------------------------
+# Sweep log ingest
+# --------------------------------------------------------------------------
+
+
+def _read_log_tail(path: Path, max_bytes: int = LOG_TAIL_BYTES) -> str:
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return ""
+    with path.open("rb") as fh:
+        if size > max_bytes:
+            fh.seek(size - max_bytes)
+        data = fh.read()
+    return data.decode("utf-8", errors="replace")
+
+
+def _sweep_log_paths(repo_root: Path) -> list[Path]:
+    logs_dir = repo_root / ".loom" / "logs"
+    if not logs_dir.is_dir():
+        return []
+    return sorted(logs_dir.glob("sweep-issue-*.log"))
+
+
+def index_sweep_logs(conn: sqlite3.Connection, repo_root: Path) -> int:
+    """Ingest sweep-log tails. Returns the count of newly indexed/changed rows."""
+    new_count = 0
+    for log_path in _sweep_log_paths(repo_root):
+        match = _SWEEP_LOG_RE.search(log_path.name)
+        if not match:
+            continue
+        issue = match.group(1)
+        try:
+            mtime = log_path.stat().st_mtime
+        except OSError:
+            continue
+        watermark = repr(mtime)
+        tail = _read_log_tail(log_path)
+        if not tail.strip():
+            continue
+        changed = _upsert_document(
+            conn,
+            source_type="sweep",
+            source_id=issue,
+            watermark=watermark,
+            title=f"Sweep issue #{issue}",
+            body=tail,
+            link=str(log_path),
+        )
+        if changed:
+            new_count += 1
+    return new_count
+
+
+# --------------------------------------------------------------------------
+# PR ingest
+# --------------------------------------------------------------------------
+
+
+def _run_gh_pr_list(repo_root: Path, limit: int = PR_FETCH_LIMIT) -> list[dict[str, Any]]:
+    """Fetch merged PRs for ``repo_root`` via ``gh pr list``.
+
+    A thin, directly-monkeypatchable seam for tests (no real network calls
+    in the test suite). Returns ``[]`` on any failure (missing ``gh``,
+    offline, non-repo) rather than raising — PR ingest is best-effort.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--state",
+                "merged",
+                "--json",
+                "number,title,body,mergedAt,url",
+                "--limit",
+                str(limit),
+            ],
+            cwd=str(repo_root),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning("gh pr list failed (skipping PR ingest): %s", exc)
+        return []
+    if result.returncode != 0:
+        logger.warning("gh pr list exited %s (skipping PR ingest): %s", result.returncode, result.stderr.strip())
+        return []
+    try:
+        data = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+    return data if isinstance(data, list) else []
+
+
+def index_prs(conn: sqlite3.Connection, repo_root: Path) -> int:
+    """Ingest merged PR titles/bodies. Returns count of newly indexed/changed rows."""
+    prs = _run_gh_pr_list(repo_root)
+    new_count = 0
+    for pr in prs:
+        number = pr.get("number")
+        if number is None:
+            continue
+        merged_at = pr.get("mergedAt") or ""
+        title = pr.get("title") or ""
+        body = pr.get("body") or ""
+        link = pr.get("url") or ""
+        changed = _upsert_document(
+            conn,
+            source_type="pr",
+            source_id=str(number),
+            watermark=str(merged_at),
+            title=title,
+            body=body,
+            link=link,
+        )
+        if changed:
+            new_count += 1
+    return new_count
+
+
+# --------------------------------------------------------------------------
+# Indexing entrypoint
+# --------------------------------------------------------------------------
+
+
+def build_index(repo_root: Path) -> dict[str, int]:
+    """Build/refresh the index for ``repo_root``.
+
+    A no-op (returns zero counts, creates nothing) when search is disabled.
+    Otherwise creates ``.loom/search-index/index.db`` if absent, and ingests
+    sweep-log tails plus merged PRs, skipping unchanged items.
+    """
+    if not is_search_enabled(repo_root):
+        return {"sweeps": 0, "prs": 0}
+
+    dest = index_dir(repo_root)
+    guard_index_dest_not_tracked(dest)
+
+    conn = _connect(index_db_path(repo_root))
+    try:
+        sweeps = index_sweep_logs(conn, repo_root)
+        prs = index_prs(conn, repo_root)
+        conn.commit()
+    finally:
+        conn.close()
+    return {"sweeps": sweeps, "prs": prs}
+
+
+# --------------------------------------------------------------------------
+# Query
+# --------------------------------------------------------------------------
+
+
+def _build_fts_query(query: str) -> str:
+    """Build an FTS5 MATCH expression favoring exact-phrase matches.
+
+    Combines a quoted phrase clause with a bareword AND-of-terms clause so
+    partial (non-adjacent term) matches still surface, while
+    :func:`_rank_results` sorts exact-phrase hits ahead of them.
+    """
+    terms = re.findall(r"\w+", query)
+    if not terms:
+        return '""'
+    escaped_phrase = '"' + query.replace('"', '""') + '"'
+    if len(terms) > 1:
+        return f"{escaped_phrase} OR ({' AND '.join(terms)})"
+    return escaped_phrase
+
+
+def query_index(repo_root: Path, query: str, top_k: int = 10) -> list[SearchResult]:
+    """Run a BM25-ranked FTS5 query over the index. Empty list if no index/hits."""
+    db_path = index_db_path(repo_root)
+    if not db_path.exists():
+        return []
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript(_SCHEMA)  # idempotent; guards a partial/corrupt DB
+        try:
+            rows = conn.execute(
+                """
+                SELECT source_type, source_id, title, body, link, bm25(documents) AS rank
+                FROM documents
+                WHERE documents MATCH ?
+                ORDER BY rank
+                LIMIT ?
+                """,
+                (_build_fts_query(query), max(top_k * 4, top_k)),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return []
+    finally:
+        conn.close()
+
+    query_lower = query.strip().lower()
+    results = []
+    for source_type, source_id, title, body, link, rank in rows:
+        summary_line = next((line.strip() for line in body.splitlines() if line.strip()), "")
+        exact_phrase = bool(query_lower) and (
+            query_lower in title.lower() or query_lower in body.lower()
+        )
+        results.append((not exact_phrase, rank, SearchResult(
+            source_type=source_type,
+            source_id=source_id,
+            title=title,
+            summary=summary_line,
+            link=link,
+            rank=rank,
+        )))
+
+    results.sort(key=lambda r: (r[0], r[1]))
+    return [r[2] for r in results[:top_k]]
+
+
+# --------------------------------------------------------------------------
+# Grep fallback (disabled path)
+# --------------------------------------------------------------------------
+
+
+def grep_fallback(repo_root: Path, query: str, top_k: int = 10) -> list[str]:
+    """Plain case-insensitive grep over sweep logs, used when search is disabled."""
+    pattern = re.compile(re.escape(query), re.IGNORECASE)
+    hits: list[str] = []
+    for log_path in _sweep_log_paths(repo_root):
+        try:
+            text = log_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            if pattern.search(line):
+                hits.append(f"{log_path}:{line_no}: {line.strip()}")
+                if len(hits) >= top_k:
+                    return hits
+    return hits
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def _default_repo_root() -> Path:
+    try:
+        from loom_tools.common.repo import find_repo_root
+
+        return find_repo_root()
+    except FileNotFoundError:
+        return Path.cwd()
+
+
+def _cmd_index(repo_root: Path) -> int:
+    if not is_search_enabled(repo_root):
+        print(
+            "Semantic search is disabled (search.enabled is false / "
+            f"{SEARCH_ENABLED_ENV} not set) — indexing is a no-op. "
+            "See defaults/docs/semantic-search.md to enable."
+        )
+        return 0
+    counts = build_index(repo_root)
+    print(f"Indexed {counts['sweeps']} sweep log(s), {counts['prs']} PR(s) (new/changed).")
+    return 0
+
+
+def _cmd_query(repo_root: Path, query: str, top_k: int) -> int:
+    if not is_search_enabled(repo_root):
+        print(
+            "[semantic index disabled — falling back to grep over "
+            f"{SWEEP_LOG_GLOB}. Enable with search.enabled or "
+            f"{SEARCH_ENABLED_ENV}=1; see defaults/docs/semantic-search.md]\n"
+        )
+        hits = grep_fallback(repo_root, query, top_k=top_k)
+        if not hits:
+            print("No matches.")
+            return 0
+        for hit in hits:
+            print(hit)
+        return 0
+
+    results = query_index(repo_root, query, top_k=top_k)
+    if not results:
+        print("No matches (index may be empty — run `loom-search index` first).")
+        return 0
+    for res in results:
+        print(f"[{res.source_type}] #{res.source_id} {res.title}")
+        if res.summary:
+            print(f"    {res.summary}")
+        print(f"    {res.link}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Two forms, dispatched manually (rather than via argparse subparsers) so
+    a bare query string is never mistaken for a subcommand name:
+
+    - ``loom-search index [--repo-root DIR]``
+    - ``loom-search "QUERY" [--top-k N] [--repo-root DIR]``
+    """
+    argv = list(sys.argv[1:] if argv is None else argv)
+
+    parser = argparse.ArgumentParser(
+        prog="loom-search",
+        description="Local-only, opt-in semantic search over sweep summaries + PR history.",
+    )
+    parser.add_argument("--repo-root", type=Path, default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--top-k", type=int, default=10, help="Max results to return (default: 10).")
+    parser.add_argument("query", nargs="*", help="Search query, or 'index' to build/refresh the index.")
+
+    if argv and argv[0] == "index":
+        args = parser.parse_args(argv[1:])
+        repo_root = (args.repo_root or _default_repo_root()).resolve()
+        return _cmd_index(repo_root)
+
+    args = parser.parse_args(argv)
+    repo_root = (args.repo_root or _default_repo_root()).resolve()
+
+    if not args.query:
+        parser.print_help()
+        return 1
+    query = " ".join(args.query)
+    return _cmd_query(repo_root, query, args.top_k)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/loom-tools/tests/test_semantic_search.py
+++ b/loom-tools/tests/test_semantic_search.py
@@ -1,0 +1,247 @@
+"""Tests for the local-only, opt-in semantic search module (#4339)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from loom_tools import semantic_search as ss
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    """Init a git repo at tmp_path with a minimal .loom/logs/ dir."""
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True, capture_output=True
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, capture_output=True)
+    (tmp_path / ".loom" / "logs").mkdir(parents=True)
+    return tmp_path
+
+
+def _write_config(repo_root: Path, config: dict) -> None:
+    (repo_root / ".loom").mkdir(exist_ok=True)
+    (repo_root / ".loom" / "config.json").write_text(json.dumps(config))
+
+
+def _write_sweep_log(repo_root: Path, issue: int, body: str) -> Path:
+    path = repo_root / ".loom" / "logs" / f"sweep-issue-{issue}.log"
+    path.write_text(body)
+    return path
+
+
+def _ignore_search_index(repo_root: Path) -> None:
+    """Add the standard gitignore entry so the gitignore-or-refuse guard passes.
+
+    Real repos already ship this entry (see .gitignore); tests that exercise
+    indexing (not the guard itself) need it present so build_index proceeds.
+    """
+    (repo_root / ".gitignore").write_text(".loom/search-index/\n")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ss.SEARCH_ENABLED_ENV, raising=False)
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    return _init_repo(tmp_path)
+
+
+class TestDisabledByDefault:
+    def test_no_config_no_env_is_disabled(self, repo: Path) -> None:
+        assert ss.is_search_enabled(repo) is False
+
+    def test_index_is_noop_when_disabled(self, repo: Path) -> None:
+        _write_sweep_log(repo, 1, "some sweep summary text")
+        counts = ss.build_index(repo)
+        assert counts == {"sweeps": 0, "prs": 0}
+        assert not ss.index_dir(repo).exists()
+
+    def test_query_falls_back_to_grep_with_note(
+        self, repo: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write_sweep_log(repo, 7, "line one\nTOKEN EXHAUSTION detected\nline three\n")
+        rc = ss.main(["token exhaustion", "--repo-root", str(repo)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "disabled" in out.lower()
+        assert "sweep-issue-7.log" in out
+
+
+class TestEnvOverConfigPrecedence:
+    def test_env_true_overrides_config_false(self, repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_config(repo, {"search": {"enabled": False}})
+        monkeypatch.setenv(ss.SEARCH_ENABLED_ENV, "1")
+        assert ss.is_search_enabled(repo) is True
+
+    def test_env_false_overrides_config_true(self, repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_config(repo, {"search": {"enabled": True}})
+        monkeypatch.setenv(ss.SEARCH_ENABLED_ENV, "0")
+        assert ss.is_search_enabled(repo) is False
+
+    def test_config_true_enables_without_env(self, repo: Path) -> None:
+        _write_config(repo, {"search": {"enabled": True}})
+        assert ss.is_search_enabled(repo) is True
+
+
+class TestIndexingAndRanking:
+    def test_indexes_fixture_sweep_logs_and_ranks_exact_phrase_first(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ss.SEARCH_ENABLED_ENV, "1")
+        monkeypatch.setattr(ss, "_run_gh_pr_list", lambda repo_root, limit=ss.PR_FETCH_LIMIT: [])
+        _ignore_search_index(repo)
+
+        _write_sweep_log(
+            repo, 101, "sweep summary: hit a token exhaustion failure during dispatch\n"
+        )
+        _write_sweep_log(
+            repo, 102, "sweep summary: an unrelated token was rotated; exhaustion of retries too\n"
+        )
+
+        counts = ss.build_index(repo)
+        assert counts["sweeps"] == 2
+        assert ss.index_db_path(repo).exists()
+
+        results = ss.query_index(repo, "token exhaustion")
+        assert results, "expected at least one hit"
+        assert results[0].source_id == "101"
+        ids_in_order = [r.source_id for r in results]
+        assert ids_in_order.index("101") < ids_in_order.index("102")
+
+    def test_incremental_reindex_indexes_zero_new_rows(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ss.SEARCH_ENABLED_ENV, "1")
+        monkeypatch.setattr(ss, "_run_gh_pr_list", lambda repo_root, limit=ss.PR_FETCH_LIMIT: [])
+        _ignore_search_index(repo)
+
+        _write_sweep_log(repo, 5, "first pass summary text\n")
+        first = ss.build_index(repo)
+        assert first["sweeps"] == 1
+
+        second = ss.build_index(repo)
+        assert second["sweeps"] == 0
+        assert second["prs"] == 0
+
+    def test_empty_index_query_returns_no_results_not_traceback(self, repo: Path) -> None:
+        assert ss.query_index(repo, "anything") == []
+
+
+class TestPrIngestMocked:
+    def test_pr_ingest_uses_mocked_gh_and_is_queryable(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ss.SEARCH_ENABLED_ENV, "1")
+        _ignore_search_index(repo)
+
+        fake_prs = [
+            {
+                "number": 4339,
+                "title": "feat: local-only opt-in semantic search",
+                "body": "Adds loom-search with FTS5 BM25 ranking.",
+                "mergedAt": "2026-07-29T00:00:00Z",
+                "url": "https://github.com/rjwalters/loom/pull/4339",
+            }
+        ]
+
+        def _fake_gh_pr_list(repo_root: Path, limit: int = ss.PR_FETCH_LIMIT) -> list[dict]:
+            assert repo_root == repo
+            return fake_prs
+
+        monkeypatch.setattr(ss, "_run_gh_pr_list", _fake_gh_pr_list)
+
+        counts = ss.build_index(repo)
+        assert counts["prs"] == 1
+
+        results = ss.query_index(repo, "semantic search")
+        assert any(r.source_type == "pr" and r.source_id == "4339" for r in results)
+
+        # Second run with the same fixture data indexes nothing new.
+        counts2 = ss.build_index(repo)
+        assert counts2["prs"] == 0
+
+    def test_gh_failure_does_not_raise(self, repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ss.SEARCH_ENABLED_ENV, "1")
+        _ignore_search_index(repo)
+
+        def _boom(repo_root: Path, limit: int = ss.PR_FETCH_LIMIT) -> list[dict]:
+            return []
+
+        monkeypatch.setattr(ss, "_run_gh_pr_list", _boom)
+        counts = ss.build_index(repo)
+        assert counts["prs"] == 0
+
+
+class TestGitignoreOrRefuseGuard:
+    def test_untracked_and_unignored_dest_refuses(self, repo: Path) -> None:
+        dest = repo / ".loom" / "search-index"
+        with pytest.raises(ss.IndexDestinationNotIgnoredError):
+            ss.guard_index_dest_not_tracked(dest)
+
+    def test_ignored_dest_proceeds(self, repo: Path) -> None:
+        (repo / ".gitignore").write_text(".loom/search-index/\n")
+        dest = repo / ".loom" / "search-index"
+        ss.guard_index_dest_not_tracked(dest)  # must not raise
+
+    def test_dest_outside_any_repo_proceeds(self, tmp_path: Path) -> None:
+        outside = tmp_path / "not-a-repo" / "search-index"
+        ss.guard_index_dest_not_tracked(outside)  # must not raise
+
+    def test_build_index_refuses_when_dest_untracked_and_unignored(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ss.SEARCH_ENABLED_ENV, "1")
+        monkeypatch.setattr(ss, "_run_gh_pr_list", lambda repo_root, limit=ss.PR_FETCH_LIMIT: [])
+        with pytest.raises(ss.IndexDestinationNotIgnoredError):
+            ss.build_index(repo)
+
+    def test_build_index_proceeds_when_dest_ignored(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (repo / ".gitignore").write_text(".loom/search-index/\n")
+        monkeypatch.setenv(ss.SEARCH_ENABLED_ENV, "1")
+        monkeypatch.setattr(ss, "_run_gh_pr_list", lambda repo_root, limit=ss.PR_FETCH_LIMIT: [])
+        counts = ss.build_index(repo)
+        assert ss.index_db_path(repo).exists()
+        assert counts == {"sweeps": 0, "prs": 0}
+
+
+class TestFtsQueryBuilder:
+    def test_multi_term_query_includes_phrase_and_and_clause(self) -> None:
+        expr = ss._build_fts_query("token exhaustion")
+        assert '"token exhaustion"' in expr
+        assert "token AND exhaustion" in expr
+
+    def test_single_term_query_is_just_the_phrase(self) -> None:
+        expr = ss._build_fts_query("token")
+        assert expr == '"token"'
+
+
+class TestCliIndexCommand:
+    def test_index_command_noop_message_when_disabled(
+        self, repo: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = ss.main(["index", "--repo-root", str(repo)])
+        assert rc == 0
+        assert not ss.index_dir(repo).exists()
+        out = capsys.readouterr().out
+        assert "disabled" in out.lower()
+
+    def test_index_command_builds_when_enabled(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv(ss.SEARCH_ENABLED_ENV, "1")
+        monkeypatch.setattr(ss, "_run_gh_pr_list", lambda repo_root, limit=ss.PR_FETCH_LIMIT: [])
+        _ignore_search_index(repo)
+        _write_sweep_log(repo, 9, "hello world\n")
+        rc = ss.main(["index", "--repo-root", str(repo)])
+        assert rc == 0
+        assert ss.index_db_path(repo).exists()
+        out = capsys.readouterr().out
+        assert "Indexed" in out


### PR DESCRIPTION
Closes #4339

## Summary

Adds `loom-search`, a repo-local, **off-by-default** CLI over completed
sweep artifacts — codecast-evaluation borrow-list item 2
(`docs/research/codecast-evaluation.md`, Question 4).

- New `loom_tools/semantic_search.py` module + `loom-search` entry point
  (`loom-tools/pyproject.toml`).
- **Index sources (v1)**: sweep-log tails (~8 KB, keyed by issue number) +
  merged PR titles/bodies for the current repo (`gh pr list --state merged
  --json number,title,body,mergedAt,url --limit 500`). Issue-closing-comment
  ingest is out of scope for v1 (doc note only).
- **Storage**: SQLite at `.loom/search-index/` (repo-local, gitignored —
  entry added to `.gitignore`). A gitignore-or-refuse guard mirroring
  `defaults/scripts/archive-transcripts.sh` refuses to write if that
  destination is ever untracked-but-not-ignored.
- **Enablement**: `search.enabled` in `.loom/config.json` (via the canonical
  `loom_tools.common.config_resolver`), env override `LOOM_SEARCH_ENABLED`
  (via `loom_tools.common.config.env_bool`). Precedence env > config >
  default (off). When disabled, `loom-search QUERY` degrades to a plain grep
  over `.loom/logs/sweep-issue-*.log` with an explanatory note; indexing is
  a no-op.
- **Ranking**: SQLite FTS5 + BM25, stdlib `sqlite3` only — zero new
  dependencies. Exact-phrase hits are surfaced ahead of partial (non-adjacent
  term) matches.
- **CLI**: `loom-search index` (incremental — mtime/`mergedAt` watermarks, a
  second run indexes nothing new) and `loom-search "QUERY"` (top-k, default
  10, ranked `sweep`/`pr` results with a title/summary line and a link).
- New doc: `defaults/docs/semantic-search.md` — usage, enablement, and the
  required threat-model note (nothing leaves the host by default except the
  normal `gh` forge read during indexing).

## Tier B (vector embeddings) — explicitly NOT built here

The schema includes an `embeddings` table placeholder and an `Embedder`
protocol stub, but Tier B itself (local ONNX model or remote embeddings
provider, each behind its own separate opt-in) is deferred. Follow-up filed
at #4370.

## Test plan

`loom-tools/tests/test_semantic_search.py` (20 tests, all passing):

- disabled-by-default: no config/env → index is a no-op, query falls back to
  grep with a note
- env-over-config precedence in both directions
- indexing fixture sweep logs + BM25 ranks exact-phrase above partial match
- incremental re-index indexes 0 new rows on unchanged fixtures
- PR ingest with a mocked `gh` call (no real network)
- gitignore-or-refuse guard: un-ignored dest refuses, ignored dest proceeds

```
PYTHONPATH=loom-tools/src:$PYTHONPATH python3 -m pytest loom-tools/tests/test_semantic_search.py -v
# 20 passed
```

Also ran `ruff check` on the new files (clean) and the existing
`test_config_resolver.py` / `test_config.py` / `tests/common/` suites (91
passed) since those are the reference modules this reuses — no regressions.
The full `loom-tools/tests` suite is very large (~2200 tests, several
sleep-based) and did not finish within this session's time budget;
`--collect-only` succeeded across the whole tree (no import-time breakage
from this change), and this PR touches no existing shared module (additive
new file + one-line `pyproject.toml`/`.gitignore` additions).