### PR TITLE
fix(loom): harvest+re-export live plist/unit env in restart bare-exec fallback

### DIFF
--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -234,6 +234,19 @@ show_help() {
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# harvest_plist_env / harvest_unit_env (used by perform_relaunch /
+# perform_systemd_relaunch below) live in lib/daemon-env-harvest.sh (#4581) so
+# scripts/loom's loom_cmd_restart() bare-exec fallback can apply the identical
+# harvest-and-preserve pattern from a single source instead of a second copy.
+_LOOM_ENV_HARVEST_LIB="$SCRIPT_DIR/../lib/daemon-env-harvest.sh"
+if [[ -r "$_LOOM_ENV_HARVEST_LIB" ]]; then
+    # shellcheck source=/dev/null
+    source "$_LOOM_ENV_HARVEST_LIB"
+else
+    err "daemon-env-harvest.sh not found at $_LOOM_ENV_HARVEST_LIB — this checkout is missing an expected lib file."
+    exit 1
+fi
+
 # ---------- repo root ----------
 find_repo_root() {
     local dir="$PWD"
@@ -862,45 +875,10 @@ log_launchd_diagnostics() {
 # hardcodes the two supervised keys), preserving the live plist's autonomy/auth
 # env, and to stop the old daemon gracefully so sweep children reparent.
 
-# harvest_plist_env <plist> — echo the live plist's EnvironmentVariables,
-# restricted to exactly the keys render_launchd_plist itself forwards (LOOM_*,
-# GH_TOKEN, GITEA_TOKEN, FORGE_TOKEN) and EXCLUDING:
-#   - PATH / HOME     (start.sh resolves PATH deterministically -- a pinned
-#                      canonical minimal PATH by default, or an explicit
-#                      LOOM_DAEMON_PATH / LOOM_DAEMON_PATH_EXTRA override,
-#                      #4172; round-tripping the plist's PATH here would
-#                      re-introduce the non-deterministic-render bug),
-#   - LOOM_DAEMON_SUPERVISOR (start.sh hardcodes it; re-exporting is pointless).
-# Emits one "<key>\t<base64(value)>" line per key so values containing spaces or
-# newlines survive. Fails loudly (return 2) when the plist is absent or
-# unparseable — it must NEVER silently return an empty set, which would let the
-# re-render narrow the autonomy flags to FLAGS-OFF defaults (the #4011 class).
-harvest_plist_env() {
-    local plist="$1"
-    if [[ ! -f "$plist" ]]; then
-        err "Cannot harvest launchd env: plist not found at $plist"
-        return 2
-    fi
-    if ! command -v plutil >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
-        err "Cannot harvest launchd env: plutil and jq are both required on the macOS launchd path."
-        return 2
-    fi
-    local json
-    json=$(plutil -convert json -o - "$plist" 2>/dev/null) || {
-        err "Cannot harvest launchd env: plist at $plist is not parseable by plutil."
-        return 2
-    }
-    printf '%s' "$json" | jq -r '
-        .EnvironmentVariables // {}
-        | to_entries[]
-        | select(.key | test("^(LOOM_[A-Za-z0-9_]*|GH_TOKEN|GITEA_TOKEN|FORGE_TOKEN)$"))
-        | select(.key != "LOOM_DAEMON_SUPERVISOR")
-        | .key + "\t" + (.value | @base64)
-    ' 2>/dev/null || {
-        err "Cannot harvest launchd env: failed to extract EnvironmentVariables from $plist."
-        return 2
-    }
-}
+# harvest_plist_env is defined in lib/daemon-env-harvest.sh (#4581, sourced
+# near the top of this script) — shared with scripts/loom's loom_cmd_restart()
+# bare-exec fallback so both call sites apply the identical harvest-and-
+# preserve pattern from one source instead of two drifting copies.
 
 # perform_relaunch <plist> <service> — re-render the LaunchAgent and relaunch it
 # under launchd supervision, preserving the live plist's autonomy/auth env.
@@ -953,37 +931,9 @@ perform_relaunch() {
     "$START_SCRIPT"
 }
 
-# harvest_unit_env <unit_path> — echo the live systemd unit's `Environment=`
-# lines, restricted to exactly the keys render_systemd_unit itself forwards
-# (LOOM_*, GH_TOKEN, GITEA_TOKEN, FORGE_TOKEN) and EXCLUDING:
-#   - PATH / HOME     (start.sh resolves PATH deterministically, mirroring the
-#                      launchd plist path — round-tripping the unit's PATH here
-#                      would re-introduce the non-deterministic-render bug),
-#   - LOOM_DAEMON_SUPERVISOR (start.sh hardcodes it; re-exporting is pointless).
-# Emits one "<key>\t<value>" line per key (a systemd `Environment=KEY=VALUE`
-# line is single-valued, unlike the plist's XML dict, so no base64 round-trip is
-# needed here). Fails loudly (return 2) when the unit file is absent — it must
-# NEVER silently return an empty set, which would let the re-render narrow the
-# autonomy flags to FLAGS-OFF defaults (the #4011 class).
-harvest_unit_env() {
-    local unit_path="$1"
-    if [[ ! -f "$unit_path" ]]; then
-        err "Cannot harvest systemd unit env: unit file not found at $unit_path"
-        return 2
-    fi
-    local line rest key value
-    while IFS= read -r line; do
-        [[ "$line" == Environment=* ]] || continue
-        rest="${line#Environment=}"
-        key="${rest%%=*}"
-        value="${rest#*=}"
-        case "$key" in
-            LOOM_DAEMON_SUPERVISOR) continue ;;
-            LOOM_*|GH_TOKEN|GITEA_TOKEN|FORGE_TOKEN) printf '%s\t%s\n' "$key" "$value" ;;
-            *) continue ;;
-        esac
-    done < "$unit_path"
-}
+# harvest_unit_env is defined in lib/daemon-env-harvest.sh (#4581, sourced
+# near the top of this script) — see the harvest_plist_env pointer comment
+# above perform_relaunch for why it moved.
 
 # perform_systemd_relaunch <unit_path> <unit> — re-render the systemd --user
 # unit and relaunch it under supervision, preserving the live unit's

