### PR TITLE
fix(loom-daemon): confine test-spawned daemons to a scratch workspace with autonomy disabled

### DIFF
--- a/loom-daemon/tests/README.md
+++ b/loom-daemon/tests/README.md
@@ -61,6 +61,23 @@ let daemon = TestDaemon::start().await?;
 let socket_path = daemon.socket_path();
 ```
 
+**Confinement invariant (#4573)** — a test daemon is a *real* `loom-daemon`
+process, so `TestDaemon::start()` spawns it fail-closed:
+
+- `LOOM_ROLE_RUNNER=0`, `LOOM_WORK_FINDER=0`, `LOOM_EPIC_SUPERVISOR=0` — these
+  env vars win outright over `.loom/config.json` in the daemon's
+  `env > config > default` chain, so a test daemon can never dispatch a real
+  sweep or run a real role session (this repo's own committed config has
+  `autonomous.roleRunner.enabled: true`).
+- `LOOM_WORKSPACE`, `LOOM_WORKSPACES_PATH`, `LOOM_WORKTREE_ROOT` — all pinned
+  inside the daemon's own `TempDir`, so it resolves *no* real repository state,
+  no matter what the invoking environment exports.
+
+If you add a new daemon spawn site to this suite, carry the same env over (see
+`integration_drain_then_exit.rs`). `integration_workspace_confinement.rs`
+enforces the invariant for `TestDaemon` and fails loudly if one of these is
+dropped.
+
 ### `TestClient`
 
 Client for communicating with the daemon.

--- a/loom-daemon/tests/common/mod.rs
+++ b/loom-daemon/tests/common/mod.rs
@@ -69,6 +69,9 @@ impl TestDaemon {
         // rather than silently picking up whatever repos are registered in
         // this *host's* real `~/.loom/workspaces.json`.
         let workspaces_path = temp_dir.path().join("workspaces.json");
+        // Absolute (required — `worktree_root()` rejects a relative override
+        // and falls back to the default) and inside the `TempDir`.
+        let worktree_root = temp_dir.path().join("worktrees");
 
         let mut process = Command::new(daemon_bin())
             .env("LOOM_SOCKET_PATH", &socket_path)
@@ -91,15 +94,23 @@ impl TestDaemon {
             .env("LOOM_EPIC_SUPERVISOR", "0")
             // Repoint the daemon's own workspace root at this test's throwaway
             // `TempDir` (#4573) instead of letting it inherit the real repo
-            // checkout via `LOOM_WORKSPACE`/cwd. `worktree_root()` derives its
-            // default (`${repo_root}/.loom/worktrees`) from this same
-            // `repo_root` parameter and only reads `LOOM_WORKTREE_ROOT`
-            // itself as an *override* of the base directory, so pinning
-            // `LOOM_WORKSPACE` alone is sufficient to keep worktree-root
-            // resolution confined to the temp dir too — no separate
-            // `LOOM_WORKTREE_ROOT` override is needed.
+            // checkout via `LOOM_WORKSPACE`/cwd.
             .env("LOOM_WORKSPACE", temp_dir.path())
             .env("LOOM_WORKSPACES_PATH", &workspaces_path)
+            // …and pin the worktree base directory too (#4573). This is NOT
+            // redundant with `LOOM_WORKSPACE`: `worktree_root()` reads
+            // `LOOM_WORKTREE_ROOT` as its *highest-priority* source
+            // (`worktree_root.rs`), ahead of both `worktree.root` in config
+            // and the `${repo_root}/.loom/worktrees` default. A spawned child
+            // inherits the parent's environment, so on a host that sets
+            // `LOOM_WORKTREE_ROOT` (the documented external-scratch-volume
+            // setup) an unpinned test daemon would resolve worktrees onto that
+            // real volume — outside its `TempDir` — even with `LOOM_WORKSPACE`
+            // confined. Setting it explicitly makes confinement independent of
+            // the invoking environment. Note the daemon namespaces an
+            // *override* by repo basename, so the effective root is
+            // `<temp>/worktrees/<temp-basename>` — still inside the `TempDir`.
+            .env("LOOM_WORKTREE_ROOT", &worktree_root)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
@@ -139,6 +150,18 @@ impl TestDaemon {
     #[allow(dead_code)]
     pub fn workspace_path(&self) -> &Path {
         self._temp_dir.path()
+    }
+
+    /// PID of the spawned daemon child, or `None` once it has been reaped.
+    ///
+    /// Exposed so the #4573 confinement regression test can read the child's
+    /// *actual* environment (`/proc/<pid>/environ` on Linux) rather than
+    /// trusting that this module's `.env()` calls are still present — the only
+    /// way to verify pass-through for `LOOM_WORKTREE_ROOT`, which the daemon
+    /// consumes internally and never reports over IPC.
+    #[allow(dead_code)]
+    pub fn pid(&self) -> Option<u32> {
+        self.process.as_ref().map(std::process::Child::id)
     }
 }
 

--- a/loom-daemon/tests/common/mod.rs
+++ b/loom-daemon/tests/common/mod.rs
@@ -63,6 +63,12 @@ impl TestDaemon {
     pub async fn start() -> Result<Self> {
         let temp_dir = TempDir::new().context("Failed to create temp directory")?;
         let socket_path = temp_dir.path().join("daemon.sock");
+        // Isolated registry file (mirrors `integration_drain_then_exit.rs`): an
+        // empty/scratch `LOOM_WORKSPACES_PATH` guarantees `effective_roots()`
+        // reduces to the single seeded default (`LOOM_WORKSPACE`, set below)
+        // rather than silently picking up whatever repos are registered in
+        // this *host's* real `~/.loom/workspaces.json`.
+        let workspaces_path = temp_dir.path().join("workspaces.json");
 
         let mut process = Command::new(daemon_bin())
             .env("LOOM_SOCKET_PATH", &socket_path)
@@ -70,6 +76,30 @@ impl TestDaemon {
             // Disable restore_from_tmux() to prevent cross-test-binary contamination
             // via the shared tmux server. Each test manages its own terminals.
             .env("LOOM_NO_RESTORE", "1")
+            // Fail-closed autonomy toggles (#4573): without these, a spawned
+            // test daemon inherits this repo's real `.loom/config.json`
+            // (`autonomous.roleRunner.enabled: true`) and can dispatch real
+            // `/loom:sweep` sessions — burning API/GitHub rate-limit quota in
+            // what is meant to be an inert integration-test daemon. Each of
+            // these env vars *wins outright* over config in the daemon's own
+            // env > config > default precedence (`resolve_enabled` in
+            // `role_runner.rs` / `work_finder.rs` / `epic_supervisor.rs`), so
+            // setting them here is authoritative regardless of what any
+            // repo's committed config says.
+            .env("LOOM_ROLE_RUNNER", "0")
+            .env("LOOM_WORK_FINDER", "0")
+            .env("LOOM_EPIC_SUPERVISOR", "0")
+            // Repoint the daemon's own workspace root at this test's throwaway
+            // `TempDir` (#4573) instead of letting it inherit the real repo
+            // checkout via `LOOM_WORKSPACE`/cwd. `worktree_root()` derives its
+            // default (`${repo_root}/.loom/worktrees`) from this same
+            // `repo_root` parameter and only reads `LOOM_WORKTREE_ROOT`
+            // itself as an *override* of the base directory, so pinning
+            // `LOOM_WORKSPACE` alone is sufficient to keep worktree-root
+            // resolution confined to the temp dir too — no separate
+            // `LOOM_WORKTREE_ROOT` override is needed.
+            .env("LOOM_WORKSPACE", temp_dir.path())
+            .env("LOOM_WORKSPACES_PATH", &workspaces_path)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
@@ -101,6 +131,14 @@ impl TestDaemon {
     /// Get the socket path for connecting clients
     pub fn socket_path(&self) -> &Path {
         &self.socket_path
+    }
+
+    /// The throwaway `TempDir` this daemon was pinned to via `LOOM_WORKSPACE`
+    /// (#4573) — the workspace root the daemon must resolve to, never the
+    /// real repo checkout.
+    #[allow(dead_code)]
+    pub fn workspace_path(&self) -> &Path {
+        self._temp_dir.path()
     }
 }
 

--- a/loom-daemon/tests/integration_drain_then_exit.rs
+++ b/loom-daemon/tests/integration_drain_then_exit.rs
@@ -67,6 +67,20 @@ async fn test_drain_then_exit_exits_143_and_stays_down() {
             // scratch daemon count that repo's REAL in-flight sweeps and the
             // drain never completes.
             .env("LOOM_WORKSPACE", &workspace_root)
+            // Fail-closed autonomy toggles (#4573). This is the suite's only
+            // daemon spawn outside `TestDaemon::start()`, so it needs the same
+            // guard: each of these env vars wins outright over config in the
+            // daemon's env > config > default chain, so a test daemon can never
+            // dispatch a real sweep or run a real role session regardless of
+            // which checkout's `.loom/config.json` it ends up resolving.
+            .env("LOOM_ROLE_RUNNER", "0")
+            .env("LOOM_WORK_FINDER", "0")
+            .env("LOOM_EPIC_SUPERVISOR", "0")
+            // Pinned for the same reason as `LOOM_WORKSPACE` above: an
+            // inherited `LOOM_WORKTREE_ROOT` is the highest-priority source in
+            // `worktree_root()`, so without this the scratch daemon would
+            // resolve worktrees onto the host's real scratch volume (#4573).
+            .env("LOOM_WORKTREE_ROOT", temp_dir.path().join("worktrees"))
             .env("RUST_LOG", "debug")
             .env("LOOM_NO_RESTORE", "1")
             // Deliberately UNSET: a then-exit drain must not require a supervisor

--- a/loom-daemon/tests/integration_workspace_confinement.rs
+++ b/loom-daemon/tests/integration_workspace_confinement.rs
@@ -11,10 +11,17 @@
 // (`autonomous.roleRunner.enabled: true`), and could dispatch real
 // `/loom:sweep` sessions, burning API/GitHub rate-limit quota.
 //
-// This test asserts the fix structurally, via the daemon's own
-// `Request::DaemonStatus` IPC query: the resolved workspace root
-// (`per_repo[0].root`) must be inside the `TestDaemon`'s own `TempDir` — not
-// the real checkout this test binary lives under.
+// Two complementary assertions pin the fix:
+//
+// 1. Via the daemon's own `Request::DaemonStatus` IPC query — the resolved
+//    workspace root (`per_repo[0].root`) must be inside the `TestDaemon`'s own
+//    `TempDir`, not the real checkout this test binary lives under, and that
+//    root's `role_runner_enabled` must be `false`. This proves the child
+//    *honored* the env, not merely that it was handed to `Command`.
+// 2. Via the child's real environment (`/proc/<pid>/environ`, Linux) — every
+//    autonomy toggle is `0` and every path is inside the `TempDir`. This is the
+//    only coverage for the vars the daemon consumes internally and never
+//    reports over IPC (notably `LOOM_WORKTREE_ROOT`).
 
 // Integration tests - expect/unwrap are acceptable here since tests should panic on failure
 #![allow(clippy::expect_used)]
@@ -24,9 +31,9 @@ mod common;
 
 use common::{TestClient, TestDaemon};
 
-/// Query `Request::DaemonStatus` and return the (single) resolved workspace
-/// root from `per_repo[0].root`.
-async fn resolved_workspace_root(client: &mut TestClient) -> std::path::PathBuf {
+/// Query `Request::DaemonStatus` and return the daemon's single resolved
+/// `per_repo` entry (the only root it can see, given the isolated registry).
+async fn resolved_repo_status(client: &mut TestClient) -> serde_json::Value {
     let response = client
         .send_request(serde_json::json!({"type": "DaemonStatus"}))
         .await
@@ -52,11 +59,14 @@ async fn resolved_workspace_root(client: &mut TestClient) -> std::path::PathBuf 
          must reduce to the single seeded default): {per_repo:?}"
     );
 
-    let root = per_repo[0]
-        .get("root")
-        .and_then(serde_json::Value::as_str)
-        .expect("per_repo[0].root");
-    std::path::PathBuf::from(root)
+    per_repo[0].clone()
+}
+
+/// Canonicalize for comparison, tolerating a path that does not exist (a
+/// platform whose temp dir is itself a symlink — e.g. macOS `/tmp` ->
+/// `/private/tmp` — must still compare equal).
+fn canon(path: &std::path::Path) -> std::path::PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 /// A spawned `TestDaemon`'s resolved workspace root must be the daemon's own
@@ -69,16 +79,19 @@ async fn test_daemon_workspace_root_is_confined_to_its_own_temp_dir() {
         .await
         .expect("Failed to connect");
 
-    let resolved_root = resolved_workspace_root(&mut client).await;
+    let repo_status = resolved_repo_status(&mut client).await;
+    let resolved_root = std::path::PathBuf::from(
+        repo_status
+            .get("root")
+            .and_then(serde_json::Value::as_str)
+            .expect("per_repo[0].root"),
+    );
 
     // The daemon must resolve to (a canonical form of) the `TestDaemon`'s own
-    // `TempDir` — canonicalize both sides so a platform whose temp dir is
-    // itself a symlink (e.g. macOS `/tmp` -> `/private/tmp`) still compares
-    // correctly.
+    // `TempDir`.
     let expected_root = daemon.workspace_path();
-    let resolved_canon = std::fs::canonicalize(&resolved_root).unwrap_or(resolved_root.clone());
-    let expected_canon =
-        std::fs::canonicalize(expected_root).unwrap_or_else(|_| expected_root.to_path_buf());
+    let resolved_canon = canon(&resolved_root);
+    let expected_canon = canon(expected_root);
     assert_eq!(
         resolved_canon, expected_canon,
         "daemon resolved workspace root {resolved_root:?} does not match its own \
@@ -92,11 +105,98 @@ async fn test_daemon_workspace_root_is_confined_to_its_own_temp_dir() {
     let real_repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .expect("loom-daemon has a parent directory (the repo root)");
-    let real_repo_canon =
-        std::fs::canonicalize(real_repo_root).unwrap_or_else(|_| real_repo_root.to_path_buf());
+    let real_repo_canon = canon(real_repo_root);
     assert_ne!(
         resolved_canon, real_repo_canon,
         "daemon resolved workspace root must not be the real repo checkout {real_repo_canon:?} \
          — a spawned test daemon must never see the real repo's committed .loom/config.json"
     );
+
+    // The autonomy toggle actually took effect *inside the child*, not merely
+    // "was passed to `Command`": `RepoStatus::role_runner_enabled` is resolved
+    // daemon-side via `role_runner::resolve_enabled(..)`, the same
+    // env > config > default chain `LOOM_ROLE_RUNNER=0` overrides. This repo's
+    // committed `.loom/config.json` has `autonomous.roleRunner.enabled: true`,
+    // so a daemon that had leaked back onto the real checkout would report
+    // `true` here.
+    assert_eq!(
+        repo_status
+            .get("role_runner_enabled")
+            .and_then(serde_json::Value::as_bool),
+        Some(false),
+        "test daemon must resolve the role runner as DISABLED (LOOM_ROLE_RUNNER=0), \
+         got: {repo_status:?}"
+    );
+}
+
+/// The confinement env vars must actually reach the spawned child's
+/// environment, with every path inside the daemon's own `TempDir` (#4573).
+///
+/// This complements the IPC assertion above: `LOOM_WORKTREE_ROOT` and
+/// `LOOM_WORK_FINDER` / `LOOM_EPIC_SUPERVISOR` are consumed internally and
+/// never surfaced over IPC, so reading the child's real environment is the only
+/// way to catch a future refactor that drops one of them.
+///
+/// Linux-only: it reads `/proc/<pid>/environ`. CI runs Linux; on other
+/// platforms the IPC assertions above still cover the workspace root.
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn test_daemon_child_env_is_fail_closed_and_temp_dir_confined() {
+    let daemon = TestDaemon::start().await.expect("Failed to start daemon");
+    let pid = daemon.pid().expect("daemon child is still running");
+
+    let raw = std::fs::read(format!("/proc/{pid}/environ"))
+        .unwrap_or_else(|e| panic!("failed to read /proc/{pid}/environ: {e}"));
+    let env: std::collections::HashMap<String, String> = String::from_utf8_lossy(&raw)
+        .split('\0')
+        .filter(|entry| !entry.is_empty())
+        .filter_map(|entry| {
+            entry
+                .split_once('=')
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+        })
+        .collect();
+
+    // Every autonomy toggle is explicitly off. `resolve_enabled()` treats a set
+    // env var as authoritative over config and only `1`/`true`/`yes`/`on`
+    // enables, so `"0"` fails closed regardless of the checkout's config.
+    for key in [
+        "LOOM_ROLE_RUNNER",
+        "LOOM_WORK_FINDER",
+        "LOOM_EPIC_SUPERVISOR",
+    ] {
+        assert_eq!(
+            env.get(key).map(String::as_str),
+            Some("0"),
+            "{key} must be explicitly disabled in the test daemon's environment"
+        );
+    }
+
+    // Every path the daemon resolves state from is inside its own `TempDir`.
+    let temp_canon = canon(daemon.workspace_path());
+    for key in [
+        "LOOM_WORKSPACE",
+        "LOOM_WORKSPACES_PATH",
+        "LOOM_WORKTREE_ROOT",
+    ] {
+        let value = env
+            .get(key)
+            .unwrap_or_else(|| panic!("{key} must be set in the test daemon's environment"));
+        let value_path = std::path::PathBuf::from(value);
+        assert!(
+            value_path.is_absolute(),
+            "{key}={value} must be absolute (a relative LOOM_WORKTREE_ROOT is \
+             rejected by worktree_root() and silently falls back to the default)"
+        );
+        // Compare against the canonical TempDir: for a path that does not exist
+        // yet (the daemon creates these lazily), `canon` returns it unchanged,
+        // so also accept the non-canonical prefix.
+        let confined = canon(&value_path).starts_with(&temp_canon)
+            || value_path.starts_with(daemon.workspace_path());
+        assert!(
+            confined,
+            "{key}={value} escapes the test daemon's TempDir {temp_canon:?} — a \
+             test daemon must never resolve state from outside its own scratch dir"
+        );
+    }
 }

--- a/loom-daemon/tests/integration_workspace_confinement.rs
+++ b/loom-daemon/tests/integration_workspace_confinement.rs
@@ -1,0 +1,102 @@
+// Regression test for Issue #4573: `TestDaemon::start()` must confine every
+// spawned test daemon to its own throwaway `TempDir`, never the real repo
+// checkout this test binary was built from.
+//
+// The incident this pins: `TestDaemon::start()` only set `LOOM_SOCKET_PATH`,
+// `RUST_LOG`, and `LOOM_NO_RESTORE` on the spawned daemon's environment. It
+// neither disabled the daemon's autonomous behavior (role runner / work
+// finder / epic supervisor) nor repointed its workspace root — so the
+// spawned test daemon inherited this repo's real `LOOM_WORKSPACE`/cwd and
+// read the real committed `.loom/config.json`
+// (`autonomous.roleRunner.enabled: true`), and could dispatch real
+// `/loom:sweep` sessions, burning API/GitHub rate-limit quota.
+//
+// This test asserts the fix structurally, via the daemon's own
+// `Request::DaemonStatus` IPC query: the resolved workspace root
+// (`per_repo[0].root`) must be inside the `TestDaemon`'s own `TempDir` — not
+// the real checkout this test binary lives under.
+
+// Integration tests - expect/unwrap are acceptable here since tests should panic on failure
+#![allow(clippy::expect_used)]
+#![allow(clippy::unwrap_used)]
+
+mod common;
+
+use common::{TestClient, TestDaemon};
+
+/// Query `Request::DaemonStatus` and return the (single) resolved workspace
+/// root from `per_repo[0].root`.
+async fn resolved_workspace_root(client: &mut TestClient) -> std::path::PathBuf {
+    let response = client
+        .send_request(serde_json::json!({"type": "DaemonStatus"}))
+        .await
+        .expect("DaemonStatus request failed");
+
+    assert_eq!(
+        response.get("type").and_then(serde_json::Value::as_str),
+        Some("DaemonStatus"),
+        "unexpected response: {response:?}"
+    );
+
+    let payload = response.get("payload").expect("DaemonStatus payload");
+    let per_repo = payload
+        .get("per_repo")
+        .and_then(serde_json::Value::as_array)
+        .expect("per_repo array");
+
+    assert_eq!(
+        per_repo.len(),
+        1,
+        "expected exactly one resolved workspace root (the isolated \
+         `LOOM_WORKSPACES_PATH` registry is empty, so `effective_roots()` \
+         must reduce to the single seeded default): {per_repo:?}"
+    );
+
+    let root = per_repo[0]
+        .get("root")
+        .and_then(serde_json::Value::as_str)
+        .expect("per_repo[0].root");
+    std::path::PathBuf::from(root)
+}
+
+/// A spawned `TestDaemon`'s resolved workspace root must be the daemon's own
+/// throwaway `TempDir` — never the real repo checkout this test binary was
+/// built from (#4573).
+#[tokio::test]
+async fn test_daemon_workspace_root_is_confined_to_its_own_temp_dir() {
+    let daemon = TestDaemon::start().await.expect("Failed to start daemon");
+    let mut client = TestClient::connect(daemon.socket_path())
+        .await
+        .expect("Failed to connect");
+
+    let resolved_root = resolved_workspace_root(&mut client).await;
+
+    // The daemon must resolve to (a canonical form of) the `TestDaemon`'s own
+    // `TempDir` — canonicalize both sides so a platform whose temp dir is
+    // itself a symlink (e.g. macOS `/tmp` -> `/private/tmp`) still compares
+    // correctly.
+    let expected_root = daemon.workspace_path();
+    let resolved_canon = std::fs::canonicalize(&resolved_root).unwrap_or(resolved_root.clone());
+    let expected_canon =
+        std::fs::canonicalize(expected_root).unwrap_or_else(|_| expected_root.to_path_buf());
+    assert_eq!(
+        resolved_canon, expected_canon,
+        "daemon resolved workspace root {resolved_root:?} does not match its own \
+         TempDir {expected_root:?} — LOOM_WORKSPACE was not honored"
+    );
+
+    // And, the load-bearing negative assertion: the resolved root must NOT be
+    // the real repo checkout this test binary was built from — the exact
+    // leak #4573 reports (a spawned test daemon inheriting the real
+    // `LOOM_WORKSPACE`/cwd and reading the real committed `.loom/config.json`).
+    let real_repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("loom-daemon has a parent directory (the repo root)");
+    let real_repo_canon =
+        std::fs::canonicalize(real_repo_root).unwrap_or_else(|_| real_repo_root.to_path_buf());
+    assert_ne!(
+        resolved_canon, real_repo_canon,
+        "daemon resolved workspace root must not be the real repo checkout {real_repo_canon:?} \
+         — a spawned test daemon must never see the real repo's committed .loom/config.json"
+    );
+}


### PR DESCRIPTION
Closes #4573

## Summary

`TestDaemon::start()` spawns a **real** `loom-daemon` child but set only
`LOOM_SOCKET_PATH`, `RUST_LOG`, and `LOOM_NO_RESTORE`. Nothing disabled the
daemon's autonomous loops and nothing repointed its workspace root, so a test
daemon inherited the invoking process's `LOOM_WORKSPACE`/cwd, resolved the
**real** checkout, and read this repo's committed `.loom/config.json` — which has
`autonomous.roleRunner.enabled: true`. A test daemon was therefore *permitted* to
poll the forge, claim issues, dispatch `/loom:sweep` sessions, and spend real
Claude/GitHub quota. Under process-per-test execution (#4385) that is one
opportunity per test, not per suite.

This makes every daemon spawn in the suite fail closed: autonomy explicitly off
and every state-resolution path pinned inside the test's own `TempDir`.

## Changes

`loom-daemon/tests/common/mod.rs` — `TestDaemon::start()`:

- `LOOM_ROLE_RUNNER=0`, `LOOM_WORK_FINDER=0`, `LOOM_EPIC_SUPERVISOR=0`. Each
  `resolve_enabled()` treats a *set* env var as authoritative over config and
  only `1`/`true`/`yes`/`on` enables, so `"0"` fails closed regardless of which
  repo's config the daemon ends up resolving.
- `LOOM_WORKSPACE` → the test's `TempDir`; `LOOM_WORKSPACES_PATH` → a scratch
  `workspaces.json` (so `effective_roots()` cannot pick up the host's real
  workspace registry); `LOOM_WORKTREE_ROOT` → `<temp>/worktrees`.
- `pid()` accessor, so the regression test can read the child's real environment.

`loom-daemon/tests/integration_workspace_confinement.rs` (new) — two
complementary regression tests, see Acceptance Criteria below.

`loom-daemon/tests/integration_drain_then_exit.rs` — the suite's only daemon
spawn outside `TestDaemon::start()`; carries the same fail-closed env. It already
pinned `LOOM_WORKSPACE`/`LOOM_WORKSPACES_PATH` for an unrelated reason (drain
would never complete while counting the host's real in-flight sweeps).

`loom-daemon/tests/README.md` — documents the confinement invariant and points a
future spawn site at it.

## Design notes (decisions the issue asked to be stated)

**`LOOM_WORKTREE_ROOT` is not redundant with `LOOM_WORKSPACE`.** The first commit
on this branch omitted it, reasoning that `worktree_root()` derives its default
from the `repo_root` argument. That holds only while the var is *unset* — it is
`worktree_root()`'s **highest-priority** source (`worktree_root.rs`), ahead of
both `worktree.root` in config and the derived default, and a spawned child
inherits the parent's environment. On a host using the documented
external-scratch-volume setup, an unpinned test daemon resolves worktrees onto
that real volume even with `LOOM_WORKSPACE` confined. It is pinned to an absolute
path (a relative override is rejected and silently falls back to the default).
The daemon namespaces an override by repo basename, so the effective root is
`<temp>/worktrees/<temp-basename>` — still inside the `TempDir`.

**Targeted `.env()` calls over `.env_clear()` + allowlist.** The issue and
Curator both raised `.env_clear()` as a structurally stronger option; it is
explicitly a stretch goal, and this PR does not take it. Rationale: the daemon
legitimately needs a large, not-fully-enumerable slice of the ambient environment
to start and to run tmux (`PATH`, `HOME`, `USER`, `TMPDIR`, `TERM`, `SHELL`, the
`XDG_*` and tmux/SSH socket vars, `CARGO_*`/`RUST*` under `cargo test`,
`GH_TOKEN`/proxy vars). A too-narrow allowlist fails in a way that is expensive
to debug and platform-dependent, and an allowlist wide enough to be safe
re-admits the same leak surface. The leak-by-omission risk it would remove is
instead covered by a test: the second regression test below asserts the child's
*actual* environment, so a future autonomous feature that adds a new toggle
without adding it here is caught by a failing test rather than by a quota bill.
If that trade ever flips, `.env_clear()` remains available and the test is
already the right guard for it.

## Acceptance Criteria Verification

- [x] **`LOOM_ROLE_RUNNER=0`, `LOOM_WORK_FINDER=0`, `LOOM_EPIC_SUPERVISOR=0` set
  on the spawned daemon's environment** — `common/mod.rs`; asserted on the
  child's real environment by
  `test_daemon_child_env_is_fail_closed_and_temp_dir_confined`.
- [x] **`LOOM_WORKSPACE` (and `LOOM_WORKTREE_ROOT`, confirmed to be read
  independently) pinned to the test's `TempDir`** — `common/mod.rs`;
  `LOOM_WORKSPACES_PATH` pinned too, since `effective_roots()` would otherwise
  merge the host's registered workspaces.
- [x] **A regression test asserts the resolved workspace root is inside the
  `TempDir`, not the real checkout.**
  `test_daemon_workspace_root_is_confined_to_its_own_temp_dir` queries
  `Request::DaemonStatus` over IPC and asserts `per_repo[0].root` equals the
  daemon's own `TempDir` (canonicalized) and is *not* the real checkout. It also
  asserts `per_repo[0].role_runner_enabled == false`, which is resolved
  daemon-side through the same `env > config > default` chain — so it proves the
  child **honored** the toggle, not merely that `Command` was handed it (a daemon
  that had leaked back onto this checkout reports `true`).
  `test_daemon_child_env_is_fail_closed_and_temp_dir_confined` reads
  `/proc/<pid>/environ` (Linux-gated; CI is Linux) and asserts all three toggles
  are `"0"` and all three paths are absolute and inside the `TempDir` — the only
  coverage for `LOOM_WORKTREE_ROOT`, which the daemon consumes internally and
  never reports over IPC.
- [x] **All four integration suites still pass unchanged** — no source changes to
  any of them; run output below.

## Test Plan

```
cargo test -p loom-daemon --test integration_basic --test integration_factory_reset \
  --test integration_security --test integration_singleton_guard
  integration_basic            9 passed
  integration_factory_reset    2 passed
  integration_security        14 passed
  integration_singleton_guard  2 passed

cargo test -p loom-daemon --test integration_workspace_confinement   2 passed
cargo test -p loom-daemon --test integration_drain_then_exit         1 passed

cargo fmt -p loom-daemon; cargo clippy -p loom-daemon --tests        clean
```

The diff is test-only (`loom-daemon/tests/**`, +294/-0, no `src/` changes), so no
`--lib`/`--bins` target can be affected. The full `bash .loom/scripts/build-gate.sh`
was not completed locally: it blocked in the machine-wide build-slot queue behind
another session's gate run for the duration of this session.

## Notes / out of scope

- `cleanup_all_loom_sessions()` killing every `loom-*` tmux session host-wide is
  the other way this suite reaches outside itself (noted in #4573's Related
  section, via #4385). Not touched here — it is a distinct blast radius from the
  autonomy/workspace leak and warrants its own change.
- Branch is based on `94e3a3c3`, currently 6 commits behind `origin/main`; the
  diff touches only files untouched by those commits.
