### PR TITLE
fix: widen dependency-phrase parser to tolerate markdown emphasis/colon

### DIFF
--- a/defaults/.claude/commands/loom/champion-pr-merge.md
+++ b/defaults/.claude/commands/loom/champion-pr-merge.md
@@ -345,9 +345,11 @@ CLOSED_ISSUE=$2
 
 echo "Checking for issues blocked by #$CLOSED_ISSUE..."
 
-# Find issues with loom:blocked that reference the closed issue
+# Find issues with loom:blocked that reference the closed issue.
+# Tolerant of markdown emphasis/colon between the phrase and #N (e.g.
+# "**Blocked by:** #1 (reason)") — #4508.
 BLOCKED_ISSUES=$(gh issue list --label "loom:blocked" --state open --json number,body \
-  --jq ".[] | select(.body | test(\"(Blocked by|Depends on|Requires) #$CLOSED_ISSUE\"; \"i\")) | .number")
+  --jq ".[] | select(.body | test(\"(Blocked by|Depends on|Requires)[*_:[:space:]]*#$CLOSED_ISSUE\"; \"i\")) | .number")
 
 if [ -z "$BLOCKED_ISSUES" ]; then
   echo "No issues found blocked by #$CLOSED_ISSUE"
@@ -360,8 +362,13 @@ for blocked in $BLOCKED_ISSUES; do
   # Get the issue body to check ALL dependencies
   BLOCKED_BODY=$(gh issue view "$blocked" --json body --jq -r '.body')
 
-  # Extract all referenced dependencies
-  ALL_DEPS=$(echo "$BLOCKED_BODY" | grep -Eo "(Blocked by|Depends on|Requires) #[0-9]+" | grep -Eo "[0-9]+" | sort -u)
+  # Extract all referenced dependencies. Two-stage (#4508): stage 1 selects
+  # lines declaring a dependency phrase, tolerant of markdown emphasis/colon
+  # between the phrase and the first #N (e.g. "**Blocked by:** #1 (x), #3
+  # (y)"); stage 2 extracts every #N on those lines, not just the first — an
+  # empty ALL_DEPS here would silently remove loom:blocked with no
+  # confirmation gate, so under-parsing is the highest-severity failure mode.
+  ALL_DEPS=$(echo "$BLOCKED_BODY" | grep -E "(Blocked by|Depends on|Requires)[*_:[:space:]]*#[0-9]+" | grep -Eo "#[0-9]+" | grep -Eo "[0-9]+" | sort -u)
 
   # Check if ALL dependencies are now closed
   ALL_RESOLVED=true

--- a/defaults/.claude/commands/loom/champion-reference.md
+++ b/defaults/.claude/commands/loom/champion-reference.md
@@ -336,7 +336,9 @@ For the authoritative, end-to-end implementation — the 6 safety criteria, the 
 - Manual close may be needed for cross-repo references
 
 **Blocked issues not unblocking**
