### PR TITLE
feat(safehouse): supervise safehoused as a launchd/systemd service on interactive hosts

### DIFF
--- a/.loom/docs/safehouse.md
+++ b/.loom/docs/safehouse.md
@@ -136,13 +136,13 @@ daemon's wire payload — missing the field entirely — still parses).
 resolvers `lib/mcp-config.sh` already defines for the safehouse-mcp worker
 injection (phase 2, below) rather than re-deriving them.
 
-## New-host onboarding (#4345)
+## New-host onboarding (#4345, #4346)
 
-The manual path from a fresh interactive host (no `safehoused`, no
-`safehouse` config block anywhere) to `loom-daemon status` reading
-`connected`. **An automated service-wrapper + install-step path is tracked as
-a follow-up (#4359)** — this section is the documented fallback until that
-lands, and stays valid afterward as the manual/debug path.
+The path from a fresh interactive host (no `safehoused`, no `safehouse` config
+block anywhere) to `loom-daemon status` reading `connected`. Step 3 registers
+`safehoused` as a **supervised service** (launchd LaunchAgent on macOS,
+`systemd --user` on Linux) via `safehoused-service.sh` (#4346); running it by
+hand is still documented as the debug fallback.
 
 1. **Bot account + credentials.** Provision (or reuse) a Matrix account for
    the `loom_daemon` persona in the target safehouse deployment — this is an
@@ -154,12 +154,26 @@ lands, and stays valid afterward as the manual/debug path.
    in its config includes `loom_daemon` (or whichever persona you assign this
    host, per "Operator setup" above) — the allowlist is boot-time and
    restart-only, no hot reload.
-3. **Run `safehoused`.** Until #4359 ships a supervised service wrapper
-   (launchd LaunchAgent / `systemd --user`, mirroring
-   `loom-daemon-start.sh`'s own pattern), start it manually or under your own
-   supervisor of choice — `nohup safehoused &`, a personal launchd plist, a
-   tmux pane, etc. Note the socket path it binds (safehoused's own config
-   controls this).
+3. **Register `safehoused` as a supervised service.** Use
+   [`safehoused-service.sh`](#supervised-service-wrapper-safehoused-servicesh-4346) —
+   it renders and installs a launchd LaunchAgent (macOS) or `systemd --user`
+   unit (Linux) that starts `safehoused` at login and keeps it up
+   (`KeepAlive`/`Restart=always`, so it survives a crash or reboot), mirroring
+   `loom-daemon-start.sh`'s own supervised-service pattern:
+   ```bash
+   # Preview the service definition first (no side effects):
+   ./.loom/scripts/cli/safehoused-service.sh --print-plist   # macOS
+   ./.loom/scripts/cli/safehoused-service.sh --print-unit    # Linux
+   # Then install + start (point --bin at your built safehoused; the socket is
+   # resolved from the same safehouse.socket / $SAFEHOUSED_SOCKET chain the
+   # daemon uses, or pass --socket explicitly):
+   ./.loom/scripts/cli/safehoused-service.sh install --bin "$(command -v safehoused)"
+   ```
+   On a headless Linux host, run `loginctl enable-linger "$USER"` once so the
+   `systemd --user` unit survives a reboot. **Fallback (debug only):** start it
+   by hand under any supervisor — `nohup safehoused &`, a tmux pane, a personal
+   plist. Either way, note the socket path safehoused binds (its own config
+   controls this) for the next step.
 4. **Socket env or config.** Either export `SAFEHOUSED_SOCKET=<path>` (the
    convention safehoused's own clients read) machine-wide, or set
    `safehouse.socket` explicitly in this host's `.loom/config.json` — see
@@ -193,6 +207,49 @@ that the persona is in safehoused's allowlist (a rejected `hello` also
 degrades to `unreachable` — check the daemon log for `safehoused rejected
 persona`), and that the daemon process can reach the socket path (permissions,
 same-host, no stale socket file from a crashed prior run).
+
+### Supervised service wrapper: `safehoused-service.sh` (#4346)
+
+`defaults/scripts/cli/safehoused-service.sh` (installed as
+`.loom/scripts/cli/safehoused-service.sh`) registers `safehoused` as a
+supervised service so it starts at login and comes back after a crash or
+reboot — the interactive-host counterpart to the cloud-host provisioning path
+(#3998). It mirrors `loom-daemon-start.sh`'s supervised-service pattern
+(launchd LaunchAgent on macOS / `systemd --user` on Linux) including the
+`--print-plist` / `--print-unit` preview modes.
+
+| Command | Effect |
+|---|---|
+| `--print-plist` / `--print-unit` | Print the launchd plist / systemd unit that *would* be installed, no side effects (any platform). |
+| `install` | Render + install + enable + start the service. |
+| `uninstall` | Stop + disable + remove the service definition. |
+| `status` | Report whether the supervised service is loaded / running. |
+
+Parameters (precedence **flag > env > config > default**): `--bin`
+(`SAFEHOUSED_BIN`, else `command -v safehoused`); `--exec "<argv>"`
+(`SAFEHOUSED_EXEC`) for a full ExecStart override when safehoused needs flags;
+`--socket` (else the shared `safehouse.socket` → `$LOOM_SAFEHOUSE_SOCKET` →
+`$SAFEHOUSED_SOCKET` chain the daemon resolves); `--config`
+(`SAFEHOUSED_CONFIG`); `--log` (default `~/.loom/logs/safehoused.log`);
+`--label` / `--unit` for the launchd label / systemd unit name.
+
+**Supervision policy differs from `loom-daemon`'s on purpose.** `loom-daemon`
+uses `KeepAlive:{SuccessfulExit:true}` / `Restart=on-success` because it has a
+clean-exit restart *primitive* (exit 0 == intentional relaunch, the
+`RestartDaemon` path). `safehoused` has no such primitive — it is a persistent
+connection daemon that should simply stay up — so the wrapper renders
+`KeepAlive=true` (launchd) / `Restart=always` + `RestartSec=5` (systemd).
+
+**Ownership decision (recorded here per #4346's acceptance criteria):** this
+wrapper is deliberately **safehoused-agnostic** and lives in *this* repo, while
+the **authoritative** service definition (safehoused's real argv, config
+schema, and key-backup / steady-state teardown semantics) is owned by the
+external `rjwalters/safehouse` repo. loom does not vendor safehoused's binary
+invocation — that would rot the moment the external repo changes it — so the
+wrapper only supervises an operator-supplied binary and bakes a minimal,
+non-secret environment (`SAFEHOUSED_SOCKET` / `SAFEHOUSED_CONFIG` when
+provided; never a forwarded token). If the safehouse repo ships its own service
+files, point the runbook at those and treat this generator as the fallback.
 
 ## What gets narrated
 

--- a/defaults/scripts/cli/safehoused-service.sh
+++ b/defaults/scripts/cli/safehoused-service.sh
@@ -1,0 +1,474 @@
+#!/usr/bin/env bash
+# safehoused-service.sh — register `safehoused` as a supervised service on an
+# interactive host: a launchd LaunchAgent on macOS, a `systemd --user` service
+# on Linux. This is the provisioning mechanic the safehouse "New-host
+# onboarding" runbook points at (see .loom/docs/safehouse.md), the local /
+# interactive-host counterpart to the cloud-host path (#3998).
+#
+# It deliberately MIRRORS loom-daemon-start.sh's own supervised-service pattern
+# (#3972 launchd / #4268 systemd --user, plus the --print-plist / --print-unit
+# preview modes) so operators who already know how the loom-daemon service is
+# provisioned see the same shape here.
+#
+# ---------------------------------------------------------------------------
+# OWNERSHIP DECISION (issue #4346): who owns the safehoused service files?
+# ---------------------------------------------------------------------------
+# This wrapper is deliberately safehoused-AGNOSTIC. It does NOT vendor
+# safehoused's real invocation, CLI flags, config schema, or the key-backup /
+# steady-state teardown semantics (`Backups::wait_for_steady_state`) — those
+# are owned by the external `rjwalters/safehouse` repo, which is the only place
+# that can know safehoused's true ExecStart and lifecycle. This script only
+# supervises an OPERATOR-SUPPLIED binary (`--bin` / `--exec`), bakes a minimal,
+# non-secret environment, and applies the launchd/systemd supervision contract.
+#
+# So: the safehouse repo owns the AUTHORITATIVE service definition if/when it
+# ships one; if it does, this repo's runbook points at that and this generator
+# remains the documented fallback + the concrete, testable mechanic loom can
+# offer today. loom does not, and should not, encode safehoused's argv — that
+# would rot the moment the external repo changes it.
+#
+# ---------------------------------------------------------------------------
+# Usage:
+#   safehoused-service.sh install         Render + install + enable + start the service
+#   safehoused-service.sh uninstall       Stop + disable + remove the service definition
+#   safehoused-service.sh status          Report whether the supervised service is loaded/running
+#   safehoused-service.sh --print-plist   Print the launchd LaunchAgent plist that WOULD be installed and exit (no side effects)
+#   safehoused-service.sh --print-unit    Print the systemd --user unit that WOULD be installed and exit (no side effects)
+#   safehoused-service.sh --help          Show this help
+#
+# Parameters (precedence: flag > env > config > default):
+#   --bin PATH        The safehoused binary. Env SAFEHOUSED_BIN; default:
+#                     `command -v safehoused`, else ~/.cargo/bin/safehoused.
+#   --exec "ARGV"     Full ExecStart / ProgramArguments override (whitespace-
+#                     separated argv, no shell quoting). Env SAFEHOUSED_EXEC.
+#                     Default: the resolved binary alone (no invented flags).
+#   --socket PATH     The AF_UNIX socket safehoused binds. Resolved (when not
+#                     passed) via the SAME env>config>default chain the daemon
+#                     and worker MCP injection use (safehouse.socket config >
+#                     $LOOM_SAFEHOUSE_SOCKET > $SAFEHOUSED_SOCKET). Baked into
+#                     the service env as SAFEHOUSED_SOCKET so the daemon and its
+#                     clients agree on one path.
+#   --config PATH     safehoused's own config file. Env SAFEHOUSED_CONFIG. Baked
+#                     into the service env as SAFEHOUSED_CONFIG when set.
+#   --log PATH        Service stdout/stderr log. Env SAFEHOUSED_LOG; default
+#                     ~/.loom/logs/safehoused.log.
+#   --label LABEL     macOS LaunchAgent label. Env SAFEHOUSED_LAUNCHD_LABEL;
+#                     default com.rjwalters.safehoused.
+#   --unit NAME       Linux systemd --user unit. Env SAFEHOUSED_SYSTEMD_UNIT;
+#                     default safehoused.service.
+#   --no-launchd      macOS: skip launchd; not supported (there is no nohup
+#                     fallback here — this script's whole purpose is supervision).
+#
+# Supervision policy (deliberately DIFFERENT from loom-daemon's):
+#   loom-daemon uses KeepAlive:{SuccessfulExit:true} / Restart=on-success
+#   because it has a clean-exit restart PRIMITIVE (exit 0 == intentional
+#   relaunch). safehoused has no such primitive — it is a persistent connection
+#   daemon that should simply stay up. So this renders:
+#     * launchd:  KeepAlive=true  (relaunch on ANY exit) + RunAtLoad=true
+#     * systemd:  Restart=always + RestartSec=5 + WantedBy=default.target
+#   Both survive re-login; reboot survival on a headless Linux host additionally
+#   needs `loginctl enable-linger "$USER"` once (surfaced by `install`).
+#
+# Exit codes:
+#   0  success (installed / uninstalled / status printed / preview printed)
+#   1  usage error / binary not found / install failed
+#   2  unsupported platform (no launchd on macOS, no reachable systemd --user on Linux)
+
+set -uo pipefail
+
+# ---------- output helpers ----------
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+else
+    RED=''; GREEN=''; YELLOW=''; NC=''
+fi
+err()  { echo -e "${RED}$*${NC}" >&2; }
+warn() { echo -e "${YELLOW}$*${NC}" >&2; }
+ok()   { echo -e "${GREEN}$*${NC}"; }
+
+show_help() {
+    # Print the leading comment banner (line 2 through the last comment line
+    # before `set -uo pipefail`), stripping the leading "# ".
+    awk 'NR>=2 { if ($0 !~ /^#/) exit; sub(/^# ?/, ""); print }' "$0"
+}
+
+# ---------- repo root (for config resolution only) ----------
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.loom" ]]; then echo "$dir"; return 0; fi
+        if [[ -f "$dir/.git" ]]; then
+            local gitdir main_repo
+            gitdir=$(sed 's/^gitdir: //' "$dir/.git")
+            main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+            if [[ -d "$main_repo/.loom" ]]; then echo "$main_repo"; return 0; fi
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo ""
+}
+
+# ---------- shared libs (domain / systemd detection + socket resolver) ----------
+_LOOM_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" 2>/dev/null && pwd)"
+if [[ -r "$_LOOM_LIB_DIR/launchd-domain.sh" ]]; then
+    # shellcheck source=../lib/launchd-domain.sh
+    source "$_LOOM_LIB_DIR/launchd-domain.sh"
+fi
+if [[ -r "$_LOOM_LIB_DIR/systemd-user.sh" ]]; then
+    # shellcheck source=../lib/systemd-user.sh
+    source "$_LOOM_LIB_DIR/systemd-user.sh"
+fi
+# mcp-config.sh gives us the SAME safehouse.socket resolver (env>config>default)
+# the daemon status line and worker MCP injection use — so the socket this
+# service binds and the socket loom connects to are resolved identically.
+if [[ -r "$_LOOM_LIB_DIR/mcp-config.sh" ]]; then
+    # shellcheck source=../lib/mcp-config.sh
+    source "$_LOOM_LIB_DIR/mcp-config.sh"
+fi
+
+# ---------- XML escaping (launchd plist) ----------
+xml_escape() {
+    local s="$1"
+    s="${s//&/&amp;}"
+    s="${s//</&lt;}"
+    s="${s//>/&gt;}"
+    printf '%s' "$s"
+}
+
+# ---------- deterministic service PATH ----------
+# The same canonical minimal PATH loom-daemon-start.sh bakes into its plist
+# (#4172): hermetic, reproducible across hosts/sessions, never the invoking
+# shell's interactive PATH. Override with SAFEHOUSED_PATH (verbatim).
+resolve_service_path() {
+    local canonical="${HOME}/.local/bin:${HOME}/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    if [[ -n "${SAFEHOUSED_PATH:-}" ]]; then
+        printf '%s' "${SAFEHOUSED_PATH}"
+        return 0
+    fi
+    printf '%s' "$canonical"
+}
+
+# ---------- label / unit resolvers ----------
+resolve_label() {
+    echo "${SAFEHOUSED_LAUNCHD_LABEL:-com.rjwalters.safehoused}"
+}
+resolve_unit() {
+    echo "${SAFEHOUSED_SYSTEMD_UNIT:-safehoused.service}"
+}
+
+# ---------- binary resolution ----------
+locate_safehoused_bin() {
+    if [[ -n "${SAFEHOUSED_BIN:-}" ]]; then echo "${SAFEHOUSED_BIN}"; return 0; fi
+    if command -v safehoused >/dev/null 2>&1; then command -v safehoused; return 0; fi
+    if [[ -x "${HOME}/.cargo/bin/safehoused" ]]; then echo "${HOME}/.cargo/bin/safehoused"; return 0; fi
+    echo ""
+}
+
+# ---------- launchd plist rendering ----------
+# render_launchd_plist <label> <workdir> <log_path> <socket> <config> <argv...>
+# Pure string rendering — safe on ANY platform (used by --print-plist). No
+# forwarded PATs: safehoused holds its Matrix credentials in its own config /
+# store, so this env is minimal and non-secret by construction.
+render_launchd_plist() {
+    local label="$1" workdir="$2" log_path="$3" socket="$4" config="$5"
+    shift 5
+    local -a argv=("$@")
+    local path_value; path_value="$(resolve_service_path)"
+
+    local env_entries=""
+    env_entries+="        <key>PATH</key>\n        <string>$(xml_escape "$path_value")</string>\n"
+    env_entries+="        <key>HOME</key>\n        <string>$(xml_escape "$HOME")</string>\n"
+    if [[ -n "$socket" ]]; then
+        env_entries+="        <key>SAFEHOUSED_SOCKET</key>\n        <string>$(xml_escape "$socket")</string>\n"
+    fi
+    if [[ -n "$config" ]]; then
+        env_entries+="        <key>SAFEHOUSED_CONFIG</key>\n        <string>$(xml_escape "$config")</string>\n"
+    fi
+
+    printf '<?xml version="1.0" encoding="UTF-8"?>\n'
+    printf '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
+    printf '<plist version="1.0">\n<dict>\n'
+    printf '    <key>Label</key>\n    <string>%s</string>\n' "$(xml_escape "$label")"
+    printf '    <key>ProgramArguments</key>\n    <array>\n'
+    local a
+    for a in "${argv[@]}"; do
+        printf '        <string>%s</string>\n' "$(xml_escape "$a")"
+    done
+    printf '    </array>\n'
+    printf '    <key>WorkingDirectory</key>\n    <string>%s</string>\n' "$(xml_escape "$workdir")"
+    printf '    <key>EnvironmentVariables</key>\n    <dict>\n'
+    printf '%b' "$env_entries"
+    printf '    </dict>\n'
+    printf '    <key>RunAtLoad</key>\n    <true/>\n'
+    # KeepAlive=true (persistent daemon, no clean-exit restart primitive):
+    # relaunch on ANY exit. Contrast loom-daemon's KeepAlive:{SuccessfulExit:true}.
+    printf '    <key>KeepAlive</key>\n    <true/>\n'
+    printf '    <key>ProcessType</key>\n    <string>Background</string>\n'
+    printf '    <key>StandardOutPath</key>\n    <string>%s</string>\n' "$(xml_escape "$log_path")"
+    printf '    <key>StandardErrorPath</key>\n    <string>%s</string>\n' "$(xml_escape "$log_path")"
+    printf '</dict>\n</plist>\n'
+}
+
+# ---------- systemd --user unit rendering ----------
+# render_systemd_unit <workdir> <log_path> <socket> <config> <exec_line>
+# Pure string rendering — safe on ANY platform (used by --print-unit). The Linux
+# mirror of render_launchd_plist. Restart=always is the persistent-daemon analog
+# of launchd KeepAlive=true (NOT loom-daemon's Restart=on-success).
+render_systemd_unit() {
+    local workdir="$1" log_path="$2" socket="$3" config="$4" exec_line="$5"
+    local path_value; path_value="$(resolve_service_path)"
+
+    local env_lines=""
+    env_lines+="Environment=PATH=${path_value}\n"
+    env_lines+="Environment=HOME=${HOME}\n"
+    if [[ -n "$socket" ]]; then
+        env_lines+="Environment=SAFEHOUSED_SOCKET=${socket}\n"
+    fi
+    if [[ -n "$config" ]]; then
+        env_lines+="Environment=SAFEHOUSED_CONFIG=${config}\n"
+    fi
+
+    printf '[Unit]\n'
+    printf 'Description=safehoused fleet-comms daemon (loom-supervised)\n'
+    printf 'After=network-online.target\n'
+    printf 'Wants=network-online.target\n'
+    printf '\n'
+    printf '[Service]\n'
+    printf 'Type=simple\n'
+    printf 'WorkingDirectory=%s\n' "$workdir"
+    printf 'ExecStart=%s\n' "$exec_line"
+    # Restart=always == launchd KeepAlive=true: a persistent daemon with no
+    # clean-exit restart primitive is simply kept up. RestartSec bounds the
+    # relaunch rate so a hard-failing safehoused does not hot-loop.
+    printf 'Restart=always\n'
+    printf 'RestartSec=5\n'
+    printf '%b' "$env_lines"
+    printf 'StandardOutput=append:%s\n' "$log_path"
+    printf 'StandardError=append:%s\n' "$log_path"
+    printf '\n'
+    printf '[Install]\n'
+    printf 'WantedBy=default.target\n'
+}
+
+# ============================================================================
+# Argument / parameter resolution
+# ============================================================================
+ACTION=""
+PRINT_PLIST=false
+PRINT_UNIT=false
+OPT_BIN=""
+OPT_EXEC=""
+OPT_SOCKET=""
+OPT_CONFIG=""
+OPT_LOG=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        install|uninstall|status)
+            if [[ -n "$ACTION" ]]; then err "Multiple actions given: '$ACTION' and '$1'"; exit 1; fi
+            ACTION="$1"; shift ;;
+        --print-plist) PRINT_PLIST=true; shift ;;
+        --print-unit)  PRINT_UNIT=true; shift ;;
+        --help|-h)     show_help; exit 0 ;;
+        --bin)    OPT_BIN="${2:-}"; shift 2 ;;
+        --exec)   OPT_EXEC="${2:-}"; shift 2 ;;
+        --socket) OPT_SOCKET="${2:-}"; shift 2 ;;
+        --config) OPT_CONFIG="${2:-}"; shift 2 ;;
+        --log)    OPT_LOG="${2:-}"; shift 2 ;;
+        --label)  SAFEHOUSED_LAUNCHD_LABEL="${2:-}"; shift 2 ;;
+        --unit)   SAFEHOUSED_SYSTEMD_UNIT="${2:-}"; shift 2 ;;
+        --no-launchd)
+            err "--no-launchd is not supported: this script's purpose is supervision (there is no nohup fallback)."
+            exit 1 ;;
+        --*) err "Unknown flag: $1"; echo ""; show_help; exit 1 ;;
+        *)   err "Unexpected argument: $1"; exit 1 ;;
+    esac
+done
+
+REPO_ROOT="$(find_repo_root)"
+
+# Binary: flag > env > discovery.
+SAFEHOUSED_BIN="${OPT_BIN:-${SAFEHOUSED_BIN:-}}"
+RESOLVED_BIN="$(locate_safehoused_bin)"
+
+# Socket: flag > (config > LOOM_SAFEHOUSE_SOCKET > SAFEHOUSED_SOCKET via the
+# shared resolver). The resolver soft-degrades to empty when nothing resolves.
+RESOLVED_SOCKET="$OPT_SOCKET"
+if [[ -z "$RESOLVED_SOCKET" ]] && command -v loom_mcp_safehouse_socket >/dev/null 2>&1; then
+    RESOLVED_SOCKET="$(loom_mcp_safehouse_socket "${REPO_ROOT:-$PWD}")"
+fi
+[[ "$RESOLVED_SOCKET" == "null" ]] && RESOLVED_SOCKET=""
+
+# Config: flag > env.
+RESOLVED_CONFIG="${OPT_CONFIG:-${SAFEHOUSED_CONFIG:-}}"
+
+# Log: flag > env > default.
+RESOLVED_LOG="${OPT_LOG:-${SAFEHOUSED_LOG:-${HOME}/.loom/logs/safehoused.log}}"
+
+# ExecStart argv: --exec override (whitespace-split) > resolved binary alone.
+declare -a ARGV
+if [[ -n "$OPT_EXEC" ]]; then
+    # Intentionally word-split (no shell quoting inside --exec).
+    # shellcheck disable=SC2206
+    ARGV=($OPT_EXEC)
+elif [[ -n "$RESOLVED_BIN" ]]; then
+    ARGV=("$RESOLVED_BIN")
+else
+    ARGV=()
+fi
+EXEC_LINE="${ARGV[*]:-}"
+
+LABEL="$(resolve_label)"
+UNIT="$(resolve_unit)"
+WORKDIR="$HOME"
+
+# ---------- --print-plist / --print-unit: pure inspection, no side effects ----------
+if [[ "$PRINT_PLIST" == "true" ]]; then
+    if [[ ${#ARGV[@]} -eq 0 ]]; then
+        # Render with a placeholder so the preview is still valid XML; warn on stderr.
+        warn "safehoused binary not found (set --bin / SAFEHOUSED_BIN); previewing with a placeholder ProgramArguments."
+        ARGV=("/path/to/safehoused")
+    fi
+    render_launchd_plist "$LABEL" "$WORKDIR" "$RESOLVED_LOG" "$RESOLVED_SOCKET" "$RESOLVED_CONFIG" "${ARGV[@]}"
+    exit 0
+fi
+if [[ "$PRINT_UNIT" == "true" ]]; then
+    preview_exec="$EXEC_LINE"
+    if [[ -z "$preview_exec" ]]; then
+        warn "safehoused binary not found (set --bin / SAFEHOUSED_BIN); previewing with a placeholder ExecStart."
+        preview_exec="/path/to/safehoused"
+    fi
+    render_systemd_unit "$WORKDIR" "$RESOLVED_LOG" "$RESOLVED_SOCKET" "$RESOLVED_CONFIG" "$preview_exec"
+    exit 0
+fi
+
+# ---------- from here on we need a real action ----------
+if [[ -z "$ACTION" ]]; then
+    show_help
+    exit 0
+fi
+
+IS_DARWIN=false
+[[ "$(uname -s)" == "Darwin" ]] && IS_DARWIN=true
+
+# ============================================================================
+# status
+# ============================================================================
+if [[ "$ACTION" == "status" ]]; then
+    if [[ "$IS_DARWIN" == "true" ]]; then
+        if ! command -v launchctl >/dev/null 2>&1; then err "launchctl not found."; exit 2; fi
+        domain="$(resolve_launchd_domain 2>/dev/null || echo "gui/$(id -u)")"
+        service="${domain}/${LABEL}"
+        if launchctl print "$service" >/dev/null 2>&1; then
+            pid=$(launchctl print "$service" 2>/dev/null | awk -F'= ' '/^[[:space:]]*pid = /{gsub(/[^0-9]/, "", $2); print $2; exit}')
+            if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+                ok "safehoused: running (launchd $service, pid $pid)"
+            else
+                warn "safehoused: loaded but not currently running (launchd $service)"
+            fi
+        else
+            echo "safehoused: not installed (launchd $service)"
+        fi
+        exit 0
+    fi
+    # Linux
+    if ! command -v systemctl >/dev/null 2>&1; then err "systemctl not found."; exit 2; fi
+    if systemctl --user status "$UNIT" >/dev/null 2>&1; then
+        state="$(systemctl --user is-active "$UNIT" 2>/dev/null)"
+        ok "safehoused: $state (systemd --user $UNIT)"
+    else
+        echo "safehoused: not installed (systemd --user $UNIT)"
+    fi
+    exit 0
+fi
+
+# ============================================================================
+# install / uninstall — need a resolved binary (install only) and a supervisor
+# ============================================================================
+if [[ "$ACTION" == "install" ]]; then
+    if [[ ${#ARGV[@]} -eq 0 ]]; then
+        err "safehoused binary not found."
+        err "Build it from the rjwalters/safehouse checkout, then pass --bin PATH or set SAFEHOUSED_BIN."
+        exit 1
+    fi
+fi
+
+if [[ "$IS_DARWIN" == "true" ]]; then
+    # ---------------- macOS: launchd LaunchAgent ----------------
+    if ! command -v launchctl >/dev/null 2>&1; then
+        err "launchctl not found on Darwin — cannot supervise safehoused."
+        exit 2
+    fi
+    DOMAIN="$(resolve_launchd_domain)"
+    SERVICE="${DOMAIN}/${LABEL}"
+    PLIST_DIR="$HOME/Library/LaunchAgents"
+    PLIST_FILE="$PLIST_DIR/${LABEL}.plist"
+
+    if [[ "$ACTION" == "uninstall" ]]; then
+        if launchctl print "$SERVICE" >/dev/null 2>&1; then
+            launchctl bootout "$SERVICE" >/dev/null 2>&1 || true
+        fi
+        rm -f "$PLIST_FILE"
+        ok "safehoused LaunchAgent removed ($SERVICE)"
+        exit 0
+    fi
+
+    # install
+    mkdir -p "$PLIST_DIR" "$(dirname "$RESOLVED_LOG")"
+    render_launchd_plist "$LABEL" "$WORKDIR" "$RESOLVED_LOG" "$RESOLVED_SOCKET" "$RESOLVED_CONFIG" "${ARGV[@]}" > "$PLIST_FILE"
+    echo "Launchd label:  $LABEL"
+    echo "Launchd plist:  $PLIST_FILE"
+
+    if launchctl print "$SERVICE" >/dev/null 2>&1; then
+        launchctl bootout "$SERVICE" >/dev/null 2>&1 || true
+    fi
+    BOOTSTRAP_ERR="$(mktemp)"
+    if ! launchctl bootstrap "$DOMAIN" "$PLIST_FILE" 2>"$BOOTSTRAP_ERR"; then
+        err "launchctl bootstrap failed for $SERVICE:"
+        cat "$BOOTSTRAP_ERR" >&2 2>/dev/null || true
+        rm -f "$BOOTSTRAP_ERR"
+        exit 1
+    fi
+    rm -f "$BOOTSTRAP_ERR"
+    launchctl kickstart -k "$SERVICE" >/dev/null 2>&1 || true
+    ok "safehoused installed + started under launchd ($SERVICE)."
+    echo "Verify with:    ./.loom/scripts/cli/safehoused-service.sh status"
+    echo "Then confirm:   loom-daemon status   (Safehouse: line should read 'connected')"
+    exit 0
+fi
+
+# ---------------- Linux: systemd --user ----------------
+if ! command -v systemctl >/dev/null 2>&1; then
+    err "systemctl not found — this script supervises via systemd --user on Linux."
+    exit 2
+fi
+if ! systemd_user_manager_reachable; then
+    err "systemd --user manager is not reachable (no XDG_RUNTIME_DIR / no active user session)."
+    err "On a headless host, enable lingering first: loginctl enable-linger \"\$USER\""
+    exit 2
+fi
+UNIT_DIR="$(resolve_systemd_unit_dir)"
+UNIT_PATH="${UNIT_DIR}/${UNIT}"
+
+if [[ "$ACTION" == "uninstall" ]]; then
+    systemctl --user disable --now "$UNIT" >/dev/null 2>&1 || true
+    rm -f "$UNIT_PATH"
+    systemctl --user daemon-reload >/dev/null 2>&1 || true
+    ok "safehoused systemd --user unit removed ($UNIT)"
+    exit 0
+fi
+
+# install
+mkdir -p "$UNIT_DIR" "$(dirname "$RESOLVED_LOG")"
+render_systemd_unit "$WORKDIR" "$RESOLVED_LOG" "$RESOLVED_SOCKET" "$RESOLVED_CONFIG" "$EXEC_LINE" > "$UNIT_PATH"
+echo "Systemd unit:   $UNIT_PATH"
+systemctl --user daemon-reload >/dev/null 2>&1 || true
+if ! systemctl --user enable --now "$UNIT" >/dev/null 2>&1; then
+    err "systemctl --user enable --now failed for $UNIT."
+    exit 1
+fi
+ok "safehoused installed + started under systemd --user ($UNIT)."
+warn "Reboot survival on a headless host requires: loginctl enable-linger \"\$USER\""
+echo "Verify with:    ./.loom/scripts/cli/safehoused-service.sh status"
+echo "Then confirm:   loom-daemon status   (Safehouse: line should read 'connected')"
+exit 0

--- a/defaults/scripts/tests/test-safehoused-service.sh
+++ b/defaults/scripts/tests/test-safehoused-service.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# test-safehoused-service.sh — Tests for safehoused-service.sh (issue #4346).
+#
+# Focus: the PURE, side-effect-free surface — the --print-plist / --print-unit
+# preview modes and parameter resolution (bin / exec / socket / config / log /
+# label / unit + precedence). The install / uninstall paths drive real
+# launchctl / systemctl and are exercised manually per the issue's test plan;
+# here we prove the rendered definitions are valid and that preview never
+# touches the filesystem.
+#
+# Style matches test-loom-daemon-start.sh — plain bash, hand-rolled assertions.
+# Bats is NOT used in this repository.
+#
+# Usage:
+#   ./defaults/scripts/tests/test-safehoused-service.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SVC_SCRIPT="$(cd "$SCRIPT_DIR/../cli" && pwd)/safehoused-service.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" == *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} $msg"
+        echo -e "  expected to contain: [$needle]"
+        echo -e "  actual: [$haystack]"
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" != *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} $msg"
+        echo -e "  expected NOT to contain: [$needle]"
+    fi
+}
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} $msg"
+        echo -e "  expected: [$expected]"
+        echo -e "  actual:   [$actual]"
+    fi
+}
+
+# ---------- fixture ----------
+# Isolated HOME so nothing touches the real ~/Library/LaunchAgents or config,
+# and no repo config-resolver interference with the socket precedence tests.
+FAKE_HOME="$(mktemp -d)"
+trap 'rm -rf "$FAKE_HOME"' EXIT
+FAKE_BIN="$FAKE_HOME/safehoused"
+: > "$FAKE_BIN"
+chmod +x "$FAKE_BIN"
+
+# Run the script from a directory with no .loom so config resolution is a no-op
+# (isolates env/flag precedence from any ambient repo config). --socket is the
+# highest-precedence source, so socket tests pass it explicitly.
+run() {
+    ( cd "$FAKE_HOME" && HOME="$FAKE_HOME" bash "$SVC_SCRIPT" "$@" )
+}
+
+# ============================================================================
+# --print-plist
+# ============================================================================
+plist="$(run --print-plist --bin "$FAKE_BIN" --socket /run/safehoused.sock 2>/dev/null)"
+assert_contains "$plist" "<string>$FAKE_BIN</string>" "plist ProgramArguments carries the resolved binary"
+assert_contains "$plist" "com.rjwalters.safehoused" "plist uses the default LaunchAgent label"
+assert_contains "$plist" "<key>RunAtLoad</key>" "plist sets RunAtLoad (starts on login / reboot)"
+# KeepAlive is a bare <true/> (persistent daemon), NOT the SuccessfulExit dict.
+assert_contains "$plist" "<key>KeepAlive</key>"$'\n'"    <true/>" "plist KeepAlive=true (persistent, no clean-exit primitive)"
+assert_not_contains "$plist" "SuccessfulExit" "plist does NOT use loom-daemon's SuccessfulExit policy"
+assert_contains "$plist" "<key>SAFEHOUSED_SOCKET</key>"$'\n'"        <string>/run/safehoused.sock</string>" "plist bakes SAFEHOUSED_SOCKET from --socket"
+
+# plutil validation (macOS only).
+if command -v plutil >/dev/null 2>&1; then
+    echo "$plist" > "$FAKE_HOME/rendered.plist"
+    if plutil -lint "$FAKE_HOME/rendered.plist" >/dev/null 2>&1; then
+        assert_eq "ok" "ok" "rendered plist passes plutil -lint"
+    else
+        assert_eq "ok" "fail" "rendered plist passes plutil -lint"
+    fi
+fi
+
+# ============================================================================
+# --print-unit
+# ============================================================================
+unit="$(run --print-unit --bin "$FAKE_BIN" --socket /run/safehoused.sock --config /etc/safehoused.toml 2>/dev/null)"
+assert_contains "$unit" "ExecStart=$FAKE_BIN" "unit ExecStart carries the resolved binary"
+assert_contains "$unit" "Restart=always" "unit Restart=always (persistent-daemon supervision)"
+assert_contains "$unit" "RestartSec=5" "unit bounds relaunch rate with RestartSec"
+assert_contains "$unit" "WantedBy=default.target" "unit WantedBy=default.target (enabled starts on login)"
+assert_contains "$unit" "Environment=SAFEHOUSED_SOCKET=/run/safehoused.sock" "unit bakes SAFEHOUSED_SOCKET"
+assert_contains "$unit" "Environment=SAFEHOUSED_CONFIG=/etc/safehoused.toml" "unit bakes SAFEHOUSED_CONFIG"
+assert_not_contains "$unit" "on-success" "unit does NOT use loom-daemon's Restart=on-success policy"
+
+# ============================================================================
+# --exec override drives ExecStart / ProgramArguments
+# ============================================================================
+unit_exec="$(run --print-unit --exec "$FAKE_BIN --config /x.toml --verbose" 2>/dev/null)"
+assert_contains "$unit_exec" "ExecStart=$FAKE_BIN --config /x.toml --verbose" "--exec overrides the ExecStart line verbatim"
+plist_exec="$(run --print-plist --exec "$FAKE_BIN --verbose" 2>/dev/null)"
+assert_contains "$plist_exec" "<string>$FAKE_BIN</string>"$'\n'"        <string>--verbose</string>" "--exec splits into ProgramArguments array entries"
+
+# ============================================================================
+# custom label / unit / log
+# ============================================================================
+plist_lbl="$(run --print-plist --bin "$FAKE_BIN" --label com.example.sh --log /tmp/x.log 2>/dev/null)"
+assert_contains "$plist_lbl" "<string>com.example.sh</string>" "--label overrides the LaunchAgent label"
+assert_contains "$plist_lbl" "<string>/tmp/x.log</string>" "--log overrides the plist log path"
+unit_u="$(run --print-unit --bin "$FAKE_BIN" --unit shd.service 2>/dev/null)"
+# The unit name is not embedded in the rendered file, but the script must accept
+# the flag and still render a valid unit.
+assert_contains "$unit_u" "ExecStart=$FAKE_BIN" "--unit is accepted and the unit still renders"
+
+# ============================================================================
+# placeholder fallback when no binary is found (still exits 0, valid preview)
+# ============================================================================
+ph_out="$(env -u SAFEHOUSED_BIN bash "$SVC_SCRIPT" --print-unit 2>/dev/null; echo "rc=$?")"
+assert_contains "$ph_out" "ExecStart=/path/to/safehoused" "missing-binary preview falls back to a placeholder ExecStart"
+assert_contains "$ph_out" "rc=0" "missing-binary preview still exits 0 (no side effects)"
+
+# ============================================================================
+# no side effects: preview never writes a plist / unit to disk
+# ============================================================================
+run --print-plist --bin "$FAKE_BIN" >/dev/null 2>&1
+run --print-unit --bin "$FAKE_BIN" >/dev/null 2>&1
+if [[ ! -e "$FAKE_HOME/Library/LaunchAgents" && ! -e "$FAKE_HOME/.config/systemd/user" ]]; then
+    assert_eq "clean" "clean" "preview modes create no LaunchAgents / systemd unit files"
+else
+    assert_eq "clean" "dirty" "preview modes create no LaunchAgents / systemd unit files"
+fi
+
+# ============================================================================
+# help + error handling
+# ============================================================================
+help_out="$(bash "$SVC_SCRIPT" --help 2>/dev/null)"
+assert_contains "$help_out" "OWNERSHIP DECISION" "--help documents the service-wrapper ownership decision"
+assert_contains "$help_out" "--print-plist" "--help documents the preview modes"
+
+badflag_rc=0
+bash "$SVC_SCRIPT" --nonsense >/dev/null 2>&1 || badflag_rc=$?
+assert_eq "1" "$badflag_rc" "unknown flag exits 1"
+
+# ---------- summary ----------
+echo ""
+echo "Tests run: $TESTS_RUN, passed: $TESTS_PASSED, failed: $TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]


### PR DESCRIPTION
## Summary

Delivers the **provisioning half** of new-host safehouse onboarding (issue #4346, split from #4345): a repeatable path that registers `safehoused` as a **supervised service** on an interactive host, so the host actually joins the fleet room and #4028 peer-claim coordination works. Builds on #4345/#4362, which added the `loom-daemon status` `Safehouse:` line that this path ends by verifying reads `connected`.

New `defaults/scripts/cli/safehoused-service.sh` mirrors `loom-daemon-start.sh`'s own supervised-service pattern — a launchd LaunchAgent on macOS, a `systemd --user` unit on Linux — including side-effect-free `--print-plist` / `--print-unit` preview modes, plus `install` / `uninstall` / `status` subcommands.

## Design decision: service-wrapper ownership (required by AC3)

**The wrapper lives in THIS repo (`loom`), and is deliberately safehoused-agnostic; the authoritative service definition remains owned by the external `rjwalters/safehouse` repo.**

Rationale: only the safehouse repo knows safehoused's real ExecStart argv, config schema, and key-backup / steady-state teardown semantics (`Backups::wait_for_steady_state`). Vendoring those here would rot the moment the external repo changes them. So this wrapper only **supervises an operator-supplied binary** (`--bin` / `--exec`), resolves the socket via the same `safehouse.socket` → `$LOOM_SAFEHOUSE_SOCKET` → `$SAFEHOUSED_SOCKET` chain the daemon uses, and bakes a **minimal, non-secret** environment (`SAFEHOUSED_SOCKET` / `SAFEHOUSED_CONFIG` when provided; never a forwarded token). This honors the issue's stated bias ("safehouse repo owning its own service files, with this repo's runbook pointing at them") while still giving loom a concrete, testable mechanic today: if/when the safehouse repo ships its own service files, the runbook points at those and this generator remains the documented fallback. The decision is also recorded in the script header and in the new `safehouse.md` subsection.

Note: this supersedes the placeholder follow-up #4359 ("service wrapper + install step"), which the onboarding runbook previously referenced as unbuilt.

## Changes

- **`defaults/scripts/cli/safehoused-service.sh`** (new) — supervised-service wrapper. Preview (`--print-plist`/`--print-unit`), `install`/`uninstall`/`status`. Params (flag > env > config > default): `--bin`/`--exec`/`--socket`/`--config`/`--log`/`--label`/`--unit`. Reuses `lib/launchd-domain.sh`, `lib/systemd-user.sh`, and `lib/mcp-config.sh`'s socket resolver. Installs automatically into consumer `.loom/scripts/cli/` via the existing recursive `defaults/scripts/` copy (no manifest edit).
- **`.loom/docs/safehouse.md`** — rewrote onboarding step 3 to register via the wrapper (with the manual `nohup` path kept as debug fallback), and added a `### Supervised service wrapper` subsection documenting the command surface, parameter precedence, the supervision-policy divergence, and the ownership decision.
- **`defaults/scripts/tests/test-safehoused-service.sh`** (new) — 25 assertions.

### Supervision policy (deliberately unlike `loom-daemon`'s)

`loom-daemon` uses `KeepAlive:{SuccessfulExit:true}` / `Restart=on-success` because it has a clean-exit restart *primitive*. `safehoused` has none — it is a persistent connection daemon that should stay up — so the wrapper renders `KeepAlive=true` (launchd) / `Restart=always` + `RestartSec=5` (systemd). Reboot survival on headless Linux additionally needs `loginctl enable-linger`, surfaced by `install`.

## Acceptance Criteria Verification

- [x] **Repeatable zero-to-connected path ending at `loom-daemon status` = `connected`** — onboarding runbook steps 1–7; step 7 verifies the `Safehouse:` line reads `connected` (the line added by #4362).
- [x] **safehoused registered as a supervised service surviving reboot** — launchd `RunAtLoad`+`KeepAlive` / systemd `WantedBy=default.target`+`Restart=always`; reboot-survival caveat (`enable-linger`) documented and surfaced.
- [x] **Ownership decision recorded in the PR description** — above, plus script header and `safehouse.md`.
- [x] **Runbook section covers the full path + verification** — `safehouse.md` New-host onboarding + the new wrapper subsection.

## Test Plan

- [x] Preview modes produce valid definitions without side effects — `--print-plist` validated via `plutil -lint`; `--print-unit` asserted; a dedicated test proves preview writes no files.
- [x] `test-safehoused-service.sh` — 25/25 pass (preview rendering, `--bin`/`--exec`/`--socket`/`--config`/`--log`/`--label`/`--unit`, placeholder fallback, help/ownership text, unknown-flag exit 1).
- [x] `shellcheck` clean on both new scripts.
- [ ] Manual: fresh-host walkthrough of the runbook ends `connected`; service survives logout/reboot per platform (requires a real safehoused deployment — out of CI scope, per the issue's manual test-plan item).

Closes #4346