### PR TITLE
fix(daemon): warn before a plist/unit re-render drops installed env keys

### DIFF
--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -75,6 +75,7 @@
 #   ./.loom/scripts/cli/loom-daemon-start.sh --no-systemd    Linux only: use legacy nohup instead of a systemd --user service
 #   ./.loom/scripts/cli/loom-daemon-start.sh --print-plist   Print the LaunchAgent plist that WOULD be installed and exit (no side effects)
 #   ./.loom/scripts/cli/loom-daemon-start.sh --print-unit    Print the systemd --user unit that WOULD be installed and exit (no side effects)
+#   ./.loom/scripts/cli/loom-daemon-start.sh --force-env     Suppress the dropped-env-key warning (#4522) for an intentional narrower re-render
 #   ./.loom/scripts/cli/loom-daemon-start.sh --help
 #
 # Environment:
@@ -258,6 +259,95 @@ extract_plist_path_value() {
         /<key>PATH<\/key>/ { want=1; next }
         want { sub(/^[ \t]*<string>/, ""); sub(/<\/string>[ \t]*$/, ""); print; exit }
     ' "$plist_file"
+}
+
+# ---------- dropped-env-key detection (#4522) ----------
+# Root cause under test: render_launchd_plist / render_systemd_unit render the
+# EnvironmentVariables dict / Environment= lines strictly from whatever THIS
+# invocation has exported ("Respected when already exported" note above). Any
+# invocation missing the operator's exports (a watchdog, a bare re-run, another
+# tool shelling out to this script) silently replaces a richer installed
+# plist/unit with a narrower one -- e.g. every LOOM_SAFEHOUSE_* key and
+# LOOM_WORK_FINDER=1 quietly gone. The functions below detect that KEY REMOVAL
+# (not a value change -- see the PATH-specific drift check above for that) so
+# it is surfaced instead of silently applied.
+
+# extract_plist_env_keys <plist_file> — list of every <key>...</key> entry
+# inside the EnvironmentVariables dict, one per line. Extends
+# extract_plist_path_value's textual-awk approach (no plutil/XML-parser
+# dependency) from a single key to the whole dict.
+extract_plist_env_keys() {
+    local plist_file="$1"
+    [[ -f "$plist_file" ]] || return 1
+    awk '
+        /<key>EnvironmentVariables<\/key>/ { in_env=1; next }
+        in_env && /<\/dict>/ { exit }
+        in_env && /<key>/ {
+            line=$0
+            sub(/^[ \t]*<key>/, "", line)
+            sub(/<\/key>.*$/, "", line)
+            print line
+        }
+    ' "$plist_file"
+}
+
+# extract_systemd_env_keys <unit_file> — list of every `Environment=KEY=...`
+# key in a rendered systemd unit, one per line. The systemd analog of
+# extract_plist_env_keys above.
+extract_systemd_env_keys() {
+    local unit_file="$1"
+    [[ -f "$unit_file" ]] || return 1
+    sed -n 's/^Environment=\([^=]*\)=.*/\1/p' "$unit_file"
+}
+
+# warn_dropped_env_keys <old_file> <new_file> <extractor_function_name> — compare
+# the env-var KEY sets (not values) between an already-installed plist/unit and
+# a freshly-rendered replacement; warn (listing the keys) when the replacement
+# DROPS a key the installed file carried. <extractor_function_name> is
+# extract_plist_env_keys or extract_systemd_env_keys.
+#
+#   - A missing old_file (first-ever install -- nothing installed yet) is not a
+#     drop: returns silently, no warning.
+#   - --force-env (FORCE_ENV=true) acknowledges an intentional narrowing (e.g.
+#     an explicit minimal re-render) and suppresses the warning.
+#   - A dropped LOOM_SAFEHOUSE_* key gets a specific migration hint (the
+#     "safehouse" block in .loom/config.json + --from-config, #4353) instead of
+#     a generic warning.
+warn_dropped_env_keys() {
+    local old_file="$1" new_file="$2" extractor="$3"
+    [[ -f "$old_file" ]] || return 0
+    [[ "${FORCE_ENV:-false}" == "true" ]] && return 0
+
+    local old_keys new_keys
+    old_keys="$("$extractor" "$old_file" 2>/dev/null || true)"
+    [[ -z "$old_keys" ]] && return 0
+    new_keys="$("$extractor" "$new_file" 2>/dev/null || true)"
+
+    local dropped=() k nk hit
+    while IFS= read -r k; do
+        [[ -z "$k" ]] && continue
+        hit=false
+        if [[ -n "$new_keys" ]]; then
+            while IFS= read -r nk; do
+                if [[ "$nk" == "$k" ]]; then hit=true; break; fi
+            done <<< "$new_keys"
+        fi
+        [[ "$hit" == "false" ]] && dropped+=("$k")
+    done <<< "$old_keys"
+
+    [[ "${#dropped[@]}" -eq 0 ]] && return 0
+
+    warn ""
+    warn "WARNING: re-rendering $new_file drops ${#dropped[@]} env key(s) present in the installed $old_file:"
+    for k in "${dropped[@]}"; do
+        if [[ "$k" == LOOM_SAFEHOUSE_* ]]; then
+            warn "  - $k (config-tier equivalent: the \"safehouse\" block in .loom/config.json + --from-config, #4353)"
+        else
+            warn "  - $k"
+        fi
+    done
+    warn "This usually means this invocation ran without the operator's exported env (a watchdog / automated re-render / a bare re-run from a different shell)."
+    warn "Pass --force-env to acknowledge an intentional narrowing and suppress this warning."
 }
 
 # render_launchd_plist <label> <daemon_bin> <workdir> <log_path>
