### PR TITLE
fix(daemon): make role-runner's per-root enabled gate diagnosable, not silent

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1915,10 +1915,10 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.mainHealthGate.enabled` | `LOOM_MAIN_HEALTH_GATE` | `false` | Gate loop on/off |
 | `autonomous.mainHealthGate.ciWorkflow` | `LOOM_GATE_CI_WORKFLOW` | *(unset)* | Forge workflow that must itself conclude `success` for forge-CI corroboration to vouch for a commit (#3987). Empty/whitespace → unset. Absent → today's unanimity rule, unchanged. See [Optional named verification workflow](#optional-named-verification-workflow-loom_gate_ci_workflow-3987) |
 | `autonomous.mainHealthGate.suppressDispatchDuringGate` | `LOOM_MAIN_HEALTH_GATE_SUPPRESS_DISPATCH` | `true` | Hold new dispatch off a root while its build-gate run is in flight (#4084), per-root so a sibling with no gate in flight keeps dispatching. Env truthy (`1`/`true`/`yes`/`on`) enables, any other value disables; wins over config. Set `false` to recover the pre-#4084 `is_halted`-only behavior. See [build-gate.md → gate-in-flight dispatch suppressor](build-gate.md) |
-| `autonomous.roleRunner.enabled` | `LOOM_ROLE_RUNNER` | `false` | Periodic standalone support-role runner on/off (#4015) |
-| `autonomous.roleRunner.roles` | *(config only)* | all 5 roles | Subset of `champion`/`curator`/`judge`/`auditor`/`guide` to dispatch; explicit empty array runs none |
+| `autonomous.roleRunner.enabled` | `LOOM_ROLE_RUNNER` | `false` | Periodic standalone support-role runner on/off (#4015). **Resolved per registered root** (#4377) — see the callout below the table |
+| `autonomous.roleRunner.roles` | *(config only)* | all 5 roles | Subset of `champion`/`curator`/`judge`/`auditor`/`guide` to dispatch; explicit empty array runs none. Also resolved from each root's own config |
 | `autonomous.roleRunner.intervalSecs` | `LOOM_ROLE_RUNNER_INTERVAL_SECS` | per-role built-in (5–15 min) | Uniform override applied to every enabled role's cadence |
-| `autonomous.roleRunner.onIdle` | *(config only)* | `[]` (none) | Subset of the same 5 roles to also fire on the work-finder **idle edge** (#4364) — the non-idle → idle transition (0 in-flight sweeps AND nothing dispatched this tick), in addition to the interval cadence. Absent → none (opposite default from `roles`); unknown names ignored with a warning. Debounced to min 60s per (root, role) and skipped while that role's interval/idle run is in progress. **Requires the work finder enabled** to observe idleness (a startup warning fires if set with the work finder off) |
+| `autonomous.roleRunner.onIdle` | *(config only)* | `[]` (none) | Subset of the same 5 roles to also fire on the work-finder **idle edge** (#4364) — the non-idle → idle transition (0 in-flight sweeps AND nothing dispatched this tick), in addition to the interval cadence. Absent → none (opposite default from `roles`); unknown names ignored with a warning. Debounced to min 60s per (root, role) and skipped while that role's interval/idle run is in progress. **Requires the work finder enabled** to observe idleness (a startup warning fires if set with the work finder off). **Also gated by that same root's own `enabled`** (#4377) — see below |
 | `autonomous.watchMonitor.enabled` | `LOOM_WATCH_MONITOR` | `true` | Durable operator-watch monitor loop (#3971). Default-on; no dispatch side effect, zero forge calls until a watch is registered |
 | `autonomous.watchMonitor.intervalSecs` | `LOOM_WATCH_MONITOR_INTERVAL_SECS` | `120` | Watch poll cadence. Zero/invalid → default |
 | `autonomous.watchMonitor.expirySecs` | `LOOM_WATCH_MONITOR_EXPIRY_SECS` | `86400` | Give-up window for an unresolved watch; `0` disables expiry |
@@ -2508,6 +2508,37 @@ re-reads the workspace registry every tick and dispatches into every
 registered repo that has that role enabled in its own config (an empty
 registry reduces to the single daemon workspace). See
 `loom-daemon/src/role_runner.rs` for the implementation.
+
+**`enabled` is resolved per root, not inherited (#4377).** `autonomous.roleRunner.enabled`
+(and `roles` / `onIdle`) is read from **each registered workspace's own**
+`.loom/config.json` — both the interval loops above and the `onIdle` idle-edge
+path call the identical `resolve_enabled(read_role_runner_config(root))` for
+`root`. The daemon workspace's own `autonomous.roleRunner.enabled` only decides
+whether these loops **start at all**; it does not propagate to the other
+workspaces `loom-daemon workspace add` registers. A registered workspace with
+no `autonomous` block of its own is therefore role-runner-disabled by default —
+including for `onIdle` — even when the daemon's own workspace has
+`enabled: true`. Set `autonomous.roleRunner.enabled: true` in **that root's
+own** config to opt it in.
+
+Before #4377 this per-root gate was silent: a disabled root's interval skip
+logged only at `debug!` (invisible at the default `info` level), and the
+`onIdle` bail logged nothing at any level. Now:
+
+- The interval loop logs a one-time `warn!` per root the first tick it sees
+  that root disabled (further identical ticks downgrade to `debug!`, mirroring
+  the `missing_roots_warned` dedup from #4326); the warning clears — and can
+  fire again — once the root re-enables and later disables again.
+- The `onIdle` path logs a one-time `warn!` on the first idle edge it observes
+  for a root that has `onIdle` roles configured but is disabled — the exact
+  silent no-op this issue fixes. A root with no `onIdle` configured stays quiet
+  when disabled: that is its normal, unconfigured state, not a
+  misconfiguration.
+- `loom-daemon status` shows each registered root's resolved role-runner
+  state in the "Managed repos" table's `ROLES` column (`on`/`off`), plus an
+  explicit note when a disabled root has `onIdle` roles configured — so the
+  "N of M registered workspaces are inert" state is diagnosable without
+  reading every root's config file by hand.
 
 ### Durable operator watches (#3971)
 

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1227,6 +1227,22 @@ pub fn build_daemon_status(
             // that is dispatching nothing is explained.
             (live, sr.quarantined_issues_sorted(), sr.unregistered_locked_issues())
         };
+        // Per-root role-runner enablement (#4377): resolved from this root's
+        // OWN `.loom/config.json`, never the daemon workspace's — the whole
+        // point of this status surface is that the two can legitimately
+        // differ (a registered workspace can be role-runner-disabled while
+        // the daemon's own workspace is enabled, or vice versa).
+        let role_runner_config = crate::role_runner::read_role_runner_config(root);
+        let role_runner_enabled = crate::role_runner::resolve_enabled(&role_runner_config);
+        let role_runner_roles = crate::role_runner::resolve_roles(&role_runner_config)
+            .iter()
+            .map(|spec| spec.name.to_string())
+            .collect();
+        let role_runner_on_idle_roles =
+            crate::role_runner::resolve_on_idle_roles(&role_runner_config)
+                .iter()
+                .map(|spec| spec.name.to_string())
+                .collect();
         per_repo.push(crate::types::RepoStatus {
             root: root.clone(),
             priority: workspace_registry.priority_of(root),
@@ -1251,6 +1267,9 @@ pub fn build_daemon_status(
             health_gate_verdict_tier: health_states
                 .gate_last_tier(root)
                 .map(|t| t.label().to_string()),
+            role_runner_enabled,
+            role_runner_roles,
+            role_runner_on_idle_roles,
         });
         in_flight.extend(live);
         unregistered_locked.extend(locked_unregistered.into_iter().map(|(issue, owner_pid)| {
@@ -4539,6 +4558,9 @@ exit 0
                 health_gate_deferred: false,
                 health_gate_deferred_reason: None,
                 health_gate_verdict_tier: Some("full".to_string()),
+                role_runner_enabled: true,
+                role_runner_roles: vec!["champion".to_string()],
+                role_runner_on_idle_roles: vec![],
             }],
             credential_preflight: Some(test_credential_preflight()),
             draining: false,

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -3708,6 +3708,13 @@ fn build_status_json_value(
             "health_gate_deferred": r.health_gate_deferred,
             "health_gate_deferred_reason": r.health_gate_deferred_reason,
             "health_gate_verdict_tier": r.health_gate_verdict_tier,
+            // Per-root role-runner enablement (#4377) — resolved from THIS
+            // root's own `.loom/config.json`, independent of the daemon
+            // workspace's own master switch. `on_idle_roles` non-empty while
+            // `enabled` is `false` is the exact silent-no-op this issue fixes.
+            "role_runner_enabled": r.role_runner_enabled,
+            "role_runner_roles": r.role_runner_roles,
+            "role_runner_on_idle_roles": r.role_runner_on_idle_roles,
         })).collect::<Vec<_>>(),
         // Forge-side pipeline snapshot (#3977) — present only when `--pipeline`
         // was passed; `null` otherwise so a consumer can tell "not requested"
@@ -4365,8 +4372,8 @@ fn print_status_human(
     if report.per_repo.is_empty() {
         println!("  (none)");
     } else {
-        println!("  {:>4}  {:>9}  {:<13}  REPO", "PRIO", "IN-FLIGHT", "GATE");
-        println!("  {:-<60}", "");
+        println!("  {:>4}  {:>9}  {:<13}  {:<5}  REPO", "PRIO", "IN-FLIGHT", "GATE", "ROLES");
+        println!("  {:-<68}", "");
         for r in &report.per_repo {
             // Same classification as the top-level summary above, condensed
             // for the table column (#3950 AC3, widened #4012).
@@ -4381,11 +4388,16 @@ fn print_status_human(
                 r.health_gate_verdict_at,
             );
             let gate = gate_status_short_label(&verdict);
+            // Per-root role-runner enablement (#4377) — resolved from this
+            // root's OWN config, so it can legitimately read "off" even while
+            // the daemon's own workspace has the loops running.
+            let roles = if r.role_runner_enabled { "on" } else { "off" };
             println!(
-                "  {:>4}  {:>9}  {:<13}  {}{}",
+                "  {:>4}  {:>9}  {:<13}  {:<5}  {}{}",
                 r.priority,
                 r.in_flight_count,
                 gate,
+                roles,
                 r.root.display(),
                 if r.root_missing {
                     "  [MISSING ROOT]"
@@ -4427,6 +4439,19 @@ fn print_status_human(
                     .collect::<Vec<_>>()
                     .join(", ");
                 println!("        quarantined (insta-crash, #3939): {list}");
+            }
+            // #4377: onIdle configured but the per-root gate is off is
+            // exactly the silent no-op this issue fixes — call it out
+            // explicitly rather than requiring the operator to cross-check
+            // the ROLES column against a separate onIdle listing.
+            if !r.role_runner_enabled && !r.role_runner_on_idle_roles.is_empty() {
+                let list = r.role_runner_on_idle_roles.join(", ");
+                println!(
+                    "        role runner disabled for this root but onIdle=[{list}] is \
+                     configured — these roles will never fire until \
+                     autonomous.roleRunner.enabled=true is set in this root's own \
+                     .loom/config.json (#4377)"
+                );
             }
         }
     }

--- a/loom-daemon/src/role_runner.rs
+++ b/loom-daemon/src/role_runner.rs
@@ -731,6 +731,12 @@ impl Drop for RoleRunGuard {
 pub struct IdleTrigger {
     prev_idle: HashMap<PathBuf, bool>,
     last_fired: HashMap<(PathBuf, &'static str), Instant>,
+    /// Roots for which a "disabled but onIdle configured" warning has
+    /// already been emitted (#4377) — the idle-path equivalent of the
+    /// interval loop's `missing_roots_warned` (#4326) dedup. Cleared for a
+    /// root the moment its role runner resolves enabled again, so a later
+    /// re-disable warns once more rather than staying silent forever.
+    disabled_warned: HashSet<PathBuf>,
 }
 
 impl IdleTrigger {
@@ -764,6 +770,14 @@ impl IdleTrigger {
     pub fn record_fired(&mut self, root: &Path, role: &'static str, now: Instant) {
         self.last_fired.insert((root.to_path_buf(), role), now);
     }
+
+    /// Whether a "disabled but onIdle configured" warning has already been
+    /// recorded for `root` (#4377) — test-observable dedup state; also the
+    /// hook a status/diagnostic surface could use without re-deriving it.
+    #[must_use]
+    pub fn disabled_warned(&self, root: &Path) -> bool {
+        self.disabled_warned.contains(root)
+    }
 }
 
 /// Decide which on-idle roles should fire for `root` right now, given this
@@ -776,7 +790,13 @@ impl IdleTrigger {
 ///    a tick that ends up not firing).
 /// 2. Bail on no edge, or on an active scheduled drain (#4090).
 /// 3. Bail when the role runner is disabled for this root
-///    ([`resolve_enabled`], precedence env > config > default).
+///    ([`resolve_enabled`], precedence env > config > default) — this is the
+///    **per-root** gate (#4377): it is resolved from `root`'s own
+///    `.loom/config.json`, independent of the daemon workspace's own master
+///    switch, which only decides whether the loops start at all. When
+///    `onIdle` roles are configured for `root` but the gate is off, this is
+///    the silent-no-op the issue exists to fix — see
+///    [`warn_if_idle_configured_but_disabled`].
 /// 4. Per configured on-idle role ([`resolve_on_idle_roles`]): skip if inside
 ///    the debounce window, or if an interval / idle run already holds the
 ///    in-progress guard; else record the fire and acquire the guard.
@@ -806,8 +826,12 @@ pub fn plan_idle_runs(
         return Vec::new();
     }
     if !resolve_enabled(config) {
+        warn_if_idle_configured_but_disabled(trigger, root, config);
         return Vec::new();
     }
+    // The root is enabled again — clear any stale disabled-warning so a
+    // later disable re-warns instead of staying silent forever (#4377).
+    trigger.disabled_warned.remove(root);
     let mut out = Vec::new();
     for spec in resolve_on_idle_roles(config) {
         if !trigger.debounce_ok(root, spec.name, now) {
@@ -833,6 +857,47 @@ pub fn plan_idle_runs(
         out.push((spec, guard));
     }
     out
+}
+
+/// Emit a warn-once-per-root line (#4377) when an idle edge fires for `root`
+/// while `onIdle` roles are configured there but the role runner is disabled
+/// for that root (`resolve_enabled` false). Before this the idle path bailed
+/// with **no log at any level** — every neighboring bail (drain, debounce,
+/// in-progress guard) already logs at `debug!`, so this was the fully-silent
+/// gap: a registered workspace with `onIdle` set but no
+/// `autonomous.roleRunner.enabled: true` in its own `.loom/config.json` got
+/// zero ticks and zero diagnostics.
+///
+/// A root with **no** `onIdle` roles configured stays silent here — disabled
+/// is that root's normal, unconfigured state, not a misconfiguration worth
+/// flagging on every idle edge. Dedup state lives on [`IdleTrigger`] (see
+/// [`IdleTrigger::disabled_warned`]) and is cleared the moment the root
+/// resolves enabled again ([`plan_idle_runs`]), so a later re-disable warns
+/// once more rather than staying silent forever.
+fn warn_if_idle_configured_but_disabled(
+    trigger: &mut IdleTrigger,
+    root: &Path,
+    config: &RoleRunnerConfig,
+) {
+    let on_idle = resolve_on_idle_roles(config);
+    if on_idle.is_empty() {
+        return;
+    }
+    if !trigger.disabled_warned.insert(root.to_path_buf()) {
+        return; // already warned for this root; stay quiet until it re-enables
+    }
+    log::warn!(
+        "role_runner: idle edge fired for {} with onIdle roles {:?} configured, but the role \
+         runner is disabled for this root (autonomous.roleRunner.enabled is false or absent in \
+         {}'s own .loom/config.json) — these roles will never fire here until \
+         autonomous.roleRunner.enabled=true is set in that root's own config; enablement is \
+         resolved per registered root, not inherited from the daemon workspace's master switch \
+         (#4377). This is a one-time warning for this root — see `loom-daemon status` for the \
+         current per-root state.",
+        root.display(),
+        on_idle.iter().map(|r| r.name).collect::<Vec<_>>(),
+        root.display(),
+    );
 }
 
 /// Observe `root`'s post-tick idle state and, on the idle edge, fire-and-forget
@@ -884,6 +949,18 @@ pub fn observe_and_fire_idle(
             }
         });
     }
+}
+
+/// Whether the interval loop ([`spawn_multi_role_task`]) should log a `WARN`
+/// (vs. a quieter, already-warned `DEBUG`) for `root` being disabled on this
+/// tick (#4377): `true` the first time `root` is newly inserted into
+/// `warned`, `false` on every subsequent tick until the caller removes it
+/// (which it does once `root` resolves enabled again). Pulled out as a pure
+/// function — mirroring [`classify_root_tick_log`] — so the warn-once dedup
+/// is unit-testable without a running loop or captured log output.
+#[must_use]
+fn should_warn_disabled_root(warned: &mut HashSet<PathBuf>, root: &Path) -> bool {
+    warned.insert(root.to_path_buf())
 }
 
 // ============================================================================
@@ -1009,6 +1086,14 @@ pub fn spawn_multi_role_task(
         // Per-root failing state (#4349), so a persistently failing tick logs
         // only on the fail edge and on recovery, not every tick.
         let mut failing_roots: HashMap<PathBuf, bool> = HashMap::new();
+        // Disabled-root warn-once state (#4377): the per-tick disabled-skip
+        // below is otherwise only a `debug!` — invisible at the default `info`
+        // level, so a registered root left disabled gets zero diagnostics.
+        // Same warn-once-then-dedup shape as `missing_roots_warned`, but
+        // without `filter_missing_roots`'s reset-every-tick semantics: an
+        // entry here is cleared only when its root resolves enabled again
+        // (see below), so re-disabling re-warns instead of staying silent.
+        let mut disabled_roots_warned: HashSet<PathBuf> = HashSet::new();
         loop {
             ticker.tick().await;
 
@@ -1041,14 +1126,40 @@ pub fn spawn_multi_role_task(
             for root in roots {
                 let config = read_role_runner_config(&root);
                 if !resolve_enabled(&config) {
-                    log::debug!(
-                        "role_runner: {} disabled for {} (autonomous.roleRunner.enabled=false or \
-                         LOOM_ROLE_RUNNER unset-falsy) — skipping",
-                        spec.name,
-                        root.display()
-                    );
+                    // Per-root gate (#4377): `enabled` is resolved from this
+                    // root's own `.loom/config.json`, independent of the
+                    // daemon workspace's master switch (which only decided
+                    // whether this loop started at all). First sighting warns
+                    // at `info`-visible `warn!`; repeats downgrade to
+                    // `debug!` so a persistently-disabled root does not spam
+                    // the log every tick forever.
+                    if should_warn_disabled_root(&mut disabled_roots_warned, &root) {
+                        log::warn!(
+                            "role_runner: {} disabled for {} — autonomous.roleRunner.enabled is \
+                             false or absent in that root's own .loom/config.json (enablement is \
+                             resolved per registered root, not inherited from the daemon \
+                             workspace's master switch, #4377); this root will receive zero {} \
+                             ticks until autonomous.roleRunner.enabled=true is set there (see \
+                             `loom-daemon status` for the current per-root state; further \
+                             identical skips for this root are logged at DEBUG until it \
+                             re-enables)",
+                            spec.name,
+                            root.display(),
+                            spec.name
+                        );
+                    } else {
+                        log::debug!(
+                            "role_runner: {} disabled for {} (autonomous.roleRunner.enabled=false \
+                             or LOOM_ROLE_RUNNER unset-falsy) — skipping (already warned above)",
+                            spec.name,
+                            root.display()
+                        );
+                    }
                     continue;
                 }
+                // The root resolved enabled again — clear any stale
+                // disabled-warning so a later disable re-warns (#4377).
+                disabled_roots_warned.remove(&root);
                 if !resolve_roles(&config).iter().any(|r| r.name == spec.name) {
                     log::debug!(
                         "role_runner: {} not in autonomous.roleRunner.roles for {} — skipping",
@@ -2124,6 +2235,183 @@ mod tests {
         assert!(plan_idle_runs(&mut t, &set, root, &cfg, false, false, now).is_empty());
         // Edge present, but role runner disabled => no fire.
         assert!(plan_idle_runs(&mut t, &set, root, &cfg, true, false, now).is_empty());
+        // #4377: onIdle is configured for this root, so the disabled-suppression
+        // must be observable, not silent.
+        assert!(t.disabled_warned(root), "onIdle configured + disabled must record a warning");
+    }
+
+    // ===================================================================
+    // #4377 — idle-path disabled-suppression is visible, not silent
+    // ===================================================================
+
+    #[test]
+    #[serial]
+    fn test_plan_idle_runs_disabled_without_on_idle_does_not_warn() {
+        // A root with no `onIdle` roles configured is disabled in its normal,
+        // unconfigured state — not a misconfiguration, so no warning.
+        std::env::remove_var(ROLE_RUNNER_ENABLE_ENV);
+        let mut t = IdleTrigger::new();
+        let set = new_in_progress_guard();
+        let root = Path::new("/tmp/loom-plan-no-onidle");
+        let cfg = RoleRunnerConfig {
+            enabled: Some(false),
+            roles: None,
+            interval_secs: None,
+            on_idle: None,
+        };
+        let now = Instant::now();
+        assert!(plan_idle_runs(&mut t, &set, root, &cfg, false, false, now).is_empty());
+        assert!(plan_idle_runs(&mut t, &set, root, &cfg, true, false, now).is_empty());
+        assert!(
+            !t.disabled_warned(root),
+            "no onIdle configured => disabled is normal, must not warn"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_plan_idle_runs_disabled_warning_dedupes_across_repeated_edges() {
+        std::env::remove_var(ROLE_RUNNER_ENABLE_ENV);
+        let mut t = IdleTrigger::new();
+        let set = new_in_progress_guard();
+        let root = Path::new("/tmp/loom-plan-dedupe");
+        let cfg = on_idle_config(Some(false), vec!["champion"]);
+        let t0 = Instant::now();
+        assert!(plan_idle_runs(&mut t, &set, root, &cfg, false, false, t0).is_empty());
+        // First edge: disabled, onIdle configured => warns.
+        assert!(plan_idle_runs(&mut t, &set, root, &cfg, true, false, t0).is_empty());
+        assert!(t.disabled_warned(root));
+        // Flap busy -> idle again: still disabled; the warning stays deduped
+        // (no observable way to detect a re-warn other than the state not
+        // regressing — the log line itself is the thing that must not repeat).
+        assert!(plan_idle_runs(
+            &mut t,
+            &set,
+            root,
+            &cfg,
+            false,
+            false,
+            t0 + Duration::from_secs(5)
+        )
+        .is_empty());
+        assert!(plan_idle_runs(
+            &mut t,
+            &set,
+            root,
+            &cfg,
+            true,
+            false,
+            t0 + Duration::from_secs(10)
+        )
+        .is_empty());
+        assert!(t.disabled_warned(root), "still deduped on the second edge");
+    }
+
+    #[test]
+    #[serial]
+    fn test_plan_idle_runs_disabled_warning_clears_once_enabled() {
+        std::env::remove_var(ROLE_RUNNER_ENABLE_ENV);
+        let mut t = IdleTrigger::new();
+        let set = new_in_progress_guard();
+        let root = Path::new("/tmp/loom-plan-clears");
+        let disabled_cfg = on_idle_config(Some(false), vec!["champion"]);
+        let enabled_cfg = on_idle_config(Some(true), vec!["champion"]);
+        let t0 = Instant::now();
+        assert!(plan_idle_runs(&mut t, &set, root, &disabled_cfg, false, false, t0).is_empty());
+        assert!(plan_idle_runs(&mut t, &set, root, &disabled_cfg, true, false, t0).is_empty());
+        assert!(t.disabled_warned(root));
+
+        // Root flips to enabled (hot-apply) well outside the debounce window.
+        assert!(plan_idle_runs(
+            &mut t,
+            &set,
+            root,
+            &enabled_cfg,
+            false,
+            false,
+            t0 + Duration::from_secs(70)
+        )
+        .is_empty());
+        let fire = plan_idle_runs(
+            &mut t,
+            &set,
+            root,
+            &enabled_cfg,
+            true,
+            false,
+            t0 + Duration::from_secs(80),
+        );
+        assert_eq!(fire.len(), 1, "enabled root must fire normally");
+        assert!(
+            !t.disabled_warned(root),
+            "warned flag must clear once the root resolves enabled"
+        );
+    }
+
+    /// Cross-config case (#4377 curated AC): a target root has `onIdle` set
+    /// but its own per-root `enabled` is absent (resolves `false`) —
+    /// independent of whatever the daemon's own workspace's master switch is
+    /// set to (the master switch only decides whether these loops start at
+    /// all, never a target root's own gate). `observe_and_fire_idle` is the
+    /// real entry point the work-finder loop calls, reading the root's own
+    /// on-disk config each tick — exercised here end-to-end rather than via
+    /// the already-parsed `RoleRunnerConfig` the other tests use.
+    #[test]
+    #[serial]
+    fn test_observe_and_fire_idle_cross_config_disabled_target_root_warns_and_suppresses() {
+        std::env::remove_var(ROLE_RUNNER_ENABLE_ENV);
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"autonomous": {"roleRunner": {"onIdle": ["champion"]}}}"#);
+        let mut trigger = IdleTrigger::new();
+        let in_progress = new_in_progress_guard();
+
+        observe_and_fire_idle(&mut trigger, &in_progress, tmp.path(), true, false); // boot idle: no edge
+        observe_and_fire_idle(&mut trigger, &in_progress, tmp.path(), false, false); // go busy: no edge
+        observe_and_fire_idle(&mut trigger, &in_progress, tmp.path(), true, false); // busy -> idle edge
+
+        assert!(
+            trigger.disabled_warned(tmp.path()),
+            "idle edge on a disabled-but-onIdle-configured root must record the warning"
+        );
+        assert!(
+            in_progress.lock().unwrap().is_empty(),
+            "a disabled root must never acquire/fire a run"
+        );
+
+        // A second flap must stay deduped — no panic, no re-fire, warned state
+        // holds (this is the "second edge does not re-warn" acceptance case).
+        observe_and_fire_idle(&mut trigger, &in_progress, tmp.path(), false, false);
+        observe_and_fire_idle(&mut trigger, &in_progress, tmp.path(), true, false);
+        assert!(trigger.disabled_warned(tmp.path()));
+        assert!(in_progress.lock().unwrap().is_empty());
+    }
+
+    // ===================================================================
+    // #4377 — interval-path disabled-root warn-once dedup
+    // ===================================================================
+
+    #[test]
+    fn test_should_warn_disabled_root_warns_once_then_dedupes_until_reenable() {
+        let mut warned: HashSet<PathBuf> = HashSet::new();
+        let root = PathBuf::from("/tmp/loom-interval-disabled-root");
+        assert!(
+            should_warn_disabled_root(&mut warned, &root),
+            "first sighting of a disabled root must warn"
+        );
+        assert!(
+            !should_warn_disabled_root(&mut warned, &root),
+            "repeat sighting must be deduped (downgraded to DEBUG by the caller)"
+        );
+        assert!(
+            !should_warn_disabled_root(&mut warned, &root),
+            "stays deduped across further ticks"
+        );
+        // Caller clears the entry once the root resolves enabled again.
+        warned.remove(&root);
+        assert!(
+            should_warn_disabled_root(&mut warned, &root),
+            "a re-disable after a re-enable must warn again"
+        );
     }
 
     #[test]

--- a/loom-daemon/src/serve.rs
+++ b/loom-daemon/src/serve.rs
@@ -344,6 +344,9 @@ mod tests {
             main_health_gate_not_evaluated_reason: None,
             main_health_gate_enabled: None,
             main_health_gate_verdict_at: None,
+            main_health_gate_deferred: false,
+            main_health_gate_deferred_reason: None,
+            main_health_gate_verdict_tier: None,
             capacity: CapacityReport {
                 ranking_present: false,
                 total_accounts: 0,

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -1302,6 +1302,38 @@ pub struct RepoStatus {
     /// [`DaemonStatusReport::main_health_gate_verdict_tier`].
     #[serde(default)]
     pub health_gate_verdict_tier: Option<String>,
+    /// Whether the periodic support-role runner (Issue #4015) is enabled for
+    /// **this** root's own `.loom/config.json` (Issue #4377) —
+    /// `role_runner::resolve_enabled(role_runner::read_role_runner_config(root))`,
+    /// resolved daemon-side, never the CLI client's environment. This is a
+    /// **per-root** gate, independent of whether the daemon's own workspace
+    /// happens to have `autonomous.roleRunner.enabled: true` — a registered
+    /// workspace can be `false` here even while the daemon's own workspace is
+    /// `true`, which was previously undiagnosable without reading that root's
+    /// config file directly (the motivating incident: 9 of 10 registered
+    /// workspaces silently receiving zero role ticks). `#[serde(default)]`
+    /// keeps pre-#4377 wire data / older daemon binaries compatible (an
+    /// absent field parses as `false`).
+    #[serde(default)]
+    pub role_runner_enabled: bool,
+    /// The interval-loop roles this root would dispatch if
+    /// [`Self::role_runner_enabled`] were `true` (Issue #4377) —
+    /// `role_runner::resolve_roles(..)` names, in [`crate::role_runner::DEFAULT_ROLES`]
+    /// order. Populated even when disabled, so `loom-daemon status` can show
+    /// *what* is being suppressed, not just *that* it is. `#[serde(default)]`
+    /// keeps pre-#4377 wire data compatible (an absent field parses as an
+    /// empty vec).
+    #[serde(default)]
+    pub role_runner_roles: Vec<String>,
+    /// This root's `autonomous.roleRunner.onIdle` roles (Issue #4377) —
+    /// `role_runner::resolve_on_idle_roles(..)` names. A non-empty value here
+    /// combined with [`Self::role_runner_enabled`] being `false` is exactly
+    /// the silent-no-op this issue fixes: `onIdle` configured, but the
+    /// per-root gate off, so it never fires. `#[serde(default)]` keeps
+    /// pre-#4377 wire data compatible (an absent field parses as an empty
+    /// vec).
+    #[serde(default)]
+    pub role_runner_on_idle_roles: Vec<String>,
 }
 
 /// One active insta-crash quarantine (Issue #4215), as surfaced by
