### PR TITLE
feat(loom-search): add Tier B pluggable local vector-embeddings ranking

### DIFF
--- a/defaults/docs/semantic-search.md
+++ b/defaults/docs/semantic-search.md
@@ -2,7 +2,8 @@
 
 Local-only, **opt-in, off-by-default** search over past sweep summaries and
 merged-PR history. Filed as the codecast-evaluation borrow-list item 2
-(`docs/research/codecast-evaluation.md`, Question 4) — issue #4339.
+(`docs/research/codecast-evaluation.md`, Question 4) — issue #4339. Tier B
+(pluggable local vector embeddings) is a follow-up, #4370.
 
 ## Why
 
@@ -29,6 +30,11 @@ Disabled by default. Enable one of:
 
 Resolution precedence is **env > config > default (off)** — the same
 convention as `autonomous.*` and `transcriptArchive`.
+
+Tier B (vector embeddings, #4370) is a **separate**, independently opt-in
+knob layered on top of the above — see "Tier B" below. `search.enabled=false`
+always fully disables `loom-search` regardless of the Tier B provider
+setting.
 
 ## Usage
 
@@ -68,15 +74,50 @@ v1 (doc note, not implemented).
 - Indexing is incremental: each sweep log is keyed by its mtime, each PR by
   its `mergedAt` timestamp; unchanged items are skipped on re-index.
 
-### Tier B (vector embeddings) — not built in v1
+### Tier B (vector embeddings, #4370)
 
-The schema includes an `embeddings` table placeholder and an `Embedder`
-protocol stub so a follow-up can add local (e.g. an ONNX model behind a
-`loom-tools[search]` optional extra) or remote embeddings, each gated by its
-own separate opt-in (a future `search.embeddings.provider` config key,
-default none). **No heavyweight ML dependency ships in this v1.** See the
-follow-up issue linked from PR #4339's implementation for the Tier B design
-discussion.
+A pluggable vector-similarity layer that fuses with (never replaces) the
+Tier A BM25 ranking above, via reciprocal rank fusion (`score = Σ 1/(60 +
+rank)` over the BM25 top-K and cosine-similarity top-K lists). Off by
+default and independent of `search.enabled` — a repo that only wants Tier A
+never triggers any of this code, including the import of the provider
+module.
+
+**Enablement** — `search.embeddings.provider` in `.loom/config.json` (env
+override `LOOM_SEARCH_EMBEDDINGS_PROVIDER`), same **env > config > default**
+precedence as `search.enabled`:
+
+```json
+{ "search": { "enabled": true, "embeddings": { "provider": "local" } } }
+```
+
+| Provider | Behavior |
+|---|---|
+| `"none"` (default) | No embeddings. Ranking is exactly the Tier A BM25 path — byte-identical to before #4370. |
+| `"local"` | A small local ONNX model via the optional [`fastembed`](https://github.com/qdrant/fastembed) package, gated behind the `loom-tools[search]` extra (`pip install 'loom-tools[search]'`). CPU-only; never a default/required dependency. |
+
+A remote-API provider is **explicitly out of scope** for #4370 — file a
+follow-up `loom:triage` issue if one is needed.
+
+**How it works**:
+
+- Embeddings are computed incrementally, piggybacking on the same
+  per-document watermark Tier A already uses — an unchanged sweep log or PR
+  is never re-embedded on re-index.
+- Vectors are stored in the existing `embeddings` table as little-endian
+  float32 blobs (`(source_type, source_id, model)` primary key), so
+  switching models never collides with a prior model's vectors.
+- Query-time similarity is brute-force cosine similarity in pure Python —
+  sufficient at this corpus size; no vector-index dependency
+  (`sqlite-vec`/`faiss`) is added.
+- If `provider=local` is configured but `fastembed` isn't installed:
+  **index time** hard-errors naming the install hint above; **query time**
+  prints a loud warning to stderr and degrades to the unmodified Tier A
+  BM25 ranking rather than failing the query.
+- If a document has no stored embedding yet (e.g. indexed before Tier B was
+  enabled, or a corrupt/short vector blob), it's skipped in the
+  cosine-similarity ranking (with a warning for a corrupt blob) — RRF still
+  runs with whatever BM25 and cosine data is available.
 
 ## Threat model
 
@@ -92,14 +133,25 @@ discussion.
 - **What leaves the host**: nothing, by default. The only network traffic is
   the `gh pr list` forge read during `loom-search index` — the same
   coordination-layer read every other Loom role already performs, not a sync
-  of local data off-host. If a future Tier B enables a remote embeddings
-  provider, that call (and its own opt-in) will be documented here at that
-  time; v1 makes no such call.
+  of local data off-host.
+- **Tier B (`search.embeddings.provider=local`, #4370)**: the **only**
+  additional outbound call is the one-time `fastembed` ONNX model download,
+  which happens on first construction of the local embedder (first `loom-search
+  index` run with `provider=local` for a given model). It is an explicit,
+  documented model-weights fetch — not telemetry and not a sync of indexed
+  content. Every subsequent `embed()` call (indexing or querying) is fully
+  offline: the model runs locally, and no indexed sweep-log/PR text is ever
+  transmitted anywhere. A remote embeddings provider remains out of scope for
+  #4370 and would need its own opt-in and its own documented network
+  behavior here before it ships.
 
-## Out of scope (v1)
+## Out of scope
 
-- Vector embeddings / any model download (Tier B follow-up issue).
+- Remote-API embeddings provider (deferred from #4370 — file a follow-up
+  `loom:triage` issue if needed).
 - Raw-transcript indexing over the #3726 transcript archive.
 - Issue-closing-comment ingest.
 - Any daemon/MCP surface — `loom-search` is a plain CLI.
 - Any networked storage backend.
+- A vector-index dependency (`sqlite-vec`/`faiss`) — brute-force cosine
+  similarity in pure Python is sufficient at this corpus size.

--- a/loom-tools/pyproject.toml
+++ b/loom-tools/pyproject.toml
@@ -70,6 +70,13 @@ loom-tokens = "loom_tools.tokens.cli:main"
 loom-resolve-model = "loom_tools.model_tiers:main"
 loom-search = "loom_tools.semantic_search:main"
 
+[project.optional-dependencies]
+# Tier B pluggable vector-embeddings for loom-search (#4370, follow-up to
+# #4339). Never a default/required dependency — only pulled in when a host
+# opts into `search.embeddings.provider=local`. See
+# defaults/docs/semantic-search.md and loom_tools/embedders.py.
+search = ["fastembed>=0.3"]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/loom-tools/src/loom_tools/embedders.py
+++ b/loom-tools/src/loom_tools/embedders.py
@@ -1,0 +1,102 @@
+"""Tier B pluggable vector-embeddings for ``loom-search`` (#4370, follow-up to #4339).
+
+Implements the ``Embedder`` protocol declared in
+:mod:`loom_tools.semantic_search` and a provider factory. Two providers:
+
+- ``"none"`` (default): no embeddings; ranking stays pure BM25, byte-identical
+  to the v1 (#4339) behavior. This module is never imported on that path.
+- ``"local"``: a small local ONNX model via the optional ``fastembed``
+  package, gated behind the ``loom-tools[search]`` extra. Imported lazily
+  (inside :class:`FastEmbedEmbedder`, not at module import time) so a
+  ``provider=none`` host never pulls in ``fastembed`` even transitively.
+
+A remote-API provider is explicitly **out of scope** for this PR — see the
+follow-up issue filed at ``loom:triage`` for that work.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+#: Default fastembed model — small (~130MB), CPU-only, ONNX-backed.
+DEFAULT_LOCAL_MODEL = "BAAI/bge-small-en-v1.5"
+
+#: Shared install hint surfaced in every missing-dependency error/warning.
+INSTALL_HINT = "pip install 'loom-tools[search]'"
+
+#: Valid values for ``search.embeddings.provider``.
+VALID_PROVIDERS = frozenset({"none", "local"})
+
+
+class Embedder(Protocol):
+    """A vector-embedding provider. Mirrors the stub declared in ``semantic_search``."""
+
+    def embed(self, text: str) -> list[float]:
+        """Return a vector embedding for ``text``."""
+        ...
+
+
+class MissingEmbeddingDependencyError(RuntimeError):
+    """Raised when a provider is configured but its optional dependency is absent."""
+
+
+class UnknownEmbeddingsProviderError(ValueError):
+    """Raised when ``search.embeddings.provider`` names an unrecognized provider."""
+
+
+class FastEmbedEmbedder:
+    """Local, CPU-only ONNX embeddings via the optional ``fastembed`` package.
+
+    The one-time model download (on first construction, first repo, first
+    model name) is the only outbound network call this provider makes; every
+    subsequent ``embed()`` call is fully offline. See
+    ``defaults/docs/semantic-search.md`` for the documented threat model.
+    """
+
+    def __init__(self, model_name: str = DEFAULT_LOCAL_MODEL) -> None:
+        try:
+            from fastembed import TextEmbedding
+        except ImportError as exc:
+            raise MissingEmbeddingDependencyError(
+                "search.embeddings.provider=local requires the 'fastembed' "
+                f"package, which is not installed. Install it with: {INSTALL_HINT}"
+            ) from exc
+        self.model_name = model_name
+        self._model = TextEmbedding(model_name=model_name)
+
+    def embed(self, text: str) -> list[float]:
+        (vector,) = self._model.embed([text])
+        return [float(x) for x in vector]
+
+
+def create_embedder(provider: str, *, model_name: str = DEFAULT_LOCAL_MODEL) -> Embedder | None:
+    """Provider factory.
+
+    Args:
+        provider: One of :data:`VALID_PROVIDERS`. ``"none"`` returns ``None``
+            (no embeddings) without importing anything else.
+        model_name: Model identifier passed through to the underlying
+            provider. Also stored verbatim as the ``embeddings.model`` column
+            so different models never collide.
+
+    Returns:
+        An :class:`Embedder` instance, or ``None`` when ``provider == "none"``.
+
+    Raises:
+        MissingEmbeddingDependencyError: ``provider`` is configured but its
+            optional dependency is not importable. Callers decide whether
+            that is a hard error (index time) or a caught, degraded warning
+            (query time) — this factory always raises so both call sites can
+            share one code path.
+        UnknownEmbeddingsProviderError: ``provider`` is not a recognized value.
+    """
+    if provider == "none":
+        return None
+    if provider == "local":
+        return FastEmbedEmbedder(model_name=model_name)
+    raise UnknownEmbeddingsProviderError(
+        f"Unknown search.embeddings.provider: {provider!r} (expected one of {sorted(VALID_PROVIDERS)})"
+    )

--- a/loom-tools/src/loom_tools/semantic_search.py
+++ b/loom-tools/src/loom_tools/semantic_search.py
@@ -21,9 +21,19 @@ this PR for the Tier B (vector embeddings) work.
 
 **Storage**: a SQLite database at ``.loom/search-index/index.db``
 (repo-local, gitignored). Ranking is SQLite FTS5 + BM25 — stdlib ``sqlite3``
-only, zero new dependencies. Tier B (pluggable embeddings) is designed in via
-the :class:`Embedder` protocol and the ``embeddings`` table, but not
-implemented in v1.
+only, zero new dependencies.
+
+**Tier B (#4370, follow-up to #4339)**: a pluggable vector-embeddings layer
+gated by its own opt-in, ``search.embeddings.provider`` in
+``.loom/config.json`` (env override ``LOOM_SEARCH_EMBEDDINGS_PROVIDER``),
+default ``"none"``. When ``"none"`` this module never imports
+:mod:`loom_tools.embedders` and ranking is exactly the Tier A BM25 path
+above. When ``"local"``, a small local ONNX model (via the optional
+``fastembed`` package, behind the ``loom-tools[search]`` extra — see
+:mod:`loom_tools.embedders`) populates the ``embeddings`` table
+incrementally (piggybacking on the same watermark as the FTS documents) and
+:func:`query_index` fuses BM25 + cosine-similarity rankings via reciprocal
+rank fusion. A remote-API provider is out of scope for #4370.
 
 **Enablement**: ``search.enabled`` in ``.loom/config.json`` (read via the
 canonical :mod:`loom_tools.common.config_resolver`), with env override
@@ -42,9 +52,11 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import math
 import os
 import re
 import sqlite3
+import struct
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -58,6 +70,15 @@ logger = logging.getLogger(__name__)
 
 #: Env var overriding ``search.enabled`` in ``.loom/config.json``.
 SEARCH_ENABLED_ENV = "LOOM_SEARCH_ENABLED"
+
+#: Env var overriding ``search.embeddings.provider`` in ``.loom/config.json``.
+EMBEDDINGS_PROVIDER_ENV = "LOOM_SEARCH_EMBEDDINGS_PROVIDER"
+
+#: Default Tier B provider — no embeddings, pure BM25 ranking.
+DEFAULT_EMBEDDINGS_PROVIDER = "none"
+
+#: ``k`` constant in the reciprocal rank fusion formula ``1 / (k + rank)``.
+RRF_K = 60
 
 #: Repo-relative directory the SQLite index lives under. Must stay gitignored
 #: (see ``.gitignore``) — a misconfigured/un-ignored destination refuses to
@@ -150,6 +171,28 @@ def is_search_enabled(repo_root: Path) -> bool:
         return env_bool(SEARCH_ENABLED_ENV, default=False)
     effective = resolve_effective_config(repo_root)
     return bool(get_path(effective, "search.enabled", False))
+
+
+def resolve_embeddings_provider(repo_root: Path) -> str:
+    """Resolve ``search.embeddings.provider`` for ``repo_root``.
+
+    Precedence: env (:data:`EMBEDDINGS_PROVIDER_ENV`) > ``search.embeddings.provider``
+    in the resolved config tree > default (:data:`DEFAULT_EMBEDDINGS_PROVIDER`,
+    ``"none"``), mirroring :func:`is_search_enabled`'s env > config > default
+    convention. This is a **separate** opt-in from ``search.enabled`` — a
+    non-``"none"`` provider with ``search.enabled`` false is still fully off,
+    since every caller of this function only runs once Tier A is enabled
+    (:func:`build_index` and :func:`query_index`'s CLI entry point both gate
+    on :func:`is_search_enabled` first).
+    """
+    if EMBEDDINGS_PROVIDER_ENV in os.environ:
+        value = os.environ[EMBEDDINGS_PROVIDER_ENV].strip().lower()
+        return value or DEFAULT_EMBEDDINGS_PROVIDER
+    effective = resolve_effective_config(repo_root)
+    value = get_path(effective, "search.embeddings.provider", DEFAULT_EMBEDDINGS_PROVIDER)
+    if not isinstance(value, str) or not value.strip():
+        return DEFAULT_EMBEDDINGS_PROVIDER
+    return value.strip().lower()
 
 
 # --------------------------------------------------------------------------
@@ -298,9 +341,16 @@ def _sweep_log_paths(repo_root: Path) -> list[Path]:
     return sorted(logs_dir.glob("sweep-issue-*.log"))
 
 
-def index_sweep_logs(conn: sqlite3.Connection, repo_root: Path) -> int:
-    """Ingest sweep-log tails. Returns the count of newly indexed/changed rows."""
-    new_count = 0
+def index_sweep_logs(conn: sqlite3.Connection, repo_root: Path) -> list[dict[str, str]]:
+    """Ingest sweep-log tails.
+
+    Returns the newly indexed/changed documents (empty dicts for unchanged
+    ones are skipped) — the same watermark gate :func:`_upsert_document`
+    already applies, reused here so Tier B embedding computation only ever
+    runs against genuinely new/changed content (never a no-op re-embed of
+    unchanged documents).
+    """
+    changed: list[dict[str, str]] = []
     for log_path in _sweep_log_paths(repo_root):
         match = _SWEEP_LOG_RE.search(log_path.name)
         if not match:
@@ -314,18 +364,21 @@ def index_sweep_logs(conn: sqlite3.Connection, repo_root: Path) -> int:
         tail = _read_log_tail(log_path)
         if not tail.strip():
             continue
-        changed = _upsert_document(
+        title = f"Sweep issue #{issue}"
+        is_changed = _upsert_document(
             conn,
             source_type="sweep",
             source_id=issue,
             watermark=watermark,
-            title=f"Sweep issue #{issue}",
+            title=title,
             body=tail,
             link=str(log_path),
         )
-        if changed:
-            new_count += 1
-    return new_count
+        if is_changed:
+            changed.append(
+                {"source_type": "sweep", "source_id": issue, "title": title, "body": tail, "link": str(log_path)}
+            )
+    return changed
 
 
 # --------------------------------------------------------------------------
@@ -372,10 +425,10 @@ def _run_gh_pr_list(repo_root: Path, limit: int = PR_FETCH_LIMIT) -> list[dict[s
     return data if isinstance(data, list) else []
 
 
-def index_prs(conn: sqlite3.Connection, repo_root: Path) -> int:
-    """Ingest merged PR titles/bodies. Returns count of newly indexed/changed rows."""
+def index_prs(conn: sqlite3.Connection, repo_root: Path) -> list[dict[str, str]]:
+    """Ingest merged PR titles/bodies. Returns the newly indexed/changed documents."""
     prs = _run_gh_pr_list(repo_root)
-    new_count = 0
+    changed: list[dict[str, str]] = []
     for pr in prs:
         number = pr.get("number")
         if number is None:
@@ -384,7 +437,7 @@ def index_prs(conn: sqlite3.Connection, repo_root: Path) -> int:
         title = pr.get("title") or ""
         body = pr.get("body") or ""
         link = pr.get("url") or ""
-        changed = _upsert_document(
+        is_changed = _upsert_document(
             conn,
             source_type="pr",
             source_id=str(number),
@@ -393,9 +446,73 @@ def index_prs(conn: sqlite3.Connection, repo_root: Path) -> int:
             body=body,
             link=link,
         )
-        if changed:
-            new_count += 1
-    return new_count
+        if is_changed:
+            changed.append({"source_type": "pr", "source_id": str(number), "title": title, "body": body, "link": link})
+    return changed
+
+
+# --------------------------------------------------------------------------
+# Tier B: embeddings (#4370, follow-up to #4339)
+# --------------------------------------------------------------------------
+
+
+def _pack_vector(vector: list[float]) -> bytes:
+    """Serialize a vector as little-endian float32, matching the ``vector BLOB`` column."""
+    return struct.pack(f"<{len(vector)}f", *vector)
+
+
+def _unpack_vector(blob: bytes) -> list[float] | None:
+    """Deserialize a little-endian float32 vector, or ``None`` for a corrupt/short blob."""
+    if not blob or len(blob) % 4 != 0:
+        logger.warning(
+            "Skipping embeddings row with corrupt/short vector blob (%d bytes)",
+            len(blob) if blob else 0,
+        )
+        return None
+    count = len(blob) // 4
+    try:
+        return list(struct.unpack(f"<{count}f", blob))
+    except struct.error:
+        logger.warning("Skipping embeddings row with unparsable vector blob")
+        return None
+
+
+def _embed_changed_documents(
+    conn: sqlite3.Connection,
+    provider: str,
+    changed: list[dict[str, str]],
+) -> None:
+    """Populate ``embeddings`` for newly indexed/changed documents (watermark-gated).
+
+    Only ever called with the subset of documents :func:`index_sweep_logs` /
+    :func:`index_prs` report as new/changed this run — unchanged documents
+    are never re-embedded. Raises :class:`loom_tools.embedders.MissingEmbeddingDependencyError`
+    (hard error, naming the ``loom-tools[search]`` install hint) when
+    ``provider`` is configured but its dependency is not importable; this is
+    intentionally NOT caught here — index-time failures should be loud.
+    """
+    if not changed:
+        return
+
+    from loom_tools.embedders import create_embedder
+
+    embedder = create_embedder(provider)
+    if embedder is None:  # provider == "none"; defensive, callers already gate on this
+        return
+
+    model = getattr(embedder, "model_name", provider)
+    for doc in changed:
+        text = f"{doc['title']}\n\n{doc['body']}".strip()
+        vector = embedder.embed(text)
+        conn.execute(
+            """
+            INSERT INTO embeddings (source_type, source_id, model, vector)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(source_type, source_id, model)
+            DO UPDATE SET vector = excluded.vector
+            """,
+            (doc["source_type"], doc["source_id"], model, _pack_vector(vector)),
+        )
 
 
 # --------------------------------------------------------------------------
@@ -408,7 +525,10 @@ def build_index(repo_root: Path) -> dict[str, int]:
 
     A no-op (returns zero counts, creates nothing) when search is disabled.
     Otherwise creates ``.loom/search-index/index.db`` if absent, and ingests
-    sweep-log tails plus merged PRs, skipping unchanged items.
+    sweep-log tails plus merged PRs, skipping unchanged items. When
+    ``search.embeddings.provider`` (Tier B, #4370) resolves to something
+    other than ``"none"``, also populates ``embeddings`` for the
+    newly-indexed/changed documents from this run.
     """
     if not is_search_enabled(repo_root):
         return {"sweeps": 0, "prs": 0}
@@ -418,12 +538,17 @@ def build_index(repo_root: Path) -> dict[str, int]:
 
     conn = _connect(index_db_path(repo_root))
     try:
-        sweeps = index_sweep_logs(conn, repo_root)
-        prs = index_prs(conn, repo_root)
+        changed_sweeps = index_sweep_logs(conn, repo_root)
+        changed_prs = index_prs(conn, repo_root)
         conn.commit()
+
+        provider = resolve_embeddings_provider(repo_root)
+        if provider != "none":
+            _embed_changed_documents(conn, provider, changed_sweeps + changed_prs)
+            conn.commit()
     finally:
         conn.close()
-    return {"sweeps": sweeps, "prs": prs}
+    return {"sweeps": len(changed_sweeps), "prs": len(changed_prs)}
 
 
 # --------------------------------------------------------------------------
@@ -447,8 +572,148 @@ def _build_fts_query(query: str) -> str:
     return escaped_phrase
 
 
+def _rank_bm25_rows(rows: list[tuple], query: str) -> list[SearchResult]:
+    """Sort raw ``bm25(documents)`` rows, exact-phrase hits first (unchanged Tier A logic)."""
+    query_lower = query.strip().lower()
+    scored = []
+    for source_type, source_id, title, body, link, rank in rows:
+        summary_line = next((line.strip() for line in body.splitlines() if line.strip()), "")
+        exact_phrase = bool(query_lower) and (
+            query_lower in title.lower() or query_lower in body.lower()
+        )
+        scored.append((not exact_phrase, rank, SearchResult(
+            source_type=source_type,
+            source_id=source_id,
+            title=title,
+            summary=summary_line,
+            link=link,
+            rank=rank,
+        )))
+    scored.sort(key=lambda r: (r[0], r[1]))
+    return [r[2] for r in scored]
+
+
+def _fetch_embeddings(conn: sqlite3.Connection, model: str) -> list[tuple[str, str, list[float]]]:
+    """Load and deserialize all stored vectors for ``model``, skipping corrupt blobs."""
+    rows = conn.execute(
+        "SELECT source_type, source_id, vector FROM embeddings WHERE model = ?", (model,)
+    ).fetchall()
+    out: list[tuple[str, str, list[float]]] = []
+    for source_type, source_id, blob in rows:
+        vector = _unpack_vector(blob)
+        if vector is not None:
+            out.append((source_type, source_id, vector))
+    return out
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Cosine similarity; ``0.0`` for empty/mismatched-dimension/zero-norm vectors (no div-by-zero)."""
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(x * x for x in b))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def _cosine_rank(
+    embedded_docs: list[tuple[str, str, list[float]]],
+    query_vector: list[float],
+    *,
+    limit: int,
+) -> list[tuple[str, str]]:
+    """Rank ``embedded_docs`` by cosine similarity to ``query_vector``, descending."""
+    scored = [
+        (_cosine_similarity(query_vector, vector), source_type, source_id)
+        for source_type, source_id, vector in embedded_docs
+    ]
+    scored.sort(key=lambda item: item[0], reverse=True)
+    return [(source_type, source_id) for _, source_type, source_id in scored[:limit]]
+
+
+def _reciprocal_rank_fusion(
+    *rankings: list[tuple[str, str]], k: int = RRF_K
+) -> dict[tuple[str, str], float]:
+    """Combine one or more ranked key lists via reciprocal rank fusion (``score = Σ 1/(k+rank)``)."""
+    scores: dict[tuple[str, str], float] = {}
+    for ranking in rankings:
+        for rank, key in enumerate(ranking, start=1):
+            scores[key] = scores.get(key, 0.0) + 1.0 / (k + rank)
+    return scores
+
+
+def _fuse_with_embeddings(
+    conn: sqlite3.Connection,
+    provider: str,
+    query: str,
+    bm25_results: list[SearchResult],
+    candidate_limit: int,
+) -> list[SearchResult] | None:
+    """Fuse ``bm25_results`` with a Tier B vector-similarity ranking via RRF.
+
+    Returns ``None`` to signal "degrade to the unmodified BM25 ranking" — a
+    missing optional dependency (loud stderr warning, per spec), an
+    embedding failure, or simply no embeddings stored yet for this model
+    (nothing to fuse). Never raises: query-time Tier B failures are always
+    non-fatal.
+    """
+    from loom_tools.embedders import MissingEmbeddingDependencyError, create_embedder
+
+    try:
+        embedder = create_embedder(provider)
+    except MissingEmbeddingDependencyError as exc:
+        print(f"[loom-search] {exc} Falling back to BM25-only ranking.", file=sys.stderr)
+        return None
+    if embedder is None:  # provider == "none"; caller already gates on this
+        return None
+
+    model = getattr(embedder, "model_name", provider)
+    embedded_docs = _fetch_embeddings(conn, model)
+    if not embedded_docs:
+        return None  # nothing to fuse yet; BM25 order stands unchanged
+
+    try:
+        query_vector = embedder.embed(query)
+    except Exception as exc:  # noqa: BLE001 - any provider-specific failure degrades, never raises
+        print(f"[loom-search] embedding the query failed ({exc}). Falling back to BM25-only ranking.", file=sys.stderr)
+        return None
+
+    cosine_keys = _cosine_rank(embedded_docs, query_vector, limit=candidate_limit)
+    bm25_keys = [(r.source_type, r.source_id) for r in bm25_results]
+    scores = _reciprocal_rank_fusion(bm25_keys, cosine_keys)
+
+    known = {(r.source_type, r.source_id): r for r in bm25_results}
+    for source_type, source_id in cosine_keys:
+        key = (source_type, source_id)
+        if key in known:
+            continue
+        row = conn.execute(
+            "SELECT title, body, link FROM documents WHERE source_type = ? AND source_id = ? LIMIT 1",
+            key,
+        ).fetchone()
+        if row is None:
+            continue
+        title, body, link = row
+        summary_line = next((line.strip() for line in body.splitlines() if line.strip()), "")
+        known[key] = SearchResult(
+            source_type=source_type, source_id=source_id, title=title, summary=summary_line, link=link, rank=0.0
+        )
+
+    ordered = sorted(scores.items(), key=lambda item: item[1], reverse=True)
+    return [known[key] for key, _ in ordered if key in known]
+
+
 def query_index(repo_root: Path, query: str, top_k: int = 10) -> list[SearchResult]:
-    """Run a BM25-ranked FTS5 query over the index. Empty list if no index/hits."""
+    """Run a ranked FTS5 query over the index. Empty list if no index/hits.
+
+    Tier A (``search.embeddings.provider`` resolves to ``"none"``, the
+    default): pure BM25 ranking — behavior is byte-identical to before #4370.
+    Tier B (provider != ``"none"``): fuses BM25 with vector-similarity
+    ranking via reciprocal rank fusion, degrading back to pure BM25 whenever
+    Tier B has nothing to contribute (see :func:`_fuse_with_embeddings`).
+    """
     db_path = index_db_path(repo_root)
     if not db_path.exists():
         return []
@@ -456,6 +721,7 @@ def query_index(repo_root: Path, query: str, top_k: int = 10) -> list[SearchResu
     conn = sqlite3.connect(str(db_path))
     try:
         conn.executescript(_SCHEMA)  # idempotent; guards a partial/corrupt DB
+        candidate_limit = max(top_k * 4, top_k)
         try:
             rows = conn.execute(
                 """
@@ -465,31 +731,21 @@ def query_index(repo_root: Path, query: str, top_k: int = 10) -> list[SearchResu
                 ORDER BY rank
                 LIMIT ?
                 """,
-                (_build_fts_query(query), max(top_k * 4, top_k)),
+                (_build_fts_query(query), candidate_limit),
             ).fetchall()
         except sqlite3.OperationalError:
-            return []
+            rows = []
+
+        bm25_results = _rank_bm25_rows(rows, query)
+
+        provider = resolve_embeddings_provider(repo_root)
+        if provider == "none":
+            return bm25_results[:top_k]
+
+        fused = _fuse_with_embeddings(conn, provider, query, bm25_results, candidate_limit)
+        return (fused if fused is not None else bm25_results)[:top_k]
     finally:
         conn.close()
-
-    query_lower = query.strip().lower()
-    results = []
-    for source_type, source_id, title, body, link, rank in rows:
-        summary_line = next((line.strip() for line in body.splitlines() if line.strip()), "")
-        exact_phrase = bool(query_lower) and (
-            query_lower in title.lower() or query_lower in body.lower()
-        )
-        results.append((not exact_phrase, rank, SearchResult(
-            source_type=source_type,
-            source_id=source_id,
-            title=title,
-            summary=summary_line,
-            link=link,
-            rank=rank,
-        )))
-
-    results.sort(key=lambda r: (r[0], r[1]))
-    return [r[2] for r in results[:top_k]]
 
 
 # --------------------------------------------------------------------------

--- a/loom-tools/tests/test_semantic_search.py
+++ b/loom-tools/tests/test_semantic_search.py
@@ -1,14 +1,40 @@
-"""Tests for the local-only, opt-in semantic search module (#4339)."""
+"""Tests for the local-only, opt-in semantic search module (#4339, #4370)."""
 
 from __future__ import annotations
 
 import json
+import logging
+import sqlite3
 import subprocess
 from pathlib import Path
 
 import pytest
 
+from loom_tools import embedders
 from loom_tools import semantic_search as ss
+
+
+class _StubEmbedder:
+    """Fixed-vector test double for :class:`loom_tools.embedders.Embedder` (#4370).
+
+    No real ``fastembed``/model download is needed in CI: ``embed()`` looks
+    up a vector by whether one of ``vectors_by_key``'s keys appears as a
+    substring of the input text (index-time calls embed the doc's
+    ``"<title>\\n\\n<body>"``, which contains the source_id), falling back to
+    ``query_vector`` (used for the raw query string at query time).
+    """
+
+    model_name = "stub-model"
+
+    def __init__(self, vectors_by_key: dict[str, list[float]], query_vector: list[float]) -> None:
+        self._vectors_by_key = vectors_by_key
+        self._query_vector = query_vector
+
+    def embed(self, text: str) -> list[float]:
+        for key, vector in self._vectors_by_key.items():
+            if key in text:
+                return vector
+        return self._query_vector
 
 
 def _init_repo(tmp_path: Path) -> Path:
@@ -42,9 +68,19 @@ def _ignore_search_index(repo_root: Path) -> None:
     (repo_root / ".gitignore").write_text(".loom/search-index/\n")
 
 
+def _embeddings_rows(repo_root: Path) -> list[tuple[str, str, str, bytes]]:
+    """Read all rows from the ``embeddings`` table directly (test helper)."""
+    conn = sqlite3.connect(str(ss.index_db_path(repo_root)))
+    try:
+        return conn.execute("SELECT source_type, source_id, model, vector FROM embeddings").fetchall()
+    finally:
+        conn.close()
+
+
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(ss.SEARCH_ENABLED_ENV, raising=False)
+    monkeypatch.delenv(ss.EMBEDDINGS_PROVIDER_ENV, raising=False)
 
 
 @pytest.fixture()
@@ -245,3 +281,260 @@ class TestCliIndexCommand:
         assert ss.index_db_path(repo).exists()
         out = capsys.readouterr().out
         assert "Indexed" in out
+
+
+# --------------------------------------------------------------------------
+# Tier B: pluggable vector embeddings (#4370, follow-up to #4339)
+# --------------------------------------------------------------------------
+
+
+class TestEmbeddingsProviderPrecedence:
+    def test_default_is_none(self, repo: Path) -> None:
+        assert ss.resolve_embeddings_provider(repo) == "none"
+
+    def test_config_true_enables_without_env(self, repo: Path) -> None:
+        _write_config(repo, {"search": {"embeddings": {"provider": "local"}}})
+        assert ss.resolve_embeddings_provider(repo) == "local"
+
+    def test_env_overrides_config(self, repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_config(repo, {"search": {"embeddings": {"provider": "local"}}})
+        monkeypatch.setenv(ss.EMBEDDINGS_PROVIDER_ENV, "none")
+        assert ss.resolve_embeddings_provider(repo) == "none"
+
+
+class TestProviderNoneUnchangedFromTierA:
+    """`provider=none` (default): zero behavior change vs. Tier A."""
+
+    def test_never_populates_embeddings_table(self, repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ss.SEARCH_ENABLED_ENV, "1")
+        monkeypatch.setattr(ss, "_run_gh_pr_list", lambda repo_root, limit=ss.PR_FETCH_LIMIT: [])
+        _ignore_search_index(repo)
+        _write_sweep_log(repo, 1, "database migration notes\n")
+
+        ss.build_index(repo)
+
+        assert _embeddings_rows(repo) == []
+
+    def test_query_results_are_byte_identical_to_pure_bm25(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ss.SEARCH_ENABLED_ENV, "1")
+        monkeypatch.setattr(ss, "_run_gh_pr_list", lambda repo_root, limit=ss.PR_FETCH_LIMIT: [])
+        _ignore_search_index(repo)
+        _write_sweep_log(repo, 101, "token exhaustion failure during dispatch\n")
+        _write_sweep_log(repo, 102, "token was rotated; exhaustion of retries too\n")
+
+        ss.build_index(repo)
+        results = ss.query_index(repo, "token exhaustion")
+
+        assert [r.source_id for r in results] == ["101", "102"]
+
+
+class TestEmbeddingsIndexing:
+    def test_provider_local_populates_embeddings_keyed_by_model(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ss.SEARCH_ENABLED_ENV, "1")
+        monkeypatch.setenv(ss.EMBEDDINGS_PROVIDER_ENV, "local")
+        monkeypatch.setattr(ss, "_run_gh_pr_list", lambda repo_root, limit=ss.PR_FETCH_LIMIT: [])
+        monkeypatch.setattr(
+            embedders,
+            "create_embedder",
+            lambda provider, **kwargs: _StubEmbedder(vectors_by_key={}, query_vector=[0.1, 0.2]),
+        )
+        _ignore_search_index(repo)
+        _write_sweep_log(repo, 55, "some sweep body text\n")
+
+        counts = ss.build_index(repo)
+        assert counts["sweeps"] == 1
+
+        rows = _embeddings_rows(repo)
+        assert len(rows) == 1
+        source_type, source_id, model, vector = rows[0]
+        assert (source_type, source_id) == ("sweep", "55")
+        assert model == "stub-model"
+        assert len(vector) % 4 == 0  # a well-formed packed-float32 blob
+
+    def test_reindex_with_unchanged_watermark_embeds_zero_new_rows(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ss.SEARCH_ENABLED_ENV, "1")
+        monkeypatch.setenv(ss.EMBEDDINGS_PROVIDER_ENV, "local")
+        monkeypatch.setattr(ss, "_run_gh_pr_list", lambda repo_root, limit=ss.PR_FETCH_LIMIT: [])
+        monkeypatch.setattr(
+            embedders,
+            "create_embedder",
+            lambda provider, **kwargs: _StubEmbedder(vectors_by_key={}, query_vector=[0.1, 0.2]),
+        )
+        _ignore_search_index(repo)
+        _write_sweep_log(repo, 55, "some sweep body text\n")
+
+        first = ss.build_index(repo)
+        assert first["sweeps"] == 1
+        assert len(_embeddings_rows(repo)) == 1
+
+        second = ss.build_index(repo)
+        assert second["sweeps"] == 0
+        assert len(_embeddings_rows(repo)) == 1  # no re-embed of the unchanged document
+
+
+class TestReciprocalRankFusion:
+    def test_fusion_reorders_when_cosine_strongly_favors_a_weaker_bm25_match(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ss.SEARCH_ENABLED_ENV, "1")
+        monkeypatch.setenv(ss.EMBEDDINGS_PROVIDER_ENV, "local")
+        monkeypatch.setattr(ss, "_run_gh_pr_list", lambda repo_root, limit=ss.PR_FETCH_LIMIT: [])
+        _ignore_search_index(repo)
+
+        # 301: exact-phrase match -> ranked first by pure BM25.
+        _write_sweep_log(repo, 301, "database migration completed successfully\n")
+        # 302: both terms present but not adjacent -> weaker BM25 match.
+        _write_sweep_log(repo, 302, "migration of the database happened yesterday\n")
+
+        query_vector = [1.0, 0.0]
+        vectors_by_key = {
+            "301": [0.0, 1.0],  # orthogonal to the query vector -> cosine ~0
+            "302": [1.0, 0.0],  # identical to the query vector -> cosine 1
+        }
+        monkeypatch.setattr(
+            embedders,
+            "create_embedder",
+            lambda provider, **kwargs: _StubEmbedder(vectors_by_key=vectors_by_key, query_vector=query_vector),
+        )
+
+        ss.build_index(repo)
+
+        # Sanity check: pure BM25 (provider=none) puts the exact-phrase doc first.
+        monkeypatch.setenv(ss.EMBEDDINGS_PROVIDER_ENV, "none")
+        bm25_only = ss.query_index(repo, "database migration")
+        assert [r.source_id for r in bm25_only] == ["301", "302"]
+
+        # Simulate "embeddings absent for a document" (e.g. 301 was indexed
+        # before Tier B was enabled and hasn't changed since) so only 302
+        # contributes a cosine rank — otherwise both docs would receive
+        # symmetric BM25+cosine contributions and tie.
+        conn = sqlite3.connect(str(ss.index_db_path(repo)))
+        conn.execute("DELETE FROM embeddings WHERE source_id = '301'")
+        conn.commit()
+        conn.close()
+
+        # Fusion (provider=local): 302's dominant cosine rank should flip the order.
+        monkeypatch.setenv(ss.EMBEDDINGS_PROVIDER_ENV, "local")
+        fused = ss.query_index(repo, "database migration")
+        assert [r.source_id for r in fused] == ["302", "301"]
+
+    def test_reciprocal_rank_fusion_helper_combines_scores(self) -> None:
+        bm25_ranking = [("sweep", "1"), ("sweep", "2")]
+        cosine_ranking = [("sweep", "2"), ("sweep", "1")]
+        scores = ss._reciprocal_rank_fusion(bm25_ranking, cosine_ranking)
+        # "2" is bm25-rank-2 + cosine-rank-1; "1" is bm25-rank-1 + cosine-rank-2.
+        # Both accumulate the same pair of terms (1/61 + 1/62) -> tie.
+        assert scores[("sweep", "1")] == pytest.approx(scores[("sweep", "2")])
+        assert scores[("sweep", "1")] == pytest.approx(1 / 61 + 1 / 62)
+
+
+class TestMissingEmbeddingDependency:
+    def test_hard_errors_at_index_time(self, repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ss.SEARCH_ENABLED_ENV, "1")
+        monkeypatch.setenv(ss.EMBEDDINGS_PROVIDER_ENV, "local")
+        monkeypatch.setattr(ss, "_run_gh_pr_list", lambda repo_root, limit=ss.PR_FETCH_LIMIT: [])
+        _ignore_search_index(repo)
+        _write_sweep_log(repo, 9, "hello world\n")
+
+        def _boom(provider: str, **kwargs: object) -> None:
+            raise embedders.MissingEmbeddingDependencyError(
+                f"search.embeddings.provider=local requires fastembed. Install with: {embedders.INSTALL_HINT}"
+            )
+
+        monkeypatch.setattr(embedders, "create_embedder", _boom)
+
+        with pytest.raises(embedders.MissingEmbeddingDependencyError, match=r"loom-tools\[search\]"):
+            ss.build_index(repo)
+
+    def test_degrades_to_bm25_with_warning_at_query_time(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv(ss.SEARCH_ENABLED_ENV, "1")
+        monkeypatch.setattr(ss, "_run_gh_pr_list", lambda repo_root, limit=ss.PR_FETCH_LIMIT: [])
+        _ignore_search_index(repo)
+        _write_sweep_log(repo, 9, "token exhaustion during dispatch\n")
+        ss.build_index(repo)  # indexed with provider=none; embeddings table stays empty
+
+        monkeypatch.setenv(ss.EMBEDDINGS_PROVIDER_ENV, "local")
+
+        def _boom(provider: str, **kwargs: object) -> None:
+            raise embedders.MissingEmbeddingDependencyError(f"boom: {embedders.INSTALL_HINT}")
+
+        monkeypatch.setattr(embedders, "create_embedder", _boom)
+
+        results = ss.query_index(repo, "token exhaustion")
+
+        assert results and results[0].source_id == "9"
+        err = capsys.readouterr().err
+        assert "loom-tools[search]" in err
+
+
+class TestEverythingOffWhenSearchDisabled:
+    def test_provider_local_with_search_disabled_is_still_fully_off(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ss.EMBEDDINGS_PROVIDER_ENV, "local")
+        _write_sweep_log(repo, 1, "hello\n")
+
+        counts = ss.build_index(repo)
+
+        assert counts == {"sweeps": 0, "prs": 0}
+        assert not ss.index_dir(repo).exists()
+
+
+class TestCorruptEmbeddingBlob:
+    def test_corrupt_or_short_blob_is_skipped_without_crashing(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setenv(ss.SEARCH_ENABLED_ENV, "1")
+        monkeypatch.setenv(ss.EMBEDDINGS_PROVIDER_ENV, "local")
+        monkeypatch.setattr(ss, "_run_gh_pr_list", lambda repo_root, limit=ss.PR_FETCH_LIMIT: [])
+        monkeypatch.setattr(
+            embedders,
+            "create_embedder",
+            lambda provider, **kwargs: _StubEmbedder(vectors_by_key={"1": [1.0, 0.0]}, query_vector=[1.0, 0.0]),
+        )
+        _ignore_search_index(repo)
+        _write_sweep_log(repo, 1, "database migration notes\n")
+
+        ss.build_index(repo)
+
+        # Corrupt the stored blob: 3 bytes is not a multiple of 4 (one float32).
+        conn = sqlite3.connect(str(ss.index_db_path(repo)))
+        conn.execute("UPDATE embeddings SET vector = ? WHERE source_id = '1'", (b"\x01\x02\x03",))
+        conn.commit()
+        conn.close()
+
+        with caplog.at_level(logging.WARNING):
+            results = ss.query_index(repo, "database migration")
+
+        assert results and results[0].source_id == "1"  # degrades to BM25-only, no crash
+        assert any(
+            "corrupt" in message.lower() or "short" in message.lower() for message in caplog.messages
+        )
+
+
+class TestCosineSimilarityEdgeCases:
+    def test_zero_vector_returns_zero_not_a_crash(self) -> None:
+        assert ss._cosine_similarity([], []) == 0.0
+        assert ss._cosine_similarity([0.0, 0.0], [1.0, 2.0]) == 0.0
+
+    def test_mismatched_dimensions_returns_zero(self) -> None:
+        assert ss._cosine_similarity([1.0], [1.0, 2.0]) == 0.0
+
+    def test_identical_vectors_return_one(self) -> None:
+        assert ss._cosine_similarity([1.0, 2.0], [1.0, 2.0]) == pytest.approx(1.0)
+
+
+class TestQueryIndexEmptyIndexNoDivisionByZero:
+    def test_empty_index_with_provider_local_returns_no_results(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ss.EMBEDDINGS_PROVIDER_ENV, "local")
+        assert ss.query_index(repo, "anything") == []


### PR DESCRIPTION
## Summary

Adds the Tier B pluggable vector-embeddings layer for `loom-search` (follow-up to #4339): a local, opt-in embeddings provider (`fastembed`, gated behind a new `loom-tools[search]` extra) that fuses with the existing BM25 ranking via reciprocal rank fusion, controlled by a new `search.embeddings.provider` config/env knob that is independent from `search.enabled`.

## Changes

- `loom-tools/src/loom_tools/embedders.py` (new) — `Embedder` protocol implementation (`FastEmbedEmbedder`, lazy-imports `fastembed`) + `create_embedder()` provider factory (`"none"` | `"local"`), `MissingEmbeddingDependencyError`.
- `loom-tools/src/loom_tools/semantic_search.py` — `resolve_embeddings_provider()` (env > config > default `"none"`, mirrors `is_search_enabled()`); `index_sweep_logs()`/`index_prs()` now report the changed-document set so `build_index()` can embed only new/changed documents (watermark-gated, never a stale re-embed); `query_index()` fuses BM25 + cosine-similarity rankings via reciprocal rank fusion (`score = Σ 1/(60+rank)`), degrading to pure BM25 whenever Tier B has nothing to contribute (provider=none, no stored embeddings, or a missing optional dependency at query time).
- `loom-tools/tests/test_semantic_search.py` — Tier B test coverage (37 tests total, all passing) using a fixed-vector stub `Embedder` (no real `fastembed`/model download needed in CI).
- `loom-tools/pyproject.toml` — adds `[project.optional-dependencies] search = ["fastembed>=0.3"]`; the default install is unaffected.
- `defaults/docs/semantic-search.md` — documents the Tier B enablement knob, provider table, RRF mechanism, and updates the threat model to name the one-time model-download outbound call.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| `provider=none` (default): zero behavior change vs. Tier A — no imports, no table writes, identical ranking | ✅ | `TestProviderNoneUnchangedFromTierA` — `embeddings` table stays empty; query results identical to pure BM25 |
| `fastembed` reachable only via `loom-tools[search]` extra; default install unaffected | ✅ | Added under `[project.optional-dependencies]`, not `dependencies`; `create_embedder`/`FastEmbedEmbedder` import `fastembed` lazily inside the class, never at module import time |
| Only outbound call is the documented one-time model download; no telemetry/off-host sync | ✅ | `defaults/docs/semantic-search.md` § Threat model updated; every `embed()` call after model construction is local-only |
| `defaults/docs/semantic-search.md` threat model names the outbound call | ✅ | New Tier B threat-model paragraph explicitly calls out the one-time `fastembed` model download |
| Config gate: `search.embeddings.provider`, env override, env > config > default | ✅ | `TestEmbeddingsProviderPrecedence` |
| Missing-dependency behavior: hard error at index, warn+BM25-fallback at query | ✅ | `TestMissingEmbeddingDependency` |
| Vector storage: little-endian float32 via `struct.pack`/`unpack` | ✅ | `_pack_vector`/`_unpack_vector`; `TestEmbeddingsIndexing` asserts blob length is a multiple of 4 |
| Ranking fusion: reciprocal rank fusion over BM25 + cosine top-K | ✅ | `_reciprocal_rank_fusion`; `TestReciprocalRankFusion` shows a doc with a dominant cosine rank flips the pure-BM25 order |
| Incremental: embedding piggybacks on the same watermark, no re-embed of unchanged docs | ✅ | `TestEmbeddingsIndexing::test_reindex_with_unchanged_watermark_embeds_zero_new_rows` |
| Edge cases: `search.enabled=false` + `provider=local` fully off; corrupt/short BLOB skipped with warning; empty index has no div-by-zero | ✅ | `TestEverythingOffWhenSearchDisabled`, `TestCorruptEmbeddingBlob`, `TestCosineSimilarityEdgeCases`, `TestQueryIndexEmptyIndexNoDivisionByZero` |
| Remote-API provider out of scope | ✅ | Not implemented; noted in docs as deferred to a future `loom:triage` issue if needed |

## Test Plan

```
PYTHONPATH=loom-tools/src:$PYTHONPATH python3 -m pytest loom-tools/tests/test_semantic_search.py -v
# 37 passed
```

No `fastembed` install or network access is required for CI — all Tier B tests use a fixed-vector stub `Embedder` monkeypatched in for `loom_tools.embedders.create_embedder`.

Closes #4370