### PR TITLE
fix(git-identity): detect + guard against corrupted local git identity

### DIFF
--- a/defaults/docs/troubleshooting.md
+++ b/defaults/docs/troubleshooting.md
@@ -113,6 +113,59 @@ git worktree remove .loom/worktrees/issue-42 --force
 git worktree prune
 ```
 
+### Corrupted local git identity (`...github.comecho`, "cannot overwrite multiple values") (#4369)
+
+**Symptom**: `git config user.email <value>` fails with `error: cannot
+overwrite multiple values`, or a commit/merge ships with a garbled author
+email like `loom-reviewer@users.noreply.github.comecho`.
+
+**Root cause**: a now-deleted Tauri-era code path once pushed two shell lines
+into an agent's terminal to set a per-role git identity — `git config
+user.email "<email>"` immediately followed by an `echo "✓ Git identity
+configured..."` line. A lost newline between the two glued the `echo`
+token onto the email, corrupting it, and because `git config user.email
+<v>` *replaces* rather than appends, repeated writes/`--add` improvisation
+could also stack multiple values for the same key. That code was removed in
+`d61acab0` (#3353) — **nothing on `main` writes `user.email`/`user.name`
+anymore** — but the corrupted/stacked values persist as residue in any
+checkout that predates the removal, and worktrees inherit them from the
+parent repo's shared `.git/config`.
+
+**Detect it**:
+
+```bash
+./.loom/scripts/check-git-identity.sh
+```
+
+This reads LOCAL (repo + per-worktree) scope only — never your global
+identity — so a normal setup with no repo-local override never
+false-positives. It exits `0` when clean, `1` (warning) when it finds
+plain stacked values with no corruption, and `3` (hard fail) when it finds
+the glued-token corruption pattern. `./.loom/scripts/worktree.sh` runs this
+check automatically at worktree creation: it hard-fails on the corruption
+pattern (a garbled commit author would otherwise ship silently — see PR
+#4303) and warns-but-proceeds on a plain multi-value.
+
+**Fix it** — preferred, falls back to your global identity (Loom no longer
+sets a per-role local identity, so the local values are pure residue):
+
+```bash
+git config --unset-all user.email && git config --unset-all user.name
+```
+
+**Alternative** — keep one specific value (e.g. no global identity is
+configured on this host):
+
+```bash
+git config --replace-all user.email <value-to-keep>
+git config --replace-all user.name  <value-to-keep>
+```
+
+After either fix, re-run `./.loom/scripts/check-git-identity.sh` to confirm
+it now reports clean, and verify a new commit picks up the intended author
+with `git commit --allow-empty -m test && git log -1 --format='%an <%ae>'`
+(then drop the test commit).
+
 ### Labels out of sync
 
 ```bash

--- a/defaults/roles/README.md
+++ b/defaults/roles/README.md
@@ -69,7 +69,6 @@ Each role can have an optional JSON metadata file with default settings:
 - **`defaultIntervalPrompt`** (string): Default prompt sent at each interval
 - **`autonomousRecommended`** (boolean): Whether autonomous mode is recommended
 - **`suggestedWorkerType`** (string): "claude" or "codex"
-- **`gitIdentity`** (object): `name` / `email` used for commits made by this role
 - **`stuckThresholds`** (object): Per-role stuck-detection limits (e.g. `maxNoOutput`, `maxNeedsInput`, in milliseconds)
 
 ## Creating Custom Roles

--- a/defaults/roles/architect.json
+++ b/defaults/roles/architect.json
@@ -5,9 +5,5 @@
   "defaultInterval": 900000,
   "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a System Architect who scans the codebase for improvement opportunities across ALL domains (features, refactoring, docs, tests, CI, security, performance). Check if there are already 3+ open proposals using `gh issue list --label=\"loom:architect\"`. If < 3, scan for opportunities and create ONE comprehensive proposal issue with proper categorization (features, refactoring, docs, tests, CI, security). After creating the issue, immediately add `loom:architect` label and assess if `loom:urgent` is warranted.",
   "autonomousRecommended": true,
-  "suggestedWorkerType": "claude",
-  "gitIdentity": {
-    "name": "Loom Architect",
-    "email": "loom-architect@users.noreply.github.com"
-  }
+  "suggestedWorkerType": "claude"
 }

--- a/defaults/roles/auditor.json
+++ b/defaults/roles/auditor.json
@@ -6,10 +6,6 @@
   "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are an Auditor, the continuous integration health monitor for the `main` branch. Fetch and check out the latest `origin/main` (`git fetch origin main && git checkout -B main origin/main`), then build the project, run the tests, and launch the software to verify it actually works at runtime. If everything succeeds, the run is clean - no label to apply. If the build/tests/runtime fail, create a bug issue with reproduction steps labeled `loom:auditor`.",
   "autonomousRecommended": true,
   "suggestedWorkerType": "claude",
-  "gitIdentity": {
-    "name": "Loom Auditor",
-    "email": "loom-auditor@users.noreply.github.com"
-  },
   "stuckThresholds": {
     "maxNoOutput": 900000,
     "maxNeedsInput": 300000

--- a/defaults/roles/builder.json
+++ b/defaults/roles/builder.json
@@ -7,10 +7,6 @@
   "autonomousRecommended": false,
   "suggestedWorkerType": "claude",
   "runtimeRequirements": ["worktreeIsolation", "mcp"],
-  "gitIdentity": {
-    "name": "Loom Worker",
-    "email": "loom-worker@users.noreply.github.com"
-  },
   "stuckThresholds": {
     "maxNoOutput": 1800000,
     "maxNeedsInput": 300000

--- a/defaults/roles/curator.json
+++ b/defaults/roles/curator.json
@@ -5,9 +5,5 @@
   "defaultInterval": 300000,
   "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are an Issue Curator who enhances issues. Use `gh issue list --state=open --json number,title,labels --jq '.[] | select(any(.labels[].name; . == \"loom:architect\" or . == \"loom:hermit\" or . == \"loom:curated\" or . == \"loom:curating\" or . == \"loom:triage\" or . == \"loom:issue\" or . == \"loom:building\" or . == \"loom:blocked\") | not) | \"#\\(.number) \\(.title)\"'` to find unlabeled issues needing curation (zero-label issues are included; already-labeled/in-flight issues are excluded). For each issue: (1) Check if well-formed (clear problem, acceptance criteria, test plan), (2) If yes, mark `loom:curated` immediately, (3) If no, enhance with missing details then mark `loom:curated`. CRITICAL: Do NOT add `loom:issue` yourself — promotion ownership is documented in curator.md ('Who promotes loom:curated -> loom:issue'). Always verify dependencies are met before adding `loom:curated` label.",
   "autonomousRecommended": true,
-  "suggestedWorkerType": "codex",
-  "gitIdentity": {
-    "name": "Loom Curator",
-    "email": "loom-curator@users.noreply.github.com"
-  }
+  "suggestedWorkerType": "codex"
 }

--- a/defaults/roles/doctor.json
+++ b/defaults/roles/doctor.json
@@ -5,9 +5,5 @@
   "defaultInterval": 300000,
   "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a PR Fixer. Check for PRs needing attention: (1) Find PRs with changes requested: `gh pr list --label=\"loom:changes-requested\" --state=open`, (2) For each PR, check review comments: `gh pr view <number>`, (3) Check out the PR branch with `gh pr checkout <number>`, address the feedback, run the project's check command (`buildGate.command` in `.loom/config.json`, e.g. `pnpm check:ci`), commit and push your fixes, then update labels (remove `loom:changes-requested`, add `loom:review-requested`) and comment that feedback is addressed. For complex changes that require substantial refactoring, create an issue with `loom:triage` + `loom:urgent` labels instead.",
   "autonomousRecommended": true,
-  "suggestedWorkerType": "claude",
-  "gitIdentity": {
-    "name": "Loom Fixer",
-    "email": "loom-fixer@users.noreply.github.com"
-  }
+  "suggestedWorkerType": "claude"
 }

--- a/defaults/roles/hermit.json
+++ b/defaults/roles/hermit.json
@@ -5,9 +5,5 @@
   "defaultInterval": 900000,
   "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Hermit. Analyze the codebase for opportunities to simplify, remove bloat, or eliminate unnecessary complexity. Look for: unused dependencies, dead code, over-engineered abstractions, commented-out code, duplicated logic, and unnecessary features. If you find something concrete worth removing, create a GitHub issue with the `loom:hermit` label explaining what to remove, why it's bloat, and the benefits of removal. Be specific and provide evidence (e.g., grep results showing no usage).",
   "autonomousRecommended": true,
-  "suggestedWorkerType": "claude",
-  "gitIdentity": {
-    "name": "Loom Hermit",
-    "email": "loom-hermit@users.noreply.github.com"
-  }
+  "suggestedWorkerType": "claude"
 }

