### PR TITLE
fix(daemon): refuse dispatch of park-labeled issues in dispatch_inner

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -2441,6 +2441,46 @@ never wedge the daemon. It is GitHub-only (uses the `closedByPullRequestsReferen
 closes-graph, filtered to `state == "OPEN"`); a Gitea workspace fails open and
 keeps today's behavior.
 
+**Park-label dispatch guard (#4444, step 2.7).** The `loom:blocked` /
+`loom:operator-only` **park** labels are the state machine's only "take this out
+of automation" signal, and until #4444 they were enforced *only* in the
+work-finder's candidate query (`SKIP_LABELS`) — one of six dispatch routes. Every
+other route (all three watchdogs, the reaper's checkpoint-resume, the epic
+supervisor, the IPC/CLI `dispatch_sweep`) funnels through
+`SweepRegistry::dispatch()` without re-reading the forge labels, so a park applied
+*after* the original dispatch was invisible to them and the daemon re-claimed
+deliberately parked work (observed on #4366). Step 2.7 — immediately after the
+2.6 open-PR guard, still before the claim lock and label flip — refuses any
+dispatch whose issue currently carries a park label, with a typed
+`ParkedIssueDispatchError` the work finder attributes to `labeled-skip` (never to
+`error(s)`). Four properties are load-bearing:
+
+- **`PARK_LABELS`, not `SKIP_LABELS`.** The guard keys on the
+  `loom:blocked` / `loom:operator-only` subset only. `loom:building` is
+  *legitimately* present on a watchdog re-dispatch or a checkpoint-resume of the
+  daemon's **own** claim, so refusing it would break exactly the recovery paths
+  this guard is meant to constrain. The two constants live side by side in
+  `work_finder.rs` (`SKIP_LABELS` is composed as `BUILDING_LABEL` +
+  `PARK_LABELS`), so they cannot drift.
+- **The #4256 resume bypass does not exempt it.** `resume_bypass_pr` exempts step
+  **2.6** for a sweep's own open PR and nothing else — a park applied after the
+  crash still stops the resume. The refusal stays failure-visible: the reaper
+  logs it and still publishes `sweep.issue.{N}.resume_dispatched` with
+  `dispatched: false`.
+- **REST, not GraphQL.** The probe is `gh api repos/{owner}/{repo}/issues/{N}
+  --jq '.labels[].name'`, a *different* rate-limit bucket from the GraphQL calls
+  steps 2.5/2.6 ride — so a park still holds while the GraphQL quota is
+  exhausted, the condition under which the #4123 guard failed open during the
+  2026-07-29 incident.
+- **Fail-open and fixture-safe.** Any `gh` error, timeout, or unresolvable repo
+  lets dispatch proceed (a forge outage must never wedge the daemon), and the
+  probe is skipped entirely when label flips are disabled (`skip_label_flip`).
+
+Operator note: because this covers the IPC/CLI route too, a manual
+`dispatch_sweep` on a parked issue is refused by design — clear the park label
+first (or use `loom-daemon quarantine clear <N>` when the park came from the
+insta-crash quarantine) rather than expecting a manual dispatch to override it.
+
 **Cost / default.** Enabling detection adds exactly one `gh issue view --json
 labels` round-trip per dispatch (measured ~0.4s against GitHub), bounded by the
 same `LOOM_REAP_GH_TIMEOUT_SECS` ceiling as the other best-effort `gh` calls.
@@ -2469,9 +2509,12 @@ Every other dispatch path still refuses via `OpenPrDispatchError`, so
 a `sweep.issue.{N}.resume_dispatched` event (`{pr, checkpoint_phase?,
 dispatched, repo?}`) is published — with `dispatched: false` on the rare
 case the resume dispatch call itself fails — and narrated over Safehouse
-(when enabled) as a `handoff`. The `restore_label_to_ready` operator-park
-guard (#4206) still applies: an issue carrying `loom:blocked` is never
-resume-dispatched.
+(when enabled) as a `handoff`. Operator parks still win: `restore_label_to_ready`
+preserves a `loom:blocked` label instead of flipping it back to `loom:issue`
+(#4206), and the resume dispatch itself is refused by the **step 2.7 park-label
+guard** (#4444) — which the 2.6 resume bypass deliberately does not exempt — so a
+park applied after the crash surfaces as `dispatched: false` rather than an
+overridden park.
 
 ### Completion narration → public fleet feed (#4426)
 

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -159,6 +159,49 @@ impl std::fmt::Display for OpenPrDispatchError {
 
 impl std::error::Error for OpenPrDispatchError {}
 
+/// Typed, matchable error returned by [`SweepRegistry::dispatch`] when the
+/// park-label guard (Issue #4444, step 2.7) refuses a dispatch because the
+/// target issue currently carries a [`PARK_LABELS`] entry (`loom:blocked` /
+/// `loom:operator-only`).
+///
+/// The work-finder's [`SKIP_LABELS`] filter only covers *its own* candidate
+/// query. Every other dispatch route — all three watchdogs (#3887 / #3895 /
+/// #3910), the reaper's checkpoint-resume (#4256), the epic supervisor, and the
+/// IPC/CLI `dispatch_sweep` — funnels through `dispatch_inner` without ever
+/// re-reading the forge labels, so a park applied *after* the original dispatch
+/// was invisible to them and the daemon overrode a deliberate human park
+/// (observed on #4366). This guard closes that hole for every route at once.
+///
+/// Like [`OpenPrDispatchError`] this is a **distinct, downcast-matchable** type
+/// (not a string-matched `anyhow` message) so the work-finder can attribute the
+/// refusal to its labeled-skip counter rather than to a generic dispatch
+/// failure.
+///
+/// [`PARK_LABELS`]: crate::work_finder::PARK_LABELS
+/// [`SKIP_LABELS`]: crate::work_finder::SKIP_LABELS
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParkedIssueDispatchError {
+    /// The issue whose dispatch was refused.
+    pub issue: u32,
+    /// The park label that triggered the refusal (`loom:blocked` or
+    /// `loom:operator-only`).
+    pub label: String,
+}
+
+impl std::fmt::Display for ParkedIssueDispatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "refusing to dispatch issue #{}: it currently carries `{}` (#4444 park-label \
+             guard). A deliberate park must survive every re-dispatch route — watchdog, \
+             checkpoint-resume, epic supervisor, IPC/CLI — until the label is cleared.",
+            self.issue, self.label
+        )
+    }
+}
+
+impl std::error::Error for ParkedIssueDispatchError {}
+
 /// Issue #4256: checkpoint phases at/after Builder completion. A crash whose
 /// checkpoint reads one of these means a PR was opened for the issue, so
 /// [`SweepRegistry::reap_once`]'s reaper-driven resume is eligible to
@@ -2502,6 +2545,56 @@ impl SweepRegistry {
             }
         }
 
+        // 2.7 Park-label guard (Issue #4444). The work-finder's `SKIP_LABELS`
+        //     hard-skip is enforced only in *its own* candidate query, so it
+        //     covers exactly one of the six dispatch routes. Every other route
+        //     — all three watchdogs (#3887 / #3895 / #3910), the reaper's
+        //     checkpoint-resume (#4256), the epic supervisor, the IPC/CLI
+        //     `dispatch_sweep` — funnels through here, and until this guard
+        //     existed none of them ever re-read the forge labels. A
+        //     `loom:blocked` / `loom:operator-only` park applied *after* the
+        //     original dispatch was therefore invisible to every re-dispatch
+        //     path, and the daemon overrode a deliberate human/agent park
+        //     (observed on #4366). Placing the check here — before the
+        //     lock/label flip — covers all routes with one probe.
+        //
+        //     Three properties are load-bearing:
+        //
+        //     - It guards on `PARK_LABELS` only, NOT the full `SKIP_LABELS`
+        //       set. `loom:building` is legitimately present on a watchdog
+        //       re-dispatch or a checkpoint-resume of the daemon's OWN claim,
+        //       so refusing it would break the review-stall watchdog's
+        //       cancel-and-re-dispatch and the reaper's resume.
+        //     - It is NOT exempted by `resume_bypass_pr`. The #4256 bypass
+        //       covers step 2.6 (its own open PR) and nothing else: a park
+        //       applied after the crash must still stop the resume, which is
+        //       the exact defect this guard fixes.
+        //     - It probes over **REST** (`gh api repos/{owner}/{repo}/issues/N`),
+        //       a separate rate-limit bucket from the GraphQL calls 2.5/2.6
+        //       ride, so the park still holds while the GraphQL quota is
+        //       exhausted — the condition under which the #4123 guard failed
+        //       open during the 2026-07-29 incident.
+        //
+        //     Best-effort and fail-open, mirroring 2.5/2.6: any forge
+        //     error/timeout/unresolvable repo returns `None` and dispatch
+        //     proceeds, so a `gh` outage can never wedge the daemon. Skipped
+        //     entirely when label flips are disabled (test fixtures without
+        //     `gh` credentials).
+        if !self.config.skip_label_flip {
+            if let Some(label) = self.first_park_label(issue_number) {
+                log::info!(
+                    "issue #{issue_number}: refusing dispatch — the issue carries `{label}`, a \
+                     deliberate park that every dispatch route must respect (#4444 park-label \
+                     guard); clear the label to re-enable automation"
+                );
+                return Err(ParkedIssueDispatchError {
+                    issue: issue_number,
+                    label,
+                }
+                .into());
+            }
+        }
+
         // 3. Acquire the claim lock atomically.
         let sweep_id = generate_sweep_id(kind);
         self.acquire_lock(issue_number, &sweep_id)?;
@@ -2980,11 +3073,76 @@ impl SweepRegistry {
             .find_map(|l| l.trim().parse::<u32>().ok())
     }
 
+    /// Best-effort probe for the first [`PARK_LABELS`] entry currently on
+    /// `issue`, used by the #4444 park-label dispatch guard (step 2.7). Returns
+    /// `Some(label)` when the issue carries a park label and `None` otherwise —
+    /// where `None` covers BOTH "not parked" and any failure (missing/failed/
+    /// timed-out `gh`, unresolvable repo, unparseable output).
+    ///
+    /// Callers MUST treat `None` as **fail-open**, matching
+    /// [`issue_is_closed`](Self::issue_is_closed) and
+    /// [`first_open_linked_pr`](Self::first_open_linked_pr): a forge outage or a
+    /// wedged `gh` must never wedge dispatch. Bounded by [`reap_gh_timeout`] like
+    /// every other dispatch-path `gh` call (#3973).
+    ///
+    /// Deliberately probes over **REST** (`gh api repos/{owner}/{repo}/issues/N`)
+    /// rather than `gh issue view --json labels` (which rides GraphQL, like
+    /// steps 2.5/2.6): REST is a separate rate-limit bucket, so a deliberate park
+    /// still holds while the GraphQL quota is exhausted — exactly the condition
+    /// under which the #4123 open-PR guard failed open during the 2026-07-29
+    /// incident. The `--jq` emits one label name per line.
+    ///
+    /// The returned label is chosen by [`PARK_LABELS`] order, not forge order, so
+    /// the refusal message is deterministic when an issue carries both.
+    ///
+    /// [`PARK_LABELS`]: crate::work_finder::PARK_LABELS
+    fn first_park_label(&self, issue: u32) -> Option<String> {
+        let labels = self.current_labels_via_rest(issue)?;
+        crate::work_finder::PARK_LABELS
+            .iter()
+            .find(|park| labels.iter().any(|l| l == *park))
+            .map(|park| (*park).to_string())
+    }
+
+    /// Read `issue`'s current label names over the GitHub REST API. `None` on any
+    /// failure (see [`first_park_label`](Self::first_park_label) for the
+    /// fail-open contract); `Some(vec![])` for an issue with no labels, which is
+    /// a *successful* read and must stay distinguishable from a failed one.
+    fn current_labels_via_rest(&self, issue: u32) -> Option<Vec<String>> {
+        let (owner, repo) = self.resolve_owner_repo()?;
+        let gh = self
+            .config
+            .gh_bin
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("gh"));
+        let mut cmd = Command::new(&gh);
+        cmd.arg("api")
+            .arg(format!("repos/{owner}/{repo}/issues/{issue}"))
+            .arg("--jq")
+            .arg(".labels[].name");
+        // Resolve against this registry's own workspace, matching the label-flip
+        // helpers and the other dispatch-path probes (#3937).
+        cmd.current_dir(&self.config.workspace_root);
+        let output = output_with_timeout(cmd, reap_gh_timeout()).ok()??;
+        if !output.status.success() {
+            return None;
+        }
+        Some(
+            String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .map(str::trim)
+                .filter(|l| !l.is_empty())
+                .map(String::from)
+                .collect(),
+        )
+    }
+
     /// Resolve `(owner, repo)` for the registry's workspace, needed because
-    /// `gh api graphql` (unlike `gh issue view`) cannot infer the repo from the
-    /// working directory. Prefers the process-global `LOOM_REPO` override
-    /// (`owner/repo`) when set, else asks `gh repo view` in the workspace root.
-    /// Returns `None` on any failure so the open-PR guard fails open.
+    /// `gh api` (unlike `gh issue view`) cannot infer the repo from the working
+    /// directory — neither the GraphQL open-PR probe nor the REST park-label
+    /// probe accepts a `--repo` flag. Prefers the process-global `LOOM_REPO`
+    /// override (`owner/repo`) when set, else asks `gh repo view` in the
+    /// workspace root. Returns `None` on any failure so both guards fail open.
     fn resolve_owner_repo(&self) -> Option<(String, String)> {
         if let Ok(repo) = std::env::var("LOOM_REPO") {
             if let Some((o, r)) = repo.split_once('/') {
@@ -4493,16 +4651,25 @@ impl SweepRegistry {
                             // credentials never attempt a real forge probe
                             // here) and only checked for phases at/after
                             // Builder completion, so a pre-PR crash never
-                            // pays for the extra forge round trip. Also
-                            // respects the #4206 operator-park guard: never
-                            // resume-dispatch an issue `restore_label_to_ready`
-                            // just deliberately left without `loom:issue`
-                            // because it carries `loom:blocked`.
+                            // pays for the extra forge round trip. A deliberate
+                            // park (`loom:blocked` / `loom:operator-only`,
+                            // possibly applied by `restore_label_to_ready`'s
+                            // #4206 pre-check moments ago) still stops the
+                            // resume — but that check now lives centrally in
+                            // `dispatch_inner` step 2.7 (#4444) rather than
+                            // here, so it covers the watchdogs and IPC/CLI too
+                            // and there is only ONE label probe per resume
+                            // dispatch. A parked issue therefore reaches the
+                            // dispatch call below and is refused there, which
+                            // is deliberately *more* visible than the old
+                            // silent call-site skip: the refusal surfaces as a
+                            // `warn!` naming the park label plus the existing
+                            // `SweepResumeDispatched { dispatched: false }`
+                            // event.
                             if !self.config.skip_label_flip
                                 && resume_phase_check
                                     .as_deref()
                                     .is_some_and(|p| RESUMABLE_CHECKPOINT_PHASES.contains(&p))
-                                && !self.issue_has_blocked_label(issue)
                             {
                                 if let Some(pr) = self.first_open_linked_pr(issue) {
                                     // Bounded resume attempts (#4256, Judge
@@ -13135,6 +13302,380 @@ exit 0\n";
             !calls.contains("api graphql"),
             "the open-PR (2.6) probe must never run once 2.5 refuses; got: {calls:?}"
         );
+    }
+
+    // --- park-label dispatch guard (Issue #4444) ---
+
+    /// Install a fake `gh` for the park-label guard (step 2.7):
+    ///
+    /// - `issue view --json state` reports `OPEN` (so the 2.5 closed-issue guard
+    ///   passes) and `issue view --json labels` reports whether `loom:blocked` is
+    ///   present (so the reap path's `issue_has_blocked_label` — still used by
+    ///   `restore_label_to_ready` — behaves faithfully);
+    /// - `api graphql` prints `graphql_pr` (the post-`--jq` open linked PR
+    ///   number, empty for none) so the 2.6 open-PR guard can be steered;
+    /// - `api repos/<owner>/<repo>/issues/<n>` prints `rest_labels`
+    ///   (whitespace-separated label names, one per output line) and exits
+    ///   `rest_exit` — the REST probe the new guard consults;
+    /// - `repo view` resolves the owner/repo.
+    ///
+    /// Every invocation is logged so a test can assert which probes ran.
+    fn park_guard_registry(
+        ws: &Path,
+        rest_labels: &str,
+        rest_exit: i32,
+        graphql_pr: &str,
+        skip_label_flip: bool,
+    ) -> (SweepRegistry, PathBuf) {
+        let gh_log = ws.join("gh-invocations.log");
+        let fake_gh = ws.join("fake-gh.sh");
+        let blocked = rest_labels.split_whitespace().any(|l| l == "loom:blocked");
+        let script = format!(
+            "#!/usr/bin/env bash\n\
+             printf '%s\\n' \"$*\" >> \"{log}\"\n\
+             if [[ \"$1\" == \"issue\" && \"$2\" == \"view\" ]]; then\n\
+             if [[ \"$*\" == *labels* ]]; then printf '%s\\n' \"{blocked}\"; \
+             else printf 'OPEN\\n'; fi\n\
+             exit 0\n\
+             fi\n\
+             if [[ \"$1\" == \"api\" && \"$2\" == \"graphql\" ]]; then\n\
+             printf '%s\\n' \"{gql}\"\n\
+             exit 0\n\
+             fi\n\
+             if [[ \"$1\" == \"api\" && \"$2\" == repos/* ]]; then\n\
+             printf '%s\\n' {labels}\n\
+             exit {rest_exit}\n\
+             fi\n\
+             if [[ \"$1\" == \"repo\" && \"$2\" == \"view\" ]]; then\n\
+             printf 'rjwalters/loom\\n'\n\
+             exit 0\n\
+             fi\n\
+             exit 0\n",
+            log = gh_log.display(),
+            blocked = blocked,
+            gql = graphql_pr,
+            labels = rest_labels,
+            rest_exit = rest_exit,
+        );
+        std::fs::write(&fake_gh, &script).unwrap();
+        let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_gh, perms).unwrap();
+        if let Ok(f) = std::fs::File::open(&fake_gh) {
+            let _ = f.sync_all();
+        }
+
+        let scripts_dir = ws.join(".loom").join("scripts");
+        std::fs::create_dir_all(&scripts_dir).unwrap();
+        let spawn = scripts_dir.join("spawn-claude.sh");
+        std::fs::write(&spawn, "#!/usr/bin/env bash\necho spawned\nexit 0\n").unwrap();
+        let mut sperms = std::fs::metadata(&spawn).unwrap().permissions();
+        sperms.set_mode(0o755);
+        std::fs::set_permissions(&spawn, sperms).unwrap();
+        if let Ok(f) = std::fs::File::open(&spawn) {
+            let _ = f.sync_all();
+        }
+        touch_sweep_command(ws);
+
+        let mut config = SweepRegistryConfig::new(ws.to_path_buf());
+        config.spawn_bin = Some(spawn);
+        config.gh_bin = Some(fake_gh);
+        config.skip_label_flip = skip_label_flip;
+        config.journal_path = Some(ws.join("test-sweeps-journal.json"));
+        (SweepRegistry::new(config), gh_log)
+    }
+
+    /// AC: `dispatch` for an issue carrying `loom:blocked` is refused with the
+    /// typed [`ParkedIssueDispatchError`], and it must NOT acquire the claim lock
+    /// or flip any labels — a deliberate park must survive every dispatch route.
+    /// The probe rides the REST bucket (`gh api repos/.../issues/N`), not
+    /// GraphQL.
+    #[test]
+    #[serial]
+    fn dispatch_refuses_blocked_issue_without_flipping_labels() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        let (mut reg, gh_log) = park_guard_registry(ws, "loom:blocked", 0, "", false);
+
+        let err = reg
+            .dispatch(&SweepKind::Issue(4444), None, None, None, None)
+            .expect_err("a parked issue must be refused");
+        let typed = err
+            .downcast_ref::<ParkedIssueDispatchError>()
+            .expect("refusal must carry the typed ParkedIssueDispatchError");
+        assert_eq!(typed.issue, 4444);
+        assert_eq!(typed.label, "loom:blocked");
+
+        let calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            calls.contains("api repos/rjwalters/loom/issues/4444"),
+            "the guard must probe labels over REST, not GraphQL; got: {calls:?}"
+        );
+        assert!(
+            !calls.contains("issue edit"),
+            "no label flip on a refused dispatch; got: {calls:?}"
+        );
+        assert!(running_issue_sweep_id(&reg, 4444).is_none(), "no lock, no entry");
+        std::env::remove_var("LOOM_REPO");
+    }
+
+    /// AC: `loom:operator-only` is the second park label and refuses identically
+    /// — the daemon must never dispatch work a human has claimed for themselves.
+    #[test]
+    #[serial]
+    fn dispatch_refuses_operator_only_issue() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        let (mut reg, _gh_log) = park_guard_registry(ws, "loom:operator-only", 0, "", false);
+
+        let err = reg
+            .dispatch(&SweepKind::Issue(4445), None, None, None, None)
+            .expect_err("an operator-only issue must be refused");
+        let typed = err
+            .downcast_ref::<ParkedIssueDispatchError>()
+            .expect("refusal must carry the typed ParkedIssueDispatchError");
+        assert_eq!(typed.label, "loom:operator-only");
+        assert!(running_issue_sweep_id(&reg, 4445).is_none());
+        std::env::remove_var("LOOM_REPO");
+    }
+
+    /// AC (the load-bearing exclusion): `loom:building` ALONE must NOT refuse.
+    /// It is legitimately present on the daemon's own in-flight claim, so a guard
+    /// keyed on the full `SKIP_LABELS` set would break the review-stall
+    /// watchdog's cancel-and-re-dispatch and the reaper's checkpoint-resume.
+    #[test]
+    #[serial]
+    fn dispatch_park_guard_allows_building_label_alone() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        let (mut reg, gh_log) = park_guard_registry(ws, "loom:building loom:curated", 0, "", false);
+
+        let out = reg
+            .dispatch(&SweepKind::Issue(4446), None, None, None, None)
+            .expect("loom:building alone must never refuse dispatch");
+        assert!(wait_until_dead(out.pid, FIXTURE_CHILD_WAIT_MS));
+
+        let calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            calls.contains("api repos/rjwalters/loom/issues/4446"),
+            "the guard still probed; it just did not refuse; got: {calls:?}"
+        );
+        assert!(
+            calls.contains("issue edit 4446"),
+            "dispatch proceeded to the label flip; got: {calls:?}"
+        );
+        if let Some(id) = running_issue_sweep_id(&reg, 4446) {
+            let _ = reg.cancel(&id, Duration::from_secs(2));
+        }
+        std::env::remove_var("LOOM_REPO");
+    }
+
+    /// AC (fail-open, the single most safety-critical property): a forge error on
+    /// the REST label probe (non-zero `gh api`) must NOT wedge dispatch — the
+    /// probe returns `None` and dispatch proceeds to spawn + label flip, exactly
+    /// like the 2.5/2.6 guards.
+    #[test]
+    #[serial]
+    fn dispatch_fails_open_when_park_label_probe_errors() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        // The park label IS present, but the probe fails ⇒ unknown ⇒ fail open.
+        let (mut reg, gh_log) = park_guard_registry(ws, "loom:blocked", 1, "", false);
+
+        let out = reg
+            .dispatch(&SweepKind::Issue(4447), None, None, None, None)
+            .expect("a gh outage on the park probe must not wedge dispatch (fail-open)");
+        assert!(wait_until_dead(out.pid, FIXTURE_CHILD_WAIT_MS));
+
+        let calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            calls.contains("api repos/rjwalters/loom/issues/4447"),
+            "the guard attempted the REST probe; got: {calls:?}"
+        );
+        assert!(
+            calls.contains("issue edit 4447"),
+            "dispatch proceeded to the label flip after failing open; got: {calls:?}"
+        );
+        if let Some(id) = running_issue_sweep_id(&reg, 4447) {
+            let _ = reg.cancel(&id, Duration::from_secs(2));
+        }
+        std::env::remove_var("LOOM_REPO");
+    }
+
+    /// AC: `skip_label_flip = true` (test fixtures without `gh` credentials)
+    /// never attempts the probe at all — not even the REST call — mirroring the
+    /// 2.5/2.6 skip condition.
+    #[test]
+    #[serial]
+    fn dispatch_skip_label_flip_bypasses_park_guard() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        let (mut reg, gh_log) = park_guard_registry(ws, "loom:blocked", 0, "", true);
+
+        let out = reg
+            .dispatch(&SweepKind::Issue(4448), None, None, None, None)
+            .expect("skip_label_flip must bypass the park guard entirely");
+        assert!(wait_until_dead(out.pid, FIXTURE_CHILD_WAIT_MS));
+
+        let calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            !calls.contains("api repos/"),
+            "no forge call at all when label flips are disabled; got: {calls:?}"
+        );
+        if let Some(id) = running_issue_sweep_id(&reg, 4448) {
+            let _ = reg.cancel(&id, Duration::from_secs(2));
+        }
+        std::env::remove_var("LOOM_REPO");
+    }
+
+    /// Guard ordering: 2.6 (open-PR) runs before 2.7 (park label), so an ordinary
+    /// dispatch of a parked issue that ALSO has an open PR is attributed to the
+    /// cheaper-to-explain open-PR refusal and never pays for the REST probe.
+    #[test]
+    #[serial]
+    fn open_pr_guard_fires_before_park_guard() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        let (mut reg, gh_log) = park_guard_registry(ws, "loom:blocked", 0, "4500", false);
+
+        let err = reg
+            .dispatch(&SweepKind::Issue(4449), None, None, None, None)
+            .expect_err("an issue with an open linked PR must be refused");
+        assert!(
+            err.downcast_ref::<OpenPrDispatchError>().is_some(),
+            "the 2.6 open-PR guard wins for an ordinary dispatch; got: {err}"
+        );
+        let calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            !calls.contains("api repos/"),
+            "the 2.7 REST probe must not run once 2.6 refuses; got: {calls:?}"
+        );
+        std::env::remove_var("LOOM_REPO");
+    }
+
+    /// THE CORE REGRESSION (#4444): a checkpoint-resume dispatch — which
+    /// deliberately bypasses the 2.6 open-PR guard for its OWN PR — must still be
+    /// refused by the 2.7 park guard when the issue was parked after the crash.
+    /// This is the path that overrode a `loom:blocked` park on #4366.
+    ///
+    /// The refusal must be failure-visible, not silent: the reaper still emits
+    /// `SweepResumeDispatched { dispatched: false }` (and logs the refusal, whose
+    /// message names the park label), and no fresh `Running` entry is created.
+    #[tokio::test]
+    #[serial]
+    async fn reaper_resume_refused_when_issue_parked_after_crash() {
+        use crate::event_bus::EventBus;
+
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        // Open linked PR #4501 (so the resume path engages and the 2.6 bypass
+        // matches) AND a `loom:blocked` park applied after the crash.
+        let (mut reg, gh_log) = park_guard_registry(ws, "loom:blocked", 0, "4501", false);
+        let bus = Arc::new(EventBus::new());
+        reg.set_event_bus(bus.clone());
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        write_checkpoint(&reg, 4366, "builder-done");
+        insert_dead_running_entry(&mut reg, 4366, "sweep-issue-4366-crashed");
+
+        let changed = reg.reap_once();
+        assert!(changed >= 1);
+
+        let mut saw_resume_false = false;
+        for _ in 0..8 {
+            let Ok(ev) = tokio::time::timeout(Duration::from_secs(5), sub.recv()).await else {
+                break;
+            };
+            if let Event::SweepResumeDispatched {
+                issue,
+                pr,
+                dispatched,
+                ..
+            } = ev.unwrap()
+            {
+                assert_eq!(issue, 4366);
+                assert_eq!(pr, 4501);
+                assert!(
+                    !dispatched,
+                    "a park applied after the crash must refuse the resume dispatch"
+                );
+                saw_resume_false = true;
+            }
+        }
+        assert!(
+            saw_resume_false,
+            "the park refusal must stay failure-visible on the resume path (not silent)"
+        );
+
+        assert!(
+            running_issue_sweep_id(&reg, 4366).is_none(),
+            "a refused resume must not create a fresh Running entry"
+        );
+        let calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            calls.contains("api repos/rjwalters/loom/issues/4366"),
+            "the resume dispatch went through the central 2.7 REST probe; got: {calls:?}"
+        );
+        assert_eq!(
+            calls
+                .lines()
+                .filter(|l| l.contains("api repos/rjwalters/loom/issues/4366"))
+                .count(),
+            1,
+            "exactly ONE park-label probe per resume dispatch (deduped with the old \
+             call-site-only check); got: {calls:?}"
+        );
+        // The park survives: the crash-path restore removed the stale claim but
+        // did NOT re-add `loom:issue` (#4206), and no fresh claim was flipped on.
+        assert!(
+            !calls.contains("--add-label loom:issue"),
+            "the operator's park must not be clobbered back to loom:issue; got: {calls:?}"
+        );
+        std::env::remove_var("LOOM_REPO");
+    }
+
+    /// Companion to the test above: with the SAME fixture but no park label, the
+    /// resume dispatch succeeds — proving the refusal above is caused by the park
+    /// label and not by some other property of the fixture.
+    #[tokio::test]
+    #[serial]
+    async fn reaper_resume_succeeds_when_issue_not_parked() {
+        use crate::event_bus::EventBus;
+
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::set_var("LOOM_REPO", "rjwalters/loom");
+        let (mut reg, _gh_log) = park_guard_registry(ws, "loom:curated", 0, "4502", false);
+        let bus = Arc::new(EventBus::new());
+        reg.set_event_bus(bus.clone());
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        write_checkpoint(&reg, 4367, "builder-done");
+        insert_dead_running_entry(&mut reg, 4367, "sweep-issue-4367-crashed");
+
+        let changed = reg.reap_once();
+        assert!(changed >= 1);
+
+        let mut saw_resume_true = false;
+        for _ in 0..8 {
+            let Ok(ev) = tokio::time::timeout(Duration::from_secs(5), sub.recv()).await else {
+                break;
+            };
+            if let Event::SweepResumeDispatched { dispatched, .. } = ev.unwrap() {
+                assert!(dispatched, "an unparked issue must still resume normally");
+                saw_resume_true = true;
+            }
+        }
+        assert!(saw_resume_true, "expected a successful resume dispatch");
+        assert!(running_issue_sweep_id(&reg, 4367).is_some());
+        std::env::remove_var("LOOM_REPO");
     }
 
     // --- reaper-driven resume (Issue #4256) ---

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -91,7 +91,7 @@ use crate::cpu_headroom::{
 use crate::disk_headroom::disk_headroom_limit;
 use crate::event_bus::EventBus;
 use crate::main_health_gate::{MainHealthState, WorkspaceHealthStates};
-use crate::sweep_registry::OpenPrDispatchError;
+use crate::sweep_registry::{OpenPrDispatchError, ParkedIssueDispatchError};
 use crate::tokens::{token_pool_size, token_pool_size_at_dir};
 use crate::types::Event;
 use crate::workspace_pool::WorkspacePool;
@@ -193,13 +193,34 @@ pub const WORK_FINDER_MAX_ADMISSIONS_PER_TICK_ENV: &str =
 /// momentarily computed room for all six.
 pub const DEFAULT_MAX_ADMISSIONS_PER_TICK: usize = 3;
 
+/// Labels marking a **deliberate park** — a human (or an agent acting on a
+/// human's behalf) has taken the issue out of the automation queue and it must
+/// stay out until the label is cleared (Issue #4444).
+///
+/// This is the strict subset of [`SKIP_LABELS`] that survives *every* dispatch
+/// route, so it is the constant the dispatch-time guard in
+/// `SweepRegistry::dispatch()` (step 2.7) consults. It deliberately EXCLUDES
+/// [`BUILDING_LABEL`]: `loom:building` is legitimately present on the daemon's
+/// own in-flight claim, so a guard that refused it would break the watchdogs'
+/// cancel-and-re-dispatch and the reaper's checkpoint-resume — both of which
+/// re-dispatch an issue the daemon itself already flipped to `loom:building`.
+pub const PARK_LABELS: &[&str] = &["loom:blocked", "loom:operator-only"];
+
+/// The daemon's own claim label. Disqualifies a *fresh* work-finder candidate
+/// (a `loom:building` row is already being worked), but is NOT a park — see
+/// [`PARK_LABELS`].
+pub const BUILDING_LABEL: &str = "loom:building";
+
 /// Labels that disqualify an issue from dispatch even if it still appears in
 /// the `loom:issue`-filtered listing.
 ///
 /// A `loom:issue` row should never itself carry these (they are mutually
 /// exclusive states in the `.github/labels.yml` state machine), but `gh`'s
 /// label cache can be briefly stale, so the finder checks defensively.
-pub const SKIP_LABELS: &[&str] = &["loom:building", "loom:blocked", "loom:operator-only"];
+///
+/// Composed as [`BUILDING_LABEL`] + [`PARK_LABELS`] rather than re-listing the
+/// label strings, so the two constants can never drift apart (#4444).
+pub const SKIP_LABELS: &[&str] = &[BUILDING_LABEL, PARK_LABELS[0], PARK_LABELS[1]];
 
 /// Label that promotes an issue ahead of its non-urgent siblings **within the
 /// same workspace-priority tier** (Issue #3946). Detection is best-effort: if no
@@ -434,7 +455,12 @@ pub struct TickReport {
     pub seen: usize,
     /// Issues for which a **new** sweep was dispatched this tick.
     pub dispatched: usize,
-    /// Issues skipped because they carried a [`SKIP_LABELS`] entry.
+    /// Issues skipped because they carried a [`SKIP_LABELS`] entry — either in
+    /// the candidate listing this tick, or at dispatch time when the
+    /// dispatch-side [`PARK_LABELS`] guard (#4444) found a park label the
+    /// listing had not caught yet (`ParkedIssueDispatchError`). Both are the
+    /// same reason, so they share one counter rather than splitting a stale-cache
+    /// race across `labeled-skip` and `error(s)`.
     pub skipped_labeled: usize,
     /// Issues skipped because a live sweep already exists for them (registry
     /// in-flight set, or an idempotency no-op from `dispatch()`).
@@ -645,6 +671,20 @@ pub fn tick_with_admission_cap(
                         "work_finder: skipping issue #{} — it already has an open linked PR \
                          (#4123 open-PR guard)",
                         item.number
+                    );
+                } else if let Some(parked) = e.downcast_ref::<ParkedIssueDispatchError>() {
+                    // Park-label guard refusal (#4444). The candidate query
+                    // already filters `SKIP_LABELS`, so reaching this means the
+                    // listing was stale relative to the forge — the dispatch-time
+                    // probe is the authoritative read. Same reason as the query
+                    // filter, so it lands on the same `labeled-skip` counter
+                    // rather than on `error(s)`.
+                    report.skipped_labeled += 1;
+                    log::info!(
+                        "work_finder: skipping issue #{} — it carries `{}` on the forge \
+                         (#4444 park-label guard; the candidate listing was stale)",
+                        item.number,
+                        parked.label
                     );
                 } else {
                     report.errors += 1;
@@ -950,6 +990,16 @@ pub fn tick_multi_with_admission_cap<S: WorkSource, D: WorkDispatcher>(
                         "work_finder: skipping issue #{} — it already has an open linked PR \
                          (#4123 open-PR guard)",
                         cand.number
+                    );
+                } else if let Some(parked) = e.downcast_ref::<ParkedIssueDispatchError>() {
+                    // Park-label guard refusal (#4444) — see the single-workspace
+                    // `tick` for the rationale. A labeled-skip, not a failure.
+                    report.skipped_labeled += 1;
+                    log::info!(
+                        "work_finder: skipping issue #{} — it carries `{}` on the forge \
+                         (#4444 park-label guard; the candidate listing was stale)",
+                        cand.number,
+                        parked.label
                     );
                 } else {
                     report.errors += 1;
@@ -2256,6 +2306,11 @@ mod tests {
         /// Issue numbers whose dispatch should be refused by the open-PR guard
         /// (#4123) — the dispatcher returns the typed [`OpenPrDispatchError`].
         pr_open_issues: HashSet<u32>,
+        /// Issue numbers whose dispatch should be refused by the park-label
+        /// guard (#4444) — the dispatcher returns the typed
+        /// [`ParkedIssueDispatchError`], simulating a `loom:blocked` park the
+        /// candidate listing had not caught yet.
+        parked_issues: HashSet<u32>,
         /// Issue numbers this dispatcher reports as quarantined (Issue #3939).
         quarantined: HashSet<u32>,
         /// Cumulative cross-host collision count this dispatcher reports (#4085).
@@ -2282,6 +2337,15 @@ mod tests {
                 // Mirror the production `SweepRegistry::dispatch` open-PR guard:
                 // refuse with the typed, downcast-matchable error (#4123).
                 return Err(OpenPrDispatchError { issue, pr: 9999 }.into());
+            }
+            if self.parked_issues.contains(&issue) {
+                // Mirror the production `SweepRegistry::dispatch` park-label
+                // guard: refuse with the typed, downcast-matchable error (#4444).
+                return Err(ParkedIssueDispatchError {
+                    issue,
+                    label: "loom:blocked".to_string(),
+                }
+                .into());
             }
             if self.fail_issues.contains(&issue) {
                 anyhow::bail!("forced dispatch failure for #{issue}");
@@ -2745,6 +2809,72 @@ exit 0
         assert_eq!(report.errors, 0, "an open-PR skip is never a dispatch error");
         assert_eq!(report.dispatched, 2, "#1 and #3 still dispatch");
         assert_eq!(disp.dispatched, vec![1, 3], "#2 never dispatched");
+    }
+
+    #[test]
+    fn test_park_labels_are_the_non_building_subset_of_skip_labels() {
+        // #4444: the dispatch-time guard keys on PARK_LABELS, so the two
+        // constants must stay in lockstep — SKIP_LABELS is exactly
+        // BUILDING_LABEL + PARK_LABELS, and PARK_LABELS must never contain
+        // `loom:building` (a guard that refused it would break the watchdogs'
+        // and the reaper's re-dispatch of the daemon's OWN claim).
+        assert!(
+            !PARK_LABELS.contains(&BUILDING_LABEL),
+            "PARK_LABELS must exclude {BUILDING_LABEL}: it is legitimately present on a \
+             watchdog / checkpoint-resume re-dispatch of the daemon's own claim"
+        );
+        for park in PARK_LABELS {
+            assert!(
+                SKIP_LABELS.contains(park),
+                "{park} is a park label, so the work-finder query must skip it too"
+            );
+        }
+        let mut expected: Vec<&str> = vec![BUILDING_LABEL];
+        expected.extend_from_slice(PARK_LABELS);
+        assert_eq!(
+            SKIP_LABELS, expected,
+            "SKIP_LABELS is composed as BUILDING_LABEL + PARK_LABELS"
+        );
+    }
+
+    #[test]
+    fn test_tick_park_label_refusal_counts_as_labeled_skip_not_error() {
+        // #2 carries `loom:blocked` on the forge but the candidate listing was
+        // stale: `dispatch()` refuses with the typed ParkedIssueDispatchError,
+        // which the finder attributes to `skipped_labeled` — NOT `errors` — while
+        // its siblings dispatch normally (#4444).
+        let mut source = FakeSource::once(vec![issue(1), issue(2), issue(3)]);
+        let mut disp = RecordingDispatcher {
+            parked_issues: HashSet::from([2]),
+            ..Default::default()
+        };
+        let report = tick(&mut source, &mut disp, 10, false).unwrap();
+
+        assert_eq!(report.skipped_labeled, 1, "#2's park refusal is a labeled-skip");
+        assert_eq!(report.errors, 0, "a park-label skip is never a dispatch error");
+        assert_eq!(report.skipped_pr_open, 0, "and it is not an open-PR skip either");
+        assert_eq!(report.dispatched, 2, "#1 and #3 still dispatch");
+        assert_eq!(disp.dispatched, vec![1, 3], "#2 never dispatched");
+    }
+
+    #[test]
+    fn test_tick_multi_park_label_refusal_counts_as_labeled_skip() {
+        // Same attribution in the multi-workspace tick (#4444).
+        let mut multi = vec![
+            (
+                FakeSource::once(vec![issue(1)]),
+                RecordingDispatcher {
+                    parked_issues: HashSet::from([1]),
+                    ..Default::default()
+                },
+            ),
+            (FakeSource::once(vec![issue(2)]), RecordingDispatcher::default()),
+        ];
+        let report = tick_multi(&mut multi, &[0, 0], 10, &[false, false]);
+
+        assert_eq!(report.skipped_labeled, 1);
+        assert_eq!(report.errors, 0);
+        assert_eq!(report.dispatched, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`SKIP_LABELS` was enforced **only** in the work-finder's candidate query — one of
six dispatch routes. Every other route (all three watchdogs #3887/#3895/#3910, the
reaper's checkpoint-resume #4256, the epic supervisor, the IPC/CLI `dispatch_sweep`)
funnels through `dispatch_inner`, which checked workspace-commands (2.4),
closed-issue (2.5) and open-PR (2.6) but **never re-read the forge labels**. A
`loom:blocked` / `loom:operator-only` park applied *after* the original dispatch was
invisible to every re-dispatch path, so the daemon overrode a deliberate human/agent
park (observed on #4366).

This adds a central park-label guard as `dispatch_inner` **step 2.7**, so every
dispatch route goes through it with one probe.

## Changes

- **`work_finder.rs`** — new `PARK_LABELS` (`loom:blocked`, `loom:operator-only`)
  and `BUILDING_LABEL` constants; `SKIP_LABELS` is now *composed* as
  `BUILDING_LABEL` + `PARK_LABELS` (const slice indexing) so the two can never
  drift apart. A unit test pins the invariant, including "`PARK_LABELS` must never
  contain `loom:building`".
- **`sweep_registry.rs`** — new typed `ParkedIssueDispatchError { issue, label }`
  and step 2.7 in `dispatch_inner`:
  - guards on `PARK_LABELS` only, so `loom:building` alone never refuses (would
    otherwise break the review-stall watchdog's cancel-and-re-dispatch and the
    reaper's checkpoint-resume of the daemon's own claim);
  - **not** exempted by `resume_bypass_pr` — the #4256 bypass covers step 2.6 and
    nothing else;
  - **fail-open** on any forge error/timeout/unresolvable repo, and skipped
    entirely under `skip_label_flip`;
  - probes over **REST** (`gh api repos/{owner}/{repo}/issues/N --jq
    '.labels[].name'`), a separate rate-limit bucket from the GraphQL calls steps
    2.5/2.6 ride, so a park still holds while the GraphQL quota is exhausted — the
    condition under which the #4123 guard failed open during the 2026-07-29
    incident.
- **Dedupe**: removed the reaper resume arm's separate `issue_has_blocked_label`
  call (added by `6c464f57`, call-site-only and GraphQL-bucket). The central guard
  now covers it, so there is exactly **one** label probe per resume dispatch. The
  refusal is deliberately *more* visible than the old silent call-site skip: a
  `warn!` naming the park label plus the existing
  `SweepResumeDispatched { dispatched: false }` event.
  (`issue_has_blocked_label` is still used by `restore_label_to_ready` (#4206) and
  the block-children path — not dead code.)
- **Work-finder attribution**: a `ParkedIssueDispatchError` lands on the existing
  `labeled-skip` counter (same reason as the query filter), never on `error(s)`,
  in both `tick` and `tick_multi`.
- **`defaults/docs/daemon-reference.md`** — documents the step 2.7 guard alongside
  the #4088 closed-issue / #4123 open-PR guard docs, and corrects the
  reaper-driven-resume paragraph's operator-park sentence. (`.loom/docs/` is a
  symlink to `defaults/docs/`, so no second copy to update.)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `dispatch_inner` gains a central park-label guard every route goes through | ✅ | Step 2.7 sits in `dispatch_inner` (the single funnel), before the claim lock / label flip — `dispatch_refuses_blocked_issue_without_flipping_labels` asserts refusal + no `issue edit` + no registry entry |
| Guard NOT bypassed by `resume_bypass_pr` | ✅ | `reaper_resume_refused_when_issue_parked_after_crash`: open PR #4501 matches the bypass (2.6 exempted), 2.7 still refuses; companion `reaper_resume_succeeds_when_issue_not_parked` proves the fixture resumes without the park |
| `loom:building` alone does NOT refuse | ✅ | `dispatch_park_guard_allows_building_label_alone` (labels `loom:building loom:curated` → dispatch spawns + flips label); plus `test_park_labels_are_the_non_building_subset_of_skip_labels` |
| Forge-probe error → dispatch proceeds (fail-open) | ✅ | `dispatch_fails_open_when_park_label_probe_errors` (`gh api` exits 1 while the park label IS present → dispatch spawns and flips) |
| `skip_label_flip` fixtures never attempt the probe | ✅ | `dispatch_skip_label_flip_bypasses_park_guard` asserts the gh log contains no `api repos/` call at all |
| `loom:operator-only` refused | ✅ | `dispatch_refuses_operator_only_issue` (typed error, `label == "loom:operator-only"`) |
| Refusal on resume path is failure-visible | ✅ | `SweepResumeDispatched { dispatched: false, pr: 4501 }` asserted on the event bus; `dispatch_inner` logs an `info!` naming the label and the reaper logs a `warn!` carrying the error Display |
| One probe per resume dispatch (dedupe) | ✅ | Same test counts exactly 1 `api repos/rjwalters/loom/issues/4366` line in the gh invocation log |
| `cargo test` / `cargo clippy` clean | ✅ | See Test Plan |
| `defaults/docs/daemon-reference.md` updated | ✅ | New "Park-label dispatch guard (#4444, step 2.7)" subsection + amended #4256 resume paragraph |

## Test Plan

- `cargo test` — **2174 lib + 50 integration tests pass**, 0 failures (9 new tests:
  7 in `sweep_registry`, 3 in `work_finder`).
  - Note: `tests/integration_basic.rs` reported 3 flaky tmux failures
    (`test_create_terminal`, `test_create_terminal_with_working_dir`,
    `test_destroy_terminal`) when the whole suite ran in parallel; re-running
    `cargo test --test integration_basic` alone passes 9/9. Unrelated to this
    change (no terminal/tmux code touched).
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --all` — applied.

## Scope notes / tradeoffs

- **Batching with the 2.5 closed-issue check was deliberately NOT done.** The
  issue offered either replacing `issue_is_closed` with a batched REST
  `{state, labels}` probe, or adding a separate REST label probe. I chose the
  separate probe: the batched form would make the existing, proven 2.5 guard depend
  on `resolve_owner_repo()` (which `gh issue view` does not need), adding a *new*
  fail-open path to an existing guard for the sake of saving one call per dispatch.
  The tradeoff is one extra `gh` round trip on dispatches that reach 2.7 — bounded
  by `LOOM_REAP_GH_TIMEOUT_SECS` like every other dispatch-path probe, and paid
  only after 2.4/2.5/2.6 all pass. Moving 2.5 to the batched REST probe is a clean
  follow-up if the call count matters.
- **Guard ordering**: 2.7 runs *after* 2.6, so an ordinary dispatch of an issue
  that is both parked and has an open PR is attributed to the open-PR refusal and
  skips the REST probe entirely (`open_pr_guard_fires_before_park_guard` pins this).
- **Operator-visible behavior change**: because the guard also covers the IPC/CLI
  route, a manual `dispatch_sweep` on a parked issue is now refused by design. The
  doc says so explicitly and names the remediation (clear the label, or
  `loom-daemon quarantine clear <N>` when the park came from the insta-crash
  quarantine).
- **Unrelated main-checkout dirt**: a concurrent `resync-installed.sh` re-stamped
  `.loom/install-metadata.json` and refreshed two `.loom/docs/*` copies in the main
  checkout at 04:02 UTC while this PR's tests were running. Those paths are disjoint
  from this diff and were not written by this session, so they were left untouched
  rather than quarantined out from under the other actor.

Closes #4444