### PR TITLE
refactor(daemon): drop the CPU-headroom admission term for one maxConcurrent knob + a machine-wide build slot

### DIFF
--- a/.loom/config.json
+++ b/.loom/config.json
@@ -15,8 +15,7 @@
     },
     "workFinder": {
       "maxConcurrent": 10
-    },
-    "estCoresPerSweep": 1.25
+    }
   },
   "buildGate": {
     "enabled": true,

--- a/defaults/docs/build-gate.md
+++ b/defaults/docs/build-gate.md
@@ -349,9 +349,61 @@ load average overstates consumption on macOS (see "measured idle fraction",
 #4031), so an operator on a chronically-loaded host may raise `loadThreshold`.
 
 Explicitly **out of scope** here (separable follow-ups): a dedicated gate cargo
-target-dir / shared build-lock to isolate contention (never shipped by #4020);
-per-test timeouts (would require adopting cargo-nextest); and any change to sweep
-spawn priority (that is #4233).
+target-dir to isolate contention (never shipped by #4020); per-test timeouts
+(would require adopting cargo-nextest); and any change to sweep spawn priority
+(that is #4233). The **shared build lock** half of that first item did land
+later — see the next section.
+
+### Machine-wide build slot (#4512)
+
+`nice` (#4020) reorders the run queue and the gate-in-flight flag (#4084) holds
+*dispatch* off one root, but neither stops the genuinely concurrent case: N
+sweep worktrees each running their own post-Builder `build-gate.sh` in separate
+processes, plus the daemon's own main-health gate, all compiling at once. Until
+#4512 the daemon's admission formula tried to prevent that up front with a CPU
+estimate (`estCoresPerSweep × cpuUtilizationTarget` minus live idle) — which
+priced *every* sweep as a build and throttled a 95%-idle 8-core host to 2
+concurrent sweeps. #4512 deleted that term and moved the protection here, to the
+stage that actually burns the cores.
+
+**Every invocation of `build-gate.sh` takes one machine-wide build slot before
+compiling**, and releases it on exit (via an `EXIT` trap, so a failed or killed
+gate never leaks the slot). N sweeps run concurrently; at most
+`LOOM_BUILD_SLOTS` (default **1**) of them build at any moment.
+
+- **Mechanism**: `defaults/scripts/lib/build-slot.sh`, sourced by
+  `build-gate.sh` (`loom_build_slot_acquire` / `loom_build_slot_release`). A
+  slot is a lock **directory** created with `mkdir` — POSIX-atomic and available
+  on stock macOS, unlike `flock` — at `~/.loom/locks/build-slot/slot-<i>`,
+  machine-wide rather than per-repo, because cores are a machine-level resource
+  shared by every workspace and worktree on the host. The daemon's Rust half
+  (`loom-daemon/src/build_slot.rs`) implements the identical protocol and wraps
+  the main-health gate's own command, so the two serialize against each other.
+- **Never blocks the gate indefinitely**: the acquire waits at most
+  `LOOM_BUILD_SLOT_WAIT_SECS` (default 300s) and then **degrades open**,
+  proceeding unserialized. A wedged holder costs one build's worth of
+  serialization, never the gate's liveness.
+- **Never fails the gate**: an unusable lock directory (unwritable, missing
+  parent, a file in the way) also degrades open, with a warning. `mkdir` locks
+  carry no heartbeat, so an abandoned slot is reaped after
+  `LOOM_BUILD_SLOT_STALE_SECS` (default 1h — deliberately long, so a peer cannot
+  reap a healthy in-progress build).
+- **Re-entrant**: when the daemon already holds a slot around this gate command
+  it exports `LOOM_BUILD_SLOT_HELD=1`, and the acquire inside `build-gate.sh` is
+  a logged no-op instead of a wait on its own parent's slot.
+- **Opt out** with `LOOM_BUILD_SLOTS=0` (every acquire degrades open — exactly
+  the pre-#4512 behavior). If `lib/build-slot.sh` is missing from an install the
+  gate prints a note and runs unserialized.
+- **Interaction with the timeout**: the daemon acquires the slot **outside** the
+  `buildGate.timeoutSeconds` window, so queueing behind another build never eats
+  into the gate's own budget and turns contention into a false `UNEVALUATED`.
+- **Interaction with deferral**: the load-aware deferral above is a *scheduling*
+  decision made before any command runs; the slot is a *mutual-exclusion*
+  decision made at the moment of compiling. They compose — a deferred tick never
+  reaches the acquire at all.
+
+Full rationale, telemetry, and the env-knob table live in
+[`daemon-reference.md` → Machine-wide build slot](daemon-reference.md).
 
 > **Rule of thumb:** if a check's outcome can differ between an idle host and a
 > busy one — or between a host with tmux and one without — it is

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1550,44 +1550,100 @@ The concurrency cap is **not** a fixed value resolved once at startup. Every
 tick the finder recomputes
 
 ```
-dynamic_cap = min(healthy-token count × per-token concurrency, disk headroom, cpu/load headroom, configured ceiling)
+dynamic_cap = min(healthy-token count × per-token concurrency, disk headroom, configured maxConcurrent)
 ```
 
-from live inputs, so pool/disk/cpu/backlog changes are honored without a
-daemon restart:
+from live inputs, so pool/disk/backlog changes are honored without a daemon
+restart. A fourth **cpu/load headroom** term sat in this `min(...)` from #3978
+until **#4512 deleted it** — see [Why there is no CPU term in
+admission](#why-there-is-no-cpu-term-in-admission-4512) below.
 
 | Input | Source | Bound it enforces |
 |-------|--------|-------------------|
 | **healthy-token count** | `available` accounts in `.ranking` in the pool directory `tokens_pool::paths::resolve_tokens_dir` resolves for the workspace — per-repo `{workspace}/.loom/tokens/` when it holds `*.token` files, else the shared machine-level pool (#3938) (`capacity::read_ranking` / `token_axis_limit`, unified with the writer in #4344 — pre-#4344 this hardcoded the per-repo path even on a shared-pool host, which could pin the dispatch cap at 0 against an orphaned per-repo `.ranking` indefinitely), falling back to the `*.token` count (`tokens::token_pool_size`) when no ranking exists | the count of accounts safe to dispatch to — never dispatch to an exhausted/blocked one (#3902) |
 | **per-token concurrency** | `LOOM_PER_TOKEN_CONCURRENCY` / `autonomous.perTokenConcurrency`, default **2** (#3947) | how many concurrent sweeps to allow **per healthy account**. A plan limit is a utilization-window token bucket, not a session count, so one healthy account can run several concurrent sessions. Before #3947 the implicit factor was `1` (one sweep per account), which collapsed the whole fleet to cap 1 when 6/7 accounts were at their weekly ceiling even though the single healthy account had ample session-window headroom |
 | **disk headroom** | `floor(free_gb / LOOM_PER_WORKTREE_GB)` on the worktree-root volume (`disk_headroom::disk_headroom_limit`, a Rust port of `disk-headroom.sh` that shells to `df -Pk`) | never provision more worktrees than the scratch volume can hold |
-| **cpu headroom** (#3978, measured-idle signal #4031) | `max(1, floor((logical_cpus × LOOM_CPU_UTILIZATION_TARGET − consumed_cores) / LOOM_EST_CORES_PER_SWEEP))`, where `consumed_cores = logical_cpus × (1 − idle_fraction)` from the measured idle fraction (loadavg fallback) (`cpu_headroom::cpu_headroom_limit`) | never start more concurrent sweeps than the host's CPU headroom can currently absorb |
-| **configured ceiling** | `LOOM_WORK_FINDER_MAX_CONCURRENT` (repurposed from Phase A's fixed target into an operator ceiling) | hard operator upper bound regardless of token/disk/cpu headroom |
+| **configured maxConcurrent** | `LOOM_WORK_FINDER_MAX_CONCURRENT` / `autonomous.workFinder.maxConcurrent` (repurposed from Phase A's fixed target into an operator ceiling) | **the** per-machine admission knob (#4512) — tuned empirically by the operator, the only *policy* term in the `min(...)` (the other two meter exhaustible resources: accounts and bytes) |
 
-**CPU headroom term (#3978, measured-idle signal #4031).** The token and disk
-axes alone let a batch of token accounts resetting from `exhausted` to
-`available` at once raise the cap regardless of how many concurrent `cargo
-build`s were already saturating the host — the incident this term fixes: 2–3
-concurrent Rust builds in sweep worktrees starved `build-gate.sh` of CPU badly
-enough that it hit its own 600s timeout, which the (separately-fixed, #3974)
-gate misreported as a verified-red `main`, halting all dispatch.
-`cpu_headroom_limit()` combines a **static** capacity (`logical_cpus ×
-utilization_target`, default target `0.75` — leaves headroom for the OS, the
-daemon itself, and the gate's own `cargo` invocations) with the cores
-**currently consumed**, subtracted from that capacity, divided by an estimated
-per-sweep core cost (`LOOM_EST_CORES_PER_SWEEP`, default `2.0`).
+#### Why there is no CPU term in admission (#4512)
+
+From #3978 until #4512 the `min(...)` carried a fourth term:
+
+```
+cpu_headroom = max(1, floor((logical_cpus × cpuUtilizationTarget − consumed_cores) / estCoresPerSweep))
+```
+
+It was built for a real incident — 2–3 concurrent Rust builds in sweep
+worktrees starved `build-gate.sh` of CPU badly enough that it hit its own 600s
+timeout, which the (separately-fixed, #3974) gate misreported as a verified-red
+`main`, halting all dispatch — and hardened over #4031/#4234. **#4512 deleted
+it anyway**, because it had become the binding constraint on fleet throughput:
+
+- It priced **every** sweep as a build (`estCoresPerSweep`). Sweep wall-clock is
+  dominated by **API wait** (curator / builder / judge conversations); the
+  sustained-heavy-CPU phases (release builds, full test suites, the build gate)
+  are a small fraction of it. So the term throttled the ~90% low-CPU majority to
+  defend against the minority case.
+- Measured evidence (8-core EC2 worker, 2026-07-29): the host sat **95% idle**
+  while the formula capped concurrency at **2**, and `loom-daemon calibrate`
+  recommended "no change" — the formula could not see past its own estimate.
+
+The replacement is two-part, and the protection moved to **where the load
+actually is**:
+
+1. **Admission is one per-machine knob.** `autonomous.workFinder.maxConcurrent`
+   is the whole policy, tuned empirically by the operator (expect 10+ on an
+   8-core API-bound worker). The two remaining terms — the token axis and disk
+   headroom — stay because they meter genuinely *exhaustible* resources
+   (accounts, bytes), not an estimate.
+2. **The genuinely heavy stages serialize where they occur**, via the
+   [machine-wide build slot](#machine-wide-build-slot-4512). N sweeps run
+   concurrently; at most `LOOM_BUILD_SLOTS` of them hold the slot while running
+   `cargo build`/`test` or the build gate; the rest of a sweep's lifecycle never
+   queues.
+
+The **host-distress circuit breaker** (#4235) is unchanged and is what makes a
+hand-tuned knob safe to raise: a mis-set `maxConcurrent` trips a **measured**
+breaker (load-per-core), instead of melting the host on the strength of a
+mis-estimated constant.
+
+`cpu_headroom.rs` survives as a pure **measurement** module — logical core
+count, load average, measured idle fraction, and the `is_host_saturated`
+predicate — consumed by the host breaker (#4235), the build gate's load-aware
+deferral (#4259), and the `status` / `calibrate` reports. Nothing it produces
+feeds the cap.
+
+**Retired knobs are accepted-but-ignored, never a config error.**
+`autonomous.cpuUtilizationTarget` / `autonomous.estCoresPerSweep` and their env
+twins `LOOM_CPU_UTILIZATION_TARGET` / `LOOM_EST_CORES_PER_SWEEP`
+(`work_finder::DEPRECATED_CPU_CONFIG_KEYS` / `DEPRECATED_CPU_ENV_VARS`) still
+parse — a fleet upgrades the daemon binary before it edits every repo's
+committed `.loom/config.json`, so a stale key must be a *visible no-op*, not a
+parse failure. One message
+(`work_finder::deprecated_cpu_knob_notice`) names exactly which config keys and
+env vars to delete, delivered over the channel the reader is actually watching:
+
+- **daemon** — `work_finder::warn_deprecated_cpu_knobs` logs it **once per
+  process** at startup, into `~/.loom/daemon.log`.
+- **CLI** — `loom-daemon calibrate` prints it to **stderr**. A CLI subcommand
+  returns from `main` *before* `setup_logging()` runs, so a `log::warn!` there
+  would go nowhere; stderr also keeps `--json`'s stdout payload clean.
+
+Deleting the settings silences it; leaving them changes nothing.
 
 *Consumed cores come from a measured idle fraction, not the load average
-(#4031).* The original #3978 term used the 1-minute load average as a stand-in
-for consumed cores. On macOS that overstated consumption by ~1.5× — an observed
-idle-but-loaded host read `load1m ≈ 6–7` alongside 76–86% CPU idle on 28 cores
-(only ~4–7 cores actually consumed). Load average counts threads in the
-runnable **and** uninterruptible-sleep states, and this daemon's workload is
-dominated by `claude` sessions **blocked on network I/O**, which inflate load
-without consuming a core — pointing the feedback loop the wrong way (more
-concurrent sweeps → more blocked `claude` → higher load → *lower* cap, while
-CPU sat idle). The term now derives `consumed_cores = logical_cpus × (1 −
-idle_fraction)` from a measured idle fraction, **per-platform**:
+(#4031).* This detail still governs what `status`/`calibrate` **report** (and
+fed the deleted term while it existed). The original #3978 term used the
+1-minute load average as a stand-in for consumed cores. On macOS that overstated
+consumption by ~1.5× — an observed idle-but-loaded host read `load1m ≈ 6–7`
+alongside 76–86% CPU idle on 28 cores (only ~4–7 cores actually consumed). Load
+average counts threads in the runnable **and** uninterruptible-sleep states, and
+this daemon's workload is dominated by `claude` sessions **blocked on network
+I/O**, which inflate load without consuming a core — pointing the (then)
+feedback loop the wrong way (more concurrent sweeps → more blocked `claude` →
+higher load → *lower* cap, while CPU sat idle). The reported CPU consumption is
+therefore `logical_cpus × (1 − idle_fraction)` from a measured idle fraction,
+**per-platform**:
 
 - **Linux** deltas two reads of the aggregate `cpu` line in `/proc/stat`
   (`idle + iowait` vs total), memoizing the previous cumulative sample and
@@ -1599,29 +1655,18 @@ idle_fraction)` from a measured idle fraction, **per-platform**:
   synchronous `ipc.rs` status path, so a runtime worker is never blocked and a
   status request + a work-finder tick never each pay the full second.
 
-The signal chain is **fail-open**: `measured idle fraction → 1-minute load
-average → static capacity`. An unreadable idle signal (missing `/proc/stat` or
-`iostat`, unsupported platform, or no delta sampled yet) falls back to the load
-average (#3978's behavior); an unreadable load average falls back to the static
-capacity, unadjusted. Like the token axis's "one healthy account is the floor,
-never a halt" policy (#3902), the CPU term is floored at `1` — a read failure or
-a noisy reading must never by itself wedge the whole dynamic cap to zero; disk
-headroom and the token axis remain the only terms allowed to floor to a genuine
-`0`. Tunable with the standard precedence **env (`LOOM_CPU_UTILIZATION_TARGET`
-/ `LOOM_EST_CORES_PER_SWEEP`) > config (`autonomous.cpuUtilizationTarget` /
-`autonomous.estCoresPerSweep`) > default (`0.75` fraction / `2.0` cores)**
-(#4032) — resolved single-root, at startup, from the same
-`WorkFinderConfig`/`read_work_finder_config` that `perTokenConcurrency` uses
-(not per-workspace: the dynamic cap is one global number per tick, computed
-before the workspace registry is even loaded). An out-of-range or
-wrong-JSON-type config value (`cpuUtilizationTarget` outside `(0, 1]`,
-`estCoresPerSweep <= 0`, a string/bool/null where a number is expected) is
-dropped to `None` at the config-read layer, not clamped, so it falls straight
-through to env/default resolution.
+Every read here is **fail-open**: an unreadable idle signal (missing
+`/proc/stat` or `iostat`, unsupported platform, or no delta sampled yet) is
+`None`, and every consumer must fail *safe* on `None` rather than assume "host
+fully loaded" — `is_host_saturated` returns `None` so the build gate runs
+instead of deferring, and the host breaker treats a missing sample as a
+non-observation. This mirrors `capacity::token_axis_limit`'s policy of falling
+back to the optimistic basis when no ranking data exists: the absence of a
+signal is not evidence of unhealthiness.
 
 **`LOOM_PER_WORKTREE_GB` deliberately stays env-only (#4032 decision).**
-Unlike the CPU knobs, `disk_headroom`'s `LOOM_PER_WORKTREE_GB` was *not*
-migrated to the same `autonomous.*` pattern. It has a second, independent
+`disk_headroom`'s `LOOM_PER_WORKTREE_GB` was *not* migrated to the
+`autonomous.*` config pattern. It has a second, independent
 Bash-side reader (`defaults/scripts/lib/disk-headroom.sh`, consumed by
 `/loom:sweep` Stage -1 wave sizing) alongside the Rust
 `disk_headroom::per_worktree_gb`. Migrating only the Rust side would create a
@@ -1631,103 +1676,184 @@ consistent env-only behavior. Wiring the Bash `config-resolver.sh` into
 `disk-headroom.sh` too is a separate, larger change; file a follow-up if that
 cost is judged worth paying.
 
-*Calibrating `LOOM_EST_CORES_PER_SWEEP`.* The host-side half of the term
-(consumed cores) is now measured continuously and needs no tuning. The one
-remaining constant — how many cores one concurrent sweep consumes during its
-build/test step — is a per-repo/host property. Its default (`2.0`) is **not**
-changed here absent a real multi-sweep measurement; a reproducible recipe lives
-at [`docs/measure-est-cores-per-sweep.md`](https://github.com/rjwalters/loom/blob/main/docs/measure-est-cores-per-sweep.md)
-(upstream Loom repo — not shipped to consumer installs)
-so an operator can calibrate it on a live fleet without re-opening the code.
+#### Machine-wide build slot (#4512)
 
-**The release-build fan-out footgun (#4234, decomposed from #4231).** `2.0` is
-calibrated against `cargo check`/`clippy`/debug-build sweep phases (#4031), not
-a **release** build: `cargo build --release` parallelizes codegen units across
-essentially every logical core, so a release-build-heavy repo's real per-sweep
-consumption can run much closer to `logical_cpus` than `2.0`. The #4231 host
-meltdown (a 6-way sweep fan-out that drove load to 118 on a 28-core host) is
-the concrete failure mode: at the shipped default, six concurrent
-release-building sweeps look like `6 × 2 = 12` cores of demand to the cpu
-headroom term when the real demand is far higher. Raise
-`autonomous.estCoresPerSweep` well above `2.0` — plausibly toward
-`logical_cpu_count()` itself — for a repo whose sweeps spend meaningful wall
-clock in a release build. The knob is resolved **once at daemon startup**
-(env > config > default, #4032), the same startup-capture as every other
-dynamic-cap knob; a live re-tune takes effect on the next daemon restart, not
-mid-run. #4234 adds a second, independent backstop for exactly this
-under-estimate — see the next section.
+Deleting the admission-time CPU term would leave nothing between N concurrent
+`cargo test --workspace` runs and the host, so #4512 pairs it with a
+**machine-wide build slot** — the bounded revival of #4003's "agents check out a
+slot only for bound work". N sweeps run concurrently, but at most
+`LOOM_BUILD_SLOTS` of them may be inside a designated high-CPU stage at once.
 
-#### Sizing a host (`loom-daemon calibrate`, #4390)
+**Shape.** A slot is a lock **directory** created with `mkdir` (POSIX-atomic,
+works across processes *and* across languages; `flock` is deliberately avoided —
+unavailable on stock macOS). The primitive is `MkdirLock`, the same one the
+token-pool state files and the per-issue claim lock (`.loom/locks/issue-<N>`)
+use. Two implementations share one protocol so they serialize against each
+other:
 
-Hand-deriving the four knobs above — reading `status`'s cap breakdown,
-understanding which term binds, picking a ceiling — is exactly what
-`loom-daemon calibrate` automates. It measures the host with the **same**
-primitives this section documents (`cpu_headroom::cpu_headroom_limit`,
+| Half | File | Used by |
+|------|------|---------|
+| Rust | `loom-daemon/src/build_slot.rs` (`acquire` / `BuildSlotLease`) | the daemon's main-health gate, around its gate command |
+| Bash | `defaults/scripts/lib/build-slot.sh` (`loom_build_slot_acquire` / `_release`) | `build-gate.sh`, i.e. every sweep's post-Builder quality gate in its own worktree |
+
+Slots live **machine-wide** at `~/.loom/locks/build-slot/slot-<i>` —
+deliberately *not* under a repo's `.loom/locks/`. The host's cores are one
+machine-level resource shared by every workspace the daemon manages, and #4512's
+operator note asked explicitly for **one unambiguous home** for machine-tier
+concurrency state rather than the ambiguous per-workspace tier (on a
+multi-workspace host, "which `.loom/config.json` supplied the number" is a real
+question).
+
+**Three hard safety properties**, all load-bearing:
+
+1. **Never deadlocks.** `acquire` waits at most `LOOM_BUILD_SLOT_WAIT_SECS`
+   (default 300s) and then **degrades open** — it returns a lease that holds no
+   slot and lets the caller run unserialized. A slow or crashed holder therefore
+   costs throughput, never liveness.
+2. **Degrades open on any lock-store failure.** An unwritable / missing /
+   permission-denied lock directory yields a degraded-open lease *immediately* —
+   no spinning, no error propagated to the caller. Refusing to build because the
+   lock store is broken would be strictly worse than building unserialized.
+3. **Re-entrant.** A holder exports `LOOM_BUILD_SLOT_HELD=1` into its child
+   environment, so a nested acquire (the daemon's main-health gate holding the
+   slot around `build-gate.sh`, which then tries to take it too) is a logged
+   no-op instead of a self-inflicted wait on its own parent's slot.
+
+Because a slot is held for the *duration of a build* (minutes), the stale-reap
+threshold is deliberately long (`LOOM_BUILD_SLOT_STALE_SECS`, default 1h) —
+`mkdir` locks carry no heartbeat, and a 30s threshold (the token-pool default)
+would let a peer reap a perfectly healthy in-progress build. A crashed holder is
+covered by property 1, not by aggressive reaping.
+
+**Telemetry.** Every state transition is logged once: on acquire (naming the
+slot and the wait), on the first wait of a round (so a queue is visible), on
+release (with the hold duration), and on degrade-open (naming *why*).
+`loom-daemon calibrate` reports the resolved slot count.
+
+**Knobs are env-only**, following the `LOOM_PER_WORKTREE_GB` precedent above for
+exactly the same reason: an independent Bash-side reader must resolve identical
+values, and honoring `.loom/config.json` on one path while silently ignoring it
+on the other is worse than consistent env-only behavior. Export them from the
+daemon's start environment.
+
+| Env var | Default | Meaning |
+|---------|---------|---------|
+| `LOOM_BUILD_SLOTS` | `1` | Concurrent build slots on this machine. `0` **disables** serialization entirely (every acquire degrades open) — exactly the pre-#4512 behavior for an operator who wants it back |
+| `LOOM_BUILD_SLOT_WAIT_SECS` | `300` | Bounded wait before degrading open |
+| `LOOM_BUILD_SLOT_STALE_SECS` | `3600` | Age at which an abandoned slot dir is reaped |
+| `LOOM_BUILD_SLOT_DIR` | `~/.loom/locks/build-slot` | Slot directory override (test seam; also relocates slots onto a chosen filesystem) |
+| `LOOM_BUILD_SLOT_HELD` | *(unset)* | Re-entrancy sentinel, set by a holder for its children — not an operator knob |
+
+Default `1` because the heavy stages (`cargo build`/`test`, the build gate)
+already parallelize across essentially every core on their own; one at a time is
+the point. #4512 allows "at most 1–2".
+
+**The #4231 release-build fan-out under this model.** #4231 was a 6-way sweep
+fan-out that drove load to 118 on a 28-core host, because six concurrent
+release-building sweeps looked like `6 × estCoresPerSweep(2.0) = 12` cores of
+demand to a term whose real demand was closer to `6 × 28`. Under #4512 the same
+fan-out admits 6 sweeps (the knob, not an estimate, decides that) but only **one
+of them compiles at a time** — the other five block in `build-gate.sh`'s slot
+acquire, so peak demand is one build's worth of parallel `cargo`, not six. The
+formula that mis-estimated the fan-out is gone; the thing it was estimating is
+now directly bounded. If the knob is nonetheless set too high for the machine,
+the #4235 host breaker trips on **measured** load-per-core and suppresses
+dispatch — a measurement, not a constant, is the last line of defence.
+
+#### Sizing a host (`loom-daemon calibrate`, #4390; measurement-only since #4512)
+
+Originally (#4390) this subcommand *recommended* — and with `--write` applied —
+new knob values, deriving a `maxConcurrent` ceiling from the CPU headroom term
+(`cpu_headroom + 25% slack`). #4512 deleted that term, so there is nothing left
+to derive a recommendation *from*: `autonomous.workFinder.maxConcurrent` is now
+the one per-machine knob, **tuned empirically by the operator**.
+
+Calibrate is therefore strictly a **measurement report**. It measures the host
+with the **same** primitives dispatch uses (`cpu_headroom::logical_cpu_count` /
+`cached_cpu_idle_fraction` / `read_loadavg_1m`,
 `disk_headroom::disk_headroom_limit`, `capacity::read_ranking` falling back to
-`tokens::token_pool_size`) and prints the same `min(...)` breakdown `status`
-uses, plus which term would bind after applying its recommendation:
+`tokens::token_pool_size`, `build_slot::resolve_slots`), so it can never
+disagree with what dispatch actually does:
 
 ```
-loom-daemon calibrate                 # read-only report (default)
+loom-daemon calibrate                 # human-readable measurement report
 loom-daemon calibrate --json          # machine-readable
-loom-daemon calibrate --write         # merge the recommendation into .loom/config.json
+loom-daemon calibrate --write         # DEPRECATED, ignored (prints a notice)
 ```
 
-- **Scope**: only `autonomous.workFinder.maxConcurrent` and
-  `autonomous.perTokenConcurrency` are ever written — every other config key
-  (including `cpuUtilizationTarget`/`estCoresPerSweep`, which calibrate flags
-  when clearly miscalibrated for the host class but never rewrites
-  automatically) is preserved untouched. `--write` is idempotent: a repeat run
-  with the same recommendation is byte-identical; without `--write`, calibrate
-  is strictly read-only.
-- **Ceiling policy**: only ever *raises* `maxConcurrent` (never lowers it) to
-  `cpu_headroom + ~25% slack`, so the measured-CPU term becomes the binding
-  constraint instead of the shipped consumer default (`3`) — this reproduces
-  this repo's own hand-derived `maxConcurrent=8` (commit `3fdfbf81`) almost
-  exactly on its 18-core/8-token host.
-- **Per-token-concurrency policy**: only raised when the token axis
-  (`healthy_accounts × per_token_concurrency`) is itself the smallest resource
-  term (i.e. tokens are the actual bottleneck), and only just enough to stop
-  binding below the cpu/disk/ceiling floor — never proactively.
-- **Disk has no config key to write** — `LOOM_PER_WORKTREE_GB` is deliberately
-  env-only (previous subsection) — so calibrate always names the env-var
-  alternative instead of a config write.
-- **Env overrides win**: if `LOOM_WORK_FINDER_MAX_CONCURRENT` /
-  `LOOM_PER_TOKEN_CONCURRENCY` are set, calibrate still computes and can write
-  a recommendation, but warns that the env var outranks whatever it just wrote
-  (env > config > default) until the env var is unset or updated to match.
-- **Fleet-safety**: raising the committed ceiling is safe fleet-wide precisely
-  because the dynamic cap keeps three other, independently-measured terms in
-  the `min(...)` — each host still binds on its **own** measured
-  cpu/tokens/disk regardless of how generous the shared ceiling is. A ceiling
-  recommended for a large pilot host does not let a small laptop
-  over-dispatch.
+- **It never writes config.** `--write` is accepted-but-ignored with a
+  deprecation notice so an existing scripted `calibrate --write` does not start
+  failing. The JSON payload keeps a `"write": {"applied": false, "config_path":
+  null}` object for machine consumers that keyed off it.
+- **What it prints**: host measurements (logical cpus, observed idle fraction +
+  1m loadavg, disk headroom, healthy/total accounts, build slots), the currently
+  resolved knobs, the `min(healthy × per-token, disk, maxConcurrent)` breakdown,
+  which term binds (`token` / `disk` / `ceiling`), and one line of advice.
+- **How to read it** (this is the tuning loop that replaces the old
+  recommendation):
+  - binds on `ceiling` **while the host sits idle** ⇒ raise `maxConcurrent`;
+  - binds on `ceiling` **while the host is saturated** (low idle fraction, or
+    the host breaker tripping) ⇒ the knob is already at/above what this machine
+    sustains — leave it or lower it;
+  - binds on `token` / `disk` ⇒ raising `maxConcurrent` changes nothing; add
+    accounts or free scratch space.
+- **Deprecation surface**: `calibrate` also prints the retired-knob notice to
+  **stderr** — an operator running it to size a host is exactly who needs to hear
+  that a stale `estCoresPerSweep` is doing nothing (see the previous
+  subsection for why stderr, not the log, on this path).
+- **Disk has no config key** — `LOOM_PER_WORKTREE_GB` is deliberately env-only
+  (previous subsection) — so calibrate names the env-var alternative instead.
+- **Env overrides win**: when `LOOM_WORK_FINDER_MAX_CONCURRENT` /
+  `LOOM_PER_TOKEN_CONCURRENCY` are set, the report says so explicitly — editing
+  `.loom/config.json` has no effect until the env var is unset or updated
+  (env > config > default).
+- **It names *which file* set the knob** (`set by: …`, JSON
+  `measurements.max_concurrent_source`). Now that one number carries the whole
+  admission policy, "edit the config" has to be unambiguous: the effective config
+  is a deep merge of up to four tiers
+  (`config_resolver::tier_paths_by_precedence`) and the daemon manages several
+  workspaces, so `maxConcurrent = 3` might be a repo's committed value, a
+  host-local override, or the built-in default. `config_resolver::source_of`
+  reports the **highest-precedence tier that actually sets the key**; `null` /
+  `"built-in default"` means no tier does. When an env var shadows a tier the
+  report says that too, so nobody edits a file that cannot take effect. For a
+  genuinely machine-wide setting (one value for every workspace on the host),
+  put it in the machine tier — `~/.local/share/loom/config/defaults.json`, or
+  `LOOM_WORK_FINDER_MAX_CONCURRENT` in the daemon's start environment — rather
+  than in each repo's `.loom/config.json`.
+- **Fleet-safety**: a generous committed `maxConcurrent` is still safe fleet-wide
+  because the two exhaustible-resource terms remain in the `min(...)` (each host
+  binds on its **own** tokens/disk), the build slot bounds concurrent heavy
+  builds per machine, and the host breaker is the measured backstop.
 - **Startup hint**: `loom-daemon-start.sh` prints one advisory line at start
-  time — `"ceiling N binds; this host could run M — run loom-daemon
-  calibrate"` — only when the ceiling is *currently* the binding term **and**
-  both the cpu and token axes have at least 2× headroom above it. Never fatal:
-  a missing `jq`, a calibrate error, or an unparseable payload all fall
-  through silently, mirroring the advisory-only safehouse status line.
-- **Restart required**: like every other dynamic-cap knob, these values are
-  captured once at daemon **startup**, not re-read per tick (see the
-  `configured ceiling` row above) — a `--write` takes effect on the *next*
-  restart (`./.loom/scripts/cli/loom-daemon-stop.sh && ./.loom/scripts/cli/loom-daemon-start.sh`),
+  time — `"maxConcurrent N binds while the host is M% idle — consider raising
+  autonomous.workFinder.maxConcurrent"` — only when the ceiling is *currently*
+  the binding term **and** the measured idle fraction is at or above 50%
+  (`calibrate::IDLE_HEADROOM_FRACTION`). Never fatal: a missing `jq`, a
+  calibrate error, or an unparseable payload all fall through silently,
+  mirroring the advisory-only safehouse status line.
+- **Restart required**: like every other dynamic-cap knob, `maxConcurrent` is
+  captured once at daemon **startup**, not re-read per tick — a config edit takes
+  effect on the *next* restart
+  (`./.loom/scripts/cli/loom-daemon-stop.sh && ./.loom/scripts/cli/loom-daemon-start.sh`),
   not live.
 
 #### Per-tick admission (ramp) cap (#4234)
 
 `resolve_dynamic_max_concurrent` is a **live** ceiling, recomputed every tick,
 so it can *jump* tick-to-tick — e.g. several exhausted token accounts resetting
-at once raises the token axis from ~2 to ~14, or a miscalibrated
-`estCoresPerSweep` (previous section) makes the cpu axis look larger than the
-host can actually sustain. Before #4234, a jump like that let a **single tick**
-admit every newly-eligible candidate up to the new, larger cap in one shot.
-Load average / measured idle fraction is a **lagging** signal sampled at
-wave-*start*: a burst admitted together all ramp their builds minutes later,
-well after the tick that "safely" admitted them observed a still-quiet host.
-This is the exact failure mode of the #4231 incident's second wave — the host
-re-spiked at 01:41 after load had already dropped to 8, because the admission
-decision had already been made by the time load caught up.
+at once raises the token axis from ~2 to ~14, or an operator raises
+`maxConcurrent` on a live host. Before #4234, a jump like that let a **single
+tick** admit every newly-eligible candidate up to the new, larger cap in one
+shot. Host load is a **lagging** signal: a burst admitted together all ramp
+their work minutes later, well after the tick that "safely" admitted them
+observed a still-quiet host. This is the exact failure mode of the #4231
+incident's second wave — the host re-spiked at 01:41 after load had already
+dropped to 8, because the admission decision had already been made by the time
+load caught up. (Since #4512 the heavy stages additionally serialize on the
+[build slot](#machine-wide-build-slot-4512), so a burst's *builds* queue even
+when its admissions do not; the ramp cap remains the smoother for everything
+else a burst does.)
 
 `autonomous.workFinder.maxAdmissionsPerTick` (`LOOM_WORK_FINDER_MAX_ADMISSIONS_PER_TICK`,
 default **3**, mirroring `maxConcurrent`'s default) bounds how many **new**
@@ -1741,7 +1867,7 @@ subsequent tick re-samples CPU/disk/token headroom fresh, so a ramp that turns
 out to be too aggressive self-corrects within one interval (default 60s)
 rather than in one uncontrolled burst. Resolved with the standard precedence
 **env > config > default**, single-root, at daemon startup — the same
-startup-capture pattern as `cpuUtilizationTarget`/`estCoresPerSweep`: the ramp
+startup-capture pattern as `maxConcurrent`/`perTokenConcurrency`: the ramp
 cap's whole purpose is to smooth admission *within* the live per-tick
 re-computation of `max_concurrent`, so the knob itself does not need to be
 live; retuning it takes effect on the next daemon restart.
@@ -1762,7 +1888,7 @@ protocol change: `dispatch_sweep` **always dispatches** — an explicit
 operator/MCP request is a deliberate act, and the work finder's own dynamic
 cap remains the hard backstop for *its own* autonomous dispatches — but now
 computes the same `resolve_dynamic_max_concurrent` headroom the work finder
-uses (token/disk/cpu/configured-max, scoped to the target repo) and, on a
+uses (token/disk/configured-max, scoped to the target repo) and, on a
 **state change** into/out of "occupancy at or over that headroom" for that
 repo, logs a warning and publishes a `daemon.dispatch.headroom_advisory`
 event-bus event (state-change-deduped — never a per-call stream, keyed
@@ -1773,15 +1899,16 @@ side channel exactly like the token-capacity advisory. Every `dispatch_sweep`
 call's log line additionally always names the current occupancy/dynamic-cap
 axes (not just on the deduped transition), so `RUST_LOG=loom_daemon=info`
 shows the same headroom picture the work finder's own tick log shows, without
-duplicating the `cpu_headroom_snapshot`/`disk_headroom_limit` plumbing
-`loom-daemon status` (`build_daemon_status`) already exposes.
+duplicating the `disk_headroom_limit` plumbing `loom-daemon status`
+(`build_daemon_status`) already exposes.
 
-The handler never calls the **refreshing** CPU probe
-(`cpu_headroom::cpu_headroom_limit`, which sleeps ~1s on macOS via `iostat`)
-while holding the sweep-registry mutex — doing so would stall every other IPC
-request scoped to the same registry for that second. It uses the
-**non-refreshing** `cpu_headroom::cpu_headroom_snapshot` (the memoized idle
-fraction; never blocks) instead, the same call `build_daemon_status` makes.
+Nothing in this handler may block, because it holds the sweep-registry mutex
+from the assessment through the dispatch call. Since #4512 the headroom is
+`min(token axis, disk, configured max)` — three cheap filesystem/config reads,
+no CPU sampling at all. (Before #4512 this had to carefully avoid the
+**refreshing** CPU probe, whose macOS `iostat` refresh sleeps ~1s and would have
+stalled every other IPC request on the same registry for that second; removing
+the CPU term removed that hazard outright.)
 
 **Per-token concurrency factor (#3947).** The token axis is `healthy × factor`,
 not `healthy × 1`. The factor is resolved with the standard precedence **env
@@ -1794,12 +1921,13 @@ account with session-window headroom — the #3909 rotating selection spread sti
 fills **distinct** accounts first (via the persistent `.rotation_cursor`), only
 stacking multiple sweeps on one account when concurrency demand exceeds the
 healthy-account count. The `loom-daemon status` view spells the arithmetic out,
-e.g. `= min(healthy 1 × per-token 2 = 2, disk headroom 120, cpu headroom 6,
-configured max 3)`, and a separate line reports the live core-count detail
-feeding the cpu headroom term — naming which signal actually fed it, e.g.
-`cpu headroom: 8 concurrent-sweep slot(s) (28 logical cores, 85% idle measured
-(≈4.2 cores consumed))`, or a `1m loadavg …` / `static capacity only` line when
-falling back (#3978 AC4; measured-idle signal #4031).
+e.g. `= min(healthy 1 × per-token 2 = 2, disk headroom 120, configured max 3)`,
+and a separate line reports the live host CPU **observation** — explicitly
+labelled as not a cap term, e.g. `host cpu (observed, not a cap term since
+#4512): 28 logical cores, 85% idle measured (≈4.2 cores consumed), 1m loadavg
+6.10`, degrading to a `1m loadavg … (no idle sample yet)` or `no CPU signal on
+this platform` line when the measurement is unavailable (#3978 AC4;
+measured-idle signal #4031; demoted to observation in #4512).
 
 **"Currently binding" vs "smallest ceiling" (#4031).** The dynamic cap is the
 *minimum* of several ceilings, but a ceiling only *binds* once in-flight
@@ -2032,8 +2160,6 @@ concurrency ceiling 5" and share it with the team:
   "autonomous": {
     "model": "sonnet",
     "perTokenConcurrency": 2,
-    "cpuUtilizationTarget": 0.75,
-    "estCoresPerSweep": 2.0,
     "workFinder": {
       "enabled": true,
       "intervalSecs": 60,
@@ -2104,8 +2230,8 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.model` | *(per-dispatch `dispatch_sweep` `model` param)* | `sonnet` | Model pinned on **every** daemon-dispatched child (work-finder, epic supervisor, and `dispatch_sweep` when its `model` param is absent). See below (#3944) |
 | `autonomous.workFinder.enabled` | `LOOM_WORK_FINDER` | `false` | Master on/off for the finder loop |
 | `autonomous.workFinder.intervalSecs` | `LOOM_WORK_FINDER_INTERVAL_SECS` | `60` | Zero/invalid → default |
-| `autonomous.workFinder.maxConcurrent` | `LOOM_WORK_FINDER_MAX_CONCURRENT` | `3` | Operator **ceiling**, not a fixed target |
-| `autonomous.workFinder.maxAdmissionsPerTick` | `LOOM_WORK_FINDER_MAX_ADMISSIONS_PER_TICK` | `3` | Per-tick **ramp** cap (#4234) — bounds how many *new* sweeps one tick may admit, independent of `maxConcurrent`/the live dynamic cap. Zero/invalid → default; resolved once at startup, mirroring `estCoresPerSweep`. See [Per-tick admission (ramp) cap](#per-tick-admission-ramp-cap-4234) below |
+| `autonomous.workFinder.maxConcurrent` | `LOOM_WORK_FINDER_MAX_CONCURRENT` | `3` | **The** per-machine admission knob since #4512 — an operator ceiling, not a fixed target, tuned empirically from `loom-daemon calibrate` / `status`. Expect well above the shipped default on an API-bound worker (10+ on 8 cores) |
+| `autonomous.workFinder.maxAdmissionsPerTick` | `LOOM_WORK_FINDER_MAX_ADMISSIONS_PER_TICK` | `3` | Per-tick **ramp** cap (#4234) — bounds how many *new* sweeps one tick may admit, independent of `maxConcurrent`/the live dynamic cap. Zero/invalid → default; resolved once at startup, mirroring `maxConcurrent`. See [Per-tick admission (ramp) cap](#per-tick-admission-ramp-cap-4234) below |
 | `autonomous.workFinder.quarantine.enabled` | `LOOM_WORK_FINDER_QUARANTINE` | `true` | Insta-crash quarantine on/off (#3939). A safety backstop — defaults on |
 | `autonomous.workFinder.quarantine.threshold` | `LOOM_WORK_FINDER_QUARANTINE_THRESHOLD` | `3` | Consecutive insta-crashes before an issue is quarantined. Zero/invalid → default |
 | `autonomous.workFinder.quarantine.ttlSecs` | `LOOM_WORK_FINDER_QUARANTINE_TTL_SECS` | `3600` | How long a quarantine entry persists before auto-release. Zero/invalid → default |
@@ -2120,8 +2246,8 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.rateLimitBreaker.enabled` | `LOOM_RATE_LIMIT_BREAKER` | `true` | GitHub rate-limit circuit breaker on/off (#4429). A safety backstop — **defaults on**. Env truthy enables, any other value disables; wins over config. See [GitHub rate-limit circuit breaker](#github-rate-limit-circuit-breaker-4429) below |
 | `autonomous.rateLimitBreaker.fallbackCooldownSecs` | `LOOM_RATE_LIMIT_BREAKER_FALLBACK_COOLDOWN_SECS` | `900` | Cooldown length when the `gh api rate_limit` reset probe fails. Zero/invalid → default; every computed cooldown is clamped to `[60, 3600]`s |
 | `autonomous.perTokenConcurrency` | `LOOM_PER_TOKEN_CONCURRENCY` | `2` | Concurrent sweeps **per healthy token** in the cap (#3947). Zero/invalid → default; clamped to a floor of 1 |
-| `autonomous.cpuUtilizationTarget` | `LOOM_CPU_UTILIZATION_TARGET` | `0.75` | Fraction of logical CPUs the CPU headroom term is willing to dedicate to sweep work (#3978, config surface #4032). Outside `(0, 1]` or wrong JSON type → default; single-root, resolved once at startup (not per-workspace) |
-| `autonomous.estCoresPerSweep` | `LOOM_EST_CORES_PER_SWEEP` | `2.0` | Estimated CPU cores one concurrent sweep consumes while building/testing (#3978, config surface #4032). `<= 0` or wrong JSON type → default; integer JSON (`2`) and float JSON (`2.0`) both accepted; single-root, resolved once at startup |
+| `autonomous.cpuUtilizationTarget` | `LOOM_CPU_UTILIZATION_TARGET` | *(none)* | **DEPRECATED — accepted but ignored (#4512).** Fed the deleted CPU-headroom admission term (#3978, config surface #4032). Any value at any type still parses (never a config error); the daemon logs one warning per process naming it and `loom-daemon calibrate` prints it to stderr. Delete it to silence the warning; tune `autonomous.workFinder.maxConcurrent` instead |
+| `autonomous.estCoresPerSweep` | `LOOM_EST_CORES_PER_SWEEP` | *(none)* | **DEPRECATED — accepted but ignored (#4512).** Same story as `cpuUtilizationTarget` above: the CPU term it sized is gone; heavy build/test stages are bounded by the [machine-wide build slot](#machine-wide-build-slot-4512) instead |
 | `autonomous.mainHealthGate.enabled` | `LOOM_MAIN_HEALTH_GATE` | `false` | Gate loop on/off |
 | `autonomous.mainHealthGate.ciWorkflow` | `LOOM_GATE_CI_WORKFLOW` | *(unset)* | Forge workflow that must itself conclude `success` for forge-CI corroboration to vouch for a commit (#3987). Empty/whitespace → unset. Absent → today's unanimity rule, unchanged. See [Optional named verification workflow](#optional-named-verification-workflow-loom_gate_ci_workflow-3987) |
 | `autonomous.mainHealthGate.suppressDispatchDuringGate` | `LOOM_MAIN_HEALTH_GATE_SUPPRESS_DISPATCH` | `true` | Hold new dispatch off a root while its build-gate run is in flight (#4084), per-root so a sibling with no gate in flight keeps dispatching. Env truthy (`1`/`true`/`yes`/`on`) enables, any other value disables; wins over config. Set `false` to recover the pre-#4084 `is_halted`-only behavior. See [build-gate.md → gate-in-flight dispatch suppressor](build-gate.md) |
@@ -2424,9 +2550,15 @@ overload. It was added after the 2026-07-27→28 meltdown (#4231): a 6-way sweep
 fan-out drove load to 118 on 28 cores, the window server was watchdog-killed five
 times, and the daemon itself crashed — and then a *second* wave re-spiked the host
 two hours later because nothing remembered the first incident. The point-in-time
-admission checks (CPU headroom #3978, the per-tick load-admission ramp cap #4234)
-each make a *fresh* decision every tick, so the instant load dipped they
-re-admitted a full wave.
+admission checks (the CPU headroom term #3978 — since removed in #4512 — and the
+per-tick load-admission ramp cap #4234) each make a *fresh* decision every tick,
+so the instant load dipped they re-admitted a full wave.
+
+Since #4512 removed the CPU estimate from admission, this **measured** breaker is
+also what makes a hand-tuned per-machine `maxConcurrent` safe to raise: a mis-set
+knob trips the breaker — on observed load-per-core, not on a constant — instead
+of melting the host, while the [machine-wide build slot](#machine-wide-build-slot-4512)
+keeps the heavy stages serialized in the first place.
 
 The breaker is the **stateful** layer those checks lack. It samples
 **load-per-core** (`loadavg_1m / logical_cpus`) once per work-finder tick and runs

--- a/defaults/scripts/build-gate.sh
+++ b/defaults/scripts/build-gate.sh
@@ -83,6 +83,33 @@ if [[ -z "${LOOM_BUILD_GATE_NICED:-}" \
   exec nice -n "${_gate_niceness}" "$0" "$@"
 fi
 
+# Machine-wide build slot (#4512).
+#
+# #4512 removed the CPU-headroom term from the daemon's admission formula (it
+# priced every sweep as a build and throttled a 95%-idle host to 2 concurrent
+# sweeps) and moved the protection HERE, to the stage that actually burns the
+# cores. Every invocation of this gate — the daemon's main-health gate, and each
+# sweep's post-builder quality gate in its own worktree — takes one machine-wide
+# slot before compiling, so N sweeps can run while at most LOOM_BUILD_SLOTS of
+# them build. Without this, deleting the admission-time CPU term would leave
+# nothing between N concurrent `cargo test --workspace` runs and the host.
+#
+# The lease NEVER blocks indefinitely and NEVER fails: it waits at most
+# LOOM_BUILD_SLOT_WAIT_SECS (default 300) and then degrades open, so a wedged or
+# crashed holder costs one build's worth of serialization, never this gate's
+# liveness. LOOM_BUILD_SLOTS=0 opts out entirely. When the daemon already holds
+# a slot around this command it exports LOOM_BUILD_SLOT_HELD=1 and the acquire
+# below is a re-entrant no-op rather than a wait on our own parent's slot.
+_build_slot_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/build-slot.sh"
+if [[ -f "$_build_slot_lib" ]]; then
+  # shellcheck source=lib/build-slot.sh
+  source "$_build_slot_lib"
+  trap loom_build_slot_release EXIT
+  loom_build_slot_acquire "build-gate(${LOOM_BUILD_GATE_TIER:-full})"
+else
+  echo "[build-gate] note: lib/build-slot.sh not found — running unserialized (#4512)" >&2
+fi
+
 cd "$(git rev-parse --show-toplevel)"
 
 # Tiered gate mode (#4259). LOOM_BUILD_GATE_TIER selects the stage set:

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -620,13 +620,17 @@ print_safehouse_status() {
     fi
 }
 
-# ---------- calibrate binding-ceiling hint (#4390) ----------
+# ---------- calibrate binding-ceiling hint (#4390, re-based on #4512) ----------
 # `loom-daemon calibrate` is purely file/host-based (no running daemon
 # required, unlike `status`), so it is safe to run right here at start time.
-# One advisory line, printed only when the configured
-# `autonomous.workFinder.maxConcurrent` ceiling is CURRENTLY the binding term
-# AND both the cpu and token axes have at least 2x headroom above it -- i.e.
-# this host is obviously bigger than the shipped default was sized for.
+# One advisory line, printed only when `autonomous.workFinder.maxConcurrent` is
+# CURRENTLY the binding term AND the host is measurably idle -- i.e. this machine
+# is under-subscribed at its current knob.
+#
+# #4512 changed the basis: calibrate no longer computes a *recommended* value
+# (the CPU-headroom term it derived one from is gone; maxConcurrent is now a
+# per-machine knob tuned empirically), so the hint reports the observed idle
+# fraction instead of a number to copy.
 # Never fatal: a missing jq, a calibrate error, or an unparseable payload all
 # fall through silently -- this is advisory-only, exactly like
 # print_safehouse_status above.
@@ -638,22 +642,25 @@ print_calibrate_hint() {
     calib_json="$("$DAEMON_BIN" calibrate --workspace "$REPO_ROOT" --json 2>/dev/null)" || return 0
     [[ -n "$calib_json" ]] || return 0
 
-    local binding ceiling cpu token_axis recommended
-    binding=$(jq -r '.recommendation.binding_term_before // empty' <<<"$calib_json" 2>/dev/null)
+    local binding ceiling idle idle_pct
+    binding=$(jq -r '.binding_term // empty' <<<"$calib_json" 2>/dev/null)
     [[ "$binding" == "ceiling" ]] || return 0
 
     ceiling=$(jq -r '.measurements.configured_max_concurrent // empty' <<<"$calib_json" 2>/dev/null)
-    cpu=$(jq -r '.measurements.cpu_headroom // empty' <<<"$calib_json" 2>/dev/null)
-    token_axis=$(jq -r '.measurements.token_axis_effective // empty' <<<"$calib_json" 2>/dev/null)
-    recommended=$(jq -r '.recommendation.recommended_max_concurrent // empty' <<<"$calib_json" 2>/dev/null)
+    # Integer percent so the comparison below is plain shell arithmetic; `null`
+    # (no idle sample on this host yet) yields an empty string and we bail.
+    idle=$(jq -r '.measurements.cpu_idle_fraction // empty' <<<"$calib_json" 2>/dev/null)
+    [[ -n "$idle" ]] || return 0
+    idle_pct=$(jq -rn --argjson f "$idle" '($f * 100) | floor' 2>/dev/null) || return 0
 
-    # Defensively require all four to be plain non-negative integers before
-    # doing shell arithmetic on them.
-    [[ "$ceiling" =~ ^[0-9]+$ && "$cpu" =~ ^[0-9]+$ && "$token_axis" =~ ^[0-9]+$ && "$recommended" =~ ^[0-9]+$ ]] || return 0
+    # Defensively require plain non-negative integers before shell arithmetic.
+    [[ "$ceiling" =~ ^[0-9]+$ && "$idle_pct" =~ ^[0-9]+$ ]] || return 0
     (( ceiling > 0 )) || return 0
 
-    if (( cpu >= 2 * ceiling )) && (( token_axis >= 2 * ceiling )); then
-        warn "ceiling ${ceiling} binds; this host could run ${recommended} -- run 'loom-daemon calibrate'"
+    # 50% idle mirrors calibrate::IDLE_HEADROOM_FRACTION -- the "grossly
+    # under-subscribed" bar (#4512's motivating host measured 95% idle at cap 2).
+    if (( idle_pct >= 50 )); then
+        warn "maxConcurrent ${ceiling} binds while the host is ${idle_pct}% idle -- consider raising autonomous.workFinder.maxConcurrent ('loom-daemon calibrate' for the full reading)"
     fi
 }
 

--- a/defaults/scripts/lib/build-slot.sh
+++ b/defaults/scripts/lib/build-slot.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# build-slot.sh — machine-wide build-slot lease for the genuinely CPU-heavy
+# sweep stages (#4512). Bash half of `loom-daemon/src/build_slot.rs`.
+#
+# Source this file (do not exec). It defines:
+#
+#   loom_build_slot_acquire [label]
+#       Take a machine-wide build slot, blocking at most
+#       LOOM_BUILD_SLOT_WAIT_SECS, then DEGRADING OPEN (returning success with no
+#       slot held) rather than blocking longer. Sets LOOM_BUILD_SLOT_PATH to the
+#       held lock dir (empty when none) and exports LOOM_BUILD_SLOT_HELD=1 for
+#       child processes so a nested acquire is a re-entrant no-op. Always
+#       returns 0 — a broken lock store must never fail a build.
+#
+#   loom_build_slot_release
+#       Release the slot taken by the last acquire (idempotent, safe in a trap).
+#
+# ---------------------------------------------------------------------------
+# Why this exists
+# ---------------------------------------------------------------------------
+# Until #4512, the daemon's admission formula carried a CPU term
+# (`estCoresPerSweep` × `cpuUtilizationTarget` minus live idle) that priced
+# EVERY sweep as if it were a build. Sweep wall-clock is dominated by API wait
+# (curator/builder/judge conversations), so that throttled the low-CPU majority
+# to defend against the heavy-build minority — an 8-core worker measured 95%
+# idle was capped at 2 concurrent sweeps. #4512 deleted the term and moved the
+# protection to where the load actually is: N sweeps run concurrently, but at
+# most LOOM_BUILD_SLOTS of them hold this slot while running `cargo
+# build`/`test` or the build gate.
+#
+# The protocol is `mkdir` (POSIX-atomic, and available on stock macOS unlike
+# `flock`), matching the token-pool lock and the per-issue claim lock. The slot
+# directory is MACHINE-WIDE — ~/.loom/locks/build-slot — deliberately not a
+# repo's .loom/locks: cores are one machine-level resource shared by every
+# workspace and every worktree on the host.
+#
+# ---------------------------------------------------------------------------
+# Safety properties (all three are load-bearing)
+# ---------------------------------------------------------------------------
+#   1. NEVER deadlocks — the wait is bounded; on expiry we proceed unserialized.
+#   2. Degrades OPEN on any lock-store failure (unwritable/missing dir).
+#   3. Re-entrant — LOOM_BUILD_SLOT_HELD short-circuits a nested acquire, so the
+#      daemon's main-health gate holding a slot around build-gate.sh does not
+#      make build-gate.sh wait on the slot its own parent holds.
+#
+# A slot is held for the duration of a build (minutes), so the stale-reap
+# threshold is deliberately long (LOOM_BUILD_SLOT_STALE_SECS, default 1h): an
+# mkdir lock carries no heartbeat, and a short threshold would let a peer reap a
+# perfectly healthy in-progress build. A crashed holder is covered by property 1.
+#
+# Constants (env-tunable; keep in lock-step with build_slot.rs):
+#   LOOM_BUILD_SLOTS            default 1     concurrent slots (0 disables)
+#   LOOM_BUILD_SLOT_WAIT_SECS   default 300   bounded wait before degrading open
+#   LOOM_BUILD_SLOT_STALE_SECS  default 3600  age at which a slot is reaped
+#   LOOM_BUILD_SLOT_DIR         default ~/.loom/locks/build-slot
+#   LOOM_BUILD_SLOT_HELD        re-entrancy sentinel (set by the holder)
+
+# Resolved lock dir currently held by this shell (empty = none).
+LOOM_BUILD_SLOT_PATH="${LOOM_BUILD_SLOT_PATH:-}"
+
+# Echo the machine-wide slot directory.
+loom_build_slot_dir() {
+    local dir="${LOOM_BUILD_SLOT_DIR:-}"
+    # Trim whitespace; an empty/blank override falls through to $HOME.
+    dir="${dir#"${dir%%[![:space:]]*}"}"
+    dir="${dir%"${dir##*[![:space:]]}"}"
+    if [[ -n "$dir" ]]; then
+        printf '%s\n' "$dir"
+        return 0
+    fi
+    printf '%s\n' "${HOME:-/tmp}/.loom/locks/build-slot"
+}
+
+# Echo a positive integer env value, or the given default when unset/invalid.
+_loom_build_slot_int() {
+    local raw="${1:-}" default="$2" allow_zero="${3:-0}"
+    if [[ "$raw" =~ ^[0-9]+$ ]]; then
+        if [[ "$raw" == "0" && "$allow_zero" != "1" ]]; then
+            printf '%s\n' "$default"
+        else
+            printf '%s\n' "$raw"
+        fi
+    else
+        printf '%s\n' "$default"
+    fi
+}
+
+# True when this shell (or an ancestor) already holds a slot.
+loom_build_slot_held() {
+    case "$(printf '%s' "${LOOM_BUILD_SLOT_HELD:-}" | tr '[:upper:]' '[:lower:]')" in
+        1 | true | yes | on) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Age of a path in whole seconds. An unreadable mtime echoes 0 (= "brand new"),
+# so a lock we cannot age is NEVER reaped — the conservative direction, matching
+# `MkdirLock::is_stale` in the Rust half.
+_loom_build_slot_age_secs() {
+    local path="$1" mtime now
+    # GNU `stat -c` first (it is an illegal option on BSD/macOS, so it fails
+    # cleanly there), then BSD `stat -f %m`. Note the reverse order would
+    # MISFIRE on GNU: `stat -f %m <path>` there means --file-system and prints a
+    # multi-line report rather than failing usefully.
+    mtime="$(stat -c %Y "$path" 2>/dev/null || true)"
+    if [[ ! "$mtime" =~ ^[0-9]+$ ]]; then
+        mtime="$(stat -f %m "$path" 2>/dev/null || true)"
+    fi
+    [[ "$mtime" =~ ^[0-9]+$ ]] || { echo 0; return 0; }
+    now="$(date +%s)"
+    if (( now > mtime )); then echo $(( now - mtime )); else echo 0; fi
+}
+
+# Try every slot once, without blocking. Echoes the acquired path on success.
+# Exit: 0 acquired, 1 all busy, 2 lock store unusable.
+_loom_build_slot_try_round() {
+    local dir="$1" slots="$2" stale="$3"
+    local i path busy=0 err=0
+    for (( i = 0; i < slots; i++ )); do
+        path="$dir/slot-$i"
+        if mkdir "$path" 2>/dev/null; then
+            printf '%s\n' "$path"
+            return 0
+        fi
+        if [[ -d "$path" ]]; then
+            if (( $(_loom_build_slot_age_secs "$path") > stale )); then
+                rmdir "$path" 2>/dev/null || true
+                if mkdir "$path" 2>/dev/null; then
+                    printf '%s\n' "$path"
+                    return 0
+                fi
+            fi
+            busy=$((busy + 1))
+        else
+            # mkdir failed and the path is not a directory ⇒ the store itself is
+            # unusable (no permission, missing parent, a FILE in the way).
+            err=1
+        fi
+    done
+    if (( busy == 0 && err == 1 )); then
+        return 2
+    fi
+    return 1
+}
+
+# Acquire a build slot. Always returns 0 (see the safety properties above).
+loom_build_slot_acquire() {
+    local label="${1:-build}"
+    LOOM_BUILD_SLOT_PATH=""
+
+    if loom_build_slot_held; then
+        echo "[build-slot] already inside a build slot (LOOM_BUILD_SLOT_HELD) — re-entrant no-op for '${label}'" >&2
+        return 0
+    fi
+
+    local slots wait_secs stale dir
+    slots="$(_loom_build_slot_int "${LOOM_BUILD_SLOTS:-}" 1 1)"
+    if [[ "$slots" == "0" ]]; then
+        echo "[build-slot] LOOM_BUILD_SLOTS=0 — build-slot serialization disabled for '${label}'" >&2
+        return 0
+    fi
+    wait_secs="$(_loom_build_slot_int "${LOOM_BUILD_SLOT_WAIT_SECS:-}" 300)"
+    stale="$(_loom_build_slot_int "${LOOM_BUILD_SLOT_STALE_SECS:-}" 3600)"
+    dir="$(loom_build_slot_dir)"
+
+    if ! mkdir -p "$dir" 2>/dev/null; then
+        echo "[build-slot] WARNING: slot dir ${dir} is unusable — proceeding WITHOUT a slot for '${label}' (degrading open)" >&2
+        return 0
+    fi
+
+    local start now path rc logged_wait=0
+    start="$(date +%s)"
+    while :; do
+        set +e
+        path="$(_loom_build_slot_try_round "$dir" "$slots" "$stale")"
+        rc=$?
+        set -e
+        if (( rc == 0 )); then
+            LOOM_BUILD_SLOT_PATH="$path"
+            export LOOM_BUILD_SLOT_HELD=1
+            now="$(date +%s)"
+            echo "[build-slot] acquired ${path} for '${label}' after $(( now - start ))s wait" >&2
+            return 0
+        fi
+        if (( rc == 2 )); then
+            echo "[build-slot] WARNING: slot lock under ${dir} is unusable — proceeding WITHOUT a slot for '${label}' (degrading open)" >&2
+            return 0
+        fi
+        if (( logged_wait == 0 )); then
+            echo "[build-slot] all ${slots} slot(s) busy — '${label}' waiting up to ${wait_secs}s" >&2
+            logged_wait=1
+        fi
+        now="$(date +%s)"
+        if (( now - start >= wait_secs )); then
+            echo "[build-slot] WARNING: all ${slots} slot(s) still busy after ${wait_secs}s — proceeding WITHOUT a slot for '${label}' (degrading open; high-CPU stages are not serialized this run)" >&2
+            return 0
+        fi
+        sleep 1
+    done
+}
+
+# Release the slot held by this shell. Idempotent; safe to call from a trap.
+loom_build_slot_release() {
+    if [[ -n "${LOOM_BUILD_SLOT_PATH:-}" ]]; then
+        rmdir "$LOOM_BUILD_SLOT_PATH" 2>/dev/null || true
+        echo "[build-slot] released ${LOOM_BUILD_SLOT_PATH}" >&2
+        LOOM_BUILD_SLOT_PATH=""
+        unset LOOM_BUILD_SLOT_HELD
+    fi
+    return 0
+}

--- a/defaults/scripts/tests/test-build-slot.sh
+++ b/defaults/scripts/tests/test-build-slot.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# test-build-slot.sh — Tests for the machine-wide build-slot lease (#4512)
+#
+# Covers defaults/scripts/lib/build-slot.sh, the Bash half of the cross-process
+# lock that replaced the CPU-headroom admission term:
+#
+#   1. acquire/release round-trip — the slot lock dir appears and disappears.
+#   2. serialization — a second acquire cannot take the only slot.
+#   3. BOUNDED WAIT + DEGRADE OPEN — a contended acquire returns 0 with no slot
+#      after the bound instead of blocking forever (the "never a deadlock" AC).
+#   4. degrade open when the lock store is unusable (a FILE where the slot dir
+#      should be).
+#   5. LOOM_BUILD_SLOTS=0 disables serialization entirely.
+#   6. multi-slot budget — 2 slots admit 2 holders, refuse the 3rd.
+#   7. stale reaping — an abandoned slot older than the threshold is reclaimed.
+#   8. re-entrancy — LOOM_BUILD_SLOT_HELD makes a nested acquire a no-op.
+#   9. path shape parity with `loom_daemon::build_slot::slot_path` ("$dir/slot-N").
+#
+# Style follows test-disk-headroom.sh: throwaway mktemp dirs, assert harness,
+# no network, no real ~/.loom.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_SLOT_LIB="$SCRIPTS_DIR/lib/build-slot.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_eq() {
+    if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 (expected '$2', got '$1')"; fi
+}
+assert_true() { if [[ "$1" == "0" ]]; then pass "$2"; else fail "$2 (expected success, got rc=$1)"; fi; }
+
+# NOTE on the `( … ) && CASE_RC=0 || CASE_RC=$?` idiom below: every case runs in
+# a subshell so its env exports (LOOM_BUILD_SLOT_DIR/HELD) cannot leak into the
+# next one, and the rc is captured explicitly so a FAILING case reports as a test
+# failure instead of aborting the whole suite under `set -e`.
+
+# shellcheck source=../lib/build-slot.sh
+source "$BUILD_SLOT_LIB"
+
+TMPROOT="$(mktemp -d)"
+cleanup() { rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+
+# Every test gets a fresh slot dir and a fast bound so the suite stays quick.
+new_slot_dir() {
+    local d
+    d="$(mktemp -d "$TMPROOT/slots.XXXXXX")"
+    printf '%s\n' "$d/build-slot"
+}
+
+export LOOM_BUILD_SLOT_WAIT_SECS=1
+unset LOOM_BUILD_SLOT_HELD || true
+
+echo ""
+echo "=== build-slot.sh: acquire / release round-trip ==="
+
+DIR="$(new_slot_dir)"
+(
+    export LOOM_BUILD_SLOT_DIR="$DIR"
+    rc=0
+    loom_build_slot_acquire "unit" >/dev/null 2>&1 || rc=$?
+    [[ "$rc" == "0" ]] || exit 1
+    [[ -n "$LOOM_BUILD_SLOT_PATH" ]] || exit 2
+    [[ -d "$LOOM_BUILD_SLOT_PATH" ]] || exit 3
+    [[ "$LOOM_BUILD_SLOT_HELD" == "1" ]] || exit 4
+    loom_build_slot_release >/dev/null 2>&1
+    [[ -d "$DIR/slot-0" ]] && exit 5
+    exit 0
+) && CASE_RC=0 || CASE_RC=$?
+assert_true "$CASE_RC" "acquire creates slot-0 + exports LOOM_BUILD_SLOT_HELD; release removes it"
+
+echo ""
+echo "=== build-slot.sh: serialization + bounded wait (never a deadlock) ==="
+
+DIR="$(new_slot_dir)"
+mkdir -p "$DIR"
+# Simulate a live holder by taking slot-0 directly (fresh mtime ⇒ not stale).
+mkdir "$DIR/slot-0"
+START="$(date +%s)"
+(
+    export LOOM_BUILD_SLOT_DIR="$DIR"
+    rc=0
+    OUT="$(loom_build_slot_acquire "contended" 2>&1)" || rc=$?
+    # Must SUCCEED (degrade open), hold no slot, and say why.
+    [[ "$rc" == "0" ]] || exit 1
+    [[ -z "$LOOM_BUILD_SLOT_PATH" ]] || exit 2
+    grep -q "waiting up to" <<<"$OUT" || exit 3
+    grep -q "degrading open" <<<"$OUT" || exit 4
+    # It must NOT have claimed to cover children (that would let a nested
+    # acquire skip a slot it never took).
+    [[ -z "${LOOM_BUILD_SLOT_HELD:-}" ]] || exit 5
+    exit 0
+) && RC=0 || RC=$?
+ELAPSED=$(( $(date +%s) - START ))
+assert_true "$RC" "a contended acquire waits the bound, then degrades open (rc=0, no slot, telemetry)"
+if (( ELAPSED >= 1 && ELAPSED < 15 )); then
+    pass "the wait is bounded (${ELAPSED}s, bound 1s) — no deadlock"
+else
+    fail "the wait was not bounded as expected (${ELAPSED}s)"
+fi
+rmdir "$DIR/slot-0"
+
+echo ""
+echo "=== build-slot.sh: degrades open when the lock store is unusable ==="
+
+DIR="$(new_slot_dir)"
+# A FILE where the slot directory should be ⇒ mkdir -p fails.
+printf 'x' > "$DIR"
+(
+    export LOOM_BUILD_SLOT_DIR="$DIR"
+    rc=0
+    OUT="$(loom_build_slot_acquire "broken-store" 2>&1)" || rc=$?
+    [[ "$rc" == "0" ]] || exit 1
+    [[ -z "$LOOM_BUILD_SLOT_PATH" ]] || exit 2
+    grep -q "unusable" <<<"$OUT" || exit 3
+    exit 0
+) && CASE_RC=0 || CASE_RC=$?
+assert_true "$CASE_RC" "an unusable slot dir degrades open (never a failure, never a spin)"
+
+echo ""
+echo "=== build-slot.sh: LOOM_BUILD_SLOTS=0 disables serialization ==="
+
+DIR="$(new_slot_dir)"
+(
+    export LOOM_BUILD_SLOT_DIR="$DIR" LOOM_BUILD_SLOTS=0
+    rc=0
+    OUT="$(loom_build_slot_acquire "opted-out" 2>&1)" || rc=$?
+    [[ "$rc" == "0" ]] || exit 1
+    [[ -z "$LOOM_BUILD_SLOT_PATH" ]] || exit 2
+    grep -q "disabled" <<<"$OUT" || exit 3
+    [[ -e "$DIR" ]] && exit 4   # must not even create the dir
+    exit 0
+) && CASE_RC=0 || CASE_RC=$?
+assert_true "$CASE_RC" "LOOM_BUILD_SLOTS=0 opts out cleanly (no dir, no slot, rc=0)"
+
+echo ""
+echo "=== build-slot.sh: multi-slot budget ==="
+
+DIR="$(new_slot_dir)"
+mkdir -p "$DIR"
+mkdir "$DIR/slot-0"    # holder A
+(
+    export LOOM_BUILD_SLOT_DIR="$DIR" LOOM_BUILD_SLOTS=2
+    rc=0
+    loom_build_slot_acquire "second-of-two" >/dev/null 2>&1 || rc=$?
+    [[ "$rc" == "0" ]] || exit 1
+    [[ "$LOOM_BUILD_SLOT_PATH" == "$DIR/slot-1" ]] || exit 2
+    exit 0
+) && CASE_RC=0 || CASE_RC=$?
+assert_true "$CASE_RC" "with 2 slots, a second holder takes slot-1"
+
+# The subshell above exited WITHOUT releasing (no trap), exactly like a crashed
+# holder, so slot-1 is still held here — that is the state the third holder must
+# face. Both slots are now occupied.
+[[ -d "$DIR/slot-1" ]] || fail "slot-1 should still be held by the previous (unreleased) holder"
+(
+    export LOOM_BUILD_SLOT_DIR="$DIR" LOOM_BUILD_SLOTS=2
+    rc=0
+    loom_build_slot_acquire "third-of-two" >/dev/null 2>&1 || rc=$?
+    [[ "$rc" == "0" ]] || exit 1
+    [[ -z "$LOOM_BUILD_SLOT_PATH" ]] || exit 2
+    exit 0
+) && CASE_RC=0 || CASE_RC=$?
+assert_true "$CASE_RC" "with 2 slots, a third holder gets none (degrades open after the bound)"
+rmdir "$DIR/slot-0" "$DIR/slot-1"
+
+echo ""
+echo "=== build-slot.sh: stale slot from a crashed holder is reaped ==="
+
+DIR="$(new_slot_dir)"
+mkdir -p "$DIR"
+mkdir "$DIR/slot-0"
+sleep 1   # let its mtime age past the 0-second-ish threshold below
+(
+    export LOOM_BUILD_SLOT_DIR="$DIR" LOOM_BUILD_SLOT_STALE_SECS=1
+    rc=0
+    loom_build_slot_acquire "after-crash" >/dev/null 2>&1 || rc=$?
+    [[ "$rc" == "0" ]] || exit 1
+    [[ "$LOOM_BUILD_SLOT_PATH" == "$DIR/slot-0" ]] || exit 2
+    exit 0
+) && CASE_RC=0 || CASE_RC=$?
+assert_true "$CASE_RC" "a slot older than LOOM_BUILD_SLOT_STALE_SECS is reclaimed"
+
+echo ""
+echo "=== build-slot.sh: re-entrancy ==="
+
+DIR="$(new_slot_dir)"
+(
+    export LOOM_BUILD_SLOT_DIR="$DIR" LOOM_BUILD_SLOT_HELD=1
+    rc=0
+    OUT="$(loom_build_slot_acquire "nested" 2>&1)" || rc=$?
+    [[ "$rc" == "0" ]] || exit 1
+    [[ -z "$LOOM_BUILD_SLOT_PATH" ]] || exit 2
+    grep -q "re-entrant" <<<"$OUT" || exit 3
+    [[ -e "$DIR/slot-0" ]] && exit 4
+    exit 0
+) && CASE_RC=0 || CASE_RC=$?
+assert_true "$CASE_RC" "LOOM_BUILD_SLOT_HELD=1 makes a nested acquire a no-op (no second slot taken)"
+
+echo ""
+echo "=== build-slot.sh: cross-language path shape parity ==="
+
+DIR="$(new_slot_dir)"
+(
+    export LOOM_BUILD_SLOT_DIR="$DIR"
+    loom_build_slot_acquire "shape" >/dev/null 2>&1
+    # `loom_daemon::build_slot::slot_path` composes exactly "$dir/slot-$i"; a
+    # divergence here silently stops the daemon gate and the sweep-side gate
+    # from serializing against each other.
+    [[ "$LOOM_BUILD_SLOT_PATH" == "$DIR/slot-0" ]] || exit 1
+    loom_build_slot_release >/dev/null 2>&1
+    exit 0
+) && CASE_RC=0 || CASE_RC=$?
+assert_true "$CASE_RC" "slot path is \$dir/slot-N, matching build_slot.rs"
+
+assert_eq "$(LOOM_BUILD_SLOT_DIR="/tmp/x" loom_build_slot_dir)" "/tmp/x" \
+    "LOOM_BUILD_SLOT_DIR overrides the default location"
+assert_eq "$(LOOM_BUILD_SLOT_DIR="   " HOME=/h loom_build_slot_dir)" "/h/.loom/locks/build-slot" \
+    "a blank override falls back to the machine-wide ~/.loom/locks/build-slot"
+
+echo ""
+echo "=== build-gate.sh sources the helper ==="
+if grep -q "lib/build-slot.sh" "$SCRIPTS_DIR/build-gate.sh"; then
+    pass "build-gate.sh sources lib/build-slot.sh (the designated high-CPU stage)"
+else
+    fail "build-gate.sh no longer takes a build slot — the #4512 serialization point is gone"
+fi
+
+echo ""
+echo "==============================================="
+echo "  Tests run:    $TESTS_RUN"
+echo -e "  ${GREEN}Passed:${NC}       $TESTS_PASSED"
+echo -e "  ${RED}Failed:${NC}       $TESTS_FAILED"
+echo "==============================================="
+
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/docs/measure-est-cores-per-sweep.md
+++ b/docs/measure-est-cores-per-sweep.md
@@ -1,6 +1,41 @@
-# Measuring `LOOM_EST_CORES_PER_SWEEP`
+# Measuring `LOOM_EST_CORES_PER_SWEEP` (HISTORICAL — the knob it tunes was retired in #4512)
 
-`LOOM_EST_CORES_PER_SWEEP` is the one hand-tuned constant left in the daemon's
+> **⚠️ This document is historical. Do not follow it as current guidance.**
+>
+> **#4512 deleted the CPU-headroom term from the daemon's admission formula.**
+> `resolve_dynamic_max_concurrent` is now `min(token axis, disk headroom,
+> configured maxConcurrent)` — there is no CPU estimate in it, and therefore
+> nothing for `LOOM_EST_CORES_PER_SWEEP` (or `LOOM_CPU_UTILIZATION_TARGET`) to
+> tune. Both knobs, and their `autonomous.estCoresPerSweep` /
+> `autonomous.cpuUtilizationTarget` config twins, are **accepted but ignored**;
+> the daemon logs one deprecation warning per process
+> (`work_finder::warn_deprecated_cpu_knobs`) naming any that are still set.
+> Measuring a value and setting it will change nothing.
+>
+> **What to do instead:**
+>
+> 1. **Tune `autonomous.workFinder.maxConcurrent` empirically.** It is the one
+>    per-machine admission knob. Run `loom-daemon calibrate` (measurement-only
+>    since #4512) or read `loom-daemon status`: if the cap binds on `ceiling`
+>    while the host sits idle, raise it; if it binds on `token`/`disk`, raising
+>    it changes nothing.
+> 2. **Rely on the machine-wide build slot for the heavy stages.** `cargo
+>    build`/`test` and the build gate take a `mkdir`-atomic slot
+>    (`LOOM_BUILD_SLOTS`, default 1) so at most one or two builds run
+>    concurrently on a host regardless of how many sweeps are admitted. This is
+>    what the per-sweep core estimate was a (poor) proxy for.
+> 3. **Trust the host-distress circuit breaker (#4235)** as the safety net — it
+>    trips on *measured* load-per-core rather than an estimated constant.
+>
+> See `defaults/docs/daemon-reference.md` → *Why there is no CPU term in
+> admission (#4512)* and *Machine-wide build slot (#4512)*.
+>
+> The rest of this file is retained only as a record of how the retired constant
+> was intended to be measured, and because the marginal-cores-per-sweep
+> methodology is still a reasonable way to characterize a host before picking a
+> `maxConcurrent`.
+
+`LOOM_EST_CORES_PER_SWEEP` was the one hand-tuned constant left in the daemon's
 CPU-headroom term (`loom-daemon/src/cpu_headroom.rs`). It estimates how many CPU
 cores a **single** concurrent sweep consumes while its build/test step is
 running. The headroom term is:

--- a/loom-daemon/src/build_slot.rs
+++ b/loom-daemon/src/build_slot.rs
@@ -1,0 +1,826 @@
+//! Machine-wide **build slot** — serializes the rare, genuinely CPU-heavy
+//! stages of a sweep instead of throttling every sweep's admission (#4512).
+//!
+//! # Why this exists (and what it replaced)
+//!
+//! Admission used to carry a CPU term: the dynamic concurrency cap included
+//! `cpu_headroom = (logical_cpus × cpuUtilizationTarget − consumed_cores) /
+//! estCoresPerSweep` (#3978/#4031). That priced **every** sweep as if it were
+//! a build. The issue→PR pipeline is dominated by API-wait (curator / builder /
+//! judge conversations); the sustained-heavy-CPU phases (release builds, full
+//! test suites, the build gate) are a small fraction of wall-clock. So the term
+//! throttled the ~90% low-CPU majority to defend against the minority case —
+//! measurably so: an 8-core worker sitting **95% idle** was capped at 2
+//! concurrent sweeps (#4512's evidence).
+//!
+//! #4512 deleted the CPU term from admission
+//! ([`crate::work_finder::resolve_dynamic_max_concurrent`] is now `min(token
+//! axis, disk headroom, configured maxConcurrent)`) and moved the protection
+//! **to where the load actually is**: N sweeps run concurrently, but at most
+//! [`DEFAULT_BUILD_SLOTS`] of them hold the build slot at any moment, so the
+//! heavy stages serialize while the rest of every sweep's lifecycle never
+//! queues. This is the bounded revival of #4003's "agents check out a slot only
+//! for bound work".
+//!
+//! # Shape: the same `mkdir`-atomic lock as the worktree / claim locks
+//!
+//! A slot is a lock **directory** created with `mkdir` (POSIX-atomic, works
+//! across processes *and* across languages — the Bash half of this,
+//! `defaults/scripts/lib/build-slot.sh`, implements the identical protocol so
+//! `build-gate.sh` in a sweep worktree serializes against the daemon's own
+//! gate). The primitive is [`MkdirLock`], the same one the token-pool state
+//! files and the per-issue claim lock (`.loom/locks/issue-<N>`) use; `flock` is
+//! deliberately avoided (unavailable on stock macOS).
+//!
+//! Slots live **machine-wide** at `~/.loom/locks/build-slot/slot-<i>` (override
+//! with [`BUILD_SLOT_DIR_ENV`]) — deliberately *not* under a repo's
+//! `.loom/locks/`: the host's cores are one machine-level resource shared by
+//! every workspace the daemon manages, and #4512's operator note asked
+//! explicitly for **one unambiguous home** for machine-tier concurrency state
+//! rather than a per-workspace tier.
+//!
+//! # Three hard safety properties
+//!
+//! 1. **Never deadlocks.** [`acquire`] waits at most
+//!    [`DEFAULT_BUILD_SLOT_WAIT_SECS`] and then **degrades open** — it returns
+//!    a lease that holds no slot and lets the caller run unserialized. A slow
+//!    or crashed holder therefore costs throughput, never liveness.
+//! 2. **Degrades open on any lock-store failure.** An unwritable / missing /
+//!    permission-denied lock directory yields
+//!    [`LeaseKind::DegradedOpen`] immediately — no spinning, no error
+//!    propagation to the caller.
+//! 3. **Re-entrant.** A holder exports [`BUILD_SLOT_HELD_ENV`] into its child
+//!    environment, so a nested acquire (the daemon's main-health gate holding
+//!    the slot around `build-gate.sh`, which then tries to take it too) is a
+//!    logged no-op instead of a self-inflicted wait.
+//!
+//! Because a slot is held for the *duration of a build* (minutes), the stale
+//! reaping threshold is deliberately long ([`DEFAULT_STALE_SLOT_SECS`], 1h) —
+//! `mkdir` locks carry no heartbeat, and a 30s threshold (the token-pool
+//! default) would let a peer reap a perfectly healthy in-progress build. A
+//! crashed holder is covered by property 1 (bounded wait → degrade open), not
+//! by aggressive reaping.
+//!
+//! # Telemetry
+//!
+//! Every state transition is logged once: `info` on acquire (naming the slot
+//! and how long it waited), `info` on the first wait of a round (so a queue is
+//! visible), `info` on release with the hold duration, and `warn` on
+//! degrade-open (naming *why*). The host-distress circuit breaker (#4235)
+//! remains the load safety net that makes a hand-tuned `maxConcurrent` safe:
+//! a mis-set knob trips the breaker — measured — instead of melting the host.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use crate::tokens_pool::locking::MkdirLock;
+
+// ============================================================================
+// Configuration (env-only, like `LOOM_PER_WORKTREE_GB`)
+// ============================================================================
+//
+// Env-only on purpose. The Bash half (`defaults/scripts/lib/build-slot.sh`,
+// sourced by `build-gate.sh` inside a sweep worktree) must resolve exactly the
+// same values as the daemon, and `disk_headroom`'s `LOOM_PER_WORKTREE_GB` set
+// the precedent (#4032 decision): a knob with an independent Bash-side reader
+// stays env-only rather than honoring `.loom/config.json` on one path and
+// silently ignoring it on the other. A repo that wants a different slot count
+// exports it from the daemon's start environment.
+
+/// Number of concurrent build slots on this machine. `0` disables build-slot
+/// serialization entirely (every acquire degrades open) — the exact pre-#4512
+/// behavior for an operator who wants it back.
+pub const BUILD_SLOTS_ENV: &str = "LOOM_BUILD_SLOTS";
+
+/// Default build-slot count: **1**. The heavy stages (`cargo build`/`test`, the
+/// build gate) parallelize across essentially every core on their own, so one
+/// at a time is the point — #4512 allows "at most 1–2", and 1 is the
+/// conservative end.
+pub const DEFAULT_BUILD_SLOTS: usize = 1;
+
+/// Bounded wait for a slot, in seconds. On expiry the acquire **degrades open**
+/// (never blocks longer, never fails).
+pub const BUILD_SLOT_WAIT_SECS_ENV: &str = "LOOM_BUILD_SLOT_WAIT_SECS";
+
+/// Default bounded wait: 300s. Long enough to actually serialize behind a
+/// typical build-gate run, short enough that a wedged holder costs one build's
+/// worth of throughput rather than stalling a sweep indefinitely.
+pub const DEFAULT_BUILD_SLOT_WAIT_SECS: u64 = 300;
+
+/// Age (seconds) at which a slot lock directory is considered abandoned and is
+/// reaped. Deliberately long — see the module docs.
+pub const BUILD_SLOT_STALE_SECS_ENV: &str = "LOOM_BUILD_SLOT_STALE_SECS";
+
+/// Default stale-slot threshold: 1h.
+pub const DEFAULT_STALE_SLOT_SECS: u64 = 3600;
+
+/// Override for the machine-wide slot directory (default
+/// `~/.loom/locks/build-slot`). Primarily a test seam; also lets an operator
+/// relocate the slots onto a specific filesystem.
+pub const BUILD_SLOT_DIR_ENV: &str = "LOOM_BUILD_SLOT_DIR";
+
+/// Re-entrancy sentinel exported into a slot holder's child environment. When
+/// set to a truthy value, [`acquire`] is a logged no-op — the caller is already
+/// running inside a slot.
+pub const BUILD_SLOT_HELD_ENV: &str = "LOOM_BUILD_SLOT_HELD";
+
+/// How often to re-probe the slots while waiting.
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Resolve the slot count from [`BUILD_SLOTS_ENV`], falling back to
+/// [`DEFAULT_BUILD_SLOTS`]. An unparseable value falls back to the default; an
+/// explicit `0` is honored (serialization disabled).
+#[must_use]
+pub fn resolve_slots() -> usize {
+    std::env::var(BUILD_SLOTS_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_BUILD_SLOTS)
+}
+
+/// Resolve the bounded wait from [`BUILD_SLOT_WAIT_SECS_ENV`].
+#[must_use]
+pub fn resolve_wait() -> Duration {
+    Duration::from_secs(
+        std::env::var(BUILD_SLOT_WAIT_SECS_ENV)
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .unwrap_or(DEFAULT_BUILD_SLOT_WAIT_SECS),
+    )
+}
+
+/// Resolve the stale-slot threshold from [`BUILD_SLOT_STALE_SECS_ENV`].
+#[must_use]
+pub fn resolve_stale() -> Duration {
+    Duration::from_secs(
+        std::env::var(BUILD_SLOT_STALE_SECS_ENV)
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .filter(|&s| s > 0)
+            .unwrap_or(DEFAULT_STALE_SLOT_SECS),
+    )
+}
+
+/// Whether this process is already running inside a build slot (a truthy
+/// [`BUILD_SLOT_HELD_ENV`]).
+#[must_use]
+pub fn is_held_here() -> bool {
+    std::env::var(BUILD_SLOT_HELD_ENV).is_ok_and(|v| {
+        matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on")
+    })
+}
+
+/// The machine-wide slot directory: [`BUILD_SLOT_DIR_ENV`] when set, else
+/// `~/.loom/locks/build-slot`. `None` when neither is resolvable (no home
+/// directory) — the caller degrades open.
+#[must_use]
+pub fn slot_dir() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var(BUILD_SLOT_DIR_ENV) {
+        let trimmed = dir.trim();
+        if !trimmed.is_empty() {
+            return Some(PathBuf::from(trimmed));
+        }
+    }
+    Some(
+        dirs::home_dir()?
+            .join(".loom")
+            .join("locks")
+            .join("build-slot"),
+    )
+}
+
+// ============================================================================
+// The lease
+// ============================================================================
+
+/// What a [`BuildSlotLease`] actually obtained — the telemetry-bearing outcome.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LeaseKind {
+    /// A slot was acquired (0-based index) after waiting `waited`.
+    Held { slot: usize, waited: Duration },
+    /// This process is already inside a slot ([`BUILD_SLOT_HELD_ENV`]) — the
+    /// acquire was a no-op and nothing is released on drop.
+    Reentrant,
+    /// No slot is held and the caller should proceed **unserialized**. `reason`
+    /// names why (disabled, lock store unusable, or the bounded wait expired).
+    DegradedOpen { reason: String },
+}
+
+impl LeaseKind {
+    /// A stable one-word identifier for logs/metrics.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Held { .. } => "held",
+            Self::Reentrant => "reentrant",
+            Self::DegradedOpen { .. } => "degraded-open",
+        }
+    }
+}
+
+/// RAII lease on a machine-wide build slot. Release (`rmdir`) happens on drop,
+/// including on panic/early-return, so a slot is never leaked by a control-flow
+/// path the caller forgot about.
+///
+/// Construction **never fails**: every failure mode collapses into
+/// [`LeaseKind::DegradedOpen`], because refusing to run a build because the
+/// lock store is broken would be strictly worse than running it unserialized.
+pub struct BuildSlotLease {
+    kind: LeaseKind,
+    /// The held lock, if any. Dropping it removes the slot directory.
+    lock: Option<MkdirLock>,
+    /// Label of the stage holding the slot, for the release log line.
+    label: String,
+    /// When the slot was acquired, for the hold-duration log line.
+    acquired_at: Instant,
+}
+
+impl BuildSlotLease {
+    /// The outcome of the acquire.
+    #[must_use]
+    pub fn kind(&self) -> &LeaseKind {
+        &self.kind
+    }
+
+    /// Whether this lease actually holds a slot (`false` for a re-entrant or
+    /// degraded-open lease). Callers use this to decide whether to export
+    /// [`BUILD_SLOT_HELD_ENV`] to children.
+    #[must_use]
+    pub fn holds_slot(&self) -> bool {
+        matches!(self.kind, LeaseKind::Held { .. })
+    }
+
+    /// The 0-based index of the held slot, or `None` when no slot is held.
+    #[must_use]
+    pub fn slot_index(&self) -> Option<usize> {
+        match self.kind {
+            LeaseKind::Held { slot, .. } => Some(slot),
+            _ => None,
+        }
+    }
+
+    /// Whether children of this process are already covered by a slot — true
+    /// when this lease holds one **or** an ancestor already did. Children get
+    /// [`BUILD_SLOT_HELD_ENV`] set exactly when this is true, which is what
+    /// makes nested acquires no-ops rather than self-waits.
+    #[must_use]
+    pub fn covers_children(&self) -> bool {
+        matches!(self.kind, LeaseKind::Held { .. } | LeaseKind::Reentrant)
+    }
+
+    fn degraded(label: &str, reason: String, warn: bool) -> Self {
+        if warn {
+            log::warn!(
+                "build_slot: proceeding WITHOUT a slot for '{label}' — {reason} \
+                 (degrading open: high-CPU stages are not serialized this run)"
+            );
+        } else {
+            log::debug!("build_slot: no slot needed for '{label}' — {reason}");
+        }
+        Self {
+            kind: LeaseKind::DegradedOpen { reason },
+            lock: None,
+            label: label.to_string(),
+            acquired_at: Instant::now(),
+        }
+    }
+}
+
+impl Drop for BuildSlotLease {
+    fn drop(&mut self) {
+        if let LeaseKind::Held { slot, .. } = self.kind {
+            // Drop the lock first so the slot is free before we log the release.
+            self.lock = None;
+            log::info!(
+                "build_slot: released slot {slot} after {:.1}s ('{}')",
+                self.acquired_at.elapsed().as_secs_f64(),
+                self.label
+            );
+        }
+    }
+}
+
+// ============================================================================
+// acquire
+// ============================================================================
+
+/// Acquire a machine-wide build slot for `label`, resolving every knob from the
+/// environment. Blocks for at most [`resolve_wait`], then degrades open.
+///
+/// **Blocking** — call from a synchronous context (or `spawn_blocking`), never
+/// inline on a tokio runtime worker.
+#[must_use]
+pub fn acquire(label: &str) -> BuildSlotLease {
+    if is_held_here() {
+        log::debug!(
+            "build_slot: '{label}' is already inside a build slot ({BUILD_SLOT_HELD_ENV} is set) \
+             — re-entrant no-op"
+        );
+        return BuildSlotLease {
+            kind: LeaseKind::Reentrant,
+            lock: None,
+            label: label.to_string(),
+            acquired_at: Instant::now(),
+        };
+    }
+    let slots = resolve_slots();
+    if slots == 0 {
+        return BuildSlotLease::degraded(
+            label,
+            format!("{BUILD_SLOTS_ENV}=0 disables build-slot serialization"),
+            false,
+        );
+    }
+    let Some(dir) = slot_dir() else {
+        return BuildSlotLease::degraded(
+            label,
+            format!("no home directory to resolve the slot dir (set {BUILD_SLOT_DIR_ENV})"),
+            true,
+        );
+    };
+    acquire_in(&dir, slots, resolve_wait(), POLL_INTERVAL, resolve_stale(), label)
+}
+
+/// [`acquire`] with every input injected — the testable core (no env reads, no
+/// `$HOME`, caller-chosen timings so a test never waits seconds).
+#[must_use]
+pub fn acquire_in(
+    dir: &Path,
+    slots: usize,
+    wait: Duration,
+    poll: Duration,
+    stale: Duration,
+    label: &str,
+) -> BuildSlotLease {
+    if slots == 0 {
+        return BuildSlotLease::degraded(label, "slot count is 0".to_string(), false);
+    }
+    if let Err(e) = std::fs::create_dir_all(dir) {
+        return BuildSlotLease::degraded(
+            label,
+            format!("slot dir {} is unusable: {e}", dir.display()),
+            true,
+        );
+    }
+
+    let started = Instant::now();
+    let deadline = started + wait;
+    let mut logged_wait = false;
+    loop {
+        match try_round(dir, slots, stale) {
+            Ok(Some((slot, lock))) => {
+                let waited = started.elapsed();
+                log::info!(
+                    "build_slot: acquired slot {slot}/{slots} for '{label}' after {:.1}s wait \
+                     ({})",
+                    waited.as_secs_f64(),
+                    dir.display()
+                );
+                return BuildSlotLease {
+                    kind: LeaseKind::Held { slot, waited },
+                    lock: Some(lock),
+                    label: label.to_string(),
+                    acquired_at: Instant::now(),
+                };
+            }
+            Ok(None) => {}
+            Err(e) => {
+                // The lock store itself is broken (permissions, vanished
+                // parent). Spinning cannot fix that — degrade open now.
+                return BuildSlotLease::degraded(
+                    label,
+                    format!("slot lock at {} is unusable: {e}", dir.display()),
+                    true,
+                );
+            }
+        }
+        if !logged_wait {
+            log::info!(
+                "build_slot: all {slots} slot(s) busy — '{label}' waiting up to {}s for a slot",
+                wait.as_secs()
+            );
+            logged_wait = true;
+        }
+        if Instant::now() >= deadline {
+            return BuildSlotLease::degraded(
+                label,
+                format!(
+                    "all {slots} slot(s) still busy after the {}s bounded wait",
+                    wait.as_secs()
+                ),
+                true,
+            );
+        }
+        std::thread::sleep(poll.min(deadline.saturating_duration_since(Instant::now())));
+    }
+}
+
+/// One non-blocking pass over every slot. `Ok(None)` = all busy; `Err` = the
+/// lock store is unusable (the caller degrades open instead of spinning).
+fn try_round(
+    dir: &Path,
+    slots: usize,
+    stale: Duration,
+) -> Result<Option<(usize, MkdirLock)>, String> {
+    let mut busy = 0usize;
+    let mut last_err = None;
+    for slot in 0..slots {
+        match MkdirLock::try_acquire(&slot_path(dir, slot), stale) {
+            Ok(Some(lock)) => return Ok(Some((slot, lock))),
+            Ok(None) => busy += 1,
+            Err(e) => last_err = Some(e),
+        }
+    }
+    // Report the store as broken only when NOT ONE slot was merely busy — a
+    // single odd slot path must not mask an otherwise healthy, contended set
+    // (that case is a normal wait, which the bounded wait already handles).
+    if busy == 0 {
+        if let Some(e) = last_err {
+            return Err(e);
+        }
+    }
+    Ok(None)
+}
+
+/// The lock path for slot `i` under `dir`.
+#[must_use]
+pub fn slot_path(dir: &Path, i: usize) -> PathBuf {
+    dir.join(format!("slot-{i}"))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn fast(dir: &Path, slots: usize, label: &str) -> BuildSlotLease {
+        acquire_in(
+            dir,
+            slots,
+            Duration::from_millis(120),
+            Duration::from_millis(10),
+            Duration::from_secs(3600),
+            label,
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // acquire / release
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn acquires_a_slot_and_releases_it_on_drop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("build-slot");
+        {
+            let lease = fast(&dir, 1, "cargo-test");
+            assert!(lease.holds_slot(), "an idle machine must hand out a slot");
+            assert_eq!(lease.kind().as_str(), "held");
+            assert!(slot_path(&dir, 0).is_dir(), "the slot lock dir must exist while held");
+            assert!(lease.covers_children());
+        }
+        assert!(!slot_path(&dir, 0).exists(), "the slot must be released on drop");
+    }
+
+    #[test]
+    fn creates_the_slot_dir_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("deep").join("nested").join("build-slot");
+        let lease = fast(&dir, 1, "gate");
+        assert!(lease.holds_slot());
+        assert!(dir.is_dir());
+    }
+
+    // ------------------------------------------------------------------
+    // serialization: a second acquire waits, then degrades open (never
+    // deadlocks) — AC "bounded wait + telemetry, never a deadlock"
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn second_acquire_waits_then_degrades_open_instead_of_blocking_forever() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("build-slot");
+        let _held = fast(&dir, 1, "first-build");
+
+        let start = Instant::now();
+        let second = fast(&dir, 1, "second-build");
+        let elapsed = start.elapsed();
+
+        assert!(!second.holds_slot(), "the single slot is taken");
+        match second.kind() {
+            LeaseKind::DegradedOpen { reason } => {
+                assert!(reason.contains("bounded wait"), "reason should name the bound: {reason}");
+            }
+            other => panic!("expected a degraded-open lease, got {other:?}"),
+        }
+        assert!(
+            elapsed >= Duration::from_millis(100),
+            "must actually wait the bound: {elapsed:?}"
+        );
+        assert!(elapsed < Duration::from_secs(5), "must not block indefinitely: {elapsed:?}");
+    }
+
+    #[test]
+    fn releasing_lets_the_next_waiter_in() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("build-slot");
+        {
+            let first = fast(&dir, 1, "first");
+            assert!(first.holds_slot());
+        }
+        let second = fast(&dir, 1, "second");
+        assert!(second.holds_slot(), "a released slot must be immediately reusable");
+    }
+
+    #[test]
+    fn multiple_slots_admit_that_many_concurrent_holders() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("build-slot");
+        let a = fast(&dir, 2, "a");
+        let b = fast(&dir, 2, "b");
+        let c = fast(&dir, 2, "c");
+        assert!(a.holds_slot());
+        assert!(b.holds_slot());
+        assert!(!c.holds_slot(), "the third holder exceeds the 2-slot budget");
+        // The two holders occupy distinct slots.
+        assert_eq!(a.slot_index(), Some(0));
+        assert_eq!(b.slot_index(), Some(1));
+        assert!(slot_path(&dir, 0).is_dir() && slot_path(&dir, 1).is_dir());
+    }
+
+    // ------------------------------------------------------------------
+    // degrade-open paths
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn degrades_open_when_the_slot_dir_cannot_be_created() {
+        let tmp = tempfile::tempdir().unwrap();
+        // A *file* where the slot directory should be: `create_dir_all` fails.
+        let path = tmp.path().join("not-a-dir");
+        std::fs::write(&path, b"x").unwrap();
+        let lease = fast(&path, 1, "gate");
+        assert!(!lease.holds_slot());
+        match lease.kind() {
+            LeaseKind::DegradedOpen { reason } => assert!(reason.contains("unusable")),
+            other => panic!("expected degraded-open, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn zero_slots_disables_serialization() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("build-slot");
+        let a = fast(&dir, 0, "a");
+        let b = fast(&dir, 0, "b");
+        assert!(!a.holds_slot() && !b.holds_slot());
+        assert_eq!(a.kind().as_str(), "degraded-open");
+        assert!(!dir.exists(), "a disabled slot must not even create the dir");
+    }
+
+    #[test]
+    fn degraded_open_lease_does_not_cover_children() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("build-slot");
+        let lease = fast(&dir, 0, "a");
+        assert!(
+            !lease.covers_children(),
+            "a lease with no slot must not tell children they are covered"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // stale reaping — a slot older than the threshold is not a permanent wedge
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn reaps_a_stale_slot_from_a_crashed_holder() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("build-slot");
+        std::fs::create_dir_all(&dir).unwrap();
+        // Simulate a holder that died without releasing.
+        std::fs::create_dir(slot_path(&dir, 0)).unwrap();
+        std::thread::sleep(Duration::from_millis(30));
+
+        let lease = acquire_in(
+            &dir,
+            1,
+            Duration::from_millis(200),
+            Duration::from_millis(10),
+            Duration::from_millis(10), // everything older than 10ms is stale
+            "after-crash",
+        );
+        assert!(lease.holds_slot(), "an abandoned slot must be reaped, not waited on forever");
+    }
+
+    // ------------------------------------------------------------------
+    // re-entrancy — the nested-acquire no-op
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn nested_acquire_is_a_reentrant_no_op() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("build-slot");
+        std::env::set_var(BUILD_SLOT_DIR_ENV, &dir);
+        std::env::set_var(BUILD_SLOT_HELD_ENV, "1");
+        let lease = acquire("nested-gate");
+        assert_eq!(lease.kind(), &LeaseKind::Reentrant);
+        assert!(!lease.holds_slot());
+        assert!(
+            lease.covers_children(),
+            "an ancestor already holds a slot, so children stay covered"
+        );
+        assert!(!slot_path(&dir, 0).exists(), "a re-entrant acquire must not take a second slot");
+        std::env::remove_var(BUILD_SLOT_HELD_ENV);
+        std::env::remove_var(BUILD_SLOT_DIR_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn is_held_here_parses_truthy_values_only() {
+        for truthy in ["1", "true", "YES", "on"] {
+            std::env::set_var(BUILD_SLOT_HELD_ENV, truthy);
+            assert!(is_held_here(), "{truthy} must be truthy");
+        }
+        for falsy in ["0", "false", "", "no"] {
+            std::env::set_var(BUILD_SLOT_HELD_ENV, falsy);
+            assert!(!is_held_here(), "{falsy} must not be truthy");
+        }
+        std::env::remove_var(BUILD_SLOT_HELD_ENV);
+        assert!(!is_held_here());
+    }
+
+    // ------------------------------------------------------------------
+    // knob resolution
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn resolves_knobs_from_env_with_defaults() {
+        std::env::remove_var(BUILD_SLOTS_ENV);
+        std::env::remove_var(BUILD_SLOT_WAIT_SECS_ENV);
+        std::env::remove_var(BUILD_SLOT_STALE_SECS_ENV);
+        assert_eq!(resolve_slots(), DEFAULT_BUILD_SLOTS);
+        assert_eq!(resolve_wait(), Duration::from_secs(DEFAULT_BUILD_SLOT_WAIT_SECS));
+        assert_eq!(resolve_stale(), Duration::from_secs(DEFAULT_STALE_SLOT_SECS));
+
+        std::env::set_var(BUILD_SLOTS_ENV, "2");
+        std::env::set_var(BUILD_SLOT_WAIT_SECS_ENV, "30");
+        std::env::set_var(BUILD_SLOT_STALE_SECS_ENV, "60");
+        assert_eq!(resolve_slots(), 2);
+        assert_eq!(resolve_wait(), Duration::from_secs(30));
+        assert_eq!(resolve_stale(), Duration::from_secs(60));
+
+        // `0` is honored for the slot count (opt-out) but not for the stale
+        // threshold (which would reap every live slot instantly).
+        std::env::set_var(BUILD_SLOTS_ENV, "0");
+        std::env::set_var(BUILD_SLOT_STALE_SECS_ENV, "0");
+        assert_eq!(resolve_slots(), 0);
+        assert_eq!(resolve_stale(), Duration::from_secs(DEFAULT_STALE_SLOT_SECS));
+
+        // Garbage falls back to the defaults.
+        std::env::set_var(BUILD_SLOTS_ENV, "many");
+        std::env::set_var(BUILD_SLOT_WAIT_SECS_ENV, "soon");
+        assert_eq!(resolve_slots(), DEFAULT_BUILD_SLOTS);
+        assert_eq!(resolve_wait(), Duration::from_secs(DEFAULT_BUILD_SLOT_WAIT_SECS));
+
+        std::env::remove_var(BUILD_SLOTS_ENV);
+        std::env::remove_var(BUILD_SLOT_WAIT_SECS_ENV);
+        std::env::remove_var(BUILD_SLOT_STALE_SECS_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn slot_dir_honors_the_env_override_and_falls_back_to_home() {
+        std::env::set_var(BUILD_SLOT_DIR_ENV, "/tmp/loom-slots-test");
+        assert_eq!(slot_dir(), Some(PathBuf::from("/tmp/loom-slots-test")));
+        // An empty/whitespace override is ignored (falls through to `$HOME`).
+        std::env::set_var(BUILD_SLOT_DIR_ENV, "   ");
+        if let Some(p) = slot_dir() {
+            assert!(
+                p.ends_with(PathBuf::from(".loom").join("locks").join("build-slot")),
+                "unexpected fallback path: {}",
+                p.display()
+            );
+        }
+        std::env::remove_var(BUILD_SLOT_DIR_ENV);
+    }
+
+    // ------------------------------------------------------------------
+    // cross-process contract: the Bash half must agree on the path shape
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn slot_path_shape_matches_the_bash_helper() {
+        // `defaults/scripts/lib/build-slot.sh` composes "$dir/slot-$i"; if this
+        // ever diverges, the daemon and the sweep-side gate stop serializing
+        // against each other (silently).
+        assert_eq!(slot_path(Path::new("/x"), 0), PathBuf::from("/x/slot-0"));
+        assert_eq!(slot_path(Path::new("/x"), 3), PathBuf::from("/x/slot-3"));
+    }
+
+    /// Repo-relative path to the Bash half, or `None` when it is not present
+    /// (a consumer repo vendoring only the crate).
+    fn bash_helper() -> Option<PathBuf> {
+        let p = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()?
+            .join("defaults/scripts/lib/build-slot.sh");
+        p.is_file().then_some(p)
+    }
+
+    #[test]
+    fn a_rust_held_slot_blocks_the_bash_half_across_processes() {
+        // THE contract that makes #4512 safe: the daemon's gate (Rust) and each
+        // sweep worktree's `build-gate.sh` (Bash) are different processes, so the
+        // two implementations must serialize against *each other*, not merely
+        // each against itself. Path-shape parity (above) is necessary but not
+        // sufficient — this exercises the real protocol end to end.
+        let Some(helper) = bash_helper() else {
+            return; // not a source checkout; nothing to cross-check
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("build-slot");
+
+        let held = fast(&dir, 1, "rust-side-build");
+        assert!(held.holds_slot(), "the Rust half must take slot 0 first");
+
+        let out = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "set -euo pipefail; source '{}'; loom_build_slot_acquire bash-side-gate; \
+                 echo \"PATH=[${{LOOM_BUILD_SLOT_PATH}}]\"",
+                helper.display()
+            ))
+            .env(BUILD_SLOT_DIR_ENV, &dir)
+            .env(BUILD_SLOT_WAIT_SECS_ENV, "1")
+            .env_remove(BUILD_SLOT_HELD_ENV)
+            .output()
+            .expect("run the bash half");
+
+        assert!(out.status.success(), "the bash half must degrade open, never fail");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stdout.contains("PATH=[]"),
+            "bash must hold NO slot while Rust holds the only one — stdout: {stdout}, \
+             stderr: {stderr}"
+        );
+        assert!(
+            stderr.contains("degrading open"),
+            "bash must report the bounded-wait degrade — stderr: {stderr}"
+        );
+
+        // And once the Rust side releases, the Bash side gets in — proving the
+        // block above was contention, not a broken lock store.
+        drop(held);
+        let out2 = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "set -euo pipefail; source '{}'; loom_build_slot_acquire bash-side-gate; \
+                 echo \"PATH=[${{LOOM_BUILD_SLOT_PATH}}]\"; loom_build_slot_release",
+                helper.display()
+            ))
+            .env(BUILD_SLOT_DIR_ENV, &dir)
+            .env(BUILD_SLOT_WAIT_SECS_ENV, "1")
+            .env_remove(BUILD_SLOT_HELD_ENV)
+            .output()
+            .expect("run the bash half again");
+        let stdout2 = String::from_utf8_lossy(&out2.stdout);
+        assert!(
+            stdout2.contains("PATH=[") && !stdout2.contains("PATH=[]"),
+            "a released slot must be visible to the other language: {stdout2}"
+        );
+    }
+
+    #[test]
+    fn a_bash_held_slot_blocks_the_rust_half_across_processes() {
+        // The mirror direction: a sweep's `build-gate.sh` holding the slot must
+        // make the daemon's own gate wait/degrade rather than build alongside it.
+        let Some(helper) = bash_helper() else {
+            return;
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("build-slot");
+
+        // Acquire in Bash and *leak* the lock dir (no release) to model a
+        // still-running holder; a fresh mtime keeps it non-stale.
+        let out = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "set -euo pipefail; source '{}'; loom_build_slot_acquire bash-side-gate",
+                helper.display()
+            ))
+            .env(BUILD_SLOT_DIR_ENV, &dir)
+            .env(BUILD_SLOT_WAIT_SECS_ENV, "1")
+            .env_remove(BUILD_SLOT_HELD_ENV)
+            .output()
+            .expect("run the bash half");
+        assert!(out.status.success());
+        assert!(slot_path(&dir, 0).is_dir(), "bash must have taken slot 0");
+
+        let lease = fast(&dir, 1, "rust-side-build");
+        assert!(!lease.holds_slot(), "Rust must not build alongside a Bash-held slot");
+        assert_eq!(lease.kind().as_str(), "degraded-open");
+    }
+}

--- a/loom-daemon/src/calibrate/mod.rs
+++ b/loom-daemon/src/calibrate/mod.rs
@@ -1,97 +1,72 @@
-//! `loom-daemon calibrate` — measure the host and recommend (or, with
-//! `--write`, apply) the autonomous concurrency knobs (issue #4390).
+//! `loom-daemon calibrate` — **measure** the host and the currently-resolved
+//! concurrency knobs, and name which admission term binds (issue #4390,
+//! reduced to measurement-only in #4512).
 //!
-//! # Motivation
+//! # What this is, after #4512
 //!
-//! [`crate::work_finder::resolve_dynamic_max_concurrent`] bounds the
-//! autonomous dispatch cap by `min(healthy_tokens × per_token, disk_headroom,
-//! cpu_headroom, configured_max)`. The three live-measured terms
-//! (`healthy_tokens`, `disk_headroom`, `cpu_headroom`) already scale with the
-//! host; the fourth, `configured_max` (`autonomous.workFinder.maxConcurrent`),
-//! does not — it is a static operator ceiling that defaults to
-//! [`crate::work_finder::DEFAULT_WORK_FINDER_MAX_CONCURRENT`] (`3`) for every
-//! consumer install, regardless of whether the host has 4 cores or 28. On a
-//! large host the ceiling becomes the accidental binding term, silently
-//! wasting the CPU/disk/token headroom the other three terms would otherwise
-//! allow. Tuning this by hand (as commit `3fdfbf81` did for this repo's own
-//! host) requires reading `loom-daemon status`'s cap breakdown, understanding
-//! the four-term formula, and knowing which config key to edit — this module
-//! automates that judgment call.
+//! Originally (#4390) this subcommand also *recommended* — and with `--write`
+//! applied — new knob values, deriving a `maxConcurrent` ceiling from the CPU
+//! headroom term (`cpu_headroom + 25% slack`). #4512 deleted that term from the
+//! admission formula: it priced every sweep as a build and throttled the
+//! API-wait-dominated majority (an 8-core worker measured **95% idle** was
+//! capped at 2). With the CPU estimate gone there is nothing left to derive a
+//! recommendation *from* — `autonomous.workFinder.maxConcurrent` is now the one
+//! per-machine knob, **tuned empirically by the operator** from observed
+//! behavior.
 //!
-//! # Two halves: pure policy, impure measurement
+//! So calibrate is now strictly a **measurement report**: it prints what the
+//! host looks like right now, what the knobs currently resolve to, the
+//! `min(token axis, disk headroom, maxConcurrent)` breakdown, and which term
+//! binds. Reading it is how an operator decides whether to raise the knob:
 //!
-//! [`recommend`] is a **pure** function over [`HostMeasurements`] — no I/O, no
-//! live host probing — so the recommendation policy is exhaustively unit
-//! tested against injected measurements (host classes: a large pilot host, a
-//! small laptop, a disk-bound host, an unbootstrapped token pool, …).
-//! [`measure`] is the **only** function in this module that touches the live
-//! host (CPU idle sampling, `df`, the token-pool ranking file) — it builds a
-//! [`HostMeasurements`] from real inputs, reusing the same measurement
+//! - **binds on `ceiling` while the host sits idle** ⇒ raise `maxConcurrent`.
+//! - **binds on `ceiling` while the host is saturated** (low idle fraction, or
+//!   the host breaker tripping) ⇒ the knob is already at/above what this machine
+//!   sustains; leave it or lower it.
+//! - **binds on `token`/`disk`** ⇒ raising `maxConcurrent` changes nothing; add
+//!   accounts or free scratch space.
+//!
+//! It never writes config. `--write` is accepted-but-ignored with a deprecation
+//! warning so an existing `loom-daemon calibrate --write` invocation in a
+//! script does not start failing.
+//!
+//! # Two halves: pure rendering, impure measurement
+//!
+//! [`measure`] is the **only** function here that touches the live host (CPU
+//! idle sampling, `df`, the token-pool ranking file) — it reuses exactly the
 //! primitives [`crate::work_finder`]'s dynamic cap and `loom-daemon status`
 //! already use, so calibrate can never disagree with what dispatch actually
-//! does.
-//!
-//! # Recommendation policy
-//!
-//! - **Ceiling** (`autonomous.workFinder.maxConcurrent`): recommend raising it
-//!   to `cpu_headroom + slack` (never lowering it — see the fleet-safety note
-//!   below) so the ceiling stops being the artificial binding term and the
-//!   measured-CPU governor binds instead, mirroring `3fdfbf81`'s manual
-//!   derivation. `slack` is [`CEILING_SLACK_FRACTION`] of `cpu_headroom`
-//!   (floored at 1), so the new ceiling does not sit razor-thin against the
-//!   CPU term (which would flip back to ceiling-bound on the next
-//!   slightly-busier tick).
-//! - **Per-token concurrency** (`autonomous.perTokenConcurrency`): only raised
-//!   when the token axis (`healthy_accounts × per_token_concurrency`) is
-//!   itself the smallest of the three *resource* terms (cpu/disk/the new
-//!   ceiling) — i.e. only when tokens are the actual bottleneck, not
-//!   proactively. Raised just enough to stop binding below that resource
-//!   floor, not further.
-//! - **Disk** has no config key at all — `LOOM_PER_WORKTREE_GB` is
-//!   deliberately env-only (see [`crate::disk_headroom`] module docs, #4032
-//!   decision) — so calibrate always names the env-var alternative rather
-//!   than a config write.
-//!
-//! # Fleet-safety note
-//!
-//! Raising the committed `maxConcurrent` ceiling is safe fleet-wide precisely
-//! because the dynamic cap keeps three other, independently-measured terms in
-//! the `min(...)`: each host still binds on its **own** measured
-//! cpu/tokens/disk regardless of how generous the shared ceiling is. A large
-//! ceiling recommended for an 18-core pilot host does not let a 4-core laptop
-//! over-dispatch — the laptop's own `cpu_headroom` term still clamps it.
+//! does. Everything else ([`binding_term`], [`report_json`], [`report_human`])
+//! is pure over [`HostMeasurements`] and unit-tested against injected host
+//! classes.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use serde_json::Value;
 
-/// Fraction of `cpu_headroom` added as slack when recommending a new ceiling,
-/// so the recommendation does not sit razor-thin against the CPU term (a
-/// ceiling equal to `cpu_headroom` would flip back to being the binding term
-/// the moment the host gets slightly busier). `0.25` reproduces this repo's
-/// own hand-derived `maxConcurrent=8` (commit `3fdfbf81`) from its measured
-/// `cpu_headroom≈6` on the 18-core pilot host almost exactly (`6 + ceil(6 ×
-/// 0.25) = 8`), which is why this constant was chosen over a flat `+N`.
-pub const CEILING_SLACK_FRACTION: f64 = 0.25;
-
 // ============================================================================
-// Measurements — the inputs to the recommendation policy
+// Measurements — the report's inputs
 // ============================================================================
 
-/// The host measurements + currently-resolved config knobs the recommendation
-/// policy ([`recommend`]) consumes. Every field is either a live measurement
-/// ([`measure`] populates it from the host) or an already-resolved config
-/// value (env > config > default, via [`crate::work_finder`]) — nothing in
-/// this struct requires further resolution, so [`recommend`] can be a pure
-/// function with no I/O, fully exercised by injected values in tests.
-#[derive(Debug, Clone, Copy, PartialEq)]
+/// The host measurements + currently-resolved config knobs the report renders.
+/// Every field is either a live measurement ([`measure`] populates it from the
+/// host) or an already-resolved config value (env > config > default, via
+/// [`crate::work_finder`]) — nothing here requires further resolution, so the
+/// rendering functions are pure and fully exercised by injected values.
+#[derive(Debug, Clone, PartialEq)]
 pub struct HostMeasurements {
     /// Host logical CPU count ([`crate::cpu_headroom::logical_cpu_count`]).
     pub logical_cpus: usize,
-    /// The CPU headroom term as currently computed
-    /// ([`crate::cpu_headroom::cpu_headroom_limit`]) — concurrent-sweep
-    /// slots the host's CPU can currently absorb.
-    pub cpu_headroom: usize,
+    /// Measured CPU idle fraction (`0.0..=1.0`), or `None` when no sample has
+    /// been taken on this platform yet
+    /// ([`crate::cpu_headroom::cached_cpu_idle_fraction`]). **Observational**
+    /// since #4512 — this is the evidence for tuning `maxConcurrent`, not an
+    /// input to the cap.
+    pub cpu_idle_fraction: Option<f64>,
+    /// Current 1-minute load average, or `None` on a platform with no source
+    /// ([`crate::cpu_headroom::read_loadavg_1m`]). The load-**per-core** ratio
+    /// derived from it is what the host-distress breaker (#4235) trips on.
+    pub loadavg_1m: Option<f64>,
     /// The disk headroom term
     /// ([`crate::disk_headroom::disk_headroom_limit`]) — worktree slots the
     /// scratch volume can hold at the resolved per-worktree GB estimate.
@@ -116,21 +91,37 @@ pub struct HostMeasurements {
     /// Total accounts recorded in the ranking (`0` when
     /// [`Self::ranking_present`] is `false`).
     pub total_accounts: usize,
-    /// The currently resolved `autonomous.workFinder.maxConcurrent` ceiling
-    /// (env > config > default —
+    /// The currently resolved `autonomous.workFinder.maxConcurrent` — **the**
+    /// per-machine admission knob (env > config > default —
     /// [`crate::work_finder::resolve_max_concurrent_with_config`]).
     pub configured_max_concurrent: usize,
     /// Whether `LOOM_WORK_FINDER_MAX_CONCURRENT` is set in the environment —
-    /// when `true`, a `--write` recommendation is masked at runtime until the
-    /// env var is unset or updated (env always outranks config).
+    /// when `true`, editing `.loom/config.json` has no effect until the env var
+    /// is unset or updated (env always outranks config).
     pub max_concurrent_env_override: bool,
+    /// **Which config tier file** actually set
+    /// `autonomous.workFinder.maxConcurrent`
+    /// ([`crate::config_resolver::source_of`]), or `None` when no tier does (the
+    /// value is then the env override or the built-in default).
+    ///
+    /// Reported because the effective config is a *merge* of up to four files and
+    /// the daemon manages several workspaces, so "which `.loom/config.json`
+    /// supplied that number?" is a genuine operator question — #4512's live
+    /// tuning session lost time to a host where the answer turned out to be a
+    /// *different repo's* config than the one being edited. Naming the file makes
+    /// the one knob that now carries the whole admission policy unambiguous.
+    pub max_concurrent_source: Option<std::path::PathBuf>,
     /// The currently resolved `autonomous.perTokenConcurrency` factor (env >
-    /// config > default —
-    /// [`crate::work_finder::resolve_per_token_concurrency`]).
+    /// config > default — [`crate::work_finder::resolve_per_token_concurrency`]).
     pub configured_per_token_concurrency: usize,
     /// Whether `LOOM_PER_TOKEN_CONCURRENCY` is set in the environment (same
-    /// env-outranks-config masking as [`Self::max_concurrent_env_override`]).
+    /// env-outranks-config note as [`Self::max_concurrent_env_override`]).
     pub per_token_concurrency_env_override: bool,
+    /// How many machine-wide build slots serialize the designated high-CPU
+    /// stages ([`crate::build_slot::resolve_slots`], `0` = disabled). Reported
+    /// because this — not an admission-time CPU estimate — is what bounds
+    /// concurrent heavy builds since #4512.
+    pub build_slots: usize,
 }
 
 impl HostMeasurements {
@@ -144,13 +135,37 @@ impl HostMeasurements {
             .saturating_mul(self.configured_per_token_concurrency.max(1))
     }
 
+    /// The dynamic cap these measurements imply — exactly
+    /// [`crate::work_finder::resolve_dynamic_max_concurrent`], so calibrate can
+    /// never print a different cap than dispatch would compute.
+    #[must_use]
+    pub fn dynamic_cap(&self) -> usize {
+        crate::work_finder::resolve_dynamic_max_concurrent(
+            self.token_axis_limit,
+            self.configured_per_token_concurrency,
+            self.disk_headroom,
+            self.configured_max_concurrent,
+        )
+    }
+
+    /// Which of the three cap terms binds ([`binding_term`]).
+    #[must_use]
+    pub fn binding_term(&self) -> BindingTerm {
+        binding_term(
+            self.token_axis_effective(),
+            self.disk_headroom,
+            self.configured_max_concurrent,
+        )
+    }
+
     /// Render this struct as the `"measurements"` JSON object for `--json`
     /// output.
     #[must_use]
     pub fn to_json(&self) -> Value {
         serde_json::json!({
             "logical_cpus": self.logical_cpus,
-            "cpu_headroom": self.cpu_headroom,
+            "cpu_idle_fraction": self.cpu_idle_fraction,
+            "loadavg_1m": self.loadavg_1m,
             "disk_headroom": disk_headroom_json(self.disk_headroom),
             "disk_free_gb": self.disk_free_gb,
             "per_worktree_gb": self.per_worktree_gb,
@@ -160,8 +175,15 @@ impl HostMeasurements {
             "total_accounts": self.total_accounts,
             "configured_max_concurrent": self.configured_max_concurrent,
             "max_concurrent_env_override": self.max_concurrent_env_override,
+            // Which tier file set the knob — `null` when the value came from the
+            // env override or the built-in default (#4512).
+            "max_concurrent_source": self
+                .max_concurrent_source
+                .as_ref()
+                .map(|p| p.display().to_string()),
             "configured_per_token_concurrency": self.configured_per_token_concurrency,
             "per_token_concurrency_env_override": self.per_token_concurrency_env_override,
+            "build_slots": self.build_slots,
         })
     }
 }
@@ -179,13 +201,14 @@ fn disk_headroom_json(disk_headroom: usize) -> Value {
 }
 
 // ============================================================================
-// Binding term — which of the four `min(...)` terms is smallest
+// Binding term — which of the three `min(...)` terms is smallest
 // ============================================================================
 
-/// Which of the four dynamic-cap terms is the binding (smallest) constraint.
+/// Which of the three dynamic-cap terms is the binding (smallest) constraint.
 /// Tie-break order mirrors `loom-daemon status`'s own diagnosis
-/// (`resolve_capacity` / `token_bound`): token axis first, then disk, then
-/// cpu, then the ceiling.
+/// (`resolve_capacity` / `token_bound`): token axis first, then disk, then the
+/// ceiling. (A fourth `Cpu` variant existed until #4512 removed the CPU term
+/// from admission.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BindingTerm {
     /// The token axis (`healthy_accounts × per_token_concurrency`) is the
@@ -193,9 +216,7 @@ pub enum BindingTerm {
     Token,
     /// Disk headroom is the smallest term.
     Disk,
-    /// CPU headroom is the smallest term.
-    Cpu,
-    /// The operator-configured ceiling is the smallest term.
+    /// The operator-configured `maxConcurrent` is the smallest term.
     Ceiling,
 }
 
@@ -206,194 +227,26 @@ impl BindingTerm {
         match self {
             Self::Token => "token",
             Self::Disk => "disk",
-            Self::Cpu => "cpu",
             Self::Ceiling => "ceiling",
         }
     }
 }
 
-/// Determine which of the four terms is smallest (binds), applying the same
+/// Determine which of the three terms is smallest (binds), applying the same
 /// tie-break order [`BindingTerm`] documents.
 #[must_use]
-fn binding_term(
+pub fn binding_term(
     token_axis_effective: usize,
     disk_headroom: usize,
-    cpu_headroom: usize,
     ceiling: usize,
 ) -> BindingTerm {
-    let min_val = token_axis_effective
-        .min(disk_headroom)
-        .min(cpu_headroom)
-        .min(ceiling);
+    let min_val = token_axis_effective.min(disk_headroom).min(ceiling);
     if token_axis_effective == min_val {
         BindingTerm::Token
     } else if disk_headroom == min_val {
         BindingTerm::Disk
-    } else if cpu_headroom == min_val {
-        BindingTerm::Cpu
     } else {
         BindingTerm::Ceiling
-    }
-}
-
-// ============================================================================
-// Recommendation — the pure policy
-// ============================================================================
-
-/// The recommended knob values, plus the reasoning an operator needs to trust
-/// them: which term binds today, which term would bind after applying the
-/// recommendation, and any warnings ([`recommend`] never silently rewrites a
-/// knob it isn't confident about — see the module docs).
-#[derive(Debug, Clone, PartialEq)]
-pub struct Recommendation {
-    /// Recommended `autonomous.workFinder.maxConcurrent`. Never smaller than
-    /// [`HostMeasurements::configured_max_concurrent`] — see the module-level
-    /// fleet-safety note for why raising it is always safe and lowering it is
-    /// never recommended.
-    pub recommended_max_concurrent: usize,
-    /// Whether [`Self::recommended_max_concurrent`] differs from the current
-    /// configured value.
-    pub max_concurrent_changed: bool,
-    /// Recommended `autonomous.perTokenConcurrency`.
-    pub recommended_per_token_concurrency: usize,
-    /// Whether [`Self::recommended_per_token_concurrency`] differs from the
-    /// current configured value.
-    pub per_token_concurrency_changed: bool,
-    /// Which term binds today, at the *current* configured knobs.
-    pub binding_term_before: BindingTerm,
-    /// Which term would bind after applying this recommendation.
-    pub binding_term_after: BindingTerm,
-    /// Advisory warnings — env overrides that would mask a `--write`, an
-    /// unbootstrapped/unhealthy token pool, or a CPU term that looks clearly
-    /// miscalibrated for the host class. Never fatal; `calibrate` still
-    /// prints a recommendation alongside them.
-    pub warnings: Vec<String>,
-}
-
-impl Recommendation {
-    /// Render this struct as the `"recommendation"` JSON object for `--json`
-    /// output.
-    #[must_use]
-    pub fn to_json(&self) -> Value {
-        serde_json::json!({
-            "recommended_max_concurrent": self.recommended_max_concurrent,
-            "max_concurrent_changed": self.max_concurrent_changed,
-            "recommended_per_token_concurrency": self.recommended_per_token_concurrency,
-            "per_token_concurrency_changed": self.per_token_concurrency_changed,
-            "binding_term_before": self.binding_term_before.as_str(),
-            "binding_term_after": self.binding_term_after.as_str(),
-            "warnings": self.warnings,
-        })
-    }
-}
-
-/// Compute the recommended knob values from `m` — pure, no I/O. See the
-/// module docs for the policy rationale.
-#[must_use]
-pub fn recommend(m: &HostMeasurements) -> Recommendation {
-    let mut warnings = Vec::new();
-
-    let token_axis_effective_before = m.token_axis_effective();
-    let binding_term_before = binding_term(
-        token_axis_effective_before,
-        m.disk_headroom,
-        m.cpu_headroom,
-        m.configured_max_concurrent,
-    );
-
-    // --- Ceiling: raise (never lower) so the CPU term binds with slack. ---
-    let slack = ((m.cpu_headroom as f64) * CEILING_SLACK_FRACTION)
-        .ceil()
-        .max(1.0) as usize;
-    let cpu_target = m.cpu_headroom.saturating_add(slack);
-    let recommended_max_concurrent = m.configured_max_concurrent.max(cpu_target);
-    let max_concurrent_changed = recommended_max_concurrent != m.configured_max_concurrent;
-
-    if max_concurrent_changed && m.max_concurrent_env_override {
-        warnings.push(format!(
-            "LOOM_WORK_FINDER_MAX_CONCURRENT is set in the environment and outranks any config \
-             value calibrate writes (env > config > default) — the recommended maxConcurrent={} \
-             will NOT take effect until that env var is unset or updated to match.",
-            recommended_max_concurrent
-        ));
-    }
-
-    // --- Per-token concurrency: only raised when tokens are the actual ---
-    // --- resource bottleneck (smaller than cpu/disk/the new ceiling),   ---
-    // --- and only just enough to stop binding below that floor.        ---
-    let resource_floor = recommended_max_concurrent
-        .min(m.cpu_headroom)
-        .min(m.disk_headroom);
-    let recommended_per_token_concurrency = if m.token_axis_limit == 0 {
-        // No healthy accounts at all — no factor can help; see the
-        // no-healthy-accounts warning below instead.
-        m.configured_per_token_concurrency
-    } else if token_axis_effective_before >= resource_floor {
-        // Tokens are not the bottleneck today; leave the factor alone.
-        m.configured_per_token_concurrency
-    } else {
-        let needed = (resource_floor as f64 / m.token_axis_limit as f64)
-            .ceil()
-            .max(1.0) as usize;
-        needed.max(m.configured_per_token_concurrency)
-    };
-    let per_token_concurrency_changed =
-        recommended_per_token_concurrency != m.configured_per_token_concurrency;
-
-    if per_token_concurrency_changed && m.per_token_concurrency_env_override {
-        warnings.push(format!(
-            "LOOM_PER_TOKEN_CONCURRENCY is set in the environment and outranks any config value \
-             calibrate writes (env > config > default) — the recommended \
-             perTokenConcurrency={} will NOT take effect until that env var is unset or updated \
-             to match.",
-            recommended_per_token_concurrency
-        ));
-    }
-
-    if m.token_axis_limit == 0 {
-        warnings.push(
-            "No healthy accounts in the token pool (unbootstrapped, or every account is \
-             exhausted/rate-limited/blocked) — dispatch is capped at 0 regardless of \
-             maxConcurrent/perTokenConcurrency until the pool has at least one healthy account \
-             (`loom-tokens bootstrap` + `loom-tokens check --ranking`)."
-                .to_string(),
-        );
-    }
-
-    // Flag a CPU term that looks clearly miscalibrated for the host class,
-    // rather than silently rewriting `cpuUtilizationTarget` /
-    // `estCoresPerSweep` (module docs). A CPU term pinned at the hard floor
-    // of 1 on a host with meaningfully more than one core is the signature of
-    // an `estCoresPerSweep` set far above what this host's cores can supply.
-    if m.logical_cpus >= 8 && m.cpu_headroom <= 1 {
-        warnings.push(format!(
-            "cpu_headroom is pinned at the floor (1) on a {}-core host — this usually means \
-             autonomous.estCoresPerSweep (or LOOM_EST_CORES_PER_SWEEP) is set too high, or \
-             autonomous.cpuUtilizationTarget too low, for this host class. calibrate does not \
-             rewrite either automatically; review them before trusting the ceiling \
-             recommendation above.",
-            m.logical_cpus
-        ));
-    }
-
-    let token_axis_effective_after = m
-        .token_axis_limit
-        .saturating_mul(recommended_per_token_concurrency.max(1));
-    let binding_term_after = binding_term(
-        token_axis_effective_after,
-        m.disk_headroom,
-        m.cpu_headroom,
-        recommended_max_concurrent,
-    );
-
-    Recommendation {
-        recommended_max_concurrent,
-        max_concurrent_changed,
-        recommended_per_token_concurrency,
-        per_token_concurrency_changed,
-        binding_term_before,
-        binding_term_after,
-        warnings,
     }
 }
 
@@ -402,24 +255,35 @@ pub fn recommend(m: &HostMeasurements) -> Recommendation {
 // ============================================================================
 
 /// Measure the live host + resolve the currently-configured knobs for
-/// `workspace_root`, building the [`HostMeasurements`] [`recommend`]
-/// consumes. Reuses exactly the primitives
+/// `workspace_root`. Reuses exactly the primitives
 /// [`crate::work_finder::spawn_multi_work_finder_task`] and `loom-daemon
 /// status` already use, so calibrate can never disagree with what dispatch
 /// actually does.
 ///
-/// **May block** (~1s on macOS, via [`crate::cpu_headroom::cpu_headroom_limit`]'s
-/// `iostat` sample). Fine for a one-shot CLI invocation; callers on an async
-/// runtime should run this through `spawn_blocking`.
+/// Also emits the retired-knob deprecation warning
+/// ([`crate::work_finder::warn_deprecated_cpu_knobs`]) — an operator running
+/// `calibrate` to size a host is exactly who needs to hear that a stale
+/// `estCoresPerSweep` is doing nothing. That call covers an *in-daemon* caller
+/// (which has a logger); the CLI path has none, so `handle_calibrate_command`
+/// additionally prints [`crate::work_finder::deprecated_cpu_knob_notice`] to
+/// stderr. Both are idempotent, so the duplication is harmless.
+///
+/// **May block** (~1s on macOS: refreshing the memoized `iostat` idle sample).
+/// Fine for a one-shot CLI invocation; callers on an async runtime should run
+/// this through `spawn_blocking`.
 #[must_use]
 pub fn measure(workspace_root: &Path) -> HostMeasurements {
     let config = crate::work_finder::read_work_finder_config(workspace_root);
+    crate::work_finder::warn_deprecated_cpu_knobs(&config);
 
-    let utilization_target = crate::work_finder::resolve_cpu_utilization_target(&config);
-    let est_cores_per_sweep = crate::work_finder::resolve_cpu_est_cores_per_sweep(&config);
     let logical_cpus = crate::cpu_headroom::logical_cpu_count();
-    let cpu_headroom =
-        crate::cpu_headroom::cpu_headroom_limit(utilization_target, est_cores_per_sweep);
+    // Refresh so a one-shot CLI run reports a *fresh* observation rather than
+    // whatever a previous process left memoized (on Linux the first refresh only
+    // seeds the cross-tick delta, so `cpu_idle_fraction` can legitimately be
+    // `None` on the very first call — the renderer says so explicitly).
+    crate::cpu_headroom::refresh_cpu_util_cache();
+    let cpu_idle_fraction = crate::cpu_headroom::cached_cpu_idle_fraction();
+    let loadavg_1m = crate::cpu_headroom::read_loadavg_1m();
 
     let disk_free_gb = crate::disk_headroom::worktree_root_free_gb(workspace_root);
     let per_worktree_gb = crate::disk_headroom::per_worktree_gb();
@@ -435,6 +299,8 @@ pub fn measure(workspace_root: &Path) -> HostMeasurements {
     let configured_max_concurrent = crate::work_finder::resolve_max_concurrent_with_config(&config);
     let max_concurrent_env_override =
         std::env::var(crate::work_finder::WORK_FINDER_MAX_CONCURRENT_ENV).is_ok();
+    let max_concurrent_source =
+        crate::config_resolver::source_of(workspace_root, "autonomous.workFinder.maxConcurrent");
     let configured_per_token_concurrency =
         crate::work_finder::resolve_per_token_concurrency(&config);
     let per_token_concurrency_env_override =
@@ -442,7 +308,8 @@ pub fn measure(workspace_root: &Path) -> HostMeasurements {
 
     HostMeasurements {
         logical_cpus,
-        cpu_headroom,
+        cpu_idle_fraction,
+        loadavg_1m,
         disk_headroom,
         disk_free_gb,
         per_worktree_gb,
@@ -451,140 +318,114 @@ pub fn measure(workspace_root: &Path) -> HostMeasurements {
         total_accounts,
         configured_max_concurrent,
         max_concurrent_env_override,
+        max_concurrent_source,
         configured_per_token_concurrency,
         per_token_concurrency_env_override,
+        build_slots: crate::build_slot::resolve_slots(),
     }
-}
-
-// ============================================================================
-// --write — merge the recommendation into .loom/config.json
-// ============================================================================
-
-/// Deep-merge `max_concurrent` / `per_token_concurrency` into `existing`
-/// (a full parsed `.loom/config.json`), touching **only**
-/// `autonomous.workFinder.maxConcurrent` and `autonomous.perTokenConcurrency`
-/// — every other key at any depth (including sibling `autonomous.workFinder`
-/// keys like `intervalSecs`/`enabled`, and sibling `autonomous` keys like
-/// `cpuUtilizationTarget`/`roleRunner`) is preserved byte-for-byte. Pure
-/// function (no I/O) so the merge is unit-tested directly, including
-/// idempotency (merging the same values twice yields the same
-/// [`Value`]) without touching a filesystem.
-///
-/// Reuses [`crate::init::deep_merge_existing_wins`] with the roles inverted
-/// from `init`'s own usage: there, the existing **consumer** config wins over
-/// the shipped template; here, the **new recommended values** (the overlay)
-/// win over whatever `existing` already has at those two leaf paths — the
-/// whole point of `--write` is to update them. The underlying merge semantics
-/// (overlay wins on conflict, base's untouched keys survive, recurses into
-/// objects) are identical; only which side is `base` and which is `overlay`
-/// differs.
-#[must_use]
-pub fn merge_workfinder_values(
-    existing: &Value,
-    max_concurrent: usize,
-    per_token_concurrency: usize,
-) -> Value {
-    let mut merged = if existing.is_object() {
-        existing.clone()
-    } else {
-        serde_json::json!({})
-    };
-    let overlay = serde_json::json!({
-        "autonomous": {
-            "perTokenConcurrency": per_token_concurrency,
-            "workFinder": {
-                "maxConcurrent": max_concurrent,
-            },
-        },
-    });
-    crate::init::deep_merge_existing_wins(&mut merged, &overlay);
-    merged
-}
-
-/// Read `<workspace_root>/.loom/config.json` (treating a missing file as
-/// `{}`), merge in the recommended `maxConcurrent` / `perTokenConcurrency`
-/// via [`merge_workfinder_values`], and write the result back with the same
-/// canonical pretty-printed + trailing-newline formatting
-/// [`crate::init::initialize_workspace`]'s own config merge uses — so a
-/// repeat `--write` with the same recommendation is byte-identical (AC).
-///
-/// Refuses (returns `Err`) rather than clobbering when the existing file is
-/// present but not a valid JSON object — `--write` must never silently
-/// discard a consumer's config.
-pub fn write_workfinder_config(
-    workspace_root: &Path,
-    max_concurrent: usize,
-    per_token_concurrency: usize,
-) -> Result<PathBuf, String> {
-    let loom_dir = workspace_root.join(".loom");
-    std::fs::create_dir_all(&loom_dir)
-        .map_err(|e| format!("Failed to create {}: {e}", loom_dir.display()))?;
-    let config_path = loom_dir.join("config.json");
-
-    let existing: Value = if config_path.exists() {
-        let raw = std::fs::read_to_string(&config_path)
-            .map_err(|e| format!("Failed to read {}: {e}", config_path.display()))?;
-        let parsed: Value = serde_json::from_str(&raw).map_err(|e| {
-            format!(
-                "{} is not valid JSON ({e}) — refusing to write; fix or remove it first",
-                config_path.display()
-            )
-        })?;
-        if !parsed.is_object() {
-            return Err(format!(
-                "{} does not contain a JSON object at the top level — refusing to write",
-                config_path.display()
-            ));
-        }
-        parsed
-    } else {
-        serde_json::json!({})
-    };
-
-    let merged = merge_workfinder_values(&existing, max_concurrent, per_token_concurrency);
-    let mut serialized = serde_json::to_string_pretty(&merged)
-        .map_err(|e| format!("Failed to serialize merged config: {e}"))?;
-    serialized.push('\n');
-    std::fs::write(&config_path, serialized)
-        .map_err(|e| format!("Failed to write {}: {e}", config_path.display()))?;
-    Ok(config_path)
 }
 
 // ============================================================================
 // Output rendering
 // ============================================================================
 
-/// Render the full `measurements` + `recommendation` (+ optional write
-/// outcome) as the top-level `--json` payload.
+/// Render the full measurement report as the top-level `--json` payload.
 #[must_use]
-pub fn report_json(m: &HostMeasurements, r: &Recommendation, written: Option<&Path>) -> Value {
+pub fn report_json(m: &HostMeasurements) -> Value {
     serde_json::json!({
         "measurements": m.to_json(),
-        "recommendation": r.to_json(),
-        "write": {
-            "applied": written.is_some(),
-            "config_path": written.map(|p| p.display().to_string()),
-        },
+        "dynamic_cap": m.dynamic_cap(),
+        "binding_term": m.binding_term().as_str(),
+        "advice": advice(m),
+        // Retained for machine consumers that keyed off it before #4512: this
+        // subcommand no longer writes anything, ever.
+        "write": { "applied": false, "config_path": Value::Null },
         "restart_required": true,
     })
 }
 
-/// Render the human-readable report — per-term measurements, the `min(...)`
-/// breakdown before and after, and the recommendation, in the same format
-/// `loom-daemon status` uses for its own cap breakdown
-/// (`print_status_human`).
+/// The one-line, actionable reading of the measurements — the whole point of
+/// the report. Pure over [`HostMeasurements`], so the tuning policy is
+/// unit-tested against injected host classes.
 #[must_use]
-#[allow(clippy::too_many_lines)]
-pub fn report_human(m: &HostMeasurements, r: &Recommendation, written: Option<&Path>) -> String {
+pub fn advice(m: &HostMeasurements) -> String {
+    match m.binding_term() {
+        BindingTerm::Ceiling => match m.cpu_idle_fraction {
+            Some(idle) if idle >= IDLE_HEADROOM_FRACTION => format!(
+                "maxConcurrent={} binds while the host is {:.0}% idle — this machine looks \
+                 under-subscribed; raise autonomous.workFinder.maxConcurrent (a step at a time) \
+                 and re-measure. The host-distress breaker is the safety net if you overshoot.",
+                m.configured_max_concurrent,
+                idle * 100.0
+            ),
+            Some(idle) => format!(
+                "maxConcurrent={} binds and the host is only {:.0}% idle — it is already close to \
+                 what this machine sustains; do not raise it further without freeing CPU.",
+                m.configured_max_concurrent,
+                idle * 100.0
+            ),
+            None => format!(
+                "maxConcurrent={} binds, but no CPU idle sample is available on this host — run \
+                 this again (or read `loom-daemon status`) once the daemon has sampled, then tune.",
+                m.configured_max_concurrent
+            ),
+        },
+        BindingTerm::Token => format!(
+            "the token axis binds ({} healthy account(s) × per-token {} = {}) — raising \
+             maxConcurrent changes nothing; add accounts (`loom-tokens bootstrap`) or refresh the \
+             ranking (`loom-tokens check --ranking`).",
+            m.token_axis_limit,
+            m.configured_per_token_concurrency.max(1),
+            m.token_axis_effective()
+        ),
+        BindingTerm::Disk => format!(
+            "disk headroom binds ({} worktree slot(s) at {} GB each) — raising maxConcurrent \
+             changes nothing; free scratch space or lower LOOM_PER_WORKTREE_GB.",
+            display_headroom(m.disk_headroom),
+            m.per_worktree_gb
+        ),
+    }
+}
+
+/// Idle fraction at or above which a host is treated as clearly
+/// under-subscribed for the purpose of the "raise the knob" advice. `0.50` is
+/// deliberately generous: #4512's motivating host measured **95%** idle at cap
+/// 2, and the point of the advice is to catch that class of gross
+/// under-subscription, not to fine-tune the last slot.
+pub const IDLE_HEADROOM_FRACTION: f64 = 0.50;
+
+/// Render the human-readable report — per-term measurements, the `min(...)`
+/// breakdown, which term binds, and the one-line advice, in the same format
+/// `loom-daemon status` uses for its own cap breakdown (`print_status_human`).
+#[must_use]
+pub fn report_human(m: &HostMeasurements) -> String {
     let mut out = String::new();
     let factor = m.configured_per_token_concurrency.max(1);
-    let token_axis_before = m.token_axis_effective();
 
-    out.push_str("\n=== loom-daemon calibrate ===\n\n");
+    out.push_str("\n=== loom-daemon calibrate (measurements) ===\n\n");
 
     out.push_str("Host measurements:\n");
     out.push_str(&format!("  logical cpus:   {}\n", m.logical_cpus));
-    out.push_str(&format!("  cpu headroom:   {} concurrent-sweep slot(s)\n", m.cpu_headroom));
+    match (m.cpu_idle_fraction, m.loadavg_1m) {
+        (Some(idle), load) => {
+            let consumed = m.logical_cpus as f64 * (1.0 - idle.clamp(0.0, 1.0));
+            out.push_str(&format!(
+                "  cpu observed:   {:.0}% idle (≈{consumed:.1} of {} cores consumed){}\n",
+                idle * 100.0,
+                m.logical_cpus,
+                load.map_or_else(String::new, |l| format!(", 1m loadavg {l:.2}"))
+            ));
+        }
+        (None, Some(load)) => {
+            out.push_str(&format!("  cpu observed:   no idle sample yet, 1m loadavg {load:.2}\n"));
+        }
+        (None, None) => {
+            out.push_str("  cpu observed:   no CPU signal available on this platform\n");
+        }
+    }
+    out.push_str(
+        "                  (observational only since #4512 — CPU is no longer an admission term)\n",
+    );
     match (m.disk_free_gb, m.disk_headroom) {
         (Some(free), headroom) if headroom != usize::MAX => {
             out.push_str(&format!(
@@ -614,87 +455,70 @@ pub fn report_human(m: &HostMeasurements, r: &Recommendation, written: Option<&P
             m.token_axis_limit
         ));
     }
+    out.push_str(&format!(
+        "  build slots:    {} (machine-wide; serializes cargo build/test + the build gate — \
+         LOOM_BUILD_SLOTS)\n",
+        if m.build_slots == 0 {
+            "0 — DISABLED".to_string()
+        } else {
+            m.build_slots.to_string()
+        }
+    ));
 
     out.push_str("\nCurrently configured:\n");
     out.push_str(&format!(
         "  autonomous.workFinder.maxConcurrent = {}{}\n",
         m.configured_max_concurrent,
         if m.max_concurrent_env_override {
-            " (from LOOM_WORK_FINDER_MAX_CONCURRENT)"
+            " (from LOOM_WORK_FINDER_MAX_CONCURRENT — env outranks config)"
         } else {
             ""
         }
     ));
+    // Name the file, not just the number (#4512): on a multi-workspace host the
+    // effective config is a merge of up to four tiers, so "edit the config" is
+    // ambiguous until the operator knows WHICH config is in play.
+    out.push_str(&match (&m.max_concurrent_source, m.max_concurrent_env_override) {
+        (Some(path), false) => format!("                  set by: {}\n", path.display()),
+        (Some(path), true) => {
+            format!(
+                "                  (config tier {} is shadowed by the env var)\n",
+                path.display()
+            )
+        }
+        (None, false) => format!(
+            "                  set by: no config tier — built-in default ({})\n",
+            crate::work_finder::DEFAULT_WORK_FINDER_MAX_CONCURRENT
+        ),
+        (None, true) => String::new(),
+    });
     out.push_str(&format!(
         "  autonomous.perTokenConcurrency      = {}{}\n",
         m.configured_per_token_concurrency,
         if m.per_token_concurrency_env_override {
-            " (from LOOM_PER_TOKEN_CONCURRENCY)"
+            " (from LOOM_PER_TOKEN_CONCURRENCY — env outranks config)"
         } else {
             ""
         }
     ));
+
+    out.push_str(&format!("\nDynamic concurrency cap: {}\n", m.dynamic_cap()));
     out.push_str(&format!(
-        "  = min(healthy {} × per-token {} = {}, disk {}, cpu {}, configured max {})\n",
+        "  = min(healthy {} × per-token {} = {}, disk {}, maxConcurrent {})\n",
         m.token_axis_limit,
         factor,
-        token_axis_before,
+        m.token_axis_effective(),
         display_headroom(m.disk_headroom),
-        m.cpu_headroom,
         m.configured_max_concurrent,
     ));
-    out.push_str(&format!("  binds on: {}\n", r.binding_term_before.as_str()));
+    out.push_str(&format!("  binds on: {}\n", m.binding_term().as_str()));
 
-    out.push_str("\nRecommendation:\n");
-    out.push_str(&format!(
-        "  autonomous.workFinder.maxConcurrent -> {}{}\n",
-        r.recommended_max_concurrent,
-        if r.max_concurrent_changed {
-            format!(" (was {})", m.configured_max_concurrent)
-        } else {
-            " (no change)".to_string()
-        }
-    ));
-    out.push_str(&format!(
-        "  autonomous.perTokenConcurrency      -> {}{}\n",
-        r.recommended_per_token_concurrency,
-        if r.per_token_concurrency_changed {
-            format!(" (was {})", m.configured_per_token_concurrency)
-        } else {
-            " (no change)".to_string()
-        }
-    ));
-    let token_axis_after = m
-        .token_axis_limit
-        .saturating_mul(r.recommended_per_token_concurrency.max(1));
-    out.push_str(&format!(
-        "  = min(healthy {} × per-token {} = {}, disk {}, cpu {}, configured max {})\n",
-        m.token_axis_limit,
-        r.recommended_per_token_concurrency.max(1),
-        token_axis_after,
-        display_headroom(m.disk_headroom),
-        m.cpu_headroom,
-        r.recommended_max_concurrent,
-    ));
-    out.push_str(&format!("  would bind on: {}\n", r.binding_term_after.as_str()));
-
-    if !r.warnings.is_empty() {
-        out.push('\n');
-        for w in &r.warnings {
-            out.push_str(&format!("WARNING: {w}\n"));
-        }
-    }
-
-    out.push('\n');
-    if let Some(path) = written {
-        out.push_str(&format!("Wrote the recommendation above to {}.\n", path.display()));
-    } else {
-        out.push_str("Not writing changes (pass --write to apply this recommendation).\n");
-    }
+    out.push_str(&format!("\nReading: {}\n", advice(m)));
     out.push_str(
-        "These knobs are read once at daemon startup, not re-read per tick — restart the \
-         daemon for a change to take effect:\n  ./.loom/scripts/cli/loom-daemon-stop.sh && \
-         ./.loom/scripts/cli/loom-daemon-start.sh\n",
+        "\nThis report is read-only — calibrate no longer recommends or writes knob values \
+         (#4512): maxConcurrent is a per-machine knob you tune from observations like the ones \
+         above. It is read once at daemon startup, so restart after editing:\n  \
+         ./.loom/scripts/cli/loom-daemon-stop.sh && ./.loom/scripts/cli/loom-daemon-start.sh\n",
     );
 
     out
@@ -714,255 +538,143 @@ mod tests {
     use super::*;
 
     // ========================================================================
-    // Test fixtures — host classes named in the #4390 test plan
+    // Test fixtures — host classes named in the #4390 test plan, re-baselined
+    // for the #4512 model (no CPU term)
     // ========================================================================
 
-    /// 18-core / 8-token pilot host (this repo's own primary build host, the
-    /// motivating case for commit `3fdfbf81`'s manual `maxConcurrent=8`).
-    /// `cpu_headroom≈6` is the real measured figure for that host at the
-    /// default `utilizationTarget=0.75`, `estCoresPerSweep=2.0` (module docs
-    /// on [`crate::cpu_headroom::DEFAULT_EST_CORES_PER_SWEEP`]).
-    fn pilot_host() -> HostMeasurements {
+    /// The #4512 motivating host: an 8-core EC2 worker sitting 95% idle whose
+    /// throughput was pinned at 2 by the old CPU term. Under the new model the
+    /// ceiling binds and the advice is "raise it".
+    fn idle_worker_host() -> HostMeasurements {
         HostMeasurements {
-            logical_cpus: 18,
-            cpu_headroom: 6,
-            disk_headroom: 700,
-            disk_free_gb: Some(1400),
+            logical_cpus: 8,
+            cpu_idle_fraction: Some(0.95),
+            loadavg_1m: Some(0.4),
+            disk_headroom: 36,
+            disk_free_gb: Some(72),
             per_worktree_gb: 2,
-            token_axis_limit: 8,
+            token_axis_limit: 6,
             ranking_present: true,
             total_accounts: 8,
-            configured_max_concurrent: 3, // consumer default (#4390 premise correction 1)
-            max_concurrent_env_override: false,
-            configured_per_token_concurrency: 2, // DEFAULT_PER_TOKEN_CONCURRENCY
-            per_token_concurrency_env_override: false,
-        }
-    }
-
-    /// 4-core / 1-token laptop host — a small dev machine with only a single
-    /// bootstrapped account.
-    fn laptop_host() -> HostMeasurements {
-        HostMeasurements {
-            logical_cpus: 4,
-            cpu_headroom: 1, // floored — 4 * 0.75 / 2.0 = 1.5 -> floor 1
-            disk_headroom: 200,
-            disk_free_gb: Some(400),
-            per_worktree_gb: 2,
-            token_axis_limit: 1,
-            ranking_present: true,
-            total_accounts: 1,
             configured_max_concurrent: 3,
             max_concurrent_env_override: false,
+            max_concurrent_source: Some(std::path::PathBuf::from("/repo/.loom/config.json")),
             configured_per_token_concurrency: 2,
             per_token_concurrency_env_override: false,
+            build_slots: 1,
         }
     }
 
-    /// A host with plenty of CPU and tokens but a nearly-full scratch volume —
-    /// disk is the real binding constraint regardless of the other knobs.
+    /// A host whose ceiling binds while the CPU is genuinely busy — the case
+    /// where the advice must NOT say "raise it".
+    fn saturated_host() -> HostMeasurements {
+        HostMeasurements {
+            cpu_idle_fraction: Some(0.05),
+            loadavg_1m: Some(24.0),
+            ..idle_worker_host()
+        }
+    }
+
+    /// Plenty of CPU and tokens, nearly-full scratch volume.
     fn disk_bound_host() -> HostMeasurements {
         HostMeasurements {
-            logical_cpus: 16,
-            cpu_headroom: 10,
-            disk_headroom: 3,
-            disk_free_gb: Some(6),
-            per_worktree_gb: 2,
-            token_axis_limit: 8,
-            ranking_present: true,
+            disk_headroom: 2,
+            disk_free_gb: Some(5),
+            configured_max_concurrent: 10,
+            ..idle_worker_host()
+        }
+    }
+
+    /// One healthy account: the token axis binds.
+    fn token_bound_host() -> HostMeasurements {
+        HostMeasurements {
+            token_axis_limit: 1,
             total_accounts: 8,
-            configured_max_concurrent: 3,
-            max_concurrent_env_override: false,
-            configured_per_token_concurrency: 2,
-            per_token_concurrency_env_override: false,
+            configured_max_concurrent: 10,
+            ..idle_worker_host()
         }
     }
 
     // ========================================================================
-    // Ceiling recommendation — makes the cpu term bind, with slack
+    // The cap is exactly `resolve_dynamic_max_concurrent` — no CPU term
     // ========================================================================
 
     #[test]
-    fn test_pilot_host_reproduces_hand_derived_ceiling_of_8() {
-        let r = recommend(&pilot_host());
-        assert_eq!(r.recommended_max_concurrent, 8, "6 + ceil(6*0.25)=2 -> 8, matching 3fdfbf81");
-        assert!(r.max_concurrent_changed);
-    }
-
-    #[test]
-    fn test_pilot_host_ceiling_binds_before_cpu_binds_after() {
-        let r = recommend(&pilot_host());
-        assert_eq!(r.binding_term_before, BindingTerm::Ceiling, "3 is the min(16, 700, 6, 3)");
-        assert_eq!(r.binding_term_after, BindingTerm::Cpu, "6 is the min(16, 700, 6, 8)");
-    }
-
-    #[test]
-    fn test_pilot_host_per_token_concurrency_unchanged() {
-        // Token axis (16) already comfortably exceeds the cpu/disk/ceiling
-        // floor (6) at the default factor of 2 — no reason to raise it.
-        let r = recommend(&pilot_host());
-        assert_eq!(r.recommended_per_token_concurrency, 2);
-        assert!(!r.per_token_concurrency_changed);
-    }
-
-    #[test]
-    fn test_laptop_host_already_correctly_sized_says_no_change() {
-        // cpu_target = 1 + ceil(1*0.25) = 2; current configured_max (3, the
-        // shipped default) is already >= that -> no change recommended.
-        let laptop = laptop_host();
-        let r = recommend(&laptop);
-        assert_eq!(r.recommended_max_concurrent, laptop.configured_max_concurrent);
-        assert!(
-            !r.max_concurrent_changed,
-            "an already-correctly-sized ceiling must say no change"
+    fn dynamic_cap_matches_the_three_term_admission_formula() {
+        let m = idle_worker_host();
+        // min(6 × 2 = 12, disk 36, maxConcurrent 3) = 3.
+        assert_eq!(m.dynamic_cap(), 3);
+        assert_eq!(
+            m.dynamic_cap(),
+            crate::work_finder::resolve_dynamic_max_concurrent(6, 2, 36, 3),
+            "calibrate must never compute a different cap than dispatch"
         );
     }
 
     #[test]
-    fn test_already_correctly_sized_ceiling_no_change_pilot_class() {
-        // Same pilot host, but the ceiling has ALREADY been hand-tuned to the
-        // recommended value (8) -> must not recommend a further change.
-        let mut m = pilot_host();
-        m.configured_max_concurrent = 8;
-        let r = recommend(&m);
-        assert_eq!(r.recommended_max_concurrent, 8);
-        assert!(!r.max_concurrent_changed);
-    }
-
-    #[test]
-    fn test_recommendation_never_lowers_the_ceiling() {
-        // An operator-set ceiling far above any measured headroom must never
-        // be recommended DOWNWARD (module docs: raising is always safe,
-        // lowering is never recommended — the other terms already clamp).
-        let mut m = pilot_host();
-        m.configured_max_concurrent = 100;
-        let r = recommend(&m);
-        assert_eq!(r.recommended_max_concurrent, 100);
-        assert!(!r.max_concurrent_changed);
+    fn a_95_percent_idle_host_is_no_longer_capped_by_its_cpu() {
+        // The #4512 evidence case: with maxConcurrent raised to 10, the cap
+        // follows — under the old formula the cpu term pinned it at 2.
+        let mut m = idle_worker_host();
+        m.configured_max_concurrent = 10;
+        assert_eq!(m.dynamic_cap(), 10);
+        assert_eq!(m.binding_term(), BindingTerm::Ceiling);
     }
 
     // ========================================================================
-    // Disk-bound host
+    // binding_term
     // ========================================================================
 
     #[test]
-    fn test_disk_bound_host_binds_on_disk_regardless_of_ceiling_recommendation() {
-        let r = recommend(&disk_bound_host());
-        // Raising the ceiling never fixes a disk-bound host: disk (3) is
-        // still the smallest term after the recommendation (min(16, 3, 10,
-        // 13)) — no config key exists that could change this.
-        assert_eq!(r.binding_term_after, BindingTerm::Disk);
+    fn binding_term_prefers_token_then_disk_then_ceiling() {
+        assert_eq!(binding_term(2, 5, 9), BindingTerm::Token);
+        assert_eq!(binding_term(9, 2, 5), BindingTerm::Disk);
+        assert_eq!(binding_term(9, 5, 2), BindingTerm::Ceiling);
+        // Ties resolve to the earliest term, matching `status`'s diagnosis.
+        assert_eq!(binding_term(3, 3, 3), BindingTerm::Token);
+        assert_eq!(binding_term(9, 3, 3), BindingTerm::Disk);
     }
 
     #[test]
-    fn test_disk_bound_host_has_no_config_key_for_disk() {
-        // There is no assertion target on Recommendation for this (disk has
-        // no config key at all — module docs) but the measurement round-trips
-        // for the render layer to surface the env-var alternative.
-        let m = disk_bound_host();
-        assert_eq!(m.per_worktree_gb, 2);
+    fn host_classes_bind_where_expected() {
+        assert_eq!(idle_worker_host().binding_term(), BindingTerm::Ceiling);
+        assert_eq!(disk_bound_host().binding_term(), BindingTerm::Disk);
+        assert_eq!(token_bound_host().binding_term(), BindingTerm::Token);
     }
 
     // ========================================================================
-    // Unbootstrapped / unhealthy token pool
+    // advice — the tuning read-out
     // ========================================================================
 
     #[test]
-    fn test_unbootstrapped_token_pool_falls_back_gracefully() {
-        let mut m = pilot_host();
-        m.token_axis_limit = 0;
-        m.ranking_present = false;
-        m.total_accounts = 0;
-        let r = recommend(&m);
-        // No factor helps a 0-healthy pool; must not panic or divide by zero.
-        assert_eq!(r.recommended_per_token_concurrency, m.configured_per_token_concurrency);
-        assert!(!r.per_token_concurrency_changed);
-        assert!(r.warnings.iter().any(|w| w.contains("No healthy accounts")));
+    fn advice_says_raise_the_knob_on_an_idle_ceiling_bound_host() {
+        let text = advice(&idle_worker_host());
+        assert!(text.contains("raise autonomous.workFinder.maxConcurrent"), "{text}");
+        assert!(text.contains("95% idle"), "{text}");
     }
 
     #[test]
-    fn test_missing_ranking_uses_raw_pool_size_without_warning() {
-        // ranking_present=false but token_axis_limit > 0 (the raw-pool-size
-        // fallback, e.g. no `loom-tokens check --ranking` has ever run) is a
-        // normal, non-alarming state — no "no healthy accounts" warning.
-        let mut m = pilot_host();
-        m.ranking_present = false;
-        m.total_accounts = 0;
-        // token_axis_limit stays 8 (the raw pool size fallback).
-        let r = recommend(&m);
-        assert!(!r.warnings.iter().any(|w| w.contains("No healthy accounts")));
-    }
-
-    // ========================================================================
-    // Per-token concurrency raised when tokens ARE the bottleneck
-    // ========================================================================
-
-    #[test]
-    fn test_per_token_concurrency_raised_when_tokens_are_the_bottleneck() {
-        // 2 healthy accounts, plenty of cpu/disk headroom and a raised
-        // ceiling target of 8 -> token axis at factor 2 (4) is below the
-        // resource floor (6, the cpu term) -> raise the factor to close the
-        // gap: ceil(6/2) = 3.
-        let mut m = pilot_host();
-        m.token_axis_limit = 2;
-        m.total_accounts = 2;
-        let r = recommend(&m);
-        assert_eq!(r.recommended_per_token_concurrency, 3);
-        assert!(r.per_token_concurrency_changed);
-    }
-
-    // ========================================================================
-    // Env overrides — warn that they mask a --write recommendation
-    // ========================================================================
-
-    #[test]
-    fn test_env_max_concurrent_override_warns_when_recommendation_changes() {
-        let mut m = pilot_host();
-        m.max_concurrent_env_override = true;
-        let r = recommend(&m);
-        assert!(r.max_concurrent_changed);
-        assert!(r
-            .warnings
-            .iter()
-            .any(|w| w.contains("LOOM_WORK_FINDER_MAX_CONCURRENT")));
+    fn advice_does_not_say_raise_when_the_host_is_saturated() {
+        let text = advice(&saturated_host());
+        assert!(!text.contains("raise autonomous"), "{text}");
+        assert!(text.contains("do not raise it further"), "{text}");
     }
 
     #[test]
-    fn test_env_max_concurrent_override_no_warning_when_already_correct() {
-        // The env override is present, but the recommendation matches the
-        // current value anyway -> nothing would actually be masked.
-        let mut m = pilot_host();
-        m.configured_max_concurrent = 8;
-        m.max_concurrent_env_override = true;
-        let r = recommend(&m);
-        assert!(!r.max_concurrent_changed);
-        assert!(!r
-            .warnings
-            .iter()
-            .any(|w| w.contains("LOOM_WORK_FINDER_MAX_CONCURRENT")));
-    }
-
-    // ========================================================================
-    // cpuUtilizationTarget / estCoresPerSweep miscalibration hint
-    // ========================================================================
-
-    #[test]
-    fn test_flags_cpu_pinned_at_floor_on_large_host() {
-        let mut m = pilot_host();
-        m.logical_cpus = 16;
-        m.cpu_headroom = 1;
-        let r = recommend(&m);
-        assert!(r
-            .warnings
-            .iter()
-            .any(|w| w.contains("estCoresPerSweep") || w.contains("cpuUtilizationTarget")));
+    fn advice_points_at_tokens_or_disk_when_those_bind() {
+        assert!(advice(&token_bound_host()).contains("loom-tokens bootstrap"));
+        assert!(advice(&disk_bound_host()).contains("LOOM_PER_WORKTREE_GB"));
+        // Neither should tell the operator to raise maxConcurrent — it would do
+        // nothing.
+        assert!(!advice(&token_bound_host()).contains("raise autonomous"));
+        assert!(!advice(&disk_bound_host()).contains("raise autonomous"));
     }
 
     #[test]
-    fn test_does_not_flag_cpu_floor_on_a_genuinely_small_host() {
-        // The laptop's cpu_headroom=1 is expected/normal for 4 cores — must
-        // not warn.
-        let r = recommend(&laptop_host());
-        assert!(!r.warnings.iter().any(|w| w.contains("estCoresPerSweep")));
+    fn advice_handles_a_host_with_no_idle_sample() {
+        let mut m = idle_worker_host();
+        m.cpu_idle_fraction = None;
+        assert!(advice(&m).contains("no CPU idle sample"));
     }
 
     // ========================================================================
@@ -970,205 +682,155 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn test_json_round_trips_measurements_and_recommendation() {
-        let m = pilot_host();
-        let r = recommend(&m);
-        let report = report_json(&m, &r, None);
+    fn json_round_trips_measurements_and_the_binding_term() {
+        let m = idle_worker_host();
+        let report = report_json(&m);
 
-        assert_eq!(report["measurements"]["logical_cpus"], 18);
-        assert_eq!(report["measurements"]["cpu_headroom"], 6);
+        assert_eq!(report["measurements"]["logical_cpus"], 8);
+        assert_eq!(report["measurements"]["cpu_idle_fraction"], 0.95);
         assert_eq!(report["measurements"]["configured_max_concurrent"], 3);
-        assert_eq!(report["recommendation"]["recommended_max_concurrent"], 8);
-        assert_eq!(report["recommendation"]["binding_term_before"], "ceiling");
-        assert_eq!(report["recommendation"]["binding_term_after"], "cpu");
+        assert_eq!(report["measurements"]["build_slots"], 1);
+        assert_eq!(report["dynamic_cap"], 3);
+        assert_eq!(report["binding_term"], "ceiling");
+        // #4512: calibrate never writes, so this is unconditionally false.
         assert_eq!(report["write"]["applied"], false);
         assert_eq!(report["restart_required"], true);
+        // The retired recommendation block must be gone, not silently zeroed.
+        assert!(report.get("recommendation").is_none());
 
-        // Round-trips through a full serialize/deserialize cycle without loss.
         let text = serde_json::to_string(&report).unwrap();
         let reparsed: Value = serde_json::from_str(&text).unwrap();
         assert_eq!(reparsed, report);
     }
 
     #[test]
-    fn test_json_reports_write_applied_when_given_a_path() {
-        let m = pilot_host();
-        let r = recommend(&m);
-        let path = PathBuf::from("/tmp/example/.loom/config.json");
-        let report = report_json(&m, &r, Some(&path));
-        assert_eq!(report["write"]["applied"], true);
-        assert_eq!(report["write"]["config_path"], "/tmp/example/.loom/config.json");
+    fn json_reports_no_cpu_headroom_term() {
+        let report = report_json(&idle_worker_host());
+        assert!(
+            report["measurements"].get("cpu_headroom").is_none(),
+            "the retired CPU headroom term must not reappear in the payload"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Knob provenance (#4512): the report must name WHICH file set the one
+    // knob that now carries the whole admission policy.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn json_names_the_config_tier_that_set_max_concurrent() {
+        let report = report_json(&idle_worker_host());
+        assert_eq!(report["measurements"]["max_concurrent_source"], "/repo/.loom/config.json");
     }
 
     #[test]
-    fn test_disk_headroom_unbounded_renders_as_string_not_a_giant_int() {
-        let mut m = pilot_host();
-        m.disk_headroom = usize::MAX;
-        m.disk_free_gb = None;
-        let json = m.to_json();
-        assert_eq!(json["disk_headroom"], "unbounded");
-    }
-
-    // ========================================================================
-    // Human report — smoke test (exact wording covered by other tests; this
-    // just guards against a panic and checks a few must-have substrings).
-    // ========================================================================
-
-    #[test]
-    fn test_human_report_contains_key_lines() {
-        let m = pilot_host();
-        let r = recommend(&m);
-        let text = report_human(&m, &r, None);
-        assert!(text.contains("loom-daemon calibrate"));
-        assert!(text.contains("maxConcurrent -> 8"));
-        assert!(text.contains("LOOM_PER_WORKTREE_GB"));
-        assert!(text.contains("Not writing changes"));
-        assert!(text.contains("loom-daemon-start.sh"));
+    fn json_reports_a_null_source_when_no_tier_sets_the_knob() {
+        let m = HostMeasurements {
+            max_concurrent_source: None,
+            ..idle_worker_host()
+        };
+        assert!(m.to_json()["max_concurrent_source"].is_null());
     }
 
     #[test]
-    fn test_human_report_names_the_written_path() {
-        let m = pilot_host();
-        let r = recommend(&m);
-        let path = PathBuf::from("/tmp/example/.loom/config.json");
-        let text = report_human(&m, &r, Some(&path));
-        assert!(text.contains("Wrote the recommendation above to /tmp/example/.loom/config.json"));
-    }
-
-    // ========================================================================
-    // --write config merge — scoping + idempotency
-    // ========================================================================
-
-    #[test]
-    fn test_merge_touches_only_workfinder_keys() {
-        let existing = serde_json::json!({
-            "autonomous": {
-                "cpuUtilizationTarget": 0.6,
-                "estCoresPerSweep": 3.5,
-                "perTokenConcurrency": 2,
-                "workFinder": {
-                    "enabled": true,
-                    "intervalSecs": 90,
-                    "maxConcurrent": 3,
-                    "maxAdmissionsPerTick": 4,
-                },
-                "roleRunner": { "enabled": true },
-            },
-            "unrelatedTopLevel": "preserved",
-        });
-
-        let merged = merge_workfinder_values(&existing, 8, 4);
-
-        // The two touched keys changed.
-        assert_eq!(merged["autonomous"]["workFinder"]["maxConcurrent"], 8);
-        assert_eq!(merged["autonomous"]["perTokenConcurrency"], 4);
-
-        // Every other key at every depth is untouched.
-        assert_eq!(merged["autonomous"]["cpuUtilizationTarget"], 0.6);
-        assert_eq!(merged["autonomous"]["estCoresPerSweep"], 3.5);
-        assert_eq!(merged["autonomous"]["workFinder"]["enabled"], true);
-        assert_eq!(merged["autonomous"]["workFinder"]["intervalSecs"], 90);
-        assert_eq!(merged["autonomous"]["workFinder"]["maxAdmissionsPerTick"], 4);
-        assert_eq!(merged["autonomous"]["roleRunner"]["enabled"], true);
-        assert_eq!(merged["unrelatedTopLevel"], "preserved");
-    }
-
-    #[test]
-    fn test_merge_is_idempotent_on_repeat_application() {
-        let existing = serde_json::json!({
-            "autonomous": { "workFinder": { "maxConcurrent": 3 } },
-        });
-        let once = merge_workfinder_values(&existing, 8, 4);
-        let twice = merge_workfinder_values(&once, 8, 4);
-        assert_eq!(once, twice, "applying the same recommendation twice must be a no-op diff");
-    }
-
-    #[test]
-    fn test_merge_from_empty_config_creates_the_nested_path() {
-        let merged = merge_workfinder_values(&serde_json::json!({}), 8, 4);
-        assert_eq!(merged["autonomous"]["workFinder"]["maxConcurrent"], 8);
-        assert_eq!(merged["autonomous"]["perTokenConcurrency"], 4);
-    }
-
-    #[test]
-    fn test_merge_from_non_object_falls_back_to_empty_base() {
-        // A malformed "existing" value (e.g. a JSON array) must not panic or
-        // propagate garbage — treated as an empty base.
-        let merged = merge_workfinder_values(&serde_json::json!([1, 2, 3]), 8, 4);
-        assert_eq!(merged["autonomous"]["workFinder"]["maxConcurrent"], 8);
-    }
-
-    // ========================================================================
-    // write_workfinder_config — filesystem round-trip + idempotency (AC)
-    // ========================================================================
-
-    #[test]
-    fn test_write_workfinder_config_creates_file_when_absent() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = write_workfinder_config(dir.path(), 8, 4).unwrap();
-        assert!(path.exists());
-        let contents = std::fs::read_to_string(&path).unwrap();
-        let parsed: Value = serde_json::from_str(&contents).unwrap();
-        assert_eq!(parsed["autonomous"]["workFinder"]["maxConcurrent"], 8);
-        assert_eq!(parsed["autonomous"]["perTokenConcurrency"], 4);
-    }
-
-    #[test]
-    fn test_write_workfinder_config_is_byte_idempotent_on_second_run() {
-        let dir = tempfile::tempdir().unwrap();
-        let path1 = write_workfinder_config(dir.path(), 8, 4).unwrap();
-        let bytes1 = std::fs::read(&path1).unwrap();
-        let path2 = write_workfinder_config(dir.path(), 8, 4).unwrap();
-        let bytes2 = std::fs::read(&path2).unwrap();
-        assert_eq!(
-            bytes1, bytes2,
-            "a repeat --write with the same recommendation must be byte-identical"
+    fn human_report_names_the_config_file_that_set_the_knob() {
+        let text = report_human(&idle_worker_host());
+        assert!(
+            text.contains("set by: /repo/.loom/config.json"),
+            "the operator must be told which file to edit:\n{text}"
         );
     }
 
     #[test]
-    fn test_write_workfinder_config_preserves_unrelated_consumer_keys() {
-        let dir = tempfile::tempdir().unwrap();
-        let loom_dir = dir.path().join(".loom");
-        std::fs::create_dir_all(&loom_dir).unwrap();
-        std::fs::write(
-            loom_dir.join("config.json"),
-            r#"{"worktree": {"root": "/custom/scratch"}, "autonomous": {"workFinder": {"maxConcurrent": 3}}}"#,
-        )
-        .unwrap();
-
-        let path = write_workfinder_config(dir.path(), 8, 4).unwrap();
-        let parsed: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
-        assert_eq!(parsed["worktree"]["root"], "/custom/scratch");
-        assert_eq!(parsed["autonomous"]["workFinder"]["maxConcurrent"], 8);
+    fn human_report_says_built_in_default_when_no_tier_sets_the_knob() {
+        let text = report_human(&HostMeasurements {
+            max_concurrent_source: None,
+            ..idle_worker_host()
+        });
+        assert!(text.contains("built-in default"), "{text}");
     }
 
     #[test]
-    fn test_write_workfinder_config_refuses_invalid_json() {
-        let dir = tempfile::tempdir().unwrap();
-        let loom_dir = dir.path().join(".loom");
-        std::fs::create_dir_all(&loom_dir).unwrap();
-        std::fs::write(loom_dir.join("config.json"), "not valid json").unwrap();
+    fn human_report_flags_a_config_tier_shadowed_by_the_env_var() {
+        // Editing the named file would change nothing while the env var is set —
+        // the exact trap #4512's operator note called out.
+        let text = report_human(&HostMeasurements {
+            max_concurrent_env_override: true,
+            ..idle_worker_host()
+        });
+        assert!(text.contains("shadowed by the env var"), "{text}");
+        assert!(text.contains("/repo/.loom/config.json"), "{text}");
+    }
 
-        let result = write_workfinder_config(dir.path(), 8, 4);
-        assert!(result.is_err());
-        // The original invalid content must survive untouched.
-        let contents = std::fs::read_to_string(loom_dir.join("config.json")).unwrap();
-        assert_eq!(contents, "not valid json");
+    #[test]
+    fn disk_headroom_unbounded_renders_as_string_not_a_giant_int() {
+        let mut m = idle_worker_host();
+        m.disk_headroom = usize::MAX;
+        m.disk_free_gb = None;
+        assert_eq!(m.to_json()["disk_headroom"], "unbounded");
     }
 
     // ========================================================================
-    // measure() smoke test — the only impure function; just guards against a
-    // panic against a real (empty) temp workspace. No live-probe assertions
-    // (host-dependent), per the #4390 test plan's "no live host probing" for
-    // the policy tests above.
+    // Human report
     // ========================================================================
 
     #[test]
-    fn test_measure_does_not_panic_on_an_empty_workspace() {
+    fn human_report_contains_key_lines() {
+        let text = report_human(&idle_worker_host());
+        assert!(text.contains("loom-daemon calibrate"));
+        assert!(text.contains("Dynamic concurrency cap: 3"));
+        assert!(text.contains("= min(healthy 6 × per-token 2 = 12, disk 36, maxConcurrent 3)"));
+        assert!(text.contains("binds on: ceiling"));
+        assert!(text.contains("build slots:    1"));
+        assert!(text.contains("LOOM_PER_WORKTREE_GB"));
+        assert!(text.contains("read-only"));
+        assert!(text.contains("loom-daemon-start.sh"));
+    }
+
+    #[test]
+    fn human_report_flags_a_disabled_build_slot() {
+        let mut m = idle_worker_host();
+        m.build_slots = 0;
+        assert!(report_human(&m).contains("0 — DISABLED"));
+    }
+
+    #[test]
+    fn human_report_handles_unmeasurable_disk_and_missing_cpu_signal() {
+        let mut m = idle_worker_host();
+        m.disk_headroom = usize::MAX;
+        m.disk_free_gb = None;
+        m.cpu_idle_fraction = None;
+        m.loadavg_1m = None;
+        let text = report_human(&m);
+        assert!(text.contains("unmeasurable"));
+        assert!(text.contains("no CPU signal available"));
+    }
+
+    #[test]
+    fn human_report_names_env_overrides() {
+        let mut m = idle_worker_host();
+        m.max_concurrent_env_override = true;
+        m.per_token_concurrency_env_override = true;
+        let text = report_human(&m);
+        assert!(text.contains("from LOOM_WORK_FINDER_MAX_CONCURRENT"));
+        assert!(text.contains("from LOOM_PER_TOKEN_CONCURRENCY"));
+    }
+
+    // ========================================================================
+    // measure() smoke test — the only impure function; guards against a panic
+    // against a real (empty) temp workspace. No live-probe assertions (host
+    // dependent).
+    // ========================================================================
+
+    #[test]
+    fn measure_does_not_panic_on_an_empty_workspace() {
         let dir = tempfile::tempdir().unwrap();
         let m = measure(dir.path());
         assert!(m.logical_cpus >= 1);
-        assert!(m.cpu_headroom >= 1);
+        // Whatever the host reports, the derived numbers must be coherent.
+        assert_eq!(m.dynamic_cap(), m.dynamic_cap());
+        if let Some(idle) = m.cpu_idle_fraction {
+            assert!((0.0..=1.0).contains(&idle));
+        }
     }
 }

--- a/loom-daemon/src/capacity.rs
+++ b/loom-daemon/src/capacity.rs
@@ -3,8 +3,8 @@
 //!
 //! The work finder (#3810) drives approved `loom:issue` work to dispatch, and
 //! #3811 bounds its concurrency by `min(token-pool size, disk headroom,
-//! cpu/load headroom (#3978), configured max)`. That policy treats the token
-//! pool as a flat count of
+//! configured max)` (a CPU/load term sat in that `min` from #3978 until #4512
+//! removed it). That policy treats the token pool as a flat count of
 //! `*.token` files — but at scale accounts hit their 5h/7d rate limits and go
 //! **exhausted**. Dispatching to an exhausted account produces the startup
 //! hangs / mid-build deaths seen while dogfooding. This module makes the
@@ -375,20 +375,18 @@ pub struct PressureAssessment {
 /// - `pool_size` — raw `*.token` count (the fallback health basis).
 /// - `token_limit` — the health-adjusted token-axis limit
 ///   ([`token_axis_limit`]).
-/// - `disk` / `cpu` / `configured_max` — the other three dynamic-cap axes
-///   (`cpu` added in #3978 — [`crate::cpu_headroom::cpu_headroom_limit`]).
+/// - `disk` / `configured_max` — the other two dynamic-cap axes. (A `cpu` axis
+///   sat here from #3978 until #4512 removed the CPU term from admission — see
+///   [`crate::work_finder::resolve_dynamic_max_concurrent`].)
 /// - `deferred` — issues the tick deferred for capacity ([`crate`]'s
 ///   `TickReport::deferred_capacity`).
 /// - `min_queued` — the advisory threshold ([`DEFAULT_ADVISORY_MIN_QUEUED`]).
 ///
-/// `token_bound` requires that the token axis is the (co-)minimum of all four
-/// cap axes: dispatch is held back by tokens specifically, not by a full disk,
-/// CPU contention, or the operator ceiling. This keeps the advisory from firing
-/// (and misleadingly telling the operator to add token accounts) when the real
-/// bottleneck is disk, CPU, or a deliberately low `maxConcurrent` — the #3978
-/// incident this guards against: a token-axis jump (exhausted accounts
-/// resetting) looks token-bound by the pre-#3978 three-axis check even though
-/// concurrent Rust builds had already made CPU the actual constraint.
+/// `token_bound` requires that the token axis is the (co-)minimum of every cap
+/// axis: dispatch is held back by tokens specifically, not by a full disk or the
+/// operator ceiling. This keeps the advisory from firing (and misleadingly
+/// telling the operator to add token accounts) when the real bottleneck is disk
+/// or a deliberately low `maxConcurrent`.
 #[must_use]
 #[allow(clippy::too_many_arguments)] // one axis per dynamic-cap input + the
                                      // advisory threshold; grouping them into a
@@ -399,13 +397,11 @@ pub fn assess_pressure(
     pool_size: usize,
     token_limit: usize,
     disk: usize,
-    cpu: usize,
     configured_max: usize,
     deferred: usize,
     min_queued: usize,
 ) -> PressureAssessment {
-    let token_bound =
-        deferred > 0 && token_limit <= disk && token_limit <= cpu && token_limit <= configured_max;
+    let token_bound = deferred > 0 && token_limit <= disk && token_limit <= configured_max;
     let pressured = token_bound && deferred >= min_queued;
 
     let (total_accounts, healthy_accounts, exhausted_accounts) = match ranking {
@@ -983,7 +979,7 @@ mod tests {
     fn assess_not_token_bound_when_nothing_deferred() {
         // No deferral ⇒ not token-bound, not pressured, regardless of health.
         let s = snap(7, 3);
-        let a = assess_pressure(Some(&s), 7, 3, 10, 10, 10, 0, DEFAULT_ADVISORY_MIN_QUEUED);
+        let a = assess_pressure(Some(&s), 7, 3, 10, 10, 0, DEFAULT_ADVISORY_MIN_QUEUED);
         assert!(!a.token_bound);
         assert!(!a.pressured);
         assert_eq!(a.healthy_accounts, 3);
@@ -992,9 +988,9 @@ mod tests {
 
     #[test]
     fn assess_token_bound_when_token_axis_is_min_and_deferred() {
-        // token_limit 3 < disk 10, cpu 10, and ceiling 10, with 4 deferred ⇒ token-bound.
+        // token_limit 3 < disk 10 and ceiling 10, with 4 deferred ⇒ token-bound.
         let s = snap(7, 3);
-        let a = assess_pressure(Some(&s), 7, 3, 10, 10, 10, 4, DEFAULT_ADVISORY_MIN_QUEUED);
+        let a = assess_pressure(Some(&s), 7, 3, 10, 10, 4, DEFAULT_ADVISORY_MIN_QUEUED);
         assert!(a.token_bound);
         assert!(a.pressured);
         assert_eq!(a.queued, 4);
@@ -1006,7 +1002,7 @@ mod tests {
     fn assess_not_token_bound_when_disk_is_the_binding_axis() {
         // disk 2 < token_limit 3 ⇒ the bottleneck is disk, not tokens.
         let s = snap(7, 3);
-        let a = assess_pressure(Some(&s), 7, 3, 2, 10, 10, 5, DEFAULT_ADVISORY_MIN_QUEUED);
+        let a = assess_pressure(Some(&s), 7, 3, 2, 10, 5, DEFAULT_ADVISORY_MIN_QUEUED);
         assert!(!a.token_bound, "disk binds, so no token advisory");
         assert!(!a.pressured);
     }
@@ -1015,20 +1011,8 @@ mod tests {
     fn assess_not_token_bound_when_ceiling_is_the_binding_axis() {
         // configured_max 2 < token_limit 3 ⇒ operator ceiling binds, not tokens.
         let s = snap(7, 3);
-        let a = assess_pressure(Some(&s), 7, 3, 10, 10, 2, 5, DEFAULT_ADVISORY_MIN_QUEUED);
+        let a = assess_pressure(Some(&s), 7, 3, 10, 2, 5, DEFAULT_ADVISORY_MIN_QUEUED);
         assert!(!a.token_bound);
-        assert!(!a.pressured);
-    }
-
-    #[test]
-    fn assess_not_token_bound_when_cpu_is_the_binding_axis() {
-        // cpu 2 < token_limit 3 ⇒ the bottleneck is CPU/load contention, not
-        // tokens — the #3978 scenario (a token-axis jump from resetting
-        // accounts, while concurrent Rust builds have already saturated the
-        // host). The advisory must not misattribute this to token capacity.
-        let s = snap(7, 3);
-        let a = assess_pressure(Some(&s), 7, 3, 10, 2, 10, 5, DEFAULT_ADVISORY_MIN_QUEUED);
-        assert!(!a.token_bound, "cpu binds, so no token advisory");
         assert!(!a.pressured);
     }
 
@@ -1036,7 +1020,7 @@ mod tests {
     fn assess_drain_none_when_no_healthy_accounts() {
         // All exhausted (token_limit 0), work queued ⇒ token-bound, no drain ETA.
         let s = snap(4, 0);
-        let a = assess_pressure(Some(&s), 4, 0, 10, 10, 10, 3, DEFAULT_ADVISORY_MIN_QUEUED);
+        let a = assess_pressure(Some(&s), 4, 0, 10, 10, 3, DEFAULT_ADVISORY_MIN_QUEUED);
         assert!(a.token_bound);
         assert!(a.pressured);
         assert_eq!(a.healthy_accounts, 0);
@@ -1047,7 +1031,7 @@ mod tests {
     fn assess_no_ranking_treats_pool_as_healthy() {
         // No ranking ⇒ pool treated as fully healthy; still token-bound if the
         // pool-sized limit is the min and work is deferred.
-        let a = assess_pressure(None, 2, 2, 10, 10, 10, 3, DEFAULT_ADVISORY_MIN_QUEUED);
+        let a = assess_pressure(None, 2, 2, 10, 10, 3, DEFAULT_ADVISORY_MIN_QUEUED);
         assert!(a.token_bound);
         assert_eq!(a.healthy_accounts, 2);
         assert_eq!(a.exhausted_accounts, 0);
@@ -1058,7 +1042,7 @@ mod tests {
     fn assess_threshold_gates_pressured() {
         // token_bound but below the queued threshold ⇒ not yet pressured.
         let s = snap(7, 3);
-        let a = assess_pressure(Some(&s), 7, 3, 10, 10, 10, 2, 5);
+        let a = assess_pressure(Some(&s), 7, 3, 10, 10, 2, 5);
         assert!(a.token_bound);
         assert!(!a.pressured, "2 queued < threshold 5");
     }
@@ -1070,7 +1054,7 @@ mod tests {
     #[test]
     fn advisory_pressure_names_the_levers() {
         let s = snap(7, 1);
-        let a = assess_pressure(Some(&s), 7, 1, 10, 10, 10, 12, DEFAULT_ADVISORY_MIN_QUEUED);
+        let a = assess_pressure(Some(&s), 7, 1, 10, 10, 12, DEFAULT_ADVISORY_MIN_QUEUED);
         let adv = CapacityAdvisory::pressure(&a);
         assert!(adv.pressured);
         assert_eq!(adv.queued, 12);
@@ -1084,7 +1068,7 @@ mod tests {
     #[test]
     fn advisory_recovery_is_symmetric() {
         let s = snap(7, 7);
-        let a = assess_pressure(Some(&s), 7, 7, 10, 10, 10, 0, DEFAULT_ADVISORY_MIN_QUEUED);
+        let a = assess_pressure(Some(&s), 7, 7, 10, 10, 0, DEFAULT_ADVISORY_MIN_QUEUED);
         let adv = CapacityAdvisory::recovery(&a);
         assert!(!adv.pressured);
         assert!(adv.message.contains("restored"));
@@ -1094,7 +1078,7 @@ mod tests {
     #[test]
     fn advisory_pressure_message_handles_zero_healthy() {
         let s = snap(3, 0);
-        let a = assess_pressure(Some(&s), 3, 0, 10, 10, 10, 5, DEFAULT_ADVISORY_MIN_QUEUED);
+        let a = assess_pressure(Some(&s), 3, 0, 10, 10, 5, DEFAULT_ADVISORY_MIN_QUEUED);
         let adv = CapacityAdvisory::pressure(&a);
         assert!(adv.message.contains("no healthy accounts"));
     }

--- a/loom-daemon/src/config_resolver.rs
+++ b/loom-daemon/src/config_resolver.rs
@@ -154,6 +154,47 @@ pub fn resolve_effective_config(repo_root: &Path) -> Value {
     effective
 }
 
+/// The tier files consulted by [`resolve_effective_config`], **highest
+/// precedence first** — the reverse of the merge order, i.e. the order in which
+/// to search for "who actually supplied this value".
+///
+/// The private/shared defaults tier is included only when
+/// [`private_defaults_path`] resolves (it is disabled by an empty
+/// [`PRIVATE_DEFAULTS_ENV`], and absent on any host without the machine-level
+/// checkout). Paths are returned whether or not the file exists — a caller that
+/// cares reads it with the same soft-fail contract the merge uses.
+#[must_use]
+pub fn tier_paths_by_precedence(repo_root: &Path) -> Vec<PathBuf> {
+    let mut paths = vec![
+        repo_root.join(LOCAL_CONFIG_REL),
+        repo_root.join(PROJECT_CONFIG_REL),
+        repo_root.join(LEGACY_CONFIG_REL),
+    ];
+    paths.extend(private_defaults_path());
+    paths
+}
+
+/// Which tier file actually supplied `dotted` — the highest-precedence tier in
+/// which the key is present and non-null, or `None` when no tier sets it (the
+/// caller's env/default fallback is what supplied the value).
+///
+/// This exists because a **multi-workspace** daemon makes "which
+/// `.loom/config.json` did that number come from?" a real operator question
+/// (#4512): the effective config is a merge across up to four files, and a knob
+/// that reads as `3` might be a repo's committed value, a host-local override,
+/// or the built-in default. Reporting the provenance alongside the value —
+/// rather than only the value — is the same fix `token_pool_dir` applied to the
+/// token pool's directory ambiguity in #4292.
+///
+/// Soft-fail throughout: an unreadable or malformed tier simply cannot be the
+/// source, exactly as it contributes nothing to the merge.
+#[must_use]
+pub fn source_of(repo_root: &Path, dotted: &str) -> Option<PathBuf> {
+    tier_paths_by_precedence(repo_root)
+        .into_iter()
+        .find(|path| get_path(&soft_read_json_object(path), dotted).is_some_and(|v| !v.is_null()))
+}
+
 /// Look up a dotted key path (e.g. `"autonomous.workFinder.enabled"`) in an
 /// already-resolved effective config tree. Returns `None` on any missing
 /// segment or when a non-object value is indexed further.
@@ -432,6 +473,99 @@ mod tests {
     // Python: `loom-tools/tests/test_config_resolver.py`
     // (`TestConformanceFixture`). Bash:
     // `defaults/scripts/tests/test-config-resolver.sh`.
+
+    // ===== source_of / tier_paths_by_precedence (#4512) =====
+
+    #[test]
+    #[serial]
+    fn test_tier_paths_are_ordered_highest_precedence_first() {
+        std::env::set_var(PRIVATE_DEFAULTS_ENV, "");
+        let root = tempdir().unwrap();
+        let paths = tier_paths_by_precedence(root.path());
+        std::env::remove_var(PRIVATE_DEFAULTS_ENV);
+        // Reverse of the merge order in `resolve_effective_config`, so the first
+        // tier that sets a key is the one that actually supplied it.
+        assert_eq!(
+            paths,
+            vec![
+                root.path().join(LOCAL_CONFIG_REL),
+                root.path().join(PROJECT_CONFIG_REL),
+                root.path().join(LEGACY_CONFIG_REL),
+            ]
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_source_of_names_the_legacy_tier_when_only_it_sets_the_key() {
+        std::env::set_var(PRIVATE_DEFAULTS_ENV, "");
+        let root = tempdir().unwrap();
+        write(
+            &root.path().join(LEGACY_CONFIG_REL),
+            r#"{"autonomous": {"workFinder": {"maxConcurrent": 8}}}"#,
+        );
+        let src = source_of(root.path(), "autonomous.workFinder.maxConcurrent");
+        std::env::remove_var(PRIVATE_DEFAULTS_ENV);
+        assert_eq!(src, Some(root.path().join(LEGACY_CONFIG_REL)));
+    }
+
+    #[test]
+    #[serial]
+    fn test_source_of_prefers_the_highest_precedence_tier_that_sets_the_key() {
+        std::env::set_var(PRIVATE_DEFAULTS_ENV, "");
+        let root = tempdir().unwrap();
+        write(
+            &root.path().join(LEGACY_CONFIG_REL),
+            r#"{"autonomous": {"workFinder": {"maxConcurrent": 8}}}"#,
+        );
+        write(
+            &root.path().join(LOCAL_CONFIG_REL),
+            r#"{"autonomous": {"workFinder": {"maxConcurrent": 20}}}"#,
+        );
+        let src = source_of(root.path(), "autonomous.workFinder.maxConcurrent");
+        std::env::remove_var(PRIVATE_DEFAULTS_ENV);
+        assert_eq!(
+            src,
+            Some(root.path().join(LOCAL_CONFIG_REL)),
+            "the host-local override is what dispatch actually sees"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_source_of_is_none_when_no_tier_sets_the_key_or_sets_it_null() {
+        std::env::set_var(PRIVATE_DEFAULTS_ENV, "");
+        let root = tempdir().unwrap();
+        assert_eq!(source_of(root.path(), "autonomous.workFinder.maxConcurrent"), None);
+
+        // An explicit `null` is "not set" — it must not be reported as a source.
+        write(
+            &root.path().join(LEGACY_CONFIG_REL),
+            r#"{"autonomous": {"workFinder": {"maxConcurrent": null}}}"#,
+        );
+        let src = source_of(root.path(), "autonomous.workFinder.maxConcurrent");
+        std::env::remove_var(PRIVATE_DEFAULTS_ENV);
+        assert_eq!(src, None);
+    }
+
+    #[test]
+    #[serial]
+    fn test_source_of_skips_a_malformed_tier_instead_of_erroring() {
+        std::env::set_var(PRIVATE_DEFAULTS_ENV, "");
+        let root = tempdir().unwrap();
+        write(&root.path().join(LOCAL_CONFIG_REL), "{ this is not json");
+        write(
+            &root.path().join(LEGACY_CONFIG_REL),
+            r#"{"autonomous": {"workFinder": {"maxConcurrent": 8}}}"#,
+        );
+        let src = source_of(root.path(), "autonomous.workFinder.maxConcurrent");
+        std::env::remove_var(PRIVATE_DEFAULTS_ENV);
+        assert_eq!(
+            src,
+            Some(root.path().join(LEGACY_CONFIG_REL)),
+            "a malformed tier contributes nothing to the merge, so it cannot be the source"
+        );
+    }
 
     fn conformance_fixture_dir() -> PathBuf {
         Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/loom-daemon/src/cpu_headroom.rs
+++ b/loom-daemon/src/cpu_headroom.rs
@@ -1,33 +1,38 @@
-//! CPU/load headroom term for the autonomous work-finder's dynamic
-//! concurrency cap (Issue #3978).
+//! Host CPU **measurement** — logical core count, load average, and measured
+//! idle fraction (#3978/#4031), plus the shared "is the host saturated?"
+//! predicate (#4259).
 //!
-//! [`crate::work_finder::resolve_dynamic_max_concurrent`] bounds the dynamic
-//! cap by `min(healthy_tokens × per_token, disk_headroom, configured_max)`.
-//! That formula models the token pool and the scratch-volume disk, but not
-//! CPU — so when a batch of exhausted tokens resets and the token axis jumps
-//! (e.g. 5 accounts recovering pushes it from ~2 to ~14), the daemon can
-//! dispatch far more concurrent `cargo build`s than the host has cores for.
-//! The result observed in #3978: 2-3 concurrent Rust builds in worktrees
-//! starved `build-gate.sh` of CPU badly enough that it hit its own 600s
-//! timeout, which the (separate, already-fixed-elsewhere — see #3974) gate
-//! then misreported as a verified-red `main`, halting all dispatch.
+//! # This module no longer gates admission (#4512)
 //!
-//! This module adds a fourth axis to the cap: how many *additional*
-//! concurrent sweeps the host's CPU can currently absorb, given
+//! Until #4512 this module also computed a *concurrency term*: `cpu_headroom =
+//! (logical_cpus × cpuUtilizationTarget − consumed_cores) / estCoresPerSweep`,
+//! folded into [`crate::work_finder::resolve_dynamic_max_concurrent`]'s
+//! `min(...)`. That term is **deleted**. It priced every sweep as if it were a
+//! build (`estCoresPerSweep`), so it throttled the ~90% of sweep wall-clock
+//! that is API-wait (curator / builder / judge conversations) in order to
+//! defend against the minority heavy-build case — measurably: an 8-core worker
+//! sitting **95% idle** was capped at 2 concurrent sweeps. The replacement, per
+//! #4512, is two-part:
 //!
-//! 1. **static capacity** — `logical_cpus × utilization_target`, the number
-//!    of cores this host is willing to dedicate to sweep work (leaving
-//!    headroom for the OS, the daemon itself, and the build-gate's own
-//!    `cargo` invocations), and
-//! 2. **current CPU consumption** — `logical_cpus × (1 − idle_fraction)`,
-//!    the number of cores actually being *consumed* right now, subtracted
-//!    from that capacity so a host that is already busy (someone else's
-//!    build, a live sweep mid-compile) backs the term off reactively.
+//! - **admission** is one per-machine knob (`autonomous.workFinder.maxConcurrent`),
+//!   tuned empirically by the operator, alongside the two hard exhaustible-resource
+//!   floors (the token axis and disk headroom);
+//! - **the genuinely heavy stages serialize where they occur**, via the
+//!   machine-wide build slot ([`crate::build_slot`]).
 //!
-//! Dividing the resulting headroom by an estimated per-sweep core cost
-//! (`est_cores_per_sweep` — a `cargo build`/`clippy` invocation typically
-//! parallelizes across several cores via rustc codegen units) yields how many
-//! more concurrent sweeps the host can start right now.
+//! What remains here is pure measurement, consumed by:
+//!
+//! - the **host-distress circuit breaker** (#4235 — [`load_per_core`]), the
+//!   load safety net that makes a hand-tuned ceiling safe to raise: a mis-set
+//!   knob trips a *measured* breaker instead of melting the host;
+//! - the **build gate's load-aware deferral** (#4259 — [`is_host_saturated`]);
+//! - `loom-daemon status` / `loom-daemon calibrate`, which report the host's
+//!   observed idle fraction so an operator can *see* whether the current
+//!   `maxConcurrent` is leaving the host idle or saturated.
+//!
+//! `LOOM_CPU_UTILIZATION_TARGET` / `LOOM_EST_CORES_PER_SWEEP` (and their
+//! `autonomous.*` config twins) are **accepted-but-ignored** with a one-shot
+//! deprecation warning — see [`crate::work_finder::warn_deprecated_cpu_knobs`].
 //!
 //! # Why measured idle fraction, not the load average (#4031)
 //!
@@ -40,9 +45,10 @@
 //! I/O**, which inflate load without consuming a core. That pointed the
 //! feedback loop the wrong way: more concurrent sweeps → more blocked `claude`
 //! processes → higher load average → *lower* concurrency cap, even while the
-//! CPU sat idle. This module now derives `consumed_cores` from a **measured
-//! idle fraction** (actual CPU consumption), per-platform, and keeps the load
-//! average only as a fail-open fallback.
+//! CPU sat idle. So the reported CPU **consumption** signal is a measured idle
+//! fraction, per-platform, with the load average kept only as a fallback for
+//! reporting and as the (separate, deliberately load-average-based) input to
+//! the saturation predicate and the host breaker.
 //!
 //! # Why shell out / read `/proc` instead of a `sysinfo`-style crate
 //!
@@ -70,22 +76,15 @@
 //!
 //! # Fail-open, not fail-closed
 //!
-//! The signal chain is **measured idle fraction → 1-minute load average →
-//! static capacity**, each stage falling forward to the next when its input is
-//! unavailable. An unreadable utilization signal (no `/proc/stat`, missing
-//! `iostat`, unsupported platform, or simply no delta sampled yet) falls back
-//! to the load average (#3978's behavior); an unreadable load average in turn
-//! falls back to the **static** capacity term (no consumption subtracted)
-//! rather than treating the read failure as "host fully loaded". This mirrors
-//! [`crate::capacity::token_axis_limit`]'s policy of falling back to the
-//! optimistic basis (the raw pool) when no ranking data exists — the absence
-//! of a signal is not evidence of unhealthiness. The term itself is floored
-//! at `1` (never `0`): like the token axis's "one healthy account is the
-//! throughput floor, never a halt" (#3902), a single mis-calibrated or noisy
-//! CPU reading must not be able to wedge the whole dynamic cap shut on its
-//! own — [`crate::disk_headroom`] and the token axis are the terms allowed to
-//! floor to zero (genuine "no room"/"no healthy accounts" signals); CPU is
-//! deliberately a soft backoff, not a hard gate.
+//! Every read here returns `Option` and **absent evidence is never treated as
+//! bad news**: an unreadable idle signal (no `/proc/stat`, missing `iostat`,
+//! unsupported platform, or simply no delta sampled yet) is `None`, and every
+//! consumer must fail safe on `None` rather than assume "host fully loaded" —
+//! [`is_host_saturated`] returns `None` so the build gate runs instead of
+//! deferring, and the host breaker treats a missing sample as a non-observation.
+//! This mirrors [`crate::capacity::token_axis_limit`]'s policy of falling back
+//! to the optimistic basis (the raw pool) when no ranking data exists: the
+//! absence of a signal is not evidence of unhealthiness.
 
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -95,146 +94,6 @@ use std::time::{Duration, Instant};
 // doesn't warn on an unused import under `-D warnings`.
 #[cfg(target_os = "macos")]
 use std::process::{Command, Stdio};
-
-// ============================================================================
-// Configuration (env > config > default — #4032)
-// ============================================================================
-//
-// Both knobs resolve **env > `.loom/config.json` → `autonomous.*` > default**,
-// matching every other autonomous-dispatch knob (`workFinder`,
-// `mainHealthGate`, `perTokenConcurrency`, `tokenRankingRefresh`,
-// `roleRunner`). Resolution is single-root and startup-time — read once from
-// the daemon's primary workspace via [`crate::work_finder::WorkFinderConfig`]
-// and threaded through as plain `f64`s — exactly like
-// [`crate::work_finder::resolve_per_token_concurrency`], not per-workspace
-// (the dynamic cap is one global number per tick; see
-// `crate::work_finder::spawn_multi_work_finder_task`'s module docs).
-//
-// `LOOM_PER_WORKTREE_GB` in [`crate::disk_headroom`] deliberately does **not**
-// get the same treatment here (#4032 decision, recorded rather than
-// implemented): it has a second, independent Bash-side reader
-// (`defaults/scripts/lib/disk-headroom.sh`, consumed by `/loom:sweep` Stage -1
-// wave sizing). Migrating only the Rust side would make the same env var honor
-// `.loom/config.json` on the daemon path while silently ignoring it on the
-// sweep path — a worse, divergent state than today's consistent env-only
-// behavior. Moving both means wiring the Bash `config-resolver.sh` into
-// `disk-headroom.sh` too, which is a separate, larger change. File a follow-up
-// if that cost is judged worth paying.
-
-/// Environment variable overriding the fraction of logical CPUs the dynamic
-/// cap is willing to dedicate to sweep work. Wins over
-/// `autonomous.cpuUtilizationTarget`.
-pub const UTILIZATION_TARGET_ENV: &str = "LOOM_CPU_UTILIZATION_TARGET";
-
-/// Default CPU utilization target: 75% of logical cores. Leaves headroom for
-/// the OS, the daemon process itself, and (crucially, per #3978) the
-/// build-gate's own `cargo`/`clippy` invocations so a fully-subscribed sweep
-/// fleet doesn't starve the gate outright.
-pub const DEFAULT_UTILIZATION_TARGET: f64 = 0.75;
-
-/// Environment variable overriding the estimated CPU cores a single
-/// concurrent sweep consumes while its build/test step is running. Wins over
-/// `autonomous.estCoresPerSweep`.
-pub const EST_CORES_PER_SWEEP_ENV: &str = "LOOM_EST_CORES_PER_SWEEP";
-
-/// Default estimated cores per sweep. `cargo build`/`clippy` parallelize
-/// rustc codegen across multiple cores; `2.0` is a conservative estimate for
-/// a Rust-heavy repo like this one (per #4031's measurement, this is now the
-/// calibrated figure for the primary host rather than an un-measured guess —
-/// still tunable per repo/host via [`EST_CORES_PER_SWEEP_ENV`] or
-/// `autonomous.estCoresPerSweep`).
-///
-/// # The release-build fan-out footgun (#4234, Gap 2 of the #4231 decomposition)
-///
-/// `2.0` is calibrated against typical `cargo check`/`clippy`/debug-build
-/// sweep phases (#4031), **not** the release-build fan-out that triggered the
-/// #4231 host meltdown. `cargo build --release` parallelizes codegen units
-/// across every logical core rustc can grab — a single release build can
-/// legitimately consume close to `ncpu` cores on its own, not `2`. Six
-/// concurrent release-building sweeps on a 28-core host is demand-side closer
-/// to `6 × 28` than `6 × 2`; at the default `2.0` this term under-estimates
-/// consumption by roughly an order of magnitude during exactly the phase that
-/// matters most.
-///
-/// This is a **calibration** gap, not a formula bug: [`cpu_headroom`] and its
-/// floor-at-`1` "never a hard halt" policy are working as designed (#3902's
-/// precedent — CPU is a soft backoff term, not `disk_headroom`'s or the token
-/// axis's hard floor-at-zero). A repo whose sweeps spend meaningful time in a
-/// release build should raise `LOOM_EST_CORES_PER_SWEEP` /
-/// `autonomous.estCoresPerSweep` well above `2.0` — plausibly toward
-/// `logical_cpu_count()` itself for a repo where release builds dominate sweep
-/// wall-clock time — rather than relying on this default. #4234 adds a second,
-/// independent backstop for exactly this under-estimate: the work finder's
-/// per-tick admission (ramp) cap
-/// ([`crate::work_finder::WORK_FINDER_MAX_ADMISSIONS_PER_TICK_ENV`]) bounds how
-/// many *new* sweeps land in any single tick regardless of how (mis)calibrated
-/// this term is, so a wrong `estCoresPerSweep` no longer alone determines
-/// whether a whole wave lands in one tick.
-pub const DEFAULT_EST_CORES_PER_SWEEP: f64 = 2.0;
-
-/// Env override for [`UTILIZATION_TARGET_ENV`] — `None` when unset,
-/// unparseable, or outside `(0, 1]` (a value of `0` would collapse capacity to
-/// nothing; a value `> 1` would claim more than the whole host).
-fn env_utilization_target() -> Option<f64> {
-    std::env::var(UTILIZATION_TARGET_ENV)
-        .ok()
-        .and_then(|v| v.trim().parse::<f64>().ok())
-        .filter(|f| *f > 0.0 && *f <= 1.0)
-}
-
-/// Env override for [`EST_CORES_PER_SWEEP_ENV`] — `None` when unset,
-/// unparseable, or `<= 0`.
-fn env_est_cores_per_sweep() -> Option<f64> {
-    std::env::var(EST_CORES_PER_SWEEP_ENV)
-        .ok()
-        .and_then(|v| v.trim().parse::<f64>().ok())
-        .filter(|f| *f > 0.0)
-}
-
-/// Resolve the CPU utilization target with precedence **env > config >
-/// default**. `config` is the already-range-filtered
-/// `autonomous.cpuUtilizationTarget` value from
-/// [`crate::work_finder::read_work_finder_config`] (`None` when absent,
-/// malformed, or out of `(0, 1]`).
-#[must_use]
-pub fn resolve_utilization_target(config: Option<f64>) -> f64 {
-    env_utilization_target()
-        .or(config)
-        .unwrap_or(DEFAULT_UTILIZATION_TARGET)
-}
-
-/// Resolve the estimated cores-per-sweep with precedence **env > config >
-/// default**. `config` is the already-range-filtered
-/// `autonomous.estCoresPerSweep` value from
-/// [`crate::work_finder::read_work_finder_config`] (`None` when absent,
-/// malformed, or `<= 0`).
-#[must_use]
-pub fn resolve_est_cores_per_sweep(config: Option<f64>) -> f64 {
-    env_est_cores_per_sweep()
-        .or(config)
-        .unwrap_or(DEFAULT_EST_CORES_PER_SWEEP)
-}
-
-/// Resolve [`UTILIZATION_TARGET_ENV`] alone, falling back to
-/// [`DEFAULT_UTILIZATION_TARGET`] when unset, unparseable, or outside `(0,
-/// 1]`. Env-only convenience wrapper around [`resolve_utilization_target`]
-/// for callers with no config value in hand (e.g. ad-hoc tooling); production
-/// call sites resolve config too and should call [`resolve_utilization_target`]
-/// directly.
-#[must_use]
-pub fn utilization_target() -> f64 {
-    resolve_utilization_target(None)
-}
-
-/// Resolve [`EST_CORES_PER_SWEEP_ENV`] alone, falling back to
-/// [`DEFAULT_EST_CORES_PER_SWEEP`] when unset, unparseable, or `<= 0`.
-/// Env-only convenience wrapper around [`resolve_est_cores_per_sweep`] for
-/// callers with no config value in hand; production call sites resolve
-/// config too and should call [`resolve_est_cores_per_sweep`] directly.
-#[must_use]
-pub fn est_cores_per_sweep() -> f64 {
-    resolve_est_cores_per_sweep(None)
-}
 
 // ============================================================================
 // Logical CPU count
@@ -590,125 +449,10 @@ pub fn cached_cpu_idle_fraction() -> Option<f64> {
         .idle_fraction
 }
 
-// ============================================================================
-// The pure headroom term
-// ============================================================================
-
-/// Compute the CPU headroom concurrency term.
-///
-/// `capacity = ncpu × utilization_target` is the number of cores this host is
-/// willing to dedicate to sweep work. From it we subtract the cores currently
-/// **consumed**, resolved via the fail-open chain (see module docs):
-///
-/// 1. a measured `idle_fraction` → `consumed = ncpu × (1 − idle_fraction)`
-///    (actual CPU consumption — the #4031 fix), else
-/// 2. the 1-minute `loadavg_1m` as a proxy (#3978's behavior), else
-/// 3. nothing — the static capacity, unadjusted.
-///
-/// The consumption is floored at `0.0` (an already-saturated host contributes
-/// no headroom rather than going negative). The resulting headroom divided by
-/// `est_cores_per_sweep` gives how many additional concurrent sweeps the host
-/// can currently absorb, floored to a minimum of `1` so a single noisy or
-/// mis-calibrated CPU reading can never by itself wedge the dynamic cap to
-/// zero (mirrors the token axis's "never a halt" floor, #3902).
-#[must_use]
-pub fn cpu_headroom(
-    ncpu: usize,
-    idle_fraction: Option<f64>,
-    loadavg_1m: Option<f64>,
-    utilization_target: f64,
-    est_cores_per_sweep: f64,
-) -> usize {
-    let capacity = ncpu as f64 * utilization_target;
-    // Prefer the measured idle fraction; fall back to load average; else no
-    // consumption term at all (static capacity).
-    let consumed = match idle_fraction {
-        Some(idle) => Some(ncpu as f64 * (1.0 - idle.clamp(0.0, 1.0))),
-        None => loadavg_1m,
-    };
-    let available = consumed.map_or(capacity, |c| (capacity - c).max(0.0));
-    let term = (available / est_cores_per_sweep.max(f64::MIN_POSITIVE)).floor();
-    // NaN/negative-infinity can't occur here (all operands are finite and
-    // `est_cores_per_sweep` is clamped away from 0), but `max(1.0)` also
-    // guards the float→usize cast below against any residual edge case.
-    term.max(1.0) as usize
-}
-
-/// A point-in-time snapshot of the inputs feeding [`cpu_headroom`], for the
-/// status surface (`ipc.rs` / `loom-daemon status`). Reads the memoized idle
-/// fraction (no blocking) plus a fresh, fast load-average read.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct CpuHeadroomSnapshot {
-    /// Host logical CPU count.
-    pub logical_cpus: usize,
-    /// Measured idle fraction (`0.0..=1.0`) if one has been sampled, else `None`.
-    pub idle_fraction: Option<f64>,
-    /// Current 1-minute load average if available, else `None`.
-    pub loadavg_1m: Option<f64>,
-    /// The resulting headroom term (concurrent-sweep slots).
-    pub cpu_headroom: usize,
-}
-
-/// Build a [`CpuHeadroomSnapshot`] from the memoized idle fraction, a fresh
-/// load-average read, and the resolved knobs. **Never blocks** — safe on the
-/// tokio runtime and from the synchronous status path. Pre-warm the idle
-/// cache with `spawn_blocking(refresh_cpu_util_cache)` for a fresh
-/// measurement.
-///
-/// `utilization_target` / `est_cores_per_sweep` are the already-resolved
-/// (env > config > default, #4032) values — callers get these from
-/// [`resolve_utilization_target`] / [`resolve_est_cores_per_sweep`] fed by
-/// [`crate::work_finder::read_work_finder_config`], resolved once at startup
-/// (or, in `ipc.rs`, freshly per status request against the same config path).
-#[must_use]
-pub fn cpu_headroom_snapshot(
-    utilization_target: f64,
-    est_cores_per_sweep: f64,
-) -> CpuHeadroomSnapshot {
-    let logical_cpus = logical_cpu_count();
-    let idle_fraction = cached_cpu_idle_fraction();
-    let loadavg_1m = read_loadavg_1m();
-    let cpu_headroom = cpu_headroom(
-        logical_cpus,
-        idle_fraction,
-        loadavg_1m,
-        utilization_target,
-        est_cores_per_sweep,
-    );
-    CpuHeadroomSnapshot {
-        logical_cpus,
-        idle_fraction,
-        loadavg_1m,
-        cpu_headroom,
-    }
-}
-
-/// Resolve the CPU headroom term end-to-end from live host inputs, refreshing
-/// the memoized idle-fraction sample first.
-///
-/// `utilization_target` / `est_cores_per_sweep` are the already-resolved
-/// (env > config > default, #4032) values — see [`cpu_headroom_snapshot`].
-///
-/// **May block** (~1s on macOS via `iostat`; fast, non-sleeping on Linux). The
-/// async work-finder loops call this through `spawn_blocking` so the macOS
-/// sampling window never blocks a tokio runtime worker.
-#[must_use]
-pub fn cpu_headroom_limit(utilization_target: f64, est_cores_per_sweep: f64) -> usize {
-    refresh_cpu_util_cache();
-    cpu_headroom(
-        logical_cpu_count(),
-        cached_cpu_idle_fraction(),
-        read_loadavg_1m(),
-        utilization_target,
-        est_cores_per_sweep,
-    )
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use serial_test::serial;
 
     // ------------------------------------------------------------------
     // parse_proc_loadavg
@@ -829,178 +573,6 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // cpu_headroom — pure math (signature: ncpu, idle, loadavg, target, est)
-    // ------------------------------------------------------------------
-
-    #[test]
-    fn cpu_headroom_static_capacity_when_no_signal_at_all() {
-        // 8 cores, 75% target, no idle + no load reading -> capacity 6.0 / 2.0
-        // cores per sweep = 3.
-        assert_eq!(cpu_headroom(8, None, None, 0.75, 2.0), 3);
-    }
-
-    #[test]
-    fn cpu_headroom_subtracts_current_load_when_no_idle_measurement() {
-        // 8 cores, 75% target -> capacity 6.0. No idle measurement; load 4.0 in
-        // use -> 2.0 available / 2.0 per sweep = 1 (the #3978 fallback path).
-        assert_eq!(cpu_headroom(8, None, Some(4.0), 0.75, 2.0), 1);
-    }
-
-    #[test]
-    fn cpu_headroom_prefers_measured_idle_over_loadavg() {
-        // The #4031 core: 28 cores, 75% target -> capacity 21.0. 85% idle means
-        // consumed = 28 × 0.15 = 4.2 cores; loadavg reads an inflated 6.0. The
-        // term must reflect the idle reading (21 - 4.2 = 16.8 / 2.0 = 8), NOT the
-        // load reading (21 - 6.0 = 15.0 / 2.0 = 7).
-        assert_eq!(cpu_headroom(28, Some(0.85), Some(6.0), 0.75, 2.0), 8);
-        // And it must ignore loadavg entirely when idle is present.
-        assert_eq!(
-            cpu_headroom(28, Some(0.85), None, 0.75, 2.0),
-            cpu_headroom(28, Some(0.85), Some(999.0), 0.75, 2.0),
-            "loadavg must not influence the term once a measured idle exists"
-        );
-    }
-
-    #[test]
-    fn cpu_headroom_floors_at_one_under_a_saturated_idle_reading() {
-        // 0% idle on an 8-core/75% host -> consumed 8.0 > capacity 6.0 ->
-        // available clamps to 0, but the term floors at 1 (soft backoff).
-        assert_eq!(cpu_headroom(8, Some(0.0), None, 0.75, 2.0), 1);
-        // Same floor via the loadavg path when load exceeds capacity.
-        assert_eq!(cpu_headroom(8, None, Some(20.0), 0.75, 2.0), 1);
-    }
-
-    #[test]
-    fn cpu_headroom_scales_with_more_cores() {
-        // 32 cores, 75% target, no signal -> 24.0 / 2.0 = 12.
-        assert_eq!(cpu_headroom(32, None, None, 0.75, 2.0), 12);
-    }
-
-    #[test]
-    fn cpu_headroom_never_zero_even_on_a_single_core_host() {
-        // 1 core, 75% target -> capacity 0.75, / 2.0 per sweep = 0.375 ->
-        // floors to 0 mathematically, but the `max(1.0)` policy floor kicks in.
-        assert_eq!(cpu_headroom(1, None, None, 0.75, 2.0), 1);
-    }
-
-    #[test]
-    fn cpu_headroom_est_cores_per_sweep_scales_the_denominator() {
-        // 16 cores, 100% target -> capacity 16.0. A heavier 4.0-cores-per-
-        // sweep estimate -> 4.
-        assert_eq!(cpu_headroom(16, None, None, 1.0, 4.0), 4);
-    }
-
-    #[test]
-    fn cpu_headroom_idle_fraction_is_clamped() {
-        // A nonsense idle fraction > 1 or < 0 can't push consumed negative /
-        // above ncpu enough to break the term (defensive clamp).
-        assert_eq!(cpu_headroom(8, Some(1.5), None, 0.75, 2.0), 3, "idle>1 clamps to full idle");
-        assert_eq!(cpu_headroom(8, Some(-0.5), None, 0.75, 2.0), 1, "idle<0 clamps to fully busy");
-    }
-
-    // ------------------------------------------------------------------
-    // env-only resolution (no config value in hand)
-    // ------------------------------------------------------------------
-
-    #[test]
-    #[serial]
-    fn utilization_target_default_and_override() {
-        std::env::remove_var(UTILIZATION_TARGET_ENV);
-        assert!((utilization_target() - DEFAULT_UTILIZATION_TARGET).abs() < f64::EPSILON);
-
-        std::env::set_var(UTILIZATION_TARGET_ENV, "0.5");
-        assert!((utilization_target() - 0.5).abs() < f64::EPSILON);
-
-        // Out-of-range and unparseable values fall back to the default.
-        std::env::set_var(UTILIZATION_TARGET_ENV, "0");
-        assert!((utilization_target() - DEFAULT_UTILIZATION_TARGET).abs() < f64::EPSILON);
-        std::env::set_var(UTILIZATION_TARGET_ENV, "1.5");
-        assert!((utilization_target() - DEFAULT_UTILIZATION_TARGET).abs() < f64::EPSILON);
-        std::env::set_var(UTILIZATION_TARGET_ENV, "garbage");
-        assert!((utilization_target() - DEFAULT_UTILIZATION_TARGET).abs() < f64::EPSILON);
-        std::env::remove_var(UTILIZATION_TARGET_ENV);
-    }
-
-    #[test]
-    #[serial]
-    fn est_cores_per_sweep_default_and_override() {
-        std::env::remove_var(EST_CORES_PER_SWEEP_ENV);
-        assert!((est_cores_per_sweep() - DEFAULT_EST_CORES_PER_SWEEP).abs() < f64::EPSILON);
-
-        std::env::set_var(EST_CORES_PER_SWEEP_ENV, "3.5");
-        assert!((est_cores_per_sweep() - 3.5).abs() < f64::EPSILON);
-
-        // Zero, negative, and unparseable values fall back to the default.
-        std::env::set_var(EST_CORES_PER_SWEEP_ENV, "0");
-        assert!((est_cores_per_sweep() - DEFAULT_EST_CORES_PER_SWEEP).abs() < f64::EPSILON);
-        std::env::set_var(EST_CORES_PER_SWEEP_ENV, "-1");
-        assert!((est_cores_per_sweep() - DEFAULT_EST_CORES_PER_SWEEP).abs() < f64::EPSILON);
-        std::env::set_var(EST_CORES_PER_SWEEP_ENV, "garbage");
-        assert!((est_cores_per_sweep() - DEFAULT_EST_CORES_PER_SWEEP).abs() < f64::EPSILON);
-        std::env::remove_var(EST_CORES_PER_SWEEP_ENV);
-    }
-
-    // ------------------------------------------------------------------
-    // resolve_utilization_target / resolve_est_cores_per_sweep — env > config
-    // > default precedence (#4032)
-    // ------------------------------------------------------------------
-
-    #[test]
-    #[serial]
-    fn resolve_utilization_target_precedence() {
-        std::env::remove_var(UTILIZATION_TARGET_ENV);
-
-        // Both unset -> built-in default.
-        assert!(
-            (resolve_utilization_target(None) - DEFAULT_UTILIZATION_TARGET).abs() < f64::EPSILON
-        );
-
-        // Config set, env unset -> config wins.
-        assert!((resolve_utilization_target(Some(0.6)) - 0.6).abs() < f64::EPSILON);
-
-        // Env set, config set -> env wins.
-        std::env::set_var(UTILIZATION_TARGET_ENV, "0.5");
-        assert!((resolve_utilization_target(Some(0.6)) - 0.5).abs() < f64::EPSILON);
-
-        // Env set, config unset -> env still wins.
-        assert!((resolve_utilization_target(None) - 0.5).abs() < f64::EPSILON);
-
-        std::env::remove_var(UTILIZATION_TARGET_ENV);
-    }
-
-    #[test]
-    #[serial]
-    fn resolve_est_cores_per_sweep_precedence() {
-        std::env::remove_var(EST_CORES_PER_SWEEP_ENV);
-
-        // Both unset -> built-in default.
-        assert!(
-            (resolve_est_cores_per_sweep(None) - DEFAULT_EST_CORES_PER_SWEEP).abs() < f64::EPSILON
-        );
-
-        // Config set, env unset -> config wins.
-        assert!((resolve_est_cores_per_sweep(Some(4.0)) - 4.0).abs() < f64::EPSILON);
-
-        // Env set, config set -> env wins.
-        std::env::set_var(EST_CORES_PER_SWEEP_ENV, "1.0");
-        assert!((resolve_est_cores_per_sweep(Some(4.0)) - 1.0).abs() < f64::EPSILON);
-
-        // Env set, config unset -> env still wins.
-        assert!((resolve_est_cores_per_sweep(None) - 1.0).abs() < f64::EPSILON);
-
-        std::env::remove_var(EST_CORES_PER_SWEEP_ENV);
-    }
-
-    // Range validation of the config value (`(0, 1]` for utilization target,
-    // `> 0` for cores-per-sweep) is applied at the config-read layer in
-    // `read_work_finder_config` (see `work_finder.rs` tests
-    // `test_config_out_of_range_cpu_utilization_target_drops_to_none` and
-    // `test_config_out_of_range_est_cores_per_sweep_drops_to_none`), not here —
-    // `resolve_utilization_target` / `resolve_est_cores_per_sweep` trust the
-    // `Option<f64>` they are handed is already filtered, exactly like
-    // `resolve_per_token_concurrency` trusts `WorkFinderConfig`.
-
-    // ------------------------------------------------------------------
     // host saturation (#4259) — pure predicate
     // ------------------------------------------------------------------
 
@@ -1035,13 +607,18 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // cpu_headroom_limit — end-to-end smoke test against the real host
+    // refresh + cached idle fraction — smoke test against the real host
     // ------------------------------------------------------------------
 
     #[test]
-    fn cpu_headroom_limit_returns_at_least_one() {
-        // Whatever this CI/dev host's load looks like, the policy floor
-        // guarantees at least 1.
-        assert!(cpu_headroom_limit(DEFAULT_UTILIZATION_TARGET, DEFAULT_EST_CORES_PER_SWEEP) >= 1);
+    fn refresh_cpu_util_cache_never_panics_and_the_cache_is_readable() {
+        // Purely observational now (#4512): the memo feeds `loom-daemon status`
+        // / `calibrate` reporting, not any admission decision. Whatever this
+        // host supports, neither call may panic and a read must be well-typed.
+        refresh_cpu_util_cache();
+        let frac = cached_cpu_idle_fraction();
+        if let Some(f) = frac {
+            assert!((0.0..=1.0).contains(&f), "idle fraction out of range: {f}");
+        }
     }
 }

--- a/loom-daemon/src/host_breaker.rs
+++ b/loom-daemon/src/host_breaker.rs
@@ -104,10 +104,15 @@ pub const DEFAULT_HOST_BREAKER_ENABLED: bool = true;
 /// Default load-per-core trip threshold. Normal healthy hosts sit well below
 /// `1.0` load-per-core; sustained `2.5×` oversubscription is clear distress
 /// (the #4231 meltdown peaked at ~4.2 load-per-core) while leaving bursty
-/// build spikes below the line. Deliberately well above the CPU-headroom
-/// utilization target (`cpuUtilizationTarget`, default ~0.85) — the breaker is
-/// for *distress*, not for the routine headroom throttling #3978/#4234 already
-/// handle.
+/// build spikes below the line. Deliberately well above the build gate's own
+/// saturation-deferral ratio ([`crate::cpu_headroom::DEFAULT_GATE_LOAD_THRESHOLD`],
+/// `0.9`) — the breaker is for *distress*, not routine scheduling politeness.
+///
+/// Since #4512 removed the CPU-headroom estimate from admission, this **measured**
+/// breaker is the load safety net that makes a hand-tuned per-machine
+/// `maxConcurrent` safe to raise: a mis-set knob trips it (and the machine-wide
+/// build slot, [`crate::build_slot`], keeps the heavy stages serialized) instead
+/// of melting the host.
 pub const DEFAULT_HOST_BREAKER_LOAD_PER_CORE: f64 = 2.5;
 
 /// Default consecutive over-threshold ticks before tripping. At the default

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1508,28 +1508,18 @@ pub fn build_daemon_status(
     // re-resolving a possibly-different one.
     let token_pool_dir = Some(tokens_dir.clone());
     let disk_headroom = crate::disk_headroom::disk_headroom_limit(workspace_root);
-    // Hoisted above the CPU snapshot (#4032) so the resolved
-    // `cpuUtilizationTarget` / `estCoresPerSweep` knobs can feed it — this read
-    // was already happening six lines below; moving it up is not a new config
-    // read, just a reorder so status and dispatch resolve through the same
-    // env > config > default path (`resolve_cpu_utilization_target` /
-    // `resolve_cpu_est_cores_per_sweep`, single-root, matching
-    // `resolve_per_token_concurrency`).
     let wf_config = crate::work_finder::read_work_finder_config(workspace_root);
     let configured_max = crate::work_finder::resolve_max_concurrent_with_config(&wf_config);
     let per_token_concurrency = crate::work_finder::resolve_per_token_concurrency(&wf_config);
-    let cpu_utilization_target = crate::work_finder::resolve_cpu_utilization_target(&wf_config);
-    let cpu_est_cores_per_sweep = crate::work_finder::resolve_cpu_est_cores_per_sweep(&wf_config);
-    // CPU headroom (#3978, measured-idle signal #4031) — a host-level resource
-    // (not per-repo). The snapshot reads the memoized idle fraction (never
-    // blocks; the caller pre-warms it via `spawn_blocking(refresh_cpu_util_cache)`
-    // before invoking `build_daemon_status`) plus a fast fresh loadavg read.
-    let cpu_snapshot =
-        crate::cpu_headroom::cpu_headroom_snapshot(cpu_utilization_target, cpu_est_cores_per_sweep);
-    let logical_cpus = cpu_snapshot.logical_cpus;
-    let loadavg_1m = cpu_snapshot.loadavg_1m;
-    let cpu_idle_fraction = cpu_snapshot.idle_fraction;
-    let cpu_headroom = cpu_snapshot.cpu_headroom;
+    // Host CPU **observations** (#3978, measured-idle signal #4031). Since #4512
+    // these no longer feed the cap — they are reported so an operator can see
+    // whether this machine's `maxConcurrent` leaves it idle or saturated. Never
+    // blocks: the idle fraction is the memoized sample (the caller pre-warms it
+    // via `spawn_blocking(refresh_cpu_util_cache)` before invoking
+    // `build_daemon_status`), plus a fast fresh loadavg read.
+    let logical_cpus = crate::cpu_headroom::logical_cpu_count();
+    let loadavg_1m = crate::cpu_headroom::read_loadavg_1m();
+    let cpu_idle_fraction = crate::cpu_headroom::cached_cpu_idle_fraction();
 
     // Token-capacity backpressure (#3902): back the token axis off from the flat
     // pool count toward the count of *healthy* accounts read from the rotation
@@ -1541,16 +1531,15 @@ pub fn build_daemon_status(
         token_axis_limit,
         per_token_concurrency,
         disk_headroom,
-        cpu_headroom,
         configured_max,
     );
     // The token axis of the cap is `healthy × per-token` (#3947), so it is the
     // binding constraint only when that *product* is the minimum across every
-    // axis — disk, cpu (#3978), and the operator ceiling.
+    // remaining axis — disk and the configured ceiling (#4512 removed the CPU
+    // axis).
     let token_axis_effective = token_axis_limit.saturating_mul(per_token_concurrency.max(1));
-    let token_bound = token_axis_effective <= disk_headroom
-        && token_axis_effective <= cpu_headroom
-        && token_axis_effective <= configured_max;
+    let token_bound =
+        token_axis_effective <= disk_headroom && token_axis_effective <= configured_max;
     // "Currently binding" vs "smallest ceiling" (#4031): the dynamic cap is the
     // minimum of several ceilings, but a ceiling only *binds* once in-flight
     // occupancy reaches it. Below the cap the limiter is work availability, not
@@ -1583,7 +1572,6 @@ pub fn build_daemon_status(
         token_pool_size,
         token_pool_dir,
         disk_headroom,
-        cpu_headroom,
         logical_cpus,
         loadavg_1m,
         cpu_idle_fraction,
@@ -1792,22 +1780,15 @@ fn resolve_dispatch_registry(
 // new `Response` variant. The advisory is a side channel (log + event bus),
 // exactly like `capacity.rs`'s token-pressure advisory.
 //
-// # Never the blocking (~1s on macOS) headroom refresh under the registry lock
+// # Nothing blocking under the registry lock
 //
 // The `DispatchSweep` arm holds the registry mutex from just after this
-// assessment through the dispatch call. `cpu_headroom::cpu_headroom_limit`
-// refreshes the memoized idle-fraction sample, which sleeps ~1s on macOS
-// (`iostat`) — calling it here would stall every other IPC request scoped to
-// the same registry (`ListSweeps` / `GetSweepStatus` / a concurrent
-// `DispatchSweep`) for that second. [`assess_dispatch_headroom`] therefore
-// uses the **non-refreshing** [`crate::cpu_headroom::cpu_headroom_snapshot`]
-// (reads the memoized cache; never blocks) — the exact same call
-// `build_daemon_status` makes, just without that function's own
-// `spawn_blocking` pre-warm (this handler is synchronous, not `async`, so it
-// cannot `.await` a `spawn_blocking` join; a same-generation `iostat` sample
-// from a recent `DaemonStatus` poll or the work-finder's own tick is
-// sufficient for an advisory signal, and a `None` idle fraction falls back
-// through `cpu_headroom`'s documented fail-open chain).
+// assessment through the dispatch call, so nothing here may block. Since #4512
+// the headroom is `min(token axis, disk, configured max)` — three cheap
+// filesystem/config reads, no CPU sampling at all. (Before #4512 this had to
+// carefully avoid `cpu_headroom_limit`, whose macOS `iostat` refresh sleeps ~1s
+// and would have stalled every other IPC request on the same registry for that
+// second; removing the CPU term removed that hazard outright.)
 
 /// Per-repo dynamic-cap headroom snapshot computed for a `dispatch_sweep`
 /// request (#4234). Mirrors the inputs `build_daemon_status` already exposes
@@ -1816,16 +1797,14 @@ fn resolve_dispatch_registry(
 struct DispatchHeadroom {
     /// Live (non-terminal) sweep count already registered for this repo.
     occupancy: usize,
-    /// `resolve_dynamic_max_concurrent` — min(token axis, disk, cpu, configured max).
+    /// `resolve_dynamic_max_concurrent` — min(token axis, disk, configured max).
     dynamic_cap: usize,
-    cpu_headroom: usize,
     disk_headroom: usize,
     token_axis_limit: usize,
 }
 
 /// Compute [`DispatchHeadroom`] for `repo_root` against the **already-locked**
-/// registry `sr`. See the module docs above for why this never calls the
-/// refreshing CPU probe.
+/// registry `sr`. See the module docs above for why nothing here may block.
 fn assess_dispatch_headroom(sr: &mut SweepRegistry, repo_root: &Path) -> DispatchHeadroom {
     // Reap-on-read (mirrors ListSweeps/GetSweepStatus, Issue #3893): a sweep
     // whose child already exited must not inflate occupancy against a stale
@@ -1840,10 +1819,6 @@ fn assess_dispatch_headroom(sr: &mut SweepRegistry, repo_root: &Path) -> Dispatc
     let wf_config = crate::work_finder::read_work_finder_config(repo_root);
     let configured_max = crate::work_finder::resolve_max_concurrent_with_config(&wf_config);
     let per_token_concurrency = crate::work_finder::resolve_per_token_concurrency(&wf_config);
-    let cpu_utilization_target = crate::work_finder::resolve_cpu_utilization_target(&wf_config);
-    let cpu_est_cores_per_sweep = crate::work_finder::resolve_cpu_est_cores_per_sweep(&wf_config);
-    let cpu_snapshot =
-        crate::cpu_headroom::cpu_headroom_snapshot(cpu_utilization_target, cpu_est_cores_per_sweep);
     let disk_headroom = crate::disk_headroom::disk_headroom_limit(repo_root);
     let token_pool_size = crate::tokens::token_pool_size(repo_root);
     let ranking = crate::capacity::read_ranking(repo_root);
@@ -1852,14 +1827,12 @@ fn assess_dispatch_headroom(sr: &mut SweepRegistry, repo_root: &Path) -> Dispatc
         token_axis_limit,
         per_token_concurrency,
         disk_headroom,
-        cpu_snapshot.cpu_headroom,
         configured_max,
     );
 
     DispatchHeadroom {
         occupancy,
         dynamic_cap,
-        cpu_headroom: cpu_snapshot.cpu_headroom,
         disk_headroom,
         token_axis_limit,
     }
@@ -1944,13 +1917,12 @@ fn dispatch_headroom_message(
     if low_headroom {
         format!(
             "dispatch_sweep: dispatching {kind:?} into {} while occupancy is at/over the \
-             computed dynamic-cap headroom (occupancy={} >= dynamic_cap={}; cpu_headroom={}, \
+             computed dynamic-cap headroom (occupancy={} >= dynamic_cap={}; \
              disk_headroom={}, token_axis_limit={}) — advisory only per #4234 (dispatch \
              proceeds; the autonomous work finder's own cap is unaffected)",
             repo_root.display(),
             h.occupancy,
             h.dynamic_cap,
-            h.cpu_headroom,
             h.disk_headroom,
             h.token_axis_limit
         )
@@ -1999,7 +1971,6 @@ fn emit_dispatch_headroom_advisory_on_change(
             "low_headroom": low_headroom,
             "occupancy": h.occupancy,
             "dynamic_cap": h.dynamic_cap,
-            "cpu_headroom": h.cpu_headroom,
             "disk_headroom": h.disk_headroom,
             "token_axis_limit": h.token_axis_limit,
             "message": message,
@@ -2700,12 +2671,11 @@ fn handle_request(
                 crate::sweep_registry::resolve_dispatch_model(&repo_root, model.as_deref());
             log::info!(
                 "dispatch_sweep: {:?} with model={resolved_model} (source={}); headroom \
-                 occupancy={} dynamic_cap={} (cpu={} disk={} tokens={})",
+                 occupancy={} dynamic_cap={} (disk={} tokens={})",
                 kind,
                 model_source.as_str(),
                 headroom.occupancy,
                 headroom.dynamic_cap,
-                headroom.cpu_headroom,
                 headroom.disk_headroom,
                 headroom.token_axis_limit
             );
@@ -3562,7 +3532,6 @@ exit 0
         DispatchHeadroom {
             occupancy,
             dynamic_cap,
-            cpu_headroom: dynamic_cap,
             disk_headroom: 10,
             token_axis_limit: 5,
         }
@@ -3589,7 +3558,6 @@ exit 0
         let h = DispatchHeadroom {
             occupancy: 4,
             dynamic_cap: 3,
-            cpu_headroom: 2,
             disk_headroom: 9,
             token_axis_limit: 6,
         };
@@ -3599,7 +3567,6 @@ exit 0
         let entered = dispatch_headroom_message(repo, true, &h, &kind);
         assert!(entered.contains("occupancy=4"), "{entered}");
         assert!(entered.contains("dynamic_cap=3"), "{entered}");
-        assert!(entered.contains("cpu_headroom=2"), "{entered}");
         assert!(entered.contains("disk_headroom=9"), "{entered}");
         assert!(entered.contains("token_axis_limit=6"), "{entered}");
         assert!(entered.contains("123"), "{entered}");
@@ -5031,7 +4998,6 @@ exit 0
             token_pool_size: 4,
             token_pool_dir: Some(std::path::PathBuf::from("/repo/a/.loom/tokens")),
             disk_headroom: 10,
-            cpu_headroom: 6,
             logical_cpus: 8,
             loadavg_1m: Some(1.25),
             cpu_idle_fraction: Some(0.90),
@@ -5106,7 +5072,6 @@ exit 0
                     Some(std::path::PathBuf::from("/repo/a/.loom/tokens"))
                 );
                 assert_eq!(r.disk_headroom, 10);
-                assert_eq!(r.cpu_headroom, 6);
                 assert_eq!(r.logical_cpus, 8);
                 assert!(r.auto_update_enabled);
                 assert_eq!(r.auto_update_consecutive_failures, 2);
@@ -5314,8 +5279,10 @@ exit 0
             !report.main_health_gate_not_evaluated,
             "absent main_health_gate_not_evaluated (#3950) defaults to false"
         );
-        // Absent pre-#3978 fields default rather than failing to parse.
-        assert_eq!(report.cpu_headroom, 0);
+        // Absent pre-#3978 fields default rather than failing to parse. (The
+        // retired `cpu_headroom` field a pre-#4512 daemon still SENDS is
+        // likewise tolerated: serde ignores unknown fields, so an old daemon
+        // and a new CLI stay wire-compatible in both directions.)
         assert_eq!(report.logical_cpus, 0);
         assert_eq!(report.loadavg_1m, None);
         // Absent pre-#4012 fields must default to `None` — NOT `false` — so a

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -132,6 +132,7 @@ pub mod activity;
 pub mod agent_session;
 pub mod auto_update;
 pub mod autonomy_marker;
+pub mod build_slot;
 pub mod calibrate;
 pub mod capacity;
 pub mod claim_reconciliation;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -166,25 +166,23 @@ enum Commands {
         pipeline: bool,
     },
 
-    /// Measure the host and recommend — or with `--write`, apply — the
-    /// autonomous concurrency knobs (`autonomous.workFinder.maxConcurrent` /
-    /// `autonomous.perTokenConcurrency`, issue #4390). Prints the same
-    /// `min(...)` cap breakdown `status` uses, plus which term would bind
-    /// after applying the recommendation. Purely file/host-based; does not
-    /// require a running daemon (unlike `status`, which reports the running
-    /// daemon's own in-memory dispatch state).
+    /// Measure the host and the currently-resolved concurrency knobs (issue
+    /// #4390; measurement-only since #4512). Prints the same `min(token axis,
+    /// disk, maxConcurrent)` cap breakdown `status` uses, which term binds, and
+    /// a one-line reading of whether this machine's `maxConcurrent` should go
+    /// up. Purely file/host-based; does not require a running daemon (unlike
+    /// `status`, which reports the running daemon's own in-memory dispatch
+    /// state). Always read-only.
     Calibrate {
-        /// Repo root to measure/write (plain path, default `.` — no upward
-        /// `.git` walk).
+        /// Repo root to measure (plain path, default `.` — no upward `.git` walk).
         #[arg(long, value_name = "PATH", default_value = ".")]
         workspace: String,
 
-        /// Merge the recommendation into `<workspace>/.loom/config.json`
-        /// (only `autonomous.workFinder.maxConcurrent` /
-        /// `autonomous.perTokenConcurrency` — every other key is preserved).
-        /// Idempotent: a repeat `--write` with the same recommendation is
-        /// byte-identical. Without this flag, calibrate is strictly
-        /// read-only.
+        /// DEPRECATED and ignored (#4512). calibrate no longer derives a
+        /// recommendation to write: the CPU-headroom term it was based on is
+        /// gone, and `autonomous.workFinder.maxConcurrent` is a per-machine knob
+        /// you tune by hand from the measurements. Retained so existing scripts
+        /// passing `--write` keep working; prints a deprecation notice.
         #[arg(long)]
         write: bool,
 
@@ -2432,16 +2430,12 @@ async fn main() -> Result<()> {
         let interval = work_finder::resolve_interval_with_config(&work_finder_config);
         let configured_max = work_finder::resolve_max_concurrent_with_config(&work_finder_config);
         let per_token_concurrency = work_finder::resolve_per_token_concurrency(&work_finder_config);
-        // CPU headroom knobs (#4032): resolved once at startup from the same
-        // `work_finder_config`, precedence env > config > default — matching
-        // `per_token_concurrency` exactly (single-root, startup-time; the
-        // dynamic cap is one global number per tick, computed before the
-        // workspace registry is even loaded, so there is no per-workspace
-        // variant of these knobs).
-        let cpu_utilization_target =
-            work_finder::resolve_cpu_utilization_target(&work_finder_config);
-        let cpu_est_cores_per_sweep =
-            work_finder::resolve_cpu_est_cores_per_sweep(&work_finder_config);
+        // Retired CPU-headroom knobs (#4512): `cpuUtilizationTarget` /
+        // `estCoresPerSweep` (and their env twins) are accepted-but-ignored, so
+        // a fleet's committed config keeps parsing across the upgrade. Warn
+        // once, here at startup, naming exactly what is being ignored and what
+        // to tune instead.
+        work_finder::warn_deprecated_cpu_knobs(&work_finder_config);
         // Per-tick admission (ramp) cap (#4234): resolved once at startup from
         // the same `work_finder_config`, precedence env > config > default —
         // the same startup-capture pattern as the CPU knobs above. Bounds how
@@ -2481,12 +2475,12 @@ async fn main() -> Result<()> {
         );
         log::info!(
             "work_finder: enabled (multi-workspace, interval={}s, configured_max={configured_max}, \
-             per_token_concurrency={per_token_concurrency}, cpu_utilization_target={cpu_utilization_target}, \
-             cpu_est_cores_per_sweep={cpu_est_cores_per_sweep}, \
-             max_admissions_per_tick={max_admissions_per_tick}, \
-             dynamic cap = min(healthy tokens × per-token, disk, cpu, configured_max), \
+             per_token_concurrency={per_token_concurrency}, \
+             max_admissions_per_tick={max_admissions_per_tick}, build_slots={}, \
+             dynamic cap = min(healthy tokens × per-token, disk, configured_max), \
              global across workspaces)",
-            interval.as_secs()
+            interval.as_secs(),
+            loom_daemon::build_slot::resolve_slots()
         );
         // Multi-workspace fan-out (#3928): re-reads `effective_roots()` each tick
         // and dispatches into each registered repo's own working tree via the
@@ -2497,8 +2491,6 @@ async fn main() -> Result<()> {
             interval,
             configured_max,
             per_token_concurrency,
-            cpu_utilization_target,
-            cpu_est_cores_per_sweep,
             max_admissions_per_tick,
             workspace_health_states.clone(),
             suppress_dispatch_during_gate,
@@ -4830,8 +4822,8 @@ struct ResolvedCapacity {
     /// fallback) — the "healthy tokens" input to the dynamic concurrency cap.
     token_axis_limit: usize,
     /// The effective dynamic cap consistent with `token_axis_limit`:
-    /// `min(token_axis_limit, disk_headroom, cpu_headroom, configured_max)`
-    /// (CPU term added in #3978).
+    /// `min(token_axis_limit, disk_headroom, configured_max)` (the CPU term
+    /// added in #3978 was removed in #4512).
     effective_cap: usize,
     /// Whether the token axis is the binding (minimum) constraint.
     token_bound: bool,
@@ -4865,24 +4857,15 @@ fn resolve_capacity(
             // pre-#3947 wire `0` as the effective floor of 1.
             let factor = report.per_token_concurrency.max(1);
             let token_axis_effective = token_axis_limit.saturating_mul(factor);
-            // The CPU term (#3978) is policy-floored at 1 by
-            // `cpu_headroom::cpu_headroom` on every real computation, so a wire
-            // value of exactly `0` unambiguously means "an older daemon that
-            // predates #3978 didn't send this field" (`#[serde(default)]`) —
-            // not a genuine zero-headroom reading. Treat it as unconstrained
-            // rather than collapsing the cap to 0 against a daemon that never
-            // computed a CPU term at all.
-            let cpu_headroom = if report.cpu_headroom == 0 {
-                usize::MAX
-            } else {
-                report.cpu_headroom
-            };
+            // #4512: the cap is min(token axis, disk, configured max). A
+            // pre-#4512 daemon still SENDS a `cpu_headroom` field; serde ignores
+            // it, and we deliberately do not reintroduce it into the client-side
+            // recomputation — the daemon's own `dynamic_cap` (shown as the
+            // headline below) remains the authority either way.
             let effective_cap = token_axis_effective
                 .min(report.disk_headroom)
-                .min(cpu_headroom)
                 .min(report.configured_max);
             let token_bound = token_axis_effective <= report.disk_headroom
-                && token_axis_effective <= cpu_headroom
                 && token_axis_effective <= report.configured_max;
             return ResolvedCapacity {
                 source: "probe",
@@ -4975,14 +4958,11 @@ fn build_status_json_value(
             // whatever cwd `loom-daemon status` itself was run from.
             "token_pool_dir": report.token_pool_dir,
             "disk_headroom": report.disk_headroom,
-            // CPU headroom term (#3978; measured-idle signal #4031) — see the
-            // field docs on `DaemonStatusReport::cpu_headroom` for the pre-#3978
-            // `0` ⇒ "field absent" wire-compat convention.
-            "cpu_headroom": report.cpu_headroom,
+            // Host CPU OBSERVATIONS (#3978/#4031), not cap terms: #4512 removed
+            // the CPU headroom term from admission. Reported because observed
+            // idle is the evidence for tuning `configured_max` on this machine.
             "logical_cpus": report.logical_cpus,
             "loadavg_1m": report.loadavg_1m,
-            // Measured CPU idle fraction (#4031), the signal that replaced
-            // loadavg as the source of consumed cores. `null` until sampled.
             "cpu_idle_fraction": report.cpu_idle_fraction,
             "configured_max": report.configured_max,
             "per_token_concurrency": report.per_token_concurrency.max(1),
@@ -5445,13 +5425,12 @@ fn print_status_human(
     let dispatch_token_axis = report.capacity.token_axis_limit;
     println!("\nDynamic concurrency cap: {dispatch_cap}  (the number dispatch uses)");
     println!(
-        "  = min(healthy {} × per-token {} = {}, disk headroom {}, cpu headroom {}, \
+        "  = min(healthy {} × per-token {} = {}, disk headroom {}, \
          configured max {})",
         dispatch_token_axis,
         factor,
         dispatch_token_axis.saturating_mul(factor),
         report.disk_headroom,
-        report.cpu_headroom,
         report.configured_max
     );
     if rc.source == "probe" && rc.effective_cap != dispatch_cap {
@@ -5464,36 +5443,32 @@ fn print_status_human(
             rc.token_axis_limit.saturating_mul(factor)
         );
     }
-    // CPU headroom detail (#3978 AC4; measured-idle signal #4031). The signal
-    // chain is measured idle → loadavg → static capacity, so the line names
-    // which signal actually fed the term. `logical_cpus == 0` means an older
+    // Host CPU OBSERVATION (#3978 AC4; measured-idle signal #4031) — since
+    // #4512 this is deliberately NOT a cap term: it is the evidence an operator
+    // uses to decide whether this machine's `maxConcurrent` should go up (host
+    // mostly idle) or not (host saturated). `logical_cpus == 0` means an older
     // daemon (pre-#3978) never sent these fields — nothing to show.
     if report.logical_cpus > 0 {
         let basis = match (report.cpu_idle_fraction, report.loadavg_1m) {
-            // Preferred: measured CPU consumption (#4031). Show consumed cores so
-            // the operator can see the term is tracking real usage, not loadavg.
-            (Some(idle), _) => {
+            (Some(idle), load) => {
                 let consumed = report.logical_cpus as f64 * (1.0 - idle.clamp(0.0, 1.0));
                 format!(
-                    "{} logical cores, {:.0}% idle measured (≈{:.1} cores consumed)",
+                    "{} logical cores, {:.0}% idle measured (≈{:.1} cores consumed){}",
                     report.logical_cpus,
                     idle * 100.0,
-                    consumed
+                    consumed,
+                    load.map_or_else(String::new, |l| format!(", 1m loadavg {l:.2}"))
                 )
             }
-            // Fallback: 1-minute load average (#3978 behavior) until an idle
-            // sample exists (e.g. the first Linux cross-tick delta not yet taken).
             (None, Some(load)) => format!(
-                "{} logical cores, 1m loadavg {load:.2} (no idle sample yet — loadavg fallback)",
+                "{} logical cores, 1m loadavg {load:.2} (no idle sample yet)",
                 report.logical_cpus
             ),
-            // Static capacity only: no CPU signal at all on this platform.
-            (None, None) => format!(
-                "{} logical cores, no CPU signal on this platform — static capacity only",
-                report.logical_cpus
-            ),
+            (None, None) => {
+                format!("{} logical cores, no CPU signal on this platform", report.logical_cpus)
+            }
         };
-        println!("  cpu headroom: {} concurrent-sweep slot(s) ({basis})", report.cpu_headroom);
+        println!("  host cpu (observed, not a cap term since #4512): {basis}");
     }
 
     // Token-capacity backpressure section (#3902, source-unified in #3936).
@@ -7869,40 +7844,49 @@ fn handle_recover_orphans_command(
     Ok(())
 }
 
-/// Handle `loom-daemon calibrate` (issue #4390): measure the host, print (or
-/// `--write` apply) the recommended `autonomous.workFinder.maxConcurrent` /
-/// `autonomous.perTokenConcurrency` values. See `loom_daemon::calibrate` for
-/// the measurement + recommendation policy this thinly wires up.
+/// Handle `loom-daemon calibrate` (issue #4390; measurement-only since #4512):
+/// measure the host + the currently-resolved knobs and print the
+/// `min(token axis, disk, maxConcurrent)` breakdown, which term binds, and the
+/// one-line tuning reading. See `loom_daemon::calibrate`.
+///
+/// `--write` is **accepted but ignored** with a deprecation notice: #4512
+/// removed the CPU-headroom term the recommendation was derived from, so there
+/// is nothing to compute and write — `maxConcurrent` is a per-machine knob the
+/// operator tunes from these measurements. Keeping the flag (rather than
+/// deleting it) means an existing `calibrate --write` in a script keeps exiting
+/// 0 instead of failing on an unknown argument.
+///
+/// The retired-knob deprecation notice is printed to **stderr** here rather than
+/// left to `work_finder::warn_deprecated_cpu_knobs`'s `log::warn!`: CLI
+/// subcommands return from `main` before `setup_logging()` runs, so on this path
+/// a log warning would go nowhere at all. stderr also keeps `--json`'s stdout
+/// payload clean for machine consumers.
 fn handle_calibrate_command(workspace: &str, write: bool, json: bool) -> Result<()> {
     use loom_daemon::calibrate;
     use loom_daemon::worktree_ops::repo;
 
     let repo_root = repo::resolve_repo_root(workspace)?;
-
     let measurements = calibrate::measure(&repo_root);
-    let recommendation = calibrate::recommend(&measurements);
 
-    let written = if write {
-        Some(
-            calibrate::write_workfinder_config(
-                &repo_root,
-                recommendation.recommended_max_concurrent,
-                recommendation.recommended_per_token_concurrency,
-            )
-            .map_err(|e| anyhow!("{e}"))?,
-        )
-    } else {
-        None
-    };
+    if let Some(notice) = loom_daemon::work_finder::deprecated_cpu_knob_notice(
+        &loom_daemon::work_finder::read_work_finder_config(&repo_root),
+    ) {
+        eprintln!("loom-daemon calibrate: {notice}");
+    }
+
+    if write {
+        eprintln!(
+            "loom-daemon calibrate: --write is deprecated and ignored (#4512). calibrate no \
+             longer derives a recommendation: the CPU-headroom admission term it was based on was \
+             removed, and autonomous.workFinder.maxConcurrent is now a per-machine knob you tune \
+             from the measurements below. Edit .loom/config.json directly, then restart the daemon."
+        );
+    }
 
     if json {
-        let report = calibrate::report_json(&measurements, &recommendation, written.as_deref());
-        println!("{}", serde_json::to_string_pretty(&report)?);
+        println!("{}", serde_json::to_string_pretty(&calibrate::report_json(&measurements))?);
     } else {
-        print!(
-            "{}",
-            calibrate::report_human(&measurements, &recommendation, written.as_deref())
-        );
+        print!("{}", calibrate::report_human(&measurements));
     }
 
     Ok(())
@@ -9010,7 +8994,6 @@ mod status_client_tests {
             token_pool_size: 4,
             token_pool_dir: Some(std::path::PathBuf::from("/repo/a/.loom/tokens")),
             disk_headroom: 10,
-            cpu_headroom: 6,
             logical_cpus: 8,
             loadavg_1m: Some(1.25),
             cpu_idle_fraction: Some(0.90),

--- a/loom-daemon/src/main_health_gate.rs
+++ b/loom-daemon/src/main_health_gate.rs
@@ -236,6 +236,14 @@ pub struct MainHealthState {
     /// same cores — the CPU contention that made a `nice -n 5` gate still time
     /// out under 2 concurrent sweeps (#4073 was necessary, not sufficient).
     /// `false` for a fresh state and whenever no gate run is executing.
+    ///
+    /// This is an **in-process** flag, scoped to one daemon and one root. The
+    /// cross-process, machine-wide equivalent — which serializes this gate's
+    /// build against `cargo`/build-gate stages in *other* processes (every
+    /// concurrent sweep worktree, another workspace's gate) — is the build slot
+    /// ([`crate::build_slot`], #4512), taken around the gate command itself.
+    /// They compose: this flag holds *dispatch* off a root with a live gate; the
+    /// slot holds *concurrent heavy builds* off each other machine-wide.
     gate_in_flight: AtomicBool,
     /// The current load-deferral streak (#4259), or `None` when the gate is not
     /// deferring. A deferred tick is a *scheduling* decision, not an
@@ -1638,8 +1646,24 @@ impl GateRunner for CommandGateRunner {
                 PrepOutcome::Ready => evaluated_sha = resolve_head_sha(&self.repo_root),
             }
         }
-        let outcome =
-            run_command_with_timeout(&self.config.command, &self.repo_root, self.config.timeout);
+        // Machine-wide build slot (#4512): the gate command is this host's
+        // heaviest recurring CPU stage (a full `cargo test` workspace build), so
+        // it takes a slot before starting rather than racing every concurrent
+        // sweep's own build. Acquired OUTSIDE the timeout window on purpose — a
+        // queue wait must not eat into `config.timeout` and turn contention into
+        // a false UNEVALUATED (the #3978/#4020 failure mode). Never blocks
+        // indefinitely and never fails: the lease degrades open on a bounded-wait
+        // expiry or an unusable lock dir, so the gate always runs.
+        let slot = crate::build_slot::acquire("main-health-gate");
+        let outcome = run_command_with_timeout(
+            &self.config.command,
+            &self.repo_root,
+            self.config.timeout,
+            slot.covers_children(),
+        );
+        // Explicit drop for the release log line's ordering (the RAII drop would
+        // fire at end of scope anyway).
+        drop(slot);
         match outcome {
             GateOutcome::Red { detail } => self.corroborate_red(evaluated_sha.as_deref(), detail),
             other => other,
@@ -2429,7 +2453,18 @@ fn classify_failed_exit(
 /// the spawn, the poll, the timeout — yields [`GateOutcome::Unevaluated`]
 /// (#3974): those say nothing about `main`, and halting on them turns an
 /// environmental hiccup into a total dispatch outage.
-fn run_command_with_timeout(command: &str, cwd: &Path, timeout: Duration) -> GateOutcome {
+///
+/// `build_slot_held` propagates [`crate::build_slot::BUILD_SLOT_HELD_ENV`] into
+/// the child (#4512). The shipped gate command is `build-gate.sh`, which takes
+/// the machine-wide build slot itself via `lib/build-slot.sh`; the sentinel makes
+/// that nested acquire a re-entrant no-op instead of a self-inflicted wait
+/// against the slot this process is already holding.
+fn run_command_with_timeout(
+    command: &str,
+    cwd: &Path,
+    timeout: Duration,
+    build_slot_held: bool,
+) -> GateOutcome {
     use std::fs::File;
 
     let log_path =
@@ -2461,6 +2496,7 @@ fn run_command_with_timeout(command: &str, cwd: &Path, timeout: Duration) -> Gat
         .arg("-c")
         .arg(command)
         .current_dir(cwd)
+        .env(crate::build_slot::BUILD_SLOT_HELD_ENV, if build_slot_held { "1" } else { "0" })
         .stdin(Stdio::null())
         .stdout(Stdio::from(out_file))
         .stderr(Stdio::from(err_file))

--- a/loom-daemon/src/serve.rs
+++ b/loom-daemon/src/serve.rs
@@ -1032,7 +1032,6 @@ mod tests {
             token_pool_size: 0,
             token_pool_dir: None,
             disk_headroom: 0,
-            cpu_headroom: 0,
             logical_cpus: 0,
             loadavg_1m: None,
             cpu_idle_fraction: None,

--- a/loom-daemon/src/tokens_pool/locking.rs
+++ b/loom-daemon/src/tokens_pool/locking.rs
@@ -13,6 +13,17 @@ const LOCK_TIMEOUT: Duration = Duration::from_secs(5);
 const LOCK_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const STALE_LOCK_THRESHOLD: Duration = Duration::from_secs(30);
 
+/// Whether the lock directory at `lock_path` is older than `stale_threshold`
+/// (its mtime is its creation time — nothing refreshes it). An unreadable
+/// mtime is conservatively **not** stale: never reap a lock we cannot age.
+fn is_stale(lock_path: &Path, stale_threshold: Duration) -> bool {
+    std::fs::metadata(lock_path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+        .is_some_and(|age| age > stale_threshold)
+}
+
 /// RAII guard for an `mkdir`-based lock. Acquires on construction (blocking,
 /// with polling + stale-lock cleanup) and releases (`rmdir`) on drop.
 pub struct MkdirLock {
@@ -21,6 +32,58 @@ pub struct MkdirLock {
 }
 
 impl MkdirLock {
+    /// **Non-blocking** single attempt at `lock_path`, reaping a lock whose
+    /// mtime is older than `stale_threshold` before retrying once.
+    ///
+    /// Distinguishes the three outcomes a caller with its own wait policy needs
+    /// (the machine-wide build slot, [`crate::build_slot`], polls several slot
+    /// paths per round and must not block on any single one):
+    ///
+    /// - `Ok(Some(lock))` — acquired; released on drop like [`Self::acquire`].
+    /// - `Ok(None)` — currently held by someone else (and not stale).
+    /// - `Err(_)` — the lock path is **unusable** (missing parent, no write
+    ///   permission, …). A caller that must never block should treat this as
+    ///   "no locking available" and degrade open rather than spin.
+    ///
+    /// # Errors
+    /// Returns an error when `mkdir` fails for any reason other than
+    /// `AlreadyExists`.
+    pub fn try_acquire(
+        lock_path: &Path,
+        stale_threshold: Duration,
+    ) -> Result<Option<Self>, String> {
+        match std::fs::create_dir(lock_path) {
+            Ok(()) => Ok(Some(Self {
+                lock_path: lock_path.to_path_buf(),
+                acquired: true,
+            })),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                if !is_stale(lock_path, stale_threshold) {
+                    return Ok(None);
+                }
+                // Reap the stale lock and make exactly one more attempt: a
+                // racing peer may have reaped and re-taken it first, which is
+                // an ordinary `Ok(None)`, not an error.
+                let _ = std::fs::remove_dir(lock_path);
+                match std::fs::create_dir(lock_path) {
+                    Ok(()) => Ok(Some(Self {
+                        lock_path: lock_path.to_path_buf(),
+                        acquired: true,
+                    })),
+                    Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(None),
+                    Err(e) => Err(format!("could not create lock dir: {e}")),
+                }
+            }
+            Err(e) => Err(format!("could not create lock dir: {e}")),
+        }
+    }
+
+    /// The path this lock occupies (for telemetry).
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.lock_path
+    }
+
     /// Acquire the lock at `lock_path`, blocking up to the default timeout
     /// (5s, polling every 100ms, reaping locks stale for >30s).
     ///
@@ -53,13 +116,9 @@ impl MkdirLock {
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                     // Stale-lock cleanup.
-                    if let Ok(meta) = std::fs::metadata(lock_path) {
-                        if let Ok(modified) = meta.modified() {
-                            if let Ok(age) = SystemTime::now().duration_since(modified) {
-                                if age > stale_threshold {
-                                    let _ = std::fs::remove_dir(lock_path);
-                                }
-                            }
+                    if lock_path.exists() {
+                        if is_stale(lock_path, stale_threshold) {
+                            let _ = std::fs::remove_dir(lock_path);
                         }
                     } else {
                         // Lock vanished between checks; loop and retry immediately.
@@ -116,6 +175,40 @@ mod tests {
             Duration::from_secs(30),
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn try_acquire_distinguishes_free_held_and_unusable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock_path = tmp.path().join(".x.lock");
+        let stale = Duration::from_secs(30);
+
+        // Free -> acquired.
+        let held = MkdirLock::try_acquire(&lock_path, stale).unwrap();
+        assert!(held.is_some());
+        assert!(lock_path.is_dir());
+
+        // Held (not stale) -> Ok(None), never an error and never a block.
+        assert!(MkdirLock::try_acquire(&lock_path, stale).unwrap().is_none());
+
+        // Released on drop -> acquirable again.
+        drop(held);
+        assert!(MkdirLock::try_acquire(&lock_path, stale).unwrap().is_some());
+
+        // Unusable path (parent does not exist) -> Err, so a non-blocking
+        // caller can degrade open instead of spinning.
+        let missing = tmp.path().join("no-such-dir").join("x.lock");
+        assert!(MkdirLock::try_acquire(&missing, stale).is_err());
+    }
+
+    #[test]
+    fn try_acquire_reaps_a_stale_lock() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock_path = tmp.path().join(".x.lock");
+        std::fs::create_dir(&lock_path).unwrap();
+        std::thread::sleep(Duration::from_millis(30));
+        let acquired = MkdirLock::try_acquire(&lock_path, Duration::from_millis(10)).unwrap();
+        assert!(acquired.is_some(), "a lock older than the stale threshold must be reaped");
     }
 
     #[test]

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -927,47 +927,37 @@ pub struct DaemonStatusReport {
     /// Dynamic-cap input 2: how many worktrees the scratch volume can hold at
     /// `LOOM_PER_WORKTREE_GB` each. Via [`crate::disk_headroom::disk_headroom_limit`].
     pub disk_headroom: usize,
-    /// Dynamic-cap input 3 (#3978): how many additional concurrent sweeps the
-    /// host's CPU/load headroom can currently absorb. Via
-    /// [`crate::cpu_headroom::cpu_headroom`]. Added because the token/disk axes
-    /// alone let a batch of resetting token accounts raise the cap regardless
-    /// of how many concurrent `cargo build`s were already saturating the host
-    /// — which starved the main-health gate's own build of CPU badly enough to
-    /// false-time-out (the #3978 incident). `#[serde(default)]` keeps pre-#3978
-    /// wire data / older clients compatible (an absent field parses as `0`,
-    /// which the status renderer never treats as a real reading — see
-    /// [`Self::logical_cpus`]).
-    #[serde(default)]
-    pub cpu_headroom: usize,
-    /// The host's logical CPU count feeding [`Self::cpu_headroom`] (#3978), via
-    /// [`crate::cpu_headroom::logical_cpu_count`]. Surfaced so the status view
-    /// can render "X healthy cores" context next to the headroom number.
-    /// `#[serde(default)]` keeps pre-#3978 wire data compatible.
+    /// The host's logical CPU count (#3978), via
+    /// [`crate::cpu_headroom::logical_cpu_count`]. **Observational only since
+    /// #4512** — the CPU headroom *term* it used to feed was removed from the
+    /// admission formula; the status view still renders it (with
+    /// [`Self::cpu_idle_fraction`]) because observed CPU usage is exactly the
+    /// evidence an operator tunes `maxConcurrent` from. `#[serde(default)]`
+    /// keeps pre-#3978 wire data compatible (`0` = "not reported").
     #[serde(default)]
     pub logical_cpus: usize,
-    /// The current 1-minute load average feeding [`Self::cpu_headroom`]
-    /// (#3978), via [`crate::cpu_headroom::read_loadavg_1m`]. `None` on a
-    /// platform/host where no load-average source is available (the CPU term
-    /// then falls back to its static, load-agnostic capacity — see the
-    /// [`crate::cpu_headroom`] module docs). `#[serde(default)]` keeps
-    /// pre-#3978 wire data compatible.
+    /// The current 1-minute load average (#3978), via
+    /// [`crate::cpu_headroom::read_loadavg_1m`]. `None` on a platform/host where
+    /// no load-average source is available. Observational (see
+    /// [`Self::logical_cpus`]); the load-per-core ratio derived from it is what
+    /// the host-distress circuit breaker (#4235) trips on. `#[serde(default)]`
+    /// keeps pre-#3978 wire data compatible.
     #[serde(default)]
     pub loadavg_1m: Option<f64>,
-    /// The measured CPU idle fraction (`0.0..=1.0`) feeding [`Self::cpu_headroom`]
-    /// (#4031), via [`crate::cpu_headroom::cached_cpu_idle_fraction`]. This is the
-    /// signal that replaced the 1-minute load average as the source of "consumed
-    /// cores" — load average overstated consumption by ~1.5× on macOS because it
-    /// counts network-I/O-blocked `claude` sessions that consume no core. `None`
-    /// when no idle sample has been taken yet (the term then falls back to
-    /// [`Self::loadavg_1m`], then to static capacity — see the
-    /// [`crate::cpu_headroom`] module docs). `#[serde(default)]` keeps pre-#4031
-    /// wire data / older clients compatible.
+    /// The measured CPU idle fraction (`0.0..=1.0`) (#4031), via
+    /// [`crate::cpu_headroom::cached_cpu_idle_fraction`] — the signal that
+    /// replaced the 1-minute load average as the source of "consumed cores"
+    /// (load average overstated consumption by ~1.5× on macOS because it counts
+    /// network-I/O-blocked `claude` sessions that consume no core). `None` when
+    /// no idle sample has been taken yet. Observational since #4512 (see
+    /// [`Self::logical_cpus`]). `#[serde(default)]` keeps pre-#4031 wire data /
+    /// older clients compatible.
     #[serde(default)]
     pub cpu_idle_fraction: Option<f64>,
     /// Whether in-flight occupancy has actually reached the dynamic cap
     /// (`in_flight.len() >= dynamic_cap`) — i.e. the cap is *currently binding*,
     /// not merely the smallest ceiling (#4031). When `false`, no resource term
-    /// (tokens/disk/CPU) is the limiter — the limiter is **work availability**,
+    /// (tokens/disk/ceiling) is the limiter — the limiter is **work availability**,
     /// and the status renderer suppresses the "token-bound" diagnosis rather than
     /// misreporting a bottleneck at, say, 1 in-flight against a cap of 7.
     /// `#[serde(default)]` keeps pre-#4031 wire data / older clients compatible
@@ -994,8 +984,11 @@ pub struct DaemonStatusReport {
     /// wire data compatible.
     #[serde(default)]
     pub preflight_advisory_message: Option<String>,
-    /// Dynamic-cap input 4: the configured operator ceiling
+    /// Dynamic-cap input 3: **the** per-machine admission knob
     /// (`autonomous.workFinder.maxConcurrent` / `LOOM_WORK_FINDER_MAX_CONCURRENT`).
+    /// Since #4512 this is the only *policy* term in the cap — the other two
+    /// meter exhaustible resources (accounts, bytes) — so it is what an operator
+    /// tunes for a host, empirically, from the observed idle fraction above.
     pub configured_max: usize,
     /// The per-token concurrency factor (#3947): how many concurrent sweeps the
     /// dynamic cap allows per *healthy* token. The token axis of the cap is
@@ -1007,10 +1000,10 @@ pub struct DaemonStatusReport {
     #[serde(default)]
     pub per_token_concurrency: usize,
     /// The effective dynamic concurrency cap —
-    /// `min(token_axis × per_token_concurrency, disk_headroom, cpu_headroom,
-    /// configured_max)` (`resolve_dynamic_max_concurrent`, CPU term #3978).
-    /// This is the total-occupancy ceiling the work finder recomputes every
-    /// tick.
+    /// `min(token_axis × per_token_concurrency, disk_headroom, configured_max)`
+    /// (`resolve_dynamic_max_concurrent`; the CPU term that sat in this `min`
+    /// from #3978 was removed in #4512). This is the total-occupancy ceiling the
+    /// work finder recomputes every tick.
     pub dynamic_cap: usize,
     /// Whether autonomous dispatch is currently halted by the reactive
     /// main-health gate (#3812). `true` means a red `main` has paused new

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -22,28 +22,39 @@
 //! 3. For each remaining issue, dispatches through the existing
 //!    [`SweepRegistry::dispatch`](crate::sweep_registry::SweepRegistry::dispatch)
 //!    path — up to a **work-driven** max-concurrency cap recomputed every tick
-//!    (Phase B, #3811; CPU/load term added in #3978): `min(token-pool size,
-//!    disk headroom, cpu/load headroom, configured max)`. `dispatch()` already
-//!    flips `loom:issue → loom:building`, acquires the per-issue `mkdir`-atomic
-//!    claim lock, and spawns the rotated-token child.
+//!    (Phase B, #3811; simplified in #4512): `min(token axis, disk headroom,
+//!    configured max)`. `dispatch()` already flips `loom:issue →
+//!    loom:building`, acquires the per-issue `mkdir`-atomic claim lock, and
+//!    spawns the rotated-token child.
 //!
-//! # Concurrency scaling (Phase B, #3811; CPU/load term #3978)
+//! # Concurrency scaling (Phase B, #3811; CPU term removed in #4512)
 //!
 //! Phase A resolved a single fixed cap once at daemon startup. Phase B replaces
 //! it with a cap **recomputed every tick** by
-//! [`resolve_dynamic_max_concurrent`] from live inputs — the token-pool size
-//! ([`crate::tokens::token_pool_size`]), the worktree-root disk headroom
-//! ([`crate::disk_headroom::disk_headroom_limit`]), the host's CPU/load
-//! headroom ([`crate::cpu_headroom::cpu_headroom_limit`], #3978 — added because
-//! the token/disk axes alone let a batch of resetting accounts push the cap up
-//! regardless of how many concurrent `cargo build`s were already saturating the
-//! host), and the operator ceiling (`LOOM_WORK_FINDER_MAX_CONCURRENT`,
-//! repurposed from Phase A's fixed target into a *ceiling*). The effective
-//! per-tick concurrency is then `min(dynamic_cap, backlog_depth)`: [`tick`]
-//! iterates the ready `loom:issue` rows and stops at the cap, so concurrency
-//! scales **up** as the backlog grows and drains to **zero** dispatches when
-//! the queue is empty — all without a daemon restart, since
-//! pool/disk/cpu/backlog are read fresh each tick.
+//! [`resolve_dynamic_max_concurrent`] from live inputs — the token axis
+//! ([`crate::tokens::token_pool_size`] / [`crate::capacity::read_ranking`]),
+//! the worktree-root disk headroom
+//! ([`crate::disk_headroom::disk_headroom_limit`]), and the per-machine
+//! operator ceiling (`LOOM_WORK_FINDER_MAX_CONCURRENT` /
+//! `autonomous.workFinder.maxConcurrent`). The effective per-tick concurrency
+//! is then `min(dynamic_cap, backlog_depth)`: [`tick`] iterates the ready
+//! `loom:issue` rows and stops at the cap, so concurrency scales **up** as the
+//! backlog grows and drains to **zero** dispatches when the queue is empty —
+//! all without a daemon restart, since pool/disk/backlog are read fresh each
+//! tick.
+//!
+//! **#4512 removed the CPU term from this formula.** A fourth axis
+//! (`cpu_headroom = (logical_cpus × cpuUtilizationTarget − consumed_cores) /
+//! estCoresPerSweep`, #3978/#4031) used to be part of the `min(...)`. It priced
+//! every sweep as a build, so it throttled the API-wait-dominated majority to
+//! defend against the heavy-build minority — an 8-core worker measured **95%
+//! idle** was capped at 2. The two hard floors that meter genuinely
+//! *exhaustible* resources (the token axis, disk headroom) stay; the CPU
+//! estimate is gone; and the heavy stages now serialize where they actually
+//! occur, on the machine-wide build slot ([`crate::build_slot`]). The host
+//! breaker (#4235, [`crate::host_breaker`]) remains the load safety net that
+//! makes a hand-tuned ceiling safe: a mis-set knob trips a **measured** breaker
+//! instead of melting the host.
 //!
 //! # Idempotency & fail-safe
 //!
@@ -85,9 +96,6 @@ use std::time::Duration;
 use anyhow::Result;
 
 use crate::capacity::{self, CapacityAdvisory};
-use crate::cpu_headroom::{
-    cpu_headroom_limit, resolve_est_cores_per_sweep, resolve_utilization_target,
-};
 use crate::disk_headroom::disk_headroom_limit;
 use crate::event_bus::EventBus;
 use crate::main_health_gate::{MainHealthState, WorkspaceHealthStates};
@@ -1152,17 +1160,17 @@ pub struct WorkFinderConfig {
     /// `autonomous` level (not under `workFinder`), so it is read even when no
     /// `workFinder` block is present. A zero/invalid value is dropped to `None`.
     pub per_token_concurrency: Option<usize>,
-    /// `autonomous.cpuUtilizationTarget` — the fraction of logical CPUs the CPU
-    /// headroom term (#3978) is willing to dedicate to sweep work (#4032). Also
-    /// lives at the `autonomous` level, alongside `perTokenConcurrency`. A
-    /// value outside `(0, 1]` (or the wrong JSON type) is dropped to `None`, so
-    /// it falls through to [`crate::cpu_headroom::DEFAULT_UTILIZATION_TARGET`].
-    pub cpu_utilization_target: Option<f64>,
-    /// `autonomous.estCoresPerSweep` — the estimated CPU cores a single
-    /// concurrent sweep consumes while building/testing (#3978, #4032). A
-    /// value `<= 0` (or the wrong JSON type) is dropped to `None`, so it falls
-    /// through to [`crate::cpu_headroom::DEFAULT_EST_CORES_PER_SWEEP`].
-    pub est_cores_per_sweep: Option<f64>,
+    /// Names of **retired** config keys found in `autonomous` — currently
+    /// `cpuUtilizationTarget` / `estCoresPerSweep` ([`DEPRECATED_CPU_CONFIG_KEYS`]),
+    /// whose CPU-headroom admission term #4512 deleted.
+    ///
+    /// They are **accepted-but-ignored**, never a config error: a fleet's
+    /// committed `.loom/config.json` must keep parsing across the upgrade. Their
+    /// presence (at any value — no range filtering, since nothing consumes the
+    /// value) is recorded here purely so
+    /// [`warn_deprecated_cpu_knobs`] can log one deprecation line naming exactly
+    /// which keys to delete.
+    pub deprecated_cpu_keys: Vec<&'static str>,
 }
 
 /// Read `.loom/config.json → autonomous.workFinder`, soft-failing every field
@@ -1189,20 +1197,17 @@ pub fn read_work_finder_config(repo_root: &Path) -> WorkFinderConfig {
         .filter(|&n| n > 0)
         .and_then(|n| usize::try_from(n).ok());
 
-    // `cpuUtilizationTarget` / `estCoresPerSweep` (#4032) also live at the
-    // `autonomous` level, mirroring `perTokenConcurrency`. `Value::as_f64`
-    // accepts both integer and float JSON (`2` and `2.0`); range filters match
-    // the env-var resolvers in `cpu_headroom.rs` exactly so a config value
-    // that would be rejected there is dropped to `None` here too, rather than
-    // being clamped or silently applied out of range.
-    let cpu_utilization_target = autonomous
-        .get("cpuUtilizationTarget")
-        .and_then(serde_json::Value::as_f64)
-        .filter(|&f| f > 0.0 && f <= 1.0);
-    let est_cores_per_sweep = autonomous
-        .get("estCoresPerSweep")
-        .and_then(serde_json::Value::as_f64)
-        .filter(|&f| f > 0.0);
+    // `cpuUtilizationTarget` / `estCoresPerSweep` used to live at the
+    // `autonomous` level too (#4032), feeding the CPU-headroom admission term
+    // #4512 deleted. They are now accepted-but-ignored: note their presence for
+    // the one-shot deprecation warning and parse nothing — no range filtering,
+    // no type coercion, because no consumer reads the value any more. A
+    // consumer's committed config keeps parsing unchanged (never a hard error).
+    let deprecated_cpu_keys: Vec<&'static str> = DEPRECATED_CPU_CONFIG_KEYS
+        .iter()
+        .copied()
+        .filter(|key| autonomous.get(*key).is_some_and(|v| !v.is_null()))
+        .collect();
 
     // The `workFinder` sub-block is optional; each field independently falls
     // through to `None` (env/default resolution) when absent.
@@ -1227,9 +1232,79 @@ pub fn read_work_finder_config(repo_root: &Path) -> WorkFinderConfig {
             .filter(|&n| n > 0)
             .and_then(|n| usize::try_from(n).ok()),
         per_token_concurrency,
-        cpu_utilization_target,
-        est_cores_per_sweep,
+        deprecated_cpu_keys,
     }
+}
+
+/// Retired `autonomous.*` config keys, accepted-but-ignored since #4512 (they
+/// fed the deleted CPU-headroom admission term, #3978/#4031).
+pub const DEPRECATED_CPU_CONFIG_KEYS: [&str; 2] = ["cpuUtilizationTarget", "estCoresPerSweep"];
+
+/// Retired env vars, accepted-but-ignored since #4512 — the env half of
+/// [`DEPRECATED_CPU_CONFIG_KEYS`].
+pub const DEPRECATED_CPU_ENV_VARS: [&str; 2] =
+    ["LOOM_CPU_UTILIZATION_TARGET", "LOOM_EST_CORES_PER_SWEEP"];
+
+/// One-shot guard so the deprecation warning is logged **once per process**, not
+/// once per config read (the config is re-read on several paths, including every
+/// `status` request).
+static DEPRECATION_WARNED: std::sync::Once = std::sync::Once::new();
+
+/// Render the deprecation notice for any retired CPU-headroom knob still set in
+/// `config` or the environment — `None` when none is set (#4512).
+///
+/// Split out from [`warn_deprecated_cpu_knobs`] because the two channels an
+/// operator actually watches are different processes: the **daemon** has a
+/// logger (`~/.loom/daemon.log`) and warns through it, while a **CLI**
+/// subcommand (`loom-daemon calibrate`) returns from `main` *before*
+/// `setup_logging()` runs, so a `log::warn!` there is a silent no-op. The CLI
+/// therefore prints this same string to stderr instead of relying on the log
+/// (see `handle_calibrate_command`). One message, two delivery paths — never a
+/// warning that exists only in a file nobody is tailing.
+#[must_use]
+pub fn deprecated_cpu_knob_notice(config: &WorkFinderConfig) -> Option<String> {
+    let env_set: Vec<&str> = DEPRECATED_CPU_ENV_VARS
+        .iter()
+        .copied()
+        .filter(|v| std::env::var_os(v).is_some())
+        .collect();
+    if config.deprecated_cpu_keys.is_empty() && env_set.is_empty() {
+        return None;
+    }
+    let mut sources = Vec::new();
+    if !config.deprecated_cpu_keys.is_empty() {
+        sources.push(format!("config `autonomous.{{{}}}`", config.deprecated_cpu_keys.join(", ")));
+    }
+    if !env_set.is_empty() {
+        sources.push(format!("env {}", env_set.join(", ")));
+    }
+    Some(format!(
+        "{} set but IGNORED — #4512 removed the CPU-headroom term from the admission formula \
+         (now min(token axis, disk headroom, maxConcurrent)). Tune \
+         `autonomous.workFinder.maxConcurrent` for this machine instead; heavy build/test stages \
+         are serialized by the machine-wide build slot (LOOM_BUILD_SLOTS), and the host-distress \
+         breaker remains the load safety net. Delete the setting(s) to silence this warning.",
+        sources.join(" and ")
+    ))
+}
+
+/// Log a single deprecation warning naming any retired CPU-headroom knob still
+/// set in config or the environment (#4512).
+///
+/// Accepted-but-ignored is a deliberate compatibility contract: a fleet upgrades
+/// the daemon binary before it edits every repo's committed `.loom/config.json`,
+/// so a stale key must **never** be a parse error — it must be a *visible*
+/// no-op. Called once at daemon startup, it is internally idempotent via
+/// [`std::sync::Once`], so extra call sites are free. CLI subcommands print
+/// [`deprecated_cpu_knob_notice`] to stderr instead (no logger is initialized on
+/// that path).
+pub fn warn_deprecated_cpu_knobs(config: &WorkFinderConfig) {
+    let Some(notice) = deprecated_cpu_knob_notice(config) else {
+        return;
+    };
+    DEPRECATION_WARNED.call_once(|| {
+        log::warn!("work_finder: {notice}");
+    });
 }
 
 /// Resolve whether the loop is enabled with precedence **env > config >
@@ -1275,8 +1350,8 @@ fn env_max_admissions_per_tick() -> Option<usize> {
 /// Resolve the per-tick admission (ramp) cap with precedence **env > config
 /// (`autonomous.workFinder.maxAdmissionsPerTick`) > default** (#4234).
 /// Resolved once at daemon startup — the same startup-capture pattern as
-/// [`resolve_cpu_utilization_target`] / [`resolve_cpu_est_cores_per_sweep`]
-/// (#4032) — and threaded through to [`spawn_work_finder_task`] /
+/// [`resolve_max_concurrent_with_config`] / [`resolve_per_token_concurrency`]
+/// — and threaded through to [`spawn_work_finder_task`] /
 /// [`spawn_multi_work_finder_task`] as a plain `usize`, mirroring
 /// `per_token_concurrency`. See [`WORK_FINDER_MAX_ADMISSIONS_PER_TICK_ENV`] for
 /// why this is a deliberate startup-capture, not a per-tick re-read: the ramp
@@ -1313,29 +1388,10 @@ pub fn resolve_per_token_concurrency(config: &WorkFinderConfig) -> usize {
         .unwrap_or(DEFAULT_PER_TOKEN_CONCURRENCY)
 }
 
-/// Resolve the CPU headroom term's utilization-target knob with precedence
-/// **env > config > default** (#4032). Thin wrapper over
-/// [`crate::cpu_headroom::resolve_utilization_target`] that reads the config
-/// half from this module's already-parsed [`WorkFinderConfig`], mirroring how
-/// [`resolve_per_token_concurrency`] reads `config.per_token_concurrency`.
-#[must_use]
-pub fn resolve_cpu_utilization_target(config: &WorkFinderConfig) -> f64 {
-    resolve_utilization_target(config.cpu_utilization_target)
-}
-
-/// Resolve the CPU headroom term's est-cores-per-sweep knob with precedence
-/// **env > config > default** (#4032). Thin wrapper over
-/// [`crate::cpu_headroom::resolve_est_cores_per_sweep`]; see
-/// [`resolve_cpu_utilization_target`].
-#[must_use]
-pub fn resolve_cpu_est_cores_per_sweep(config: &WorkFinderConfig) -> f64 {
-    resolve_est_cores_per_sweep(config.est_cores_per_sweep)
-}
-
 /// Compute the **work-driven dynamic concurrency cap** (Phase B, #3811;
-/// per-token concurrency factor added in #3947; CPU/load term added in
-/// #3978): `min(token_limit × per_token_concurrency, disk_headroom,
-/// cpu_headroom, configured_max)`.
+/// per-token concurrency factor added in #3947; CPU term **removed** in
+/// #4512): `min(token_limit × per_token_concurrency, disk_headroom,
+/// configured_max)`.
 ///
 /// This is the total-concurrency ceiling for the loop, recomputed every tick
 /// from live inputs. It deliberately does **not** fold in the backlog depth:
@@ -1346,11 +1402,11 @@ pub fn resolve_cpu_est_cores_per_sweep(config: &WorkFinderConfig) -> f64 {
 /// `loom:building` sweeps that are **not** in the ready backlog. Folding backlog
 /// into the cap here would under-utilize the pool whenever prior-tick sweeps are
 /// still running (a smaller "new work" number would cap total occupancy below
-/// the pool/disk/cpu ceiling). Keeping the cap as `min(token×factor, disk, cpu,
+/// the pool/disk ceiling). Keeping the cap as `min(token×factor, disk,
 /// configured)` and letting `tick` apply the backlog bound is what makes
 /// concurrency scale up with the backlog and drain to zero when it empties.
 ///
-/// The bounds map directly to the resource each protects:
+/// The three bounds map directly to the resource each protects:
 /// - `token_limit` — the count of *healthy* accounts (or the raw pool when no
 ///   ranking exists). **Multiplied by `per_token_concurrency`** (#3947): a plan
 ///   limit is a utilization-window token bucket, not a session count, so one
@@ -1360,17 +1416,32 @@ pub fn resolve_cpu_est_cores_per_sweep(config: &WorkFinderConfig) -> f64 {
 ///   even though the single healthy account had ample session-window headroom.
 /// - `disk_headroom` — never provision more worktrees than the scratch volume
 ///   can hold at `LOOM_PER_WORKTREE_GB` each.
-/// - `cpu_headroom` (#3978) — never start more concurrent sweeps than the host
-///   has CPU/load headroom for, at `LOOM_EST_CORES_PER_SWEEP` estimated cores
-///   each. This is the term the pre-#3978 formula lacked: a token-axis jump
-///   (e.g. several exhausted accounts resetting at once) used to raise the
-///   cap regardless of how many concurrent `cargo build`s were already
-///   running in worktrees, which could starve the main-health gate's own
-///   build of CPU badly enough to false-time-out. See
-///   [`crate::cpu_headroom::cpu_headroom_limit`].
-/// - `configured_max` — the operator ceiling
-///   (`LOOM_WORK_FINDER_MAX_CONCURRENT`), a hard upper bound regardless of how
-///   much token/disk/cpu headroom exists.
+/// - `configured_max` — **the** per-machine admission knob
+///   (`LOOM_WORK_FINDER_MAX_CONCURRENT` / `autonomous.workFinder.maxConcurrent`),
+///   tuned empirically per host.
+///
+/// # Why there is no CPU term any more (#4512)
+///
+/// A fourth axis used to sit in this `min(...)`: `cpu_headroom = (logical_cpus ×
+/// cpuUtilizationTarget − consumed_cores) / estCoresPerSweep` (#3978, measured-idle
+/// signal #4031). It was **deleted**, deliberately reversing that design:
+///
+/// - It priced **every** sweep as a build (`estCoresPerSweep`, calibrated
+///   against Rust build phases), but sweep wall-clock is dominated by API-wait
+///   (curator / builder / judge conversations). It therefore throttled the
+///   low-CPU majority to defend against the heavy-build minority: on an 8-core
+///   worker measured **95% idle**, the term computed a cap of `2`.
+/// - The two remaining axes meter genuinely **exhaustible** resources (accounts,
+///   bytes) and can be counted exactly. A CPU *estimate* is neither exact nor
+///   exhaustible — it was a proxy for "will a build starve another build".
+/// - That real concern is now handled where the load actually is: the
+///   machine-wide build slot ([`crate::build_slot`]) serializes the designated
+///   high-CPU stages across concurrent sweeps, so N sweeps run while at most 1–2
+///   build.
+/// - The safety net for a mis-set knob is **measurement, not estimation**: the
+///   host-distress circuit breaker ([`crate::host_breaker`], #4235) suspends
+///   dispatch on observed load-per-core, and the per-tick admission ramp cap
+///   (#4234) still bounds how fast occupancy can grow.
 ///
 /// `per_token_concurrency` is clamped to a floor of `1` so a mis-set `0`
 /// degrades to the pre-#3947 one-sweep-per-account behavior rather than
@@ -1381,13 +1452,11 @@ pub fn resolve_dynamic_max_concurrent(
     token_limit: usize,
     per_token_concurrency: usize,
     disk_headroom: usize,
-    cpu_headroom: usize,
     configured_max: usize,
 ) -> usize {
     token_limit
         .saturating_mul(per_token_concurrency.max(1))
         .min(disk_headroom)
-        .min(cpu_headroom)
         .min(configured_max)
 }
 
@@ -1399,14 +1468,14 @@ pub fn resolve_dynamic_max_concurrent(
 /// handle so the daemon can keep it alive for the process lifetime.
 ///
 /// Every `interval`, the task recomputes the **dynamic** concurrency cap
-/// (Phase B, #3811; CPU/load term #3978) — `min(token-pool size, disk
-/// headroom, cpu/load headroom, configured_max)` via
-/// [`resolve_dynamic_max_concurrent`] — from live inputs read fresh under
-/// `workspace_root`, then runs one [`tick`] with it. The cap is **not** captured
-/// once at startup, so a pool that grows/shrinks (`loom-tokens bootstrap`), a
-/// scratch volume that fills/frees, current host load, or a draining backlog
-/// are all honored without a daemon restart. `configured_max` is the operator
-/// ceiling (`LOOM_WORK_FINDER_MAX_CONCURRENT`).
+/// (Phase B, #3811; CPU term removed in #4512) — `min(token axis, disk
+/// headroom, configured_max)` via [`resolve_dynamic_max_concurrent`] — from
+/// live inputs read fresh under `workspace_root`, then runs one [`tick`] with
+/// it. The cap is **not** captured once at startup, so a pool that
+/// grows/shrinks (`loom-tokens bootstrap`), a scratch volume that fills/frees,
+/// or a draining backlog are all honored without a daemon restart.
+/// `configured_max` is the per-machine admission knob
+/// (`LOOM_WORK_FINDER_MAX_CONCURRENT`).
 ///
 /// Unlike the epic supervisor, no dedicated OS thread is needed:
 /// [`SweepRegistry::dispatch`] returns promptly (fire-and-forget child spawn),
@@ -1424,8 +1493,6 @@ pub fn spawn_work_finder_task<S, D>(
     workspace_root: PathBuf,
     configured_max: usize,
     per_token_concurrency: usize,
-    cpu_utilization_target: f64,
-    cpu_est_cores_per_sweep: f64,
     max_admissions_per_tick: usize,
     health_state: Arc<MainHealthState>,
     suppress_dispatch_during_gate: bool,
@@ -1439,7 +1506,7 @@ where
         "work_finder: starting loop (interval={}s, configured_max={configured_max}, \
          per_token_concurrency={per_token_concurrency}, \
          max_admissions_per_tick={max_admissions_per_tick}, \
-         dynamic cap = min(healthy tokens × per-token, disk, cpu, configured_max))",
+         dynamic cap = min(healthy tokens × per-token, disk, configured_max))",
         interval.as_secs()
     );
     tokio::spawn(async move {
@@ -1531,40 +1598,28 @@ where
             let token_limit = ranking.as_ref().map_or(pool_size, |r| r.available);
             log_healthy_token_transition(&mut was_healthy_tokens, token_limit, ranking.as_ref());
             let disk = disk_headroom_limit(&workspace_root);
-            // CPU headroom (#3978; measured-idle signal #4031): the term the
-            // pre-#3978 formula lacked. `cpu_headroom_limit()` refreshes the
-            // memoized idle sample, which sleeps ~1s on macOS (`iostat`), so it
-            // is moved off the runtime via `spawn_blocking`; a join error falls
-            // back to the policy floor of 1 (soft backoff, never a hard halt).
-            // `cpu_utilization_target` / `cpu_est_cores_per_sweep` are resolved
-            // once at startup (env > config > default, #4032) and captured by
-            // this task, mirroring `per_token_concurrency`. NOTE (#4234): a
-            // release-build-heavy repo should raise `estCoresPerSweep` well
-            // above the shipped default of 2.0 — a `cargo build --release`
-            // parallelizes across every core via rustc codegen units, so 6
-            // concurrent release builds demand far closer to `6 × ncpu` than
-            // `6 × 2`. The per-tick `max_admissions_per_tick` ramp cap below is
-            // a second, independent backstop for exactly this under-estimate:
-            // even if `estCoresPerSweep` is miscalibrated too low and the cpu
-            // axis over-admits, the ramp cap still bounds how many of those
-            // over-admitted sweeps land in any single tick.
-            let cpu = tokio::task::spawn_blocking(move || {
-                cpu_headroom_limit(cpu_utilization_target, cpu_est_cores_per_sweep)
-            })
-            .await
-            .unwrap_or(1);
+            // Refresh the memoized CPU idle sample. Purely **observational**
+            // since #4512 — it no longer feeds admission, it feeds the
+            // `idle=` figure below plus `loom-daemon status` / `calibrate`, which
+            // is how an operator decides whether to raise or lower
+            // `maxConcurrent` for this machine. The refresh sleeps ~1s on macOS
+            // (`iostat`), so it stays on `spawn_blocking`; a join error just
+            // leaves the previous sample in place.
+            let _ = tokio::task::spawn_blocking(crate::cpu_headroom::refresh_cpu_util_cache).await;
+            let idle = crate::cpu_headroom::cached_cpu_idle_fraction();
             let max_concurrent = resolve_dynamic_max_concurrent(
                 token_limit,
                 per_token_concurrency,
                 disk,
-                cpu,
                 configured_max,
             );
             let axis_line = format!(
                 "work_finder: dynamic cap = {max_concurrent} (pool={pool_size}, \
                  healthy_tokens={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
-                 cpu={cpu}, configured_max={configured_max}, \
-                 max_admissions_per_tick={max_admissions_per_tick}, halted={halted})"
+                 configured_max={configured_max}, \
+                 max_admissions_per_tick={max_admissions_per_tick}, halted={halted}, \
+                 observed_idle={})",
+                format_idle(idle)
             );
             if was_max_concurrent != Some(max_concurrent) {
                 log::info!("{axis_line}");
@@ -1601,7 +1656,7 @@ where
                         log::info!(
                             "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
                              healthy={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
-                             cpu={cpu}, ceiling={configured_max}, ramp_cap={max_admissions_per_tick}); \
+                             ceiling={configured_max}, ramp_cap={max_admissions_per_tick}); \
                              {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, \
                              {} quarantine-skip, {} backoff-skip, {} pr-open-skip, \
                              {} peer-claim-skip, \
@@ -1630,7 +1685,6 @@ where
                             pool_size,
                             token_limit,
                             disk,
-                            cpu,
                             configured_max,
                             report.deferred_capacity,
                             capacity::DEFAULT_ADVISORY_MIN_QUEUED,
@@ -1695,17 +1749,13 @@ where
 /// the `(repo, issue)` key that disambiguates them is phase c (#3929). No new
 /// topic shape is introduced here (CLAUDE.md: "New topics require a follow-up
 /// issue").
-#[allow(clippy::too_many_arguments)] // dynamic-cap inputs (#4032 adds two more
-                                     // resolved-once-at-startup f64 knobs, mirroring
-                                     // per_token_concurrency) + shared state.
+#[allow(clippy::too_many_arguments)] // dynamic-cap inputs + shared state.
 pub fn spawn_multi_work_finder_task(
     pool: Arc<WorkspacePool>,
     fallback_root: PathBuf,
     interval: Duration,
     configured_max: usize,
     per_token_concurrency: usize,
-    cpu_utilization_target: f64,
-    cpu_est_cores_per_sweep: f64,
     max_admissions_per_tick: usize,
     health_states: Arc<WorkspaceHealthStates>,
     suppress_dispatch_during_gate: bool,
@@ -1716,7 +1766,7 @@ pub fn spawn_multi_work_finder_task(
     log::info!(
         "work_finder: starting multi-workspace loop (interval={}s, configured_max={configured_max}, \
          per_token_concurrency={per_token_concurrency}, max_admissions_per_tick={max_admissions_per_tick}, \
-         dynamic cap = min(healthy tokens × per-token, disk, cpu, configured_max), global across workspaces)",
+         dynamic cap = min(healthy tokens × per-token, disk, configured_max), global across workspaces)",
         interval.as_secs()
     );
     tokio::spawn(async move {
@@ -1798,24 +1848,17 @@ pub fn spawn_multi_work_finder_task(
             let token_limit = ranking.as_ref().map_or(pool_size, |r| r.available);
             log_healthy_token_transition(&mut was_healthy_tokens, token_limit, ranking.as_ref());
             let disk = disk_headroom_limit(&fallback_root);
-            // CPU headroom (#3978; measured-idle signal #4031) — also a
-            // machine-level resource, probed once per tick and shared across
-            // every workspace. Moved off the runtime via `spawn_blocking` since
-            // the macOS `iostat` refresh sleeps ~1s; a join error falls back to
-            // the policy floor of 1. `cpu_utilization_target` /
-            // `cpu_est_cores_per_sweep` are resolved once at startup (env >
-            // config > default, #4032) and captured by this task, mirroring
-            // `per_token_concurrency`.
-            let cpu = tokio::task::spawn_blocking(move || {
-                cpu_headroom_limit(cpu_utilization_target, cpu_est_cores_per_sweep)
-            })
-            .await
-            .unwrap_or(1);
+            // Refresh the memoized CPU idle sample — **observational only**
+            // since #4512 (see the single-workspace loop above). It feeds the
+            // `observed_idle=` figure in the axis line and `loom-daemon status`
+            // / `calibrate`, which is how an operator tunes this machine's
+            // `maxConcurrent`; it no longer gates admission.
+            let _ = tokio::task::spawn_blocking(crate::cpu_headroom::refresh_cpu_util_cache).await;
+            let idle = crate::cpu_headroom::cached_cpu_idle_fraction();
             let max_concurrent = resolve_dynamic_max_concurrent(
                 token_limit,
                 per_token_concurrency,
                 disk,
-                cpu,
                 configured_max,
             );
 
@@ -1882,9 +1925,10 @@ pub fn spawn_multi_work_finder_task(
             let axis_line = format!(
                 "work_finder: dynamic cap = {max_concurrent} (pool={pool_size}, \
                  healthy_tokens={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
-                 cpu={cpu}, configured_max={configured_max}, \
+                 configured_max={configured_max}, \
                  max_admissions_per_tick={max_admissions_per_tick}, any_halted={any_halted}, \
-                 workspaces={}, priorities={priorities:?})",
+                 observed_idle={}, workspaces={}, priorities={priorities:?})",
+                format_idle(idle),
                 pairs.len()
             );
             if was_max_concurrent != Some(max_concurrent) {
@@ -1925,7 +1969,7 @@ pub fn spawn_multi_work_finder_task(
                 log::info!(
                     "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
                      healthy={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
-                     cpu={cpu}, ceiling={configured_max}, ramp_cap={max_admissions_per_tick}); \
+                     ceiling={configured_max}, ramp_cap={max_admissions_per_tick}); \
                      {} workspace(s), \
                      {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, \
                      {} quarantine-skip, {} backoff-skip, {} pr-open-skip, \
@@ -1954,7 +1998,6 @@ pub fn spawn_multi_work_finder_task(
                     pool_size,
                     token_limit,
                     disk,
-                    cpu,
                     configured_max,
                     report.deferred_capacity,
                     capacity::DEFAULT_ADVISORY_MIN_QUEUED,
@@ -1983,6 +2026,17 @@ pub fn spawn_multi_work_finder_task(
             }
         }
     })
+}
+
+/// Render the measured CPU idle fraction for the per-tick axis line as a
+/// percentage, or `"n/a"` when no sample exists yet (#4512).
+///
+/// This figure is **observational**: it is no longer an input to the cap (the
+/// CPU term is gone), it is the evidence an operator uses to decide whether this
+/// machine's `maxConcurrent` is too low (host sits idle) or too high (host is
+/// saturated / the breaker trips).
+fn format_idle(idle: Option<f64>) -> String {
+    idle.map_or_else(|| "n/a".to_string(), |f| format!("{:.0}%", f * 100.0))
 }
 
 /// Log the count of healthy (`available`) token accounts once, on a **state
@@ -3722,29 +3776,45 @@ exit 0
 
     // ===================================================================
     // resolve_dynamic_max_concurrent — Phase B work-driven policy (#3811),
-    // per-token concurrency factor (#3947), CPU/load headroom term (#3978)
+    // per-token concurrency factor (#3947), CPU term REMOVED (#4512)
     // ===================================================================
 
     #[test]
-    fn test_dynamic_cap_is_min_of_four_inputs() {
-        // Never exceeds any of the four bounds (factor 1 = pre-#3947 semantics).
-        assert_eq!(resolve_dynamic_max_concurrent(10, 1, 10, 10, 10), 10);
-        assert_eq!(resolve_dynamic_max_concurrent(2, 1, 9, 9, 9), 2, "token axis binds");
-        assert_eq!(resolve_dynamic_max_concurrent(9, 1, 3, 9, 9), 3, "disk binds");
-        assert_eq!(resolve_dynamic_max_concurrent(9, 1, 9, 4, 9), 4, "cpu binds");
-        assert_eq!(resolve_dynamic_max_concurrent(9, 1, 9, 9, 4), 4, "ceiling binds");
+    fn test_dynamic_cap_is_min_of_three_inputs() {
+        // Never exceeds any of the three bounds (factor 1 = pre-#3947 semantics).
+        assert_eq!(resolve_dynamic_max_concurrent(10, 1, 10, 10), 10);
+        assert_eq!(resolve_dynamic_max_concurrent(2, 1, 9, 9), 2, "token axis binds");
+        assert_eq!(resolve_dynamic_max_concurrent(9, 1, 3, 9), 3, "disk binds");
+        assert_eq!(resolve_dynamic_max_concurrent(9, 1, 9, 4), 4, "maxConcurrent binds");
+    }
+
+    #[test]
+    fn test_dynamic_cap_has_no_cpu_term_at_all() {
+        // #4512 AC1: the formula is exactly min(token axis, disk, maxConcurrent).
+        // The arity itself is the guard (a 5-arg call no longer compiles), and the
+        // value must be independent of host CPU state: this same input yields the
+        // same cap on a 95%-idle 8-core worker and on a saturated one, which is
+        // the whole point — an idle host must not be throttled to 2 by an
+        // estimate (`estCoresPerSweep`) that priced every sweep as a build.
+        assert_eq!(resolve_dynamic_max_concurrent(6, 2, 36, 10), 10);
+        // The exact #4512 evidence line: healthy 6 × per-token 2 = 12, disk 36,
+        // configured 10 ⇒ 10. Pre-#4512 the cpu term pinned this host at 2.
+        assert_eq!(
+            resolve_dynamic_max_concurrent(6, 2, 36, 10).min(12),
+            10,
+            "no CPU estimate may clamp an idle host below its configured knob"
+        );
     }
 
     #[test]
     fn test_dynamic_cap_pool_size_bound_never_over_subscribes() {
-        // With a large disk headroom, cpu headroom, and ceiling and factor 1,
-        // the token-pool size is the hard bound — the cap never exceeds the
-        // number of accounts.
+        // With a large disk headroom and ceiling and factor 1, the token-pool
+        // size is the hard bound — the cap never exceeds the number of accounts.
         for pool in 0..=5 {
             assert_eq!(
-                resolve_dynamic_max_concurrent(pool, 1, 100, 100, 100),
+                resolve_dynamic_max_concurrent(pool, 1, 100, 100),
                 pool,
-                "cap must equal pool size {pool} when disk/cpu/ceiling are larger"
+                "cap must equal pool size {pool} when disk/ceiling are larger"
             );
         }
     }
@@ -3754,24 +3824,10 @@ exit 0
         // A nearly-full scratch volume (disk headroom 1) caps concurrency at 1
         // even with a big pool, high ceiling, AND a big per-token factor (#3947):
         // stacking never provisions more worktrees than the disk can hold.
-        assert_eq!(resolve_dynamic_max_concurrent(8, 4, 1, 8, 8), 1);
+        assert_eq!(resolve_dynamic_max_concurrent(8, 4, 1, 8), 1);
         // A full volume (0 headroom) drops the cap to 0 — dispatch nothing.
-        assert_eq!(resolve_dynamic_max_concurrent(8, 4, 0, 8, 8), 0);
-    }
-
-    #[test]
-    fn test_dynamic_cap_cpu_headroom_bound() {
-        // #3978 core: a saturated host (cpu headroom 1) caps concurrency at 1
-        // even with a big pool, ample disk, AND a big per-token factor — never
-        // start more concurrent sweep builds than the host's CPU/load headroom
-        // can currently absorb (this is what starved the build-gate's own
-        // `cargo` invocation of CPU in the #3978 incident).
-        assert_eq!(resolve_dynamic_max_concurrent(8, 4, 8, 1, 8), 1);
-        // Unlike disk, the cpu_headroom *term itself* is policy-floored at 1
-        // (see `crate::cpu_headroom::cpu_headroom`), so a caller can never pass
-        // 0 for it from the real end-to-end path — but the raw `min` here still
-        // honors whatever is passed, including a defensive 0.
-        assert_eq!(resolve_dynamic_max_concurrent(8, 4, 8, 0, 8), 0);
+        // #4512 keeps this hard floor: disk meters an exhaustible resource.
+        assert_eq!(resolve_dynamic_max_concurrent(8, 4, 0, 8), 0);
     }
 
     #[test]
@@ -3779,7 +3835,7 @@ exit 0
         // No usable tokens ⇒ cap 0 regardless of the factor (0 × N = 0) ⇒ a
         // subsequent tick dispatches nothing (the spawn path would hard-fail
         // EX_CONFIG anyway).
-        let cap = resolve_dynamic_max_concurrent(0, 2, 10, 10, 10);
+        let cap = resolve_dynamic_max_concurrent(0, 2, 10, 10);
         assert_eq!(cap, 0);
         let mut source = FakeSource::once((1..=3).map(issue).collect());
         let mut disp = RecordingDispatcher::default();
@@ -3792,18 +3848,13 @@ exit 0
     #[test]
     fn test_dynamic_cap_per_token_factor_multiplies_token_axis() {
         // #3947 core: the token axis is `healthy × per-token`, not `healthy × 1`.
-        // 3 healthy accounts × factor 2 = 6, bounded only by disk/cpu/ceiling.
-        assert_eq!(resolve_dynamic_max_concurrent(3, 2, 100, 100, 100), 6);
+        // 3 healthy accounts × factor 2 = 6, bounded only by disk/ceiling.
+        assert_eq!(resolve_dynamic_max_concurrent(3, 2, 100, 100), 6);
         // 2 healthy × factor 3 = 6.
-        assert_eq!(resolve_dynamic_max_concurrent(2, 3, 100, 100, 100), 6);
-        // The product is still clamped by disk, cpu, and the operator ceiling.
-        assert_eq!(resolve_dynamic_max_concurrent(3, 2, 4, 100, 100), 4, "disk clamps the product");
-        assert_eq!(resolve_dynamic_max_concurrent(3, 2, 100, 4, 100), 4, "cpu clamps the product");
-        assert_eq!(
-            resolve_dynamic_max_concurrent(3, 2, 100, 100, 5),
-            5,
-            "ceiling clamps the product"
-        );
+        assert_eq!(resolve_dynamic_max_concurrent(2, 3, 100, 100), 6);
+        // The product is still clamped by disk and the configured knob.
+        assert_eq!(resolve_dynamic_max_concurrent(3, 2, 4, 100), 4, "disk clamps the product");
+        assert_eq!(resolve_dynamic_max_concurrent(3, 2, 100, 5), 5, "ceiling clamps the product");
     }
 
     #[test]
@@ -3811,8 +3862,8 @@ exit 0
         // The load-bearing #3947 scenario (6/7 accounts at their weekly ceiling):
         // ONE healthy account with factor 2 must allow TWO concurrent sweeps —
         // the pre-#3947 implicit 1:1 cap would have collapsed this to 1.
-        let cap = resolve_dynamic_max_concurrent(1, 2, 120, 120, 3);
-        assert_eq!(cap, 2, "1 healthy × per-token 2 = 2 (disk 120, cpu 120, ceiling 3 don't bind)");
+        let cap = resolve_dynamic_max_concurrent(1, 2, 120, 3);
+        assert_eq!(cap, 2, "1 healthy × per-token 2 = 2 (disk 120, ceiling 3 don't bind)");
 
         // And that cap actually dispatches 2 (not 1) against a 2-deep backlog.
         let mut source = FakeSource::once((1..=2).map(issue).collect());
@@ -3827,19 +3878,25 @@ exit 0
     fn test_dynamic_cap_zero_factor_degrades_to_one() {
         // A mis-set factor 0 must NOT collapse the cap to zero — it degrades to
         // the pre-#3947 one-sweep-per-account behavior (floor of 1).
-        assert_eq!(resolve_dynamic_max_concurrent(4, 0, 100, 100, 100), 4);
+        assert_eq!(resolve_dynamic_max_concurrent(4, 0, 100, 100), 4);
     }
 
     #[test]
-    fn test_dynamic_cap_token_axis_jump_bounded_by_cpu_the_3978_scenario() {
-        // The exact incident this issue fixes: several exhausted token
-        // accounts reset at once, jumping the healthy-token count from 2 to
-        // 14 (a pre-#3978 formula would raise the cap to 14 × per-token
-        // regardless of host load). With concurrent Rust builds already
-        // saturating the host (cpu headroom backed off to 3), the cap must
-        // stay bounded at 3, not jump to a CPU-starving 28.
-        let cap = resolve_dynamic_max_concurrent(14, 2, 100, 3, 100);
-        assert_eq!(cap, 3, "cpu headroom protects the host even as the token axis spikes");
+    fn test_token_axis_jump_is_now_bounded_by_max_concurrent_not_cpu() {
+        // The #3978 scenario, re-baselined for #4512: several exhausted token
+        // accounts reset at once, jumping the healthy-token count from 2 to 14,
+        // so the token axis spikes to 14 × 2 = 28. There is no longer a CPU
+        // term to absorb that spike — the per-machine `maxConcurrent` knob is
+        // what bounds it (here 8), and the per-tick admission ramp cap (#4234)
+        // still limits how fast occupancy climbs toward it, with the host
+        // breaker (#4235) as the measured safety net.
+        assert_eq!(resolve_dynamic_max_concurrent(14, 2, 100, 8), 8);
+        // A machine whose operator has NOT tuned the knob rides the shipped
+        // default rather than an estimate of its cores.
+        assert_eq!(
+            resolve_dynamic_max_concurrent(14, 2, 100, DEFAULT_WORK_FINDER_MAX_CONCURRENT),
+            DEFAULT_WORK_FINDER_MAX_CONCURRENT
+        );
     }
 
     // ===================================================================
@@ -3848,10 +3905,10 @@ exit 0
 
     #[test]
     fn test_scale_up_with_growing_backlog_bounded_by_dynamic_cap() {
-        // Fixed resources: pool=4, factor=1, disk=10, cpu=10, ceiling=10 ⇒
+        // Fixed resources: pool=4, factor=1, disk=10, ceiling=10 ⇒
         // dynamic cap 4. As the backlog grows tick-over-tick, effective
         // concurrency scales up but is bounded by the cap (min(cap, backlog)).
-        let cap = resolve_dynamic_max_concurrent(4, 1, 10, 10, 10);
+        let cap = resolve_dynamic_max_concurrent(4, 1, 10, 10);
         assert_eq!(cap, 4);
 
         // Backlog 2 (< cap): all 2 dispatch, nothing deferred.
@@ -3873,7 +3930,7 @@ exit 0
     fn test_scale_to_zero_on_empty_backlog() {
         // Even with ample resources (cap 5), an empty backlog dispatches nothing
         // — no capacity is pre-reserved and no idle workers are spawned.
-        let cap = resolve_dynamic_max_concurrent(5, 1, 5, 5, 5);
+        let cap = resolve_dynamic_max_concurrent(5, 1, 5, 5);
         assert_eq!(cap, 5);
         let mut source = FakeSource::once(vec![]);
         let mut disp = RecordingDispatcher::default();
@@ -3934,90 +3991,144 @@ exit 0
                 max_concurrent: Some(5),
                 max_admissions_per_tick: Some(4),
                 per_token_concurrency: Some(4),
-                cpu_utilization_target: Some(0.6),
-                est_cores_per_sweep: Some(3.5),
+                // Retired keys are recorded (accepted-but-ignored), not parsed.
+                deprecated_cpu_keys: vec!["cpuUtilizationTarget", "estCoresPerSweep"],
             }
         );
     }
 
     // ===================================================================
-    // cpuUtilizationTarget / estCoresPerSweep config parsing (#4032)
+    // Retired cpuUtilizationTarget / estCoresPerSweep knobs: accepted but
+    // IGNORED, never a config error (#4512, replacing the #4032 parsing tests)
     // ===================================================================
 
     #[test]
-    fn test_config_cpu_knobs_read_without_work_finder_block() {
-        // Both knobs live at the `autonomous` level (#4032), so they are read
-        // even when the `workFinder` sub-block is absent — mirroring
-        // `perTokenConcurrency`.
+    fn test_deprecated_cpu_knobs_are_accepted_and_recorded_not_parsed() {
+        // A fleet upgrades the daemon binary before it edits every repo's
+        // committed config, so a stale key must parse fine and simply do nothing
+        // — recorded only so the deprecation warning can name it.
         let tmp = tempfile::tempdir().unwrap();
         write_config(
             tmp.path(),
-            r#"{"autonomous": {"cpuUtilizationTarget": 0.5, "estCoresPerSweep": 1.5}}"#,
+            r#"{"autonomous": {"cpuUtilizationTarget": 0.5, "estCoresPerSweep": 1.5,
+                "workFinder": {"enabled": true, "maxConcurrent": 10}}}"#,
         );
         let cfg = read_work_finder_config(tmp.path());
-        assert_eq!(cfg.cpu_utilization_target, Some(0.5));
-        assert_eq!(cfg.est_cores_per_sweep, Some(1.5));
-        assert_eq!(cfg.enabled, None);
+        assert_eq!(cfg.deprecated_cpu_keys, vec!["cpuUtilizationTarget", "estCoresPerSweep"]);
+        // The live knobs in the same block still parse normally: a deprecated
+        // sibling must never poison the rest of the config.
+        assert_eq!(cfg.enabled, Some(true));
+        assert_eq!(cfg.max_concurrent, Some(10));
     }
 
     #[test]
-    fn test_config_integer_cpu_knobs_parse_as_f64() {
-        // `Value::as_f64` handles integer JSON as well as float — assert it
-        // (#4032 AC: "estCoresPerSweep": 2 as well as 2.0).
-        let tmp = tempfile::tempdir().unwrap();
-        write_config(tmp.path(), r#"{"autonomous": {"estCoresPerSweep": 2}}"#);
-        let cfg = read_work_finder_config(tmp.path());
-        assert_eq!(cfg.est_cores_per_sweep, Some(2.0));
-    }
-
-    #[test]
-    fn test_config_out_of_range_cpu_utilization_target_drops_to_none() {
-        for bad in ["0", "-1", "1.5"] {
+    fn test_deprecated_cpu_knobs_accepted_at_any_value_including_nonsense() {
+        // Pre-#4512 these were range-filtered/type-checked because a value was
+        // consumed. Nothing consumes them now, so out-of-range, wrong-type, and
+        // even absurd values are all equally inert — and equally non-fatal.
+        for body in [
+            r#"{"autonomous": {"cpuUtilizationTarget": 0}}"#,
+            r#"{"autonomous": {"cpuUtilizationTarget": 1.5}}"#,
+            r#"{"autonomous": {"estCoresPerSweep": -2}}"#,
+            r#"{"autonomous": {"estCoresPerSweep": "many"}}"#,
+            r#"{"autonomous": {"estCoresPerSweep": true}}"#,
+        ] {
             let tmp = tempfile::tempdir().unwrap();
-            write_config(
-                tmp.path(),
-                &format!(r#"{{"autonomous": {{"cpuUtilizationTarget": {bad}}}}}"#),
-            );
-            assert_eq!(
-                read_work_finder_config(tmp.path()).cpu_utilization_target,
-                None,
-                "cpuUtilizationTarget={bad} must drop to None, not be clamped"
-            );
+            write_config(tmp.path(), body);
+            let cfg = read_work_finder_config(tmp.path());
+            assert_eq!(cfg.deprecated_cpu_keys.len(), 1, "must be accepted-but-noted: {body}");
+            // And it must not disturb any live knob.
+            assert_eq!(cfg.max_concurrent, None);
+            assert_eq!(cfg.enabled, None);
         }
     }
 
     #[test]
-    fn test_config_out_of_range_est_cores_per_sweep_drops_to_none() {
-        for bad in ["0", "-2"] {
-            let tmp = tempfile::tempdir().unwrap();
-            write_config(
-                tmp.path(),
-                &format!(r#"{{"autonomous": {{"estCoresPerSweep": {bad}}}}}"#),
-            );
-            assert_eq!(
-                read_work_finder_config(tmp.path()).est_cores_per_sweep,
-                None,
-                "estCoresPerSweep={bad} must drop to None, not be clamped"
-            );
-        }
-    }
-
-    #[test]
-    fn test_config_wrong_json_type_cpu_knobs_drop_to_none() {
-        // A string, bool, or null where a number is expected must not panic
-        // and must resolve to None (soft-fail to env/default resolution).
+    fn test_deprecated_cpu_knobs_absent_or_null_are_not_reported() {
         let tmp = tempfile::tempdir().unwrap();
-        write_config(
-            tmp.path(),
-            r#"{"autonomous": {"cpuUtilizationTarget": "0.8", "estCoresPerSweep": true}}"#,
-        );
-        let cfg = read_work_finder_config(tmp.path());
-        assert_eq!(cfg.cpu_utilization_target, None);
-        assert_eq!(cfg.est_cores_per_sweep, None);
+        write_config(tmp.path(), r#"{"autonomous": {"workFinder": {"maxConcurrent": 4}}}"#);
+        assert!(read_work_finder_config(tmp.path())
+            .deprecated_cpu_keys
+            .is_empty());
 
+        // An explicit `null` is "not set" — warning about it would be noise.
         let tmp2 = tempfile::tempdir().unwrap();
         write_config(tmp2.path(), r#"{"autonomous": {"estCoresPerSweep": null}}"#);
-        assert_eq!(read_work_finder_config(tmp2.path()).est_cores_per_sweep, None);
+        assert!(read_work_finder_config(tmp2.path())
+            .deprecated_cpu_keys
+            .is_empty());
+    }
+
+    #[test]
+    fn test_warn_deprecated_cpu_knobs_is_a_noop_without_any_retired_setting() {
+        // No config keys, no env vars — nothing to warn about, and (crucially)
+        // no panic and no config error. The one-shot `Once` inside means this
+        // test cannot assert the log line itself; the observable contract is
+        // that it is safe and side-effect-free on the clean path.
+        warn_deprecated_cpu_knobs(&WorkFinderConfig::default());
+    }
+
+    #[test]
+    #[serial]
+    fn test_deprecated_cpu_knob_notice_is_none_when_nothing_is_set() {
+        for var in DEPRECATED_CPU_ENV_VARS {
+            std::env::remove_var(var);
+        }
+        assert!(deprecated_cpu_knob_notice(&WorkFinderConfig::default()).is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn test_deprecated_cpu_knob_notice_names_the_config_keys_that_are_set() {
+        for var in DEPRECATED_CPU_ENV_VARS {
+            std::env::remove_var(var);
+        }
+        let cfg = WorkFinderConfig {
+            deprecated_cpu_keys: vec!["estCoresPerSweep"],
+            ..Default::default()
+        };
+        let notice = deprecated_cpu_knob_notice(&cfg).expect("a set key must produce a notice");
+        assert!(notice.contains("estCoresPerSweep"), "must name the key: {notice}");
+        assert!(notice.contains("IGNORED"), "must say it is ignored: {notice}");
+        // Actionable: it must point at the knob that replaced it.
+        assert!(
+            notice.contains("autonomous.workFinder.maxConcurrent"),
+            "must name the replacement knob: {notice}"
+        );
+        // A config-only notice must not fabricate an env source.
+        assert!(!notice.contains("env LOOM_"), "no env source was set: {notice}");
+    }
+
+    #[test]
+    #[serial]
+    fn test_deprecated_cpu_knob_notice_names_env_vars_and_combines_both_sources() {
+        std::env::set_var(DEPRECATED_CPU_ENV_VARS[0], "0.85");
+        let env_only = deprecated_cpu_knob_notice(&WorkFinderConfig::default())
+            .expect("a set env var must produce a notice");
+        assert!(env_only.contains(DEPRECATED_CPU_ENV_VARS[0]), "{env_only}");
+
+        let both = deprecated_cpu_knob_notice(&WorkFinderConfig {
+            deprecated_cpu_keys: vec!["estCoresPerSweep"],
+            ..Default::default()
+        })
+        .expect("notice");
+        assert!(both.contains("estCoresPerSweep"), "{both}");
+        assert!(both.contains(DEPRECATED_CPU_ENV_VARS[0]), "{both}");
+        assert!(both.contains(" and "), "both sources must be joined: {both}");
+
+        for var in DEPRECATED_CPU_ENV_VARS {
+            std::env::remove_var(var);
+        }
+    }
+
+    #[test]
+    fn test_deprecated_knob_name_tables_stay_in_sync() {
+        // The config keys and env vars are two halves of one deprecation; a
+        // future edit that adds one must add the other (the warning names both).
+        assert_eq!(DEPRECATED_CPU_CONFIG_KEYS.len(), DEPRECATED_CPU_ENV_VARS.len());
+        assert!(DEPRECATED_CPU_ENV_VARS
+            .iter()
+            .all(|v| v.starts_with("LOOM_")));
     }
 
     #[test]
@@ -4306,56 +4417,31 @@ exit 0
 
     #[test]
     #[serial]
-    fn test_resolve_cpu_utilization_target_precedence() {
-        use crate::cpu_headroom::{DEFAULT_UTILIZATION_TARGET, UTILIZATION_TARGET_ENV};
-        std::env::remove_var(UTILIZATION_TARGET_ENV);
-
-        // Default when neither env nor config set.
-        assert!(
-            (resolve_cpu_utilization_target(&WorkFinderConfig::default())
-                - DEFAULT_UTILIZATION_TARGET)
-                .abs()
-                < f64::EPSILON
-        );
-
-        // Config used when env unset.
+    fn test_retired_cpu_env_vars_are_ignored_not_honored() {
+        // #4512: `LOOM_CPU_UTILIZATION_TARGET` / `LOOM_EST_CORES_PER_SWEEP` no
+        // longer resolve to anything (the functions that read them are gone).
+        // The observable contract is that setting them changes NO cap input and
+        // is not an error — only the deprecation warning notices them.
+        for var in DEPRECATED_CPU_ENV_VARS {
+            std::env::set_var(var, "0.01");
+        }
         let cfg = WorkFinderConfig {
-            cpu_utilization_target: Some(0.6),
+            max_concurrent: Some(10),
+            per_token_concurrency: Some(2),
             ..Default::default()
         };
-        assert!((resolve_cpu_utilization_target(&cfg) - 0.6).abs() < f64::EPSILON);
-
-        // Env overrides config.
-        std::env::set_var(UTILIZATION_TARGET_ENV, "0.5");
-        assert!((resolve_cpu_utilization_target(&cfg) - 0.5).abs() < f64::EPSILON);
-        std::env::remove_var(UTILIZATION_TARGET_ENV);
-    }
-
-    #[test]
-    #[serial]
-    fn test_resolve_cpu_est_cores_per_sweep_precedence() {
-        use crate::cpu_headroom::{DEFAULT_EST_CORES_PER_SWEEP, EST_CORES_PER_SWEEP_ENV};
-        std::env::remove_var(EST_CORES_PER_SWEEP_ENV);
-
-        // Default when neither env nor config set.
-        assert!(
-            (resolve_cpu_est_cores_per_sweep(&WorkFinderConfig::default())
-                - DEFAULT_EST_CORES_PER_SWEEP)
-                .abs()
-                < f64::EPSILON
+        assert_eq!(resolve_max_concurrent_with_config(&cfg), 10);
+        assert_eq!(resolve_per_token_concurrency(&cfg), 2);
+        assert_eq!(
+            resolve_dynamic_max_concurrent(6, resolve_per_token_concurrency(&cfg), 36, 10),
+            10,
+            "a retired env knob must not clamp the cap"
         );
-
-        // Config used when env unset.
-        let cfg = WorkFinderConfig {
-            est_cores_per_sweep: Some(4.0),
-            ..Default::default()
-        };
-        assert!((resolve_cpu_est_cores_per_sweep(&cfg) - 4.0).abs() < f64::EPSILON);
-
-        // Env overrides config.
-        std::env::set_var(EST_CORES_PER_SWEEP_ENV, "1.0");
-        assert!((resolve_cpu_est_cores_per_sweep(&cfg) - 1.0).abs() < f64::EPSILON);
-        std::env::remove_var(EST_CORES_PER_SWEEP_ENV);
+        // Safe to call with only env-side deprecation present (no config keys).
+        warn_deprecated_cpu_knobs(&cfg);
+        for var in DEPRECATED_CPU_ENV_VARS {
+            std::env::remove_var(var);
+        }
     }
 
     // ===================================================================
@@ -4363,7 +4449,7 @@ exit 0
     // ===================================================================
 
     fn pressured_assessment() -> capacity::PressureAssessment {
-        // token_limit 1 < disk 10, cpu 10, ceiling 10; 12 deferred ⇒ token-bound
+        // token_limit 1 < disk 10, ceiling 10; 12 deferred ⇒ token-bound
         // + pressured.
         let snap = capacity::RankingSnapshot {
             total: 7,
@@ -4375,7 +4461,6 @@ exit 0
             Some(&snap),
             7,
             1,
-            10,
             10,
             10,
             12,
@@ -4394,7 +4479,6 @@ exit 0
             Some(&snap),
             7,
             7,
-            10,
             10,
             10,
             0,


### PR DESCRIPTION
## Summary

The dynamic concurrency cap carried a CPU term since #3978:

```
cpu_headroom = (logical_cpus × cpuUtilizationTarget − consumed_cores) / estCoresPerSweep
```

It priced **every** sweep as a build, but sweep wall-clock is dominated by API wait (curator / builder / judge conversations) — so it throttled the low-CPU majority to defend against the heavy-build minority. The issue's measured evidence: an 8-core worker sitting **95% idle** was capped at **2**, and `loom-daemon calibrate` recommended "no change" because the formula could not see past its own estimate.

Admission is now `min(token axis, disk headroom, configured maxConcurrent)` — two terms that meter genuinely *exhaustible* resources (accounts, bytes) plus one per-machine operator knob — and the protection for the genuinely heavy stages moves to **where the load actually is**: a machine-wide build slot.

## Changes

- **`work_finder.rs`** — `resolve_dynamic_max_concurrent` loses the CPU term (it is now a `min` of token axis × per-token factor, disk headroom, configured max). `resolve_cpu_utilization_target` / `resolve_cpu_est_cores_per_sweep` and their threading through `spawn_multi_work_finder_task` are gone. New `deprecated_cpu_knob_notice` / `warn_deprecated_cpu_knobs` + `DEPRECATED_CPU_CONFIG_KEYS` / `DEPRECATED_CPU_ENV_VARS`.
- **`build_slot.rs` (new)** + **`defaults/scripts/lib/build-slot.sh` (new)** — a machine-wide `mkdir`-atomic slot lease at `~/.loom/locks/build-slot/slot-<i>`, built on the existing `MkdirLock` primitive (the same shape as the per-issue claim lock). Two implementations, one protocol, so the daemon and each sweep worktree serialize against **each other**.
- **`main_health_gate.rs`** — the gate command takes a slot, acquired *outside* the timeout window so a queue wait cannot turn contention into a false `Unevaluated` (the #3978/#4020 failure mode), and exports `LOOM_BUILD_SLOT_HELD` to the child.
- **`build-gate.sh`** — sources the Bash half and takes a slot around the compile, with a `trap` release.
- **`calibrate/`** + **`main.rs`** — measurement-only. Nothing is derivable as a recommendation once the CPU term is gone, so `--write` is accepted-but-ignored. The report prints host observations, the resolved knobs, the `min(...)` breakdown, the binding term, and one line of tuning advice.
- **`config_resolver.rs`** — new `source_of` / `tier_paths_by_precedence`: which config tier actually set a key. Surfaced by calibrate as `set by: <path>`.
- **`cpu_headroom.rs`** — shrunk to a pure *measurement* module (host breaker #4235, the gate's load deferral #4259, status/calibrate reports). Nothing it produces feeds the cap.
- **`types.rs` / `ipc.rs` / `capacity.rs` / `main.rs` status renderer** — `cpu_headroom` is dropped from `DaemonStatusReport`; `logical_cpus` / `loadavg_1m` / `cpu_idle_fraction` stay as **observations** (that is exactly the evidence an operator tunes the knob from) and the human line says so.
- **Docs** — `defaults/docs/daemon-reference.md` (new "Why there is no CPU term in admission" + "Machine-wide build slot" sections, env table, calibrate section), `defaults/docs/build-gate.md`, `docs/measure-est-cores-per-sweep.md` (marked HISTORICAL). This repo's own `.loom/config.json` drops its now-inert `estCoresPerSweep`.

## Acceptance Criteria Verification

- [x] **`resolve_dynamic_max_concurrent` = `min(token axis, disk headroom, configured maxConcurrent)` — no CPU estimate term.** The function is now four lines with three terms; `cpu_headroom` is not imported by `work_finder` at all. Covered by the rewritten binding-axis test table, including a case asserting a retired env knob cannot clamp the cap.
- [x] **A machine-wide build-slot lease serializes designated high-CPU stages across concurrent sweeps (bounded wait + telemetry, never a deadlock; degrades open if the lock dir is unavailable).** `build_slot::acquire` waits at most `LOOM_BUILD_SLOT_WAIT_SECS` (300s) then returns `DegradedOpen`; an unusable lock store degrades open *immediately* (no spin); `LOOM_BUILD_SLOT_HELD` makes nested acquires re-entrant no-ops; every transition is logged (acquire with wait time, first wait of a round, release with hold duration, degrade-open with reason). Both directions of the cross-language contract are tested as **real subprocesses**, not just by path-shape parity.
- [x] **`estCoresPerSweep` / `cpuUtilizationTarget` config+env accepted-but-ignored with a deprecation warning (no config break), docs updated.** Any value at any type still parses (tested with out-of-range, string, and bool values) and never disturbs a sibling knob. The notice reaches the reader on **both** channels: the daemon logs it once per process, and `loom-daemon calibrate` prints it to stderr — CLI subcommands return from `main` before `setup_logging()`, so a log-only warning would have been invisible on exactly the path an operator uses to size a host.
- [x] **The #4231 scenario reasoned through under the new model.** #4231 was a 6-way fan-out that drove load to 118 on a 28-core host, because six concurrent release builds looked like `6 × estCoresPerSweep(2.0) = 12` cores of demand to a term whose real demand was closer to `6 × 28`. Under this change the same fan-out admits 6 sweeps (the knob decides that, not an estimate) but **only one compiles at a time** — the other five block in `build-gate.sh`'s slot acquire — so peak demand is one build's worth of parallel `cargo`, not six. The formula that mis-estimated the fan-out is gone; the thing it was estimating is now directly bounded. If the knob is nonetheless set too high, the #4235 host breaker trips on **measured** load-per-core: a measurement, not a constant, is the last line of defence. Written up in `daemon-reference.md` § "The #4231 release-build fan-out under this model".

Also addressed from the operator's follow-up comment ("give it ONE unambiguous home … nothing in `loom-daemon status` names which file supplied the number"): slots live machine-wide at `~/.loom/locks/build-slot`, deliberately *not* per-workspace, and calibrate now names the tier file that set `maxConcurrent` (and says so when an env var shadows it). See the *deferred* note below for the `status`-side half.

## Test Plan

- `cargo test --workspace` — **2,620 passed, 0 failed** (2,497 in the daemon lib).
- `cargo clippy --package loom-daemon --package loom-api --all-targets` with the CI allow-list — clean under `-D warnings`.
- `cargo fmt --all -- --check` — clean.
- `bash defaults/scripts/tests/test-build-slot.sh` — **13/13** (acquire/release, bounded wait, degrade-open on a broken store, `LOOM_BUILD_SLOTS=0` opt-out, multi-slot budget, stale reaping, re-entrancy, path-shape parity, and that `build-gate.sh` sources the helper).
- `bash defaults/scripts/tests/test-loom-daemon-start.sh` — **60/60** (the calibrate start-time hint was re-based off the removed recommendation fields).
- `bash defaults/scripts/tests/test-config-resolver.sh` — **14/14** (cross-language conformance fixture still matches).
- New Rust coverage: 17 `build_slot` tests (including two genuine **cross-process** Rust↔Bash serialization tests in both directions), 5 `config_resolver::source_of` tests, 5 calibrate provenance tests, 3 `deprecated_cpu_knob_notice` tests.
- Live smoke: `loom-daemon calibrate` on this host renders the new report, prints the deprecation notice to stderr (this host really does have `LOOM_EST_CORES_PER_SWEEP` exported), names `set by: …/.loom/config.json`, and keeps `--json` stdout clean.

### Pre-existing failures (not caused by this change)

Two integration tests are load-flaky on this 8-core host and fail **identically on `main`** at the same commit — `integration_singleton_guard::test_stale_socket_is_reclaimed` (connect retry budget) and `integration_basic::test_create_terminal_with_working_dir` (tmux session dies before capture). Both pass in the full-suite runs above; verified against `main` rather than assumed.

## Notes for the reviewer

- **Deliberately deferred**: `DaemonStatusReport` does not gain a `configured_max_source` wire field. Doing it properly means threading provenance through `ipc.rs` + the status renderer + wire-compat defaults, and `status` already has the harder ambiguity that on a multi-workspace daemon the *cap itself* is resolved from the seeded default workspace. Calibrate is the sizing tool and is purely file-based, so it is the right first home; a follow-up can extend it to `status`.
- **Config safety**: the deprecation path is intentionally asymmetric — retired keys are recorded but never *parsed* (no range filter, no type coercion), because nothing consumes the value and a fleet must be able to upgrade the binary before editing every repo's committed config.
- `LOOM_BUILD_SLOTS` defaults to **1** (the issue allows 1–2); `0` restores the exact pre-change unserialized behavior for an operator who wants it.

Closes #4512