@@ -784,6 +874,11 @@ NO_LAUNCHD=false
 NO_SYSTEMD=false
 PRINT_PLIST=false
 PRINT_UNIT=false
+# --force-env (#4522): acknowledges an intentional narrower re-render and
+# suppresses warn_dropped_env_keys' warning. Script-only (like --print-plist),
+# not a daemon autonomy flag -- excluded from the persisted .daemon.flags file
+# below.
+FORCE_ENV=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --help|-h) show_help; exit 0 ;;
@@ -797,6 +892,7 @@ while [[ $# -gt 0 ]]; do
         --no-systemd) NO_SYSTEMD=true; shift ;;
         --print-plist) PRINT_PLIST=true; shift ;;
         --print-unit) PRINT_UNIT=true; shift ;;
+        --force-env) FORCE_ENV=true; shift ;;
         *) err "Unknown option '$1'"; echo "Use --help for usage" >&2; exit 1 ;;
     esac
 done
@@ -979,11 +1075,11 @@ fi
 # `loom-daemon-update.sh` reads this file to restart with EXACTLY the same
 # autonomy flags after a rebuild — the FLAGS-OFF/opt-in contract must never
 # widen across an update. Script-only flags that don't describe daemon
-# autonomy state (--foreground/--fg, --help/-h) are filtered out; everything
-# else (--from-config, --work-finder, --health-gate, --no-work-finder,
-# --no-health-gate) is preserved verbatim, one per line. Written on every
-# start attempt (success or failure) so the record always reflects the most
-# recent invocation.
+# autonomy state (--foreground/--fg, --help/-h, --print-plist, --print-unit,
+# --force-env, #4522) are filtered out; everything else (--from-config,
+# --work-finder, --health-gate, --no-work-finder, --no-health-gate) is
+# preserved verbatim, one per line. Written on every start attempt (success or
+# failure) so the record always reflects the most recent invocation.
 FLAGS_FILE="$DAEMON_STATE_HOME/.daemon.flags"
 : > "$FLAGS_FILE"
 # Guard the array expansion: a bare invocation (the common case) leaves
@@ -993,7 +1089,7 @@ FLAGS_FILE="$DAEMON_STATE_HOME/.daemon.flags"
 if [[ "${#ORIGINAL_ARGS[@]}" -gt 0 ]]; then
     for _flag_arg in "${ORIGINAL_ARGS[@]}"; do
         case "$_flag_arg" in
-            --foreground|--fg|--help|-h|--no-launchd|--no-systemd|--print-plist|--print-unit) continue ;;
+            --foreground|--fg|--help|-h|--no-launchd|--no-systemd|--print-plist|--print-unit|--force-env) continue ;;
             *) echo "$_flag_arg" >> "$FLAGS_FILE" ;;
         esac
     done
@@ -1055,7 +1151,8 @@ fi
 
 # ---------- --print-plist: pure inspection, no side effects ----------
 if [[ "$PRINT_PLIST" == "true" ]]; then
