### PR TITLE
fix(guards): expand unquoted leading ~/ before Bash write-target resolution

### DIFF
--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -1888,6 +1888,95 @@ normalize_abs_path() {
     fi
 }
 
+# =============================================================================
+# expand_leading_tilde() — shell-accurate tilde expansion for write targets
+# (#4382, same fix family as the quote-aware `>` scanning of #4245/#4289).
+#
+# extract_write_targets() (below) is a plain-whitespace/quote-aware TOKENIZER,
+# not a shell evaluator — it never performs word expansions (tilde, variable,
+# glob, ...). A raw token like `~/.local/bin/x` was therefore resolved as a
+# REPO-RELATIVE path (cwd-prefixed) even though the real shell would expand it
+# to "$HOME/.local/bin/x" before `cp`/`mv`/`tee`/`sed -i`/redirection ever see
+# it — producing a false-positive worktree-confinement deny on a write that
+# actually lands far outside the repo (#4382).
+#
+# This performs ONLY the narrow, unambiguous piece of shell word-expansion
+# tilde-expansion applies to: an UNQUOTED, UNESCAPED tilde as the FIRST
+# character of the token, i.e. exactly the shell-eligible positions:
+#   ~/rest        -> "$HOME/rest"
+#   ~             -> "$HOME"
+#   ~user/rest    -> "<user's home>/rest"   (only if that user resolves)
+#   ~user         -> "<user's home>"
+#
+# Because qsplit() (the shared tokenizer, #3755) copies a quoted span
+# VERBATIM including its quote characters, and leaves a literal backslash
+# untouched, a token whose raw text does not start with a bare `~` was NOT
+# eligible for shell tilde-expansion and MUST stay untouched here:
+#   '~/x'   -> starts with a quote char, shell never expands it (stays literal)
+#   \~/x    -> starts with a literal backslash, shell never expands it either
+#   foo~/x  -> tilde is not the leading character -- not an expansion position
+# Any of these three cases falls through unchanged (echoed back as-is), which
+# preserves the existing (correct) repo-relative/deny behavior for them.
+#
+# `~user` lookup uses getent (Linux) / dscl (macOS) with the username passed
+# as a plain CLI argument (never eval'd/interpolated into a shell string) so a
+# hostile username token cannot inject a command. If the user cannot be
+# resolved on this host, the token is returned UNCHANGED (falls back to the
+# existing repo-relative treatment) -- consistent with this file's fail-open
+# contract: uncertainty here biases toward the (safe) deny path, never toward
+# a silent new allow.
+# =============================================================================
+expand_leading_tilde() {
+    local tok="$1"
+    # shellcheck disable=SC2088 # intentional: these `~`-prefixed case
+    # patterns are literal PATTERN matches against an unexpanded leading
+    # tilde in $tok (the whole point of this function), not an attempt at
+    # shell tilde expansion.
+    case "$tok" in
+        '~')
+            [[ -n "$HOME" ]] && { printf '%s' "$HOME"; return; }
+            printf '%s' "$tok"
+            return
+            ;;
+        '~/'*)
+            if [[ -n "$HOME" ]]; then
+                printf '%s' "$HOME/${tok#\~/}"
+            else
+                printf '%s' "$tok"
+            fi
+            return
+            ;;
+        '~'*)
+            local rest="${tok#\~}"
+            local user="${rest%%/*}"
+            local remainder=""
+            if [[ "$rest" == */* ]]; then
+                remainder="/${rest#*/}"
+            fi
+            if [[ -n "$user" ]]; then
+                local home=""
+                if command -v getent >/dev/null 2>&1; then
+                    home=$(getent passwd "$user" 2>/dev/null | cut -d: -f6)
+                elif command -v dscl >/dev/null 2>&1; then
+                    home=$(dscl . -read "/Users/$user" NFSHomeDirectory 2>/dev/null | awk '{print $2}')
+                fi
+                if [[ -n "$home" ]]; then
+                    printf '%s' "${home}${remainder}"
+                    return
+                fi
+            fi
+            # Unresolvable ~user (unknown user / no lookup tool available):
+            # leave untouched -- falls back to repo-relative resolution.
+            printf '%s' "$tok"
+            return
+            ;;
+        *)
+            printf '%s' "$tok"
+            return
+            ;;
+    esac
+}
+
 # Cheap pre-check keeps awk off the hot path for the ~99% of commands that have
 # no recursive/force rm at all.
 if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
@@ -2060,6 +2149,15 @@ if worktree_isolation_guard_enabled && \
     WRITE_TARGETS=$(extract_write_targets "$COMMAND_ASK_SCAN" "$CWD" | head -20)
     while IFS=$'\037' read -r _wcwd _wtarget; do
         [[ -z "$_wtarget" ]] && continue
