### PR TITLE
fix(daemon): stop misdiagnosing prior-boot heartbeats as a wedge

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -2703,7 +2703,8 @@ service's exit code affects the next scheduled run.
 | Marker | Reality | Watchdog |
 |--------|---------|----------|
 | present | daemon alive, heartbeat fresh | silent (OK) |
-| present | daemon alive, heartbeat **stale** | **report** — daemon may be wedged |
+| present | daemon alive, heartbeat **stale**, written this boot (younger than the process) | **report** — daemon may be wedged |
+| present | daemon alive, heartbeat **older than the process itself** (#4368: a previous-boot/enablement leftover) | silent (liveness-only; not evidence about the current process) |
 | present | daemon alive, no heartbeat file | silent (liveness-only; heartbeat disabled or not yet written) |
 | present | daemon **not loaded/alive** | **report** — the #4011 outage |
 | **absent** | **nothing running** | silent — deliberate stop, no false page |
@@ -2791,7 +2792,27 @@ disagree, and reports one of four states with a distinct exit code:
 | `not-expected` | marker absent (deliberate stop, or never started) | `1` | suggest `loom-daemon-start.sh` |
 | `expected-but-dead` | marker present, no live process — the #4011 divergence | `3` | suggest `loom-daemon-start.sh`; points at `daemon-watchdog.log` |
 | `alive-starting` | marker present, process alive, IPC failed, **process age ≤ startup-grace window** — a normal `bootout`/`bootstrap` restart whose socket has not bound yet (#4213) | `4` | **none** — reports "still starting, not a fault"; NO stop/start remediation |
-| `alive-but-unresponsive` | marker present, process alive, IPC failed, process **older** than the grace window (or age undeterminable) | `4` | does **not** suggest a start (singleton guard refuses); prints the live pid; heartbeat freshness qualifies fresh ⇒ IPC/socket fault, stale ⇒ likely wedged |
+| `alive-but-unresponsive` | marker present, process alive, IPC failed, process **older** than the grace window (or age undeterminable) | `4` | does **not** suggest a start (singleton guard refuses); prints the live pid; heartbeat freshness qualifies fresh ⇒ IPC/socket fault, stale ⇒ likely wedged, **prior-boot** ⇒ not evidence about the current process |
+
+The heartbeat freshness qualifier on `alive-but-unresponsive` also gates the
+"do NOT run `loom-daemon-start.sh` … stop && start" remediation (#4368): it is
+only printed for a **current-boot `stale`** verdict — heartbeat age exceeds
+the staleness threshold *and* is younger than the process's own age, i.e. the
+evidence actually points at a wedge. `fresh` / `unknown` / **`prior-boot`**
+print inspect-first guidance (`ps -p <pid> -o pid,etime,command`, `loom-daemon
+status --json`) instead of the imperative restart, since none of those three
+qualifiers indicate a fault. `prior-boot` fires when the heartbeat file's mtime
+is strictly older than the live process's own start time (`heartbeat_age_secs
+> process_age_secs`) — necessarily a leftover from a previous boot or a
+previous enablement of the opt-in heartbeat loop, checked *before* the
+staleness threshold (even a heartbeat that would otherwise look "fresh" by age
+alone is not current-boot evidence if it predates the process). Equal ages are
+deliberately **not** `prior-boot` (current-boot evidence, falls through to the
+ordinary threshold check); an undeterminable process age makes **no**
+prior-boot claim and degrades to the pre-#4368 fresh/stale verdicts.
+`loom-daemon-watchdog.sh` §3 mirrors the same mtime-vs-process-start
+comparison (via `ps -o etime= -p <pid>`) before its own stale WARN, so `status`
+and the watchdog log can never contradict each other on this qualifier either.
 
 The startup-grace window defaults to `90s` (sized above the observed ~40–60s
 socket-bind latency after a `launchctl bootout`/`bootstrap` cycle) and is

--- a/defaults/scripts/cli/loom-daemon-watchdog.sh
+++ b/defaults/scripts/cli/loom-daemon-watchdog.sh
@@ -161,6 +161,7 @@ detect_daemon_liveness() {
     liveness_detail=""
     job_loaded=false
     launchd_service=""
+    live_pid=""
     if [[ "$USE_LAUNCHD" == "true" ]] && command -v launchctl >/dev/null 2>&1; then
         # Resolve the domain (gui/<uid> ↦ user/<uid>, #4130) the same way the
         # start did, so a headless daemon in user/<uid> is probed correctly.
@@ -171,6 +172,7 @@ detect_daemon_liveness() {
         if [[ -n "$launchd_pid" ]] && kill -0 "$launchd_pid" 2>/dev/null; then
             daemon_alive=true
             liveness_detail="launchd job $launchd_service alive (pid $launchd_pid)"
+            live_pid="$launchd_pid"
         elif [[ "$launchd_print_rc" -eq 0 ]]; then
             job_loaded=true
             liveness_detail="launchd job $launchd_service is LOADED but NOT running (no live pid)"
@@ -184,6 +186,7 @@ detect_daemon_liveness() {
             if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
                 daemon_alive=true
                 liveness_detail="pid $pid (from $PID_FILE) alive"
+                live_pid="$pid"
             else
                 liveness_detail="pid file $PID_FILE present but pid not alive"
             fi
@@ -191,6 +194,44 @@ detect_daemon_liveness() {
             liveness_detail="no live pid file at ${PID_FILE:-<none>}"
         fi
     fi
+}
+
+# Parse a `ps -o etime=` duration ([[dd-]hh:]mm:ss) into whole seconds —
+# mirrors the Rust probe's `parse_etime` exactly (`daemon_install_state.rs`,
+# #4368) so the two never disagree on a process's age. Any unexpected shape
+# or non-numeric field fails (exit 1, nothing echoed) — the caller treats an
+# unparseable age as *unknown* and makes no prior-boot claim, never a false
+# one either way.
+parse_etime_secs() {
+    local raw days rest hours minutes seconds parts
+    raw="$(printf '%s' "${1:-}" | tr -d '[:space:]')"
+    [[ -z "$raw" ]] && return 1
+    days=0
+    rest="$raw"
+    if [[ "$raw" == *-* ]]; then
+        days="${raw%%-*}"
+        rest="${raw#*-}"
+        [[ "$days" =~ ^[0-9]+$ ]] || return 1
+    fi
+    IFS=':' read -r -a parts <<< "$rest"
+    case "${#parts[@]}" in
+        1) hours=0; minutes=0; seconds="${parts[0]}" ;;
+        2) hours=0; minutes="${parts[0]}"; seconds="${parts[1]}" ;;
+        3) hours="${parts[0]}"; minutes="${parts[1]}"; seconds="${parts[2]}" ;;
+        *) return 1 ;;
+    esac
+    [[ "$hours" =~ ^[0-9]+$ && "$minutes" =~ ^[0-9]+$ && "$seconds" =~ ^[0-9]+$ ]] || return 1
+    echo $(( days * 86400 + hours * 3600 + minutes * 60 + seconds ))
+}
+
+# Live process age in seconds via `ps -o etime= -p <pid>`, degrading to
+# nothing (no output, non-zero return) on any failure — the caller must never
+# turn an unknown age into a false prior-boot claim (#4368).
+process_age_secs() {
+    local pid="$1" etime
+    [[ -n "$pid" ]] || return 1
+    etime="$(ps -o etime= -p "$pid" 2>/dev/null)" || return 1
+    parse_etime_secs "$etime"
 }
 
 # ---------- 1. intent: is a daemon expected at all? ----------
@@ -337,6 +378,21 @@ if [[ -f "$HEARTBEAT_FILE" ]]; then
     if [[ "$mtime" =~ ^[0-9]+$ ]]; then
         now="$(date -u +%s)"
         age=$(( now - mtime ))
+        # Prior-boot detection (#4368): if this heartbeat file predates the
+        # live process's own start time, it is not evidence about the current
+        # process at all — necessarily left over from a previous boot (or a
+        # previous enablement of the opt-in heartbeat loop). Checked BEFORE
+        # the staleness threshold below, mirroring the Rust probe's
+        # `check_heartbeat` exactly (`daemon_install_state.rs`) so `status`
+        # and this watchdog can never contradict each other. Only claim this
+        # when the process age is actually known; an unparseable `ps` age
+        # degrades to the ordinary Stale/Fresh checks below rather than a
+        # false claim either way.
+        proc_age="$(process_age_secs "$live_pid" 2>/dev/null)" || proc_age=""
+        if [[ -n "$proc_age" ]] && (( age > proc_age )); then
+            report OK "daemon alive (${liveness_detail}); heartbeat ${HEARTBEAT_FILE} is from a PREVIOUS boot (${age}s old; this process is only ${proc_age}s old) — not evidence about the current process. Liveness-only OK; re-check after the process is well past startup if you still suspect a wedge."
+            exit 0
+        fi
         if (( age > STALE_SECS )); then
             report DIVERGENCE \
                 "Daemon process is alive (${liveness_detail}) but its heartbeat ${HEARTBEAT_FILE} is STALE (${age}s old > ${STALE_SECS}s threshold) — the daemon may be wedged. Inspect with 'loom-daemon status'; consider ./.loom/scripts/cli/loom-daemon-stop.sh && ...start.sh."

--- a/defaults/scripts/tests/test-loom-daemon-watchdog.sh
+++ b/defaults/scripts/tests/test-loom-daemon-watchdog.sh
@@ -91,6 +91,22 @@ log_hasi() { grep -qi "$1" "$WDLOG" 2>/dev/null; }
 # substitution pipe (which would otherwise block the caller for the full sleep).
 sleeper() { sleep 60 >/dev/null 2>&1 & echo $!; }
 
+# A `ps` stub that always reports a fixed `-o etime=` value (used by the
+# prior-boot heartbeat tests, #4368) — deterministic regardless of how long
+# the real sleeper process has actually been alive by the time the watchdog
+# runs. Prints the stub directory; add it to the FRONT of PATH via
+# `run_watchdog PATH="$(make_ps_stub ...):$PATH"`.
+make_ps_stub() { # <etime-value, e.g. "02:00:00">
+    local dir
+    dir="$(mktemp -d)"
+    cat > "$dir/ps" <<EOF
+#!/usr/bin/env bash
+echo "$1"
+EOF
+    chmod +x "$dir/ps"
+    echo "$dir"
+}
+
 # ===================================================================
 # 1. Marker ABSENT ⇒ no daemon expected ⇒ silent OK (exit 0).
 # ===================================================================
@@ -138,18 +154,55 @@ kill "$live_pid" 2>/dev/null || true
 assert_rc 0 "$RC" "alive + fresh heartbeat: exits 0"
 
 # ===================================================================
-# 3. Intent present, daemon ALIVE, heartbeat STALE ⇒ DIVERGENCE (wedged).
+# 3. Intent present, daemon ALIVE, heartbeat STALE (but written THIS boot,
+#    i.e. younger than the process itself) ⇒ DIVERGENCE (wedged).
+#    A `ps` stub pins the process age to 7200s — comfortably older than the
+#    3600s-old heartbeat — so this exercises the genuine current-boot-stale
+#    verdict deterministically, never the #4368 prior-boot path (which a
+#    freshly-spawned real sleeper pid would otherwise always hit, since its
+#    real age is far younger than any meaningfully back-dated heartbeat).
 # ===================================================================
+PS_STUB3="$(make_ps_stub "02:00:00")"
 live_pid=$(sleeper)
 echo "$live_pid" > "$WORKDIR/pidB"
 write_marker "$WORKDIR/pidB" 60
 printf 'old\n' > "$HEARTBEAT"
 back_date_file "$HEARTBEAT" 3600   # 1h old, well past the 300s default threshold
 : > "$WDLOG"
-run_watchdog
+run_watchdog PATH="$PS_STUB3:$PATH"
 kill "$live_pid" 2>/dev/null || true
-assert_rc 1 "$RC" "alive + STALE heartbeat: exits 1 (divergence)"
+assert_rc 1 "$RC" "alive + STALE heartbeat (current boot): exits 1 (divergence)"
 if log_has STALE; then pass "alive + stale heartbeat: reports it as wedged/stale"; else fail "alive + stale heartbeat: no STALE report"; fi
+rm -rf "$PS_STUB3"
+
+# ===================================================================
+# 3b. Intent present, daemon ALIVE, heartbeat OLDER than the process itself
+#     ⇒ liveness-only OK, NEVER a DIVERGENCE/STALE report (#4368). A `ps`
+#     stub pins the process age to 5s while the heartbeat is 3600s old —
+#     exactly the shape of the reported incident (a migrated/leftover
+#     heartbeat file from a previous boot outliving a fresh restart).
+# ===================================================================
+PS_STUB3B="$(make_ps_stub "00:00:05")"
+live_pid=$(sleeper)
+echo "$live_pid" > "$WORKDIR/pidB2"
+write_marker "$WORKDIR/pidB2" 60
+printf 'old\n' > "$HEARTBEAT"
+back_date_file "$HEARTBEAT" 3600
+: > "$WDLOG"
+run_watchdog PATH="$PS_STUB3B:$PATH"
+kill "$live_pid" 2>/dev/null || true
+assert_rc 0 "$RC" "alive + heartbeat older than process (prior boot): exits 0, not flagged as wedged"
+if log_hasi "previous boot"; then
+    pass "prior-boot heartbeat: reports it as a previous-boot file, not a wedge"
+else
+    fail "prior-boot heartbeat: missing the previous-boot report"
+fi
+if log_has DIVERGENCE; then
+    fail "prior-boot heartbeat: must NOT be reported as a DIVERGENCE"
+else
+    pass "prior-boot heartbeat: not reported as a DIVERGENCE"
+fi
+rm -rf "$PS_STUB3B"
 
 # ===================================================================
 # 4. Intent present, daemon DEAD ⇒ DIVERGENCE (expected but not running).
@@ -196,17 +249,21 @@ kill "$live_pid" 2>/dev/null || true
 assert_rc 0 "$RC" "heartbeat 120s old < 300s threshold: not flagged (no flapping)"
 
 # ===================================================================
-# 7. LOOM_DAEMON_HEARTBEAT_STALE_SECS override is honored.
+# 7. LOOM_DAEMON_HEARTBEAT_STALE_SECS override is honored. A `ps` stub pins
+#    the process age well past the 10s heartbeat age so this exercises the
+#    current-boot-stale verdict, not the #4368 prior-boot path.
 # ===================================================================
+PS_STUB7="$(make_ps_stub "00:01:00")"
 live_pid=$(sleeper)
 echo "$live_pid" > "$WORKDIR/pidF"
 write_marker "$WORKDIR/pidF" 60
 printf 'x\n' > "$HEARTBEAT"
 back_date_file "$HEARTBEAT" 10
 : > "$WDLOG"
-run_watchdog LOOM_DAEMON_HEARTBEAT_STALE_SECS=5
+run_watchdog PATH="$PS_STUB7:$PATH" LOOM_DAEMON_HEARTBEAT_STALE_SECS=5
 kill "$live_pid" 2>/dev/null || true
 assert_rc 1 "$RC" "STALE_SECS override: 10s-old heartbeat with 5s threshold is flagged"
+rm -rf "$PS_STUB7"
 
 # ===================================================================
 # 8. launchd path via a stubbed launchctl reporting the job is NOT loaded ⇒

--- a/loom-daemon/src/daemon_install_state.rs
+++ b/loom-daemon/src/daemon_install_state.rs
@@ -31,7 +31,10 @@
 //!    than the grace window (or its age is undeterminable) →
 //!    [`InstallState::AliveButUnresponsive`], qualified by heartbeat
 //!    freshness: fresh ⇒ likely an IPC/socket-layer fault, stale ⇒ likely a
-//!    wedged daemon.
+//!    wedged daemon, **prior-boot** (#4368) ⇒ the heartbeat file predates
+//!    this process's own start time and is therefore NOT evidence about the
+//!    current process (treated like `Unknown` for advice purposes — the
+//!    caller must not print the stop/start remediation for it).
 //!
 //! The startup-grace discriminator is **process age alone** (via
 //! `ps -o etime= -p <pid>`), never socket-file presence: the `Err` arm has
@@ -133,11 +136,17 @@ impl InstallState {
 /// sharpens "alive but not answering" into "likely an IPC fault" (fresh) vs
 /// "likely wedged" (stale). `Unknown` is a degradation (no heartbeat file,
 /// unreadable mtime, or heartbeat loop disabled) — never a false report.
+/// `PriorBoot` (#4368) is a distinct degradation: the heartbeat file's mtime
+/// predates the live process's own start time, so it is necessarily left
+/// over from a previous boot (or a previous enablement of the opt-in
+/// heartbeat loop) and carries NO evidence about the current process —
+/// never rendered as `Stale`/wedged.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HeartbeatFreshness {
     Fresh,
     Stale,
     Unknown,
+    PriorBoot,
 }
 
 impl HeartbeatFreshness {
@@ -147,6 +156,7 @@ impl HeartbeatFreshness {
             HeartbeatFreshness::Fresh => "fresh",
             HeartbeatFreshness::Stale => "stale",
             HeartbeatFreshness::Unknown => "unknown",
+            HeartbeatFreshness::PriorBoot => "prior-boot",
         }
     }
 }
@@ -547,13 +557,37 @@ fn heartbeat_age_secs(path: &Path) -> Option<u64> {
 /// Classify heartbeat freshness against the staleness threshold — mirrors
 /// the watchdog's degrade-don't-false-report rules: an absent file or an
 /// unreadable mtime both yield `Unknown`, never a false `Stale`.
+///
+/// `process_age_secs` (#4368) is the live process's own age, when known. A
+/// heartbeat file strictly older than the process's own start time predates
+/// this boot and is classified `PriorBoot` — checked *before* the staleness
+/// threshold, since even a heartbeat that would otherwise look "fresh" by
+/// age alone is not current-boot evidence if it is older than the process
+/// itself (e.g. a very recent restart with a leftover heartbeat file from
+/// seconds before it). Equal ages are deliberately NOT `PriorBoot` — a
+/// heartbeat written in the same instant as process start is still
+/// current-boot evidence, so it falls through to the ordinary threshold
+/// check. `None` (unparseable `ps` age) makes no prior-boot claim and
+/// degrades to the pre-#4368 Stale/Fresh verdicts, per the module's
+/// degrade-don't-false-report rule.
 fn check_heartbeat(
     heartbeat_file: &Path,
     stale_threshold_secs: u64,
+    process_age_secs: Option<u64>,
 ) -> (HeartbeatFreshness, Option<u64>) {
     match heartbeat_age_secs(heartbeat_file) {
-        Some(age) if age > stale_threshold_secs => (HeartbeatFreshness::Stale, Some(age)),
-        Some(age) => (HeartbeatFreshness::Fresh, Some(age)),
+        Some(age) => {
+            if let Some(proc_age) = process_age_secs {
+                if age > proc_age {
+                    return (HeartbeatFreshness::PriorBoot, Some(age));
+                }
+            }
+            if age > stale_threshold_secs {
+                (HeartbeatFreshness::Stale, Some(age))
+            } else {
+                (HeartbeatFreshness::Fresh, Some(age))
+            }
+        }
         None => (HeartbeatFreshness::Unknown, None),
     }
 }
@@ -570,9 +604,27 @@ fn resolve_stale_threshold(interval_secs: u64, env_override: Option<u64>) -> u64
 
 /// Pure(ish) classification given an already-resolved loom dir, marker path,
 /// and env overrides — split out from [`probe`] so tests can drive it against
-/// tempdir fixtures without touching real env vars or `~/.loom`.
+/// tempdir fixtures without touching real env vars or `~/.loom`. Always uses
+/// the real [`process_age_secs`] (`ps`-backed) lookup; see
+/// [`classify_with_process_age_fn`] for the injectable variant tests use to
+/// pin a deterministic process age.
 #[must_use]
 pub fn classify(loom_dir: &Path, marker_path: &Path, env: &EnvOverrides) -> InstallStateReport {
+    classify_with_process_age_fn(loom_dir, marker_path, env, process_age_secs)
+}
+
+/// [`classify`]'s implementation, parameterized over the process-age lookup.
+/// Production code always goes through [`classify`] (which passes the real
+/// `ps`-backed [`process_age_secs`]); tests use this directly with a fixed
+/// closure so heartbeat-vs-process-age comparisons (#4368) are deterministic
+/// — the test binary's own real uptime, shared across every unit test
+/// running in this one process, is not a value any single test can control.
+fn classify_with_process_age_fn(
+    loom_dir: &Path,
+    marker_path: &Path,
+    env: &EnvOverrides,
+    process_age_fn: impl Fn(u32) -> Option<u64>,
+) -> InstallStateReport {
     let watchdog_log_path = loom_dir.join("logs").join("daemon-watchdog.log");
 
     let contents = match std::fs::read_to_string(marker_path) {
@@ -613,7 +665,7 @@ pub fn classify(loom_dir: &Path, marker_path: &Path, env: &EnvOverrides) -> Inst
     // from the prior run may still exist during startup). An undeterminable
     // age makes no grace claim and falls through to the fault/wedged verdict.
     let grace_threshold = resolve_startup_grace(env.startup_grace_secs_override);
-    let process_age = liveness.pid.and_then(process_age_secs);
+    let process_age = liveness.pid.and_then(process_age_fn);
     if let Some(age) = process_age {
         if age <= grace_threshold {
             return InstallStateReport {
@@ -633,7 +685,7 @@ pub fn classify(loom_dir: &Path, marker_path: &Path, env: &EnvOverrides) -> Inst
 
     let stale_threshold =
         resolve_stale_threshold(fields.heartbeat_interval_secs, env.heartbeat_stale_secs_override);
-    let (freshness, age) = check_heartbeat(&fields.heartbeat_file, stale_threshold);
+    let (freshness, age) = check_heartbeat(&fields.heartbeat_file, stale_threshold, process_age);
 
     InstallStateReport {
         state: InstallState::AliveButUnresponsive,
@@ -773,7 +825,13 @@ mod tests {
                 heartbeat.display()
             ),
         );
-        let report = classify(dir.path(), &marker, &no_env_overrides());
+        // Pin a large synthetic process age (#4368) so this test's intent —
+        // "a fresh heartbeat classifies as Fresh" — cannot be perturbed by
+        // the test binary's own real (and much smaller, at least early in a
+        // run) uptime being compared against the 5s heartbeat age.
+        let report = classify_with_process_age_fn(dir.path(), &marker, &no_env_overrides(), |_| {
+            Some(1_000_000)
+        });
         assert_eq!(report.state, InstallState::AliveButUnresponsive);
         assert_eq!(report.heartbeat_freshness, Some(HeartbeatFreshness::Fresh));
         assert_eq!(report.heartbeat_stale_threshold_secs, Some(300));
@@ -792,7 +850,14 @@ mod tests {
                 heartbeat.display()
             ),
         );
-        let report = classify(dir.path(), &marker, &no_env_overrides());
+        // Pin a synthetic process age comfortably larger than the 1000s
+        // heartbeat age (#4368) — without this, the real (tiny) test-binary
+        // uptime would make this heartbeat look older than the process and
+        // misclassify as PriorBoot instead of exercising the Stale verdict
+        // this test targets.
+        let report = classify_with_process_age_fn(dir.path(), &marker, &no_env_overrides(), |_| {
+            Some(1_000_000)
+        });
         assert_eq!(report.state, InstallState::AliveButUnresponsive);
         assert_eq!(report.heartbeat_freshness, Some(HeartbeatFreshness::Stale));
     }
@@ -812,7 +877,9 @@ mod tests {
         );
         let mut env = no_env_overrides();
         env.heartbeat_stale_secs_override = Some(10);
-        let report = classify(dir.path(), &marker, &env);
+        // See the #4368 note above — pin process age so the 20s heartbeat
+        // age is never mistaken for a prior-boot file.
+        let report = classify_with_process_age_fn(dir.path(), &marker, &env, |_| Some(1_000_000));
         assert_eq!(report.heartbeat_freshness, Some(HeartbeatFreshness::Stale));
         assert_eq!(report.heartbeat_stale_threshold_secs, Some(10));
     }
@@ -933,6 +1000,110 @@ mod tests {
     }
 
     #[test]
+    fn heartbeat_freshness_as_str_matches_taxonomy() {
+        assert_eq!(HeartbeatFreshness::Fresh.as_str(), "fresh");
+        assert_eq!(HeartbeatFreshness::Stale.as_str(), "stale");
+        assert_eq!(HeartbeatFreshness::Unknown.as_str(), "unknown");
+        assert_eq!(HeartbeatFreshness::PriorBoot.as_str(), "prior-boot");
+    }
+
+    // ===================================================================
+    // Prior-boot heartbeat detection (#4368)
+    // ===================================================================
+
+    #[test]
+    fn check_heartbeat_prior_boot_when_older_than_process() {
+        let dir = tempfile::tempdir().unwrap();
+        let heartbeat = write_heartbeat(dir.path(), Duration::from_secs(1000));
+        let (freshness, age) = check_heartbeat(&heartbeat, 300, Some(10));
+        assert_eq!(freshness, HeartbeatFreshness::PriorBoot);
+        assert_eq!(age, Some(1000));
+    }
+
+    #[test]
+    fn check_heartbeat_current_boot_stale_when_younger_than_process() {
+        // Heartbeat is well past the staleness threshold, but it is younger
+        // than the process itself — this IS current-boot evidence, so the
+        // real-wedge verdict (Stale) must be preserved, never PriorBoot.
+        let dir = tempfile::tempdir().unwrap();
+        let heartbeat = write_heartbeat(dir.path(), Duration::from_secs(1000));
+        let (freshness, age) = check_heartbeat(&heartbeat, 300, Some(5000));
+        assert_eq!(freshness, HeartbeatFreshness::Stale);
+        assert_eq!(age, Some(1000));
+    }
+
+    #[test]
+    fn check_heartbeat_no_prior_boot_claim_when_process_age_unknown() {
+        // Unparseable `ps` age (`None`) must never manufacture a prior-boot
+        // claim — degrade to the pre-#4368 Stale/Fresh verdicts instead.
+        let dir = tempfile::tempdir().unwrap();
+        let heartbeat = write_heartbeat(dir.path(), Duration::from_secs(1000));
+        let (freshness, age) = check_heartbeat(&heartbeat, 300, None);
+        assert_eq!(freshness, HeartbeatFreshness::Stale);
+        assert_eq!(age, Some(1000));
+    }
+
+    #[test]
+    fn check_heartbeat_boundary_equal_ages_is_not_prior_boot() {
+        // A heartbeat exactly as old as the process itself is deliberately
+        // NOT prior-boot (a strictly-older file is) — it is current-boot
+        // evidence and falls through to the ordinary threshold check.
+        let dir = tempfile::tempdir().unwrap();
+        let heartbeat = write_heartbeat(dir.path(), Duration::from_secs(500));
+        let (freshness, age) = check_heartbeat(&heartbeat, 300, Some(500));
+        assert_eq!(freshness, HeartbeatFreshness::Stale);
+        assert_eq!(age, Some(500));
+    }
+
+    #[test]
+    fn heartbeat_older_than_process_start_is_prior_boot_end_to_end() {
+        // End-to-end wiring proof (via classify_with_process_age_fn, so the
+        // injected process age is deterministic): a heartbeat file from
+        // 83814s ago — the exact age observed in the #4368 incident — with a
+        // young (9s) process must classify PriorBoot, never Stale, and must
+        // NOT be mistaken for the startup-grace path either (grace defaults
+        // to 0 in `no_env_overrides`, so the 9s process falls through to the
+        // AliveButUnresponsive branch as intended).
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = write_pid_file(dir.path(), std::process::id());
+        let heartbeat = write_heartbeat(dir.path(), Duration::from_secs(83_814));
+        let marker = write_marker(
+            dir.path(),
+            &format!(
+                "pid_file={}\nheartbeat_file={}\nheartbeat_interval_secs=60\nuse_launchd=false\n",
+                pid_file.display(),
+                heartbeat.display()
+            ),
+        );
+        let report =
+            classify_with_process_age_fn(dir.path(), &marker, &no_env_overrides(), |_| Some(9));
+        assert_eq!(report.state, InstallState::AliveButUnresponsive);
+        assert_eq!(report.heartbeat_freshness, Some(HeartbeatFreshness::PriorBoot));
+        assert_eq!(report.heartbeat_age_secs, Some(83_814));
+        assert_eq!(report.process_age_secs, Some(9));
+    }
+
+    #[test]
+    fn stale_heartbeat_with_unknown_process_age_makes_no_prior_boot_claim_end_to_end() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = write_pid_file(dir.path(), std::process::id());
+        let heartbeat = write_heartbeat(dir.path(), Duration::from_secs(1000));
+        let marker = write_marker(
+            dir.path(),
+            &format!(
+                "pid_file={}\nheartbeat_file={}\nheartbeat_interval_secs=60\nuse_launchd=false\n",
+                pid_file.display(),
+                heartbeat.display()
+            ),
+        );
+        let report =
+            classify_with_process_age_fn(dir.path(), &marker, &no_env_overrides(), |_| None);
+        assert_eq!(report.state, InstallState::AliveButUnresponsive);
+        assert_eq!(report.heartbeat_freshness, Some(HeartbeatFreshness::Stale));
+        assert!(report.process_age_secs.is_none());
+    }
+
+    #[test]
     fn alive_starting_reuses_alive_but_unresponsive_exit_code() {
         assert_eq!(InstallState::AliveStarting.exit_code(), EXIT_ALIVE_BUT_UNRESPONSIVE);
         assert_eq!(InstallState::AliveStarting.exit_code(), 4);
@@ -1010,7 +1181,11 @@ mod tests {
         );
         let mut env = no_env_overrides();
         env.startup_grace_secs_override = Some(0);
-        let report = classify(dir.path(), &marker, &env);
+        // Pin a synthetic process age (#4368, see the note on
+        // `alive_with_stale_heartbeat_is_stale`) comfortably larger than the
+        // 5s heartbeat age so the fresh-heartbeat verdict this test targets
+        // is not perturbed by prior-boot detection.
+        let report = classify_with_process_age_fn(dir.path(), &marker, &env, |_| Some(1_000_000));
         assert_eq!(report.state, InstallState::AliveButUnresponsive);
         assert_eq!(report.heartbeat_freshness, Some(HeartbeatFreshness::Fresh));
         // The grace threshold used is still surfaced for JSON consumers.

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -3323,6 +3323,17 @@ fn print_status_unreachable_human(
                             r.heartbeat_stale_threshold_secs.unwrap_or_default()
                         );
                     }
+                    Some(daemon_install_state::HeartbeatFreshness::PriorBoot) => {
+                        eprintln!(
+                            "Heartbeat file is from a PREVIOUS boot ({}s old; this process is \
+                             only {}s old) — it is not evidence about the current process. (A \
+                             daemon that wedged before writing its first heartbeat this boot \
+                             would look identical — re-check after the process is well past \
+                             startup if you still suspect a wedge.)",
+                            r.heartbeat_age_secs.unwrap_or_default(),
+                            r.process_age_secs.unwrap_or_default()
+                        );
+                    }
                     _ => {
                         eprintln!(
                             "Heartbeat status unknown (no heartbeat file, or disabled) — \
@@ -3331,18 +3342,41 @@ fn print_status_unreachable_human(
                     }
                 }
                 eprintln!();
-                if let Some(pid) = r.pid {
-                    eprintln!("Do NOT run loom-daemon-start.sh — the singleton guard will refuse");
-                    eprintln!(
-                        "while pid {pid} is alive. Inspect it directly, or restart explicitly:"
-                    );
+                // Advice gating (#4368): the imperative stop/start remediation
+                // is only warranted for a *current-boot* Stale verdict — the
+                // one case where the evidence actually points at a wedge.
+                // Fresh/Unknown/PriorBoot get inspect-first guidance instead,
+                // so an operator is never steered into restarting a daemon
+                // that is merely mid-fault-diagnosis or missing heartbeat
+                // evidence, not actually wedged.
+                if r.heartbeat_freshness == Some(daemon_install_state::HeartbeatFreshness::Stale) {
+                    if let Some(pid) = r.pid {
+                        eprintln!(
+                            "Do NOT run loom-daemon-start.sh — the singleton guard will refuse"
+                        );
+                        eprintln!(
+                            "while pid {pid} is alive. Inspect it directly, or restart explicitly:"
+                        );
+                    } else {
+                        eprintln!(
+                            "Do NOT run loom-daemon-start.sh — the singleton guard will refuse"
+                        );
+                        eprintln!(
+                            "while the daemon is alive. Inspect it directly, or restart explicitly:"
+                        );
+                    }
+                    eprintln!("  ./.loom/scripts/cli/loom-daemon-stop.sh && ./.loom/scripts/cli/loom-daemon-start.sh");
                 } else {
-                    eprintln!("Do NOT run loom-daemon-start.sh — the singleton guard will refuse");
-                    eprintln!(
-                        "while the daemon is alive. Inspect it directly, or restart explicitly:"
-                    );
+                    eprintln!("Inspect before acting — this evidence does not indicate a wedge:");
+                    if let Some(pid) = r.pid {
+                        eprintln!(
+                            "  ps -p {pid} -o pid,etime,command   # confirm what it is actually doing"
+                        );
+                    }
+                    eprintln!("  loom-daemon status --json           # machine-readable detail");
+                    eprintln!("If it is still unresponsive after inspecting, restart explicitly:");
+                    eprintln!("  ./.loom/scripts/cli/loom-daemon-stop.sh && ./.loom/scripts/cli/loom-daemon-start.sh");
                 }
-                eprintln!("  ./.loom/scripts/cli/loom-daemon-stop.sh && ./.loom/scripts/cli/loom-daemon-start.sh");
             }
         },
     }


### PR DESCRIPTION
## Summary

`loom-daemon status` (and the host-side watchdog) could misdiagnose a healthy,
still-booting daemon as "likely wedged" because a stale heartbeat file was
being compared only against a fixed staleness threshold, never against the
live process's own age. Two 2026-07-28 incidents reproduced this: a
migrated/leftover heartbeat file from a previous boot (83814s old) rendered as
"STALE ... the daemon is likely wedged" against a daemon that had just started
seconds earlier, and a separate incident printed the imperative "Do NOT run
loom-daemon-start.sh ... stop && start" remediation even when the evidence
didn't actually indicate a fault.

AC 1 (the pre-IPC startup-grace window, `InstallState::AliveStarting`) was
already implemented on `main` via #4213/PR #4250 before this issue was filed —
verified against current `main` per the curator's note, and left untouched.
This PR implements the remaining two acceptance criteria plus watchdog parity.

## Changes

- `loom-daemon/src/daemon_install_state.rs`: add
  `HeartbeatFreshness::PriorBoot` (`as_str()` → `"prior-boot"`). `check_heartbeat`
  now takes the live process's own age and classifies a heartbeat file whose
  mtime is strictly older than the process's start time as `PriorBoot` —
  checked *before* the staleness threshold, so even an otherwise-"fresh"-looking
  heartbeat that predates the process is still flagged. Equal ages are
  deliberately **not** `PriorBoot` (current-boot evidence). An unparseable
  process age (`ps` failure) makes **no** prior-boot claim and degrades to the
  pre-existing Stale/Fresh verdicts. `classify()` is split into a testable
  `classify_with_process_age_fn` so unit tests can pin a deterministic
  synthetic process age instead of depending on the real (and highly variable)
  uptime of the shared test-binary process.
- `loom-daemon/src/main.rs`: the `AliveButUnresponsive` render arm now (a)
  prints a dedicated "heartbeat file is from a PREVIOUS boot ... not evidence
  about the current process" message for `PriorBoot`, and (b) gates the
  imperative stop/start remediation to only print for a genuine current-boot
  `Stale` verdict — `Fresh`/`Unknown`/`PriorBoot` now print inspect-first
  guidance (`ps -p <pid> -o pid,etime,command`, `loom-daemon status --json`)
  instead. The `--json` surface picks up `"prior-boot"` automatically via the
  existing `as_str()`-mapped `heartbeat.freshness` field — no schema change
  needed.
- `defaults/scripts/cli/loom-daemon-watchdog.sh`: §3's staleness check now
  compares the heartbeat mtime against the live process's own age (via
  `ps -o etime= -p <pid>`, parsed with the same `[[dd-]hh:]mm:ss` logic as the
  Rust probe) *before* the stale-threshold WARN, downgrading a prior-boot
  heartbeat file to the existing liveness-only OK report with a "previous
  boot" note instead of a `DIVERGENCE`/wedge report.
- `defaults/scripts/tests/test-loom-daemon-watchdog.sh`: added a `ps` stub
  helper (`make_ps_stub`) so the staleness/prior-boot comparisons are testable
  deterministically (a freshly-spawned real sleeper pid can't otherwise be
  made reliably "older" than an artificially back-dated heartbeat file).
  Updated the existing STALE tests (#3, #7) to pin a process age older than
  their heartbeat ages so they keep exercising the genuine current-boot-stale
  path, and added a new case (#3b) for the prior-boot path.

## Acceptance Criteria Verification

- [x] **AC 1** (startup-phase detection) — already implemented on `main`
  (`InstallState::AliveStarting`, #4213/PR #4250); verified present and
  untouched by this change.
- [x] **AC 2** (prior-boot heartbeat is never treated as current-process
  evidence) — `HeartbeatFreshness::PriorBoot`; unit tests
  `check_heartbeat_prior_boot_when_older_than_process`,
  `check_heartbeat_current_boot_stale_when_younger_than_process`,
  `check_heartbeat_no_prior_boot_claim_when_process_age_unknown`,
  `check_heartbeat_boundary_equal_ages_is_not_prior_boot`,
  `heartbeat_older_than_process_start_is_prior_boot_end_to_end` (reproduces the
  exact 83814s incident value end-to-end via `classify_with_process_age_fn`).
- [x] **AC 3** (advice gating) — the stop/start remediation only prints for a
  current-boot `Stale` verdict in `main.rs`'s `AliveButUnresponsive` arm;
  `Fresh`/`Unknown`/`PriorBoot` get inspect-first guidance instead.
- [x] Watchdog parity — `loom-daemon-watchdog.sh` §3 mirrors the same
  mtime-vs-process-start comparison before its stale WARN.

## Test Plan

- `cd loom-daemon && cargo test --lib` — 1772 passed, 0 failed (includes the 8
  new/updated `daemon_install_state` tests above; full crate suite, not just
  the touched module).
- `cargo clippy --lib --bin loom-daemon -- -D warnings` — clean, no warnings.
- `cargo fmt --check` — clean.
- `bash defaults/scripts/tests/test-loom-daemon-watchdog.sh` — 24/24 passed
  (run 3x to check for flakiness from the real-subprocess-based liveness
  checks; consistently green), including the new prior-boot case and the
  reworked STALE tests (#3, #3b, #7).
- `bash -n` + `shellcheck` on the watchdog script — clean.
- Manual: `LOOM_DAEMON_STARTUP_GRACE_SECS=0 loom-daemon status` against a
  fixture with a heavily back-dated heartbeat file and a young pid now prints
  the "previous boot" message with no stop/start imperative (exercised via the
  `heartbeat_older_than_process_start_is_prior_boot_end_to_end` unit test,
  which reproduces this exact scenario deterministically).

Closes #4368