### PR TITLE
harden(sync-labels): honor --, widen the gitea veto to config tiers, tighten NWO, preflight --repo before deletions

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -3035,8 +3035,14 @@ done
 
 `--dry-run` is deliberately forge-free (it reports intent from labels.yml alone
 and makes zero `gh` calls), so it also validates the parse and the NWO offline.
-`--repo` is GitHub-only — for a Gitea root, run `sync-labels.sh` from a checkout
-of that repo so the Gitea helpers can resolve a base URL and token.
+Because that means a dry run cannot tell a typo'd NWO apart from a repo that
+really exists, the **real** run preflights the named target with `gh repo view`
+before deleting anything and aborts if it is missing or read-only (#4524) —
+nothing is deleted when the preflight fails. `--repo` is GitHub-only — an
+explicitly configured Gitea forge rejects it, whether that comes from
+`LOOM_FORGE_TYPE=gitea` or `forge.type: gitea` in any config tier. For a Gitea
+root, run `sync-labels.sh` from a checkout of that repo so the Gitea helpers can
+resolve a base URL and token.
 
 **3. Refresh a stale install.** A root installed before the machine-level daemon
 model carries a committed file-copy of `.loom/` that **shadows** the machine

--- a/defaults/scripts/sync-labels.sh
+++ b/defaults/scripts/sync-labels.sh
@@ -10,11 +10,12 @@
 # Supports both GitHub (via the gh CLI) and Gitea (via the forge API).
 #
 # Usage:
-#   .loom/scripts/sync-labels.sh [WORKTREE_PATH]
-#   .loom/scripts/sync-labels.sh --repo OWNER/NAME [--dry-run] [WORKTREE_PATH]
+#   .loom/scripts/sync-labels.sh [--] [WORKTREE_PATH]
+#   .loom/scripts/sync-labels.sh --repo OWNER/NAME [--dry-run] [--] [WORKTREE_PATH]
 #
 #   WORKTREE_PATH  Directory containing .github/labels.yml and a git remote.
-#                  Defaults to the current directory.
+#                  Defaults to the current directory. `--` ends option parsing,
+#                  so a path that begins with `-` can still be passed.
 #
 # --repo OWNER/NAME (#4498) retargets the sync at an arbitrary GitHub repo
 # while still reading labels.yml from WORKTREE_PATH. Because every GitHub label
@@ -25,10 +26,14 @@
 #     .loom/scripts/sync-labels.sh --repo "$r"
 #   done
 #
-# --repo bypasses forge detection entirely (the target is named, not inferred
-# from a git remote) and is GitHub-only. Pair it with --dry-run first: --repo
-# makes the default-label deletions land on a repo you are not standing in, so
-# a typo'd NWO is worth previewing.
+# --repo bypasses repository *resolution* (the target is named, not inferred
+# from a git remote) and is GitHub-only — an explicitly configured Gitea forge
+# (LOOM_FORGE_TYPE or forge.type in the resolved config) rejects it. Pair it
+# with --dry-run first: --repo makes the default-label deletions land on a repo
+# you are not standing in, so a typo'd NWO is worth previewing. A real (non
+# dry-run) --repo sync additionally preflights the named target with
+# `gh repo view` before deleting anything (#4524), because a dry run is
+# deliberately forge-free and so cannot tell a typo apart from a real repo.
 #
 # This is the installed-tree counterpart of the source-only
 # scripts/install/sync-labels.sh. It is self-contained apart from the
@@ -40,8 +45,8 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: sync-labels.sh [WORKTREE_PATH]
-       sync-labels.sh --repo OWNER/NAME [--dry-run] [WORKTREE_PATH]
+Usage: sync-labels.sh [--] [WORKTREE_PATH]
+       sync-labels.sh --repo OWNER/NAME [--dry-run] [--] [WORKTREE_PATH]
 
 Sync Loom workflow labels from .github/labels.yml onto the forge (GitHub or
 Gitea). Creates missing labels, updates existing ones to match labels.yml,
@@ -58,6 +63,8 @@ Options:
                     GitHub-only (uses the gh CLI).
       --dry-run     Print the label operations that would run and exit without
                     calling the forge. Recommended before a --repo run.
+      --            End of options: every remaining argument is positional, so
+                    a WORKTREE_PATH beginning with '-' can be passed.
   -h, --help        Show this help and exit.
 EOF
 }
@@ -66,8 +73,29 @@ WORKTREE_PATH="."
 REPO_OVERRIDE=""
 DRY_RUN=0
 POSITIONAL_SEEN=0
