### PR TITLE
feat(fleet): sync-labels.sh --repo flag + "bringing a new repo online" runbook

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -2796,6 +2796,139 @@ logged only at `debug!` (invisible at the default `info` level), and the
   "N of M registered workspaces are inert" state is diagnosable without
   reading every root's config file by hand.
 
+#### Bringing a new repo online (runbook, #4498)
+
+`loom-daemon workspace add` registers a repo for *dispatch*. It does **not** give
+that repo a **queue** — no role runner means no Curator, Judge, Champion, Auditor,
+or Guide runs there, so nothing ever reaches `loom:issue` and dispatch has nothing
+to pick up. A newly-registered root therefore shows `ROLES off` in
+`loom-daemon status` and sits inert indefinitely, looking registered-and-healthy.
+The steps below are what turns a registered root into a *self-feeding* one.
+
+**1. Choose a config surface.** `autonomous.roleRunner.enabled` is read from the
+root's own **effective** config, which `config_resolver::resolve_effective_config`
+(`loom-daemon/src/config_resolver.rs:143-153`) deep-merges from four tiers,
+lowest → highest priority:
+
+| # | Tier | Path | Tracked? |
+|---|------|------|----------|
+| 1 | machine-level defaults | `~/.local/share/loom/config/defaults.json` (override: `LOOM_CONFIG_DEFAULTS_FILE`; set it empty to disable the tier) | no — outside every checkout |
+| 2 | legacy per-repo | `<root>/.loom/config.json` | yes |
+| 3 | project | `<root>/.loom-project/project.json` | yes (Epic #3835 Phase 6) |
+| 4 | host-local | `<root>/.loom-local/local.json` | no (git-ignored) |
+
+Two valid ways to flip a root on, with very different blast radii:
+
+- **Machine-level (tier 1)** — one edit per *host* turns on **every** registered
+  root that does not set `roleRunner.enabled` itself. This is the right lever for
+  a fleet of repos you own that should all behave the same way. Because it is the
+  lowest-priority tier, any repo that wants to opt back out can simply set
+  `enabled: false` in its own config and win.
+- **Per-repo (tier 2/3/4)** — one edit per *repo*, in that repo's own checkout.
+  Use this when a root needs a different `roles`/`onIdle` set than the host
+  default, or when the repo's maintainers should see the setting in review.
+
+Either way the JSON block is the same shape as the example above:
+
+```json
+{
+  "autonomous": {
+    "roleRunner": {
+      "enabled": true,
+      "roles": ["champion", "curator", "judge", "auditor", "guide"],
+      "intervalSecs": 300,
+      "onIdle": ["champion"]
+    }
+  }
+}
+```
+
+Remember `onIdle` is **inert unless the work finder is enabled** for that root,
+and that `LOOM_ROLE_RUNNER` (env) outranks all four config tiers.
+
+**2. Sync the repo's labels.** The whole coordination protocol is label-based, so
+a repo with no `loom:*` labels cannot hold a queue — a Curator that tries to apply
+`loom:curated` just fails. Since every GitHub label operation is a `gh label` API
+call, this needs **no checkout of the target repo**: run
+`sync-labels.sh --repo OWNER/NAME` from a workspace that already has an
+authoritative `.github/labels.yml` (labels.yml is read locally; only the target
+moves). Preview first — `--repo` points the default-label *deletions* at a repo
+you are not standing in, so a typo'd NWO is worth catching:
+
+```bash
+# From a checkout whose .github/labels.yml is the source of truth (e.g. loom):
+for r in OWNER/klayout-tools \
+         OWNER/gf180-bandgap OWNER/gf180-ldo OWNER/gf180-temp-por \
+         OWNER/gf180-pll OWNER/gf180-sar-adc OWNER/gf180-trng \
+         OWNER/sky130-bandgap; do
+  ./.loom/scripts/sync-labels.sh --repo "$r" --dry-run   # preview
+done
+# ...then re-run without --dry-run to apply.
+```
+
+`--dry-run` is deliberately forge-free (it reports intent from labels.yml alone
+and makes zero `gh` calls), so it also validates the parse and the NWO offline.
+`--repo` is GitHub-only — for a Gitea root, run `sync-labels.sh` from a checkout
+of that repo so the Gitea helpers can resolve a base URL and token.
+
+**3. Refresh a stale install.** A root installed before the machine-level daemon
+model carries a committed file-copy of `.loom/` that **shadows** the machine
+checkout and drifts stale — including the role prompts the role runner invokes.
+Run `loom migrate --dry-run` then `loom migrate` in that root (see
+`defaults/docs/machine-dispatcher.md` → `loom migrate`); for a still-file-copy
+install that is not being migrated yet, `./.loom/scripts/resync-installed.sh`
+refreshes the copies in place.
+
+A repo on the **v0.15 multi-repo canary vintage** predates a cluster of
+multi-repo fixes. Rule these out before blaming a new symptom on config — several
+of them present exactly as "registered, enabled, and still nothing happens":
+
+| Issue | Symptom if the install predates the fix |
+|-------|------------------------------------------|
+| #3936 | `loom-daemon status`'s token-capacity summary contradicts its own per-token table |
+| #3937 | sweep-registry label flips run `gh issue edit` unscoped — cross-repo claims fail, yet dispatch proceeds *unclaimed* |
+| #3938 | dispatched sweeps die in ~2s: no `.loom/tokens/` pool outside the primary workspace (fixed by the shared machine-level pool — see "Token pool provisioning for managed repos" above; bootstrap it once per host) |
+| #3939 | no backoff/quarantine for insta-crashing dispatches — the same few issues are re-dispatched every tick, starving the rest of the queue |
+
+**4. Verify.** In order, because each step's failure looks like the next one's:
+
+1. `loom-daemon status` — the new root appears in "Managed repos" with
+   `ROLES on`. Still `off` means the config edit did not land in a tier that root
+   actually reads (tier 1 is per-*host*: check `LOOM_CONFIG_DEFAULTS_FILE` is not
+   set to something else, and that the daemon process's `$HOME` is the one you
+   edited). A restart is not required — each role task re-reads the registry and
+   per-root config every tick.
+2. Within one Auditor/Curator interval (default 300s), expect **≥1 issue labeled
+   `loom:triage`** in that repo — the Auditor files what it finds, the Curator
+   enriches it. An empty queue after two intervals with `ROLES on` means the role
+   invocation itself is failing; role failures are never fatal and are logged +
+   skipped, so read the daemon log rather than waiting.
+3. Then, and only then, expect dispatch: `loom:issue` → a sweep → a PR.
+
+> **Caveat (#4501).** A dispatched child that dies immediately — e.g. on a
+> `Fable 5 limit` classified as non-retryable, where dispatch inherited the
+> interactive model default instead of pinning a work model — is
+> indistinguishable at the forge from "the role runner is still off": both look
+> like a repo with no activity. Confirm step 1's `ROLES on` and step 2's
+> `loom:triage` issue *before* concluding anything about dispatch, and treat an
+> insta-dying child as #4501 rather than a config problem.
+
+**Which steps an agent cannot do for you.** Steps 1, 3, and 4 are operator steps,
+run by hand on **each daemon host** — repeat them per host, since tier 1 is
+per-machine and a multi-host fleet has one copy of it per machine:
+
+- **Step 1 (config edit)** and **step 3 (install refresh)** are host-local
+  filesystem writes: a file in the operator's home directory, or another repo's
+  own checkout. Neither is reachable from a Builder worktree — the
+  worktree-isolation guard confines Edit/Write to the current worktree, and the
+  machine-level defaults file lives outside every git checkout entirely.
+- **Step 4 (verification)** needs `loom-daemon status` against the *running*
+  daemon on that host, plus a real Auditor/Curator cycle to elapse. An agent can
+  read the forge state but cannot observe another host's daemon.
+- **Step 2 (label sync)** is the exception: `--repo` makes it pure forge API, so
+  it runs from any checkout with `gh` auth for the targets — one loop covers the
+  whole target set at once.
+
 ### Durable operator watches (#3971)
 
 **Problem it fixes.** An operator armed a 4-hour background poll watching two

--- a/defaults/scripts/sync-labels.sh
+++ b/defaults/scripts/sync-labels.sh
@@ -11,9 +11,24 @@
 #
 # Usage:
 #   .loom/scripts/sync-labels.sh [WORKTREE_PATH]
+#   .loom/scripts/sync-labels.sh --repo OWNER/NAME [--dry-run] [WORKTREE_PATH]
 #
 #   WORKTREE_PATH  Directory containing .github/labels.yml and a git remote.
 #                  Defaults to the current directory.
+#
+# --repo OWNER/NAME (#4498) retargets the sync at an arbitrary GitHub repo
+# while still reading labels.yml from WORKTREE_PATH. Because every GitHub label
+# operation here is a `gh label` API call, no local checkout of the target repo
+# is needed — so one workspace can bring a whole fleet of repos online:
+#
+#   for r in owner/klayout-tools owner/gf180-ldo owner/sky130-bandgap; do
+#     .loom/scripts/sync-labels.sh --repo "$r"
+#   done
+#
+# --repo bypasses forge detection entirely (the target is named, not inferred
+# from a git remote) and is GitHub-only. Pair it with --dry-run first: --repo
+# makes the default-label deletions land on a repo you are not standing in, so
+# a typo'd NWO is worth previewing.
 #
 # This is the installed-tree counterpart of the source-only
 # scripts/install/sync-labels.sh. It is self-contained apart from the
@@ -26,36 +41,99 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage: sync-labels.sh [WORKTREE_PATH]
+       sync-labels.sh --repo OWNER/NAME [--dry-run] [WORKTREE_PATH]
 
 Sync Loom workflow labels from .github/labels.yml onto the forge (GitHub or
 Gitea). Creates missing labels, updates existing ones to match labels.yml,
 and removes GitHub's default labels.
 
 Arguments:
-  WORKTREE_PATH   Directory containing .github/labels.yml (default: .)
+  WORKTREE_PATH     Directory containing .github/labels.yml (default: .)
 
 Options:
-  -h, --help      Show this help and exit.
+      --repo OWNER/NAME
+                    Sync onto this GitHub repo instead of the one detected from
+                    WORKTREE_PATH's git remote. labels.yml is still read from
+                    WORKTREE_PATH, so no checkout of the target is needed.
+                    GitHub-only (uses the gh CLI).
+      --dry-run     Print the label operations that would run and exit without
+                    calling the forge. Recommended before a --repo run.
+  -h, --help        Show this help and exit.
 EOF
 }
 
 WORKTREE_PATH="."
-case "${1:-}" in
-  -h|--help)
-    usage
-    exit 0
-    ;;
-  -*)
-    echo "Unknown option: $1" >&2
+REPO_OVERRIDE=""
+DRY_RUN=0
+POSITIONAL_SEEN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --repo)
+      if [[ $# -lt 2 || -z "$2" ]]; then
+        echo "Option --repo requires an OWNER/NAME argument" >&2
+        usage >&2
+        exit 2
+      fi
+      REPO_OVERRIDE="$2"
+      shift 2
+      ;;
+    --repo=*)
+      REPO_OVERRIDE="${1#--repo=}"
+      if [[ -z "$REPO_OVERRIDE" ]]; then
+        echo "Option --repo requires an OWNER/NAME argument" >&2
+        usage >&2
+        exit 2
+      fi
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --)
+      shift
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      if [[ "$POSITIONAL_SEEN" -eq 1 ]]; then
+        echo "Unexpected extra argument: $1" >&2
+        usage >&2
+        exit 2
+      fi
+      WORKTREE_PATH="$1"
+      POSITIONAL_SEEN=1
+      shift
+      ;;
+  esac
+done
+
+# Validate --repo eagerly: an NWO typo would otherwise be discovered only after
+# the first default-label deletion had already been attempted somewhere.
+if [[ -n "$REPO_OVERRIDE" ]]; then
+  if [[ ! "$REPO_OVERRIDE" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+    echo "Invalid --repo value: '$REPO_OVERRIDE' (expected OWNER/NAME)" >&2
     usage >&2
     exit 2
-    ;;
-  "")
-    ;;
-  *)
-    WORKTREE_PATH="$1"
-    ;;
-esac
+  fi
+  # --repo names a GitHub repo and drives it purely through `gh label`; there is
+  # no equivalent "point at an arbitrary remote" path for the Gitea helpers
+  # (they need a resolved base URL + token for that host), so fail loudly rather
+  # than silently syncing GitHub while the operator expects Gitea.
+  if [[ "$(printf '%s' "${LOOM_FORGE_TYPE:-}" | tr '[:upper:]' '[:lower:]')" == "gitea" ]]; then
+    echo "--repo is GitHub-only, but LOOM_FORGE_TYPE=gitea is set" >&2
+    echo "Run sync-labels.sh from a checkout of the Gitea repo instead." >&2
+    exit 2
+  fi
+fi
 
 # Source the shipped forge-agnostic helper library. Provides forge_detect,
 # forge_get_repo_nwo, forge_split_nwo, and gitea_api.