-    render_launchd_plist "$(resolve_launchd_label)" "$DAEMON_BIN" "$REPO_ROOT" "$START_LOG"
+    _plist_rendered="$(render_launchd_plist "$(resolve_launchd_label)" "$DAEMON_BIN" "$REPO_ROOT" "$START_LOG")"
+    printf '%s\n' "$_plist_rendered"
     # PATH-drift check (#4172): if a live plist is already installed for this
     # label, compare its PATH against the one just rendered and warn (stderr
     # only -- READ-ONLY, no side effect) when they differ. This is what makes
@@ -1072,13 +1169,32 @@ if [[ "$PRINT_PLIST" == "true" ]]; then
                 echo "+ new:  $PLIST_PATH_VALUE"
             } >&2
         fi
+        # Dropped-env-key check (#4522): read-only inspection counterpart of
+        # the same check the real install path below runs before overwriting.
+        _plist_new_tmp="$(mktemp "${TMPDIR:-/tmp}/loom-print-plist.XXXXXX")"
+        printf '%s\n' "$_plist_rendered" > "$_plist_new_tmp"
+        warn_dropped_env_keys "$_live_plist" "$_plist_new_tmp" extract_plist_env_keys
+        rm -f "$_plist_new_tmp"
     fi
     exit 0
 fi
 
 # ---------- --print-unit: pure inspection, no side effects (#4268) ----------
 if [[ "$PRINT_UNIT" == "true" ]]; then
-    render_systemd_unit "$DAEMON_BIN" "$REPO_ROOT" "$START_LOG"
+    _unit_rendered="$(render_systemd_unit "$DAEMON_BIN" "$REPO_ROOT" "$START_LOG")"
+    printf '%s\n' "$_unit_rendered"
+    # Dropped-env-key check (#4522): read-only inspection counterpart of the
+    # same check the real install path below runs before overwriting.
+    _live_unit=""
+    if declare -f resolve_systemd_unit_path >/dev/null 2>&1; then
+        _live_unit="$(resolve_systemd_unit_path 2>/dev/null || true)"
+    fi
+    if [[ -n "$_live_unit" && -f "$_live_unit" ]]; then
+        _unit_new_tmp="$(mktemp "${TMPDIR:-/tmp}/loom-print-unit.XXXXXX")"
+        printf '%s\n' "$_unit_rendered" > "$_unit_new_tmp"
+        warn_dropped_env_keys "$_live_unit" "$_unit_new_tmp" extract_systemd_env_keys
+        rm -f "$_unit_new_tmp"
+    fi
     exit 0
 fi
 
@@ -1110,7 +1226,13 @@ if [[ "$USE_LAUNCHD" == "true" ]]; then
     PLIST_FILE="$PLIST_DIR/${LAUNCHD_LABEL}.plist"
     mkdir -p "$PLIST_DIR"
 
-    render_launchd_plist "$LAUNCHD_LABEL" "$DAEMON_BIN" "$REPO_ROOT" "$START_LOG" > "$PLIST_FILE"
+    # Render to a scratch file first -- NOT directly over $PLIST_FILE -- so the
+    # dropped-env-key check (#4522) below can compare against whatever
+    # $PLIST_FILE already contains before it gets clobbered.
+    _PLIST_NEW_TMP="$(mktemp "$PLIST_DIR/.${LAUNCHD_LABEL}.new.XXXXXX")"
+    render_launchd_plist "$LAUNCHD_LABEL" "$DAEMON_BIN" "$REPO_ROOT" "$START_LOG" > "$_PLIST_NEW_TMP"
+    warn_dropped_env_keys "$PLIST_FILE" "$_PLIST_NEW_TMP" extract_plist_env_keys
+    mv "$_PLIST_NEW_TMP" "$PLIST_FILE"
 
     # Harden the rendered plist when it carries a forwarded credential
     # (#4005): the token-forwarding loop in render_launchd_plist writes any
@@ -1203,7 +1325,13 @@ if [[ "$IS_LINUX_SYSTEMD" == "true" ]]; then
     SYSTEMD_UNIT_PATH="$(resolve_systemd_unit_path)"
     mkdir -p "$SYSTEMD_UNIT_DIR"
 