+# Set by `--`: from that point on every remaining argument is positional, even
+# one that starts with `-`. Without this the `--)` case below was a no-op shift
+# and a `-`-leading path still fell into the "Unknown option" branch (#4524).
+POSITIONAL_ONLY=0
+
+# Accept the single positional argument (WORKTREE_PATH), rejecting a second one.
+# Factored out so the pre-`--` and post-`--` paths cannot drift apart.
+take_positional() {
+  if [[ "$POSITIONAL_SEEN" -eq 1 ]]; then
+    echo "Unexpected extra argument: $1" >&2
+    usage >&2
+    exit 2
+  fi
+  WORKTREE_PATH="$1"
+  POSITIONAL_SEEN=1
+}
 
 while [[ $# -gt 0 ]]; do
+  if [[ "$POSITIONAL_ONLY" -eq 1 ]]; then
+    take_positional "$1"
+    shift
+    continue
+  fi
   case "$1" in
     -h|--help)
       usage
@@ -96,6 +124,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --)
+      POSITIONAL_ONLY=1
       shift
       ;;
     -*)
@@ -104,13 +133,7 @@ while [[ $# -gt 0 ]]; do
       exit 2
       ;;
     *)
-      if [[ "$POSITIONAL_SEEN" -eq 1 ]]; then
-        echo "Unexpected extra argument: $1" >&2
-        usage >&2
-        exit 2
-      fi
-      WORKTREE_PATH="$1"
-      POSITIONAL_SEEN=1
+      take_positional "$1"
       shift
       ;;
   esac
@@ -118,19 +141,16 @@ done
 
 # Validate --repo eagerly: an NWO typo would otherwise be discovered only after
 # the first default-label deletion had already been attempted somewhere.
+#
+# Each segment must START with an alphanumeric: that is what rejects
+# path-traversal shapes ('../..', 'owner/..', './x') and `-`-leading segments
+# ('-foo/bar', which a downstream `gh ... -R -foo/bar` would read as a flag
+# bundle rather than a repo). Dots and dashes remain legal *inside* a segment,
+# so real names like 'my-org/my-repo.name' still pass.
 if [[ -n "$REPO_OVERRIDE" ]]; then
-  if [[ ! "$REPO_OVERRIDE" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+  if [[ ! "$REPO_OVERRIDE" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
     echo "Invalid --repo value: '$REPO_OVERRIDE' (expected OWNER/NAME)" >&2
     usage >&2
-    exit 2
-  fi
-  # --repo names a GitHub repo and drives it purely through `gh label`; there is
-  # no equivalent "point at an arbitrary remote" path for the Gitea helpers
-  # (they need a resolved base URL + token for that host), so fail loudly rather
-  # than silently syncing GitHub while the operator expects Gitea.
-  if [[ "$(printf '%s' "${LOOM_FORGE_TYPE:-}" | tr '[:upper:]' '[:lower:]')" == "gitea" ]]; then
-    echo "--repo is GitHub-only, but LOOM_FORGE_TYPE=gitea is set" >&2
-    echo "Run sync-labels.sh from a checkout of the Gitea repo instead." >&2
     exit 2
   fi
 fi
@@ -165,7 +185,43 @@ warning() {
   echo -e "${YELLOW}⚠ Warning: $*${NC}" >&2
 }
 
-cd "$WORKTREE_PATH"
+# `cd --`: WORKTREE_PATH may legitimately start with '-' now that `--` ends
+# option parsing, and a bare `cd -x` would be parsed as a cd flag.
+cd -- "$WORKTREE_PATH"
+
+# _configured_forge_type -> echoes the EXPLICITLY configured forge type
+# (lowercased), or "auto" when nothing configures one.
+#
+# Mirrors the first two tiers of forge_detect's precedence (forge-helpers.sh):
+# the LOOM_FORGE_TYPE env var, then forge.type from the resolved config-tier
+# chain (loom_config_get over defaults/.loom/config.json/.loom-project/
+# .loom-local). Deliberately stops short of forge_detect's third tier —
+# git-remote autodetection — because --repo names its target explicitly, so
+# only an explicit *setting* should veto it, never an inference drawn from the
+# checkout the operator happens to be standing in.
+_configured_forge_type() {
+  local value="${LOOM_FORGE_TYPE:-}"
+  if [[ -z "$value" ]]; then
+    value="$(loom_config_get "$(_forge_config_root)" "forge.type" "auto" 2>/dev/null || echo "auto")"
+  fi
+  printf '%s' "$value" | tr '[:upper:]' '[:lower:]'
+}
+
+# --repo names a GitHub repo and drives it purely through `gh label`; there is
+# no equivalent "point at an arbitrary remote" path for the Gitea helpers (they
+# need a resolved base URL + token for that host), so fail loudly rather than
+# silently syncing GitHub while the operator expects Gitea. Runs after the cd
+# so the config tiers resolve against WORKTREE_PATH's repo, exactly like the
+# forge_detect call further below.
+if [[ -n "$REPO_OVERRIDE" && "$(_configured_forge_type)" == "gitea" ]]; then
+  if [[ -n "${LOOM_FORGE_TYPE:-}" ]]; then
+    echo "--repo is GitHub-only, but LOOM_FORGE_TYPE=gitea is set" >&2
+  else
+    echo "--repo is GitHub-only, but the resolved Loom config sets forge.type=gitea" >&2
+  fi
+  echo "Run sync-labels.sh from a checkout of the Gitea repo instead." >&2
+  exit 2
+fi
 
 if [[ -n "$REPO_OVERRIDE" ]]; then
   # Explicit target: skip forge_detect / forge_get_repo_nwo entirely. Both of
@@ -330,6 +386,50 @@ DEFAULT_LABELS=(
   "question"
   "wontfix"
 )
+
+# --- Deletion preflight for --repo (#4524) ----------------------------------
+#
+# --dry-run is deliberately forge-free, so it CANNOT distinguish a typo'd NWO
+# from the repo you meant — if the typo happens to name a real repo you can
+# administer, the preview looks perfectly reasonable and the real run then
+# deletes that repo's default labels. The loop below is the first irreversible
+# step, so verify the named target actually exists and is writable by the
+# current gh identity before entering it.
+#
+# Scoped to the --repo path on purpose: the no-flag path already resolved REPO
+# via `gh repo view` in the current checkout (existence proven), and adding a
+# second call there would change its byte-for-byte behavior.
+repo_override_preflight() {
+  local out permission err_file
+  # stderr goes to a file rather than being folded into $out with 2>&1: a gh
+  # deprecation notice on stderr would otherwise be mistaken for the permission.
+  err_file="$(mktemp)"
+  if ! out=$(gh repo view "$REPO" --json nameWithOwner,viewerPermission \
+      --jq '.viewerPermission // ""' 2>"$err_file"); then
+    cat "$err_file" >&2
+    rm -f "$err_file"
+    error "--repo target '$REPO' is not reachable (see the gh error above) — verify the OWNER/NAME spelling and that this gh identity can see it; nothing was deleted"
+  fi
+  rm -f "$err_file"
+  permission="$(printf '%s' "$out" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')"
+  case "$permission" in
+    ADMIN | MAINTAIN | WRITE)
+      info "Preflight OK: $REPO exists and is writable ($permission)"
+      ;;
+    "")
+      # Some tokens (e.g. fine-grained PATs) omit viewerPermission. Existence
+      # is still proven, so warn rather than block.
+      warning "Could not determine your permission on $REPO; continuing (repository exists)"
+      ;;
+    *)
+      error "--repo target '$REPO' is not writable by this gh identity (permission: $permission) — label sync would fail partway (nothing was deleted)"
+      ;;
+  esac
+}
+
+if [[ -n "$REPO_OVERRIDE" && "$DRY_RUN" -eq 0 ]]; then
+  repo_override_preflight
+fi
 
 info "Removing default labels..."
 for label in "${DEFAULT_LABELS[@]}"; do

--- a/defaults/scripts/tests/test-sync-labels-repo-flag.sh
+++ b/defaults/scripts/tests/test-sync-labels-repo-flag.sh
@@ -17,8 +17,9 @@
 #
 # The load-bearing assertions:
 #   1. --repo resolves the target WITHOUT consulting the forge/git for the NWO
-#      (no `gh repo view` in the log) and works from a directory that is not a
-#      git repo at all — the short-circuit, proven rather than asserted.
+#      (no *bare* `gh repo view --json nameWithOwner` in the log) and works
+#      from a directory that is not a git repo at all — the short-circuit,
+#      proven rather than asserted.
 #   2. Every mutating gh call carries `-R <override>`, never the invoking repo.
 #   3. labels.yml is still read from WORKTREE_PATH (the source stays local;
 #      only the target moves).
@@ -30,6 +31,18 @@
 #      remote still hard-errors.
 #   6. Argument-parsing rejections: missing/invalid NWO, unknown option, extra
 #      positional, and --repo combined with a Gitea forge.
+#
+# Issue #4524 hardened four things on top of that (PR #4506 judge follow-ups),
+# each with its own section below:
+#   7. `--` is honored as a real end-of-options terminator (a `-`-leading
+#      WORKTREE_PATH after it is a path, not an "Unknown option").
+#   8. The Gitea rejection also fires for forge.type=gitea resolved from the
+#      config-tier chain, not just the LOOM_FORGE_TYPE env var.
+#   9. The NWO regex rejects path-traversal ('../..') and `-`-leading segments
+#      ('-foo/bar') while still accepting real names ('my-org/my-repo.name').
+#  10. A real (non-dry-run) --repo sync preflights the named target with
+#      `gh repo view <NWO>` BEFORE the first deletion, so a typo that names a
+#      real administrable repo is caught before anything is destroyed.
 #
 # Usage:
 #   ./defaults/scripts/tests/test-sync-labels-repo-flag.sh
@@ -106,7 +119,13 @@ mkdir -p "$STUB_DIR"
 # Appends every invocation's argv to $LOOM_TEST_GH_LOG (one line per call), so a
 # test can assert both what WAS called and what was NOT.
 #
-#   gh repo view ...   -> echoes $LOOM_TEST_GH_NWO, or exits 1 when it is empty
+#   gh repo view <NWO> ... -> the #4524 existence/permission preflight (an
+#                         EXPLICIT target, not resolution). Answers from
+#                         $LOOM_TEST_GH_REPO_VIEW: "" => ADMIN, "fail" =>
+#                         exit 1 (repo missing / invisible), anything else is
+#                         echoed as the viewerPermission.
+#   gh repo view ...   -> NWO *resolution* (no positional target): echoes
+#                         $LOOM_TEST_GH_NWO, or exits 1 when it is empty
 #                         (simulating "no resolvable remote here")
 #   gh label list ...  -> echoes nothing (script takes the `create` branch)
 #   gh label create|edit|delete ... -> exit 0
@@ -116,6 +135,16 @@ printf '%s\n' "$*" >> "${LOOM_TEST_GH_LOG:?stub gh: LOOM_TEST_GH_LOG not set}"
 
 case "$1" in
   repo)
+    if [[ "${2:-}" == "view" && -n "${3:-}" && "$3" != -* ]]; then
+      case "${LOOM_TEST_GH_REPO_VIEW:-}" in
+        fail)
+          echo "stub gh: Could not resolve to a Repository with the name '$3'." >&2
+          exit 1
+          ;;
+        "")  printf 'ADMIN\n'; exit 0 ;;
+        *)   printf '%s\n' "$LOOM_TEST_GH_REPO_VIEW"; exit 0 ;;
+      esac
+    fi
     if [[ -z "${LOOM_TEST_GH_NWO:-}" ]]; then
       echo "stub gh: no remote configured" >&2
       exit 1
