### PR TITLE
feat(daemon): SSE event tail endpoint GET /api/events (dashboard phase 2)

### DIFF
--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -265,13 +265,16 @@ enum Commands {
     },
 
     /// Start a minimal read-only HTTP status-snapshot listener (Issue #4391,
-    /// dashboard phase 1 of #4329). A single `GET /api/status` endpoint
-    /// serializes the same `DaemonStatusReport` `loom-daemon status --json`
-    /// already aggregates — fetched live over the *existing* Unix socket (the
-    /// same `DaemonStatus` IPC request `status` sends), so the aggregation
-    /// logic in `ipc::build_daemon_status` runs exactly once and is never
-    /// duplicated here. No new persistent store, no mutation, no SSE/HTML
-    /// (those are later phases #4392-#4394).
+    /// dashboard phases 1-2 of #4329). `GET /api/status` (#4391) serializes the
+    /// same `DaemonStatusReport` `loom-daemon status --json` already
+    /// aggregates — fetched live over the *existing* Unix socket (the same
+    /// `DaemonStatus` IPC request `status` sends), so the aggregation logic in
+    /// `ipc::build_daemon_status` runs exactly once and is never duplicated
+    /// here. `GET /api/events` (#4392) tails the daemon's event bus as
+    /// `text/event-stream`, bridged from the same socket's existing
+    /// `SubscribeEvents` request over the frozen `sweep.*` topics. Both are
+    /// read-only: no new persistent store, no mutation, no publish, no HTML
+    /// page yet (that is phase #4393, docs #4394).
     ///
     /// Off by default: nothing listens until this subcommand is explicitly
     /// run — a running daemon started without `serve` never opens this port.
@@ -3313,7 +3316,8 @@ async fn handle_serve_command(port: u16, bind: &str, allow_non_loopback: bool) -
         .map_err(|e| anyhow!("failed to bind {addr}:{port}: {e}"))?;
     let local_addr = listener.local_addr()?;
     println!(
-        "loom-daemon serve: listening on http://{local_addr}/api/status (proxying {})",
+        "loom-daemon serve: listening on http://{local_addr}/api/status and \
+         http://{local_addr}/api/events (proxying {})",
         socket_path.display()
     );
 

--- a/loom-daemon/src/serve.rs
+++ b/loom-daemon/src/serve.rs
@@ -1,13 +1,22 @@
-//! `loom-daemon serve` (Issue #4391 — dashboard phase 1 of #4329).
+//! `loom-daemon serve` (Issue #4391 — dashboard phase 1 of #4329; Issue #4392 —
+//! phase 2).
 //!
-//! A minimal, read-only HTTP status-snapshot listener. A single endpoint —
-//! `GET /api/status` — serializes the same [`crate::types::DaemonStatusReport`]
-//! data `loom-daemon status --json` already aggregates, fetched live over the
-//! *existing* Unix socket (the same `Request::DaemonStatus` / `Response::DaemonStatus`
-//! wire contract [`crate::ipc::build_daemon_status`] already answers) — this
-//! module never re-derives the report itself, and it starts nothing until the
-//! `serve` subcommand is explicitly invoked (never from the default daemon-run
-//! path, never from a config value alone).
+//! A minimal, read-only HTTP listener with two endpoints, both proxied over the
+//! daemon's *existing* Unix socket:
+//!
+//! - `GET /api/status` (#4391) — serializes the same
+//!   [`crate::types::DaemonStatusReport`] data `loom-daemon status --json`
+//!   already aggregates (the same `Request::DaemonStatus` / `Response::DaemonStatus`
+//!   wire contract [`crate::ipc::build_daemon_status`] already answers), so this
+//!   module never re-derives the report itself.
+//! - `GET /api/events` (#4392) — a `text/event-stream` (SSE) tail of the
+//!   daemon's event bus, bridged from the same socket's existing
+//!   `Request::SubscribeEvents` / `Response::EventStream` contract, so the
+//!   topic-prefix filtering runs exactly once, in
+//!   [`crate::event_bus::EventBus::subscribe`], never re-implemented here.
+//!
+//! Nothing starts until the `serve` subcommand is explicitly invoked (never
+//! from the default daemon-run path, never from a config value alone).
 //!
 //! # Security posture
 //!
@@ -22,32 +31,96 @@
 //!   address (loopback or a specific tailnet IP).
 //! - Read-only and stateless: every request re-fetches the live snapshot over
 //!   the socket; nothing is written to disk, and no daemon state is mutated.
+//!   The SSE bridge **subscribes only** — it never sends `Request::PublishEvent`
+//!   and never constructs an [`crate::types::Event`] of its own, so no traffic
+//!   this listener originates can ever appear on the bus.
+//! - `/api/events` adds no new bind, no new port and no new opt-in knob: it is
+//!   routed off the same [`TcpListener`] `/api/status` already answers, so it
+//!   inherits phase 1's bind validation ([`validate_bind`]) unchanged.
 //!
 //! # HTTP dependency decision
 //!
 //! Hand-rolled HTTP/1.1 over [`tokio::net::TcpListener`] rather than pulling in
-//! `axum`/`hyper`: a single read-only GET endpoint on a localhost-by-default
-//! surface does not warrant a full HTTP framework and its dependency tree
+//! `axum`/`hyper`: two read-only GET endpoints on a localhost-by-default
+//! surface do not warrant a full HTTP framework and its dependency tree
 //! (`loom-daemon/Cargo.toml` currently has no HTTP framework at all — tokio
 //! only). This keeps the same tradeoff the daemon already makes for its