@@ -89,18 +167,33 @@ warning() {
 
 cd "$WORKTREE_PATH"
 
-# Detect forge type (github/gitea) from env, config, or git remote.
-forge_detect
+if [[ -n "$REPO_OVERRIDE" ]]; then
+  # Explicit target: skip forge_detect / forge_get_repo_nwo entirely. Both of
+  # those read the *current directory's* git remote, which is precisely what
+  # --repo exists to avoid needing — WORKTREE_PATH supplies labels.yml, the
+  # flag supplies the target, and no checkout of the target is required.
+  FORGE_TYPE="github"
+  REPO="$REPO_OVERRIDE"
+  if [[ "$DRY_RUN" -eq 0 ]] && ! command -v gh >/dev/null 2>&1; then
+    error "--repo requires the gh CLI, which was not found on PATH"
+  fi
+else
+  # Detect forge type (github/gitea) from env, config, or git remote.
+  forge_detect
 
-# Resolve the target repository NWO (owner/repo).
-REPO="$(forge_get_repo_nwo || true)"
-if [[ -z "$REPO" ]]; then
-  error "Could not determine repository from git remote"
+  # Resolve the target repository NWO (owner/repo).
+  REPO="$(forge_get_repo_nwo || true)"
+  if [[ -z "$REPO" ]]; then
+    error "Could not determine repository from git remote"
+  fi
 fi
 # Populate FORGE_OWNER / FORGE_REPO for the Gitea API paths.
 forge_split_nwo "$REPO"
 
 info "Target repository: $REPO (${FORGE_TYPE})"
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  info "Dry run: no labels will be created, updated, or deleted."
+fi
 
 LABELS_FILE=".github/labels.yml"
 
@@ -240,7 +333,9 @@ DEFAULT_LABELS=(
 
 info "Removing default labels..."
 for label in "${DEFAULT_LABELS[@]}"; do
-  if [[ "$FORGE_TYPE" == "github" ]]; then
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    info "[dry-run] would delete default label: $label"
+  elif [[ "$FORGE_TYPE" == "github" ]]; then
     github_delete_label "$label"
   elif [[ "$FORGE_TYPE" == "gitea" ]]; then
     gitea_delete_label "$label"
@@ -269,7 +364,13 @@ while IFS= read -u 3 -r line; do
       color="${BASH_REMATCH[1]}"
     fi
 
-    if [[ "$FORGE_TYPE" == "github" ]]; then
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      # Deliberately forge-free: a dry run must be answerable offline (it is the
+      # preview an operator runs before pointing --repo at a repo they are not
+      # standing in), so it reports intent from labels.yml alone and never asks
+      # the forge which labels already exist.
+      info "[dry-run] would create or update label: $name (color=$color)"
+    elif [[ "$FORGE_TYPE" == "github" ]]; then
       github_sync_label "$name" "$description" "$color"
     elif [[ "$FORGE_TYPE" == "gitea" ]]; then
       gitea_sync_label "$name" "$description" "$color"
@@ -280,7 +381,11 @@ while IFS= read -u 3 -r line; do
 done 3< "$LABELS_FILE"
 
 if [ "$label_count" -gt 0 ]; then
-  success "Synced $label_count labels"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    success "Dry run complete: $label_count labels would be synced to $REPO"
+  else
+    success "Synced $label_count labels"
+  fi
 else
   warning "No labels found in $LABELS_FILE"
 fi

--- a/defaults/scripts/tests/test-sync-labels-repo-flag.sh
+++ b/defaults/scripts/tests/test-sync-labels-repo-flag.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# test-sync-labels-repo-flag.sh - Unit tests for sync-labels.sh's --repo /
+# --dry-run flags (issue #4498).
+#
+# Why --repo exists: bringing a new repo online in a daemon fleet needs that
+# repo's Loom labels created on the forge. Every GitHub label operation in
+# sync-labels.sh is already a `gh label` API call, so the only thing that
+# forced a local checkout of the target was target *resolution* — the script
+# inferred the NWO from the current directory's git remote via
+# forge_detect/forge_get_repo_nwo. `--repo OWNER/NAME` names the target
+# instead, so one workspace can sync labels onto klayout-tools and every
+# gf180-*/sky130-* canary without cloning any of them.
+#
+# This is a black-box test: sync-labels.sh is a full CLI script, so we stub
+# `gh` on PATH, run the real script as a subprocess from a scratch directory,
+# and assert on exit codes, stderr, and the recorded `gh` argv log.
+#
+# The load-bearing assertions:
+#   1. --repo resolves the target WITHOUT consulting the forge/git for the NWO
+#      (no `gh repo view` in the log) and works from a directory that is not a
+#      git repo at all — the short-circuit, proven rather than asserted.
+#   2. Every mutating gh call carries `-R <override>`, never the invoking repo.
+#   3. labels.yml is still read from WORKTREE_PATH (the source stays local;
+#      only the target moves).
+#   4. --dry-run is completely forge-free (zero gh invocations) — it is the
+#      preview an operator runs before pointing deletions at a repo they are
+#      not standing in.
+#   5. The no-flag path is byte-for-byte the old behavior (additive flag):
+#      NWO still comes from `gh repo view`, and a directory with no resolvable
+#      remote still hard-errors.
+#   6. Argument-parsing rejections: missing/invalid NWO, unknown option, extra
+#      positional, and --repo combined with a Gitea forge.
+#
+# Usage:
+#   ./defaults/scripts/tests/test-sync-labels-repo-flag.sh
+
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPTS_DIR/../.." && pwd)"
+SLS="$SCRIPTS_DIR/sync-labels.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected: '$expected'"
+        echo "    Actual:   '$actual'"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if ! printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Unexpected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+if [[ ! -x "$SLS" ]]; then
+    echo -e "${RED}FATAL${NC}: $SLS not found or not executable" >&2
+    exit 2
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP" 2>/dev/null || true' EXIT
+
+STUB_DIR="$TMP/stub"
+mkdir -p "$STUB_DIR"
+
+# --- Stub gh on PATH ---------------------------------------------------------
+# Appends every invocation's argv to $LOOM_TEST_GH_LOG (one line per call), so a
+# test can assert both what WAS called and what was NOT.
+#
+#   gh repo view ...   -> echoes $LOOM_TEST_GH_NWO, or exits 1 when it is empty
+#                         (simulating "no resolvable remote here")
+#   gh label list ...  -> echoes nothing (script takes the `create` branch)
+#   gh label create|edit|delete ... -> exit 0
+cat > "$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${LOOM_TEST_GH_LOG:?stub gh: LOOM_TEST_GH_LOG not set}"
+
+case "$1" in
+  repo)
+    if [[ -z "${LOOM_TEST_GH_NWO:-}" ]]; then
+      echo "stub gh: no remote configured" >&2
+      exit 1
+    fi
+    printf '%s\n' "$LOOM_TEST_GH_NWO"
+    exit 0
+    ;;
+  label)
+    case "$2" in
+      list)   exit 0 ;;
+      create|edit|delete) exit 0 ;;
+    esac
+    echo "stub gh: unhandled label args: $*" >&2
+    exit 3
+    ;;
+esac
+echo "stub gh: unhandled args: $*" >&2
+exit 3
+STUB
+chmod +x "$STUB_DIR/gh"
+
+# --- Scratch source tree -----------------------------------------------------
+# Deliberately NOT a git repo: `git remote get-url origin` and `git rev-parse`
+# find nothing here, which is exactly the condition --repo must tolerate. It
+# holds only the labels.yml the sync reads (the source stays local; --repo
+# moves the target).
+SRC="$TMP/src"
+mkdir -p "$SRC/.github"
+cat > "$SRC/.github/labels.yml" <<'EOF'
+# BEGIN LOOM LABELS
+- name: loom:issue
+  description: "Approved and ready for a Builder"
+  color: "3B82F6"
+- name: loom:pr
+  description: "Approved pull request"
+  color: "10B981"
+# END LOOM LABELS
+EOF
+
+GH_LOG="$TMP/gh.log"
+
+# Run the real script with the stub gh first on PATH, from $SRC.
+#   run_sls [--nwo NWO] -- <script args...>
+# Sets: RC, OUT (merged stdout+stderr), LOG (recorded gh argv lines).
+RC=0
+OUT=""
+LOG=""
+run_sls() {
+    local nwo=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --nwo) nwo="$2"; shift 2 ;;
+            --) shift; break ;;
+            *) break ;;
+        esac
+    done
+    : > "$GH_LOG"
+    OUT="$(
+        cd "$SRC" || exit 99
+        PATH="$STUB_DIR:$PATH" \
+        LOOM_TEST_GH_LOG="$GH_LOG" \
+        LOOM_TEST_GH_NWO="$nwo" \
+        LOOM_FORGE_TYPE="${LOOM_FORGE_TYPE_OVERRIDE:-}" \
+        bash "$SLS" "$@" 2>&1
+    )"
+    RC=$?
+    LOG="$(cat "$GH_LOG")"
+}
+
+echo ""
+echo "=== --repo short-circuits NWO resolution (no git remote needed) ==="
+
+# The scratch dir has no git remote and the stub `gh repo view` fails, so the
+# legacy resolution path cannot produce an NWO. --repo must still succeed.
+run_sls -- --repo octocat/hello-world
+assert_eq "0" "$RC" "--repo succeeds in a directory with no resolvable remote"
+assert_contains "$OUT" "Target repository: octocat/hello-world (github)" \
+    "--repo resolves REPO to the flag value"
+assert_not_contains "$LOG" "repo view" \
+    "--repo never calls 'gh repo view' (forge_get_repo_nwo short-circuited)"
+assert_contains "$LOG" "label delete bug -R octocat/hello-world" \
+    "default-label deletion targets the override NWO"
+assert_contains "$LOG" "label create loom:issue -R octocat/hello-world" \
+    "label create targets the override NWO"
+assert_contains "$OUT" "Synced 2 labels" \
+    "labels.yml is still read from WORKTREE_PATH (both labels synced)"
+# Every recorded gh call must name exactly one target, and it must be the
+# override: a stray fallback to remote-based resolution would surface here as a
+# second distinct -R value (or as a call with no -R at all).
+assert_eq "-R octocat/hello-world" \
+    "$(printf '%s\n' "$LOG" | grep -o -- '-R [^ ]*' | sort -u | tr '\n' ' ' | sed 's/ *$//')" \
+    "the override NWO is the ONLY -R target in the whole gh log"
+assert_eq "" \
+    "$(printf '%s\n' "$LOG" | grep -v -- '-R octocat/hello-world' || true)" \
+    "no gh call was made without the override target"
+
+# --repo=OWNER/NAME is the same flag.
+run_sls -- --repo=octocat/hello-world
+assert_eq "0" "$RC" "--repo=OWNER/NAME form accepted"
+assert_contains "$OUT" "Target repository: octocat/hello-world (github)" \
+    "--repo= form resolves the same target"
+
+# The flag order relative to the positional path must not matter.
+run_sls -- --repo octocat/hello-world "$SRC"
+assert_eq "0" "$RC" "--repo composes with an explicit WORKTREE_PATH positional"
+assert_contains "$OUT" "Target repository: octocat/hello-world (github)" \
+    "--repo plus positional still targets the override"
+
+echo ""
+echo "=== --dry-run is forge-free ==="
+
+run_sls -- --repo octocat/hello-world --dry-run
+assert_eq "0" "$RC" "--repo --dry-run exits 0"
+assert_eq "" "$LOG" "--dry-run makes ZERO gh calls"
+assert_contains "$OUT" "[dry-run] would delete default label: bug" \
+    "--dry-run reports the default-label deletions it would make"
+assert_contains "$OUT" "[dry-run] would create or update label: loom:issue" \
+    "--dry-run reports the labels it would sync"
+assert_contains "$OUT" "Dry run complete: 2 labels would be synced to octocat/hello-world" \
+    "--dry-run names the resolved target in its summary"
+
+echo ""
+echo "=== No-flag path is unchanged (the flag is additive) ==="
+
+# With a resolvable NWO, the legacy path still resolves via `gh repo view` and
+# targets whatever that returned — untouched by this change.
+run_sls --nwo owner/from-remote --
+assert_eq "0" "$RC" "no-flag run succeeds when the NWO resolves"
+assert_contains "$LOG" "repo view" \
+    "no-flag run still calls 'gh repo view' (legacy resolution intact)"
+assert_contains "$OUT" "Target repository: owner/from-remote (github)" \
+    "no-flag run resolves the NWO from the forge, not from a flag"
+assert_contains "$LOG" "label create loom:issue -R owner/from-remote" \
+    "no-flag run targets the resolved repo"
+assert_not_contains "$OUT" "dry-run" \
+    "no-flag run emits no dry-run output"
+
+# ...and with nothing resolvable it must still hard-error, as before.
+run_sls --
+assert_eq "1" "$RC" "no-flag run in a non-repo still fails"
+assert_contains "$OUT" "Could not determine repository from git remote" \
+    "no-flag failure keeps its original error message"
+
+# --dry-run alone (no --repo) previews against the detected repo.
+run_sls --nwo owner/from-remote -- --dry-run
+assert_eq "0" "$RC" "--dry-run without --repo exits 0"
+assert_contains "$OUT" "Target repository: owner/from-remote (github)" \
+    "--dry-run without --repo still detects the local repo"
+assert_not_contains "$LOG" "label create" \
+    "--dry-run without --repo performs no label mutations"
+
+echo ""
+echo "=== Argument-parsing rejections (exit 2, no forge contact) ==="
+
+run_sls -- --repo
+assert_eq "2" "$RC" "--repo with no value exits 2"
+assert_contains "$OUT" "Option --repo requires an OWNER/NAME argument" \
+    "--repo with no value explains itself"
+assert_eq "" "$LOG" "--repo with no value contacts no forge"
+
+run_sls -- --repo=
+assert_eq "2" "$RC" "--repo= with an empty value exits 2"
+
+for bad in bad-nwo owner/repo/extra "own er/repo" /repo owner/; do
+    run_sls -- --repo "$bad"
+    assert_eq "2" "$RC" "invalid --repo value '$bad' exits 2"
+    assert_contains "$OUT" "Invalid --repo value" \
+        "invalid --repo value '$bad' is reported as invalid"
+done
+
+run_sls -- --bogus
+assert_eq "2" "$RC" "unknown option exits 2"
+assert_contains "$OUT" "Unknown option: --bogus" "unknown option is named"
+
+run_sls -- "$SRC" extra
+assert_eq "2" "$RC" "a second positional argument exits 2"
+assert_contains "$OUT" "Unexpected extra argument: extra" \
+    "the extra positional is named (previously silently ignored)"
+
+echo ""
+echo "=== --repo is GitHub-only ==="
+
+LOOM_FORGE_TYPE_OVERRIDE="gitea" run_sls -- --repo octocat/hello-world
+assert_eq "2" "$RC" "--repo with LOOM_FORGE_TYPE=gitea exits 2"
+assert_contains "$OUT" "--repo is GitHub-only" \
+    "the Gitea combination fails loudly instead of silently syncing GitHub"
+assert_eq "" "$LOG" "the Gitea rejection contacts no forge"
+
+echo ""
+echo "=== --help documents the new flags ==="
+
+run_sls -- --help
+assert_eq "0" "$RC" "--help exits 0"
+assert_contains "$OUT" "--repo OWNER/NAME" "--help documents --repo"
+assert_contains "$OUT" "--dry-run" "--help documents --dry-run"
+
+echo ""
+echo "=== Installed-tree parity (.loom/scripts is a symlinked dir) ==="
+
+# AC: ".loom/scripts/sync-labels.sh reflects the change automatically". In this
+# repo .loom/scripts is a whole-directory symlink to defaults/scripts, so the
+# two paths must resolve to the same file — one edit covers both surfaces.
+INSTALLED="$REPO_ROOT/.loom/scripts/sync-labels.sh"
+if [[ -e "$INSTALLED" ]]; then
+    LINKED_REAL="$(cd "$(dirname "$INSTALLED")" && pwd -P)/$(basename "$INSTALLED")"
+    SOURCE_REAL="$(cd "$(dirname "$SLS")" && pwd -P)/$(basename "$SLS")"
+    assert_eq "$SOURCE_REAL" "$LINKED_REAL" \
+        ".loom/scripts/sync-labels.sh resolves to defaults/scripts/sync-labels.sh"
+else
+    echo "  SKIP: $INSTALLED not present (source-only checkout)"
+fi
+
+echo ""
+echo "────────────────────────────────"
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -3097,6 +3097,32 @@ fi
 echo ""
 
 # ==========================================================================
