### PR TITLE
fix(daemon): gate mid-build worktree reset on a live-use veto; guard worktree.sh remove

### DIFF
--- a/.loom/docs/safehouse.md
+++ b/.loom/docs/safehouse.md
@@ -95,7 +95,7 @@ personas (`loom_builder_42`) are blocked upstream until safehoused grows prefix
 support and are tracked in #3999 — do not attempt to register personas at
 dispatch time; there is no such path.
 
-## Connection status: not configured / unreachable / connected (#4345)
+## Connection status: not configured / unreachable / connected / send-rejected (#4345, #4464)
 
 Before #4345, `safehouse.enabled` false/absent, enabled-but-unreachable, and
 enabled-and-connected all looked identical to an operator — silence. Two
@@ -117,6 +117,16 @@ surfaces now report the live state:
     (`safehouse.room` unset is valid only when safehoused joined exactly one
     room, resolved server-side — the daemon is never told that resolved name,
     so the line omits it rather than guessing).
+  - `connected, sends rejected: <reason>` (#4464) — the `hello` handshake
+    succeeds (the socket is reachable) but every `send` is rejected at the
+    protocol layer, so nothing reaches the room. The canonical cause is a
+    **multi-room safehoused with `safehouse.room` unset**: safehoused replies
+    `'room' required: N rooms joined` and the fix is to set `safehouse.room`
+    (see the troubleshooting entry below). This state is **sticky** — a
+    reconnect whose `hello` succeeds does not clear it; only a `send` that is
+    actually accepted returns the line to `connected`. Distinct from
+    `unreachable` on purpose: "unreachable" would send an operator chasing the
+    socket/persona instead of the config.
 - **`loom-daemon-start.sh`** prints a cheaper, **static**, pre-connect check at
   start time (`ok`/`warn` colored, one line): it runs *before* the daemon
   connects, so it can only distinguish "not configured" from "configured" —
@@ -138,6 +148,26 @@ daemon's wire payload — missing the field entirely — still parses).
 `loom-daemon-start.sh`'s static check reuses the same env>config>default
 resolvers `lib/mcp-config.sh` already defines for the safehouse-mcp worker
 injection (phase 2, below) rather than re-deriving them.
+
+### Troubleshooting: `'room' required` rejection (multi-room host) (#4464)
+
+**Symptom.** `loom-daemon status` shows `Safehouse: connected, sends rejected:
+'room' required: N rooms joined`, and the daemon log carries
+`[WARN] safehouse: narration rejected — set safehouse.room — safehoused
+rejected send: 'room' required: …`. Sweeps proceed normally (the degradation
+contract holds), but the room shows nothing from this host and peer-claim dedup
+(#4028/#4431) is silently disabled here.
+
+**Cause.** Omitting `safehouse.room` is valid **only when safehoused joined
+exactly one room** — safehoused then resolves the sole room server-side. Once
+safehoused joins two or more rooms it can no longer guess, so it rejects every
+`send` that does not name a `room`.
+
+**Fix.** Set `safehouse.room` in `.loom/config.json` (or `LOOM_SAFEHOUSE_ROOM`)
+to the room this host should narrate into, then restart the daemon
+(`loom-daemon restart`). The status line returns to `connected` on the first
+accepted send. `loom-daemon-start.sh` also prints a static caveat at start time
+whenever a socket is configured but `safehouse.room` is unset.
 
 ## New-host onboarding (#4345, #4346)
 

--- a/.loom/docs/token-pool.md
+++ b/.loom/docs/token-pool.md
@@ -521,3 +521,35 @@ refuses to silently auto-clear `.bad_tokens` — that masks real auth problems.
 PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -v
 bash .loom/scripts/tests/test-spawn-claude.sh
 ```
+
+## Codex provider health
+
+Codex profiles use a separate, provider-aware health file at
+`.loom/account-health.json`. Loom never rewrites Claude's `.ranking`,
+`.bad_tokens`, `.failure_counts`, allowlist, or rotation cursor for Codex.
+The health file contains account names and stable reason categories only—never
+`auth.json`, credential contents, or raw child output—and is written atomically
+under a sibling `mkdir` lock.
+
+For managed headless runs, `spawn-codex.sh` asks the native selector for an
+eligible profile and exports that profile as `CODEX_HOME`. Selection excludes
+disabled profiles, persistent `reauth_required` holds, and unexpired cooldowns;
+then prefers fewer recent transient failures and round-robins equal candidates.
+If none are healthy, selection exits closed rather than using ambient
+`~/.codex`.
+
+Terminal policy is intentionally conservative:
+
+- `TOKEN_EXPIRED` requires an explicit verified-reauth clear and never expires
+  merely because time passed or an ordinary success was observed.
+- `TOKEN_EXHAUSTED` cools down for
+  `LOOM_CODEX_EXHAUSTED_COOLDOWN_SECS` (default five hours).
+- `RECOVERABLE` and `SESSION_LIMIT` apply short temporary backoffs.
+- Success records freshness and clears transient counters.
+- Timeouts, fatal/configuration failures, refusals, and deleted-cwd outcomes do
+  not poison account health.
+
+Codex exposes no trustworthy quota-headroom percentage here. Status/capacity
+therefore reports raw, enabled, healthy, cooldown, and reauth-required counts;
+transcript token totals remain observability and are never presented as
+remaining quota. Claude's existing global daemon concurrency cap is unchanged.

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -2207,6 +2207,35 @@ the forge** (best-effort, fail-open on a `gh` error) — this covers all three
 watchdogs, since each re-dispatches through the same method, so no self-heal path
 can ever re-claim a closed/merged issue.
 
+**Mid-build-death live-use veto (#4449).** The mid-build-death watchdog (#3895)
+infers "died mid-build" from `(terminal state ∧ no PR ∧ dirty worktree)` and then
+resets the worktree (`git reset --hard` + `git clean -fd`) before re-dispatching.
+That signature is necessary but **not sufficient**: on 2026-07-29 the daemon's
+tracked sweep for issue #4366 had indeed died, but an *untracked* recovery session
+was concurrently editing the same worktree — and the watchdog destroyed its
+tested-but-uncommitted fix mid `git commit`. `git status` cannot tell dead-sweep
+debris from a live session's work in progress, so the watchdog now also requires
+that **nothing live still holds the worktree**. Four signals veto the reset (any
+one is enough):
+
+| Signal | What it means |
+|--------|---------------|
+| `.loom-in-use` marker in the worktree | A session (including a manual, non-daemon one) claims it. This is the one an operator can plant by hand to fence off a worktree. |
+| `.loom/locks/issue-<N>/owner.json` whose `owner_pid` is **alive** | A live claim holder. A dead owner's lock is ignored, so a stale lock never wedges recovery. |
+| `index.lock` in the worktree's gitdir | A git index write (`git add`/`git commit`) is in flight — precisely the #4449 window. |
+| A live process whose cwd is inside the worktree | An operator shell, a manual role session, or an orphaned grandchild still writing files. |
+
+A veto logs one loud `midbuild-watchdog: … REFUSING to git reset --hard …` line
+naming the holder, leaves the worktree untouched, and **does not consume** the
+single recovery retry — so a genuinely-dead sweep is still recovered on a later
+tick once the holder goes away. If the holder is stale, clear it (remove
+`.loom-in-use` / the claim-lock / the `index.lock`, or exit the shell) and the
+next tick recovers normally. Independently, every `clean_worktree` call now logs
+the porcelain status + diffstat of what it is about to destroy, so a wipe can
+never again be silent in the daemon log. The same defense-in-depth guard exists on
+the script side: `worktree.sh remove <N>` refuses a worktree with uncommitted
+changes and requires an explicit `--force` to discard them.
+
 **Review-phase stall watchdog (#3910).** The startup watchdog rescues a sweep
 that shows *no* progress, and the mid-build-death watchdog (#3895) rescues one
 that made progress then *died*. Neither covers a sweep that is **still alive**

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -509,6 +509,17 @@ print_safehouse_status() {
     fi
     if [[ -S "$socket" ]]; then
         ok "Safehouse:     configured (socket present at $socket) -- see 'loom-daemon status' for live connection state"
+        # #4464: omitting safehouse.room is only valid when safehoused joined
+        # exactly ONE room; on a multi-room host it makes safehoused reject
+        # every send ('room' required) -- which silently kills narration and
+        # peer-claim dedup, and 'loom-daemon status' will show
+        # "connected, sends rejected: ...". Surface the caveat statically here.
+        local room
+        room=$(loom_config_get "$REPO_ROOT" "safehouse.room" "" 2>/dev/null || true)
+        if [[ -z "$room" ]]; then
+            echo "               note: safehouse.room is unset -- valid only if safehoused joined exactly one room;" \
+                 "a multi-room host needs an explicit safehouse.room or every send is rejected"
+        fi
     else
         warn "Safehouse:     configured, unreachable (socket $socket does not exist -- is safehoused running?)"
     fi

--- a/defaults/scripts/spawn-codex.sh
+++ b/defaults/scripts/spawn-codex.sh
@@ -198,6 +198,10 @@ log_warn() { echo -e "${YELLOW}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] WARN${NC} $*" 
 log_error() { echo -e "${RED}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] ERROR${NC} $*" >&2; }
 
 _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "${_SCRIPT_DIR}/lib/locate-daemon-bin.sh" ]]; then
+    # shellcheck source=./lib/locate-daemon-bin.sh
+    source "${_SCRIPT_DIR}/lib/locate-daemon-bin.sh"
+fi
 
 # --- Repo root resolution (handles worktrees; mirrors spawn-claude.sh) ---
 _resolve_workspace() {
@@ -525,6 +529,35 @@ CODEX_PROFILE_NAME=""
 if [[ -n "${LOOM_SPAWN_NO_EXPORT:-}" ]]; then
     log_info "spawn-codex: LOOM_SPAWN_NO_EXPORT set — skipping CODEX_HOME resolution"
 else
+    # A managed headless dispatch with no explicit pin uses the provider-aware
+    # selector. This fails closed when every profile is disabled, cooling down,
+    # or awaiting reauthentication; it never falls back to ambient ~/.codex.
+    if [[ "$HAS_PROMPT" == "true" && -z "${LOOM_CODEX_NO_EXEC:-}" \
+          && -z "${LOOM_CODEX_HOME:-}" \
+          && -z "${CODEX_HOME:-}" && -z "${LOOM_CODEX_PROFILE:-}" ]]; then
+        if ! declare -F loom_locate_daemon_bin >/dev/null 2>&1; then
+            log_error "Provider-aware account selection support is not installed."
+            exit 78
+        fi
+        _daemon_bin="$(loom_locate_daemon_bin "$WORKSPACE")"
+        if [[ -z "$_daemon_bin" ]] \
+            || ! "$_daemon_bin" tokens select --help 2>&1 | grep -q -- '--provider'; then
+            log_error "No loom-daemon binary supporting provider-aware account selection was found."
+            exit 78
+        fi
+        _selection_stderr_file="$(mktemp)"
+        _selection_output=""
+        if ! _selection_output="$("$_daemon_bin" tokens select --provider codex \
+            --workspace "$WORKSPACE" --export 2>"$_selection_stderr_file")"; then
+            log_error "Codex account selection failed:"
+            cat "$_selection_stderr_file" >&2 || true
+            rm -f "$_selection_stderr_file"
+            exit 78
+        fi
+        cat "$_selection_stderr_file" >&2 || true
+        rm -f "$_selection_stderr_file"
+        eval "$_selection_output"
+    fi
     _requested_home=""
     _requested_source=""
     if [[ -n "${LOOM_CODEX_HOME:-}" ]]; then
@@ -543,7 +576,7 @@ else
         _auth_candidate="${_requested_home}/auth.json"
         if [[ -f "$_auth_candidate" && -r "$_auth_candidate" && -s "$_auth_candidate" ]]; then
             export CODEX_HOME="$_requested_home"
-            CODEX_PROFILE_NAME="$(basename "$_requested_home")"
+            CODEX_PROFILE_NAME="${LOOM_ACCOUNT_NAME:-$(basename "$_requested_home")}"
             # Directory NAME only — never the path contents, never auth.json.
             log_info "spawn-codex: using Codex profile '$CODEX_PROFILE_NAME' (source=$_requested_source)"
             echo "# LOOM_ACCOUNT name=$CODEX_PROFILE_NAME" >&2
@@ -662,6 +695,31 @@ _tokens_used="$(
 )"
 if [[ -n "$_tokens_used" ]]; then
     log_info "spawn-codex: tokens_used=$_tokens_used"
+fi
+
+# Stable, bounded terminal feedback for the daemon. The classifier remains the
+# single source of truth; this adapter only packages its result with the
+# provider/account attribution already selected for this child. Raw output is
+# neither included in this record nor persisted by the health layer.
+_classifier_lib="${_SCRIPT_DIR}/lib/classify-error.sh"
+if [[ -f "$_classifier_lib" ]]; then
+    # shellcheck source=./lib/classify-error.sh
+    source "$_classifier_lib"
+    _classifier_input="$(tail -c 65536 "$_stderr_file" 2>/dev/null || true)"
+    _terminal_category="$(classify_error "$_classifier_input" "$_exit_code" codex)"
+    _terminal_account="${LOOM_ACCOUNT_NAME:-${CODEX_PROFILE_NAME:-unknown}}"
+    if [[ ! "$_terminal_account" =~ ^[A-Za-z0-9._-]+$ ]]; then
+        _terminal_account="unknown"
+    fi
+    case "$_terminal_category" in
+        SUCCESS|TOKEN_EXPIRED|TOKEN_EXHAUSTED|RECOVERABLE|TIMEOUT|FATAL|CWD_DELETED|MODEL_REFUSAL|SESSION_LIMIT)
+            printf '# LOOM_TERMINAL_RESULT v=1 provider=codex account=%s category=%s exit_code=%s\n' \
+                "$_terminal_account" "$_terminal_category" "$_exit_code" >&2
+            ;;
+        *)
+            log_warn "spawn-codex: classifier returned an invalid category; terminal feedback omitted"
+            ;;
+    esac
 fi
 
 exit "$_exit_code"

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -703,6 +703,17 @@ EOF
         echo -e "${RED}✗${NC} safehouse: enabled + socket file present -> 'configured (socket present ...)' (#4345)"
         echo "  output: $sh3_out"
     fi
+    # #4464: SH3's config has no `safehouse.room`, so the room-unset caveat MUST
+    # be surfaced (omitting room is valid only for a single-room safehoused).
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if echo "$sh3_out" | grep -q 'safehouse.room is unset'; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} safehouse: room unset -> room caveat surfaced (#4464)"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} safehouse: room unset -> room caveat surfaced (#4464)"
+        echo "  output: $sh3_out"
+    fi
     if [[ -f "$SH3_HOME/.loom/.daemon.pid" ]]; then
         kill "$(cat "$SH3_HOME/.loom/.daemon.pid" 2>/dev/null)" 2>/dev/null || true
     fi
@@ -710,6 +721,44 @@ else
     echo "  (skipping SH3: python3 AF_UNIX bind unavailable on this host)"
 fi
 rm -rf "$SH3_HOME"
+
+# SH4. #4464: same as SH3 but WITH an explicit safehouse.room set -> the caveat
+#      must NOT appear (the single-room contract is satisfied by an explicit room).
+SH4_HOME="$(mktemp -d)"
+mkdir -p "$SH4_HOME/.loom"
+SH4_SOCK="$SH4_HOME/.loom/safehoused.sock"
+if command -v python3 >/dev/null 2>&1 \
+    && python3 -c "
+import socket
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.bind('$SH4_SOCK')
+" 2>/dev/null; then
+    cat > "$SH4_HOME/.loom/config.json" <<EOF
+{"safehouse": {"enabled": true, "socket": "$SH4_SOCK", "room": "loom-fleet"}}
+EOF
+    sh4_out=$( ( cd "$SH4_HOME" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+        -u LOOM_SAFEHOUSE_ENABLED -u LOOM_SAFEHOUSE_SOCKET -u SAFEHOUSED_SOCKET \
+        LOOM_DAEMON_BIN="$SH_BG_FAKE_BIN" \
+        LOOM_SOCKET_PATH="$SH4_HOME/.loom/loom-daemon.sock" \
+        LOOM_AUTONOMY_MARKER="$SH4_HOME/.loom/autonomy-desired" \
+        LOOM_WATCHDOG_LABEL="com.example.loom-sandbox-$$-sh4-watchdog" \
+        bash "$START_SCRIPT" --no-launchd --no-systemd 2>&1 ) )
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if echo "$sh4_out" | grep -q 'safehouse.room is unset'; then
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} safehouse: room set -> no room caveat (#4464)"
+        echo "  output: $sh4_out"
+    else
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} safehouse: room set -> no room caveat (#4464)"
+    fi
+    if [[ -f "$SH4_HOME/.loom/.daemon.pid" ]]; then
+        kill "$(cat "$SH4_HOME/.loom/.daemon.pid" 2>/dev/null)" 2>/dev/null || true
+    fi
+else
+    echo "  (skipping SH4: python3 AF_UNIX bind unavailable on this host)"
+fi
+rm -rf "$SH4_HOME"
 
 # ---------- summary ----------
 echo

--- a/defaults/scripts/tests/test-spawn-codex.sh
+++ b/defaults/scripts/tests/test-spawn-codex.sh
@@ -514,6 +514,7 @@ if [[ -n "\$_stdin" ]]; then echo "MOCK-SAW-STDIN:\$_stdin" >&2; fi
   echo "--------"
   echo "tokens used"
   echo "2,502"
+  [[ -n "\${MOCK_ERROR:-}" ]] && echo "\$MOCK_ERROR"
 } >&2
 echo "MOCK-FINAL-MESSAGE"
 exit "\${MOCK_RC:-0}"
@@ -547,6 +548,10 @@ assert_contains "spawn-codex: session=$MOCK_SESSION" "$mock_stderr" \
     "the 'session id:' line is parsed and reported as the transcript join key"
 assert_contains "spawn-codex: tokens_used=2502" "$mock_stderr" \
     "'tokens used' is parsed (comma-stripped) and reported"
+assert_contains \
+    "# LOOM_TERMINAL_RESULT v=1 provider=codex account=unknown category=SUCCESS exit_code=0" \
+    "$mock_stderr" \
+    "a successful child emits one strict structured terminal record"
 assert_not_contains "MOCK-SAW-STDIN" "$mock_stderr" \
     "the child's stdin is /dev/null (no <stdin> append, no hang)"
 
@@ -565,6 +570,21 @@ run_mock MOCK_RC=42 -- -p "hi" >/dev/null 2>&1
 mock_rc=$?
 set -e
 assert_eq "42" "$mock_rc" "the codex exit code is passed through (PIPESTATUS)"
+
+set +e
+classified_stderr="$({ run_mock MOCK_RC=42 LOOM_ACCOUNT_NAME=profile-a \
+    MOCK_ERROR="Not signed in. recognizable-secret" -- -p "hi" >/dev/null; } 2>&1)"
+classified_rc=$?
+set -e
+assert_eq "42" "$classified_rc" \
+    "structured classification preserves the original child exit code"
+terminal_record="$(printf '%s\n' "$classified_stderr" | grep '^# LOOM_TERMINAL_RESULT ' || true)"
+assert_eq \
+    "# LOOM_TERMINAL_RESULT v=1 provider=codex account=profile-a category=TOKEN_EXPIRED exit_code=42" \
+    "$terminal_record" \
+    "the structured record matches the direct Codex classifier and carries account identity"
+assert_not_contains "recognizable-secret" "$terminal_record" \
+    "the structured record never copies raw child output"
 
 set +e
 run_mock MOCK_RC=0 -- -p "hi" >/dev/null 2>&1

--- a/defaults/scripts/tests/test-worktree-remove.sh
+++ b/defaults/scripts/tests/test-worktree-remove.sh
@@ -10,6 +10,13 @@
 #   4. --keep-branch leaves the local branch intact after removal.
 #   5. Running `remove` from a shell whose cwd is inside the target worktree
 #      completes successfully (script cd's out first — no shell corruption).
+#   6. A worktree with uncommitted changes is REFUSED (#4449): non-zero exit,
+#      worktree + work intact, message lists what it found and how to proceed.
+#   7. The same worktree removes cleanly with an explicit --force.
+#   8. Loom runtime markers (.loom-managed et al) do NOT count as uncommitted
+#      work — otherwise the guard would refuse every managed worktree in a repo
+#      whose .gitignore predates #3838.
+#   9. A staged-only (index) change also triggers the refusal.
 #
 # Follows the throwaway-repo harness pattern in test-worktree-sentinel.sh:
 # a bare origin remote + a working repo, with worktree.sh + its lib/ helpers
@@ -166,6 +173,124 @@ if ( cd "$REPO/.loom/worktrees/issue-104" && \
 else
     cd "$REPO"
     fail "in-worktree remove exited non-zero (see /tmp/rm-out5.$$)"
+fi
+
+# --- Test 6: a dirty worktree is refused (#4449) -----------------------------
+# The data-loss precedent: `git worktree remove --force` discards the working
+# tree unconditionally, so `remove` must refuse rather than destroy work.
+echo ""
+echo "Test 6: remove refuses a worktree with uncommitted changes (#4449)"
+make_worktree 105
+cd "$REPO"
+echo "an uncommitted fix that must not be destroyed" > ".loom/worktrees/issue-105/wip.txt"
+if ./.loom/scripts/worktree.sh remove 105 >/tmp/rm-out6.$$ 2>&1; then
+    fail "remove succeeded on a dirty worktree (should have refused)"
+else
+    pass "remove exited non-zero for a dirty worktree"
+fi
+if [[ -d ".loom/worktrees/issue-105" ]]; then
+    pass "dirty worktree directory left untouched"
+else
+    fail "dirty worktree directory was removed"
+fi
+if [[ -f ".loom/worktrees/issue-105/wip.txt" ]]; then
+    pass "uncommitted work survived the refused removal"
+else
+    fail "uncommitted work was destroyed"
+fi
+if grep -q "Refusing to remove" /tmp/rm-out6.$$ 2>/dev/null; then
+    pass "refusal message mentions 'Refusing to remove'"
+else
+    fail "no clear refusal message emitted"
+fi
+if grep -q "wip.txt" /tmp/rm-out6.$$ 2>/dev/null; then
+    pass "refusal lists the uncommitted path it found"
+else
+    fail "refusal did not list what it found"
+fi
+# The refusal must tell the caller how to proceed (AC: commit / patch / stash /
+# force), not just say no.
+remedies=0
+for needle in "commit" "diff HEAD" "stash" "--force"; do
+    grep -qi -- "$needle" /tmp/rm-out6.$$ 2>/dev/null && remedies=$((remedies + 1))
+done
+if [[ "$remedies" -eq 4 ]]; then
+    pass "refusal explains all four ways to proceed (commit/patch/stash/--force)"
+else
+    fail "refusal is missing remediation guidance ($remedies/4 found)"
+fi
+# --json mode must still emit a single parseable refusal document on stdout.
+if ./.loom/scripts/worktree.sh remove 105 --json >/tmp/rm-out6b.$$ 2>/dev/null; then
+    fail "remove --json succeeded on a dirty worktree (should have refused)"
+else
+    if grep -q '"success": false' /tmp/rm-out6b.$$ && grep -q '"removed": false' /tmp/rm-out6b.$$; then
+        pass "--json refusal reports success=false, removed=false on stdout"
+    else
+        fail "--json refusal did not emit the expected JSON (see /tmp/rm-out6b.$$)"
+    fi
+fi
+
+# --- Test 7: --force removes the dirty worktree ------------------------------
+echo ""
+echo "Test 7: remove --force discards uncommitted changes and removes the worktree"
+cd "$REPO"
+if ./.loom/scripts/worktree.sh remove 105 --force >/tmp/rm-out7.$$ 2>&1; then
+    if [[ ! -d ".loom/worktrees/issue-105" ]]; then
+        pass "dirty worktree removed with --force"
+    else
+        fail "dirty worktree still present after remove --force"
+    fi
+    if grep -qi "discarding them (--force)" /tmp/rm-out7.$$ 2>/dev/null; then
+        pass "--force announces that it discarded the uncommitted changes"
+    else
+        fail "--force did not announce the discard"
+    fi
+else
+    fail "remove --force exited non-zero on a dirty worktree (see /tmp/rm-out7.$$)"
+fi
+
+# --- Test 8: Loom runtime markers are not "uncommitted work" -----------------
+# worktree.sh writes .loom-managed into every worktree it creates. A repo whose
+# .gitignore predates #3838 does not ignore it, so a naive porcelain check would
+# see every managed worktree as dirty and refuse ALL removals.
+echo ""
+echo "Test 8: Loom runtime markers alone do not trigger the dirty refusal"
+make_worktree 106
+cd "$REPO"
+# Prove the marker really is visible to git in this harness (no .gitignore).
+if git -C ".loom/worktrees/issue-106" status --porcelain --untracked-files=all | grep -q ".loom-managed"; then
+    pass "precondition: .loom-managed is untracked+visible to git in this repo"
+else
+    echo "  (note: .loom-managed already ignored here — guard still exercised below)"
+fi
+touch ".loom/worktrees/issue-106/.loom-in-use" ".loom/worktrees/issue-106/.loom-checkpoint"
+if ./.loom/scripts/worktree.sh remove 106 >/tmp/rm-out8.$$ 2>&1; then
+    pass "remove succeeded with only Loom runtime markers present"
+else
+    fail "remove refused a worktree whose only 'changes' are Loom markers (see /tmp/rm-out8.$$)"
+fi
+if [[ ! -d ".loom/worktrees/issue-106" ]]; then
+    pass "marker-only worktree was removed"
+else
+    fail "marker-only worktree still present"
+fi
+
+# --- Test 9: a staged-only change also triggers the refusal ------------------
+echo ""
+echo "Test 9: remove refuses a worktree with staged-but-uncommitted changes"
+make_worktree 107
+cd "$REPO"
+echo "staged content" > ".loom/worktrees/issue-107/staged.txt"
+git -C ".loom/worktrees/issue-107" add staged.txt
+if ./.loom/scripts/worktree.sh remove 107 >/tmp/rm-out9.$$ 2>&1; then
+    fail "remove succeeded on a worktree with staged changes (should have refused)"
+else
+    pass "remove exited non-zero for staged-but-uncommitted changes"
+fi
+if [[ -f ".loom/worktrees/issue-107/staged.txt" ]]; then
+    pass "staged work survived the refused removal"
+else
+    fail "staged work was destroyed"
 fi
 
 # --- Summary ----------------------------------------------------------------

--- a/defaults/scripts/worktree.sh
+++ b/defaults/scripts/worktree.sh
@@ -8,7 +8,7 @@
 #   pnpm worktree <issue-number> <branch>              # Create worktree with custom branch name
 #   pnpm worktree <issue-number> --sparse <paths...>   # Cone-mode sparse checkout
 #   pnpm worktree <issue-number> --full                # Convert sparse worktree to full
-#   pnpm worktree remove <issue-number> [--keep-branch]# Remove one managed worktree
+#   pnpm worktree remove <issue-number> [--keep-branch] [--force]  # Remove one managed worktree
 #   pnpm worktree --check                              # Check if currently in a worktree
 #   pnpm worktree --json <issue-number>                # Machine-readable output
 #   pnpm worktree --return-to <dir> <issue-number>     # Store return directory
@@ -316,13 +316,23 @@ cleanup_partial_worktree_state() {
 # discovery fallback — those belong to merge-pr.sh's distinct call-sites):
 #   1. Idempotent no-op if the worktree dir is absent (still prune).
 #   2. Refuse to remove a dir lacking the .loom-managed sentinel (user-owned).
-#   3. Discover the attached branch BEFORE removal (the porcelain entry vanishes
+#   3. Refuse to remove a worktree with uncommitted changes unless --force (#4449).
+#   4. Discover the attached branch BEFORE removal (the porcelain entry vanishes
 #      once the worktree is gone).
-#   4. Hop out of the worktree first if our cwd is inside it (CWD-safety).
-#   5. `git worktree remove --force`; warn (don't hard-fail) on failure.
-#   6. `git branch -d` the attached branch (safe delete, refuses on unmerged
+#   5. Hop out of the worktree first if our cwd is inside it (CWD-safety).
+#   6. `git worktree remove --force`; warn (don't hard-fail) on failure.
+#   7. `git branch -d` the attached branch (safe delete, refuses on unmerged
 #      commits) unless --keep-branch.
-#   7. `git worktree prune`.
+#   8. `git worktree prune`.
+#
+# Guard 3 exists because step 6 is `git worktree remove --force`, which discards
+# the working tree unconditionally — there is no "safe" variant to fall back to
+# once it runs. #4449 is the live precedent for why an unconditional destructive
+# removal is unacceptable: a tested-but-uncommitted fix was destroyed in the
+# window before its `git commit`, with no dirty-check anywhere on the path. The
+# create path already preserves a dirty worktree (see the "Worktree has
+# uncommitted changes - preserving existing work" branch); this makes the removal
+# path consistent with it, and `--force` is the explicit opt-in to the loss.
 #
 # `loom-clean` remains the bulk/stale-cleanup path across all closed issues;
 # this verb targets one specific issue's worktree.
@@ -347,21 +357,51 @@ _worktree_attached_branch() {
         '
 }
 
-# remove_worktree_command [--keep-branch] [--json] <issue-number>
+# Print a worktree's uncommitted-change lines in `git status --porcelain`
+# format, EXCLUDING Loom runtime marker files (#4449).
+#
+# `.loom-managed` / `.loom-in-use` / `.loom-checkpoint` / `.no-changes-needed` are
+# runtime breadcrumbs every managed worktree legitimately carries. A correctly
+# installed repo gitignores them, but a stale / pre-#3838 `.gitignore` does not —
+# and if they counted as "uncommitted work", the dirty guard below would refuse
+# to remove *every* managed worktree, which is worse than no guard at all. They
+# carry no work, so they are filtered out here rather than special-cased at each
+# call site.
+#
+# Empty output ⇒ nothing worth preserving. Never fails (a non-repo path or a
+# missing git prints nothing).
+_worktree_dirty_lines() {
+    local wt="$1"
+    git -C "$wt" status --porcelain --untracked-files=all 2>/dev/null | awk '
+        {
+            # Porcelain v1: 2 status chars + 1 space, then the path. Renames
+            # render as "old -> new" and never match a bare marker name.
+            path = substr($0, 4)
+            gsub(/^"/, "", path); gsub(/"$/, "", path)
+            if (path == ".loom-managed"      || path == ".loom-in-use" ||
+                path == ".loom-checkpoint"   || path == ".no-changes-needed") next
+            print
+        }
+    ' || true
+}
+
+# remove_worktree_command [--keep-branch] [--force] [--json] <issue-number>
 #
 # Invoked from the early arg dispatch below. Returns 0 on success (including the
 # idempotent no-op) and 1 on refusal / usage error / removal failure.
 remove_worktree_command() {
-    local issue_number="" keep_branch=false json=false
+    local issue_number="" keep_branch=false json=false force=false
+    local usage="Usage: pnpm worktree remove <issue-number> [--keep-branch] [--force] [--json]"
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --keep-branch) keep_branch=true; shift ;;
             --json)        json=true; shift ;;
+            --force|-f)    force=true; shift ;;
             --*)
                 print_error "Unknown flag for remove: $1"
                 echo ""
-                echo "Usage: pnpm worktree remove <issue-number> [--keep-branch] [--json]"
+                echo "$usage"
                 return 1
                 ;;
             *)
@@ -378,13 +418,13 @@ remove_worktree_command() {
     if [[ -z "$issue_number" ]]; then
         print_error "remove requires an issue number"
         echo ""
-        echo "Usage: pnpm worktree remove <issue-number> [--keep-branch] [--json]"
+        echo "$usage"
         return 1
     fi
     if ! [[ "$issue_number" =~ ^[0-9]+$ ]]; then
         print_error "Issue number must be numeric (got: '$issue_number')"
         echo ""
-        echo "Usage: pnpm worktree remove <issue-number> [--keep-branch] [--json]"
+        echo "$usage"
         return 1
     fi
 
@@ -431,11 +471,39 @@ remove_worktree_command() {
         return 1
     fi
 
-    # 3. Discover the attached branch BEFORE removal (porcelain entry vanishes
+    # 3. Dirty guard (#4449): step 5's `git worktree remove --force` discards the
+    #    working tree unconditionally, so uncommitted work must be surfaced and
+    #    the removal refused unless the caller explicitly opts into the loss.
+    #    Defense in depth alongside the create path, which already preserves a
+    #    dirty worktree rather than resetting it.
+    local dirty_lines dirty_count
+    dirty_lines="$(_worktree_dirty_lines "$worktree_path")"
+    if [[ -n "$dirty_lines" ]]; then
+        dirty_count=$(printf '%s\n' "$dirty_lines" | grep -c . || true)
+        if [[ "$force" != true ]]; then
+            print_error "Refusing to remove $worktree_path — it has $dirty_count uncommitted change(s):"
+            printf '%s\n' "$dirty_lines" | head -20 >&2
+            if [[ "$dirty_count" -gt 20 ]]; then
+                echo "  ... and $((dirty_count - 20)) more" >&2
+            fi
+            echo "" >&2
+            echo "Removing it would destroy that work irreversibly. To proceed, pick one:" >&2
+            echo "  1. Commit it:    git -C $worktree_path add -A && git -C $worktree_path commit -m '...'" >&2
+            echo "  2. Save a patch: git -C $worktree_path diff HEAD > /tmp/issue-$issue_number.patch" >&2
+            echo "  3. Stash it:     git -C $worktree_path stash push -u -m 'issue-$issue_number'" >&2
+            echo "  4. Discard it:   re-run with --force (the uncommitted changes are lost)" >&2
+            _rm_json false false "untouched"
+            return 1
+        fi
+        _rm_warning "Worktree has $dirty_count uncommitted change(s) - discarding them (--force)"
+        printf '%s\n' "$dirty_lines" | head -20 >&2
+    fi
+
+    # 4. Discover the attached branch BEFORE removal (porcelain entry vanishes
     #    once the worktree is gone).
     attached_branch="$(_worktree_attached_branch "$repo_root" "$worktree_path")" || attached_branch=""
 
-    # 4. CWD-safety: if our shell is inside the worktree, hop out first.
+    # 5. CWD-safety: if our shell is inside the worktree, hop out first.
     local worktree_real current_dir in_worktree=false
     worktree_real="$(cd "$worktree_path" 2>/dev/null && pwd -P)" || worktree_real="$worktree_path"
     current_dir="$(pwd -P 2>/dev/null || pwd)"
@@ -444,7 +512,7 @@ remove_worktree_command() {
         cd "$repo_root" 2>/dev/null || true
     fi
 
-    # 5. Remove the worktree.
+    # 6. Remove the worktree.
     _rm_info "Removing worktree: $worktree_path"
     local removed=false
     if git -C "$repo_root" worktree remove "$worktree_path" --force >/dev/null 2>&1; then
@@ -458,7 +526,7 @@ remove_worktree_command() {
         _rm_warning "Could not remove worktree at $worktree_path"
     fi
 
-    # 6. Branch cleanup (unless --keep-branch). Deferred until after removal so
+    # 7. Branch cleanup (unless --keep-branch). Deferred until after removal so
     #    the worktree's checkout lock on the branch is released first.
     local branch_status="none"
     if [[ "$keep_branch" == true ]]; then
@@ -479,7 +547,7 @@ remove_worktree_command() {
         fi
     fi
 
-    # 7. Prune the git worktree registration.
+    # 8. Prune the git worktree registration.
     git -C "$repo_root" worktree prune 2>/dev/null || true
 
     if [[ "$removed" == true ]]; then
@@ -632,7 +700,7 @@ Usage:
   pnpm worktree <issue-number> --base <branch>          Branch off <branch> (stacked PR, #3729)
   pnpm worktree <issue-number> --sparse <paths...>      Cone-mode sparse checkout
   pnpm worktree <issue-number> --full                   Convert sparse worktree to full
-  pnpm worktree remove <issue-number> [--keep-branch]   Remove one managed worktree
+  pnpm worktree remove <N> [--keep-branch] [--force]    Remove one managed worktree
   pnpm worktree --check                                 Check if in a worktree
   pnpm worktree --json <issue-number>                   Machine-readable JSON output
   pnpm worktree --return-to <dir> <issue-number>        Store return directory
@@ -666,12 +734,20 @@ Examples:
     branch (safe delete — refuses on unmerged commits). This is the sanctioned
     single-worktree removal path so you never need 'git worktree remove'
     directly. It honors the .loom-managed sentinel (refuses to remove a
-    user-provisioned worktree), is idempotent (clear no-op if absent), and
-    prunes the git worktree registration. Use 'loom-clean' for bulk/stale
+    user-provisioned worktree), REFUSES when the worktree has uncommitted
+    changes (#4449 — see --force below), is idempotent (clear no-op if absent),
+    and prunes the git worktree registration. Use 'loom-clean' for bulk/stale
     cleanup across all closed issues.
 
   pnpm worktree remove 42 --keep-branch
     Same as above but leaves the local feature branch intact.
+
+  pnpm worktree remove 42 --force
+    Removes the worktree even when it has uncommitted changes, DISCARDING them.
+    Without --force, a dirty worktree makes 'remove' exit non-zero, list what it
+    found, and print how to preserve the work (commit / save a patch / stash).
+    Loom runtime markers (.loom-managed, .loom-in-use, .loom-checkpoint,
+    .no-changes-needed) never count as uncommitted work.
 
   pnpm worktree --check
     Shows current worktree status

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -4806,6 +4806,7 @@ exit 0
                 state: "connected".to_string(),
                 socket: Some(std::path::PathBuf::from("/tmp/safehoused.sock")),
                 room: Some("fleet".to_string()),
+                reason: None,
             }),
         };
         let resp = Response::DaemonStatus(Box::new(report));

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -29,7 +29,7 @@ use loom_daemon::workspace_pool::WorkspacePool;
 use loom_daemon::worktree_ops::{aggressive, clean};
 use loom_daemon::{extract_configured_terminal_ids, rotate_log_file};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand};
 use std::fs;
@@ -972,6 +972,11 @@ enum TokensAction {
         /// root when called from a worktree — no upward `.git` walk).
         #[arg(long, value_name = "PATH", default_value = ".")]
         workspace: String,
+
+        /// Account provider. The default preserves the legacy Claude token
+        /// selector and every one of its state formats.
+        #[arg(long, value_name = "PROVIDER", default_value = "claude")]
+        provider: String,
 
         /// Emit shell-evalable `export CLAUDE_CODE_OAUTH_TOKEN=...` /
         /// `export LOOM_TOKEN_NAME=...` lines (plus a non-exported
@@ -6326,17 +6331,59 @@ fn handle_forge_command(action: ForgeAction) -> Result<()> {
 /// file-based — does not require a running daemon. See
 /// `loom-daemon/src/tokens_pool/mod.rs` for the ported subset and what is
 /// deliberately deferred.
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
 fn handle_tokens_command(action: TokensAction) -> Result<()> {
     use loom_daemon::tokens_pool::{allowlist, bad_tokens, failure_counts, select};
 
     match action {
         TokensAction::Select {
             workspace,
+            provider,
             export,
             no_key,
             auto_unpin,
         } => {
             let ws = resolve_tokens_workspace(&workspace)?;
+            if provider == "codex" {
+                let selected = loom_daemon::tokens_pool::select_account(
+                    &ws,
+                    loom_daemon::tokens_pool::AccountProvider::Codex,
+                )
+                .map_err(|error| anyhow!(error))?;
+                let directory = match &selected.binding {
+                    loom_daemon::tokens_pool::AccountBinding::CodexHome { directory } => directory,
+                    _ => unreachable!("Codex selection returned a non-Codex binding"),
+                };
+                if export {
+                    println!(
+                        "export CODEX_HOME={}",
+                        shell_single_quote(&directory.display().to_string())
+                    );
+                    println!(
+                        "export LOOM_ACCOUNT_PROVIDER='codex'\nexport LOOM_ACCOUNT_NAME={}",
+                        shell_single_quote(&selected.id.name)
+                    );
+                    println!("LOOM_TOKEN_MODE='{}'", selected.mode);
+                } else {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "provider": "codex",
+                            "name": selected.id.name,
+                            "credential_kind": "codex_home",
+                            "credential_reference": directory,
+                            "mode": selected.mode,
+                        })
+                    );
+                }
+                return Ok(());
+            }
+            if provider != "claude" {
+                bail!("invalid provider {provider:?}; expected claude or codex");
+            }
             if auto_unpin {
                 if let Some(msg) = loom_daemon::tokens_pool::maybe_auto_unpin(&ws) {
                     eprintln!("{msg}");

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -4388,11 +4388,13 @@ fn build_status_json_value(
         })),
         // Live safehouse fleet-comms connection state (#4345) — `null` only
         // from a pre-#4345 daemon binary that never computed one. `state` is
-        // one of "not_configured" / "unreachable" / "connected".
+        // one of "not_configured" / "unreachable" / "connected" /
+        // "send_rejected" (#4464, carries `reason`).
         "safehouse": report.safehouse.as_ref().map(|s| serde_json::json!({
             "state": s.state,
             "socket": s.socket,
             "room": s.room,
+            "reason": s.reason,
         })),
     })
 }
@@ -4932,7 +4934,28 @@ fn print_status_human(
                     .map_or_else(|| "unresolved".to_string(), |p| p.display().to_string())
             );
         }
-        Some(_) => println!("Safehouse:     not configured"),
+        // #4464: handshake succeeds but every send is rejected — the socket is
+        // reachable, so "unreachable" would point the operator at the wrong
+        // fix. Surface the rejection reason directly (canonically a missing
+        // `safehouse.room` on a multi-room host).
+        Some(s) if s.state == "send_rejected" => {
+            println!(
+                "Safehouse:     connected, sends rejected: {} (socket: {})",
+                s.reason.as_deref().unwrap_or("unknown reason"),
+                s.socket
+                    .as_ref()
+                    .map_or_else(|| "?".to_string(), |p| p.display().to_string())
+            );
+        }
+        Some(s) if s.state == "not_configured" => println!("Safehouse:     not configured"),
+        // #4464: an unknown state string (version skew with a newer daemon)
+        // degrades legibly — print the raw state rather than mislabeling it
+        // "not configured" (the old fallthrough, which hid real states).
+        Some(s) => println!("Safehouse:     {} (socket: {})", s.state, {
+            s.socket
+                .as_ref()
+                .map_or_else(|| "?".to_string(), |p| p.display().to_string())
+        }),
         None => {
             println!("Safehouse:     unknown (older daemon binary — restart to pick up #4345)")
         }

--- a/loom-daemon/src/safehouse.rs
+++ b/loom-daemon/src/safehouse.rs
@@ -290,6 +290,17 @@ pub enum SafehouseState {
         socket: PathBuf,
         room: Option<String>,
     },
+    /// The `hello` handshake succeeded, but the most recent `send` was rejected
+    /// at the protocol layer (`ok:false`) — the socket is reachable and the
+    /// connection is healthy, only the send was refused (#4464). The canonical
+    /// case is a multi-room safehoused with [`SafehouseConfig::room`] unset,
+    /// whose `send` returns `'room' required: N rooms joined`. Distinct from
+    /// [`Unreachable`](Self::Unreachable) so `loom-daemon status` points the
+    /// operator at `safehouse.room` rather than at the socket/persona. `reason`
+    /// carries the raw safehoused `error` string. **Sticky**: a reconnect whose
+    /// `hello` succeeds does not clear it; only a `send` that is accepted
+    /// returns the state to [`Connected`](Self::Connected).
+    SendRejected { socket: PathBuf, reason: String },
 }
 
 impl SafehouseState {
@@ -302,16 +313,25 @@ impl SafehouseState {
                 state: "not_configured".to_owned(),
                 socket: None,
                 room: None,
+                reason: None,
             },
             Self::Unreachable { socket } => crate::types::SafehouseStatus {
                 state: "unreachable".to_owned(),
                 socket: Some(socket.clone()),
                 room: None,
+                reason: None,
             },
             Self::Connected { socket, room } => crate::types::SafehouseStatus {
                 state: "connected".to_owned(),
                 socket: Some(socket.clone()),
                 room: room.clone(),
+                reason: None,
+            },
+            Self::SendRejected { socket, reason } => crate::types::SafehouseStatus {
+                state: "send_rejected".to_owned(),
+                socket: Some(socket.clone()),
+                room: None,
+                reason: Some(reason.clone()),
             },
         }
     }
@@ -1098,6 +1118,35 @@ async fn completion_for_exit(
 // Client
 // ============================================================================
 
+/// Why a [`SafehouseClient::send`] failed — split so the sink can tell a
+/// **protocol rejection** (the connection is healthy; retrying identically will
+/// be rejected identically) apart from a **transport failure** (the connection
+/// is gone; reconnect) without string-matching an untyped `anyhow` chain
+/// (#4464).
+#[derive(Debug)]
+pub enum SendError {
+    /// safehoused accepted the request over the wire but refused it at the
+    /// protocol layer (`ok:false`). `reason` is the raw `error` string — the
+    /// canonical case is `'room' required: N rooms joined` on a multi-room host
+    /// with [`SafehouseConfig::room`] unset. The connection stays usable.
+    Rejected { reason: String },
+    /// A transport-level failure (write/read I/O, closed connection, or a reply
+    /// `id` desync) — the connection is unusable and the caller should
+    /// reconnect.
+    Transport(anyhow::Error),
+}
+
+impl std::fmt::Display for SendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rejected { reason } => write!(f, "safehoused rejected send: {reason}"),
+            Self::Transport(err) => write!(f, "{err:#}"),
+        }
+    }
+}
+
+impl std::error::Error for SendError {}
+
 /// A blocking-free async envelope-v1 client over one `AF_UNIX` connection.
 pub struct SafehouseClient {
     reader: BufReader<OwnedReadHalf>,
@@ -1138,24 +1187,32 @@ impl SafehouseClient {
 
     /// Serialize and send one narration envelope, then read + `id`-match the
     /// reply (skipping any interleaved push line).
-    pub async fn send(&mut self, env: &Envelope) -> Result<()> {
+    pub async fn send(&mut self, env: &Envelope) -> std::result::Result<(), SendError> {
         let id = self.next_id;
         self.next_id = self.next_id.wrapping_add(1);
-        let req = build_send_request(env, id, self.room.as_deref())?;
-        self.write_line(&req).await?;
-        let reply = self.read_reply().await?;
+        // A malformed envelope is a transport-class caller bug (the connection
+        // is fine) but is not a server rejection either; surface it as
+        // Transport so the sink logs it rather than treating it as sticky.
+        let req =
+            build_send_request(env, id, self.room.as_deref()).map_err(SendError::Transport)?;
+        self.write_line(&req).await.map_err(SendError::Transport)?;
+        let reply = self.read_reply().await.map_err(SendError::Transport)?;
         if !reply.get("ok").and_then(Value::as_bool).unwrap_or(false) {
-            let err = reply
+            let reason = reply
                 .get("error")
                 .and_then(Value::as_str)
-                .unwrap_or("unknown error");
-            bail!("safehoused rejected send: {err}");
+                .unwrap_or("unknown error")
+                .to_owned();
+            return Err(SendError::Rejected { reason });
         }
         // Replies echo the request id (handle_conn stamps it). A mismatch means
-        // the stream desynced — treat it as a hard error so the sink reconnects.
+        // the stream desynced — treat it as a transport error so the sink
+        // reconnects.
         if let Some(reply_id) = reply.get("id").and_then(Value::as_u64) {
             if reply_id != id {
-                bail!("safehoused reply id {reply_id} != request id {id} (stream desync)");
+                return Err(SendError::Transport(anyhow::anyhow!(
+                    "safehoused reply id {reply_id} != request id {id} (stream desync)"
+                )));
             }
         }
         Ok(())
@@ -1338,6 +1395,11 @@ async fn run_sink(
     let mut backoff = min_backoff;
     // Suppress duplicate outage warnings — one warn per outage, not per event.
     let mut warned = false;
+    // Sticky protocol-rejection state (#4464): `Some(reason)` once a `send` is
+    // rejected at the protocol layer (e.g. `'room' required`). Survives
+    // reconnects (a fresh `hello` does not clear it) and is only cleared by a
+    // `send` that is actually accepted. Also dedups the rejection WARN.
+    let mut send_rejected: Option<String> = None;
     // Short-TTL cache for the dispatch-line title lookup (issue #4201).
     let mut title_cache: HashMap<(String, u32), (String, Instant)> = HashMap::new();
     // Forge `owner/repo` slugs, and the (workspace, issue) pairs already
@@ -1424,11 +1486,21 @@ async fn run_sink(
                     client = Some(connected);
                     backoff = min_backoff;
                     warned = false;
+                    // Stickiness (#4464): a successful `hello` does not clear a
+                    // prior send-rejection — only an accepted `send` does — so
+                    // a reconnect after a transport blip preserves the
+                    // `send_rejected` diagnosis rather than flashing "connected".
                     set_state(
                         &state,
-                        SafehouseState::Connected {
-                            socket: socket.clone(),
-                            room: config.room.clone(),
+                        match &send_rejected {
+                            Some(reason) => SafehouseState::SendRejected {
+                                socket: socket.clone(),
+                                reason: reason.clone(),
+                            },
+                            None => SafehouseState::Connected {
+                                socket: socket.clone(),
+                                room: config.room.clone(),
+                            },
                         },
                     );
                 }
@@ -1455,8 +1527,8 @@ async fn run_sink(
         }
 
         // Send this event's envelopes in order, stopping at the first failure
-        // (the connection is gone; the rest would fail identically).
-        let mut send_failure: Option<anyhow::Error> = None;
+        // (the connection is gone or every send would be rejected identically).
+        let mut send_failure: Option<SendError> = None;
         if let Some(connected) = client.as_mut() {
             for envelope in &outbox {
                 if let Err(err) = connected.send(envelope).await {
@@ -1465,20 +1537,67 @@ async fn run_sink(
                 }
             }
         }
-        if let Some(err) = send_failure {
-            log::warn!(
-                "safehouse: narration send failed ({err:#}); will reconnect, sweep unaffected"
-            );
-            client = None;
-            set_state(
-                &state,
-                SafehouseState::Unreachable {
-                    socket: socket.clone(),
-                },
-            );
-            next_attempt = Instant::now() + backoff;
-            backoff = (backoff * 2).min(max_backoff);
-            warned = true;
+        match send_failure {
+            // An accepted send clears any prior sticky rejection (#4464): the
+            // config was fixed (e.g. `safehouse.room` set + daemon restarted) —
+            // return the status to "connected".
+            None => {
+                if send_rejected.take().is_some() {
+                    log::info!("safehouse: narration accepted again; resuming");
+                    set_state(
+                        &state,
+                        SafehouseState::Connected {
+                            socket: socket.clone(),
+                            room: config.room.clone(),
+                        },
+                    );
+                }
+            }
+            // Protocol rejection (#4464): the connection is healthy, so keep it
+            // — retrying would be rejected identically until the operator fixes
+            // config. Sticky: report "connected, sends rejected: <reason>" and
+            // name the fix when the reason is a missing room. Dropped narration
+            // is never retried (module contract), so we simply move on.
+            Some(SendError::Rejected { reason }) => {
+                if send_rejected.as_deref() != Some(reason.as_str()) {
+                    if reason.contains("'room' required") {
+                        log::warn!(
+                            "safehouse: narration rejected — set safehouse.room — \
+                             safehoused rejected send: {reason}; sweep unaffected"
+                        );
+                    } else {
+                        log::warn!(
+                            "safehouse: narration rejected (safehoused rejected send: \
+                             {reason}); sweep unaffected"
+                        );
+                    }
+                }
+                send_rejected = Some(reason.clone());
+                set_state(
+                    &state,
+                    SafehouseState::SendRejected {
+                        socket: socket.clone(),
+                        reason,
+                    },
+                );
+            }
+            // Transport failure: the connection is gone — drop it and reconnect
+            // with backoff, exactly as before.
+            Some(SendError::Transport(err)) => {
+                log::warn!(
+                    "safehouse: narration send failed ({err:#}); will reconnect, sweep unaffected"
+                );
+                client = None;
+                set_state(
+                    &state,
+                    SafehouseState::Unreachable {
+                        socket: socket.clone(),
+                    },
+                );
+                next_attempt = Instant::now() + backoff;
+                backoff = (backoff * 2).min(max_backoff);
+                warned = true;
+            }
         }
     }
 }
@@ -1681,6 +1800,10 @@ async fn run_coordination(
 
         let (reader, mut writer, mut next_id, room) = client.into_parts();
         let mut lines = reader.lines();
+        // Per-connection dedup for the claim-ad rejection WARN (#4464): one WARN
+        // per outage, reset on each fresh connection — mirrors the sink's
+        // `send_rejected` discipline.
+        let mut ad_rejected = false;
         let reconnect = loop {
             tokio::select! {
                 line = lines.next_line() => {
@@ -1695,9 +1818,41 @@ async fn run_coordination(
                             };
                             if value.get("event").is_some() {
                                 sink.on_event(&value);
+                            } else if value.get("id").is_some()
+                                && !value.get("ok").and_then(Value::as_bool).unwrap_or(true)
+                            {
+                                // A rejected reply (has `id`, no `event`,
+                                // `ok:false`) to one of our own claim ads
+                                // (#4464). On a multi-room host with
+                                // `safehouse.room` unset these are rejected
+                                // server-side with no other signal, silently
+                                // disabling peer-claim dedup (#4028/#4431). WARN
+                                // once per outage and name the fix when it is a
+                                // missing room; dispatch is unaffected.
+                                if !ad_rejected {
+                                    let reason = value
+                                        .get("error")
+                                        .and_then(Value::as_str)
+                                        .unwrap_or("unknown error");
+                                    if reason.contains("'room' required") {
+                                        log::warn!(
+                                            "safehouse: peer claim-ad rejected — set \
+                                             safehouse.room — safehoused rejected send: \
+                                             {reason}; peer-claim dedup disabled, dispatch \
+                                             unaffected"
+                                        );
+                                    } else {
+                                        log::warn!(
+                                            "safehouse: peer claim-ad rejected (safehoused \
+                                             rejected send: {reason}); peer-claim dedup \
+                                             disabled, dispatch unaffected"
+                                        );
+                                    }
+                                    ad_rejected = true;
+                                }
                             }
-                            // A reply echo (has `id`, no `event`) to one of our
-                            // own sends: nothing to do, drop it.
+                            // An accepted reply echo (has `id`, `ok:true`) to
+                            // one of our own sends: nothing to do, drop it.
                         }
                         Ok(None) => break true,          // peer closed → reconnect
                         Err(e) => {
@@ -1822,6 +1977,19 @@ mod tests {
         .to_status();
         assert_eq!(connected_no_room.state, "connected");
         assert!(connected_no_room.room.is_none());
+
+        // #4464: the send-rejected state renders a socket + reason, no room,
+        // and a distinct wire string so `loom-daemon status` can say
+        // "connected, sends rejected: <reason>" rather than "unreachable".
+        let send_rejected = SafehouseState::SendRejected {
+            socket: PathBuf::from("/tmp/x.sock"),
+            reason: "'room' required: 3 rooms joined".to_owned(),
+        }
+        .to_status();
+        assert_eq!(send_rejected.state, "send_rejected");
+        assert_eq!(send_rejected.socket, Some(PathBuf::from("/tmp/x.sock")));
+        assert!(send_rejected.room.is_none());
+        assert_eq!(send_rejected.reason.as_deref(), Some("'room' required: 3 rooms joined"));
     }
 
     // ---- config resolution (config > default, no env) ----
@@ -2968,6 +3136,327 @@ mod tests {
         assert_eq!(received[0]["v"], json!(1));
         assert_eq!(received[0]["task_id"], json!("42"));
         assert!(received[0].get("from").is_none());
+    }
+
+    /// #4464: a protocol rejection (`ok:false`) is surfaced as the typed
+    /// [`SendError::Rejected`] carrying safehoused's raw reason — the sink can
+    /// tell it from a transport failure without string-matching an untyped
+    /// error chain.
+    #[tokio::test]
+    async fn send_rejection_is_typed_and_names_the_reason() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("safehoused.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read_half, mut write_half) = stream.into_split();
+            let mut lines = BufReader::new(read_half).lines();
+            // hello → ok
+            let _ = lines.next_line().await.unwrap().unwrap();
+            write_half
+                .write_all(b"{\"ok\":true,\"id\":0}\n")
+                .await
+                .unwrap();
+            // send → rejected with the canonical multi-room reason
+            let req: Value =
+                serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+            let id = req["id"].clone();
+            write_half
+                .write_all(
+                    format!(
+                        "{{\"ok\":false,\"error\":\"'room' required: 3 rooms joined\",\"id\":{id}}}\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            // Hold the connection open so the client observes the reply (a
+            // rejection, not an EOF), which is the whole point of the split.
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        });
+
+        let mut client = SafehouseClient::connect(&socket, "loom_daemon", None)
+            .await
+            .unwrap();
+        let err = client
+            .send(&Envelope {
+                to: "*".to_owned(),
+                kind: "task".to_owned(),
+                task_id: Some("42".to_owned()),
+                body: "issue #42 → builder".to_owned(),
+                meta: None,
+            })
+            .await
+            .expect_err("a rejected send must be an error");
+        match err {
+            SendError::Rejected { reason } => {
+                assert!(
+                    reason.contains("'room' required"),
+                    "reason must carry safehoused's raw error, got: {reason}"
+                );
+            }
+            SendError::Transport(e) => panic!("expected Rejected, got Transport: {e:#}"),
+        }
+        server.abort();
+    }
+
+    /// #4464: a transport-level failure (peer closes mid-send) is surfaced as
+    /// [`SendError::Transport`], NOT `Rejected` — the sink must reconnect
+    /// rather than stick on a rejection diagnosis.
+    #[tokio::test]
+    async fn send_transport_failure_is_typed_transport() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("safehoused.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read_half, mut write_half) = stream.into_split();
+            let mut lines = BufReader::new(read_half).lines();
+            // hello → ok, then drop the connection: the send's reply read hits EOF.
+            let _ = lines.next_line().await.unwrap().unwrap();
+            write_half
+                .write_all(b"{\"ok\":true,\"id\":0}\n")
+                .await
+                .unwrap();
+            drop(write_half);
+            drop(lines);
+        });
+
+        let mut client = SafehouseClient::connect(&socket, "loom_daemon", None)
+            .await
+            .unwrap();
+        // The server has (or will imminently) close the connection after the
+        // hello; the send's reply read then hits EOF.
+        server.await.unwrap();
+        let err = client
+            .send(&Envelope {
+                to: "*".to_owned(),
+                kind: "task".to_owned(),
+                task_id: Some("42".to_owned()),
+                body: "body".to_owned(),
+                meta: None,
+            })
+            .await
+            .expect_err("a closed connection must fail the send");
+        assert!(
+            matches!(err, SendError::Transport(_)),
+            "a closed connection is a transport failure, got: {err:?}"
+        );
+    }
+
+    /// #4464: the sink reports `send_rejected` (with the reason) rather than
+    /// `unreachable` when safehoused rejects the send, and clears back to
+    /// `connected` once a send is accepted (config fixed + daemon restarted).
+    #[tokio::test]
+    async fn sink_send_rejection_reports_send_rejected_then_clears_on_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("safehoused.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+
+        // hello → ok; send 1 → rejected; send 2 → accepted.
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read_half, mut write_half) = stream.into_split();
+            let mut lines = BufReader::new(read_half).lines();
+            let _ = lines.next_line().await.unwrap().unwrap(); // hello
+            write_half
+                .write_all(b"{\"ok\":true,\"id\":0}\n")
+                .await
+                .unwrap();
+            // send 1 → reject
+            let r1: Value =
+                serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+            let id1 = r1["id"].clone();
+            write_half
+                .write_all(
+                    format!(
+                        "{{\"ok\":false,\"error\":\"'room' required: 3 rooms joined\",\"id\":{id1}}}\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            // send 2 → accept (the operator set safehouse.room + restarted, in
+            // effect — here we just accept to exercise the clear-on-success arm)
+            let r2: Value =
+                serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+            let id2 = r2["id"].clone();
+            write_half
+                .write_all(format!("{{\"ok\":true,\"event_id\":\"$e\",\"id\":{id2}}}\n").as_bytes())
+                .await
+                .unwrap();
+            tokio::time::sleep(Duration::from_millis(300)).await;
+        });
+
+        let bus = Arc::new(EventBus::new());
+        let subscription = bus.subscribe(Vec::<String>::new());
+        let state = new_shared_state();
+        let sink = tokio::spawn(run_sink(
+            SafehouseConfig {
+                enabled: true,
+                socket: Some(socket.clone()),
+                ..SafehouseConfig::default()
+            },
+            socket.clone(),
+            subscription,
+            Duration::from_millis(50),
+            Duration::from_millis(200),
+            state.clone(),
+        ));
+
+        // Event 1 → rejected → send_rejected (with reason), NOT unreachable.
+        let _ = bus.publish(Event::SweepPhase {
+            issue: 1,
+            phase: "builder".to_owned(),
+            pr_number: None,
+            repo: None,
+        });
+        let s = wait_for_state(&state, |s| matches!(s, SafehouseState::SendRejected { .. })).await;
+        match s {
+            SafehouseState::SendRejected { socket: sk, reason } => {
+                assert_eq!(sk, socket);
+                assert!(reason.contains("'room' required"), "reason: {reason}");
+            }
+            other => panic!("expected SendRejected, got {other:?}"),
+        }
+
+        // Event 2 → accepted → clears back to connected.
+        let _ = bus.publish(Event::SweepPhase {
+            issue: 2,
+            phase: "builder".to_owned(),
+            pr_number: None,
+            repo: None,
+        });
+        let s = wait_for_state(&state, |s| matches!(s, SafehouseState::Connected { .. })).await;
+        assert!(matches!(s, SafehouseState::Connected { .. }), "got {s:?}");
+
+        drop(bus);
+        let _ = tokio::time::timeout(Duration::from_secs(2), sink).await;
+        server.abort();
+    }
+
+    /// #4464: the send-rejected diagnosis is sticky across a reconnect — a
+    /// fresh `hello` after a transport blip must NOT flash "connected"; only an
+    /// accepted send clears it.
+    #[tokio::test]
+    async fn sink_send_rejected_survives_reconnect() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("safehoused.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+
+        let server = tokio::spawn(async move {
+            // Connection 1: hello ok, reject send 1, then close (transport drop).
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read_half, mut write_half) = stream.into_split();
+            let mut lines = BufReader::new(read_half).lines();
+            let _ = lines.next_line().await.unwrap().unwrap(); // hello
+            write_half
+                .write_all(b"{\"ok\":true,\"id\":0}\n")
+                .await
+                .unwrap();
+            let r1: Value =
+                serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+            let id1 = r1["id"].clone();
+            write_half
+                .write_all(
+                    format!(
+                        "{{\"ok\":false,\"error\":\"'room' required: 3 rooms joined\",\"id\":{id1}}}\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            drop(write_half);
+            drop(lines);
+
+            // Connection 2: hello ok, then stall before replying to the send so
+            // the sink's state is observable at "just reconnected, no send
+            // accepted yet" — it must be SendRejected, not Connected.
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read_half, mut write_half) = stream.into_split();
+            let mut lines = BufReader::new(read_half).lines();
+            let _ = lines.next_line().await.unwrap().unwrap(); // hello
+            write_half
+                .write_all(b"{\"ok\":true,\"id\":0}\n")
+                .await
+                .unwrap();
+            let _ = lines.next_line().await.unwrap().unwrap(); // send (read, do not reply yet)
+            tokio::time::sleep(Duration::from_millis(400)).await;
+        });
+
+        let bus = Arc::new(EventBus::new());
+        let subscription = bus.subscribe(Vec::<String>::new());
+        let state = new_shared_state();
+        let sink = tokio::spawn(run_sink(
+            SafehouseConfig {
+                enabled: true,
+                socket: Some(socket.clone()),
+                ..SafehouseConfig::default()
+            },
+            socket.clone(),
+            subscription,
+            Duration::from_millis(30),
+            Duration::from_millis(60),
+            state.clone(),
+        ));
+
+        // Event 1 → conn1 rejects → SendRejected.
+        let _ = bus.publish(Event::SweepPhase {
+            issue: 1,
+            phase: "builder".to_owned(),
+            pr_number: None,
+            repo: None,
+        });
+        wait_for_state(&state, |s| matches!(s, SafehouseState::SendRejected { .. })).await;
+
+        // Event 2 → send on the now-closed conn1 fails (transport) → Unreachable.
+        let _ = bus.publish(Event::SweepPhase {
+            issue: 2,
+            phase: "builder".to_owned(),
+            pr_number: None,
+            repo: None,
+        });
+        wait_for_state(&state, |s| matches!(s, SafehouseState::Unreachable { .. })).await;
+
+        // Event 3 → reconnect (conn2 hello ok); the send stalls server-side so
+        // the state settles at the reconnect value. Stickiness ⇒ SendRejected.
+        tokio::time::sleep(Duration::from_millis(80)).await; // clear the backoff window
+        let _ = bus.publish(Event::SweepPhase {
+            issue: 3,
+            phase: "builder".to_owned(),
+            pr_number: None,
+            repo: None,
+        });
+        let s = wait_for_state(&state, |s| matches!(s, SafehouseState::SendRejected { .. })).await;
+        assert!(
+            matches!(s, SafehouseState::SendRejected { .. }),
+            "a reconnect whose hello succeeds must NOT clear the send-rejected \
+             diagnosis, got {s:?}"
+        );
+
+        drop(bus);
+        let _ = tokio::time::timeout(Duration::from_secs(2), sink).await;
+        server.abort();
+    }
+
+    /// Poll `state` until `pred` holds (or panic after ~1s) — test helper for
+    /// the lazily-connecting sink whose transitions are not synchronous with
+    /// `bus.publish`.
+    async fn wait_for_state(
+        state: &SharedSafehouseState,
+        pred: impl Fn(&SafehouseState) -> bool,
+    ) -> SafehouseState {
+        for _ in 0..100 {
+            let s = snapshot_state(state);
+            if pred(&s) {
+                return s;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        let s = snapshot_state(state);
+        panic!("state never satisfied predicate; last = {s:?}");
     }
 
     #[tokio::test]

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -13138,8 +13138,16 @@ exit 0\n";
 
     #[test]
     fn midbuild_ignores_stale_claim_lock_with_dead_owner() {
-        // The inverse guard: a lock left behind by a DEAD owner must not wedge
-        // the legitimate dead-sweep recovery path forever.
+        // The inverse guard: the dead sweep's OWN claim-lock, left behind
+        // because the reaper never released it, must not wedge the legitimate
+        // dead-sweep recovery path forever.
+        //
+        // The lock's `sweep_id` is deliberately the dead entry's own id. A lock
+        // naming a *different* sweep is a separate, pre-existing refusal
+        // (`lock_owned_by_other`, #4463: a newer sweep superseded this one) that
+        // fails closed on the id comparison alone and is covered by its own
+        // tests. This test isolates the #4449 live-use veto: a dead owner PID is
+        // not live-use evidence, so recovery proceeds.
         let tmp = tempdir().unwrap();
         let ws = tmp.path();
         let (mut reg, _rec) = fixture_registry(ws);
@@ -13151,7 +13159,7 @@ exit 0\n";
         std::fs::write(
             lock.join("owner.json"),
             format!(
-                r#"{{"issue": 6104, "owner_pid": 2147483640, "acquired_at": "{}", "sweep_id": "dead-sweep"}}"#,
+                r#"{{"issue": 6104, "owner_pid": 2147483640, "acquired_at": "{}", "sweep_id": "sweep-issue-6104-dead"}}"#,
                 Utc::now().to_rfc3339()
             ),
         )

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -898,10 +898,31 @@ pub fn review_stall_decision(
 // philosophy as #3892). A pre-flight token-health gate reads `.ranking` and
 // defers the re-dispatch when the whole pool is exhausted, so a mid-run
 // exhaustion is less likely to recur.
+//
+// ## The live-use veto (Issue #4449)
+//
+// That signature is NECESSARY but not SUFFICIENT, which cost real work on
+// 2026-07-29: the daemon's tracked sweep for issue #4366 had indeed died, but a
+// separate, untracked recovery Doctor session was concurrently editing the same
+// worktree. `(terminal ∧ no PR ∧ dirty)` matched, the watchdog ran
+// `git reset --hard` + `git clean -fd`, and a tested-but-uncommitted fix was
+// destroyed in the window between the test run and `git commit`.
+//
+// Dirtiness cannot distinguish "debris a dead sweep left behind" from "a live
+// session's work in progress" — both look identical to `git status`. So the
+// watchdog now requires a second, independent condition: NOTHING LIVE may still
+// hold the worktree. `SweepRegistry::worktree_in_use` gathers four signals (a
+// `.loom-in-use` marker, a claim-lock whose owner PID is alive, an in-flight
+// `index.lock`, and processes whose cwd is inside the worktree); any one of them
+// vetoes the reset, yielding `MidbuildDecision::InUse` — logged loudly, with the
+// single recovery retry left unconsumed so a genuinely-dead sweep is still
+// recovered on a later tick once the holder goes away. And `clean_worktree` now
+// logs the porcelain status + diffstat of everything it is about to destroy, so
+// a wipe can never again be silent in the daemon log.
 
 /// The mid-build-death watchdog's per-sweep decision (Issue #3895). Pure state
 /// machine — [`midbuild_decision`] maps `(worktree_dirty, produced_pr,
-/// already_retried)` onto exactly one of these.
+/// already_retried, worktree_in_use)` onto exactly one of these.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MidbuildDecision {
     /// Not a mid-build death (no dirty worktree, or a PR was produced) — leave
@@ -913,28 +934,165 @@ pub enum MidbuildDecision {
     /// A dead sweep matching the signature but already recovered once — give up
     /// (bounded: never loop). Left for the operator.
     GiveUp,
+    /// The signature matches BUT the worktree is still held by a live session
+    /// the daemon does not track (Issue #4449) — refuse the destructive reset
+    /// and leave both the worktree and the single recovery retry untouched.
+    InUse,
 }
 
-/// Pure mid-build-death state machine (Issue #3895).
+/// Pure mid-build-death state machine (Issue #3895, extended by #4449).
 ///
 /// - No dirty worktree, or the sweep already produced a PR ⇒
 ///   [`MidbuildDecision::Healthy`] (nothing to recover).
-/// - Dirty worktree + no PR + not yet recovered ⇒ [`MidbuildDecision::Recover`].
-/// - Dirty worktree + no PR + already recovered ⇒ [`MidbuildDecision::GiveUp`]
-///   — the recovery is bounded to exactly one re-dispatch per issue.
+/// - Dirty worktree + no PR + **a live session still using the worktree** ⇒
+///   [`MidbuildDecision::InUse`] (#4449). This gate sits *above* the retry
+///   bookkeeping on purpose: "someone is editing this right now" is never a
+///   dead-sweep-recovery candidate, and a refusal must not burn the single
+///   recovery retry (the worktree may be legitimately free on a later tick).
+/// - Dirty worktree + no PR + not in use + not yet recovered ⇒
+///   [`MidbuildDecision::Recover`].
+/// - Dirty worktree + no PR + not in use + already recovered ⇒
+///   [`MidbuildDecision::GiveUp`] — the recovery is bounded to exactly one
+///   re-dispatch per issue.
+///
+/// # Why the in-use gate exists (#4449)
+///
+/// Before #4449 the watchdog inferred "died mid-build" from `(terminal state ∧
+/// no PR ∧ dirty worktree)` alone and immediately reset the worktree. On
+/// 2026-07-29 that inference was wrong: the daemon's own tracked sweep for
+/// issue #4366 *had* died, but a separate, untracked recovery Doctor session was
+/// concurrently and legitimately working in the same worktree. The watchdog read
+/// that session's uncommitted fix as dead-sweep debris and destroyed it mid
+/// `git commit`. Dirtiness alone cannot distinguish the two cases — only a
+/// liveness signal can.
 #[must_use]
 pub fn midbuild_decision(
     worktree_dirty: bool,
     produced_pr: bool,
     already_retried: bool,
+    worktree_in_use: bool,
 ) -> MidbuildDecision {
     if !worktree_dirty || produced_pr {
         MidbuildDecision::Healthy
+    } else if worktree_in_use {
+        MidbuildDecision::InUse
     } else if already_retried {
         MidbuildDecision::GiveUp
     } else {
         MidbuildDecision::Recover
     }
+}
+
+/// One piece of evidence that a *live* process is still using an issue
+/// worktree, gathered by [`SweepRegistry::worktree_in_use`] (Issue #4449).
+///
+/// Any non-empty set of evidence vetoes the mid-build watchdog's destructive
+/// `git reset --hard` / `git clean -fd` path. Each variant carries enough detail
+/// to name the holder in the daemon log so a refusal is actionable rather than
+/// mysterious.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorktreeUseEvidence {
+    /// A `.loom-in-use` marker file names an owning session. Written by flows
+    /// that enter a worktree (including manual, non-daemon sessions), so this
+    /// is the one signal an operator can set by hand to fence off a worktree.
+    InUseMarker { task_id: String, pid: String },
+    /// A claim-lock (`.loom/locks/issue-<N>/owner.json`) whose recorded owner
+    /// PID is still alive. A dead owner's lock is *not* evidence (the reaper /
+    /// `reconstruct` prune those), so this only fires for a genuinely live
+    /// claim the in-memory registry does not represent as active.
+    LiveClaimLock { pid: u32, sweep_id: String },
+    /// One or more live processes have their current working directory inside
+    /// the worktree — an operator's shell, a manual role session, or an
+    /// orphaned grandchild still writing files.
+    LiveProcesses(Vec<u32>),
+    /// A git operation is mid-flight (`index.lock` present) — precisely the
+    /// `git commit` window in which #4449 lost an uncommitted fix.
+    GitOperationInFlight(PathBuf),
+}
+
+impl std::fmt::Display for WorktreeUseEvidence {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InUseMarker { task_id, pid } => {
+                write!(f, ".loom-in-use marker (task: {task_id}, pid: {pid})")
+            }
+            Self::LiveClaimLock { pid, sweep_id } => {
+                write!(f, "live claim-lock owner (pid {pid}, sweep {sweep_id})")
+            }
+            Self::LiveProcesses(pids) => {
+                write!(f, "live process(es) with cwd inside the worktree: {pids:?}")
+            }
+            Self::GitOperationInFlight(path) => {
+                write!(f, "git operation in flight ({} exists)", path.display())
+            }
+        }
+    }
+}
+
+/// Render a set of [`WorktreeUseEvidence`] as a single `; `-joined log fragment.
+#[must_use]
+pub fn describe_worktree_use(evidence: &[WorktreeUseEvidence]) -> String {
+    evidence
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+/// Max lines of `git status` / `git diff --stat` echoed into the
+/// "about to discard" log line (Issue #4449) — enough to identify the lost work,
+/// bounded so a runaway worktree cannot flood the daemon log.
+const DISCARD_LOG_MAX_LINES: usize = 40;
+
+/// Truncate `text` to at most `max` lines, appending a `… (+N more)` marker when
+/// lines were dropped. Returns an empty string for empty/blank input.
+#[must_use]
+fn truncate_lines(text: &str, max: usize) -> String {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    let lines: Vec<&str> = trimmed.lines().collect();
+    if lines.len() <= max {
+        return lines.join("\n");
+    }
+    let extra = lines.len() - max;
+    let mut out = lines[..max].join("\n");
+    out.push_str(&format!("\n… (+{extra} more line(s))"));
+    out
+}
+
+/// Resolve a worktree's `index.lock` path — the marker git holds while an index
+/// write (`git add`, `git commit`, …) is in flight (Issue #4449).
+///
+/// Asks git itself (`git rev-parse --git-path index.lock`) rather than assuming
+/// `<wt>/.git/index.lock`, because a linked worktree's `.git` is a *file*
+/// pointing at `.git/worktrees/<name>/`. Returns `None` when the path cannot be
+/// resolved (not a repo, git unavailable) — the caller treats that as "no
+/// evidence" and relies on the other signals.
+#[must_use]
+fn git_index_lock_path(worktree: &Path) -> Option<PathBuf> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(worktree)
+        .args(["rev-parse", "--git-path", "index.lock"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let rel = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if rel.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(&rel);
+    // `--git-path` yields a path relative to the *worktree* when git was invoked
+    // with `-C <worktree>`; absolutise it so `exists()` is cwd-independent.
+    Some(if path.is_absolute() {
+        path
+    } else {
+        worktree.join(path)
+    })
 }
 
 /// Decide, from a `.loom/tokens/.ranking` file's contents, whether the token
@@ -1669,6 +1827,12 @@ pub struct SweepRegistry {
     /// Issues the mid-build-death watchdog has already logged a give-up for
     /// (Issue #3895), so the loud give-up warning fires once per issue.
     midbuild_gaveup: HashSet<u32>,
+    /// Issues whose worktree the mid-build-death watchdog has already refused to
+    /// reset because a live, untracked session still holds it (Issue #4449).
+    /// Log-once bookkeeping only — it never suppresses the refusal itself, and
+    /// the issue is removed again as soon as the worktree stops being in use so a
+    /// later refusal (or a genuine give-up) still surfaces.
+    midbuild_inuse: HashSet<u32>,
     /// Issues the review-phase stall watchdog has already restarted once (Issue
     /// #3910). Bounds the "log went silent mid-review (hung Judge/Doctor)"
     /// recovery to a single re-dispatch per issue — a second stall resolves to
@@ -1833,6 +1997,7 @@ impl SweepRegistry {
             watchdog_progressed: HashSet::new(),
             midbuild_retried: HashSet::new(),
             midbuild_gaveup: HashSet::new(),
+            midbuild_inuse: HashSet::new(),
             review_stall_retried: HashSet::new(),
             review_stall_gaveup: HashSet::new(),
             quarantine_config: QuarantineConfig::default(),
@@ -1867,6 +2032,7 @@ impl SweepRegistry {
             watchdog_progressed: HashSet::new(),
             midbuild_retried: HashSet::new(),
             midbuild_gaveup: HashSet::new(),
+            midbuild_inuse: HashSet::new(),
             review_stall_retried: HashSet::new(),
             review_stall_gaveup: HashSet::new(),
             quarantine_config: QuarantineConfig::default(),
@@ -5325,16 +5491,132 @@ impl SweepRegistry {
         }
     }
 
+    /// Gather every signal that issue `N`'s worktree is still being used by a
+    /// **live** process the in-memory registry does not represent as an active
+    /// sweep (Issue #4449). An empty vec means "no live holder found".
+    ///
+    /// This is the veto gate on the mid-build watchdog's destructive path. It
+    /// deliberately fails *closed* on ambiguity in the one direction that matters:
+    /// any positive signal blocks the reset. Signals that cannot be probed on
+    /// this host simply contribute nothing (the probe helpers already degrade to
+    /// "unknown ⇒ empty"), so a host without `/proc` or `lsof` still gets the
+    /// marker / claim-lock / index.lock signals.
+    ///
+    /// Order is cheapest-first so the common "nothing is using it" case does the
+    /// least work: two `stat`s and a `read_to_string` before the process scan.
+    fn worktree_in_use(&self, issue: u32) -> Vec<WorktreeUseEvidence> {
+        let wt = self.worktree_path(issue);
+        let mut evidence = Vec::new();
+        if !wt.exists() {
+            return evidence;
+        }
+
+        // 1. Explicit `.loom-in-use` marker — the one signal a manual session
+        //    (or an operator) can plant by hand to fence off a worktree.
+        if let Some(marker) = crate::worktree_ops::safety::read_in_use_marker(&wt) {
+            evidence.push(WorktreeUseEvidence::InUseMarker {
+                task_id: marker.task_id,
+                pid: marker.pid,
+            });
+        }
+
+        // 2. A claim-lock whose recorded owner PID is still alive. A dead owner
+        //    is NOT evidence — the reaper and `reconstruct` prune those, and
+        //    treating a stale lock as "in use" would wedge legitimate recovery.
+        let owner_path = self
+            .config
+            .locks_dir()
+            .join(format!("issue-{issue}"))
+            .join("owner.json");
+        if let Some(owner) = std::fs::read_to_string(&owner_path)
+            .ok()
+            .and_then(|s| serde_json::from_str::<LockOwner>(&s).ok())
+        {
+            if is_pid_alive(owner.owner_pid) {
+                evidence.push(WorktreeUseEvidence::LiveClaimLock {
+                    pid: owner.owner_pid,
+                    sweep_id: owner.sweep_id,
+                });
+            }
+        }
+
+        // 3. A git operation mid-flight (`index.lock`) — the exact `git commit`
+        //    window in which #4449 destroyed an uncommitted fix.
+        if let Some(lock) = git_index_lock_path(&wt) {
+            if lock.exists() {
+                evidence.push(WorktreeUseEvidence::GitOperationInFlight(lock));
+            }
+        }
+
+        // 4. Live processes with a cwd inside the worktree (shells, manual role
+        //    sessions, orphaned grandchildren still writing files).
+        let pids = crate::worktree_ops::safety::find_processes_using_directory(&wt);
+        if !pids.is_empty() {
+            evidence.push(WorktreeUseEvidence::LiveProcesses(pids));
+        }
+
+        evidence
+    }
+
+    /// Record, at `warn`, exactly what a [`clean_worktree`] call is about to
+    /// destroy (Issue #4449) — the porcelain status plus a diffstat, truncated to
+    /// [`DISCARD_LOG_MAX_LINES`]. A wipe must never be silent in the daemon log:
+    /// this line is the only forensic trace that survives the `reset --hard`.
+    ///
+    /// [`clean_worktree`]: SweepRegistry::clean_worktree
+    fn log_worktree_discard(&self, wt: &Path, issue: u32) {
+        let run = |args: &[&str]| -> String {
+            Command::new("git")
+                .arg("-C")
+                .arg(wt)
+                .args(args)
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| String::from_utf8_lossy(&o.stdout).trim_end().to_string())
+                .unwrap_or_default()
+        };
+        let status = truncate_lines(
+            &run(&["status", "--porcelain", "--untracked-files=all"]),
+            DISCARD_LOG_MAX_LINES,
+        );
+        let diffstat = truncate_lines(&run(&["diff", "--stat", "HEAD"]), DISCARD_LOG_MAX_LINES);
+        if status.is_empty() && diffstat.is_empty() {
+            // Nothing probeable to report (missing git, unborn HEAD, …) — still
+            // announce the destructive action so the log shows it happened.
+            log::warn!(
+                "clean-worktree: discarding uncommitted state in {} (issue #{issue}) via \
+                 `git reset --hard` + `git clean -fd`; could not enumerate the discarded \
+                 changes (#4449).",
+                wt.display()
+            );
+            return;
+        }
+        log::warn!(
+            "clean-worktree: DISCARDING uncommitted state in {} (issue #{issue}) via \
+             `git reset --hard` + `git clean -fd` — this is irreversible (#4449).\n\
+             status --porcelain:\n{status}\n\
+             diff --stat HEAD:\n{diffstat}",
+            wt.display()
+        );
+    }
+
     /// Discard a mid-build-death worktree's uncommitted changes so the
     /// re-dispatched sweep resumes from a clean checkout (Issue #3895): a
     /// `git reset --hard` followed by `git clean -fd`. Best-effort — any commits
     /// the dead sweep managed to make are preserved (only the dirty working tree
     /// and untracked files are dropped).
+    ///
+    /// Every call first logs what it is about to destroy via
+    /// [`log_worktree_discard`](Self::log_worktree_discard) (Issue #4449) — the
+    /// #4449 incident was made unrecoverable partly because the wipe left no
+    /// trace at all in the daemon log.
     fn clean_worktree(&self, issue: u32) -> Result<()> {
         let wt = self.worktree_path(issue);
         if !wt.exists() {
             return Ok(());
         }
+        self.log_worktree_discard(&wt, issue);
         let reset = Command::new("git")
             .arg("-C")
             .arg(&wt)
@@ -5405,6 +5687,16 @@ impl SweepRegistry {
     /// re-dispatch (without consuming the single retry) when the whole pool is
     /// `exhausted`/`blocked`, so a mid-run exhaustion is less likely to recur.
     ///
+    /// **Live-use veto (Issue #4449)**: before anything destructive happens, a
+    /// dirty worktree is probed for live holders ([`worktree_in_use`]). A dirty
+    /// worktree is only *dead-sweep debris* if nothing live still owns it — if a
+    /// `.loom-in-use` marker, a live claim-lock owner, an in-flight `index.lock`,
+    /// or a process with its cwd inside the worktree says otherwise, the decision
+    /// resolves to [`MidbuildDecision::InUse`]: log loudly, touch nothing, and do
+    /// **not** consume the single recovery retry.
+    ///
+    /// [`worktree_in_use`]: SweepRegistry::worktree_in_use
+    ///
     /// No new event topics are introduced (the taxonomy is frozen): the
     /// re-dispatch reuses `sweep.global.dispatch` from [`dispatch`], and a
     /// bounded give-up / a pool-exhausted defer surface on the existing frozen
@@ -5436,8 +5728,39 @@ impl SweepRegistry {
                 continue;
             }
             let dirty = self.worktree_dirty(issue);
+            // #4449: a dirty worktree is only dead-sweep debris if nothing LIVE
+            // is still using it. Probe only when dirty (the probe is the
+            // expensive part and a clean worktree is never reset anyway).
+            let in_use = if dirty {
+                self.worktree_in_use(issue)
+            } else {
+                Vec::new()
+            };
+            if in_use.is_empty() {
+                // No longer held — clear the log-once latch so a later refusal
+                // (or a genuine give-up) still surfaces in the daemon log.
+                self.midbuild_inuse.remove(&issue);
+            }
             let already_retried = self.midbuild_retried.contains(&issue);
-            match midbuild_decision(dirty, false, already_retried) {
+            match midbuild_decision(dirty, false, already_retried, !in_use.is_empty()) {
+                MidbuildDecision::InUse => {
+                    if self.midbuild_inuse.insert(issue) {
+                        log::warn!(
+                            "midbuild-watchdog: issue #{issue} ({sweep_id}) matches the \
+                             mid-build-death signature (terminal, no PR, dirty worktree) but its \
+                             worktree at {} is STILL IN USE by a live session the daemon does not \
+                             track — {}. REFUSING to `git reset --hard` it: that is exactly how \
+                             #4449 destroyed an active recovery session's uncommitted fix \
+                             mid-commit. The worktree is left intact and the single recovery retry \
+                             is NOT consumed; the watchdog re-assesses once the holder releases \
+                             it. If the holder is stale, clear it (remove .loom-in-use / the \
+                             claim-lock / the index.lock, or exit the shell) and the next tick \
+                             will recover normally.",
+                            self.worktree_path(issue).display(),
+                            describe_worktree_use(&in_use),
+                        );
+                    }
+                }
                 MidbuildDecision::Healthy => {}
                 MidbuildDecision::GiveUp => {
                     if self.midbuild_gaveup.insert(issue) {
@@ -12404,26 +12727,75 @@ exit 0\n";
     #[test]
     fn midbuild_decision_no_dirty_worktree_is_healthy() {
         // No dirty worktree ⇒ nothing to recover, regardless of retry state.
-        assert_eq!(midbuild_decision(false, false, false), MidbuildDecision::Healthy);
-        assert_eq!(midbuild_decision(false, false, true), MidbuildDecision::Healthy);
+        assert_eq!(midbuild_decision(false, false, false, false), MidbuildDecision::Healthy);
+        assert_eq!(midbuild_decision(false, false, true, false), MidbuildDecision::Healthy);
     }
 
     #[test]
     fn midbuild_decision_produced_pr_is_healthy() {
         // A dead sweep that produced a PR is a completed Builder, not a
         // mid-build death — never recovered even with a dirty worktree.
-        assert_eq!(midbuild_decision(true, true, false), MidbuildDecision::Healthy);
+        assert_eq!(midbuild_decision(true, true, false, false), MidbuildDecision::Healthy);
     }
 
     #[test]
     fn midbuild_decision_dirty_no_pr_first_time_recovers() {
-        assert_eq!(midbuild_decision(true, false, false), MidbuildDecision::Recover);
+        assert_eq!(midbuild_decision(true, false, false, false), MidbuildDecision::Recover);
     }
 
     #[test]
     fn midbuild_decision_dirty_no_pr_after_retry_gives_up() {
         // Bounded: a second mid-build death gives up (never loops).
-        assert_eq!(midbuild_decision(true, false, true), MidbuildDecision::GiveUp);
+        assert_eq!(midbuild_decision(true, false, true, false), MidbuildDecision::GiveUp);
+    }
+
+    #[test]
+    fn midbuild_decision_in_use_worktree_is_never_recovered() {
+        // #4449: a live holder vetoes the destructive path, and the veto sits
+        // ABOVE the retry bookkeeping — it must win over both Recover and
+        // GiveUp so a refusal never consumes the single recovery retry.
+        assert_eq!(midbuild_decision(true, false, false, true), MidbuildDecision::InUse);
+        assert_eq!(midbuild_decision(true, false, true, true), MidbuildDecision::InUse);
+    }
+
+    #[test]
+    fn midbuild_decision_in_use_is_irrelevant_when_not_dirty_or_pr_exists() {
+        // The in-use flag must not manufacture work: a clean worktree or a
+        // produced PR is still Healthy even while a session holds the worktree.
+        assert_eq!(midbuild_decision(false, false, false, true), MidbuildDecision::Healthy);
+        assert_eq!(midbuild_decision(true, true, false, true), MidbuildDecision::Healthy);
+    }
+
+    // --- #4449 helpers: truncate_lines / describe_worktree_use ---
+
+    #[test]
+    fn truncate_lines_keeps_short_input_and_caps_long_input() {
+        assert_eq!(truncate_lines("", 5), "");
+        assert_eq!(truncate_lines("   \n  ", 5), "");
+        assert_eq!(truncate_lines("a\nb", 5), "a\nb");
+        let long = (1..=10)
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let capped = truncate_lines(&long, 3);
+        assert!(capped.starts_with("1\n2\n3"), "keeps the first `max` lines: {capped}");
+        assert!(capped.contains("+7 more"), "reports how many lines were dropped: {capped}");
+    }
+
+    #[test]
+    fn describe_worktree_use_joins_every_signal() {
+        let described = describe_worktree_use(&[
+            WorktreeUseEvidence::InUseMarker {
+                task_id: "t1".into(),
+                pid: "42".into(),
+            },
+            WorktreeUseEvidence::LiveProcesses(vec![7, 9]),
+        ]);
+        assert!(described.contains(".loom-in-use"), "{described}");
+        assert!(described.contains("pid: 42"), "{described}");
+        assert!(described.contains("[7, 9]"), "{described}");
+        assert!(described.contains("; "), "signals are joined: {described}");
+        assert_eq!(describe_worktree_use(&[]), "");
     }
 
     // --- ranking_has_capacity token-health gate ---
@@ -12659,6 +13031,187 @@ exit 0\n";
             !ws.join(".loom/worktrees/issue-6003/dirty.txt").exists(),
             "worktree cleaned on recovery"
         );
+    }
+
+    // --- #4449: the live-use veto on the destructive recovery path -----------
+
+    /// Assert the watchdog refused to touch issue `N`'s dirty worktree: nothing
+    /// recovered, the uncommitted edit still on disk, and — critically — the
+    /// single recovery retry NOT consumed (the worktree may be free later).
+    fn assert_midbuild_refused(reg: &mut SweepRegistry, ws: &Path, issue: u32, why: &str) {
+        assert_eq!(reg.midbuild_watchdog_once(), 0, "no recovery when {why}");
+        assert!(
+            ws.join(format!(".loom/worktrees/issue-{issue}/dirty.txt"))
+                .exists(),
+            "uncommitted work MUST survive when {why} (#4449)"
+        );
+        assert!(
+            !reg.midbuild_retried.contains(&issue),
+            "a refusal must NOT consume the single recovery retry when {why}"
+        );
+        assert!(
+            reg.midbuild_inuse.contains(&issue),
+            "the refusal is recorded (and logged once) when {why}"
+        );
+    }
+
+    #[test]
+    fn midbuild_refuses_to_wipe_worktree_held_by_in_use_marker() {
+        // The #4449 incident shape: the daemon's tracked sweep really did die
+        // (terminal, no PR) but a SEPARATE live session is still using the
+        // worktree. A `.loom-in-use` marker is the explicit form of that signal.
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        let (mut reg, _rec) = fixture_registry(ws);
+
+        let wt = make_dirty_git_worktree(ws, 6101);
+        insert_terminal_issue(&mut reg, "sweep-issue-6101-dead", 6101, None);
+        std::fs::write(
+            wt.join(".loom-in-use"),
+            r#"{"shepherd_task_id": "recovery-doctor", "pid": 4321}"#,
+        )
+        .unwrap();
+
+        assert!(!reg.worktree_in_use(6101).is_empty(), "marker is detected as a live holder");
+        assert_midbuild_refused(&mut reg, ws, 6101, "a .loom-in-use marker names a live session");
+
+        // Once the holder releases the worktree, the legitimate dead-sweep
+        // recovery still works — the veto defers, it does not disable.
+        std::fs::remove_file(wt.join(".loom-in-use")).unwrap();
+        assert_eq!(reg.midbuild_watchdog_once(), 1, "recovery resumes once the holder releases");
+        assert!(reg.midbuild_retried.contains(&6101));
+        assert!(!reg.midbuild_inuse.contains(&6101), "the log-once latch is cleared");
+        assert!(!wt.join("dirty.txt").exists(), "worktree cleaned on the real recovery");
+    }
+
+    #[test]
+    fn midbuild_refuses_to_wipe_worktree_with_git_operation_in_flight() {
+        // The precise window #4449 lost work in: a `git commit` was mid-write,
+        // so git held index.lock. Never reset a worktree in that state.
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        let (mut reg, _rec) = fixture_registry(ws);
+
+        let wt = make_dirty_git_worktree(ws, 6102);
+        insert_terminal_issue(&mut reg, "sweep-issue-6102-dead", 6102, None);
+        let index_lock =
+            git_index_lock_path(&wt).expect("index.lock path resolves for a real repo");
+        std::fs::write(&index_lock, "").unwrap();
+
+        assert_midbuild_refused(&mut reg, ws, 6102, "a git index.lock write is in flight");
+
+        // Committing finishes (lock released) ⇒ recovery is available again.
+        std::fs::remove_file(&index_lock).unwrap();
+        assert_eq!(reg.midbuild_watchdog_once(), 1, "recovery resumes once index.lock clears");
+    }
+
+    #[test]
+    fn midbuild_refuses_to_wipe_worktree_with_live_claim_lock_owner() {
+        // A claim-lock whose owner PID is ALIVE means some session (daemon or
+        // not) still owns this issue — never reset its worktree underneath it.
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        let (mut reg, _rec) = fixture_registry(ws);
+
+        make_dirty_git_worktree(ws, 6103);
+        insert_terminal_issue(&mut reg, "sweep-issue-6103-dead", 6103, None);
+        let lock = reg.config.locks_dir().join("issue-6103");
+        std::fs::create_dir_all(&lock).unwrap();
+        // Our own PID is trivially alive — stands in for the live holder.
+        std::fs::write(
+            lock.join("owner.json"),
+            format!(
+                r#"{{"issue": 6103, "owner_pid": {}, "acquired_at": "{}", "sweep_id": "manual-session"}}"#,
+                std::process::id(),
+                Utc::now().to_rfc3339()
+            ),
+        )
+        .unwrap();
+
+        assert_midbuild_refused(
+            &mut reg,
+            ws,
+            6103,
+            "a live claim-lock owner still holds the issue",
+        );
+    }
+
+    #[test]
+    fn midbuild_ignores_stale_claim_lock_with_dead_owner() {
+        // The inverse guard: a lock left behind by a DEAD owner must not wedge
+        // the legitimate dead-sweep recovery path forever.
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        let (mut reg, _rec) = fixture_registry(ws);
+
+        make_dirty_git_worktree(ws, 6104);
+        insert_terminal_issue(&mut reg, "sweep-issue-6104-dead", 6104, None);
+        let lock = reg.config.locks_dir().join("issue-6104");
+        std::fs::create_dir_all(&lock).unwrap();
+        std::fs::write(
+            lock.join("owner.json"),
+            format!(
+                r#"{{"issue": 6104, "owner_pid": 2147483640, "acquired_at": "{}", "sweep_id": "dead-sweep"}}"#,
+                Utc::now().to_rfc3339()
+            ),
+        )
+        .unwrap();
+
+        assert!(
+            reg.worktree_in_use(6104).is_empty(),
+            "a dead owner's lock is not live-use evidence"
+        );
+        assert_eq!(reg.midbuild_watchdog_once(), 1, "a stale lock does not block recovery");
+        assert!(!ws.join(".loom/worktrees/issue-6104/dirty.txt").exists());
+    }
+
+    #[test]
+    fn midbuild_refuses_to_wipe_worktree_with_live_process_cwd_inside() {
+        // The signal that would have saved the #4449 session with no cooperation
+        // from it at all: a live process whose cwd is inside the worktree.
+        // `find_processes_using_directory` degrades to an empty list on hosts
+        // where it cannot probe (no /proc, no lsof), so self-skip there rather
+        // than assert something the host cannot express.
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        let (mut reg, _rec) = fixture_registry(ws);
+
+        let wt = make_dirty_git_worktree(ws, 6105);
+        insert_terminal_issue(&mut reg, "sweep-issue-6105-dead", 6105, None);
+
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .current_dir(&wt)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn a live process with cwd inside the worktree");
+
+        // The child's `chdir` happens after `fork`, so poll briefly rather than
+        // read the probe once and race it.
+        let mut detected = Vec::new();
+        for _ in 0..40 {
+            detected = crate::worktree_ops::safety::find_processes_using_directory(&wt);
+            if !detected.is_empty() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        if detected.is_empty() {
+            // Probe unavailable on this host — nothing to assert; don't leak.
+            let _ = child.kill();
+            let _ = child.wait();
+            return;
+        }
+        assert!(
+            detected.contains(&child.id()),
+            "the probe found the spawned holder: {detected:?}"
+        );
+
+        assert_midbuild_refused(&mut reg, ws, 6105, "a live process has its cwd in the worktree");
+
+        let _ = child.kill();
+        let _ = child.wait();
     }
 
     #[test]

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -56,6 +56,7 @@ use crate::peer_claims::{self, ClaimAd, PeerClaimView};
 use crate::quarantine_reconciliation;
 use crate::sweep_journal;
 use crate::tokens_pool::bad_tokens;
+use crate::tokens_pool::{self, AccountId, AccountProvider, TerminalClassification};
 use crate::types::{Event, SweepId, SweepInfo, SweepKind, SweepOutcome, SweepState};
 
 use anyhow::{anyhow, Context, Result};
@@ -390,6 +391,56 @@ const TOKEN_NAME_LOG_MARKER: &str = "using OAuth account '";
 const ACCOUNT_LOG_MARKER: &str = "# LOOM_ACCOUNT name=";
 const RUNTIME_LOG_MARKER: &str = "# LOOM_RUNTIME_RESOLVED runtime=";
 const CLI_START_MARKER: &str = "# LOOM_CLI_START";
+const TERMINAL_RESULT_MARKER: &str = "# LOOM_TERMINAL_RESULT ";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TerminalResult {
+    provider: AccountProvider,
+    account: String,
+    category: TerminalClassification,
+    exit_code: i32,
+}
+
+/// Parse the adapter's strict v1 record from only the current dispatch region.
+/// Unknown fields, duplicate records, malformed identities, and unknown
+/// categories all fail closed: no account health is mutated.
+fn parse_terminal_result_after(contents: &str, header_anchor: &str) -> Option<TerminalResult> {
+    let region = &contents[contents.rfind(header_anchor)?..];
+    let records: Vec<_> = region
+        .lines()
+        .filter(|line| line.starts_with(TERMINAL_RESULT_MARKER))
+        .collect();
+    if records.len() != 1 {
+        return None;
+    }
+    let fields: HashMap<_, _> = records[0][TERMINAL_RESULT_MARKER.len()..]
+        .split_ascii_whitespace()
+        .filter_map(|field| field.split_once('='))
+        .collect();
+    if fields.len() != 5 || fields.get("v") != Some(&"1") {
+        return None;
+    }
+    let provider = match *fields.get("provider")? {
+        "claude" => AccountProvider::Claude,
+        "codex" => AccountProvider::Codex,
+        _ => return None,
+    };
+    let account = fields.get("account")?.to_string();
+    if account == UNKNOWN_TOKEN_NAME
+        || account.is_empty()
+        || !account
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+    {
+        return None;
+    }
+    Some(TerminalResult {
+        provider,
+        account,
+        category: fields.get("category")?.parse().ok()?,
+        exit_code: fields.get("exit_code")?.parse().ok()?,
+    })
+}
 
 /// Issue #3802: how long `spawn_child` polls the per-sweep log for the
 /// `TOKEN_NAME_LOG_MARKER` line before giving up and recording
@@ -3223,6 +3274,44 @@ impl SweepRegistry {
         self.record_terminal_outcome(issue, insta_crash);
     }
 
+    /// Persist provider health before any reaper retry/failover decision.
+    fn apply_provider_health_feedback(&self, sweep_id: &SweepId, exit_code: Option<i32>) {
+        let Some(info) = self.entries.get(sweep_id) else {
+            return;
+        };
+        if info.runtime != "codex" || info.token_name == UNKNOWN_TOKEN_NAME {
+            return;
+        }
+        let Ok(contents) = std::fs::read_to_string(&info.log_path) else {
+            return;
+        };
+        let anchor = format!("sweep_id={sweep_id}");
+        let Some(result) = parse_terminal_result_after(&contents, &anchor) else {
+            return;
+        };
+        if result.provider != AccountProvider::Codex
+            || result.account != info.token_name
+            || exit_code.is_some_and(|code| code != result.exit_code)
+        {
+            log::warn!("sweep_registry: ignored mismatched Codex terminal feedback for {sweep_id}");
+            return;
+        }
+        let id = AccountId {
+            provider: result.provider,
+            name: result.account,
+        };
+        if let Err(error) = tokens_pool::record_terminal(
+            &self.config.workspace_root,
+            &id,
+            result.category,
+            "spawn-codex:v1",
+        ) {
+            log::warn!(
+                "sweep_registry: failed to persist Codex terminal feedback for {sweep_id}: {error}"
+            );
+        }
+    }
+
     /// Classify whether an insta-crash death was caused by account exhaustion
     /// (#4122).
     ///
@@ -4431,6 +4520,9 @@ impl SweepRegistry {
             // handle fall back to the `kill(pid, 0)` probe.
             let (is_dead, exit_code) = self.poll_liveness(&sweep_id, pid);
             if is_dead {
+                // #4493: account health must be updated before any bounded
+                // re-dispatch path below asks the selector for another profile.
+                self.apply_provider_health_feedback(&sweep_id, exit_code);
                 {
                     changes += 1;
                     let issue = match &kind {
@@ -10788,6 +10880,7 @@ exit 0
                 kind: kind.clone(),
                 pid: 2_147_483_640,
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: registry.compute_log_path(8801),
                 idempotency_key: None,
                 started_at,
@@ -10977,6 +11070,40 @@ exit 0
 
         let pr = generate_sweep_id(&SweepKind::PrSet(vec![10, 20]));
         assert!(pr.starts_with("sweep-prs-10-20-"));
+    }
+
+    #[test]
+    fn terminal_result_parser_is_anchored_strict_and_provider_aware() {
+        let log = "\
+sweep_id=old
+# LOOM_TERMINAL_RESULT v=1 provider=codex account=stale category=TOKEN_EXPIRED exit_code=1
+sweep_id=current
+# LOOM_TERMINAL_RESULT v=1 provider=codex account=profile-a category=TOKEN_EXHAUSTED exit_code=42
+";
+        assert_eq!(
+            parse_terminal_result_after(log, "sweep_id=current"),
+            Some(TerminalResult {
+                provider: AccountProvider::Codex,
+                account: "profile-a".into(),
+                category: TerminalClassification::TokenExhausted,
+                exit_code: 42,
+            })
+        );
+        assert!(parse_terminal_result_after(
+            "sweep_id=current\n# LOOM_TERMINAL_RESULT v=9 provider=codex account=a category=SUCCESS exit_code=0",
+            "sweep_id=current"
+        )
+        .is_none());
+        assert!(parse_terminal_result_after(
+            "sweep_id=current\n# LOOM_TERMINAL_RESULT v=1 provider=codex account=unknown category=SUCCESS exit_code=0",
+            "sweep_id=current"
+        )
+        .is_none());
+        assert!(parse_terminal_result_after(
+            "sweep_id=current\n# LOOM_TERMINAL_RESULT v=1 provider=codex account=a category=BOGUS exit_code=1",
+            "sweep_id=current"
+        )
+        .is_none());
     }
 
     #[test]
@@ -13602,6 +13729,7 @@ exit 0\n";
                 kind: SweepKind::Issue(9256),
                 pid: std::process::id(), // alive
                 token_name: "unknown".into(),
+                runtime: "unknown".into(),
                 log_path: reg.compute_log_path(9256),
                 idempotency_key: None,
                 started_at: Utc::now(),

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -847,10 +847,31 @@ pub fn review_stall_decision(
 // philosophy as #3892). A pre-flight token-health gate reads `.ranking` and
 // defers the re-dispatch when the whole pool is exhausted, so a mid-run
 // exhaustion is less likely to recur.
+//
+// ## The live-use veto (Issue #4449)
+//
+// That signature is NECESSARY but not SUFFICIENT, which cost real work on
+// 2026-07-29: the daemon's tracked sweep for issue #4366 had indeed died, but a
+// separate, untracked recovery Doctor session was concurrently editing the same
+// worktree. `(terminal ∧ no PR ∧ dirty)` matched, the watchdog ran
+// `git reset --hard` + `git clean -fd`, and a tested-but-uncommitted fix was
+// destroyed in the window between the test run and `git commit`.
+//
+// Dirtiness cannot distinguish "debris a dead sweep left behind" from "a live
+// session's work in progress" — both look identical to `git status`. So the
+// watchdog now requires a second, independent condition: NOTHING LIVE may still
+// hold the worktree. `SweepRegistry::worktree_in_use` gathers four signals (a
+// `.loom-in-use` marker, a claim-lock whose owner PID is alive, an in-flight
+// `index.lock`, and processes whose cwd is inside the worktree); any one of them
+// vetoes the reset, yielding `MidbuildDecision::InUse` — logged loudly, with the
+// single recovery retry left unconsumed so a genuinely-dead sweep is still
+// recovered on a later tick once the holder goes away. And `clean_worktree` now
+// logs the porcelain status + diffstat of everything it is about to destroy, so
+// a wipe can never again be silent in the daemon log.
 
 /// The mid-build-death watchdog's per-sweep decision (Issue #3895). Pure state
 /// machine — [`midbuild_decision`] maps `(worktree_dirty, produced_pr,
-/// already_retried)` onto exactly one of these.
+/// already_retried, worktree_in_use)` onto exactly one of these.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MidbuildDecision {
     /// Not a mid-build death (no dirty worktree, or a PR was produced) — leave
@@ -862,28 +883,165 @@ pub enum MidbuildDecision {
     /// A dead sweep matching the signature but already recovered once — give up
     /// (bounded: never loop). Left for the operator.
     GiveUp,
+    /// The signature matches BUT the worktree is still held by a live session
+    /// the daemon does not track (Issue #4449) — refuse the destructive reset
+    /// and leave both the worktree and the single recovery retry untouched.
+    InUse,
 }
 
-/// Pure mid-build-death state machine (Issue #3895).
+/// Pure mid-build-death state machine (Issue #3895, extended by #4449).
 ///
 /// - No dirty worktree, or the sweep already produced a PR ⇒
 ///   [`MidbuildDecision::Healthy`] (nothing to recover).
-/// - Dirty worktree + no PR + not yet recovered ⇒ [`MidbuildDecision::Recover`].
-/// - Dirty worktree + no PR + already recovered ⇒ [`MidbuildDecision::GiveUp`]
-///   — the recovery is bounded to exactly one re-dispatch per issue.
+/// - Dirty worktree + no PR + **a live session still using the worktree** ⇒
+///   [`MidbuildDecision::InUse`] (#4449). This gate sits *above* the retry
+///   bookkeeping on purpose: "someone is editing this right now" is never a
+///   dead-sweep-recovery candidate, and a refusal must not burn the single
+///   recovery retry (the worktree may be legitimately free on a later tick).
+/// - Dirty worktree + no PR + not in use + not yet recovered ⇒
+///   [`MidbuildDecision::Recover`].
+/// - Dirty worktree + no PR + not in use + already recovered ⇒
+///   [`MidbuildDecision::GiveUp`] — the recovery is bounded to exactly one
+///   re-dispatch per issue.
+///
+/// # Why the in-use gate exists (#4449)
+///
+/// Before #4449 the watchdog inferred "died mid-build" from `(terminal state ∧
+/// no PR ∧ dirty worktree)` alone and immediately reset the worktree. On
+/// 2026-07-29 that inference was wrong: the daemon's own tracked sweep for
+/// issue #4366 *had* died, but a separate, untracked recovery Doctor session was
+/// concurrently and legitimately working in the same worktree. The watchdog read
+/// that session's uncommitted fix as dead-sweep debris and destroyed it mid
+/// `git commit`. Dirtiness alone cannot distinguish the two cases — only a
+/// liveness signal can.
 #[must_use]
 pub fn midbuild_decision(
     worktree_dirty: bool,
     produced_pr: bool,
     already_retried: bool,
+    worktree_in_use: bool,
 ) -> MidbuildDecision {
     if !worktree_dirty || produced_pr {
         MidbuildDecision::Healthy
+    } else if worktree_in_use {
+        MidbuildDecision::InUse
     } else if already_retried {
         MidbuildDecision::GiveUp
     } else {
         MidbuildDecision::Recover
     }
+}
+
+/// One piece of evidence that a *live* process is still using an issue
+/// worktree, gathered by [`SweepRegistry::worktree_in_use`] (Issue #4449).
+///
+/// Any non-empty set of evidence vetoes the mid-build watchdog's destructive
+/// `git reset --hard` / `git clean -fd` path. Each variant carries enough detail
+/// to name the holder in the daemon log so a refusal is actionable rather than
+/// mysterious.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorktreeUseEvidence {
+    /// A `.loom-in-use` marker file names an owning session. Written by flows
+    /// that enter a worktree (including manual, non-daemon sessions), so this
+    /// is the one signal an operator can set by hand to fence off a worktree.
+    InUseMarker { task_id: String, pid: String },
+    /// A claim-lock (`.loom/locks/issue-<N>/owner.json`) whose recorded owner
+    /// PID is still alive. A dead owner's lock is *not* evidence (the reaper /
+    /// `reconstruct` prune those), so this only fires for a genuinely live
+    /// claim the in-memory registry does not represent as active.
+    LiveClaimLock { pid: u32, sweep_id: String },
+    /// One or more live processes have their current working directory inside
+    /// the worktree — an operator's shell, a manual role session, or an
+    /// orphaned grandchild still writing files.
+    LiveProcesses(Vec<u32>),
+    /// A git operation is mid-flight (`index.lock` present) — precisely the
+    /// `git commit` window in which #4449 lost an uncommitted fix.
+    GitOperationInFlight(PathBuf),
+}
+
+impl std::fmt::Display for WorktreeUseEvidence {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InUseMarker { task_id, pid } => {
+                write!(f, ".loom-in-use marker (task: {task_id}, pid: {pid})")
+            }
+            Self::LiveClaimLock { pid, sweep_id } => {
+                write!(f, "live claim-lock owner (pid {pid}, sweep {sweep_id})")
+            }
+            Self::LiveProcesses(pids) => {
+                write!(f, "live process(es) with cwd inside the worktree: {pids:?}")
+            }
+            Self::GitOperationInFlight(path) => {
+                write!(f, "git operation in flight ({} exists)", path.display())
+            }
+        }
+    }
+}
+
+/// Render a set of [`WorktreeUseEvidence`] as a single `; `-joined log fragment.
+#[must_use]
+pub fn describe_worktree_use(evidence: &[WorktreeUseEvidence]) -> String {
+    evidence
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+/// Max lines of `git status` / `git diff --stat` echoed into the
+/// "about to discard" log line (Issue #4449) — enough to identify the lost work,
+/// bounded so a runaway worktree cannot flood the daemon log.
+const DISCARD_LOG_MAX_LINES: usize = 40;
+
+/// Truncate `text` to at most `max` lines, appending a `… (+N more)` marker when
+/// lines were dropped. Returns an empty string for empty/blank input.
+#[must_use]
+fn truncate_lines(text: &str, max: usize) -> String {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    let lines: Vec<&str> = trimmed.lines().collect();
+    if lines.len() <= max {
+        return lines.join("\n");
+    }
+    let extra = lines.len() - max;
+    let mut out = lines[..max].join("\n");
+    out.push_str(&format!("\n… (+{extra} more line(s))"));
+    out
+}
+
+/// Resolve a worktree's `index.lock` path — the marker git holds while an index
+/// write (`git add`, `git commit`, …) is in flight (Issue #4449).
+///
+/// Asks git itself (`git rev-parse --git-path index.lock`) rather than assuming
+/// `<wt>/.git/index.lock`, because a linked worktree's `.git` is a *file*
+/// pointing at `.git/worktrees/<name>/`. Returns `None` when the path cannot be
+/// resolved (not a repo, git unavailable) — the caller treats that as "no
+/// evidence" and relies on the other signals.
+#[must_use]
+fn git_index_lock_path(worktree: &Path) -> Option<PathBuf> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(worktree)
+        .args(["rev-parse", "--git-path", "index.lock"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let rel = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if rel.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(&rel);
+    // `--git-path` yields a path relative to the *worktree* when git was invoked
+    // with `-C <worktree>`; absolutise it so `exists()` is cwd-independent.
+    Some(if path.is_absolute() {
+        path
+    } else {
+        worktree.join(path)
+    })
 }
 
 /// Decide, from a `.loom/tokens/.ranking` file's contents, whether the token
@@ -1605,6 +1763,12 @@ pub struct SweepRegistry {
     /// Issues the mid-build-death watchdog has already logged a give-up for
     /// (Issue #3895), so the loud give-up warning fires once per issue.
     midbuild_gaveup: HashSet<u32>,
+    /// Issues whose worktree the mid-build-death watchdog has already refused to
+    /// reset because a live, untracked session still holds it (Issue #4449).
+    /// Log-once bookkeeping only — it never suppresses the refusal itself, and
+    /// the issue is removed again as soon as the worktree stops being in use so a
+    /// later refusal (or a genuine give-up) still surfaces.
+    midbuild_inuse: HashSet<u32>,
     /// Issues the review-phase stall watchdog has already restarted once (Issue
     /// #3910). Bounds the "log went silent mid-review (hung Judge/Doctor)"
     /// recovery to a single re-dispatch per issue — a second stall resolves to
@@ -1769,6 +1933,7 @@ impl SweepRegistry {
             watchdog_progressed: HashSet::new(),
             midbuild_retried: HashSet::new(),
             midbuild_gaveup: HashSet::new(),
+            midbuild_inuse: HashSet::new(),
             review_stall_retried: HashSet::new(),
             review_stall_gaveup: HashSet::new(),
             quarantine_config: QuarantineConfig::default(),
@@ -1803,6 +1968,7 @@ impl SweepRegistry {
             watchdog_progressed: HashSet::new(),
             midbuild_retried: HashSet::new(),
             midbuild_gaveup: HashSet::new(),
+            midbuild_inuse: HashSet::new(),
             review_stall_retried: HashSet::new(),
             review_stall_gaveup: HashSet::new(),
             quarantine_config: QuarantineConfig::default(),
@@ -5129,16 +5295,132 @@ impl SweepRegistry {
         }
     }
 
+    /// Gather every signal that issue `N`'s worktree is still being used by a
+    /// **live** process the in-memory registry does not represent as an active
+    /// sweep (Issue #4449). An empty vec means "no live holder found".
+    ///
+    /// This is the veto gate on the mid-build watchdog's destructive path. It
+    /// deliberately fails *closed* on ambiguity in the one direction that matters:
+    /// any positive signal blocks the reset. Signals that cannot be probed on
+    /// this host simply contribute nothing (the probe helpers already degrade to
+    /// "unknown ⇒ empty"), so a host without `/proc` or `lsof` still gets the
+    /// marker / claim-lock / index.lock signals.
+    ///
+    /// Order is cheapest-first so the common "nothing is using it" case does the
+    /// least work: two `stat`s and a `read_to_string` before the process scan.
+    fn worktree_in_use(&self, issue: u32) -> Vec<WorktreeUseEvidence> {
+        let wt = self.worktree_path(issue);
+        let mut evidence = Vec::new();
+        if !wt.exists() {
+            return evidence;
+        }
+
+        // 1. Explicit `.loom-in-use` marker — the one signal a manual session
+        //    (or an operator) can plant by hand to fence off a worktree.
+        if let Some(marker) = crate::worktree_ops::safety::read_in_use_marker(&wt) {
+            evidence.push(WorktreeUseEvidence::InUseMarker {
+                task_id: marker.task_id,
+                pid: marker.pid,
+            });
+        }
+
+        // 2. A claim-lock whose recorded owner PID is still alive. A dead owner
+        //    is NOT evidence — the reaper and `reconstruct` prune those, and
+        //    treating a stale lock as "in use" would wedge legitimate recovery.
+        let owner_path = self
+            .config
+            .locks_dir()
+            .join(format!("issue-{issue}"))
+            .join("owner.json");
+        if let Some(owner) = std::fs::read_to_string(&owner_path)
+            .ok()
+            .and_then(|s| serde_json::from_str::<LockOwner>(&s).ok())
+        {
+            if is_pid_alive(owner.owner_pid) {
+                evidence.push(WorktreeUseEvidence::LiveClaimLock {
+                    pid: owner.owner_pid,
+                    sweep_id: owner.sweep_id,
+                });
+            }
+        }
+
+        // 3. A git operation mid-flight (`index.lock`) — the exact `git commit`
+        //    window in which #4449 destroyed an uncommitted fix.
+        if let Some(lock) = git_index_lock_path(&wt) {
+            if lock.exists() {
+                evidence.push(WorktreeUseEvidence::GitOperationInFlight(lock));
+            }
+        }
+
+        // 4. Live processes with a cwd inside the worktree (shells, manual role
+        //    sessions, orphaned grandchildren still writing files).
+        let pids = crate::worktree_ops::safety::find_processes_using_directory(&wt);
+        if !pids.is_empty() {
+            evidence.push(WorktreeUseEvidence::LiveProcesses(pids));
+        }
+
+        evidence
+    }
+
+    /// Record, at `warn`, exactly what a [`clean_worktree`] call is about to
+    /// destroy (Issue #4449) — the porcelain status plus a diffstat, truncated to
+    /// [`DISCARD_LOG_MAX_LINES`]. A wipe must never be silent in the daemon log:
+    /// this line is the only forensic trace that survives the `reset --hard`.
+    ///
+    /// [`clean_worktree`]: SweepRegistry::clean_worktree
+    fn log_worktree_discard(&self, wt: &Path, issue: u32) {
+        let run = |args: &[&str]| -> String {
+            Command::new("git")
+                .arg("-C")
+                .arg(wt)
+                .args(args)
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| String::from_utf8_lossy(&o.stdout).trim_end().to_string())
+                .unwrap_or_default()
+        };
+        let status = truncate_lines(
+            &run(&["status", "--porcelain", "--untracked-files=all"]),
+            DISCARD_LOG_MAX_LINES,
+        );
+        let diffstat = truncate_lines(&run(&["diff", "--stat", "HEAD"]), DISCARD_LOG_MAX_LINES);
+        if status.is_empty() && diffstat.is_empty() {
+            // Nothing probeable to report (missing git, unborn HEAD, …) — still
+            // announce the destructive action so the log shows it happened.
+            log::warn!(
+                "clean-worktree: discarding uncommitted state in {} (issue #{issue}) via \
+                 `git reset --hard` + `git clean -fd`; could not enumerate the discarded \
+                 changes (#4449).",
+                wt.display()
+            );
+            return;
+        }
+        log::warn!(
+            "clean-worktree: DISCARDING uncommitted state in {} (issue #{issue}) via \
+             `git reset --hard` + `git clean -fd` — this is irreversible (#4449).\n\
+             status --porcelain:\n{status}\n\
+             diff --stat HEAD:\n{diffstat}",
+            wt.display()
+        );
+    }
+
     /// Discard a mid-build-death worktree's uncommitted changes so the
     /// re-dispatched sweep resumes from a clean checkout (Issue #3895): a
     /// `git reset --hard` followed by `git clean -fd`. Best-effort — any commits
     /// the dead sweep managed to make are preserved (only the dirty working tree
     /// and untracked files are dropped).
+    ///
+    /// Every call first logs what it is about to destroy via
+    /// [`log_worktree_discard`](Self::log_worktree_discard) (Issue #4449) — the
+    /// #4449 incident was made unrecoverable partly because the wipe left no
+    /// trace at all in the daemon log.
     fn clean_worktree(&self, issue: u32) -> Result<()> {
         let wt = self.worktree_path(issue);
         if !wt.exists() {
             return Ok(());
         }
+        self.log_worktree_discard(&wt, issue);
         let reset = Command::new("git")
             .arg("-C")
             .arg(&wt)
@@ -5209,6 +5491,16 @@ impl SweepRegistry {
     /// re-dispatch (without consuming the single retry) when the whole pool is
     /// `exhausted`/`blocked`, so a mid-run exhaustion is less likely to recur.
     ///
+    /// **Live-use veto (Issue #4449)**: before anything destructive happens, a
+    /// dirty worktree is probed for live holders ([`worktree_in_use`]). A dirty
+    /// worktree is only *dead-sweep debris* if nothing live still owns it — if a
+    /// `.loom-in-use` marker, a live claim-lock owner, an in-flight `index.lock`,
+    /// or a process with its cwd inside the worktree says otherwise, the decision
+    /// resolves to [`MidbuildDecision::InUse`]: log loudly, touch nothing, and do
+    /// **not** consume the single recovery retry.
+    ///
+    /// [`worktree_in_use`]: SweepRegistry::worktree_in_use
+    ///
     /// No new event topics are introduced (the taxonomy is frozen): the
     /// re-dispatch reuses `sweep.global.dispatch` from [`dispatch`], and a
     /// bounded give-up / a pool-exhausted defer surface on the existing frozen
@@ -5240,8 +5532,39 @@ impl SweepRegistry {
                 continue;
             }
             let dirty = self.worktree_dirty(issue);
+            // #4449: a dirty worktree is only dead-sweep debris if nothing LIVE
+            // is still using it. Probe only when dirty (the probe is the
+            // expensive part and a clean worktree is never reset anyway).
+            let in_use = if dirty {
+                self.worktree_in_use(issue)
+            } else {
+                Vec::new()
+            };
+            if in_use.is_empty() {
+                // No longer held — clear the log-once latch so a later refusal
+                // (or a genuine give-up) still surfaces in the daemon log.
+                self.midbuild_inuse.remove(&issue);
+            }
             let already_retried = self.midbuild_retried.contains(&issue);
-            match midbuild_decision(dirty, false, already_retried) {
+            match midbuild_decision(dirty, false, already_retried, !in_use.is_empty()) {
+                MidbuildDecision::InUse => {
+                    if self.midbuild_inuse.insert(issue) {
+                        log::warn!(
+                            "midbuild-watchdog: issue #{issue} ({sweep_id}) matches the \
+                             mid-build-death signature (terminal, no PR, dirty worktree) but its \
+                             worktree at {} is STILL IN USE by a live session the daemon does not \
+                             track — {}. REFUSING to `git reset --hard` it: that is exactly how \
+                             #4449 destroyed an active recovery session's uncommitted fix \
+                             mid-commit. The worktree is left intact and the single recovery retry \
+                             is NOT consumed; the watchdog re-assesses once the holder releases \
+                             it. If the holder is stale, clear it (remove .loom-in-use / the \
+                             claim-lock / the index.lock, or exit the shell) and the next tick \
+                             will recover normally.",
+                            self.worktree_path(issue).display(),
+                            describe_worktree_use(&in_use),
+                        );
+                    }
+                }
                 MidbuildDecision::Healthy => {}
                 MidbuildDecision::GiveUp => {
                     if self.midbuild_gaveup.insert(issue) {
@@ -11974,26 +12297,75 @@ exit 0\n";
     #[test]
     fn midbuild_decision_no_dirty_worktree_is_healthy() {
         // No dirty worktree ⇒ nothing to recover, regardless of retry state.
-        assert_eq!(midbuild_decision(false, false, false), MidbuildDecision::Healthy);
-        assert_eq!(midbuild_decision(false, false, true), MidbuildDecision::Healthy);
+        assert_eq!(midbuild_decision(false, false, false, false), MidbuildDecision::Healthy);
+        assert_eq!(midbuild_decision(false, false, true, false), MidbuildDecision::Healthy);
     }
 
     #[test]
     fn midbuild_decision_produced_pr_is_healthy() {
         // A dead sweep that produced a PR is a completed Builder, not a
         // mid-build death — never recovered even with a dirty worktree.
-        assert_eq!(midbuild_decision(true, true, false), MidbuildDecision::Healthy);
+        assert_eq!(midbuild_decision(true, true, false, false), MidbuildDecision::Healthy);
     }
 
     #[test]
     fn midbuild_decision_dirty_no_pr_first_time_recovers() {
-        assert_eq!(midbuild_decision(true, false, false), MidbuildDecision::Recover);
+        assert_eq!(midbuild_decision(true, false, false, false), MidbuildDecision::Recover);
     }
 
     #[test]
     fn midbuild_decision_dirty_no_pr_after_retry_gives_up() {
         // Bounded: a second mid-build death gives up (never loops).
-        assert_eq!(midbuild_decision(true, false, true), MidbuildDecision::GiveUp);
+        assert_eq!(midbuild_decision(true, false, true, false), MidbuildDecision::GiveUp);
+    }
+
+    #[test]
+    fn midbuild_decision_in_use_worktree_is_never_recovered() {
+        // #4449: a live holder vetoes the destructive path, and the veto sits
+        // ABOVE the retry bookkeeping — it must win over both Recover and
+        // GiveUp so a refusal never consumes the single recovery retry.
+        assert_eq!(midbuild_decision(true, false, false, true), MidbuildDecision::InUse);
+        assert_eq!(midbuild_decision(true, false, true, true), MidbuildDecision::InUse);
+    }
+
+    #[test]
+    fn midbuild_decision_in_use_is_irrelevant_when_not_dirty_or_pr_exists() {
+        // The in-use flag must not manufacture work: a clean worktree or a
+        // produced PR is still Healthy even while a session holds the worktree.
+        assert_eq!(midbuild_decision(false, false, false, true), MidbuildDecision::Healthy);
+        assert_eq!(midbuild_decision(true, true, false, true), MidbuildDecision::Healthy);
+    }
+
+    // --- #4449 helpers: truncate_lines / describe_worktree_use ---
+
+    #[test]
+    fn truncate_lines_keeps_short_input_and_caps_long_input() {
+        assert_eq!(truncate_lines("", 5), "");
+        assert_eq!(truncate_lines("   \n  ", 5), "");
+        assert_eq!(truncate_lines("a\nb", 5), "a\nb");
+        let long = (1..=10)
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let capped = truncate_lines(&long, 3);
+        assert!(capped.starts_with("1\n2\n3"), "keeps the first `max` lines: {capped}");
+        assert!(capped.contains("+7 more"), "reports how many lines were dropped: {capped}");
+    }
+
+    #[test]
+    fn describe_worktree_use_joins_every_signal() {
+        let described = describe_worktree_use(&[
+            WorktreeUseEvidence::InUseMarker {
+                task_id: "t1".into(),
+                pid: "42".into(),
+            },
+            WorktreeUseEvidence::LiveProcesses(vec![7, 9]),
+        ]);
+        assert!(described.contains(".loom-in-use"), "{described}");
+        assert!(described.contains("pid: 42"), "{described}");
+        assert!(described.contains("[7, 9]"), "{described}");
+        assert!(described.contains("; "), "signals are joined: {described}");
+        assert_eq!(describe_worktree_use(&[]), "");
     }
 
     // --- ranking_has_capacity token-health gate ---
@@ -12229,6 +12601,187 @@ exit 0\n";
             !ws.join(".loom/worktrees/issue-6003/dirty.txt").exists(),
             "worktree cleaned on recovery"
         );
+    }
+
+    // --- #4449: the live-use veto on the destructive recovery path -----------
+
+    /// Assert the watchdog refused to touch issue `N`'s dirty worktree: nothing
+    /// recovered, the uncommitted edit still on disk, and — critically — the
+    /// single recovery retry NOT consumed (the worktree may be free later).
+    fn assert_midbuild_refused(reg: &mut SweepRegistry, ws: &Path, issue: u32, why: &str) {
+        assert_eq!(reg.midbuild_watchdog_once(), 0, "no recovery when {why}");
+        assert!(
+            ws.join(format!(".loom/worktrees/issue-{issue}/dirty.txt"))
+                .exists(),
+            "uncommitted work MUST survive when {why} (#4449)"
+        );
+        assert!(
+            !reg.midbuild_retried.contains(&issue),
+            "a refusal must NOT consume the single recovery retry when {why}"
+        );
+        assert!(
+            reg.midbuild_inuse.contains(&issue),
+            "the refusal is recorded (and logged once) when {why}"
+        );
+    }
+
+    #[test]
+    fn midbuild_refuses_to_wipe_worktree_held_by_in_use_marker() {
+        // The #4449 incident shape: the daemon's tracked sweep really did die
+        // (terminal, no PR) but a SEPARATE live session is still using the
+        // worktree. A `.loom-in-use` marker is the explicit form of that signal.
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        let (mut reg, _rec) = fixture_registry(ws);
+
+        let wt = make_dirty_git_worktree(ws, 6101);
+        insert_terminal_issue(&mut reg, "sweep-issue-6101-dead", 6101, None);
+        std::fs::write(
+            wt.join(".loom-in-use"),
+            r#"{"shepherd_task_id": "recovery-doctor", "pid": 4321}"#,
+        )
+        .unwrap();
+
+        assert!(!reg.worktree_in_use(6101).is_empty(), "marker is detected as a live holder");
+        assert_midbuild_refused(&mut reg, ws, 6101, "a .loom-in-use marker names a live session");
+
+        // Once the holder releases the worktree, the legitimate dead-sweep
+        // recovery still works — the veto defers, it does not disable.
+        std::fs::remove_file(wt.join(".loom-in-use")).unwrap();
+        assert_eq!(reg.midbuild_watchdog_once(), 1, "recovery resumes once the holder releases");
+        assert!(reg.midbuild_retried.contains(&6101));
+        assert!(!reg.midbuild_inuse.contains(&6101), "the log-once latch is cleared");
+        assert!(!wt.join("dirty.txt").exists(), "worktree cleaned on the real recovery");
+    }
+
+    #[test]
+    fn midbuild_refuses_to_wipe_worktree_with_git_operation_in_flight() {
+        // The precise window #4449 lost work in: a `git commit` was mid-write,
+        // so git held index.lock. Never reset a worktree in that state.
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        let (mut reg, _rec) = fixture_registry(ws);
+
+        let wt = make_dirty_git_worktree(ws, 6102);
+        insert_terminal_issue(&mut reg, "sweep-issue-6102-dead", 6102, None);
+        let index_lock =
+            git_index_lock_path(&wt).expect("index.lock path resolves for a real repo");
+        std::fs::write(&index_lock, "").unwrap();
+
+        assert_midbuild_refused(&mut reg, ws, 6102, "a git index.lock write is in flight");
+
+        // Committing finishes (lock released) ⇒ recovery is available again.
+        std::fs::remove_file(&index_lock).unwrap();
+        assert_eq!(reg.midbuild_watchdog_once(), 1, "recovery resumes once index.lock clears");
+    }
+
+    #[test]
+    fn midbuild_refuses_to_wipe_worktree_with_live_claim_lock_owner() {
+        // A claim-lock whose owner PID is ALIVE means some session (daemon or
+        // not) still owns this issue — never reset its worktree underneath it.
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        let (mut reg, _rec) = fixture_registry(ws);
+
+        make_dirty_git_worktree(ws, 6103);
+        insert_terminal_issue(&mut reg, "sweep-issue-6103-dead", 6103, None);
+        let lock = reg.config.locks_dir().join("issue-6103");
+        std::fs::create_dir_all(&lock).unwrap();
+        // Our own PID is trivially alive — stands in for the live holder.
+        std::fs::write(
+            lock.join("owner.json"),
+            format!(
+                r#"{{"issue": 6103, "owner_pid": {}, "acquired_at": "{}", "sweep_id": "manual-session"}}"#,
+                std::process::id(),
+                Utc::now().to_rfc3339()
+            ),
+        )
+        .unwrap();
+
+        assert_midbuild_refused(
+            &mut reg,
+            ws,
+            6103,
+            "a live claim-lock owner still holds the issue",
+        );
+    }
+
+    #[test]
+    fn midbuild_ignores_stale_claim_lock_with_dead_owner() {
+        // The inverse guard: a lock left behind by a DEAD owner must not wedge
+        // the legitimate dead-sweep recovery path forever.
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        let (mut reg, _rec) = fixture_registry(ws);
+
+        make_dirty_git_worktree(ws, 6104);
+        insert_terminal_issue(&mut reg, "sweep-issue-6104-dead", 6104, None);
+        let lock = reg.config.locks_dir().join("issue-6104");
+        std::fs::create_dir_all(&lock).unwrap();
+        std::fs::write(
+            lock.join("owner.json"),
+            format!(
+                r#"{{"issue": 6104, "owner_pid": 2147483640, "acquired_at": "{}", "sweep_id": "dead-sweep"}}"#,
+                Utc::now().to_rfc3339()
+            ),
+        )
+        .unwrap();
+
+        assert!(
+            reg.worktree_in_use(6104).is_empty(),
+            "a dead owner's lock is not live-use evidence"
+        );
+        assert_eq!(reg.midbuild_watchdog_once(), 1, "a stale lock does not block recovery");
+        assert!(!ws.join(".loom/worktrees/issue-6104/dirty.txt").exists());
+    }
+
+    #[test]
+    fn midbuild_refuses_to_wipe_worktree_with_live_process_cwd_inside() {
+        // The signal that would have saved the #4449 session with no cooperation
+        // from it at all: a live process whose cwd is inside the worktree.
+        // `find_processes_using_directory` degrades to an empty list on hosts
+        // where it cannot probe (no /proc, no lsof), so self-skip there rather
+        // than assert something the host cannot express.
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        let (mut reg, _rec) = fixture_registry(ws);
+
+        let wt = make_dirty_git_worktree(ws, 6105);
+        insert_terminal_issue(&mut reg, "sweep-issue-6105-dead", 6105, None);
+
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .current_dir(&wt)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn a live process with cwd inside the worktree");
+
+        // The child's `chdir` happens after `fork`, so poll briefly rather than
+        // read the probe once and race it.
+        let mut detected = Vec::new();
+        for _ in 0..40 {
+            detected = crate::worktree_ops::safety::find_processes_using_directory(&wt);
+            if !detected.is_empty() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        if detected.is_empty() {
+            // Probe unavailable on this host — nothing to assert; don't leak.
+            let _ = child.kill();
+            let _ = child.wait();
+            return;
+        }
+        assert!(
+            detected.contains(&child.id()),
+            "the probe found the spawned holder: {detected:?}"
+        );
+
+        assert_midbuild_refused(&mut reg, ws, 6105, "a live process has its cwd in the worktree");
+
+        let _ = child.kill();
+        let _ = child.wait();
     }
 
     #[test]

--- a/loom-daemon/src/tokens_pool/account_registry.rs
+++ b/loom-daemon/src/tokens_pool/account_registry.rs
@@ -324,10 +324,9 @@ pub fn select_account(workspace: &Path, provider: AccountProvider) -> Result<Sel
             })
         }
         AccountProvider::Codex => {
-            let descriptor = account_inventory(workspace, provider)?
-                .into_iter()
-                .find(|account| account.enabled)
-                .ok_or_else(|| anyhow!("no enabled Codex profiles are available"))?;
+            let inventory = account_inventory(workspace, provider)?;
+            let descriptor =
+                super::health::select_healthy_at(workspace, provider, &inventory, epoch_now())?;
             Ok(SelectedAccount {
                 id: descriptor.id,
                 binding: AccountBinding::CodexHome {
@@ -337,6 +336,13 @@ pub fn select_account(workspace: &Path, provider: AccountProvider) -> Result<Sel
             })
         }
     }
+}
+
+fn epoch_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 #[cfg(test)]

--- a/loom-daemon/src/tokens_pool/health.rs
+++ b/loom-daemon/src/tokens_pool/health.rs
@@ -1,0 +1,692 @@
+//! Provider-scoped account health for runtimes which do not have Claude's
+//! quota probe. This state is deliberately separate from the legacy Claude
+//! `.ranking`, `.bad_tokens`, and `.failure_counts` files.
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use super::account_registry::{AccountDescriptor, AccountId, AccountProvider};
+use super::locking::MkdirLock;
+
+const SCHEMA_VERSION: u32 = 1;
+pub const DEFAULT_EXHAUSTED_COOLDOWN_SECS: u64 = 5 * 60 * 60;
+pub const DEFAULT_RECOVERABLE_BACKOFF_SECS: u64 = 60;
+pub const DEFAULT_SESSION_BACKOFF_SECS: u64 = 30;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TerminalClassification {
+    Success,
+    TokenExpired,
+    TokenExhausted,
+    Recoverable,
+    Timeout,
+    Fatal,
+    CwdDeleted,
+    ModelRefusal,
+    SessionLimit,
+}
+
+impl std::str::FromStr for TerminalClassification {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        Ok(match value {
+            "SUCCESS" => Self::Success,
+            "TOKEN_EXPIRED" => Self::TokenExpired,
+            "TOKEN_EXHAUSTED" => Self::TokenExhausted,
+            "RECOVERABLE" => Self::Recoverable,
+            "TIMEOUT" => Self::Timeout,
+            "FATAL" => Self::Fatal,
+            "CWD_DELETED" => Self::CwdDeleted,
+            "MODEL_REFUSAL" => Self::ModelRefusal,
+            "SESSION_LIMIT" => Self::SessionLimit,
+            other => bail!("unknown terminal classification {other:?}"),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HealthReason {
+    Healthy,
+    ReauthRequired,
+    PlanExhausted,
+    TransientFailure,
+    SessionLimit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AccountHealth {
+    pub provider: AccountProvider,
+    pub name: String,
+    pub reason: HealthReason,
+    pub updated_at: u64,
+    pub signal_provenance: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cooldown_until: Option<u64>,
+    #[serde(default)]
+    pub consecutive_transient_failures: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_success: Option<u64>,
+}
+
+impl AccountHealth {
+    fn id(&self) -> AccountId {
+        AccountId {
+            provider: self.provider,
+            name: self.name.clone(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_eligible_at(&self, now: u64) -> bool {
+        self.reason != HealthReason::ReauthRequired
+            && self.cooldown_until.is_none_or(|deadline| deadline <= now)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HealthFile {
+    version: u32,
+    #[serde(default)]
+    accounts: Vec<AccountHealth>,
+    #[serde(default)]
+    cursors: HashMap<String, u64>,
+}
+
+impl Default for HealthFile {
+    fn default() -> Self {
+        Self {
+            version: SCHEMA_VERSION,
+            accounts: Vec::new(),
+            cursors: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProviderCapacity {
+    pub provider: AccountProvider,
+    pub raw: usize,
+    pub enabled: usize,
+    pub healthy: usize,
+    pub cooldown: usize,
+    pub reauth_required: usize,
+    pub observed_at: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct NoHealthyAccountError {
+    pub provider: AccountProvider,
+    pub reasons: Vec<String>,
+}
+
+impl std::fmt::Display for NoHealthyAccountError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "no healthy {:?} account is available: {}",
+            self.provider,
+            self.reasons.join(", ")
+        )
+    }
+}
+
+impl std::error::Error for NoHealthyAccountError {}
+
+fn now_epoch() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn state_path(workspace: &Path) -> PathBuf {
+    workspace.join(".loom").join("account-health.json")
+}
+
+fn lock_path(workspace: &Path) -> PathBuf {
+    workspace.join(".loom").join("account-health.lock")
+}
+
+fn read_state(workspace: &Path) -> Result<HealthFile> {
+    let path = state_path(workspace);
+    if !path.exists() {
+        return Ok(HealthFile::default());
+    }
+    let state: HealthFile = serde_json::from_slice(
+        &fs::read(&path).with_context(|| format!("failed to read {}", path.display()))?,
+    )
+    .with_context(|| format!("malformed provider health state {}", path.display()))?;
+    if state.version != SCHEMA_VERSION {
+        bail!(
+            "unsupported provider health schema version {} in {}",
+            state.version,
+            path.display()
+        );
+    }
+    let mut ids = HashSet::new();
+    for account in &state.accounts {
+        if account.name.is_empty() || !ids.insert(account.id()) {
+            bail!("invalid or duplicate account in provider health state");
+        }
+    }
+    Ok(state)
+}
+
+fn write_state(workspace: &Path, state: &HealthFile) -> Result<()> {
+    let path = state_path(workspace);
+    let parent = path.parent().expect("health path has parent");
+    fs::create_dir_all(parent)?;
+    let temporary = parent.join(format!(".account-health.{}.tmp", std::process::id()));
+    let bytes = serde_json::to_vec_pretty(state)?;
+    fs::write(&temporary, bytes)?;
+    fs::rename(&temporary, &path)?;
+    Ok(())
+}
+
+fn with_state<T>(
+    workspace: &Path,
+    operation: impl FnOnce(&mut HealthFile) -> Result<T>,
+) -> Result<T> {
+    fs::create_dir_all(workspace.join(".loom"))?;
+    let _lock = MkdirLock::acquire(&lock_path(workspace)).map_err(anyhow::Error::msg)?;
+    let mut state = read_state(workspace)?;
+    let result = operation(&mut state)?;
+    write_state(workspace, &state)?;
+    Ok(result)
+}
+
+fn cooldown_from_env(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+pub fn record_terminal(
+    workspace: &Path,
+    id: &AccountId,
+    classification: TerminalClassification,
+    provenance: &str,
+) -> Result<()> {
+    record_terminal_at(workspace, id, classification, provenance, now_epoch())
+}
+
+pub fn record_terminal_at(
+    workspace: &Path,
+    id: &AccountId,
+    classification: TerminalClassification,
+    provenance: &str,
+    now: u64,
+) -> Result<()> {
+    if id.name.is_empty() || provenance.is_empty() {
+        bail!("account identity and signal provenance are required");
+    }
+    with_state(workspace, |state| {
+        let existing = state.accounts.iter().position(|entry| entry.id() == *id);
+        if matches!(
+            classification,
+            TerminalClassification::Timeout
+                | TerminalClassification::Fatal
+                | TerminalClassification::CwdDeleted
+                | TerminalClassification::ModelRefusal
+        ) {
+            return Ok(());
+        }
+        let entry = existing.map_or_else(
+            || AccountHealth {
+                provider: id.provider,
+                name: id.name.clone(),
+                reason: HealthReason::Healthy,
+                updated_at: now,
+                signal_provenance: provenance.to_string(),
+                cooldown_until: None,
+                consecutive_transient_failures: 0,
+                last_success: None,
+            },
+            |index| state.accounts.remove(index),
+        );
+        let mut entry = entry;
+        entry.updated_at = now;
+        entry.signal_provenance = provenance.to_string();
+        match classification {
+            // Once authentication has expired, ordinary runtime feedback cannot
+            // verify that credentials were repaired. Keep the hold sticky until
+            // clear_reauth() performs that explicit transition.
+            _ if entry.reason == HealthReason::ReauthRequired => {
+                entry.cooldown_until = None;
+                if classification == TerminalClassification::Success {
+                    entry.last_success = Some(now);
+                    entry.consecutive_transient_failures = 0;
+                }
+            }
+            TerminalClassification::Success => {
+                entry.last_success = Some(now);
+                entry.consecutive_transient_failures = 0;
+                entry.reason = HealthReason::Healthy;
+                entry.cooldown_until = None;
+            }
+            TerminalClassification::TokenExpired => {
+                entry.reason = HealthReason::ReauthRequired;
+                entry.cooldown_until = None;
+            }
+            TerminalClassification::TokenExhausted => {
+                entry.reason = HealthReason::PlanExhausted;
+                entry.cooldown_until = Some(now.saturating_add(cooldown_from_env(
+                    "LOOM_CODEX_EXHAUSTED_COOLDOWN_SECS",
+                    DEFAULT_EXHAUSTED_COOLDOWN_SECS,
+                )));
+            }
+            TerminalClassification::Recoverable => {
+                entry.reason = HealthReason::TransientFailure;
+                entry.consecutive_transient_failures =
+                    entry.consecutive_transient_failures.saturating_add(1);
+                entry.cooldown_until = Some(now.saturating_add(cooldown_from_env(
+                    "LOOM_CODEX_RECOVERABLE_BACKOFF_SECS",
+                    DEFAULT_RECOVERABLE_BACKOFF_SECS,
+                )));
+            }
+            TerminalClassification::SessionLimit => {
+                entry.reason = HealthReason::SessionLimit;
+                entry.cooldown_until = Some(now.saturating_add(cooldown_from_env(
+                    "LOOM_CODEX_SESSION_BACKOFF_SECS",
+                    DEFAULT_SESSION_BACKOFF_SECS,
+                )));
+            }
+            TerminalClassification::Timeout
+            | TerminalClassification::Fatal
+            | TerminalClassification::CwdDeleted
+            | TerminalClassification::ModelRefusal => unreachable!(),
+        }
+        state.accounts.push(entry);
+        state
+            .accounts
+            .sort_by(|a, b| (a.provider as u8, &a.name).cmp(&(b.provider as u8, &b.name)));
+        Ok(())
+    })
+}
+
+/// Clear an auth hold only after the caller has independently verified reauth.
+pub fn clear_reauth(workspace: &Path, id: &AccountId, provenance: &str) -> Result<()> {
+    with_state(workspace, |state| {
+        let entry = state
+            .accounts
+            .iter_mut()
+            .find(|entry| entry.id() == *id)
+            .ok_or_else(|| anyhow!("no health record for {:?}/{}", id.provider, id.name))?;
+        if entry.reason != HealthReason::ReauthRequired {
+            bail!("account is not awaiting reauthentication");
+        }
+        entry.reason = HealthReason::Healthy;
+        entry.cooldown_until = None;
+        entry.consecutive_transient_failures = 0;
+        entry.updated_at = now_epoch();
+        entry.signal_provenance = provenance.to_string();
+        Ok(())
+    })
+}
+
+pub fn account_health(workspace: &Path, id: &AccountId) -> Result<Option<AccountHealth>> {
+    Ok(read_state(workspace)?
+        .accounts
+        .into_iter()
+        .find(|entry| entry.id() == *id))
+}
+
+pub fn select_healthy_at(
+    workspace: &Path,
+    provider: AccountProvider,
+    inventory: &[AccountDescriptor],
+    now: u64,
+) -> Result<AccountDescriptor> {
+    with_state(workspace, |state| {
+        for entry in &mut state.accounts {
+            if entry.reason == HealthReason::TransientFailure
+                && entry.cooldown_until.is_some_and(|deadline| deadline <= now)
+            {
+                entry.reason = HealthReason::Healthy;
+                entry.cooldown_until = None;
+                entry.consecutive_transient_failures = 0;
+                entry.updated_at = now;
+            }
+        }
+        let health: HashMap<AccountId, AccountHealth> = state
+            .accounts
+            .iter()
+            .cloned()
+            .map(|entry| (entry.id(), entry))
+            .collect();
+        let mut candidates: Vec<_> = inventory
+            .iter()
+            .filter(|account| account.id.provider == provider && account.enabled)
+            .filter(|account| {
+                health
+                    .get(&account.id)
+                    .is_none_or(|entry| entry.is_eligible_at(now))
+            })
+            .cloned()
+            .collect();
+        candidates.sort_by_key(|account| {
+            (
+                health
+                    .get(&account.id)
+                    .map_or(0, |entry| entry.consecutive_transient_failures),
+                account.id.name.clone(),
+            )
+        });
+        if candidates.is_empty() {
+            let reasons = inventory
+                .iter()
+                .filter(|account| account.id.provider == provider)
+                .map(|account| {
+                    let reason = if !account.enabled {
+                        "disabled".to_string()
+                    } else if let Some(entry) = health.get(&account.id) {
+                        match entry.reason {
+                            HealthReason::ReauthRequired => "reauth_required".to_string(),
+                            _ => entry.cooldown_until.map_or_else(
+                                || "unavailable".to_string(),
+                                |until| format!("cooldown_until={until}"),
+                            ),
+                        }
+                    } else {
+                        "unavailable".to_string()
+                    };
+                    format!("{}={reason}", account.id.name)
+                })
+                .collect();
+            return Err(NoHealthyAccountError { provider, reasons }.into());
+        }
+        let fewest = health
+            .get(&candidates[0].id)
+            .map_or(0, |entry| entry.consecutive_transient_failures);
+        candidates.retain(|account| {
+            health
+                .get(&account.id)
+                .map_or(0, |entry| entry.consecutive_transient_failures)
+                == fewest
+        });
+        let cursor_key = format!("{provider:?}").to_ascii_lowercase();
+        let cursor = state.cursors.entry(cursor_key).or_default();
+        let chosen = candidates[*cursor as usize % candidates.len()].clone();
+        *cursor = cursor.saturating_add(1);
+        Ok(chosen)
+    })
+}
+
+pub fn provider_capacity_at(
+    workspace: &Path,
+    provider: AccountProvider,
+    inventory: &[AccountDescriptor],
+    now: u64,
+) -> Result<ProviderCapacity> {
+    let state = read_state(workspace)?;
+    let health: HashMap<_, _> = state
+        .accounts
+        .into_iter()
+        .map(|entry| (entry.id(), entry))
+        .collect();
+    let accounts: Vec<_> = inventory
+        .iter()
+        .filter(|account| account.id.provider == provider)
+        .collect();
+    let enabled: Vec<_> = accounts.iter().filter(|account| account.enabled).collect();
+    let reauth_required = enabled
+        .iter()
+        .filter(|account| {
+            health
+                .get(&account.id)
+                .is_some_and(|entry| entry.reason == HealthReason::ReauthRequired)
+        })
+        .count();
+    let cooldown = enabled
+        .iter()
+        .filter(|account| {
+            health.get(&account.id).is_some_and(|entry| {
+                entry.reason != HealthReason::ReauthRequired
+                    && entry.cooldown_until.is_some_and(|until| until > now)
+            })
+        })
+        .count();
+    Ok(ProviderCapacity {
+        provider,
+        raw: accounts.len(),
+        enabled: enabled.len(),
+        healthy: enabled.len().saturating_sub(reauth_required + cooldown),
+        cooldown,
+        reauth_required,
+        observed_at: now,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tokens_pool::account_registry::{CredentialKind, InventoryProvenance};
+
+    fn descriptor(provider: AccountProvider, name: &str) -> AccountDescriptor {
+        AccountDescriptor {
+            id: AccountId {
+                provider,
+                name: name.into(),
+            },
+            credential_kind: CredentialKind::CodexHome,
+            credential_reference: PathBuf::from(name),
+            enabled: true,
+            provenance: InventoryProvenance::Shared,
+        }
+    }
+
+    #[test]
+    fn exhausted_fails_over_and_expires_at_deadline() {
+        let tmp = tempfile::tempdir().unwrap();
+        let accounts = vec![
+            descriptor(AccountProvider::Codex, "a"),
+            descriptor(AccountProvider::Codex, "b"),
+        ];
+        record_terminal_at(
+            tmp.path(),
+            &accounts[0].id,
+            TerminalClassification::TokenExhausted,
+            "adapter_v1",
+            100,
+        )
+        .unwrap();
+        assert_eq!(
+            select_healthy_at(tmp.path(), AccountProvider::Codex, &accounts, 101)
+                .unwrap()
+                .id
+                .name,
+            "b"
+        );
+        assert!(select_healthy_at(
+            tmp.path(),
+            AccountProvider::Codex,
+            &accounts,
+            100 + DEFAULT_EXHAUSTED_COOLDOWN_SECS
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn expired_survives_time_and_success_until_explicit_clear() {
+        let tmp = tempfile::tempdir().unwrap();
+        let account = descriptor(AccountProvider::Codex, "a");
+        record_terminal_at(
+            tmp.path(),
+            &account.id,
+            TerminalClassification::TokenExpired,
+            "adapter_v1",
+            1,
+        )
+        .unwrap();
+        record_terminal_at(
+            tmp.path(),
+            &account.id,
+            TerminalClassification::Success,
+            "adapter_v1",
+            u64::MAX - 1,
+        )
+        .unwrap();
+        assert!(select_healthy_at(
+            tmp.path(),
+            AccountProvider::Codex,
+            std::slice::from_ref(&account),
+            u64::MAX
+        )
+        .is_err());
+        clear_reauth(tmp.path(), &account.id, "verified_reauth").unwrap();
+        assert!(select_healthy_at(tmp.path(), AccountProvider::Codex, &[account], u64::MAX).is_ok());
+    }
+
+    #[test]
+    fn expired_survives_all_later_runtime_feedback_until_explicit_clear() {
+        for classification in [
+            TerminalClassification::TokenExhausted,
+            TerminalClassification::Recoverable,
+            TerminalClassification::SessionLimit,
+        ] {
+            let tmp = tempfile::tempdir().unwrap();
+            let account = descriptor(AccountProvider::Codex, "a");
+            record_terminal_at(
+                tmp.path(),
+                &account.id,
+                TerminalClassification::TokenExpired,
+                "adapter_v1",
+                1,
+            )
+            .unwrap();
+            record_terminal_at(tmp.path(), &account.id, classification, "adapter_v1", 2).unwrap();
+
+            let health = account_health(tmp.path(), &account.id).unwrap().unwrap();
+            assert_eq!(health.reason, HealthReason::ReauthRequired);
+            assert_eq!(health.cooldown_until, None);
+            assert!(select_healthy_at(
+                tmp.path(),
+                AccountProvider::Codex,
+                std::slice::from_ref(&account),
+                u64::MAX
+            )
+            .is_err());
+        }
+    }
+
+    #[test]
+    fn expired_transient_backoff_restores_fair_rotation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let accounts = vec![
+            descriptor(AccountProvider::Codex, "a"),
+            descriptor(AccountProvider::Codex, "b"),
+        ];
+        record_terminal_at(
+            tmp.path(),
+            &accounts[0].id,
+            TerminalClassification::Recoverable,
+            "adapter_v1",
+            100,
+        )
+        .unwrap();
+
+        assert_eq!(
+            select_healthy_at(tmp.path(), AccountProvider::Codex, &accounts, 101)
+                .unwrap()
+                .id
+                .name,
+            "b"
+        );
+
+        let deadline = 100 + DEFAULT_RECOVERABLE_BACKOFF_SECS;
+        let first =
+            select_healthy_at(tmp.path(), AccountProvider::Codex, &accounts, deadline).unwrap();
+        let second =
+            select_healthy_at(tmp.path(), AccountProvider::Codex, &accounts, deadline).unwrap();
+        assert_ne!(first.id, second.id);
+        assert!([first.id.name, second.id.name].contains(&"a".to_string()));
+
+        let recovered = account_health(tmp.path(), &accounts[0].id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(recovered.reason, HealthReason::Healthy);
+        assert_eq!(recovered.cooldown_until, None);
+        assert_eq!(recovered.consecutive_transient_failures, 0);
+    }
+
+    #[test]
+    fn neutral_failures_do_not_poison_and_same_names_are_provider_scoped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let codex = descriptor(AccountProvider::Codex, "same");
+        let claude = descriptor(AccountProvider::Claude, "same");
+        record_terminal_at(
+            tmp.path(),
+            &codex.id,
+            TerminalClassification::TokenExpired,
+            "adapter_v1",
+            1,
+        )
+        .unwrap();
+        for category in [
+            TerminalClassification::Timeout,
+            TerminalClassification::Fatal,
+            TerminalClassification::CwdDeleted,
+            TerminalClassification::ModelRefusal,
+        ] {
+            record_terminal_at(tmp.path(), &claude.id, category, "adapter_v1", 2).unwrap();
+        }
+        assert!(account_health(tmp.path(), &claude.id).unwrap().is_none());
+        assert_eq!(
+            account_health(tmp.path(), &codex.id)
+                .unwrap()
+                .unwrap()
+                .reason,
+            HealthReason::ReauthRequired
+        );
+    }
+
+    #[test]
+    fn round_robin_is_persistent_and_capacity_is_honest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let accounts = vec![
+            descriptor(AccountProvider::Codex, "a"),
+            descriptor(AccountProvider::Codex, "b"),
+        ];
+        let first = select_healthy_at(tmp.path(), AccountProvider::Codex, &accounts, 1).unwrap();
+        let second = select_healthy_at(tmp.path(), AccountProvider::Codex, &accounts, 1).unwrap();
+        assert_ne!(first.id, second.id);
+        let capacity =
+            provider_capacity_at(tmp.path(), AccountProvider::Codex, &accounts, 1).unwrap();
+        assert_eq!((capacity.raw, capacity.enabled, capacity.healthy), (2, 2, 2));
+    }
+
+    #[test]
+    fn state_never_contains_credentials_or_raw_output() {
+        let tmp = tempfile::tempdir().unwrap();
+        let id = AccountId {
+            provider: AccountProvider::Codex,
+            name: "safe-name".into(),
+        };
+        record_terminal_at(tmp.path(), &id, TerminalClassification::Recoverable, "adapter_v1", 1)
+            .unwrap();
+        let state = fs::read_to_string(state_path(tmp.path())).unwrap();
+        assert!(!state.contains("auth.json"));
+        assert!(!state.contains("recognizable-secret"));
+    }
+
+    #[test]
+    fn malformed_and_unknown_schema_fail_closed() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir(tmp.path().join(".loom")).unwrap();
+        fs::write(state_path(tmp.path()), r#"{"version":99,"accounts":[]}"#).unwrap();
+        assert!(read_state(tmp.path()).is_err());
+        fs::write(state_path(tmp.path()), "{broken").unwrap();
+        assert!(read_state(tmp.path()).is_err());
+    }
+}

--- a/loom-daemon/src/tokens_pool/mod.rs
+++ b/loom-daemon/src/tokens_pool/mod.rs
@@ -67,6 +67,7 @@ pub mod bad_tokens;
 pub mod bootstrap;
 pub mod check;
 pub mod failure_counts;
+pub mod health;
 pub mod locking;
 pub mod monitor;
 pub mod monitor_db;
@@ -78,6 +79,10 @@ pub mod select;
 pub use account_registry::{
     account_inventory, select_account, AccountBinding, AccountDescriptor, AccountId,
     AccountProvider, CredentialKind, InventoryProvenance, SelectedAccount,
+};
+pub use health::{
+    account_health, clear_reauth, provider_capacity_at, record_terminal, select_healthy_at,
+    AccountHealth, HealthReason, NoHealthyAccountError, ProviderCapacity, TerminalClassification,
 };
 pub use select::{EmptyTokenPoolError, SelectedToken, EX_CONFIG};
 

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -1203,7 +1203,10 @@ pub struct DaemonStatusReport {
 /// "New-host onboarding" for the operator story.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SafehouseStatus {
-    /// One of `"not_configured"`, `"unreachable"`, `"connected"`.
+    /// One of `"not_configured"`, `"unreachable"`, `"connected"`,
+    /// `"send_rejected"` (#4464: handshake succeeds but every `send` is
+    /// rejected at the protocol layer, e.g. `'room' required` on a multi-room
+    /// host with `safehouse.room` unset).
     pub state: String,
     /// The resolved socket path the daemon last tried/uses, when known.
     /// `None` for `"not_configured"` (including the "enabled but no socket
@@ -1218,6 +1221,12 @@ pub struct SafehouseStatus {
     /// case).
     #[serde(default)]
     pub room: Option<String>,
+    /// The rejection reason, present only when `state == "send_rejected"`
+    /// (#4464) — the raw `error` string safehoused returned for the rejected
+    /// `send` (e.g. `'room' required: 3 rooms joined`). `#[serde(default)]`
+    /// keeps pre-#4464 wire payloads (which never carried it) compatible.
+    #[serde(default)]
+    pub reason: Option<String>,
 }
 
 /// Host-distress circuit-breaker snapshot for `loom-daemon status` (Issue

--- a/loom-daemon/src/worktree_ops/mod.rs
+++ b/loom-daemon/src/worktree_ops/mod.rs
@@ -28,5 +28,5 @@ pub mod logs;
 pub(crate) mod naming;
 pub mod orphan_recovery;
 pub mod repo;
-mod safety;
+pub(crate) mod safety;
 mod spawn_loop_state;


### PR DESCRIPTION
## Summary

The mid-build-death watchdog (#3895) inferred "died mid-build" from
`(terminal state ∧ no PR ∧ dirty worktree)` alone and immediately ran
`git reset --hard` + `git clean -fd` on the worktree. That signature is
**necessary but not sufficient**: `git status` cannot distinguish debris a dead
sweep left behind from a live session's work in progress — both look identical.

On 2026-07-29 that inference was wrong in the worst possible way. The daemon's
tracked sweep for issue #4366 *had* died, but a separate, **untracked** recovery
Doctor session was concurrently and legitimately editing the same worktree. The
watchdog read that session's tested-but-uncommitted fix as dead-sweep debris and
destroyed it in the window between the test run and `git commit` — silently, with
no trace at all in the daemon log.

This PR adds the missing second condition (**nothing live may still hold the
worktree**), makes every wipe loud, and closes the same gap defensively on the
script side.

Per the Curator's root-cause correction, the primary fix is in the daemon
(`SweepRegistry::midbuild_watchdog_once` / `clean_worktree`), **not** in
`worktree.sh` — nothing in the incident's timeline called `worktree.sh remove`.
The `worktree.sh` guard is the separately-real defensive gap the original filing
described, implemented as defense in depth.

## Changes

### Primary fix — `loom-daemon/src/sweep_registry.rs`

- **`SweepRegistry::worktree_in_use()`** (new) gathers four live-holder signals,
  cheapest-first, and returns them as `Vec<WorktreeUseEvidence>`:

  | Signal | Why it counts |
  |---|---|
  | `.loom-in-use` marker in the worktree | A session (incl. manual/non-daemon) claims it; the one signal an operator can plant by hand to fence off a worktree |
  | `.loom/locks/issue-<N>/owner.json` whose `owner_pid` is **alive** | A live claim holder. A **dead** owner's lock is deliberately NOT evidence, so a stale lock can never wedge legitimate recovery |
  | `index.lock` in the worktree's gitdir | A git index write is in flight — precisely the `git commit` window that lost the #4449 work |
  | A live process with cwd inside the worktree | Operator shell, manual role session, or an orphaned grandchild still writing files |

  Signals that cannot be probed on a host contribute nothing (the existing
  `worktree_ops::safety` probes already degrade to "unknown ⇒ empty"), so a host
  without `/proc`/`lsof` still gets the other three.

- **`midbuild_decision()`** takes a fourth `worktree_in_use` input and gains a
  `MidbuildDecision::InUse` arm. The in-use gate is ordered **above** the retry
  bookkeeping on purpose: a refusal must not burn the single recovery retry, since
  the worktree may legitimately be free on a later tick.

- **The `InUse` arm** logs one loud, log-once line naming the holder and how to
  clear it if stale, leaves the worktree untouched, and does not re-dispatch. The
  latch clears as soon as the worktree stops being in use, so a later refusal (or
  a genuine give-up) still surfaces.

- **`clean_worktree()`** now calls a new `log_worktree_discard()` first, emitting
  the porcelain status + `diff --stat HEAD` of everything it is about to destroy
  (each bounded to 40 lines). A wipe can never again be silent in the daemon log.

- `worktree_ops::safety` promoted `mod` → `pub(crate) mod` to reuse its existing
  `read_in_use_marker` / `find_processes_using_directory` probes rather than
  reimplementing them.

### Defense in depth — `defaults/scripts/worktree.sh`

- `remove <N>` now **refuses** when `git status --porcelain` is non-empty: it
  prints the count, lists the offending paths (capped at 20), and prints all four
  ways to proceed — commit, save a patch, stash, or `--force`. Exits 1; in
  `--json` mode still emits a single `{"success": false, "removed": false, …}`
  document on stdout.
- New **`--force`** (`-f`) flag discards the dirty state explicitly, announcing
  what it discarded.
- Loom runtime markers (`.loom-managed`, `.loom-in-use`, `.loom-checkpoint`,
  `.no-changes-needed`) are filtered out of the dirty check. This is load-bearing,
  not cosmetic: `worktree.sh` writes `.loom-managed` into every worktree it
  creates, so in a repo whose `.gitignore` predates #3838 a naive porcelain check
  would refuse **every** managed worktree. Test 8 asserts this.
- Step numbering in the guard-order doc block renumbered (3→8) and help/usage
  text updated.

### Docs — `defaults/docs/daemon-reference.md`

New "Mid-build-death live-use veto (#4449)" subsection in the watchdog section:
the incident, the four-signal table, and the operator remediation path for a
stale holder. (No `CLAUDE.md` change — budget check passes at 314/320.)

## Acceptance Criteria Verification

Using the Curator's **updated** criteria (which supersede the filing's):

- [x] **`midbuild_watchdog_once()` gains a live-process check before
  `clean_worktree()`** — `(terminal ∧ no PR ∧ dirty)` is no longer sufficient;
  `worktree_in_use()` must also be empty. Implemented with an explicit "in-use
  marker written by any session, including manual/non-daemon" signal plus a
  PID-liveness probe and an `index.lock` probe, exactly as the AC suggested.
- [x] **`clean_worktree()` logs what it discarded before the
  `reset --hard`/`clean -fd`** — `log_worktree_discard()` emits both the file
  list and a diffstat at `warn`; the no-op fallback still announces the action.
- [x] **`worktree.sh remove` independently gains the dirty-check guard
  (refuse, or `--force`)** — with remediation guidance, per the original body.
- [x] **Regression test in `sweep_registry.rs::tests` near
  `worktree_dirty_and_clean_roundtrip` / `midbuild_leaves_clean_worktree_alone`
  covering a terminal/no-PR/dirty sweep whose worktree is concurrently held by a
  live non-tracked process** — four such tests (one per signal), each asserting
  the uncommitted file survives, nothing was recovered, and the retry was not
  consumed.
- [x] **No regression to the legitimate dead-sweep recovery path** —
  `midbuild_recovers_dead_sweep_with_dirty_worktree_once`,
  `midbuild_recovery_is_bounded_to_one`, `midbuild_leaves_clean_worktree_alone`,
  `midbuild_skips_sweep_that_produced_a_pr`,
  `midbuild_token_gate_defers_when_pool_exhausted_then_proceeds`, and
  `midbuild_ignores_running_sweeps` all still pass unchanged. Two new tests pin
  the *inverse* direction explicitly: recovery resumes on the next tick once the
  holder releases, and a stale dead-owner lock does not block recovery.

## Test Plan

**New Rust tests (10)** in `loom-daemon/src/sweep_registry.rs::tests`:

| Test | Asserts |
|---|---|
| `midbuild_refuses_to_wipe_worktree_held_by_in_use_marker` | Refusal + work survives + retry unconsumed; then recovery **resumes** after the marker is removed |
| `midbuild_refuses_to_wipe_worktree_with_git_operation_in_flight` | Same for a live `index.lock`; recovery resumes once it clears |
| `midbuild_refuses_to_wipe_worktree_with_live_claim_lock_owner` | Same for a claim-lock owned by a live PID |
| `midbuild_refuses_to_wipe_worktree_with_live_process_cwd_inside` | Same for a real spawned child with cwd in the worktree (polls past the post-`fork` chdir race; self-skips where the host cannot probe) |
| `midbuild_ignores_stale_claim_lock_with_dead_owner` | Inverse guard: a dead owner's lock does **not** wedge recovery |
| `midbuild_decision_in_use_worktree_is_never_recovered` | Pure: `InUse` beats both `Recover` and `GiveUp` |
| `midbuild_decision_in_use_is_irrelevant_when_not_dirty_or_pr_exists` | Pure: the flag never manufactures work |
| `truncate_lines_keeps_short_input_and_caps_long_input` | Log-bounding helper |
| `describe_worktree_use_joins_every_signal` | Log-rendering helper |

**New bash cases (4)** in `defaults/scripts/tests/test-worktree-remove.sh`
(tests 6–9): dirty refusal (message content, path listing, all four remedies
present, `--json` shape), `--force` removal + discard announcement, marker-only
worktree still removable, staged-only change also refused.

**Results:**
- `cargo test -p loom-daemon --lib` → **2179 passed, 0 failed**
- `cargo test --workspace --lib --bins` → **2179 + 37 + 4 passed, 0 failed**
- `bash defaults/scripts/tests/test-worktree-remove.sh` → **26 passed, 0 failed**
  (was 13 before this PR)
- `cargo fmt --all -- --check` clean; `cargo clippy` with CI's exact flag set clean
- `bash -n` + `shellcheck -S warning` clean on both changed shell files
- `scripts/check-claude-md-budget.sh` + `scripts/check-agents-md-sync.sh` pass

**Manual verification of the live-process signal.** To confirm the
`find_processes_using_directory` path is genuinely exercised (rather than
silently self-skipping), the test's skip branch was temporarily replaced with a
`panic!` and re-run on this Linux host — it did **not** panic, so the probe
really did detect the spawned holder. Reverted before committing.

## Notes for the reviewer

- **Two pre-existing flaky failures in `loom-daemon/tests/integration_basic.rs`**
  on this host ("Daemon failed to create socket within 5s"). They are unrelated
  to this diff: a *different* set of tests fails on each run (2 on one run, 5 on
  the next), they exercise tmux terminal create/destroy over IPC (no code path
  this PR touches), and `.loom/scripts/build-gate.sh` already documents this
  target as host-dependent and excludes it from the local gate. CI runs the full
  `cargo test --workspace` in a controlled environment.
- **CI wiring for the bash suite was dropped.** `test-worktree-remove.sh` runs
  nowhere in CI today (it is not referenced by any workflow). I added a step to
  the `installer-tests` job, but the push was rejected — the pushing token lacks
  the `workflow` scope — so that hunk was reverted to keep the PR pushable. A
  maintainer/operator can add this one line to `.github/workflows/ci.yml` after
  `test-install-reinstall-safety.sh` (the job's `scripts` paths-filter already
  covers `defaults/**`):
  ```yaml
        - name: Run worktree remove tests, incl. the dirty-worktree guard (#4449)
          run: bash defaults/scripts/tests/test-worktree-remove.sh
  ```
  The Rust regression tests — the primary coverage for this incident — do run in
  CI via `cargo test --workspace`.
- **Trade-off worth a second opinion:** a permanently-stale `index.lock` or an
  unreleased `.loom-in-use` marker will keep the watchdog refusing recovery
  indefinitely. That is deliberate — silent data loss is strictly worse than a
  visible stall — and the refusal log names the exact file to remove. Flagging it
  as a conscious choice rather than an oversight.
- Overlaps `sweep_registry.rs` with **#4444** (same 2026-07-29 incident window,
  different code path — `dispatch_inner`'s label re-check). No functional overlap;
  a textual merge conflict is possible if #4444 lands first, confined to the
  `midbuild_watchdog_once` region.

Closes #4449