### PR TITLE
feat(install): add binary-format sanity gate to provision_machine_daemon

### DIFF
--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -465,6 +465,18 @@ export LOOM_WATCHDOG_LABEL="${LOOM_LAUNCHD_LABEL}-watchdog"
 # file, which would otherwise be the only thing catching a regression.
 export LOOM_DAEMON_BIN_DIR="$BASE_WORKDIR/machine-level-bin-sandbox"
 
+# Binary-format sanity gate bypass (#4397, deferred from #4381's incident
+# review): provision_machine_daemon now refuses to install anything that
+# isn't a real compiled binary (Mach-O/ELF — see _pmd_is_real_binary in
+# scripts/install/provision-daemon.sh). EVERY fake daemon binary this suite
+# writes (write_fake_daemon et al.) is a bash script standing in for the real
+# compiled binary, so THIS SUITE — and only this suite — sets the explicit,
+# auditable bypass suite-wide. Production callers (scripts/install-loom.sh,
+# defaults/scripts/cli/loom-daemon-update.sh) never set it; the gate itself is
+# exercised directly (both the reject-a-script and accept-a-real-binary
+# cases) by tests/install/test-provision-daemon.sh.
+export LOOM_PROVISION_ALLOW_SCRIPT=1
+
 # Suite-level decoy (#4078): a process whose argv ends in `/loom-daemon`, which
 # the stop script's label-blind `pgrep -f '(^|/)loom-daemon$'` fallback would
 # match. The whole update suite runs under a scratch LOOM_LAUNCHD_LABEL and

--- a/scripts/install/provision-daemon.sh
+++ b/scripts/install/provision-daemon.sh
@@ -182,6 +182,32 @@ SHIM_EOF
   fi
 }
 
