### PR TITLE
fix(sweep): per-builder main-clean cadence + atomic contamination quarantine (#4380)

### DIFF
--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -343,6 +343,17 @@ git -C "<WORKTREE_ABS>" status        # your changes should appear HERE
 ./.loom/scripts/check-main-clean.sh   # exits 3 if you contaminated main (#3513)
 ```
 
+**If it exits 3, clean up ALL-OR-NOTHING — never file by file (#4380).** Do not
+walk the offending paths with `git checkout -- <path>` / `rm <path>`; a
+half-restored main checkout is worse than either extreme. Re-run the check with
+`--quarantine` to move every offending path (tracked *and* untracked) into a
+stash rescue ref in one operation, then replay that diff inside your worktree:
+
+```bash
+./.loom/scripts/check-main-clean.sh --quarantine --label "issue=<N>"   # exit 4 ⇒ quarantined
+git -C "<MAIN_ROOT>" stash show -p stash@{0}                           # nothing was discarded
+```
+
 **If your working directory does NOT contain `.loom/worktrees/issue-`:**
 1. **STOP** - do not write any code
 2. Create the worktree: `./.loom/scripts/worktree.sh <issue-number>`

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -1355,7 +1355,7 @@ The numbered phases below (Curator → Builder → Judge → Doctor → Merge) a
 
 ### 0. Snapshot the main-worktree baseline (once, before wave 1) (#3648)
 
-**Before dispatching the first wave's builders**, snapshot main's current working-tree state so the per-wave contamination backstop (step 4's `check-main-clean.sh`) can distinguish builder contamination from dirt that predated the sweep:
+**Before dispatching the first wave's builders**, snapshot main's current working-tree state so the per-builder contamination backstop (step 4's `check-main-clean.sh`) can distinguish builder contamination from dirt that predated the sweep:
 
 ```bash
 MAIN_CLEAN_BASELINE=".loom/sweep-checkpoint/main-clean-baseline-${RUN_ID}.txt"
@@ -1531,6 +1531,19 @@ Each builder is responsible for:
 
 **Await all builders in the wave** before proceeding to Judge. Collect each builder's PR number (or failure marker). This await is **mandatory and explicit** — block on every builder's `TaskOutput` / completion notification. The harness may launch each Task async regardless of `run_in_background: false`, so proceeding to Judge on a dispatch flag alone can start Judge before builders finish; the "await all builders before Judge" rule is enforced by this explicit block, not by any dispatch flag (see "Subagent dispatch is async-only", #3822).
 
+**Run the main-clean check after EACH builder returns, not once per wave (#4380).** As each individual builder's `TaskOutput` arrives — before moving on to the next one's result and long before the wave advances to Judge — run the contamination check with that builder's issue in the label:
+
+```bash
+# Immediately after builder for issue N returns (per builder, inside the await loop):
+./.loom/scripts/check-main-clean.sh \
+    --baseline "$MAIN_CLEAN_BASELINE" \
+    --quarantine \
+    --label "run=$RUN_ID issue=$N"
+# exit 0 ⇒ clean · exit 4 ⇒ contamination found and QUARANTINED (continue) · exit 3 ⇒ dirty, NOT quarantined (hard-block)
+```
+
+Why per builder rather than per wave: with a single post-wave check, N builders share one detection point, so any contamination is attributable only to "some builder in this wave" and the risk window is wave-sized. Checking after each `TaskOutput` narrows the window to one builder and makes attribution exact — the `--label` value names the culprit in the quarantine log entry. See the Backstop section below for the full semantics, and keep the per-wave check as a final belt-and-suspenders pass.
+
 **Assert the Builder's cwd before it edits anything.** Before the Builder
 subagent prompt does any Write/Edit/Bash file mutation, it MUST capture
 `WORKTREE_ABS="$(cd .loom/worktrees/issue-N && pwd)"` and verify both: the
@@ -1542,15 +1555,51 @@ Validation" / "Validation Checklist", #4178). A denied write is never a signal
 to retry the same target through a different tool (Edit/Write vs. Bash) — see
 below.
 
-**Backstop: verify the main worktree is clean after the builders return (#3513).** A builder subagent is dispatched via the Task tool ("one level deep", step 4 above) and inherits the orchestrator's single shared process env, which has **no** `LOOM_WORKTREE_PATH` — the Task tool exposes no per-subagent env-injection parameter (#3719). `guard-worktree-paths.sh`'s path-derived fallback (#4007) DOES fire on this path regardless — it denies an Edit/Write target resolving into the main checkout while any managed worktree exists, with no env var required — and `guard-destructive-generic.sh` extends the identical confinement to the common Bash-tool write idioms (`>`/`>>` redirection, `tee`, `sed -i`, `cp`/`mv`, #4178, closing the escape sweep #4063 used: a write denied on Edit/Write retried through Bash instead). Despite that guard coverage, this `check-main-clean.sh` backstop stays load-bearing — it is a whole-tree status check, not an idiom scan, so it catches anything the guards' heuristics don't recognize (e.g. an interpreter one-liner like `python -c`, deliberately out of scope for #4178's pattern list) or a write that landed before any worktree existed. After the wave's builders return and before advancing any PR to Judge, run:
+**Backstop: verify the main worktree is clean after EACH builder returns (#3513, per-builder cadence + atomic quarantine #4380).** A builder subagent is dispatched via the Task tool ("one level deep", step 4 above) and inherits the orchestrator's single shared process env, which has **no** `LOOM_WORKTREE_PATH`, because the Task tool exposes no per-subagent env-injection parameter (#3719).
+
+> **Do not re-derive the stale "the guard cannot arm here" claim.** The absent env var does **not** disable worktree confinement. `guard-worktree-paths.sh`'s **path-derived fallback** (#4007, PR #4129) arms with **no env var at all**: it denies any Edit/Write whose target resolves into the main checkout while any `.loom-managed` worktree exists anywhere in the repo. This is directly evidenced, not theoretical — `.loom/logs/hook-errors.log` records a dense deny cluster during the 2026-07-29 #4364 build (`[guard-worktree-paths] Denied: BLOCKED: Edit/Write path '…/loom-daemon/src/main_health_gate.rs' resolves to the main repository checkout …`). `guard-destructive-generic.sh` extends the identical confinement to the common Bash-tool write idioms (`>`/`>>` redirection, `tee`, `sed -i`, `cp`/`mv`, #4178 / PR #4210), closing the escape #4063 used (a write denied on Edit/Write retried through Bash instead).
+>
+> **Both guards are PreToolUse DENY hooks. Neither guard reverts anything** — they block *before* the write lands, and never touch a file that already exists. So a builder narrative like "the guard reverted most of my edits" is a misreading of *denied* writes (which never landed) as *reverted* writes; the "partial" part of that story came from the builder's own ad-hoc per-file `git checkout --` cleanup, not from any hook. That ad-hoc cleanup is exactly what the `--quarantine` mode below replaces.
+
+This `check-main-clean.sh` backstop stays load-bearing despite the guard coverage: it is a whole-tree status check, not an idiom scan, so it catches anything the guards' heuristics don't recognize (an interpreter one-liner like `python -c`, `git apply`/`patch`, most deletion vectors — all deliberately out of scope for #4178's pattern list) or a write that landed before any worktree existed.
+
+**Cadence: after each individual builder's `TaskOutput`, plus once more after the whole wave.** The per-builder run is the primary one — its `--label` carries that builder's issue number, which is what makes the quarantine log entry attributable. The post-wave run is belt-and-suspenders (it catches anything that landed between the last builder's return and the Judge hand-off) and is labelled with the wave rather than an issue:
 
 ```bash
-./.loom/scripts/check-main-clean.sh --baseline "$MAIN_CLEAN_BASELINE"   # exit 3 ⇒ NEW main dirt (builder contamination)
+# Per builder, inside the await loop (primary — narrow window, exact attribution):
+./.loom/scripts/check-main-clean.sh --baseline "$MAIN_CLEAN_BASELINE" \
+    --quarantine --label "run=$RUN_ID issue=$N"
+
+# Once more after all builders in the wave return, before advancing any PR to Judge:
+./.loom/scripts/check-main-clean.sh --baseline "$MAIN_CLEAN_BASELINE" \
+    --quarantine --label "run=$RUN_ID wave=$WAVE_INDEX"
 ```
 
-The `--baseline` argument points at the snapshot taken once at step 0 (before wave 1). With it, the check subtracts any dirt that predated the sweep and exits `3` **only** on changes that appeared after the snapshot — so pre-existing working-tree dirt (a regenerated lockfile, an operator scratch edit) no longer false-positives as contamination on every wave (#3648). If the baseline file is missing or unreadable, the check warns and falls back to the whole-status hard-fail (fail-safe).
+The `--baseline` argument points at the snapshot taken once at step 0 (before wave 1). With it, the check subtracts any dirt that predated the sweep and flags **only** changes that appeared after the snapshot — so pre-existing working-tree dirt (a regenerated lockfile, an operator scratch edit) no longer false-positives as contamination on every check (#3648). If the baseline file is missing or unreadable, the check warns and falls back to the whole-status hard-fail (fail-safe).
 
-If it exits `3`, the main worktree carries **new** uncommitted changes a builder left behind. Surface this loudly in the wave summary — **quote the specific offending paths** the check printed under `Offending changes:` so the operator can see exactly which files escaped a worktree — and **hard-block the wave from advancing any PR to Judge** until the contamination is investigated and the stray changes reverted (move them into the owning issue worktree, then restore main). The guard-hook denials plus the cwd-assertion prompt discipline above are the primary defense; this status check is the backstop that catches whatever they miss.
+**Exit codes and what to do with each:**
+
+| Exit | Meaning | Action |
+|------|---------|--------|
+| `0` | Main is clean (or carries only baselined dirt) | Continue normally. |
+| `4` | New dirt was found and **quarantined** to a stash rescue ref; main is provably back at the baseline | **Continue** — do not hard-block. Record the quarantine in the wave summary (see below). |
+| `3` | New dirt was found and could **not** be quarantined (or `--quarantine` was not passed) | **Hard-block** the wave from advancing any PR to Judge until it is resolved. |
+
+**Remediation is ALL-OR-NOTHING, and `--quarantine` performs it.** On detection, the check moves **every** offending path — tracked modifications *and* untracked files together — into a stash rescue ref in **one** `git stash push --include-untracked` operation scoped to exactly those paths, then emits **exactly one** structured JSON line naming the label, the offending paths, and the stash commit:
+
+```
+{"event":"main-clean.quarantine","ts":"…","result":"quarantined","label":"run=… issue=4364","main":"/…","stash_ref":"stash@{0}","stash_commit":"<sha>","paths":["…"],"count":2}
+```
+
+That entry goes to stderr and is appended to `.loom/logs/main-quarantine.log` (override with `--log FILE`). Properties that matter:
+
+- **It is a rescue, never a discard.** The full diff survives in the stash; recover it with `git stash show -p <sha>` and replay it into the owning issue worktree.
+- **Baselined dirt is spared.** Only the paths the check flagged as *new* are stashed, so an operator's unrelated working-tree edits are untouched.
+- **It is verified.** After stashing, the check re-runs detection and only reports success (exit `4`) if main is back at the baseline; a residual-dirt result is reported as a failure (exit `3`), never as a partial success.
+
+**Do NOT restore contamination piecemeal.** Per-file `git checkout -- <path>` / `rm <path>` sequences are forbidden as the remediation path: they are what produced the half-restored main checkout this section exists to prevent, and a main checkout that is neither the baseline nor the builder's intended change is worse than either extreme. If for any reason you must remediate by hand (e.g. `--quarantine` itself failed and returned `3`), do it as a **single** `git stash push --include-untracked -m "loom-quarantine: run=$RUN_ID issue=$N" -- <all offending paths>` — one operation, all paths, logged.
+
+**Reporting.** Surface every non-zero result loudly in the wave summary — **quote the specific offending paths** the check printed (under `Offending changes:` on exit `3`, or in the `paths` array of the quarantine entry on exit `4`) so the operator can see exactly which files escaped a worktree, along with the stash sha when one was created. The guard-hook denials plus the cwd-assertion prompt discipline above are the primary defense; this status check is the backstop that catches whatever they miss, and the quarantine is what makes its cleanup deterministic.
 
 **On successful PR creation**, write the `builder-done` checkpoint for that issue (record the PR number):
 ```bash

--- a/defaults/scripts/check-main-clean.sh
+++ b/defaults/scripts/check-main-clean.sh
@@ -18,6 +18,8 @@
 #   ./.loom/scripts/check-main-clean.sh                  # check main worktree, exit 3 if dirty
 #   ./.loom/scripts/check-main-clean.sh --snapshot FILE  # record main's porcelain state to FILE, exit 0
 #   ./.loom/scripts/check-main-clean.sh --baseline FILE  # check main, ignoring dirt recorded in FILE
+#   ./.loom/scripts/check-main-clean.sh --baseline FILE --quarantine [--label TEXT] [--log FILE]
+#                                                        # ...and atomically stash any new dirt away
 #   ./.loom/scripts/check-main-clean.sh --help           # show usage
 #
 # Baseline mechanism (#3648):
@@ -31,7 +33,7 @@
 #   contamination; pre-existing dirt is ignored.
 #
 #     ./.loom/scripts/check-main-clean.sh --snapshot .loom/main-clean-baseline.txt   # once, before wave 1
-#     ./.loom/scripts/check-main-clean.sh --baseline .loom/main-clean-baseline.txt   # after each wave
+#     ./.loom/scripts/check-main-clean.sh --baseline .loom/main-clean-baseline.txt   # after each builder
 #
 #   Fail-safe: if the --baseline FILE is missing or unreadable, the check warns
 #   to stderr and falls back to the plain whole-status behavior (never a silent
@@ -39,12 +41,48 @@
 #   identical to the pre-#3648 whole-status hard-fail — the builder.md /
 #   builder-worktree.md manual call sites depend on that contract.
 #
+# Quarantine mode (#4380):
+#   Detection alone leaves remediation to whoever reads the failure — historically
+#   an ad-hoc, per-file `git checkout --` restore that can (and did) stop half
+#   way, leaving main in a state that is neither the pre-sweep baseline nor the
+#   builder's intended change. `--quarantine` makes remediation ATOMIC and
+#   LOGGED: on detecting new dirt, every offending path (tracked AND untracked)
+#   is moved to a stash rescue ref in ONE `git stash push --include-untracked`
+#   operation, and exactly one structured JSON line is emitted describing what
+#   was quarantined and where it went.
+#
+#     ./.loom/scripts/check-main-clean.sh --baseline "$MAIN_CLEAN_BASELINE" \
+#         --quarantine --label "run=$RUN_ID issue=$N"
+#
+#   - It is a RESCUE, never a discard: the full diff survives in the stash
+#     (`git stash list` / `git stash show -p <ref>`), so the work can be replayed
+#     into the correct worktree. Nothing is ever deleted.
+#   - Only paths the check flagged as NEW are stashed. Pre-existing (baselined)
+#     dirt is passed to `git stash push` as an explicit pathspec exclusion — an
+#     operator's unrelated working-tree edits are never swept up.
+#   - `--label TEXT` keys the stash message (e.g. the sweep RUN_ID + issue
+#     number) so a quarantined stash is attributable to the builder that caused
+#     it. Defaults to `$LOOM_QUARANTINE_LABEL`, else "unattributed".
+#   - `--log FILE` appends the same one-line JSON entry to FILE (best effort;
+#     never fails the check). Defaults to `<main>/.loom/logs/main-quarantine.log`
+#     when that directory exists.
+#   - Exit 4 (not 3) on a SUCCESSFUL quarantine: main is provably back at the
+#     baseline, so the caller can log and continue rather than hard-blocking. If
+#     the quarantine could not be completed, the exit stays 3 (hard-block).
+#   - `--quarantine` is intended with `--baseline`. It is accepted without one,
+#     in which case ALL non-Loom-owned dirt in main is quarantined (still a
+#     rescue ref, but with no notion of "pre-existing" to protect). It is a
+#     usage error with `--snapshot`.
+#
 # Exit codes:
 #   0 - Main worktree is clean (or, in --baseline mode, only pre-existing dirt
 #       remains); or a --snapshot completed successfully.
 #   2 - Usage error or could not resolve the main worktree (not a git repo).
 #   3 - Main worktree is DIRTY: uncommitted changes detected (the contamination
 #       this guard exists to catch). In --baseline mode, only NEW changes count.
+#       Also returned when a requested --quarantine could NOT be completed.
+#   4 - Main worktree WAS dirty and the new dirt was successfully quarantined to
+#       a stash rescue ref (--quarantine only). Main is back at the baseline.
 #
 # Notes:
 #   - "Dirty" means `git status --porcelain` on the MAIN worktree returns any
@@ -70,6 +108,7 @@ set -euo pipefail
 EXIT_OK=0
 EXIT_USAGE=2
 EXIT_MAIN_DIRTY=3
+EXIT_QUARANTINED=4
 
 # ---- Loom-owned transient state paths (#3778) ----------------------------
 # Runtime bookkeeping the sweep orchestrator itself writes under .loom/ during a
@@ -135,46 +174,92 @@ filter_loom_owned() {
     printf '%s' "${out%$'\n'}"
 }
 
+# Print the leading comment block (everything from line 2 up to the first
+# non-comment line) with the "# " prefix stripped. Derived from the file itself
+# so it can never drift out of sync with a hardcoded line range.
 usage() {
-    sed -n '2,54p' "$0" | sed 's/^# \{0,1\}//'
+    awk 'NR > 1 { if ($0 !~ /^#/) exit; sub(/^# ?/, ""); print }' "$0"
+}
+
+# unquote_path <porcelain-path> -> the real filesystem path.
+# `git status --porcelain` v1 wraps paths containing special characters in
+# double quotes and C-escapes them (\", \\, \ooo octal). Passing that literal
+# text to `git stash push` as a pathspec would miss the file, so decode it.
+unquote_path() {
+    local p="$1"
+    if [[ "$p" == \"*\" ]]; then
+        p="${p%\"}"
+        p="${p#\"}"
+        p=$(printf '%b' "$p")
+    fi
+    printf '%s' "$p"
 }
 
 # ---- Argument parsing ----------------------------------------------------
 # Modes: plain (no args, legacy back-compat), snapshot, baseline.
+# Flags:  --quarantine [--label TEXT] [--log FILE]  (#4380)
 MODE="plain"
 MODE_FILE=""
+QUARANTINE=0
+QUARANTINE_LABEL="${LOOM_QUARANTINE_LABEL:-}"
+QUARANTINE_LOG="${LOOM_QUARANTINE_LOG:-}"
 
-case "${1:-}" in
-    -h|--help)
-        usage
-        exit "$EXIT_OK"
-        ;;
-    "")
-        ;;
-    --snapshot)
-        if [[ -z "${2:-}" ]]; then
-            echo "check-main-clean.sh: --snapshot requires a file argument" >&2
-            echo "Run with --help for usage." >&2
-            exit "$EXIT_USAGE"
-        fi
-        MODE="snapshot"
-        MODE_FILE="$2"
-        ;;
-    --baseline)
-        if [[ -z "${2:-}" ]]; then
-            echo "check-main-clean.sh: --baseline requires a file argument" >&2
-            echo "Run with --help for usage." >&2
-            exit "$EXIT_USAGE"
-        fi
-        MODE="baseline"
-        MODE_FILE="$2"
-        ;;
-    *)
-        echo "check-main-clean.sh: unknown argument: $1" >&2
+require_value() {
+    # require_value <flag> <value-or-empty>
+    if [[ -z "$2" ]]; then
+        echo "check-main-clean.sh: $1 requires a file argument" >&2
         echo "Run with --help for usage." >&2
         exit "$EXIT_USAGE"
-        ;;
-esac
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit "$EXIT_OK"
+            ;;
+        --snapshot)
+            require_value "--snapshot" "${2:-}"
+            MODE="snapshot"
+            MODE_FILE="$2"
+            shift 2
+            ;;
+        --baseline)
+            require_value "--baseline" "${2:-}"
+            MODE="baseline"
+            MODE_FILE="$2"
+            shift 2
+            ;;
+        --quarantine)
+            QUARANTINE=1
+            shift
+            ;;
+        --label)
+            require_value "--label" "${2:-}"
+            QUARANTINE_LABEL="$2"
+            shift 2
+            ;;
+        --log)
+            require_value "--log" "${2:-}"
+            QUARANTINE_LOG="$2"
+            shift 2
+            ;;
+        *)
+            echo "check-main-clean.sh: unknown argument: $1" >&2
+            echo "Run with --help for usage." >&2
+            exit "$EXIT_USAGE"
+            ;;
+    esac
+done
+
+if [[ "$QUARANTINE" -eq 1 && "$MODE" == "snapshot" ]]; then
+    echo "check-main-clean.sh: --quarantine is not valid with --snapshot (nothing is checked in snapshot mode)" >&2
+    echo "Run with --help for usage." >&2
+    exit "$EXIT_USAGE"
+fi
+
+[[ -n "$QUARANTINE_LABEL" ]] || QUARANTINE_LABEL="unattributed"
 
 # ---- Resolve the main worktree root --------------------------------------
 # Resolve the canonical git common dir, then the main worktree root (its parent).
@@ -241,6 +326,124 @@ if [[ "$MODE" == "baseline" ]]; then
     fi
 fi
 
+# ---- Quarantine mode: atomically rescue new dirt to a stash ref (#4380) --
+# Runs only when contamination was actually detected. Everything below is a
+# no-op for callers that did not pass --quarantine.
+
+# json_escape <text> -> the text, escaped for embedding in a JSON string.
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\n'/\\n}"
+    printf '%s' "$s"
+}
+
+# emit_quarantine_log <json-line>
+# Writes EXACTLY ONE structured entry: to stderr always, and appended to the
+# quarantine log file when one is configured/derivable (best effort — a failed
+# append never changes the check's verdict).
+emit_quarantine_log() {
+    local line="$1"
+    printf '%s\n' "$line" >&2
+    local target="$QUARANTINE_LOG"
+    if [[ -z "$target" && -d "$main_root/.loom/logs" ]]; then
+        target="$main_root/.loom/logs/main-quarantine.log"
+    fi
+    if [[ -n "$target" ]]; then
+        local dir
+        dir=$(dirname "$target")
+        [[ -d "$dir" ]] || mkdir -p "$dir" 2>/dev/null || true
+        printf '%s\n' "$line" >> "$target" 2>/dev/null || true
+    fi
+}
+
+# Collect the offending (NEW) paths from the porcelain lines. Rename lines
+# ("old -> new") contribute BOTH sides so the rename is undone as a whole.
+collect_offending_paths() {
+    local line path
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        path="${line:3}"
+        if [[ "$path" == *" -> "* ]]; then
+            OFFENDING_PATHS+=("$(unquote_path "${path%% -> *}")")
+            path="${path##* -> }"
+        fi
+        OFFENDING_PATHS+=("$(unquote_path "$path")")
+    done <<< "$effective_status"
+}
+
+if [[ -n "$effective_status" && "$QUARANTINE" -eq 1 ]]; then
+    OFFENDING_PATHS=()
+    collect_offending_paths
+
+    ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+    stash_msg="loom-quarantine: $QUARANTINE_LABEL"
+
+    # Build the JSON path array once — reused by the success and failure entries.
+    paths_json=""
+    for p in "${OFFENDING_PATHS[@]}"; do
+        [[ -n "$paths_json" ]] && paths_json+=","
+        paths_json+="\"$(json_escape "$p")\""
+    done
+
+    quarantine_fail() {
+        # quarantine_fail <reason>
+        emit_quarantine_log "{\"event\":\"main-clean.quarantine\",\"ts\":\"$ts\",\"result\":\"failed\",\"label\":\"$(json_escape "$QUARANTINE_LABEL")\",\"main\":\"$(json_escape "$main_root")\",\"reason\":\"$(json_escape "$1")\",\"paths\":[$paths_json],\"count\":${#OFFENDING_PATHS[@]}}"
+        echo "ERROR: check-main-clean.sh: could not quarantine main-worktree contamination." >&2
+        echo "       Reason: $1" >&2
+        echo "       Main worktree: $main_root" >&2
+        echo "       The contamination is STILL PRESENT — do not advance the wave." >&2
+        echo "       Resolve it manually with a single atomic operation, e.g.:" >&2
+        echo "         git -C \"$main_root\" stash push --include-untracked -m \"$stash_msg\" -- <paths>" >&2
+        exit "$EXIT_MAIN_DIRTY"
+    }
+
+    # ONE operation covering tracked + untracked dirt. Restricted to the
+    # offending pathspecs so baselined (pre-existing) dirt is left untouched;
+    # `:(literal,top)` anchors each at the repo root and disables glob magic so
+    # a path containing `*`/`[` cannot over-match.
+    stash_pathspecs=()
+    for p in "${OFFENDING_PATHS[@]}"; do
+        stash_pathspecs+=(":(literal,top)$p")
+    done
+
+    stash_err=$(git -C "$main_root" stash push --include-untracked \
+        -m "$stash_msg" -- "${stash_pathspecs[@]}" 2>&1) || \
+        quarantine_fail "git stash push failed: $(printf '%s' "$stash_err" | tr '\n' ' ')"
+
+    stash_sha=$(git -C "$main_root" rev-parse --verify --quiet refs/stash 2>/dev/null || true)
+    if [[ -z "$stash_sha" ]]; then
+        quarantine_fail "git stash push reported success but no stash ref exists"
+    fi
+
+    # Verify the rescue was COMPLETE: re-run the same detection and require that
+    # no new dirt remains. A partial quarantine is exactly the failure mode this
+    # mode exists to prevent, so it is reported as a hard failure, not a success.
+    post_status=$(filter_loom_owned "$(git -C "$main_root" status --porcelain 2>/dev/null || true)")
+    post_effective="$post_status"
+    if [[ "$MODE" == "baseline" && -r "$MODE_FILE" ]]; then
+        post_effective=$(comm -13 \
+            <(sort "$MODE_FILE") \
+            <(printf '%s\n' "$post_status" | sort) \
+            | sed '/^$/d')
+    fi
+    if [[ -n "$post_effective" ]]; then
+        quarantine_fail "residual dirt remains after stash: $(printf '%s' "$post_effective" | tr '\n' ';')"
+    fi
+
+    emit_quarantine_log "{\"event\":\"main-clean.quarantine\",\"ts\":\"$ts\",\"result\":\"quarantined\",\"label\":\"$(json_escape "$QUARANTINE_LABEL")\",\"main\":\"$(json_escape "$main_root")\",\"stash_ref\":\"stash@{0}\",\"stash_commit\":\"$stash_sha\",\"stash_message\":\"$(json_escape "$stash_msg")\",\"paths\":[$paths_json],\"count\":${#OFFENDING_PATHS[@]}}"
+
+    echo "check-main-clean.sh: QUARANTINED ${#OFFENDING_PATHS[@]} contaminating path(s) from the main worktree." >&2
+    echo "       Main worktree: $main_root (now matches the baseline)" >&2
+    echo "       Rescue ref:    stash@{0} = $stash_sha  (\"$stash_msg\")" >&2
+    echo "       Nothing was discarded — recover the diff with:" >&2
+    echo "         git -C \"$main_root\" stash show -p $stash_sha" >&2
+    exit "$EXIT_QUARANTINED"
+fi
+
 if [[ -n "$effective_status" ]]; then
     echo "ERROR: MAIN worktree is dirty (uncommitted changes detected)." >&2
     echo "       Main worktree: $main_root" >&2
@@ -259,6 +462,13 @@ if [[ -n "$effective_status" ]]; then
         [[ -z "$line" ]] && continue
         echo "         $line" >&2
     done <<< "$effective_status"
+    echo "" >&2
+    echo "       Remediation must be ALL-OR-NOTHING (#4380). Do NOT restore these" >&2
+    echo "       paths piecemeal with per-file 'git checkout --' / 'rm' — a half-" >&2
+    echo "       restored main is worse than either extreme. Re-run this check with" >&2
+    echo "       --quarantine to move every offending path (tracked + untracked) to" >&2
+    echo "       a stash rescue ref in one operation, then replay the diff into the" >&2
+    echo "       owning issue worktree." >&2
     exit "$EXIT_MAIN_DIRTY"
 fi
 

--- a/defaults/scripts/tests/test-check-main-clean.sh
+++ b/defaults/scripts/tests/test-check-main-clean.sh
@@ -20,6 +20,9 @@
 #   - no-arg invocation remains a byte-for-byte whole-status hard-fail (back-compat)
 #   - Loom-owned transient state (.loom/sweep-checkpoint/, etc.) is excluded
 #     internally even when the repo's .gitignore has drifted and omits it (#3778)
+#   - --quarantine atomically stashes NEW dirt (tracked + untracked) to a rescue
+#     ref, leaves main byte-identical to the baseline, preserves the full diff in
+#     the stash, spares baselined dirt, and exits 4 (#4380)
 #
 # Usage:
 #   ./.loom/scripts/tests/test-check-main-clean.sh
@@ -339,6 +342,175 @@ else
     fail "expected 3 reporting only leaked_module.py, got rc=$RC; out=$out"
 fi
 rm -rf "$REPO"
+
+# ========================================================================
+# Atomic quarantine of detected contamination (#4380)
+# ========================================================================
+# The "partial revert" failure mode: a builder contaminates main with BOTH a
+# modified tracked file and a new untracked file, then restores only some of it
+# by hand. `--quarantine` replaces that ad-hoc path with ONE `git stash push
+# --include-untracked` covering every offending path, so main lands back exactly
+# at the pre-contamination baseline and the full diff survives in a rescue ref.
+
+# Build a repo with a committed source file plus a pre-existing (baselined) edit.
+make_repo_with_source() {
+    local dir
+    dir=$(mktemp -d)
+    git -C "$dir" init -q
+    git -C "$dir" config user.email t@t.t
+    git -C "$dir" config user.name test
+    printf '.loom/worktrees/\n.loom/sweep-checkpoint/\n' > "$dir/.gitignore"
+    printf 'original tracked content\n' > "$dir/tracked_source.py"
+    git -C "$dir" add .gitignore tracked_source.py
+    git -C "$dir" commit -q -m init
+    echo "$dir"
+}
+
+echo "Test 21: --quarantine atomically rescues tracked + untracked contamination"
+REPO=$(make_repo_with_source)
+SNAP="$REPO/.loom/sweep-checkpoint/main-clean-baseline-run1.txt"
+
+# Pre-existing operator dirt that predates the sweep — must survive untouched.
+printf 'operator scratch\n' > "$REPO/operator_scratch.txt"
+( cd "$REPO" && "$SCRIPT" --snapshot "$SNAP" >/dev/null 2>&1 ); RC=$?
+if [[ "$RC" -ne 0 ]]; then fail "Test 21 setup: --snapshot expected 0, got $RC"; fi
+
+# Capture the exact pre-contamination state of main (content + porcelain).
+BASELINE_PORCELAIN=$(git -C "$REPO" status --porcelain)
+BASELINE_TRACKED=$(cat "$REPO/tracked_source.py")
+BASELINE_SCRATCH=$(cat "$REPO/operator_scratch.txt")
+
+# --- Contaminate: one MODIFIED TRACKED file + one UNTRACKED file ---
+printf 'original tracked content\ncontaminating edit\n' > "$REPO/tracked_source.py"
+printf 'def leaked():\n    return 42\n' > "$REPO/leaked_module.py"
+
+out=$( cd "$REPO" && "$SCRIPT" --baseline "$SNAP" --quarantine \
+        --label "run=RUNID-TEST issue=4380" 2>&1 ); RC=$?
+
+# 21a: the check flags the contamination and reports a successful quarantine (exit 4)
+if [[ "$RC" -eq 4 ]]; then
+    pass "--quarantine exits 4 (quarantined, caller may continue)"
+else
+    fail "expected exit 4 from --quarantine, got $RC; out=$out"
+fi
+
+# 21b: exactly ONE structured log entry, naming the label and both paths
+json_lines=$(printf '%s\n' "$out" | grep -c '"event":"main-clean.quarantine"' || true)
+json_line=$(printf '%s\n' "$out" | grep '"event":"main-clean.quarantine"' | head -1)
+if [[ "$json_lines" -eq 1 ]] \
+   && [[ "$json_line" == *'"result":"quarantined"'* ]] \
+   && [[ "$json_line" == *'run=RUNID-TEST issue=4380'* ]] \
+   && [[ "$json_line" == *"tracked_source.py"* ]] \
+   && [[ "$json_line" == *"leaked_module.py"* ]]; then
+    pass "exactly one structured log entry, attributed and naming both paths"
+else
+    fail "expected 1 structured entry naming label + both paths, got $json_lines; line=$json_line"
+fi
+
+# 21c: main is byte-identical to the pre-contamination baseline
+AFTER_PORCELAIN=$(git -C "$REPO" status --porcelain)
+if [[ "$AFTER_PORCELAIN" == "$BASELINE_PORCELAIN" ]] \
+   && [[ "$(cat "$REPO/tracked_source.py")" == "$BASELINE_TRACKED" ]] \
+   && [[ ! -e "$REPO/leaked_module.py" ]]; then
+    pass "main worktree is byte-identical to the pre-contamination baseline"
+else
+    fail "main not restored to baseline: porcelain='$AFTER_PORCELAIN'"
+fi
+
+# 21d: baselined (pre-existing) operator dirt was NOT swept up
+if [[ -f "$REPO/operator_scratch.txt" ]] \
+   && [[ "$(cat "$REPO/operator_scratch.txt")" == "$BASELINE_SCRATCH" ]]; then
+    pass "pre-existing baselined dirt left untouched by the quarantine"
+else
+    fail "quarantine swept up pre-existing dirt (operator_scratch.txt)"
+fi
+
+# 21e: the rescue ref retains the FULL diff — tracked edit AND untracked file
+STASH_LIST=$(git -C "$REPO" stash list)
+STASH_DIFF=$(git -C "$REPO" stash show -p --include-untracked 'stash@{0}' 2>/dev/null \
+             || git -C "$REPO" stash show -p 'stash@{0}' 2>/dev/null)
+STASH_FILES=$(git -C "$REPO" stash show --name-only --include-untracked 'stash@{0}' 2>/dev/null || true)
+if [[ "$STASH_LIST" == *"loom-quarantine: run=RUNID-TEST issue=4380"* ]] \
+   && [[ "$STASH_DIFF" == *"contaminating edit"* ]] \
+   && [[ "$STASH_FILES" == *"leaked_module.py"* ]]; then
+    pass "rescue stash retains the full diff (tracked edit + untracked file)"
+else
+    fail "stash lost part of the diff: list='$STASH_LIST' files='$STASH_FILES'"
+fi
+
+# 21f: nothing was discarded — the untracked file is recoverable from the stash
+git -C "$REPO" stash pop -q 2>/dev/null || true
+if [[ -e "$REPO/leaked_module.py" ]] \
+   && [[ "$(cat "$REPO/tracked_source.py")" == *"contaminating edit"* ]]; then
+    pass "quarantine is a rescue, not a discard (stash pop restores everything)"
+else
+    fail "stash pop did not restore the quarantined contamination"
+fi
+rm -rf "$REPO"
+
+# -------- Test 22: --quarantine on a clean main is a no-op (exit 0) --------
+echo "Test 22: --quarantine on a clean main creates no stash (exit 0)"
+REPO=$(make_repo_with_source)
+SNAP="$REPO/.loom/sweep-checkpoint/main-clean-baseline-run2.txt"
+( cd "$REPO" && "$SCRIPT" --snapshot "$SNAP" >/dev/null 2>&1 )
+out=$( cd "$REPO" && "$SCRIPT" --baseline "$SNAP" --quarantine 2>&1 ); RC=$?
+if [[ "$RC" -eq 0 ]] && [[ -z "$(git -C "$REPO" stash list)" ]]; then
+    pass "exit 0 and no stash created when main is clean"
+else
+    fail "expected 0 + empty stash list, got rc=$RC; stash='$(git -C "$REPO" stash list)'"
+fi
+rm -rf "$REPO"
+
+# -------- Test 23: --quarantine writes its entry to --log FILE --------
+echo "Test 23: --quarantine appends the structured entry to --log FILE"
+REPO=$(make_repo_with_source)
+SNAP="$REPO/.loom/sweep-checkpoint/main-clean-baseline-run3.txt"
+( cd "$REPO" && "$SCRIPT" --snapshot "$SNAP" >/dev/null 2>&1 )
+echo "leak" > "$REPO/leaked.txt"
+LOGFILE="$REPO/.loom/logs/quarantine-test.log"
+( cd "$REPO" && "$SCRIPT" --baseline "$SNAP" --quarantine --label "run=R issue=1" \
+    --log "$LOGFILE" >/dev/null 2>&1 ); RC=$?
+if [[ "$RC" -eq 4 && -f "$LOGFILE" ]] \
+   && [[ "$(grep -c '"event":"main-clean.quarantine"' "$LOGFILE")" -eq 1 ]] \
+   && grep -q '"result":"quarantined"' "$LOGFILE"; then
+    pass "--log FILE receives exactly one structured entry"
+else
+    fail "expected 1 structured entry in $LOGFILE, got rc=$RC"
+fi
+rm -rf "$REPO"
+
+# -------- Test 24: --quarantine with --snapshot is a usage error --------
+echo "Test 24: --quarantine is rejected with --snapshot (exit 2)"
+REPO=$(make_repo_with_source)
+( cd "$REPO" && "$SCRIPT" --snapshot "$REPO/snap.txt" --quarantine >/dev/null 2>&1 ); RC=$?
+if [[ "$RC" -eq 2 ]]; then
+    pass "exit 2 for --snapshot --quarantine"
+else
+    fail "expected 2, got $RC"
+fi
+
+# -------- Test 25: detection-only mode still exits 3 and forbids piecemeal restore --------
+echo "Test 25: without --quarantine, detection stays a hard-fail (exit 3)"
+echo "leak" > "$REPO/leaked.txt"
+out=$( cd "$REPO" && "$SCRIPT" 2>&1 ); RC=$?
+if [[ "$RC" -eq 3 ]] \
+   && echo "$out" | grep -qi "ALL-OR-NOTHING" \
+   && echo "$out" | grep -q -- "--quarantine"; then
+    pass "exit 3 with all-or-nothing remediation guidance (no piecemeal restore)"
+else
+    fail "expected 3 + all-or-nothing guidance, got rc=$RC; out=$out"
+fi
+rm -rf "$REPO"
+
+# -------- Test 26: --label / --log require a value (exit 2) --------
+echo "Test 26: --label and --log require a value"
+"$SCRIPT" --label >/dev/null 2>&1; RC1=$?
+"$SCRIPT" --log >/dev/null 2>&1; RC2=$?
+if [[ "$RC1" -eq 2 && "$RC2" -eq 2 ]]; then
+    pass "exit 2 when --label/--log missing their value"
+else
+    fail "expected 2/2, got label=$RC1 log=$RC2"
+fi
 
 # -------- Summary --------
 echo ""


### PR DESCRIPTION
Closes #4380

Implements the curator-rescoped ACs (structural: per-builder cadence + atomic quarantine), not the original three.

## AC1 — per-builder contamination check (sweep.md)

`defaults/.claude/commands/loom/sweep.md` Wave Lifecycle step 4 now runs `check-main-clean.sh --baseline` **after each individual builder's `TaskOutput`**, inside the await loop, with `--label "run=$RUN_ID issue=$N"` so any new dirt is attributed to that specific builder in the quarantine log entry. The post-wave pass is retained as a final belt-and-suspenders check (labelled by wave). Step 0's baseline wording updated from "per-wave" to "per-builder".

## AC2 — atomic quarantine, no piecemeal restore

`defaults/scripts/check-main-clean.sh` gains `--quarantine` (plus `--label TEXT` and `--log FILE`):

- Moves **every** offending path — tracked modifications *and* untracked files — into a stash rescue ref in **one** `git stash push --include-untracked` scoped to exactly those pathspecs (`:(literal,top)` anchored, so a path containing glob chars can't over-match). Porcelain-quoted/escaped paths are decoded first; rename lines contribute both sides.
- Emits **exactly one** structured JSON line to stderr and appends it to `.loom/logs/main-quarantine.log` (override with `--log`):
  ```
  {"event":"main-clean.quarantine","ts":"…","result":"quarantined","label":"run=… issue=4364","main":"/…","stash_ref":"stash@{0}","stash_commit":"<sha>","paths":["…"],"count":2}
  ```
- **Never a discard** — the full diff is recoverable via `git stash show -p <sha>` / `stash pop`.
- **Baselined dirt is spared**: only paths flagged as *new* are stashed, so an operator's unrelated working-tree edits are untouched.
- **Verified, not assumed**: after stashing it re-runs detection against the baseline and only reports success if main is clean. Residual dirt is reported as a failure (exit 3), never a partial success — the exact "half-restored main" failure mode this issue is about.

New exit code **4** = "was dirty, quarantined, main is back at the baseline" so the orchestrator can log and continue instead of hard-blocking the whole wave (the contamination is gone from main). Exit **3** stays "dirty and NOT quarantined" → hard-block. sweep.md now carries an exit-code table for 0/3/4.

`sweep.md`'s remediation text no longer describes or permits piecemeal in-place restore — per-file `git checkout -- <path>` / `rm <path>` is explicitly forbidden as the remediation path, and even the manual fallback is specified as a single all-paths `git stash push`. The same guidance was added to `builder.md`'s manual `check-main-clean.sh` call site, and the script's own exit-3 output now says it.

Plain / `--snapshot` / `--baseline` behavior is byte-for-byte unchanged (back-compat contract for the `builder.md` / `builder-worktree.md` call sites). Argument parsing was generalized from a single-flag `case` to a loop; `usage()` now derives the header from the file instead of a hardcoded `sed` line range.

## AC3 — regression test

11 new assertions in `defaults/scripts/tests/test-check-main-clean.sh` (tests 21–26). The core case simulates contamination with **one modified tracked file + one untracked file** in main, on top of pre-existing baselined operator dirt, and verifies:

- the check flags it and exits 4;
- main is **byte-identical to the pre-contamination baseline** (porcelain + file contents + the untracked file gone);
- the **rescue stash retains the full diff** (tracked edit *and* untracked file), and `stash pop` restores everything — nothing discarded;
- baselined dirt was **not** swept up;
- **exactly one** structured entry, carrying the label and both paths.

Plus: clean-main is a no-op creating no stash; `--log FILE` receives exactly one entry; `--quarantine` with `--snapshot` is a usage error; detection-only still exits 3 with the all-or-nothing guidance; `--label`/`--log` require values.

Suite: **31/31 pass** (20 pre-existing + 11 new). `shellcheck --severity=warning` clean on both files.

Also ran the issue's stated verification method by hand — a `python3 -c` write appending to a tracked file *and* creating a new one in a main checkout — which the per-builder check flags, quarantines atomically, logs in one entry, and leaves main clean against the baseline (exit 4).

## AC4 — SKIPPED (no evidence of a specific bypass vector)

`guard-destructive-generic.sh`'s `extract_write_targets()` is **unchanged**, deliberately. `.loom/logs/hook-errors.log` for the #4364 build window (2026-07-29T05:37–05:41Z) contains **only** `[guard-worktree-paths] Denied: … Edit/Write path …` entries — 16 of them against `loom-daemon/src/main_health_gate.rs` and `defaults/scripts/cli/loom-daemon-update.sh`. There is no log record, and no other incident artifact, identifying a *specific* Bash idiom that actually landed a write in main. Per the issue's explicit instruction ("Do not invent a vector speculatively"), and given that each `extract_write_targets()` addition risks regressing the hard-won #4245/#4289 false-positive fixes (with #4382 open in the same function family), no extension was added. Confirmed unaffected anyway: `tests/hooks/test-guard-destructive.sh` **482/482 pass** and `defaults/hooks/tests/test-guard-worktree-paths.sh` **23/23 pass**.

## AC5 — corrected stale claim (sweep.md §Backstop)

The Backstop section previously read as if the missing `LOOM_WORKTREE_PATH` left the Task-subagent path unguarded. It now carries a callout that:

- the **#4007 path-derived fallback arms with no env var at all** (denies any Edit/Write resolving into the main checkout while a `.loom-managed` worktree exists), cited to the actual hook-errors.log deny cluster from the #4364 build — so no future reader re-derives "the guard cannot arm here";
- **both guards are PreToolUse DENY hooks and neither reverts anything** — they block before the write lands. The "the guard reverted most of it" narrative was a misread of *denied* writes as *reverted* writes; the "partial" part came from the builder's own ad-hoc per-file cleanup, which is exactly what `--quarantine` replaces.

## Notes for the reviewer

- `.loom/scripts` is a symlink to `defaults/scripts`, so the `check-main-clean.sh` change is live in this repo immediately with no resync. `.claude/commands/loom/*.md` are independent (gitignored) installed copies — they pick up the sweep.md/builder.md changes on the operator's next `./.loom/scripts/resync-installed.sh` after merge. Not touched here (that would mean writing into the main checkout).
- Out of scope per the issue and not attempted: cross-issue isolation (worktree-A builder writing into worktree B), which has no per-subagent identity signal (#3719).
