### PR TITLE
fix: rotate on per-model usage ceilings and pin the role runner's model

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1814,6 +1814,26 @@ which backs off stacking for the saturated account; a bounded
 spinning, after which it falls through to normal transient backoff (still without
 marking the token bad).
 
+**Per-model limit handling + one retry verdict (#4501).** The CLI also emits a
+**per-model** ceiling — `You've reached your Fable 5 limit. Run /usage-credits to
+continue or switch models with /model.` — whose model name sits between "your" and
+"limit". That phrasing matched none of the older "hit your … limit" patterns, so
+rotation never fired and every child died instantly; `classify-error.sh` now
+matches the `reached your <model> limit` family as `TOKEN_EXHAUSTED` (ordered
+*after* the `SESSION_LIMIT` branch so "reached your concurrent session limit`"
+keeps its capacity classification). Reusing `TOKEN_EXHAUSTED` is a deliberate safe
+over-approximation: a Fable-only ceiling does not exhaust `sonnet` on the same
+account, so the pool is slightly pessimistic but rotation is correct, and no
+downstream consumer has to learn a new category. Relatedly, `claude-wrapper.sh`'s
+retry decision no longer keeps its own pattern list — `is_transient_error` derives
+it from `classify_error`'s category via the shared `classification_is_transient`
+**deny-list** (terminal: `SUCCESS`, `TIMEOUT`, `TOKEN_EXPIRED`, `CWD_DELETED`,
+`MODEL_REFUSAL`, `FATAL`; everything else retried, bounded by `LOOM_MAX_RETRIES`).
+That makes the observed contradiction — `Non-transient error detected - not
+retrying` printed next to `classification=RECOVERABLE` — structurally impossible,
+and means an *unrecognized* non-zero exit is now retried rather than dying on
+attempt 1.
+
 The **effective** per-tick concurrency is then `min(dynamic_cap, backlog_depth)`:
 `tick()` iterates the ready `loom:issue` rows and stops at the cap, so
 concurrency **scales up** as the backlog grows and drains to **zero** dispatches
@@ -2062,6 +2082,7 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.roleRunner.enabled` | `LOOM_ROLE_RUNNER` | `false` | Periodic standalone support-role runner on/off (#4015). **Resolved per registered root** (#4377) — see the callout below the table |
 | `autonomous.roleRunner.roles` | *(config only)* | all 5 roles | Subset of `champion`/`curator`/`judge`/`auditor`/`guide` to dispatch; explicit empty array runs none. Also resolved from each root's own config |
 | `autonomous.roleRunner.intervalSecs` | `LOOM_ROLE_RUNNER_INTERVAL_SECS` | per-role built-in (5–15 min) | Uniform override applied to every enabled role's cadence |
+| `autonomous.roleRunner.model` | *(config only)* | `sonnet` | Model every role child is pinned to via `--model` (#4501). Resolved through the same `resolve_dispatch_model` chain as sweep dispatch: this key > `autonomous.model` > shipped default; blanks treated as unset. A role child never inherits the account's interactive CLI default |
 | `autonomous.roleRunner.onIdle` | *(config only)* | `[]` (none) | Subset of the same 5 roles to also fire on the work-finder **idle edge** (#4364) — the non-idle → idle transition (0 in-flight sweeps AND nothing dispatched this tick), in addition to the interval cadence. Absent → none (opposite default from `roles`); unknown names ignored with a warning. Debounced to min 60s per (root, role) and skipped while that role's interval/idle run is in progress. **Requires the work finder enabled** to observe idleness (a startup warning fires if set with the work finder off). **Also gated by that same root's own `enabled`** (#4377) — see below |
 | `autonomous.idleExit.enabled` | `LOOM_AUTONOMOUS_IDLE_EXIT_ENABLED` | `false` | End the daemon cleanly after the idle window so a host guard can take over. Independent of Work Finder; never invokes a power command |
 | `autonomous.idleExit.idleMinutes` | `LOOM_AUTONOMOUS_IDLE_EXIT_MINUTES` | `60` | Continuous idle/starvation window. Zero/invalid → default |
@@ -2761,6 +2782,19 @@ leaves the daemon's behavior byte-for-byte unchanged:
 | `LOOM_ROLE_RUNNER_INTERVAL_SECS` | `autonomous.roleRunner.intervalSecs` | env > config > default | per-role built-in (see above) |
 | — | `autonomous.roleRunner.roles` | config only | all five roles |
 | — | `autonomous.roleRunner.onIdle` | config only | `[]` (none) |
+| — | `autonomous.roleRunner.model` | config only (`roleRunner.model` > `autonomous.model` > default) | `sonnet` (`DEFAULT_DISPATCH_MODEL`) |
+
+**Role children are model-pinned (#4501).** Every role spawn appends an explicit
+`--model <resolved>` (immediately after the prompt, mirroring sweep dispatch), so
+a scheduled role never inherits the selected account's *interactive* CLI default.
+Before this, a host whose CLI default was `fable` ran every curator/champion/judge
+tick on the most constrained quota tier and then died instantly on "You've reached
+your Fable 5 limit". Resolution reuses `resolve_dispatch_model` — the same chain
+sweeps use, including the #3982 logical-tier aliases (`opus` → `claude-opus-5`) —
+with `autonomous.roleRunner.model` occupying the explicit-request tier. Blank
+values are treated as unset at every tier (`--model ""` is never emitted). The
+resolved model and the tier that supplied it are recorded in the per-role log
+header: `==== loom-daemon role_runner: <ts> role=<role> model=<m> (source=<tier>) ====`.
 
 `roles` restricts the dispatched subset (an explicit empty array runs none;
 unknown names are ignored with a warning). `intervalSecs` — both the env var

--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -949,63 +949,67 @@ check_api_reachable() {
     return 0  # Don't fail on network check - let Claude CLI handle it
 }
 
-# Detect if error output indicates a transient/retryable error
+# The category `is_transient_error` last derived its verdict from, exported so
+# the caller's log line can name the SAME verdict it acted on (issue #4501).
+# Initialized here so `set -u` is safe even if a caller reads it before the
+# first classification.
+_LAST_ERROR_CLASSIFICATION="UNCLASSIFIED"
+
+# Detect if error output indicates a transient/retryable error.
+#
+# Issue #4501: this predicate USED to carry its own array of transient phrasings,
+# entirely disjoint from `classify-error.sh`'s pattern tables. That made the
+# retry decision and the printed classification two independent verdict systems,
+# which produced this self-contradicting permanent-death block on a live host:
+#
+#   [ERROR] Non-transient error detected - not retrying
+#   [ERROR] exit_code=1 classification=RECOVERABLE
+#
+# (the CLI had emitted "You've reached your Fable 5 limit …", which matched
+# neither the old exhaustion regex nor the local array, so no rotation happened
+# AND no retry happened, while `log_permanent_death`'s independent
+# `classify_error` call reported the generic RECOVERABLE catch-all.)
+#
+# The verdict is now derived from `classify_error`'s category via the shared
+# `classification_is_transient` deny-list, so the two can never disagree again.
+# Notable consequences, all intentional:
+#   * An UNRECOGNIZED non-zero exit is now retried (the catch-all category is
+#     RECOVERABLE) instead of dying on attempt 1 — bounded by MAX_RETRIES and
+#     exponential backoff. This subsumes both the old `Execution error` special
+#     case (#4255) and the old "empty output with exit code 1" heuristic.
+#   * Genuinely terminal categories (TOKEN_EXPIRED, CWD_DELETED, MODEL_REFUSAL,
+#     FATAL, TIMEOUT) are still NOT retried — see `classification_is_transient`.
 is_transient_error() {
     local output="$1"
     local exit_code="${2:-1}"
 
     # Rate limit abort is NOT transient — the CLI hit a usage/plan limit
     # and showed an interactive prompt.  Retrying will hit the same limit.
+    # Checked before classification because this sentinel is the wrapper's own
+    # (the output/startup monitors emit it), not a CLI phrasing: the account
+    # rotation path above consumes it first, and reaching here means rotation
+    # was already capped or the pool was empty.
     if echo "${output}" | grep -q "RATE_LIMIT_ABORT"; then
+        _LAST_ERROR_CLASSIFICATION="RATE_LIMIT_ABORT"
         return 1
     fi
 
-    # Known transient error patterns
-    local patterns=(
-        "No messages returned"
-        "Rate limit exceeded"
-        "rate_limit"
-        "Connection refused"
-        "ECONNREFUSED"
-        "network error"
-        "NetworkError"
-        "ETIMEDOUT"
-        "ECONNRESET"
-        "ENETUNREACH"
-        "socket hang up"
-        "503 Service"
-        "502 Bad Gateway"
-        "500 Internal Server Error"
-        "overloaded"
-        "temporarily unavailable"
-        "MCP server failed"
-        "MCP.*failed"
-        "plugins failed"
-        "plugin.*failed to install"
-        # Issue #4255: the Claude CLI's bare `Execution error` fatal. This is the
-        # single most common unattended-death signature — 21% of daemon sweep
-        # logs terminated on it — yet it matched NONE of the patterns above, and
-        # because the CLI prints it (non-empty output) the empty-output-with-
-        # exit-1 heuristic below never fired either, so the wrapper died on
-        # attempt 1 without a single retry. Treat it as transient/retryable
-        # (bounded by MAX_RETRIES): it is an opaque transport/harness fault, not
-        # a deterministic build failure, so a retry frequently succeeds.
-        "Execution error"
-    )
-
-    for pattern in "${patterns[@]}"; do
-        if echo "${output}" | grep -qi "${pattern}"; then
-            log_info "Detected transient error pattern: ${pattern}"
-            return 0
-        fi
-    done
-
-    # Exit code 1 with no output often indicates API issues
-    if [[ "${exit_code}" -eq 1 && -z "${output}" ]]; then
-        log_info "Empty output with exit code 1 - treating as transient"
-        return 0
+    # Degraded path: `lib/classify-error.sh` was not sourced (it is optional at
+    # the top of this file). Retry-by-default on any non-zero exit, matching the
+    # deny-list policy's fail-safe direction, still bounded by MAX_RETRIES.
+    if ! declare -F classify_error >/dev/null 2>&1 \
+       || ! declare -F classification_is_transient >/dev/null 2>&1; then
+        _LAST_ERROR_CLASSIFICATION="UNCLASSIFIED"
+        log_warn "classify-error.sh not sourced — treating a non-zero exit as transient (bounded by MAX_RETRIES)"
+        [[ "${exit_code}" -ne 0 ]]
+        return
     fi
 
+    _LAST_ERROR_CLASSIFICATION="$(classify_error "${output}" "${exit_code}")"
+    if classification_is_transient "${_LAST_ERROR_CLASSIFICATION}"; then
+        log_info "Transient error (classification=${_LAST_ERROR_CLASSIFICATION}) - retrying"
+        return 0
+    fi
     return 1
 }
 
@@ -1025,8 +1029,15 @@ log_permanent_death() {
     local output="$2"
     local reason="${3:-permanent failure}"
 
-    local classification="UNCLASSIFIED"
-    if declare -F classify_error >/dev/null 2>&1; then
+    # Prefer the verdict the retry loop ACTED on (#4501). Both call sites reach
+    # here right after `is_transient_error` classified this exact
+    # `(output, exit_code)` pair, so reusing its cached category is equivalent by
+    # construction *and* removes the last way the printed classification could
+    # differ from the one the retry decision used (e.g. the wrapper's own
+    # RATE_LIMIT_ABORT sentinel, which classify_error would report as the generic
+    # RECOVERABLE). Falls back to a fresh classification for a direct caller.
+    local classification="${_LAST_ERROR_CLASSIFICATION:-UNCLASSIFIED}"
+    if [[ "${classification}" == "UNCLASSIFIED" ]] && declare -F classify_error >/dev/null 2>&1; then
         classification="$(classify_error "${output}" "${exit_code}" 2>/dev/null || echo "UNCLASSIFIED")"
     fi
 
@@ -1069,13 +1080,17 @@ is_account_exhaustion() {
     fi
 
     # Otherwise defer to the shared classifier (widened TOKEN_EXHAUSTED set).
-    # Fall back to an inline regex if the classifier lib was not sourced.
+    # This is why the #4501 regex fix in `lib/classify-error.sh` — adding the
+    # per-model "reached your <model> limit" ceiling — reaches the rotation path
+    # here with no change needed in this function.
+    # Fall back to an inline regex if the classifier lib was not sourced (kept
+    # in lockstep with the classifier's pattern, including the #4501 addition).
     if declare -F classify_error >/dev/null 2>&1; then
         [[ "$(classify_error "${output}" "${exit_code}")" == "TOKEN_EXHAUSTED" ]]
         return
     fi
     [[ "${exit_code}" -ne 0 ]] && echo "${output}" \
-        | grep -qiE "hit your (limit|session limit|weekly limit)|hit\.your\.limit|monthly usage limit|out of extra usage"
+        | grep -qiE "hit your (limit|session limit|weekly limit)|hit\.your\.limit|monthly usage limit|out of extra usage|reached your ([^[:space:]]+[[:space:]]+){0,3}limit"
 }
 
 # Return 0 if the captured output indicates a concurrent-session-limit fault
@@ -1145,7 +1160,11 @@ _exhaustion_phrase() {
         return
     fi
     local m
-    m="$(echo "${output}" | grep -ioE "hit your (limit|session limit|weekly limit)|monthly usage limit|out of extra usage|used 100% of your weekly limit" | head -1)"
+    # Kept in lockstep with the classifier's TOKEN_EXHAUSTED regex so the
+    # rotation log line quotes the phrase that actually fired — including the
+    # per-model "reached your <model> limit" ceiling added in #4501 (which
+    # names the constrained model, e.g. "reached your Fable 5 limit").
+    m="$(echo "${output}" | grep -ioE "hit your (limit|session limit|weekly limit)|monthly usage limit|out of extra usage|used 100% of your weekly limit|reached your ([^[:space:]]+[[:space:]]+){0,3}limit" | head -1)"
     echo "${m:-usage limit}"
 }
 
@@ -1956,7 +1975,10 @@ run_with_retry() {
 
         # Check if this is a transient error worth retrying
         if ! is_transient_error "${output}" "${exit_code}"; then
-            log_error "Non-transient error detected - not retrying"
+            # Name the classification the decision was derived from (#4501) so
+            # this line and log_permanent_death's `classification=` below always
+            # agree — they now come from the same `classify_error` call.
+            log_error "Non-transient error detected (classification=${_LAST_ERROR_CLASSIFICATION:-UNCLASSIFIED}) - not retrying"
             # Issue #4255: structured permanent-death diagnostics (exit code +
             # classification + stderr tail) in place of a bare `Output: ...`.
             log_permanent_death "${exit_code}" "${output}" "non-transient error"

--- a/defaults/scripts/lib/classify-error.sh
+++ b/defaults/scripts/lib/classify-error.sh
@@ -2,14 +2,27 @@
 # classify-error.sh — Classify a (output, exit_code, [provider]) triple into
 # an error category.
 #
-# Source this file (do not exec). Defines a single public function:
+# Source this file (do not exec). Defines two public functions:
+#
+#   classification_is_transient <category> -> exit 0 when a caller's retry loop
+#       should retry, 1 when the category is terminal. THE single source of
+#       truth for every retry decision (issue #4501) — see the function's own
+#       comment for the deny-list policy and why no caller may keep a private
+#       pattern list alongside it.
 #
 #   classify_error <output> <exit_code> [provider] -> echoes one of:
 #       SUCCESS         — exit 0 (regardless of output content)
 #       TIMEOUT         — exit 124/137 (productive cycle, not a failure)
 #       CWD_DELETED     — working directory was removed
 #       TOKEN_EXPIRED   — 401 / OAuth token expired (skip this token)
-#       TOKEN_EXHAUSTED — quota/weekly limit hit (rotate)
+#       TOKEN_EXHAUSTED — quota/weekly/per-model limit hit (rotate). Covers
+#                         both the "hit your … limit" family (#3738) and the
+#                         per-model "reached your <model> limit" ceiling the
+#                         CLI emits today (#4501) — the latter is a safe
+#                         over-approximation (the account may still have
+#                         headroom on a cheaper model) chosen over a new
+#                         model-dimensioned category so no downstream consumer
+#                         has to learn a new enum value.
 #       SESSION_LIMIT   — concurrent-session-limit fault (issue #3947): the
 #                         account is NOT out of quota, it just cannot start
 #                         another *simultaneous* session right now (a capacity
@@ -68,7 +81,10 @@
 #   TOKEN_EXPIRED -> SESSION_LIMIT -> TOKEN_EXHAUSTED -> the "No messages
 #   returned" RECOVERABLE case. SESSION_LIMIT must precede TOKEN_EXHAUSTED
 #   because "concurrent session limit" contains the substring "session limit"
-#   that the exhaustion regex also matches (#3947). MODEL_REFUSAL is matched
+#   that the exhaustion regex also matches (#3947) — and, since #4501 widened
+#   the exhaustion regex to "reached your <model> limit", it now also contains
+#   the "reached your … limit" shape, making that ordering load-bearing for a
+#   second reason. MODEL_REFUSAL is matched
 #   only when exit_code != 0, preserving the #3233 exit-code-first guarantee
 #   (a clean exit whose output merely mentions "refusal" stays SUCCESS).
 #
@@ -157,7 +173,28 @@ _classify_error_claude() {
     # file rather than duplicating the pattern (issue #3738) — moving the
     # pattern into this table preserves that single-source property; the
     # wrapper still reaches it only via `classify_error`, never a copy.
-    if echo "$output" | grep -qiE "hit your (limit|session limit|weekly limit)|hit\.your\.limit|monthly usage limit|out of extra usage"; then
+    #
+    # Issue #4501 adds the "reached your <model> limit" family: the CLI now
+    # emits a PER-MODEL ceiling — "You've reached your Fable 5 limit. Run
+    # /usage-credits to continue or switch models with /model." — where the
+    # model name sits between "your" and "limit", so none of the "hit your …"
+    # phrasings above fired and every daemon-dispatched child died permanently
+    # at CLI start instead of rotating. `([^[:space:]]+[[:space:]]+){0,3}`
+    # bounds the filler to at most three words so the pattern cannot swallow a
+    # whole unrelated sentence that merely ends in "limit". Ordered AFTER the
+    # SESSION_LIMIT branch above so "reached your concurrent session limit"
+    # keeps its distinct capacity classification (#3947).
+    #
+    # Deliberately reuses TOKEN_EXHAUSTED rather than introducing a
+    # model-dimensioned MODEL_LIMIT category: a Fable-only ceiling does not
+    # exhaust `sonnet` on the same account, so marking the whole account
+    # exhausted is a *safe over-approximation* (correct rotation, slightly
+    # pessimistic pool) that needs no change in any downstream consumer
+    # (`spawn-codex.sh`'s terminal-result allowlist,
+    # `loom-daemon/src/tokens_pool/health.rs`'s `TerminalClassification`,
+    # `bad_tokens.rs`/`failure_counts.rs`). Per-model account state is tracked
+    # as an explicit follow-up, not smuggled in here.
+    if echo "$output" | grep -qiE "hit your (limit|session limit|weekly limit)|hit\.your\.limit|monthly usage limit|out of extra usage|reached your ([^[:space:]]+[[:space:]]+){0,3}limit"; then
         echo "TOKEN_EXHAUSTED"
         return
     fi
@@ -374,4 +411,62 @@ is_recoverable_error() {
     local classification
     classification=$(classify_error "$1" "$2")
     [[ "$classification" != "FATAL" && "$classification" != "SUCCESS" ]]
+}
+
+# --- Retry verdict: the single source of truth (issue #4501) --------------
+#
+# classification_is_transient <category> -> exit 0 when a caller's retry loop
+# SHOULD retry the same invocation, 1 when the failure is terminal for that
+# caller. The argument is a category emitted by `classify_error`.
+#
+# Why this lives here. Before #4501, `claude-wrapper.sh::is_transient_error`
+# kept its OWN pattern array, disjoint from this file's tables, so the retry
+# decision and the printed `classification=` were two independent verdict
+# systems that could — and did — contradict each other in the same log block:
+#
+#   [ERROR] Non-transient error detected - not retrying
+#   [ERROR] exit_code=1 classification=RECOVERABLE
+#
+# Deriving the verdict from the category makes that contradiction structurally
+# impossible: there is now exactly one classifier, and the retry decision is a
+# pure function of its output.
+#
+# Policy is a DENY-LIST. Only categories whose fault cannot be cleared by
+# retrying the same invocation are terminal; everything else — including the
+# generic RECOVERABLE catch-all for an *unrecognized* non-zero exit — is
+# retried, bounded by the caller's own retry cap. Retry-by-default is the
+# fail-safe direction for unattended daemon children: an allow-list of known
+# transient phrasings has twice turned a new CLI wording into an instant
+# permanent death (#4255's bare `Execution error`, #4501's "reached your
+# <model> limit"), while an over-retry costs only a bounded backoff. It also
+# matches the documented contract of the catch-all in
+# `_classify_error_generic` ("unknown non-zero exit, treat as recoverable in
+# daemon mode").
+classification_is_transient() {
+    case "$1" in
+        # Terminal — retrying the same invocation cannot succeed:
+        #   SUCCESS       nothing to retry.
+        #   TIMEOUT       the wall-clock budget was already spent, and a 137 is
+        #                 normally an external kill (daemon reaper / OOM) —
+        #                 surface it rather than re-spending the budget.
+        #   TOKEN_EXPIRED this token needs re-auth, not another attempt.
+        #   CWD_DELETED   the working directory is gone.
+        #   MODEL_REFUSAL the same model refuses the same turn again; the sweep
+        #                 orchestrator drops a ladder rung instead (see
+        #                 sweep.md, "Refusal-aware fallback").
+        #   FATAL         a configuration fault (the `codex` table's category).
+        SUCCESS|TIMEOUT|TOKEN_EXPIRED|CWD_DELETED|MODEL_REFUSAL|FATAL)
+            return 1
+            ;;
+        # Retryable: RECOVERABLE (including the unknown-non-zero-exit
+        # catch-all), plus TOKEN_EXHAUSTED and SESSION_LIMIT. The latter two are
+        # normally consumed by a caller's account-rotation / re-selection path
+        # BEFORE this predicate is reached; they land here only when that path
+        # is capped or found no alternate account, where a bounded
+        # backoff-and-retry (rather than a permanent death) is exactly what
+        # claude-wrapper.sh's own comments already promise.
+        *)
+            return 0
+            ;;
+    esac
 }

--- a/defaults/scripts/tests/test-spawn-claude.sh
+++ b/defaults/scripts/tests/test-spawn-claude.sh
@@ -245,6 +245,69 @@ assert_eq "TOKEN_EXHAUSTED" "$result" "weekly 'session limit' stays TOKEN_EXHAUS
 result=$(classify_error "Note: agents pause on a concurrent session limit." 0)
 assert_eq "SUCCESS" "$result" "exit=0 mentioning 'concurrent session' is SUCCESS (#3233/#3947)"
 
+# --- Per-model limit vectors (issue #4501) ---
+# The CLI now emits a PER-MODEL ceiling whose model name sits between "your" and
+# "limit" — "You've reached your Fable 5 limit. Run /usage-credits to continue or
+# switch models with /model." None of the "hit your …" phrasings matched it, so
+# `is_account_exhaustion` returned false, no rotation happened, and the child died
+# permanently at CLI start. Classified as TOKEN_EXHAUSTED (a safe
+# over-approximation — see classify-error.sh) so it reaches the rotation path.
+
+# Vector #36: the exact live message → TOKEN_EXHAUSTED
+result=$(classify_error "You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model." 1)
+assert_eq "TOKEN_EXHAUSTED" "$result" "'reached your Fable 5 limit' -> TOKEN_EXHAUSTED (#4501)"
+
+# Vector #37: no model name in between → still TOKEN_EXHAUSTED
+result=$(classify_error "You've reached your limit" 1)
+assert_eq "TOKEN_EXHAUSTED" "$result" "'reached your limit' -> TOKEN_EXHAUSTED (#4501)"
+
+# Vector #38: the Codex-style wording reaching the claude table → TOKEN_EXHAUSTED
+result=$(classify_error "You have reached your usage limit for this account" 1)
+assert_eq "TOKEN_EXHAUSTED" "$result" "'reached your usage limit' -> TOKEN_EXHAUSTED (#4501)"
+
+# Vector #39 (ORDERING HAZARD, #3947 must survive): the concurrency wording keeps
+# its distinct capacity classification even though it also matches the widened
+# "reached your … limit" shape — SESSION_LIMIT is checked FIRST.
+result=$(classify_error "Error: you have reached your concurrent session limit" 1)
+assert_eq "SESSION_LIMIT" "$result" "'reached your concurrent session limit' still SESSION_LIMIT (#4501 preserves #3947)"
+
+# Vector #40 (REGRESSION, #3233): a clean exit whose output merely mentions a
+# model limit is still SUCCESS — exit-code-first ordering is untouched.
+result=$(classify_error "Tip: you'll see 'reached your Fable 5 limit' when the tier is capped." 0)
+assert_eq "SUCCESS" "$result" "exit=0 mentioning 'reached your Fable 5 limit' is SUCCESS (#3233/#4501)"
+
+# Vector #41 (BOUNDED FILLER): the model-name gap is capped at three words, so an
+# unrelated sentence that merely ends in "limit" is not swallowed into exhaustion.
+result=$(classify_error "reached your goal well before the team agreed on any spending limit" 1)
+assert_eq "RECOVERABLE" "$result" "a long unrelated 'reached your … limit' sentence is not exhaustion (#4501)"
+
+# --- Retry-verdict vectors (issue #4501) ---
+# `classification_is_transient` is now THE single source of truth for every retry
+# decision, so the printed classification and the retry choice cannot disagree.
+
+for _c in RECOVERABLE TOKEN_EXHAUSTED SESSION_LIMIT; do
+    if classification_is_transient "$_c"; then
+        assert_eq "retry" "retry" "classification_is_transient $_c -> retry (#4501)"
+    else
+        assert_eq "retry" "terminal" "classification_is_transient $_c -> retry (#4501)"
+    fi
+done
+for _c in SUCCESS TIMEOUT TOKEN_EXPIRED CWD_DELETED MODEL_REFUSAL FATAL; do
+    if classification_is_transient "$_c"; then
+        assert_eq "terminal" "retry" "classification_is_transient $_c -> terminal (#4501)"
+    else
+        assert_eq "terminal" "terminal" "classification_is_transient $_c -> terminal (#4501)"
+    fi
+done
+
+# The contradiction this issue exists to kill: a RECOVERABLE verdict can never
+# coexist with a "not retrying" decision, whatever the output text.
+if classification_is_transient "RECOVERABLE"; then
+    assert_eq "retry" "retry" "RECOVERABLE is always retryable — the #4501 contradiction cannot recur"
+else
+    assert_eq "retry" "terminal" "RECOVERABLE is always retryable — the #4501 contradiction cannot recur"
+fi
+
 # --- Provider-selector vectors (issue #4190) ---
 # classify_error() now accepts an optional 3rd provider arg with precedence
 # 3rd arg > $LOOM_RUNTIME > "claude". These vectors prove the split into
@@ -1115,23 +1178,53 @@ EE_DIR="$(mktemp -d)"
 trap 'rm -rf "$TEST_WS" "$STUB_DIR" "$EE_DIR"' EXIT
 
 # --- Unit: is_transient_error() now recognizes the bare `Execution error` ---
+#
+# #4501 note: the verdict is now DERIVED from `classify_error`'s category via the
+# shared `classification_is_transient` deny-list, so an *unrecognized* non-zero
+# exit (the RECOVERABLE catch-all) is retried instead of dying on attempt 1 —
+# bounded by MAX_RETRIES. Genuinely terminal categories are still not retried, so
+# this driver now pins those (MODEL_REFUSAL, CWD_DELETED, TOKEN_EXPIRED) as the
+# non-transient side of the contract instead of an unrecognized string.
 cat > "$EE_DIR/transient-driver.sh" <<'DRIVER'
 #!/usr/bin/env bash
 CLAUDE_WRAPPER_SOURCE_ONLY=1 source "$WRAPPER"
 set +e
 if is_transient_error "Execution error" 1; then echo "TRANSIENT=yes"; else echo "TRANSIENT=no"; fi
-# A genuinely deterministic non-transient failure must still be non-transient.
+# An unrecognized non-zero exit classifies RECOVERABLE and is therefore retried
+# (#4501) — the retry decision may never contradict the printed classification.
 if is_transient_error "error: unknown option '--frobnicate'" 1; then
     echo "UNKNOWN=transient"
 else
     echo "UNKNOWN=fatal"
 fi
+echo "UNKNOWN_CLASS=${_LAST_ERROR_CLASSIFICATION}"
+# Terminal categories are still NOT retried.
+for _out in 'stop_reason: "refusal"' "current working directory was deleted" "OAuth token has expired"; do
+    if is_transient_error "$_out" 1; then
+        echo "TERMINAL_${_LAST_ERROR_CLASSIFICATION}=transient"
+    else
+        echo "TERMINAL_${_LAST_ERROR_CLASSIFICATION}=fatal"
+    fi
+done
+# A model-limit death is exhaustion (rotation), never a permanent death.
+is_transient_error "You've reached your Fable 5 limit. Run /usage-credits to continue." 1
+echo "MODEL_LIMIT_CLASS=${_LAST_ERROR_CLASSIFICATION}"
 DRIVER
 ee_transient=$(WRAPPER="$WRAPPER" bash "$EE_DIR/transient-driver.sh" 2>&1)
 assert_contains "TRANSIENT=yes" "$ee_transient" \
     "is_transient_error treats bare 'Execution error' as transient (#4255)"
-assert_contains "UNKNOWN=fatal" "$ee_transient" \
-    "is_transient_error still treats an unrelated deterministic error as non-transient (#4255)"
+assert_contains "UNKNOWN=transient" "$ee_transient" \
+    "is_transient_error retries an unrecognized non-zero exit (classification=RECOVERABLE) (#4501)"
+assert_contains "UNKNOWN_CLASS=RECOVERABLE" "$ee_transient" \
+    "is_transient_error derives its verdict from classify_error's category (#4501)"
+assert_contains "TERMINAL_MODEL_REFUSAL=fatal" "$ee_transient" \
+    "is_transient_error still refuses to retry MODEL_REFUSAL (#4501)"
+assert_contains "TERMINAL_CWD_DELETED=fatal" "$ee_transient" \
+    "is_transient_error still refuses to retry CWD_DELETED (#4501)"
+assert_contains "TERMINAL_TOKEN_EXPIRED=fatal" "$ee_transient" \
+    "is_transient_error still refuses to retry TOKEN_EXPIRED (#4501)"
+assert_contains "MODEL_LIMIT_CLASS=TOKEN_EXHAUSTED" "$ee_transient" \
+    "a model-limit death classifies TOKEN_EXHAUSTED, not the RECOVERABLE catch-all (#4501)"
 
 # --- Unit: log_permanent_death() emits exit code + classification + tail ---
 cat > "$EE_DIR/death-driver.sh" <<'DRIVER'
@@ -1191,8 +1284,10 @@ STUB
   ee_rc=$?
   set -e
 
-  assert_contains "Detected transient error pattern: Execution error" "$ee_out" \
-      "wrapper retries on the bare 'Execution error' output (#4255)"
+  # #4501: the retry log line now names the derived classification instead of a
+  # matched pattern from the (deleted) local pattern array.
+  assert_contains "Transient error (classification=RECOVERABLE) - retrying" "$ee_out" \
+      "wrapper retries on the bare 'Execution error' output (#4255/#4501)"
   assert_contains "Max retries (2) exceeded" "$ee_out" \
       "wrapper stops after LOOM_MAX_RETRIES attempts (#4255)"
   assert_contains "permanent death" "$ee_out" \
@@ -1210,6 +1305,173 @@ STUB
 fi
 
 rm -rf "$EE_DIR"
+
+# ============================================================
+# Section 9: per-model limit deaths rotate instead of dying (issue #4501)
+#
+# The CLI's per-model ceiling ("You've reached your Fable 5 limit. Run
+# /usage-credits to continue or switch models with /model.") matched none of the
+# pre-#4501 exhaustion phrasings, so every daemon-dispatched child died in ~2s
+# with the self-contradicting block:
+#
+#   [ERROR] Non-transient error detected - not retrying
+#   [ERROR] exit_code=1 classification=RECOVERABLE
+#
+# It must now rotate accounts WITHOUT consuming a MAX_RETRIES attempt, stay
+# bounded (whole-pool exhaustion still terminates with ACCOUNT_POOL_EXHAUSTED),
+# and never emit the "non-transient" + RECOVERABLE contradiction.
+# ============================================================
+
+echo ""
+echo "Testing claude-wrapper.sh model-limit rotation (#4501)..."
+
+if [[ -z "$DAEMON_BIN" ]]; then
+    echo "  (skipping model-limit rotation tests — loom-daemon binary not found)"
+else
+  # --- Rotation: alpha hits the Fable ceiling, beta succeeds ---
+  ML_WS="$(mktemp -d)"
+  mkdir -p "$ML_WS/.loom/tokens"
+  chmod 700 "$ML_WS/.loom/tokens"
+  printf '%s' "tok-alpha" > "$ML_WS/.loom/tokens/alpha.token"
+  printf '%s' "tok-beta"  > "$ML_WS/.loom/tokens/beta.token"
+  chmod 600 "$ML_WS/.loom/tokens/"*.token
+
+  ML_STUB="$(mktemp -d)"
+  cat > "$ML_STUB/claude" <<'STUB'
+#!/usr/bin/env bash
+case " $* " in
+  *" -p "*) ;;
+  *) exit 0 ;;
+esac
+if [[ "${CLAUDE_CODE_OAUTH_TOKEN}" == "tok-alpha" ]]; then
+    echo "You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model."
+    exit 1
+fi
+echo "stub-claude success on token=${CLAUDE_CODE_OAUTH_TOKEN}"
+exit 0
+STUB
+  chmod +x "$ML_STUB/claude"
+
+  # MAX_RETRIES=1: if rotation consumed an attempt, beta would never be tried.
+  set +e
+  ml_out=$(
+    LOOM_WORKSPACE="$ML_WS" \
+    LOOM_TOKEN_NAME="alpha" \
+    CLAUDE_CODE_OAUTH_TOKEN="tok-alpha" \
+    LOOM_DAEMON_BIN="$DAEMON_BIN" \
+    LOOM_MAX_RETRIES=1 \
+    LOOM_SHEPHERD_TASK_ID="test-model-limit" \
+    LOOM_STARTUP_MONITOR_WINDOW=1 \
+    PATH="$ML_STUB:$PATH" \
+    bash "$WRAPPER" -p "ping" 2>&1
+  )
+  ml_rc=$?
+  set -e
+
+  assert_contains "stub-claude success on token=tok-beta" "$ml_out" \
+      "wrapper rotates off a per-model limit death and succeeds on the next account (#4501)"
+  assert_eq "0" "$ml_rc" \
+      "wrapper exits 0 after model-limit rotation (MAX_RETRIES=1 not consumed) (#4501)"
+  assert_contains "reached your Fable 5 limit" "$ml_out" \
+      "rotation log names the per-model phrase that fired (#4501)"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  if [[ "$ml_out" != *"permanent death"* && "$ml_out" != *"Non-transient error detected"* ]]; then
+      TESTS_PASSED=$((TESTS_PASSED + 1))
+      echo -e "  ${GREEN}PASS${NC}: a per-model limit death never logs permanent death / 'non-transient' (#4501)"
+  else
+      TESTS_FAILED=$((TESTS_FAILED + 1))
+      echo -e "  ${RED}FAIL${NC}: a per-model limit death never logs permanent death / 'non-transient' (#4501)"
+      echo "    In: '$ml_out'"
+  fi
+
+  # --- Bounded: a single-account pool still terminates (no infinite rotation) ---
+  ML_WS2="$(mktemp -d)"
+  mkdir -p "$ML_WS2/.loom/tokens"
+  chmod 700 "$ML_WS2/.loom/tokens"
+  printf '%s' "tok-solo" > "$ML_WS2/.loom/tokens/solo.token"
+  chmod 600 "$ML_WS2/.loom/tokens/solo.token"
+
+  ML_STUB2="$(mktemp -d)"
+  cat > "$ML_STUB2/claude" <<'STUB'
+#!/usr/bin/env bash
+case " $* " in
+  *" -p "*) ;;
+  *) exit 0 ;;
+esac
+echo "You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model."
+exit 1
+STUB
+  chmod +x "$ML_STUB2/claude"
+
+  set +e
+  ml2_out=$(
+    LOOM_WORKSPACE="$ML_WS2" \
+    LOOM_TOKEN_NAME="solo" \
+    CLAUDE_CODE_OAUTH_TOKEN="tok-solo" \
+    LOOM_DAEMON_BIN="$DAEMON_BIN" \
+    LOOM_MAX_RETRIES=1 \
+    LOOM_SHEPHERD_TASK_ID="test-model-limit" \
+    LOOM_STARTUP_MONITOR_WINDOW=1 \
+    PATH="$ML_STUB2:$PATH" \
+    bash "$WRAPPER" -p "ping" 2>&1
+  )
+  ml2_rc=$?
+  set -e
+
+  assert_contains "ACCOUNT_POOL_EXHAUSTED" "$ml2_out" \
+      "model-limit rotation stays bounded: whole-pool exhaustion still terminates (#4501)"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  if [[ "$ml2_rc" -ne 0 ]]; then
+      TESTS_PASSED=$((TESTS_PASSED + 1))
+      echo -e "  ${GREEN}PASS${NC}: model-limit whole-pool exhaustion exits non-zero (#4501)"
+  else
+      TESTS_FAILED=$((TESTS_FAILED + 1))
+      echo -e "  ${RED}FAIL${NC}: model-limit whole-pool exhaustion exits non-zero (#4501)"
+  fi
+
+  # --- The contradiction itself: "Non-transient" and classification=RECOVERABLE
+  #     can never appear together in a wrapper run. ---
+  TESTS_RUN=$((TESTS_RUN + 1))
+  if [[ ( "$ml_out" != *"Non-transient error detected"* || "$ml_out" != *"classification=RECOVERABLE"* ) \
+     && ( "$ml2_out" != *"Non-transient error detected"* || "$ml2_out" != *"classification=RECOVERABLE"* ) ]]; then
+      TESTS_PASSED=$((TESTS_PASSED + 1))
+      echo -e "  ${GREEN}PASS${NC}: no run pairs 'Non-transient error detected' with classification=RECOVERABLE (#4501)"
+  else
+      TESTS_FAILED=$((TESTS_FAILED + 1))
+      echo -e "  ${RED}FAIL${NC}: no run pairs 'Non-transient error detected' with classification=RECOVERABLE (#4501)"
+  fi
+
+  rm -rf "$ML_WS" "$ML_STUB" "$ML_WS2" "$ML_STUB2"
+fi
+
+# --- Unit: the "non-transient" log line always names the classification it
+#     acted on, so the two log lines can never disagree (#4501). ---
+NT_DIR="$(mktemp -d)"
+cat > "$NT_DIR/non-transient-driver.sh" <<'DRIVER'
+#!/usr/bin/env bash
+CLAUDE_WRAPPER_SOURCE_ONLY=1 source "$WRAPPER"
+set +e
+# MODEL_REFUSAL is terminal: the wrapper's message and log_permanent_death's
+# classification must name the SAME category.
+is_transient_error 'stop_reason: "refusal"' 1
+echo "MSG=Non-transient error detected (classification=${_LAST_ERROR_CLASSIFICATION}) - not retrying"
+log_permanent_death 1 'stop_reason: "refusal"' "non-transient error" 2>&1
+# The wrapper's own RATE_LIMIT_ABORT sentinel stays non-transient, and the death
+# block reports the SAME verdict the retry decision used (a fresh classify_error
+# would report the generic RECOVERABLE for this text).
+if is_transient_error "# RATE_LIMIT_ABORT" 1; then echo "ABORT=transient"; else echo "ABORT=fatal"; fi
+log_permanent_death 1 "# RATE_LIMIT_ABORT" "non-transient error" 2>&1
+DRIVER
+nt_out=$(WRAPPER="$WRAPPER" bash "$NT_DIR/non-transient-driver.sh" 2>&1)
+assert_contains "MSG=Non-transient error detected (classification=MODEL_REFUSAL) - not retrying" "$nt_out" \
+    "the 'non-transient' log line names the derived classification (#4501)"
+assert_contains "classification=MODEL_REFUSAL" "$nt_out" \
+    "log_permanent_death agrees with the retry decision's classification (#4501)"
+assert_contains "ABORT=fatal" "$nt_out" \
+    "the RATE_LIMIT_ABORT sentinel path is unchanged: still non-transient (#4501)"
+assert_contains "classification=RATE_LIMIT_ABORT" "$nt_out" \
+    "log_permanent_death reuses the derived verdict, not a second classification (#4501)"
+rm -rf "$NT_DIR"
 
 # ============================================================
 # Summary

--- a/loom-daemon/src/role_runner.rs
+++ b/loom-daemon/src/role_runner.rs
@@ -243,6 +243,10 @@ pub struct ScriptRoleInvocationRunner {
     /// sweeps use.
     spawn_bin: Option<PathBuf>,
     timeout: Duration,
+    /// Explicit model override (tests only). Production leaves this `None` and
+    /// resolves per invocation via [`resolve_role_runner_model`] — the same
+    /// precedence chain sweep dispatch uses (issue #4501).
+    model: Option<String>,
 }
 
 impl ScriptRoleInvocationRunner {
@@ -253,6 +257,7 @@ impl ScriptRoleInvocationRunner {
             workspace_root,
             spawn_bin: None,
             timeout: DEFAULT_ROLE_TIMEOUT,
+            model: None,
         }
     }
 
@@ -260,6 +265,14 @@ impl ScriptRoleInvocationRunner {
     #[must_use]
     pub fn with_spawn_bin(mut self, bin: PathBuf) -> Self {
         self.spawn_bin = Some(bin);
+        self
+    }
+
+    /// Override the resolved model (tests only) — bypasses
+    /// [`resolve_role_runner_model`].
+    #[must_use]
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
         self
     }
 
@@ -291,6 +304,14 @@ impl RoleInvocationRunner for ScriptRoleInvocationRunner {
             Ok(p) => p,
             Err(e) => return RoleTickOutcome::Failure(e),
         };
+        // Issue #4501: pin the child's model instead of inheriting the account's
+        // interactive CLI default (`fable` on the host that filed the issue,
+        // where every role child burned the most constrained quota tier and then
+        // died on "You've reached your Fable 5 limit").
+        let (model, model_source) = match &self.model {
+            Some(m) => (m.clone(), "override"),
+            None => resolve_role_runner_model(&self.workspace_root),
+        };
         run_role_with_timeout(
             &script,
             &self.workspace_root,
@@ -298,13 +319,46 @@ impl RoleInvocationRunner for ScriptRoleInvocationRunner {
             prompt,
             self.logs_dir(),
             self.timeout,
+            &model,
+            model_source,
         )
     }
 }
 
-/// Run `spawn-claude.sh -p "<prompt>" --dangerously-skip-permissions` in
-/// `workspace_root`, appending combined output to
-/// `<logs_dir>/role-<role>.log` (never a pipe — avoids the pipe-buffer
+/// Issue #4501: resolve the model a role-runner child must run with, joining the
+/// SAME precedence chain sweep dispatch uses
+/// ([`sweep_registry::resolve_dispatch_model`]) with the role-runner-specific
+/// `autonomous.roleRunner.model` occupying the "explicit request" tier:
+///
+/// **`autonomous.roleRunner.model` > `autonomous.model` > shipped
+/// [`sweep_registry::DEFAULT_DISPATCH_MODEL`] (`sonnet`)**
+///
+/// Empty/whitespace values are treated as unset at every tier, so the resolved
+/// model is never the empty string and never the CLI-inherited interactive
+/// default. Returns the model plus a label naming the tier that supplied it (for
+/// the per-role log header).
+///
+/// Before this, `run_role_with_timeout` emitted **no** `--model` argument at
+/// all, so every scheduled curator/champion/judge/auditor/guide child inherited
+/// whatever the selected account's interactive `claude` default happened to be —
+/// the live defect this resolution exists to prevent.
+#[must_use]
+pub fn resolve_role_runner_model(repo_root: &Path) -> (String, &'static str) {
+    let configured = read_role_runner_config(repo_root).model;
+    let (model, source) = sweep_registry::resolve_dispatch_model(repo_root, configured.as_deref());
+    let label = match source {
+        // `Param` can only arise from `autonomous.roleRunner.model` here — this
+        // function is the only caller and it passes exactly that value.
+        sweep_registry::ModelSource::Param => "autonomous.roleRunner.model",
+        sweep_registry::ModelSource::Config => "autonomous.model",
+        sweep_registry::ModelSource::Default => "default",
+    };
+    (model, label)
+}
+
+/// Run `spawn-claude.sh -p "<prompt>" --model <model>
+/// --dangerously-skip-permissions` in `workspace_root`, appending combined
+/// output to `<logs_dir>/role-<role>.log` (never a pipe — avoids the pipe-buffer
 /// deadlock pattern documented in [`crate::main_health_gate`] /
 /// [`crate::token_ranking_refresh`]) and killing it after `timeout`.
 #[allow(clippy::too_many_arguments)]
@@ -315,6 +369,8 @@ fn run_role_with_timeout(
     prompt: &str,
     logs_dir: PathBuf,
     timeout: Duration,
+    model: &str,
+    model_source: &str,
 ) -> RoleTickOutcome {
     if let Err(e) = std::fs::create_dir_all(&logs_dir) {
         return RoleTickOutcome::Failure(format!(
@@ -331,9 +387,14 @@ fn run_role_with_timeout(
             .append(true)
             .open(&log_path)
         {
+            // The resolved model + the tier that supplied it are recorded in the
+            // per-role log header (#4501) so an operator can confirm from
+            // `role-<role>.log` alone which model a scheduled child ran with —
+            // the manual verification this fix needs on a live host.
             let _ = writeln!(
                 f,
-                "\n==== loom-daemon role_runner: {} role={role} ====",
+                "\n==== loom-daemon role_runner: {} role={role} model={model} \
+                 (source={model_source}) ====",
                 chrono::Utc::now().to_rfc3339()
             );
         }
@@ -358,9 +419,18 @@ fn run_role_with_timeout(
     };
 
     let mut cmd = Command::new(script);
-    cmd.arg("-p")
-        .arg(prompt)
-        .arg("--dangerously-skip-permissions");
+    cmd.arg("-p").arg(prompt);
+    // Model pin (issue #4501): appended immediately after the prompt, exactly as
+    // `sweep_registry::spawn_child` does, so a role child never inherits the
+    // account's interactive CLI default (`fable` on the affected host — the most
+    // constrained quota tier, and the escalation ceiling rather than the floor).
+    // An empty value is treated as unset — `--model ""` must never be emitted —
+    // mirroring the same guard on the sweep-dispatch path; `resolve_role_runner_model`
+    // already filters blanks at every tier, so this is belt-and-braces.
+    if !model.is_empty() {
+        cmd.arg("--model").arg(model);
+    }
+    cmd.arg("--dangerously-skip-permissions");
     // Transient-error recovery (issue #4255): scheduled role spawns are the
     // same unattended class as daemon-dispatched sweeps, so route them through
     // `claude-wrapper.sh` (retry/backoff/classification, bounded by
@@ -521,6 +591,13 @@ pub struct RoleRunnerConfig {
     /// because idle firing is a distinct opt-in surface. Resolved by
     /// [`resolve_on_idle_roles`].
     pub on_idle: Option<Vec<String>>,
+    /// `autonomous.roleRunner.model` — the model every role child is pinned to
+    /// (issue #4501). `None` (key absent, blank, or non-string) falls through to
+    /// `autonomous.model` and then the shipped
+    /// [`sweep_registry::DEFAULT_DISPATCH_MODEL`]; it never falls through to the
+    /// account's interactive CLI default. Resolved by
+    /// [`resolve_role_runner_model`].
+    pub model: Option<String>,
 }
 
 /// Read `.loom/config.json -> autonomous.roleRunner`, soft-failing every
@@ -556,6 +633,16 @@ pub fn read_role_runner_config(repo_root: &Path) -> RoleRunnerConfig {
                 .collect::<Vec<_>>()
         });
 
+    // `model` (#4501): a blank / whitespace-only / non-string value soft-fails to
+    // `None` so it falls through to `autonomous.model` -> the shipped default
+    // rather than emitting `--model ""` or an inherited interactive default.
+    let model = block
+        .get("model")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|m| !m.is_empty())
+        .map(String::from);
+
     RoleRunnerConfig {
         enabled: block.get("enabled").and_then(serde_json::Value::as_bool),
         roles,
@@ -564,6 +651,7 @@ pub fn read_role_runner_config(repo_root: &Path) -> RoleRunnerConfig {
             .and_then(serde_json::Value::as_u64)
             .filter(|&s| s > 0),
         on_idle,
+        model,
     }
 }
 
@@ -1520,15 +1608,137 @@ mod tests {
     #[test]
     fn test_invoke_receives_prompt_and_skip_permissions_flag() {
         let tmp = tempfile::tempdir().unwrap();
-        // Fail unless invoked with -p "/curator" --dangerously-skip-permissions.
+        // Fail unless invoked with
+        //   -p "/curator" --model <m> --dangerously-skip-permissions
+        // (the `--model` pin was inserted after the prompt by #4501, mirroring
+        // `sweep_registry::spawn_child`'s argv order).
         let script = write_fake_script(
             tmp.path(),
             "fake-spawn.sh",
-            "[ \"$1\" = \"-p\" ] && [ \"$2\" = \"/curator\" ] && [ \"$3\" = \"--dangerously-skip-permissions\" ] && exit 0 || exit 1",
+            "[ \"$1\" = \"-p\" ] && [ \"$2\" = \"/curator\" ] && [ \"$3\" = \"--model\" ] && [ -n \"$4\" ] && [ \"$5\" = \"--dangerously-skip-permissions\" ] && exit 0 || exit 1",
         );
         let mut runner =
             ScriptRoleInvocationRunner::new(tmp.path().to_path_buf()).with_spawn_bin(script);
         assert_eq!(runner.invoke("curator", "/curator"), RoleTickOutcome::Success);
+    }
+
+    /// Issue #4501: a role spawn pins the model explicitly — a role child must
+    /// never inherit the account's interactive CLI default (`fable` on the host
+    /// that filed the issue, where every child instantly died on "You've reached
+    /// your Fable 5 limit"). With no config the pin is the shipped
+    /// `DEFAULT_DISPATCH_MODEL` (`sonnet`).
+    #[test]
+    fn test_invoke_appends_resolved_model_defaulting_to_sonnet() {
+        let tmp = tempfile::tempdir().unwrap();
+        let script = write_fake_script(
+            tmp.path(),
+            "fake-spawn.sh",
+            "printf '%s\\n' \"$@\" > argv.txt; exit 0",
+        );
+        let mut runner =
+            ScriptRoleInvocationRunner::new(tmp.path().to_path_buf()).with_spawn_bin(script);
+        assert_eq!(runner.invoke("curator", "/loom:curator"), RoleTickOutcome::Success);
+        let argv = fs::read_to_string(tmp.path().join("argv.txt")).unwrap();
+        let args: Vec<&str> = argv.lines().collect();
+        let idx = args
+            .iter()
+            .position(|a| *a == "--model")
+            .expect("role spawn argv must contain --model");
+        assert_eq!(
+            args[idx + 1],
+            sweep_registry::DEFAULT_DISPATCH_MODEL,
+            "default role-runner model must be the shipped dispatch default; argv: {args:?}"
+        );
+        assert_ne!(args[idx + 1], "fable", "role children must never run fable by default");
+    }
+
+    /// Issue #4501: `autonomous.roleRunner.model` wins over the shipped default
+    /// (and over `autonomous.model`) — the explicit-request tier of the shared
+    /// `resolve_dispatch_model` chain.
+    #[test]
+    fn test_invoke_config_model_override_wins() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(
+            tmp.path(),
+            r#"{"autonomous": {"model": "opus", "roleRunner": {"enabled": true, "model": "claude-sonnet-4-6"}}}"#,
+        );
+        let script = write_fake_script(
+            tmp.path(),
+            "fake-spawn.sh",
+            "printf '%s\\n' \"$@\" > argv.txt; exit 0",
+        );
+        let mut runner =
+            ScriptRoleInvocationRunner::new(tmp.path().to_path_buf()).with_spawn_bin(script);
+        assert_eq!(runner.invoke("curator", "/loom:curator"), RoleTickOutcome::Success);
+        let argv = fs::read_to_string(tmp.path().join("argv.txt")).unwrap();
+        assert!(
+            argv.contains("--model\nclaude-sonnet-4-6\n"),
+            "autonomous.roleRunner.model must win; argv: {argv}"
+        );
+    }
+
+    /// Issue #4501: with only `autonomous.model` set, the role runner joins the
+    /// SAME chain sweep dispatch uses rather than keeping a private default.
+    #[test]
+    fn test_resolve_role_runner_model_precedence_chain() {
+        // No config at all -> shipped default, labelled `default`.
+        let bare = tempfile::tempdir().unwrap();
+        assert_eq!(
+            resolve_role_runner_model(bare.path()),
+            (sweep_registry::DEFAULT_DISPATCH_MODEL.to_string(), "default")
+        );
+
+        // `autonomous.model` only -> that value, labelled `autonomous.model`.
+        // Routing through `resolve_dispatch_model` also means the role runner
+        // inherits the #3982 logical-tier alias resolution for free
+        // (`opus` -> `claude-opus-5`), exactly as sweep dispatch does.
+        let shared = tempfile::tempdir().unwrap();
+        write_config(shared.path(), r#"{"autonomous": {"model": "opus"}}"#);
+        assert_eq!(
+            resolve_role_runner_model(shared.path()),
+            ("claude-opus-5".to_string(), "autonomous.model")
+        );
+
+        // Both -> the role-runner-specific value, labelled as such.
+        let both = tempfile::tempdir().unwrap();
+        write_config(
+            both.path(),
+            r#"{"autonomous": {"model": "opus", "roleRunner": {"model": "haiku"}}}"#,
+        );
+        assert_eq!(
+            resolve_role_runner_model(both.path()),
+            ("haiku".to_string(), "autonomous.roleRunner.model")
+        );
+
+        // A blank override is treated as unset at every tier (never `--model ""`).
+        let blank = tempfile::tempdir().unwrap();
+        write_config(blank.path(), r#"{"autonomous": {"roleRunner": {"model": "   "}}}"#);
+        assert_eq!(read_role_runner_config(blank.path()).model, None);
+        assert_eq!(
+            resolve_role_runner_model(blank.path()),
+            (sweep_registry::DEFAULT_DISPATCH_MODEL.to_string(), "default")
+        );
+    }
+
+    /// Issue #4501: the per-role log header records the pinned model and the tier
+    /// that supplied it, so an operator can verify the pin from
+    /// `role-<role>.log` alone on a live host.
+    #[test]
+    fn test_invoke_log_header_records_pinned_model() {
+        let tmp = tempfile::tempdir().unwrap();
+        let script = write_fake_script(tmp.path(), "fake-spawn.sh", "exit 0");
+        let mut runner =
+            ScriptRoleInvocationRunner::new(tmp.path().to_path_buf()).with_spawn_bin(script);
+        assert_eq!(runner.invoke("guide", "/loom:guide"), RoleTickOutcome::Success);
+        let log = fs::read_to_string(tmp.path().join(".loom").join("logs").join("role-guide.log"))
+            .unwrap();
+        assert!(
+            log.contains(&format!(
+                "model={} (source=default)",
+                sweep_registry::DEFAULT_DISPATCH_MODEL
+            )),
+            "{log}"
+        );
     }
 
     /// Issue #4255: a scheduled role spawn routes through `claude-wrapper.sh` by
@@ -1541,11 +1751,14 @@ mod tests {
     fn test_invoke_appends_use_wrapper_flag() {
         std::env::remove_var("LOOM_USE_WRAPPER");
         let tmp = tempfile::tempdir().unwrap();
-        // Succeeds only when the 4th arg is exactly --use-wrapper.
+        // Succeeds only when --use-wrapper directly follows
+        // --dangerously-skip-permissions (argv is now
+        // `-p <prompt> --model <m> --dangerously-skip-permissions --use-wrapper`
+        // since the #4501 model pin).
         let script = write_fake_script(
             tmp.path(),
             "fake-spawn.sh",
-            "[ \"$3\" = \"--dangerously-skip-permissions\" ] && [ \"$4\" = \"--use-wrapper\" ] && exit 0 || exit 1",
+            "[ \"$5\" = \"--dangerously-skip-permissions\" ] && [ \"$6\" = \"--use-wrapper\" ] && exit 0 || exit 1",
         );
         let mut runner =
             ScriptRoleInvocationRunner::new(tmp.path().to_path_buf()).with_spawn_bin(script);
@@ -1560,11 +1773,12 @@ mod tests {
     fn test_invoke_opt_out_omits_use_wrapper_flag() {
         std::env::set_var("LOOM_USE_WRAPPER", "0");
         let tmp = tempfile::tempdir().unwrap();
-        // Succeeds only when there is NO 4th arg (argv ends at skip-permissions).
+        // Succeeds only when nothing follows --dangerously-skip-permissions
+        // (argv ends there; the #4501 model pin shifted it to $5).
         let script = write_fake_script(
             tmp.path(),
             "fake-spawn.sh",
-            "[ \"$3\" = \"--dangerously-skip-permissions\" ] && [ -z \"$4\" ] && exit 0 || exit 1",
+            "[ \"$5\" = \"--dangerously-skip-permissions\" ] && [ -z \"$6\" ] && exit 0 || exit 1",
         );
         let mut runner =
             ScriptRoleInvocationRunner::new(tmp.path().to_path_buf()).with_spawn_bin(script);
@@ -1651,6 +1865,7 @@ mod tests {
                 roles: Some(vec!["curator".to_string(), "guide".to_string()]),
                 interval_secs: Some(120),
                 on_idle: None,
+                model: None,
             }
         );
     }
@@ -1690,6 +1905,7 @@ mod tests {
                 roles: Some(vec!["curator".to_string()]),
                 interval_secs: Some(60),
                 on_idle: None,
+                model: None,
             }
         );
     }
@@ -1728,6 +1944,7 @@ mod tests {
             roles: Some(vec![]),
             interval_secs: None,
             on_idle: None,
+            model: None,
         };
         assert_eq!(resolve_roles(&config), Vec::new());
     }
@@ -1739,6 +1956,7 @@ mod tests {
             roles: Some(vec!["guide".to_string(), "champion".to_string()]),
             interval_secs: None,
             on_idle: None,
+            model: None,
         };
         let roles = resolve_roles(&config);
         assert_eq!(roles.iter().map(|r| r.name).collect::<Vec<_>>(), vec!["champion", "guide"]);
@@ -1751,6 +1969,7 @@ mod tests {
             roles: Some(vec!["curator".to_string(), "not-a-role".to_string()]),
             interval_secs: None,
             on_idle: None,
+            model: None,
         };
         let roles = resolve_roles(&config);
         assert_eq!(roles.iter().map(|r| r.name).collect::<Vec<_>>(), vec!["curator"]);
@@ -1776,6 +1995,7 @@ mod tests {
             roles: None,
             interval_secs: None,
             on_idle: None,
+            model: None,
         }));
     }
 
@@ -1788,6 +2008,7 @@ mod tests {
             roles: None,
             interval_secs: None,
             on_idle: None,
+            model: None,
         }));
         std::env::set_var(ROLE_RUNNER_ENABLE_ENV, "1");
         assert!(resolve_enabled(&RoleRunnerConfig {
@@ -1795,6 +2016,7 @@ mod tests {
             roles: None,
             interval_secs: None,
             on_idle: None,
+            model: None,
         }));
         std::env::remove_var(ROLE_RUNNER_ENABLE_ENV);
     }