-    render_systemd_unit "$DAEMON_BIN" "$REPO_ROOT" "$START_LOG" > "$SYSTEMD_UNIT_PATH"
+    # Render to a scratch file first -- NOT directly over $SYSTEMD_UNIT_PATH --
+    # so the dropped-env-key check (#4522) below can compare against whatever
+    # $SYSTEMD_UNIT_PATH already contains before it gets clobbered.
+    _UNIT_NEW_TMP="$(mktemp "$SYSTEMD_UNIT_DIR/.${SYSTEMD_UNIT}.new.XXXXXX")"
+    render_systemd_unit "$DAEMON_BIN" "$REPO_ROOT" "$START_LOG" > "$_UNIT_NEW_TMP"
+    warn_dropped_env_keys "$SYSTEMD_UNIT_PATH" "$_UNIT_NEW_TMP" extract_systemd_env_keys
+    mv "$_UNIT_NEW_TMP" "$SYSTEMD_UNIT_PATH"
 
     # Harden the rendered unit when it carries a forwarded credential (#4005
     # analog): the env-forwarding loop in render_systemd_unit writes any exported

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -760,6 +760,259 @@ else
 fi
 rm -rf "$SH4_HOME"
 
+# ---------- dropped-env-key detection on re-render (#4522) ----------
+# Root cause under test: render_launchd_plist / render_systemd_unit render the
+# EnvironmentVariables dict / Environment= lines strictly from whatever THIS
+# invocation has exported -- so a re-render from a context missing the
+# operator's exports (a watchdog, a bare re-run, another tool shelling out to
+# this script) used to silently replace a richer installed plist/unit with a
+# narrower one (every LOOM_SAFEHOUSE_* key + LOOM_WORK_FINDER gone, no trace).
+# warn_dropped_env_keys() now diffs the KEY sets (not values) between the
+# installed file and the freshly-rendered replacement and warns before the
+# overwrite happens.
+
+# ---------- launchd (plist) path -- exercised read-only via --print-plist,
+# same technique as the #4172 PATH-drift tests above (the real launchd
+# install branch is Darwin-gated with no test-force seam, matching every
+# other launchd install test in this suite/repo).
+DEK_HOME="$(mktemp -d)"
+mkdir -p "$DEK_HOME/Library/LaunchAgents"
+DEK_LABEL="com.rjwalters.loom-daemon-dek-test"
+DEK_LIVE_PLIST="$DEK_HOME/Library/LaunchAgents/${DEK_LABEL}.plist"
+
+# DEK1. First-ever install (no existing plist) must NOT warn.
+dek1_out=$( env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE -u LOOM_SAFEHOUSE_ENABLED \
+    HOME="$DEK_HOME" LOOM_LAUNCHD_LABEL="$DEK_LABEL" LOOM_DAEMON_BIN="$FAKE_BIN" \
+    bash "$START_SCRIPT" --print-plist 2>&1 >/dev/null )
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! echo "$dek1_out" | grep -qi 'drops.*env key'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} dropped-env-key (plist): first-ever install (no existing plist) never warns (#4522)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} dropped-env-key (plist): first-ever install (no existing plist) never warns"
+    echo "  output: $dek1_out"
+fi
+
+# Install the "rich" plist (LOOM_SAFEHOUSE_ENABLED + LOOM_WORK_FINDER present).
+env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE HOME="$DEK_HOME" LOOM_LAUNCHD_LABEL="$DEK_LABEL" \
+    LOOM_SAFEHOUSE_ENABLED=1 LOOM_WORK_FINDER=1 LOOM_DAEMON_BIN="$FAKE_BIN" \
+    bash "$START_SCRIPT" --print-plist > "$DEK_LIVE_PLIST" 2>/dev/null
+
+# DEK2. Re-rendering with LOOM_SAFEHOUSE_ENABLED no longer exported warns and
+#       names the dropped key, with the LOOM_SAFEHOUSE_* migration hint.
+dek2_out=$( env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE -u LOOM_SAFEHOUSE_ENABLED \
+    HOME="$DEK_HOME" LOOM_LAUNCHD_LABEL="$DEK_LABEL" LOOM_DAEMON_BIN="$FAKE_BIN" \
+    bash "$START_SCRIPT" --print-plist 2>&1 >/dev/null )
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$dek2_out" | grep -qi 'drops 1 env key' && echo "$dek2_out" | grep -q 'LOOM_SAFEHOUSE_ENABLED'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} dropped-env-key (plist): re-render missing an exported key warns and names it (#4522)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} dropped-env-key (plist): re-render missing an exported key warns and names it"
+    echo "  output: $dek2_out"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$dek2_out" | grep -q 'safehouse.*block.*--from-config'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} dropped-env-key (plist): LOOM_SAFEHOUSE_* drop prints the config-tier migration hint (#4353)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} dropped-env-key (plist): LOOM_SAFEHOUSE_* drop prints the config-tier migration hint"
+    echo "  output: $dek2_out"
+fi
+
+# DEK3. Re-rendering with the SAME (or a superset of) keys does not warn.
+dek3_out=$( env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE HOME="$DEK_HOME" LOOM_LAUNCHD_LABEL="$DEK_LABEL" \
+    LOOM_SAFEHOUSE_ENABLED=1 LOOM_WORK_FINDER=1 LOOM_DAEMON_PATH_EXTRA=/extra/bin LOOM_DAEMON_BIN="$FAKE_BIN" \
+    bash "$START_SCRIPT" --print-plist 2>&1 >/dev/null )
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! echo "$dek3_out" | grep -qi 'drops.*env key'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} dropped-env-key (plist): re-render with the same/superset keys never warns (#4522)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} dropped-env-key (plist): re-render with the same/superset keys never warns"
+    echo "  output: $dek3_out"
+fi
+
+# DEK4. --force-env suppresses the warning for an intentional narrowing.
+dek4_out=$( env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE -u LOOM_SAFEHOUSE_ENABLED \
+    HOME="$DEK_HOME" LOOM_LAUNCHD_LABEL="$DEK_LABEL" LOOM_DAEMON_BIN="$FAKE_BIN" \
+    bash "$START_SCRIPT" --print-plist --force-env 2>&1 >/dev/null )
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! echo "$dek4_out" | grep -qi 'drops.*env key'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} dropped-env-key (plist): --force-env suppresses the warning (#4522)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} dropped-env-key (plist): --force-env suppresses the warning"
+    echo "  output: $dek4_out"
+fi
+rm -rf "$DEK_HOME"
+
+# ---------- systemd (unit) path -- exercised through the REAL install site
+# (mv over $SYSTEMD_UNIT_PATH), reusing the LOOM_SYSTEMD_FORCE + stub
+# systemctl seam already established above (S1-S5) so this covers the actual
+# overwrite code path, not just a read-only render.
+DEK_SD_BIN="$WORKDIR/dek-sd-bin"; mkdir -p "$DEK_SD_BIN"
+DEK_SD_LOG="$WORKDIR/dek-sd.log"; : > "$DEK_SD_LOG"
+cat > "$DEK_SD_BIN/systemctl" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$DEK_SD_LOG"
+if [[ "\${1:-}" == "--user" ]]; then shift; fi
+case "\${1:-}" in
+  show) echo "\$\$" ;;
+  *)    exit 0 ;;
+esac
+EOF
+chmod +x "$DEK_SD_BIN/systemctl"
+DEK_SD_UNIT="loom-daemon-dek-test-$$.service"
+DEK_SD_HOME="$(mktemp -d)"; mkdir -p "$DEK_SD_HOME/.loom/logs"
+DEK_SD_UNIT_PATH="$DEK_SD_HOME/.config/systemd/user/$DEK_SD_UNIT"
+
+# DEK5. First-ever install (no existing unit) must NOT warn.
+dek5_out=$( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE -u LOOM_SAFEHOUSE_ENABLED \
+    PATH="$DEK_SD_BIN:$PATH" HOME="$DEK_SD_HOME" \
+    LOOM_SYSTEMD_FORCE=1 LOOM_SYSTEMD_UNIT="$DEK_SD_UNIT" \
+    LOOM_DAEMON_BIN="$FAKE_BIN" \
+    LOOM_SOCKET_PATH="$DEK_SD_HOME/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$DEK_SD_HOME/.loom/autonomy-desired" \
+    bash "$START_SCRIPT" --no-launchd 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! echo "$dek5_out" | grep -qi 'drops.*env key'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} dropped-env-key (systemd): first-ever install (no existing unit) never warns (#4522)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} dropped-env-key (systemd): first-ever install (no existing unit) never warns"
+    echo "  output: $dek5_out"
+fi
+if [[ -f "$DEK_SD_HOME/.loom/.daemon.pid" ]]; then
+    kill "$(cat "$DEK_SD_HOME/.loom/.daemon.pid" 2>/dev/null)" 2>/dev/null || true
+    rm -f "$DEK_SD_HOME/.loom/.daemon.pid"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -f "$DEK_SD_UNIT_PATH" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} dropped-env-key (systemd): first-ever install still writes the unit file"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} dropped-env-key (systemd): first-ever install still writes the unit file"
+fi
+
+# DEK6. Re-render with fewer keys (LOOM_SAFEHOUSE_ENABLED dropped from the
+#       invoking env) warns and names the dropped key, before the unit is
+#       overwritten. Re-run with the rich env first so the installed unit
+#       actually carries the key.
+: > "$DEK_SD_LOG"
+sleep 30 & DEK_SD_PID1=$!
+( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    PATH="$DEK_SD_BIN:$PATH" HOME="$DEK_SD_HOME" \
+    LOOM_SYSTEMD_FORCE=1 LOOM_SYSTEMD_UNIT="$DEK_SD_UNIT" \
+    LOOM_SAFEHOUSE_ENABLED=1 LOOM_WORK_FINDER=1 \
+    LOOM_DAEMON_BIN="$FAKE_BIN" \
+    LOOM_SOCKET_PATH="$DEK_SD_HOME/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$DEK_SD_HOME/.loom/autonomy-desired" \
+    bash "$START_SCRIPT" --no-launchd >/dev/null 2>&1 )
+kill "$DEK_SD_PID1" 2>/dev/null || true
+if [[ -f "$DEK_SD_HOME/.loom/.daemon.pid" ]]; then
+    kill "$(cat "$DEK_SD_HOME/.loom/.daemon.pid" 2>/dev/null)" 2>/dev/null || true
+    rm -f "$DEK_SD_HOME/.loom/.daemon.pid"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -f "$DEK_SD_UNIT_PATH" ]] && grep -q 'LOOM_SAFEHOUSE_ENABLED' "$DEK_SD_UNIT_PATH"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} dropped-env-key (systemd): fixture install carries LOOM_SAFEHOUSE_ENABLED (setup for DEK6b)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} dropped-env-key (systemd): fixture install carries LOOM_SAFEHOUSE_ENABLED"
+    cat "$DEK_SD_UNIT_PATH" 2>/dev/null | sed 's/^/    /'
+fi
+
+sleep 30 & DEK_SD_PID2=$!
+dek6_out=$( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE -u LOOM_SAFEHOUSE_ENABLED \
+    PATH="$DEK_SD_BIN:$PATH" HOME="$DEK_SD_HOME" \
+    LOOM_SYSTEMD_FORCE=1 LOOM_SYSTEMD_UNIT="$DEK_SD_UNIT" \
+    LOOM_DAEMON_BIN="$FAKE_BIN" \
+    LOOM_SOCKET_PATH="$DEK_SD_HOME/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$DEK_SD_HOME/.loom/autonomy-desired" \
+    bash "$START_SCRIPT" --no-launchd 2>&1 )
+kill "$DEK_SD_PID2" 2>/dev/null || true
+if [[ -f "$DEK_SD_HOME/.loom/.daemon.pid" ]]; then
+    kill "$(cat "$DEK_SD_HOME/.loom/.daemon.pid" 2>/dev/null)" 2>/dev/null || true
+    rm -f "$DEK_SD_HOME/.loom/.daemon.pid"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$dek6_out" | grep -qi 'drops 1 env key' && echo "$dek6_out" | grep -q 'LOOM_SAFEHOUSE_ENABLED' \
+    && echo "$dek6_out" | grep -q 'safehouse.*block.*--from-config'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} dropped-env-key (systemd): real re-render missing a key warns, names it, and prints the migration hint (#4522)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} dropped-env-key (systemd): real re-render missing a key warns, names it, and prints the migration hint"
+    echo "  output: $dek6_out"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -f "$DEK_SD_UNIT_PATH" ]] && ! grep -q 'LOOM_SAFEHOUSE_ENABLED' "$DEK_SD_UNIT_PATH"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} dropped-env-key (systemd): the WARNED narrowing still actually installs (warn, don't block)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} dropped-env-key (systemd): the WARNED narrowing still actually installs"
+fi
+
+# DEK7. --force-env suppresses the warning on the real install path too.
+sleep 30 & DEK_SD_PID3=$!
+( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    PATH="$DEK_SD_BIN:$PATH" HOME="$DEK_SD_HOME" \
+    LOOM_SYSTEMD_FORCE=1 LOOM_SYSTEMD_UNIT="$DEK_SD_UNIT" \
+    LOOM_SAFEHOUSE_ENABLED=1 LOOM_WORK_FINDER=1 \
+    LOOM_DAEMON_BIN="$FAKE_BIN" \
+    LOOM_SOCKET_PATH="$DEK_SD_HOME/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$DEK_SD_HOME/.loom/autonomy-desired" \
+    bash "$START_SCRIPT" --no-launchd >/dev/null 2>&1 )
+kill "$DEK_SD_PID3" 2>/dev/null || true
+if [[ -f "$DEK_SD_HOME/.loom/.daemon.pid" ]]; then
+    kill "$(cat "$DEK_SD_HOME/.loom/.daemon.pid" 2>/dev/null)" 2>/dev/null || true
+    rm -f "$DEK_SD_HOME/.loom/.daemon.pid"
+fi
+sleep 30 & DEK_SD_PID4=$!
+dek7_out=$( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE -u LOOM_SAFEHOUSE_ENABLED \
+    PATH="$DEK_SD_BIN:$PATH" HOME="$DEK_SD_HOME" \
+    LOOM_SYSTEMD_FORCE=1 LOOM_SYSTEMD_UNIT="$DEK_SD_UNIT" \
+    LOOM_DAEMON_BIN="$FAKE_BIN" \
+    LOOM_SOCKET_PATH="$DEK_SD_HOME/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$DEK_SD_HOME/.loom/autonomy-desired" \
+    bash "$START_SCRIPT" --no-launchd --force-env 2>&1 )
+kill "$DEK_SD_PID4" 2>/dev/null || true
+if [[ -f "$DEK_SD_HOME/.loom/.daemon.pid" ]]; then
+    kill "$(cat "$DEK_SD_HOME/.loom/.daemon.pid" 2>/dev/null)" 2>/dev/null || true
+    rm -f "$DEK_SD_HOME/.loom/.daemon.pid"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! echo "$dek7_out" | grep -qi 'drops.*env key'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} dropped-env-key (systemd): --force-env suppresses the warning on the real install path (#4522)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} dropped-env-key (systemd): --force-env suppresses the warning on the real install path"
+    echo "  output: $dek7_out"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$dek7_out" | grep -q -- '--force-env'; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} dropped-env-key (systemd): --force-env is excluded from the persisted .daemon.flags file"
+elif [[ -f "$DEK_SD_HOME/.loom/.daemon.flags" ]] && grep -q -- '--force-env' "$DEK_SD_HOME/.loom/.daemon.flags"; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} dropped-env-key (systemd): --force-env is excluded from the persisted .daemon.flags file"
+else
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} dropped-env-key (systemd): --force-env is excluded from the persisted .daemon.flags file"
+fi
+rm -rf "$DEK_SD_HOME"
+
 # ---------- summary ----------
 echo
 echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"


