### PR TITLE
fix(resync): report a deliberately git-tracked vendored guard as a note, not a WARN

### DIFF
--- a/defaults/docs/guard-hooks.md
+++ b/defaults/docs/guard-hooks.md
@@ -103,6 +103,21 @@ Loom ships with several built-in `PreToolUse` guard hooks, registered independen
 
 You can also add project-specific guards to protect read-only directories from accidental edits (see below).
 
+### Which generic guard is authoritative — and why the vendored copy stays (#4403, #4566)
+
+**At runtime the canonical Repo Skills guard always wins** when it is present: `guard-destructive.sh` is a dispatcher, so the vendored `guard-destructive-generic.sh` is a *fallback*, never a second guard running alongside it.
+
+Whether the vendored copy is **installed** is a separate, per-repo choice, and both answers are supported:
+
+| Repo layout | Vendored `.loom/hooks/guard-destructive-generic.sh` | What `resync-installed.sh` does |
+|---|---|---|
+| `.loom/` gitignored (the usual consumer repo) | untracked, per-host | **removes** it once a canonical Repo Skills guard is detected locally — the dispatcher covers this host |
+| `.loom/` committed (**Loom itself dogfoods this layout**) | **git-tracked on purpose** | **keeps** it, and reports an informational `unchanged … (git-tracked vendored fallback kept)` line |
+
+The committed case is deliberate, not drift: a git-tracked vendored guard is repo-shared state, so contributors and CI runners **without** Repo Skills installed still get full generic-guard coverage. Resync must therefore never delete it on the strength of one host's local, typically-gitignored `.claude/skills/repo/` install (#4403) — and because that state is the expected steady state rather than an anomaly, it is reported as a `note` (suppressed under `--quiet`) instead of a `WARN` that would reprint on every resync forever (#4566).
+
+If a repo genuinely wants to rely on Repo Skills provisioning instead, it drops the vendored copy **deliberately and repo-wide** with `git rm .loom/hooks/guard-destructive-generic.sh`; after that commit the branch above stops firing entirely and hosts without Repo Skills fall back to no generic guard, so make that trade consciously.
+
 ### SQL DDL/DML Guard Opt-Out (`guards.sqlDdl` / `LOOM_GUARD_SQL`)
 
 `guard-destructive.sh` blocks SQL DDL/DML patterns — `DROP DATABASE`, `DROP TABLE`, `DROP SCHEMA`, `TRUNCATE TABLE`, and `DELETE FROM` without a `WHERE` clause. For most repos this is a useful safety net, but for a project that is **itself a database engine** (e.g. a SQLite-compatible engine running a SQL conformance suite) those statements are the product's own dev/test vocabulary and the guard is a category error — the match is a case-insensitive substring, so it even fires when the words appear in a comment or a `--description` label.