+
+        # Shell-accurate tilde expansion (#4382): an unquoted/unescaped
+        # leading `~/` or `~user/` in the raw token is what the real shell
+        # would expand BEFORE cp/mv/tee/sed -i/redirection ever see it, so
+        # expand it here before the relative-path resolution below runs.
+        # Quoted ('~/x') / escaped (\~/x) tildes are left untouched (see
+        # expand_leading_tilde()'s doc comment) — no change to their
+        # existing repo-relative treatment.
+        _wtarget=$(expand_leading_tilde "$_wtarget")
 
         # Resolve to absolute; a relative target with no resolvable cwd is
         # ambiguous — skip it (allow on uncertainty, never deny on it).

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -1888,6 +1888,95 @@ normalize_abs_path() {
     fi
 }
 
+# =============================================================================
+# expand_leading_tilde() — shell-accurate tilde expansion for write targets
+# (#4382, same fix family as the quote-aware `>` scanning of #4245/#4289).
+#
+# extract_write_targets() (below) is a plain-whitespace/quote-aware TOKENIZER,
+# not a shell evaluator — it never performs word expansions (tilde, variable,
+# glob, ...). A raw token like `~/.local/bin/x` was therefore resolved as a
+# REPO-RELATIVE path (cwd-prefixed) even though the real shell would expand it
+# to "$HOME/.local/bin/x" before `cp`/`mv`/`tee`/`sed -i`/redirection ever see
+# it — producing a false-positive worktree-confinement deny on a write that
+# actually lands far outside the repo (#4382).
+#
+# This performs ONLY the narrow, unambiguous piece of shell word-expansion
+# tilde-expansion applies to: an UNQUOTED, UNESCAPED tilde as the FIRST
+# character of the token, i.e. exactly the shell-eligible positions:
+#   ~/rest        -> "$HOME/rest"
+#   ~             -> "$HOME"
+#   ~user/rest    -> "<user's home>/rest"   (only if that user resolves)
+#   ~user         -> "<user's home>"
+#
+# Because qsplit() (the shared tokenizer, #3755) copies a quoted span
+# VERBATIM including its quote characters, and leaves a literal backslash
+# untouched, a token whose raw text does not start with a bare `~` was NOT
+# eligible for shell tilde-expansion and MUST stay untouched here:
+#   '~/x'   -> starts with a quote char, shell never expands it (stays literal)
+#   \~/x    -> starts with a literal backslash, shell never expands it either
+#   foo~/x  -> tilde is not the leading character -- not an expansion position
+# Any of these three cases falls through unchanged (echoed back as-is), which
+# preserves the existing (correct) repo-relative/deny behavior for them.
+#
+# `~user` lookup uses getent (Linux) / dscl (macOS) with the username passed
+# as a plain CLI argument (never eval'd/interpolated into a shell string) so a
+# hostile username token cannot inject a command. If the user cannot be
+# resolved on this host, the token is returned UNCHANGED (falls back to the
+# existing repo-relative treatment) -- consistent with this file's fail-open
+# contract: uncertainty here biases toward the (safe) deny path, never toward
+# a silent new allow.
+# =============================================================================
+expand_leading_tilde() {
+    local tok="$1"
+    # shellcheck disable=SC2088 # intentional: these `~`-prefixed case
+    # patterns are literal PATTERN matches against an unexpanded leading
+    # tilde in $tok (the whole point of this function), not an attempt at
+    # shell tilde expansion.
+    case "$tok" in
+        '~')
+            [[ -n "$HOME" ]] && { printf '%s' "$HOME"; return; }
+            printf '%s' "$tok"
+            return
+            ;;
+        '~/'*)
+            if [[ -n "$HOME" ]]; then
+                printf '%s' "$HOME/${tok#\~/}"
+            else
+                printf '%s' "$tok"
+            fi
+            return
+            ;;
+        '~'*)
+            local rest="${tok#\~}"
+            local user="${rest%%/*}"
+            local remainder=""
+            if [[ "$rest" == */* ]]; then
+                remainder="/${rest#*/}"
+            fi
+            if [[ -n "$user" ]]; then
+                local home=""
+                if command -v getent >/dev/null 2>&1; then
+                    home=$(getent passwd "$user" 2>/dev/null | cut -d: -f6)
+                elif command -v dscl >/dev/null 2>&1; then
+                    home=$(dscl . -read "/Users/$user" NFSHomeDirectory 2>/dev/null | awk '{print $2}')
+                fi
+                if [[ -n "$home" ]]; then
+                    printf '%s' "${home}${remainder}"
+                    return
+                fi
+            fi
+            # Unresolvable ~user (unknown user / no lookup tool available):
+            # leave untouched -- falls back to repo-relative resolution.
+            printf '%s' "$tok"
+            return
+            ;;
+        *)
+            printf '%s' "$tok"
+            return
+            ;;
+    esac
+}
+
 # Cheap pre-check keeps awk off the hot path for the ~99% of commands that have
 # no recursive/force rm at all.
 if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
