### PR TITLE
fix: add REST fallback to check-duplicate.sh when GraphQL is rate-limited

### DIFF
--- a/defaults/scripts/check-duplicate.sh
+++ b/defaults/scripts/check-duplicate.sh
@@ -21,11 +21,26 @@
 #   1 - Potential duplicates found (listed to stdout)
 #   2 - Error (invalid arguments, gh command failed, etc.)
 #
+# A confirmed duplicate always wins over a partial failure (#4526): if ANY
+# search pool (open issues / merged PRs / closed issues) finds a match, the
+# exit code is 1 even when another pool could not be searched at all. Exit 2
+# means "no answer at all", never "we found something but also had trouble".
+#
 # Output format (when duplicates found):
 #   DUPLICATE_FOUND
 #   #<number>: <title> (similarity: <percent>%)
 #   PR #<number>: <title> (similarity: <percent>%)
 #   ...
+#
+# Degraded-coverage marker lines (#4526), appended after the match list when
+# GraphQL rate-limiting forced a degraded search. Both are informational: they
+# are not matches, and the --json parser reports them as `search_incomplete`
+# rather than as entries in `matches`.
+#   SEARCH_INCOMPLETE: <pools> -- that pool could not be searched at all
+#                                 (GraphQL rate-limited AND REST fallback
+#                                 failed), so the match list is partial
+#   REST_FALLBACK: <pools>     -- that pool was answered by the REST fallback,
+#                                 whose similarity ranking basis differs
 #
 # Degenerate-result self-detection (#4409): if more than half of the
 # candidates scanned in a given search (open issues / merged PRs / closed
@@ -251,15 +266,37 @@ calculate_similarity() {
     echo "$percent"
 }
 
-# Detect GitHub's GraphQL rate-limit error signature in captured `gh` output
-# (stdout+stderr merged via `2>&1`). GraphQL and REST draw on independent
-# quotas (confirmed live during the #4526 incident: `gh issue/pr list --json
-# ...` failed with this exact string while `gh api repos/OWNER/REPO/...`
-# succeeded), so this specific error -- and only this one -- justifies
-# retrying the same query via REST instead of giving up.
+# Detect a GitHub rate-limit rejection in captured `gh` output (stdout+stderr
+# merged via `2>&1`). GraphQL and REST draw on independent quotas (confirmed
+# live during the #4526 incident: `gh issue/pr list --json ...` failed with a
+# rate-limit error while `gh api repos/OWNER/REPO/...` succeeded), so this
+# class of error -- and only this class -- justifies retrying the same query
+# via REST instead of giving up.
+#
+# The signature table below mirrors loom-daemon/src/rate_limit_breaker.rs's
+# RATE_LIMIT_SIGNATURES, which is this repo's tested ground truth for what
+# `gh` actually prints. Two phrasings matter and they are NOT substrings of
+# each other:
+#
+#   GraphQL (`gh issue list` / `gh pr list`, i.e. every call in this script):
+#     "GraphQL: API rate limit already exceeded for user ID ..."
+#   REST (`gh api ...`, i.e. the fallbacks below):
+#     "HTTP 403: API rate limit exceeded for ..."
+#
+# The word "already" breaks the contiguous "API rate limit exceeded" match, so
+# a single-pattern check misses the GraphQL form -- which is precisely the
+# form #4526 is about. Matching is case-insensitive, as in the Rust original.
 is_rate_limit_error() {
-    local text="$1"
-    [[ "$text" == *"API rate limit exceeded"* ]]
+    local text
+    text=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+    case "$text" in
+        *"api rate limit exceeded"*) return 0 ;;
+        *"api rate limit already exceeded"*) return 0 ;;
+        *"secondary rate limit"*) return 0 ;;
+        *"abuse detection mechanism"*) return 0 ;;
+        *"was submitted too quickly"*) return 0 ;;
+    esac
+    return 1
 }
 
 # Resolve "owner/repo" via REST, for the REST fallback paths below. Mirrors