--- a/defaults/scripts/lib/daemon-env-harvest.sh
+++ b/defaults/scripts/lib/daemon-env-harvest.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# daemon-env-harvest.sh — shared harvesters for a live launchd plist's /
+# systemd unit's LOOM_*/token EnvironmentVariables (#4581).
+#
+# Extracted from loom-daemon-update.sh's perform_relaunch / perform_systemd_
+# relaunch (#4118/#4126), which already apply the harvest-and-preserve
+# pattern on ITS equivalent refused-restart fallback: before re-rendering the
+# plist/unit, read back the LIVE installed file's LOOM_*/token env and
+# re-export it, so the re-render never silently narrows to whatever LOOM_*
+# vars happen to be exported in the invoking shell. scripts/loom's
+# `loom_cmd_restart()` bare-exec fallback had the identical shape but skipped
+# this step entirely (the #4522/#4579 incident) — sharing this lib lets both
+# call sites apply the same, single-sourced pattern instead of drifting.
+#
+# Source this file (do not exec). Defines two functions:
+#
+#   harvest_plist_env <plist>
+#     Echoes "<key>\t<base64(value)>" lines (one per key, base64 so values
+#     with spaces/newlines survive) restricted to exactly the keys
+#     render_launchd_plist (loom-daemon-start.sh) itself forwards — LOOM_*,
+#     GH_TOKEN, GITEA_TOKEN, FORGE_TOKEN — and EXCLUDING:
+#       - PATH / HOME     (start.sh resolves PATH deterministically; round-
+#                          tripping the plist's PATH here would re-introduce
+#                          the non-deterministic-render bug it fixed, #4172)
+#       - LOOM_DAEMON_SUPERVISOR (start.sh hardcodes it; re-exporting is
+#                          pointless)
+#     Returns 2 (with a stderr diagnostic) when the plist is missing or
+#     unparseable (plutil/jq absent, or the plist fails to parse) — NEVER
+#     silently returns an empty set, which would let a caller re-render into
+#     a silently-narrowed, FLAGS-OFF-defaults autonomy config (#4011).
+#
+#   harvest_unit_env <unit_path>
+#     Echoes "<key>\t<value>" lines (no base64 — a systemd `Environment=`
+#     line is single-valued) with the identical key allowlist/exclusion,
+#     mirroring render_systemd_unit (loom-daemon-start.sh). Returns 2 (with a
+#     stderr diagnostic) when the unit file is missing — same "never return
+#     an empty set silently" contract as harvest_plist_env.
+#
+# Callers decide what "harvest failed" means for them (loom-daemon-update.sh's
+# perform_relaunch/perform_systemd_relaunch treat it as a hard abort; see
+# scripts/loom's loom_cmd_restart() for the equivalent bare-exec-fallback use).
+
+harvest_plist_env() {
+    local plist="$1"
+    if [[ ! -f "$plist" ]]; then
+        echo "Cannot harvest launchd env: plist not found at $plist" >&2
+        return 2
+    fi
+    if ! command -v plutil >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+        echo "Cannot harvest launchd env: plutil and jq are both required on the macOS launchd path." >&2
+        return 2
+    fi
+    local json
+    json=$(plutil -convert json -o - "$plist" 2>/dev/null) || {
+        echo "Cannot harvest launchd env: plist at $plist is not parseable by plutil." >&2
+        return 2
+    }
+    printf '%s' "$json" | jq -r '
+        .EnvironmentVariables // {}
+        | to_entries[]
+        | select(.key | test("^(LOOM_[A-Za-z0-9_]*|GH_TOKEN|GITEA_TOKEN|FORGE_TOKEN)$"))
+        | select(.key != "LOOM_DAEMON_SUPERVISOR")
+        | .key + "\t" + (.value | @base64)
+    ' 2>/dev/null || {
+        echo "Cannot harvest launchd env: failed to extract EnvironmentVariables from $plist." >&2
+        return 2
+    }
+}
+
+harvest_unit_env() {
+    local unit_path="$1"
+    if [[ ! -f "$unit_path" ]]; then
+        echo "Cannot harvest systemd unit env: unit file not found at $unit_path" >&2
+        return 2
+    fi
+    local line rest key value
+    while IFS= read -r line; do
+        [[ "$line" == Environment=* ]] || continue
+        rest="${line#Environment=}"
+        key="${rest%%=*}"
+        value="${rest#*=}"
+        case "$key" in
+            LOOM_DAEMON_SUPERVISOR) continue ;;
+            LOOM_*|GH_TOKEN|GITEA_TOKEN|FORGE_TOKEN) printf '%s\t%s\n' "$key" "$value" ;;
+            *) continue ;;
+        esac
+    done < "$unit_path"
+}

