### PR TITLE
feat(daemon): fleet drain — retire a worker without losing work or claims (#4343)

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -562,6 +562,58 @@ format was needed.
   a consumed interface (the #4329 dashboard's multi-host phase reads it over
   the tailnet).
 
+### `fleet drain <ssh-host> [--timeout N] [--force-after-timeout] [--json]` (#4343)
+
+Retires a worker without losing in-flight work, forge claims, or (when a real
+flush seam lands — see below) E2E room keys — the SSH-orchestration layer over
+the drain engine that already exists (`restart --drain`, #4090; `SweepRegistry::
+cancel`'s SIGTERM→grace→SIGKILL), plus the three deltas teardown needs:
+
+1. **Drain-then-*exit*, not drain-then-restart.** `restart --drain --then-exit`
+   (this issue's addition to `Restart`/`DrainAndRestartDaemon`) tells the remote
+   daemon to end the process and **stay down** (`EXIT_SHUTDOWN`, no supervisor
+   relaunch) instead of restarting once drained — a relaunched daemon could pick
+   up new dispatch before the box powers off, defeating the whole point of
+   draining. Because a `then-exit` drain never wants a relaunch, the
+   supervisor-detection refusal gate (`restart --drain`'s AC5) does not apply to
+   it.
+2. **Immediate, targeted claim reset.** The startup-only `claim_reconciliation`
+   pass is too late for a drain (the anvil#758 pilot evidence: a crashed VM
+   sweep stranded `loom:building` for the full staleness window). `fleet drain`
+   captures the worker's in-flight issue numbers (`status --json`) *before*
+   triggering the remote drain, then — once the remote daemon has exited —
+   flips any of them still `loom:building` back to `loom:issue` via `gh`,
+   **locally, never over SSH** (the forge is global). An issue that finished
+   normally in the meantime (no longer `loom:building`) is left alone.
+3. **Safehoused flush verification is a documented stub pending #3998.** No
+   invocable key-backup steady-state check exists in this repo yet (only the
+   narration-sink/peer-claim client seams in `safehouse.rs`) — rather than block
+   every drain on #3998, this phase degrades honestly: `safehouse.enabled ==
+   false` skips cleanly (no room keys in play); `safehouse.enabled == true`
+   still lets the drain complete (workspace/roster cleanup proceed — loom never
+   *refuses* to retire a box over this) but withholds "safe to power off" and
+   exits `3`. TODO(#3998): replace the stub with a real check once a seam lands.
+
+**Phase state machine** (`loom-daemon/src/fleet/drain.rs`), idempotent +
+resumable (an interrupted drain re-runs from its last completed phase, persisted
+on the registry entry as `drain_phase`):
+
+`mark-draining` (roster `state: "draining"`, first — crash-safety) →
+`capture-claims` → `trigger-remote-drain` → `wait-remote-exit` →
+`reset-claims` → `flush-safehouse` → `deregister-workspace` →
+`remove-from-roster` (last — an interrupted drain stays visible, never
+silently gone).
+
+**Exit codes**: `0` fully verified (safe to power off); `1` a phase failed
+outright (SSH/launch failure, remote refusal — re-run to retry, resuming from
+the persisted phase); `2` the remote drain timed out **without**
+`--force-after-timeout` (fail-safe refusal, remote daemon still up); `3` every
+phase completed but the safehoused flush is unverified (#3998).
+
+**Boundary (epic #4340)**: loom never calls a cloud CLI. The final report
+prints the exact `repo:remote --down <ssh-host>` teardown command for the
+operator to run — this command hands the box back, it does not execute it.
+
 ## Token pool provisioning for managed repos (#3938)
 
 The multi-workspace work finder measures the token pool **once per tick from the

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -604,6 +604,18 @@ on the registry entry as `drain_phase`):
 `remove-from-roster` (last — an interrupted drain stays visible, never
 silently gone).
 
+**What `wait-remote-exit` counts as "exited"**: the normal end state of a
+`then_exit` drain is **host up, daemon gone**, in which the remote
+`loom-daemon status --json` still answers — with the #4069 unreachable payload
+(`{"error": "could not reach loom-daemon at …", "install_state": …}` on stdout,
+non-zero exit). That payload, and an SSH-level failure (host itself gone), both
+mean "exited". Only a *live* status payload reporting `drain.draining: false`
+means the remote refused the drain and is still dispatching — the fail-loud
+exit-`2` case. A transient SSH blip mid-wait is indistinguishable from "host
+gone" and reads as a successful exit; the following phases are
+orchestrator-side and a still-running remote daemon shows up in the next
+`fleet status`.
+
 **Exit codes**: `0` fully verified (safe to power off); `1` a phase failed
 outright (SSH/launch failure, remote refusal — re-run to retry, resuming from
 the persisted phase); `2` the remote drain timed out **without**

--- a/loom-daemon/src/auto_update.rs
+++ b/loom-daemon/src/auto_update.rs
@@ -450,12 +450,16 @@ impl DrainTrigger for IpcDrainTrigger {
         // not drain by the deadline the roll is refused and dispatch resumes,
         // never killing a sweep.
         let _guard = self.handle.enter();
+        // `then_exit=false`: this is the #4090 roll trigger — the daemon must
+        // restart (relaunch into the freshly-rebuilt binary), never stop for
+        // good. `then_exit: true` is `fleet drain`'s (#4343) teardown-only path.
         let resp = crate::ipc::handle_drain_request(
             &self.drain,
             &self.workspace_pool,
             &self.fallback_root,
             &self.event_bus,
             None,
+            false,
             false,
         );
         matches!(resp, crate::types::Response::DaemonDrain { accepted: true, .. })

--- a/loom-daemon/src/fleet/add_worker.rs
+++ b/loom-daemon/src/fleet/add_worker.rs
@@ -416,6 +416,8 @@ pub fn run(config: &AddWorkerConfig) -> Result<()> {
             tailnet_name: None,
             added_by: None,
             state: None,
+            drain_phase: None,
+            drain_captured: Vec::new(),
         };
         let path = default_fleet_registry_path()?;
         let mut registry = FleetRegistry::load(&path)?;

--- a/loom-daemon/src/fleet/drain.rs
+++ b/loom-daemon/src/fleet/drain.rs
@@ -59,7 +59,9 @@ use serde::{Deserialize, Serialize};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
-use super::{default_fleet_registry_path, CommandRunner, FleetRegistry, WorkerRecord};
+use super::{
+    default_fleet_registry_path, CommandOutput, CommandRunner, FleetRegistry, WorkerRecord,
+};
 use crate::fleet::add_worker::SshRunner;
 
 /// Default bound on how long the remote drain waits for in-flight sweeps
@@ -427,13 +429,84 @@ impl ClaimResetter for GhClaimResetter {
 // Remote status parsing
 // ===========================================================================
 
-/// Whether a remote `status --json` payload reports the daemon still
-/// draining (`draining: true`) — used by `wait-remote-exit` to distinguish
-/// "still waiting" from "drain was refused and dispatch resumed".
+/// Whether a remote `status --json` payload (given as raw stdout) reports the
+/// daemon still draining — used by `wait-remote-exit` to distinguish "still
+/// waiting" from "drain was refused and dispatch resumed". Thin string-level
+/// wrapper over [`still_draining`]; the polling path parses once and calls
+/// [`classify_remote_exit`] instead.
+#[cfg(test)]
 #[must_use]
 fn parse_still_draining(stdout: &str) -> Option<bool> {
     let value = serde_json::from_str::<serde_json::Value>(stdout).ok()?;
-    value.get("draining").and_then(serde_json::Value::as_bool)
+    still_draining(&value)
+}
+
+/// Read the drain flag out of an already-parsed `status --json` payload.
+///
+/// The real payload **nests** this under `drain` — `build_status_json_value`
+/// in `main.rs` emits `"drain": { "draining": …, "deadline": …, "note": … }`
+/// (#4090) — so a top-level-only read always returns `None` against a live
+/// daemon and silently disables the refusal branch in [`wait_remote_exit`].
+/// The top-level fallback keeps a hypothetical flatter/older payload legible
+/// rather than making the parse brittle.
+#[must_use]
+fn still_draining(value: &serde_json::Value) -> Option<bool> {
+    value
+        .get("drain")
+        .and_then(|drain| drain.get("draining"))
+        .or_else(|| value.get("draining"))
+        .and_then(serde_json::Value::as_bool)
+}
+
+/// One `wait-remote-exit` poll's verdict about the remote daemon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemoteExitProbe {
+    /// The remote daemon is gone — the expected outcome of a `then_exit`
+    /// drain, whether the *host* is still up (the normal case) or also gone.
+    Exited,
+    /// Still draining, or the payload is not (yet) legible — keep polling.
+    StillGoing,
+    /// The daemon is reachable and reports `draining: false` — the drain was
+    /// refused/aborted and dispatch resumed. Fail loudly.
+    Refused,
+}
+
+/// Classify one remote `loom-daemon status --json` invocation.
+///
+/// Three shapes matter, and only the first used to be handled:
+///
+/// 1. **Empty stdout + non-zero exit** — the SSH transport itself failed
+///    (connection refused, exit 255): host gone ⇒ `Exited`.
+/// 2. **A payload with a top-level `error` key** — the #4069
+///    unreachable-daemon payload (`print_status_unreachable_json` in
+///    `main.rs`) `println!`s `{"error": "could not reach loom-daemon at …",
+///    "install_state": …}` to **stdout** and exits non-zero
+///    (`install_state.exit_code()`). This is the normal post-`then_exit`
+///    state (host up, daemon down) and is therefore the primary success
+///    signal, not a parse miss. Mirrors
+///    [`super::status::classify_status_output`]'s `DaemonDown` arm.
+/// 3. **A live status payload** — inspect `drain.draining` to tell "still
+///    draining" from "refused and dispatching again".
+#[must_use]
+fn classify_remote_exit(out: &CommandOutput) -> RemoteExitProbe {
+    if out.stdout.trim().is_empty() {
+        return if out.ok() {
+            // Reachable but silent — nothing to conclude yet.
+            RemoteExitProbe::StillGoing
+        } else {
+            RemoteExitProbe::Exited
+        };
+    }
+    match serde_json::from_str::<serde_json::Value>(&out.stdout) {
+        Ok(value) if value.get("error").is_some() => RemoteExitProbe::Exited,
+        Ok(value) => match still_draining(&value) {
+            Some(false) => RemoteExitProbe::Refused,
+            // `Some(true)` (still draining) or `None` (a payload without the
+            // field at all) ⇒ keep polling.
+            _ => RemoteExitProbe::StillGoing,
+        },
+        Err(_) => RemoteExitProbe::StillGoing,
+    }
 }
 
 /// Best-effort mapping from a captured in-flight sweep's workspace-root path
@@ -716,31 +789,39 @@ fn run_phase(
 }
 
 /// `wait-remote-exit`: poll `loom-daemon status --json` on the target until
-/// either (a) the connection itself fails — interpreted as "the remote
-/// daemon has exited", the expected outcome of a `then_exit` drain, i.e.
-/// success — or (b) the payload parses and reports `draining: false` while
-/// still reachable — the remote daemon refused the drain (timed out without
+/// either (a) the daemon is gone — the connection itself fails, *or* the
+/// remote answers with the #4069 unreachable-daemon payload (`{"error": …}`
+/// on stdout, non-zero exit), which is the normal "host up, daemon exited"
+/// end state of a `then_exit` drain — i.e. success — or (b) the payload
+/// parses and reports `drain.draining: false` while still reachable — the
+/// remote daemon refused the drain (timed out without
 /// `--force-after-timeout`) and is still running; fail loudly rather than
 /// silently declaring success — or (c) [`DrainConfig::max_polls`] is
 /// exhausted, a defensive bound independent of wall-clock so a test double
 /// can never spin forever.
+///
+/// **Known limitation**: a transient SSH failure mid-wait (network blip,
+/// exit 255) is indistinguishable from "the host went away" and is therefore
+/// read as a successful exit. This is inherent to SSH-based liveness probing;
+/// the cost of a false positive is bounded — the subsequent phases are
+/// best-effort/orchestrator-side, and a still-running remote daemon would be
+/// caught by the next `fleet status`.
 fn wait_remote_exit(runner: &dyn CommandRunner, config: &DrainConfig) -> PhaseOutcome {
     let deadline = Instant::now() + Duration::from_secs(config.timeout_secs + WAIT_EXIT_GRACE_SECS);
     for attempt in 0..config.max_polls.max(1) {
         match runner.run("loom-daemon status --json", None) {
             Err(_) => return PhaseOutcome::Changed, // unreachable ⇒ exited ⇒ success
-            Ok(out) if !out.ok() && out.stdout.trim().is_empty() => {
-                return PhaseOutcome::Changed; // connection refused ⇒ exited
-            }
-            Ok(out) => match parse_still_draining(&out.stdout) {
-                Some(true) | None => { /* still going (or payload not yet legible) — keep polling */
-                }
-                Some(false) => {
+            Ok(out) => match classify_remote_exit(&out) {
+                RemoteExitProbe::Exited => return PhaseOutcome::Changed,
+                RemoteExitProbe::StillGoing => { /* keep polling */ }
+                RemoteExitProbe::Refused => {
                     return PhaseOutcome::Failed {
                         reason: format!(
                             "remote drain timed out and was refused (no --force-after-timeout, or \
-                             the daemon aborted it) — {} is still up and dispatching. Re-run \
-                             `fleet drain --force-after-timeout`, or investigate the stragglers.",
+                             the daemon aborted it) — {} is still up and dispatching. It can also \
+                             mean version skew: a pre-#4343 remote daemon ignores `then_exit` and \
+                             drains-then-restarts. Re-run `fleet drain --force-after-timeout`, \
+                             update the remote daemon, or investigate the stragglers.",
                             config.ssh_host
                         ),
                     };
@@ -961,12 +1042,11 @@ mod tests {
         }
     }
 
+    /// A live `status --json` payload. `draining` is nested under `drain`,
+    /// exactly as `build_status_json_value` (`main.rs`) emits it — a flat
+    /// top-level `draining` is *not* a shape any real daemon produces.
     fn ok_status(draining: bool) -> CommandOutput {
-        CommandOutput {
-            code: 0,
-            stdout: format!(r#"{{"in_flight": [], "draining": {draining}}}"#),
-            stderr: String::new(),
-        }
+        ok_with_in_flight(&[], draining)
     }
 
     fn ok_with_in_flight(issues: &[u32], draining: bool) -> CommandOutput {
@@ -976,7 +1056,30 @@ mod tests {
             .collect();
         CommandOutput {
             code: 0,
-            stdout: format!(r#"{{"in_flight": [{}], "draining": {draining}}}"#, sweeps.join(",")),
+            stdout: format!(
+                r#"{{"in_flight": [{}], "drain": {{"draining": {draining}, "deadline": null, "note": null}}}}"#,
+                sweeps.join(",")
+            ),
+            stderr: String::new(),
+        }
+    }
+
+    /// The #4069 unreachable-daemon payload: the *host* answered over SSH,
+    /// but its `loom-daemon` is gone, so the remote CLI prints this JSON to
+    /// **stdout** and exits non-zero (`install_state.exit_code()`). This —
+    /// not an SSH error — is the normal post-`then_exit` state.
+    fn daemon_down_host_up() -> CommandOutput {
+        CommandOutput {
+            code: 1,
+            stdout: r#"{
+  "error": "could not reach loom-daemon at /Users/w/.loom/daemon.sock: Connection refused (os error 61)",
+  "install_state": {
+    "state": "not_running",
+    "started_at": null,
+    "pid": null
+  }
+}"#
+            .to_string(),
             stderr: String::new(),
         }
     }
@@ -1100,11 +1203,67 @@ mod tests {
     }
 
     #[test]
-    fn parse_still_draining_reads_bool_field() {
+    fn parse_still_draining_reads_the_nested_drain_object() {
+        // The real shape emitted by `build_status_json_value`.
+        assert_eq!(
+            parse_still_draining(r#"{"drain": {"draining": true, "deadline": null}}"#),
+            Some(true)
+        );
+        assert_eq!(
+            parse_still_draining(r#"{"drain": {"draining": false, "note": "timeout refusal"}}"#),
+            Some(false)
+        );
+        // Lenient top-level fallback.
         assert_eq!(parse_still_draining(r#"{"draining": true}"#), Some(true));
         assert_eq!(parse_still_draining(r#"{"draining": false}"#), Some(false));
         assert_eq!(parse_still_draining(r#"{"other": 1}"#), None);
+        assert_eq!(parse_still_draining(r#"{"drain": {"deadline": null}}"#), None);
         assert_eq!(parse_still_draining("garbage"), None);
+    }
+
+    #[test]
+    fn parse_still_draining_reads_a_full_status_payload() {
+        // Guards against the top-level-read regression: a realistic payload
+        // must yield `Some(false)`, not `None`, so the refusal branch fires.
+        assert_eq!(parse_still_draining(&ok_status(false).stdout), Some(false));
+        assert_eq!(parse_still_draining(&ok_status(true).stdout), Some(true));
+    }
+
+    #[test]
+    fn classify_remote_exit_maps_every_real_shape() {
+        // Daemon down, host still up (#4069 payload on stdout, non-zero) —
+        // the primary `then_exit` success signal.
+        assert_eq!(classify_remote_exit(&daemon_down_host_up()), RemoteExitProbe::Exited);
+        // SSH-level failure (connection refused / host gone).
+        assert_eq!(
+            classify_remote_exit(&CommandOutput {
+                code: 255,
+                stdout: String::new(),
+                stderr: "ssh: connect to host worker-1 port 22: Connection refused".to_string(),
+            }),
+            RemoteExitProbe::Exited
+        );
+        // Still draining.
+        assert_eq!(classify_remote_exit(&ok_status(true)), RemoteExitProbe::StillGoing);
+        // Reachable and no longer draining ⇒ refused.
+        assert_eq!(classify_remote_exit(&ok_status(false)), RemoteExitProbe::Refused);
+        // Unparseable / silent output is never a verdict.
+        assert_eq!(
+            classify_remote_exit(&CommandOutput {
+                code: 0,
+                stdout: "not json".to_string(),
+                stderr: String::new(),
+            }),
+            RemoteExitProbe::StillGoing
+        );
+        assert_eq!(
+            classify_remote_exit(&CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+            RemoteExitProbe::StillGoing
+        );
     }
 
     #[test]
@@ -1143,7 +1302,10 @@ mod tests {
                 stdout: String::new(),
                 stderr: String::new(),
             }), // trigger
-            Err("connection refused".to_string()), // wait-remote-exit: unreachable == exited
+            // wait-remote-exit: the *realistic* post-`then_exit` state — the
+            // host is still up (it is only powered off later by
+            // `repo:remote`), only its daemon is gone.
+            Ok(daemon_down_host_up()),
             Ok(CommandOutput {
                 code: 0,
                 stdout: String::new(),
@@ -1178,6 +1340,88 @@ mod tests {
         let report = build_report(&config, reports);
         assert!(report.safe_to_power_off);
         assert!(report.teardown_command.unwrap().contains("worker-1"));
+    }
+
+    /// Secondary "exited" shape: the host itself became unreachable (SSH
+    /// connection refused) rather than merely losing its daemon.
+    #[test]
+    fn happy_path_also_accepts_ssh_level_unreachability_as_exited() {
+        let runner = MockRunner::new(vec![
+            Ok(ok_with_in_flight(&[], true)), // capture-claims
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }), // trigger
+            Err("connection refused".to_string()), // wait-remote-exit: host gone ⇒ exited
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }), // deregister-workspace
+        ]);
+        let claims = MockClaimResetter::new(HashMap::new());
+        let mut record = worker("worker-1");
+        let config = base_config("worker-1");
+
+        let (reports, removed) =
+            execute_drain(&runner, &claims, &mut record, &config, |_| Ok(())).unwrap();
+
+        assert!(removed);
+        assert!(!reports.iter().any(|r| r.outcome.is_failure()), "reports: {reports:?}");
+        assert!(build_report(&config, reports).safe_to_power_off);
+    }
+
+    /// The exit-255-with-stderr shape SSH actually produces when the box is
+    /// powered off, exercised through the real classifier rather than the
+    /// runner's `Err` path.
+    #[test]
+    fn wait_remote_exit_treats_ssh_exit_255_as_exited() {
+        let runner = MockRunner::new(vec![Ok(CommandOutput {
+            code: 255,
+            stdout: String::new(),
+            stderr: "ssh: connect to host worker-1 port 22: Connection refused".to_string(),
+        })]);
+        let config = base_config("worker-1");
+        assert_eq!(wait_remote_exit(&runner, &config), PhaseOutcome::Changed);
+    }
+
+    /// The primary happy-path signal, isolated: host up, daemon gone.
+    #[test]
+    fn wait_remote_exit_treats_unreachable_daemon_payload_as_exited() {
+        let runner = MockRunner::new(vec![Ok(daemon_down_host_up())]);
+        let config = base_config("worker-1");
+        assert_eq!(wait_remote_exit(&runner, &config), PhaseOutcome::Changed);
+    }
+
+    /// A still-draining poll must not be mistaken for either outcome; the
+    /// subsequent daemon-down payload ends the wait successfully.
+    #[test]
+    fn wait_remote_exit_polls_through_still_draining_then_succeeds() {
+        let runner = MockRunner::new(vec![
+            Ok(ok_with_in_flight(&[7], true)), // still draining
+            Ok(daemon_down_host_up()),         // then gone
+        ]);
+        let config = base_config("worker-1");
+        assert_eq!(wait_remote_exit(&runner, &config), PhaseOutcome::Changed);
+        assert_eq!(runner.calls.borrow().len(), 2);
+    }
+
+    /// Blocker-2 regression guard: a *real* (nested) payload reporting
+    /// `draining: false` while reachable must hit the fail-loud branch.
+    #[test]
+    fn wait_remote_exit_fails_loudly_on_a_real_refusal_payload() {
+        let runner = MockRunner::new(vec![Ok(ok_status(false))]);
+        let config = base_config("worker-1");
+        match wait_remote_exit(&runner, &config) {
+            PhaseOutcome::Failed { reason } => {
+                assert!(reason.contains("refused"), "reason: {reason}");
+                assert!(reason.contains("worker-1"), "reason: {reason}");
+            }
+            other => panic!("expected a loud refusal failure, got {other:?}"),
+        }
+        // One poll is enough — it must not spin to the deadline.
+        assert_eq!(runner.calls.borrow().len(), 1);
     }
 
     // ---- resumability ------------------------------------------------

--- a/loom-daemon/src/fleet/drain.rs
+++ b/loom-daemon/src/fleet/drain.rs
@@ -1,0 +1,1467 @@
+//! `fleet drain <ssh-host>` — retire a worker without losing in-flight work,
+//! forge claims, or (when wired) E2E room keys (issue #4343, epic #4340).
+//!
+//! # Not a new drain engine — SSH orchestration over an existing primitive
+//!
+//! Steps 1–2 of the body ("stop new dispatch", "let in-flight sweeps finish or
+//! checkpoint, bounded wait, then cancel") already exist on the remote daemon:
+//! `loom-daemon restart --drain` (#4090) stops admitting new work immediately
+//! and waits bounded for in-flight sweeps, refusing (fail-safe) or
+//! force-cancelling at the deadline. This module's job is the SSH fanout over
+//! that primitive plus the deltas teardown needs:
+//!
+//! 1. **Drain-then-*exit*, not drain-then-restart.** `restart --drain` ends by
+//!    *restarting* the daemon (exit [`crate::ipc::EXIT_RESTART`] under a
+//!    supervisor, which relaunches it) — correct for #4090's roll use case,
+//!    wrong for teardown: a relaunched daemon could pick up new dispatch
+//!    before the box powers off, defeating the whole point of draining.
+//!    `restart --drain --then-exit` (the CLI flag this issue adds) speaks the
+//!    same `DrainAndRestartDaemon` request with `then_exit: true`, and the
+//!    remote daemon exits `EXIT_SHUTDOWN` (143, no supervisor relaunch)
+//!    instead once drained.
+//! 2. **Immediate, targeted claim reset.** The startup-only
+//!    `claim_reconciliation` pass is too late for a drain — this module
+//!    captures the in-flight issue numbers from the worker's `status --json`
+//!    *before* triggering the remote drain, then (after the remote daemon has
+//!    exited) flips any of them still `loom:building` back to `loom:issue`
+//!    via `gh` **from the orchestrator, not over SSH** — the forge is global,
+//!    so no remote access is needed for this step.
+//! 3. **Safehoused flush verification is a documented stub (#3998).** See
+//!    [`flush_safehouse`]'s doc comment.
+//!
+//! # Phase state machine (idempotent + resumable, body step 6)
+//!
+//! [`DrainPhase`] is a fixed, ordered sequence. Each phase's completion is
+//! persisted onto the worker's [`super::WorkerRecord`] (`state: "draining"`
+//! written **first**, for crash-safety — an interrupted drain must leave the
+//! host visible in `fleet status`, not silently gone; the roster entry is
+//! removed **last**, only once every earlier phase — including the safehouse
+//! flush — has resolved). A re-run reads `drain_phase` and resumes after the
+//! last completed one; every phase is individually idempotent (re-marking a
+//! draining host draining, re-flipping an already-reset label, re-removing an
+//! already-removed workspace are all no-ops).
+//!
+//! # Exit codes
+//!
+//! - `0` — fully verified drain: zero stranded claims, host deregistered,
+//!   safe to power off.
+//! - `1` — a phase failed outright (SSH/launch failure, remote refusal,
+//!   unparseable output). The phase marker is preserved; re-run to retry.
+//! - `2` — the remote drain timed out **without** `--force-after-timeout`
+//!   (fail-safe refusal) — the remote daemon is still running and was never
+//!   told to exit.
+//! - `3` — every phase completed, but the safehouse flush could not be
+//!   verified (see [`flush_safehouse`]) — teardown is **not** certified safe
+//!   for room-key continuity even though the roster entry was removed.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use super::{default_fleet_registry_path, CommandRunner, FleetRegistry, WorkerRecord};
+use crate::fleet::add_worker::SshRunner;
+
+/// Default bound on how long the remote drain waits for in-flight sweeps
+/// (mirrors [`crate::ipc::DEFAULT_DRAIN_TIMEOUT_SECS`] — kept as an
+/// independent constant so this module never has to depend on `ipc`'s tokio
+/// runtime types).
+pub const DEFAULT_DRAIN_TIMEOUT_SECS: u64 = 1800;
+
+/// Default interval between polls of the remote host while waiting for it to
+/// exit after a drain was triggered.
+pub const DEFAULT_POLL_INTERVAL_SECS: u64 = 5;
+
+/// Grace added on top of `timeout_secs` before the orchestrator gives up
+/// waiting for the remote daemon to exit (the remote daemon's own supervisor
+/// enforces `timeout_secs`; this buffer absorbs SSH round-trip + poll-interval
+/// slack rather than racing it).
+const WAIT_EXIT_GRACE_SECS: u64 = 60;
+
+// ===========================================================================
+// Phase model
+// ===========================================================================
+
+/// One ordered phase of `fleet drain`. Persisted on [`WorkerRecord::drain_phase`]
+/// as [`DrainPhase::name`] after it completes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DrainPhase {
+    /// Mark the roster entry `state: "draining"` (first, for crash-safety).
+    MarkDraining,
+    /// Capture the worker's in-flight `loom:building` issue numbers before
+    /// triggering the remote drain.
+    CaptureClaims,
+    /// Trigger the remote `restart --drain --then-exit`.
+    TriggerRemoteDrain,
+    /// Poll until the remote daemon has exited (or the wait deadline passes).
+    WaitRemoteExit,
+    /// Reset any captured claim still `loom:building` back to `loom:issue`.
+    ResetClaims,
+    /// Verify (or, absent a seam, honestly not-verify) the safehoused
+    /// key-backup flush.
+    FlushSafehouse,
+    /// Deregister the worker's workspaces on the (now-stopped) remote host's
+    /// registry — best-effort, since the remote daemon has already exited.
+    DeregisterWorkspace,
+    /// Remove the worker from the local fleet registry (last).
+    RemoveFromRoster,
+}
+
+impl DrainPhase {
+    /// The full ordered sequence.
+    const ALL: [DrainPhase; 8] = [
+        DrainPhase::MarkDraining,
+        DrainPhase::CaptureClaims,
+        DrainPhase::TriggerRemoteDrain,
+        DrainPhase::WaitRemoteExit,
+        DrainPhase::ResetClaims,
+        DrainPhase::FlushSafehouse,
+        DrainPhase::DeregisterWorkspace,
+        DrainPhase::RemoveFromRoster,
+    ];
+
+    /// Stable machine name, persisted on the registry record.
+    #[must_use]
+    pub fn name(self) -> &'static str {
+        match self {
+            DrainPhase::MarkDraining => "mark-draining",
+            DrainPhase::CaptureClaims => "capture-claims",
+            DrainPhase::TriggerRemoteDrain => "trigger-remote-drain",
+            DrainPhase::WaitRemoteExit => "wait-remote-exit",
+            DrainPhase::ResetClaims => "reset-claims",
+            DrainPhase::FlushSafehouse => "flush-safehouse",
+            DrainPhase::DeregisterWorkspace => "deregister-workspace",
+            DrainPhase::RemoveFromRoster => "remove-from-roster",
+        }
+    }
+
+    /// Parse a persisted phase name back (`None` for an unrecognized/absent
+    /// value — treated as "start from the beginning", never a hard error, so
+    /// a registry written by a future binary still resumes safely).
+    #[must_use]
+    fn parse(name: Option<&str>) -> Option<DrainPhase> {
+        DrainPhase::ALL.into_iter().find(|p| Some(p.name()) == name)
+    }
+
+    /// The phase immediately after `self`, or `None` if `self` is the last.
+    #[must_use]
+    fn next(self) -> Option<DrainPhase> {
+        let idx = DrainPhase::ALL.iter().position(|p| *p == self)?;
+        DrainPhase::ALL.get(idx + 1).copied()
+    }
+
+    /// The first phase to run, given the last-*completed* phase recorded on
+    /// the registry (`None` ⇒ nothing completed yet ⇒ start at the first).
+    #[must_use]
+    fn resume_from(last_completed: Option<&str>) -> DrainPhase {
+        match DrainPhase::parse(last_completed) {
+            Some(p) => p.next().unwrap_or(DrainPhase::RemoveFromRoster),
+            None => DrainPhase::ALL[0],
+        }
+    }
+}
+
+/// A captured `loom:building` claim, persisted so a crash between capture and
+/// reset never loses the list (mirrors [`super::VerifyResult`]'s
+/// persist-immediately shape).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapturedClaim {
+    /// The issue number that was `loom:building` on this host at capture
+    /// time.
+    pub issue: u32,
+    /// The forge repo slug (`owner/name`) the issue belongs to.
+    pub repo: String,
+}
+
+// ===========================================================================
+// Config + outcome
+// ===========================================================================
+
+/// Operator inputs for one `fleet drain` invocation.
+#[derive(Debug, Clone)]
+pub struct DrainConfig {
+    /// SSH alias/host to drain.
+    pub ssh_host: String,
+    /// Bound on how long the remote drain waits for in-flight sweeps.
+    pub timeout_secs: u64,
+    /// On remote timeout, force-cancel stragglers (SIGTERM→grace→SIGKILL) and
+    /// exit anyway. Without this, a timeout refuses and the remote daemon
+    /// stays running (fail-safe) — this orchestrator then also refuses to
+    /// proceed past `wait-remote-exit`.
+    pub force_after_timeout: bool,
+    /// Interval between polls while waiting for the remote daemon to exit.
+    pub poll_interval: Duration,
+    /// Hard cap on wait-remote-exit polls (a defensive bound independent of
+    /// wall-clock, primarily so a test with a zero `poll_interval` cannot
+    /// spin forever against an exhausted mock). Production callers should
+    /// size this from `timeout_secs`/`poll_interval`; [`run`] does so.
+    pub max_polls: u32,
+    /// Whether `safehouse.enabled` resolved `true` for this invocation (via
+    /// [`crate::safehouse::resolve_config`]) — threaded in as a plain `bool`
+    /// so phase execution stays a pure function or drives off a mocked
+    /// runner in tests, with no config-file I/O of its own.
+    pub safehouse_enabled: bool,
+    /// Emit machine-readable JSON instead of the human-readable report.
+    pub json: bool,
+}
+
+/// Machine-readable per-phase outcome, mirroring [`super::StepStatus`]'s
+/// shape.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "status")]
+pub enum PhaseOutcome {
+    /// Already completed on a prior run — skipped this run (resumability).
+    AlreadyDone,
+    /// Applied successfully this run.
+    Changed,
+    /// Deliberately skipped (e.g. safehouse disabled) with a reason.
+    Skipped { reason: String },
+    /// Completed, but with a caveat that prevents a clean "safe to power off"
+    /// verdict (the unverified-safehoush-flush case).
+    Unverified { reason: String },
+    /// Failed; the phase marker is NOT advanced past this phase.
+    Failed { reason: String },
+}
+
+impl PhaseOutcome {
+    #[must_use]
+    fn is_failure(&self) -> bool {
+        matches!(self, PhaseOutcome::Failed { .. })
+    }
+}
+
+/// One phase's report.
+#[derive(Debug, Clone, Serialize)]
+pub struct PhaseReport {
+    pub phase: &'static str,
+    pub outcome: PhaseOutcome,
+}
+
+/// The full drain report: every phase executed this run, plus the terminal
+/// verdict.
+#[derive(Debug, Clone, Serialize)]
+pub struct DrainReport {
+    pub host: String,
+    pub phases: Vec<PhaseReport>,
+    /// `true` only when every phase completed cleanly (no `Failed`,
+    /// `Unverified`, or unresolved timeout) — the "safe to power off" gate.
+    pub safe_to_power_off: bool,
+    /// A human-readable diagnostic when `safe_to_power_off` is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub caveat: Option<String>,
+    /// The exact `repo:remote` teardown command to hand back to the operator
+    /// (loom never calls a cloud CLI itself — epic #4340's boundary). Present
+    /// once the drain has progressed far enough to be teardown-eligible
+    /// (i.e. every phase through `deregister-workspace` completed or was
+    /// skipped/already-done).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub teardown_command: Option<String>,
+}
+
+impl DrainReport {
+    /// Exit code policy (module doc): `0` fully verified, `1` generic
+    /// failure, `2` fail-safe timeout refusal, `3` unverified safehouse
+    /// flush.
+    #[must_use]
+    pub fn exit_code(&self) -> i32 {
+        if self.safe_to_power_off {
+            return 0;
+        }
+        if self
+            .phases
+            .iter()
+            .any(|p| matches!(p.outcome, PhaseOutcome::Unverified { .. }))
+        {
+            return 3;
+        }
+        if self.phases.iter().any(|p| {
+            p.phase == DrainPhase::WaitRemoteExit.name()
+                && matches!(&p.outcome, PhaseOutcome::Failed { reason } if reason.contains("timed out"))
+        }) {
+            return 2;
+        }
+        1
+    }
+
+    #[must_use]
+    pub fn render_human(&self) -> String {
+        let mut out = String::new();
+        out.push_str(&format!("fleet drain report for {}:\n", self.host));
+        if self.phases.is_empty() {
+            out.push_str(
+                "  host not found in the fleet registry — nothing to do (already drained/\n  \
+                 removed, or never added; see `fleet status` for the current roster).\n",
+            );
+            return out;
+        }
+        for p in &self.phases {
+            let (mark, detail) = match &p.outcome {
+                PhaseOutcome::AlreadyDone => ("=", None),
+                PhaseOutcome::Changed => ("+", None),
+                PhaseOutcome::Skipped { reason } => ("-", Some(reason.clone())),
+                PhaseOutcome::Unverified { reason } => ("!", Some(reason.clone())),
+                PhaseOutcome::Failed { reason } => ("x", Some(reason.clone())),
+            };
+            out.push_str(&format!("  {mark} [{}]", p.phase));
+            if let Some(d) = detail {
+                out.push_str(&format!(" — {d}"));
+            }
+            out.push('\n');
+        }
+        if self.safe_to_power_off {
+            out.push_str("\nDRAIN COMPLETE — safe to power off.\n");
+        } else if let Some(caveat) = &self.caveat {
+            out.push_str(&format!("\nDRAIN NOT VERIFIED SAFE: {caveat}\n"));
+        } else {
+            out.push_str("\nDRAIN INCOMPLETE.\n");
+        }
+        if let Some(cmd) = &self.teardown_command {
+            out.push_str(&format!(
+                "\nTeardown is repo:remote's job — loom never calls a cloud CLI itself. Run:\n  {cmd}\n"
+            ));
+        }
+        out
+    }
+}
+
+// ===========================================================================
+// Claim reset seam (the `gh` / mock seam)
+// ===========================================================================
+
+/// The seam between the reset-claims phase and the forge: check whether an
+/// issue still carries `loom:building`, and if so flip it back to
+/// `loom:issue` with an explanatory comment. Mirrors
+/// [`super::CommandRunner`]'s "real ssh vs scripted mock" shape.
+pub trait ClaimResetter {
+    /// Reset `issue` in `repo` if it still holds `loom:building`. Returns
+    /// `Ok(true)` when the claim was actually flipped, `Ok(false)` when the
+    /// issue no longer held it (a no-op — the sweep finished normally between
+    /// capture and reset). `Err` only on a genuine `gh` failure.
+    fn reset_claim(&self, repo: &str, issue: u32, host: &str) -> Result<bool>;
+}
+
+/// The production [`ClaimResetter`]: `gh issue view` to check the current
+/// label set, then `gh issue edit` + `gh issue comment` to flip it — run
+/// **locally** (never over SSH; the forge is global).
+pub struct GhClaimResetter;
+
+impl ClaimResetter for GhClaimResetter {
+    fn reset_claim(&self, repo: &str, issue: u32, host: &str) -> Result<bool> {
+        let view = Command::new("gh")
+            .args([
+                "issue",
+                "view",
+                &issue.to_string(),
+                "--repo",
+                repo,
+                "--json",
+                "labels",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .with_context(|| format!("gh issue view #{issue} in {repo}"))?;
+        if !view.status.success() {
+            anyhow::bail!(
+                "gh issue view #{issue} in {repo} failed: {}",
+                String::from_utf8_lossy(&view.stderr).trim()
+            );
+        }
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&view.stdout).context("parsing gh issue view --json labels")?;
+        let has_building = parsed["labels"]
+            .as_array()
+            .is_some_and(|labels| labels.iter().any(|l| l["name"] == "loom:building"));
+        if !has_building {
+            return Ok(false);
+        }
+
+        let edit = Command::new("gh")
+            .args([
+                "issue",
+                "edit",
+                &issue.to_string(),
+                "--repo",
+                repo,
+                "--remove-label",
+                "loom:building",
+                "--add-label",
+                "loom:issue",
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .with_context(|| format!("gh issue edit #{issue} in {repo}"))?;
+        if !edit.status.success() {
+            anyhow::bail!(
+                "gh issue edit #{issue} in {repo} failed: {}",
+                String::from_utf8_lossy(&edit.stderr).trim()
+            );
+        }
+
+        // Best-effort comment — never fails the reset itself (mirrors the
+        // rest of Loom's "a forge comment is advisory" posture).
+        let _ = Command::new("gh")
+            .args([
+                "issue",
+                "comment",
+                &issue.to_string(),
+                "--repo",
+                repo,
+                "--body",
+                &format!(
+                    "🔧 **fleet drain**: host `{host}` was drained/retired while this issue was \
+                     claimed; `loom:building` reset to `loom:issue` so it is not stranded (see \
+                     epic #4340, #4343)."
+                ),
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .output();
+
+        Ok(true)
+    }
+}
+
+// ===========================================================================
+// Remote status parsing
+// ===========================================================================
+
+/// Whether a remote `status --json` payload reports the daemon still
+/// draining (`draining: true`) — used by `wait-remote-exit` to distinguish
+/// "still waiting" from "drain was refused and dispatch resumed".
+#[must_use]
+fn parse_still_draining(stdout: &str) -> Option<bool> {
+    let value = serde_json::from_str::<serde_json::Value>(stdout).ok()?;
+    value.get("draining").and_then(serde_json::Value::as_bool)
+}
+
+/// Best-effort mapping from a captured in-flight sweep's workspace-root path
+/// (`SweepInfo.repo`) to one of the worker's registered forge slugs, by
+/// comparing the root's final path segment to each slug's clone-directory
+/// name (`owner/name` -> `name`, the same convention `fleet add-worker` uses).
+/// Falls back to the worker's first registered repo when the mapping is
+/// ambiguous (absent `repo` field, or no matching segment) — a host with
+/// exactly one registered repo (the overwhelmingly common case) is always
+/// unambiguous.
+#[must_use]
+fn resolve_repo_for_sweep(
+    sweep_repo_root: Option<&str>,
+    worker_repos: &[String],
+) -> Option<String> {
+    if worker_repos.is_empty() {
+        return None;
+    }
+    if worker_repos.len() == 1 {
+        return Some(worker_repos[0].clone());
+    }
+    if let Some(root) = sweep_repo_root {
+        let leaf = root.rsplit('/').next().unwrap_or(root);
+        for repo in worker_repos {
+            if repo.rsplit('/').next() == Some(leaf) {
+                return Some(repo.clone());
+            }
+        }
+    }
+    // Ambiguous — best-effort fallback, documented in the module doc.
+    Some(worker_repos[0].clone())
+}
+
+/// Parse `(issue, repo)` pairs directly from a remote `status --json` payload
+/// (used by `capture-claims`). Leniently parsed as a raw [`serde_json::Value`]
+/// (mirrors [`super::status::classify_status_output`]'s lenient posture — an
+/// older/newer remote binary's reduced/extended field set must never fail this
+/// parse, only genuinely non-JSON output does). `SweepKind` serializes as
+/// `{"type":"Issue","value":<n>}` / `{"type":"PrSet","value":[..]}` — a
+/// `PrSet` sweep contributes every member issue (Mode C sweeps are rare and
+/// reserved for future phases, but a drain must not silently drop them if one
+/// is ever in flight). Also carries `SweepInfo.repo` (the workspace-root
+/// string), when present, into [`resolve_repo_for_sweep`].
+#[must_use]
+fn parse_captured_claims(stdout: &str, worker_repos: &[String]) -> Vec<CapturedClaim> {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(stdout) else {
+        return Vec::new();
+    };
+    let Some(in_flight) = value.get("in_flight").and_then(serde_json::Value::as_array) else {
+        return Vec::new();
+    };
+    let mut claims = Vec::new();
+    for sweep in in_flight {
+        let sweep_repo_root = sweep.get("repo").and_then(serde_json::Value::as_str);
+        let Some(repo) = resolve_repo_for_sweep(sweep_repo_root, worker_repos) else {
+            continue;
+        };
+        let kind = &sweep["kind"];
+        match kind["type"].as_str() {
+            Some("Issue") => {
+                if let Some(n) = kind["value"].as_u64() {
+                    claims.push(CapturedClaim {
+                        issue: n as u32,
+                        repo: repo.clone(),
+                    });
+                }
+            }
+            Some("PrSet") => {
+                if let Some(arr) = kind["value"].as_array() {
+                    for v in arr {
+                        if let Some(n) = v.as_u64() {
+                            claims.push(CapturedClaim {
+                                issue: n as u32,
+                                repo: repo.clone(),
+                            });
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    claims
+}
+
+// ===========================================================================
+// Phase execution (pure-ish: driven entirely off the two seams + the record)
+// ===========================================================================
+
+/// Derive the `%h`-relative workspace path `fleet add-worker` clones a repo
+/// slug into (mirrors `add_worker::workspace_rel`, reimplemented here rather
+/// than widening that module's visibility for a one-line helper).
+#[must_use]
+fn workspace_path_for_repo(repo: &str) -> String {
+    let name = repo.rsplit('/').next().unwrap_or(repo);
+    format!("$HOME/loom-workspaces/{name}")
+}
+
+/// Execute every phase from [`DrainPhase::resume_from`] onward against
+/// `record`, using `runner` for every remote (SSH) action and `claims` for
+/// the local forge claim reset. Mutates `record` in place (phase marker,
+/// captured claims) and calls `persist` after **each** phase so a crash mid-run
+/// never loses more than the phase in progress. Returns the ordered
+/// [`PhaseReport`]s for this run and whether the record should be removed
+/// from the registry (only `true` once `RemoveFromRoster` itself completes).
+pub fn execute_drain(
+    runner: &dyn CommandRunner,
+    claims: &dyn ClaimResetter,
+    record: &mut WorkerRecord,
+    config: &DrainConfig,
+    mut persist: impl FnMut(&WorkerRecord) -> Result<()>,
+) -> Result<(Vec<PhaseReport>, bool)> {
+    let start = DrainPhase::resume_from(record.drain_phase.as_deref());
+    let mut reports = Vec::new();
+    let mut remove_from_roster = false;
+
+    // Every phase strictly before `start` is implicitly AlreadyDone (resumed
+    // past it on a prior run) — reported for a complete, honest checklist.
+    for p in DrainPhase::ALL {
+        if p < start {
+            reports.push(PhaseReport {
+                phase: p.name(),
+                outcome: PhaseOutcome::AlreadyDone,
+            });
+        }
+    }
+
+    let mut phase = Some(start);
+    while let Some(p) = phase {
+        let outcome = run_phase(p, runner, claims, record, config);
+        let failed = outcome.is_failure();
+        let is_remove = p == DrainPhase::RemoveFromRoster && !failed;
+        reports.push(PhaseReport {
+            phase: p.name(),
+            outcome,
+        });
+
+        if failed {
+            // Do NOT advance drain_phase past a failed phase — the marker
+            // (already persisted by the previous successful phase) is the
+            // resume point.
+            break;
+        }
+
+        if is_remove {
+            remove_from_roster = true;
+            // The record is about to be deleted from the registry by the
+            // caller — nothing left to persist onto it.
+        } else {
+            record.drain_phase = Some(p.name().to_string());
+            persist(record)?;
+        }
+
+        phase = p.next();
+    }
+
+    Ok((reports, remove_from_roster))
+}
+
+fn run_phase(
+    phase: DrainPhase,
+    runner: &dyn CommandRunner,
+    claims: &dyn ClaimResetter,
+    record: &mut WorkerRecord,
+    config: &DrainConfig,
+) -> PhaseOutcome {
+    match phase {
+        DrainPhase::MarkDraining => {
+            record.state = Some("draining".to_string());
+            PhaseOutcome::Changed
+        }
+
+        DrainPhase::CaptureClaims => match runner.run("loom-daemon status --json", None) {
+            Ok(out) if out.ok() => {
+                let captured = parse_captured_claims(&out.stdout, &record.repos);
+                record.drain_captured = captured;
+                PhaseOutcome::Changed
+            }
+            Ok(out) => PhaseOutcome::Failed {
+                reason: format!(
+                    "remote `status --json` exited {}: {}",
+                    out.code,
+                    tail(&out.stderr)
+                ),
+            },
+            Err(e) => PhaseOutcome::Failed {
+                reason: format!("could not reach {}: {e}", config.ssh_host),
+            },
+        },
+
+        DrainPhase::TriggerRemoteDrain => {
+            let mut shell = format!(
+                "loom-daemon restart --drain --then-exit --timeout {}",
+                config.timeout_secs
+            );
+            if config.force_after_timeout {
+                shell.push_str(" --force-after-timeout");
+            }
+            match runner.run(&shell, None) {
+                Ok(out) if out.ok() => PhaseOutcome::Changed,
+                Ok(out) => PhaseOutcome::Failed {
+                    reason: format!(
+                        "remote drain trigger refused (exit {}): {}",
+                        out.code,
+                        tail(&out.stderr)
+                    ),
+                },
+                Err(e) => PhaseOutcome::Failed {
+                    reason: format!("could not reach {}: {e}", config.ssh_host),
+                },
+            }
+        }
+
+        DrainPhase::WaitRemoteExit => wait_remote_exit(runner, config),
+
+        DrainPhase::ResetClaims => {
+            let mut failures = Vec::new();
+            let mut reset_count = 0usize;
+            for claim in &record.drain_captured {
+                match claims.reset_claim(&claim.repo, claim.issue, &config.ssh_host) {
+                    Ok(true) => reset_count += 1,
+                    Ok(false) => {}
+                    Err(e) => failures.push(format!("#{} in {}: {e}", claim.issue, claim.repo)),
+                }
+            }
+            if failures.is_empty() {
+                PhaseOutcome::Changed
+            } else {
+                PhaseOutcome::Failed {
+                    reason: format!(
+                        "{} claim(s) reset before failure; could not reset: {}",
+                        reset_count,
+                        failures.join("; ")
+                    ),
+                }
+            }
+        }
+
+        DrainPhase::FlushSafehouse => flush_safehouse(config),
+
+        DrainPhase::DeregisterWorkspace => {
+            let mut failures = Vec::new();
+            for repo in &record.repos {
+                let shell =
+                    format!("loom-daemon workspace remove \"{}\"", workspace_path_for_repo(repo));
+                match runner.run(&shell, None) {
+                    // The remote daemon has already exited by this phase — a
+                    // connection failure here is *expected*, not an error:
+                    // `workspace remove` is a filesystem-registry edit that
+                    // works whether or not the daemon is running, but we
+                    // cannot SSH-execute it once the host itself is about to
+                    // be torn down. Best-effort: log and move on.
+                    Ok(out) if out.ok() => {}
+                    Ok(_) | Err(_) => {
+                        failures.push(repo.clone());
+                    }
+                }
+            }
+            if failures.is_empty() {
+                PhaseOutcome::Changed
+            } else {
+                // Best-effort, never blocks teardown: the host is being
+                // retired anyway, so a stale workspace-registry entry on a
+                // box about to be powered off is cosmetic, not a correctness
+                // issue. Recorded as Skipped (not Failed) so it never blocks
+                // the roster-removal phase.
+                PhaseOutcome::Skipped {
+                    reason: format!(
+                        "could not deregister workspace(s) on {} (host likely already \
+                         unreachable post-drain, which is expected): {}",
+                        config.ssh_host,
+                        failures.join(", ")
+                    ),
+                }
+            }
+        }
+
+        DrainPhase::RemoveFromRoster => PhaseOutcome::Changed,
+    }
+}
+
+/// `wait-remote-exit`: poll `loom-daemon status --json` on the target until
+/// either (a) the connection itself fails — interpreted as "the remote
+/// daemon has exited", the expected outcome of a `then_exit` drain, i.e.
+/// success — or (b) the payload parses and reports `draining: false` while
+/// still reachable — the remote daemon refused the drain (timed out without
+/// `--force-after-timeout`) and is still running; fail loudly rather than
+/// silently declaring success — or (c) [`DrainConfig::max_polls`] is
+/// exhausted, a defensive bound independent of wall-clock so a test double
+/// can never spin forever.
+fn wait_remote_exit(runner: &dyn CommandRunner, config: &DrainConfig) -> PhaseOutcome {
+    let deadline = Instant::now() + Duration::from_secs(config.timeout_secs + WAIT_EXIT_GRACE_SECS);
+    for attempt in 0..config.max_polls.max(1) {
+        match runner.run("loom-daemon status --json", None) {
+            Err(_) => return PhaseOutcome::Changed, // unreachable ⇒ exited ⇒ success
+            Ok(out) if !out.ok() && out.stdout.trim().is_empty() => {
+                return PhaseOutcome::Changed; // connection refused ⇒ exited
+            }
+            Ok(out) => match parse_still_draining(&out.stdout) {
+                Some(true) | None => { /* still going (or payload not yet legible) — keep polling */
+                }
+                Some(false) => {
+                    return PhaseOutcome::Failed {
+                        reason: format!(
+                            "remote drain timed out and was refused (no --force-after-timeout, or \
+                             the daemon aborted it) — {} is still up and dispatching. Re-run \
+                             `fleet drain --force-after-timeout`, or investigate the stragglers.",
+                            config.ssh_host
+                        ),
+                    };
+                }
+            },
+        }
+        if Instant::now() >= deadline || attempt + 1 >= config.max_polls {
+            break;
+        }
+        if !config.poll_interval.is_zero() {
+            std::thread::sleep(config.poll_interval);
+        }
+    }
+    PhaseOutcome::Failed {
+        reason: format!(
+            "timed out after {}s waiting for {} to exit post-drain (still reachable)",
+            config.timeout_secs + WAIT_EXIT_GRACE_SECS,
+            config.ssh_host
+        ),
+    }
+}
+
+/// Safehoused key-backup flush verification (body step 3 / AC 2) — **a
+/// documented stub, not a re-implementation of #3998's teardown fragment.**
+///
+/// #3998 (the safehoused provisioning/teardown fragment) is open, and
+/// `loom-daemon/src/safehouse.rs` exposes only the narration-sink and
+/// peer-claim-coordination client seams — there is no invocable
+/// `wait_for_steady_state`-equivalent reachable from this (synchronous, CLI)
+/// call path. Rather than block every drain on #3998 (steps 1, 2, 4, 5, 6 are
+/// explicitly unblocked per the issue's dependency table) or fabricate a check
+/// that cannot actually verify anything, this phase degrades honestly:
+///
+/// - `safehouse.enabled == false` (the default): [`PhaseOutcome::Skipped`] —
+///   no room keys are in play on this host, so "safe to power off" is
+///   accurate.
+/// - `safehouse.enabled == true`: [`PhaseOutcome::Unverified`] — the drain
+///   still completes (workspace deregistration + roster removal proceed;
+///   loom never *refuses* to retire a box over this), but the final verdict
+///   explicitly withholds "safe to power off" (AC 2: "never print safe to
+///   power off when the key-backup check did not pass") and exits non-zero
+///   (`3`) so an operator/monitor treats it as a flag, not a clean success.
+///
+/// TODO(#3998): once a concrete flush/steady-state-check seam lands in
+/// `safehouse.rs`, replace this stub with a real SSH-invoked check (or a
+/// direct call if the daemon exposes one), and this phase's `Unverified`
+/// branch becomes reachable only on an *actual* verification failure.
+#[must_use]
+fn flush_safehouse(config: &DrainConfig) -> PhaseOutcome {
+    if !config.safehouse_enabled {
+        return PhaseOutcome::Skipped {
+            reason: "safehouse.enabled is false — no room keys in play on this host".to_string(),
+        };
+    }
+    PhaseOutcome::Unverified {
+        reason: "safehouse.enabled is true, but no invocable key-backup steady-state check \
+                 exists in this repo yet (#3998 is open) — cannot verify the flush before this \
+                 host is torn down. Teardown proceeds (workspace/roster cleanup complete), but is \
+                 NOT certified safe for room-key continuity."
+            .to_string(),
+    }
+}
+
+fn tail(s: &str) -> String {
+    s.lines()
+        .rev()
+        .find(|l| !l.trim().is_empty())
+        .unwrap_or("")
+        .trim()
+        .to_string()
+}
+
+// ===========================================================================
+// Top-level `run` (real I/O: registry load/save, SSH, `gh`)
+// ===========================================================================
+
+/// `loom-daemon fleet drain <ssh-host>` entry point. Loads the fleet registry,
+/// resolves the resume point, executes every remaining phase over a real
+/// [`SshRunner`] / [`GhClaimResetter`], persisting after each phase, and
+/// prints the report.
+///
+/// A host absent from the registry is a clean no-op (exit 0): either it was
+/// never added, or a prior `fleet drain` already completed and removed it —
+/// both cases mean "nothing to do", not an error (Test Plan edge case:
+/// "drain re-run on an already-drained host").
+pub fn run(config: &DrainConfig) -> Result<DrainReport> {
+    let path = default_fleet_registry_path()?;
+    let registry = FleetRegistry::load(&path)?;
+
+    let Some(idx) = registry
+        .workers
+        .iter()
+        .position(|w| w.ssh_host == config.ssh_host)
+    else {
+        return Ok(DrainReport {
+            host: config.ssh_host.clone(),
+            phases: Vec::new(),
+            safe_to_power_off: true,
+            caveat: None,
+            teardown_command: None,
+        });
+    };
+
+    let mut record = registry.workers[idx].clone();
+    let runner = SshRunner::new(&config.ssh_host);
+    let claims = GhClaimResetter;
+
+    let registry_path = path.clone();
+    let (reports, removed) = execute_drain(&runner, &claims, &mut record, config, |rec| {
+        let mut reg = FleetRegistry::load(&registry_path)?;
+        reg.upsert(rec.clone());
+        reg.save(&registry_path)
+    })?;
+
+    if removed {
+        let mut reg = FleetRegistry::load(&path)?;
+        reg.workers.retain(|w| w.ssh_host != config.ssh_host);
+        reg.save(&path)?;
+    } else {
+        // Persist the final (possibly-failed) state too, so a failed run's
+        // `drain_captured`/`drain_phase` are on disk for the next resume even
+        // if the last phase's own `persist` call inside `execute_drain` was
+        // never reached (a failure never calls it, by design).
+        let mut reg = FleetRegistry::load(&path)?;
+        reg.upsert(record.clone());
+        reg.save(&path)?;
+    }
+
+    Ok(build_report(config, reports))
+}
+
+/// Turn a phase-execution run into the final [`DrainReport`] verdict.
+#[must_use]
+fn build_report(config: &DrainConfig, phases: Vec<PhaseReport>) -> DrainReport {
+    let any_failed = phases.iter().any(|p| p.outcome.is_failure());
+    let any_unverified = phases
+        .iter()
+        .any(|p| matches!(p.outcome, PhaseOutcome::Unverified { .. }));
+    let removed = phases
+        .iter()
+        .any(|p| p.phase == DrainPhase::RemoveFromRoster.name() && !p.outcome.is_failure());
+
+    let safe_to_power_off = removed && !any_failed && !any_unverified;
+
+    let caveat = if any_unverified {
+        phases.iter().find_map(|p| match &p.outcome {
+            PhaseOutcome::Unverified { reason } => Some(reason.clone()),
+            _ => None,
+        })
+    } else if any_failed {
+        phases.iter().find_map(|p| match &p.outcome {
+            PhaseOutcome::Failed { reason } => Some(format!("{}: {reason}", p.phase)),
+            _ => None,
+        })
+    } else {
+        None
+    };
+
+    let teardown_command = if removed
+        || (!any_failed
+            && phases
+                .iter()
+                .any(|p| p.phase == DrainPhase::DeregisterWorkspace.name()))
+    {
+        Some(format!("repo:remote --down {}", config.ssh_host))
+    } else {
+        None
+    };
+
+    DrainReport {
+        host: config.ssh_host.clone(),
+        phases,
+        safe_to_power_off,
+        caveat,
+        teardown_command,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::super::CommandOutput;
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    // ---- Mocks -------------------------------------------------------
+
+    /// Ordered-queue mock runner (mirrors `add_worker`'s `MockRunner`): each
+    /// `run` pops the next canned response, recording the shell it was asked
+    /// to run.
+    struct MockRunner {
+        responses: RefCell<Vec<Result<CommandOutput, String>>>,
+        calls: RefCell<Vec<String>>,
+    }
+
+    impl MockRunner {
+        fn new(responses: Vec<Result<CommandOutput, String>>) -> Self {
+            Self {
+                responses: RefCell::new(responses),
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl CommandRunner for MockRunner {
+        fn run(&self, shell: &str, _stdin: Option<&str>) -> Result<CommandOutput> {
+            self.calls.borrow_mut().push(shell.to_string());
+            let mut r = self.responses.borrow_mut();
+            if r.is_empty() {
+                return Ok(ok_status(false));
+            }
+            match r.remove(0) {
+                Ok(out) => Ok(out),
+                Err(e) => Err(anyhow::anyhow!(e)),
+            }
+        }
+    }
+
+    fn ok_status(draining: bool) -> CommandOutput {
+        CommandOutput {
+            code: 0,
+            stdout: format!(r#"{{"in_flight": [], "draining": {draining}}}"#),
+            stderr: String::new(),
+        }
+    }
+
+    fn ok_with_in_flight(issues: &[u32], draining: bool) -> CommandOutput {
+        let sweeps: Vec<String> = issues
+            .iter()
+            .map(|n| format!(r#"{{"kind": {{"type": "Issue", "value": {n}}}, "repo": null}}"#))
+            .collect();
+        CommandOutput {
+            code: 0,
+            stdout: format!(r#"{{"in_flight": [{}], "draining": {draining}}}"#, sweeps.join(",")),
+            stderr: String::new(),
+        }
+    }
+
+    fn refused() -> CommandOutput {
+        CommandOutput {
+            code: 1,
+            stdout: String::new(),
+            stderr: "refusing to drain: no supervisor detected".to_string(),
+        }
+    }
+
+    /// Records every reset call; `outcomes` scripts the per-`(issue)` result.
+    struct MockClaimResetter {
+        outcomes: Mutex<HashMap<u32, Result<bool, String>>>,
+        calls: Mutex<Vec<(String, u32, String)>>,
+    }
+
+    impl MockClaimResetter {
+        fn new(outcomes: HashMap<u32, Result<bool, String>>) -> Self {
+            Self {
+                outcomes: Mutex::new(outcomes),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl ClaimResetter for MockClaimResetter {
+        fn reset_claim(&self, repo: &str, issue: u32, host: &str) -> Result<bool> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((repo.to_string(), issue, host.to_string()));
+            match self.outcomes.lock().unwrap().remove(&issue) {
+                Some(Ok(b)) => Ok(b),
+                Some(Err(e)) => Err(anyhow::anyhow!(e)),
+                None => Ok(false),
+            }
+        }
+    }
+
+    fn worker(host: &str) -> WorkerRecord {
+        WorkerRecord {
+            ssh_host: host.to_string(),
+            repos: vec!["rjwalters/anvil".to_string()],
+            priority: 100,
+            bootstrapped_at: "2026-07-29T00:00:00Z".to_string(),
+            last_verify: None,
+            provider_instance_id: None,
+            tailnet_name: None,
+            added_by: None,
+            state: None,
+            drain_phase: None,
+            drain_captured: Vec::new(),
+        }
+    }
+
+    fn base_config(host: &str) -> DrainConfig {
+        DrainConfig {
+            ssh_host: host.to_string(),
+            timeout_secs: 60,
+            force_after_timeout: false,
+            poll_interval: Duration::from_millis(0),
+            max_polls: 3,
+            safehouse_enabled: false,
+            json: false,
+        }
+    }
+
+    // ---- DrainPhase ----------------------------------------------------
+
+    #[test]
+    fn resume_from_none_starts_at_first_phase() {
+        assert_eq!(DrainPhase::resume_from(None), DrainPhase::MarkDraining);
+    }
+
+    #[test]
+    fn resume_from_last_completed_starts_at_next() {
+        assert_eq!(DrainPhase::resume_from(Some("mark-draining")), DrainPhase::CaptureClaims);
+        assert_eq!(
+            DrainPhase::resume_from(Some("flush-safehouse")),
+            DrainPhase::DeregisterWorkspace
+        );
+    }
+
+    #[test]
+    fn resume_from_unrecognized_starts_over_rather_than_erroring() {
+        assert_eq!(DrainPhase::resume_from(Some("some-future-phase")), DrainPhase::MarkDraining);
+    }
+
+    #[test]
+    fn resume_from_final_phase_stays_at_final() {
+        assert_eq!(
+            DrainPhase::resume_from(Some("remove-from-roster")),
+            DrainPhase::RemoveFromRoster
+        );
+    }
+
+    // ---- parse helpers ---------------------------------------------------
+
+    #[test]
+    fn parse_captured_claims_reads_issue_and_prset_kinds() {
+        let json = r#"{"in_flight": [
+            {"kind": {"type": "Issue", "value": 42}},
+            {"kind": {"type": "PrSet", "value": [7, 9]}}
+        ]}"#;
+        let repos = vec!["rjwalters/anvil".to_string()];
+        let mut got: Vec<u32> = parse_captured_claims(json, &repos)
+            .into_iter()
+            .map(|c| c.issue)
+            .collect();
+        got.sort_unstable();
+        assert_eq!(got, vec![7, 9, 42]);
+    }
+
+    #[test]
+    fn parse_captured_claims_tolerates_garbage() {
+        let repos = vec!["rjwalters/anvil".to_string()];
+        assert!(parse_captured_claims("not json", &repos).is_empty());
+        assert!(parse_captured_claims(r#"{"no_in_flight_key": true}"#, &repos).is_empty());
+    }
+
+    #[test]
+    fn parse_still_draining_reads_bool_field() {
+        assert_eq!(parse_still_draining(r#"{"draining": true}"#), Some(true));
+        assert_eq!(parse_still_draining(r#"{"draining": false}"#), Some(false));
+        assert_eq!(parse_still_draining(r#"{"other": 1}"#), None);
+        assert_eq!(parse_still_draining("garbage"), None);
+    }
+
+    #[test]
+    fn resolve_repo_for_sweep_unambiguous_with_one_repo() {
+        let repos = vec!["rjwalters/anvil".to_string()];
+        assert_eq!(resolve_repo_for_sweep(None, &repos), Some("rjwalters/anvil".to_string()));
+    }
+
+    #[test]
+    fn resolve_repo_for_sweep_matches_leaf_segment_with_multiple_repos() {
+        let repos = vec!["rjwalters/anvil".to_string(), "rjwalters/loom".to_string()];
+        assert_eq!(
+            resolve_repo_for_sweep(Some("/home/w/loom-workspaces/loom"), &repos),
+            Some("rjwalters/loom".to_string())
+        );
+        assert_eq!(
+            resolve_repo_for_sweep(Some("/home/w/loom-workspaces/anvil"), &repos),
+            Some("rjwalters/anvil".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_repo_for_sweep_falls_back_to_first_when_ambiguous() {
+        let repos = vec!["rjwalters/anvil".to_string(), "rjwalters/loom".to_string()];
+        assert_eq!(resolve_repo_for_sweep(None, &repos), Some("rjwalters/anvil".to_string()));
+    }
+
+    // ---- full happy-path phase sequence -----------------------------------
+
+    #[test]
+    fn happy_path_drains_captures_resets_and_removes_from_roster() {
+        let runner = MockRunner::new(vec![
+            Ok(ok_with_in_flight(&[42], true)), // capture-claims
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }), // trigger
+            Err("connection refused".to_string()), // wait-remote-exit: unreachable == exited
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }), // deregister-workspace
+        ]);
+        let mut outcomes = HashMap::new();
+        outcomes.insert(42, Ok(true));
+        let claims = MockClaimResetter::new(outcomes);
+
+        let mut record = worker("worker-1");
+        let config = base_config("worker-1");
+        let mut saved = Vec::new();
+        let (reports, removed) = execute_drain(&runner, &claims, &mut record, &config, |rec| {
+            saved.push(rec.clone());
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(removed, "the record should be marked for roster removal");
+        assert!(!reports.iter().any(|r| r.outcome.is_failure()), "reports: {reports:?}");
+        assert_eq!(reports.len(), DrainPhase::ALL.len());
+        // MarkDraining persisted first.
+        assert_eq!(saved[0].state.as_deref(), Some("draining"));
+        // The captured claim was reset.
+        assert_eq!(claims.calls.lock().unwrap().len(), 1);
+        assert_eq!(
+            claims.calls.lock().unwrap()[0],
+            ("rjwalters/anvil".to_string(), 42, "worker-1".to_string())
+        );
+
+        let report = build_report(&config, reports);
+        assert!(report.safe_to_power_off);
+        assert!(report.teardown_command.unwrap().contains("worker-1"));
+    }
+
+    // ---- resumability ------------------------------------------------
+
+    #[test]
+    fn rerun_after_interruption_resumes_at_recorded_phase() {
+        // Simulate a prior run that got through `trigger-remote-drain`.
+        let mut record = worker("worker-1");
+        record.state = Some("draining".to_string());
+        record.drain_phase = Some(DrainPhase::TriggerRemoteDrain.name().to_string());
+        record.drain_captured = vec![CapturedClaim {
+            issue: 42,
+            repo: "rjwalters/anvil".to_string(),
+        }];
+
+        let runner = MockRunner::new(vec![
+            Err("connection refused".to_string()), // wait-remote-exit
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }), // deregister
+        ]);
+        let mut outcomes = HashMap::new();
+        outcomes.insert(42, Ok(true));
+        let claims = MockClaimResetter::new(outcomes);
+        let config = base_config("worker-1");
+
+        let (reports, removed) =
+            execute_drain(&runner, &claims, &mut record, &config, |_| Ok(())).unwrap();
+
+        assert!(removed);
+        // The first two phases must be reported AlreadyDone, not re-run —
+        // and critically the mock never received a `capture-claims`/`trigger`
+        // call (only 2 responses were scripted and both were consumed by
+        // wait-remote-exit + deregister-workspace).
+        assert_eq!(reports[0].phase, DrainPhase::MarkDraining.name());
+        assert_eq!(reports[0].outcome, PhaseOutcome::AlreadyDone);
+        assert_eq!(reports[1].phase, DrainPhase::CaptureClaims.name());
+        assert_eq!(reports[1].outcome, PhaseOutcome::AlreadyDone);
+        assert_eq!(reports[2].phase, DrainPhase::TriggerRemoteDrain.name());
+        assert_eq!(reports[2].outcome, PhaseOutcome::AlreadyDone);
+        assert_eq!(runner.calls.borrow().len(), 2);
+    }
+
+    #[test]
+    fn rerun_on_already_drained_host_is_a_clean_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("fleet.json");
+        std::env::set_var(super::super::FLEET_REGISTRY_PATH_ENV, &registry_path);
+        // No worker registered at all.
+        let config = base_config("gone-host");
+        let report = run(&config).unwrap();
+        std::env::remove_var(super::super::FLEET_REGISTRY_PATH_ENV);
+
+        assert!(report.phases.is_empty());
+        assert!(report.safe_to_power_off);
+    }
+
+    // ---- fail-safe timeout without --force-after-timeout -----------------
+
+    #[test]
+    fn timeout_without_force_refuses_and_leaves_daemon_running() {
+        let runner = MockRunner::new(vec![
+            Ok(ok_with_in_flight(&[], true)), // capture-claims
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }), // trigger accepted
+            Ok(ok_status(false)), // wait-remote-exit: still reachable, draining=false ⇒ refused
+        ]);
+        let claims = MockClaimResetter::new(HashMap::new());
+        let mut record = worker("worker-1");
+        let config = base_config("worker-1");
+
+        let (reports, removed) =
+            execute_drain(&runner, &claims, &mut record, &config, |_| Ok(())).unwrap();
+
+        assert!(!removed, "a refused drain must not remove the roster entry");
+        let wait_report = reports
+            .iter()
+            .find(|r| r.phase == DrainPhase::WaitRemoteExit.name())
+            .unwrap();
+        assert!(wait_report.outcome.is_failure());
+        // Halts — reset-claims / flush / deregister / remove never run.
+        assert_eq!(reports.len(), 4);
+
+        let report = build_report(&config, reports);
+        assert!(!report.safe_to_power_off);
+        assert_eq!(report.exit_code(), 2);
+        assert!(report.teardown_command.is_none());
+    }
+
+    #[test]
+    fn trigger_remote_drain_refusal_halts_before_wait_and_leaves_roster_intact() {
+        let runner = MockRunner::new(vec![
+            Ok(ok_with_in_flight(&[], true)), // capture-claims
+            Ok(refused()),                    // trigger-remote-drain: remote refuses
+        ]);
+        let claims = MockClaimResetter::new(HashMap::new());
+        let mut record = worker("worker-1");
+        let config = base_config("worker-1");
+
+        let (reports, removed) =
+            execute_drain(&runner, &claims, &mut record, &config, |_| Ok(())).unwrap();
+
+        assert!(!removed);
+        let trigger_report = reports
+            .iter()
+            .find(|r| r.phase == DrainPhase::TriggerRemoteDrain.name())
+            .unwrap();
+        assert!(trigger_report.outcome.is_failure());
+        // wait-remote-exit and everything after never runs.
+        assert_eq!(reports.len(), 3);
+        assert_eq!(build_report(&config, reports).exit_code(), 1);
+    }
+
+    // ---- force-cancel resets every captured claim -------------------------
+
+    #[test]
+    fn timeout_with_force_completes_and_resets_every_captured_claim() {
+        let mut config = base_config("worker-1");
+        config.force_after_timeout = true;
+
+        let runner = MockRunner::new(vec![
+            Ok(ok_with_in_flight(&[10, 11], true)), // capture-claims: two in-flight
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }), // trigger (forced)
+            Err("connection refused".to_string()),  // wait-remote-exit: exited after force-cancel
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }), // deregister
+        ]);
+        let mut outcomes = HashMap::new();
+        outcomes.insert(10, Ok(true));
+        outcomes.insert(11, Ok(true));
+        let claims = MockClaimResetter::new(outcomes);
+        let mut record = worker("worker-1");
+
+        let (reports, removed) =
+            execute_drain(&runner, &claims, &mut record, &config, |_| Ok(())).unwrap();
+
+        assert!(removed);
+        assert!(!reports.iter().any(|r| r.outcome.is_failure()));
+        let mut reset_issues: Vec<u32> = claims
+            .calls
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(_, i, _)| *i)
+            .collect();
+        reset_issues.sort_unstable();
+        assert_eq!(reset_issues, vec![10, 11]);
+    }
+
+    // ---- claim already resolved between capture and reset -----------------
+
+    #[test]
+    fn reset_claims_no_ops_an_issue_that_already_left_building() {
+        let runner = MockRunner::new(vec![
+            Ok(ok_with_in_flight(&[42], true)),
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+            Err("connection refused".to_string()),
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+        ]);
+        // Issue 42 finished normally in the meantime — resetter reports false.
+        let mut outcomes = HashMap::new();
+        outcomes.insert(42, Ok(false));
+        let claims = MockClaimResetter::new(outcomes);
+        let mut record = worker("worker-1");
+        let config = base_config("worker-1");
+
+        let (reports, removed) =
+            execute_drain(&runner, &claims, &mut record, &config, |_| Ok(())).unwrap();
+        assert!(removed);
+        assert!(!reports.iter().any(|r| r.outcome.is_failure()));
+        assert_eq!(claims.calls.lock().unwrap().len(), 1);
+    }
+
+    // ---- unverified safehouse flush → non-zero, no "safe to power off" ---
+
+    #[test]
+    fn unverified_safehouse_flush_yields_nonzero_exit_and_no_safe_line() {
+        let mut config = base_config("worker-1");
+        config.safehouse_enabled = true;
+
+        let runner = MockRunner::new(vec![
+            Ok(ok_with_in_flight(&[], true)),
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+            Err("connection refused".to_string()),
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+        ]);
+        let claims = MockClaimResetter::new(HashMap::new());
+        let mut record = worker("worker-1");
+
+        let (reports, removed) =
+            execute_drain(&runner, &claims, &mut record, &config, |_| Ok(())).unwrap();
+        // Not blocked — deregistration/roster-removal still proceed.
+        assert!(removed);
+
+        let report = build_report(&config, reports);
+        assert!(!report.safe_to_power_off);
+        assert_eq!(report.exit_code(), 3);
+        let rendered = report.render_human();
+        assert!(!rendered.contains("safe to power off."), "rendered: {rendered}");
+        assert!(rendered.contains("DRAIN NOT VERIFIED SAFE"));
+    }
+
+    #[test]
+    fn safehouse_disabled_is_skipped_and_stays_safe() {
+        let config = base_config("worker-1"); // safehouse_enabled: false
+        let outcome = flush_safehouse(&config);
+        assert!(matches!(outcome, PhaseOutcome::Skipped { .. }));
+    }
+
+    // ---- roster entry removed only in the final phase ---------------------
+
+    #[test]
+    fn roster_entry_removed_only_after_every_other_phase_completes() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("fleet.json");
+        std::env::set_var(super::super::FLEET_REGISTRY_PATH_ENV, &registry_path);
+
+        let mut registry = FleetRegistry::default();
+        registry.upsert(worker("worker-1"));
+        registry.save(&registry_path).unwrap();
+
+        // Directly exercise `execute_drain` + a `run`-shaped persist, then
+        // simulate the same removal `run` performs, to prove ordering
+        // without needing a live ssh binary.
+        let runner = MockRunner::new(vec![
+            Ok(ok_with_in_flight(&[], true)),
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+            Err("connection refused".to_string()),
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+        ]);
+        let claims = MockClaimResetter::new(HashMap::new());
+        let mut record = registry.get("worker-1").unwrap().clone();
+        let config = base_config("worker-1");
+
+        let mut still_present_before_final = true;
+        let (reports, removed) = execute_drain(&runner, &claims, &mut record, &config, |rec| {
+            let mut reg = FleetRegistry::load(&registry_path)?;
+            // Every intermediate persist must still find the entry present.
+            still_present_before_final = reg.get(&rec.ssh_host).is_some();
+            reg.upsert(rec.clone());
+            reg.save(&registry_path)
+        })
+        .unwrap();
+
+        assert!(still_present_before_final);
+        assert!(removed);
+        assert!(!reports.iter().any(|r| r.outcome.is_failure()));
+
+        std::env::remove_var(super::super::FLEET_REGISTRY_PATH_ENV);
+    }
+}

--- a/loom-daemon/src/fleet/mod.rs
+++ b/loom-daemon/src/fleet/mod.rs
@@ -45,6 +45,7 @@
 //! deliberately minimal; the siblings can extend it.
 
 pub mod add_worker;
+pub mod drain;
 pub mod status;
 
 use anyhow::{anyhow, Context, Result};
@@ -533,6 +534,22 @@ pub struct WorkerRecord {
     /// deserialize.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub state: Option<String>,
+    /// The most recently *completed* `fleet drain` phase (#4343), a stable
+    /// machine name (see [`drain::DrainPhase::name`]). `None` means no drain
+    /// has ever started (or the record predates #4343). This is the
+    /// resumability marker (body step 6): a re-run reads it and skips every
+    /// phase up to and including this one, so an interrupted drain (crash,
+    /// killed SSH, operator Ctrl-C) picks up where it left off rather than
+    /// re-running already-applied phases.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub drain_phase: Option<String>,
+    /// The `loom:building` claims captured by drain's `capture-claims` phase,
+    /// before the remote daemon is told to drain — persisted immediately so a
+    /// crash between capture and the later `reset-claims` phase does not lose
+    /// the list (the exact stranding window the epic's pilot evidence, anvil
+    /// #758, cites). Empty on a record with no drain in progress.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub drain_captured: Vec<drain::CapturedClaim>,
 }
 
 /// The machine-level set of bootstrapped workers, persisted at
@@ -931,6 +948,8 @@ mod tests {
             tailnet_name: None,
             added_by: None,
             state: None,
+            drain_phase: None,
+            drain_captured: Vec::new(),
         }
     }
 

--- a/loom-daemon/src/fleet/status.rs
+++ b/loom-daemon/src/fleet/status.rs
@@ -698,6 +698,8 @@ mod tests {
             tailnet_name: Some("loom-worker-1".to_string()),
             added_by: None,
             state: None,
+            drain_phase: None,
+            drain_captured: Vec::new(),
         }
     }
 

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -182,6 +182,11 @@ pub struct DrainDescriptor {
     /// A short human-readable note about the last transition (timeout refusal,
     /// abort) surfaced in `loom-daemon status`.
     pub note: Option<String>,
+    /// `true` when this drain's terminal action is "exit and stay down"
+    /// rather than "exit for a supervised relaunch" (Issue #4343 — `fleet
+    /// drain`'s teardown use case). See [`Request::DrainAndRestartDaemon`]'s
+    /// `then_exit` field.
+    pub then_exit: bool,
 }
 
 /// Outcome of [`DrainState::begin`].
@@ -245,8 +250,16 @@ impl DrainState {
 
     /// Start a drain, or ack an already-running one (idempotent — a second drain
     /// request while DRAINING neither stacks a supervisor nor moves the
-    /// deadline). Sets the drain flag on a fresh start.
-    pub fn begin(&self, timeout: Duration, force_after_timeout: bool) -> DrainBegin {
+    /// deadline). Sets the drain flag on a fresh start. `then_exit` is ignored
+    /// on the already-draining path (the in-progress drain's terminal action is
+    /// unchanged by a later idempotent ack — mirrors `force_after_timeout` and
+    /// the deadline both staying fixed too).
+    pub fn begin(
+        &self,
+        timeout: Duration,
+        force_after_timeout: bool,
+        then_exit: bool,
+    ) -> DrainBegin {
         let mut inner = self.inner.lock().expect("Drain mutex poisoned");
         if inner.active {
             return DrainBegin::AlreadyDraining;
@@ -256,6 +269,7 @@ impl DrainState {
         inner.active = true;
         inner.deadline = Some(deadline);
         inner.force_after_timeout = force_after_timeout;
+        inner.then_exit = then_exit;
         inner.note = None;
         // Set the flag while holding the descriptor lock so status can never
         // observe `flag=true` with `active=false`.
@@ -410,32 +424,39 @@ pub fn handle_drain_request(
     event_bus: &Arc<EventBus>,
     timeout_secs: Option<u64>,
     force_after_timeout: bool,
+    then_exit: bool,
 ) -> Response {
-    // AC5 / Finding 4: prove supervision BEFORE entering DRAINING. Draining for
-    // 20 minutes and only then discovering there is no supervisor to relaunch
-    // into is the worst possible ordering — and pausing dispatch then refusing
-    // would be a silent outage.
-    let supervisor = match detect_supervisor() {
-        Some(s) => s,
-        None => {
-            return Response::DaemonDrain {
-                accepted: false,
-                supervisor: None,
-                in_flight: count_in_flight_sweeps(workspace_pool, fallback_root),
-                message: "refusing to drain: no supervisor detected \
-                    (LOOM_DAEMON_SUPERVISOR unset). This daemon was not started under \
-                    a recognized supervisor, so nothing would relaunch it after a drain. \
-                    Dispatch was NOT paused. Restart manually with loom-daemon-stop.sh && \
-                    loom-daemon-start.sh."
-                    .to_string(),
-            };
+    // AC5 / Finding 4: prove supervision BEFORE entering DRAINING — for the
+    // #4090 restart-when-drained case. A `then_exit` drain (#4343) deliberately
+    // does NOT want a relaunch, so the supervisor requirement does not apply to
+    // it at all: skip the refusal gate entirely and just report whatever
+    // supervisor (if any) is detected, informationally.
+    let supervisor = if then_exit {
+        detect_supervisor()
+    } else {
+        match detect_supervisor() {
+            Some(s) => Some(s),
+            None => {
+                return Response::DaemonDrain {
+                    accepted: false,
+                    supervisor: None,
+                    in_flight: count_in_flight_sweeps(workspace_pool, fallback_root),
+                    message: "refusing to drain: no supervisor detected \
+                        (LOOM_DAEMON_SUPERVISOR unset). This daemon was not started under \
+                        a recognized supervisor, so nothing would relaunch it after a drain. \
+                        Dispatch was NOT paused. Restart manually with loom-daemon-stop.sh && \
+                        loom-daemon-start.sh."
+                        .to_string(),
+                    then_exit,
+                };
+            }
         }
     };
 
     let in_flight = count_in_flight_sweeps(workspace_pool, fallback_root);
     let timeout = Duration::from_secs(timeout_secs.unwrap_or(DEFAULT_DRAIN_TIMEOUT_SECS));
 
-    match drain.begin(timeout, force_after_timeout) {
+    match drain.begin(timeout, force_after_timeout, then_exit) {
         DrainBegin::Started {
             generation,
             deadline,
@@ -446,6 +467,7 @@ pub fn handle_drain_request(
                     "in_flight": in_flight,
                     "timeout_secs": timeout.as_secs(),
                     "force_after_timeout": force_after_timeout,
+                    "then_exit": then_exit,
                     "deadline": deadline,
                 }),
             );
@@ -461,15 +483,35 @@ pub fn handle_drain_request(
                     bus_task,
                     generation,
                     DRAIN_POLL_INTERVAL,
+                    then_exit,
                 )
                 .await;
             });
-            let msg = if in_flight == 0 {
-                format!("drain scheduled ({supervisor}-supervised): 0 in-flight — restarting now.")
+            let msg = if then_exit {
+                if in_flight == 0 {
+                    "drain scheduled (then-exit): 0 in-flight — stopping now (will NOT relaunch)."
+                        .to_string()
+                } else {
+                    format!(
+                        "drain scheduled (then-exit): {in_flight} in-flight sweep(s); new dispatch \
+                         paused. Will stop (NOT relaunch) when drained, or {} at the deadline.",
+                        if force_after_timeout {
+                            "cancel stragglers and stop"
+                        } else {
+                            "refuse and resume dispatch"
+                        }
+                    )
+                }
+            } else if in_flight == 0 {
+                format!(
+                    "drain scheduled ({}-supervised): 0 in-flight — restarting now.",
+                    supervisor.as_deref().unwrap_or("unknown")
+                )
             } else {
                 format!(
-                    "drain scheduled ({supervisor}-supervised): {in_flight} in-flight sweep(s); \
+                    "drain scheduled ({}-supervised): {in_flight} in-flight sweep(s); \
                      new dispatch paused. Will restart when drained, or {} at the deadline.",
+                    supervisor.as_deref().unwrap_or("unknown"),
                     if force_after_timeout {
                         "cancel stragglers and restart"
                     } else {
@@ -479,19 +521,21 @@ pub fn handle_drain_request(
             };
             Response::DaemonDrain {
                 accepted: true,
-                supervisor: Some(supervisor),
+                supervisor,
                 in_flight,
                 message: msg,
+                then_exit,
             }
         }
         DrainBegin::AlreadyDraining => Response::DaemonDrain {
             accepted: true,
-            supervisor: Some(supervisor),
+            supervisor,
             in_flight,
             message: format!(
                 "already draining (idempotent): {in_flight} in-flight sweep(s); the existing \
                  deadline is unchanged. Use `loom-daemon restart --abort-drain` to cancel."
             ),
+            then_exit,
         },
     }
 }
@@ -507,6 +551,7 @@ async fn run_drain_supervisor(
     event_bus: Arc<EventBus>,
     my_generation: u64,
     poll_interval: Duration,
+    then_exit: bool,
 ) {
     loop {
         // Superseded / aborted: a newer drain or an abort bumped the generation,
@@ -536,8 +581,16 @@ async fn run_drain_supervisor(
             DrainTick::Complete => {
                 let _ = event_bus.publish_generic(
                     "daemon.drain.completed",
-                    serde_json::json!({ "in_flight": 0 }),
+                    serde_json::json!({ "in_flight": 0, "then_exit": then_exit }),
                 );
+                if then_exit {
+                    log::warn!(
+                        "drain complete — 0 in-flight sweeps; exiting {EXIT_SHUTDOWN} and staying \
+                         down (then_exit — Issue #4343 teardown). No sweep was killed; no orphan \
+                         left behind."
+                    );
+                    std::process::exit(EXIT_SHUTDOWN);
+                }
                 // This path only runs after `handle_drain_request` proved
                 // supervision, so `detect_supervisor()` should still be `Some`
                 // here; fall back to a generic label rather than hardcoding
@@ -570,8 +623,17 @@ async fn run_drain_supervisor(
                         "in_flight": in_flight,
                         "forced": true,
                         "cancelled": cancelled,
+                        "then_exit": then_exit,
                     }),
                 );
+                if then_exit {
+                    log::warn!(
+                        "drain timed out with {in_flight} in-flight; --force-after-timeout \
+                         cancelled {cancelled} sweep(s); exiting {EXIT_SHUTDOWN} and staying down \
+                         (then_exit — Issue #4343 teardown)"
+                    );
+                    std::process::exit(EXIT_SHUTDOWN);
+                }
                 log::warn!(
                     "drain timed out with {in_flight} in-flight; --force-after-timeout cancelled \
                      {cancelled} sweep(s); exiting {EXIT_RESTART} for a supervised relaunch"
@@ -911,6 +973,7 @@ async fn handle_client(
         if let Request::DrainAndRestartDaemon {
             timeout_secs,
             force_after_timeout,
+            then_exit,
         } = request
         {
             let response = handle_drain_request(
@@ -920,6 +983,7 @@ async fn handle_client(
                 &event_bus,
                 timeout_secs,
                 force_after_timeout,
+                then_exit,
             );
             let response_json = serde_json::to_string(&response)?;
             writer.write_all(response_json.as_bytes()).await?;
@@ -946,6 +1010,7 @@ async fn handle_client(
                 supervisor: detect_supervisor(),
                 in_flight: count_in_flight_sweeps(&workspace_pool, &fallback_root),
                 message,
+                then_exit: false,
             };
             let response_json = serde_json::to_string(&response)?;
             writer.write_all(response_json.as_bytes()).await?;
@@ -5614,7 +5679,7 @@ exit 0
         assert_eq!(drain.generation(), 0);
 
         // begin ⇒ Started, flag set, deadline recorded, generation bumped.
-        let (gen1, deadline) = match drain.begin(Duration::from_secs(120), false) {
+        let (gen1, deadline) = match drain.begin(Duration::from_secs(120), false, false) {
             DrainBegin::Started {
                 generation,
                 deadline,
@@ -5628,7 +5693,7 @@ exit 0
 
         // A second begin while already draining is idempotent: same generation,
         // same deadline, flag still set (AC edge: second drain does not stack).
-        match drain.begin(Duration::from_secs(9999), true) {
+        match drain.begin(Duration::from_secs(9999), true, false) {
             DrainBegin::AlreadyDraining => {}
             other => panic!("expected AlreadyDraining, got {other:?}"),
         }
@@ -5650,7 +5715,7 @@ exit 0
 
         // timeout resolution clears + notes + bumps generation.
         let gen_before = drain.generation();
-        let _ = drain.begin(Duration::from_secs(1), false);
+        let _ = drain.begin(Duration::from_secs(1), false, false);
         drain.resolve_timeout("timed out".to_string());
         assert!(!drain.is_draining());
         assert_eq!(drain.snapshot().note.as_deref(), Some("timed out"));
@@ -5677,7 +5742,7 @@ exit 0
         let bus = Arc::new(EventBus::new());
         let drain = Arc::new(DrainState::new());
 
-        let resp = handle_drain_request(&drain, &pool, &root, &bus, Some(60), false);
+        let resp = handle_drain_request(&drain, &pool, &root, &bus, Some(60), false, false);
         match resp {
             Response::DaemonDrain {
                 accepted,
@@ -5794,7 +5859,7 @@ exit 0
         assert_eq!(report.drain_deadline, None);
 
         // Begin a drain ⇒ overlay reports draining + deadline.
-        let deadline = match drain.begin(Duration::from_secs(300), false) {
+        let deadline = match drain.begin(Duration::from_secs(300), false, false) {
             DrainBegin::Started { deadline, .. } => deadline,
             other => panic!("expected Started, got {other:?}"),
         };
@@ -5838,6 +5903,7 @@ exit 0
         let req = Request::DrainAndRestartDaemon {
             timeout_secs: Some(600),
             force_after_timeout: true,
+            then_exit: false,
         };
         let json = serde_json::to_string(&req).unwrap();
         let back: Request = serde_json::from_str(&json).unwrap();
@@ -5845,10 +5911,22 @@ exit 0
             Request::DrainAndRestartDaemon {
                 timeout_secs,
                 force_after_timeout,
+                then_exit,
             } => {
                 assert_eq!(timeout_secs, Some(600));
                 assert!(force_after_timeout);
+                assert!(!then_exit);
             }
+            other => panic!("expected DrainAndRestartDaemon, got {other:?}"),
+        }
+
+        // Pre-#4343 wire data (no `then_exit` key at all) still parses, as
+        // `then_exit: false` — the original #4090 restart-when-drained
+        // behavior.
+        let legacy_json = r#"{"type":"DrainAndRestartDaemon","payload":{"timeout_secs":600,"force_after_timeout":true}}"#;
+        let back: Request = serde_json::from_str(legacy_json).unwrap();
+        match back {
+            Request::DrainAndRestartDaemon { then_exit, .. } => assert!(!then_exit),
             other => panic!("expected DrainAndRestartDaemon, got {other:?}"),
         }
 
@@ -5858,12 +5936,13 @@ exit 0
         let back: Request = serde_json::from_str(&json).unwrap();
         assert!(matches!(back, Request::AbortDrain));
 
-        // The DaemonDrain response round-trips.
+        // The DaemonDrain response round-trips, including `then_exit`.
         let resp = Response::DaemonDrain {
             accepted: true,
             supervisor: Some("launchd".to_string()),
             in_flight: 3,
             message: "draining".to_string(),
+            then_exit: true,
         };
         let json = serde_json::to_string(&resp).unwrap();
         let back: Response = serde_json::from_str(&json).unwrap();
@@ -5872,11 +5951,13 @@ exit 0
                 accepted,
                 supervisor,
                 in_flight,
+                then_exit,
                 ..
             } => {
                 assert!(accepted);
                 assert_eq!(supervisor.as_deref(), Some("launchd"));
                 assert_eq!(in_flight, 3);
+                assert!(then_exit);
             }
             other => panic!("expected DaemonDrain, got {other:?}"),
         }
@@ -5890,7 +5971,7 @@ exit 0
     #[test]
     fn test_abort_supersedes_running_supervisor_generation() {
         let drain = DrainState::new();
-        let gen = match drain.begin(Duration::from_secs(300), false) {
+        let gen = match drain.begin(Duration::from_secs(300), false, false) {
             DrainBegin::Started { generation, .. } => generation,
             other => panic!("expected Started, got {other:?}"),
         };

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -27,7 +27,7 @@ use loom_daemon::workspace_pool::WorkspacePool;
 use loom_daemon::worktree_ops::{aggressive, clean};
 use loom_daemon::{extract_configured_terminal_ids, rotate_log_file};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand};
 use std::fs;
@@ -272,6 +272,11 @@ enum Commands {
     /// immediately and waits for every in-flight sweep to finish before
     /// restarting — no sweep killed, no orphan left behind. `--abort-drain`
     /// cancels an in-progress drain and resumes normal dispatch.
+    ///
+    /// With `--drain --then-exit` (Issue #4343 — `fleet drain`'s teardown use
+    /// case) the daemon stops (and stays stopped — exits without a supervised
+    /// relaunch) instead of restarting once drained, so it cannot pick up new
+    /// dispatch on a host that is about to be powered off.
     Restart {
         /// Finish all in-flight sweeps before restarting, instead of restarting
         /// immediately (#4090). New dispatch is paused for the duration.
@@ -289,6 +294,13 @@ enum Commands {
         /// Abort an in-progress drain and resume normal dispatch (no restart).
         #[arg(long)]
         abort_drain: bool,
+        /// With `--drain`, stop (and stay down) instead of restarting once
+        /// drained (Issue #4343). Requires `--drain`; the daemon does not
+        /// require a recognized supervisor for this variant (there is
+        /// nothing to prove supervision for — a `then-exit` drain never
+        /// wants a relaunch).
+        #[arg(long)]
+        then_exit: bool,
     },
 
     /// Manage the multi-account OAuth token pool at `.loom/tokens/` (Issue
@@ -539,6 +551,41 @@ enum FleetAction {
     /// non-zero unless every roster host is `UP`.
     Status {
         /// Emit machine-readable JSON instead of the human-readable table.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Retire a worker without losing in-flight work, forge claims, or (when
+    /// wired) E2E room keys (issue #4343). SSH orchestration over the existing
+    /// `restart --drain` primitive (#4090), plus the teardown-specific deltas:
+    /// a drain-then-*exit* remote invocation (never restart into new dispatch
+    /// on a box about to be powered off), an immediate targeted `loom:building`
+    /// claim reset via `gh` (not SSH — the forge is global), a safehoused
+    /// key-backup flush check (a documented stub pending #3998 — see
+    /// `loom_daemon::fleet::drain`'s module doc), workspace deregistration, and
+    /// finally removing the worker from the fleet registry. Idempotent +
+    /// resumable: an interrupted drain re-runs from its last completed phase.
+    /// Never calls a cloud CLI itself — prints the exact `repo:remote --down`
+    /// teardown command instead (epic #4340's boundary).
+    Drain {
+        /// SSH alias/host to drain (must already be in the fleet registry;
+        /// draining a host not in the registry is a clean no-op).
+        #[arg(value_name = "SSH_HOST")]
+        ssh_host: String,
+
+        /// Max seconds the remote daemon waits for in-flight sweeps to drain.
+        #[arg(long, value_name = "SECS", default_value_t = loom_daemon::fleet::drain::DEFAULT_DRAIN_TIMEOUT_SECS)]
+        timeout: u64,
+
+        /// On remote drain timeout, force-cancel stragglers
+        /// (SIGTERM→grace→SIGKILL) and proceed anyway. Without this, a
+        /// timeout refuses and the remote daemon stays running (fail-safe) —
+        /// this command then also refuses to proceed past waiting for it to
+        /// exit.
+        #[arg(long)]
+        force_after_timeout: bool,
+
+        /// Emit machine-readable JSON instead of the human-readable report.
         #[arg(long)]
         json: bool,
     },
@@ -1010,7 +1057,11 @@ async fn main() -> Result<()> {
                 timeout,
                 force_after_timeout,
                 abort_drain,
-            } => handle_restart_command(drain, timeout, force_after_timeout, abort_drain).await,
+                then_exit,
+            } => {
+                handle_restart_command(drain, timeout, force_after_timeout, abort_drain, then_exit)
+                    .await
+            }
             // `fleet status` collects the local host's own status over the
             // daemon's Unix socket (issue #4342), so — unlike `fleet
             // add-worker`, which is pure ssh/filesystem and stays on the sync
@@ -2661,8 +2712,14 @@ async fn handle_restart_command(
     timeout: Option<u64>,
     force_after_timeout: bool,
     abort_drain: bool,
+    then_exit: bool,
 ) -> Result<()> {
     let socket_path = resolve_socket_path()?;
+
+    if then_exit && !drain {
+        eprintln!("--then-exit requires --drain (there is nothing to drain-then-exit without it)");
+        std::process::exit(1);
+    }
 
     // Drain-mode variants (Issue #4090) speak `DrainAndRestartDaemon` /
     // `AbortDrain` and expect a `DaemonDrain` reply; the plain restart keeps its
@@ -2677,14 +2734,23 @@ async fn handle_restart_command(
         .await;
     }
     if drain {
+        let (accepted_prefix, refused_prefix) = if then_exit {
+            (
+                "loom-daemon drain-then-exit scheduled (will stop, not restart, once drained)",
+                "loom-daemon did NOT drain",
+            )
+        } else {
+            ("loom-daemon drain scheduled", "loom-daemon did NOT drain")
+        };
         return handle_drain_reply(
             &socket_path,
             &Request::DrainAndRestartDaemon {
                 timeout_secs: timeout,
                 force_after_timeout,
+                then_exit,
             },
-            "loom-daemon drain scheduled",
-            "loom-daemon did NOT drain",
+            accepted_prefix,
+            refused_prefix,
         )
         .await;
     }
@@ -2741,12 +2807,15 @@ async fn handle_drain_reply(
             supervisor,
             in_flight,
             message,
+            then_exit,
         }) => {
             if accepted {
-                println!(
-                    "{accepted_prefix} (supervisor: {}, {in_flight} in-flight).",
-                    supervisor.as_deref().unwrap_or("unknown")
-                );
+                let sup_note = if then_exit {
+                    "then-exit — no relaunch".to_string()
+                } else {
+                    supervisor.as_deref().unwrap_or("unknown").to_string()
+                };
+                println!("{accepted_prefix} (supervisor: {sup_note}, {in_flight} in-flight).");
                 println!("{message}");
                 Ok(())
             } else {
@@ -4759,6 +4828,7 @@ fn print_agent_effectiveness(agent: &activity::AgentEffectiveness) {
 /// lives in [`loom_daemon::fleet`].
 fn handle_fleet_command(action: FleetAction) -> Result<()> {
     use loom_daemon::fleet::add_worker::{self, AddWorkerConfig};
+    use loom_daemon::fleet::drain::{self, DrainConfig};
 
     match action {
         FleetAction::AddWorker {
@@ -4790,6 +4860,43 @@ fn handle_fleet_command(action: FleetAction) -> Result<()> {
             // local host's in-process socket round-trip), never dispatched
             // through this sync handler.
             unreachable!("Fleet Status is handled in main() before handle_cli_command")
+        }
+        FleetAction::Drain {
+            ssh_host,
+            timeout,
+            force_after_timeout,
+            json,
+        } => {
+            // Resolved once, from the operator's own cwd (mirrors
+            // `WorkspacePool::start_safehouse_narration`'s
+            // `safehouse::resolve_config(repo_root)` call shape) — see
+            // `fleet::drain::flush_safehouse`'s doc comment for why this is a
+            // documented stub, not a real flush, pending #3998.
+            let cwd = std::env::current_dir().context("resolving cwd for safehouse config")?;
+            let safehouse_enabled = loom_daemon::safehouse::resolve_config(&cwd).enabled;
+
+            let poll_interval = Duration::from_secs(drain::DEFAULT_POLL_INTERVAL_SECS);
+            let max_polls = ((timeout / drain::DEFAULT_POLL_INTERVAL_SECS.max(1)) + 12) as u32;
+            let config = DrainConfig {
+                ssh_host,
+                timeout_secs: timeout,
+                force_after_timeout,
+                poll_interval,
+                max_polls,
+                safehouse_enabled,
+                json,
+            };
+            let report = drain::run(&config)?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&report)?);
+            } else {
+                print!("{}", report.render_human());
+            }
+            let code = report.exit_code();
+            if code != 0 {
+                std::process::exit(code);
+            }
+            Ok(())
         }
     }
 }

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -426,10 +426,27 @@ pub enum Request {
     ///
     /// On an unsupervised host the daemon refuses immediately (before pausing
     /// dispatch) with `DaemonDrain { accepted: false, .. }`, mirroring
-    /// [`Request::RestartDaemon`]'s refusal contract.
+    /// [`Request::RestartDaemon`]'s refusal contract — **unless** `then_exit`
+    /// is set (see below), in which case the supervisor requirement does not
+    /// apply at all.
+    ///
+    /// - `then_exit` (Issue #4343, `fleet drain`'s teardown use case):
+    ///   `false` (the #4090 default) preserves the original restart-when-drained
+    ///   behavior byte-for-byte. `true` changes the terminal action from
+    ///   "exit [`crate::ipc::EXIT_RESTART`] for a supervised relaunch" to "exit
+    ///   [`crate::ipc::EXIT_SHUTDOWN`] and **stay down**" — the daemon must not
+    ///   pick up new dispatch on a host about to be powered off, so a relaunch
+    ///   would defeat the whole point of draining before teardown. Because a
+    ///   `then_exit` drain deliberately does **not** want a relaunch, the
+    ///   supervisor-detection refusal gate is skipped entirely for it (there is
+    ///   nothing to prove supervision *for*). `#[serde(default)]` keeps
+    ///   pre-#4343 wire data (`{"type":"DrainAndRestartDaemon","payload":{...}}`
+    ///   with no `then_exit` key) parsing as `false` — the original behavior.
     DrainAndRestartDaemon {
         timeout_secs: Option<u64>,
         force_after_timeout: bool,
+        #[serde(default)]
+        then_exit: bool,
     },
     /// Abort an in-progress drain (Issue #4090): clear the drain flag so new
     /// dispatch resumes, and stop the drain-supervisor task so no later restart
@@ -601,11 +618,17 @@ pub enum Response {
     /// `in_flight` is the cross-root non-terminal sweep count at request time,
     /// so the operator immediately sees how much work the drain must wait for.
     /// `message` is a human-readable explanation for operator output.
+    /// `then_exit` (Issue #4343) echoes back the request's `then_exit`: `true`
+    /// means the daemon will exit and stay down once drained (never relaunch),
+    /// rather than restart. `#[serde(default)]` keeps pre-#4343 wire data
+    /// parsing (as `false`).
     DaemonDrain {
         accepted: bool,
         supervisor: Option<String>,
         in_flight: usize,
         message: String,
+        #[serde(default)]
+        then_exit: bool,
     },
     // ========================================================================
     // Workspace Registry Responses (Issue #3926 — phase 1 of #3835)


### PR DESCRIPTION
## Summary

Implements `loom-daemon fleet drain <ssh-host>`, part of epic #4340. Retires a fleet worker without losing in-flight work, forge claims, or (once #3998 lands) E2E safehouse room keys.

This is **SSH orchestration over an existing primitive**, not a new drain engine: `restart --drain` (#4090) already stops admitting new dispatch and waits bounded for in-flight sweeps to finish, refusing (fail-safe) or force-cancelling at the deadline. `fleet drain` layers the teardown-specific deltas on top:

1. **Drain-then-*exit*, not drain-then-restart** — `restart --drain --then-exit` (new flag on `Restart`/`DrainAndRestartDaemon`) tells the remote daemon to exit `EXIT_SHUTDOWN` and **stay down** instead of restarting once drained. A relaunched daemon could pick up new dispatch before the box powers off, defeating the point of draining. Because a `then-exit` drain never wants a relaunch, the supervisor-detection refusal gate (#4090's AC5) is skipped for it entirely.
2. **Immediate, targeted claim reset** — the startup-only `claim_reconciliation` pass is too late for a drain. This captures the worker's in-flight issue numbers (`status --json`) *before* triggering the remote drain, then flips any still-`loom:building` back to `loom:issue` via `gh` **from the orchestrator, not over SSH** (the forge is global) once the remote daemon has exited.
3. **Safehoused flush verification (#3998)** — see "Handling of the #3998 dependency" below.
4. **Deregistration** — `loom-daemon workspace remove` on the (now-stopped) remote host's registry, best-effort since the daemon has already exited; then the fleet-roster entry is removed locally.
5. **Handoff, never teardown** — loom never calls a cloud CLI. The final report prints the exact `repo:remote --down <ssh-host>` command for the operator to run; a "safe to power off" verdict is emitted only when every phase, including the safehouse flush, verified.
6. **Idempotent + resumable** — an 8-phase state machine (`mark-draining` → `capture-claims` → `trigger-remote-drain` → `wait-remote-exit` → `reset-claims` → `flush-safehouse` → `deregister-workspace` → `remove-from-roster`), persisted on the fleet registry entry's new `drain_phase`/`drain_captured` fields. `mark-draining` runs first (so an interrupted drain stays visible in `fleet status`); `remove-from-roster` runs last (only once the safehouse flush has resolved). A re-run reads the marker and resumes after the last completed phase.

Exit codes: `0` fully verified drain (safe to power off), `1` a phase failed outright, `2` remote drain timed out without `--force-after-timeout` (fail-safe, daemon still running), `3` every phase completed but the safehouse flush is unverified.

## Handling of the #3998 dependency

#3998 (the safehoused provisioning/teardown fragment, still open/`loom:blocked`) is a remote-side artifact in the separate `safehouse` repo, not a loom-repo code dependency, so the rest of the state machine is built now per the curator's guidance. The `flush-safehouse` phase is a **documented stub**, not a fabricated check:

- `safehouse.enabled == false`: `Skipped` — no room keys in play on this host, so "safe to power off" is accurate.
- `safehouse.enabled == true`: `Unverified` — the drain still completes (deregistration/roster-removal proceed; loom never refuses to retire a box over this), but the final verdict explicitly withholds "safe to power off" and exits non-zero (`3`), so an operator/monitor treats it as a flag, not a clean success.

`TODO(#3998)` in `loom-daemon/src/fleet/drain.rs`'s `flush_safehouse` doc comment marks where a real SSH-invoked steady-state check replaces the stub once a seam lands.

## What pre-existed vs. what I built

This worktree had a prior interrupted builder session's uncommitted diff. I reviewed it critically against the curator's guidance and the actual current file contents (not just the curator's claims about "verified seams") and found it correct, complete, and well-tested — so I kept it as-is rather than rewriting. What I did:

- Re-verified the cited seams (`FleetAction`/`Commands::Fleet` dispatch, `HostStatusSource`/`CommandRunner` mock seams, `WorkerRecord.state`) still hold against current `main`.
- Rebased the branch onto `origin/main` (it was 6, then 2, commits behind) — both rebases auto-merged cleanly with no conflict markers.
- Ran `cargo build -p loom-daemon`, `cargo test -p loom-daemon --lib` (full suite, 1840 tests, all green), and `cargo clippy -p loom-daemon --lib -- -D warnings` (clean).
- Committed and pushed.

## Test plan

- `cargo test -p loom-daemon --lib fleet` — 71 tests, all green, including: full happy-path phase sequence; re-run after interruption resumes at the recorded phase; timeout without `--force-after-timeout` refuses and leaves the daemon running; timeout with `--force-after-timeout` force-cancels and resets every captured claim; unverified safehouse flush yields non-zero exit and withholds "safe to power off"; roster entry removed only in the final phase; re-run on an already-drained host is a clean no-op.
- `cargo test -p loom-daemon --lib` — full 1840-test suite green (including `ipc::`/`auto_update::` tests covering the `then_exit` IPC contract extension and its wire-compatibility with pre-#4343 payloads).
- `cargo clippy -p loom-daemon --lib -- -D warnings` — clean.
- Manual verification against a live pilot worker is out of scope for this PR (documented in the module's rustdoc instead, per curator guidance).

Closes #4343