### PR TITLE
fix(sweep): Approval gate preserves loom:curated at promotion (#3288)

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -1499,10 +1499,11 @@ Curator runs sequentially per-issue within wave setup — it is cheap and does n
 Each issue must reach `loom:issue` before the Builder can claim it. This promotion is authorized — see `.loom/roles/curator.md` § "Who promotes `loom:curated` → `loom:issue`" for the full rule. In short: the orchestrator only ever promotes an issue that is already a member of *this sweep's own resolved candidate set*, so the promotion executes an approval already given one step earlier in this same run (the operator named or confirmed the issue, or the daemon dispatch that started this sweep did) — it is not independent agent judgment, and it is not the Curator acting.
 
 - If the issue already has `loom:issue`, proceed.
-- Otherwise, promote it:
+- Otherwise, promote it (add-only — matches Champion promotion):
   ```bash
-  gh issue edit N --remove-label "loom:curated" --add-label "loom:issue"
+  gh issue edit N --add-label "loom:issue"
   ```
+  **Do not remove `loom:curated`.** Per #3288 (Option A), `loom:curated` is a persistent milestone marker, not a transient step label — a promoted issue carries *both* `loom:curated` and `loom:issue`. Stripping it here would falsely surface the issue in the Curator Priority 1 "approved-but-uncurated" query (`loom:issue` without `loom:curated`) and drop the Builder prioritization signal that ranks `loom:issue` + `loom:curated` ahead of `loom:issue` alone. This keeps sweep promotion consistent with `champion-issue-promo.md`, which also preserves `loom:curated`.
 
 ### 4. Builder phase (parallel within the wave)
 


### PR DESCRIPTION
## Summary

The `/loom:sweep` Wave Lifecycle **Approval gate** (step 3) stripped `loom:curated` when promoting an issue to `loom:issue` — the lone promotion path still doing so. This contradicted the settled per-label semantics from #3288 (Option A: `loom:curated` is a *persistent milestone marker*, not a transient step label) and diverged from Champion promotion (`champion-issue-promo.md`), which preserves `loom:curated`.

## Change

`defaults/.claude/commands/loom/sweep.md` step 3 — the promotion command is now **add-only**:

```bash
gh issue edit N --add-label "loom:issue"   # was: --remove-label "loom:curated" --add-label "loom:issue"
```

Surrounding prose now states that `loom:curated` persists as a milestone marker (citing #3288) and explains the two consequences the strip caused: false hits in the Curator Priority 1 "approved-but-uncurated" query (`loom:issue` without `loom:curated`) and loss of the Builder prioritization signal.

## Acceptance criteria

- [x] Approval gate promotion no longer removes `loom:curated`.
- [x] `grep -rn 'remove-label "loom:curated"' defaults/` returns no hits.
- [x] Wave Lifecycle step 3 prose updated to state `loom:curated` persists, citing #3288.
- [x] Installed copy: `.claude/commands/loom` is a symlink to `defaults/.claude/commands/loom` in this repo (resolves correctly), so editing the defaults file is sufficient; no separate copy to edit.

## Test results

- `grep -rn 'remove-label "loom:curated"' defaults/` → no hits.
- `scripts/check-claude-md-budget.sh` → OK (314/320 lines).
- Symlink `.claude/commands/loom -> ../../defaults/.claude/commands/loom` resolves.

Closes #4484

🤖 Generated with [Claude Code](https://claude.com/claude-code)