@@ -155,19 +184,56 @@ cat > "$SRC/.github/labels.yml" <<'EOF'
 # END LOOM LABELS
 EOF
 
+# A SECOND labels.yml, in a subdirectory whose name begins with '-'. It exists
+# to exercise the `--` end-of-options terminator (#4524): only a real
+# terminator lets this be passed as WORKTREE_PATH instead of being rejected as
+# an unknown option. It holds exactly ONE label, so "Synced 1 labels" proves
+# the sync actually read THIS tree and not $SRC's two-label file.
+mkdir -p "$SRC/-alt/.github"
+cat > "$SRC/-alt/.github/labels.yml" <<'EOF'
+# BEGIN LOOM LABELS
+- name: loom:only
+  description: "The lone label in the dash-prefixed tree"
+  color: "AABBCC"
+# END LOOM LABELS
+EOF
+
+# A config-tier root that declares Gitea WITHOUT setting LOOM_FORGE_TYPE — the
+# #4524 case the old env-only guard missed. Passed to the script as $REPO_ROOT,
+# which is the first tier of forge-helpers.sh's _forge_config_root precedence.
+CFG_GITEA="$TMP/cfg-gitea"
+mkdir -p "$CFG_GITEA/.loom"
+echo '{"forge":{"type":"gitea"}}' > "$CFG_GITEA/.loom/config.json"
+
+# ...and the same shape declaring GitHub, to prove the guard keys on the value
+# and not merely on "a config file exists".
+CFG_GITHUB="$TMP/cfg-github"
+mkdir -p "$CFG_GITHUB/.loom"
+echo '{"forge":{"type":"github"}}' > "$CFG_GITHUB/.loom/config.json"
+
 GH_LOG="$TMP/gh.log"
 
 # Run the real script with the stub gh first on PATH, from $SRC.
