### PR TITLE
fix(daemon): --from-config composes with --work-finder/--health-gate instead of silently ignoring them

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -2553,6 +2553,11 @@ process:
 # Enable strictly per .loom/config.json → autonomous (no env forcing):
 ./.loom/scripts/cli/loom-daemon-start.sh --from-config
 
+# --from-config COMPOSES with an explicit flag (#4353): the named loop is
+# forced, the other is left for config to drive:
+./.loom/scripts/cli/loom-daemon-start.sh --from-config --work-finder      # force finder ON, gate config-driven
+./.loom/scripts/cli/loom-daemon-start.sh --from-config --no-health-gate   # force gate OFF, finder config-driven
+
 # Explicit-off / foreground variants:
 ./.loom/scripts/cli/loom-daemon-start.sh --no-work-finder   # force finder off (explicit; same as default)
 ./.loom/scripts/cli/loom-daemon-start.sh --no-health-gate   # force gate off (explicit; same as default)
@@ -2568,9 +2573,13 @@ process:
   and `LOOM_MAIN_HEALTH_GATE=0`, so a plain start is a **reliability daemon** that
   does **not** auto-dispatch sweeps — consistent with the ecosystem-wide opt-in /
   default-off contract. An already-exported env var always wins; `--work-finder`
-  / `--health-gate` force the respective loop on; `--from-config` leaves both
-  unset so `.loom/config.json → autonomous` drives (precedence env > config >
-  default),
+  / `--health-gate` force the respective loop on; `--from-config` alone leaves
+  both unset so `.loom/config.json → autonomous` drives (precedence env >
+  config > default). **`--from-config` composes with an explicit flag rather
+  than ignoring it (#4353)**: `--from-config --work-finder` (or
+  `--no-work-finder`/`--health-gate`/`--no-health-gate`) still FORCES that one
+  var while leaving the other loop unset for config to drive — a
+  pre-exported env var still wins over the forced flag,
 - locates the `loom-daemon` binary (`LOOM_DAEMON_BIN` → `PATH` → `target/{release,debug}`),
 - runs the **advisory** host-sleep check (`check-host-sleep.sh`, #3350) — never blocks the start,
 - **on macOS, backgrounds the daemon as a launchd LaunchAgent** in the resolved

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -68,6 +68,8 @@
 #   ./.loom/scripts/cli/loom-daemon-start.sh --from-config   Enable per .loom/config.json only
 #   ./.loom/scripts/cli/loom-daemon-start.sh --no-work-finder    Force work finder OFF (explicit)
 #   ./.loom/scripts/cli/loom-daemon-start.sh --no-health-gate    Force health gate OFF (explicit)
+#   ./.loom/scripts/cli/loom-daemon-start.sh --from-config --work-finder   Config-driven, but FORCE the work finder on (#4353)
+#   ./.loom/scripts/cli/loom-daemon-start.sh --from-config --no-health-gate   Config-driven, but FORCE the health gate off (#4353)
 #   ./.loom/scripts/cli/loom-daemon-start.sh --foreground    Run in the foreground (no PID file)
 #   ./.loom/scripts/cli/loom-daemon-start.sh --no-launchd    macOS only: use legacy nohup instead of a LaunchAgent
 #   ./.loom/scripts/cli/loom-daemon-start.sh --no-systemd    Linux only: use legacy nohup instead of a systemd --user service
@@ -79,6 +81,7 @@
 #   LOOM_DAEMON_BIN     Path to the loom-daemon binary (else auto-detected)
 #   LOOM_SOCKET_PATH    Override the daemon socket (default ~/.loom/loom-daemon.sock)
 #   LOOM_WORK_FINDER / LOOM_MAIN_HEALTH_GATE  Respected when already exported
+#                        (always wins, even under --from-config -- #4353)
 #   LOOM_DAEMON_LAUNCHD  macOS only: 0/false/no forces the legacy nohup path (same as --no-launchd)
 #   LOOM_DAEMON_SYSTEMD  Linux only: 0/false/no forces the legacy nohup path (same as --no-systemd)
 #   LOOM_SYSTEMD_UNIT    Linux only: override the systemd --user unit name (default loom-daemon.service)
@@ -699,8 +702,14 @@ ORIGINAL_ARGS=("$@")
 # --health-gate, or hand control to config with --from-config.
 FROM_CONFIG=false
 FOREGROUND=false
-WANT_WORK_FINDER=false
-WANT_HEALTH_GATE=false
+# Tri-state (#4353): "" = not passed on the CLI (unset), "on" = an explicit
+# --work-finder/--health-gate, "off" = an explicit --no-work-finder/
+# --no-health-gate. This lets --from-config tell "the operator asked to force
+# this loop" apart from "the operator said nothing, config drives it" --
+# a plain boolean collapsed both to the same false and silently dropped the
+# force.
+WANT_WORK_FINDER=""
+WANT_HEALTH_GATE=""
 NO_LAUNCHD=false
 NO_SYSTEMD=false
 PRINT_PLIST=false
@@ -710,10 +719,10 @@ while [[ $# -gt 0 ]]; do
         --help|-h) show_help; exit 0 ;;
         --from-config) FROM_CONFIG=true; shift ;;
         --foreground|--fg) FOREGROUND=true; shift ;;
