### PR TITLE
feat: route daemon sweeps through runtime adapters

### DIFF
--- a/defaults/docs/runtime-adapters.md
+++ b/defaults/docs/runtime-adapters.md
@@ -400,8 +400,11 @@ LOOM_RUNTIME=claude .loom/scripts/spawn-worker.sh --use-wrapper -p "..."
 ```
 
 Callers migrate from `spawn-claude.sh` to `spawn-worker.sh` to gain runtime
-selection; until they do, `spawn-claude.sh` keeps working unchanged (existing
-daemon/tooling callers are intentionally left on the direct path in Phase 1).
+selection; direct `spawn-claude.sh` callers remain supported. The daemon
+`SweepRegistry` uses this dispatcher and sends generic `--effort`,
+`--dangerously-skip-permissions`, and `--use-wrapper` conventions. Each adapter
+must consume or translate these options and must not pass options unsupported
+by its CLI.
 
 The machine-level `loom sweep <N>` dispatcher (`scripts/loom`'s `loom_cmd_sweep`)
 is one such migrated caller (#4480): it resolves the repo's `spawn-worker.sh` and
@@ -409,9 +412,24 @@ execs `spawn-worker.sh -p "/loom:sweep <N>" --dangerously-skip-permissions`
 instead of `claude` directly, so a Codex-hosted (or any non-Claude) operator can
 dispatch the canonical single-issue lifecycle. With nothing configured this stays
 byte-for-byte the old `claude -p ... --dangerously-skip-permissions` invocation
-(via `spawn-worker.sh` → `spawn-claude.sh`). The daemon's own
-`sweep_registry.rs` dispatch still defaults straight to `spawn-claude.sh` — a
-sibling gap tracked separately, deliberately out of #4480's scope.
+(via `spawn-worker.sh` → `spawn-claude.sh`).
+
+### Adapter observability markers
+
+Daemon-compatible runners emit a small, secret-free contract on stderr:
+
+```text
+# LOOM_RUNTIME_RESOLVED runtime=<runtime>
+# LOOM_ACCOUNT name=<account-or-profile>   # optional
+# LOOM_CLI_START runtime=<runtime>
+```
+
+The dispatcher emits runtime resolution, an adapter emits account/profile
+selection when available, and the runner emits CLI-start immediately before
+launching the runtime CLI. Account values are display names only; credential
+values and credential paths must never appear. Parsers anchor these markers
+after the newest daemon dispatch header. Historical `spawn-claude:` preamble
+and `# CLAUDE_CLI_START` records remain supported.
 
 ### Runtime resolution (precedence)
 