-#   run_sls [--nwo NWO] -- <script args...>
+#   run_sls [--nwo NWO] [--repo-view ANSWER] [--repo-root DIR] -- <script args...>
+#
+#   --repo-view   what the stub's targeted `gh repo view <NWO>` answers
+#                 (default ADMIN; "fail" => the repo is missing/invisible)
+#   --repo-root   value for $REPO_ROOT, i.e. the root the config-tier chain
+#                 resolves from (default: unset/empty)
+#
+# LOOM_CONFIG_DEFAULTS_FILE is pinned to empty so the host's private-defaults
+# tier (~/.local/share/loom/config/defaults.json) can never leak into a run.
 # Sets: RC, OUT (merged stdout+stderr), LOG (recorded gh argv lines).
 RC=0
 OUT=""
 LOG=""
 run_sls() {
-    local nwo=""
+    local nwo="" repo_view="" repo_root=""
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --nwo) nwo="$2"; shift 2 ;;
+            --repo-view) repo_view="$2"; shift 2 ;;
+            --repo-root) repo_root="$2"; shift 2 ;;
             --) shift; break ;;
             *) break ;;
         esac
@@ -178,6 +244,9 @@ run_sls() {
         PATH="$STUB_DIR:$PATH" \
         LOOM_TEST_GH_LOG="$GH_LOG" \
         LOOM_TEST_GH_NWO="$nwo" \
+        LOOM_TEST_GH_REPO_VIEW="$repo_view" \
+        LOOM_CONFIG_DEFAULTS_FILE="" \
+        REPO_ROOT="$repo_root" \
         LOOM_FORGE_TYPE="${LOOM_FORGE_TYPE_OVERRIDE:-}" \
         bash "$SLS" "$@" 2>&1
     )"
