### PR TITLE
fix(daemon): classify claude-wrapper pre-flight deaths and trip a workspace advisory

### DIFF
--- a/loom-daemon/src/event_bus.rs
+++ b/loom-daemon/src/event_bus.rs
@@ -23,8 +23,8 @@
 //! |-------|-----------|---------|
 //! | `sweep.issue.{N}.phase`   | Sweep child via `PublishEvent` | `{phase, pr_number?}` |
 //! | `sweep.issue.{N}.blocker` | Sweep child | `{reason, label_added}` |
-//! | `sweep.issue.{N}.exited`  | Daemon reaper | `{exit_code, duration_sec}` |
-//! | `sweep.issue.{N}.crashed` | Daemon reaper | `{checkpoint_phase}` |
+//! | `sweep.issue.{N}.exited`  | Daemon reaper | `{exit_code, duration_sec, death_class?}` |
+//! | `sweep.issue.{N}.crashed` | Daemon reaper | `{checkpoint_phase, death_class?}` |
 //! | `sweep.global.dispatch`   | Daemon | `{sweep_id, kind}` |
 //! | `sweep.global.completed`  | Daemon | `{sweep_id, outcome}` |
 //! | `epic.issue.{N}.decompose` | Epic supervisor | `{epic, action, state}` |
@@ -37,6 +37,7 @@
 //! | `daemon.drain.aborted`   | Daemon (IPC) | `{was_draining}` |
 //! | `daemon.drain.timeout`   | Drain supervisor | `{in_flight, forced, cancelled?}` |
 //! | `daemon.dispatch.headroom_advisory` | Daemon (IPC, `dispatch_sweep`) | `{repo_root, low_headroom, occupancy, dynamic_cap, cpu_headroom, disk_headroom, token_axis_limit, message}` |
+//! | `daemon.preflight.advisory` | Daemon reaper (`SweepRegistry`) | `{workspace_root, consecutive_deaths, marker, message}` |
 //!
 //! New topics require a follow-up issue — the taxonomy is intentionally
 //! pinned. The four `epic.issue.{N}.*` topics were authorized by **#3873**
@@ -51,8 +52,15 @@
 //! advisory-first headroom consult — fired on a state change into/out of
 //! "occupancy at or over the dynamic concurrency cap," mirroring
 //! `daemon.capacity.advisory`'s dedup discipline but scoped to a single
-//! dispatch request rather than the work finder's periodic tick. The bus
-//! accepts arbitrary topic
+//! dispatch request rather than the work finder's periodic tick. The
+//! `daemon.preflight.advisory` topic was authorized by **#4386** for the
+//! reaper's workspace-level claude-wrapper pre-flight-death tripwire — fired
+//! on a state change into/out of "N consecutive dispatches, across different
+//! issues, died at the wrapper's MCP-init pre-flight check before ever
+//! exec'ing the CLI," the same dedup discipline as the two advisories above.
+//! Per-death classification (`death_class`) rides the existing frozen
+//! `sweep.issue.{N}.exited` / `.crashed` topics as an additive payload field
+//! rather than a new topic (#4386). The bus accepts arbitrary topic
 //! strings (`publish` does not reject unknown topics) so the publisher side
 //! stays open for future extension, but the documented taxonomy is the
 //! contract subscribers should rely on.
