### PR TITLE
test(daemon): pin synthetic process age in 6 flaky install-state tests

### DIFF
--- a/loom-daemon/src/autonomy_marker.rs
+++ b/loom-daemon/src/autonomy_marker.rs
@@ -365,7 +365,16 @@ mod tests {
             startup_grace_secs_override: Some(0),
             is_darwin: false,
         };
-        let report = crate::daemon_install_state::classify(dir.path(), &marker, &env);
+        // Pin a synthetic process age well beyond the zero grace window
+        // (#4406): the real `ps -o etime=` lookup reports `00:00` for a
+        // sub-second-old test binary, which parses to 0 and satisfies
+        // `age <= grace`, flaking this assertion to AliveStarting.
+        let report = crate::daemon_install_state::classify_with_process_age_fn(
+            dir.path(),
+            &marker,
+            &env,
+            |_| Some(1_000_000),
+        );
         // Marker present + our own live pid ⇒ NOT the not-expected/dead states.
         assert_eq!(report.state, crate::daemon_install_state::InstallState::AliveButUnresponsive,);
         assert_eq!(report.started_at.as_deref(), Some("2026-07-28T00:00:00Z"));

--- a/loom-daemon/src/daemon_install_state.rs
+++ b/loom-daemon/src/daemon_install_state.rs
@@ -616,10 +616,14 @@ pub fn classify(loom_dir: &Path, marker_path: &Path, env: &EnvOverrides) -> Inst
 /// [`classify`]'s implementation, parameterized over the process-age lookup.
 /// Production code always goes through [`classify`] (which passes the real
 /// `ps`-backed [`process_age_secs`]); tests use this directly with a fixed
-/// closure so heartbeat-vs-process-age comparisons (#4368) are deterministic
-/// — the test binary's own real uptime, shared across every unit test
-/// running in this one process, is not a value any single test can control.
-fn classify_with_process_age_fn(
+/// closure so heartbeat-vs-process-age comparisons (#4368) and startup-grace
+/// comparisons (#4213) are deterministic — the test binary's own real uptime,
+/// shared across every unit test running in this one process, is not a value
+/// any single test can control.
+///
+/// `pub(crate)` so sibling modules' tests (e.g. `autonomy_marker`) can pin an
+/// age too; there is no production caller outside [`classify`] (#4406).
+pub(crate) fn classify_with_process_age_fn(
     loom_dir: &Path,
     marker_path: &Path,
     env: &EnvOverrides,
@@ -730,9 +734,16 @@ mod tests {
             launchd_override: None,
             launchd_label_override: None,
             heartbeat_stale_secs_override: None,
-            // A zero grace window makes the test process (always older than 0s)
-            // fall through to the existing verdicts by default — tests that want
-            // the startup-grace path set a huge window explicitly.
+            // A zero grace window is the *default* here so most tests reach the
+            // post-grace verdicts. It is NOT sufficient on its own: a real
+            // process under one second old reports `ps -o etime=` as `00:00`,
+            // which parses to 0 and satisfies `age <= grace` — so a test that
+            // asserts a post-grace verdict against a real `ps`-backed age
+            // flakes to `AliveStarting` whenever the test binary is still in
+            // its first wall-clock second (#4406). Any test that wants a
+            // post-grace verdict must ALSO pin a synthetic process age via
+            // `classify_with_process_age_fn`. Tests that want the
+            // startup-grace path set a huge window explicitly.
             startup_grace_secs_override: Some(0),
             is_darwin: false,
         }
@@ -779,7 +790,13 @@ mod tests {
                 pid_file.display()
             ),
         );
-        let report = classify(dir.path(), &marker, &no_env_overrides());
+        // Pin a synthetic process age well beyond the zero grace window
+        // (#4406) — a real `ps` age of `00:00` for a sub-second-old test
+        // binary would otherwise satisfy `age <= grace` and flake to
+        // AliveStarting.
+        let report = classify_with_process_age_fn(dir.path(), &marker, &no_env_overrides(), |_| {
+            Some(1_000_000)
+        });
         assert_eq!(report.state, InstallState::AliveButUnresponsive);
         assert_eq!(report.state.exit_code(), EXIT_ALIVE_BUT_UNRESPONSIVE);
         assert_eq!(report.pid, Some(std::process::id()));
@@ -906,7 +923,11 @@ mod tests {
             dir.path(),
             &format!("pid_file={}\nuse_launchd=false\n", pid_file.display()),
         );
-        let report = classify(dir.path(), &marker, &no_env_overrides());
+        // Pinned synthetic age (#4406, see `marker_present_live_pid_...`) so
+        // the zero grace window is genuinely cleared.
+        let report = classify_with_process_age_fn(dir.path(), &marker, &no_env_overrides(), |_| {
+            Some(1_000_000)
+        });
         assert_eq!(report.state, InstallState::AliveButUnresponsive);
         // No heartbeat file was ever written at the fallback location, so the
         // qualifier degrades to Unknown rather than falsely reporting Stale.
@@ -941,7 +962,11 @@ mod tests {
                 dir.path().join("no-such-heartbeat").display()
             ),
         );
