### PR TITLE
fix: report the active drain's terminal action in DaemonDrain acks

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -594,6 +594,31 @@ cancel`'s SIGTERM→grace→SIGKILL), plus the three deltas teardown needs:
    draining. Because a `then-exit` drain never wants a relaunch, the
    supervisor-detection refusal gate (`restart --drain`'s AC5) does not apply to
    it.
+
+   **`then_exit` is escalated one-way, and the ack reports reality (#4521).**
+   A drain request that lands while a drain is *already* in progress is
+   idempotent — it never stacks a supervisor and never moves the active
+   deadline — but `then_exit` is not simply ignored: `--then-exit` **escalates**
+   an in-progress relaunch-drain (e.g. the auto-update roll, which drains with
+   `then_exit=false`) to stay-down, and the already-running supervisor observes
+   the change because it re-reads the terminal action from the drain descriptor
+   on every poll. The reverse never happens: a plain `--drain` against an active
+   teardown drain does **not** downgrade it back to a relaunch. Escalation was
+   chosen over "refuse and tell the operator to `--abort-drain` + re-issue"
+   because that two-command path races the very window it exists for — the roll
+   can complete between the abort and the re-issue and relaunch the daemon on a
+   host that is about to be powered off. When a roll is escalated this way, the
+   daemon logs that the rebuilt binary will not be picked up until it is started
+   again.
+
+   Consequently the `DaemonDrain` reply's `then_exit` reports the **active**
+   drain's terminal action, never an echo of the request, and
+   `loom-daemon restart` renders "will stop" vs "will RESTART" from the reply.
+   When the reply disagrees with what was asked, the CLI prints a loud warning —
+   this is also the version-skew detector: a daemon older than `--then-exit`
+   support silently drops the unknown wire field and replies `then_exit: false`,
+   so `--drain --then-exit` against a stale incumbent now says so instead of
+   promising a teardown that never happens (roll the daemon, then re-issue).
 2. **Immediate, targeted claim reset.** The startup-only `claim_reconciliation`
    pass is too late for a drain (the anvil#758 pilot evidence: a crashed VM
    sweep stranded `loom:building` for the full staleness window). `fleet drain`

--- a/loom-daemon/src/auto_update.rs
+++ b/loom-daemon/src/auto_update.rs
@@ -462,6 +462,26 @@ impl DrainTrigger for IpcDrainTrigger {
             false,
             false,
         );
+        // Issue #4521: the reply's `then_exit` reports the ACTIVE drain's
+        // terminal action, not this request's. `true` here means an operator
+        // teardown drain (`--drain --then-exit`) was already in flight, so this
+        // roll piggybacks on a drain that will STOP the daemon rather than
+        // relaunch it into the freshly-built binary. That is intentional
+        // (then-exit is never downgraded — the host is being torn down), but it
+        // must not be silent: the new binary will not be picked up until the
+        // daemon is started again.
+        if let crate::types::Response::DaemonDrain {
+            accepted: true,
+            then_exit: true,
+            ..
+        } = &resp
+        {
+            log::warn!(
+                "auto-update roll joined an in-progress then-exit (teardown) drain: the daemon \
+                 will STOP when drained and will NOT relaunch into the rebuilt binary. Start it \
+                 again to pick up the update."
+            );
+        }
         matches!(resp, crate::types::Response::DaemonDrain { accepted: true, .. })
     }
 }

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -201,7 +201,18 @@ pub enum DrainBegin {
     /// A drain was already in progress; the request is an idempotent ack and no
     /// second supervisor should be spawned (the deadline/generation are
     /// unchanged).
-    AlreadyDraining,
+    AlreadyDraining {
+        /// The **active** drain's actual terminal action after this request was
+        /// applied — `true` ⇒ it will exit and stay down, `false` ⇒ it will exit
+        /// for a supervised relaunch. Never a blind echo of the request
+        /// (Issue #4521): the caller must render its ack from this, or it will
+        /// promise a teardown that never happens.
+        active_then_exit: bool,
+        /// `true` when this request *escalated* an in-progress relaunch-drain to
+        /// stay-down (the one-way `then_exit` transition — see
+        /// [`DrainState::begin`]).
+        escalated: bool,
+    },
 }
 
 impl Default for DrainState {
@@ -250,10 +261,30 @@ impl DrainState {
 
     /// Start a drain, or ack an already-running one (idempotent — a second drain
     /// request while DRAINING neither stacks a supervisor nor moves the
-    /// deadline). Sets the drain flag on a fresh start. `then_exit` is ignored
-    /// on the already-draining path (the in-progress drain's terminal action is
-    /// unchanged by a later idempotent ack — mirrors `force_after_timeout` and
-    /// the deadline both staying fixed too).
+    /// deadline). Sets the drain flag on a fresh start.
+    ///
+    /// **`then_exit` on the already-draining path (Issue #4521 — design
+    /// decision).** `timeout`/`force_after_timeout` stay pinned to the active
+    /// drain (a later idempotent ack must not move a deadline someone is already
+    /// waiting on), but `then_exit` is **escalated one-way**:
+    /// `relaunch → stay-down`, never the reverse.
+    ///
+    /// Rationale: the two options were (a) refuse the escalation and tell the
+    /// operator to `--abort-drain` and re-issue, or (b) escalate in place. (a)
+    /// is racy in exactly the case that matters — an operator tearing a host
+    /// down while an auto-update roll-drain (`then_exit=false`,
+    /// `auto_update.rs`) is in flight would have to abort and re-issue, and the
+    /// roll can complete *between* those two commands, relaunching the daemon on
+    /// a host that is about to be powered off. (b) is monotonic and safe: exiting
+    /// and staying down is strictly the more conservative terminal action, and
+    /// the operator's teardown intent is honored on the first command. The
+    /// reverse direction is deliberately **not** applied — a roll trigger
+    /// arriving during an operator teardown drain must never silently downgrade
+    /// the teardown into a relaunch.
+    ///
+    /// The escalation is observed by the already-running supervisor because it
+    /// re-reads `then_exit` from this descriptor at its terminal tick rather
+    /// than using a value captured at spawn (see [`run_drain_supervisor`]).
     pub fn begin(
         &self,
         timeout: Duration,
@@ -262,7 +293,19 @@ impl DrainState {
     ) -> DrainBegin {
         let mut inner = self.inner.lock().expect("Drain mutex poisoned");
         if inner.active {
-            return DrainBegin::AlreadyDraining;
+            let escalated = then_exit && !inner.then_exit;
+            if escalated {
+                inner.then_exit = true;
+                inner.note = Some(
+                    "in-progress drain escalated to then-exit — will stop and stay down \
+                     (was: exit for a supervised relaunch)"
+                        .to_string(),
+                );
+            }
+            return DrainBegin::AlreadyDraining {
+                active_then_exit: inner.then_exit,
+                escalated,
+            };
         }
         let deadline = Utc::now()
             + chrono::Duration::from_std(timeout).unwrap_or_else(|_| chrono::Duration::seconds(0));
@@ -483,7 +526,6 @@ pub fn handle_drain_request(
                     bus_task,
                     generation,
                     DRAIN_POLL_INTERVAL,
-                    then_exit,
                 )
                 .await;
             });
@@ -527,16 +569,107 @@ pub fn handle_drain_request(
                 then_exit,
             }
         }
-        DrainBegin::AlreadyDraining => Response::DaemonDrain {
-            accepted: true,
-            supervisor,
-            in_flight,
-            message: format!(
-                "already draining (idempotent): {in_flight} in-flight sweep(s); the existing \
-                 deadline is unchanged. Use `loom-daemon restart --abort-drain` to cancel."
-            ),
-            then_exit,
-        },
+        // Issue #4521: the ack must describe the **active** drain's terminal
+        // action, never the requested one. Echoing the request here is what let
+        // an operator's `--drain --then-exit` be acked as "will stop" while an
+        // in-progress relaunch-drain (an auto-update roll) exited 0 and launchd
+        // brought the daemon straight back up.
+        DrainBegin::AlreadyDraining {
+            active_then_exit,
+            escalated,
+        } => {
+            let _ = event_bus.publish_generic(
+                "daemon.drain.already_draining",
+                serde_json::json!({
+                    "in_flight": in_flight,
+                    "requested_then_exit": then_exit,
+                    "active_then_exit": active_then_exit,
+                    "escalated": escalated,
+                }),
+            );
+            if escalated {
+                log::warn!(
+                    "drain escalated to then-exit (Issue #4521): an in-progress relaunch-drain \
+                     (e.g. an auto-update roll) will now exit {EXIT_SHUTDOWN} and stay down \
+                     instead of relaunching"
+                );
+            }
+            let message = if escalated {
+                format!(
+                    "already draining (idempotent) — ESCALATED to then-exit: the in-progress \
+                     drain was a relaunch drain (e.g. an auto-update roll) and will now STOP \
+                     and stay down when drained, NOT relaunch. {in_flight} in-flight sweep(s); \
+                     the existing deadline is unchanged. If a relaunch was wanted after all, \
+                     `loom-daemon restart --abort-drain` and re-issue without --then-exit."
+                )
+            } else if active_then_exit && !then_exit {
+                format!(
+                    "already draining (idempotent): the in-progress drain is a then-exit \
+                     teardown — it will STOP and stay down when drained, NOT relaunch, so this \
+                     restart-when-drained request will not be honored (then-exit is never \
+                     downgraded). {in_flight} in-flight sweep(s); the existing deadline is \
+                     unchanged. Use `loom-daemon restart --abort-drain` to cancel."
+                )
+            } else if active_then_exit {
+                format!(
+                    "already draining (idempotent): the in-progress drain will STOP and stay \
+                     down when drained (then-exit). {in_flight} in-flight sweep(s); the existing \
+                     deadline is unchanged. Use `loom-daemon restart --abort-drain` to cancel."
+                )
+            } else {
+                format!(
+                    "already draining (idempotent): the in-progress drain will RESTART when \
+                     drained. {in_flight} in-flight sweep(s); the existing deadline is \
+                     unchanged. Use `loom-daemon restart --abort-drain` to cancel."
+                )
+            };
+            Response::DaemonDrain {
+                accepted: true,
+                supervisor,
+                in_flight,
+                message,
+                then_exit: active_then_exit,
+            }
+        }
+    }
+}
+
+/// The exit code a terminal drain tick must use (Issue #4521).
+///
+/// Load-bearing and deliberately extracted as a pure function so the contract is
+/// unit-testable without spawning a process: a **then-exit** drain must exit
+/// [`EXIT_SHUTDOWN`] (143, non-zero) so a `KeepAlive:{SuccessfulExit:true}`
+/// launchd job stays down — exiting [`EXIT_RESTART`] (0) there is precisely the
+/// "drained, then relaunched anyway" failure. A relaunch drain exits
+/// [`EXIT_RESTART`] so the supervisor brings it straight back.
+#[must_use]
+pub fn drain_exit_code(then_exit: bool) -> i32 {
+    if then_exit {
+        EXIT_SHUTDOWN
+    } else {
+        EXIT_RESTART
+    }
+}
+
+/// The operator-facing log line emitted when a drain completes with zero
+/// in-flight sweeps (Issue #4090, pinned by Issue #4521).
+///
+/// The two terminal actions **must** produce visibly different lines — a host
+/// log has to say which one fired without the reader guessing. Extracted as a
+/// pure function so that distinctness is a test assertion rather than a
+/// convention. `supervisor` is only interpolated on the relaunch line.
+#[must_use]
+pub fn drain_complete_log_line(then_exit: bool, supervisor: &str) -> String {
+    if then_exit {
+        format!(
+            "drain complete — 0 in-flight sweeps; exiting {EXIT_SHUTDOWN} and staying down \
+             (then_exit — Issue #4343 teardown). No sweep was killed; no orphan left behind."
+        )
+    } else {
+        format!(
+            "drain complete — 0 in-flight sweeps; exiting {EXIT_RESTART} for a \
+             {supervisor}-supervised relaunch. No sweep was killed; no orphan left behind."
+        )
     }
 }
 
@@ -544,6 +677,12 @@ pub fn handle_drain_request(
 /// and owns the eventual `std::process::exit(EXIT_RESTART)`; on a fail-safe
 /// timeout it clears the drain flag and stays up. Stops without exiting if it
 /// has been superseded (a new drain) or aborted (generation moved on).
+///
+/// The terminal action (`then_exit`) is **re-read from [`DrainState`] on every
+/// tick** rather than captured at spawn (Issue #4521): an in-progress
+/// relaunch-drain can be escalated to stay-down by a later
+/// `--drain --then-exit` request, and a supervisor holding a stale `false` would
+/// exit `0` and be relaunched by the supervisor anyway.
 async fn run_drain_supervisor(
     drain: Arc<DrainState>,
     workspace_pool: Arc<WorkspacePool>,
@@ -551,7 +690,6 @@ async fn run_drain_supervisor(
     event_bus: Arc<EventBus>,
     my_generation: u64,
     poll_interval: Duration,
-    then_exit: bool,
 ) {
     loop {
         // Superseded / aborted: a newer drain or an abort bumped the generation,
@@ -568,10 +706,13 @@ async fn run_drain_supervisor(
         }
 
         let in_flight = count_in_flight_sweeps(&workspace_pool, &fallback_root);
-        let (past_deadline, force) = {
+        // One consistent read of the live descriptor per tick. `then_exit` comes
+        // from here — not from a spawn-time argument — so a mid-drain escalation
+        // (relaunch → stay-down, Issue #4521) is honored by this supervisor.
+        let (past_deadline, force, then_exit) = {
             let snap = drain.snapshot();
             let past = snap.deadline.is_some_and(|d| Utc::now() >= d);
-            (past, snap.force_after_timeout)
+            (past, snap.force_after_timeout, snap.then_exit)
         };
 
         match evaluate_drain_tick(in_flight, past_deadline, force) {
@@ -584,23 +725,16 @@ async fn run_drain_supervisor(
                     serde_json::json!({ "in_flight": 0, "then_exit": then_exit }),
                 );
                 if then_exit {
-                    log::warn!(
-                        "drain complete — 0 in-flight sweeps; exiting {EXIT_SHUTDOWN} and staying \
-                         down (then_exit — Issue #4343 teardown). No sweep was killed; no orphan \
-                         left behind."
-                    );
-                    std::process::exit(EXIT_SHUTDOWN);
+                    log::warn!("{}", drain_complete_log_line(true, ""));
+                    std::process::exit(drain_exit_code(true));
                 }
                 // This path only runs after `handle_drain_request` proved
                 // supervision, so `detect_supervisor()` should still be `Some`
                 // here; fall back to a generic label rather than hardcoding
                 // launchd if the environment somehow changed underneath us.
                 let sup = detect_supervisor().unwrap_or_else(|| "supervisor".to_string());
-                log::warn!(
-                    "drain complete — 0 in-flight sweeps; exiting {EXIT_RESTART} for a \
-                     {sup}-supervised relaunch. No sweep was killed; no orphan left behind."
-                );
-                std::process::exit(EXIT_RESTART);
+                log::warn!("{}", drain_complete_log_line(false, &sup));
+                std::process::exit(drain_exit_code(false));
             }
             DrainTick::TimedOutRefuse => {
                 let note = format!(
@@ -632,13 +766,13 @@ async fn run_drain_supervisor(
                          cancelled {cancelled} sweep(s); exiting {EXIT_SHUTDOWN} and staying down \
                          (then_exit — Issue #4343 teardown)"
                     );
-                    std::process::exit(EXIT_SHUTDOWN);
+                    std::process::exit(drain_exit_code(true));
                 }
                 log::warn!(
                     "drain timed out with {in_flight} in-flight; --force-after-timeout cancelled \
                      {cancelled} sweep(s); exiting {EXIT_RESTART} for a supervised relaunch"
                 );
-                std::process::exit(EXIT_RESTART);
+                std::process::exit(drain_exit_code(false));
             }
         }
     }
@@ -5858,7 +5992,13 @@ exit 0
         // A second begin while already draining is idempotent: same generation,
         // same deadline, flag still set (AC edge: second drain does not stack).
         match drain.begin(Duration::from_secs(9999), true, false) {
-            DrainBegin::AlreadyDraining => {}
+            DrainBegin::AlreadyDraining {
+                active_then_exit,
+                escalated,
+            } => {
+                assert!(!active_then_exit, "active drain is still a relaunch drain");
+                assert!(!escalated, "a then_exit=false request escalates nothing");
+            }
             other => panic!("expected AlreadyDraining, got {other:?}"),
         }
         assert_eq!(drain.generation(), gen1, "idempotent begin does not bump gen");
@@ -5884,6 +6024,133 @@ exit 0
         assert!(!drain.is_draining());
         assert_eq!(drain.snapshot().note.as_deref(), Some("timed out"));
         assert!(drain.generation() > gen_before);
+    }
+
+    /// Issue #4521 AC1 — `then_exit` on the already-draining path is escalated
+    /// **one way** (relaunch → stay-down) and the outcome reported back is the
+    /// ACTIVE drain's terminal action, never a blind echo of the request.
+    #[test]
+    fn test_drain_then_exit_escalates_one_way() {
+        // A relaunch-drain is in flight (this is the auto-update roll's shape:
+        // `then_exit=false`).
+        let drain = DrainState::new();
+        let deadline = match drain.begin(Duration::from_secs(120), false, false) {
+            DrainBegin::Started { deadline, .. } => deadline,
+            other => panic!("expected Started, got {other:?}"),
+        };
+        assert!(!drain.snapshot().then_exit);
+
+        // An operator teardown request lands mid-roll: it must NOT be silently
+        // ignored (the #4521 defect) — the active drain escalates to stay-down.
+        match drain.begin(Duration::from_secs(9999), true, true) {
+            DrainBegin::AlreadyDraining {
+                active_then_exit,
+                escalated,
+            } => {
+                assert!(active_then_exit, "the active drain now stays down");
+                assert!(escalated, "the escalation must be reported to the caller");
+            }
+            other => panic!("expected AlreadyDraining, got {other:?}"),
+        }
+        assert!(
+            drain.snapshot().then_exit,
+            "the escalation must be visible to the already-running supervisor, \
+             which re-reads the descriptor"
+        );
+        // Everything else about the active drain is still pinned.
+        assert_eq!(drain.snapshot().deadline, Some(deadline));
+        assert!(!drain.snapshot().force_after_timeout);
+
+        // Escalating again is a no-op that still reports the truth.
+        match drain.begin(Duration::from_secs(1), false, true) {
+            DrainBegin::AlreadyDraining {
+                active_then_exit,
+                escalated,
+            } => {
+                assert!(active_then_exit);
+                assert!(!escalated, "already stay-down — nothing to escalate");
+            }
+            other => panic!("expected AlreadyDraining, got {other:?}"),
+        }
+
+        // A relaunch request against an active teardown drain must NOT downgrade
+        // it: the reply still says "will stay down".
+        match drain.begin(Duration::from_secs(1), false, false) {
+            DrainBegin::AlreadyDraining {
+                active_then_exit,
+                escalated,
+            } => {
+                assert!(active_then_exit, "then-exit is never downgraded");
+                assert!(!escalated);
+            }
+            other => panic!("expected AlreadyDraining, got {other:?}"),
+        }
+        assert!(drain.snapshot().then_exit);
+
+        // After an abort, a fresh drain starts from the requested terminal
+        // action again (the escalation does not leak across drains).
+        assert!(drain.abort());
+        match drain.begin(Duration::from_secs(30), false, false) {
+            DrainBegin::Started { .. } => {}
+            other => panic!("expected Started, got {other:?}"),
+        }
+        assert!(!drain.snapshot().then_exit, "a fresh drain honors its own then_exit");
+    }
+
+    /// Issue #4521 AC3 — the drain-completion exit-code contract: a then-exit
+    /// drain must exit `EXIT_SHUTDOWN` (143, **non-zero**) so a launchd job with
+    /// `KeepAlive:{SuccessfulExit:true}` stays down; a relaunch drain exits
+    /// `EXIT_RESTART` (0) so it comes straight back. Exiting 0 on the then-exit
+    /// path is the "drained, then relaunched anyway" failure.
+    #[test]
+    fn test_drain_exit_code_selection() {
+        assert_eq!(drain_exit_code(true), EXIT_SHUTDOWN);
+        assert_eq!(drain_exit_code(true), 143);
+        assert_ne!(drain_exit_code(true), 0, "then-exit must never exit 0");
+        assert_eq!(drain_exit_code(false), EXIT_RESTART);
+        assert_eq!(drain_exit_code(false), 0);
+    }
+
+    /// Issue #4521 AC3 — the supervisor's branch selection follows the LIVE
+    /// descriptor, not a value captured when it was spawned. This is what makes
+    /// a mid-drain escalation effective: the supervisor re-reads `then_exit`
+    /// from `DrainState` on each tick (see `run_drain_supervisor`), so the same
+    /// read modeled here flips 0 → 143 after an escalation.
+    #[test]
+    fn test_supervisor_branch_follows_live_then_exit() {
+        let drain = DrainState::new();
+        let _ = drain.begin(Duration::from_secs(120), false, false);
+
+        // Tick 1 (pre-escalation): zero in-flight ⇒ Complete ⇒ relaunch exit.
+        assert_eq!(evaluate_drain_tick(0, false, false), DrainTick::Complete);
+        assert_eq!(drain_exit_code(drain.snapshot().then_exit), EXIT_RESTART);
+
+        // An operator teardown request escalates the drain in place.
+        let _ = drain.begin(Duration::from_secs(120), false, true);
+
+        // Tick 2 (post-escalation, same supervisor): the very same read now
+        // selects the stay-down exit.
+        assert_eq!(evaluate_drain_tick(0, false, false), DrainTick::Complete);
+        assert_eq!(drain_exit_code(drain.snapshot().then_exit), EXIT_SHUTDOWN);
+
+        // The forced-timeout terminal branch reads the same field.
+        assert_eq!(evaluate_drain_tick(2, true, true), DrainTick::TimedOutForce);
+        assert_eq!(drain_exit_code(drain.snapshot().then_exit), EXIT_SHUTDOWN);
+    }
+
+    /// Issue #4521 AC4 (regression pin) — the two drain-complete log lines stay
+    /// **distinct**, so a host log tells an operator which terminal action fired
+    /// without guessing. Asserted against the exact bodies
+    /// `run_drain_supervisor`'s `DrainTick::Complete` arm emits.
+    #[test]
+    fn test_drain_complete_log_lines_remain_distinct() {
+        let then_exit_line = drain_complete_log_line(true, "launchd");
+        let relaunch_line = drain_complete_log_line(false, "launchd");
+        assert_ne!(then_exit_line, relaunch_line);
+        assert!(then_exit_line.contains("staying down"));
+        assert!(then_exit_line.contains("143"));
+        assert!(relaunch_line.contains("supervised relaunch"));
+        assert!(!relaunch_line.contains("staying down"));
     }
 
     /// AC5 (immediate unsupervised refusal): with no supervisor, a drain request
@@ -5921,6 +6188,81 @@ exit 0
         assert!(!drain.is_draining(), "refused drain must NOT pause dispatch");
         assert_eq!(drain.generation(), 0, "refused drain must not bump generation");
 
+        std::env::remove_var(crate::workspace_registry::REGISTRY_PATH_ENV);
+    }
+
+    /// Issue #4521 AC1 — the `AlreadyDraining` ack reports the ACTIVE drain's
+    /// terminal action, not the requested one.
+    ///
+    /// The pre-fix behavior echoed the request: an operator's
+    /// `--drain --then-exit` landing on an in-progress auto-update roll-drain
+    /// was acked `then_exit: true` ("will stop") while the daemon exited 0 and
+    /// launchd relaunched it — the exact incident shape.
+    ///
+    /// No supervisor task is spawned on this path (only `DrainBegin::Started`
+    /// spawns one), so the drain state is primed with `DrainState::begin`
+    /// directly and the process is never at risk of the supervisor's `exit`.
+    #[test]
+    #[serial_test::serial]
+    fn test_already_draining_ack_reports_active_terminal_action() {
+        let (sr, dir, _rec) = setup_sweep_registry_in_tempdir();
+        let root = dir.path().to_path_buf();
+        let empty_reg = dir.path().join("no-such-workspaces.json");
+        std::env::set_var(crate::workspace_registry::REGISTRY_PATH_ENV, &empty_reg);
+        let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
+        pool.seed(root.clone(), sr);
+        let bus = Arc::new(EventBus::new());
+
+        // An auto-update roll-drain is already in flight (`then_exit=false`).
+        let drain = Arc::new(DrainState::new());
+        let _ = drain.begin(Duration::from_secs(600), false, false);
+
+        // Operator teardown request during that window. `then_exit=true` skips
+        // the supervisor gate, so no `LOOM_DAEMON_SUPERVISOR` is needed.
+        let resp = handle_drain_request(&drain, &pool, &root, &bus, Some(60), false, true);
+        match resp {
+            Response::DaemonDrain {
+                accepted,
+                then_exit,
+                ref message,
+                ..
+            } => {
+                assert!(accepted);
+                assert!(
+                    then_exit,
+                    "the ack must report the ACTIVE drain's terminal action (escalated to \
+                     stay-down), not a blind echo"
+                );
+                assert!(message.contains("ESCALATED"), "message was: {message}");
+            }
+            other => panic!("expected DaemonDrain, got {other:?}"),
+        }
+        assert!(drain.snapshot().then_exit, "the active drain now stays down");
+
+        // The reverse: a plain relaunch drain request against the now-teardown
+        // drain must be acked with `then_exit: true` — it is NOT downgraded, and
+        // the ack must not promise a restart that will never happen.
+        std::env::set_var("LOOM_DAEMON_SUPERVISOR", "launchd");
+        let resp = handle_drain_request(&drain, &pool, &root, &bus, Some(60), false, false);
+        match resp {
+            Response::DaemonDrain {
+                accepted,
+                then_exit,
+                ref message,
+                ..
+            } => {
+                assert!(accepted);
+                assert!(then_exit, "then-exit is never downgraded");
+                assert!(
+                    message.contains("not be honored") || message.contains("NOT relaunch"),
+                    "message was: {message}"
+                );
+            }
+            other => panic!("expected DaemonDrain, got {other:?}"),
+        }
+        assert!(drain.snapshot().then_exit);
+
+        std::env::remove_var("LOOM_DAEMON_SUPERVISOR");
         std::env::remove_var(crate::workspace_registry::REGISTRY_PATH_ENV);
     }
 

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -3804,23 +3804,9 @@ async fn handle_restart_command(
     // `AbortDrain` and expect a `DaemonDrain` reply; the plain restart keeps its
     // #4054 `RestartDaemon` / `DaemonRestart` contract byte-for-byte.
     if abort_drain {
-        return handle_drain_reply(
-            &socket_path,
-            &Request::AbortDrain,
-            "loom-daemon drain aborted",
-            "no drain was in progress",
-        )
-        .await;
+        return handle_drain_reply(&socket_path, &Request::AbortDrain, DrainReplyKind::Abort).await;
     }
     if drain {
-        let (accepted_prefix, refused_prefix) = if then_exit {
-            (
-                "loom-daemon drain-then-exit scheduled (will stop, not restart, once drained)",
-                "loom-daemon did NOT drain",
-            )
-        } else {
-            ("loom-daemon drain scheduled", "loom-daemon did NOT drain")
-        };
         return handle_drain_reply(
             &socket_path,
             &Request::DrainAndRestartDaemon {
@@ -3828,8 +3814,11 @@ async fn handle_restart_command(
                 force_after_timeout,
                 then_exit,
             },
-            accepted_prefix,
-            refused_prefix,
+            // Issue #4521: the outcome line is rendered from the *reply*, not
+            // from this flag — see `handle_drain_reply`.
+            DrainReplyKind::Drain {
+                requested_then_exit: then_exit,
+            },
         )
         .await;
     }
@@ -3870,6 +3859,80 @@ async fn handle_restart_command(
     }
 }
 
+/// Which drain-mode variant [`handle_drain_reply`] is rendering (Issue #4521).
+///
+/// Carries the *requested* `then_exit` only so the reply can be compared against
+/// it and a version-skew warning raised — never so the outcome line can be
+/// rendered from the request.
+#[derive(Debug, Clone, Copy)]
+enum DrainReplyKind {
+    /// `AbortDrain` — no `then_exit` semantics at all.
+    Abort,
+    /// `DrainAndRestartDaemon` with the `--then-exit` flag as requested.
+    Drain { requested_then_exit: bool },
+}
+
+/// Render the accepted-ack prefix for a `DaemonDrain` reply (Issue #4521).
+///
+/// **Load-bearing: derived from `reply_then_exit` (what the daemon says the
+/// active drain will do), never from the requested flag.** The original defect
+/// picked this line from the CLI's own `--then-exit` argument, so both a stale
+/// daemon (which dropped the unknown wire field) and an already-in-progress
+/// relaunch-drain produced a confident "will stop, not restart" promise for a
+/// daemon that then exited 0 and was relaunched by launchd.
+///
+/// Pure so the request/reply divergence cases are unit-testable.
+fn drain_accepted_prefix(kind: DrainReplyKind, reply_then_exit: bool) -> &'static str {
+    match kind {
+        DrainReplyKind::Abort => "loom-daemon drain aborted",
+        DrainReplyKind::Drain { .. } => {
+            if reply_then_exit {
+                "loom-daemon drain-then-exit scheduled (will stop, not restart, once drained)"
+            } else {
+                "loom-daemon drain scheduled (will RESTART once drained)"
+            }
+        }
+    }
+}
+
+/// The loud version-skew / escalation warning to print when the reply's
+/// `then_exit` contradicts what was requested (Issue #4521), or `None` when they
+/// agree (or there is nothing to compare, i.e. `--abort-drain`).
+///
+/// Pure for testability; the caller prints it to stderr.
+fn drain_then_exit_mismatch_warning(
+    kind: DrainReplyKind,
+    reply_then_exit: bool,
+) -> Option<&'static str> {
+    let DrainReplyKind::Drain {
+        requested_then_exit,
+    } = kind
+    else {
+        return None;
+    };
+    if requested_then_exit == reply_then_exit {
+        return None;
+    }
+    if requested_then_exit {
+        Some(
+            "WARNING: --then-exit was requested but the daemon reports it will RESTART when \
+             drained, not stay down.\n\
+             \x20 This host will come back up. Two known causes:\n\
+             \x20   1. Version skew: the running daemon predates the --then-exit support and \
+             silently dropped the flag — roll the daemon onto the current binary and re-issue.\n\
+             \x20   2. A drain was already in progress and could not be escalated.\n\
+             \x20 Verify with `loom-daemon status` before assuming this host is torn down.",
+        )
+    } else {
+        Some(
+            "WARNING: a plain --drain was requested but the daemon reports a then-exit drain is \
+             active — it will STOP and stay down when drained, NOT restart.\n\
+             \x20 then-exit is never downgraded. Use `loom-daemon restart --abort-drain` and \
+             re-issue if a relaunch was intended.",
+        )
+    }
+}
+
 /// Shared reply handler for the drain-mode restart variants (Issue #4090): both
 /// `DrainAndRestartDaemon` and `AbortDrain` answer with a `DaemonDrain` frame.
 /// A refused request (unsupervised host, or abort with no drain in progress)
@@ -3877,9 +3940,12 @@ async fn handle_restart_command(
 async fn handle_drain_reply(
     socket_path: &Path,
     request: &Request,
-    accepted_prefix: &str,
-    refused_prefix: &str,
+    kind: DrainReplyKind,
 ) -> Result<()> {
+    let refused_prefix = match kind {
+        DrainReplyKind::Abort => "no drain was in progress",
+        DrainReplyKind::Drain { .. } => "loom-daemon did NOT drain",
+    };
     match query_daemon(socket_path, request).await {
         Ok(Response::DaemonDrain {
             accepted,
@@ -3894,8 +3960,13 @@ async fn handle_drain_reply(
                 } else {
                     supervisor.as_deref().unwrap_or("unknown").to_string()
                 };
+                let accepted_prefix = drain_accepted_prefix(kind, then_exit);
                 println!("{accepted_prefix} (supervisor: {sup_note}, {in_flight} in-flight).");
                 println!("{message}");
+                if let Some(warning) = drain_then_exit_mismatch_warning(kind, then_exit) {
+                    eprintln!();
+                    eprintln!("{warning}");
+                }
                 Ok(())
             } else {
                 eprintln!("{refused_prefix}: {message}");
@@ -3917,6 +3988,78 @@ async fn handle_drain_reply(
             eprintln!("  ./.loom/scripts/cli/loom-daemon-start.sh");
             std::process::exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod drain_reply_render_tests {
+    //! Issue #4521 AC2: the drain outcome line is rendered from the daemon's
+    //! REPLY, and a request/reply divergence raises a loud warning. The
+    //! divergence cases are exactly the two ways an operator gets lied to:
+    //! version skew (a stale daemon drops the unknown `then_exit` wire field and
+    //! defaults it to `false`) and an already-in-progress drain with a different
+    //! terminal action.
+    use super::{drain_accepted_prefix, drain_then_exit_mismatch_warning, DrainReplyKind};
+
+    const DRAIN_THEN_EXIT: DrainReplyKind = DrainReplyKind::Drain {
+        requested_then_exit: true,
+    };
+    const DRAIN_RELAUNCH: DrainReplyKind = DrainReplyKind::Drain {
+        requested_then_exit: false,
+    };
+
+    #[test]
+    fn prefix_follows_the_reply_not_the_request() {
+        // Requested --then-exit, daemon confirms it: "will stop".
+        assert!(drain_accepted_prefix(DRAIN_THEN_EXIT, true).contains("will stop, not restart"));
+        // Requested --then-exit but the daemon reports a relaunch (stale daemon,
+        // or an un-escalatable active drain): the CLI must NOT promise a stop.
+        let skewed = drain_accepted_prefix(DRAIN_THEN_EXIT, false);
+        assert!(skewed.contains("will RESTART"), "got: {skewed}");
+        assert!(!skewed.contains("will stop"), "got: {skewed}");
+        // Plain drain against an active teardown drain renders the stop wording.
+        assert!(drain_accepted_prefix(DRAIN_RELAUNCH, true).contains("will stop, not restart"));
+        assert!(drain_accepted_prefix(DRAIN_RELAUNCH, false).contains("will RESTART"));
+    }
+
+    #[test]
+    fn abort_prefix_is_unchanged_and_never_warns() {
+        assert_eq!(
+            drain_accepted_prefix(DrainReplyKind::Abort, false),
+            "loom-daemon drain aborted"
+        );
+        assert_eq!(drain_accepted_prefix(DrainReplyKind::Abort, true), "loom-daemon drain aborted");
+        assert!(drain_then_exit_mismatch_warning(DrainReplyKind::Abort, false).is_none());
+        assert!(drain_then_exit_mismatch_warning(DrainReplyKind::Abort, true).is_none());
+    }
+
+    #[test]
+    fn agreement_produces_no_warning() {
+        assert!(drain_then_exit_mismatch_warning(DRAIN_THEN_EXIT, true).is_none());
+        assert!(drain_then_exit_mismatch_warning(DRAIN_RELAUNCH, false).is_none());
+    }
+
+    /// The incident shape: `--then-exit` requested, daemon replies `false`. The
+    /// warning must name the version-skew cause explicitly — that is what a
+    /// deploy operator needs in order to roll the daemon and re-issue rather
+    /// than assume the host is torn down.
+    #[test]
+    fn requested_then_exit_but_reply_says_restart_warns_loudly() {
+        let warning =
+            drain_then_exit_mismatch_warning(DRAIN_THEN_EXIT, false).expect("divergence must warn");
+        assert!(warning.starts_with("WARNING:"));
+        assert!(warning.contains("Version skew"));
+        assert!(warning.contains("RESTART"));
+        assert!(warning.contains("loom-daemon status"));
+    }
+
+    #[test]
+    fn plain_drain_against_active_teardown_warns() {
+        let warning =
+            drain_then_exit_mismatch_warning(DRAIN_RELAUNCH, true).expect("divergence must warn");
+        assert!(warning.starts_with("WARNING:"));
+        assert!(warning.contains("never downgraded"));
+        assert!(warning.contains("--abort-drain"));
     }
 }
 

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -442,6 +442,13 @@ pub enum Request {
     ///   nothing to prove supervision *for*). `#[serde(default)]` keeps
     ///   pre-#4343 wire data (`{"type":"DrainAndRestartDaemon","payload":{...}}`
     ///   with no `then_exit` key) parsing as `false` — the original behavior.
