### PR TITLE
feat(watchdog): add bounded in-band IPC liveness probe with pid-keyed debounce

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -3162,6 +3162,11 @@ loop is not reusable as the reporter). It has three cooperating parts:
 | watchdog interval | `LOOM_WATCHDOG_INTERVAL_SECS` | — | `300` (launchd `StartInterval` / systemd `OnUnitActiveSec`+`OnBootSec`) |
 | watchdog job/unit basename override | `LOOM_WATCHDOG_LABEL` | — | `<daemon label/unit>-watchdog` |
 | staleness threshold | `LOOM_DAEMON_HEARTBEAT_STALE_SECS` | — | `max(5 × cadence, 300)` |
+| IPC probe on/off (#4398) | `LOOM_WATCHDOG_IPC_PROBE` | — | on |
+| IPC probe budget (#4398) | `LOOM_WATCHDOG_STATUS_PROBE_TIMEOUT_SECS` | — | `15` |
+| IPC probe argv (#4398) | `LOOM_WATCHDOG_IPC_PROBE_ARGS` | — | `quarantine list` |
+| confirmed-hang threshold (#4398) | `LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD` | — | `3` consecutive ticks |
+| IPC probe startup grace (#4398) | `LOOM_WATCHDOG_IPC_PROBE_GRACE_SECS` | — | `LOOM_DAEMON_STARTUP_GRACE_SECS`, else `90` |
 
 **Why an interval timer, not a resident process or `KeepAlive`/`Restart=`.** The
 reporter must itself be supervised, but a long-lived resident watchdog just moves
@@ -3180,7 +3185,8 @@ service's exit code affects the next scheduled run.
 
 | Marker | Reality | Watchdog |
 |--------|---------|----------|
-| present | daemon alive, heartbeat fresh | silent (OK) |
+| present | daemon alive, heartbeat fresh, IPC round-trip OK | silent (OK) |
+| present | daemon alive, heartbeat fresh, **IPC round-trip fails** (#4398) | **report** — 1 tick: "not yet confirmed"; N consecutive: **IPC UNRESPONSIVE (CONFIRMED)** |
 | present | daemon alive, heartbeat **stale**, written this boot (younger than the process) | **report** — daemon may be wedged |
 | present | daemon alive, heartbeat **older than the process itself** (#4368: a previous-boot/enablement leftover) | silent (liveness-only; not evidence about the current process) |
 | present | daemon alive, no heartbeat file | silent (liveness-only; heartbeat disabled or not yet written) |
@@ -3188,7 +3194,53 @@ service's exit code affects the next scheduled run.
 | **absent** | **nothing running** | silent — deliberate stop, no false page |
 | **absent** | **daemon IS running** | **report (WARN)** — state mismatch, crash protection disarmed (#4331) |
 
-The last row is the #4331 fix. Before it, a missing marker short-circuited to a
+**In-band hang detection (#4398).** Rows 1–2 above are the #4398 addition. Both
+pre-existing checks are *out-of-band*: neither ever talks to the daemon over the
+socket it serves work on, and two incidents proved that is not enough. In #4381
+the installed binary was replaced by a stub that answered `--version` and then
+hung forever — a pid-alive check passes against that indefinitely. On 2026-07-29
+the production daemon (pid 1484) was alive **and writing a fresh heartbeat**
+while every `loom-daemon status` round-trip hung: the heartbeat writer
+(`daemon_heartbeat::spawn_heartbeat_task`) and the IPC accept loop are
+independent `tokio::spawn`ed tasks on a multi-threaded runtime, so one keeps
+ticking while the other is wedged. After liveness is confirmed the watchdog now
+also runs a **bounded in-band round-trip** through the resolved `loom-daemon`
+CLI, with these properties:
+
+- **Bounded twice.** The CLI bounds its own connect + round-trip (5s each,
+  `query_daemon_bounded`); the watchdog additionally wraps the invocation in a
+  hard external budget (default 15s), so even a CLI that never returns at all
+  cannot hang the tick. macOS ships no `timeout(1)`, so the no-`timeout` path is
+  a real built-in bounded runner, not a degrade-to-unbounded.
+- **`quarantine list`, not `status --json`.** `status --json` looks like the
+  obvious probe but, *after* a successful round-trip, it also runs a per-account
+  token-pool network check plus a self-update check — measured at **15.3s against
+  a healthy daemon**, which would make the probe budget itself the
+  false-positive generator. `quarantine list` is a pure IPC round-trip with no
+  post-reply work (~5ms). Override with `LOOM_WATCHDOG_IPC_PROBE_ARGS`.
+- **Debounced, pid-keyed.** One failed round-trip can be transient contention
+  (#4279). A single failure is reported loudly but only **N consecutive**
+  failures (default 3), tallied in `<loom_dir>/.watchdog-probe-fail-count` and
+  **keyed to the live pid** so a relaunched daemon never inherits its
+  predecessor's streak, are called a confirmed hang. A successful probe clears
+  the streak.
+- **Startup-grace aware.** A probe against a process younger than the grace
+  window (default 90s, the same `daemon_install_state::DEFAULT_STARTUP_GRACE_SECS`
+  `status` uses) is skipped outright and never counts toward the tally — the
+  post-relaunch socket-bind window is not a wedge.
+- **Gracefully degrading.** No resolvable `loom-daemon` binary, a build whose CLI
+  does not know the probe subcommand, or a daemon-side *application* error (which
+  proves IPC works) all skip the probe rather than invent a divergence. The probe
+  never becomes a new hard dependency that pages on its own absence.
+- **Report-only, deliberately.** Unlike #4232's narrow auto-`kickstart`, there is
+  no provably-safe unattended remediation for a wedged-but-alive process — the
+  only real fix is killing it, which would equally kill a daemon merely under
+  heavy legitimate load. A confirmed hang escalates to a maximally actionable
+  DIVERGENCE report (distinct `IPC UNRESPONSIVE (CONFIRMED)` text, explicit
+  recovery commands, exit `1`) and stops there. Auto-kill remediation, if ever
+  wanted, needs its own narrow provably-safe gate.
+
+The last no-marker row is the #4331 fix. Before it, a missing marker short-circuited to a
 bare `[OK] … nothing to check` **without probing reality at all** — so a
 supervised daemon running with its marker gone (see "Marker ownership" below) was
 reported healthy while the watchdog would in fact never revive it. The no-marker

--- a/defaults/scripts/cli/loom-daemon-watchdog.sh
+++ b/defaults/scripts/cli/loom-daemon-watchdog.sh
@@ -42,6 +42,54 @@
 #   OPERATOR INTENT: present ⇒ a daemon is expected; absent ⇒ it was
 #   deliberately stopped (or never started) ⇒ stay silent.
 #
+# HANG-AWARE IPC LIVENESS PROBE (#4398)
+#   Process-exists + heartbeat-fresh are BOTH out-of-band signals: neither ever
+#   talks to the daemon over the socket it actually serves work on. Two observed
+#   incidents show why that is not enough:
+#     - #4381: the installed loom-daemon binary was replaced by a stub that
+#       answered `--version` and then hung forever. A pid-alive check passes
+#       against that indefinitely.
+#     - 2026-07-29: the production daemon (pid 1484) was alive AND writing a
+#       FRESH heartbeat while every `loom-daemon status` round-trip hung. The
+#       heartbeat writer (`daemon_heartbeat::spawn_heartbeat_task`) and the IPC
+#       accept loop are independent `tokio::spawn`ed tasks on a multi-threaded
+#       runtime, so one can keep ticking while the other is wedged.
+#   So after liveness is confirmed, this job also runs a BOUNDED in-band IPC
+#   round-trip through the installed loom-daemon CLI. Design points:
+#     * BOUNDED TWICE. The CLI bounds its own connect + round-trip (5s each,
+#       `query_daemon_bounded`); this job additionally wraps the invocation in a
+#       hard external timeout, so even a CLI that never returns at all (the
+#       #4381 stub) cannot hang the watchdog tick.
+#     * LIGHTWEIGHT SUBCOMMAND, NOT `status`. The probe defaults to
+#       `quarantine list` — a pure IPC round-trip with no post-reply work.
+#       `loom-daemon status --json` looks like the obvious probe but, AFTER a
+#       successful round-trip, it also runs a per-account token-pool network
+#       check plus a self-update check; measured at 15.3s against a HEALTHY
+#       daemon, which would make the probe timeout itself the false-positive
+#       generator. Override with LOOM_WATCHDOG_IPC_PROBE_ARGS if desired.
+#     * DEBOUNCED. A single failed round-trip can be transient contention (a
+#       per-connection task dropping a `status` under concurrent-sweep load —
+#       #4279). One failure is REPORTED (loud, logged) but only N consecutive
+#       failures, tracked in <loom_dir>/.watchdog-probe-fail-count and keyed to
+#       the live pid, are called a CONFIRMED hang.
+#     * STARTUP-GRACE AWARE. For up to ~90s after a supervised relaunch the
+#       socket may not be bound yet even though launchd reports a live pid
+#       (#4213). A probe against a process younger than the grace window is
+#       skipped entirely and never counts toward the confirmed-hang tally —
+#       the same window `daemon_install_state::DEFAULT_STARTUP_GRACE_SECS`
+#       uses, so `status` and this watchdog cannot disagree.
+#     * GRACEFULLY DEGRADING. No resolvable loom-daemon binary, a build whose
+#       CLI does not know the probe subcommand, or any daemon-side application
+#       error (the IPC round-trip demonstrably WORKED) skips the probe rather
+#       than inventing a divergence. The probe must never become a new hard
+#       dependency that pages on its own absence.
+#     * REPORT-ONLY, DELIBERATELY. Unlike #4232's narrow auto-`kickstart`, there
+#       is NO provably-safe unattended remediation for a wedged-but-alive
+#       process: the only real fix is killing it, which would also kill a daemon
+#       that is merely under heavy legitimate load. A confirmed hang therefore
+#       escalates to a maximally actionable DIVERGENCE report (exit 1) with the
+#       explicit recovery commands — never an automatic kill/restart.
+#
 # BOUNDED AUTO-REMEDIATION (#4232)
 #   The watchdog was deliberately report-only until #4232: on 2026-07-28 a
 #   `loom-daemon restart` was ack'd (the running daemon exited 0, honoring its
@@ -66,8 +114,10 @@
 #   1  DIVERGENCE / state mismatch reported — a daemon is expected but is not
 #      running (and either the #4232 remediation gate did not apply, or it fired
 #      but the daemon is still not confirmed running), or is running but its
-#      heartbeat is stale (possibly wedged), OR (#4331) a daemon IS running while
-#      the marker is ABSENT (crash protection disarmed — a WARN state mismatch)
+#      heartbeat is stale (possibly wedged), OR (#4398) it is running with a
+#      fresh heartbeat but its bounded IPC round-trip failed, OR (#4331) a daemon
+#      IS running while the marker is ABSENT (crash protection disarmed — a WARN
+#      state mismatch)
 #   2  usage error
 #
 # Usage:
@@ -91,6 +141,26 @@
 #                                (default 3).
 #   LOOM_WATCHDOG_KICKSTART_RECHECK_INTERVAL  #4232: seconds between re-checks
 #                                (default 1; may be fractional).
+#   LOOM_WATCHDOG_IPC_PROBE       #4398: 0/false/no disables the bounded in-band
+#                                IPC probe entirely (pid + heartbeat checks only).
+#   LOOM_WATCHDOG_STATUS_PROBE_TIMEOUT_SECS  #4398: hard external budget for the
+#                                probe (default 15). Must stay comfortably above
+#                                the CLI's own 5s connect + 5s round-trip bound.
+#   LOOM_WATCHDOG_IPC_PROBE_ARGS  #4398: the loom-daemon argv used as the probe
+#                                (default 'quarantine list' — a pure IPC
+#                                round-trip with no post-reply work).
+#   LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD  #4398: consecutive failed probes
+#                                before a hang is called CONFIRMED (default 3).
+#   LOOM_WATCHDOG_IPC_PROBE_GRACE_SECS  #4398: post-relaunch socket-bind grace
+#                                window; a younger process is not probed
+#                                (default: LOOM_DAEMON_STARTUP_GRACE_SECS, else 90).
+#   LOOM_WATCHDOG_IPC_PROBE_STATE  #4398: path to the consecutive-failure counter
+#                                (default <loom dir>/.watchdog-probe-fail-count).
+#   LOOM_WATCHDOG_FORCE_PORTABLE_TIMEOUT  #4398: 1 forces the built-in bounded
+#                                runner instead of `timeout(1)` (test seam for
+#                                the default macOS no-`timeout` shape).
+#   LOOM_DAEMON_BIN               Explicit loom-daemon binary for the IPC probe
+#                                (same resolution order as loom-daemon-start.sh).
 
 set -uo pipefail
 
@@ -127,6 +197,26 @@ SOCKET_PATH="${LOOM_SOCKET_PATH:-$HOME/.loom/loom-daemon.sock}"
 LOOM_DIR="$(dirname "$SOCKET_PATH")"
 MARKER="${LOOM_AUTONOMY_MARKER:-$LOOM_DIR/autonomy-desired}"
 WATCHDOG_LOG="${LOOM_WATCHDOG_LOG:-$LOOM_DIR/logs/daemon-watchdog.log}"
+
+# ---------- IPC probe knobs (#4398) ----------
+# The external budget must stay comfortably ABOVE the CLI's own worst case (5s
+# connect + 5s round-trip, doubled by the single #4279 reconnect retry) so on a
+# merely-slow-but-healthy daemon the CLI's own bound is always what fires first
+# and this timeout is never the thing that manufactures a "hang".
+PROBE_TIMEOUT_SECS="${LOOM_WATCHDOG_STATUS_PROBE_TIMEOUT_SECS:-15}"
+[[ "$PROBE_TIMEOUT_SECS" =~ ^[0-9]+$ ]] || PROBE_TIMEOUT_SECS=15
+PROBE_ARGS="${LOOM_WATCHDOG_IPC_PROBE_ARGS:-quarantine list}"
+PROBE_FAIL_THRESHOLD="${LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD:-3}"
+[[ "$PROBE_FAIL_THRESHOLD" =~ ^[1-9][0-9]*$ ]] || PROBE_FAIL_THRESHOLD=3
+# Mirrors daemon_install_state::DEFAULT_STARTUP_GRACE_SECS (90) and honors the
+# same LOOM_DAEMON_STARTUP_GRACE_SECS override, so `loom-daemon status` and this
+# watchdog can never disagree about when a young daemon is merely *starting*.
+PROBE_GRACE_SECS="${LOOM_WATCHDOG_IPC_PROBE_GRACE_SECS:-${LOOM_DAEMON_STARTUP_GRACE_SECS:-90}}"
+[[ "$PROBE_GRACE_SECS" =~ ^[0-9]+$ ]] || PROBE_GRACE_SECS=90
+PROBE_STATE_FILE="${LOOM_WATCHDOG_IPC_PROBE_STATE:-$LOOM_DIR/.watchdog-probe-fail-count}"
+# Set true once a probe divergence has been REPORTED on this tick, so the
+# heartbeat section's otherwise-healthy exits still surface a non-zero code.
+PROBE_DIVERGED=false
 
 # Append a timestamped line to the watchdog log (best-effort) and echo to
 # stderr, which launchd captures to the job's StandardErrorPath. This IS the
@@ -232,6 +322,198 @@ process_age_secs() {
     [[ -n "$pid" ]] || return 1
     etime="$(ps -o etime= -p "$pid" 2>/dev/null)" || return 1
     parse_etime_secs "$etime"
+}
+
+# ---------- bounded in-band IPC probe (#4398) ----------
+
+# Resolve the loom-daemon binary the probe should invoke, in the SAME order
+# loom-daemon-start.sh's `locate_daemon_bin` uses (LOOM_DAEMON_BIN override ->
+# PATH -> in-repo cargo targets) so the watchdog and the start path can never
+# disagree about which binary is "the" daemon CLI. Echoes nothing and returns 1
+# when nothing is resolvable — the caller must then SKIP the probe, never
+# report a divergence: a watchdog that pages because its own optional helper
+# is missing is worse than one that quietly keeps doing the other two checks.
+locate_daemon_bin() {
+    if [[ -n "${LOOM_DAEMON_BIN:-}" && -x "${LOOM_DAEMON_BIN}" ]]; then
+        echo "${LOOM_DAEMON_BIN}"; return 0
+    fi
+    if command -v loom-daemon >/dev/null 2>&1; then
+        command -v loom-daemon; return 0
+    fi
+    local root candidate
+    root="$(marker_get repo_root 2>/dev/null)"
+    if [[ -n "$root" ]]; then
+        for candidate in \
+            "$root/loom-daemon/target/release/loom-daemon" \
+            "$root/loom-daemon/target/debug/loom-daemon" \
+            "$root/target/release/loom-daemon" \
+            "$root/target/debug/loom-daemon"; do
+            if [[ -x "$candidate" ]]; then echo "$candidate"; return 0; fi
+        done
+    fi
+    return 1
+}
+
+# Run a command under a HARD wall-clock budget, returning 124 on timeout exactly
+# like GNU `timeout` does. macOS ships no `timeout(1)`, and for this probe an
+# unbounded fallback is not acceptable — "the CLI never returns" is precisely the
+# failure mode being detected (#4381's hung stub) — so the no-`timeout` path is a
+# real bounded implementation, not a degrade-to-unbounded.
+#
+# `-k 2` is load-bearing on the `timeout(1)` path: a non-interactive bash that is
+# blocked in a foreground command defers SIGTERM, so without the KILL escalation
+# `timeout` itself would wait indefinitely for a child that ignores the TERM —
+# reintroducing the very unbounded wait this helper exists to prevent.
+# LOOM_WATCHDOG_FORCE_PORTABLE_TIMEOUT=1 forces the fallback path, so the
+# no-`timeout(1)` behavior (the default macOS shape) is testable on any host.
+bounded_run() { # <timeout_secs> <cmd> [args...]
+    local secs="$1"; shift
+    if [[ ! "${LOOM_WATCHDOG_FORCE_PORTABLE_TIMEOUT:-}" =~ ^(1|true|yes)$ ]]; then
+        if command -v timeout >/dev/null 2>&1; then
+            timeout -k 2 "$secs" "$@"
+            return $?
+        fi
+        if command -v gtimeout >/dev/null 2>&1; then
+            gtimeout -k 2 "$secs" "$@"
+            return $?
+        fi
+    fi
+    # Portable fallback: run the command in the background and pair it with a
+    # killer subshell that TERM/KILLs it once the budget elapses.
+    "$@" &
+    local cmd_pid=$!
+    (
+        sleep "$secs"
+        kill -TERM "$cmd_pid" 2>/dev/null
+        sleep 2
+        kill -KILL "$cmd_pid" 2>/dev/null
+    ) >/dev/null 2>&1 &
+    local killer_pid=$! rc=0
+    wait "$cmd_pid" 2>/dev/null || rc=$?
+    kill "$killer_pid" 2>/dev/null
+    wait "$killer_pid" 2>/dev/null
+    # Normalize a killed-by-the-budget exit (128+TERM / 128+KILL) to `timeout`'s
+    # own 124 so the caller has ONE code to branch on regardless of which
+    # implementation ran.
+    case "$rc" in 143|137) rc=124 ;; esac
+    return "$rc"
+}
+
+# Read the consecutive-failure tally for <pid> from the state file. The tally is
+# KEYED TO THE PID: a relaunched daemon is a different process and must start
+# its own streak, never inherit the wedged predecessor's (which would escalate a
+# healthy fresh daemon on its first failed tick).
+probe_fail_count_for_pid() { # <pid>
+    local pid="$1" saved_pid saved_count
+    [[ -r "$PROBE_STATE_FILE" ]] || { echo 0; return 0; }
+    read -r saved_pid saved_count < "$PROBE_STATE_FILE" 2>/dev/null || { echo 0; return 0; }
+    [[ "$saved_pid" == "$pid" && "$saved_count" =~ ^[0-9]+$ ]] || { echo 0; return 0; }
+    echo "$saved_count"
+}
+
+probe_fail_count_write() { # <pid> <count>
+    mkdir -p "$(dirname "$PROBE_STATE_FILE")" 2>/dev/null
+    printf '%s %s\n' "$1" "$2" > "$PROBE_STATE_FILE" 2>/dev/null || true
+}
+
+probe_fail_count_clear() {
+    rm -f "$PROBE_STATE_FILE" 2>/dev/null || true
+}
+
+# Perform the bounded IPC round-trip and classify the outcome. Sets:
+#   probe_verdict  healthy | unresponsive | skipped
+#   probe_detail   human-readable reason (mirrored into the report)
+# NEVER exits, never blocks longer than PROBE_TIMEOUT_SECS (+ the 2s KILL grace
+# of the portable fallback).
+run_ipc_probe() { # <live_pid> <proc_age_or_empty>
+    probe_verdict=skipped
+    probe_detail=""
+    local pid="$1" age="$2"
+
+    if [[ "${LOOM_WATCHDOG_IPC_PROBE:-}" =~ ^(0|false|no)$ ]]; then
+        probe_detail="IPC probe disabled via LOOM_WATCHDOG_IPC_PROBE"
+        return 0
+    fi
+
+    # Post-relaunch socket-bind window (#4213/#4331): a live pid whose socket is
+    # not bound yet is STARTING, not wedged. Skip outright so it cannot count
+    # toward a confirmed hang. An UNPARSEABLE age does not skip — `ps` failing
+    # for a live pid is not a real deployment state, and silently disabling the
+    # probe on it would reintroduce the blind spot; the N-consecutive debounce
+    # still spans far more than any bind window.
+    if [[ "$age" =~ ^[0-9]+$ ]] && (( age < PROBE_GRACE_SECS )); then
+        probe_detail="process is only ${age}s old (< ${PROBE_GRACE_SECS}s startup grace) — socket may not be bound yet"
+        return 0
+    fi
+
+    local bin
+    bin="$(locate_daemon_bin)" || bin=""
+    if [[ -z "$bin" ]]; then
+        probe_detail="no loom-daemon binary resolvable (LOOM_DAEMON_BIN unset, not on PATH, no in-repo build)"
+        return 0
+    fi
+
+    local -a probe_argv
+    # shellcheck disable=SC2206  # deliberate word-splitting of the argv override
+    read -r -a probe_argv <<< "$PROBE_ARGS"
+    if (( ${#probe_argv[@]} == 0 )); then
+        probe_detail="LOOM_WATCHDOG_IPC_PROBE_ARGS is empty — nothing to probe with"
+        return 0
+    fi
+
+    local out rc=0
+    out="$(mktemp "${TMPDIR:-/tmp}/loom-watchdog-probe.XXXXXX" 2>/dev/null)" || out=""
+    if [[ -n "$out" ]]; then
+        LOOM_SOCKET_PATH="$SOCKET_PATH" bounded_run "$PROBE_TIMEOUT_SECS" \
+            "$bin" "${probe_argv[@]}" > "$out" 2>&1
+        rc=$?
+    else
+        LOOM_SOCKET_PATH="$SOCKET_PATH" bounded_run "$PROBE_TIMEOUT_SECS" \
+            "$bin" "${probe_argv[@]}" >/dev/null 2>&1
+        rc=$?
+    fi
+    local probe_output=""
+    if [[ -n "$out" ]]; then
+        probe_output="$(cat "$out" 2>/dev/null)"
+        rm -f "$out" 2>/dev/null
+    fi
+
+    case "$rc" in
+        0)
+            probe_verdict=healthy
+            probe_detail="'$(basename "$bin") ${PROBE_ARGS}' round-tripped over ${SOCKET_PATH} within ${PROBE_TIMEOUT_SECS}s"
+            return 0
+            ;;
+        124)
+            # The CLI never returned inside our hard budget even though it bounds
+            # its own connect/round-trip at 5s each — i.e. the binary itself is
+            # not answering (the #4381 hung-stub shape).
+            probe_verdict=unresponsive
+            probe_detail="'$(basename "$bin") ${PROBE_ARGS}' did NOT return within the ${PROBE_TIMEOUT_SECS}s probe budget (the CLI's own 5s connect + 5s round-trip bounds did not even fire)"
+            return 0
+            ;;
+        2|126|127)
+            # clap usage error / not executable: this build's CLI does not
+            # understand the probe, or the binary cannot be run at all. Skip.
+            probe_verdict=skipped
+            probe_detail="probe command '$(basename "$bin") ${PROBE_ARGS}' is unsupported by this binary (exit ${rc}) — skipping the IPC probe"
+            return 0
+            ;;
+    esac
+
+    # Any other non-zero exit: only call it UNRESPONSIVE on positive evidence
+    # that the round-trip itself failed. A daemon that ANSWERED with an
+    # application-level error proves IPC works, so it must degrade to `skipped`.
+    if printf '%s' "$probe_output" | grep -qiE 'alive-starting|socket has not bound'; then
+        probe_verdict=skipped
+        probe_detail="probe reports the daemon is still STARTING (socket not bound yet) — not counted as a hang"
+    elif printf '%s' "$probe_output" | grep -qiE 'could not reach loom-daemon|round-trip timed out|connect timed out|connect failed|closed the connection without responding|alive-but-unresponsive'; then
+        probe_verdict=unresponsive
+        probe_detail="'$(basename "$bin") ${PROBE_ARGS}' failed the IPC round-trip (exit ${rc}): $(printf '%s' "$probe_output" | head -n1)"
+    else
+        probe_verdict=skipped
+        probe_detail="probe exited ${rc} without an IPC-failure signature (the daemon answered) — not counted as a hang: $(printf '%s' "$probe_output" | head -n1)"
+    fi
 }
 
 # ---------- 1. intent: is a daemon expected at all? ----------
@@ -357,7 +639,67 @@ if [[ "$daemon_alive" != "true" ]]; then
     exit 1
 fi
 
-# ---------- 3. reality: is the heartbeat fresh? ----------
+# ---------- 3. reality: does the daemon still ANSWER over its socket? ----------
+# The two checks above are both out-of-band; this is the only in-band one (#4398).
+# See "HANG-AWARE IPC LIVENESS PROBE" in the header for the full rationale — in
+# short: the heartbeat writer and the IPC accept loop are independent tokio
+# tasks, so "pid alive + heartbeat fresh" can hold while every socket round-trip
+# hangs and dispatch is effectively dead.
+#
+# The process age is computed ONCE here and reused by the #4368 prior-boot
+# heartbeat check below, so both consumers see the same number.
+proc_age="$(process_age_secs "$live_pid" 2>/dev/null)" || proc_age=""
+
+run_ipc_probe "$live_pid" "$proc_age"
+
+case "$probe_verdict" in
+    healthy)
+        # A successful round-trip ends any prior failure streak outright: the
+        # confirmed-hang tally must only ever count CONSECUTIVE failures.
+        probe_fail_count_clear
+        [[ "$VERBOSE" == "true" ]] && report OK "IPC probe OK: ${probe_detail}."
+        ;;
+    unresponsive)
+        probe_fail_streak=$(( $(probe_fail_count_for_pid "$live_pid") + 1 ))
+        probe_fail_count_write "$live_pid" "$probe_fail_streak"
+        if (( probe_fail_streak >= PROBE_FAIL_THRESHOLD )); then
+            # CONFIRMED, SUSTAINED hang. Deliberately report-only: there is no
+            # provably-safe unattended remediation for a wedged-but-alive
+            # process (the only real fix is killing it, which would equally kill
+            # a daemon merely under heavy legitimate load), so unlike #4232's
+            # narrow auto-kickstart gate this escalates to a maximally
+            # actionable report and stops there.
+            report DIVERGENCE \
+                "daemon IPC UNRESPONSIVE (CONFIRMED): the process is alive (${liveness_detail}) — and its heartbeat may well look FRESH — but the bounded socket round-trip has now failed on ${probe_fail_streak} CONSECUTIVE watchdog ticks (threshold ${PROBE_FAIL_THRESHOLD}). ${probe_detail}. The heartbeat writer and the IPC accept loop are independent tokio tasks, so a fresh heartbeat does NOT prove the daemon can still serve work: autonomous dispatch is effectively DEAD while this holds. No automatic kill/restart is attempted (#4398 — there is no provably-safe unattended remediation for a wedged-but-alive process). RECOVER: 'loom-daemon restart' (note: the restart primitive travels over this same wedged socket and may itself hang), else ./.loom/scripts/cli/loom-daemon-stop.sh && ./.loom/scripts/cli/loom-daemon-start.sh [flags]. Diagnose with: LOOM_SOCKET_PATH=${SOCKET_PATH} ${PROBE_TIMEOUT_SECS}s-bounded 'loom-daemon status'; sample the process with 'sample ${live_pid}' (macOS) or 'gdb -p ${live_pid}' to capture the wedge before killing it."
+            exit 1
+        fi
+        # Below threshold: loud + logged, but explicitly NOT a confirmed hang —
+        # one failed round-trip can be transient contention (#4279: a
+        # per-connection task dropping a request under concurrent-sweep load
+        # that the very next one answers).
+        report DIVERGENCE \
+            "daemon IPC probe FAILED while the process is alive (${liveness_detail}): ${probe_detail}. This is consecutive failure ${probe_fail_streak} of ${PROBE_FAIL_THRESHOLD} — NOT yet a confirmed hang (a single failure can be transient contention under concurrent-sweep load, #4279) and no remediation is attempted. If the next watchdog tick round-trips cleanly the streak resets."
+        PROBE_DIVERGED=true
+        ;;
+    *)
+        # skipped: startup grace, no resolvable binary, unsupported subcommand,
+        # probe disabled, or a daemon-side application error (which PROVES IPC
+        # works). None of these may increment the tally or invent a divergence —
+        # and none may clear an existing streak either.
+        [[ "$VERBOSE" == "true" ]] && report OK "IPC probe skipped: ${probe_detail}."
+        ;;
+esac
+
+# Final exit for the paths below that find nothing wrong themselves. A probe
+# divergence already REPORTED above still owns the exit code — otherwise a
+# wedged-but-heartbeating daemon would exit 0 and the report would be the only
+# trace, which is exactly the signal-vs-exit-code split #4398 closes.
+exit_ok() {
+    [[ "$PROBE_DIVERGED" == "true" ]] && exit 1
+    exit 0
+}
+
+# ---------- 4. reality: is the heartbeat fresh? ----------
 # The daemon writes HEARTBEAT_FILE on a declared cadence (#4011). A live daemon
 # whose heartbeat has gone stale is likely wedged — still a process, but not
 # doing its periodic work. The threshold is a comfortable multiple of the
@@ -387,11 +729,10 @@ if [[ -f "$HEARTBEAT_FILE" ]]; then
         # and this watchdog can never contradict each other. Only claim this
         # when the process age is actually known; an unparseable `ps` age
         # degrades to the ordinary Stale/Fresh checks below rather than a
-        # false claim either way.
-        proc_age="$(process_age_secs "$live_pid" 2>/dev/null)" || proc_age=""
+        # false claim either way. `proc_age` is computed once in section 3.
         if [[ -n "$proc_age" ]] && (( age > proc_age )); then
             report OK "daemon alive (${liveness_detail}); heartbeat ${HEARTBEAT_FILE} is from a PREVIOUS boot (${age}s old; this process is only ${proc_age}s old) — not evidence about the current process. Liveness-only OK; re-check after the process is well past startup if you still suspect a wedge."
-            exit 0
+            exit_ok
         fi
         if (( age > STALE_SECS )); then
             report DIVERGENCE \
@@ -399,11 +740,11 @@ if [[ -f "$HEARTBEAT_FILE" ]]; then
             exit 1
         fi
         report OK "daemon healthy (${liveness_detail}); heartbeat fresh (${age}s ≤ ${STALE_SECS}s)."
-        exit 0
+        exit_ok
     fi
     # Unreadable mtime — degrade to liveness-only rather than false-report.
     report OK "daemon alive (${liveness_detail}); heartbeat mtime unreadable — liveness-only OK."
-    exit 0
+    exit_ok
 fi
 
 # No heartbeat file but the daemon is alive: either the heartbeat loop is
@@ -411,4 +752,4 @@ fi
 # written yet. Degrade to liveness-only — do NOT false-report, since the daemon
 # clearly IS running.
 report OK "daemon alive (${liveness_detail}); no heartbeat file at ${HEARTBEAT_FILE} (heartbeat disabled or not yet written) — liveness-only OK."
-exit 0
+exit_ok

--- a/defaults/scripts/tests/test-loom-daemon-watchdog.sh
+++ b/defaults/scripts/tests/test-loom-daemon-watchdog.sh
@@ -3,18 +3,21 @@
 # autonomy-loss detector (issue #4011).
 #
 # The watchdog compares operator INTENT (the autonomy-desired marker) against
-# REALITY (daemon liveness + heartbeat freshness) and reports on divergence. This
-# suite drives it entirely from files it creates in a tempdir — a real daemon is
-# never started, and no invocation ever touches ~/.loom or the operator's real
-# launchd jobs (liveness is exercised through the pid-file path with
-# LOOM_DAEMON_LAUNCHD=0, plus one stubbed-launchctl case).
+# REALITY (daemon liveness + heartbeat freshness + — since #4398 — a bounded
+# in-band IPC round-trip) and reports on divergence. This suite drives it
+# entirely from files it creates in a tempdir — a real daemon is never started,
+# and no invocation ever touches ~/.loom or the operator's real launchd jobs
+# (liveness is exercised through the pid-file path with LOOM_DAEMON_LAUNCHD=0,
+# plus one stubbed-launchctl case; the #4398 probe always runs against a stub
+# binary pinned via LOOM_DAEMON_BIN, never the installed loom-daemon).
 #
 # Style matches the other daemon lifecycle tests — plain bash, hand-rolled
 # assertions. Bats is NOT used in this repository.
 #
 # Exit-code contract under test:
 #   0  no divergence (healthy, or no daemon expected)
-#   1  DIVERGENCE reported (expected-but-not-running, or wedged/stale heartbeat)
+#   1  DIVERGENCE reported (expected-but-not-running, wedged/stale heartbeat, or
+#      #4398: alive + heartbeat-fresh but the bounded IPC round-trip failed)
 
 set -uo pipefail
 
@@ -75,11 +78,29 @@ back_date_file() { # <file> <seconds_ago>
 # default pid file is `<loom_dir>/.daemon.pid`: without this the probe would look
 # at the operator's real ~/.loom/.daemon.pid and a live host daemon could break
 # the "nothing alive" cases.
+#
+# LOOM_WATCHDOG_IPC_PROBE=0 is the harness DEFAULT (#4398): the pre-#4398 cases
+# below assert the pid + heartbeat contract, and must not become dependent on
+# whether the host happens to have a `loom-daemon` on PATH or a live socket. It
+# is listed BEFORE "$@" so a caller can re-enable the probe by passing
+# LOOM_WATCHDOG_IPC_PROBE=1 (later `env` assignments win). The dedicated probe
+# cases in section 12+ do exactly that.
 run_watchdog() {
     : > "$OUT"
-    env "$@" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
+    env LOOM_WATCHDOG_IPC_PROBE=0 "$@" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
         LOOM_SOCKET_PATH="$WORKDIR/loom-daemon.sock" \
         LOOM_DAEMON_LAUNCHD=0 bash "$WATCHDOG" > "$OUT" 2>&1
+    RC=$?
+}
+
+# As run_watchdog, but with --verbose so the OK/skip diagnostics (which the
+# non-verbose report() deliberately suppresses on stderr but always writes to the
+# log) are asserted from the same log the operator would read.
+run_watchdog_verbose() {
+    : > "$OUT"
+    env LOOM_WATCHDOG_IPC_PROBE=0 "$@" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
+        LOOM_SOCKET_PATH="$WORKDIR/loom-daemon.sock" \
+        LOOM_DAEMON_LAUNCHD=0 bash "$WATCHDOG" --verbose > "$OUT" 2>&1
     RC=$?
 }
 
@@ -105,6 +126,71 @@ echo "$1"
 EOF
     chmod +x "$dir/ps"
     echo "$dir"
+}
+
+# ---------------------------------------------------------------------------
+# #4398 IPC-probe fixtures.
+#
+# The watchdog shells out to the resolved `loom-daemon` binary for its bounded
+# in-band probe, so the probe is driven entirely by a stub binary pinned via
+# LOOM_DAEMON_BIN — no real daemon, no real socket, no `timeout` dependency on
+# the outcome. Each mode reproduces one shape the classifier must handle:
+#
+#   ok          successful IPC round-trip (exit 0)
+#   slow-ok     eventually-responsive round-trip (the #4279 under-load case):
+#               sleeps, then succeeds — must NOT be called a hang
+#   hang        never returns at all (#4381's `while true; sleep 1` stub) —
+#               only the watchdog's own hard budget can end it
+#   unreachable the CLI's own bounded round-trip failed and it said so (exit 1)
+#   usage       this build's CLI does not know the probe subcommand (clap, exit 2)
+#   daemon-err  the daemon ANSWERED with an application error (exit 1) — proof
+#               that IPC works, so it must degrade to "skipped", not "hang"
+make_daemon_stub() { # <mode> [sleep_secs]
+    local mode="$1" secs="${2:-2}" dir
+    dir="$(mktemp -d)"
+    case "$mode" in
+        ok)
+            printf '#!/usr/bin/env bash\necho "no active quarantines"\nexit 0\n' > "$dir/loom-daemon" ;;
+        slow-ok)
+            printf '#!/usr/bin/env bash\nsleep %s\necho "no active quarantines"\nexit 0\n' "$secs" > "$dir/loom-daemon" ;;
+        hang)
+            printf '#!/usr/bin/env bash\nwhile true; do sleep 1; done\n' > "$dir/loom-daemon" ;;
+        unreachable)
+            printf '#!/usr/bin/env bash\necho "Could not reach loom-daemon at /tmp/x.sock: round-trip timed out after 5s" >&2\nexit 1\n' > "$dir/loom-daemon" ;;
+        usage)
+            printf '#!/usr/bin/env bash\necho "error: unrecognized subcommand" >&2\nexit 2\n' > "$dir/loom-daemon" ;;
+        daemon-err)
+            printf '#!/usr/bin/env bash\necho "Daemon error: workspace not registered" >&2\nexit 1\n' > "$dir/loom-daemon" ;;
+        *) echo "unknown stub mode $mode" >&2; return 1 ;;
+    esac
+    chmod +x "$dir/loom-daemon"
+    echo "$dir"
+}
+
+PROBE_STATE="$WORKDIR/.watchdog-probe-fail-count"
+
+# Stand up "daemon alive (past the startup grace) + heartbeat FRESH" — the exact
+# state in which pid-alive and heartbeat-fresh both pass and only the in-band
+# probe can tell a healthy daemon from a wedged one.
+#
+# Sets two GLOBALS (and must therefore never be called in a command
+# substitution, whose subshell would discard them):
+#   LIVE_PID      the live pid the caller must kill afterwards
+#   PS_STUB_DIR   a `ps` stub pinning the process age to 7200s — well past any
+#                 grace window — which the caller must put at the FRONT of PATH
+#                 and `rm -rf` afterwards. Without it the freshly spawned
+#                 sleeper's real age is ~0s and every probe would be skipped by
+#                 the startup-grace guard.
+PS_STUB_DIR=""
+LIVE_PID=""
+start_alive_and_fresh() { # <pid_file_suffix>
+    PS_STUB_DIR="$(make_ps_stub "02:00:00")"
+    LIVE_PID=$(sleeper)
+    echo "$LIVE_PID" > "$WORKDIR/pid$1"
+    write_marker "$WORKDIR/pid$1" 60
+    printf '%s pid=%s ts=now\n' "$(date +%s)" "$LIVE_PID" > "$HEARTBEAT"
+    : > "$WDLOG"
+    rm -f "$PROBE_STATE"
 }
 
 # ===================================================================