-        let report = classify(dir.path(), &marker, &no_env_overrides());
+        // Pinned synthetic age (#4406, see `marker_present_live_pid_...`) so
+        // the zero grace window is genuinely cleared.
+        let report = classify_with_process_age_fn(dir.path(), &marker, &no_env_overrides(), |_| {
+            Some(1_000_000)
+        });
         assert_eq!(report.state, InstallState::AliveButUnresponsive);
         assert_eq!(report.heartbeat_freshness, Some(HeartbeatFreshness::Unknown));
         assert!(report.heartbeat_age_secs.is_none());
@@ -959,7 +984,9 @@ mod tests {
         );
         let mut env = no_env_overrides();
         env.launchd_override = Some(false);
-        let report = classify(dir.path(), &marker, &env);
+        // Pinned synthetic age (#4406, see `marker_present_live_pid_...`) so
+        // the zero grace window is genuinely cleared.
+        let report = classify_with_process_age_fn(dir.path(), &marker, &env, |_| Some(1_000_000));
         assert_eq!(report.state, InstallState::AliveButUnresponsive);
     }
 
@@ -972,8 +999,12 @@ mod tests {
             &format!("pid_file={}\nuse_launchd=true\n", pid_file.display()),
         );
         // is_darwin: false with no explicit launchd_override — the blanket
-        // non-Darwin rule must still force the pid-file path.
-        let report = classify(dir.path(), &marker, &no_env_overrides());
+        // non-Darwin rule must still force the pid-file path. Pinned synthetic
+        // age (#4406, see `marker_present_live_pid_...`) so the zero grace
+        // window is genuinely cleared.
+        let report = classify_with_process_age_fn(dir.path(), &marker, &no_env_overrides(), |_| {
+            Some(1_000_000)
+        });
         assert_eq!(report.state, InstallState::AliveButUnresponsive);
     }
 
