### PR TITLE
feat(daemon): report watchdog protection state on status's reachable path

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -3363,9 +3363,70 @@ compatibility. The probe never fails the command — an
 unreadable/malformed marker, absent `launchctl`, a stale/unowned pid, or an
 unreadable heartbeat mtime all degrade to a less-specific verdict (or, if no
 loom dir can be resolved at all, `install_state` is simply omitted and the
-generic pre-#4069 message is printed). The success path (a reachable, healthy
-daemon) is untouched — this probe only runs after `query_daemon_status` has
-already failed.
+generic pre-#4069 message is printed). `install_state` itself only ever runs
+after `query_daemon_status` has already failed — the reachable path's own
+protection reporting is the separate probe described next.
+
+**Fourth consumer: `status`'s REACHABLE path — watchdog protection state
+(#4354, AC4 of #4331).** `install_state` above answers *"why is the daemon
+unreachable?"*, so it runs only on the `Err` arm. A **reachable** daemon (one
+answering over IPC) needs a different question answered: *"is it actually
+protected?"* Before #4354 it did not surface one, so a healthy-looking daemon
+could be running with crash protection silently disarmed, and an operator would
+only find out by reading `daemon-watchdog.log` or poking
+`launchctl`/`systemctl` by hand. `status` now prints a `Protection:` line (and a
+`protection` object under `--json`) built from a **sibling** classification —
+`ProtectionState` in the same `daemon_install_state.rs` module, deliberately
+*not* new `InstallState` variants, whose exit-code semantics above must not
+change:
+
+| State (`--json` `state`) | Human phrase | Meaning |
+|--------------------------|--------------|---------|
+| `protected` | `protected` | autonomy-desired marker present **and** the watchdog job/timer is provisioned |
+| `no-marker` | `unprotected — no autonomy-desired marker` | no marker: crash protection is DISARMED — the watchdog fires on cadence but logs `[OK] … nothing to check` (the #4331 state) |
+| `watchdog-not-provisioned` | `watchdog job not provisioned` | marker present, but no watchdog launchd job / systemd timer is scheduled — nothing will ever notice a future death |
+| `unknown` | `unknown` | marker present but the provisioning probe could not answer (no `launchctl`/`systemctl`, or an unreachable `systemctl --user` bus) — a degradation, never a false verdict |
+
+Two independent facts feed this, and **both** are always reported: the JSON
+object carries `marker_present` and `watchdog_provisioned` separately (the
+latter `null` when undeterminable) alongside `marker_path`, `watchdog_job`,
+`watchdog_job_kind`, `detail`, and the dominant `state`. When both are bad,
+`state` is `no-marker` — the stronger statement, since even a provisioned
+watchdog is inert without a marker — while `watchdog_provisioned: false` still
+records the second fact for a script.
+
+**How the probe resolves its inputs** (client-side and host-local, so nothing is
+plumbed through the IPC report):
+
+- **Marker** — via the same `LOOM_AUTONOMY_MARKER`-honoring resolver the startup
+  healer uses (`autonomy_marker::resolve_marker_path`, now the single
+  implementation `daemon_install_state` also delegates to), else
+  `<loom_dir>/autonomy-desired`.
+- **Watchdog job** — mirrors `loom-daemon-start.sh` exactly: launchd
+  `${LOOM_WATCHDOG_LABEL:-<daemon-label>-watchdog}` (daemon label from
+  `LOOM_LAUNCHD_LABEL`, else the marker's own `launchd_label`, else
+  `com.rjwalters.loom-daemon`), probed with
+  `launchctl print <domain>/<label>` in the `resolve_launchd_domain` domain
+  (`LOOM_LAUNCHD_DOMAIN` → `gui/<uid>` → `user/<uid>`); systemd
+  `${LOOM_WATCHDOG_LABEL:-<LOOM_SYSTEMD_UNIT%.service>-watchdog}.timer`, probed
+  with `systemctl --user is-enabled <unit>`. A **non-Darwin host always resolves
+  the systemd side** (the same non-Darwin blanket override the unreachable path
+  applies), so `launchctl`'s absence on Linux is never even consulted.
+- **Provisioning verdict** — `enabled`/`enabled-runtime` ⇒ provisioned; any other
+  `is-enabled` verdict (`disabled`, `static`, `masked`, absent, …) ⇒ **not**
+  provisioned, deliberately collapsing "present but disabled" and "absent" into
+  the same operator-relevant answer (neither will fire). A `Failed to connect to
+  bus` / missing-binary / undeterminable-domain outcome ⇒ `unknown`.
+
+Like the `install_state` probe, it is **read-only and never fails the command**:
+at most three query-only subprocess calls, no writes, and the reachable path
+still **exits 0** whatever protection state it reports (only `no-marker` and
+`watchdog-not-provisioned` add remediation lines — `protected` and `unknown`
+print none, since `unknown` is a probe limitation on this host, not evidence of a
+fault). When no loom dir resolves at all the `Protection:` line is omitted and
+`--json`'s `protection` is `null`. The unreachable-path `install_state` output
+and its exit codes are unchanged. `fleet status`'s local-host row carries the
+same `protection` field, since it shares the `status --json` payload builder.
 
 ### macOS session-bootstrap hazard (#3972)
 

--- a/loom-daemon/src/daemon_install_state.rs
+++ b/loom-daemon/src/daemon_install_state.rs
@@ -52,6 +52,18 @@
 //!
 //! This module changes reporting only: it starts nothing, stops nothing, and
 //! writes no state (Non-goal in #4069 — do not add writes here).
+//!
+//! # Watchdog protection state (#4354, AC4 of #4331)
+//!
+//! [`InstallState`] above answers "why is the daemon unreachable?" and therefore
+//! only runs on the `Err` arm. A *reachable* daemon needs a different question
+//! answered: **is it actually protected?** — i.e. is the autonomy-desired marker
+//! present (so a crash is detectable at all), and is the watchdog launchd job /
+//! systemd timer actually provisioned (so something is scheduled to notice)?
+//! [`ProtectionState`] / [`probe_protection`] are that **sibling** classification.
+//! They deliberately do NOT add [`InstallState`] variants: those variants carry
+//! exit-code semantics (#4069) that the reachable path must not perturb — the
+//! reachable path always exits 0 regardless of protection state.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -289,12 +301,12 @@ fn resolve_loom_dir() -> Option<PathBuf> {
 /// Resolve the autonomy-desired marker path: `LOOM_AUTONOMY_MARKER` env
 /// override first (matching `loom-daemon-start.sh`'s `INTENT_MARKER`), else
 /// `<loom_dir>/autonomy-desired`.
+///
+/// Delegates to [`crate::autonomy_marker::resolve_marker_path`] (#4354) so this
+/// module, the startup healer (#4331), and the watchdog can never resolve the
+/// marker differently — there is exactly one implementation of the rule.
 fn resolve_marker_path(loom_dir: &Path) -> PathBuf {
-    std::env::var("LOOM_AUTONOMY_MARKER")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| loom_dir.join(MARKER_FILENAME))
+    crate::autonomy_marker::resolve_marker_path(loom_dir)
 }
 
 // ============================================================================
