### PR TITLE
feat(cli): make loom sweep runtime-neutral instead of hardwiring Claude Code

### DIFF
--- a/defaults/docs/runtime-adapters.md
+++ b/defaults/docs/runtime-adapters.md
@@ -403,6 +403,16 @@ Callers migrate from `spawn-claude.sh` to `spawn-worker.sh` to gain runtime
 selection; until they do, `spawn-claude.sh` keeps working unchanged (existing
 daemon/tooling callers are intentionally left on the direct path in Phase 1).
 
+The machine-level `loom sweep <N>` dispatcher (`scripts/loom`'s `loom_cmd_sweep`)
+is one such migrated caller (#4480): it resolves the repo's `spawn-worker.sh` and
+execs `spawn-worker.sh -p "/loom:sweep <N>" --dangerously-skip-permissions`
+instead of `claude` directly, so a Codex-hosted (or any non-Claude) operator can
+dispatch the canonical single-issue lifecycle. With nothing configured this stays
+byte-for-byte the old `claude -p ... --dangerously-skip-permissions` invocation
+(via `spawn-worker.sh` → `spawn-claude.sh`). The daemon's own
+`sweep_registry.rs` dispatch still defaults straight to `spawn-claude.sh` — a
+sibling gap tracked separately, deliberately out of #4480's scope.
+
 ### Runtime resolution (precedence)
 
 The runtime is resolved with the standard Loom precedence chain

--- a/defaults/scripts/tests/test-loom-dispatcher.sh
+++ b/defaults/scripts/tests/test-loom-dispatcher.sh
@@ -28,6 +28,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 DISPATCHER="$REPO_ROOT/scripts/loom"
 PROVISION_LIB="$REPO_ROOT/scripts/install/provision-dispatcher.sh"
 REAL_RESOLVER="$REPO_ROOT/defaults/scripts/lib/config-resolver.sh"
+REAL_SPAWN_WORKER="$REPO_ROOT/defaults/scripts/spawn-worker.sh"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -87,6 +88,30 @@ make_consumer_repo() {
 echo "POOL_MANAGER args=[$*]"
 EOF
     chmod +x "$r/.loom/bin/loom"
+    printf '%s\n' "$r"
+}
+
+# Build a fake consumer repo whose .loom/scripts carries a REAL spawn-worker.sh
+# + config-resolver.sh, plus stub spawn-<runtime>.sh runners that just echo
+# their own name and argv (no real claude/codex, no live tokens) — the pattern
+# test-spawn-worker.sh uses. Exercises `loom sweep`'s runtime routing (#4480).
+# Echoes the repo path.
+make_sweep_repo() {
+    local r; r="$(mktemp -d)"
+    mkdir -p "$r/.loom/scripts/lib"
+    cp "$REAL_SPAWN_WORKER" "$r/.loom/scripts/spawn-worker.sh"
+    cp "$REAL_RESOLVER" "$r/.loom/scripts/lib/config-resolver.sh"
+    # Stub runners: each announces which runtime ran and forwards its argv so a
+    # test can assert on both the selected runner and the passthrough flags.
+    cat > "$r/.loom/scripts/spawn-claude.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "STUB_CLAUDE argv=[$*]"
+EOF
+    cat > "$r/.loom/scripts/spawn-codex.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "STUB_CODEX argv=[$*]"
+EOF
+    chmod +x "$r/.loom/scripts/"spawn-*.sh
     printf '%s\n' "$r"
 }
 
@@ -362,6 +387,74 @@ MIGREPO="$(make_consumer_repo)"
 migrate_run=$(cd "$MIGREPO" && LOOM_HOME="$CHK" bash "$DISPATCHER" migrate --dry-run 2>&1 || true)
 assert_contains "$migrate_run" "MIGRATE args=" "'loom migrate' delegates to migrate-consumer.sh"
 assert_contains "$migrate_run" "machine_checkout=[$CHK]" "'loom migrate' hands off LOOM_MACHINE_CHECKOUT"
+
+# ── #4480: `loom sweep` is runtime-neutral (routes through spawn-worker.sh) ───
+echo "Test 19: 'loom sweep' default path (no env, no config) routes to spawn-claude.sh unchanged"
+SWEEPREPO="$(make_sweep_repo)"
+set +e
+out=$(cd "$SWEEPREPO" && LOOM_CONFIG_DEFAULTS_FILE="" LOOM_HOME="$CHK" bash "$DISPATCHER" sweep 4467 2>&1)
+rc=$?
+set -e 2>/dev/null || true
+assert_eq "$rc" "0" "'loom sweep' default path exits 0"
+assert_contains "$out" "STUB_CLAUDE" "default (no env/config) resolves to spawn-claude.sh"
+assert_not_contains "$out" "STUB_CODEX" "default path does not touch the codex runner"
+assert_contains "$out" 'argv=[-p /loom:sweep 4467 --dangerously-skip-permissions]' "default path forwards the same claude args as before (byte-for-byte)"
+
+echo "Test 20: 'LOOM_RUNTIME=codex loom sweep' routes to spawn-codex.sh"
+set +e
+out=$(cd "$SWEEPREPO" && LOOM_RUNTIME=codex LOOM_CONFIG_DEFAULTS_FILE="" LOOM_HOME="$CHK" bash "$DISPATCHER" sweep 4467 2>&1)
+rc=$?
+set -e 2>/dev/null || true
+assert_eq "$rc" "0" "'LOOM_RUNTIME=codex loom sweep' exits 0"
+assert_contains "$out" "STUB_CODEX" "LOOM_RUNTIME=codex resolves to spawn-codex.sh"
+assert_not_contains "$out" "STUB_CLAUDE" "codex env path does not touch the claude runner"
+assert_contains "$out" 'argv=[-p /loom:sweep 4467 --dangerously-skip-permissions]' "codex path forwards the same passthrough args"
+
+if command -v jq >/dev/null 2>&1; then
+    echo "Test 21: 'loom sweep' honors .loom/config.json runtimes.default (no env)"
+    SWEEPCFG="$(make_sweep_repo)"
+    echo '{"runtimes":{"default":"codex"}}' > "$SWEEPCFG/.loom/config.json"
+    set +e
+    out=$(cd "$SWEEPCFG" && LOOM_CONFIG_DEFAULTS_FILE="" LOOM_HOME="$CHK" bash "$DISPATCHER" sweep 4467 2>&1)
+    rc=$?
+    set -e 2>/dev/null || true
+    assert_eq "$rc" "0" "'loom sweep' with runtimes.default=codex exits 0"
+    assert_contains "$out" "STUB_CODEX" "runtimes.default=codex (no env) resolves to spawn-codex.sh"
+    assert_not_contains "$out" "STUB_CLAUDE" "config-selected codex path does not touch the claude runner"
+else
+    echo "Test 21: SKIP (jq not on PATH)"
+fi
+
+echo "Test 22: 'loom sweep' with an unknown runtime exits 78 naming runtime, source, and runners present"
+set +e
+out=$(cd "$SWEEPREPO" && LOOM_RUNTIME=nonexistent LOOM_CONFIG_DEFAULTS_FILE="" LOOM_HOME="$CHK" bash "$DISPATCHER" sweep 4467 2>&1)
+rc=$?
+set -e 2>/dev/null || true
+assert_eq "$rc" "78" "unknown runtime exits 78 (EX_CONFIG)"
+assert_contains "$out" "nonexistent" "error names the resolved runtime"
+assert_contains "$out" "env (LOOM_RUNTIME)" "error names where the runtime was resolved from"
+assert_contains "$out" "claude" "error lists the runners actually present on disk"
+assert_not_contains "$out" "STUB_CLAUDE" "unknown runtime never falls through to a runner"
+
+echo "Test 23: 'loom sweep' still refuses outside a Loom repo and with no issue arg (unchanged)"
+NRSWEEP=$(mktemp -d)
+set +e
+out=$(cd "$NRSWEEP" && LOOM_HOME="$CHK" bash "$DISPATCHER" sweep 4467 2>&1)
+rc=$?
+set -e 2>/dev/null || true
+assert_eq "$rc" "1" "'loom sweep' outside a Loom repo exits 1"
+assert_contains "$out" "must run inside a Loom repo" "'loom sweep' outside a repo keeps the existing message"
+
+set +e
+out=$(cd "$SWEEPREPO" && LOOM_HOME="$CHK" bash "$DISPATCHER" sweep 2>&1)
+rc=$?
+set -e 2>/dev/null || true
+assert_eq "$rc" "1" "'loom sweep' with no issue arg exits 1"
+assert_contains "$out" "usage: loom sweep" "'loom sweep' with no arg keeps the existing usage message"
+
+echo "Test 24: 'loom sweep' no longer hardcodes a Claude-only prerequisite gate (#4480)"
+src="$(cat "$DISPATCHER")"
+assert_not_contains "$src" "'claude' CLI not found on PATH; cannot dispatch a sweep." "the Claude-only prereq gate was removed from sweep"
 
 echo ""
 echo "======================================"

--- a/scripts/loom
+++ b/scripts/loom
@@ -317,22 +317,41 @@ loom_cmd_restart() {
 }
 
 # `sweep <issue>` dispatches a single-issue lifecycle for the CURRENT repo.
+#
+# Runtime-neutral (#4480): rather than exec'ing `claude` directly, sweep routes
+# through the resolved repo's `spawn-worker.sh` — the runtime-resolution seam
+# (`LOOM_RUNTIME` env > `.loom/config.json` runtimes.default > built-in
+# "claude"). With nothing configured this is byte-for-byte identical to before
+# (spawn-worker.sh -> spawn-claude.sh -> `claude -p ... --dangerously-skip-permissions`),
+# but a Codex-hosted (or any non-Claude) operator can now dispatch the canonical
+# single-issue lifecycle too. Prerequisite checking (which runtime, which binary
+# is missing, unknown-runtime -> exit 78) belongs to spawn-worker.sh and each
+# spawn-<runtime>.sh — so the old hardcoded `command -v claude` gate is gone: it
+# always blamed Claude even on a fully-usable Codex-only host.
 loom_cmd_sweep() {
     loom_detect_context
     if [[ -z "$LOOM_CTX_ROOT" ]]; then
         _err "'sweep' must run inside a Loom repo (no .loom/ found from $PWD)."
         exit 1
     fi
-    if ! command -v claude >/dev/null 2>&1; then
-        _err "'claude' CLI not found on PATH; cannot dispatch a sweep."
-        exit 1
-    fi
     if [[ $# -eq 0 ]]; then
         _err "usage: loom sweep <issue-number> [more issues|flags]"
         exit 1
     fi
+    local scripts_dir
+    if ! scripts_dir="$(loom_checkout_scripts_dir "$LOOM_CTX_ROOT")"; then
+        _err "no scripts/ tree found under $LOOM_CTX_ROOT (looked in defaults/scripts and .loom/scripts)."
+        exit 1
+    fi
+    local spawn_worker="$scripts_dir/spawn-worker.sh"
+    if [[ ! -x "$spawn_worker" ]]; then
+        _err "spawn-worker.sh not found or not executable at $spawn_worker."
+        exit 1
+    fi
+    # cd into the repo root so spawn-worker.sh's own workspace/config resolution
+    # (git rev-parse --git-common-dir -> .loom/config.json) lands on this repo.
     cd "$LOOM_CTX_ROOT"
-    exec claude -p "/loom:sweep $*" --dangerously-skip-permissions
+    exec "$spawn_worker" -p "/loom:sweep $*" --dangerously-skip-permissions
 }
 
 # `migrate` takes a historical file-copy Loom install in the CURRENT repo to the


### PR DESCRIPTION
## Summary

`loom sweep <N>` (the machine-level dispatcher, `scripts/loom`'s `loom_cmd_sweep`) hardwired Claude Code: it gated on `command -v claude` and exec'd `claude` directly, bypassing the runtime-adapter seam (`spawn-worker.sh`) that #4167/#4468 already shipped. A Codex-hosted (or any non-Claude) operator could not dispatch the canonical single-issue lifecycle through `loom sweep` even though `spawn-worker.sh` and `runtimes.default` already support it (this is what forced the manual Curator/Builder/Judge/Doctor/Merge reproduction in #4467).

This rewrites `loom_cmd_sweep` to resolve the repo's scripts dir via the existing `loom_checkout_scripts_dir()` helper and exec `spawn-worker.sh`, which resolves the runtime with the standard precedence (`LOOM_RUNTIME` env → `.loom/config.json` `runtimes.default` → built-in `"claude"`). The hardcoded Claude-only prereq gate is removed — prerequisite / unknown-runtime checking (exit 78) belongs to `spawn-worker.sh` and each `spawn-<runtime>.sh`, so errors now name the *selected* runtime instead of always blaming Claude.

## Zero regression

With no `LOOM_RUNTIME` and no `runtimes.default`, `spawn-worker.sh` resolves `"claude"` and execs `spawn-claude.sh`, which execs `claude -p "/loom:sweep $*" --dangerously-skip-permissions` — the same terminal command as before, just through the seam instead of around it. A dedicated test asserts this argv byte-for-byte.

## Acceptance criteria

- [x] Runtime resolved with `spawn-worker.sh` precedence (env → config → default).
- [x] No env/config → still execs `claude -p "/loom:sweep $*" --dangerously-skip-permissions` (via `spawn-worker.sh` → `spawn-claude.sh`).
- [x] `LOOM_RUNTIME=codex` / `runtimes.default: "codex"` → dispatches through `spawn-codex.sh`.
- [x] Unknown runtime → exit `78`, naming the runtime, its source, and runners present.
- [x] Error names the *selected* runtime + its missing prerequisite (not unconditionally Claude).
- [x] Still refuses outside a Loom repo and with no issue-number arg (unchanged).
- [x] Smoke coverage for default / `LOOM_RUNTIME=codex` / `runtimes.default` / unknown-runtime paths, stubbed-runner pattern (no real claude/codex, no live tokens).
- [x] `sweep_registry.rs` `resolve_spawn_bin()` default left unchanged (out of scope).

## Scope note — daemon sibling gap left out (per issue Scope decision)

`loom-daemon/src/sweep_registry.rs`'s `resolve_spawn_bin()` defaults straight to `spawn-claude.sh`, so every daemon-dispatched sweep is *also* hardwired to Claude — an independent, larger-blast-radius bug (production-critical for every daemon dispatch, covered by Rust tests asserting on `spawn-claude.sh` by name). Deliberately not touched here; it deserves its own curated issue with the same fix shape (route through `spawn-worker.sh`). Flagged in `runtime-adapters.md`.

## Test results

- `bash defaults/scripts/tests/test-loom-dispatcher.sh` → 86/86 pass (6 new sweep cases across Tests 19-24).
- `bash defaults/scripts/tests/test-spawn-worker.sh` → 26/26 pass (no regression).
- `shellcheck scripts/loom` → clean.

## Files changed

- `scripts/loom` — `loom_cmd_sweep()` rewritten to route through `spawn-worker.sh`; Claude-only prereq gate removed.
- `defaults/scripts/tests/test-loom-dispatcher.sh` — sweep runtime-resolution smoke coverage.
- `defaults/docs/runtime-adapters.md` — note `loom sweep` as a migrated `spawn-worker.sh` caller + the `sweep_registry.rs` sibling gap.

Closes #4480

🤖 Generated with [Claude Code](https://claude.com/claude-code)