@@ -507,6 +515,7 @@ mod tests {
             issue: 42,
             exit_code: Some(0),
             duration_sec: 12,
+            death_class: None,
             repo: None,
         });
         let _ = bus.publish_generic("sweep.global.dispatch", json!({"sweep_id": "x"}));

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1422,6 +1422,16 @@ pub fn build_daemon_status(
     // occupancy reaches it. Below the cap the limiter is work availability, not
     // any resource term — so gate the token-bound diagnosis on real occupancy.
     let capacity_bound = in_flight.len() >= dynamic_cap;
+    // Claude-wrapper pre-flight-death tripwire (#4386), read from the
+    // fallback/default workspace's own registry — mirrors the top-level
+    // `main_health_gate_*` fields' fallback-root scoping above/below.
+    let (preflight_advisory_active, preflight_advisory_message) = {
+        let registry = workspace_pool.get_or_provision(fallback_root);
+        let sr = registry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        sr.preflight_advisory()
+    };
     let capacity = crate::types::CapacityReport {
         ranking_present: ranking.is_some(),
         total_accounts: ranking.as_ref().map_or(token_pool_size, |r| r.total),
@@ -1444,6 +1454,8 @@ pub fn build_daemon_status(
         loadavg_1m,
         cpu_idle_fraction,
         capacity_bound,
+        preflight_advisory_active,
+        preflight_advisory_message,
         configured_max,
         per_token_concurrency,
         dynamic_cap,
@@ -4595,6 +4607,8 @@ exit 0
             loadavg_1m: Some(1.25),
             cpu_idle_fraction: Some(0.90),
             capacity_bound: false,
+            preflight_advisory_active: false,
+            preflight_advisory_message: None,
             configured_max: 5,
             per_token_concurrency: 2,
             dynamic_cap: 3,

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -1403,6 +1403,18 @@ async fn main() -> Result<()> {
         quarantine_config.insta_crash_secs
     );
 
+    // Claude-wrapper pre-flight-death workspace tripwire (#4386): resolve
+    // env > config > default for the default workspace so a fleet-wide,
+    // cross-issue spawn failure (e.g. a stale `.mcp.json`) trips a visible
+    // advisory instead of reading as an idle-healthy daemon.
+    let preflight_tripwire_config =
+        sweep_registry::resolve_preflight_tripwire_config(&sweep_workspace);
+    sweep.set_preflight_tripwire_config(preflight_tripwire_config);
+    log::info!(
+        "sweep_registry: pre-flight-death tripwire threshold={} (#4386)",
+        preflight_tripwire_config.threshold
+    );
+
     // Cross-host collision detection (#4085, Phase 0 of #4028): resolve env >
     // config > default(off) for the default workspace so a shared-backlog
     // deployment can measure the baseline duplicate-dispatch rate. Detection
@@ -3784,6 +3796,13 @@ fn build_status_json_value(
         // not any resource term, so scripted consumers don't misread the
         // token/CPU ceiling as a bottleneck at low occupancy.
         "capacity_bound": report.capacity_bound,
+        // Claude-wrapper pre-flight-death workspace tripwire (#4386): `true`
+        // means N consecutive dispatches, across different issues, died at
+        // the wrapper's MCP-init pre-flight check before ever reaching
+        // `# CLAUDE_CLI_START` — the classic stale-`.mcp.json` fleet-wide
+        // silent-failure signature. `message` is `null` when not tripped.
+        "preflight_advisory_active": report.preflight_advisory_active,
+        "preflight_advisory_message": report.preflight_advisory_message,
         "dynamic_cap": {
             "token_pool_size": report.token_pool_size,
             // The directory the daemon resolved for the pool above (#4292) —
@@ -4212,6 +4231,18 @@ fn print_status_human(
         }
     }
 
+    // Claude-wrapper pre-flight-death tripwire (#4386): printed prominently,
+    // ahead of the capacity section, so a fleet-wide spawn failure is visible
+    // even to an operator skimming just the top of `status`. Printed FIRST so
+    // the "not capacity-bound … the limiter is work availability" line further
+    // below is never the only diagnosis shown while this is tripped — see the
+    // guard on that line.
+    if report.preflight_advisory_active {
+        if let Some(msg) = &report.preflight_advisory_message {
+            println!("\n{msg}");
+        }
+    }
+
     // Capacity figures resolved from a single source (fresh probe when
     // available, else the daemon's ranking snapshot) so the cap's healthy-tokens
     // input, the Token-capacity summary, and the Per-token table all agree (#3936).
@@ -4363,11 +4394,21 @@ fn print_status_human(
                 // defect — at, say, 1 in-flight against a cap of 7 the limiter
                 // is simply how much ready work exists. Suppress the
                 // token-bound diagnosis.
-                println!(
-                    "  not capacity-bound ({} in flight, cap {dispatch_cap} — the limiter is \
-                     work availability, not tokens/disk/CPU)",
-                    report.in_flight.len(),
-                );
+                //
+                // #4386: while the pre-flight tripwire is active, this bare
+                // "work availability" line is actively misleading — every
+                // dispatch IS starting, it just dies within ~1s at
+                // claude-wrapper pre-flight, which reads as "no work" rather
+                // than "everything is crashing." The warning printed above
+                // already names the real cause, so suppress this line rather
+                // than let it stand uncontested.
+                if !report.preflight_advisory_active {
+                    println!(
+                        "  not capacity-bound ({} in flight, cap {dispatch_cap} — the limiter is \
+                         work availability, not tokens/disk/CPU)",
+                        report.in_flight.len(),
+                    );
+                }
             } else if rc.token_bound {
                 if rc.healthy == 0 {
                     println!(
@@ -4392,7 +4433,10 @@ fn print_status_human(
              health basis)",
             report.token_pool_size
         );
-        if !capacity_bound {
+        if !capacity_bound && !report.preflight_advisory_active {
+            // #4386: same suppression as the ranking-present branch above —
+            // the warning printed at the top of `status` already names the
+            // real cause while the tripwire is active.
             println!(
                 "  not capacity-bound ({} in flight, cap {dispatch_cap} — the limiter is work \
                  availability, not tokens/disk/CPU)",
@@ -7238,6 +7282,8 @@ mod status_client_tests {
             loadavg_1m: Some(1.25),
             cpu_idle_fraction: Some(0.90),
             capacity_bound: false,
+            preflight_advisory_active: false,
+            preflight_advisory_message: None,
             configured_max: 5,
             per_token_concurrency: 2,
             dynamic_cap: 3,

--- a/loom-daemon/src/safehouse.rs
+++ b/loom-daemon/src/safehouse.rs
@@ -562,6 +562,7 @@ pub fn event_to_envelope(event: &Event) -> Option<Envelope> {
             issue,
             exit_code,
             duration_sec,
+            death_class: _,
             repo,
         } => {
             let prefix = repo_issue_prefix(repo.as_deref(), *issue);
@@ -585,6 +586,7 @@ pub fn event_to_envelope(event: &Event) -> Option<Envelope> {
             issue,
             checkpoint_phase,
             classification: _,
+            death_class: _,
             repo,
         } => {
             let phase = checkpoint_phase.as_deref().unwrap_or("unknown");
@@ -1584,6 +1586,7 @@ mod tests {
             issue: 42,
             exit_code: Some(0),
             duration_sec: 12,
+            death_class: None,
             repo: Some("/repos/vibesql".to_owned()),
         };
         let env = event_to_envelope(&exited).unwrap();
@@ -1595,6 +1598,7 @@ mod tests {
             issue: 42,
             exit_code: Some(78),
             duration_sec: 24,
+            death_class: None,
             repo: Some("/repos/vibesql".to_owned()),
         };
         let env = event_to_envelope(&exited_failed).unwrap();
@@ -1604,6 +1608,7 @@ mod tests {
             issue: 42,
             checkpoint_phase: Some("judge".to_owned()),
             classification: None,
+            death_class: None,
             repo: Some("/repos/vibesql".to_owned()),
         };
         let env = event_to_envelope(&crashed).unwrap();

--- a/loom-daemon/src/serve.rs
+++ b/loom-daemon/src/serve.rs
@@ -625,6 +625,8 @@ mod tests {
             loadavg_1m: None,
             cpu_idle_fraction: None,
             capacity_bound: false,
+            preflight_advisory_active: false,
+            preflight_advisory_message: None,
             configured_max: 0,
             per_token_concurrency: 1,
             dynamic_cap: 0,
@@ -921,12 +923,14 @@ mod tests {
                 issue: 4392,
                 exit_code: Some(0),
                 duration_sec: 12,
+                death_class: None,
                 repo: None,
             },
             Event::SweepCrashed {
                 issue: 4392,
                 checkpoint_phase: Some("judge".to_string()),
                 classification: None,
+                death_class: None,
                 repo: None,
             },
             Event::SweepGlobalDispatch {

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -663,6 +663,74 @@ impl Default for QuarantineConfig {
     }
 }
 
+// ============================================================================
+// Claude-wrapper pre-flight-death workspace tripwire (Issue #4386)
+// ============================================================================
+//
+// The per-issue insta-crash quarantine above (#3939) never trips on a
+// fleet-wide, environmental spawn failure (e.g. a stale `.mcp.json`): a dozen
+// *different* issues each dying once at claude-wrapper pre-flight never
+// reaches any single issue's consecutive threshold, so nothing quarantines
+// and `loom-daemon dispatch` / `status` report success and an idle-healthy
+// daemon while every child dies within ~1s. This tripwire tracks the
+// consecutive pre-flight-death streak **across issues**, independent of the
+// per-issue tally, and trips a workspace-level advisory once the streak
+// reaches [`PreflightTripwireConfig::threshold`].
+
+/// Env var overriding the consecutive-pre-flight-death threshold at which the
+/// workspace-level advisory trips (Issue #4386). A zero/invalid value falls
+/// through to config/default.
+pub const PREFLIGHT_TRIPWIRE_THRESHOLD_ENV: &str = "LOOM_PREFLIGHT_TRIPWIRE_THRESHOLD";
+
+/// Default consecutive-pre-flight-death threshold before the workspace
+/// advisory trips (#4386).
+pub const DEFAULT_PREFLIGHT_TRIPWIRE_THRESHOLD: u32 = 3;
+
+/// Resolved pre-flight-death tripwire parameters (Issue #4386), set on the
+/// registry at construction so [`SweepRegistry::reap_once`] can enforce it
+/// without a per-tick config read. Mirrors [`QuarantineConfig`]'s shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreflightTripwireConfig {
+    /// Consecutive cross-issue pre-flight deaths before the workspace
+    /// advisory trips.
+    pub threshold: u32,
+}
+
+impl Default for PreflightTripwireConfig {
+    fn default() -> Self {
+        Self {
+            threshold: DEFAULT_PREFLIGHT_TRIPWIRE_THRESHOLD,
+        }
+    }
+}
+
+/// Read `.loom/config.json → autonomous.workFinder.preflightTripwire.threshold`
+/// (Issue #4386), soft-failing to `None` on a missing file, malformed JSON, or
+/// an absent block — mirrors [`read_quarantine_file_config`].
+#[must_use]
+fn read_preflight_tripwire_file_threshold(repo_root: &Path) -> Option<u32> {
+    let effective = crate::config_resolver::resolve_effective_config(repo_root);
+    crate::config_resolver::get_path(&effective, "autonomous.workFinder.preflightTripwire")
+        .and_then(|c| c.get("threshold"))
+        .and_then(serde_json::Value::as_u64)
+        .filter(|&n| n > 0)
+        .and_then(|n| u32::try_from(n).ok())
+}
+
+/// Resolve the full [`PreflightTripwireConfig`] for `repo_root` with
+/// precedence **env > config > default** (Issue #4386), mirroring
+/// [`resolve_quarantine_config`].
+#[must_use]
+pub fn resolve_preflight_tripwire_config(repo_root: &Path) -> PreflightTripwireConfig {
+    let threshold = std::env::var(PREFLIGHT_TRIPWIRE_THRESHOLD_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .filter(|&n| n > 0)
+        .or_else(|| read_preflight_tripwire_file_threshold(repo_root))
+        .unwrap_or(DEFAULT_PREFLIGHT_TRIPWIRE_THRESHOLD);
+    PreflightTripwireConfig { threshold }
+}
+
 /// Compute how long a spawn must wait so that consecutive spawns are separated
 /// by at least `stagger` (Issue #3887). Pure function of the last spawn instant,
 /// the configured gap, and the current instant — unit-tested in isolation.
@@ -1033,6 +1101,104 @@ fn classify_account_exhaustion(log_tail: &str) -> Option<&'static str> {
         .iter()
         .find(|(_, re)| re.is_match(log_tail))
         .map(|(label, _)| *label)
+}
+
+// ============================================================================
+// Claude-wrapper pre-flight-death classification (Issue #4386)
+// ============================================================================
+
+/// The claude-wrapper pre-flight-death signature table (#4386): explicit
+/// positive markers `defaults/scripts/claude-wrapper.sh` emits when it aborts
+/// **before ever exec'ing the CLI** (e.g. its MCP-init pre-flight probe
+/// fails). Matched against the tail of a dead sweep's log exactly like
+/// [`exhaustion_signatures`] — kept as a table so a future explicit
+/// wrapper-abort marker is one new row, not a new code path.
+///
+/// Unlike `exhaustion_signatures`, this table only covers markers with an
+/// explicit positive signature in the log. The complementary "the process
+/// died without EVER reaching `# CLAUDE_CLI_START`" case has no marker of its
+/// own — it's an absence, not a positive signature — so it is checked
+/// separately by [`classify_preflight_death`], after this table comes up
+/// empty.
+fn preflight_death_signatures() -> &'static [(&'static str, Regex)] {
+    static SIGS: OnceLock<Vec<(&'static str, Regex)>> = OnceLock::new();
+    SIGS.get_or_init(|| {
+        vec![(
+            "preflight-mcp-failed",
+            // Emitted by claude-wrapper.sh's MCP-init pre-flight check right
+            // before it bails without ever exec'ing the CLI. Case-sensitive:
+            // a literal sentinel token, not free-form prose (mirrors
+            // `RATE_LIMIT_ABORT` in `exhaustion_signatures`).
+            Regex::new(r"#\s*MCP_PREFLIGHT_FAILED").expect("valid static preflight regex"),
+        )]
+    })
+}
+
+/// The literal marker `claude-wrapper.sh` logs immediately before exec'ing the
+/// CLI (Issue #4386). Its absence from a dead sweep's ENTIRE log tail means
+/// the child never got that far — the complementary, absence-based half of
+/// [`classify_preflight_death`].
+const CLAUDE_CLI_START_MARKER: &str = "# CLAUDE_CLI_START";
+
+/// Classify `log_tail` as a claude-wrapper pre-flight death (Issue #4386):
+/// either an explicit [`preflight_death_signatures`] marker matched, or —
+/// when no explicit marker matched — the tail never reached
+/// [`CLAUDE_CLI_START_MARKER`] at all, meaning the child died before the
+/// wrapper ever exec'd the CLI. Returns the matched label, else `None`.
+///
+/// Callers are responsible for the precedence rule with
+/// [`classify_account_exhaustion`] (exhaustion wins — see
+/// `SweepRegistry::record_preflight_streak`) and for treating an
+/// unreadable/missing log as `None`/"unknown" rather than calling this with
+/// an empty tail (mirrors how [`classify_crash`] is fed by its callers).
+fn classify_preflight_death(log_tail: &str) -> Option<&'static str> {
+    if let Some((label, _)) = preflight_death_signatures()
+        .iter()
+        .find(|(_, re)| re.is_match(log_tail))
+    {
+        return Some(label);
+    }
+    if !log_tail.contains(CLAUDE_CLI_START_MARKER) {
+        return Some("preflight-no-cli-start");
+    }
+    None
+}
+
+/// The three-way outcome of consulting a dead sweep's log tail for the #4386
+/// pre-flight workspace tripwire, feeding
+/// `SweepRegistry::record_preflight_streak`'s streak update.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PreflightOutcome {
+    /// [`classify_preflight_death`] matched — this death counts toward (and
+    /// is reported as) the pre-flight streak.
+    Preflight(&'static str),
+    /// The tail reached [`CLAUDE_CLI_START_MARKER`] (and no exhaustion
+    /// signature matched) — definitively NOT a pre-flight death, resetting
+    /// the streak.
+    NonPreflight,
+    /// The log was unreadable/missing, OR an account-exhaustion signature
+    /// matched (exhaustion wins — that death is already attributed to the
+    /// account, #4122). Neutral: neither increments nor resets the streak.
+    Unknown,
+}
+
+/// Classify a dead sweep's (possibly absent) log tail for the #4386 pre-flight
+/// workspace tripwire. `tail` is `None` when the log was missing/unreadable at
+/// reap time.
+fn classify_preflight_outcome(tail: Option<&str>) -> PreflightOutcome {
+    let Some(t) = tail else {
+        return PreflightOutcome::Unknown;
+    };
+    if classify_account_exhaustion(t).is_some() {
+        // Exhaustion wins (#4122): this death is already attributed to the
+        // spawn account, so it must not also be counted toward — or reset —
+        // the pre-flight streak.
+        return PreflightOutcome::Unknown;
+    }
+    match classify_preflight_death(t) {
+        Some(label) => PreflightOutcome::Preflight(label),
+        None => PreflightOutcome::NonPreflight,
+    }
 }
 
 /// The `self-kill:background-wait` signature regex (Issue #4389, a recurrence
@@ -1449,6 +1615,30 @@ pub struct SweepRegistry {
     /// which the work-finder skips. `None` (default) ⇒ the work-finder sees an
     /// empty set (no behavior change).
     peer_claims: Option<Arc<Mutex<PeerClaimView>>>,
+    /// Workspace-level claude-wrapper pre-flight-death tripwire parameters
+    /// (Issue #4386). `main.rs` / [`crate::workspace_pool::WorkspacePool`] set
+    /// the resolved env > config > default value at provision time, mirroring
+    /// [`quarantine_config`](Self::quarantine_config).
+    preflight_tripwire_config: PreflightTripwireConfig,
+    /// Consecutive claude-wrapper pre-flight deaths this registry's reaper has
+    /// observed, **across issues** (Issue #4386) — distinct from
+    /// [`insta_crash_counts`](Self::insta_crash_counts), which is per-issue and
+    /// so never trips on a fleet-wide environmental failure spread across many
+    /// different issues. Incremented by [`record_preflight_streak`](Self::record_preflight_streak)
+    /// on a death classified as pre-flight; reset to `0` by any death that
+    /// reached `# CLAUDE_CLI_START` (or by genuine checkpoint-proven progress).
+    preflight_death_streak: u32,
+    /// The most recent pre-flight death-class marker that fed
+    /// [`preflight_death_streak`](Self::preflight_death_streak) (e.g.
+    /// `"preflight-mcp-failed"`), carried into the advisory message. `None`
+    /// once the streak resets to `0`.
+    preflight_death_last_marker: Option<String>,
+    /// Whether the workspace-level pre-flight advisory is currently tripped
+    /// (Issue #4386) — mirrors the dedup discipline `daemon.capacity.advisory`
+    /// / `daemon.dispatch.headroom_advisory` use, so
+    /// [`Event::PreflightAdvisory`] fires only on a state-change transition,
+    /// never every tick.
+    preflight_advisory_tripped: bool,
 }
 
 /// Classification of a pre-flip label read (Issue #4085). Detection only — the
@@ -1528,6 +1718,10 @@ impl SweepRegistry {
             collision_count: 0,
             peer_claim_publisher: None,
             peer_claims: None,
+            preflight_tripwire_config: PreflightTripwireConfig::default(),
+            preflight_death_streak: 0,
+            preflight_death_last_marker: None,
+            preflight_advisory_tripped: false,
         }
     }
 
@@ -1558,6 +1752,10 @@ impl SweepRegistry {
             collision_count: 0,
             peer_claim_publisher: None,
             peer_claims: None,
+            preflight_tripwire_config: PreflightTripwireConfig::default(),
+            preflight_death_streak: 0,
+            preflight_death_last_marker: None,
+            preflight_advisory_tripped: false,
         }
     }
 
@@ -1607,6 +1805,48 @@ impl SweepRegistry {
     #[must_use]
     pub fn quarantine_config(&self) -> QuarantineConfig {
         self.quarantine_config
+    }
+
+    /// Set the claude-wrapper pre-flight-death workspace-tripwire parameters
+    /// (Issue #4386). `main.rs` and the workspace pool call this once at
+    /// provision time with the resolved env > config > default value,
+    /// mirroring [`set_quarantine_config`](Self::set_quarantine_config).
+    pub fn set_preflight_tripwire_config(&mut self, config: PreflightTripwireConfig) {
+        self.preflight_tripwire_config = config;
+    }
+
+    /// Read-only accessor for the pre-flight tripwire parameters (Issue #4386).
+    #[must_use]
+    pub fn preflight_tripwire_config(&self) -> PreflightTripwireConfig {
+        self.preflight_tripwire_config
+    }
+
+    /// Current pre-flight-death advisory state (Issue #4386), for
+    /// `DaemonStatusReport`: `(tripped, message)`. `message` is always `None`
+    /// when `tripped` is `false`.
+    #[must_use]
+    pub fn preflight_advisory(&self) -> (bool, Option<String>) {
+        if !self.preflight_advisory_tripped {
+            return (false, None);
+        }
+        let marker = self
+            .preflight_death_last_marker
+            .as_deref()
+            .unwrap_or("unknown");
+        let message = format!(
+            "WARNING: last {} dispatches died at claude-wrapper pre-flight ({marker}) — check \
+             .mcp.json",
+            self.preflight_death_streak
+        );
+        (true, Some(message))
+    }
+
+    /// Current consecutive pre-flight-death streak (Issue #4386), for tests /
+    /// observability. Read-only — production code should consult
+    /// [`preflight_advisory`](Self::preflight_advisory) instead.
+    #[must_use]
+    pub fn preflight_death_streak(&self) -> u32 {
+        self.preflight_death_streak
     }
 
     /// Enable or disable cross-host dispatch-collision detection (Issue #4085).
@@ -2855,6 +3095,114 @@ impl SweepRegistry {
         true
     }
 
+    // ------------------------------------------------------------------------
+    // Claude-wrapper pre-flight-death workspace tripwire (Issue #4386)
+    // ------------------------------------------------------------------------
+
+    /// Consult the workspace-level pre-flight-death streak for one terminal
+    /// Issue sweep, updating [`preflight_death_streak`](Self::preflight_death_streak)
+    /// and the tripwire advisory, and returning the death-class label to carry
+    /// on the terminal event's `death_class` payload field (`None` when this
+    /// death is not classified as pre-flight).
+    ///
+    /// `insta_crash` is the SAME checkpoint-less-fast-death window bool the
+    /// caller already computes for [`record_insta_crash_outcome`] — a
+    /// pre-flight death is, by construction, always inside that window
+    /// (claude-wrapper bails within ~1s), so this only needs to inspect the
+    /// log tail when `insta_crash` is `true`:
+    ///
+    /// - `insta_crash == false` (a clean exit, a slow death, or a call site
+    ///   that already proved genuine checkpoint progress this run): this
+    ///   death definitely is not a pre-flight death — reset the streak
+    ///   unconditionally and return `None`.
+    /// - `insta_crash == true`: classify the tail via
+    ///   [`classify_preflight_outcome`]. A `Preflight` verdict increments the
+    ///   streak and returns the matched label; `NonPreflight` (the log reached
+    ///   `# CLAUDE_CLI_START`) resets the streak; `Unknown` (unreadable log,
+    ///   or an account-exhaustion signature — exhaustion wins, #4122) leaves
+    ///   the streak untouched. Either way `update_preflight_advisory` runs so
+    ///   a threshold crossing is caught immediately.
+    fn record_preflight_streak(&mut self, sweep_id: &SweepId, insta_crash: bool) -> Option<String> {
+        if !insta_crash {
+            self.reset_preflight_streak();
+            return None;
+        }
+        let tail = self
+            .entries
+            .get(sweep_id)
+            .map(|info| info.log_path.clone())
+            .and_then(|p| tail_lines(&p, EXHAUSTION_LOG_TAIL_LINES).ok())
+            .map(|lines| lines.join("\n"));
+
+        match classify_preflight_outcome(tail.as_deref()) {
+            PreflightOutcome::Preflight(label) => {
+                self.preflight_death_streak += 1;
+                self.preflight_death_last_marker = Some(label.to_string());
+                self.update_preflight_advisory();
+                Some(label.to_string())
+            }
+            PreflightOutcome::NonPreflight => {
+                self.reset_preflight_streak();
+                None
+            }
+            PreflightOutcome::Unknown => None,
+        }
+    }
+
+    /// Reset the cross-issue pre-flight-death streak to `0` (Issue #4386):
+    /// called for any terminal outcome that is definitively NOT a pre-flight
+    /// death (reached `# CLAUDE_CLI_START`, or genuine checkpoint-proven
+    /// progress this run). Always re-evaluates the advisory so a tripped
+    /// state clears the instant a healthy dispatch is observed.
+    fn reset_preflight_streak(&mut self) {
+        self.preflight_death_streak = 0;
+        self.preflight_death_last_marker = None;
+        self.update_preflight_advisory();
+    }
+
+    /// Re-evaluate the workspace-level pre-flight advisory against
+    /// [`preflight_death_streak`](Self::preflight_death_streak) and
+    /// [`PreflightTripwireConfig::threshold`], emitting
+    /// [`Event::PreflightAdvisory`] on the `daemon.preflight.advisory` topic
+    /// **only on a state-change transition** (into or out of tripped) — the
+    /// same dedup discipline `daemon.capacity.advisory` /
+    /// `daemon.dispatch.headroom_advisory` use, so this never fires every
+    /// tick.
+    fn update_preflight_advisory(&mut self) {
+        let threshold = self.preflight_tripwire_config.threshold.max(1);
+        let should_trip = self.preflight_death_streak >= threshold;
+        if should_trip == self.preflight_advisory_tripped {
+            return;
+        }
+        self.preflight_advisory_tripped = should_trip;
+        let marker = self.preflight_death_last_marker.clone().unwrap_or_default();
+        let message = if should_trip {
+            format!(
+                "WARNING: last {} dispatches died at claude-wrapper pre-flight ({marker}) — check \
+                 .mcp.json",
+                self.preflight_death_streak
+            )
+        } else {
+            "pre-flight advisory cleared — a recent dispatch reached claude-wrapper CLI start \
+             (#4386)"
+                .to_string()
+        };
+        log::warn!(
+            "sweep_registry: workspace {} pre-flight advisory {} (streak={}, threshold={}) \
+             (#4386)",
+            self.config.workspace_root.display(),
+            if should_trip { "TRIPPED" } else { "cleared" },
+            self.preflight_death_streak,
+            threshold
+        );
+        self.emit_event(Event::PreflightAdvisory {
+            workspace_root: self.config.workspace_root.display().to_string(),
+            consecutive_deaths: self.preflight_death_streak,
+            marker,
+            message,
+        });
+    }
+
     /// Record a terminal sweep outcome against the insta-crash tally (#3939).
     ///
     /// `insta_crash` is `true` only when the reaper classified the death as a
@@ -3799,7 +4147,8 @@ impl SweepRegistry {
                 issue: *issue,
                 exit_code: None,
                 duration_sec,
-                repo: None, // stamped by emit_event (#3929)
+                death_class: None, // manual cancel, never a pre-flight death (#4386)
+                repo: None,        // stamped by emit_event (#3929)
             });
         }
         self.emit_event(Event::SweepGlobalCompleted {
@@ -3926,6 +4275,39 @@ impl SweepRegistry {
                                 .and_then(|p| tail_lines(p, EXHAUSTION_LOG_TAIL_LINES).ok())
                                 .map(|lines| lines.join("\n"))
                                 .and_then(|tail| classify_crash(&tail, exit_code));
+                            // Issue #4386: whether THIS run's checkpoint write
+                            // proves genuine progress (see the comment above
+                            // the `if checkpoint_written_by_run` branch below)
+                            // — hoisted here because it also determines
+                            // whether this death can even be a pre-flight
+                            // death: genuine progress definitely reached past
+                            // `# CLAUDE_CLI_START`, so there is nothing left
+                            // to classify.
+                            let checkpoint_progress =
+                                checkpoint_written_by_run(&checkpoint, started_at);
+                            let insta_crash = duration_sec
+                                < self.quarantine_config.insta_crash_secs
+                                && exit_code != Some(0);
+                            // Reaper-side pre-flight-death classification +
+                            // workspace tripwire streak update (#4386),
+                            // consulted alongside the #4255 crash
+                            // classification above. Precedence: exhaustion
+                            // wins (handled inside `record_preflight_streak`),
+                            // so a death already attributed to the account is
+                            // never also charged toward — or reset — the
+                            // pre-flight streak.
+                            let death_class = if checkpoint_progress {
+                                self.reset_preflight_streak();
+                                None
+                            } else {
+                                self.record_preflight_streak(&sweep_id, insta_crash)
+                            };
+                            // Captured before `death_class` moves into the
+                            // `SweepCrashed` event below — the carve-out check
+                            // further down needs to know whether THIS death was
+                            // pre-flight-classified without re-borrowing the
+                            // (by-then-moved) `Option<String>`.
+                            let is_preflight_death = death_class.is_some();
                             // Captured before `checkpoint_phase` moves into the
                             // `SweepCrashed` event below — needed for the
                             // reaper-driven resume check further down (#4256).
@@ -3940,6 +4322,7 @@ impl SweepRegistry {
                                 issue,
                                 checkpoint_phase,
                                 classification,
+                                death_class,
                                 repo: None, // stamped by emit_event (#3929)
                             });
                             events_to_emit.push(Event::SweepGlobalCompleted {
@@ -3961,7 +4344,7 @@ impl SweepRegistry {
                             // fall through to the same pre-work insta-crash test the
                             // checkpoint-less branch below uses, so a sub-window
                             // non-clean death still counts toward quarantine.
-                            if checkpoint_written_by_run(&checkpoint, started_at) {
+                            if checkpoint_progress {
                                 self.record_terminal_outcome(issue, false);
                                 // #4256: a run that advanced the checkpoint made
                                 // real progress (reached Judge/Doctor and wrote a
@@ -3973,12 +4356,17 @@ impl SweepRegistry {
                                 // capped. Mirrors `record_terminal_outcome`'s
                                 // reset of `insta_crash_counts` on progress.
                                 self.resume_attempt_counts.remove(&issue);
-                            } else {
-                                let insta_crash = duration_sec
-                                    < self.quarantine_config.insta_crash_secs
-                                    && exit_code != Some(0);
+                            } else if !is_preflight_death {
                                 // #4122: re-attribute account-exhaustion deaths
                                 // to the spawn account instead of the issue.
+                                // #4386: a pre-flight-classified death is skipped
+                                // entirely here — it must not charge the issue's
+                                // quarantine tally either, same carve-out
+                                // reasoning as exhaustion. The exhaustion case
+                                // itself is NOT skipped (`PreflightOutcome::Unknown`
+                                // always yields a `None`/non-preflight death_class,
+                                // so exhaustion still reaches — and is handled
+                                // inside — `record_insta_crash_outcome`).
                                 self.record_insta_crash_outcome(&sweep_id, issue, insta_crash);
                             }
                             // Reaper-driven resume (Issue #4256): a crash whose
@@ -4123,16 +4511,6 @@ impl SweepRegistry {
                                     at: now,
                                 };
                             }
-                            events_to_emit.push(Event::SweepExited {
-                                issue,
-                                exit_code,
-                                duration_sec,
-                                repo: None, // stamped by emit_event (#3929)
-                            });
-                            events_to_emit.push(Event::SweepGlobalCompleted {
-                                sweep_id: sweep_id.clone(),
-                                outcome: SweepOutcome::Exited,
-                            });
                             // Insta-crash quarantine (#3939): a checkpoint-less
                             // death inside the insta-crash window that did NOT
                             // exit cleanly (exit_code != 0, or an unknown
@@ -4141,12 +4519,41 @@ impl SweepRegistry {
                             // toward quarantine. A clean exit (code 0 — the
                             // legitimate self-skip / no-work path) or a slow death
                             // past the window resets the tally instead.
+                            //
+                            // Hoisted so the #4386 pre-flight classification below
+                            // can consult the same window bool the tally uses —
+                            // this branch has no checkpoint at all, so (unlike the
+                            // Crashed branch above) there is no "genuine progress"
+                            // carve-out to check first.
                             let insta_crash = duration_sec
                                 < self.quarantine_config.insta_crash_secs
                                 && exit_code != Some(0);
-                            // #4122: re-attribute account-exhaustion deaths to
-                            // the spawn account instead of the issue.
-                            self.record_insta_crash_outcome(&sweep_id, issue, insta_crash);
+                            let death_class = self.record_preflight_streak(&sweep_id, insta_crash);
+                            let is_preflight_death = death_class.is_some();
+                            events_to_emit.push(Event::SweepExited {
+                                issue,
+                                exit_code,
+                                duration_sec,
+                                death_class,
+                                repo: None, // stamped by emit_event (#3929)
+                            });
+                            events_to_emit.push(Event::SweepGlobalCompleted {
+                                sweep_id: sweep_id.clone(),
+                                outcome: SweepOutcome::Exited,
+                            });
+                            if !is_preflight_death {
+                                // #4122: re-attribute account-exhaustion deaths to
+                                // the spawn account instead of the issue.
+                                // #4386: a pre-flight-classified death must not
+                                // charge the issue's quarantine tally either (same
+                                // carve-out reasoning as exhaustion) — skipped
+                                // entirely here. The exhaustion case itself is
+                                // NOT skipped (`PreflightOutcome::Unknown` always
+                                // yields a `None` death_class, so exhaustion still
+                                // reaches — and is handled inside —
+                                // `record_insta_crash_outcome`).
+                                self.record_insta_crash_outcome(&sweep_id, issue, insta_crash);
+                            }
                         }
                         // Block-the-subtree (issue #3729, v1 item 4): if this
                         // parent ended in `loom:blocked` and stacked children
@@ -4676,7 +5083,8 @@ impl SweepRegistry {
                             issue,
                             checkpoint_phase: None,
                             classification: None,
-                            repo: None, // stamped by emit_event (#3929)
+                            death_class: None, // mid-build death, not pre-flight (#4386)
+                            repo: None,        // stamped by emit_event (#3929)
                         });
                     }
                 }
@@ -4696,7 +5104,8 @@ impl SweepRegistry {
                                 issue,
                                 checkpoint_phase: None,
                                 classification: None,
-                                repo: None, // stamped by emit_event (#3929)
+                                death_class: None, // pool-exhausted defer, not pre-flight (#4386)
+                                repo: None,        // stamped by emit_event (#3929)
                             });
                         }
                         continue;
@@ -4857,7 +5266,8 @@ impl SweepRegistry {
                             issue,
                             checkpoint_phase: None,
                             classification: None,
-                            repo: None, // stamped by emit_event (#3929)
+                            death_class: None, // review-stall give-up, not pre-flight (#4386)
+                            repo: None,        // stamped by emit_event (#3929)
                         });
                     }
                 }
@@ -7835,6 +8245,28 @@ exit 0
         assert_eq!(classify_account_exhaustion(""), None);
     }
 
+    /// #4386: `classify_preflight_death` matches the explicit
+    /// `# MCP_PREFLIGHT_FAILED` marker, matches a tail that never reaches
+    /// `# CLAUDE_CLI_START` at all, and does NOT match a normal tail that
+    /// does reach `# CLAUDE_CLI_START`.
+    #[test]
+    fn classify_preflight_death_matches_signatures() {
+        assert_eq!(
+            classify_preflight_death("spawn-claude: dispatching\n# MCP_PREFLIGHT_FAILED\n"),
+            Some("preflight-mcp-failed")
+        );
+        assert_eq!(
+            classify_preflight_death("spawn-claude: dispatching\nsome other early failure\n"),
+            Some("preflight-no-cli-start")
+        );
+        assert_eq!(
+            classify_preflight_death(
+                "spawn-claude: dispatching\n# CLAUDE_CLI_START\nClaude: working on it\n"
+            ),
+            None
+        );
+    }
+
     /// AC #1: an exhaustion insta-crash marks the account bad and does NOT
     /// charge the issue's quarantine tally — three in a row never quarantine.
     #[test]
@@ -7879,7 +8311,13 @@ exit 0
                 56,
                 seq,
                 "agent-3",
-                "loom-daemon dispatch: start\nsome unrelated crash: boom\n",
+                // Includes `# CLAUDE_CLI_START` (#4386): a REAL wrapper log for
+                // "the CLI actually started, then something unrelated crashed
+                // it" always carries this marker — the wrapper logs it
+                // unconditionally right before exec'ing the CLI. Without it,
+                // this log would misclassify as a pre-flight death (#4386's
+                // own carve-out), which is not what this fixture is testing.
+                "loom-daemon dispatch: start\n# CLAUDE_CLI_START\nsome unrelated crash: boom\n",
             );
             registry.reap_once();
         }
@@ -7924,6 +8362,199 @@ exit 0
         );
         assert!(!registry.is_quarantined(57));
         assert!(bad_tokens::is_bad(dir.path(), "agent-3"));
+    }
+
+    // ------------------------------------------------------------------------
+    // Claude-wrapper pre-flight-death workspace tripwire (Issue #4386)
+    // ------------------------------------------------------------------------
+
+    /// AC: a reaped sweep whose log shows the claude-wrapper pre-flight
+    /// marker is classified `death_class: Some("preflight-mcp-failed")` on
+    /// its terminal event, and does NOT charge the issue's insta-crash
+    /// quarantine tally (same carve-out reasoning as #4122's account
+    /// exhaustion).
+    #[tokio::test]
+    async fn reaper_preflight_death_does_not_charge_insta_crash_tally() {
+        use crate::event_bus::EventBus;
+
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        let bus = Arc::new(EventBus::new());
+        registry.set_event_bus(bus.clone());
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        insert_dead_running_with_log(
+            &mut registry,
+            4386,
+            0,
+            "unknown",
+            "spawn-claude: dispatching\n# MCP_PREFLIGHT_FAILED\n",
+        );
+        let changed = registry.reap_once();
+        assert!(changed >= 1);
+
+        let mut saw_exited = false;
+        for _ in 0..2 {
+            let ev = sub.recv().await.unwrap();
+            if let Event::SweepExited {
+                issue, death_class, ..
+            } = ev
+            {
+                assert_eq!(issue, 4386);
+                assert_eq!(death_class.as_deref(), Some("preflight-mcp-failed"));
+                saw_exited = true;
+            }
+        }
+        assert!(saw_exited, "expected a classified sweep.issue.4386.exited event");
+
+        assert_eq!(
+            registry.insta_crash_count(4386),
+            0,
+            "pre-flight deaths must not charge the issue's quarantine tally (#4386)"
+        );
+        assert!(!registry.is_quarantined(4386));
+        assert_eq!(registry.preflight_death_streak(), 1);
+    }
+
+    /// AC: 3 consecutive pre-flight deaths across DIFFERENT issues trip the
+    /// workspace-level advisory (default threshold 3); a sweep whose log
+    /// reaches `# CLAUDE_CLI_START` resets the streak and clears the
+    /// advisory; the advisory event fires only on the state-change
+    /// transition (dedup), never every tick.
+    #[tokio::test]
+    async fn workspace_tripwire_trips_across_issues_resets_on_progress_and_dedups() {
+        use crate::event_bus::EventBus;
+
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        let bus = Arc::new(EventBus::new());
+        registry.set_event_bus(bus.clone());
+        let mut sub = bus.subscribe(["daemon.preflight.advisory"]);
+
+        assert!(!registry.preflight_advisory().0);
+
+        // Two pre-flight deaths (different issues) do NOT yet trip (default
+        // threshold 3).
+        for (issue, seq) in [(9101u32, 0u32), (9102, 0)] {
+            insert_dead_running_with_log(
+                &mut registry,
+                issue,
+                seq,
+                "unknown",
+                "# MCP_PREFLIGHT_FAILED\n",
+            );
+            registry.reap_once();
+        }
+        assert!(!registry.preflight_advisory().0);
+        assert_eq!(registry.preflight_death_streak(), 2);
+        assert!(
+            matches!(sub.try_recv(), Err(crate::event_bus::RecvError::Empty)),
+            "no advisory before the streak reaches the threshold"
+        );
+
+        // A third consecutive pre-flight death, on a THIRD different issue,
+        // trips it.
+        insert_dead_running_with_log(&mut registry, 9103, 0, "unknown", "# MCP_PREFLIGHT_FAILED\n");
+        registry.reap_once();
+        let (tripped, message) = registry.preflight_advisory();
+        assert!(tripped, "3 consecutive cross-issue pre-flight deaths must trip the advisory");
+        let message = message.expect("advisory message present when tripped");
+        assert!(message.contains("pre-flight"));
+        assert!(message.contains("mcp.json"));
+
+        match sub.recv().await.unwrap() {
+            Event::PreflightAdvisory {
+                consecutive_deaths, ..
+            } => assert_eq!(consecutive_deaths, 3),
+            other => panic!("unexpected event: {other:?}"),
+        }
+
+        // A fourth consecutive pre-flight death (still tripped) must NOT
+        // re-fire the advisory event — dedup on state change only.
+        insert_dead_running_with_log(&mut registry, 9104, 0, "unknown", "# MCP_PREFLIGHT_FAILED\n");
+        registry.reap_once();
+        assert!(registry.preflight_advisory().0);
+        assert!(
+            matches!(sub.try_recv(), Err(crate::event_bus::RecvError::Empty)),
+            "advisory must not re-fire while already tripped (dedup)"
+        );
+
+        // A sweep whose log reaches `# CLAUDE_CLI_START` resets the streak
+        // and clears the advisory, firing the clearing transition event.
+        insert_dead_running_with_log(
+            &mut registry,
+            9105,
+            0,
+            "unknown",
+            "# CLAUDE_CLI_START\nsome later crash\n",
+        );
+        registry.reap_once();
+        assert_eq!(registry.preflight_death_streak(), 0);
+        assert!(!registry.preflight_advisory().0);
+        match sub.recv().await.unwrap() {
+            Event::PreflightAdvisory {
+                consecutive_deaths, ..
+            } => assert_eq!(consecutive_deaths, 0),
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    /// Edge case (#4386): a dead sweep whose log file is missing/unreadable
+    /// at reap time is classified "unknown", NOT pre-flight — it must
+    /// neither increment nor reset the workspace streak.
+    #[test]
+    fn reaper_preflight_classification_unreadable_log_is_unknown_not_reset() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+
+        // Prime a genuine streak of 2 via two real pre-flight deaths.
+        insert_dead_running_with_log(&mut registry, 9201, 0, "unknown", "# MCP_PREFLIGHT_FAILED\n");
+        registry.reap_once();
+        insert_dead_running_with_log(&mut registry, 9202, 0, "unknown", "# MCP_PREFLIGHT_FAILED\n");
+        registry.reap_once();
+        assert_eq!(registry.preflight_death_streak(), 2);
+
+        // A dead sweep with NO log file at all (missing/unreadable).
+        insert_dead_running(&mut registry, 9203, 0);
+        registry.reap_once();
+        assert_eq!(
+            registry.preflight_death_streak(),
+            2,
+            "an unreadable log must classify as unknown — neither incrementing nor resetting \
+             the pre-flight streak"
+        );
+    }
+
+    /// Edge case (#4386): when BOTH an account-exhaustion signature and a
+    /// pre-flight marker are present in the same log tail, exhaustion wins —
+    /// it is already attributed to the account, so it must not also be
+    /// charged toward (or reset) the pre-flight streak.
+    #[test]
+    fn reaper_preflight_marker_with_exhaustion_signature_exhaustion_wins() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        seed_token_pool(dir.path(), "agent-9");
+
+        insert_dead_running_with_log(
+            &mut registry,
+            9301,
+            0,
+            "agent-9",
+            "Claude: hit your weekly limit\n# MCP_PREFLIGHT_FAILED\n",
+        );
+        registry.reap_once();
+
+        assert!(
+            bad_tokens::is_bad(dir.path(), "agent-9"),
+            "exhaustion still marks the account bad"
+        );
+        assert_eq!(registry.insta_crash_count(9301), 0);
+        assert!(!registry.is_quarantined(9301));
+        assert_eq!(
+            registry.preflight_death_streak(),
+            0,
+            "an exhaustion-classified death must not count toward the pre-flight streak (#4386)"
+        );
     }
 
     /// AC #1 + #3 (#4009): a death whose checkpoint was written BY THIS run

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -947,6 +947,26 @@ pub struct DaemonStatusReport {
     /// (an absent field parses as `false` — "not capacity-bound").
     #[serde(default)]
     pub capacity_bound: bool,
+    /// Whether the default/primary workspace's claude-wrapper pre-flight-death
+    /// tripwire is currently tripped (Issue #4386): N consecutive dispatches,
+    /// across *different* issues, died at the wrapper's MCP-init pre-flight
+    /// check before ever reaching `# CLAUDE_CLI_START` — the classic
+    /// stale-`.mcp.json` fleet-wide silent-failure signature. See
+    /// `SweepRegistry::preflight_advisory`. While `true`, the status renderer
+    /// must surface [`Self::preflight_advisory_message`] instead of — or
+    /// immediately alongside — the bare "not capacity-bound … the limiter is
+    /// work availability" line, so a fleet-wide spawn failure never reads as
+    /// an idle-healthy daemon. `#[serde(default)]` keeps pre-#4386 wire data /
+    /// older clients compatible (an absent field parses as `false`).
+    #[serde(default)]
+    pub preflight_advisory_active: bool,
+    /// The operator-facing advisory message when
+    /// [`Self::preflight_advisory_active`] is `true` (e.g. `"WARNING: last 3
+    /// dispatches died at claude-wrapper pre-flight (preflight-mcp-failed) —
+    /// check .mcp.json"`), else `None`. `#[serde(default)]` keeps pre-#4386
+    /// wire data compatible.
+    #[serde(default)]
+    pub preflight_advisory_message: Option<String>,
     /// Dynamic-cap input 4: the configured operator ceiling
     /// (`autonomous.workFinder.maxConcurrent` / `LOOM_WORK_FINDER_MAX_CONCURRENT`).
     pub configured_max: usize,
@@ -1543,6 +1563,17 @@ pub enum Event {
         #[serde(skip_serializing_if = "Option::is_none")]
         exit_code: Option<i32>,
         duration_sec: i64,
+        /// Issue #4386: set to a claude-wrapper pre-flight-death label (e.g.
+        /// `"preflight-mcp-failed"`, `"preflight-no-cli-start"`) when the
+        /// reaper's [`crate::sweep_registry::classify_preflight_death`]-derived
+        /// classification matched this dead sweep's log tail. `None` for every
+        /// other exit (including the common clean self-skip/no-work case).
+        /// This is an additive payload extension of the existing frozen
+        /// `sweep.issue.{N}.exited` topic — the topic string is unchanged.
+        /// `#[serde(default)]` keeps pre-#4386 wire data / older clients
+        /// compatible.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        death_class: Option<String>,
         /// Owning managed-workspace root (Issue #3929). See [`Self::SweepPhase`].
         #[serde(default, skip_serializing_if = "Option::is_none")]
         repo: Option<String>,
@@ -1560,6 +1591,14 @@ pub enum Event {
         /// when the log yields no recognizable signature (or is unreadable).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         classification: Option<String>,
+        /// Issue #4386: set to a claude-wrapper pre-flight-death label when
+        /// this dead sweep's log tail matched the pre-flight classifier —
+        /// same additive-payload-extension rationale as `SweepExited`'s
+        /// `death_class` field, applied here too because a stale checkpoint
+        /// from an earlier dispatch can route a pre-flight death through this
+        /// Crashed branch instead of `SweepExited`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        death_class: Option<String>,
         /// Owning managed-workspace root (Issue #3929). See [`Self::SweepPhase`].
         #[serde(default, skip_serializing_if = "Option::is_none")]
         repo: Option<String>,
@@ -1642,6 +1681,29 @@ pub enum Event {
         /// Operator-facing advisory message naming the concrete levers.
         message: String,
     },
+    /// `daemon.preflight.advisory` — a workspace's reaper crossed (or cleared)
+    /// the consecutive claude-wrapper pre-flight-death threshold (Issue
+    /// #4386): N dispatches in a row, across *different* issues, died at the
+    /// wrapper's MCP-init pre-flight check before ever reaching `# CLAUDE_CLI_
+    /// START` (the classic stale-`.mcp.json` fleet-wide silent failure).
+    /// Published by [`crate::sweep_registry::SweepRegistry`]'s reaper on
+    /// **state change only** (entered/left the tripped state), mirroring
+    /// `daemon.capacity.advisory`'s dedup discipline — never every tick. This
+    /// issue (#4386) is the authorizing issue for this topic per the frozen-
+    /// taxonomy "new topics require a follow-up issue" rule (see
+    /// `event_bus.rs`'s module doc). Advisory only — it never blocks
+    /// dispatch; it tells the operator to check `.mcp.json`.
+    PreflightAdvisory {
+        /// The workspace root whose reaper tripped (or cleared) the advisory.
+        workspace_root: String,
+        /// Consecutive pre-flight deaths observed at the transition.
+        consecutive_deaths: u32,
+        /// The most recent matched pre-flight death-class marker (e.g.
+        /// `"preflight-mcp-failed"`), or empty on the clearing transition.
+        marker: String,
+        /// Operator-facing advisory message naming the concrete cause.
+        message: String,
+    },
     /// Synthetic event signalling that the subscription fell behind the
     /// publisher. The number of events dropped is reported in `skipped`.
     /// Matches `tokio::sync::broadcast::Receiver::Lagged` semantics.
@@ -1671,6 +1733,7 @@ impl Event {
     /// | `SweepGlobalCompleted {..}` | `sweep.global.completed` |
     /// | `EpicAction {epic, action, ..}` | `epic.issue.{epic}.{action}` |
     /// | `CapacityAdvisory {..}` | `daemon.capacity.advisory` |
+    /// | `PreflightAdvisory {..}` | `daemon.preflight.advisory` |
     /// | `TopicLag {..}` | `sweep.system.topic_lag` |
     /// | `Generic {topic, ..}` | the explicit topic string |
     ///
@@ -1696,6 +1759,7 @@ impl Event {
                 format!("epic.issue.{epic}.{}", action.as_str())
             }
             Self::CapacityAdvisory { .. } => "daemon.capacity.advisory".to_string(),
+            Self::PreflightAdvisory { .. } => "daemon.preflight.advisory".to_string(),
             Self::TopicLag { .. } => "sweep.system.topic_lag".to_string(),
             Self::Generic { topic, .. } => topic.clone(),
         }
@@ -1708,7 +1772,8 @@ impl Event {
     /// specific workspace) is never overwritten.
     ///
     /// `SweepGlobalCompleted` (already carries a unique `sweep_id`), `EpicAction`,
-    /// `CapacityAdvisory`, `TopicLag`, and `Generic` are left untouched. Called
+    /// `CapacityAdvisory`, `PreflightAdvisory` (already carries its own
+    /// `workspace_root` field), `TopicLag`, and `Generic` are left untouched. Called
     /// centrally from `SweepRegistry::emit_event` so every emitted sweep event
     /// is stamped with its registry's `workspace_root` without touching each
     /// construction site.
@@ -1823,6 +1888,7 @@ mod tests {
             issue: 7,
             exit_code: Some(0),
             duration_sec: 5,
+            death_class: None,
             repo: None,
         };
         assert_eq!(exited.topic(), "sweep.issue.7.exited");
@@ -1831,6 +1897,7 @@ mod tests {
             issue: 7,
             checkpoint_phase: Some("doctor".to_string()),
             classification: None,
+            death_class: None,
             repo: Some("/repos/c".to_string()),
         };
         assert_eq!(crashed.topic(), "sweep.issue.7.crashed");
@@ -1884,6 +1951,7 @@ mod tests {
             issue: 1,
             exit_code: None,
             duration_sec: 0,
+            death_class: None,
             repo: None,
         };
         ev.set_repo_if_absent("/repos/x");

--- a/loom-daemon/src/workspace_pool.rs
+++ b/loom-daemon/src/workspace_pool.rs
@@ -284,6 +284,11 @@ impl WorkspacePool {
         // workspace so the reaper quarantines a repeatedly-insta-crashing issue
         // instead of letting it be re-dispatched every tick.
         registry.set_quarantine_config(sweep_registry::resolve_quarantine_config(root));
+        // Claude-wrapper pre-flight-death workspace tripwire (#4386): resolve
+        // env > config > default for this workspace, mirroring the
+        // insta-crash quarantine config above.
+        registry
+            .set_preflight_tripwire_config(sweep_registry::resolve_preflight_tripwire_config(root));
         // Cross-host collision detection (#4085): resolve env > config >
         // default(off) so a shared-backlog deployment measures the baseline
         // duplicate-dispatch rate. Detection only — never changes dispatch.


### PR DESCRIPTION
## Summary

Fixes the fleet-wide silent-failure gap: `loom-daemon dispatch` reported success and `loom-daemon status` read as idle-healthy even when every spawned child died within ~1s at the claude-wrapper MCP pre-flight check (e.g. a stale `.mcp.json`), because the existing per-issue insta-crash quarantine (#3939) never trips when many *different* issues each die once.

## Changes

- **`sweep_registry.rs`**: table-driven `classify_preflight_death(log_tail)` (mirrors #4122's `classify_account_exhaustion`) matching an explicit `# MCP_PREFLIGHT_FAILED` marker, or the tail never reaching `# CLAUDE_CLI_START`. Consulted from both reap branches (checkpoint-present "Crashed" and checkpoint-less "Exited") alongside the existing #4255 crash classification.
- Exhaustion still wins when both signatures match (`PreflightOutcome::Unknown` — never charged as pre-flight, per curator guidance).
- Pre-flight-classified deaths are exempted from the issue's insta-crash quarantine tally (same carve-out reasoning as #4122).
- New `SweepRegistry` workspace-level cross-issue consecutive pre-flight-death streak + `PreflightTripwireConfig` (env `LOOM_PREFLIGHT_TRIPWIRE_THRESHOLD` > config `autonomous.workFinder.preflightTripwire.threshold` > default 3), reset by any sweep whose log reaches `# CLAUDE_CLI_START`.
- **`types.rs`**: additive `death_class: Option<String>` payload field on the existing frozen `SweepExited`/`SweepCrashed` events (no new topic); new `Event::PreflightAdvisory` variant on the new `daemon.preflight.advisory` topic; new `DaemonStatusReport::{preflight_advisory_active, preflight_advisory_message}` fields.
- **`event_bus.rs`**: module-doc taxonomy table updated, authorizing `daemon.preflight.advisory` per this issue.
- **`main.rs`**: `status` prints the advisory prominently when tripped, and suppresses the "not capacity-bound … the limiter is work availability" line while tripped (both the ranking-present and no-ranking branches); JSON status (`build_status_json_value`) carries the two new fields.
- **`ipc.rs`** / **`workspace_pool.rs`**: `build_daemon_status` reads the fallback workspace's registry for the advisory state; `resolve_preflight_tripwire_config` wired into both the default-workspace startup path (`main.rs`) and per-workspace provisioning (`workspace_pool.rs`), mirroring the quarantine-config pattern.
- `defaults/scripts/claude-wrapper.sh` and `role_runner.rs` — reference only, untouched (per curator guidance).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|---------------|
| Reaper-side classification (`classify_preflight_death`, table-driven) | ✅ | `sweep_registry.rs::classify_preflight_death` + `preflight_death_signatures()`; unit test `classify_preflight_death_matches_signatures` |
| Consulted from reap path, exhaustion wins on double-match | ✅ | `record_preflight_streak`/`classify_preflight_outcome`; test `reaper_preflight_marker_with_exhaustion_signature_exhaustion_wins` |
| Distinct per-death reporting (`death_class` on existing frozen topics, not a new topic) | ✅ | `Event::SweepExited`/`SweepCrashed` gain `death_class`; test `reaper_preflight_death_does_not_charge_insta_crash_tally` asserts the event payload |
| Workspace-level tripwire, N=3 default, env>config>default | ✅ | `PreflightTripwireConfig` + `resolve_preflight_tripwire_config`; test `workspace_tripwire_trips_across_issues_resets_on_progress_and_dedups` |
| `DaemonStatusReport` warning field; status suppresses bare "limiter is work availability" line while tripped | ✅ | `preflight_advisory_active`/`preflight_advisory_message` fields; `print_status_human` + `build_status_json_value` updated |
| New topic `daemon.preflight.advisory`, dedup on state change only | ✅ | `Event::PreflightAdvisory`, `update_preflight_advisory`; test asserts no duplicate event on a 4th consecutive death, then one clearing event on reset |
| No insta-crash tally charge for pre-flight deaths | ✅ | Gated `record_insta_crash_outcome` calls on `death_class.is_none()` in both reap branches; test asserts tally stays 0 |
| Edge cases: unreadable log → unknown not pre-flight; exhaustion+preflight → exhaustion wins | ✅ | `reaper_preflight_classification_unreadable_log_is_unknown_not_reset`, `reaper_preflight_marker_with_exhaustion_signature_exhaustion_wins` |

## Test Plan

- `cargo test --lib sweep_registry::` — 207 passed (was 199; 8 new tests added, 1 pre-existing fixture updated to include a realistic `# CLAUDE_CLI_START` marker so it still represents a post-CLI-start crash rather than misclassifying as pre-flight).
- `cargo test --lib` (full crate) — 1922 passed, 0 failed.
- `cargo check`, `cargo clippy --all-targets` — clean, no warnings.
- `cargo fmt --check` — clean.

Closes #4386