### PR TITLE
feat(daemon): mint GitHub App installation tokens for fleet hosts

### DIFF
--- a/defaults/docs/github-authentication.md
+++ b/defaults/docs/github-authentication.md
@@ -159,6 +159,101 @@ consequences of the non-Aqua domain are covered in
 As before, export a `GH_TOKEN` for forge auth in a headless session (the login
 keychain may be locked) — the #4005 credential preflight reports this loudly.
 
+## GitHub App identity (#4430)
+
+Every fleet host authenticating as the same personal account (or the same
+long-lived fine-grained PAT) shares one 5,000/hr REST + 5,000/hr GraphQL
+budget with **every other host and the operator's own interactive use** — a
+busy fleet can exhaust it fleet-wide. A GitHub App gives each **installation**
+(e.g. one per GitHub account/org the fleet operates against) its own
+rate-limit bucket, centralizes repo access in one place (adding a repo to the
+fleet is an installation edit, not a PAT rebuild per host), and mints
+short-lived (~1h) tokens on-host from a private key instead of parking a
+long-lived PAT on a cloud disk. Commits/comments made with a minted token
+attribute to the app's bot identity (e.g. `2am-loom[bot]`), not a personal
+account.
+
+**This is entirely opt-in and fallback-first.** With no app credentials
+configured (the default on every host until an operator does the setup
+below), `loom-daemon` behaves exactly as described above — `GH_TOKEN`/
+`GITHUB_TOKEN` env, then `gh`'s own credential store. Configuring the app
+changes nothing about that fallback; it only adds a mechanism that is tried
+*first*, and that falls back to the same ambient path on any failure
+(unreadable/revoked key, network hiccup, GitHub API error) rather than
+hard-failing.
+
+### Setup (operator, one-time per GitHub account/org)
+
+1. Create a GitHub App (under whichever account/org owns the target repos)
+   with **Contents: Read & write**, **Issues: Read & write**, **Pull
+   requests: Read & write**, **Metadata: Read** permissions.
+2. Generate a private key for the app (downloads a `.pem` file) and copy it to
+   each fleet host that should mint tokens for that account/org — e.g.
+   `~/.config/loom/github-app-key.pem`, readable only by the daemon's user
+   (`chmod 600`).
+3. Install the app on the account/org's repositories (all of them, or just the
+   ones Loom manages).
+4. Provision the app id + private-key path to the host, either as env vars or
+   in `.loom/config.json`:
+
+   ```bash
+   # Env (highest precedence) — export before starting the daemon:
+   export LOOM_GITHUB_APP_ID=123456
+   export LOOM_GITHUB_APP_KEY_PATH=~/.config/loom/github-app-key.pem
+   ./.loom/scripts/cli/loom-daemon-start.sh
+   ```
+
+   ```json
+   // .loom/config.json — config beats nothing but env (env > config):
+   {
+     "forge": {
+       "githubApp": {
+         "appId": "123456",
+         "privateKeyPath": "/home/loom/.config/loom/github-app-key.pem"
+       }
+     }
+   }
+   ```
+
+**Installation selection is derivable, not configured further.** The daemon
+resolves *which* installation covers the workspace it's running in from the
+repo itself (`GET /repos/{owner}/{repo}/installation`, JWT-authed) — a fleet
+spanning multiple accounts/orgs needs only the one app id + key path above;
+each workspace's own git remote picks the right installation automatically.
+
+### What happens once configured
+
+At startup (and on a periodic refresh tick thereafter, well inside the
+token's ~1h lifetime), the daemon mints a JWT from the app id + private key
+(RS256, signed locally via `openssl` — the key never leaves the host) and
+exchanges it for a short-lived installation access token, which it exports as
+its own process's `GH_TOKEN` — every `gh`/`git` child the daemon spawns from
+that point inherits it. The token is cached on disk (`0600`, keyed by
+installation) and re-minted whenever fewer than 10 minutes of its lifetime
+remain, so a live daemon never has to wait on a fresh mint mid-tick.
+
+`loom-daemon status` and the startup log line report this as mechanism
+`github-app` with a **non-secret fingerprint** — `app <id> installation
+<id>` — never the token, JWT, or key material itself:
+
+```
+Forge credential: OK — github-app (app 123456 installation 789)
+```
+
+### Troubleshooting the app path
+
+- **Unreadable/revoked/rotated key**: the daemon logs the failure by name
+  (`credential_preflight: github-app mint failed (…)`) and falls back to
+  ambient `gh` auth rather than hard-failing — check `LOOM_GITHUB_APP_KEY_PATH`
+  / `forge.githubApp.privateKeyPath` points at a file the daemon's user can
+  read.
+- **App not installed on this repo/org**: the installation-resolution call
+  (`GET /repos/{owner}/{repo}/installation`) 404s; install the app on the
+  repo, or verify the workspace's git remote points at the account/org the
+  app is installed on.
+- **Clock skew**: the minted JWT's `iat` is backdated 60 seconds per GitHub's
+  own guidance, tolerating modest host clock drift without a manual fix.
+
 ## Troubleshooting
 
 ### Token not being picked up

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -310,6 +310,24 @@ extract_plist_path_value() {
 # still forwarded verbatim so the launchd job sees EXACTLY the autonomy flags
 # and auth this invocation resolved -- never wider, never narrower (#3972 AC:
 # "preserves the current flag semantics").
+#
+# Reconciling this STATIC forwarding with the #4430 MINTED GitHub App token
+# path (deliberate, not an oversight): `LOOM_GITHUB_APP_ID` /
+# `LOOM_GITHUB_APP_KEY_PATH` already match the `LOOM_[A-Za-z0-9_]*` pattern
+# above, so they ride along into the plist exactly like any other LOOM_* flag
+# -- but note that's a non-secret app id and a *path* to the private key, never
+# the key material itself (which stays on disk wherever the operator put it,
+# read only by openssl at mint time). Any GH_TOKEN forwarded here is this
+# invocation's snapshot at RENDER time; the daemon's own #4430 preflight/
+# refresh loop calls `std::env::set_var("GH_TOKEN", …)` on its OWN process
+# environment once a fresh installation token is minted, which the plist's
+# static value cannot see or fight (it only seeds the daemon's env at
+# process start, same as it always did) -- every `gh`/`git` child spawned
+# AFTER that point inherits the live, minted value, not the stale plist one.
+# If minting ever fails (revoked/unreadable key, network hiccup), the daemon
+# falls back to whatever GH_TOKEN this static forwarding already provided --
+# so leaving GH_TOKEN forwarding in place is exactly the right fallback
+# layer, not a footgun to remove.
 render_launchd_plist() {
     local label="$1" bin="$2" workdir="$3" log_path="$4"
     local plist_path_value="$PLIST_PATH_VALUE"
@@ -381,7 +399,11 @@ render_launchd_plist() {
 #     (#4172, $PLIST_PATH_VALUE), not the invoking shell's PATH; every already-
 #     exported LOOM_* / GH_TOKEN / GITEA_TOKEN / FORGE_TOKEN var is forwarded
 #     verbatim so the service sees EXACTLY the autonomy flags + auth this
-#     invocation resolved -- never wider, never narrower.
+#     invocation resolved -- never wider, never narrower. See
+#     render_launchd_plist's #4430 reconciliation note above -- this static
+#     forwarding and the daemon's own minted-GitHub-App-token refresh loop
+#     are complementary (static = render-time seed/fallback, minted = live
+#     process-env override), never in conflict.
 render_systemd_unit() {
     local bin="$1" workdir="$2" log_path="$3"
     local unit_path_value="$PLIST_PATH_VALUE"

--- a/defaults/scripts/lib/github-app-token.sh
+++ b/defaults/scripts/lib/github-app-token.sh
@@ -1,0 +1,444 @@
+#!/usr/bin/env bash
+# github-app-token.sh - GitHub App identity: JWT minting + installation-token
+# fetch/cache/refresh, shell-only (openssl + curl) (#4430).
+#
+# # Why shell, not a new Rust dependency
+#
+# `loom-daemon` has no HTTP client and no JWT/RSA crate (see
+# `loom-daemon/Cargo.toml`); every forge call already shells out to `gh`. This
+# lib mints the two things a fleet host needs to authenticate as a GitHub App
+# installation with nothing more than tools already assumed present
+# (`openssl`, `curl`, `jq`):
+#
+#   1. A short-lived (<=10 min) RS256 JWT signed with the app's private key
+#      (`github_app_jwt`) -- proves "I am app <id>".
+#   2. An installation access token minted from that JWT
+#      (`github_app_get_token`) -- a normal `ghs_...` token good for ~1h,
+#      scoped to exactly the repos the app installation covers, with its own
+#      rate-limit bucket separate from any personal account.
+#
+# `loom-daemon` invokes this file as an executable (`get-token` / `status`
+# subcommands below), not sourced -- see `loom-daemon/src/credential_preflight.rs`.
+#
+# # Config precedence (env > config > default), matching GiteaConfig (#4061)
+#
+#   LOOM_GITHUB_APP_ID          > forge.githubApp.appId
+#   LOOM_GITHUB_APP_KEY_PATH    > forge.githubApp.privateKeyPath
+#
+# Installation selection is DERIVABLE, not configured: `GET
+# /repos/{owner}/{repo}/installation` (JWT-authed) resolves the installation
+# for any repo the app can see, cached per-owner so a fleet spanning multiple
+# GitHub accounts/orgs (e.g. rjwalters vs 2AMLogic) resolves the right
+# installation for whichever repo it is currently operating on.
+#
+# # Fallback-first (the load-bearing default)
+#
+# `github_app_configured` returns 1 (with `_GH_APP_LAST_ERROR` set, never a
+# secret) whenever the app id or private key path is absent/unreadable --
+# every caller (the CLI dispatch below, and `credential_preflight.rs`) treats
+# that as "fall back to ambient `gh` auth", never a hard failure. With no app
+# credentials configured anywhere (env or config), this file's production
+# entry points are never even invoked with real work to do -- byte-identical
+# behavior to a host that has never heard of this feature.
+#
+# # Secret handling
+#
+# - The private key is read only by `openssl` (as a `-sign` keyfile argument);
+#   this script never echoes, greps, or logs its contents.
+# - Minted tokens are cached to disk at `0600` (owner read/write only),
+#   directory `0700`.
+# - No function in this file ever writes a token, JWT, or key material to
+#   stdout labelled as anything other than exactly the value the caller asked
+#   for (`get-token`'s JSON envelope) -- diagnostics (`status`, errors) carry
+#   only non-secret fields: app id, installation id, a token's expiry, and
+#   human-readable remedy text.
+#
+# Usage (executable):
+#   ./github-app-token.sh status                 # cheap, no network
+#   ./github-app-token.sh get-token OWNER/REPO    # mints/reuses a token
+#
+# Usage (sourced, for tests / advanced callers):
+#   source ".../lib/github-app-token.sh"
+#   github_app_configured && github_app_get_token "owner/repo"
+
+set -euo pipefail
+
+# ${BASH_SOURCE[0]:-$0} -- see forge-helpers.sh for the zsh-portable rationale
+# (this file is occasionally sourced directly by a zsh-default shell too).
+_LOOM_GH_APP_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=./config-resolver.sh
+source "$_LOOM_GH_APP_LIB_DIR/config-resolver.sh"
+
+# --- Config resolution (mirrors forge-helpers.sh::_forge_config_root) ---
+
+# _github_app_config_root -> echoes the root to resolve config from.
+# Precedence: $REPO_ROOT (env) > $WORKSPACE_ROOT (env) > canonical repo root
+# via `git rev-parse --git-common-dir` > "." as a last resort.
+_github_app_config_root() {
+  if [[ -n "${REPO_ROOT:-}" ]]; then
+    echo "$REPO_ROOT"
+    return 0
+  fi
+  if [[ -n "${WORKSPACE_ROOT:-}" ]]; then
+    echo "$WORKSPACE_ROOT"
+    return 0
+  fi
+
+  local git_common_dir
+  if git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null)"; then
+    if [[ "$git_common_dir" != /* ]]; then
+      git_common_dir="$(cd "$git_common_dir" && pwd)"
+    fi
+    dirname "$git_common_dir"
+    return 0
+  fi
+
+  echo "."
+}
+
+# Global state populated by _github_app_load_config / github_app_configured.
+_GH_APP_ID=""
+_GH_APP_KEY_PATH=""
+_GH_APP_LAST_ERROR=""
+# Populated by github_app_get_token on success, for the CLI envelope.
+GITHUB_APP_INSTALLATION_ID=""
+GITHUB_APP_TOKEN_EXPIRES_AT=""
+
+# _github_app_load_config -> resolves _GH_APP_ID / _GH_APP_KEY_PATH from env
+# (highest precedence) or config (forge.githubApp.appId /
+# forge.githubApp.privateKeyPath), matching the #4061 GiteaConfig precedence
+# pattern (env beats config).
+_github_app_load_config() {
+  _GH_APP_ID="${LOOM_GITHUB_APP_ID:-}"
+  _GH_APP_KEY_PATH="${LOOM_GITHUB_APP_KEY_PATH:-}"
+
+  if [[ ( -z "$_GH_APP_ID" || -z "$_GH_APP_KEY_PATH" ) ]] && command -v jq >/dev/null 2>&1; then
+    local root
+    root="$(_github_app_config_root)"
+    if [[ -z "$_GH_APP_ID" ]]; then
+      _GH_APP_ID="$(loom_config_get "$root" "forge.githubApp.appId" "")"
+    fi
+    if [[ -z "$_GH_APP_KEY_PATH" ]]; then
+      _GH_APP_KEY_PATH="$(loom_config_get "$root" "forge.githubApp.privateKeyPath" "")"
+    fi
+  fi
+}
+
+# github_app_configured -> returns 0 when an app id and a readable private
+# key are both resolved; 1 otherwise with a human-readable, non-secret
+# reason in $_GH_APP_LAST_ERROR. This is the single gate every production
+# entry point checks before doing any work -- absent config is NOT an error,
+# just "fall back to ambient auth" (the load-bearing default, #4430 AC1).
+github_app_configured() {
+  _github_app_load_config
+  if [[ -z "$_GH_APP_ID" ]]; then
+    _GH_APP_LAST_ERROR="github app not configured (set LOOM_GITHUB_APP_ID or forge.githubApp.appId)"
+    return 1
+  fi
+  if [[ -z "$_GH_APP_KEY_PATH" ]]; then
+    _GH_APP_LAST_ERROR="github app private key path not configured (set LOOM_GITHUB_APP_KEY_PATH or forge.githubApp.privateKeyPath)"
+    return 1
+  fi
+  if [[ ! -r "$_GH_APP_KEY_PATH" ]]; then
+    _GH_APP_LAST_ERROR="github app private key not readable at ${_GH_APP_KEY_PATH} -- check the path and file permissions (revoked/rotated/never-provisioned keys all look like this)"
+    return 1
+  fi
+  return 0
+}
+
+# --- base64url helpers (JWT is base64url, RFC 7515) ---
+#
+# Both directions are pipeline-only (never capture raw binary through a bash
+# variable): bash's variables are effectively NUL-terminated C strings, so an
+# RSA signature (which can contain an embedded 0x00 byte) silently truncates
+# if it passes through `$(...)` before being base64-encoded. Piping openssl's
+# raw stdout directly into the base64 step keeps every bash-variable capture
+# text-safe.
+
+# _github_app_b64url -> reads stdin, writes base64url (no padding) to stdout.
+_github_app_b64url() {
+  openssl base64 -A | tr '+/' '-_' | tr -d '='
+}
+
+# _github_app_b64url_decode_to_file <b64url-string> <out-file> -> restores
+# padding, translates the alphabet back, and writes raw decoded bytes to
+# out-file (never through a bash variable -- see note above). Test-only helper
+# (signature verification needs the raw bytes on disk for `openssl -verify`).
+_github_app_b64url_decode_to_file() {
+  local input="$1" out="$2" padded rem
+  padded="$input"
+  rem=$(( ${#padded} % 4 ))
+  case "$rem" in
+    2) padded+="==" ;;
+    3) padded+="=" ;;
+    0) : ;;
+    *) : ;; # length%4==1 cannot occur for valid base64url
+  esac
+  printf '%s' "$padded" | tr -- '-_' '+/' | openssl base64 -d -A > "$out"
+}
+
+# --- JWT minting (RS256, GitHub App auth) ---
+
+# github_app_jwt -> mints a fresh RS256 JWT on stdout using the configured
+# app id + private key. Returns 1 (with $_GH_APP_LAST_ERROR set) when not
+# configured or signing fails. Pure/local -- no network call, so this is
+# fully unit-testable with a throwaway keypair (test-github-app-token.sh).
+#
+# `iat` is backdated 60s to tolerate clock skew between this host and
+# GitHub's API (GitHub's own JWT guide: "to protect against clock drift... we
+# recommend that you set this 60 seconds in the past"). `exp` is 9 minutes
+# out, inside GitHub's 10-minute ceiling with headroom for the request
+# round-trip.
+github_app_jwt() {
+  if ! github_app_configured; then
+    return 1
+  fi
+
+  local now iat exp header payload header_b64 payload_b64 signing_input signature_b64
+  now=$(date +%s)
+  iat=$((now - 60))
+  exp=$((now + 540))
+  header='{"alg":"RS256","typ":"JWT"}'
+  payload="{\"iat\":${iat},\"exp\":${exp},\"iss\":\"${_GH_APP_ID}\"}"
+  header_b64=$(printf '%s' "$header" | _github_app_b64url)
+  payload_b64=$(printf '%s' "$payload" | _github_app_b64url)
+  signing_input="${header_b64}.${payload_b64}"
+
+  if ! signature_b64=$(printf '%s' "$signing_input" | openssl dgst -sha256 -sign "$_GH_APP_KEY_PATH" 2>/dev/null | _github_app_b64url); then
+    _GH_APP_LAST_ERROR="failed to sign JWT with the configured private key at ${_GH_APP_KEY_PATH} (revoked, rotated, or not a valid RSA private key)"
+    return 1
+  fi
+  if [[ -z "$signature_b64" ]]; then
+    _GH_APP_LAST_ERROR="openssl produced no signature -- check that ${_GH_APP_KEY_PATH} is a valid RSA private key"
+    return 1
+  fi
+
+  printf '%s.%s' "$signing_input" "$signature_b64"
+}
+
+# --- Token cache (0600, keyed by installation id) ---
+
+# _github_app_cache_dir -> echoes the cache directory, creating it (0700) if
+# absent. Overridable via LOOM_GITHUB_APP_CACHE_DIR (tests use this to avoid
+# touching a real $HOME).
+_github_app_cache_dir() {
+  local dir="${LOOM_GITHUB_APP_CACHE_DIR:-${HOME:-/tmp}/.cache/loom/github-app}"
+  mkdir -p "$dir"
+  chmod 700 "$dir" 2>/dev/null || true
+  echo "$dir"
+}
+
+# _github_app_cache_path <installation_id> -> echoes the token-cache file path.
+_github_app_cache_path() {
+  echo "$(_github_app_cache_dir)/installation-${1}.json"
+}
+
+# _github_app_installation_cache_path <owner> -> echoes the owner->installation
+# mapping cache file path. This value is not a secret (an installation id is
+# just an integer identifying a repo grant) so it does not need 0600, but it
+# lives in the same 0700 directory as the token cache for simplicity.
+_github_app_installation_cache_path() {
+  echo "$(_github_app_cache_dir)/owner-${1}.installation"
+}
+
+# _github_app_write_cache <installation_id> <token> <expires_at_iso8601> ->
+# atomically writes the token cache file at 0600. Uses a temp file + rename
+# (same pattern as every other Loom bookkeeping writer) so a concurrent
+# reader never observes a torn file.
+_github_app_write_cache() {
+  local installation_id="$1" token="$2" expires_at="$3"
+  local path tmp
+  path="$(_github_app_cache_path "$installation_id")"
+  tmp="${path}.tmp.$$"
+  jq -cn --arg token "$token" --arg expires_at "$expires_at" --arg installation_id "$installation_id" \
+    '{token: $token, expires_at: $expires_at, installation_id: $installation_id}' > "$tmp"
+  chmod 600 "$tmp"
+  mv "$tmp" "$path"
+}
+
+# _github_app_read_cache <installation_id> -> echoes the cached JSON (token +
+# expires_at) if the file exists and parses; echoes nothing (exit 1) otherwise.
+_github_app_read_cache() {
+  local path
+  path="$(_github_app_cache_path "$1")"
+  if [[ ! -f "$path" ]]; then
+    return 1
+  fi
+  jq -c 'if (.token? and .expires_at?) then . else empty end' "$path" 2>/dev/null || return 1
+}
+
+# _github_app_parse_iso8601 <YYYY-MM-DDTHH:MM:SSZ> -> echoes the unix epoch
+# seconds. Tries GNU date first, then BSD/macOS date -- the two hosts Loom's
+# fleet actually runs on (#4172 precedent for this exact GNU/BSD split).
+_github_app_parse_iso8601() {
+  local ts="$1"
+  date -u -d "$ts" +%s 2>/dev/null && return 0
+  date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$ts" +%s 2>/dev/null && return 0
+  return 1
+}
+
+# _github_app_needs_remint <expires_epoch> -> returns 0 (true, "remint now")
+# when fewer than 600s (10 minutes) of lifetime remain -- the #4430 AC2
+# refresh window. A malformed/empty epoch is treated as "needs remint" (fail
+# safe toward re-minting, never toward silently reusing an unparseable
+# expiry).
+_github_app_needs_remint() {
+  local expires_epoch="${1:-}"
+  if [[ -z "$expires_epoch" || ! "$expires_epoch" =~ ^-?[0-9]+$ ]]; then
+    return 0
+  fi
+  local now remaining
+  now=$(date +%s)
+  remaining=$((expires_epoch - now))
+  [[ "$remaining" -lt 600 ]]
+}
+
+# --- Network calls (installation resolution + token minting) ---
+#
+# Neither of these is required for the unit test suite (#4430 AC: "none
+# require a live GitHub App") -- they are exercised only by the executable
+# CLI dispatch below, in production, once an app is actually installed.
+
+# _github_app_api_get_installation <owner/repo> -> echoes the installation id
+# on stdout. Requires a fresh JWT (github_app_jwt).
+_github_app_api_get_installation() {
+  local nwo="$1" jwt resp http_code body
+  jwt=$(github_app_jwt) || return 1
+  resp=$(curl -sS -w '\n%{http_code}' \
+    -H "Authorization: Bearer $jwt" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/repos/${nwo}/installation" 2>/dev/null) || {
+    _GH_APP_LAST_ERROR="could not reach the GitHub API to resolve the installation for ${nwo}"
+    return 1
+  }
+  http_code=$(echo "$resp" | tail -1)
+  body=$(echo "$resp" | sed '$d')
+  if [[ "$http_code" -ge 200 && "$http_code" -lt 300 ]]; then
+    echo "$body" | jq -r '.id'
+    return 0
+  fi
+  _GH_APP_LAST_ERROR="could not resolve the GitHub App installation for ${nwo} (HTTP ${http_code} -- is the app installed on this repo/org?)"
+  return 1
+}
+
+# _github_app_api_mint_token <installation_id> -> echoes
+# '{"token":...,"expires_at":...}' on stdout. Requires a fresh JWT.
+_github_app_api_mint_token() {
+  local installation_id="$1" jwt resp http_code body
+  jwt=$(github_app_jwt) || return 1
+  resp=$(curl -sS -w '\n%{http_code}' -X POST \
+    -H "Authorization: Bearer $jwt" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/app/installations/${installation_id}/access_tokens" 2>/dev/null) || {
+    _GH_APP_LAST_ERROR="could not reach the GitHub API to mint an installation token for installation ${installation_id}"
+    return 1
+  }
+  http_code=$(echo "$resp" | tail -1)
+  body=$(echo "$resp" | sed '$d')
+  if [[ "$http_code" -ge 200 && "$http_code" -lt 300 ]]; then
+    echo "$body"
+    return 0
+  fi
+  _GH_APP_LAST_ERROR="could not mint an installation token for installation ${installation_id} (HTTP ${http_code})"
+  return 1
+}
+
+# --- Top-level entry point ---
+
+# github_app_get_token <owner/repo> -> echoes a valid installation token on
+# stdout, minting or reusing the cache as needed. On success also sets
+# GITHUB_APP_INSTALLATION_ID and GITHUB_APP_TOKEN_EXPIRES_AT (non-secret).
+# Returns 1 (with $_GH_APP_LAST_ERROR set) on any failure -- callers MUST
+# treat that as "fall back to ambient auth", not a hard error (#4430 AC:
+# expired/revoked/unreadable key falls back rather than hard-failing).
+github_app_get_token() {
+  local nwo="$1"
+  if ! github_app_configured; then
+    return 1
+  fi
+  local owner="${nwo%%/*}"
+  if [[ -z "$owner" || "$owner" == "$nwo" ]]; then
+    _GH_APP_LAST_ERROR="expected owner/repo, got '${nwo}'"
+    return 1
+  fi
+
+  local installation_id
+  installation_id=$(cat "$(_github_app_installation_cache_path "$owner")" 2>/dev/null || echo "")
+  if [[ -z "$installation_id" ]]; then
+    installation_id=$(_github_app_api_get_installation "$nwo") || return 1
+    printf '%s' "$installation_id" > "$(_github_app_installation_cache_path "$owner")"
+  fi
+
+  local cached token expires_at expires_epoch
+  cached=$(_github_app_read_cache "$installation_id" || echo "")
+  if [[ -n "$cached" ]]; then
+    token=$(echo "$cached" | jq -r '.token')
+    expires_at=$(echo "$cached" | jq -r '.expires_at')
+    expires_epoch=$(_github_app_parse_iso8601 "$expires_at" || echo "")
+    if ! _github_app_needs_remint "$expires_epoch"; then
+      GITHUB_APP_INSTALLATION_ID="$installation_id"
+      GITHUB_APP_TOKEN_EXPIRES_AT="$expires_at"
+      echo "$token"
+      return 0
+    fi
+  fi
+
+  local mint_resp
+  mint_resp=$(_github_app_api_mint_token "$installation_id") || return 1
+  token=$(echo "$mint_resp" | jq -r '.token')
+  expires_at=$(echo "$mint_resp" | jq -r '.expires_at')
+  if [[ -z "$token" || "$token" == "null" ]]; then
+    _GH_APP_LAST_ERROR="installation token mint response for installation ${installation_id} did not include a token"
+    return 1
+  fi
+  _github_app_write_cache "$installation_id" "$token" "$expires_at"
+  GITHUB_APP_INSTALLATION_ID="$installation_id"
+  GITHUB_APP_TOKEN_EXPIRES_AT="$expires_at"
+  echo "$token"
+}
+
+# --- Executable CLI dispatch ---
+#
+# `loom-daemon` invokes this file as a subprocess (never sourced) via the two
+# subcommands below. Both ALWAYS exit 0 and communicate outcome through a JSON
+# envelope on stdout (`status` field) -- this sidesteps relying on distinct
+# process exit codes surviving a `Command` capture, and keeps the daemon-side
+# parser to "read one line of JSON, branch on `.status`".
+if [[ "${BASH_SOURCE[0]:-$0}" == "${0}" ]]; then
+  _gh_app_cmd="${1:-}"
+  case "$_gh_app_cmd" in
+    status)
+      if github_app_configured; then
+        jq -cn --arg app_id "$_GH_APP_ID" --arg key_path "$_GH_APP_KEY_PATH" \
+          '{status:"configured", app_id:$app_id, key_path:$key_path}'
+      else
+        jq -cn --arg message "$_GH_APP_LAST_ERROR" '{status:"not_configured", message:$message}'
+      fi
+      ;;
+    get-token)
+      shift || true
+      _nwo="${1:-}"
+      if [[ -z "$_nwo" ]]; then
+        jq -cn '{status:"error", message:"owner/repo argument required"}'
+        exit 0
+      fi
+      if ! github_app_configured; then
+        jq -cn --arg message "$_GH_APP_LAST_ERROR" '{status:"not_configured", message:$message}'
+        exit 0
+      fi
+      if _gh_app_token=$(github_app_get_token "$_nwo"); then
+        jq -cn --arg token "$_gh_app_token" --arg installation_id "$GITHUB_APP_INSTALLATION_ID" \
+          --arg app_id "$_GH_APP_ID" --arg expires_at "$GITHUB_APP_TOKEN_EXPIRES_AT" \
+          '{status:"ok", token:$token, installation_id:$installation_id, app_id:$app_id, expires_at:$expires_at}'
+      else
+        jq -cn --arg message "$_GH_APP_LAST_ERROR" '{status:"error", message:$message}'
+      fi
+      ;;
+    *)
+      echo "Usage: github-app-token.sh {status|get-token OWNER/REPO}" >&2
+      exit 64
+      ;;
+  esac
+fi

--- a/defaults/scripts/tests/test-github-app-token.sh
+++ b/defaults/scripts/tests/test-github-app-token.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# test-github-app-token.sh - Unit tests for github-app-token.sh (#4430)
+#
+# Covers, per the issue's acceptance criteria, all without a live GitHub App:
+#   - JWT construction: signature verifies against a generated test keypair,
+#     iat backdated ~60s, exp within GitHub's 10-minute ceiling.
+#   - Refresh-window logic (cache/re-mint decision).
+#   - Cache file permissions (0600) and no-secret-in-output.
+#   - Mechanism/fallback selection (config precedence: env beats config;
+#     unconfigured/unreadable key -> not configured, never a hard error).
+#
+# Usage:
+#   ./.loom/scripts/tests/test-github-app-token.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/lib"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: $1"
+}
+fail() {
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: $1"
+    [[ -n "${2:-}" ]] && echo "    $2"
+}
+
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "SKIP: openssl not available -- cannot test JWT signing"
+    exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "SKIP: jq not available -- github-app-token.sh requires it"
+    exit 0
+fi
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# A throwaway RSA keypair -- generated fresh per test run, never committed,
+# never used against a real GitHub App.
+KEY_PATH="$WORK_DIR/test-app-key.pem"
+PUB_PATH="$WORK_DIR/test-app-key.pub.pem"
+openssl genrsa -out "$KEY_PATH" 2048 >/dev/null 2>&1
+openssl rsa -in "$KEY_PATH" -pubout -out "$PUB_PATH" >/dev/null 2>&1
+chmod 600 "$KEY_PATH"
+
+# Isolate the token cache from the real $HOME for the whole test run.
+export LOOM_GITHUB_APP_CACHE_DIR="$WORK_DIR/cache"
+
+# Source the library under test.
+# shellcheck source=../lib/github-app-token.sh
+source "$LIB_DIR/github-app-token.sh"
+
+# ============================================================================
+# Mechanism / fallback selection (config precedence, #4061-style)
+# ============================================================================
+echo "Testing github_app_configured (mechanism/fallback selection)..."
+
+unset LOOM_GITHUB_APP_ID LOOM_GITHUB_APP_KEY_PATH 2>/dev/null || true
+REPO_ROOT="$WORK_DIR/no-config-repo"
+mkdir -p "$REPO_ROOT"
+if ! (REPO_ROOT="$REPO_ROOT" github_app_configured); then
+    pass "unconfigured (no env, no config) -> github_app_configured fails, i.e. fallback path"
+else
+    fail "unconfigured should NOT report configured"
+fi
+
+LOOM_GITHUB_APP_ID="12345" LOOM_GITHUB_APP_KEY_PATH="$KEY_PATH" \
+  REPO_ROOT="$REPO_ROOT" bash -c "
+    source '$LIB_DIR/github-app-token.sh'
+    github_app_configured
+  "
+if [[ $? -eq 0 ]]; then
+    pass "env LOOM_GITHUB_APP_ID + LOOM_GITHUB_APP_KEY_PATH -> configured"
+else
+    fail "env-configured app should report configured"
+fi
+
+# Config file precedence: env absent, config supplies both keys.
+CONFIG_REPO="$WORK_DIR/config-repo"
+mkdir -p "$CONFIG_REPO/.loom"
+cat > "$CONFIG_REPO/.loom/config.json" <<EOF
+{"forge":{"githubApp":{"appId":"99999","privateKeyPath":"$KEY_PATH"}}}
+EOF
+unset LOOM_GITHUB_APP_ID LOOM_GITHUB_APP_KEY_PATH 2>/dev/null || true
+if (REPO_ROOT="$CONFIG_REPO" bash -c "
+    source '$LIB_DIR/github-app-token.sh'
+    github_app_configured && [[ \"\$_GH_APP_ID\" == '99999' ]]
+  "); then
+    pass "config forge.githubApp.{appId,privateKeyPath} resolves when env is absent"
+else
+    fail "config-sourced app id/key path should resolve"
+fi
+
+# Env beats config: env app id should win over the config file's app id.
+if (LOOM_GITHUB_APP_ID="11111" REPO_ROOT="$CONFIG_REPO" bash -c "
+    source '$LIB_DIR/github-app-token.sh'
+    github_app_configured && [[ \"\$_GH_APP_ID\" == '11111' ]]
+  "); then
+    pass "env LOOM_GITHUB_APP_ID beats config forge.githubApp.appId"
+else
+    fail "env app id should take precedence over config"
+fi
+
+# Unreadable key path -> not configured, with a remedy-naming message, never
+# a hard failure (the caller sees this as 'fall back', not a crash).
+UNREADABLE_KEY="$WORK_DIR/does-not-exist.pem"
+if ! (LOOM_GITHUB_APP_ID="12345" LOOM_GITHUB_APP_KEY_PATH="$UNREADABLE_KEY" \
+      bash -c "source '$LIB_DIR/github-app-token.sh'; github_app_configured"); then
+    msg=$(LOOM_GITHUB_APP_ID="12345" LOOM_GITHUB_APP_KEY_PATH="$UNREADABLE_KEY" \
+      bash -c "source '$LIB_DIR/github-app-token.sh'; github_app_configured || echo \"\$_GH_APP_LAST_ERROR\"")
+    if [[ "$msg" == *"not readable"* ]]; then
+        pass "unreadable private key -> not configured, remedy-naming message"
+    else
+        fail "expected a 'not readable' remedy message" "got: $msg"
+    fi
+else
+    fail "unreadable private key should NOT report configured"
+fi
+
+# ============================================================================
+# JWT construction: signature verifies against the test public key
+# ============================================================================
+echo "Testing github_app_jwt..."
+
+export LOOM_GITHUB_APP_ID="424242"
+export LOOM_GITHUB_APP_KEY_PATH="$KEY_PATH"
+
+jwt=$(github_app_jwt)
+if [[ -z "$jwt" ]]; then
+    fail "github_app_jwt produced no output"
+else
+    signing_input="${jwt%.*}"
+    signature_b64="${jwt##*.}"
+    header_b64="${signing_input%%.*}"
+    payload_b64="${signing_input#*.}"
+
+    sig_file="$WORK_DIR/sig.bin"
+    _github_app_b64url_decode_to_file "$signature_b64" "$sig_file"
+
+    if printf '%s' "$signing_input" | openssl dgst -sha256 -verify "$PUB_PATH" -signature "$sig_file" >/dev/null 2>&1; then
+        pass "JWT signature verifies against the test public key"
+    else
+        fail "JWT signature did NOT verify against the test public key"
+    fi
+
+    # Decode header/payload (base64url -> file -> read as text; these are
+    # plain JSON, safe to read back into a bash variable unlike the raw
+    # signature bytes above).
+    header_file="$WORK_DIR/header.json"
+    payload_file="$WORK_DIR/payload.json"
+    _github_app_b64url_decode_to_file "$header_b64" "$header_file"
+    _github_app_b64url_decode_to_file "$payload_b64" "$payload_file"
+
+    alg=$(jq -r '.alg' "$header_file")
+    typ=$(jq -r '.typ' "$header_file")
+    if [[ "$alg" == "RS256" && "$typ" == "JWT" ]]; then
+        pass "JWT header declares alg=RS256, typ=JWT"
+    else
+        fail "unexpected JWT header" "alg=$alg typ=$typ"
+    fi
+
+    iss=$(jq -r '.iss' "$payload_file")
+    iat=$(jq -r '.iat' "$payload_file")
+    exp=$(jq -r '.exp' "$payload_file")
+    now=$(date +%s)
+    if [[ "$iss" == "424242" ]]; then
+        pass "JWT iss matches the configured app id"
+    else
+        fail "JWT iss mismatch" "expected 424242, got $iss"
+    fi
+
+    iat_skew=$((now - iat))
+    if [[ "$iat_skew" -ge 55 && "$iat_skew" -le 90 ]]; then
+        pass "JWT iat is backdated ~60s for clock-skew tolerance"
+    else
+        fail "JWT iat not backdated as expected" "now-iat=$iat_skew (want ~60)"
+    fi
+
+    lifetime=$((exp - iat))
+    if [[ "$lifetime" -le 600 ]]; then
+        pass "JWT lifetime is within GitHub's 10-minute ceiling"
+    else
+        fail "JWT lifetime exceeds the 10-minute ceiling" "lifetime=${lifetime}s"
+    fi
+fi
+
+# ============================================================================
+# Refresh-window logic
+# ============================================================================
+echo "Testing _github_app_needs_remint..."
+
+future_epoch=$(( $(date +%s) + 3600 ))
+if ! _github_app_needs_remint "$future_epoch"; then
+    pass "token with 1h remaining -> no remint needed"
+else
+    fail "token with 1h remaining should NOT need a remint"
+fi
+
+soon_epoch=$(( $(date +%s) + 120 ))
+if _github_app_needs_remint "$soon_epoch"; then
+    pass "token with 2min remaining -> remint needed (<10min window)"
+else
+    fail "token with 2min remaining SHOULD need a remint"
+fi
+
+boundary_epoch=$(( $(date +%s) + 599 ))
+if _github_app_needs_remint "$boundary_epoch"; then
+    pass "token with 599s remaining -> remint needed (just inside the 10min window)"
+else
+    fail "token with 599s remaining SHOULD need a remint"
+fi
+
+if _github_app_needs_remint ""; then
+    pass "malformed/empty expiry fails safe toward remint"
+else
+    fail "malformed/empty expiry should fail safe toward remint"
+fi
+
+# ============================================================================
+# Cache: 0600 perms, correct round-trip, no secret in unrelated output
+# ============================================================================
+echo "Testing token cache..."
+
+_github_app_write_cache "777" "ghs_supersecrettokenvalue1234567890" "2099-01-01T00:00:00Z"
+cache_file="$(_github_app_cache_path "777")"
+if [[ -f "$cache_file" ]]; then
+    perms=$(stat -c '%a' "$cache_file" 2>/dev/null || stat -f '%Lp' "$cache_file" 2>/dev/null)
+    if [[ "$perms" == "600" ]]; then
+        pass "cache file written at 0600"
+    else
+        fail "cache file has wrong permissions" "got $perms, want 600"
+    fi
+else
+    fail "cache file was not written"
+fi
+
+read_back=$(_github_app_read_cache "777")
+cached_token=$(echo "$read_back" | jq -r '.token')
+if [[ "$cached_token" == "ghs_supersecrettokenvalue1234567890" ]]; then
+    pass "cache round-trips the token value"
+else
+    fail "cache round-trip mismatch" "got: $cached_token"
+fi
+
+# No-secret-in-output: the `status` CLI path (and JWT signing errors) must
+# never leak a token/JWT/key value. Simulate a `get-token`-shaped diagnostic
+# by asserting the last-error string never contains the private key's PEM
+# body or the cached token above.
+key_body=$(tail -n +2 "$KEY_PATH" | head -n 1)
+status_output=$(LOOM_GITHUB_APP_ID="424242" LOOM_GITHUB_APP_KEY_PATH="$KEY_PATH" \
+  bash "$LIB_DIR/github-app-token.sh" status)
+if [[ "$status_output" != *"$key_body"* && "$status_output" != *"ghs_supersecrettokenvalue1234567890"* ]]; then
+    pass "\`status\` CLI output contains no key/token material"
+else
+    fail "\`status\` output leaked secret material" "$status_output"
+fi
+status_status=$(echo "$status_output" | jq -r '.status')
+if [[ "$status_status" == "configured" ]]; then
+    pass "\`status\` CLI reports configured when app id + readable key are set"
+else
+    fail "\`status\` CLI should report configured" "$status_output"
+fi
+
+unset LOOM_GITHUB_APP_ID LOOM_GITHUB_APP_KEY_PATH
+not_configured_output=$(bash "$LIB_DIR/github-app-token.sh" status)
+not_configured_status=$(echo "$not_configured_output" | jq -r '.status')
+if [[ "$not_configured_status" == "not_configured" ]]; then
+    pass "\`status\` CLI reports not_configured with no app credentials"
+else
+    fail "\`status\` CLI should report not_configured" "$not_configured_output"
+fi
+
+get_token_output=$(bash "$LIB_DIR/github-app-token.sh" get-token owner/repo)
+get_token_status=$(echo "$get_token_output" | jq -r '.status')
+if [[ "$get_token_status" == "not_configured" ]]; then
+    pass "\`get-token\` CLI falls back to not_configured (never a hard failure) when unconfigured"
+else
+    fail "\`get-token\` CLI should report not_configured when unconfigured" "$get_token_output"
+fi
+
+# --- Summary ---
+echo ""
+echo "────────────────────────────────"
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/loom-daemon/src/credential_preflight.rs
+++ b/loom-daemon/src/credential_preflight.rs
@@ -29,29 +29,70 @@
 //! The result is also carried in [`crate::types::DaemonStatusReport`] so an
 //! operator can see it via `loom-daemon status` without reading logs.
 //!
+//! # GitHub App identity (#4430) — a deliberate revision of the original
+//! "no new credential store" non-goal
+//!
+//! The original #4005 non-goal below stated this module would never
+//! provision, write, or manage a loom-specific credential file, reasoning
+//! that a second secret-at-rest surface added attack surface for no
+//! capability gain over the existing `GH_TOKEN`/keychain forwarding. #4430
+//! revisits that trade-off deliberately: every fleet host authenticating as
+//! the same personal account shares one 5,000/hr rate-limit bucket with the
+//! operator's own interactive use, and long-lived PATs sitting on cloud disks
+//! drift per-host. A GitHub App installation token is the opposite shape —
+//! **short-lived** (1h, minted on-host from an app private key the operator
+//! provisions once) and **per-installation rate-limited** — so the
+//! calculus changes: a small, deliberately-scoped token *cache* (never the
+//! private key itself, which stays wherever the operator put it) is worth
+//! the added surface.
+//!
+//! [`run_with_github_app`] is the new entry point that supersedes [`run`] at
+//! the call site in `main.rs`: it attempts the `"github-app"` mechanism
+//! first (via the shell helper below) and falls through to the byte-identical
+//! [`run`] ambient-`gh`-auth path whenever the app mechanism is unconfigured
+//! *or* fails for any reason (expired/revoked/unreadable key, network
+//! hiccup, GitHub API error) — see [`GithubAppOutcome`]. [`run`] itself is
+//! unchanged and remains the whole story for every host that has never heard
+//! of this feature (#4430 AC: "with them absent, behavior is unchanged").
+//!
+//! Minting itself is **shell, not Rust**: `loom-daemon` has no HTTP client or
+//! JWT/RSA crate (see `Cargo.toml`), so JWT signing (`openssl dgst -sha256
+//! -sign`) and the installation-token HTTP calls (`curl`) live in
+//! `defaults/scripts/lib/github-app-token.sh`, invoked here via `Command`
+//! exactly like every other forge call in this codebase. See that file's own
+//! header comment for the minting/caching/refresh algorithm.
+//!
 //! # Non-goals
 //!
-//! - **No new credential store.** This reads the credential `gh` would
-//!   already use (env vars it inherits, or its own store) — it never
-//!   provisions, writes, or manages a loom-specific PAT file. The existing
-//!   plist env-forwarding mechanism (`loom-daemon-start.sh`) already reaches
-//!   the daemon and every dispatched sweep child; a second secret-at-rest
-//!   surface would add attack surface for no capability gain.
+//! - **No secret ever crosses into a `CredentialPreflightReport` or a log
+//!   line.** The minted token is threaded back to the caller *only* via
+//!   [`GithubAppPreflight::minted_gh_token`] (for `main.rs` to
+//!   `std::env::set_var("GH_TOKEN", …)`) — never through [`log`], never
+//!   through [`crate::types::DaemonStatusReport`]. The report/status surface
+//!   carries only the non-secret fingerprint `app <id> installation <id>`.
 //! - **GitHub only.** The daemon's own forge calls all shell out to `gh`,
-//!   which only ever resolves GitHub credentials. `GITEA_TOKEN`/
+//!   which only ever resolves GitHub credentials (whether that's an ambient
+//!   credential or a `GH_TOKEN` this process minted itself). `GITEA_TOKEN`/
 //!   `FORGE_TOKEN` forwarding exists solely for dispatched sweep children
 //!   targeting a Gitea-backed repo — the daemon process itself never calls a
 //!   Gitea API, so there is nothing to preflight for it here. See
 //!   `.loom/docs/github-authentication.md` § "Headless and SSH-only daemon operation".
-//! - **Never blocks or hangs.** Bounded by [`PREFLIGHT_TIMEOUT`] via the
-//!   reused [`crate::main_health_gate::run_capture_with_timeout`] helper — an
-//!   unlocked-keychain prompt or a hung `gh` is exactly the failure mode this
-//!   preflight must survive, not itself trigger.
+//! - **Never blocks or hangs.** Bounded by [`PREFLIGHT_TIMEOUT`] /
+//!   [`GITHUB_APP_MINT_TIMEOUT`] via the reused
+//!   [`crate::main_health_gate::run_capture_with_timeout`] helper — an
+//!   unlocked-keychain prompt, a hung `gh`, or a hung mint script is exactly
+//!   the failure mode this preflight must survive, not itself trigger.
+//! - **No `--app-id`/`--app-key-file` fleet-provisioning flags in this PR.**
+//!   `loom-daemon/src/fleet/add_worker.rs` keeps its existing `--pat-file`
+//!   path unchanged; that flag is explicit follow-up work once this core
+//!   lands (#4430 scope note).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::time::Duration;
 
 use chrono::Utc;
+use serde_json::Value;
 
 use crate::main_health_gate::run_capture_with_timeout;
 use crate::types::CredentialPreflightReport;
@@ -243,6 +284,278 @@ pub fn run(probe: &dyn GhAuthProbe) -> CredentialPreflightReport {
     report
 }
 
+// ============================================================================
+// GitHub App identity (#4430)
+// ============================================================================
+
+/// Bound on the `github-app-token.sh get-token` subprocess: a local JWT sign
+/// (fast) plus up to two GitHub API round-trips (installation resolution +
+/// token mint). Generous headroom for a slow network without risking a hung
+/// preflight or refresh tick.
+pub const GITHUB_APP_MINT_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Default cadence for the background refresh tick that keeps the daemon's
+/// own `GH_TOKEN` process env current across a token's ~1h lifetime.
+/// Comfortably inside the 10-minute re-mint window the shell helper enforces,
+/// so a tick never arrives after the window has already closed.
+pub const GITHUB_APP_REFRESH_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Outcome of one GitHub App mint attempt (`github-app-token.sh get-token`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GithubAppOutcome {
+    /// No app id / private-key path configured anywhere (env or config) —
+    /// the load-bearing default. Every caller treats this identically to "no
+    /// GitHub App feature exists on this host": fall through to the ambient
+    /// `gh` auth path, never a failure.
+    NotConfigured,
+    /// A token was minted (or reused from the shell helper's on-disk cache).
+    /// `token` must NEVER be logged, printed, or serialized — only
+    /// `installation_id`/`app_id`/`expires_at` are safe to surface.
+    Minted {
+        token: String,
+        installation_id: String,
+        app_id: String,
+        expires_at: String,
+    },
+    /// Configured, but minting failed this attempt (unreadable/revoked key,
+    /// network failure, GitHub API error, malformed response, …). `reason`
+    /// is human-readable and already scrubbed of secret material by the
+    /// shell helper. Callers fall back to ambient auth rather than hard-fail.
+    Error(String),
+}
+
+/// Injectable seam for minting an installation token, mirroring
+/// [`GhAuthProbe`]. The real implementation shells out to
+/// `github-app-token.sh get-token <owner/repo>` (#4430) — no new Rust
+/// HTTP/JWT dependency, per the issue's shell-first mandate.
+pub trait GithubAppMinter {
+    /// Attempt to resolve a usable installation token for `owner_repo`
+    /// (`"owner/repo"`, the installation-selection key — see module docs).
+    fn mint(&self, owner_repo: &str) -> GithubAppOutcome;
+}
+
+/// The concrete minter: `bash <script_path> get-token <owner_repo>`, bounded
+/// by [`GITHUB_APP_MINT_TIMEOUT`].
+pub struct RealGithubAppMinter {
+    /// Path to `github-app-token.sh` (see [`resolve_github_app_script`]).
+    pub script_path: PathBuf,
+    /// Working directory for the subprocess (any existing directory works —
+    /// the script resolves its own config root independently).
+    pub cwd: PathBuf,
+}
+
+impl GithubAppMinter for RealGithubAppMinter {
+    fn mint(&self, owner_repo: &str) -> GithubAppOutcome {
+        let script_path_str = self.script_path.to_string_lossy().to_string();
+        let stdout = match run_capture_with_timeout(
+            "bash",
+            &[script_path_str.as_str(), "get-token", owner_repo],
+            &self.cwd,
+            GITHUB_APP_MINT_TIMEOUT,
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                return GithubAppOutcome::Error(format!(
+                    "could not run github-app-token.sh get-token: {e}"
+                ))
+            }
+        };
+        parse_github_app_response(&stdout)
+    }
+}
+
+/// Parse `github-app-token.sh`'s single-line JSON envelope
+/// (`{"status": "ok"|"not_configured"|"error", …}`) into a
+/// [`GithubAppOutcome`]. Split out from I/O so it is unit-testable without a
+/// real subprocess — mirrors [`resolve`].
+fn parse_github_app_response(stdout: &str) -> GithubAppOutcome {
+    let parsed: Value = match serde_json::from_str(stdout.trim()) {
+        Ok(v) => v,
+        Err(e) => {
+            return GithubAppOutcome::Error(format!(
+                "could not parse github-app-token.sh output ({e})"
+            ))
+        }
+    };
+    let status = parsed.get("status").and_then(Value::as_str).unwrap_or("");
+    match status {
+        "not_configured" => GithubAppOutcome::NotConfigured,
+        "ok" => {
+            let get = |k: &str| {
+                parsed
+                    .get(k)
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string()
+            };
+            let token = get("token");
+            if token.is_empty() {
+                return GithubAppOutcome::Error(
+                    "github-app-token.sh reported ok but returned no token".to_string(),
+                );
+            }
+            GithubAppOutcome::Minted {
+                token,
+                installation_id: get("installation_id"),
+                app_id: get("app_id"),
+                expires_at: get("expires_at"),
+            }
+        }
+        _ => {
+            let message = parsed
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("github-app-token.sh reported an unrecognized status")
+                .to_string();
+            GithubAppOutcome::Error(message)
+        }
+    }
+}
+
+/// Resolve the `github-app-token.sh` path: prefer the installed
+/// `.loom/scripts/lib/` copy, else the in-repo `defaults/scripts/lib/`
+/// source — mirrors `auto_update::ScriptAutoUpdateProbe::resolve_script`.
+/// `None` when neither exists (a stale install predating #4430, or a
+/// workspace root that isn't a Loom-managed checkout at all) — every caller
+/// treats a `None` exactly like [`GithubAppOutcome::NotConfigured`].
+#[must_use]
+pub fn resolve_github_app_script(root: &Path) -> Option<PathBuf> {
+    let installed = root.join(".loom/scripts/lib/github-app-token.sh");
+    if installed.exists() {
+        return Some(installed);
+    }
+    let source = root.join("defaults/scripts/lib/github-app-token.sh");
+    if source.exists() {
+        return Some(source);
+    }
+    None
+}
+
+/// Resolve the `owner/repo` name-with-owner for `cwd`'s `origin` remote via a
+/// plain `git remote get-url` + URL parse — deliberately **not** a `gh` call,
+/// so this never depends on the very credential this module is trying to
+/// establish. Installation selection is derivable per repo (#4430: "GET
+/// /repos/{owner}/{repo}/installation resolves the installation for any repo
+/// the app can see"), so this is the key the shell helper caches against.
+#[must_use]
+pub fn nwo_from_git_remote(cwd: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let url = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    if url.is_empty() {
+        return None;
+    }
+    let stripped = url.strip_suffix(".git").unwrap_or(url.as_str());
+
+    let path = if let Some(rest) = stripped.strip_prefix("git@") {
+        // SSH: git@host:owner/repo
+        let (_host, p) = rest.split_once(':')?;
+        p
+    } else if let Some(rest) = stripped.strip_prefix("https://") {
+        // HTTPS: https://host/owner/repo
+        let (_host, p) = rest.split_once('/')?;
+        p
+    } else if let Some(rest) = stripped.strip_prefix("http://") {
+        let (_host, p) = rest.split_once('/')?;
+        p
+    } else {
+        return None;
+    };
+
+    let trimmed = path.trim_matches('/');
+    let (owner, repo) = trimmed.split_once('/')?;
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some(format!("{owner}/{repo}"))
+}
+
+/// The full startup preflight result when the GitHub App mechanism is in
+/// play: the report to surface (log line, `loom-daemon status`,
+/// [`crate::types::DaemonStatusReport`]) plus the minted token — if any —
+/// for the caller to export as the daemon process's own `GH_TOKEN`.
+///
+/// `minted_gh_token` is the ONLY channel a token value travels through; it is
+/// deliberately excluded from [`Self::report`] (and therefore from every log
+/// line and status surface) by construction.
+pub struct GithubAppPreflight {
+    pub report: CredentialPreflightReport,
+    pub minted_gh_token: Option<String>,
+}
+
+/// Runs the full #4430 preflight: attempt a GitHub App mint first (when
+/// `owner_repo` resolved at all); fall through to the byte-identical
+/// pre-#4430 [`run`] (ambient `gh` auth) whenever the app mechanism is
+/// unconfigured, and STILL fall through — with an additional log line naming
+/// the failure — when it is configured but minting fails for any reason
+/// (#4430 AC: "daemon falls back to ambient auth rather than hard-failing").
+///
+/// This is the call site `main.rs` uses in place of [`run`] directly; `run`
+/// itself is unchanged, so a host with no `owner_repo` resolved (e.g. the
+/// daemon's workspace root isn't a git checkout) or no app configured gets
+/// exactly the pre-#4430 log lines and report shape.
+#[must_use]
+pub fn run_with_github_app(
+    gh_probe: &dyn GhAuthProbe,
+    app_minter: &dyn GithubAppMinter,
+    owner_repo: Option<&str>,
+) -> GithubAppPreflight {
+    let Some(owner_repo) = owner_repo else {
+        return GithubAppPreflight {
+            report: run(gh_probe),
+            minted_gh_token: None,
+        };
+    };
+
+    match app_minter.mint(owner_repo) {
+        GithubAppOutcome::NotConfigured => GithubAppPreflight {
+            report: run(gh_probe),
+            minted_gh_token: None,
+        },
+        GithubAppOutcome::Minted {
+            token,
+            installation_id,
+            app_id,
+            ..
+        } => {
+            let fingerprint = format!("app {app_id} installation {installation_id}");
+            log::info!(
+                "credential_preflight: forge credential resolved via github-app ({fingerprint}) — #4430"
+            );
+            GithubAppPreflight {
+                report: CredentialPreflightReport {
+                    ok: true,
+                    mechanism: "github-app".to_string(),
+                    fingerprint: Some(fingerprint),
+                    message: format!(
+                        "authenticated via github-app (app {app_id}, installation {installation_id})"
+                    ),
+                    checked_at: Utc::now(),
+                },
+                minted_gh_token: Some(token),
+            }
+        }
+        GithubAppOutcome::Error(reason) => {
+            log::error!(
+                "credential_preflight: github-app mint failed ({reason}); falling back to ambient \
+                 gh auth — #4430"
+            );
+            let mut fallback = run(gh_probe);
+            fallback.message = format!("github-app unavailable ({reason}); {}", fallback.message);
+            GithubAppPreflight {
+                report: fallback,
+                minted_gh_token: None,
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -371,5 +684,205 @@ mod tests {
             cwd: std::env::temp_dir(),
         };
         assert!(probe.probe().is_err());
+    }
+
+    // ------------------------------------------------------------------
+    // GitHub App identity (#4430)
+    // ------------------------------------------------------------------
+
+    struct FixedMinter(GithubAppOutcome);
+    impl GithubAppMinter for FixedMinter {
+        fn mint(&self, _owner_repo: &str) -> GithubAppOutcome {
+            self.0.clone()
+        }
+    }
+
+    #[test]
+    fn parse_github_app_response_not_configured() {
+        let outcome = parse_github_app_response(
+            r#"{"status":"not_configured","message":"github app not configured"}"#,
+        );
+        assert_eq!(outcome, GithubAppOutcome::NotConfigured);
+    }
+
+    #[test]
+    fn parse_github_app_response_ok_minted() {
+        let outcome = parse_github_app_response(
+            r#"{"status":"ok","token":"ghs_abc123","installation_id":"999","app_id":"42","expires_at":"2099-01-01T00:00:00Z"}"#,
+        );
+        assert_eq!(
+            outcome,
+            GithubAppOutcome::Minted {
+                token: "ghs_abc123".to_string(),
+                installation_id: "999".to_string(),
+                app_id: "42".to_string(),
+                expires_at: "2099-01-01T00:00:00Z".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_github_app_response_ok_without_token_is_an_error_never_a_panic() {
+        let outcome = parse_github_app_response(r#"{"status":"ok"}"#);
+        assert!(matches!(outcome, GithubAppOutcome::Error(_)));
+    }
+
+    #[test]
+    fn parse_github_app_response_error_status_carries_message() {
+        let outcome = parse_github_app_response(
+            r#"{"status":"error","message":"could not resolve installation"}"#,
+        );
+        assert_eq!(outcome, GithubAppOutcome::Error("could not resolve installation".to_string()));
+    }
+
+    #[test]
+    fn parse_github_app_response_malformed_json_never_panics() {
+        let outcome = parse_github_app_response("not json at all");
+        assert!(matches!(outcome, GithubAppOutcome::Error(_)));
+    }
+
+    #[test]
+    fn run_with_github_app_no_owner_repo_falls_back_to_ambient_run() {
+        let stdout = json_active("GH_TOKEN", "success", "");
+        let probe = FixedProbe(Ok(stdout));
+        let minter = FixedMinter(GithubAppOutcome::NotConfigured);
+        let result = run_with_github_app(&probe, &minter, None);
+        assert_eq!(result.report.mechanism, "GH_TOKEN");
+        assert!(result.minted_gh_token.is_none());
+    }
+
+    #[test]
+    fn run_with_github_app_not_configured_falls_back_to_ambient_run_byte_identical() {
+        let stdout = json_active("keyring", "success", "octocat");
+        let probe = FixedProbe(Ok(stdout));
+        let minter = FixedMinter(GithubAppOutcome::NotConfigured);
+        let result = run_with_github_app(&probe, &minter, Some("owner/repo"));
+        // Identical to calling `run(&probe)` directly (modulo `checked_at`,
+        // which is a fresh `Utc::now()` timestamp on each call).
+        let direct = run(&probe);
+        assert_eq!(result.report.ok, direct.ok);
+        assert_eq!(result.report.mechanism, direct.mechanism);
+        assert_eq!(result.report.fingerprint, direct.fingerprint);
+        assert_eq!(result.report.message, direct.message);
+        assert!(result.minted_gh_token.is_none());
+    }
+
+    #[test]
+    fn run_with_github_app_minted_reports_github_app_mechanism_and_returns_token() {
+        let stdout = json_active("keyring", "success", "octocat");
+        let probe = FixedProbe(Ok(stdout));
+        let minter = FixedMinter(GithubAppOutcome::Minted {
+            token: "ghs_supersecrettoken".to_string(),
+            installation_id: "999".to_string(),
+            app_id: "42".to_string(),
+            expires_at: "2099-01-01T00:00:00Z".to_string(),
+        });
+        let result = run_with_github_app(&probe, &minter, Some("owner/repo"));
+        assert!(result.report.ok);
+        assert_eq!(result.report.mechanism, "github-app");
+        assert_eq!(result.report.fingerprint.as_deref(), Some("app 42 installation 999"));
+        assert!(!result.report.message.contains("ghs_supersecrettoken"));
+        assert_eq!(result.minted_gh_token.as_deref(), Some("ghs_supersecrettoken"));
+    }
+
+    #[test]
+    fn run_with_github_app_error_falls_back_to_ambient_auth_never_a_hard_failure() {
+        let stdout = json_active("GH_TOKEN", "success", "");
+        let probe = FixedProbe(Ok(stdout));
+        let minter =
+            FixedMinter(GithubAppOutcome::Error("github app private key not readable".to_string()));
+        let result = run_with_github_app(&probe, &minter, Some("owner/repo"));
+        // Falls back to the ambient mechanism (still resolvable here), not a
+        // hard failure -- mirrors the #4430 AC on expired/revoked/unreadable
+        // keys.
+        assert!(result.report.ok);
+        assert_eq!(result.report.mechanism, "GH_TOKEN");
+        assert!(result.report.message.contains("github-app unavailable"));
+        assert!(result.minted_gh_token.is_none());
+    }
+
+    #[test]
+    fn nwo_from_git_remote_parses_ssh_and_https_urls() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+
+        let init = Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(path)
+            .status()
+            .unwrap();
+        assert!(init.success());
+
+        let add = Command::new("git")
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:rjwalters/loom.git",
+            ])
+            .current_dir(path)
+            .status()
+            .unwrap();
+        assert!(add.success());
+
+        assert_eq!(nwo_from_git_remote(path), Some("rjwalters/loom".to_string()));
+
+        let set_url = Command::new("git")
+            .args([
+                "remote",
+                "set-url",
+                "origin",
+                "https://github.com/2AMLogic/klayout-tools.git",
+            ])
+            .current_dir(path)
+            .status()
+            .unwrap();
+        assert!(set_url.success());
+
+        assert_eq!(nwo_from_git_remote(path), Some("2AMLogic/klayout-tools".to_string()));
+    }
+
+    #[test]
+    fn nwo_from_git_remote_no_remote_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let init = Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(dir.path())
+            .status()
+            .unwrap();
+        assert!(init.success());
+        assert_eq!(nwo_from_git_remote(dir.path()), None);
+    }
+
+    #[test]
+    fn resolve_github_app_script_prefers_installed_over_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join(".loom/scripts/lib")).unwrap();
+        std::fs::create_dir_all(root.join("defaults/scripts/lib")).unwrap();
+        std::fs::write(
+            root.join("defaults/scripts/lib/github-app-token.sh"),
+            "#!/usr/bin/env bash\n",
+        )
+        .unwrap();
+        // Only the source copy exists -> that one wins.
+        assert_eq!(
+            resolve_github_app_script(root),
+            Some(root.join("defaults/scripts/lib/github-app-token.sh"))
+        );
+
+        std::fs::write(root.join(".loom/scripts/lib/github-app-token.sh"), "#!/usr/bin/env bash\n")
+            .unwrap();
+        // Both exist -> the installed copy wins.
+        assert_eq!(
+            resolve_github_app_script(root),
+            Some(root.join(".loom/scripts/lib/github-app-token.sh"))
+        );
+    }
+
+    #[test]
+    fn resolve_github_app_script_neither_present_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(resolve_github_app_script(dir.path()), None);
     }
 }

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -1261,18 +1261,111 @@ async fn main() -> Result<()> {
         Err(e) => log::warn!("sweep_registry: reconstruction failed: {e}"),
     }
 
-    // Startup forge-credential preflight (Issue #4005). Resolved once, here —
-    // immediately before the claim-reconciliation pass below, the daemon's
-    // first `gh` consumer — so a headless/SSH-only start with neither an
-    // exported GH_TOKEN/GITHUB_TOKEN nor an unlockable GUI login keychain is
-    // diagnosed loudly at boot instead of surfacing as silent per-tick 401s
-    // for the life of the process. Non-fatal and bounded (same posture as the
-    // reconciliation pass itself): a `gh` hiccup here never blocks startup.
+    // Startup forge-credential preflight (Issue #4005; GitHub App identity
+    // mechanism added by #4430). Resolved once, here — immediately before the
+    // claim-reconciliation pass below, the daemon's first `gh` consumer — so
+    // a headless/SSH-only start with neither an exported GH_TOKEN/GITHUB_TOKEN
+    // nor an unlockable GUI login keychain is diagnosed loudly at boot
+    // instead of surfacing as silent per-tick 401s for the life of the
+    // process. Non-fatal and bounded (same posture as the reconciliation pass
+    // itself): a `gh` hiccup here never blocks startup.
+    //
+    // #4430: when a GitHub App id + private key are configured (env or
+    // `forge.githubApp.*` config — see `defaults/scripts/lib/github-app-token.sh`),
+    // this mints a short-lived installation token and exports it as this
+    // process's own `GH_TOKEN`, so every `gh`/`git` child the daemon spawns
+    // from this point on inherits it. Absent that config, `owner_repo`
+    // resolves fine but the shell helper reports "not_configured" and
+    // `run_with_github_app` falls through to the byte-identical pre-#4430
+    // `run(...)` path below — no behavior change for any host that hasn't
+    // opted in.
     let credential_preflight_probe = credential_preflight::RealGhAuthProbe {
         gh_bin: "gh".to_string(),
         cwd: sweep_workspace.clone(),
     };
-    let credential_preflight = credential_preflight::run(&credential_preflight_probe);
+    let github_app_script = credential_preflight::resolve_github_app_script(&sweep_workspace);
+    let github_app_owner_repo = credential_preflight::nwo_from_git_remote(&sweep_workspace);
+    let github_app_preflight = match &github_app_script {
+        Some(script_path) => {
+            let minter = credential_preflight::RealGithubAppMinter {
+                script_path: script_path.clone(),
+                cwd: sweep_workspace.clone(),
+            };
+            credential_preflight::run_with_github_app(
+                &credential_preflight_probe,
+                &minter,
+                github_app_owner_repo.as_deref(),
+            )
+        }
+        // No `github-app-token.sh` on disk at all (stale install predating
+        // #4430, or a workspace root with no `.loom`/`defaults` tree) —
+        // exactly the pre-#4430 path, with zero extra subprocess overhead.
+        None => credential_preflight::GithubAppPreflight {
+            report: credential_preflight::run(&credential_preflight_probe),
+            minted_gh_token: None,
+        },
+    };
+    if let Some(token) = &github_app_preflight.minted_gh_token {
+        // NEVER logged: only the fingerprint in `github_app_preflight.report`
+        // is. Exported into this process's own env so every `gh`/`git`
+        // child spawned from here on (Command::new without env_clear)
+        // inherits it.
+        std::env::set_var("GH_TOKEN", token);
+    }
+    let credential_preflight = github_app_preflight.report;
+
+    // #4430: keep the minted installation token fresh across its ~1h
+    // lifetime for a long-running daemon. A no-op tick (unconfigured, or the
+    // shell helper's own cache still has >10min left) costs a handful of
+    // cheap subprocess execs and never touches `GH_TOKEN`; a genuine mint
+    // failure is logged and the loop keeps whatever `GH_TOKEN` the process
+    // already has (fail-open, matching the startup preflight's posture).
+    if let (Some(script_path), Some(owner_repo)) = (&github_app_script, &github_app_owner_repo) {
+        let script_path = script_path.clone();
+        let cwd = sweep_workspace.clone();
+        let owner_repo = owner_repo.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(credential_preflight::GITHUB_APP_REFRESH_INTERVAL).await;
+                let script_path = script_path.clone();
+                let cwd = cwd.clone();
+                let owner_repo = owner_repo.clone();
+                let outcome = tokio::task::spawn_blocking(move || {
+                    let minter = credential_preflight::RealGithubAppMinter { script_path, cwd };
+                    credential_preflight::GithubAppMinter::mint(&minter, &owner_repo)
+                })
+                .await;
+                match outcome {
+                    Ok(credential_preflight::GithubAppOutcome::Minted {
+                        token,
+                        installation_id,
+                        app_id,
+                        ..
+                    }) => {
+                        std::env::set_var("GH_TOKEN", token);
+                        log::debug!(
+                            "credential_preflight: github-app refresh tick minted a token \
+                             (app {app_id} installation {installation_id}) — #4430"
+                        );
+                    }
+                    Ok(credential_preflight::GithubAppOutcome::NotConfigured) => {
+                        // Cheap no-op tick -- nothing to refresh.
+                    }
+                    Ok(credential_preflight::GithubAppOutcome::Error(reason)) => {
+                        log::warn!(
+                            "credential_preflight: github-app refresh tick failed ({reason}); \
+                             GH_TOKEN left unchanged — #4430"
+                        );
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "credential_preflight: github-app refresh task join error: {e} — #4430"
+                        );
+                    }
+                }
+            }
+        });
+    }
 
     // GitHub rate-limit circuit breaker (#4429). Registered here — before the
     // startup reconciliation passes just below — because *every* gh-polling

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -1456,21 +1456,27 @@ pub struct CapacityReport {
     pub token_bound: bool,
 }
 
-/// Startup forge-credential preflight snapshot (#4005) — see
-/// [`crate::credential_preflight`] for the resolution logic. Resolved exactly
-/// once, before the daemon's first `gh` consumer, so headless/SSH-only
-/// operation (no unlockable GUI login keychain) is diagnosed loudly at boot
-/// instead of surfacing as an unexplained per-tick `401` on every forge call.
+/// Startup forge-credential preflight snapshot (#4005; GitHub App identity
+/// mechanism added by #4430) — see [`crate::credential_preflight`] for the
+/// resolution logic. Resolved exactly once, before the daemon's first `gh`
+/// consumer, so headless/SSH-only operation (no unlockable GUI login
+/// keychain) is diagnosed loudly at boot instead of surfacing as an
+/// unexplained per-tick `401` on every forge call.
 ///
 /// GitHub-only: the daemon's own forge calls all shell out to `gh`, which
-/// resolves GitHub credentials exclusively. `GITEA_TOKEN`/`FORGE_TOKEN`
-/// forwarding (`loom-daemon-start.sh`) exists only for dispatched sweep
-/// children targeting a Gitea-backed repo — the daemon process itself never
-/// calls a Gitea API, so there is nothing here to preflight for it.
+/// resolves GitHub credentials exclusively (whether that's an ambient
+/// `GH_TOKEN`/keyring credential, or a `GH_TOKEN` this process minted itself
+/// via the `"github-app"` mechanism below and exported into its own
+/// environment). `GITEA_TOKEN`/`FORGE_TOKEN` forwarding (`loom-daemon-start.sh`)
+/// exists only for dispatched sweep children targeting a Gitea-backed repo —
+/// the daemon process itself never calls a Gitea API, so there is nothing
+/// here to preflight for it.
 ///
 /// **Never carries a token value** — only a resolution-mechanism label and a
-/// non-secret fingerprint (last 4 chars of an env-sourced token, or the
-/// authenticated `gh` login for a credential-store resolution).
+/// non-secret fingerprint (last 4 chars of an env-sourced token, the
+/// authenticated `gh` login for a credential-store resolution, or `app
+/// <id> installation <id>` for the GitHub App mechanism — never the minted
+/// token itself).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CredentialPreflightReport {
     /// `true` when a usable GitHub credential was resolved; `false` when
@@ -1480,13 +1486,17 @@ pub struct CredentialPreflightReport {
     pub ok: bool,
     /// Which mechanism resolved the credential: `"GH_TOKEN"` / `"GITHUB_TOKEN"`
     /// (the daemon's own process environment) or `gh`'s own `tokenSource`
-    /// (e.g. `"keyring"`, `"oauth_token"`) reported by `gh auth status`.
+    /// (e.g. `"keyring"`, `"oauth_token"`) reported by `gh auth status`;
+    /// `"github-app"` when a GitHub App installation token was minted and
+    /// exported as `GH_TOKEN` (#4430 — see
+    /// [`crate::credential_preflight::resolve_with_github_app`]).
     /// `"none"` when nothing resolved; `"unknown"` when the probe itself
     /// failed to run. NEVER a token value.
     pub mechanism: String,
     /// A non-secret fingerprint: the last 4 characters of an env-sourced
-    /// token, or the authenticated `gh` login for a credential-store
-    /// resolution. `None` when no credential resolved.
+    /// token, the authenticated `gh` login for a credential-store
+    /// resolution, or `app <id> installation <id>` for the `"github-app"`
+    /// mechanism. `None` when no credential resolved.
     pub fingerprint: Option<String>,
     /// Human-readable, log/print-safe summary — never contains a token.
     /// Names both remediations (export `GH_TOKEN` before starting the


### PR DESCRIPTION
## Summary

Adds a GitHub App identity mechanism for fleet hosts, so the daemon can
authenticate via short-lived (1h) installation tokens minted on-host from an
app private key, instead of every host sharing the same personal-account
rate-limit bucket. Fallback-first: with no app credentials configured (the
default), `loom-daemon` behaves byte-identically to before this PR.

## Changes

- `defaults/scripts/lib/github-app-token.sh` (new): shell-only (openssl +
  curl + jq) RS256 JWT minting, `GET /repos/{owner}/{repo}/installation`
  installation resolution (cached per-owner), and installation-token
  fetch/cache/refresh (cache file `0600`, re-mint when <10 min of lifetime
  remain). Config precedence env > config, matching the `GiteaConfig`
  pattern (#4061): `LOOM_GITHUB_APP_ID`/`LOOM_GITHUB_APP_KEY_PATH` env beat
  `forge.githubApp.appId`/`forge.githubApp.privateKeyPath` config. Exposes
  an executable CLI (`status`, `get-token OWNER/REPO`) that always exits 0
  and communicates outcome via a `{"status": ...}` JSON envelope, so the
  daemon-side Rust caller never has to rely on subtle exit-code semantics.
- `defaults/scripts/tests/test-github-app-token.sh` (new): 20 assertions —
  JWT signature verifies against a generated throwaway RSA keypair, header/
  claims correctness (`iat` backdated ~60s, `exp` within GitHub's 10-minute
  ceiling), refresh-window boundary logic, cache-file `0600` permissions and
  round-trip, config precedence (env beats config; unreadable key => not
  configured), and no-secret-in-output. None require a live GitHub App.
- `loom-daemon/src/credential_preflight.rs`: new `GithubAppOutcome` /
  `GithubAppMinter` / `RealGithubAppMinter` seam (mirrors the existing
  `GhAuthProbe` pattern) that shells out to `github-app-token.sh get-token`
  via `Command`, plus `run_with_github_app` -- the new preflight entry point
  that tries the app mechanism first and falls through to the byte-identical
  pre-existing `run(...)` (ambient `gh` auth) whenever unconfigured or on any
  mint failure. Revised the module's "no new credential store" non-goal
  doc -- deliberately, per the issue's guidance -- to explain why a small,
  scoped token cache is worth the added surface this time.
- `loom-daemon/src/types.rs`: extended `CredentialPreflightReport`'s doc
  comments to describe the new `"github-app"` mechanism value and its
  `app <id> installation <id>` fingerprint shape (no new field needed -- the
  existing generic `mechanism`/`fingerprint` fields already cover it, so
  `loom-daemon status` picks this up for free).
- `loom-daemon/src/main.rs`: wires the app-token mint attempt ahead of the
  claim-reconciliation startup pass (the daemon's first `gh` consumer),
  exports a minted token as the daemon's own `GH_TOKEN` process env, and
  spawns a background refresh tick (every 5 min, comfortably inside the
  10-min re-mint window) that re-invokes the mint and refreshes `GH_TOKEN`
  so long-running daemons keep a live token across sweep-child spawns.
- `defaults/scripts/cli/loom-daemon-start.sh`: documents (no behavior
  change needed) how the static `GH_TOKEN`/`LOOM_*` env-forwarding into the
  launchd plist / systemd unit reconciles with the new minted-token path --
  `LOOM_GITHUB_APP_ID`/`LOOM_GITHUB_APP_KEY_PATH` already ride along via the
  existing `LOOM_*` forwarding pattern (a non-secret app id + a *path* to the
  key, never the key material), and any statically-forwarded `GH_TOKEN`
  becomes exactly the right fallback layer if minting ever fails.
- `defaults/docs/github-authentication.md`: new "GitHub App identity"
  section covering operator setup, config keys, and the fallback rule.

**Not in this PR** (explicitly out of scope per the issue): creating the
actual GitHub App / installing it / provisioning real credentials to hosts
(operator-only prerequisites -- this PR only builds and unit-tests the
mechanism); `loom-daemon/src/fleet/add_worker.rs` gaining `--app-id`/
`--app-key-file` flags (follow-up once this core lands -- the existing
`--pat-file` path is untouched).

**Informational (attribution grep, per Curator guidance -- not fixed here):**
`defaults/.claude/commands/loom/sweep.md` documents `--author @me` /
`--author rjwalters` as the convention for "my agent-filed issues/PRs".
Under `2am-loom[bot]` attribution, PRs/issues authored by the app would not
match `--author @me` run interactively by the human operator -- noted for
awareness, not addressed in this PR (no functional call site needed fixing
to satisfy this issue's acceptance criteria; `judge.md`'s self-review-
prevention note already generalizes fine to a bot identity).

I could not add CI wiring for the new test script in `.github/workflows/
ci.yml` (`installer-tests` job) -- pushing a change to a workflow file
requires a `workflow`-scoped token, and this session's `gh`/git credential
does not have that scope. The test script itself is fully self-contained
and passes locally (20/20); a maintainer with `workflow` scope can add:
```yaml
      - name: Run GitHub App token minting tests (#4430)
        run: bash defaults/scripts/tests/test-github-app-token.sh
```
to the `installer-tests` job (right after the `test-install-reinstall-safety.sh`
step) in a follow-up. The existing `shell-lint.yml` workflow already
shellchecks the new `.sh` files automatically (glob-based, no wiring needed).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| App credentials configured (env/config) => daemon-spawned `gh`/`git` authenticate via minted installation token exposed as `GH_TOKEN`; absent => behavior unchanged, fallback covered by tests | Done | `run_with_github_app_minted_reports_github_app_mechanism_and_returns_token`, `run_with_github_app_not_configured_falls_back_to_ambient_run_byte_identical` (Rust); `main.rs` sets `GH_TOKEN` only when a token was minted |
| JWT -> installation-token minting, per-owner installation resolution + refresh (cache 0600, re-mint <10min) | Done | `github-app-token.sh` (`github_app_jwt`, `_github_app_api_get_installation`, `github_app_get_token`); shell tests for JWT construction, cache 0600, and `_github_app_needs_remint` boundary (599s / 600s / 1h / malformed) |
| `credential_preflight` reports the app mechanism with a non-secret fingerprint in logs and `loom-daemon status`; module-doc non-goal revised | Done | `run_with_github_app` logs `mechanism="github-app"`, `fingerprint="app <id> installation <id>"`; module docs in `credential_preflight.rs` add a "GitHub App identity (#4430)" section explicitly revising the prior non-goal |
| No secret material ever logged; a test asserts fingerprint-only output | Done | Shell test "`status` CLI output contains no key/token material"; Rust tests assert `report.message`/`fingerprint` never contain the minted token value |
| Unit tests cover JWT construction (sig verifies against test pubkey), refresh-window logic, mechanism/fallback selection -- no live GitHub App required | Done | `test-github-app-token.sh` (20/20 local pass, no network); `credential_preflight` Rust tests (25/25 local pass) |
| `defaults/docs/github-authentication.md` gains a "GitHub App identity" section (setup, config keys, fallback rule) | Done | New section added, mirroring the operator checklist from the issue |

## Test Plan

- `bash defaults/scripts/tests/test-github-app-token.sh` -- 20/20 passed
  (throwaway RSA keypair, no network).
- `shellcheck --severity=warning` on both new `.sh` files and the modified
  `loom-daemon-start.sh` -- clean.
- `cargo test --lib credential_preflight` -- 25/25 passed; full `cargo test
  --lib` -- 1933/1933 passed.
- `cargo clippy --package loom-daemon --package loom-api -- -D warnings
  <same allow-flags as CI>` -- clean.
- `cargo fmt --all -- --check` and `cargo check --workspace --all-targets` --
  clean.
- Manual, pre-App (no operator prerequisites needed): confirmed via the
  `NotConfigured`/fallback tests that with no app config the daemon takes
  exactly the pre-#4430 `run(...)` path (same log lines, same report shape).

Closes #4430