### PR TITLE
docs(loom-daemon): document nextest as closing the Tokio-runtime aggregate-suite flake (#4561)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -39,6 +39,23 @@
 #
 # When that lands, delete this block *and* the matching `<div class="warning">`
 # note in `loom-daemon/src/lib.rs`'s crate docs in the same commit.
+#
+# A SECOND FAILURE CLASS THIS FILE ALSO CLOSES -> #4561 (2026-07-30)
+#
+# A #4494 Doctor verification pass on PR #4543 hit a Tokio-runtime-context test
+# failure in a full `cargo test --workspace` run (2,264+ tests) that did not
+# reproduce when the same test was run alone — consistent with thread-local
+# Tokio runtime state (not just env vars/statics) colliding between two
+# unrelated tests under `cargo test`'s shared-process, multi-threaded harness.
+# That is the same process-shared-state hazard class #4385 diagnosed for env
+# mutation, just a different piece of thread-local state leaking across the
+# same kind of boundary. #4561's verification: `cargo nextest run --workspace
+# --profile ci -p loom-daemon --lib` (2,486 tests), run 3 consecutive times —
+# 2486/2486 passed on every run, no Tokio-runtime failure. Process-per-test
+# isolation closes this class structurally for the same reason it closes the
+# env-mutation race: no thread-local (or process-global) state survives across
+# a process boundary. No code fix was needed or made; #4561 is a
+# document-as-covered resolution, not a fixture change.
 
 nextest-version = "0.9.98"
 

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -20,6 +20,18 @@
 //! while every *unmarked* test in the same binary — including every future one
 //! nobody remembers to mark — still runs concurrently with them.
 //!
+//! **Thread-local Tokio runtime context is the same class of hazard.** A
+//! #4494 Doctor-verification run of the full `cargo test --workspace` suite
+//! hit a Tokio-runtime-context test failure that did not reproduce in
+//! isolation — consistent with thread-local runtime state (not just env vars)
+//! colliding between two unrelated tests under `cargo test`'s shared-process,
+//! multi-threaded harness (issue #4561). `cargo nextest run` closes it for the
+//! same structural reason it closes the env-mutation race: no thread-local (or
+//! process-global) state survives a process boundary. Verified via 3
+//! consecutive `cargo nextest run --workspace --profile ci -p loom-daemon
+//! --lib` runs (2,486 tests each) with zero failures — see #4561 and the
+//! matching note in `.config/nextest.toml`.
+//!
 //! ## How the suite is meant to run
 //!
 //! The workspace suite runs under [`cargo nextest`](https://nexte.st) — **one


### PR DESCRIPTION
## Summary

Closes #4561.

During the #4494 Doctor verification pass on PR #4543, a full `cargo test
--workspace` run (2,264+ daemon tests) hit a Tokio-runtime-context test
failure that did not reproduce when the same test was run in isolation —
consistent with thread-local Tokio runtime state leaking/colliding between
tests under `cargo test`'s shared-process, multi-threaded harness. The
Curator's own investigation (already in the issue) found the flake did not
reproduce under `cargo nextest` either, and recommended the acceptance
criteria collapse from "remove the coupling" to "confirm nextest's process
isolation closes this class and document it as covered" if that held up
under my own verification.

## Outcome landed: document-as-covered, not a code fix

**I reproduced the Curator's finding independently, with a stronger signal
(3 consecutive runs instead of 1):**

```
$ cargo nextest run --workspace --profile ci -p loom-daemon --lib   # run 1
Summary [ 144.168s] 2486 tests run: 2486 passed (1 slow), 0 skipped

$ cargo nextest run --workspace --profile ci -p loom-daemon --lib   # run 2
Summary [ 144.414s] 2486 tests run: 2486 passed (1 slow), 0 skipped

$ cargo nextest run --workspace --profile ci -p loom-daemon --lib   # run 3
Summary [ 142.902s] 2486 tests run: 2486 passed (1 slow), 0 skipped
```

Zero failures across 3 runs / 7,458 total test executions. Since `cargo
nextest` runs every test in its own OS process, no thread-local (or
process-global) state — including Tokio runtime context — can cross between
tests at all. This is the exact same structural mechanism #4385/#4560
already established for the env-mutation race; the Tokio-runtime flake is
simply a second member of the same "cargo test shared-process harness lets
thread-local state leak between unrelated tests" hazard class, and nextest
closes both by construction.

I did **not** chase the investigation leads in the issue (the
`sweep_registry.rs` test-owned runtime, the `ipc.rs` shared static runtime,
the `epic_supervisor.rs` production `block_on` path, or the `Handle::current()`
call sites) because the flake never reproduced to give a real panic message
or failing test name to root-cause against — chasing static-analysis leads
without a live repro would be guessing, and the issue itself says the fix
criteria should collapse to documentation in exactly this situation.

## What changed

- `.config/nextest.toml` — new header section recording the #4561 finding
  (the 3x clean-run evidence) alongside the existing #4385 rationale for why
  the file exists.
- `loom-daemon/src/lib.rs` — extended the crate-level "Test isolation
  convention" docs (the place a daemon test author already reads) to note
  that thread-local Tokio runtime context is the same class of hazard as the
  env-mutation race, with the same nextest-closes-it story and a pointer to
  #4561.

No fixture or production code changed — there was no coupling to remove,
since the flake could not be reproduced to identify one.

## Scope note: build-gate.sh left untouched (deliberately)

The issue asked me to consider whether the local build gate
(`defaults/scripts/build-gate.sh`, which currently runs plain `cargo test
--workspace --lib --bins`) should switch to `cargo nextest run` too, given
it's the literal "build gate" the issue title names. I decided **not** to
make that change in this PR:

- `cargo-nextest` is not installed by any Loom setup/install script today
  (verified — no `scripts/install/**` or `.loom/scripts/**` reference it).
  Switching the *mandatory* post-builder quality gate to require it would
  turn every builder session on a host without `cargo-nextest` installed
  into an automatic gate failure (issue bounced back to `loom:issue`), which
  is a much larger blast radius than this issue's Tokio-runtime-flake scope.
- The CI-side equivalent of this same switch is already tracked separately
  as #4559 (blocked only on a `workflow`-scope credential a maintainer needs
  to apply) — this repo already has an established, deliberate place to land
  "switch the Rust test invocation to nextest" changes.
- Nothing about this decision blocks the acceptance criteria here: the
  Tokio-runtime flake is closed for local full-suite verification the moment
  a contributor runs `cargo nextest run` themselves, which the existing
  `loom-daemon/src/lib.rs` docs already recommend as the preferred full-suite
  command.

Happy to file a follow-up issue for a guarded (nextest-presence-checked)
`build-gate.sh` switch if maintainers want it — didn't want to bundle a
build-gate mechanism change into a docs-only flake-classification PR.

## Test plan

- [x] `cargo nextest run --workspace --profile ci -p loom-daemon --lib` x3 —
      2486/2486 passed every run, no Tokio-runtime failure (see above)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p loom-daemon --all-targets -- -D warnings` — clean
- [x] `cargo build --workspace --lib --bins` — clean
- [x] `cargo doc -p loom-daemon --no-deps --lib` — builds (pre-existing
      unrelated rustdoc lint warnings only; no new ones from this change)