### PR TITLE
fix(scripts): refuse resync-installed.sh runs from a linked worktree

### DIFF
--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -390,6 +390,27 @@ never to fall back to the other tool for the same target path — that fallback
 is exactly how sweep #4063 escaped and edited live guard hooks in the main
 checkout.
 
+### NEVER run `resync-installed.sh` from your worktree (#4563)
+
+**Do not run `./.loom/scripts/resync-installed.sh` (or any variant of it) while
+working an issue.** It always resolves the installed `.loom/` against the
+**primary** worktree, so running it from `.loom/worktrees/issue-<N>` writes to the
+**main checkout** — not to your worktree. Nothing in your own `git status`
+changes, so the contamination is invisible to you until `check-main-clean.sh`
+quarantines it (that is exactly what happened on 2026-07-30: a wave-2 builder
+resynced from its worktree and wrote four installed paths into `main` mid-sweep).
+
+You never need it: **editing `defaults/` is the whole job.** Propagating those
+edits into the installed `.loom/hooks|scripts|roles|docs|bin/` +
+`.claude/commands/loom/` copies is the periodic `chore: resync installed Loom
+surfaces` commit's job, made from the main checkout **after** your PR merges. Do
+not "helpfully" refresh the installed copies in your PR.
+
+The script now refuses to run from a linked worktree (exit `1`, `--dry-run`
+included). If you see that refusal, the fix is to **stop**, not to re-run with
+`--allow-worktree` — that override exists for a human operator deliberately
+rewriting the main checkout's installed copies, not for a Builder mid-issue.
+
 ### Working with gh CLI from a Worktree
 
 **You do NOT need to `cd` to the main repo to use `gh` or `.loom/scripts/` commands.**

--- a/defaults/docs/troubleshooting.md
+++ b/defaults/docs/troubleshooting.md
@@ -665,9 +665,27 @@ This is a **detect → fix** pair:
 `scripts/setup-mcp.sh`), and the metadata `install_date` + `installed_files`
 fields (installer-owned).
 
