### PR TITLE
fix: root-cause the 3 red CI-excluded test suites and re-wire them

### DIFF
--- a/defaults/scripts/archive-transcripts.sh
+++ b/defaults/scripts/archive-transcripts.sh
@@ -90,9 +90,30 @@ lower() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
 # slugify a path the way Claude Code names its projects/ subdirs: '/' -> '-'.
 slugify() { printf '%s' "$1" | sed 's#/#-#g'; }
 
-# portable mtime epoch (BSD stat then GNU stat).
-file_mtime_epoch() { stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || echo 0; }
-file_size()        { stat -f %z "$1" 2>/dev/null || stat -c %s "$1" 2>/dev/null || echo 0; }
+# Portable mtime epoch / size. GNU `stat -c` first (it is an illegal option on
+# BSD/macOS, so it fails cleanly there), then BSD `stat -f`. The reverse order
+# MISFIRES on GNU: `stat -f %m <path>` there means --file-system (a bare mode
+# flag, not a format arg) and prints a multi-line filesystem report to stdout
+# while still exiting non-zero — a `2>/dev/null || fallback` chain doesn't
+# catch this because the polluted stdout was already emitted before the
+# command failed, so it leaks into the captured value ahead of the fallback's
+# real output. Validate the captured value is purely numeric instead of
+# trusting the exit code (same technique as build-slot.sh's
+# _loom_build_slot_age_secs).
+file_mtime_epoch() {
+    local v
+    v="$(stat -c %Y "$1" 2>/dev/null || true)"
+    [[ "$v" =~ ^[0-9]+$ ]] || v="$(stat -f %m "$1" 2>/dev/null || true)"
+    [[ "$v" =~ ^[0-9]+$ ]] || v=0
+    printf '%s\n' "$v"
+}
+file_size() {
+    local v
+    v="$(stat -c %s "$1" 2>/dev/null || true)"
+    [[ "$v" =~ ^[0-9]+$ ]] || v="$(stat -f %z "$1" 2>/dev/null || true)"
+    [[ "$v" =~ ^[0-9]+$ ]] || v=0
+    printf '%s\n' "$v"
+}
 epoch_to_date()    { date -r "$1" +%Y-%m-%d 2>/dev/null || date -d "@$1" +%Y-%m-%d 2>/dev/null || date +%Y-%m-%d; }
 iso_now()          { date -u +%Y-%m-%dT%H:%M:%SZ; }
 