--- a/defaults/roles/judge.json
+++ b/defaults/roles/judge.json
@@ -7,10 +7,6 @@
   "autonomousRecommended": true,
   "suggestedWorkerType": "codex",
   "runtimeRequirements": ["mcp"],
-  "gitIdentity": {
-    "name": "Loom Reviewer",
-    "email": "loom-reviewer@users.noreply.github.com"
-  },
   "stuckThresholds": {
     "maxNoOutput": 600000,
     "maxNeedsInput": 180000

--- a/defaults/roles/loom.json
+++ b/defaults/roles/loom.json
@@ -5,9 +5,5 @@
   "defaultInterval": 60000,
   "defaultIntervalPrompt": "Observe the running loom-daemon and keep work flowing: call mcp__loom__list_sweeps to inspect the sweep registry, dispatch ready `loom:issue` work with mcp__loom__dispatch_sweep, and use mcp__loom__get_sweep_status / mcp__loom__tail_sweep_log / mcp__loom__cancel_sweep to monitor and intervene. The daemon is a long-lived process you coordinate via MCP tools, not by spawning shell processes.",
   "autonomousRecommended": true,
-  "suggestedWorkerType": "claude",
-  "gitIdentity": {
-    "name": "Loom Daemon",
-    "email": "loom-daemon@users.noreply.github.com"
-  }
+  "suggestedWorkerType": "claude"
 }

