### PR TITLE
feat(daemon): promote peer-claims to primary in-flight signal on safehouse hosts

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -2057,7 +2057,8 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.watchdog.reviewStallTimeoutSecs` | `LOOM_SWEEP_REVIEW_STALL_TIMEOUT_SECS` | `2700` | Log-silence window before a hung Judge/Doctor sweep is re-dispatched |
 | `autonomous.collisionDetection.enabled` | `LOOM_DETECT_COLLISIONS` | `false` | Cross-host dispatch-collision baseline (#4085). Off by default — adds one extra `gh issue view --json labels` round-trip per dispatch. Detection only: a collision is logged/counted, never acted on |
 | `safehouse.enabled` | `LOOM_SAFEHOUSE_ENABLED` | `false` | Enables safehouse fleet-comms (#3997) **and** cross-host soft-claim coordination (#4028). Off by default — a byte-for-byte no-op (no socket, no coordination task) when unset |
-| `safehouse.peerClaimTtlSecs` | `LOOM_PEER_CLAIM_TTL_SECS` | `120` | Peer-claim TTL, in seconds (#4028) — how long a peer's soft claim suppresses local dispatch (measured against local receipt, not the advertiser's clock). Default = 2× the 60s work-finder tick |
+| `safehouse.peerClaimTtlSecs` | `LOOM_PEER_CLAIM_TTL_SECS` | `120` | Peer-claim TTL, in seconds (#4028) — how long a peer's soft claim suppresses local dispatch (measured against local receipt, not the advertiser's clock). Default = 2× the 60s work-finder tick. Since #4431 live claims are re-advertised every reaper tick, so the TTL only bounds how long a **crashed** host's claim lingers |
+| `safehouse.claimReconcileIntervalSecs` | `LOOM_CLAIM_RECONCILE_INTERVAL_SECS` | `1800` when `safehouse.enabled`, else `600` | Periodic `loom:building`/PR-claim reconciliation cadence (#4431). With safehouse peer-claims carrying the fast in-flight signal (re-advertised each reaper tick), label reconciliation demotes to a slow healing sweep. Env wins on any host; floored at 60s |
 | *(host identity)* | `LOOM_HOST_ID` | `$HOSTNAME` → `hostname` → `unknown-host` | This host's identity string, used in collision log records (#4085) **and** peer-claim self-recognition (#4028); set it where the daemon runs without `$HOSTNAME` exported |
 | `autonomous.autoUpdate.enabled` | `LOOM_AUTO_UPDATE` | `false` | Autonomous self-update loop on/off (#4055). **Opt-in** (it rebuilds + restarts the daemon process). Exactly one loop per daemon, not a per-workspace fan-out. See [Autonomous self-update loop](#autonomous-self-update-loop-4055) below |
 | `autonomous.autoUpdate.intervalSecs` | `LOOM_AUTO_UPDATE_INTERVAL_SECS` | `900` | Cadence between staleness checks. Zero/invalid → default |
@@ -2457,6 +2458,22 @@ for the full design.
   clock skew is not comparable across hosts), so a crashed peer cannot
   permanently starve an issue. A peer also emits a `retract` ad from its reaper on
   a terminal sweep outcome, freeing the issue before the TTL.
+- **Re-advertisement heartbeat (#4431).** The dispatch-time ad is no longer
+  one-shot: the reaper re-advertises every live (`Running`/`Pending`) Issue
+  sweep's claim each tick (default 30s — ~4 refreshes per TTL window), and a
+  repeat ad **restarts** the receiver's TTL clock. A live sweep's claim
+  therefore never expires from peers' views mid-run, while a crashed host's
+  claims still free within one TTL of its last heartbeat. This is what lets
+  the peer claim serve as the **primary fast in-flight signal** on
+  safehouse-enabled hosts, with the `loom:building` label demoted to a slow
+  healing audit trail:
+- **Safehouse-conditional reconciliation cadence (#4431).** On a host with
+  `safehouse.enabled`, `claim_reconciliation`'s periodic pass defaults to
+  **1800s** (30 min, healing-only) instead of 600s. Precedence:
+  `LOOM_CLAIM_RECONCILE_INTERVAL_SECS` env >
+  `safehouse.claimReconcileIntervalSecs` config > 1800s (safehouse) / 600s
+  (no safehouse), floored at 60s. Hosts without safehouse are byte-for-byte
+  unchanged.
 - **Self-claim recognition.** A daemon never backs off on its own advertisement:
   the claim body carries the host identity (`host_identity()`:
   `LOOM_HOST_ID` > `$HOSTNAME` > `hostname` > `unknown-host` — loom's single,

--- a/loom-daemon/src/claim_reconciliation.rs
+++ b/loom-daemon/src/claim_reconciliation.rs
@@ -168,11 +168,25 @@ pub const DEFAULT_RECONCILE_INTERVAL_SECS: u64 = 600;
 /// (e.g. `5` meaning "5 minutes") cannot turn this into a `gh`-API busy loop.
 pub const MIN_RECONCILE_INTERVAL_SECS: u64 = 60;
 
+/// Default periodic reconciliation interval when safehouse peer-claims are
+/// live (Issue #4431): 30 minutes. With claims advertised at dispatch and
+/// re-advertised every reaper tick (`sweep_registry::readvertise_peer_claims`),
+/// the fleet room — not the `loom:building` label — is the fast in-flight
+/// claim signal, and this pass demotes to a slow *healing* sweep for the
+/// divergence cases safehouse cannot see (a host that crashed without
+/// retracting, a stranded label from a pre-safehouse dispatch). Hosts without
+/// `safehouse.enabled` keep [`DEFAULT_RECONCILE_INTERVAL_SECS`] unchanged.
+pub const DEFAULT_SAFEHOUSE_RECONCILE_INTERVAL_SECS: u64 = 1800;
+
 /// Resolve the periodic reconciliation interval from
 /// [`RECONCILE_INTERVAL_ENV`], falling back to
 /// [`DEFAULT_RECONCILE_INTERVAL_SECS`] for an absent, unparseable, or
 /// non-positive value, and always clamped up to
 /// [`MIN_RECONCILE_INTERVAL_SECS`] regardless of source.
+///
+/// Env-only resolution — the safehouse-aware default lives in
+/// [`resolve_reconcile_interval_for`], which callers with a workspace root
+/// should prefer.
 #[must_use]
 pub fn resolve_reconcile_interval() -> Duration {
     let secs = std::env::var(RECONCILE_INTERVAL_ENV)
@@ -180,6 +194,44 @@ pub fn resolve_reconcile_interval() -> Duration {
         .and_then(|s| s.parse::<u64>().ok())
         .filter(|&v| v > 0)
         .unwrap_or(DEFAULT_RECONCILE_INTERVAL_SECS);
+    Duration::from_secs(secs.max(MIN_RECONCILE_INTERVAL_SECS))
+}
+
+/// Resolve the periodic reconciliation interval for a workspace, safehouse-
+/// aware (Issue #4431). Precedence, first match wins:
+///
+/// 1. [`RECONCILE_INTERVAL_ENV`] — the operator's explicit choice, any host.
+/// 2. `.loom/config.json → safehouse.claimReconcileIntervalSecs` — a per-repo
+///    override of the safehouse-mode cadence (zero/invalid ignored).
+/// 3. [`DEFAULT_SAFEHOUSE_RECONCILE_INTERVAL_SECS`] when `safehouse.enabled`
+///    resolves true for `root` — peer-claims carry the fast signal, labels
+///    demote to a healing cadence.
+/// 4. [`DEFAULT_RECONCILE_INTERVAL_SECS`] otherwise — byte-for-byte the
+///    pre-#4431 behavior for hosts without safehouse (e.g. robb-pro).
+///
+/// Always clamped up to [`MIN_RECONCILE_INTERVAL_SECS`] regardless of source.
+#[must_use]
+pub fn resolve_reconcile_interval_for(root: &Path) -> Duration {
+    if let Some(secs) = std::env::var(RECONCILE_INTERVAL_ENV)
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&v| v > 0)
+    {
+        return Duration::from_secs(secs.max(MIN_RECONCILE_INTERVAL_SECS));
+    }
+    let safehouse_enabled = crate::safehouse::resolve_config(root).enabled;
+    let config_override = crate::config_resolver::get_path(
+        &crate::config_resolver::resolve_effective_config(root),
+        "safehouse",
+    )
+    .and_then(|block| block.get("claimReconcileIntervalSecs"))
+    .and_then(serde_json::Value::as_u64)
+    .filter(|&v| v > 0);
+    let secs = config_override.unwrap_or(if safehouse_enabled {
+        DEFAULT_SAFEHOUSE_RECONCILE_INTERVAL_SECS
+    } else {
+        DEFAULT_RECONCILE_INTERVAL_SECS
+    });
     Duration::from_secs(secs.max(MIN_RECONCILE_INTERVAL_SECS))
 }
 
@@ -699,9 +751,12 @@ pub fn run_reconciliation_pass(fallback_root: &Path) {
 pub fn spawn_periodic_reconciliation_task(
     fallback_root: std::path::PathBuf,
 ) -> tokio::task::JoinHandle<()> {
-    let interval = resolve_reconcile_interval();
+    // Safehouse-aware cadence (#4431): with live peer-claims carrying the
+    // fast in-flight signal (re-advertised each reaper tick), a
+    // safehouse-enabled host demotes this pass to a slow healing sweep.
+    let interval = resolve_reconcile_interval_for(&fallback_root);
     log::info!(
-        "claim_reconciliation: periodic pass enabled (interval={}s, #4348)",
+        "claim_reconciliation: periodic pass enabled (interval={}s, #4348/#4431)",
         interval.as_secs()
     );
     tokio::spawn(async move {
@@ -1430,6 +1485,84 @@ mod tests {
     // ------------------------------------------------------------------
     // Periodic-interval resolution (Issue #4348)
     // ------------------------------------------------------------------
+
+    /// Write a `.loom/config.json` with the given `safehouse` block into a
+    /// fresh tempdir root (Issue #4431 interval tests).
+    fn root_with_safehouse_config(
+        dir: &std::path::Path,
+        safehouse_json: &str,
+    ) -> std::path::PathBuf {
+        let root = dir.join("repo");
+        std::fs::create_dir_all(root.join(".loom")).unwrap();
+        std::fs::write(
+            root.join(".loom").join("config.json"),
+            format!(r#"{{"safehouse": {safehouse_json}}}"#),
+        )
+        .unwrap();
+        root
+    }
+
+    /// #4431: precedence env > config override > safehouse-mode default >
+    /// legacy default, floor always enforced.
+    #[test]
+    #[serial]
+    fn resolve_reconcile_interval_for_is_safehouse_aware() {
+        std::env::remove_var(RECONCILE_INTERVAL_ENV);
+        // The safehouse env toggle would shadow the config file — clear it so
+        // the test exercises the config layer (hosts like loom-worker-1 set
+        // it in the daemon unit, but tests must not depend on that).
+        std::env::remove_var("LOOM_SAFEHOUSE_ENABLED");
+        let dir = tempdir().unwrap();
+
+        // Safehouse enabled → the slow healing cadence.
+        let root = root_with_safehouse_config(dir.path(), r#"{"enabled": true}"#);
+        assert_eq!(
+            resolve_reconcile_interval_for(&root),
+            std::time::Duration::from_secs(DEFAULT_SAFEHOUSE_RECONCILE_INTERVAL_SECS)
+        );
+
+        // Safehouse disabled (or absent) → byte-for-byte the pre-#4431 default.
+        let root = root_with_safehouse_config(dir.path(), r#"{"enabled": false}"#);
+        assert_eq!(
+            resolve_reconcile_interval_for(&root),
+            std::time::Duration::from_secs(DEFAULT_RECONCILE_INTERVAL_SECS)
+        );
+        assert_eq!(
+            resolve_reconcile_interval_for(dir.path()),
+            std::time::Duration::from_secs(DEFAULT_RECONCILE_INTERVAL_SECS),
+            "no config file at all must resolve to the legacy default"
+        );
+
+        // Per-repo config override wins over the safehouse-mode default…
+        let root = root_with_safehouse_config(
+            dir.path(),
+            r#"{"enabled": true, "claimReconcileIntervalSecs": 900}"#,
+        );
+        assert_eq!(resolve_reconcile_interval_for(&root), std::time::Duration::from_secs(900));
+        // …but a zero/invalid override is ignored, and the floor still holds.
+        let root = root_with_safehouse_config(
+            dir.path(),
+            r#"{"enabled": true, "claimReconcileIntervalSecs": 0}"#,
+        );
+        assert_eq!(
+            resolve_reconcile_interval_for(&root),
+            std::time::Duration::from_secs(DEFAULT_SAFEHOUSE_RECONCILE_INTERVAL_SECS)
+        );
+        let root = root_with_safehouse_config(
+            dir.path(),
+            r#"{"enabled": true, "claimReconcileIntervalSecs": 5}"#,
+        );
+        assert_eq!(
+            resolve_reconcile_interval_for(&root),
+            std::time::Duration::from_secs(MIN_RECONCILE_INTERVAL_SECS)
+        );
+
+        // The operator env var beats everything, on any host.
+        std::env::set_var(RECONCILE_INTERVAL_ENV, "300");
+        let root = root_with_safehouse_config(dir.path(), r#"{"enabled": true}"#);
+        assert_eq!(resolve_reconcile_interval_for(&root), std::time::Duration::from_secs(300));
+        std::env::remove_var(RECONCILE_INTERVAL_ENV);
+    }
 
     #[test]
     #[serial]

--- a/loom-daemon/src/peer_claims.rs
+++ b/loom-daemon/src/peer_claims.rs
@@ -22,6 +22,22 @@
 //! the final claim (a real cross-host CAS) is **Phase 2**, out of scope here — see
 //! #4028's "Design options for the atomic authority" section.
 //!
+//! # Primary in-flight signal on safehouse hosts (#4431)
+//!
+//! Since #4431 the peer claim is the **primary fast signal** that an issue is
+//! in flight on a safehouse-enabled fleet: the forge `loom:building` label
+//! remains the durable audit trail, but its reconciliation pass demotes to a
+//! slow healing cadence
+//! ([`crate::claim_reconciliation::DEFAULT_SAFEHOUSE_RECONCILE_INTERVAL_SECS`]).
+//! The contract that makes this safe is **re-advertisement**: the dispatch-time
+//! ad is no longer one-shot — `sweep_registry::readvertise_peer_claims`
+//! re-publishes every live sweep's claim each reaper tick (default 30s, well
+//! under the TTL), and [`PeerClaimView::observe_at`] refreshes the local
+//! expiry clock on every repeat `Advertise`. A live claim therefore never
+//! expires from peers' views mid-run, while a crashed host's claims still free
+//! within one TTL of its last heartbeat — the promotion changes how *long* a
+//! claim stays visible, not the "soft, eventually-consistent" nature above.
+//!
 //! # TTL is measured against LOCAL receipt, never the advertiser's clock
 //!
 //! A crashed peer must not starve an issue forever, so every peer claim expires
@@ -487,6 +503,32 @@ mod tests {
         // At/after the TTL: expired.
         assert!(!view.is_claimed_at("loom", 1, base + Duration::from_secs(100)));
         assert!(!view.is_claimed_at("loom", 1, base + Duration::from_secs(101)));
+    }
+
+    /// #4431 crux: a repeat `Advertise` for the same (repo, issue) must
+    /// refresh the local expiry clock, so a claim re-advertised by the
+    /// holder's reaper heartbeat survives arbitrarily far past the original
+    /// TTL — while still expiring one TTL after the LAST heartbeat (the
+    /// crash-release property).
+    #[test]
+    fn readvertisement_refreshes_ttl_so_a_live_claim_never_expires_mid_run() {
+        let ttl = Duration::from_secs(120);
+        let mut view = PeerClaimView::new("me".into(), ttl);
+        let base = Instant::now();
+        view.observe_at(&ad(ClaimKind::Advertise, 7, "loom", "peer"), base);
+
+        // Re-advertised at t+90 (inside the window): the clock restarts.
+        view.observe_at(
+            &ad(ClaimKind::Advertise, 7, "loom", "peer"),
+            base + Duration::from_secs(90),
+        );
+        // t+150 is past the ORIGINAL expiry (t+120) but inside the refreshed
+        // window (t+90 + 120 = t+210): still claimed.
+        assert!(view.is_claimed_at("loom", 7, base + Duration::from_secs(150)));
+        assert!(view.is_claimed_at("loom", 7, base + Duration::from_secs(209)));
+        // One TTL after the LAST heartbeat: expired — a crashed holder still
+        // frees the issue promptly.
+        assert!(!view.is_claimed_at("loom", 7, base + Duration::from_secs(210)));
     }
 
     #[test]

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -1696,6 +1696,43 @@ impl SweepRegistry {
         }
     }
 
+    /// Re-advertise the peer claim of every live (`Running`/`Pending`) Issue
+    /// sweep over the safehouse room (Issue #4431).
+    ///
+    /// The dispatch-time advertisement is a one-shot publish, and peer claims
+    /// expire after [`crate::peer_claims::DEFAULT_PEER_CLAIM_TTL`] (120s) —
+    /// tuned for the *soft-backoff* era when the forge label was the durable
+    /// signal behind it. With claim reconciliation slowed to a healing cadence
+    /// on safehouse-enabled hosts (#4431), a live sweep's claim must not
+    /// silently fall out of peers' [`crate::peer_claims::PeerClaimView`]s
+    /// mid-run. The reaper calls this every tick (default 30s, well under the
+    /// TTL), so a live claim is refreshed ~4× per TTL window while a crashed
+    /// host's claims still expire within one TTL of its last heartbeat — the
+    /// crash-release property the short TTL exists for is preserved exactly.
+    ///
+    /// Same fail-open contract as [`Self::publish_peer_claim`]: a no-op
+    /// without a publisher (`safehouse.enabled` false), and a full/closed
+    /// channel drops the ad without blocking the reaper. Returns how many
+    /// claims were re-advertised (for the reaper's debug line).
+    pub fn readvertise_peer_claims(&self) -> usize {
+        if self.peer_claim_publisher.is_none() {
+            return 0;
+        }
+        let live: Vec<u32> = self
+            .entries
+            .values()
+            .filter(|info| matches!(info.state, SweepState::Running | SweepState::Pending))
+            .filter_map(|info| match info.kind {
+                SweepKind::Issue(issue) => Some(issue),
+                _ => None,
+            })
+            .collect();
+        for issue in &live {
+            self.publish_peer_claim(peer_claims::ClaimKind::Advertise, *issue);
+        }
+        live.len()
+    }
+
     /// The set of issue numbers currently quarantined for insta-crashing (Issue
     /// #3939). Consumed by the work finder to skip re-dispatch. TTL expiry is
     /// applied by [`reap_once`](Self::reap_once) (which the work-finder's
@@ -5229,7 +5266,23 @@ pub fn spawn_reaper_task(registry: Arc<Mutex<SweepRegistry>>) -> tokio::task::Jo
             ticker.tick().await;
             let changed = {
                 match registry.lock() {
-                    Ok(mut r) => r.reap_once(),
+                    Ok(mut r) => {
+                        let changed = r.reap_once();
+                        // Peer-claim heartbeat (#4431): re-advertise every
+                        // live claim each reaper tick so it never expires
+                        // from peers' views mid-run, now that label
+                        // reconciliation is a slow healing cadence on
+                        // safehouse-enabled hosts. Runs after `reap_once` so
+                        // a just-reaped (dead) sweep is never re-advertised.
+                        let readvertised = r.readvertise_peer_claims();
+                        if readvertised > 0 {
+                            log::debug!(
+                                "sweep_registry: re-advertised {readvertised} live peer \
+                                 claim(s) (#4431)"
+                            );
+                        }
+                        changed
+                    }
                     Err(poisoned) => {
                         log::error!("sweep_registry: mutex poisoned ({poisoned:?})");
                         return;
@@ -5795,6 +5848,67 @@ mod tests {
     /// exec bit, because parallel-test load on macOS occasionally races the
     /// chmod with the child's posix_spawn exec call and the script silently
     /// fails to launch (no shebang resolution, no exec-bit yet).
+    /// #4431: the reaper's peer-claim heartbeat must re-advertise every live
+    /// (`Running`/`Pending`) Issue sweep's claim — and ONLY those (a
+    /// terminal-state entry is a dead sweep whose claim must be allowed to
+    /// expire), and be a publisher-less no-op (safehouse disabled).
+    #[test]
+    fn readvertise_republishes_live_issue_claims_only() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _log) = fixture_registry(dir.path());
+
+        // No publisher attached (safehouse.enabled false): a silent no-op.
+        assert_eq!(registry.readvertise_peer_claims(), 0);
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        registry.set_peer_claim_publisher(tx);
+
+        let mk_info =
+            |sweep_id: &str, issue: u32, state: SweepState, log_path: PathBuf| SweepInfo {
+                sweep_id: sweep_id.to_string(),
+                kind: SweepKind::Issue(issue),
+                pid: 0,
+                token_name: "unknown".into(),
+                log_path,
+                idempotency_key: None,
+                started_at: Utc::now(),
+                state,
+                latest_phase: None,
+                pr_number: None,
+                model: None,
+                effort: None,
+                depends_on: None,
+                repo: None,
+            };
+        let live_log = registry.compute_log_path(4431);
+        let dead_log = registry.compute_log_path(999);
+        registry.entries.insert(
+            "sweep-live".to_string(),
+            mk_info("sweep-live", 4431, SweepState::Running, live_log),
+        );
+        registry.entries.insert(
+            "sweep-dead".to_string(),
+            mk_info(
+                "sweep-dead",
+                999,
+                SweepState::Exited {
+                    code: None,
+                    at: Utc::now(),
+                },
+                dead_log,
+            ),
+        );
+
+        assert_eq!(registry.readvertise_peer_claims(), 1);
+        let ad = rx.try_recv().expect("one re-advertisement published");
+        assert_eq!(ad.issue, 4431);
+        assert_eq!(ad.kind, crate::peer_claims::ClaimKind::Advertise);
+        assert!(
+            rx.try_recv().is_err(),
+            "the terminal-state sweep's claim must NOT be re-advertised"
+        );
+    }
+
     fn fixture_registry(workspace: &Path) -> (SweepRegistry, PathBuf) {
         let record_log = workspace.join("fake-spawn.log");
         // We use /bin/bash as the spawn binary, and the dispatch path appends


### PR DESCRIPTION
Closes #4431. Fourth child of epic #4432 (after #4440/#4429 merged and #4443/#4428 in review).

## The curator's crux, resolved

The curator flagged the correctness risk precisely: peer claims were a **one-shot publish at dispatch** with a 120s TTL tuned for soft backoff — promoting them to the primary signal while slowing label reconciliation would let a live sweep's claim silently expire from peers' views mid-run, reopening the double-dispatch window. Resolution: **re-advertisement heartbeat**, not TTL extension:

- `SweepRegistry::readvertise_peer_claims()` re-publishes every live (`Running`/`Pending`) Issue sweep's claim; the reaper calls it each tick (default 30s ≈ 4 refreshes per TTL window), after `reap_once` so a just-reaped sweep is never re-advertised.
- `PeerClaimView::observe_at` already restarts the local expiry clock on a repeat `Advertise` (no receiver change needed — covered by a new test).
- A crashed host's claims still free within **one TTL of its last heartbeat** — the crash-release property the short TTL exists for is preserved exactly, which is why re-advertisement beats a long TTL (stale claims from dead hosts would linger and starve issues fleet-wide).

## Safehouse-conditional reconciliation cadence

`resolve_reconcile_interval_for(root)`: env `LOOM_CLAIM_RECONCILE_INTERVAL_SECS` > config `safehouse.claimReconcileIntervalSecs` > **1800s** when `safehouse.enabled` > 600s otherwise, floored at 60s. A safehouse host's `loom:building` pass demotes to a healing sweep (stranded claims from crashed hosts, pre-safehouse dispatches); a host without safehouse (e.g. robb-pro) is byte-for-byte unchanged — the existing `workspace_pool` short-circuit already guarantees the no-safehouse path never consults peer claims.

## Curator corrections honored

- `quarantine_reconciliation` is startup-only (no periodic task) — no cadence change made there, per the curator's verified correction.
- Reused `peer_claimed_issues()` / `WorkSource::peer_claimed()` as-is — the dispatch-skip path is unchanged; this PR changes how long a claim stays visible and how often labels are polled, not the skip semantics.

## Message-volume note

Re-advertisement adds ~2 room events/min per live sweep (30s tick). At realistic fleet load (≤10 concurrent sweeps) that's ≤20 msg/min of tiny `task` envelopes — bounded `try_send`, fail-open drop under backlog, same as the dispatch-time ad.

## Testing

- `peer_claims`: new test proving a re-advertised claim survives past the original TTL and still expires one TTL after the LAST heartbeat.
- `sweep_registry`: new test proving re-advertisement publishes for live Issue sweeps only (terminal-state entries excluded; publisher-less = silent no-op).
- `claim_reconciliation`: new test covering the full interval precedence chain (env > config override > safehouse default > legacy default; zero/invalid override ignored; 60s floor).
- 263 tests across the three touched modules pass; clippy `--all-targets` + `cargo fmt --check` clean.
- Docs: daemon-reference gains the `safehouse.claimReconcileIntervalSecs` row, the re-advertisement heartbeat bullet, and the TTL row now notes it only bounds a crashed host's lingering claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)