--- a/defaults/scripts/tests/test-loom-dispatcher.sh
+++ b/defaults/scripts/tests/test-loom-dispatcher.sh
@@ -29,6 +29,7 @@ DISPATCHER="$REPO_ROOT/scripts/loom"
 PROVISION_LIB="$REPO_ROOT/scripts/install/provision-dispatcher.sh"
 REAL_RESOLVER="$REPO_ROOT/defaults/scripts/lib/config-resolver.sh"
 REAL_SPAWN_WORKER="$REPO_ROOT/defaults/scripts/spawn-worker.sh"
+REAL_HARVEST_LIB="$REPO_ROOT/defaults/scripts/lib/daemon-env-harvest.sh"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -76,6 +77,28 @@ echo "STUB_UPDATE args=[$*] machine_checkout=[${LOOM_MACHINE_CHECKOUT:-}]"
 EOF
     chmod +x "$c/defaults/scripts/cli/"*.sh
     cp "$REAL_RESOLVER" "$c/defaults/scripts/lib/config-resolver.sh"
+    printf '%s\n' "$c"
+}
+
+# Like make_checkout(), but ALSO ships a real copy of lib/daemon-env-harvest.sh
+# (#4581) and a loom-daemon-start.sh stub that echoes back the LOOM_WORK_FINDER
+# / LOOM_MAIN_HEALTH_GATE env it inherited — so a restart-fallback test can
+# assert the harvest-and-preserve pattern actually re-exported values from a
+# live plist/unit BEFORE this stub ran, not merely that the stub ran at all.
+make_checkout_with_harvest() {
+    local c; c="$(mktemp -d)"
+    mkdir -p "$c/defaults/scripts/cli" "$c/defaults/scripts/lib"
+    cat > "$c/defaults/scripts/cli/loom-daemon-start.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "STUB_START args=[$*] LOOM_WORK_FINDER=[${LOOM_WORK_FINDER:-}] LOOM_MAIN_HEALTH_GATE=[${LOOM_MAIN_HEALTH_GATE:-}]"
+EOF
+    cat > "$c/defaults/scripts/cli/loom-daemon-stop.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "STUB_STOP args=[$*]"
+EOF
+    chmod +x "$c/defaults/scripts/cli/"*.sh
+    cp "$REAL_RESOLVER" "$c/defaults/scripts/lib/config-resolver.sh"
+    cp "$REAL_HARVEST_LIB" "$c/defaults/scripts/lib/daemon-env-harvest.sh"
     printf '%s\n' "$c"
 }
 