@@ -194,8 +263,12 @@ run_sls -- --repo octocat/hello-world
 assert_eq "0" "$RC" "--repo succeeds in a directory with no resolvable remote"
 assert_contains "$OUT" "Target repository: octocat/hello-world (github)" \
     "--repo resolves REPO to the flag value"
-assert_not_contains "$LOG" "repo view" \
-    "--repo never calls 'gh repo view' (forge_get_repo_nwo short-circuited)"
+# The short-circuit proof, kept precise after #4524 added a preflight: what
+# --repo must never do is ASK the forge which repo this is. That call is the
+# bare, targetless `gh repo view --json nameWithOwner` in forge_get_repo_nwo;
+# the preflight below is a different call (it NAMES the target).
+assert_not_contains "$LOG" "repo view --json nameWithOwner --jq" \
+    "--repo never resolves the NWO from the forge (forge_get_repo_nwo short-circuited)"
 assert_contains "$LOG" "label delete bug -R octocat/hello-world" \
     "default-label deletion targets the override NWO"
 assert_contains "$LOG" "label create loom:issue -R octocat/hello-world" \
@@ -208,8 +281,10 @@ assert_contains "$OUT" "Synced 2 labels" \
 assert_eq "-R octocat/hello-world" \
     "$(printf '%s\n' "$LOG" | grep -o -- '-R [^ ]*' | sort -u | tr '\n' ' ' | sed 's/ *$//')" \
     "the override NWO is the ONLY -R target in the whole gh log"
+# The preflight names its target positionally (`gh repo view` has no -R flag),
+# so match on the NWO itself rather than on '-R': no call may go anywhere else.
 assert_eq "" \
-    "$(printf '%s\n' "$LOG" | grep -v -- '-R octocat/hello-world' || true)" \
+    "$(printf '%s\n' "$LOG" | grep -v -- 'octocat/hello-world' || true)" \
     "no gh call was made without the override target"
 
 # --repo=OWNER/NAME is the same flag.
@@ -267,6 +342,12 @@ assert_contains "$OUT" "Target repository: owner/from-remote (github)" \
 assert_not_contains "$LOG" "label create" \
     "--dry-run without --repo performs no label mutations"
 
+# Byte-identical proof for #4524's preflight: the no-flag path must NOT gain a
+# second `gh repo view`. Exactly one `gh repo ...` call — the resolution one.
+run_sls --nwo owner/from-remote --
+assert_eq "1" "$(printf '%s\n' "$LOG" | grep -c '^repo ' || true)" \
+    "no-flag run still makes exactly ONE 'gh repo view' call (no preflight added)"
+
 echo ""
 echo "=== Argument-parsing rejections (exit 2, no forge contact) ==="
 
@@ -286,6 +367,72 @@ for bad in bad-nwo owner/repo/extra "own er/repo" /repo owner/; do
         "invalid --repo value '$bad' is reported as invalid"
 done
 