+# sync-labels.sh --repo / --dry-run (fleet onboarding, #4498)
+# ==========================================================================
+# Its own unit suite lives at defaults/scripts/tests/test-sync-labels-repo-flag.sh
+# (the --repo NWO short-circuit proven from a non-git directory, target
+# exclusivity in the gh argv log, the forge-free --dry-run preview, unchanged
+# no-flag resolution, and the argument-parsing rejections). Fold its result into
+# the installer suite so it runs in CI + the build gate rather than dev-only.
+echo "Test: sync-labels.sh --repo flag suite (test-sync-labels-repo-flag.sh)"
+SYNC_LABELS_TEST="$DEFAULTS_DIR/scripts/tests/test-sync-labels-repo-flag.sh"
+if [[ -f "$SYNC_LABELS_TEST" ]]; then
+  set +e
+  SYNC_LABELS_TEST_OUT=$(bash "$SYNC_LABELS_TEST" 2>&1)
+  SYNC_LABELS_TEST_RC=$?
+  set -e
+  if [[ $SYNC_LABELS_TEST_RC -eq 0 ]]; then
+    pass "test-sync-labels-repo-flag.sh: all cases passed"
+  else
+    fail "test-sync-labels-repo-flag.sh failed (rc=$SYNC_LABELS_TEST_RC)"
+    echo "$SYNC_LABELS_TEST_OUT" | tail -20
+  fi
+else
+  fail "test-sync-labels-repo-flag.sh not found at $SYNC_LABELS_TEST"
+fi
+echo ""
+
+# ==========================================================================
 # Summary
 # ==========================================================================
 echo "======================================"


