### PR TITLE
feat(runtime): port the fork's Codex adapter onto the runtime seam (attribution: gpeyton)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,3 +111,74 @@ jobs:
         run: bash scripts/test-installer.sh
       - name: Run installer reinstall-safety tests (#4188)
         run: bash defaults/scripts/tests/test-install-reinstall-safety.sh
+
+  codex-adapter-smoke:
+    name: Codex Adapter Smoke (mocked)
+    needs: changes
+    if: always() && (github.event_name == 'push' || needs.changes.outputs.scripts == 'true')
+    # Tier-2 admission gate for the Codex runtime adapter (epic #4167 Phase 2,
+    # issue #4468): a green leg here is what admits the adapter per
+    # defaults/docs/runtime-adapters.md's tier policy.
+    #
+    # NO LIVE OpenAI CALLS. The suite is hermetic by construction — it uses
+    # spawn-codex.sh's LOOM_CODEX_NO_EXEC argv-only hook plus a fake `codex`
+    # shim on a temp PATH, so the real Codex CLI is never installed or invoked
+    # and no credential is required. `codex` is deliberately NOT on PATH here,
+    # which also exercises the missing-binary (exit 127) path.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Syntax-check the Codex adapter and its test
+        run: |
+          bash -n defaults/scripts/spawn-codex.sh
+          bash -n defaults/scripts/tests/test-spawn-codex.sh
+      - name: Assert the suite cannot reach a real Codex CLI
+        # Structural guard: the test must never install, download, or otherwise
+        # obtain the real Codex CLI. Combined with `codex` being absent from
+        # this runner's PATH, that makes a live OpenAI call impossible.
+        run: |
+          if grep -nE '(npm|brew|pipx?|curl|wget) .*(codex|openai)' \
+              defaults/scripts/tests/test-spawn-codex.sh; then
+            echo "::error::test-spawn-codex.sh must not install or fetch a real Codex CLI"
+            exit 1
+          fi
+          # This leg is expected to run on a runner with no Codex CLI at all.
+          # A warning rather than a failure: if a future runner image ships
+          # `codex`, the suite is still hermetic (every dispatch test prepends
+          # its own mock to PATH, and the argv tests never exec anything), so a
+          # hard failure here would be spurious rather than protective.
+          if command -v codex >/dev/null 2>&1; then
+            echo "::warning::a real 'codex' is on PATH; the suite still mocks every dispatch, but verify no test bypasses the mock"
+          fi
+      - name: Validate the Codex runtime capability manifest
+        run: |
+          # Valid JSON with the tri-state schema check-runtime-capabilities.sh reads.
+          jq -e '.runtime == "codex" and (.capabilities | type == "object")' \
+            defaults/runtimes/codex.json > /dev/null
+          bad="$(jq -r '.capabilities | to_entries[]
+                        | select(.value != "yes" and .value != "no" and .value != "partial")
+                        | .key' defaults/runtimes/codex.json)"
+          if [[ -n "$bad" ]]; then
+            echo "::error::codex.json capability value outside yes|no|partial: $bad"
+            exit 1
+          fi
+          # Codex declares worktreeIsolation=partial, so the Builder role (which
+          # requires it) must fail closed with EX_CONFIG (78). This pins the
+          # guardrail-parity doc's residual gap 2 to an executable assertion.
+          rc=0
+          bash defaults/scripts/check-runtime-capabilities.sh \
+            --role builder --runtime codex --dir defaults >/dev/null 2>&1 || rc=$?
+          if [[ "$rc" != "78" ]]; then
+            echo "::error::builder+codex must be incompatible (expected 78, got $rc)"
+            exit 1
+          fi
+          # Judge requires only mcp (declared "yes"), so it must be compatible.
+          bash defaults/scripts/check-runtime-capabilities.sh \
+            --role judge --runtime codex --dir defaults >/dev/null
+      - name: Assert the guardrail-parity doc exists (contract point 6)
+        # No runtime is admitted without a parity doc naming its residual gaps.
+        run: |
+          test -f defaults/docs/guardrail-parity-codex.md
+          grep -q '## Residual gaps' defaults/docs/guardrail-parity-codex.md
+      - name: Run the mocked Codex adapter test suite
+        run: bash defaults/scripts/tests/test-spawn-codex.sh

--- a/defaults/docs/guardrail-parity-codex.md
+++ b/defaults/docs/guardrail-parity-codex.md
@@ -1,0 +1,296 @@
+# Guardrail Parity: Codex
+
+This is the **required guardrail-parity document** for the Codex runtime adapter
+(`defaults/scripts/spawn-codex.sh`), per contract point 6 of
+[`runtime-adapters.md`](runtime-adapters.md). No runtime is admitted to Loom
+without one. It maps **Loom guard *intent* → Codex enforcement mechanism** and
+then names, explicitly, every protection Loom has that a Codex worker does
+**not** get.
+
+Read this before dispatching a Codex worker at anything you care about.
+
+> **Provenance.** The Codex adapter is a port of the Codex support built in the
+> [gpeyton/loom](https://github.com/gpeyton/loom) fork by Graham Peyton (fork
+> PRs #15/#16/#20/#40, including its `GUARDRAIL-PARITY.md`, the template for
+> this document). Every claim below was **re-verified against codex-cli
+> 0.146.0** on 2026-07-29 (epic #4167 Phase 2, issue #4468) and several of the
+> fork's statements no longer hold on that version — those are called out
+> inline. Do not carry a claim from the fork's doc into this one without
+> re-checking the CLI.
+
+> **Path convention.** This file lives at
+> `defaults/docs/guardrail-parity-codex.md` in the Loom source repo and cites
+> `defaults/` paths. A consumer install maps `defaults/docs/` → `.loom/docs/`,
+> so the installed copy is `.loom/docs/guardrail-parity-codex.md`.
+
+## Tier status
+
+**Codex is tier-2: CI-gated, no operator dogfooding.** It passes a mocked spawn
++ classifier CI leg; it is not run against production workloads. Promotion to
+tier-1 requires someone committing to tier-1 ownership of this adapter, this
+document, and that CI leg — see the contract's tier policy. Nothing in this
+document should be read as "Codex is safe to point at your repos".
+
+## The enforcement mechanisms Codex actually has (0.146.0)
+
+| Mechanism | What it controls | How the adapter drives it |
+|---|---|---|
+| `-s` / `--sandbox <mode>` | Filesystem + network confinement for model-run shell commands. Modes: `read-only`, `workspace-write`, `danger-full-access`. | The adapter's central knob — see the mapping table below. |
+| `[sandbox_workspace_write] network_access` | Outbound network from inside a `workspace-write` sandbox. **Off by default.** | `LOOM_CODEX_NETWORK=1` → `-c sandbox_workspace_write.network_access=true`. Read only under `workspace-write`; inert otherwise. |
+| `sandbox_permissions` / `writable_roots` / `--add-dir` | Widen a `workspace-write` sandbox to extra readable/writable roots. | **Not driven by the adapter.** Passes through if an operator supplies it. |
+| `--skip-git-repo-check` | Waives Codex's refusal to run outside a git work tree. | Injected **only** when the cwd is genuinely not inside a work tree (see "Trusted-directory check" below). |
+| `$CODEX_HOME/hooks.json` (`pre_tool_use`, `permission_request`, `post_tool_use`, `user_prompt_submit`, `session_start`, `session_end`, `pre_compact`, `post_compact`, `subagent_start`, `subagent_stop`) | Per-tool-call and per-prompt interception — the direct analogue of Claude Code's hook taxonomy. | **Not wired by Loom in this phase.** This is the single most consequential residual gap; see gap 1. |
+| `approval_policy` / `-a` | When Codex pauses to ask a human. | **Irrelevant to Loom.** `codex exec` is non-interactive and exposes no `-a` at all; there is no human to answer, so approvals gate nothing. The sandbox is the only load-bearing guard. |
+| `AGENTS.md` | Repository instructions, read natively by Codex via ancestor traversal. | Advisory context, not a boundary. Loom's `AGENTS.md` codegen is a separate issue (contract point 5). |
+
+### Corrections to the fork's parity doc, verified on 0.146.0
+
+1. **`--full-auto` does not exist on `codex exec`.** The fork maps its safe mode
+   to `--full-auto`; that flag is absent from `codex exec --help` on 0.146.0.
+   `-s workspace-write` is the replacement, and it is what this adapter emits.
+2. **`-a` / `--ask-for-approval` is top-level only**, not an `exec` flag. Any
+   parity claim that rests on `approval_policy = "on-request"` is inert for
+   Loom's headless dispatch.
+3. **Codex has a hook system now.** The fork states Codex has no hooks "as a
+   concept". On 0.146.0 it has a `hooks.json` engine with a `pre_tool_use`
+   event, a persisted hook-trust model, and a
+   `--dangerously-bypass-hook-trust` escape hatch. The gap is therefore
+   *unwired*, not *impossible* — a materially better position than the fork
+   documented, and a concrete follow-up rather than an architectural dead end.
+4. **A sandbox denial does not fail the run.** Verified with `-s read-only`: a
+   blocked `touch` returns `Operation not permitted` to the model and the
+   `codex exec` process still exits **0**. Denials are in-session tool
+   failures, so they never reach error classification (see
+   `defaults/scripts/lib/classify-error.sh`'s `codex` table for why no
+   "sandbox denial" pattern is encoded there).
+
+## Loom guard intent → Codex mechanism
+
+Loom's guards are Claude Code `PreToolUse` / `Stop` hooks wired in
+`.claude/settings.json` to scripts under `.loom/hooks/`. **None of them fire for
+a Codex worker** — they are Claude Code hooks, and Loom does not currently
+install anything into Codex's own `hooks.json`. The column below therefore
+records what Codex's *sandbox* incidentally covers, not what runs.
+
+| Loom guard (`defaults/hooks/`) | Claude matcher | Intent | Codex coverage | How / why |
+|---|---|---|---|---|
+| `guard-destructive.sh` → `guard-destructive-generic.sh` | `Bash` | Deny catastrophic Bash (`rm -rf /`, force-push to `main`, `gh repo delete`, fork bombs, `curl … \| sh`, cloud/SQL destruction); ask on borderline ops; scope `rm` to the repo; Bash-tool write-confinement (`>`, `tee`, `sed -i`, `cp`/`mv`, #4178) | **partial** | `read-only` blocks every write, so under the adapter's default the destructive-write half is fully covered — more strictly than the guard itself. `workspace-write` blocks writes and `rm` outside the workspace root, and (with network off) blocks `curl \| sh` and remote cloud destruction by making the network unreachable. **Not covered:** command-pattern semantics. Codex cannot recognize `DROP DATABASE`, `DELETE` without `WHERE`, `git push --force` to `main`, or a fork bomb *as such* — anything reachable without leaving the workspace or the network proceeds. With `LOOM_CODEX_NETWORK=1` (which a Builder needs to push) the network-derived coverage evaporates and a force-push to `main` becomes reachable with nothing to stop it. |
+| `guard-worktree-paths.sh` | `Edit\|Write` | Confine Edit/Write to the builder's own `issue-N` worktree; deny escapes into the main checkout (#2441, #4007) | **partial** | `workspace-write` confines writes to the **workspace root** — a strictly coarser boundary. It blocks escaping the repo, but **not** the per-worktree boundary: a Codex builder can write into a sibling `issue-M` worktree, or into the main checkout, because all of those live under the same root. This is the exact class of escape #4178 documented. Mitigation: one Codex worker per workspace root, or narrow `writable_roots` by hand. |
+| `guard-loom-workflow.sh` | `Bash` | `gh pr merge` → `merge-pr.sh` redirect; `pip install -e` worktree block (#2495); `loom-daemon workspace` registry-mutation ask (#4326) | **none** | Pure command-pattern convention with no OS analogue. A Codex worker learns these only from `AGENTS.md` / role prompts — advisory, never enforced. |
+| `guard-background-subagents.sh` | `Stop` | Block one stop when the transcript shows dispatched-but-unresolved `Task` subagents, so ending a headless turn does not kill live background work (#4257) | **none** | Depends on Claude Code's `Stop` event and transcript shape. Codex has `session_end` and `subagent_stop` events that could host an equivalent, but nothing is wired (gap 1). Note the underlying hazard is *also* absent today: Loom does not dispatch Codex subagents at all. |
+| `guard-readonly-dirs.sh.template` | `Edit\|Write` | Optional per-project read-only path protection | **partial** | Expressible as narrowed `writable_roots` under `workspace-write`, but the adapter does not generate it — an operator must configure it manually. |
+| `skill-router.sh` | `UserPromptSubmit` | Inject an agent routing table / `AGENT_ROUTE` suggestion per prompt (opt-in) | **none** | Context injection, not a boundary. Codex has a `user_prompt_submit` hook event that could host it; unwired (gap 1). Static equivalent: `AGENTS.md`. |
+| `methodology-inject.sh` | *(present, not wired here)* | Inject universal/role/topic context from `.loom/context/` | **none** | Same as above: not a boundary, and a `user_prompt_submit` equivalent exists but is unwired. |
+| `post-worktree.sh` | *(invoked by `worktree.sh`)* | Copy the `loom-daemon` binary into a new worktree | **covered** | Runtime-neutral — `worktree.sh` runs it regardless of which runtime drives the work. Not a Claude hook. |
+
+## Sandbox-mode mapping (what the adapter emits)
+
+Precedence, highest first:
+
+| # | Signal | Effective sandbox |
+|---|---|---|
+| 1 | An explicit `-s` / `--sandbox` (or `--dangerously-bypass-approvals-and-sandbox`) in the passthrough args | as given |
+| 2 | `LOOM_CODEX_SANDBOX=read-only\|workspace-write\|danger-full-access` | as given (invalid value → exit 78) |
+| 3 | Loom's runner-neutral `--dangerously-skip-permissions` convention | `workspace-write` |
+| 4 | *(default)* | `read-only` |
+
+### Why the default is `read-only`, and why skip-permissions is **not** full access
+
+The fork maps Loom's skip-permissions convention to
+`--dangerously-bypass-approvals-and-sandbox` — no sandbox at all — on the
+argument that Loom's Claude workers already run unattended with full tool
+access, so Codex should match: *"parity, not a new exposure."*
+
+**Upstream declines that mapping**, for one reason: the premise is not parity.
+Claude's unattended posture is backstopped by `PreToolUse` guards that fire on
+every Bash/Edit/Write call *even under* `--dangerously-skip-permissions`. Those
+guards do not exist for a Codex worker. Handing Codex the same flag therefore
+produces a **strictly weaker** trust boundary than the Claude path it is
+imitating — an agent with Claude's authority and none of Claude's backstops.
+
+`workspace-write` is the closest honest analogue of what the Claude guards
+actually enforce (`guard-worktree-paths.sh`'s write confinement, plus
+`guard-destructive-generic.sh`'s out-of-repo `rm`/write scoping). It is
+deliberately imperfect — see gap 2 — but it is a real boundary rather than an
+assumed one.
+
+`read-only` is the *default* because a tier-2 runtime with no wired guards
+should not be able to write anything unless someone said so. It is also the
+right mode for the read-only Loom roles (Judge, Curator, Guide, Champion
+evaluation), which is where a Codex canary should start.
+
+Operators who want the fork's posture opt in explicitly:
+
+```bash
+LOOM_CODEX_SANDBOX=danger-full-access .loom/scripts/spawn-codex.sh -p "…"
+```
+
+The adapter emits `-s danger-full-access` rather than
+`--dangerously-bypass-approvals-and-sandbox` for that case: same sandbox
+posture, without additionally waiving Codex's hook-trust prompt (which is a
+separate protection, and one Loom will want intact once gap 1 is closed).
+
+### The network coupling (read this before dispatching a Builder)
+
+`workspace-write` blocks outbound network by default. A Loom **Builder** must
+`git push` and call `gh` — so a Builder-equivalent Codex worker needs
+`LOOM_CODEX_NETWORK=1`, which sets
+`-c sandbox_workspace_write.network_access=true`.
+
+That single flag removes most of what the sandbox was contributing to the
+`guard-destructive.sh` row above: with the network reachable, force-push to
+`main`, `gh repo delete`, cloud-CLI destruction, and `curl … | sh` all become
+possible again, and Codex has no pattern matcher to stop any of them. **A
+networked `workspace-write` Codex Builder is meaningfully less protected than a
+Claude Builder.** Keep Codex on read-only roles until gap 1 is closed.
+
+### Trusted-directory check
+
+`codex exec` refuses to start outside a git work tree ("Not inside a trusted
+directory and `--skip-git-repo-check` was not specified.", exit 1). That is a
+real guardrail, so the adapter injects `--skip-git-repo-check` **only** when
+`git rev-parse --is-inside-work-tree` says the cwd is not inside one — never
+unconditionally. Worktree dispatch (`.loom/worktrees/issue-N`) is inside a work
+tree and keeps the check enabled. Scratch-dir dispatch gets the waiver plus a
+warning line. The refusal itself classifies as `FATAL` (not `RECOVERABLE`), so a
+mis-set cwd fails fast instead of retrying forever.
+
+## Residual gaps
+
+Known, documented, and accepted for tier-2. None is silent.
+
+1. **Loom's guard hooks do not run at all.** This is the headline gap. Every
+   `PreToolUse` protection in `.loom/hooks/` is a Claude Code hook; a Codex
+   worker executes with none of them. Codex 0.146.0 *does* expose a
+   `$CODEX_HOME/hooks.json` engine with `pre_tool_use` / `user_prompt_submit` /
+   `post_tool_use` events and a hook-trust model, so this is a **wiring gap,
+   not an architectural one** — but it is unwired today, and no Loom guard
+   intent is mechanically enforced for Codex beyond what the sandbox happens to
+   cover. Closing it (translating `guard-destructive` / `guard-worktree-paths`
+   into Codex `pre_tool_use` handlers, and deciding how hook trust is
+   provisioned) is follow-up work, not part of this phase.
+2. **No per-worktree write isolation.** `workspace-write` confines to the
+   workspace root, not to one `issue-N` worktree. Parallel Codex builders under
+   one root are not isolated from each other or from the main checkout — the
+   #4178 escape class. Mitigation: one Codex worker per workspace root, or hand-
+   narrowed `writable_roots`.
+3. **No command-pattern blocking.** Codex cannot recognize a dangerous command
+   as dangerous. `DROP DATABASE`, `DELETE` without `WHERE`, `git push --force
+   origin main`, `systemctl stop`, a fork bomb — if it is reachable without
+   leaving the sandbox, it runs.
+4. **Loom's workflow nudges are advisory only.** The `gh pr merge` →
+   `merge-pr.sh` redirect, the `pip install -e` worktree block, and the
+   `loom-daemon workspace` ask are conventions Codex learns from `AGENTS.md` at
+   best. Nothing enforces them. **A Codex worker can merge a PR with
+   `gh pr merge`, bypassing `merge-pr.sh`'s worktree-cleanup and
+   merge-ordering handling.**
+5. **Label-mutation commands are ungated for every runtime.** Nothing in Loom —
+   Claude or Codex — gates `gh issue edit --add-label` / `--remove-label`. A
+   worker can move an issue anywhere in the state machine. This is *not* a
+   Codex-specific regression, but it is worth stating in a trust-boundary
+   document: Codex inherits it with no compensating guard, so a Codex worker
+   that mishandles labels leaves no enforcement layer between it and the
+   coordination state.
+6. **No per-prompt context injection.** `skill-router` / `methodology-inject`
+   have no wired Codex equivalent (a `user_prompt_submit` event exists —
+   gap 1). Not a safety boundary; the static substitute is `AGENTS.md`.
+7. **Approvals gate nothing.** `codex exec` is non-interactive and exposes no
+   approval flag. Any parity argument resting on `approval_policy` is void for
+   Loom dispatch. The sandbox is the only enforced guard.
+8. **Cost/usage fidelity is aggregate, not per-turn.** The adapter reports the
+   `tokens used` total and resolves the session JSONL path
+   (`$CODEX_HOME/sessions/<Y>/<M>/<D>/rollout-<ts>-<session-id>.jsonl`), but
+   nothing parses that transcript into per-message usage the way the Claude
+   archiver does. Not a safety gap; a contract-point-4 fidelity gap.
+9. **Native Codex agents are not a supported backend.** Codex exposes
+   in-session collaboration primitives (`spawn_agent`, `wait_agent`,
+   `interrupt_agent`, …). Per the fork's finding (fork PR #59), these are
+   **prohibited** for Loom lifecycle dispatch: they are not a Loom
+   orchestration backend, they bypass the label state machine and the worktree
+   model entirely, and a supervisor holding them has been observed to kill live
+   children and take over their work. This is enforced by documentation only —
+   Codex has no policy hook that can block a session from calling them. Loom
+   dispatch is one process per role via `spawn-worker.sh`, never native agents.
+
+## Admission checklist (contract point 5/6)
+
+- [x] Guard-intent → mechanism map (above)
+- [x] Explicit residual-gap section (above)
+- [x] Sandbox-mode mapping with stated precedence and rationale
+- [x] Fork's native-agent prohibition recorded (gap 9)
+- [x] Error-classification table for the runtime
+      (`defaults/scripts/lib/classify-error.sh`, `codex` provider)
+- [x] Mocked CI smoke leg (`defaults/scripts/tests/test-spawn-codex.sh`)
+- [ ] Loom guard intent mechanically enforced under Codex — **open** (gap 1);
+      not required for tier-2, required for tier-1
+
+## CODEX_HOME profile layout, refresh, and security posture
+
+The adapter selects a Codex account by pointing `CODEX_HOME` at a profile
+directory. This section is the auth-surface documentation absorbed from the
+companion provisioning issue #4469 so it has exactly one owner.
+
+### Layout
+
+```text
+~/.loom/codex-profiles/            # profile root (LOOM_CODEX_PROFILE_ROOT)
+└── <account>/                     # one CODEX_HOME per account, mode 0700
+    ├── auth.json                  # OAuth/refresh-token bundle, mode 0600
+    ├── sessions/<Y>/<M>/<D>/…      # per-session rollout JSONL transcripts
+    └── …                          # Codex's own state (caches, logs, skills)
+```
+
+Provision a profile with `CODEX_HOME=~/.loom/codex-profiles/<account> codex
+login`. Select it at spawn time by any of:
+
+| Precedence | Env var | Meaning |
+|---|---|---|
+| 1 | `LOOM_CODEX_HOME` | Absolute profile directory |
+| 2 | `CODEX_HOME` | Honored verbatim if pre-set |
+| 3 | `LOOM_CODEX_PROFILE` | Bare account name under `LOOM_CODEX_PROFILE_ROOT` (default `~/.loom/codex-profiles`) |
+| 4 | *(none)* | Codex's ambient `~/.codex` login state |
+
+### Refresh
+
+`auth.json` holds a refresh-token bundle; Codex refreshes the access token
+itself and rewrites `auth.json` in place. Consequences:
+
+- The profile directory must be **writable** by the spawned worker, not just
+  readable.
+- A profile is an **authoritative copy, not a cache**. `~/.codex/auth.json` and
+  a `~/.loom/codex-profiles/<account>/auth.json` copied from it diverge the
+  moment either refreshes. Copying a live profile produces two bundles racing
+  to rotate the same credential; re-run `codex login` per profile instead.
+- Refresh failure is a real runtime error mode, and it is what the `codex`
+  classifier table's `TOKEN_EXPIRED` patterns are matching ("refresh token has
+  expired", "Failed to refresh token", "Not signed in. Please run 'codex
+  login'", `401 Unauthorized`).
+
+### Security posture
+
+- Profile dirs `0700`, `auth.json` `0600`. A profile is a live credential.
+- The adapter **assigns** the directory to `CODEX_HOME` — it never copies
+  `auth.json`. Nothing under `.loom/` ever holds a credential copy.
+- Logging discipline: the adapter logs the profile **directory name** only
+  (`spawn-codex: using Codex profile 'alice'`). Never the path's contents, never
+  a byte of `auth.json`. Preserve this in any change to the adapter.
+- An **explicitly requested** profile with no usable `auth.json` exits **78**
+  (`EX_CONFIG`) rather than silently degrading to a different account — a silent
+  fallback would attribute work and cost to the wrong account. Ambient auth
+  (tier 4) is not a request and never fails here; Codex reports its own auth
+  error, which classifies as `TOKEN_EXPIRED`.
+- **No token-pool integration in this phase.** There is no rotation, no
+  `.bad_tokens` marking, no provider-aware selection. One operator-provisioned
+  profile per dispatch. Provider-aware pooling is epic #4167 Phase 4.
+
+## References
+
+- [`runtime-adapters.md`](runtime-adapters.md) — the seven-point contract and tier policy
+- [ADR-0012](../../docs/adr/0012-runtime-adapter-contract.md) — runtime adapter contract
+- [`guard-hooks.md`](guard-hooks.md) — the Loom guard catalog this maps against
+- `defaults/scripts/spawn-codex.sh` — the adapter
+- `defaults/scripts/lib/classify-error.sh` — the `codex` provider table
+- Codex config reference: <https://developers.openai.com/codex/config-reference>
+- Codex sandboxing concepts: <https://developers.openai.com/codex/concepts/sandboxing>
+- Fork: <https://github.com/gpeyton/loom> — `defaults/.codex/GUARDRAIL-PARITY.md`
+- Epic #4167 · Phase 2 issue #4468 · companion auth issue #4469 · canary #4470

--- a/defaults/docs/runtime-adapters.md
+++ b/defaults/docs/runtime-adapters.md
@@ -41,6 +41,14 @@ The contract exists to *generalize* Loom, not to demote Claude Code.
 These are operator policy statements recorded on #4167; the contract encodes
 them but does not decide them.
 
+### Adapter status
+
+| Runtime | Adapter | Tier | Parity doc | CI leg | Notes |
+|---------|---------|------|-----------|--------|-------|
+| Claude Code | `defaults/scripts/spawn-claude.sh` | **1** (default) | n/a — Loom's guards *are* the Claude implementation | the whole existing suite | Zero-regression default; no `LOOM_RUNTIME` needed. |
+| OpenAI Codex CLI | `defaults/scripts/spawn-codex.sh` | **2** | [`guardrail-parity-codex.md`](guardrail-parity-codex.md) | `codex-adapter-smoke` in `.github/workflows/ci.yml` (mocked; no live calls) | **Shipped** by epic #4167 Phase 2 (#4468), ported from the gpeyton fork. Requires Codex CLI ≥ 0.146.0. Capability manifest `defaults/runtimes/codex.json` declares `worktreeIsolation: partial`, so `check-runtime-capabilities.sh` fails Builder+codex closed while Judge+codex passes. |
+| Amp, oh-my-pi (omp), … | — | — | — | — | Not started. |
+
 ## The seven contract points
 
 Every runtime adapter implements the same seven-point contract. Each point below
@@ -121,6 +129,17 @@ logical `opus` → an OpenAI reasoning-model ID). The fork's "cost of being wron
 tiering is the seed for how a non-Claude runtime should choose which concrete
 model a tier maps to.
 
+**The Codex adapter deliberately does NOT do this yet (#4468).** It ships
+*model-mapping minimalism*: `LOOM_MODEL` is forwarded verbatim to `codex -m`, an
+explicit `-m`/`--model` wins, `LOOM_CODEX_MODEL` supplies an optional static
+adapter default, and with none of those set **no `-m` flag is emitted at all** so
+the Codex CLI/profile default is preserved (exactly `spawn-claude.sh`'s
+no-`--model` behavior). There is no logical-tier→OpenAI-ID table, because Loom's
+tier names (`opus`, `sonnet`, `fable`) are Claude names and inventing an
+OpenAI-side mapping is precisely the reconciliation flagged below. Reasoning
+effort maps to a config override (`-c model_reasoning_effort=<v>`) because
+`codex exec` has no `--effort` flag. Full tier resolution for Codex is Phase 4.
+
 **Complexity tier map (`sweep.tierModels`, issue #4238).** The higher-level
 `sweep.tierModels[<runtime>][<tier>]` map (Curator marker → logical tier →
 model, `mechanical`/`routine`/`complex`) is exactly this per-runtime table. It is
@@ -180,24 +199,48 @@ set:
 | `SESSION_LIMIT` | concurrent-session cap (healthy account) | re-select, retry, do **not** mark bad |
 | `MODEL_REFUSAL` | safety classifier refused the turn | drop one ladder rung, no Doctor cycle consumed |
 | `RECOVERABLE` | rate limit / 5xx / network | retry with backoff |
-| `FATAL` | reserved | non-recoverable |
+| `FATAL` | non-recoverable **configuration** fault — retrying the identical invocation cannot succeed | fail fast; do not retry, do not rotate |
 
-Today this file is a single Claude-only `classify_error()` function — its regexes
-match Claude Code's actual error wording (its 401 phrasing, its quota/weekly-limit
-strings, its concurrent-session message) against the shared category set. It is
-the **Claude reference implementation**, not yet a multi-provider structure.
+This file is now a **shared classification engine plus per-provider pattern
+tables** (the structure #4190 extracted, seeded by the fork's PR #6): the engine
+owns exit-code-first ordering, the category enum, and the generic-transient
+fallthrough; each provider table owns only that runtime's failure-signature
+regexes. Provider selection is `classify_error <output> <exit_code> [provider]`
+with precedence *explicit 3rd arg > `$LOOM_RUNTIME` > `"claude"`*, so two-arg
+legacy callers (e.g. `claude-wrapper.sh`) classify bit-identically to before the
+split. An unknown provider never errors — it matches no table and resolves
+through the generic transients.
 
-The important design point for adapters is the **contract requirement** this file
-must grow into: a **per-provider pattern-table** organization, where each category
-is matched by a *provider-specific* regex over that runtime's error wording, all
-mapping onto the **same** category set. Restructuring `classify-error.sh` into
-per-provider tables is exactly what the fork's PR #6 targets — that is the future
-shape this contract point specifies, not the current upstream state. Once
-restructured, a new adapter contributes its runtime's pattern table (Codex's 401
-wording, its quota-exhaustion phrasing, its concurrent-session message) without
-touching the categories. The category *contract* is shared; the *patterns* are
-per-runtime. Callers such as `claude-wrapper.sh` source this file rather than
-duplicating the patterns, so the category set must stay stable across runtimes.
+Two tables ship today:
+
+- **`claude`** — the reference implementation: `CWD_DELETED` → `MODEL_REFUSAL` →
+  `TOKEN_EXPIRED` → `SESSION_LIMIT` → `TOKEN_EXHAUSTED` → the CLI's
+  "No messages returned" transient. Order is load-bearing (`SESSION_LIMIT`
+  before `TOKEN_EXHAUSTED`, #3947).
+- **`codex`** — added with the Codex adapter (#4468): `FATAL` config faults
+  (trusted-directory refusal, unknown `-c` config field, unconstructable
+  sandbox) → `TOKEN_EXHAUSTED` (plan/quota wording) → `TOKEN_EXPIRED`
+  (401 / `codex login` / refresh-token failures). Every pattern was observed on,
+  or extracted from, codex-cli 0.146.0 — none is guessed.
+
+Adding a runtime therefore means **contributing a table, never touching the
+categories**. Two lessons from the Codex table are worth carrying into the next
+adapter:
+
+- **Leave a category unimplemented rather than guessing.** `codex` deliberately
+  has no `CWD_DELETED` / `SESSION_LIMIT` / `MODEL_REFUSAL` patterns because that
+  runtime has no known wording for them, and reusing Claude's phrasing would
+  produce confident nonsense. An unmatched category simply falls through to
+  `RECOVERABLE`, which is the correct conservative default.
+- **Pick the ordering that makes mis-classification cheap.** `codex` checks
+  quota wording *before* 401 wording because `TOKEN_EXPIRED` marks an account bad
+  with a reason that persists until manual intervention, while
+  `TOKEN_EXHAUSTED`'s TTL-expires on its own.
+
+`FATAL` is no longer purely reserved: the `codex` table is its first producer.
+No `claude` input returns `FATAL`, so every pre-existing caller is unaffected.
+Callers such as `claude-wrapper.sh` source this file rather than duplicating the
+patterns, so the category set must stay stable across runtimes.
 
 ### 4. Usage accounting
 
@@ -250,6 +293,10 @@ section. Loom's `PreToolUse` guards (`guard-destructive.sh`,
 they are Claude Code hooks. Another runtime has its own sandbox model
 (allow/deny command lists, filesystem confinement, network policy), which will
 not match Loom's guards one-for-one.
+
+**Shipped example:** [`guardrail-parity-codex.md`](guardrail-parity-codex.md) is
+the Codex adapter's parity doc (#4468) and the reference shape for the next one.
+Naming convention: `defaults/docs/guardrail-parity-<runtime>.md`.
 
 **Adapter obligation:** every adapter MUST ship a `GUARDRAIL-PARITY.md`-style map
 of *Loom guard intent → runtime sandbox mechanism* (e.g. "force-push-to-main
@@ -314,12 +361,25 @@ exist as data + a standalone checker, ahead of dispatch wiring:
   not yet wired into `spawn-worker.sh` or any dispatch path; that wiring is a
   follow-up decision.
 
+**Second manifest (#4468):** `defaults/runtimes/codex.json` declares
+`mcp: "yes"`, `subagents: "no"` (the fork PR #59 prohibition), `hooks: "partial"`
+(Codex 0.146.0 has a `hooks.json` engine with a `pre_tool_use` event, but Loom
+wires nothing into it), `skills: "partial"`, and
+`worktreeIsolation: "partial"` (Codex's `workspace-write` sandbox confines to the
+workspace root, not to one `issue-N` worktree). Because `"partial"` fails closed,
+`check-runtime-capabilities.sh --role builder --runtime codex` exits 78 while
+`--role judge --runtime codex` passes — the manifest mechanically encodes the
+parity doc's residual gap 2, and the CI leg asserts both outcomes. That is the
+intended relationship between points 6 and 7: the parity doc states the gap in
+prose, the manifest makes it enforceable.
+
 ## Phase 1: the `spawn-worker.sh` runtime-dispatch seam
 
 Contract point 1 ([Spawn](#1-spawn)) is realized today by a concrete
 **runtime-dispatch seam** so the underlying runtime is a swappable adapter rather
-than a hardwired path. Claude Code is adapter #1; a future Codex adapter
-(`spawn-codex.sh`) slots in behind the same seam with no caller change. This is
+than a hardwired path. Claude Code is adapter #1; the Codex adapter
+(`spawn-codex.sh`, shipped in Phase 2 / #4468) slots in behind the same seam
+with no caller change — the seam needed no modification to admit it. This is
 **Phase 1** of epic **#4167** and is a **zero-behavior-change** extraction: with
 nothing configured, the seam execs the same `spawn-claude.sh` Loom always ran.
 (This upstreams the dispatch-seam shape the fork's PR #9 built — see the [fork
@@ -381,6 +441,40 @@ executable). It must satisfy the [Spawn interface](#1-spawn) above — accept th
 same passthrough-args contract and `exec` its underlying CLI. Then select it
 per-run with `LOOM_RUNTIME=<runtime>` or repo-wide with `runtimes.default`.
 
+`spawn-codex.sh` is the worked example. Use it as the shape for a third adapter,
+and note the four things it had to do that the bare Spawn table does not spell
+out — each of which is likely to recur:
+
+1. **Translate Loom's flag conventions, do not forward them.** `-p`/`--prompt`
+   and `--dangerously-skip-permissions` are *Loom* conventions. On `codex exec`,
+   `-p` means `--profile`, so forwarding it would have silently selected a
+   config profile instead of passing a prompt. Consume Loom's flags, re-emit the
+   runtime's.
+2. **Own your own scheduling priority.** `spawn-worker.sh` deliberately applies
+   no `nice`/`taskpolicy` (issue #4233) — it only `exec`s, so a runner-level
+   re-exec covers the whole tree with no double-apply. Copy `spawn-claude.sh`'s
+   `LOOM_SWEEP_NICED` block into the new runner.
+3. **Check which stream your runtime's metadata is on.** Codex writes the agent's
+   final message to stdout and *everything else* — including the `session id:`
+   line that is the transcript join key — to stderr. Reporting it therefore
+   requires running the CLI as a child with stderr tee'd (recovering the exit
+   code from `PIPESTATUS`) rather than a plain `exec`. Verify empirically; do not
+   assume.
+4. **Neutralize stdin.** A dispatched worker's stdin is a pipe nobody writes to.
+   `codex exec` reads non-TTY stdin and appends it to the prompt, so the child
+   would block forever; the adapter redirects `</dev/null`. Any runtime with a
+   "read the prompt from stdin" mode needs the same treatment.
+
+Two contract points gate admission, and neither is optional:
+a **guardrail-parity document** (point 6 — see
+[`guardrail-parity-codex.md`](guardrail-parity-codex.md) for the required shape,
+including an explicit residual-gap section) and a **CI leg** proving the adapter
+spawns correctly against a mocked CLI with no live API calls (the tier-2 gate;
+`codex-adapter-smoke` in `.github/workflows/ci.yml` is the model). Add a
+capability manifest at `defaults/runtimes/<runtime>.json` (point 7) at the same
+time — declaring a capability `"partial"` fails role matching closed, which is
+how Codex is correctly kept out of Builder dispatch.
+
 ### Unknown-runtime failure (exit 78)
 
 If the resolved runtime has no matching `spawn-<runtime>.sh` runner, the
@@ -392,10 +486,15 @@ Spawn contract's *missing-pool* facet uses — with an actionable message naming
 - the `spawn-*.sh` runners actually present on disk.
 
 ```text
-ERROR Unknown runtime 'codex' (resolved from config (runtimes.default)):
-ERROR no runner found at /…/.loom/scripts/spawn-codex.sh.
-ERROR Available runtimes on disk: claude.
+ERROR Unknown runtime 'amp' (resolved from config (runtimes.default)):
+ERROR no runner found at /…/.loom/scripts/spawn-amp.sh.
+ERROR Available runtimes on disk: claude codex.
 ```
+
+(The example named `codex` before Phase 2 shipped `spawn-codex.sh`; `codex` is
+now a *known* runtime. A regression test in
+`defaults/scripts/tests/test-spawn-codex.sh` asserts that `codex` moving from
+unknown to known did not weaken this guard for other names.)
 
 ### Scope (Phase 1)
 
@@ -413,17 +512,17 @@ adapter contract is the interface that work slots into as **upstream PRs from th
 fork** (not cherry-picks). This is the "your work slots in here" map for the
 collaboration:
 
-| Fork PR | What it built | Contract slot |
-|---------|---------------|---------------|
-| #9 | `spawn-worker.sh` spawn dispatcher | **1. Spawn** — the runtime-neutral dispatch entry point |
-| #6 | Restructured `classify-error.sh` into per-provider pattern tables | **3. Error classification** — the per-runtime pattern-table shape |
-| #15 | Codex runner | **1. Spawn** — Codex's `spawn-<runtime>.sh` implementation |
-| #16 | `.codex/` config | **5. Instruction format** — Codex's config/instruction file set |
-| #20, #40 | `GUARDRAIL-PARITY.md` guardrail parity | **6. Permission / sandbox mapping** — the parity-doc requirement |
-| #8 | `AGENTS.md` codegen | **5. Instruction format** — single-source instruction generation |
-| #12, #17 | Provider-aware account pool (per-account provider, waterfall fill, `CODEX_HOME` rotation) | **4. Usage accounting** — provider-aware selection consuming the pool signals |
-| #14 | Reusable CI role workflow (`loom-role.yml`) parameterized by runtime | Cross-cutting — the tier-2 CI gate every non-Claude adapter must pass |
-| #59 | Finding: native Codex agents prohibited for Loom lifecycles | **6/7. Constraint** — encoded in the parity doc + capability matrix |
+| Fork PR | What it built | Contract slot | Upstream status |
+|---------|---------------|---------------|-----------------|
+| #9 | `spawn-worker.sh` spawn dispatcher | **1. Spawn** — the runtime-neutral dispatch entry point | **landed** (Phase 1) |
+| #6 | Restructured `classify-error.sh` into per-provider pattern tables | **3. Error classification** — the per-runtime pattern-table shape | **landed** (#4190) |
+| #15 | Codex runner | **1. Spawn** — Codex's `spawn-<runtime>.sh` implementation | **landed** as `defaults/scripts/spawn-codex.sh` (#4468). Ported, not cherry-picked: token-pool auth deferred to Phase 4, `--full-auto`/`-a` replaced (absent on `codex exec` 0.146.0), and the skip-permissions → sandbox mapping deliberately diverges (see the parity doc). |
+| #16 | `.codex/` config | **5. Instruction format** — Codex's config/instruction file set | not started (separate issue) |
+| #20, #40 | `GUARDRAIL-PARITY.md` guardrail parity | **6. Permission / sandbox mapping** — the parity-doc requirement | **landed** as [`guardrail-parity-codex.md`](guardrail-parity-codex.md) (#4468), re-verified against 0.146.0 — several fork claims no longer hold and are corrected there |
+| #8 | `AGENTS.md` codegen | **5. Instruction format** — single-source instruction generation | not started (separate issue) |
+| #12, #17 | Provider-aware account pool (per-account provider, waterfall fill, `CODEX_HOME` rotation) | **4. Usage accounting** — provider-aware selection consuming the pool signals | Phase 4. #4468 ships only single-profile `CODEX_HOME` passthrough — no pool, no rotation, no bad-token marking. |
+| #14 | Reusable CI role workflow (`loom-role.yml`) parameterized by runtime | Cross-cutting — the tier-2 CI gate every non-Claude adapter must pass | partially landed: Codex has its own `codex-adapter-smoke` leg in `ci.yml` (#4468); the parameterized reusable workflow is not adopted |
+| #59 | Finding: native Codex agents prohibited for Loom lifecycles | **6/7. Constraint** — encoded in the parity doc + capability matrix | **landed** — recorded as residual gap 9 in the parity doc; `codex.json` declares `subagents: "no"` |
 
 ## Non-goals
 
@@ -439,5 +538,9 @@ collaboration:
 - Epic **#4167** — first-class multi-runtime worker support (the seven contract
   points' authoritative framing, the phasing, and the fork PR list).
 - **#4165** — fork divergence triage (harvest tracking).
+- [`guardrail-parity-codex.md`](guardrail-parity-codex.md) — the Codex adapter's
+  guardrail-parity doc (contract point 6), including the `CODEX_HOME` profile
+  layout / refresh / security-posture reference absorbed from #4469.
+- **#4468** — Codex adapter port (Phase 2). **#4470** — Codex canary runs.
 - [ADR-0012: Multi-Runtime Worker Support via a Runtime Adapter Contract](../../docs/adr/0012-runtime-adapter-contract.md).
 - Fork: https://github.com/gpeyton/loom · `AGENTS.md` standard: https://agents.md

--- a/defaults/runtimes/codex.json
+++ b/defaults/runtimes/codex.json
@@ -1,0 +1,10 @@
+{
+  "runtime": "codex",
+  "capabilities": {
+    "mcp": "yes",
+    "subagents": "no",
+    "hooks": "partial",
+    "skills": "partial",
+    "worktreeIsolation": "partial"
+  }
+}

--- a/defaults/scripts/lib/classify-error.sh
+++ b/defaults/scripts/lib/classify-error.sh
@@ -26,8 +26,16 @@
 #                         orchestrator drops one ladder rung (e.g. fable→opus)
 #                         WITHOUT consuming a Doctor cycle (see sweep.md).
 #       RECOVERABLE     — transient (rate limit, 5xx, network, etc.)
-#       FATAL           — non-recoverable (currently never returned;
-#                         reserved for future explicit FATAL signals)
+#       FATAL           — non-recoverable: retrying the same invocation cannot
+#                         succeed because the fault is in the CONFIGURATION,
+#                         not the transport or the account. Never returned for
+#                         provider `claude` (its table has no FATAL patterns),
+#                         so the pre-#4468 claim "currently never returned"
+#                         still holds for every Claude caller. The `codex`
+#                         table (issue #4468) is the first to use it — e.g.
+#                         Codex's trusted-directory refusal and an
+#                         unknown-config-key rejection, both of which loop
+#                         forever under a RECOVERABLE retry.
 #
 # Design — engine vs. provider pattern tables (issue #4190):
 #   classify_error() is a two-layer design: a shared CLASSIFICATION ENGINE
@@ -35,8 +43,9 @@
 #   fallthrough) plus provider-scoped PATTERN TABLES that hold the actual
 #   failure-signature regexes. This keeps a future non-Claude runtime adapter
 #   (Codex, Amp, ... — see #4167) additive: register a new provider table
-#   instead of editing the shared engine. Today only the `claude` table is
-#   populated; a `codex` stub exists for the future adapter to fill in.
+#   instead of editing the shared engine. Both the `claude` and `codex` tables
+#   are populated today (the latter filled in by epic #4167 Phase 2, issue
+#   #4468, alongside `defaults/scripts/spawn-codex.sh`).
 #
 #   Provider selector precedence (highest first): optional 3rd positional
 #   arg > `$LOOM_RUNTIME` (the same env var `spawn-worker.sh` uses for
@@ -47,10 +56,9 @@
 #   does NOT introduce a `LOOM_WORKER` selector (that name belongs to an
 #   older fork design; upstream's convention is `LOOM_RUNTIME`).
 #
-#   An unrecognized provider (or no table for a recognized-but-unimplemented
-#   provider, e.g. `codex` today) never errors — it simply has no
-#   provider-specific matches and falls straight through to the shared
-#   generic-transient table below. Provider tables are ordered case dispatch
+#   An unrecognized provider never errors — it simply has no provider-specific
+#   matches and falls straight through to the shared generic-transient table
+#   below. Provider tables are ordered case dispatch
 #   (sequential pattern checks), NOT associative-array iteration, so match
 #   order is always deterministic — bash does not guarantee iteration order
 #   for associative arrays.
@@ -86,7 +94,10 @@
 # selector/table shape — all six Claude-specific categories, in their
 # current documented order, are carried into the `claude` table below.
 #
-# Test vectors live in `defaults/scripts/tests/test-spawn-claude.sh`.
+# Test vectors: the `claude` table's live in
+# `defaults/scripts/tests/test-spawn-claude.sh`; the `codex` table's (plus the
+# cross-provider isolation checks that prove the claude vectors are unchanged)
+# live in `defaults/scripts/tests/test-spawn-codex.sh`.
 
 # shellcheck disable=SC2120  # OK that callers pass the args; we don't default.
 
@@ -161,15 +172,109 @@ _classify_error_claude() {
     # No Claude-specific pattern matched — fall through to the generic table.
 }
 
-# _classify_error_codex <output> -> stub for the future Codex runtime adapter
-# (#4167). Intentionally empty: upstream has no Codex runner yet, so there are
-# no real failure signatures to encode. Every input falls through to the
-# shared generic table below (rate-limit/5xx/network/catch-all), which is
-# already correct default behavior for an as-yet-unimplemented provider.
-# TODO(#4167): populate with Codex-specific failure signatures (401/quota/
-# rate-limit wording) when the Codex adapter ships. Do not guess at wording.
+# _classify_error_codex <output> -> echoes a category, or nothing if no
+# Codex-specific pattern matched (caller falls through to the generic table).
+# Only called when exit_code != 0.
+#
+# Provider table for the OpenAI Codex CLI adapter (`spawn-codex.sh`, epic #4167
+# Phase 2 / issue #4468). Ported from the gpeyton/loom fork's codex table by
+# Graham Peyton, then re-grounded against the real CLI: every phrase below was
+# either OBSERVED in `codex exec` output on codex-cli 0.146.0 (2026-07-29) or
+# extracted verbatim from that binary's own message strings. Nothing here is
+# guessed — where a category has no defensible Codex signature it is left
+# unimplemented and documented as such rather than filled with Claude wording.
+#
+# Match order and why:
+#   1. FATAL config faults    unambiguous, and they must not be retried.
+#   2. TOKEN_EXHAUSTED        BEFORE TOKEN_EXPIRED: OpenAI has served
+#                             `insufficient_quota` with a 401 status as well as
+#                             429, and mis-classifying a quota fault as an auth
+#                             fault is the expensive direction — TOKEN_EXPIRED
+#                             marks an account bad with reason `auth` (persists
+#                             until a manual `loom-tokens unblock`), whereas
+#                             TOKEN_EXHAUSTED uses reason `exhausted` (TTL-
+#                             expires on its own). Quota wording is also the
+#                             more specific signal, so letting it win is both
+#                             safer and more precise.
+#   3. TOKEN_EXPIRED          401 / not-signed-in / refresh-token failures.
+#
+# Deliberately NOT implemented for codex (documented, not forgotten):
+#   CWD_DELETED    No Codex-specific signature for "the workspace vanished
+#                  mid-run" is known. Claude's "current working directory was
+#                  deleted" phrasing is Claude-CLI-specific and is NOT reused.
+#   SESSION_LIMIT  Codex exposes no concurrent-session-cap error wording. A
+#                  bare 429 stays RECOVERABLE via the generic table, which is
+#                  the correct conservative behavior (retry, don't mark bad).
+#   MODEL_REFUSAL  The Responses API can emit a refusal content part, but the
+#                  Codex CLI has no stable surfaced wording for it, and a
+#                  refusal does not reliably produce a non-zero exit.
+#
+# Sandbox denials are deliberately absent — and that is a FINDING, not an
+# omission. A Codex sandbox denial is an in-session tool failure, not a process
+# failure: verified on 0.146.0 with `-s read-only`, a blocked `touch` returns
+# `Operation not permitted` to the model and the `codex exec` process still
+# exits **0**. Exit-code-first classification therefore never reaches this
+# table for a denial, and adding an "Operation not permitted" pattern here
+# would be dead code that could only ever fire as a false positive on some
+# unrelated non-zero exit. What IS classified below is a sandbox/trust fault
+# that genuinely aborts the run: the trusted-directory refusal, and Codex
+# failing to construct its sandbox at all. See
+# `defaults/docs/guardrail-parity-codex.md` for the full trust-boundary map.
 _classify_error_codex() {
-    :
+    local output="$1"
+
+    # --- FATAL: configuration faults that no retry can fix -----------------
+    # Observed verbatim on 0.146.0 when `codex exec` runs outside a git work
+    # tree: "Not inside a trusted directory and --skip-git-repo-check was not
+    # specified." (exit 1, on stderr). `spawn-codex.sh` injects
+    # --skip-git-repo-check when the cwd is genuinely not a work tree, so
+    # reaching this means something upstream mis-set the cwd — a retry loops.
+    #
+    # "unknown configuration field" is the CLI's own rejection of a bad
+    # `-c key=value` override (observed with --strict-config); also
+    # non-retryable.
+    #
+    # `landlock_sandbox_executable_not_provided` is Codex's internal error code
+    # (string present in the 0.146.0 binary) for being unable to construct its
+    # Linux sandbox — a host/config problem, not a transient one. Classifying
+    # it FATAL is the safe direction: a worker that cannot establish its
+    # sandbox must NOT be silently retried into running unsandboxed.
+    if echo "$output" | grep -qiE "not inside a trusted directory|unknown configuration field|landlock_sandbox_executable_not_provided"; then
+        echo "FATAL"
+        return
+    fi
+
+    # --- TOKEN_EXHAUSTED: plan/quota exhaustion — rotate, mark `exhausted` ---
+    # Strings taken verbatim from the 0.146.0 binary: "You've hit your usage
+    # limit.", "You've reached your usage limit.", "You've reached your
+    # workspace credit limit", "Your workspace is out of credits". Plus the
+    # documented OpenAI API error codes the CLI relays (`rate_limit_exceeded`,
+    # `insufficient_quota`, "exceeded your current quota").
+    # A BARE 429 with no quota wording is intentionally NOT matched here — it
+    # is a transient throttle and belongs to the generic RECOVERABLE table.
+    if echo "$output" | grep -qiE "hit your usage limit|reached your usage limit|usage limit reached|workspace credit limit|out of credits|insufficient_quota|rate_limit_exceeded|exceeded your current quota|quota exceeded"; then
+        echo "TOKEN_EXHAUSTED"
+        return
+    fi
+
+    # --- TOKEN_EXPIRED: this credential is bad — skip/re-auth this profile ---
+    # `401 Unauthorized` was OBSERVED end-to-end: pointing CODEX_HOME at an
+    # unauthenticated profile makes 0.146.0 emit
+    #   "failed to connect to websocket: HTTP error: 401 Unauthorized"
+    # and exit 1. The remaining phrases are verbatim binary strings for the
+    # ChatGPT-login/refresh-token failure modes a rotated `CODEX_HOME` profile
+    # actually hits: "Not signed in. Please run 'codex login'", "...refresh
+    # token has expired. Please log out and sign in again", "Your session has
+    # expired. Please reauthenticate.", "Failed to refresh token", "ChatGPT
+    # auth is missing a refresh token". `invalid_api_key` / "incorrect api key"
+    # cover the API-key (OPENAI_API_KEY) side.
+    if echo "$output" | grep -qiE "401[^a-z]*unauthorized|invalid_api_key|invalid api key|incorrect api key|not signed in|please run .?codex login|refresh token has expired|refresh token was (already used|revoked)|missing a refresh token|no refresh token available|failed to refresh token|session has expired|please reauthenticate"; then
+        echo "TOKEN_EXPIRED"
+        return
+    fi
+
+    # No Codex-specific pattern matched — fall through to the generic table
+    # (rate-limit/429, 5xx, network, catch-all RECOVERABLE).
 }
 
 # _classify_error_provider <output> <provider> -> dispatches to the matching

--- a/defaults/scripts/spawn-codex.sh
+++ b/defaults/scripts/spawn-codex.sh
@@ -1,0 +1,642 @@
+#!/usr/bin/env bash
+# spawn-codex.sh - Runtime adapter #2: the OpenAI Codex CLI worker runner.
+#
+# This is the Codex sibling of `spawn-claude.sh`, sitting behind the same
+# `spawn-worker.sh` dispatch seam: `LOOM_RUNTIME=codex` (or `.loom/config.json`
+# -> `runtimes.default = "codex"`) makes the dispatcher exec THIS script with
+# every argument forwarded verbatim. It implements contract point 1 (Spawn) of
+# `.loom/docs/runtime-adapters.md` against the Codex CLI's headless mode.
+#
+# Attribution: this adapter is a PORT of the Codex worker support built in the
+# gpeyton/loom fork by Graham Peyton (fork PRs #15/#16/#20/#40), restructured to
+# land behind upstream's runtime-adapter contract (epic #4167, Phase 2, issue
+# #4468). It is a design port, not a cherry-pick: the auth chain is deliberately
+# narrowed to `CODEX_HOME` profile passthrough (no provider-aware token pool —
+# that is Phase 4), and the sandbox default is inverted from the fork's
+# full-access posture (see "Sandbox mapping" below).
+#
+# Trust boundary: `defaults/docs/guardrail-parity-codex.md` is the required
+# guardrail-parity document for this adapter (contract point 6). Read it before
+# promoting Codex beyond tier-2 — Codex has NO PreToolUse-hook equivalent, so
+# Loom's guard hooks do not fire for a Codex worker at all.
+#
+# ---------------------------------------------------------------------------
+# Minimum supported Codex CLI version: 0.146.0
+#
+#   Every flag and config key below was verified against `codex exec --help` on
+#   codex-cli 0.146.0 (2026-07-29). The Codex CLI surface churns between
+#   releases; if a future Codex renames or removes any of these, bump this pin
+#   and re-verify:
+#     - `codex exec "<prompt>"`               non-interactive run
+#     - `-m <model>` / `--model <model>`      model selection
+#     - `-s <mode>` / `--sandbox <mode>`      read-only|workspace-write|danger-full-access
+#     - `--skip-git-repo-check`               allow running outside a git repo
+#     - `-c <key=value>`                      config override (TOML-parsed value)
+#
+#   Flags the fork's runner used that DO NOT EXIST on `codex exec` 0.146.0:
+#     - `--full-auto`            (absent; `-s workspace-write` is the replacement)
+#     - `-a/--ask-for-approval`  (top-level only; `codex exec` is always
+#                                 non-interactive, so approvals never gate it)
+#   `--dangerously-bypass-approvals-and-sandbox` still exists but this adapter
+#   prefers `-s danger-full-access`, which is the same sandbox posture without
+#   also waiving Codex's hook-trust prompt.
+#
+#   IMPORTANT — `-p` collision: on `codex exec`, `-p` means `--profile`, NOT
+#   "prompt". Loom's runner-neutral convention is `-p "<prompt>"`, so this
+#   script CONSUMES `-p`/`--prompt` and re-delivers the value as `codex exec`'s
+#   positional PROMPT argument. `-p` is therefore never forwarded to codex. To
+#   select a Codex config profile, pass the long form `--profile <name>`, which
+#   passes through untouched.
+# ---------------------------------------------------------------------------
+#
+# Live-CLI behaviors this adapter handles (observed on 0.146.0, issue #4468):
+#
+#   1. Stdin. `codex exec` reads stdin whenever stdin is not a TTY, printing
+#      "Reading additional input from stdin..." and appending it as a `<stdin>`
+#      block to the prompt. Under Loom dispatch stdin is a pipe nobody writes
+#      to, so the child would block forever. This script ALWAYS redirects the
+#      child's stdin from /dev/null — the prompt is delivered positionally, so
+#      stdin has no job to do.
+#   2. Git-repo trust check. `codex exec` refuses to run outside a git repo
+#      ("Not inside a trusted directory and --skip-git-repo-check was not
+#      specified.", exit 1). Worktree dispatch is fine (a worktree IS a git
+#      dir), so `--skip-git-repo-check` is injected ONLY when the cwd is
+#      genuinely not inside a work tree — never unconditionally, because the
+#      check is a real guardrail for scratch-dir dispatch.
+#   3. Stream split. `codex exec` writes ONLY the agent's final message to
+#      stdout. Everything else — the banner (`model:`, `sandbox:`,
+#      `session id: <uuid>`), the `user`/`codex` message blocks, and
+#      `tokens used\n<N>` — goes to STDERR. (The issue's intel described these
+#      as stdout; the live CLI disagrees, so this adapter reads them from
+#      stderr.) To report the transcript join key without disturbing the
+#      caller's stdout, the child's stderr is tee'd through a temp file while
+#      stdout passes straight through untouched.
+#   4. Transcript. The durable per-session JSONL lives at
+#      `$CODEX_HOME/sessions/<YYYY>/<MM>/<DD>/rollout-<ts>-<session-id>.jsonl`.
+#      The `session id:` banner line is the join key (contract point 2); this
+#      script resolves and logs the concrete path when it can find it.
+#
+# Contract point 1 (Spawn) interface conformance:
+#
+#   | Facet                | Codex mapping                                      |
+#   |----------------------|----------------------------------------------------|
+#   | Args passthrough     | unknown args accumulate and are forwarded verbatim; |
+#   |                      | `--` forwards the remainder                        |
+#   | Prompt delivery      | `-p`/`--prompt` -> `codex exec "<prompt>"` positional |
+#   | Model tier env       | `LOOM_MODEL` -> `-m <v>`; explicit `-m`/`--model` wins |
+#   | Effort tier env      | `LOOM_EFFORT` -> `-c model_reasoning_effort=<v>`   |
+#   |                      | (codex exec has no `--effort` flag)                |
+#   | Missing-credential   | exit **78** (EX_CONFIG) when an EXPLICITLY requested |
+#   |                      | Codex profile has no usable `auth.json`            |
+#   | Runtime-missing      | exit **127** when `codex` is not on PATH (matches   |
+#   |                      | spawn-claude.sh; 78 is reserved for config errors  |
+#   |                      | and unknown-runtime dispatch)                      |
+#   | Observability        | one `spawn-codex: model=<v>` line, one              |
+#   |                      | `spawn-codex: sandbox=<mode> source=<where>` line, |
+#   |                      | plus profile/session/transcript/tokens lines       |
+#
+# Auth (CODEX_HOME profile passthrough — NO token pool in this phase):
+#   Precedence, highest first:
+#     1. `LOOM_CODEX_HOME` — pins one profile directory explicitly.
+#     2. A pre-set `CODEX_HOME` in the environment — honored verbatim.
+#     3. `LOOM_CODEX_PROFILE` — a bare account name resolved under the profile
+#        root (`LOOM_CODEX_PROFILE_ROOT`, default `~/.loom/codex-profiles`), so
+#        `LOOM_CODEX_PROFILE=alice` -> `~/.loom/codex-profiles/alice`.
+#     4. Ambient auth — nothing is set, and the Codex CLI resolves its own
+#        default `~/.codex` login state (`codex login`).
+#   Tiers 1-3 are an ASSIGNMENT, never a copy: the selected directory becomes
+#   `CODEX_HOME` and Codex reads `$CODEX_HOME/auth.json` in place. Nothing under
+#   `.loom/` ever holds a copy of `auth.json`.
+#   An explicitly-requested profile (tiers 1-3) with no usable `auth.json`
+#   (regular, non-empty, readable) exits **78** rather than silently degrading
+#   to a different account — the contract's missing-credential facet. Tier 4 is
+#   not a "request", so ambient auth never fails here; Codex reports its own
+#   auth error (a `401 Unauthorized` stream error, classified TOKEN_EXPIRED).
+#   Logging discipline: only ever the profile DIRECTORY NAME is logged — never
+#   the full path's contents and never a byte of `auth.json`.
+#
+# Sandbox mapping (SAFETY-CRITICAL — read guardrail-parity-codex.md):
+#   Codex's sandbox is the ONLY enforced guard for a Loom-spawned Codex worker
+#   (Codex has no hook system, so `guard-destructive.sh` /
+#   `guard-worktree-paths.sh` never run). This adapter therefore defaults to the
+#   most restrictive mode and requires an explicit signal to widen it.
+#   Precedence, highest first:
+#     1. An explicit `-s`/`--sandbox` in the passthrough args.
+#     2. `LOOM_CODEX_SANDBOX` (read-only|workspace-write|danger-full-access).
+#     3. Loom's runner-neutral `--dangerously-skip-permissions` convention ->
+#        `workspace-write` (writes confined to the workspace; NOT full access).
+#     4. Default: `read-only`.
+#   DELIBERATE DIVERGENCE FROM THE FORK: the fork maps skip-permissions to
+#   `--dangerously-bypass-approvals-and-sandbox` (no sandbox at all), reasoning
+#   that Claude already runs unattended with full tool access. Upstream declines
+#   that mapping because Claude's unattended posture is backstopped by PreToolUse
+#   guards that Codex cannot run — so "same flag, same posture" would be a
+#   strictly weaker trust boundary, not parity. `workspace-write` is the closest
+#   honest analogue of `guard-worktree-paths.sh`'s intent. Operators who want the
+#   fork's posture opt in explicitly with
+#   `LOOM_CODEX_SANDBOX=danger-full-access`.
+#   Network: `workspace-write` blocks outbound network by default, so a Codex
+#   worker cannot `git push` or call `gh`. `LOOM_CODEX_NETWORK=1` adds
+#   `-c sandbox_workspace_write.network_access=true` (workspace-write only).
+#
+# Usage:
+#   .loom/scripts/spawn-codex.sh -p "your prompt"
+#   LOOM_RUNTIME=codex .loom/scripts/spawn-worker.sh -p "your prompt"
+#   LOOM_CODEX_SANDBOX=workspace-write LOOM_CODEX_NETWORK=1 \
+#       .loom/scripts/spawn-codex.sh -p "..." --dangerously-skip-permissions
+#   .loom/scripts/spawn-codex.sh                 # interactive (bare `codex`)
+#
+# Env vars:
+#   LOOM_MODEL           Model passed as `codex -m <value>`. Lowest priority: an
+#                        explicit `-m`/`--model` in the passthrough args wins.
+#                        When neither is set, NO model flag is emitted and the
+#                        Codex CLI/profile default is preserved (Phase-2
+#                        model-mapping minimalism — logical tier -> model ID
+#                        resolution is epic #4167 Phase 4).
+#   LOOM_CODEX_MODEL     Static per-adapter default model, used only when
+#                        neither an explicit flag nor LOOM_MODEL is present.
+#                        Unset by default (no `-m` emitted).
+#   LOOM_EFFORT          Reasoning effort, mapped to
+#                        `-c model_reasoning_effort=<value>`. Skipped when an
+#                        explicit `-c model_reasoning_effort=` override is
+#                        already present in the passthrough args.
+#   LOOM_CODEX_SANDBOX   read-only | workspace-write | danger-full-access.
+#                        Overrides the skip-permissions mapping and the default.
+#   LOOM_CODEX_NETWORK   When 1 and the effective sandbox is workspace-write,
+#                        adds `-c sandbox_workspace_write.network_access=true`.
+#   LOOM_CODEX_HOME      Pins one CODEX_HOME profile directory (auth tier 1).
+#   CODEX_HOME           Honored verbatim if pre-set (auth tier 2).
+#   LOOM_CODEX_PROFILE   Bare profile/account name resolved under the profile
+#                        root (auth tier 3).
+#   LOOM_CODEX_PROFILE_ROOT  Profile root for LOOM_CODEX_PROFILE. Default
+#                        `~/.loom/codex-profiles`.
+#   LOOM_SPAWN_NO_EXPORT If set, skip ALL auth resolution (mirrors
+#                        spawn-claude.sh) — the caller already prepared the env.
+#   LOOM_WORKSPACE       Override repo-root detection (config lookups).
+#   LOOM_CODEX_NO_CAPTURE  If set, `exec codex` directly instead of running it
+#                        as a child with stderr tee'd. Preserves the pid but
+#                        forfeits session-id / transcript / token reporting.
+#   LOOM_CODEX_NO_EXEC   Test/CI hook: print the argv this script WOULD run
+#                        (prefixed `spawn-codex would-exec:`) and exit 0. Never
+#                        touches the real CLI. Does not change production
+#                        behavior.
+#   LOOM_SWEEP_NICENESS / LOOM_SWEEP_NICE / LOOM_SWEEP_TASKPOLICY_CLASS
+#                        Scheduling priority, applied by this runner exactly the
+#                        way spawn-claude.sh applies it (issue #4233 — priority
+#                        is a per-runner policy, never the dispatcher's).
+
+set -euo pipefail
+
+# --- Logging helpers (match spawn-claude.sh / spawn-worker.sh convention) ---
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')]${NC} $*" >&2; }
+log_warn() { echo -e "${YELLOW}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] WARN${NC} $*" >&2; }
+log_error() { echo -e "${RED}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] ERROR${NC} $*" >&2; }
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Repo root resolution (handles worktrees; mirrors spawn-claude.sh) ---
+_resolve_workspace() {
+    if [[ -n "${LOOM_WORKSPACE:-}" ]]; then
+        printf '%s\n' "$LOOM_WORKSPACE"
+        return
+    fi
+
+    local git_common_dir
+    if git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null)"; then
+        if [[ ! "$git_common_dir" = /* ]]; then
+            git_common_dir="$(cd "$git_common_dir" && pwd)"
+        fi
+        printf '%s\n' "$(dirname "$git_common_dir")"
+        return
+    fi
+
+    cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd
+}
+
+WORKSPACE="$(_resolve_workspace)"
+
+# --- Sweep/role-runner scheduling priority (issue #4233) ---
+# Applied HERE, in the runner, not in spawn-worker.sh — the dispatcher only
+# `exec`s, which preserves the pid, so a runner-level re-exec still covers every
+# process the dispatch would otherwise have spawned, with no double-apply. Same
+# `LOOM_SWEEP_NICED` sentinel and same precedence chain spawn-claude.sh uses
+# (env > config > default 10); `LOOM_SWEEP_NICE=0` disables the mechanism.
+if [[ -z "${LOOM_SWEEP_NICED:-}" && "${LOOM_SWEEP_NICE:-1}" != "0" ]]; then
+    _sweep_niceness="${LOOM_SWEEP_NICENESS:-}"
+    _sweep_taskpolicy_class="${LOOM_SWEEP_TASKPOLICY_CLASS:-}"
+    _sweep_config_lib="${_SCRIPT_DIR}/lib/config-resolver.sh"
+    if [[ ( -z "$_sweep_niceness" || -z "$_sweep_taskpolicy_class" ) \
+          && -f "$_sweep_config_lib" ]]; then
+        # shellcheck source=./lib/config-resolver.sh
+        source "$_sweep_config_lib"
+        [[ -z "$_sweep_niceness" ]] \
+            && _sweep_niceness="$(loom_config_get "$WORKSPACE" "autonomous.spawnNiceness" "")"
+        [[ -z "$_sweep_taskpolicy_class" ]] \
+            && _sweep_taskpolicy_class="$(loom_config_get "$WORKSPACE" "autonomous.spawnTaskpolicyClass" "")"
+    fi
+    : "${_sweep_niceness:=10}"
+
+    if [[ -n "$_sweep_taskpolicy_class" ]] && command -v taskpolicy >/dev/null 2>&1; then
+        if taskpolicy -c "$_sweep_taskpolicy_class" -p $$ >/dev/null 2>&1; then
+            log_info "spawn-codex: applied taskpolicy -c $_sweep_taskpolicy_class (issue #4233)"
+        else
+            log_warn "spawn-codex: taskpolicy -c $_sweep_taskpolicy_class failed (non-fatal, continuing at default policy class)"
+        fi
+    fi
+
+    if [[ "$_sweep_niceness" != "0" ]] && command -v nice >/dev/null 2>&1; then
+        export LOOM_SWEEP_NICED=1
+        log_info "spawn-codex: re-exec at nice -n $_sweep_niceness (issue #4233; LOOM_SWEEP_NICE=0 to disable)"
+        exec nice -n "$_sweep_niceness" "$0" "$@"
+    fi
+fi
+
+# --- Daemon self-claim marker visibility (mirrors spawn-claude.sh) ---
+log_info "spawn-codex: LOOM_SWEEP_CLAIM_OWNED=${LOOM_SWEEP_CLAIM_OWNED:-unset}"
+
+# --- Argument parsing ---
+# Buckets:
+#   PROMPT            prompt text extracted from -p/--prompt (exec mode)
+#   PASSTHROUGH_ARGS  everything else, forwarded to codex verbatim
+PROMPT=""
+HAS_PROMPT=false
+SKIP_PERMISSIONS=false
+HAS_MODEL_ARG=false
+EXPLICIT_MODEL=""
+HAS_SANDBOX_ARG=false
+EXPLICIT_SANDBOX=""
+HAS_EFFORT_OVERRIDE=false
+HAS_SKIP_GIT_CHECK_ARG=false
+PASSTHROUGH_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -p|--prompt)
+            if [[ $# -lt 2 ]]; then
+                log_error "$1 requires a value"
+                exit 78  # EX_CONFIG
+            fi
+            PROMPT="$2"
+            HAS_PROMPT=true
+            shift 2
+            ;;
+        -p=*)
+            PROMPT="${1#-p=}"
+            HAS_PROMPT=true
+            shift
+            ;;
+        --prompt=*)
+            PROMPT="${1#--prompt=}"
+            HAS_PROMPT=true
+            shift
+            ;;
+        --dangerously-skip-permissions)
+            # Loom's runner-neutral skip-permissions convention. Consumed here
+            # (codex does not understand this Claude-specific flag) and mapped
+            # to a Codex sandbox mode below.
+            SKIP_PERMISSIONS=true
+            shift
+            ;;
+        -m|--model)
+            HAS_MODEL_ARG=true
+            PASSTHROUGH_ARGS+=("$1")
+            if [[ $# -ge 2 ]]; then
+                EXPLICIT_MODEL="$2"
+                PASSTHROUGH_ARGS+=("$2")
+                shift 2
+            else
+                shift
+            fi
+            ;;
+        -m=*)
+            HAS_MODEL_ARG=true
+            EXPLICIT_MODEL="${1#-m=}"
+            PASSTHROUGH_ARGS+=("$1")
+            shift
+            ;;
+        --model=*)
+            HAS_MODEL_ARG=true
+            EXPLICIT_MODEL="${1#--model=}"
+            PASSTHROUGH_ARGS+=("$1")
+            shift
+            ;;
+        -s|--sandbox)
+            HAS_SANDBOX_ARG=true
+            PASSTHROUGH_ARGS+=("$1")
+            if [[ $# -ge 2 ]]; then
+                EXPLICIT_SANDBOX="$2"
+                PASSTHROUGH_ARGS+=("$2")
+                shift 2
+            else
+                shift
+            fi
+            ;;
+        -s=*)
+            HAS_SANDBOX_ARG=true
+            EXPLICIT_SANDBOX="${1#-s=}"
+            PASSTHROUGH_ARGS+=("$1")
+            shift
+            ;;
+        --sandbox=*)
+            HAS_SANDBOX_ARG=true
+            EXPLICIT_SANDBOX="${1#--sandbox=}"
+            PASSTHROUGH_ARGS+=("$1")
+            shift
+            ;;
+        --dangerously-bypass-approvals-and-sandbox)
+            # Codex's own no-sandbox flag. Treated as an explicit sandbox
+            # decision so this script never ALSO injects `-s <mode>` (which
+            # Codex would reject as conflicting).
+            HAS_SANDBOX_ARG=true
+            EXPLICIT_SANDBOX="danger-full-access"
+            PASSTHROUGH_ARGS+=("$1")
+            shift
+            ;;
+        --skip-git-repo-check)
+            HAS_SKIP_GIT_CHECK_ARG=true
+            PASSTHROUGH_ARGS+=("$1")
+            shift
+            ;;
+        -c|--config)
+            PASSTHROUGH_ARGS+=("$1")
+            if [[ $# -ge 2 ]]; then
+                case "$2" in
+                    model_reasoning_effort=*) HAS_EFFORT_OVERRIDE=true ;;
+                esac
+                PASSTHROUGH_ARGS+=("$2")
+                shift 2
+            else
+                shift
+            fi
+            ;;
+        -c=*|--config=*)
+            case "$1" in
+                *model_reasoning_effort=*) HAS_EFFORT_OVERRIDE=true ;;
+            esac
+            PASSTHROUGH_ARGS+=("$1")
+            shift
+            ;;
+        --help|-h)
+            # macOS-safe: `sed '$d'` (delete last line) instead of the GNU-only
+            # `head -n -1`, matching spawn-worker.sh's help renderer.
+            sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' \
+                | sed '$d'
+            exit 0
+            ;;
+        --)
+            shift
+            PASSTHROUGH_ARGS+=("$@")
+            break
+            ;;
+        *)
+            PASSTHROUGH_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# --- Model selection (mirrors spawn-claude.sh's #3477 precedence) ---
+# Precedence: explicit -m/--model > LOOM_MODEL > LOOM_CODEX_MODEL (the adapter's
+# static default, unset by default) > nothing (Codex CLI/profile default).
+# Exactly one structured `spawn-codex: model=<value>` line per spawn.
+#
+# Phase-2 minimalism (issue #4468): there is NO logical-tier -> model-ID table
+# here. Loom's logical tiers (`opus`, `sonnet`, `fable`) are Claude names; the
+# `sweep.modelAliases`/`sweep.tierModels` indirection that would map them onto
+# OpenAI model IDs is epic #4167 Phase 4. Until then LOOM_MODEL is forwarded
+# verbatim and the adapter's static default is "whatever the profile already
+# chose", which is the operator's own selection.
+CODEX_DEFAULT_MODEL="${LOOM_CODEX_MODEL:-}"
+if [[ "$HAS_MODEL_ARG" == "true" ]]; then
+    if [[ -n "${LOOM_MODEL:-}" ]]; then
+        log_info "spawn-codex: explicit -m/--model in args wins over LOOM_MODEL='$LOOM_MODEL'"
+    fi
+    log_info "spawn-codex: model=${EXPLICIT_MODEL:-default} (from -m/--model arg)"
+elif [[ -n "${LOOM_MODEL:-}" ]]; then
+    PASSTHROUGH_ARGS+=(-m "$LOOM_MODEL")
+    log_info "spawn-codex: model=$LOOM_MODEL (from LOOM_MODEL)"
+elif [[ -n "$CODEX_DEFAULT_MODEL" ]]; then
+    PASSTHROUGH_ARGS+=(-m "$CODEX_DEFAULT_MODEL")
+    log_info "spawn-codex: model=$CODEX_DEFAULT_MODEL (from LOOM_CODEX_MODEL adapter default)"
+else
+    log_info "spawn-codex: model=default"
+fi
+
+# --- Effort selection ---
+# `codex exec` has no `--effort` flag; the equivalent knob is the
+# `model_reasoning_effort` config key. Mirrors the model precedence: an explicit
+# `-c model_reasoning_effort=` in the passthrough args wins, then LOOM_EFFORT,
+# then nothing (no override emitted, CLI default preserved).
+if [[ "$HAS_EFFORT_OVERRIDE" == "true" ]]; then
+    if [[ -n "${LOOM_EFFORT:-}" ]]; then
+        log_info "spawn-codex: explicit -c model_reasoning_effort= wins over LOOM_EFFORT='$LOOM_EFFORT'"
+    fi
+elif [[ -n "${LOOM_EFFORT:-}" ]]; then
+    PASSTHROUGH_ARGS+=(-c "model_reasoning_effort=$LOOM_EFFORT")
+    log_info "spawn-codex: effort=$LOOM_EFFORT (from LOOM_EFFORT)"
+fi
+
+# --- Sandbox mapping (SAFETY-CRITICAL; see header + guardrail-parity-codex.md) ---
+VALID_SANDBOX_MODES="read-only workspace-write danger-full-access"
+SANDBOX_MODE=""
+SANDBOX_SOURCE=""
+if [[ "$HAS_SANDBOX_ARG" == "true" ]]; then
+    SANDBOX_MODE="${EXPLICIT_SANDBOX:-unknown}"
+    SANDBOX_SOURCE="explicit-arg"
+    if [[ -n "${LOOM_CODEX_SANDBOX:-}" ]]; then
+        log_info "spawn-codex: explicit sandbox arg wins over LOOM_CODEX_SANDBOX='$LOOM_CODEX_SANDBOX'"
+    fi
+elif [[ -n "${LOOM_CODEX_SANDBOX:-}" ]]; then
+    SANDBOX_MODE="$LOOM_CODEX_SANDBOX"
+    SANDBOX_SOURCE="LOOM_CODEX_SANDBOX"
+    if [[ " $VALID_SANDBOX_MODES " != *" $SANDBOX_MODE "* ]]; then
+        log_error "Invalid LOOM_CODEX_SANDBOX='$SANDBOX_MODE'."
+        log_error "Valid modes: $VALID_SANDBOX_MODES."
+        exit 78  # EX_CONFIG
+    fi
+    PASSTHROUGH_ARGS+=(-s "$SANDBOX_MODE")
+elif [[ "$SKIP_PERMISSIONS" == "true" ]]; then
+    # Loom's skip-permissions convention maps to workspace-write, NOT full
+    # access — see the header's "DELIBERATE DIVERGENCE FROM THE FORK".
+    SANDBOX_MODE="workspace-write"
+    SANDBOX_SOURCE="loom-skip-permissions-convention"
+    PASSTHROUGH_ARGS+=(-s "$SANDBOX_MODE")
+else
+    SANDBOX_MODE="read-only"
+    SANDBOX_SOURCE="adapter-default"
+    PASSTHROUGH_ARGS+=(-s "$SANDBOX_MODE")
+fi
+log_info "spawn-codex: sandbox=$SANDBOX_MODE source=$SANDBOX_SOURCE"
+
+# Outbound network inside a workspace-write sandbox is OFF in Codex by default,
+# which blocks `git push` / `gh` for a Builder-equivalent worker. Opt in
+# explicitly; a no-op (with a warning) under any other sandbox mode.
+if [[ "${LOOM_CODEX_NETWORK:-}" == "1" ]]; then
+    if [[ "$SANDBOX_MODE" == "workspace-write" ]]; then
+        PASSTHROUGH_ARGS+=(-c "sandbox_workspace_write.network_access=true")
+        log_info "spawn-codex: network=enabled (workspace-write + LOOM_CODEX_NETWORK=1)"
+    else
+        log_warn "spawn-codex: LOOM_CODEX_NETWORK=1 has no effect under sandbox=$SANDBOX_MODE (the network_access key is read only for workspace-write)"
+    fi
+fi
+
+# --- Git-repo trust check (live-CLI behavior 2) ---
+# `codex exec` refuses to run outside a git work tree. Worktrees ARE work trees,
+# so dispatch into `.loom/worktrees/issue-N` needs nothing. Inject
+# `--skip-git-repo-check` ONLY when the cwd is genuinely not inside one, so the
+# guardrail keeps applying wherever it can.
+if [[ "$HAS_SKIP_GIT_CHECK_ARG" != "true" ]]; then
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        log_info "spawn-codex: cwd is inside a git work tree — leaving Codex's trusted-directory check enabled"
+    else
+        PASSTHROUGH_ARGS+=(--skip-git-repo-check)
+        log_warn "spawn-codex: cwd '$PWD' is not inside a git work tree — injecting --skip-git-repo-check (Codex would otherwise refuse to start)"
+    fi
+fi
+
+# --- Auth: CODEX_HOME profile passthrough (see header) ---
+CODEX_PROFILE_NAME=""
+if [[ -n "${LOOM_SPAWN_NO_EXPORT:-}" ]]; then
+    log_info "spawn-codex: LOOM_SPAWN_NO_EXPORT set — skipping CODEX_HOME resolution"
+else
+    _requested_home=""
+    _requested_source=""
+    if [[ -n "${LOOM_CODEX_HOME:-}" ]]; then
+        _requested_home="${LOOM_CODEX_HOME%/}"
+        _requested_source="LOOM_CODEX_HOME"
+    elif [[ -n "${CODEX_HOME:-}" ]]; then
+        _requested_home="${CODEX_HOME%/}"
+        _requested_source="CODEX_HOME"
+    elif [[ -n "${LOOM_CODEX_PROFILE:-}" ]]; then
+        _profile_root="${LOOM_CODEX_PROFILE_ROOT:-$HOME/.loom/codex-profiles}"
+        _requested_home="${_profile_root%/}/${LOOM_CODEX_PROFILE}"
+        _requested_source="LOOM_CODEX_PROFILE"
+    fi
+
+    if [[ -n "$_requested_home" ]]; then
+        _auth_candidate="${_requested_home}/auth.json"
+        if [[ -f "$_auth_candidate" && -r "$_auth_candidate" && -s "$_auth_candidate" ]]; then
+            export CODEX_HOME="$_requested_home"
+            CODEX_PROFILE_NAME="$(basename "$_requested_home")"
+            # Directory NAME only — never the path contents, never auth.json.
+            log_info "spawn-codex: using Codex profile '$CODEX_PROFILE_NAME' (source=$_requested_source)"
+        else
+            log_error "Codex profile requested via $_requested_source has no usable auth.json."
+            log_error "Expected a regular, non-empty, readable file at <profile>/auth.json."
+            log_error "Provision the profile with:"
+            log_error "  CODEX_HOME=$_requested_home codex login"
+            log_error "Or unset $_requested_source to fall back to the Codex CLI's own"
+            log_error "default login state (~/.codex)."
+            exit 78  # EX_CONFIG
+        fi
+    else
+        log_info "spawn-codex: no Codex profile requested — using the Codex CLI's ambient login state (~/.codex)"
+    fi
+fi
+
+# --- Assemble the codex invocation ---
+# Non-interactive (prompt present): `codex exec [flags] "<prompt>"`.
+# Interactive (no prompt):          `codex [flags]`.
+CODEX_ARGS=()
+if [[ "$HAS_PROMPT" == "true" ]]; then
+    CODEX_ARGS+=(exec)
+fi
+CODEX_ARGS+=(${PASSTHROUGH_ARGS[@]+"${PASSTHROUGH_ARGS[@]}"})
+if [[ "$HAS_PROMPT" == "true" ]]; then
+    CODEX_ARGS+=("$PROMPT")
+fi
+
+# --- Test/CI hook: surface the resolved argv without touching the real CLI ---
+# Checked BEFORE the binary check so the mocked test can assert argv assembly on
+# a host with no `codex` installed at all.
+if [[ -n "${LOOM_CODEX_NO_EXEC:-}" ]]; then
+    echo "spawn-codex would-exec: codex ${CODEX_ARGS[*]}"
+    exit 0
+fi
+
+# --- Binary check ---
+# Exit 127 (not 78): 78/EX_CONFIG is reserved for configuration errors,
+# including spawn-worker.sh's unknown-runtime dispatch failure. A missing
+# runtime binary is the contract's "Runtime-missing" facet, which
+# spawn-claude.sh answers with 127.
+if ! command -v codex >/dev/null 2>&1; then
+    log_error "'codex' command not found in PATH."
+    log_error "Install the OpenAI Codex CLI (>= 0.146.0), e.g.:"
+    log_error "  npm install -g @openai/codex     # or: brew install codex"
+    exit 127
+fi
+
+# --- Dispatch ---
+# Interactive runs (no prompt) and an explicit LOOM_CODEX_NO_CAPTURE keep a
+# plain pid-preserving `exec`. Note stdin is NOT redirected in the interactive
+# case — an operator at the keyboard needs it.
+if [[ "$HAS_PROMPT" != "true" || -n "${LOOM_CODEX_NO_CAPTURE:-}" ]]; then
+    exec codex ${CODEX_ARGS[@]+"${CODEX_ARGS[@]}"}
+fi
+
+# Headless run. Two live-CLI behaviors force a child (not `exec`) here:
+#   - stdin must be /dev/null so `codex exec` does not block reading a pipe
+#     nobody writes to (behavior 1);
+#   - the `session id:` / `tokens used` lines land on STDERR (behavior 3), so
+#     they must be tee'd to be observable while the caller's stdout — the agent's
+#     final message, and nothing else — passes through byte-for-byte.
+# fd juggling: `2>&1 1>&3` sends codex's STDERR into the pipe (to tee) and its
+# STDOUT to fd 3, which the outer `3>&1` has already pointed at this script's
+# real stdout. PIPESTATUS[0] recovers codex's own exit code, so the contract's
+# exit-code passthrough is preserved despite not using `exec`.
+_stderr_file="$(mktemp -t loom-spawn-codex.XXXXXX 2>/dev/null || mktemp)"
+# shellcheck disable=SC2064  # expand $_stderr_file now, at trap-install time.
+trap "rm -f '$_stderr_file'" EXIT
+
+set +e
+{ codex ${CODEX_ARGS[@]+"${CODEX_ARGS[@]}"} </dev/null 2>&1 1>&3 3>&- \
+    | tee "$_stderr_file" >&2; } 3>&1
+_exit_code=${PIPESTATUS[0]}
+set -e
+
+# --- Session / transcript / cost reporting (contract points 1, 2 and 4) ---
+# `session id: <uuid>` is the transcript join key. The durable per-session JSONL
+# is `$CODEX_HOME/sessions/<YYYY>/<MM>/<DD>/rollout-<ts>-<session-id>.jsonl`;
+# resolve the concrete path when the session dir is reachable, and fall back to
+# reporting just the id when it is not (e.g. `--ephemeral`, or ambient auth
+# whose CODEX_HOME this script never set).
+_session_id="$(
+    grep -aoE 'session id:[[:space:]]*[0-9a-fA-F-]{8,}' "$_stderr_file" 2>/dev/null \
+    | head -1 | sed -E 's/.*session id:[[:space:]]*//' || true
+)"
+if [[ -n "$_session_id" ]]; then
+    log_info "spawn-codex: session=$_session_id"
+    _sessions_root="${CODEX_HOME:-$HOME/.codex}/sessions"
+    _transcript=""
+    if [[ -d "$_sessions_root" ]]; then
+        _transcript="$(
+            find "$_sessions_root" -type f -name "*${_session_id}*.jsonl" 2>/dev/null \
+            | head -1 || true
+        )"
+    fi
+    if [[ -n "$_transcript" ]]; then
+        log_info "spawn-codex: transcript=$_transcript"
+    else
+        log_info "spawn-codex: transcript=unresolved (session $_session_id; searched $_sessions_root)"
+    fi
+else
+    log_info "spawn-codex: transcript=unresolved (no 'session id:' line in codex output)"
+fi
+
+# `tokens used` is followed by the count on the NEXT line. This is an aggregate
+# per-session signal, not the per-turn usage the Claude transcript carries — the
+# durable JSONL above is the higher-fidelity source once mapped (Phase 4).
+_tokens_used="$(
+    grep -aA1 '^tokens used' "$_stderr_file" 2>/dev/null \
+    | tail -1 | tr -d ' ,' | grep -aE '^[0-9]+$' || true
+)"
+if [[ -n "$_tokens_used" ]]; then
+    log_info "spawn-codex: tokens_used=$_tokens_used"
+fi
+
+exit "$_exit_code"

--- a/defaults/scripts/tests/test-spawn-codex.sh
+++ b/defaults/scripts/tests/test-spawn-codex.sh
@@ -1,0 +1,801 @@
+#!/usr/bin/env bash
+# test-spawn-codex.sh — Tests for the Codex runtime adapter (issue #4468,
+# epic #4167 Phase 2).
+#
+# Style matches test-spawn-worker.sh / test-spawn-claude.sh — plain bash,
+# hand-rolled assertions. Bats is NOT used in this repository.
+#
+# NO LIVE OpenAI CALLS. Two mechanisms keep this hermetic:
+#   1. `LOOM_CODEX_NO_EXEC=1` makes spawn-codex.sh print the argv it WOULD run
+#      and exit 0 — used for every argv-assembly / precedence assertion, and it
+#      works on a host with no `codex` installed at all.
+#   2. A fake `codex` shim on a temp PATH that reproduces codex-cli 0.146.0's
+#      observed stream split (final message on stdout; banner, `session id:`
+#      and `tokens used` on stderr) — used for the dispatch/reporting tests.
+#
+# Coverage:
+#   1. argv assembly + prompt delivery
+#   2. sandbox mapping + precedence (SAFETY-CRITICAL)
+#   3. model + effort mapping
+#   4. git-repo trust check
+#   5. args passthrough + usage errors
+#   6. CODEX_HOME profile selection (incl. exit 78 + credential hygiene)
+#   7. missing binary -> 127 (NOT 78)
+#   8. mocked dispatch: stdout/stderr split, stdin, session/transcript/tokens,
+#      exit-code passthrough
+#   9. LOOM_RUNTIME=codex resolution through spawn-worker.sh
+#  10. classify-error.sh `codex` provider vectors (+ `claude` unchanged)
+#
+# Usage:
+#   ./.loom/scripts/tests/test-spawn-codex.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SPAWN_CODEX="$SCRIPTS_DIR/spawn-codex.sh"
+CLASSIFY_LIB="$SCRIPTS_DIR/lib/classify-error.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected: '$expected'"
+        echo "    Actual:   '$actual'"
+    fi
+}
+
+assert_contains() {
+    local needle="$1" haystack="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" == *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+assert_not_contains() {
+    local needle="$1" haystack="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" != *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Unexpected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+# ============================================================
+# Section 0: syntax + help
+# ============================================================
+
+echo "Testing spawn-codex.sh syntax and help..."
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if bash -n "$SPAWN_CODEX" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: spawn-codex.sh passes bash -n"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: spawn-codex.sh fails bash -n"
+fi
+
+set +e
+help_out="$(bash "$SPAWN_CODEX" --help 2>&1)"
+help_rc=$?
+set -e
+assert_eq "0" "$help_rc" "--help exits 0"
+assert_contains "Runtime adapter #2" "$help_out" "--help renders the header docs"
+assert_contains "gpeyton/loom fork" "$help_out" \
+    "--help preserves attribution to the gpeyton/loom fork"
+assert_not_contains "set -euo" "$help_out" \
+    "--help stops before the shebang body (no 'set -euo' leak)"
+
+# ============================================================
+# Helper: run spawn-codex.sh in argv-only (LOOM_CODEX_NO_EXEC) mode.
+#
+# LOOM_SWEEP_NICE=0 disables the #4233 nice re-exec so the test observes one
+# clean pass. LOOM_SPAWN_NO_EXPORT=1 skips auth resolution unless a test is
+# specifically exercising it. `env -u` clears host-inherited Codex vars so a
+# developer's own CODEX_HOME/profile can never perturb an assertion.
+# ============================================================
+
+run_argv() {
+    # usage: run_argv [VAR=val ...] -- <args...>
+    local -a envs=()
+    while [[ $# -gt 0 && "$1" != "--" ]]; do envs+=("$1"); shift; done
+    shift || true
+    env -u CODEX_HOME -u LOOM_CODEX_HOME -u LOOM_CODEX_PROFILE \
+        -u LOOM_CODEX_SANDBOX -u LOOM_CODEX_NETWORK -u LOOM_MODEL \
+        -u LOOM_EFFORT -u LOOM_CODEX_MODEL \
+        LOOM_SWEEP_NICE=0 LOOM_CODEX_NO_EXEC=1 LOOM_SPAWN_NO_EXPORT=1 \
+        ${envs[@]+"${envs[@]}"} \
+        bash "$SPAWN_CODEX" "$@" 2>/dev/null || true
+}
+
+run_argv_stderr() {
+    local -a envs=()
+    while [[ $# -gt 0 && "$1" != "--" ]]; do envs+=("$1"); shift; done
+    shift || true
+    # Capture stderr ONLY: stdout is discarded inside the group, and the
+    # group's stderr becomes this function's stdout.
+    { env -u CODEX_HOME -u LOOM_CODEX_HOME -u LOOM_CODEX_PROFILE \
+        -u LOOM_CODEX_SANDBOX -u LOOM_CODEX_NETWORK -u LOOM_MODEL \
+        -u LOOM_EFFORT -u LOOM_CODEX_MODEL \
+        LOOM_SWEEP_NICE=0 LOOM_CODEX_NO_EXEC=1 LOOM_SPAWN_NO_EXPORT=1 \
+        ${envs[@]+"${envs[@]}"} \
+        bash "$SPAWN_CODEX" "$@" >/dev/null; } 2>&1 || true
+}
+
+# ============================================================
+# Section 1: argv assembly + prompt delivery (contract point 1)
+# ============================================================
+
+echo ""
+echo "Testing spawn-codex.sh argv assembly + prompt delivery..."
+
+out="$(run_argv -- -p "hello world")"
+assert_contains "spawn-codex would-exec: codex exec" "$out" \
+    "-p produces a 'codex exec' invocation"
+assert_contains "hello world" "$out" "the prompt text reaches the argv"
+
+# The prompt must be the LAST (positional) argument, because on `codex exec`
+# `-p` means --profile, not prompt. Assert the tail explicitly.
+assert_eq "hello world" "${out##* -s read-only }" \
+    "the prompt is delivered POSITIONALLY as the final argv element"
+assert_not_contains "codex exec -p" "$out" \
+    "-p is CONSUMED, never forwarded to codex (where -p means --profile)"
+
+# --prompt and the =-forms are equivalent.
+assert_contains "alt-form" "$(run_argv -- --prompt "alt-form")" \
+    "--prompt is accepted as a synonym for -p"
+assert_contains "eq-form" "$(run_argv -- --prompt=eq-form)" \
+    "--prompt=VALUE is accepted"
+assert_contains "short-eq" "$(run_argv -- -p=short-eq)" \
+    "-p=VALUE is accepted"
+
+# No prompt -> interactive shape: bare `codex`, no `exec` subcommand.
+out="$(run_argv -- --some-flag)"
+assert_not_contains "codex exec" "$out" \
+    "no -p means no 'exec' subcommand (interactive shape)"
+assert_contains "spawn-codex would-exec: codex" "$out" \
+    "no -p still assembles a bare 'codex' invocation"
+
+# Observability: exactly one model line and one sandbox line per spawn.
+err="$(run_argv_stderr -- -p x)"
+assert_eq "1" "$(printf '%s\n' "$err" | grep -c 'spawn-codex: model=')" \
+    "exactly ONE structured 'spawn-codex: model=' line per spawn"
+assert_eq "1" "$(printf '%s\n' "$err" | grep -c 'spawn-codex: sandbox=')" \
+    "exactly ONE structured 'spawn-codex: sandbox=' line per spawn"
+assert_contains "spawn-codex: LOOM_SWEEP_CLAIM_OWNED=" "$err" \
+    "the daemon self-claim marker is logged on every spawn"
+
+# ============================================================
+# Section 2: sandbox mapping + precedence (SAFETY-CRITICAL)
+# ============================================================
+
+echo ""
+echo "Testing spawn-codex.sh sandbox mapping (SAFETY-CRITICAL)..."
+
+out="$(run_argv -- -p x)"
+assert_contains "-s read-only" "$out" \
+    "DEFAULT sandbox is read-only (most restrictive; tier-2 posture)"
+
+err="$(run_argv_stderr -- -p x)"
+assert_contains "sandbox=read-only source=adapter-default" "$err" \
+    "default sandbox logs source=adapter-default"
+
+# Loom's skip-permissions convention maps to workspace-write, NOT full access.
+out="$(run_argv -- -p x --dangerously-skip-permissions)"
+assert_contains "-s workspace-write" "$out" \
+    "--dangerously-skip-permissions maps to workspace-write"
+assert_not_contains "danger-full-access" "$out" \
+    "--dangerously-skip-permissions does NOT map to danger-full-access (fork divergence)"
+assert_not_contains "--dangerously-bypass-approvals-and-sandbox" "$out" \
+    "--dangerously-skip-permissions never emits Codex's bypass-everything flag"
+assert_not_contains "--dangerously-skip-permissions" "$out" \
+    "the Claude-specific flag is CONSUMED, never forwarded to codex"
+
+# LOOM_CODEX_SANDBOX overrides the convention.
+out="$(run_argv LOOM_CODEX_SANDBOX=danger-full-access -- -p x --dangerously-skip-permissions)"
+assert_contains "-s danger-full-access" "$out" \
+    "LOOM_CODEX_SANDBOX overrides the skip-permissions mapping"
+assert_not_contains "-s workspace-write" "$out" \
+    "LOOM_CODEX_SANDBOX replaces (not appends to) the convention's mode"
+
+# An explicit -s/--sandbox arg beats the env var, and is not duplicated.
+out="$(run_argv LOOM_CODEX_SANDBOX=danger-full-access -- -p x -s read-only)"
+assert_contains "-s read-only" "$out" \
+    "explicit -s wins over LOOM_CODEX_SANDBOX"
+assert_not_contains "danger-full-access" "$out" \
+    "explicit -s suppresses the env-var mode entirely"
+assert_eq "1" "$(printf '%s\n' "$out" | grep -oc -- '-s ' || true)" \
+    "explicit -s is never duplicated by an injected -s"
+
+out="$(run_argv -- -p x --sandbox=workspace-write)"
+assert_contains "--sandbox=workspace-write" "$out" \
+    "--sandbox=VALUE is recognized as explicit and passed through"
+assert_not_contains "-s read-only" "$out" \
+    "--sandbox=VALUE suppresses the injected default"
+
+# Codex's own bypass flag counts as an explicit sandbox decision (Codex would
+# reject a conflicting -s alongside it).
+out="$(run_argv -- -p x --dangerously-bypass-approvals-and-sandbox)"
+assert_contains "--dangerously-bypass-approvals-and-sandbox" "$out" \
+    "Codex's bypass flag passes through when the operator supplies it"
+assert_not_contains "-s read-only" "$out" \
+    "Codex's bypass flag suppresses the injected -s (no conflicting flags)"
+
+# An invalid LOOM_CODEX_SANDBOX is a config error, not a silent widening.
+set +e
+bad_out="$(env -u CODEX_HOME LOOM_SWEEP_NICE=0 LOOM_CODEX_NO_EXEC=1 \
+    LOOM_SPAWN_NO_EXPORT=1 LOOM_CODEX_SANDBOX=wide-open \
+    bash "$SPAWN_CODEX" -p x 2>&1)"
+bad_rc=$?
+set -e
+assert_eq "78" "$bad_rc" "an invalid LOOM_CODEX_SANDBOX exits 78 (EX_CONFIG)"
+assert_contains "Invalid LOOM_CODEX_SANDBOX" "$bad_out" \
+    "the invalid-sandbox message names the offending env var"
+assert_contains "read-only workspace-write danger-full-access" "$bad_out" \
+    "the invalid-sandbox message lists the valid modes"
+
+# Network coupling: only meaningful under workspace-write.
+out="$(run_argv LOOM_CODEX_SANDBOX=workspace-write LOOM_CODEX_NETWORK=1 -- -p x)"
+assert_contains "sandbox_workspace_write.network_access=true" "$out" \
+    "LOOM_CODEX_NETWORK=1 enables network under workspace-write"
+
+out="$(run_argv LOOM_CODEX_NETWORK=1 -- -p x)"
+assert_not_contains "network_access" "$out" \
+    "LOOM_CODEX_NETWORK=1 injects nothing under read-only"
+err="$(run_argv_stderr LOOM_CODEX_NETWORK=1 -- -p x)"
+assert_contains "has no effect under sandbox=read-only" "$err" \
+    "LOOM_CODEX_NETWORK=1 warns when the sandbox cannot use it"
+
+# ============================================================
+# Section 3: model + effort mapping (contract point 2)
+# ============================================================
+
+echo ""
+echo "Testing spawn-codex.sh model + effort mapping..."
+
+out="$(run_argv -- -p x)"
+assert_not_contains " -m " "$out" \
+    "no model configured emits NO -m flag (Codex/profile default preserved)"
+err="$(run_argv_stderr -- -p x)"
+assert_contains "spawn-codex: model=default" "$err" \
+    "no model configured logs model=default"
+
+out="$(run_argv LOOM_MODEL=gpt-5.6-sol -- -p x)"
+assert_contains "-m gpt-5.6-sol" "$out" "LOOM_MODEL maps to -m <value>"
+
+out="$(run_argv LOOM_MODEL=from-env -- -p x -m from-arg)"
+assert_contains "-m from-arg" "$out" "an explicit -m wins over LOOM_MODEL"
+assert_not_contains "from-env" "$out" "LOOM_MODEL is not also appended"
+err="$(run_argv_stderr LOOM_MODEL=from-env -- -p x -m from-arg)"
+assert_contains "explicit -m/--model in args wins over LOOM_MODEL" "$err" \
+    "the model-precedence override is logged"
+
+out="$(run_argv LOOM_CODEX_MODEL=adapter-default -- -p x)"
+assert_contains "-m adapter-default" "$out" \
+    "LOOM_CODEX_MODEL supplies the adapter's static default model"
+out="$(run_argv LOOM_CODEX_MODEL=adapter-default LOOM_MODEL=tier-model -- -p x)"
+assert_contains "-m tier-model" "$out" \
+    "LOOM_MODEL outranks the adapter's static default"
+
+# codex exec has no --effort flag; the knob is a config override.
+out="$(run_argv LOOM_EFFORT=high -- -p x)"
+assert_contains "-c model_reasoning_effort=high" "$out" \
+    "LOOM_EFFORT maps to -c model_reasoning_effort=<value>"
+out="$(run_argv -- -p x)"
+assert_not_contains "model_reasoning_effort" "$out" \
+    "no LOOM_EFFORT emits no reasoning-effort override"
+out="$(run_argv LOOM_EFFORT=high -- -p x -c model_reasoning_effort=low)"
+assert_not_contains "model_reasoning_effort=high" "$out" \
+    "an explicit -c model_reasoning_effort= wins over LOOM_EFFORT"
+
+# ============================================================
+# Section 4: git-repo trust check (live-CLI behavior)
+# ============================================================
+
+echo ""
+echo "Testing spawn-codex.sh git-repo trust check..."
+
+NOTGIT="$TMPROOT/not-a-repo"
+mkdir -p "$NOTGIT"
+
+out="$(cd "$NOTGIT" && run_argv -- -p x)"
+assert_contains "--skip-git-repo-check" "$out" \
+    "outside a git work tree, --skip-git-repo-check is injected"
+
+err="$(cd "$NOTGIT" && run_argv_stderr -- -p x)"
+assert_contains "is not inside a git work tree" "$err" \
+    "the injection is warned about, not silent"
+
+# Inside a work tree the guardrail is left ENABLED (this repo is one).
+out="$(cd "$SCRIPTS_DIR" && run_argv -- -p x)"
+assert_not_contains "--skip-git-repo-check" "$out" \
+    "inside a git work tree, the trusted-directory check is NOT waived"
+
+# An operator-supplied flag is not duplicated.
+out="$(cd "$NOTGIT" && run_argv -- -p x --skip-git-repo-check)"
+assert_eq "1" "$(printf '%s\n' "$out" | grep -oc -- '--skip-git-repo-check' || true)" \
+    "an explicit --skip-git-repo-check is not duplicated"
+
+# ============================================================
+# Section 5: args passthrough + usage errors
+# ============================================================
+
+echo ""
+echo "Testing spawn-codex.sh args passthrough + usage errors..."
+
+out="$(run_argv -- -p x --json --color never)"
+assert_contains "--json" "$out" "unknown flags pass through verbatim"
+assert_contains "--color never" "$out" "flag+value pairs pass through verbatim"
+
+out="$(run_argv -- -p x -- --after-ddash)"
+assert_contains "--after-ddash" "$out" "-- forwards the remainder verbatim"
+
+out="$(run_argv -- -p x --profile someprofile)"
+assert_contains "--profile someprofile" "$out" \
+    "--profile (Codex's own long form) passes through untouched"
+
+set +e
+noval_out="$(env LOOM_SWEEP_NICE=0 LOOM_CODEX_NO_EXEC=1 LOOM_SPAWN_NO_EXPORT=1 \
+    bash "$SPAWN_CODEX" -p 2>&1)"
+noval_rc=$?
+set -e
+assert_eq "78" "$noval_rc" "-p with no value exits 78 (EX_CONFIG)"
+assert_contains "requires a value" "$noval_out" "-p with no value says so"
+
+# ============================================================
+# Section 6: CODEX_HOME profile selection (auth)
+# ============================================================
+
+echo ""
+echo "Testing spawn-codex.sh CODEX_HOME profile selection..."
+
+GOOD_PROFILE="$TMPROOT/profiles/alice"
+mkdir -p "$GOOD_PROFILE"
+printf '{"SUPER_SECRET_TOKEN":"tok-do-not-log"}\n' > "$GOOD_PROFILE/auth.json"
+EMPTY_PROFILE="$TMPROOT/profiles/bob"
+mkdir -p "$EMPTY_PROFILE"
+: > "$EMPTY_PROFILE/auth.json"   # zero-byte == unusable
+MISSING_PROFILE="$TMPROOT/profiles/carol"
+mkdir -p "$MISSING_PROFILE"      # no auth.json at all
+
+run_auth() {
+    # Like run_argv but WITHOUT LOOM_SPAWN_NO_EXPORT, so auth resolution runs.
+    local -a envs=()
+    while [[ $# -gt 0 && "$1" != "--" ]]; do envs+=("$1"); shift; done
+    shift || true
+    env -u CODEX_HOME -u LOOM_CODEX_HOME -u LOOM_CODEX_PROFILE \
+        LOOM_SWEEP_NICE=0 LOOM_CODEX_NO_EXEC=1 \
+        ${envs[@]+"${envs[@]}"} \
+        bash "$SPAWN_CODEX" "$@" 2>&1 || true
+}
+
+out="$(run_auth "LOOM_CODEX_HOME=$GOOD_PROFILE" -- -p x)"
+assert_contains "using Codex profile 'alice' (source=LOOM_CODEX_HOME)" "$out" \
+    "LOOM_CODEX_HOME with a usable auth.json selects the profile"
+assert_not_contains "tok-do-not-log" "$out" \
+    "auth.json CONTENTS are never logged (credential hygiene)"
+assert_not_contains "$GOOD_PROFILE/auth.json" "$out" \
+    "the auth.json path is not echoed on the success path"
+
+out="$(run_auth "CODEX_HOME=$GOOD_PROFILE" -- -p x)"
+assert_contains "source=CODEX_HOME" "$out" \
+    "a pre-set CODEX_HOME is honored verbatim (auth tier 2)"
+
+out="$(run_auth "LOOM_CODEX_PROFILE_ROOT=$TMPROOT/profiles" \
+    LOOM_CODEX_PROFILE=alice -- -p x)"
+assert_contains "source=LOOM_CODEX_PROFILE" "$out" \
+    "LOOM_CODEX_PROFILE resolves a bare name under the profile root"
+assert_contains "using Codex profile 'alice'" "$out" \
+    "LOOM_CODEX_PROFILE logs the directory NAME only"
+
+# LOOM_CODEX_HOME outranks a pre-set CODEX_HOME.
+out="$(run_auth "LOOM_CODEX_HOME=$GOOD_PROFILE" "CODEX_HOME=$MISSING_PROFILE" -- -p x)"
+assert_contains "source=LOOM_CODEX_HOME" "$out" \
+    "LOOM_CODEX_HOME outranks a pre-set CODEX_HOME"
+
+# An explicitly-requested profile with no usable credential fails LOUDLY.
+for bad in "$EMPTY_PROFILE" "$MISSING_PROFILE"; do
+    set +e
+    env -u CODEX_HOME -u LOOM_CODEX_PROFILE LOOM_SWEEP_NICE=0 \
+        LOOM_CODEX_NO_EXEC=1 LOOM_CODEX_HOME="$bad" \
+        bash "$SPAWN_CODEX" -p x >/dev/null 2>&1
+    bad_auth_rc=$?
+    set -e
+    assert_eq "78" "$bad_auth_rc" \
+        "a requested profile with an unusable auth.json exits 78 ($(basename "$bad"))"
+done
+
+out="$(run_auth "LOOM_CODEX_HOME=$MISSING_PROFILE" -- -p x)"
+assert_contains "has no usable auth.json" "$out" \
+    "the missing-credential message explains the fault"
+assert_contains "codex login" "$out" \
+    "the missing-credential message gives the provisioning command"
+
+# No profile requested -> ambient auth, never a failure.
+out="$(run_auth -- -p x)"
+assert_contains "using the Codex CLI's ambient login state" "$out" \
+    "no profile requested falls through to ambient auth (not an error)"
+
+out="$(run_argv -- -p x)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -n "$out" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: LOOM_SPAWN_NO_EXPORT skips auth resolution without failing"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: LOOM_SPAWN_NO_EXPORT skips auth resolution without failing"
+fi
+
+# ============================================================
+# Section 7: missing binary -> 127 (NOT 78)
+# ============================================================
+
+echo ""
+echo "Testing spawn-codex.sh missing-binary failure..."
+
+# An empty PATH (plus the coreutils dirs the script needs) with no `codex`.
+EMPTY_BIN="$TMPROOT/empty-bin"
+mkdir -p "$EMPTY_BIN"
+set +e
+missing_out="$(env -u CODEX_HOME LOOM_SWEEP_NICE=0 LOOM_SPAWN_NO_EXPORT=1 \
+    PATH="$EMPTY_BIN:/usr/bin:/bin" \
+    bash "$SPAWN_CODEX" -p x 2>&1)"
+missing_rc=$?
+set -e
+assert_eq "127" "$missing_rc" \
+    "a missing codex binary exits 127, NOT 78 (78 is reserved for config errors)"
+assert_contains "'codex' command not found in PATH" "$missing_out" \
+    "the missing-binary message names the binary"
+assert_contains "0.146.0" "$missing_out" \
+    "the missing-binary message states the minimum supported version"
+
+# ============================================================
+# Section 8: mocked dispatch — stream split, stdin, session/tokens, exit code
+# ============================================================
+
+echo ""
+echo "Testing spawn-codex.sh mocked dispatch (fake codex on PATH)..."
+
+MOCK_BIN="$TMPROOT/mock-bin"
+mkdir -p "$MOCK_BIN"
+MOCK_SESSION="019fafeb-bdff-7fc1-a1c2-fba0ae4e5f29"
+cat > "$MOCK_BIN/codex" <<MOCK
+#!/usr/bin/env bash
+# Fake codex CLI reproducing codex-cli 0.146.0's OBSERVED stream split:
+#   stdout = the agent's final message, and nothing else
+#   stderr = banner (incl. 'session id:'), message blocks, 'tokens used'
+# Records its argv and whether it saw any stdin, for assertions.
+printf '%s\n' "\$@" > "\$MOCK_ARGV_FILE"
+_stdin="\$(cat)"
+if [[ -n "\$_stdin" ]]; then echo "MOCK-SAW-STDIN:\$_stdin" >&2; fi
+{
+  echo "OpenAI Codex v0.146.0"
+  echo "--------"
+  echo "sandbox: read-only"
+  echo "session id: $MOCK_SESSION"
+  echo "--------"
+  echo "tokens used"
+  echo "2,502"
+} >&2
+echo "MOCK-FINAL-MESSAGE"
+exit "\${MOCK_RC:-0}"
+MOCK
+chmod +x "$MOCK_BIN/codex"
+
+MOCK_ARGV_FILE="$TMPROOT/mock-argv.txt"
+
+run_mock() {
+    local -a envs=()
+    while [[ $# -gt 0 && "$1" != "--" ]]; do envs+=("$1"); shift; done
+    shift || true
+    env -u CODEX_HOME -u LOOM_CODEX_HOME -u LOOM_CODEX_PROFILE \
+        LOOM_SWEEP_NICE=0 LOOM_SPAWN_NO_EXPORT=1 \
+        MOCK_ARGV_FILE="$MOCK_ARGV_FILE" \
+        PATH="$MOCK_BIN:$PATH" \
+        ${envs[@]+"${envs[@]}"} \
+        bash "$SPAWN_CODEX" "$@"
+}
+
+# stdout carries ONLY the agent's final message — the banner/session/token
+# lines must not contaminate it (a caller pipes this).
+mock_stdout="$(run_mock -- -p "hi" 2>/dev/null)"
+assert_eq "MOCK-FINAL-MESSAGE" "$mock_stdout" \
+    "stdout carries ONLY the agent's final message (banner stays on stderr)"
+
+mock_stderr="$({ run_mock -- -p "hi" >/dev/null; } 2>&1)"
+assert_contains "session id: $MOCK_SESSION" "$mock_stderr" \
+    "the child's stderr is still forwarded to the caller's stderr"
+assert_contains "spawn-codex: session=$MOCK_SESSION" "$mock_stderr" \
+    "the 'session id:' line is parsed and reported as the transcript join key"
+assert_contains "spawn-codex: tokens_used=2502" "$mock_stderr" \
+    "'tokens used' is parsed (comma-stripped) and reported"
+assert_not_contains "MOCK-SAW-STDIN" "$mock_stderr" \
+    "the child's stdin is /dev/null (no <stdin> append, no hang)"
+
+# Even with data waiting on OUR stdin, the child must see none of it.
+mock_stderr="$(printf 'unwanted stdin payload\n' | { run_mock -- -p "hi" >/dev/null; } 2>&1)"
+assert_not_contains "MOCK-SAW-STDIN" "$mock_stderr" \
+    "piped stdin is NOT forwarded to the child (the 0.146.0 stdin-append hang)"
+
+# The mock received the argv the adapter assembled, prompt last.
+assert_contains "exec" "$(cat "$MOCK_ARGV_FILE")" "the mock was invoked with the exec subcommand"
+assert_eq "hi" "$(tail -1 "$MOCK_ARGV_FILE")" "the prompt is the final positional argv element"
+
+# Exit-code passthrough despite not using `exec`.
+set +e
+run_mock MOCK_RC=42 -- -p "hi" >/dev/null 2>&1
+mock_rc=$?
+set -e
+assert_eq "42" "$mock_rc" "the codex exit code is passed through (PIPESTATUS)"
+
+set +e
+run_mock MOCK_RC=0 -- -p "hi" >/dev/null 2>&1
+mock_rc0=$?
+set -e
+assert_eq "0" "$mock_rc0" "a clean codex exit stays 0"
+
+# Transcript-path resolution: a real session JSONL under $CODEX_HOME/sessions.
+SESSION_PROFILE="$TMPROOT/profiles/dana"
+mkdir -p "$SESSION_PROFILE/sessions/2026/07/29"
+printf '{"k":"v"}\n' > "$SESSION_PROFILE/auth.json"
+TRANSCRIPT="$SESSION_PROFILE/sessions/2026/07/29/rollout-2026-07-29T15-08-10-${MOCK_SESSION}.jsonl"
+: > "$TRANSCRIPT"
+mock_stderr="$({ env -u LOOM_CODEX_PROFILE LOOM_SWEEP_NICE=0 \
+    MOCK_ARGV_FILE="$MOCK_ARGV_FILE" PATH="$MOCK_BIN:$PATH" \
+    LOOM_CODEX_HOME="$SESSION_PROFILE" \
+    bash "$SPAWN_CODEX" -p "hi" >/dev/null; } 2>&1 || true)"
+assert_contains "spawn-codex: transcript=$TRANSCRIPT" "$mock_stderr" \
+    "the session id resolves to the concrete transcript JSONL path"
+
+# No session dir -> reported as unresolved, never a failure.
+NO_SESSIONS="$TMPROOT/profiles/erin"
+mkdir -p "$NO_SESSIONS"
+printf '{"k":"v"}\n' > "$NO_SESSIONS/auth.json"
+set +e
+mock_stderr="$({ env -u LOOM_CODEX_PROFILE LOOM_SWEEP_NICE=0 \
+    MOCK_ARGV_FILE="$MOCK_ARGV_FILE" PATH="$MOCK_BIN:$PATH" \
+    LOOM_CODEX_HOME="$NO_SESSIONS" \
+    bash "$SPAWN_CODEX" -p "hi" >/dev/null; } 2>&1)"
+unresolved_rc=$?
+set -e
+assert_contains "transcript=unresolved" "$mock_stderr" \
+    "an unresolvable transcript is reported, not guessed"
+assert_eq "0" "$unresolved_rc" \
+    "an unresolvable transcript does NOT fail the spawn"
+
+# LOOM_CODEX_NO_CAPTURE takes the plain exec path (no session reporting).
+mock_stderr="$({ run_mock LOOM_CODEX_NO_CAPTURE=1 -- -p "hi" >/dev/null; } 2>&1)"
+assert_not_contains "spawn-codex: session=" "$mock_stderr" \
+    "LOOM_CODEX_NO_CAPTURE=1 skips session reporting (plain exec path)"
+assert_contains "session id: $MOCK_SESSION" "$mock_stderr" \
+    "LOOM_CODEX_NO_CAPTURE=1 still passes the child's stderr through"
+
+# ============================================================
+# Section 9: LOOM_RUNTIME=codex resolves through spawn-worker.sh
+# ============================================================
+
+echo ""
+echo "Testing LOOM_RUNTIME=codex dispatch through spawn-worker.sh..."
+
+STAGE="$TMPROOT/stage"
+WS="$TMPROOT/ws"
+mkdir -p "$STAGE/lib" "$WS/.loom"
+cp "$SCRIPTS_DIR/spawn-worker.sh" "$STAGE/spawn-worker.sh"
+cp "$SCRIPTS_DIR/lib/config-resolver.sh" "$STAGE/lib/config-resolver.sh"
+cp "$SPAWN_CODEX" "$STAGE/spawn-codex.sh"
+# A stub claude runner so the "available runtimes" list and the default path
+# stay realistic without ever reaching the real token-selection code.
+cat > "$STAGE/spawn-claude.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "stub-claude reached"
+STUB
+chmod +x "$STAGE"/spawn-*.sh
+
+out="$(env -u LOOM_RUNTIME -u CODEX_HOME -u LOOM_CODEX_HOME \
+    LOOM_WORKSPACE="$WS" LOOM_CONFIG_DEFAULTS_FILE="" \
+    LOOM_RUNTIME=codex LOOM_SWEEP_NICE=0 LOOM_CODEX_NO_EXEC=1 \
+    LOOM_SPAWN_NO_EXPORT=1 \
+    bash "$STAGE/spawn-worker.sh" -p "routed" 2>&1 || true)"
+assert_contains "runtime=codex (from env (LOOM_RUNTIME))" "$out" \
+    "spawn-worker.sh resolves LOOM_RUNTIME=codex"
+assert_contains "spawn-codex would-exec: codex exec" "$out" \
+    "spawn-worker.sh dispatches into the real spawn-codex.sh"
+assert_contains "routed" "$out" "the prompt survives the dispatcher hop"
+assert_not_contains "stub-claude reached" "$out" \
+    "codex dispatch does not also reach the claude runner"
+
+if command -v jq >/dev/null 2>&1; then
+    printf '{ "runtimes": { "default": "codex" } }\n' > "$WS/.loom/config.json"
+    out="$(env -u LOOM_RUNTIME -u CODEX_HOME -u LOOM_CODEX_HOME \
+        LOOM_WORKSPACE="$WS" LOOM_CONFIG_DEFAULTS_FILE="" \
+        LOOM_SWEEP_NICE=0 LOOM_CODEX_NO_EXEC=1 LOOM_SPAWN_NO_EXPORT=1 \
+        bash "$STAGE/spawn-worker.sh" -p "cfg" 2>&1 || true)"
+    assert_contains "runtime=codex (from config (runtimes.default))" "$out" \
+        "runtimes.default=codex resolves through the dispatcher"
+    assert_contains "spawn-codex would-exec" "$out" \
+        "config-resolved codex dispatch reaches spawn-codex.sh"
+    rm -f "$WS/.loom/config.json"
+fi
+
+# codex moving from unknown -> known must not weaken the unknown-runtime guard.
+set +e
+unknown_out="$(env -u LOOM_RUNTIME LOOM_WORKSPACE="$WS" \
+    LOOM_CONFIG_DEFAULTS_FILE="" LOOM_RUNTIME=bogus \
+    bash "$STAGE/spawn-worker.sh" -p x 2>&1)"
+unknown_rc=$?
+set -e
+assert_eq "78" "$unknown_rc" \
+    "an unknown runtime still exits 78 now that spawn-codex.sh exists"
+assert_contains "codex" "$unknown_out" \
+    "the available-runtimes list now includes codex"
+
+# ============================================================
+# Section 10: classify-error.sh `codex` provider vectors
+# ============================================================
+
+echo ""
+echo "Testing classify-error.sh codex provider table..."
+
+# shellcheck source=../lib/classify-error.sh
+source "$CLASSIFY_LIB"
+
+assert_classify() {
+    local expected="$1" output="$2" rc="$3" provider="$4" msg="$5"
+    assert_eq "$expected" "$(classify_error "$output" "$rc" "$provider")" "$msg"
+}
+
+# --- exit-code-first invariants hold for codex too (#3233) ---
+assert_classify "SUCCESS" "You've hit your usage limit." 0 codex \
+    "exit 0 is SUCCESS even when the output mentions a usage limit (#3233)"
+assert_classify "SUCCESS" "Operation not permitted" 0 codex \
+    "a sandbox denial on a clean exit stays SUCCESS (denials do not fail the run)"
+assert_classify "TIMEOUT" "anything" 124 codex "exit 124 is TIMEOUT for codex"
+assert_classify "TIMEOUT" "anything" 137 codex "exit 137 is TIMEOUT for codex"
+
+# --- FATAL: non-retryable configuration faults ---
+assert_classify "FATAL" \
+    "Not inside a trusted directory and --skip-git-repo-check was not specified." \
+    1 codex "the trusted-directory refusal is FATAL (retrying loops forever)"
+assert_classify "FATAL" \
+    "Error loading config.toml: unknown configuration field \`bogus\` in -c override" \
+    1 codex "an unknown -c config field is FATAL"
+assert_classify "FATAL" "landlock_sandbox_executable_not_provided" 1 codex \
+    "an unconstructable sandbox is FATAL (never silently retried unsandboxed)"
+
+# --- TOKEN_EXPIRED: 401 / login / refresh-token failures ---
+assert_classify "TOKEN_EXPIRED" \
+    "ERROR codex_api: failed to connect to websocket: HTTP error: 401 Unauthorized, url: wss://api.openai.com/v1/responses" \
+    1 codex "the observed 401 Unauthorized stream error is TOKEN_EXPIRED"
+assert_classify "TOKEN_EXPIRED" \
+    "Not signed in. Please run 'codex login' to sign in with ChatGPT" \
+    1 codex "a not-signed-in profile is TOKEN_EXPIRED"
+assert_classify "TOKEN_EXPIRED" \
+    "Your token could not be refreshed because your refresh token has expired. Please log out and sign in again." \
+    1 codex "an expired refresh token is TOKEN_EXPIRED"
+assert_classify "TOKEN_EXPIRED" "Failed to refresh token: bad grant" 1 codex \
+    "a refresh failure is TOKEN_EXPIRED"
+assert_classify "TOKEN_EXPIRED" "Your session has expired. Please reauthenticate." 1 codex \
+    "an expired session is TOKEN_EXPIRED"
+assert_classify "TOKEN_EXPIRED" \
+    '{"error":{"code":"invalid_api_key","message":"Incorrect API key provided"}}' \
+    1 codex "invalid_api_key is TOKEN_EXPIRED"
+
+# --- TOKEN_EXHAUSTED: plan/quota exhaustion ---
+assert_classify "TOKEN_EXHAUSTED" \
+    "You've hit your usage limit. Upgrade to Pro to continue using Codex" \
+    1 codex "\"hit your usage limit\" is TOKEN_EXHAUSTED"
+assert_classify "TOKEN_EXHAUSTED" \
+    "You've reached your usage limit. Increase your limits to continue using codex." \
+    1 codex "\"reached your usage limit\" is TOKEN_EXHAUSTED"
+assert_classify "TOKEN_EXHAUSTED" \
+    "Your workspace is out of credits. Ask your workspace admin." 1 codex \
+    "an out-of-credits workspace is TOKEN_EXHAUSTED"
+assert_classify "TOKEN_EXHAUSTED" \
+    '{"error":{"code":"insufficient_quota","message":"You exceeded your current quota"}}' \
+    1 codex "insufficient_quota is TOKEN_EXHAUSTED"
+assert_classify "TOKEN_EXHAUSTED" \
+    '{"error":{"code":"rate_limit_exceeded"}}' 1 codex \
+    "rate_limit_exceeded is TOKEN_EXHAUSTED"
+
+# Quota wording must WIN over a co-occurring 401 (the ordering rationale: a
+# TOKEN_EXPIRED verdict marks the account bad with reason `auth`, which persists
+# until a manual unblock, whereas `exhausted` TTL-expires on its own).
+assert_classify "TOKEN_EXHAUSTED" \
+    "HTTP error: 401 Unauthorized — insufficient_quota: You exceeded your current quota" \
+    1 codex "quota wording outranks a co-occurring 401 (safer mis-classification direction)"
+
+# --- RECOVERABLE: transients still resolve through the generic table ---
+assert_classify "RECOVERABLE" "HTTP error: 429 Too Many Requests" 1 codex \
+    "a BARE 429 stays RECOVERABLE (not TOKEN_EXHAUSTED) for codex"
+assert_classify "RECOVERABLE" "HTTP error: 503 Service Unavailable" 1 codex \
+    "a 5xx is RECOVERABLE for codex"
+assert_classify "RECOVERABLE" "ECONNREFUSED connecting to api.openai.com" 1 codex \
+    "a network error is RECOVERABLE for codex"
+assert_classify "RECOVERABLE" "something nobody has ever seen before" 1 codex \
+    "an unrecognized codex failure falls through to RECOVERABLE"
+
+# --- Deliberately unimplemented codex categories ---
+assert_classify "RECOVERABLE" "The current working directory was deleted" 1 codex \
+    "Claude's CWD_DELETED wording is NOT reused for codex (documented gap)"
+assert_classify "RECOVERABLE" 'stop_reason: "refusal"' 1 codex \
+    "Claude's MODEL_REFUSAL wording is NOT reused for codex (documented gap)"
+assert_classify "RECOVERABLE" "maximum number of concurrent sessions" 1 codex \
+    "codex has no SESSION_LIMIT signature; a concurrency fault stays RECOVERABLE"
+
+# --- The claude table is UNCHANGED by this addition (regression guard) ---
+echo ""
+echo "Testing classify-error.sh claude table is unchanged..."
+
+assert_classify "CWD_DELETED" "The current working directory was deleted" 1 claude \
+    "claude CWD_DELETED unchanged"
+assert_classify "MODEL_REFUSAL" 'stop_reason: "refusal"' 1 claude \
+    "claude MODEL_REFUSAL unchanged"
+assert_classify "TOKEN_EXPIRED" "401 authentication_error" 1 claude \
+    "claude TOKEN_EXPIRED unchanged"
+assert_classify "SESSION_LIMIT" "maximum number of concurrent sessions" 1 claude \
+    "claude SESSION_LIMIT unchanged"
+assert_classify "TOKEN_EXHAUSTED" "You've hit your weekly limit" 1 claude \
+    "claude TOKEN_EXHAUSTED unchanged"
+assert_classify "RECOVERABLE" "No messages returned" 1 claude \
+    "claude 'No messages returned' unchanged"
+assert_classify "SUCCESS" "500 rate limit" 0 claude \
+    "claude exit-code-first (#3233) unchanged"
+
+# claude never returns FATAL — the codex table is the only FATAL producer.
+assert_classify "RECOVERABLE" \
+    "Not inside a trusted directory and --skip-git-repo-check was not specified." \
+    1 claude "the codex FATAL patterns do NOT leak into the claude table"
+
+# Two-arg calls (claude-wrapper.sh) and unknown providers are unaffected.
+assert_eq "TOKEN_EXHAUSTED" "$(classify_error "You've hit your weekly limit" 1)" \
+    "a two-arg call still defaults to the claude table"
+assert_classify "RECOVERABLE" "Not inside a trusted directory" 1 amp \
+    "an unknown provider matches no provider table and falls through"
+
+# The LOOM_RUNTIME selector reaches the codex table.
+assert_eq "FATAL" \
+    "$(LOOM_RUNTIME=codex classify_error "Not inside a trusted directory" 1)" \
+    "LOOM_RUNTIME=codex selects the codex table for a two-arg call"
+
+# ============================================================
+# Summary
+# ============================================================
+
+echo ""
+echo "==================================="
+echo "Tests run:    $TESTS_RUN"
+echo -e "Tests passed: ${GREEN}$TESTS_PASSED${NC}"
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    echo -e "Tests failed: ${RED}$TESTS_FAILED${NC}"
+    exit 1
+fi
+echo "All tests passed."


### PR DESCRIPTION
Closes #4468
Part of #4167 (Phase 2 — Codex adapter)

## Attribution

**Ports Codex support from the [gpeyton/loom](https://github.com/gpeyton/loom) fork by Graham Peyton** (fork PRs #15 runner, #16 config, #20/#40 guardrail parity, #6 classifier tables, #59 native-agent finding).

This is a **design port, not a cherry-pick**. The fork's implementation predates the contract doc, so each piece lands behind the interface `defaults/docs/runtime-adapters.md` defines — and every fork claim was re-verified against the live **codex-cli 0.146.0** before being carried across. Several no longer hold; those are corrected inline in the parity doc rather than silently propagated.

## What landed

| File | Change |
|---|---|
| `defaults/scripts/spawn-codex.sh` | **new** — adapter #2 (contract point 1) |
| `defaults/docs/guardrail-parity-codex.md` | **new** — contract point 6's required parity doc |
| `defaults/runtimes/codex.json` | **new** — capability manifest (contract point 7) |
| `defaults/scripts/tests/test-spawn-codex.sh` | **new** — 135 hermetic assertions |
| `.github/workflows/ci.yml` | `codex-adapter-smoke` leg (tier-2 admission gate) |
| `defaults/scripts/lib/classify-error.sh` | filled the `_classify_error_codex()` stub |
| `defaults/docs/runtime-adapters.md` | status tables + accurate §3 + "adding an adapter" guide |

No config change was needed to register the runtime — `spawn-worker.sh` discovers `spawn-<runtime>.sh` by filename, and the seam needed **zero** modification to admit Codex. That is the Phase-1 design paying off, and there is a regression test asserting `codex` moving from unknown → known did not weaken the exit-78 unknown-runtime guard for other names.

## Live-CLI intel from the issue: honored, with one correction

The issue's comment recorded five behaviors from the #4469 smoke test. All are handled; **item 3 was wrong about the stream**, which materially changed the implementation:

| # | Intel | Handling |
|---|---|---|
| 1 | Git-repo trust check | `--skip-git-repo-check` injected **only** when `git rev-parse --is-inside-work-tree` fails. Worktrees keep the check enabled; scratch dirs get the waiver plus a warning. The refusal classifies `FATAL`, so a mis-set cwd fails fast instead of retrying forever. |
| 2 | Stdin append hang | The child's stdin is **always** `</dev/null` on the headless path; the prompt is delivered positionally so stdin has no job. Two tests assert the child sees no stdin even when data is waiting on ours. |
| 3 | Output shape "(stdout, plain mode)" | **Corrected.** On 0.146.0 stdout carries *only* the agent's final message; the banner, `session id:`, and `tokens used` all go to **stderr**. Verified twice (success and 401 paths). The adapter therefore tees the child's stderr through a temp file while stdout passes through byte-for-byte — and recovers the exit code from `PIPESTATUS` so exit-code passthrough survives not using `exec`. |
| 4 | `--sandbox read-only` honored headlessly | It is the adapter's **default**. See the sandbox divergence below. |
| 5 | `CODEX_HOME` selection works | Implemented as a 4-tier passthrough chain (`LOOM_CODEX_HOME` > pre-set `CODEX_HOME` > `LOOM_CODEX_PROFILE` under `~/.loom/codex-profiles/` > ambient `~/.codex`). |

Additionally, `session id:` is resolved to the concrete transcript path (`$CODEX_HOME/sessions/<Y>/<M>/<D>/rollout-<ts>-<session-id>.jsonl`) and `tokens used` is parsed (comma-stripped) as the contract-point-4 cost signal.

## Two deliberate divergences from the fork

### 1. Sandbox default is `read-only`; skip-permissions maps to `workspace-write`, not full access

The fork maps Loom's `--dangerously-skip-permissions` to `--dangerously-bypass-approvals-and-sandbox` (no sandbox at all), arguing *"parity, not a new exposure"* — Claude already runs unattended with full tool access.

**That premise does not hold.** Claude's unattended posture is backstopped by `PreToolUse` guards that fire on every Bash/Edit/Write call *even under* `--dangerously-skip-permissions`. Those guards cannot run under Codex. Handing Codex the same flag therefore produces a **strictly weaker** boundary than the Claude path it imitates — an agent with Claude's authority and none of Claude's backstops. `workspace-write` is the closest honest analogue of what the guards actually enforce.

Precedence: explicit `-s`/`--sandbox` arg > `LOOM_CODEX_SANDBOX` > skip-permissions convention > `read-only`. The fork's posture is one env var away (`LOOM_CODEX_SANDBOX=danger-full-access`), and an invalid value exits 78 rather than silently widening.

The coupling is documented prominently: `workspace-write` blocks outbound network, so a Builder-equivalent worker needs `LOOM_CODEX_NETWORK=1` — **and that flag removes most of what the sandbox was contributing**. The parity doc says so in plain words rather than burying it.

### 2. Auth is narrowed to single-profile `CODEX_HOME` passthrough

No token pool, no rotation, no `.bad_tokens` marking — that is Phase 4, and it is an explicit non-goal here. An **explicitly requested** profile with no usable `auth.json` exits **78** rather than silently degrading to a different account (which would misattribute work and cost); ambient auth is not a "request" and never fails here.

Credential hygiene, asserted by tests: the directory is **assigned** to `CODEX_HOME`, never copied; only the profile *directory name* is ever logged.

## Corrections to the fork's parity doc (verified on 0.146.0)

1. **`--full-auto` does not exist** on `codex exec`. The fork's safe mode targets it. `-s workspace-write` is the replacement.
2. **`-a`/`--ask-for-approval` is top-level only.** Any parity claim resting on `approval_policy` is inert for headless dispatch.
3. **Codex has a hook system now.** The fork says Codex has no hooks "as a concept"; 0.146.0 ships a `hooks.json` engine with `pre_tool_use` / `user_prompt_submit` / `post_tool_use` events and a hook-trust model. The gap is therefore **unwired, not impossible** — a better position than documented, and a concrete follow-up. (This also revises the issue's own AC wording, which assumed "no PreToolUse-equivalent hook interception".)
4. **A sandbox denial exits 0.** Verified: under `-s read-only` a blocked `touch` returns `Operation not permitted` to the model and the process still exits 0. Denials are in-session tool failures, so exit-code-first classification never sees them — which is *why* the classifier has no "sandbox denial" pattern. Adding one would be dead code that could only fire as a false positive.

## Error classification

Every pattern was **observed in real `codex exec` output or extracted verbatim from the 0.146.0 binary's own message strings** — nothing guessed:

- **`FATAL`** (first producer of this category) — trusted-directory refusal, `unknown configuration field`, `landlock_sandbox_executable_not_provided`. All unretryable; a `RECOVERABLE` verdict would loop forever, and a worker that cannot construct its sandbox must never be retried into running unsandboxed.
- **`TOKEN_EXHAUSTED`** — `You've hit/reached your usage limit`, `workspace credit limit`, `out of credits`, `insufficient_quota`, `rate_limit_exceeded`. A **bare 429 stays `RECOVERABLE`** (transient throttle, not exhaustion).
- **`TOKEN_EXPIRED`** — the observed `HTTP error: 401 Unauthorized` stream error, plus `Not signed in. Please run 'codex login'`, `refresh token has expired`, `Failed to refresh token`, `session has expired`, `invalid_api_key`.

Quota wording is checked **before** 401 wording: `TOKEN_EXPIRED` marks an account bad with a reason that persists until manual `loom-tokens unblock`, while `TOKEN_EXHAUSTED`'s TTL-expires — so that ordering makes mis-classification cheap in the right direction. There is a test for the co-occurring case.

`CWD_DELETED`, `SESSION_LIMIT`, and `MODEL_REFUSAL` are **left unimplemented for codex and documented as such**, because that runtime has no known wording for them and reusing Claude's phrasing would produce confident nonsense. Unmatched categories fall through to `RECOVERABLE`.

**The `claude` table is byte-identically unchanged**, with 8 regression assertions proving it — including that the new `FATAL` patterns do not leak across, and that two-arg calls (`claude-wrapper.sh`) still default to the claude table.

## Capability manifest ↔ parity doc

`codex.json` declares `worktreeIsolation: "partial"` (Codex's `workspace-write` confines to the *workspace root*, not one `issue-N` worktree — the #4178 escape class). Because `"partial"` fails closed:

```
check-runtime-capabilities.sh --role builder --runtime codex  -> 78 (incompatible)
check-runtime-capabilities.sh --role judge   --runtime codex  ->  0 (compatible)
```

Both outcomes are asserted in the CI leg. That is the intended relationship between contract points 6 and 7: **the parity doc states the residual gap in prose, the manifest makes it enforceable.** `subagents: "no"` encodes fork PR #59's native-agent prohibition; `hooks: "partial"` reflects correction 3.

## Test results

| Suite | Result |
|---|---|
| `test-spawn-codex.sh` (new) | **135/135 pass** |
| `test-spawn-worker.sh` | 26/26 pass (dispatcher unaffected) |
| `test-spawn-claude.sh` | 129/129 pass (Claude path unaffected) |
| `test-check-runtime-capabilities.sh` | 17/17 pass |
| `scripts/test-installer.sh` | 161/161 pass (new `docs/*` + `runtimes/*` auto-map) |
| `test-install-reinstall-safety.sh` | 15/15 pass |
| `bash -n` all new/changed scripts | clean |
| `shellcheck --severity=warning` across **all** `defaults/scripts/` | clean |
| `check-phantom-labels.sh` / `check-claude-md-budget.sh` | OK (314/320 lines — CLAUDE.md untouched) |
| CI leg's non-suite steps, simulated locally | all pass |

New-suite coverage: argv assembly, prompt-as-positional (the `-p`-means-`--profile` collision), sandbox mapping + full precedence chain, invalid-mode → 78, network coupling, model/effort precedence, git-repo check in all four states, args passthrough, `-p` without a value → 78, profile selection across all tiers, unusable-`auth.json` → 78, credential non-leakage, missing binary → **127 not 78**, stdout/stderr split, stdin neutralization, session/transcript/token reporting, exit-code passthrough, `LOOM_RUNTIME=codex` + `runtimes.default=codex` through the dispatcher, and the classifier vectors above.

## Live smoke run

One real read-only run through the adapter against the operator-provisioned profile:

```
$ CODEX_HOME=~/.loom/codex-profiles/r.j.walters ./defaults/scripts/spawn-codex.sh \
      -p 'Reply with exactly: ADAPTER-SMOKE-OK'
```

**Exit 0.** stdout was exactly `ADAPTER-SMOKE-OK` (nothing else). Adapter log lines:

```
spawn-codex: LOOM_SWEEP_CLAIM_OWNED=unset
spawn-codex: model=default
spawn-codex: sandbox=read-only source=adapter-default
spawn-codex: cwd is inside a git work tree — leaving Codex's trusted-directory check enabled
spawn-codex: using Codex profile 'r.j.walters' (source=CODEX_HOME)
spawn-codex: session=019faffe-302c-7283-97b2-fcf0df3427af
spawn-codex: transcript=/Users/rwalters/.loom/codex-profiles/r.j.walters/sessions/2026/07/29/rollout-2026-07-29T15-28-19-019faffe-302c-7283-97b2-fcf0df3427af.jsonl
spawn-codex: tokens_used=2502
```

The reported transcript path was confirmed to exist (36 KB JSONL), and a grep of the full stderr for `access_token` / `refresh_token` / `id_token` / `sk-` found **no credential material**.

## #4469 absorption

Per the operator's heads-up, #4469's one remaining AC — the `CODEX_HOME` profile-layout / refresh / security-posture doc section — **is absorbed here**, as a dedicated section of `guardrail-parity-codex.md` (layout + modes, the selection-precedence table, the "authoritative copy, not a cache" refresh caveat, and the security posture). `runtime-adapters.md`'s Related section points at it. **#4469 can close when this lands.**

## Non-goals respected

No daemon spawn-path migration, no provider-aware token pool, no `AGENTS.md` codegen, no role-prompt changes, no new labels, no `.codex/` config tree. The Claude path is untouched and no existing caller changes behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