+echo ""
+echo "=== NWO validation rejects traversal / '-'-leading segments (#4524) ==="
+
+# The pre-#4524 class ([A-Za-z0-9._-]+ per segment) accepted every value below.
+# '../..' and friends are path-traversal shapes that must never reach a gh
+# argument; '-foo/bar' would be read by gh as a bundle of short flags rather
+# than a repository. Each segment must now START with an alphanumeric.
+for bad in "../.." "./x" "owner/.." "../owner" "-foo/bar" "owner/-bar" \
+           ".hidden/repo" "owner/.hidden" "_leading/repo"; do
+    run_sls -- --repo "$bad"
+    assert_eq "2" "$RC" "hardened NWO check rejects '$bad'"
+    assert_contains "$OUT" "Invalid --repo value" \
+        "'$bad' is reported as an invalid --repo value"
+    assert_eq "" "$LOG" "'$bad' never reaches the forge"
+done
+
+# ...and the tightening must not have caught real names. Dots, dashes and
+# underscores stay legal INSIDE a segment. --dry-run keeps these assertions
+# about parsing rather than about the stubbed forge.
+for good in owner/repo my-org/my-repo owner-2/repo.name a/b \
+            under_score/re_po owner/repo-1.2.3 0rg/9repo; do
+    run_sls -- --repo "$good" --dry-run
+    assert_eq "0" "$RC" "legitimate NWO '$good' is still accepted"
+    assert_contains "$OUT" "Target repository: $good (github)" \
+        "legitimate NWO '$good' resolves to itself"
+done
+
+echo ""
+echo "=== '--' is a real end-of-options terminator (#4524) ==="
+
+# Baseline: without --, a '-'-leading path is (still) an unknown option. That
+# is exactly why -- has to work.
+run_sls -- --repo octocat/hello-world -alt
+assert_eq "2" "$RC" "a '-'-leading WORKTREE_PATH without -- is rejected as an option"
+assert_contains "$OUT" "Unknown option: -alt" \
+    "the '-'-leading path is named as the rejected option"
+
+# With --, it becomes the positional WORKTREE_PATH — proven by the label count:
+# the dash-prefixed tree holds ONE label, $SRC holds two.
+run_sls -- --repo octocat/hello-world -- -alt
+assert_eq "0" "$RC" "-- lets a '-'-leading WORKTREE_PATH through"
+assert_contains "$OUT" "Synced 1 labels" \
+    "-- routed '-alt' to WORKTREE_PATH (its one-label labels.yml was read)"
+assert_contains "$LOG" "label create loom:only -R octocat/hello-world" \
+    "the synced label came from the dash-prefixed tree, not from \$SRC"
+
+# After --, an option-looking token is a PATH: --dry-run must not be re-parsed
+# as the flag (it becomes a nonexistent directory, so the cd fails).
+run_sls -- --repo octocat/hello-world -- --dry-run
+assert_eq "1" "$RC" "a --dry-run after -- is treated as a (nonexistent) path"
+assert_not_contains "$OUT" "[dry-run] would" \
+    "a --dry-run after -- does not re-enable dry-run mode"
+
+# A trailing -- with no operand stays the harmless no-op it always was.
+run_sls -- --repo octocat/hello-world --
+assert_eq "0" "$RC" "a trailing -- with no operand is a no-op"
+assert_contains "$OUT" "Synced 2 labels" \
+    "the trailing -- left WORKTREE_PATH at its default"
+
+# The extra-positional rejection still applies on the post---- path (the two
+# branches share one take_positional helper).
+run_sls -- -- "$SRC" extra
+assert_eq "2" "$RC" "a second positional after -- still exits 2"
+assert_contains "$OUT" "Unexpected extra argument: extra" \
+    "the post-'--' extra positional is named"
+
 run_sls -- --bogus
 assert_eq "2" "$RC" "unknown option exits 2"
 assert_contains "$OUT" "Unknown option: --bogus" "unknown option is named"
@@ -304,6 +451,82 @@ assert_contains "$OUT" "--repo is GitHub-only" \
     "the Gitea combination fails loudly instead of silently syncing GitHub"
 assert_eq "" "$LOG" "the Gitea rejection contacts no forge"
 
+# #4524: forge.type=gitea resolved from the CONFIG TIERS, with LOOM_FORGE_TYPE
+# unset, must reject --repo exactly like the env var does. The pre-#4524 guard
+# read only the env var, so this combination silently synced GitHub instead.
+run_sls --repo-root "$CFG_GITEA" -- --repo octocat/hello-world
+assert_eq "2" "$RC" "--repo with config-tier forge.type=gitea exits 2"
+assert_contains "$OUT" "--repo is GitHub-only" \
+    "the config-tier Gitea setting fails just as loudly as the env var"
+assert_contains "$OUT" "forge.type=gitea" \
+    "the rejection names the config setting, not a phantom LOOM_FORGE_TYPE"
+assert_eq "" "$LOG" "the config-tier Gitea rejection contacts no forge"
+
+# The guard must key on the VALUE, not on "a config file exists".
+run_sls --repo-root "$CFG_GITHUB" -- --repo octocat/hello-world
+assert_eq "0" "$RC" "--repo with config-tier forge.type=github is allowed"
+assert_contains "$OUT" "Synced 2 labels" "the GitHub config-tier run syncs normally"
+
+# Env var beats the config tier, matching forge_detect's precedence.
+LOOM_FORGE_TYPE_OVERRIDE="github" run_sls --repo-root "$CFG_GITEA" -- --repo octocat/hello-world
+assert_eq "0" "$RC" "LOOM_FORGE_TYPE=github overrides a config-tier gitea setting"
+
+# The Gitea guard is scoped to --repo: a config-tier gitea repo without the
+# flag still takes the normal (Gitea) detection path, not this rejection.
+run_sls --repo-root "$CFG_GITEA" -- --dry-run
+assert_not_contains "$OUT" "--repo is GitHub-only" \
+    "config-tier gitea WITHOUT --repo is not rejected"
+
+echo ""
+echo "=== --repo preflights the target before any deletion (#4524) ==="
+
+# --dry-run is deliberately forge-free, so it cannot tell a typo'd NWO apart
+# from a real repo. The real run therefore verifies the target FIRST.
+run_sls -- --repo octocat/hello-world
+assert_eq "0" "$RC" "a reachable, writable --repo target syncs normally"
+assert_contains "$LOG" "repo view octocat/hello-world --json nameWithOwner,viewerPermission" \
+    "the real --repo path preflights the named target with 'gh repo view'"
+assert_contains "$(printf '%s\n' "$LOG" | head -1)" "repo view octocat/hello-world" \
+    "the preflight is the FIRST gh call — it precedes every label operation"
+
+# A typo that resolves to nothing this identity can see must abort before the
+# deletion loop, not partway through it.
+run_sls --repo-view fail -- --repo octocat/typo-repo
+assert_eq "1" "$RC" "an unreachable --repo target aborts"
+assert_contains "$OUT" "is not reachable" \
+    "the abort explains that the target could not be reached"
+assert_contains "$OUT" "nothing was deleted" \
+    "the abort states explicitly that nothing was deleted"
+assert_not_contains "$LOG" "label delete" \
+    "the unreachable target aborted BEFORE any label deletion"
+assert_not_contains "$LOG" "label create" \
+    "the unreachable target aborted before any label creation"
+assert_eq "1" "$(printf '%s\n' "$LOG" | grep -c . || true)" \
+    "the preflight was the only gh call made against the bad target"
+
+# Existing-but-read-only is the other half of "existence/permission": deleting
+# labels there would fail partway, so refuse up front.
+run_sls --repo-view READ -- --repo octocat/hello-world
+assert_eq "1" "$RC" "a read-only --repo target aborts"
+assert_contains "$OUT" "is not writable" "the read-only abort names the problem"
+assert_contains "$OUT" "READ" "the read-only abort reports the observed permission"
+assert_not_contains "$LOG" "label delete" \
+    "the read-only target aborted before any label deletion"
+
+# Some tokens omit viewerPermission entirely. Existence is still proven, so
+# warn and continue rather than blocking a legitimate sync.
+run_sls --repo-view " " -- --repo octocat/hello-world
+assert_eq "0" "$RC" "an indeterminate permission does not block the sync"
+assert_contains "$OUT" "Could not determine your permission" \
+    "an indeterminate permission is warned about"
+assert_contains "$LOG" "label delete bug -R octocat/hello-world" \
+    "the sync proceeds once existence is proven"
+
+# The preflight is real-run only: --dry-run must stay forge-free.
+run_sls -- --repo octocat/hello-world --dry-run
+assert_eq "" "$LOG" \
+    "--dry-run makes no preflight call (it stays completely forge-free)"
+
 echo ""
 echo "=== --help documents the new flags ==="
 
