### PR TITLE
fix(merge-pr): detect closing keywords in a partial-increment PR's commit messages

### DIFF
--- a/defaults/.claude/commands/loom/builder-pr.md
+++ b/defaults/.claude/commands/loom/builder-pr.md
@@ -641,10 +641,23 @@ the cause — Loom's `feature/issue-N` convention does not create a Development-
   grep -inE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#N\b' <<<"$PR_BODY"
   ```
 
+- **The same rule applies to every commit message on the branch** (#4595). The squash message
+  GitHub composes from your commits is parsed for closing keywords too, so a stray
+  `close #N` in a commit body closes the issue even when the PR body is spotless. Scan them
+  before pushing — and amend/reword (`git commit --amend`, `git rebase -i`) if one is there:
+
+  ```bash
+  # Must print nothing for the tracked issue N:
+  git log --format=%B origin/main..HEAD \
+    | grep -inE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#N\b'
+  ```
+
 **Backstop (not a substitute for the above)**: `merge-pr.sh` detects this contradiction
-before merging and warns, then reopens the issue immediately after the merge if GitHub closed
-it anyway. That leaves a close/reopen flicker plus notification churn on the issue — fix the
-body instead of relying on it.
+before merging — in the PR body, in any commit message of the PR, and in GitHub's
+`closingIssuesReferences` — and warns naming which source is at fault, then reopens the issue
+immediately after the merge if GitHub closed it anyway. That leaves a close/reopen flicker
+plus notification churn on the issue — fix the body or the commit message instead of relying
+on it.
 
 ### PR Creation Checklist
 

--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -431,7 +431,8 @@ Or, if you have already verified/reconciled them, re-run with --allow-stacked-ch
 _check_no_open_stacked_children
 
 # ---------------------------------------------------------------------------
-# Partial-increment closing-keyword conflict detection (#4569).
+# Partial-increment closing-keyword conflict detection (#4569, extended by
+# #4595 to cover commit messages).
 #
 # ROOT CAUSE (established from the rjwalters/censusapi#5 -> censusapi#2 incident,
 # NOT from the branch-name theory the report floated):
@@ -454,6 +455,15 @@ _check_no_open_stacked_children
 #       keyword), so the close did not come from the commit message either;
 #     - the `closed` event has `commit_id: null` with the merger as actor at the
 #       merge instant — the signature of a PR-body closing-reference close.
+#
+# SECOND SOURCE (#4595): the same parser also runs over the SQUASH COMMIT
+#   MESSAGE. forge_merge_pr() squash-merges with no commit_title/commit_message
+#   override, so GitHub composes that message from the PR's own commit messages —
+#   a stray `close #N` in any commit message closes #N on merge even when the PR
+#   body only ever says `Part of #N`. That close is fully attributable (the
+#   `closed` event carries the merge `commit_id`), it is just invisible to both
+#   the body regex and `closingIssuesReferences`, so the commit messages are
+#   consulted as a third signal below.
 #
 # Fix shape: DETECT (here, pre-merge, with a loud actionable warning) plus
 # SELF-HEAL (post-merge reopen in _reset_one_partial_issue below). Prevention by
@@ -480,21 +490,51 @@ _partial_increment_refs() {
       | sort -un; } || true
 }
 
-# Issue numbers referenced with a GitHub CLOSING keyword anywhere in the text,
-# one per line, deduped. The regex is deliberately the same one
+# Issue numbers referenced with a GitHub CLOSING keyword anywhere in the text
+# read from stdin, one per line, deduped. The regex is deliberately the same one
 # forge_pr_close_targets() uses on its Gitea branch (the canonical keyword set,
 # with `\b` guarding against substring traps like `Discloses #N`).
 #
-# Why a body regex and not only the authoritative GraphQL
+# Why a text regex and not only the authoritative GraphQL
 # `closingIssuesReferences`: that field is GraphQL-only, and the incident this
 # guard exists for happened while GraphQL quota was exhausted (the PR was even
 # created via raw REST for that reason). A quota-free text signal is the one that
 # still works in exactly the conditions where this bug bites.
