### PR TITLE
test(daemon): join the workspace_pool safehouse tests to the shared #[serial] group

### DIFF
--- a/loom-daemon/src/workspace_pool.rs
+++ b/loom-daemon/src/workspace_pool.rs
@@ -549,7 +549,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial(loom_safehouse_env)]
+    #[serial_test::serial]
     async fn start_safehouse_narration_surfaces_unreachable_for_enabled_unresolved_socket() {
         clear_safehouse_env();
         let dir = tempdir().unwrap();
@@ -581,7 +581,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial(loom_safehouse_env)]
+    #[serial_test::serial]
     async fn start_peer_coordination_disabled_reports_not_configured_even_after_prior_state() {
         clear_safehouse_env();
         let dir = tempdir().unwrap();


### PR DESCRIPTION
## Why this PR exists

This is the **2-line fix the Judge requested on #4560 before it merged.** #4560 was carrying `loom:pr` *and* `loom:changes-requested` simultaneously — two concurrent Judge passes raced, the first approved and the second (more thorough) found a real defect but did not strip `loom:pr`. The merge went through on the stale approval at 05:29:52Z, before a Doctor could push the fix, so the blocker landed on `main` as dd89e0c2.

Judge's rejection comment (the authoritative verdict): https://github.com/rjwalters/loom/pull/4560#issuecomment-3736420196

Closes #4568.

## The defect

`loom-daemon/src/workspace_pool.rs:552` and `:584` on `main`:

```rust
#[serial_test::serial(loom_safehouse_env)]
```

Both tests call `clear_safehouse_env()`, which `remove_var`s `LOOM_SAFEHOUSE_ENABLED` / `_SOCKET` / `_ROOM` / `_PERSONA` and `SAFEHOUSED_SOCKET`. But `loom_safehouse_env` was a **new named key with no other members in the crate**, while every existing test that mutates those same five variables uses the **unnamed** `#[serial]` key:

| Site | What it does |
|---|---|
| `safehouse.rs:2041` `env_overrides_config_for_all_keys` | sets all four `LOOM_SAFEHOUSE_*`, asserts on `apply_env_overrides` |
| `safehouse.rs:2065` `env_enabled_false_overrides_config_true` | `set_var(ENABLED_ENV, "0")` then asserts `!...enabled` |
| `safehouse.rs:2074` `socket_falls_back_to_safehoused_socket_env` | `set_var(SAFEHOUSED_SOCKET_ENV, ...)` then asserts on `resolve_socket` |
| `claim_reconciliation.rs` | `remove_var("LOOM_SAFEHOUSE_ENABLED")` — remove-only, benign either way |

`serial_test` keys are **independent locks**, so the private key gave *no* mutual exclusion against the group guarding the same variables. Under plain `cargo test` — where all of these share one `loom-daemon` lib test process — a `clear_safehouse_env()` landing between a `set_var` and its assertion flips either safehouse test red.

Three reasons this warranted a follow-up PR rather than a backlog item:

1. **It is on the live path, indefinitely.** The nextest workflow flip is deferred to #4559 (`loom:operator-only` + `loom:blocked`, needs a human with `workflow` scope), so CI keeps running plain `cargo test --workspace` — precisely the execution model where this race is reachable. Before #4560 these two tests touched no env at all, so the window is newly introduced.
2. **It contradicts #4560's own new crate docs**, which state `#[serial]` is "a no-op under nextest but still load-bearing for developers running plain `cargo test`." With an unshared key it was decorative on exactly the path where it was meant to be load-bearing.
3. **The thesis of #4385** is that a narrow, unmarked concurrent env mutation is a real defect, not an acceptable probability.

## The change

Test-attribute-only, exactly as prescribed — `#[serial_test::serial(loom_safehouse_env)]` → `#[serial_test::serial]` at both sites. No production code, no behavior, no other file. Under nextest this is a no-op either way, so it costs nothing in the target state. `grep -rn loom_safehouse_env loom-daemon/src/` is now **0**.

## Verification

| Check | Result |
|---|---|
| `cargo test -p loom-daemon --lib workspace_pool` | 15 passed, 0 failed — includes both modified tests |
| `cargo test -p loom-daemon --lib safehouse` | 83 passed, 0 failed — the three `safehouse.rs` env tests now share the lock |
| `cargo test -p loom-daemon --lib` (full suite, the race-prone shared-process path) | 6 runs: 5x `2451 passed; 0 failed`; 1 run had a single unrelated flake (below) |
| `cargo fmt --all -- --check` | clean |
| `grep -rn "loom_safehouse_env" loom-daemon/src/` | 0 hits |

The safehouse / `workspace_pool` tests passed in **all six** full-suite runs.

### Pre-existing unrelated flake (documented, not addressed here)

One full-suite run failed `forge_cmd::tests::repo_nwo_prefers_gh_when_it_succeeds`. This is **not** related to this change and is pre-existing on `main`:

- `forge_cmd.rs` contains **0** references to any `SAFEHOUSE` variable.
- That test (`forge_cmd.rs:926`) carries **no** `#[serial]` at all — it is one of the unmarked subprocess-spawn tests (`Command`-spawns a generated `fake-gh.sh` in a tempdir), i.e. exactly the flake class #4385 was filed about and that nextest's process-per-test model fixes once #4559 lands.
- 8 targeted `--lib forge_cmd` runs (a process containing zero safehouse tests) were 21/21 green each time, confirming it is host-load sensitivity rather than an interaction with this diff.
- This host is running many concurrent agent sessions, the condition #4560's own PR body documented for local reproduction.

## Non-blocking notes from the Judge — deliberately NOT addressed

Both were explicitly marked "no action required" and are out of scope here:
- `nextest-version = "0.9.98"` as a hard floor (deliberate and defensible).
- `.config/nextest.toml` missing from the `backend` paths filter until #4559 lands (that is hunk 1 of #4559, already covered).

Also left alone per the Judge's explicit "I am **not** asking for a change": `clear_safehouse_env()` removes without restoring. That asymmetry is deliberate and benign — it only ever makes the environment *more* hermetic — and touching it would have widened this diff beyond the prescribed 2 lines.