-        --work-finder) WANT_WORK_FINDER=true; shift ;;
-        --health-gate) WANT_HEALTH_GATE=true; shift ;;
-        --no-work-finder) WANT_WORK_FINDER=false; shift ;;
-        --no-health-gate) WANT_HEALTH_GATE=false; shift ;;
+        --work-finder) WANT_WORK_FINDER="on"; shift ;;
+        --health-gate) WANT_HEALTH_GATE="on"; shift ;;
+        --no-work-finder) WANT_WORK_FINDER="off"; shift ;;
+        --no-health-gate) WANT_HEALTH_GATE="off"; shift ;;
         --no-launchd) NO_LAUNCHD=true; shift ;;
         --no-systemd) NO_SYSTEMD=true; shift ;;
         --print-plist) PRINT_PLIST=true; shift ;;
@@ -817,6 +826,15 @@ fi
 # (LOOM_WORK_FINDER unset => off, LOOM_MAIN_HEALTH_GATE unset => off). Opt in with
 # --work-finder / --health-gate (force the var to 1), or pass --from-config to
 # leave both unset so .loom/config.json -> autonomous drives.
+#
+# --from-config COMPOSES with --work-finder/--health-gate/--no-work-finder/
+# --no-health-gate rather than ignoring them (#4353): --from-config alone still
+# leaves both vars unset for config to drive (byte-for-byte the pre-#4353
+# behavior — test case 6 asserts this stays green); pairing it with an
+# explicit --work-finder / --no-work-finder additionally FORCES that one var
+# (same env-var-wins-if-already-exported rule), while the loop with no
+# explicit flag is still left to config. So `--from-config --work-finder`
+# forces LOOM_WORK_FINDER=1 and leaves LOOM_MAIN_HEALTH_GATE unset.
 export LOOM_WORKSPACE="${LOOM_WORKSPACE:-$REPO_ROOT}"
 
 # ---------- guard-hook autonomy defaults (#3898) ----------
@@ -838,17 +856,44 @@ export LOOM_GUARD_DECISION_LOG="${LOOM_GUARD_DECISION_LOG:-1}"
 export LOOM_FORCE_SCOPE="${LOOM_FORCE_SCOPE:-protected}"
 
 if [[ "$FROM_CONFIG" == "true" ]]; then