--- a/defaults/scripts/check-git-identity.sh
+++ b/defaults/scripts/check-git-identity.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# check-git-identity.sh - Detect corrupted / stacked local git identity config (#4369).
+#
+# Background: a now-deleted Tauri-era code path (`terminal-actions.ts`,
+# `setupWorktreeForAgent()`, removed in d61acab0 / #3353) pushed two shell
+# lines into an agent's terminal to set a per-role git identity:
+#   git config user.email "${gitIdentity.email}"
+#   echo "✓ Git identity configured: ${gitIdentity.name} <${gitIdentity.email}>"
+# A lost newline between the two lines glued the second line's first token
+# onto the first line's value, producing corrupted local-scope emails like
+# `loom-reviewer@users.noreply.github.comecho`. Because `git config user.email`
+# REPLACES rather than appends, repeated writes/`--add` improvisation could
+# also stack multiple values for the same key. Both symptoms persist in
+# long-lived checkouts that predate the code's removal, even though nothing
+# on `main` writes `user.email`/`user.name` anymore (see #4369).
+#
+# This script is a read-only detector: it never mutates git config. It flags
+# two independent conditions in the LOCAL (repo + per-worktree) config scope:
+#   1. CORRUPTION: a user.email (or user.name) value matching the glued-token
+#      pattern (a GitHub noreply email immediately followed by extra
+#      characters with no separator, e.g. "...github.comecho"). This is the
+#      garbled-commit-author failure mode and is always a hard problem.
+#   2. MULTI-VALUE: more than one value stored locally for user.email or
+#      user.name (via `--get-all`), with no corrupted value among them. This
+#      is ambiguous but not necessarily broken (`git config user.<field> <v>`
+#      will still refuse to *set* while multiple values exist, but reads that
+#      pick a single value may still work) — treated as a lower-severity
+#      warning.
+#
+# Deliberately reads LOCAL (+ per-worktree, when `extensions.worktreeConfig`
+# is enabled) scope only — never global/system — so a normal global identity
+# with no repo-local override never false-positives. `git config --get-all`
+# WITHOUT `--local`/`--worktree` also surfaces global/system values, which
+# would incorrectly flag perfectly ordinary setups.
+#
+# Usage:
+#   ./.loom/scripts/check-git-identity.sh          # check the current repo
+#   ./.loom/scripts/check-git-identity.sh --help   # show usage
+#
+# Exit codes:
+#   0 - Clean: no corrupted value and at most one local value per field.
+#   1 - WARNING: multiple local values for user.email and/or user.name, but
+#       none match the corruption pattern (ambiguous, not necessarily broken).
+#   2 - Usage error or not inside a git repository.
+#   3 - CORRUPTION detected: a value matches the glued-token pattern. This is
+#       the failure mode that ships garbled commit authors (see PR #4303).
+#
+# Remediation (never applied automatically — this script only detects and
+# prints the command; auto-remediation is a judgment call, see #4369):
+#   Preferred (most repos have a working global identity to fall back to):
+#     git config --unset-all user.email && git config --unset-all user.name
+#   Alternative (no global identity, or you want to keep a specific value):
+#     git config --replace-all user.email <value-to-keep>
+#     git config --replace-all user.name  <value-to-keep>
+
+set -uo pipefail  # no -e: git config "not found" exits are expected control flow
+
+EXIT_OK=0
+EXIT_MULTI_VALUE=1
+EXIT_USAGE=2
+EXIT_CORRUPTED=3
+
+# Anchored to the specific corruption vector (a GitHub noreply email with
+# extra characters glued directly after ".com", no separator) rather than a
+# generic "\.com[a-z]+$" — the generic form would false-positive on ordinary
+# addresses with unusual-but-valid TLDs (e.g. "user@company.comm").
+CORRUPTION_REGEX='users\.noreply\.github\.com[a-zA-Z0-9]+$'
+
+usage() {
+    sed -n '2,54p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+case "${1:-}" in
+    -h|--help)
+        usage
+        exit "$EXIT_OK"
+        ;;
+    "")
+        ;;
+    *)
+        echo "check-git-identity.sh: unknown argument: $1" >&2
+        echo "Run with --help for usage." >&2
+        exit "$EXIT_USAGE"
+        ;;
+esac
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    echo "check-git-identity.sh: not inside a git repository" >&2
+    exit "$EXIT_USAGE"
+fi
+
+# get_values <field> -> unique local-scope values for that config key, one
+# per line, in first-seen order. Combines --local and --worktree so a value
+# set only in a per-worktree config (extensions.worktreeConfig=true) is not
+# missed; when that extension is off, --worktree reads the same file as
+# --local, so the de-dup keeps the merged output equivalent to plain --local.
+get_values() {
+    local field="$1"
+    { git config --local --get-all "$field" 2>/dev/null || true
+      git config --worktree --get-all "$field" 2>/dev/null || true; } \
+      | awk '!seen[$0]++'
+}
+
+has_global_fallback() {
+    [[ -n "$(git config --global --get user.email 2>/dev/null || true)" ]]
+}
+
+print_remediation() {
+    local field="$1"
+    echo "" >&2
+    echo "  Remediation:" >&2
+    echo "    Preferred (falls back to your global identity):" >&2
+    echo "      git config --unset-all user.email && git config --unset-all user.name" >&2
+    echo "    Alternative (keep one specific value, e.g. no global identity is set):" >&2
+    echo "      git config --replace-all $field <value-to-keep>" >&2
+    if ! has_global_fallback; then
+        echo "" >&2
+        echo "    NOTE: no global user.email is configured on this host — the" >&2
+        echo "    'unset-all' path would leave commits failing with 'Author identity" >&2
+        echo "    unknown' until you set one (git config --global user.email <you>)," >&2
+        echo "    or use the --replace-all fallback above instead." >&2
+    fi
+}
+
+corrupted=0
+multi_value=0
+
+# Bash 3.2 compatible (macOS ships /bin/bash 3.2 - no mapfile/readarray):
+# gather values into a newline-joined string rather than an array.
+for field in user.email user.name; do
+    values_raw=$(get_values "$field")
+    [[ -z "$values_raw" ]] && continue
+    count=$(printf '%s\n' "$values_raw" | grep -c '')
+
+    field_corrupted=0
+    while IFS= read -r v; do
+        [[ -z "$v" ]] && continue
+        if [[ "$v" =~ $CORRUPTION_REGEX ]]; then
+            field_corrupted=1
+            corrupted=1
+        fi
+    done <<< "$values_raw"
+
+    if [[ "$field_corrupted" -eq 1 ]]; then
+        echo "ERROR: check-git-identity.sh: corrupted $field value detected." >&2
+        echo "       A stored value looks like a glued-together shell command output" >&2
+        echo "       (a GitHub noreply email with extra characters appended directly" >&2
+        echo "       after '.com', no separator) — the #4369 failure mode that ships" >&2
+        echo "       garbled commit authors." >&2
+        echo "" >&2
+        echo "  Stored $field value(s):" >&2
+        while IFS= read -r v; do [[ -n "$v" ]] && echo "    - $v" >&2; done <<< "$values_raw"
+        print_remediation "$field"
+    elif [[ "$count" -gt 1 ]]; then
+        multi_value=1
+        echo "WARNING: check-git-identity.sh: multiple local $field values ($count) detected." >&2
+        echo "         'git config $field <value>' will refuse to overwrite until this" >&2
+        echo "         is resolved ('cannot overwrite multiple values')." >&2
+        echo "" >&2
+        echo "  Stored $field value(s):" >&2
+        while IFS= read -r v; do [[ -n "$v" ]] && echo "    - $v" >&2; done <<< "$values_raw"
+        print_remediation "$field"
+    fi
+done
+
+if [[ "$corrupted" -eq 1 ]]; then
+    exit "$EXIT_CORRUPTED"
+elif [[ "$multi_value" -eq 1 ]]; then
+    exit "$EXIT_MULTI_VALUE"
+fi
+
+echo "check-git-identity.sh: local git identity is clean (no corruption, no stacked values)"
+exit "$EXIT_OK"

