### PR TITLE
feat: add provider-scoped Codex account health

### DIFF
--- a/.loom/docs/token-pool.md
+++ b/.loom/docs/token-pool.md
@@ -521,3 +521,35 @@ refuses to silently auto-clear `.bad_tokens` — that masks real auth problems.
 PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -v
 bash .loom/scripts/tests/test-spawn-claude.sh
 ```
+
+## Codex provider health
+
+Codex profiles use a separate, provider-aware health file at
+`.loom/account-health.json`. Loom never rewrites Claude's `.ranking`,
+`.bad_tokens`, `.failure_counts`, allowlist, or rotation cursor for Codex.
+The health file contains account names and stable reason categories only—never
+`auth.json`, credential contents, or raw child output—and is written atomically
+under a sibling `mkdir` lock.
+
+For managed headless runs, `spawn-codex.sh` asks the native selector for an
+eligible profile and exports that profile as `CODEX_HOME`. Selection excludes
+disabled profiles, persistent `reauth_required` holds, and unexpired cooldowns;
+then prefers fewer recent transient failures and round-robins equal candidates.
+If none are healthy, selection exits closed rather than using ambient
+`~/.codex`.
+
+Terminal policy is intentionally conservative:
+
+- `TOKEN_EXPIRED` requires an explicit verified-reauth clear and never expires
+  merely because time passed or an ordinary success was observed.
+- `TOKEN_EXHAUSTED` cools down for
+  `LOOM_CODEX_EXHAUSTED_COOLDOWN_SECS` (default five hours).
+- `RECOVERABLE` and `SESSION_LIMIT` apply short temporary backoffs.
+- Success records freshness and clears transient counters.
+- Timeouts, fatal/configuration failures, refusals, and deleted-cwd outcomes do
+  not poison account health.
+
+Codex exposes no trustworthy quota-headroom percentage here. Status/capacity
+therefore reports raw, enabled, healthy, cooldown, and reauth-required counts;
+transcript token totals remain observability and are never presented as
+remaining quota. Claude's existing global daemon concurrency cap is unchanged.

--- a/defaults/scripts/spawn-codex.sh
+++ b/defaults/scripts/spawn-codex.sh
@@ -198,6 +198,10 @@ log_warn() { echo -e "${YELLOW}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] WARN${NC} $*" 
 log_error() { echo -e "${RED}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] ERROR${NC} $*" >&2; }
 
 _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "${_SCRIPT_DIR}/lib/locate-daemon-bin.sh" ]]; then
+    # shellcheck source=./lib/locate-daemon-bin.sh
+    source "${_SCRIPT_DIR}/lib/locate-daemon-bin.sh"
+fi
 
 # --- Repo root resolution (handles worktrees; mirrors spawn-claude.sh) ---
 _resolve_workspace() {
@@ -525,6 +529,35 @@ CODEX_PROFILE_NAME=""
 if [[ -n "${LOOM_SPAWN_NO_EXPORT:-}" ]]; then
     log_info "spawn-codex: LOOM_SPAWN_NO_EXPORT set — skipping CODEX_HOME resolution"
 else
+    # A managed headless dispatch with no explicit pin uses the provider-aware
+    # selector. This fails closed when every profile is disabled, cooling down,
+    # or awaiting reauthentication; it never falls back to ambient ~/.codex.
+    if [[ "$HAS_PROMPT" == "true" && -z "${LOOM_CODEX_NO_EXEC:-}" \
+          && -z "${LOOM_CODEX_HOME:-}" \
+          && -z "${CODEX_HOME:-}" && -z "${LOOM_CODEX_PROFILE:-}" ]]; then
+        if ! declare -F loom_locate_daemon_bin >/dev/null 2>&1; then
+            log_error "Provider-aware account selection support is not installed."
+            exit 78
+        fi
+        _daemon_bin="$(loom_locate_daemon_bin "$WORKSPACE")"
+        if [[ -z "$_daemon_bin" ]] \
+            || ! "$_daemon_bin" tokens select --help 2>&1 | grep -q -- '--provider'; then
+            log_error "No loom-daemon binary supporting provider-aware account selection was found."
+            exit 78
+        fi
+        _selection_stderr_file="$(mktemp)"
+        _selection_output=""
+        if ! _selection_output="$("$_daemon_bin" tokens select --provider codex \
+            --workspace "$WORKSPACE" --export 2>"$_selection_stderr_file")"; then
+            log_error "Codex account selection failed:"
+            cat "$_selection_stderr_file" >&2 || true
+            rm -f "$_selection_stderr_file"
+            exit 78
+        fi
+        cat "$_selection_stderr_file" >&2 || true
+        rm -f "$_selection_stderr_file"
+        eval "$_selection_output"
+    fi
     _requested_home=""
     _requested_source=""
     if [[ -n "${LOOM_CODEX_HOME:-}" ]]; then
@@ -543,7 +576,7 @@ else
         _auth_candidate="${_requested_home}/auth.json"
         if [[ -f "$_auth_candidate" && -r "$_auth_candidate" && -s "$_auth_candidate" ]]; then
             export CODEX_HOME="$_requested_home"
-            CODEX_PROFILE_NAME="$(basename "$_requested_home")"
+            CODEX_PROFILE_NAME="${LOOM_ACCOUNT_NAME:-$(basename "$_requested_home")}"
             # Directory NAME only — never the path contents, never auth.json.
             log_info "spawn-codex: using Codex profile '$CODEX_PROFILE_NAME' (source=$_requested_source)"
             echo "# LOOM_ACCOUNT name=$CODEX_PROFILE_NAME" >&2
@@ -662,6 +695,31 @@ _tokens_used="$(
 )"
 if [[ -n "$_tokens_used" ]]; then
     log_info "spawn-codex: tokens_used=$_tokens_used"
+fi
+
+# Stable, bounded terminal feedback for the daemon. The classifier remains the
+# single source of truth; this adapter only packages its result with the
+# provider/account attribution already selected for this child. Raw output is
+# neither included in this record nor persisted by the health layer.
+_classifier_lib="${_SCRIPT_DIR}/lib/classify-error.sh"
+if [[ -f "$_classifier_lib" ]]; then
+    # shellcheck source=./lib/classify-error.sh
+    source "$_classifier_lib"
+    _classifier_input="$(tail -c 65536 "$_stderr_file" 2>/dev/null || true)"
+    _terminal_category="$(classify_error "$_classifier_input" "$_exit_code" codex)"
+    _terminal_account="${LOOM_ACCOUNT_NAME:-${CODEX_PROFILE_NAME:-unknown}}"
+    if [[ ! "$_terminal_account" =~ ^[A-Za-z0-9._-]+$ ]]; then
+        _terminal_account="unknown"
+    fi
+    case "$_terminal_category" in
+        SUCCESS|TOKEN_EXPIRED|TOKEN_EXHAUSTED|RECOVERABLE|TIMEOUT|FATAL|CWD_DELETED|MODEL_REFUSAL|SESSION_LIMIT)
+            printf '# LOOM_TERMINAL_RESULT v=1 provider=codex account=%s category=%s exit_code=%s\n' \
+                "$_terminal_account" "$_terminal_category" "$_exit_code" >&2
+            ;;
+        *)
+            log_warn "spawn-codex: classifier returned an invalid category; terminal feedback omitted"
+            ;;
+    esac
 fi
 
 exit "$_exit_code"

--- a/defaults/scripts/tests/test-spawn-codex.sh
+++ b/defaults/scripts/tests/test-spawn-codex.sh
@@ -514,6 +514,7 @@ if [[ -n "\$_stdin" ]]; then echo "MOCK-SAW-STDIN:\$_stdin" >&2; fi
   echo "--------"
   echo "tokens used"
   echo "2,502"
+  [[ -n "\${MOCK_ERROR:-}" ]] && echo "\$MOCK_ERROR"
 } >&2
 echo "MOCK-FINAL-MESSAGE"
 exit "\${MOCK_RC:-0}"
@@ -547,6 +548,10 @@ assert_contains "spawn-codex: session=$MOCK_SESSION" "$mock_stderr" \
     "the 'session id:' line is parsed and reported as the transcript join key"
 assert_contains "spawn-codex: tokens_used=2502" "$mock_stderr" \
     "'tokens used' is parsed (comma-stripped) and reported"
+assert_contains \
+    "# LOOM_TERMINAL_RESULT v=1 provider=codex account=unknown category=SUCCESS exit_code=0" \
+    "$mock_stderr" \
+    "a successful child emits one strict structured terminal record"
 assert_not_contains "MOCK-SAW-STDIN" "$mock_stderr" \
     "the child's stdin is /dev/null (no <stdin> append, no hang)"
 
@@ -565,6 +570,21 @@ run_mock MOCK_RC=42 -- -p "hi" >/dev/null 2>&1
 mock_rc=$?
 set -e
 assert_eq "42" "$mock_rc" "the codex exit code is passed through (PIPESTATUS)"
+
+set +e
+classified_stderr="$({ run_mock MOCK_RC=42 LOOM_ACCOUNT_NAME=profile-a \
+    MOCK_ERROR="Not signed in. recognizable-secret" -- -p "hi" >/dev/null; } 2>&1)"
+classified_rc=$?
+set -e
+assert_eq "42" "$classified_rc" \
+    "structured classification preserves the original child exit code"
+terminal_record="$(printf '%s\n' "$classified_stderr" | grep '^# LOOM_TERMINAL_RESULT ' || true)"
+assert_eq \
+    "# LOOM_TERMINAL_RESULT v=1 provider=codex account=profile-a category=TOKEN_EXPIRED exit_code=42" \
+    "$terminal_record" \
+    "the structured record matches the direct Codex classifier and carries account identity"
+assert_not_contains "recognizable-secret" "$terminal_record" \
+    "the structured record never copies raw child output"
 
 set +e
 run_mock MOCK_RC=0 -- -p "hi" >/dev/null 2>&1

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -29,7 +29,7 @@ use loom_daemon::workspace_pool::WorkspacePool;
 use loom_daemon::worktree_ops::{aggressive, clean};
 use loom_daemon::{extract_configured_terminal_ids, rotate_log_file};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand};
 use std::fs;
@@ -972,6 +972,11 @@ enum TokensAction {
         /// root when called from a worktree — no upward `.git` walk).
         #[arg(long, value_name = "PATH", default_value = ".")]
         workspace: String,
+
+        /// Account provider. The default preserves the legacy Claude token
+        /// selector and every one of its state formats.
+        #[arg(long, value_name = "PROVIDER", default_value = "claude")]
+        provider: String,
 
         /// Emit shell-evalable `export CLAUDE_CODE_OAUTH_TOKEN=...` /
         /// `export LOOM_TOKEN_NAME=...` lines (plus a non-exported
@@ -6326,17 +6331,59 @@ fn handle_forge_command(action: ForgeAction) -> Result<()> {
 /// file-based — does not require a running daemon. See
 /// `loom-daemon/src/tokens_pool/mod.rs` for the ported subset and what is
 /// deliberately deferred.
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
 fn handle_tokens_command(action: TokensAction) -> Result<()> {
     use loom_daemon::tokens_pool::{allowlist, bad_tokens, failure_counts, select};
 
     match action {
         TokensAction::Select {
             workspace,
+            provider,
             export,
             no_key,
             auto_unpin,
         } => {
             let ws = resolve_tokens_workspace(&workspace)?;
+            if provider == "codex" {
+                let selected = loom_daemon::tokens_pool::select_account(
+                    &ws,
+                    loom_daemon::tokens_pool::AccountProvider::Codex,
+                )
+                .map_err(|error| anyhow!(error))?;
+                let directory = match &selected.binding {
+                    loom_daemon::tokens_pool::AccountBinding::CodexHome { directory } => directory,
+                    _ => unreachable!("Codex selection returned a non-Codex binding"),
+                };
+                if export {
+                    println!(
+                        "export CODEX_HOME={}",
+                        shell_single_quote(&directory.display().to_string())
+                    );
+                    println!(
+                        "export LOOM_ACCOUNT_PROVIDER='codex'\nexport LOOM_ACCOUNT_NAME={}",
+                        shell_single_quote(&selected.id.name)
+                    );
+                    println!("LOOM_TOKEN_MODE='{}'", selected.mode);
+                } else {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "provider": "codex",
+                            "name": selected.id.name,
+                            "credential_kind": "codex_home",
+                            "credential_reference": directory,
+                            "mode": selected.mode,
+                        })
+                    );
+                }
+                return Ok(());
+            }
+            if provider != "claude" {
+                bail!("invalid provider {provider:?}; expected claude or codex");
+            }
             if auto_unpin {
                 if let Some(msg) = loom_daemon::tokens_pool::maybe_auto_unpin(&ws) {
                     eprintln!("{msg}");

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -56,6 +56,7 @@ use crate::peer_claims::{self, ClaimAd, PeerClaimView};
 use crate::quarantine_reconciliation;
 use crate::sweep_journal;
 use crate::tokens_pool::bad_tokens;
+use crate::tokens_pool::{self, AccountId, AccountProvider, TerminalClassification};
 use crate::types::{Event, SweepId, SweepInfo, SweepKind, SweepOutcome, SweepState};
 
 use anyhow::{anyhow, Context, Result};
@@ -390,6 +391,56 @@ const TOKEN_NAME_LOG_MARKER: &str = "using OAuth account '";
 const ACCOUNT_LOG_MARKER: &str = "# LOOM_ACCOUNT name=";
 const RUNTIME_LOG_MARKER: &str = "# LOOM_RUNTIME_RESOLVED runtime=";
 const CLI_START_MARKER: &str = "# LOOM_CLI_START";
+const TERMINAL_RESULT_MARKER: &str = "# LOOM_TERMINAL_RESULT ";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TerminalResult {
+    provider: AccountProvider,
+    account: String,
+    category: TerminalClassification,
+    exit_code: i32,
+}
+
+/// Parse the adapter's strict v1 record from only the current dispatch region.
+/// Unknown fields, duplicate records, malformed identities, and unknown
+/// categories all fail closed: no account health is mutated.
+fn parse_terminal_result_after(contents: &str, header_anchor: &str) -> Option<TerminalResult> {
+    let region = &contents[contents.rfind(header_anchor)?..];
+    let records: Vec<_> = region
+        .lines()
+        .filter(|line| line.starts_with(TERMINAL_RESULT_MARKER))
+        .collect();
+    if records.len() != 1 {
+        return None;
+    }
+    let fields: HashMap<_, _> = records[0][TERMINAL_RESULT_MARKER.len()..]
+        .split_ascii_whitespace()
+        .filter_map(|field| field.split_once('='))
+        .collect();
+    if fields.len() != 5 || fields.get("v") != Some(&"1") {
+        return None;
+    }
+    let provider = match *fields.get("provider")? {
+        "claude" => AccountProvider::Claude,
+        "codex" => AccountProvider::Codex,
+        _ => return None,
+    };
+    let account = fields.get("account")?.to_string();
+    if account == UNKNOWN_TOKEN_NAME
+        || account.is_empty()
+        || !account
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+    {
+        return None;
+    }
+    Some(TerminalResult {
+        provider,
+        account,
+        category: fields.get("category")?.parse().ok()?,
+        exit_code: fields.get("exit_code")?.parse().ok()?,
+    })
+}
 
 /// Issue #3802: how long `spawn_child` polls the per-sweep log for the
 /// `TOKEN_NAME_LOG_MARKER` line before giving up and recording
@@ -3223,6 +3274,44 @@ impl SweepRegistry {
         self.record_terminal_outcome(issue, insta_crash);
     }
 
+    /// Persist provider health before any reaper retry/failover decision.
+    fn apply_provider_health_feedback(&self, sweep_id: &SweepId, exit_code: Option<i32>) {
+        let Some(info) = self.entries.get(sweep_id) else {
+            return;
+        };
+        if info.runtime != "codex" || info.token_name == UNKNOWN_TOKEN_NAME {
+            return;
+        }
+        let Ok(contents) = std::fs::read_to_string(&info.log_path) else {
+            return;
+        };
+        let anchor = format!("sweep_id={sweep_id}");
+        let Some(result) = parse_terminal_result_after(&contents, &anchor) else {
+            return;
+        };
+        if result.provider != AccountProvider::Codex
+            || result.account != info.token_name
+            || exit_code.is_some_and(|code| code != result.exit_code)
+        {
+            log::warn!("sweep_registry: ignored mismatched Codex terminal feedback for {sweep_id}");
+            return;
+        }
+        let id = AccountId {
+            provider: result.provider,
+            name: result.account,
+        };
+        if let Err(error) = tokens_pool::record_terminal(
+            &self.config.workspace_root,
+            &id,
+            result.category,
+            "spawn-codex:v1",
+        ) {
+            log::warn!(
+                "sweep_registry: failed to persist Codex terminal feedback for {sweep_id}: {error}"
+            );
+        }
+    }
+
     /// Classify whether an insta-crash death was caused by account exhaustion
     /// (#4122).
     ///
@@ -4431,6 +4520,9 @@ impl SweepRegistry {
             // handle fall back to the `kill(pid, 0)` probe.
             let (is_dead, exit_code) = self.poll_liveness(&sweep_id, pid);
             if is_dead {
+                // #4493: account health must be updated before any bounded
+                // re-dispatch path below asks the selector for another profile.
+                self.apply_provider_health_feedback(&sweep_id, exit_code);
                 {
                     changes += 1;
                     let issue = match &kind {
@@ -10977,6 +11069,40 @@ exit 0
 
         let pr = generate_sweep_id(&SweepKind::PrSet(vec![10, 20]));
         assert!(pr.starts_with("sweep-prs-10-20-"));
+    }
+
+    #[test]
+    fn terminal_result_parser_is_anchored_strict_and_provider_aware() {
+        let log = "\
+sweep_id=old
+# LOOM_TERMINAL_RESULT v=1 provider=codex account=stale category=TOKEN_EXPIRED exit_code=1
+sweep_id=current
+# LOOM_TERMINAL_RESULT v=1 provider=codex account=profile-a category=TOKEN_EXHAUSTED exit_code=42
+";
+        assert_eq!(
+            parse_terminal_result_after(log, "sweep_id=current"),
+            Some(TerminalResult {
+                provider: AccountProvider::Codex,
+                account: "profile-a".into(),
+                category: TerminalClassification::TokenExhausted,
+                exit_code: 42,
+            })
+        );
+        assert!(parse_terminal_result_after(
+            "sweep_id=current\n# LOOM_TERMINAL_RESULT v=9 provider=codex account=a category=SUCCESS exit_code=0",
+            "sweep_id=current"
+        )
+        .is_none());
+        assert!(parse_terminal_result_after(
+            "sweep_id=current\n# LOOM_TERMINAL_RESULT v=1 provider=codex account=unknown category=SUCCESS exit_code=0",
+            "sweep_id=current"
+        )
+        .is_none());
+        assert!(parse_terminal_result_after(
+            "sweep_id=current\n# LOOM_TERMINAL_RESULT v=1 provider=codex account=a category=BOGUS exit_code=1",
+            "sweep_id=current"
+        )
+        .is_none());
     }
 
     #[test]

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -10880,6 +10880,7 @@ exit 0
                 kind: kind.clone(),
                 pid: 2_147_483_640,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(8801),
                 idempotency_key: None,
                 started_at,
@@ -13728,6 +13729,7 @@ exit 0\n";
                 kind: SweepKind::Issue(9256),
                 pid: std::process::id(), // alive
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: reg.compute_log_path(9256),
                 idempotency_key: None,
                 started_at: Utc::now(),

--- a/loom-daemon/src/tokens_pool/account_registry.rs
+++ b/loom-daemon/src/tokens_pool/account_registry.rs
@@ -324,10 +324,9 @@ pub fn select_account(workspace: &Path, provider: AccountProvider) -> Result<Sel
             })
         }
         AccountProvider::Codex => {
-            let descriptor = account_inventory(workspace, provider)?
-                .into_iter()
-                .find(|account| account.enabled)
-                .ok_or_else(|| anyhow!("no enabled Codex profiles are available"))?;
+            let inventory = account_inventory(workspace, provider)?;
+            let descriptor =
+                super::health::select_healthy_at(workspace, provider, &inventory, epoch_now())?;
             Ok(SelectedAccount {
                 id: descriptor.id,
                 binding: AccountBinding::CodexHome {
@@ -337,6 +336,13 @@ pub fn select_account(workspace: &Path, provider: AccountProvider) -> Result<Sel
             })
         }
     }
+}
+
+fn epoch_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 #[cfg(test)]

--- a/loom-daemon/src/tokens_pool/health.rs
+++ b/loom-daemon/src/tokens_pool/health.rs
@@ -259,14 +259,21 @@ pub fn record_terminal_at(
         entry.updated_at = now;
         entry.signal_provenance = provenance.to_string();
         match classification {
+            // Once authentication has expired, ordinary runtime feedback cannot
+            // verify that credentials were repaired. Keep the hold sticky until
+            // clear_reauth() performs that explicit transition.
+            _ if entry.reason == HealthReason::ReauthRequired => {
+                entry.cooldown_until = None;
+                if classification == TerminalClassification::Success {
+                    entry.last_success = Some(now);
+                    entry.consecutive_transient_failures = 0;
+                }
+            }
             TerminalClassification::Success => {
                 entry.last_success = Some(now);
                 entry.consecutive_transient_failures = 0;
-                // A normal success must not silently clear an auth hold.
-                if entry.reason != HealthReason::ReauthRequired {
-                    entry.reason = HealthReason::Healthy;
-                    entry.cooldown_until = None;
-                }
+                entry.reason = HealthReason::Healthy;
+                entry.cooldown_until = None;
             }
             TerminalClassification::TokenExpired => {
                 entry.reason = HealthReason::ReauthRequired;
@@ -342,6 +349,16 @@ pub fn select_healthy_at(
     now: u64,
 ) -> Result<AccountDescriptor> {
     with_state(workspace, |state| {
+        for entry in &mut state.accounts {
+            if entry.reason == HealthReason::TransientFailure
+                && entry.cooldown_until.is_some_and(|deadline| deadline <= now)
+            {
+                entry.reason = HealthReason::Healthy;
+                entry.cooldown_until = None;
+                entry.consecutive_transient_failures = 0;
+                entry.updated_at = now;
+            }
+        }
         let health: HashMap<AccountId, AccountHealth> = state
             .accounts
             .iter()
@@ -529,6 +546,78 @@ mod tests {
         .is_err());
         clear_reauth(tmp.path(), &account.id, "verified_reauth").unwrap();
         assert!(select_healthy_at(tmp.path(), AccountProvider::Codex, &[account], u64::MAX).is_ok());
+    }
+
+    #[test]
+    fn expired_survives_all_later_runtime_feedback_until_explicit_clear() {
+        for classification in [
+            TerminalClassification::TokenExhausted,
+            TerminalClassification::Recoverable,
+            TerminalClassification::SessionLimit,
+        ] {
+            let tmp = tempfile::tempdir().unwrap();
+            let account = descriptor(AccountProvider::Codex, "a");
+            record_terminal_at(
+                tmp.path(),
+                &account.id,
+                TerminalClassification::TokenExpired,
+                "adapter_v1",
+                1,
+            )
+            .unwrap();
+            record_terminal_at(tmp.path(), &account.id, classification, "adapter_v1", 2).unwrap();
+
+            let health = account_health(tmp.path(), &account.id).unwrap().unwrap();
+            assert_eq!(health.reason, HealthReason::ReauthRequired);
+            assert_eq!(health.cooldown_until, None);
+            assert!(select_healthy_at(
+                tmp.path(),
+                AccountProvider::Codex,
+                std::slice::from_ref(&account),
+                u64::MAX
+            )
+            .is_err());
+        }
+    }
+
+    #[test]
+    fn expired_transient_backoff_restores_fair_rotation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let accounts = vec![
+            descriptor(AccountProvider::Codex, "a"),
+            descriptor(AccountProvider::Codex, "b"),
+        ];
+        record_terminal_at(
+            tmp.path(),
+            &accounts[0].id,
+            TerminalClassification::Recoverable,
+            "adapter_v1",
+            100,
+        )
+        .unwrap();
+
+        assert_eq!(
+            select_healthy_at(tmp.path(), AccountProvider::Codex, &accounts, 101)
+                .unwrap()
+                .id
+                .name,
+            "b"
+        );
+
+        let deadline = 100 + DEFAULT_RECOVERABLE_BACKOFF_SECS;
+        let first =
+            select_healthy_at(tmp.path(), AccountProvider::Codex, &accounts, deadline).unwrap();
+        let second =
+            select_healthy_at(tmp.path(), AccountProvider::Codex, &accounts, deadline).unwrap();
+        assert_ne!(first.id, second.id);
+        assert!([first.id.name, second.id.name].contains(&"a".to_string()));
+
+        let recovered = account_health(tmp.path(), &accounts[0].id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(recovered.reason, HealthReason::Healthy);
+        assert_eq!(recovered.cooldown_until, None);
+        assert_eq!(recovered.consecutive_transient_failures, 0);
     }
 
     #[test]

--- a/loom-daemon/src/tokens_pool/health.rs
+++ b/loom-daemon/src/tokens_pool/health.rs
@@ -1,0 +1,603 @@
+//! Provider-scoped account health for runtimes which do not have Claude's
+//! quota probe. This state is deliberately separate from the legacy Claude
+//! `.ranking`, `.bad_tokens`, and `.failure_counts` files.
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use super::account_registry::{AccountDescriptor, AccountId, AccountProvider};
+use super::locking::MkdirLock;
+
+const SCHEMA_VERSION: u32 = 1;
+pub const DEFAULT_EXHAUSTED_COOLDOWN_SECS: u64 = 5 * 60 * 60;
+pub const DEFAULT_RECOVERABLE_BACKOFF_SECS: u64 = 60;
+pub const DEFAULT_SESSION_BACKOFF_SECS: u64 = 30;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TerminalClassification {
+    Success,
+    TokenExpired,
+    TokenExhausted,
+    Recoverable,
+    Timeout,
+    Fatal,
+    CwdDeleted,
+    ModelRefusal,
+    SessionLimit,
+}
+
+impl std::str::FromStr for TerminalClassification {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        Ok(match value {
+            "SUCCESS" => Self::Success,
+            "TOKEN_EXPIRED" => Self::TokenExpired,
+            "TOKEN_EXHAUSTED" => Self::TokenExhausted,
+            "RECOVERABLE" => Self::Recoverable,
+            "TIMEOUT" => Self::Timeout,
+            "FATAL" => Self::Fatal,
+            "CWD_DELETED" => Self::CwdDeleted,
+            "MODEL_REFUSAL" => Self::ModelRefusal,
+            "SESSION_LIMIT" => Self::SessionLimit,
+            other => bail!("unknown terminal classification {other:?}"),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HealthReason {
+    Healthy,
+    ReauthRequired,
+    PlanExhausted,
+    TransientFailure,
+    SessionLimit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AccountHealth {
+    pub provider: AccountProvider,
+    pub name: String,
+    pub reason: HealthReason,
+    pub updated_at: u64,
+    pub signal_provenance: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cooldown_until: Option<u64>,
+    #[serde(default)]
+    pub consecutive_transient_failures: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_success: Option<u64>,
+}
+
+impl AccountHealth {
+    fn id(&self) -> AccountId {
+        AccountId {
+            provider: self.provider,
+            name: self.name.clone(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_eligible_at(&self, now: u64) -> bool {
+        self.reason != HealthReason::ReauthRequired
+            && self.cooldown_until.is_none_or(|deadline| deadline <= now)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HealthFile {
+    version: u32,
+    #[serde(default)]
+    accounts: Vec<AccountHealth>,
+    #[serde(default)]
+    cursors: HashMap<String, u64>,
+}
+
+impl Default for HealthFile {
+    fn default() -> Self {
+        Self {
+            version: SCHEMA_VERSION,
+            accounts: Vec::new(),
+            cursors: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProviderCapacity {
+    pub provider: AccountProvider,
+    pub raw: usize,
+    pub enabled: usize,
+    pub healthy: usize,
+    pub cooldown: usize,
+    pub reauth_required: usize,
+    pub observed_at: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct NoHealthyAccountError {
+    pub provider: AccountProvider,
+    pub reasons: Vec<String>,
+}
+
+impl std::fmt::Display for NoHealthyAccountError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "no healthy {:?} account is available: {}",
+            self.provider,
+            self.reasons.join(", ")
+        )
+    }
+}
+
+impl std::error::Error for NoHealthyAccountError {}
+
+fn now_epoch() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn state_path(workspace: &Path) -> PathBuf {
+    workspace.join(".loom").join("account-health.json")
+}
+
+fn lock_path(workspace: &Path) -> PathBuf {
+    workspace.join(".loom").join("account-health.lock")
+}
+
+fn read_state(workspace: &Path) -> Result<HealthFile> {
+    let path = state_path(workspace);
+    if !path.exists() {
+        return Ok(HealthFile::default());
+    }
+    let state: HealthFile = serde_json::from_slice(
+        &fs::read(&path).with_context(|| format!("failed to read {}", path.display()))?,
+    )
+    .with_context(|| format!("malformed provider health state {}", path.display()))?;
+    if state.version != SCHEMA_VERSION {
+        bail!(
+            "unsupported provider health schema version {} in {}",
+            state.version,
+            path.display()
+        );
+    }
+    let mut ids = HashSet::new();
+    for account in &state.accounts {
+        if account.name.is_empty() || !ids.insert(account.id()) {
+            bail!("invalid or duplicate account in provider health state");
+        }
+    }
+    Ok(state)
+}
+
+fn write_state(workspace: &Path, state: &HealthFile) -> Result<()> {
+    let path = state_path(workspace);
+    let parent = path.parent().expect("health path has parent");
+    fs::create_dir_all(parent)?;
+    let temporary = parent.join(format!(".account-health.{}.tmp", std::process::id()));
+    let bytes = serde_json::to_vec_pretty(state)?;
+    fs::write(&temporary, bytes)?;
+    fs::rename(&temporary, &path)?;
+    Ok(())
+}
+
+fn with_state<T>(
+    workspace: &Path,
+    operation: impl FnOnce(&mut HealthFile) -> Result<T>,
+) -> Result<T> {
+    fs::create_dir_all(workspace.join(".loom"))?;
+    let _lock = MkdirLock::acquire(&lock_path(workspace)).map_err(anyhow::Error::msg)?;
+    let mut state = read_state(workspace)?;
+    let result = operation(&mut state)?;
+    write_state(workspace, &state)?;
+    Ok(result)
+}
+
+fn cooldown_from_env(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+pub fn record_terminal(
+    workspace: &Path,
+    id: &AccountId,
+    classification: TerminalClassification,
+    provenance: &str,
+) -> Result<()> {
+    record_terminal_at(workspace, id, classification, provenance, now_epoch())
+}
+
+pub fn record_terminal_at(
+    workspace: &Path,
+    id: &AccountId,
+    classification: TerminalClassification,
+    provenance: &str,
+    now: u64,
+) -> Result<()> {
+    if id.name.is_empty() || provenance.is_empty() {
+        bail!("account identity and signal provenance are required");
+    }
+    with_state(workspace, |state| {
+        let existing = state.accounts.iter().position(|entry| entry.id() == *id);
+        if matches!(
+            classification,
+            TerminalClassification::Timeout
+                | TerminalClassification::Fatal
+                | TerminalClassification::CwdDeleted
+                | TerminalClassification::ModelRefusal
+        ) {
+            return Ok(());
+        }
+        let entry = existing.map_or_else(
+            || AccountHealth {
+                provider: id.provider,
+                name: id.name.clone(),
+                reason: HealthReason::Healthy,
+                updated_at: now,
+                signal_provenance: provenance.to_string(),
+                cooldown_until: None,
+                consecutive_transient_failures: 0,
+                last_success: None,
+            },
+            |index| state.accounts.remove(index),
+        );
+        let mut entry = entry;
+        entry.updated_at = now;
+        entry.signal_provenance = provenance.to_string();
+        match classification {
+            TerminalClassification::Success => {
+                entry.last_success = Some(now);
+                entry.consecutive_transient_failures = 0;
+                // A normal success must not silently clear an auth hold.
+                if entry.reason != HealthReason::ReauthRequired {
+                    entry.reason = HealthReason::Healthy;
+                    entry.cooldown_until = None;
+                }
+            }
+            TerminalClassification::TokenExpired => {
+                entry.reason = HealthReason::ReauthRequired;
+                entry.cooldown_until = None;
+            }
+            TerminalClassification::TokenExhausted => {
+                entry.reason = HealthReason::PlanExhausted;
+                entry.cooldown_until = Some(now.saturating_add(cooldown_from_env(
+                    "LOOM_CODEX_EXHAUSTED_COOLDOWN_SECS",
+                    DEFAULT_EXHAUSTED_COOLDOWN_SECS,
+                )));
+            }
+            TerminalClassification::Recoverable => {
+                entry.reason = HealthReason::TransientFailure;
+                entry.consecutive_transient_failures =
+                    entry.consecutive_transient_failures.saturating_add(1);
+                entry.cooldown_until = Some(now.saturating_add(cooldown_from_env(
+                    "LOOM_CODEX_RECOVERABLE_BACKOFF_SECS",
+                    DEFAULT_RECOVERABLE_BACKOFF_SECS,
+                )));
+            }
+            TerminalClassification::SessionLimit => {
+                entry.reason = HealthReason::SessionLimit;
+                entry.cooldown_until = Some(now.saturating_add(cooldown_from_env(
+                    "LOOM_CODEX_SESSION_BACKOFF_SECS",
+                    DEFAULT_SESSION_BACKOFF_SECS,
+                )));
+            }
+            TerminalClassification::Timeout
+            | TerminalClassification::Fatal
+            | TerminalClassification::CwdDeleted
+            | TerminalClassification::ModelRefusal => unreachable!(),
+        }
+        state.accounts.push(entry);
+        state
+            .accounts
+            .sort_by(|a, b| (a.provider as u8, &a.name).cmp(&(b.provider as u8, &b.name)));
+        Ok(())
+    })
+}
+
+/// Clear an auth hold only after the caller has independently verified reauth.
+pub fn clear_reauth(workspace: &Path, id: &AccountId, provenance: &str) -> Result<()> {
+    with_state(workspace, |state| {
+        let entry = state
+            .accounts
+            .iter_mut()
+            .find(|entry| entry.id() == *id)
+            .ok_or_else(|| anyhow!("no health record for {:?}/{}", id.provider, id.name))?;
+        if entry.reason != HealthReason::ReauthRequired {
+            bail!("account is not awaiting reauthentication");
+        }
+        entry.reason = HealthReason::Healthy;
+        entry.cooldown_until = None;
+        entry.consecutive_transient_failures = 0;
+        entry.updated_at = now_epoch();
+        entry.signal_provenance = provenance.to_string();
+        Ok(())
+    })
+}
+
+pub fn account_health(workspace: &Path, id: &AccountId) -> Result<Option<AccountHealth>> {
+    Ok(read_state(workspace)?
+        .accounts
+        .into_iter()
+        .find(|entry| entry.id() == *id))
+}
+
+pub fn select_healthy_at(
+    workspace: &Path,
+    provider: AccountProvider,
+    inventory: &[AccountDescriptor],
+    now: u64,
+) -> Result<AccountDescriptor> {
+    with_state(workspace, |state| {
+        let health: HashMap<AccountId, AccountHealth> = state
+            .accounts
+            .iter()
+            .cloned()
+            .map(|entry| (entry.id(), entry))
+            .collect();
+        let mut candidates: Vec<_> = inventory
+            .iter()
+            .filter(|account| account.id.provider == provider && account.enabled)
+            .filter(|account| {
+                health
+                    .get(&account.id)
+                    .is_none_or(|entry| entry.is_eligible_at(now))
+            })
+            .cloned()
+            .collect();
+        candidates.sort_by_key(|account| {
+            (
+                health
+                    .get(&account.id)
+                    .map_or(0, |entry| entry.consecutive_transient_failures),
+                account.id.name.clone(),
+            )
+        });
+        if candidates.is_empty() {
+            let reasons = inventory
+                .iter()
+                .filter(|account| account.id.provider == provider)
+                .map(|account| {
+                    let reason = if !account.enabled {
+                        "disabled".to_string()
+                    } else if let Some(entry) = health.get(&account.id) {
+                        match entry.reason {
+                            HealthReason::ReauthRequired => "reauth_required".to_string(),
+                            _ => entry.cooldown_until.map_or_else(
+                                || "unavailable".to_string(),
+                                |until| format!("cooldown_until={until}"),
+                            ),
+                        }
+                    } else {
+                        "unavailable".to_string()
+                    };
+                    format!("{}={reason}", account.id.name)
+                })
+                .collect();
+            return Err(NoHealthyAccountError { provider, reasons }.into());
+        }
+        let fewest = health
+            .get(&candidates[0].id)
+            .map_or(0, |entry| entry.consecutive_transient_failures);
+        candidates.retain(|account| {
+            health
+                .get(&account.id)
+                .map_or(0, |entry| entry.consecutive_transient_failures)
+                == fewest
+        });
+        let cursor_key = format!("{provider:?}").to_ascii_lowercase();
+        let cursor = state.cursors.entry(cursor_key).or_default();
+        let chosen = candidates[*cursor as usize % candidates.len()].clone();
+        *cursor = cursor.saturating_add(1);
+        Ok(chosen)
+    })
+}
+
+pub fn provider_capacity_at(
+    workspace: &Path,
+    provider: AccountProvider,
+    inventory: &[AccountDescriptor],
+    now: u64,
+) -> Result<ProviderCapacity> {
+    let state = read_state(workspace)?;
+    let health: HashMap<_, _> = state
+        .accounts
+        .into_iter()
+        .map(|entry| (entry.id(), entry))
+        .collect();
+    let accounts: Vec<_> = inventory
+        .iter()
+        .filter(|account| account.id.provider == provider)
+        .collect();
+    let enabled: Vec<_> = accounts.iter().filter(|account| account.enabled).collect();
+    let reauth_required = enabled
+        .iter()
+        .filter(|account| {
+            health
+                .get(&account.id)
+                .is_some_and(|entry| entry.reason == HealthReason::ReauthRequired)
+        })
+        .count();
+    let cooldown = enabled
+        .iter()
+        .filter(|account| {
+            health.get(&account.id).is_some_and(|entry| {
+                entry.reason != HealthReason::ReauthRequired
+                    && entry.cooldown_until.is_some_and(|until| until > now)
+            })
+        })
+        .count();
+    Ok(ProviderCapacity {
+        provider,
+        raw: accounts.len(),
+        enabled: enabled.len(),
+        healthy: enabled.len().saturating_sub(reauth_required + cooldown),
+        cooldown,
+        reauth_required,
+        observed_at: now,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tokens_pool::account_registry::{CredentialKind, InventoryProvenance};
+
+    fn descriptor(provider: AccountProvider, name: &str) -> AccountDescriptor {
+        AccountDescriptor {
+            id: AccountId {
+                provider,
+                name: name.into(),
+            },
+            credential_kind: CredentialKind::CodexHome,
+            credential_reference: PathBuf::from(name),
+            enabled: true,
+            provenance: InventoryProvenance::Shared,
+        }
+    }
+
+    #[test]
+    fn exhausted_fails_over_and_expires_at_deadline() {
+        let tmp = tempfile::tempdir().unwrap();
+        let accounts = vec![
+            descriptor(AccountProvider::Codex, "a"),
+            descriptor(AccountProvider::Codex, "b"),
+        ];
+        record_terminal_at(
+            tmp.path(),
+            &accounts[0].id,
+            TerminalClassification::TokenExhausted,
+            "adapter_v1",
+            100,
+        )
+        .unwrap();
+        assert_eq!(
+            select_healthy_at(tmp.path(), AccountProvider::Codex, &accounts, 101)
+                .unwrap()
+                .id
+                .name,
+            "b"
+        );
+        assert!(select_healthy_at(
+            tmp.path(),
+            AccountProvider::Codex,
+            &accounts,
+            100 + DEFAULT_EXHAUSTED_COOLDOWN_SECS
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn expired_survives_time_and_success_until_explicit_clear() {
+        let tmp = tempfile::tempdir().unwrap();
+        let account = descriptor(AccountProvider::Codex, "a");
+        record_terminal_at(
+            tmp.path(),
+            &account.id,
+            TerminalClassification::TokenExpired,
+            "adapter_v1",
+            1,
+        )
+        .unwrap();
+        record_terminal_at(
+            tmp.path(),
+            &account.id,
+            TerminalClassification::Success,
+            "adapter_v1",
+            u64::MAX - 1,
+        )
+        .unwrap();
+        assert!(select_healthy_at(
+            tmp.path(),
+            AccountProvider::Codex,
+            std::slice::from_ref(&account),
+            u64::MAX
+        )
+        .is_err());
+        clear_reauth(tmp.path(), &account.id, "verified_reauth").unwrap();
+        assert!(select_healthy_at(tmp.path(), AccountProvider::Codex, &[account], u64::MAX).is_ok());
+    }
+
+    #[test]
+    fn neutral_failures_do_not_poison_and_same_names_are_provider_scoped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let codex = descriptor(AccountProvider::Codex, "same");
+        let claude = descriptor(AccountProvider::Claude, "same");
+        record_terminal_at(
+            tmp.path(),
+            &codex.id,
+            TerminalClassification::TokenExpired,
+            "adapter_v1",
+            1,
+        )
+        .unwrap();
+        for category in [
+            TerminalClassification::Timeout,
+            TerminalClassification::Fatal,
+            TerminalClassification::CwdDeleted,
+            TerminalClassification::ModelRefusal,
+        ] {
+            record_terminal_at(tmp.path(), &claude.id, category, "adapter_v1", 2).unwrap();
+        }
+        assert!(account_health(tmp.path(), &claude.id).unwrap().is_none());
+        assert_eq!(
+            account_health(tmp.path(), &codex.id)
+                .unwrap()
+                .unwrap()
+                .reason,
+            HealthReason::ReauthRequired
+        );
+    }
+
+    #[test]
+    fn round_robin_is_persistent_and_capacity_is_honest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let accounts = vec![
+            descriptor(AccountProvider::Codex, "a"),
+            descriptor(AccountProvider::Codex, "b"),
+        ];
+        let first = select_healthy_at(tmp.path(), AccountProvider::Codex, &accounts, 1).unwrap();
+        let second = select_healthy_at(tmp.path(), AccountProvider::Codex, &accounts, 1).unwrap();
+        assert_ne!(first.id, second.id);
+        let capacity =
+            provider_capacity_at(tmp.path(), AccountProvider::Codex, &accounts, 1).unwrap();
+        assert_eq!((capacity.raw, capacity.enabled, capacity.healthy), (2, 2, 2));
+    }
+
+    #[test]
+    fn state_never_contains_credentials_or_raw_output() {
+        let tmp = tempfile::tempdir().unwrap();
+        let id = AccountId {
+            provider: AccountProvider::Codex,
+            name: "safe-name".into(),
+        };
+        record_terminal_at(tmp.path(), &id, TerminalClassification::Recoverable, "adapter_v1", 1)
+            .unwrap();
+        let state = fs::read_to_string(state_path(tmp.path())).unwrap();
+        assert!(!state.contains("auth.json"));
+        assert!(!state.contains("recognizable-secret"));
+    }
+
+    #[test]
+    fn malformed_and_unknown_schema_fail_closed() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir(tmp.path().join(".loom")).unwrap();
+        fs::write(state_path(tmp.path()), r#"{"version":99,"accounts":[]}"#).unwrap();
+        assert!(read_state(tmp.path()).is_err());
+        fs::write(state_path(tmp.path()), "{broken").unwrap();
+        assert!(read_state(tmp.path()).is_err());
+    }
+}

--- a/loom-daemon/src/tokens_pool/mod.rs
+++ b/loom-daemon/src/tokens_pool/mod.rs
@@ -67,6 +67,7 @@ pub mod bad_tokens;
 pub mod bootstrap;
 pub mod check;
 pub mod failure_counts;
+pub mod health;
 pub mod locking;
 pub mod monitor;
 pub mod monitor_db;
@@ -78,6 +79,10 @@ pub mod select;
 pub use account_registry::{
     account_inventory, select_account, AccountBinding, AccountDescriptor, AccountId,
     AccountProvider, CredentialKind, InventoryProvenance, SelectedAccount,
+};
+pub use health::{
+    account_health, clear_reauth, provider_capacity_at, record_terminal, select_healthy_at,
+    AccountHealth, HealthReason, NoHealthyAccountError, ProviderCapacity, TerminalClassification,
 };
 pub use select::{EmptyTokenPoolError, SelectedToken, EX_CONFIG};
 


### PR DESCRIPTION
## Summary

Connect Codex terminal classifications to durable provider/account health so managed daemon runs can avoid expired, exhausted, or temporarily unhealthy profiles without changing Claude's legacy token-pool formats.

## Changes

- Add atomically persisted, mkdir-lock guarded `(provider, account)` health state with cooldown, reauth, transient-failure, success-freshness, capacity, and explicit verified-reauth-clear APIs.
- Make Codex selection eligibility-first and fail-closed, with conservative transient ordering and a persistent provider-scoped round-robin cursor.
- Add `tokens select --provider codex` and use it for managed headless `spawn-codex.sh` dispatches without falling back to ambient `~/.codex`.
- Emit a bounded strict terminal classifier record and consume it in the daemon reaper before retry/re-dispatch decisions.
- Document the Codex health policy and preserve Claude `.ranking`, `.bad_tokens`, `.failure_counts`, allowlist, cursor, and capacity behavior unchanged.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Structured provider/account/category result with exit passthrough and no secrets | ✅ | `test-spawn-codex.sh` strict record, classifier, exit-code, and redaction assertions |
| Exhaustion cooldown and automatic eligibility recovery | ✅ | `exhausted_fails_over_and_expires_at_deadline` |
| Persistent reauth hold with explicit verified clear | ✅ | `expired_survives_time_and_success_until_explicit_clear` |
| Recoverable/session backoff and neutral non-account failures | ✅ | transition matrix and `neutral_failures_do_not_poison_and_same_names_are_provider_scoped` |
| Atomic provider-scoped persistence and malformed-state fail closed | ✅ | lock/rename implementation plus malformed/schema and same-name provider tests |
| Deterministic fair ranking and secret-free all-unavailable errors | ✅ | persistent round-robin, failure ordering, typed `NoHealthyAccountError` |
| Feedback precedes bounded daemon retry selection | ✅ | reaper calls provider feedback before existing retry/re-dispatch branches |
| Separate provider capacity without changing Claude global cap | ✅ | `ProviderCapacity` raw/enabled/healthy/cooldown/reauth fields; no capacity cap call sites changed |
| Claude legacy state remains unchanged | ✅ | existing build gate and token selector code/formats untouched |

## Test Plan

- `bash defaults/scripts/tests/test-spawn-codex.sh` — 143 passed
- `cargo test -p loom-daemon tokens_pool::health` — 6 passed
- `cargo test -p loom-daemon terminal_result_parser` — 1 passed
- `cargo clippy -p loom-daemon -- -D warnings`
- `cargo fmt --all -- --check`
- `bash .loom/scripts/build-gate.sh` — passed (workspace unit/build gate)

Closes #4493