@@ -311,6 +534,7 @@ run_sls -- --help
 assert_eq "0" "$RC" "--help exits 0"
 assert_contains "$OUT" "--repo OWNER/NAME" "--help documents --repo"
 assert_contains "$OUT" "--dry-run" "--help documents --dry-run"
+assert_contains "$OUT" "End of options" "--help documents the -- terminator (#4524)"
 
 echo ""
 echo "=== Installed-tree parity (.loom/scripts is a symlinked dir) ==="


### PR DESCRIPTION
## Summary

Addresses the four explicitly non-blocking judge follow-ups from PR #4506 (review comment 5125912516) on `sync-labels.sh --repo`. All four land in `defaults/scripts/sync-labels.sh` (which `.loom/scripts/sync-labels.sh` is a directory symlink to, so both surfaces are covered by one edit).

## Changes

**1. `--` is a real end-of-options terminator.** The `--)` case was a bare `shift` — the token was swallowed as a no-op, so anything after it that started with `-` still hit the `-*)` "Unknown option" branch. A `POSITIONAL_ONLY` flag now short-circuits option dispatch for the rest of argv, and the positional handling is factored into a `take_positional()` helper so the pre-`--` and post-`--` paths cannot drift apart. `cd "$WORKTREE_PATH"` becomes `cd -- "$WORKTREE_PATH"`, since a `-`-leading path is now reachable and a bare `cd -x` would be parsed as a cd flag.

**2. The Gitea veto covers config tiers, not just the env var.** New `_configured_forge_type()` mirrors the first two tiers of `forge_detect`'s precedence (`forge-helpers.sh:92-121`): `LOOM_FORGE_TYPE`, then `forge.type` via `loom_config_get` over the resolved config-tier chain. So `forge.type: gitea` set in `.loom/config.json` / `.loom-project/project.json` / `.loom-local/local.json` now fails loudly instead of silently syncing GitHub. It deliberately stops short of `forge_detect`'s *third* tier (git-remote autodetection): `--repo` names its target explicitly, so only an explicit **setting** should veto it, never an inference from whichever checkout the operator happens to be standing in. The guard moved below the `cd` so the tiers resolve against WORKTREE_PATH's repo, exactly like the `forge_detect` call further down. The message distinguishes the env-var case from the config case.

**3. Tightened NWO regex.** `^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$` -> `^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$`. Requiring each segment to *start* with an alphanumeric is what rejects path-traversal shapes (`../..`, `owner/..`, `./x`, `../owner`) and `-`-leading segments (`-foo/bar`, which a downstream `gh ... -R -foo/bar` would read as a flag bundle). Dots/dashes/underscores stay legal *inside* a segment, so `my-org/my-repo.name`, `owner-2/repo.name`, `owner/repo-1.2.3` still pass.