+    ///
+    ///   When a drain is **already in progress**, `timeout_secs` and
+    ///   `force_after_timeout` are ignored (the active deadline is pinned) but
+    ///   `then_exit: true` **escalates** the active drain one-way from relaunch
+    ///   to stay-down (Issue #4521); `then_exit: false` never downgrades an
+    ///   active teardown drain. The reply's `then_exit` reports what the active
+    ///   drain will actually do — see [`Response::DaemonDrain`].
     DrainAndRestartDaemon {
         timeout_secs: Option<u64>,
         force_after_timeout: bool,
@@ -618,10 +625,21 @@ pub enum Response {
     /// `in_flight` is the cross-root non-terminal sweep count at request time,
     /// so the operator immediately sees how much work the drain must wait for.
     /// `message` is a human-readable explanation for operator output.
-    /// `then_exit` (Issue #4343) echoes back the request's `then_exit`: `true`
-    /// means the daemon will exit and stay down once drained (never relaunch),
-    /// rather than restart. `#[serde(default)]` keeps pre-#4343 wire data
-    /// parsing (as `false`).
+    /// `then_exit` (Issue #4343) reports the **active** drain's terminal action:
+    /// `true` means the daemon will exit and stay down once drained (never
+    /// relaunch), `false` means it will exit for a supervised relaunch.
+    ///
+    /// It is **not** an echo of the request (Issue #4521). On the
+    /// already-draining path the requested value may differ from the active
+    /// drain's: a `then_exit: true` request escalates an in-progress
+    /// relaunch-drain one-way to stay-down (so the reply is `true`), while a
+    /// `then_exit: false` request against an active teardown drain is *not*
+    /// honored (the reply stays `true`). Clients MUST render "will stop" vs
+    /// "will restart" from this field, never from their own request — a client
+    /// that renders from the request promises a teardown the daemon never
+    /// performs. `#[serde(default)]` keeps pre-#4343 wire data parsing (as
+    /// `false`), which is also how a new client detects version skew against an
+    /// old daemon that silently dropped the request's `then_exit`.
     DaemonDrain {
         accepted: bool,
         supervisor: Option<String>,

--- a/loom-daemon/tests/common/mod.rs
+++ b/loom-daemon/tests/common/mod.rs
@@ -28,6 +28,10 @@ static TEST_PREFIX: LazyLock<String> =
 /// The previous 5s budget was calibrated for `cargo test`, which runs one test
 /// binary at a time, and it produced spurious "failed to create socket within 5s"
 /// failures on a loaded host.
+// Not every test binary that includes this module uses `TestDaemon` (e.g. tests
+// that need raw `Child` control over the daemon they spawn), so the shared
+// helper is `dead_code`-exempt rather than warning per-binary.
+#[allow(dead_code)]
 const DAEMON_SOCKET_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Absolute path to the `loom-daemon` binary under test.
@@ -46,12 +50,14 @@ pub fn daemon_bin() -> PathBuf {
 }
 
 /// Test daemon instance that cleans up on drop
+#[allow(dead_code)]
 pub struct TestDaemon {
     _temp_dir: TempDir,
     socket_path: PathBuf,
     process: Option<Child>,
 }
 
+#[allow(dead_code)]
 impl TestDaemon {
     /// Start a new daemon instance with a unique socket path
     pub async fn start() -> Result<Self> {

--- a/loom-daemon/tests/integration_drain_then_exit.rs
+++ b/loom-daemon/tests/integration_drain_then_exit.rs
@@ -1,0 +1,166 @@
+// Integration test for the drain-then-exit teardown contract (Issue #4521).
+//
+// The incident this pins: `loom-daemon restart --drain --then-exit` drained
+// correctly and then the daemon came straight back up, because the completion
+// path exited `0`. Under launchd's `KeepAlive:{SuccessfulExit:true}` a `0` exit
+// can NEVER stay stopped — the terminal exit code IS the contract, so it is
+// asserted end-to-end against the real binary rather than only in a unit test.
+//
+// The assertion is deliberately narrow and behavioral:
+//   1. the process exits `143` (EXIT_SHUTDOWN, non-zero), and
+//   2. it does not re-listen (nothing answers on the socket afterwards).
+//
+// expect/unwrap are acceptable here since tests should panic on failure.
+#![allow(clippy::expect_used)]
+#![allow(clippy::unwrap_used)]
+
+mod common;
+
+use common::{daemon_bin, TestClient};
+use serial_test::serial;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Kills the spawned daemon if the test panics before it exits on its own, so a
+/// failing assertion never leaks a daemon that keeps polling this host.
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// `EXIT_SHUTDOWN` — the "exited on purpose, stay down" code. Hardcoded rather
+/// than imported so this test pins the *observable* number a supervisor sees.
+const EXPECTED_EXIT_CODE: i32 = 143;
+
+/// Liveness bound for the drain-then-exit round trip. Sized like the other
+/// daemon integration bounds (#4385): generous, because the poll loop below
+/// returns as soon as the child exits, so a large bound costs a passing run
+/// nothing and only stops a saturated host from turning a liveness check into a
+/// latency assertion.
+const DRAIN_EXIT_WAIT: Duration = Duration::from_secs(60);
+
+/// Requesting `--drain --then-exit` with zero in-flight sweeps must terminate
+/// the daemon with a NON-ZERO exit (143) and leave nothing listening.
+#[tokio::test]
+#[serial]
+async fn test_drain_then_exit_exits_143_and_stays_down() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let socket_path = temp_dir.path().join("daemon.sock");
+    // An empty workspace registry + a scratch workspace root guarantee the
+    // cross-root in-flight count is 0, so the drain reaches its terminal tick
+    // immediately instead of waiting on this host's real sweeps.
+    let workspaces_json = temp_dir.path().join("workspaces.json");
+    let workspace_root = temp_dir.path().join("workspace");
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+
+    let mut child = ChildGuard(
+        Command::new(daemon_bin())
+            .current_dir(&workspace_root)
+            .env("LOOM_SOCKET_PATH", &socket_path)
+            .env("LOOM_WORKSPACES_PATH", &workspaces_json)
+            // Pinned, not merely inherited: this test may run on a host that is
+            // itself running Loom, where an inherited `LOOM_WORKSPACE` makes the
+            // scratch daemon count that repo's REAL in-flight sweeps and the
+            // drain never completes.
+            .env("LOOM_WORKSPACE", &workspace_root)
+            .env("RUST_LOG", "debug")
+            .env("LOOM_NO_RESTORE", "1")
+            // Deliberately UNSET: a then-exit drain must not require a supervisor
+            // (there is nothing to relaunch into), so this also pins that the
+            // supervisor refusal gate is skipped for `then_exit`.
+            .env_remove("LOOM_DAEMON_SUPERVISOR")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn daemon"),
+    );
+
+    // Wait for the socket to appear, then connect.
+    let start = Instant::now();
+    while !socket_path.exists() {
+        assert!(start.elapsed() < DRAIN_EXIT_WAIT, "daemon never created its socket");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let mut client = TestClient::connect(&socket_path)
+        .await
+        .expect("connect to daemon");
+    client
+        .ping()
+        .await
+        .expect("daemon answers Ping before drain");
+
+    // Request the teardown drain. The reply is best-effort on purpose: the
+    // supervisor task can win the race against the reply flush when there are
+    // zero in-flight sweeps, and this test asserts the *exit contract*, not the
+    // ack. When a reply does arrive it must report `then_exit: true` (the
+    // active drain's terminal action, Issue #4521).
+    let request = serde_json::json!({
+        "type": "DrainAndRestartDaemon",
+        "payload": {
+            "timeout_secs": 60,
+            "force_after_timeout": false,
+            "then_exit": true
+        }
+    });
+    if let Ok(reply) = client.send_request(request).await {
+        assert_eq!(
+            reply.get("type").and_then(serde_json::Value::as_str),
+            Some("DaemonDrain"),
+            "unexpected reply: {reply:?}"
+        );
+        let payload = reply.get("payload").expect("DaemonDrain payload");
+        assert_eq!(
+            payload.get("accepted").and_then(serde_json::Value::as_bool),
+            Some(true),
+            "then-exit drain must be accepted without a supervisor: {reply:?}"
+        );
+        assert_eq!(
+            payload
+                .get("then_exit")
+                .and_then(serde_json::Value::as_bool),
+            Some(true),
+            "the reply must report the active drain's terminal action: {reply:?}"
+        );
+    }
+    drop(client);
+
+    // The daemon must END. Not restart, not linger.
+    let start = Instant::now();
+    let status = loop {
+        match child.0.try_wait().expect("try_wait") {
+            Some(status) => break status,
+            None => {
+                assert!(
+                    start.elapsed() < DRAIN_EXIT_WAIT,
+                    "daemon did not exit after drain-then-exit with 0 in-flight"
+                );
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        }
+    };
+
+    assert_eq!(
+        status.code(),
+        Some(EXPECTED_EXIT_CODE),
+        "drain-then-exit must exit {EXPECTED_EXIT_CODE} (EXIT_SHUTDOWN); a 0 exit is relaunched \
+         forever by launchd's KeepAlive:{{SuccessfulExit:true}}. Got {status:?}"
+    );
+    assert!(
+        !status.success(),
+        "the exit MUST be non-zero — that is the whole stays-down contract"
+    );
+
+    // And nothing re-listens: a fresh connect+Ping must not be answered.
+    let re_listened = match TestClient::connect(&socket_path).await {
+        Ok(mut c) => c.ping().await.is_ok(),
+        Err(_) => false,
+    };
+    assert!(
+        !re_listened,
+        "nothing may answer on the socket after a drain-then-exit — the daemon must stay down"
+    );
+}


### PR DESCRIPTION
## Summary

The originally reported defect (`restart --drain --then-exit` relaunching under launchd) is **already fixed on main** by #4420 — the completion path exits `EXIT_SHUTDOWN = 143`, which `KeepAlive:{SuccessfulExit:true}` does not relaunch. The incident was version skew during a deploy.

This PR fixes the three residual defects the Curator verified still reachable on current main, all of which reproduce the *same* observable failure (an ack promising teardown, followed by a relaunch):

1. `DrainState::begin` silently ignored `then_exit` when a drain was already in progress, while the `AlreadyDraining` response arm set `accepted: true` and echoed the **requested** `then_exit`. The autonomous self-update loop drains with `then_exit=false` (a roll); an operator teardown request landing in that window was acked "will stop" and the daemon exited 0 and came back.
2. The CLI picked its outcome line ("drain-then-exit scheduled…") from its **own** flag, not the reply — so against a stale daemon that drops the unknown `then_exit` wire field it still promised teardown.
3. Nothing exercised `then_exit` reaching the drain-completion exit path.

### AC1 design decision: escalate (documented at the decision point)

Given the implementer's-choice between "ack states the drain will relaunch + point at `--abort-drain`" and "escalate the active drain to stay-down", this PR **escalates**, one-way (`relaunch -> stay-down`, never the reverse).

Rationale (also in the `DrainState::begin` doc comment and in `defaults/docs/daemon-reference.md`): the refuse-and-retry path is racy in exactly the case that matters — an operator would have to `--abort-drain` and re-issue, and the auto-update roll can complete *between* those two commands, relaunching the daemon on a host that is about to be powered off. Escalation is monotonic and conservative (staying down is strictly the safer terminal action) and honors teardown intent on the first command.

The roll is not stranded silently: the escalation is logged by the daemon, surfaced in the ack message (which explicitly points at `--abort-drain` + re-issue if a relaunch was wanted), and `IpcDrainTrigger::trigger` logs that the rebuilt binary will not be picked up until the daemon is started again.

## Changes

- **`loom-daemon/src/ipc.rs`**
  - `DrainBegin::AlreadyDraining` now carries `active_then_exit` + `escalated`.
  - `DrainState::begin` escalates `then_exit` one-way on the already-draining path (`timeout` / `force_after_timeout` / deadline stay pinned as before).
  - `run_drain_supervisor` **re-reads `then_exit` from `DrainState` on every tick** (one consistent snapshot read alongside deadline/force) instead of capturing it at spawn, so a running supervisor observes a mid-drain escalation. The `then_exit` parameter is gone.
  - New pure `drain_exit_code(then_exit)` (143 vs 0) and `drain_complete_log_line(then_exit, supervisor)` so the stays-down contract and the log-line distinctness are assertions, not conventions.
  - The `AlreadyDraining` response arm renders four truthful messages (escalated / matched teardown / matched relaunch / not-honored downgrade), returns `then_exit: active_then_exit`, and publishes a `daemon.drain.already_draining` event.
- **`loom-daemon/src/main.rs`** — new `DrainReplyKind` + pure `drain_accepted_prefix` / `drain_then_exit_mismatch_warning`. `handle_drain_reply` renders the outcome from the reply and prints a loud stderr warning on request/reply divergence, naming version skew as cause #1.
- **`loom-daemon/src/types.rs`** — `Response::DaemonDrain.then_exit` and `Request::DrainAndRestartDaemon.then_exit` doc contracts updated (reply = active drain's action, not an echo; escalation semantics).
- **`loom-daemon/src/auto_update.rs`** — the roll trigger warns when it joins an in-progress then-exit drain (the rebuilt binary will not be launched until the daemon is started again).
- **`defaults/docs/daemon-reference.md`** (symlinked as `.loom/docs/daemon-reference.md`) — documents the escalation rule, the reply-not-request contract, and the version-skew warning.
- **Tests** — 6 new unit tests + 1 new integration test (details below).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `DaemonDrain.then_exit` always reflects the ACTIVE drain, never a blind echo | PASS | `ipc::tests::test_already_draining_ack_reports_active_terminal_action` — a `then_exit=true` request against an active roll-drain is acked `then_exit: true` + "ESCALATED"; the reverse (`then_exit=false` against an active teardown) is acked `then_exit: true` with a "will not be honored" message |
| Escalation is one-way, and the running supervisor observes it | PASS | `ipc::tests::test_drain_then_exit_escalates_one_way` (relaunch->stay-down escalates, stay-down->relaunch does not, deadline/force stay pinned, no leak across drains) and `test_supervisor_branch_follows_live_then_exit` (the supervisor's live-descriptor read flips `0 -> 143` after escalation) |
| Design choice documented | PASS | `DrainState::begin` doc comment (decision point) + `defaults/docs/daemon-reference.md` + the "AC1 design decision" section above |
| `handle_drain_reply` renders "will stop" vs "will restart" from the RESPONSE | PASS | `drain_reply_render_tests::prefix_follows_the_reply_not_the_request` — requested `--then-exit` + reply `then_exit=false` renders "will RESTART" and never "will stop" |
| Loud warning when reply's `then_exit` differs from the request's | PASS | `drain_reply_render_tests::requested_then_exit_but_reply_says_restart_warns_loudly` (names version skew + `loom-daemon status`) and `plain_drain_against_active_teardown_warns`; `agreement_produces_no_warning` / `abort_prefix_is_unchanged_and_never_warns` pin the negative cases |
| A test covers `then_exit` reaching the drain-completion path | PASS | Unit: `test_drain_exit_code_selection` + `test_supervisor_branch_follows_live_then_exit`. Integration: `tests/integration_drain_then_exit.rs` spawns the built binary, requests drain-then-exit with 0 in-flight, asserts exit code **143** (and `!status.success()`) and that nothing re-listens on the socket |
| The two drain-complete log lines remain distinct (don't regress) | PASS | `ipc::tests::test_drain_complete_log_lines_remain_distinct` pins them via the extracted `drain_complete_log_line`, which is what the supervisor actually emits |
| Edge: `--abort-drain` then a fresh `--drain --then-exit` works | PASS | Covered at the end of `test_drain_then_exit_escalates_one_way` (post-abort, a fresh drain honors its own `then_exit`) |
| Edge: the auto-update roll path (`then_exit=false`) still relaunches as before | PASS | `DrainBegin::Started` path is unchanged; `test_drain_state_lifecycle` (updated) asserts a `then_exit=false` request escalates nothing, and `drain_exit_code(false) == EXIT_RESTART == 0` |

## Test Plan

```
cargo fmt --all -- --check                                   # clean
cargo clippy -p loom-daemon -p loom-api -- -D warnings ...   # clean (CI's exact flag set)
cargo test -p loom-daemon --lib                              # 2456 passed, 0 failed
cargo test -p loom-daemon --bin loom-daemon                  #   51 passed, 0 failed
cargo test -p loom-daemon --test integration_drain_then_exit #    1 passed
cargo test -p loom-daemon --test integration_basic \
                          --test integration_singleton_guard #   11 passed
```

The integration test pins `LOOM_WORKSPACE` / `LOOM_WORKSPACES_PATH` to scratch paths deliberately: on a host that is *itself* running Loom, an inherited `LOOM_WORKSPACE` makes the scratch daemon count that repo's real in-flight sweeps and the drain never completes. It also wraps the child in a kill-on-drop guard so a failing assertion cannot leak a daemon. The reply assertion is best-effort (the supervisor can win the race against the reply flush at 0 in-flight) — the exit code and the no-re-listen check are the load-bearing assertions.

## Pre-existing Issues (Not Addressed)

Two subprocess-spawning tests flaked intermittently on this (heavily loaded) build host and pass deterministically in isolation and at reduced parallelism — both are untouched by this diff:

- `auto_update::tests::test_run_update_script_exit_1_is_retryable` (runs a helper script under a timeout)
- `disk_headroom::tests::test_worktree_root_free_gb_returns_a_value` (shells out to `df -Pk`)

`RUST_TEST_THREADS=4 cargo test -p loom-daemon --lib` -> 2456 passed, 0 failed.

Closes #4521