+# _pmd_is_real_binary <path>
+#
+# Issue #4397 (deferred from #4381's incident review, PR #4396): a `file(1)`-based
+# sanity check that <path> is an actual compiled executable (Mach-O on Darwin,
+# ELF on Linux) rather than a shell script, text file, or other non-binary
+# masquerading as the daemon. Matches on the `Mach-O` / `ELF` substrings that
+# `file -b` emits for every architecture/variant this repo ships for (universal
+# binaries, PIE executables, shared objects, etc. all still contain one of
+# those two tokens); a shell script instead reports "... script text
+# executable" and a plain text file reports "ASCII text" — neither matches.
+#
+# Soft-passes (returns 0) when `file` itself is unavailable, rather than
+# blocking an install on a missing diagnostic tool that has nothing to do with
+# the binary's actual validity — the pre-existing `-x` executable-bit check in
+# the caller is still enforced regardless.
+_pmd_is_real_binary() {
+  local path="$1"
+  command -v file >/dev/null 2>&1 || return 0
+  local desc
+  desc="$(file -b "$path" 2>/dev/null)"
+  case "$desc" in
+    *Mach-O*|*ELF*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # provision_machine_daemon <src_bin> [dest_dir]
 #
 # Installs <src_bin> to <dest_dir>/loom-daemon (default: LOOM_DAEMON_BIN_DIR,
@@ -206,6 +232,26 @@ provision_machine_daemon() {
 
   if [[ -z "$src_bin" || ! -x "$src_bin" ]]; then
     _pmd_warn "built binary not found at '${src_bin:-<unset>}'; skipping machine-level install"
+    return 1
+  fi
+
+  # Binary-format sanity gate (#4397, deferred from #4381's incident review):
+  # refuse to install anything that isn't a real compiled binary to the
+  # machine-level daemon path. #4396 sandboxed + checksum-guarded the TEST
+  # SUITE's own fixtures from ever touching the real destination; this gate
+  # protects every CALLER of this function (the installer, self-update, any
+  # future script) so a shell script, text file, or other non-binary can never
+  # be installed as `loom-daemon`, regardless of caller. LOOM_PROVISION_ALLOW_SCRIPT=1
+  # is an explicit, auditable test-only bypass — set suite-wide by
+  # tests/install/test-provision-daemon.sh and
+  # defaults/scripts/tests/test-loom-daemon-update.sh (whose fixture "daemon"
+  # stand-ins are bash scripts standing in for the real compiled binary);
+  # production callers (scripts/install-loom.sh,
+  # defaults/scripts/cli/loom-daemon-update.sh) never set it.
+  if [[ -z "${LOOM_PROVISION_ALLOW_SCRIPT:-}" ]] && ! _pmd_is_real_binary "$src_bin"; then
+    _pmd_warn "refusing to install '$src_bin': not a compiled binary (Mach-O/ELF executable expected)"
+    _pmd_warn "  file(1) reports: $(file -b "$src_bin" 2>/dev/null || echo '<file unavailable>')"
+    _pmd_warn "  if this is a deliberate test fixture standing in for the real daemon binary, set LOOM_PROVISION_ALLOW_SCRIPT=1"
     return 1
   fi
 

--- a/tests/install/test-provision-daemon.sh
+++ b/tests/install/test-provision-daemon.sh
@@ -58,6 +58,17 @@ assert_contains() {
 WORKDIR="$(mktemp -d)"
 trap 'rm -rf "$WORKDIR"' EXIT
 
+# Binary-format sanity gate bypass (#4397, deferred from #4381's incident
+# review): provision_machine_daemon now refuses to install anything that
+# isn't a real compiled binary (Mach-O/ELF — see _pmd_is_real_binary in
+# scripts/install/provision-daemon.sh). Every fake "daemon" binary this suite
+# writes (make_fake_bin below) is a bash script standing in for the real
+# compiled binary, so THIS SUITE — and only this suite — sets the explicit,
+# auditable bypass suite-wide. Production callers (scripts/install-loom.sh,
+# defaults/scripts/cli/loom-daemon-update.sh) never set it. Tests 14/15 below
+# exercise the gate itself with the bypass explicitly unset.
+export LOOM_PROVISION_ALLOW_SCRIPT=1
+
 # Build a fake loom-daemon binary that prints $1 as its --version.
 make_fake_bin() {
   local path="$1" ver="$2"
@@ -378,6 +389,35 @@ assert_eq "LOOM_CODESIGN_IDENTITY unset: provision returns 0" "0" "$rc13"
 codesign_args_unset="$(cat "$CODESIGN_ARGS_UNSET_FILE" 2>/dev/null || echo "<missing>")"
 assert_contains "LOOM_CODESIGN_IDENTITY unset: ad-hoc path is unchanged (-s -)" \
   "$codesign_args_unset" "-s -"
+
+# ---------- test 14: binary-format gate (#4397) — refuses a script-based
+# "binary" when LOOM_PROVISION_ALLOW_SCRIPT is unset (production behavior).
+# ---------------------------------------------------------------------------
+SRC14="$WORKDIR/src14/loom-daemon"
+mkdir -p "$WORKDIR/src14"
+make_fake_bin "$SRC14" "0.16.0"   # a bash script, standing in for the real binary
+DEST14="$WORKDIR/dest14"
+out14=$( ( unset LOOM_PROVISION_ALLOW_SCRIPT
+  LOOM_DAEMON_BIN_DIR="$DEST14" provision_machine_daemon "$SRC14" ) 2>&1 )
+rc14=$?
+assert_eq "gate rejects a script-based fake binary without the bypass" "1" "$rc14"
+assert_contains "gate rejection names the reason" "$out14" "not a compiled binary"
+assert_eq "gate rejection installs nothing" "0" "$( [[ -e "$DEST14/loom-daemon" ]] && echo 1 || echo 0 )"
+
+# ---------- test 15: binary-format gate (#4397) — accepts a REAL compiled
+# executable (a copy of /bin/cat, standing in for a real Mach-O/ELF daemon
+# binary) even without the bypass.
+# ---------------------------------------------------------------------------
+SRC15="$WORKDIR/src15/loom-daemon"
+mkdir -p "$WORKDIR/src15"
+cp "$(command -v cat)" "$SRC15"
+chmod +x "$SRC15"
+DEST15="$WORKDIR/dest15"
+out15=$( ( unset LOOM_PROVISION_ALLOW_SCRIPT
+  LOOM_DAEMON_BIN_DIR="$DEST15" provision_machine_daemon "$SRC15" ) 2>&1 )
+rc15=$?
+assert_eq "gate accepts a real compiled binary without the bypass" "0" "$rc15"
+assert_eq "real binary is installed at dest" "1" "$( [[ -x "$DEST15/loom-daemon" ]] && echo 1 || echo 0 )"
 
 # ---------- summary ----------
 echo ""


### PR DESCRIPTION
## Summary

Closes #4397. Deferred from #4381's incident review (PR #4396): adds a
`file(1)`-based binary-format sanity gate directly inside
`provision_machine_daemon` (`scripts/install/provision-daemon.sh`), so it
refuses to install anything to the machine-level `~/.local/bin/loom-daemon`
path that isn't a real compiled binary (Mach-O on Darwin, ELF on Linux).

- `#4396` sandboxed + checksum-guarded the *test suite's own fixtures* from
  ever touching the real production binary again.
- This issue closes the complementary gap: `provision_machine_daemon` itself
  now refuses a non-binary regardless of *which* caller invokes it — the
  installer (`scripts/install-loom.sh`), self-update
  (`defaults/scripts/cli/loom-daemon-update.sh`), or any future script.

### Fixture-conflict resolution

The issue offered two options for the fixture conflict (every
`write_fake_daemon`/`make_fake_bin` fixture is a bash script standing in for
the compiled binary). I chose the **explicit, auditable test-mode bypass**
(`LOOM_PROVISION_ALLOW_SCRIPT=1`) over reworking all fixtures to precompiled
stand-in binaries:

- Reworking fixtures would touch ~15 call sites across two large test files
  (`tests/install/test-provision-daemon.sh`'s 13 pre-existing tests, and
  `defaults/scripts/tests/test-loom-daemon-update.sh`'s 107-test suite),
  introduce a compiler dependency into the test harness, and require each
  fixture writer (`write_fake_daemon`, `write_fake_daemon_restart`, the fake
  `cargo` stand-in, etc.) to emit binaries with controllable `--version` /
  `restart` / long-running behavior — a much larger, riskier surface than the
  actual defect being closed.
- The bypass is a single env var, set suite-wide only by the two test files
  that need it, with a comment at each export site naming exactly which
  production callers never set it (so it stays auditable, not silently
  discoverable/settable in production).

### Changes

- `scripts/install/provision-daemon.sh`: new `_pmd_is_real_binary` helper
  (matches `Mach-O`/`ELF` in `file -b` output; soft-passes if `file` is
  unavailable) and a gate inside `provision_machine_daemon` that calls it
  before any install, honoring `LOOM_PROVISION_ALLOW_SCRIPT=1`.
- `tests/install/test-provision-daemon.sh`: exports the bypass suite-wide;
  adds test 14 (rejects a script-based fake binary with the bypass
  explicitly unset — asserts exit 1, no install, and the rejection reason)
  and test 15 (accepts a real compiled binary — a copy of `/bin/cat` — with
  the bypass explicitly unset).
- `defaults/scripts/tests/test-loom-daemon-update.sh`: exports the bypass
  suite-wide (its fixtures are bash scripts too), alongside the existing
  `LOOM_DAEMON_BIN_DIR` sandbox export from #4396.

## Test plan

- [x] `bash tests/install/test-provision-daemon.sh` — 40/40 pass (38
      pre-existing + 2 new gate tests).
- [x] `bash defaults/scripts/tests/test-loom-daemon-update.sh` — 107/107
      pass, including the #4381 checksum regression guard (real
      `~/.local/bin/loom-daemon` byte-identical before/after).
- [x] `shellcheck -x` on all three modified files — no new warnings vs. the
      pre-change baseline (verified via `git stash` diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)