**4. `gh repo view` preflight before the deletion loop.** `--dry-run` is deliberately forge-free, so it cannot distinguish a typo'd NWO from the repo you meant — if the typo names a real repo you can administer, the preview looks perfectly reasonable and the real run then deletes that repo's default labels. The real (non-dry-run) `--repo` path now runs `gh repo view "$REPO" --json nameWithOwner,viewerPermission` immediately before the `DEFAULT_LABELS` loop (the first irreversible step) and aborts if the target is unreachable or read-only. `viewerPermission` absent (some fine-grained PATs omit it) warns and continues, since existence is still proven. Scoped to the `--repo` path on purpose: the no-flag path already resolved REPO via `gh repo view` in the current checkout, and adding a second call there would change its byte-for-byte behavior. stderr is captured to a temp file rather than folded into the value with `2>&1`, so a gh deprecation notice can't be mistaken for the permission.

Docs: the `--repo` fleet-onboarding paragraph in `defaults/docs/daemon-reference.md` now states the preflight and the widened Gitea rejection.

## Acceptance Criteria Verification

- [x] **All four addressed in `defaults/scripts/sync-labels.sh`** — see Changes above.
- [x] **Cases added to `defaults/scripts/tests/test-sync-labels-repo-flag.sh`** — four new sections (`NWO validation rejects traversal / '-'-leading segments`, `'--' is a real end-of-options terminator`, config-tier cases folded into `--repo is GitHub-only`, `--repo preflights the target before any deletion`).
- [x] **The 52 existing assertions stay green.** 52/52 with the new script, but note that **two had to be re-expressed rather than relaxed**, because they were written against the pre-preflight world:
  - `assert_not_contains "$LOG" "repo view"` — its stated intent is proving the NWO *resolution* short-circuit (`forge_get_repo_nwo`). That call is the targetless `gh repo view --json nameWithOwner --jq ...`; the preflight is a different call that *names* its target. The assertion now matches that exact resolution argv, so it still fails if resolution ever creeps back.
  - `no gh call was made without the override target` — `gh repo view` has no `-R` flag (verified against gh 2.96.0: the repo is positional), so the preflight names the target positionally. The assertion now matches on the NWO itself. The companion `the override NWO is the ONLY -R target` assertion is unchanged and still passes.
- [x] **No-flag behavior stays byte-identical.** All the existing short-circuit/no-flag proofs pass unchanged, plus a new explicit guard: the no-flag run still makes **exactly one** `gh repo ...` call (resolution only, no preflight added).

## Test Plan

- [x] `bash defaults/scripts/tests/test-sync-labels-repo-flag.sh` -> **131/131 passed, 0 failed** (52 pre-existing + 79 new).
  - The test harness gained: a stub `gh` that distinguishes a targeted `repo view <NWO>` (preflight, answer controlled by `LOOM_TEST_GH_REPO_VIEW`) from the targetless resolution call; `run_sls --repo-view` / `--repo-root` options; `LOOM_CONFIG_DEFAULTS_FILE=""` pinned so the host's private-defaults config tier can never leak into a run; a one-label `-alt/` scratch tree whose name begins with `-` (so `Synced 1 labels` *proves* `--` routed it to WORKTREE_PATH rather than merely not erroring); and `.loom/config.json` fixtures declaring gitea and github.
- [x] `bash defaults/scripts/tests/test-forge-helpers.sh` -> 36/36 passed.
- [x] `bash defaults/scripts/tests/test-config-resolver.sh` -> 14/14 passed.
- [x] `shellcheck -x` clean on both changed shell files.
- [x] Manual verification against real `gh`: `sync-labels.sh --repo rjwalters/definitely-does-not-exist-4524-preflight .` aborted at the preflight with exit 1 and `nothing was deleted`, before any label operation. (The account was rate-limited at the time, so the underlying gh failure was a 403 rather than a 404 — the preflight fails **closed** either way, which is the desired behavior before irreversible deletions.)
- [x] Edge cases: `owner/repo.name`, `my-org/my-repo`, `owner-2/repo.name`, `under_score/re_po`, `owner/repo-1.2.3`, `0rg/9repo` all still accepted (asserted).

### Pre-existing failure, not caused by this PR

`bash .loom/scripts/build-gate.sh` fails on one `loom-daemon` unit test. This is a **pre-existing parallel-execution flake**, not related to this shell-only diff:
- `quarantine_reconciliation::tests::reconcile_workspace_never_touches_manual_block` passes in isolation (in this branch's worktree) and fails only in the full parallel run.
- The same full run on **`main`** also fails, with *different* tests (`pipeline_snapshot::tests::gh_pipeline_source_counts_each_metric_independently`, `...records_error_but_keeps_other_metrics`).

Closes #4524