@@ -1820,6 +2042,7 @@ mod tests {
                     roles: None,
                     interval_secs: Some(42),
                     on_idle: None,
+                    model: None,
                 }
             ),
             Duration::from_secs(42)
@@ -1835,6 +2058,7 @@ mod tests {
                     roles: None,
                     interval_secs: Some(42),
                     on_idle: None,
+                    model: None,
                 }
             ),
             Duration::from_secs(7)
@@ -2084,6 +2308,7 @@ mod tests {
             roles: None,
             interval_secs: None,
             on_idle: Some(vec!["guide".to_string(), "champion".to_string()]),
+            model: None,
         };
         let roles = resolve_on_idle_roles(&config);
         assert_eq!(roles.iter().map(|r| r.name).collect::<Vec<_>>(), vec!["champion", "guide"]);
@@ -2100,6 +2325,7 @@ mod tests {
                 "builder".to_string(),
                 "nope".to_string(),
             ]),
+            model: None,
         };
         let roles = resolve_on_idle_roles(&config);
         assert_eq!(roles.iter().map(|r| r.name).collect::<Vec<_>>(), vec!["champion"]);
@@ -2112,6 +2338,7 @@ mod tests {
             roles: None,
             interval_secs: None,
             on_idle: Some(vec![]),
+            model: None,
         };
         assert_eq!(resolve_on_idle_roles(&config), Vec::new());
     }
