### PR TITLE
fix(tokens): registry-anchored fallback for daemon startup + tokens check --ranking (#4292)

### DIFF
--- a/.loom/docs/token-pool.md
+++ b/.loom/docs/token-pool.md
@@ -339,6 +339,71 @@ that used to derive it from the source tree the running binary was compiled
 from) — a consumer repo with no loom checkout now selects a token successfully
 with zero manual configuration and no Python package to locate at all.
 
+### Full anchoring precedence, and machine-level daemon startup (#4292)
+
+Everything above resolves the pool for a caller whose **workspace root is
+already known** to be a real repo checkout (an explicit `--workspace`, a
+worktree's own root, or a per-request-resolved dispatch target). A
+machine-level daemon (#3835/#3926) is different: at startup its own primary
+workspace is seeded from `LOOM_WORKSPACE` or, absent that, its **own process
+cwd** — and under `systemd` with no `WorkingDirectory=` override that cwd
+defaults to `$HOME`, which is not a repo checkout at all.
+
+Feeding a non-workspace cwd straight into the `#3938` per-repo/shared fallback
+is worse than "no tokens": the **default** shared pool is *also*
+`~/.loom/tokens`, so `workspace_root == $HOME` makes the per-repo and shared
+probes coincidentally check the exact same (usually empty) directory — masking
+wherever the pool was actually bootstrapped (e.g. a per-repo pool at the
+daemon's real, differently-located checkout) behind a plausible-looking but
+wrong "no tokens found" warning.
+
+The full precedence, in order, for every consumer (`loom-daemon status`, the
+daemon's own dispatch-capacity accounting, `tokens check --ranking`'s
+default-`--workspace` case, and the daemon's autonomous ranking-refresh loop):
+
+1. **Explicit `--workspace <path>`** (a CLI flag naming a real, possibly
+   unregistered, repo) — always wins outright, resolved via the per-repo/shared
+   precedence above. Never redirected, so pointing at a specific repo is never
+   silently overridden.
+2. **Default (`--workspace` omitted / `.` / the daemon's own seeded cwd) and
+   the candidate root falls under a registered workspace** — either because
+   `loom-daemon workspace add` was never run at all (an empty registry trusts
+   the candidate unconditionally, preserving `#3938`'s byte-for-byte
+   single-workspace behavior for every repo-local install), or because the
+   candidate matches a registered root — resolved via the same per-repo/shared
+   precedence, anchored at the registered root when the candidate is a
+   subdirectory of it.
+3. **Default and the candidate matches no registered workspace** — the
+   machine-level-daemon-at-`$HOME` case — skips the per-repo probe entirely and
+   resolves straight to the shared machine-level pool (`~/.loom/tokens`,
+   override `LOOM_SHARED_TOKENS_DIR`). Falls back to per-repo(candidate) only
+   when the shared pool is itself disabled (`LOOM_SHARED_TOKENS_DIR=""`).
+
+**Operational contract**: for step 3 to actually find tokens, a machine-level
+daemon's pool must be bootstrapped at the shared location —
+`loom-tokens bootstrap --shared` (or `import-from-monitor --shared`) — rather
+than per-repo at whatever directory happens to be the daemon's own checkout.
+Registering the daemon's own checkout as a workspace
+(`loom-daemon workspace add <checkout>`) is the alternative: that makes step 2
+apply instead, so a per-repo pool bootstrapped there (without `--shared`) is
+found too.
+
+**No `WorkingDirectory=` needed**: with the pool bootstrapped per the
+contract above, a `systemd`-managed daemon started with the unit's default
+`$HOME` cwd (or any other non-workspace directory) now finds its token pool —
+and reports accurate dispatch capacity — without an operator having to
+discover and set an explicit `WorkingDirectory=` override (`.loom/docs/daemon-reference.md`
+covers `#4268`/`#4319`/`#4321`, which already set `WorkingDirectory=` as
+first-class in *generated* systemd units; this section is for bare/unmanaged
+daemon startups and ad hoc CLI invocations from arbitrary cwds — the generated
+units already cover the managed case).
+
+Implementation: [`resolve_tokens_dir_anchored()`](../../loom-daemon/src/tokens_pool/paths.rs)
+delegates step 2/3's "is this candidate a recognized Loom workspace" question
+to the same registry-membership check `#4299` established for CLI
+`--workspace` defaulting (`workspace_registry::resolve_client_workspace_default`)
+rather than a second, parallel detection path.
+
 ## Hard-fail on missing pool
 
 `spawn-claude.sh` exits `78` (`EX_CONFIG`) with a message instructing the user to

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -652,15 +652,22 @@ guess. `token_pool_dir` is `null` only when talking to a pre-#4292 daemon binary
 machine mode, else `find_repo_root()`), so the daemon's primary workspace is never
 an incidental cwd when started that way. A **hand-rolled** unit that omits
 `WorkingDirectory=` starts with whatever cwd the service manager happens to use
-(often `~`) as the primary workspace instead. Since the per-repo pool for that
-workspace is `<cwd>/.loom/tokens/`, an operator who then bootstraps the
-machine-level pool via plain `loom-tokens bootstrap` from an **arbitrary**
-directory (not `~`, not a real repo checkout) will *not* populate the location the
-daemon resolves to by default. Always provision with `loom-tokens bootstrap
+(often `~`) as the primary workspace instead — as of #4292 (trip-wires 1 & 3,
+completing this issue) that no longer needs a `WorkingDirectory=` override to
+find its pool: dispatch-capacity accounting, `loom-daemon status`, and
+`tokens check --ranking`'s default `--workspace` all now ask whether that
+seeded primary workspace is itself a *recognized* Loom workspace (registry
+membership, reusing the #4299 check) before applying the per-repo/shared
+`#3938` precedence — and when it is not (the bare-`$HOME` case), they anchor
+straight to the shared machine-level pool instead of a per-repo(`$HOME`) path
+that can coincidentally collide with the shared *default* and mask wherever
+the pool was actually bootstrapped. The operational contract is unchanged:
+always provision a machine-level daemon's pool with `loom-tokens bootstrap
 --shared` (or `import-from-monitor --shared`) — which always targets
-`~/.loom/tokens/` regardless of cwd — so the daemon's default (cwd-anchored,
-falling back to shared) and the provisioning step agree, whether or not the unit
-that starts the daemon sets `WorkingDirectory=`.
+`~/.loom/tokens/` regardless of cwd — so the daemon's anchoring and the
+provisioning step agree, whether or not the unit that starts the daemon sets
+`WorkingDirectory=`. Full precedence chain: `.loom/docs/token-pool.md` →
+"Full anchoring precedence, and machine-level daemon startup (#4292)".
 
 ## Per-repo status breakdown + per-repo main-health gate (#3930 — phase d)
 

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1270,12 +1270,19 @@ pub fn build_daemon_status(
     // the same basis as pre-#3930 (which read them from the default registry's
     // `workspace_root`, i.e. `fallback_root`).
     let workspace_root = fallback_root;
-    let token_pool_size = crate::tokens::token_pool_size(workspace_root);
-    // Same precedence as `token_pool_size` (per-repo first, else the #3938
-    // shared machine-level pool), exposed on the report (#4292) so a client
-    // reading `status` from any cwd sees exactly which directory the daemon
-    // used rather than silently re-resolving a possibly-different one.
-    let token_pool_dir = Some(crate::tokens_pool::paths::resolve_tokens_dir(workspace_root));
+    // Registry-aware anchoring (#4292, trip-wire 1): `workspace_root` is the
+    // daemon's own seeded default (its cwd at startup, or `LOOM_WORKSPACE`),
+    // which for a machine-level daemon started under systemd with a bare cwd
+    // (e.g. `$HOME`) is not itself a real repo checkout. `workspace_registry`
+    // is already loaded above for `effective_roots`, so this reuses it rather
+    // than a second registry read.
+    let tokens_dir =
+        crate::tokens_pool::paths::resolve_tokens_dir_anchored(workspace_root, &workspace_registry);
+    let token_pool_size = crate::tokens::token_pool_size_at_dir(&tokens_dir);
+    // Exposed on the report (#4292) so a client reading `status` from any cwd
+    // sees exactly which directory the daemon used rather than silently
+    // re-resolving a possibly-different one.
+    let token_pool_dir = Some(tokens_dir.clone());
     let disk_headroom = crate::disk_headroom::disk_headroom_limit(workspace_root);
     // Hoisted above the CPU snapshot (#4032) so the resolved
     // `cpuUtilizationTarget` / `estCoresPerSweep` knobs can feed it — this read
@@ -1304,7 +1311,7 @@ pub fn build_daemon_status(
     // pool count toward the count of *healthy* accounts read from the rotation
     // ranking. When no ranking exists, `token_axis_limit` == the raw pool size,
     // so the dynamic cap is byte-for-byte the pre-#3902 value.
-    let ranking = crate::capacity::read_ranking(workspace_root);
+    let ranking = crate::capacity::read_ranking_at(&tokens_dir);
     let token_axis_limit = ranking.as_ref().map_or(token_pool_size, |r| r.available);
     let dynamic_cap = crate::work_finder::resolve_dynamic_max_concurrent(
         token_axis_limit,

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -4728,6 +4728,53 @@ fn resolve_tokens_workspace(workspace: &str) -> Result<PathBuf> {
     }
 }
 
+/// Resolve the effective tokens-pool directory for a `tokens` CLI
+/// subcommand's `--workspace` flag (issue #4292, trip-wire 3).
+///
+/// An **explicit** `--workspace` (anything other than the clap default `"."`)
+/// always resolves via today's per-repo/shared precedence
+/// ([`resolve_tokens_workspace`] +
+/// [`tokens_pool::paths::resolve_tokens_dir`], #3938) — unchanged, so an
+/// operator pointing at a specific (possibly unregistered) repo is never
+/// silently redirected.
+///
+/// Only the **default** `"."` case additionally asks whether the resolved cwd
+/// is itself a recognized Loom workspace, reusing the exact registry check
+/// #4299 established for CLI `--workspace` defaulting
+/// ([`workspace_registry::resolve_client_workspace_default`], via
+/// [`tokens_pool::paths::resolve_tokens_dir_anchored`]) rather than a second,
+/// parallel detection path. When it is not — the machine-level daemon's own
+/// `tokens check --ranking` invoked from a bare cwd, or an operator running
+/// `loom-daemon tokens check` from `$HOME` — this anchors straight to the
+/// shared machine-level pool instead of a per-repo(cwd) path that can
+/// coincidentally collide with the shared default (both resolve to
+/// `~/.loom/tokens` when cwd is `$HOME`).
+///
+/// Returns `(tokens_dir, anchored_to_shared)` — the second element is `true`
+/// only when the "not a recognized workspace" branch fired, so callers can
+/// surface *how* the directory was chosen (not just *which* directory).
+fn resolve_tokens_pool_dir_for_cli(workspace: &str) -> Result<(PathBuf, bool)> {
+    use loom_daemon::tokens_pool::paths;
+    use loom_daemon::workspace_registry::{resolve_client_workspace_default, WorkspaceRegistry};
+
+    let ws = resolve_tokens_workspace(workspace)?;
+    if workspace != "." {
+        return Ok((paths::resolve_tokens_dir(&ws), false));
+    }
+
+    let registry = WorkspaceRegistry::load_default().unwrap_or_default();
+    if registry.workspaces.is_empty() {
+        return Ok((paths::resolve_tokens_dir(&ws), false));
+    }
+    // Only actually "anchored to shared" when the shared pool is enabled and
+    // would be used — if `LOOM_SHARED_TOKENS_DIR=""` opts out,
+    // `resolve_tokens_dir_anchored` falls back to the per-repo(cwd) path
+    // instead, and the caller's messaging should say so.
+    let anchored_to_shared = resolve_client_workspace_default(&ws, &registry).is_none()
+        && paths::shared_tokens_dir().is_some();
+    Ok((paths::resolve_tokens_dir_anchored(&ws, &registry), anchored_to_shared))
+}
+
 #[cfg(test)]
 mod resolve_tokens_workspace_tests {
     //! Tests for [`resolve_tokens_workspace`] (issue #4292). No test here
@@ -4767,6 +4814,144 @@ mod resolve_tokens_workspace_tests {
             .expect("current_dir")
             .join("some/relative/repo");
         assert_eq!(resolved, expected);
+    }
+}
+
+#[cfg(test)]
+mod resolve_tokens_pool_dir_for_cli_tests {
+    //! Tests for [`resolve_tokens_pool_dir_for_cli`] (issue #4292, trip-wire
+    //! 3). Like `resolve_tokens_workspace_tests`, no test here `chdir`s the
+    //! process — cases that need to distinguish "cwd is/isn't a registered
+    //! workspace" register the test's *actual* `current_dir()` (or a sibling
+    //! of it) in a scratch `LOOM_WORKSPACES_PATH` registry instead.
+    use super::resolve_tokens_pool_dir_for_cli;
+    use loom_daemon::tokens_pool::paths::{
+        per_repo_tokens_dir, shared_tokens_dir, SHARED_TOKENS_DIR_ENV,
+    };
+    use loom_daemon::workspace_registry::{
+        normalize_path, Workspace, WorkspaceRegistry, REGISTRY_PATH_ENV,
+    };
+    use serial_test::serial;
+    use std::fs;
+
+    /// Mirrors how `WorkspaceRegistry::add` actually stores roots — normalized
+    /// / canonicalized — so a raw `tempdir().path()` (which can differ from
+    /// its canonical form, e.g. macOS `/var/folders` -> `/private/var/folders`)
+    /// compares correctly against the canonicalized query path inside
+    /// `resolve_client_workspace_default`.
+    fn write_registry(path: &std::path::Path, roots: &[&std::path::Path]) {
+        let registry = WorkspaceRegistry {
+            version: 1,
+            workspaces: roots
+                .iter()
+                .map(|r| Workspace {
+                    root: normalize_path(r),
+                    priority: 100,
+                    config_overrides: None,
+                })
+                .collect(),
+        };
+        fs::write(path, serde_json::to_string_pretty(&registry).unwrap()).unwrap();
+    }
+
+    /// Explicit (non-`"."`) `--workspace` never consults the registry, even
+    /// when one is present and would otherwise redirect to shared.
+    #[test]
+    #[serial]
+    fn explicit_workspace_bypasses_registry_anchoring() {
+        let registry_dir = tempfile::tempdir().unwrap();
+        let unrelated = tempfile::tempdir().unwrap();
+        write_registry(&registry_dir.path().join("workspaces.json"), &[unrelated.path()]);
+        std::env::set_var(REGISTRY_PATH_ENV, registry_dir.path().join("workspaces.json"));
+        std::env::set_var(SHARED_TOKENS_DIR_ENV, "");
+
+        let explicit = tempfile::tempdir().unwrap();
+        let (dir, anchored) =
+            resolve_tokens_pool_dir_for_cli(explicit.path().to_str().unwrap()).unwrap();
+        assert_eq!(dir, per_repo_tokens_dir(explicit.path()));
+        assert!(!anchored, "an explicit --workspace must never anchor to shared");
+
+        std::env::remove_var(REGISTRY_PATH_ENV);
+        std::env::remove_var(SHARED_TOKENS_DIR_ENV);
+    }
+
+    /// An empty registry (no `loom-daemon workspace add` ever run) preserves
+    /// today's byte-for-byte per-repo/shared behavior for the default `"."`
+    /// case too — never anchors to shared.
+    #[test]
+    #[serial]
+    fn empty_registry_default_workspace_is_unaffected() {
+        let registry_dir = tempfile::tempdir().unwrap();
+        // A registry file that parses to an empty registry.
+        write_registry(&registry_dir.path().join("workspaces.json"), &[]);
+        std::env::set_var(REGISTRY_PATH_ENV, registry_dir.path().join("workspaces.json"));
+
+        let (dir, anchored) = resolve_tokens_pool_dir_for_cli(".").unwrap();
+        let cwd = std::env::current_dir().unwrap();
+        assert_eq!(dir, loom_daemon::tokens_pool::paths::resolve_tokens_dir(&cwd));
+        assert!(!anchored);
+
+        std::env::remove_var(REGISTRY_PATH_ENV);
+    }
+
+    /// A non-empty registry that happens to register the test's own cwd
+    /// resolves against that (registered) root — unchanged per-repo/shared
+    /// precedence, no shared-anchoring.
+    #[test]
+    #[serial]
+    fn non_empty_registry_with_cwd_registered_is_unaffected() {
+        let cwd = std::env::current_dir().unwrap();
+        let registry_dir = tempfile::tempdir().unwrap();
+        write_registry(&registry_dir.path().join("workspaces.json"), &[&cwd]);
+        std::env::set_var(REGISTRY_PATH_ENV, registry_dir.path().join("workspaces.json"));
+
+        let (dir, anchored) = resolve_tokens_pool_dir_for_cli(".").unwrap();
+        assert_eq!(dir, loom_daemon::tokens_pool::paths::resolve_tokens_dir(&cwd));
+        assert!(!anchored);
+
+        std::env::remove_var(REGISTRY_PATH_ENV);
+    }
+
+    /// A non-empty registry that does NOT include the test's cwd anchors the
+    /// default `"."` case straight to the shared pool (the machine-level
+    /// daemon / bare-cwd CLI-invocation case this trip-wire fixes).
+    #[test]
+    #[serial]
+    fn non_empty_registry_with_cwd_unregistered_anchors_to_shared() {
+        let cwd = std::env::current_dir().unwrap();
+        let unrelated = tempfile::tempdir().unwrap();
+        assert_ne!(unrelated.path(), cwd, "sanity: must not coincide with cwd");
+        let registry_dir = tempfile::tempdir().unwrap();
+        write_registry(&registry_dir.path().join("workspaces.json"), &[unrelated.path()]);
+        std::env::set_var(REGISTRY_PATH_ENV, registry_dir.path().join("workspaces.json"));
+        std::env::remove_var(SHARED_TOKENS_DIR_ENV); // default shared dir enabled
+
+        let (dir, anchored) = resolve_tokens_pool_dir_for_cli(".").unwrap();
+        assert_eq!(dir, shared_tokens_dir().unwrap());
+        assert!(anchored);
+
+        std::env::remove_var(REGISTRY_PATH_ENV);
+    }
+
+    /// The `LOOM_SHARED_TOKENS_DIR=""` opt-out disables shared-anchoring too,
+    /// not just the original per-repo/shared fallback — falls back to the
+    /// per-repo(cwd) path and reports `anchored = false`.
+    #[test]
+    #[serial]
+    fn shared_pool_disabled_falls_back_to_per_repo_cwd() {
+        let cwd = std::env::current_dir().unwrap();
+        let unrelated = tempfile::tempdir().unwrap();
+        let registry_dir = tempfile::tempdir().unwrap();
+        write_registry(&registry_dir.path().join("workspaces.json"), &[unrelated.path()]);
+        std::env::set_var(REGISTRY_PATH_ENV, registry_dir.path().join("workspaces.json"));
+        std::env::set_var(SHARED_TOKENS_DIR_ENV, "");
+
+        let (dir, anchored) = resolve_tokens_pool_dir_for_cli(".").unwrap();
+        assert_eq!(dir, loom_daemon::tokens_pool::paths::resolve_tokens_dir(&cwd));
+        assert!(!anchored);
+
+        std::env::remove_var(REGISTRY_PATH_ENV);
+        std::env::remove_var(SHARED_TOKENS_DIR_ENV);
     }
 }
 
@@ -5131,8 +5316,14 @@ fn handle_tokens_command(action: TokensAction) -> Result<()> {
                 self, CheckOptions, CurlTransport, DEFAULT_PROBE_MODEL, DEFAULT_PROBE_PROMPT,
             };
 
-            let ws = resolve_tokens_workspace(&workspace)?;
-            let tokens_dir = loom_daemon::tokens_pool::paths::resolve_tokens_dir(&ws);
+            let (tokens_dir, anchored_to_shared) = resolve_tokens_pool_dir_for_cli(&workspace)?;
+            if anchored_to_shared {
+                eprintln!(
+                    "note: --workspace defaulted to a directory that is not a registered Loom \
+                     workspace; anchoring to the shared machine-level pool at {} (issue #4292)",
+                    tokens_dir.display()
+                );
+            }
 
             let source_flag = match source {
                 Some(raw) => match check::Source::parse(&raw) {

--- a/loom-daemon/src/tokens.rs
+++ b/loom-daemon/src/tokens.rs
@@ -99,6 +99,18 @@ pub fn token_pool_size(workspace_root: &Path) -> usize {
     token_pool_size_resolved(workspace_root, shared_tokens_dir().as_deref())
 }
 
+/// Count the `*.token` files in an **already-resolved** pool directory (issue
+/// #4292). Unlike [`token_pool_size`], this performs no per-repo/shared
+/// resolution of its own — callers that have already anchored a directory via
+/// [`crate::tokens_pool::paths::resolve_tokens_dir_anchored`] (registry-aware,
+/// so a non-workspace `workspace_root` like a bare daemon's `$HOME` cwd
+/// correctly lands on the shared pool instead of a coincidentally-identical
+/// but empty per-repo(`$HOME`) path) pass the result straight through here.
+#[must_use]
+pub fn token_pool_size_at_dir(tokens_dir: &Path) -> usize {
+    count_token_files(tokens_dir)
+}
+
 /// Env-free core of [`token_pool_size`]: count the per-repo pool, falling back
 /// to an explicit `shared` pool directory when the per-repo pool is
 /// absent/empty. Split out so it is deterministically testable without touching
@@ -158,6 +170,21 @@ mod tests {
             ],
         );
         assert_eq!(token_pool_size_resolved(tmp.path(), None), 3);
+    }
+
+    #[test]
+    fn test_token_pool_size_at_dir_counts_directly_no_further_resolution() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Note: files placed directly in `tmp`, not under `.loom/tokens/` — the
+        // caller is expected to have already resolved the pool dir (#4292).
+        write_flat_pool(tmp.path(), &["a.token", "b.token", "index.json"]);
+        assert_eq!(token_pool_size_at_dir(tmp.path()), 2);
+    }
+
+    #[test]
+    fn test_token_pool_size_at_dir_missing_dir_is_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(token_pool_size_at_dir(&tmp.path().join("does-not-exist")), 0);
     }
 
     #[test]

--- a/loom-daemon/src/tokens_pool/paths.rs
+++ b/loom-daemon/src/tokens_pool/paths.rs
@@ -95,6 +95,56 @@ pub fn resolve_tokens_dir(workspace: &Path) -> PathBuf {
     repo_dir
 }
 
+/// Registry-aware variant of [`resolve_tokens_dir`] for a caller whose nominal
+/// workspace root is `candidate` but may not itself be a recognized Loom
+/// workspace (issue #4292, trip-wires 1 & 3).
+///
+/// A machine-level daemon (#3835/#3926) started under systemd with a bare,
+/// unconfigured cwd (e.g. `$HOME`) — or any CLI invocation that lets
+/// `--workspace` default to `.` from such a cwd — resolves `candidate` to a
+/// directory that is not actually a repo checkout. Feeding that straight into
+/// [`resolve_tokens_dir`] is worse than merely "no tokens": because the
+/// **default** shared pool is *also* `~/.loom/tokens` (see
+/// [`shared_tokens_dir`]), `candidate == $HOME` makes the per-repo and shared
+/// probes coincidentally check the *same* empty directory, silently masking
+/// wherever the pool was actually bootstrapped (e.g. a per-repo pool at the
+/// daemon's real, differently-located checkout).
+///
+/// This reuses the exact "is `candidate` a recognized Loom workspace"
+/// question #4299 already answers for CLI `--workspace` defaulting
+/// ([`crate::workspace_registry::resolve_client_workspace_default`]) rather
+/// than a second, parallel detection path:
+///
+/// - **Registry empty** (no `loom-daemon workspace add` ever run — the
+///   pre-#3926 single-workspace deployment style): trust `candidate`
+///   unconditionally, i.e. byte-for-byte [`resolve_tokens_dir`]. A
+///   repo-local install with no machine-level registry is never affected by
+///   this function.
+/// - **`candidate` falls under (or exactly at) a registered workspace root**:
+///   resolve against that root's own [`resolve_tokens_dir`] precedence
+///   (per-repo first, else shared) — unchanged behavior, just anchored at the
+///   more precise registered root rather than a possibly-nested `candidate`.
+/// - **`candidate` matches no registered root**: `candidate` is not a real
+///   Loom workspace at all (the machine-level-daemon-at-`$HOME` case this
+///   function exists to fix) — skip the per-repo probe entirely and resolve
+///   straight to [`shared_tokens_dir`]. Falls back to
+///   `resolve_tokens_dir(candidate)` only when the shared pool is itself
+///   disabled (`LOOM_SHARED_TOKENS_DIR=""`), so that opt-out still disables
+///   every anchoring surface, not just the original per-repo/shared fallback.
+#[must_use]
+pub fn resolve_tokens_dir_anchored(
+    candidate: &Path,
+    registry: &crate::workspace_registry::WorkspaceRegistry,
+) -> PathBuf {
+    if registry.workspaces.is_empty() {
+        return resolve_tokens_dir(candidate);
+    }
+    match crate::workspace_registry::resolve_client_workspace_default(candidate, registry) {
+        Some(root) => resolve_tokens_dir(&root),
+        None => shared_tokens_dir().unwrap_or_else(|| resolve_tokens_dir(candidate)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -183,6 +233,112 @@ mod tests {
     fn shared_dir_honors_explicit_path() {
         std::env::set_var(SHARED_TOKENS_DIR_ENV, "/tmp/loom-shared-xyz");
         assert_eq!(shared_tokens_dir(), Some(PathBuf::from("/tmp/loom-shared-xyz")));
+        std::env::remove_var(SHARED_TOKENS_DIR_ENV);
+    }
+
+    // =====================================================================
+    // resolve_tokens_dir_anchored (issue #4292, trip-wires 1 & 3)
+    // =====================================================================
+
+    use crate::workspace_registry::{normalize_path, Workspace, WorkspaceRegistry};
+
+    /// Build a test registry the same way `WorkspaceRegistry::add` would:
+    /// entries store the **normalized/canonicalized** root
+    /// ([`normalize_path`]), which is what `resolve_client_workspace_default`
+    /// assumes when comparing against an already-normalized query path (a
+    /// raw, un-canonicalized `tempdir().path()` can otherwise mismatch a
+    /// symlink-resolved query, e.g. macOS `/var/folders` -> `/private/var/folders`).
+    fn registry_with(roots: &[&Path]) -> WorkspaceRegistry {
+        WorkspaceRegistry {
+            version: 1,
+            workspaces: roots
+                .iter()
+                .map(|r| Workspace {
+                    root: normalize_path(r),
+                    priority: 100,
+                    config_overrides: None,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn anchored_empty_registry_trusts_candidate_unchanged() {
+        std::env::set_var(SHARED_TOKENS_DIR_ENV, "");
+        let repo = tempfile::tempdir().unwrap();
+        write_pool(&per_repo_tokens_dir(repo.path()), &["a.token"]);
+        let registry = WorkspaceRegistry::default();
+        assert_eq!(
+            resolve_tokens_dir_anchored(repo.path(), &registry),
+            per_repo_tokens_dir(repo.path())
+        );
+        std::env::remove_var(SHARED_TOKENS_DIR_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn anchored_registered_candidate_uses_its_own_per_repo_shared_precedence() {
+        std::env::set_var(SHARED_TOKENS_DIR_ENV, "");
+        let repo = tempfile::tempdir().unwrap();
+        write_pool(&per_repo_tokens_dir(repo.path()), &["a.token"]);
+        let registry = registry_with(&[repo.path()]);
+        // The resolved root is the registry's *normalized* copy of `repo.path()`
+        // (e.g. macOS `/var/folders` -> `/private/var/folders`) — same
+        // underlying directory, different string form.
+        let canonical_repo = crate::workspace_registry::normalize_path(repo.path());
+        assert_eq!(
+            resolve_tokens_dir_anchored(repo.path(), &registry),
+            per_repo_tokens_dir(&canonical_repo)
+        );
+        std::env::remove_var(SHARED_TOKENS_DIR_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn anchored_unregistered_candidate_skips_straight_to_shared() {
+        let repo = tempfile::tempdir().unwrap(); // registered, unrelated
+        let candidate = tempfile::tempdir().unwrap(); // NOT registered (e.g. $HOME)
+        let shared = tempfile::tempdir().unwrap();
+        write_pool(shared.path(), &["s.token"]);
+        // Even if `candidate` coincidentally has its own (empty) `.loom/tokens`
+        // dir, it must never be probed once it's known not to be a workspace.
+        std::env::set_var(SHARED_TOKENS_DIR_ENV, shared.path().to_str().unwrap());
+        let registry = registry_with(&[repo.path()]);
+        assert_eq!(resolve_tokens_dir_anchored(candidate.path(), &registry), shared.path());
+        std::env::remove_var(SHARED_TOKENS_DIR_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn anchored_unregistered_candidate_falls_back_to_candidate_when_shared_disabled() {
+        let repo = tempfile::tempdir().unwrap();
+        let candidate = tempfile::tempdir().unwrap();
+        std::env::set_var(SHARED_TOKENS_DIR_ENV, ""); // opt-out
+        let registry = registry_with(&[repo.path()]);
+        assert_eq!(
+            resolve_tokens_dir_anchored(candidate.path(), &registry),
+            per_repo_tokens_dir(candidate.path())
+        );
+        std::env::remove_var(SHARED_TOKENS_DIR_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn anchored_candidate_under_registered_root_resolves_at_the_root() {
+        std::env::set_var(SHARED_TOKENS_DIR_ENV, "");
+        let repo = tempfile::tempdir().unwrap();
+        write_pool(&per_repo_tokens_dir(repo.path()), &["a.token"]);
+        let nested = repo.path().join("subdir");
+        std::fs::create_dir_all(&nested).unwrap();
+        let registry = registry_with(&[repo.path()]);
+        let canonical_repo = crate::workspace_registry::normalize_path(repo.path());
+        // `candidate` is a subdirectory of the registered root, not the root
+        // itself — resolution should still land on the registered root's pool.
+        assert_eq!(
+            resolve_tokens_dir_anchored(&nested, &registry),
+            per_repo_tokens_dir(&canonical_repo)
+        );
         std::env::remove_var(SHARED_TOKENS_DIR_ENV);
     }
 }

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -92,7 +92,7 @@ use crate::disk_headroom::disk_headroom_limit;
 use crate::event_bus::EventBus;
 use crate::main_health_gate::{MainHealthState, WorkspaceHealthStates};
 use crate::sweep_registry::OpenPrDispatchError;
-use crate::tokens::token_pool_size;
+use crate::tokens::{token_pool_size, token_pool_size_at_dir};
 use crate::types::Event;
 use crate::workspace_pool::WorkspacePool;
 use crate::workspace_registry::{filter_missing_roots, WorkspaceRegistry};
@@ -1529,7 +1529,16 @@ where
 /// The dynamic cap inputs (token pool, disk headroom) are **machine-level**
 /// resources, so they are probed once per tick from `fallback_root` (the
 /// daemon's primary workspace) and the resulting cap is a single global budget
-/// shared across every workspace — never replicated per repo.
+/// shared across every workspace — never replicated per repo. The token pool
+/// specifically is resolved via
+/// [`resolve_tokens_dir_anchored`](crate::tokens_pool::paths::resolve_tokens_dir_anchored)
+/// against the freshly-reloaded registry (issue #4292, trip-wire 1): when
+/// `fallback_root` is not itself a recognized Loom workspace (e.g. a
+/// machine-level daemon started under systemd with a bare `$HOME` cwd and no
+/// `WorkingDirectory=` override), this anchors straight to the shared
+/// machine-level pool rather than probing a per-repo(`fallback_root`) path
+/// that can coincidentally collide with the shared default and mask a real,
+/// differently-located bootstrap.
 ///
 /// # Known limitation (documented tradeoff, deferred to phase c #3929)
 ///
@@ -1589,10 +1598,27 @@ pub fn spawn_multi_work_finder_task(
         loop {
             ticker.tick().await;
 
+            // Resolve the current set of workspaces fresh each tick so registry
+            // edits (add / remove / set-priority) are hot-applied. Loaded before
+            // the token-pool probe below so both can share the same read
+            // (issue #4292, trip-wire 1: registry-aware anchoring needs it too).
+            let registry = WorkspaceRegistry::load_default().unwrap_or_else(|e| {
+                log::warn!("work_finder: could not load workspace registry ({e}); using cwd");
+                WorkspaceRegistry::default()
+            });
+
             // Dynamic cap from live *machine-level* inputs (one token pool, one
             // scratch volume) probed from the daemon's primary workspace.
-            let pool_size = token_pool_size(&fallback_root);
-            let ranking = capacity::read_ranking(&fallback_root);
+            // `fallback_root` (the daemon's own seeded default) may not itself
+            // be a recognized Loom workspace — e.g. a machine-level daemon
+            // started under systemd with a bare `$HOME` cwd — in which case
+            // `resolve_tokens_dir_anchored` (#4292) resolves straight to the
+            // shared machine-level pool instead of a coincidentally-identical,
+            // but empty, per-repo(`$HOME`) path.
+            let tokens_dir =
+                crate::tokens_pool::paths::resolve_tokens_dir_anchored(&fallback_root, &registry);
+            let pool_size = token_pool_size_at_dir(&tokens_dir);
+            let ranking = capacity::read_ranking_at(&tokens_dir);
             let token_limit = ranking.as_ref().map_or(pool_size, |r| r.available);
             log_healthy_token_transition(&mut was_healthy_tokens, token_limit, ranking.as_ref());
             let disk = disk_headroom_limit(&fallback_root);
@@ -1617,12 +1643,6 @@ pub fn spawn_multi_work_finder_task(
                 configured_max,
             );
 
-            // Resolve the current set of workspaces fresh each tick so registry
-            // edits (add / remove / set-priority) are hot-applied.
-            let registry = WorkspaceRegistry::load_default().unwrap_or_else(|e| {
-                log::warn!("work_finder: could not load workspace registry ({e}); using cwd");
-                WorkspaceRegistry::default()
-            });
             let roots = registry.effective_roots(&fallback_root);
             // Skip registered roots whose directory no longer exists on disk
             // (#4326 — e.g. a leaked/stale registry entry) so a dangling entry


### PR DESCRIPTION
## Summary

Completes the remaining scope of #4292 (trip-wires 1 and 3). Trip-wire 2
(`loom-daemon status` client-cwd mismatch) already landed as #4318 and is
untouched here.

**Root cause (shared by both trip-wires)**: a machine-level daemon's own
seeded workspace (its cwd at startup, or `LOOM_WORKSPACE`) can be a
non-workspace directory — e.g. `$HOME` under systemd with no
`WorkingDirectory=` override. Feeding that straight into the existing
per-repo/shared precedence (#3938) is *worse* than "no tokens": the shared
pool's own **default** is also `~/.loom/tokens`, so `workspace_root == $HOME`
makes the per-repo and shared probes coincidentally check the exact same
(usually empty) directory — masking wherever the pool was actually
bootstrapped (e.g. a per-repo pool at the daemon's real, differently-located
checkout) behind a plausible-looking "no tokens found" warning.

**Fix — `resolve_tokens_dir_anchored()`** (`loom-daemon/src/tokens_pool/paths.rs`):
asks whether the candidate root is a *recognized Loom workspace*, reusing the
exact registry-membership check #4299 already established for CLI
`--workspace` defaulting (`workspace_registry::resolve_client_workspace_default`)
rather than a second, parallel detection path. When it isn't, resolution
skips the per-repo probe entirely and anchors straight to the shared
machine-level pool. An **empty** registry (no `loom-daemon workspace add`
ever run — the common repo-local single-workspace install) trusts the
candidate unconditionally, so every existing repo-local install is
byte-for-byte unaffected. `LOOM_SHARED_TOKENS_DIR=""` still disables the
shared-pool fallback on every surface, including this new anchoring.

### Trip-wire 1 — daemon startup / dispatch capacity

- `work_finder::spawn_multi_work_finder_task` (the production multi-workspace
  loop wired into `main.rs`) and `ipc::build_daemon_status`'s dynamic-cap
  accounting now resolve the daemon's own token pool through the anchored
  path instead of the raw seeded `workspace_root`/`fallback_root`.
- New `token_pool_size_at_dir()` (`tokens.rs`) and `read_ranking_at_dir()`
  (`capacity.rs`, `read_ranking()` now delegates to it) let these call sites
  consume an already-anchored directory directly instead of re-deriving
  `{workspace_root}/.loom/tokens/…` from a possibly-wrong root.
- **Operational contract** (documented in `.loom/docs/token-pool.md` and
  `defaults/docs/daemon-reference.md`): a machine-level daemon's pool must be
  bootstrapped at the shared location (`loom-tokens bootstrap --shared`) —
  or the daemon's own checkout registered via `loom-daemon workspace add` —
  for step 3 of the precedence to actually find tokens.

### Trip-wire 3 — `tokens check --ranking` write location

- New `resolve_tokens_pool_dir_for_cli()` (`main.rs`) applies the same
  anchoring **only** to the CLI's default (unset/`"."`) `--workspace` case —
  an explicit `--workspace` always resolves via the unchanged per-repo/shared
  precedence, so pointing at a specific (possibly unregistered) repo is never
  silently redirected. Wired into `TokensAction::Check`, with an `eprintln!`
  note when the shared-anchoring branch actually fires, naming the resolved
  directory.

## Not in scope

- `#4344` (daemon in-memory healthy-count wedging at 0 after restart) — a
  separate, unrelated live incident, explicitly excluded per the dispatch.
- Trip-wire 2 (already done in #4318) — `collect_token_usage()` / the status
  usage-table anchoring is untouched.
- `select`/`pin`/`unpin`/`unblock`/`mark-bad`/`bootstrap`/`import-from-monitor`
  CLI subcommands — these are typically invoked with an explicit
  `--workspace` (e.g. `spawn-claude.sh`'s worktree-resolved root) and were
  left alone to keep this PR's blast radius to the two named trip-wires; they
  can adopt `resolve_tokens_pool_dir_for_cli` in a follow-up if the same gap
  is observed there.

## Python lockstep

`loom-tools/src/loom_tools/tokens/paths.py` is **unchanged**. Its
`resolve_tokens_dir` / `shared_tokens_dir` precedence semantics are untouched
by this PR — I only added a *pre-filter* ("is the candidate a recognized Loom
workspace") ahead of that unchanged precedence, and it has no Python
analogue to keep in lockstep: `loom-tokens`' CLI already fails closed via
`find_repo_root()` (requires an actual git repo ancestor) rather than
silently resolving an unrelated cwd like `$HOME`, so it never hits the
ambiguity this PR resolves for the Rust daemon/CLI surfaces. Verified via
`PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/ -k token`
(386 passed, 8 skipped, no change).

## Test plan

- [x] `cargo build --lib --bin loom-daemon`
- [x] `cargo clippy --lib --bin loom-daemon --tests -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --lib` (1562 passed)
- [x] `cargo test --bin loom-daemon` (35 passed, including 5 new
      `resolve_tokens_pool_dir_for_cli_tests` covering explicit-workspace
      bypass, empty-registry pass-through, registered-cwd pass-through,
      unregistered-cwd shared-anchoring, and the `LOOM_SHARED_TOKENS_DIR=""`
      opt-out)
- [x] New unit tests in `tokens_pool/paths.rs` for
      `resolve_tokens_dir_anchored` (empty registry / registered candidate /
      nested-under-registered-root / unregistered-candidate-anchors-to-shared
      / shared-disabled-falls-back)
- [x] `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/ -k token`
      (386 passed, confirming no drift)

Closes #4292

🤖 Generated with [Claude Code](https://claude.com/claude-code)