### PR TITLE
fix(daemon): refuse dispatch/recovery for an issue with a confirmed-live sweep claim (#4556)

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -4543,6 +4543,59 @@ releases it explicitly. On daemon startup, `SweepRegistry::reconstruct`
 admits live-lock owners back into the registry and drops stale locks
 whose owner PID is dead.
 
+### Live-claim guard (#4556)
+
+Lock *existence* is not the same question as "is a sweep for this issue
+running right now?", and every re-dispatch path answers the first while
+needing the second. Issue #4275 was dispatched **seven times in 77
+minutes** onto one shared worktree because each path first convinced
+itself the sweep was dead — the claim reconciler on a dead-looking
+recorded PID, the mid-build watchdog on a terminal registry entry, the
+review-stall watchdog on a silent log — and *released the lock or
+reverted the label before dispatching*, so the existence check had
+nothing left to collide with. Three further dispatches came from a
+second `loom-daemon` on the same host, which shared neither the first
+daemon's memory nor its `.loom/locks/`.
+
+`live_claim::probe` answers the stronger question, read-only, with three
+short-circuiting evidence legs — a live `.loom/locks/issue-<N>/owner.json`
+owner, a live record in the machine-level `~/.loom/sweeps.json` journal
+(matched across related repo roots, so a daemon running out of a nested
+worktree and one running out of the parent checkout see each other), and
+a `/proc` scan for a live `/loom:sweep <N>` process whose cwd is inside
+the workspace. It gates four places:
+
+| Site | Refusal |
+|---|---|
+| `SweepRegistry::dispatch` (step 2.9) | `LiveClaimDispatchError`, before any lock, label write, or forge call — covers all six dispatch routes, including both watchdogs |
+| `midbuild_watchdog_once` | refuses **up front**, because that path `git reset --hard`s the shared worktree and burns its single retry *before* it calls `dispatch` |
+| `release_lock_owned` | `LockReleaseOutcome::HolderAlive` — the caller's dead-sweep verdict was wrong, so the lock stays and the label restore / re-dispatch are skipped |
+| `claim_reconciliation` | vetoes a `Reclaim`, so `loom:building` is not reverted out from under a working sweep |
+
+In `midbuild_watchdog_once` the probe **must** stay ahead of
+`claim_lock_for_midbuild` (#4564/#4602). That call takes the issue lock
+over *in place*, rewriting `owner.json` to the daemon's own PID and a
+`midbuild-watchdog-…` sweep id, and it does so precisely in the
+false-dead case this guard exists to catch. Probing afterwards would
+read the watchdog's own record instead of the live sweep's (silencing
+leg 1), and the refusal path returns without releasing, so the live
+sweep's claim record would stay clobbered and its own `release_lock_owned`
+would then read `Superseded` and skip its label restore.
+`midbuild_live_claim_probe_runs_before_the_lock_takeover` pins the order
+by byte-comparing `owner.json` across a refused tick.
+
+Fail-open throughout: a missing/corrupt `owner.json`, an unreadable
+journal, a zombie PID, or a recorded PID whose argv does not name this
+issue's sweep (a recycled PID) all resolve to "no evidence", so a stale
+file can never wedge an issue. Every refusal logs at `WARN`; the
+work-finder counts a refusal as an in-flight skip, not an error.
+
+Integration tests spawn the daemon with its machine-level state confined
+to a fixture (`isolate_daemon_state`: `LOOM_WORKSPACES_PATH`,
+`LOOM_SWEEPS_JOURNAL_PATH`, `LOOM_WATCHES_PATH`, `LOOM_WATCH_RESULTS_LOG`,
+plus the cwd), so a test daemon has no managed workspace to reconcile or
+dispatch against.
+
 ## What this page does NOT describe
 
 The legacy schema and tuning advice that historically lived here — the

--- a/loom-daemon/src/claim_reconciliation.rs
+++ b/loom-daemon/src/claim_reconciliation.rs
@@ -498,6 +498,37 @@ pub fn decide(
     }
 }
 
+/// Live-claim veto (Issue #4556) — downgrade a computed `Reclaim` to `Keep`
+/// when the issue still has a **confirmed-live** sweep claim behind it.
+///
+/// [`decide`]'s liveness evidence is a single recorded PID (the journal entry,
+/// or the checkpoint→run-registry join). That PID is the sweep *leader* the
+/// daemon spawned, so a leader that has exited — or a journal entry that was
+/// never written, or was pruned — makes a still-working sweep look dead. On
+/// #4275 that misfire is on the record: at `03:08:15.992Z` this pass reclaimed
+/// `loom:building -> loom:issue` on `DeadPid { pid: 2781227 }` while sweep
+/// processes for the issue were still alive, re-exposing it to the work-finder
+/// and seeding a re-dispatch 37 seconds later.
+///
+/// The veto consults evidence a dead-leader PID cannot invalidate — a live
+/// claim-lock owner, a live machine-level journal record from this repo *or a
+/// nested worktree daemon*, or a live `/loom:sweep <N>` process rooted in the
+/// workspace ([`crate::live_claim::probe`]).
+///
+/// Applies to **every** [`ReclaimReason`], not just the dead-PID ones: a live
+/// sweep means the claim is legitimate no matter which rule proposed dropping
+/// it. Pure and total — the caller supplies the (impure) probe result.
+#[must_use]
+pub fn apply_live_claim_veto(
+    action: ReconcileAction,
+    live_claim: Option<&crate::live_claim::LiveClaimEvidence>,
+) -> ReconcileAction {
+    match (action, live_claim) {
+        (ReconcileAction::Reclaim(_), Some(_)) => ReconcileAction::Keep,
+        (action, _) => action,
+    }
+}
+
 /// Plan reconciliation decisions for every `issue` in `issues`, given an
 /// already-loaded `journal`. Performs no I/O of its own — `run_registry_pid_for`
 /// is the caller's injected checkpoint→run-registry lookup (production passes
@@ -1014,9 +1045,10 @@ pub fn spawn_periodic_reconciliation_task(
 /// best-effort `Command` wrapper.
 pub mod forge {
     use super::{
-        plan, plan_pr, resolve_no_progress_grace_minutes, resolve_stale_hours, BuildingIssue,
-        ClaimedPr, NoProgressEvidence, PrClaimKind, PrReclaimReason, PrReconcileAction,
-        ReclaimReason, ReconcileAction, MAX_ISSUES_PER_WORKSPACE,
+        apply_live_claim_veto, plan, plan_pr, resolve_no_progress_grace_minutes,
+        resolve_stale_hours, BuildingIssue, ClaimedPr, NoProgressEvidence, PrClaimKind,
+        PrReclaimReason, PrReconcileAction, ReclaimReason, ReconcileAction,
+        MAX_ISSUES_PER_WORKSPACE,
     };
     use crate::sweep_journal;
     use anyhow::{anyhow, Context, Result};
@@ -1213,6 +1245,30 @@ pub mod forge {
             let ReconcileAction::Reclaim(reason) = action else {
                 continue;
             };
+            // #4556 live-claim veto: a dead *recorded* pid is not proof the sweep
+            // is gone. Probe for a confirmed-live claim (live lock owner / live
+            // machine-level journal record / live `/loom:sweep <N>` process) and
+            // leave the label alone if one exists — reverting `loom:building` out
+            // from under a working sweep is what re-exposed #4275 to the
+            // work-finder and started its seven-dispatch storm. Probed only on a
+            // Reclaim decision, so a healthy pass pays nothing.
+            //
+            // Judge note (#4605): pass this pass's already-resolved
+            // `journal_path` rather than `None`. `None` would make the probe's
+            // leg 2 re-resolve the process-global default, which silently
+            // diverges from — and could disagree with — the very journal
+            // `plan()` decided against whenever a workspace overrides the path.
+            let live_claim =
+                crate::live_claim::probe(root, Some(journal_path.as_path()), issue_number);
+            if matches!(apply_live_claim_veto(action, live_claim.as_ref()), ReconcileAction::Keep) {
+                log::warn!(
+                    "claim_reconciliation: NOT reclaiming #{issue_number} in {} despite \
+                     {reason:?} — the issue still has {} (#4556 live-claim veto)",
+                    root.display(),
+                    live_claim.map_or_else(|| "a live claim".to_string(), |e| e.to_string()),
+                );
+                continue;
+            }
             match reclaim(gh_bin, root, issue_number) {
                 Ok(()) => {
                     reclaimed += 1;
@@ -1595,6 +1651,57 @@ mod tests {
         let entry = journal_entry("/repo/a", 42, 111);
         let action = decide(&issue(42, None), Some(&entry), None, None, 10.0, &|_| false, 4.0, now);
         assert_eq!(action, ReconcileAction::Reclaim(ReclaimReason::DeadPid { pid: 111 }));
+    }
+
+    // --- #4556 live-claim veto ---
+
+    fn live_lock_evidence() -> crate::live_claim::LiveClaimEvidence {
+        crate::live_claim::LiveClaimEvidence::ClaimLock {
+            pid: 111,
+            sweep_id: "sweep-issue-4275-live".to_string(),
+        }
+    }
+
+    #[test]
+    fn live_claim_veto_downgrades_a_dead_pid_reclaim_to_keep() {
+        // The confirmed #4275 misfire: `DeadPid { pid: 2781227 }` reverted
+        // loom:building -> loom:issue at 03:08:15Z while the sweep was alive.
+        let action = ReconcileAction::Reclaim(ReclaimReason::DeadPid { pid: 2_781_227 });
+        assert_eq!(
+            apply_live_claim_veto(action, Some(&live_lock_evidence())),
+            ReconcileAction::Keep
+        );
+    }
+
+    #[test]
+    fn live_claim_veto_applies_to_every_reclaim_reason() {
+        // A live sweep means the claim is legitimate regardless of which rule
+        // proposed dropping it.
+        for reason in [
+            ReclaimReason::DeadPid { pid: 1 },
+            ReclaimReason::DeadRunRegistry { pid: 1 },
+            ReclaimReason::NoRecordStale { age_hours: 99.0 },
+        ] {
+            assert_eq!(
+                apply_live_claim_veto(
+                    ReconcileAction::Reclaim(reason),
+                    Some(&live_lock_evidence())
+                ),
+                ReconcileAction::Keep,
+                "{reason:?} must be vetoed by a live claim"
+            );
+        }
+    }
+
+    #[test]
+    fn live_claim_veto_is_a_no_op_without_live_evidence() {
+        let action = ReconcileAction::Reclaim(ReclaimReason::DeadPid { pid: 1 });
+        assert_eq!(apply_live_claim_veto(action, None), action, "no evidence => unchanged");
+        assert_eq!(
+            apply_live_claim_veto(ReconcileAction::Keep, Some(&live_lock_evidence())),
+            ReconcileAction::Keep,
+            "Keep is never escalated"
+        );
     }
 
     #[test]

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -167,6 +167,7 @@ pub mod idle_exit;
 pub mod init;
 pub mod ipc;
 pub mod issue_creation_mutex;
+pub mod live_claim;
 pub mod main_health_gate;
 pub mod metrics_collector;
 pub mod peer_claims;

--- a/loom-daemon/src/live_claim.rs
+++ b/loom-daemon/src/live_claim.rs
@@ -1,0 +1,756 @@
+//! Confirmed-live sweep-claim probe (Issue #4556).
+//!
+//! ## Problem
+//!
+//! Every pre-#4556 dedup signal for "is issue #N already being worked?" is
+//! either *scoped to one daemon process* or *only proves a file exists*:
+//!
+//! | Signal | Weakness |
+//! |---|---|
+//! | [`crate::types::SweepInfo`] entries (`in_flight()`) | in-memory; wiped by a daemon restart, invisible to a second daemon instance |
+//! | `loom:building` label | reverted by [`crate::claim_reconciliation`] the moment a recorded PID *looks* dead |
+//! | `.loom/locks/issue-<N>/` ([`crate::sweep_registry::SweepRegistry`]'s `acquire_lock`) | existence-only; every reaper / cancel / watchdog path *releases* it on a dead-PID verdict, and the release is what re-opens the door |
+//!
+//! Issue #4275 was dispatched **seven times in 77 minutes** on one host
+//! because those weaknesses compose: the reconciler saw a dead recorded PID and
+//! reverted `loom:building` -> `loom:issue`; the mid-build and review-stall
+//! watchdogs each released the lock and re-dispatched; and three further
+//! dispatches came from a *second* `loom-daemon` instance on the same host
+//! (a debug build run out of a worktree) that shared neither the first
+//! daemon's memory nor its `.loom/locks/`. At the peak four sweep processes for
+//! one issue were alive at once, all writing into one worktree.
+//!
+//! ## What this module adds
+//!
+//! A single **read-only** probe answering the strictly stronger question: *is
+//! there a sweep process for issue #N that is confirmed running right now?*
+//! It never mutates the filesystem, so it can gate destructive work (a lock
+//! release, a label revert, a re-dispatch) without freeing anything itself.
+//!
+//! Three independent evidence legs, cheapest-first, short-circuiting on the
+//! first hit:
+//!
+//! 1. **Live claim lock** — `.loom/locks/issue-<N>/owner.json` whose
+//!    `owner_pid` is a live, non-zombie process. Unlike `acquire_lock`'s
+//!    `AlreadyExists` check this distinguishes a *live* holder from an
+//!    abandoned lock dir, so it is safe to consult *before* a release.
+//! 2. **Machine-level sweep journal** — `~/.loom/sweeps.json`
+//!    ([`crate::sweep_journal`]) entry whose `pid` is live. This file is
+//!    machine-level, so it survives a daemon restart **and** is shared by every
+//!    `loom-daemon` instance on the host. Repo matching is deliberately
+//!    *related-path* rather than exact (see [`repos_are_related`]) so a daemon
+//!    running out of `.loom/worktrees/issue-N` and one running out of the
+//!    parent checkout see each other's claims — they are the same repo, so
+//!    issue #N means the same GitHub issue to both.
+//! 3. **Live sweep process scan** — a process whose cwd is inside the
+//!    workspace root and whose argv contains `/loom:sweep <N>`
+//!    ([`cmdline_targets_sweep_issue`]). This is the last-resort leg that
+//!    catches a sweep no local bookkeeping knows about at all: the exact
+//!    signature of the three unattributed #4275 dispatches, where `ps` showed
+//!    `claude -p /loom:sweep 4275 --claim-owned 4275` processes with no
+//!    corresponding entry in the production daemon's log.
+//!
+//! ## Fail-open by design
+//!
+//! Every leg resolves to "no evidence" on any ambiguity — missing/corrupt
+//! `owner.json`, unreadable journal, no `/proc`, an unreadable `cwd` symlink.
+//! A garbage file must never wedge an issue permanently; the guards built on
+//! this probe only ever refuse on **positively-confirmed** liveness. That is
+//! the same fail-open contract [`crate::sweep_registry`]'s `lock_owned_by_other`
+//! (#4463) already follows.
+//!
+//! Zombies are explicitly **not** live ([`pid_is_live_process`]): a terminated
+//! -but-unreaped child keeps its PID allocated, so a bare `kill(pid, 0)` probe
+//! reports it alive forever — precisely the false-positive that would turn this
+//! guard into a permanent wedge.
+
+use std::path::Path;
+// Only leg 3's `/proc` scan owns a `PathBuf` (the canonicalized workspace root);
+// gating the import keeps a non-Linux build warning-free under `-D warnings`.
+#[cfg(target_os = "linux")]
+use std::path::PathBuf;
+
+use crate::sweep_journal::{self, SweepJournal};
+
+/// Which signal proved a live claim. Carried into the refusal log line / typed
+/// error so an operator can tell a live-lock refusal from a cross-instance
+/// process-scan refusal without re-deriving the evidence by hand.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LiveClaimEvidence {
+    /// `.loom/locks/issue-<N>/owner.json` records a live owner PID.
+    ClaimLock { pid: u32, sweep_id: String },
+    /// The machine-level sweep journal records a live PID for this issue.
+    Journal { pid: u32, repo: String },
+    /// A live process rooted in this workspace is running `/loom:sweep <N>`.
+    SweepProcess { pid: u32 },
+}
+
+impl LiveClaimEvidence {
+    /// The confirmed-live PID behind this evidence.
+    #[must_use]
+    pub fn pid(&self) -> u32 {
+        match self {
+            Self::ClaimLock { pid, .. }
+            | Self::Journal { pid, .. }
+            | Self::SweepProcess { pid } => *pid,
+        }
+    }
+}
+
+impl std::fmt::Display for LiveClaimEvidence {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClaimLock { pid, sweep_id } => {
+                write!(f, "a live claim lock owned by sweep {sweep_id} (pid {pid})")
+            }
+            Self::Journal { pid, repo } => {
+                write!(f, "a live sweep-journal record for {repo} (pid {pid})")
+            }
+            Self::SweepProcess { pid } => {
+                write!(f, "a live `/loom:sweep` process (pid {pid})")
+            }
+        }
+    }
+}
+
+/// Minimal read-side view of a claim lock's `owner.json`.
+///
+/// Deliberately its own type rather than a re-export of `sweep_registry`'s
+/// private `LockOwner`: this module only needs two fields, and keeping the
+/// read-side shape local means a future writer-side field addition cannot
+/// break the probe (unknown fields are ignored by serde).
+#[derive(Debug, serde::Deserialize)]
+struct LockOwnerView {
+    owner_pid: u32,
+    #[serde(default)]
+    sweep_id: String,
+}
+
+/// Whether `pid` is a **live, non-zombie** process.
+///
+/// `kill(pid, 0)` alone is insufficient: a terminated-but-unreaped child is a
+/// zombie whose PID is still allocated, so the bare probe reports it alive
+/// indefinitely (the same trap documented on `SweepRegistry::children`). A
+/// zombie holds no locks and writes no files, so treating it as a live claim
+/// would wedge an issue forever — exactly the failure mode this guard must not
+/// introduce.
+#[must_use]
+pub fn pid_is_live_process(pid: u32) -> bool {
+    crate::sweep_registry::is_pid_alive(pid) && !pid_is_zombie(pid)
+}
+
+/// Linux: read `/proc/<pid>/stat` and report whether the process state is `Z`.
+/// Any read/parse failure resolves to `false` (not-a-zombie) so an unreadable
+/// `stat` never *adds* liveness evidence it cannot prove.
+#[cfg(target_os = "linux")]
+fn pid_is_zombie(pid: u32) -> bool {
+    let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+        return false;
+    };
+    // Format: `pid (comm) state ...`. `comm` may contain spaces AND parens, so
+    // the only safe split point is the LAST ')'.
+    let Some(after_comm) = stat.rfind(')').map(|i| &stat[i + 1..]) else {
+        return false;
+    };
+    after_comm.split_whitespace().next() == Some("Z")
+}
+
+#[cfg(not(target_os = "linux"))]
+fn pid_is_zombie(_pid: u32) -> bool {
+    false
+}
+
+/// Whether `pid` is a live process whose argv targets `/loom:sweep <issue>`.
+///
+/// The **positive-confirmation** primitive behind
+/// [`crate::sweep_registry::LockReleaseOutcome::HolderAlive`]: refusing a lock
+/// release on bare PID liveness would also refuse when an unrelated process has
+/// recycled the PID, wedging the issue permanently. Requiring the argv to name
+/// this exact issue's sweep makes a false refusal essentially impossible.
+///
+/// Linux reads `/proc/<pid>/cmdline`. On other platforms there is no cheap
+/// portable equivalent, so this returns `false` — "cannot confirm" — and every
+/// caller falls open to its pre-#4556 behavior rather than refusing on a guess.
+#[must_use]
+pub fn pid_is_sweep_process_for(pid: u32, issue: u32) -> bool {
+    if !pid_is_live_process(pid) {
+        return false;
+    }
+    read_pid_cmdline(pid).is_some_and(|c| cmdline_targets_sweep_issue(&c, issue))
+}
+
+#[cfg(target_os = "linux")]
+fn read_pid_cmdline(pid: u32) -> Option<String> {
+    let raw = std::fs::read(format!("/proc/{pid}/cmdline")).ok()?;
+    Some(String::from_utf8_lossy(&raw).replace('\0', " "))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_pid_cmdline(_pid: u32) -> Option<String> {
+    None
+}
+
+/// The liveness predicate the *evidence legs* use: `pid` is live **and**, when
+/// this platform can read its argv, that argv targets `/loom:sweep <issue>`.
+///
+/// Both bookkeeping legs record the PID of the process the daemon spawned —
+/// `spawn-worker.sh -p "/loom:sweep <N> --claim-owned <N>" …`, which `exec`s
+/// through to `claude` **without changing PID**, so the needle is present for
+/// the whole life of a real sweep (see `SweepRegistry::spawn_child`). Requiring
+/// it therefore costs nothing for a genuine claim while removing the only way
+/// this guard could wedge an issue permanently: a *stale* lock or journal
+/// record whose PID has since been recycled by an unrelated live process. Both
+/// records are removed on reap/cancel and pruned on the next journal write, but
+/// a daemon that dies between a sweep's exit and its reap leaves exactly that
+/// stale record behind, and an unverified PID probe would then refuse every
+/// future dispatch of the issue forever.
+///
+/// Unverifiable argv (non-Linux, or a `/proc` hardened against reading another
+/// process's `cmdline`) falls back to bare liveness — the same signal every
+/// pre-#4556 liveness check already used, so the guard is never *weaker* than
+/// the code it supplements on those hosts.
+#[must_use]
+pub fn pid_is_live_claim_for(pid: u32, issue: u32) -> bool {
+    if !pid_is_live_process(pid) {
+        return false;
+    }
+    match read_pid_cmdline(pid) {
+        Some(cmdline) => cmdline_targets_sweep_issue(&cmdline, issue),
+        // Cannot read the argv on this platform: fall back to bare liveness.
+        None => true,
+    }
+}
+
+/// Leg 1: the per-issue claim lock's owner, when its PID is confirmed live.
+///
+/// `is_live` is injected so tests can drive both verdicts without spawning
+/// processes. Fail-open: a missing lock dir, unreadable or unparseable
+/// `owner.json`, or a dead/zombie owner all resolve to `None`.
+#[must_use]
+pub fn live_lock_owner_in(
+    locks_dir: &Path,
+    issue: u32,
+    is_live: &dyn Fn(u32) -> bool,
+) -> Option<LiveClaimEvidence> {
+    let owner_path = locks_dir.join(format!("issue-{issue}")).join("owner.json");
+    let raw = std::fs::read_to_string(&owner_path).ok()?;
+    let owner: LockOwnerView = serde_json::from_str(&raw).ok()?;
+    if !is_live(owner.owner_pid) {
+        return None;
+    }
+    Some(LiveClaimEvidence::ClaimLock {
+        pid: owner.owner_pid,
+        sweep_id: owner.sweep_id,
+    })
+}
+
+/// Whether two workspace-root strings name the **same repository** for the
+/// purpose of issue-number identity.
+///
+/// Exact equality is not sufficient. The three unattributed #4275 dispatches
+/// came from a `loom-daemon` whose `workspace_root` was
+/// `<repo>/.loom/worktrees/issue-4385` — a git worktree of the very same
+/// checkout. Two roots in an ancestor/descendant relationship therefore refer
+/// to one GitHub repo, and "issue #N" means the same issue to both, so each
+/// must be able to see the other's journal claim.
+///
+/// Path-component-wise (never a raw string prefix), so `/repo/loom` and
+/// `/repo/loom-2` are correctly *unrelated*.
+#[must_use]
+pub fn repos_are_related(a: &str, b: &str) -> bool {
+    if a == b {
+        return true;
+    }
+    let (pa, pb) = (Path::new(a), Path::new(b));
+    pa.starts_with(pb) || pb.starts_with(pa)
+}
+
+/// Leg 2: a machine-level sweep-journal record for this issue whose PID is
+/// confirmed live, from this workspace root or any related one
+/// ([`repos_are_related`]).
+#[must_use]
+pub fn live_journal_claim(
+    journal: &SweepJournal,
+    workspace_root: &Path,
+    issue: u32,
+    is_live: &dyn Fn(u32) -> bool,
+) -> Option<LiveClaimEvidence> {
+    let root = workspace_root.display().to_string();
+    journal
+        .entries
+        .iter()
+        .find(|e| e.issue == issue && repos_are_related(&e.repo, &root) && is_live(e.pid))
+        .map(|e| LiveClaimEvidence::Journal {
+            pid: e.pid,
+            repo: e.repo.clone(),
+        })
+}
+
+/// Whether a process command line is running `/loom:sweep <issue>`.
+///
+/// `cmdline` is the process argv joined by single spaces (the daemon spawns
+/// `claude -p "/loom:sweep <N> --claim-owned <N>"`, so the issue number lives
+/// *inside* one argv element — see `SweepRegistry::spawn_child`).
+///
+/// Deliberately strict, to keep the process-scan leg from ever refusing a
+/// legitimate dispatch:
+///
+/// - The token immediately after `/loom:sweep` must parse as exactly `issue`,
+///   so `/loom:sweep 42751` never matches issue 4275.
+/// - `/loom:sweep` must be followed by whitespace, so `/loom:sweeper` and a
+///   bare `/loom:sweep` with no argument never match.
+/// - PR-set mode (`/loom:sweep --prs 4275`) does **not** match: it claims no
+///   issue, so it is not a competing issue sweep.
+#[must_use]
+pub fn cmdline_targets_sweep_issue(cmdline: &str, issue: u32) -> bool {
+    const NEEDLE: &str = "/loom:sweep";
+    let mut rest = cmdline;
+    while let Some(idx) = rest.find(NEEDLE) {
+        let after = &rest[idx + NEEDLE.len()..];
+        if after.starts_with(char::is_whitespace)
+            && after
+                .split_whitespace()
+                .next()
+                .and_then(|t| t.parse::<u32>().ok())
+                == Some(issue)
+        {
+            return true;
+        }
+        rest = after;
+    }
+    false
+}
+
+/// Whether `path` is `root` itself or lives beneath it (component-wise).
+///
+/// Only leg 3's `/proc` scan needs this, so it is gated to match its single
+/// caller — otherwise a non-Linux build trips `dead_code` under `-D warnings`.
+#[cfg(target_os = "linux")]
+fn path_within(path: &Path, root: &Path) -> bool {
+    path.starts_with(root)
+}
+
+/// Leg 3 (Linux): scan `/proc` for a live process whose cwd is inside
+/// `workspace_root` and whose argv targets `/loom:sweep <issue>`.
+///
+/// Ordered cheap-first: the `cwd` readlink is one syscall and prunes to the
+/// handful of processes rooted in this workspace before any `cmdline` read
+/// happens. Scoping on cwd is what makes this leg **repo-scoped** (the daemon
+/// spawns every sweep child with `current_dir(workspace_root)`), so a sweep for
+/// another checkout's issue #N can never refuse a dispatch here.
+///
+/// Zombies are skipped for free: a zombie's `cwd` symlink is no longer
+/// readable, so it never reaches the `cmdline` check.
+#[cfg(target_os = "linux")]
+#[must_use]
+pub fn live_sweep_process_in(workspace_root: &Path, issue: u32) -> Option<LiveClaimEvidence> {
+    let root: PathBuf = workspace_root
+        .canonicalize()
+        .unwrap_or_else(|_| workspace_root.to_path_buf());
+    let self_pid = std::process::id();
+    let entries = std::fs::read_dir("/proc").ok()?;
+    for entry in entries.flatten() {
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|s| s.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        if pid == self_pid {
+            continue;
+        }
+        let Ok(cwd) = std::fs::read_link(entry.path().join("cwd")) else {
+            continue;
+        };
+        if !path_within(&cwd, &root) {
+            continue;
+        }
+        let Ok(raw) = std::fs::read(entry.path().join("cmdline")) else {
+            continue;
+        };
+        let cmdline = String::from_utf8_lossy(&raw).replace('\0', " ");
+        if cmdline_targets_sweep_issue(&cmdline, issue) {
+            return Some(LiveClaimEvidence::SweepProcess { pid });
+        }
+    }
+    None
+}
+
+/// Leg 3 on non-Linux hosts: not implemented.
+///
+/// The `/proc` scan has no portable equivalent that is both cheap and
+/// cwd-scoped (`lsof +d` is neither). Legs 1 and 2 — the live claim lock and
+/// the machine-level journal — are fully cross-platform, so the guard still
+/// holds for every sweep either daemon bookkeeping knows about; only the
+/// "completely untracked ghost sweep" case degrades to no-evidence here.
+#[cfg(not(target_os = "linux"))]
+#[must_use]
+pub fn live_sweep_process_in(_workspace_root: &Path, _issue: u32) -> Option<LiveClaimEvidence> {
+    None
+}
+
+/// The full production probe: is there a **confirmed-live** sweep claim on
+/// `issue` for the repository rooted at `workspace_root`?
+///
+/// `journal_path` overrides the machine-level journal location (tests and
+/// `SweepRegistryConfig::journal_path` both use this); `None` resolves
+/// [`sweep_journal::default_journal_path`].
+///
+/// Read-only and short-circuiting: leg 1 (a `read_to_string`) and leg 2 (one
+/// small JSON file) run before the `/proc` scan, so the common
+/// nothing-is-claimed case costs two file reads plus a bounded directory walk.
+#[must_use]
+pub fn probe(
+    workspace_root: &Path,
+    journal_path: Option<&Path>,
+    issue: u32,
+) -> Option<LiveClaimEvidence> {
+    // Both bookkeeping legs verify the recorded PID's argv where the platform
+    // allows it ([`pid_is_live_claim_for`]), so a *stale* record whose PID has
+    // been recycled by an unrelated process can never wedge the issue.
+    let is_live: &dyn Fn(u32) -> bool = &|pid| pid_is_live_claim_for(pid, issue);
+
+    let locks_dir = workspace_root.join(".loom").join("locks");
+    if let Some(evidence) = live_lock_owner_in(&locks_dir, issue, is_live) {
+        return Some(evidence);
+    }
+
+    let journal_path = journal_path
+        .map(Path::to_path_buf)
+        .or_else(|| sweep_journal::default_journal_path().ok());
+    if let Some(path) = journal_path {
+        let journal = sweep_journal::load(&path);
+        if let Some(evidence) = live_journal_claim(&journal, workspace_root, issue, is_live) {
+            return Some(evidence);
+        }
+    }
+
+    live_sweep_process_in(workspace_root, issue)
+}
+
+/// Block until a freshly-spawned stand-in sweep child's argv actually names the
+/// sweep (test support, shared with [`crate::sweep_registry`]'s tests).
+///
+/// `Command::spawn` returns as soon as the **fork** succeeds; until the child
+/// reaches `exec`, `/proc/<pid>/cmdline` still shows the *parent's* argv (the
+/// test binary). Without this wait an argv-verifying probe can read the
+/// pre-exec argv and correctly decline, which under a loaded full-suite run
+/// turns every such assertion into a flake — observed as three intermittent
+/// failures that each passed when run alone. Bounded, and a timeout simply
+/// proceeds so the assertion under test reports the real failure rather than
+/// hanging.
+#[cfg(test)]
+pub(crate) fn wait_until_argv_visible(pid: u32, issue: u32) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        match read_pid_cmdline(pid) {
+            // Not readable at all (non-Linux): nothing to wait for — the bare
+            // liveness fallback in `pid_is_live_claim_for` applies there.
+            None => return,
+            Some(c) if cmdline_targets_sweep_issue(&c, issue) => return,
+            Some(_) => std::thread::sleep(std::time::Duration::from_millis(10)),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::sweep_journal::JournalEntry;
+    use chrono::Utc;
+    use tempfile::tempdir;
+
+    fn write_lock(locks_dir: &Path, issue: u32, pid: u32, sweep_id: &str) {
+        let dir = locks_dir.join(format!("issue-{issue}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("owner.json"),
+            format!(
+                r#"{{"issue": {issue}, "owner_pid": {pid}, "acquired_at": "2026-07-30T00:00:00Z", "sweep_id": "{sweep_id}"}}"#
+            ),
+        )
+        .unwrap();
+    }
+
+    /// A stand-in for a real sweep child: a long-lived process whose argv
+    /// contains `/loom:sweep <issue>`, killed on drop.
+    ///
+    /// `sh -c <script> <argv0>` puts the third argument in `$0`, so the needle
+    /// lands in the process's argv without being interpreted — the same shape
+    /// `SweepRegistry::spawn_child` produces (`spawn-worker.sh -p "/loom:sweep
+    /// <N> --claim-owned <N>"`, which `exec`s through to `claude` keeping both
+    /// the PID and the needle).
+    struct FakeSweep(std::process::Child);
+
+    impl FakeSweep {
+        fn spawn(issue: u32) -> Self {
+            let child = std::process::Command::new("sh")
+                .arg("-c")
+                .arg("sleep 120")
+                .arg(format!("/loom:sweep {issue} --claim-owned {issue}"))
+                .spawn()
+                .unwrap();
+            wait_until_argv_visible(child.id(), issue);
+            Self(child)
+        }
+
+        fn pid(&self) -> u32 {
+            self.0.id()
+        }
+    }
+
+    impl Drop for FakeSweep {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+
+    fn journal_with(repo: &str, issue: u32, pid: u32) -> SweepJournal {
+        SweepJournal {
+            version: 1,
+            entries: vec![JournalEntry {
+                repo: repo.to_string(),
+                issue,
+                pid,
+                started_at: Utc::now(),
+            }],
+        }
+    }
+
+    // ---- leg 1: live claim lock ------------------------------------------
+
+    #[test]
+    fn live_lock_owner_reports_a_live_pid() {
+        let dir = tempdir().unwrap();
+        write_lock(dir.path(), 4275, 4242, "sweep-issue-4275-1");
+        let evidence = live_lock_owner_in(dir.path(), 4275, &|_| true).unwrap();
+        assert_eq!(
+            evidence,
+            LiveClaimEvidence::ClaimLock {
+                pid: 4242,
+                sweep_id: "sweep-issue-4275-1".to_string()
+            }
+        );
+        assert_eq!(evidence.pid(), 4242);
+    }
+
+    #[test]
+    fn live_lock_owner_ignores_a_dead_pid() {
+        // The whole point of #4556: a lock file that EXISTS is not a live
+        // claim. `acquire_lock` refuses on existence; this probe must not.
+        let dir = tempdir().unwrap();
+        write_lock(dir.path(), 4275, 4242, "sweep-issue-4275-1");
+        assert!(live_lock_owner_in(dir.path(), 4275, &|_| false).is_none());
+    }
+
+    #[test]
+    fn live_lock_owner_fails_open_on_missing_and_corrupt_owner() {
+        let dir = tempdir().unwrap();
+        // Missing entirely.
+        assert!(live_lock_owner_in(dir.path(), 4275, &|_| true).is_none());
+        // Present but unparseable.
+        let lock = dir.path().join("issue-4275");
+        std::fs::create_dir_all(&lock).unwrap();
+        std::fs::write(lock.join("owner.json"), "not json").unwrap();
+        assert!(live_lock_owner_in(dir.path(), 4275, &|_| true).is_none());
+    }
+
+    #[test]
+    fn live_lock_owner_is_scoped_to_the_requested_issue() {
+        let dir = tempdir().unwrap();
+        write_lock(dir.path(), 4275, 4242, "sweep-issue-4275-1");
+        assert!(live_lock_owner_in(dir.path(), 4276, &|_| true).is_none());
+    }
+
+    // ---- leg 2: machine-level journal ------------------------------------
+
+    #[test]
+    fn live_journal_claim_matches_the_same_root() {
+        let journal = journal_with("/repo/loom", 4275, 999);
+        let evidence =
+            live_journal_claim(&journal, Path::new("/repo/loom"), 4275, &|_| true).unwrap();
+        assert_eq!(evidence.pid(), 999);
+    }
+
+    #[test]
+    fn live_journal_claim_ignores_a_dead_pid() {
+        let journal = journal_with("/repo/loom", 4275, 999);
+        assert!(live_journal_claim(&journal, Path::new("/repo/loom"), 4275, &|_| false).is_none());
+    }
+
+    #[test]
+    fn live_journal_claim_sees_a_nested_worktree_daemons_claim() {
+        // The three unattributed #4275 dispatches came from a daemon rooted at
+        // <repo>/.loom/worktrees/issue-4385. Its journal claim must be visible
+        // to the parent checkout's daemon, and vice versa.
+        let journal = journal_with("/repo/loom/.loom/worktrees/issue-4385", 4275, 999);
+        assert!(live_journal_claim(&journal, Path::new("/repo/loom"), 4275, &|_| true).is_some());
+
+        let parent = journal_with("/repo/loom", 4275, 999);
+        assert!(live_journal_claim(
+            &parent,
+            Path::new("/repo/loom/.loom/worktrees/issue-4385"),
+            4275,
+            &|_| true
+        )
+        .is_some());
+    }
+
+    #[test]
+    fn live_journal_claim_ignores_an_unrelated_repo() {
+        let journal = journal_with("/repo/other", 4275, 999);
+        assert!(live_journal_claim(&journal, Path::new("/repo/loom"), 4275, &|_| true).is_none());
+    }
+
+    #[test]
+    fn repos_are_related_is_component_wise_not_string_prefix() {
+        assert!(repos_are_related("/repo/loom", "/repo/loom"));
+        assert!(repos_are_related("/repo/loom", "/repo/loom/.loom/worktrees/issue-1"));
+        assert!(repos_are_related("/repo/loom/.loom/worktrees/issue-1", "/repo/loom"));
+        // A sibling whose name merely starts with the same characters is NOT
+        // the same repo.
+        assert!(!repos_are_related("/repo/loom", "/repo/loom-2"));
+        assert!(!repos_are_related("/repo/loom", "/other/loom"));
+    }
+
+    // ---- leg 3: sweep-process cmdline matcher ----------------------------
+
+    #[test]
+    fn cmdline_matches_the_real_daemon_spawn_shape() {
+        // Exactly what `ps` showed during the #4275 incident.
+        let cmdline =
+            "claude -p /loom:sweep 4275 --claim-owned 4275 --dangerously-skip-permissions";
+        assert!(cmdline_targets_sweep_issue(cmdline, 4275));
+        assert!(!cmdline_targets_sweep_issue(cmdline, 4276));
+    }
+
+    #[test]
+    fn cmdline_requires_an_exact_issue_token() {
+        // Prefix/suffix digits must never match — the classic substring bug.
+        assert!(!cmdline_targets_sweep_issue("claude -p /loom:sweep 42751", 4275));
+        assert!(!cmdline_targets_sweep_issue("claude -p /loom:sweep 14275", 4275));
+    }
+
+    #[test]
+    fn cmdline_ignores_sweep_without_an_issue_argument() {
+        assert!(!cmdline_targets_sweep_issue("claude -p /loom:sweep", 4275));
+        assert!(!cmdline_targets_sweep_issue("claude -p /loom:sweeper 4275", 4275));
+        // PR-set mode claims no issue.
+        assert!(!cmdline_targets_sweep_issue("claude -p /loom:sweep --prs 4275", 4275));
+    }
+
+    #[test]
+    fn cmdline_scans_past_a_non_matching_occurrence() {
+        let cmdline = "sh -c echo /loom:sweep --prs 1 ; claude -p /loom:sweep 4275";
+        assert!(cmdline_targets_sweep_issue(cmdline, 4275));
+    }
+
+    #[test]
+    fn cmdline_matcher_terminates_on_repeated_needles() {
+        // Regression guard for the scan loop's advance step: a cmdline made of
+        // nothing but non-matching needles must terminate, not spin.
+        let cmdline = "/loom:sweep /loom:sweep /loom:sweep";
+        assert!(!cmdline_targets_sweep_issue(cmdline, 4275));
+    }
+
+    // ---- composed probe --------------------------------------------------
+
+    #[test]
+    fn probe_finds_nothing_in_a_pristine_workspace() {
+        let dir = tempdir().unwrap();
+        let journal = dir.path().join("sweeps.json");
+        assert!(probe(dir.path(), Some(&journal), 4275).is_none());
+    }
+
+    #[test]
+    fn probe_reports_the_live_lock_leg_first() {
+        let dir = tempdir().unwrap();
+        let locks = dir.path().join(".loom").join("locks");
+        let sweep = FakeSweep::spawn(4275);
+        write_lock(&locks, 4275, sweep.pid(), "sweep-issue-4275-live");
+        let journal = dir.path().join("sweeps.json");
+        let evidence = probe(dir.path(), Some(&journal), 4275).unwrap();
+        assert!(matches!(evidence, LiveClaimEvidence::ClaimLock { .. }));
+    }
+
+    #[test]
+    fn probe_falls_through_a_dead_lock_to_the_journal_leg() {
+        let dir = tempdir().unwrap();
+        let locks = dir.path().join(".loom").join("locks");
+        // PID 0 is treated as dead by `is_pid_alive`, so leg 1 declines.
+        write_lock(&locks, 4275, 0, "sweep-issue-4275-dead");
+        let journal_path = dir.path().join("sweeps.json");
+        let sweep = FakeSweep::spawn(4275);
+        let journal = journal_with(&dir.path().display().to_string(), 4275, sweep.pid());
+        std::fs::write(&journal_path, serde_json::to_string(&journal).unwrap()).unwrap();
+        let evidence = probe(dir.path(), Some(&journal_path), 4275).unwrap();
+        assert!(matches!(evidence, LiveClaimEvidence::Journal { .. }));
+    }
+
+    /// A *stale* record whose PID has been recycled by an unrelated live
+    /// process must NOT count as a live claim: that is the only way this guard
+    /// could wedge an issue permanently (the record is never pruned, because
+    /// `prune_dead` also sees the recycled PID as alive).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn probe_ignores_a_live_pid_whose_argv_is_not_this_issues_sweep() {
+        let dir = tempdir().unwrap();
+        let locks = dir.path().join(".loom").join("locks");
+        // Our own PID: live, but its argv is the test binary, not a sweep.
+        write_lock(&locks, 4275, std::process::id(), "sweep-issue-4275-recycled");
+        let journal_path = dir.path().join("sweeps.json");
+        let journal = journal_with(&dir.path().display().to_string(), 4275, std::process::id());
+        std::fs::write(&journal_path, serde_json::to_string(&journal).unwrap()).unwrap();
+        assert!(probe(dir.path(), Some(&journal_path), 4275).is_none());
+    }
+
+    /// A sweep process for a *different* issue must not satisfy the argv check.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn pid_is_live_claim_for_is_scoped_to_the_issue() {
+        let sweep = FakeSweep::spawn(4275);
+        assert!(pid_is_live_claim_for(sweep.pid(), 4275));
+        assert!(!pid_is_live_claim_for(sweep.pid(), 4276));
+        assert!(!pid_is_live_claim_for(0, 4275), "a dead pid is never a claim");
+    }
+
+    #[test]
+    fn probe_ignores_a_dead_lock_and_a_dead_journal_entry() {
+        let dir = tempdir().unwrap();
+        let locks = dir.path().join(".loom").join("locks");
+        write_lock(&locks, 4275, 0, "sweep-issue-4275-dead");
+        let journal_path = dir.path().join("sweeps.json");
+        let journal = journal_with(&dir.path().display().to_string(), 4275, 0);
+        std::fs::write(&journal_path, serde_json::to_string(&journal).unwrap()).unwrap();
+        // Leg 3 cannot fire: no live process has its cwd inside a fresh tempdir.
+        assert!(probe(dir.path(), Some(&journal_path), 4275).is_none());
+    }
+
+    #[test]
+    fn our_own_pid_is_a_live_process_and_pid_zero_is_not() {
+        assert!(pid_is_live_process(std::process::id()));
+        assert!(!pid_is_live_process(0));
+    }
+
+    #[test]
+    fn evidence_display_names_the_leg() {
+        assert!(LiveClaimEvidence::ClaimLock {
+            pid: 1,
+            sweep_id: "s".into()
+        }
+        .to_string()
+        .contains("claim lock"));
+        assert!(LiveClaimEvidence::Journal {
+            pid: 1,
+            repo: "/r".into()
+        }
+        .to_string()
+        .contains("sweep-journal"));
+        assert!(LiveClaimEvidence::SweepProcess { pid: 1 }
+            .to_string()
+            .contains("/loom:sweep"));
+    }
+}

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -265,6 +265,56 @@ enum OpenPrProbe {
     ProbeFailed,
 }
 
+/// Typed, matchable error returned by [`SweepRegistry::dispatch`] when the
+/// live-claim guard (Issue #4556, step 2.9) refuses a dispatch because a sweep
+/// process for this issue is **confirmed still running**.
+///
+/// ## Why the existing guards were not enough
+///
+/// `acquire_lock` (step 3) already refuses when `.loom/locks/issue-<N>/`
+/// *exists*, and #4463 made every reaper / cancel / watchdog *release* of that
+/// lock ownership-checked. Neither covers the incident this guard closes:
+/// issue #4275 was dispatched **seven times in 77 minutes** because each
+/// re-dispatch path first *convinced itself the sweep was dead* — the
+/// reconciler on a dead-looking recorded PID, the mid-build watchdog on a
+/// terminal registry entry, the review-stall watchdog on a silent log — and
+/// therefore released the lock (or reverted the label) before dispatching, so
+/// step 3 had nothing left to collide with. Three further dispatches came from
+/// a *second* `loom-daemon` instance on the same host that shared neither the
+/// first daemon's memory nor its `.loom/locks/`.
+///
+/// Step 2.9 asks the strictly stronger question — is a sweep process for this
+/// issue confirmed *live* right now? — via [`crate::live_claim::probe`], whose
+/// evidence legs (live lock owner, machine-level journal, `/proc` sweep-process
+/// scan) survive lock release, label drift, daemon restart, and a second daemon
+/// instance.
+///
+/// Distinct, downcast-matchable type — same rationale as
+/// [`OpenPrDispatchError`]: a live-claim refusal is a *deliberate skip*, not a
+/// dispatch failure, so the work-finder attributes it to its in-flight skip
+/// counter instead of the generic error tally.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveClaimDispatchError {
+    /// The issue whose dispatch was refused.
+    pub issue: u32,
+    /// Which signal proved the claim is still live.
+    pub evidence: crate::live_claim::LiveClaimEvidence,
+}
+
+impl std::fmt::Display for LiveClaimDispatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "refusing to dispatch issue #{}: it still has a confirmed-live sweep claim — {} \
+             (#4556 live-claim guard). A second concurrent sweep would share one worktree with \
+             the live one.",
+            self.issue, self.evidence
+        )
+    }
+}
+
+impl std::error::Error for LiveClaimDispatchError {}
+
 /// Issue #4256: checkpoint phases at/after Builder completion. A crash whose
 /// checkpoint reads one of these means a PR was opened for the issue, so
 /// [`SweepRegistry::reap_once`]'s reaper-driven resume is eligible to