@@ -717,6 +729,395 @@ pub fn probe() -> Option<InstallStateReport> {
     let loom_dir = resolve_loom_dir()?;
     let marker_path = resolve_marker_path(&loom_dir);
     Some(classify(&loom_dir, &marker_path, &EnvOverrides::from_env()))
+}
+
+// ============================================================================
+// Watchdog protection state (#4354) — the REACHABLE-path sibling classification
+// ============================================================================
+
+/// Whether a *reachable* daemon is actually protected against a future death.
+///
+/// Two independent host-local facts feed this, both visible to the CLI process
+/// with no IPC involvement:
+///
+/// 1. the **autonomy-desired marker** — absent ⇒ the watchdog logs
+///    `[OK] … nothing to check` and crash protection is disarmed (the #4331
+///    state), and
+/// 2. the **watchdog job/timer** — not provisioned ⇒ nothing is scheduled to
+///    ever notice a death, however armed the marker is.
+///
+/// Precedence when both are bad: [`ProtectionState::NoMarker`] wins for the
+/// single-word verdict (it is the stronger statement — even a provisioned
+/// watchdog is inert without a marker), but
+/// [`ProtectionReport::watchdog_provisioned`] still carries the second fact
+/// verbatim so `--json` consumers and the human detail line report **both**.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProtectionState {
+    /// Marker present AND the watchdog job/timer is provisioned.
+    Protected,
+    /// No autonomy-desired marker — crash protection is disarmed (#4331).
+    NoMarker,
+    /// Marker present, but no watchdog launchd job / systemd timer is
+    /// provisioned: nothing is scheduled to detect a future death.
+    WatchdogNotProvisioned,
+    /// Marker present but the provisioning probe could not answer (no
+    /// `launchctl`/`systemctl`, or a `systemctl --user` bus that could not be
+    /// reached). A degradation, never a false verdict.
+    Unknown,
+}
+
+impl ProtectionState {
+    /// Machine-readable enum value for `--json` rendering.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ProtectionState::Protected => "protected",
+            ProtectionState::NoMarker => "no-marker",
+            ProtectionState::WatchdogNotProvisioned => "watchdog-not-provisioned",
+            ProtectionState::Unknown => "unknown",
+        }
+    }
+
+    /// The operator-facing phrase for the human `Protection:` line — the exact
+    /// wording #4354's AC1 specifies.
+    #[must_use]
+    pub fn description(self) -> &'static str {
+        match self {
+            ProtectionState::Protected => "protected",
+            ProtectionState::NoMarker => "unprotected — no autonomy-desired marker",
+            ProtectionState::WatchdogNotProvisioned => "watchdog job not provisioned",
+            ProtectionState::Unknown => "unknown",
+        }
+    }
+}
+
+/// The scheduled watchdog job this host would use, resolved (name and all) the
+/// same way `loom-daemon-start.sh` provisions it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WatchdogJob {
+    /// macOS launchd job — `${LOOM_WATCHDOG_LABEL:-<daemon-label>-watchdog}`
+    /// (`loom-daemon-start.sh::resolve_watchdog_label`), probed with
+    /// `launchctl print <domain>/<label>`.
+    Launchd { label: String },
+    /// `systemd --user` timer unit —
+    /// `${LOOM_WATCHDOG_LABEL:-<daemon-unit%.service>-watchdog}.timer`
+    /// (`loom-daemon-start.sh::resolve_systemd_watchdog_unit`), probed with
+    /// `systemctl --user is-enabled <unit>`.
+    SystemdTimer { timer_unit: String },
+}
+
+impl WatchdogJob {
+    /// The job's identifier as an operator would type it.
+    #[must_use]
+    pub fn identifier(&self) -> &str {
+        match self {
+            WatchdogJob::Launchd { label } => label,
+            WatchdogJob::SystemdTimer { timer_unit } => timer_unit,
+        }
+    }
+
+    /// Which scheduling mechanism this is (`"launchd"` / `"systemd-timer"`).
+    #[must_use]
+    pub fn kind_str(&self) -> &'static str {
+        match self {
+            WatchdogJob::Launchd { .. } => "launchd",
+            WatchdogJob::SystemdTimer { .. } => "systemd-timer",
+        }
+    }
+}
+
+/// The full protection classification for one probe.
+#[derive(Debug, Clone)]
+pub struct ProtectionReport {
+    pub state: ProtectionState,
+    /// Whether the autonomy-desired marker file was readable.
+    pub marker_present: bool,
+    /// The marker path that was checked (after `LOOM_AUTONOMY_MARKER`).
+    pub marker_path: PathBuf,
+    /// The watchdog job whose provisioning was probed.
+    pub job: WatchdogJob,
+    /// `Some(true/false)` when the provisioning probe answered; `None` when it
+    /// could not be run at all (degradation ⇒ [`ProtectionState::Unknown`]).
+    pub watchdog_provisioned: Option<bool>,
+    /// One-sentence operator-facing explanation carrying BOTH facts.
+    pub detail: String,
+}
+
+/// Env overrides the protection probe honors — a **separate** struct from
+/// [`EnvOverrides`] on purpose: that one encodes the unreachable path's
+/// marker-vs-heartbeat precedence (#4069) and is constructed literally by
+/// sibling tests, so widening it here would couple two unrelated
+/// classifications. Split out so unit tests drive every branch without mutating
+/// process-global env vars.
+#[derive(Debug, Clone)]
+pub struct ProtectionEnv {
+    /// From `LOOM_WATCHDOG_LABEL` — overrides the derived watchdog job name on
+    /// BOTH platforms, exactly as `loom-daemon-start.sh` does.
+    pub watchdog_label_override: Option<String>,
+    /// From `LOOM_LAUNCHD_LABEL` — the *daemon* label the watchdog label is
+    /// derived from (`<daemon-label>-watchdog`).
+    pub launchd_label_override: Option<String>,
+    /// From `LOOM_SYSTEMD_UNIT` — the *daemon* unit the watchdog unit is
+    /// derived from (`<unit%.service>-watchdog`).
+    pub systemd_unit_override: Option<String>,
+    /// From `LOOM_LAUNCHD_DOMAIN` — the launchd domain to probe in, mirroring
+    /// `lib/launchd-domain.sh::resolve_launchd_domain`'s override.
+    pub launchd_domain_override: Option<String>,
+    /// From `LOOM_DAEMON_LAUNCHD` — see [`parse_launchd_override`]; can only
+    /// ever force launchd *off*.
+    pub launchd_override: Option<bool>,
+    /// Whether this host can have a launchd job at all.
+    pub is_darwin: bool,
+}
+
+impl ProtectionEnv {
+    /// Resolve from the real process environment + platform.
+    #[must_use]
+    pub fn from_env() -> Self {
+        let non_empty = |key: &str| std::env::var(key).ok().filter(|s| !s.is_empty());
+        ProtectionEnv {
+            watchdog_label_override: non_empty("LOOM_WATCHDOG_LABEL"),
+            launchd_label_override: non_empty("LOOM_LAUNCHD_LABEL"),
+            systemd_unit_override: non_empty("LOOM_SYSTEMD_UNIT"),
+            launchd_domain_override: non_empty("LOOM_LAUNCHD_DOMAIN"),
+            launchd_override: parse_launchd_override(
+                std::env::var("LOOM_DAEMON_LAUNCHD").ok().as_deref(),
+            ),
+            is_darwin: cfg!(target_os = "macos"),
+        }
+    }
+}
+
+/// Default `systemd --user` daemon unit, matching
+/// `lib/systemd-user.sh::resolve_systemd_unit`'s fallback.
+pub const DEFAULT_SYSTEMD_UNIT: &str = "loom-daemon.service";
+
+/// Resolve which watchdog job this host schedules, mirroring
+/// `loom-daemon-start.sh` exactly:
+///
+/// - launchd (`use_launchd`): `${LOOM_WATCHDOG_LABEL:-<daemon-label>-watchdog}`
+///   where the daemon label is `${LOOM_LAUNCHD_LABEL:-<marker label>}`
+///   (`resolve_watchdog_label`, `loom-daemon-start.sh:511`).
+/// - systemd otherwise: `${LOOM_WATCHDOG_LABEL:-<daemon-unit%.service>-watchdog}`
+///   plus the `.timer` suffix the timer unit carries
+///   (`resolve_systemd_watchdog_unit`, `loom-daemon-start.sh:596`).
+///
+/// `use_launchd` is already the env-and-platform-resolved value (a non-Darwin
+/// host is always `false`), so a Linux host never resolves — or probes — a
+/// launchd job, and `launchctl`'s absence there is never even consulted.
+#[must_use]
+pub fn resolve_watchdog_job(
+    use_launchd: bool,
+    daemon_launchd_label: &str,
+    env: &ProtectionEnv,
+) -> WatchdogJob {
+    if use_launchd {
+        let label = env
+            .watchdog_label_override
+            .clone()
+            .unwrap_or_else(|| format!("{daemon_launchd_label}-watchdog"));
+        return WatchdogJob::Launchd { label };
+    }
+    let daemon_unit = env
+        .systemd_unit_override
+        .clone()
+        .unwrap_or_else(|| DEFAULT_SYSTEMD_UNIT.to_string());
+    let base = env
+        .watchdog_label_override
+        .clone()
+        .unwrap_or_else(|| format!("{}-watchdog", daemon_unit.trim_end_matches(".service")));
+    WatchdogJob::SystemdTimer {
+        timer_unit: format!("{base}.timer"),
+    }
+}
+
+/// Resolve the launchd domain to probe in, mirroring
+/// `lib/launchd-domain.sh::resolve_launchd_domain`: an explicit
+/// `LOOM_LAUNCHD_DOMAIN` wins, else `gui/<uid>` when that domain resolves, else
+/// the SSH-reachable background `user/<uid>` domain. `None` only when the uid
+/// itself is undeterminable (⇒ the caller degrades to `Unknown`).
+fn resolve_launchd_domain(override_value: Option<&str>) -> Option<String> {
+    if let Some(explicit) = override_value.filter(|s| !s.is_empty()) {
+        return Some(explicit.to_string());
+    }
+    let uid = current_uid()?;
+    let gui = format!("gui/{uid}");
+    let gui_ok = Command::new("launchctl")
+        .args(["print", &gui])
+        .output()
+        .is_ok_and(|o| o.status.success());
+    if gui_ok {
+        return Some(gui);
+    }
+    Some(format!("user/{uid}"))
+}
+
+/// Is the watchdog launchd job loaded? `launchctl print <domain>/<label>` exits
+/// 0 only for a bootstrapped job, so a nonzero exit is a real
+/// "not provisioned". A missing/unspawnable `launchctl` (or an undeterminable
+/// domain) yields `None` — unknown, never a false negative.
+fn launchctl_job_provisioned(label: &str, domain_override: Option<&str>) -> Option<bool> {
+    let domain = resolve_launchd_domain(domain_override)?;
+    let output = Command::new("launchctl")
+        .args(["print", &format!("{domain}/{label}")])
+        .output()
+        .ok()?;
+    Some(output.status.success())
+}
+
+/// Is the watchdog systemd timer provisioned? `systemctl --user is-enabled
+/// <unit>` prints its verdict on stdout: `enabled` / `enabled-runtime` ⇒
+/// provisioned; any other verdict (`disabled`, `static`, `masked`, `not-found`,
+/// …) ⇒ NOT provisioned, which deliberately collapses "present but disabled"
+/// and "absent" into the same operator-relevant answer — neither will fire.
+///
+/// No stdout verdict at all is ambiguous, so it is disambiguated from stderr: a
+/// "no such file" complaint is a genuine absence (`Some(false)`), while anything
+/// else — most importantly `Failed to connect to bus` on a host with no user
+/// manager — is `None` (unknown), never a false "not provisioned".
+fn systemd_timer_provisioned(timer_unit: &str) -> Option<bool> {
+    let output = Command::new("systemctl")
+        .args(["--user", "is-enabled", timer_unit])
+        .output()
+        .ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    match stdout.lines().map(str::trim).find(|l| !l.is_empty()) {
+        Some("enabled" | "enabled-runtime") => Some(true),
+        Some(_) => Some(false),
+        None => {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
+            if stderr.contains("no such file") || stderr.contains("not found") {
+                Some(false)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// The real provisioning probe: dispatch to the mechanism the resolved job
+/// names. Read-only (`launchctl print` / `systemctl is-enabled` are both
+/// queries) and never fails — every failure mode degrades to `None`.
+fn probe_watchdog_provisioned(job: &WatchdogJob, domain_override: Option<&str>) -> Option<bool> {
+    match job {
+        WatchdogJob::Launchd { label } => launchctl_job_provisioned(label, domain_override),
+        WatchdogJob::SystemdTimer { timer_unit } => systemd_timer_provisioned(timer_unit),
+    }
+}
+
+/// Classify protection from an already-resolved loom dir + marker path, with the
+/// provisioning check **injected** — the same testability seam [`classify`] uses
+/// for process age, so unit tests pin every (marker × provisioning) combination
+/// without a live launchd/systemd on the host.
+#[must_use]
+pub fn classify_protection(
+    loom_dir: &Path,
+    marker_path: &Path,
+    env: &ProtectionEnv,
+    // `FnMut` (not `Fn`) so a test's injected probe can record which job it was
+    // asked about; production passes a plain closure and it is called exactly
+    // once either way.
+    mut provisioned_fn: impl FnMut(&WatchdogJob) -> Option<bool>,
+) -> ProtectionReport {
+    // Marker read is the ONLY filesystem touch, and its failure (absent or
+    // unreadable) is a first-class verdict, never an error.
+    let contents = std::fs::read_to_string(marker_path).ok();
+    let marker_present = contents.is_some();
+    let fields = contents
+        .as_deref()
+        .map(|c| resolve_marker_fields(&parse_marker(c), loom_dir));
+
+    // Which supervisor owns the watchdog job — same env-wins-over-marker rule
+    // plus the non-Darwin blanket override the unreachable path applies. With no
+    // marker to consult, fall back to the platform default (launchd on Darwin).
+    let marker_use_launchd = fields.as_ref().map_or(env.is_darwin, |f| f.use_launchd);
+    let use_launchd = env.launchd_override.unwrap_or(marker_use_launchd) && env.is_darwin;
+    let daemon_label = env
+        .launchd_label_override
+        .clone()
+        .or_else(|| fields.as_ref().map(|f| f.launchd_label.clone()))
+        .unwrap_or_else(|| DEFAULT_LAUNCHD_LABEL.to_string());
+
+    let job = resolve_watchdog_job(use_launchd, &daemon_label, env);
+    let watchdog_provisioned = provisioned_fn(&job);
+
+    let kind = job.kind_str();
+    let id = job.identifier().to_string();
+    let marker_display = marker_path.display();
+
+    let (state, detail) = match (marker_present, watchdog_provisioned) {
+        // No marker: the strongest verdict, but still report the watchdog fact.
+        (false, provisioned) => {
+            let watchdog_note = match provisioned {
+                Some(true) => {
+                    format!("the watchdog {kind} job {id} IS provisioned but has nothing to check")
+                }
+                Some(false) => {
+                    format!("the watchdog {kind} job {id} is not provisioned either")
+                }
+                None => format!("watchdog {kind} job {id} provisioning is undeterminable"),
+            };
+            (
+                ProtectionState::NoMarker,
+                format!(
+                    "no autonomy-desired marker at {marker_display} — crash protection is \
+                     DISARMED; {watchdog_note}"
+                ),
+            )
+        }
+        (true, Some(true)) => (
+            ProtectionState::Protected,
+            format!(
+                "autonomy-desired marker present at {marker_display}; watchdog {kind} job {id} \
+                 is provisioned"
+            ),
+        ),
+        (true, Some(false)) => (
+            ProtectionState::WatchdogNotProvisioned,
+            format!(
+                "autonomy-desired marker present at {marker_display}, but the watchdog {kind} \
+                 job {id} is not provisioned — nothing is scheduled to detect a future daemon \
+                 death"
+            ),
+        ),
+        (true, None) => (
+            ProtectionState::Unknown,
+            format!(
+                "autonomy-desired marker present at {marker_display}, but the watchdog {kind} \
+                 job {id} could not be probed on this host"
+            ),
+        ),
+    };
+
+    ProtectionReport {
+        state,
+        marker_present,
+        marker_path: marker_path.to_path_buf(),
+        job,
+        watchdog_provisioned,
+        detail,
+    }
+}
+
+/// Production entry point for the reachable path (#4354): resolve the loom dir +
+/// marker path from env (via [`crate::autonomy_marker::resolve_marker_path`], so
+/// `LOOM_AUTONOMY_MARKER` is honored identically to the watchdog and the startup
+/// healer) and classify with the real launchd/systemd provisioning probe.
+///
+/// Returns `None` only when no loom dir can be resolved at all — the caller then
+/// prints nothing rather than guessing. Read-only and infallible by
+/// construction: at most three query-only subprocess calls, no writes, and no
+/// path that can fail `loom-daemon status` (the reachable path still exits 0
+/// whatever this reports).
+#[must_use]
+pub fn probe_protection() -> Option<ProtectionReport> {
+    let loom_dir = resolve_loom_dir()?;
+    let marker_path = resolve_marker_path(&loom_dir);
+    let env = ProtectionEnv::from_env();
+    let domain_override = env.launchd_domain_override.clone();
+    Some(classify_protection(&loom_dir, &marker_path, &env, |job| {
+        probe_watchdog_provisioned(job, domain_override.as_deref())
+    }))
 }
 
 #[cfg(test)]
@@ -1251,5 +1652,315 @@ mod tests {
 
         // Unset defers to the marker.
         assert_eq!(parse_launchd_override(None), None);
+    }
+
+    // ===================================================================
+    // Watchdog protection state (#4354)
+    // ===================================================================
+
+    /// Deterministic protection env: no overrides, non-Darwin (so the systemd
+    /// timer branch is selected regardless of the host the tests run on).
+    fn protection_env() -> ProtectionEnv {
+        ProtectionEnv {
+            watchdog_label_override: None,
+            launchd_label_override: None,
+            systemd_unit_override: None,
+            launchd_domain_override: None,
+            launchd_override: None,
+            is_darwin: false,
+        }
+    }
+
+    fn darwin_protection_env() -> ProtectionEnv {
+        ProtectionEnv {
+            is_darwin: true,
+            ..protection_env()
+        }
+    }
+
+    #[test]
+    fn protection_marker_present_and_watchdog_provisioned_is_protected() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = write_marker(dir.path(), "use_launchd=false\n");
+        let report = classify_protection(dir.path(), &marker, &protection_env(), |_| Some(true));
+        assert_eq!(report.state, ProtectionState::Protected);
+        assert!(report.marker_present);
+        assert_eq!(report.watchdog_provisioned, Some(true));
+        assert!(report.detail.contains("is provisioned"), "{}", report.detail);
+    }
+
+    #[test]
+    fn protection_marker_absent_is_no_marker_even_when_watchdog_provisioned() {
+        // The #4331 state: the watchdog job exists and fires on cadence, but with
+        // no marker it logs "nothing to check" — protection is disarmed. The
+        // verdict must say so, while still reporting the watchdog fact (AC1).
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join(MARKER_FILENAME);
+        let report = classify_protection(dir.path(), &marker, &protection_env(), |_| Some(true));
+        assert_eq!(report.state, ProtectionState::NoMarker);
+        assert!(!report.marker_present);
+        assert_eq!(report.watchdog_provisioned, Some(true));
+        assert!(report.detail.contains("DISARMED"), "{}", report.detail);
+        assert!(report.detail.contains("IS provisioned"), "{}", report.detail);
+        assert_eq!(
+            ProtectionState::NoMarker.description(),
+            "unprotected — no autonomy-desired marker"
+        );
+    }
+
+    #[test]
+    fn protection_marker_absent_and_watchdog_absent_reports_both_facts() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join(MARKER_FILENAME);
+        let report = classify_protection(dir.path(), &marker, &protection_env(), |_| Some(false));
+        assert_eq!(report.state, ProtectionState::NoMarker);
+        assert_eq!(report.watchdog_provisioned, Some(false));
+        assert!(report.detail.contains("not provisioned either"), "{}", report.detail);
+    }
+
+    #[test]
+    fn protection_marker_present_watchdog_absent_is_watchdog_not_provisioned() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = write_marker(dir.path(), "use_launchd=false\n");
+        let report = classify_protection(dir.path(), &marker, &protection_env(), |_| Some(false));
+        assert_eq!(report.state, ProtectionState::WatchdogNotProvisioned);
+        assert_eq!(report.watchdog_provisioned, Some(false));
+        assert_eq!(
+            ProtectionState::WatchdogNotProvisioned.description(),
+            "watchdog job not provisioned"
+        );
+    }
+
+    #[test]
+    fn protection_undeterminable_probe_degrades_to_unknown() {
+        // AC4: never fail, never guess — an unanswerable provisioning probe is
+        // `unknown`, not a false "not provisioned".
+        let dir = tempfile::tempdir().unwrap();
+        let marker = write_marker(dir.path(), "use_launchd=false\n");
+        let report = classify_protection(dir.path(), &marker, &protection_env(), |_| None);
+        assert_eq!(report.state, ProtectionState::Unknown);
+        assert!(report.watchdog_provisioned.is_none());
+        assert!(report.detail.contains("could not be probed"), "{}", report.detail);
+    }
+
+    #[test]
+    fn protection_state_taxonomy_strings_are_stable() {
+        assert_eq!(ProtectionState::Protected.as_str(), "protected");
+        assert_eq!(ProtectionState::NoMarker.as_str(), "no-marker");
+        assert_eq!(ProtectionState::WatchdogNotProvisioned.as_str(), "watchdog-not-provisioned");
+        assert_eq!(ProtectionState::Unknown.as_str(), "unknown");
+        assert_eq!(ProtectionState::Protected.description(), "protected");
+        assert_eq!(ProtectionState::Unknown.description(), "unknown");
+    }
+
+    #[test]
+    fn watchdog_job_defaults_mirror_the_start_script() {
+        // Darwin: `<daemon label>-watchdog` (loom-daemon-start.sh:511).
+        let job = resolve_watchdog_job(true, DEFAULT_LAUNCHD_LABEL, &darwin_protection_env());
+        assert_eq!(
+            job,
+            WatchdogJob::Launchd {
+                label: "com.rjwalters.loom-daemon-watchdog".to_string()
+            }
+        );
+        assert_eq!(job.kind_str(), "launchd");
+
+        // systemd: `<daemon unit%.service>-watchdog.timer` (…:596).
+        let job = resolve_watchdog_job(false, DEFAULT_LAUNCHD_LABEL, &protection_env());
+        assert_eq!(
+            job,
+            WatchdogJob::SystemdTimer {
+                timer_unit: "loom-daemon-watchdog.timer".to_string()
+            }
+        );
+        assert_eq!(job.kind_str(), "systemd-timer");
+        assert_eq!(job.identifier(), "loom-daemon-watchdog.timer");
+    }
+
+    #[test]
+    fn watchdog_label_env_override_is_honored_on_both_platforms() {
+        // AC3: LOOM_WATCHDOG_LABEL wins over the derived name, exactly as
+        // `resolve_watchdog_label` / `resolve_systemd_watchdog_unit` do.
+        let mut env = darwin_protection_env();
+        env.watchdog_label_override = Some("com.example.custom-wd".to_string());
+        assert_eq!(
+            resolve_watchdog_job(true, DEFAULT_LAUNCHD_LABEL, &env),
+            WatchdogJob::Launchd {
+                label: "com.example.custom-wd".to_string()
+            }
+        );
+
+        let mut env = protection_env();
+        env.watchdog_label_override = Some("my-wd".to_string());
+        assert_eq!(
+            resolve_watchdog_job(false, DEFAULT_LAUNCHD_LABEL, &env),
+            WatchdogJob::SystemdTimer {
+                timer_unit: "my-wd.timer".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn watchdog_job_derives_from_the_daemon_label_and_unit_overrides() {
+        // launchd: the derivation base is the *already-resolved* daemon label
+        // `resolve_watchdog_job` is handed — `LOOM_LAUNCHD_LABEL`'s precedence
+        // over the marker is applied one level up, in `classify_protection` (see
+        // `protection_launchd_label_override_beats_the_marker_label` below).
+        assert_eq!(
+            resolve_watchdog_job(true, "com.example.loom-daemon", &darwin_protection_env()),
+            WatchdogJob::Launchd {
+                label: "com.example.loom-daemon-watchdog".to_string()
+            }
+        );
+
+        // systemd: `LOOM_SYSTEMD_UNIT` is the derivation base, with `.service`
+        // stripped before the `-watchdog` suffix (loom-daemon-start.sh:596).
+        let mut env = protection_env();
+        env.systemd_unit_override = Some("loom-scratch.service".to_string());
+        assert_eq!(
+            resolve_watchdog_job(false, DEFAULT_LAUNCHD_LABEL, &env),
+            WatchdogJob::SystemdTimer {
+                timer_unit: "loom-scratch-watchdog.timer".to_string()
+            }
+        );
+        // A unit name with no `.service` suffix is left verbatim, matching
+        // `resolve_systemd_unit`'s documented no-normalization rule.
+        let mut env = protection_env();
+        env.systemd_unit_override = Some("loom-scratch".to_string());
+        assert_eq!(
+            resolve_watchdog_job(false, DEFAULT_LAUNCHD_LABEL, &env),
+            WatchdogJob::SystemdTimer {
+                timer_unit: "loom-scratch-watchdog.timer".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn protection_launchd_label_override_beats_the_marker_label() {
+        // AC3: `LOOM_LAUNCHD_LABEL` wins over the marker's recorded
+        // `launchd_label`, mirroring the watchdog's env-wins-over-marker rule —
+        // so the derived `<label>-watchdog` job probed is the env one.
+        let dir = tempfile::tempdir().unwrap();
+        let marker =
+            write_marker(dir.path(), "use_launchd=true\nlaunchd_label=com.example.from-marker\n");
+        let mut env = darwin_protection_env();
+        env.launchd_label_override = Some("com.example.from-env".to_string());
+        let mut probed = None;
+        let _ = classify_protection(dir.path(), &marker, &env, |job| {
+            probed = Some(job.clone());
+            Some(true)
+        });
+        assert_eq!(
+            probed,
+            Some(WatchdogJob::Launchd {
+                label: "com.example.from-env-watchdog".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn protection_marker_launchd_label_feeds_the_watchdog_label_on_darwin() {
+        // With no LOOM_LAUNCHD_LABEL override, the *marker's* recorded label is
+        // the derivation base — so a host started under a custom label probes the
+        // matching watchdog job, not the default one.
+        let dir = tempfile::tempdir().unwrap();
+        let marker =
+            write_marker(dir.path(), "use_launchd=true\nlaunchd_label=com.example.alt-daemon\n");
+        let mut probed = None;
+        let report = classify_protection(dir.path(), &marker, &darwin_protection_env(), |job| {
+            probed = Some(job.clone());
+            Some(true)
+        });
+        assert_eq!(report.state, ProtectionState::Protected);
+        assert_eq!(
+            probed,
+            Some(WatchdogJob::Launchd {
+                label: "com.example.alt-daemon-watchdog".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn protection_non_darwin_never_probes_a_launchd_job() {
+        // Even a marker claiming launchd resolves to the systemd timer on a
+        // non-Darwin host — the "launchctl absent on Linux falls through to the
+        // systemd probe" edge case, resolved before any probe is attempted.
+        let dir = tempfile::tempdir().unwrap();
+        let marker =
+            write_marker(dir.path(), "use_launchd=true\nlaunchd_label=com.example.alt-daemon\n");
+        let mut probed = None;
+        let report = classify_protection(dir.path(), &marker, &protection_env(), |job| {
+            probed = Some(job.clone());
+            Some(false)
+        });
+        assert_eq!(report.state, ProtectionState::WatchdogNotProvisioned);
+        assert_eq!(
+            probed,
+            Some(WatchdogJob::SystemdTimer {
+                timer_unit: "loom-daemon-watchdog.timer".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn protection_env_launchd_override_forces_the_systemd_probe_on_darwin() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = write_marker(dir.path(), "use_launchd=true\n");
+        let mut env = darwin_protection_env();
+        env.launchd_override = Some(false);
+        let mut probed = None;
+        let _ = classify_protection(dir.path(), &marker, &env, |job| {
+            probed = Some(job.clone());
+            Some(true)
+        });
+        assert!(
+            matches!(probed, Some(WatchdogJob::SystemdTimer { .. })),
+            "LOOM_DAEMON_LAUNCHD=0 must force the pid-file/systemd side: {probed:?}"
+        );
+    }
+
+    #[test]
+    fn protection_report_records_the_marker_path_it_checked() {
+        // AC3: the reported path is whatever was resolved (a
+        // LOOM_AUTONOMY_MARKER override lands here verbatim via
+        // `probe_protection`), so an operator can confirm which file was read.
+        let dir = tempfile::tempdir().unwrap();
+        let custom = dir.path().join("custom-autonomy-marker");
+        fs::write(&custom, "use_launchd=false\n").unwrap();
+        let report = classify_protection(dir.path(), &custom, &protection_env(), |_| Some(true));
+        assert_eq!(report.marker_path, custom);
+        assert!(report.detail.contains("custom-autonomy-marker"), "{}", report.detail);
+    }
+
+    #[test]
+    fn protection_marker_resolution_honors_the_autonomy_marker_override() {
+        // The module's resolver now delegates to `autonomy_marker` (#4354) — this
+        // pins that the delegation preserves both the default and the override
+        // behavior. Env is read process-globally, so assert the default here and
+        // rely on `autonomy_marker`'s own override coverage for the env case.
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            resolve_marker_path(dir.path()),
+            crate::autonomy_marker::resolve_marker_path(dir.path())
+        );
+    }
+
+    #[test]
+    fn protection_probe_never_panics_against_the_real_host() {
+        // AC4 (read-only, never fails): the production entry point must return a
+        // report (or `None` when no loom dir resolves) on ANY host — with or
+        // without launchctl/systemctl, with or without a marker.
+        if let Some(report) = probe_protection() {
+            // Whatever the host looks like, the verdict is one of the four and
+            // the detail is non-empty.
+            assert!(matches!(
+                report.state,
+                ProtectionState::Protected
+                    | ProtectionState::NoMarker
+                    | ProtectionState::WatchdogNotProvisioned
+                    | ProtectionState::Unknown
+            ));
+            assert!(!report.detail.is_empty());
+        }
     }
 }

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -3823,10 +3823,32 @@ async fn handle_status_command(json: bool, pipeline: bool) -> Result<()> {
         None
     };
 
+    // Watchdog protection state (#4354, AC4 of #4331) — the REACHABLE-path
+    // counterpart to the `install_state` classification above. A healthy daemon
+    // answering over IPC can still be unprotected: no autonomy-desired marker
+    // (crash protection disarmed) or no watchdog job/timer provisioned (nothing
+    // scheduled to notice a future death). Both facts are host-local and visible
+    // to this CLI process, so nothing is plumbed through the IPC report.
+    // Read-only, and never fails the command: an unanswerable probe degrades to
+    // `unknown` and `status` still exits 0.
+    let protection = daemon_install_state::probe_protection();
+
     if json {
-        print_status_json(&report, token_usage.as_ref(), &update, pipeline_snapshots.as_deref())?;
+        print_status_json(
+            &report,
+            token_usage.as_ref(),
+            &update,
+            pipeline_snapshots.as_deref(),
+            protection.as_ref(),
+        )?;
     } else {
-        print_status_human(&report, token_usage.as_ref(), &update, pipeline_snapshots.as_deref());
+        print_status_human(
+            &report,
+            token_usage.as_ref(),
+            &update,
+            pipeline_snapshots.as_deref(),
+            protection.as_ref(),
+        );
     }
     Ok(())
 }
@@ -3909,8 +3931,18 @@ async fn collect_local_fleet_report() -> loom_daemon::fleet::status::HostReport 
         Ok(daemon_report) => {
             let token_usage = collect_token_usage(daemon_report.token_pool_dir.as_deref());
             let update = self_update::check();
-            let value =
-                build_status_json_value(&daemon_report, token_usage.as_ref(), &update, None);
+            // Same host-local protection probe the reachable `status` path runs
+            // (#4354), so the local fleet row carries the `protection` field a
+            // remote host's own `status --json` would self-report — payload-shape
+            // parity is the whole point of sharing this builder.
+            let protection = daemon_install_state::probe_protection();
+            let value = build_status_json_value(
+                &daemon_report,
+                token_usage.as_ref(),
+                &update,
+                None,
+                protection.as_ref(),
+            );
             HostReport::local_up(value)
         }
         Err(e) => {
@@ -4201,6 +4233,7 @@ fn build_status_json_value(
     token_usage: Option<&serde_json::Value>,
     update: &self_update::SelfUpdateStatus,
     pipeline: Option<&[loom_daemon::pipeline_snapshot::RepoPipelineSnapshot]>,
+    protection: Option<&daemon_install_state::ProtectionReport>,
 ) -> serde_json::Value {
     let rc = resolve_capacity(report, token_usage);
     serde_json::json!({
@@ -4394,6 +4427,24 @@ fn build_status_json_value(
             "socket": s.socket,
             "room": s.room,
         })),
+        // Watchdog protection state (#4354) — client-side, host-local, read-only.
+        // `state` is one of "protected" / "no-marker" /
+        // "watchdog-not-provisioned" / "unknown". `marker_present` and
+        // `watchdog_provisioned` carry the two underlying facts separately, so a
+        // consumer can see BOTH even though `state` names only the dominant one
+        // (a missing marker outranks the watchdog fact). `null` only when no loom
+        // dir could be resolved at all.
+        "protection": protection.map(|p| serde_json::json!({
+            "state": p.state.as_str(),
+            "marker_present": p.marker_present,
+            "marker_path": p.marker_path.display().to_string(),
+            "watchdog_job": p.job.identifier(),
+            "watchdog_job_kind": p.job.kind_str(),
+            // `null` ⇒ the provisioning probe could not answer (no
+            // launchctl/systemctl, or an unreachable `systemctl --user` bus).
+            "watchdog_provisioned": p.watchdog_provisioned,
+            "detail": p.detail,
+        })),
     })
 }
 
@@ -4403,8 +4454,9 @@ fn print_status_json(
     token_usage: Option<&serde_json::Value>,
     update: &self_update::SelfUpdateStatus,
     pipeline: Option<&[loom_daemon::pipeline_snapshot::RepoPipelineSnapshot]>,
+    protection: Option<&daemon_install_state::ProtectionReport>,
 ) -> Result<()> {
-    let combined = build_status_json_value(report, token_usage, update, pipeline);
+    let combined = build_status_json_value(report, token_usage, update, pipeline, protection);
     println!("{}", serde_json::to_string_pretty(&combined)?);
     Ok(())
 }
@@ -4619,6 +4671,7 @@ fn print_status_human(
     token_usage: Option<&serde_json::Value>,
     update: &self_update::SelfUpdateStatus,
     pipeline: Option<&[loom_daemon::pipeline_snapshot::RepoPipelineSnapshot]>,
+    protection: Option<&daemon_install_state::ProtectionReport>,
 ) {
     println!("\n=== Loom Autonomous Daemon Status ===\n");
 
@@ -4935,6 +4988,41 @@ fn print_status_human(
         Some(_) => println!("Safehouse:     not configured"),
         None => {
             println!("Safehouse:     unknown (older daemon binary — restart to pick up #4345)")
+        }
+    }
+
+    // Watchdog protection state (#4354): this daemon is answering, so it is
+    // alive — but is anything positioned to notice when it *stops* being? Before
+    // this line an operator had to read `daemon-watchdog.log` or poke
+    // `launchctl`/`systemctl` by hand to find out. Client-side, read-only, and
+    // never fatal: `unknown` when the provisioning probe cannot answer, and this
+    // line is simply omitted when no loom dir resolved at all.
+    if let Some(p) = protection {
+        println!("Protection:    {}", p.state.description());
+        println!("               {}", p.detail);
+        match p.state {
+            daemon_install_state::ProtectionState::NoMarker => {
+                // The #4331 state. A supervised daemon self-heals the marker at
+                // startup, so seeing this on a supervised host means the marker
+                // went away *after* boot — a restart re-arms it.
+                println!(
+                    "               Crash protection is DISARMED — the watchdog will log \
+                     \"nothing to check\"."
+                );
+                println!("               Re-arm with a supervised restart:");
+                println!("                 ./.loom/scripts/cli/loom-daemon-stop.sh && ./.loom/scripts/cli/loom-daemon-start.sh");
+            }
+            daemon_install_state::ProtectionState::WatchdogNotProvisioned => {
+                println!("               Nothing is scheduled to detect a future daemon death.");
+                println!(
+                    "               Re-provision it (the start script installs the watchdog job):"
+                );
+                println!("                 ./.loom/scripts/cli/loom-daemon-start.sh");
+            }
+            // Protected / Unknown: no remediation — `unknown` is a probe
+            // limitation on this host, not evidence of a fault, so steering the
+            // operator into a restart for it would be the #4213 ghost-chase.
+            _ => {}
         }
     }
 
@@ -7841,7 +7929,11 @@ mod status_client_tests {
     /// A fully-populated report the fake daemon can serialize back to the client
     /// on a successful round-trip. Every field is compiler-checked, so a schema
     /// change surfaces here rather than as a silently-skewed wire payload.
-    fn sample_report() -> DaemonStatusReport {
+    ///
+    /// `pub(super)` so the reachable-path status-rendering tests (#4354) build
+    /// their payload from this same fixture instead of duplicating the whole
+    /// struct.
+    pub(super) fn sample_report() -> DaemonStatusReport {
         DaemonStatusReport {
             in_flight: vec![],
             unregistered_locked: vec![],
@@ -7990,5 +8082,139 @@ mod status_client_tests {
             elapsed < Duration::from_secs(2),
             "absent-socket path took too long: {elapsed:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod status_protection_tests {
+    //! Reachable-path watchdog-protection surfacing (#4354, AC4 of #4331).
+    //!
+    //! These tests pin the `--json` contract for the `protection` object and the
+    //! deliberate separation from the unreachable path's `install_state` block
+    //! (#4069): the reachable payload carries `protection` and never
+    //! `install_state`, and `protection` is wire-compatible-nullable so a host
+    //! where no loom dir resolves still emits a well-formed payload.
+    use super::build_status_json_value;
+    use super::status_client_tests::sample_report;
+    use loom_daemon::daemon_install_state::{ProtectionReport, ProtectionState, WatchdogJob};
+    use std::path::PathBuf;
+
+    fn protection(
+        state: ProtectionState,
+        marker_present: bool,
+        watchdog_provisioned: Option<bool>,
+    ) -> ProtectionReport {
+        ProtectionReport {
+            state,
+            marker_present,
+            marker_path: PathBuf::from("/home/u/.loom/autonomy-desired"),
+            job: WatchdogJob::SystemdTimer {
+                timer_unit: "loom-daemon-watchdog.timer".to_string(),
+            },
+            watchdog_provisioned,
+            detail: "fixture detail".to_string(),
+        }
+    }
+
+    /// The `update` argument's fixture — an "unknown" self-update status is
+    /// enough for these tests (they assert only on the `protection` object).
+    fn no_update() -> loom_daemon::self_update::SelfUpdateStatus {
+        loom_daemon::self_update::SelfUpdateStatus {
+            built_commit: "abc1234".to_string(),
+            source_commit: None,
+            update_available: None,
+        }
+    }
+
+    #[test]
+    fn protection_object_is_emitted_on_the_reachable_path() {
+        let report = sample_report();
+        let value = build_status_json_value(
+            &report,
+            None,
+            &no_update(),
+            None,
+            Some(&protection(ProtectionState::Protected, true, Some(true))),
+        );
+        let p = &value["protection"];
+        assert_eq!(p["state"], "protected");
+        assert_eq!(p["marker_present"], true);
+        assert_eq!(p["marker_path"], "/home/u/.loom/autonomy-desired");
+        assert_eq!(p["watchdog_job"], "loom-daemon-watchdog.timer");
+        assert_eq!(p["watchdog_job_kind"], "systemd-timer");
+        assert_eq!(p["watchdog_provisioned"], true);
+        assert_eq!(p["detail"], "fixture detail");
+    }
+
+    #[test]
+    fn protection_object_carries_both_facts_for_the_no_marker_verdict() {
+        // `state` names the dominant fact (no marker), but a consumer must still
+        // be able to read the watchdog fact independently (#4354 AC1: "both
+        // should be reported").
+        let value = build_status_json_value(
+            &sample_report(),
+            None,
+            &no_update(),
+            None,
+            Some(&protection(ProtectionState::NoMarker, false, Some(true))),
+        );
+        let p = &value["protection"];
+        assert_eq!(p["state"], "no-marker");
+        assert_eq!(p["marker_present"], false);
+        assert_eq!(p["watchdog_provisioned"], true);
+    }
+
+    #[test]
+    fn protection_watchdog_not_provisioned_and_unknown_serialize_distinctly() {
+        let not_provisioned = build_status_json_value(
+            &sample_report(),
+            None,
+            &no_update(),
+            None,
+            Some(&protection(ProtectionState::WatchdogNotProvisioned, true, Some(false))),
+        );
+        assert_eq!(not_provisioned["protection"]["state"], "watchdog-not-provisioned");
+        assert_eq!(not_provisioned["protection"]["watchdog_provisioned"], false);
+
+        // An unanswerable probe is `unknown` with a NULL provisioning fact —
+        // never `false` (AC4: degrade, never mis-report).
+        let unknown = build_status_json_value(
+            &sample_report(),
+            None,
+            &no_update(),
+            None,
+            Some(&protection(ProtectionState::Unknown, true, None)),
+        );
+        assert_eq!(unknown["protection"]["state"], "unknown");
+        assert!(unknown["protection"]["watchdog_provisioned"].is_null());
+    }
+
+    #[test]
+    fn protection_is_null_when_no_report_could_be_built() {
+        // No loom dir resolvable ⇒ the field is present but null, so the payload
+        // stays well-formed for consumers that always read it.
+        let value = build_status_json_value(&sample_report(), None, &no_update(), None, None);
+        assert!(value["protection"].is_null());
+    }
+
+    #[test]
+    fn reachable_payload_never_carries_the_unreachable_install_state_block() {
+        // #4069 regression guard: `install_state` (with its exit-code semantics)
+        // belongs to the unreachable `Err` arm ONLY. Protection is a sibling
+        // classification, so adding it must not leak `install_state` into the
+        // reachable payload — nor gain an exit code of its own (the reachable
+        // path always exits 0).
+        let value = build_status_json_value(
+            &sample_report(),
+            None,
+            &no_update(),
+            None,
+            Some(&protection(ProtectionState::NoMarker, false, Some(false))),
+        );
+        assert!(
+            value.get("install_state").is_none(),
+            "install_state must stay on the unreachable path only"
+        );
+        assert!(value.get("protection").is_some());
     }
 }


### PR DESCRIPTION
## Summary

`loom-daemon status` classified daemon install state **only** on the IPC-unreachable path (#4069), so a healthy, reachable daemon never reported whether it was actually *protected*. An operator could not tell from `status` alone that a running daemon had **no autonomy-desired marker** (crash protection disarmed — the #4331 state) or **no watchdog job/timer provisioned** (nothing scheduled to detect a future death); finding out meant reading `daemon-watchdog.log` or poking `launchctl`/`systemctl` by hand.

This adds a `ProtectionState` **sibling** classification and wires it into the reachable (`Ok`) arm of `handle_status_command`, in both the human and `--json` views.

## Changes

**`loom-daemon/src/daemon_install_state.rs`**
- New `ProtectionState` (`Protected` / `NoMarker` / `WatchdogNotProvisioned` / `Unknown`), `WatchdogJob`, `ProtectionReport`, `ProtectionEnv`, `resolve_watchdog_job()`, `classify_protection()` (provisioning check injected — the same testability seam `classify()` uses for process age) and the production `probe_protection()`.
- **Deliberately NOT new `InstallState` variants**: those carry the unreachable path's exit-code mappings (#4069) that AC4 says must not change. The reachable path always exits 0 regardless of protection state.
- Marker resolution now **delegates** to `autonomy_marker::resolve_marker_path` (#4331/#4355) instead of keeping a second copy of the `LOOM_AUTONOMY_MARKER` rule, so the healer, the watchdog, and both `status` paths can never resolve the marker differently.
- Watchdog job identifier mirrors `loom-daemon-start.sh` exactly: launchd `${LOOM_WATCHDOG_LABEL:-<daemon-label>-watchdog}` probed via `launchctl print <domain>/<label>` in the `resolve_launchd_domain` domain (`LOOM_LAUNCHD_DOMAIN` → `gui/<uid>` → `user/<uid>`); systemd `${LOOM_WATCHDOG_LABEL:-<LOOM_SYSTEMD_UNIT%.service>-watchdog}.timer` probed via `systemctl --user is-enabled`.

**`loom-daemon/src/main.rs`**
- `handle_status_command`'s reachable arm runs `probe_protection()` and passes it to both printers.
- Human: `Protection:    <phrase>` + a detail line, plus remediation for the two actionable states only (`protected`/`unknown` print none — `unknown` is a probe limitation, not evidence of a fault, so steering into a restart would be the #4213 ghost-chase).
- `--json`: a `protection` object (`state`, `marker_present`, `marker_path`, `watchdog_job`, `watchdog_job_kind`, `watchdog_provisioned`, `detail`), `null` when no loom dir resolves. `fleet status`'s local-host row gets the same field via the shared `build_status_json_value`.

**`defaults/docs/daemon-reference.md`** — a "Fourth consumer: `status`'s REACHABLE path" subsection extending the #4011/#4069 status table: the three-state (plus `unknown`) table, both-facts-always-reported rule, input resolution, and the read-only/never-fails contract. (Only the `defaults/` copy — the installed `.loom/docs/` copy follows via resync, matching recent commits on this file.)

## Design notes

- **State precedence when both facts are bad**: `state` is `no-marker` (the stronger statement — even a provisioned watchdog is inert without a marker), while `watchdog_provisioned` still records the second fact, so `--json` and the human detail line report **both** (AC1's "both should be reported").
- **`enabled`/`enabled-runtime` ⇒ provisioned**; any other `is-enabled` verdict (`disabled`, `static`, `masked`, `not-found`) ⇒ not provisioned, collapsing "present but disabled" and "absent" into the same operator-relevant answer (neither will fire). A `Failed to connect to bus` / missing binary / undeterminable domain ⇒ `unknown`, never a false "not provisioned".
- **Non-Darwin never resolves a launchd job** (the same non-Darwin blanket override the unreachable path applies), so `launchctl`'s absence on Linux is never consulted — the curator's "falls through to the systemd probe" edge case is resolved before any probe runs.
- `classify_protection` takes `FnMut` (not `Fn`) so a test's injected probe can record which job it was asked about; production calls it exactly once.

## Acceptance Criteria Verification

- [x] **`status` (human + `--json`) prints a protection line/field** with `protected` / `unprotected — no autonomy-desired marker` / `watchdog job not provisioned` — verified against this host's live daemon (see Test Plan).
- [x] **Runs on the reachable path**, not only the `Err` arm — `probe_protection()` is called in `handle_status_command`'s `Ok` branch; a small refactor added the sibling probe rather than extending `daemon_install_state`'s unreachable-only verdicts, plus a client-side `launchctl print` / `systemctl --user is-enabled` provisioning probe.
- [x] **Respects `LOOM_AUTONOMY_MARKER` / `LOOM_WATCHDOG_LABEL`** (and `LOOM_LAUNCHD_LABEL` / `LOOM_SYSTEMD_UNIT` / `LOOM_LAUNCHD_DOMAIN` / `LOOM_DAEMON_LAUNCHD`), mirroring the watchdog's resolution — unit tests + live end-to-end runs below.
- [x] **Read-only, never fails the command** (degrades to `unknown`), and **does not regress the unreachable-path `install_state` output** (#4069) — verified: `install_state` payload byte-identical, exit `1` for `not-expected`; a dedicated test asserts the reachable payload never carries `install_state`.
- [x] **Rust tests for the new classification + `--json` field** — 16 new tests (11 classification/resolution in `daemon_install_state`, 5 `--json` in a new `status_protection_tests` module).

## Test Plan

**Automated** (`cargo test -p loom-daemon`): 2179 lib + 42 bin tests pass, including the 16 new ones — all four protection states with an injected provisioning result; `LOOM_WATCHDOG_LABEL` / `LOOM_LAUNCHD_LABEL` (env beats marker) / `LOOM_SYSTEMD_UNIT` overrides; marker-`launchd_label`-feeds-watchdog-label; non-Darwin never probes launchd; `LOOM_DAEMON_LAUNCHD=0` forces the systemd side; `.service`-suffix-optional unit names; `--json` field shape for all four states incl. `watchdog_provisioned: null` for `unknown` and `protection: null` when no report; `install_state`-absence regression; and a never-panics smoke against the real host.

`cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo check --workspace` are all clean.

**Manual end-to-end** against this host's live (reachable) daemon, all exiting `0`:

| Scenario | Result |
|---|---|
| real host (marker absent, no watchdog timer) | `unprotected — no autonomy-desired marker`, `watchdog_provisioned: false` — both facts reported |
| `LOOM_AUTONOMY_MARKER=<tmp marker>` + `LOOM_WATCHDOG_LABEL=<an enabled user timer>` | `protected` |
| marker present, `LOOM_WATCHDOG_LABEL` → a `disabled` timer | `watchdog-not-provisioned` |
| marker present, watchdog timer `not-found` | `watchdog-not-provisioned` |
| marker present, `PATH=/nonexistent` (no `systemctl`) | `unknown`, `watchdog_provisioned: null` |
| `LOOM_SYSTEMD_UNIT=loom-scratch.service` | probes `loom-scratch-watchdog.timer` |
| `LOOM_SOCKET_PATH=<missing>` (unreachable path) | unchanged `install_state: not-expected`, exit `1`, no `protection` key |

## Notes for the reviewer

- **Not tested on macOS** — no Darwin host available. The launchd branch is covered by unit tests with an injected probe and by label/domain-resolution tests, but `launchctl print` was not exercised live.
- **Pre-existing, unrelated failures on this host** (present before this change, untouched by it): `.loom/scripts/build-gate.sh`'s final step needs `uv`, which is not installed here (the Rust steps it runs — fmt, clippy, check, `cargo test --workspace --lib --bins` — all pass); and 3 host-dependent integration targets (`integration_basic::test_ping_pong` / `test_send_input`, `integration_security::test_reject_empty_id`, `integration_singleton_guard`) fail on tmux/socket-timing, which is exactly why build-gate scopes itself to `--lib --bins` (CI-only per #3985).
- **Deliberately left alone**: the existing `launchctl_pid()` on the unreachable path still hardcodes `gui/<uid>` rather than using `resolve_launchd_domain` (a pre-#4130-style inconsistency). My new probe mirrors `resolve_launchd_domain` as the curator specified, but changing `launchctl_pid` would alter unreachable-path behavior, which AC4 forbids. Worth a separate issue if you agree.

Closes #4354