### PR TITLE
fix(scripts): check-duplicate.sh similarity saturates at 100% on full-body queries

### DIFF
--- a/defaults/scripts/check-duplicate.sh
+++ b/defaults/scripts/check-duplicate.sh
@@ -26,8 +26,25 @@
 #   #<number>: <title> (similarity: <percent>%)
 #   PR #<number>: <title> (similarity: <percent>%)
 #   ...
+#
+# Degenerate-result self-detection (#4409): if more than half of the
+# candidates scanned in a given search (open issues / merged PRs / closed
+# issues) score at/above --threshold, that search's similarity scores aren't
+# discriminating anything for this query. Its block prints NON_DISCRIMINATIVE
+# instead of DUPLICATE_FOUND (still exit code 1, so existing
+# `if ! check-duplicate.sh ...` callers still fall back to manual review --
+# they just should NOT treat the (absent) match list as real duplicates).
 
 set -euo pipefail
+
+# Minimum number of scanned candidates before degenerate-result
+# self-detection (#4409) kicks in. Below this, "more than half matched" is
+# not a meaningful signal -- e.g. with only 1 candidate scanned, a single
+# real match is trivially ">50%" even though nothing about the scorer is
+# actually broken. 4 is a low floor chosen to still catch the reported
+# failure mode (dozens of candidates ~all scoring at/above threshold) while
+# not misfiring on small candidate pools.
+readonly MIN_SCANNED_FOR_DEGENERATE=4
 
 # Forge-agnostic issue/PR operations via the native `loom-daemon forge`
 # subcommand (port of the retired `loom-forge`). On GitHub it is a byte-identical
@@ -82,7 +99,17 @@ USAGE:
 OPTIONS:
     --title TEXT            The title of the issue to check
     --body TEXT             The body/description of the issue (optional)
