### PR TITLE
fix(judge,doctor,champion): add verdict-time CAS recheck and verdict-label janitor

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -36,6 +36,22 @@
 # - loom:reviewing (Judge reviewing PR)
 # - loom:treating (Doctor fixing bug/PR feedback)
 
+# PR verdict-label mutual exclusion (#4570): {loom:review-requested,
+# loom:reviewing, loom:changes-requested, loom:pr} form a mutually-exclusive
+# verdict class on a PR — at most ONE of these four should be present at a
+# time, with one legal transient exception: `loom:review-requested` and
+# `loom:reviewing` may coexist while a Judge's claim is active (the review is
+# in progress but has not yet produced a verdict). `loom:changes-requested`
+# and `loom:pr` are terminal verdicts and must never coexist with each other,
+# nor with a live `loom:reviewing` claim from a DIFFERENT actor's concurrent
+# review. A PR observed carrying `loom:pr` + `loom:changes-requested`
+# simultaneously is in an off-graph, contradictory state (see the PR #4560
+# incident, 2026-07-30) that must never be auto-merged — Champion's
+# Verdict-State Janitor (defaults/.claude/commands/loom/champion-pr-merge.md)
+# resolves it fail-safe (`loom:changes-requested` wins), and Judge/Doctor's
+# Verdict-Time CAS Recheck (judge.md / doctor.md) is the write-time guard that
+# prevents it from being produced in the first place.
+
 # Role-Specific Workflow Labels
 - name: loom:building
   description: "Builder is implementing this issue. Applied by: Builder only (claim label)."

--- a/defaults/.claude/commands/loom/champion-pr-merge.md
+++ b/defaults/.claude/commands/loom/champion-pr-merge.md
@@ -12,6 +12,61 @@ The Champion acts as the final step in the PR pipeline, merging PRs that have pa
 
 ---
 
