### PR TITLE
fix(daemon): guard redundant GH_TOKEN refresh-tick writes + validate installation id

### DIFF
--- a/defaults/scripts/lib/github-app-token.sh
+++ b/defaults/scripts/lib/github-app-token.sh
@@ -315,7 +315,17 @@ _github_app_api_get_installation() {
   http_code=$(echo "$resp" | tail -1)
   body=$(echo "$resp" | sed '$d')
   if [[ "$http_code" -ge 200 && "$http_code" -lt 300 ]]; then
-    echo "$body" | jq -r '.id'
+    # Validate before echoing: a 2xx body missing `.id` yields the literal
+    # string "null", which is non-empty and would poison the per-owner cache
+    # persistently (#4456). Installation ids are numeric -- reject anything
+    # else at the source so the caller never caches a bad value.
+    local id
+    id=$(echo "$body" | jq -r '.id')
+    if [[ ! "$id" =~ ^[0-9]+$ ]]; then
+      _GH_APP_LAST_ERROR="GitHub App installation response for ${nwo} did not include a numeric installation id (HTTP ${http_code})"
+      return 1
+    fi
+    printf '%s' "$id"
     return 0
   fi
   _GH_APP_LAST_ERROR="could not resolve the GitHub App installation for ${nwo} (HTTP ${http_code} -- is the app installed on this repo/org?)"
@@ -366,7 +376,11 @@ github_app_get_token() {
 
   local installation_id
   installation_id=$(cat "$(_github_app_installation_cache_path "$owner")" 2>/dev/null || echo "")
-  if [[ -z "$installation_id" ]]; then
+  # Treat a missing OR non-numeric cache value as a miss (#4456): a
+  # pre-poisoned cache file holding the literal "null" (or any non-numeric
+  # junk from an older build) is non-empty, so a bare `-z` test would keep
+  # reusing it forever. Re-resolving self-heals such hosts.
+  if [[ ! "$installation_id" =~ ^[0-9]+$ ]]; then
     installation_id=$(_github_app_api_get_installation "$nwo") || return 1
     printf '%s' "$installation_id" > "$(_github_app_installation_cache_path "$owner")"
   fi

--- a/defaults/scripts/tests/test-github-app-token.sh
+++ b/defaults/scripts/tests/test-github-app-token.sh
@@ -290,6 +290,92 @@ else
     fail "\`get-token\` CLI should report not_configured when unconfigured" "$get_token_output"
 fi
 
+# ============================================================================
+# Installation-id validation (#4456): a 2xx response missing/`null` `.id` must
+# not be echoed (and thus never cached), and a pre-poisoned cache holding a
+# non-numeric value must be treated as a miss (self-healing).
+# ============================================================================
+echo "Testing installation-id validation (#4456)..."
+
+# Stub the network + JWT so these run without a live GitHub App. `curl` is
+# dispatched on the request URL (its last argument); `github_app_jwt` is a
+# constant so no signing is required.
+STUB_INSTALL_BODY='{"id": 55}'
+STUB_INSTALL_CODE='200'
+curl() {
+    local url=""
+    for _a in "$@"; do url="$_a"; done
+    case "$url" in
+        */installation) printf '%s\n%s' "$STUB_INSTALL_BODY" "$STUB_INSTALL_CODE" ;;
+        */access_tokens) printf '%s\n%s' '{"token":"ghs_mintedvalue","expires_at":"2099-01-01T00:00:00Z"}' '200' ;;
+        *) printf '%s\n%s' '{}' '404' ;;
+    esac
+}
+github_app_jwt() { echo "fake.jwt.signature"; }
+
+export LOOM_GITHUB_APP_ID="424242"
+export LOOM_GITHUB_APP_KEY_PATH="$KEY_PATH"
+
+# Valid numeric id -> echoed, success.
+STUB_INSTALL_BODY='{"id": 55}'
+if resolved_id=$(_github_app_api_get_installation "acme/widgets") && [[ "$resolved_id" == "55" ]]; then
+    pass "installation resolve echoes a numeric id on a well-formed 2xx response"
+else
+    fail "well-formed 2xx installation response should echo the numeric id" "got: ${resolved_id:-<none>}"
+fi
+
+# 2xx body with `"id": null` -> must NOT echo, must return 1 with an error set.
+# Run in the current shell (stdout redirected to a file, not command
+# substitution) so the `_GH_APP_LAST_ERROR` the function sets is observable.
+inst_out="$WORK_DIR/get-installation.out"
+STUB_INSTALL_BODY='{"id": null}'
+_GH_APP_LAST_ERROR=""
+if _github_app_api_get_installation "acme/widgets" > "$inst_out" 2>/dev/null; then
+    fail "2xx response with null id should fail, not succeed" "echoed: $(cat "$inst_out")"
+else
+    echoed=$(cat "$inst_out")
+    if [[ "$echoed" != *"null"* && -n "$_GH_APP_LAST_ERROR" ]]; then
+        pass "2xx response with null id -> returns 1, no 'null' echoed, error set"
+    else
+        fail "null id should not be echoed and must set _GH_APP_LAST_ERROR" "echoed='${echoed}' err='${_GH_APP_LAST_ERROR}'"
+    fi
+fi
+
+# 2xx body with no `.id` field at all -> same rejection.
+STUB_INSTALL_BODY='{"message":"Not Found"}'
+_GH_APP_LAST_ERROR=""
+if _github_app_api_get_installation "acme/widgets" > "$inst_out" 2>/dev/null; then
+    fail "2xx response missing .id should fail" "echoed: $(cat "$inst_out")"
+else
+    if [[ -n "$_GH_APP_LAST_ERROR" ]]; then
+        pass "2xx response missing .id -> returns 1 with error set"
+    else
+        fail "missing .id must set _GH_APP_LAST_ERROR"
+    fi
+fi
+
+# Pre-poisoned cache holding the literal "null" -> treated as a miss and
+# re-resolved (self-healing), so github_app_get_token still succeeds and the
+# cache file is rewritten with the numeric id.
+STUB_INSTALL_BODY='{"id": 55}'
+poison_owner="poisoned"
+poison_cache="$(_github_app_installation_cache_path "$poison_owner")"
+mkdir -p "$(dirname "$poison_cache")"
+printf '%s' "null" > "$poison_cache"
+if heal_token=$(github_app_get_token "${poison_owner}/repo") && [[ "$heal_token" == "ghs_mintedvalue" ]]; then
+    cache_after=$(cat "$poison_cache")
+    if [[ "$cache_after" == "55" ]]; then
+        pass "pre-poisoned 'null' installation cache is treated as a miss and self-heals to the numeric id"
+    else
+        fail "poisoned cache should be rewritten with the numeric id" "cache now: '${cache_after}'"
+    fi
+else
+    fail "github_app_get_token should self-heal past a poisoned 'null' cache" "got: ${heal_token:-<none>}"
+fi
+
+unset -f curl github_app_jwt
+unset LOOM_GITHUB_APP_ID LOOM_GITHUB_APP_KEY_PATH
+
 # --- Summary ---
 echo ""
 echo "────────────────────────────────"

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -1304,6 +1304,63 @@ enum CleanupAction {
     },
 }
 
