### PR TITLE
curator: enforce closed complexity-marker enum, split fall-through diagnostics

### DIFF
--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -511,7 +511,7 @@ A `RELATED_OPEN_WORK` hit is **not** grounds for closing or auto-rescoping on it
 - Estimate complexity and effort when helpful
 - Break down large features into phased deliverables
 
-### Complexity routing marker (`<!-- loom:complexity=<tier> -->`, issues #3702, #4238)
+### Complexity routing marker (`<!-- loom:complexity=<tier> -->`, issues #3702, #4238, #4448)
 
 Emit a single machine-readable marker into the curated issue body so the sweep orchestrator routes the downstream Builder to the right model. Classify by **how expensive it is to be wrong**, not by how much work it looks like — the one question is *would a mistake be caught?*
 
@@ -519,24 +519,24 @@ Emit a single machine-readable marker into the curated issue body so the sweep o
 <!-- loom:complexity=mechanical -->
 ```
 
-There are **three** cost-of-being-wrong strata (issue #4238 added `mechanical` beneath `routine`):
+There are **three, and only three**, cost-of-being-wrong strata (issue #4238 added `mechanical` beneath `routine`). The value **MUST** be exactly one of `mechanical`, `routine`, or `complex` — no synonyms and no paraphrasing. Values like `trivial`, `large`, `moderate`, or `hard` are **not** valid; they fall through to `routine` at resolution time (see `resolve-tier-model.sh`) but corrupt the stratification signal, so treat an out-of-vocabulary value as a curation defect, not a style choice (issue #4448).
 
 | Value | Emit when |
 |---|---|
 | `mechanical` | A mistake is obvious just reading the change — file splits, dead-code deletion, renames, hardcoded constants, ARIA attributes, mock fixes. |
-| `routine` | The approach is clear once you've read the relevant code, and a mistake would surface in tests or review. Most bug fixes and small features. **Default.** |
+| `routine` | The approach is clear once you've read the relevant code, and a mistake would surface in tests or review. Most bug fixes and small features. **Default stratum** — take this one when genuinely torn between it and `mechanical`. |
 | `complex` | Deciding the approach takes judgement, and a mistake could pass tests and review unnoticed — architecture, cross-cutting change, subtle logic. Money, security, and destructive migrations are common cases, not the whole list. |
 
-- **Format**: an HTML comment (invisible in rendered Markdown, trivially greppable). Values are `mechanical` | `routine` | `complex`. Put it in your enhancement section (e.g. near the Problem Statement). **Absent marker ⇒ `routine`** — do **not** emit `<!-- loom:complexity=routine -->` explicitly.
+- **Format**: an HTML comment (invisible in rendered Markdown, trivially greppable). Put it in your enhancement section (e.g. near the Problem Statement). **Always emit the marker explicitly, including `routine`** — do not rely on omission. (`resolve-tier-model.sh` still treats an absent marker as `routine` for backward compatibility with issues curated before this rule, but that fallback is not a substitute for emitting one — the validator below blocks on an absent marker for exactly this reason.)
 - **What it does**: at Builder dispatch the sweep skill reads it as precedence **tier 2.5** (between tiers 2 and 3) and resolves the Builder's model from `sweep.tierModels[<runtime>][<tier>]` — `mechanical` routes cheaper, `complex` routes more capable. **Never name a model here; the tier is runtime-neutral.** See `sweep.md` → "Tier 2.5 — complexity marker".
 - **Hard bounds** (the router's authority is deliberately bounded): **never resolves to `fable`, and never a label.** The frontier model is reserved for the objective escalation ladder on Judge rejection or an explicit operator param. A `roleConfig.model` pin or explicit dispatch param (tiers 1–2) still overrides the marker.
 - **Cheap when the tier map is unconfigured.** With no `sweep.tierModels` in `.loom/config.json` and no `sweep.optimization` profile set (or set to `balanced`, the default), the marker is inert and dispatch falls through to the role default exactly as before — so adding markers is safe even before a workspace opts into cost/speed routing. A workspace opts in either by hand-authoring `sweep.tierModels`, or by setting `sweep.optimization: cost | speed` (a policy switch that materializes a preset over the same map — see `model-selection.md` "Optimization profile switch").
 - **Use sparingly / take the higher tier when torn.** Marking everything `complex` defeats the cheap-first default; marking real judgement calls `mechanical` risks a cheap model on expensive-to-be-wrong work. When genuinely torn, take the higher tier.
 
-Optionally verify a curated issue carries a valid marker before applying `loom:curated`:
+**Required before applying `loom:curated`**: run the validator below and confirm exit 0. This is not optional — do not apply `loom:curated` if it fails:
 
 ```bash
