### PR TITLE
feat(daemon): opt-in idle exit for remote hosts

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -494,8 +494,9 @@ the plan/ordering/checklist; the per-phase shell is rendered in
    as the **#4292** token-pool-cwd workaround — the rendered unit carries a
    `#4292` marker so it is removed when that lands.
 9. **idle-shutdown** (optional, `--idle-shutdown-minutes N`) — a cron guard that
-   powers the host off after N idle minutes, skipping while claude / loom-daemon
-   are working.
+   powers the host off after N idle minutes. This is stage 2:
+   `autonomous.idleExit` is stage 1. On daemon-managed hosts use a short guard
+   window (typically 15–30 minutes); the running-daemon veto remains.
 10. **safehouse** (optional, `--safehouse`) — **skip-with-notice** until #3998
     (the safehoused provisioning fragment) lands.
 11. **verify** — `loom-daemon status` sane from the workspace cwd, ranking
@@ -2046,6 +2047,9 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.roleRunner.roles` | *(config only)* | all 5 roles | Subset of `champion`/`curator`/`judge`/`auditor`/`guide` to dispatch; explicit empty array runs none. Also resolved from each root's own config |
 | `autonomous.roleRunner.intervalSecs` | `LOOM_ROLE_RUNNER_INTERVAL_SECS` | per-role built-in (5–15 min) | Uniform override applied to every enabled role's cadence |
 | `autonomous.roleRunner.onIdle` | *(config only)* | `[]` (none) | Subset of the same 5 roles to also fire on the work-finder **idle edge** (#4364) — the non-idle → idle transition (0 in-flight sweeps AND nothing dispatched this tick), in addition to the interval cadence. Absent → none (opposite default from `roles`); unknown names ignored with a warning. Debounced to min 60s per (root, role) and skipped while that role's interval/idle run is in progress. **Requires the work finder enabled** to observe idleness (a startup warning fires if set with the work finder off). **Also gated by that same root's own `enabled`** (#4377) — see below |
+| `autonomous.idleExit.enabled` | `LOOM_AUTONOMOUS_IDLE_EXIT_ENABLED` | `false` | End the daemon cleanly after the idle window so a host guard can take over. Independent of Work Finder; never invokes a power command |
+| `autonomous.idleExit.idleMinutes` | `LOOM_AUTONOMOUS_IDLE_EXIT_MINUTES` | `60` | Continuous idle/starvation window. Zero/invalid → default |
+| `autonomous.idleExit.onTokenStarvation` | `LOOM_AUTONOMOUS_IDLE_EXIT_ON_TOKEN_STARVATION` | `true` | Also exit after zero healthy accounts for the full window with no sweep in flight, even if roles keep cycling |
 | `autonomous.watchMonitor.enabled` | `LOOM_WATCH_MONITOR` | `true` | Durable operator-watch monitor loop (#3971). Default-on; no dispatch side effect, zero forge calls until a watch is registered |
 | `autonomous.watchMonitor.intervalSecs` | `LOOM_WATCH_MONITOR_INTERVAL_SECS` | `120` | Watch poll cadence. Zero/invalid → default |
 | `autonomous.watchMonitor.expirySecs` | `LOOM_WATCH_MONITOR_EXPIRY_SECS` | `86400` | Give-up window for an unresolved watch; `0` disables expiry |
@@ -2063,6 +2067,32 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.autoUpdate.enabled` | `LOOM_AUTO_UPDATE` | `false` | Autonomous self-update loop on/off (#4055). **Opt-in** (it rebuilds + restarts the daemon process). Exactly one loop per daemon, not a per-workspace fan-out. See [Autonomous self-update loop](#autonomous-self-update-loop-4055) below |
 | `autonomous.autoUpdate.intervalSecs` | `LOOM_AUTO_UPDATE_INTERVAL_SECS` | `900` | Cadence between staleness checks. Zero/invalid → default |
 | `autonomous.autoUpdate.settleSecs` | `LOOM_AUTO_UPDATE_SETTLE_SECS` | `600` | Settle window: wait this long after first observing a stale commit — resetting on every further commit — before rolling, so a burst of merges collapses into one roll. Zero/invalid → default |
+
+### Idle exit for remote hosts (#4467)
+
+```json
+{
+  "autonomous": {
+    "idleExit": {
+      "enabled": false,
+      "idleMinutes": 60,
+      "onTokenStarvation": true
+    }
+  }
+}
+```
+
+Ordinary idleness requires zero in-flight sweeps, no active role run, and no
+dispatch/completion event for the full window. Token starvation has a separate
+clock: role sessions do not reset it, but live sweeps and healthy-account
+recovery do. On either trigger the daemon writes
+`<loom-dir>/idle-exit.json`, publishes `daemon.idle_exit`, removes its socket,
+and exits 0. It never calls `shutdown`, `sudo`, or a provider API.
+
+The fleet add-worker systemd unit uses `Restart=on-failure`, so exit 0 stays
+down. macOS launchd uses `KeepAlive:SuccessfulExit`, so exit 0 relaunches the
+daemon; idle exit is meaningful only under on-failure-style supervision. A
+loud warning is logged when it is enabled under launchd.
 
 ### Daemon log path override (`LOOM_DAEMON_LOG`, #4010)
 

--- a/loom-daemon/src/fleet/add_worker.rs
+++ b/loom-daemon/src/fleet/add_worker.rs
@@ -634,15 +634,15 @@ systemctl --user enable --now loom-daemon.service
 }
 
 fn render_idle_shutdown(minutes: u32) -> String {
-    // Guard: power off after N idle minutes, but never while a sweep child
-    // (claude) runs or the daemon reports in-flight sweeps. Pilot-equivalent.
+    // Stage 2 of power-off: autonomous.idleExit is stage 1. A running daemon
+    // remains a veto because only it can interpret queued/rate-limited work.
     format!(
         r#"set -e
 mkdir -p "$HOME/.local/bin"
 cat > "$HOME/.local/bin/loom-idle-shutdown.sh" <<'GUARD'
 #!/usr/bin/env bash
-# loom-idle-shutdown (#4341): power off after {minutes} idle minutes, skipping
-# while claude or loom-daemon are actively working.
+# loom-idle-shutdown (#4341/#4467), stage 2. autonomous.idleExit must first
+# stop loom-daemon; this guard remains the sole power-off authority.
 set -euo pipefail
 export PATH="$HOME/.local/bin:$PATH"
 LIMIT={minutes}
@@ -650,6 +650,7 @@ STAMP="$HOME/.loom/last-active"
 mkdir -p "$HOME/.loom"
 active=0
 if pgrep -x claude >/dev/null 2>&1; then active=1; fi
+if pgrep -f '[l]oom-daemon' >/dev/null 2>&1; then active=1; fi
 if loom-daemon status --json 2>/dev/null | grep -Eq '"active_sweeps"[[:space:]]*:[[:space:]]*[1-9]'; then active=1; fi
 if [ "$active" = "1" ]; then
   date +%s > "$STAMP"

--- a/loom-daemon/src/idle_exit.rs
+++ b/loom-daemon/src/idle_exit.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::event_bus::EventBus;
-use crate::role_runner::{active_run_count, InProgressGuard};
+use crate::role_runner::{active_run_count, role_run_start_generation, InProgressGuard};
 use crate::types::Event;
 use crate::workspace_pool::WorkspacePool;
 
@@ -210,6 +210,7 @@ pub fn spawn_task(
             Instant::now(),
         );
         let mut events = bus.subscribe(["sweep.global.dispatch", "sweep.global.completed"]);
+        let mut role_generation = role_run_start_generation();
         let mut interval = tokio::time::interval(Duration::from_secs(15));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
@@ -217,6 +218,11 @@ pub fn spawn_task(
             let mut lifecycle_activity = false;
             while events.try_recv().is_ok() {
                 lifecycle_activity = true;
+            }
+            let current_role_generation = role_run_start_generation();
+            if current_role_generation != role_generation {
+                lifecycle_activity = true;
+                role_generation = current_role_generation;
             }
             let in_flight = crate::ipc::count_in_flight_sweeps(&pool, &root);
             let active_roles = active_run_count(&roles);
@@ -311,6 +317,21 @@ mod tests {
             tracker.observe(idle(), start + Duration::from_secs(119)),
             Some(IdleExitTrigger::Idle)
         );
+    }
+
+    #[test]
+    fn role_start_generation_captures_short_completed_run() {
+        let before = role_run_start_generation();
+        let roles = crate::role_runner::new_in_progress_guard();
+        {
+            let _run = crate::role_runner::RoleRunGuard::try_acquire(
+                roles,
+                PathBuf::from("/tmp/idle-exit-role-test"),
+                "champion",
+            )
+            .unwrap();
+        }
+        assert!(role_run_start_generation() > before);
     }
 
     #[test]

--- a/loom-daemon/src/idle_exit.rs
+++ b/loom-daemon/src/idle_exit.rs
@@ -259,6 +259,9 @@ pub fn spawn_task(
                 message: message.clone(),
             });
             log::info!("idle_exit: {message}");
+            // Give asynchronous narration sinks a bounded chance to forward the
+            // already-published fleet announcement before process termination.
+            tokio::time::sleep(Duration::from_millis(250)).await;
             let _ = tokio::fs::remove_file(&socket).await;
             std::process::exit(0);
         }
