### PR TITLE
feat(safehouse): add title/additions/deletions/tokens to completion-v1 meta

### DIFF
--- a/.loom/docs/safehouse.md
+++ b/.loom/docs/safehouse.md
@@ -458,15 +458,37 @@ what feeds the public fleet feed on 2amlogic.com. Loom is the producer:
   post-merge phase event because it is daemon-only (no skill edit), has the
   sweep timing to hand, and verifies rather than trusts.
 - **`meta` (`completion-v1`)**: `{schema, agent, repo, ref, result, started_at,
-  completed_at}` required, plus optional `issue`/`tokens` (envelope-v1 preserves
-  unknown `meta` keys, so no schema rev is needed for extensions). `body` stays
-  required human prose — a room reader sees a sentence, `meta` is the machine
-  view.
+  completed_at}` required, plus optional `issue`/`tokens`/`title`/`additions`/
+  `deletions` (envelope-v1 preserves unknown `meta` keys, so no schema rev is
+  needed for extensions). `body` stays required human prose — a room reader sees
+  a sentence, `meta` is the machine view.
 - **`repo` is the forge `owner/repo` slug** (`gh repo view --json
   nameWithOwner`, cached per workspace for the daemon's lifetime), deliberately
   **not** the path-basename convention above: the feed links `ref` (the PR URL)
-  and displays the forge identity. `tokens` is omitted rather than guessed — no
-  cheap token source is wired to the sink.
+  and displays the forge identity.
+- **Display fields (#4497)** feed the site's row format
+  `<repo>#<issue>: <title> +A −D · <dur> · <tokens> tok`, i.e. the
+  development-cost-of-quality-code view:
+  - `title`/`additions`/`deletions` come out of the **same** `gh pr list` call
+    that verifies the merge (`--json number,url,mergedAt,title,additions,deletions`),
+    so they cost **zero** extra forge round-trips. Each degrades independently:
+    a row that omits one still publishes the completion without that key. A `gh`
+    too old to know a field rejects the whole request, so that one case retries
+    the pre-#4497 `number,url,mergedAt` set rather than losing the completion.
+  - Unlike `tokens`, a real **`0`** additions/deletions is a fact about the merge
+    (an empty-diff merge, a pure revert) and is published as `0`; a blank `title`
+    is omitted.
+  - `tokens` is a best-effort **input + output** total from the in-process
+    activity DB's per-issue rollup (`ActivityDb::get_cost_by_issue`), read on the
+    blocking pool with a 5s cap. **Attribution is knowingly imperfect** — the
+    rollup keys on a bare issue number (no repo column, so a multi-repo daemon
+    conflates identical numbers across repos) and only counts token samples that
+    are linked to the issue through `agent_inputs`, making the figure a floor.
+    That is a deliberate operator call: for a cost *trend*,
+    imperfect-but-consistent beats absent. An empty or zero rollup omits the key
+    rather than charting free work.
+  - Absent `tokens`/`title`/`additions`/`deletions` ⇒ the envelope is identical
+    to the pre-#4497 one; none of the four can block or fail an emission.
 - **Timestamps** come from the reaper's clock (`started_at = exit − duration_sec`,
   `completed_at = exit`), so the pair is always self-consistent.
 - **`result: "failure"` is out of scope for v1**: `completion-v1` requires a