+**Run it from the main checkout only (#4563).** The installed `.loom/` is always
+resolved against the **primary** worktree (via `git rev-parse --git-common-dir`),
+so a resync launched from a linked worktree — an issue/PR worktree under
+`.loom/worktrees/` — writes to the **main checkout**, not to the worktree you are
+standing in. That is exactly how a wave-2 Builder contaminated `main` mid-sweep on
+2026-07-30 (four installed paths written into `main` and quarantined by
+`check-main-clean.sh`). The script therefore **refuses to run** (exit `1`,
+including under `--dry-run`) when its own `git rev-parse --show-toplevel` differs
+from the resolved main-checkout root. Landing a `defaults/` change does **not**
+require you to resync: installed-copy propagation is the periodic
+`chore: resync installed Loom surfaces` commit's job, made from the main checkout
+after the change merges. An operator who really does mean "rewrite the main
+checkout's installed copies from this worktree" can pass `--allow-worktree` (or
+export `LOOM_RESYNC_ALLOW_WORKTREE=1`); it then proceeds with a warning naming the
+main-checkout target. Running from the main checkout — including any subdirectory
+of it — is unaffected.
+
 The intended flow is **"freshness warning says you're stale → run resync"**:
 
 ```bash
+cd <main checkout>                              # NOT .loom/worktrees/issue-N (#4563)
 git merge --ff-only origin/main                 # bring defaults/ current
 ./.loom/scripts/resync-installed.sh --dry-run   # preview what would change (exits 2 on drift)
 ./.loom/scripts/resync-installed.sh             # apply

--- a/defaults/scripts/resync-installed.sh
+++ b/defaults/scripts/resync-installed.sh
@@ -76,6 +76,20 @@
 #     residual emission role
 #   install-metadata.json's install_date + installed_files - owned by the installer
 #
+# WORKTREE RESTRICTION (#4563): the installed .loom/ is ALWAYS resolved against
+# the PRIMARY worktree (via `git rev-parse --git-common-dir`), so running this
+# from a linked worktree — an issue/PR worktree under .loom/worktrees/ — writes
+# to the MAIN checkout, not to the worktree you are standing in. A Builder that
+# does so contaminates main mid-sweep (the 2026-07-30 incident: four installed
+# paths written into main from a wave-2 builder's worktree and quarantined by
+# check-main-clean.sh). The script therefore REFUSES to run when its own
+# `--show-toplevel` differs from the resolved main-checkout root, and exits 1.
+# Installed-copy propagation is the periodic resync commit's job: land the
+# defaults/ change, then resync from the main checkout. An operator who really
+# does mean "write the main checkout's installed copies from here" can pass
+# --allow-worktree (or export LOOM_RESYNC_ALLOW_WORKTREE=1). Running from the
+# main checkout itself — including any subdirectory of it — is unaffected.
+#
 # Local-override convention: list a relative path (e.g. `hooks/guard-destructive.sh`,
 # `scripts/foo.sh`, `roles/custom-role.md`, `docs/notes.md`, `bin/loom`,
 # `commands/loom/mine.md`, or `package.json` to pin the #4285 stub version edit)
@@ -87,11 +101,21 @@
 #   ./.loom/scripts/resync-installed.sh            # sync; report what changed
 #   ./.loom/scripts/resync-installed.sh --dry-run  # preview only; make no changes
 #   ./.loom/scripts/resync-installed.sh --quiet    # only report updated/skipped
+#   ./.loom/scripts/resync-installed.sh --allow-worktree
+#                                                  # permit running from a linked
+#                                                  # worktree (still writes the MAIN
+#                                                  # checkout's installed copies)
 #   ./.loom/scripts/resync-installed.sh --help     # show usage
+#
+# Environment:
+#   LOOM_RESYNC_ALLOW_WORKTREE=1  - same as --allow-worktree (for non-interactive
+#                                   callers), matching the LOOM_ALLOW_* override
+#                                   convention used elsewhere in .loom/scripts.
 #
 # Exit codes:
 #   0 - Success. Sync applied (or already in sync); or --dry-run found no drift.
-#   1 - Error (not in a git repo, or the source tree could not be located).
+#   1 - Error (not in a git repo, the source tree could not be located, or
+#       invoked from a linked worktree without --allow-worktree).
 #   2 - --dry-run only: drift detected (one or more files WOULD be updated).
 #       Lets callers (e.g. the #3770 warning) use --dry-run as a cheap check.
 #
@@ -119,6 +143,9 @@ fi
 
 DRY_RUN=0
 QUIET=0
+# #4563: refuse to run from a linked worktree unless explicitly overridden.
+ALLOW_WORKTREE=0
+[[ "${LOOM_RESYNC_ALLOW_WORKTREE:-}" == "1" ]] && ALLOW_WORKTREE=1
 
 err()  { printf '%b\n' "${RED}ERROR: $*${NC}" >&2; }
 warn() { printf '%b\n' "${YELLOW}WARN: $*${NC}" >&2; }
@@ -129,10 +156,17 @@ note() { [[ "$QUIET" -eq 1 ]] || printf '%b\n' "$*"; }
 
 for arg in "$@"; do
     case "$arg" in
-        --dry-run|-n) DRY_RUN=1 ;;
-        --quiet|-q)   QUIET=1 ;;
+        --dry-run|-n)     DRY_RUN=1 ;;
+        --quiet|-q)       QUIET=1 ;;
+        --allow-worktree) ALLOW_WORKTREE=1 ;;
         --help|-h)
-            sed -n '2,69p' "$0" | sed 's/^# \{0,1\}//'
+            # Print the whole leading comment block (line 2 through the last
+            # consecutive `#` line). Derived, not a hard-coded line range — the
+            # previous `sed -n '2,69p'` silently truncated the Usage/Exit-codes
+            # sections as the header grew past it.
+            awk 'NR==1 { next }
+                 /^#/  { sub(/^# ?/, ""); print; next }
+                 { exit }' "$0"
             exit 0
             ;;
         *)
@@ -165,6 +199,51 @@ fi
 if [[ -z "$REPO_ROOT" || ! -d "$REPO_ROOT/.loom" ]]; then
     err "Could not resolve the installed repo root (no .loom/ found)."
     exit 1