@@ -1166,8 +1197,11 @@ mod tests {
 
     #[test]
     fn process_beyond_grace_falls_through_to_fault_verdict() {
-        // A zero-second grace window puts the (always older) test process
-        // beyond grace, so the existing AliveButUnresponsive verdict stands.
+        // A zero-second grace window plus a pinned process age puts the
+        // process beyond grace, so the existing AliveButUnresponsive verdict
+        // stands. The pinned age is load-bearing, not decorative: a real
+        // sub-second-old process reports `etime` as `00:00`, which would land
+        // inside the zero window (#4406).
         let dir = tempfile::tempdir().unwrap();
         let pid_file = write_pid_file(dir.path(), std::process::id());
         let heartbeat = write_heartbeat(dir.path(), Duration::from_secs(5));


### PR DESCRIPTION
Closes #4406

## Problem

Six `loom-daemon` unit tests asserted the post-startup-grace verdict
`AliveButUnresponsive` while letting `classify` resolve the *test binary's own*
process age through the real `ps`-backed lookup.

`ps -o etime=` reports `00:00` for any process under one wall-clock second old,
which `parse_etime` turns into `0`. The startup-grace check is
`age <= grace_threshold`, and the shared `no_env_overrides()` fixture pins
`startup_grace_secs_override: Some(0)` — so `0 <= 0` fires and the verdict is
`AliveStarting`, not `AliveButUnresponsive`.

Whether a run passed therefore depended on whether the scoped
`cargo test --lib daemon_install_state` invocation happened to land inside the
test binary's first second (~40% locally). The fixture's comment actively
encoded the wrong assumption ("the test process (always older than 0s) fall[s]
through"), which is how the pattern got copied six times.

## Changes

All test-only, except one visibility widening.

**`loom-daemon/src/daemon_install_state.rs`**
- Migrated the 5 enumerated tests from `classify` to
  `classify_with_process_age_fn(..., |_| Some(1_000_000))` — the same pinned-age
  pattern PR #4400 introduced and already uses for the tests it touched:
  - `marker_present_live_pid_is_alive_but_unresponsive`
  - `marker_missing_fields_uses_fallback_paths`
  - `heartbeat_absent_degrades_to_unknown_not_stale`
  - `env_launchd_override_forces_pid_file_path_even_when_marker_says_launchd`
  - `non_darwin_forces_pid_file_path_regardless_of_marker`
- Corrected the `no_env_overrides()` comment: a zero grace window is *not*
  sufficient on its own, and any test wanting a post-grace verdict must also
  pin a synthetic age.
- Corrected the same stale claim in
  `process_beyond_grace_falls_through_to_fault_verdict`'s comment (that test
  already pins an age; its comment still said "the (always older) test
  process").
- Widened `classify_with_process_age_fn` from `fn` to `pub(crate) fn` so a
  sibling module's test can reach it (documented as having no production caller
  other than `classify`).

**`loom-daemon/src/autonomy_marker.rs`**
- Migrated the 6th call site,
  `healed_marker_is_parseable_by_the_install_state_probe`, to the pinned-age
  variant. (Found by the Curator; it has the identical
  `std::process::id()` + `startup_grace_secs_override: Some(0)` +
  `assert_eq!(..., AliveButUnresponsive)` shape.)

No production code path changes. `classify` remains the only production caller
of `classify_with_process_age_fn`; the grace logic itself is untouched.

## Test Plan

- `cargo test --lib daemon_install_state` x8 consecutive scoped runs (the
  issue's reproduction loop, extended): **29 passed, 0 failed** every time.
- `cargo test --lib autonomy_marker` x4: **7 passed, 0 failed** every time.
- `cargo fmt --check`: clean.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test` (full `loom-daemon` suite): **1825 passed, 4 failed**.

### About those 4 failures — pre-existing, unrelated, and reproduced on bare main

The 4 failures are all in `main_health_gate::tests::test_run_gate_tick_*`. They
are **not** caused by this change:

- Reproduced identically on the **unmodified main checkout** (`d23ef3ca`),
  same 4 tests, same assertions (`first tick must run and be green`).
- Root cause is host load, not code: `run_gate_tick` consults the real
  1-minute load average via `cpu_headroom::is_host_saturated`, and this host
  was at load 45 across 28 cores (1.6/core) from parallel cargo builds — so
  the gate took the `GateTierDecision::Defer` path and returned `None` instead
  of `Some(GateOutcome::Green { .. })`.
- Confirmed by running the same 4 tests scoped with
  `LOOM_BUILD_GATE_LOAD_THRESHOLD=1000`: **4 passed, 0 failed**.

Notably this is the *same family* of defect as #4406 — a test asserting a
verdict while consulting real host state instead of an injected value — but a
different mechanism (load average vs. process age), in a module outside this
issue's scope. Flagging it here rather than expanding scope.

## Acceptance Criteria

- [x] All 6 tests use a pinned synthetic process age instead of the real
      `ps`-backed lookup
- [x] The misleading `no_env_overrides()` comment is corrected
- [x] The reproduction loop passes consistently (8/8 scoped runs green)
- [x] No production (non-`#[cfg(test)]`) code paths change except the
      `pub(crate)` visibility widening of `classify_with_process_age_fn`
- [x] Tests that intentionally exercise the startup-grace path still pass —
      `young_process_within_grace_is_alive_starting` (huge grace window, real
      age, deliberately unmigrated since a real age *inside* a `u64::MAX`
      window is exactly its intent) and
      `heartbeat_older_than_process_start_is_prior_boot_end_to_end`
      (injected 9s vs. 0s grace) are both untouched and green.