### PR TITLE
fix(scripts): distinguish gh fetch failure from absent complexity marker (#4472)

### DIFF
--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -537,7 +537,10 @@ There are **three, and only three**, cost-of-being-wrong strata (issue #4238 add
 
 ```bash
 ./.loom/scripts/require-complexity-marker.sh <issue>   # exit 0 = has a valid tier; exit 1 = missing or out-of-vocabulary
+                                                       # exit 2 = could not fetch (retry/check quota, NOT a curation defect)
 ```
+
+Exit 2 means the issue body could not be fetched (both GraphQL and REST failed — usually API quota exhaustion), not that the marker is absent. Retry once quota recovers; do not re-edit the body on an exit-2.
 
 ## Where to Add Enhancements
 

--- a/defaults/scripts/require-complexity-marker.sh
+++ b/defaults/scripts/require-complexity-marker.sh
@@ -29,7 +29,23 @@ if [[ -z "$REPO" ]]; then
 fi
 [[ -n "$REPO" ]] || { echo "could not determine repo; pass it explicitly or set LOOM_REPO" >&2; exit 2; }
 
-body="$(gh issue view "$ISSUE" -R "$REPO" --json body -q .body 2>/dev/null || true)"
+# Fetch the issue body, distinguishing a fetch FAILURE from a genuinely empty
+# body (#4472). `gh issue view` is a GraphQL call; under quota exhaustion (routine
+# at fleet scale, epic #4432) it fails, and a swallowed failure would parse as an
+# empty tier and print the BLOCKED-missing text — indistinguishable from an
+# unmarked issue, blocking curation while quota is out. So: try GraphQL, fall back
+# to REST (which draws on a separate quota), and only if BOTH fail exit 2
+# ("could not evaluate", already this script's semantics for repo-resolution
+# failures) rather than 1 (missing marker). An empty body from a *successful*
+# fetch remains exit 1.
+if body="$(gh issue view "$ISSUE" -R "$REPO" --json body -q .body 2>/dev/null)"; then
+  :
+elif body="$(gh api "repos/$REPO/issues/$ISSUE" --jq .body 2>/dev/null)"; then
+  :
+else
+  echo "BLOCKED: could not fetch issue $REPO#$ISSUE body (both GraphQL and REST failed — likely GitHub API quota exhaustion). Retry or check quota; this is not a curation defect." >&2
+  exit 2
+fi
 tier="$(printf '%s' "$body" | grep -o 'loom:complexity=[a-z]*' | head -1 | cut -d= -f2)"
 
 case "$tier" in

--- a/defaults/scripts/resolve-tier-model.sh
+++ b/defaults/scripts/resolve-tier-model.sh
@@ -54,7 +54,21 @@ if [[ -z "$REPO" ]]; then
 fi
 [[ -n "$REPO" ]] || { echo "could not determine repo; pass it explicitly or set LOOM_REPO" >&2; exit 2; }
 
-body="$(gh issue view "$ISSUE" -R "$REPO" --json body -q .body 2>/dev/null || true)"
+# Fetch the issue body with a GraphQL->REST fallback (#4472). `gh issue view` is
+# a GraphQL call; under quota exhaustion (routine at fleet scale, epic #4432) it
+# fails and a swallowed failure parses as an empty tier -> `routine`, silently
+# disabling cost/speed routing. REST draws on a separate quota, so try it before
+# giving up. If BOTH fail we still fall through to `routine` (a non-breaking
+# default for this non-blocking resolver — unlike require-complexity-marker.sh
+# this script never blocks curation) but say so, so the degradation shows in logs.
+if body="$(gh issue view "$ISSUE" -R "$REPO" --json body -q .body 2>/dev/null)"; then
+  :
+elif body="$(gh api "repos/$REPO/issues/$ISSUE" --jq .body 2>/dev/null)"; then
+  :
+else
+  echo "$REPO#$ISSUE: could not fetch body (GraphQL+REST failed — likely API quota) -> routine" >&2
+  body=""
+fi
 tier="$(printf '%s' "$body" | grep -o 'loom:complexity=[a-z]*' | head -1 | cut -d= -f2)"
 # Two distinct fall-through cases (#4448): an absent marker is the expected
 # default for issues curated before the marker existed (or before it became

--- a/defaults/scripts/tests/test-require-complexity-marker.sh
+++ b/defaults/scripts/tests/test-require-complexity-marker.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# test-require-complexity-marker.sh - Tests for require-complexity-marker.sh's
+# fetch-failure vs absent-marker distinction (#4472) and the pre-existing
+# tier-parsing behaviour it must not regress.
+#
+# The bug (#4472): the body fetch swallowed every `gh` failure with `|| true`
+# `2>/dev/null`, so a GraphQL quota exhaustion produced an empty body that parsed
+# as an empty tier and printed the BLOCKED-missing text — indistinguishable from
+# a genuinely unmarked issue, blocking curation while quota was out. The fix adds
+# a GraphQL->REST fallback and, on total fetch failure, exits 2 ("could not
+# evaluate", the script's existing usage/repo-resolution exit code) with a
+# fetch-error message instead of exit 1 (missing marker).
+#
+# Style matches test-resolve-tier-model.sh: a fake `gh` stub on PATH answers both
+# the `gh issue view ... -q .body` (GraphQL) and `gh api repos/.../issues/... --jq
+# .body` (REST) invocations, keyed off issue number, so scenarios can force
+# GraphQL failure, REST fallback, or both-fail without network access. The repo is
+# passed explicitly (2nd positional arg), so forge auto-detection is never hit.
+#
+# Usage:
+#   ./defaults/scripts/tests/test-require-complexity-marker.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+MARKER_SCRIPT="$SCRIPTS_DIR/require-complexity-marker.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_contains() {
+    local needle="$1" haystack="$2" msg="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        pass "$msg"
+    else
+        fail "$msg (expected substring '$needle' in: $haystack)"
+    fi
+}
+
+assert_not_contains() {
+    local needle="$1" haystack="$2" msg="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        pass "$msg"
+    else
+        fail "$msg (unexpected substring '$needle' in: $haystack)"
+    fi
+}
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        pass "$msg"
+    else
+        fail "$msg (expected '$expected', got '$actual')"
+    fi
+}
+
+if [[ ! -x "$MARKER_SCRIPT" ]]; then
+    echo -e "${RED}FATAL${NC}: $MARKER_SCRIPT not found or not executable" >&2
+    exit 1
+fi
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/test-require-complexity-marker.XXXXXX")"
+# shellcheck disable=SC2329  # invoked indirectly via the EXIT trap below
+cleanup() { rm -rf "$WORKDIR" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# ---- Fake `gh` stub ---------------------------------------------------------
+# Handles two invocations:
+#   gh issue view <issue> -R <repo> --json body -q .body   (GraphQL path)
+#   gh api repos/<repo>/issues/<issue> --jq .body          (REST fallback)
+# Bodies are keyed off issue number; per-invocation success/failure is scripted
+# so a scenario can force GraphQL failure with REST success (fallback), or both
+# failing (fetch error / exit 2).
+#
+#   9001 = valid marker via GraphQL
+#   9002 = no marker via GraphQL (successful fetch, empty tier)
+#   9003 = invalid/out-of-vocabulary tier via GraphQL
+#   9004 = GraphQL FAILS, REST returns a valid marker (fallback path)
+#   9005 = both GraphQL and REST FAIL (fetch error)
+#   9006 = GraphQL succeeds but returns an EMPTY body (successful fetch, no marker)
+FAKE_BIN="$WORKDIR/bin"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/gh" <<'FAKEGH'
+#!/usr/bin/env bash
+# GraphQL path: gh issue view <issue> -R <repo> --json body -q .body
+if [[ "$1" == "issue" && "$2" == "view" ]]; then
+    issue="$3"
+    case "$issue" in
+        9001) echo "Body.
+
+<!-- loom:complexity=routine -->
+" ; exit 0 ;;
+        9002) echo "An issue body with no complexity marker at all." ; exit 0 ;;
+        9003) echo "Drifted marker.
+
+<!-- loom:complexity=trivial -->
+" ; exit 0 ;;
+        9004) exit 1 ;;   # GraphQL quota exhausted -> forces REST fallback
+        9005) exit 1 ;;   # GraphQL fails ...
+        9006) echo "" ; exit 0 ;;
+        *) echo "" ; exit 0 ;;
+    esac
+fi
+# REST fallback path: gh api repos/<repo>/issues/<issue> --jq .body
+if [[ "$1" == "api" ]]; then
+    # 2nd arg looks like repos/owner/repo/issues/<issue>
+    issue="${2##*/}"
+    case "$issue" in
+        9004) echo "Recovered via REST.
+
+<!-- loom:complexity=complex -->
+" ; exit 0 ;;
+        9005) exit 1 ;;   # ... and REST fails too -> fetch error
+        *) exit 1 ;;
+    esac
+fi
+exit 1
+FAKEGH
+chmod +x "$FAKE_BIN/gh"
+
+REPO="owner/repo"
+
+run_marker() {
+    local issue="$1"
+    PATH="$FAKE_BIN:$PATH" "$MARKER_SCRIPT" "$issue" "$REPO"
+}
+
+# -------- Test 1: script exists and is executable --------
+echo "Test 1: script exists and is executable"
+if [[ -x "$MARKER_SCRIPT" ]]; then
+    pass "require-complexity-marker.sh is executable"
+else
+    fail "require-complexity-marker.sh is missing or not executable"
+fi
+
+# -------- Test 2: successful GraphQL fetch, valid marker -> exit 0 --------
+echo "Test 2: valid marker via GraphQL -> exit 0"
+out="$(run_marker 9001 2>&1)"; rc=$?
+assert_eq "0" "$rc" "valid marker exits 0"
+assert_contains "is tagged routine" "$out" "valid marker reports the tier"
+
+# -------- Test 3: successful fetch, no marker -> exit 1 BLOCKED --------
+echo "Test 3: successful fetch, absent marker -> exit 1 BLOCKED (unchanged)"
+out="$(run_marker 9002 2>&1)"; rc=$?
+assert_eq "1" "$rc" "absent marker exits 1"
+assert_contains "BLOCKED: issue has no complexity marker" "$out" "absent marker prints the BLOCKED-missing text"
+
+# -------- Test 4: successful fetch, invalid tier -> exit 1 --------
+echo "Test 4: successful fetch, invalid tier -> exit 1 (unchanged)"
+out="$(run_marker 9003 2>&1)"; rc=$?
+assert_eq "1" "$rc" "invalid tier exits 1"
+assert_contains "invalid tier 'trivial'" "$out" "invalid tier names the offending value"
+
+# -------- Test 5: GraphQL fails, REST fallback succeeds -> normal eval --------
+echo "Test 5: GraphQL fails + REST fallback returns valid marker -> exit 0 on REST body"
+out="$(run_marker 9004 2>&1)"; rc=$?
+assert_eq "0" "$rc" "REST-fallback body with a valid marker exits 0"
+assert_contains "is tagged complex" "$out" "REST-fallback body's tier is used"
+assert_not_contains "BLOCKED" "$out" "REST-fallback success never prints BLOCKED"
+
+# -------- Test 6: both GraphQL and REST fail -> exit 2 fetch error --------
+echo "Test 6: both fetches fail -> exit 2 fetch error, NOT exit 1 BLOCKED-missing"
+out="$(run_marker 9005 2>&1)"; rc=$?
+assert_eq "2" "$rc" "total fetch failure exits 2 (could not evaluate), not 1"
+assert_contains "could not fetch" "$out" "fetch failure prints a fetch-error message"
+assert_contains "quota" "$out" "fetch-error message names the likely cause (quota)"
+assert_not_contains "issue has no complexity marker" "$out" "fetch failure never prints the BLOCKED-missing text"
+
+# -------- Test 7: successful fetch of an EMPTY body -> exit 1 BLOCKED --------
+# A successful-but-empty fetch must NOT be conflated with a fetch failure: it is
+# a genuinely unmarked issue and stays exit 1, per the original report.
+echo "Test 7: successful fetch of empty body -> exit 1 BLOCKED (not conflated with fetch failure)"
+out="$(run_marker 9006 2>&1)"; rc=$?
+assert_eq "1" "$rc" "empty-but-successful fetch exits 1 (missing marker), not 2"
+assert_contains "BLOCKED: issue has no complexity marker" "$out" "empty-but-successful fetch prints the BLOCKED-missing text"
+assert_not_contains "could not fetch" "$out" "empty-but-successful fetch is not a fetch error"
+
+# -------- Summary --------
+echo ""
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo -e "${RED}FAILED${NC}: $TESTS_FAILED test(s) failed"
+    exit 1
+fi
+echo -e "${GREEN}OK${NC}: all tests passed"
+exit 0

