### PR TITLE
feat(daemon): ETag-cached REST listings for the hot polls — unchanged polls cost zero rate limit

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -2327,6 +2327,15 @@ To disable it entirely, set `LOOM_RATE_LIMIT_BREAKER=0` or
 `autonomous.rateLimitBreaker.enabled = false` (the pre-#4429
 hammer-through-exhaustion behavior).
 
+**Steady-state consumption** is attacked separately (#4428): the hot polls
+(work-finder `loom:issue`, claim reconciliation `loom:building`, epic
+supervisor `loom:epic`/`loom:epic-phase`) go through an ETag-cached REST
+listing (`forge_listing`) instead of GraphQL `gh issue list` — a poll where
+nothing changed answers `304 Not Modified`, which costs **zero** rate limit.
+The cache is in-memory, per (workspace, query), for the daemon's lifetime; a
+restart re-fetches each listing once. PR-side claim listings stay on
+`gh pr list` (they need `headRefName`, which REST issue rows do not carry).
+
 ### Cross-host dispatch-collision baseline (#4085, Phase 0 of #4028)
 
 When two `loom-daemon` hosts share one repo backlog, both can dispatch the same

--- a/loom-daemon/src/claim_reconciliation.rs
+++ b/loom-daemon/src/claim_reconciliation.rs
@@ -739,44 +739,20 @@ pub mod forge {
     use std::path::Path;
     use std::process::{Command, Stdio};
 
-    #[derive(Debug, Deserialize)]
-    struct GhBuildingIssue {
-        number: u32,
-        #[serde(rename = "updatedAt", default)]
-        updated_at: Option<String>,
-    }
-
     fn list_building_issues(gh_bin: &Path, root: &Path) -> Result<Vec<BuildingIssue>> {
-        let mut cmd = Command::new(gh_bin);
-        cmd.arg("issue")
-            .arg("list")
-            .arg("--label")
-            .arg("loom:building")
-            .arg("--state")
-            .arg("open")
-            .arg("--limit")
-            .arg(MAX_ISSUES_PER_WORKSPACE.to_string())
-            .arg("--json")
-            .arg("number,updatedAt");
-        cmd.current_dir(root);
-        if let Ok(repo) = std::env::var("LOOM_REPO") {
-            cmd.arg("--repo").arg(repo);
-        }
-        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
-        let out = cmd
-            .output()
-            .with_context(|| format!("failed to invoke {}", gh_bin.display()))?;
-        if !out.status.success() {
-            return Err(anyhow!(
-                "gh issue list --label loom:building failed in {}: {}",
-                root.display(),
-                String::from_utf8_lossy(&out.stderr).trim()
-            ));
-        }
-        let rows: Vec<GhBuildingIssue> =
-            serde_json::from_slice(&out.stdout).context("parse gh issue list JSON")?;
+        // ETag-cached REST listing (#4428): an unchanged claim set costs zero
+        // rate limit (304). `LOOM_REPO` precedence is handled inside; the
+        // `pull_request` filter keeps the pre-#4428 issue-only semantics.
+        let rows = crate::forge_listing::list_issues_cached(
+            gh_bin,
+            Some(root),
+            None,
+            "loom:building",
+            "open",
+        )?;
         Ok(rows
             .into_iter()
+            .filter(|r| !r.is_pull_request)
             .map(|r| BuildingIssue {
                 number: r.number,
                 updated_at: r
@@ -1597,31 +1573,13 @@ mod tests {
         journal.entries.push(journal_entry(&repo_str, 99, 0));
         sweep_journal::save(&journal_path, &journal).unwrap();
 
-        // Fake `gh`: `issue list` reports one loom:building issue labeled
-        // *just now* -- fresh enough that the NoRecordStale (age-based) path
-        // would say Keep. Only the DeadPid evidence should trigger a reclaim.
+        // Fake `gh`: the REST listing (#4428) reports one loom:building issue
+        // labeled *just now* -- fresh enough that the NoRecordStale
+        // (age-based) path would say Keep. Only the DeadPid evidence should
+        // trigger a reclaim.
         let gh_log = dir.path().join("gh-invocations.log");
-        let fake_gh = dir.path().join("fake-gh.sh");
         let now = Utc::now().to_rfc3339();
-        let script = format!(
-            r#"#!/usr/bin/env bash
-printf '%s\n' "$*" >> "{log}"
-if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
-  echo '[{{"number":99,"updatedAt":"{now}"}}]'
-  exit 0
-fi
-exit 0
-"#,
-            log = gh_log.display(),
-            now = now,
-        );
-        std::fs::write(&fake_gh, &script).unwrap();
-        #[cfg(unix)]
-        {
-            let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();
-            perms.set_mode(0o755);
-            std::fs::set_permissions(&fake_gh, perms).unwrap();
-        }
+        let fake_gh = write_fake_gh(dir.path(), &gh_log, 99, &now);
 
         let (checked, reclaimed) = forge::reconcile_workspace(&fake_gh, &repo_root);
 
@@ -1653,10 +1611,13 @@ exit 0
     // ------------------------------------------------------------------
 
     /// Write a fake `gh` script (tests only) that logs every invocation to
-    /// `gh_log` and, for `issue list`, reports exactly one `loom:building`
-    /// issue (`issue_number`, `updated_at`). Every other subcommand (e.g.
-    /// `issue edit`) just logs and exits 0 -- a test asserts on `gh_log`'s
-    /// contents to see whether a reclaim was actually attempted.
+    /// `gh_log` and, for the ETag-cached REST listing (`gh api …/issues?…`,
+    /// #4428), reports exactly one `loom:building` issue (`issue_number`,
+    /// `updated_at`) as an `--include`-style HTTP response with **no ETag**
+    /// (so the process-global cache never carries state across tests). Every
+    /// other subcommand (e.g. `issue edit`) just logs and exits 0 -- a test
+    /// asserts on `gh_log`'s contents to see whether a reclaim was actually
+    /// attempted.
     fn write_fake_gh(
         dir: &std::path::Path,
         gh_log: &std::path::Path,
@@ -1667,8 +1628,9 @@ exit 0
         let script = format!(
             r#"#!/usr/bin/env bash
 printf '%s\n' "$*" >> "{log}"
-if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
-  echo '[{{"number":{issue_number},"updatedAt":"{updated_at}"}}]'
+if [ "$1" = "api" ]; then
+  printf 'HTTP/2.0 200 OK\r\n\r\n'
+  echo '[{{"number":{issue_number},"state":"open","labels":[{{"name":"loom:building"}}],"updated_at":"{updated_at}"}}]'
   exit 0
 fi
 exit 0

--- a/loom-daemon/src/epic_supervisor.rs
+++ b/loom-daemon/src/epic_supervisor.rs
@@ -1304,34 +1304,30 @@ pub mod forge {
         }
 
         fn gh_json(&self, label: &str, state: &str) -> Result<Vec<GhIssue>> {
-            let mut cmd = Command::new(&self.gh_bin);
-            cmd.arg("issue")
-                .arg("list")
-                .arg("--label")
-                .arg(label)
-                .arg("--state")
-                .arg(state)
-                .arg("--limit")
-                .arg("200")
-                .arg("--json")
-                .arg("number,body,state,labels");
-            if let Some(ref repo) = self.repo {
-                cmd.arg("--repo").arg(repo);
-            }
-            if let Some(ref cwd) = self.cwd {
-                cmd.current_dir(cwd);
-            }
-            cmd.stderr(Stdio::piped());
-            let out = cmd
-                .output()
-                .with_context(|| format!("failed to invoke {}", self.gh_bin.display()))?;
-            if !out.status.success() {
-                return Err(anyhow!(
-                    "gh issue list --label {label} failed: {}",
-                    String::from_utf8_lossy(&out.stderr).trim()
-                ));
-            }
-            serde_json::from_slice(&out.stdout).context("parse gh issue list JSON")
+            // ETag-cached REST listing (#4428): unchanged epic sets cost zero
+            // rate limit (304). REST reports state lowercase (`"open"` vs
+            // GraphQL's `"OPEN"`) — `EpicSnapshot::is_open` compares
+            // case-insensitively, so both forms are safe. The `pull_request`
+            // filter keeps the pre-#4428 issue-only semantics.
+            let rows = crate::forge_listing::list_issues_cached(
+                &self.gh_bin,
+                self.cwd.as_deref(),
+                self.repo.as_deref(),
+                label,
+                state,
+            )?;
+            Ok(rows
+                .into_iter()
+                .filter(|r| !r.is_pull_request)
+                .map(|r| GhIssue {
+                    number: r.number,
+                    // REST `body` is nullable; the GraphQL-era parse defaulted
+                    // an absent body to empty, so keep that semantics.
+                    body: r.body.unwrap_or_default(),
+                    state: r.state,
+                    labels: r.labels.into_iter().map(|name| GhLabel { name }).collect(),
+                })
+                .collect())
         }
     }
 

--- a/loom-daemon/src/forge_listing.rs
+++ b/loom-daemon/src/forge_listing.rs
@@ -190,9 +190,7 @@ pub fn parse_http_response(raw: &str) -> Option<HttpResponse> {
     let status: u16 = parts.next()?.parse().ok()?;
 
     let mut etag = None;
-    let mut header_len = status_line.len() + 1;
     for line in lines {
-        header_len += line.len() + 1;
         let trimmed = line.trim_end_matches('\r');
         if trimmed.is_empty() {
             break;
@@ -203,10 +201,20 @@ pub fn parse_http_response(raw: &str) -> Option<HttpResponse> {
             }
         }
     }
-    let body = raw
-        .get(header_len.min(raw.len())..)
-        .unwrap_or("")
-        .to_string();
+    // Locate the header/body boundary directly on the raw text rather than
+    // reconstructing the header block's length line-by-line: `str::lines()`
+    // strips a `\r\n` terminator as ONE line ending, so a per-line
+    // `len() + 1` sum undercounts every CRLF-terminated header by a byte
+    // and corrupts the body slice on any real (~20-header) response — the
+    // #4443-review bug. Searching for the blank-line separator is
+    // terminator-width-agnostic; the earliest match wins so a CRLF header
+    // block is never mis-split by a later LF-only sequence in the body.
+    let body = ["\r\n\r\n", "\n\n"]
+        .iter()
+        .filter_map(|sep| raw.find(sep).map(|idx| (idx, idx + sep.len())))
+        .min_by_key(|&(idx, _)| idx)
+        .map(|(_, body_start)| raw[body_start..].to_string())
+        .unwrap_or_default();
     Some(HttpResponse { status, etag, body })
 }
 
@@ -295,6 +303,73 @@ mod tests {
         let r = parse_http_response(raw).unwrap();
         assert_eq!(r.status, 304);
         assert!(r.body.trim().is_empty());
+    }
+
+    /// Regression for the #4443 review finding: a response with GitHub's real
+    /// ~20-header block (CRLF terminators) must split headers/body exactly.
+    /// The old line-length reconstruction undercounted each `\r\n` header by
+    /// one byte, so the "body" started inside the header block (e.g.
+    /// `"58\r\nX-Xss-Protection: 0\r\n\r\n[{…"`) and every real 200 fetch
+    /// failed to parse — masked in the small fixtures above because their
+    /// few stray bytes were pure whitespace that `trim()` swallowed.
+    #[test]
+    fn parses_realistic_multi_header_crlf_response() {
+        let headers = [
+            "HTTP/2.0 200 OK",
+            "Access-Control-Allow-Origin: *",
+            "Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, \
+             X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, \
+             X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, \
+             X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset, Warning",
+            "Cache-Control: private, max-age=60, s-maxage=60",
+            "Content-Security-Policy: default-src 'none'",
+            "Content-Type: application/json; charset=utf-8",
+            "Etag: W/\"6289abc123def\"",
+            "Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin",
+            "Server: github.com",
+            "Strict-Transport-Security: max-age=31536000; includeSubdomains; preload",
+            "Vary: Accept, Authorization, Cookie, X-GitHub-OTP",
+            "X-Accepted-Oauth-Scopes: repo",
+            "X-Content-Type-Options: nosniff",
+            "X-Frame-Options: deny",
+            "X-Github-Api-Version-Selected: 2022-11-28",
+            "X-Github-Media-Type: github.v3; format=json",
+            "X-Github-Request-Id: E5E5:1234:ABCDEF:FEDCBA:66A7B8C9",
+            "X-Oauth-Scopes: gist, read:org, repo, workflow",
+            "X-Ratelimit-Limit: 5000",
+            "X-Ratelimit-Remaining: 4034",
+            "X-Ratelimit-Reset: 1785356436",
+            "X-Ratelimit-Resource: core",
+            "X-Ratelimit-Used: 966",
+            "Content-Length: 58",
+            "X-Xss-Protection: 0",
+        ]
+        .join("\r\n");
+        let body_json =
+            r#"[{"number": 4441, "state": "open", "labels": [{"name": "loom:issue"}]}]"#;
+        let raw = format!("{headers}\r\n\r\n{body_json}");
+
+        let r = parse_http_response(&raw).unwrap();
+        assert_eq!(r.status, 200);
+        assert_eq!(r.etag.as_deref(), Some("W/\"6289abc123def\""));
+        assert_eq!(
+            r.body, body_json,
+            "the body must be EXACTLY the JSON payload — no header-tail bytes"
+        );
+        let issues = parse_rest_issues(&r.body).unwrap();
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].number, 4441);
+    }
+
+    /// The boundary search must not be confused by an LF-only pair occurring
+    /// AFTER the CRLF header/body boundary (e.g. inside a JSON string value).
+    #[test]
+    fn crlf_boundary_wins_over_later_lf_pair_in_body() {
+        let raw = "HTTP/2.0 200 OK\r\nEtag: \"x\"\r\n\r\n[{\"number\": 1, \"state\": \"open\", \
+                   \"labels\": [], \"body\": \"line1\\n\\nline2\"}]";
+        let r = parse_http_response(raw).unwrap();
+        assert!(r.body.starts_with("[{"));
+        assert_eq!(parse_rest_issues(&r.body).unwrap()[0].number, 1);
     }
 
     #[test]

--- a/loom-daemon/src/forge_listing.rs
+++ b/loom-daemon/src/forge_listing.rs
@@ -1,0 +1,428 @@
+//! ETag-cached REST issue listing (Issue #4428).
+//!
+//! The daemon's hot polling loops (work-finder every 60s per workspace, epic
+//! supervisor every 300s, claim reconciliation every 600s) re-fetch issue
+//! lists that change rarely relative to their cadence. They previously went
+//! through `gh issue list` — **GraphQL**, which has no conditional-request
+//! mechanism, so every poll burned shared budget even when nothing changed
+//! (the 2026-07-29 exhaustion, #4429/#4432).
+//!
+//! The REST issues endpoint supports conditional requests: a `GET` with
+//! `If-None-Match: <etag>` that matches returns **304 Not Modified at zero
+//! rate-limit cost** (verified live: `x-ratelimit-remaining` unchanged across
+//! a 304). This module wraps `gh api` — keeping the daemon's zero-HTTP-client
+//! house style (`forge_cmd`) — with a process-lifetime ETag cache:
+//!
+//! - First fetch: `200` → parse, cache `(etag, issues)`, return.
+//! - Subsequent fetches: send `If-None-Match`; `304` → serve the cached
+//!   parse (free); `200` → something changed, re-cache, return.
+//!
+//! One deliberate semantic difference from `gh issue list`: REST
+//! `/repos/{owner}/{repo}/issues` returns **pull requests too** (marked with
+//! a `pull_request` key). [`RestIssue::is_pull_request`] carries the marker
+//! and every converted call site filters on it, so consumers see the same
+//! issue-only (or PR-only) sets as before.
+//!
+//! Scope: single page, `per_page=100` (the old `gh issue list --limit`
+//! ceilings were 100–200; a repo with >100 simultaneously-labeled items is
+//! far outside normal operation). A full page logs a truncation warning
+//! rather than silently capping.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::sync::{Mutex, OnceLock};
+
+use anyhow::{anyhow, Context, Result};
+
+/// One page's worth — matches GitHub's REST maximum and brackets the old
+/// `gh issue list --limit` values (100–200) used by the converted call sites.
+pub const PER_PAGE: usize = 100;
+
+/// An issue (or PR — see [`Self::is_pull_request`]) as returned by the REST
+/// `/repos/{owner}/{repo}/issues` listing, reduced to the union of fields the
+/// daemon's polling loops actually consume.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RestIssue {
+    pub number: u32,
+    /// Label names (flattened from the REST label objects).
+    pub labels: Vec<String>,
+    /// RFC-3339 creation timestamp. Lexicographic order == chronological.
+    pub created_at: Option<String>,
+    /// RFC-3339 last-update timestamp.
+    pub updated_at: Option<String>,
+    /// `"open"` / `"closed"` (REST lowercase; compare case-insensitively —
+    /// GraphQL-era consumers saw `"OPEN"`).
+    pub state: String,
+    pub body: Option<String>,
+    /// Present when the row is actually a pull request (REST issue listings
+    /// include PRs). Call sites filter on this to keep pre-#4428 semantics.
+    pub is_pull_request: bool,
+}
+
+/// List open/closed issues carrying `label`, via the ETag cache.
+///
+/// - `cwd`: the workspace root `gh` resolves `{owner}/{repo}` placeholders
+///   from (its `git remote`). `None` uses the daemon's own cwd.
+/// - `repo_override`: an explicit `owner/repo` (from a `--repo`-style caller
+///   knob); when absent, the `LOOM_REPO` env var is honored — the same
+///   precedence the previous `gh issue list` call sites applied.
+/// - `state`: `"open"`, `"closed"`, or `"all"` (REST accepts all three).
+///
+/// Errors carry the `gh` stderr tail so [`crate::rate_limit_breaker`]'s
+/// classifier sees rate-limit text unchanged.
+pub fn list_issues_cached(
+    gh_bin: &Path,
+    cwd: Option<&Path>,
+    repo_override: Option<&str>,
+    label: &str,
+    state: &str,
+) -> Result<Vec<RestIssue>> {
+    let env_repo = std::env::var("LOOM_REPO").ok();
+    let repo = repo_override.or(env_repo.as_deref());
+    let url = build_issues_url(repo, label, state);
+    // The cache key must include the resolution context: with the
+    // `{owner}/{repo}` placeholder form, the SAME url string resolves to
+    // DIFFERENT repos depending on `cwd`.
+    let cache_key = format!(
+        "{}|{url}",
+        cwd.map(Path::display)
+            .map_or_else(String::new, |d| d.to_string())
+    );
+
+    let cached_etag = cache()
+        .lock()
+        .ok()
+        .and_then(|c| c.get(&cache_key).map(|e| e.etag.clone()));
+
+    let mut cmd = Command::new(gh_bin);
+    cmd.arg("api").arg("--include").arg(&url);
+    if let Some(ref etag) = cached_etag {
+        cmd.arg("-H").arg(format!("If-None-Match: {etag}"));
+    }
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let out = cmd
+        .output()
+        .with_context(|| format!("failed to invoke {}", gh_bin.display()))?;
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let response = parse_http_response(&stdout);
+
+    match response {
+        Some(ref r) if r.status == 304 => {
+            // Free cache hit (a 304 does not count against the rate limit).
+            if let Ok(guard) = cache().lock() {
+                if let Some(entry) = guard.get(&cache_key) {
+                    log::debug!("forge_listing: 304 cache hit for {url}");
+                    return Ok(entry.issues.clone());
+                }
+            }
+            // A 304 can only happen because WE sent the etag, so the entry
+            // existing is an invariant; if it is somehow gone, drop the etag
+            // path and error so the next call re-fetches unconditionally.
+            if let Ok(mut guard) = cache().lock() {
+                guard.remove(&cache_key);
+            }
+            Err(anyhow!(
+                "forge_listing: 304 for {url} but the cache entry vanished; will re-fetch"
+            ))
+        }
+        Some(ref r) if r.status == 200 && out.status.success() => {
+            let issues = parse_rest_issues(&r.body)
+                .with_context(|| format!("parse REST issues JSON from {url}"))?;
+            if issues.len() >= PER_PAGE {
+                log::warn!(
+                    "forge_listing: {url} returned a full page ({PER_PAGE}); the listing may be \
+                     truncated — items beyond the first page are not seen this poll"
+                );
+            }
+            if let (Some(etag), Ok(mut guard)) = (r.etag.clone(), cache().lock()) {
+                guard.insert(
+                    cache_key,
+                    CacheEntry {
+                        etag,
+                        issues: issues.clone(),
+                    },
+                );
+            }
+            Ok(issues)
+        }
+        _ => Err(anyhow!(
+            "gh api {url} failed{}: {}",
+            cwd.map(|d| format!(" in {}", d.display()))
+                .unwrap_or_default(),
+            String::from_utf8_lossy(&out.stderr).trim()
+        )),
+    }
+}
+
+/// Build the REST listing URL. With no explicit repo, gh's
+/// `{owner}/{repo}` placeholders resolve from the `cwd` repo's remote.
+#[must_use]
+pub fn build_issues_url(repo: Option<&str>, label: &str, state: &str) -> String {
+    let repo_path = repo.unwrap_or("{owner}/{repo}");
+    format!("repos/{repo_path}/issues?labels={label}&state={state}&per_page={PER_PAGE}")
+}
+
+/// A parsed `gh api --include` response: the status from the first
+/// `HTTP/x.y NNN` line, the `ETag` header, and the body (everything past the
+/// first blank line).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpResponse {
+    pub status: u16,
+    pub etag: Option<String>,
+    pub body: String,
+}
+
+/// Parse `gh api --include` output. Returns `None` when the first line is not
+/// an HTTP status line (e.g. gh failed before issuing the request).
+#[must_use]
+pub fn parse_http_response(raw: &str) -> Option<HttpResponse> {
+    let mut lines = raw.lines();
+    let status_line = lines.next()?;
+    let mut parts = status_line.split_whitespace();
+    let proto = parts.next()?;
+    if !proto.starts_with("HTTP/") {
+        return None;
+    }
+    let status: u16 = parts.next()?.parse().ok()?;
+
+    let mut etag = None;
+    let mut header_len = status_line.len() + 1;
+    for line in lines {
+        header_len += line.len() + 1;
+        let trimmed = line.trim_end_matches('\r');
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some((name, value)) = trimmed.split_once(':') {
+            if name.eq_ignore_ascii_case("etag") {
+                etag = Some(value.trim().to_string());
+            }
+        }
+    }
+    let body = raw
+        .get(header_len.min(raw.len())..)
+        .unwrap_or("")
+        .to_string();
+    Some(HttpResponse { status, etag, body })
+}
+
+/// Parse a REST issues-listing body into [`RestIssue`]s.
+#[must_use = "parse failures must surface as listing errors"]
+pub fn parse_rest_issues(body: &str) -> Result<Vec<RestIssue>> {
+    #[derive(serde::Deserialize)]
+    struct RawLabel {
+        name: String,
+    }
+    #[derive(serde::Deserialize)]
+    struct RawIssue {
+        number: u32,
+        #[serde(default)]
+        labels: Vec<RawLabel>,
+        #[serde(default)]
+        created_at: Option<String>,
+        #[serde(default)]
+        updated_at: Option<String>,
+        #[serde(default)]
+        state: String,
+        #[serde(default)]
+        body: Option<String>,
+        #[serde(default)]
+        pull_request: Option<serde_json::Value>,
+    }
+    let rows: Vec<RawIssue> = serde_json::from_str(body.trim())?;
+    Ok(rows
+        .into_iter()
+        .map(|r| RestIssue {
+            number: r.number,
+            labels: r.labels.into_iter().map(|l| l.name).collect(),
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+            state: r.state,
+            body: r.body,
+            is_pull_request: r.pull_request.is_some(),
+        })
+        .collect())
+}
+
+// ============================================================================
+// Process-lifetime cache
+// ============================================================================
+
+#[derive(Debug, Clone)]
+struct CacheEntry {
+    etag: String,
+    issues: Vec<RestIssue>,
+}
+
+/// Process-global ETag cache: one entry per (cwd, url). Process-lifetime is
+/// the right scope — a daemon restart re-fetches each listing exactly once,
+/// and the cache can never serve across identities (one gh credential per
+/// daemon process).
+fn cache() -> &'static Mutex<HashMap<String, CacheEntry>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, CacheEntry>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // ===== parse_http_response =====
+
+    const OK_RESPONSE: &str = "HTTP/2.0 200 OK\r\n\
+        Etag: W/\"abc123\"\r\n\
+        X-Ratelimit-Remaining: 4034\r\n\
+        \r\n\
+        [{\"number\": 7}]";
+
+    #[test]
+    fn parses_200_with_etag_and_body() {
+        let r = parse_http_response(OK_RESPONSE).unwrap();
+        assert_eq!(r.status, 200);
+        assert_eq!(r.etag.as_deref(), Some("W/\"abc123\""));
+        assert_eq!(r.body.trim(), "[{\"number\": 7}]");
+    }
+
+    #[test]
+    fn parses_304_without_body() {
+        let raw = "HTTP/2.0 304 Not Modified\r\nCache-Control: private, max-age=60\r\n\r\n";
+        let r = parse_http_response(raw).unwrap();
+        assert_eq!(r.status, 304);
+        assert!(r.body.trim().is_empty());
+    }
+
+    #[test]
+    fn rejects_non_http_output() {
+        assert!(parse_http_response("gh: command not found").is_none());
+        assert!(parse_http_response("").is_none());
+    }
+
+    #[test]
+    fn header_parse_survives_lf_only_lines() {
+        let raw = "HTTP/1.1 200 OK\nEtag: \"x\"\n\n[]";
+        let r = parse_http_response(raw).unwrap();
+        assert_eq!(r.status, 200);
+        assert_eq!(r.etag.as_deref(), Some("\"x\""));
+        assert_eq!(r.body, "[]");
+    }
+
+    // ===== parse_rest_issues =====
+
+    #[test]
+    fn parses_issues_and_marks_pull_requests() {
+        let body = r#"[
+            {"number": 42, "state": "open",
+             "labels": [{"name": "loom:issue"}, {"name": "tier:goal-supporting"}],
+             "created_at": "2026-07-29T00:00:00Z", "updated_at": "2026-07-29T01:00:00Z",
+             "body": "the body"},
+            {"number": 43, "state": "open", "labels": [],
+             "pull_request": {"url": "https://api.github.com/repos/o/r/pulls/43"}}
+        ]"#;
+        let issues = parse_rest_issues(body).unwrap();
+        assert_eq!(issues.len(), 2);
+        assert_eq!(issues[0].number, 42);
+        assert_eq!(issues[0].labels, vec!["loom:issue", "tier:goal-supporting"]);
+        assert!(!issues[0].is_pull_request);
+        assert_eq!(issues[0].state, "open");
+        assert!(issues[1].is_pull_request);
+    }
+
+    #[test]
+    fn rejects_malformed_bodies() {
+        assert!(parse_rest_issues("not json").is_err());
+        assert!(parse_rest_issues("{\"not\": \"an array\"}").is_err());
+    }
+
+    // ===== build_issues_url =====
+
+    #[test]
+    fn url_uses_placeholders_without_override_and_repo_with() {
+        assert_eq!(
+            build_issues_url(None, "loom:issue", "open"),
+            "repos/{owner}/{repo}/issues?labels=loom:issue&state=open&per_page=100"
+        );
+        assert_eq!(
+            build_issues_url(Some("rjwalters/loom"), "loom:epic-phase", "all"),
+            "repos/rjwalters/loom/issues?labels=loom:epic-phase&state=all&per_page=100"
+        );
+    }
+
+    // ===== end-to-end cache flow with a fake gh =====
+
+    /// A fake `gh` that returns 200+ETag+body on the first call and, when the
+    /// caller presents that ETag, 304 + exit 1 (mirroring real gh) after.
+    fn write_fake_gh(dir: &Path) -> PathBuf {
+        let path = dir.join("fake-gh.sh");
+        let body = r#"#!/bin/sh
+case "$*" in
+  *'If-None-Match: W/"round1"'*)
+    printf 'HTTP/2.0 304 Not Modified\r\n\r\n'
+    echo 'gh: Not Modified (HTTP 304)' 1>&2
+    exit 1
+    ;;
+  *)
+    printf 'HTTP/2.0 200 OK\r\nEtag: W/"round1"\r\n\r\n'
+    printf '[{"number": 7, "state": "open", "labels": [{"name": "loom:issue"}]}]\n'
+    ;;
+esac
+"#;
+        std::fs::write(&path, body).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&path, perms).unwrap();
+        }
+        path
+    }
+
+    #[test]
+    fn caches_etag_and_serves_304_from_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let gh = write_fake_gh(dir.path());
+        // A unique repo string keys this test's cache slot so parallel tests
+        // (and reruns in one process) never collide.
+        let repo = format!("test/etag-flow-{}", std::process::id());
+
+        // Round 1: 200 → parsed + cached.
+        let first =
+            list_issues_cached(&gh, Some(dir.path()), Some(&repo), "loom:issue", "open").unwrap();
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].number, 7);
+
+        // Round 2: fake gh sees our If-None-Match and answers 304 + exit 1;
+        // the listing must come back identical, straight from the cache.
+        let second =
+            list_issues_cached(&gh, Some(dir.path()), Some(&repo), "loom:issue", "open").unwrap();
+        assert_eq!(second, first);
+    }
+
+    #[test]
+    fn errors_carry_stderr_for_the_rate_limit_classifier() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fake-gh.sh");
+        std::fs::write(
+            &path,
+            "#!/bin/sh\necho 'gh: API rate limit exceeded for user ID 1 (HTTP 403)' 1>&2\nexit 1\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&path, perms).unwrap();
+        }
+        let repo = format!("test/limit-{}", std::process::id());
+        let err = list_issues_cached(&path, Some(dir.path()), Some(&repo), "loom:issue", "open")
+            .unwrap_err();
+        assert!(crate::rate_limit_breaker::indicates_rate_limit(&err.to_string()));
+    }
+}

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -28,6 +28,7 @@ pub mod errors;
 pub mod event_bus;
 pub mod fleet;
 pub mod forge_cmd;
