### PR TITLE
fix(narration): upgrade child-published sweep.issue.N.phase|blocker to typed events

### DIFF
--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -2686,18 +2686,26 @@ fn handle_request(
         // Event Bus Handlers (Issue #3453 — Phase B of #3449)
         // ====================================================================
         Request::PublishEvent { topic, payload } => {
-            // Generic publish path used by sweep children — the topic is
-            // the canonical name (e.g., "sweep.issue.123.phase") and the
-            // payload is opaque JSON. See `defaults/.claude/commands/loom/
-            // sweep.md` for the per-topic payload schema.
-            let event = Event::Generic {
-                topic: topic.clone(),
-                payload,
-            };
+            // Publish path used by sweep children — the topic is the canonical
+            // name (e.g., "sweep.issue.123.phase") and the payload is JSON. See
+            // `defaults/.claude/commands/loom/sweep.md` for the per-topic
+            // payload schema.
+            //
+            // Issue #4466: the two documented child-published topics
+            // (`sweep.issue.{N}.phase` / `.blocker`) are upgraded to their
+            // typed variants here so the narration sink can emit the documented
+            // room lines — an `Event::Generic` is never narrated. Unknown
+            // topics and malformed payloads fall through to `Event::Generic`
+            // unchanged (publish is fire-and-forget advisory).
+            let topic_ack = topic.clone();
+            let event = Event::from_published(topic, payload);
             match event_bus.publish(event) {
-                Ok(receivers) => Response::EventPublished { topic, receivers },
+                Ok(receivers) => Response::EventPublished {
+                    topic: topic_ack,
+                    receivers,
+                },
                 Err(_) => Response::EventPublished {
-                    topic,
+                    topic: topic_ack,
                     receivers: 0,
                 },
             }
@@ -4179,14 +4187,149 @@ exit 0
             other => panic!("Expected EventPublished, got: {other:?}"),
         }
 
-        // Subscriber should now see the published event.
+        // Issue #4466: the documented child-published `sweep.issue.{N}.phase`
+        // topic is upgraded to the typed `Event::SweepPhase` variant (was
+        // previously delivered as `Event::Generic`, which the narration sink
+        // never narrated).
         let ev = sub.recv().await.unwrap();
         match ev {
-            Event::Generic { topic, payload } => {
-                assert_eq!(topic, "sweep.issue.123.phase");
-                assert_eq!(payload, serde_json::json!({"phase": "builder"}));
+            Event::SweepPhase {
+                issue,
+                phase,
+                pr_number,
+                repo,
+            } => {
+                assert_eq!(issue, 123);
+                assert_eq!(phase, "builder");
+                assert_eq!(pr_number, None);
+                assert_eq!(repo, None);
             }
-            other => panic!("Expected Generic event, got: {other:?}"),
+            other => panic!("Expected SweepPhase event, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_request_publish_event_upgrades_blocker_topic() {
+        // Issue #4466: `sweep.issue.{N}.blocker` upgrades to `Event::SweepBlocker`
+        // with the full documented payload (incl. the optional `repo`).
+        let (tm, db, sr, bus) = setup_test_context();
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        handle_request(
+            Request::PublishEvent {
+                topic: "sweep.issue.456.blocker".to_string(),
+                payload: serde_json::json!({
+                    "reason": "needs human decision",
+                    "label_added": "loom:operator-only",
+                    "repo": "/work/loom",
+                }),
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+            &test_pool(),
+        );
+
+        match sub.recv().await.unwrap() {
+            Event::SweepBlocker {
+                issue,
+                reason,
+                label_added,
+                repo,
+            } => {
+                assert_eq!(issue, 456);
+                assert_eq!(reason, "needs human decision");
+                assert_eq!(label_added, "loom:operator-only");
+                assert_eq!(repo.as_deref(), Some("/work/loom"));
+            }
+            other => panic!("Expected SweepBlocker event, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_request_publish_event_phase_carries_pr_and_repo() {
+        // Issue #4466: the optional `pr_number` + `repo` fields survive the
+        // typed upgrade (the phase narration line appends ` · PR #M open`).
+        let (tm, db, sr, bus) = setup_test_context();
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        handle_request(
+            Request::PublishEvent {
+                topic: "sweep.issue.789.phase".to_string(),
+                payload: serde_json::json!({
+                    "phase": "judge",
+                    "pr_number": 501,
+                    "repo": "/work/loom",
+                }),
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+            &test_pool(),
+        );
+
+        match sub.recv().await.unwrap() {
+            Event::SweepPhase {
+                issue,
+                phase,
+                pr_number,
+                repo,
+            } => {
+                assert_eq!(issue, 789);
+                assert_eq!(phase, "judge");
+                assert_eq!(pr_number, Some(501));
+                assert_eq!(repo.as_deref(), Some("/work/loom"));
+            }
+            other => panic!("Expected SweepPhase event, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_request_publish_event_malformed_and_unknown_stay_generic() {
+        // Issue #4466: publish is fire-and-forget advisory — a malformed
+        // payload (missing required `phase`), an unknown sweep sub-topic, a
+        // non-integer issue segment, and an entirely unrelated topic all stay
+        // `Event::Generic` with the payload passed through UNCHANGED.
+        let (tm, db, sr, bus) = setup_test_context();
+
+        let cases: &[(&str, serde_json::Value)] = &[
+            // Documented topic, but the required `phase` field is missing.
+            ("sweep.issue.123.phase", serde_json::json!({"pr_number": 5})),
+            // Documented blocker topic, but `label_added` is missing.
+            ("sweep.issue.123.blocker", serde_json::json!({"reason": "x"})),
+            // Unknown sweep sub-topic.
+            ("sweep.issue.123.other", serde_json::json!({"phase": "builder"})),
+            // Non-integer issue segment.
+            ("sweep.issue.abc.phase", serde_json::json!({"phase": "builder"})),
+            // Entirely unrelated topic.
+            ("custom.topic", serde_json::json!({"phase": "builder"})),
+        ];
+
+        for (topic, payload) in cases {
+            let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+            handle_request(
+                Request::PublishEvent {
+                    topic: (*topic).to_string(),
+                    payload: payload.clone(),
+                },
+                &tm,
+                &db,
+                &sr,
+                &bus,
+                &test_pool(),
+            );
+            match sub.recv().await.unwrap() {
+                Event::Generic {
+                    topic: got_topic,
+                    payload: got_payload,
+                } => {
+                    assert_eq!(&got_topic, topic, "topic preserved for {topic}");
+                    assert_eq!(&got_payload, payload, "payload passed through for {topic}");
+                }
+                other => panic!("Expected Generic event for {topic}, got: {other:?}"),
+            }
         }
     }
 

--- a/loom-daemon/src/safehouse.rs
+++ b/loom-daemon/src/safehouse.rs
@@ -2449,6 +2449,40 @@ mod tests {
         assert!(event_to_envelope(&Event::TopicLag { skipped: 3 }).is_none());
     }
 
+    #[test]
+    fn narrates_child_published_phase_and_blocker_after_typed_upgrade() {
+        // Issue #4466: a child-published `sweep.issue.{N}.*` event arrives via
+        // `PublishEvent`; before the typed-upgrade fix it became `Event::Generic`
+        // and `event_to_envelope` returned `None` (silently dropped). Drive the
+        // exact `PublishEvent` construction (`Event::from_published`) end to end
+        // and assert the documented room lines now appear.
+        let phase = Event::from_published(
+            "sweep.issue.42.phase".to_owned(),
+            json!({"phase": "builder", "pr_number": 99, "repo": "/repos/vibesql"}),
+        );
+        let env = event_to_envelope(&phase).expect("phase must narrate (was dropped as Generic)");
+        assert_eq!(env.kind, "task");
+        assert_eq!(env.task_id.as_deref(), Some("vibesql_42"));
+        assert!(env.body.starts_with("vibesql#42 · builder"));
+        assert!(env.body.contains("PR #99 open"));
+
+        let blocker = Event::from_published(
+            "sweep.issue.42.blocker".to_owned(),
+            json!({"reason": "missing dep", "label_added": "loom:blocked", "repo": "/repos/vibesql"}),
+        );
+        let env =
+            event_to_envelope(&blocker).expect("blocker must narrate (was dropped as Generic)");
+        assert_eq!(env.kind, "handoff");
+        assert_eq!(env.body, "vibesql#42 · BLOCKED — missing dep");
+
+        // A malformed child payload still falls through to Generic and stays
+        // un-narrated (publish is fire-and-forget advisory — never rejected).
+        let malformed =
+            Event::from_published("sweep.issue.42.phase".to_owned(), json!({"pr_number": 1}));
+        assert!(matches!(malformed, Event::Generic { .. }));
+        assert!(event_to_envelope(&malformed).is_none());
+    }
+
     // ---- dispatch-title fetch (issue #4201, sink-side gh lookup) ----
 
     /// Write an executable fake `gh` script at `dir/fake-gh.sh` that logs its

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -1831,6 +1831,87 @@ impl Event {
             *slot = Some(repo.to_string());
         }
     }
+
+    /// Build the bus event for a child-published `PublishEvent { topic, payload }`
+    /// request (Issue #4466).
+    ///
+    /// The two **child-published** sweep topics — `sweep.issue.{N}.phase` and
+    /// `sweep.issue.{N}.blocker` — are upgraded to their typed [`Event`]
+    /// variants ([`Event::SweepPhase`] / [`Event::SweepBlocker`]) when the topic
+    /// parses and the payload matches the documented schema
+    /// (`defaults/.claude/commands/loom/sweep.md`). This is what lets the
+    /// narration sink ([`crate::safehouse::event_to_envelope`]) emit the
+    /// documented `task` / `handoff` room lines — a raw [`Event::Generic`] is
+    /// never narrated, so before this upgrade the child's phase/blocker lines
+    /// silently never reached the room.
+    ///
+    /// Publish is **fire-and-forget advisory**: an unknown topic, a
+    /// non-integer issue segment, or a payload that does not match the
+    /// documented schema is never rejected — it falls through to
+    /// [`Event::Generic`] with the topic + payload passed through **unchanged**
+    /// (byte-for-byte the pre-#4466 behavior for everything except the two
+    /// documented topics). Unknown fields in an otherwise-valid payload are
+    /// ignored for forward-compatibility.
+    #[must_use]
+    pub fn from_published(topic: String, payload: serde_json::Value) -> Self {
+        match Self::try_typed_child_event(&topic, &payload) {
+            Some(event) => event,
+            None => Self::Generic { topic, payload },
+        }
+    }
+
+    /// Attempt to parse a child-published `topic` + `payload` into a typed
+    /// sweep event. Returns `None` (→ caller keeps it [`Event::Generic`]) for
+    /// any topic outside the two documented child-published topics, or for a
+    /// payload that does not match the documented schema. See
+    /// [`Self::from_published`].
+    fn try_typed_child_event(topic: &str, payload: &serde_json::Value) -> Option<Self> {
+        // Segment-aligned parse of `sweep.issue.{N}.{kind}` — exactly four
+        // segments, matching the bus's segment-aligned prefix routing (so
+        // `sweep.issuetype.foo` is NOT mistaken for a sweep-issue topic).
+        let segments: Vec<&str> = topic.split('.').collect();
+        if segments.len() != 4 || segments[0] != "sweep" || segments[1] != "issue" {
+            return None;
+        }
+        let issue: u32 = segments[2].parse().ok()?;
+
+        match segments[3] {
+            "phase" => {
+                #[derive(Deserialize)]
+                struct PhasePayload {
+                    phase: String,
+                    #[serde(default)]
+                    pr_number: Option<i32>,
+                    #[serde(default)]
+                    repo: Option<String>,
+                }
+                let p: PhasePayload = serde_json::from_value(payload.clone()).ok()?;
+                Some(Self::SweepPhase {
+                    issue,
+                    phase: p.phase,
+                    pr_number: p.pr_number,
+                    repo: p.repo,
+                })
+            }
+            "blocker" => {
+                #[derive(Deserialize)]
+                struct BlockerPayload {
+                    reason: String,
+                    label_added: String,
+                    #[serde(default)]
+                    repo: Option<String>,
+                }
+                let p: BlockerPayload = serde_json::from_value(payload.clone()).ok()?;
+                Some(Self::SweepBlocker {
+                    issue,
+                    reason: p.reason,
+                    label_added: p.label_added,
+                    repo: p.repo,
+                })
+            }
+            _ => None,
+        }
+    }
 }
 
 /// The four action classes the epic supervisor emits on the event bus, one per
@@ -1982,6 +2063,139 @@ mod tests {
                 assert!(pr_number.is_none());
             }
             other => panic!("expected SweepPhase, got {other:?}"),
+        }
+    }
+
+    // ---- Issue #4466: child-published topics upgrade to typed variants ----
+
+    #[test]
+    fn from_published_upgrades_phase_topic() {
+        let ev = Event::from_published(
+            "sweep.issue.123.phase".to_string(),
+            serde_json::json!({"phase": "builder", "pr_number": 42, "repo": "/work/loom"}),
+        );
+        match ev {
+            Event::SweepPhase {
+                issue,
+                phase,
+                pr_number,
+                repo,
+            } => {
+                assert_eq!(issue, 123);
+                assert_eq!(phase, "builder");
+                assert_eq!(pr_number, Some(42));
+                assert_eq!(repo.as_deref(), Some("/work/loom"));
+            }
+            other => panic!("expected SweepPhase, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_published_upgrades_phase_topic_minimal_payload() {
+        // Only the required `phase` field — optionals default to None.
+        let ev = Event::from_published(
+            "sweep.issue.7.phase".to_string(),
+            serde_json::json!({"phase": "curator"}),
+        );
+        match ev {
+            Event::SweepPhase {
+                issue,
+                phase,
+                pr_number,
+                repo,
+            } => {
+                assert_eq!(issue, 7);
+                assert_eq!(phase, "curator");
+                assert!(pr_number.is_none());
+                assert!(repo.is_none());
+            }
+            other => panic!("expected SweepPhase, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_published_upgrades_blocker_topic() {
+        let ev = Event::from_published(
+            "sweep.issue.456.blocker".to_string(),
+            serde_json::json!({"reason": "needs human", "label_added": "loom:blocked"}),
+        );
+        match ev {
+            Event::SweepBlocker {
+                issue,
+                reason,
+                label_added,
+                repo,
+            } => {
+                assert_eq!(issue, 456);
+                assert_eq!(reason, "needs human");
+                assert_eq!(label_added, "loom:blocked");
+                assert!(repo.is_none());
+            }
+            other => panic!("expected SweepBlocker, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_published_keeps_generic_for_unknown_and_malformed() {
+        // Malformed payload (missing required field), unknown sub-topic,
+        // non-integer issue, and unrelated topics all stay Generic with the
+        // payload passed through unchanged.
+        let cases: &[(&str, serde_json::Value)] = &[
+            ("sweep.issue.1.phase", serde_json::json!({"pr_number": 5})),
+            ("sweep.issue.1.blocker", serde_json::json!({"reason": "x"})),
+            ("sweep.issue.1.other", serde_json::json!({"phase": "builder"})),
+            ("sweep.issue.abc.phase", serde_json::json!({"phase": "builder"})),
+            ("sweep.issuetype.foo", serde_json::json!({"phase": "builder"})),
+            ("custom.topic", serde_json::json!({"k": "v"})),
+        ];
+        for (topic, payload) in cases {
+            let ev = Event::from_published((*topic).to_string(), payload.clone());
+            match ev {
+                Event::Generic {
+                    topic: got_topic,
+                    payload: got_payload,
+                } => {
+                    assert_eq!(&got_topic, topic);
+                    assert_eq!(&got_payload, payload, "payload unchanged for {topic}");
+                }
+                other => panic!("expected Generic for {topic}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn from_published_phase_rejects_wrong_typed_pr_number() {
+        // A non-integer `pr_number` is a malformed payload → stays Generic.
+        let ev = Event::from_published(
+            "sweep.issue.1.phase".to_string(),
+            serde_json::json!({"phase": "builder", "pr_number": "not-an-int"}),
+        );
+        assert!(matches!(ev, Event::Generic { .. }));
+    }
+
+    #[test]
+    fn set_repo_if_absent_stamps_upgraded_child_events() {
+        // Issue #4466: an upgraded child-published event with no `repo` in its
+        // payload is stampable via the same `set_repo_if_absent` path the
+        // daemon uses for its own sweep events.
+        let mut phase = Event::from_published(
+            "sweep.issue.9.phase".to_string(),
+            serde_json::json!({"phase": "judge"}),
+        );
+        phase.set_repo_if_absent("/repos/stamped");
+        match &phase {
+            Event::SweepPhase { repo, .. } => assert_eq!(repo.as_deref(), Some("/repos/stamped")),
+            other => panic!("expected SweepPhase, got {other:?}"),
+        }
+
+        let mut blocker = Event::from_published(
+            "sweep.issue.9.blocker".to_string(),
+            serde_json::json!({"reason": "x", "label_added": "loom:blocked"}),
+        );
+        blocker.set_repo_if_absent("/repos/stamped");
+        match &blocker {
+            Event::SweepBlocker { repo, .. } => assert_eq!(repo.as_deref(), Some("/repos/stamped")),
+            other => panic!("expected SweepBlocker, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the narration hole where child-published `sweep.issue.{N}.phase` and `sweep.issue.{N}.blocker` events arrived on the bus as `Event::Generic` and were never narrated — despite `.loom/docs/safehouse.md`'s "What gets narrated" table and `event_bus.rs`'s topic table promising `task` / `handoff` room lines.

Root cause (verified against `origin/main`): `Request::PublishEvent` (`ipc.rs`) constructed `Event::Generic { topic, payload }` unconditionally, and `event_to_envelope` (`safehouse.rs`) returns `None` for `Generic`. The typed `SweepPhase` / `SweepBlocker` variants were production-dead — constructed only in tests and SSE frozen-frame fixtures. A silently dropped `blocker` (a human-must-act signal) was the worst instance.

## Approach — option (a) from the issue

The `PublishEvent` handler now upgrades exactly the two documented child-published topics to their typed variants via a new `Event::from_published(topic, payload)`:

- Segment-aligned parse of `sweep.issue.{N}.{phase|blocker}` (so `sweep.issuetype.foo` is not mistaken for a sweep topic).
- Payload validated against the documented schema (`defaults/.claude/commands/loom/sweep.md`) — `{phase, pr_number?, repo?}` / `{reason, label_added, repo?}`.
- **Unknown topics, non-integer issue segments, and malformed payloads fall through to `Event::Generic` with the topic + payload passed through unchanged** — publish stays fire-and-forget advisory, byte-for-byte the prior behavior for everything except the two documented topics.

`set_repo_if_absent` already covers both upgraded variants (verified by a new test). No variant, wire-format, or SSE-contract changes. The daemon-emitted topics (`exited`/`crashed`/dispatch) are untouched. Docs already promised this behavior, so no doc edits were needed — the runtime now matches.

## Tests

- `types.rs`: `from_published` upgrades phase + blocker (full + minimal payload); malformed/unknown/non-integer/`sweep.issuetype.*`/unrelated topics stay `Generic` unchanged; wrong-typed `pr_number` stays `Generic`; `set_repo_if_absent` stamps upgraded child events.
- `ipc.rs`: `Request::PublishEvent` for `sweep.issue.123.phase` → bus receives typed `SweepPhase`; `.blocker` → `SweepBlocker`; `pr_number`+`repo` survive; the malformed/unknown matrix stays `Generic`. The pre-existing Generic-asserting test was updated deliberately.
- `safehouse.rs`: end-to-end `from_published` → `event_to_envelope` produces the documented `task` (`<repo>#N · <phase> · PR #M open`) and `handoff` (`<repo>#N · BLOCKED — <reason>`) lines; a malformed child payload stays `Generic` and un-narrated.

`cargo test -p loom-daemon --lib`: 2166 passed, 0 failed. `cargo fmt --check` clean. `cargo clippy --lib` clean.

Closes #4466

🤖 Generated with [Claude Code](https://claude.com/claude-code)