### PR TITLE
docs: document Codex operator launch postures

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,32 @@ From a script:
 claude -p "/loom:sweep 42" --dangerously-skip-permissions
 ```
 
+For a full Builder-through-Merge lifecycle from an **interactive Codex parent
+session**, launch Codex explicitly with:
+
+```bash
+codex --dangerously-bypass-approvals-and-sandbox
+```
+
+> **Warning:** this flag disables both Codex approval prompts and the Codex
+> sandbox. Use it only in an environment where you accept that trust boundary
+> for Loom's network, git, worktree, daemon-socket, and process operations.
+
+For non-mutating Curator or Judge investigation, use a read-only session
+instead:
+
+```bash
+codex --sandbox read-only --ask-for-approval never
+```
+
+The read-only posture cannot claim issues, edit labels, build in worktrees,
+create PRs, or merge; restart Codex with the full-lifecycle posture before
+performing those operations. These flags configure only the interactive parent
+session. They do not configure Codex workers dispatched by `loom-daemon`; that
+policy is tracked in [#4478](https://github.com/rjwalters/loom/issues/4478).
+See the [Codex guardrail-parity document](defaults/docs/guardrail-parity-codex.md)
+for the runtime trust-boundary comparison.
+
 Sweep is self-contained — there is no separate daemon to start. Checkpoints under `.loom/sweep-checkpoint/` survive crashes; restarting the sweep resumes from the last completed phase.
 
 ### Multi-Issue Mode (loom-daemon, Tier 2)

--- a/docs/autonomous-mode-e2e.md
+++ b/docs/autonomous-mode-e2e.md
@@ -35,6 +35,33 @@ crons — but the label-transition wait in Step 5 is a scripted assertion so the
   (`.github/workflows/loom-*.yml`), or you run Curator / Judge / Champion
   manually per step (the playbook shows the manual triggers).
 
+### Codex operator launch posture
+
+When the operator drives a full Builder-through-Merge lifecycle from an
+**interactive Codex parent session**, start that session with:
+
+```bash
+codex --dangerously-bypass-approvals-and-sandbox
+```
+
+> **Warning:** this disables both Codex approval prompts and the Codex sandbox.
+> Use it only where the operator accepts that trust boundary for Loom's network,
+> git, worktree, daemon-socket, and process operations.
+
+For non-mutating Curator or Judge investigation only, use:
+
+```bash
+codex --sandbox read-only --ask-for-approval never
+```
+
+That read-only session cannot claim or relabel issues, modify worktrees, create
+PRs, or merge. Restart Codex with the full-lifecycle posture before performing
+those operations. These launch flags apply only to the interactive parent
+session, not to Codex workers dispatched by `loom-daemon`. Daemon worker policy
+is tracked separately in [#4478](https://github.com/rjwalters/loom/issues/4478);
+the [Codex guardrail-parity document](../defaults/docs/guardrail-parity-codex.md)
+describes the runtime trust boundary in detail.
+
 ## Step 1 — Enable autonomous mode in config
 
 Add the `autonomous` block to `.loom/config.json` (see


### PR DESCRIPTION
## Summary
Document the explicit Codex launch posture for interactive Loom operators, including the trusted full lifecycle and safe read-only investigation modes.

## Changes
- Add full Builder-through-Merge Codex launch examples and prominent sandbox/approval warnings.
- Add a read-only Curator/Judge investigation posture and state its mutation limits.
- Distinguish interactive parent-session flags from daemon-dispatched worker policy, linking #4478 and the Codex guardrail-parity document.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Full lifecycle command documented | ✅ | Both docs use `codex --dangerously-bypass-approvals-and-sandbox`. |
| Read-only alternative documented | ✅ | Both docs use `codex --sandbox read-only --ask-for-approval never` and limit it to non-mutating investigation. |
| Security warning is prominent | ✅ | Both sections warn that approvals and the Codex sandbox are disabled. |
| Parent and daemon policy distinguished | ✅ | Both sections say the flags affect only the interactive parent and link #4478. |
| Guardrail parity linked from landed source | ✅ | Both links resolve to `defaults/docs/guardrail-parity-codex.md` on the build base. |
| No mutation-probing preflight | ✅ | Documentation-only diff; no command or automatic issue mutation was introduced. |

## Test Plan
- `codex --dangerously-bypass-approvals-and-sandbox --version` → `codex-cli 0.146.0`.
- `codex --sandbox read-only --ask-for-approval never --version` → `codex-cli 0.146.0`.
- `git diff --check` passed.
- New local guardrail-parity link targets resolve.
- `./.loom/scripts/verify-install.sh check-links` ran; it reports one pre-existing dangling link in untouched `.loom/docs/daemon-reference.md` to `.claude/commands/loom/judge.md`.
- `bash .loom/scripts/build-gate.sh`: 1,970 passed, 1 transient host-level `df -Pk` test failed; the exact failed test passed immediately in isolation.

Closes #4481