### PR TITLE
fix(champion): add idempotency guard to transient-rejection PR comments

### DIFF
--- a/defaults/.claude/commands/loom/champion-pr-merge.md
+++ b/defaults/.claude/commands/loom/champion-pr-merge.md
@@ -728,14 +728,48 @@ If ANY safety criterion fails, do NOT merge. How the failure is handled depends 
 
 ### Transient failures — keep `loom:pr`, retry next tick
 
-Add a comment explaining why, and **keep the `loom:pr` label** so the PR is re-evaluated on the next Champion tick once the blocking condition clears:
+Add a comment explaining why, and **keep the `loom:pr` label** so the PR is re-evaluated on the next Champion tick once the blocking condition clears.
+
+**Idempotency guard (mirrors the stale-PR pattern above, #4586).** A static failing
+criterion (e.g. a size check that cannot pass without a new push) is guaranteed to
+fail identically on every re-evaluation, and closely-spaced Champion ticks (cron +
+daemon role runner, or a busy period with multiple ticks in flight) can hit the same
+PR several times before the condition changes — left unguarded, this reposts a
+near-identical rejection comment on every single tick (8 duplicates in 5 minutes was
+observed on PR #4540, all citing the identical static size-check failure). Key the
+marker to the **specific failing criterion** (not the PR as a whole) so a PR that
+starts failing a *different* criterion still gets a fresh comment, and compare the
+new reason text against the most recently posted comment for that criterion so a
+*changed* reason (the same criterion, but the specifics moved — e.g. CI now fails a
+different check) still gets a fresh comment too:
 
 ```bash
-gh pr comment <number> --body "**Champion: Cannot Auto-Merge**
+PR_NUMBER=<number>
+# Slug for the criterion that failed: label-check | size-check | critical-file |
+# merge-conflict | ci-status. (Recency-check failures use the dedicated Stale PR
+# path below, not this one.)
+CRITERION_KEY="<CRITERION_SLUG>"
+REJECT_MARKER="<!-- champion:reject:$CRITERION_KEY -->"
+REASON="<SPECIFIC_REASON>"  # exact reason text that will go in the comment body
+
+# Idempotency guard: find the most recent comment already posted for this
+# criterion (if any) and compare its reason text against the current one.
+# Skip re-commenting only when the reason is unchanged — a PR that still fails
+# the same criterion but for a *different* specific reason (e.g. CI now fails a
+# different check) still gets a fresh comment.
+LAST_COMMENT=$(gh pr view "$PR_NUMBER" --json comments \
+  --jq --arg marker "$REJECT_MARKER" \
+  '[.comments[] | select(.body | contains($marker))] | last | .body // ""')
+
+if [ -n "$LAST_COMMENT" ] && echo "$LAST_COMMENT" | grep -qF "$REASON"; then
+  echo "Rejection reason for $CRITERION_KEY unchanged since last comment on #$PR_NUMBER — skipping duplicate comment"
+else
+  gh pr comment "$PR_NUMBER" --body "$REJECT_MARKER
+**Champion: Cannot Auto-Merge**
 
 This PR cannot be automatically merged due to the following:
 
-- <CRITERION_NAME>: <SPECIFIC_REASON>
+- <CRITERION_NAME>: $REASON
 
 **Next steps:**
 - <SPECIFIC_ACTION_1>
@@ -745,9 +779,11 @@ Keeping \`loom:pr\` label. Champion will retry on the next tick once the blockin
 
 ---
 *Automated by Champion role*"
+  echo "Posted rejection comment for $CRITERION_KEY on #$PR_NUMBER"
+fi
 ```
 
-**Do NOT remove the `loom:pr` label for transient failures** — the next tick retries automatically.
+**Do NOT remove the `loom:pr` label for transient failures** — the next tick retries automatically. This guard only gates the *comment*, never the retry itself — a still-failing PR is still re-evaluated (and, once the condition clears, still eligible to merge) on every tick; only the redundant comment is suppressed.
 
 ### Stale PR (recency check failed) — comment once, route to Doctor
 


### PR DESCRIPTION
Closes #4586

## Problem

Champion's PR-rejection comment path (`champion-pr-merge.md`, "Transient
failures - keep `loom:pr`, retry next tick") had no idempotency guard. A PR
that repeatedly fails the same static safety criterion across closely-spaced
Champion evaluation cycles got a fresh, near-identical rejection comment on
every single tick instead of recognizing the condition was unchanged.

Observed on PR #4540: 8 duplicate "Champion: Cannot Auto-Merge" comments
posted within ~5 minutes, all citing the identical static size-check failure
(292 lines changed vs 200-line limit).

## Fix

Applied the same idempotency-marker pattern already used for the Stale PR
path in the same file (`<!-- champion:stale-pr-notice -->`) to the general
"Transient failures" rejection path:

- Marker is keyed to the **specific failing criterion**
  (`<!-- champion:reject:<criterion> -->`, e.g. `champion:reject:size-check`)
  rather than the PR as a whole, so a PR that starts failing a *different*
  criterion still gets a fresh comment.
- Before commenting, look up the most recently posted comment for that
  criterion and compare its reason text against the current evaluation's
  reason. Skip commenting only when the reason is unchanged; a changed reason
  (same criterion, different specifics — e.g. a different CI check now
  failing) still posts a fresh comment.
- The guard only gates the *comment* — it never touches the `loom:pr` label or
  the retry cadence itself, so a still-failing PR is still re-evaluated (and
  merge-eligible once fixed) on every tick as before.

Verified the new bash snippet manually (unchanged-reason → skip,
changed-reason → post) and confirmed every `bash` code block in the file
still parses (`bash -n`) after the edit. No lockstep counterpart file exists
for `champion-pr-merge.md` in this repo — `.claude/commands/loom/` is a
gitignored symlink to `defaults/.claude/commands/loom/` here, so
`defaults/.claude/commands/loom/champion-pr-merge.md` is the only file that
needed to change.

## Root-cause investigation (sub-10-minute cadence)

The issue also asked to investigate why Champion appears to re-evaluate the
same PR much faster than the documented ~10-minute interval. Traced through
`loom-daemon/src/role_runner.rs`:

- The role runner already has a solid **in-process** overlap guard
  (`RoleRunGuard` / `InProgressGuard`) preventing a single daemon process from
  running two overlapping ticks for the same `(repo root, role)` pair — this
  repo's `.loom/config.json` doesn't even set `onIdle` for champion, so the
  idle-edge path isn't in play here either.
- The daemon also has a **host-local** single-instance guard
  (`loom-daemon-start.sh` refuses a second start against a live PID file).
- **Neither guard is cross-host.** Two independent `loom-daemon` processes
  (different hosts, or different clones on one host) each running the role
  runner against the same forge-tracked repo would each pass their own
  in-memory guard and dispatch overlapping Champion invocations, since GitHub
  is the only shared state and nothing coordinates role-runner ticks across
  processes. `autonomous.collisionDetection` (#4085) already exists as a
  detection-only baseline for exactly this class of problem, but it's wired
  into sweep dispatch only, not the standalone role runner.
- GH Actions cron for Champion is disabled in this repo (`schedule:` commented
  out in `.github/workflows/loom-champion.yml`), so a GH-Actions-vs-daemon
  double-fire isn't the likely cause here specifically, but is a related
  instance of the same class of problem for repos that enable both.

Filed #4623 to track extending collision awareness to the role runner
(mirrors #4085's baseline, and is the same underlying problem class as the
closed #4570 concurrent-Judge race, just at the process/host level instead of
the per-PR label-write level). This PR's idempotency guard fixes the
user-visible symptom (duplicate comments) independent of whatever the root
cause of the frequent ticks turns out to be.

## Test plan

- [x] `bash -n` on every `bash` code block extracted from the edited file —
      all parse cleanly.
- [x] Manual dry run of the new marker-comparison logic against synthetic
      `gh pr view --json comments` payloads: unchanged reason → skip;
      changed reason → post.
- [x] `.loom/scripts/validate-roles.sh` run (pre-existing unrelated warnings
      only — champion/doctor label wiring, not touched by this change).
- [x] Confirmed no lockstep counterpart file needs the same edit in this repo.