### PR DESCRIPTION
Closes #4498

## Problem

`loom-daemon workspace add` gives a repo **dispatch** but not a **queue**. The role runner's `enabled` gate is resolved per root from that root's own effective config (#4377), so a newly-registered root shows `ROLES off` in `loom-daemon status` and sits inert indefinitely while looking registered-and-healthy — no Curator/Judge/Champion/Auditor/Guide runs there, so nothing ever reaches `loom:issue`.

Two things were missing to turn a registered root into a self-feeding one:

1. A way to create that repo's `loom:*` labels (the coordination protocol is label-based — a Curator that tries to apply `loom:curated` to a repo without the label just fails). `sync-labels.sh` already did exactly this work over the `gh label` API, but resolved its target from the *current directory's* git remote, so it required a local checkout of every target.
2. A written procedure. The per-root gate, the four config tiers, the label prerequisite, the stale-install friction, and the verification order were each documented separately or not at all.

## What this delivers

### 1. `sync-labels.sh --repo OWNER/NAME`

Every GitHub label operation in the script was *already* a `gh label` API call. The only thing forcing a local checkout of the target was target **resolution** — `forge_detect` + `forge_get_repo_nwo` both read the current directory's git remote. `--repo` names the target instead and short-circuits both, so one workspace can bring a whole fleet online:

```bash
for r in OWNER/klayout-tools OWNER/gf180-ldo OWNER/sky130-bandgap; do
  ./.loom/scripts/sync-labels.sh --repo "$r"
done
```

`labels.yml` is still read from `WORKTREE_PATH` — only the *target* moves. `.loom/scripts/sync-labels.sh` needs no separate edit (`.loom/scripts` is a whole-directory symlink to `defaults/scripts`; a test assertion pins that).

### 2. `--dry-run`

Added because `--repo` introduces a new risk that did not exist before: it points the default-label **deletions** at a repo the operator is not standing in, so a typo'd NWO deletes 9 labels somewhere unintended. The dry run is deliberately **forge-free** — zero `gh` calls, reporting intent from `labels.yml` alone — so it validates the parse *and* the resolved target offline, before anything is mutated.

`--repo` is also validated eagerly against an `OWNER/NAME` pattern (rather than discovered after the first deletion attempt) and rejected outright when `LOOM_FORGE_TYPE=gitea`, instead of silently syncing GitHub while the operator expects Gitea.

**Behavior with no new flags is unchanged**: same forge detection, same NWO resolution path, same error text. The one deliberate difference: a second positional argument now exits 2 instead of being silently ignored.

### 3. Runbook

New `#### Bringing a new repo online` subsection in `defaults/docs/daemon-reference.md`, placed directly after the per-root `enabled`-not-inherited callout it follows from:

- **Config surface** — the four tiers (machine-level `~/.local/share/loom/config/defaults.json` / `LOOM_CONFIG_DEFAULTS_FILE` → `.loom/config.json` → `.loom-project/project.json` → `.loom-local/local.json`, cited to `config_resolver.rs:143-153`) with the machine-level-vs-per-repo **blast-radius tradeoff** spelled out, plus the exact `roleRunner` JSON block.
- **Label sync** via the new flag.
- **Stale-install refresh** (`loom migrate` / `resync-installed.sh`) with a #3936-#3939 friction table — several of those present *exactly* as "registered, enabled, still nothing happens", so they are worth ruling out before blaming config.
- **Ordered verification**: `ROLES on` → a `loom:triage` issue within one interval → dispatch. Ordered deliberately, because each step's failure mode looks like the next step's.
- **#4501 caveat**: a child that dies instantly on a model limit is indistinguishable at the forge from "the role runner is still off" — both look like a repo with no activity.
- A closing section naming which steps an agent structurally *cannot* perform (host-local writes outside any worktree; observing another host's daemon) versus step 2, which `--repo` makes runnable from anywhere.

## Tests

New `defaults/scripts/tests/test-sync-labels-repo-flag.sh` — 52 assertions, black-box against a stubbed `gh` that logs its argv.

It **proves** the short-circuit rather than asserting it: the `--repo` cases run from a scratch directory that is not a git repo *and* whose stub `gh repo view` fails, so the legacy resolution path could not have produced an NWO. If the short-circuit regressed, those cases fail rather than silently passing. Also pinned:

- **Target exclusivity** — the override is the only `-R` value in the entire gh log, and no call is made without it (a stray fallback to remote-based resolution surfaces as a second distinct target).
- **Zero-call dry run** — the gh log is empty, which is the load-bearing safety property.
- **Unchanged no-flag path**, both directions: with a resolvable NWO it still calls `gh repo view` and targets what that returned; with nothing resolvable it still hard-errors with the original message.
- Every parse rejection (missing value, 5 invalid NWO shapes, unknown option, extra positional, Gitea combination), each confirmed to contact no forge.
- Installed-tree symlink parity.

Folded into `scripts/test-installer.sh` so it runs in **CI + the build gate** rather than dev-only.

### Results

| Check | Result |
|-------|--------|
| `test-sync-labels-repo-flag.sh` | 52/52 passed |
| `scripts/test-installer.sh` (full) | 162 passed, 0 failed |
| `tests/install/test-uninstall-labels-block.sh` | 16/16 passed |
| `bash -n` on all touched scripts | clean |
| `shellcheck --severity=warning` over all of `defaults/scripts/**/*.sh` (the CI leg) | clean |
| `check-phantom-labels` / `check-labels-drift` / `check-label-descriptions` / `check-claude-md-budget` | all OK |

`cargo test` is unaffected — no `.rs`, `Cargo.toml`, or `Cargo.lock` file is touched by this PR (bash + docs only).

## Out of scope (operator steps, called out as such in the runbook)

Flipping `autonomous.roleRunner.enabled` for the target roots, refreshing their installs, and observing a seeded backlog all require writes to host-local paths outside any Loom checkout (a home-directory file, or another repo's own checkout) or observation of a daemon on another host. Neither is reachable from a Builder worktree, so the runbook documents them as per-host manual steps rather than pretending to automate them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