--- a/defaults/scripts/tests/test-check-git-identity.sh
+++ b/defaults/scripts/tests/test-check-git-identity.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# test-check-git-identity.sh - Smoke tests for check-git-identity.sh (#4369)
+#
+# Exercises the local-scope git identity hygiene detector: clean single-value
+# identity, stacked/multi-value identity, the glued-shell-command corruption
+# pattern (e.g. "...github.comecho"), global-only identity, per-worktree
+# config, and the printed remediation command. Each test runs against a
+# throwaway temp git repo so the result is deterministic and independent of
+# the host's real git identity.
+#
+# Uses GIT_CONFIG_GLOBAL (git >= 2.32) to sandbox the "global" scope per test
+# so results never depend on — and never mutate — the host's real ~/.gitconfig.
+#
+# Usage:
+#   ./.loom/scripts/tests/test-check-git-identity.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPERS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$HELPERS_DIR/check-git-identity.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: $1"
+}
+
+fail() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: $1"
+}
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# Sandboxed empty global config so tests never read/depend on the real host
+# ~/.gitconfig. A per-test override can point this at a populated file to
+# simulate "global identity present".
+EMPTY_GLOBAL="$WORKDIR/empty-global-config"
+: > "$EMPTY_GLOBAL"
+
+# make_repo -> path to a fresh temp git repo with NO identity configured at
+# any scope (relies on GIT_CONFIG_GLOBAL sandboxing at call sites, not on
+# `git config user.*`, so the repo itself starts with zero local values).
+make_repo() {
+    local dir
+    dir=$(mktemp -d)
+    GIT_CONFIG_GLOBAL="$EMPTY_GLOBAL" git -C "$dir" init -q
+    echo "$dir"
+}
+
+# run_rc <repo> [global-config-file] -- runs the script with a sandboxed
+# global config (defaults to the empty one) and records stdout+stderr / rc.
+run_check() {
+    local repo="$1" global="${2:-$EMPTY_GLOBAL}"
+    OUT=$(cd "$repo" && GIT_CONFIG_GLOBAL="$global" "$SCRIPT" 2>&1)
+    RC=$?
+}
+
+# -------- Test 1: script exists and is executable --------
+echo "Test 1: script exists and is executable"
+if [[ -x "$SCRIPT" ]]; then
+    pass "check-git-identity.sh is executable"
+else
+    fail "check-git-identity.sh is missing or not executable: $SCRIPT"
+    echo "FAILED: $TESTS_FAILED/$TESTS_RUN"
+    exit 1
+fi
+
+# -------- Test 2: --help exits 0 and prints usage --------
+echo "Test 2: --help exits 0 with usage output"
+out=$("$SCRIPT" --help 2>&1); rc=$?
+if [[ "$rc" -eq 0 && "$out" == *"check-git-identity.sh"* && "$out" == *"Exit codes"* ]]; then
+    pass "--help prints usage and exits 0"
+else
+    fail "--help: expected 0 + usage text, got rc=$rc"
+fi
+
+# -------- Test 3: unknown argument exits 2 --------
+echo "Test 3: unknown argument exits 2"
+"$SCRIPT" --bogus >/dev/null 2>&1; rc=$?
+if [[ "$rc" -eq 2 ]]; then pass "exit 2 on unknown argument"; else fail "expected 2, got $rc"; fi
+
+# -------- Test 4: not a git repository exits 2 --------
+echo "Test 4: not inside a git repository exits 2"
+NOTAREPO=$(mktemp -d)
+out=$(cd "$NOTAREPO" && "$SCRIPT" 2>&1); rc=$?
+if [[ "$rc" -eq 2 ]] && echo "$out" | grep -qi "not inside a git repository"; then
+    pass "exit 2 + message outside a git repo"
+else
+    fail "expected 2 + message, got rc=$rc; out=$out"
+fi
+rm -rf "$NOTAREPO"
+
+# -------- Test 5: clean single-value local identity exits 0 --------
+echo "Test 5: clean single-value local identity exits 0"
+REPO=$(make_repo)
+git -C "$REPO" config user.email "dev@example.com"
+git -C "$REPO" config user.name "Dev Person"
+run_check "$REPO"
+if [[ "$RC" -eq 0 ]]; then pass "exit 0 on clean single-value identity"; else fail "expected 0, got $RC; out=$OUT"; fi
+rm -rf "$REPO"
+
+# -------- Test 6: no local identity at all (global-only, sandboxed) exits 0 --------
+echo "Test 6: no local values (global-only identity) exits 0"
+REPO=$(make_repo)
+GLOBAL_WITH_ID="$WORKDIR/global-with-identity"
+git config --file "$GLOBAL_WITH_ID" user.email "global@example.com"
+git config --file "$GLOBAL_WITH_ID" user.name "Global Person"
+run_check "$REPO" "$GLOBAL_WITH_ID"
+if [[ "$RC" -eq 0 ]]; then
+    pass "exit 0 with only a global identity set (no local override)"
+else
+    fail "expected 0, got $RC; out=$OUT"
+fi
+rm -rf "$REPO"
+
+# -------- Test 7: stacked (multi-value) local user.email -> warn (exit 1) --------
+echo "Test 7: stacked local user.email values warn (exit 1)"
+REPO=$(make_repo)
+git -C "$REPO" config user.email "first@example.com"
+git -C "$REPO" config --add user.email "second@example.com"
+run_check "$REPO"
+if [[ "$RC" -eq 1 ]] \
+   && echo "$OUT" | grep -q "first@example.com" \
+   && echo "$OUT" | grep -q "second@example.com" \
+   && echo "$OUT" | grep -qi "WARNING"; then
+    pass "exit 1 + both stacked values listed"
+else
+    fail "expected 1 + both values, got rc=$RC; out=$OUT"
+fi
+rm -rf "$REPO"
+
+# -------- Test 8: corrupted value (glued 'echo') -> hard fail (exit 3) --------
+echo "Test 8: corrupted '...github.comecho' value hard-fails (exit 3)"
+REPO=$(make_repo)
+git -C "$REPO" config user.email "loom-worker@users.noreply.github.com"
+git -C "$REPO" config --add user.email "loom-worker@users.noreply.github.comecho"
+run_check "$REPO"
+if [[ "$RC" -eq 3 ]] \
+   && echo "$OUT" | grep -q "loom-worker@users.noreply.github.comecho" \
+   && echo "$OUT" | grep -qi "ERROR"; then
+    pass "exit 3 + corrupted value reported"
+else
+    fail "expected 3 + corrupted value, got rc=$RC; out=$OUT"
+fi
+
+# -------- Test 9: corruption output includes the documented remediation --------
+echo "Test 9: corruption output includes the documented one-liner remediation"
+if echo "$OUT" | grep -q "git config --unset-all user.email && git config --unset-all user.name" \
+   && echo "$OUT" | grep -q -- "--replace-all user.email"; then
+    pass "remediation one-liner + --replace-all fallback both printed"
+else
+    fail "expected both remediation commands in output; out=$OUT"
+fi
+rm -rf "$REPO"
+
+# -------- Test 10: single corrupted value (no stacking) still hard-fails --------
+echo "Test 10: a single (non-stacked) corrupted value still hard-fails"
+REPO=$(make_repo)
+git -C "$REPO" config user.email "loom-reviewer@users.noreply.github.comecho"
+run_check "$REPO"
+if [[ "$RC" -eq 3 ]]; then pass "exit 3 on a single corrupted value"; else fail "expected 3, got $RC; out=$OUT"; fi
+rm -rf "$REPO"
+
+# -------- Test 11: legitimate unusual TLD is NOT flagged as corruption --------
+echo "Test 11: 'first.last@company.comm' is not flagged as corruption"
+REPO=$(make_repo)
+git -C "$REPO" config user.email "first.last@company.comm"
+run_check "$REPO"
+if [[ "$RC" -eq 0 ]]; then
+    pass "exit 0 for legitimate unusual-TLD address (no false positive)"
+else
+    fail "expected 0 (no false positive), got $RC; out=$OUT"
+fi
+rm -rf "$REPO"
+
+# -------- Test 12: no global identity -> remediation mentions --replace-all fallback --------
+echo "Test 12: no global identity present -> message mentions --replace-all fallback"
+REPO=$(make_repo)
+git -C "$REPO" config user.email "loom-curator@users.noreply.github.comecho"
+run_check "$REPO" "$EMPTY_GLOBAL"
+if [[ "$RC" -eq 3 ]] && echo "$OUT" | grep -qi -- "--replace-all"; then
+    pass "no-global-identity case still surfaces the --replace-all fallback"
+else
+    fail "expected 3 + --replace-all mention, got rc=$RC; out=$OUT"
+fi
+rm -rf "$REPO"
+
+# -------- Test 13: worktree-specific config (extensions.worktreeConfig) is read --------
+echo "Test 13: a value set only in a per-worktree config is detected"
+REPO=$(make_repo)
+git -C "$REPO" config user.email "main@example.com"
+git -C "$REPO" config extensions.worktreeConfig true
+git -C "$REPO" worktree add -q "$WORKDIR/wt13" -b feature-13 >/dev/null 2>&1
+git -C "$WORKDIR/wt13" config --worktree user.email "worktree-only@example.com"
+run_check "$WORKDIR/wt13"
+if [[ "$RC" -eq 1 ]] \
+   && echo "$OUT" | grep -q "main@example.com" \
+   && echo "$OUT" | grep -q "worktree-only@example.com"; then
+    pass "per-worktree config value detected alongside the repo-level value"
+else
+    fail "expected 1 + both values, got rc=$RC; out=$OUT"
+fi
+git -C "$REPO" worktree remove --force "$WORKDIR/wt13" >/dev/null 2>&1 || true
+rm -rf "$REPO"
+
+# -------- Test 14: corruption takes priority over a co-occurring multi-value warning --------
+echo "Test 14: corruption (exit 3) takes priority over plain multi-value (exit 1)"
+REPO=$(make_repo)
+git -C "$REPO" config user.email "clean@example.com"
+git -C "$REPO" config --add user.email "loom-worker@users.noreply.github.comecho"
+run_check "$REPO"
+if [[ "$RC" -eq 3 ]]; then
+    pass "corruption exit code (3) wins over plain multi-value (1)"
+else
+    fail "expected 3, got $RC; out=$OUT"
+fi
+rm -rf "$REPO"
+
+# -------- Summary --------
+echo ""
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+    echo -e "${GREEN}All $TESTS_PASSED/$TESTS_RUN tests passed${NC}"
+    exit 0
+else
+    echo -e "${RED}FAILED: $TESTS_FAILED/$TESTS_RUN tests failed${NC}"
+    exit 1
+fi