@@ -484,7 +506,13 @@ what feeds the public fleet feed on 2amlogic.com. Loom is the producer:
   non-empty, `schema == "completion-v1"`, `agent` a valid persona, `repo` an
   `owner/repo` slug, `ref` an absolute http(s) URL, `result` ∈
   {`success`,`failure`}, both timestamps RFC3339 with `completed_at >=
-  started_at`). Nothing here relies on server-side validation.
+  started_at`, `issue`/`tokens`/`additions`/`deletions` non-negative integers
+  when present, `title` a non-empty string when present). Nothing here relies on
+  server-side validation.
+- **Redaction is downstream.** Every `meta` string — `title` included — is
+  published as an ordinary JSON string, so safehoused's egress deny-pattern pass
+  redacts it exactly like `repo`/`ref`. Loom applies no bespoke encoding that
+  could let a value slip past that pass.
 - **Same degradation contract**: a failing/absent/slow `gh`, an unreachable
   safehoused, or a rejected envelope drops the completion silently and never
   affects the sweep.

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -2522,15 +2522,22 @@ When a sweep exits, the narration sink additionally asks the forge whether that
 issue's PR actually **merged** (`gh pr list --head feature/issue-N --state
 merged`, in the event's workspace root). If it did, the sink emits a second
 envelope of type **`completion`** carrying a `completion-v1` `meta`
-(`{schema, agent, repo, ref, result, started_at, completed_at, issue, tokens?}`)
-alongside the human `ack`. safehoused's egress mirrors well-formed `completion`
-envelopes out of allowlisted rooms to its `sink_url` — that is what fills the
-public fleet feed. Notes:
+(`{schema, agent, repo, ref, result, started_at, completed_at, issue,
+tokens?, title?, additions?, deletions?}`) alongside the human `ack`.
+safehoused's egress mirrors well-formed `completion` envelopes out of allowlisted
+rooms to its `sink_url` — that is what fills the public fleet feed. Notes:
 
 - **`repo` is the forge `owner/repo` slug** (`gh repo view --json nameWithOwner`,
   cached per workspace), not the path-basename narration convention (#4201);
-  `ref` is the PR URL. `tokens` is omitted (no cheap sink-side source) rather
-  than guessed.
+  `ref` is the PR URL.
+- **Display fields (#4497)** back the feed's
+  `<repo>#<issue>: <title> +A −D · <dur> · <tokens> tok` rows.
+  `title`/`additions`/`deletions` come from the *same* `gh pr list` call that
+  verifies the merge (zero extra round-trips) and degrade per-field; `tokens` is
+  a best-effort input+output total from the in-process activity DB's per-issue
+  rollup, whose attribution is knowingly imperfect (bare issue number, no repo
+  column; only linked samples counted) but consistent enough for a cost trend.
+  All four are optional — absent, the envelope is identical to the pre-#4497 one.
 - **Exit 0 ≠ merged.** No merged PR ⇒ no completion, so `result: "success"` is
   never claimed for unmerged work. `result: "failure"` is not emitted in v1 —
   `completion-v1` requires a `ref`, and a sweep with no merged PR has no

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -1850,8 +1850,11 @@ async fn main() -> Result<()> {
 
     // Optional safehouse fleet-comms narration (#3997): subscribe the shared
     // event bus and narrate sweep-lifecycle transitions into an E2E Matrix room.
-    // Byte-for-byte no-op when `safehouse.enabled` is false/absent.
-    workspace_pool.start_safehouse_narration(&sweep_workspace);
+    // Byte-for-byte no-op when `safehouse.enabled` is false/absent. The activity
+    // DB handle (#4497) is the same `Arc` the IPC server gets, shared so the
+    // public-feed `completion` envelope can carry a best-effort per-issue token
+    // total; the sink only ever reads, on the blocking pool.
+    workspace_pool.start_safehouse_narration(&sweep_workspace, Some(activity_db.clone()));
 
     // Optional cross-host soft-claim coordination (#4028): a dedicated safehouse
     // connection that advertises this daemon's dispatch claims and consumes peer

--- a/loom-daemon/src/safehouse.rs
+++ b/loom-daemon/src/safehouse.rs
@@ -51,6 +51,7 @@ use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::UnixStream;
 use tokio::sync::mpsc::error::TryRecvError;
 
+use crate::activity::ActivityDb;
 use crate::event_bus::{EventBus, RecvError};
 use crate::peer_claims::{ClaimAd, PeerClaimView};
 use crate::types::{Event, SweepKind};
@@ -132,6 +133,25 @@ const COMPLETION_REQUIRED_KEYS: [&str; 7] = [
 /// on timeout the completion is simply not narrated — the sweep is long over by
 /// then and nothing downstream waits on it.
 const MERGE_CHECK_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// `gh pr list --json` fields the completion emit point requests.
+/// `number,url,mergedAt` are load-bearing (a missing one degrades the whole
+/// lookup, and with it the completion); `title,additions,deletions` are the
+/// #4497 feed display fields, harvested from the same call and degrading
+/// per-field.
+const MERGED_PR_FIELDS: &str = "number,url,mergedAt,title,additions,deletions";
+
+/// The pre-#4497 field set, retried only when a `gh` too old to know one of the
+/// display fields rejects [`MERGED_PR_FIELDS`] outright — so an older host keeps
+/// publishing completions instead of losing them to a cosmetic field.
+const MERGED_PR_FIELDS_BASE: &str = "number,url,mergedAt";
+
+/// Timeout for the sink-side activity-DB token rollup behind a `completion`
+/// envelope (#4497). The query is a single indexed SQLite aggregate on a local
+/// file, but it contends with the IPC handler's writes for the DB mutex, so it
+/// runs on the blocking pool under this cap; on timeout `tokens` is simply
+/// omitted.
+const TOKEN_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Reconnect backoff floor and ceiling. The floor keeps a burst of events from
 /// hammering an absent peer (one `warn`, not a hot loop); the ceiling caps the
@@ -448,7 +468,24 @@ pub struct CompletionMeta {
     /// schema revision downstream. Omitted entirely when `None` — the feed
     /// handles absence, and the issue's rule is "omit rather than guess".
     pub issue: Option<u32>,
+    /// Best-effort total (input + output) tokens the activity DB attributes to
+    /// this issue (#4497), for the feed's cost-of-quality-code trend. **Known
+    /// imperfect** — see [`fetch_issue_tokens`] for the attribution caveats
+    /// (issue-number-only, so no repo qualification, and dependent on the
+    /// activity DB having a per-issue rollup at all). Imperfect-but-consistent
+    /// beats absent for trend purposes; a zero/absent rollup still omits the
+    /// key rather than publishing a bogus `0`.
     pub tokens: Option<u64>,
+    /// Merged PR title (#4497) — the feed renders rows as
+    /// `<repo>#<issue>: <title> +A −D`. Trimmed; an empty title is treated as
+    /// absent.
+    pub title: Option<String>,
+    /// Merged PR diff size (#4497), from the same `gh pr list` call that
+    /// verifies the merge. Unlike `tokens`, a real `0` is **meaningful** for a
+    /// merge (a docs-only revert legitimately adds nothing), so zeros are
+    /// published rather than filtered.
+    pub additions: Option<u64>,
+    pub deletions: Option<u64>,
 }
 
 impl CompletionMeta {
@@ -472,6 +509,24 @@ impl CompletionMeta {
         // nothing", so it is omitted rather than published as a real zero.
         if let Some(tokens) = self.tokens.filter(|t| *t > 0) {
             obj.insert("tokens".into(), json!(tokens));
+        }
+        // Display fields (#4497). `title` is trimmed and an empty one is
+        // dropped (an empty string would render as a blank row label); the
+        // counts publish real zeros because `0 additions` is a fact about the
+        // merge, not the "no data" sentinel a `0` token count would be.
+        if let Some(title) = self
+            .title
+            .as_deref()
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+        {
+            obj.insert("title".into(), json!(title));
+        }
+        if let Some(additions) = self.additions {
+            obj.insert("additions".into(), json!(additions));
+        }
+        if let Some(deletions) = self.deletions {
+            obj.insert("deletions".into(), json!(deletions));
         }
         validate_completion_meta(&meta)?;
         Ok(meta)
@@ -550,12 +605,24 @@ pub fn validate_completion_meta(meta: &Value) -> Result<()> {
             get("started_at")
         );
     }
-    // `issue`/`tokens` are optional extension fields; when present they must
-    // still be non-negative integers rather than strings/floats.
-    for key in ["issue", "tokens"] {
+    // `issue`/`tokens`/`additions`/`deletions` are optional extension fields;
+    // when present they must still be non-negative integers rather than
+    // strings/floats.
+    for key in ["issue", "tokens", "additions", "deletions"] {
         if let Some(v) = obj.get(key) {
             if v.as_u64().is_none() {
                 bail!("completion `meta.{key}` must be a non-negative integer, got {v}");
+            }
+        }
+    }
+    // `title` (#4497) is an optional string; a present-but-blank one would
+    // render as an empty row label on the feed, so it is rejected here rather
+    // than published (the builder omits it instead — see `to_meta_value`).
+    if let Some(v) = obj.get("title") {
+        match v.as_str() {
+            Some(s) if !s.trim().is_empty() => {}
+            _ => {
+                bail!("completion `meta.title`, when present, must be a non-empty string, got {v}")
             }
         }
     }
@@ -919,6 +986,13 @@ struct MergedPr {
     number: u32,
     /// Canonical web URL (`completion-v1` `ref`).
     url: String,
+    /// Display fields (#4497), read from the *same* `gh pr list` call that
+    /// verifies the merge — zero extra round-trips. Each degrades to `None`
+    /// independently: a row missing one of them still yields a `MergedPr`, so a
+    /// completion is never lost over a cosmetic field.
+    title: Option<String>,
+    additions: Option<u64>,
+    deletions: Option<u64>,
 }
 
 /// Build the `completion` envelope for a merged sweep. Pure and total: every
@@ -963,26 +1037,27 @@ pub fn build_completion_envelope(
 /// `None` here and narrates no completion, so `result: "success"` is never
 /// claimed for unmerged work. Every failure — missing `gh`, no network,
 /// unauthenticated, timeout, malformed JSON — also degrades to `None`.
+///
+/// The same single call also harvests the feed's display fields (#4497:
+/// `title`/`additions`/`deletions`), so enriching the completion costs **zero**
+/// extra forge round-trips on the happy path.
 async fn fetch_merged_pr(workspace_root: &Path, issue: u32) -> Option<MergedPr> {
     let gh_bin = env_nonempty(GH_BIN_ENV).unwrap_or_else(|| "gh".to_owned());
     let branch = crate::worktree_ops::naming::branch_name(issue);
-    let run = tokio::process::Command::new(&gh_bin)
-        .arg("pr")
-        .arg("list")
-        .arg("--head")
-        .arg(&branch)
-        .arg("--state")
-        .arg("merged")
-        .arg("--json")
-        .arg("number,url,mergedAt")
-        .arg("--limit")
-        .arg("1")
-        .current_dir(workspace_root)
-        .output();
-    let output = tokio::time::timeout(MERGE_CHECK_TIMEOUT, run)
-        .await
-        .ok()?
-        .ok()?;
+    let mut output =
+        run_merged_pr_query(&gh_bin, &branch, MERGED_PR_FIELDS, workspace_root).await?;
+    if !output.status.success() && rejects_unknown_json_field(&output.stderr) {
+        // A `gh` old enough not to know one of the #4497 display fields rejects
+        // the *whole* request rather than omitting that field, which would have
+        // silently cost us every completion. Retry the pre-#4497 field set so
+        // such a host keeps publishing completions, just without the extras.
+        log::debug!(
+            "safehouse: gh rejected the completion display fields; \
+             retrying with the base field set (completion will omit title/additions/deletions)"
+        );
+        output =
+            run_merged_pr_query(&gh_bin, &branch, MERGED_PR_FIELDS_BASE, workspace_root).await?;
+    }
     if !output.status.success() {
         return None;
     }
@@ -997,7 +1072,63 @@ async fn fetch_merged_pr(workspace_root: &Path, issue: u32) -> Option<MergedPr> 
     }
     let number = u32::try_from(row.get("number")?.as_u64()?).ok()?;
     let url = row.get("url")?.as_str()?.to_owned();
-    (!url.is_empty()).then_some(MergedPr { number, url })
+    // Display fields are read with `and_then`/`filter` rather than `?`: an
+    // absent or wrongly-typed one must degrade that field alone, never the
+    // merge verification.
+    let title = row
+        .get("title")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .map(ToOwned::to_owned);
+    let additions = row.get("additions").and_then(Value::as_u64);
+    let deletions = row.get("deletions").and_then(Value::as_u64);
+    (!url.is_empty()).then_some(MergedPr {
+        number,
+        url,
+        title,
+        additions,
+        deletions,
+    })
+}
+
+/// One `gh pr list --head <branch> --state merged --json <fields>` invocation,
+/// bounded by [`MERGE_CHECK_TIMEOUT`]. `None` means the process could not be
+/// run or did not finish in time; a nonzero exit is returned to the caller so it
+/// can inspect `stderr`.
+async fn run_merged_pr_query(
+    gh_bin: &str,
+    branch: &str,
+    fields: &str,
+    workspace_root: &Path,
+) -> Option<std::process::Output> {
+    let run = tokio::process::Command::new(gh_bin)
+        .arg("pr")
+        .arg("list")
+        .arg("--head")
+        .arg(branch)
+        .arg("--state")
+        .arg("merged")
+        .arg("--json")
+        .arg(fields)
+        .arg("--limit")
+        .arg("1")
+        .current_dir(workspace_root)
+        .output();
+    tokio::time::timeout(MERGE_CHECK_TIMEOUT, run)
+        .await
+        .ok()?
+        .ok()
+}
+
+/// Whether `gh` failed specifically because it does not recognize one of the
+/// requested `--json` fields (`unknown JSON field: "additions"`), as opposed to
+/// the ordinary degradations (no auth, no network, not a repo). Only this case
+/// is worth a retry with a narrower field set.
+fn rejects_unknown_json_field(stderr: &[u8]) -> bool {
+    String::from_utf8_lossy(stderr)
+        .to_ascii_lowercase()
+        .contains("unknown json field")
 }
 
 /// Best-effort `gh repo view --json nameWithOwner` lookup for the forge
@@ -1042,6 +1173,56 @@ async fn fetch_repo_slug_cached(
     Some(slug)
 }
 
+/// Best-effort per-issue token total for a `completion` envelope (#4497):
+/// `sum(input + output)` over the activity DB's per-issue cost rollup
+/// ([`ActivityDb::get_cost_by_issue`]). The DB is already in-process, so this
+/// needs no forge call and no new accounting.
+///
+/// **Attribution is imperfect, by explicit operator decision** — for a cost
+/// *trend*, imperfect-but-consistent beats absent. Two known limits, documented
+/// here rather than papered over:
+///
+/// 1. **Not repo-qualified.** The activity DB's forge-correlation table keys on
+///    a bare issue number with no repo column, so a daemon managing several
+///    repos conflates identical issue numbers across them.
+/// 2. **Only as good as the prompt↔usage linkage.** The rollup joins recorded
+///    token samples to an issue through `agent_inputs`; samples recorded without
+///    that link contribute nothing, so the figure is a **floor**, not a full
+///    accounting — and is empty on hosts where nothing has established the link
+///    yet, in which case the key is simply omitted.
+///
+/// Every failure — no DB handle, a poisoned mutex, a query error, a timeout, an
+/// empty rollup — degrades to `None`. A zero total is likewise indistinguishable
+/// from "accounting had nothing" and is filtered out downstream by
+/// [`CompletionMeta::to_meta_value`], so no bogus `0` reaches the feed.
+async fn fetch_issue_tokens(
+    activity_db: Option<&Arc<Mutex<ActivityDb>>>,
+    issue: u32,
+) -> Option<u64> {
+    let db = activity_db?.clone();
+    let issue_number = i32::try_from(issue).ok()?;
+    // The rusqlite handle sits behind a std mutex shared with the IPC recorder's
+    // writes, so lock+query goes to the blocking pool: the sink must never park
+    // a daemon-runtime worker on it (and a std guard cannot cross an `await`).
+    let query = tokio::task::spawn_blocking(move || {
+        let rollup = {
+            let guard = db.lock().ok()?;
+            guard.get_cost_by_issue(Some(issue_number)).ok()?
+        };
+        let total = rollup.iter().fold(0_i64, |acc, row| {
+            acc.saturating_add(
+                row.total_input_tokens
+                    .saturating_add(row.total_output_tokens),
+            )
+        });
+        u64::try_from(total).ok()
+    });
+    tokio::time::timeout(TOKEN_LOOKUP_TIMEOUT, query)
+        .await
+        .ok()?
+        .ok()?
+}
+
 /// The Option-B emit point (#4426): on a `SweepExited`, verify against forge
 /// truth that the sweep's PR actually merged and, if so, build the
 /// public-feed `completion` envelope.
@@ -1065,6 +1246,13 @@ async fn fetch_repo_slug_cached(
 /// one (an open PR is un-finished, not failed, and is usually resumed). The
 /// wire support exists ([`CompletionResult::Failure`]) for a follow-up that
 /// identifies a genuinely terminal negative outcome.
+///
+/// The feed's display fields (#4497) ride along here: `title`/`additions`/
+/// `deletions` come out of the merge-verification call itself (no extra forge
+/// round-trip) and `tokens` out of the in-process activity DB when a handle was
+/// threaded in. All four are optional and independently degradable — with all
+/// four absent the envelope is byte-identical to the pre-#4497 one.
+#[allow(clippy::too_many_arguments)]
 async fn completion_for_exit(
     persona: &str,
     workspace_root: &str,
@@ -1073,6 +1261,7 @@ async fn completion_for_exit(
     exited_at: DateTime<Utc>,
     slug_cache: &mut HashMap<String, String>,
     already_narrated: &mut std::collections::HashSet<(String, u32)>,
+    activity_db: Option<&Arc<Mutex<ActivityDb>>>,
 ) -> Option<Envelope> {
     let key = (workspace_root.to_owned(), issue);
     if already_narrated.contains(&key) {
@@ -1080,6 +1269,9 @@ async fn completion_for_exit(
     }
     let merged = fetch_merged_pr(Path::new(workspace_root), issue).await?;
     let slug = fetch_repo_slug_cached(slug_cache, workspace_root).await?;
+    // Only reached once the merge is confirmed, so a completion is never delayed
+    // by a token lookup it would not have published.
+    let tokens = fetch_issue_tokens(activity_db, issue).await;
 
     // Sweep timing comes from the one clock that produced `duration_sec` (the
     // reaper's), so the pair is always self-consistent — mixing in the forge's
@@ -1093,10 +1285,12 @@ async fn completion_for_exit(
         started_at: started_at.to_rfc3339_opts(SecondsFormat::Secs, true),
         completed_at: exited_at.to_rfc3339_opts(SecondsFormat::Secs, true),
         issue: Some(issue),
-        // No cheap token source is wired to the sink (the activity DB lives
-        // behind the IPC handler, not the bus subscriber), so this is omitted
-        // rather than guessed — the feed handles absence.
-        tokens: None,
+        // Best-effort, knowingly imperfect attribution (#4497) — see
+        // `fetch_issue_tokens`. Absent/zero ⇒ the key is omitted, never guessed.
+        tokens,
+        title: merged.title,
+        additions: merged.additions,
+        deletions: merged.deletions,
     };
     match build_completion_envelope(Some(workspace_root), issue, merged.number, duration_sec, &meta)
     {
@@ -1274,12 +1468,17 @@ impl SafehouseClient {
 /// with the resolved config-only state immediately (before any connection
 /// attempt) and further updated by [`run_sink`] as connect/disconnect
 /// transitions happen — see [`SafehouseState`].
+///
+/// `activity_db` (#4497) is the optional in-process handle the completion emit
+/// point uses for its best-effort per-issue `tokens` rollup; `None` simply omits
+/// that one field.
 #[must_use]
 pub fn spawn_sink(
     config: SafehouseConfig,
     bus: &EventBus,
     runtime: &tokio::runtime::Handle,
     state: SharedSafehouseState,
+    activity_db: Option<Arc<Mutex<ActivityDb>>>,
 ) -> Option<tokio::task::JoinHandle<()>> {
     if !config.enabled {
         // Disabled ⇒ do not even subscribe. No syscalls, no behavior change.
@@ -1305,8 +1504,16 @@ pub fn spawn_sink(
     // Empty topic set ⇒ receive every event; we filter in `event_to_envelope`.
     let subscription = bus.subscribe(Vec::<String>::new());
     Some(runtime.spawn(async move {
-        run_sink(config, socket, subscription, DEFAULT_MIN_BACKOFF, DEFAULT_MAX_BACKOFF, state)
-            .await;
+        run_sink(
+            config,
+            socket,
+            subscription,
+            DEFAULT_MIN_BACKOFF,
+            DEFAULT_MAX_BACKOFF,
+            state,
+            activity_db,
+        )
+        .await;
     }))
 }
 
@@ -1370,6 +1577,7 @@ async fn fetch_title_cached(
 /// narrates them, reconnecting lazily with capped exponential backoff. A
 /// connection failure never blocks or fails a sweep — it degrades to a single
 /// `warn` per outage (not per event) and drops that narration.
+#[allow(clippy::too_many_arguments)]
 async fn run_sink(
     config: SafehouseConfig,
     socket: PathBuf,
@@ -1377,6 +1585,7 @@ async fn run_sink(
     min_backoff: Duration,
     max_backoff: Duration,
     state: SharedSafehouseState,
+    activity_db: Option<Arc<Mutex<ActivityDb>>>,
 ) {
     // Report "configured, not yet connected" immediately — the sink connects
     // lazily on the first narrated event (below), so without this a daemon
@@ -1461,6 +1670,7 @@ async fn run_sink(
                 Utc::now(),
                 &mut slug_cache,
                 &mut completed,
+                activity_db.as_ref(),
             )
             .await
             {
@@ -2189,6 +2399,9 @@ mod tests {
             completed_at: "2026-07-29T10:12:30Z".to_owned(),
             issue: Some(4321),
             tokens: Some(791_000),
+            title: Some("Add repo-qualified task_id".to_owned()),
+            additions: Some(214),
+            deletions: Some(37),
         }
     }
 
@@ -2224,6 +2437,11 @@ mod tests {
         assert_eq!(req["meta"]["completed_at"], json!("2026-07-29T10:12:30Z"));
         assert_eq!(req["meta"]["issue"], json!(4321));
         assert_eq!(req["meta"]["tokens"], json!(791_000));
+        // Feed display fields (#4497) ride the same `meta`, so the egress
+        // publishes them with no schema revision.
+        assert_eq!(req["meta"]["title"], json!("Add repo-qualified task_id"));
+        assert_eq!(req["meta"]["additions"], json!(214));
+        assert_eq!(req["meta"]["deletions"], json!(37));
         assert!(req["body"].as_str().unwrap().contains("merged ✓"));
     }
 
@@ -2308,6 +2526,28 @@ mod tests {
                 m["tokens"] = json!("791000");
                 m
             }),
+            // #4497 display fields are validated to the same standard as the
+            // pre-existing extensions.
+            ("additions is a string", {
+                let mut m = valid.clone();
+                m["additions"] = json!("214");
+                m
+            }),
+            ("deletions is negative", {
+                let mut m = valid.clone();
+                m["deletions"] = json!(-1);
+                m
+            }),
+            ("title is blank", {
+                let mut m = valid.clone();
+                m["title"] = json!("   ");
+                m
+            }),
+            ("title is not a string", {
+                let mut m = valid.clone();
+                m["title"] = json!(4497);
+                m
+            }),
         ];
         // Every required key, dropped one at a time.
         for key in COMPLETION_REQUIRED_KEYS {
@@ -2340,12 +2580,25 @@ mod tests {
         let meta = CompletionMeta {
             issue: None,
             tokens: None,
+            title: None,
+            additions: None,
+            deletions: None,
             ..sample_completion_meta()
         }
         .to_meta_value()
         .unwrap();
         assert!(meta.get("issue").is_none(), "absent issue must be omitted, not null/0");
         assert!(meta.get("tokens").is_none(), "absent tokens must be omitted, not null/0");
+        assert!(meta.get("title").is_none(), "absent title must be omitted, not null/empty");
+        assert!(meta.get("additions").is_none(), "absent additions must be omitted, not 0");
+        assert!(meta.get("deletions").is_none(), "absent deletions must be omitted, not 0");
+        // With every extension absent, the envelope is exactly the required
+        // completion-v1 object — no new keys, so no new failure modes (#4497).
+        assert_eq!(
+            meta.as_object().unwrap().len(),
+            COMPLETION_REQUIRED_KEYS.len(),
+            "all-absent extensions ⇒ meta identical to the required-keys-only envelope; got {meta}"
+        );
         // A zero token count is indistinguishable from "no accounting data".
         let zeroed = CompletionMeta {
             tokens: Some(0),
@@ -2354,6 +2607,67 @@ mod tests {
         .to_meta_value()
         .unwrap();
         assert!(zeroed.get("tokens").is_none());
+        // A blank/whitespace title would render as an empty feed row label.
+        for blank in ["", "   ", "\n\t"] {
+            let meta = CompletionMeta {
+                title: Some(blank.to_owned()),
+                ..sample_completion_meta()
+            }
+            .to_meta_value()
+            .unwrap();
+            assert!(meta.get("title").is_none(), "blank title must be omitted: {blank:?}");
+        }
+    }
+
+    #[test]
+    fn completion_meta_publishes_zero_diff_counts_and_trims_the_title() {
+        // Unlike `tokens`, `0` additions/deletions is a *fact* about the merge
+        // (a pure revert, an empty-diff merge commit), not a "no data" sentinel
+        // — so it is published rather than filtered (#4497).
+        let meta = CompletionMeta {
+            additions: Some(0),
+            deletions: Some(0),
+            title: Some("  fix: trim me  ".to_owned()),
+            ..sample_completion_meta()
+        }
+        .to_meta_value()
+        .unwrap();
+        assert_eq!(meta["additions"], json!(0));
+        assert_eq!(meta["deletions"], json!(0));
+        assert_eq!(meta["title"], json!("fix: trim me"));
+    }
+
+    #[test]
+    fn completion_meta_carries_the_title_verbatim_for_downstream_redaction() {
+        // Deny-pattern redaction is safehoused's egress job (it redacts every
+        // string in the published payload), not loom's — so the contract loom
+        // owns is that `title` reaches the wire as an ordinary JSON string in
+        // `meta`, exactly like `repo`/`ref`, with no escaping or bespoke
+        // encoding that would let it bypass that pass (#4497 AC3).
+        let secretish = "fix: rotate ghp_EXAMPLETOKEN0123456789 in \"prod\"\\config";
+        let env = build_completion_envelope(
+            Some("/x/loom"),
+            4497,
+            4500,
+            60,
+            &CompletionMeta {
+                title: Some(secretish.to_owned()),
+                ..sample_completion_meta()
+            },
+        )
+        .unwrap();
+        let req = build_send_request(&env, 1, Some("fleet")).unwrap();
+        assert_eq!(
+            req["meta"]["title"],
+            json!(secretish),
+            "title must be a plain JSON string in meta, like every other redactable field"
+        );
+        // And it survives a JSON round-trip through the wire encoding intact —
+        // the shape safehoused's redactor walks.
+        let line = serde_json::to_string(&req).unwrap();
+        let parsed: Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(parsed["meta"]["title"], json!(secretish));
+        assert!(parsed["meta"]["title"].is_string());
     }
 
     #[test]
@@ -2756,6 +3070,7 @@ mod tests {
             Duration::from_millis(20),
             Duration::from_millis(80),
             new_shared_state(),
+            None,
         ));
 
         bus.publish(Event::SweepGlobalDispatch {
@@ -2814,7 +3129,93 @@ mod tests {
         (script_path, log)
     }
 
-    const MERGED_PR_JSON: &str = r#"[{"number":4400,"url":"https://github.com/rjwalters/loom/pull/4400","mergedAt":"2026-07-29T10:12:00Z"}]"#;
+    /// A `gh pr list` row carrying everything the enriched query asks for: the
+    /// load-bearing merge facts plus the #4497 feed display fields.
+    const MERGED_PR_JSON: &str = r#"[{"number":4400,"url":"https://github.com/rjwalters/loom/pull/4400","mergedAt":"2026-07-29T10:12:00Z","title":"feat: enrich completion meta","additions":214,"deletions":37}]"#;
+
+    /// The pre-#4497 row shape: merge facts only. Stands in for a forge/`gh`
+    /// that answers the query but returns none of the display fields — the
+    /// completion must still publish, minus those keys.
+    const MERGED_PR_JSON_NO_DISPLAY_FIELDS: &str = r#"[{"number":4400,"url":"https://github.com/rjwalters/loom/pull/4400","mergedAt":"2026-07-29T10:12:00Z"}]"#;
+
+    /// Build an activity DB under `dir` carrying exactly one per-issue token
+    /// rollup for `issue`, wired the way [`fetch_issue_tokens`]'s query reads it:
+    /// a recorded input, a forge event linking that input to the issue, and a
+    /// resource-usage sample linked to the same input.
+    fn seed_activity_db_with_issue_tokens(
+        dir: &std::path::Path,
+        issue: i32,
+        tokens_input: i64,
+        tokens_output: i64,
+    ) -> Arc<Mutex<ActivityDb>> {
+        use crate::activity::{
+            AgentInput, InputContext, InputType, PromptForgeEvent, PromptForgeEventType,
+        };
+
+        let db = ActivityDb::new(dir.join("activity.db")).unwrap();
+        let input_id = db
+            .record_input(&AgentInput {
+                id: None,
+                terminal_id: "loom-builder-1".to_owned(),
+                timestamp: Utc::now(),
+                input_type: InputType::Autonomous,
+                content: "/loom:builder".to_owned(),
+                agent_role: Some("builder".to_owned()),
+                context: InputContext::default(),
+            })
+            .unwrap();
+        db.record_prompt_forge_event(&PromptForgeEvent {
+            id: None,
+            input_id: Some(input_id),
+            issue_number: Some(issue),
+            pr_number: None,
+            label_before: None,
+            label_after: None,
+            event_type: PromptForgeEventType::PrCreated,
+        })
+        .unwrap();
+        db.record_resource_usage(&crate::activity::resource_usage::ResourceUsage {
+            input_id: Some(input_id),
+            model: "claude-opus-5".to_owned(),
+            tokens_input,
+            tokens_output,
+            tokens_cache_read: None,
+            tokens_cache_write: None,
+            cost_usd: 1.25,
+            duration_ms: Some(1_000),
+            provider: "anthropic".to_owned(),
+            timestamp: Utc::now(),
+        })
+        .unwrap();
+        Arc::new(Mutex::new(db))
+    }
+
+    /// Write an executable fake `gh` whose `pr list` arm **rejects** the
+    /// enriched `--json` field set exactly the way a `gh` too old to know
+    /// `additions` does, and answers the narrower pre-#4497 set. Also logs every
+    /// invocation so a test can prove the retry happened.
+    fn write_fake_gh_rejecting_display_fields(dir: &std::path::Path) -> (PathBuf, PathBuf) {
+        let log = dir.join("gh-forge-invocations.log");
+        let script_path = dir.join("fake-old-gh.sh");
+        let body = format!(
+            "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"{}\"\n\
+             case \"$1 $2\" in\n  \
+             'pr list')\n    \
+             if [[ \"$*\" == *additions* ]]; then\n      \
+             echo 'unknown JSON field: \"additions\"' >&2\n      exit 1\n    fi\n    \
+             printf '%s\\n' {}; exit 0 ;;\n  \
+             'repo view') printf '%s\\n' {}; exit 0 ;;\n  \
+             *) exit 1 ;;\nesac\n",
+            log.display(),
+            shell_quote(MERGED_PR_JSON_NO_DISPLAY_FIELDS),
+            shell_quote("rjwalters/loom"),
+        );
+        std::fs::write(&script_path, body).unwrap();
+        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).unwrap();
+        (script_path, log)
+    }
 
     #[tokio::test]
     #[serial]
@@ -2836,6 +3237,7 @@ mod tests {
             exited_at,
             &mut HashMap::new(),
             &mut std::collections::HashSet::new(),
+            None,
         )
         .await;
 
@@ -2853,9 +3255,160 @@ mod tests {
         // started_at is derived from the exit clock minus duration_sec.
         assert_eq!(meta["started_at"], json!("2026-07-29T10:00:00Z"));
         assert_eq!(meta["completed_at"], json!("2026-07-29T10:12:30Z"));
-        // No cheap token source is wired to the sink — omitted, never guessed.
+        // Feed display fields (#4497), harvested from the same `gh pr list` call
+        // that verified the merge — no extra forge round-trip.
+        assert_eq!(meta["title"], json!("feat: enrich completion meta"));
+        assert_eq!(meta["additions"], json!(214));
+        assert_eq!(meta["deletions"], json!(37));
+        // No activity-DB handle was threaded in ⇒ `tokens` is omitted, never
+        // guessed (the degradation contract).
         assert!(meta.get("tokens").is_none());
         assert!(build_send_request(&envelope, 1, None).is_ok());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn completion_for_exit_omits_display_fields_the_forge_did_not_return() {
+        // The pre-#4497 row shape: the merge facts are all there, none of the
+        // display fields are. The completion must still publish, with an
+        // envelope byte-identical to the pre-#4497 one (#4497 AC2).
+        let dir = tempfile::tempdir().unwrap();
+        let (fake_gh, _log) = write_fake_forge_gh(
+            dir.path(),
+            Some(MERGED_PR_JSON_NO_DISPLAY_FIELDS),
+            Some("rjwalters/loom"),
+        );
+        std::env::set_var(GH_BIN_ENV, &fake_gh);
+
+        let envelope = completion_for_exit(
+            "loom_daemon",
+            &dir.path().to_string_lossy(),
+            4426,
+            750,
+            Utc::now(),
+            &mut HashMap::new(),
+            &mut std::collections::HashSet::new(),
+            None,
+        )
+        .await;
+
+        std::env::remove_var(GH_BIN_ENV);
+        let envelope = envelope.expect("missing display fields must not cost us the completion");
+        let meta = envelope.meta.as_ref().unwrap();
+        for key in ["title", "additions", "deletions", "tokens"] {
+            assert!(meta.get(key).is_none(), "{key} must be omitted when unavailable");
+        }
+        // Required keys + `issue`, i.e. exactly the pre-#4497 envelope.
+        assert_eq!(meta.as_object().unwrap().len(), COMPLETION_REQUIRED_KEYS.len() + 1);
+        assert!(build_send_request(&envelope, 1, None).is_ok());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn completion_for_exit_retries_the_base_field_set_when_gh_rejects_the_new_ones() {
+        // A `gh` that does not know `additions` rejects the *whole* request, so
+        // without the narrower retry #4497 would have silently cost every
+        // completion on such a host.
+        let dir = tempfile::tempdir().unwrap();
+        let (fake_gh, log) = write_fake_gh_rejecting_display_fields(dir.path());
+        std::env::set_var(GH_BIN_ENV, &fake_gh);
+
+        let envelope = completion_for_exit(
+            "loom_daemon",
+            &dir.path().to_string_lossy(),
+            4426,
+            750,
+            Utc::now(),
+            &mut HashMap::new(),
+            &mut std::collections::HashSet::new(),
+            None,
+        )
+        .await;
+
+        std::env::remove_var(GH_BIN_ENV);
+        let envelope = envelope.expect("an old gh must still yield a completion, minus the extras");
+        let meta = envelope.meta.as_ref().unwrap();
+        assert_eq!(meta["ref"], json!("https://github.com/rjwalters/loom/pull/4400"));
+        assert!(meta.get("title").is_none());
+        assert!(meta.get("additions").is_none());
+        let calls = std::fs::read_to_string(&log).unwrap_or_default();
+        assert!(
+            calls.contains("additions"),
+            "the enriched field set must be tried first; log: {calls:?}"
+        );
+        assert!(
+            calls
+                .lines()
+                .any(|l| l.starts_with("pr list") && !l.contains("additions")),
+            "the rejection must be retried with the base field set; log: {calls:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn completion_for_exit_carries_tokens_from_the_activity_db_rollup() {
+        // The per-issue rollup is the sink's token source (#4497). Attribution is
+        // knowingly imperfect (see `fetch_issue_tokens`), but when the DB *has* a
+        // rollup for the issue the completion must publish input+output.
+        let dir = tempfile::tempdir().unwrap();
+        let (fake_gh, _log) =
+            write_fake_forge_gh(dir.path(), Some(MERGED_PR_JSON), Some("rjwalters/loom"));
+        std::env::set_var(GH_BIN_ENV, &fake_gh);
+
+        let db = seed_activity_db_with_issue_tokens(dir.path(), 4426, 700_000, 91_000);
+
+        let envelope = completion_for_exit(
+            "loom_daemon",
+            &dir.path().to_string_lossy(),
+            4426,
+            750,
+            Utc::now(),
+            &mut HashMap::new(),
+            &mut std::collections::HashSet::new(),
+            Some(&db),
+        )
+        .await;
+
+        std::env::remove_var(GH_BIN_ENV);
+        let envelope = envelope.expect("a merged PR must produce a completion envelope");
+        let meta = envelope.meta.as_ref().unwrap();
+        assert_eq!(meta["tokens"], json!(791_000), "tokens = input + output");
+        assert!(build_send_request(&envelope, 1, None).is_ok());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn completion_for_exit_omits_tokens_when_the_rollup_is_empty() {
+        // "Omit rather than guess": an activity DB with no rollup for this issue
+        // must not publish a `0`, which the feed would chart as free work.
+        let dir = tempfile::tempdir().unwrap();
+        let (fake_gh, _log) =
+            write_fake_forge_gh(dir.path(), Some(MERGED_PR_JSON), Some("rjwalters/loom"));
+        std::env::set_var(GH_BIN_ENV, &fake_gh);
+
+        // Seeded for a *different* issue, so this issue's rollup is empty.
+        let db = seed_activity_db_with_issue_tokens(dir.path(), 999, 12_345, 678);
+
+        let envelope = completion_for_exit(
+            "loom_daemon",
+            &dir.path().to_string_lossy(),
+            4426,
+            750,
+            Utc::now(),
+            &mut HashMap::new(),
+            &mut std::collections::HashSet::new(),
+            Some(&db),
+        )
+        .await;
+
+        std::env::remove_var(GH_BIN_ENV);
+        let meta = envelope
+            .as_ref()
+            .and_then(|e| e.meta.as_ref())
+            .expect("an empty rollup must never cost us the completion");
+        assert!(meta.get("tokens").is_none(), "an empty rollup ⇒ omitted, not 0");
+        // The forge-sourced display fields are unaffected by the token miss.
+        assert_eq!(meta["title"], json!("feat: enrich completion meta"));
     }
 
     #[tokio::test]
@@ -2875,6 +3428,7 @@ mod tests {
             Utc::now(),
             &mut HashMap::new(),
             &mut std::collections::HashSet::new(),
+            None,
         )
         .await;
 
@@ -2897,6 +3451,7 @@ mod tests {
             Utc::now(),
             &mut HashMap::new(),
             &mut std::collections::HashSet::new(),
+            None,
         )
         .await;
 
@@ -2925,6 +3480,7 @@ mod tests {
             Utc::now(),
             &mut slug_cache,
             &mut completed,
+            None,
         )
         .await;
         let second = completion_for_exit(
@@ -2935,6 +3491,7 @@ mod tests {
             Utc::now(),
             &mut slug_cache,
             &mut completed,
+            None,
         )
         .await;
 
@@ -2976,6 +3533,7 @@ mod tests {
             Duration::from_millis(20),
             Duration::from_millis(80),
             new_shared_state(),
+            None,
         ));
 
         bus.publish(Event::SweepExited {
@@ -3005,6 +3563,11 @@ mod tests {
         assert_eq!(received[1]["meta"]["repo"], json!("rjwalters/loom"));
         assert_eq!(received[1]["meta"]["result"], json!("success"));
         assert_eq!(received[1]["meta"]["issue"], json!(4426));
+        // The #4497 display fields make it all the way onto the wire, where
+        // safehoused's egress redacts and publishes them.
+        assert_eq!(received[1]["meta"]["title"], json!("feat: enrich completion meta"));
+        assert_eq!(received[1]["meta"]["additions"], json!(214));
+        assert_eq!(received[1]["meta"]["deletions"], json!(37));
         // Both lines thread together under the repo-qualified task_id.
         assert_eq!(received[0]["task_id"], received[1]["task_id"]);
         assert!(received[1]["body"].as_str().unwrap().contains("merged ✓"));
@@ -3034,6 +3597,7 @@ mod tests {
             Duration::from_millis(20),
             Duration::from_millis(80),
             new_shared_state(),
+            None,
         ));
 
         bus.publish(Event::SweepExited {
@@ -3304,6 +3868,7 @@ mod tests {
             Duration::from_millis(50),
             Duration::from_millis(200),
             state.clone(),
+            None,
         ));
 
         // Event 1 → rejected → send_rejected (with reason), NOT unreachable.
@@ -3400,6 +3965,7 @@ mod tests {
             Duration::from_millis(30),
             Duration::from_millis(60),
             state.clone(),
+            None,
         ));
 
         // Event 1 → conn1 rejects → SendRejected.
@@ -3469,6 +4035,7 @@ mod tests {
             &bus,
             &tokio::runtime::Handle::current(),
             state.clone(),
+            None,
         );
         assert!(handle.is_none(), "disabled ⇒ no sink task");
         // The load-bearing no-op assertion: no subscription was created.
@@ -3498,6 +4065,7 @@ mod tests {
             Duration::from_millis(50),
             Duration::from_millis(200),
             state.clone(),
+            None,
         ));
 
         // Publish a burst; the sink must consume them all without wedging.
@@ -3550,6 +4118,7 @@ mod tests {
             Duration::from_millis(20),
             Duration::from_millis(80),
             state.clone(),
+            None,
         ));
 
         // First event: delivered over listener1.

--- a/loom-daemon/src/workspace_pool.rs
+++ b/loom-daemon/src/workspace_pool.rs
@@ -137,13 +137,22 @@ impl WorkspacePool {
     /// returns without subscribing or touching a socket. Best-effort by
     /// contract — a missing/refused peer degrades to a `warn`, never a sweep
     /// failure. The handle is detached (daemon-lifetime).
-    pub fn start_safehouse_narration(&self, repo_root: &Path) {
+    ///
+    /// `activity_db` (#4497) is threaded to the completion emit point purely so
+    /// its public-feed `meta` can carry a best-effort per-issue `tokens` total;
+    /// `None` omits that field and changes nothing else.
+    pub fn start_safehouse_narration(
+        &self,
+        repo_root: &Path,
+        activity_db: Option<Arc<Mutex<crate::activity::ActivityDb>>>,
+    ) {
         let config = crate::safehouse::resolve_config(repo_root);
         let _ = crate::safehouse::spawn_sink(
             config,
             &self.event_bus,
             &self.runtime,
             self.safehouse_state.clone(),
+            activity_db,
         );
     }
 
@@ -525,7 +534,7 @@ mod tests {
         );
         let pool = pool();
 
-        pool.start_safehouse_narration(&root);
+        pool.start_safehouse_narration(&root, None);
         // The sink reports "configured, not yet connected" immediately on
         // spawn (before any connect attempt) — poll briefly rather than
         // assuming the spawned task has already run once.
@@ -556,7 +565,7 @@ mod tests {
         let pool = pool();
 
         // Drive the cell to a non-default state first via the narration sink.
-        pool.start_safehouse_narration(&root);
+        pool.start_safehouse_narration(&root, None);
         let mut status = pool.safehouse_status();
         for _ in 0..50 {
             if status.state != "not_configured" {


### PR DESCRIPTION
## Summary

The public fleet feed on 2amlogic.com renders completion entries as
`<repo>#<issue>: <title> +<additions> −<deletions> · <dur> · <tokens> tok`, and its
ingest already accepts and stores all four as extension fields — but the producer
only sent `{schema, agent, repo, ref, result, started_at, completed_at, issue}`.
This wires the four display fields at the existing emit point (the narration sink,
on `SweepExited`, after the forge-truth merge check). envelope-v1 preserves unknown
`meta` keys and safehoused's egress publishes the raw redacted `meta`, so **no
schema revision** was needed.

Per the operator's 2026-07-29 priority update on the issue, `tokens` is treated as a
**wanted** field rather than an optional nicety: it is wired to the activity DB's
per-issue rollup and its attribution imperfections are documented on the field, not
used as a reason to omit it.

## Changes

**`loom-daemon/src/safehouse.rs`**

- `fetch_merged_pr` now requests `--json number,url,mergedAt,title,additions,deletions`
  — the display fields come out of the **same** `gh pr list` call that already
  verifies the merge, so **zero extra forge round-trips**. Each is read with
  `and_then`/`filter` rather than `?`, so an absent or wrongly-typed one degrades
  that field alone and never costs the completion.
- **Old-`gh` safety net.** A `gh` that does not know one of the new fields rejects
  the *whole* request (it does not silently omit the field), which would have cost
  every completion on such a host. That one case — and only that one, matched on
  `unknown JSON field` in stderr — retries the pre-#4497 `number,url,mergedAt` set.
  Ordinary degradations (no auth, no network, not a repo) do **not** trigger a
  second spawn.
- `MergedPr` and `CompletionMeta` gain `title`/`additions`/`deletions`;
  `CompletionMeta::tokens` (which already existed, hardcoded `None`) is now
  populated.
- `fetch_issue_tokens` sums `total_input_tokens + total_output_tokens` over
  `ActivityDb::get_cost_by_issue`, on the **blocking pool** under a 5s cap — the
  rusqlite handle is behind a `std::sync::Mutex` shared with the IPC recorder's
  writes, so the sink must never park a daemon-runtime worker on it (and a std
  guard cannot cross an `await`).
- `to_meta_value` inserts each field only when present. `title` is trimmed and a
  blank one is dropped; `additions`/`deletions` publish **real zeros**, since `0`
  additions is a fact about a merge (an empty-diff merge, a pure revert) rather than
  the "no data" sentinel a `0` token count would be.
- `validate_completion_meta` extends its non-negative-integer check to
  `additions`/`deletions`, and requires `title`, when present, to be a non-empty
  string — so a malformed extension is refused client-side rather than silently
  degraded to `chat` by safehoused.

**Plumbing** — the activity DB handle is threaded `main.rs` →
`WorkspacePool::start_safehouse_narration` → `spawn_sink` → `run_sink` →
`completion_for_exit` as an `Option<Arc<Mutex<ActivityDb>>>`. It is the same `Arc`
the IPC server already holds, and the sink only ever reads.

**Docs** — `.loom/docs/safehouse.md` (completion-v1 field table, the new display-fields
subsection, the redaction-is-downstream note) and `defaults/docs/daemon-reference.md`
(`.loom/docs/daemon-reference.md` is a symlink to it, so both are covered).

### `tokens` attribution: honest caveats (please review this call)

`get_cost_by_issue` is the sanctioned rollup and is now wired, but two limits are
documented on `fetch_issue_tokens` rather than hidden:

1. **Not repo-qualified.** `prompt_github` keys on a bare `issue_number` with no repo
   column, so a daemon managing several repos conflates identical issue numbers.
2. **Only as good as the prompt↔usage linkage.** The rollup joins
   `resource_usage → agent_inputs → prompt_github` on `input_id`. The live daemon
   recorder currently passes `input_id: None` for both sides
   (`ipc.rs` `record_resource_usage_from_output(None, …)` and
   `to_prompt_forge_event(None)`), so **on today's main the join is empty and
   `tokens` will be omitted in practice** until that linkage is established.

The plumbing is correct and lights up the moment attribution lands; fixing the
recorder's `input_id` linkage is a separate defect in the activity recorder and out
of scope here. I have **not** filed a follow-up issue for it yet — happy to, or to
extend scope, on the reviewer's call.

## Acceptance Criteria Verification

- [x] **Merged-sweep completions carry `title`, `additions`, `deletions` when the
      forge query returns them, `tokens` when the activity DB has a per-issue
      rollup.** — `completion_for_exit_emits_when_the_pr_merged` asserts all three
      display fields; `completion_for_exit_carries_tokens_from_the_activity_db_rollup`
      seeds a real `ActivityDb` (input + forge event + usage sample) and asserts
      `meta["tokens"] == 791000` (= 700000 input + 91000 output);
      `run_sink_narrates_exit_ack_then_completion` asserts they reach the wire.
- [x] **All four absent ⇒ envelope identical to today's (no new failure modes on the
      emit path).** — `completion_meta_omits_absent_optional_fields` asserts the
      all-absent `meta` has exactly `COMPLETION_REQUIRED_KEYS.len()` keys;
      `completion_for_exit_omits_display_fields_the_forge_did_not_return` asserts a
      pre-#4497 forge row still yields a completion whose `meta` is required keys +
      `issue`; `completion_for_exit_omits_tokens_when_the_rollup_is_empty` asserts an
      empty rollup omits `tokens` (never a bogus `0`) without costing the completion;
      `completion_for_exit_retries_the_base_field_set_when_gh_rejects_the_new_ones`
      asserts an old `gh` still publishes. The existing
      `completion_for_exit_degrades_to_none_when_gh_fails` /
      `..._is_silent_when_the_pr_did_not_merge` are unchanged and still pass.
- [x] **Deny-pattern redaction applies to `title` like every other string — covered
      by a test.** — Redaction happens in `safehoused`, an operator-supplied external
      binary, so the contract *loom* owns is that `title` reaches the wire as an
      ordinary JSON string in `meta` (no bespoke escaping that could bypass the
      egress pass). `completion_meta_carries_the_title_verbatim_for_downstream_redaction`
      pushes a token-like, quote- and backslash-bearing title through
      `build_send_request` + a full JSON round-trip and asserts it arrives byte-exact
      and `is_string()`, alongside `repo`/`ref`.

## Test Plan

```
cargo test --manifest-path loom-daemon/Cargo.toml --lib safehouse
  → 83 passed; 0 failed

cargo test --manifest-path loom-daemon/Cargo.toml --lib
  → 2262 passed; 1 failed

cargo clippy --manifest-path loom-daemon/Cargo.toml --all-targets   → clean
cargo fmt                                                           → applied
bash .loom/scripts/build-gate.sh                                    → exit 0
```

New/extended tests (all in `loom-daemon/src/safehouse.rs`):
`completion_for_exit_omits_display_fields_the_forge_did_not_return`,
`completion_for_exit_retries_the_base_field_set_when_gh_rejects_the_new_ones`,
`completion_for_exit_carries_tokens_from_the_activity_db_rollup`,
`completion_for_exit_omits_tokens_when_the_rollup_is_empty`,
`completion_meta_publishes_zero_diff_counts_and_trims_the_title`,
`completion_meta_carries_the_title_verbatim_for_downstream_redaction`, plus extended
`completion_meta_omits_absent_optional_fields`,
`send_request_accepts_completion_with_valid_meta`,
`send_request_refuses_every_flavor_of_malformed_completion_meta` (4 new malformed
cases), `completion_for_exit_emits_when_the_pr_merged`,
`run_sink_narrates_exit_ack_then_completion`.

### Notes for the reviewer

- **The one full-suite failure is a pre-existing, load-induced flake, unrelated to
  this change**: `auto_update::tests::test_run_update_script_exit_4_is_terminal`
  (a subprocess exit-code test in a module this PR does not touch). It passes in
  isolation — this host was running 4+ concurrent sweeps with parallel cargo builds.
- **This host's main checkout is dirty from other concurrent sweeps** (`.gitignore`,
  an empty `1h` file, `.loom/docs/advanced-hooks.md`, `.loom/docs/ci-integration.md`,
  `.loom/install-metadata.json`), so `check-main-clean.sh` exits 3. None of it came
  from this session — every edit here landed in `.loom/worktrees/issue-4497` and this
  branch contains exactly 5 files. Left untouched deliberately: quarantining another
  in-flight agent's work would destroy it.

Closes #4497