@@ -2143,6 +2193,35 @@ pub enum LockReleaseOutcome {
     /// after the releasing one died). The lock was left intact; the caller MUST
     /// NOT restore the label or re-dispatch.
     Superseded,
+    /// The lock's own recorded owner is **still a live `/loom:sweep <N>`
+    /// process** (Issue #4556): the caller's dead-sweep verdict was wrong. The
+    /// lock was left intact and, exactly like [`Self::Superseded`], the caller
+    /// MUST NOT restore the label or re-dispatch.
+    ///
+    /// This is the release-side half of the #4556 fix. #4463 stopped a *dying*
+    /// sweep's cleanup from clobbering a lock a *newer* sweep had re-acquired,
+    /// but it still trusted the caller's claim that the sweep it names is dead.
+    /// Issue #4275's storm began with exactly that trust being misplaced: a
+    /// false-dead verdict released a live sweep's lock and reverted its label,
+    /// re-opening the issue to the work-finder.
+    ///
+    /// Deliberately narrow to avoid the opposite failure (a permanently wedged
+    /// issue): a bare `kill(pid, 0)` would also match an unrelated process that
+    /// recycled the PID, so this outcome requires the PID to be live **and** its
+    /// argv to target `/loom:sweep <N>`
+    /// ([`crate::live_claim::pid_is_sweep_process_for`]). Anything less
+    /// positive fails open and releases as before.
+    HolderAlive,
+}
+
+impl LockReleaseOutcome {
+    /// Whether the lock was deliberately **left in place** — the caller's sweep
+    /// is not the live owner, so it must skip its label restore and any
+    /// re-dispatch ([`Self::Superseded`], #4463; [`Self::HolderAlive`], #4556).
+    #[must_use]
+    pub fn retained(self) -> bool {
+        matches!(self, Self::Superseded | Self::HolderAlive)
+    }
 }
 
 /// On-disk owner metadata written inside the lock dir. Schema mirrors
