### PR TITLE
fix(sweep): make PROBE_POOL token count zsh-safe

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -772,7 +772,7 @@ A pool exists if **either** of these is true (logical OR, both checked):
 Both checks are cheap, local, and side-effect-free. The configured-pool count mirrors `bootstrap.py`'s source precedence but does **not** dedupe by email — a raw sum of `ACCOUNT_KEY_*` lines is an accepted approximation for this boolean `>= 2` gate (worst case a single account declared in two sources double-counts at the `== 1` vs `== 2` boundary, a false-positive toward daemon use that still requires `PROBE_DAEMON` to also be true):
 
 ```bash
-TOKEN_FILE_COUNT=$(ls .loom/tokens/*.token 2>/dev/null | wc -l | tr -d ' ')
+TOKEN_FILE_COUNT=$(find .loom/tokens -maxdepth 1 -name '*.token' 2>/dev/null | wc -l | tr -d ' ')
 
 # Repo-local (mirrors bootstrap.py: .loom/accounts.env if present, else legacy .env)
 # NOTE: `grep -c` prints `0` AND exits non-zero on an existing-but-empty file, so a


### PR DESCRIPTION
## Summary

`defaults/.claude/commands/loom/sweep.md`'s Stage -1 `PROBE_POOL` snippet used
`ls .loom/tokens/*.token 2>/dev/null | wc -l | tr -d ' '` to count materialized
token files. Under zsh (the macOS default shell), an unmatched glob raises a
shell-level error *before* `ls` runs (`no matches found: .loom/tokens/*.token`),
and `2>/dev/null` on `ls` does not suppress it since the error originates from
zsh's glob expansion, not from `ls` itself. This was observed live during a
`/loom:sweep all` Stage -1 probe on a repo with no materialized tokens.

Replaced with `find .loom/tokens -maxdepth 1 -name '*.token' 2>/dev/null | wc -l
| tr -d ' '`, which passes the pattern as a literal argument to `find` and never
triggers shell-level glob expansion, so it is safe under both bash and zsh
regardless of match count.

Per the curated issue, this is the only occurrence of the bare-glob-through-`ls`
pattern in `defaults/.claude/commands/loom/*.md` (the worktree count in the
dry-run verification block, `ls .loom/worktrees/ 2>/dev/null | wc -l`, has no
glob and is unaffected). There is no installed `.claude/commands/loom/sweep.md`
copy in this repo's own working tree to update in parallel.

Closes #4509

## Test plan

- [x] Verified the replacement snippet under bash: absent `.loom/tokens/` dir
      -> `0`, empty dir -> `0`, dir with 2 dummy `.token` files -> `2`, no
      errors in any case.
- [ ] zsh not available on the build host to spot-check directly, but `find
      -name` is not subject to shell glob expansion (unlike `ls *.token`), so
      the fix is expected to behave identically under zsh.