### PR TITLE
fix(merge-pr): defend Part of/Contributes to against a stray closing keyword

### DIFF
--- a/defaults/.claude/commands/loom/builder-pr.md
+++ b/defaults/.claude/commands/loom/builder-pr.md
@@ -578,7 +578,7 @@ Closes #123
 
 ### Why This Matters
 
-GitHub's auto-close feature only works with specific keywords at the start of a line:
+GitHub's auto-close feature only works with specific keywords **immediately followed** by the issue reference:
 - `Closes #X`
 - `Fixes #X`
 - `Resolves #X`
@@ -587,6 +587,14 @@ GitHub's auto-close feature only works with specific keywords at the start of a 
 - `Resolved #X`
 
 **Any other phrasing will NOT trigger auto-close.**
+
+> **The keyword does NOT have to start a line — GitHub scans the ENTIRE body.**
+> `close`/`closes`/`closed`/`fix`/`fixes`/`fixed`/`resolve`/`resolves`/`resolved` creates a
+> real closing reference **wherever** it appears — mid-sentence, inside a numbered list, in a
+> "follow-up" checklist. What breaks the link is a word between the keyword and the reference
+> (`close issue #X`, `Fixes issue #X`), not its position in the body. This cuts both ways: it
+> is why `Fixes issue #123` silently fails to close, and why a stray `then close #123` buried
+> in prose silently *does* close — see "Partial increments" below (#4569).
 
 ### Partial increments (family/epic issues)
 
@@ -600,6 +608,43 @@ Contributes to #123
 `Part of #N` references the issue (keeping the PR discoverable) but does NOT trigger auto-close, so the family/epic issue survives the merge. Only the **final increment** that completes the family uses `Closes #N`.
 
 **Both the PR body and the commit message must carry the same reference.** This repo squash-merges, and GitHub harvests closing keywords from the squash commit message as well as the PR body — a stray `Closes #N` in the commit body will auto-close the family issue even when the PR body says `Part of #N`. When in doubt on a `loom:epic` issue, prefer `Part of #N`.
+
+#### A stray closing keyword ANYWHERE in the body defeats `Part of #N` (#4569)
+
+`Part of #N` / `Contributes to #N` is not a shield. GitHub does not weigh the two references
+against each other — **one** closing keyword adjacent to `#N` anywhere in the body is enough
+to close the issue on merge, no matter how explicitly the rest of the body says otherwise.
+
+This is a real, observed failure, not a hypothetical. A partial-increment PR ended with the
+deliberate trailer `Contributes to #2` and an operator-handoff section that read:
+
+```markdown
+## Operator follow-up (after merge)
+
+3. Verify `npm view censusapi` resolves to `0.0.1`, then close #2.   ← closes #2 on merge!
+```
+
+GitHub honored that `close #2`. The issue was closed on squash-merge and had to be reopened
+by hand. (For the record: the head branch was `feature/issue-2`, but branch naming was *not*
+the cause — Loom's `feature/issue-N` convention does not create a Development-sidebar link.)
+
+**Rules for a partial-increment PR body:**
+
+- **Never** write a closing keyword immediately before the tracked issue's number. Write
+  `then close the issue`, or `then close issue #2` (the intervening word breaks the link).
+- The tracked issue number should appear exactly once with a keyword: the `Part of #N` /
+  `Contributes to #N` reference. Scan the whole body — including checklists, test plans, and
+  operator-handoff sections — before creating the PR:
+
+  ```bash
+  # Must print nothing for the tracked issue N:
+  grep -inE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#N\b' <<<"$PR_BODY"
+  ```
+
+**Backstop (not a substitute for the above)**: `merge-pr.sh` detects this contradiction
+before merging and warns, then reopens the issue immediately after the merge if GitHub closed
+it anyway. That leaves a close/reopen flicker plus notification churn on the issue — fix the
+body instead of relying on it.
 
 ### PR Creation Checklist
 

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -1020,6 +1020,15 @@ If EITHER is true, the PR is a **partial increment** of a larger tracked body of
 - Do NOT flag the missing closing keyword.
 - Do NOT insert or rewrite a closing keyword (skip the auto-fix in "Minor PR Description Fixes" below).
 - Verify the non-closing reference (`Part of #N` / `Contributes to #N`) is present so the PR stays discoverable; if it references the issue only as bare "Issue #N", ask the Builder to change it to `Part of #N` (do not "fix" it to `Closes #N`).
+- **Verify no STRAY closing keyword targets #N anywhere else in the body (#4569).** `Part of #N` does not shield the issue: GitHub honors any `close`/`fix`/`resolve` keyword immediately followed by `#N` **anywhere** in the body — including buried in prose, a numbered list, or an "Operator follow-up (after merge)" section — and closes the issue on merge regardless. This has happened for real ("…then close #2" in a handoff checklist closed the very issue the PR declared `Contributes to #2`).
+
+  ```bash
+  # Run for the tracked issue N. ANY output is a defect that will close #N on merge.
+  gh pr view <number> --json body -q .body \
+    | grep -inE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#N\b'
+  ```
+
+  This is a **minor PR description fix** you should make directly (it does not need a Builder round-trip): edit the body so the keyword is no longer adjacent to the reference — `then close the issue`, or `then close issue #N`. An intervening word breaks the link; moving the phrase to a different line does not.
 - Evaluate the code on its own merits and approve/reject normally.
 
 **If PR description is missing "Closes #X" syntax (and the partial-increment exception above does NOT apply):**

--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -430,6 +430,147 @@ Or, if you have already verified/reconciled them, re-run with --allow-stacked-ch
 # Invoke the guard before either merge path attempts the actual merge API call.
 _check_no_open_stacked_children
 
+# ---------------------------------------------------------------------------
+# Partial-increment closing-keyword conflict detection (#4569).
+#
+# ROOT CAUSE (established from the rjwalters/censusapi#5 -> censusapi#2 incident,
+# NOT from the branch-name theory the report floated):
+#
+#   GitHub's closing-reference parser scans the ENTIRE PR body and honors ANY
+#   `close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved` that is
+#   IMMEDIATELY followed by `#N` — wherever it appears, including buried in
+#   prose, inside a list item, or mid-sentence. It is NOT limited to a
+#   line-leading trailer.
+#
+#   censusapi PR #5 ended with the deliberate non-closing trailer
+#   `Contributes to #2`, but an earlier "Operator follow-up (after merge)" step
+#   read "...then close #2". GitHub honored that `close #2` as a real closing
+#   reference and closed issue #2 on squash-merge, silently defeating the #3599
+#   partial-increment convention. The evidence:
+#     - issue #2's timeline has NO `connected` event, so there was no
+#       Development-sidebar / branch-name link -> the `feature/issue-N`
+#       branch-name auto-link hypothesis is RULED OUT;
+#     - the squash commit message contained only `Contributes to #2` (no closing
+#       keyword), so the close did not come from the commit message either;
+#     - the `closed` event has `commit_id: null` with the merger as actor at the
+#       merge instant — the signature of a PR-body closing-reference close.
+#
+# Fix shape: DETECT (here, pre-merge, with a loud actionable warning) plus
+# SELF-HEAL (post-merge reopen in _reset_one_partial_issue below). Prevention by
+# rewriting the PR body at merge time was rejected — mutating a body the Judge
+# already reviewed is a worse failure mode than a seconds-long close/reopen.
+#
+# Two globals are published for the post-merge pass, both space-separated:
+#   PARTIAL_OPEN_BEFORE_MERGE - partial-increment refs that were OPEN right
+#       before the merge (so "closed afterwards" is attributable to this merge).
+#   PARTIAL_CONFLICT_ISSUES   - the subset that ALSO carries a closing reference
+#       from this PR, i.e. the ones GitHub is about to close against the
+#       declared intent. Only these are auto-reopened; that keeps a deliberate
+#       human close inside the merge window (which carries no closing reference)
+#       from being reverted.
+PARTIAL_OPEN_BEFORE_MERGE=""
+PARTIAL_CONFLICT_ISSUES=""
+
+# Issue numbers referenced with a NON-closing partial-increment keyword
+# (`Part of #N` / `Contributes to #N`, case-insensitive), one per line, deduped.
+_partial_increment_refs() {
+  { printf '%s\n' "$1" \
+      | grep -oiE '(Part of|Contributes to)[[:space:]]+#[0-9]+' \
+      | grep -oE '[0-9]+' \
+      | sort -un; } || true
+}
+
+# Issue numbers referenced with a GitHub CLOSING keyword anywhere in the text,
+# one per line, deduped. The regex is deliberately the same one
+# forge_pr_close_targets() uses on its Gitea branch (the canonical keyword set,
+# with `\b` guarding against substring traps like `Discloses #N`).
+#
+# Why a body regex and not only the authoritative GraphQL
+# `closingIssuesReferences`: that field is GraphQL-only, and the incident this
+# guard exists for happened while GraphQL quota was exhausted (the PR was even
+# created via raw REST for that reason). A quota-free text signal is the one that
+# still works in exactly the conditions where this bug bites.
+_body_closing_refs() {
+  { printf '%s\n' "$1" \
+      | grep -oiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\b[[:space:]]+#[0-9]+' \
+      | grep -oE '[0-9]+' \
+      | sort -un; } || true
+}
+
+# Membership tests over the space-separated globals above.
+_partial_ref_is_conflicted() {
+  [[ -n "${PARTIAL_CONFLICT_ISSUES:-}" ]] || return 1
+  [[ " $PARTIAL_CONFLICT_ISSUES " == *" $1 "* ]]
+}
+_partial_ref_was_open_before_merge() {
+  [[ -n "${PARTIAL_OPEN_BEFORE_MERGE:-}" ]] || return 1
+  [[ " $PARTIAL_OPEN_BEFORE_MERGE " == *" $1 "* ]]
+}
+
+# Populate the two globals and warn about each detected conflict. Best-effort:
+# never fails the merge, and a lookup failure simply yields a smaller set.
+_check_partial_increment_close_conflict() {
+  [[ "$FORGE_TYPE" == "github" ]] || return 0
+
+  local pr_body
+  pr_body="$(echo "$PR_JSON" | jq -r '.body // ""')"
+  [[ -n "$pr_body" ]] || return 0
+
+  local partial_refs
+  partial_refs="$(_partial_increment_refs "$pr_body")"
+  [[ -n "$partial_refs" ]] || return 0
+
+  # Closing references GitHub will honor on merge: the body's own closing
+  # keywords (quota-free) UNION GitHub's authoritative closingIssuesReferences
+  # (best-effort — empty under GraphQL quota exhaustion, but when it does answer
+  # it also surfaces a Development-sidebar link that no body text reveals).
+  local body_close_refs graphql_close_refs close_refs
+  body_close_refs="$(_body_closing_refs "$pr_body")"
+  graphql_close_refs="$(forge_pr_close_targets "$PR_NUMBER" "$GH" 2>/dev/null || true)"
+  close_refs="$(printf '%s\n%s\n' "$body_close_refs" "$graphql_close_refs" \
+    | grep -E '^[0-9]+$' | sort -un || true)"
+
+  local issue_num issue_json
+  while IFS= read -r issue_num; do
+    [[ -n "$issue_num" ]] || continue
+
+    # Fresh (uncached) read — plain `gh api`, not $GH, mirroring
+    # _reset_one_partial_issue's freshness discipline. Skip PRs that slipped
+    # through the regex (the issues endpoint also returns PRs).
+    issue_json="$(gh api "repos/$REPO_NWO/issues/$issue_num" 2>/dev/null || echo '{}')"
+    if [[ "$(echo "$issue_json" | jq -r 'has("pull_request")')" == "true" ]]; then
+      continue
+    fi
+    # Only an issue that is OPEN right now can be closed BY this merge; one that
+    # is already closed was closed by something else and is not ours to revert.
+    if [[ "$(echo "$issue_json" | jq -r '.state // ""')" != "open" ]]; then
+      continue
+    fi
+    PARTIAL_OPEN_BEFORE_MERGE="${PARTIAL_OPEN_BEFORE_MERGE:+$PARTIAL_OPEN_BEFORE_MERGE }$issue_num"
+
+    if ! grep -qx "$issue_num" <<<"$close_refs"; then
+      continue
+    fi
+    PARTIAL_CONFLICT_ISSUES="${PARTIAL_CONFLICT_ISSUES:+$PARTIAL_CONFLICT_ISSUES }$issue_num"
+
+    local offending dr=""
+    # Match _check_no_open_stacked_children's dry-run contract: report the
+    # would-be outcome without claiming a merge is happening.
+    [[ "${DRY_RUN:-false}" == "true" ]] && dr="[dry-run] "
+    offending="$(printf '%s\n' "$pr_body" \
+      | grep -oiE "\\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\\b[[:space:]]+#$issue_num\\b" \
+      | sort -u | tr '\n' '|' | sed 's/|$//; s/|/", "/g' || true)"
+    warning "${dr}Partial-increment conflict (#4569): PR #$PR_NUMBER declares a NON-closing \`Part of\`/\`Contributes to\` reference to #$issue_num, but its body ALSO carries a closing reference to #$issue_num${offending:+ (\"$offending\")} — GitHub honors a closing keyword ANYWHERE in the body, so merging this PR WILL close #$issue_num against the declared intent."
+    warning "  ${dr}merge-pr.sh would reopen #$issue_num immediately after the merge. To avoid the close/reopen flicker entirely, edit the PR body so no closing keyword is immediately followed by \`#$issue_num\` (e.g. write \`close the issue\` or \`close issue #$issue_num\` instead of \`close #$issue_num\`), then re-run this merge."
+  done <<< "$partial_refs"
+
+  return 0
+}
+
+# Runs before either merge path so the operator sees the conflict BEFORE the
+# close happens, and so --dry-run reports it without merging. Best-effort.
+_check_partial_increment_close_conflict || true
+
 info "Merging PR #$PR_NUMBER: $PR_TITLE"
 info "Branch: $PR_BRANCH"
 
@@ -466,7 +607,7 @@ info "Branch: $PR_BRANCH"
 # second builder), or is actually a PR.
 _reset_one_partial_issue() {
   local issue_num="$1"
-  local issue_json issue_state issue_labels
+  local issue_json issue_state issue_labels reopened=false
 
   # Fresh (uncached) read so we see the label state AS OF the merge, not as of
   # PR creation. Plain `gh api` is uncached; use it directly (not $GH, which may
@@ -481,8 +622,33 @@ _reset_one_partial_issue() {
 
   issue_state="$(echo "$issue_json" | jq -r '.state // ""')"
   if [[ "$issue_state" != "open" ]]; then
-    info "Partial-increment reset: issue #$issue_num is not open (state='${issue_state:-unknown}') — skipping"
-    return 0
+    # #4569: a partial-increment issue that was OPEN pre-merge and is closed now
+    # was closed BY this merge. If the pre-merge guard recorded a closing
+    # reference to it from this very PR (a stray `close #N` in prose, or a
+    # Development-sidebar link), that close contradicts the PR's own declared
+    # `Part of` / `Contributes to` intent — revert it, then fall through to the
+    # normal label swap so the issue re-enters the ready queue.
+    if _partial_ref_is_conflicted "$issue_num"; then
+      warning "Partial-increment reset: issue #$issue_num was auto-closed by PR #$PR_NUMBER's merge despite its non-closing \`Part of\`/\`Contributes to\` reference (a closing reference to #$issue_num was detected pre-merge) — reopening (#4569)"
+      if gh issue reopen "$issue_num" --repo "$REPO_NWO" >/dev/null 2>&1; then
+        success "Issue #$issue_num reopened (premature auto-close reverted)"
+        reopened=true
+        _post_premature_close_comment "$issue_num"
+      else
+        warning "Could not reopen issue #$issue_num after its premature auto-close — reopen manually: gh issue reopen $issue_num --repo $REPO_NWO"
+        return 0
+      fi
+    elif _partial_ref_was_open_before_merge "$issue_num"; then
+      # Open before the merge, closed after it, but this PR carries no closing
+      # reference we can attribute it to. Could be a deliberate close by a human
+      # or another agent in the same window, so do NOT revert it — just make the
+      # coincidence loud enough to investigate.
+      warning "Partial-increment reset: issue #$issue_num was open before PR #$PR_NUMBER merged and is now closed (state='${issue_state:-unknown}'), but no closing reference to it was detected on this PR — NOT reopening automatically (it may be a deliberate close). If this was a premature auto-close, reopen it with: gh issue reopen $issue_num --repo $REPO_NWO"
+      return 0
+    else
+      info "Partial-increment reset: issue #$issue_num is not open (state='${issue_state:-unknown}') — skipping"
+      return 0
+    fi
   fi
 
   issue_labels="$(echo "$issue_json" | jq -r '.labels[]?.name' 2>/dev/null || true)"
@@ -497,13 +663,15 @@ _reset_one_partial_issue() {
        --remove-label "loom:building" \
        --add-label "loom:issue" >/dev/null 2>&1; then
     success "Issue #$issue_num: loom:building -> loom:issue (partial increment; issue remains open)"
-    local ts comment
+    local ts comment reopen_note=""
     ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    [[ "$reopened" == "true" ]] && reopen_note="
+- **Reopened** this issue (GitHub had auto-closed it from a stray closing keyword in PR #$PR_NUMBER's body — see #4569)"
     comment="## Partial Increment Merged
 
 PR #$PR_NUMBER merged with a non-closing \`Part of\` / \`Contributes to\` reference, so this issue remains **open** for further work.
 
-**Action taken**:
+**Action taken**:$reopen_note
 - Removed \`loom:building\` label
 - Added \`loom:issue\` label to return to the ready queue
 
@@ -518,6 +686,28 @@ This issue is now available for the next increment (a subsequent \`/loom:sweep\`
   fi
 }
 
+# Audit trail for a reverted premature auto-close (#4569). Posted right after
+# the reopen so the record survives even when the label swap below is skipped
+# (e.g. the issue no longer carries loom:building). Best-effort.
+_post_premature_close_comment() {
+  local issue_num="$1" ts comment
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  comment="## Premature Auto-Close Reverted
+
+PR #$PR_NUMBER referenced this issue with a **non-closing** \`Part of\` / \`Contributes to\` keyword — a declared partial increment, so this issue was meant to stay **open** after the merge. GitHub closed it anyway, because a **closing keyword** (\`close\`/\`fix\`/\`resolve\` and their tense variants) appeared somewhere else in the PR body immediately followed by \`#$issue_num\`.
+
+GitHub honors a closing keyword **anywhere** in a PR body — not only in a line-leading trailer — so prose like \"…then close #$issue_num\" in a follow-up checklist creates a real closing link that overrides the intended \`Contributes to #$issue_num\`.
+
+**Action taken**: reopened this issue.
+
+**To avoid this**: never put a closing keyword immediately before \`#$issue_num\` anywhere in a partial-increment PR body. Write \`close the issue\` or \`close issue #$issue_num\` instead of \`close #$issue_num\`.
+
+---
+*Reopened by merge-pr.sh (#4569) at $ts*"
+  gh issue comment "$issue_num" --repo "$REPO_NWO" --body "$comment" >/dev/null 2>&1 || \
+    warning "Could not post premature-close comment on issue #$issue_num (reopen still applied)"
+}
+
 # Parse the merged PR body for non-closing partial-increment references and
 # reset each referenced issue. Best-effort; returns 0 unconditionally.
 _reset_partial_increment_labels() {
@@ -527,14 +717,11 @@ _reset_partial_increment_labels() {
   pr_body="$(echo "$PR_JSON" | jq -r '.body // ""')"
   [[ -n "$pr_body" ]] || return 0
 
-  # Extract issue numbers referenced with a NON-closing partial-increment
-  # keyword: "Part of #N" / "Contributes to #N" (case-insensitive), deduped.
-  # grep -oiE emits e.g. "Part of #123"; a second grep strips to the number.
+  # Issue numbers referenced with a NON-closing partial-increment keyword.
+  # Shares _partial_increment_refs with the pre-merge #4569 conflict guard so the
+  # two passes can never disagree about which issues are partial increments.
   local refs
-  refs="$(printf '%s\n' "$pr_body" \
-    | grep -oiE '(Part of|Contributes to)[[:space:]]+#[0-9]+' \
-    | grep -oE '[0-9]+' \
-    | sort -u || true)"
+  refs="$(_partial_increment_refs "$pr_body")"
   [[ -n "$refs" ]] || return 0
 
   local issue_num

--- a/defaults/scripts/tests/test-merge-pr-partial-increment.sh
+++ b/defaults/scripts/tests/test-merge-pr-partial-increment.sh
@@ -10,13 +10,24 @@
 # orphan_recovery.py's recover_issue() semantics). Closing keywords
 # (`Closes`/`Fixes`/`Resolves`) are untouched (GitHub auto-closes those).
 #
-# Strategy: the two functions under test (_reset_one_partial_issue and
-# _reset_partial_increment_labels) depend only on globals (PR_JSON, REPO_NWO,
-# PR_NUMBER, FORGE_TYPE) and the `gh` CLI. We extract just those two function
-# definitions from merge-pr.sh and source them, stub `gh` on PATH to serve
-# canned issue JSON and record mutating calls, then assert on the recorded
-# calls. Extracting from source (rather than replicating) keeps the test in
-# lockstep with the script.
+# Also covers the #4569 closing-keyword conflict guard: GitHub honors a closing
+# keyword ANYWHERE in a PR body (not just a line-leading trailer), so prose like
+# "...then close #N" in a follow-up checklist silently overrides the deliberate
+# `Contributes to #N` trailer and closes the issue on merge. merge-pr.sh detects
+# that pre-merge (_check_partial_increment_close_conflict, warning + two
+# published globals) and reverts it post-merge (reopen inside
+# _reset_one_partial_issue) — while explicitly NOT reverting a close it cannot
+# attribute to this PR (a deliberate close in the same window).
+#
+# Strategy: the functions under test (_partial_increment_refs,
+# _body_closing_refs, _check_partial_increment_close_conflict,
+# _reset_one_partial_issue, _reset_partial_increment_labels) depend only on
+# globals (PR_JSON, REPO_NWO, PR_NUMBER, FORGE_TYPE, GH,
+# PARTIAL_CONFLICT_ISSUES, PARTIAL_OPEN_BEFORE_MERGE) and the `gh` CLI. We
+# extract just those function definitions from merge-pr.sh and source them, stub
+# `gh` on PATH to serve canned issue JSON and record mutating calls, then assert
+# on the recorded calls. Extracting from source (rather than replicating) keeps
+# the test in lockstep with the script.
 #
 # Usage:
 #   ./.loom/scripts/tests/test-merge-pr-partial-increment.sh
@@ -91,22 +102,34 @@ info()    { echo "INFO: $*"; }
 success() { echo "OK: $*"; }
 warning() { echo "WARN: $*" >&2; }
 
-# --- Extract the two functions under test from merge-pr.sh and source them ---
-# From `_reset_one_partial_issue() {` up to (not including) the
-# `# Handle auto-merge mode` line — this span contains exactly the two function
-# definitions plus intervening comments (harmless when sourced).
+# --- Extract the functions under test from merge-pr.sh and source them ---
+# Two spans, each bounded by an anchor line that is NOT part of the span:
+#   1. `_partial_increment_refs() {` .. `_check_partial_increment_close_conflict
+#      || true` — the #4569 pre-merge guard and its two pure-text ref extractors.
+#      Stopping at the INVOCATION line keeps the top-level call out of the
+#      sourced file (we drive the guard explicitly from the tests).
+#   2. `_reset_one_partial_issue() {` .. `# Handle auto-merge mode` — the
+#      post-merge reset/reopen pass.
+# Both spans contain only function definitions plus comments (harmless when
+# sourced).
 FUNCS_FILE="$(mktemp)"
 trap 'rm -rf "$FUNCS_FILE" "$STUB_DIR" 2>/dev/null || true' EXIT
 awk '
-  /^_reset_one_partial_issue\(\) \{/ { capture=1 }
-  /^# Handle auto-merge mode/        { capture=0 }
+  /^_partial_increment_refs\(\) \{/                     { capture=1 }
+  /^_check_partial_increment_close_conflict \|\| true/   { capture=0 }
+  /^_reset_one_partial_issue\(\) \{/                    { capture=1 }
+  /^# Handle auto-merge mode/                           { capture=0 }
   capture { print }
 ' "$MERGE_PR_SRC" > "$FUNCS_FILE"
 
-if ! grep -q '_reset_partial_increment_labels()' "$FUNCS_FILE"; then
-    echo -e "${RED}FATAL${NC}: could not extract functions from $MERGE_PR_SRC" >&2
-    exit 2
-fi
+for _fn in _partial_increment_refs _body_closing_refs \
+           _check_partial_increment_close_conflict _reset_one_partial_issue \
+           _reset_partial_increment_labels; do
+    if ! grep -q "^${_fn}() {" "$FUNCS_FILE"; then
+        echo -e "${RED}FATAL${NC}: could not extract $_fn from $MERGE_PR_SRC" >&2
+        exit 2
+    fi
+done
 # shellcheck disable=SC1090
 source "$FUNCS_FILE"
 
@@ -148,6 +171,16 @@ export PATH="$STUB_DIR:$PATH"
 REPO_NWO="owner/repo"
 PR_NUMBER="999"
 FORGE_TYPE="github"
+GH="gh"
+PARTIAL_OPEN_BEFORE_MERGE=""
+PARTIAL_CONFLICT_ISSUES=""
+
+# Shim for the GraphQL-backed close-target helper merge-pr.sh gets from
+# forge-helpers.sh. Driven by $FORGE_CLOSE_TARGETS so tests can simulate both
+# "GraphQL answered" and "GraphQL quota exhausted -> empty" (the condition the
+# #4569 incident actually occurred under).
+FORGE_CLOSE_TARGETS=""
+forge_pr_close_targets() { printf '%s' "$FORGE_CLOSE_TARGETS"; }
 
 # Canned issue fixtures.
 cat > "$STUB_DIR/issue-123.json" <<'EOF'
@@ -166,8 +199,23 @@ cat > "$STUB_DIR/issue-321.json" <<'EOF'
 {"state":"open","pull_request":{"url":"x"},"labels":[{"name":"loom:building"}]}
 EOF
 
-reset_log() { : > "$STUB_DIR/gh-calls.log"; }
+# Clearing the two #4569 globals here keeps every pre-existing case below running
+# against the same "no conflict recorded" state it was written for.
+reset_log() {
+  : > "$STUB_DIR/gh-calls.log"
+  PARTIAL_OPEN_BEFORE_MERGE=""
+  PARTIAL_CONFLICT_ISSUES=""
+  FORGE_CLOSE_TARGETS=""
+}
 read_log()  { cat "$STUB_DIR/gh-calls.log" 2>/dev/null || true; }
+
+# Run one of the functions under test IN THE CURRENT SHELL (never a command
+# substitution — the #4569 guard publishes its results via globals, which a
+# subshell would discard) while capturing its stderr for assertions.
+run_capturing_stderr() {
+    "$@" 2>"$STUB_DIR/stderr.log" || true
+}
+read_stderr() { cat "$STUB_DIR/stderr.log" 2>/dev/null || true; }
 
 echo "Testing _reset_partial_increment_labels behavior..."
 
@@ -253,6 +301,156 @@ assert_contains "$log" "issue edit 123 --repo owner/repo --remove-label loom:bui
 assert_not_contains "$log" "issue edit 888" \
   "Mixed body: Closes #888 is NOT touched"
 
+# ---------------------------------------------------------------------------
+# #4569: closing-keyword conflict detection + premature-close revert.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Testing _body_closing_refs (GitHub closing-keyword extraction)..."
+
+# The incident phrasing: a closing keyword buried in prose, NOT line-leading.
+assert_eq "123" "$(_body_closing_refs '3. Verify the publish, then close #123.')" \
+  "Prose 'then close #123' is a closing reference (keyword is not line-leading)"
+assert_eq "123" "$(_body_closing_refs 'Closes #123')" \
+  "Canonical 'Closes #123' trailer extracted"
+assert_eq "$(printf '7\n9')" "$(_body_closing_refs 'Fixes #7 and resolved #9')" \
+  "Tense/case variants (Fixes/resolved) both extracted, numerically sorted"
+assert_eq "" "$(_body_closing_refs 'Contributes to #123')" \
+  "Non-closing 'Contributes to #123' is NOT a closing reference"
+assert_eq "" "$(_body_closing_refs 'Discloses #123 and Updates #456')" \
+  "Word-boundary guard: 'Discloses'/'Updates' are not closing keywords"
+assert_eq "" "$(_body_closing_refs 'close issue #123')" \
+  "'close issue #123' is NOT a closing reference (keyword not adjacent to #N)"
+assert_eq "1234" "$(_body_closing_refs 'Closes #1234')" \
+  "Full number is extracted (no #123 prefix confusion)"
+
+echo ""
+echo "Testing _check_partial_increment_close_conflict (pre-merge guard)..."
+
+# T11: reproduces the censusapi#5 -> censusapi#2 incident shape — a deliberate
+# `Contributes to #123` trailer plus an "Operator follow-up" step saying
+# "...then close #123", with GraphQL unavailable (quota exhausted).
+reset_log
+PR_JSON='{"body":"## Summary\n\nBuilder scope only; publish steps stay with the operator.\n\n## Operator follow-up (after merge)\n\n1. npm publish\n2. Verify, then close #123.\n\nContributes to #123\n"}'
+run_capturing_stderr _check_partial_increment_close_conflict
+guard_err="$(read_stderr)"
+assert_eq "123" "$PARTIAL_CONFLICT_ISSUES" \
+  "Incident shape: #123 recorded as a closing-keyword conflict (body regex, no GraphQL)"
+assert_eq "123" "$PARTIAL_OPEN_BEFORE_MERGE" \
+  "Incident shape: #123 recorded as open before the merge"
+assert_contains "$guard_err" "Partial-increment conflict (#4569)" \
+  "Incident shape: emits the actionable pre-merge warning"
+assert_contains "$guard_err" "close #123" \
+  "Incident shape: warning quotes the offending phrase"
+
+# T12: a clean partial-increment body -> tracked as open-before-merge, no conflict.
+reset_log
+PR_JSON='{"body":"Implements a slice.\n\nContributes to #123"}'
+_check_partial_increment_close_conflict 2>/dev/null
+assert_eq "" "$PARTIAL_CONFLICT_ISSUES" \
+  "Clean 'Contributes to #123' body -> no conflict recorded"
+assert_eq "123" "$PARTIAL_OPEN_BEFORE_MERGE" \
+  "Clean body -> #123 still recorded as open before the merge"
+
+# T13: closing keyword aimed at a DIFFERENT issue -> not a conflict.
+reset_log
+PR_JSON='{"body":"Closes #888\n\nPart of #123"}'
+_check_partial_increment_close_conflict 2>/dev/null
+assert_eq "" "$PARTIAL_CONFLICT_ISSUES" \
+  "Closes #888 + Part of #123 -> no conflict (different issues)"
+
+# T14: partial ref already closed BEFORE the merge -> tracked in neither set,
+# so nothing this merge does can be blamed on it.
+reset_log
+PR_JSON='{"body":"Part of #777"}'
+_check_partial_increment_close_conflict 2>/dev/null
+assert_eq "" "$PARTIAL_CONFLICT_ISSUES" "Pre-closed #777 -> no conflict recorded"
+assert_eq "" "$PARTIAL_OPEN_BEFORE_MERGE" "Pre-closed #777 -> not recorded as open before merge"
+
+# T15: GraphQL-only closing link (e.g. a Development-sidebar link no body text
+# reveals) is also caught, via the forge_pr_close_targets union.
+reset_log
+FORGE_CLOSE_TARGETS="123"
+PR_JSON='{"body":"Contributes to #123"}'
+_check_partial_increment_close_conflict 2>/dev/null
+assert_eq "123" "$PARTIAL_CONFLICT_ISSUES" \
+  "closingIssuesReferences-only link (no body keyword) -> conflict recorded"
+
+# T16: the reference target is a PR -> never tracked, never mutated.
+reset_log
+PR_JSON='{"body":"Part of #321"}'
+_check_partial_increment_close_conflict 2>/dev/null
+assert_eq "" "$PARTIAL_OPEN_BEFORE_MERGE" "Partial ref that is a PR (#321) -> not tracked"
+
+# T17: gitea -> guard is a no-op (matches the GitHub-only reset path).
+reset_log
+FORGE_TYPE="gitea"
+PR_JSON='{"body":"Contributes to #123\n\nthen close #123"}'
+_check_partial_increment_close_conflict 2>/dev/null
+assert_eq "" "$PARTIAL_CONFLICT_ISSUES" "FORGE_TYPE=gitea -> conflict guard no-op"
+FORGE_TYPE="github"
+
+# T17b: --dry-run still DETECTS and reports the conflict, but must not phrase it
+# as an accomplished merge (same dry-run contract as
+# _check_no_open_stacked_children: report the would-be outcome, prefixed).
+reset_log
+DRY_RUN=true
+PR_JSON='{"body":"Verify, then close #123.\n\nContributes to #123"}'
+run_capturing_stderr _check_partial_increment_close_conflict
+dryrun_err="$(read_stderr)"
+assert_eq "123" "$PARTIAL_CONFLICT_ISSUES" \
+  "--dry-run still detects the closing-keyword conflict"
+assert_contains "$dryrun_err" "[dry-run] Partial-increment conflict (#4569)" \
+  "--dry-run prefixes the conflict warning"
+assert_contains "$dryrun_err" "would reopen #123" \
+  "--dry-run phrases the reopen as conditional, not as an accomplished action"
+assert_not_contains "$dryrun_err" "will reopen #123" \
+  "--dry-run does not claim a reopen will happen"
+DRY_RUN=false
+
+echo ""
+echo "Testing the post-merge premature-close revert..."
+
+# T18: conflicted + closed after the merge -> reopen, comment, THEN the normal
+# label swap (the issue re-enters the ready queue in the same pass).
+reset_log
+PARTIAL_OPEN_BEFORE_MERGE="777"
+PARTIAL_CONFLICT_ISSUES="777"
+PR_JSON='{"body":"Verify, then close #777.\n\nContributes to #777"}'
+run_capturing_stderr _reset_partial_increment_labels
+revert_err="$(read_stderr)"
+log="$(read_log)"
+assert_contains "$log" "issue reopen 777 --repo owner/repo" \
+  "Conflicted + auto-closed #777 -> reopened (repo-scoped)"
+assert_contains "$log" "issue edit 777 --repo owner/repo --remove-label loom:building --add-label loom:issue" \
+  "Reopened #777 falls through to the normal loom:building -> loom:issue swap"
+assert_contains "$log" "issue comment 777 --repo owner/repo" \
+  "Reopened #777 -> posts an auditable comment"
+assert_contains "$revert_err" "was auto-closed by PR #999's merge" \
+  "Reopen path warns with the attribution"
+
+# T19: EDGE CASE — open before the merge, closed after it, but NO closing
+# reference on this PR (e.g. a human closed it deliberately in the same window):
+# warn loudly, but do NOT reopen.
+reset_log
+PARTIAL_OPEN_BEFORE_MERGE="777"
+PARTIAL_CONFLICT_ISSUES=""
+PR_JSON='{"body":"Contributes to #777"}'
+run_capturing_stderr _reset_partial_increment_labels
+edge_err="$(read_stderr)"
+assert_eq "" "$(read_log)" \
+  "Deliberate close in the merge window (no closing reference) -> no reopen, no label mutation"
+assert_contains "$edge_err" "NOT reopening automatically" \
+  "Deliberate-close case still warns so the coincidence is investigable"
+
+# T20: closed BEFORE the merge and untracked -> byte-for-byte the pre-#4569
+# skip (already asserted by T3; re-asserted here with the globals in play).
+reset_log
+PR_JSON='{"body":"Part of #777"}'
+_reset_partial_increment_labels 2>/dev/null
+assert_eq "" "$(read_log)" \
+  "Untracked closed #777 -> unchanged log-and-skip behavior"
+
 # --- Source-contains guards (fail if a refactor drops the key behavior) ---
 echo ""
 echo "Testing merge-pr.sh source guards..."
@@ -267,6 +465,12 @@ assert_contains "$src" "--add-label \"loom:issue\"" \
   "merge-pr.sh restores loom:issue"
 assert_contains "$src" "--repo \"\$REPO_NWO\"" \
   "merge-pr.sh scopes the partial-increment mutations to REPO_NWO"
+assert_contains "$src" "_check_partial_increment_close_conflict || true" \
+  "merge-pr.sh invokes the #4569 conflict guard BEFORE either merge path"
+assert_contains "$src" 'gh issue reopen "$issue_num"' \
+  "merge-pr.sh reverts a premature auto-close with gh issue reopen"
+assert_contains "$src" 'close[sd]?|fix(e[sd])?|resolve[sd]?' \
+  "merge-pr.sh matches the canonical GitHub closing-keyword set"
 
 # --- Summary ---
 echo ""


### PR DESCRIPTION
## Summary

A partial-increment PR that deliberately declared `Contributes to #2` still auto-closed its tracked issue on squash-merge (rjwalters/censusapi#5 → censusapi issue 2), silently defeating the #3599 non-closing convention.

**Root cause established — and it is NOT the `feature/issue-N` branch-name auto-link the report suspected.** Evidence gathered from the live incident:

| Hypothesis | Verdict | Evidence |
|---|---|---|
| Branch-name Development-sidebar auto-link | **Ruled out** | The issue's timeline has **no `connected` event**. Loom's `feature/issue-N` convention does not create a sidebar link. |
| Closing keyword in the squash commit message | **Ruled out** | The squash commit carried only `Contributes to #2`. |
| Closing keyword elsewhere in the **PR body** | **CONFIRMED** | The PR's "Operator follow-up (after merge)" section read `3. Verify ..., then close #<the issue>.` — and `closingIssuesReferences` on that PR does list the issue. The `closed` event has `commit_id: null` with the merger as actor, the signature of a body-reference close. |

So: **GitHub's closing-reference parser scans the entire PR body** and honors any closing keyword immediately followed by the reference — mid-sentence, inside a numbered list, in a handoff checklist. `Part of #N` / `Contributes to #N` is *not* a shield; GitHub does not weigh the two references against each other. One adjacent closing keyword anywhere wins.

Because prevention at merge time would mean mutating a body the Judge already reviewed, this implements **detect (pre-merge) + self-heal (post-merge)**, and pushes the durable fix into the authoring/review docs.

## Changes

`defaults/scripts/merge-pr.sh`

- **`_check_partial_increment_close_conflict()`** — new pre-merge guard, invoked before either merge path (so `--dry-run` reports it without merging). For each `Part of`/`Contributes to` reference it warns when the *same PR* also carries a closing reference to that issue, quoting the offending phrase and the exact remedy. Close targets are the **union** of a quota-free body regex and the existing `forge_pr_close_targets()` helper — the body regex is load-bearing because the incident occurred while **GraphQL quota was exhausted**, precisely when the authoritative `closingIssuesReferences` field returns nothing. The GraphQL side still contributes links no body text reveals.
- Publishes two globals, `PARTIAL_OPEN_BEFORE_MERGE` and `PARTIAL_CONFLICT_ISSUES`, so the post-merge pass can **attribute** a close to this merge rather than guessing.
- **`_reset_one_partial_issue()`** — the branch that previously only logged `issue #N is not open (state='closed') — skipping` (the exact symptom line in the report) now reopens the issue when it was open pre-merge, is closed post-merge, **and** a closing reference was attributed to this PR; it then falls through to the existing `loom:building` → `loom:issue` swap unchanged, so the issue re-enters the ready queue in the same pass. It also posts an audit comment explaining the mechanism.
- **Deliberate closes are never reverted**: an issue closed inside the merge window with *no* attributable closing reference is warned about loudly but left closed.
- `_partial_increment_refs()` is now shared by both passes, so the pre- and post-merge views can never disagree about which issues are partial increments.
- Gated on `FORGE_TYPE == "github"` (matching the existing reset path) and best-effort throughout — it never fails a merge.

Docs (the durable fix — the backstop leaves a close/reopen flicker plus notification churn):

- `defaults/.claude/commands/loom/builder-pr.md` — corrects the standing claim that closing keywords only work "at the start of a line", and adds a section showing the real failure with the concrete remedy: an intervening word breaks the link (`close the issue` / `close issue #<N>`), repositioning the phrase does not.
- `defaults/.claude/commands/loom/judge.md` — adds a stray-closing-keyword check to the partial-increment review path, classified as a minor description fix the Judge makes directly (no Builder round-trip).

## Acceptance Criteria Verification

- [x] **Reproduce: does a `feature/issue-N` head branch cause the auto-close?** Answered — **no.** Ruled out via the absent `connected` timeline event (table above). The real mechanism was found and confirmed instead, so no fix is aimed at branch naming.
- [x] **`merge-pr.sh` / `builder-pr.md` defends the partial-increment convention.** All three shapes the issue offered are covered: pre-merge check of close targets (warn), post-merge detect-and-reopen, and authoring/review guidance.
- [x] **Document the finding in the partial-increment convention docs either way.** Done in `builder-pr.md` (authoring) and `judge.md` (review), both recording that branch naming was *not* the cause.

## Test Plan

- [x] `defaults/scripts/tests/test-merge-pr-partial-increment.sh` — **52/52 passed** (was 24; +28 new assertions). All pre-existing cases still pass unchanged.
  - Keyword extraction: prose-embedded keywords detected; `Contributes to` not treated as closing; word-boundary guard (`Discloses`/`Updates`); `close issue #<N>` correctly *not* a closing reference; no `#123`/`#1234` prefix confusion.
  - Pre-merge guard: the exact incident shape (deliberate trailer + "then close" in an operator checklist, GraphQL unavailable) is detected and warned about; clean bodies produce no conflict; a closing keyword aimed at a *different* issue is not a conflict; a GraphQL-only link with no body keyword is still caught; PR-valued and already-closed references are never tracked; `FORGE_TYPE=gitea` is a no-op.
  - Post-merge: conflicted + auto-closed → reopen, comment, then the normal label swap. **Edge case — deliberate close in the merge window → warns, does NOT reopen, no label mutation.** Untracked pre-closed issue → byte-for-byte the old skip.
  - `--dry-run` still detects and reports, prefixed `[dry-run]` and phrased conditionally (matches `_check_no_open_stacked_children`'s dry-run contract).
  - Source-contains guards fail loudly if a future refactor drops the guard invocation, the reopen, or the keyword set.
- [x] `shellcheck --severity=warning --format=gcc` (the CI invocation) — clean on both changed shell files.
- [x] `bash -n` — clean on both changed shell files.
- [x] `bash scripts/check-claude-md-budget.sh` — OK (315/320 lines; unchanged by this PR).
- [x] `cargo test --lib --bins` via the build gate — passed.
- [x] **Dogfooded**: scanned this PR's own body and squash commit message with the grep the new docs prescribe. It caught a real `close #<N>` adjacent reference in my first commit message that would have closed an unrelated issue in this repo — amended before pushing. The guard's premise verified itself.

### Pre-existing failures (not caused by this PR)

- `defaults/scripts/tests/test-loom-dispatcher.sh` — 3 failures (`node/npm not on PATH`, codex runtime resolution). Verified identical on a clean tree with my diff stashed.
- Build gate stage `loom-tools pytest` — `uv: command not found` on this host. This PR touches no Python.

Closes #4569
