### PR TITLE
fix(scripts): replace dead Python fallback in clean/cleanup/recover-orphans wrappers with rebuild-instruction error

### DIFF
--- a/defaults/docs/troubleshooting.md
+++ b/defaults/docs/troubleshooting.md
@@ -66,6 +66,11 @@ loom-clean --deep --force  # Non-interactive deep clean
 loom-clean --deep --dry-run  # Preview deep clean
 ```
 
+`loom-clean` is a thin shim for `loom-daemon clean` and needs a `loom-daemon`
+binary built at or after commit `dba33666` (PR #4301) — see [fail on a stale
+binary](#loom-clean--loom-cleanup--loom-recover-orphans-fail-on-a-stale-binary-4384)
+if it errors out instead of running.
+
 **What loom-clean does**:
 - Removes worktrees for closed GitHub issues (prompts per worktree in interactive mode)
 - Deletes local feature branches for closed issues
@@ -112,6 +117,53 @@ git worktree remove .loom/worktrees/issue-42 --force
 # Prune orphaned worktrees
 git worktree prune
 ```
+
+### `loom-clean` / `loom-cleanup` / `loom-recover-orphans` fail on a stale binary (#4384)
+
+**Symptom**: one of the three commands below fails outright instead of doing
+anything — either with a `No module named loom_tools.clean` traceback (an
+old pip-installed console script), or with an explicit `ERROR clean.sh: … does
+not support the 'clean' subcommand (stale build)` from the wrapper.
+
+**Root cause**: all three are now thin front-ends for native `loom-daemon`
+subcommands (#4272 / PR #4301, commit `dba33666`):
+
+| Command / wrapper | Native subcommand |
+|---|---|
+| `loom-clean`, `./.loom/scripts/clean.sh` | `loom-daemon clean` |
+| `./.loom/scripts/cleanup.sh` | `loom-daemon cleanup logs` |
+| `loom-recover-orphans`, `./.loom/scripts/recover-orphaned-shepherds.sh` | `loom-daemon recover-orphans` |
+
+The same commit deleted the Python implementations (`loom_tools/clean.py`,
+`cleanup.py`, `orphan_recovery.py`) and their console-script entry points, so
+**there is no fallback**: a `loom-daemon` binary built before `dba33666` leaves
+no working path at all. The wrappers capability-probe the binary and now fail
+loudly with the remedy rather than degrading into a traceback.
+
+**Check whether your binary is the problem**:
+
+```bash
+loom-daemon --version          # note the commit
+loom-daemon clean --help       # "error: unrecognized subcommand 'clean'" => stale
+```
+
+**Remedy — rebuild or update `loom-daemon`, then retry**:
+
+```bash
+cargo build --release -p loom-daemon        # source checkout
+./.loom/scripts/cli/loom-daemon-update.sh   # installed host (self-update)
+```
+
+Use `loom-daemon clean --force` / `loom-daemon recover-orphans --recover`
+directly in the meantime — the native subcommands take the same flags.
+
+**If a stale pip-era shim is shadowing the current one**: the installer writes
+`loom-clean` / `loom-recover-orphans` shims next to the provisioned
+`loom-daemon` (usually `~/.local/bin`). A pre-#4301 pip/homebrew install can
+leave `from loom_tools.clean import main` shims earlier on `PATH` that will
+never work again. Confirm with `command -v loom-clean` and remove them (e.g.
+`pip uninstall loom-tools`, or delete the stale shim) so the daemon-backed one
+resolves.
 
 ### Corrupted local git identity (`...github.comecho`, "cannot overwrite multiple values") (#4369)
 
@@ -284,6 +336,11 @@ loom-recover-orphans --recover
 # JSON output for automation
 loom-recover-orphans --json
 ```
+
+`loom-recover-orphans` is a thin shim for `loom-daemon recover-orphans` — if it
+fails with `No module named loom_tools.orphan_recovery` or a "stale build"
+error, see [`loom-clean` / `loom-cleanup` / `loom-recover-orphans` fail on a
+stale binary](#loom-clean--loom-cleanup--loom-recover-orphans-fail-on-a-stale-binary-4384).
 
 **What it does**:
 - Finds issues with `loom:building` label that have been stuck

--- a/defaults/scripts/clean.sh
+++ b/defaults/scripts/clean.sh
@@ -3,10 +3,13 @@
 #
 # Delegates to the native `loom-daemon clean` subcommand (issue #4272, epic
 # #4081 Phase 3 family 2 — a byte-compatible Rust port of the historical
-# Python `loom-clean` CLI). Falls back to the `run_loom_tool` Python fallback
-# chain (source PYTHONPATH -> venv console script -> installed console
-# script) when the resolved daemon binary predates the `clean` subcommand (a
-# host mid-roll), following the `probe-tokens.sh` precedent from Phase 2.
+# Python `loom-clean` CLI). A capability probe still detects a daemon binary
+# that predates the `clean` subcommand (a host mid-roll), but there is NO
+# fallback to fall back to: PR #4301 (commit dba33666) deleted
+# `loom_tools/clean.py` and its `loom-clean` console-script entry in the very
+# same commit that added the probe, so the old `run_loom_tool` branch could
+# only ever produce `No module named loom_tools.clean`. A stale binary now
+# fails loudly with a rebuild remedy instead (#4384).
 #
 # Usage:
 #   clean.sh             # Interactive cleanup
@@ -33,10 +36,19 @@ if [[ -n "$DAEMON_BIN" ]] && "$DAEMON_BIN" clean --help >/dev/null 2>&1; then
     exec "$DAEMON_BIN" clean "$@"
 fi
 
+# No usable path remains. Fail loudly and actionably rather than degrading
+# into a `No module named loom_tools.clean` traceback (#4384).
 if [[ -n "$DAEMON_BIN" ]]; then
-    echo "WARNING clean.sh: $DAEMON_BIN does not support 'clean' (stale build); falling back to loom-clean" >&2
+    DAEMON_VERSION="$("$DAEMON_BIN" --version 2>/dev/null || true)"
+    echo "ERROR clean.sh: $DAEMON_BIN does not support the 'clean' subcommand (stale build)." >&2
+    echo "  Reported version: ${DAEMON_VERSION:-unknown}" >&2
+else
+    echo "ERROR clean.sh: no loom-daemon binary could be resolved." >&2
+    echo "  Searched: \$LOOM_DAEMON_BIN, PATH, then $REPO_ROOT/{loom-daemon/,}target/{release,debug}/loom-daemon" >&2
 fi
-
-# Source shared loom-tools helper (Python fallback chain).
-source "$SCRIPT_DIR/lib/loom-tools.sh"
-run_loom_tool "clean" "clean" "$@"
+echo "  'loom-daemon clean' requires a binary built at or after commit dba33666 (PR #4301)." >&2
+echo "  There is no Python fallback — loom_tools/clean.py was deleted in that same commit." >&2
+echo "  Remedy: rebuild or update loom-daemon, then retry:" >&2
+echo "    cargo build --release -p loom-daemon        # source checkout" >&2
+echo "    ./.loom/scripts/cli/loom-daemon-update.sh   # installed host (self-update)" >&2
+exit 1

--- a/defaults/scripts/cleanup.sh
+++ b/defaults/scripts/cleanup.sh
@@ -3,10 +3,13 @@
 #
 # Delegates to the native `loom-daemon cleanup logs` subcommand (issue
 # #4272, epic #4081 Phase 3 family 2 — a byte-compatible Rust port of the
-# historical Python `loom-cleanup` CLI). Falls back to the `run_loom_tool`
-# Python fallback chain when the resolved daemon binary predates the
-# `cleanup` subcommand (a host mid-roll), following the `probe-tokens.sh`
-# precedent from Phase 2.
+# historical Python `loom-cleanup` CLI). A capability probe still detects a
+# daemon binary that predates the `cleanup` subcommand (a host mid-roll), but
+# there is NO fallback to fall back to: PR #4301 (commit dba33666) deleted
+# `loom_tools/cleanup.py` and its `loom-cleanup` console-script entry in the
+# very same commit that added the probe, so the old `run_loom_tool` branch
+# could only ever produce `No module named loom_tools.cleanup`. A stale binary
+# now fails loudly with a rebuild remedy instead (#4384).
 #
 # History: this script was previously named daemon-cleanup.sh and dispatched
 # event-driven cleanup for the Loom daemon (shepherd-complete, daemon-startup,
@@ -35,10 +38,19 @@ if [[ -n "$DAEMON_BIN" ]] && "$DAEMON_BIN" cleanup logs --help >/dev/null 2>&1; 
     exec "$DAEMON_BIN" cleanup "$@"
 fi
 
+# No usable path remains. Fail loudly and actionably rather than degrading
+# into a `No module named loom_tools.cleanup` traceback (#4384).
 if [[ -n "$DAEMON_BIN" ]]; then
-    echo "WARNING cleanup.sh: $DAEMON_BIN does not support 'cleanup logs' (stale build); falling back to loom-cleanup" >&2
+    DAEMON_VERSION="$("$DAEMON_BIN" --version 2>/dev/null || true)"
+    echo "ERROR cleanup.sh: $DAEMON_BIN does not support the 'cleanup logs' subcommand (stale build)." >&2
+    echo "  Reported version: ${DAEMON_VERSION:-unknown}" >&2
+else
+    echo "ERROR cleanup.sh: no loom-daemon binary could be resolved." >&2
+    echo "  Searched: \$LOOM_DAEMON_BIN, PATH, then $REPO_ROOT/{loom-daemon/,}target/{release,debug}/loom-daemon" >&2
 fi
-
-# Source shared loom-tools helper (Python fallback chain).
-source "$SCRIPT_DIR/lib/loom-tools.sh"
-run_loom_tool "cleanup" "cleanup" "$@"
+echo "  'loom-daemon cleanup' requires a binary built at or after commit dba33666 (PR #4301)." >&2
+echo "  There is no Python fallback — loom_tools/cleanup.py was deleted in that same commit." >&2
+echo "  Remedy: rebuild or update loom-daemon, then retry:" >&2
+echo "    cargo build --release -p loom-daemon        # source checkout" >&2
+echo "    ./.loom/scripts/cli/loom-daemon-update.sh   # installed host (self-update)" >&2
+exit 1

--- a/defaults/scripts/recover-orphaned-shepherds.sh
+++ b/defaults/scripts/recover-orphaned-shepherds.sh
@@ -3,10 +3,14 @@
 #
 # Delegates to the native `loom-daemon recover-orphans` subcommand (issue
 # #4272, epic #4081 Phase 3 family 2 — a byte-compatible Rust port of the
-# historical Python `loom-recover-orphans` CLI). Falls back to the
-# `run_loom_tool` Python fallback chain when the resolved daemon binary
-# predates the `recover-orphans` subcommand (a host mid-roll), following the
-# `probe-tokens.sh` precedent from Phase 2.
+# historical Python `loom-recover-orphans` CLI). A capability probe still
+# detects a daemon binary that predates the `recover-orphans` subcommand (a
+# host mid-roll), but there is NO fallback to fall back to: PR #4301 (commit
+# dba33666) deleted `loom_tools/orphan_recovery.py` and its
+# `loom-recover-orphans` console-script entry in the very same commit that
+# added the probe, so the old `run_loom_tool` branch could only ever produce
+# `No module named loom_tools.orphan_recovery`. A stale binary now fails
+# loudly with a rebuild remedy instead (#4384).
 #
 # The script name is preserved for back-compat with operator muscle memory
 # and any CLAUDE.md / docs that link to it.
@@ -32,10 +36,19 @@ if [[ -n "$DAEMON_BIN" ]] && "$DAEMON_BIN" recover-orphans --help >/dev/null 2>&
     exec "$DAEMON_BIN" recover-orphans "$@"
 fi
 
+# No usable path remains. Fail loudly and actionably rather than degrading
+# into a `No module named loom_tools.orphan_recovery` traceback (#4384).
 if [[ -n "$DAEMON_BIN" ]]; then
-    echo "WARNING recover-orphaned-shepherds.sh: $DAEMON_BIN does not support 'recover-orphans' (stale build); falling back to loom-recover-orphans" >&2
+    DAEMON_VERSION="$("$DAEMON_BIN" --version 2>/dev/null || true)"
+    echo "ERROR recover-orphaned-shepherds.sh: $DAEMON_BIN does not support the 'recover-orphans' subcommand (stale build)." >&2
+    echo "  Reported version: ${DAEMON_VERSION:-unknown}" >&2
+else
+    echo "ERROR recover-orphaned-shepherds.sh: no loom-daemon binary could be resolved." >&2
+    echo "  Searched: \$LOOM_DAEMON_BIN, PATH, then $REPO_ROOT/{loom-daemon/,}target/{release,debug}/loom-daemon" >&2
 fi
-
-# Source shared loom-tools helper (Python fallback chain).
-source "$SCRIPT_DIR/lib/loom-tools.sh"
-run_loom_tool "recover-orphans" "orphan_recovery" "$@"
+echo "  'loom-daemon recover-orphans' requires a binary built at or after commit dba33666 (PR #4301)." >&2
+echo "  There is no Python fallback — loom_tools/orphan_recovery.py was deleted in that same commit." >&2
+echo "  Remedy: rebuild or update loom-daemon, then retry:" >&2
+echo "    cargo build --release -p loom-daemon        # source checkout" >&2
+echo "    ./.loom/scripts/cli/loom-daemon-update.sh   # installed host (self-update)" >&2
+exit 1

--- a/defaults/scripts/tests/test-clean-stale-binary.sh
+++ b/defaults/scripts/tests/test-clean-stale-binary.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# test-clean-stale-binary.sh - Regression guard for #4384.
+#
+# clean.sh / cleanup.sh / recover-orphaned-shepherds.sh delegate to the native
+# `loom-daemon clean` / `cleanup logs` / `recover-orphans` subcommands (#4272,
+# PR #4301). Each capability-probes the resolved binary first, because a host
+# mid-roll can carry a `loom-daemon` predating those subcommands.
+#
+# The original probe fell back to the `run_loom_tool` Python chain — but PR
+# #4301 (commit dba33666) deleted `loom_tools/clean.py`, `cleanup.py`, and
+# `orphan_recovery.py` (plus their console-script entries) in the very same
+# commit, so the fallback was dead on arrival and produced a raw
+# `No module named loom_tools.clean` traceback on every stale-binary host.
+#
+# This test asserts (modelled on test-probe-tokens-fallback.sh, the Phase 2
+# precedent the wrappers already cite):
+#   1. All three wrappers exist and are executable.
+#   2. None of them references `run_loom_tool` / `lib/loom-tools.sh` / `python3`
+#      in executable code — the dead fallback tier is gone, not just fixed.
+#   3. With a `loom-daemon` that rejects the subcommand, each wrapper exits
+#      non-zero, names the resolved binary path AND its reported version, names
+#      the rebuild remedy, emits no `No module named` traceback, and never
+#      invokes `python3`.
+#   4. With a capable `loom-daemon`, each wrapper delegates unchanged and passes
+#      its arguments through verbatim (`--dry-run`, `--force`, `logs`, …).
+#   5. With no resolvable `loom-daemon` at all, each wrapper still fails with a
+#      coherent, actionable message (no unbound-variable / traceback noise).
+#
+# Usage:
+#   ./.loom/scripts/tests/test-clean-stale-binary.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+CLEAN_SCRIPT="$SCRIPTS_DIR/clean.sh"
+CLEANUP_SCRIPT="$SCRIPTS_DIR/cleanup.sh"
+RECOVER_SCRIPT="$SCRIPTS_DIR/recover-orphaned-shepherds.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: $1"
+}
+
+fail() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: $1"
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+STRIPPED_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+
+# ---------- stubs ----------
+STUB_DIR="$WORK/stubs"
+mkdir -p "$STUB_DIR"
+
+# A `python3` that must never run. If any wrapper still reaches for the Python
+# fallback chain, this drops a marker file we can detect.
+PY_MARKER="$WORK/python3-was-invoked"
+cat > "$STUB_DIR/python3" <<EOF
+#!/usr/bin/env bash
+echo "python3 stub invoked with: \$*" >> "$PY_MARKER"
+exit 1
+EOF
+chmod +x "$STUB_DIR/python3"
+
+# A stale loom-daemon: knows --version, rejects every subcommand (mirrors the
+# real "error: unrecognized subcommand" clap failure).
+STALE_BIN="$WORK/stale/loom-daemon"
+mkdir -p "$(dirname "$STALE_BIN")"
+cat > "$STALE_BIN" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+    echo "loom-daemon 0.15.0 (commit 615545ba, built 2026-07-29T15:23:18Z)"
+    exit 0
+fi
+echo "error: unrecognized subcommand '${1:-}'" >&2
+exit 2
+EOF
+chmod +x "$STALE_BIN"
+
+# A current loom-daemon: answers the `--help` capability probe silently and
+# records the real delegated invocation for arg-passthrough assertions.
+CURRENT_BIN="$WORK/current/loom-daemon"
+ARGS_FILE="$WORK/delegated-args"
+mkdir -p "$(dirname "$CURRENT_BIN")"
+cat > "$CURRENT_BIN" <<EOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "--version" ]]; then
+    echo "loom-daemon 0.16.0 (commit deadbeef, built 2026-07-29T00:00:00Z)"
+    exit 0
+fi
+# The capability probe is "<subcommand> [sub] --help" — answer it, don't record.
+for arg in "\$@"; do
+    if [[ "\$arg" == "--help" ]]; then exit 0; fi
+done
+echo "\$*" >> "$ARGS_FILE"
+exit 0
+EOF
+chmod +x "$CURRENT_BIN"
+
+# ---------- Test 1: all three wrappers exist and are executable ----------
+echo "Test 1: wrappers exist and are executable"
+missing=0
+for s in "$CLEAN_SCRIPT" "$CLEANUP_SCRIPT" "$RECOVER_SCRIPT"; do
+    if [[ -x "$s" ]]; then
+        pass "$(basename "$s") is executable"
+    else
+        fail "$(basename "$s") is missing or not executable: $s"
+        missing=1
+    fi
+done
+if [[ "$missing" -eq 1 ]]; then
+    echo "FAILED: $TESTS_FAILED/$TESTS_RUN"
+    exit 1
+fi
+
+# ---------- Test 2: dead Python fallback tier is gone from executable code ----
+# Comments explaining the history (why there is no fallback) are allowed —
+# only non-comment lines count.
+echo "Test 2: no run_loom_tool / loom-tools.sh / python3 in executable code"
+for s in "$CLEAN_SCRIPT" "$CLEANUP_SCRIPT" "$RECOVER_SCRIPT"; do
+    code_hits="$(grep -vE '^[[:space:]]*#' "$s" | grep -nE 'run_loom_tool|lib/loom-tools\.sh|python3' || true)"
+    if [[ -n "$code_hits" ]]; then
+        fail "$(basename "$s") executable code still reaches for the Python fallback: $code_hits"
+    else
+        pass "$(basename "$s") executable code has no Python fallback tier"
+    fi
+done
+
+# ---------- Test 3: stale binary -> loud, actionable failure ----------
+echo "Test 3: stale loom-daemon -> non-zero exit with rebuild remedy, no python3"
+run_stale() {
+    # $1 = script, rest = args
+    local script="$1"; shift
+    LOOM_DAEMON_BIN="$STALE_BIN" PATH="$STUB_DIR:$STRIPPED_PATH" \
+        "$script" "$@" 2>&1
+}
+
+check_stale() {
+    local script="$1"; shift
+    local name; name="$(basename "$script")"
+    local out rc
+    out="$(run_stale "$script" "$@")"
+    rc=$?
+
+    if [[ "$rc" -ne 0 ]]; then
+        pass "$name exits non-zero on a stale binary (rc=$rc)"
+    else
+        fail "$name exited 0 on a stale binary (expected non-zero). Output: $out"
+    fi
+    if [[ "$out" == *"$STALE_BIN"* ]]; then
+        pass "$name names the resolved (stale) binary path"
+    else
+        fail "$name did not name the stale binary path. Got: $out"
+    fi
+    if [[ "$out" == *"615545ba"* ]]; then
+        pass "$name reports the stale binary's version"
+    else
+        fail "$name did not report the stale binary's version. Got: $out"
+    fi
+    if [[ "$out" == *"cargo build --release -p loom-daemon"* ]]; then
+        pass "$name names the rebuild remedy"
+    else
+        fail "$name did not name the rebuild remedy. Got: $out"
+    fi
+    if [[ "$out" == *"loom-daemon-update.sh"* ]]; then
+        pass "$name names the installed-host update remedy"
+    else
+        fail "$name did not name the update remedy. Got: $out"
+    fi
+    if [[ "$out" == *"No module named"* ]]; then
+        fail "$name still produced a 'No module named' traceback. Got: $out"
+    else
+        pass "$name produced no 'No module named' traceback"
+    fi
+}
+
+check_stale "$CLEAN_SCRIPT" --dry-run
+check_stale "$CLEANUP_SCRIPT" logs --dry-run
+check_stale "$RECOVER_SCRIPT" --recover
+
+if [[ -f "$PY_MARKER" ]]; then
+    fail "python3 was invoked by a wrapper: $(cat "$PY_MARKER")"
+else
+    pass "python3 was never invoked by any wrapper"
+fi
+
+# ---------- Test 4: capable binary -> unchanged delegation, args passed through
+echo "Test 4: capable loom-daemon -> delegation with verbatim arg passthrough"
+run_current() {
+    local script="$1"; shift
+    LOOM_DAEMON_BIN="$CURRENT_BIN" PATH="$STUB_DIR:$STRIPPED_PATH" \
+        "$script" "$@" >/dev/null 2>&1
+}
+
+check_current() {
+    local script="$1"; local expected="$2"; shift 2
+    local name; name="$(basename "$script")"
+    : > "$ARGS_FILE"
+    run_current "$script" "$@"
+    local rc=$?
+    if [[ "$rc" -eq 0 ]]; then
+        pass "$name exits 0 on a capable binary"
+    else
+        fail "$name expected exit 0 on a capable binary, got $rc"
+    fi
+    local recorded; recorded="$(cat "$ARGS_FILE" 2>/dev/null)"
+    if [[ "$recorded" == "$expected" ]]; then
+        pass "$name delegated as 'loom-daemon $expected'"
+    else
+        fail "$name delegated as 'loom-daemon $recorded' (expected '$expected')"
+    fi
+}
+
+check_current "$CLEAN_SCRIPT"   "clean --dry-run --force"          --dry-run --force
+check_current "$CLEANUP_SCRIPT" "cleanup logs --dry-run"           logs --dry-run
+check_current "$RECOVER_SCRIPT" "recover-orphans --recover --json" --recover --json
+
+if [[ -f "$PY_MARKER" ]]; then
+    fail "python3 was invoked on the happy path: $(cat "$PY_MARKER")"
+else
+    pass "python3 was never invoked on the happy path"
+fi
+
+# ---------- Test 5: no resolvable binary at all -> coherent failure ----------
+# Stage hermetic copies of the wrappers so REPO_ROOT (SCRIPT_DIR/../..) has no
+# target/{release,debug}/loom-daemon build-output candidate underneath it —
+# otherwise this checkout's own freshly-built binary would be resolved.
+echo "Test 5: no resolvable loom-daemon -> coherent, actionable failure"
+STAGE="$WORK/stage/defaults/scripts"
+mkdir -p "$STAGE/lib"
+cp "$CLEAN_SCRIPT" "$CLEANUP_SCRIPT" "$RECOVER_SCRIPT" "$STAGE/"
+cp "$SCRIPTS_DIR/lib/locate-daemon-bin.sh" "$STAGE/lib/"
+
+for s in clean.sh cleanup.sh recover-orphaned-shepherds.sh; do
+    out="$(LOOM_DAEMON_BIN="/nonexistent/loom-daemon" PATH="$STUB_DIR:$STRIPPED_PATH" \
+        "$STAGE/$s" 2>&1)"
+    rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        pass "$s exits non-zero with no resolvable binary (rc=$rc)"
+    else
+        fail "$s exited 0 with no resolvable binary. Output: $out"
+    fi
+    if [[ "$out" == *"no loom-daemon binary could be resolved"* ]]; then
+        pass "$s reports that no daemon binary could be resolved"
+    else
+        fail "$s message was not coherent for the missing-binary case. Got: $out"
+    fi
+    if [[ "$out" == *"cargo build --release -p loom-daemon"* ]]; then
+        pass "$s names the rebuild remedy with no resolvable binary"
+    else
+        fail "$s did not name the rebuild remedy. Got: $out"
+    fi
+done
+
+if [[ -f "$PY_MARKER" ]]; then
+    fail "python3 was invoked in the missing-binary case: $(cat "$PY_MARKER")"
+else
+    pass "python3 was never invoked in the missing-binary case"
+fi
+
+# ---------- Summary ----------
+echo ""
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo -e "${RED}FAILED${NC}: $TESTS_FAILED test(s) failed"
+    exit 1
+fi
+echo -e "${GREEN}OK${NC}: all tests passed"
+exit 0


### PR DESCRIPTION
Closes #4384

## Problem

PR #4301 (commit `dba33666`) added the `loom-daemon clean` / `cleanup logs` / `recover-orphans` subcommands **and**, in the very same commit, deleted `loom_tools/clean.py`, `cleanup.py`, `orphan_recovery.py` plus their console-script entries. The capability probe it added to the three wrappers fell back to the `run_loom_tool` Python chain on a stale binary — a chain that no longer had anything to run. The fallback was dead on arrival: a stale-binary host got

```
WARNING clean.sh: /Users/…/loom-daemon does not support 'clean' (stale build); falling back to loom-clean
python3.14: No module named loom_tools.clean
```

instead of an actionable error. This broke `loom-clean --force`, the CLAUDE.md-documented troubleshooting quick fix, on any host mid-roll.

## Fix (curated option b — remove the dead fallback, keep the probe)

- **Keep the capability probe** in all three wrappers; it correctly detects a stale binary.
- **Replace the Python-fallback branch** with a hard, non-zero failure naming the resolved binary path, its reported `--version`, the required commit (`dba33666`), and the exact remedy (`cargo build --release -p loom-daemon` on a source checkout, or `./.loom/scripts/cli/loom-daemon-update.sh` on an installed host).
- The **binary-entirely-absent** case gets its own coherent message naming the search path (`$LOOM_DAEMON_BIN`, PATH, then the repo-root build-output candidates).
- **Happy path unchanged**: with a capable binary each wrapper still `exec`s `loom-daemon clean` / `cleanup logs` / `recover-orphans` with args passed through verbatim.

`defaults/scripts/lib/loom-tools.sh` and the seven surviving `run_loom_tool` callers (agent-spawn, agent-wait, checkpoint, resolve-model, resolve-tier-model, sweep-experiment, validate-phase, agent-metrics) are untouched — their modules still exist on `main`.

## Docs

`defaults/docs/troubleshooting.md` gains a dedicated section (linked from both the `loom-clean` and `loom-recover-orphans` quick-fix blocks) covering the symptom, the wrapper → native-subcommand mapping, the `≥ dba33666` requirement, the rebuild/update remedy, the "use `loom-daemon clean --force` directly in the meantime" workaround, and the stale pip-era `PATH` shim case.

## Testing

New `defaults/scripts/tests/test-clean-stale-binary.sh` (executable, modelled on `test-probe-tokens-fallback.sh`), 42 assertions:

1. All three wrappers exist and are executable.
2. No `run_loom_tool` / `lib/loom-tools.sh` / `python3` in **executable** code (history comments allowed).
3. Stubbed stale `loom-daemon` (rejects every subcommand, answers `--version`) → each wrapper exits non-zero, names the stale path + version + both remedies, emits no `No module named` traceback.
4. Stubbed capable `loom-daemon` → each wrapper exits 0 and delegates verbatim (`clean --dry-run --force`, `cleanup logs --dry-run`, `recover-orphans --recover --json`).
5. No resolvable binary at all (hermetically staged copies so this checkout's own build output isn't picked up) → coherent failure with the remedy.
6. A `python3` stub on PATH drops a marker file — asserted never created, in all three scenarios.

```
$ ./defaults/scripts/tests/test-clean-stale-binary.sh
Results: 42/42 passed
OK: all tests passed
```

Also green: `test-probe-tokens-fallback.sh` (7/7), `test-verify-install-scope.sh` (16/16), `test-resync-installed.sh` (57/57), `test-install-reinstall-safety.sh` (15/15, the CI-run one); `shellcheck -S warning` clean on all four changed/added scripts. Manually verified the happy path on this host (`clean.sh --dry-run` delegates and runs normally now that the binary is current).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