@@ -2227,6 +2454,7 @@ mod tests {
             roles: None,
             interval_secs: None,
             on_idle: Some(roles.into_iter().map(str::to_string).collect()),
+            model: None,
         }
     }
 
@@ -2297,6 +2525,7 @@ mod tests {
             roles: None,
             interval_secs: None,
             on_idle: None,
+            model: None,
         };
         let now = Instant::now();
         assert!(plan_idle_runs(&mut t, &set, root, &cfg, false, false, now).is_empty());

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -1240,13 +1240,62 @@ fn exhaustion_signatures() -> &'static [(&'static str, Regex)] {
     })
 }
 
+/// The PER-MODEL usage-ceiling signature (#4501): `You've reached your Fable 5
+/// limit. Run /usage-credits to continue or switch models with /model.` The model
+/// name sits between "your" and "limit", so none of the "hit your … limit"
+/// phrasings in [`exhaustion_signatures`] matched it — a child that insta-crashed
+/// on this banner was charged to the ISSUE's quarantine tally instead of the
+/// ACCOUNT, which is exactly backwards. The filler is bounded to at most three
+/// words so an unrelated sentence merely ending in "limit" cannot match.
+///
+/// Kept out of [`exhaustion_signatures`] because it needs the line-wise
+/// concurrency exclusion below, which a plain `(label, regex)` row cannot express
+/// (the `regex` crate has no lookaround).
+fn model_limit_signature() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)reached your (?:\S+\s+){0,3}limit")
+            .expect("valid static model-limit regex")
+    })
+}
+
+/// The concurrent-session-limit wording (#3947), used ONLY to exclude a line from
+/// [`model_limit_signature`] (#4501). `Error: you have reached your concurrent
+/// session limit` also matches the "reached your … limit" shape, but it is a
+/// CAPACITY fault (the account is healthy, it just cannot start another
+/// simultaneous session) — marking the account bad for it would shrink the healthy
+/// pool. This mirrors `classify-error.sh`'s SESSION_LIMIT-before-TOKEN_EXHAUSTED
+/// ordering on the daemon side.
+fn session_capacity_exclusion() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r"(?i)concurrent (session|sessions|request)|maximum number of concurrent|too many concurrent|simultaneous session|another session is (already )?(active|running)",
+        )
+        .expect("valid static session-capacity regex")
+    })
+}
+
 /// Scan `log_tail` for any account-exhaustion signature (#4122). Returns the
 /// matched signature label on the first hit, else `None`.
