### PR TITLE
fix(daemon): MCP preflight candidate fallback + role-runner missing-root hygiene

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -348,53 +348,77 @@ check_stop_signal() {
     return 1
 }
 
-# Resolve workspace root for MCP config lookup.
-# In worktrees, WORKSPACE may point to the worktree itself; the MCP config
-# (.mcp.json) lives in the git common directory (the main checkout).
-resolve_mcp_workspace() {
-    # If .mcp.json exists in WORKSPACE, use it directly
+# Resolve the ordered list of MCP config candidate directories for
+# pre-flight (#4349). In worktrees, WORKSPACE may point to the worktree
+# itself, whose own .mcp.json (if any) can dangle after that worktree's
+# mcp-loom build is deleted (e.g. a stale/half-removed worktree left
+# registered — the #4349 incident); the git common directory (the primary
+# checkout, where mcp-loom always actually lives, per scripts/setup-mcp.sh)
+# is the durable fallback candidate. Emits one directory per line, in
+# priority order: WORKSPACE first (if it carries its own .mcp.json), then
+# the git common directory's repo root (if distinct and it also carries a
+# .mcp.json). Emits nothing when neither candidate has a .mcp.json — that is
+# the #4230 non-fatal "no MCP configured" case, handled by the caller.
+mcp_candidate_workspaces() {
+    local -a candidates=()
+
     if [[ -f "${WORKSPACE}/.mcp.json" ]]; then
-        echo "${WORKSPACE}"
-        return
+        candidates+=("${WORKSPACE}")
     fi
 
-    # In a worktree, try the git common directory (main checkout)
-    local common_dir
+    local common_dir repo_root
     if common_dir=$(git -C "${WORKSPACE}" rev-parse --git-common-dir 2>/dev/null); then
         # common_dir is the .git dir; parent is the repo root
-        local repo_root
         repo_root=$(cd "${common_dir}/.." 2>/dev/null && pwd)
-        if [[ -f "${repo_root}/.mcp.json" ]]; then
-            echo "${repo_root}"
-            return
+        if [[ -n "${repo_root}" ]] && [[ -f "${repo_root}/.mcp.json" ]]; then
+            local already_listed="" c
+            for c in ${candidates[@]+"${candidates[@]}"}; do
+                [[ "${c}" == "${repo_root}" ]] && already_listed=1
+            done
+            [[ -z "${already_listed}" ]] && candidates+=("${repo_root}")
         fi
     fi
 
-    # Fallback to WORKSPACE
-    echo "${WORKSPACE}"
+    if [[ ${#candidates[@]} -gt 0 ]]; then
+        printf '%s\n' "${candidates[@]}"
+    fi
+    # Always return success — an empty candidate list is a valid, expected
+    # outcome (#4230), not an error. A bare `false`-valued last test above
+    # would otherwise propagate as this function's exit status and trip
+    # `set -e` at any future direct (non-pipeline) call site.
+    return 0
 }
 
-# Pre-flight check: verify MCP server can start
-# Attempts to launch the mcp-loom Node.js server and checks for the startup
-# message on stderr. If the built bundle is missing, or is stale (older than
-# any file under the sibling src/ tree), it rebuilds before the smoke test; a
-# smoke-test failure also triggers a rebuild-and-retry.
-check_mcp_server() {
-    local mcp_workspace
-    mcp_workspace=$(resolve_mcp_workspace)
-
-    local mcp_config="${mcp_workspace}/.mcp.json"
-    if [[ ! -f "${mcp_config}" ]]; then
-        # Non-fatal skip. Absent .mcp.json is now the NORMAL, healthy state under
-        # user-scope `loom` registration (#4230, epic #3835 Phase 3c): the loom
-        # server is machine-level, not project-scoped, so there is no per-repo
-        # config to smoke-test here. The per-session bundle-staleness gate this
-        # skip removes moves to `loom update` (which rebuilds the served
-        # mcp-loom bundle for every repo at once). This skip must NOT be promoted
-        # to a failure — doing so would spuriously fail every migrated repo.
-        log_warn "MCP config not found at ${mcp_config} - skipping MCP pre-flight (expected under user-scope loom, #4230)"
-        return 0  # Non-fatal: MCP may not be configured (or is user-scoped)
+# Resolve workspace root for MCP config lookup (back-compat single-candidate
+# form — the highest-priority candidate from mcp_candidate_workspaces, or
+# WORKSPACE itself when no candidate has a .mcp.json).
+resolve_mcp_workspace() {
+    local first
+    first=$(mcp_candidate_workspaces | head -n1)
+    if [[ -n "${first}" ]]; then
+        echo "${first}"
+    else
+        echo "${WORKSPACE}"
     fi
+}
+
+# Attempt MCP pre-flight for ONE candidate workspace directory: extract the
+# entry point from ${1}/.mcp.json, ensure it exists (rebuilding if
+# missing/stale), and smoke-test it. Split out of check_mcp_server so the
+# latter can iterate an ordered candidate list and fall back to the next
+# candidate on a real failure (#4349), rather than hard-failing on the
+# first candidate's broken bundle.
+#
+# Return codes distinguish "not a real candidate" from "a real, configured
+# candidate that is unhealthy" — only the latter should make an
+# all-candidates-failed case a hard failure rather than a #4230-style skip:
+#   0 = healthy candidate (pre-flight for this candidate passes)
+#   1 = real but unhealthy candidate (entry missing & unrebuildable, or the
+#       smoke test still fails after a rebuild attempt)
+#   2 = not a real candidate (mcp.json present but no parseable entry point)
+_check_mcp_candidate() {
+    local mcp_workspace="$1"
+    local mcp_config="${mcp_workspace}/.mcp.json"
 
     # Extract the MCP server entry point from .mcp.json
     # Use timeout to prevent hanging on resource-contended systems (see issue #2472).
@@ -412,15 +436,17 @@ for name, srv in servers.items():
 " 2>/dev/null || echo "")
 
     if [[ -z "${mcp_entry}" ]]; then
-        log_warn "Could not extract MCP entry point from ${mcp_config} - skipping MCP pre-flight"
-        return 0
+        log_warn "Could not extract MCP entry point from ${mcp_config} - not a usable pre-flight candidate"
+        return 2
     fi
 
     # Check if the entry point file exists
     if [[ ! -f "${mcp_entry}" ]]; then
         log_warn "MCP entry point missing: ${mcp_entry}"
-        _try_mcp_rebuild "${mcp_entry}"
-        return $?
+        if _try_mcp_rebuild "${mcp_entry}"; then
+            return 0
+        fi
+        return 1
     fi
 
     # Staleness check: a bundle older than any file under the sibling src/ tree
@@ -434,12 +460,11 @@ for name, srv in servers.items():
     if [[ -d "${mcp_src}" ]] && \
        [[ -n "$(find "${mcp_src}" -type f -newer "${mcp_entry}" -print -quit 2>/dev/null)" ]]; then
         log_warn "MCP bundle is stale (src newer than dist) - rebuilding: ${mcp_entry}"
-        if ! _try_mcp_rebuild "${mcp_entry}"; then
-            log_warn "MCP rebuild for stale bundle failed - continuing with existing bundle"
-        else
+        if _try_mcp_rebuild "${mcp_entry}"; then
             # Rebuild succeeded and already re-verified the smoke test.
             return 0
         fi
+        log_warn "MCP rebuild for stale bundle failed - continuing with existing bundle"
     fi
 
     # Smoke test: start MCP server and verify it emits the startup message
@@ -449,19 +474,77 @@ for name, srv in servers.items():
     mcp_stderr=$(timeout 5 node "${mcp_entry}" </dev/null 2>&1 || true)
 
     if echo "${mcp_stderr}" | grep -qi "running on stdio"; then
-        log_info "MCP server health check passed"
+        log_info "MCP server health check passed (${mcp_config})"
         return 0
     fi
 
     # MCP server failed to start - log the error
-    log_warn "MCP server health check failed"
+    log_warn "MCP server health check failed (${mcp_config})"
     if [[ -n "${mcp_stderr}" ]]; then
         log_warn "MCP stderr: ${mcp_stderr}"
     fi
 
     # Attempt rebuild and retry
-    _try_mcp_rebuild "${mcp_entry}"
-    return $?
+    if _try_mcp_rebuild "${mcp_entry}"; then
+        return 0
+    fi
+    return 1
+}
+
+# Pre-flight check: verify an MCP server can start.
+# Iterates the ordered candidate list from mcp_candidate_workspaces (#4349):
+# WORKSPACE's own .mcp.json first, falling back to the git common
+# directory's .mcp.json when the first candidate's bundle is missing and
+# unrebuildable (e.g. a broken/half-deleted worktree). The session only
+# hard-fails when NO candidate config is healthy AND at least one candidate
+# was a real, parseable config (preserving the #4230 skip when every
+# candidate is unparseable or absent).
+check_mcp_server() {
+    local -a candidates=()
+    local line
+    while IFS= read -r line; do
+        [[ -n "${line}" ]] && candidates+=("${line}")
+    done < <(mcp_candidate_workspaces)
+
+    if [[ ${#candidates[@]} -eq 0 ]]; then
+        # Non-fatal skip. Absent .mcp.json (in WORKSPACE and, for a worktree,
+        # the git common dir) is now the NORMAL, healthy state under
+        # user-scope `loom` registration (#4230, epic #3835 Phase 3c): the
+        # loom server is machine-level, not project-scoped, so there is no
+        # per-repo config to smoke-test here. This skip must NOT be promoted
+        # to a failure — doing so would spuriously fail every migrated repo.
+        log_warn "MCP config not found at ${WORKSPACE}/.mcp.json (or the git common dir) - skipping MCP pre-flight (expected under user-scope loom, #4230)"
+        return 0
+    fi
+
+    local saw_real_candidate=0
+    local idx=0
+    local candidate rc
+    for candidate in "${candidates[@]}"; do
+        idx=$((idx + 1))
+        # Capture the return code without letting a non-zero result trip
+        # `set -e` (a bare failing statement would abort the whole script
+        # instead of falling through to the next candidate).
+        rc=0
+        _check_mcp_candidate "${candidate}" || rc=$?
+        if [[ ${rc} -eq 0 ]]; then
+            if [[ ${idx} -gt 1 ]]; then
+                log_warn "MCP pre-flight: falling back to ${candidate}/.mcp.json (candidate #1 was unusable)"
+            fi
+            return 0
+        elif [[ ${rc} -eq 1 ]]; then
+            saw_real_candidate=1
+        fi
+        # rc == 2 (unparseable): not a real candidate, keep trying the rest.
+    done
+
+    if [[ ${saw_real_candidate} -eq 0 ]]; then
+        log_warn "No candidate MCP config had a parseable entry point - skipping MCP pre-flight (expected under user-scope loom, #4230)"
+        return 0
+    fi
+
+    log_error "MCP pre-flight failed for all ${#candidates[@]} candidate config(s): ${candidates[*]}"
+    return 1
 }
 
 # Check global MCP configurations from ~/.claude.json for missing binaries.

--- a/defaults/scripts/tests/test-mcp-config.sh
+++ b/defaults/scripts/tests/test-mcp-config.sh
@@ -377,6 +377,102 @@ fi
 rm -rf "$_empty_repo"
 
 # ============================================================
+# Section 7: claude-wrapper.sh MCP pre-flight candidate-list fallback (#4349)
+#
+# A broken worktree's dangling .mcp.json must not hard-fail the pre-flight
+# when the git common dir (primary checkout) carries a healthy config —
+# check_mcp_server() now tries an ORDERED candidate list (WORKSPACE first,
+# then the git common dir) instead of pinning to whichever resolves first.
+# ============================================================
+echo ""
+echo "Testing claude-wrapper.sh MCP pre-flight candidate-list fallback (#4349)..."
+
+WRAPPER="$SCRIPTS_DIR/claude-wrapper.sh"
+HAVE_NODE=false
+command -v node >/dev/null 2>&1 && HAVE_NODE=true
+HAVE_GIT=false
+command -v git >/dev/null 2>&1 && HAVE_GIT=true
+
+# Healthy mcp-loom stub: writes the exact startup line check_mcp_server greps for.
+_write_healthy_mcp_stub() {
+    local dir="$1" # e.g. .../mcp-loom
+    mkdir -p "$dir/dist"
+    cat >"$dir/dist/index.js" <<'JS'
+process.stderr.write("Loom MCP server running on stdio\n");
+JS
+}
+
+if $HAVE_NODE && $HAVE_GIT; then
+    _fx="$(mktemp -d)"
+    git init -q "$_fx/main"
+    git -C "$_fx/main" config user.email t@t.com
+    git -C "$_fx/main" config user.name t
+    echo x >"$_fx/main/README.md"
+    git -C "$_fx/main" add -A
+    git -C "$_fx/main" commit -qm init
+    _main_root="$(cd "$_fx/main" && pwd)" # resolve any /private symlink up front
+
+    _write_healthy_mcp_stub "$_main_root/mcp-loom"
+    cat >"$_main_root/.mcp.json" <<JSON
+{ "mcpServers": { "loom": { "command": "node", "args": ["$_main_root/mcp-loom/dist/index.js"] } } }
+JSON
+    git -C "$_main_root" add -A
+    git -C "$_main_root" commit -qm "add mcp"
+    git -C "$_main_root" worktree add -q -b feature/pf-test "$_fx/wt"
+    _wt_root="$(cd "$_fx/wt" && pwd)"
+
+    # 7a. Broken worktree candidate (no rebuildable package) + healthy common-dir
+    #     candidate -> pre-flight PASSES via fallback, with one WARN naming it.
+    _write_healthy_mcp_stub "$_wt_root/mcp-loom"
+    cat >"$_wt_root/.mcp.json" <<JSON
+{ "mcpServers": { "loom": { "command": "node", "args": ["$_wt_root/mcp-loom/dist/index.js"] } } }
+JSON
+    rm -rf "$_wt_root/mcp-loom" # dangling entry point, no package.json to rebuild
+
+    _fallback_out="$(LOOM_WORKSPACE="$_wt_root" CLAUDE_WRAPPER_SOURCE_ONLY=1 bash -c '
+        source "$1"
+        check_mcp_server
+        echo "RC=$?"
+    ' _ "$WRAPPER" 2>&1)"
+    assert_contains "RC=0" "$_fallback_out" \
+        "broken worktree + healthy common-dir config: pre-flight passes via fallback (#4349)"
+    assert_contains "falling back to" "$_fallback_out" \
+        "fallback path logs one WARN naming the fallback candidate (#4349)"
+    assert_not_contains "MCP_PREFLIGHT_FAILED" "$_fallback_out" \
+        "fallback path never emits the MCP_PREFLIGHT_FAILED sentinel"
+
+    # 7b. Both candidates broken (no rebuildable package anywhere) -> hard FAIL.
+    rm -rf "$_main_root/mcp-loom"
+    _both_broken_out="$(LOOM_WORKSPACE="$_wt_root" CLAUDE_WRAPPER_SOURCE_ONLY=1 bash -c '
+        source "$1"
+        check_mcp_server
+        echo "RC=$?"
+    ' _ "$WRAPPER" 2>&1 || true)"
+    assert_not_contains "RC=0" "$_both_broken_out" \
+        "both candidates broken: pre-flight does NOT report success"
+    assert_contains "MCP pre-flight failed for all" "$_both_broken_out" \
+        "both candidates broken: hard failure names all failed candidates (#4349)"
+
+    # 7c. Neither candidate has a .mcp.json at all -> #4230 non-fatal skip preserved.
+    _no_cfg_ws="$(mktemp -d)"
+    _no_cfg_out="$(LOOM_WORKSPACE="$_no_cfg_ws" CLAUDE_WRAPPER_SOURCE_ONLY=1 bash -c '
+        source "$1"
+        check_mcp_server
+        echo "RC=$?"
+    ' _ "$WRAPPER" 2>&1)"
+    assert_contains "RC=0" "$_no_cfg_out" \
+        "no .mcp.json anywhere: pre-flight is a non-fatal skip (#4230 preserved)"
+    assert_contains "#4230" "$_no_cfg_out" \
+        "no .mcp.json anywhere: skip message cites #4230"
+    rm -rf "$_no_cfg_ws"
+
+    git -C "$_main_root" worktree remove --force "$_wt_root" >/dev/null 2>&1 || true
+    rm -rf "$_fx"
+else
+    echo -e "  ${YELLOW}SKIP${NC}: MCP pre-flight fallback tests (node and/or git not installed)"
+fi
+
+# ============================================================
 # Summary
 # ============================================================
 echo ""

--- a/loom-daemon/src/role_runner.rs
+++ b/loom-daemon/src/role_runner.rs
@@ -83,7 +83,7 @@ use std::sync::{Arc, Mutex, PoisonError};
 use std::time::{Duration, Instant};
 
 use crate::sweep_registry::{self, SweepRegistryConfig};
-use crate::workspace_registry::WorkspaceRegistry;
+use crate::workspace_registry::{filter_missing_roots, WorkspaceRegistry};
 
 // ============================================================================
 // Constants
@@ -973,12 +973,20 @@ where
 ///
 /// Every `interval` it re-reads [`WorkspaceRegistry::effective_roots`]
 /// against `fallback_root` (an **empty** registry yields the single
-/// `fallback_root`) and, for each registered root whose own
-/// `.loom/config.json` has this role enabled (`resolve_enabled` AND the role
-/// name present in `resolve_roles` — precedence env > config > default), runs
-/// one invocation. Invocations run **sequentially** per tick (no shared
-/// mutable state to leak across repos, and it avoids bursting concurrent
-/// `claude` sessions across every registered repo at once).
+/// `fallback_root`), drops any root whose directory no longer exists on disk
+/// via the shared [`filter_missing_roots`] hygiene (#4326/#4349 — warn once
+/// per missing period, never auto-remove), and, for each surviving root
+/// whose own `.loom/config.json` has this role enabled (`resolve_enabled`
+/// AND the role name present in `resolve_roles` — precedence env > config >
+/// default), runs one invocation. Invocations run **sequentially** per tick
+/// (no shared mutable state to leak across repos, and it avoids bursting
+/// concurrent `claude` sessions across every registered repo at once).
+///
+/// A repeatedly-failing root (e.g. a broken MCP preflight, #4349) logs once
+/// on the fail edge and once on recovery — not once per tick — via a
+/// per-root failing-state map tracked across ticks (mirrors the
+/// `was_halted`/`was_pressured` state-change-dedup discipline in
+/// [`crate::work_finder`]).
 pub fn spawn_multi_role_task(
     spec: RoleSpec,
     fallback_root: PathBuf,
@@ -995,6 +1003,12 @@ pub fn spawn_multi_role_task(
         let mut ticker = tokio::time::interval(interval);
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         ticker.tick().await; // skip immediate first tick (see module docs)
+                             // Missing-root warn-once-per-period state (#4326), shared discipline
+                             // with `work_finder` via `filter_missing_roots`.
+        let mut missing_roots_warned: HashSet<PathBuf> = HashSet::new();
+        // Per-root failing state (#4349), so a persistently failing tick logs
+        // only on the fail edge and on recovery, not every tick.
+        let mut failing_roots: HashMap<PathBuf, bool> = HashMap::new();
         loop {
             ticker.tick().await;
 
@@ -1018,6 +1032,11 @@ pub fn spawn_multi_role_task(
                     WorkspaceRegistry::default()
                 })
                 .effective_roots(&fallback_root);
+            // Skip registered roots whose directory no longer exists on disk
+            // (#4326) so a dangling entry cannot burn every tick forever —
+            // warn-and-skip, never auto-remove (`loom-daemon status` flags it,
+            // `workspace remove` clears it).
+            let roots = filter_missing_roots(roots, &mut missing_roots_warned);
 
             for root in roots {
                 let config = read_role_runner_config(&root);
@@ -1064,7 +1083,13 @@ pub fn spawn_multi_role_task(
                 .await;
                 let elapsed = tick_start.elapsed();
                 match joined {
-                    Ok(outcome) => log_outcome_for_root(spec.name, &root, &outcome, elapsed),
+                    Ok(outcome) => log_outcome_for_root_deduped(
+                        spec.name,
+                        &root,
+                        &outcome,
+                        elapsed,
+                        &mut failing_roots,
+                    ),
                     Err(e) => log::error!(
                         "role_runner: {} invocation task for {} panicked ({e}); continuing to the \
                          next repo",
@@ -1116,7 +1141,15 @@ fn log_outcome(role: &str, outcome: &RoleTickOutcome, elapsed: Duration) {
     }
 }
 
-/// Root-aware variant of [`log_outcome`] for the multi-workspace loop.
+/// Root-aware variant of [`log_outcome`] for the **fire-and-forget idle path**
+/// ([`observe_and_fire_idle`], #4364). Unlike the repeating multi-workspace
+/// interval loop — which uses [`log_outcome_for_root_deduped`] to suppress a
+/// persistently-failing root's per-tick WARN noise (#4349) — an idle-triggered
+/// run fires exactly once on a busy→idle *edge* and is dispatched as a detached
+/// `tokio::spawn`. There is no repeating tick and no natural place to thread
+/// the per-root `failing` dedup state through the detached task, so a single
+/// plain (un-deduped) log line with root context is the correct, minimal fit
+/// here. See #4376 for the design rationale.
 fn log_outcome_for_root(role: &str, root: &Path, outcome: &RoleTickOutcome, elapsed: Duration) {
     match outcome {
         RoleTickOutcome::Success if tick_is_implausibly_fast(outcome, elapsed) => {
@@ -1140,6 +1173,131 @@ fn log_outcome_for_root(role: &str, root: &Path, outcome: &RoleTickOutcome, elap
             root.display()
         ),
     }
+}
+
+/// The classified log action for one root's tick outcome, given whether that
+/// root was already failing on the *previous* tick. Pulled out of
+/// [`log_outcome_for_root_deduped`] as a pure function so the state-change
+/// dedup logic (#4349) is unit-testable without capturing `log` crate output
+/// — mirrors why [`tick_is_implausibly_fast`] was extracted the same way.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RootTickLogAction {
+    /// Steady-state success: log at `INFO`, same as always.
+    Success,
+    /// Success, but implausibly fast: log at `WARN`, same as always.
+    SuccessImplausiblyFast,
+    /// Success immediately after a failing period: log once at `INFO` with
+    /// an explicit "recovered" message (the edge back to healthy).
+    Recovered,
+    /// Success immediately after a failing period, but implausibly fast:
+    /// log once at `WARN` combining both signals.
+    RecoveredImplausiblyFast,
+    /// First failure (edge into a failing period): log at `WARN`, same as
+    /// always.
+    FailureEdge,
+    /// Repeat failure (already failing on the previous tick): downgrade to
+    /// `DEBUG` — the identical failure no longer re-logs at `WARN` every
+    /// tick forever (the #4349 symptom: a broken worktree's MCP preflight
+    /// failing every 5-minute champion/curator tick with ERROR-level noise).
+    FailureRepeat,
+}
+
+impl RootTickLogAction {
+    /// Whether this action should mark the root as failing for the *next*
+    /// tick's edge/repeat decision.
+    #[must_use]
+    fn is_failing(self) -> bool {
+        matches!(self, Self::FailureEdge | Self::FailureRepeat)
+    }
+}
+
+#[must_use]
+fn classify_root_tick_log(
+    outcome: &RoleTickOutcome,
+    elapsed: Duration,
+    was_failing: bool,
+) -> RootTickLogAction {
+    match outcome {
+        RoleTickOutcome::Failure(_) if was_failing => RootTickLogAction::FailureRepeat,
+        RoleTickOutcome::Failure(_) => RootTickLogAction::FailureEdge,
+        RoleTickOutcome::Success if tick_is_implausibly_fast(outcome, elapsed) && was_failing => {
+            RootTickLogAction::RecoveredImplausiblyFast
+        }
+        RoleTickOutcome::Success if tick_is_implausibly_fast(outcome, elapsed) => {
+            RootTickLogAction::SuccessImplausiblyFast
+        }
+        RoleTickOutcome::Success if was_failing => RootTickLogAction::Recovered,
+        RoleTickOutcome::Success => RootTickLogAction::Success,
+    }
+}
+
+/// Root-aware, **state-change-deduped** variant of [`log_outcome`] for the
+/// multi-workspace loop (#4349). `failing` tracks, per root, whether the
+/// *previous* tick for that root ended in [`RoleTickOutcome::Failure`] — see
+/// [`RootTickLogAction`] for the per-transition logging rules.
+fn log_outcome_for_root_deduped(
+    role: &str,
+    root: &Path,
+    outcome: &RoleTickOutcome,
+    elapsed: Duration,
+    failing: &mut HashMap<PathBuf, bool>,
+) {
+    let was_failing = failing.get(root).copied().unwrap_or(false);
+    let action = classify_root_tick_log(outcome, elapsed, was_failing);
+    let reason = match outcome {
+        RoleTickOutcome::Failure(reason) => reason.as_str(),
+        RoleTickOutcome::Success => "",
+    };
+    match action {
+        RootTickLogAction::Success => {
+            log::info!(
+                "role_runner: {role} tick completed for {} in {elapsed:.1?}",
+                root.display()
+            );
+        }
+        RootTickLogAction::SuccessImplausiblyFast => {
+            log::warn!(
+                "role_runner: {role} tick completed for {} in {elapsed:.1?} — implausibly fast \
+                 for a real session (threshold {IMPLAUSIBLY_FAST_TICK:.0?}); this may be a no-op \
+                 that exited 0 without doing real work (e.g. a slash-command prompt that did not \
+                 resolve)",
+                root.display()
+            );
+        }
+        RootTickLogAction::Recovered => {
+            log::info!(
+                "role_runner: {role} recovered for {} — tick completed in {elapsed:.1?} after a \
+                 prior failing period",
+                root.display()
+            );
+        }
+        RootTickLogAction::RecoveredImplausiblyFast => {
+            log::warn!(
+                "role_runner: {role} tick for {} recovered from a failing period but completed \
+                 in {elapsed:.1?} — implausibly fast for a real session (threshold \
+                 {IMPLAUSIBLY_FAST_TICK:.0?}); this may be a no-op that exited 0 without doing \
+                 real work",
+                root.display()
+            );
+        }
+        RootTickLogAction::FailureEdge => {
+            log::warn!(
+                "role_runner: {role} tick failed for {} after {elapsed:.1?} (logged and \
+                 skipped, never fatal; further identical failures for this root are logged at \
+                 DEBUG until it recovers): {reason}",
+                root.display()
+            );
+        }
+        RootTickLogAction::FailureRepeat => {
+            log::debug!(
+                "role_runner: {role} tick failed for {} again after {elapsed:.1?} (repeat of an \
+                 already-logged failure; not re-warned every tick — see the fail-edge WARN \
+                 above, or the eventual recovery INFO): {reason}",
+                root.display()
+            );
+        }
+    }
+    failing.insert(root.to_path_buf(), action.is_failing());
 }
 
 #[cfg(test)]
@@ -2081,5 +2239,191 @@ mod tests {
         wait_for_calls(&calls, 1, Duration::from_secs(2)).await;
 
         handle.abort();
+    }
+
+    // ===================================================================
+    // classify_root_tick_log / log_outcome_for_root_deduped — #4349 state-
+    // change log dedup: a repeatedly failing root logs once on the fail
+    // edge and once on recovery, not once per tick.
+    // ===================================================================
+
+    const NORMAL_TICK: Duration = Duration::from_secs(90);
+
+    #[test]
+    fn test_classify_first_failure_is_edge() {
+        assert_eq!(
+            classify_root_tick_log(&RoleTickOutcome::Failure("boom".into()), NORMAL_TICK, false),
+            RootTickLogAction::FailureEdge
+        );
+    }
+
+    #[test]
+    fn test_classify_repeat_failure_is_downgraded() {
+        assert_eq!(
+            classify_root_tick_log(&RoleTickOutcome::Failure("boom".into()), NORMAL_TICK, true),
+            RootTickLogAction::FailureRepeat
+        );
+    }
+
+    #[test]
+    fn test_classify_success_after_failure_is_recovery() {
+        assert_eq!(
+            classify_root_tick_log(&RoleTickOutcome::Success, NORMAL_TICK, true),
+            RootTickLogAction::Recovered
+        );
+    }
+
+    #[test]
+    fn test_classify_steady_state_success_is_plain() {
+        assert_eq!(
+            classify_root_tick_log(&RoleTickOutcome::Success, NORMAL_TICK, false),
+            RootTickLogAction::Success
+        );
+    }
+
+    #[test]
+    fn test_classify_implausibly_fast_variants() {
+        assert_eq!(
+            classify_root_tick_log(&RoleTickOutcome::Success, Duration::from_millis(100), false),
+            RootTickLogAction::SuccessImplausiblyFast
+        );
+        assert_eq!(
+            classify_root_tick_log(&RoleTickOutcome::Success, Duration::from_millis(100), true),
+            RootTickLogAction::RecoveredImplausiblyFast
+        );
+    }
+
+    #[test]
+    fn test_log_outcome_for_root_deduped_tracks_failing_state_across_ticks() {
+        let root = PathBuf::from("/tmp/does-not-need-to-exist-for-this-test");
+        let mut failing: HashMap<PathBuf, bool> = HashMap::new();
+
+        // Tick 1: failure -> edge, marks failing.
+        log_outcome_for_root_deduped(
+            "champion",
+            &root,
+            &RoleTickOutcome::Failure("MCP_PREFLIGHT_FAILED".into()),
+            NORMAL_TICK,
+            &mut failing,
+        );
+        assert_eq!(failing.get(&root), Some(&true));
+
+        // Ticks 2-4: identical repeat failures -> still marked failing (the
+        // dedup happens in the log call, not observable here directly, but
+        // the state must remain `true` without ever clearing).
+        for _ in 0..3 {
+            log_outcome_for_root_deduped(
+                "champion",
+                &root,
+                &RoleTickOutcome::Failure("MCP_PREFLIGHT_FAILED".into()),
+                NORMAL_TICK,
+                &mut failing,
+            );
+            assert_eq!(failing.get(&root), Some(&true));
+        }
+
+        // Tick 5: recovers -> state flips back to healthy.
+        log_outcome_for_root_deduped(
+            "champion",
+            &root,
+            &RoleTickOutcome::Success,
+            NORMAL_TICK,
+            &mut failing,
+        );
+        assert_eq!(failing.get(&root), Some(&false));
+
+        // Tick 6: steady-state success keeps it healthy.
+        log_outcome_for_root_deduped(
+            "champion",
+            &root,
+            &RoleTickOutcome::Success,
+            NORMAL_TICK,
+            &mut failing,
+        );
+        assert_eq!(failing.get(&root), Some(&false));
+    }
+
+    #[test]
+    fn test_log_outcome_for_root_deduped_is_independent_per_root() {
+        // A failure on one registered root must not affect another root's
+        // failing state (each workspace's health is tracked independently).
+        let root_a = PathBuf::from("/tmp/root-a");
+        let root_b = PathBuf::from("/tmp/root-b");
+        let mut failing: HashMap<PathBuf, bool> = HashMap::new();
+
+        log_outcome_for_root_deduped(
+            "curator",
+            &root_a,
+            &RoleTickOutcome::Failure("boom".into()),
+            NORMAL_TICK,
+            &mut failing,
+        );
+        log_outcome_for_root_deduped(
+            "curator",
+            &root_b,
+            &RoleTickOutcome::Success,
+            NORMAL_TICK,
+            &mut failing,
+        );
+
+        assert_eq!(failing.get(&root_a), Some(&true));
+        assert_eq!(failing.get(&root_b), Some(&false));
+    }
+
+    // ===================================================================
+    // spawn_multi_role_task missing-root hygiene (#4326/#4349) — a
+    // registered root whose directory no longer exists is skipped, not
+    // spawned against, mirroring work_finder's filter_missing_roots.
+    // ===================================================================
+
+    #[tokio::test]
+    #[serial]
+    async fn test_multi_role_task_skips_missing_registered_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let existing_root = tmp.path().join("existing");
+        let missing_root = tmp.path().join("gone");
+        std::fs::create_dir_all(&existing_root).unwrap();
+        write_config(&existing_root, r#"{"autonomous":{"roleRunner":{"enabled":true}}}"#);
+        // `add` validates the path exists at registration time, so create the
+        // "missing" root first, register it, then delete it — reproducing a
+        // registered-but-later-deleted worktree (#4349's #4188 scenario).
+        std::fs::create_dir_all(&missing_root).unwrap();
+
+        let registry_path = tmp.path().join("workspaces.json");
+        std::env::set_var(
+            crate::workspace_registry::REGISTRY_PATH_ENV,
+            registry_path.to_str().unwrap(),
+        );
+        let mut registry = WorkspaceRegistry::default();
+        registry.add(&existing_root, None).unwrap();
+        registry.add(&missing_root, None).unwrap();
+        registry.save_default().unwrap();
+        std::fs::remove_dir_all(&missing_root).unwrap();
+
+        let spec = RoleSpec {
+            name: "curator",
+            prompt: "/loom:curator",
+            default_interval_secs: 1,
+        };
+        let drain = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let in_progress = new_in_progress_guard();
+        let handle = spawn_multi_role_task(
+            spec,
+            tmp.path().to_path_buf(),
+            Duration::from_millis(20),
+            drain,
+            in_progress,
+        );
+
+        // Let a couple of ticks fire. The missing root must never be spawned
+        // against (there is no script at its `.loom/config.json`/spawn path
+        // to invoke, so a spawn attempt would either fail loudly or panic
+        // the resolve step; the assertion here is simply that the loop
+        // survives several ticks without erroring the test process, which
+        // it would if the missing root were not filtered before dispatch).
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        handle.abort();
+
+        std::env::remove_var(crate::workspace_registry::REGISTRY_PATH_ENV);
     }
 }

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -95,7 +95,7 @@ use crate::sweep_registry::OpenPrDispatchError;
 use crate::tokens::token_pool_size;
 use crate::types::Event;
 use crate::workspace_pool::WorkspacePool;
-use crate::workspace_registry::WorkspaceRegistry;
+use crate::workspace_registry::{filter_missing_roots, WorkspaceRegistry};
 
 // ============================================================================
 // Constants
@@ -1771,52 +1771,6 @@ pub fn spawn_multi_work_finder_task(
             }
         }
     })
-}
-
-/// Filter a resolved root list down to directories that still exist on disk
-/// (Issue #4326), warning once per missing/recovered transition rather than
-/// every tick.
-///
-/// Deliberately **not** folded into
-/// [`WorkspaceRegistry::effective_roots`](crate::workspace_registry::WorkspaceRegistry::effective_roots)
-/// — that helper's empty-registry branch falls back to the daemon's cwd, and
-/// dropping missing roots *inside* it would make an all-roots-missing
-/// registry indistinguishable from an empty one, silently redirecting
-/// dispatch into the daemon's own cwd. Filtering here instead means an
-/// all-missing registry yields zero roots for this tick — no dispatch, no
-/// cwd fallback — while the dangling entries stay registered so
-/// `loom-daemon status` can flag them and an operator can `workspace remove`
-/// them. This is warn-and-skip, **never auto-remove**: a root can be
-/// transiently absent (an unmounted network volume, an in-progress restore),
-/// and auto-deregistering would destroy operator state on a transient
-/// condition.
-///
-/// `warned` carries the set of roots currently known-missing across ticks so
-/// a long-dangling entry logs once on first-seen-missing (not once per tick),
-/// and — if it later reappears and then disappears again — re-warns instead
-/// of staying silent forever.
-fn filter_missing_roots(roots: Vec<PathBuf>, warned: &mut HashSet<PathBuf>) -> Vec<PathBuf> {
-    let mut existing = Vec::with_capacity(roots.len());
-    let mut still_missing: HashSet<PathBuf> = HashSet::new();
-    for root in roots {
-        if root.is_dir() {
-            existing.push(root);
-        } else {
-            if !warned.contains(&root) {
-                log::warn!(
-                    "work_finder: registered workspace root {} does not exist on disk; \
-                     skipping it for this tick (entry stays registered — run \
-                     `loom-daemon workspace remove {}` to deregister it if this is \
-                     permanent, or `loom-daemon status` to confirm)",
-                    root.display(),
-                    root.display()
-                );
-            }
-            still_missing.insert(root);
-        }
-    }
-    *warned = still_missing;
-    existing
 }
 
 /// Emit the add-capacity advisory / recovery on a token-pressure **state
@@ -4228,82 +4182,5 @@ exit 0
             vec![10],
             "sibling root with no gate in flight is unaffected"
         );
-    }
-
-    // ===================================================================
-    // Missing-root hygiene (Issue #4326)
-    // ===================================================================
-
-    #[test]
-    fn test_filter_missing_roots_skips_only_the_missing_one() {
-        // A registry with one existing and one missing root dispatches only
-        // into the existing root — the missing one is dropped, not the whole
-        // tick.
-        let tmp = tempfile::tempdir().unwrap();
-        let existing = tmp.path().to_path_buf();
-        let missing = tmp.path().join("does-not-exist");
-        let mut warned = HashSet::new();
-
-        let filtered = filter_missing_roots(vec![existing.clone(), missing.clone()], &mut warned);
-
-        assert_eq!(filtered, vec![existing], "only the existing root survives");
-        assert!(warned.contains(&missing), "the missing root is tracked as warned");
-    }
-
-    #[test]
-    fn test_filter_missing_roots_all_missing_does_not_fall_back_to_cwd() {
-        // The all-missing case must yield an EMPTY root list, never a silent
-        // fallback to the daemon's cwd (that fallback is
-        // `effective_roots`'s exclusive, empty-*registry* behavior — a
-        // non-empty registry whose entries all happen to be missing on disk
-        // is a distinct case and must not reuse it).
-        let tmp = tempfile::tempdir().unwrap();
-        let missing_a = tmp.path().join("gone-a");
-        let missing_b = tmp.path().join("gone-b");
-        let mut warned = HashSet::new();
-
-        let filtered = filter_missing_roots(vec![missing_a, missing_b], &mut warned);
-
-        assert!(filtered.is_empty(), "an all-missing registry yields zero roots, not cwd");
-        assert_eq!(warned.len(), 2);
-    }
-
-    #[test]
-    fn test_filter_missing_roots_warns_once_then_recovers() {
-        // The `warned` set only ever tracks roots missing on the *current*
-        // call — a caller that re-checks each tick (as the work-finder loop
-        // does) naturally re-warns if a root disappears again after
-        // recovering, and stays silent tick-over-tick while it remains
-        // missing (the loop only logs for roots newly inserted into
-        // `warned`, exercised by the loop itself, not this pure-function
-        // test — this test just verifies the recovery bookkeeping).
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path().join("flaky");
-        let mut warned = HashSet::new();
-
-        // First call: missing.
-        let filtered = filter_missing_roots(vec![root.clone()], &mut warned);
-        assert!(filtered.is_empty());
-        assert!(warned.contains(&root));
-
-        // Root reappears (e.g. a remounted volume).
-        std::fs::create_dir_all(&root).unwrap();
-        let filtered = filter_missing_roots(vec![root.clone()], &mut warned);
-        assert_eq!(filtered, vec![root.clone()]);
-        assert!(warned.is_empty(), "a recovered root is no longer tracked as missing");
-
-        // Root disappears again — should be treated as newly-missing (i.e.
-        // would re-warn), not silently skipped as "already known".
-        std::fs::remove_dir_all(&root).unwrap();
-        let filtered = filter_missing_roots(vec![root.clone()], &mut warned);
-        assert!(filtered.is_empty());
-        assert!(warned.contains(&root));
-    }
-
-    #[test]
-    fn test_filter_missing_roots_empty_input_returns_empty() {
-        let mut warned = HashSet::new();
-        assert!(filter_missing_roots(vec![], &mut warned).is_empty());
-        assert!(warned.is_empty());
     }
 }

--- a/loom-daemon/src/workspace_registry.rs
+++ b/loom-daemon/src/workspace_registry.rs
@@ -29,6 +29,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 /// Environment override for the registry file location (mirrors
@@ -432,6 +433,56 @@ pub enum DispatchRootResolution {
         /// The currently-registered workspace roots, in registry order.
         registered: Vec<PathBuf>,
     },
+}
+
+/// Skip registered roots whose directory no longer exists on disk (#4326),
+/// warning once per missing period rather than once per tick.
+///
+/// Shared by [`crate::work_finder`] (single- and multi-workspace loops) and
+/// [`crate::role_runner::spawn_multi_role_task`] (#4349) — both re-read
+/// [`WorkspaceRegistry::effective_roots`] every tick and must apply the same
+/// missing-root hygiene before dispatching against the result, rather than
+/// each maintaining its own drifting copy of this predicate.
+///
+/// Deliberately does **not** live inside [`WorkspaceRegistry::effective_roots`]
+/// — that helper's empty-registry branch falls back to the daemon's cwd, and
+/// dropping missing roots *inside* it would make an all-roots-missing
+/// registry indistinguishable from an empty one, silently redirecting
+/// dispatch into the daemon's own cwd. Filtering here instead means an
+/// all-missing registry yields zero roots for this tick — no dispatch, no
+/// cwd fallback — while the dangling entries stay registered so
+/// `loom-daemon status` can flag them and an operator can `workspace remove`
+/// them. This is warn-and-skip, **never auto-remove**: a root can be
+/// transiently absent (an unmounted network volume, an in-progress restore),
+/// and auto-deregistering would destroy operator state on a transient
+/// condition.
+///
+/// `warned` carries the set of roots currently known-missing across ticks so
+/// a long-dangling entry logs once on first-seen-missing (not once per tick),
+/// and — if it later reappears and then disappears again — re-warns instead
+/// of staying silent forever.
+pub fn filter_missing_roots(roots: Vec<PathBuf>, warned: &mut HashSet<PathBuf>) -> Vec<PathBuf> {
+    let mut existing = Vec::with_capacity(roots.len());
+    let mut still_missing: HashSet<PathBuf> = HashSet::new();
+    for root in roots {
+        if root.is_dir() {
+            existing.push(root);
+        } else {
+            if !warned.contains(&root) {
+                log::warn!(
+                    "workspace_registry: registered workspace root {} does not exist on disk; \
+                     skipping it for this tick (entry stays registered — run \
+                     `loom-daemon workspace remove {}` to deregister it if this is \
+                     permanent, or `loom-daemon status` to confirm)",
+                    root.display(),
+                    root.display()
+                );
+            }
+            still_missing.insert(root);
+        }
+    }
+    *warned = still_missing;
+    existing
 }
 
 #[cfg(test)]
@@ -899,5 +950,82 @@ mod tests {
 
         let canonical_inner = std::fs::canonicalize(&inner).unwrap();
         assert_eq!(resolve_client_workspace_default(&inner, &reg), Some(canonical_inner));
+    }
+
+    // ===================================================================
+    // Missing-root hygiene (Issue #4326; hoisted here shared for #4349)
+    // ===================================================================
+
+    #[test]
+    fn test_filter_missing_roots_skips_only_the_missing_one() {
+        // A registry with one existing and one missing root dispatches only
+        // into the existing root — the missing one is dropped, not the whole
+        // tick.
+        let tmp = tempdir().unwrap();
+        let existing = tmp.path().to_path_buf();
+        let missing = tmp.path().join("does-not-exist");
+        let mut warned = HashSet::new();
+
+        let filtered = filter_missing_roots(vec![existing.clone(), missing.clone()], &mut warned);
+
+        assert_eq!(filtered, vec![existing], "only the existing root survives");
+        assert!(warned.contains(&missing), "the missing root is tracked as warned");
+    }
+
+    #[test]
+    fn test_filter_missing_roots_all_missing_does_not_fall_back_to_cwd() {
+        // The all-missing case must yield an EMPTY root list, never a silent
+        // fallback to the daemon's cwd (that fallback is
+        // `effective_roots`'s exclusive, empty-*registry* behavior — a
+        // non-empty registry whose entries all happen to be missing on disk
+        // is a distinct case and must not reuse it).
+        let tmp = tempdir().unwrap();
+        let missing_a = tmp.path().join("gone-a");
+        let missing_b = tmp.path().join("gone-b");
+        let mut warned = HashSet::new();
+
+        let filtered = filter_missing_roots(vec![missing_a, missing_b], &mut warned);
+
+        assert!(filtered.is_empty(), "an all-missing registry yields zero roots, not cwd");
+        assert_eq!(warned.len(), 2);
+    }
+
+    #[test]
+    fn test_filter_missing_roots_warns_once_then_recovers() {
+        // The `warned` set only ever tracks roots missing on the *current*
+        // call — a caller that re-checks each tick (as the work-finder loop
+        // does) naturally re-warns if a root disappears again after
+        // recovering, and stays silent tick-over-tick while it remains
+        // missing (the loop only logs for roots newly inserted into
+        // `warned`, exercised by the loop itself, not this pure-function
+        // test — this test just verifies the recovery bookkeeping).
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("flaky");
+        let mut warned = HashSet::new();
+
+        // First call: missing.
+        let filtered = filter_missing_roots(vec![root.clone()], &mut warned);
+        assert!(filtered.is_empty());
+        assert!(warned.contains(&root));
+
+        // Root reappears (e.g. a remounted volume).
+        std::fs::create_dir_all(&root).unwrap();
+        let filtered = filter_missing_roots(vec![root.clone()], &mut warned);
+        assert_eq!(filtered, vec![root.clone()]);
+        assert!(warned.is_empty(), "a recovered root is no longer tracked as missing");
+
+        // Root disappears again — should be treated as newly-missing (i.e.
+        // would re-warn), not silently skipped as "already known".
+        std::fs::remove_dir_all(&root).unwrap();
+        let filtered = filter_missing_roots(vec![root.clone()], &mut warned);
+        assert!(filtered.is_empty());
+        assert!(warned.contains(&root));
+    }
+
+    #[test]
+    fn test_filter_missing_roots_empty_input_returns_empty() {
+        let mut warned = HashSet::new();
+        assert!(filter_missing_roots(vec![], &mut warned).is_empty());
+        assert!(warned.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

A broken/half-deleted worktree left in the daemon's workspace registry (e.g.
`.loom/worktrees/issue-4188` after its `mcp-loom` build was removed) failed
every 5-minute champion/curator role tick forever with ERROR-level noise,
because `claude-wrapper.sh`'s MCP pre-flight pinned to that worktree's own
`.mcp.json` with no fallback, and `spawn_multi_role_task` had none of the
missing-root hygiene `work_finder` already applies.

## Changes

- `defaults/scripts/claude-wrapper.sh`: `check_mcp_server()` now iterates an
  **ordered candidate list** (`mcp_candidate_workspaces()`: the resolved
  `WORKSPACE`'s own `.mcp.json` first, then the git common dir's) instead of
  pinning to whichever `resolve_mcp_workspace()` picked. A candidate whose
  entry point is missing/unbuildable falls through to the next candidate;
  the session only hard-fails when **no** candidate config is healthy AND at
  least one candidate was a real, parseable config (the #4230 "no MCP
  configured" non-fatal skip is preserved when every candidate is absent or
  unparseable). `resolve_mcp_workspace()` is kept as a back-compat
  single-candidate wrapper over the new list.
- `loom-daemon/src/role_runner.rs`:
  - `spawn_multi_role_task` now filters registered roots through the shared
    `filter_missing_roots` (warn once per missing period, never
    auto-delete — the daemon does NOT prune worktrees itself, per CLAUDE.md;
    that stays `loom-clean`'s job).
  - Added `classify_root_tick_log` / `log_outcome_for_root_deduped`: a
    per-root failing-state map (`HashMap<PathBuf, bool>`) tracked across
    ticks so a persistently-failing root logs once on the fail edge (WARN)
    and once on recovery (INFO), with repeat failures downgraded to DEBUG —
    instead of re-warning identically every tick forever.
- `loom-daemon/src/workspace_registry.rs`: hoisted `filter_missing_roots`
  (previously private to `work_finder.rs`) here as a shared `pub fn`, along
  with its existing test suite, so `work_finder` and `role_runner` apply
  identical missing-root discipline instead of drifting copies.
- `loom-daemon/src/work_finder.rs`: now imports the hoisted
  `filter_missing_roots` instead of defining its own; behavior unchanged.
- `defaults/scripts/tests/test-mcp-config.sh`: new fixture-based section
  (real `git worktree` + stub `mcp-loom` bundles) covering the fallback,
  both-candidates-broken hard failure, and the no-config-anywhere #4230 skip.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Preflight fallback: broken/unbuildable entry point re-resolves from the git common dir and smoke-tests it; only fails when no candidate is healthy; one WARN names the fallback | ✅ | New `test-mcp-config.sh` Section 7 (fixture-based, real `git worktree`) — see fallback-pass, both-broken-fail, and no-config-skip cases below |
| Role-runner missing-root hygiene: `spawn_multi_role_task` applies the same discipline as `work_finder` (#4326) | ✅ | `filter_missing_roots` hoisted to `workspace_registry.rs`, applied in `spawn_multi_role_task`; new `test_multi_role_task_skips_missing_registered_root` |
| Log dedup on state change: a repeating identical role-tick failure logs on the fail edge and on recovery, not every tick | ✅ | `classify_root_tick_log` unit tests (`test_classify_first_failure_is_edge`, `test_classify_repeat_failure_is_downgraded`, `test_classify_success_after_failure_is_recovery`) + `test_log_outcome_for_root_deduped_tracks_failing_state_across_ticks` |
| Scope guard — no auto-prune: the daemon must not delete worktrees itself | ✅ | `filter_missing_roots` is warn-and-skip only (unchanged semantics from #4326); no `git worktree`/`rm` calls added anywhere in this diff |
| #4230 absent-config non-fatal skip preserved exactly | ✅ | `test-mcp-config.sh` "no .mcp.json anywhere" case asserts `RC=0` + `#4230` in the skip message |

## Test Plan

- `cargo test -p loom-daemon role_runner::` — 39 passed (includes new
  `classify_root_tick_log`/dedup tests + the missing-root multi-workspace test)
- `cargo test -p loom-daemon workspace_registry::` — 35 passed (includes the
  hoisted `filter_missing_roots` suite)
- `cargo test -p loom-daemon work_finder::` — 106 passed (unaffected by the hoist)
- `cargo test --workspace --lib --bins` — 1616 + 30 passed
- `cargo clippy -p loom-daemon --all-targets` — clean
- `cargo fmt -p loom-daemon -- --check` — clean
- `bash defaults/scripts/tests/test-mcp-config.sh` — 53 passed (7 new
  fallback/hard-fail/skip cases against a real `git worktree` fixture)
- `bash defaults/scripts/tests/test-spawn-claude.sh` — 116/129 passed;
  remaining 13 failures are pre-existing `nice`/`taskpolicy` env-specific
  failures unrelated to this change (confirmed identical failure count on
  `origin/main` before this diff)
- `bash .loom/scripts/build-gate.sh` (full repo gate: cargo test, loom-tools
  pytest, installer suite) — all green after a fresh `cargo build --release`
  (the worktree's copied release binary was stale from a prior commit,
  unrelated to this change; loom-tools `test_rust_conformance.py` was
  failing against it and now passes: 2118 passed, 1 skipped)
- Manual fixture verification (real `git init` + `git worktree add`): broken
  worktree `.mcp.json` (deleted `mcp-loom`, no `package.json` to rebuild) +
  healthy common-dir config → pre-flight passes via fallback with one WARN,
  no `MCP_PREFLIGHT_FAILED`; both broken → hard fail naming both candidates;
  no config anywhere → non-fatal `#4230` skip

Closes #4349