@@ -2060,6 +2149,15 @@ if worktree_isolation_guard_enabled && \
     WRITE_TARGETS=$(extract_write_targets "$COMMAND_ASK_SCAN" "$CWD" | head -20)
     while IFS=$'\037' read -r _wcwd _wtarget; do
         [[ -z "$_wtarget" ]] && continue
+
+        # Shell-accurate tilde expansion (#4382): an unquoted/unescaped
+        # leading `~/` or `~user/` in the raw token is what the real shell
+        # would expand BEFORE cp/mv/tee/sed -i/redirection ever see it, so
+        # expand it here before the relative-path resolution below runs.
+        # Quoted ('~/x') / escaped (\~/x) tildes are left untouched (see
+        # expand_leading_tilde()'s doc comment) — no change to their
+        # existing repo-relative treatment.
+        _wtarget=$(expand_leading_tilde "$_wtarget")
 
         # Resolve to absolute; a relative target with no resolvable cwd is
         # ambiguous — skip it (allow on uncertainty, never deny on it).

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -2295,6 +2295,61 @@ assert_allow "write-confinement: CWD=linked worktree, write inside the worktree 
 assert_allow "write-confinement: CWD=linked worktree, write to /tmp allows (#4210)" \
     "echo x > /tmp/loom-test-$$-linked.sh" "$WT_LINKED_DIR"
 
+# -------------------------------------------------------------------------
+# Tilde expansion for write targets (#4382, same fix family as #4245/#4289's
+# quote-aware `>` scanning). Reported incident: `cp <built-binary>
+# ~/.local/bin/loom-daemon` from a main-checkout cwd was denied because the
+# raw `~/.local/bin/loom-daemon` token was resolved as REPO-relative -- the
+# real shell expands the leading `~` to $HOME first, landing the write far
+# outside the checkout entirely.
+#
+# HOME_FIXTURE_OUTSIDE is a throwaway dir with no relation to WT_REPO, used to
+# make the "expands outside the repo -> allow" cases deterministic regardless
+# of the operator's real $HOME.
+HOME_FIXTURE_OUTSIDE=$(mktemp -d)
+CURRENT_UNIX_USER=$(id -un 2>/dev/null || whoami)
+
+assert_allow_env "write-confinement (#4382): unquoted leading '~/' expands to \$HOME, landing outside the checkout allows" \
+    "HOME=$HOME_FIXTURE_OUTSIDE" \
+    "cp /tmp/a.sh ~/.local/bin/loom-daemon" "$WT_REPO"
+assert_allow_env "write-confinement (#4382): bare unquoted '~' (whole word) expands to \$HOME, outside the checkout allows" \
+    "HOME=$HOME_FIXTURE_OUTSIDE" \
+    "cp /tmp/a.sh ~" "$WT_REPO"
+assert_allow "write-confinement (#4382): unquoted '~user/' (current user) resolves via the passwd db, outside the checkout allows" \
+    "cp /tmp/a.sh ~${CURRENT_UNIX_USER}/.local/bin/loom-daemon" "$WT_REPO"
+
+# Expansion must not become a blanket allow -- if $HOME itself resolves inside
+# the main checkout, the expanded (now-absolute) target still denies exactly
+# like any other absolute main-checkout write. This also proves the guard
+# expands using its OWN process $HOME (set once, before the command is ever
+# parsed) rather than scanning the command text for a `HOME=...` token -- an
+# inline `HOME=<repo> cmd ~/x` game in the analyzed command string cannot
+# redefine what "$HOME" means to the guard, mirroring real bash: a same-line
+# `VAR=value command` prefix only changes the CHILD command's environment, it
+# never affects tilde expansion of that same command line (word expansion
+# runs against the invoking shell's own $HOME, not the prefix assignment).
+assert_deny_env "write-confinement (#4382): expanded '~/' landing INSIDE the main checkout still denies (no blanket ~ allow)" \
+    "HOME=$WT_REPO" \
+    "cp /tmp/a.sh ~/defaults/hooks/f.sh" "$WT_REPO"
+
+# Quoted / escaped tildes are NOT expanded by a real shell -- must keep the
+# existing literal repo-relative treatment (no regression).
+assert_deny "write-confinement (#4382): single-quoted leading tilde stays literal (shell never expands it), still denies" \
+    "cp /tmp/a.sh '~/defaults/hooks/f.sh'" "$WT_REPO"
+assert_deny "write-confinement (#4382): backslash-escaped leading tilde stays literal (shell never expands it), still denies" \
+    "cp /tmp/a.sh \~/defaults/hooks/f.sh" "$WT_REPO"
+
+# A tilde that is not the FIRST character of the token is not an expansion
+# position at all (e.g. `foo~/bar`) -- must stay untouched/literal.
+assert_deny "write-confinement (#4382): non-leading tilde ('backup~/f.sh') is not an expansion case, still resolves repo-relative" \
+    "cp /tmp/a.sh defaults/hooks/backup~/f.sh" "$WT_REPO"
+
+# An unresolvable ~user (no matching account) is left untouched rather than
+# guessed -- falls back to the existing (safe) repo-relative/deny treatment.
+assert_deny "write-confinement (#4382): unresolvable '~nonexistentuser/' falls back to literal repo-relative path, still denies" \
+    "cp /tmp/a.sh ~nonexistentloomuser999/defaults/hooks/f.sh" "$WT_REPO"
+
+rm -rf "$HOME_FIXTURE_OUTSIDE"
 rm -rf "$WT_REPO" "$WT_REPO_NOWT" "$WT_REPO_OFF" "$WT_REPO_LINKED"
 
 echo ""