+///
+/// The per-model ceiling (#4501) is matched LINE-WISE after the table rows, so a
+/// line whose wording is a concurrent-session capacity fault (#3947) is skipped
+/// rather than mistaken for quota exhaustion.
 fn classify_account_exhaustion(log_tail: &str) -> Option<&'static str> {
-    exhaustion_signatures()
+    if let Some(label) = exhaustion_signatures()
         .iter()
         .find(|(_, re)| re.is_match(log_tail))
         .map(|(label, _)| *label)
+    {
+        return Some(label);
+    }
+    log_tail
+        .lines()
+        .any(|line| {
+            model_limit_signature().is_match(line) && !session_capacity_exclusion().is_match(line)
+        })
+        .then_some("model-limit")
 }
 
 // ============================================================================
@@ -9179,6 +9228,55 @@ exit 0
         );
         assert_eq!(classify_account_exhaustion("thread 'main' panicked at foo.rs:1"), None);
         assert_eq!(classify_account_exhaustion(""), None);
+    }
+
+    /// Issue #4501: the CLI's PER-MODEL ceiling is an account fault too. Before
+    /// this, a child that insta-crashed on "You've reached your Fable 5 limit"
+    /// matched no signature, so the reaper charged the ISSUE's quarantine tally
+    /// instead of marking the account bad — the daemon-side half of the same
+    /// missed phrasing `classify-error.sh` missed.
+    #[test]
+    fn classify_account_exhaustion_matches_per_model_ceiling() {
+        assert_eq!(
+            classify_account_exhaustion(
+                "You've reached your Fable 5 limit. Run /usage-credits to continue or switch \
+                 models with /model."
+            ),
+            Some("model-limit")
+        );
+        assert_eq!(
+            classify_account_exhaustion("Claude: you have reached your limit"),
+            Some("model-limit")
+        );
+        // A concurrent-session capacity fault (#3947) must NOT be treated as
+        // exhaustion — marking the account bad would shrink the healthy pool.
+        assert_eq!(
+            classify_account_exhaustion("Error: you have reached your concurrent session limit"),
+            None
+        );
+        // An unrelated sentence that merely ends in "limit" is not exhaustion.
+        assert_eq!(
+            classify_account_exhaustion(
+                "reached your goal well before the team agreed on any spending limit"
+            ),
+            None
+        );
+        // Mixed tail: the model-limit line still classifies even when a
+        // concurrency line is also present.
+        assert_eq!(
+            classify_account_exhaustion(
+                "Error: you have reached your concurrent session limit\n\
+                 You've reached your Fable 5 limit. Run /usage-credits to continue."
+            ),
+            Some("model-limit")
+        );
+        // The legacy table still wins its label when both shapes appear.
+        assert_eq!(
+            classify_account_exhaustion(
+                "You've hit your weekly limit\nYou've reached your Fable 5 limit."
+            ),
+            Some("rate-limited")
+        );
     }
 
     /// #4386: `classify_preflight_death` matches the explicit