@@ -356,6 +379,72 @@ set -e 2>/dev/null || true
 assert_eq "$rc" "0" "'loom restart --machine' with no loom-daemon on PATH falls back to stop+start"
 assert_contains "$out" "STUB_STOP" "fallback invokes the stop delegate (no loom-daemon on PATH)"
 assert_contains "$out" "STUB_START" "fallback invokes the start delegate (no loom-daemon on PATH)"
+
+# ── #4581: bare-exec fallback harvests + re-exports the live plist/unit env ──
+echo "Test 16b: 'loom restart --machine' harvests + re-exports the live systemd unit's LOOM_* env before the bare-exec fallback (#4581)"
+CHK_HARVEST=$(make_checkout_with_harvest)
+HOME_HARVEST=$(mktemp -d)
+mkdir -p "$HOME_HARVEST/.config/systemd/user"
+cat > "$HOME_HARVEST/.config/systemd/user/loom-daemon.service" <<'EOF'
+[Service]
+Environment=LOOM_DAEMON_SUPERVISOR=systemd
+Environment=LOOM_WORK_FINDER=1
+Environment=LOOM_MAIN_HEALTH_GATE=1
+Environment=PATH=/opt/sentinel-4581/bin:/usr/bin:/bin
+EOF
+set +e
+out=$(cd "$CONSUMER" && PATH="/usr/bin:/bin" HOME="$HOME_HARVEST" LOOM_HOME="$CHK_HARVEST" bash "$DISPATCHER" restart --machine 2>&1)
+rc=$?
+set -e 2>/dev/null || true
+assert_eq "$rc" "0" "harvest-and-preserve restart fallback still exits 0"
+assert_contains "$out" "LOOM_WORK_FINDER=[1]" "harvested LOOM_WORK_FINDER reaches start_target's re-render (#4581)"
+assert_contains "$out" "LOOM_MAIN_HEALTH_GATE=[1]" "harvested LOOM_MAIN_HEALTH_GATE reaches start_target's re-render (#4581)"
+assert_contains "$out" "preserved 2 LOOM_*/token env var(s)" "dispatcher reports the harvested count"
+
+echo "Test 16c: 'loom restart --machine' skips harvesting (no-op) when no plist/unit is installed yet (first-ever start, #4581)"
+CHK_HARVEST_EMPTY=$(make_checkout_with_harvest)
+HOME_EMPTY=$(mktemp -d)
+set +e
+out=$(cd "$CONSUMER" && PATH="/usr/bin:/bin" HOME="$HOME_EMPTY" LOOM_HOME="$CHK_HARVEST_EMPTY" bash "$DISPATCHER" restart --machine 2>&1)
+rc=$?
+set -e 2>/dev/null || true
+assert_eq "$rc" "0" "restart fallback with nothing installed yet still exits 0"
+assert_contains "$out" "STUB_START" "fallback still reaches start_target with nothing to harvest"
+assert_not_contains "$out" "preserved" "no harvest-preserved message when no plist/unit exists"
+
+echo "Test 16d: 'loom restart --machine' aborts (exit 6) rather than falling back silently when a live plist exists but cannot be read (#4581, the #4011 class)"
+CHK_HARVEST_BAD=$(make_checkout_with_harvest)
+HOME_DARWIN=$(mktemp -d)
+mkdir -p "$HOME_DARWIN/Library/LaunchAgents"
+echo "not a real plist" > "$HOME_DARWIN/Library/LaunchAgents/com.rjwalters.loom-daemon.plist"
+# Fake `uname` -> Darwin so the launchd-gated harvest branch fires
+# deterministically on any host (mirrors test-loom-daemon-update.sh's
+# write_fake_launchd_loaded_bin pattern). `plutil` is genuinely absent on this
+# (Linux) test host, which is exactly the "cannot harvest" failure this test
+# exercises — no plutil stub needed.
+FAKE_UNAME_BIN=$(mktemp -d)
+cat > "$FAKE_UNAME_BIN/uname" <<'EOF'
+#!/usr/bin/env bash
+echo "Darwin"
+EOF
+chmod +x "$FAKE_UNAME_BIN/uname"
+set +e
+out=$(cd "$CONSUMER" && PATH="$FAKE_UNAME_BIN:/usr/bin:/bin" HOME="$HOME_DARWIN" LOOM_HOME="$CHK_HARVEST_BAD" bash "$DISPATCHER" restart --machine 2>&1)
+rc=$?
+set -e 2>/dev/null || true
+assert_eq "$rc" "6" "restart fallback aborts (exit 6) when the live plist cannot be parsed"
+assert_contains "$out" "Refusing to fall back" "abort message explains the refusal"
+assert_not_contains "$out" "STUB_START" "aborted fallback never reaches start_target (no silently-narrowed relaunch)"
+
+echo "Test 16e: 'loom restart --machine' still falls back cleanly when this checkout predates daemon-env-harvest.sh (#4581 backward-compat)"
+CHK_NO_HARVEST_LIB=$(make_checkout)
+set +e
+out=$(cd "$CONSUMER" && PATH="/usr/bin:/bin" LOOM_HOME="$CHK_NO_HARVEST_LIB" bash "$DISPATCHER" restart --machine 2>&1)
+rc=$?
+set -e 2>/dev/null || true
+assert_eq "$rc" "0" "restart fallback exits 0 even when daemon-env-harvest.sh is absent from the checkout"
+assert_contains "$out" "daemon-env-harvest.sh not found" "missing-lib warning is surfaced, not silently swallowed"
+assert_contains "$out" "STUB_START" "fallback still reaches start_target when the harvest lib predates #4581"
 
 echo "Test 17: 'restart' is documented in help output"
 help_out=$(LOOM_HOME="$CHK" bash "$DISPATCHER" help 2>&1)