### PR DESCRIPTION
## Summary

The #4178 Bash-write confinement guard (`guard-destructive-generic.sh`) resolves an unexpanded tilde path as repo-relative, producing a false-positive deny on writes that actually land far outside the repository.

Reported incident (#4382): `cp <built-binary> ~/.local/bin/loom-daemon` from a main-checkout cwd was denied as a "worktree-isolation bypass", even though the real destination (`$HOME/.local/bin/loom-daemon`) is nowhere near the checkout. `extract_write_targets()` is a whitespace/quote-aware tokenizer, not a shell evaluator, so it never performed the tilde expansion a real shell does before `cp`/`mv`/`tee`/`sed -i`/redirection ever see the argument.

## Fix

Adds `expand_leading_tilde()` in `defaults/hooks/guard-destructive-generic.sh` (same fix family as #4245/#4289's quote-aware `>` scanning), applied to each extracted write target immediately before the existing relative-path resolution step:

- An **unquoted, unescaped leading `~/`** (or bare `~`) expands to `$HOME`.
- **`~user/`** resolves via `getent` (Linux) / `dscl` (macOS), with the username passed as a plain CLI argument (never `eval`'d/interpolated), so a hostile username token can't inject a command. If the user can't be resolved, the token is left untouched (falls back to the existing repo-relative treatment -- fail-safe toward deny, never toward a new silent allow).
- **Quoted (`'~/x'`) and backslash-escaped (`\~/x`) tildes are left untouched.** `qsplit()` (the shared tokenizer, #3755) preserves quote/escape characters verbatim, so these never match the leading-tilde case and keep their current (correct) literal/repo-relative treatment -- no regression.
- A tilde that isn't the **first character** of the token (e.g. `foo~/bar`) is never touched either.
- The guard reads its **own process `$HOME`**, not the command text, so an inline `HOME=<repo> cmd ~/x` game in the analyzed command string cannot redefine expansion -- this mirrors real bash, where a same-line `VAR=value command` prefix only changes the *child* command's environment and never affects tilde expansion of that same command line.

`.loom/hooks/guard-destructive-generic.sh` (the installed copy) is synced byte-for-byte from `defaults/hooks/guard-destructive-generic.sh` (the source of truth), per this repo's install/sync convention.

## Testing

Added 8 regression tests to `tests/hooks/test-guard-destructive.sh` under a new "Tilde expansion for write targets (#4382)" section, covering both directions from the acceptance criteria:
- unquoted `~/...` and bare `~` expand and allow when they land outside the checkout
- `~user/...` (current user) resolves via the passwd db and allows
- expansion landing *inside* the checkout (`HOME=<repo>`) still denies -- proves this isn't a blanket `~` allow
- single-quoted and backslash-escaped leading tildes stay literal and still deny (regression)
- a non-leading tilde (`backup~/f.sh`) is not an expansion case and still denies
- an unresolvable `~nonexistentuser/` falls back to literal/deny

Full suite: `bash tests/hooks/test-guard-destructive.sh` -- **490/490 passing**.

`shellcheck --severity=warning` clean on the modified file (one SC2088 false-positive on the intentional literal `~`-prefixed case pattern is explicitly suppressed with a rationale comment).

Closes #4382

🤖 Generated with [Claude Code](https://claude.com/claude-code)