--- a/defaults/scripts/tests/ci-excluded.txt
+++ b/defaults/scripts/tests/ci-excluded.txt
@@ -15,7 +15,4 @@
 test-install-reinstall-safety.sh  Already wired in the "Installer Integration Tests" job (#4188); excluded here to avoid double-running it.
 test-spawn-codex.sh  Already wired in the "Codex Adapter Smoke (mocked)" job (#4468), which adds adapter-specific hermeticity guards; excluded here to avoid double-running it.
 test-loom-daemon-update.sh  Non-hermetic: exercises the daemon update+rebuild lifecycle and hangs past 120s locally (waits on process/rebuild orchestration). Wiring it needs a portability/timeout pass — follow-up.
-test-sweep-pr-mode.sh  Currently failing (7 stale doc-literal assertions vs the sweep command doc); a pre-existing, platform-independent failure. Fixing the assertions is out of scope for this CI-wiring PR — follow-up.
 test-spawn-claude.sh  Non-hermetic: spawn-claude.sh's token selection requires a built loom-daemon binary (#4228), absent on a fresh ubuntu runner (FATAL: no loom-daemon binary). Wiring it needs a cargo build step or a binary stub — follow-up.
-test-archive-transcripts.sh  Fails on ubuntu-latest: Case 4 (idempotent second run) re-copies files instead of skipping unchanged, a behavioral difference in the archiver on Linux filesystems. Non-trivial to fix here — follow-up.
-test-install-active-session.sh  Fails on ubuntu-latest: check-active-session.sh detection output omits multiple expected needles (worktrees / daemon PID / active state / reason) on Linux. Needs a portability investigation of the helper — follow-up.

--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -8,6 +8,7 @@
 # check-ci-suite-manifest.sh enforces that every test-*.sh is in exactly one
 # of these two files. Blank lines and lines beginning with `#` are ignored.
 
+test-archive-transcripts.sh
 test-blame-issue.sh
 test-build-rs-watchset.sh
 test-build-slot.sh
@@ -30,6 +31,7 @@ test-forge-helpers.sh
 test-github-app-token.sh
 test-gitignore-guard.sh
 test-guard-hook-schema.sh
+test-install-active-session.sh
 test-install-pr-markers.sh
 test-install-source-guard.sh
 test-install-stash-scope.sh
@@ -66,6 +68,7 @@ test-spawn-worker.sh
 test-sweep-auto-stack.sh
 test-sweep-checkpoint.sh
 test-sweep-experiment.sh
+test-sweep-pr-mode.sh
 test-sweep-run-registry.sh
 test-sync-labels-repo-flag.sh
 test-verify-install-scope.sh

--- a/defaults/scripts/tests/test-archive-transcripts.sh
+++ b/defaults/scripts/tests/test-archive-transcripts.sh
@@ -60,8 +60,23 @@ assert_file "$S/index.json"                              "index.json emitted"
 echo ""
 
 echo "Case 2: file/dir modes are 0600/0700"
-DMODE="$(stat -f '%Lp' "$S" 2>/dev/null || stat -c '%a' "$S")"
-FMODE="$(stat -f '%Lp' "$S/UUID1.jsonl" 2>/dev/null || stat -c '%a' "$S/UUID1.jsonl")"
+# GNU `stat -c` first (it is an illegal option on BSD/macOS, so it fails
+# cleanly there), then BSD `stat -f '%Lp'`. The reverse order MISFIRES on
+# GNU: `stat -f '%Lp' <path>` there means --file-system (a bare mode flag,
+# not a format arg) and prints a multi-line filesystem report to stdout
+# while still exiting non-zero, so a `2>/dev/null || fallback` chain doesn't
+# catch it — the polluted stdout was already emitted before the command
+# failed. Validate the captured value is purely numeric instead of trusting
+# the exit code.
+stat_mode() {
+  local v
+  v="$(stat -c '%a' "$1" 2>/dev/null || true)"
+  [[ "$v" =~ ^[0-7]+$ ]] || v="$(stat -f '%Lp' "$1" 2>/dev/null || true)"
+  [[ "$v" =~ ^[0-7]+$ ]] || v=""
+  printf '%s' "$v"
+}
+DMODE="$(stat_mode "$S")"
+FMODE="$(stat_mode "$S/UUID1.jsonl")"
 assert_eq "$DMODE" "700" "session dir is 0700"
 assert_eq "$FMODE" "600" "transcript file is 0600"
 echo ""

--- a/defaults/scripts/tests/test-sweep-pr-mode.sh
+++ b/defaults/scripts/tests/test-sweep-pr-mode.sh
@@ -109,10 +109,10 @@ assert_contains "Skip: loom:operator-only PRs" 'loom:operator-only'
 echo
 echo "--- Load-bearing constraints (#3289, #3298, #3373) ---"
 
-# #3289: one level deep, never spawn /shepherd as subagent.
+# #3289: one level deep, never spawn a nested /loom:sweep as subagent.
 assert_contains "One-level-deep callout preserved" 'One level deep'
-assert_contains "Never-dispatch-/shepherd-as-subagent guard preserved (issue-side, original phrasing)" 'Do NOT, under any circumstances, dispatch `/shepherd` as a subagent'
-assert_contains "Never-invoke /shepherd/judge/doctor slash commands as subagents (Mode C constraints)" '`/shepherd`, `/judge`, or `/doctor` as a subagent'
+assert_contains "Never-dispatch-nested-orchestrator-as-subagent guard preserved (issue-side)" 'Do NOT, under any circumstances, dispatch a nested orchestrator skill (`/loom:sweep`) as a subagent from `/loom:sweep`'
+assert_contains "Never-invoke /loom:sweep, /loom:judge, or /loom:doctor as a subagent (Mode C constraints)" 'Never invoke `/loom:sweep`, `/loom:judge`, or `/loom:doctor` as a subagent from `/loom:sweep`'
 
 # Sequential per-PR Judge.
 assert_contains "Per-PR Judge sequential within wave" 'Per-PR Judge is sequential'
@@ -129,7 +129,7 @@ assert_contains "Checkpoint fallback for PRs without Closes #N" "lacks a Closes 
 echo
 echo "--- Dry-run output (PR-set format) ---"
 
-assert_contains "PR-set dry-run header" '/sweep --prs --dry-run plan'
+assert_contains "PR-set dry-run header" '/loom:sweep --prs --dry-run plan'
 assert_contains "PR-set dry-run shows would-Judge" 'would Judge'
 assert_contains "PR-set dry-run shows would-Doctor-then-Judge" 'would Doctor → Judge'
 assert_contains "PR-set dry-run shows would-merge" 'would merge'
@@ -150,10 +150,10 @@ assert_contains "--builders-per-wave ignored in Mode C" '`--builders-per-wave N`
 echo
 echo "--- Examples section coverage ---"
 
-assert_contains "Example: explicit numeric PR list with --prs" '/sweep --prs 100 101 102'
-assert_contains "Example: NL description with --prs" '/sweep --prs all open loom:pr'
-assert_contains "Example: NL trigger without --prs" '/sweep all open loom:pr PRs'
-assert_contains "Example: PR-set dry-run" '/sweep --prs 100 101 102 --dry-run'
+assert_contains "Example: explicit numeric PR list with --prs" '/loom:sweep --prs 100 101 102'
+assert_contains "Example: NL description with --prs" '/loom:sweep --prs all open loom:pr'
+assert_contains "Example: NL trigger without --prs" '/loom:sweep all open loom:pr PRs'
+assert_contains "Example: PR-set dry-run" '/loom:sweep --prs 100 101 102 --dry-run'
 
 echo
 echo "--- Constraints + Limitations updated ---"

--- a/scripts/install/check-active-session.sh
+++ b/scripts/install/check-active-session.sh
@@ -53,17 +53,27 @@ fi
 
 # Portable mtime-in-epoch-seconds reader. Echoes the mtime on stdout, or
 # nothing (and a non-zero exit) when the file doesn't exist.
+#
+# GNU `stat -c` is tried FIRST, BSD `stat -f` second. `-c` is an illegal
+# option on BSD/macOS, so it fails there cleanly (no stdout). The reverse
+# order MISFIRES on GNU/Linux: there, `-f` means --file-system (a bare mode
+# flag, not a format arg), so `stat -f '%m' <path>` prints a multi-line
+# filesystem report to stdout while still exiting non-zero. Because only
+# stderr is redirected, that polluted stdout survives into the captured
+# value ahead of the real epoch from the fallback branch, corrupting every
+# downstream `$((now - mtime))` arithmetic comparison and silently
+# suppressing indicators 2 and 3 on Linux (#4565).
 _file_mtime_epoch() {
   local path="$1"
   if [[ ! -e "$path" ]]; then
     return 1
   fi
-  # BSD stat (macOS)
-  if stat -f '%m' "$path" 2>/dev/null; then
-    return 0
-  fi
   # GNU stat (Linux)
   if stat -c '%Y' "$path" 2>/dev/null; then
+    return 0
+  fi
+  # BSD stat (macOS)
+  if stat -f '%m' "$path" 2>/dev/null; then
     return 0
   fi
   return 1


### PR DESCRIPTION
## Summary

Fixes the 3 test suites listed in `defaults/scripts/tests/ci-excluded.txt` as
genuinely-red (not non-hermetic) and re-wires them into `ci-wired.txt`, per
the #4455 CI manifest split (#4542 merged).

## Changes

1. **`defaults/scripts/tests/test-sweep-pr-mode.sh`** — updated 7 stale
   doc-literal assertions. They quoted the pre-rename `/sweep` invocation
   syntax and the deprecated `/shepherd`-as-subagent guard phrasing; the
   skill file (`defaults/.claude/commands/loom/sweep.md`) has since been
   renamed to `/loom:sweep` and the guard reworded to reference
   `/loom:sweep`/`/loom:judge`/`/loom:doctor` directly. Assertions were
   updated to the current, exact phrasing (still literal/structural checks —
   they will fail again if the relevant guard text or examples are removed),
   not loosened to vacuously pass.

2. **`defaults/scripts/archive-transcripts.sh`** (root cause for
   `test-archive-transcripts.sh` Case 4, "idempotent — second run copies
   nothing new"): `file_mtime_epoch`/`file_size` tried BSD `stat -f` before
   GNU `stat -c`. On Linux, `stat -f` doesn't mean "format" the way it does
   on BSD — it's a bare `--file-system` mode flag — so `stat -f %m <path>`
   prints a multi-line filesystem report to stdout *and* exits non-zero. The
   `2>/dev/null || fallback` idiom only suppresses stderr, so that polluted
   stdout survived into the captured mtime/size, corrupting the idempotency
   comparison (`ss == ds && sm <= dm`) and making the archiver re-copy
   unchanged files on every run on Linux. Fixed by trying GNU `stat -c`
   first (fails cleanly on BSD/macOS, so is safe there) and validating the
   captured value is purely numeric before trusting it — the same technique
   already used by `defaults/scripts/lib/build-slot.sh`'s
   `_loom_build_slot_age_secs`. The test's own `Case 2` stat calls (file/dir
   mode assertions) had the identical bug and got the same fix.

3. **`scripts/install/check-active-session.sh`** (root cause for
   `test-install-active-session.sh` ubuntu failures): `_file_mtime_epoch` had
   the same BSD-first stat ordering bug, which corrupted the
   `$((now - mtime))` recency arithmetic on Linux and silently suppressed
   indicators 2 (recent daemon state) and 3 (in-flight worktrees). Swapped to
   GNU-first, matching the safe order used elsewhere in the repo.

4. Moved all three suite names from `ci-excluded.txt` to `ci-wired.txt`
   (removing their exclusion-reason lines), now that they pass on this
   (ubuntu-like) host.

## Acceptance Criteria Verification

- [x] `test-sweep-pr-mode.sh` fixed — doc-literal assertions updated to
      match current `sweep.md` phrasing (structural, not vacuous).
- [x] `test-archive-transcripts.sh` fixed at the root cause (archiver
      `stat` portability bug), not by loosening the idempotency assertion.
- [x] `test-install-active-session.sh` fixed at the root cause
      (`check-active-session.sh`'s `stat` portability bug), not by loosening
      assertions.
- [x] All three suite names moved from `ci-excluded.txt` to `ci-wired.txt`.
- [x] `defaults/scripts/tests/check-ci-suite-manifest.sh` passes (every
      `test-*.sh` in exactly one of the two manifest files).

## Test Plan

```
$ bash defaults/scripts/tests/test-sweep-pr-mode.sh
Results: 58 passed, 0 failed   (exit 0)

$ bash defaults/scripts/tests/test-archive-transcripts.sh
Tests run: 23, Passed: 23, Failed: 0   (exit 0)

$ bash defaults/scripts/tests/test-install-active-session.sh
Tests run: 37, Passed: 37, Failed: 0   (exit 0)

$ bash defaults/scripts/tests/check-ci-suite-manifest.sh
OK: 78 suites (74 wired, 4 excluded) — every test-*.sh is accounted for.
```

All three suites verified locally on ubuntu-like Linux (this session's
host). `test-sweep-pr-mode.sh`'s fix is a platform-independent doc-literal
match, so this local run is representative for macOS too.

Closes #4565