-_body_closing_refs() {
-  { printf '%s\n' "$1" \
-      | grep -oiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\b[[:space:]]+#[0-9]+' \
+_closing_refs_stdin() {
+  { grep -oiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\b[[:space:]]+#[0-9]+' \
       | grep -oE '[0-9]+' \
       | sort -un; } || true
+}
+
+# Same, for text passed as $1 (the PR body, historically the only source).
+_body_closing_refs() {
+  { printf '%s\n' "$1" | _closing_refs_stdin; } || true
+}
+
+# The literal offending snippets ("close #N", "Fixes #N", …) that reference
+# issue $2 with a closing keyword inside the text $1, rendered for a warning as
+# `snippet", "snippet`. Empty when the text carries no such reference — which is
+# how the caller tells WHICH source (body vs. commit messages) is at fault.
+_closing_ref_snippets() {
+  { printf '%s\n' "$1" \
+      | grep -oiE "\\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\\b[[:space:]]+#$2\\b" \
+      | sort -u | tr '\n' '|' | sed 's/|$//; s/|/", "/g'; } || true
+}
+
+# Every commit message of this PR, concatenated (#4595). merge-pr.sh squash-
+# merges without overriding the commit message (forge_merge_pr passes no
+# commit_title/commit_message), so GitHub composes the squash message from these
+# commits — a `close #N` in any of them is a real closing reference that neither
+# the PR body regex nor `closingIssuesReferences` reveals.
+#
+# REST (not GraphQL), so it survives the same quota exhaustion the body regex
+# exists for, and `--paginate` so a >30-commit PR is not silently truncated.
+# Plain `gh api` (not $GH) for freshness, `--jq` deliberately avoided in favor of
+# a jq pipe (jq is already a hard dependency). Best-effort: any failure yields an
+# empty string, which degrades to the pre-#4595 behavior (no attribution).
+_pr_commit_messages() {
+  { gh api "repos/$REPO_NWO/pulls/$PR_NUMBER/commits" --paginate 2>/dev/null \
+      | jq -r '.[].commit.message' 2>/dev/null; } || true
 }
 
 # Membership tests over the space-separated globals above.
@@ -520,14 +560,21 @@ _check_partial_increment_close_conflict() {
   partial_refs="$(_partial_increment_refs "$pr_body")"
   [[ -n "$partial_refs" ]] || return 0
 
-  # Closing references GitHub will honor on merge: the body's own closing
-  # keywords (quota-free) UNION GitHub's authoritative closingIssuesReferences
-  # (best-effort — empty under GraphQL quota exhaustion, but when it does answer
-  # it also surfaces a Development-sidebar link that no body text reveals).
-  local body_close_refs graphql_close_refs close_refs
+  # Closing references GitHub will honor on merge, from three unioned signals:
+  #   1. the body's own closing keywords (quota-free regex);
+  #   2. this PR's COMMIT MESSAGES (#4595) — quota-free REST, and the source of
+  #      the squash commit message this script does not override;
+  #   3. GitHub's authoritative closingIssuesReferences (best-effort — empty
+  #      under GraphQL quota exhaustion, but when it does answer it also
+  #      surfaces a Development-sidebar link that no text reveals).
+  # The commit fetch happens only past the partial_refs early-return above, so
+  # the common (non-partial-increment) path costs zero extra API calls.
+  local body_close_refs commit_messages commit_close_refs graphql_close_refs close_refs
   body_close_refs="$(_body_closing_refs "$pr_body")"
+  commit_messages="$(_pr_commit_messages)"
+  commit_close_refs="$(printf '%s\n' "$commit_messages" | _closing_refs_stdin)"
   graphql_close_refs="$(forge_pr_close_targets "$PR_NUMBER" "$GH" 2>/dev/null || true)"
-  close_refs="$(printf '%s\n%s\n' "$body_close_refs" "$graphql_close_refs" \
+  close_refs="$(printf '%s\n%s\n%s\n' "$body_close_refs" "$commit_close_refs" "$graphql_close_refs" \
     | grep -E '^[0-9]+$' | sort -un || true)"
 
   local issue_num issue_json
@@ -553,15 +600,25 @@ _check_partial_increment_close_conflict() {
     fi
     PARTIAL_CONFLICT_ISSUES="${PARTIAL_CONFLICT_ISSUES:+$PARTIAL_CONFLICT_ISSUES }$issue_num"
 
-    local offending dr=""
+    local body_offending commit_offending dr=""
     # Match _check_no_open_stacked_children's dry-run contract: report the
     # would-be outcome without claiming a merge is happening.
     [[ "${DRY_RUN:-false}" == "true" ]] && dr="[dry-run] "
-    offending="$(printf '%s\n' "$pr_body" \
-      | grep -oiE "\\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\\b[[:space:]]+#$issue_num\\b" \
-      | sort -u | tr '\n' '|' | sed 's/|$//; s/|/", "/g' || true)"
-    warning "${dr}Partial-increment conflict (#4569): PR #$PR_NUMBER declares a NON-closing \`Part of\`/\`Contributes to\` reference to #$issue_num, but its body ALSO carries a closing reference to #$issue_num${offending:+ (\"$offending\")} — GitHub honors a closing keyword ANYWHERE in the body, so merging this PR WILL close #$issue_num against the declared intent."
-    warning "  ${dr}merge-pr.sh would reopen #$issue_num immediately after the merge. To avoid the close/reopen flicker entirely, edit the PR body so no closing keyword is immediately followed by \`#$issue_num\` (e.g. write \`close the issue\` or \`close issue #$issue_num\` instead of \`close #$issue_num\`), then re-run this merge."
+    body_offending="$(_closing_ref_snippets "$pr_body" "$issue_num")"
+    commit_offending="$(_closing_ref_snippets "$commit_messages" "$issue_num")"
+
+    # Name the source, because the operator remedy differs per source: edit the
+    # PR body, reword/amend a commit, or unlink a Development-sidebar reference.
+    if [[ -n "$body_offending" ]]; then
+      warning "${dr}Partial-increment conflict (#4569): PR #$PR_NUMBER declares a NON-closing \`Part of\`/\`Contributes to\` reference to #$issue_num, but its body ALSO carries a closing reference to #$issue_num (\"$body_offending\") — GitHub honors a closing keyword ANYWHERE in the body, so merging this PR WILL close #$issue_num against the declared intent."
+      warning "  ${dr}merge-pr.sh would reopen #$issue_num immediately after the merge. To avoid the close/reopen flicker entirely, edit the PR body so no closing keyword is immediately followed by \`#$issue_num\` (e.g. write \`close the issue\` or \`close issue #$issue_num\` instead of \`close #$issue_num\`), then re-run this merge."
+    elif [[ -n "$commit_offending" ]]; then
+      warning "${dr}Partial-increment conflict (#4595): PR #$PR_NUMBER declares a NON-closing \`Part of\`/\`Contributes to\` reference to #$issue_num, but a closing keyword in a commit message of this PR references #$issue_num (\"$commit_offending\") — this merge squashes without overriding the commit message, so GitHub composes the squash message from these commits and merging WILL close #$issue_num against the declared intent."
+      warning "  ${dr}merge-pr.sh would reopen #$issue_num immediately after the merge. To avoid the close/reopen flicker entirely, reword the offending commit message (\`git commit --amend\` / \`git rebase -i\` + force-push) so no closing keyword is immediately followed by \`#$issue_num\`, then re-run this merge."
+    else
+      warning "${dr}Partial-increment conflict (#4569): PR #$PR_NUMBER declares a NON-closing \`Part of\`/\`Contributes to\` reference to #$issue_num, but GitHub reports #$issue_num as a closing target of this PR (no closing keyword found in the body or commit messages — most likely a Development-sidebar link), so merging this PR WILL close #$issue_num against the declared intent."
+      warning "  ${dr}merge-pr.sh would reopen #$issue_num immediately after the merge. To avoid the close/reopen flicker entirely, unlink #$issue_num from this PR's Development sidebar, then re-run this merge."
+    fi
   done <<< "$partial_refs"
 
   return 0
@@ -666,7 +723,7 @@ _reset_one_partial_issue() {
     local ts comment reopen_note=""
     ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     [[ "$reopened" == "true" ]] && reopen_note="
-- **Reopened** this issue (GitHub had auto-closed it from a stray closing keyword in PR #$PR_NUMBER's body — see #4569)"
+- **Reopened** this issue (GitHub had auto-closed it from a stray closing keyword in PR #$PR_NUMBER's body or one of its commit messages — see #4569)"
     comment="## Partial Increment Merged
 
 PR #$PR_NUMBER merged with a non-closing \`Part of\` / \`Contributes to\` reference, so this issue remains **open** for further work.
@@ -694,13 +751,13 @@ _post_premature_close_comment() {
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   comment="## Premature Auto-Close Reverted
 
-PR #$PR_NUMBER referenced this issue with a **non-closing** \`Part of\` / \`Contributes to\` keyword — a declared partial increment, so this issue was meant to stay **open** after the merge. GitHub closed it anyway, because a **closing keyword** (\`close\`/\`fix\`/\`resolve\` and their tense variants) appeared somewhere else in the PR body immediately followed by \`#$issue_num\`.
+PR #$PR_NUMBER referenced this issue with a **non-closing** \`Part of\` / \`Contributes to\` keyword — a declared partial increment, so this issue was meant to stay **open** after the merge. GitHub closed it anyway, because a **closing keyword** (\`close\`/\`fix\`/\`resolve\` and their tense variants) immediately followed by \`#$issue_num\` appeared elsewhere in the PR — in the body, or in one of the PR's commit messages (this merge squashes without overriding the commit message, so GitHub composes the squash message from those commits).
 
-GitHub honors a closing keyword **anywhere** in a PR body — not only in a line-leading trailer — so prose like \"…then close #$issue_num\" in a follow-up checklist creates a real closing link that overrides the intended \`Contributes to #$issue_num\`.
+GitHub honors a closing keyword **anywhere** in a PR body or squash commit message — not only in a line-leading trailer — so prose like \"…then close #$issue_num\" in a follow-up checklist, or a stray \`close #$issue_num\` in a commit message, creates a real closing link that overrides the intended \`Contributes to #$issue_num\`.
 
 **Action taken**: reopened this issue.
 
-**To avoid this**: never put a closing keyword immediately before \`#$issue_num\` anywhere in a partial-increment PR body. Write \`close the issue\` or \`close issue #$issue_num\` instead of \`close #$issue_num\`.
+**To avoid this**: never put a closing keyword immediately before \`#$issue_num\` anywhere in a partial-increment PR's body **or commit messages**. Write \`close the issue\` or \`close issue #$issue_num\` instead of \`close #$issue_num\`.
 
 ---
 *Reopened by merge-pr.sh (#4569) at $ts*"

--- a/defaults/scripts/tests/test-merge-pr-partial-increment.sh
+++ b/defaults/scripts/tests/test-merge-pr-partial-increment.sh
@@ -19,8 +19,17 @@
 # _reset_one_partial_issue) — while explicitly NOT reverting a close it cannot
 # attribute to this PR (a deliberate close in the same window).
 #
+# #4595 extends that guard to a third source: the PR's COMMIT MESSAGES. merge-pr.sh
+# squash-merges without overriding the commit message, so GitHub composes the
+# squash message from the PR's commits and honors a `close #N` there even when the
+# PR body only says `Part of #N`. The guard unions a paginated REST read of
+# `pulls/<N>/commits` into its close-reference set, names the commit message as
+# the source in its warning (the operator remedy is amend/reword, not a body
+# edit), and degrades to today's warn-only behavior when that fetch fails.
+#
 # Strategy: the functions under test (_partial_increment_refs,
-# _body_closing_refs, _check_partial_increment_close_conflict,
+# _closing_refs_stdin, _body_closing_refs, _closing_ref_snippets,
+# _pr_commit_messages, _check_partial_increment_close_conflict,
 # _reset_one_partial_issue, _reset_partial_increment_labels) depend only on
 # globals (PR_JSON, REPO_NWO, PR_NUMBER, FORGE_TYPE, GH,
 # PARTIAL_CONFLICT_ISSUES, PARTIAL_OPEN_BEFORE_MERGE) and the `gh` CLI. We
@@ -122,7 +131,8 @@ awk '
   capture { print }
 ' "$MERGE_PR_SRC" > "$FUNCS_FILE"
 
-for _fn in _partial_increment_refs _body_closing_refs \
+for _fn in _partial_increment_refs _closing_refs_stdin _body_closing_refs \
+           _closing_ref_snippets _pr_commit_messages \
            _check_partial_increment_close_conflict _reset_one_partial_issue \
            _reset_partial_increment_labels; do
     if ! grep -q "^${_fn}() {" "$FUNCS_FILE"; then
@@ -138,15 +148,44 @@ STUB_DIR="$(mktemp -d)"
 cat > "$STUB_DIR/gh" <<'STUB'
 #!/usr/bin/env bash
 # Stub gh for test-merge-pr-partial-increment.sh.
-#   gh api repos/OWNER/REPO/issues/N   -> cat $STUB_DIR/issue-N.json (or {})
-#   gh issue edit N ...                -> record to $STUB_DIR/gh-calls.log
-#   gh issue comment N ...             -> record to $STUB_DIR/gh-calls.log
+#   gh api repos/OWNER/REPO/issues/N        -> cat $STUB_DIR/issue-N.json (or {})
+#   gh api repos/OWNER/REPO/pulls/N/commits -> cat $STUB_DIR/pr-commits.json (or [])
+#        (exits 1 when LOOM_TEST_COMMITS_FAIL=1, simulating a fetch failure)
+#   gh issue edit N ...                     -> record to $STUB_DIR/gh-calls.log
+#   gh issue comment N ...                  -> record to $STUB_DIR/gh-calls.log
 STUB_DIR_FROM_ENV="${LOOM_TEST_STUB_DIR:?stub gh: LOOM_TEST_STUB_DIR not set}"
 LOG="$STUB_DIR_FROM_ENV/gh-calls.log"
 
 if [[ "$1" == "api" ]]; then
-  # Last arg is the api path: repos/owner/repo/issues/N
-  path="${!#}"
+  # Scan argv for the api path rather than assuming it is the last argument:
+  # flags such as --paginate / --jq '<program>' may follow it (#4595).
+  shift
+  path=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      # Flags that take a value: drop the flag AND its argument.
+      --jq|-q|--field|-f|--raw-field|-F|--header|-H|--method|-X|--input)
+        shift
+        [[ $# -gt 0 ]] && shift
+        continue
+        ;;
+      -*) shift; continue ;;
+      *) path="$1"; break ;;
+    esac
+  done
+
+  case "$path" in
+    */pulls/*/commits)
+      if [[ "${LOOM_TEST_COMMITS_FAIL:-}" == "1" ]]; then
+        echo "stub gh: simulated commits fetch failure" >&2
+        exit 1
+      fi
+      canned="$STUB_DIR_FROM_ENV/pr-commits.json"
+      if [[ -f "$canned" ]]; then cat "$canned"; else echo '[]'; fi
+      exit 0
+      ;;
+  esac
+
   num="${path##*/}"
   canned="$STUB_DIR_FROM_ENV/issue-$num.json"
   if [[ -f "$canned" ]]; then cat "$canned"; else echo '{}'; fi
@@ -199,13 +238,31 @@ cat > "$STUB_DIR/issue-321.json" <<'EOF'
 {"state":"open","pull_request":{"url":"x"},"labels":[{"name":"loom:building"}]}
 EOF
 
+# Canned `pulls/<N>/commits` payload: one JSON commit object per message given.
+# Written in the GitHub REST shape the script reads (.[].commit.message).
+set_commits() {
+  local first=1 m
+  {
+    printf '['
+    for m in "$@"; do
+      [[ $first -eq 1 ]] || printf ','
+      first=0
+      printf '{"sha":"deadbeef","commit":{"message":%s}}' "$(printf '%s' "$m" | jq -Rs .)"
+    done
+    printf ']'
+  } > "$STUB_DIR/pr-commits.json"
+}
+
 # Clearing the two #4569 globals here keeps every pre-existing case below running
-# against the same "no conflict recorded" state it was written for.
+# against the same "no conflict recorded" state it was written for; resetting the
+# commits fixture to empty does the same for the #4595 commit-message signal.
 reset_log() {
   : > "$STUB_DIR/gh-calls.log"
   PARTIAL_OPEN_BEFORE_MERGE=""
   PARTIAL_CONFLICT_ISSUES=""
   FORGE_CLOSE_TARGETS=""
+  set_commits
+  unset LOOM_TEST_COMMITS_FAIL
 }
 read_log()  { cat "$STUB_DIR/gh-calls.log" 2>/dev/null || true; }
 
@@ -409,6 +466,135 @@ assert_not_contains "$dryrun_err" "will reopen #123" \
 DRY_RUN=false
 
 echo ""
+echo "Testing the commit-message closing-keyword signal (#4595)..."
+
+# T21: the #4595 shape — PR body is CLEAN (`Contributes to #123` only), but a
+# commit message carries `close #123`. This repo squash-merges without overriding
+# the commit message, so GitHub composes the squash message from the commits and
+# honors that keyword: it must be recorded as a conflict.
+reset_log
+set_commits "feat: implement the slice
+
+close #123"
+PR_JSON='{"body":"Implements a slice.\n\nContributes to #123"}'
+run_capturing_stderr _check_partial_increment_close_conflict
+commit_err="$(read_stderr)"
+assert_eq "123" "$PARTIAL_CONFLICT_ISSUES" \
+  "Clean body + commit message 'close #123' -> conflict recorded (commit-message signal)"
+assert_eq "123" "$PARTIAL_OPEN_BEFORE_MERGE" \
+  "Commit-message conflict -> #123 also recorded as open before the merge"
+assert_contains "$commit_err" "closing keyword in a commit message of this PR" \
+  "Commit-message conflict -> warning names the commit message as the source"
+assert_contains "$commit_err" "close #123" \
+  "Commit-message conflict -> warning quotes the offending commit-message phrase"
+assert_contains "$commit_err" "reword the offending commit message" \
+  "Commit-message conflict -> remedy is amend/reword, not editing the PR body"
+assert_not_contains "$commit_err" "its body ALSO carries" \
+  "Commit-message conflict -> does NOT blame the (clean) PR body"
+
+# T22: commits fetch FAILS (e.g. REST error) -> empty signal, conservative
+# behavior: still tracked as open-before-merge, but no conflict, so the
+# post-merge pass warns instead of reopening. Never blocks the merge.
+reset_log
+export LOOM_TEST_COMMITS_FAIL=1
+PR_JSON='{"body":"Implements a slice.\n\nContributes to #123"}'
+run_capturing_stderr _check_partial_increment_close_conflict
+assert_eq "" "$PARTIAL_CONFLICT_ISSUES" \
+  "Commits fetch failure -> degrades to an empty signal (no conflict recorded)"
+assert_eq "123" "$PARTIAL_OPEN_BEFORE_MERGE" \
+  "Commits fetch failure -> #123 still tracked as open before the merge"
+unset LOOM_TEST_COMMITS_FAIL
+
+# T22b: fetch failure is survivable — the guard still returns 0 (best-effort,
+# never fails or blocks the merge).
+reset_log
+export LOOM_TEST_COMMITS_FAIL=1
+PR_JSON='{"body":"Contributes to #123"}'
+guard_rc=0
+_check_partial_increment_close_conflict 2>/dev/null || guard_rc=$?
+assert_eq "0" "$guard_rc" "Commits fetch failure -> guard still exits 0 (never blocks the merge)"
+unset LOOM_TEST_COMMITS_FAIL
+
+# T23: clean body AND clean commits -> no conflict at all.
+reset_log
+set_commits "feat: implement the slice" "docs: note the follow-up work"
+PR_JSON='{"body":"Implements a slice.\n\nContributes to #123"}'
+_check_partial_increment_close_conflict 2>/dev/null
+assert_eq "" "$PARTIAL_CONFLICT_ISSUES" \
+  "Clean body + clean commits -> no conflict recorded"
+assert_eq "123" "$PARTIAL_OPEN_BEFORE_MERGE" \
+  "Clean body + clean commits -> #123 recorded as open before the merge"
+
+# T24: multi-commit PR where only a MIDDLE commit carries the keyword — all
+# commit messages must be aggregated, not just the first or last.
+reset_log
+set_commits "feat: part one" "fixup: resolves #123 while here" "chore: part three"
+PR_JSON='{"body":"Part of #123"}'
+run_capturing_stderr _check_partial_increment_close_conflict
+mid_err="$(read_stderr)"
+assert_eq "123" "$PARTIAL_CONFLICT_ISSUES" \
+  "Middle commit's 'resolves #123' -> conflict recorded (all commit messages aggregated)"
+assert_contains "$mid_err" "resolves #123" \
+  "Middle-commit conflict -> warning quotes the offending phrase"
+
+# T25: 'close issue #123' in a commit message is NOT a closing reference (same
+# word-adjacency rule the body regex enforces).
+reset_log
+set_commits "chore: follow-up will close issue #123 later"
+PR_JSON='{"body":"Part of #123"}'
+_check_partial_increment_close_conflict 2>/dev/null
+assert_eq "" "$PARTIAL_CONFLICT_ISSUES" \
+  "Commit 'close issue #123' -> not a closing reference, no conflict"
+
+# T26: a commit closing a DIFFERENT issue than the partial ref -> ignored.
+reset_log
+set_commits "fix: closes #888"
+PR_JSON='{"body":"Part of #123"}'
+_check_partial_increment_close_conflict 2>/dev/null
+assert_eq "" "$PARTIAL_CONFLICT_ISSUES" \
+  "Commit 'closes #888' + Part of #123 -> no conflict (different issues)"
+
+# T27: end-to-end — the commit-message conflict recorded pre-merge drives the
+# post-merge reopen. #456 is open when the guard runs and closed when the reset
+# pass runs (the fixture is swapped mid-test to simulate the merge's auto-close).
+reset_log
+set_commits "feat: slice
+
+close #456"
+PR_JSON='{"body":"Implements a slice.\n\nContributes to #456"}'
+_check_partial_increment_close_conflict 2>/dev/null
+assert_eq "456" "$PARTIAL_CONFLICT_ISSUES" \
+  "End-to-end: commit-message conflict on #456 recorded pre-merge"
+: > "$STUB_DIR/gh-calls.log"
+cat > "$STUB_DIR/issue-456.json" <<'EOF'
+{"state":"closed","labels":[{"name":"loom:building"}]}
+EOF
+run_capturing_stderr _reset_partial_increment_labels
+e2e_log="$(read_log)"
+assert_contains "$e2e_log" "issue reopen 456 --repo owner/repo" \
+  "End-to-end: #456 auto-closed by the commit-message keyword is reopened post-merge"
+assert_contains "$e2e_log" "issue edit 456 --repo owner/repo --remove-label loom:building --add-label loom:issue" \
+  "End-to-end: reopened #456 falls through to the loom:building -> loom:issue swap"
+# Restore the shared fixture for any later case.
+cat > "$STUB_DIR/issue-456.json" <<'EOF'
+{"state":"open","labels":[{"name":"loom:building"}]}
+EOF
+
+# T28: the commit fetch must not happen at all when the PR has no partial-
+# increment reference (zero extra API calls on the common path). A failing
+# commits endpoint would be reached only if the guard fetched it.
+reset_log
+export LOOM_TEST_COMMITS_FAIL=1
+PR_JSON='{"body":"All done.\n\nCloses #123"}'
+run_capturing_stderr _check_partial_increment_close_conflict
+nofetch_err="$(read_stderr)"
+assert_eq "" "$PARTIAL_OPEN_BEFORE_MERGE" \
+  "No partial-increment ref -> guard returns before any commit fetch"
+assert_not_contains "$nofetch_err" "simulated commits fetch failure" \
+  "No partial-increment ref -> commits endpoint is never called"
+unset LOOM_TEST_COMMITS_FAIL
+
+echo ""
 echo "Testing the post-merge premature-close revert..."
 
 # T18: conflicted + closed after the merge -> reopen, comment, THEN the normal
@@ -471,6 +657,10 @@ assert_contains "$src" 'gh issue reopen "$issue_num"' \
   "merge-pr.sh reverts a premature auto-close with gh issue reopen"
 assert_contains "$src" 'close[sd]?|fix(e[sd])?|resolve[sd]?' \
   "merge-pr.sh matches the canonical GitHub closing-keyword set"
+assert_contains "$src" 'repos/$REPO_NWO/pulls/$PR_NUMBER/commits' \
+  "merge-pr.sh reads the PR's commit messages for closing keywords (#4595)"
+assert_contains "$src" '--paginate' \
+  "merge-pr.sh paginates the commits fetch (>30-commit PRs are not truncated)"
 
 # --- Summary ---
 echo ""


### PR DESCRIPTION
Closes #4595

## Summary

The #4569 partial-increment close-conflict guard in `defaults/scripts/merge-pr.sh` unioned two attribution signals — a quota-free regex over the **PR body** and GitHub's GraphQL `closingIssuesReferences`. Neither sees a closing keyword that lives only in a **commit message**. `forge_merge_pr()` squash-merges with no `commit_title`/`commit_message` override, so GitHub composes the squash message from the PR's own commits: a stray `close #<N>` there closes the family issue on merge even when the PR body only says `Part of #<N>`. That close *is* attributable to the merge (the `closed` event carries the merge `commit_id`), but it fell into the deliberately conservative "open before, closed after, no attributable closing reference" branch — warn loudly, do not reopen.

This adds the commit messages as a third signal.

## Changes

`defaults/scripts/merge-pr.sh`

- **`_pr_commit_messages()`** — reads `repos/$REPO_NWO/pulls/$PR_NUMBER/commits` via REST (so it survives the same GraphQL quota exhaustion the body regex exists for) with `--paginate` (a >30-commit PR is not silently truncated), piping to `jq -r '.[].commit.message'` rather than `--jq`. Unioned into `close_refs`, which drives **both** halves of the guard (the pre-merge warning and `PARTIAL_CONFLICT_ISSUES`, which the post-merge pass reopens from).
- **Zero extra API calls on the common path** — the fetch sits past the `partial_refs` early-return, so a PR with no `Part of`/`Contributes to` reference never touches the endpoint.
- **Graceful degradation** — any failure yields an empty string, restoring exactly the pre-change behavior (loud warning, no reopen). The guard still returns 0 and never blocks the merge.
- **`_closing_refs_stdin()`** — the closing-keyword regex, factored to read stdin; `_body_closing_refs()` is now a thin wrapper over it. **`_closing_ref_snippets()`** — the offending-snippet extraction, factored so it can run against either source.
- **Source-naming warning** — the pre-merge warning now says which source is at fault, because the operator remedy differs: edit the PR body / reword-amend a commit / unlink a Development-sidebar reference. The body-sourced wording (and the `--dry-run` contract) is byte-compatible with before.
- **`_post_premature_close_comment()`** no longer claims the keyword "appeared somewhere else in the PR body" — commit messages are now a possible attributed source.

`defaults/scripts/tests/test-merge-pr-partial-increment.sh`

- The `gh` stub now **scans argv for the API path** instead of assuming it is the last argument (`--paginate` follows it, and value-taking flags like `--jq <program>` are skipped), serves a canned `pulls/<n>/commits` fixture via a `set_commits` helper, and simulates a fetch failure with `LOOM_TEST_COMMITS_FAIL=1`. `reset_log` resets both so every pre-existing case runs against an empty commits fixture.

`defaults/.claude/commands/loom/builder-pr.md`

- The matching pre-push scan over commit messages (`git log --format=%B origin/main..HEAD | grep -inE …`), and the backstop paragraph now describes all three sources.

## Test plan

| Acceptance criterion | Verified |
|---|---|
| Commit-message signal unioned into `close_refs` | Source guard asserts `repos/$REPO_NWO/pulls/$PR_NUMBER/commits` + `--paginate` in `merge-pr.sh`; T21 asserts the resulting conflict |
| Fetch only when a partial-increment ref exists | T28 — with a failing commits endpoint and a `Closes #123`-only body, the guard returns before any fetch (no failure ever surfaces) |
| Clean body + commit `close #N` → recorded in `PARTIAL_CONFLICT_ISSUES` → reopened | T21 (recorded) and T27 (end-to-end: guard records it, fixture flipped to closed, `_reset_partial_increment_labels` issues `gh issue reopen` + the label swap) |
| Warning distinguishes commit-message from PR-body source | T21 — asserts "closing keyword in a commit message of this PR" and "reword the offending commit message", and asserts the clean body is *not* blamed |
| Failed fetch degrades gracefully | T22 (no conflict recorded, still tracked as open-before-merge), T22b (guard exits 0) |
| No regression | All 24 pre-existing assertions pass; full suite **74/74** |

Extra cases: T23 clean body + clean commits, T24 keyword in the *middle* commit of a 3-commit PR (aggregation), T25 `close issue #123` non-match, T26 commit closing a different issue.

```
$ ./defaults/scripts/tests/test-merge-pr-partial-increment.sh
Results: 74/74 passed, 0 failed

$ for t in defaults/scripts/tests/test-merge-pr-*.sh; do "$t"; done   # all rc=0
$ shellcheck --severity=warning --format=gcc defaults/scripts/merge-pr.sh defaults/scripts/tests/test-merge-pr-partial-increment.sh   # clean
```

**Live verification** (read-only, real `gh`): sourcing the extracted functions against real PR #4592 — whose commit messages carry a closing reference to the already-closed #4569 — `_pr_commit_messages` returned 2054 bytes, `_closing_refs_stdin` extracted `4569`, and `_closing_ref_snippets` produced the exact snippet. With a simulated `Part of #4569` body the guard correctly recorded **no** conflict (the issue is already closed, so nothing this merge does is attributable to it) — confirming both the real REST payload shape and the no-false-positive path.

Rust workspace untouched (shell + markdown only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)