### PR TITLE
docs(doctor): add stale loom:treating claim check and pre-push head-SHA recheck

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -46,7 +46,7 @@
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:treating
-  description: "Doctor is fixing this bug or addressing PR feedback. Applied by: Doctor only (claim label)."
+  description: "Doctor is fixing this bug or PR. Applied by: Doctor. Stale after LOOM_STALE_TREATING_MINUTES (60m)."
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:reviewing

--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -144,7 +144,12 @@ Check for an argument passed via the slash command:
 If a number is provided (e.g., `/doctor 123`):
 1. Treat that number as the target **PR** to fix
 2. **Skip** the "Finding Work" section entirely
-3. Claim the PR: `gh pr edit <number> --add-label "loom:treating"`
+3. Claim the PR — run the "Stale `loom:treating` Claim Check" first (a
+   dispatched PR can already be claimed by a concurrent Doctor), then:
+   ```bash
+   gh pr edit <number> --add-label "loom:treating"
+   CLAIM_HEAD_SHA=$(gh pr view <number> --json headRefOid --jq '.headRefOid')
+   ```
 4. Proceed directly to fixing that PR
 
 **How judge feedback reaches you.** When `/loom:sweep` dispatches a Doctor after a
@@ -192,6 +197,13 @@ gh pr list --label="loom:pr" --state=open --json number,title,labels,mergeable \
 gh pr list --label="loom:changes-requested" --state=open --json number,title,labels \
   | jq -r '.[] | select(.labels | all(.name != "loom:treating")) | "#\(.number): \(.title)"'
 ```
+
+> **Claim discipline for every queue above.** The `loom:treating` filter in these
+> queries is a point-in-time snapshot: a claim can land between your list call and
+> your `gh pr edit`, and an *existing* claim tells you nothing about whether its
+> holder is still alive. Before adding `loom:treating` to any PR — from any queue,
+> from PR Fix Mode, or from an explicit user instruction — run the
+> "Stale `loom:treating` Claim Check" in the Work Process below.
 
 ### Other PRs Needing Attention
 
@@ -299,8 +311,9 @@ When the user explicitly instructs you to work on a specific PR by number:
 # User says: "heal pr 588"
 # PR has: no loom labels yet
 
-# ✅ Proceed immediately
+# ✅ Proceed immediately (still run the stale-claim check if loom:treating is present)
 gh pr edit 588 --add-label "loom:treating"
+CLAIM_HEAD_SHA=$(gh pr view 588 --json headRefOid --jq '.headRefOid')
 gh pr comment 588 --body "Addressing issues on this PR per user request"
 
 # Check out and fix — always inside a dedicated worktree (see "PR Branch Isolation")
@@ -315,6 +328,10 @@ else
   cd ".loom/worktrees/pr-588"
 fi
 # ... address feedback, resolve conflicts ...
+
+# Pre-push head-SHA recheck (see "Pre-Push Head-SHA Recheck")
+[ "$(gh pr view 588 --json headRefOid --jq '.headRefOid')" = "$CLAIM_HEAD_SHA" ] \
+  || echo "Head moved since claim — re-verify the blocker before pushing"
 
 # Complete normally
 git push
@@ -336,9 +353,10 @@ gh pr edit 588 --remove-label "loom:treating" --add-label "loom:review-requested
 ## Work Process
 
 1. **Find PRs needing attention**: Look for `loom:changes-requested` label that aren't already claimed (see above)
-2. **Claim the PR**: Add `loom:treating` to prevent duplicate work
+2. **Claim the PR** (staleness-aware — see "Stale `loom:treating` Claim Check" immediately below **before** running this): Add `loom:treating` to prevent duplicate work, and record the head SHA you are starting from
    ```bash
    gh pr edit <number> --add-label "loom:treating"
+   CLAIM_HEAD_SHA=$(gh pr view <number> --json headRefOid --jq '.headRefOid')
    ```
 3. **Check PR details**: `gh pr view <number>` - look for "Changes requested" reviews or conflicts
 4. **Read feedback**: Understand what the reviewer is asking for
@@ -356,6 +374,7 @@ gh pr edit 588 --remove-label "loom:treating" --add-label "loom:review-requested
    - Do NOT push until all local checks pass
    - This prevents multiple fix-push-fail cycles
 9. **Commit and push**: Push your fixes to the PR branch
+   - **Pre-push head-SHA recheck (MANDATORY)**: before the push, re-compare the PR's `headRefOid` against the `CLAIM_HEAD_SHA` you captured in step 2 — see "Pre-Push Head-SHA Recheck" below. If the head moved, another agent pushed while you were working; re-verify the blocker is still unaddressed and stand down rather than duplicating (or clobbering) their fix.
    - **DCO / sign-off**: if `commit.signoff` is `true` in `.loom/config.json` (read it the same way as `buildGate.command`), or the repo has a DCO / required `sign-off` check, add `--signoff` to **every** commit you author — including `git commit --amend --signoff` when re-authoring during a rebase — so each carries a `Signed-off-by:` trailer. Harmless when not required; git will not add a duplicate trailer. Reference: `defaults/docs/commit-signoff.md`.
    - **9a. Rebase any stacked children** (best-effort): if the just-pushed branch matches `feature/issue-<N>` (i.e. you amended a stacked *parent*), run:
      ```bash