--- a/defaults/scripts/worktree.sh
+++ b/defaults/scripts/worktree.sh
@@ -1028,6 +1028,41 @@ if [[ -n "$PRUNE_OUTPUT" ]]; then
     fi
 fi
 
+# ─── Git identity hygiene check (#4369) ─────────────────────────────────────
+# Worktrees share the parent repo's local git config, so a corrupted local
+# user.email/user.name (stacked values, or a value with a glued-on shell
+# command like "...github.comecho" — Tauri-era residue, see
+# check-git-identity.sh's header) poisons every worktree created from this
+# repo, including this one. Hard-fail on the corruption pattern (it would
+# otherwise ship a garbled commit author silently — see PR #4303); warn (but
+# proceed) on a plain multi-value that doesn't match the corruption pattern,
+# since a pre-existing-but-unambiguous local config shouldn't strand a sweep.
+GIT_IDENTITY_CHECK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check-git-identity.sh"
+if [[ -x "$GIT_IDENTITY_CHECK" ]]; then
+    # Note: in --json mode fd 1 is already redirected to stderr (see the
+    # stdout-purity block above), so this plain `echo`/print output lands on
+    # stderr in both modes — only the explicit `>&3` JSON document below
+    # reaches the caller's stdout.
+    # `if VAR=$(cmd); then` (rather than a bare assignment) so a non-zero exit
+    # from the check does not trip `set -e` before we can inspect $? below.
+    if GIT_IDENTITY_OUTPUT=$("$GIT_IDENTITY_CHECK" 2>&1); then
+        GIT_IDENTITY_RC=0
+    else
+        GIT_IDENTITY_RC=$?
+    fi
+    if [[ "$GIT_IDENTITY_RC" -eq 3 ]]; then
+        print_error "Corrupted local git identity detected — refusing to create a worktree."
+        echo "$GIT_IDENTITY_OUTPUT"
+        if [[ "$JSON_OUTPUT" == "true" ]]; then
+            echo '{"success": false, "error": "corrupted-git-identity", "issueNumber": '"$ISSUE_NUMBER"'}' >&3
+        fi
+        exit 1
+    elif [[ "$GIT_IDENTITY_RC" -eq 1 ]]; then
+        print_warning "Stacked local git identity values detected (non-fatal — see details below)."
+        echo "$GIT_IDENTITY_OUTPUT"
+    fi
+fi
+
 # Resolve the repo's default branch once (cwd is now the main workspace, so
 # git symbolic-ref sees refs/remotes/origin/HEAD). Hard-fail rather than proceed
 # with an empty/wrong branch — an empty `origin/` refspec is worse than the


