### PR TITLE
fix(scripts): resync-installed.sh must not delete a git-tracked vendored guard

### DIFF
--- a/defaults/scripts/resync-installed.sh
+++ b/defaults/scripts/resync-installed.sh
@@ -344,6 +344,15 @@ resync_tree() {
 # canonical guard at runtime. Resync must therefore neither resurrect the vendored
 # copy nor leave a stale one behind. Same marker probe the dispatcher/installer
 # use, so all three agree on which guard wins.
+#
+# Guard against #4403: the canonical Repo Skills guard is a LOCAL, typically
+# gitignored, per-host install (`.claude/skills/repo/`), but the vendored guard
+# it defers to (`.loom/hooks/guard-destructive-generic.sh`) can be git-tracked in
+# a repo that commits `.loom/` (this repo dogfoods that layout). Removing a
+# tracked file based purely on one contributor's local skill install deletes a
+# repo-shared file for everyone else. So below, before removing the vendored
+# guard, we check whether the target is git-tracked and skip the removal (with a
+# warning) if so — only untracked (the normal consumer-repo) targets are removed.
 CANONICAL_GUARD_PRESENT=0
 if [[ -r "$REPO_ROOT/.claude/skills/repo/hooks/guard-destructive.sh" ]] && \
    grep -q 'repo#29' "$REPO_ROOT/.claude/skills/repo/hooks/guard-destructive.sh" 2>/dev/null; then
@@ -360,7 +369,14 @@ if [[ -d "$DEFAULTS_DIR/hooks" && -d "$INSTALLED_HOOKS" ]]; then
         # The vendored generic guard is conditional on the canonical guard (#4041).
         if [[ "$name" == "guard-destructive-generic.sh" && "$CANONICAL_GUARD_PRESENT" -eq 1 ]]; then
             if [[ -f "$INSTALLED_HOOKS/$name" ]]; then
-                if [[ "$DRY_RUN" -eq 1 ]]; then
+                if git -C "$REPO_ROOT" ls-files --error-unmatch -- ".loom/hooks/$name" >/dev/null 2>&1; then
+                    # #4403: this target is git-tracked in the consuming repo, so it's
+                    # repo-shared state, not this host's local install. Removing it
+                    # would delete a committed file for every other contributor based
+                    # solely on this host's local, typically-gitignored Repo Skills
+                    # install. Leave it alone and warn instead.
+                    warn "hooks/$name is git-tracked in this repo but a canonical Repo Skills guard was detected locally — NOT removing a repo-shared tracked file based on one host's local install. If .loom/hooks/$name should genuinely be dropped repo-wide, remove it deliberately with 'git rm .loom/hooks/$name'."
+                elif [[ "$DRY_RUN" -eq 1 ]]; then
                     printf '%b\n' "  ${BOLD}would remove${NC} hooks/$name ${YELLOW}(canonical Repo Skills guard present)${NC}"
                 else
                     rm -f "$INSTALLED_HOOKS/$name" 2>/dev/null || true

--- a/defaults/scripts/tests/test-resync-installed.sh
+++ b/defaults/scripts/tests/test-resync-installed.sh
@@ -18,6 +18,9 @@
 #   (l) symlinked install target -> skipped, not clobbered
 #   (m) recorded loom_source gone -> clear error, exit 1
 #   (n) metadata re-stamp -> loom_version/loom_commit/last_resync present after apply
+# Canonical-guard-defer (#4041, #4403):
+#   (o) canonical guard + git-TRACKED vendored guard -> preserved, WARN, tree clean
+#   (p) canonical guard + UNTRACKED vendored guard   -> removed (unchanged behavior)
 # Plus contract checks:
 #   - --help prints usage, exit 0
 #   - unknown arg exits 1
@@ -537,6 +540,63 @@ if grep -q "skipped.*package.json" <<<"$OUT"; then
     pass "(#4285) pinned package.json reported as skipped"
 else
     fail "(#4285) pinned package.json not reported skipped"
+fi
+
+# --- (#4403) canonical-guard-defer: git-tracked target must NOT be removed --
+echo "Test group 14: canonical guard present + tracked vendored guard is preserved (#4403)"
+REPO="$(make_fixture)"
+mkdir -p "$REPO/.claude/skills/repo/hooks"
+printf '#!/usr/bin/env bash\n# rjwalters/repo#29 canonical guard\necho canonical\n' \
+    > "$REPO/.claude/skills/repo/hooks/guard-destructive.sh"
+printf '#!/usr/bin/env bash\necho vendored\n' \
+    > "$REPO/defaults/hooks/guard-destructive-generic.sh"
+printf '#!/usr/bin/env bash\necho vendored\n' \
+    > "$REPO/.loom/hooks/guard-destructive-generic.sh"
+git -C "$REPO" add .loom/hooks/guard-destructive-generic.sh >/dev/null 2>&1
+git -C "$REPO" commit -qm "track vendored guard" >/dev/null 2>&1
+OUT="$(cd "$REPO" && bash "$SCRIPT" 2>&1)"
+RC=$?
+if [[ $RC -eq 0 ]]; then pass "(#4403) apply exits 0 with a tracked vendored guard present"; else fail "(#4403) apply exits 0 (got $RC)"; fi
+if [[ -f "$REPO/.loom/hooks/guard-destructive-generic.sh" ]]; then
+    pass "(#4403) git-tracked hooks/guard-destructive-generic.sh preserved (not removed)"
+else
+    fail "(#4403) git-tracked hooks/guard-destructive-generic.sh was removed"
+fi
+if grep -qi "WARN.*git-tracked" <<<"$OUT"; then
+    pass "(#4403) a WARN is printed explaining the tracked file was preserved"
+else
+    fail "(#4403) no WARN printed for the preserved tracked file"
+fi
+if [[ -z "$(cd "$REPO" && git status --porcelain -- .loom/hooks/guard-destructive-generic.sh 2>&1)" ]]; then
+    pass "(#4403) tracked guard file stays non-dirty (no local mods/deletions) after the run"
+else
+    fail "(#4403) tracked guard file is dirty after the run"
+fi
+
+# --- (#4403) canonical-guard-defer: untracked target keeps existing behavior -
+echo "Test group 15: canonical guard present + UNTRACKED vendored guard is still removed (#4403)"
+REPO="$(make_fixture)"
+mkdir -p "$REPO/.claude/skills/repo/hooks"
+printf '#!/usr/bin/env bash\n# rjwalters/repo#29 canonical guard\necho canonical\n' \
+    > "$REPO/.claude/skills/repo/hooks/guard-destructive.sh"
+printf '#!/usr/bin/env bash\necho vendored\n' \
+    > "$REPO/defaults/hooks/guard-destructive-generic.sh"
+printf '#!/usr/bin/env bash\necho vendored\n' \
+    > "$REPO/.loom/hooks/guard-destructive-generic.sh"
+# Note: intentionally NOT git-added, so this is the normal consumer-repo case
+# where .loom/ isn't committed.
+OUT="$(cd "$REPO" && bash "$SCRIPT" 2>&1)"
+RC=$?
+if [[ $RC -eq 0 ]]; then pass "(#4403) apply exits 0 with an untracked vendored guard present"; else fail "(#4403) apply exits 0 (got $RC)"; fi
+if [[ ! -f "$REPO/.loom/hooks/guard-destructive-generic.sh" ]]; then
+    pass "(#4403) untracked hooks/guard-destructive-generic.sh removed (existing behavior unchanged)"
+else
+    fail "(#4403) untracked hooks/guard-destructive-generic.sh was NOT removed"
+fi
+if grep -q "removed.*hooks/guard-destructive-generic.sh" <<<"$OUT"; then
+    pass "(#4403) removal reported as before"
+else
+    fail "(#4403) removal not reported"
 fi
 
 # --- contract checks ---------------------------------------------------------


### PR DESCRIPTION
## Summary

`defaults/scripts/resync-installed.sh`'s canonical-guard-defer branch (#4041 /
PR #4107) removed `.loom/hooks/guard-destructive-generic.sh` whenever a
canonical Repo Skills guard (`.claude/skills/repo/hooks/guard-destructive.sh`
with a `repo#29` marker) was detected locally — even when the target was
git-tracked in the consuming repo. That deleted a repo-shared, committed file
based purely on one contributor's local, untracked Repo Skills install, which
is exactly what happened to this repo's own vendored guard on 2026-07-29.

This PR adds a git-tracked check before the `rm -f` call:

- If `.loom/hooks/guard-destructive-generic.sh` is **git-tracked**, the removal
  is skipped and a `warn`-level message explains why, pointing at a deliberate
  `git rm` if that's genuinely the intended repo-wide state.
- If it's **untracked** (the normal consumer-repo case, where `.loom/` isn't
  committed), the existing `rm -f` behavior is unchanged.

No daemon/Rust changes — `EPHEMERAL_PATTERNS` was already investigated and
ruled out as unrelated to this incident.

## Changes

- `defaults/scripts/resync-installed.sh`: added the tracked-file guard +
  updated header comment documenting the rationale and the incident.
- `defaults/scripts/tests/test-resync-installed.sh`: two new regression test
  groups — (o) tracked target is preserved with a WARN, (p) untracked target
  keeps the existing removal behavior.

## Test plan

- [x] `bash defaults/scripts/tests/test-resync-installed.sh` — 64/64 passed
- [x] `shellcheck defaults/scripts/resync-installed.sh` — clean
- [x] `shellcheck defaults/scripts/tests/test-resync-installed.sh` — clean

Closes #4403