--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -1776,6 +1776,7 @@ run_with_retry() {
         # distinguish wrapper pre-flight output from actual Claude CLI output.
         # The "# " prefix means it is also filtered as a header line.
         echo "# CLAUDE_CLI_START" >&2
+        echo "# LOOM_CLI_START runtime=claude" >&2
         set +e  # Temporarily disable errexit to capture exit code
         unset CLAUDECODE  # Prevent nested session guard from blocking subprocess
         # Export per-agent config dir if set (for session isolation)

--- a/defaults/scripts/spawn-claude.sh
+++ b/defaults/scripts/spawn-claude.sh
@@ -417,6 +417,7 @@ if [[ -z "${LOOM_SPAWN_NO_EXPORT:-}" && -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; th
     fi
 
     log_info "spawn-claude: using OAuth account '${LOOM_TOKEN_NAME:-unknown}' (mode=${LOOM_TOKEN_MODE:-unknown})"
+    echo "# LOOM_ACCOUNT name=${LOOM_TOKEN_NAME:-unknown}" >&2
     unset LOOM_TOKEN_MODE
 fi
 
@@ -527,4 +528,5 @@ if ! command -v claude >/dev/null 2>&1; then
     log_error "Install Claude Code or pass --use-wrapper to invoke claude-wrapper.sh."
     exit 127
 fi
+echo "# LOOM_CLI_START runtime=claude" >&2
 exec claude "${PASSTHROUGH_ARGS[@]}"

--- a/defaults/scripts/spawn-codex.sh
+++ b/defaults/scripts/spawn-codex.sh
@@ -271,6 +271,7 @@ EXPLICIT_MODEL=""
 HAS_SANDBOX_ARG=false
 EXPLICIT_SANDBOX=""
 HAS_EFFORT_OVERRIDE=false
+GENERIC_EFFORT=""
 HAS_SKIP_GIT_CHECK_ARG=false
 PASSTHROUGH_ARGS=()
 
@@ -300,6 +301,23 @@ while [[ $# -gt 0 ]]; do
             # (codex does not understand this Claude-specific flag) and mapped
             # to a Codex sandbox mode below.
             SKIP_PERMISSIONS=true
+            shift
+            ;;
+        --effort)
+            if [[ $# -lt 2 ]]; then
+                log_error "$1 requires a value"
+                exit 78
+            fi
+            GENERIC_EFFORT="$2"
+            shift 2
+            ;;
+        --effort=*)
+            GENERIC_EFFORT="${1#--effort=}"
+            shift
+            ;;
+        --use-wrapper)
+            # Generic daemon retry convention. Codex already owns retry
+            # behavior; consume the convention instead of forwarding it.
             shift
             ;;
         -m|--model)
@@ -436,6 +454,9 @@ if [[ "$HAS_EFFORT_OVERRIDE" == "true" ]]; then
     if [[ -n "${LOOM_EFFORT:-}" ]]; then
         log_info "spawn-codex: explicit -c model_reasoning_effort= wins over LOOM_EFFORT='$LOOM_EFFORT'"
     fi
+elif [[ -n "$GENERIC_EFFORT" ]]; then
+    PASSTHROUGH_ARGS+=(-c "model_reasoning_effort=$GENERIC_EFFORT")
+    log_info "spawn-codex: effort=$GENERIC_EFFORT (from --effort)"
 elif [[ -n "${LOOM_EFFORT:-}" ]]; then
     PASSTHROUGH_ARGS+=(-c "model_reasoning_effort=$LOOM_EFFORT")
     log_info "spawn-codex: effort=$LOOM_EFFORT (from LOOM_EFFORT)"
@@ -525,6 +546,7 @@ else
             CODEX_PROFILE_NAME="$(basename "$_requested_home")"
             # Directory NAME only — never the path contents, never auth.json.
             log_info "spawn-codex: using Codex profile '$CODEX_PROFILE_NAME' (source=$_requested_source)"
+            echo "# LOOM_ACCOUNT name=$CODEX_PROFILE_NAME" >&2
         else
             log_error "Codex profile requested via $_requested_source has no usable auth.json."
             log_error "Expected a regular, non-empty, readable file at <profile>/auth.json."
@@ -555,6 +577,7 @@ fi
 # Checked BEFORE the binary check so the mocked test can assert argv assembly on
 # a host with no `codex` installed at all.
 if [[ -n "${LOOM_CODEX_NO_EXEC:-}" ]]; then
+    echo "# LOOM_CLI_START runtime=codex" >&2
     echo "spawn-codex would-exec: codex ${CODEX_ARGS[*]}"
     exit 0
 fi
@@ -576,6 +599,7 @@ fi
 # plain pid-preserving `exec`. Note stdin is NOT redirected in the interactive
 # case — an operator at the keyboard needs it.
 if [[ "$HAS_PROMPT" != "true" || -n "${LOOM_CODEX_NO_CAPTURE:-}" ]]; then
+    echo "# LOOM_CLI_START runtime=codex" >&2
     exec codex ${CODEX_ARGS[@]+"${CODEX_ARGS[@]}"}
 fi
 
@@ -594,6 +618,7 @@ _stderr_file="$(mktemp -t loom-spawn-codex.XXXXXX 2>/dev/null || mktemp)"
 trap "rm -f '$_stderr_file'" EXIT
 
 set +e
+echo "# LOOM_CLI_START runtime=codex" >&2
 { codex ${CODEX_ARGS[@]+"${CODEX_ARGS[@]}"} </dev/null 2>&1 1>&3 3>&- \
     | tee "$_stderr_file" >&2; } 3>&1
 _exit_code=${PIPESTATUS[0]}

--- a/defaults/scripts/spawn-worker.sh
+++ b/defaults/scripts/spawn-worker.sh
@@ -140,4 +140,5 @@ if [[ ! -f "$RUNNER" ]]; then
 fi
 
 log_info "spawn-worker: runtime=$RUNTIME (from $RUNTIME_SOURCE) -> $(basename "$RUNNER")"
+echo "# LOOM_RUNTIME_RESOLVED runtime=$RUNTIME" >&2
 exec "$RUNNER" "$@"

--- a/defaults/scripts/tests/test-spawn-codex.sh
+++ b/defaults/scripts/tests/test-spawn-codex.sh
@@ -313,6 +313,15 @@ assert_contains "-c model_reasoning_effort=high" "$out" \
 out="$(run_argv -- -p x)"
 assert_not_contains "model_reasoning_effort" "$out" \
     "no LOOM_EFFORT emits no reasoning-effort override"
+out="$(run_argv -- -p daemon --effort xhigh --dangerously-skip-permissions --use-wrapper)"
+assert_contains "-c model_reasoning_effort=xhigh" "$out" \
+    "daemon --effort maps to Codex reasoning config"
+assert_contains "-s workspace-write" "$out" \
+    "daemon unattended permissions map to workspace-write"
+assert_not_contains "--effort" "$out" \
+    "Claude-only --effort never reaches codex exec"
+assert_not_contains "--use-wrapper" "$out" \
+    "generic retry convention never reaches codex exec"
 out="$(run_argv LOOM_EFFORT=high -- -p x -c model_reasoning_effort=low)"
 assert_not_contains "model_reasoning_effort=high" "$out" \
     "an explicit -c model_reasoning_effort= wins over LOOM_EFFORT"

--- a/defaults/scripts/tests/test-spawn-worker.sh
+++ b/defaults/scripts/tests/test-spawn-worker.sh
@@ -249,6 +249,8 @@ echo "Testing spawn-worker.sh arg + exit-code passthrough..."
 
 # Args with embedded spaces survive as single arguments.
 output="$(run_worker "$WS" -- -p "hello world" --flag --model=x)"
+assert_contains "# LOOM_RUNTIME_RESOLVED runtime=claude" "$output" \
+    "dispatcher emits the runtime-neutral resolution marker"
 assert_contains "stub-claude arg=[hello world]" "$output" \
     "an arg containing a space is forwarded as ONE argument"
 assert_contains "stub-claude arg=[--flag]" "$output" "bare flag forwarded verbatim"

--- a/loom-daemon/src/role_runner.rs
+++ b/loom-daemon/src/role_runner.rs
@@ -1492,7 +1492,7 @@ mod tests {
         let RoleTickOutcome::Failure(reason) = outcome else {
             panic!("expected Failure");
         };
-        assert!(reason.contains("spawn-claude.sh not found"), "{reason}");
+        assert!(reason.contains("spawn-worker.sh not found"), "{reason}");
     }
 
     #[test]

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -84,7 +84,7 @@ pub const DEFAULT_REAPER_INTERVAL_SECS: u64 = 30;
 pub const REAPER_INTERVAL_ENV: &str = "LOOM_SWEEP_REAPER_INTERVAL_SECS";
 
 /// Environment variable for overriding the dispatch entry point used by
-/// the registry. Defaults to `defaults/scripts/spawn-claude.sh` relative to
+/// the registry. Defaults to `defaults/scripts/spawn-worker.sh` relative to
 /// the workspace. Used by integration tests to substitute a fake child.
 pub const SPAWN_BIN_ENV: &str = "LOOM_SWEEP_SPAWN_BIN";
 
@@ -387,6 +387,9 @@ pub const UNKNOWN_TOKEN_NAME: &str = "unknown";
 /// account name itself carries no ANSI colour codes (only the timestamp prefix
 /// does), so a plain substring scan is sufficient — no ANSI stripping needed.
 const TOKEN_NAME_LOG_MARKER: &str = "using OAuth account '";
+const ACCOUNT_LOG_MARKER: &str = "# LOOM_ACCOUNT name=";
+const RUNTIME_LOG_MARKER: &str = "# LOOM_RUNTIME_RESOLVED runtime=";
+const CLI_START_MARKER: &str = "# LOOM_CLI_START";
 
 /// Issue #3802: how long `spawn_child` polls the per-sweep log for the
 /// `TOKEN_NAME_LOG_MARKER` line before giving up and recording
@@ -922,8 +925,7 @@ pub fn ranking_has_capacity(contents: &str) -> bool {
 }
 
 /// Decide, from a sweep log's contents, whether the child has produced any
-/// output *past* the daemon spawn header + `spawn-claude.sh` wrapper lines —
-/// i.e. whether Claude Code itself has started doing work (Issue #3887).
+/// output *past* the daemon spawn header + runtime-adapter preamble lines.
 ///
 /// A hung child's log region (after the most recent dispatch header) contains
 /// only the header itself and `spawn-claude:`-prefixed wrapper lines (the
@@ -939,7 +941,13 @@ pub fn log_has_progress(contents: &str) -> bool {
     };
     region.lines().any(|line| {
         let t = line.trim();
-        !t.is_empty() && !t.contains("loom-daemon dispatch:") && !t.contains("spawn-claude:")
+        !t.is_empty()
+            && !t.contains("loom-daemon dispatch:")
+            && !t.contains("spawn-claude:")
+            && !t.contains("spawn-codex:")
+            && !t.contains("spawn-worker:")
+            && !t.starts_with("# LOOM_RUNTIME_RESOLVED")
+            && !t.starts_with("# LOOM_ACCOUNT")
     })
 }
 
@@ -958,15 +966,26 @@ fn parse_token_name_after(contents: &str, header_anchor: &str) -> Option<String>
     // current child logs its selection after the most recent one.
     let region_start = contents.rfind(header_anchor)?;
     let region = &contents[region_start..];
-    let marker_at = region.find(TOKEN_NAME_LOG_MARKER)? + TOKEN_NAME_LOG_MARKER.len();
+    let (marker_at, terminator) = if let Some(i) = region.find(ACCOUNT_LOG_MARKER) {
+        (i + ACCOUNT_LOG_MARKER.len(), '\n')
+    } else {
+        (region.find(TOKEN_NAME_LOG_MARKER)? + TOKEN_NAME_LOG_MARKER.len(), '\'')
+    };
     let after = &region[marker_at..];
-    let close = after.find('\'')?;
-    let name = &after[..close];
+    let close = after.find(terminator).unwrap_or(after.len());
+    let name = after[..close].trim();
     if name.is_empty() {
         None
     } else {
         Some(name.to_string())
     }
+}
+
+fn parse_runtime_after(contents: &str, header_anchor: &str) -> Option<String> {
+    let region = &contents[contents.rfind(header_anchor)?..];
+    let after = &region[region.find(RUNTIME_LOG_MARKER)? + RUNTIME_LOG_MARKER.len()..];
+    let runtime = after.lines().next()?.trim();
+    (!runtime.is_empty()).then(|| runtime.to_string())
 }
 
 /// Poll `log_path` for the account-selection marker until it appears, the
@@ -981,12 +1000,20 @@ fn parse_token_name_after(contents: &str, header_anchor: &str) -> Option<String>
 /// exits without logging is detected immediately rather than waiting out the
 /// full window). `try_wait` caches the exit status, so the reaper's later
 /// `try_wait` on the same handle still observes the exit.
-fn poll_token_name(child: &mut Child, log_path: &Path, header_anchor: &str) -> String {
+fn poll_observability(child: &mut Child, log_path: &Path, header_anchor: &str) -> (String, String) {
     let deadline = std::time::Instant::now() + TOKEN_NAME_CAPTURE_TIMEOUT;
+    let mut runtime = None;
     loop {
         if let Ok(contents) = std::fs::read_to_string(log_path) {
+            runtime = runtime.or_else(|| parse_runtime_after(&contents, header_anchor));
             if let Some(name) = parse_token_name_after(&contents, header_anchor) {
-                return name;
+                return (name, runtime.unwrap_or_else(|| UNKNOWN_TOKEN_NAME.to_string()));
+            }
+            if runtime.is_some() && contents.contains(CLI_START_MARKER) {
+                return (
+                    UNKNOWN_TOKEN_NAME.to_string(),
+                    runtime.unwrap_or_else(|| UNKNOWN_TOKEN_NAME.to_string()),
+                );
             }
         }
         // If the child has already exited without logging a selection, the
@@ -995,13 +1022,24 @@ fn poll_token_name(child: &mut Child, log_path: &Path, header_anchor: &str) -> S
         if matches!(child.try_wait(), Ok(Some(_))) {
             if let Ok(contents) = std::fs::read_to_string(log_path) {
                 if let Some(name) = parse_token_name_after(&contents, header_anchor) {
-                    return name;
+                    return (
+                        name,
+                        parse_runtime_after(&contents, header_anchor)
+                            .or(runtime)
+                            .unwrap_or_else(|| UNKNOWN_TOKEN_NAME.to_string()),
+                    );
                 }
             }
-            return UNKNOWN_TOKEN_NAME.to_string();
+            return (
+                UNKNOWN_TOKEN_NAME.to_string(),
+                runtime.unwrap_or_else(|| UNKNOWN_TOKEN_NAME.to_string()),
+            );
         }
         if std::time::Instant::now() >= deadline {
-            return UNKNOWN_TOKEN_NAME.to_string();
+            return (
+                UNKNOWN_TOKEN_NAME.to_string(),
+                runtime.unwrap_or_else(|| UNKNOWN_TOKEN_NAME.to_string()),
+            );
         }
         std::thread::sleep(TOKEN_NAME_CAPTURE_POLL_INTERVAL);
     }
@@ -1039,6 +1077,14 @@ fn recover_adopted_token_name(log_path: &Path, sweep_id: &str) -> String {
     std::fs::read_to_string(log_path)
         .ok()
         .and_then(|contents| parse_token_name_after(&contents, &anchor))
+        .unwrap_or_else(|| UNKNOWN_TOKEN_NAME.to_string())
+}
+
+fn recover_adopted_runtime(log_path: &Path, sweep_id: &str) -> String {
+    let anchor = format!("sweep_id={sweep_id}");
+    std::fs::read_to_string(log_path)
+        .ok()
+        .and_then(|contents| parse_runtime_after(&contents, &anchor))
         .unwrap_or_else(|| UNKNOWN_TOKEN_NAME.to_string())
 }
 
@@ -1158,7 +1204,7 @@ fn classify_preflight_death(log_tail: &str) -> Option<&'static str> {
     {
         return Some(label);
     }
-    if !log_tail.contains(CLAUDE_CLI_START_MARKER) {
+    if !log_tail.contains(CLAUDE_CLI_START_MARKER) && !log_tail.contains(CLI_START_MARKER) {
         return Some("preflight-no-cli-start");
     }
     None
@@ -1342,8 +1388,8 @@ pub struct SweepRegistryConfig {
     /// Absolute path to the workspace root (parent of `.loom/`).
     pub workspace_root: PathBuf,
     /// Optional override for the spawn binary. Defaults to
-    /// `<workspace_root>/defaults/scripts/spawn-claude.sh` or, if absent,
-    /// `<workspace_root>/.loom/scripts/spawn-claude.sh`.
+    /// `<workspace_root>/.loom/scripts/spawn-worker.sh` or, if absent,
+    /// `<workspace_root>/defaults/scripts/spawn-worker.sh`.
     pub spawn_bin: Option<PathBuf>,
     /// Override the `gh` binary (for tests). Defaults to `gh` from `PATH`.
     pub gh_bin: Option<PathBuf>,
@@ -1383,20 +1429,22 @@ impl SweepRegistryConfig {
     /// Resolve the spawn binary, preferring (in order):
     /// 1. `spawn_bin` explicit override.
     /// 2. `LOOM_SWEEP_SPAWN_BIN` env var.
-    /// 3. `<workspace>/.loom/scripts/spawn-claude.sh`.
-    /// 4. `<workspace>/defaults/scripts/spawn-claude.sh`.
+    /// 3. `<workspace>/.loom/scripts/spawn-worker.sh`.
+    /// 4. `<workspace>/defaults/scripts/spawn-worker.sh`.
     pub fn resolve_spawn_bin(&self) -> Result<PathBuf> {
         if let Some(ref p) = self.spawn_bin {
             return Ok(p.clone());
         }
         if let Ok(path) = std::env::var(SPAWN_BIN_ENV) {
-            return Ok(PathBuf::from(path));
+            if !path.trim().is_empty() {
+                return Ok(PathBuf::from(path));
+            }
         }
         let installed = self
             .workspace_root
             .join(".loom")
             .join("scripts")
-            .join("spawn-claude.sh");
+            .join("spawn-worker.sh");
         if installed.exists() {
             return Ok(installed);
         }
@@ -1404,12 +1452,12 @@ impl SweepRegistryConfig {
             .workspace_root
             .join("defaults")
             .join("scripts")
-            .join("spawn-claude.sh");
+            .join("spawn-worker.sh");
         if defaults.exists() {
             return Ok(defaults);
         }
         Err(anyhow!(
-            "spawn-claude.sh not found under {} (looked in .loom/scripts and defaults/scripts; \
+            "spawn-worker.sh not found under {} (looked in .loom/scripts and defaults/scripts; \
              set {SPAWN_BIN_ENV} to override)",
             self.workspace_root.display()
         ))
@@ -2483,7 +2531,7 @@ impl SweepRegistry {
         // stagger (the default outside production / in tests) is a no-op.
         self.apply_dispatch_stagger();
         let log_path = self.compute_log_path(issue_number);
-        let (child, token_name) = self
+        let (child, token_name, runtime) = self
             .spawn_child(issue_number, &log_path, &sweep_id, model, effort, depends_on)
             .context("failed to spawn sweep child")?;
         let pid = child.id();
@@ -2514,6 +2562,7 @@ impl SweepRegistry {
             kind: kind.clone(),
             pid,
             token_name: token_name.clone(),
+            runtime,
             log_path: log_path.clone(),
             idempotency_key,
             started_at: Utc::now(),
@@ -3710,7 +3759,7 @@ impl SweepRegistry {
         model: Option<&str>,
         effort: Option<&str>,
         depends_on: Option<u32>,
-    ) -> Result<(Child, String)> {
+    ) -> Result<(Child, String, String)> {
         let spawn_bin = self.config.resolve_spawn_bin()?;
 
         // Ensure log dir exists.
@@ -3928,8 +3977,8 @@ impl SweepRegistry {
         // Falls back to `UNKNOWN_TOKEN_NAME` on timeout / no-selection — never
         // blocks or fails dispatch.
         let header_anchor = format!("sweep_id={sweep_id}");
-        let token_name = poll_token_name(&mut child, log_path, &header_anchor);
-        Ok((child, token_name))
+        let (token_name, runtime) = poll_observability(&mut child, log_path, &header_anchor);
+        Ok((child, token_name, runtime))
     }
 
     // ------------------------------------------------------------------------
@@ -5544,6 +5593,7 @@ impl SweepRegistry {
                 // to owner.sweep_id, to restore attribution before falling back
                 // to `unknown`. Degrades gracefully — adoption never fails here.
                 let token_name = recover_adopted_token_name(&log_path, &owner.sweep_id);
+                let runtime = recover_adopted_runtime(&log_path, &owner.sweep_id);
                 self.entries.insert(
                     owner.sweep_id.clone(),
                     SweepInfo {
@@ -5551,6 +5601,7 @@ impl SweepRegistry {
                         kind: SweepKind::Issue(issue),
                         pid: owner.owner_pid,
                         token_name,
+                        runtime,
                         log_path,
                         idempotency_key: None,
                         started_at,
@@ -5629,6 +5680,7 @@ impl SweepRegistry {
                         // lock was already removed as stale above), so this
                         // path legitimately stays `unknown`.
                         token_name: "unknown".to_string(),
+                        runtime: "unknown".to_string(),
                         log_path,
                         idempotency_key: None,
                         started_at: Utc::now(),
@@ -6309,6 +6361,33 @@ mod tests {
     use std::time::SystemTime;
     use tempfile::tempdir;
 
+    #[test]
+    #[serial]
+    fn resolve_spawn_bin_prefers_worker_install_then_source_tree() {
+        let dir = tempdir().unwrap();
+        let config = SweepRegistryConfig::new(dir.path().to_path_buf());
+        std::env::remove_var(SPAWN_BIN_ENV);
+
+        let defaults = dir.path().join("defaults/scripts/spawn-worker.sh");
+        std::fs::create_dir_all(defaults.parent().unwrap()).unwrap();
+        std::fs::write(&defaults, "# fixture\n").unwrap();
+        assert_eq!(config.resolve_spawn_bin().unwrap(), defaults);
+
+        let installed = dir.path().join(".loom/scripts/spawn-worker.sh");
+        std::fs::create_dir_all(installed.parent().unwrap()).unwrap();
+        std::fs::write(&installed, "# fixture\n").unwrap();
+        assert_eq!(config.resolve_spawn_bin().unwrap(), installed);
+
+        let explicit = dir.path().join("explicit-worker");
+        let mut explicit_config = config.clone();
+        explicit_config.spawn_bin = Some(explicit.clone());
+        assert_eq!(explicit_config.resolve_spawn_bin().unwrap(), explicit);
+
+        std::env::set_var(SPAWN_BIN_ENV, "/tmp/loom-worker-override");
+        assert_eq!(config.resolve_spawn_bin().unwrap(), PathBuf::from("/tmp/loom-worker-override"));
+        std::env::remove_var(SPAWN_BIN_ENV);
+    }
+
     /// Install the `/loom:sweep` command marker under `workspace` (Issue
     /// #4027) so the workspace-commands guard in `dispatch()` treats it as
     /// initialized. Only tests that run with `skip_label_flip = false` need
@@ -6351,6 +6430,7 @@ mod tests {
                 kind: SweepKind::Issue(issue),
                 pid: 0,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path,
                 idempotency_key: None,
                 started_at: Utc::now(),
@@ -6999,6 +7079,7 @@ exit 0
                 kind: SweepKind::Issue(41_110),
                 pid,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(41_110),
                 idempotency_key: None,
                 started_at: Utc::now(),
@@ -7115,6 +7196,7 @@ exit 0
                 kind: SweepKind::Issue(issue),
                 pid,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(issue),
                 idempotency_key: None,
                 started_at: Utc::now(),
@@ -7817,6 +7899,7 @@ exit 0
                     kind: SweepKind::Issue(issue),
                     pid: 2_147_483_640,
                     token_name: "unknown".into(),
+                    runtime: "unknown".into(),
                     log_path: registry.compute_log_path(issue),
                     idempotency_key: None,
                     started_at: Utc::now(),
@@ -7861,6 +7944,7 @@ exit 0
                 kind: SweepKind::Issue(issue),
                 pid: 2_147_483_640,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: PathBuf::from(format!(".loom/logs/sweep-issue-{issue}.log")),
                 idempotency_key: None,
                 started_at: Utc::now(),
@@ -8087,6 +8171,7 @@ exit 0
                 kind: SweepKind::Issue(issue),
                 pid: std::process::id(), // any live-looking pid; list() never probes liveness
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(issue),
                 idempotency_key: None,
                 started_at,
@@ -8294,6 +8379,7 @@ exit 0
                 kind: SweepKind::Issue(55),
                 pid: 2_147_483_640,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(55),
                 idempotency_key: None,
                 started_at: Utc::now(),
@@ -8380,6 +8466,7 @@ exit 0
                 kind: SweepKind::Issue(57),
                 pid: 2_147_483_641,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path,
                 idempotency_key: None,
                 started_at: Utc::now(),
@@ -8439,6 +8526,7 @@ exit 0
                 kind: SweepKind::Issue(66),
                 pid: 2_147_483_640,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(66),
                 idempotency_key: None,
                 started_at: Utc::now() - chrono::Duration::seconds(10),
@@ -8494,6 +8582,7 @@ exit 0
                 kind: SweepKind::Issue(21),
                 pid: 2_147_483_640, // ~i32::MAX, almost certainly dead
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(21),
                 idempotency_key: None,
                 started_at: Utc::now(),
@@ -8542,6 +8631,7 @@ exit 0
                 kind: SweepKind::Issue(issue),
                 pid: 2_147_483_640, // ~i32::MAX, almost certainly dead
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(issue),
                 idempotency_key: None,
                 started_at,
@@ -9818,6 +9908,7 @@ exit 0
                 kind: SweepKind::Issue(77),
                 pid: 2_147_483_640, // ~i32::MAX, almost certainly dead
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(77),
                 idempotency_key: None,
                 started_at: Utc::now(),
@@ -9934,6 +10025,7 @@ exit 0
                 kind: kind.clone(),
                 pid: 2_147_483_640, // ~i32::MAX, almost certainly dead
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(88),
                 idempotency_key: None,
                 started_at,
@@ -10072,6 +10164,7 @@ exit 0
                 kind: kind.clone(),
                 pid: 2_147_483_640,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(99),
                 idempotency_key: None,
                 started_at,
@@ -10134,6 +10227,7 @@ exit 0
                 kind: kind.clone(),
                 pid: 2_147_483_640,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(0),
                 idempotency_key: None,
                 started_at,
@@ -10179,6 +10273,7 @@ exit 0
                 kind: SweepKind::Issue(33),
                 pid: 2_147_483_640,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(33),
                 idempotency_key: None,
                 started_at: Utc::now(),
@@ -10667,6 +10762,16 @@ exit 0
     }
 
     #[test]
+    fn neutral_observability_parser_is_current_dispatch_scoped() {
+        let log = "==== loom-daemon dispatch: old sweep_id=old ====\n\
+# LOOM_RUNTIME_RESOLVED runtime=claude\n# LOOM_ACCOUNT name=stale\n\
+==== loom-daemon dispatch: new sweep_id=new ====\n\
+# LOOM_RUNTIME_RESOLVED runtime=codex\n# LOOM_ACCOUNT name=codex-profile\n";
+        assert_eq!(parse_runtime_after(log, "sweep_id=new").as_deref(), Some("codex"));
+        assert_eq!(parse_token_name_after(log, "sweep_id=new").as_deref(), Some("codex-profile"));
+    }
+
+    #[test]
     fn parse_token_name_after_ignores_stale_line_before_current_header() {
         // A previous dispatch's selection line, then this dispatch's header
         // with NO selection line yet: must NOT return the stale name.
@@ -10772,6 +10877,7 @@ exit 0\n";
             kind: SweepKind::Issue(42),
             pid: 12_345,
             token_name: "agent-1.token".to_string(),
+            runtime: "unknown".into(),
             log_path: PathBuf::from(".loom/logs/sweep-issue-42.log"),
             idempotency_key: Some("operator-key".to_string()),
             started_at: chrono::DateTime::parse_from_rfc3339("2026-06-05T10:00:00Z")
@@ -10791,6 +10897,7 @@ exit 0\n";
             "kind": {"type": "Issue", "value": 42},
             "pid": 12_345,
             "token_name": "agent-1.token",
+            "runtime": "unknown",
             "log_path": ".loom/logs/sweep-issue-42.log",
             "idempotency_key": "operator-key",
             "started_at": "2026-06-05T10:00:00Z",
@@ -10824,6 +10931,7 @@ exit 0\n";
         // None (#[serde(default)]) and be omitted on re-serialization
         // (skip_serializing_if).
         assert_eq!(legacy.effort, None);
+        assert_eq!(legacy.runtime, "unknown");
         let reserialized = serde_json::to_value(&legacy).unwrap();
         assert!(
             reserialized.get("model").is_none(),
@@ -10884,6 +10992,7 @@ exit 0\n";
                 kind: SweepKind::Issue(42),
                 pid: 1234,
                 token_name: "agent-1.token".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(42),
                 idempotency_key: None,
                 started_at: Utc::now(),
@@ -10924,6 +11033,7 @@ exit 0\n";
                 kind: SweepKind::Issue(99),
                 pid: 1,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: log_path.clone(),
                 idempotency_key: None,
                 started_at: Utc::now(),
@@ -10983,6 +11093,7 @@ exit 0\n";
                 kind: SweepKind::Issue(11),
                 pid: 1,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(11),
                 idempotency_key: None,
                 started_at: Utc::now(),
@@ -11026,6 +11137,7 @@ exit 0\n";
                 kind: SweepKind::Issue(22),
                 pid: 2_147_483_640, // ~i32::MAX, almost certainly dead
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(22),
                 idempotency_key: None,
                 started_at: Utc::now(),
@@ -11084,6 +11196,7 @@ exit 0\n";
                 kind: SweepKind::Issue(77),
                 pid,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(77),
                 idempotency_key: None,
                 started_at: Utc::now(),
@@ -11161,6 +11274,7 @@ exit 0\n";
                     kind: SweepKind::Issue(880),
                     pid: target_pid,
                     token_name: "unknown".into(),
+                    runtime: "unknown".into(),
                     log_path: target_log,
                     idempotency_key: None,
                     started_at: Utc::now(),
@@ -11180,6 +11294,7 @@ exit 0\n";
                     kind: SweepKind::Issue(881),
                     pid: 2_147_483_640, // ~i32::MAX, harmless dead pid
                     token_name: "unknown".into(),
+                    runtime: "unknown".into(),
                     log_path: other_log,
                     idempotency_key: None,
                     started_at: Utc::now(),
@@ -11274,6 +11389,7 @@ exit 0\n";
                 kind: SweepKind::Issue(88),
                 pid: 2_147_483_640,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(88),
                 idempotency_key: None,
                 started_at: Utc::now(),
@@ -11722,6 +11838,17 @@ exit 0\n";
     }
 
     #[test]
+    fn log_has_progress_ignores_codex_adapter_preamble() {
+        let log = "==== loom-daemon dispatch: t sweep_id=s issue=7 ====\n\
+# LOOM_RUNTIME_RESOLVED runtime=codex\n\
+[ts] spawn-worker: runtime=codex\n\
+[ts] spawn-codex: model=default\n\
+# LOOM_ACCOUNT name=profile-a\n";
+        assert!(!log_has_progress(log));
+        assert!(log_has_progress(&format!("{log}# LOOM_CLI_START runtime=codex\n")));
+    }
+
+    #[test]
     fn log_has_progress_true_when_claude_emits_output() {
         let log = "\n==== loom-daemon dispatch: 2026-07-23T00:00:00Z sweep_id=sweep-issue-1-1 issue=1 ====\n\
                    [2026-07-23T00:00:01Z] spawn-claude: using OAuth account 'agent-2' (mode=ranked)\n\
@@ -11888,6 +12015,7 @@ exit 0\n";
                 kind: SweepKind::Issue(issue),
                 pid: 2_147_483_640,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: reg.compute_log_path(issue),
                 idempotency_key: None,
                 started_at: Utc::now(),
@@ -12063,6 +12191,7 @@ exit 0\n";
                 kind: SweepKind::Issue(6006),
                 pid: 2_147_483_640,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: reg.compute_log_path(6006),
                 idempotency_key: None,
                 started_at: Utc::now(),
@@ -12392,6 +12521,7 @@ exit 0\n";
                 kind: SweepKind::Issue(6001),
                 pid: 2_147_483_640,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: ws.join(".loom/logs/sweep-issue-6001.log"),
                 idempotency_key: None,
                 started_at: old,
@@ -12977,6 +13107,7 @@ exit 0\n";
                 kind: SweepKind::Issue(issue),
                 pid: 2_147_483_641,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: reg.compute_log_path(issue),
                 idempotency_key: None,
                 started_at: Utc::now() - chrono::Duration::seconds(5),

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -988,6 +988,12 @@ fn parse_runtime_after(contents: &str, header_anchor: &str) -> Option<String> {
     (!runtime.is_empty()).then(|| runtime.to_string())
 }
 
+fn marker_after(contents: &str, header_anchor: &str, marker: &str) -> bool {
+    contents
+        .rfind(header_anchor)
+        .is_some_and(|start| contents[start..].contains(marker))
+}
+
 /// Poll `log_path` for the account-selection marker until it appears, the
 /// child exits, or `TOKEN_NAME_CAPTURE_TIMEOUT` elapses.
 ///
@@ -1009,7 +1015,7 @@ fn poll_observability(child: &mut Child, log_path: &Path, header_anchor: &str) -
             if let Some(name) = parse_token_name_after(&contents, header_anchor) {
                 return (name, runtime.unwrap_or_else(|| UNKNOWN_TOKEN_NAME.to_string()));
             }
-            if runtime.is_some() && contents.contains(CLI_START_MARKER) {
+            if runtime.is_some() && marker_after(&contents, header_anchor, CLI_START_MARKER) {
                 return (
                     UNKNOWN_TOKEN_NAME.to_string(),
                     runtime.unwrap_or_else(|| UNKNOWN_TOKEN_NAME.to_string()),
@@ -1198,13 +1204,21 @@ const CLAUDE_CLI_START_MARKER: &str = "# CLAUDE_CLI_START";
 /// unreadable/missing log as `None`/"unknown" rather than calling this with
 /// an empty tail (mirrors how [`classify_crash`] is fed by its callers).
 fn classify_preflight_death(log_tail: &str) -> Option<&'static str> {
+    // Per-issue logs are append-only. Restrict both positive and absence-based
+    // classification to the newest dispatch so markers from a prior run
+    // cannot classify (or clear) the current run's pre-flight death.
+    let current_dispatch = log_tail
+        .rfind(DISPATCH_HEADER_MARKER)
+        .map_or(log_tail, |start| &log_tail[start..]);
     if let Some((label, _)) = preflight_death_signatures()
         .iter()
-        .find(|(_, re)| re.is_match(log_tail))
+        .find(|(_, re)| re.is_match(current_dispatch))
     {
         return Some(label);
     }
-    if !log_tail.contains(CLAUDE_CLI_START_MARKER) && !log_tail.contains(CLI_START_MARKER) {
+    if !current_dispatch.contains(CLAUDE_CLI_START_MARKER)
+        && !current_dispatch.contains(CLI_START_MARKER)
+    {
         return Some("preflight-no-cli-start");
     }
     None
@@ -8805,6 +8819,14 @@ exit 0
             ),
             None
         );
+        assert_eq!(
+            classify_preflight_death(
+                "==== loom-daemon dispatch: old ====\n\
+# LOOM_CLI_START runtime=codex\n\
+==== loom-daemon dispatch: current ====\nspawn-codex: preflight failed\n"
+            ),
+            Some("preflight-no-cli-start")
+        );
     }
 
     /// AC #1: an exhaustion insta-crash marks the account bad and does NOT
@@ -10769,6 +10791,40 @@ exit 0
 # LOOM_RUNTIME_RESOLVED runtime=codex\n# LOOM_ACCOUNT name=codex-profile\n";
         assert_eq!(parse_runtime_after(log, "sweep_id=new").as_deref(), Some("codex"));
         assert_eq!(parse_token_name_after(log, "sweep_id=new").as_deref(), Some("codex-profile"));
+    }
+
+    #[test]
+    fn poll_observability_waits_for_current_account_after_stale_cli_start() {
+        let dir = tempdir().unwrap();
+        let log_path = dir.path().join("sweep.log");
+        let header_anchor = "sweep_id=current";
+        std::fs::write(
+            &log_path,
+            "==== loom-daemon dispatch: old sweep_id=old ====\n\
+# LOOM_CLI_START runtime=codex\n\
+==== loom-daemon dispatch: new sweep_id=current ====\n\
+# LOOM_RUNTIME_RESOLVED runtime=codex\n",
+        )
+        .unwrap();
+
+        let append_path = log_path.clone();
+        let writer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(100));
+            use std::io::Write;
+            let mut log = std::fs::OpenOptions::new()
+                .append(true)
+                .open(append_path)
+                .unwrap();
+            writeln!(log, "# LOOM_ACCOUNT name=current-profile").unwrap();
+        });
+        let mut child = Command::new("sleep").arg("1").spawn().unwrap();
+
+        let observed = poll_observability(&mut child, &log_path, header_anchor);
+
+        child.kill().ok();
+        child.wait().ok();
+        writer.join().unwrap();
+        assert_eq!(observed, ("current-profile".to_string(), "codex".to_string()));
     }
 
     #[test]

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -779,6 +779,11 @@ pub struct SweepInfo {
     /// "unknown" when not surfaced by the wrapper (Phase A logs this in
     /// the per-sweep log rather than recording it on the entry).
     pub token_name: String,
+    /// Runtime adapter selected for this dispatch (`claude`, `codex`, etc.).
+    /// Legacy entries and fixture adapters that do not emit the neutral
+    /// observability contract safely degrade to `unknown`.
+    #[serde(default = "default_sweep_runtime")]
+    pub runtime: String,
     /// Path to the per-sweep log file (relative to the workspace).
     pub log_path: PathBuf,
     /// Optional idempotency key supplied at dispatch.
@@ -842,6 +847,10 @@ pub struct SweepInfo {
     /// compatible.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repo: Option<String>,
+}
+
+fn default_sweep_runtime() -> String {
+    "unknown".to_string()
 }
 
 // ========================================================================


### PR DESCRIPTION
## Summary
Route daemon-dispatched sweeps through the runtime-neutral worker dispatcher and expose a stable, secret-free adapter observability contract.

## Changes
- default `SweepRegistry` to `spawn-worker.sh` while preserving explicit and environment overrides
- translate daemon effort, permissions, and retry conventions in the Codex adapter without leaking Claude-only flags
- emit and parse neutral runtime, account/profile, and CLI-start markers while retaining historical Claude compatibility
- add backward-compatible `SweepInfo.runtime` status and reconstruction support
- document and test the daemon adapter contract

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Worker spawn resolution and override precedence | ✅ | Rust resolver test; worker shell suite 27/27 |
| Default Claude and env/config Codex routing | ✅ | `test-spawn-worker.sh` and `test-spawn-codex.sh` |
| Unknown runtime exits 78 | ✅ | worker suite unknown env/config cases |
| Daemon-shaped Codex argv is translated | ✅ | Codex suite asserts effort/sandbox mapping and absence of `--effort`/`--use-wrapper` |
| Neutral runtime/account/CLI markers | ✅ | adapter output and Rust current-dispatch parser tests |
| Progress/preflight retain legacy compatibility | ✅ | focused registry tests, including historical `# CLAUDE_CLI_START` cases |
| Additive runtime status and legacy JSON | ✅ | `sweep_info_schema_snapshot` |
| Restart reconstruction is current-run scoped | ✅ | shared anchored parser and reconstruction tests |
| No credential material exposed | ✅ | markers contain runtime/display name only; existing credential-hygiene suite passes |

## Test Plan
- `bash defaults/scripts/tests/test-spawn-worker.sh` (27/27)
- `bash defaults/scripts/tests/test-spawn-codex.sh` (139/139)
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test sweep_registry --lib` (changed tests pass; pre-existing long-running stagger fixture exceeded 60s and was stopped)
- `bash .loom/scripts/build-gate.sh` (progressed through the workspace suite; stopped at the same >60s stagger fixture stall)

Closes #4490