@@ -683,10 +720,37 @@ main() {
         exit 2
     fi
 
+    # Verdict tracking (#4526). "A duplicate was found" and "a search pool
+    # could not be checked at all" are INDEPENDENT facts, and each of the
+    # three pools (open issues / merged PRs / closed issues) can report them
+    # separately -- partial rate-limiting across pools is the exact scenario
+    # this fallback exists for. Keeping the two facts in separate variables
+    # (instead of overwriting one exit code as each pool reports in) is what
+    # stops a total failure in one pool from discarding a confirmed match
+    # found by another: `exit_code` is derived from both, once, below.
+    #
+    #   duplicate_found  -> any pool produced a match/NON_DISCRIMINATIVE line
+    #   incomplete_pools -> human-readable list of pools where GraphQL was
+    #                       rate-limited AND the REST fallback also failed
+    #   fallback_pools   -> pools that were answered by the REST fallback
+    #
+    # Comma-joined strings rather than arrays: this script runs under
+    # `set -u` on bash 3.2 (macOS system bash), where empty-array expansion
+    # is a portability landmine.
+    local duplicate_found=false
+    local incomplete_pools=""
+    local fallback_pools=""
+    local header_labeled_rest=false
+
     # Search for similar issues
     local result
     local exit_code=0
     result=$(search_similar_issues "$title" "$body" "$threshold") || exit_code=$?
+    if [[ $exit_code -eq 1 ]]; then
+        duplicate_found=true
+    elif [[ $exit_code -eq 2 ]]; then
+        incomplete_pools="open issues"
+    fi
 
     # If --include-merged-prs, also search merged PRs and closed issues
     local merged_result=""
@@ -698,11 +762,15 @@ main() {
         closed_result=$(search_closed_issues "$title" "$body" "$threshold") || closed_exit_code=$?
 
         # #4526: a GraphQL rate-limit that ALSO fails via REST means this
-        # pool genuinely could not be checked -- surface that as exit 2
-        # ("could not run at all"), not silently as "no duplicates" the way
-        # a plain `return 0` used to.
-        if [[ $merged_exit_code -eq 2 || $closed_exit_code -eq 2 ]]; then
-            exit_code=2
+        # pool genuinely could not be checked. Record it; the final verdict
+        # below turns that into exit 2 ("could not run at all") rather than
+        # silently reporting "no duplicates" the way a plain `return 0` used
+        # to -- but only when no other pool found a real duplicate.
+        if [[ $merged_exit_code -eq 2 ]]; then
+            incomplete_pools="${incomplete_pools:+${incomplete_pools}, }merged PRs"
+        fi
+        if [[ $closed_exit_code -eq 2 ]]; then
+            incomplete_pools="${incomplete_pools:+${incomplete_pools}, }closed issues"
         fi
 
         # Strip the leading REST-fallback sentinel line (if present) from
@@ -719,28 +787,48 @@ main() {
             closed_rest_fallback=true
             closed_result="${closed_result#RATE_LIMIT_FALLBACK$'\n'}"
         fi
+        if $merged_rest_fallback; then
+            fallback_pools="${fallback_pools:+${fallback_pools}, }merged PRs"
+        fi
+        if $closed_rest_fallback; then
+            fallback_pools="${fallback_pools:+${fallback_pools}, }closed issues"
+        fi
 
         # If we found matches in merged PRs or closed issues, flag as duplicate
         if [[ -n "$merged_result" || -n "$closed_result" ]]; then
-            if [[ $exit_code -eq 0 ]]; then
-                # No open issue duplicates found, but merged/closed matches
-                # exist. Only synthesize a "DUPLICATE_FOUND" umbrella header
-                # when at least one of merged/closed is a real match list --
-                # a degenerate (#4409) result already self-announces with its
-                # own "NON_DISCRIMINATIVE (...)" line, and prefixing THAT
-                # with "DUPLICATE_FOUND" would be misleading. Check each side
+            if ! $duplicate_found; then
+                # The open-issues search produced no match of its own (either
+                # it found nothing, or it could not run at all -- in both
+                # cases $result is empty here, so overwriting it is safe), but
+                # merged/closed matches exist. Only synthesize a
+                # "DUPLICATE_FOUND" umbrella header when at least one of
+                # merged/closed is a real match list -- a degenerate (#4409)
+                # result already self-announces with its own
+                # "NON_DISCRIMINATIVE (...)" line, and prefixing THAT with
+                # "DUPLICATE_FOUND" would be misleading. Check each side
                 # independently (not "both must be non-degenerate") so a real
                 # match on one side still gets its header even when the other
                 # side is degenerate.
                 if [[ ( -n "$merged_result" && "$merged_result" != NON_DISCRIMINATIVE* ) || \
                       ( -n "$closed_result" && "$closed_result" != NON_DISCRIMINATIVE* ) ]]; then
-                    if $merged_rest_fallback || $closed_rest_fallback; then
+                    if [[ -n "$fallback_pools" ]]; then
                         result="DUPLICATE_FOUND (REST fallback -- similarity ranking basis differs from GraphQL)"$'\n'
+                        header_labeled_rest=true
                     else
                         result="DUPLICATE_FOUND"$'\n'
                     fi
                 fi
-                exit_code=1
+                duplicate_found=true
+            fi
+            # Re-establish the line separator before appending another pool's
+            # list. `result=$(search_similar_issues ...)` came back through a
+            # command substitution, which STRIPS the trailing newline, so
+            # appending directly splices the last open-issue line and the
+            # first merged-PR line into one line -- which the --json parser
+            # then reads as a single bogus match (the second entry's number
+            # lost, its title swallowed into the first entry's title).
+            if [[ -n "$result" && "$result" != *$'\n' ]]; then
+                result+=$'\n'
             fi
             if [[ -n "$merged_result" ]]; then
                 result+="$merged_result"$'\n'
@@ -749,6 +837,42 @@ main() {
                 result+="$closed_result"$'\n'
             fi
         fi
+    fi
+
+    # Degraded-coverage notes (#4526). Appended as their own marker lines so a
+    # Curator reading text output learns WHY a match list may be partial or
+    # differently ranked, and so --json can surface it as a field. Both are
+    # skipped by the --json line parser below.
+    #
+    # SEARCH_INCOMPLETE only appears alongside a real match: with no match the
+    # verdict is exit 2 and the per-pool stderr errors already say what broke.
+    if [[ -n "$result" && "$result" != *$'\n' ]] && \
+       { [[ -n "$incomplete_pools" ]] || [[ -n "$fallback_pools" ]]; } && $duplicate_found; then
+        result+=$'\n'
+    fi
+    if [[ -n "$incomplete_pools" ]] && $duplicate_found; then
+        result+="SEARCH_INCOMPLETE: ${incomplete_pools} -- GraphQL rate-limited and REST fallback also failed; matches below are partial"$'\n'
+    fi
+    # REST_FALLBACK covers the interleaving the umbrella header above cannot:
+    # the open-issues search already matched via ordinary GraphQL (so its own
+    # plain "DUPLICATE_FOUND" header stands) while a LATER pool fell back to
+    # REST. Without this, that REST-sourced subset would be reported with no
+    # indication its similarity ranking basis differs.
+    if [[ -n "$fallback_pools" ]] && ! $header_labeled_rest && $duplicate_found; then
+        result+="REST_FALLBACK: ${fallback_pools} -- answered via REST; similarity ranking basis differs from GraphQL"$'\n'
+    fi
+
+    # Final verdict (#4526): a confirmed duplicate ALWAYS outranks incomplete
+    # coverage. Reporting exit 2 when some other pool did find a match would
+    # discard the actionable answer -- and in --json mode the exit-2 branch
+    # below emits a bare {"error": ...} with no `matches` array at all, so the
+    # match would vanish entirely rather than merely be mis-coded.
+    if $duplicate_found; then
+        exit_code=1
+    elif [[ -n "$incomplete_pools" ]]; then
+        exit_code=2
+    else
+        exit_code=0
     fi
 
     # Cross-reference probe (--issue N only, issue #4162). Distinct from
@@ -780,6 +904,16 @@ main() {
                 degenerate=true
             fi
 
+            # Degraded-coverage flag (#4526): true when at least one search
+            # pool could not be checked at all (GraphQL rate-limited and its
+            # REST fallback also failed) while another pool still produced
+            # matches. Surfaced separately from `matches` so a caller can tell
+            # "no other duplicates exist" from "we could not look everywhere".
+            local search_incomplete=false
+            if [[ -n "$incomplete_pools" ]]; then
+                search_incomplete=true
+            fi
+
             # Parse duplicates into JSON (unconditional -- harmless no-op on
             # an empty $result, e.g. exit_code 0 or "related work only")
             local matches="[]"
@@ -788,6 +922,10 @@ main() {
                 # (#4526) emits "DUPLICATE_FOUND (REST fallback -- ...)".
                 [[ "$line" == DUPLICATE_FOUND* ]] && continue
                 [[ "$line" == NON_DISCRIMINATIVE* ]] && continue
+                # Degraded-coverage marker lines (#4526) -- reported via the
+                # `search_incomplete` field, never as a match.
+                [[ "$line" == SEARCH_INCOMPLETE:* ]] && continue
+                [[ "$line" == REST_FALLBACK:* ]] && continue
                 [[ -z "$line" ]] && continue
 
                 # Parse "#123: Title (similarity: 75%)" or "PR #123: Title (similarity: 75%)"
@@ -821,13 +959,9 @@ main() {
             fi
 
             if [[ "$matches" == "[]" ]]; then
-                if $degenerate; then
-                    echo "{\"duplicate_found\": false, \"degenerate\": true, \"matches\": []}"
-                else
-                    echo '{"duplicate_found": false, "degenerate": false, "matches": []}'
-                fi
+                echo "{\"duplicate_found\": false, \"degenerate\": $degenerate, \"search_incomplete\": $search_incomplete, \"matches\": []}"
             else
-                echo "{\"duplicate_found\": true, \"degenerate\": $degenerate, \"matches\": $matches}"
+                echo "{\"duplicate_found\": true, \"degenerate\": $degenerate, \"search_incomplete\": $search_incomplete, \"matches\": $matches}"
             fi
         fi
     else

--- a/defaults/scripts/check-duplicate.sh
+++ b/defaults/scripts/check-duplicate.sh
@@ -251,6 +251,23 @@ calculate_similarity() {
     echo "$percent"
 }
 
+# Detect GitHub's GraphQL rate-limit error signature in captured `gh` output
+# (stdout+stderr merged via `2>&1`). GraphQL and REST draw on independent
+# quotas (confirmed live during the #4526 incident: `gh issue/pr list --json
+# ...` failed with this exact string while `gh api repos/OWNER/REPO/...`
+# succeeded), so this specific error -- and only this one -- justifies
+# retrying the same query via REST instead of giving up.
+is_rate_limit_error() {
+    local text="$1"
+    [[ "$text" == *"API rate limit exceeded"* ]]
+}
+
+# Resolve "owner/repo" via REST, for the REST fallback paths below. Mirrors
+# the resolution already used by search_cross_references() (#4162).
+get_repo_nwo() {
+    gh repo view --json nameWithOwner --jq '.nameWithOwner'
+}
+
 # Search for similar issues
 search_similar_issues() {
     local title="$1"
@@ -266,11 +283,26 @@ search_similar_issues() {
         return 0
     fi
 
-    # Search open issues
+    # Search open issues. On a GraphQL rate-limit failure, retry via REST
+    # (an independent quota, #4526) before giving up.
     local issues
+    local rest_fallback=false
     if ! issues=$($FORGE issue list --state=open --limit=50 --json number,title,body 2>&1); then
-        print_error "Failed to fetch issues: $issues"
-        return 2
+        if is_rate_limit_error "$issues"; then
+            local repo_nwo rest_issues
+            if repo_nwo=$(get_repo_nwo 2>&1) && \
+               rest_issues=$(gh api "repos/${repo_nwo}/issues?state=open&per_page=50" 2>&1); then
+                # REST's /issues endpoint also returns PRs; exclude them.
+                issues=$(echo "$rest_issues" | jq -c '[.[] | select(.pull_request == null)]')
+                rest_fallback=true
+            else
+                print_error "GraphQL rate-limited fetching open issues, and REST fallback also failed: ${rest_issues:-$repo_nwo}"
+                return 2
+            fi
+        else
+            print_error "Failed to fetch issues: $issues"
+            return 2
+        fi
     fi
 
     # Process each issue for similarity
@@ -315,7 +347,15 @@ search_similar_issues() {
         return 1
     fi
 
-    echo "DUPLICATE_FOUND"
+    # Degraded-mode labeling (#4526): a REST-sourced result set ranks
+    # candidates differently than GraphQL's, so a Curator reading the output
+    # needs to know the basis changed. Callers matching on "DUPLICATE_FOUND"
+    # must match a prefix, not exact-equals (see main()'s --json parser below).
+    if $rest_fallback; then
+        echo "DUPLICATE_FOUND (REST fallback -- similarity ranking basis differs from GraphQL)"
+    else
+        echo "DUPLICATE_FOUND"
+    fi
     echo -n "$duplicates"
     return 1
 }
@@ -334,11 +374,26 @@ search_merged_prs() {
         return 0
     fi
 
-    # Search recently merged PRs
+    # Search recently merged PRs. On a GraphQL rate-limit failure, retry via
+    # REST (#4526). REST has no `state=merged` filter, so fetch closed PRs
+    # and filter to actually-merged ones locally.
     local prs
+    local rest_fallback=false
     if ! prs=$($FORGE pr list --state=merged --limit=20 --json number,title,body 2>&1); then
-        print_warning "Failed to fetch merged PRs: $prs"
-        return 0
+        if is_rate_limit_error "$prs"; then
+            local repo_nwo rest_prs
+            if repo_nwo=$(get_repo_nwo 2>&1) && \
+               rest_prs=$(gh api "repos/${repo_nwo}/pulls?state=closed&per_page=20" 2>&1); then
+                prs=$(echo "$rest_prs" | jq -c '[.[] | select(.merged_at != null)]')
+                rest_fallback=true
+            else
+                print_error "GraphQL rate-limited fetching merged PRs, and REST fallback also failed: ${rest_prs:-$repo_nwo}"
+                return 2
+            fi
+        else
+            print_warning "Failed to fetch merged PRs: $prs"
+            return 0
+        fi
     fi
 
     # Process each PR for similarity
@@ -380,6 +435,12 @@ search_merged_prs() {
         return 0
     fi
 
+    # A leading sentinel line (stripped by main(), never shown to the user)
+    # so the caller can label the umbrella DUPLICATE_FOUND header when this
+    # pool's result came from the REST fallback (#4526).
+    if $rest_fallback; then
+        echo "RATE_LIMIT_FALLBACK"
+    fi
     echo -n "$duplicates"
 }
 
@@ -397,11 +458,26 @@ search_closed_issues() {
         return 0
     fi
 
-    # Search recently closed issues
+    # Search recently closed issues. On a GraphQL rate-limit failure, retry
+    # via REST (#4526).
     local issues
+    local rest_fallback=false
     if ! issues=$($FORGE issue list --state=closed --limit=20 --json number,title,body 2>&1); then
-        print_warning "Failed to fetch closed issues: $issues"
-        return 0
+        if is_rate_limit_error "$issues"; then
+            local repo_nwo rest_issues
+            if repo_nwo=$(get_repo_nwo 2>&1) && \
+               rest_issues=$(gh api "repos/${repo_nwo}/issues?state=closed&per_page=20" 2>&1); then
+                # REST's /issues endpoint also returns PRs; exclude them.
+                issues=$(echo "$rest_issues" | jq -c '[.[] | select(.pull_request == null)]')
+                rest_fallback=true
+            else
+                print_error "GraphQL rate-limited fetching closed issues, and REST fallback also failed: ${rest_issues:-$repo_nwo}"
+                return 2
+            fi
+        else
+            print_warning "Failed to fetch closed issues: $issues"
+            return 0
+        fi
     fi
 
     # Process each issue for similarity
@@ -443,6 +519,11 @@ search_closed_issues() {
         return 0
     fi
 
+    # See search_merged_prs()'s matching comment: leading sentinel line,
+    # stripped by main(), never shown to the user (#4526).
+    if $rest_fallback; then
+        echo "RATE_LIMIT_FALLBACK"
+    fi
     echo -n "$duplicates"
 }
 
@@ -611,8 +692,33 @@ main() {
     local merged_result=""
     local closed_result=""
     if $include_merged_prs; then
-        merged_result=$(search_merged_prs "$title" "$body" "$threshold")
-        closed_result=$(search_closed_issues "$title" "$body" "$threshold")
+        local merged_exit_code=0
+        local closed_exit_code=0
+        merged_result=$(search_merged_prs "$title" "$body" "$threshold") || merged_exit_code=$?
+        closed_result=$(search_closed_issues "$title" "$body" "$threshold") || closed_exit_code=$?
+
+        # #4526: a GraphQL rate-limit that ALSO fails via REST means this
+        # pool genuinely could not be checked -- surface that as exit 2
+        # ("could not run at all"), not silently as "no duplicates" the way
+        # a plain `return 0` used to.
+        if [[ $merged_exit_code -eq 2 || $closed_exit_code -eq 2 ]]; then
+            exit_code=2
+        fi
+
+        # Strip the leading REST-fallback sentinel line (if present) from
+        # each result before it's displayed or aggregated, remembering
+        # whether it fired so the umbrella DUPLICATE_FOUND header below can
+        # be labeled correctly (#4526).
+        local merged_rest_fallback=false
+        local closed_rest_fallback=false
+        if [[ "$merged_result" == "RATE_LIMIT_FALLBACK"$'\n'* ]]; then
+            merged_rest_fallback=true
+            merged_result="${merged_result#RATE_LIMIT_FALLBACK$'\n'}"
+        fi
+        if [[ "$closed_result" == "RATE_LIMIT_FALLBACK"$'\n'* ]]; then
+            closed_rest_fallback=true
+            closed_result="${closed_result#RATE_LIMIT_FALLBACK$'\n'}"
+        fi
 
         # If we found matches in merged PRs or closed issues, flag as duplicate
         if [[ -n "$merged_result" || -n "$closed_result" ]]; then
@@ -628,7 +734,11 @@ main() {
                 # side is degenerate.
                 if [[ ( -n "$merged_result" && "$merged_result" != NON_DISCRIMINATIVE* ) || \
                       ( -n "$closed_result" && "$closed_result" != NON_DISCRIMINATIVE* ) ]]; then
-                    result="DUPLICATE_FOUND"$'\n'
+                    if $merged_rest_fallback || $closed_rest_fallback; then
+                        result="DUPLICATE_FOUND (REST fallback -- similarity ranking basis differs from GraphQL)"$'\n'
+                    else
+                        result="DUPLICATE_FOUND"$'\n'
+                    fi
                 fi
                 exit_code=1
             fi
@@ -674,7 +784,9 @@ main() {
             # an empty $result, e.g. exit_code 0 or "related work only")
             local matches="[]"
             while IFS= read -r line; do
-                [[ "$line" == "DUPLICATE_FOUND" ]] && continue
+                # Prefix match, not exact-equals: the REST-fallback path
+                # (#4526) emits "DUPLICATE_FOUND (REST fallback -- ...)".
+                [[ "$line" == DUPLICATE_FOUND* ]] && continue
                 [[ "$line" == NON_DISCRIMINATIVE* ]] && continue
                 [[ -z "$line" ]] && continue
 

--- a/defaults/scripts/tests/test-check-duplicate.sh
+++ b/defaults/scripts/tests/test-check-duplicate.sh
@@ -129,6 +129,22 @@ cat > "$STUB_DIR/gh" <<'STUB'
 #!/usr/bin/env bash
 STUB_DIR_FROM_ENV="${LOOM_TEST_STUB_DIR:?stub gh: LOOM_TEST_STUB_DIR not set}"
 
+# The rate-limit error text the stubbed GraphQL calls emit. Defaults to the
+# REAL phrasing GitHub's GraphQL API returns -- "API rate limit ALREADY
+# exceeded" -- which is what loom-daemon/src/rate_limit_breaker.rs documents
+# and unit-tests (RATE_LIMIT_SIGNATURES). This matters: "already exceeded"
+# does not contain "API rate limit exceeded" as a contiguous substring, so a
+# stub using the REST phrasing would let a check that only matches the REST
+# form pass every test while never firing in production (#4526). Tests can
+# override via $STUB_DIR/rate-limit-message to exercise other phrasings.
+rate_limit_message() {
+  if [[ -f "$STUB_DIR_FROM_ENV/rate-limit-message" ]]; then
+    cat "$STUB_DIR_FROM_ENV/rate-limit-message"
+  else
+    echo "GraphQL: API rate limit already exceeded for user ID 12345667."
+  fi
+}
+
 case "$1" in
   auth)
     exit 0
@@ -152,7 +168,7 @@ case "$1" in
         shift
       done
       if [[ -f "$STUB_DIR_FROM_ENV/issue-list-rate-limit-$state" ]]; then
-        echo "GraphQL: API rate limit exceeded for installation ID 123. (issue)" >&2
+        echo "$(rate_limit_message) (issue)" >&2
         exit 1
       fi
       canned="$STUB_DIR_FROM_ENV/issues-$state.json"
@@ -165,7 +181,7 @@ case "$1" in
   pr)
     if [[ "$2" == "list" ]]; then
       if [[ -f "$STUB_DIR_FROM_ENV/pr-list-rate-limit" ]]; then
-        echo "GraphQL: API rate limit exceeded for installation ID 123. (pr)" >&2
+        echo "$(rate_limit_message) (pr)" >&2
         exit 1
       fi
       canned="$STUB_DIR_FROM_ENV/prs-merged.json"
@@ -226,6 +242,7 @@ reset_state() {
     rm -f "$STUB_DIR/timeline-fail" "$STUB_DIR/repo-view-fail"
     rm -f "$STUB_DIR"/issue-list-rate-limit-* "$STUB_DIR/pr-list-rate-limit"
     rm -f "$STUB_DIR/rest-issues-fail" "$STUB_DIR/rest-prs-fail"
+    rm -f "$STUB_DIR/rate-limit-message"
 }
 
 run_cds() {
@@ -595,6 +612,205 @@ run_cds --threshold 50 --title "Alpha Bravo Charlie Delta"
 assert_eq "1" "$RC" "(v) Ordinary GraphQL success -> exit 1"
 assert_contains "$OUT" "DUPLICATE_FOUND" "(v) Ordinary GraphQL success still emits a DUPLICATE_FOUND header"
 assert_not_contains "$OUT" "REST fallback" "(v) Ordinary GraphQL success never mentions the REST fallback"
+
+echo ""
+echo "Testing rate-limit signature coverage (both GraphQL and REST phrasings)..."
+
+# (w) The REST phrasing ("API rate limit exceeded", no "already") must ALSO
+# trigger the fallback. Cases (p)-(v) above now run against the default stub
+# message, which is the GraphQL phrasing ("API rate limit ALREADY exceeded"),
+# so this case pins the other half of the signature table. A single-pattern
+# check for either phrasing alone fails one of these two groups: "already
+# exceeded" does not contain "API rate limit exceeded" contiguously, and vice
+# versa. Ground truth: loom-daemon/src/rate_limit_breaker.rs
+# RATE_LIMIT_SIGNATURES lists both as distinct, both-required entries.
+reset_state
+echo "HTTP 403: API rate limit exceeded for 1.2.3.4" > "$STUB_DIR/rate-limit-message"
+: > "$STUB_DIR/issue-list-rate-limit-open"
+cat > "$STUB_DIR/rest-issues-open.json" <<'EOF'
+[{"number": 811, "title": "Alpha Bravo Charlie Delta", "body": "", "pull_request": null}]
+EOF
+run_cds --threshold 50 --title "Alpha Bravo Charlie Delta"
+assert_eq "1" "$RC" "(w) REST phrasing 'API rate limit exceeded' also triggers the fallback -> exit 1"
+assert_contains "$OUT" "DUPLICATE_FOUND (REST fallback" "(w) REST-phrasing rate limit is recognized, not treated as a hard error"
+assert_contains "$OUT" "#811" "(w) REST fallback still finds the match under the REST phrasing"
+
+# (w2) Case-insensitivity: the signature match lowercases first (mirroring
+# rate_limit_breaker.rs's to_ascii_lowercase), so an all-caps deployment
+# variant is still recognized.
+reset_state
+echo "GRAPHQL: API RATE LIMIT ALREADY EXCEEDED FOR USER ID 99" > "$STUB_DIR/rate-limit-message"
+: > "$STUB_DIR/issue-list-rate-limit-open"
+cat > "$STUB_DIR/rest-issues-open.json" <<'EOF'
+[{"number": 812, "title": "Alpha Bravo Charlie Delta", "body": "", "pull_request": null}]
+EOF
+run_cds --threshold 50 --title "Alpha Bravo Charlie Delta"
+assert_eq "1" "$RC" "(w2) Rate-limit signature match is case-insensitive -> exit 1"
+assert_contains "$OUT" "#812" "(w2) Uppercase rate-limit text still routes to the REST fallback"
+
+# (w3) Secondary rate limits are in the same signature table and also route
+# to the REST fallback rather than the hard-error path.
+reset_state
+echo "You have exceeded a secondary rate limit. Please wait a few minutes." > "$STUB_DIR/rate-limit-message"
+: > "$STUB_DIR/issue-list-rate-limit-open"
+cat > "$STUB_DIR/rest-issues-open.json" <<'EOF'
+[{"number": 813, "title": "Alpha Bravo Charlie Delta", "body": "", "pull_request": null}]
+EOF
+run_cds --threshold 50 --title "Alpha Bravo Charlie Delta"
+assert_eq "1" "$RC" "(w3) Secondary rate limit routes to the REST fallback -> exit 1"
+assert_contains "$OUT" "#813" "(w3) Secondary-rate-limit text still routes to the REST fallback"
+
+# (w4) Regression guard on the narrow gate: a NON-rate-limit GraphQL failure
+# must still take the original hard-error path (exit 2), never the fallback.
+reset_state
+echo "GraphQL: Could not resolve to a Repository with the name 'owner/repo'." > "$STUB_DIR/rate-limit-message"
+: > "$STUB_DIR/issue-list-rate-limit-open"
+cat > "$STUB_DIR/rest-issues-open.json" <<'EOF'
+[{"number": 814, "title": "Alpha Bravo Charlie Delta", "body": "", "pull_request": null}]
+EOF
+run_cds --threshold 50 --title "Alpha Bravo Charlie Delta"
+assert_eq "2" "$RC" "(w4) Non-rate-limit GraphQL failure still hard-errors -> exit 2"
+assert_contains "$ERR" "Failed to fetch issues" "(w4) Non-rate-limit failure uses the original error path"
+assert_not_contains "$OUT" "#814" "(w4) Non-rate-limit failure never consults the REST fallback fixture"
+
+echo ""
+echo "Testing partial-failure vs confirmed-duplicate precedence (issue #4526)..."
+
+# (x) THE regression this section exists for: the open-issues search finds a
+# real duplicate via ordinary GraphQL while the merged-PRs pool fails
+# COMPLETELY (GraphQL rate-limited AND REST fallback failed). A confirmed
+# duplicate must win: exit 1 with the match reported, plus a
+# SEARCH_INCOMPLETE note naming the pool that could not be checked. The
+# earlier draft unconditionally overwrote the exit code with 2 whenever any
+# pool totally failed, silently discarding the real match.
+reset_state
+cat > "$STUB_DIR/issues-open.json" <<'EOF'
+[{"number": 801, "title": "Alpha Bravo Charlie Delta", "body": ""}]
+EOF
+: > "$STUB_DIR/pr-list-rate-limit"
+: > "$STUB_DIR/rest-prs-fail"
+run_cds --include-merged-prs --threshold 50 --title "Alpha Bravo Charlie Delta"
+assert_eq "1" "$RC" "(x) Confirmed open-issue duplicate outranks a total merged-PR failure -> exit 1, not 2"
+assert_contains "$OUT" "DUPLICATE_FOUND" "(x) The confirmed duplicate is still reported"
+assert_contains "$OUT" "#801: Alpha Bravo Charlie Delta (similarity: 100%)" "(x) The match itself is not discarded"
+assert_contains "$OUT" "SEARCH_INCOMPLETE: merged PRs" "(x) The uncheckable pool is named in a SEARCH_INCOMPLETE note"
+assert_contains "$ERR" "REST fallback also failed" "(x) stderr still explains the merged-PR pool failure"
+
+# (x2) Same scenario in --json mode, where the old behavior was worse than a
+# wrong exit code: the exit-2 branch emits a bare {"error": ...} and drops the
+# `matches` array entirely, so a confirmed duplicate vanished from the output.
+reset_state
+cat > "$STUB_DIR/issues-open.json" <<'EOF'
+[{"number": 801, "title": "Alpha Bravo Charlie Delta", "body": ""}]
+EOF
+: > "$STUB_DIR/pr-list-rate-limit"
+: > "$STUB_DIR/rest-prs-fail"
+run_cds --include-merged-prs --threshold 50 --title "Alpha Bravo Charlie Delta" --json
+assert_eq "1" "$RC" "(x2) --json: confirmed duplicate + total pool failure -> exit 1"
+assert_eq "true" "$(echo "$OUT" | jq -r '.duplicate_found')" "(x2) --json reports duplicate_found true"
+assert_eq "801" "$(echo "$OUT" | jq -r '.matches[0].number')" "(x2) --json still carries the confirmed match"
+assert_eq "1" "$(echo "$OUT" | jq -r '.matches | length')" "(x2) --json matches contains exactly the real match"
+assert_eq "true" "$(echo "$OUT" | jq -r '.search_incomplete')" "(x2) --json flags the degraded coverage separately from the match"
+assert_not_contains "$OUT" '"error"' "(x2) --json no longer collapses to a bare error object"
+
+# (x3) Mirror image: the OPEN-issues pool fails completely while the
+# merged-PRs pool finds a real duplicate. Same principle, opposite direction
+# -- the match must survive and get its DUPLICATE_FOUND header even though
+# the pool searched first could not run.
+reset_state
+: > "$STUB_DIR/issue-list-rate-limit-open"
+: > "$STUB_DIR/rest-issues-fail"
+cat > "$STUB_DIR/prs-merged.json" <<'EOF'
+[{"number": 901, "title": "Alpha Bravo Charlie Delta", "body": ""}]
+EOF
+run_cds --include-merged-prs --threshold 50 --title "Alpha Bravo Charlie Delta"
+assert_eq "1" "$RC" "(x3) Merged-PR duplicate outranks a total open-issues failure -> exit 1"
+assert_contains "$OUT" "DUPLICATE_FOUND" "(x3) The merged-PR match still gets an umbrella header"
+assert_contains "$OUT" "PR #901: Alpha Bravo Charlie Delta (similarity: 100%)" "(x3) The merged-PR match is reported"
+assert_contains "$OUT" "SEARCH_INCOMPLETE: open issues" "(x3) The uncheckable open-issues pool is named"
+
+# (y) Total failure with NO duplicate anywhere still means exit 2 -- the
+# precedence fix must not weaken the "could not run at all" signal that the
+# rest of this section depends on.
+reset_state
+cat > "$STUB_DIR/issues-open.json" <<'EOF'
+[{"number": 805, "title": "Completely unrelated banana fruit basket", "body": ""}]
+EOF
+: > "$STUB_DIR/pr-list-rate-limit"
+: > "$STUB_DIR/rest-prs-fail"
+run_cds --include-merged-prs --threshold 50 --title "Alpha Bravo Charlie Delta"
+assert_eq "2" "$RC" "(y) Total pool failure with no duplicate found anywhere -> still exit 2"
+assert_not_contains "$OUT" "SEARCH_INCOMPLETE" "(y) No SEARCH_INCOMPLETE note when there is no match to qualify"
+
+# (y2) ...and its --json form still reports the bare error object, unchanged.
+reset_state
+: > "$STUB_DIR/pr-list-rate-limit"
+: > "$STUB_DIR/rest-prs-fail"
+run_cds --include-merged-prs --threshold 50 --title "Alpha Bravo Charlie Delta" --json
+assert_eq "2" "$RC" "(y2) --json: total failure with no match -> exit 2"
+assert_contains "$OUT" '"error"' "(y2) --json still reports the error object when nothing could be determined"
+
+# (z) Non-blocking gap from review, fixed here: the open-issues search matches
+# via ORDINARY GraphQL (so its plain DUPLICATE_FOUND header stands) while the
+# merged-PRs pool separately succeeds through the REST fallback. Without a
+# REST_FALLBACK note the REST-sourced subset would be reported with no hint
+# that its similarity ranking basis differs.
+reset_state
+cat > "$STUB_DIR/issues-open.json" <<'EOF'
+[{"number": 801, "title": "Alpha Bravo Charlie Delta", "body": ""}]
+EOF
+: > "$STUB_DIR/pr-list-rate-limit"
+cat > "$STUB_DIR/rest-prs.json" <<'EOF'
+[{"number": 901, "title": "Alpha Bravo Charlie Delta", "body": "", "merged_at": "2026-01-01T00:00:00Z"}]
+EOF
+run_cds --include-merged-prs --threshold 50 --title "Alpha Bravo Charlie Delta"
+assert_eq "1" "$RC" "(z) Ordinary-GraphQL open match + REST-fallback merged match -> exit 1"
+assert_contains "$OUT" "#801: Alpha Bravo Charlie Delta (similarity: 100%)" "(z) Open-issue match reported"
+assert_contains "$OUT" "PR #901: Alpha Bravo Charlie Delta (similarity: 100%)" "(z) REST-fallback merged-PR match reported"
+assert_contains "$OUT" "REST_FALLBACK: merged PRs" "(z) REST provenance is labeled even though the umbrella header came from the open-issues search"
+
+# (z2) The new marker lines must never be parsed as matches by --json.
+reset_state
+cat > "$STUB_DIR/issues-open.json" <<'EOF'
+[{"number": 801, "title": "Alpha Bravo Charlie Delta", "body": ""}]
+EOF
+: > "$STUB_DIR/pr-list-rate-limit"
+cat > "$STUB_DIR/rest-prs.json" <<'EOF'
+[{"number": 901, "title": "Alpha Bravo Charlie Delta", "body": "", "merged_at": "2026-01-01T00:00:00Z"}]
+EOF
+run_cds --include-merged-prs --threshold 50 --title "Alpha Bravo Charlie Delta" --json
+assert_eq "2" "$(echo "$OUT" | jq -r '.matches | length')" "(z2) --json parses exactly the two real matches, not the REST_FALLBACK marker line"
+assert_eq "false" "$(echo "$OUT" | jq -r '.search_incomplete')" "(z2) A successful REST fallback is NOT reported as incomplete coverage"
+
+# (z3) Line-splicing regression, latent on main and first exposed by (z)/(z2):
+# `result=$(search_similar_issues ...)` loses its trailing newline to command
+# substitution, so appending the merged-PR list ran the two pools' lists
+# together on ONE line ("#801: ... (similarity: 100%)PR #901: ..."). Text
+# output was merely garbled; --json was worse, parsing the spliced pair as a
+# single match whose title swallowed the second entry and whose number was
+# lost. Exercised here with no rate-limiting at all, so it pins the plain
+# multi-pool aggregation path independently of the #4526 fallback.
+reset_state
+cat > "$STUB_DIR/issues-open.json" <<'EOF'
+[{"number": 801, "title": "Alpha Bravo Charlie Delta", "body": ""}]
+EOF
+cat > "$STUB_DIR/prs-merged.json" <<'EOF'
+[{"number": 901, "title": "Alpha Bravo Charlie Delta", "body": ""}]
+EOF
+cat > "$STUB_DIR/issues-closed.json" <<'EOF'
+[{"number": 1001, "title": "Alpha Bravo Charlie Delta", "body": ""}]
+EOF
+run_cds --include-merged-prs --threshold 50 --title "Alpha Bravo Charlie Delta"
+assert_eq "1" "$RC" "(z3) Matches in all three pools (no rate limiting) -> exit 1"
+assert_contains "$OUT" "#801: Alpha Bravo Charlie Delta (similarity: 100%)" "(z3) Open-issue match occupies its own line"
+assert_contains "$OUT" "PR #901: Alpha Bravo Charlie Delta (similarity: 100%)" "(z3) Merged-PR match occupies its own line"
+assert_contains "$OUT" "Closed #1001: Alpha Bravo Charlie Delta (similarity: 100%)" "(z3) Closed-issue match occupies its own line"
+assert_not_contains "$OUT" "100%)PR #901" "(z3) Open-issue and merged-PR lines are not spliced onto one line"
+
+run_cds --include-merged-prs --threshold 50 --title "Alpha Bravo Charlie Delta" --json
+assert_eq "3" "$(echo "$OUT" | jq -r '.matches | length')" "(z3) --json parses all three pool matches separately"
+assert_eq "801 901 1001" "$(echo "$OUT" | jq -r '[.matches[].number] | join(" ")')" "(z3) --json recovers every match number, none swallowed by a splice"
+assert_eq "issue pr closed_issue" "$(echo "$OUT" | jq -r '[.matches[].type] | join(" ")')" "(z3) --json assigns each match its correct pool type"
 
 # --- Summary ---
 echo ""

--- a/defaults/scripts/tests/test-check-duplicate.sh
+++ b/defaults/scripts/tests/test-check-duplicate.sh
@@ -111,10 +111,20 @@ chmod +x "$STUB_DIR/loom-daemon"
 #   gh auth status                                     -> exit 0 (authenticated)
 #   gh repo view --json nameWithOwner --jq ...          -> "owner/repo" (or fail
 #                                                          if $STUB_DIR/repo-view-fail exists)
-#   gh issue list --state=open|closed ...               -> cat $STUB_DIR/issues-<state>.json (or [])
-#   gh pr list --state=merged ...                        -> cat $STUB_DIR/prs-merged.json (or [])
+#   gh issue list --state=open|closed ...               -> cat $STUB_DIR/issues-<state>.json (or [];
+#                                                           simulates a GraphQL rate-limit failure if
+#                                                           $STUB_DIR/issue-list-rate-limit-<state> exists)
+#   gh pr list --state=merged ...                        -> cat $STUB_DIR/prs-merged.json (or [];
+#                                                           simulates a GraphQL rate-limit failure if
+#                                                           $STUB_DIR/pr-list-rate-limit exists)
 #   gh api repos/OWNER/REPO/issues/N/timeline --paginate -> cat $STUB_DIR/timeline-N.json (or [];
 #                                                           fails if $STUB_DIR/timeline-fail exists)
+#   gh api repos/OWNER/REPO/issues?state=<state>&...     -> REST fallback (#4526): cat
+#                                                           $STUB_DIR/rest-issues-<state>.json (or [];
+#                                                           fails if $STUB_DIR/rest-issues-fail exists)
+#   gh api repos/OWNER/REPO/pulls?state=closed&...       -> REST fallback (#4526): cat
+#                                                           $STUB_DIR/rest-prs.json (or [];
+#                                                           fails if $STUB_DIR/rest-prs-fail exists)
 cat > "$STUB_DIR/gh" <<'STUB'
 #!/usr/bin/env bash
 STUB_DIR_FROM_ENV="${LOOM_TEST_STUB_DIR:?stub gh: LOOM_TEST_STUB_DIR not set}"
@@ -141,6 +151,10 @@ case "$1" in
         esac
         shift
       done
+      if [[ -f "$STUB_DIR_FROM_ENV/issue-list-rate-limit-$state" ]]; then
+        echo "GraphQL: API rate limit exceeded for installation ID 123. (issue)" >&2
+        exit 1
+      fi
       canned="$STUB_DIR_FROM_ENV/issues-$state.json"
       if [[ -f "$canned" ]]; then cat "$canned"; else echo "[]"; fi
       exit 0
@@ -150,6 +164,10 @@ case "$1" in
     ;;
   pr)
     if [[ "$2" == "list" ]]; then
+      if [[ -f "$STUB_DIR_FROM_ENV/pr-list-rate-limit" ]]; then
+        echo "GraphQL: API rate limit exceeded for installation ID 123. (pr)" >&2
+        exit 1
+      fi
       canned="$STUB_DIR_FROM_ENV/prs-merged.json"
       if [[ -f "$canned" ]]; then cat "$canned"; else echo "[]"; fi
       exit 0
@@ -158,16 +176,38 @@ case "$1" in
     exit 3
     ;;
   api)
-    if [[ -f "$STUB_DIR_FROM_ENV/timeline-fail" ]]; then
-      echo "stub gh: api call failed" >&2
-      exit 1
-    fi
     path="$2"
-    num="${path%/timeline}"
-    num="${num##*/}"
-    canned="$STUB_DIR_FROM_ENV/timeline-$num.json"
-    if [[ -f "$canned" ]]; then cat "$canned"; else echo "[]"; fi
-    exit 0
+    if [[ "$path" == *"/timeline" ]]; then
+      if [[ -f "$STUB_DIR_FROM_ENV/timeline-fail" ]]; then
+        echo "stub gh: api call failed" >&2
+        exit 1
+      fi
+      num="${path%/timeline}"
+      num="${num##*/}"
+      canned="$STUB_DIR_FROM_ENV/timeline-$num.json"
+      if [[ -f "$canned" ]]; then cat "$canned"; else echo "[]"; fi
+      exit 0
+    elif [[ "$path" == *"/issues?"* ]]; then
+      if [[ -f "$STUB_DIR_FROM_ENV/rest-issues-fail" ]]; then
+        echo "stub gh: rest issues api call failed" >&2
+        exit 1
+      fi
+      state="open"
+      [[ "$path" == *"state=closed"* ]] && state="closed"
+      canned="$STUB_DIR_FROM_ENV/rest-issues-$state.json"
+      if [[ -f "$canned" ]]; then cat "$canned"; else echo "[]"; fi
+      exit 0
+    elif [[ "$path" == *"/pulls?"* ]]; then
+      if [[ -f "$STUB_DIR_FROM_ENV/rest-prs-fail" ]]; then
+        echo "stub gh: rest pulls api call failed" >&2
+        exit 1
+      fi
+      canned="$STUB_DIR_FROM_ENV/rest-prs.json"
+      if [[ -f "$canned" ]]; then cat "$canned"; else echo "[]"; fi
+      exit 0
+    fi
+    echo "stub gh: unhandled api args: $*" >&2
+    exit 3
     ;;
   *)
     echo "stub gh: unhandled args: $*" >&2
@@ -182,7 +222,10 @@ export PATH="$STUB_DIR:$PATH"
 
 reset_state() {
     rm -f "$STUB_DIR"/issues-*.json "$STUB_DIR"/prs-merged.json "$STUB_DIR"/timeline-*.json
+    rm -f "$STUB_DIR"/rest-issues-*.json "$STUB_DIR/rest-prs.json"
     rm -f "$STUB_DIR/timeline-fail" "$STUB_DIR/repo-view-fail"
+    rm -f "$STUB_DIR"/issue-list-rate-limit-* "$STUB_DIR/pr-list-rate-limit"
+    rm -f "$STUB_DIR/rest-issues-fail" "$STUB_DIR/rest-prs-fail"
 }
 
 run_cds() {
@@ -465,6 +508,93 @@ run_cds --title "guard-destructive.sh emits PreToolUse decisions without hookEve
 assert_eq "1" "$RC" "(o) Real historical duplicate pair (#3550/#3551) -> exit 1 at the calibrated default threshold"
 assert_contains "$OUT" "#3550" "(o) Real historical duplicate pair (#3550/#3551) -> flagged as a candidate"
 assert_contains "$OUT" "(similarity: 26%)" "(o) Real historical duplicate pair scores the expected 26% true-Jaccard"
+
+echo ""
+echo "Testing check-duplicate.sh REST fallback on GraphQL rate limit (issue #4526)..."
+
+# (p) Open-issues GraphQL rate-limited -> REST fallback succeeds and is used.
+# REST's /issues endpoint also returns PRs, so the fixture includes one
+# (#802) to confirm it's filtered out (pull_request != null).
+reset_state
+: > "$STUB_DIR/issue-list-rate-limit-open"
+cat > "$STUB_DIR/rest-issues-open.json" <<'EOF'
+[
+  {"number": 801, "title": "Alpha Bravo Charlie Delta", "body": "", "pull_request": null},
+  {"number": 802, "title": "Alpha Bravo Charlie Delta", "body": "", "pull_request": {"url": "x"}}
+]
+EOF
+run_cds --threshold 50 --title "Alpha Bravo Charlie Delta"
+assert_eq "1" "$RC" "(p) Rate-limited GraphQL open-issues search falls back to REST -> exit 1"
+assert_contains "$OUT" "DUPLICATE_FOUND (REST fallback" "(p) REST fallback output is labeled distinctly from a normal GraphQL match"
+assert_contains "$OUT" "#801: Alpha Bravo Charlie Delta (similarity: 100%)" "(p) REST fallback finds the matching issue"
+assert_not_contains "$OUT" "#802" "(p) REST fallback excludes PR entries returned by the /issues endpoint"
+
+# (q) Open-issues GraphQL rate-limited AND the REST fallback also fails ->
+# exit 2 ("could not run at all"), not silently treated as no duplicates.
+reset_state
+: > "$STUB_DIR/issue-list-rate-limit-open"
+: > "$STUB_DIR/rest-issues-fail"
+run_cds --title "Alpha Bravo Charlie Delta"
+assert_eq "2" "$RC" "(q) Rate-limited GraphQL AND failed REST fallback (open issues) -> exit 2"
+assert_contains "$ERR" "REST fallback also failed" "(q) stderr explains both GraphQL and REST failed"
+
+# (r) Merged-PRs GraphQL rate-limited -> REST fallback succeeds. REST has no
+# state=merged filter, so the fetch is `pulls?state=closed` filtered locally
+# to merged_at != null; the fixture includes a closed-but-unmerged PR (#902)
+# to confirm it's excluded.
+reset_state
+: > "$STUB_DIR/pr-list-rate-limit"
+cat > "$STUB_DIR/rest-prs.json" <<'EOF'
+[
+  {"number": 901, "title": "Alpha Bravo Charlie Delta", "body": "", "merged_at": "2026-01-01T00:00:00Z"},
+  {"number": 902, "title": "Alpha Bravo Charlie Delta", "body": "", "merged_at": null}
+]
+EOF
+run_cds --include-merged-prs --threshold 50 --title "Alpha Bravo Charlie Delta"
+assert_eq "1" "$RC" "(r) Rate-limited GraphQL merged-PR search falls back to REST -> exit 1"
+assert_contains "$OUT" "DUPLICATE_FOUND (REST fallback" "(r) REST fallback header labeled for the merged-PR pool"
+assert_contains "$OUT" "PR #901: Alpha Bravo Charlie Delta (similarity: 100%)" "(r) REST fallback finds the merged PR"
+assert_not_contains "$OUT" "PR #902" "(r) REST fallback excludes the closed-but-unmerged PR (merged_at null)"
+
+# (s) Merged-PRs GraphQL rate-limited AND the REST fallback also fails ->
+# exit 2, matching the open-issues both-failed case.
+reset_state
+: > "$STUB_DIR/pr-list-rate-limit"
+: > "$STUB_DIR/rest-prs-fail"
+run_cds --include-merged-prs --title "Alpha Bravo Charlie Delta"
+assert_eq "2" "$RC" "(s) Rate-limited GraphQL AND failed REST fallback (merged PRs) -> exit 2"
+assert_contains "$ERR" "REST fallback also failed" "(s) stderr explains both GraphQL and REST failed (merged PRs)"
+
+# (t) Closed-issues GraphQL rate-limited -> REST fallback succeeds.
+reset_state
+: > "$STUB_DIR/issue-list-rate-limit-closed"
+cat > "$STUB_DIR/rest-issues-closed.json" <<'EOF'
+[{"number": 1001, "title": "Alpha Bravo Charlie Delta", "body": "", "pull_request": null}]
+EOF
+run_cds --include-merged-prs --threshold 50 --title "Alpha Bravo Charlie Delta"
+assert_eq "1" "$RC" "(t) Rate-limited GraphQL closed-issues search falls back to REST -> exit 1"
+assert_contains "$OUT" "DUPLICATE_FOUND (REST fallback" "(t) REST fallback header labeled for the closed-issues pool"
+assert_contains "$OUT" "Closed #1001: Alpha Bravo Charlie Delta (similarity: 100%)" "(t) REST fallback finds the closed issue"
+
+# (u) Closed-issues GraphQL rate-limited AND the REST fallback also fails ->
+# exit 2, matching the other two both-failed cases.
+reset_state
+: > "$STUB_DIR/issue-list-rate-limit-closed"
+: > "$STUB_DIR/rest-issues-fail"
+run_cds --include-merged-prs --title "Alpha Bravo Charlie Delta"
+assert_eq "2" "$RC" "(u) Rate-limited GraphQL AND failed REST fallback (closed issues) -> exit 2"
+assert_contains "$ERR" "REST fallback also failed" "(u) stderr explains both GraphQL and REST failed (closed issues)"
+
+# (v) Regression: an ordinary successful (non-rate-limited) GraphQL call must
+# NOT trigger the REST fallback path or its labeling.
+reset_state
+cat > "$STUB_DIR/issues-open.json" <<'EOF'
+[{"number": 1101, "title": "Alpha Bravo Charlie Delta", "body": ""}]
+EOF
+run_cds --threshold 50 --title "Alpha Bravo Charlie Delta"
+assert_eq "1" "$RC" "(v) Ordinary GraphQL success -> exit 1"
+assert_contains "$OUT" "DUPLICATE_FOUND" "(v) Ordinary GraphQL success still emits a DUPLICATE_FOUND header"
+assert_not_contains "$OUT" "REST fallback" "(v) Ordinary GraphQL success never mentions the REST fallback"
 
 # --- Summary ---
 echo ""


### PR DESCRIPTION
## Summary

`check-duplicate.sh` has three call sites (`search_similar_issues()`, `search_merged_prs()`, `search_closed_issues()`) that use `gh issue/pr list --json ...` (GraphQL-backed). When GraphQL quota is exhausted, GraphQL and REST draw from independent quotas — the open-issues path hard-errored (exit 2) while the merged-PR/closed-issue paths silently treated the failure as "no duplicates found," both wrong. This PR adds a REST fallback (mirroring the existing pattern already used by `search_cross_references()` in the same file) so all three call sites recover from a GraphQL rate-limit instead of failing or silently reporting a false negative.

## Changes

- Added `is_rate_limit_error()` — detects GitHub's GraphQL rate-limit signature (`API rate limit exceeded`) in captured `gh` output.
- Added `get_repo_nwo()` — resolves `owner/repo` via `gh repo view`, shared by the three new REST fallback call sites.
- `search_similar_issues()`: on a rate-limited GraphQL fetch, retries via `gh api repos/OWNER/REPO/issues?state=open&per_page=50`, filtering out PR entries (`.pull_request == null`).
- `search_merged_prs()`: on a rate-limited GraphQL fetch, retries via `gh api repos/OWNER/REPO/pulls?state=closed&per_page=20`, filtering to actually-merged PRs locally (`.merged_at != null`) since REST has no `state=merged` filter.
- `search_closed_issues()`: on a rate-limited GraphQL fetch, retries via `gh api repos/OWNER/REPO/issues?state=closed&per_page=20`, same PR filter as open issues.
- Degraded-mode labeling: when the REST fallback fires and matches are found, the output header reads `DUPLICATE_FOUND (REST fallback -- similarity ranking basis differs from GraphQL)` instead of the bare `DUPLICATE_FOUND`. The `--json` output parser (and the umbrella-header synthesis in `main()`) now matches a `DUPLICATE_FOUND` *prefix*, not exact-equals.
- Exit-code semantics: exit 2 now means "GraphQL **and** REST both failed" for each of the three searches (mirroring the two-tier GraphQL-then-REST-then-exit-2 shape already used by `.loom/scripts/require-complexity-marker.sh`, #4472) — previously `search_merged_prs`/`search_closed_issues` silently returned 0 ("no duplicates") on *any* GraphQL failure, which this fixes for the rate-limit case specifically.
- Audited `defaults/.claude/commands/loom/curator.md`'s `DUPLICATE_FOUND` usage: it only branches on `check-duplicate.sh`'s exit code (`if !`), never an exact string match, so no change was needed there.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Detects GraphQL rate-limit failure and retries via REST instead of failing | ✅ | `is_rate_limit_error()` added; all three call sites gate the REST retry on it; new stub-`gh` tests (p), (r), (t) exercise each search path |
| Degraded-mode output is clearly labeled | ✅ | `DUPLICATE_FOUND (REST fallback -- ...)` header; tests (p), (r), (t), plus regression test (v) confirms it's absent on ordinary successful GraphQL calls |
| Exit code distinguishes "no duplicates (REST fallback)" from "could not run at all" | ✅ | Exit 2 only when both GraphQL and REST fail (per search); tests (q), (s), (u) cover both-failed for all three call sites |

## Test Plan

- `bash defaults/scripts/tests/test-check-duplicate.sh` — 74/74 passed (54 pre-existing + 20 new), including:
  - (p)/(q): open-issues rate-limit → REST success (labeled, PR-entry filtered) / REST failure → exit 2
  - (r)/(s): merged-PRs rate-limit → REST success (unmerged PR filtered) / REST failure → exit 2
  - (t)/(u): closed-issues rate-limit → REST success / REST failure → exit 2
  - (v): ordinary successful GraphQL call never mentions "REST fallback" (no regression)
  - All 54 pre-existing cases (cross-reference probe, keyword-similarity scoring, degenerate-result detection, real historical duplicate pairs) remain green
- `shellcheck defaults/scripts/check-duplicate.sh defaults/scripts/tests/test-check-duplicate.sh` — clean, no warnings

Closes #4526