-- Verify dependency format: "Blocked by #123" or "Depends on #123"
+- Verify dependency format: "Blocked by #123" or "Depends on #123" — markdown
+  emphasis and an optional colon before `#N` are also tolerated, e.g.
+  "**Blocked by:** #123 (reason)" or "_Depends on_ #123" (#4508)
 - Check if all dependencies are truly closed
 - Manual unblock may be needed for complex dependency patterns
 

--- a/defaults/.claude/commands/loom/guide.md
+++ b/defaults/.claude/commands/loom/guide.md
@@ -501,20 +501,29 @@ gh issue list --label "loom:blocked" --state open --json number,title,body
 
 ### Dependency Parsing
 
-Recognize these patterns in issue bodies:
+Recognize these patterns in issue bodies. The phrase forms tolerate markdown
+emphasis (`*`/`_`) and an optional colon between the phrase and the first
+`#N` — e.g. `**Blocked by:** #1 (reason), #3 (reason)` — and every `#N` on a
+matched line is captured, not just the first (#4508):
 
 | Pattern | Example |
 |---------|---------|
-| Explicit blocker | `Blocked by #123` |
-| Depends on | `Depends on #123` |
+| Explicit blocker | `Blocked by #123`, `**Blocked by:** #123` |
+| Depends on | `Depends on #123`, `_Depends on_ #123` |
 | Requires | `Requires #123` |
 | Task list | `- [ ] #123: Description` |
 
 ```bash
 parse_dependencies() {
   local body="$1"
-  # Match dependency patterns and extract issue numbers
-  echo "$body" | grep -oE '(Blocked by|Depends on|Requires|\- \[.\]) #[0-9]+' | grep -oE '#[0-9]+' | tr -d '#' | sort -u
+  # Two-stage parse (#4508): stage 1 selects lines that declare a dependency
+  # phrase, tolerant of markdown emphasis/colon between the phrase and the
+  # first #N (e.g. "**Blocked by:** #1"); stage 2 extracts every #N on those
+  # lines, so comma-separated lists ("#1 (reason), #3 (reason)") capture all
+  # refs, not just the first.
+  echo "$body" \
+    | grep -E '(Blocked by|Depends on|Requires|\- \[.\])[*_:[:space:]]*#[0-9]+' \
+    | grep -oE '#[0-9]+' | tr -d '#' | sort -u
 }
 ```
 

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -183,7 +183,7 @@ Combine flags as needed. Always pass `--state open` explicitly (Mode C operates 
   | `loom:curated` | Promote to `loom:issue` (Approval gate, step 3) → build. |
   | Uncurated: none / `loom:triage` / `loom:curating` | Curate (step 2) → promote → build. |
   | Stale `loom:building` | Reclaim → build. "Stale" = no **open** linked PR **and** `updatedAt` older than `LOOM_STALE_BUILDING_HOURS` (default 2). "Open linked PR" here means the **union** probe (step 1, #3359 + #3677) — `closedByPullRequestsReferences` **and** timeline `cross-referenced` open-PR events — so an in-flight non-closing `Part of #N` slice PR counts and blocks reclaim. Fresh `loom:building` (recently updated, or has an open PR) is genuinely in flight → route its open PR (if any) to Judge/Merge, else skip with `in flight (fresh loom:building)`. |
-  | `loom:blocked` | Probe the blocker: if every `#N` it depends on (parsed from the blocker comment / issue body via GitHub's reference parser) is CLOSED/MERGED, remove `loom:blocked` → build. If a dependency is still open → skip with `still blocked by #N`. If no dependency is parseable → remove `loom:blocked` and attempt anyway (fast/sloppy). |
+  | `loom:blocked` | Probe the blocker: if every `#N` it depends on (parsed from the blocker comment / issue body via `defaults/.claude/commands/loom/guide.md`'s `parse_dependencies` convention — tolerant of markdown emphasis/colon between the phrase and `#N`, e.g. `**Blocked by:** #1 (reason), #3 (reason)`, #4508) is CLOSED/MERGED, remove `loom:blocked` → build. If a dependency is still open → skip with `still blocked by #N`. If no dependency is parseable → remove `loom:blocked` and attempt anyway (fast/sloppy). |
   | `loom:epic` | Fan out: build its open `loom:epic-phase` children (already in the candidate set). Skip the container with `expanded to #a #b …`. If it has **no** open phase children → skip with `needs decomposition (run Champion/Architect)` — a container is not directly buildable. |
   | `loom:epic-phase` | Build directly (a phase issue is a normal buildable unit). |
   | Has an **open** linked PR (any label) | Drive the existing PR through Judge / Doctor → Merge via the step-1 union probe (#3359 + #3677 — closing-keyword **and** non-closing `Part of #N` timeline references) — do not build a duplicate. Takes precedence over every row above. |
@@ -1670,14 +1670,16 @@ The step is **best-effort** — a reconciliation failure never fails the parent 
 
 This section is the single home for the opt-in `--auto-stack` behavior. It is entered **only** when `AUTO_STACK=true` (Modes A/B). Absent the flag, none of this runs and the sweep is byte-for-byte unchanged. It **generalizes the single-value `--depends-on` / `worktree.sh --base` / auto-reconcile mechanics above (already shipped, #3729/#3747/#3752) from one global value to a per-issue dependency map** — it does **not** introduce any new worktree/PR/merge machinery. Mode C never runs this (no Builder phase to stack).
 
-**1. Detection — authoritative body-text signal, same-candidate-set only.** During the Stage 0 candidate survey (which already reads each candidate's `title,labels,state` — auto-stack adds `body` to that same `gh issue view N --json` read, **no new API call**), grep each candidate's body for the dependency phrases. **Reuse the exact regex vocabulary already established in `defaults/roles/guide.md` (`parse_dependencies`, the `(Blocked by|Depends on|Requires|\- \[.\]) #[0-9]+` convention), restricted here to `Depends on` / `Requires` only:**
+**1. Detection — authoritative body-text signal, same-candidate-set only.** During the Stage 0 candidate survey (which already reads each candidate's `title,labels,state` — auto-stack adds `body` to that same `gh issue view N --json` read, **no new API call**), grep each candidate's body for the dependency phrases. **Reuse the exact regex vocabulary already established in `defaults/.claude/commands/loom/guide.md` (`parse_dependencies`, the `(Blocked by|Depends on|Requires|\- \[.\])[*_:[:space:]]*#[0-9]+` convention — tolerant of markdown emphasis/colon between the phrase and `#N`, #4508), restricted here to `Depends on` / `Requires` only:**
 
 ```bash
 # Modeled on guide.md's parse_dependencies — restricted to the two declaration phrases.
 # Deliberately EXCLUDES `Blocked by` (that phrase drives the distinct loom:blocked
 # unblock machinery in guide.md / champion-reference.md and is NOT repurposed here)
 # and EXCLUDES the `- [ ]` task-list form (not a stacking declaration).
-echo "$BODY" | grep -oE '(Depends on|Requires) #[0-9]+' | grep -oE '#[0-9]+' | tr -d '#' | sort -u
+# Two-stage (#4508): select matching lines, tolerant of markdown emphasis/colon
+# before the first #N, then extract every #N on those lines.
+echo "$BODY" | grep -E '(Depends on|Requires)[*_:[:space:]]*#[0-9]+' | grep -oE '#[0-9]+' | tr -d '#' | sort -u
 ```
 
 A matched `#A` becomes a **stacking edge only when `#A` is also a member of this sweep invocation's own deduplicated candidate list.** A `Depends on #A` naming an issue **outside** the candidate set is left completely untouched — it is not an edge, it does not stack, and it flows through the existing `loom:blocked` handling exactly as today (this feature never touches out-of-set references). This "same-candidate-set only" restriction is load-bearing: it is what keeps auto-stack scoped to one sweep's own resolved set and prevents it from silently reaching out to arbitrary external issues.
@@ -1708,7 +1710,7 @@ This is the **safe** half of broad dependency-awareness: the *detection* of depe
     --depends-on "<operator --depends-on values, if any>"
 ```
 
-- **Parser reuse (not a second parser).** `warn-out-of-set-deps.sh` REUSES the exact `(Depends on|Requires|Part of) #[0-9]+` vocabulary — a restriction of guide.md's `parse_dependencies` — rather than introducing a divergent parser. It EXCLUDES `Blocked by` (that phrase drives the distinct `loom:blocked` unblock machinery), exactly as `--auto-stack` does.
+- **Parser reuse (not a second parser).** `warn-out-of-set-deps.sh` REUSES the exact `(Depends on|Requires|Part of)[*_:[:space:]]*#[0-9]+` vocabulary (tolerant of markdown emphasis/colon before `#N`, #4508) — a restriction of guide.md's `parse_dependencies` — rather than introducing a divergent parser. It EXCLUDES `Blocked by` (that phrase drives the distinct `loom:blocked` unblock machinery), exactly as `--auto-stack` does.
 - **Warn condition.** For each referenced `#A` that is **open** AND **not** a member of this sweep's resolved candidate set AND **not** already covered by an operator `--depends-on`, emit a clear advisory warning, e.g.:
   `warning: issue #B declares "Depends on #A", but #A is not in this sweep's candidate set — pass --depends-on <A> or include #A to stack them; otherwise #B may build against a stale base.`
 - **No auto-expansion — the load-bearing safety property stays intact.** The candidate set is **never** auto-grown to include `#A`; the tool never probes/expands to external issues beyond the single openness check on a referenced number. This is detection + advisory *only* — the inverse (auto-adding un-named external issues) was **rejected** (operator, 2026-07-23) precisely because it would break the same-set guarantee.

--- a/defaults/scripts/tests/test-dependency-parse.sh
+++ b/defaults/scripts/tests/test-dependency-parse.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# test-dependency-parse.sh - Fixture tests for the dependency-phrase parser
+# vocabulary widened in #4508.
+#
+# Before #4508, the documented dependency-phrase matcher
+# `(Blocked by|Depends on|Requires) #[0-9]+` (established in guide.md's
+# `parse_dependencies` and reused by sweep.md's --auto-stack detection,
+# warn-out-of-set-deps.sh, and champion-pr-merge.md's unblock loop) failed to
+# match the common markdown-bold/colon form `**Blocked by:** #1 (x), #3 (y)`
+# — an empty parse that, under the aggressive `/loom:sweep all` taxonomy,
+# would silently strip `loom:blocked` and build out of dependency order (see
+# #4508 for the incident). This file asserts the fix's two properties:
+#
+#   1. The widened separator `[*_:[:space:]]*` between the phrase and the
+#      first `#N` tolerates markdown emphasis (`*`/`_`) and an optional
+#      colon, on every reuser site.
+#   2. The two-stage parse (select matching lines, then extract every `#N`
+#      on those lines) captures ALL refs in a comma-separated list, not just
+#      the first.
+#
+# It also guards the load-bearing phrase-set split (#4508's curator
+# enhancement): guide.md keeps all four alternatives (incl. the `- [ ]`
+# checkbox form); the --auto-stack / warn-out-of-set-deps sites stay
+# restricted to `Depends on`/`Requires`(/`Part of`) and must NEVER match
+# `Blocked by` — that phrase drives the distinct loom:blocked machinery.
+#
+# Strategy: warn-out-of-set-deps.sh's `parse_out_of_set_deps` is REAL,
+# sourceable code (guarded on `BASH_SOURCE == $0`), so it is tested directly
+# — no duplication. guide.md's `parse_dependencies` and the markdown-embedded
+# snippets in sweep.md / champion-pr-merge.md are prose (Claude reads and
+# executes them, they are not standalone scripts), so this file mirrors each
+# one verbatim in a local function and pins the shipped doc text with a
+# literal `assert_doc_contains` check — if a future edit changes the doc
+# without updating this file (or vice versa), the corresponding check fails.
+#
+# Usage:
+#   ./.loom/scripts/tests/test-dependency-parse.sh
+
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)"
+DEFAULTS_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
+GUIDE_MD="$DEFAULTS_DIR/.claude/commands/loom/guide.md"
+SWEEP_MD="$DEFAULTS_DIR/.claude/commands/loom/sweep.md"
+CHAMPION_MD="$DEFAULTS_DIR/.claude/commands/loom/champion-pr-merge.md"
+
+# Source warn-out-of-set-deps.sh's real parse_out_of_set_deps BEFORE defining
+# our own RED/GREEN/NC below — the script's own `[[ -t 2 ]]` color block
+# redefines RED/NC (not GREEN), so sourcing first (then setting ours last)
+# keeps this file's output colors consistent regardless of source order.
+# shellcheck source=/dev/null
+source "$SCRIPTS_DIR/warn-out-of-set-deps.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected: '$expected'"
+        echo "    Actual:   '$actual'"
+    fi
+}
+
+# Pin a literal snippet as present verbatim in a doc file — catches drift
+# between this test's mirrored functions and the shipped markdown.
+assert_doc_contains() {
+    local file="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if grep -qF -- "$needle" "$file"; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg (missing literal in $file: $needle)"
+    fi
+}
+
+# =====================================================================
+# guide.md's parse_dependencies — mirrors defaults/.claude/commands/loom/guide.md
+# verbatim (four alternatives incl. checkbox form; widened separator).
+# =====================================================================
+guide_parse_dependencies() {
+    local body="$1"
+    echo "$body" \
+        | grep -E '(Blocked by|Depends on|Requires|\- \[.\])[*_:[:space:]]*#[0-9]+' \
+        | grep -oE '#[0-9]+' | tr -d '#' | sort -u
+}
+
+# =====================================================================
+# sweep.md's --auto-stack detection snippet — mirrors
+# defaults/.claude/commands/loom/sweep.md verbatim (restricted to
+# Depends on / Requires; deliberately EXCLUDES Blocked by).
+# =====================================================================
+sweep_auto_stack_detect() {
+    local body="$1"
+    echo "$body" | grep -E '(Depends on|Requires)[*_:[:space:]]*#[0-9]+' | grep -oE '#[0-9]+' | tr -d '#' | sort -u
+}
+
+# =====================================================================
+# champion-pr-merge.md's ALL_DEPS extraction — mirrors
+# defaults/.claude/commands/loom/champion-pr-merge.md verbatim.
+# =====================================================================
+champion_all_deps() {
+    local blocked_body="$1"
+    echo "$blocked_body" | grep -E "(Blocked by|Depends on|Requires)[*_:[:space:]]*#[0-9]+" | grep -Eo "#[0-9]+" | grep -Eo "[0-9]+" | sort -u
+}
+
+echo "--- guide.md parse_dependencies: markdown-bold/colon forms ---"
+
+out="$(guide_parse_dependencies '**Blocked by:** #1 (short reason), #3 (short reason)')"
+assert_eq $'1\n3' "$out" "captures ALL refs from a bold+colon comma-list, not just #1"
+
+out="$(guide_parse_dependencies 'Blocked by: #2')"
+assert_eq "2" "$out" "plain phrase + colon (no bold)"
+
+out="$(guide_parse_dependencies '_Depends on_ #5')"
+assert_eq "5" "$out" "italic-wrapped phrase"
+
+echo
+echo "--- guide.md parse_dependencies: regression (plain unformatted forms) ---"
+
+out="$(guide_parse_dependencies 'Blocked by #7')"
+assert_eq "7" "$out" "plain Blocked by #N (no regression)"
+
+out="$(guide_parse_dependencies 'Depends on #8')"
+assert_eq "8" "$out" "plain Depends on #N (no regression)"
+
+out="$(guide_parse_dependencies 'Requires #9')"
+assert_eq "9" "$out" "plain Requires #N (no regression)"
+
+out="$(guide_parse_dependencies '- [ ] #12: some description')"
+assert_eq "12" "$out" "checkbox form still works (- [ ] #N)"
+
+echo
+echo "--- guide.md parse_dependencies: edge case (unrelated same-line ref) ---"
+
+out="$(guide_parse_dependencies 'Depends on #5 (see #99)')"
+assert_eq $'5\n99' "$out" "captures the unrelated same-line #99 too (documented conservative trade-off)"
+
+echo
+echo "--- sweep.md --auto-stack detection: widened separator, phrase-set unchanged ---"
+
+out="$(sweep_auto_stack_detect '**Depends on:** #101 (x), #102 (y)')"
+assert_eq $'101\n102' "$out" "captures all refs from a bold+colon comma-list"
+
+out="$(sweep_auto_stack_detect 'Requires #9')"
+assert_eq "9" "$out" "plain Requires #N (no regression)"
+
+out="$(sweep_auto_stack_detect '**Blocked by:** #1')"
+assert_eq "" "$out" "Blocked by NEVER matches --auto-stack detection (phrase-set split preserved)"
+
+echo
+echo "--- champion-pr-merge.md ALL_DEPS: previously-empty parse now resolves ---"
+
+out="$(champion_all_deps '**Blocked by:** #1 (reason), #3 (reason)')"
+assert_eq $'1\n3' "$out" "bold+colon comma-list yields 1 3 (previously empty -> silent unblock)"
+
+out="$(champion_all_deps 'Blocked by #7
+Depends on #8
+Requires #9')"
+assert_eq $'7\n8\n9' "$out" "plain unformatted forms (no regression)"
+
+echo
+echo "--- champion-pr-merge.md BLOCKED_ISSUES jq filter: widened separator ---"
+
+if command -v jq >/dev/null 2>&1; then
+    matched="$(echo '{"body":"**Blocked by:** #1 (reason), #3 (reason)"}' \
+        | jq -r '.body | test("(Blocked by|Depends on|Requires)[*_:[:space:]]*#1"; "i")')"
+    assert_eq "true" "$matched" "jq test() matches bold+colon form for the closed-issue number"
+
+    matched="$(echo '{"body":"Depends on #5"}' \
+        | jq -r '.body | test("(Blocked by|Depends on|Requires)[*_:[:space:]]*#7"; "i")')"
+    assert_eq "false" "$matched" "jq test() does not match an unrelated issue number"
+else
+    echo "  SKIP: jq not available"
+fi
+
+echo
+echo "--- warn-out-of-set-deps.sh parse_out_of_set_deps: real sourced code ---"
+
+out="$(parse_out_of_set_deps '**Depends on:** #201 (x), #202 (y)')"
+assert_eq $'201\n202' "$out" "bold+colon comma-list captures all refs"
+
+out="$(parse_out_of_set_deps 'Part of: #303')"
+assert_eq "303" "$out" "colon-only form (Part of)"
+
+out="$(parse_out_of_set_deps '**Blocked by:** #400')"
+assert_eq "" "$out" "Blocked by NEVER matches warn-out-of-set-deps (phrase-set split preserved)"
+
+echo
+echo "--- Doc pins: shipped markdown matches the mirrored functions above ---"
+
+assert_doc_contains "$GUIDE_MD" \
+    "grep -E '(Blocked by|Depends on|Requires|\- \[.\])[*_:[:space:]]*#[0-9]+'" \
+    "guide.md parse_dependencies ships the widened four-alternative pattern"
+
+assert_doc_contains "$SWEEP_MD" \
+    "grep -E '(Depends on|Requires)[*_:[:space:]]*#[0-9]+'" \
+    "sweep.md --auto-stack detection ships the widened two-phrase pattern"
+
+assert_doc_contains "$CHAMPION_MD" \
+    'grep -E "(Blocked by|Depends on|Requires)[*_:[:space:]]*#[0-9]+"' \
+    "champion-pr-merge.md ALL_DEPS extraction ships the widened pattern"
+
+assert_doc_contains "$CHAMPION_MD" \
+    'test(\"(Blocked by|Depends on|Requires)[*_:[:space:]]*#$CLOSED_ISSUE\"; \"i\")' \
+    "champion-pr-merge.md BLOCKED_ISSUES jq filter ships the widened pattern"
+
+echo
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+[[ $TESTS_FAILED -eq 0 ]] || exit 1

--- a/defaults/scripts/tests/test-sweep-auto-stack.sh
+++ b/defaults/scripts/tests/test-sweep-auto-stack.sh
@@ -80,7 +80,7 @@ echo
 echo "--- Detection: authoritative body-text signal, same-candidate-set only ---"
 
 assert_contains "Detection reuses guide.md parse_dependencies convention" 'parse_dependencies'
-assert_contains "Detection restricted to Depends on / Requires" '(Depends on|Requires) #[0-9]+'
+assert_contains "Detection restricted to Depends on / Requires" '(Depends on|Requires)[*_:[:space:]]*#[0-9]+'
 assert_contains "Blocked by deliberately excluded from stacking detection" 'EXCLUDES `Blocked by`'
 assert_contains "body field added to existing gh issue view read (no new API call)" 'no new API call'
 # THE load-bearing guard: same-candidate-set restriction must be stated explicitly.
@@ -146,7 +146,7 @@ echo
 echo "--- Cross-file: guide.md regex convention still present (reused, not modified) ---"
 
 if [[ -f "$GUIDE_MD" ]]; then
-    if grep -qF -- '(Blocked by|Depends on|Requires|\- \[.\]) #[0-9]+' "$GUIDE_MD"; then
+    if grep -qF -- '(Blocked by|Depends on|Requires|\- \[.\])[*_:[:space:]]*#[0-9]+' "$GUIDE_MD"; then
         echo "PASS: guide.md parse_dependencies regex convention intact (reused by --auto-stack)"
         PASS=$((PASS + 1))
     else

--- a/defaults/scripts/warn-out-of-set-deps.sh
+++ b/defaults/scripts/warn-out-of-set-deps.sh
@@ -72,16 +72,20 @@ show_help() {
 
 # ---- parser (reused vocabulary, extracted by tests) ----
 # Parse out-of-set dependency references from an issue body. REUSES guide.md's
-# parse_dependencies vocabulary (the `(Blocked by|Depends on|Requires|- [.]) #N`
-# convention #3759's --auto-stack also derives from), restricted to the three
-# DECLARATION phrases this item covers: Depends on / Requires / Part of.
+# parse_dependencies vocabulary (the
+# `(Blocked by|Depends on|Requires|- [.])[*_:[:space:]]*#N` convention #3759's
+# --auto-stack also derives from — tolerant of markdown emphasis/colon between
+# the phrase and #N, e.g. "**Depends on:** #101", #4508), restricted to the
+# three DECLARATION phrases this item covers: Depends on / Requires / Part of.
 #
 # Deliberately EXCLUDES `Blocked by` (that phrase belongs to the loom:blocked
 # machinery, exactly as --auto-stack excludes it from stacking detection).
+# Two-stage: select matching lines, then extract every #N on those lines (not
+# just the first), so comma-separated lists are captured in full.
 # Emits the deduplicated referenced issue numbers, one per line.
 parse_out_of_set_deps() {
     local body="$1"
-    echo "$body" | grep -oE '(Depends on|Requires|Part of) #[0-9]+' \
+    echo "$body" | grep -E '(Depends on|Requires|Part of)[*_:[:space:]]*#[0-9]+' \
         | grep -oE '#[0-9]+' | tr -d '#' | sort -un
 }
 


### PR DESCRIPTION
## Summary

The documented dependency-phrase matcher `(Blocked by|Depends on|Requires) #[0-9]+` failed to match the common markdown-bold/colon form `**Blocked by:** #1 (x), #3 (y)` — an empty parse that, under `/loom:sweep all`'s aggressive taxonomy, would silently strip `loom:blocked` and build issues out of dependency order (see #4508 for the incident). This PR widens the separator tolerance across every reuser site and switches each to a two-stage parse that captures ALL `#N` refs on a matching line, not just the first.

## Changes

- `defaults/.claude/commands/loom/guide.md` — `parse_dependencies` widened to `(Blocked by|Depends on|Requires|\- \[.\])[*_:[:space:]]*#[0-9]+` (all four alternatives, incl. the checkbox form); two-stage extraction; format table + prose updated.
- `defaults/.claude/commands/loom/sweep.md` — `--auto-stack` detection snippet widened (kept restricted to `Depends on|Requires`, deliberately excludes `Blocked by`); parser-reuse prose updated (also fixes a stale citation pointing at `defaults/roles/guide.md` instead of the canonical `defaults/.claude/commands/loom/guide.md`); `warn-out-of-set-deps.sh` parser-reuse prose updated; aggressive-taxonomy `loom:blocked` row prose updated to reference the widened convention.
- `defaults/.claude/commands/loom/champion-pr-merge.md` — the highest-severity site: widened both the `BLOCKED_ISSUES` jq `test()` filter and the `ALL_DEPS` two-stage extraction (an empty parse here previously removed `loom:blocked` with no confirmation gate).
- `defaults/.claude/commands/loom/champion-reference.md` — documented the tolerated forms.
- `defaults/scripts/warn-out-of-set-deps.sh` — `parse_out_of_set_deps` widened (kept restricted to `Depends on|Requires|Part of`; still excludes `Blocked by`).
- `defaults/scripts/tests/test-sweep-auto-stack.sh` — updated the verbatim regex assertions (lines 83, 149) in lockstep with the widened patterns; the negative assertion (line 141, sweep.md must NOT contain the 3-phrase `Blocked by` pattern) needed no change since that literal was never reintroduced.
- **New**: `defaults/scripts/tests/test-dependency-parse.sh` — fixture tests for every site above.

Per-site phrase sets are deliberately preserved, not merged (load-bearing, test-enforced): `Blocked by` still drives only the `loom:blocked` machinery and is never usable as a stacking-edge phrase in `--auto-stack` or `warn-out-of-set-deps.sh`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Matcher tolerates markdown emphasis + optional colon, captures all `#N` refs | done | `test-dependency-parse.sh`: `**Blocked by:** #1 (x), #3 (y)` -> `1\n3` (guide.md, champion-pr-merge.md, jq filter, warn-out-of-set-deps.sh all verified) |
| All reusers audited and fixed consistently (phrase sets preserved) | done | guide.md / sweep.md auto-stack / warn-out-of-set-deps.sh / champion-pr-merge.md all updated; negative fixtures confirm `Blocked by` never leaks into the 2/3-phrase sites |
| Fixtures cover bold+colon, colon-only, italic, plain forms | done | `test-dependency-parse.sh`: `**Blocked by:** #1 (x), #3 (y)`, `Blocked by: #2`, `_Depends on_ #5`, plain `Blocked by #7`/`Depends on #8`/`Requires #9`, checkbox `- [ ] #12` |
| sweep.md's documented regex snippets match implementation | done | Snippet at sweep.md's auto-stack section + `test-sweep-auto-stack.sh` doc-pin assertions updated in lockstep |

## Test Plan

- `bash defaults/scripts/tests/test-dependency-parse.sh` -> 22/22 passed (new fixture test)
- `bash defaults/scripts/tests/test-sweep-auto-stack.sh` -> 41/42 passed; the 1 failure (`Daemon path forwards depends_on per candidate`) is pre-existing on `origin/main`, unrelated to this change (verified by running the same test against an unmodified `origin/main` checkout)
- `bash defaults/scripts/tests/test-warn-out-of-set-deps.sh` -> 15/15 passed (unchanged behavior, still green)
- Manual verification: champion-pr-merge.md's `ALL_DEPS` pipeline against `**Blocked by:** #1 (reason), #3 (reason)` now yields `1 3` (previously empty)
- Edge case: `Depends on #5 (see #99)` -> captures both `5` and `99` (documented conservative over-capture trade-off, per curator guidance)
- `cargo test --workspace --lib --bins` -> 2266 + 46 passed, 0 failed (no Rust code touched by this PR; confirms no regression)
- `bash scripts/test-installer.sh` -> 175 passed, 1 pre-existing failure (`test-loom-dispatcher.sh`) reproduced identically on unmodified `origin/main`, unrelated to this change

## Pre-existing Issues (Not Addressed)

- `.loom/scripts/build-gate.sh`'s pytest stage fails in this sandbox because `uv` is not installed on the host — unrelated to this PR (no Python files touched); Rust and bash-test stages ran to completion and are green.
- `test-loom-dispatcher.sh` (part of `scripts/test-installer.sh`) fails identically on an unmodified `origin/main` checkout — pre-existing, unrelated to this change.

Closes #4508