-//! Unix-socket IPC protocol (also hand-rolled, newline-delimited JSON).
-//! Revisit if a later phase (SSE, #4392) needs persistent multi-frame
-//! connections beyond what this minimal responder supports.
+//! Unix-socket IPC protocol (also hand-rolled, newline-delimited JSON). SSE
+//! (#4392) did not change that calculus: `text/event-stream` is a plain-text
+//! framing (`data: <json>\n\n`) over an ordinary chunk-free HTTP/1.1 response,
+//! so the long-lived `/api/events` connection needs no framework support
+//! beyond what [`tokio::net::TcpStream`] already provides.
 
-use crate::types::{DaemonStatusReport, Request, Response};
+use crate::types::{DaemonStatusReport, Event, Request, Response};
 use anyhow::{anyhow, Result};
 use serde::Serialize;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream, UnixStream};
 
 /// Default TCP port for `loom-daemon serve`.
 pub const DEFAULT_PORT: u16 = 7420;
 
-/// Path this module's single endpoint answers.
+/// Path the JSON status-snapshot endpoint answers (Issue #4391).
 const STATUS_PATH: &str = "/api/status";
+
+/// Path the SSE event-tail endpoint answers (Issue #4392).
+const EVENTS_PATH: &str = "/api/events";
+
+/// Topic **prefixes** the SSE bridge subscribes to, passed verbatim as
+/// `Request::SubscribeEvents { topics }` so the daemon applies them through the
+/// very same [`crate::event_bus::EventBus::subscribe`] /
+/// [`crate::event_bus::topic_matches`] prefix filter every other subscriber
+/// uses. Matching is segment-aligned prefix match, so `sweep.issue` covers
+/// `sweep.issue.{N}.phase` / `.blocker` / `.exited` / `.crashed` for every `N`
+/// without needing a glob the bus does not support.
+///
+/// Every entry is an existing, already-authorized topic (or a prefix of one)
+/// from `event_bus.rs`'s frozen taxonomy — **this module never invents a
+/// topic**, and never renames one on the way out (see [`sse_frame`], which
+/// emits [`Event::topic`] verbatim):
+///
+/// | Prefix | Covers | Authorized by |
+/// |--------|--------|---------------|
+/// | `sweep.issue` | the four frozen per-issue topics (`phase`/`blocker`/`exited`/`crashed`), plus `resume_dispatched` (#4256) | v0.10.0 frozen taxonomy |
+/// | `sweep.global.dispatch` | frozen global dispatch topic | v0.10.0 frozen taxonomy |
+/// | `sweep.global.completed` | frozen global completion topic | v0.10.0 frozen taxonomy |
+/// | `epic.issue` | `epic.issue.{N}.{decompose,expand,join,close}` | #3873 |
+/// | `daemon.capacity.advisory` | work-finder capacity backpressure advisory | #3902 |
+/// | `daemon.drain` | `daemon.drain.{started,completed,aborted,timeout}` | #4090 |
+/// | `daemon.dispatch.headroom_advisory` | dispatch-time headroom advisory | #4234 |
+///
+/// The first three rows are the **required** set (#4392: the six frozen
+/// `sweep.*` topics MUST stream). The remaining rows are the issue's explicitly
+/// optional, already-authorized follow-up topics — included because a fleet
+/// dashboard wants them, and safe to include because each frame carries its
+/// exact source topic, so a consumer can never confuse one for a frozen
+/// `sweep.*` topic.
+pub const SSE_TOPIC_PREFIXES: &[&str] = &[
+    "sweep.issue",
+    "sweep.global.dispatch",
+    "sweep.global.completed",
+    "epic.issue",
+    "daemon.capacity.advisory",
+    "daemon.drain",
+    "daemon.dispatch.headroom_advisory",
+];
+
+/// How often the SSE bridge writes a heartbeat comment (`: keepalive`) when no
+/// events are flowing. Two jobs: keep intermediaries from reaping an idle
+/// connection, and give the bridge a periodic write that fails once the client
+/// has gone away even if the bus is silent (so the upstream subscription is
+/// dropped rather than leaked).
+const SSE_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Reconnect delay (ms) advertised to `EventSource` clients via the SSE
+/// `retry:` field. This bridge has **no replay buffer** (the "no new persistent
+/// store" constraint), so a reconnecting client resumes from live — and
+/// deliberately never emits an `id:` field, which would imply a
+/// `Last-Event-ID` replay capability that does not exist.
+const SSE_RETRY_MS: u64 = 3_000;
 
 /// Bounded timeout for a single connect + `DaemonStatus` round-trip against
 /// the daemon's own Unix socket. Deliberately a single attempt (unlike
@@ -233,6 +306,216 @@ async fn write_json_response(stream: &mut TcpStream, status_line: &str, body: &s
     Ok(())
 }
 
