### PR TITLE
fix(daemon): add missing main_health_gate_* fields to serve.rs test helper

### DIFF
--- a/loom-daemon/src/serve.rs
+++ b/loom-daemon/src/serve.rs
@@ -344,6 +344,9 @@ mod tests {
             main_health_gate_not_evaluated_reason: None,
             main_health_gate_enabled: None,
             main_health_gate_verdict_at: None,
+            main_health_gate_deferred: false,
+            main_health_gate_deferred_reason: None,
+            main_health_gate_verdict_tier: None,
             capacity: CapacityReport {
                 ranking_present: false,
                 total_accounts: 0,


### PR DESCRIPTION
## Summary

Fixes the semantic merge conflict between #4404 (serve skeleton) and #4297 (tiered build gate): `serve.rs`'s `empty_report()` test helper predates #4297's three new `DaemonStatusReport` fields, breaking `cargo check --workspace --all-targets` on main.

## Fix

Added the three missing fields to the `empty_report()` initializer with the neutral defaults the issue specifies:
- `main_health_gate_deferred: false`
- `main_health_gate_deferred_reason: None`
- `main_health_gate_verdict_tier: None`

No behavior change outside `#[cfg(test)]` code.

## Test plan

- [x] `cargo check --workspace --all-targets` passes (was failing with E0063 on bare main)
- [x] `cargo test -p loom-daemon --lib serve` — all 6 `serve::tests::*` pass, including `build_snapshot_round_trips_zero_workspaces_edge_case`

Closes #4412