### PR TITLE
install: reword deleted loom-status/loom-clean references in info strings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ loom/
 ├── loom-daemon/            # Rust daemon (terminal management, orchestration)
 ├── loom-api/               # Rust shared types and protocol definitions
 ├── mcp-loom/               # Unified MCP server (TypeScript)
-├── loom-tools/             # Python tools (loom-status, loom-clean, loom-tokens, etc.)
+├── loom-tools/             # Python tools (loom-tokens, loom-claim, loom-checkpoint, etc.)
 ├── .loom/                  # Workspace config and agent roles
 ├── defaults/               # Default configuration templates
 ├── docs/                   # Documentation

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -118,7 +118,7 @@ loom/
 │       └── ...
 ├── loom-api/              # Shared Rust types and IPC protocol
 ├── mcp-loom/              # Unified MCP server (TypeScript/Node)
-├── loom-tools/            # Python tools (loom-status, loom-clean, loom-tokens, etc.)
+├── loom-tools/            # Python tools (loom-tokens, loom-claim, loom-checkpoint, etc.)
 ├── defaults/              # Default configuration templates installed into target repos
 ├── scripts/               # Installation, daemon, and maintenance scripts
 ├── .github/workflows/     # GitHub Actions CI

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -156,7 +156,7 @@ Usage:
 ./clean.sh --deep           # Include build artifacts
 ./clean.sh --dry-run        # Preview only
 ./clean.sh --safe --force   # Safe mode, non-interactive
-loom-clean                  # Direct invocation (requires loom-tools venv)
+loom-clean                  # Direct invocation (PATH shim to `loom-daemon clean`, no venv required)
 ```
 
 ### cleanup-branches.sh

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -1262,7 +1262,7 @@ fi
 echo ""
 
 # Set up Python tools (loom-tools package)
-# This creates a virtual environment in loom-tools/.venv and installs loom-status, loom-clean, etc.
+# This creates a virtual environment in loom-tools/.venv and installs loom-tokens, loom-claim, etc.
 info "Setting up Python tools..."
 if [[ -x "$LOOM_ROOT/scripts/install/setup-python-tools.sh" ]]; then
   if "$LOOM_ROOT/scripts/install/setup-python-tools.sh" --loom-root "$LOOM_ROOT"; then
@@ -1270,11 +1270,11 @@ if [[ -x "$LOOM_ROOT/scripts/install/setup-python-tools.sh" ]]; then
   else
     warning "Python tools setup failed (non-fatal for installation)"
     info "Run manually: $LOOM_ROOT/scripts/install/setup-python-tools.sh --loom-root $LOOM_ROOT"
-    info "Without Python tools, loom-status and some scripts will not work."
+    info "Without Python tools, loom-tokens and some scripts will not work."
   fi
 else
   warning "Python setup script not found"
-  info "Python tools (loom-status, loom-clean, etc.) may not be available."
+  info "Python tools (loom-tokens, loom-claim, etc.) may not be available."
 fi
 
 # Store Loom source repository path for wrapper scripts


### PR DESCRIPTION
## Summary
- `scripts/install-loom.sh` had 3 info/comment strings referencing the deleted Python console script `loom-status` (and `loom-clean`) — reworded to name surviving Python tools (`loom-tokens`, `loom-claim`).
- `CONTRIBUTING.md` and `docs/guides/development.md` had an identical project-tree comment listing `loom-status, loom-clean, loom-tokens` — reworded identically to reference only live console scripts.
- `scripts/README.md` claimed `loom-clean` "requires loom-tools venv" — this is no longer true since `loom-clean` is now a PATH shim to `loom-daemon clean` (native Rust, zero pip installs). Corrected the description.

No behavior changes — comment/info-string wording only.

## Verification
- `bash -n scripts/install-loom.sh` passes.
- `grep -nE "loom-status|loom-clean" scripts/install-loom.sh CONTRIBUTING.md docs/guides/development.md scripts/README.md` shows only the two intentional `scripts/README.md` references to the live `loom-clean` shim / `clean.sh` section header — no stale references to the deleted Python tools remain.
- Preserve-AC files (`.loom/bin/loom`, `defaults/.loom/bin/loom`, `defaults/scripts/cli/loom-help.sh`, `scripts/install/setup-python-tools.sh:116`, migration/history comments, `loom-tools/src/loom_tools/models/spawn_loop_state.py`) untouched.

Closes #4387