### PR DESCRIPTION
## What changed

`loom-daemon-start.sh` renders the launchd `EnvironmentVariables` dict / systemd
`Environment=` lines strictly from whatever the invoking process has exported
("Respected when already exported"). Any invocation missing the operator's
exports silently replaced the richer installed plist/unit with a narrower one —
every `LOOM_SAFEHOUSE_*` key, `LOOM_WORK_FINDER`, etc. gone, with no trace.

This PR adds a diff-and-warn step before either overwrite site:

- `extract_plist_env_keys()` / `extract_systemd_env_keys()` — lightweight
  textual extraction (awk/sed, no `plutil`/XML-parser dependency) of the env
  key set from an installed plist/unit, extending the existing
  `extract_plist_path_value()` pattern from a single key to the whole dict.
- `warn_dropped_env_keys(old_file, new_file, extractor)` — renders the
  replacement to a **scratch file first** (never overwrites in place before
  comparing), diffs the KEY sets (not values) against the installed file, and
  `warn()`s (matching the script's existing `warn()`/`err()` style) when a key
  is dropped. A `LOOM_SAFEHOUSE_*` drop gets a specific migration hint ("move
  to the `safehouse` block in `.loom/config.json` + `--from-config`", #4353)
  instead of a generic warning.
- Wired into **both** the real launchd write site and the real systemd write
  site (parity — the curator flagged the systemd path as an identical gap).
- Wired into `--print-plist` / `--print-unit` too (read-only inspection,
  cross-platform testable, same pattern as the existing #4172 PATH-drift
  check).
- New `--force-env` flag suppresses the warning for an intentional narrower
  re-render (excluded from the persisted `.daemon.flags` file, like
  `--print-plist`/`--print-unit`).
- A missing installed file (first-ever install) never warns.
- The warning is advisory only — the re-render still installs (warn, don't
  block), matching every other advisory check in this script (PATH drift,
  systemd-user-manager-unreachable, etc.).

## Investigative finding: which automated path caused the incident

Traced through every invoker of `loom-daemon-start.sh`:

- **`loom-daemon-watchdog.sh`**: auto-remediation is `launchctl kickstart
  <label>` (**not** a re-invocation of `loom-daemon-start.sh`) — it relaunches
  the *existing* plist unchanged. Not implicated.
- **The in-daemon autonomous self-update loop** (`autonomous.autoUpdate`,
  #4055): uses `loom-daemon-update.sh --no-restart` + the supervised
  `RestartDaemon` IPC primitive, which also never re-renders the plist (launchd's
  `KeepAlive:{SuccessfulExit:true}` just relaunches the same on-disk file). Not
  implicated.
- **`loom-daemon-update.sh`'s refused-restart fallback** (`perform_relaunch` /
  `perform_systemd_relaunch`, #4118/#4126): this *does* re-render the plist/unit,
  but it already harvests and re-exports the live file's `LOOM_*`/token env
  before re-rendering (or **aborts** with exit 6 if the harvest fails) — and
  that guard was merged 2026-07-28, the day *before* the incident. Not
  implicated (and was already safe by design).
- **`scripts/loom`'s `loom restart` verb** (`loom_cmd_restart()`, lines
  284–317): this is the culprit. It first tries the supervised IPC primitive
  (`loom-daemon restart`, safe — no re-render). But when that is "unavailable
  or refused (not launchd-managed, or not currently running)" it falls back to:
  ```bash
  "$stop_target" --restarting
  exec "$start_target" ${passthrough[@]+"${passthrough[@]}"}
  ```
  — a bare `exec` of `loom-daemon-start.sh` with only the CLI passthrough args,
  **no env re-export at all**. It inherits exactly whatever `LOOM_*` vars
  happen to be exported in the shell/session that ran `loom restart` — a fresh
  terminal, a different SSH session, or any wrapper that doesn't re-source the
  operator's shell profile reproduces the incident exactly (rich plist →
  minimal plist, silently). This matches the incident's "around a
  drain-restart cycle" description precisely (`loom restart` is literally the
  "drain-and-roll" verb in the code comments).