@@ -1852,6 +1884,9 @@ mod tests {
             health_gate_deferred: false,
             health_gate_deferred_reason: None,
             health_gate_verdict_tier: None,
+            role_runner_enabled: false,
+            role_runner_roles: vec![],
+            role_runner_on_idle_roles: vec![],
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #4377

The role-runner's per-root enablement gate (`autonomous.roleRunner.enabled`,
resolved from each registered workspace's *own* `.loom/config.json`) was
completely silent when a registered root was disabled — no log line, no
status field. A repo with `onIdle` configured but its own `enabled` unset got
zero role ticks and zero diagnostics, indistinguishable from "working as
configured" (the incident that motivated this issue: 9 of 10 registered
workspaces on one host silently inert).

This is a **diagnostics-only** change — no change to which roots fire, or to
enablement semantics (both the interval loops and the `onIdle` idle-edge
path already gated per-root identically before this PR; the curator's
2026-07-29 rescope superseded the original issue's "pick one semantic" framing).

## Changes

- **Idle path** (`plan_idle_runs` / `observe_and_fire_idle`,
  `loom-daemon/src/role_runner.rs`): warn once per root, on the first idle
  edge that fires for a root with `onIdle` roles configured but the role
  runner disabled. Dedup state lives on `IdleTrigger.disabled_warned` and is
  cleared the moment the root resolves enabled again (a later re-disable
  warns once more). A root with **no** `onIdle` configured stays silent —
  disabled is its normal, unconfigured state, not a misconfiguration.
- **Interval path** (`spawn_multi_role_task`): warn once per root on the
  disabled-skip, mirroring the `missing_roots_warned` warn-once shape from
  #4326; further identical ticks downgrade to `debug!` until the root
  re-enables.
- **Status surface**: `DaemonStatusReport`/`RepoStatus` gains
  `role_runner_enabled` / `role_runner_roles` / `role_runner_on_idle_roles`
  per registered root (resolved daemon-side from that root's own config,
  never the CLI client's). `loom-daemon status` renders a `ROLES` (`on`/`off`)
  column in the "Managed repos" table, plus an explicit note line when a
  disabled root has `onIdle` roles configured.
- **Docs**: `defaults/docs/daemon-reference.md`'s roleRunner section now
  states explicitly that `enabled` (and `roles`/`onIdle`) is resolved **per
  registered root**, independent of the daemon workspace's own master
  switch (which only decides whether the loops start at all), and documents
  the new warn-once logging and status column.

## Test plan

- [x] `cargo test role_runner --lib` — includes new coverage: idle-disabled
  warning fires once and dedupes across repeated edges, clears once
  re-enabled, stays silent when no `onIdle` is configured, and an
  end-to-end `observe_and_fire_idle` cross-config case reading real
  on-disk config (master-workspace-agnostic target root: `onIdle` set,
  `enabled` absent). Also a pure-function test for the interval loop's
  warn-once dedup helper.
- [x] `cargo test --lib` (full suite, 1770 tests) — all pass.
- [x] `cargo test --bin loom-daemon` (main.rs unit tests) — all pass.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [ ] Manual verification on a live multi-workspace host (not performed in
  this sandbox): register a root with `onIdle` set and `enabled` absent →
  one warning on the first idle edge; `loom-daemon status` shows it as
  role-runner-disabled.