### PR TITLE
fix(daemon): downgrade dead-tmux-server restore log to debug when there is nothing to restore

### DIFF
--- a/loom-daemon/src/terminal.rs
+++ b/loom-daemon/src/terminal.rs
@@ -1095,6 +1095,18 @@ impl TerminalManager {
         log::info!("Set CLAUDE_CONFIG_DIR={config_dir_str} for session {tmux_session}");
     }
 
+    /// Classify a tmux `list-sessions` stderr string encountered during
+    /// `restore_from_tmux` as an *expected* "nothing to restore" condition.
+    ///
+    /// A dead tmux server (`no server running`) at restore time implies zero
+    /// live sessions by definition — there is nothing restorable *from tmux*,
+    /// which is the normal state on a host that has never run the Manual
+    /// Orchestration Mode tmux pool (e.g. autonomous-only), and also the
+    /// normal state immediately after a reboot. See #4378.
+    fn is_expected_empty_restore(stderr: &str) -> bool {
+        stderr.contains("no server running")
+    }
+
     /// Handle tmux command errors with consistent logging
     /// Returns true if the error indicates the tmux server is dead
     fn handle_tmux_error(stderr: &str, operation: &str) -> bool {
@@ -1644,6 +1656,16 @@ impl TerminalManager {
         // Enhanced logging: Check for tmux server failure
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
+
+            // Issue #4378: log the expected "nothing to restore" case at
+            // debug instead of routing it through `handle_tmux_error`'s
+            // ERROR siren, mirroring the existing `clean_stale_sessions`
+            // precedent for the same stderr pattern.
+            if Self::is_expected_empty_restore(&stderr) {
+                log::debug!("No tmux server during restore_from_tmux — nothing to restore");
+                return Ok(());
+            }
+
             Self::handle_tmux_error(&stderr, "restore_from_tmux");
 
             // Return early with empty list if server is dead
@@ -2079,6 +2101,27 @@ mod tests {
     #[test]
     fn test_validate_terminal_id_rejects_dots() {
         assert!(TerminalManager::validate_terminal_id("terminal.1").is_err());
+    }
+
+    // ===== is_expected_empty_restore tests (#4378) =====
+
+    #[test]
+    fn test_is_expected_empty_restore_no_server_running() {
+        assert!(TerminalManager::is_expected_empty_restore(
+            "no server running on /private/tmp/tmux-501/loom"
+        ));
+    }
+
+    #[test]
+    fn test_is_expected_empty_restore_no_sessions_is_not_expected() {
+        // "no sessions" is a distinct condition already handled separately by
+        // `handle_tmux_error` (debug, not error) — it must not be reclassified here.
+        assert!(!TerminalManager::is_expected_empty_restore("no sessions"));
+    }
+
+    #[test]
+    fn test_is_expected_empty_restore_other_error_is_not_expected() {
+        assert!(!TerminalManager::is_expected_empty_restore("some other tmux error"));
     }
 
     // ===== handle_tmux_error tests =====


### PR DESCRIPTION
## Summary

`restore_from_tmux_with_filter` logs an ERROR-level 🚨 siren every time `tmux -L loom list-sessions` fails with "no server running" — even when there is nothing to restore in the first place. On a host that has never run the Manual Orchestration Mode tmux pool (e.g. autonomous-only), this fires **twice** on every daemon boot: once from the eager boot-time `restore_from_tmux()` call, and again from `list_terminals()`'s lazy re-restore (triggered because the registry is still empty after the first failed attempt). A dead server at restore time implies zero live sessions by definition, so this is the expected steady state, not an anomaly — but the ERROR-level noise trains operators to ignore the error channel, which is exactly where real failures need to land.

## Changes

- Extracted the stderr classification into a new pure helper, `TerminalManager::is_expected_empty_restore`, which recognizes the `"no server running"` condition.
- In `restore_from_tmux_with_filter`, check this classification **before** delegating to `handle_tmux_error`: if the server is dead, log at `debug` and return `Ok(())` early instead of routing through the ERROR siren. This mirrors the existing `clean_stale_sessions` precedent in the same file, which already treats the identical stderr pattern as a silent `Ok(0)`.
- `handle_tmux_error` itself is untouched — its other call sites (`new`, `has_tmux_session`, `attach_to_session`, `kill_session`) operate on sessions the daemon believes are live, where a dead server genuinely is anomalous, and its `bool` return still drives control flow there. All of its existing unit tests pass unchanged.
- Added three unit tests for the new helper: `no server running` classifies as expected-empty; `no sessions` (a distinct, already-separately-handled condition) does not; an arbitrary other tmux error does not.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 0 configured-or-restorable terminals: skip the socket probe entirely or log at debug | ✅ | `restore_from_tmux_with_filter` still probes (`list-sessions`), but a "no server running" failure now logs at `debug` unconditionally instead of ERROR — a dead server at restore time means zero sessions were ever restorable, so there is no distinct "configured" case to special-case (see rationale below) |
| A genuinely dead tmux server with restorable terminal state may keep the ERROR | ✅ (permissive "may", satisfied by design) | A dead server at restore time implies zero live sessions to restore *from tmux*, regardless of what a workspace config declares — retaining the ERROR via a configured-terminals heuristic would re-create the false alarm on every reboot of a normal MOM host (launchd starts the daemon before any tmux session exists). AC 2 is worded permissively, and downgrading uniformly satisfies AC 1 and AC 3 without that regression. |
| No more ERROR lines on a clean autonomous-only boot | ✅ | Both restore call sites (eager boot-time `restore_from_tmux()` and `list_terminals()`'s lazy re-restore) route through the same `is_expected_empty_restore` check, so both no longer emit ERROR when the tmux server is absent |

## Test Plan

- `cargo check` / `cargo clippy --lib -- -D warnings` — clean.
- `cargo fmt -- --check src/terminal.rs` — clean.
- `cargo test --lib terminal::` — all 52 tests in the `terminal` module pass, including the 3 new `is_expected_empty_restore` tests.
- Manual reasoning: with no `-L loom` tmux server running, `restore_from_tmux_with_filter` now hits the new early-return branch and logs at `debug` instead of calling `handle_tmux_error`, eliminating both ERROR lines per boot described in the issue.

## Pre-existing Issues (Not Addressed)

`cargo test` at the workspace level currently fails to *compile* (test-only code) due to an unrelated, already-tracked regression: #4412 (`serve.rs`'s `empty_report()` test helper is missing three `DaemonStatusReport` fields added by a near-simultaneous PR, #4297 × #4404 semantic conflict). This blocks running the full `cargo test` suite in this worktree; I verified the `terminal` module in isolation by locally reapplying #4412's documented one-line fix to `serve.rs`, running `cargo test --lib terminal::` (52/52 passed, see Test Plan), then reverting that unrelated file before committing — `src/serve.rs` has no changes in this PR's diff.

Closes #4378