--- a/defaults/scripts/tests/test-resolve-tier-model.sh
+++ b/defaults/scripts/tests/test-resolve-tier-model.sh
@@ -72,6 +72,7 @@ FAKE_BIN="$WORKDIR/bin"
 mkdir -p "$FAKE_BIN"
 cat > "$FAKE_BIN/gh" <<'FAKEGH'
 #!/usr/bin/env bash
+# GraphQL path: gh issue view <issue> -R <repo> --json body -q .body
 if [[ "$1" == "issue" && "$2" == "view" ]]; then
     issue="$3"
     case "$issue" in
@@ -90,9 +91,23 @@ More text." ;;
 <!-- loom:complexity=complex -->
 <!-- loom:complexity=mechanical -->
 " ;;
+        9005) exit 1 ;;   # GraphQL quota exhausted -> forces REST fallback (#4472)
+        9006) exit 1 ;;   # GraphQL fails ...
         *) echo "" ;;
     esac
     exit 0
+fi
+# REST fallback path: gh api repos/<repo>/issues/<issue> --jq .body (#4472)
+if [[ "$1" == "api" ]]; then
+    issue="${2##*/}"
+    case "$issue" in
+        9005) echo "Recovered via REST.
+
+<!-- loom:complexity=complex -->
+" ; exit 0 ;;
+        9006) exit 1 ;;   # ... and REST fails too -> falls through to routine
+        *) exit 1 ;;
+    esac
 fi
 exit 1
 FAKEGH