@@ -442,6 +528,297 @@ if echo "$help_out" | grep -qi 'autonomy-desired' && echo "$help_out" | grep -qi
 else
     fail "--help missing marker/StartInterval documentation"
 fi
+if echo "$help_out" | grep -q 'LOOM_WATCHDOG_STATUS_PROBE_TIMEOUT_SECS' \
+    && echo "$help_out" | grep -q 'LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD'; then
+    pass "--help documents the #4398 IPC-probe knobs"
+else
+    fail "--help missing the #4398 IPC-probe knob documentation"
+fi
+
+# ===================================================================
+# 12. IPC probe SUCCEEDS ⇒ unchanged healthy behavior (#4398). pid alive +
+#     heartbeat fresh + a clean bounded socket round-trip ⇒ exit 0, no
+#     DIVERGENCE, and no fail-count state left behind.
+# ===================================================================
+STUB12="$(make_daemon_stub ok)"
+start_alive_and_fresh 12
+run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
+    LOOM_DAEMON_BIN="$STUB12/loom-daemon"
+kill "$LIVE_PID" 2>/dev/null || true
+assert_rc 0 "$RC" "probe succeeds: exits 0 (healthy, unchanged behavior)"
+if log_has DIVERGENCE; then
+    fail "probe succeeds: must not report a DIVERGENCE"
+else
+    pass "probe succeeds: no DIVERGENCE reported"
+fi
+if [[ -f "$PROBE_STATE" ]]; then
+    fail "probe succeeds: no fail-count state file should exist"
+else
+    pass "probe succeeds: no fail-count state file left behind"
+fi
+rm -rf "$PS_STUB_DIR" "$STUB12"
+
+# ===================================================================
+# 13. Probe times out ONCE ⇒ DIVERGENCE reported, but explicitly NOT a
+#     confirmed hang and NO remediation (#4398). Uses the #4381 stub shape (a
+#     binary that never returns at all), so only the watchdog's own hard budget
+#     can end the probe.
+# ===================================================================
+STUB13="$(make_daemon_stub hang)"
+start_alive_and_fresh 13
+t0=$(date +%s)
+run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
+    LOOM_DAEMON_BIN="$STUB13/loom-daemon" \
+    LOOM_WATCHDOG_STATUS_PROBE_TIMEOUT_SECS=2 \
+    LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD=3
+elapsed=$(( $(date +%s) - t0 ))
+kill "$LIVE_PID" 2>/dev/null || true
+assert_rc 1 "$RC" "probe times out once: exits 1 (DIVERGENCE reported)"
+if log_has DIVERGENCE && log_hasi 'consecutive failure 1 of 3'; then
+    pass "probe times out once: reported as failure 1 of 3, not yet confirmed"
+else
+    fail "probe times out once: missing the 'failure 1 of 3' DIVERGENCE ($(cat "$WDLOG" 2>/dev/null))"
+fi
+# Matched on the FULL escalation phrase, not a bare "CONFIRMED" — the
+# below-threshold message legitimately contains the words "NOT yet a confirmed
+# hang", which a looser pattern would false-match.
+if log_hasi 'IPC UNRESPONSIVE (CONFIRMED)'; then
+    fail "probe times out once: must NOT escalate to a CONFIRMED hang"
+else
+    pass "probe times out once: does not escalate to a CONFIRMED hang"
+fi
+if (( elapsed < 20 )); then
+    pass "probe times out once: the watchdog itself stayed bounded (${elapsed}s with a never-returning binary)"
+else
+    fail "probe times out once: watchdog took ${elapsed}s — the probe budget did not bound it"
+fi
+rm -rf "$PS_STUB_DIR" "$STUB13"
+
+# ===================================================================
+# 14. Probe times out N times CONSECUTIVELY ⇒ escalation (#4398): distinct
+#     "IPC UNRESPONSIVE (CONFIRMED)" text, an explicit recovery command, exit 1
+#     — and still no automatic kill/restart.
+# ===================================================================
+STUB14="$(make_daemon_stub hang)"
+start_alive_and_fresh 14
+probe_env=(PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1
+    LOOM_DAEMON_BIN="$STUB14/loom-daemon"
+    LOOM_WATCHDOG_STATUS_PROBE_TIMEOUT_SECS=2
+    LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD=2)
+run_watchdog "${probe_env[@]}"            # tick 1 -> failure 1 of 2
+rc14a=$RC
+: > "$WDLOG"
+run_watchdog "${probe_env[@]}"            # tick 2 -> CONFIRMED
+rc14b=$RC
+kill "$LIVE_PID" 2>/dev/null || true
+assert_rc 1 "$rc14a" "consecutive timeouts (tick 1): exits 1"
+assert_rc 1 "$rc14b" "consecutive timeouts (tick 2, at threshold): exits 1"
+if log_hasi 'IPC UNRESPONSIVE (CONFIRMED)'; then
+    pass "consecutive timeouts: escalates with distinct 'IPC UNRESPONSIVE (CONFIRMED)' text"
+else
+    fail "consecutive timeouts: missing the escalation text ($(cat "$WDLOG" 2>/dev/null))"
+fi
+if log_hasi 'loom-daemon-stop.sh' && log_hasi 'loom-daemon restart'; then
+    pass "consecutive timeouts: escalation names explicit recovery commands"
+else
+    fail "consecutive timeouts: escalation missing explicit recovery commands"
+fi
+if log_hasi 'no automatic kill/restart'; then
+    pass "consecutive timeouts: escalation states that no auto-remediation was attempted"
+else
+    fail "consecutive timeouts: escalation should state that no auto-remediation was attempted"
+fi
+rm -rf "$PS_STUB_DIR" "$STUB14"
+
+# ===================================================================
+# 15. Post-relaunch socket-bind window (#4331/#4213): a probe against a process
+#     YOUNGER than the grace window is skipped outright — no DIVERGENCE, and it
+#     may never count toward the confirmed-hang tally.
+# ===================================================================
+STUB15="$(make_daemon_stub hang)"
+start_alive_and_fresh 15
+rm -rf "$PS_STUB_DIR"
+PS_STUB_DIR="$(make_ps_stub "00:00:10")"   # 10s old ⇒ inside the 90s default grace
+run_watchdog_verbose PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
+    LOOM_DAEMON_BIN="$STUB15/loom-daemon" \
+    LOOM_WATCHDOG_STATUS_PROBE_TIMEOUT_SECS=2 \
+    LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD=2
+kill "$LIVE_PID" 2>/dev/null || true
+assert_rc 0 "$RC" "young process (inside startup grace): probe skipped, exits 0"
+if log_has DIVERGENCE; then
+    fail "young process: must NOT report a DIVERGENCE during the socket-bind window"
+else
+    pass "young process: no DIVERGENCE during the socket-bind window"
+fi
+if [[ -f "$PROBE_STATE" ]]; then
+    fail "young process: must NOT count toward the confirmed-hang tally"
+else
+    pass "young process: does not count toward the confirmed-hang tally"
+fi
+if log_hasi 'startup grace'; then
+    pass "young process: verbose log explains the grace-window skip"
+else
+    fail "young process: verbose log should explain the grace-window skip"
+fi
+rm -rf "$PS_STUB_DIR" "$STUB15"
+
+# ===================================================================
+# 16. No resolvable `loom-daemon` binary ⇒ graceful degrade (#4398): the probe
+#     is skipped, NOT reported. The watchdog must never page because its own
+#     optional helper is missing. PATH is narrowed to the base system dirs so
+#     the host's real installed loom-daemon is not picked up, and the marker's
+#     repo_root ($WORKDIR) holds no cargo target either.
+# ===================================================================
+STUB16_PS="$(make_ps_stub "02:00:00")"
+start_alive_and_fresh 16
+rm -rf "$PS_STUB_DIR"
+run_watchdog_verbose PATH="$STUB16_PS:/usr/bin:/bin" LOOM_WATCHDOG_IPC_PROBE=1 \
+    LOOM_DAEMON_BIN="$WORKDIR/definitely-not-a-binary"
+kill "$LIVE_PID" 2>/dev/null || true
+assert_rc 0 "$RC" "no loom-daemon binary resolvable: exits 0 (graceful degrade)"
+if log_has DIVERGENCE; then
+    fail "no loom-daemon binary: must NOT report a DIVERGENCE"
+else
+    pass "no loom-daemon binary: no false DIVERGENCE"
+fi
+if log_hasi 'no loom-daemon binary resolvable'; then
+    pass "no loom-daemon binary: verbose log explains the skip"
+else
+    fail "no loom-daemon binary: verbose log should explain the skip ($(cat "$WDLOG" 2>/dev/null))"
+fi
+rm -rf "$STUB16_PS"
+
+# ===================================================================
+# 17. No false positive under load (#4279): a slow-but-eventually-responsive
+#     round-trip that completes INSIDE the probe budget is healthy, not a hang.
+# ===================================================================
+STUB17="$(make_daemon_stub slow-ok 2)"
+start_alive_and_fresh 17
+run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
+    LOOM_DAEMON_BIN="$STUB17/loom-daemon" \
+    LOOM_WATCHDOG_STATUS_PROBE_TIMEOUT_SECS=15
+kill "$LIVE_PID" 2>/dev/null || true
+assert_rc 0 "$RC" "slow-but-responsive probe (2s < 15s budget): exits 0, not flagged as hung"
+if log_has DIVERGENCE; then
+    fail "slow-but-responsive probe: must NOT be reported as a hang"
+else
+    pass "slow-but-responsive probe: not reported as a hang"
+fi
+rm -rf "$PS_STUB_DIR" "$STUB17"
+
+# ===================================================================
+# 18. A daemon-side APPLICATION error proves IPC works ⇒ degrade to skipped,
+#     never a hang. Same for a CLI that does not know the probe subcommand
+#     (an older installed build): exit 2 must not be read as a wedge.
+# ===================================================================
+STUB18="$(make_daemon_stub daemon-err)"
+start_alive_and_fresh 18
+run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
+    LOOM_DAEMON_BIN="$STUB18/loom-daemon" LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD=1
+kill "$LIVE_PID" 2>/dev/null || true
+assert_rc 0 "$RC" "daemon answered with an application error: exits 0 (IPC demonstrably works)"
+if log_has DIVERGENCE; then
+    fail "daemon application error: must NOT be reported as an IPC hang"
+else
+    pass "daemon application error: not reported as an IPC hang"
+fi
+rm -rf "$PS_STUB_DIR" "$STUB18"
+
+STUB18B="$(make_daemon_stub usage)"
+start_alive_and_fresh 18b
+run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
+    LOOM_DAEMON_BIN="$STUB18B/loom-daemon" LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD=1
+kill "$LIVE_PID" 2>/dev/null || true
+assert_rc 0 "$RC" "probe subcommand unsupported by this build: exits 0 (graceful degrade)"
+if log_has DIVERGENCE; then
+    fail "unsupported probe subcommand: must NOT be reported as an IPC hang"
+else
+    pass "unsupported probe subcommand: not reported as an IPC hang"
+fi
+rm -rf "$PS_STUB_DIR" "$STUB18B"
+
+# ===================================================================
+# 19. The tally counts CONSECUTIVE failures only, and is keyed to the live pid.
+#     19a: a successful probe clears a pre-existing streak.
+#     19b: a streak recorded against a DIFFERENT pid is not inherited by a
+#          freshly relaunched daemon (which would otherwise escalate on its
+#          very first failed tick).
+# ===================================================================
+STUB19="$(make_daemon_stub ok)"
+start_alive_and_fresh 19
+printf '%s 5\n' "$LIVE_PID" > "$PROBE_STATE"
+run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
+    LOOM_DAEMON_BIN="$STUB19/loom-daemon"
+kill "$LIVE_PID" 2>/dev/null || true
+assert_rc 0 "$RC" "successful probe after a streak: exits 0"
+if [[ -f "$PROBE_STATE" ]]; then
+    fail "successful probe: must clear the consecutive-failure streak"
+else
+    pass "successful probe: clears the consecutive-failure streak"
+fi
+rm -rf "$PS_STUB_DIR" "$STUB19"
+
+STUB19B="$(make_daemon_stub unreachable)"
+start_alive_and_fresh 19b
+printf '999999 9\n' > "$PROBE_STATE"    # a streak owned by a DIFFERENT (dead) pid
+run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
+    LOOM_DAEMON_BIN="$STUB19B/loom-daemon" LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD=2
+kill "$LIVE_PID" 2>/dev/null || true
+assert_rc 1 "$RC" "failed probe after a relaunch: exits 1 (reported)"
+if log_hasi 'consecutive failure 1 of 2'; then
+    pass "fail tally is pid-keyed: a relaunched daemon starts its own streak"
+else
+    fail "fail tally is pid-keyed: streak from a previous pid must not be inherited ($(cat "$WDLOG" 2>/dev/null))"
+fi
+if log_hasi 'IPC UNRESPONSIVE (CONFIRMED)'; then
+    fail "fail tally is pid-keyed: must not escalate on the new pid's first failure"
+else
+    pass "fail tally is pid-keyed: no escalation on the new pid's first failure"
+fi
+rm -rf "$PS_STUB_DIR" "$STUB19B"
+
+# ===================================================================
+# 20. The probe is opt-out-able (LOOM_WATCHDOG_IPC_PROBE=0): a never-returning
+#     binary is not even invoked, so behavior is byte-identical to pre-#4398.
+# ===================================================================
+STUB20="$(make_daemon_stub hang)"
+start_alive_and_fresh 20
+t0=$(date +%s)
+run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=0 \
+    LOOM_DAEMON_BIN="$STUB20/loom-daemon" \
+    LOOM_WATCHDOG_STATUS_PROBE_TIMEOUT_SECS=2
+elapsed=$(( $(date +%s) - t0 ))
+kill "$LIVE_PID" 2>/dev/null || true
+assert_rc 0 "$RC" "LOOM_WATCHDOG_IPC_PROBE=0: probe disabled, exits 0"
+if (( elapsed < 2 )); then
+    pass "LOOM_WATCHDOG_IPC_PROBE=0: the probe binary is never invoked (${elapsed}s)"
+else
+    fail "LOOM_WATCHDOG_IPC_PROBE=0: took ${elapsed}s — the probe appears to have run"
+fi
+rm -rf "$PS_STUB_DIR" "$STUB20"
+
+# ===================================================================
+# 21. The bound holds with NO `timeout(1)` on the host (the default macOS
+#     shape): LOOM_WATCHDOG_FORCE_PORTABLE_TIMEOUT=1 exercises the built-in
+#     bounded runner against a never-returning binary.
+# ===================================================================
+STUB21="$(make_daemon_stub hang)"
+start_alive_and_fresh 21
+t0=$(date +%s)
+run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
+    LOOM_WATCHDOG_FORCE_PORTABLE_TIMEOUT=1 \
+    LOOM_DAEMON_BIN="$STUB21/loom-daemon" \
+    LOOM_WATCHDOG_STATUS_PROBE_TIMEOUT_SECS=2 \
+    LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD=3
+elapsed=$(( $(date +%s) - t0 ))
+kill "$LIVE_PID" 2>/dev/null || true
+assert_rc 1 "$RC" "no timeout(1) available: portable bounded runner still detects the hang (exit 1)"
+if (( elapsed < 20 )); then
+    pass "no timeout(1) available: the watchdog stayed bounded (${elapsed}s)"
+else
+    fail "no timeout(1) available: watchdog took ${elapsed}s — the portable bound did not hold"
+fi
+rm -rf "$PS_STUB_DIR" "$STUB21"
 
 echo
 echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"


