### PR TITLE
fix: give install-metadata.json a merge=ours driver to stop cross-host resync conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# BEGIN LOOM-MANAGED (merge drivers, #4528)
+# install-metadata.json is a machine-local install stamp (loom_version,
+# loom_commit, last_resync, loom_source) that every host's resync re-writes --
+# always keep our side on a merge conflict; the file is fully re-derived by
+# the next resync regardless of which side "wins". A `merge=ours` attribute
+# alone is inert: the `ours` driver must also be enabled in local (never
+# committed) git config -- `git config merge.ours.driver true` -- which Loom's
+# install and resync scripts set automatically (see #4528).
+.loom/install-metadata.json merge=ours
+# END LOOM-MANAGED (merge drivers, #4528)

--- a/defaults/docs/troubleshooting.md
+++ b/defaults/docs/troubleshooting.md
@@ -644,7 +644,13 @@ This is a **detect → fix** pair:
   those are reported `skipped`, never overwritten). Loom-internal files declared in
   `defaults/.loom-internal.list` are skipped (never resurrected into a consumer).
   On a successful non-dry-run it also re-stamps `loom_version`, `loom_commit`, and
-  a new `last_resync` date into `.loom/install-metadata.json`. One guard exception
+  a new `last_resync` date into `.loom/install-metadata.json`. Since that file is a
+  machine-local stamp every host's resync rewrites, resync also ensures (every
+  run, self-healing existing installs) a `merge=ours` attribute for it in a
+  Loom-managed `.gitattributes` block plus the required local (never committed)
+  `git config merge.ours.driver true` — so two hosts that each committed a resync
+  no longer conflict on `git merge`/`git pull`; the file is fully re-derived by the
+  next resync regardless of which side "wins" (#4528). One guard exception
   (#4041): the vendored generic guard `hooks/guard-destructive-generic.sh` is
   **not** resynced (and any stale copy is removed) in a repo where the canonical
   Repo Skills guard (`.claude/skills/repo/hooks/guard-destructive.sh`, carrying the

--- a/defaults/scripts/resync-installed.sh
+++ b/defaults/scripts/resync-installed.sh
@@ -37,6 +37,11 @@
 # On a successful non-dry-run it also re-stamps loom_version, loom_commit, and a
 # last_resync date into .loom/install-metadata.json (requires jq or python3;
 # skipped with a warning if neither is present — the file sync still succeeds).
+# It also ensures a `merge=ours` driver is wired up for that same file (#4528)
+# — a machine-local stamp every host re-writes, guaranteeing merge conflicts
+# between hosts otherwise — via a Loom-managed .gitattributes block plus local
+# git config (never committed; runs every time so a pre-#4528 install
+# self-heals on its next resync).
 #
 # It also refreshes the marker-delimited Loom-managed `.gitignore` block via the
 # daemon's `update-gitignore` subcommand (#4280) — the ephemeral-pattern list is
@@ -558,6 +563,73 @@ fi
 # `update-gitignore` subcommand rather than duplicating the list in shell. A
 # missing/too-old binary is a LOUD stderr warning, never a silent skip.
 
+# ---------- ensure the install-metadata.json merge=ours driver (#4528) ----------
+#
+# .loom/install-metadata.json is a machine-local install stamp: every host's
+# resync (the restamp_metadata step above) re-writes loom_version,
+# loom_commit, and last_resync (plus loom_source, an absolute host-specific
+# path) on every run. Because the file must stay tracked (it is the
+# authoritative ownership manifest consumed by verify-install.sh and
+# uninstall-loom.sh — see is_untracked_runtime_file() in verify-install.sh,
+# which already treats its exact byte content as non-checksum-tracked
+# runtime state), any two hosts that each commit a resync and then
+# `git merge`/`git pull` the other's commit collide on this file, every
+# time, on the exact same lines.
+#
+# The fix: a `merge=ours` attribute for the path in a Loom-managed marker
+# block in .gitattributes (committed, shared) plus the `ours` driver enabled
+# in LOCAL (never committed) git config -- `git config merge.ours.driver
+# true` -- which git-attributes(5) requires a `merge=ours` attribute to be
+# paired with. This is safe because the file is fully re-derived by the
+# next resync regardless of which side "wins" a given merge conflict.
+#
+# Runs on every resync (including a fresh, non-dry-run first run on an
+# existing install predating this fix) so existing hosts self-heal the
+# first time they resync after upgrading past #4528, with no separate
+# migration step required.
+
+ensure_install_metadata_merge_driver() {
+    local ga="$REPO_ROOT/.gitattributes"
+    local begin="# BEGIN LOOM-MANAGED (merge drivers, #4528)"
+    local end="# END LOOM-MANAGED (merge drivers, #4528)"
+    local rule=".loom/install-metadata.json merge=ours"
+    local changed=0
+
+    if [[ ! -f "$ga" ]] || ! grep -qF "$rule" "$ga" 2>/dev/null; then
+        if [[ "$DRY_RUN" -eq 1 ]]; then
+            note "  ${BOLD}would add${NC} .loom/install-metadata.json merge=ours rule to .gitattributes"
+        else
+            {
+                [[ -s "$ga" ]] && printf '\n'
+                printf '%s\n' "$begin"
+                printf '%s\n' "# install-metadata.json is a machine-local install stamp (loom_version,"
+                printf '%s\n' "# loom_commit, last_resync, loom_source) that every host's resync"
+                printf '%s\n' "# re-writes -- always keep our side on a merge conflict; the file is"
+                printf '%s\n' "# fully re-derived by the next resync regardless of which side \"wins\"."
+                printf '%s\n' "$rule"
+                printf '%s\n' "$end"
+            } >> "$ga"
+            changed=1
+        fi
+    fi
+
+    local current
+    current="$(git -C "$REPO_ROOT" config --get merge.ours.driver 2>/dev/null || true)"
+    if [[ "$current" != "true" ]]; then
+        if [[ "$DRY_RUN" -eq 1 ]]; then
+            note "  ${BOLD}would set${NC} local git config merge.ours.driver=true"
+        else
+            git -C "$REPO_ROOT" config merge.ours.driver true 2>/dev/null || true
+            changed=1
+        fi
+    fi
+
+    if [[ "$changed" -eq 1 ]]; then
+        note "  ${GREEN}configured${NC} install-metadata.json merge=ours driver (.gitattributes + local git config)"
+    fi
+}
+ensure_install_metadata_merge_driver
+
 refresh_gitignore_block() {
     local locate_lib bin
     locate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/locate-daemon-bin.sh"
@@ -650,7 +722,7 @@ suggest_commit_if_resync_only_dirt() {
         path="${path%\"}"
         path="${path#\"}"
         case "$path" in
-            .loom/hooks/*|.loom/scripts/*|.loom/roles/*|.loom/docs/*|.loom/bin/*|.claude/commands/loom/*|.loom/install-metadata.json)
+            .loom/hooks/*|.loom/scripts/*|.loom/roles/*|.loom/docs/*|.loom/bin/*|.claude/commands/loom/*|.loom/install-metadata.json|.gitattributes)
                 resync_paths+=("$path")
                 ;;
             *)

--- a/defaults/scripts/tests/test-resync-installed.sh
+++ b/defaults/scripts/tests/test-resync-installed.sh
@@ -374,6 +374,68 @@ else
     fail "(n) --dry-run re-stamped metadata (should be preview-only)"
 fi
 
+# --- (#4528) install-metadata.json merge=ours driver wiring -----------------
+echo "Test group 12g: resync wires the install-metadata.json merge=ours driver (#4528)"
+REPO="$(make_fixture)"
+(cd "$REPO" && bash "$SCRIPT" >/dev/null 2>&1)
+GA="$REPO/.gitattributes"
+if [[ -f "$GA" ]] && grep -qxF ".loom/install-metadata.json merge=ours" "$GA"; then
+    pass "(q) .gitattributes gets the install-metadata.json merge=ours rule"
+else
+    fail "(q) .gitattributes missing the merge=ours rule"
+fi
+if [[ "$(git -C "$REPO" config --get merge.ours.driver 2>/dev/null)" == "true" ]]; then
+    pass "(q) local git config merge.ours.driver=true is set"
+else
+    fail "(q) local git config merge.ours.driver was not set"
+fi
+# Idempotent rerun: no duplicate marker block.
+(cd "$REPO" && bash "$SCRIPT" >/dev/null 2>&1)
+OCCURRENCES="$(grep -cxF ".loom/install-metadata.json merge=ours" "$GA")"
+if [[ "$OCCURRENCES" -eq 1 ]]; then
+    pass "(q) rerun does not duplicate the .gitattributes rule"
+else
+    fail "(q) rerun duplicated the .gitattributes rule (found $OCCURRENCES occurrences)"
+fi
+# --dry-run must NOT write .gitattributes or local git config.
+REPO="$(make_fixture)"
+(cd "$REPO" && bash "$SCRIPT" --dry-run >/dev/null 2>&1)
+if [[ ! -f "$REPO/.gitattributes" ]]; then
+    pass "(q) --dry-run leaves .gitattributes absent (preview-only)"
+else
+    fail "(q) --dry-run wrote .gitattributes (should be preview-only)"
+fi
+if [[ -z "$(git -C "$REPO" config --get merge.ours.driver 2>/dev/null)" ]]; then
+    pass "(q) --dry-run leaves merge.ours.driver unset (preview-only)"
+else
+    fail "(q) --dry-run set merge.ours.driver (should be preview-only)"
+fi
+# End-to-end: a real merge conflict on install-metadata.json between two
+# divergent branches resolves automatically to "ours" once the driver+
+# attribute are wired up, instead of stopping for manual resolution.
+MERGE_REPO="$(make_fixture)"
+(cd "$MERGE_REPO" && bash "$SCRIPT" >/dev/null 2>&1)
+git -C "$MERGE_REPO" add -A >/dev/null 2>&1
+git -C "$MERGE_REPO" commit -qm "wire merge driver" >/dev/null 2>&1
+MERGE_REPO_DEFAULT_BRANCH="$(git -C "$MERGE_REPO" symbolic-ref --short HEAD)"
+git -C "$MERGE_REPO" checkout -qb host-a >/dev/null 2>&1
+printf '{\n  "loom_version": "1.1.1",\n  "loom_commit": "aaa1111",\n  "install_date": "2020-01-01",\n  "loom_source": "%s",\n  "installed_files": []\n}\n' \
+    "$MERGE_REPO" > "$MERGE_REPO/.loom/install-metadata.json"
+git -C "$MERGE_REPO" commit -qam "host-a resync stamp" >/dev/null 2>&1
+git -C "$MERGE_REPO" checkout -q "$MERGE_REPO_DEFAULT_BRANCH" >/dev/null 2>&1
+printf '{\n  "loom_version": "2.2.2",\n  "loom_commit": "bbb2222",\n  "install_date": "2020-01-01",\n  "loom_source": "%s",\n  "installed_files": []\n}\n' \
+    "$MERGE_REPO" > "$MERGE_REPO/.loom/install-metadata.json"
+git -C "$MERGE_REPO" commit -qam "host-b resync stamp" >/dev/null 2>&1
+if git -C "$MERGE_REPO" merge -q host-a >/dev/null 2>&1; then
+    if grep -q '"loom_version": *"2.2.2"' "$MERGE_REPO/.loom/install-metadata.json"; then
+        pass "(q) two hosts' resync stamps merge cleanly, keeping the local (ours) side"
+    else
+        fail "(q) merge succeeded but did not keep the local side's stamp"
+    fi
+else
+    fail "(q) merge of two divergent resync stamps still conflicts"
+fi
+
 # --- (#4280) .gitignore managed-block refresh + audit ------------------------
 echo "Test group 12b: resync refreshes the Loom-managed .gitignore block (#4280)"
 # Resolve a loom-daemon binary that supports `update-gitignore` (this feature).

--- a/install.sh
+++ b/install.sh
@@ -289,6 +289,17 @@ finalize_quick_install() {
 METADATA
   success "Recorded installation metadata"
 
+  # 3b. Wire the install-metadata.json merge=ours driver (#4528) so this
+  # host's resync commits stop conflicting with other hosts' on `git merge`.
+  if [[ -f "$loom_root/scripts/install/gitattributes.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "$loom_root/scripts/install/gitattributes.sh"
+    ensure_install_metadata_merge_driver "$target"
+    success "Configured install-metadata.json merge=ours driver (.gitattributes + local git config)"
+  else
+    warning "gitattributes.sh not found — install-metadata.json merge=ours driver not configured"
+  fi
+
   # Quick Install ships .github/labels.yml but does NOT create the labels on
   # the forge (that is a Full Install step). Point the operator at the shipped
   # sync script so the label-based workflow doesn't break on first use (#3582).

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -222,6 +222,11 @@ source "$LOOM_ROOT/scripts/install/provision-hooks.sh"
 # shellcheck source=scripts/install/dogfood-commands.sh
 source "$LOOM_ROOT/scripts/install/dogfood-commands.sh"
 
+# install-metadata.json merge=ours wiring (#4528) — extracted so the test
+# suite can exercise it without running the full installer.
+# shellcheck source=scripts/install/gitattributes.sh
+source "$LOOM_ROOT/scripts/install/gitattributes.sh"
+
 # Check the state of the Loom *source* checkout (the directory that contains
 # this script). We refuse to install from a feature branch, a stale main, or
 # an arbitrary detached HEAD unless the operator explicitly opts in. Detached
@@ -1561,6 +1566,12 @@ cat > .loom/install-metadata.json <<METADATA
 }
 METADATA
 success "Installation metadata recorded ($(echo "$INSTALLED_FILES_JSON" | grep -o '"' | wc -l | awk '{print $1/2}') files tracked)"
+echo ""
+
+# Wire the install-metadata.json merge=ours driver (#4528) so this host's
+# resync commits stop conflicting with other hosts' on `git merge`.
+ensure_install_metadata_merge_driver "$TARGET_PATH"
+success "Configured install-metadata.json merge=ours driver (.gitattributes + local git config)"
 echo ""
 
 # Reconcile install-metadata.json against on-disk state.

--- a/scripts/install/gitattributes.sh
+++ b/scripts/install/gitattributes.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# scripts/install/gitattributes.sh — install-metadata.json merge=ours wiring (#4528)
+#
+# `.loom/install-metadata.json` is a machine-local install stamp: every
+# host's `resync-installed.sh` re-writes loom_version, loom_commit, and
+# last_resync (plus loom_source, an absolute host-specific path) on every
+# run. Because the file is COMMITTED (it must stay tracked — it is the
+# authoritative ownership manifest consumed by verify-install.sh and
+# uninstall-loom.sh), any two hosts that each commit a resync and then
+# `git merge`/`git pull` the other's commit collide on this file, every
+# time, on the exact same lines.
+#
+# The fix: a `merge=ours` attribute for the path, so a real conflict on this
+# file always resolves to "keep our side" instead of stopping for manual
+# resolution. This is safe specifically BECAUSE the file is fully re-derived
+# by the next resync regardless of which side "wins" a given merge — nothing
+# is permanently lost, only a stamp gets refreshed a cycle later than it
+# otherwise would have.
+#
+# A `merge=ours` attribute alone does nothing: git-attributes(5) requires the
+# `ours` driver to be defined in LOCAL (never committed) git config —
+# `git config merge.ours.driver true`. `.gitattributes` is committed and
+# shared; the driver config is not, so every write site below (fresh
+# install, quick install, and resync) sets it, which also self-heals any
+# existing install the first time one of those paths next runs.
+#
+# Source this file with:
+#     source "$LOOM_ROOT/scripts/install/gitattributes.sh"
+# then call:
+#     ensure_install_metadata_merge_driver "$TARGET_PATH"
+
+_GITATTRS_MERGE_BEGIN="# BEGIN LOOM-MANAGED (merge drivers, #4528)"
+_GITATTRS_MERGE_END="# END LOOM-MANAGED (merge drivers, #4528)"
+_GITATTRS_MERGE_RULE=".loom/install-metadata.json merge=ours"
+
+ensure_install_metadata_merge_driver() {
+  local target="$1"
+  local ga="$target/.gitattributes"
+
+  if [[ ! -f "$ga" ]] || ! grep -qF "$_GITATTRS_MERGE_RULE" "$ga" 2>/dev/null; then
+    {
+      [[ -s "$ga" ]] && printf '\n'
+      printf '%s\n' "$_GITATTRS_MERGE_BEGIN"
+      printf '%s\n' "# install-metadata.json is a machine-local install stamp (loom_version,"
+      printf '%s\n' "# loom_commit, last_resync, loom_source) that every host's resync"
+      printf '%s\n' "# re-writes -- always keep our side on a merge conflict; the file is"
+      printf '%s\n' "# fully re-derived by the next resync regardless of which side \"wins\"."
+      printf '%s\n' "$_GITATTRS_MERGE_RULE"
+      printf '%s\n' "$_GITATTRS_MERGE_END"
+    } >> "$ga"
+  fi
+
+  # Idempotent: only write local git config when not already set.
+  local current
+  current="$(git -C "$target" config --get merge.ours.driver 2>/dev/null || true)"
+  if [[ "$current" != "true" ]]; then
+    git -C "$target" config merge.ours.driver true 2>/dev/null || true
+  fi
+}

--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -1261,6 +1261,38 @@ if [[ -f "$WORKTREE_ABS/.gitignore" ]]; then
   fi
 fi
 
+# Handle .gitattributes - remove the Loom-managed merge-driver block (#4528)
+#
+# Written by scripts/install/gitattributes.sh (full/quick install) and
+# defaults/scripts/resync-installed.sh (self-heal on existing installs) to
+# give .loom/install-metadata.json a `merge=ours` attribute. Marker-delimited
+# the same way as the CLAUDE.md / .gitignore blocks above — delete BEGIN..END
+# inclusive in one pass, leaving any other .gitattributes content untouched.
+if [[ -f "$WORKTREE_ABS/.gitattributes" ]]; then
+  GITATTRS="$WORKTREE_ABS/.gitattributes"
+  GITATTRS_BEGIN_MARKER="# BEGIN LOOM-MANAGED (merge drivers, #4528)"
+  GITATTRS_END_MARKER="# END LOOM-MANAGED (merge drivers, #4528)"
+
+  if grep -qxF "$GITATTRS_BEGIN_MARKER" "$GITATTRS" 2>/dev/null && \
+     grep -qxF "$GITATTRS_END_MARKER" "$GITATTRS" 2>/dev/null; then
+    info "Removing Loom-managed merge-driver block from .gitattributes..."
+    awk -v b="$GITATTRS_BEGIN_MARKER" -v e="$GITATTRS_END_MARKER" '
+      $0 == b { inblock = 1; next }
+      inblock { if ($0 == e) inblock = 0; next }
+      { print }
+    ' "$GITATTRS" > "${GITATTRS}.tmp" && mv "${GITATTRS}.tmp" "$GITATTRS"
+
+    if [[ ! -s "$GITATTRS" ]] || ! grep -q '[^[:space:]]' "$GITATTRS" 2>/dev/null; then
+      rm -f "$GITATTRS"
+      REMOVED_LIST+=(".gitattributes")
+      success ".gitattributes removed (was entirely Loom-managed content)"
+    else
+      REMOVED_LIST+=(".gitattributes (Loom-managed block removed)")
+      success ".gitattributes Loom-managed block removed"
+    fi
+  fi
+fi
+
 # Handle .claude/settings.json - remove only Loom hooks and permissions
 if [[ -f "$WORKTREE_ABS/.claude/settings.json" ]]; then
   SETTINGS_FILE="$WORKTREE_ABS/.claude/settings.json"


### PR DESCRIPTION
## Summary

`.loom/install-metadata.json` is a machine-local install stamp — every host's `resync-installed.sh` re-writes `loom_version`, `loom_commit`, and `last_resync` (plus `loom_source`, an absolute host-specific path) on every run. Because the file must stay tracked (it is the authoritative ownership manifest `verify-install.sh` and `uninstall-loom.sh` consume — see `is_untracked_runtime_file()` in `verify-install.sh`, which already treats its exact byte content as non-checksum-tracked runtime state), any two hosts that each commit a resync and then `git merge`/`git pull` the other's collide on this file every time, on the exact same lines. This happened three separate times in one session (2026-07-29/30), always resolved identically with `git checkout --ours`.

## Chosen approach (option a from the issue)

A `.gitattributes` `merge=ours` driver for the path. Rejected alternatives:
- **(b) untrack + gitignore**: contradicted by existing test coverage (`scripts/test-install-quick-gitignore-stash.sh` scenario 9 explicitly asserts the file stays a *tracked modification*, not untracked, after reinstall) and by how heavily `verify-install.sh`/`uninstall-loom.sh` depend on it staying tracked (it's the single source of truth for Loom's ownership boundary).
- **(c) split shared/machine-local halves**: every field except `installed_files` is rewritten by every resync anyway (`loom_version`, `loom_commit`, `last_resync`, `loom_source`), and `installed_files` itself is fully regenerated (not diffed/patched) from the current `defaults/` tree on every resync — so there's no genuinely stable "shared half" left to split out, and a schema change would ripple through the installer, uninstaller, and verify-install's parsing logic for no real benefit over (a).

**(a) is safe specifically because the file is fully re-derived by the next resync regardless of which side "wins" a given merge** — nothing is permanently lost, only a stamp refreshes a cycle later than it otherwise would have.

## Changes

- `.gitattributes` (new, this repo's own self-install): `.loom/install-metadata.json merge=ours` in a Loom-managed marker block.
- `scripts/install/gitattributes.sh` (new): `ensure_install_metadata_merge_driver()` — idempotently writes the marker block to the target's `.gitattributes` and sets local (never committed) `git config merge.ours.driver true`. A `merge=ours` attribute alone is inert without this — git-attributes(5) requires the `ours` driver to be defined in local config.
- Wired into all three write sites so every host self-heals without a separate migration step:
  - `scripts/install-loom.sh` (full install) — sourced + called right after the `install-metadata.json` write.
  - `install.sh` (`finalize_quick_install`) — same, quick-install path.
  - `defaults/scripts/resync-installed.sh` — self-contained equivalent (this file, unlike the two above, ships into every consumer's `.loom/scripts/`), runs on every resync so a pre-#4528 install self-heals the first time it resyncs.
- `scripts/uninstall-loom.sh` — symmetric marker-block removal for `.gitattributes`, mirroring the existing `CLAUDE.md`/`.gitignore` marker-block removal pattern.
- `defaults/docs/troubleshooting.md` — documents the new resync behavior.
- `defaults/scripts/tests/test-resync-installed.sh` — new test group 12g: `.gitattributes` gets the rule, local git config gets set, idempotent rerun doesn't duplicate, `--dry-run` doesn't write either, and an end-to-end scenario constructs two divergent branches each carrying a different resync stamp and confirms `git merge` now resolves automatically (keeping the local side) instead of conflicting.

## Install/uninstall/verify-install impact

- **Install** (full + quick): now also writes the `.gitattributes` block and sets local git config immediately after writing `install-metadata.json`. No schema change to the metadata file itself.
- **Uninstall**: strips the managed block from `.gitattributes` (removes the whole file if it was Loom-managed content only), same pattern as the `.gitignore`/`CLAUDE.md` smart removal.
- **verify-install**: unaffected — `install-metadata.json` was already excluded from checksum tracking (`is_untracked_runtime_file()`), and its schema is unchanged. `.gitattributes` is not added to the checksum-tracked manifest (it's local-git-config-adjacent, not a pure-copy surface).

## Test Plan

- [x] `bash defaults/scripts/tests/test-resync-installed.sh` — 70/70 passed (new group 12g included).
- [x] `bash scripts/test-install-quick-gitignore-stash.sh` — same pass/fail split as unmodified `main` (13 pre-existing failures unrelated to this change, confirmed by running the identical suite against `main`).
- [x] `bash scripts/test-installer.sh` — 175/176 passed; the 1 failure (`test-loom-dispatcher.sh` runtime-dispatch stub assertion) reproduces identically on unmodified `main`, unrelated to this change.
- [x] `bash scripts/test-migrate-consumer.sh` — 38/38 passed.
- [x] `bash defaults/scripts/tests/test-verify-install-scope.sh` — 16/16 passed.
- [x] `bash defaults/scripts/tests/test-install-reinstall-safety.sh` — 8/8 passed (1 skip: missing `node`/`pnpm` in this sandbox, unrelated).
- [x] `shellcheck --severity=warning` over `defaults/scripts/**/*.sh` (the CI-gated surface) — clean.
- [x] `bash -n` syntax check on every modified/new shell file.

## Acceptance Criteria (from #4528)

- [x] Picked and implemented option (a): `.gitattributes` `merge=ours` driver, with the driver enablement scripted (not just documented) at all three write sites.
- [x] Rationale recorded (this PR body + inline comments in `resync-installed.sh`/`gitattributes.sh`), including install/uninstall/verify-install impacts.
- [x] Post-change: two hosts resyncing concurrently no longer conflict on merge — verified by the new end-to-end test in `test-resync-installed.sh` (constructs two divergent resync-stamp commits and confirms `git merge` auto-resolves instead of conflicting).

Closes #4528
