### PR TITLE
test(loom-daemon): serialize fake-gh subprocess tests against PATH mutators

### DIFF
--- a/loom-daemon/src/pipeline_snapshot.rs
+++ b/loom-daemon/src/pipeline_snapshot.rs
@@ -305,6 +305,7 @@ pub fn format_count(count: Option<usize>) -> String {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::sync::Mutex;
 
     // ===================================================================
@@ -465,7 +466,14 @@ mod tests {
         path
     }
 
+    /// `#[serial]` is load-bearing (#4547): concurrent `std::env::set_var`
+    /// (used by `disk_headroom.rs`'s PATH-mutating tests) races any
+    /// concurrently-running thread that reads the process environment,
+    /// including the implicit env read inside every `std::process::Command`
+    /// spawn below — not just subprocesses that literally do a `PATH`
+    /// lookup for their own executable.
     #[test]
+    #[serial]
     fn gh_pipeline_source_counts_each_metric_independently() {
         let tmp = tempfile::tempdir().unwrap();
         let gh = write_fake_gh(
@@ -511,7 +519,11 @@ esac
         assert!(snap.is_complete());
     }
 
+    /// `#[serial]` is load-bearing (#4547): the fake-`gh` script this test
+    /// spawns is a subprocess whose resolution depends on the inherited
+    /// `PATH`, which `disk_headroom.rs`'s tests mutate process-globally.
     #[test]
+    #[serial]
     fn gh_pipeline_source_records_error_but_keeps_other_metrics() {
         let tmp = tempfile::tempdir().unwrap();
         let gh = write_fake_gh(
@@ -544,7 +556,11 @@ esac
         assert_eq!(snap.merged_24h, Some(0));
     }
 
+    /// `#[serial]` is load-bearing (#4547) for the same reason as
+    /// `gh_pipeline_source_counts_each_metric_independently` above — even a
+    /// failed `Command::spawn` attempt reads the process environment.
     #[test]
+    #[serial]
     fn gh_pipeline_source_missing_binary_is_a_contained_failure() {
         let tmp = tempfile::tempdir().unwrap();
         let source = GhPipelineSource::new().with_gh_bin(PathBuf::from("/no/such/gh-binary"));

--- a/loom-daemon/src/quarantine_reconciliation.rs
+++ b/loom-daemon/src/quarantine_reconciliation.rs
@@ -587,14 +587,19 @@ mod tests {
     /// A `loom:blocked` issue carrying the daemon's quarantine comment is
     /// released, and the recorded `gh` argv proves the real label-flip
     /// command ran (not just the in-memory decision).
+    ///
+    /// `#[serial]` is load-bearing (#4547): the fake-`gh` script below spawns
+    /// a subprocess whose `bash` resolution depends on the inherited `PATH`,
+    /// which `disk_headroom.rs`'s tests mutate process-globally.
     #[test]
+    #[serial]
     fn reconcile_workspace_releases_issue_with_quarantine_comment() {
         let dir = tempdir().unwrap();
         let repo_root = dir.path().join("repo");
         std::fs::create_dir_all(&repo_root).unwrap();
         let gh_log = dir.path().join("gh-invocations.log");
         let script = format!(
-            r#"#!/usr/bin/env bash
+            r#"#!/bin/bash
 printf '%s\n' "$*" >> "{log}"
 if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
   echo '[{{"number":99,"comments":[{{"body":"Auto-quarantined by loom-daemon (#3939): insta-crashed 3 times"}}]}}]'
@@ -620,14 +625,18 @@ exit 0
     /// A `loom:blocked` issue with NO daemon quarantine comment (an
     /// operator's manual block) is left untouched — no `gh issue edit` call
     /// is ever made for it.
+    ///
+    /// `#[serial]` is load-bearing (#4547) for the same reason as
+    /// `reconcile_workspace_releases_issue_with_quarantine_comment` above.
     #[test]
+    #[serial]
     fn reconcile_workspace_never_touches_manual_block() {
         let dir = tempdir().unwrap();
         let repo_root = dir.path().join("repo");
         std::fs::create_dir_all(&repo_root).unwrap();
         let gh_log = dir.path().join("gh-invocations.log");
         let script = format!(
-            r#"#!/usr/bin/env bash
+            r#"#!/bin/bash
 printf '%s\n' "$*" >> "{log}"
 if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
   echo '[{{"number":77,"comments":[{{"body":"Blocked manually pending a human decision"}}]}}]'
@@ -652,14 +661,21 @@ exit 0
 
     /// The per-workspace cap is passed through to `gh issue list --limit`, so
     /// an unexpectedly huge backlog cannot turn startup into an API storm.
+    ///
+    /// `#[serial]` is load-bearing (#4547): `std::env::set_var`/`remove_var`
+    /// (used by `disk_headroom.rs`'s PATH-mutating tests) race any
+    /// concurrently-running thread that reads the process environment —
+    /// including the implicit env read inside `std::process::Command`'s
+    /// child-spawn plumbing below, not just literal `PATH` lookups.
     #[test]
+    #[serial]
     fn reconcile_workspace_passes_issue_cap_to_gh_list() {
         let dir = tempdir().unwrap();
         let repo_root = dir.path().join("repo");
         std::fs::create_dir_all(&repo_root).unwrap();
         let gh_log = dir.path().join("gh-invocations.log");
         let script = format!(
-            r#"#!/usr/bin/env bash
+            r#"#!/bin/bash
 printf '%s\n' "$*" >> "{log}"
 echo '[]'
 exit 0
@@ -681,12 +697,16 @@ exit 0
 
     /// A `gh issue list` failure is absorbed (logged, not propagated) so one
     /// repo's forge hiccup never blocks startup.
+    ///
+    /// `#[serial]` is load-bearing (#4547) for the same reason as
+    /// `reconcile_workspace_passes_issue_cap_to_gh_list` above.
     #[test]
+    #[serial]
     fn reconcile_workspace_absorbs_gh_list_failure() {
         let dir = tempdir().unwrap();
         let repo_root = dir.path().join("repo");
         std::fs::create_dir_all(&repo_root).unwrap();
-        let fake_gh = write_fake_gh(dir.path(), "#!/usr/bin/env bash\necho 'boom' >&2\nexit 1\n");
+        let fake_gh = write_fake_gh(dir.path(), "#!/bin/bash\necho 'boom' >&2\nexit 1\n");
 
         let (checked, released) = forge::reconcile_workspace(&fake_gh, &repo_root);
         assert_eq!(checked, 0);


### PR DESCRIPTION
## Summary

`loom-daemon/src/disk_headroom.rs` has two tests
(`test_worktree_root_free_gb_returns_none_on_df_failure`,
`test_disk_headroom_limit_skips_clamp_on_unmeasurable_probe`) that mutate the
process-global `PATH` env var via `std::env::set_var`/restore, guarded by
`#[serial]` (unnamed group). Several fake-`gh` subprocess tests in
`quarantine_reconciliation.rs` and `pipeline_snapshot.rs` were **not** tagged
`#[serial]`, so cargo's default multi-threaded test runner could schedule them
concurrently with the PATH-mutation window, causing intermittent failures.

The failure mode is broader than "stale `PATH` resolves the wrong `bash`":
concurrent `std::env::set_var`/`remove_var` races **any** thread reading the
process environment — including the implicit env read inside every
`std::process::Command` spawn — which is unsound even for subprocesses that
don't do a literal `PATH` lookup for their own executable (they're invoked by
absolute path already). I confirmed this empirically: after tagging only the
two tests named in #4547, a stress run at `--test-threads=16` still flaked in
`gh_pipeline_source_counts_each_metric_independently` (untagged) and even in
the already-`#[serial]` `gh_pipeline_source_records_error_but_keeps_other_metrics`
(collateral corruption from the untagged test racing nearby).

## Changes

- `loom-daemon/src/quarantine_reconciliation.rs`: added `#[serial]` to all
  four fake-`gh`-spawning tests (`reconcile_workspace_releases_issue_with_quarantine_comment`,
  `reconcile_workspace_never_touches_manual_block`,
  `reconcile_workspace_passes_issue_cap_to_gh_list`,
  `reconcile_workspace_absorbs_gh_list_failure`), and replaced every
  `#!/usr/bin/env bash` fixture shebang with the absolute `#!/bin/bash` so
  subprocess resolution no longer depends on inherited `PATH` at all.
- `loom-daemon/src/pipeline_snapshot.rs`: added `use serial_test::serial;` and
  `#[serial]` to all three `GhPipelineSource`-backed subprocess tests
  (`gh_pipeline_source_counts_each_metric_independently`,
  `gh_pipeline_source_records_error_but_keeps_other_metrics`,
  `gh_pipeline_source_missing_binary_is_a_contained_failure`). This file's
  fixture shebang was already `#!/bin/sh` (absolute), so no shebang change
  needed there.

## Why this is still needed (not superseded by #4560)

#4560 (merged) introduced `cargo nextest` process-per-test isolation as the
long-term structural fix for this whole class of env-mutation race, and
closed #4385/#4545. However, `.github/workflows/ci.yml` still runs plain
`cargo test --workspace` (line 69) — the `backend-tests` CI job has not been
switched over to nextest yet (blocked on a `workflow`-scoped credential per
`loom-daemon/src/lib.rs`'s module doc, tracked in #4559). Until that switch
lands, this race is still live in the actual "Rust Unit Tests" CI check, and
`#[serial]` is explicitly documented as load-bearing for the plain-`cargo
test` path.

## Test plan

- [x] `cargo test -p loom-daemon --lib` — 2465 passed, 0 failed
- [x] `cargo fmt --check -p loom-daemon` — clean
- [x] `cargo clippy -p loom-daemon --lib --no-deps` — clean
- [x] Stress test: `cargo test -p loom-daemon --lib -- --test-threads=<8|16|32> quarantine_reconciliation::tests:: pipeline_snapshot::tests:: disk_headroom::tests::`, 40+ iterations at threads=16/32, zero failures (versus reproducible failures before the fix, both at threads=8 and threads=16, in different tests each time)
- [x] `grep -n "usr/bin/env bash" loom-daemon/src/quarantine_reconciliation.rs` — no matches

Closes #4547

🤖 Generated with [Claude Code](https://claude.com/claude-code)