@@ -294,6 +297,20 @@ mod tests {
         let mut running = idle();
         running.in_flight = 1;
         assert_eq!(tracker.observe(running, start + Duration::from_secs(120)), None);
+    }
+
+    #[test]
+    fn active_role_resets_ordinary_idle_clock() {
+        let start = Instant::now();
+        let mut tracker = IdleTracker::new(Duration::from_secs(60), false, start);
+        let mut role = idle();
+        role.active_roles = 1;
+        assert_eq!(tracker.observe(role, start + Duration::from_secs(59)), None);
+        assert_eq!(tracker.observe(idle(), start + Duration::from_secs(118)), None);
+        assert_eq!(
+            tracker.observe(idle(), start + Duration::from_secs(119)),
+            Some(IdleExitTrigger::Idle)
+        );
     }
 
     #[test]
@@ -347,5 +364,13 @@ mod tests {
         write_marker(&path, &marker).unwrap();
         let parsed: IdleExitMarker = serde_json::from_slice(&fs::read(path).unwrap()).unwrap();
         assert_eq!(parsed, marker);
+    }
+
+    #[test]
+    fn absent_config_is_disabled_with_documented_defaults() {
+        let config = IdleExitConfig::default();
+        assert_eq!(config.enabled, None);
+        assert_eq!(config.idle_minutes.unwrap_or(DEFAULT_IDLE_MINUTES), 60);
+        assert!(config.on_token_starvation.unwrap_or(true));
     }
 }