--- a/defaults/scripts/resync-installed.sh
+++ b/defaults/scripts/resync-installed.sh
@@ -440,8 +440,19 @@ resync_tree() {
 # a repo that commits `.loom/` (this repo dogfoods that layout). Removing a
 # tracked file based purely on one contributor's local skill install deletes a
 # repo-shared file for everyone else. So below, before removing the vendored
-# guard, we check whether the target is git-tracked and skip the removal (with a
-# warning) if so — only untracked (the normal consumer-repo) targets are removed.
+# guard, we check whether the target is git-tracked and skip the removal if so —
+# only untracked (the normal consumer-repo) targets are removed.
+#
+# #4566: that skip is reported as an informational `note`, NOT a `warn`. The
+# condition is a *steady state*, not an anomaly: it can only arise where a
+# maintainer deliberately committed the vendored fallback (posture (a) — keep the
+# tracked copy so contributors/CI without Repo Skills still get full generic-guard
+# coverage; see defaults/docs/guard-hooks.md). Resync already takes the only
+# correct action automatically, every run, forever — so an alarm-level line that
+# reprints on every resync with no way to acknowledge it is pure noise. A repo
+# that genuinely wants posture (b) drops the vendored copy deliberately with
+# `git rm .loom/hooks/guard-destructive-generic.sh`, after which this branch stops
+# firing entirely.
 CANONICAL_GUARD_PRESENT=0
 if [[ -r "$REPO_ROOT/.claude/skills/repo/hooks/guard-destructive.sh" ]] && \
    grep -q 'repo#29' "$REPO_ROOT/.claude/skills/repo/hooks/guard-destructive.sh" 2>/dev/null; then
@@ -463,8 +474,12 @@ if [[ -d "$DEFAULTS_DIR/hooks" && -d "$INSTALLED_HOOKS" ]]; then
                     # repo-shared state, not this host's local install. Removing it
                     # would delete a committed file for every other contributor based
                     # solely on this host's local, typically-gitignored Repo Skills
-                    # install. Leave it alone and warn instead.
-                    warn "hooks/$name is git-tracked in this repo but a canonical Repo Skills guard was detected locally — NOT removing a repo-shared tracked file based on one host's local install. If .loom/hooks/$name should genuinely be dropped repo-wide, remove it deliberately with 'git rm .loom/hooks/$name'."
+                    # install. Leave it alone.
+                    #
+                    # #4566: report this as a `note`, not a `warn` — a committed
+                    # vendored fallback is a deliberate, documented posture, so this
+                    # is the expected steady state on every run, not an anomaly.
+                    note "  ${GREEN}unchanged${NC} hooks/$name ${YELLOW}(git-tracked vendored fallback kept — canonical Repo Skills guard present; see defaults/docs/guard-hooks.md)${NC}"
                 elif [[ "$DRY_RUN" -eq 1 ]]; then
                     printf '%b\n' "  ${BOLD}would remove${NC} hooks/$name ${YELLOW}(canonical Repo Skills guard present)${NC}"
                 else

--- a/defaults/scripts/tests/test-resync-installed.sh
+++ b/defaults/scripts/tests/test-resync-installed.sh
@@ -18,8 +18,9 @@
 #   (l) symlinked install target -> skipped, not clobbered
 #   (m) recorded loom_source gone -> clear error, exit 1
 #   (n) metadata re-stamp -> loom_version/loom_commit/last_resync present after apply
-# Canonical-guard-defer (#4041, #4403):
-#   (o) canonical guard + git-TRACKED vendored guard -> preserved, WARN, tree clean
+# Canonical-guard-defer (#4041, #4403, #4566):
+#   (o) canonical guard + git-TRACKED vendored guard -> preserved, tree clean, and
+#       reported as an informational note (NOT a WARN) that --quiet suppresses
 #   (p) canonical guard + UNTRACKED vendored guard   -> removed (unchanged behavior)
 # Worktree-isolation refusal (#4563):
 #   (q) invoked from a linked worktree -> non-zero exit, NOTHING written to main
@@ -628,15 +629,40 @@ if [[ -f "$REPO/.loom/hooks/guard-destructive-generic.sh" ]]; then
 else
     fail "(#4403) git-tracked hooks/guard-destructive-generic.sh was removed"
 fi
-if grep -qi "WARN.*git-tracked" <<<"$OUT"; then
-    pass "(#4403) a WARN is printed explaining the tracked file was preserved"
+if grep -q "git-tracked vendored fallback kept" <<<"$OUT"; then
+    pass "(#4403) the preserved tracked file is reported explicitly"
 else
-    fail "(#4403) no WARN printed for the preserved tracked file"
+    fail "(#4403) no report explaining the preserved tracked file"
+fi
+# #4566: a committed vendored guard is a deliberate, documented posture, so this
+# is the expected steady state on EVERY run — it must not be reported at
+# alarm level (a WARN here reprinted forever with no way to acknowledge it).
+# (Scoped to this message: an unrelated WARN, e.g. the #4280 missing-daemon
+# .gitignore notice, can legitimately appear in the same run.)
+if grep -qEi "WARN.*(git-tracked|guard-destructive-generic)" <<<"$OUT"; then
+    fail "(#4566) tracked vendored guard must not produce a WARN (got: $(grep -Ei "WARN.*(git-tracked|guard-destructive-generic)" <<<"$OUT" | head -1))"
+else
+    pass "(#4566) no WARN for the deliberately-tracked vendored guard"
 fi
 if [[ -z "$(cd "$REPO" && git status --porcelain -- .loom/hooks/guard-destructive-generic.sh 2>&1)" ]]; then
     pass "(#4403) tracked guard file stays non-dirty (no local mods/deletions) after the run"
 else
     fail "(#4403) tracked guard file is dirty after the run"
+fi
+# #4566: routed through note(), so --quiet suppresses it entirely while the
+# file is still preserved (behavior unchanged, only the reporting is quieter).
+OUT_Q="$(cd "$REPO" && bash "$SCRIPT" --quiet 2>&1)"
+RC=$?
+if [[ $RC -eq 0 ]]; then pass "(#4566) --quiet rerun exits 0"; else fail "(#4566) --quiet rerun exits 0 (got $RC)"; fi
+if grep -q "git-tracked vendored fallback kept" <<<"$OUT_Q"; then
+    fail "(#4566) --quiet still printed the tracked-guard message (not routed through note())"
+else
+    pass "(#4566) --quiet suppresses the tracked-guard message"
+fi
+if [[ -f "$REPO/.loom/hooks/guard-destructive-generic.sh" ]]; then
+    pass "(#4566) --quiet rerun still preserves the git-tracked vendored guard"
+else
+    fail "(#4566) --quiet rerun removed the git-tracked vendored guard"
 fi
 
 # --- (#4403) canonical-guard-defer: untracked target keeps existing behavior -


### PR DESCRIPTION
## Summary

`resync-installed.sh` correctly refuses to delete `.loom/hooks/guard-destructive-generic.sh` when that file is **git-tracked** and a canonical Repo Skills guard is installed locally (#4403) — one host's gitignored `.claude/skills/repo/` install must never drive a repo-wide deletion. The problem was the *reporting level*: the refusal was announced with `warn()`, so every resync on such a host reprinted an alarm-level block, forever, with no way to acknowledge it.

This adopts **posture (a)** from the issue — keep the tracked copy as the repo-shared fallback — and teaches resync to recognize it as intentional. That posture was already this repo's design, not an open question:

- `guard-destructive.sh`'s own header documents the vendored fallback exists "so standalone-Loom repos WITHOUT Repo Skills" keep full coverage.
- `resync-installed.sh`'s `#4403` comment block already says this repo "dogfoods that layout" (commits `.loom/` like a consumer repo would).
- `defaults/docs/guard-hooks.md` already described the dispatcher/canonical/vendored relationship.

So the condition is a **steady state**, not an anomaly: it can only arise where a maintainer deliberately committed the vendored fallback, and resync already takes the only correct action automatically on every run. `warn` -> `note` is the surgical fix; no `git rm`, no behavior change.

## Changes

- **`defaults/scripts/resync-installed.sh`** — the git-tracked branch now emits one concise `note` line (`unchanged hooks/guard-destructive-generic.sh (git-tracked vendored fallback kept — canonical Repo Skills guard present; see defaults/docs/guard-hooks.md)`) instead of the multi-sentence `WARN`. `note()` respects `--quiet`; `warn()` never did. The refusal logic, the untracked-target removal path, dry-run output, counters, and exit codes are untouched. Comments now record *why* this is expected rather than transitional, and how a repo deliberately opts into posture (b).
- **`defaults/docs/guard-hooks.md`** — new subsection "Which generic guard is authoritative — and why the vendored copy stays (#4403, #4566)": the canonical Repo Skills guard always wins at runtime; a table of the two supported per-repo postures (`.loom/` gitignored -> vendored copy removed; `.loom/` committed -> kept, as Loom itself does); and the explicit `git rm .loom/hooks/guard-destructive-generic.sh` escape hatch with its consequence spelled out.
- **`defaults/scripts/tests/test-resync-installed.sh`** — test group 14 now asserts the message is reported, is **not** a WARN, and is suppressed under `--quiet` while the tracked file still survives and the run still exits 0.

Note: only `defaults/` is edited. The installed twin at `.loom/scripts/resync-installed.sh` is **not** git-tracked in this repo (`git ls-files` returns nothing for it) — it is a local resync target, refreshed by the periodic `chore: resync installed Loom surfaces` commit from the main checkout, per builder.md #4563. The curator comment's suggestion to keep both in sync does not apply.

## Acceptance Criteria Verification

- [x] **Decide the posture** — posture (a): the tracked vendored copy stays; no `git rm`. Rationale recorded in the code comment (`resync-installed.sh`, `#4566` block), the commit message, and `guard-hooks.md`.
- [x] **The recurring WARN disappears on hosts matching the decided posture** — the message is now `note`-level: no `WARN:` prefix, not written to stderr, and suppressed entirely under `--quiet`/`-q`. Asserted by three new test cases.
- [x] **`defaults/docs/guard-hooks.md` documents which guard is authoritative and why** — new dedicated subsection (previously the relationship was buried mid-bullet in the `guard-destructive.sh` entry and said nothing about the tracked-vs-untracked resync postures).

## Test Plan

- [x] `bash defaults/scripts/tests/test-resync-installed.sh` -> **88/88 passed** (was 85 cases; +3 for #4566, one rewritten).
- [x] **Coverage is real, not tautological**: ran the *new* test file against `origin/main`'s `resync-installed.sh` in a scratch tree — the two new/rewritten assertions fail there, quoting the old `WARN: hooks/guard-destructive-generic.sh is git-tracked in this repo…` line. They pass only with this change.
- [x] Edge case — **untracked** vendored guard (the normal consumer repo): group 15 still passes unchanged (file removed, removal still reported).
- [x] Edge case — **posture (b)** (`git rm` performed): the `ls-files` probe then fails, so the branch stops firing entirely and the removal path takes over; group 15 is exactly that state.
- [x] `shellcheck` on both changed scripts: no new findings. The two remaining info-level notes (SC2094 in the untouched `.gitignore` block, SC2317 on the `cleanup` EXIT trap) are pre-existing and below CI's `--severity=warning` threshold.
- [x] `bash scripts/test-installer.sh` -> 175 passed. Two pre-existing failures unrelated to this diff (`Test 23: After uninstall, .claude removed` and the `test-loom-dispatcher.sh` codex-runtime case); neither touches `resync-installed.sh`, the guard hooks, or `guard-hooks.md`.
- [ ] Live manual reproduction on a dual-guard host was **not possible**: this host has no `.claude/skills/repo/hooks/guard-destructive.sh`, so the branch never fires here, and builder.md #4563 forbids running `resync-installed.sh` from a worktree. The test fixture reproduces the exact condition (canonical guard carrying the `repo#29` marker + git-tracked vendored guard) and is run twice, once plain and once with `--quiet`.

Closes #4566