-    --threshold NUM         Similarity threshold percentage (default: 60)
+    --threshold NUM         Similarity threshold percentage, on a true Jaccard
+                             scale -- matches / |union| (default: 18). 60%+
+                             Jaccard is rarely reachable on richly-worded
+                             bodies; 18 is calibrated against real historical
+                             pairs from this repo (#4409): a confirmed
+                             duplicate (#3550/#3551) scored 19%, while
+                             unrelated richly-worded issues scored 4-13%.
+                             This is a noisy signal on long, jargon-heavy
+                             bodies (a second real duplicate pair scored only
+                             13%, indistinguishable from unrelated) -- treat
+                             a miss as inconclusive, not proof of no overlap.
     --include-merged-prs    Also check recently merged PRs and closed issues
     --issue N               Also probe for OPEN issues/PRs that cross-reference
                              issue N (GitHub timeline API). Curator use --
@@ -160,11 +187,35 @@ calculate_similarity() {
     local keywords1="$1"
     local keywords2="$2"
 
-    # Convert to arrays using read -ra for safe word splitting
+    # Convert the newline-delimited keyword lists (one keyword per line, from
+    # extract_keywords' `sort -u`) into arrays. NOTE (#4409): `read -ra arr <<<
+    # "$multiline_str"` looks like it splits on all IFS whitespace, but `read`
+    # only ever consumes a SINGLE LINE of its input -- everything after the
+    # first newline is silently discarded. Since each keyword already sits on
+    # its own line, that made arr1/arr2 collapse to a ONE-ELEMENT array (just
+    # the alphabetically-first keyword) for any multi-keyword input, turning
+    # every comparison into a coin flip on that one token (0% or 100%) instead
+    # of a real set comparison -- this is bash's `read` semantics in every
+    # version, not a bash-3.2-only quirk. `mapfile`/`readarray` would fix it
+    # but require bash 4+, which macOS's shipped `/bin/bash` (3.2) doesn't
+    # have; splitting on IFS=$'\n' via an unquoted array assignment works on
+    # both and keeps this script bash-3.2-safe.
+    # The unquoted array assignments below are the intended word split (one
+    # array element per keyword line) -- `set -f` around them neutralizes the
+    # linter's other concern (accidental pathname/glob expansion) even though
+    # extract_keywords' alnum-only filter already guarantees no keyword can
+    # contain a glob metacharacter.
     local -a arr1
     local -a arr2
-    read -ra arr1 <<< "$keywords1"
-    read -ra arr2 <<< "$keywords2"
+    local old_ifs="$IFS"
+    IFS=$'\n'
+    set -f
+    # shellcheck disable=SC2206 # unquoted-intentionally, see comment above
+    arr1=($keywords1)
+    # shellcheck disable=SC2206 # unquoted-intentionally, see comment above
+    arr2=($keywords2)
+    set +f
+    IFS="$old_ifs"
 
     # Handle empty arrays
     if [[ ${#arr1[@]} -eq 0 ]] || [[ ${#arr2[@]} -eq 0 ]]; then
@@ -183,14 +234,20 @@ calculate_similarity() {
         done
     done
 
-    # Calculate percentage based on smaller set (Jaccard-like)
-    local smaller=${#arr1[@]}
-    if [[ ${#arr2[@]} -lt $smaller ]]; then
-        smaller=${#arr2[@]}
+    # True Jaccard similarity: matches / |union| = matches / (|A|+|B|-matches).
+    # (Previously normalized by the SMALLER set: percent = matches*100/min(|A|,|B|).
+    # That normalization saturates near 100% whenever one set is much larger
+    # than the other -- e.g. a full issue body (hundreds of keywords) compared
+    # against a short candidate title+body: matches approaches |B| regardless
+    # of actual relatedness. True Jaccard is symmetric and bounded by the
+    # union, so a large query set dilutes rather than saturates. See #4409.)
+    local union=$(( ${#arr1[@]} + ${#arr2[@]} - matches ))
+    if [[ $union -eq 0 ]]; then
+        echo "0"
+        return
     fi
 
-    # Percentage of smaller set matched
-    local percent=$((matches * 100 / smaller))
+    local percent=$((matches * 100 / union))
     echo "$percent"
 }
 
@@ -198,7 +255,7 @@ calculate_similarity() {
 search_similar_issues() {
     local title="$1"
     local body="${2:-}"
-    local threshold="${3:-60}"
+    local threshold="${3:-18}"
 
     # Extract keywords from new issue
     local new_keywords
@@ -217,7 +274,8 @@ search_similar_issues() {
     fi
 
     # Process each issue for similarity
-    local found_duplicates=false
+    local scanned=0
+    local matched=0
     local duplicates=""
 
     while IFS= read -r issue; do
@@ -228,6 +286,7 @@ search_similar_issues() {
 
         # Skip if no number
         [[ -z "$num" || "$num" == "null" ]] && continue
+        scanned=$((scanned + 1))
 
         # Extract keywords from existing issue
         local existing_keywords
@@ -238,25 +297,34 @@ search_similar_issues() {
         similarity=$(calculate_similarity "$new_keywords" "$existing_keywords")
 
         if [[ $similarity -ge $threshold ]]; then
-            found_duplicates=true
+            matched=$((matched + 1))
             duplicates+="#${num}: ${title_text} (similarity: ${similarity}%)"$'\n'
         fi
     done < <(echo "$issues" | jq -c '.[]')
 
-    if $found_duplicates; then
-        echo "DUPLICATE_FOUND"
-        echo -n "$duplicates"
+    if [[ $matched -eq 0 ]]; then
+        return 0
+    fi
+
+    # Degenerate-result self-detection (#4409): if more than half of the
+    # scanned candidates exceed threshold, the similarity scores aren't
+    # discriminating anything for this query -- warn instead of dumping a
+    # wall of "duplicates" that's really just noise.
+    if [[ $scanned -ge $MIN_SCANNED_FOR_DEGENERATE ]] && (( matched * 2 > scanned )); then
+        echo "NON_DISCRIMINATIVE (open issues): ${matched} of ${scanned} candidates scored >= ${threshold}% similarity -- not discriminative, fall back to manual review (e.g. gh issue list --search)."
         return 1
     fi
 
-    return 0
+    echo "DUPLICATE_FOUND"
+    echo -n "$duplicates"
+    return 1
 }
 
 # Search for similar recently merged PRs
 search_merged_prs() {
     local title="$1"
     local body="${2:-}"
-    local threshold="${3:-60}"
+    local threshold="${3:-18}"
 
     # Extract keywords from new issue
     local new_keywords
@@ -274,7 +342,8 @@ search_merged_prs() {
     fi
 
     # Process each PR for similarity
-    local found_duplicates=false
+    local scanned=0
+    local matched=0
     local duplicates=""
 
     while IFS= read -r pr; do
@@ -285,6 +354,7 @@ search_merged_prs() {
 
         # Skip if no number
         [[ -z "$num" || "$num" == "null" ]] && continue
+        scanned=$((scanned + 1))
 
         # Extract keywords from existing PR
         local existing_keywords
@@ -295,21 +365,29 @@ search_merged_prs() {
         similarity=$(calculate_similarity "$new_keywords" "$existing_keywords")
 
         if [[ $similarity -ge $threshold ]]; then
-            found_duplicates=true
+            matched=$((matched + 1))
             duplicates+="PR #${num}: ${title_text} (similarity: ${similarity}%)"$'\n'
         fi
     done < <(echo "$prs" | jq -c '.[]')
 
-    if $found_duplicates; then
-        echo "$duplicates"
+    if [[ $matched -eq 0 ]]; then
+        return 0
     fi
+
+    # Degenerate-result self-detection (#4409), same as search_similar_issues.
+    if [[ $scanned -ge $MIN_SCANNED_FOR_DEGENERATE ]] && (( matched * 2 > scanned )); then
+        echo "NON_DISCRIMINATIVE (merged PRs): ${matched} of ${scanned} candidates scored >= ${threshold}% similarity -- not discriminative, fall back to manual review."
+        return 0
+    fi
+
+    echo -n "$duplicates"
 }
 
 # Search for similar recently closed issues
 search_closed_issues() {
     local title="$1"
     local body="${2:-}"
-    local threshold="${3:-60}"
+    local threshold="${3:-18}"
 
     # Extract keywords from new issue
     local new_keywords
@@ -327,7 +405,8 @@ search_closed_issues() {
     fi
 
     # Process each issue for similarity
-    local found_duplicates=false
+    local scanned=0
+    local matched=0
     local duplicates=""
 
     while IFS= read -r issue; do
@@ -338,6 +417,7 @@ search_closed_issues() {
 
         # Skip if no number
         [[ -z "$num" || "$num" == "null" ]] && continue
+        scanned=$((scanned + 1))
 
         # Extract keywords from existing issue
         local existing_keywords
@@ -348,14 +428,22 @@ search_closed_issues() {
         similarity=$(calculate_similarity "$new_keywords" "$existing_keywords")
 
         if [[ $similarity -ge $threshold ]]; then
-            found_duplicates=true
+            matched=$((matched + 1))
             duplicates+="Closed #${num}: ${title_text} (similarity: ${similarity}%)"$'\n'
         fi
     done < <(echo "$issues" | jq -c '.[]')
 
-    if $found_duplicates; then
-        echo "$duplicates"
+    if [[ $matched -eq 0 ]]; then
+        return 0
     fi
+
+    # Degenerate-result self-detection (#4409), same as search_similar_issues.
+    if [[ $scanned -ge $MIN_SCANNED_FOR_DEGENERATE ]] && (( matched * 2 > scanned )); then
+        echo "NON_DISCRIMINATIVE (closed issues): ${matched} of ${scanned} candidates scored >= ${threshold}% similarity -- not discriminative, fall back to manual review."
+        return 0
+    fi
+
+    echo -n "$duplicates"
 }
 
 # Probe for OPEN issues/PRs whose bodies or comments cross-reference the given
@@ -427,7 +515,7 @@ format_related_open_work() {
 main() {
     local title=""
     local body=""
-    local threshold=60
+    local threshold=18
     local json_output=false
     local include_merged_prs=false
     local issue=""
@@ -529,15 +617,26 @@ main() {
         # If we found matches in merged PRs or closed issues, flag as duplicate
         if [[ -n "$merged_result" || -n "$closed_result" ]]; then
             if [[ $exit_code -eq 0 ]]; then
-                # No open issue duplicates found, but merged/closed matches exist
-                result="DUPLICATE_FOUND"$'\n'
+                # No open issue duplicates found, but merged/closed matches
+                # exist. Only synthesize a "DUPLICATE_FOUND" umbrella header
+                # when at least one of merged/closed is a real match list --
+                # a degenerate (#4409) result already self-announces with its
+                # own "NON_DISCRIMINATIVE (...)" line, and prefixing THAT
+                # with "DUPLICATE_FOUND" would be misleading. Check each side
+                # independently (not "both must be non-degenerate") so a real
+                # match on one side still gets its header even when the other
+                # side is degenerate.
+                if [[ ( -n "$merged_result" && "$merged_result" != NON_DISCRIMINATIVE* ) || \
+                      ( -n "$closed_result" && "$closed_result" != NON_DISCRIMINATIVE* ) ]]; then
+                    result="DUPLICATE_FOUND"$'\n'
+                fi
                 exit_code=1
             fi
             if [[ -n "$merged_result" ]]; then
-                result+="$merged_result"
+                result+="$merged_result"$'\n'
             fi
             if [[ -n "$closed_result" ]]; then
-                result+="$closed_result"
+                result+="$closed_result"$'\n'
             fi
         fi
     fi
@@ -561,11 +660,22 @@ main() {
         if [[ $exit_code -eq 2 ]]; then
             echo '{"error": "Failed to check duplicates"}'
         else
+            # Degenerate-result flag (#4409): true when any search's
+            # candidate pool self-detected as non-discriminative (>50% of
+            # scanned candidates over threshold). Surfaced separately from
+            # `matches` so callers can distinguish a real duplicate list from
+            # noise instead of silently misreading one as the other.
+            local degenerate=false
+            if echo "$result" | grep -q '^NON_DISCRIMINATIVE'; then
+                degenerate=true
+            fi
+
             # Parse duplicates into JSON (unconditional -- harmless no-op on
             # an empty $result, e.g. exit_code 0 or "related work only")
             local matches="[]"
             while IFS= read -r line; do
                 [[ "$line" == "DUPLICATE_FOUND" ]] && continue
+                [[ "$line" == NON_DISCRIMINATIVE* ]] && continue
                 [[ -z "$line" ]] && continue
 
                 # Parse "#123: Title (similarity: 75%)" or "PR #123: Title (similarity: 75%)"
@@ -599,9 +709,13 @@ main() {
             fi
 
             if [[ "$matches" == "[]" ]]; then
-                echo '{"duplicate_found": false, "matches": []}'
+                if $degenerate; then
+                    echo "{\"duplicate_found\": false, \"degenerate\": true, \"matches\": []}"
+                else
+                    echo '{"duplicate_found": false, "degenerate": false, "matches": []}'
+                fi
             else
-                echo "{\"duplicate_found\": true, \"matches\": $matches}"
+                echo "{\"duplicate_found\": true, \"degenerate\": $degenerate, \"matches\": $matches}"
             fi
         fi
     else

--- a/defaults/scripts/tests/test-check-duplicate.sh
+++ b/defaults/scripts/tests/test-check-duplicate.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # test-check-duplicate.sh - Unit tests for check-duplicate.sh's --issue
-# cross-reference probe (issue #4162).
+# cross-reference probe (issue #4162) and its keyword-similarity scoring
+# (issue #4409).
 #
 # check-duplicate.sh's existing keyword-similarity check answers "has this
 # been reported before?" -- it is structurally blind to an OPEN issue that
@@ -16,6 +17,17 @@
 # black-box test: check-duplicate.sh is a full CLI script (main "$@" at
 # EOF, not sourced functions), so we stub `gh` and `loom-daemon` on PATH and
 # invoke the real script as a subprocess, asserting on stdout/exit code.
+#
+# Issue #4409 fixed two compounding bugs in calculate_similarity(): (1) `read
+# -ra arr <<< "$multiline_str"` only ever consumes ONE line, so a multi-keyword
+# (i.e. any realistically-worded) title/body collapsed to a single-element
+# array -- comparisons became a coin flip on one token instead of a real set
+# comparison; (2) even with arrays populated correctly, normalizing by the
+# SMALLER set saturated near 100% whenever a large query keyword set was
+# compared against a small candidate set. The tests below use small,
+# hand-built keyword sets (plain English words, no stopwords) run through the
+# real CLI against a stubbed candidate pool, so the resulting percentages are
+# exact and checkable by hand (see comments at each candidate).
 #
 # Usage:
 #   ./.loom/scripts/tests/test-check-duplicate.sh
@@ -284,6 +296,175 @@ run_cds --issue 80 --title "Some issue title"
 assert_eq "0" "$RC" "(g) repo view failure -> exit code driven by similarity check alone"
 assert_not_contains "$OUT" "RELATED_OPEN_WORK" "(g) repo view failure -> probe result skipped"
 assert_contains "$ERR" "Failed to resolve repository" "(g) repo view failure -> stderr warning emitted"
+
+echo ""
+echo "Testing check-duplicate.sh keyword-similarity scoring (issue #4409)..."
+
+# All fixtures below use NATO-alphabet words (alpha, bravo, ...) as keywords:
+# real English words, none of them in extract_keywords' stopword list, all
+# >= 3 chars, so every keyword survives extraction and the resulting Jaccard
+# percentages (matches * 100 / (|A| + |B| - matches)) are exact and easy to
+# verify by hand.
+
+# (h) Identical keyword sets -> 100% similarity (union == intersection).
+reset_state
+cat > "$STUB_DIR/issues-open.json" <<'EOF'
+[{"number": 501, "title": "Alpha Bravo Charlie Delta", "body": ""}]
+EOF
+run_cds --threshold 50 --title "Alpha Bravo Charlie Delta"
+assert_eq "1" "$RC" "(h) Identical keyword sets -> exit 1 (duplicate found)"
+assert_contains "$OUT" "#501: Alpha Bravo Charlie Delta (similarity: 100%)" \
+  "(h) Identical keyword sets score exactly 100%"
+
+# (i) Disjoint keyword sets -> 0% similarity, never flagged even at a
+# near-zero threshold.
+reset_state
+cat > "$STUB_DIR/issues-open.json" <<'EOF'
+[{"number": 502, "title": "Yankee Zulu Xray Whiskey", "body": ""}]
+EOF
+run_cds --threshold 1 --title "Alpha Bravo Charlie Delta"
+assert_eq "0" "$RC" "(i) Disjoint keyword sets -> exit 0 (no duplicate)"
+assert_not_contains "$OUT" "DUPLICATE_FOUND" "(i) Disjoint keyword sets never flagged"
+
+# (j) Partial overlap -> exact Jaccard percentage, not the old
+# matches/min(|A|,|B|) normalization. Query {alpha,bravo,charlie,delta} (4)
+# vs candidate {alpha,bravo,echo,foxtrot,golf} (5): matches=2 (alpha,bravo),
+# union=4+5-2=7, percent=2*100/7=28 (integer division). The pre-#4409
+# min-set normalization would have scored this matches/min(4,5)=2/4=50% --
+# a materially different (and saturating) number.
+reset_state
+cat > "$STUB_DIR/issues-open.json" <<'EOF'
+[{"number": 503, "title": "Alpha Bravo Echo Foxtrot Golf", "body": ""}]
+EOF
+run_cds --threshold 28 --title "Alpha Bravo Charlie Delta"
+assert_eq "1" "$RC" "(j) Partial overlap at threshold==percent -> exit 1"
+assert_contains "$OUT" "#503: Alpha Bravo Echo Foxtrot Golf (similarity: 28%)" \
+  "(j) Partial overlap scores exact true-Jaccard percentage (28%, not 50%)"
+run_cds --threshold 29 --title "Alpha Bravo Charlie Delta"
+assert_eq "0" "$RC" "(j) Partial overlap just below threshold -> exit 0"
+assert_not_contains "$OUT" "DUPLICATE_FOUND" "(j) 28% does not clear a 29% threshold"
+
+# (k) Empty keyword set on the CANDIDATE side (all stopwords) -> the existing
+# early-return in calculate_similarity (arr2 has 0 elements) must still yield
+# 0%, not a crash or division by zero.
+reset_state
+cat > "$STUB_DIR/issues-open.json" <<'EOF'
+[{"number": 504, "title": "The Is Are", "body": ""}]
+EOF
+run_cds --threshold 1 --title "Alpha Bravo Charlie Delta"
+assert_eq "0" "$RC" "(k) All-stopword candidate -> empty keyword set -> exit 0, no crash"
+assert_not_contains "$OUT" "DUPLICATE_FOUND" "(k) Empty candidate keyword set never matches"
+
+# (k2) Empty keyword set on the QUERY side (title is entirely stopwords) --
+# search_similar_issues' own early return (before ever calling
+# calculate_similarity), with a warning on stderr and no forge calls.
+reset_state
+run_cds --title "Is Are Was"
+assert_eq "0" "$RC" "(k2) All-stopword query title -> exit 0, no crash"
+assert_contains "$ERR" "No significant keywords" "(k2) All-stopword query title warns on stderr"
+
+# (l) One-word title on both sides: identical single-keyword sets -> 100%,
+# disjoint single-keyword sets -> 0%.
+reset_state
+cat > "$STUB_DIR/issues-open.json" <<'EOF'
+[
+  {"number": 505, "title": "Alpha", "body": ""},
+  {"number": 506, "title": "Bravo", "body": ""}
+]
+EOF
+run_cds --threshold 50 --title "Alpha"
+assert_eq "1" "$RC" "(l) One-word query matches its identical one-word candidate"
+assert_contains "$OUT" "#505: Alpha (similarity: 100%)" "(l) Identical one-word sets score 100%"
+assert_not_contains "$OUT" "#506" "(l) Disjoint one-word candidate (Bravo) not matched"
+
+# (m) Degenerate-result self-detection: when more than half of the scanned
+# candidates score >= threshold, the search must self-announce
+# NON_DISCRIMINATIVE instead of dumping a DUPLICATE_FOUND wall. Query has 7
+# keywords; of 4 open-issue candidates, 3 share enough keywords to clear the
+# default --threshold (18) and 1 is unrelated:
+#   #601 "Quantum flux widget"              -> matches=2/union=8  -> 25%
+#   #602 "Capacitor reactor system"         -> matches=2/union=8  -> 25%
+#   #603 "Completely unrelated banana fruit basket" -> matches=0  ->  0%
+#   #604 "Core module driver suite"         -> matches=3/union=8  -> 37%
+# matched=3 of scanned=4 -> 3*2=6 > 4 -> degenerate.
+reset_state
+cat > "$STUB_DIR/issues-open.json" <<'EOF'
+[
+  {"number": 601, "title": "Quantum flux widget", "body": ""},
+  {"number": 602, "title": "Capacitor reactor system", "body": ""},
+  {"number": 603, "title": "Completely unrelated banana fruit basket", "body": ""},
+  {"number": 604, "title": "Core module driver suite", "body": ""}
+]
+EOF
+run_cds --title "Quantum Flux Capacitor Reactor Core Module Driver"
+assert_eq "1" "$RC" "(m) Degenerate result set -> still exit 1 (caller should not treat as safe)"
+assert_contains "$OUT" "NON_DISCRIMINATIVE" "(m) Degenerate result set -> NON_DISCRIMINATIVE warning emitted"
+assert_contains "$OUT" "3 of 4 candidates" "(m) NON_DISCRIMINATIVE reports matched/scanned counts"
+assert_not_contains "$OUT" "DUPLICATE_FOUND" "(m) Degenerate result set -> no DUPLICATE_FOUND wall"
+
+# (m2) Same fixture, --json: degenerate flag set, duplicate_found false,
+# empty matches (a degenerate result is noise, not a real match list).
+run_cds --title "Quantum Flux Capacitor Reactor Core Module Driver" --json
+assert_eq "1" "$RC" "(m2) --json degenerate result -> exit 1"
+degenerate_flag="$(echo "$OUT" | jq -r '.degenerate')"
+assert_eq "true" "$degenerate_flag" "(m2) --json degenerate flag is true"
+duplicate_found_flag="$(echo "$OUT" | jq -r '.duplicate_found')"
+assert_eq "false" "$duplicate_found_flag" "(m2) --json duplicate_found is false for a degenerate (noise) result"
+matches_len="$(echo "$OUT" | jq -r '.matches | length')"
+assert_eq "0" "$matches_len" "(m2) --json matches is empty for a degenerate result"
+
+# (n) Mixed real-match + degenerate-result header regression test: when
+# --include-merged-prs turns up a REAL match in one pool (merged PRs) and a
+# DEGENERATE result in the other (closed issues), the real match must still
+# get a "DUPLICATE_FOUND" header -- an earlier draft of this fix required
+# BOTH pools to be non-degenerate before adding the header, which silently
+# swallowed a real duplicate whenever the other pool happened to be noisy.
+reset_state
+echo "[]" > "$STUB_DIR/issues-open.json"
+cat > "$STUB_DIR/prs-merged.json" <<'EOF'
+[
+  {"number": 701, "title": "Quantum flux widget", "body": ""},
+  {"number": 702, "title": "Zulu Yankee Xray", "body": ""},
+  {"number": 703, "title": "Whiskey Tango Foxtrot", "body": ""}
+]
+EOF
+cat > "$STUB_DIR/issues-closed.json" <<'EOF'
+[
+  {"number": 601, "title": "Quantum flux widget", "body": ""},
+  {"number": 602, "title": "Capacitor reactor system", "body": ""},
+  {"number": 603, "title": "Completely unrelated banana fruit basket", "body": ""},
+  {"number": 604, "title": "Core module driver suite", "body": ""}
+]
+EOF
+run_cds --include-merged-prs --title "Quantum Flux Capacitor Reactor Core Module Driver"
+assert_eq "1" "$RC" "(n) Mixed real+degenerate -> exit 1"
+assert_contains "$OUT" "DUPLICATE_FOUND" \
+  "(n) A real match in one pool still gets a DUPLICATE_FOUND header even when the other pool is degenerate"
+assert_contains "$OUT" "PR #701: Quantum flux widget (similarity: 25%)" \
+  "(n) Real merged-PR match is listed under the header"
+assert_contains "$OUT" "NON_DISCRIMINATIVE (closed issues)" \
+  "(n) Degenerate closed-issues pool still self-announces alongside the real match"
+
+# (o) Real historical duplicate pair, threshold calibration (#4409): #3551
+# ("guard-destructive.sh emits PreToolUse decisions without hookEventName ->
+# guard is a silent no-op") was closed with "Closing as already fixed. This
+# is a duplicate of #3550" -- an actual confirmed duplicate from this repo's
+# history, not a synthetic fixture. Titles only (both are real, verbatim):
+# keyword sets {decisions,destructive,emits,guard,hookeventname,pretooluse,
+# silent,without} (8) vs {ask,decisions,deny,destructive,discarded,guard,
+# hookeventname,hookspecificoutput,missing,required,silently} (11); 4 shared
+# words (decisions, destructive, guard, hookeventname); union=8+11-4=15;
+# true Jaccard = 4*100/15 = 26% -- clears the calibrated default threshold
+# (18, no --threshold flag passed here) even though the two titles share no
+# common phrasing beyond individual keywords.
+reset_state
+cat > "$STUB_DIR/issues-open.json" <<'EOF'
+[{"number": 3550, "title": "guard-destructive.sh: hookSpecificOutput missing required hookEventName -- deny/ask decisions silently discarded", "body": ""}]
+EOF
+run_cds --title "guard-destructive.sh emits PreToolUse decisions without hookEventName -> guard is a silent no-op"
+assert_eq "1" "$RC" "(o) Real historical duplicate pair (#3550/#3551) -> exit 1 at the calibrated default threshold"
+assert_contains "$OUT" "#3550" "(o) Real historical duplicate pair (#3550/#3551) -> flagged as a candidate"
+assert_contains "$OUT" "(similarity: 26%)" "(o) Real historical duplicate pair scores the expected 26% true-Jaccard"
 
 # --- Summary ---
 echo ""


### PR DESCRIPTION
## Summary

`calculate_similarity()` in `defaults/scripts/check-duplicate.sh` normalized
by `min(|A|,|B|)` instead of the union, so a large query keyword set (e.g. a
full curated issue body passed as the query) covered nearly all of any small
candidate's keyword set -- every score saturated near 100%, including for
totally unrelated issues (confirmed live during curation of #4380 and
#4412: ~21 candidates all scored exactly 100%).

## Root cause + fix

- **Primary bug**: `percent = matches * 100 / min(|A|,|B|)` -> switched to
  true Jaccard: `percent = matches * 100 / (|A| + |B| - matches)` (with a
  `union == 0` guard). This is symmetric and bounded by the union, so a large
  query set *dilutes* the score rather than saturating it.
- **Second, independent, compounding bug found in the same function**:
  `read -ra arr1 <<< "$keywords1"` only ever consumes a **single line** of
  its input (bash `read` semantics, every version) -- since
  `extract_keywords` emits one keyword per line, this silently collapsed
  `arr1`/`arr2` to a **one-element array** for any multi-keyword input,
  turning every comparison into a coin flip on one token instead of a real
  set comparison. Fixed via `IFS=$'\n'; set -f; arr=($str)` (bash 3.2 safe --
  macOS's shipped `/bin/bash` has no `mapfile`/`readarray`; `set -f` guards
  against accidental glob expansion on top of `extract_keywords`' existing
  alnum-only filter). shellcheck SC2206 is suppressed with a comment
  explaining why the word-split is intentional.

## Threshold recalibration

Lowered the default `--threshold` from 60 to **18**, calibrated against real
historical data (not guessed):

- A confirmed historical duplicate pair, **#3550/#3551** (#3551 was closed
  with *"Closing as already fixed. This is a duplicate of #3550"*): title-only
  Jaccard = **26%**, full title+body = **19%**.
- Three genuinely unrelated, richly-worded issues (**#4340, #4196, #4081**)
  scored **4-13%** against two different full-body queries (**#4380** and
  **#4412**, the two issues cited in the original bug report) -- confirming
  the saturation bug is gone (previously these all scored ~100%).

Caveat documented in the script's `--help` text and code comments: this is
a noisy signal on long, jargon-heavy technical bodies -- a second real
duplicate pair I found (**#4004/#4079**) scored only 13%, indistinguishable
from the unrelated-pair range. A miss at this threshold should be treated as
inconclusive, not proof of no overlap; this is an inherent limitation of
bag-of-words Jaccard on a corpus with heavy shared domain vocabulary, not
something fixable by threshold tuning alone.

## Degenerate-result self-detection

Added to all three call sites (`search_similar_issues` / open issues,
`search_merged_prs` / merged PRs, `search_closed_issues` / closed issues):
if more than half of a search's scanned candidates score at/above
`--threshold`, that search prints `NON_DISCRIMINATIVE (...)` instead of a
`DUPLICATE_FOUND` wall of noise (still signals non-zero from the open-issues
search, so `if ! check-duplicate.sh ...` callers still fall back to manual
review -- they just shouldn't treat the match list as real duplicates).
Requires a minimum of 4 scanned candidates before this kicks in, to avoid
misfiring when a search only has 1-3 candidates (where any single match is
trivially ">50%" without anything actually being broken). `--json` output
gets a new `degenerate` boolean field.

Fixed a header bug in an interim version of this fix: when `--include-merged-prs`
turns up a **real** match in one pool (e.g. merged PRs) and a **degenerate**
result in the other (e.g. closed issues), the real match must still get its
`DUPLICATE_FOUND` header -- the first draft required *both* pools to be
non-degenerate before adding the header, which silently swallowed a real
duplicate whenever the other pool happened to be noisy. Covered by a
dedicated regression test.

**Out of scope, unchanged, per the issue**: the `--issue` cross-reference
probe (`search_cross_references` / `format_related_open_work`, timeline-API
based) -- it was explicitly reported as working correctly.

## Test plan

- `defaults/scripts/tests/test-check-duplicate.sh`: 24 pre-existing tests
  (unchanged, still passing) + 30 new tests for the Jaccard fix: identical
  sets (100%), disjoint sets (0%), partial overlap (exact known Jaccard
  percentage, contrasted against what the old min-set normalization would
  have given), empty-keyword-set edge cases on both the query and candidate
  side (existing early-return path), one-word bodies, degenerate-result
  detection (text and `--json`), the mixed real-match/degenerate-pool header
  regression, and a fixture built on the real #3550/#3551 historical
  duplicate pair. **54/54 passing.**
- Manual reproduction: fetched real issue bodies (`gh issue view --json
  title,body`) for #4380, #4412 (queries) and #4340, #4196, #4081
  (previously-saturated "unrelated" candidates), and #3550/#3551,
  #4004/#4079 (real duplicate pairs), and ran them through the actual
  `extract_keywords`/`calculate_similarity` functions -- confirmed the
  before/after numbers cited above.
- `shellcheck defaults/scripts/check-duplicate.sh defaults/scripts/tests/test-check-duplicate.sh`: clean (0 warnings/errors), per this repo's `.shellcheckrc`.

Closes #4409