--- a/loom-daemon/src/idle_exit.rs
+++ b/loom-daemon/src/idle_exit.rs
@@ -1,0 +1,351 @@
+//! Opt-in daemon idle exit for remote hosts (issue #4467).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::event_bus::EventBus;
+use crate::role_runner::{active_run_count, InProgressGuard};
+use crate::types::Event;
+use crate::workspace_pool::WorkspacePool;
+
+pub const ENABLE_ENV: &str = "LOOM_AUTONOMOUS_IDLE_EXIT_ENABLED";
+pub const MINUTES_ENV: &str = "LOOM_AUTONOMOUS_IDLE_EXIT_MINUTES";
+pub const STARVATION_ENV: &str = "LOOM_AUTONOMOUS_IDLE_EXIT_ON_TOKEN_STARVATION";
+pub const DEFAULT_IDLE_MINUTES: u64 = 60;
+pub const MARKER_FILENAME: &str = "idle-exit.json";
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct IdleExitConfig {
+    pub enabled: Option<bool>,
+    pub idle_minutes: Option<u64>,
+    pub on_token_starvation: Option<bool>,
+}
+
+#[must_use]
+pub fn read_config(root: &Path) -> IdleExitConfig {
+    let config = crate::config_resolver::resolve_effective_config(root);
+    let Some(block) = crate::config_resolver::get_path(&config, "autonomous.idleExit") else {
+        return IdleExitConfig::default();
+    };
+    IdleExitConfig {
+        enabled: block.get("enabled").and_then(serde_json::Value::as_bool),
+        idle_minutes: block
+            .get("idleMinutes")
+            .and_then(serde_json::Value::as_u64)
+            .filter(|value| *value > 0),
+        on_token_starvation: block
+            .get("onTokenStarvation")
+            .and_then(serde_json::Value::as_bool),
+    }
+}
+
+fn env_bool(name: &str) -> Option<bool> {
+    std::env::var(name).ok().map(|value| {
+        matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on")
+    })
+}
+
+#[must_use]
+pub fn resolve_enabled(config: &IdleExitConfig) -> bool {
+    env_bool(ENABLE_ENV).or(config.enabled).unwrap_or(false)
+}
+
+#[must_use]
+pub fn resolve_minutes(config: &IdleExitConfig) -> u64 {
+    std::env::var(MINUTES_ENV)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .filter(|value| *value > 0)
+        .or(config.idle_minutes)
+        .unwrap_or(DEFAULT_IDLE_MINUTES)
+}
+
+#[must_use]
+pub fn resolve_starvation(config: &IdleExitConfig) -> bool {
+    env_bool(STARVATION_ENV)
+        .or(config.on_token_starvation)
+        .unwrap_or(true)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IdleExitTrigger {
+    Idle,
+    TokenStarvation,
+}
+
+impl IdleExitTrigger {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Idle => "idle",
+            Self::TokenStarvation => "token_starvation",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Observation {
+    pub in_flight: usize,
+    pub active_roles: usize,
+    pub lifecycle_activity: bool,
+    pub healthy_tokens: usize,
+}
+
+#[derive(Debug)]
+pub struct IdleTracker {
+    threshold: Duration,
+    starvation_enabled: bool,
+    idle_since: Instant,
+    starved_since: Instant,
+}
+
+impl IdleTracker {
+    #[must_use]
+    pub fn new(threshold: Duration, starvation_enabled: bool, now: Instant) -> Self {
+        Self {
+            threshold,
+            starvation_enabled,
+            idle_since: now,
+            starved_since: now,
+        }
+    }
+
+    #[must_use]
+    pub fn observe(&mut self, value: Observation, now: Instant) -> Option<IdleExitTrigger> {
+        if value.in_flight > 0 {
+            self.idle_since = now;
+            self.starved_since = now;
+            return None;
+        }
+        if value.active_roles > 0 || value.lifecycle_activity {
+            self.idle_since = now;
+        }
+        if value.healthy_tokens > 0 || value.lifecycle_activity {
+            self.starved_since = now;
+        }
+        if self.starvation_enabled
+            && value.healthy_tokens == 0
+            && now.duration_since(self.starved_since) >= self.threshold
+        {
+            return Some(IdleExitTrigger::TokenStarvation);
+        }
+        if value.active_roles == 0
+            && !value.lifecycle_activity
+            && now.duration_since(self.idle_since) >= self.threshold
+        {
+            return Some(IdleExitTrigger::Idle);
+        }
+        None
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IdleExitMarker {
+    pub exited_at: DateTime<Utc>,
+    pub trigger: IdleExitTrigger,
+    pub idle_minutes: u64,
+    pub in_flight_sweeps: usize,
+    pub active_role_runs: usize,
+    pub healthy_tokens: usize,
+    pub total_tokens: usize,
+}
+
+#[must_use]
+pub fn marker_path(socket: &Path) -> PathBuf {
+    socket
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(MARKER_FILENAME)
+}
+
+pub fn write_marker(path: &Path, marker: &IdleExitMarker) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "marker has no parent".to_string())?;
+    fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    let temporary = path.with_extension(format!("json.tmp-{}", std::process::id()));
+    fs::write(
+        &temporary,
+        serde_json::to_vec_pretty(marker).map_err(|error| error.to_string())?,
+    )
+    .map_err(|error| error.to_string())?;
+    fs::rename(temporary, path).map_err(|error| error.to_string())
+}
+
+fn token_counts(root: &Path) -> (usize, usize) {
+    crate::capacity::read_ranking(root).map_or_else(
+        || {
+            let total = crate::tokens::token_pool_size(root);
+            (total, total)
+        },
+        |ranking| (ranking.available, ranking.total),
+    )
+}
+
+pub fn spawn_task(
+    config: IdleExitConfig,
+    root: PathBuf,
+    pool: Arc<WorkspacePool>,
+    roles: InProgressGuard,
+    bus: Arc<EventBus>,
+    socket: PathBuf,
+) -> tokio::task::JoinHandle<()> {
+    let minutes = resolve_minutes(&config);
+    let starvation = resolve_starvation(&config);
+    tokio::spawn(async move {
+        let marker_path = marker_path(&socket);
+        if let Err(error) = fs::remove_file(&marker_path) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                log::warn!("idle_exit: stale-marker cleanup failed: {error}");
+            }
+        }
+        let mut tracker = IdleTracker::new(
+            Duration::from_secs(minutes.saturating_mul(60)),
+            starvation,
+            Instant::now(),
+        );
+        let mut events = bus.subscribe(["sweep.global.dispatch", "sweep.global.completed"]);
+        let mut interval = tokio::time::interval(Duration::from_secs(15));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            let mut lifecycle_activity = false;
+            while events.try_recv().is_ok() {
+                lifecycle_activity = true;
+            }
+            let in_flight = crate::ipc::count_in_flight_sweeps(&pool, &root);
+            let active_roles = active_run_count(&roles);
+            let (healthy_tokens, total_tokens) = token_counts(&root);
+            let Some(trigger) = tracker.observe(
+                Observation {
+                    in_flight,
+                    active_roles,
+                    lifecycle_activity,
+                    healthy_tokens,
+                },
+                Instant::now(),
+            ) else {
+                continue;
+            };
+            let marker = IdleExitMarker {
+                exited_at: Utc::now(),
+                trigger,
+                idle_minutes: minutes,
+                in_flight_sweeps: in_flight,
+                active_role_runs: active_roles,
+                healthy_tokens,
+                total_tokens,
+            };
+            if let Err(error) = write_marker(&marker_path, &marker) {
+                log::error!("idle_exit: marker write failed; refusing exit: {error}");
+                continue;
+            }
+            let message = format!(
+                "idle for {minutes}m ({}) — exiting for host idle-shutdown",
+                trigger.as_str()
+            );
+            let _ = bus.publish(Event::DaemonIdleExit {
+                trigger: trigger.as_str().to_string(),
+                idle_minutes: minutes,
+                in_flight_sweeps: in_flight,
+                active_role_runs: active_roles,
+                healthy_tokens,
+                total_tokens,
+                message: message.clone(),
+            });
+            log::info!("idle_exit: {message}");
+            let _ = tokio::fs::remove_file(&socket).await;
+            std::process::exit(0);
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn idle() -> Observation {
+        Observation {
+            in_flight: 0,
+            active_roles: 0,
+            lifecycle_activity: false,
+            healthy_tokens: 1,
+        }
+    }
+
+    #[test]
+    fn accrues_idle_and_resets_on_activity() {
+        let start = Instant::now();
+        let mut tracker = IdleTracker::new(Duration::from_secs(60), false, start);
+        assert_eq!(tracker.observe(idle(), start + Duration::from_secs(59)), None);
+        let mut active = idle();
+        active.lifecycle_activity = true;
+        assert_eq!(tracker.observe(active, start + Duration::from_secs(59)), None);
+        assert_eq!(
+            tracker.observe(idle(), start + Duration::from_secs(119)),
+            Some(IdleExitTrigger::Idle)
+        );
+        let mut running = idle();
+        running.in_flight = 1;
+        assert_eq!(tracker.observe(running, start + Duration::from_secs(120)), None);
+    }
+
+    #[test]
+    fn starvation_ignores_roles_but_not_sweeps_or_recovery() {
+        let start = Instant::now();
+        let mut tracker = IdleTracker::new(Duration::from_secs(60), true, start);
+        let starved = Observation {
+            active_roles: 1,
+            healthy_tokens: 0,
+            ..idle()
+        };
+        assert_eq!(
+            tracker.observe(starved, start + Duration::from_secs(60)),
+            Some(IdleExitTrigger::TokenStarvation)
+        );
+        assert_eq!(
+            tracker.observe(
+                Observation {
+                    in_flight: 1,
+                    ..starved
+                },
+                start + Duration::from_secs(61)
+            ),
+            None
+        );
+        assert_eq!(
+            tracker.observe(
+                Observation {
+                    healthy_tokens: 1,
+                    ..starved
+                },
+                start + Duration::from_secs(121)
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn marker_round_trip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(MARKER_FILENAME);
+        let marker = IdleExitMarker {
+            exited_at: Utc::now(),
+            trigger: IdleExitTrigger::Idle,
+            idle_minutes: 60,
+            in_flight_sweeps: 0,
+            active_role_runs: 0,
+            healthy_tokens: 1,
+            total_tokens: 2,
+        };
+        write_marker(&path, &marker).unwrap();
+        let parsed: IdleExitMarker = serde_json::from_slice(&fs::read(path).unwrap()).unwrap();
+        assert_eq!(parsed, marker);
+    }
+}

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -34,6 +34,7 @@ pub mod git_parser;
 pub mod git_utils;
 pub mod health_monitor;
 pub mod host_breaker;
+pub mod idle_exit;
 pub mod init;
 pub mod ipc;
 pub mod issue_creation_mutex;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -9,6 +9,7 @@ use loom_daemon::epic_supervisor;
 use loom_daemon::event_bus::EventBus;
 use loom_daemon::health_monitor;
 use loom_daemon::host_breaker;
+use loom_daemon::idle_exit;
 use loom_daemon::ipc::IpcServer;
 use loom_daemon::main_health_gate;
 use loom_daemon::metrics_collector;
@@ -2049,6 +2050,32 @@ async fn main() -> Result<()> {
         log::debug!(
             "auto_update: disabled (set LOOM_AUTO_UPDATE=1 or autonomous.autoUpdate.enabled=true to opt in)"
         );
+        None
+    };
+
+    // Independent, opt-in idle exit (#4467). The daemon only exits; the host
+    // guard retains sole authority to power off.
+    let idle_exit_config = idle_exit::read_config(&sweep_workspace);
+    let _idle_exit_handle = if idle_exit::resolve_enabled(&idle_exit_config) {
+        let minutes = idle_exit::resolve_minutes(&idle_exit_config);
+        let starvation = idle_exit::resolve_starvation(&idle_exit_config);
+        if loom_daemon::ipc::detect_supervisor().as_deref() == Some("launchd") {
+            log::warn!(
+                "idle_exit: ENABLED under launchd; KeepAlive:SuccessfulExit relaunches exit(0), \
+                 so idle exit is meaningful only under on-failure-style supervision"
+            );
+        }
+        log::info!("idle_exit: enabled (idle_minutes={minutes}, on_token_starvation={starvation})");
+        Some(idle_exit::spawn_task(
+            idle_exit_config,
+            sweep_workspace.clone(),
+            workspace_pool.clone(),
+            role_in_progress.clone(),
+            event_bus.clone(),
+            socket_path.clone(),
+        ))
+    } else {
+        log::debug!("idle_exit: disabled (opt in with autonomous.idleExit.enabled=true)");
         None
     };
 

--- a/loom-daemon/src/role_runner.rs
+++ b/loom-daemon/src/role_runner.rs
@@ -79,6 +79,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::{Duration, Instant};
 
@@ -668,6 +669,8 @@ pub fn resolve_interval_for_role(spec: &RoleSpec, config: &RoleRunnerConfig) -> 
 /// (the taxonomy is frozen, #4364).
 pub type InProgressGuard = Arc<Mutex<HashSet<(PathBuf, &'static str)>>>;
 
+static ROLE_RUN_START_GENERATION: AtomicU64 = AtomicU64::new(0);
+
 /// Construct an empty [`InProgressGuard`]. One instance is created in `main.rs`
 /// and cloned into every interval role loop and the work-finder's idle path so
 /// they share a single view.
@@ -680,6 +683,15 @@ pub fn new_in_progress_guard() -> InProgressGuard {
 #[must_use]
 pub fn active_run_count(set: &InProgressGuard) -> usize {
     set.lock().unwrap_or_else(PoisonError::into_inner).len()
+}
+
+/// Monotonic process-wide count of successfully started role invocations.
+///
+/// Unlike an active-count sample, a generation change cannot miss a short role
+/// that starts and finishes between idle-exit polling ticks.
+#[must_use]
+pub fn role_run_start_generation() -> u64 {
+    ROLE_RUN_START_GENERATION.load(Ordering::Relaxed)
 }
 
 /// RAII guard: [`try_acquire`](Self::try_acquire) inserts `(root, role)` into
@@ -708,6 +720,7 @@ impl RoleRunGuard {
             }
             guard.insert(key.clone());
         }
+        ROLE_RUN_START_GENERATION.fetch_add(1, Ordering::Relaxed);
         Some(Self { set, key })
     }
 }

--- a/loom-daemon/src/role_runner.rs
+++ b/loom-daemon/src/role_runner.rs
@@ -676,6 +676,12 @@ pub fn new_in_progress_guard() -> InProgressGuard {
     Arc::new(Mutex::new(HashSet::new()))
 }
 
+/// Number of role invocations active across all managed workspaces.
+#[must_use]
+pub fn active_run_count(set: &InProgressGuard) -> usize {
+    set.lock().unwrap_or_else(PoisonError::into_inner).len()
+}
+
 /// RAII guard: [`try_acquire`](Self::try_acquire) inserts `(root, role)` into
 /// the shared [`InProgressGuard`]; [`Drop`] removes it.
 ///

--- a/loom-daemon/src/safehouse.rs
+++ b/loom-daemon/src/safehouse.rs
@@ -2382,6 +2382,21 @@ mod tests {
         };
         let env = event_to_envelope(&resume_failed).unwrap();
         assert!(env.body.contains("still stranded"), "got: {}", env.body);
+
+        let idle_exit = Event::DaemonIdleExit {
+            trigger: "token_starvation".to_owned(),
+            idle_minutes: 60,
+            in_flight_sweeps: 0,
+            active_role_runs: 1,
+            healthy_tokens: 0,
+            total_tokens: 8,
+            message: "idle for 60m — exiting for host idle-shutdown".to_owned(),
+        };
+        let env = event_to_envelope(&idle_exit).unwrap();
+        assert_eq!(env.kind, "handoff");
+        assert_eq!(env.task_id.as_deref(), Some("daemon-idle-exit"));
+        assert!(env.body.contains("host idle-shutdown"));
+        assert_eq!(env.meta.unwrap()["trigger"], "token_starvation");
     }
 
     #[test]

--- a/loom-daemon/src/safehouse.rs
+++ b/loom-daemon/src/safehouse.rs
@@ -2740,6 +2740,7 @@ mod tests {
             issue: 4426,
             exit_code: Some(0),
             duration_sec: 750,
+            death_class: None,
             repo: Some(dir.path().to_string_lossy().into_owned()),
         })
         .unwrap();
@@ -2796,6 +2797,7 @@ mod tests {
             issue: 4426,
             exit_code: Some(1),
             duration_sec: 90,
+            death_class: None,
             repo: Some(dir.path().to_string_lossy().into_owned()),
         })
         .unwrap();