This PR's diff-and-warn mechanism now makes that fallback path (and every
other invocation, present or future) self-diagnosing — the next occurrence
prints a warning instead of a silent narrowing. A natural follow-up (not
included here, to keep this PR scoped to the diff-and-warn mechanism the issue
asked for) would be applying the same harvest-and-preserve pattern
`perform_relaunch` already uses to `scripts/loom`'s stop-then-start fallback.

## Test plan

Extended `defaults/scripts/tests/test-loom-daemon-start.sh` (all cases from
the issue's test plan, 12 new assertions, suite total 60/60 passing):

- Plist path (via `--print-plist`, cross-platform, same technique as the
  existing #4172 PATH-drift tests since the real launchd install branch is
  Darwin-gated with no test-force seam anywhere else in this suite):
  first-ever install never warns; a re-render missing a previously-exported
  key warns and names it; the `LOOM_SAFEHOUSE_*` migration hint prints;
  same/superset keys never warn; `--force-env` suppresses.
- Systemd path — exercised through the **real install site** (the
  `LOOM_SYSTEMD_FORCE=1` + stub-`systemctl` seam already established in this
  suite, so this covers the actual overwrite code path, not just a read-only
  render): first-ever install never warns; a real re-render missing a key
  warns, names it, prints the migration hint, and still installs (warn, don't
  block); `--force-env` suppresses on the real path; `--force-env` is excluded
  from the persisted `.daemon.flags` file.

Also ran (all green, no regressions):
- `defaults/scripts/tests/test-loom-daemon-launchd-plist.sh` (42/42)
- `defaults/scripts/tests/test-loom-daemon-stop.sh` (33/33)
- `shellcheck --severity=warning` clean on both changed files (CI's exact
  invocation)

`test-loom-daemon-update.sh` was not touched by this PR (verified via `git
diff --stat main`) and times out locally due to an unrelated slow `cargo
build` step in this sandbox — pre-existing, not a regression from this change.

Closes #4522