@@ -2239,6 +2318,12 @@ pub struct SweepRegistry {
     /// the issue is removed again as soon as the worktree stops being in use so a
     /// later refusal (or a genuine give-up) still surfaces.
     midbuild_inuse: HashSet<u32>,
+    /// Issues whose mid-build recovery the watchdog has already refused because
+    /// the issue still has a confirmed-live sweep claim (Issue #4556). Log-once
+    /// bookkeeping only — exactly like `midbuild_inuse`, it never suppresses the
+    /// refusal itself, never consumes the single recovery retry, and is cleared
+    /// as soon as the claim goes away so a later refusal still surfaces.
+    midbuild_liveclaim: HashSet<u32>,
     /// Issues the review-phase stall watchdog has already restarted once (Issue
     /// #3910). Bounds the "log went silent mid-review (hung Judge/Doctor)"
     /// recovery to a single re-dispatch per issue — a second stall resolves to
@@ -2437,6 +2522,7 @@ impl SweepRegistry {
             midbuild_retried: HashSet::new(),
             midbuild_gaveup: HashSet::new(),
             midbuild_inuse: HashSet::new(),
+            midbuild_liveclaim: HashSet::new(),
             review_stall_retried: HashSet::new(),
             review_stall_gaveup: HashSet::new(),
             quarantine_config: QuarantineConfig::default(),
@@ -2476,6 +2562,7 @@ impl SweepRegistry {
             midbuild_retried: HashSet::new(),
             midbuild_gaveup: HashSet::new(),
             midbuild_inuse: HashSet::new(),
+            midbuild_liveclaim: HashSet::new(),
             review_stall_retried: HashSet::new(),
             review_stall_gaveup: HashSet::new(),
             quarantine_config: QuarantineConfig::default(),
@@ -3491,6 +3578,57 @@ impl SweepRegistry {
             }
         }
 
+        // 2.9 Live-claim guard (Issue #4556). The single hard, dispatch-time
+        //     refusal for an issue whose sweep is *confirmed still running*.
+        //
+        //     Every guard before this one, and `acquire_lock` below, keys on
+        //     state that a re-dispatch path has already invalidated by the time
+        //     it dispatches:
+        //
+        //     - `acquire_lock` refuses only on the lock **existing**, and every
+        //       reaper / cancel / watchdog path releases that lock *first*, on
+        //       the strength of its own dead-sweep verdict.
+        //     - The `loom:building` label is reverted by
+        //       `claim_reconciliation` the moment a recorded PID looks dead
+        //       (confirmed on #4275 at 03:08:15Z), re-exposing the issue to the
+        //       work-finder.
+        //     - The in-memory entry set (`issue_has_active_sweep`,
+        //       `in_flight()`) is scoped to ONE daemon process — invisible to a
+        //       second `loom-daemon` instance on the same host, which is where
+        //       3 of the 7 #4275 dispatches came from.
+        //
+        //     `live_claim::probe` asks the strictly stronger question instead:
+        //     is a sweep process for this issue *alive right now*? Its three
+        //     evidence legs (live lock owner / machine-level `~/.loom/sweeps.json`
+        //     journal / `/proc` scan for a `/loom:sweep <N>` process rooted in
+        //     this workspace) each survive a lock release, a label revert, a
+        //     daemon restart, AND a second daemon instance.
+        //
+        //     Placed with the other pre-flip guards so ONE check covers all six
+        //     dispatch routes — work-finder, epic supervisor, IPC/CLI, and all
+        //     three watchdogs — and so a refusal costs no lock, no label write,
+        //     and no forge round trip. Deliberately NOT exempted by
+        //     `resume_bypass_pr`: a checkpoint-resume of a crashed sweep is
+        //     still a duplicate if the "crashed" sweep turns out to be alive.
+        //     Not gated on `skip_label_flip` either — it is pure local
+        //     filesystem bookkeeping with no `gh` dependency.
+        //
+        //     Fail-open: `probe` returns `None` on every ambiguity (missing or
+        //     corrupt `owner.json`, unreadable journal, no `/proc`), and treats
+        //     a zombie PID as dead, so a garbage file can never wedge an issue.
+        if let Some(evidence) = self.live_claim_evidence(issue_number) {
+            log::warn!(
+                "sweep_registry: refusing to dispatch issue #{issue_number} — {evidence} \
+                 (#4556 live-claim guard). This is the duplicate-dispatch storm guard; the \
+                 live sweep keeps its claim and runs its own lifecycle."
+            );
+            return Err(LiveClaimDispatchError {
+                issue: issue_number,
+                evidence,
+            }
+            .into());
+        }
+
         // 3. Acquire the claim lock atomically.
         let sweep_id = generate_sweep_id(kind);
         self.acquire_lock(issue_number, &sweep_id)?;
@@ -3776,10 +3914,19 @@ impl SweepRegistry {
     /// label restore and any re-dispatch: the newer sweep is the live owner and
     /// runs its own lifecycle.
     ///
+    /// Issue #4556 adds a second refusal: even when the owner **is** this
+    /// sweep, the lock is left intact and
+    /// [`LockReleaseOutcome::HolderAlive`] returned if the recorded
+    /// `owner_pid` is still a live `/loom:sweep <N>` process. #4463 trusted the
+    /// caller's assertion that the sweep it names is dead; #4275's
+    /// seven-dispatch storm started with exactly that assertion being wrong (a
+    /// false-dead verdict released a live sweep's lock and reverted its label).
+    ///
     /// FAIL-OPEN: a missing / unreadable / corrupt / unparseable `owner.json`
     /// falls back to the legacy unconditional removal — the release only refuses
-    /// on a *positively-read, conflicting* owner, so a garbage lock file can
-    /// never wedge an issue permanently. A non-existent lock dir is a no-op
+    /// on a *positively-read, conflicting* owner or a *positively-confirmed*
+    /// live sweep process, so a garbage lock file can never wedge an issue
+    /// permanently. A non-existent lock dir is a no-op
     /// ([`LockReleaseOutcome::Released`], idempotent).
     #[must_use]
     pub fn release_lock_owned(&self, issue: u32, sweep_id: &str) -> LockReleaseOutcome {
@@ -3790,10 +3937,38 @@ impl SweepRegistry {
         if self.lock_owned_by_other(issue, sweep_id) {
             return LockReleaseOutcome::Superseded;
         }
+        if let Some(pid) = self.live_sweep_lock_owner_pid(issue) {
+            log::warn!(
+                "release_lock: issue #{issue} lock is owned by sweep {sweep_id}, which the \
+                 caller believes is dead — but pid {pid} is STILL a live `/loom:sweep {issue}` \
+                 process. Leaving the lock intact and skipping any label restore / re-dispatch \
+                 (#4556 false-dead verdict guard)."
+            );
+            return LockReleaseOutcome::HolderAlive;
+        }
         if let Err(e) = std::fs::remove_dir_all(&lock) {
             log::warn!("release_lock: failed to remove lock dir {}: {e}", lock.display());
         }
         LockReleaseOutcome::Released
+    }
+
+    /// The lock's recorded `owner_pid` when it is **positively confirmed** to
+    /// still be a live `/loom:sweep <issue>` process (Issue #4556).
+    ///
+    /// Fail-open in both directions that matter: a missing / unparseable
+    /// `owner.json` yields `None`, and so does a live PID whose argv does *not*
+    /// name this issue's sweep (a recycled PID). Only a positive match refuses a
+    /// release, so this can never wedge an issue.
+    fn live_sweep_lock_owner_pid(&self, issue: u32) -> Option<u32> {
+        let owner_path = self
+            .config
+            .locks_dir()
+            .join(format!("issue-{issue}"))
+            .join("owner.json");
+        let raw = std::fs::read_to_string(&owner_path).ok()?;
+        let owner: LockOwner = serde_json::from_str(&raw).ok()?;
+        crate::live_claim::pid_is_sweep_process_for(owner.owner_pid, issue)
+            .then_some(owner.owner_pid)
     }
 
     /// Read-only ownership probe (Issue #4463): `true` iff the issue lock's
@@ -3918,6 +4093,26 @@ impl SweepRegistry {
                 None
             }
         }
+    }
+
+    /// Confirmed-live claim probe for `issue` (Issue #4556) — the evidence
+    /// behind the dispatch-time live-claim guard (step 2.9) and reusable by any
+    /// caller that must distinguish "a lock file exists" from "a sweep process
+    /// is running".
+    ///
+    /// Read-only: unlike [`release_lock_owned`](Self::release_lock_owned) it
+    /// never touches the filesystem, so it is safe to consult *before* a
+    /// release, a label revert, or a re-dispatch. Delegates to
+    /// [`crate::live_claim::probe`], scoped to this registry's workspace root
+    /// and its configured journal path (tests point that at a tempdir, so the
+    /// probe never reads the real `~/.loom/sweeps.json`).
+    #[must_use]
+    pub fn live_claim_evidence(&self, issue: u32) -> Option<crate::live_claim::LiveClaimEvidence> {
+        crate::live_claim::probe(
+            &self.config.workspace_root,
+            self.config.journal_path.as_deref(),
+            issue,
+        )
     }
 
     /// Best-effort removal of this registry's sweep-journal entry for
@@ -5568,9 +5763,10 @@ impl SweepRegistry {
             // Ownership-checked release (#4463): if a newer sweep re-acquired
             // this issue's lock after the sweep being cancelled died, leave its
             // live lock intact and skip the label restore below — the newer
-            // sweep owns the claim and runs its own lifecycle.
-            let superseded =
-                self.release_lock_owned(*issue, sweep_id) == LockReleaseOutcome::Superseded;
+            // sweep owns the claim and runs its own lifecycle. #4556 extends the
+            // same skip to `HolderAlive`: the cancelled sweep's OWN pid is still
+            // a live `/loom:sweep <N>` process, so the claim is not free either.
+            let superseded = self.release_lock_owned(*issue, sweep_id).retained();
             // Best-effort tidy-up of the machine-level liveness journal
             // (#3953) — this cancelled sweep no longer exists.
             self.journal_remove_best_effort(*issue);
@@ -5706,9 +5902,11 @@ impl SweepRegistry {
                         // live sweep re-acquired after this dead one. When the
                         // lock is `Superseded`, skip the label restore AND the
                         // resume/re-dispatch below — the dead sweep is not
-                        // crashed-needing-recovery, it is superseded.
-                        let superseded = self.release_lock_owned(issue, &sweep_id)
-                            == LockReleaseOutcome::Superseded;
+                        // crashed-needing-recovery, it is superseded. #4556 folds
+                        // in `HolderAlive` (this sweep's own pid is still a live
+                        // `/loom:sweep <N>` process, so the reap verdict was
+                        // wrong) via the shared `retained()` predicate.
+                        let superseded = self.release_lock_owned(issue, &sweep_id).retained();
                         // Best-effort tidy-up of the machine-level liveness
                         // journal (#3953): the reaper just confirmed this
                         // PID is dead, so drop its entry now rather than
@@ -6869,6 +7067,68 @@ impl SweepRegistry {
                         }
                         continue;
                     }
+                    // #4556: probe for a confirmed-live sweep claim BEFORE any
+                    // of the destructive recovery below. ORDERING IS
+                    // LOAD-BEARING — this MUST stay ahead of
+                    // `claim_lock_for_midbuild` (#4602/#4564), for two reasons:
+                    //
+                    // 1. That call TAKES OVER `.loom/locks/issue-<N>/owner.json`
+                    //    in place, rewriting `owner_pid` to this daemon's pid and
+                    //    `sweep_id` to `midbuild-watchdog-<dead>`. It does so
+                    //    precisely when the lock still names the sweep this
+                    //    daemon believes is dead — i.e. the false-dead case this
+                    //    guard exists to catch. Probing afterwards would read the
+                    //    watchdog's own record, whose argv is `loom-daemon`, not
+                    //    `/loom:sweep <N>`, silently demoting the probe to its
+                    //    weaker journal / process-scan legs.
+                    // 2. The refusal path below `continue`s without releasing, so
+                    //    a takeover that happened first would leave the live
+                    //    sweep's owner record permanently clobbered: its own
+                    //    `release_lock_owned` would then read `Superseded` and
+                    //    skip its label restore.
+                    //
+                    // The dispatch-time live-claim guard (step 2.9) is NOT
+                    // sufficient on its own here either, because this path does
+                    // its destructive work FIRST — it burns the single recovery
+                    // retry, `git reset --hard`s the shared worktree, and releases
+                    // the lock — and only then calls `dispatch`. A refusal at that
+                    // point would come too late: the live sweep's uncommitted work
+                    // is already gone.
+                    //
+                    // Strictly stronger than the `#4463` ownership probe inside
+                    // `claim_lock_for_midbuild` below, which only sees a lock
+                    // re-acquired by a *newer* sweep in this daemon's own
+                    // `.loom/locks/`: this probe also catches a still-live sweep
+                    // whose lock a false-dead verdict already released, and one
+                    // owned by a second `loom-daemon` instance on this host (3 of
+                    // #4275's 7 dispatches). Complements the `#4449`
+                    // `worktree_in_use` veto, which asks whether the *worktree* is
+                    // held; this asks whether the *sweep* is alive, and a sweep
+                    // stalled between phases holds neither an index.lock nor a
+                    // `.loom-in-use` marker.
+                    //
+                    // Like `InUse`, the retry latch is deliberately NOT consumed:
+                    // once the live sweep really finishes, a genuinely stuck
+                    // worktree is still recoverable on a later tick.
+                    if let Some(evidence) = self.live_claim_evidence(issue) {
+                        if self.midbuild_liveclaim.insert(issue) {
+                            log::warn!(
+                                "midbuild-watchdog: issue #{issue} ({sweep_id}) matches the \
+                                 mid-build-death signature, but the issue still has {evidence}. \
+                                 REFUSING to claim its lock, clean its worktree or re-dispatch: \
+                                 the sweep this daemon believes is dead is demonstrably alive, and \
+                                 recovering here would `git reset --hard` its in-progress work, \
+                                 clobber its lock-owner record and start a second sweep on the \
+                                 same worktree (#4556). The single recovery retry is NOT consumed; \
+                                 the watchdog re-assesses once the live sweep exits."
+                            );
+                        }
+                        continue;
+                    }
+                    // No live claim: clear the log-once latch so a later refusal
+                    // still surfaces.
+                    self.midbuild_liveclaim.remove(&issue);
+
                     // #4463/#4564: before we clean the worktree or re-dispatch,
                     // take EXCLUSIVE ownership of the issue lock. If a newer
                     // sweep holds it (cross-instance double dispatch), its
@@ -12968,6 +13228,429 @@ exit 0
         let (registry, _record_log) = fixture_registry(dir.path());
         let outcome = registry.release_lock_owned(4467, "sweep-issue-4467-none");
         assert_eq!(outcome, LockReleaseOutcome::Released);
+    }
+
+    // --- dispatch-time live-claim guard (Issue #4556) ---
+
+    /// Seed the machine-level sweep journal (confined to this fixture's tempdir)
+    /// with a `(repo, issue, pid)` record — the "a sweep is alive but the lock
+    /// and label are already gone" state that #4275's re-dispatch paths created.
+    fn write_journal_entry(reg: &SweepRegistry, repo: &str, issue: u32, pid: u32) {
+        let path = reg.config.resolve_journal_path().unwrap();
+        let journal = crate::sweep_journal::SweepJournal {
+            version: crate::sweep_journal::JOURNAL_VERSION,
+            entries: vec![crate::sweep_journal::JournalEntry {
+                repo: repo.to_string(),
+                issue,
+                pid,
+                started_at: Utc::now(),
+            }],
+        };
+        std::fs::write(&path, serde_json::to_string(&journal).unwrap()).unwrap();
+    }
+
+    /// A stand-in for a real sweep child, killed on drop: a long-lived process
+    /// whose argv contains `/loom:sweep <issue>` (`sh -c <cmd> <argv0>` puts
+    /// the third arg in `$0`, so the needle lands in the process's argv without
+    /// being interpreted). Mirrors what [`SweepRegistry::spawn_child`] produces
+    /// — `spawn-worker.sh -p "/loom:sweep <N> --claim-owned <N>"`, which
+    /// `exec`s through to `claude` keeping both the PID and the needle — so the
+    /// #4556 guard's argv verification sees a realistic claim holder rather
+    /// than the test binary's own PID.
+    struct FakeSweep(std::process::Child);
+
+    impl FakeSweep {
+        fn spawn(issue: u32) -> Self {
+            let child = Command::new("sh")
+                .arg("-c")
+                .arg("sleep 120")
+                .arg(format!("/loom:sweep {issue} --claim-owned {issue}"))
+                .spawn()
+                .unwrap();
+            // `spawn` returns at fork, not exec — wait for the argv to become
+            // visible or every argv-verifying assertion below is a load-flake.
+            crate::live_claim::wait_until_argv_visible(child.id(), issue);
+            Self(child)
+        }
+
+        fn pid(&self) -> u32 {
+            self.0.id()
+        }
+    }
+
+    impl Drop for FakeSweep {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+
+    /// The headline #4556 guard: a lock whose owner PID is **live** refuses a
+    /// dispatch with the typed [`LiveClaimDispatchError`], before any lock or
+    /// label write happens.
+    #[test]
+    fn dispatch_refuses_when_the_claim_lock_owner_is_live() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        let sweep = FakeSweep::spawn(4556);
+        write_lock_owner(&registry, 4556, "sweep-issue-4556-live", sweep.pid());
+
+        let err = registry
+            .dispatch(&SweepKind::Issue(4556), None, None, None, None)
+            .unwrap_err();
+        let typed = err
+            .downcast_ref::<LiveClaimDispatchError>()
+            .expect("a live claim lock must surface the typed #4556 refusal");
+        assert_eq!(typed.issue, 4556);
+        assert!(matches!(typed.evidence, crate::live_claim::LiveClaimEvidence::ClaimLock { .. }));
+        assert!(registry.entries.is_empty(), "a refused dispatch must not record an entry");
+    }
+
+    /// The gap #4463's ownership-checked *release* could not close: the lock is
+    /// already gone (a watchdog / reaper released it on a false-dead verdict) but
+    /// the sweep process is still alive. The machine-level journal survives that
+    /// release, so the guard still refuses.
+    #[test]
+    fn dispatch_refuses_when_the_journal_records_a_live_sweep_and_the_lock_is_gone() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        assert!(
+            !registry.config.locks_dir().join("issue-4557").exists(),
+            "precondition: no lock — the released-lock state this guard covers"
+        );
+        let sweep = FakeSweep::spawn(4557);
+        write_journal_entry(&registry, &dir.path().display().to_string(), 4557, sweep.pid());
+
+        let err = registry
+            .dispatch(&SweepKind::Issue(4557), None, None, None, None)
+            .unwrap_err();
+        assert!(matches!(
+            err.downcast_ref::<LiveClaimDispatchError>()
+                .map(|e| &e.evidence),
+            Some(crate::live_claim::LiveClaimEvidence::Journal { .. })
+        ));
+    }
+
+    /// A daemon rooted at `<repo>/.loom/worktrees/issue-N` — the stray
+    /// debug-build instance that produced 3 of #4275's 7 dispatches — records
+    /// its claims in the same machine-level journal under a *nested* repo path.
+    /// The parent checkout's daemon must see that claim.
+    #[test]
+    fn dispatch_refuses_when_a_nested_worktree_daemon_holds_the_claim() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        let nested = dir
+            .path()
+            .join(".loom")
+            .join("worktrees")
+            .join("issue-4385")
+            .display()
+            .to_string();
+        let sweep = FakeSweep::spawn(4558);
+        write_journal_entry(&registry, &nested, 4558, sweep.pid());
+
+        let err = registry
+            .dispatch(&SweepKind::Issue(4558), None, None, None, None)
+            .unwrap_err();
+        assert!(
+            err.downcast_ref::<LiveClaimDispatchError>().is_some(),
+            "a nested-worktree daemon's live claim must refuse the parent's dispatch; got: {err}"
+        );
+    }
+
+    /// Test Plan item 2 / the issue's headline acceptance criterion: **N**
+    /// dispatch requests for one issue inside a bounded window produce exactly
+    /// **one** live sweep. Here the live sweep is already running (its claim
+    /// proven by the journal) and every one of the next five requests — the
+    /// shape of #4275's storm, where the work-finder, the reconciler, and two
+    /// watchdogs each fired — is refused without a lock, a label write, or an
+    /// entry.
+    #[test]
+    fn n_dispatch_requests_for_a_live_issue_produce_zero_extra_sweeps() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        let sweep = FakeSweep::spawn(4559);
+        write_journal_entry(&registry, &dir.path().display().to_string(), 4559, sweep.pid());
+
+        for attempt in 1..=5 {
+            let err = registry
+                .dispatch(&SweepKind::Issue(4559), None, None, None, None)
+                .unwrap_err();
+            assert!(
+                err.downcast_ref::<LiveClaimDispatchError>().is_some(),
+                "attempt {attempt} must be refused by the live-claim guard; got: {err}"
+            );
+        }
+        assert!(registry.entries.is_empty(), "no duplicate sweep may be recorded");
+        assert!(
+            !registry.config.locks_dir().join("issue-4559").exists(),
+            "a refusal must cost no lock write"
+        );
+    }
+
+    /// A dead recorded PID must NOT refuse — the guard fails open so a stale
+    /// journal entry or an abandoned lock can never wedge an issue.
+    #[test]
+    fn dispatch_proceeds_when_every_recorded_claim_pid_is_dead() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        // PID 0 is always treated as dead by `is_pid_alive`.
+        write_journal_entry(&registry, &dir.path().display().to_string(), 4560, 0);
+
+        assert!(
+            registry.live_claim_evidence(4560).is_none(),
+            "a dead journal PID is not live-claim evidence"
+        );
+        let outcome = registry
+            .dispatch(&SweepKind::Issue(4560), None, None, None, None)
+            .expect("a dead recorded claim must not block a legitimate dispatch");
+        assert!(outcome.was_new);
+    }
+
+    /// A journal claim for the SAME issue number in an UNRELATED repo must not
+    /// refuse: issue numbers are per-repo, so a sibling checkout's #N is a
+    /// different issue.
+    #[test]
+    fn dispatch_ignores_a_live_claim_from_an_unrelated_repo() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        let sweep = FakeSweep::spawn(4561);
+        write_journal_entry(&registry, "/some/other/checkout", 4561, sweep.pid());
+
+        assert!(registry.live_claim_evidence(4561).is_none());
+        assert!(registry
+            .dispatch(&SweepKind::Issue(4561), None, None, None, None)
+            .is_ok());
+    }
+
+    /// The mid-build-death watchdog (#3895) must not recover an issue whose
+    /// sweep is still alive — the 03:08:52Z re-dispatch in the #4275 timeline.
+    ///
+    /// The dispatch-time guard alone would be **too late** here: this path
+    /// `git reset --hard`s the shared worktree and burns the single recovery
+    /// retry *before* it calls `dispatch`. So the refusal must happen up front,
+    /// and this test asserts exactly that — the uncommitted mid-build work
+    /// survives and the retry is not consumed.
+    ///
+    /// Nothing holds the worktree (no `.loom-in-use`, no `index.lock`, no live
+    /// lock owner), so the #4449 live-use veto does *not* fire: the only thing
+    /// standing between the live sweep and a `git reset --hard` is #4556's
+    /// live-claim probe.
+    #[test]
+    fn midbuild_watchdog_does_not_recover_an_issue_with_a_live_claim() {
+        let dir = tempdir().unwrap();
+        let ws = dir.path();
+        let (mut reg, _record_log) = fixture_registry(ws);
+
+        make_dirty_git_worktree(ws, 4562);
+        insert_terminal_issue(&mut reg, "sweep-issue-4562-dead", 4562, None);
+        // The live sweep's claim survives in the machine-level journal even
+        // though this daemon believes sweep-…-dead is terminal — the exact
+        // state a false-dead verdict leaves behind once it has released the
+        // lock and reverted the label.
+        let sweep = FakeSweep::spawn(4562);
+        write_journal_entry(&reg, &ws.display().to_string(), 4562, sweep.pid());
+        assert!(
+            reg.worktree_in_use(4562).is_empty(),
+            "precondition: the #4449 live-use veto must NOT be what refuses here"
+        );
+
+        assert_eq!(
+            reg.midbuild_watchdog_once(),
+            0,
+            "no recovery while a live sweep claim exists for the issue"
+        );
+        assert!(
+            ws.join(".loom/worktrees/issue-4562/dirty.txt").exists(),
+            "the live sweep's uncommitted mid-build work MUST survive (#4556)"
+        );
+        assert!(
+            !reg.midbuild_retried.contains(&4562),
+            "a live-claim refusal must NOT consume the single recovery retry"
+        );
+        assert!(
+            reg.midbuild_liveclaim.contains(&4562),
+            "the refusal is recorded and logged once"
+        );
+        assert!(reg.entries.values().all(|i| i.state.is_terminal()), "no new sweep was created");
+    }
+
+    /// The inverse: once the live claim is gone, the same mid-build recovery
+    /// proceeds normally. Without this the guard could wedge the recovery path
+    /// permanently on a stale record.
+    #[test]
+    fn midbuild_watchdog_recovers_once_the_live_claim_is_gone() {
+        let dir = tempdir().unwrap();
+        let ws = dir.path();
+        let (mut reg, _record_log) = fixture_registry(ws);
+
+        make_dirty_git_worktree(ws, 4566);
+        insert_terminal_issue(&mut reg, "sweep-issue-4566-dead", 4566, None);
+        {
+            let sweep = FakeSweep::spawn(4566);
+            write_journal_entry(&reg, &ws.display().to_string(), 4566, sweep.pid());
+            assert_eq!(reg.midbuild_watchdog_once(), 0, "refused while the claim is live");
+            assert!(reg.midbuild_liveclaim.contains(&4566));
+        } // the stand-in sweep exits here
+        assert!(
+            reg.live_claim_evidence(4566).is_none(),
+            "the journal record's pid is dead once the stand-in sweep exits"
+        );
+
+        assert_eq!(reg.midbuild_watchdog_once(), 1, "recovery resumes once the claim dies");
+        assert!(!reg.midbuild_liveclaim.contains(&4566), "the log-once latch is cleared");
+        assert!(
+            reg.midbuild_retried.contains(&4566),
+            "the retry is consumed by the real recovery"
+        );
+    }
+
+    /// Ordering regression pin for the #4556 × #4602/#4564 interaction: the
+    /// live-claim probe MUST run **before** `claim_lock_for_midbuild`.
+    ///
+    /// #4602 replaced the watchdog's read-only `lock_owned_by_other` probe with
+    /// a *mutating* takeover that rewrites `.loom/locks/issue-<N>/owner.json` to
+    /// this daemon's pid and a `midbuild-watchdog-…` sweep id. A "keep both
+    /// hunks" rebase that leaves the #4556 probe after that call compiles, and
+    /// every other #4556 test still passes — but it is wrong twice over:
+    ///
+    /// 1. the probe's strongest leg (the live lock owner) is destroyed by the
+    ///    very call it is meant to gate, since the daemon's argv is
+    ///    `loom-daemon`, not `/loom:sweep <N>`; and
+    /// 2. the refusal path `continue`s without releasing, so the live sweep's
+    ///    owner record stays clobbered — its own `release_lock_owned` then reads
+    ///    `Superseded` and skips its label restore.
+    ///
+    /// The fixture makes the takeover genuinely **eligible** (a leftover lock
+    /// naming the dead sweep, with a dead owner pid) so that neither the #4449
+    /// live-use veto nor the #4463 peer-owner refusal is what stops the
+    /// recovery, and leaves the live claim visible **only** through the journal
+    /// leg. Byte-comparing `owner.json` across the refused tick is what fails
+    /// under the inverted order.
+    #[test]
+    fn midbuild_live_claim_probe_runs_before_the_lock_takeover() {
+        // Above every plausible `pid_max`, so `is_pid_alive` reports dead.
+        const DEAD_OWNER_PID: u32 = 2_147_483_640;
+        let dir = tempdir().unwrap();
+        let ws = dir.path();
+        let (mut reg, _record_log) = fixture_registry(ws);
+
+        make_dirty_git_worktree(ws, 4602);
+        insert_terminal_issue(&mut reg, "sweep-issue-4602-dead", 4602, None);
+        let lock = write_lock_owner(&reg, 4602, "sweep-issue-4602-dead", DEAD_OWNER_PID);
+        let owner_path = lock.join("owner.json");
+        let owner_before = std::fs::read_to_string(&owner_path).unwrap();
+
+        let sweep = FakeSweep::spawn(4602);
+        write_journal_entry(&reg, &ws.display().to_string(), 4602, sweep.pid());
+
+        assert!(
+            reg.worktree_in_use(4602).is_empty(),
+            "precondition: the #4449 live-use veto must NOT be what refuses here \
+             (the lock's owner pid is dead, so it is not live-use evidence)"
+        );
+        assert!(
+            !reg.lock_owned_by_other(4602, "sweep-issue-4602-dead"),
+            "precondition: the #4463 peer-owner probe must NOT be what refuses here — \
+             the takeover is eligible, which is exactly what makes an ordering \
+             regression observable"
+        );
+
+        assert_eq!(
+            reg.midbuild_watchdog_once(),
+            0,
+            "the journal-visible live claim must refuse the recovery"
+        );
+
+        assert_eq!(
+            std::fs::read_to_string(&owner_path).unwrap(),
+            owner_before,
+            "ORDERING REGRESSION: `claim_lock_for_midbuild` (#4602) rewrote the live \
+             sweep's owner.json, which means the #4556 live-claim probe ran AFTER it. \
+             The probe must come first — see the ORDERING IS LOAD-BEARING comment in \
+             `midbuild_watchdog_once`'s Recover arm."
+        );
+        assert!(
+            reg.midbuild_liveclaim.contains(&4602),
+            "the refusal must be the live-claim one, logged once"
+        );
+        assert!(
+            !reg.midbuild_retried.contains(&4602),
+            "a live-claim refusal must NOT consume the single recovery retry"
+        );
+        assert!(
+            ws.join(".loom/worktrees/issue-4602/dirty.txt").exists(),
+            "the live sweep's uncommitted mid-build work MUST survive"
+        );
+    }
+
+    /// The review-stall watchdog (#3910) must not re-dispatch either — the
+    /// 03:54:25Z re-dispatch in the #4275 timeline.
+    ///
+    /// Unlike the mid-build path this one is *safe* to guard at dispatch time:
+    /// it cancels its own child (SIGTERM → grace → SIGKILL) first and takes no
+    /// destructive action on the worktree, so a refusal after the cancel costs
+    /// nothing. The guard therefore lives in the shared `dispatch` entry point,
+    /// where it also covers a claim held by a sweep this daemon never spawned.
+    #[test]
+    fn review_stall_watchdog_does_not_redispatch_an_issue_with_a_live_claim() {
+        let dir = tempdir().unwrap();
+        let ws = dir.path();
+        let (mut reg, _record_log) = fixture_registry(ws);
+        let sweep = FakeSweep::spawn(4563);
+        write_journal_entry(&reg, &ws.display().to_string(), 4563, sweep.pid());
+
+        // The watchdog's re-dispatch is the only step that can create a second
+        // sweep; assert it is refused for a live-claimed issue.
+        let err = reg
+            .dispatch(&SweepKind::Issue(4563), None, None, None, None)
+            .unwrap_err();
+        assert!(
+            err.downcast_ref::<LiveClaimDispatchError>().is_some(),
+            "the watchdogs' shared re-dispatch entry point must refuse; got: {err}"
+        );
+    }
+
+    /// Release-side half of the fix: a lock whose owner is this very sweep, but
+    /// whose PID is still a live `/loom:sweep <N>` process, is NOT released —
+    /// the caller's dead-sweep verdict was wrong (`HolderAlive`), so the label
+    /// restore and re-dispatch it would have triggered are both skipped.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn release_lock_owned_refuses_when_the_owner_is_a_live_sweep_process() {
+        let dir = tempdir().unwrap();
+        let (registry, _record_log) = fixture_registry(dir.path());
+        let sweep = FakeSweep::spawn(4564);
+        let lock = write_lock_owner(&registry, 4564, "sweep-issue-4564-mine", sweep.pid());
+
+        let outcome = registry.release_lock_owned(4564, "sweep-issue-4564-mine");
+
+        assert_eq!(outcome, LockReleaseOutcome::HolderAlive);
+        assert!(outcome.retained(), "HolderAlive must suppress the label restore / re-dispatch");
+        assert!(lock.exists(), "a live sweep's lock must survive a false-dead release");
+    }
+
+    /// The inverse: a live PID that is *not* a sweep for this issue (a recycled
+    /// PID) must NOT block the release. Without this the guard could wedge an
+    /// issue permanently.
+    #[test]
+    fn release_lock_owned_releases_when_a_live_pid_is_not_this_issues_sweep() {
+        let dir = tempdir().unwrap();
+        let (registry, _record_log) = fixture_registry(dir.path());
+        // Our own PID: live, but its argv is the test binary, not `/loom:sweep`.
+        let lock = write_lock_owner(&registry, 4565, "sweep-issue-4565-mine", std::process::id());
+
+        let outcome = registry.release_lock_owned(4565, "sweep-issue-4565-mine");
+        assert_eq!(outcome, LockReleaseOutcome::Released);
+        assert!(!outcome.retained());
+        assert!(!lock.exists(), "a recycled PID must not wedge the lock");
+    }
+
+    #[test]
+    fn lock_release_outcome_retained_covers_both_refusals() {
+        assert!(!LockReleaseOutcome::Released.retained());
+        assert!(LockReleaseOutcome::Superseded.retained());
+        assert!(LockReleaseOutcome::HolderAlive.retained());
     }
 
     /// Regression (Test Plan item 2, retained guard): two dispatch requests for

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -99,7 +99,9 @@ use crate::capacity::{self, CapacityAdvisory};
 use crate::disk_headroom::disk_headroom_limit;
 use crate::event_bus::EventBus;
 use crate::main_health_gate::{MainHealthState, WorkspaceHealthStates};