--- a/scripts/loom
+++ b/scripts/loom
@@ -273,6 +273,80 @@ loom_cmd_update() {
     exec "$target" "$@"
 }
 
+# loom_restart_harvest_live_env <scripts_dir> — before loom_cmd_restart's
+# bare-exec fallback re-renders the plist/unit via start_target, harvest and
+# re-export the LIVE installed launchd plist's / systemd unit's LOOM_*/token
+# env (#4581). Mirrors the harvest-and-preserve pattern
+# loom-daemon-update.sh's perform_relaunch / perform_systemd_relaunch
+# (#4118/#4126) already apply on its equivalent refused-restart path — shared
+# via lib/daemon-env-harvest.sh (harvest_plist_env / harvest_unit_env) so both
+# call sites stay byte-for-byte identical instead of drifting.
+#
+# Without this, the fallback's bare `exec` inherited only whatever LOOM_* vars
+# happened to be exported in the INVOKING shell — a fresh terminal, a
+# different SSH session, or any wrapper that doesn't re-source the operator's
+# profile silently narrowed a rich plist down to FLAGS-OFF defaults (the
+# #4522/#4579 incident this closes).
+#
+# Best-effort by design when there is nothing to harvest: a daemon that has
+# never been installed under launchd/systemd yet (first-ever start), or one
+# running the legacy pid-file/nohup path, has no live plist/unit file — in
+# that case the invoking shell's env is legitimately the only source, exactly
+# as before, so this is a silent no-op. It is a HARD abort (exit 6) only when
+# a plist/unit file DOES exist but cannot be read back — proceeding then would
+# silently narrow a real, live autonomy config (the #4011 class), the exact
+# failure this issue closes.
+loom_restart_harvest_live_env() {
+    local scripts_dir="$1"
+    local harvest_lib="$scripts_dir/lib/daemon-env-harvest.sh"
+    if [[ ! -r "$harvest_lib" ]]; then
+        _warn "daemon-env-harvest.sh not found under $scripts_dir/lib — skipping live-env harvest (this checkout may predate #4581)."
+        return 0
+    fi
+    # shellcheck source=/dev/null
+    source "$harvest_lib"
+
+    local count=0 harvested k
+    if [[ "$(uname -s 2>/dev/null)" == "Darwin" ]]; then
+        local label plist
+        label="${LOOM_LAUNCHD_LABEL:-com.rjwalters.loom-daemon}"
+        plist="$HOME/Library/LaunchAgents/${label}.plist"
+        if [[ -f "$plist" ]]; then
+            if ! harvested="$(harvest_plist_env "$plist")"; then
+                _err "Refusing to fall back to a bare restart: could not read the live plist's EnvironmentVariables at $plist."
+                _err "Falling back now would silently narrow the autonomy flags to FLAGS-OFF defaults (#4011) — aborting."
+                exit 6
+            fi
+            local v64
+            while IFS=$'\t' read -r k v64; do
+                [[ -z "$k" ]] && continue
+                export "$k=$(printf '%s' "$v64" | base64 --decode)"
+                count=$((count + 1))
+            done <<< "$harvested"
+        fi
+    else
+        local unit unit_path
+        unit="${LOOM_SYSTEMD_UNIT:-loom-daemon.service}"
+        unit_path="$HOME/.config/systemd/user/${unit}"
+        if [[ -f "$unit_path" ]]; then
+            if ! harvested="$(harvest_unit_env "$unit_path")"; then
+                _err "Refusing to fall back to a bare restart: could not read the live unit's Environment= values at $unit_path."
+                _err "Falling back now would silently narrow the autonomy flags to FLAGS-OFF defaults (#4011) — aborting."
+                exit 6
+            fi
+            local v
+            while IFS=$'\t' read -r k v; do
+                [[ -z "$k" ]] && continue
+                export "$k=$v"
+                count=$((count + 1))
+            done <<< "$harvested"
+        fi
+    fi
+    if [[ "$count" -gt 0 ]]; then
+        echo "loom: preserved ${count} LOOM_*/token env var(s) from the live installed plist/unit across the restart fallback (#4581)."
+    fi
+}
+
 # `restart` (Gap 3, #4229): the filed scope lists start|stop|status|restart, but
 # only the first three shipped in #4157/#4208. Thin delegate mirroring
 # start/stop — same collision guard (the per-repo pool manager has no