@@ -368,8 +387,123 @@ gh pr edit 588 --remove-label "loom:treating" --add-label "loom:review-requested
     - Add `loom:review-requested` label (green badge)
     - Comment to notify reviewer that feedback is addressed
 
+### Stale `loom:treating` Claim Check (Step 2)
+
+Run this **before** claiming a PR in step 2 above — and everywhere else you
+claim a PR (PR Fix Mode, the Priority 1 / Priority 2 queues, the explicit-user
+override). The Finding Work queries already filter out PRs that carry
+`loom:treating`, but a PR can still surface with the label — a stale claim
+whose Doctor died mid-fix, or a claim applied between your list call and your
+edit — and a claim label alone tells you nothing about whether its holder is
+still alive. Without this check a dead claim blocks the PR from ever being
+treated again; without the *fresh* half of it, two live Doctors duplicate the
+same fix (the failure this section exists to prevent).
+
+**If the PR does NOT carry `loom:treating`:** proceed to claim as today — no
+behavior change: `gh pr edit <number> --add-label "loom:treating"`.
+
+**If the PR DOES carry `loom:treating`:** determine the claim's age and
+whether anyone has commented since the claim was made:
+
+```bash
+N=<pr-number>
+CLAIMED_AT=$(gh api "repos/{owner}/{repo}/issues/$N/timeline" --paginate \
+  --jq '[.[] | select(.event=="labeled" and .label.name=="loom:treating")] | last | .created_at')
+COMMENTS_AFTER=$(gh api "repos/{owner}/{repo}/issues/$N/comments" \
+  | jq --arg t "$CLAIMED_AT" '[.[] | select(.created_at > $t)] | length')
+```
+
+Then decide:
+
+| Condition | Verdict | Action |
+|-----------|---------|--------|
+| Claim age < `LOOM_STALE_TREATING_MINUTES` (default **60**), OR `COMMENTS_AFTER > 0` | **Fresh** — a Doctor is actively fixing this PR | **Do not stomp the claim.** Skip this PR and move to the next candidate in the queue. |
+| Claim age ≥ `LOOM_STALE_TREATING_MINUTES` AND `COMMENTS_AFTER == 0` | **Stale** — the claiming Doctor's process almost certainly died mid-fix | Reclaim (see below), then proceed with the normal fix from step 3. |
+| Timeline API call fails or returns empty (`CLAIMED_AT` unset) | **Unknown — fail safe** | Treat as **fresh**. Never stomp a claim on API failure or missing data. |
+
+**Reclaiming a stale claim:**
+
+```bash
+gh pr edit $N --remove-label "loom:treating"
+gh pr comment $N --body "Reclaiming stale loom:treating claim (age > ${LOOM_STALE_TREATING_MINUTES:-60}m, no follow-up comment) — a prior Doctor's process likely died mid-fix."
+gh pr edit $N --add-label "loom:treating"
+CLAIM_HEAD_SHA=$(gh pr view $N --json headRefOid --jq '.headRefOid')
+# Continue to step 3 (Check PR details) and fix normally
+```
+
+**Env var**: `LOOM_STALE_TREATING_MINUTES` (default **60**) — deliberately
+longer than the Judge's `LOOM_STALE_REVIEWING_MINUTES` (30): a Doctor's fix
+cycle (assess all CI failures → fix → verify locally → push → re-verify
+remotely) legitimately runs longer than a single review pass. Use the
+**treating** var here; do not borrow the Judge's 30-minute threshold.
+
+**Daemon backstop (#4367)**: this check is the fast path — it only fires when
+another Doctor happens to revisit the same PR. `loom-daemon`'s
+`claim_reconciliation` pass (`reconcile_pr_claims`) reconciles stale
+`loom:treating` (and `loom:reviewing`) as an always-on backstop at startup and
+on its periodic tick, sharing this exact env var and default. That pass runs on
+an interval (up to ~10 minutes of lag) and cannot see an *in-flight* Doctor, so
+it never substitutes for this check or the pre-push recheck below. See
+[`daemon-reference.md`'s "Stale-claim reconciliation" section](../../../docs/daemon-reference.md#pr-side-claim-labels-loomreviewing--loomtreating-4367).
+
+### Pre-Push Head-SHA Recheck (Step 9)
+
+The claim check above closes the window at *claim* time. It does not close the
+window that opens **while you work**: a Doctor dispatched from another path
+(fleet vs. orchestrator) may claim and fix the same PR after you started, or a
+Builder may push to the branch. `--force-with-lease` protects the *branch* from
+a clobbering push, but it does nothing to stop two Doctors from duplicating an
+hour of *work* before either one pushes.
+
+So immediately before your final push (step 9), re-read the PR head and compare
+it to the SHA you captured at claim time:
+
+```bash
+N=<pr-number>
+CURRENT_HEAD_SHA=$(gh pr view $N --json headRefOid --jq '.headRefOid')
+if [ -z "$CURRENT_HEAD_SHA" ]; then
+  echo "Head SHA unavailable — fail safe: push with --force-with-lease and re-verify CI after"
+elif [ "$CURRENT_HEAD_SHA" = "$CLAIM_HEAD_SHA" ]; then
+  echo "Head unchanged since claim — safe to push"
+else
+  echo "Head moved: $CLAIM_HEAD_SHA -> $CURRENT_HEAD_SHA — another agent pushed. Re-verify before pushing."
+fi
+```
+
+**If the head moved**, do NOT push yet. Re-verify that the blocker you were
+dispatched for is still unaddressed:
+
+```bash
+gh pr view $N --comments          # is the Judge's blocking comment already answered?
+gh pr checks $N                   # are the failing checks that sent you here now green?
+gh pr view $N --json labels --jq '.labels[].name'   # is it back on loom:review-requested / loom:pr?
+git fetch origin && git log --oneline "$CLAIM_HEAD_SHA..origin/$(git branch --show-current)"
+```
+
+| Finding | Action |
+|---------|--------|
+| The concurrent push already fixes the blocker (checks green / Judge feedback addressed) | **Stand down.** Do not push. Comment, drop your claim, and exit (see below). |
+| The blocker is still unaddressed, and the new commits are unrelated (e.g. a rebase onto main, an unrelated fix) | Rebase your work onto the new head, re-run local checks, then push with `--force-with-lease`. Never `--force`. |
+| Your work and theirs overlap partially | Keep only the parts still needed, rebase, re-run local checks, then push with `--force-with-lease`. |
+| You cannot tell | Prefer standing down and commenting — a duplicate fix costs more than a deferred one. |
+
+**Standing down** (a concurrent fix already landed):
+
+```bash
+gh pr comment $N --body "🩺 Doctor standing down: PR head moved from \`$CLAIM_HEAD_SHA\` to \`$CURRENT_HEAD_SHA\` while I was working, and the blocker I was dispatched for is already addressed by the concurrent push. Discarding my duplicate fix — no push made."
+gh pr edit $N --remove-label "loom:treating"
+```
+
+Do **not** add `loom:review-requested` when standing down — the Doctor who
+actually pushed owns that transition. Leave the PR's state labels alone and
+exit; your only label action is removing your own claim.
+
 **Pre-completion checklist** (verify before signaling completion):
 - [ ] All CI checks pass (verified via `gh pr checks <number>`)
+- [ ] I ran the stale `loom:treating` claim check before claiming (skipped the PR
+      on a fresh claim; reclaimed only on a stale one)
+- [ ] I re-compared the PR's `headRefOid` against `CLAIM_HEAD_SHA` immediately
+      before pushing, and on a mismatch re-verified the blocker (or stood down)
 - [ ] My commit(s) address the specific feedback quoted from the Judge's review
 - [ ] If any comment I posted came from a scratch file, I used `--body-file
       <path>` (or `gh api -F body=@<path>`) — NEVER `--body @<path>` (see the
@@ -634,8 +768,11 @@ gh pr list --label="loom:changes-requested" --state=open --json number,title,lab
 gh pr list --state=open --json number,title,mergeable \
   | jq -r '.[] | select(.mergeable == "CONFLICTING") | "#\(.number): \(.title)"'
 
-# Claim the PR before starting work
+# Claim the PR before starting work (run the stale-claim check first if the PR
+# already carries loom:treating — see "Stale `loom:treating` Claim Check"), and
+# record the head SHA you are starting from for the pre-push recheck
 gh pr edit 42 --add-label "loom:treating"
+CLAIM_HEAD_SHA=$(gh pr view 42 --json headRefOid --jq '.headRefOid')
 
 # View PR details and review status
 gh pr view 42
@@ -672,6 +809,15 @@ git commit -m "Address review feedback
 - Fix null handling in foo.ts:15
 - Add test case for error condition
 - Update README with new API docs"
+
+# Pre-push head-SHA recheck — did another agent push while you worked?
+CURRENT_HEAD_SHA=$(gh pr view 42 --json headRefOid --jq '.headRefOid')
+if [ -n "$CURRENT_HEAD_SHA" ] && [ "$CURRENT_HEAD_SHA" != "$CLAIM_HEAD_SHA" ]; then
+  # Re-verify the blocker (gh pr view 42 --comments / gh pr checks 42) before
+  # continuing — stand down if a concurrent fix already landed.
+  echo "Head moved: $CLAIM_HEAD_SHA -> $CURRENT_HEAD_SHA"
+fi
+
 git push
 
 # Signal completion and unclaim (amber → green, remove in-progress)

--- a/defaults/.github/labels.yml
+++ b/defaults/.github/labels.yml
@@ -46,7 +46,7 @@
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:treating
-  description: "Doctor is fixing this bug or addressing PR feedback. Applied by: Doctor only (claim label)."
+  description: "Doctor is fixing this bug or PR. Applied by: Doctor. Stale after LOOM_STALE_TREATING_MINUTES (60m)."
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:reviewing

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1298,7 +1298,7 @@ Thresholds are minutes-scale, not hours, and env-overridable:
 | Claim label | Env var | Default |
 |-------------|---------|---------|
 | `loom:reviewing` | `LOOM_STALE_REVIEWING_MINUTES` | 30 — the SAME env var `.claude/commands/loom/judge.md`'s "Stale `loom:reviewing` Claim Check" already established, so the agent-side fast path and this always-on daemon backstop share one convention |
-| `loom:treating` | `LOOM_STALE_TREATING_MINUTES` | 60 — a Doctor's fix cycle legitimately runs longer than a single Judge review pass |
+| `loom:treating` | `LOOM_STALE_TREATING_MINUTES` | 60 — a Doctor's fix cycle legitimately runs longer than a single Judge review pass; the SAME env var `.claude/commands/loom/doctor.md`'s "Stale `loom:treating` Claim Check" fast path uses (#4527) |
 
 Reclaiming removes only the stale claim label — the PR's state label (still
 present in the normal case) restores discoverability by itself. As a safety
@@ -1307,6 +1307,16 @@ net, if the PR is left carrying none of `loom:review-requested` /
 `forge::reclaim_pr` adds `loom:review-requested` so a fresh Judge pass picks
 it back up. Log lines mirror the issue-side format, e.g. `claim_reconciliation:
 removed stale loom:reviewing from PR #N in <root> (DeadPid { pid: … }, …)`.
+
+**Agent-side fast paths are complementary, not redundant (#4527).** This pass
+is periodic (up to `LOOM_CLAIM_RECONCILE_INTERVAL_SECS`, default 600s, of lag)
+and only ever sees *finished* state, so both role prompts carry a synchronous
+check that fires the moment another agent revisits the same PR: judge.md's
+"Stale `loom:reviewing` Claim Check" and doctor.md's "Stale `loom:treating`
+Claim Check", sharing these exact env vars and defaults. doctor.md additionally
+carries a **pre-push head-SHA recheck** (capture `headRefOid` at claim time,
+re-compare before the final push) — the one race this pass structurally cannot
+cover, since it never hooks into an in-flight Doctor's push.
 
 ## Stacked-PR dependency — #3729 (v1), #3747 (v2 item 1)
 


### PR DESCRIPTION
## Summary

Doctor already claims PRs with `loom:treating`, but had no way to distinguish a **live** claim from a **dead** one, and no protection against a second Doctor duplicating an *in-flight* fix. This adds the two agent-side mechanisms that close those windows, mirroring the pattern judge.md already establishes for `loom:reviewing`.

## Changes

- **`defaults/.claude/commands/loom/doctor.md`**
  - New **"Stale `loom:treating` Claim Check (Step 2)"** section: `labeled` timeline-timestamp lookup, comments-after count, and the same fresh / stale / unknown decision table judge.md uses — with reclaim commands. Uses `LOOM_STALE_TREATING_MINUTES` (default **60**, matching `DEFAULT_STALE_TREATING_MINUTES` in `loom-daemon/src/claim_reconciliation.rs`), explicitly **not** the Judge's 30-minute var. Fails safe to "fresh" when the timeline call fails or returns empty, so a claim is never stomped on missing data.
  - New **"Pre-Push Head-SHA Recheck (Step 9)"** section: capture `headRefOid` as `CLAIM_HEAD_SHA` at claim time, re-compare immediately before the final push, and on a mismatch re-verify the blocker is still unaddressed (comments / checks / labels / `git log CLAIM_HEAD_SHA..origin/<branch>`) before continuing. A finding table covers all four outcomes, plus a **stand-down** path that comments and drops *only* the `loom:treating` claim (it never touches `loom:review-requested` — the Doctor who actually pushed owns that transition).
  - Wired into every claim site: PR Fix Mode, Work Process step 2, the explicit-user override example, and Example Commands. Work Process step 9 gains a MANDATORY pre-push recheck bullet, and a Finding Work note explains why the queues' `loom:treating` filter is only a point-in-time snapshot.
  - Two new pre-completion checklist items (ran the claim check; ran the head-SHA recheck).
- **`.github/labels.yml` + `defaults/.github/labels.yml`** — `loom:treating` description gains the staleness clause matching `loom:reviewing`'s pattern. Kept byte-identical across both copies and within GitHub's 100-char limit (99 chars), so `check-labels-drift.sh` and `check-label-descriptions.sh` both stay green; "(claim label)" was traded for the staleness clause to fit, exactly as `loom:reviewing` does.
- **`defaults/docs/daemon-reference.md`** — cross-links the agent-side fast paths from the PR-side claim-label section so the periodic daemon backstop (#4367) is not mistaken for full coverage, and notes that the pre-push recheck is the one race the daemon pass structurally cannot cover.

## Acceptance Criteria Verification

- [x] **doctor.md gains a "Stale `loom:treating` Claim Check"** placed with the claim step (step 2), mirroring judge.md's structure — timeline lookup, comments-after check, fresh/stale decision table, reclaim commands. Uses `LOOM_STALE_TREATING_MINUTES` (60). Verified: `grep -n "LOOM_STALE_REVIEWING_MINUTES" defaults/.claude/commands/loom/doctor.md` returns only the one comparative mention explaining *not* to use it.
- [x] **Pre-push head-SHA recheck**: `CLAIM_HEAD_SHA` captured at all four claim sites; re-compared before the final push; mismatch → re-verify then rebase-or-stand-down, with a concrete PR comment for the stand-down case.
- [x] **`.github/labels.yml` staleness clause** citing `LOOM_STALE_TREATING_MINUTES` (60m), matching `loom:reviewing`'s pattern.
- [x] **No change to `sweep.md`** — verified both Doctor phase sections (issue-side step 6, PR-set Mode C C1b) delegate entirely via "Load and follow the instructions in `.claude/commands/loom/doctor.md`" with no inline claim logic; they read cleanly with no dangling references after this change.
- [x] **No change to `loom-daemon/src/claim_reconciliation.rs`** — the #4367 backstop already covers periodic `loom:treating` reclaim; this PR adds only the synchronous fast path and the pre-push recheck it cannot provide.

## Test Plan

This is a role-prompt / registry change with no executable code path, so verification is by the repo's doc + registry lints plus a read-through of the affected call sites:

- [x] `bash defaults/scripts/check-labels-drift.sh` → OK (both labels.yml copies identical)
- [x] `bash defaults/scripts/check-label-descriptions.sh` → OK (all within 100 chars; the new `loom:treating` description is 99)
- [x] `bash defaults/scripts/check-phantom-labels.sh` → OK (all labels referenced in the new prose exist in the registry)
- [x] `bash scripts/check-agents-md-sync.sh` → OK
- [x] `bash scripts/check-claude-md-budget.sh` → OK (315/320 lines, unchanged)
- [x] `./.loom/scripts/check-main-clean.sh` → clean (all edits confined to the issue worktree)
- [x] Read-through of `sweep.md` lines ~1288 (Mode C C1b) and ~1773 (step 6): pure delegation, no inline Doctor claim logic to update.
- [ ] Live behavioral verification (fresh claim → skip; stale claim → reclaim; head moved → stand down) requires two concurrently dispatched Doctors on one PR and is left to the next real Doctor dispatch — the incident shape this documents (PR #4303, `daemon-reference.md`) is not reproducible on demand.

**Note on scope**: only `defaults/` is edited here. The installed `.claude/commands/loom/` and `.loom/docs/` copies are refreshed separately by `resync-installed.sh` (the repo's `chore: resync installed Loom surfaces` commits) — consistent with how every prior role-prompt PR in this repo (#4575, #4351, #4247) landed.

Closes #4527
