### PR TITLE
docs(daemon): mandate explicit workspace_root on dispatch_sweep examples

### DIFF
--- a/defaults/.claude/commands/loom/loom.md
+++ b/defaults/.claude/commands/loom/loom.md
@@ -150,19 +150,24 @@ When the daemon is running, you coordinate work via MCP tools where available, a
    gh pr list --label="loom:review-requested" --json number,title --limit=20
    ```
 
-3. **Dispatch new sweeps** via MCP or CLI:
+3. **Dispatch new sweeps** via MCP or CLI. Derive the target workspace root once
+   and pass it explicitly — omitting it routes through registry resolution
+   (#4299/PR #4322), which can silently target the daemon's default workspace
+   instead of the repo you meant (#4503):
    ```
+   WORKSPACE_ROOT=$(git rev-parse --show-toplevel)
    For each ready loom:issue not already in the daemon registry:
-     mcp__loom__dispatch_sweep  kind={"Issue": <N>}
+     mcp__loom__dispatch_sweep  kind={"Issue": <N>}  workspace_root=$WORKSPACE_ROOT
    ```
    ```bash
    # CLI equivalent (#3952) — same underlying IPC DispatchSweep request:
-   loom-daemon dispatch <N> [--model M] [--effort E] [--depends-on P]
+   loom-daemon dispatch <N> --workspace "$WORKSPACE_ROOT" [--model M] [--effort E] [--depends-on P]
    ```
    `kind`/`<N>` is the only required input. Optional params on both surfaces:
    `model`, `effort`, `depends_on` (a single parent issue for stacked PRs);
    MCP additionally takes `idempotency_key` (dedup) and CLI additionally takes
-   `--workspace` (target a non-default managed workspace root). The daemon
+   `--workspace` (target a non-default managed workspace root — always pass
+   it explicitly rather than relying on the default). The daemon
    picks an OAuth token from the pool (`spawn-claude.sh` rotation), fork+execs
    `claude -p "/loom:sweep N"`, and registers the child PID in the in-memory
    `SweepRegistry`. Token rotation only happens at this process-spawn

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -898,16 +898,22 @@ The resolved `WAVE_SIZE` replaces `--builders-per-wave` everywhere the wave-part
 
 When `DECIDE` lands on `use_daemon`, the skill **dispatches each candidate issue** to the daemon and **exits sub-2-second**. There is no in-session orchestration after dispatch — operators monitor with `mcp__loom__list_sweeps` (Phase A) or the richer Phase C tools once they land.
 
+**Derive `WORKSPACE_ROOT` once, before dispatching, and pass it explicitly on every `dispatch_sweep` call below.** Omitting `workspace_root` routes through the daemon's workspace-registry resolution (#4299/PR #4322): on a host with multiple managed workspaces registered, it either returns a structured ambiguity error, or — the dangerous case — silently resolves to the daemon's seeded default workspace when that default happens to be registered, targeting the wrong repo with no warning. Always pin the target explicitly:
+
+```bash
+WORKSPACE_ROOT=$(git rev-parse --show-toplevel)
+```
+
 For each candidate issue `N` in the candidate set:
 
 ```text
-mcp__loom__dispatch_sweep(kind={"Issue": N})
+mcp__loom__dispatch_sweep(kind={"Issue": N}, workspace_root=$WORKSPACE_ROOT)
 ```
 
 **When `AUTO_STACK=true` and edge detection populated `DEPENDS_ON[N]` for candidate `N`** (see "Auto-stack detection and wave ordering"), forward the detected parent on the dispatch:
 
 ```text
-mcp__loom__dispatch_sweep(kind={"Issue": N}, depends_on=<parent>)
+mcp__loom__dispatch_sweep(kind={"Issue": N}, depends_on=<parent>, workspace_root=$WORKSPACE_ROOT)
 ```
 
 This is purely "start populating a parameter that already exists" — the daemon and the `mcp__loom__dispatch_sweep` schema already accept `depends_on` (#3729/#3742), forwarding it to the child as `--depends-on <parent>`, so there is **no daemon-side code change**. Candidates with no detected edge dispatch exactly as today (no `depends_on` argument). To respect the parent-before-child topological ordering on the daemon path, dispatch the reordered candidate list in order (a parent stacked-before its child is dispatched first so its `feature/issue-<parent>` branch exists when the child's Builder resolves the base).
@@ -1627,11 +1633,11 @@ Stacked-PR mode pipelines a genuine dependency: when issue B consumes issue A's 
 
 ```text
 # Parent A (independent):
-mcp__loom__dispatch_sweep  kind={"Issue": A}
+mcp__loom__dispatch_sweep  kind={"Issue": A}  workspace_root=$WORKSPACE_ROOT
 # Child B stacked on A:
-mcp__loom__dispatch_sweep  kind={"Issue": B}  depends_on=A
+mcp__loom__dispatch_sweep  kind={"Issue": B}  depends_on=A  workspace_root=$WORKSPACE_ROOT
 # Grandchild C stacked on B (A→B→C works because each hop names only its parent):
