### PR TITLE
test(role_runner): neutralize private-defaults tier in config-surface tests

### DIFF
--- a/loom-daemon/src/role_runner.rs
+++ b/loom-daemon/src/role_runner.rs
@@ -1831,35 +1831,60 @@ mod tests {
     // Config surface — autonomous.roleRunner
     // ===================================================================
 
+    // NOTE: these tests read `read_role_runner_config`, which merges the
+    // private-defaults tier (`config_resolver::private_defaults_path()`) ahead
+    // of the tempdir-scoped config under test. That tier resolves off
+    // `$LOOM_CONFIG_DEFAULTS_FILE` / `$HOME` — independent of `tmp.path()` — so
+    // a host's real `~/.local/share/loom/config/defaults.json` can leak into
+    // the result. Neutralize it for the duration of each test (#4538), and use
+    // the same named serial group (`loom_config_env`) as the other tests below
+    // that mutate this exact env var — a bare `#[serial]` would not serialize
+    // against it, since `serial_test` locks are per-key.
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_missing_file_is_default() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
-        assert_eq!(read_role_runner_config(tmp.path()), RoleRunnerConfig::default());
+        let cfg = read_role_runner_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg, RoleRunnerConfig::default());
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_malformed_json_is_default() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), "{not valid json");
-        assert_eq!(read_role_runner_config(tmp.path()), RoleRunnerConfig::default());
+        let cfg = read_role_runner_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg, RoleRunnerConfig::default());
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_missing_block_is_default() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), r#"{"autonomous": {"workFinder": {"enabled": true}}}"#);
-        assert_eq!(read_role_runner_config(tmp.path()), RoleRunnerConfig::default());
+        let cfg = read_role_runner_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg, RoleRunnerConfig::default());
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_reads_enabled_roles_and_interval() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         write_config(
             tmp.path(),
             r#"{"autonomous": {"roleRunner": {"enabled": true, "roles": ["curator", "guide"], "intervalSecs": 120}}}"#,
         );
+        let cfg = read_role_runner_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
         assert_eq!(
-            read_role_runner_config(tmp.path()),
+            cfg,
             RoleRunnerConfig {
                 enabled: Some(true),
                 roles: Some(vec!["curator".to_string(), "guide".to_string()]),
@@ -1871,10 +1896,14 @@ mod tests {
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_zero_interval_is_dropped_to_none() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), r#"{"autonomous": {"roleRunner": {"intervalSecs": 0}}}"#);
-        assert_eq!(read_role_runner_config(tmp.path()).interval_secs, None);
+        let interval_secs = read_role_runner_config(tmp.path()).interval_secs;
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(interval_secs, None);
     }
 
     // ===================================================================
@@ -2256,31 +2285,48 @@ mod tests {
     // onIdle config parsing (#4364)
     // ===================================================================
 
+    // NOTE: see the comment above `test_config_missing_file_is_default` — these
+    // tests read `read_role_runner_config` too, so they need the same
+    // private-defaults-tier guard + `#[serial(loom_config_env)]` (#4538).
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_on_idle_absent_is_none() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), r#"{"autonomous": {"roleRunner": {"enabled": true}}}"#);
-        assert_eq!(read_role_runner_config(tmp.path()).on_idle, None);
+        let on_idle = read_role_runner_config(tmp.path()).on_idle;
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(on_idle, None);
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_on_idle_parses_array() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), r#"{"autonomous": {"roleRunner": {"onIdle": ["champion"]}}}"#);
-        assert_eq!(read_role_runner_config(tmp.path()).on_idle, Some(vec!["champion".to_string()]));
+        let on_idle = read_role_runner_config(tmp.path()).on_idle;
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(on_idle, Some(vec!["champion".to_string()]));
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_on_idle_non_array_soft_fails_to_none() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         // A non-array (string) value must not panic — it soft-fails to `None`,
         // matching the `roles` contract.
         write_config(tmp.path(), r#"{"autonomous": {"roleRunner": {"onIdle": "champion"}}}"#);
-        assert_eq!(read_role_runner_config(tmp.path()).on_idle, None);
+        let on_idle = read_role_runner_config(tmp.path()).on_idle;
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(on_idle, None);
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_on_idle_drops_non_string_entries() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         // Non-string entries are dropped; string entries survive (unknown
         // *names* are filtered later in `resolve_on_idle_roles`).
@@ -2288,7 +2334,9 @@ mod tests {
             tmp.path(),
             r#"{"autonomous": {"roleRunner": {"onIdle": ["champion", 7, true]}}}"#,
         );
-        assert_eq!(read_role_runner_config(tmp.path()).on_idle, Some(vec!["champion".to_string()]));
+        let on_idle = read_role_runner_config(tmp.path()).on_idle;
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(on_idle, Some(vec!["champion".to_string()]));
     }
 
     // ===================================================================