+fi
+
+# ---------- refuse to run from a linked worktree (#4563) ----------
+#
+# The resolution above is the whole point of the refusal: from an issue/PR
+# worktree it hands back the MAIN checkout, so every write below lands in main
+# rather than in the worktree the caller is standing in. That is a
+# worktree-isolation escape a Builder cannot see (nothing in its own `git
+# status` changes) — it surfaces only as contamination of main.
+#
+# Detection is generic: compare this invocation's own worktree top against the
+# resolved main-checkout root. No path pattern is hard-coded, so a repo that
+# relocates its worktree root (worktree.root / lib/worktree-root.sh) is covered
+# too. Both sides are normalized to physical absolute paths first, because
+# `git rev-parse --git-common-dir` returns a RELATIVE path (e.g. "../../.git")
+# from a subdirectory of the main checkout — a raw string compare there would
+# refuse a perfectly legitimate run.
+
+abs_path() {
+    local p="$1"
+    [[ -d "$p" ]] || { printf '%s' "$p"; return 0; }
+    (cd "$p" 2>/dev/null && pwd -P) || printf '%s' "$p"
+}
+
+WORKTREE_TOP="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -n "$WORKTREE_TOP" && "$(abs_path "$WORKTREE_TOP")" != "$(abs_path "$REPO_ROOT")" ]]; then
+    if [[ "$ALLOW_WORKTREE" -eq 1 ]]; then
+        warn "Running from a linked worktree ($WORKTREE_TOP) — writes target the MAIN checkout at $REPO_ROOT (--allow-worktree)."
+    else
+        err "Refusing to run: invoked from a linked git worktree."
+        err "  this worktree : $WORKTREE_TOP"
+        err "  would write to: $REPO_ROOT  (the MAIN checkout — NOT this worktree)"
+        printf '\n' >&2
+        err "The installed .loom/ surfaces are always resolved against the primary"
+        err "worktree, so a resync from here silently modifies the main checkout and"
+        err "contaminates it mid-sweep (#4563)."
+        printf '\n' >&2
+        err "Installed-copy propagation is the periodic resync commit's job: commit your"
+        err "defaults/ change, get it merged, then run this from the main checkout:"
+        err "  cd $REPO_ROOT && ./.loom/scripts/resync-installed.sh"
+        printf '\n' >&2
+        err "If you genuinely intend to rewrite the MAIN checkout's installed copies from"
+        err "here, re-run with --allow-worktree (or LOOM_RESYNC_ALLOW_WORKTREE=1)."
+        exit 1
+    fi
 fi
 
 # ---------- resolve the defaults/ source tree ----------

--- a/defaults/scripts/tests/test-resync-installed.sh
+++ b/defaults/scripts/tests/test-resync-installed.sh
@@ -21,8 +21,12 @@
 # Canonical-guard-defer (#4041, #4403):
 #   (o) canonical guard + git-TRACKED vendored guard -> preserved, WARN, tree clean
 #   (p) canonical guard + UNTRACKED vendored guard   -> removed (unchanged behavior)
+# Worktree-isolation refusal (#4563):
+#   (q) invoked from a linked worktree -> non-zero exit, NOTHING written to main
+#   (r) --allow-worktree / LOOM_RESYNC_ALLOW_WORKTREE=1 -> permitted (warns)
+#   (s) main checkout (incl. a subdirectory of it)      -> unaffected, exit 0
 # Plus contract checks:
-#   - --help prints usage, exit 0
+#   - --help prints usage (documenting --allow-worktree), exit 0
 #   - unknown arg exits 1
 #   - not-a-git-repo exits 1
 #
@@ -661,6 +665,108 @@ else
     fail "(#4403) removal not reported"
 fi
 