+/// Decide whether a freshly minted/cached `GH_TOKEN` value warrants a
+/// `std::env::set_var` write, given the value currently exported in the process
+/// environment (#4456).
+///
+/// The `github-app` refresh tick fires every `GITHUB_APP_REFRESH_INTERVAL`
+/// (~5min), but the shell helper only re-mints when the cached token is close
+/// to expiry (~hourly). A cache hit still reports [`GithubAppOutcome::Minted`]
+/// with the *unchanged* token, so writing unconditionally rewrites `GH_TOKEN`
+/// ~10 of every ~11 ticks with an identical value. Each redundant `set_var`
+/// under the multithreaded tokio runtime opens a (tiny) `environ`
+/// use-after-free window against the `gh`/`git` children the daemon constantly
+/// spawns, for no benefit.
+///
+/// Returns `true` only when the minted value actually differs from `current`
+/// (including the case where nothing is exported yet, `current == None`). This
+/// is a pure seam so the guard can be unit-tested without mutating the
+/// process-global environment (which would add to the test-race hazard tracked
+/// by #4385).
+fn gh_token_needs_update(current: Option<&str>, minted: &str) -> bool {
+    current != Some(minted)
+}
+
+#[cfg(test)]
+mod gh_token_guard_tests {
+    //! Tests for the #4456 value-changed guard on the `github-app` refresh
+    //! tick. Deliberately a *pure* function test — it does not touch the
+    //! process-global `GH_TOKEN`, so it neither races nor adds to the
+    //! test-env-mutation hazard tracked by #4385.
+    use super::gh_token_needs_update;
+
+    #[test]
+    fn cache_hit_same_value_skips_write() {
+        // The ~10-of-11 common case: the shell helper returned the unchanged
+        // cached token, so no `set_var` is warranted.
+        assert!(!gh_token_needs_update(Some("ghs_abc"), "ghs_abc"));
+    }
+
+    #[test]
+    fn genuine_rotation_writes() {
+        // A real ~hourly rotation: the minted value differs -> write.
+        assert!(gh_token_needs_update(Some("ghs_old"), "ghs_new"));
+    }
+
+    #[test]
+    fn unset_env_writes() {
+        // Nothing exported yet (Err(VarError) -> None): treat as different so
+        // the first post-boot tick still exports the token.
+        assert!(gh_token_needs_update(None, "ghs_first"));
+    }
+
+    #[test]
+    fn empty_current_differs_from_nonempty() {
+        // An empty exported value is not equal to a real minted token.
+        assert!(gh_token_needs_update(Some(""), "ghs_real"));
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -1550,9 +1607,12 @@ async fn main() -> Result<()> {
     let credential_preflight = github_app_preflight.report;
 
     // #4430: keep the minted installation token fresh across its ~1h
-    // lifetime for a long-running daemon. A no-op tick (unconfigured, or the
-    // shell helper's own cache still has >10min left) costs a handful of
-    // cheap subprocess execs and never touches `GH_TOKEN`; a genuine mint
+    // lifetime for a long-running daemon. Ticks that don't rotate the token
+    // never *write* `GH_TOKEN`: the `NotConfigured` arm is a true no-op, and a
+    // cache-hit tick (the shell helper's own cache still has plenty of life —
+    // ~10 of every ~11 ticks) *reads* the current value but skips the
+    // `set_var` because the minted value is unchanged (#4456 value-changed
+    // guard). Only a genuine rotation (value differs) rewrites the env; a mint
     // failure is logged and the loop keeps whatever `GH_TOKEN` the process
     // already has (fail-open, matching the startup preflight's posture).
     if let (Some(script_path), Some(owner_repo)) = (&github_app_script, &github_app_owner_repo) {
@@ -1577,11 +1637,25 @@ async fn main() -> Result<()> {
                         app_id,
                         ..
                     }) => {
-                        std::env::set_var("GH_TOKEN", token);
-                        log::debug!(
-                            "credential_preflight: github-app refresh tick minted a token \
-                             (app {app_id} installation {installation_id}) — #4430"
-                        );
+                        // #4456: only write when the value actually rotated. A
+                        // cache-hit tick returns the unchanged token, and a
+                        // redundant `set_var` under the multithreaded runtime
+                        // needlessly races the `environ` reads of spawned
+                        // `gh`/`git` children.
+                        if gh_token_needs_update(std::env::var("GH_TOKEN").ok().as_deref(), &token)
+                        {
+                            std::env::set_var("GH_TOKEN", token);
+                            log::debug!(
+                                "credential_preflight: github-app refresh tick rotated GH_TOKEN \
+                                 (app {app_id} installation {installation_id}) — #4430"
+                            );
+                        } else {
+                            log::debug!(
+                                "credential_preflight: github-app refresh tick cache hit, \
+                                 GH_TOKEN unchanged (app {app_id} installation {installation_id}) \
+                                 — #4456"
+                            );
+                        }
                     }
                     Ok(credential_preflight::GithubAppOutcome::NotConfigured) => {
                         // Cheap no-op tick -- nothing to refresh.

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -1527,7 +1527,7 @@ pub struct CredentialPreflightReport {
     /// (e.g. `"keyring"`, `"oauth_token"`) reported by `gh auth status`;
     /// `"github-app"` when a GitHub App installation token was minted and
     /// exported as `GH_TOKEN` (#4430 — see
-    /// [`crate::credential_preflight::resolve_with_github_app`]).
+    /// [`crate::credential_preflight::run_with_github_app`]).
     /// `"none"` when nothing resolved; `"unknown"` when the probe itself
     /// failed to run. NEVER a token value.
     pub mechanism: String,


### PR DESCRIPTION
## Summary

Hardens the daemon's only production `std::env::set_var("GH_TOKEN", …)` sites introduced by the #4430 GitHub App installation-token work (surfaced during Judge review of #4454). The refresh tick fires every ~5min but the shell helper only re-mints near expiry (~hourly), so a cache-hit tick returned `GithubAppOutcome::Minted` with the *unchanged* token and rewrote `GH_TOKEN` ~10 of every ~11 ticks. Each redundant `set_var` under the multithreaded tokio runtime needlessly races the `environ` reads of the `gh`/`git` children the daemon constantly spawns.

## Changes

- **`loom-daemon/src/main.rs`** — added a pure `gh_token_needs_update(current, minted)` seam and applied it in the refresh tick's `Minted` arm, so `set_var` fires only on a genuine rotation (value changed). Corrected the stale loop comment: a cache-hit tick now *reads* but does not *write* `GH_TOKEN`. Added `gh_token_guard_tests` (pure function tests — no global-env mutation, so no addition to the #4385 test-race hazard).
- **`defaults/scripts/lib/github-app-token.sh`** — validate the installation id is numeric before echoing it (a 2xx body missing `.id` yields the literal string `null`, which is non-empty and would persistently poison the per-owner installation cache), and treat a pre-poisoned non-numeric cached value as a miss so already-poisoned hosts self-heal on the next call.
- **`defaults/scripts/tests/test-github-app-token.sh`** — new coverage: 2xx with `null`/missing `.id` returns 1 with `_GH_APP_LAST_ERROR` set and nothing echoed; a pre-poisoned `null` cache is treated as a miss and self-heals to the numeric id.
- **`loom-daemon/src/types.rs`** — fixed doc link `resolve_with_github_app` → `run_with_github_app`.
- **`loom-daemon/src/sweep_registry.rs`** — added the `runtime` field to two test `SweepInfo` constructors left behind by #4510. This is a **pre-existing break of the entire `loom-daemon --lib` test target on `origin/main`** (unrelated to this issue) that blocked running the new tests; fixed minimally with the same `runtime: "unknown".into()` value all 33 other constructors use.

## Acceptance Criteria Verification

- [x] Refresh tick skips `set_var` when the minted/cached token equals the current `GH_TOKEN`; main.rs comment updated to match actual behavior.
- [x] types.rs doc link fixed to `run_with_github_app`.
- [x] Installation-id cache write validates a non-empty, non-`null` (numeric) id before persisting; read side treats an invalid cached value as a miss.
- [x] (Optional/stretch) Per-`Command` env migration evaluated — **not implemented here** (out of scope): threading a token store through every `Command::new("gh")`/`git` call site in the daemon is a large cross-cutting change; the value-changed guard already shrinks the race window from every-5-min to ~hourly, and #4385 tracks the same per-`Command` principle in the test suite. Recommend a dedicated follow-up if the residual ~hourly window warrants full retirement of runtime `set_var`.

## Test Plan

- [x] `cargo test -p loom-daemon --lib` — 2202 passed (was failing to compile on main due to the #4510 oversight, now fixed).
- [x] `cargo test -p loom-daemon --lib --bins` — exit 0; bin target 41 passed including the 4 new `gh_token_guard_tests` (cache-hit skip, genuine rotation, unset env, empty-current).
- [x] `bash defaults/scripts/tests/test-github-app-token.sh` — 24/24 passed (including the 4 new installation-id validation cases).
- [x] `cargo fmt --check` — clean.
- [x] Edge cases covered by tests: first-ever tick after boot (env already equals minted value → no write), genuine rotation (values differ → write), `GH_TOKEN` unset at tick time (`None` → treated as different).

Closes #4456