### PR TITLE
feat: add secure Codex account lifecycle commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,6 +1223,7 @@ dependencies = [
  "dirs",
  "env_logger",
  "hex",
+ "libc",
  "log",
  "regex",
  "reqwest",

--- a/defaults/docs/guardrail-parity-codex.md
+++ b/defaults/docs/guardrail-parity-codex.md
@@ -260,11 +260,24 @@ targeting the profile's `CODEX_HOME`—never put a secret in argv or registry
 metadata.
 
 Every lifecycle command is all-or-nothing over the (profile, registry) pair. A
-failed `import` removes the profile it committed; a failed `remove` restores the
-live profile, its registry entry, **and** any `recovery.json` that invocation
-staged, so a later recoverable removal is never blocked by residue from a failed
-one. `--purge` destroys credential bytes only after the registry commit
-succeeds, so no failure leaves a registry entry pointing at deleted credentials.
+failed `add` or `import` removes the profile it created, so the name stays
+reusable; concurrent creations of the same name are serialized by an exclusive
+profile-directory claim, so a losing call can never delete the winner's
+credential. A failed `remove` restores the live profile's registry entry
+**and** removes any `recovery.json` that invocation staged, so a later
+recoverable removal is never blocked by residue from a failed one. `remove`
+commits the registry update *before* moving the profile: if the process dies
+mid-command, the residue is an inert orphan directory (only that name is
+blocked until an operator clears it), never a registry entry pointing at a
+vanished directory that would poison `accounts list` for every account.
+`--purge` destroys credential bytes only after the registry commit succeeds.
+
+Manually provisioned profiles (directories created under the profile root
+before `.loom/accounts.json` exists) appear in `accounts list` as discovered
+accounts. The first `disable`, `enable`, or `remove` adopts the whole
+discovered set into the registry, so mutating one discovered account never
+hides the others and lifecycle commands work on exactly the accounts `list`
+shows.
 
 Select a profile at spawn time by any of:
 

--- a/defaults/docs/guardrail-parity-codex.md
+++ b/defaults/docs/guardrail-parity-codex.md
@@ -259,6 +259,13 @@ only an explicit non-empty regular file, installs it atomically with mode
 targeting the profile's `CODEX_HOME`—never put a secret in argv or registry
 metadata.
 
+Every lifecycle command is all-or-nothing over the (profile, registry) pair. A
+failed `import` removes the profile it committed; a failed `remove` restores the
+live profile, its registry entry, **and** any `recovery.json` that invocation
+staged, so a later recoverable removal is never blocked by residue from a failed
+one. `--purge` destroys credential bytes only after the registry commit
+succeeds, so no failure leaves a registry entry pointing at deleted credentials.
+
 Select a profile at spawn time by any of:
 
 | Precedence | Env var | Meaning |

--- a/defaults/docs/guardrail-parity-codex.md
+++ b/defaults/docs/guardrail-parity-codex.md
@@ -240,8 +240,26 @@ companion provisioning issue #4469 so it has exactly one owner.
     └── …                          # Codex's own state (caches, logs, skills)
 ```
 
-Provision a profile with `CODEX_HOME=~/.loom/codex-profiles/<account> codex
-login`. Select it at spawn time by any of:
+Provision profiles through the secret-safe lifecycle CLI:
+
+```bash
+loom-daemon accounts add codex alice --device-auth
+loom-daemon accounts import codex bob --auth-file ~/.codex/auth.json
+loom-daemon accounts status codex alice --json
+loom-daemon accounts disable codex alice
+loom-daemon accounts reauth codex alice --device-auth
+loom-daemon accounts remove codex alice       # recoverable quarantine
+loom-daemon accounts remove codex alice --purge
+```
+
+`add` and `reauth` inherit the terminal for browser/device login. Import accepts
+only an explicit non-empty regular file, installs it atomically with mode
+`0600`, and never parses or prints it. Codex also supports `codex login
+--with-api-key` and `--with-access-token`; pipe those secrets on stdin while
+targeting the profile's `CODEX_HOME`—never put a secret in argv or registry
+metadata.
+
+Select a profile at spawn time by any of:
 
 | Precedence | Env var | Meaning |
 |---|---|---|
@@ -269,8 +287,10 @@ itself and rewrites `auth.json` in place. Consequences:
 ### Security posture
 
 - Profile dirs `0700`, `auth.json` `0600`. A profile is a live credential.
-- The adapter **assigns** the directory to `CODEX_HOME` — it never copies
-  `auth.json`. Nothing under `.loom/` ever holds a credential copy.
+- The adapter **assigns** the directory to `CODEX_HOME`; lifecycle import makes
+  the one intentional copy into the machine profile root. Repository `.loom/`,
+  token pools, daemon JSON, logs, and registry metadata never hold credential
+  contents.
 - Logging discipline: the adapter logs the profile **directory name** only
   (`spawn-codex: using Codex profile 'alice'`). Never the path's contents, never
   a byte of `auth.json`. Preserve this in any change to the adapter.
@@ -279,9 +299,13 @@ itself and rewrites `auth.json` in place. Consequences:
   fallback would attribute work and cost to the wrong account. Ambient auth
   (tier 4) is not a request and never fails here; Codex reports its own auth
   error, which classifies as `TOKEN_EXPIRED`.
-- **No token-pool integration in this phase.** There is no rotation, no
-  `.bad_tokens` marking, no provider-aware selection. One operator-provisioned
-  profile per dispatch. Provider-aware pooling is epic #4167 Phase 4.
+- Provider-aware inventory and lifecycle management are available, but there is
+  no health ranking, cooldown, automatic rotation, or failure feedback yet.
+  Those policies remain epic #4167 Phase 4 issue #4493.
+- The registry currently exposes no active-use lease/interlock. Operators must
+  not remove a profile while a worker is using it; lifecycle removal cannot yet
+  prove that condition and #4493 remains the integration point for runtime
+  feedback.
 
 ## References
 

--- a/defaults/docs/runtime-adapters.md
+++ b/defaults/docs/runtime-adapters.md
@@ -271,6 +271,13 @@ as `token_fidelity: sweep-aggregate-log | none`). The provider-aware account poo
 profile rotation) is the fork's shipped work (fork PRs #12/#17) and is the
 consumer of these signals.
 
+Loom's native account foundation separates lifecycle from policy:
+`loom-daemon accounts` securely creates, imports, inspects, disables,
+reauthenticates, quarantines, and purges named Codex profiles, while automatic
+ranking/rotation remains deferred to #4493. The lifecycle CLI treats
+`auth.json` as opaque mutable canonical state, enforces `0700`/`0600`
+permissions, and emits only bounded secret-free diagnostics.
+
 ### 5. Instruction format
 
 **Contract:** declare which instruction files the runtime reads, and generate

--- a/loom-daemon/Cargo.toml
+++ b/loom-daemon/Cargo.toml
@@ -25,6 +25,7 @@ hex = "0.4.3"
 # drops reqwest's default blocking/cookie/multipart surface this exporter
 # never touches.
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "rustls-native-certs", "json"] }
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3.27"

--- a/loom-daemon/src/cli/accounts.rs
+++ b/loom-daemon/src/cli/accounts.rs
@@ -9,8 +9,21 @@ use crate::AccountsAction;
 
 pub(crate) fn handle_accounts_command(action: AccountsAction, workspace: &str) -> Result<()> {
     use loom_daemon::tokens_pool::account_lifecycle::{
-        AccountLifecycle, AccountStatus, ProcessCodexRunner,
+        login_exit_code, AccountLifecycle, AccountStatus, ProcessCodexRunner,
     };
+
+    fn preserve_login_exit<T>(result: Result<T>) -> Result<T> {
+        match result {
+            Ok(value) => Ok(value),
+            Err(error) => {
+                if let Some(code) = login_exit_code(&error) {
+                    eprintln!("error: {error}");
+                    std::process::exit(code);
+                }
+                Err(error)
+            }
+        }
+    }
 
     fn require_codex(provider: &str) -> Result<()> {
         if provider.eq_ignore_ascii_case("codex") {
@@ -68,7 +81,7 @@ pub(crate) fn handle_accounts_command(action: AccountsAction, workspace: &str) -
             json,
         } => {
             require_codex(&provider)?;
-            print_status(&service.add(&name, device_auth)?, json)
+            print_status(&preserve_login_exit(service.add(&name, device_auth))?, json)
         }
         AccountsAction::Import {
             provider,
@@ -124,7 +137,7 @@ pub(crate) fn handle_accounts_command(action: AccountsAction, workspace: &str) -
             json,
         } => {
             require_codex(&provider)?;
-            print_status(&service.reauth(&name, device_auth)?, json)
+            print_status(&preserve_login_exit(service.reauth(&name, device_auth))?, json)
         }
         AccountsAction::Remove {
             provider,

--- a/loom-daemon/src/cli/accounts.rs
+++ b/loom-daemon/src/cli/accounts.rs
@@ -1,0 +1,151 @@
+//! `loom-daemon accounts` handler (Issue #4492): secret-safe machine-level
+//! Codex account lifecycle commands over
+//! `loom_daemon::tokens_pool::account_lifecycle`.
+
+use anyhow::{anyhow, Result};
+
+use super::tokens::resolve_tokens_workspace;
+use crate::AccountsAction;
+
+pub(crate) fn handle_accounts_command(action: AccountsAction, workspace: &str) -> Result<()> {
+    use loom_daemon::tokens_pool::account_lifecycle::{
+        AccountLifecycle, AccountStatus, ProcessCodexRunner,
+    };
+
+    fn require_codex(provider: &str) -> Result<()> {
+        if provider.eq_ignore_ascii_case("codex") {
+            Ok(())
+        } else {
+            Err(anyhow!(
+                "provider {provider:?} is not supported by `accounts`; Claude token behavior is unchanged"
+            ))
+        }
+    }
+
+    fn print_status(status: &AccountStatus, json: bool) -> Result<()> {
+        if json {
+            println!("{}", serde_json::to_string_pretty(status)?);
+        } else {
+            println!(
+                "codex/{}: {} ({:?}); credential={}, directory-permissions={}, \
+                 auth-permissions={}, owner={}, login={:?}",
+                status.name,
+                if status.enabled {
+                    "enabled"
+                } else {
+                    "disabled"
+                },
+                status.provenance,
+                status.diagnostics.auth_shape,
+                if status.diagnostics.directory_mode_valid {
+                    "valid"
+                } else {
+                    "unsafe"
+                },
+                if status.diagnostics.auth_mode_valid {
+                    "valid"
+                } else {
+                    "unsafe"
+                },
+                if status.diagnostics.owner_valid {
+                    "valid"
+                } else {
+                    "mismatch"
+                },
+                status.login_state,
+            );
+        }
+        Ok(())
+    }
+
+    let workspace = resolve_tokens_workspace(workspace)?;
+    let service = AccountLifecycle::new(workspace, ProcessCodexRunner)?;
+    match action {
+        AccountsAction::Add {
+            provider,
+            name,
+            device_auth,
+            json,
+        } => {
+            require_codex(&provider)?;
+            print_status(&service.add(&name, device_auth)?, json)
+        }
+        AccountsAction::Import {
+            provider,
+            name,
+            auth_file,
+            json,
+        } => {
+            require_codex(&provider)?;
+            print_status(&service.import(&name, &auth_file)?, json)
+        }
+        AccountsAction::List { provider, json } => {
+            require_codex(&provider)?;
+            let statuses = service.list(false)?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&statuses)?);
+            } else if statuses.is_empty() {
+                println!("No Codex accounts registered.");
+            } else {
+                for status in &statuses {
+                    print_status(status, false)?;
+                }
+            }
+            Ok(())
+        }
+        AccountsAction::Status {
+            provider,
+            name,
+            json,
+        } => {
+            require_codex(&provider)?;
+            print_status(&service.status(&name)?, json)
+        }
+        AccountsAction::Disable {
+            provider,
+            name,
+            json,
+        } => {
+            require_codex(&provider)?;
+            print_status(&service.disable(&name)?, json)
+        }
+        AccountsAction::Enable {
+            provider,
+            name,
+            json,
+        } => {
+            require_codex(&provider)?;
+            print_status(&service.enable(&name)?, json)
+        }
+        AccountsAction::Reauth {
+            provider,
+            name,
+            device_auth,
+            json,
+        } => {
+            require_codex(&provider)?;
+            print_status(&service.reauth(&name, device_auth)?, json)
+        }
+        AccountsAction::Remove {
+            provider,
+            name,
+            purge,
+            json,
+        } => {
+            require_codex(&provider)?;
+            let result = service.remove(&name, purge)?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&result)?);
+            } else if let Some(reference) = result.recovery_reference {
+                println!(
+                    "Retired codex/{} to private quarantine as {reference}. Recovery remains \
+                     machine-local; re-import its auth.json to restore.",
+                    result.name
+                );
+            } else {
+                println!("Irreversibly purged codex/{}.", result.name);
+            }
+            Ok(())
+        }
+    }
+}

--- a/loom-daemon/src/cli/mod.rs
+++ b/loom-daemon/src/cli/mod.rs
@@ -6,6 +6,7 @@
 //! (a sibling of this module, not nested under it) owns the daemon's own
 //! bootstrap/service-loop body, which is not a CLI subcommand handler.
 
+pub(crate) mod accounts;
 pub(crate) mod cleanup_ops;
 pub(crate) mod common;
 pub(crate) mod dispatch;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -355,6 +355,16 @@ enum Commands {
         action: TokensAction,
     },
 
+    /// Manage secret-safe machine-level AI account profiles.
+    Accounts {
+        #[command(subcommand)]
+        action: AccountsAction,
+
+        /// Loom workspace whose provider-aware account registry is updated.
+        #[arg(long, value_name = "PATH", default_value = ".", global = true)]
+        workspace: String,
+    },
+
     /// Standalone CLI surface over `terminal.rs`'s per-agent
     /// `CLAUDE_CONFIG_DIR` isolation (issue #4415, epic #4081 Phase 3 family
     /// 4): create/remove/validate an agent's isolated config directory, and
@@ -1530,6 +1540,90 @@ enum TokensAction {
     },
 }
 
+/// Sub-actions for `loom-daemon accounts`.
+#[derive(Subcommand)]
+enum AccountsAction {
+    /// Create a named profile and run the provider's interactive login.
+    Add {
+        #[arg(value_name = "PROVIDER")]
+        provider: String,
+        #[arg(value_name = "NAME")]
+        name: String,
+        #[arg(long)]
+        device_auth: bool,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Import an explicit opaque Codex auth file into a new named profile.
+    Import {
+        #[arg(value_name = "PROVIDER")]
+        provider: String,
+        #[arg(value_name = "NAME")]
+        name: String,
+        #[arg(long, value_name = "PATH")]
+        auth_file: PathBuf,
+        #[arg(long)]
+        json: bool,
+    },
+    /// List registered accounts and secret-free structural diagnostics.
+    List {
+        #[arg(long, value_name = "PROVIDER", default_value = "codex")]
+        provider: String,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Probe one account's structural and login status.
+    Status {
+        #[arg(value_name = "PROVIDER")]
+        provider: String,
+        #[arg(value_name = "NAME")]
+        name: String,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Make an account ineligible without changing its credential state.
+    Disable {
+        #[arg(value_name = "PROVIDER")]
+        provider: String,
+        #[arg(value_name = "NAME")]
+        name: String,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Restore eligibility after structural and permission validation.
+    Enable {
+        #[arg(value_name = "PROVIDER")]
+        provider: String,
+        #[arg(value_name = "NAME")]
+        name: String,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Reauthenticate the existing canonical profile in place.
+    Reauth {
+        #[arg(value_name = "PROVIDER")]
+        provider: String,
+        #[arg(value_name = "NAME")]
+        name: String,
+        #[arg(long)]
+        device_auth: bool,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Retire to private quarantine, or irreversibly delete with `--purge`.
+    Remove {
+        #[arg(value_name = "PROVIDER")]
+        provider: String,
+        #[arg(value_name = "NAME")]
+        name: String,
+        /// Irreversibly delete credential state instead of quarantining it.
+        #[arg(long)]
+        purge: bool,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
 /// Sub-actions for `loom-daemon claude-config` (issue #4415).
 #[derive(Subcommand)]
 enum ClaudeConfigAction {
@@ -1674,6 +1768,7 @@ async fn main() {
     }
 }
 
+use cli::accounts::handle_accounts_command;
 use cli::cleanup_ops::{
     handle_clean_command, handle_cleanup_command, handle_recover_orphans_command,
 };
@@ -1793,6 +1888,7 @@ fn handle_cli_command(command: Commands) -> Result<()> {
         Commands::Workspace { action } => handle_workspace_command(action),
         Commands::Fleet { action } => handle_fleet_command(action),
         Commands::Tokens { action } => handle_tokens_command(action),
+        Commands::Accounts { action, workspace } => handle_accounts_command(action, &workspace),
         Commands::ClaudeConfig { action } => handle_claude_config_command(action),
         Commands::AgentSpawn {
             role,

--- a/loom-daemon/src/tokens_pool/account_lifecycle.rs
+++ b/loom-daemon/src/tokens_pool/account_lifecycle.rs
@@ -119,6 +119,17 @@ pub trait CodexCommandRunner {
 pub struct ProcessCodexRunner;
 
 impl ProcessCodexRunner {
+    fn classify_status(success: bool, text: &str) -> &'static str {
+        let text = text.to_ascii_lowercase();
+        if text.contains("not logged in") {
+            "not logged in"
+        } else if success && text.contains("logged in") {
+            "logged in"
+        } else {
+            "Codex login status failed"
+        }
+    }
+
     fn bounded_status(profile: &Path) -> Result<RunnerOutput> {
         let mut child = match Command::new("codex")
             .args(["login", "status"])
@@ -155,14 +166,8 @@ impl ProcessCodexRunner {
                             .read_to_end(&mut bytes)?;
                     }
                 }
-                let text = String::from_utf8_lossy(&bytes).to_ascii_lowercase();
-                let summary = if status.success() && text.contains("logged in") {
-                    "logged in"
-                } else if text.contains("not logged in") {
-                    "not logged in"
-                } else {
-                    "Codex login status failed"
-                };
+                let summary =
+                    Self::classify_status(status.success(), &String::from_utf8_lossy(&bytes));
                 return Ok(RunnerOutput {
                     success: status.success(),
                     unavailable: false,
@@ -303,7 +308,11 @@ impl<R: CodexCommandRunner> AccountLifecycle<R> {
             let _ = fs::remove_dir(&profile);
         }
         result?;
-        register_codex_account(&self.workspace, name, name, true)?;
+        if let Err(error) = register_codex_account(&self.workspace, name, name, true) {
+            fs::remove_dir_all(&profile)
+                .context("account registry update failed and imported profile rollback failed")?;
+            return Err(error.context("account registry update failed; imported profile removed"));
+        }
         self.status_without_probe(name)
     }
 
@@ -366,11 +375,37 @@ impl<R: CodexCommandRunner> AccountLifecycle<R> {
         let recovery_reference = format!("{name}-{stamp}-{}", now.subsec_nanos());
         validate_name(&recovery_reference)?;
         let destination = quarantine.join(&recovery_reference);
+        let recovery_file = account.credential_reference.join("recovery.json");
+        if !purge {
+            let metadata = serde_json::json!({
+                "version": 1,
+                "provider": "codex",
+                "name": name,
+                "retired_at_unix": stamp,
+                "original_reference": name,
+            });
+            let mut file =
+                private_file(&recovery_file).context("failed to create recovery metadata")?;
+            let metadata_result = (|| -> Result<()> {
+                serde_json::to_writer_pretty(&mut file, &metadata)?;
+                file.write_all(b"\n")?;
+                file.sync_all()?;
+                Ok(())
+            })();
+            if metadata_result.is_err() {
+                let _ = fs::remove_file(&recovery_file);
+            }
+            metadata_result.context("failed to prepare recovery metadata")?;
+        }
         fs::rename(&account.credential_reference, &destination)
             .context("failed to quarantine profile atomically")?;
         if let Err(error) = unregister_codex_account(&self.workspace, name) {
             fs::rename(&destination, &account.credential_reference)
                 .context("account registry update failed and profile rollback also failed")?;
+            if !purge {
+                fs::remove_file(&recovery_file)
+                    .context("account registry update failed and metadata rollback also failed")?;
+            }
             return Err(error.context("account registry update failed; profile was restored"));
         }
         if purge {
@@ -386,16 +421,6 @@ impl<R: CodexCommandRunner> AccountLifecycle<R> {
                 recovery_reference: None,
             });
         }
-        let metadata = serde_json::json!({
-            "version": 1,
-            "provider": "codex",
-            "name": name,
-            "retired_at_unix": stamp,
-            "original_reference": name,
-        });
-        let mut file = private_file(&destination.join("recovery.json"))?;
-        serde_json::to_writer_pretty(&mut file, &metadata)?;
-        file.write_all(b"\n")?;
         Ok(RemovalOutcome {
             provider: AccountProvider::Codex,
             name: name.into(),
@@ -857,6 +882,27 @@ mod tests {
 
     #[test]
     #[serial]
+    fn import_registry_failure_removes_committed_profile_without_secret_leak() {
+        let (workspace, root) = setup();
+        let source = root.path().join("source");
+        fs::write(&source, "recognizable-fake-secret").unwrap();
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", root.path());
+        let service = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
+        let lock = per_repo_accounts_file(workspace.path()).with_extension("json.lock");
+        fs::create_dir_all(lock.parent().unwrap()).unwrap();
+        fs::create_dir(&lock).unwrap();
+
+        let error = service.import("alice", &source).unwrap_err().to_string();
+        fs::remove_dir(&lock).unwrap();
+        assert!(error.contains("registry"));
+        assert!(!root.path().join("alice").exists());
+        assert!(service.list(false).unwrap().is_empty());
+        assert!(!error.contains("recognizable-fake-secret"));
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
     fn registry_failure_rolls_quarantine_and_purge_back_to_live_profile() {
         let (workspace, root) = setup();
         let source_dir = tempfile::tempdir().unwrap();
@@ -895,6 +941,62 @@ mod tests {
         assert!(service.find("alice").is_ok());
         assert!(!error.contains("recognizable-fake-secret"));
         std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn recovery_metadata_collision_leaves_live_profile_and_registry_unchanged() {
+        let (workspace, root) = setup();
+        let source = root.path().join("source");
+        fs::write(&source, "recognizable-fake-secret").unwrap();
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", root.path());
+        let service = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
+        service.import("alice", &source).unwrap();
+        let recovery = root.path().join("alice/recovery.json");
+        fs::write(&recovery, "recognizable-existing-metadata").unwrap();
+
+        let error = service.remove("alice", false).unwrap_err().to_string();
+        assert!(root.path().join("alice").join(AUTH_FILE).exists());
+        assert!(service.find("alice").is_ok());
+        assert_eq!(fs::read_to_string(recovery).unwrap(), "recognizable-existing-metadata");
+        assert!(!error.contains("recognizable-fake-secret"));
+        assert!(!error.contains("recognizable-existing-metadata"));
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(unix)]
+    fn bounded_status_real_process_does_not_misclassify_not_logged_in() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let fixture = tempfile::tempdir().unwrap();
+        let bin = fixture.path().join("bin");
+        fs::create_dir(&bin).unwrap();
+        let codex = bin.join("codex");
+        fs::write(&codex, "#!/bin/sh\nprintf 'Not logged in\\n'\nexit 0\n").unwrap();
+        fs::set_permissions(&codex, fs::Permissions::from_mode(0o700)).unwrap();
+        let old_path = std::env::var_os("PATH");
+        let joined = std::env::join_paths(
+            std::iter::once(bin).chain(
+                old_path
+                    .as_deref()
+                    .map(std::env::split_paths)
+                    .into_iter()
+                    .flatten(),
+            ),
+        )
+        .unwrap();
+        std::env::set_var("PATH", joined);
+        let output = ProcessCodexRunner::bounded_status(fixture.path()).unwrap();
+        if let Some(path) = old_path {
+            std::env::set_var("PATH", path);
+        } else {
+            std::env::remove_var("PATH");
+        }
+
+        assert!(output.success);
+        assert_eq!(output.summary, "not logged in");
     }
 
     #[test]

--- a/loom-daemon/src/tokens_pool/account_lifecycle.rs
+++ b/loom-daemon/src/tokens_pool/account_lifecycle.rs
@@ -254,8 +254,7 @@ impl<R: CodexCommandRunner> AccountLifecycle<R> {
     pub fn add(&self, name: &str, device_auth: bool) -> Result<AccountStatus> {
         validate_name(name)?;
         self.ensure_absent(name)?;
-        let profile = self.profile(name)?;
-        ensure_private_dir(&profile)?;
+        let profile = self.claim_profile_dir(name)?;
         let result = self.runner.login(&profile, device_auth)?;
         if !result.success {
             if fs::read_dir(&profile)?.next().is_none() {
@@ -263,12 +262,22 @@ impl<R: CodexCommandRunner> AccountLifecycle<R> {
             }
             return Err(login_failure(result));
         }
-        tighten_profile_permissions(&profile)?;
-        let diagnostics = inspect_profile(&profile);
-        if !diagnostics.valid() {
-            bail!("Codex login completed but the profile credential is missing or unsafe");
+        // The post-login commit is all-or-nothing over the (profile, registry)
+        // pair, mirroring `import`: any failure removes the profile this call
+        // created, so the name stays reusable instead of being wedged as an
+        // unregistered credential directory that `remove` cannot reach.
+        let commit = (|| -> Result<()> {
+            tighten_profile_permissions(&profile)?;
+            if !inspect_profile(&profile).valid() {
+                bail!("Codex login completed but the profile credential is missing or unsafe");
+            }
+            register_codex_account(&self.workspace, name, name, true)
+        })();
+        if let Err(error) = commit {
+            fs::remove_dir_all(&profile)
+                .context("account setup failed and new profile rollback also failed")?;
+            return Err(error.context("account setup failed; new profile was removed"));
         }
-        register_codex_account(&self.workspace, name, name, true)?;
         self.status(name)
     }
 
@@ -288,7 +297,7 @@ impl<R: CodexCommandRunner> AccountLifecycle<R> {
         if source == destination {
             bail!("authentication source and destination must differ");
         }
-        ensure_private_dir(&profile)?;
+        self.claim_profile_dir(name)?;
         let staged = profile.join(format!(".auth.json.tmp-{}", std::process::id()));
         let result = (|| -> Result<()> {
             let mut input = OpenOptions::new()
@@ -309,6 +318,9 @@ impl<R: CodexCommandRunner> AccountLifecycle<R> {
         }
         result?;
         if let Err(error) = register_codex_account(&self.workspace, name, name, true) {
+            // Safe to delete unconditionally: `claim_profile_dir` guarantees
+            // this call exclusively created the directory, so a concurrent
+            // winner's profile can never be destroyed by this rollback.
             fs::remove_dir_all(&profile)
                 .context("account registry update failed and imported profile rollback failed")?;
             return Err(error.context("account registry update failed; imported profile removed"));
@@ -397,32 +409,53 @@ impl<R: CodexCommandRunner> AccountLifecycle<R> {
             }
             metadata_result.context("failed to prepare recovery metadata")?;
         }
+        // The registry commit happens *before* the profile leaves its live
+        // location. If the process dies between the two steps, the residue is
+        // an orphan profile directory with no registry entry — annoying but
+        // inert. The previous order (rename, then unregister) could leave a
+        // registry entry pointing at a vanished directory, which poisoned
+        // `codex_inventory` for every account until the registry was
+        // hand-edited.
+        let removed = match unregister_codex_account(&self.workspace, name) {
+            Ok(removed) => removed,
+            Err(error) => {
+                // Registry and profile are both untouched; remove only the
+                // metadata this call staged so the profile is byte-identical
+                // to its pre-command state. Cleanup is best effort and only
+                // annotates the error when residue actually survives.
+                let metadata_left_behind =
+                    !purge && fs::remove_file(&recovery_file).is_err() && recovery_file.exists();
+                let result: Result<RemovalOutcome> =
+                    Err(error.context("account registry update failed; profile is unchanged"));
+                return if metadata_left_behind {
+                    result.context("recovery metadata rollback also failed")
+                } else {
+                    result
+                };
+            }
+        };
         if let Err(error) = fs::rename(&account.credential_reference, &destination) {
-            // A failed rename leaves the live profile in place, but this
-            // invocation already staged `recovery.json` inside it. Remove only
-            // the metadata this call created so the profile is byte-identical
-            // to its pre-command state and a later recoverable removal is not
-            // blocked by stale metadata at `create_new`. The rename error is
-            // the actionable one, so metadata cleanup is best effort and only
-            // annotates the error when residue actually survives.
+            // The profile is still live: restore its registry entry verbatim
+            // and remove the metadata this call staged. The rename error is
+            // the actionable one; rollback failures only annotate it.
+            let reregistered = register_codex_account(
+                &self.workspace,
+                name,
+                &removed.credential_reference,
+                removed.enabled,
+            );
             let metadata_left_behind =
                 !purge && fs::remove_file(&recovery_file).is_err() && recovery_file.exists();
-            let result: Result<RemovalOutcome> =
+            let mut result: Result<RemovalOutcome> =
                 Err(error).context("failed to quarantine profile atomically");
-            return if metadata_left_behind {
-                result.context("recovery metadata rollback also failed")
-            } else {
-                result
-            };
-        }
-        if let Err(error) = unregister_codex_account(&self.workspace, name) {
-            fs::rename(&destination, &account.credential_reference)
-                .context("account registry update failed and profile rollback also failed")?;
-            if !purge {
-                fs::remove_file(&recovery_file)
-                    .context("account registry update failed and metadata rollback also failed")?;
+            if let Err(reregister_error) = reregistered {
+                result =
+                    result.context(format!("registry rollback also failed: {reregister_error:#}"));
             }
-            return Err(error.context("account registry update failed; profile was restored"));
+            if metadata_left_behind {
+                result = result.context("recovery metadata rollback also failed");
+            }
+            return result;
         }
         if purge {
             // Only destroy bytes after the registry commit. A deletion error
@@ -497,6 +530,36 @@ impl<R: CodexCommandRunner> AccountLifecycle<R> {
     fn profile(&self, name: &str) -> Result<PathBuf> {
         validate_name(name)?;
         Ok(self.root.join(name))
+    }
+
+    /// Atomically claim the profile directory for `name`. The non-recursive
+    /// `create_dir` is the mutual-exclusion point for concurrent `add`/`import`
+    /// of the same name: exactly one caller creates the directory and thereby
+    /// owns every later rollback of it; the loser fails here without ever
+    /// touching the winner's files or registration.
+    fn claim_profile_dir(&self, name: &str) -> Result<PathBuf> {
+        let profile = self.profile(name)?;
+        let mut builder = fs::DirBuilder::new();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            builder.mode(0o700);
+        }
+        match builder.create(&profile) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                bail!("Codex account {name:?} already exists");
+            }
+            Err(error) => {
+                return Err(anyhow!(error).context("failed to create Codex profile directory"))
+            }
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&profile, fs::Permissions::from_mode(0o700))?;
+        }
+        Ok(profile)
     }
 }
 
@@ -631,6 +694,7 @@ mod tests {
     struct FakeRunner {
         calls: Mutex<Vec<(PathBuf, Vec<String>)>>,
         fail_login: bool,
+        skip_auth_write: bool,
     }
 
     struct StatusRunner(RunnerOutput);
@@ -652,7 +716,7 @@ mod tests {
                 args.push("--device-auth".into());
             }
             self.calls.lock().unwrap().push((profile.into(), args));
-            if !self.fail_login {
+            if !self.fail_login && !self.skip_auth_write {
                 let mut options = OpenOptions::new();
                 options.write(true).create(true).truncate(true);
                 #[cfg(unix)]
@@ -694,6 +758,20 @@ mod tests {
 
     fn setup() -> (tempfile::TempDir, tempfile::TempDir) {
         (tempfile::tempdir().unwrap(), tempfile::tempdir().unwrap())
+    }
+
+    /// A manually provisioned (pre-registry) profile with safe permissions,
+    /// as an operator would create with `codex login` by hand.
+    fn provision_manual_profile(root: &Path, name: &str) {
+        let dir = root.join(name);
+        fs::create_dir(&dir).unwrap();
+        fs::write(dir.join(AUTH_FILE), "recognizable-fake-secret").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&dir, fs::Permissions::from_mode(0o700)).unwrap();
+            fs::set_permissions(dir.join(AUTH_FILE), fs::Permissions::from_mode(0o600)).unwrap();
+        }
     }
 
     #[test]
@@ -1031,6 +1109,173 @@ mod tests {
         assert!(removed.recovery_reference.is_some());
         assert!(!root.path().join("alice").exists());
         assert!(service.find("alice").is_err());
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn concurrent_import_of_same_name_never_destroys_the_winner() {
+        let (workspace, root) = setup();
+        let source_dir = tempfile::tempdir().unwrap();
+        let source = source_dir.path().join("auth.json");
+        fs::write(&source, "recognizable-fake-secret").unwrap();
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", root.path());
+        let service = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
+
+        let outcomes: Vec<Result<AccountStatus>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..4)
+                .map(|_| scope.spawn(|| service.import("alice", &source)))
+                .collect();
+            handles
+                .into_iter()
+                .map(|handle| handle.join().unwrap())
+                .collect()
+        });
+
+        assert_eq!(outcomes.iter().filter(|outcome| outcome.is_ok()).count(), 1);
+        for failure in outcomes.iter().filter(|outcome| outcome.is_err()) {
+            let message = format!("{:#}", failure.as_ref().unwrap_err());
+            assert!(message.contains("exists"));
+            assert!(!message.contains("recognizable-fake-secret"));
+        }
+        // No loser's rollback may have deleted the winner's profile or its
+        // registration.
+        assert_eq!(
+            fs::read_to_string(root.path().join("alice").join(AUTH_FILE)).unwrap(),
+            "recognizable-fake-secret"
+        );
+        let listed = service.list(false).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert!(listed[0].diagnostics.valid());
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn add_registry_failure_rolls_back_profile_and_frees_the_name() {
+        let (workspace, root) = setup();
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", root.path());
+        let service = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
+        let lock = per_repo_accounts_file(workspace.path()).with_extension("json.lock");
+        fs::create_dir_all(lock.parent().unwrap()).unwrap();
+        fs::create_dir(&lock).unwrap();
+
+        let error = format!("{:#}", service.add("alice", false).unwrap_err());
+        fs::remove_dir(&lock).unwrap();
+        assert!(error.contains("new profile was removed"));
+        assert!(!error.contains("recognizable-fake-secret"));
+        assert!(!root.path().join("alice").exists());
+        assert!(service.list(false).unwrap().is_empty());
+        // The name is immediately reusable, not permanently wedged.
+        service.add("alice", false).unwrap();
+        assert_eq!(service.list(false).unwrap().len(), 1);
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn add_without_credential_rolls_back_profile_and_frees_the_name() {
+        let (workspace, root) = setup();
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", root.path());
+        let broken = AccountLifecycle::new(
+            workspace.path(),
+            FakeRunner {
+                skip_auth_write: true,
+                ..FakeRunner::default()
+            },
+        )
+        .unwrap();
+
+        let error = format!("{:#}", broken.add("alice", false).unwrap_err());
+        assert!(error.contains("new profile was removed"));
+        assert!(!root.path().join("alice").exists());
+        assert!(broken.list(false).unwrap().is_empty());
+        // A later, healthy login can claim the same name.
+        let healthy = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
+        healthy.add("alice", false).unwrap();
+        assert_eq!(healthy.list(false).unwrap().len(), 1);
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn discovered_profiles_support_disable_enable_and_remove() {
+        let (workspace, root) = setup();
+        provision_manual_profile(root.path(), "alice");
+        provision_manual_profile(root.path(), "bob");
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", root.path());
+        let service = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
+
+        let listed = service.list(false).unwrap();
+        assert_eq!(listed.len(), 2);
+        assert!(listed
+            .iter()
+            .all(|account| account.provenance == InventoryProvenance::Shared));
+
+        // Mutating one discovered account adopts the whole discovered set, so
+        // `list` shows the same accounts before and after.
+        let disabled = service.disable("alice").unwrap();
+        assert!(!disabled.enabled);
+        let listed = service.list(false).unwrap();
+        assert_eq!(listed.len(), 2);
+        let bob = listed.iter().find(|account| account.name == "bob").unwrap();
+        assert!(bob.enabled);
+
+        assert!(service.enable("alice").unwrap().enabled);
+
+        let removed = service.remove("bob", false).unwrap();
+        assert!(removed.recovery_reference.is_some());
+        assert!(!root.path().join("bob").exists());
+        assert_eq!(service.list(false).unwrap().len(), 1);
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn disable_enable_and_remove_work_pre_registry_without_registry_file() {
+        let (workspace, root) = setup();
+        provision_manual_profile(root.path(), "alice");
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", root.path());
+        let service = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
+
+        // `remove` on a discovered account adopts and then unregisters it in
+        // one lifecycle command; the quarantine copy keeps the credential.
+        let removed = service.remove("alice", false).unwrap();
+        let recovery = root
+            .path()
+            .join(".quarantine")
+            .join(removed.recovery_reference.unwrap());
+        assert!(recovery.join(AUTH_FILE).exists());
+        assert!(service.list(false).unwrap().is_empty());
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn orphan_profile_directory_does_not_poison_registered_inventory() {
+        let (workspace, root) = setup();
+        let source = root.path().join("source");
+        fs::write(&source, "recognizable-fake-secret").unwrap();
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", root.path());
+        let service = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
+        service.import("alice", &source).unwrap();
+        service.import("bob", &source).unwrap();
+
+        // Crash residue from the reordered `remove` (killed between the
+        // registry commit and the quarantine rename) is a live directory with
+        // no registry entry. It must not affect any other account's lifecycle.
+        provision_manual_profile(root.path(), "carol");
+        assert_eq!(service.list(false).unwrap().len(), 2);
+        service.disable("alice").unwrap();
+        service.remove("alice", false).unwrap();
+        assert_eq!(service.list(false).unwrap().len(), 1);
+        // Only the orphaned name itself stays blocked until an operator
+        // clears the directory.
+        assert!(service
+            .import("carol", &source)
+            .unwrap_err()
+            .to_string()
+            .contains("exists"));
         std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
     }
 

--- a/loom-daemon/src/tokens_pool/account_lifecycle.rs
+++ b/loom-daemon/src/tokens_pool/account_lifecycle.rs
@@ -78,7 +78,37 @@ pub struct RunnerOutput {
     pub success: bool,
     pub unavailable: bool,
     pub timed_out: bool,
+    pub exit_code: Option<i32>,
     pub summary: String,
+}
+
+#[derive(Debug)]
+pub struct LoginCommandFailed {
+    pub exit_code: Option<i32>,
+    summary: String,
+}
+
+impl std::fmt::Display for LoginCommandFailed {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.summary)
+    }
+}
+
+impl std::error::Error for LoginCommandFailed {}
+
+#[must_use]
+pub fn login_exit_code(error: &anyhow::Error) -> Option<i32> {
+    error
+        .downcast_ref::<LoginCommandFailed>()
+        .and_then(|failure| failure.exit_code)
+}
+
+fn login_failure(output: RunnerOutput) -> anyhow::Error {
+    LoginCommandFailed {
+        exit_code: output.exit_code,
+        summary: output.summary,
+    }
+    .into()
 }
 
 pub trait CodexCommandRunner {
@@ -103,6 +133,7 @@ impl ProcessCodexRunner {
                     success: false,
                     unavailable: true,
                     timed_out: false,
+                    exit_code: None,
                     summary: "Codex CLI is not installed or not on PATH".into(),
                 });
             }
@@ -136,6 +167,7 @@ impl ProcessCodexRunner {
                     success: status.success(),
                     unavailable: false,
                     timed_out: false,
+                    exit_code: status.code(),
                     summary: summary.into(),
                 });
             }
@@ -146,6 +178,7 @@ impl ProcessCodexRunner {
                     success: false,
                     unavailable: false,
                     timed_out: true,
+                    exit_code: None,
                     summary: "Codex login status timed out".into(),
                 });
             }
@@ -168,6 +201,7 @@ impl CodexCommandRunner for ProcessCodexRunner {
                     success: false,
                     unavailable: true,
                     timed_out: false,
+                    exit_code: None,
                     summary: "Codex CLI is not installed or not on PATH".into(),
                 });
             }
@@ -177,6 +211,7 @@ impl CodexCommandRunner for ProcessCodexRunner {
             success: status.success(),
             unavailable: false,
             timed_out: false,
+            exit_code: status.code(),
             summary: if status.success() {
                 "login completed"
             } else {
@@ -221,7 +256,7 @@ impl<R: CodexCommandRunner> AccountLifecycle<R> {
             if fs::read_dir(&profile)?.next().is_none() {
                 let _ = fs::remove_dir(&profile);
             }
-            bail!("{}", result.summary);
+            return Err(login_failure(result));
         }
         tighten_profile_permissions(&profile)?;
         let diagnostics = inspect_profile(&profile);
@@ -312,7 +347,7 @@ impl<R: CodexCommandRunner> AccountLifecycle<R> {
             .runner
             .login(&account.credential_reference, device_auth)?;
         if !result.success {
-            bail!("{}", result.summary);
+            return Err(login_failure(result));
         }
         tighten_profile_permissions(&account.credential_reference)?;
         let status = self.status(name)?;
@@ -324,28 +359,32 @@ impl<R: CodexCommandRunner> AccountLifecycle<R> {
 
     pub fn remove(&self, name: &str, purge: bool) -> Result<RemovalOutcome> {
         let account = self.find(name)?;
+        let quarantine = self.root.join(".quarantine");
+        ensure_private_dir(&quarantine)?;
+        let now = SystemTime::now().duration_since(UNIX_EPOCH)?;
+        let stamp = now.as_secs();
+        let recovery_reference = format!("{name}-{stamp}-{}", now.subsec_nanos());
+        validate_name(&recovery_reference)?;
+        let destination = quarantine.join(&recovery_reference);
+        fs::rename(&account.credential_reference, &destination)
+            .context("failed to quarantine profile atomically")?;
+        if let Err(error) = unregister_codex_account(&self.workspace, name) {
+            fs::rename(&destination, &account.credential_reference)
+                .context("account registry update failed and profile rollback also failed")?;
+            return Err(error.context("account registry update failed; profile was restored"));
+        }
         if purge {
-            fs::remove_dir_all(&account.credential_reference)
-                .context("failed to purge Codex profile")?;
-            unregister_codex_account(&self.workspace, name)?;
+            // Only destroy bytes after the registry commit. A deletion error
+            // may leave private quarantine residue, but never a stale live
+            // registry entry pointing at a partially deleted profile.
+            fs::remove_dir_all(&destination)
+                .context("failed to purge quarantined Codex profile")?;
             return Ok(RemovalOutcome {
                 provider: AccountProvider::Codex,
                 name: name.into(),
                 purged: true,
                 recovery_reference: None,
             });
-        }
-        let quarantine = self.root.join(".quarantine");
-        ensure_private_dir(&quarantine)?;
-        let stamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
-        let recovery_reference = format!("{name}-{stamp}");
-        validate_name(&recovery_reference)?;
-        let destination = quarantine.join(&recovery_reference);
-        fs::rename(&account.credential_reference, &destination)
-            .context("failed to quarantine profile atomically")?;
-        if let Err(error) = unregister_codex_account(&self.workspace, name) {
-            let _ = fs::rename(&destination, &account.credential_reference);
-            return Err(error);
         }
         let metadata = serde_json::json!({
             "version": 1,
@@ -488,6 +527,14 @@ fn tighten_profile_permissions(profile: &Path) -> Result<()> {
 }
 
 fn inspect_profile(profile: &Path) -> ProfileDiagnostics {
+    #[cfg(unix)]
+    let invoking_uid = unsafe { libc::geteuid() };
+    #[cfg(not(unix))]
+    let invoking_uid = 0;
+    inspect_profile_for_uid(profile, invoking_uid)
+}
+
+fn inspect_profile_for_uid(profile: &Path, invoking_uid: u32) -> ProfileDiagnostics {
     let profile_meta = fs::symlink_metadata(profile).ok();
     let auth_meta = fs::symlink_metadata(profile.join(AUTH_FILE)).ok();
     let auth_shape = match &auth_meta {
@@ -514,7 +561,9 @@ fn inspect_profile(profile: &Path) -> ProfileDiagnostics {
             .as_ref()
             .is_some_and(|meta| meta.mode() & 0o077 == 0);
         let owner_valid = match (&profile_meta, &auth_meta) {
-            (Some(directory), Some(auth)) => directory.uid() == auth.uid(),
+            (Some(directory), Some(auth)) => {
+                directory.uid() == invoking_uid && auth.uid() == invoking_uid
+            }
             _ => false,
         };
         (directory_mode_valid, auth_mode_valid, owner_valid)
@@ -532,6 +581,7 @@ fn inspect_profile(profile: &Path) -> ProfileDiagnostics {
 
 #[cfg(test)]
 mod tests {
+    use super::super::paths::per_repo_accounts_file;
     use super::*;
     use serial_test::serial;
     use std::sync::Mutex;
@@ -540,6 +590,18 @@ mod tests {
     struct FakeRunner {
         calls: Mutex<Vec<(PathBuf, Vec<String>)>>,
         fail_login: bool,
+    }
+
+    struct StatusRunner(RunnerOutput);
+
+    impl CodexCommandRunner for StatusRunner {
+        fn login(&self, _profile: &Path, _device_auth: bool) -> Result<RunnerOutput> {
+            unreachable!("status-only test runner")
+        }
+
+        fn login_status(&self, _profile: &Path) -> Result<RunnerOutput> {
+            Ok(self.0.clone())
+        }
     }
 
     impl CodexCommandRunner for FakeRunner {
@@ -564,6 +626,7 @@ mod tests {
                 success: !self.fail_login,
                 unavailable: false,
                 timed_out: false,
+                exit_code: self.fail_login.then_some(23),
                 summary: if self.fail_login {
                     "cancelled"
                 } else {
@@ -582,6 +645,7 @@ mod tests {
                 success: true,
                 unavailable: false,
                 timed_out: false,
+                exit_code: Some(0),
                 summary: "logged in".into(),
             })
         }
@@ -666,7 +730,8 @@ mod tests {
             },
         )
         .unwrap();
-        assert!(service.add("alice", false).is_err());
+        let error = service.add("alice", false).unwrap_err();
+        assert_eq!(login_exit_code(&error), Some(23));
         assert!(!root.path().join("alice").exists());
         assert!(service.list(false).unwrap().is_empty());
         std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
@@ -710,6 +775,9 @@ mod tests {
         let metadata = fs::read_to_string(recovery.join("recovery.json")).unwrap();
         assert!(!metadata.contains("recognizable-fake-secret"));
         assert!(recovery.join("auth.json").exists());
+        service.import("alice", &source).unwrap();
+        let second = service.remove("alice", false).unwrap();
+        assert_ne!(recovery.file_name().unwrap(), second.recovery_reference.as_deref().unwrap());
         service.import("bob", &source).unwrap();
         assert!(service.remove("bob", true).unwrap().purged);
         assert!(!root.path().join("bob").exists());
@@ -728,6 +796,165 @@ mod tests {
         let service = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
         for name in ["../escape", "/absolute", "a/b", r"a\b"] {
             assert!(service.add(name, false).is_err());
+        }
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn diagnostics_cover_unsafe_shapes_modes_and_invoking_owner() {
+        let (_workspace, root) = setup();
+        let profile = root.path().join("alice");
+        fs::create_dir(&profile).unwrap();
+
+        let missing = inspect_profile(&profile);
+        assert_eq!(missing.auth_shape, "missing");
+
+        let auth = profile.join(AUTH_FILE);
+        fs::write(&auth, "").unwrap();
+        assert_eq!(inspect_profile(&profile).auth_shape, "empty");
+        fs::remove_file(&auth).unwrap();
+        fs::create_dir(&auth).unwrap();
+        assert_eq!(inspect_profile(&profile).auth_shape, "non_regular");
+        fs::remove_dir(&auth).unwrap();
+        fs::write(&auth, "recognizable-fake-secret").unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{MetadataExt, PermissionsExt};
+            fs::set_permissions(&profile, fs::Permissions::from_mode(0o755)).unwrap();
+            fs::set_permissions(&auth, fs::Permissions::from_mode(0o644)).unwrap();
+            let unsafe_modes = inspect_profile(&profile);
+            assert!(!unsafe_modes.directory_mode_valid);
+            assert!(!unsafe_modes.auth_mode_valid);
+
+            fs::set_permissions(&profile, fs::Permissions::from_mode(0o700)).unwrap();
+            fs::set_permissions(&auth, fs::Permissions::from_mode(0o600)).unwrap();
+            let actual_uid = fs::metadata(&profile).unwrap().uid();
+            assert!(!inspect_profile_for_uid(&profile, actual_uid.saturating_add(1)).owner_valid);
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn import_rejects_symlink_and_never_echoes_secret_in_errors() {
+        let (workspace, root) = setup();
+        let source_dir = tempfile::tempdir().unwrap();
+        let source = source_dir.path().join("auth.json");
+        fs::write(&source, "recognizable-fake-secret").unwrap();
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", root.path());
+        let service = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
+        #[cfg(unix)]
+        {
+            let link = source_dir.path().join("auth-link.json");
+            std::os::unix::fs::symlink(&source, &link).unwrap();
+            let error = service.import("alice", &link).unwrap_err().to_string();
+            assert!(error.contains("regular file"));
+            assert!(!error.contains("recognizable-fake-secret"));
+        }
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn registry_failure_rolls_quarantine_and_purge_back_to_live_profile() {
+        let (workspace, root) = setup();
+        let source_dir = tempfile::tempdir().unwrap();
+        let source = source_dir.path().join("auth.json");
+        fs::write(&source, "recognizable-fake-secret").unwrap();
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", root.path());
+        let service = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
+
+        for (name, purge) in [("retire", false), ("purge", true)] {
+            service.import(name, &source).unwrap();
+            let lock = per_repo_accounts_file(workspace.path()).with_extension("json.lock");
+            fs::create_dir(&lock).unwrap();
+            let error = service.remove(name, purge).unwrap_err().to_string();
+            fs::remove_dir(&lock).unwrap();
+            assert!(error.contains("registry"));
+            assert!(root.path().join(name).join(AUTH_FILE).exists());
+            assert!(service.find(name).is_ok());
+            assert!(!error.contains("recognizable-fake-secret"));
+        }
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn quarantine_setup_failure_leaves_live_profile_and_registry_unchanged() {
+        let (workspace, root) = setup();
+        let source = root.path().join("source");
+        fs::write(&source, "recognizable-fake-secret").unwrap();
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", root.path());
+        let service = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
+        service.import("alice", &source).unwrap();
+        fs::write(root.path().join(".quarantine"), "not a directory").unwrap();
+
+        let error = service.remove("alice", false).unwrap_err().to_string();
+        assert!(root.path().join("alice").join(AUTH_FILE).exists());
+        assert!(service.find("alice").is_ok());
+        assert!(!error.contains("recognizable-fake-secret"));
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn status_maps_missing_timeout_nonzero_and_not_logged_in_without_output_leaks() {
+        let cases = [
+            (
+                RunnerOutput {
+                    success: false,
+                    unavailable: true,
+                    timed_out: false,
+                    exit_code: None,
+                    summary: "Codex CLI is not installed or not on PATH".into(),
+                },
+                LoginState::CliMissing,
+            ),
+            (
+                RunnerOutput {
+                    success: false,
+                    unavailable: false,
+                    timed_out: true,
+                    exit_code: None,
+                    summary: "Codex login status timed out".into(),
+                },
+                LoginState::TimedOut,
+            ),
+            (
+                RunnerOutput {
+                    success: false,
+                    unavailable: false,
+                    timed_out: false,
+                    exit_code: Some(9),
+                    summary: "Codex login status failed".into(),
+                },
+                LoginState::Failed,
+            ),
+            (
+                RunnerOutput {
+                    success: false,
+                    unavailable: false,
+                    timed_out: false,
+                    exit_code: Some(1),
+                    summary: "not logged in".into(),
+                },
+                LoginState::NotLoggedIn,
+            ),
+        ];
+        for (index, (output, expected)) in cases.into_iter().enumerate() {
+            let (workspace, root) = setup();
+            let source = root.path().join(format!("source-{index}"));
+            fs::write(&source, "recognizable-fake-secret").unwrap();
+            std::env::set_var("LOOM_CODEX_PROFILE_ROOT", root.path());
+            let importer = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
+            importer.import("alice", &source).unwrap();
+            let service = AccountLifecycle::new(workspace.path(), StatusRunner(output)).unwrap();
+            let status = service.status("alice").unwrap();
+            assert_eq!(status.login_state, expected);
+            assert!(!serde_json::to_string(&status)
+                .unwrap()
+                .contains("recognizable-fake-secret"));
         }
         std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
     }

--- a/loom-daemon/src/tokens_pool/account_lifecycle.rs
+++ b/loom-daemon/src/tokens_pool/account_lifecycle.rs
@@ -397,8 +397,24 @@ impl<R: CodexCommandRunner> AccountLifecycle<R> {
             }
             metadata_result.context("failed to prepare recovery metadata")?;
         }
-        fs::rename(&account.credential_reference, &destination)
-            .context("failed to quarantine profile atomically")?;
+        if let Err(error) = fs::rename(&account.credential_reference, &destination) {
+            // A failed rename leaves the live profile in place, but this
+            // invocation already staged `recovery.json` inside it. Remove only
+            // the metadata this call created so the profile is byte-identical
+            // to its pre-command state and a later recoverable removal is not
+            // blocked by stale metadata at `create_new`. The rename error is
+            // the actionable one, so metadata cleanup is best effort and only
+            // annotates the error when residue actually survives.
+            let metadata_left_behind =
+                !purge && fs::remove_file(&recovery_file).is_err() && recovery_file.exists();
+            let result: Result<RemovalOutcome> =
+                Err(error).context("failed to quarantine profile atomically");
+            return if metadata_left_behind {
+                result.context("recovery metadata rollback also failed")
+            } else {
+                result
+            };
+        }
         if let Err(error) = unregister_codex_account(&self.workspace, name) {
             fs::rename(&destination, &account.credential_reference)
                 .context("account registry update failed and profile rollback also failed")?;
@@ -961,6 +977,60 @@ mod tests {
         assert_eq!(fs::read_to_string(recovery).unwrap(), "recognizable-existing-metadata");
         assert!(!error.contains("recognizable-fake-secret"));
         assert!(!error.contains("recognizable-existing-metadata"));
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(unix)]
+    fn quarantine_rename_failure_rolls_back_staged_recovery_metadata() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Permission-based rename injection is meaningless as root.
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+
+        let (workspace, root) = setup();
+        let source_dir = tempfile::tempdir().unwrap();
+        let source = source_dir.path().join("auth.json");
+        fs::write(&source, "recognizable-fake-secret").unwrap();
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", root.path());
+        let service = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
+        service.import("alice", &source).unwrap();
+
+        // Pre-create `.quarantine` so lifecycle setup succeeds, then make the
+        // profile root non-writable. Staging `recovery.json` inside the live
+        // profile still succeeds, but unlinking `alice` from the root during
+        // `fs::rename` fails with EACCES.
+        fs::create_dir(root.path().join(".quarantine")).unwrap();
+        fs::set_permissions(root.path(), fs::Permissions::from_mode(0o500)).unwrap();
+        let error = service.remove("alice", false).unwrap_err().to_string();
+        fs::set_permissions(root.path(), fs::Permissions::from_mode(0o700)).unwrap();
+
+        assert!(error.contains("quarantine"));
+        // The staged metadata this invocation created must not survive.
+        assert!(!root.path().join("alice/recovery.json").exists());
+        assert!(!error.contains("recovery metadata rollback also failed"));
+        // Profile, credential bytes, and registry are all untouched.
+        assert!(root.path().join("alice").join(AUTH_FILE).is_file());
+        assert_eq!(
+            fs::read_to_string(root.path().join("alice").join(AUTH_FILE)).unwrap(),
+            "recognizable-fake-secret"
+        );
+        assert!(service.find("alice").is_ok());
+        assert!(!error.contains("recognizable-fake-secret"));
+        assert!(fs::read_dir(root.path().join(".quarantine"))
+            .unwrap()
+            .next()
+            .is_none());
+
+        // A later recoverable removal is not blocked by stale metadata.
+        let removed = service.remove("alice", false).unwrap();
+        assert!(!removed.purged);
+        assert!(removed.recovery_reference.is_some());
+        assert!(!root.path().join("alice").exists());
+        assert!(service.find("alice").is_err());
         std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
     }
 

--- a/loom-daemon/src/tokens_pool/account_lifecycle.rs
+++ b/loom-daemon/src/tokens_pool/account_lifecycle.rs
@@ -1,0 +1,734 @@
+//! Secret-safe lifecycle management for machine-level Codex profiles.
+//!
+//! Codex owns `auth.json`; Loom treats it as opaque mutable state and never
+//! reads, parses, serializes, or logs its contents.
+
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::Serialize;
+
+use super::account_registry::{
+    account_inventory, register_codex_account, set_codex_account_enabled, unregister_codex_account,
+    validate_name, AccountDescriptor, AccountProvider, CredentialKind, InventoryProvenance,
+};
+use super::paths::codex_profile_root;
+
+const AUTH_FILE: &str = "auth.json";
+const STATUS_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_STATUS_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoginState {
+    LoggedIn,
+    NotLoggedIn,
+    CliMissing,
+    TimedOut,
+    Failed,
+    NotChecked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProfileDiagnostics {
+    pub profile_exists: bool,
+    pub auth_shape: &'static str,
+    pub directory_mode_valid: bool,
+    pub auth_mode_valid: bool,
+    pub owner_valid: bool,
+}
+
+impl ProfileDiagnostics {
+    #[must_use]
+    pub fn valid(&self) -> bool {
+        self.profile_exists
+            && self.auth_shape == "valid"
+            && self.directory_mode_valid
+            && self.auth_mode_valid
+            && self.owner_valid
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AccountStatus {
+    pub schema_version: u32,
+    pub provider: AccountProvider,
+    pub name: String,
+    pub enabled: bool,
+    pub credential_kind: CredentialKind,
+    pub provenance: InventoryProvenance,
+    pub diagnostics: ProfileDiagnostics,
+    pub login_state: LoginState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RemovalOutcome {
+    pub provider: AccountProvider,
+    pub name: String,
+    pub purged: bool,
+    pub recovery_reference: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerOutput {
+    pub success: bool,
+    pub unavailable: bool,
+    pub timed_out: bool,
+    pub summary: String,
+}
+
+pub trait CodexCommandRunner {
+    fn login(&self, profile: &Path, device_auth: bool) -> Result<RunnerOutput>;
+    fn login_status(&self, profile: &Path) -> Result<RunnerOutput>;
+}
+
+pub struct ProcessCodexRunner;
+
+impl ProcessCodexRunner {
+    fn bounded_status(profile: &Path) -> Result<RunnerOutput> {
+        let mut child = match Command::new("codex")
+            .args(["login", "status"])
+            .env("CODEX_HOME", profile)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(RunnerOutput {
+                    success: false,
+                    unavailable: true,
+                    timed_out: false,
+                    summary: "Codex CLI is not installed or not on PATH".into(),
+                });
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let started = Instant::now();
+        loop {
+            if let Some(status) = child.try_wait()? {
+                let mut bytes = Vec::new();
+                if let Some(stdout) = child.stdout.take() {
+                    stdout
+                        .take(MAX_STATUS_BYTES as u64)
+                        .read_to_end(&mut bytes)?;
+                }
+                if bytes.is_empty() {
+                    if let Some(stderr) = child.stderr.take() {
+                        stderr
+                            .take(MAX_STATUS_BYTES as u64)
+                            .read_to_end(&mut bytes)?;
+                    }
+                }
+                let text = String::from_utf8_lossy(&bytes).to_ascii_lowercase();
+                let summary = if status.success() && text.contains("logged in") {
+                    "logged in"
+                } else if text.contains("not logged in") {
+                    "not logged in"
+                } else {
+                    "Codex login status failed"
+                };
+                return Ok(RunnerOutput {
+                    success: status.success(),
+                    unavailable: false,
+                    timed_out: false,
+                    summary: summary.into(),
+                });
+            }
+            if started.elapsed() >= STATUS_TIMEOUT {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Ok(RunnerOutput {
+                    success: false,
+                    unavailable: false,
+                    timed_out: true,
+                    summary: "Codex login status timed out".into(),
+                });
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    }
+}
+
+impl CodexCommandRunner for ProcessCodexRunner {
+    fn login(&self, profile: &Path, device_auth: bool) -> Result<RunnerOutput> {
+        let mut command = Command::new("codex");
+        command.arg("login").env("CODEX_HOME", profile);
+        if device_auth {
+            command.arg("--device-auth");
+        }
+        let status = match command.status() {
+            Ok(status) => status,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(RunnerOutput {
+                    success: false,
+                    unavailable: true,
+                    timed_out: false,
+                    summary: "Codex CLI is not installed or not on PATH".into(),
+                });
+            }
+            Err(error) => return Err(error.into()),
+        };
+        Ok(RunnerOutput {
+            success: status.success(),
+            unavailable: false,
+            timed_out: false,
+            summary: if status.success() {
+                "login completed"
+            } else {
+                "Codex login failed or was cancelled"
+            }
+            .into(),
+        })
+    }
+
+    fn login_status(&self, profile: &Path) -> Result<RunnerOutput> {
+        Self::bounded_status(profile)
+    }
+}
+
+pub struct AccountLifecycle<R> {
+    workspace: PathBuf,
+    root: PathBuf,
+    runner: R,
+}
+
+impl<R: CodexCommandRunner> AccountLifecycle<R> {
+    pub fn new(workspace: impl Into<PathBuf>, runner: R) -> Result<Self> {
+        let workspace = workspace.into();
+        let root = codex_profile_root()
+            .ok_or_else(|| anyhow!("Codex profiles are disabled by LOOM_CODEX_PROFILE_ROOT"))?;
+        reject_repository_local_root(&workspace, &root)?;
+        ensure_private_dir(&root)?;
+        Ok(Self {
+            workspace,
+            root,
+            runner,
+        })
+    }
+
+    pub fn add(&self, name: &str, device_auth: bool) -> Result<AccountStatus> {
+        validate_name(name)?;
+        self.ensure_absent(name)?;
+        let profile = self.profile(name)?;
+        ensure_private_dir(&profile)?;
+        let result = self.runner.login(&profile, device_auth)?;
+        if !result.success {
+            if fs::read_dir(&profile)?.next().is_none() {
+                let _ = fs::remove_dir(&profile);
+            }
+            bail!("{}", result.summary);
+        }
+        tighten_profile_permissions(&profile)?;
+        let diagnostics = inspect_profile(&profile);
+        if !diagnostics.valid() {
+            bail!("Codex login completed but the profile credential is missing or unsafe");
+        }
+        register_codex_account(&self.workspace, name, name, true)?;
+        self.status(name)
+    }
+
+    pub fn import(&self, name: &str, source: &Path) -> Result<AccountStatus> {
+        validate_name(name)?;
+        self.ensure_absent(name)?;
+        let source_meta = fs::symlink_metadata(source)
+            .context("authentication source is missing or unreadable")?;
+        if !source_meta.file_type().is_file() || source_meta.len() == 0 {
+            bail!("authentication source must be a non-empty regular file");
+        }
+        let source = source
+            .canonicalize()
+            .context("authentication source cannot be resolved")?;
+        let profile = self.profile(name)?;
+        let destination = profile.join(AUTH_FILE);
+        if source == destination {
+            bail!("authentication source and destination must differ");
+        }
+        ensure_private_dir(&profile)?;
+        let staged = profile.join(format!(".auth.json.tmp-{}", std::process::id()));
+        let result = (|| -> Result<()> {
+            let mut input = OpenOptions::new()
+                .read(true)
+                .open(&source)
+                .context("authentication source is unreadable")?;
+            let mut output = private_file(&staged)?;
+            std::io::copy(&mut input, &mut output).context("authentication import failed")?;
+            output
+                .sync_all()
+                .context("authentication import sync failed")?;
+            fs::rename(&staged, &destination).context("authentication import commit failed")?;
+            Ok(())
+        })();
+        if result.is_err() {
+            let _ = fs::remove_file(&staged);
+            let _ = fs::remove_dir(&profile);
+        }
+        result?;
+        register_codex_account(&self.workspace, name, name, true)?;
+        self.status_without_probe(name)
+    }
+
+    pub fn list(&self, probe: bool) -> Result<Vec<AccountStatus>> {
+        account_inventory(&self.workspace, AccountProvider::Codex)?
+            .into_iter()
+            .map(|account| self.status_for(account, probe))
+            .collect()
+    }
+
+    pub fn status(&self, name: &str) -> Result<AccountStatus> {
+        let account = self.find(name)?;
+        self.status_for(account, true)
+    }
+
+    pub fn status_without_probe(&self, name: &str) -> Result<AccountStatus> {
+        let account = self.find(name)?;
+        self.status_for(account, false)
+    }
+
+    pub fn disable(&self, name: &str) -> Result<AccountStatus> {
+        self.find(name)?;
+        set_codex_account_enabled(&self.workspace, name, false)?;
+        self.status_without_probe(name)
+    }
+
+    pub fn enable(&self, name: &str) -> Result<AccountStatus> {
+        let account = self.find(name)?;
+        let diagnostics = inspect_profile(&account.credential_reference);
+        if !diagnostics.valid() {
+            bail!("profile must pass credential shape and permission validation before enabling");
+        }
+        set_codex_account_enabled(&self.workspace, name, true)?;
+        self.status_without_probe(name)
+    }
+
+    pub fn reauth(&self, name: &str, device_auth: bool) -> Result<AccountStatus> {
+        let account = self.find(name)?;
+        let enabled = account.enabled;
+        let result = self
+            .runner
+            .login(&account.credential_reference, device_auth)?;
+        if !result.success {
+            bail!("{}", result.summary);
+        }
+        tighten_profile_permissions(&account.credential_reference)?;
+        let status = self.status(name)?;
+        if status.enabled != enabled {
+            bail!("account enabled state changed unexpectedly during reauthentication");
+        }
+        Ok(status)
+    }
+
+    pub fn remove(&self, name: &str, purge: bool) -> Result<RemovalOutcome> {
+        let account = self.find(name)?;
+        if purge {
+            fs::remove_dir_all(&account.credential_reference)
+                .context("failed to purge Codex profile")?;
+            unregister_codex_account(&self.workspace, name)?;
+            return Ok(RemovalOutcome {
+                provider: AccountProvider::Codex,
+                name: name.into(),
+                purged: true,
+                recovery_reference: None,
+            });
+        }
+        let quarantine = self.root.join(".quarantine");
+        ensure_private_dir(&quarantine)?;
+        let stamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+        let recovery_reference = format!("{name}-{stamp}");
+        validate_name(&recovery_reference)?;
+        let destination = quarantine.join(&recovery_reference);
+        fs::rename(&account.credential_reference, &destination)
+            .context("failed to quarantine profile atomically")?;
+        if let Err(error) = unregister_codex_account(&self.workspace, name) {
+            let _ = fs::rename(&destination, &account.credential_reference);
+            return Err(error);
+        }
+        let metadata = serde_json::json!({
+            "version": 1,
+            "provider": "codex",
+            "name": name,
+            "retired_at_unix": stamp,
+            "original_reference": name,
+        });
+        let mut file = private_file(&destination.join("recovery.json"))?;
+        serde_json::to_writer_pretty(&mut file, &metadata)?;
+        file.write_all(b"\n")?;
+        Ok(RemovalOutcome {
+            provider: AccountProvider::Codex,
+            name: name.into(),
+            purged: false,
+            recovery_reference: Some(recovery_reference),
+        })
+    }
+
+    fn status_for(&self, account: AccountDescriptor, probe: bool) -> Result<AccountStatus> {
+        let diagnostics = inspect_profile(&account.credential_reference);
+        let login_state = if !probe || !diagnostics.valid() {
+            LoginState::NotChecked
+        } else {
+            let output = self.runner.login_status(&account.credential_reference)?;
+            if output.unavailable {
+                LoginState::CliMissing
+            } else if output.timed_out {
+                LoginState::TimedOut
+            } else if output.success && output.summary == "logged in" {
+                LoginState::LoggedIn
+            } else if output.summary == "not logged in" {
+                LoginState::NotLoggedIn
+            } else {
+                LoginState::Failed
+            }
+        };
+        Ok(AccountStatus {
+            schema_version: 1,
+            provider: account.id.provider,
+            name: account.id.name,
+            enabled: account.enabled,
+            credential_kind: account.credential_kind,
+            provenance: account.provenance,
+            diagnostics,
+            login_state,
+        })
+    }
+
+    fn find(&self, name: &str) -> Result<AccountDescriptor> {
+        validate_name(name)?;
+        account_inventory(&self.workspace, AccountProvider::Codex)?
+            .into_iter()
+            .find(|account| account.id.name == name)
+            .ok_or_else(|| anyhow!("Codex account {name:?} does not exist"))
+    }
+
+    fn ensure_absent(&self, name: &str) -> Result<()> {
+        if account_inventory(&self.workspace, AccountProvider::Codex)?
+            .iter()
+            .any(|account| account.id.name == name)
+            || self.profile(name)?.exists()
+        {
+            bail!("Codex account {name:?} already exists");
+        }
+        Ok(())
+    }
+
+    fn profile(&self, name: &str) -> Result<PathBuf> {
+        validate_name(name)?;
+        Ok(self.root.join(name))
+    }
+}
+
+fn reject_repository_local_root(workspace: &Path, root: &Path) -> Result<()> {
+    let workspace = workspace
+        .canonicalize()
+        .context("workspace cannot be resolved")?;
+    let absolute_root = if root.is_absolute() {
+        root.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(root)
+    };
+    let canonical_intent = absolute_root
+        .ancestors()
+        .find(|candidate| candidate.exists())
+        .and_then(|existing| existing.canonicalize().ok().map(|base| (existing, base)))
+        .map(|(existing, base)| {
+            absolute_root
+                .strip_prefix(existing)
+                .map_or(base.clone(), |suffix| base.join(suffix))
+        })
+        .unwrap_or(absolute_root);
+    if canonical_intent.starts_with(&workspace) {
+        bail!("Codex profile root must not be repository-local");
+    }
+    Ok(())
+}
+
+fn ensure_private_dir(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(path)?;
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    }
+    #[cfg(not(unix))]
+    fs::create_dir_all(path)?;
+    Ok(())
+}
+
+fn private_file(path: &Path) -> Result<fs::File> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    Ok(options.open(path)?)
+}
+
+fn tighten_profile_permissions(profile: &Path) -> Result<()> {
+    ensure_private_dir(profile)?;
+    let auth = profile.join(AUTH_FILE);
+    if !auth.is_file() {
+        bail!("Codex login did not create a regular auth.json");
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&auth, fs::Permissions::from_mode(0o600))
+            .context("failed to secure Codex auth file permissions")?;
+    }
+    Ok(())
+}
+
+fn inspect_profile(profile: &Path) -> ProfileDiagnostics {
+    let profile_meta = fs::symlink_metadata(profile).ok();
+    let auth_meta = fs::symlink_metadata(profile.join(AUTH_FILE)).ok();
+    let auth_shape = match &auth_meta {
+        None => "missing",
+        Some(meta) if !meta.file_type().is_file() => "non_regular",
+        Some(meta) if meta.len() == 0 => "empty",
+        Some(_)
+            if OpenOptions::new()
+                .read(true)
+                .open(profile.join(AUTH_FILE))
+                .is_err() =>
+        {
+            "unreadable"
+        }
+        Some(_) => "valid",
+    };
+    #[cfg(unix)]
+    let (directory_mode_valid, auth_mode_valid, owner_valid) = {
+        use std::os::unix::fs::MetadataExt;
+        let directory_mode_valid = profile_meta
+            .as_ref()
+            .is_some_and(|meta| meta.is_dir() && meta.mode() & 0o077 == 0);
+        let auth_mode_valid = auth_meta
+            .as_ref()
+            .is_some_and(|meta| meta.mode() & 0o077 == 0);
+        let owner_valid = match (&profile_meta, &auth_meta) {
+            (Some(directory), Some(auth)) => directory.uid() == auth.uid(),
+            _ => false,
+        };
+        (directory_mode_valid, auth_mode_valid, owner_valid)
+    };
+    #[cfg(not(unix))]
+    let (directory_mode_valid, auth_mode_valid, owner_valid) = (true, true, true);
+    ProfileDiagnostics {
+        profile_exists: profile_meta.is_some_and(|meta| meta.is_dir()),
+        auth_shape,
+        directory_mode_valid,
+        auth_mode_valid,
+        owner_valid,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct FakeRunner {
+        calls: Mutex<Vec<(PathBuf, Vec<String>)>>,
+        fail_login: bool,
+    }
+
+    impl CodexCommandRunner for FakeRunner {
+        fn login(&self, profile: &Path, device_auth: bool) -> Result<RunnerOutput> {
+            let mut args = vec!["login".to_string()];
+            if device_auth {
+                args.push("--device-auth".into());
+            }
+            self.calls.lock().unwrap().push((profile.into(), args));
+            if !self.fail_login {
+                let mut options = OpenOptions::new();
+                options.write(true).create(true).truncate(true);
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::OpenOptionsExt;
+                    options.mode(0o600);
+                }
+                let mut file = options.open(profile.join(AUTH_FILE))?;
+                file.write_all(b"recognizable-fake-secret")?;
+            }
+            Ok(RunnerOutput {
+                success: !self.fail_login,
+                unavailable: false,
+                timed_out: false,
+                summary: if self.fail_login {
+                    "cancelled"
+                } else {
+                    "login completed"
+                }
+                .into(),
+            })
+        }
+
+        fn login_status(&self, profile: &Path) -> Result<RunnerOutput> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((profile.into(), vec!["login".into(), "status".into()]));
+            Ok(RunnerOutput {
+                success: true,
+                unavailable: false,
+                timed_out: false,
+                summary: "logged in".into(),
+            })
+        }
+    }
+
+    fn setup() -> (tempfile::TempDir, tempfile::TempDir) {
+        (tempfile::tempdir().unwrap(), tempfile::tempdir().unwrap())
+    }
+
+    #[test]
+    #[serial]
+    fn add_two_profiles_device_auth_and_reauth_keep_canonical_identity() {
+        let (workspace, root) = setup();
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", root.path());
+        let service = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
+        service.add("alice", true).unwrap();
+        service.add("bob", false).unwrap();
+        service.disable("alice").unwrap();
+        let reauthed = service.reauth("alice", true).unwrap();
+        assert!(!reauthed.enabled);
+        assert_eq!(service.list(false).unwrap().len(), 2);
+        let calls = service.runner.calls.lock().unwrap();
+        assert_eq!(calls[0].0.file_name().unwrap(), "alice");
+        assert_eq!(calls[0].1, ["login", "--device-auth"]);
+        assert_eq!(calls[2].0.file_name().unwrap(), "bob");
+        assert_eq!(calls[4].0.file_name().unwrap(), "alice");
+        assert!(!format!("{:?}", &*calls).contains("recognizable-fake-secret"));
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn import_is_private_atomic_and_secret_free() {
+        let (workspace, root) = setup();
+        let source_dir = tempfile::tempdir().unwrap();
+        let source = source_dir.path().join("auth.json");
+        fs::write(&source, "recognizable-fake-secret").unwrap();
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", root.path());
+        let service = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
+        let status = service.import("alice", &source).unwrap();
+        assert!(status.diagnostics.valid());
+        let encoded = serde_json::to_string(&status).unwrap();
+        assert!(!encoded.contains("recognizable-fake-secret"));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(root.path().join("alice"))
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
+            assert_eq!(
+                fs::metadata(root.path().join("alice/auth.json"))
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+        assert!(service
+            .import("alice", &source)
+            .unwrap_err()
+            .to_string()
+            .contains("exists"));
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn failed_add_leaves_no_account_or_empty_profile() {
+        let (workspace, root) = setup();
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", root.path());
+        let service = AccountLifecycle::new(
+            workspace.path(),
+            FakeRunner {
+                fail_login: true,
+                ..FakeRunner::default()
+            },
+        )
+        .unwrap();
+        assert!(service.add("alice", false).is_err());
+        assert!(!root.path().join("alice").exists());
+        assert!(service.list(false).unwrap().is_empty());
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn enable_requires_safe_shape_and_disable_is_non_destructive() {
+        let (workspace, root) = setup();
+        let source_dir = tempfile::tempdir().unwrap();
+        let source = source_dir.path().join("auth.json");
+        fs::write(&source, "recognizable-fake-secret").unwrap();
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", root.path());
+        let service = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
+        service.import("alice", &source).unwrap();
+        service.disable("alice").unwrap();
+        assert_eq!(
+            fs::read_to_string(root.path().join("alice/auth.json")).unwrap(),
+            "recognizable-fake-secret"
+        );
+        fs::remove_file(root.path().join("alice/auth.json")).unwrap();
+        assert!(service.enable("alice").is_err());
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn remove_quarantines_without_secret_metadata_and_purge_is_explicit() {
+        let (workspace, root) = setup();
+        let source_dir = tempfile::tempdir().unwrap();
+        let source = source_dir.path().join("auth.json");
+        fs::write(&source, "recognizable-fake-secret").unwrap();
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", root.path());
+        let service = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
+        service.import("alice", &source).unwrap();
+        let removed = service.remove("alice", false).unwrap();
+        let recovery = root
+            .path()
+            .join(".quarantine")
+            .join(removed.recovery_reference.unwrap());
+        let metadata = fs::read_to_string(recovery.join("recovery.json")).unwrap();
+        assert!(!metadata.contains("recognizable-fake-secret"));
+        assert!(recovery.join("auth.json").exists());
+        service.import("bob", &source).unwrap();
+        assert!(service.remove("bob", true).unwrap().purged);
+        assert!(!root.path().join("bob").exists());
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn rejects_names_and_repository_local_root() {
+        let (workspace, _) = setup();
+        let local_root = workspace.path().join(".loom/codex-profiles");
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", &local_root);
+        assert!(AccountLifecycle::new(workspace.path(), FakeRunner::default()).is_err());
+        let external = tempfile::tempdir().unwrap();
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", external.path());
+        let service = AccountLifecycle::new(workspace.path(), FakeRunner::default()).unwrap();
+        for name in ["../escape", "/absolute", "a/b", r"a\b"] {
+            assert!(service.add(name, false).is_err());
+        }
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+}

--- a/loom-daemon/src/tokens_pool/account_registry.rs
+++ b/loom-daemon/src/tokens_pool/account_registry.rs
@@ -182,6 +182,40 @@ fn lock_registry(workspace: &Path) -> Result<MkdirLock> {
     MkdirLock::acquire(&path).map_err(|error| anyhow!("failed to lock account registry: {error}"))
 }
 
+/// Pre-registry Codex profiles discovered on disk, expressed as registry
+/// entries. The first mutation of an existing account (`disable`, `enable`,
+/// `remove`) adopts the whole discovered set so `accounts list` keeps showing
+/// manually provisioned profiles once `.loom/accounts.json` exists, and those
+/// mutations work on exactly the accounts `list` shows.
+fn adopted_codex_entries() -> Result<Vec<RegistryEntry>> {
+    let Some(root) = codex_profile_root() else {
+        return Ok(Vec::new());
+    };
+    Ok(discovered_codex_profiles(&root)?
+        .into_iter()
+        .map(|(name, _)| RegistryEntry {
+            provider: AccountProvider::Codex,
+            name: name.clone(),
+            credential_kind: CredentialKind::CodexHome,
+            credential_reference: name,
+            enabled: true,
+        })
+        .collect())
+}
+
+/// Registry entries when the registry file exists, otherwise the discovered
+/// pre-registry inventory. Callers must hold the registry lock.
+fn registry_entries_or_adopted(workspace: &Path) -> Result<Option<Vec<RegistryEntry>>> {
+    if let Some(entries) = read_repo_registry(workspace)? {
+        return Ok(Some(entries));
+    }
+    let adopted = adopted_codex_entries()?;
+    if adopted.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(adopted))
+}
+
 pub(crate) fn register_codex_account(
     workspace: &Path,
     name: &str,
@@ -191,11 +225,26 @@ pub(crate) fn register_codex_account(
     validate_name(name)?;
     validate_name(credential_reference)?;
     let _lock = lock_registry(workspace)?;
+    // Deliberately no pre-registry adoption here: the caller may be creating
+    // the very first profile under the root, and adoption would rediscover the
+    // directory the caller itself just claimed.
     let mut entries = read_repo_registry(workspace)?.unwrap_or_default();
-    if entries
+    if let Some(existing) = entries
         .iter()
-        .any(|entry| entry.provider == AccountProvider::Codex && entry.name == name)
+        .find(|entry| entry.provider == AccountProvider::Codex && entry.name == name)
     {
+        // Idempotent for a byte-identical entry: if a concurrent
+        // `disable`/`enable`/`remove` adopted this caller's in-flight profile
+        // between directory claim and registration, the adopted entry is
+        // exactly the one this call would write, so it must not be treated as
+        // a conflict (and above all must not push the caller into a rollback
+        // that deletes a directory the registry now references).
+        if existing.credential_kind == CredentialKind::CodexHome
+            && existing.credential_reference == credential_reference
+            && existing.enabled == enabled
+        {
+            return Ok(());
+        }
         bail!("Codex account {name:?} already exists");
     }
     entries.push(RegistryEntry {
@@ -211,7 +260,7 @@ pub(crate) fn register_codex_account(
 pub(crate) fn set_codex_account_enabled(workspace: &Path, name: &str, enabled: bool) -> Result<()> {
     validate_name(name)?;
     let _lock = lock_registry(workspace)?;
-    let mut entries = read_repo_registry(workspace)?
+    let mut entries = registry_entries_or_adopted(workspace)?
         .ok_or_else(|| anyhow!("Codex account {name:?} does not exist"))?;
     let entry = entries
         .iter_mut()
@@ -221,17 +270,30 @@ pub(crate) fn set_codex_account_enabled(workspace: &Path, name: &str, enabled: b
     write_repo_registry(workspace, entries)
 }
 
-pub(crate) fn unregister_codex_account(workspace: &Path, name: &str) -> Result<()> {
+/// Secret-free identity of the entry a successful [`unregister_codex_account`]
+/// removed, so callers can restore it verbatim if a later filesystem step of
+/// their transaction fails.
+#[derive(Debug, Clone)]
+pub(crate) struct RemovedCodexEntry {
+    pub(crate) credential_reference: String,
+    pub(crate) enabled: bool,
+}
+
+pub(crate) fn unregister_codex_account(workspace: &Path, name: &str) -> Result<RemovedCodexEntry> {
     validate_name(name)?;
     let _lock = lock_registry(workspace)?;
-    let mut entries = read_repo_registry(workspace)?
+    let mut entries = registry_entries_or_adopted(workspace)?
         .ok_or_else(|| anyhow!("Codex account {name:?} does not exist"))?;
-    let before = entries.len();
-    entries.retain(|entry| !(entry.provider == AccountProvider::Codex && entry.name == name));
-    if entries.len() == before {
-        bail!("Codex account {name:?} does not exist");
-    }
-    write_repo_registry(workspace, entries)
+    let position = entries
+        .iter()
+        .position(|entry| entry.provider == AccountProvider::Codex && entry.name == name)
+        .ok_or_else(|| anyhow!("Codex account {name:?} does not exist"))?;
+    let removed = entries.remove(position);
+    write_repo_registry(workspace, entries)?;
+    Ok(RemovedCodexEntry {
+        credential_reference: removed.credential_reference,
+        enabled: removed.enabled,
+    })
 }
 
 fn validate_codex_directory(root: &Path, reference: &str) -> Result<PathBuf> {
@@ -314,6 +376,28 @@ fn claude_inventory(workspace: &Path) -> Result<Vec<AccountDescriptor>> {
     Ok(out)
 }
 
+/// Codex profile directories discovered directly under `root`, with their
+/// canonical paths. Hidden names are skipped so machine-private state such as
+/// `.quarantine` is never surfaced as an account.
+fn discovered_codex_profiles(root: &Path) -> Result<Vec<(String, PathBuf)>> {
+    let Ok(canonical_root) = root.canonicalize() else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(root)?.filter_map(std::result::Result::ok) {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.starts_with('.') || validate_name(&name).is_err() {
+            continue;
+        }
+        let Ok(directory) = validate_codex_directory(&canonical_root, &name) else {
+            continue;
+        };
+        out.push((name, directory));
+    }
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(out)
+}
+
 fn codex_inventory(workspace: &Path) -> Result<Vec<AccountDescriptor>> {
     let root = codex_profile_root()
         .ok_or_else(|| anyhow!("Codex profile root is disabled by LOOM_CODEX_PROFILE_ROOT"))?;
@@ -345,18 +429,7 @@ fn codex_inventory(workspace: &Path) -> Result<Vec<AccountDescriptor>> {
             });
         }
     } else {
-        let canonical_root = match root.canonicalize() {
-            Ok(path) => path,
-            Err(_) => return Ok(out),
-        };
-        for entry in std::fs::read_dir(&root)?.filter_map(std::result::Result::ok) {
-            let name = entry.file_name().to_string_lossy().into_owned();
-            if validate_name(&name).is_err() {
-                continue;
-            }
-            let Ok(directory) = validate_codex_directory(&canonical_root, &name) else {
-                continue;
-            };
+        for (name, directory) in discovered_codex_profiles(&root)? {
             out.push(AccountDescriptor {
                 id: AccountId {
                     provider: AccountProvider::Codex,
@@ -498,6 +571,8 @@ mod tests {
         let profiles = tempfile::tempdir().unwrap();
         fs::create_dir(profiles.path().join("alice")).unwrap();
         fs::create_dir(profiles.path().join("bob")).unwrap();
+        // Machine-private state below the root must never surface as accounts.
+        fs::create_dir(profiles.path().join(".quarantine")).unwrap();
         std::env::set_var("LOOM_CODEX_PROFILE_ROOT", profiles.path());
         assert_eq!(account_capacity(workspace.path(), AccountProvider::Codex).unwrap(), 2);
         std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
@@ -557,8 +632,11 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn concurrent_registry_updates_do_not_lose_accounts() {
         let workspace = tempfile::tempdir().unwrap();
+        let profiles = tempfile::tempdir().unwrap();
+        std::env::set_var("LOOM_CODEX_PROFILE_ROOT", profiles.path());
         let workspace_path = workspace.path().to_path_buf();
         let start = std::sync::Arc::new(std::sync::Barrier::new(8));
         let handles: Vec<_> = (0..8)
@@ -580,6 +658,7 @@ mod tests {
         assert!(!per_repo_accounts_file(&workspace_path)
             .with_extension("json.lock")
             .exists());
+        std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
     }
 
     #[test]

--- a/loom-daemon/src/tokens_pool/account_registry.rs
+++ b/loom-daemon/src/tokens_pool/account_registry.rs
@@ -110,7 +110,7 @@ impl SelectedAccount {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RegistryFile {
     #[serde(default = "registry_version")]
@@ -122,7 +122,7 @@ const fn registry_version() -> u32 {
     1
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RegistryEntry {
     provider: AccountProvider,
@@ -137,7 +137,7 @@ const fn default_enabled() -> bool {
     true
 }
 
-fn validate_name(name: &str) -> Result<()> {
+pub(crate) fn validate_name(name: &str) -> Result<()> {
     let path = Path::new(name);
     if name.is_empty()
         || path.is_absolute()
@@ -148,6 +148,72 @@ fn validate_name(name: &str) -> Result<()> {
         bail!("invalid account name {name:?}: expected one relative path component");
     }
     Ok(())
+}
+
+fn write_repo_registry(workspace: &Path, entries: Vec<RegistryEntry>) -> Result<()> {
+    let path = per_repo_accounts_file(workspace);
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("account registry has no parent directory"))?;
+    std::fs::create_dir_all(parent).context("failed to create account registry directory")?;
+    let file = RegistryFile {
+        version: registry_version(),
+        accounts: entries,
+    };
+    let bytes = serde_json::to_vec_pretty(&file)?;
+    let temp = parent.join(format!(".accounts.json.tmp-{}", std::process::id()));
+    std::fs::write(&temp, bytes).context("failed to stage account registry update")?;
+    std::fs::rename(&temp, &path).context("failed to commit account registry update")?;
+    Ok(())
+}
+
+pub(crate) fn register_codex_account(
+    workspace: &Path,
+    name: &str,
+    credential_reference: &str,
+    enabled: bool,
+) -> Result<()> {
+    validate_name(name)?;
+    validate_name(credential_reference)?;
+    let mut entries = read_repo_registry(workspace)?.unwrap_or_default();
+    if entries
+        .iter()
+        .any(|entry| entry.provider == AccountProvider::Codex && entry.name == name)
+    {
+        bail!("Codex account {name:?} already exists");
+    }
+    entries.push(RegistryEntry {
+        provider: AccountProvider::Codex,
+        name: name.to_string(),
+        credential_kind: CredentialKind::CodexHome,
+        credential_reference: credential_reference.to_string(),
+        enabled,
+    });
+    write_repo_registry(workspace, entries)
+}
+
+pub(crate) fn set_codex_account_enabled(workspace: &Path, name: &str, enabled: bool) -> Result<()> {
+    validate_name(name)?;
+    let mut entries = read_repo_registry(workspace)?
+        .ok_or_else(|| anyhow!("Codex account {name:?} does not exist"))?;
+    let entry = entries
+        .iter_mut()
+        .find(|entry| entry.provider == AccountProvider::Codex && entry.name == name)
+        .ok_or_else(|| anyhow!("Codex account {name:?} does not exist"))?;
+    entry.enabled = enabled;
+    write_repo_registry(workspace, entries)
+}
+
+pub(crate) fn unregister_codex_account(workspace: &Path, name: &str) -> Result<()> {
+    validate_name(name)?;
+    let mut entries = read_repo_registry(workspace)?
+        .ok_or_else(|| anyhow!("Codex account {name:?} does not exist"))?;
+    let before = entries.len();
+    entries.retain(|entry| !(entry.provider == AccountProvider::Codex && entry.name == name));
+    if entries.len() == before {
+        bail!("Codex account {name:?} does not exist");
+    }
+    write_repo_registry(workspace, entries)
 }
 
 fn validate_codex_directory(root: &Path, reference: &str) -> Result<PathBuf> {

--- a/loom-daemon/src/tokens_pool/account_registry.rs
+++ b/loom-daemon/src/tokens_pool/account_registry.rs
@@ -11,6 +11,7 @@ use std::path::{Component, Path, PathBuf};
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 
+use super::locking::MkdirLock;
 use super::paths::{codex_profile_root, per_repo_accounts_file, resolve_tokens_dir};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -161,10 +162,24 @@ fn write_repo_registry(workspace: &Path, entries: Vec<RegistryEntry>) -> Result<
         accounts: entries,
     };
     let bytes = serde_json::to_vec_pretty(&file)?;
-    let temp = parent.join(format!(".accounts.json.tmp-{}", std::process::id()));
+    let temp =
+        parent.join(format!(".accounts.json.tmp-{}-{}", std::process::id(), uuid::Uuid::new_v4()));
     std::fs::write(&temp, bytes).context("failed to stage account registry update")?;
     std::fs::rename(&temp, &path).context("failed to commit account registry update")?;
     Ok(())
+}
+
+fn registry_lock_path(workspace: &Path) -> PathBuf {
+    per_repo_accounts_file(workspace).with_extension("json.lock")
+}
+
+fn lock_registry(workspace: &Path) -> Result<MkdirLock> {
+    let path = registry_lock_path(workspace);
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("account registry lock has no parent directory"))?;
+    std::fs::create_dir_all(parent).context("failed to create account registry directory")?;
+    MkdirLock::acquire(&path).map_err(|error| anyhow!("failed to lock account registry: {error}"))
 }
 
 pub(crate) fn register_codex_account(
@@ -175,6 +190,7 @@ pub(crate) fn register_codex_account(
 ) -> Result<()> {
     validate_name(name)?;
     validate_name(credential_reference)?;
+    let _lock = lock_registry(workspace)?;
     let mut entries = read_repo_registry(workspace)?.unwrap_or_default();
     if entries
         .iter()
@@ -194,6 +210,7 @@ pub(crate) fn register_codex_account(
 
 pub(crate) fn set_codex_account_enabled(workspace: &Path, name: &str, enabled: bool) -> Result<()> {
     validate_name(name)?;
+    let _lock = lock_registry(workspace)?;
     let mut entries = read_repo_registry(workspace)?
         .ok_or_else(|| anyhow!("Codex account {name:?} does not exist"))?;
     let entry = entries
@@ -206,6 +223,7 @@ pub(crate) fn set_codex_account_enabled(workspace: &Path, name: &str, enabled: b
 
 pub(crate) fn unregister_codex_account(workspace: &Path, name: &str) -> Result<()> {
     validate_name(name)?;
+    let _lock = lock_registry(workspace)?;
     let mut entries = read_repo_registry(workspace)?
         .ok_or_else(|| anyhow!("Codex account {name:?} does not exist"))?;
     let before = entries.len();
@@ -536,6 +554,32 @@ mod tests {
         );
         assert!(account_inventory(workspace.path(), AccountProvider::Codex).is_err());
         std::env::remove_var("LOOM_CODEX_PROFILE_ROOT");
+    }
+
+    #[test]
+    fn concurrent_registry_updates_do_not_lose_accounts() {
+        let workspace = tempfile::tempdir().unwrap();
+        let workspace_path = workspace.path().to_path_buf();
+        let start = std::sync::Arc::new(std::sync::Barrier::new(8));
+        let handles: Vec<_> = (0..8)
+            .map(|index| {
+                let workspace_path = workspace_path.clone();
+                let start = start.clone();
+                std::thread::spawn(move || {
+                    start.wait();
+                    let name = format!("account-{index}");
+                    register_codex_account(&workspace_path, &name, &name, true).unwrap();
+                })
+            })
+            .collect();
+        for handle in handles {
+            handle.join().unwrap();
+        }
+        let entries = read_repo_registry(&workspace_path).unwrap().unwrap();
+        assert_eq!(entries.len(), 8);
+        assert!(!per_repo_accounts_file(&workspace_path)
+            .with_extension("json.lock")
+            .exists());
     }
 
     #[test]

--- a/loom-daemon/src/tokens_pool/bad_tokens.rs
+++ b/loom-daemon/src/tokens_pool/bad_tokens.rs
@@ -521,6 +521,9 @@ mod tests {
     /// #4122: an exhaustion (non-auth) entry older than the cooldown no longer
     /// reports `is_bad`, while an auth entry of the same age remains permanent.
     #[test]
+    // Reads the process-global cooldown default, so it must not overlap the
+    // `#[serial]` tests that mutate `EXHAUSTION_COOLDOWN_ENV`.
+    #[serial]
     fn exhaustion_entry_expires_after_cooldown_auth_stays() {
         let tmp = make_pool();
         let dir = pool_dir(tmp.path());
@@ -556,6 +559,9 @@ mod tests {
     /// and how long is left on the cooldown — the detail the empty-pool error
     /// renders per token.
     #[test]
+    // Reads the process-global cooldown default, so it must not overlap the
+    // `#[serial]` tests that mutate `EXHAUSTION_COOLDOWN_ENV`.
+    #[serial]
     fn blocking_entry_reports_exhaustion_class_and_cooldown_remaining() {
         let tmp = make_pool();
         let dir = pool_dir(tmp.path());
@@ -588,6 +594,9 @@ mod tests {
     /// entry reported is the deciding (fresh) one, not the stale one an
     /// operator would see at the top of the file.
     #[test]
+    // Reads the process-global cooldown default, so it must not overlap the
+    // `#[serial]` tests that mutate `EXHAUSTION_COOLDOWN_ENV`.
+    #[serial]
     fn blocking_entry_reports_the_deciding_fresh_line_not_the_stale_one() {
         let tmp = make_pool();
         let dir = pool_dir(tmp.path());
@@ -626,6 +635,9 @@ mod tests {
     /// #4122: a fresh exhaustion entry still blocks (the cooldown only expires
     /// aged entries).
     #[test]
+    // Reads the process-global cooldown default, so it must not overlap the
+    // `#[serial]` tests that mutate `EXHAUSTION_COOLDOWN_ENV`.
+    #[serial]
     fn fresh_exhaustion_entry_still_blocks() {
         let tmp = make_pool();
         mark_bad(tmp.path(), "agent-1", "exhausted: weekly limit").unwrap();

--- a/loom-daemon/src/tokens_pool/mod.rs
+++ b/loom-daemon/src/tokens_pool/mod.rs
@@ -61,6 +61,7 @@
 //! the conformance suite under `loom-tools/tests/tokens/test_rust_conformance.py`
 //! diffs fixture pools driven through both CLIs.
 
+pub mod account_lifecycle;
 pub mod account_registry;
 pub mod allowlist;
 pub mod bad_tokens;

--- a/loom-daemon/tests/accounts_cli.rs
+++ b/loom-daemon/tests/accounts_cli.rs
@@ -1,0 +1,41 @@
+#[cfg(unix)]
+#[test]
+fn login_child_exit_status_is_preserved_by_cli() {
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+
+    let fixture = tempfile::tempdir().unwrap();
+    let bin_dir = fixture.path().join("bin");
+    let workspace = fixture.path().join("workspace");
+    let profiles = fixture.path().join("profiles");
+    std::fs::create_dir(&bin_dir).unwrap();
+    std::fs::create_dir(&workspace).unwrap();
+    let codex = bin_dir.join("codex");
+    std::fs::write(&codex, "#!/bin/sh\nexit 23\n").unwrap();
+    std::fs::set_permissions(&codex, std::fs::Permissions::from_mode(0o700)).unwrap();
+    let inherited_path = std::env::var_os("PATH").unwrap_or_default();
+    let path = std::env::join_paths(
+        std::iter::once(bin_dir.clone()).chain(std::env::split_paths(&inherited_path)),
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_loom-daemon"))
+        .args([
+            "accounts",
+            "--workspace",
+            workspace.to_str().unwrap(),
+            "add",
+            "codex",
+            "alice",
+        ])
+        .env("LOOM_CODEX_PROFILE_ROOT", &profiles)
+        .env("PATH", path)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(23));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Codex login failed or was cancelled"));
+    assert!(!stderr.contains("auth.json"));
+    assert!(!profiles.join("alice").exists());
+}


### PR DESCRIPTION
## Summary

Add a native, provider-aware `loom-daemon accounts` lifecycle for canonical machine-level Codex profiles. Credential contents remain opaque while operators can add, import, inspect, disable, enable, reauthenticate, quarantine, or explicitly purge profiles.

## Changes

- Add `accounts add|import|list|status|disable|enable|reauth|remove` with Codex-only provider validation and stable secret-free JSON.
- Add an isolated lifecycle service with an injectable subprocess runner, `CODEX_HOME` binding, device-auth support, bounded login-status probing, atomic registry updates/imports, containment checks, and `0700`/`0600` enforcement.
- Add recoverable private quarantine by default and require `--purge` for irreversible deletion.
- Document canonical-profile operation, stdin-based auth alternatives, residual active-use interlock, and the #4493 ranking/failover boundary.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Distinct named profiles and correct `CODEX_HOME` | ✅ | `add_two_profiles_device_auth_and_reauth_keep_canonical_identity` asserts per-profile runner paths. |
| Device auth, cancellation, and no false healthy record | ✅ | Fake-runner tests assert `--device-auth`; failed add removes only its empty new profile and writes no registry record. |
| Atomic private import and unsafe-path/overwrite refusal | ✅ | `import_is_private_atomic_and_secret_free` plus name/repository-root rejection tests; import uses same-directory create-new staging and rename. |
| Stable secret-free list/status schema | ✅ | `AccountStatus` has schema version 1 and contains only identity/state/diagnostic enums; seeded secret is absent from JSON and Debug assertions. |
| Actionable shape, permission, CLI, timeout, and login diagnostics | ✅ | Structural inspection distinguishes missing/empty/unreadable/non-regular/mode/owner; bounded runner maps unavailable/timeout/nonzero/not-logged-in without relaying raw output. |
| Idempotent disable/enable with validation | ✅ | Disable preserves auth bytes; enable refuses missing/unsafe credential state; registry mutation preserves identity. |
| In-place reauth without silent enable | ✅ | Test reauthenticates the same profile and proves disabled state remains disabled. |
| Recoverable default removal and explicit purge | ✅ | Quarantine/purge test verifies machine-private recovery state, secret-free metadata, and explicit irreversible path. |
| #4491 containment and duplicate identity rules | ✅ | Lifecycle consumes registry validation; tests reject traversal, absolute, separator, and repository-local roots; create-new operations refuse duplicates. |
| Secrets absent from outputs and metadata | ✅ | Recognizable fake secret assertions cover JSON, Debug/call capture, registry behavior, and quarantine metadata. |
| Claude token behavior unchanged | ✅ | No Claude token CLI or formats changed; provider validation rejects Claude on the new surface. |

## Test Plan

- `cargo test -p loom-daemon account_lifecycle -- --test-threads=1` — 6 passed.
- `cargo check -p loom-daemon` — passed.
- `cargo clippy -p loom-daemon --all-targets -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `cargo run -q -p loom-daemon -- accounts --help` — all eight lifecycle commands rendered.
- Repository build gate reached the full 2,173-test daemon suite; four pre-existing `role_runner` tests failed because the effective project-tier config supplies enabled roles where those tests expect an empty default. The same failures reproduce isolated without this diff. The run was stopped after the unrelated configured dispatch-stagger test exceeded 60 seconds.

Closes #4492