### PR TITLE
fix(daemon): correct init banner's removed daemon.sh and bare role commands

### DIFF
--- a/loom-daemon/src/init/scaffolding.rs
+++ b/loom-daemon/src/init/scaffolding.rs
@@ -993,8 +993,9 @@ pub fn setup_repository_scaffolding(
     }
 
     // Install loom.sh convenience wrapper at repo root (always update from defaults)
-    // This is a thin wrapper around .loom/scripts/daemon.sh that lets
-    // users run `./loom.sh` from the repo root instead of the full script path.
+    // This is a thin wrapper around .loom/scripts/start-daemon.sh (the tmux
+    // agent-pool path) that lets users run `./loom.sh` from the repo root
+    // instead of the full script path.
     let loom_sh_src = defaults_path.join("loom.sh");
     let loom_sh_dst = workspace_path.join("loom.sh");
     if loom_sh_src.exists() {

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -2277,8 +2277,12 @@ fn handle_cli_command(command: Commands) -> Result<()> {
                         println!("\nSelf-installation skips file copying to prevent data loss.");
                         println!("   The Loom repo's .loom/ directory IS the source of truth.");
                         println!("\nTo use Loom orchestration:");
-                        println!("  - Open Claude Code terminals with /builder, /judge, etc.");
-                        println!("  - Or start the daemon: ./.loom/scripts/daemon.sh start");
+                        println!(
+                            "  - Open Claude Code terminals with /loom:builder, /loom:judge, etc."
+                        );
+                        println!(
+                            "  - Or start the daemon: ./.loom/scripts/cli/loom-daemon-start.sh"
+                        );
 
                         return Ok(());
                     }
@@ -2353,10 +2357,12 @@ fn handle_cli_command(command: Commands) -> Result<()> {
                     println!("  2. Choose your workflow:");
                     println!("     Manual Mode (recommended to start):");
                     println!("       cd {workspace_str} && claude");
-                    println!("       Then use /builder, /judge, or other role commands");
+                    println!("       Then use /loom:builder, /loom:judge, or other role commands");
                     println!("     Daemon Mode (autonomous orchestration):");
-                    println!("       cd {workspace_str} && ./.loom/scripts/daemon.sh start");
-                    println!("       Then in Claude Code: /loom");
+                    println!(
+                        "       cd {workspace_str} && ./.loom/scripts/cli/loom-daemon-start.sh"
+                    );
+                    println!("       Then in Claude Code: /loom:loom");
                     Ok(())
                 }
                 Err(e) => {


### PR DESCRIPTION
## Summary

`loom-daemon init`'s success banner (both the self-install and consumer-init
branches) still pointed at the removed `.loom/scripts/daemon.sh` (deleted in
#3432) and used unnamespaced role commands. Fixes:

- Self-install banner: `/builder, /judge, etc.` -> `/loom:builder, /loom:judge, etc.`;
  `./.loom/scripts/daemon.sh start` -> `./.loom/scripts/cli/loom-daemon-start.sh`
- Consumer init banner: `/builder, /judge, or other role commands` -> `/loom:builder,
  /loom:judge, or other role commands`; `./.loom/scripts/daemon.sh start` ->
  `./.loom/scripts/cli/loom-daemon-start.sh`; `Then in Claude Code: /loom` ->
  `Then in Claude Code: /loom:loom`
- Stale comment in `scaffolding.rs` claiming `loom.sh` wraps `daemon.sh` -> corrected
  to say it wraps `.loom/scripts/start-daemon.sh` (the tmux agent-pool path)

Wording now matches the 10+ other `./.loom/scripts/cli/loom-daemon-start.sh`
sites already in `main.rs`.

Closes #4379

## Verification

- `grep -n 'daemon\.sh' loom-daemon/src/main.rs` -> no hits
- No bare `/loom`, `/builder`, `/judge` (without `loom:` prefix) remains in
  init output strings in `main.rs`
- `cargo build --bin loom-daemon` — clean
- `cargo clippy --bin loom-daemon -- -D warnings` — clean
- `cargo fmt --check` — clean

## Note: `cargo test init` blocked by a pre-existing, unrelated main breakage

`cargo test` (and therefore `cargo test init`, since the whole crate must
compile to build the test binary) currently fails to compile on unmodified
`origin/main` with:

```
error[E0063]: missing fields `main_health_gate_deferred`,
`main_health_gate_deferred_reason` and `main_health_gate_verdict_tier` in
initializer of `types::DaemonStatusReport`
  --> loom-daemon/src/serve.rs:328:9
```

This is a semantic conflict between two commits that landed minutes apart
on main (`#4297`/`5192592e` added 3 fields to `DaemonStatusReport`; `#4404`/
`a410a506` added a test-only `empty_report()` builder that predates the new
fields). I verified this reproduces identically with and without this PR's
diff (isolated via a patch file, not `git stash`, to avoid a stash race with
a concurrent builder in another worktree — see below). It is unrelated to
this issue's scope (init banner strings) and already tracked in #4412
(`loom:urgent`), so I did not fix it here per the "don't fix pre-existing
issues you notice in other files" builder policy. Once #4412 lands,
`cargo test init` should be re-run to confirm this PR's change doesn't
regress it (it touches no test code, so I don't expect any impact).

## Aside: recovered a stash race, no working-tree loss

During verification I briefly used `git stash` (before realizing it's a
repo-global shared stack across all worktrees) and popped a concurrent
builder's `feature/issue-4378` WIP into this worktree by mistake. No data
was lost: I restored their WIP as a named stash entry
(`git stash store`, message references the race + timestamp) so they can
recover it, reverted the contamination from this worktree, and reapplied my
own commit's changes via `git stash apply <commit-hash>` (found via `git
fsck --unreachable`) rather than by index. Flagging here in case the
#4378 builder notices their worktree's stash history changed.