-use crate::sweep_registry::{DispatchBackoffError, OpenPrDispatchError, ParkedIssueDispatchError};
+use crate::sweep_registry::{
+    DispatchBackoffError, LiveClaimDispatchError, OpenPrDispatchError, ParkedIssueDispatchError,
+};
 use crate::tokens::{token_pool_size, token_pool_size_at_dir};
 use crate::types::Event;
 use crate::workspace_pool::WorkspacePool;
@@ -733,6 +735,18 @@ pub fn tick_with_admission_cap(
                     // tick start (the window can be armed mid-tick by a reap).
                     report.skipped_backoff += 1;
                     log::info!("work_finder: skipping issue #{} — {e}", item.number);
+                } else if e.downcast_ref::<LiveClaimDispatchError>().is_some() {
+                    // Live-claim guard refusal (#4556): a sweep process for this
+                    // issue is confirmed still running, so this candidate is
+                    // genuinely in flight — `in_flight()` just could not see it
+                    // (a reverted label, a released lock, or another daemon
+                    // instance on this host). Counted as an in-flight skip rather
+                    // than an error, but logged at WARN: reaching here means one
+                    // of those weaker signals lied, which is the #4275
+                    // duplicate-dispatch storm signature and worth an operator's
+                    // attention.
+                    report.skipped_in_flight += 1;
+                    log::warn!("work_finder: skipping issue #{} — {e}", item.number);
                 } else {
                     report.errors += 1;
                     log::warn!("work_finder: dispatch for issue #{} failed: {e}", item.number);
@@ -1065,6 +1079,11 @@ pub fn tick_multi_with_admission_cap<S: WorkSource, D: WorkDispatcher>(
                     // `tick` for the rationale. A skip, not a failure.
                     report.skipped_backoff += 1;
                     log::info!("work_finder: skipping issue #{} — {e}", cand.number);
+                } else if e.downcast_ref::<LiveClaimDispatchError>().is_some() {
+                    // Live-claim guard refusal (#4556) — see the single-workspace
+                    // `tick` for the rationale. An in-flight skip, not a failure.
+                    report.skipped_in_flight += 1;
+                    log::warn!("work_finder: skipping issue #{} — {e}", cand.number);
                 } else {
                     report.errors += 1;
                     log::warn!("work_finder: dispatch for issue #{} failed: {e}", cand.number);
@@ -2454,6 +2473,13 @@ mod tests {
         collisions: u64,
         /// Issue numbers a peer host has soft-claimed over safehouse (#4028).
         peer_claimed: HashSet<u32>,
+        /// Issue numbers whose dispatch should be refused by the live-claim
+        /// guard (#4556) — the dispatcher returns the typed
+        /// [`LiveClaimDispatchError`], as `SweepRegistry::dispatch` step 2.9 does
+        /// when a sweep process for the issue is confirmed still running while
+        /// `in_flight()` cannot see it (a reverted label, a released lock, or a
+        /// second daemon instance on the same host).
+        live_claim_issues: HashSet<u32>,
     }
 
     impl WorkDispatcher for RecordingDispatcher {
@@ -2492,6 +2518,15 @@ mod tests {
                 return Err(ParkedIssueDispatchError {
                     issue,
                     label: "loom:blocked".to_string(),
+                }
+                .into());
+            }
+            if self.live_claim_issues.contains(&issue) {
+                // Mirror the production `SweepRegistry::dispatch` live-claim
+                // guard: refuse with the typed, downcast-matchable error (#4556).
+                return Err(LiveClaimDispatchError {
+                    issue,
+                    evidence: crate::live_claim::LiveClaimEvidence::SweepProcess { pid: 4242 },
                 }
                 .into());
             }
@@ -2828,6 +2863,28 @@ exit 0
 
         assert_eq!(report.skipped_backoff, 1, "#7's refusal is a backoff skip");
         assert_eq!(report.errors, 0, "a backoff refusal is never a dispatch error");
+        assert_eq!(report.dispatched, 1);
+        assert_eq!(disp.dispatched, vec![8]);
+    }
+
+    #[test]
+    fn test_tick_attributes_live_claim_refusal_to_skipped_in_flight() {
+        // #4556: `in_flight()` is scoped to ONE daemon process and is seeded from
+        // labels/locks that a false-dead verdict may already have cleared — so an
+        // issue whose sweep is genuinely still running can reach the dispatch
+        // call. The registry's step-2.9 guard refuses it with the typed
+        // `LiveClaimDispatchError`. That is an in-flight skip (the issue really
+        // IS in flight), never a dispatch error, and it must not consume the
+        // healthy candidate's slot.
+        let mut source = FakeSource::once(vec![issue(4275), issue(8)]);
+        let mut disp = RecordingDispatcher {
+            live_claim_issues: HashSet::from([4275]),
+            ..Default::default()
+        };
+        let report = tick(&mut source, &mut disp, 10, false).unwrap();
+
+        assert_eq!(report.skipped_in_flight, 1, "#4275's refusal is an in-flight skip");
+        assert_eq!(report.errors, 0, "a live-claim refusal is never a dispatch error");
         assert_eq!(report.dispatched, 1);
         assert_eq!(disp.dispatched, vec![8]);
     }

--- a/loom-daemon/tests/common/mod.rs
+++ b/loom-daemon/tests/common/mod.rs
@@ -49,6 +49,40 @@ pub fn daemon_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_loom-daemon"))
 }
 
+/// Confine a to-be-spawned `loom-daemon` to `fixture` for every piece of
+/// **machine-level** state it would otherwise share with the operator's real
+/// daemon (Issue #4556).
+///
+/// Without this, a test daemon inherits the test process's cwd (the crate root)
+/// *and* the real `~/.loom/` files, so it starts up pointed at the operator's
+/// actual managed repositories:
+///
+/// | State | Real location | Consequence of sharing it |
+/// |---|---|---|
+/// | Managed-workspace registry | `~/.loom/workspaces.json` | the startup claim-reconciliation pass and every autonomous tick run against **real repos and real GitHub issues** |
+/// | Sweep liveness journal | `~/.loom/sweeps.json` | a test daemon prunes/rewrites records describing the real daemon's live sweeps |
+/// | Watch registry + results log | `~/.loom/watches.json` | test watches leak into the real daemon's watch set |
+/// | Default sweep workspace | cwd | claim locks and worktree paths resolve inside the real checkout |
+///
+/// This is the confirmed mechanism behind the three #4275 dispatches that had
+/// no entry in the production daemon's log: a debug `loom-daemon` spawned by
+/// the test suite, sharing the real workspace registry, re-dispatching an issue
+/// the production daemon was already sweeping. Isolation **by construction** —
+/// an empty fixture registry lists no managed workspaces, so a test daemon has
+/// nothing to reconcile or dispatch against no matter what it is asked to do.
+///
+/// Each path points at a *non-existent* file inside `fixture`; every loader
+/// treats a missing file as empty state and creates it on first write, so no
+/// pre-seeding is required.
+#[allow(dead_code)]
+pub fn isolate_daemon_state(cmd: &mut Command, fixture: &Path) {
+    cmd.current_dir(fixture)
+        .env("LOOM_WORKSPACES_PATH", fixture.join("workspaces.json"))
+        .env("LOOM_SWEEPS_JOURNAL_PATH", fixture.join("sweeps.json"))
+        .env("LOOM_WATCHES_PATH", fixture.join("watches.json"))
+        .env("LOOM_WATCH_RESULTS_LOG", fixture.join("watch-results.log"));
+}
+
 /// Test daemon instance that cleans up on drop
 #[allow(dead_code)]
 pub struct TestDaemon {
@@ -73,8 +107,8 @@ impl TestDaemon {
         // and falls back to the default) and inside the `TempDir`.
         let worktree_root = temp_dir.path().join("worktrees");
 
-        let mut process = Command::new(daemon_bin())
-            .env("LOOM_SOCKET_PATH", &socket_path)
+        let mut cmd = Command::new(daemon_bin());
+        cmd.env("LOOM_SOCKET_PATH", &socket_path)
             .env("RUST_LOG", "debug")
             // Disable restore_from_tmux() to prevent cross-test-binary contamination
             // via the shared tmux server. Each test manages its own terminals.
@@ -110,7 +144,15 @@ impl TestDaemon {
             // the invoking environment. Note the daemon namespaces an
             // *override* by repo basename, so the effective root is
             // `<temp>/worktrees/<temp-basename>` — still inside the `TempDir`.
-            .env("LOOM_WORKTREE_ROOT", &worktree_root)
+            .env("LOOM_WORKTREE_ROOT", &worktree_root);
+        // #4556: confine every *remaining* machine-level file (sweep journal,
+        // watch registry, watch-results log) and the cwd-derived default
+        // workspace to this fixture too, so a test daemon can never reconcile,
+        // dispatch against, or rewrite liveness state for the operator's real
+        // repositories. Complements the #4573 vars set above (which already
+        // pin the workspace registry and worktree root).
+        isolate_daemon_state(&mut cmd, temp_dir.path());
+        let mut process = cmd
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()

--- a/loom-daemon/tests/integration_drain_then_exit.rs
+++ b/loom-daemon/tests/integration_drain_then_exit.rs
@@ -16,7 +16,7 @@
 
 mod common;
 
-use common::{daemon_bin, TestClient};
+use common::{daemon_bin, isolate_daemon_state, TestClient};
 use serial_test::serial;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -53,15 +53,17 @@ async fn test_drain_then_exit_exits_143_and_stays_down() {
     // An empty workspace registry + a scratch workspace root guarantee the
     // cross-root in-flight count is 0, so the drain reaches its terminal tick
     // immediately instead of waiting on this host's real sweeps.
-    let workspaces_json = temp_dir.path().join("workspaces.json");
     let workspace_root = temp_dir.path().join("workspace");
     std::fs::create_dir_all(&workspace_root).expect("create workspace root");
 
+    let mut cmd = Command::new(daemon_bin());
+    // Shared #4556 confinement (empty fixture workspace registry, fixture sweep
+    // journal / watch files, fixture cwd) — the generalized form of the
+    // isolation this test has always needed.
+    isolate_daemon_state(&mut cmd, temp_dir.path());
     let mut child = ChildGuard(
-        Command::new(daemon_bin())
-            .current_dir(&workspace_root)
+        cmd.current_dir(&workspace_root)
             .env("LOOM_SOCKET_PATH", &socket_path)
-            .env("LOOM_WORKSPACES_PATH", &workspaces_json)
             // Pinned, not merely inherited: this test may run on a host that is
             // itself running Loom, where an inherited `LOOM_WORKSPACE` makes the
             // scratch daemon count that repo's REAL in-flight sweeps and the

--- a/loom-daemon/tests/integration_singleton_guard.rs
+++ b/loom-daemon/tests/integration_singleton_guard.rs
@@ -10,7 +10,7 @@
 
 mod common;
 
-use common::{cleanup_test_sessions, daemon_bin, TestClient, TestDaemon};
+use common::{cleanup_test_sessions, daemon_bin, isolate_daemon_state, TestClient, TestDaemon};
 use serial_test::serial;
 use std::io::BufRead;
 use std::os::unix::fs::FileTypeExt;
@@ -68,6 +68,13 @@ const REFUSAL_MARKER: &str = "refusing to start";
 /// inert and the main reason these tests were load-sensitive (#4531).
 fn daemon_command(socket_path: &Path, workspace: &Path) -> Command {
     let mut cmd = Command::new(daemon_bin());
+    // The refusal path is reached before any workspace work, but a daemon that
+    // does NOT refuse (the failure these tests detect) would otherwise come up
+    // pointed at the operator's real machine-level state — sweep journal, watch
+    // registry, cwd-derived default workspace — so confine all of it to the
+    // per-test fixture first (#4556). Complements the #4573 vars below, which
+    // pin the workspace registry and worktree root.
+    isolate_daemon_state(&mut cmd, workspace);
     cmd.env("LOOM_SOCKET_PATH", socket_path)
         .env("RUST_LOG", "debug")
         .env("LOOM_NO_RESTORE", "1")


### PR DESCRIPTION
Closes #4556

## Problem

Issue #4275 was dispatched **seven times in 77 minutes** onto one shared worktree, with four sweeps alive at once. Every dedup signal the daemon had was either scoped to one process or only proved a file exists:

| Signal | Weakness |
|---|---|
| `in_flight()` / `issue_has_active_sweep` | in-memory; invisible to a second `loom-daemon` on the same host (3 of the 7 dispatches) |
| `loom:building` label | reverted by `claim_reconciliation` the moment a recorded PID *looks* dead (confirmed on #4275 at 03:08:15Z) |
| `.loom/locks/issue-<N>/` (`acquire_lock`) | existence-only — and every reaper / cancel / watchdog path *releases* it first, on the strength of its own dead-sweep verdict, so there was nothing left to collide with |

#4463 made the lock *release* ownership-checked, which stops a dying sweep from clobbering a lock a **newer** sweep re-acquired. But it still trusts the caller's assertion that the sweep it names is dead — the exact assumption that failed here. This PR adds the missing dispatch-time half.

## What this adds

New `loom-daemon/src/live_claim.rs`: a **read-only** probe answering the strictly stronger question — *is a sweep process for issue N confirmed running right now?* Three short-circuiting evidence legs, cheapest first:

1. **Live claim lock** — `.loom/locks/issue-<N>/owner.json` whose `owner_pid` is live. Unlike `acquire_lock`'s existence check this distinguishes a live holder from an abandoned dir, so it is safe to consult *before* a release.
2. **Machine-level sweep journal** — a live record in `~/.loom/sweeps.json`. Matched across *related* repo roots, so a daemon running out of `.loom/worktrees/issue-N` and one running out of the parent checkout see each other's claims (path-component-wise, so `/repo/loom` and `/repo/loom-2` stay unrelated).
3. **Live sweep process scan** — `/proc` scan for a process whose cwd is inside the workspace and whose argv contains `/loom:sweep <N>`. The last-resort leg that catches a sweep no local bookkeeping knows about — the exact signature of #4275's three unattributed dispatches.

Each leg survives a lock release, a label revert, a daemon restart, **and** a second daemon instance.

### Gated at four sites

| Site | Refusal |
|---|---|
| `SweepRegistry::dispatch` **step 2.9** | typed `LiveClaimDispatchError`, before any lock, label write or forge call — so one check covers all six dispatch routes (work-finder, epic supervisor, IPC/CLI, all three watchdogs). The work-finder attributes it to `skipped_in_flight`, never `errors`. |
| `midbuild_watchdog_once` | refuses **up front**. This was the important find: that path `git reset --hard`s the shared worktree and burns its single recovery retry *before* it calls `dispatch`, so a step-2.9 refusal would arrive after the live sweep's uncommitted work was already destroyed. |
| `release_lock_owned` | new `LockReleaseOutcome::HolderAlive` when the lock's own owner PID is still a live `/loom:sweep <N>` process; folded into cancel/reap via a shared `retained()` predicate alongside `Superseded`. |
| `claim_reconciliation` | `apply_live_claim_veto` downgrades a `Reclaim` to `Keep`, so `loom:building` is not reverted out from under a working sweep. |

The review-stall watchdog is deliberately guarded only at dispatch time: it cancels its own child first and takes no destructive action on the worktree, so a refusal after the cancel costs nothing.

### Fail-open by design

Missing/corrupt `owner.json`, unreadable journal, no `/proc`, zombie PIDs, and — critically — a **live PID whose argv does not name this issue's sweep** (a recycled PID behind a stale record) all resolve to "no evidence". Only positively-confirmed liveness ever refuses, so a garbage file can never wedge an issue permanently. On non-Linux hosts, where argv is unreadable, the bookkeeping legs fall back to bare liveness — the same signal every pre-#4556 check already used, so the guard is never *weaker* than the code it supplements.

## Stray-debug-daemon lead: confirmed and closed

The issue's unconfirmed lead is real. `TestDaemon::start()` spawned the real binary with **no cwd override and no `LOOM_WORKSPACES_PATH`**, so every integration-test daemon came up reading the operator's real `~/.loom/workspaces.json` — and this repo's `.loom/config.json` has `autonomous.roleRunner.enabled=true`. A test daemon could therefore run its startup claim-reconciliation pass and autonomous ticks against **real repos and real GitHub issues**.

`isolate_daemon_state()` now confines the workspace registry, sweep journal, watch registry, watch results log, and cwd to a per-test fixture, for all three daemon-spawning test sites. Isolation **by construction**: an empty fixture registry lists no managed workspaces, so a test daemon has nothing to reconcile or dispatch against regardless of what it is asked to do. (`integration_drain_then_exit` had hand-rolled a subset of this; it now uses the shared helper.)

## Per-issue worktree lock — considered, not added

Acceptance criterion 5 asks to *consider* a per-issue worktree lockfile. Rejected as redundant: leg 3 is already a cwd-scoped, per-worktree liveness check that needs no new on-disk state to go stale, and it composes with the existing `#4449` `worktree_in_use` veto (`.loom-in-use` marker / `index.lock` / live process cwd). A fourth lock file would add a new wedge surface for no new coverage.

## Tests

Full `cargo test --lib`: **2523 passed, 0 failed**. `cargo fmt --all --check`, the CI `cargo clippy` invocation, and `cargo check --workspace --all-targets` are all clean. `cargo test --test integration_drain_then_exit` passes.

New coverage:

- `live_claim`: all three legs (live/dead/corrupt/missing/wrong-issue), nested-worktree repo relation, component-wise `repos_are_related`, argv matcher (exact issue token, `/loom:sweeper`, PR-set mode, repeated-needle termination), composed `probe` precedence, and the recycled-PID non-wedge case.
- `dispatch_refuses_when_the_claim_lock_owner_is_live` / `…_journal_records_a_live_sweep_and_the_lock_is_gone` (the gap #4463 could not close) / `…_a_nested_worktree_daemon_holds_the_claim`.
- **Test Plan item 2**: `n_dispatch_requests_for_a_live_issue_produce_zero_extra_sweeps` — five requests against one live issue, all refused, no entry and no lock write.
- **Test Plan item 1**: `midbuild_watchdog_does_not_recover_an_issue_with_a_live_claim` asserts the uncommitted work survives and the single retry is *not* consumed, with a precondition asserting the `#4449` veto is not what refused; `midbuild_watchdog_recovers_once_the_live_claim_is_gone` pins the inverse so the guard cannot wedge recovery. Plus the review-stall equivalent.
- Non-wedge guards: `dispatch_proceeds_when_every_recorded_claim_pid_is_dead`, `dispatch_ignores_a_live_claim_from_an_unrelated_repo`, `release_lock_owned_releases_when_a_live_pid_is_not_this_issues_sweep`.

Tests use a `FakeSweep` RAII stand-in (`sh -c 'sleep 120' '/loom:sweep <N> …'`) rather than the test binary's own PID, so the argv verification is exercised for real. `Command::spawn` returns at *fork*, not exec, so a shared `wait_until_argv_visible` helper blocks until the child's argv is actually observable — without it the argv-verifying assertions flake under a loaded full-suite run (caught during this work: three tests passed alone, failed in the full suite).

## Notes for the reviewer

- `integration_singleton_guard` was **not** run locally: its `cleanup_all_loom_sessions()` kills every `loom-*` tmux session on the host, which would disrupt this machine's live Loom. It compiles and its only change is the isolation call. (That nuclear cleanup is a pre-existing hazard, out of scope here.)
- Acceptance criterion 4 (PID-liveness race in `claim_reconciliation`) is addressed by *vetoing* the reclaim with stronger evidence rather than by re-litigating the recorded-PID check itself — a dead leader PID genuinely can coexist with a working sweep, so the check is not wrong, it is just insufficient on its own.