--- a/loom-daemon/src/safehouse.rs
+++ b/loom-daemon/src/safehouse.rs
@@ -852,6 +852,28 @@ pub fn event_to_envelope(event: &Event) -> Option<Envelope> {
                 meta: None,
             })
         }
+        Event::DaemonIdleExit {
+            trigger,
+            idle_minutes,
+            in_flight_sweeps,
+            active_role_runs,
+            healthy_tokens,
+            total_tokens,
+            message,
+        } => Some(Envelope {
+            to: "*".to_owned(),
+            kind: "handoff".to_owned(),
+            task_id: Some("daemon-idle-exit".to_owned()),
+            body: message.clone(),
+            meta: Some(serde_json::json!({
+                "trigger": trigger,
+                "idle_minutes": idle_minutes,
+                "in_flight_sweeps": in_flight_sweeps,
+                "active_role_runs": active_role_runs,
+                "healthy_tokens": healthy_tokens,
+                "total_tokens": total_tokens,
+            })),
+        }),
         // SweepGlobalCompleted (no issue number — SweepExited covers it),
         // SweepGlobalDispatch(PrSet), EpicAction, CapacityAdvisory, TopicLag,
         // Generic: not narrated in phase 1.

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -1714,6 +1714,17 @@ pub enum Event {
         /// Operator-facing advisory message naming the concrete cause.
         message: String,
     },
