### PR TITLE
feat(daemon): fleet spin-up/teardown safehouse provisioning (#3998)

### DIFF
--- a/.loom/docs/safehouse.md
+++ b/.loom/docs/safehouse.md
@@ -18,10 +18,13 @@ below.
 > **Out of scope** (tracked separately): per-worker personas (`loom_builder_42`)
 > and `SAFEHOUSE_PERSONA` forwarding to workers → **#3999**; inbound **human**
 > steering (reading `@`-mentions back to agents) → follow-up (it reuses the same
-> inbound read task #4028 adds); cloud-host provisioning of `safehoused` →
-> **#3998**; carrying the judge verdict value in an event payload (needs a
-> frozen-taxonomy amendment) → follow-up; the **atomic cross-host claim
-> authority** (a real CAS behind the soft claim) → Phase 2 of #4028.
+> inbound read task #4028 adds); carrying the judge verdict value in an event
+> payload (needs a frozen-taxonomy amendment) → follow-up; the **atomic
+> cross-host claim authority** (a real CAS behind the soft claim) → Phase 2 of
+> #4028. Cloud-host provisioning of `safehoused` (formerly tracked here as
+> **#3998**) has landed — see
+> [Fleet provisioning: cloud workers](#fleet-provisioning-cloud-workers-fleet-add-worker---safehouse-3998)
+> below.
 
 ## The degradation contract (read this first)
 
@@ -250,6 +253,99 @@ wrapper only supervises an operator-supplied binary and bakes a minimal,
 non-secret environment (`SAFEHOUSED_SOCKET` / `SAFEHOUSED_CONFIG` when
 provided; never a forwarded token). If the safehouse repo ships its own service
 files, point the runbook at those and treat this generator as the fallback.
+
+## Fleet provisioning: cloud workers (`fleet add-worker --safehouse`, #3998)
+
+The onboarding runbook above is for an interactive host an operator sets up by
+hand. `loom-daemon fleet add-worker <ssh-host> --repo <owner/name> --safehouse
+<inputs>` (epic #4340, `loom-daemon/src/fleet/add_worker.rs`) is the same
+onboarding **encoded as an ordered, idempotent plan** that a cloud worker's
+spin-up runs unattended over SSH — no cloud-init fragment, no cloud CLI, no
+Tailscale API call from loom itself (epic #4340's boundary: a VM comes from
+`repo:remote`, loom only consumes "a reachable box + an SSH alias").
+
+### What the plan does
+
+With `--safehouse`, `fleet add-worker` appends seven steps after the plain
+worker's bootstrap (each following the same check/apply contract as the rest
+of the plan, so a re-run against an already-provisioned host reports every one
+`AlreadyDone`):
+
+1. **`safehouse-tailscale-install`** — installs the `tailscale` apt package.
+2. **`safehouse-tailscale-join`** — `tailscale up --auth-key=file:<path>` with
+   the operator-minted key (below). No `--advertise-tags`: the tag is baked
+   into the key server-side.
+3. **`safehouse-build`** — `cargo build --release -p safehoused` from a fresh
+   `rjwalters/safehouse` checkout.
+4. **`safehouse-config`** — writes `~/.loom/safehoused/config.toml` (`0600`):
+   homeserver URL, the per-host Matrix account, fresh store/recovery
+   passphrases, and the persona allowlist. **Must precede step 6** — the
+   allowlist is boot-time-only (no reload), and the plan's step order enforces
+   this (asserted in `add_worker.rs`'s tests).
+5. **`safehouse-room-invite`** — joins the fleet room via
+   [safehouse#39](https://github.com/rjwalters/safehouse/issues/39)'s
+   daemon-side `invite` op — never raw CS-API temporary devices. loom does not
+   vendor this invocation (owned by the external repo); override it with
+   `--safehouse-invite-exec "<argv>"` if it changes upstream.
+6. **`safehouse-supervise`** — installs `safehoused` under `systemd --user` via
+   [`safehoused-service.sh`](#supervised-service-wrapper-safehoused-servicesh-4346)
+   (the same script the interactive runbook uses) and enables lingering.
+7. **`safehouse-daemon-restart`** — wires `LOOM_SAFEHOUSE_ENABLED` /
+   `_SOCKET` / `_ROOM` into the worker's own `loom-daemon` systemd unit and
+   restarts it — env-only, per #3997's decision (no worker-side
+   `.loom/config.json` edit).
+
+**Without `--safehouse`, behavior is byte-for-byte unchanged**: a single
+`safehouse` skip-with-notice entry, a plain worker, zero safehouse
+provisioning.
+
+### Inputs the operator must mint
+
+Every secret travels the same way `AddWorkerConfig`'s existing `--pat-file` /
+`--accounts-env` do: read locally at preflight, transferred to the worker only
+over **ssh stdin**, landing only in `0600` files. None of these ever appear on
+a command line, in the rendered `--dry-run` plan text, in a daemon log at any
+level, or in the fleet registry.
+
+| Flag | Contents | Notes |
+|---|---|---|
+| `--safehouse-tailnet-auth-key-file PATH` | A Tailscale auth key | **Operator-minted, ephemeral + `tag:loom-worker`** — loom never calls the Tailscale API. Ephemeral means a dead VM auto-deregisters from the tailnet with no fleet-roster bookkeeping. |
+| `--safehouse-secrets-file PATH` | `KEY=VALUE` lines: `SAFEHOUSE_MATRIX_USER_ID`, `SAFEHOUSE_MATRIX_PASSWORD`, `SAFEHOUSE_STORE_PASSPHRASE`, `SAFEHOUSE_RECOVERY_PASSPHRASE` | The Matrix account is **operator-created** on the homeserver (the [safehouse#25 verified sequence](#operator-setup-provisioning-the-persona-requires-a-safehoused-restart)) — `fleet add-worker` never needs homeserver admin credentials, only the resulting account. Passphrases are freshly generated per host. |
+| `--safehouse-homeserver-url URL` | Not secret | Must resolve inside the tailnet. |
+| `--safehouse-room ROOM` | Not secret | The fleet room this host joins. |
+| `--safehouse-persona NAME` (repeatable) | Not secret | Mirrors the studio host's allowlist (#3999) — at least one required. |
+| `--safehouse-repo-url URL` | Not secret | Defaults to `rjwalters/safehouse`. |
+| `--safehouse-invite-exec "ARGV"` | Not secret | Overrides the default `safehoused invite --config <path>` if safehouse#39's CLI surface changes upstream. |
+
+`--safehouse` with any of the first five omitted fails **preflight** — before
+any SSH connection — with a message naming exactly which flag is missing (no
+half-joined host).
+
+### Required tailnet ACL
+
+The auth key's `tag:loom-worker` is expected to carry an ACL restricting
+workers to reaching only the homeserver's `443`, not the rest of the tailnet.
+loom documents this requirement; it does not manage the tailnet ACL itself
+(epic #4340's boundary — no Tailscale API call from this repo).
+
+### Teardown: `fleet drain`'s flush verification
+
+`fleet drain <ssh-host>`'s `flush-safehouse` phase (`loom-daemon/src/fleet/drain.rs`)
+is the spin-up's counterpart: it stops the worker's `safehoused` unit over SSH
+(`systemctl --user stop safehoused`) — a supervised stop **is** the flush,
+since safehoused's SIGTERM/ctrl-c shutdown path calls
+`client.encryption().backups().wait_for_steady_state()` and prints
+`"safehoused: room-key backup flushed; bye"` before exiting — then verifies via
+the journal line, falling back to the unit's `ExecMainStatus` when the journal
+has rotated. The verdict maps onto drain's existing contract:
+
+- `safehouse.enabled == false` — `Skipped`, no room keys in play, exit `0`.
+- Flush verified — `Changed`, eligible for "safe to power off", exit `0`.
+- Flush **not** verified (nonzero remote exit, or the host was unreachable) —
+  `Unverified`; the drain still completes (workspace/roster cleanup proceed —
+  loom never refuses to retire a box over this), but the report withholds
+  "safe to power off" and exits `3` so an operator/monitor treats it as a flag,
+  not a clean success.
 
 ## What gets narrated
 

--- a/loom-daemon/src/fleet/add_worker.rs
+++ b/loom-daemon/src/fleet/add_worker.rs
@@ -32,6 +32,27 @@ use super::{
 /// Default upstream Loom repo cloned to the worker's machine-level layout.
 pub const DEFAULT_LOOM_REPO_URL: &str = "https://github.com/rjwalters/loom";
 
+/// Default checkout the `safehoused` binary is built from on the worker
+/// (issue #3998's spin-up half — `safehoused` itself is owned by the external
+/// `rjwalters/safehouse` repo, never vendored here).
+pub const DEFAULT_SAFEHOUSE_REPO_URL: &str = "https://github.com/rjwalters/safehouse";
+
+/// The AF_UNIX socket path `safehoused` is supervised to bind on a fleet
+/// worker, and the value wired into the worker's `loom-daemon` unit as
+/// `LOOM_SAFEHOUSE_SOCKET` (#3998). Deterministic (not resolved via the
+/// shared `mcp-config.sh` chain) so the two ends of the pipe always agree on
+/// a fresh worker with no prior `.loom/config.json` safehouse block.
+const SAFEHOUSE_SOCKET_PATH: &str = "$HOME/.loom/safehoused.sock";
+
+/// Default invocation for the safehouse#39 daemon-side room-membership
+/// `invite` op, run once against the freshly-written config so the host's
+/// Matrix account joins the fleet room without raw CS-API temp devices.
+/// Overridable via `--safehouse-invite-exec` (mirrors
+/// `safehoused-service.sh`'s `--exec`: this repo does not vendor safehoused's
+/// argv, since that is owned by the external `rjwalters/safehouse` repo).
+const DEFAULT_SAFEHOUSE_INVITE_EXEC: &str =
+    r#"safehoused invite --config "$HOME/.loom/safehoused/config.toml""#;
+
 /// Base directory (systemd `%h`-relative) under which workspace repos are
 /// cloned on the worker.
 const WORKSPACE_BASE: &str = "loom-workspaces";
@@ -63,6 +84,36 @@ pub struct AddWorkerConfig {
     /// Idle-shutdown guard: power the host off after this many idle minutes.
     /// `None` disables the guard.
     pub idle_shutdown_minutes: Option<u32>,
+    /// Local path to the operator-minted, ephemeral + `tag:loom-worker`
+    /// Tailscale auth key. Read locally at preflight; transferred to the
+    /// worker only via ssh stdin. Required when `safehouse_enabled`.
+    pub safehouse_tailnet_auth_key_file: Option<PathBuf>,
+    /// Local path to a `KEY=VALUE` env-style file carrying the per-host
+    /// Matrix account credentials and store/recovery passphrases
+    /// (`SAFEHOUSE_MATRIX_USER_ID`, `SAFEHOUSE_MATRIX_PASSWORD`,
+    /// `SAFEHOUSE_STORE_PASSPHRASE`, `SAFEHOUSE_RECOVERY_PASSPHRASE`). Read
+    /// locally at preflight; transferred to the worker only via ssh stdin.
+    /// Required when `safehouse_enabled`.
+    pub safehouse_secrets_file: Option<PathBuf>,
+    /// The external `rjwalters/safehouse` checkout `safehoused` is built
+    /// from on the worker.
+    pub safehouse_repo_url: String,
+    /// The homeserver URL (resolves inside the tailnet) written into
+    /// safehoused's config. Not secret. Required when `safehouse_enabled`.
+    pub safehouse_homeserver_url: Option<String>,
+    /// The fleet room safehoused joins. Not secret. Required when
+    /// `safehouse_enabled`.
+    pub safehouse_room: Option<String>,
+    /// The persona allowlist this host's `safehoused` boots with — mirrors
+    /// the studio host's allowlist (#3999). Not secret. Must be non-empty
+    /// when `safehouse_enabled`; written into the boot-time TOML **before**
+    /// safehoused's first start (hard ordering constraint — no reload).
+    pub safehouse_personas: Vec<String>,
+    /// Override for the safehouse#39 room-`invite` op invocation. `None`
+    /// uses [`DEFAULT_SAFEHOUSE_INVITE_EXEC`]. loom does not vendor
+    /// safehoused's real CLI surface (owned by the external repo), so this
+    /// mirrors `safehoused-service.sh --exec`.
+    pub safehouse_invite_exec: Option<String>,
 }
 
 /// Secret payloads read locally during preflight, then fed to the plan over
@@ -73,6 +124,12 @@ pub struct Secrets {
     pub pat: Option<String>,
     /// `accounts.env` contents, if `--accounts-env` was supplied.
     pub accounts_env: Option<String>,
+    /// Tailnet auth-key contents, if `--safehouse-tailnet-auth-key-file` was
+    /// supplied.
+    pub safehouse_tailnet_auth_key: Option<String>,
+    /// The safehouse secrets env-file contents, if
+    /// `--safehouse-secrets-file` was supplied.
+    pub safehouse_secrets: Option<String>,
 }
 
 /// The production [`CommandRunner`]: runs one rendered shell command per call
@@ -159,6 +216,45 @@ fn repo_dir_name(repo: &str) -> &str {
     repo.rsplit('/').next().unwrap_or(repo)
 }
 
+/// Non-secret operator strings that get interpolated into rendered shell
+/// (homeserver URL, room) must pass this before they are ever formatted into
+/// a step's `apply`/`check` text — mirrors [`validate_repo`]'s shell-injection
+/// defense for the same reason: this text is echoed verbatim in `--dry-run`
+/// output and executed on the worker.
+fn validate_safe_token(label: &str, value: &str, extra: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        bail!("--{label} must not be empty");
+    }
+    if !value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || extra.contains(c))
+    {
+        bail!(
+            "--{label} '{value}' contains characters outside [A-Za-z0-9{extra}]; refusing to \
+             render it into shell"
+        );
+    }
+    Ok(())
+}
+
+/// A safehouse persona name: `[a-z0-9_]`, 1..=64 chars (mirrors
+/// `safehouse.rs`'s `valid_persona` charset — this module cannot depend on
+/// `safehouse` directly without pulling in its async/tokio surface, so the
+/// charset is duplicated deliberately, the same tradeoff `drain.rs`'s module
+/// doc makes for `DEFAULT_DRAIN_TIMEOUT_SECS`).
+fn validate_persona_name(persona: &str) -> Result<()> {
+    if persona.is_empty() || persona.len() > 64 {
+        bail!("--safehouse-persona '{persona}' must be 1..=64 characters");
+    }
+    if !persona
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    {
+        bail!("--safehouse-persona '{persona}' must match [a-z0-9_]");
+    }
+    Ok(())
+}
+
 /// `%h`-relative workspace path for a repo (systemd expands `%h` to the user's
 /// home in a user unit; the shell steps use `"$HOME/..."` for the same path).
 fn workspace_rel(repo: &str) -> String {
@@ -199,6 +295,77 @@ pub fn preflight(config: &AddWorkerConfig) -> Result<Secrets> {
         }
         secrets.accounts_env = Some(contents);
     }
+
+    // Safehouse (#3998): when requested, every input is required up front —
+    // a half-specified `--safehouse` would otherwise render a broken plan
+    // (a config step with no homeserver/room, or a join step with no key)
+    // rather than failing fast before any remote action (AC: "no half-joined
+    // host").
+    if config.safehouse_enabled {
+        let mut missing = Vec::new();
+        if config.safehouse_tailnet_auth_key_file.is_none() {
+            missing.push("--safehouse-tailnet-auth-key-file");
+        }
+        if config.safehouse_secrets_file.is_none() {
+            missing.push("--safehouse-secrets-file");
+        }
+        if config
+            .safehouse_homeserver_url
+            .as_deref()
+            .unwrap_or("")
+            .trim()
+            .is_empty()
+        {
+            missing.push("--safehouse-homeserver-url");
+        }
+        if config
+            .safehouse_room
+            .as_deref()
+            .unwrap_or("")
+            .trim()
+            .is_empty()
+        {
+            missing.push("--safehouse-room");
+        }
+        if config.safehouse_personas.is_empty() {
+            missing.push("--safehouse-persona (at least one)");
+        }
+        if !missing.is_empty() {
+            bail!(
+                "--safehouse requires the following input(s), none of which were supplied: {}",
+                missing.join(", ")
+            );
+        }
+        if let Some(homeserver) = &config.safehouse_homeserver_url {
+            validate_safe_token("safehouse-homeserver-url", homeserver, ".:/_-")?;
+        }
+        if let Some(room) = &config.safehouse_room {
+            validate_safe_token("safehouse-room", room, "!#:._-")?;
+        }
+        for persona in &config.safehouse_personas {
+            validate_persona_name(persona)?;
+        }
+    }
+    if let Some(path) = &config.safehouse_tailnet_auth_key_file {
+        let contents = std::fs::read_to_string(path).with_context(|| {
+            format!("reading --safehouse-tailnet-auth-key-file {} (does it exist?)", path.display())
+        })?;
+        let trimmed = contents.trim();
+        if trimmed.is_empty() {
+            bail!("--safehouse-tailnet-auth-key-file {} is empty", path.display());
+        }
+        secrets.safehouse_tailnet_auth_key = Some(trimmed.to_string());
+    }
+    if let Some(path) = &config.safehouse_secrets_file {
+        let contents = std::fs::read_to_string(path).with_context(|| {
+            format!("reading --safehouse-secrets-file {} (does it exist?)", path.display())
+        })?;
+        if contents.trim().is_empty() {
+            bail!("--safehouse-secrets-file {} is empty", path.display());
+        }
+        secrets.safehouse_secrets = Some(contents);
+    }
+
     Ok(secrets)
 }
 
@@ -339,18 +506,19 @@ pub fn build_plan(config: &AddWorkerConfig, secrets: &Secrets) -> Plan {
         ),
     }
 
-    // 10. Optional safehouse wiring (#3998 not yet landed → skip-with-notice).
+    // 10. Optional safehouse wiring: tailnet join, safehoused build/config/
+    //     room-invite/supervision, then restart the worker's loom-daemon with
+    //     LOOM_SAFEHOUSE_* env so narration flows (#3998). Every sub-step
+    //     below follows the same check/apply contract as the rest of the
+    //     plan, so a re-run against an already-provisioned host (the pilot,
+    //     `loom-worker-1`) reports every one `AlreadyDone`.
     if config.safehouse_enabled {
-        plan.push_skip(
-            "safehouse",
-            "wire safehouse fleet-comms (tailnet join, account, LOOM_SAFEHOUSE_* env)",
-            "requires #3998 (safehoused provisioning fragment) which has not landed",
-        );
+        push_safehouse_steps(&mut plan, config, secrets, &primary_rel);
     } else {
         plan.push_skip(
             "safehouse",
             "wire safehouse fleet-comms",
-            "safehouse not requested (pass --safehouse to enable once #3998 lands)",
+            "safehouse not requested (pass --safehouse plus its input flags to enable)",
         );
     }
 
@@ -363,6 +531,110 @@ pub fn build_plan(config: &AddWorkerConfig, secrets: &Secrets) -> Plan {
     ));
 
     plan
+}
+
+/// Append the safehouse spin-up sub-sequence (#3998) to `plan`: tailnet join,
+/// `safehoused` build, boot-time TOML config, room-membership invite,
+/// supervision, then a restart of the worker's own `loom-daemon` with
+/// `LOOM_SAFEHOUSE_*` env. Split out of [`build_plan`] purely for
+/// readability — still pure, still called only when `config.safehouse_enabled`.
+///
+/// **Ordering is the load-bearing part of this function**: `safehouse-config`
+/// (which writes the boot-time persona TOML) MUST precede
+/// `safehouse-supervise` (which first starts `safehoused`) — the allowlist is
+/// boot-time-only, no reload (AC: "written before the unit first starts").
+fn push_safehouse_steps(
+    plan: &mut Plan,
+    config: &AddWorkerConfig,
+    secrets: &Secrets,
+    primary_rel: &str,
+) {
+    // 10a. Install the tailscale package (apt repo, arch/codename-agnostic).
+    plan.push_step(Step::new(
+        "safehouse-tailscale-install",
+        "install the tailscale package (apt repo)",
+        Some("command -v tailscale >/dev/null 2>&1".to_string()),
+        render_safehouse_tailscale_install(),
+    ));
+
+    // 10b. Join the tailnet with an operator-minted ephemeral + tag:loom-worker
+    //     auth key (fed over stdin, never on a command line — an expired/
+    //     revoked key fails this step's apply fast, with tailscale's own
+    //     diagnostic surfaced via the checklist's stderr tail).
+    plan.push_step(
+        Step::new(
+            "safehouse-tailscale-join",
+            "tailscale up with an ephemeral + tag:loom-worker auth key (via stdin)",
+            Some("tailscale ip -4 >/dev/null 2>&1".to_string()),
+            render_safehouse_tailscale_join(),
+        )
+        .with_stdin(StepStdin {
+            content: secrets
+                .safehouse_tailnet_auth_key
+                .clone()
+                .unwrap_or_default(),
+            secret: true,
+        }),
+    );
+
+    // 10c. Build safehoused from the external rjwalters/safehouse checkout.
+    plan.push_step(Step::new(
+        "safehouse-build",
+        "cargo build --release -p safehoused from a safehouse checkout",
+        Some(r#"test -x "$HOME/.local/bin/safehoused""#.to_string()),
+        render_safehouse_build(&config.safehouse_repo_url),
+    ));
+
+    // 10d. Write the boot-time config.toml (0600): homeserver URL, per-host
+    //     Matrix account, fresh store/recovery passphrases (via stdin), and
+    //     the persona allowlist mirroring the studio host. MUST land before
+    //     10f (first start) — see this function's doc comment.
+    let homeserver = config.safehouse_homeserver_url.as_deref().unwrap_or("");
+    let room = config.safehouse_room.as_deref().unwrap_or("");
+    plan.push_step(
+        Step::new(
+            "safehouse-config",
+            "write ~/.loom/safehoused/config.toml (0600): homeserver, account, passphrases, personas",
+            Some(r#"test -f "$HOME/.loom/safehoused/config.toml""#.to_string()),
+            render_safehouse_config(homeserver, room, &config.safehouse_personas),
+        )
+        .with_stdin(StepStdin {
+            content: secrets.safehouse_secrets.clone().unwrap_or_default(),
+            secret: true,
+        }),
+    );
+
+    // 10e. Room membership via safehouse#39's daemon-side `invite` op — not
+    //     raw CS-API temp devices.
+    plan.push_step(Step::new(
+        "safehouse-room-invite",
+        "join the fleet room via safehouse#39's invite op",
+        Some(r#"test -f "$HOME/.loom/safehoused/.invited""#.to_string()),
+        render_safehouse_room_invite(config.safehouse_invite_exec.as_deref()),
+    ));
+
+    // 10f. Supervise safehoused under systemd --user + linger (mirrors the
+    //     daemon-unit step's own supervision pattern, step 8). This is the
+    //     first point safehoused ever starts — 10d must precede this.
+    plan.push_step(Step::new(
+        "safehouse-supervise",
+        "install + enable the safehoused systemd --user unit (linger)",
+        Some("systemctl --user is-enabled safehoused.service >/dev/null 2>&1".to_string()),
+        render_safehouse_supervise(primary_rel),
+    ));
+
+    // 10g. Restart the worker's own loom-daemon with LOOM_SAFEHOUSE_* env so
+    //     sweep narration flows (env-only wiring, #3997 — no worker-side
+    //     .loom/config.json edit).
+    plan.push_step(Step::new(
+        "safehouse-daemon-restart",
+        "wire LOOM_SAFEHOUSE_ENABLED/SOCKET/ROOM into the loom-daemon unit and restart it",
+        Some(
+            r#"grep -q '^Environment=LOOM_SAFEHOUSE_ENABLED=true$' "$HOME/.config/systemd/user/loom-daemon.service" 2>/dev/null"#
+                .to_string(),
+        ),
+        render_safehouse_daemon_restart(room),
+    ));
 }
 
 /// Top-level orchestration for `loom-daemon fleet add-worker`.
@@ -693,9 +965,160 @@ LIST="$(loom-daemon workspace list --json 2>/dev/null || echo '{{}}')"
     )
 }
 
+// ---------------------------------------------------------------------------
+// Safehouse spin-up templates (#3998)
+// ---------------------------------------------------------------------------
+
+fn render_safehouse_tailscale_install() -> String {
+    // Codename-derived apt repo (works across Ubuntu releases, not just the
+    // pilot's 24.04/"noble") — the same approach `base-deps` uses for the gh
+    // apt repo.
+    r#"set -e
+if ! command -v tailscale >/dev/null 2>&1; then
+  CODENAME="$(lsb_release -cs 2>/dev/null || echo noble)"
+  curl -fsSL "https://pkgs.tailscale.com/stable/ubuntu/${CODENAME}.noarmor.gpg" | sudo tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
+  curl -fsSL "https://pkgs.tailscale.com/stable/ubuntu/${CODENAME}.tailscale-keyring.list" | sudo tee /etc/apt/sources.list.d/tailscale.list >/dev/null
+  sudo apt-get update -qq
+  sudo apt-get install -y tailscale
+fi
+sudo systemctl enable --now tailscaled 2>/dev/null || true
+"#
+    .to_string()
+}
+
+fn render_safehouse_tailscale_join() -> String {
+    // The auth key arrives on stdin; written to a 0600 tempfile and fed to
+    // `tailscale up` via the `file:` prefix so the raw key never appears on
+    // the command line (where `ps` on the worker would expose it) or in a
+    // rendered plan/log line. The key is operator-minted ephemeral +
+    // tag:loom-worker (epic #4340's boundary: loom never calls the Tailscale
+    // API itself), so no --advertise-tags flag is needed here — the tag is
+    // baked into the key server-side.
+    r#"set -e
+umask 077
+KEY_FILE="$(mktemp)"
+cat > "$KEY_FILE"
+chmod 600 "$KEY_FILE"
+sudo tailscale up --auth-key="file:$KEY_FILE" --hostname="$(hostname -s)" --ssh=false
+rm -f "$KEY_FILE"
+"#
+    .to_string()
+}
+
+fn render_safehouse_build(safehouse_repo_url: &str) -> String {
+    format!(
+        r#"set -e
+. "$HOME/.cargo/env" 2>/dev/null || true
+SH_SRC="$HOME/.local/share/safehouse"
+if [ -d "$SH_SRC/.git" ]; then
+  git -C "$SH_SRC" pull --ff-only
+else
+  mkdir -p "$(dirname "$SH_SRC")"
+  git clone {safehouse_repo_url} "$SH_SRC"
+fi
+cd "$SH_SRC"
+cargo build --release -p safehoused
+mkdir -p "$HOME/.local/bin"
+install -m 0755 "$SH_SRC/target/release/safehoused" "$HOME/.local/bin/safehoused"
+"#
+    )
+}
+
+/// `homeserver`/`room` are pre-validated shell-safe (`validate_safe_token`) by
+/// [`preflight`] before this is ever called. `personas` are pre-validated by
+/// [`validate_persona_name`] — safe to interpolate as bare TOML string
+/// literals. The Matrix account + store/recovery passphrases arrive on stdin
+/// as a `KEY=VALUE` env file and are sourced into shell variables that are
+/// referenced (never literal) in the rendered heredoc, so the secret VALUES
+/// never appear in this rendered text (only the variable NAMES do).
+fn render_safehouse_config(homeserver: &str, room: &str, personas: &[String]) -> String {
+    let persona_list = personas
+        .iter()
+        .map(|p| format!("\"{p}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        r#"set -e
+umask 077
+mkdir -p "$HOME/.loom/safehoused"
+ENV_FILE="$(mktemp)"
+cat > "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+set -a
+. "$ENV_FILE"
+set +a
+cat > "$HOME/.loom/safehoused/config.toml" <<TOML
+homeserver_url = "{homeserver}"
+room = "{room}"
+personas = [{persona_list}]
+
+[account]
+user_id = "$SAFEHOUSE_MATRIX_USER_ID"
+password = "$SAFEHOUSE_MATRIX_PASSWORD"
+
+[encryption]
+store_passphrase = "$SAFEHOUSE_STORE_PASSPHRASE"
+recovery_passphrase = "$SAFEHOUSE_RECOVERY_PASSPHRASE"
+TOML
+chmod 600 "$HOME/.loom/safehoused/config.toml"
+rm -f "$ENV_FILE"
+"#
+    )
+}
+
+fn render_safehouse_room_invite(invite_exec: Option<&str>) -> String {
+    let exec = invite_exec.unwrap_or(DEFAULT_SAFEHOUSE_INVITE_EXEC);
+    format!(
+        r#"set -e
+export PATH="$HOME/.local/bin:$PATH"
+{exec}
+touch "$HOME/.loom/safehoused/.invited"
+"#
+    )
+}
+
+fn render_safehouse_supervise(primary_rel: &str) -> String {
+    // Reuses the already-shipped `safehoused-service.sh` (cloned onto the
+    // worker by the workspace-clone step's `loom-daemon init`) rather than a
+    // one-off `systemd-run` invocation, so the worker gets the same
+    // Restart=always + linger-aware supervision contract the interactive-host
+    // runbook documents (`.loom/docs/safehouse.md`). `--socket` is pinned to
+    // a deterministic path (not the config-driven resolver) so a fresh worker
+    // with no prior `.loom/config.json` safehouse block still agrees with the
+    // env this plan wires into loom-daemon in the next step.
+    format!(
+        r#"set -e
+export PATH="$HOME/.local/bin:$PATH"
+"$HOME/{primary_rel}/.loom/scripts/cli/safehoused-service.sh" install \
+  --bin "$HOME/.local/bin/safehoused" \
+  --socket "{SAFEHOUSE_SOCKET_PATH}" \
+  --config "$HOME/.loom/safehoused/config.toml"
+loginctl enable-linger "$USER" 2>/dev/null || true
+"#
+    )
+}
+
+fn render_safehouse_daemon_restart(room: &str) -> String {
+    // Patches the loom-daemon unit's env in place (idempotent: strips any
+    // prior LOOM_SAFEHOUSE_* lines before re-inserting) rather than a
+    // worker-side .loom/config.json edit — #3997's decision that loom's
+    // safehouse config is wired entirely via env on a fleet worker.
+    format!(
+        r#"set -e
+UNIT="$HOME/.config/systemd/user/loom-daemon.service"
+test -f "$UNIT" || {{ echo "loom-daemon systemd unit not found (the daemon-unit step must run first)" >&2; exit 1; }}
+sed -i '/^Environment=LOOM_SAFEHOUSE_/d' "$UNIT"
+sed -i "/^Environment=PATH=/a Environment=LOOM_SAFEHOUSE_ENABLED=true\nEnvironment=LOOM_SAFEHOUSE_SOCKET={SAFEHOUSE_SOCKET_PATH}\nEnvironment=LOOM_SAFEHOUSE_ROOM={room}" "$UNIT"
+systemctl --user daemon-reload
+systemctl --user restart loom-daemon.service
+"#
+    )
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
+    use super::super::PlanEntry;
     use super::*;
 
     fn base_config() -> AddWorkerConfig {
@@ -709,6 +1132,42 @@ mod tests {
             accounts_env_file: None,
             safehouse_enabled: false,
             idle_shutdown_minutes: None,
+            safehouse_tailnet_auth_key_file: None,
+            safehouse_secrets_file: None,
+            safehouse_repo_url: DEFAULT_SAFEHOUSE_REPO_URL.to_string(),
+            safehouse_homeserver_url: None,
+            safehouse_room: None,
+            safehouse_personas: Vec::new(),
+            safehouse_invite_exec: None,
+        }
+    }
+
+    /// A full, valid `--safehouse` config — every required input present and
+    /// well-formed. Individual tests mutate a field to exercise a specific
+    /// failure.
+    fn safehouse_config() -> AddWorkerConfig {
+        let mut config = base_config();
+        config.safehouse_enabled = true;
+        config.safehouse_tailnet_auth_key_file = Some(PathBuf::from("/does/not/matter"));
+        config.safehouse_secrets_file = Some(PathBuf::from("/does/not/matter"));
+        config.safehouse_homeserver_url = Some("matrix.internal.example".to_string());
+        config.safehouse_room = Some("!fleet:matrix.internal.example".to_string());
+        config.safehouse_personas = vec!["loom_daemon".to_string()];
+        config
+    }
+
+    fn safehouse_secrets() -> Secrets {
+        Secrets {
+            pat: None,
+            accounts_env: None,
+            safehouse_tailnet_auth_key: Some("tskey-auth-ephemeral-tagged".to_string()),
+            safehouse_secrets: Some(
+                "SAFEHOUSE_MATRIX_USER_ID=@safehoused-worker1:matrix.internal.example\n\
+                 SAFEHOUSE_MATRIX_PASSWORD=hunter2-matrix-pw\n\
+                 SAFEHOUSE_STORE_PASSPHRASE=store-pass-xyz\n\
+                 SAFEHOUSE_RECOVERY_PASSPHRASE=recovery-pass-xyz\n"
+                    .to_string(),
+            ),
         }
     }
 
@@ -797,6 +1256,7 @@ mod tests {
         let secrets = Secrets {
             pat: Some("pat".to_string()),
             accounts_env: Some("ACCOUNT_EMAIL_1=a@b.c".to_string()),
+            ..Secrets::default()
         };
         let plan = build_plan(&config, &secrets);
         let names: Vec<&str> = plan
@@ -846,6 +1306,7 @@ mod tests {
         let secrets = Secrets {
             pat: Some("the-pat".to_string()),
             accounts_env: Some("ACCOUNT_EMAIL_1=a@b.c".to_string()),
+            ..Secrets::default()
         };
         let plan = build_plan(&config, &secrets);
         for name in ["forge-auth", "token-accounts"] {
@@ -884,19 +1345,321 @@ mod tests {
     }
 
     #[test]
-    fn safehouse_is_skip_with_3998_notice_when_enabled() {
-        let mut config = base_config();
-        config.safehouse_enabled = true;
-        let plan = build_plan(&config, &Secrets::default());
+    fn safehouse_disabled_stays_a_single_skip_and_plain_worker_unchanged() {
+        // AC: "Without --safehouse, behavior is unchanged: skip-with-notice,
+        // plain worker, zero safehouse provisioning."
+        let plan = build_plan(&base_config(), &Secrets::default());
+        let names: Vec<&str> = plan.entries.iter().map(PlanEntry::name).collect();
+        assert_eq!(names.iter().filter(|n| n.starts_with("safehouse")).count(), 1);
         let entry = plan
             .entries
             .iter()
             .find(|e| e.name() == "safehouse")
             .unwrap();
         match entry {
-            super::super::PlanEntry::Skip { reason, .. } => assert!(reason.contains("#3998")),
+            PlanEntry::Skip { reason, .. } => assert!(
+                reason.contains("not requested"),
+                "reason should explain safehouse was not requested: {reason}"
+            ),
             other => panic!("expected safehouse skip, got {other:?}"),
         }
+    }
+
+    // ---- safehouse enabled: real steps (#3998) --------------------------
+
+    fn safehouse_step_names() -> Vec<&'static str> {
+        vec![
+            "safehouse-tailscale-install",
+            "safehouse-tailscale-join",
+            "safehouse-build",
+            "safehouse-config",
+            "safehouse-room-invite",
+            "safehouse-supervise",
+            "safehouse-daemon-restart",
+        ]
+    }
+
+    #[test]
+    fn safehouse_enabled_renders_full_step_sequence_in_order_between_idle_shutdown_and_verify() {
+        let config = safehouse_config();
+        let plan = build_plan(&config, &safehouse_secrets());
+        let names: Vec<&str> = plan.entries.iter().map(PlanEntry::name).collect();
+
+        // No bare "safehouse" skip entry remains once real steps render.
+        assert!(!names.contains(&"safehouse"));
+
+        let idle_pos = names.iter().position(|n| *n == "idle-shutdown").unwrap();
+        let verify_pos = names.iter().position(|n| *n == "verify").unwrap();
+        let safehouse_positions: Vec<usize> = safehouse_step_names()
+            .iter()
+            .map(|want| {
+                names
+                    .iter()
+                    .position(|n| n == want)
+                    .unwrap_or_else(|| panic!("missing step {want}"))
+            })
+            .collect();
+
+        // Exact ordering, and the whole block sits between idle-shutdown and verify.
+        let mut sorted = safehouse_positions.clone();
+        sorted.sort_unstable();
+        assert_eq!(
+            safehouse_positions, sorted,
+            "safehouse steps must render in the documented order"
+        );
+        assert!(safehouse_positions
+            .iter()
+            .all(|&p| p > idle_pos && p < verify_pos));
+    }
+
+    #[test]
+    fn safehouse_config_step_precedes_supervise_step_boot_time_ordering_constraint() {
+        // AC: the persona allowlist is written before safehoused's first
+        // start (boot-time-only, no reload) — asserted directly on the
+        // rendered plan's step order, not just by construction.
+        let config = safehouse_config();
+        let plan = build_plan(&config, &safehouse_secrets());
+        let names: Vec<&str> = plan.entries.iter().map(PlanEntry::name).collect();
+        let config_pos = names.iter().position(|n| *n == "safehouse-config").unwrap();
+        let supervise_pos = names
+            .iter()
+            .position(|n| *n == "safehouse-supervise")
+            .unwrap();
+        assert!(
+            config_pos < supervise_pos,
+            "safehouse-config ({config_pos}) must precede safehouse-supervise ({supervise_pos})"
+        );
+    }
+
+    #[test]
+    fn safehouse_every_step_has_a_check_for_idempotent_rerun() {
+        // AC: a re-run on an already-provisioned host reports AlreadyDone —
+        // that classification is driven entirely by a present `check`.
+        let config = safehouse_config();
+        let plan = build_plan(&config, &safehouse_secrets());
+        for want in safehouse_step_names() {
+            let step = plan
+                .entries
+                .iter()
+                .find_map(|e| match e {
+                    PlanEntry::Step(s) if s.name == want => Some(s),
+                    _ => None,
+                })
+                .unwrap_or_else(|| panic!("missing step {want}"));
+            assert!(step.check.is_some(), "{want} must have a check phase (idempotency)");
+        }
+    }
+
+    #[test]
+    fn safehouse_full_plan_reruns_idempotently_when_every_check_passes() {
+        struct AlwaysOkRunner;
+        impl CommandRunner for AlwaysOkRunner {
+            fn run(&self, _shell: &str, _stdin: Option<&str>) -> Result<CommandOutput> {
+                Ok(CommandOutput {
+                    code: 0,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                })
+            }
+        }
+        let config = safehouse_config();
+        let plan = build_plan(&config, &safehouse_secrets());
+        let reports = super::super::execute_plan(&AlwaysOkRunner, &plan);
+        for name in safehouse_step_names() {
+            let report = reports.iter().find(|r| r.name == name).unwrap();
+            assert_eq!(
+                report.status,
+                StepStatus::AlreadyDone,
+                "{name} should be AlreadyDone on a passing check"
+            );
+        }
+    }
+
+    #[test]
+    fn safehouse_tailscale_join_and_config_steps_carry_secret_stdin_not_in_rendered_text() {
+        let config = safehouse_config();
+        let secrets = safehouse_secrets();
+        let plan = build_plan(&config, &secrets);
+
+        for name in ["safehouse-tailscale-join", "safehouse-config"] {
+            let step = plan
+                .entries
+                .iter()
+                .find_map(|e| match e {
+                    PlanEntry::Step(s) if s.name == name => Some(s),
+                    _ => None,
+                })
+                .unwrap();
+            let stdin = step.stdin.as_ref().expect("secret step must carry stdin");
+            assert!(stdin.secret, "{name} stdin must be marked secret");
+        }
+
+        let dry = plan.render_dry_run("worker-1");
+        assert!(!dry.contains("tskey-auth-ephemeral-tagged"));
+        assert!(!dry.contains("hunter2-matrix-pw"));
+        assert!(!dry.contains("store-pass-xyz"));
+        assert!(!dry.contains("recovery-pass-xyz"));
+    }
+
+    #[test]
+    fn safehouse_config_step_apply_references_secret_vars_not_values() {
+        let config = safehouse_config();
+        let secrets = safehouse_secrets();
+        let plan = build_plan(&config, &secrets);
+        let step = plan
+            .entries
+            .iter()
+            .find_map(|e| match e {
+                PlanEntry::Step(s) if s.name == "safehouse-config" => Some(s),
+                _ => None,
+            })
+            .unwrap();
+        // Non-secret operator values ARE interpolated.
+        assert!(step.apply.contains("matrix.internal.example"));
+        assert!(step.apply.contains("!fleet:matrix.internal.example"));
+        assert!(step.apply.contains("loom_daemon"));
+        // Secret values are referenced only via their sourced variable names.
+        assert!(step.apply.contains("$SAFEHOUSE_MATRIX_USER_ID"));
+        assert!(step.apply.contains("$SAFEHOUSE_MATRIX_PASSWORD"));
+        assert!(step.apply.contains("$SAFEHOUSE_STORE_PASSPHRASE"));
+        assert!(step.apply.contains("$SAFEHOUSE_RECOVERY_PASSPHRASE"));
+        assert!(!step.apply.contains("hunter2-matrix-pw"));
+    }
+
+    #[test]
+    fn safehouse_room_invite_uses_the_daemon_side_op_not_raw_cs_api() {
+        let config = safehouse_config();
+        let plan = build_plan(&config, &safehouse_secrets());
+        let step = plan
+            .entries
+            .iter()
+            .find_map(|e| match e {
+                PlanEntry::Step(s) if s.name == "safehouse-room-invite" => Some(s),
+                _ => None,
+            })
+            .unwrap();
+        assert!(step.apply.contains("safehoused invite"));
+        assert!(!step.apply.to_lowercase().contains("client-server"));
+        assert!(!step.apply.contains("/_matrix/client"));
+
+        // An operator override replaces the default invocation.
+        let mut overridden = safehouse_config();
+        overridden.safehouse_invite_exec = Some("safehoused invite --room-override x".to_string());
+        let plan2 = build_plan(&overridden, &safehouse_secrets());
+        let step2 = plan2
+            .entries
+            .iter()
+            .find_map(|e| match e {
+                PlanEntry::Step(s) if s.name == "safehouse-room-invite" => Some(s),
+                _ => None,
+            })
+            .unwrap();
+        assert!(step2.apply.contains("--room-override x"));
+    }
+
+    #[test]
+    fn safehouse_supervise_step_installs_via_the_shared_service_script_and_lingers() {
+        let config = safehouse_config();
+        let plan = build_plan(&config, &safehouse_secrets());
+        let step = plan
+            .entries
+            .iter()
+            .find_map(|e| match e {
+                PlanEntry::Step(s) if s.name == "safehouse-supervise" => Some(s),
+                _ => None,
+            })
+            .unwrap();
+        assert!(step.apply.contains("safehoused-service.sh"));
+        assert!(step.apply.contains("install"));
+        assert!(step.apply.contains("enable-linger"));
+    }
+
+    #[test]
+    fn safehouse_daemon_restart_step_wires_env_and_restarts() {
+        let config = safehouse_config();
+        let plan = build_plan(&config, &safehouse_secrets());
+        let step = plan
+            .entries
+            .iter()
+            .find_map(|e| match e {
+                PlanEntry::Step(s) if s.name == "safehouse-daemon-restart" => Some(s),
+                _ => None,
+            })
+            .unwrap();
+        assert!(step.apply.contains("LOOM_SAFEHOUSE_ENABLED=true"));
+        assert!(step.apply.contains("LOOM_SAFEHOUSE_SOCKET"));
+        assert!(step
+            .apply
+            .contains("LOOM_SAFEHOUSE_ROOM=!fleet:matrix.internal.example"));
+        assert!(step
+            .apply
+            .contains("systemctl --user restart loom-daemon.service"));
+    }
+
+    // ---- safehouse preflight ---------------------------------------------
+
+    #[test]
+    fn preflight_safehouse_enabled_requires_every_input() {
+        let mut config = base_config();
+        config.safehouse_enabled = true;
+        let err = preflight(&config).unwrap_err().to_string();
+        assert!(err.contains("--safehouse-tailnet-auth-key-file"), "err: {err}");
+        assert!(err.contains("--safehouse-secrets-file"), "err: {err}");
+        assert!(err.contains("--safehouse-homeserver-url"), "err: {err}");
+        assert!(err.contains("--safehouse-room"), "err: {err}");
+        assert!(err.contains("--safehouse-persona"), "err: {err}");
+    }
+
+    #[test]
+    fn preflight_safehouse_enabled_with_full_inputs_reads_secrets() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_file = dir.path().join("tailnet.key");
+        let secrets_file = dir.path().join("safehouse.env");
+        std::fs::write(&key_file, "tskey-ephemeral-tagged\n").unwrap();
+        std::fs::write(
+            &secrets_file,
+            "SAFEHOUSE_MATRIX_USER_ID=@w1:example\nSAFEHOUSE_MATRIX_PASSWORD=pw\n\
+             SAFEHOUSE_STORE_PASSPHRASE=sp\nSAFEHOUSE_RECOVERY_PASSPHRASE=rp\n",
+        )
+        .unwrap();
+
+        let mut config = safehouse_config();
+        config.safehouse_tailnet_auth_key_file = Some(key_file);
+        config.safehouse_secrets_file = Some(secrets_file);
+
+        let secrets = preflight(&config).unwrap();
+        assert_eq!(secrets.safehouse_tailnet_auth_key.as_deref(), Some("tskey-ephemeral-tagged"));
+        assert!(secrets
+            .safehouse_secrets
+            .as_ref()
+            .unwrap()
+            .contains("SAFEHOUSE_MATRIX_USER_ID"));
+    }
+
+    #[test]
+    fn preflight_rejects_invalid_persona_name() {
+        let mut config = safehouse_config();
+        config.safehouse_personas = vec!["Not-Valid!".to_string()];
+        let err = preflight(&config).unwrap_err().to_string();
+        assert!(err.contains("safehouse-persona"), "err: {err}");
+    }
+
+    #[test]
+    fn preflight_rejects_unsafe_homeserver_url_and_room() {
+        let mut config = safehouse_config();
+        config.safehouse_homeserver_url = Some("https://evil; rm -rf /".to_string());
+        assert!(preflight(&config).is_err());
+
+        let mut config2 = safehouse_config();
+        config2.safehouse_room = Some("!room`whoami`:example".to_string());
+        assert!(preflight(&config2).is_err());
+    }
+
+    #[test]
+    fn preflight_safehouse_disabled_ignores_missing_safehouse_inputs() {
+        // AC: without --safehouse, nothing about safehouse gates preflight.
+        let config = base_config();
+        assert!(preflight(&config).is_ok());
     }
 
     #[test]
@@ -954,6 +1717,7 @@ mod tests {
         let secrets = Secrets {
             pat: Some("pat".to_string()),
             accounts_env: Some("ACCOUNT_EMAIL_1=a@b.c".to_string()),
+            ..Secrets::default()
         };
         let plan = build_plan(&config, &secrets);
         for entry in &plan.entries {
@@ -995,6 +1759,7 @@ mod tests {
         let secrets = Secrets {
             pat: Some("pat".to_string()),
             accounts_env: Some("env".to_string()),
+            ..Secrets::default()
         };
         let plan = build_plan(&config, &secrets);
         let out = plan.render_dry_run(&config.ssh_host);

--- a/loom-daemon/src/fleet/drain.rs
+++ b/loom-daemon/src/fleet/drain.rs
@@ -26,7 +26,8 @@
 //!    exited) flips any of them still `loom:building` back to `loom:issue`
 //!    via `gh` **from the orchestrator, not over SSH** — the forge is global,
 //!    so no remote access is needed for this step.
-//! 3. **Safehoused flush verification is a documented stub (#3998).** See
+//! 3. **Safehoused flush verification via a supervised stop (#3998).** A
+//!    supervised `systemctl --user stop safehoused` IS the flush — see
 //!    [`flush_safehouse`]'s doc comment.
 //!
 //! # Phase state machine (idempotent + resumable, body step 6)
@@ -745,7 +746,7 @@ fn run_phase(
             }
         }
 
-        DrainPhase::FlushSafehouse => flush_safehouse(config),
+        DrainPhase::FlushSafehouse => flush_safehouse(config, runner),
 
         DrainPhase::DeregisterWorkspace => {
             let mut failures = Vec::new();
@@ -844,46 +845,92 @@ fn wait_remote_exit(runner: &dyn CommandRunner, config: &DrainConfig) -> PhaseOu
     }
 }
 
-/// Safehoused key-backup flush verification (body step 3 / AC 2) — **a
-/// documented stub, not a re-implementation of #3998's teardown fragment.**
+/// Safehoused key-backup flush verification (body step 3 / AC 2, #3998).
 ///
-/// #3998 (the safehoused provisioning/teardown fragment) is open, and
-/// `loom-daemon/src/safehouse.rs` exposes only the narration-sink and
-/// peer-claim-coordination client seams — there is no invocable
-/// `wait_for_steady_state`-equivalent reachable from this (synchronous, CLI)
-/// call path. Rather than block every drain on #3998 (steps 1, 2, 4, 5, 6 are
-/// explicitly unblocked per the issue's dependency table) or fabricate a check
-/// that cannot actually verify anything, this phase degrades honestly:
+/// `safehoused` has no clean-exit restart primitive of its own — a supervised
+/// **stop IS the flush**: safehoused's SIGTERM/ctrl-c shutdown path calls
+/// `client.encryption().backups().wait_for_steady_state()` and prints
+/// `"safehoused: room-key backup flushed; bye"` before exiting (confirmed on
+/// the safehouse repo's `main`, `safehoused/src/main.rs`). So this phase, over
+/// `runner`:
+///
+/// 1. `systemctl --user stop safehoused` (idempotent — a no-op, exit 0, on an
+///    already-stopped unit, so a drain of a host where safehoused is already
+///    down verifies via unit state rather than hanging).
+/// 2. Polls `systemctl --user is-active safehoused` briefly for the stop to
+///    settle (bounded — never spins forever).
+/// 3. Verifies via the journal's flush line, falling back to the unit's
+///    `ExecMainStatus` (ordinarily a stale/rotated journal case) when the
+///    line is absent but the unit exited cleanly.
 ///
 /// - `safehouse.enabled == false` (the default): [`PhaseOutcome::Skipped`] —
-///   no room keys are in play on this host, so "safe to power off" is
-///   accurate.
-/// - `safehouse.enabled == true`: [`PhaseOutcome::Unverified`] — the drain
-///   still completes (workspace deregistration + roster removal proceed;
-///   loom never *refuses* to retire a box over this), but the final verdict
-///   explicitly withholds "safe to power off" (AC 2: "never print safe to
-///   power off when the key-backup check did not pass") and exits non-zero
+///   no room keys are in play on this host; "safe to power off" is accurate
+///   without touching the host.
+/// - `safehouse.enabled == true` and the flush verifies (remote exit 0):
+///   [`PhaseOutcome::Changed`] — eligible for "safe to power off" (AC:
+///   verified ⇒ exit 0).
+/// - `safehouse.enabled == true` and the flush does **not** verify (remote
+///   nonzero exit, or the host could not be reached): [`PhaseOutcome::Unverified`]
+///   — the drain still completes (workspace deregistration + roster removal
+///   proceed; loom never *refuses* to retire a box over this), but the final
+///   verdict explicitly withholds "safe to power off" and exits non-zero
 ///   (`3`) so an operator/monitor treats it as a flag, not a clean success.
-///
-/// TODO(#3998): once a concrete flush/steady-state-check seam lands in
-/// `safehouse.rs`, replace this stub with a real SSH-invoked check (or a
-/// direct call if the daemon exposes one), and this phase's `Unverified`
-/// branch becomes reachable only on an *actual* verification failure.
 #[must_use]
-fn flush_safehouse(config: &DrainConfig) -> PhaseOutcome {
+fn flush_safehouse(config: &DrainConfig, runner: &dyn CommandRunner) -> PhaseOutcome {
     if !config.safehouse_enabled {
         return PhaseOutcome::Skipped {
             reason: "safehouse.enabled is false — no room keys in play on this host".to_string(),
         };
     }
-    PhaseOutcome::Unverified {
-        reason: "safehouse.enabled is true, but no invocable key-backup steady-state check \
-                 exists in this repo yet (#3998 is open) — cannot verify the flush before this \
-                 host is torn down. Teardown proceeds (workspace/roster cleanup complete), but is \
-                 NOT certified safe for room-key continuity."
-            .to_string(),
+    match runner.run(FLUSH_SAFEHOUSE_SHELL, None) {
+        Ok(out) if out.ok() => PhaseOutcome::Changed,
+        Ok(out) => PhaseOutcome::Unverified {
+            reason: format!(
+                "safehoused key-backup flush could not be verified on {} (exit {}): {} — \
+                 teardown proceeds (workspace/roster cleanup complete), but is NOT certified \
+                 safe for room-key continuity.",
+                config.ssh_host,
+                out.code,
+                tail(&out.stderr)
+            ),
+        },
+        Err(e) => PhaseOutcome::Unverified {
+            reason: format!(
+                "could not reach {} to stop safehoused and verify the key-backup flush: {e} — \
+                 teardown proceeds (workspace/roster cleanup complete), but is NOT certified \
+                 safe for room-key continuity.",
+                config.ssh_host
+            ),
+        },
     }
 }
+
+/// Remote shell for [`flush_safehouse`]: stop the `safehoused` unit (its
+/// SIGTERM path IS the flush) and verify. Exits `0` when the flush is
+/// verified (journal line, or a clean `ExecMainStatus` when the unit is
+/// inactive), non-zero otherwise. Bounded polling (`30` × `1s` max) so an
+/// already-stopped unit — or one that never comes down — never hangs the
+/// drain.
+const FLUSH_SAFEHOUSE_SHELL: &str = r#"set +e
+systemctl --user stop safehoused >/dev/null 2>&1
+i=0
+while [ "$i" -lt 30 ]; do
+  state="$(systemctl --user is-active safehoused 2>/dev/null)"
+  [ "$state" = "active" ] || break
+  sleep 1
+  i=$((i + 1))
+done
+if journalctl --user -u safehoused --no-pager -n 200 2>/dev/null | grep -q "room-key backup flushed"; then
+  exit 0
+fi
+exit_status="$(systemctl --user show safehoused -p ExecMainStatus --value 2>/dev/null)"
+state="$(systemctl --user is-active safehoused 2>/dev/null)"
+if [ "$exit_status" = "0" ] && [ "$state" != "active" ]; then
+  exit 0
+fi
+echo "safehoused flush not verified (state=$state exec_main_status=$exit_status)" >&2
+exit 1
+"#;
 
 fn tail(s: &str) -> String {
     s.lines()
@@ -1615,7 +1662,7 @@ mod tests {
         assert_eq!(claims.calls.lock().unwrap().len(), 1);
     }
 
-    // ---- unverified safehouse flush → non-zero, no "safe to power off" ---
+    // ---- safehouse flush verification (#3998) -----------------------------
 
     #[test]
     fn unverified_safehouse_flush_yields_nonzero_exit_and_no_safe_line() {
@@ -1630,6 +1677,14 @@ mod tests {
                 stderr: String::new(),
             }),
             Err("connection refused".to_string()),
+            // FlushSafehouse's own stop-and-verify call: the remote script
+            // could not verify the flush (state still unclear).
+            Ok(CommandOutput {
+                code: 1,
+                stdout: String::new(),
+                stderr: "safehoused flush not verified (state=activating exec_main_status=)"
+                    .to_string(),
+            }),
             Ok(CommandOutput {
                 code: 0,
                 stdout: String::new(),
@@ -1644,6 +1699,17 @@ mod tests {
         // Not blocked — deregistration/roster-removal still proceed.
         assert!(removed);
 
+        let flush_report = reports
+            .iter()
+            .find(|r| r.phase == DrainPhase::FlushSafehouse.name())
+            .unwrap();
+        match &flush_report.outcome {
+            PhaseOutcome::Unverified { reason } => {
+                assert!(reason.contains("not verified"), "reason: {reason}")
+            }
+            other => panic!("expected Unverified, got {other:?}"),
+        }
+
         let report = build_report(&config, reports);
         assert!(!report.safe_to_power_off);
         assert_eq!(report.exit_code(), 3);
@@ -1653,10 +1719,104 @@ mod tests {
     }
 
     #[test]
-    fn safehouse_disabled_is_skipped_and_stays_safe() {
+    fn unreachable_host_during_flush_yields_unverified_not_failed() {
+        // A drain must never let an SSH hiccup during the flush phase halt
+        // the run — workspace deregistration + roster removal must still
+        // proceed (loom never refuses to retire a box over this).
+        let mut config = base_config("worker-1");
+        config.safehouse_enabled = true;
+
+        let runner = MockRunner::new(vec![
+            Ok(ok_with_in_flight(&[], true)),
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+            Err("connection refused".to_string()),
+            Err("ssh: connect to host worker-1 port 22: Connection timed out".to_string()),
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+        ]);
+        let claims = MockClaimResetter::new(HashMap::new());
+        let mut record = worker("worker-1");
+        let config2 = config.clone();
+
+        let (reports, removed) =
+            execute_drain(&runner, &claims, &mut record, &config, |_| Ok(())).unwrap();
+        assert!(removed);
+        assert!(!reports.iter().any(|r| r.outcome.is_failure()));
+        let report = build_report(&config2, reports);
+        assert_eq!(report.exit_code(), 3);
+    }
+
+    #[test]
+    fn verified_safehouse_flush_yields_exit_zero_and_safe_line() {
+        let mut config = base_config("worker-1");
+        config.safehouse_enabled = true;
+
+        let runner = MockRunner::new(vec![
+            Ok(ok_with_in_flight(&[], true)),
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+            Err("connection refused".to_string()),
+            // FlushSafehouse's stop-and-verify call succeeds (journal showed
+            // "room-key backup flushed", or a clean ExecMainStatus).
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+            Ok(CommandOutput {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+        ]);
+        let claims = MockClaimResetter::new(HashMap::new());
+        let mut record = worker("worker-1");
+        let config2 = config.clone();
+
+        let (reports, removed) =
+            execute_drain(&runner, &claims, &mut record, &config, |_| Ok(())).unwrap();
+        assert!(removed);
+
+        let flush_report = reports
+            .iter()
+            .find(|r| r.phase == DrainPhase::FlushSafehouse.name())
+            .unwrap();
+        assert_eq!(flush_report.outcome, PhaseOutcome::Changed);
+
+        let report = build_report(&config2, reports);
+        assert!(report.safe_to_power_off);
+        assert_eq!(report.exit_code(), 0);
+        assert!(report.render_human().contains("safe to power off."));
+    }
+
+    #[test]
+    fn safehouse_disabled_is_skipped_and_stays_safe_without_touching_the_host() {
         let config = base_config("worker-1"); // safehouse_enabled: false
-        let outcome = flush_safehouse(&config);
+        let runner = MockRunner::new(vec![]);
+        let outcome = flush_safehouse(&config, &runner);
         assert!(matches!(outcome, PhaseOutcome::Skipped { .. }));
+        assert!(runner.calls.borrow().is_empty(), "disabled flush must never touch the host");
+    }
+
+    #[test]
+    fn flush_safehouse_stop_command_targets_the_safehoused_unit() {
+        // The rendered remote shell must stop (never kill -9) the unit and
+        // check both the journal flush line and the unit's exit status —
+        // asserted directly on the constant so a future edit cannot silently
+        // drop either verification path.
+        assert!(FLUSH_SAFEHOUSE_SHELL.contains("systemctl --user stop safehoused"));
+        assert!(FLUSH_SAFEHOUSE_SHELL.contains("room-key backup flushed"));
+        assert!(FLUSH_SAFEHOUSE_SHELL.contains("ExecMainStatus"));
     }
 
     // ---- roster entry removed only in the final phase ---------------------

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -653,7 +653,13 @@ enum WorkspaceAction {
 }
 
 /// Sub-actions for `loom-daemon fleet` (epic #4340).
+// `AddWorker` legitimately carries many operator-supplied `--safehouse-*`
+// flags (#3998) next to `Drain`/`Status`'s few fields — boxing individual
+// clap-derive `Option`/`Vec` fields would break the derive macro's
+// Option-arity detection for negligible benefit on a parsed-once-at-startup
+// CLI enum, so this size skew is accepted rather than worked around.
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 enum FleetAction {
     /// Bootstrap a provisioned host into a working loom worker (issue #4341).
     /// Runs an ordered, idempotent plan over `ssh <ssh-host>`: base deps, the
@@ -693,10 +699,58 @@ enum FleetAction {
         #[arg(long, value_name = "URL", default_value = loom_daemon::fleet::add_worker::DEFAULT_LOOM_REPO_URL)]
         loom_repo: String,
 
-        /// Wire safehouse fleet-comms on the worker. Config-gated: skip-with-notice
-        /// until #3998 (the safehoused provisioning fragment) lands.
+        /// Wire safehouse fleet-comms on the worker (issue #3998): tailnet
+        /// join, `safehoused` build/config/room-invite/supervision, then a
+        /// restart of the worker's own loom-daemon with `LOOM_SAFEHOUSE_*`
+        /// env. Requires every `--safehouse-*` input below; preflight fails
+        /// fast (before touching the host) if any is missing.
         #[arg(long)]
         safehouse: bool,
+
+        /// Local path to the operator-minted, ephemeral + `tag:loom-worker`
+        /// Tailscale auth key. Read locally at preflight; transferred to the
+        /// worker only via ssh stdin. Required with `--safehouse`.
+        #[arg(long, value_name = "PATH")]
+        safehouse_tailnet_auth_key_file: Option<String>,
+
+        /// Local path to a `KEY=VALUE` env-style file carrying the per-host
+        /// Matrix account credentials and store/recovery passphrases
+        /// (`SAFEHOUSE_MATRIX_USER_ID`, `SAFEHOUSE_MATRIX_PASSWORD`,
+        /// `SAFEHOUSE_STORE_PASSPHRASE`, `SAFEHOUSE_RECOVERY_PASSPHRASE`).
+        /// Read locally at preflight; transferred to the worker only via ssh
+        /// stdin. Required with `--safehouse`.
+        #[arg(long, value_name = "PATH")]
+        safehouse_secrets_file: Option<String>,
+
+        /// The external `rjwalters/safehouse` checkout `safehoused` is built
+        /// from on the worker.
+        #[arg(long, value_name = "URL", default_value = loom_daemon::fleet::add_worker::DEFAULT_SAFEHOUSE_REPO_URL)]
+        safehouse_repo_url: String,
+
+        /// The homeserver URL (resolves inside the tailnet) written into
+        /// safehoused's config. Not secret. Required with `--safehouse`.
+        #[arg(long, value_name = "URL")]
+        safehouse_homeserver_url: Option<String>,
+
+        /// The fleet room safehoused joins. Not secret. Required with
+        /// `--safehouse`.
+        #[arg(long, value_name = "ROOM")]
+        safehouse_room: Option<String>,
+
+        /// A persona this host's safehoused boots with (repeat for several).
+        /// Mirrors the studio host's allowlist (#3999). Not secret. At least
+        /// one is required with `--safehouse` — the allowlist is written
+        /// into the boot-time TOML before safehoused's first start
+        /// (boot-time-only, no reload).
+        #[arg(long = "safehouse-persona", value_name = "NAME")]
+        safehouse_personas: Vec<String>,
+
+        /// Override the safehouse#39 room-`invite` op invocation (loom does
+        /// not vendor safehoused's argv — owned by the external
+        /// `rjwalters/safehouse` repo). Default: `safehoused invite --config
+        /// <path>`.
+        #[arg(long, value_name = "ARGV")]
+        safehouse_invite_exec: Option<String>,
 
         /// Install an idle-shutdown cron guard that powers the host off after
         /// this many idle minutes (skipping while claude / loom-daemon work).
@@ -729,8 +783,9 @@ enum FleetAction {
     /// a drain-then-*exit* remote invocation (never restart into new dispatch
     /// on a box about to be powered off), an immediate targeted `loom:building`
     /// claim reset via `gh` (not SSH — the forge is global), a safehoused
-    /// key-backup flush check (a documented stub pending #3998 — see
-    /// `loom_daemon::fleet::drain`'s module doc), workspace deregistration, and
+    /// key-backup flush check (a supervised `systemctl --user stop
+    /// safehoused` IS the flush, #3998 — see `loom_daemon::fleet::drain`'s
+    /// module doc), workspace deregistration, and
     /// finally removing the worker from the fleet registry. Idempotent +
     /// resumable: an interrupted drain re-runs from its last completed phase.
     /// Never calls a cloud CLI itself — prints the exact `repo:remote --down`
@@ -5615,6 +5670,13 @@ fn handle_fleet_command(action: FleetAction) -> Result<()> {
             accounts_env,
             loom_repo,
             safehouse,
+            safehouse_tailnet_auth_key_file,
+            safehouse_secrets_file,
+            safehouse_repo_url,
+            safehouse_homeserver_url,
+            safehouse_room,
+            safehouse_personas,
+            safehouse_invite_exec,
             idle_shutdown_minutes,
             dry_run,
         } => {
@@ -5628,6 +5690,13 @@ fn handle_fleet_command(action: FleetAction) -> Result<()> {
                 accounts_env_file: accounts_env.map(PathBuf::from),
                 safehouse_enabled: safehouse,
                 idle_shutdown_minutes,
+                safehouse_tailnet_auth_key_file: safehouse_tailnet_auth_key_file.map(PathBuf::from),
+                safehouse_secrets_file: safehouse_secrets_file.map(PathBuf::from),
+                safehouse_repo_url,
+                safehouse_homeserver_url,
+                safehouse_room,
+                safehouse_personas,
+                safehouse_invite_exec,
             };
             add_worker::run(&config)
         }
@@ -5646,8 +5715,8 @@ fn handle_fleet_command(action: FleetAction) -> Result<()> {
             // Resolved once, from the operator's own cwd (mirrors
             // `WorkspacePool::start_safehouse_narration`'s
             // `safehouse::resolve_config(repo_root)` call shape) — see
-            // `fleet::drain::flush_safehouse`'s doc comment for why this is a
-            // documented stub, not a real flush, pending #3998.
+            // `fleet::drain::flush_safehouse`'s doc comment for the real
+            // supervised-stop flush check this now gates on (#3998).
             let cwd = std::env::current_dir().context("resolving cwd for safehouse config")?;
             let safehouse_enabled = loom_daemon::safehouse::resolve_config(&cwd).enabled;
 


### PR DESCRIPTION
## Summary

Fills the two pre-built seams `loom-daemon`'s fleet module left for #3998:

- **Spin-up (`fleet add-worker --safehouse`)**: replaces the skip-with-notice
  placeholder with 7 real, idempotent `Step`s — tailscale apt install,
  `tailscale up` with an operator-minted ephemeral + `tag:loom-worker` auth key
  (fed via ssh stdin), `safehoused` build from the external
  `rjwalters/safehouse` checkout, boot-time `config.toml` (0600, homeserver +
  account + passphrases + persona allowlist, fed via ssh stdin), room
  membership via safehouse#39's daemon-side `invite` op, `systemd --user`
  supervision + linger via the existing `safehoused-service.sh`, and finally a
  restart of the worker's own `loom-daemon` with
  `LOOM_SAFEHOUSE_ENABLED/SOCKET/ROOM` env so narration flows. Every new
  input (tailnet auth key, Matrix credentials, store/recovery passphrases) is
  required up front by `preflight` (fails fast, before any SSH) and travels
  only via ssh stdin, mirroring the existing `pat_file` pattern — never on a
  command line, in rendered `--dry-run` text, in daemon logs, or in the fleet
  registry.
- **Teardown (`fleet drain`)**: replaces the `flush_safehouse` always-Unverified
  stub with a real supervised stop (`systemctl --user stop safehoused` — a
  supervised stop *is* the flush, since safehoused's SIGTERM path calls
  `wait_for_steady_state()` before exiting) plus verification via the journal's
  flush line (falling back to `ExecMainStatus` when the journal has rotated).
  The existing exit-code contract from #4420 is unchanged: `Skipped` when
  safehouse is off, verified flush → `Changed`/exit 0/"safe to power off",
  unverified → `Unverified`/exit 3 (drain still completes — never blocks
  teardown on this).
- `.loom/docs/safehouse.md` gains a "Fleet provisioning: cloud workers"
  section documenting the step sequence, the inputs an operator must mint, the
  required tailnet ACL, and the drain/flush contract.

## Note on this PR's history

This picks up a mostly-complete implementation left uncommitted in a prior
interrupted sweep run on this branch. I reviewed the full diff against the
current (2026-07-29) curator spec, found it a faithful and well-tested
implementation of the acceptance criteria, rebased it onto current `main`
(picking up the merged #4420 `drain.rs` this issue's teardown half depends
on), and verified it end-to-end before committing.

## Test plan

- [x] `cargo test -p loom-daemon fleet` — 95 passed, 0 failed (covers: full
      step sequence + ordering when `--safehouse` is set; unchanged
      skip-with-notice when it isn't; persona-TOML-before-first-start
      ordering asserted directly; every safehouse step has a `check` for
      idempotent re-run; a full re-run against an always-`AlreadyDone` runner
      reports every safehouse step `AlreadyDone`; secret stdin never appears
      in rendered dry-run text; preflight requires every `--safehouse-*` input
      and validates homeserver/room/persona strings for shell-injection;
      drain's flush maps `Skipped`/verified/unverified onto exit 0/0/3
      correctly, including an unreachable-host-during-flush case that still
      lets teardown complete)
- [x] `cargo build --workspace` — clean
- [x] `cargo clippy -p loom-daemon --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p loom-daemon -- --check` — clean
- [x] Security check: rendered a `--dry-run` plan with real-looking secret
      values (tailnet key, Matrix password, store/recovery passphrases) and
      grepped the output — zero hits. Confirmed the fleet registry's
      `WorkerRecord` carries no safehouse secret fields.

Note: `cargo test --workspace` shows unrelated, pre-existing flakiness in
`integration_security.rs` (daemon-spawn timing under heavy concurrent load on
this shared build host — different tests fail on each run, none touching the
`fleet`/`safehouse` code this PR changes). Out of scope for this issue.

Closes #3998