### PR DESCRIPTION
## Summary

`read_role_runner_config` merges `config_resolver::private_defaults_path()` (the
tier-1 private/shared-defaults resolver) ahead of the tempdir-scoped config a
test passes in. That tier resolves off `$LOOM_CONFIG_DEFAULTS_FILE` / `$HOME`,
independent of the test's `tmp.path()`, so a host's real
`~/.local/share/loom/config/defaults.json` (or a `LOOM_CONFIG_DEFAULTS_FILE`
pointed file) can leak into several `role_runner::tests` config-surface test
results. This is test-isolation-only — no behavior change to
`read_role_runner_config` itself.

## Changes

- Neutralize the private-defaults tier for the duration of each affected test
  (`std::env::set_var(LOOM_CONFIG_DEFAULTS_FILE, "")` before, `remove_var`
  after) in `loom-daemon/src/role_runner.rs`:
  - `test_config_missing_file_is_default`
  - `test_config_malformed_json_is_default`
  - `test_config_missing_block_is_default`
  - `test_config_reads_enabled_roles_and_interval`
  - `test_config_zero_interval_is_dropped_to_none`
  - `test_config_on_idle_absent_is_none`
  - `test_config_on_idle_parses_array`
  - `test_config_on_idle_non_array_soft_fails_to_none`
  - `test_config_on_idle_drops_non_string_entries`
- Mark all of the above `#[serial(loom_config_env)]` — the same **named**
  serial group already used by the two existing `test_config_project_tier_*`
  tests that mutate this exact env var, since a bare `#[serial]` uses a
  different (unnamed) lock key and would not serialize against it.
- `test_config_project_tier_only_is_honored_like_legacy` and
  `test_config_project_tier_overrides_legacy_overlap_and_supplies_non_overlap`
  already had the guard — left unchanged.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| The three originally-reported tests + the rest of the `// Config surface — autonomous.roleRunner` block pass regardless of a real `~/.local/share/loom/config/defaults.json` / `LOOM_CONFIG_DEFAULTS_FILE` | ✅ | Ran with a stray `~/.local/share/loom/config/defaults.json` present containing `{"autonomous":{"roleRunner":{"enabled":true,"roles":["curator"]}}}` — all pass (see Test Plan) |
| Fix neutralizes the private-defaults tier for the test's duration | ✅ | `LOOM_CONFIG_DEFAULTS_FILE=""` set before, `remove_var` after, in each affected test |
| Any test mutating `LOOM_CONFIG_DEFAULTS_FILE` marked `#[serial(loom_config_env)]`, not bare `#[serial]` | ✅ | All 9 newly-guarded tests use `#[serial(loom_config_env)]`, matching the existing `test_config_project_tier_*` tests |
| No behavior change to `read_role_runner_config` itself | ✅ | Only test bodies changed; `git diff` touches only `#[cfg(test)] mod tests` |

## Test Plan

- Manual repro (per issue): created `~/.local/share/loom/config/defaults.json`
  with `{"autonomous":{"roleRunner":{"enabled":true,"roles":["curator"]}}}`,
  ran `cargo test -p loom-daemon --lib role_runner::tests::test_config_missing_file_is_default -- --exact --test-threads=1` — passes after the fix (fails on
  unmodified `main` with the same stray file, confirmed by reverting the patch
  in-place and re-running).
- `cargo test -p loom-daemon --lib role_runner::tests::test_config` — all 11
  tests pass both with and without the stray `defaults.json` present.
- `cargo test -p loom-daemon --lib role_runner::` (full module) run 3x with the
  stray file present and 3x without — the newly `#[serial(loom_config_env)]`
  annotated tests are consistently green in both cases; no flakiness introduced
  by the new annotations.
- `cargo check -p loom-daemon --lib`, `cargo clippy -p loom-daemon --lib
  --tests`, `cargo fmt -- --check` all clean.

Note: while regression-testing the full `role_runner::` module with the stray
`defaults.json` present, I found one *other* pre-existing test in the same file
(`test_observe_and_fire_idle_cross_config_disabled_target_root_warns_and_suppresses`,
outside the `// Config surface` block and not in this issue's Affected Files
list) that also reads config via `observe_and_fire_idle` and is susceptible to
the same private-defaults leak — it fails with the stray file present both
before and after this patch (confirmed unrelated to this change). Left
out-of-scope per the issue's explicit test list; flagging here as a candidate
for a small follow-up rather than fixing unilaterally.

Closes #4538