@@ -280,7 +354,10 @@ loom_cmd_update() {
 # preferring drain-and-roll semantics: try the daemon's own supervised restart
 # IPC first (`loom-daemon restart`, #4077 — never tears down in-flight sweep
 # children, unlike a bootout), falling back to a plain stop-then-start when the
-# daemon isn't launchd-managed (or isn't running at all yet).
+# daemon isn't launchd-managed (or isn't running at all yet). The fallback
+# harvests+re-exports the live installed plist's/unit's LOOM_*/token env
+# before re-rendering (#4581, loom_restart_harvest_live_env above) instead of
+# relying on whatever the invoking shell happens to have exported.
 loom_cmd_restart() {
     loom_detect_context
     loom_collision_guard restart "$@"
@@ -312,6 +389,12 @@ loom_cmd_restart() {
         _err "loom-daemon-stop.sh failed — not starting a new binary on top of a possibly-still-running old one."
         exit 1
     fi
+    # Harvest-and-preserve (#4581): re-export the live installed plist's/unit's
+    # LOOM_*/token env BEFORE the bare exec below, so start_target's re-render
+    # does not silently narrow to whatever LOOM_* vars this shell happens to
+    # have exported. No-op when nothing is installed yet; aborts (exit 6) if a
+    # plist/unit exists but cannot be read back.
+    loom_restart_harvest_live_env "$scripts_dir"
     # `${arr[@]+…}` guard: see loom_exec_checkout_script above.
     exec "$start_target" ${passthrough[@]+"${passthrough[@]}"}
 }


### PR DESCRIPTION
## Summary

`scripts/loom`'s `loom_cmd_restart()` tries the supervised `loom-daemon restart`
IPC first, but when that's unavailable/refused it fell back to a bare
`exec "$start_target" ...` with no env re-export at all — it inherited only
whatever `LOOM_*` vars happened to be exported in the invoking shell. A fresh
terminal, different SSH session, or any wrapper that doesn't re-source the
operator's profile reproduces the #4522 incident (rich plist re-rendered down
to a minimal one, silently narrowed).

`loom-daemon-update.sh`'s equivalent refused-restart fallback
(`perform_relaunch` / `perform_systemd_relaunch`, #4118/#4126) already
harvests and re-exports the live file's `LOOM_*`/token env before
re-rendering (or aborts with exit 6 if the harvest fails). This PR ports that
same harvest-and-preserve pattern into `loom_cmd_restart()`'s fallback.

## Changes

- New `defaults/scripts/lib/daemon-env-harvest.sh`: extracts
  `harvest_plist_env` / `harvest_unit_env` out of
  `loom-daemon-update.sh` (previously private, duplicated-in-spirit logic) so
  both `loom-daemon-update.sh` and `scripts/loom` share a single
  implementation instead of drifting.
- `defaults/scripts/cli/loom-daemon-update.sh`: sources the new shared lib
  instead of defining `harvest_plist_env`/`harvest_unit_env` inline; behavior
  is unchanged (`perform_relaunch`/`perform_systemd_relaunch` call the same
  functions, now imported).
- `scripts/loom`: new `loom_restart_harvest_live_env()` helper, invoked from
  `loom_cmd_restart()`'s bare-exec fallback right before the `exec`. On
  Darwin it harvests from the live launchd plist
  (`$HOME/Library/LaunchAgents/${LOOM_LAUNCHD_LABEL:-com.rjwalters.loom-daemon}.plist`);
  elsewhere it harvests from the live systemd `--user` unit
  (`$HOME/.config/systemd/user/${LOOM_SYSTEMD_UNIT:-loom-daemon.service}`).
  No-op (nothing to harvest) when no plist/unit is installed yet — the
  legitimate first-ever-start case. Hard abort (exit 6) when a plist/unit
  exists but cannot be read back, rather than silently narrowing autonomy
  flags to FLAGS-OFF defaults. Backward-compatible: warns and continues (no
  harvest) if a checkout predates this lib file.
- `defaults/scripts/tests/test-loom-dispatcher.sh`: 5 new test cases (16b-16e)
  covering the harvest-and-preserve pass-through, the no-op case, the
  hard-abort case, and the backward-compat (missing-lib) case.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Bare-exec fallback harvests + re-exports live plist/unit `LOOM_*`/token env before re-rendering | done | New Test 16b: a fake systemd unit exporting `LOOM_WORK_FINDER=1`/`LOOM_MAIN_HEALTH_GATE=1` is harvested and observed in `start_target`'s env, with no reliance on the invoking shell's env |
| Aborts with a clear error if harvest fails (mirrors `perform_relaunch`/`perform_systemd_relaunch`'s exit 6) | done | New Test 16d: a live plist exists but cannot be parsed (fakes `uname`->Darwin; `plutil` genuinely absent on the test host) -> exits 6, prints "Refusing to fall back...", never reaches `start_target` |
| Reuses the same pattern as `loom-daemon-update.sh`, not a second copy | done | `harvest_plist_env`/`harvest_unit_env` now live in one file (`lib/daemon-env-harvest.sh`), sourced by both `loom-daemon-update.sh` and `scripts/loom` |
| No regression to existing restart behavior (no-op when nothing installed, backward-compat with older checkouts) | done | New Test 16c (no plist/unit -> silent no-op, still reaches `start_target`) and Test 16e (lib file absent -> warns, still reaches `start_target`) |

## Test Plan

- `bash -n` + `shellcheck --severity=warning` on all touched/added shell files - clean.
- `bash defaults/scripts/tests/test-loom-dispatcher.sh` - 96/99 passed (the 3
  failures are pre-existing, in Test 21's `runtimes.default` config
  resolution, unrelated to this change - reproduced identically on `main`
  before this PR).
- Manual end-to-end reproduction outside the test harness: built a fake
  machine checkout + systemd unit fixture and confirmed `loom restart
  --machine`'s fallback path re-exports `LOOM_WORK_FINDER`/
  `LOOM_MAIN_HEALTH_GATE` from the live unit into `start_target`'s env
  (previously would have been empty); confirmed the no-plist/no-lib no-op
  cases and the hard-abort-on-unreadable-plist case all behave as designed.
- `defaults/scripts/tests/test-loom-daemon-update.sh` (the suite covering
  `perform_relaunch`/`perform_systemd_relaunch`) was not run to full
  completion - one of its "full flow" fixtures triggers a real
  `cargo build --release` plus long polling loops, and reproduces the same
  multi-minute stall on this sandbox with or without this PR's changes
  (confirmed on a pre-change baseline run). Not wired into CI
  (`.github/workflows/ci.yml` has no reference to it), consistent with it
  being a manual/on-demand suite.

Closes #4581