+pub mod forge_listing;
 pub mod forge_parser;
 pub mod git_parser;
 pub mod git_utils;

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -1971,30 +1971,10 @@ pub mod forge {
     use super::{WorkDispatcher, WorkItem, WorkSource};
     use crate::sweep_registry::SweepRegistry;
     use crate::types::{SweepKind, SweepState};
-    use anyhow::{anyhow, Context, Result};
-    use serde::Deserialize;
+    use anyhow::{anyhow, Result};
     use std::collections::HashSet;
     use std::path::{Path, PathBuf};
-    use std::process::{Command, Stdio};
     use std::sync::{Arc, Mutex};
-
-    /// Minimal `gh issue list --json number,labels,createdAt` row.
-    #[derive(Debug, Deserialize)]
-    struct GhIssue {
-        number: u32,
-        #[serde(default)]
-        labels: Vec<GhLabel>,
-        /// Issue creation timestamp for age ordering (#3946). `#[serde(default)]`
-        /// tolerates older `gh` output that omits it (the item then sorts by
-        /// number as its age proxy).
-        #[serde(rename = "createdAt", default)]
-        created_at: Option<String>,
-    }
-
-    #[derive(Debug, Deserialize)]
-    struct GhLabel {
-        name: String,
-    }
 
     /// A forge-backed [`WorkSource`] that lists open `loom:issue` items via
     /// `gh`. Mirrors [`crate::epic_supervisor::forge::GhEpicSource`].
@@ -2052,44 +2032,21 @@ pub mod forge {
 
     impl WorkSource for GhWorkSource {
         fn list_ready_issues(&mut self) -> Result<Vec<WorkItem>> {
-            let mut cmd = Command::new(&self.gh_bin);
-            cmd.arg("issue")
-                .arg("list")
-                .arg("--label")
-                .arg("loom:issue")
-                .arg("--state")
-                .arg("open")
-                .arg("--limit")
-                .arg("200")
-                .arg("--json")
-                .arg("number,labels,createdAt");
-            if let Some(ref repo) = self.repo {
-                cmd.arg("--repo").arg(repo);
-            }
-            if let Some(ref cwd) = self.cwd {
-                cmd.current_dir(cwd);
-            }
-            cmd.stderr(Stdio::piped());
-            let out = cmd
-                .output()
-                .with_context(|| format!("failed to invoke {}", self.gh_bin.display()))?;
-            if !out.status.success() {
-                return Err(anyhow!(
-                    "gh issue list --label loom:issue failed: {}",
-                    String::from_utf8_lossy(&out.stderr).trim()
-                ));
-            }
-            let rows: Vec<GhIssue> =
-                serde_json::from_slice(&out.stdout).context("parse gh issue list JSON")?;
+            // ETag-cached REST listing (#4428): a poll where nothing changed
+            // costs zero rate limit (304), replacing the per-tick GraphQL
+            // `gh issue list`. REST issue listings include PRs, so filter the
+            // `pull_request`-marked rows to keep the pre-#4428 issue-only set.
+            let rows = crate::forge_listing::list_issues_cached(
+                &self.gh_bin,
+                self.cwd.as_deref(),
+                self.repo.as_deref(),
+                "loom:issue",
+                "open",
+            )?;
             Ok(rows
                 .into_iter()
-                .map(|r| {
-                    WorkItem::with_created_at(
-                        r.number,
-                        r.labels.into_iter().map(|l| l.name).collect(),
-                        r.created_at,
-                    )
-                })
+                .filter(|r| !r.is_pull_request)
+                .map(|r| WorkItem::with_created_at(r.number, r.labels, r.created_at))
                 .collect())
         }
     }


### PR DESCRIPTION
Closes #4428. Companion to #4440 (the #4429 breaker, merged): that one stops the bleeding during exhaustion; this one cuts steady-state consumption so exhaustion stops happening.

## Problem

The daemon's hot polls — work-finder (`loom:issue`, 60s × workspaces), epic supervisor (`loom:epic`/`loom:epic-phase`, 300s), claim reconciliation (`loom:building`, 600s) — re-fetch lists that change rarely relative to their cadence, via GraphQL `gh issue list`, which has **no conditional-request mechanism**. Every poll burned shared budget even when nothing changed; the fleet exhausted GraphQL twice on 2026-07-29 (#4432).

## Change

New `forge_listing` module: wraps `gh api --include` (keeping the zero-HTTP-client house style) with a process-lifetime ETag cache keyed by (workspace, query).

- First fetch: `200` → parse + cache `(etag, issues)`.
- Later fetches send `If-None-Match`; `304` → served from cache at **zero rate-limit cost** — verified live against the real endpoint (`x-ratelimit-remaining` unchanged across a 304, 4034 → 4034).
- Errors carry the gh stderr tail, so #4440's rate-limit classifier sees exhaustion text unchanged; the two changes compose.

Converted call sites (each filters REST's `pull_request`-marked rows to keep issue-only semantics; `--repo`/`LOOM_REPO` precedence preserved): `work_finder::GhWorkSource::list_ready_issues`, `claim_reconciliation::forge::list_building_issues`, `epic_supervisor::GhEpicSource::gh_json` (REST lowercase `state` is safe — `is_open` compares case-insensitively).

Deliberately NOT converted: PR-side claim listings (`gh pr list` — REST issue rows lack `headRefName`), quarantine reconciliation (startup-only), pipeline snapshot (status-time). Single page `per_page=100` with a truncation warning on a full page (old `--limit` ceilings were 100–200) — no silent cap.

## Expected effect

Steady-state polling on an idle fleet drops to ~zero budget: every work-finder tick that finds nothing new is a 304. Label changes are picked up within one tick (ETag miss → fresh 200).

## Testing

- 9 new unit tests: HTTP response parsing (200/304/garbage, CRLF+LF), REST issue parsing + PR marking, URL building, and an end-to-end fake-gh cache flow (200 → cached → 304 served from cache) plus an error-text/classifier composition test with #4429's `indicates_rate_limit`.
- Updated the 4 claim-reconciliation fixtures that faked `gh issue list` to answer the REST form (ETag-free so the process-global cache never leaks across tests).
- Full `--lib` suite: 1908 passed; the only failures are pre-existing host-environment flakes (`disk_headroom::test_worktree_root_free_gb_returns_a_value` fails identically on pristine `origin/main` on this host; `tokens_pool` probes flake under live fleet load and pass on rerun).
- clippy `--all-targets` clean; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)