### PR TITLE
docs: document loom-daemon serve (fleet dashboard) security posture and endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,7 @@ Configuration lives in `.loom/config.json` (committed for team sharing): a
 - **MCP hooks** — the unified `mcp-loom` server is registered once per machine at
   user scope (`scripts/install-loom.sh`, refreshed by `loom update`); `setup-mcp.sh`
   is demoted to a bundle-rebuild/legacy-migration tool. See the mcp-loom README.
+- **Fleet dashboard** (`loom-daemon serve`, opt-in, read-only, loopback by default): [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) §Fleet dashboard.
 
 ### Multi-Account Token Pool (operating summary)
 

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -3880,6 +3880,86 @@ throwaway issue from `loom:triage` → Curator → `loom:issue` → work-finder
 dispatch → PR → merge, with a scripted label-transition assertion, and confirms
 the operator only ever created the issue.
 
+## Fleet dashboard (`loom-daemon serve`)
+
+`loom-daemon serve` (#4329 phases 1-3: #4391 status snapshot, #4392 SSE event
+tail, #4393 page rendering) starts a **separate, opt-in** read-only HTTP
+listener that proxies the running daemon's existing Unix socket for
+browser-based fleet visibility. It is not part of the normal daemon-run path —
+a daemon started without `serve` never opens this port, and `serve` itself
+never mutates daemon state or the sweep registry; every request re-fetches a
+live snapshot over IPC.
+
+### Starting it
+
+```bash
+loom-daemon serve                                   # http://127.0.0.1:7420/
+loom-daemon serve --port 9000                        # non-default port, still loopback-only
+loom-daemon serve --peers http://host2:7420,http://host3:7420   # multihost fleet view
+```
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--port` | `7420` | TCP port for the HTTP listener |
+| `--bind` | `127.0.0.1` | Interface address to bind |
+| `--allow-non-loopback` | off | Required opt-in to bind any non-loopback `--bind` address |
+| `--peers` | `""` (empty) | Comma-separated peer `serve` base URLs, served verbatim at `GET /api/peers` for client-side fan-out |
+
+### Security posture (localhost-only invariant)
+
+- **Off by default**: nothing listens on any port unless `loom-daemon serve`
+  is explicitly invoked — a plain `loom-daemon` run (autonomous or not) never
+  opens this listener.
+- **Binds `127.0.0.1` by default.** A wildcard/unspecified bind (`0.0.0.0` /
+  `::`) is refused **unconditionally**, even with `--allow-non-loopback` —
+  this endpoint can never become reachable from the public internet, only
+  from an explicit interface address.
+- A non-loopback `--bind` (e.g. a tailnet interface address, for cross-host
+  fleet visibility) requires the *separate* explicit `--allow-non-loopback`
+  flag — the bind address alone is never enough to opt in.
+- **Read-only, stateless, no steering endpoints.** Every route is a bare
+  `GET`; any other method gets `405`. The SSE bridge only ever sends the
+  IPC `SubscribeEvents` request — it never publishes an event and never
+  writes to the daemon socket beyond that one subscribe call, so nothing
+  this listener originates can appear on the bus. Nothing is written to
+  disk. There is no dispatch/cancel/restart/steering route of any kind.
+- Every response carries a permissive `Access-Control-Allow-Origin: *`
+  header (required for the dashboard's client-side peer fan-out); this is
+  judged safe specifically because the surface is read-only, carries no
+  credentials, and is loopback-by-default — the bind posture is the
+  access-control layer, not CORS.
+
+### What it serves
+
+| Route | Content |
+|-------|---------|
+| `GET /` | The embedded single-page dashboard (plain HTML/CSS/vanilla JS, no build toolchain, compiled into the binary) |
+| `GET /api/status` | JSON status snapshot: the same `DaemonStatusReport` `loom-daemon status --json` aggregates, flattened with a `hostname` field |
+| `GET /api/events` | `text/event-stream` (SSE) tail of the daemon's event bus |
+| `GET /api/pipeline` | Forge-side queue counts per managed repo (same source `status --pipeline` uses), fronted by a 20s in-process cache |
+| `GET /api/tokens` | Per-account rows (name / status / 5h utilization) read from the resolved token pool's `.ranking` file |
+| `GET /api/peers` | The configured `--peers` list, verbatim — this daemon never fetches a peer itself; the browser fetches each peer's own `/api/status`/`/api/events` directly |
+
+The dashboard page renders: the in-flight sweep registry, the dynamic
+concurrency cap/capacity breakdown, per-token usage bars, the per-repo
+main-health gate state, per-repo pipeline queue counts, configured fleet
+peers, and a live event tail — each panel backed by one of the routes above.
+
+### Event tail topics
+
+`GET /api/events` subscribes to the six frozen `sweep.*` topics from the
+[event taxonomy](#event-taxonomy-frozen-for-v0100) above — `sweep.issue.{N}.phase`,
+`.blocker`, `.exited`, `.crashed`, `sweep.global.dispatch`, and
+`sweep.global.completed` — through the exact same `SubscribeEvents` IPC
+request and `event_bus::topic_matches` prefix filter every other subscriber
+uses. It additionally includes the already-authorized `epic.issue.*`,
+`daemon.capacity.advisory`, `daemon.drain.*`, and
+`daemon.dispatch.headroom_advisory` topics, clearly separable from the
+frozen six because every SSE frame carries its exact source topic in the
+JSON payload (never renamed or re-namespaced). There is no replay buffer:
+a reconnecting client (`EventSource`'s built-in retry) resumes from live,
+never from history.
+
 ## Locks and lifecycle
 
 Each dispatched sweep acquires a directory lock under


### PR DESCRIPTION
## Summary

Phase 4 of 4 (docs) for #4329's fleet dashboard. Documents `loom-daemon serve` — the read-only local fleet dashboard shipped in phases 1-3 (#4391, #4392, #4393, all merged) — in `defaults/docs/daemon-reference.md`, plus a single-line pointer from `CLAUDE.md`.

## Changes

- `defaults/docs/daemon-reference.md`: new "Fleet dashboard (`loom-daemon serve`)" section covering:
  - How to start it (`loom-daemon serve`, flags `--port`/`--bind`/`--allow-non-loopback`/`--peers`, all verified against `main.rs`'s `Serve` subcommand definition).
  - The security posture actually shipped: off by default, `127.0.0.1` bind by default, wildcard (`0.0.0.0`/`::`) refused unconditionally even with `--allow-non-loopback`, non-loopback bind requires the separate explicit `--allow-non-loopback` opt-in, read-only/no steering endpoints, permissive CORS and why it's safe here.
  - What each route serves (`GET /`, `/api/status`, `/api/events`, `/api/pipeline`, `/api/tokens`, `/api/peers`) and what the dashboard page renders (registry, cap/capacity breakdown, token bars, per-repo gate state, pipeline queue counts, fleet peers, live event tail).
  - The event-tail topics: the six frozen `sweep.*` topics (`sweep.issue.{N}.phase/blocker/exited/crashed`, `sweep.global.dispatch`, `sweep.global.completed`) plus the already-authorized optional topics (`epic.issue.*`, `daemon.capacity.advisory`, `daemon.drain.*`, `daemon.dispatch.headroom_advisory`), clearly labeled as separate from the frozen six.
- `.loom/docs/daemon-reference.md` is a symlink to `defaults/docs/daemon-reference.md`, so it follows automatically — no separate edit needed.
- `CLAUDE.md`: one-line pointer bullet under "## Configuration" — no inline detail, per repo convention.

All facts (route paths, flag names/defaults, bind-validation rules, topic list) were pulled directly from the merged `loom-daemon/src/serve.rs` and `loom-daemon/src/main.rs` `Serve` subcommand, not re-derived from the original proposal text.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `scripts/check-claude-md-budget.sh` passes after the `CLAUDE.md` edit | ✅ | `./scripts/check-claude-md-budget.sh` → "OK — CLAUDE.md is 315 lines (budget 320)" |
| Doc lists default bind address | ✅ | "Binds `127.0.0.1` by default" in Security posture section |
| Doc lists off-by-default behavior | ✅ | "Off by default: nothing listens... unless `loom-daemon serve` is explicitly invoked" |
| Doc lists the opt-in flag for non-loopback | ✅ | `--allow-non-loopback` documented in the flags table and Security posture section, including the wildcard-refused-even-with-flag rule |
| Doc lists the endpoints served (`/`, JSON snapshot, SSE) | ✅ | "What it serves" table: `/`, `/api/status`, `/api/events`, plus `/api/pipeline`/`/api/tokens`/`/api/peers` (also shipped in phase 3) |
| Doc lists the six frozen event topics (+ optional authorized topics) | ✅ | "Event tail topics" section names all six frozen topics plus the four optional-but-authorized topic families, explicitly distinguished |
| `CLAUDE.md` change is a single-line pointer, no inline detail | ✅ | One bullet line added under "## Configuration", linking to the new doc section |

## Test Plan

```
$ ./scripts/check-claude-md-budget.sh
check-claude-md-budget: OK — CLAUDE.md is 315 lines (budget 320).
```

- Manually cross-checked every documented flag name, default, endpoint path, and topic list against `loom-daemon/src/serve.rs` and the `Serve` subcommand in `loom-daemon/src/main.rs` on `origin/main` (all three dependency phases merged).
- `git diff --stat` confirms only `CLAUDE.md` and `defaults/docs/daemon-reference.md` changed (docs-only PR, no code).

Closes #4394