-mcp__loom__dispatch_sweep  kind={"Issue": C}  depends_on=B
+mcp__loom__dispatch_sweep  kind={"Issue": C}  depends_on=B  workspace_root=$WORKSPACE_ROOT
 ```
 
 The daemon forwards `depends_on` to the child as `--depends-on <parent>`; the child's Builder branches off `feature/issue-<parent>` and opens its PR with `--base feature/issue-<parent>` (see the gated path in the Builder phase above). A single optional parent makes diamonds / multi-parent stacks **unrepresentable** — there is no rejection logic because the type itself forbids them.

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1292,12 +1292,15 @@ dispatch surface is opt-in, daemon-`dispatch_sweep`-only, and
 linear-chains-only.**
 
 **Dispatch a chain** — N independent `dispatch_sweep` calls, each naming its
-immediate predecessor via `depends_on` (there is no multi-node planner):
+immediate predecessor via `depends_on` (there is no multi-node planner). Always
+pass `workspace_root` explicitly — omitting it can silently target the wrong
+managed workspace (#4503; see workspace_root note above):
 
 ```text
-dispatch_sweep  kind={"Issue": A}                    # parent (independent)
-dispatch_sweep  kind={"Issue": B}  depends_on=A      # child stacked on A
-dispatch_sweep  kind={"Issue": C}  depends_on=B      # A→B→C linear chain
+WORKSPACE_ROOT=$(git rev-parse --show-toplevel)
+dispatch_sweep  kind={"Issue": A}  workspace_root=$WORKSPACE_ROOT                    # parent (independent)
+dispatch_sweep  kind={"Issue": B}  depends_on=A  workspace_root=$WORKSPACE_ROOT      # child stacked on A
+dispatch_sweep  kind={"Issue": C}  depends_on=B  workspace_root=$WORKSPACE_ROOT      # A→B→C linear chain
 ```
 
 The daemon forwards `depends_on` to the child as `--depends-on <parent>`; the

--- a/mcp-loom/src/tools/sweeps.ts
+++ b/mcp-loom/src/tools/sweeps.ts
@@ -712,12 +712,16 @@ export const sweepTools: Tool[] = [
         workspace_root: {
           type: "string",
           description:
-            "Optional target managed-workspace root (issue #3929). Omit to " +
-            "dispatch into the daemon's default workspace (unchanged behavior). " +
-            "Provide a registered repo root to dispatch the sweep into that " +
-            "repo's working tree / sweep registry — required to address a " +
-            "managed repo other than the default when two repos share issue " +
-            "numbers.",
+            "Optional target managed-workspace root (issue #3929). Omitting " +
+            "it is NOT a safe no-op on a host with multiple registered " +
+            "workspaces (post-#4299/PR #4322 registry resolution): the " +
+            "daemon either returns a structured ambiguity error when no " +
+            "default applies, or — the dangerous case — silently resolves " +
+            "to the daemon's seeded default workspace when that default is " +
+            "itself registered, dispatching into the wrong repo with no " +
+            "warning (issue #4503). Callers should always pass the repo " +
+            "root they intend to target, e.g. `$(git rev-parse " +
+            "--show-toplevel)`, rather than relying on omission.",
         },
         force: {
           type: "boolean",


### PR DESCRIPTION
Closes #4503

## Summary
- Every documented `mcp__loom__dispatch_sweep` call example omitted `workspace_root`, which — post-#4299/PR #4322 registry resolution — can silently target the daemon's default workspace instead of the repo an orchestrator actually intends, on hosts with multiple managed workspaces registered. Confirmed live incident on 2026-07-29.
- This is a documentation + tool-schema-description-only change (Option A from the curated issue). No Rust/daemon behavior change.

## Changes
1. `defaults/.claude/commands/loom/sweep.md` — the "daemon-dispatch path" section now mandates deriving `WORKSPACE_ROOT=$(git rev-parse --show-toplevel)` once and passing `workspace_root` on the base dispatch example and the `depends_on` variant; the "How to dispatch a chain" A/B/C stacked-dispatch example now passes `workspace_root` on all three calls.
2. `defaults/.claude/commands/loom/loom.md` — the bare `dispatch_sweep kind={"Issue": <N>}` example now derives and passes `workspace_root` (MCP) / `--workspace` (CLI equivalent).
3. `defaults/docs/daemon-reference.md` — the stacked-chain example now passes `workspace_root` on each of the three calls.
4. `.loom/docs/daemon-reference.md` — this is a git-tracked symlink to `defaults/docs/daemon-reference.md` (`120000` mode), so editing file #3 above updates this mirror automatically; no separate diff needed.
5. `mcp-loom/src/tools/sweeps.ts` — rewrote the `workspace_root` description on the `dispatch_sweep` tool schema: removed the stale "unchanged behavior" claim, documented the actual post-#4299 omission semantics (structured ambiguity error vs. silent resolution to the seeded default when that default is itself registered), and recommended callers always pass `$(git rev-parse --show-toplevel)`.

## Constraints preserved
- No changes to any Rust code (`workspace_registry.rs`, `ipc.rs`, `main.rs` untouched).
- No changes to `workspace_root` semantics for `list_sweeps` / `get_sweep_status` / `cancel_sweep` — scoped to `dispatch_sweep` docs/schema only.
- Local untracked `.claude/commands/loom/*.md` installed mirrors not touched (refreshed by `resync-installed.sh`).

## Test plan
- [x] `grep -nE 'dispatch_sweep.*kind=' defaults/.claude/commands/loom/sweep.md defaults/.claude/commands/loom/loom.md defaults/docs/daemon-reference.md .loom/docs/daemon-reference.md | grep -v workspace_root` returns nothing.
- [ ] `mcp-loom` typecheck/build — no Node.js toolchain available in this sandbox; change is a string-literal-only edit to an existing object property, verified by inspection to be syntactically valid TypeScript.
- Rust daemon code untouched, so `cargo test -p loom-daemon workspace_registry` was not run (optional per issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)