### PR DESCRIPTION
## Summary

The daemon watchdog only ever probed **out-of-band** signals — process existence (`launchctl print` pid / `kill -0`) and heartbeat-file mtime. Neither ever talks to the daemon over the socket it actually serves work on, and two incidents show that gap is live, not hypothetical:

- **#4381** — the installed `loom-daemon` was replaced by a stub that answered `--version` and then hung forever (`while true; sleep 1`). `kill -0` passes against that indefinitely.
- **2026-07-29** — the production daemon (pid 1484) was alive **and writing a fresh heartbeat** while every `loom-daemon status` round-trip hung. `daemon_heartbeat::spawn_heartbeat_task` and the IPC accept loop are independent `tokio::spawn`ed tasks on a multi-threaded runtime, so one keeps ticking while the other is wedged — pid-alive + heartbeat-fresh both pass while dispatch is dead.

This adds a **bounded in-band IPC round-trip** as a third check, gated on `daemon_alive == true`. Shell-only, as scoped.

## Changes

`defaults/scripts/cli/loom-daemon-watchdog.sh`

- **New section 3** (heartbeat becomes section 4): `run_ipc_probe` shells out to the resolved `loom-daemon` CLI and classifies the result as `healthy` / `unresponsive` / `skipped`.
- **`bounded_run`** — hard external wall-clock budget (default 15s, `LOOM_WATCHDOG_STATUS_PROBE_TIMEOUT_SECS`), normalizing every implementation to `timeout`'s 124. macOS ships **no `timeout(1)`**, so the fallback is a real bounded implementation (background child + killer subshell), not a degrade-to-unbounded — "the CLI never returns" is precisely the failure being detected. `-k 2` on the `timeout(1)` path is load-bearing: a non-interactive bash blocked in a foreground command defers SIGTERM, so without the KILL escalation `timeout` itself would wait forever.
- **`locate_daemon_bin`** — same resolution order as `loom-daemon-start.sh` (`LOOM_DAEMON_BIN` → `command -v` → in-repo cargo targets, rooted at the marker's `repo_root`).
- **Debounce state** — `<loom_dir>/.watchdog-probe-fail-count`, **keyed to the live pid**, threshold 3 consecutive ticks (`LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD`). A success clears the streak; a relaunched daemon never inherits its predecessor's.
- **Startup grace** — a process younger than 90s (`LOOM_WATCHDOG_IPC_PROBE_GRACE_SECS`, defaulting through `LOOM_DAEMON_STARTUP_GRACE_SECS`, mirroring `daemon_install_state::DEFAULT_STARTUP_GRACE_SECS`) is skipped outright, so the post-relaunch socket-bind window can never count toward a hang. `proc_age` is now computed once and shared with the #4368 prior-boot heartbeat check.
- **`exit_ok`** — the heartbeat section's otherwise-healthy `exit 0` paths now exit 1 if a probe divergence was already reported on this tick, so a wedged-but-heartbeating daemon does not exit 0.
- **Opt-out** — `LOOM_WATCHDOG_IPC_PROBE=0`.

`defaults/scripts/tests/test-loom-daemon-watchdog.sh` — 35 new assertions (20 → 55).
`defaults/docs/daemon-reference.md` — decision-matrix rows, env table, and an "In-band hang detection (#4398)" subsection.

## Two deliberate design decisions (called out explicitly, per the issue)

**1. The probe is `quarantine list`, NOT `status --json`.** The issue proposed `timeout 15 loom-daemon status --json`. That would have been a guaranteed false-positive generator: after a *successful* round-trip, `handle_status_command` also runs `collect_token_usage` (a per-account **curl probe** of the token pool, staggered) plus `self_update::check()`. Measured on this host against a **healthy** daemon:

```
$ time loom-daemon status --json    # rc=0
real  0m15.289s
$ time loom-daemon quarantine list  # rc=0
real  0m0.005s
```

15.3s vs. the proposed 15s budget — the probe's own timeout would have fired on a perfectly healthy daemon on the very first tick. `quarantine list` is a pure IPC round-trip (`Request::ListQuarantines` → `query_daemon` → `query_daemon_bounded`, 5s-bounded, no post-reply work). Overridable via `LOOM_WATCHDOG_IPC_PROBE_ARGS` for operators who want `status --json` (the classifier already recognizes its `alive-but-unresponsive` / `alive-starting` output). The issue's premise — "invoke the existing bounded primitive, don't build a new one" — is preserved; only the *subcommand* changed, and the exit-code/output classifier handles both.

**2. NO auto-restart, in either the single-failure or the confirmed-hang path.** Per the issue's guidance: unlike #4232's mathematically narrow always-safe `kickstart` gate, there is no provably-safe unattended remediation for a wedged-but-alive process — the only real fix is killing it, which would equally kill a daemon merely under heavy legitimate load. A confirmed hang escalates to a maximally actionable report and stops:

```
[DIVERGENCE] daemon IPC UNRESPONSIVE (CONFIRMED): the process is alive (...) — and its heartbeat
may well look FRESH — but the bounded socket round-trip has now failed on 3 CONSECUTIVE watchdog
ticks (threshold 3). ... No automatic kill/restart is attempted (#4398 ...). RECOVER: 'loom-daemon
restart' (note: the restart primitive travels over this same wedged socket and may itself hang),
else ./.loom/scripts/cli/loom-daemon-stop.sh && ./.loom/scripts/cli/loom-daemon-start.sh [flags].
Diagnose with: ... 'sample <pid>' (macOS) or 'gdb -p <pid>' to capture the wedge before killing it.
```

Auto-kill remediation, if ever wanted, needs its own narrow provably-safe gate — a separate issue, deliberately not conflated here.

## Acceptance Criteria Verification

| AC | Status | Evidence |
|---|---|---|
| Bounded-timeout IPC probe whenever `daemon_alive == true`, in addition to pid + heartbeat | ✅ | New section 3, gated behind the existing `daemon_alive != true` early-exit. The marker-absent-but-alive path (#4331) already exits 1 loudly, so it is not probed — documented in the header. |
| Probe bounded (default ~15s, env-overridable) and never hangs the invocation, even if the daemon accepts then never responds | ✅ | `bounded_run` (double-bounded: CLI's own 5s+5s, plus the external budget). Tests 13/21 use a `while true; sleep 1` stub (the #4381 shape) and assert the whole watchdog run finishes in ~2-3s; test 21 forces the no-`timeout(1)` fallback. |
| A single timed-out probe is reported (DIVERGENCE, logged) but triggers no auto-remediation | ✅ | Test 13: exit 1, log contains "consecutive failure 1 of 3", and asserts the escalation text is **absent**. No `launchctl`/kill call exists on this path. |
| No false positives under heavy dispatch load | ✅ | The CLI's own bounded #4279 reconnect retry is inside the probe budget; test 17 simulates a slow-but-eventually-responsive round-trip (2s reply, 15s budget) → exit 0, no DIVERGENCE. Plus the 3-consecutive-tick debounce (>2 StartInterval periods). |
| No false positives during the post-relaunch socket-bind window | ✅ | Test 15: `ps` stub pins age to 10s (< 90s grace) with a hanging stub → exit 0, no DIVERGENCE, **and no state file created** (does not count toward the tally). |
| On N consecutive timed-out probes, escalate with distinct text + explicit recovery command + exit 1; auto-restart decision made explicit | ✅ | Test 14 (threshold 2, two ticks): asserts `IPC UNRESPONSIVE (CONFIRMED)`, that both `loom-daemon restart` and `loom-daemon-stop.sh` appear, and that the message states no auto-remediation was attempted. Decision stated above: **no auto-restart**. |
| New tests: probe succeeds / times out once / times out N times / young-process grace / no binary resolvable | ✅ | Sections 12, 13, 14, 15, 16 respectively — plus 17 (slow-but-responsive), 18 (daemon-side app error + unsupported subcommand), 19 (streak clear + pid-keying), 20 (opt-out), 21 (portable bound). |
| Existing tests pass unmodified in spirit; additive, not a replacement | ✅ | All 20 pre-existing assertions unchanged and green. The harness now defaults `LOOM_WATCHDOG_IPC_PROBE=0` for them so they stay hermetic (they assert the pid+heartbeat contract and must not depend on whether the host has a `loom-daemon` on PATH or a live socket); the probe cases re-enable it explicitly. |
| Probe budget comfortably > the CLI's worst-case bounded round-trip | ✅ | 15s default vs. 5s connect + 5s round-trip (x2 for the #4279 retry). Documented at the knob and in the header. |

Graceful degradation is also covered beyond the AC: a **daemon-side application error** (exit 1 with `Daemon error: …`) proves IPC works, so it degrades to `skipped` rather than being read as a wedge (test 18) — as does an older CLI that does not know the probe subcommand (clap exit 2, test 18b).

## Test Plan

- [x] `bash defaults/scripts/tests/test-loom-daemon-watchdog.sh` — **55 tests, 55 passed, 0 failed** (was 20/20)
- [x] `bash defaults/scripts/tests/test-loom-daemon-start.sh` — 46/46 passed (adjacent lifecycle suite, no regression)
- [x] `bash -n` + `shellcheck -S warning` clean on both changed scripts
- [x] Manual verification per the issue's test plan: a fake `loom-daemon` whose subcommand outlives the probe timeout → DIVERGENCE after N ticks, never a false OK (tests 13/14/21 encode exactly this; also reproduced by hand against a live daemon socket)
- [x] Probe budget empirically re-derived (the 15.3s `status --json` measurement above)
- [x] `./.loom/scripts/check-main-clean.sh` — main worktree clean

**Pre-existing failure, unrelated:** `bash scripts/test-installer.sh` reports `test-loom-dispatcher.sh failed (rc=1)`. Verified identical on a clean `origin/main` archive (`git archive origin/main` → same single failure), and the dispatcher suite passes standalone on both — an environment-sensitive pre-existing flake in the installer wrapper, untouched by this PR.

**Observation (not fixed here, out of scope):** `test-loom-daemon-watchdog.sh` is not registered in `.github/workflows/ci.yml` or `build-gate.sh` — it only runs when invoked by hand. That predates this PR; worth a follow-up issue if the maintainer wants the suite gated.

Closes #4398