+# --- (#4563) refuse to run from a linked worktree ----------------------------
+#
+# The installed .loom/ is always resolved against the PRIMARY worktree, so a run
+# from a linked (issue/PR) worktree writes to the MAIN checkout — the 2026-07-30
+# contamination incident. Assert the refusal, that it wrote NOTHING to main, and
+# that the explicit overrides still permit the write.
+echo "Test group 16: linked-worktree invocation is refused (#4563)"
+REPO="$(make_fixture)"
+LINKED_WT="$WORKDIR/linked-wt"
+rm -rf "$LINKED_WT"
+if ! git -C "$REPO" worktree add -q -b wt-4563 "$LINKED_WT" >/dev/null 2>&1; then
+    skip "(#4563) git worktree add unavailable in this environment"
+else
+    RC=0; OUT="$(cd "$LINKED_WT" && bash "$SCRIPT" 2>&1)" || RC=$?
+    if [[ $RC -ne 0 ]]; then
+        pass "(#4563) run from a linked worktree exits non-zero (got $RC)"
+    else
+        fail "(#4563) run from a linked worktree did NOT refuse (exit 0)"
+    fi
+    if grep -qi "worktree" <<<"$OUT"; then
+        pass "(#4563) refusal explains the worktree context"
+    else
+        fail "(#4563) refusal message does not mention the worktree"
+    fi
+    if grep -q -- "--allow-worktree" <<<"$OUT"; then
+        pass "(#4563) refusal names the --allow-worktree override"
+    else
+        fail "(#4563) refusal does not name the override flag"
+    fi
+    # (b) NOTHING written under the main checkout's .loom/
+    if [[ "$(cat "$REPO/.loom/hooks/guard.sh")" == "OLD" ]]; then
+        pass "(#4563) main checkout's drifted hooks/guard.sh left UNCHANGED"
+    else
+        fail "(#4563) main checkout's hooks/guard.sh was written from the worktree"
+    fi
+    if [[ ! -f "$REPO/.loom/scripts/lib/bar.sh" ]]; then
+        pass "(#4563) main checkout's missing scripts/lib/bar.sh NOT created"
+    else
+        fail "(#4563) a file was created under the main checkout's .loom/"
+    fi
+    if grep -q '"loom_version": "0.0.0"' "$REPO/.loom/install-metadata.json"; then
+        pass "(#4563) main checkout's install-metadata.json NOT re-stamped"
+    else
+        fail "(#4563) main checkout's install-metadata.json was re-stamped"
+    fi
+    # --dry-run is refused too: it reports on the MAIN checkout, not this worktree.
+    RC=0; (cd "$LINKED_WT" && bash "$SCRIPT" --dry-run >/dev/null 2>&1) || RC=$?
+    if [[ $RC -eq 1 ]]; then
+        pass "(#4563) --dry-run from a linked worktree is also refused (exit 1)"
+    else
+        fail "(#4563) --dry-run from a linked worktree was not refused (got $RC)"
+    fi
+
+    # (c) the override permits the write (still targeting the MAIN checkout).
+    RC=0; OUT="$(cd "$LINKED_WT" && bash "$SCRIPT" --allow-worktree 2>&1)" || RC=$?
+    if [[ $RC -eq 0 ]]; then
+        pass "(#4563) --allow-worktree permits the run (exit 0)"
+    else
+        fail "(#4563) --allow-worktree did not permit the run (got $RC)"
+    fi
+    if [[ "$(cat "$REPO/.loom/hooks/guard.sh")" == "A" ]]; then
+        pass "(#4563) --allow-worktree wrote the main checkout's installed copy"
+    else
+        fail "(#4563) --allow-worktree did not apply the resync"
+    fi
+    if grep -qi "WARN.*linked worktree" <<<"$OUT"; then
+        pass "(#4563) --allow-worktree still WARNs that writes target the main checkout"
+    else
+        fail "(#4563) --allow-worktree did not warn about the main-checkout target"
+    fi
+
+    # The env override is the non-interactive equivalent of the flag.
+    REPO="$(make_fixture)"
+    rm -rf "$LINKED_WT"
+    git -C "$REPO" worktree add -q -b wt-4563-env "$LINKED_WT" >/dev/null 2>&1
+    RC=0; (cd "$LINKED_WT" && LOOM_RESYNC_ALLOW_WORKTREE=1 bash "$SCRIPT" >/dev/null 2>&1) || RC=$?
+    if [[ $RC -eq 0 && "$(cat "$REPO/.loom/hooks/guard.sh")" == "A" ]]; then
+        pass "(#4563) LOOM_RESYNC_ALLOW_WORKTREE=1 is equivalent to --allow-worktree"
+    else
+        fail "(#4563) LOOM_RESYNC_ALLOW_WORKTREE=1 did not permit the run (rc=$RC)"
+    fi
+fi
+
+# --- (#4563) the MAIN checkout is completely unaffected ----------------------
+#
+# Including from a SUBDIRECTORY of it, where `git rev-parse --git-common-dir`
+# returns a RELATIVE path ("../../.git") — a naive string compare against the
+# absolute `--show-toplevel` would refuse this legitimate run.
+echo "Test group 17: main-checkout invocation (incl. subdirectories) still works (#4563)"
+REPO="$(make_fixture)"
+RC=0; (cd "$REPO/defaults/scripts" && bash "$SCRIPT" >/dev/null 2>&1) || RC=$?
+if [[ $RC -eq 0 ]]; then
+    pass "(#4563) run from a main-checkout subdirectory exits 0"
+else
+    fail "(#4563) run from a main-checkout subdirectory was refused (got $RC)"
+fi
+if [[ "$(cat "$REPO/.loom/hooks/guard.sh")" == "A" ]]; then
+    pass "(#4563) run from a main-checkout subdirectory still applies the resync"
+else
+    fail "(#4563) run from a main-checkout subdirectory did not apply the resync"
+fi
+
 # --- contract checks ---------------------------------------------------------
 echo "Test group 13: flag/contract checks"
 if bash "$SCRIPT" --help 2>&1 | grep -q "resync-installed.sh"; then