### PR DESCRIPTION
## Summary

Implements the rescoped acceptance criteria from the curated issue: the
historical writer of corrupted `user.email` values (Tauri-era
`terminal-actions.ts`) is already deleted (`d61acab0`), so this PR adds
detection, guard-hook wiring, remediation docs, and removes the dead
`gitIdentity` metadata that's now unused.

- **New `defaults/scripts/check-git-identity.sh`**: a read-only, LOCAL-scope-
  only detector (never global/system) for:
  1. **Corruption** — a `user.email`/`user.name` value matching the glued-
     shell-command pattern (e.g. `...github.comecho`) — hard problem, exit 3.
  2. **Multi-value** — more than one locally-stored value for a field with no
     corruption — ambiguous but non-fatal, exit 1 (warning).
  Reads both `--local` and `--worktree` scope so a value set only in a
  per-worktree config (`extensions.worktreeConfig`) is not missed, without
  ever surfacing global/system values (which would false-positive on
  ordinary setups). The corruption regex is anchored to
  `users\.noreply\.github\.com[a-zA-Z0-9]+$` specifically (not a generic
  `\.com[a-z]+$`) so it doesn't flag legitimate unusual TLDs like
  `user@company.comm`. Auto-remediation is deliberately out of scope — the
  script only detects and prints the exact remediation command.
