### PR TITLE
test(disk_headroom): serialize the real-df smoke test against PATH-stub siblings

### DIFF
--- a/loom-daemon/src/disk_headroom.rs
+++ b/loom-daemon/src/disk_headroom.rs
@@ -265,11 +265,19 @@ mod tests {
     // ===================================================================
 
     #[test]
+    #[serial]
     fn test_worktree_root_free_gb_returns_a_value() {
         // Integration smoke: the repo root's volume has some free space, so a
         // real `df -Pk` should parse to a value. We only assert it doesn't panic
         // and returns a plausible (non-astronomical) integer — the exact GB is
         // environment-dependent.
+        //
+        // `#[serial]` is load-bearing (#4525): the sibling tests below prepend a
+        // stub-`df` dir to the process-global `PATH`, and cargo's default
+        // multi-threaded runner would otherwise schedule this real-`df` probe
+        // inside that window — the stub always exits 1, so the probe returns
+        // `None` and the `.expect(...)` panics. Sharing the serial lock with
+        // those PATH mutators closes the race.
         let tmp = tempfile::tempdir().unwrap();
         let free = worktree_root_free_gb(tmp.path())
             .expect("a real df -Pk against a real tempdir should succeed in the test env");


### PR DESCRIPTION
## Summary

`disk_headroom::tests::test_worktree_root_free_gb_returns_a_value` was the only test in the `worktree_root_free_gb` family **not** annotated `#[serial]`. Its two siblings temporarily prepend a stub-`df` directory (a `df` that always exits 1) to the **process-global** `PATH`, and cargo's default multi-threaded runner could schedule the real-`df` smoke test inside that window — the probe then returned `None` and the `.expect(...)` panicked. That is the flake hit twice live on 2026-07-29/30 (the #4406 build report and the first build-gate run of the #4408 doctor).

Adding `#[serial]` puts the smoke test on the same `serial_test` lock as the two PATH mutators, so the real-`df` probe can never run while `df` is shadowed.

## Changes

- `loom-daemon/src/disk_headroom.rs` — added `#[serial]` to `test_worktree_root_free_gb_returns_a_value`, plus a comment explaining why the attribute is load-bearing (so a future reader does not "clean it up" and reopen the race).

No production code changed; the two PATH-mutating siblings were deliberately left untouched (they are already correctly annotated).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| The real-`df` smoke test no longer races PATH-mutating siblings | Yes | Serialized via `#[serial]` (the `serial_test::serial` already imported at line 162), sharing the lock with `test_worktree_root_free_gb_returns_none_on_df_failure` and `test_disk_headroom_limit_skips_clamp_on_unmeasurable_probe`. Before/after measurement below. |
| Repro loop stays green >= 8 consecutive full-module runs | Yes | **25/25** consecutive green at `--test-threads=8`, plus **10/10** at default threading. |

### Before / after measurement (8-core host)

`cargo test -p loom-daemon --lib disk_headroom::tests -- --test-threads=8`, 25 consecutive runs:

| | Failures |
|---|---|
| Before the fix (change stashed) | **24 / 25** — all `panicked at loom-daemon/src/disk_headroom.rs:275` on the `.expect(...)` |
| After the fix | **0 / 25** |

The race reproduced almost deterministically once the module is run in isolation on 8 threads, which is exactly the shape of a build-gate/module-scoped run.

## Test Plan

- `cargo test -p loom-daemon --lib disk_headroom::tests -- --test-threads=8` x 25 → 25 green (0 failures).
- `cargo test -p loom-daemon --lib disk_headroom::tests` (default threading) x 10 → 10 green.
- `cargo test -p loom-daemon --lib disk_headroom::tests -- --test-threads=1` → `ok. 14 passed`.
- `cargo fmt --all -- --check` → clean; `cargo clippy --all-targets` → clean.
- Full build gate (`bash .loom/scripts/build-gate.sh`) → `2460 passed; 0 failed` (x2 consecutive green).

## Pre-existing Issues (Not Addressed)

While running the full gate under **high host load** (15-min load average ~5.4 on 8 cores) I observed two single-shot, unrelated failures that did **not** reproduce afterwards. Both are in modules untouched by this diff, both passed in isolation, and both disappeared once load dropped (full suite then went 2/2 green in this worktree *and* 2/2 green on unmodified `main`):

- `pipeline_snapshot::tests::gh_pipeline_source_records_error_but_keeps_other_metrics` — recorded a different error string than the fake-`gh` stub emits (5/5 green solo).
- `quarantine_reconciliation::tests::reconcile_workspace_never_touches_manual_block`.

Both look like the same "test consults real host state / racy under parallel load" family as #4406 / #4441 / this issue, but they are out of scope here and are noted rather than fixed.

Closes #4525