### PR TITLE
fix(guard): tighten gh-comment-body-@ pattern to path-shaped @, not bare @mentions

### DIFF
--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -1532,7 +1532,15 @@ done
 # (`--body @/tmp/x`) is untouched by redaction either way, so a naive
 # implementation that only smoke-tests the unquoted shape can look correct
 # while silently missing the quoted shape actually seen in the field.
-GH_COMMENT_BODY_AT_PATTERN="(^|[;&|[:space:]])gh[[:space:]]+(pr|issue)[[:space:]]+comment[^;&]*(-b|--body)[[:space:]]*=?[[:space:]]*[\"']?@"
+#
+# The `@` must be followed by a path-shaped character (`/`, `.`, or `~`) —
+# every real incident/test case is an absolute or relative path
+# (`@/tmp/...`, `@./relative/path`, `@~/home/path`). A bare `@word` right
+# after the opening quote is an @mention addressed to a reviewer (e.g.
+# `--body "@reviewer Could you clarify..."`, the shape doctor.md's own
+# "Can't Understand Feedback" example uses) and must NOT be treated as the
+# `-F body=@path` anti-pattern (#4577).
+GH_COMMENT_BODY_AT_PATTERN="(^|[;&|[:space:]])gh[[:space:]]+(pr|issue)[[:space:]]+comment[^;&]*(-b|--body)[[:space:]]*=?[[:space:]]*[\"']?@[/.~]"
 if echo "$COMMAND" | grep -qiE "$GH_COMMENT_BODY_AT_PATTERN"; then
     deny "BLOCKED: 'gh pr comment'/'gh issue comment --body @path' does NOT expand the file — it posts the literal string '@path' as the comment (lost the PR #4457 review this way). Use --body \"\$(cat <<'EOF' ... EOF)\", -F/--body-file <path>, or 'gh api ... -F body=@<path>' instead." "gh-comment-body-literal-at"
 fi

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -691,6 +691,13 @@ EOF
 assert_allow "Allow gh pr comment with quoted prose containing @mention" \
     'gh pr comment 123 --body "cc @reviewer please take another look"'
 
+# Regression (#4577): an @mention immediately after the opening quote (no
+# leading word) is not path-shaped and must not be caught by
+# GH_COMMENT_BODY_AT_PATTERN — this exact shape is doctor.md's own
+# documented "Can't Understand Feedback" example.
+assert_allow "Allow gh pr comment with leading @mention (no leading word before @)" \
+    'gh pr comment 123 --body "@reviewer Could you clarify what you mean by X?"'
+
 assert_allow "Allow gh pr comment --body-file (distinct flag, actually reads the file)" \
     "gh pr comment 123 --body-file /tmp/review.md"
 


### PR DESCRIPTION
## Summary

PR #4575 added a hard-deny guard (`GH_COMMENT_BODY_AT_PATTERN` in
`defaults/hooks/guard-destructive-generic.sh`) for the literal-`@` incident
(#4523). The pattern was too broad: it denied ANY `--body`/`-b` value that
begins with `@` immediately inside the quote, not just path-shaped values —
so it false-positived on a legitimate workflow: replying to a named
reviewer, e.g. `--body "@reviewer Could you clarify..."`. This exact shape
is already used in `defaults/.claude/commands/loom/doctor.md`'s own "Can't
Understand Feedback" example, so the guard blocked a documented Doctor
workflow.

This PR tightens the regex so the `@` must be followed by a path-shaped
character (`/`, `.`, or `~`) rather than any character — every real
incident/test case (a `/tmp/...` path, a `/private/tmp/...` path, a
`./relative/path`, a `~/home/path`) is an absolute or relative path, while
an `@mention` is followed by a bare word character.

## Changes

- `defaults/hooks/guard-destructive-generic.sh`: `GH_COMMENT_BODY_AT_PATTERN`
  now ends in `[\"']?@[/.~]` instead of `[\"']?@`, plus an explanatory
  comment.
- `tests/hooks/test-guard-destructive.sh`: added a regression `assert_allow`
  test for a bare `@reviewer` mention immediately after the opening quote
  (the shape not covered by the existing `"cc @reviewer ..."` case, which
  has a leading word before the `@`).

Per the issue's explicit note, `.loom/hooks/guard-destructive-generic.sh`
(the installed copy, separately drifted per #4566) is left untouched —
`defaults/hooks/guard-destructive-generic.sh` is the canonical source for
this fix.

## Acceptance criteria

- [x] `GH_COMMENT_BODY_AT_PATTERN` only denies when `@` is followed by a
  path-shaped character (`/`, `.`, or `~`) — a bare `@word` mention is no
  longer matched.
- [x] All existing deny cases for this pattern still deny (verified below).
- [x] New regression test for the bare `@reviewer` mention shape added and
  passing.
- [x] `.loom/hooks/guard-destructive-generic.sh` left untouched (only
  `defaults/hooks/guard-destructive-generic.sh` and
  `tests/hooks/test-guard-destructive.sh` modified — confirmed via `git diff
  --name-only`).

## Test plan (actual output)

1. Manual reproduction from the issue — now ALLOWED (empty output = no
   deny). Ran the guard hook against a JSON payload wrapping a comment
   command whose body starts with an `@reviewer` mention: no `deny` was
   produced (the hook script produced no output for that input).

2. Path-shaped cases still DENY — ran the guard hook against payloads whose
   body values start with an `@`-prefixed absolute path, a `@`-prefixed
   relative-dot path, and a `@`-prefixed tilde path; all three produced a
   `permissionDecision: deny` with the `gh-comment-body-literal-at` reason.

3. Full guard test suite:
   ```
   $ bash tests/hooks/test-guard-destructive.sh
   =========================================
     Total:  501
     Passed: 501
     Failed: 0
   =========================================
   ALL TESTS PASSED
   ```
   Relevant lines from the run:
   ```
   PASS: Block gh pr comment --body @path (unquoted)
   PASS: Block gh pr comment --body @path (double-quoted)
   PASS: Block gh pr comment --body @path (single-quoted)
   PASS: Block gh issue comment --body @path (unquoted)
   PASS: Block gh pr comment -b @path (short flag)
   PASS: Allow gh pr comment with quoted prose containing @mention
   PASS: Allow gh pr comment with leading @mention (no leading word before @)
   PASS: Allow gh api -F body=@path (distinct flag, actually reads the file)
   ```

4. shellcheck:
   ```
   $ shellcheck -S warning defaults/hooks/guard-destructive-generic.sh
   $ echo $?
   0
   ```
   No new warnings introduced.

## Coordination note

Sibling PR #4612 (targeting #4601) adds two separate additive deny rules to
the same file for a different anti-pattern, explicitly leaving
`GH_COMMENT_BODY_AT_PATTERN` byte-identical — no textual overlap with this
change.

Closes #4577