- **New `defaults/scripts/tests/test-check-git-identity.sh`**: 14 tests
  covering clean/global-only/stacked/corrupted/single-corrupted/worktree-
  specific-config/no-global-identity-fallback/false-positive-avoidance cases.
- **`defaults/scripts/worktree.sh`**: invokes the check at worktree creation.
  Hard-fails (refuses to create the worktree) on the corruption pattern;
  warns but proceeds on a plain multi-value.
- **Removed the dead `gitIdentity` block** from all 8
  `defaults/roles/*.json` files that had it (architect, auditor, builder,
  curator, doctor, hermit, judge, loom) and the corresponding row in
  `defaults/roles/README.md` — verified zero code readers on `main`.
- **`defaults/docs/troubleshooting.md`**: new "Corrupted local git identity"
  section with the detect/fix workflow for consumers with already-corrupted
  checkouts.

## Test plan

- [x] New `test-check-git-identity.sh`: 14/14 tests pass, covering the full
      matrix from the curated issue's test plan (clean, stacked, corrupted,
      single corrupted, legitimate unusual-TLD non-flag, no-global-identity
      fallback message, per-worktree config detection, priority ordering).
- [x] Manual verification against a scratch repo: reproduced the corrupted
      state via `git config --add user.email
      loom-worker@users.noreply.github.comecho`, ran `worktree.sh` and
      confirmed it refuses with the remediation message (exit 1); ran the
      documented one-liner remediation and confirmed the worktree then
      creates cleanly; confirmed the plain multi-value case only warns and
      still creates the worktree.
- [x] `shellcheck --severity=warning` clean on both new scripts and on the
      modified `worktree.sh` (one pre-existing unrelated SC2126 style hint
      at line 1489, not touched by this change).
- [x] Existing worktree test suite (`test-worktree-*.sh`, 8 files) all still
      pass after the `worktree.sh` change.
- [x] `check-claude-md-budget.sh` / `check-phantom-labels.sh` /
      `check-labels-drift.sh` / `check-label-descriptions.sh` all clean.
- [x] All 8 edited `defaults/roles/*.json` files validated as syntactically
      valid JSON after the edit; grepped for zero remaining `gitIdentity`
      references and zero non-comment code readers anywhere in the repo.

Closes #4369