@@ -163,6 +178,23 @@ assert_contains "3" "$rc" "absent-marker case exits 3 (no tierModels configured)
 rc=0
 run_resolve 9003 >/dev/null 2>&1 || rc=$?
 assert_contains "3" "$rc" "invalid-marker case exits 3 (no tierModels configured)"
+
+# -------- Test 7: GraphQL failure falls back to REST body (#4472) --------
+# When `gh issue view` (GraphQL) fails under quota exhaustion, the resolver must
+# fall back to the REST body rather than silently defaulting to routine. Issue
+# 9005's GraphQL fetch fails and REST returns a valid `complex` marker.
+echo "Test 7: GraphQL failure falls back to REST-fetched body"
+err="$(run_resolve 9005 2>&1 1>/dev/null)"
+assert_contains "tier=complex" "$err" "REST-fallback body's tier (complex) is resolved, not routine"
+assert_not_contains "could not fetch" "$err" "successful REST fallback emits no fetch-error message"
+
+# -------- Test 8: both fetches fail -> routine, with a diagnostic (#4472) --------
+# When GraphQL and REST both fail, the non-blocking resolver still degrades to
+# routine (unchanged, non-breaking) but says so, so the degradation is visible.
+echo "Test 8: total fetch failure degrades to routine with a diagnostic"
+err="$(run_resolve 9006 2>&1 1>/dev/null)"
+assert_contains "could not fetch body" "$err" "total fetch failure logs a fetch-error diagnostic"
+assert_contains "-> routine" "$err" "total fetch failure still degrades to routine"
 
 # -------- Summary --------
 echo ""