### PR DESCRIPTION
## Summary

Two compounding defects made every daemon-dispatched child on an affected host die permanently in ~2s at CLI start with `You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model.` — the root cause of the live "daemon dispatches but in-flight stays 0" blocker.

1. **Classification/retry contradiction.** The CLI's new **per-model** ceiling puts the model name between "your" and "limit", so it matched none of the `hit your … limit` phrasings: `is_account_exhaustion` returned false (no rotation), and `is_transient_error` — which kept its **own** pattern array, disjoint from `classify_error`'s tables — said "non-transient", while `log_permanent_death`'s independent `classify_error` call printed the generic `classification=RECOVERABLE` in the same block.
2. **Role-runner children inherited the interactive CLI default.** Sweep dispatch already pins a model (`resolve_dispatch_model`, #3954), but `role_runner.rs` spawned `spawn-claude.sh` with **no `--model`**, so every scheduled curator/champion/judge/auditor/guide child ran the account's interactive default — `fable` on the affected host, i.e. the most constrained quota tier and the escalation ceiling rather than the floor.

## Changes

**Defect 1 — classification + one retry verdict**

- `defaults/scripts/lib/classify-error.sh`
  - Widened the Claude `TOKEN_EXHAUSTED` regex to match the `reached your <model> limit` family, ordered **after** the `SESSION_LIMIT` branch so `reached your concurrent session limit` keeps its capacity classification (#3947). The filler between "your" and "limit" is bounded to three words, so an unrelated sentence merely ending in "limit" cannot match.
  - Deliberately **reuses `TOKEN_EXHAUSTED`** instead of adding a model-dimensioned `MODEL_LIMIT`: a Fable-only ceiling does not exhaust `sonnet` on the same account, so this is a *safe over-approximation* (correct rotation, slightly pessimistic pool) that requires no change in any consumer (`spawn-codex.sh`'s terminal-result allowlist, `tokens_pool/health.rs`'s `TerminalClassification`, `bad_tokens.rs`, `failure_counts.rs`) and keeps the Python/Rust `tokens_pool` lockstep untouched. Per-model account state remains an explicit follow-up.
  - New public **`classification_is_transient <category>`** — THE single source of truth for retry decisions. Deny-list policy: `SUCCESS`, `TIMEOUT`, `TOKEN_EXPIRED`, `CWD_DELETED`, `MODEL_REFUSAL`, `FATAL` are terminal; everything else (including the RECOVERABLE catch-all) retries.
- `defaults/scripts/claude-wrapper.sh`
  - `is_transient_error` now **derives** its verdict from `classify_error`'s category via that helper; its local pattern array is deleted. Consequence (intentional): an *unrecognized* non-zero exit is now retried, bounded by `LOOM_MAX_RETRIES`/backoff, instead of dying on attempt 1 — retry-by-default is the fail-safe direction for unattended children, and an allow-list of phrasings has now twice (#4255 `Execution error`, this issue) turned a new CLI wording into an instant permanent death. This subsumes the old `Execution error` special case and the old "empty output with exit 1" heuristic.
  - Both log lines now name the **same** derived category (`Non-transient error detected (classification=…)`, and `log_permanent_death` reuses the derived verdict), so `classification=RECOVERABLE` next to "not retrying" is structurally impossible.
  - `is_account_exhaustion` needed no logic change (it already defers to `classify_error`) — verified; only its no-lib fallback regex and `_exhaustion_phrase` were kept in lockstep.
- `loom-daemon/src/sweep_registry.rs`
  - `classify_account_exhaustion` gains the same per-model signature (label `model-limit`), matched **line-wise** with a concurrent-session exclusion (the `regex` crate has no lookaround). Without this the reaper charged such an insta-crash to the **issue's** quarantine tally instead of marking the **account** bad — the daemon-side half of the same missed phrasing.

**Defect 2 — role-runner model pin (curator's rescope; sweep dispatch untouched)**

- `loom-daemon/src/role_runner.rs`: new `resolve_role_runner_model()` joins the same chain sweeps use — `autonomous.roleRunner.model`, else `autonomous.model`, else the shipped `DEFAULT_DISPATCH_MODEL` (`sonnet`), including #3982 tier aliases (`opus` becomes `claude-opus-5`) — and role spawns append `--model <resolved>` immediately after the prompt, mirroring `sweep_registry::spawn_child`. Blanks are treated as unset at every tier (`--model ""` is never emitted). The resolved model + source tier are recorded in the per-role log header for on-host verification.
- `defaults/docs/daemon-reference.md`: documents `autonomous.roleRunner.model`, the pin, and the classification/retry-verdict change.

## Acceptance Criteria Verification

- [x] `classify-error.sh` handles the "reached your `<model>` limit" pattern — as `TOKEN_EXHAUSTED` (rationale for reusing it over a new `MODEL_LIMIT` above; the Rust classifier's exhaustion table gains the matching signature).
- [x] The wrapper treats it as transient-with-rotation — rotates to the next account **without** consuming a `MAX_RETRIES` attempt, never "permanent death" (integration test asserts both).
- [x] Dispatch pins a default child model so children never default to fable; explicit override still wins — done for the role runner (the live unpinned path); sweep dispatch was already pinned on main and is not touched.
- [x] The `classification=RECOVERABLE` + "non-transient, not retrying" contradiction cannot recur — single `classify_error`-derived verdict, asserted directly.
- [x] Regression tests for both the wrapper retry path on a mocked model-limit death and the dispatch-time model pin.

## Test Plan

- `defaults/scripts/tests/test-spawn-claude.sh`: **161 assertions, 155 pass, 6 pre-existing failures** (all in Section 7 `#4233` nice/taskpolicy — byte-identical failures on `main` on this host: the process is already niced / `LOOM_SWEEP_NICED` is set by the daemon session). 33 new assertions:
  - the exact live message, `reached your limit`, and `reached your usage limit` classify as `TOKEN_EXHAUSTED`
  - `reached your concurrent session limit` still classifies as `SESSION_LIMIT` (ordering hazard)
  - exit-0 output mentioning the phrase is still `SUCCESS` (#3233 guarantee)
  - a long unrelated `reached your … limit` sentence is not exhaustion
  - full category-to-retry-verdict map, incl. "RECOVERABLE is always retryable"
  - mocked model-limit death rotates alpha to beta and exits 0 with `LOOM_MAX_RETRIES=1` (attempt not consumed), logs the phrase, and logs **no** permanent death
  - rotation stays **bounded**: single-account pool still ends in `ACCOUNT_POOL_EXHAUSTED`, non-zero exit
  - `RATE_LIMIT_ABORT` sentinel path unchanged (still non-transient), and `log_permanent_death` reports the verdict actually acted on
  - no run pairs "Non-transient error detected" with `classification=RECOVERABLE`
- `defaults/scripts/tests/test-spawn-codex.sh`: 143/143 pass (its "claude table unchanged" regression guards included).
- `cargo test -p loom-daemon --lib --bins`: **2262 passed, 0 failed**, including new `role_runner` tests (argv contains `--model`, default resolves to `sonnet` and never `fable`, config override wins, precedence chain + blank handling, log header) and `classify_account_exhaustion_matches_per_model_ceiling`.
- `cargo fmt --check`, `cargo clippy -p loom-daemon --all-targets`, and `shellcheck --severity=warning` on all three touched shell files: clean.
- Not from this branch: `loom-daemon/tests/integration_basic.rs` fails intermittently on this host ("Daemon failed to create socket within 5s") on `main` too, and `.loom/scripts/build-gate.sh`'s pytest stage exits 127 here because `uv` is not installed on this host (both branch-independent).

**Note (#4232):** the Rust half only takes effect after a daemon roll — verify the new pid after restart.

Closes #4501