+// ============================================================================
+// SSE event tail (`GET /api/events`, Issue #4392)
+// ============================================================================
+
+/// True when `topic` would be delivered by this bridge's subscription, decided
+/// with the bus's own [`crate::event_bus::topic_matches`] rule against
+/// [`SSE_TOPIC_PREFIXES`] — the same predicate the daemon side applies, so this
+/// is a faithful local mirror of the server-side filter rather than a second
+/// implementation of matching.
+#[must_use]
+pub fn topic_is_streamed(topic: &str) -> bool {
+    SSE_TOPIC_PREFIXES
+        .iter()
+        .any(|prefix| crate::event_bus::topic_matches(topic, prefix))
+}
+
+/// The HTTP response head for the SSE stream, followed by the stream preamble.
+///
+/// `Connection: close` and the absence of `Content-Length` mean the body runs
+/// until the connection ends — the standard framing for an unbounded
+/// `text/event-stream`. `X-Accel-Buffering: no` tells a reverse proxy (should
+/// an operator front this loopback listener with one) not to buffer the stream.
+#[must_use]
+fn sse_response_head() -> String {
+    format!(
+        "HTTP/1.1 200 OK\r\n\
+         Content-Type: text/event-stream\r\n\
+         Cache-Control: no-cache, no-store\r\n\
+         X-Accel-Buffering: no\r\n\
+         Connection: close\r\n\
+         \r\n\
+         retry: {SSE_RETRY_MS}\n\
+         : connected to the loom-daemon event bus\n\n"
+    )
+}
+
+/// Render one bus [`Event`] as a single SSE frame.
+///
+/// Frames deliberately carry **no `event:` field**: the SSE event-name field is
+/// a fixed string, but the frozen taxonomy's topics are parameterized by issue
+/// number (`sweep.issue.{N}.phase`), so a browser could not
+/// `addEventListener` for them. Instead every frame arrives as the default
+/// `message` type and carries its exact source topic in the JSON payload's
+/// `topic` field — verbatim from [`Event::topic`], never renamed or
+/// re-namespaced — with the full typed event under `event`. A consumer routes
+/// on `topic`, and the six frozen `sweep.*` topics are therefore
+/// indistinguishable from how the bus itself names them.
+///
+/// `serde_json::to_string` on this payload cannot fail (an [`Event`]'s
+/// `Serialize` impl is infallible and the map keys are static), so the
+/// unreachable error branch degrades to an SSE comment rather than tearing
+/// down a live stream.
+#[must_use]
+pub fn sse_frame(event: &Event) -> String {
+    let payload = serde_json::json!({
+        "topic": event.topic(),
+        "event": event,
+    });
+    match serde_json::to_string(&payload) {
+        // A `data:` value must not contain a newline; `to_string` (compact,
+        // not `to_string_pretty`) never emits one.
+        Ok(json) => format!("data: {json}\n\n"),
+        Err(e) => format!(": unserializable event ({e})\n\n"),
+    }
+}
+
+/// Translate one newline-delimited IPC response line from the daemon into zero
+/// or more SSE frames.
+///
+/// A [`Response::EventStream`] frame may carry more than one event (the wire
+/// contract allows batching), so this returns a `Vec`. Anything else — an
+/// unparseable line, a [`Response::Error`], or a response variant that is not
+/// part of the subscription stream — yields no frames and is skipped rather
+/// than killing the stream.
+#[must_use]
+fn sse_frames_for_response_line(line: &str) -> Vec<String> {
+    match serde_json::from_str::<Response>(line) {
+        Ok(Response::EventStream { events }) => events.iter().map(sse_frame).collect(),
+        Ok(Response::Error { message }) => {
+            log::debug!("serve: event stream got an error response from the daemon: {message}");
+            vec![]
+        }
+        Ok(other) => {
+            log::debug!("serve: ignoring non-event response on the event stream: {other:?}");
+            vec![]
+        }
+        Err(e) => {
+            log::debug!("serve: unparseable event-stream line ({e})");
+            vec![]
+        }
+    }
+}
+
+/// Open an event subscription on the daemon's Unix socket.
+///
+/// Sends exactly one `Request::SubscribeEvents { topics }` — the read-only IPC
+/// verb — and returns the split halves of the connection. The write half is
+/// returned (rather than dropped) purely so it stays alive for the life of the
+/// stream; the bridge never writes to it again, which is what makes the
+/// "subscribe, never publish" invariant structural rather than a convention.
+async fn open_event_subscription(
+    socket_path: &Path,
+) -> Result<(tokio::net::unix::OwnedReadHalf, tokio::net::unix::OwnedWriteHalf)> {
+    let connect = async {
+        let stream = UnixStream::connect(socket_path)
+            .await
+            .map_err(|e| anyhow!("connect to daemon socket failed: {e}"))?;
+        let (reader, mut writer) = stream.into_split();
+
+        let topics: Vec<String> = SSE_TOPIC_PREFIXES
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        let request_json = serde_json::to_string(&Request::SubscribeEvents { topics })?;
+        writer.write_all(request_json.as_bytes()).await?;
+        writer.write_all(b"\n").await?;
+        writer.flush().await?;
+        Ok::<_, anyhow::Error>((reader, writer))
+    };
+
+    tokio::time::timeout(FETCH_TIMEOUT, connect)
+        .await
+        .map_err(|_| anyhow!("event subscription timed out after {}s", FETCH_TIMEOUT.as_secs()))?
+}
+
+/// Serve `GET /api/events`: bridge the daemon's event bus onto this connection
+/// as `text/event-stream`.
+///
+/// Lifecycle: subscribe over IPC first (so an unreachable daemon still gets a
+/// clean 503 JSON body rather than a half-open stream), then commit to a 200
+/// and pump frames until either side goes away. Termination is deliberately
+/// total — client EOF, a failed write, the daemon closing the subscription, or
+/// a socket error all return `Ok(())`, at which point both halves of the IPC
+/// connection drop and the daemon-side [`crate::event_bus::Subscription`] is
+/// released. There is no path that leaves the upstream subscription alive after
+/// this function returns.
+async fn handle_event_stream(stream: &mut TcpStream, socket_path: &Path) -> Result<()> {
+    let (daemon_reader, _daemon_writer) = match open_event_subscription(socket_path).await {
+        Ok(halves) => halves,
+        Err(e) => {
+            let body = serde_json::json!({ "error": format!("daemon unreachable: {e}") });
+            write_json_response(stream, "503 Service Unavailable", &body.to_string()).await?;
+            return Ok(());
+        }
+    };
+
+    let (mut client_reader, mut client_writer) = stream.split();
+
+    if client_writer
+        .write_all(sse_response_head().as_bytes())
+        .await
+        .is_err()
+        || client_writer.flush().await.is_err()
+    {
+        return Ok(());
+    }
+
+    let mut daemon_lines = BufReader::new(daemon_reader).lines();
+    let mut heartbeat = tokio::time::interval(SSE_HEARTBEAT_INTERVAL);
+    // `interval` fires immediately on its first tick; consume it so the first
+    // heartbeat lands one full interval after the preamble.
+    heartbeat.tick().await;
+    // Scratch buffer for the client half. A well-behaved SSE client sends
+    // nothing after its request, so this read is really an EOF detector.
+    let mut client_scratch = [0u8; 512];
+
+    loop {
+        tokio::select! {
+            line = daemon_lines.next_line() => match line {
+                Ok(Some(line)) => {
+                    for frame in sse_frames_for_response_line(&line) {
+                        if client_writer.write_all(frame.as_bytes()).await.is_err() {
+                            return Ok(());
+                        }
+                    }
+                    if client_writer.flush().await.is_err() {
+                        return Ok(());
+                    }
+                }
+                Ok(None) => {
+                    // Daemon closed the subscription (shutdown/restart). Tell
+                    // the client in-band, then end the response; `EventSource`
+                    // reconnects on its own after `retry:`.
+                    let _ = client_writer.write_all(b": daemon closed the event stream\n\n").await;
+                    let _ = client_writer.flush().await;
+                    return Ok(());
+                }
+                Err(e) => {
+                    log::debug!("serve: event subscription read error: {e}");
+                    return Ok(());
+                }
+            },
+            read = client_reader.read(&mut client_scratch) => match read {
+                // Client hung up (or errored) — drop the subscription.
+                Ok(0) | Err(_) => return Ok(()),
+                // Unexpected trailing bytes from the client: this endpoint has
+                // no client->server channel, so discard and keep streaming.
+                Ok(_) => {}
+            },
+            _ = heartbeat.tick() => {
+                if client_writer.write_all(b": keepalive\n\n").await.is_err()
+                    || client_writer.flush().await.is_err()
+                {
+                    return Ok(());
+                }
+            }
+        }
+    }
+}
+
 /// Handle a single accepted connection: parse the request, route it, and
 /// write exactly one response. Every branch is read-only — this function
 /// never mutates daemon state and never writes to disk.