-./.loom/scripts/require-complexity-marker.sh <issue>   # exit 0 = has a valid tier
+./.loom/scripts/require-complexity-marker.sh <issue>   # exit 0 = has a valid tier; exit 1 = missing or out-of-vocabulary
 ```
 
 ## Where to Add Enhancements

--- a/defaults/scripts/resolve-tier-model.sh
+++ b/defaults/scripts/resolve-tier-model.sh
@@ -56,9 +56,22 @@ fi
 
 body="$(gh issue view "$ISSUE" -R "$REPO" --json body -q .body 2>/dev/null || true)"
 tier="$(printf '%s' "$body" | grep -o 'loom:complexity=[a-z]*' | head -1 | cut -d= -f2)"
+# Two distinct fall-through cases (#4448): an absent marker is the expected
+# default for issues curated before the marker existed (or before it became
+# mandatory) and stays a quiet info line; an out-of-vocabulary value (a
+# curator paraphrasing the closed enum — `trivial`/`large`/`moderate` etc.)
+# is a drift bug worth naming so it shows up in logs, not just silently
+# routed to routine. Both still resolve to `routine` — no behavior change.
 case "$tier" in
   mechanical|routine|complex) ;;
-  *) echo "$REPO#$ISSUE: no valid complexity marker -> routine" >&2; tier="routine" ;;
+  "")
+    echo "$REPO#$ISSUE: no complexity marker -> routine" >&2
+    tier="routine"
+    ;;
+  *)
+    echo "$REPO#$ISSUE: invalid complexity tier '$tier' -> routine" >&2
+    tier="routine"
+    ;;
 esac
 
 # --tier mode returns "" + exit 3 when the runtime/tier has no mapping.

--- a/defaults/scripts/tests/test-resolve-tier-model.sh
+++ b/defaults/scripts/tests/test-resolve-tier-model.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# test-resolve-tier-model.sh - Tests for resolve-tier-model.sh's complexity-tier
+# parsing (#4448).
+#
+# resolve-tier-model.sh's `grep -o 'loom:complexity=[a-z]*' | case` layer had no
+# shell-level test coverage — only the Python `--tier` lookup behind it
+# (loom-tools/tests/test_model_tiers.py) was exercised. This harness targets
+# that layer: valid marker, absent marker, out-of-vocabulary marker (the drift
+# bug #4448 was filed for — curators emitting `trivial`/`large`/`moderate`
+# instead of the closed `mechanical|routine|complex` enum), and first-marker-
+# wins when a body carries more than one marker.
+#
+# Style matches test-blame-issue.sh: a fake `gh` stub on PATH answers the
+# `gh issue view <issue> -R <repo> --json body -q .body` invocation the script
+# makes, keyed off issue number, so no network access is required. The repo
+# argument is passed explicitly to the script (its 3rd positional arg), so the
+# forge-remote auto-detection path is never exercised here.
+#
+# Usage:
+#   ./defaults/scripts/tests/test-resolve-tier-model.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RESOLVE_SCRIPT="$SCRIPTS_DIR/resolve-tier-model.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_contains() {
+    local needle="$1" haystack="$2" msg="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        pass "$msg"
+    else
+        fail "$msg (expected substring '$needle' in: $haystack)"
+    fi
+}
+
+assert_not_contains() {
+    local needle="$1" haystack="$2" msg="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        pass "$msg"
+    else
+        fail "$msg (unexpected substring '$needle' in: $haystack)"
+    fi
+}
+
+if [[ ! -x "$RESOLVE_SCRIPT" ]]; then
+    echo -e "${RED}FATAL${NC}: $RESOLVE_SCRIPT not found or not executable" >&2
+    exit 1
+fi
+
+# Scratch area for the fixture repo + fake gh -- cleaned on exit.
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/test-resolve-tier-model.XXXXXX")"
+# shellcheck disable=SC2329  # invoked indirectly via the EXIT trap below
+cleanup() { rm -rf "$WORKDIR" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# ---- Fake `gh` stub ---------------------------------------------------------
+# Answers exactly the `gh issue view <issue> -R <repo> --json body -q .body`
+# invocation resolve-tier-model.sh makes, keyed off a synthetic issue number.
+FAKE_BIN="$WORKDIR/bin"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/gh" <<'FAKEGH'
+#!/usr/bin/env bash
+if [[ "$1" == "issue" && "$2" == "view" ]]; then
+    issue="$3"
+    case "$issue" in
+        9001) echo "Some issue body.
+
+<!-- loom:complexity=mechanical -->
+
+More text." ;;
+        9002) echo "An issue body with no complexity marker at all." ;;
+        9003) echo "Drifted marker from a paraphrasing curator.
+
+<!-- loom:complexity=trivial -->
+" ;;
+        9004) echo "Body with two markers -- first one wins.
+
+<!-- loom:complexity=complex -->
+<!-- loom:complexity=mechanical -->
+" ;;
+        *) echo "" ;;
+    esac
+    exit 0
+fi
+exit 1
+FAKEGH
+chmod +x "$FAKE_BIN/gh"
+
+# ---- Fixture repo -------------------------------------------------------
+# resolve-tier-model.sh requires a git repo (for `git rev-parse --show-toplevel`
+# to locate .loom/config.json) and passes through to Python's model_tiers
+# --tier lookup, which needs loom-tools on the real source tree -- that lookup
+# is resolved relative to resolve-tier-model.sh's own location, not this
+# fixture's cwd, so an unconfigured fixture repo (no .loom/config.json) is
+# sufficient: it always falls through to "no tierModels/optimization-preset
+# entry" (exit 3), which every test here treats as expected, not a failure --
+# these tests target the tier-parsing layer, not model resolution.
+REPO="$WORKDIR/repo"
+mkdir -p "$REPO"
+git init --quiet "$REPO"
+
+run_resolve() {
+    local issue="$1"
+    ( cd "$REPO" && PATH="$FAKE_BIN:$PATH" "$RESOLVE_SCRIPT" "$issue" claude "owner/repo" )
+}
+
+# -------- Test 1: script exists and is executable --------
+echo "Test 1: script exists and is executable"
+if [[ -x "$RESOLVE_SCRIPT" ]]; then
+    pass "resolve-tier-model.sh is executable"
+else
+    fail "resolve-tier-model.sh is missing or not executable"
+fi
+
+# -------- Test 2: valid marker resolves to itself, no warning --------
+echo "Test 2: valid marker (mechanical) resolves as-is"
+err="$(run_resolve 9001 2>&1 1>/dev/null)"
+assert_contains "tier=mechanical" "$err" "valid marker resolves tier=mechanical"
+assert_not_contains "invalid complexity tier" "$err" "valid marker emits no invalid-tier warning"
+assert_not_contains "no complexity marker" "$err" "valid marker emits no absent-marker message"
+
+# -------- Test 3: absent marker -> routine, info-level, no warning --------
+echo "Test 3: absent marker falls through to routine (info-level, not a warning)"
+err="$(run_resolve 9002 2>&1 1>/dev/null)"
+assert_contains "no complexity marker -> routine" "$err" "absent marker logs the info-level fall-through message"
+assert_not_contains "invalid complexity tier" "$err" "absent marker never emits the invalid-tier warning"
+
+# -------- Test 4: out-of-vocabulary marker names the invalid value --------
+echo "Test 4: out-of-vocabulary marker ('trivial') is named in the warning"
+err="$(run_resolve 9003 2>&1 1>/dev/null)"
+assert_contains "invalid complexity tier 'trivial' -> routine" "$err" "invalid marker warning names the offending value"
+assert_not_contains "no complexity marker" "$err" "invalid marker is not conflated with the absent-marker message"
+
+# -------- Test 5: first-marker-wins when multiple markers are present --------
+echo "Test 5: first marker wins when a body carries two"
+err="$(run_resolve 9004 2>&1 1>/dev/null)"
+assert_contains "tier=complex" "$err" "first marker (complex) wins over the second (mechanical)"
+assert_not_contains "tier=mechanical" "$err" "second marker is not the one resolved"
+
+# -------- Test 6: all four cases still exit 3 (unconfigured tierModels) --------
+# Confirms the resolution layer itself is unchanged -- only the diagnostics
+# were split -- by checking the well-known "no mapping" fall-through exit code
+# every case shares in an unconfigured fixture repo.
+echo "Test 6: unconfigured repo still falls through to exit 3 in every case"
+rc=0
+run_resolve 9001 >/dev/null 2>&1 || rc=$?
+assert_contains "3" "$rc" "valid-marker case exits 3 (no tierModels configured)"
+rc=0
+run_resolve 9002 >/dev/null 2>&1 || rc=$?
+assert_contains "3" "$rc" "absent-marker case exits 3 (no tierModels configured)"
+rc=0
+run_resolve 9003 >/dev/null 2>&1 || rc=$?
+assert_contains "3" "$rc" "invalid-marker case exits 3 (no tierModels configured)"
+
+# -------- Summary --------
+echo ""
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo -e "${RED}FAILED${NC}: $TESTS_FAILED test(s) failed"
+    exit 1
+fi
+echo -e "${GREEN}OK${NC}: all tests passed"
+exit 0


### PR DESCRIPTION
Closes #4448

## Summary

Three curator sessions on 2026-07-29 emitted out-of-vocabulary complexity tiers (`trivial`, `large`, `moderate`) instead of the closed `mechanical|routine|complex` enum. This corrupts the tier-2.5 model-routing signal and the model-cost experiment's stratification key (#3725). Root cause: the enum was documented in prose but never structurally enforced — the validator existed but was only "Optionally" referenced.

## Changes

- **`defaults/roles/curator.md`** (a symlink to the command copy below, so one edit covers both) / **`defaults/.claude/commands/loom/curator.md`**: the "Complexity routing marker" section now states the enum with **MUST** + the three literal values adjacent to the marker-emission instruction, and makes `./.loom/scripts/require-complexity-marker.sh <issue>` a **required** step before applying `loom:curated` (previously "Optionally verify").

- **`defaults/scripts/resolve-tier-model.sh`**: split the single fall-through `case` arm into two — absent marker (info-level: `no complexity marker -> routine`) vs out-of-vocabulary value (warning that names the invalid value: `invalid complexity tier 'trivial' -> routine`). Both still resolve to `routine`; no change to the model-resolution behavior.

- **`defaults/scripts/tests/test-resolve-tier-model.sh`** (new): covers valid marker, absent marker, out-of-vocabulary marker (asserts the warning names the value), and first-marker-wins when a body carries more than one marker. Stubs `gh` via a PATH shim per the `test-blame-issue.sh` convention. Passes standalone (`bash defaults/scripts/tests/test-resolve-tier-model.sh` → 13/13); CI wiring is explicitly out of scope (#4451).

- **`defaults/scripts/require-complexity-marker.sh`**: unchanged. It already blocks (exit 1) on both an absent marker and an out-of-vocabulary one, which is exactly the behavior the resolved contradiction below requires — no code change needed.

## Design decisions (per the issue's request to record these)

1. **Contradiction resolution** (`curator.md` said "absent marker ⇒ routine — do not emit routine explicitly" while `require-complexity-marker.sh` blocks on an absent marker): resolved by requiring **explicit emission of one of the three values going forward**. This aligns with the validator becoming mandatory. `resolve-tier-model.sh` keeps `absent ⇒ routine` as a **backward-compatible fallback** for issues curated before this rule — it is no longer the recommended authoring pattern, just a safety net for older issues. The "do not emit `routine` explicitly" clause was deleted from the prompt.

2. **Normalization**: **no synonym map**. A `trivial→mechanical` / `moderate→routine` / `large→complex` table would institutionalize the exact drift this issue exists to stop, and would fork parsing logic across two bash scripts plus the future native port (#4275). Fall-through-only, with the new named warning as the enforcement/observability mechanism instead.

## Test plan

- [x] `bash defaults/scripts/tests/test-resolve-tier-model.sh` — 13/13 passed
- [x] Manual verification matching the issue's test plan: a scratch fixture with `loom:complexity=trivial` → stderr `invalid complexity tier 'trivial' -> routine`; no marker → stderr `no complexity marker -> routine` (no warning)
- [x] `bash -n` + `shellcheck` clean on `resolve-tier-model.sh` and the new test file
- [x] `pytest loom-tools/tests/test_model_tiers.py` — 119 passed (unaffected, confirms no regression on the Python side `resolve-tier-model.sh` shells out to)

## Out of scope (per the issue)

- Wiring `defaults/scripts/tests/` into CI (#4451)
- The native port of `model_tiers` (#4275)
- Retro-fixing the drifted markers on #4403/#4398 (any curator pass can do these independently)