### PR TITLE
fix: deliver GitHub App tokens via daemon-owned GH_CONFIG_DIR, not a recurring set_var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,11 @@ Thumbs.db
 # removed (see loom_tools.semantic_search.guard_index_dest_not_tracked).
 .loom/search-index/
 
+# Daemon-owned GH_CONFIG_DIR for GitHub App installation-token delivery
+# (#4458) — host-local hosts.yml/config.yml, rewritten atomically by the
+# credential refresh tick. Never committed (mirrors `.loom/tokens/` above).
+.loom/gh-config/
+
 # Loom workspace config (DO commit for team sharing)
 # - config.json: Persistent terminal configurations (roles, themes, intervals)
 # - roles/: Custom role definitions

--- a/defaults/docs/github-authentication.md
+++ b/defaults/docs/github-authentication.md
@@ -226,11 +226,28 @@ each workspace's own git remote picks the right installation automatically.
 At startup (and on a periodic refresh tick thereafter, well inside the
 token's ~1h lifetime), the daemon mints a JWT from the app id + private key
 (RS256, signed locally via `openssl` — the key never leaves the host) and
-exchanges it for a short-lived installation access token, which it exports as
-its own process's `GH_TOKEN` — every `gh`/`git` child the daemon spawns from
-that point inherits it. The token is cached on disk (`0600`, keyed by
-installation) and re-minted whenever fewer than 10 minutes of its lifetime
-remain, so a live daemon never has to wait on a fresh mint mid-tick.
+exchanges it for a short-lived installation access token. The token is
+cached on disk (`0600`, keyed by installation) and re-minted whenever fewer
+than 10 minutes of its lifetime remain, so a live daemon never has to wait on
+a fresh mint mid-tick.
+
+**Delivery mechanism (#4458).** Earlier releases exported the minted token as
+this process's own `GH_TOKEN` on every refresh — a `std::env::set_var` from a
+background task that recurred roughly every 5 minutes for the life of the
+process, racing the `environ` reads every concurrently spawned `gh`/`git`
+child performs (undefined behavior on POSIX; the reason `set_var` is
+`unsafe` as of Rust edition 2024). The daemon now instead owns a dedicated
+`GH_CONFIG_DIR` (`<workspace>/.loom/gh-config/`, `0700`) whose `hosts.yml` it
+rewrites **atomically** (write a temp file, then rename into place) on every
+rotation — a pure file operation with no process-env mutation at all. `gh`
+re-reads its config from disk on every invocation, so every one of the
+daemon's own `gh`/`git` children (`Command::new` without `env_clear`) picks
+up a fresh token automatically, without any per-call-site change. The single
+`std::env::set_var("GH_CONFIG_DIR", …)` that points the process at this
+directory (clearing any ambient `GH_TOKEN`/`GITHUB_TOKEN` at the same time,
+so the app token isn't outranked by an operator-exported one) fires at most
+once per process lifetime, before any task that spawns `gh`/`git` exists to
+race it.
 
 `loom-daemon status` and the startup log line report this as mechanism
 `github-app` with a **non-secret fingerprint** — `app <id> installation
@@ -253,6 +270,32 @@ Forge credential: OK — github-app (app 123456 installation 789)
   app is installed on.
 - **Clock skew**: the minted JWT's `iat` is backdated 60 seconds per GitHub's
   own guidance, tolerating modest host clock drift without a manual fix.
+
+### Long-running sweep children and credential snapshots (#4458)
+
+The daemon's own forge calls (claim reconciliation, the main-health gate, the
+refresh tick, work finder, …) all run inside the one long-lived daemon
+process, so once `GH_CONFIG_DIR`/`hosts.yml` are set up they stay current for
+every one of those calls, for the life of the process — the daemon's own
+forge auth never goes stale between restarts.
+
+**Dispatched sweep children are a different story.** A sweep worker (the
+tmux-hosted Claude session `loom-daemon` spawns per issue/PR, often running
+for an hour or more on a complex issue) inherits whatever forge-credential
+environment is ambient **at the moment it is spawned** — an operator-exported
+`GH_TOKEN`/`GITHUB_TOKEN`, or the daemon's own credential setup, whichever
+resolves. That is a **snapshot**, not a live subscription: env beats the
+ambient keyring/`gh`-config lookup inside that child's own process (the same
+precedence order described throughout this doc), so if the snapshotted
+reference stops being valid partway through a long sweep — a GitHub App
+installation token's ~1h lifetime is the common case — the child does not
+re-resolve credentials on its own. Its own `gh` calls start 401ing with **no
+automatic fallback**, and the daemon rotating its own credential afterwards
+does not reach an already-running child. If you run consistently long sweeps
+against a GitHub-App-only host, prefer a long-lived PAT (`export GH_TOKEN`
+before starting the daemon — see "Headless and SSH-only daemon operation"
+above) for that workload, or expect to restart a sweep that 401s mid-run past
+the ~1h mark.
 
 ## Troubleshooting
 

--- a/loom-daemon/src/credential_preflight.rs
+++ b/loom-daemon/src/credential_preflight.rs
@@ -66,9 +66,10 @@
 //!
 //! - **No secret ever crosses into a `CredentialPreflightReport` or a log
 //!   line.** The minted token is threaded back to the caller *only* via
-//!   [`GithubAppPreflight::minted_gh_token`] (for `main.rs` to
-//!   `std::env::set_var("GH_TOKEN", …)`) — never through [`log`], never
-//!   through [`crate::types::DaemonStatusReport`]. The report/status surface
+//!   [`GithubAppPreflight::minted_gh_token`] (for `main.rs` to publish via
+//!   [`publish_github_app_token`] — see "File-based token delivery (#4458)"
+//!   below) — never through [`log`], never through
+//!   [`crate::types::DaemonStatusReport`]. The report/status surface
 //!   carries only the non-secret fingerprint `app <id> installation <id>`.
 //! - **GitHub only.** The daemon's own forge calls all shell out to `gh`,
 //!   which only ever resolves GitHub credentials (whether that's an ambient
@@ -556,6 +557,116 @@ pub fn run_with_github_app(
     }
 }
 
+// ============================================================================
+// File-based token delivery (#4458)
+// ============================================================================
+//
+// The startup preflight and the refresh tick above both used to publish the
+// minted installation token by calling `std::env::set_var("GH_TOKEN", …)`
+// directly in `main.rs`. That is sound *once* at boot (nothing else is
+// spawning `gh`/`git` children yet), but the refresh tick repeats it for the
+// life of the process from a background tokio task — racing the `environ`
+// reads every concurrent `Command::spawn` in this multithreaded runtime
+// performs (~76 `Command::new("gh"|"git")` call sites across 16 files, with
+// no central spawn choke point to inject through instead — see #4458's
+// issue body for the full census). Concurrent `setenv`/`getenv` is undefined
+// behavior on POSIX, which is exactly why `set_var` is `unsafe` as of Rust
+// edition 2024.
+//
+// The fix below replaces the *recurring* write with a **daemon-owned
+// `GH_CONFIG_DIR`** whose `hosts.yml` is rewritten atomically (write a temp
+// file, then `rename` into place — atomic on the same filesystem). `gh`
+// re-reads its config from disk on every invocation, so every one of those
+// ~76 call sites picks up a fresh token automatically, with zero call-site
+// changes and zero recurring `std::env::set_var` calls: the tick becomes a
+// pure file operation. The one remaining `std::env::set_var` — pointing
+// `GH_CONFIG_DIR` at this directory — fires at most once per process
+// lifetime (see `main.rs`), before the tick task or any other `gh`-spawning
+// task exists to race it.
+//
+// This was verified empirically against the `gh` CLI actually pinned in this
+// environment (2.96.0): a `GH_CONFIG_DIR` whose `hosts.yml` has no sibling
+// `config.yml` triggers `gh`'s one-time "multi-account migration", which
+// calls `GET /user` to resolve a login name — a call a GitHub App
+// installation token (not a user-authenticated credential) cannot make, so
+// *every* `gh` invocation hard-fails with "failed to migrate config" instead
+// of a normal 401. Writing a `config.yml` with `version: 1` up front (done by
+// [`publish_github_app_token`] on first use) skips that migration path
+// entirely — this is the reason a bare `hosts.yml` is not sufficient.
+//
+// Trade-off accepted: `GH_CONFIG_DIR` is host-global for the daemon process,
+// so it also shadows the operator's own `~/.config/gh` (aliases, `gh` prefs)
+// for every child the daemon spawns while a GitHub App is configured. That
+// is judged acceptable here — the daemon's own `gh` calls are all
+// non-interactive, alias-free API/CLI invocations — over the alternative
+// (injecting `.env("GH_TOKEN", …)` from a shared store at each of the ~76
+// call sites), which would preserve the operator's ambient config but cost a
+// multi-file refactor for a residual, currently-dormant hazard (see #4458).
+
+/// Directory (under the workspace root's own `.loom/`) the daemon owns for
+/// GitHub-App-token delivery via `GH_CONFIG_DIR` (#4458). Mirrors the
+/// existing `.loom/tokens/` convention (`tokens.rs`) — host-local, never
+/// committed (see `.gitignore`).
+#[must_use]
+pub fn github_app_gh_config_dir(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(".loom").join("gh-config")
+}
+
+/// Static `config.yml` companion `hosts.yml` needs so `gh` skips its
+/// one-time multi-account migration (see module doc above for why that
+/// migration is fatal for a GitHub-App-only credential).
+const GH_CONFIG_YAML: &str = "version: 1\ngit_protocol: https\n";
+
+/// Build the `hosts.yml` content `gh` expects for `token` on `github.com`.
+/// Split from the file I/O so it is unit-testable without touching disk
+/// (mirrors [`parse_github_app_response`]). `user` is set to
+/// `x-access-token` — the conventional placeholder for a GitHub App
+/// installation token (not a real user account); `gh` does not validate it
+/// against the API, it only uses `oauth_token` for authentication.
+fn gh_hosts_yaml(token: &str) -> String {
+    format!("github.com:\n    oauth_token: {token}\n    user: x-access-token\n    git_protocol: https\n")
+}
+
+/// Set `mode` on `path`, a no-op on non-unix targets (the daemon is
+/// unix-only in practice, but this keeps the crate cross-platform-buildable).
+fn set_private_mode(path: &Path, mode: u32) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (path, mode);
+    }
+    Ok(())
+}
+
+/// Atomically publish `token` into `config_dir/hosts.yml` (write-then-rename,
+/// same filesystem — no partial-file window), creating `config_dir` and its
+/// static `config.yml` companion on first use. This is a **pure file
+/// operation**: it never touches `std::env`, so it cannot race the
+/// `environ` reads of any concurrently spawned `gh`/`git` child (#4458) —
+/// the refresh tick in `main.rs` calls this in place of the old
+/// `std::env::set_var("GH_TOKEN", …)`.
+pub fn publish_github_app_token(config_dir: &Path, token: &str) -> std::io::Result<()> {
+    std::fs::create_dir_all(config_dir)?;
+    set_private_mode(config_dir, 0o700)?;
+
+    let config_path = config_dir.join("config.yml");
+    if !config_path.exists() {
+        std::fs::write(&config_path, GH_CONFIG_YAML)?;
+        set_private_mode(&config_path, 0o600)?;
+    }
+
+    let hosts_path = config_dir.join("hosts.yml");
+    let tmp_path = config_dir.join("hosts.yml.tmp");
+    std::fs::write(&tmp_path, gh_hosts_yaml(token))?;
+    set_private_mode(&tmp_path, 0o600)?;
+    std::fs::rename(&tmp_path, &hosts_path)?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -884,5 +995,82 @@ mod tests {
     fn resolve_github_app_script_neither_present_returns_none() {
         let dir = tempfile::tempdir().unwrap();
         assert_eq!(resolve_github_app_script(dir.path()), None);
+    }
+
+    #[test]
+    fn github_app_gh_config_dir_lives_under_dot_loom() {
+        let root = Path::new("/tmp/some-workspace");
+        assert_eq!(github_app_gh_config_dir(root), root.join(".loom").join("gh-config"));
+    }
+
+    #[test]
+    fn gh_hosts_yaml_embeds_token_and_skips_migration_fields() {
+        // #4458: the format must include `oauth_token` (auth) and
+        // `git_protocol` (gh reads this without a network call); `user` is
+        // an unvalidated placeholder for a GitHub App token.
+        let yaml = gh_hosts_yaml("ghs_example_token");
+        assert!(yaml.contains("oauth_token: ghs_example_token"));
+        assert!(yaml.contains("user: x-access-token"));
+        assert!(yaml.contains("git_protocol: https"));
+        assert!(yaml.starts_with("github.com:\n"));
+    }
+
+    #[test]
+    fn publish_github_app_token_writes_hosts_and_config_atomically() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_dir = dir.path().join("gh-config");
+
+        publish_github_app_token(&config_dir, "ghs_first").unwrap();
+
+        let hosts = std::fs::read_to_string(config_dir.join("hosts.yml")).unwrap();
+        assert!(hosts.contains("oauth_token: ghs_first"));
+        let config = std::fs::read_to_string(config_dir.join("config.yml")).unwrap();
+        assert!(config.contains("version: 1"));
+
+        // No leftover temp file after a successful publish (rename consumed it).
+        assert!(!config_dir.join("hosts.yml.tmp").exists());
+    }
+
+    #[test]
+    fn publish_github_app_token_rotation_overwrites_hosts_but_not_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_dir = dir.path().join("gh-config");
+
+        publish_github_app_token(&config_dir, "ghs_old").unwrap();
+        let config_before = std::fs::read_to_string(config_dir.join("config.yml")).unwrap();
+
+        // Simulate a real #4430 rotation: a second publish with a new value
+        // (this is what the refresh tick calls in place of the old
+        // `std::env::set_var("GH_TOKEN", …)` — a pure file rewrite, no env
+        // mutation anywhere in this path).
+        publish_github_app_token(&config_dir, "ghs_new").unwrap();
+
+        let hosts_after = std::fs::read_to_string(config_dir.join("hosts.yml")).unwrap();
+        assert!(hosts_after.contains("oauth_token: ghs_new"));
+        assert!(!hosts_after.contains("ghs_old"));
+
+        // `config.yml` is written once and never rewritten on rotation.
+        let config_after = std::fs::read_to_string(config_dir.join("config.yml")).unwrap();
+        assert_eq!(config_before, config_after);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn publish_github_app_token_sets_private_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let config_dir = dir.path().join("gh-config");
+        publish_github_app_token(&config_dir, "ghs_secret").unwrap();
+
+        let hosts_mode = std::fs::metadata(config_dir.join("hosts.yml"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(hosts_mode, 0o600);
+
+        let dir_mode = std::fs::metadata(&config_dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(dir_mode, 0o700);
     }
 }

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -1927,28 +1927,75 @@ async fn main() -> Result<()> {
             minted_gh_token: None,
         },
     };
+    // #4458: deliver the minted installation token via a daemon-owned
+    // `GH_CONFIG_DIR` (`credential_preflight::publish_github_app_token`)
+    // instead of exporting it as this process's `GH_TOKEN`. Every `gh` child
+    // this daemon spawns (`Command::new("gh")` without `env_clear`, ~76
+    // call sites — see the issue body's census) re-reads
+    // `$GH_CONFIG_DIR/hosts.yml` fresh on each invocation, so the refresh
+    // tick below becomes a pure file rewrite with **zero** recurring
+    // `std::env::set_var` calls — the UB race (concurrent `setenv` vs. the
+    // `environ` reads inside every concurrently spawned `Command`) this issue
+    // eliminates. `github_app_gh_config_dir_active` tracks whether the
+    // one-time env activation below has happened yet, so it fires **at most
+    // once** for the life of the process (see the tick closure further down
+    // for the rare case where activation happens there instead of here).
+    //
+    // The one remaining `std::env::set_var` (`GH_CONFIG_DIR` itself, plus the
+    // paired `remove_var` calls) is that single activation: it runs here,
+    // before the refresh-tick task (or any other tokio task that spawns
+    // `gh`/`git`) has been created, so there is no concurrent `Command::spawn`
+    // in this process yet to race the `environ` write — the residual window
+    // this issue's acceptance criteria allow a startup site to keep, given a
+    // comment naming the race and the rationale for accepting it. Clearing
+    // `GH_TOKEN`/`GITHUB_TOKEN` here (not just setting `GH_CONFIG_DIR`)
+    // matters too: `gh` checks the env vars *before* `GH_CONFIG_DIR`'s
+    // `hosts.yml`, so an operator-exported ambient token would otherwise
+    // silently outrank the just-minted app token — the pre-#4458 code
+    // achieved the same override by unconditionally overwriting `GH_TOKEN`.
+    let github_app_config_dir = credential_preflight::github_app_gh_config_dir(&sweep_workspace);
+    let mut github_app_gh_config_dir_active = false;
     if let Some(token) = &github_app_preflight.minted_gh_token {
-        // NEVER logged: only the fingerprint in `github_app_preflight.report`
-        // is. Exported into this process's own env so every `gh`/`git`
-        // child spawned from here on (Command::new without env_clear)
-        // inherits it.
-        std::env::set_var("GH_TOKEN", token);
+        match credential_preflight::publish_github_app_token(&github_app_config_dir, token) {
+            Ok(()) => {
+                std::env::remove_var("GH_TOKEN");
+                std::env::remove_var("GITHUB_TOKEN");
+                std::env::set_var("GH_CONFIG_DIR", &github_app_config_dir);
+                github_app_gh_config_dir_active = true;
+            }
+            Err(e) => {
+                // Fail open, matching the mint-failure posture elsewhere in
+                // this preflight: never block startup, never leave the
+                // daemon worse off than the pre-#4430 ambient path.
+                log::warn!(
+                    "credential_preflight: failed to publish github-app token to {} ({e}); \
+                     falling back to ambient gh auth — #4458",
+                    github_app_config_dir.display()
+                );
+            }
+        }
     }
     let credential_preflight = github_app_preflight.report;
 
     // #4430: keep the minted installation token fresh across its ~1h
     // lifetime for a long-running daemon. Ticks that don't rotate the token
-    // never *write* `GH_TOKEN`: the `NotConfigured` arm is a true no-op, and a
+    // never *write* anything: the `NotConfigured` arm is a true no-op, and a
     // cache-hit tick (the shell helper's own cache still has plenty of life —
-    // ~10 of every ~11 ticks) *reads* the current value but skips the
-    // `set_var` because the minted value is unchanged (#4456 value-changed
-    // guard). Only a genuine rotation (value differs) rewrites the env; a mint
-    // failure is logged and the loop keeps whatever `GH_TOKEN` the process
-    // already has (fail-open, matching the startup preflight's posture).
+    // ~10 of every ~11 ticks) compares against `current_token` (a plain local
+    // captured by this task, never the process env — #4456's original
+    // intent, now trivially true since there is no shared `GH_TOKEN` env var
+    // left to read) and skips the write because the minted value is
+    // unchanged. Only a genuine rotation (value differs) rewrites
+    // `hosts.yml`; a mint failure is logged and the loop keeps whatever
+    // credential `GH_CONFIG_DIR` already has on disk (fail-open, matching the
+    // startup preflight's posture).
     if let (Some(script_path), Some(owner_repo)) = (&github_app_script, &github_app_owner_repo) {
         let script_path = script_path.clone();
         let cwd = sweep_workspace.clone();
         let owner_repo = owner_repo.clone();
+        let config_dir = github_app_config_dir.clone();
+        let mut current_token = github_app_preflight.minted_gh_token.clone();
+        let mut config_dir_active = github_app_gh_config_dir_active;
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(credential_preflight::GITHUB_APP_REFRESH_INTERVAL).await;
@@ -1967,18 +2014,50 @@ async fn main() -> Result<()> {
                         app_id,
                         ..
                     }) => {
-                        // #4456: only write when the value actually rotated. A
-                        // cache-hit tick returns the unchanged token, and a
-                        // redundant `set_var` under the multithreaded runtime
-                        // needlessly races the `environ` reads of spawned
-                        // `gh`/`git` children.
-                        if gh_token_needs_update(std::env::var("GH_TOKEN").ok().as_deref(), &token)
-                        {
-                            std::env::set_var("GH_TOKEN", token);
-                            log::debug!(
-                                "credential_preflight: github-app refresh tick rotated GH_TOKEN \
-                                 (app {app_id} installation {installation_id}) — #4430"
-                            );
+                        // #4456/#4458: only rewrite when the value actually
+                        // rotated, and do it as a pure file write — no
+                        // `std::env::set_var` anywhere in this arm once
+                        // `config_dir_active` is already true (the common
+                        // case: activation happened at startup above).
+                        if gh_token_needs_update(current_token.as_deref(), &token) {
+                            // Rare edge case: the app becomes configured
+                            // *after* startup (e.g. the shell helper's own
+                            // config appears mid-run) without the daemon
+                            // restarting, so activation didn't happen above.
+                            // This is a second, still-bounded (at most once
+                            // per process) `std::env::set_var` window — the
+                            // recurring, steady-state race this issue targets
+                            // is the one eliminated; this cold-start
+                            // transition is unchanged in kind from the
+                            // pre-#4458 code's own equivalent one-time
+                            // `set_var` in this same arm.
+                            if !config_dir_active {
+                                std::env::remove_var("GH_TOKEN");
+                                std::env::remove_var("GITHUB_TOKEN");
+                                std::env::set_var("GH_CONFIG_DIR", &config_dir);
+                                config_dir_active = true;
+                            }
+                            match credential_preflight::publish_github_app_token(
+                                &config_dir,
+                                &token,
+                            ) {
+                                Ok(()) => {
+                                    current_token = Some(token);
+                                    log::debug!(
+                                        "credential_preflight: github-app refresh tick rotated \
+                                         GH_TOKEN (app {app_id} installation {installation_id}) \
+                                         — #4430"
+                                    );
+                                }
+                                Err(e) => {
+                                    log::warn!(
+                                        "credential_preflight: github-app refresh tick failed to \
+                                         publish token to {} ({e}); GH_CONFIG_DIR left unchanged \
+                                         (app {app_id} installation {installation_id}) — #4458",
+                                        config_dir.display()
+                                    );
+                                }
+                            }
                         } else {
                             log::debug!(
                                 "credential_preflight: github-app refresh tick cache hit, \


### PR DESCRIPTION
## Summary

Eliminates the #4430 GitHub App refresh tick's recurring
`std::env::set_var("GH_TOKEN", …)` (and the startup site) — a UB race
against the `environ` reads every concurrently-spawned `gh`/`git` child
performs in this multithreaded daemon.

## Design choice (and why)

Two options were on the table (per the issue's census of ~76
`Command::new("gh"|"git")` call sites across 16 files, with no central spawn
choke point):

1. **Shared token store + `.env()` injection** at every spawn site — call-site
   changes across ~16 files.
2. **File-based delivery via a daemon-owned `GH_CONFIG_DIR`** whose
   `hosts.yml` the refresh tick rewrites atomically — zero call-site
   changes, at the cost of shadowing the operator's own `~/.config/gh`
   (aliases/prefs) for the daemon's own children while an App is configured.

**Chose option 2.** The daemon's own `gh` calls are all non-interactive,
alias-free API/CLI invocations, so hiding the operator's personal `gh`
config from them costs nothing functionally, while option 1's per-call-site
refactor is out of proportion to a currently-dormant hazard (no GitHub App
is provisioned fleet-wide yet).

**Important implementation detail found while validating this empirically**
against the `gh` CLI actually pinned in this environment (2.96.0): a
`GH_CONFIG_DIR` whose `hosts.yml` has no sibling `config.yml` triggers `gh`'s
one-time "multi-account migration", which calls `GET /user` to resolve a
login name — a call a GitHub App installation token (not a
user-authenticated credential) cannot make, so *every* `gh` invocation would
hard-fail with "failed to migrate config" instead of a normal 401. Writing a
`config.yml` with `version: 1` up front (done by `publish_github_app_token`
on first use) sidesteps that migration entirely. This was reproduced and
fixed against the real binary, not just reasoned about.

## Changes

- `loom-daemon/src/credential_preflight.rs`: adds
  `github_app_gh_config_dir` (path resolver, mirrors the `.loom/tokens/`
  convention), `publish_github_app_token` (atomic write-then-rename of
  `hosts.yml` + one-time `config.yml`), plus unit tests.
- `loom-daemon/src/main.rs`: both the startup preflight and the refresh tick
  now call `publish_github_app_token` instead of `std::env::set_var`. The
  one remaining env mutation (`GH_CONFIG_DIR`, plus clearing any ambient
  `GH_TOKEN`/`GITHUB_TOKEN` so it can't outrank the file-based token) fires
  **at most once per process lifetime** — commented in place, naming the
  race and why the residual window is accepted.
- `defaults/docs/github-authentication.md`: documents the new delivery
  mechanism, and adds the requested "long-running sweep children and
  credential snapshots" section — a dispatched sweep child's forge
  credential is a snapshot at spawn time, not a live subscription, so a
  sweep running past the credential's lifetime gets no automatic fallback
  once it 401s.
- `.gitignore`: adds `.loom/gh-config/` (host-local, never committed —
  mirrors `.loom/tokens/`).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Post-startup `set_var("GH_TOKEN")` eliminated via shared store / `GH_CONFIG_DIR`, rationale recorded | ✅ | Both sites replaced with `publish_github_app_token`; rationale in code comments + this PR body |
| Startup site removed or comment on residual race | ✅ | Removed entirely (no `set_var("GH_TOKEN")` remains anywhere in production code); the one `GH_CONFIG_DIR` env write left is commented in place naming the once-only window |
| `github-authentication.md` documents >1h-child trade-off | ✅ | New "Long-running sweep children and credential snapshots (#4458)" section |
| Fallback-first preserved (unconfigured hosts byte-identical) | ✅ | All new code is gated on `minted_gh_token.is_some()` — `NotConfigured`/`Error` paths are untouched |
| No secret in logs/status/reports | ✅ | Token never passed to `log!`/`CredentialPreflightReport`; only the existing non-secret fingerprint is |
| Existing `credential_preflight` tests pass unchanged | ✅ | `cargo test -p loom-daemon --lib credential_preflight` → 30 passed (26 pre-existing + 4 new file-write tests) |
| Grep gate: no non-test `set_var("GH_TOKEN")` remains | ✅ | `grep -rn 'set_var("GH_TOKEN"' src/` → only the one pre-existing `#[cfg(test)]` usage in `run_never_includes_a_token_looking_value_in_message` (unrelated #4005 ambient-fallback test) |

## Test Plan

- `cargo check -p loom-daemon` — clean
- `cargo clippy -p loom-daemon --all-targets` — no warnings
- `cargo fmt --all -- --check` — clean
- `cargo test -p loom-daemon --lib` — 2456 passed, 0 failed
- `cargo test -p loom-daemon --bin loom-daemon` — 46 passed, 0 failed (includes the `#4456` `gh_token_guard_tests`, kept and now driving the file-write path's own change-detection)
- New unit tests for `publish_github_app_token` (atomic write, rotation overwrites `hosts.yml` but not `config.yml`, 0600/0700 permissions) and `gh_hosts_yaml` (pure content builder)
- Manually reproduced the `gh` "multi-account migration" bug against a fake token + bare `hosts.yml` (no `config.yml`), then confirmed adding `config.yml` with `version: 1` fixes it, against the real `gh` 2.96.0 binary in this environment
- Edge cases: empty store at spawn (unconfigured host — untouched code path, ambient env unchanged); mid-sweep rotation for dispatched sweep children is documented as a known limitation, not fixed (see the new doc section)

Closes #4458