@@ -669,6 +775,12 @@ else
     fail "--help did not print usage"
 fi
 if bash "$SCRIPT" --help >/dev/null 2>&1; then pass "--help exits 0"; else fail "--help did not exit 0"; fi
+HELP_OUT="$(bash "$SCRIPT" --help 2>&1)"
+if grep -q -- "--allow-worktree" <<<"$HELP_OUT" && grep -qi "linked worktree" <<<"$HELP_OUT"; then
+    pass "(#4563) --help documents --allow-worktree and the refusal behavior"
+else
+    fail "(#4563) --help does not document --allow-worktree / the refusal behavior"
+fi
 
 REPO="$(make_fixture)"
 RC=0; (cd "$REPO" && bash "$SCRIPT" --bogus >/dev/null 2>&1) || RC=$?


### PR DESCRIPTION
## Summary

`defaults/scripts/resync-installed.sh` resolves the installed `.loom/` against the **primary** worktree (via `git rev-parse --git-common-dir`), so a run launched from an issue/PR worktree writes to the **main checkout** — not to the worktree the caller is standing in. Nothing in the caller's own `git status` changes, so the contamination is invisible until `check-main-clean.sh` quarantines it. That is exactly what happened on 2026-07-30 (sweep `sweep-20260730T000350Z-31296-087c2c47`, wave-2 builder for #4472): four installed paths (`.loom/docs/advanced-hooks.md`, `.loom/docs/ci-integration.md`, `.loom/install-metadata.json`, `loom-tools/uv.lock`) were written into `main` mid-sweep and had to be quarantined.

The script now **refuses to run from a linked worktree** (exit `1`), behind an explicit operator override. Running from the main checkout — including any subdirectory of it — is completely unaffected.

## Changes