+    /// `daemon.idle_exit` — the daemon is cleanly yielding to a host
+    /// idle-shutdown guard (Issue #4467).
+    DaemonIdleExit {
+        trigger: String,
+        idle_minutes: u64,
+        in_flight_sweeps: usize,
+        active_role_runs: usize,
+        healthy_tokens: usize,
+        total_tokens: usize,
+        message: String,
+    },
     /// Synthetic event signalling that the subscription fell behind the
     /// publisher. The number of events dropped is reported in `skipped`.
     /// Matches `tokio::sync::broadcast::Receiver::Lagged` semantics.
@@ -1770,6 +1781,7 @@ impl Event {
             }
             Self::CapacityAdvisory { .. } => "daemon.capacity.advisory".to_string(),
             Self::PreflightAdvisory { .. } => "daemon.preflight.advisory".to_string(),
+            Self::DaemonIdleExit { .. } => "daemon.idle_exit".to_string(),
             Self::TopicLag { .. } => "sweep.system.topic_lag".to_string(),
             Self::Generic { topic, .. } => topic.clone(),
         }


### PR DESCRIPTION
## Summary

- add default-off autonomous.idleExit config with env overrides
- track ordinary idleness and token starvation independently of Work Finder
- write a machine-readable marker, publish a safehouse fleet event, and exit 0 without issuing power commands
- expose active role-run count and preserve the fleet guard as stage-two power authority
- document systemd/launchd supervision semantics

## Validation

- env RUSTC_WRAPPER= cargo test idle_exit::tests
- env RUSTC_WRAPPER= cargo test fleet::add_worker::tests
- env RUSTC_WRAPPER= cargo check --all-targets
- cargo fmt --all -- --check
- env RUSTC_WRAPPER= cargo clippy --all-targets -- -D warnings

Closes #4467