+## Verdict-State Janitor (run FIRST, before the 6 safety criteria)
+
+**Every `loom:pr` PR must pass this janitor step before any of the 6 safety
+criteria below are evaluated.** It is a fail-safe against a real race
+(#4570, PR #4560 incident, 2026-07-30): two Judges reviewing the same PR
+concurrently can leave it carrying **both** `loom:pr` and
+`loom:changes-requested` simultaneously — an off-graph state the label
+lifecycle never intends to produce (see the mutual-exclusion invariant
+documented in `.github/labels.yml`). Judge's and Doctor's Verdict-Time CAS
+Recheck (`judge.md` / `doctor.md`) prevent this at write time going forward,
+but this janitor is the mechanized fail-safe for any instance that still
+slips through (a pre-existing contradictory state from before this fix
+shipped, a manual label edit, or a bug elsewhere) — mechanizing exactly the
+manual correction the incident required a human-in-the-loop Judge to perform.
+
+**Verification / resolution command** (run once per candidate `loom:pr` PR,
+before Step 1 of the 6 criteria below):
+
+```bash
+PR_NUMBER=<number>
+LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | join(",")')
+
+if echo "$LABELS" | grep -qw "loom:changes-requested"; then
+  JANITOR_MARKER="<!-- champion:verdict-janitor-notice -->"
+  # Idempotency guard — mirrors the stale-PR notice pattern below: only
+  # comment + relabel once per contradictory episode, so a 10-minute cron
+  # tick doesn't re-post while the contradiction is being resolved.
+  if gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -qF "$JANITOR_MARKER"; then
+    echo "Verdict-janitor notice already posted for #$PR_NUMBER — skipping (still not eligible to merge)"
+  else
+    gh pr comment "$PR_NUMBER" --body "$JANITOR_MARKER
+**Champion: Verdict-State Janitor**
+
+This PR carries both \`loom:pr\` and \`loom:changes-requested\` simultaneously — a contradictory verdict state that should never coexist (see the mutual-exclusion invariant in \`.github/labels.yml\`). This usually means two Judges reviewed the PR concurrently and their verdicts raced.
+
+Resolving fail-safe: \`loom:changes-requested\` wins. Removing \`loom:pr\` so this PR is not auto-merged. Doctor will address the outstanding rejection; re-request Judge review once addressed.
+
+---
+*Automated by Champion role*"
+    gh pr edit "$PR_NUMBER" --remove-label "loom:pr"
+    echo "Resolved contradictory verdict state on #$PR_NUMBER (loom:pr removed) — skipping merge"
+  fi
+  # Skip this PR entirely for this pass — do not proceed to the 6 safety
+  # criteria and do not merge. In a batch loop: `continue`. In a single-PR
+  # invocation: exit without merging.
+fi
+```
+
+**Never merge a PR that failed this janitor check in the same pass** — even
+though the janitor just removed `loom:pr`, a fresh Judge pass on the
+corrected state (which re-adds `loom:pr` if it approves) is what makes the PR
+eligible again, not this loop continuing on to the 6 criteria below.
+
+---
+
 ## Safety Criteria
 
 For each `loom:pr` PR, verify ALL 6 safety criteria. If ANY criterion fails, do NOT merge.
@@ -27,6 +82,16 @@ LABELS=$(gh pr view <number> --json labels --jq '.labels[].name' | tr '\n' ' ')
 # Check for loom:pr label
 if ! echo "$LABELS" | grep -q "loom:pr"; then
   echo "FAIL: Missing loom:pr label"
+  exit 1
+fi
+
+# Check for a contradictory loom:changes-requested alongside loom:pr. The
+# Verdict-State Janitor above should already have resolved this before
+# criterion evaluation ever runs, but this check is defense-in-depth: if a
+# PR somehow reaches here still carrying both labels, fail closed rather
+# than silently auto-merging over an open Judge rejection (#4570).
+if echo "$LABELS" | grep -q "loom:changes-requested"; then
+  echo "FAIL: loom:changes-requested present alongside loom:pr (contradictory verdict state)"
   exit 1
 fi
 

--- a/defaults/.claude/commands/loom/champion-reference.md
+++ b/defaults/.claude/commands/loom/champion-reference.md
@@ -317,7 +317,7 @@ gh issue create --title "Follow-on: Work identified in PR #$PR_NUMBER" --label "
 
 This file previously carried a second, full copy of the end-to-end merge script. That duplicate diverged from `champion-pr-merge.md` over time (it lacked Step 5.5 Follow-on Issue Creation and repeated the same bugs — invalid `gh pr checks --json` fields, etc.), forcing every fix to be applied twice. It has been removed to eliminate the drift (issue #3781).
 
-For the authoritative, end-to-end implementation — the 6 safety criteria, the pre-merge comment, the squash merge via `merge-pr.sh`, linked-issue closure verification, dependent-issue unblocking, and Step 5.5 Follow-on Issue Creation — see **`champion-pr-merge.md`**. The edge cases and decision matrix above remain here as the reference for non-standard situations; they describe *behavior*, and defer to `champion-pr-merge.md` for the *script*.
+For the authoritative, end-to-end implementation — the Verdict-State Janitor (run before all else, resolves a contradictory `loom:pr` + `loom:changes-requested` state fail-safe, #4570), the 6 safety criteria, the pre-merge comment, the squash merge via `merge-pr.sh`, linked-issue closure verification, dependent-issue unblocking, and Step 5.5 Follow-on Issue Creation — see **`champion-pr-merge.md`**. The edge cases and decision matrix above remain here as the reference for non-standard situations; they describe *behavior*, and defer to `champion-pr-merge.md` for the *script*.
 
 ---
 

--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -382,7 +382,7 @@ gh pr edit 588 --remove-label "loom:treating" --add-label "loom:review-requested
      ```
      This discovers open child PRs stacked on your branch and rebases any that went stale onto your new tip (safe children auto-rebase + force-with-lease; children whose issue is still `loom:building` get a deferred-reconciliation comment instead). It is a no-op when there are no stacked children. This is **best-effort** — a failure here (rebase conflict, non-GitHub forge) never fails your own Doctor work; carry on to step 10. Preview first with `--dry-run` if unsure.
 10. **Verify CI remotely**: Run `gh pr checks <number>` after push to confirm all checks pass
-11. **Signal completion and unclaim**:
+11. **Signal completion and unclaim** (run the Verdict-Time CAS Recheck — see below — immediately before this write; abort/stand down instead if it finds your claim lost or the PR already moved):
     - Remove `loom:changes-requested` and `loom:treating` labels
     - Add `loom:review-requested` label (green badge)
     - Comment to notify reviewer that feedback is addressed
@@ -498,12 +498,47 @@ Do **not** add `loom:review-requested` when standing down — the Doctor who
 actually pushed owns that transition. Leave the PR's state labels alone and
 exit; your only label action is removing your own claim.
 
+### Verdict-Time CAS Recheck (Step 11 — immediately before the completion label write)
+
+The Pre-Push Head-SHA Recheck above catches a concurrent **code** race. It
+does not catch a concurrent **label** race: while you were fixing and
+pushing, another actor may already have changed the PR's label state — a
+Judge reclaimed `loom:treating` as stale and is now reviewing it fresh, or
+another Doctor already completed the same fix and wrote
+`loom:review-requested`. GitHub's label API has no compare-and-swap, so
+nothing stops your completion write from landing on top of that in-flight
+state (the Judge-side analog of this raced in the PR #4560 incident,
+2026-07-30 — see `judge.md`'s "Verdict-Time CAS Recheck" and the
+mutual-exclusion invariant in `.github/labels.yml`).
+
+**Immediately before Step 11's completion write** (`loom:changes-requested` +
+`loom:treating` → `loom:review-requested`), re-read the PR's current labels:
+
+```bash
+N=<pr-number>
+CURRENT_LABELS=$(gh pr view $N --json labels --jq '[.labels[].name] | join(",")')
+```
+
+| Condition | Verdict | Action |
+|-----------|---------|--------|
+| `loom:treating` is still present (your claim intact), and neither `loom:review-requested` nor `loom:pr` is already present | **Safe** | Proceed with the completion write as planned. |
+| `loom:treating` was removed or replaced (e.g. reclaimed as stale by another Doctor, or a Judge/Champion touched the PR while you worked) | **Claim lost** | **ABORT.** Do not write the completion label — use the "Standing down" flow above (comment, remove only your own claim if still present, exit). |
+| `loom:review-requested` or `loom:pr` is already present | **Raced** | **ABORT.** Another Doctor already completed this fix, or the PR moved forward without you. Do not write a duplicate or contradictory label — comment and stand down instead. |
+| The `gh pr view` call fails or returns empty | **Unknown — fail safe** | Do NOT write the completion label. Retry the recheck once; if it still fails, abort and note the API failure rather than guessing. |
+
+This is the same technique as the Pre-Push Head-SHA Recheck, applied to the
+**label** state instead of the code state — re-run immediately before the
+write that actually matters, not just at claim time.
+
 **Pre-completion checklist** (verify before signaling completion):
 - [ ] All CI checks pass (verified via `gh pr checks <number>`)
 - [ ] I ran the stale `loom:treating` claim check before claiming (skipped the PR
       on a fresh claim; reclaimed only on a stale one)
 - [ ] I re-compared the PR's `headRefOid` against `CLAIM_HEAD_SHA` immediately
       before pushing, and on a mismatch re-verified the blocker (or stood down)
+- [ ] I re-read the PR's labels immediately before the completion write (Verdict-Time
+      CAS Recheck above), and aborted/stood down on a lost claim or a raced verdict
+      label instead of writing over it
 - [ ] My commit(s) address the specific feedback quoted from the Judge's review
 - [ ] If any comment I posted came from a scratch file, I used `--body-file
       <path>` (or `gh api -F body=@<path>`) — NEVER `--body @<path>` (see the
@@ -819,6 +854,12 @@ if [ -n "$CURRENT_HEAD_SHA" ] && [ "$CURRENT_HEAD_SHA" != "$CLAIM_HEAD_SHA" ]; t
 fi
 
 git push
+
+# Verdict-Time CAS Recheck — re-read labels one more time before the
+# completion write (see "Verdict-Time CAS Recheck" above); abort/stand down
+# instead of writing if loom:treating is gone or loom:review-requested/loom:pr
+# already appeared.
+CURRENT_LABELS=$(gh pr view 42 --json labels --jq '[.labels[].name] | join(",")')
 
 # Signal completion and unclaim (amber → green, remove in-progress)
 gh pr edit 42 --remove-label "loom:changes-requested" --remove-label "loom:treating" --add-label "loom:review-requested"

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -161,6 +161,8 @@ If no argument is provided, use the normal finding work workflow below.
 gh pr list --label="loom:review-requested" --state=open
 ```
 
+**Before either command below, run the Verdict-Time CAS Recheck** (see "Verdict-Time CAS Recheck" under Evaluation Process) — abort instead of writing if the recheck finds your claim lost or another Judge's verdict already landed.
+
 **After approval (green → blue) — BOTH commands are REQUIRED:**
 ```bash
 gh pr comment <number> --body "LGTM! Code quality is excellent, tests pass, implementation is solid." && \
@@ -299,7 +301,7 @@ fi
 8. **Verify CI status**: Check GitHub CI passes before approving (see CI Status Check below)
 9. **Evaluate changes**: Examine diff, look for issues, suggest improvements
 10. **Provide feedback**: Use `gh pr comment` to provide evaluation feedback
-11. **Update labels** (⚠️ NEVER use `gh pr review` - see warning at top of file). **The label update is the PRIMARY deliverable — always run it immediately after the comment using `&&`:**
+11. **Update labels** (⚠️ NEVER use `gh pr review` - see warning at top of file). **Run the Verdict-Time CAS Recheck (see below) immediately before this step** — abort instead of writing if it finds your claim lost or another Judge's verdict already landed. **The label update is the PRIMARY deliverable — always run it immediately after the comment using `&&`:**
    - If approved: `gh pr comment ... && gh pr edit <number> --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:pr"` (blue badge - ready for Champion auto-merge)
    - If changes needed: `gh pr comment ... && gh pr edit <number> --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:changes-requested"` (amber badge - Doctor will address)
 
@@ -366,6 +368,54 @@ below, and any cron-invoked pass over `loom:review-requested` PRs: a
 cron-invoked Judge and a `/loom:sweep`-dispatched Judge must apply the
 identical rule so neither stomps the other's fresh claim nor stalls behind a
 dead one.
+
+### Verdict-Time CAS Recheck (MANDATORY immediately before every verdict-label write)
+
+The Stale Claim Check above closes the race window at **claim time** (step 2).
+It does not close the window that opens **while you review**: a full
+evaluation (rebase, tests, CI wait) can run several minutes, and GitHub's
+label API has no compare-and-swap — two Judges can each pass their own claim
+check and then both still write a verdict label, because nothing re-validates
+the PR's label state in between claim and write. This is exactly what
+happened in the PR #4560 incident (2026-07-30): Judge B's approval write
+landed 8 minutes into Judge A's still-fresh `loom:reviewing` claim, leaving
+the PR carrying `loom:pr` **and** `loom:changes-requested` simultaneously
+until Judge A manually corrected it — a state that would have let Champion
+auto-merge a PR with an open rejection (see the mutual-exclusion invariant in
+`.github/labels.yml`).
+
+**Immediately before running ANY verdict-label-writing command in this
+document** — the primary approve/reject write (Label Workflow, Step 11), the
+DIRTY/merge-conflict fallback writes, the CI-failure rejection, the fast-track
+approval, the minor-PR-description-fix approval, and the trivial-fix approval
+— re-read the PR's current labels one more time:
+
+```bash
+N=<pr-number>
+CURRENT_LABELS=$(gh pr view $N --json labels --jq '[.labels[].name] | join(",")')
+```
+
+Then decide:
+
+| Condition | Verdict | Action |
+|-----------|---------|--------|
+| `loom:reviewing` is still present (your claim intact), and neither `loom:pr` nor `loom:changes-requested` has appeared | **Safe** | Proceed with the verdict write as planned. |
+| `loom:reviewing` was removed or replaced (e.g. reclaimed as stale by another Judge while you were still working) | **Claim lost** | **ABORT.** Discard your verdict — do not write any label. Post a short standing-down note (see below). Do NOT re-add `loom:reviewing`. |
+| A verdict label (`loom:pr` or `loom:changes-requested`) is already present that you did not just write | **Raced** | **ABORT.** Another Judge's verdict landed first. Discard your verdict and post a short note citing the label you observed — do NOT overwrite their verdict, even if you disagree with it (raise disagreement as a plain PR comment, not a second label write). |
+| The `gh pr view` call fails or returns empty | **Unknown — fail safe** | Treat as raced/claim-lost: do NOT write the verdict. Retry the recheck once; if it still fails, abort and note the API failure rather than guessing. |
+
+**Standing down** (claim lost or raced):
+
+```bash
+gh pr comment $N --body "Standing down: re-checked labels immediately before writing my verdict and found <loom:reviewing removed | loom:pr or loom:changes-requested already present> — another Judge's verdict raced mine. Discarding my review; not writing any label."
+```
+
+This shrinks the race window from the full review duration (minutes) to the
+gap between the recheck and the write (seconds). It is not a new mechanism —
+it is the existing Stale Claim Check re-run one more time, at the point that
+actually matters (the write), not just at claim entry. Doctor applies the
+analogous recheck (label state, not just head SHA) immediately before its own
+completion write — see `doctor.md`'s "Verdict-Time CAS Recheck".
 
 **Pre-approval checklist** (verify before executing approval commands):
 - [ ] I am using `gh pr comment`, NOT `gh pr review`
@@ -596,6 +646,11 @@ gh pr view <number> --json mergeStateStatus --jq '.mergeStateStatus'
 
 This reduces the Doctor→Judge→Merge cycle by handling simple conflicts directly.
 
+**Both `gh pr edit` fallback writes below are verdict-label writes** — run the
+Verdict-Time CAS Recheck immediately before each one (see "Verdict-Time CAS
+Recheck" above) and abort instead of writing if it finds your claim lost or
+another Judge's verdict already landed.
+
 ```bash
 PR_NUMBER=<number>
 MERGE_STATE=$(gh pr view $PR_NUMBER --json mergeStateStatus --jq '.mergeStateStatus')
@@ -723,6 +778,8 @@ gh pr comment <number> --body "🔀 Rebased branch and resolved merge conflict (
 
 ### For Complex Conflicts (Request Changes)
 
+Run the Verdict-Time CAS Recheck immediately before the `gh pr edit` below.
+
 ```bash
 git rebase --abort
 gh pr comment <number> --body "$(cat <<'FEEDBACK'
@@ -801,7 +858,7 @@ gh pr view <PR_NUMBER> --json mergeStateStatus --jq '.mergeStateStatus'
 
 ### When CI Fails
 
-If CI checks are failing, **do NOT approve**. Instead, apply `loom:ci-failure` for visibility:
+If CI checks are failing, **do NOT approve**. Instead, apply `loom:ci-failure` for visibility. Run the Verdict-Time CAS Recheck immediately before the `gh pr edit` below.
 
 ```bash
 gh pr comment <number> --body "$(cat <<'EOF'
@@ -937,7 +994,7 @@ gh pr checks <PR_NUMBER>
 gh pr view <PR_NUMBER> --json mergeStateStatus --jq '.mergeStateStatus'
 ```
 
-**4. Approve with fast-track audit trail:**
+**4. Approve with fast-track audit trail** (run the Verdict-Time CAS Recheck immediately before the `gh pr edit` below):
 
 ```bash
 gh pr comment <PR_NUMBER> --body "$(cat <<'EOF'
@@ -1134,7 +1191,7 @@ echo -e "\nCloses #123" >> /tmp/pr-body.txt
 gh pr edit <number> --body-file /tmp/pr-body.txt
 ```
 
-**Step 3: Document the change in your comment**
+**Step 3: Document the change in your comment** (run the Verdict-Time CAS Recheck immediately before the `gh pr edit` below)
 
 ```bash
 # Comment with approval note about the fix
@@ -1217,7 +1274,7 @@ git commit -m "Remove unused import (during evaluation)"
 git push
 ```
 
-**Step 5: Note the fix in your approval comment**
+**Step 5: Note the fix in your approval comment** (run the Verdict-Time CAS Recheck immediately before the `gh pr edit` below)
 
 ```bash
 gh pr comment <number> --body "$(cat <<'EOF'

--- a/defaults/.github/labels.yml
+++ b/defaults/.github/labels.yml
@@ -36,6 +36,22 @@
 # - loom:reviewing (Judge reviewing PR)
 # - loom:treating (Doctor fixing bug/PR feedback)
 
+# PR verdict-label mutual exclusion (#4570): {loom:review-requested,
+# loom:reviewing, loom:changes-requested, loom:pr} form a mutually-exclusive
+# verdict class on a PR — at most ONE of these four should be present at a
+# time, with one legal transient exception: `loom:review-requested` and
+# `loom:reviewing` may coexist while a Judge's claim is active (the review is
+# in progress but has not yet produced a verdict). `loom:changes-requested`
+# and `loom:pr` are terminal verdicts and must never coexist with each other,
+# nor with a live `loom:reviewing` claim from a DIFFERENT actor's concurrent
+# review. A PR observed carrying `loom:pr` + `loom:changes-requested`
+# simultaneously is in an off-graph, contradictory state (see the PR #4560
+# incident, 2026-07-30) that must never be auto-merged — Champion's
+# Verdict-State Janitor (defaults/.claude/commands/loom/champion-pr-merge.md)
+# resolves it fail-safe (`loom:changes-requested` wins), and Judge/Doctor's
+# Verdict-Time CAS Recheck (judge.md / doctor.md) is the write-time guard that
+# prevents it from being produced in the first place.
+
 # Role-Specific Workflow Labels
 - name: loom:building
   description: "Builder is implementing this issue. Applied by: Builder only (claim label)."

--- a/defaults/scripts/check-cas-recheck-consistency.sh
+++ b/defaults/scripts/check-cas-recheck-consistency.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# check-cas-recheck-consistency.sh - Regression guard for the verdict-time
+# CAS recheck + verdict-label mutual-exclusion janitor (#4570).
+#
+# Why: #4570 closed a real incident (PR #4560, 2026-07-30) where two
+# concurrent Judges produced a contradictory `loom:pr` + `loom:changes-requested`
+# label state on the same PR. The fix is prompt/doc-only (Option A — these are
+# role prompts, not compiled code), so there is no compiler to catch a
+# regression if a future edit strips the recheck sections back out, or if the
+# Champion janitor / criterion-1 fix gets silently reverted. This script is
+# the executable tie that would fail CI if any of that guidance regresses.
+#
+# What it checks:
+#   1. defaults/.claude/commands/loom/judge.md contains the Verdict-Time CAS
+#      Recheck section, and its symlinked defaults/roles/judge.md resolves to
+#      the same content (single-source-of-truth invariant, not a copy-drift
+#      check — see #1185).
+#   2. Same for doctor.md.
+#   3. defaults/.claude/commands/loom/champion-pr-merge.md contains the
+#      Verdict-State Janitor section AND criterion 1's verification snippet
+#      actually checks for loom:changes-requested (not just loom:pr presence).
+#   4. .github/labels.yml and defaults/.github/labels.yml both document the
+#      verdict-label mutual-exclusion invariant (byte-identity between the
+#      two files is separately enforced by check-labels-drift.sh).
+#
+# Usage:
+#   check-cas-recheck-consistency.sh [ROOT]
+#     ROOT  Repository root. Defaults to `git rev-parse --show-toplevel`, then
+#           the script's own repo root. If <ROOT>/defaults does not exist
+#           (e.g. an installed downstream repo with no source tree), the
+#           check is a clean no-op.
+#
+# Exit codes: 0 = all checks pass (or nothing to check); 1 = a regression was
+# detected (details printed to stderr).
+
+set -euo pipefail
+
+# --- Resolve ROOT -----------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ $# -ge 1 && -n "${1:-}" ]]; then
+  ROOT="$1"
+else
+  if ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+  else
+    # defaults/scripts/ -> defaults/ -> repo root
+    ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+  fi
+fi
+
+if [[ ! -d "$ROOT/defaults" ]]; then
+  echo "check-cas-recheck-consistency: no defaults/ under $ROOT — nothing to check (ok)."
+  exit 0
+fi
+
+FAIL=0
+
+fail() {
+  echo "check-cas-recheck-consistency: FAIL — $1" >&2
+  FAIL=1
+}
+
+# --- 1 & 2: Judge / Doctor Verdict-Time CAS Recheck section present ---------
+JUDGE_MD="$ROOT/defaults/.claude/commands/loom/judge.md"
+JUDGE_SYMLINK="$ROOT/defaults/roles/judge.md"
+DOCTOR_MD="$ROOT/defaults/.claude/commands/loom/doctor.md"
+DOCTOR_SYMLINK="$ROOT/defaults/roles/doctor.md"
+CHAMPION_MERGE_MD="$ROOT/defaults/.claude/commands/loom/champion-pr-merge.md"
+LABELS_ROOT="$ROOT/.github/labels.yml"
+LABELS_DEFAULTS="$ROOT/defaults/.github/labels.yml"
+
+for f in "$JUDGE_MD" "$DOCTOR_MD" "$CHAMPION_MERGE_MD" "$LABELS_ROOT" "$LABELS_DEFAULTS"; do
+  if [[ ! -f "$f" ]]; then
+    fail "missing expected file: ${f#"$ROOT"/}"
+  fi
+done
+
+if [[ "$FAIL" -eq 1 ]]; then
+  exit 1
+fi
+
+# defaults/roles/<role>.md is a symlink into defaults/.claude/commands/loom/
+# (single source of truth since #1185) — assert that invariant still holds
+# rather than requiring a second, independently-maintained copy.
+if [[ ! -L "$JUDGE_SYMLINK" ]]; then
+  fail "$JUDGE_SYMLINK is no longer a symlink — if judge.md was de-consolidated into two independent copies, this script (and CLAUDE.md's role-file guidance) needs updating"
+elif [[ "$(readlink -f "$JUDGE_SYMLINK")" != "$(readlink -f "$JUDGE_MD")" ]]; then
+  fail "$JUDGE_SYMLINK does not resolve to $JUDGE_MD"
+fi
+
+if [[ ! -L "$DOCTOR_SYMLINK" ]]; then
+  fail "$DOCTOR_SYMLINK is no longer a symlink — see the judge.md note above"
+elif [[ "$(readlink -f "$DOCTOR_SYMLINK")" != "$(readlink -f "$DOCTOR_MD")" ]]; then
+  fail "$DOCTOR_SYMLINK does not resolve to $DOCTOR_MD"
+fi
+
+if ! grep -q "### Verdict-Time CAS Recheck" "$JUDGE_MD"; then
+  fail "judge.md is missing the 'Verdict-Time CAS Recheck' section (#4570)"
+fi
+
+if ! grep -q "### Verdict-Time CAS Recheck" "$DOCTOR_MD"; then
+  fail "doctor.md is missing the 'Verdict-Time CAS Recheck' section (#4570)"
+fi
+
+# --- 3: Champion Verdict-State Janitor + criterion-1 fix --------------------
+if ! grep -q "## Verdict-State Janitor" "$CHAMPION_MERGE_MD"; then
+  fail "champion-pr-merge.md is missing the 'Verdict-State Janitor' section (#4570)"
+fi
+
+# Criterion 1's verification snippet must actually check for
+# loom:changes-requested, not just loom:pr presence (the doc-vs-check
+# contradiction #4570 fixed). Look for the grep check within the file.
+if ! grep -q 'grep -q "loom:changes-requested"' "$CHAMPION_MERGE_MD"; then
+  fail "champion-pr-merge.md criterion 1 no longer checks for loom:changes-requested alongside loom:pr — the doc-vs-check contradiction (#4570) may have regressed"
+fi
+
+# --- 4: labels.yml mutual-exclusion invariant documented --------------------
+if ! grep -q "verdict-label mutual exclusion" "$LABELS_ROOT"; then
+  fail ".github/labels.yml is missing the verdict-label mutual-exclusion invariant comment (#4570)"
+fi
+
+if ! grep -q "verdict-label mutual exclusion" "$LABELS_DEFAULTS"; then
+  fail "defaults/.github/labels.yml is missing the verdict-label mutual-exclusion invariant comment (#4570)"
+fi
+
+if [[ "$FAIL" -eq 1 ]]; then
+  exit 1
+fi
+
+echo "check-cas-recheck-consistency: OK — Verdict-Time CAS Recheck (Judge + Doctor), Champion's Verdict-State Janitor, criterion 1's fix, and the labels.yml mutual-exclusion invariant are all present."


### PR DESCRIPTION
## Summary

Closes the write-time race behind the PR #4560 incident (2026-07-30): two
Judges reviewing the same PR concurrently could each pass the existing
stale-claim check and then both still write a verdict label, since GitHub's
label API has no compare-and-swap. The PR briefly carried both `loom:pr` and
`loom:changes-requested` simultaneously — a state that would have let
Champion auto-merge a PR with an open Judge rejection.

## Changes

- **`defaults/.claude/commands/loom/judge.md`**: adds a "Verdict-Time CAS
  Recheck" section immediately after the existing Stale `loom:reviewing`
  Claim Check — re-reads the PR's labels immediately before every
  verdict-label write and aborts (discarding the verdict, posting a
  standing-down note) if the claim was lost or another Judge's verdict
  already landed. Every verdict-write site in the file (primary approve/
  reject, DIRTY/merge-conflict fallback, CI-failure rejection, fast-track
  approval, minor-PR-description-fix approval, trivial-fix approval)
  references it.
- **`defaults/.claude/commands/loom/doctor.md`**: adds the analogous
  "Verdict-Time CAS Recheck" for Doctor's completion write
  (`loom:changes-requested` + `loom:treating` → `loom:review-requested`),
  next to the existing Pre-Push Head-SHA Recheck — closes the *label* race
  the way that section already closes the *code* race. Updated the
  pre-completion checklist and the Work Process / Example Commands write
  sites.
- **`defaults/.claude/commands/loom/champion-pr-merge.md`**: adds a
  "Verdict-State Janitor" step that runs *before* the 6 safety criteria for
  every `loom:pr` PR — detects a contradictory `loom:pr` +
  `loom:changes-requested` state, resolves it fail-safe
  (`loom:changes-requested` wins, `loom:pr` removed, one idempotent
  explanatory comment reusing the stale-PR notice's idempotency pattern),
  and skips merging. Also fixes criterion 1's verification snippet, which
  previously only grepped for `loom:pr` **presence** and never checked for
  `loom:changes-requested` — despite its own rationale text claiming the
  latter "fails this check." The snippet now actually fails on the
  contradictory state (defense-in-depth alongside the janitor).
- **`defaults/.claude/commands/loom/champion-reference.md`**: updates the
  "Complete Auto-Merge Workflow Script" pointer to mention the new janitor
  step.
- **`.github/labels.yml`** (+ byte-identical `defaults/.github/labels.yml`
  copy): documents the verdict-label mutual-exclusion invariant —
  `{loom:review-requested, loom:reviewing, loom:changes-requested, loom:pr}`
  are mutually exclusive modulo the transient claim+request overlap during
  an active review.
- **`defaults/scripts/check-cas-recheck-consistency.sh`** (new): a
  regression guard asserting the CAS-recheck sections (Judge + Doctor), the
  Champion janitor section, the criterion-1 fix, and the labels.yml
  invariant are all present — the "regression coverage" acceptance
  criterion for this prompt/doc-only fix (Option A per the issue's own
  curator guidance; there is no compiler for role prompts, so this script is
  the executable tie against future regression).

## Deviations from the issue's stated plan

- **The issue's Curator note says `defaults/roles/<role>.md` and
  `defaults/.claude/commands/loom/<role>.md` are two lockstep-synced copies
  that both need editing.** That's stale: `defaults/roles/judge.md` and
  `defaults/roles/doctor.md` are actually **symlinks** into
  `defaults/.claude/commands/loom/` (single source of truth since #1185 —
  confirmed via `readlink`/`git log`), not independent copies. There is only
  one real file per role to edit; I edited only the symlink targets. (This
  does NOT apply to `.github/labels.yml` / `defaults/.github/labels.yml`,
  which really are two separate byte-identical files per the
  `check-labels-drift.sh` parity contract — both were updated identically.)
- **Did not wire `check-cas-recheck-consistency.sh` into `.github/workflows/ci.yml`.**
  I added the CI step, ran it green locally, then the push was rejected:
  "refusing to allow a Personal Access Token to create or update workflow
  `.github/workflows/ci.yml` without `workflow` scope." I reverted that hunk
  (no `ci.yml` diff in this PR) rather than block the PR on it. The script
  itself is included and passes locally (`bash
  defaults/scripts/check-cas-recheck-consistency.sh`); wiring it into
  `installer-tests` (next to `check-labels-drift.sh` /
  `check-phantom-labels.sh`) is a one-line follow-up for whoever has
  `workflow` scope (human maintainer, or a bot token with that scope).
- **Champion janitor implementation is Option A (prompt-only)**, per the
  issue's own recommendation — no new `.loom/scripts/` file, no Rust
  changes to `claim_reconciliation.rs` (noted in the issue as prior art, not
  a mandate).

## Acceptance Criteria Verification

- [x] Verdict-time CAS recheck (Judge): documented next to the Stale Claim
      Check; every verdict-write site references it.
- [x] Verdict-time CAS recheck (Doctor): documented next to the Pre-Push
      Head-SHA Recheck; the Work Process step 11 and Example Commands site
      reference it.
- [x] Mutual-exclusion invariant declared in both `labels.yml` copies.
- [x] Fail-safe janitor in Champion, run before the 6 criteria, with the
      criterion-1 doc-vs-check contradiction fixed.
- [x] Regression coverage: `defaults/scripts/check-cas-recheck-consistency.sh`
      (not yet wired into CI — see deviation above).

## Test Plan

- [x] `bash defaults/scripts/check-cas-recheck-consistency.sh` — passes.
- [x] `bash defaults/scripts/check-labels-drift.sh` — passes (labels.yml
      copies still byte-identical).
- [x] `bash defaults/scripts/check-phantom-labels.sh` — passes (no new
      phantom label references).
- [x] `bash defaults/scripts/check-label-descriptions.sh` — passes.
- [x] `shellcheck defaults/scripts/check-cas-recheck-consistency.sh` — clean.
- [~] `bash scripts/test-installer.sh` — 175/176 pass. The 1 failure
      (`test-loom-dispatcher.sh`: "config-selected codex path does not touch
      the claude runner") is **pre-existing and unrelated** — that test file
      is untouched by this PR's diff (`git diff --stat origin/main --
      defaults/scripts/tests/test-loom-dispatcher.sh` is empty).
- Manual verification of the janitor / criterion-1 fix and the CAS-recheck
  abort path is scripted behavior review only in this PR (no live PR/label
  fixture was exercised against the GitHub API) — the consistency script is
  the executable regression guard; a maintainer with forge write access may
  additionally want to dry-run the janitor snippet against a scratch PR
  carrying both `loom:pr` and `loom:changes-requested`.

Closes #4570