**`defaults/scripts/resync-installed.sh`**
- After `REPO_ROOT` resolution, compare this invocation's own `git rev-parse --show-toplevel` against the resolved main-checkout root; refuse with a clear error (exit `1`) when they differ. The message names both paths, points at the periodic-resync convention (`chore: resync installed Loom surfaces`, made from the main checkout after the change merges), and names the override.
- Detection is **generic** — no worktree path is hard-coded — so a repo that relocates its worktree root (`worktree.root` / `lib/worktree-root.sh`) is covered too.
- Both sides are normalized to **physical absolute paths** first. This is load-bearing: `git rev-parse --git-common-dir` returns a *relative* path (`../../.git`) from a subdirectory of the main checkout, so a raw string compare would refuse a perfectly legitimate run (regression-tested).
- `--dry-run` is refused too — from a worktree it reports drift of the *main* checkout, which is precisely the misleading framing that caused the incident.
- Override: `--allow-worktree` (curator's suggested name) **or** `LOOM_RESYNC_ALLOW_WORKTREE=1`, matching the existing `LOOM_ALLOW_*` env-override convention in `lib/forge-helpers.sh`. The override still emits a `WARN` naming the main-checkout target.
- `--help` now derives the leading comment block instead of hard-coding `sed -n '2,69p'`. That range had drifted stale as the header grew and was silently truncating the **Usage** and **Exit codes** sections — i.e. the flag could not have been documented in `--help` without this.

**`defaults/scripts/tests/test-resync-installed.sh`** — new groups 16/17 (13 assertions) using the existing synthetic-repo conventions.

**`defaults/docs/troubleshooting.md`** — the resync section gains a "run it from the main checkout only (#4563)" paragraph, and the intended-flow snippet leads with `cd <main checkout>`.

**`defaults/.claude/commands/loom/builder.md`** (canonical builder role source; `defaults/roles/builder.md` is a symlink to it) — new subsection: never run `resync-installed.sh` from an issue/PR worktree; propagating `defaults/` edits into the installed copies is the periodic resync commit's job; and if you hit the refusal the fix is to *stop*, not to re-run with `--allow-worktree`.

**Installed twins deliberately not touched.** `.loom/scripts/resync-installed.sh` and `.claude/commands/loom/builder.md` (the installed copies) are refreshed by the periodic `chore: resync installed Loom surfaces` commit — every prior fix to this script (#4594, #4438, #4312, #4302, …) touched `defaults/` only. `.loom/docs/troubleshooting.md` is a symlink into `defaults/`, so it is already current.

## Acceptance Criteria Verification

1. **Refuse from any linked worktree, generic detection, `--allow-worktree` override** — done; verified live (below).
2. **Main checkout completely unaffected (exit 0, normal behavior)** — done; covered by the pre-existing 71 assertions plus a new subdirectory case (the relative `--git-common-dir` trap).
3. **`--help` documents the flag and the refusal** — done, and asserted by a new contract check.
4. **Installed twin** — checked: propagates via the periodic resync commit, per the established convention (see above). `defaults/docs/troubleshooting.md` updated with the worktree restriction.
5. **`builder.md` gains the explicit "never run it from a worktree" line** — done (previously zero mentions of `resync-installed.sh`).
6. **Regression test covering (a) non-zero exit, (b) no writes under main's `.loom/`, (c) override permits the write** — done.

Scope kept to the issue: no changes to `install-metadata.json` merge semantics (#4528).

## Test Plan

`bash defaults/scripts/tests/test-resync-installed.sh` — **84/84 passed** (was 71; +13):

```
Test group 16: linked-worktree invocation is refused (#4563)
  PASS: (#4563) run from a linked worktree exits non-zero (got 1)
  PASS: (#4563) refusal explains the worktree context
  PASS: (#4563) refusal names the --allow-worktree override
  PASS: (#4563) main checkout's drifted hooks/guard.sh left UNCHANGED
  PASS: (#4563) main checkout's missing scripts/lib/bar.sh NOT created
  PASS: (#4563) main checkout's install-metadata.json NOT re-stamped
  PASS: (#4563) --dry-run from a linked worktree is also refused (exit 1)
  PASS: (#4563) --allow-worktree permits the run (exit 0)
  PASS: (#4563) --allow-worktree wrote the main checkout's installed copy
  PASS: (#4563) --allow-worktree still WARNs that writes target the main checkout
  PASS: (#4563) LOOM_RESYNC_ALLOW_WORKTREE=1 is equivalent to --allow-worktree
Test group 17: main-checkout invocation (incl. subdirectories) still works (#4563)
  PASS: (#4563) run from a main-checkout subdirectory exits 0
  PASS: (#4563) run from a main-checkout subdirectory still applies the resync
Test group 13: flag/contract checks
  PASS: (#4563) --help documents --allow-worktree and the refusal behavior
```

**Bug reproduction / fix confirmation** (synthetic repo + real `git worktree add`, old script vs new from the same linked worktree):

```
old-script rc=0   main .loom/hooks/guard.sh = A     <-- pre-fix: silently contaminated main
new-script rc=1   main .loom/hooks/guard.sh = OLD   <-- post-fix: refused, main untouched
```

Also run: `bash defaults/scripts/check-phantom-labels.sh` (OK), `bash scripts/check-agents-md-sync.sh` (OK), `shellcheck -x` on both changed shell files (only the two pre-existing SC2094/SC2317 infos, unchanged by this PR), `./.loom/scripts/check-main-clean.sh` (clean — no contamination from this very PR, which is the scenario the bug is about).

`bash scripts/test-installer.sh`: 175 passed / 1 failed — the failure is `test-loom-dispatcher.sh` ("config-selected codex path does not touch the claude runner"), **pre-existing on `main`** (verified: the same suite fails 3/86 on the unmodified main checkout) and unrelated to this change.

Closes #4563