@@ -258,7 +541,7 @@ async fn handle_connection(mut stream: TcpStream, socket_path: PathBuf) -> Resul
         }
     };
 
-    if parsed.path != STATUS_PATH {
+    if parsed.path != STATUS_PATH && parsed.path != EVENTS_PATH {
         write_json_response(
             &mut stream,
             "404 Not Found",
@@ -276,6 +559,12 @@ async fn handle_connection(mut stream: TcpStream, socket_path: PathBuf) -> Resul
         )
         .await?;
         return Ok(());
+    }
+
+    // The SSE tail (#4392) is a long-lived response: it owns the connection
+    // from here until either side disconnects.
+    if parsed.path == EVENTS_PATH {
+        return handle_event_stream(&mut stream, &socket_path).await;
     }
 
     match fetch_snapshot(&socket_path).await {
@@ -298,7 +587,7 @@ async fn handle_connection(mut stream: TcpStream, socket_path: PathBuf) -> Resul
 pub async fn run(listener: TcpListener, socket_path: PathBuf) -> Result<()> {
     let local_addr = listener.local_addr().ok();
     log::info!(
-        "serve: listening on {} (proxying {})",
+        "serve: listening on {} ({STATUS_PATH}, {EVENTS_PATH}; proxying {})",
         local_addr.map_or_else(|| "?".to_string(), |a| a.to_string()),
         socket_path.display()
     );
@@ -590,5 +879,542 @@ mod tests {
             after.is_empty(),
             "serve must never write files under an unrelated scratch dir: {after:?}"
         );
+    }
+
+    // ========================================================================
+    // SSE event tail (`GET /api/events`, Issue #4392)
+    // ========================================================================
+
+    use crate::event_bus::EventBus;
+    use crate::types::{EpicActionClass, Event, SweepKind, SweepOutcome};
+    use std::sync::Arc;
+
+    /// The six topics frozen for v0.10.0 that #4392 requires this endpoint to
+    /// stream, spelled out literally (not derived from
+    /// [`SSE_TOPIC_PREFIXES`]) so the assertion is independent of the
+    /// implementation it checks.
+    const FROZEN_SWEEP_TOPICS: &[&str] = &[
+        "sweep.issue.4392.phase",
+        "sweep.issue.4392.blocker",
+        "sweep.issue.4392.exited",
+        "sweep.issue.4392.crashed",
+        "sweep.global.dispatch",
+        "sweep.global.completed",
+    ];
+
+    /// One constructed [`Event`] per frozen topic, in the same order.
+    fn frozen_sweep_events() -> Vec<Event> {
+        vec![
+            Event::SweepPhase {
+                issue: 4392,
+                phase: "builder".to_string(),
+                pr_number: None,
+                repo: None,
+            },
+            Event::SweepBlocker {
+                issue: 4392,
+                reason: "dependency".to_string(),
+                label_added: "loom:blocked".to_string(),
+                repo: None,
+            },
+            Event::SweepExited {
+                issue: 4392,
+                exit_code: Some(0),
+                duration_sec: 12,
+                repo: None,
+            },
+            Event::SweepCrashed {
+                issue: 4392,
+                checkpoint_phase: Some("judge".to_string()),
+                classification: None,
+                repo: None,
+            },
+            Event::SweepGlobalDispatch {
+                sweep_id: "sweep-4392".to_string(),
+                kind: SweepKind::Issue(4392),
+                repo: None,
+            },
+            Event::SweepGlobalCompleted {
+                sweep_id: "sweep-4392".to_string(),
+                outcome: SweepOutcome::Exited,
+            },
+        ]
+    }
+
+    // ----- Unit: topic filter -----
+
+    #[test]
+    fn sse_filter_passes_all_six_frozen_sweep_topics() {
+        for topic in FROZEN_SWEEP_TOPICS {
+            assert!(
+                topic_is_streamed(topic),
+                "frozen v0.10.0 topic must stream on /api/events: {topic}"
+            );
+        }
+    }
+
+    #[test]
+    fn sse_filter_passes_the_frozen_topics_for_any_issue_number() {
+        // The bus offers prefix matching, not globbing, so `sweep.issue.{N}.*`
+        // has to be covered by a prefix rather than enumerated per issue.
+        for issue in [1u32, 42, 4392, 999_999] {
+            for suffix in ["phase", "blocker", "exited", "crashed"] {
+                let topic = format!("sweep.issue.{issue}.{suffix}");
+                assert!(topic_is_streamed(&topic), "must stream {topic}");
+            }
+        }
+    }
+
+    #[test]
+    fn sse_filter_subscribes_only_to_topics_from_the_frozen_taxonomy() {
+        // Guards #4392's "never invent new topics": every subscribed prefix is
+        // an existing taxonomy entry (or a segment-aligned prefix of one),
+        // authorized by the issue number named in `SSE_TOPIC_PREFIXES`' docs.
+        let expected = [
+            "sweep.issue",
+            "sweep.global.dispatch",
+            "sweep.global.completed",
+            "epic.issue",
+            "daemon.capacity.advisory",
+            "daemon.drain",
+            "daemon.dispatch.headroom_advisory",
+        ];
+        assert_eq!(
+            SSE_TOPIC_PREFIXES, &expected,
+            "the subscribed prefix set is a frozen contract — adding one requires a follow-up \
+             issue authorizing the topic in event_bus.rs's taxonomy"
+        );
+    }
+
+    #[test]
+    fn sse_filter_rejects_topics_outside_the_taxonomy() {
+        for topic in [
+            "dashboard.custom.ping", // an invented topic
+            "sweep.issuetype.foo",   // near-miss: prefix match is segment-aligned
+            "sweeps.global.dispatch",
+            "daemon.drainage.started",
+            "",
+        ] {
+            assert!(
+                !topic_is_streamed(topic),
+                "must not stream a topic outside the taxonomy: {topic:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn sse_filter_passes_the_optional_authorized_follow_up_topics() {
+        for topic in [
+            "epic.issue.4329.decompose",
+            "epic.issue.4329.expand",
+            "epic.issue.4329.join",
+            "epic.issue.4329.close",
+            "daemon.capacity.advisory",
+            "daemon.drain.started",
+            "daemon.drain.completed",
+            "daemon.drain.aborted",
+            "daemon.drain.timeout",
+            "daemon.dispatch.headroom_advisory",
+        ] {
+            assert!(topic_is_streamed(topic), "must stream {topic}");
+        }
+    }
+
+    // ----- Unit: frame translation -----
+
+    #[test]
+    fn sse_frame_carries_each_frozen_topic_verbatim() {
+        for (event, expected_topic) in frozen_sweep_events().iter().zip(FROZEN_SWEEP_TOPICS) {
+            let frame = sse_frame(event);
+            assert!(frame.ends_with("\n\n"), "frame must be blank-line terminated: {frame:?}");
+            let data = frame
+                .strip_prefix("data: ")
+                .and_then(|rest| rest.strip_suffix("\n\n"))
+                .unwrap_or_else(|| panic!("frame must be a single `data:` line: {frame:?}"));
+            assert!(!data.contains('\n'), "a `data:` value must be newline-free: {data:?}");
+            let value: serde_json::Value = serde_json::from_str(data).expect("valid json payload");
+            assert_eq!(
+                value["topic"],
+                serde_json::json!(*expected_topic),
+                "the frame must carry the bus topic verbatim — no renaming"
+            );
+            assert_eq!(value["topic"], serde_json::json!(event.topic()));
+            assert!(value.get("event").is_some(), "frame must carry the typed event");
+        }
+    }
+
+    #[test]
+    fn sse_frame_preserves_the_typed_event_payload() {
+        let frame = sse_frame(&Event::SweepGlobalDispatch {
+            sweep_id: "sweep-4392".to_string(),
+            kind: SweepKind::Issue(4392),
+            repo: Some("/repos/loom".to_string()),
+        });
+        let data = frame.trim_start_matches("data: ").trim_end_matches("\n\n");
+        let value: serde_json::Value = serde_json::from_str(data).expect("valid json");
+        assert_eq!(value["topic"], serde_json::json!("sweep.global.dispatch"));
+        assert_eq!(value["event"]["sweep_id"], serde_json::json!("sweep-4392"));
+        assert_eq!(value["event"]["repo"], serde_json::json!("/repos/loom"));
+    }
+
+    #[test]
+    fn sse_frame_omits_the_event_name_field_so_browsers_get_onmessage() {
+        // A per-issue topic cannot be an SSE `event:` name (a client cannot
+        // `addEventListener` for `sweep.issue.{N}.phase`), so routing lives in
+        // the payload's `topic` instead. Assert the framing stays that way.
+        let frame = sse_frame(&Event::SweepPhase {
+            issue: 7,
+            phase: "judge".to_string(),
+            pr_number: Some(1234),
+            repo: None,
+        });
+        assert!(
+            !frame.contains("event:"),
+            "frames must use the default `message` type: {frame:?}"
+        );
+        assert!(!frame.contains("id:"), "no `id:` — this bridge has no replay buffer: {frame:?}");
+    }
+
+    #[test]
+    fn sse_frame_renders_an_optional_authorized_topic_without_disguising_it() {
+        let frame = sse_frame(&Event::EpicAction {
+            epic: 4329,
+            action: EpicActionClass::Expand,
+            state: "epic:designed".to_string(),
+        });
+        let data = frame.trim_start_matches("data: ").trim_end_matches("\n\n");
+        let value: serde_json::Value = serde_json::from_str(data).expect("valid json");
+        // The optional follow-up topics stay recognizably themselves — never
+        // relabelled into the frozen `sweep.*` namespace.
+        assert_eq!(value["topic"], serde_json::json!("epic.issue.4329.expand"));
+        assert!(!value["topic"]
+            .as_str()
+            .unwrap_or_default()
+            .starts_with("sweep."));
+    }
+
+    #[test]
+    fn sse_frames_for_response_line_translates_a_batched_event_stream_frame() {
+        let response = Response::EventStream {
+            events: frozen_sweep_events(),
+        };
+        let line = serde_json::to_string(&response).expect("serialize");
+        let frames = sse_frames_for_response_line(&line);
+        assert_eq!(frames.len(), FROZEN_SWEEP_TOPICS.len());
+        for (frame, topic) in frames.iter().zip(FROZEN_SWEEP_TOPICS) {
+            assert!(frame.contains(topic), "frame {frame:?} should carry topic {topic}");
+        }
+    }
+
+    #[test]
+    fn sse_frames_for_response_line_skips_junk_without_emitting_frames() {
+        assert!(sse_frames_for_response_line("not json at all").is_empty());
+        assert!(sse_frames_for_response_line("").is_empty());
+        let err = serde_json::to_string(&Response::Error {
+            message: "boom".to_string(),
+        })
+        .expect("serialize");
+        assert!(sse_frames_for_response_line(&err).is_empty());
+    }
+
+    #[test]
+    fn sse_response_head_declares_an_unbounded_event_stream() {
+        let head = sse_response_head();
+        assert!(head.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(head.contains("Content-Type: text/event-stream\r\n"));
+        assert!(head.contains("Cache-Control: no-cache"));
+        assert!(
+            !head.contains("Content-Length"),
+            "an SSE body is unbounded — a Content-Length would truncate it: {head:?}"
+        );
+        assert!(head.contains(&format!("retry: {SSE_RETRY_MS}")));
+    }
+
+    // ----- Integration harness: a fake daemon that answers SubscribeEvents -----
+
+    struct FakeEventDaemon {
+        socket_path: PathBuf,
+        bus: Arc<EventBus>,
+    }
+
+    /// Spin up a fake daemon Unix socket that answers `SubscribeEvents` from a
+    /// **real** [`EventBus`], forwarding matching events as
+    /// `Response::EventStream` lines exactly the way `ipc::stream_events`
+    /// does — same `bus.subscribe(topics)` prefix filter, same one-event-per-
+    /// frame encoding, same "stop on write error" termination. Accepts
+    /// repeatedly so a reconnect can be exercised.
+    async fn spawn_fake_event_daemon() -> FakeEventDaemon {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket_path = dir.path().join("fake-daemon.sock");
+        std::mem::forget(dir);
+        let listener = UnixListener::bind(&socket_path).expect("bind fake socket");
+        let bus = Arc::new(EventBus::new());
+        let bus_for_accept = Arc::clone(&bus);
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                let bus = Arc::clone(&bus_for_accept);
+                tokio::spawn(async move {
+                    let (reader, mut writer) = stream.into_split();
+                    let mut lines = BufReader::new(reader).lines();
+                    let Ok(Some(line)) = lines.next_line().await else {
+                        return;
+                    };
+                    let request: Request = serde_json::from_str(&line).expect("valid IPC request");
+                    let Request::SubscribeEvents { topics } = request else {
+                        panic!("the SSE bridge must only ever send SubscribeEvents: {request:?}");
+                    };
+                    let mut subscription = bus.subscribe(topics);
+                    while let Ok(event) = subscription.recv().await {
+                        let frame = Response::EventStream {
+                            events: vec![event],
+                        };
+                        let json = serde_json::to_string(&frame).expect("serialize");
+                        if writer.write_all(json.as_bytes()).await.is_err()
+                            || writer.write_all(b"\n").await.is_err()
+                            || writer.flush().await.is_err()
+                        {
+                            break;
+                        }
+                    }
+                    // Subscription drops here — the leak check below observes
+                    // this through `bus.receiver_count()`.
+                });
+            }
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        FakeEventDaemon { socket_path, bus }
+    }
+
+    /// Poll until the bus reports exactly `want` subscribers, or fail.
+    async fn wait_for_receiver_count(bus: &EventBus, want: usize) {
+        for _ in 0..300 {
+            if bus.receiver_count() == want {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("bus never settled at {want} receivers (last: {})", bus.receiver_count());
+    }
+
+    /// Open an SSE connection and read until the stream preamble arrives.
+    async fn connect_sse(addr: std::net::SocketAddr) -> (TcpStream, String) {
+        let mut stream = TcpStream::connect(addr).await.expect("connect");
+        stream
+            .write_all(
+                b"GET /api/events HTTP/1.1\r\nHost: 127.0.0.1\r\nAccept: text/event-stream\r\n\r\n",
+            )
+            .await
+            .expect("write request");
+        let head = read_until(&mut stream, ": connected").await;
+        (stream, head)
+    }
+
+    /// Read from `stream` until `needle` appears or a bounded timeout expires.
+    async fn read_until(stream: &mut TcpStream, needle: &str) -> String {
+        let mut acc = String::new();
+        let mut buf = [0u8; 4096];
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match tokio::time::timeout(remaining, stream.read(&mut buf)).await {
+                Ok(Ok(0)) | Ok(Err(_)) | Err(_) => break,
+                Ok(Ok(n)) => {
+                    acc.push_str(&String::from_utf8_lossy(&buf[..n]));
+                    if acc.contains(needle) {
+                        break;
+                    }
+                }
+            }
+        }
+        acc
+    }
+
+    /// Extract the parsed payloads of every `data:` line seen so far.
+    fn data_payloads(text: &str) -> Vec<serde_json::Value> {
+        text.lines()
+            .filter_map(|l| l.strip_prefix("data: "))
+            .filter_map(|json| serde_json::from_str(json).ok())
+            .collect()
+    }
+
+    // ----- Integration: live delivery on an ephemeral port -----
+
+    #[tokio::test]
+    async fn sse_endpoint_delivers_a_published_sweep_global_dispatch_event() {
+        let fake = spawn_fake_event_daemon().await;
+        let tcp_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("bind tcp");
+        let addr = tcp_listener.local_addr().expect("local addr");
+        // Same listener, same loopback-only posture as phase 1 — /api/events
+        // adds no second bind.
+        assert!(addr.ip().is_loopback());
+        let server_task = tokio::spawn(run(tcp_listener, fake.socket_path.clone()));
+
+        let (mut client, head) = connect_sse(addr).await;
+        assert!(head.contains("200 OK"), "head: {head:?}");
+        assert!(head.contains("text/event-stream"), "head: {head:?}");
+
+        // The bus drops events published with no receivers, so wait until the
+        // bridge's subscription has actually landed.
+        wait_for_receiver_count(&fake.bus, 1).await;
+
+        fake.bus
+            .publish(Event::SweepGlobalDispatch {
+                sweep_id: "sweep-4392".to_string(),
+                kind: SweepKind::Issue(4392),
+                repo: None,
+            })
+            .expect("publish");
+
+        let body = read_until(&mut client, "sweep.global.dispatch").await;
+        let payloads = data_payloads(&body);
+        let dispatch = payloads
+            .iter()
+            .find(|p| p["topic"] == serde_json::json!("sweep.global.dispatch"))
+            .unwrap_or_else(|| panic!("no dispatch frame in stream: {body:?}"));
+        assert_eq!(dispatch["event"]["sweep_id"], serde_json::json!("sweep-4392"));
+
+        server_task.abort();
+    }
+
+    #[tokio::test]
+    async fn sse_endpoint_delivers_every_frozen_sweep_topic_and_filters_the_rest() {
+        let fake = spawn_fake_event_daemon().await;
+        let tcp_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("bind tcp");
+        let addr = tcp_listener.local_addr().expect("local addr");
+        let server_task = tokio::spawn(run(tcp_listener, fake.socket_path.clone()));
+
+        let (mut client, _head) = connect_sse(addr).await;
+        wait_for_receiver_count(&fake.bus, 1).await;
+
+        // Negative control published FIRST: if the server-side prefix filter
+        // were a no-op this would arrive before any frozen topic below.
+        fake.bus
+            .publish_generic(
+                "unrelated.topic.for.this.test",
+                serde_json::json!({ "should": "never reach the client" }),
+            )
+            .expect("publish");
+        for event in frozen_sweep_events() {
+            fake.bus.publish(event).expect("publish");
+        }
+
+        let body = read_until(&mut client, "sweep.global.completed").await;
+        let topics: Vec<String> = data_payloads(&body)
+            .iter()
+            .filter_map(|p| p["topic"].as_str().map(str::to_string))
+            .collect();
+        for expected in FROZEN_SWEEP_TOPICS {
+            assert!(
+                topics.iter().any(|t| t == expected),
+                "frozen topic {expected} missing from stream: {topics:?}"
+            );
+        }
+        assert!(
+            !body.contains("unrelated.topic.for.this.test"),
+            "the subscription's topic filter must be honored: {body:?}"
+        );
+
+        server_task.abort();
+    }
+
+    // ----- Edge: disconnect / reconnect -----
+
+    #[tokio::test]
+    async fn sse_client_disconnect_releases_the_subscription_and_reconnect_works() {
+        let fake = spawn_fake_event_daemon().await;
+        let tcp_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("bind tcp");
+        let addr = tcp_listener.local_addr().expect("local addr");
+        let server_task = tokio::spawn(run(tcp_listener, fake.socket_path.clone()));
+
+        // --- first client, then an abrupt disconnect ---
+        let (first, _head) = connect_sse(addr).await;
+        wait_for_receiver_count(&fake.bus, 1).await;
+        drop(first);
+
+        // The bridge sees EOF and drops its IPC connection; the daemon side
+        // notices on its next write and releases the subscription. Publishing
+        // into that race must not panic anything.
+        for _ in 0..50 {
+            if fake.bus.receiver_count() == 0 {
+                break;
+            }
+            let _ = fake
+                .bus
+                .publish_generic("sweep.global.dispatch", serde_json::json!({ "probe": true }));
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        wait_for_receiver_count(&fake.bus, 0).await;
+
+        // --- reconnect on the same listener ---
+        let (mut second, head) = connect_sse(addr).await;
+        assert!(head.contains("text/event-stream"), "head: {head:?}");
+        wait_for_receiver_count(&fake.bus, 1).await;
+
+        fake.bus
+            .publish(Event::SweepGlobalCompleted {
+                sweep_id: "sweep-4392".to_string(),
+                outcome: SweepOutcome::Exited,
+            })
+            .expect("publish");
+        let body = read_until(&mut second, "sweep.global.completed").await;
+        assert!(
+            body.contains("sweep.global.completed"),
+            "reconnected client must receive live events: {body:?}"
+        );
+
+        // The listener survived the disconnect: /api/status still answers.
+        assert!(!server_task.is_finished(), "the serve loop must survive a client disconnect");
+
+        server_task.abort();
+    }
+
+    #[tokio::test]
+    async fn sse_endpoint_returns_503_when_the_daemon_is_unreachable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket_path = dir.path().join("nonexistent.sock");
+        let tcp_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("bind tcp");
+        let addr = tcp_listener.local_addr().expect("local addr");
+        let server_task = tokio::spawn(run(tcp_listener, socket_path));
+
+        let (status, body) = http_get(addr, "/api/events").await;
+        assert_eq!(status, 503, "body: {body:?}");
+        assert!(body.contains("daemon unreachable"), "body: {body:?}");
+
+        server_task.abort();
+    }
+
+    #[tokio::test]
+    async fn sse_endpoint_rejects_non_get_methods() {
+        let fake = spawn_fake_event_daemon().await;
+        let tcp_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("bind tcp");
+        let addr = tcp_listener.local_addr().expect("local addr");
+        let server_task = tokio::spawn(run(tcp_listener, fake.socket_path.clone()));
+
+        let mut stream = TcpStream::connect(addr).await.expect("connect");
+        stream
+            .write_all(b"POST /api/events HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+            .await
+            .expect("write request");
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.expect("read response");
+        let text = String::from_utf8_lossy(&buf);
+        assert!(text.starts_with("HTTP/1.1 405"), "response: {text:?}");
+        // Read-only invariant: a rejected write attempt never reaches the bus.
+        assert_eq!(fake.bus.receiver_count(), 0);
+
+        server_task.abort();
     }
 }


### PR DESCRIPTION
Closes #4392

## Summary

Adds `GET /api/events`, a Server-Sent Events (SSE) endpoint on the same `loom-daemon serve` listener phase 1 (#4391) added, streaming the daemon's event bus as `text/event-stream` frames.

- The SSE bridge subscribes to the daemon over the *existing* Unix socket via `Request::SubscribeEvents` — the same IPC verb `stream_events` already answers — so topic-prefix filtering runs exactly once, in `EventBus::subscribe`/`topic_matches`, never re-implemented here.
- Streams all six frozen v0.10.0 topics: `sweep.issue.{N}.phase/blocker/exited/crashed`, `sweep.global.dispatch/completed`.
- Also streams the already-authorized optional follow-up topics (`epic.issue.*`, `daemon.capacity.advisory`, `daemon.drain.*`, `daemon.dispatch.headroom_advisory`) — each frame carries its exact source topic verbatim, so these are never confused with the frozen `sweep.*` set.
- Read-only invariant: the bridge only ever sends `SubscribeEvents`; it never constructs or publishes an `Event`.
- No new bind, no new port, no opt-in knob — routed off the same `TcpListener` `/api/status` already answers, inheriting phase 1's `validate_bind` posture unchanged.
- No persistent store; no replay buffer (no `id:` field on frames — reconnects resume from live, matching the "no new persistent store" constraint).
- Heartbeat comment every 15s to keep intermediaries from reaping idle connections and to detect a gone-away client even when the bus is silent.

## Test plan

- Unit: frame translation (topic passthrough, no renaming, no invented topics), response-line parsing (batched/garbage/error lines), SSE response head shape.
- Integration: live daemon-bus round trip on an ephemeral port — publishes a `sweep.global.dispatch` event and asserts delivery; asserts all six frozen topics arrive while a non-taxonomy topic is filtered out.
- Edge case: client disconnect releases the upstream subscription (`EventBus::receiver_count()` returns to 0) and a fresh client on the same listener reconnects and receives live events; the serve loop survives the disconnect.
- Also verified: 405 on non-GET, 503 JSON body when the daemon socket is unreachable, read-only invariant holds (bus receiver count stays 0 on a rejected write attempt).

All 1887 daemon lib tests pass; `cargo clippy --all-targets -- -D warnings` is clean.

## Out of scope (later phases)

- HTML page consuming the stream (phase 3, #4393).
- Docs (phase 4, #4394).