### PR TITLE
test(role_runner): guard cross-config idle test against private-defaults leak

### DIFF
--- a/loom-daemon/src/role_runner.rs
+++ b/loom-daemon/src/role_runner.rs
@@ -1750,8 +1750,17 @@ mod tests {
 
     /// Issue #4501: with only `autonomous.model` set, the role runner joins the
     /// SAME chain sweep dispatch uses rather than keeping a private default.
+    //
+    // NOTE: see the comment above `test_config_missing_file_is_default` —
+    // `resolve_role_runner_model` reads `read_role_runner_config` internally
+    // (and this test also calls it directly for the `blank` case), so it needs
+    // the same private-defaults-tier guard + `#[serial(loom_config_env)]`
+    // (#4593, discovered during review of #4590 / #4538).
     #[test]
+    #[serial(loom_config_env)]
     fn test_resolve_role_runner_model_precedence_chain() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+
         // No config at all -> shipped default, labelled `default`.
         let bare = tempfile::tempdir().unwrap();
         assert_eq!(
@@ -1789,6 +1798,8 @@ mod tests {
             resolve_role_runner_model(blank.path()),
             (sweep_registry::DEFAULT_DISPATCH_MODEL.to_string(), "default")
         );
+
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
     }
 
     /// Issue #4501: the per-role log header records the pinned model and the tier
@@ -2743,10 +2754,16 @@ mod tests {
     /// real entry point the work-finder loop calls, reading the root's own
     /// on-disk config each tick — exercised here end-to-end rather than via
     /// the already-parsed `RoleRunnerConfig` the other tests use.
+    // NOTE: see the comment above `test_config_missing_file_is_default` — this
+    // test's `observe_and_fire_idle` calls read the private-defaults tier via
+    // `read_role_runner_config` too, so it needs the same guard +
+    // `#[serial(loom_config_env)]` (#4593, discovered during review of #4590 /
+    // #4538).
     #[test]
-    #[serial]
+    #[serial(loom_config_env)]
     fn test_observe_and_fire_idle_cross_config_disabled_target_root_warns_and_suppresses() {
         std::env::remove_var(ROLE_RUNNER_ENABLE_ENV);
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), r#"{"autonomous": {"roleRunner": {"onIdle": ["champion"]}}}"#);
         let mut trigger = IdleTrigger::new();
@@ -2769,6 +2786,7 @@ mod tests {
         // holds (this is the "second edge does not re-warn" acceptance case).
         observe_and_fire_idle(&mut trigger, &in_progress, tmp.path(), false, false);
         observe_and_fire_idle(&mut trigger, &in_progress, tmp.path(), true, false);
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
         assert!(trigger.disabled_warned(tmp.path()));
         assert!(in_progress.lock().unwrap().is_empty());
     }


### PR DESCRIPTION
## Summary

`test_observe_and_fire_idle_cross_config_disabled_target_root_warns_and_suppresses` calls `observe_and_fire_idle` -> `read_role_runner_config` -> `config_resolver::resolve_effective_config`, which merges the private-defaults tier (`config_resolver::private_defaults_path()`) ahead of the tempdir-scoped config under test. That tier resolves off `$LOOM_CONFIG_DEFAULTS_FILE` / `$HOME`, independent of the test's `tmp.path()`, so a host's real `~/.local/share/loom/config/defaults.json` (or a `LOOM_CONFIG_DEFAULTS_FILE`-pointed file) could leak into the test's result — the same class of bug fixed for sibling tests by PR #4590 (closing #4538), but this test was outside that issue's explicit Affected Files list.

- Neutralized `crate::config_resolver::PRIVATE_DEFAULTS_ENV` for the duration of the test (set to `""` before the `observe_and_fire_idle` calls, `remove_var` after) and changed `#[serial]` to `#[serial(loom_config_env)]`, matching the pattern already used by `test_config_on_idle_absent_is_none` and the other guarded tests fixed in PR #4590.
- Scanned the rest of `role_runner.rs`'s test module for any other direct caller of `read_role_runner_config` / `observe_and_fire_idle` lacking the guard, per the acceptance criteria's "no other test... is left without the same guard" requirement. Found one: `test_resolve_role_runner_model_precedence_chain` (calls `resolve_role_runner_model`, which reads `read_role_runner_config` internally, plus a direct call for its "blank override" case) — applied the identical guard + `#[serial(loom_config_env)]` there as well. No other test in the file calls either function unguarded.
- Test-only change; no production code touched.

## Test plan

- [x] `cargo test -p loom-daemon --lib role_runner::tests::test_observe_and_fire_idle_cross_config_disabled_target_root_warns_and_suppresses -- --exact --test-threads=1` passes without a seeded `~/.local/share/loom/config/defaults.json`
- [x] Same command passes with `~/.local/share/loom/config/defaults.json` seeded to `{"autonomous": {"roleRunner": {"enabled": true, "roles": ["curator"]}}}` (per the issue's reproduction steps) — seeded file created, verified, then removed afterward so it doesn't affect other tools on this host
- [x] `cargo test -p loom-daemon --lib role_runner:: -- --test-threads=1` — full module regression, 70 passed / 0 failed, no `#[serial(loom_config_env)]` deadlock/conflict
- [x] `cargo fmt -p loom-daemon -- --check` clean
- [x] `cargo clippy -p loom-daemon --lib --tests` clean

Closes #4593