### PR DESCRIPTION
## Summary

`require-complexity-marker.sh` swallowed every `gh issue view` failure with `|| true 2>/dev/null`. Under GraphQL quota exhaustion (routine at fleet scale, epic #4432), the empty body parsed as an empty tier and printed the BLOCKED-missing text — indistinguishable from a genuinely unmarked issue. A Curator following the "do not apply loom:curated if it fails" rule was blocked from curating anything while quota was out (or re-edited already-correct bodies).

## Changes

- **`defaults/scripts/require-complexity-marker.sh`** — split fetch failure from missing marker: try GraphQL, fall back to REST (`gh api repos/<nwo>/issues/<n> --jq .body`, a separate quota), and only if BOTH fail `exit 2` ("could not evaluate" — already the script's usage/repo-resolution exit code) with a fetch-error message naming quota as the likely cause. An empty body from a *successful* fetch remains `exit 1` (missing marker).
- **`defaults/scripts/resolve-tier-model.sh`** — same GraphQL→REST fallback for the byte-identical vulnerable fetch. Its failure mode was silent (empty body → `routine`, quietly disabling cost/speed routing); it now recovers via REST and, on total failure, still degrades to `routine` (non-breaking) but logs the degradation.
- **`defaults/.claude/commands/loom/curator.md`** (one real file; `defaults/roles/curator.md` is a symlink to it) — document `exit 2 = could not fetch (retry/check quota, NOT a curation defect)`.
- **Tests** — new `test-require-complexity-marker.sh` (7 cases: valid/absent/invalid marker, GraphQL-fail→REST-fallback, both-fail→exit 2, empty-but-successful→exit 1) + fallback coverage added to `test-resolve-tier-model.sh`.

## Test results

Both suites pass (17/17 each). `shellcheck` clean on all four scripts.

## Scope

Per-script fix only (~30 LOC + doc lines). No caching / backoff / token rotation — that is epic #4432's delivered scope.

Closes #4472

🤖 Generated with [Claude Code](https://claude.com/claude-code)