-    echo -e "${BOLD}Autonomous mode: driven by .loom/config.json -> autonomous (env not forced)${NC}"
+    # Compose (#4353): --from-config alone leaves BOTH vars unset for config to
+    # drive. An explicit --work-finder/--no-work-finder (or the health-gate
+    # equivalent) additionally FORCES that one var -- using the
+    # ${VAR:-default} form so an already-exported env var still wins over the
+    # CLI flag, exactly like the non-config branch below. The loop with no
+    # explicit flag is left untouched (stays unset, config drives it).
+    FORCED_DESC=()
+    if [[ "$WANT_WORK_FINDER" == "on" ]]; then
+        export LOOM_WORK_FINDER="${LOOM_WORK_FINDER:-1}"
+        FORCED_DESC+=("work_finder=${LOOM_WORK_FINDER}")
+    elif [[ "$WANT_WORK_FINDER" == "off" ]]; then
+        export LOOM_WORK_FINDER="${LOOM_WORK_FINDER:-0}"
+        FORCED_DESC+=("work_finder=${LOOM_WORK_FINDER}")
+    fi
+    if [[ "$WANT_HEALTH_GATE" == "on" ]]; then
+        export LOOM_MAIN_HEALTH_GATE="${LOOM_MAIN_HEALTH_GATE:-1}"
+        FORCED_DESC+=("main_health_gate=${LOOM_MAIN_HEALTH_GATE}")
+    elif [[ "$WANT_HEALTH_GATE" == "off" ]]; then
+        export LOOM_MAIN_HEALTH_GATE="${LOOM_MAIN_HEALTH_GATE:-0}"
+        FORCED_DESC+=("main_health_gate=${LOOM_MAIN_HEALTH_GATE}")
+    fi
+    if [[ "${#FORCED_DESC[@]}" -eq 0 ]]; then
+        echo -e "${BOLD}Autonomous mode: driven by .loom/config.json -> autonomous (env not forced)${NC}"
+    else
+        FORCED_JOINED="$(IFS=', '; echo "${FORCED_DESC[*]}")"
+        echo -e "${BOLD}Autonomous mode: config-driven; forced: ${FORCED_JOINED}${NC}"
+    fi
+    unset FORCED_DESC FORCED_JOINED
 else
     # An already-exported env var always wins. Otherwise --work-finder /
     # --health-gate force the loop ON (=1); the default (flags off) forces it
     # OFF (=0), so a plain start is a reliability daemon that never auto-dispatches.
-    if [[ "$WANT_WORK_FINDER" == "true" ]]; then
+    if [[ "$WANT_WORK_FINDER" == "on" ]]; then
         export LOOM_WORK_FINDER="${LOOM_WORK_FINDER:-1}"
     else
         export LOOM_WORK_FINDER="${LOOM_WORK_FINDER:-0}"
     fi
-    if [[ "$WANT_HEALTH_GATE" == "true" ]]; then
+    if [[ "$WANT_HEALTH_GATE" == "on" ]]; then
         export LOOM_MAIN_HEALTH_GATE="${LOOM_MAIN_HEALTH_GATE:-1}"
     else
         export LOOM_MAIN_HEALTH_GATE="${LOOM_MAIN_HEALTH_GATE:-0}"

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -87,6 +87,47 @@ assert_eq "FAKE_DAEMON WF=[] HG=[]" "$out" "--from-config leaves both env vars u
 out=$( ( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --no-work-finder --foreground 2>/dev/null ) | grep '^FAKE_DAEMON' )
 assert_eq "FAKE_DAEMON WF=[0] HG=[0]" "$out" "--no-work-finder forces finder off"
 
+# ---------- --from-config composition (#4353) ----------
+# --from-config used to be a strict either/or: it never looked at
+# --work-finder/--health-gate at all, so pairing it with an explicit flag
+# silently dropped the flag. It must now COMPOSE: the named loop is forced,
+# the other loop is left unset for config to drive.
+
+# 7a. --from-config --work-finder forces the finder ON, leaves the gate unset
+#     for config to drive.
+out=$( ( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --from-config --work-finder --foreground 2>/dev/null ) | grep '^FAKE_DAEMON' )
+assert_eq "FAKE_DAEMON WF=[1] HG=[]" "$out" "--from-config --work-finder forces finder ON, gate stays config-driven (#4353)"
+
+# 7b. --from-config --no-work-finder forces the finder OFF, gate stays unset.
+out=$( ( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --from-config --no-work-finder --foreground 2>/dev/null ) | grep '^FAKE_DAEMON' )
+assert_eq "FAKE_DAEMON WF=[0] HG=[]" "$out" "--from-config --no-work-finder forces finder OFF, gate stays config-driven (#4353)"
+
+# 7c. --from-config --health-gate forces the gate ON, finder stays unset.
+out=$( ( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --from-config --health-gate --foreground 2>/dev/null ) | grep '^FAKE_DAEMON' )
+assert_eq "FAKE_DAEMON WF=[] HG=[1]" "$out" "--from-config --health-gate forces gate ON, finder stays config-driven (#4353)"
+
+# 7d. --from-config --no-health-gate forces the gate OFF, finder stays unset.
+out=$( ( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --from-config --no-health-gate --foreground 2>/dev/null ) | grep '^FAKE_DAEMON' )
+assert_eq "FAKE_DAEMON WF=[] HG=[0]" "$out" "--from-config --no-health-gate forces gate OFF, finder stays config-driven (#4353)"
+
+# 7e. A pre-exported env var still wins over the forced flag under
+#     --from-config (env > CLI flag, same precedence as the non-config path).
+out=$( ( cd "$WORKDIR" && env -u LOOM_MAIN_HEALTH_GATE LOOM_WORK_FINDER=1 LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --from-config --no-work-finder --foreground 2>/dev/null ) | grep '^FAKE_DAEMON' )
+assert_eq "FAKE_DAEMON WF=[1] HG=[]" "$out" "pre-exported LOOM_WORK_FINDER=1 wins over --from-config --no-work-finder (#4353)"
+
+# 7f. The startup banner names the forced loop and never prints the
+#     "env not forced" wording when something WAS forced.
+banner_out=$( ( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --from-config --work-finder --foreground 2>&1 ) )
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$banner_out" | grep -q 'forced: work_finder=1' && ! echo "$banner_out" | grep -q 'env not forced'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} startup banner names the forced loop, never prints 'env not forced' when something was forced (#4353)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} startup banner names the forced loop, never prints 'env not forced' when something was forced (#4353)"
+    echo "  output: $banner_out"
+fi
+
 # 8. --help mentions the FLAGS-OFF default and the opt-in flags.
 help_out=$(bash "$START_SCRIPT" --help 2>/dev/null)
 TESTS_RUN=$((TESTS_RUN + 1))


### PR DESCRIPTION
## Summary

Closes #4353

`defaults/scripts/cli/loom-daemon-start.sh`'s env-composition block was a
strict either/or: when `--from-config` was passed, the script never looked
at `WANT_WORK_FINDER`/`WANT_HEALTH_GATE` at all, so `--from-config
--work-finder`/`--no-work-finder`/`--health-gate`/`--no-health-gate` were
silently dropped — the loop stayed fully config-driven even though the
operator explicitly asked to force it.

### Fix

- Converted `WANT_WORK_FINDER`/`WANT_HEALTH_GATE` to tri-state (`""` =
  unset/not-passed, `"on"`, `"off"`) instead of a boolean that collapsed
  "not passed" and "explicit off" to the same value.
- In the `FROM_CONFIG=true` branch: an explicit `--work-finder`/
  `--no-work-finder` (or the health-gate equivalent) now forces that ONE var
  using the `${VAR:-default}` form (so an already-exported env var still
  wins), while the loop with no explicit flag is left untouched (stays
  unset, config drives it). Plain `--from-config` alone is unchanged —
  leaves both vars unset (existing test case 6 stays green).
- Startup banner now names what was forced, e.g. `Autonomous mode:
  config-driven; forced: work_finder=1`, and never prints the misleading
  "env not forced" wording when something WAS forced.
- Updated the header usage block, the precedence comment, and
  `defaults/docs/daemon-reference.md`'s "`--from-config` leaves both"
  wording to describe the composed semantics.
- `.daemon.flags` persistence (`ORIGINAL_ARGS`-based, ie. issue #3968) is
  untouched — it already stores the raw CLI args verbatim, so
  `loom-daemon-update.sh`'s replay automatically reproduces the composed
  behavior once composition is correct at start time. Verified manually
  (see test plan) rather than re-running the update-suite (which has a
  known live hazard against the production `loom-daemon` binary).

Did **not** implement the "reject the combination" alternative — composition
is the fix the issue calls for.

## Test plan

- [x] `bash defaults/scripts/tests/test-loom-daemon-start.sh` — all 46 tests
      pass, including 6 new cases:
  - `--from-config --work-finder` → `LOOM_WORK_FINDER=1`, gate unset
  - `--from-config --no-work-finder` → `LOOM_WORK_FINDER=0`, gate unset
  - `--from-config --health-gate` → `LOOM_MAIN_HEALTH_GATE=1`, finder unset
  - `--from-config --no-health-gate` → `LOOM_MAIN_HEALTH_GATE=0`, finder unset
  - pre-exported `LOOM_WORK_FINDER=1` wins over `--from-config
    --no-work-finder`
  - startup banner names the forced loop, never prints "env not forced" when
    something was forced
  - existing test case 6 (plain `--from-config` leaves both unset) stays green
- [x] `bash -n` syntax check
- [x] Manual check: `--from-config --work-finder --foreground` persists
      `--from-config` + `--work-finder` verbatim to `.daemon.flags` (the
      exact args `loom-daemon-update.sh` replays on restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)