### PR TITLE
fix: break judge/doctor/daemon stale-claim livelock from self-refreshing stand-down comments

### DIFF
--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -414,8 +414,9 @@ CLAIMED_AT=$(gh api "repos/{owner}/{repo}/issues/$N/timeline" --paginate \
 MARKER="<!-- loom:standdown claim=$CLAIMED_AT -->"
 COMMENTS_JSON=$(gh api "repos/{owner}/{repo}/issues/$N/comments" \
   | jq --arg t "$CLAIMED_AT" '[.[] | select(.created_at > $t)]')
-COMMENTS_AFTER=$(echo "$COMMENTS_JSON" | jq --arg m "$MARKER" '[.[] | select(.body | contains($m) | not)] | length')
-STANDDOWN_COUNT=$(echo "$COMMENTS_JSON" | jq --arg m "$MARKER" '[.[] | select(.body | contains($m))] | length')
+# printf, not echo: zsh's echo interprets \n escapes inside the JSON, corrupting it
+COMMENTS_AFTER=$(printf '%s\n' "$COMMENTS_JSON" | jq --arg m "$MARKER" '[.[] | select(.body | contains($m) | not)] | length')
+STANDDOWN_COUNT=$(printf '%s\n' "$COMMENTS_JSON" | jq --arg m "$MARKER" '[.[] | select(.body | contains($m))] | length')
 ```
 
 Then decide:

--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -403,25 +403,67 @@ same fix (the failure this section exists to prevent).
 behavior change: `gh pr edit <number> --add-label "loom:treating"`.
 
 **If the PR DOES carry `loom:treating`:** determine the claim's age and
-whether anyone has commented since the claim was made:
+whether anyone has *genuinely* commented since the claim was made — see
+"Stand-down marker convention" below for why the comment count excludes
+stand-down comments:
 
 ```bash
 N=<pr-number>
 CLAIMED_AT=$(gh api "repos/{owner}/{repo}/issues/$N/timeline" --paginate \
   --jq '[.[] | select(.event=="labeled" and .label.name=="loom:treating")] | last | .created_at')
-COMMENTS_AFTER=$(gh api "repos/{owner}/{repo}/issues/$N/comments" \
-  | jq --arg t "$CLAIMED_AT" '[.[] | select(.created_at > $t)] | length')
+MARKER="<!-- loom:standdown claim=$CLAIMED_AT -->"
+COMMENTS_JSON=$(gh api "repos/{owner}/{repo}/issues/$N/comments" \
+  | jq --arg t "$CLAIMED_AT" '[.[] | select(.created_at > $t)]')
+COMMENTS_AFTER=$(echo "$COMMENTS_JSON" | jq --arg m "$MARKER" '[.[] | select(.body | contains($m) | not)] | length')
+STANDDOWN_COUNT=$(echo "$COMMENTS_JSON" | jq --arg m "$MARKER" '[.[] | select(.body | contains($m))] | length')
 ```
 
 Then decide:
 
 | Condition | Verdict | Action |
 |-----------|---------|--------|
-| Claim age < `LOOM_STALE_TREATING_MINUTES` (default **60**), OR `COMMENTS_AFTER > 0` | **Fresh** — a Doctor is actively fixing this PR | **Do not stomp the claim.** Skip this PR and move to the next candidate in the queue. |
+| `STANDDOWN_COUNT >= LOOM_MAX_STANDDOWN_STREAK` (default **3**) | **Stale — bounded fallback** (see below) | Force-reclaim regardless of claim age or `COMMENTS_AFTER`. Breaks the livelock even if the marker/exclusion logic above is somehow bypassed. |
+| Claim age < `LOOM_STALE_TREATING_MINUTES` (default **60**), OR `COMMENTS_AFTER > 0` | **Fresh** — a Doctor is actively fixing this PR | **Do not stomp the claim.** Post a marked stand-down comment (see below), then skip this PR and move to the next candidate in the queue. |
 | Claim age ≥ `LOOM_STALE_TREATING_MINUTES` AND `COMMENTS_AFTER == 0` | **Stale** — the claiming Doctor's process almost certainly died mid-fix | Reclaim (see below), then proceed with the normal fix from step 3. |
 | Timeline API call fails or returns empty (`CLAIMED_AT` unset) | **Unknown — fail safe** | Treat as **fresh**. Never stomp a claim on API failure or missing data. |
 
-**Reclaiming a stale claim:**
+**Stand-down marker convention (#4618 — breaks the livelock)**: a "standing
+down, not stomping" comment is evidence of **no activity**, not activity — it
+means a *later* Doctor pass declined to touch the claim, not that the
+*original* claimant is still working. Before #4618, `COMMENTS_AFTER` counted
+every comment after the claim indiscriminately, so each stand-down comment
+satisfied the very freshness test the next pass ran, making the claim look
+eternally fresh even though nothing was actually happening (the `loom:reviewing`
+analog of this played out on PR #4614: 3 consecutive stand-down comments over
+30+ minutes, never reclaimed — the same defect shape applies here to
+`loom:treating`). Every stand-down comment you post in the "Fresh" row above
+MUST end with the `<!-- loom:standdown claim=$CLAIMED_AT -->` marker so it is
+excluded from `COMMENTS_AFTER` on every subsequent pass, and counted in
+`STANDDOWN_COUNT` instead:
+
+```bash
+gh pr comment $N --body "Doctor pass: PR still carries a fresh \`loom:treating\` claim (claimed $CLAIMED_AT) — standing down without reclaiming. Not stomping.
+<!-- loom:standdown claim=$CLAIMED_AT -->"
+```
+
+**Bounded fallback (AC3, #4618)**: `STANDDOWN_COUNT` is a hard cap
+independent of the marker-exclusion logic working correctly — it counts how
+many stand-down comments have accumulated against *this exact*
+`$CLAIMED_AT` (the marker embeds it, so a genuine reclaim — which changes
+`CLAIMED_AT` — resets the count to zero automatically). Once
+`LOOM_MAX_STANDDOWN_STREAK` marked comments have piled up against the same
+claim with no reclaim, force-reclaim regardless of age or `COMMENTS_AFTER`,
+using this reclaim comment:
+
+```bash
+gh pr edit $N --remove-label "loom:treating"
+gh pr comment $N --body "Reclaiming loom:treating claim: $STANDDOWN_COUNT consecutive stand-down comments have accumulated against claim $CLAIMED_AT with no actual fix progress (bounded fallback, LOOM_MAX_STANDDOWN_STREAK=${LOOM_MAX_STANDDOWN_STREAK:-3}) — breaking the livelock."
+gh pr edit $N --add-label "loom:treating"
+CLAIM_HEAD_SHA=$(gh pr view $N --json headRefOid --jq '.headRefOid')
+# Continue to step 3 (Check PR details) and fix normally
+```
+
+**Reclaiming a stale claim** (the ordinary claim-age path):
 
 ```bash
 gh pr edit $N --remove-label "loom:treating"
@@ -431,20 +473,27 @@ CLAIM_HEAD_SHA=$(gh pr view $N --json headRefOid --jq '.headRefOid')
 # Continue to step 3 (Check PR details) and fix normally
 ```
 
-**Env var**: `LOOM_STALE_TREATING_MINUTES` (default **60**) — deliberately
+**Env vars**: `LOOM_STALE_TREATING_MINUTES` (default **60**) — deliberately
 longer than the Judge's `LOOM_STALE_REVIEWING_MINUTES` (30): a Doctor's fix
 cycle (assess all CI failures → fix → verify locally → push → re-verify
 remotely) legitimately runs longer than a single review pass. Use the
 **treating** var here; do not borrow the Judge's 30-minute threshold.
+`LOOM_MAX_STANDDOWN_STREAK` (default **3**) — the AC3 bounded-fallback cap
+described above, shared with `judge.md`'s identical check.
 
-**Daemon backstop (#4367)**: this check is the fast path — it only fires when
-another Doctor happens to revisit the same PR. `loom-daemon`'s
-`claim_reconciliation` pass (`reconcile_pr_claims`) reconciles stale
-`loom:treating` (and `loom:reviewing`) as an always-on backstop at startup and
-on its periodic tick, sharing this exact env var and default. That pass runs on
-an interval (up to ~10 minutes of lag) and cannot see an *in-flight* Doctor, so
-it never substitutes for this check or the pre-push recheck below. See
-[`daemon-reference.md`'s "Stale-claim reconciliation" section](../../../docs/daemon-reference.md#pr-side-claim-labels-loomreviewing--loomtreating-4367).
+**Daemon backstop (#4367, freshness signal fixed by #4618)**: this check is
+the fast path — it only fires when another Doctor happens to revisit the same
+PR. `loom-daemon`'s `claim_reconciliation` pass (`reconcile_pr_claims`)
+reconciles stale `loom:treating` (and `loom:reviewing`) as an always-on
+backstop at startup and on its periodic tick, sharing this exact env var and
+default — and, since #4618, deriving its own age gate from the claim label's
+own `labeled` timeline-event timestamp rather than the PR's aggregate
+`updatedAt`, for the identical reason the marker convention above exists (a
+stand-down comment self-refreshes `updatedAt` but not the label event). That
+pass runs on an interval (up to ~10 minutes of lag) and cannot see an
+*in-flight* Doctor, so it never substitutes for this check or the pre-push
+recheck below. See [`daemon-reference.md`'s "Stale-claim reconciliation"
+section](../../../docs/daemon-reference.md#pr-side-claim-labels-loomreviewing--loomtreating-4367).
 
 ### Pre-Push Head-SHA Recheck (Step 9)
 

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -332,8 +332,9 @@ CLAIMED_AT=$(gh api "repos/{owner}/{repo}/issues/$N/timeline" --paginate \
 MARKER="<!-- loom:standdown claim=$CLAIMED_AT -->"
 COMMENTS_JSON=$(gh api "repos/{owner}/{repo}/issues/$N/comments" \
   | jq --arg t "$CLAIMED_AT" '[.[] | select(.created_at > $t)]')
-COMMENTS_AFTER=$(echo "$COMMENTS_JSON" | jq --arg m "$MARKER" '[.[] | select(.body | contains($m) | not)] | length')
-STANDDOWN_COUNT=$(echo "$COMMENTS_JSON" | jq --arg m "$MARKER" '[.[] | select(.body | contains($m))] | length')
+# printf, not echo: zsh's echo interprets \n escapes inside the JSON, corrupting it
+COMMENTS_AFTER=$(printf '%s\n' "$COMMENTS_JSON" | jq --arg m "$MARKER" '[.[] | select(.body | contains($m) | not)] | length')
+STANDDOWN_COUNT=$(printf '%s\n' "$COMMENTS_JSON" | jq --arg m "$MARKER" '[.[] | select(.body | contains($m))] | length')
 ```
 
 Then decide:

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -321,25 +321,65 @@ practice, not hours, so the grace period is minutes, not hours.
 behavior change: `gh pr edit <number> --add-label "loom:reviewing"`.
 
 **If the PR DOES carry `loom:reviewing`:** determine the claim's age and
-whether anyone has commented since the claim was made:
+whether anyone has *genuinely* commented since the claim was made — see
+"Stand-down marker convention" below for why the comment count excludes
+stand-down comments:
 
 ```bash
 N=<pr-number>
 CLAIMED_AT=$(gh api "repos/{owner}/{repo}/issues/$N/timeline" --paginate \
   --jq '[.[] | select(.event=="labeled" and .label.name=="loom:reviewing")] | last | .created_at')
-COMMENTS_AFTER=$(gh api "repos/{owner}/{repo}/issues/$N/comments" \
-  | jq --arg t "$CLAIMED_AT" '[.[] | select(.created_at > $t)] | length')
+MARKER="<!-- loom:standdown claim=$CLAIMED_AT -->"
+COMMENTS_JSON=$(gh api "repos/{owner}/{repo}/issues/$N/comments" \
+  | jq --arg t "$CLAIMED_AT" '[.[] | select(.created_at > $t)]')
+COMMENTS_AFTER=$(echo "$COMMENTS_JSON" | jq --arg m "$MARKER" '[.[] | select(.body | contains($m) | not)] | length')
+STANDDOWN_COUNT=$(echo "$COMMENTS_JSON" | jq --arg m "$MARKER" '[.[] | select(.body | contains($m))] | length')
 ```
 
 Then decide:
 
 | Condition | Verdict | Action |
 |-----------|---------|--------|
-| Claim age < `LOOM_STALE_REVIEWING_MINUTES` (default **30**), OR `COMMENTS_AFTER > 0` | **Fresh** — a Judge is actively working this PR | **Do not stomp the claim.** Skip this PR and continue the batch to the next candidate PR. |
+| `STANDDOWN_COUNT >= LOOM_MAX_STANDDOWN_STREAK` (default **3**) | **Stale — bounded fallback** (see below) | Force-reclaim regardless of claim age or `COMMENTS_AFTER`. Breaks the livelock even if the marker/exclusion logic above is somehow bypassed. |
+| Claim age < `LOOM_STALE_REVIEWING_MINUTES` (default **30**), OR `COMMENTS_AFTER > 0` | **Fresh** — a Judge is actively working this PR | **Do not stomp the claim.** Post a marked stand-down comment (see below), then skip this PR and continue the batch to the next candidate PR. |
 | Claim age ≥ `LOOM_STALE_REVIEWING_MINUTES` AND `COMMENTS_AFTER == 0` | **Stale** — the claiming Judge's process almost certainly died mid-review | Reclaim (see below), then proceed with the normal review from step 3. |
 | Timeline API call fails or returns empty (`CLAIMED_AT` unset) | **Unknown — fail safe** | Treat as **fresh**. Never stomp a claim on API failure or missing data. |
 
-**Reclaiming a stale claim:**
+**Stand-down marker convention (#4618 — breaks the livelock)**: a "standing
+down, not stomping" comment is evidence of **no activity**, not activity — it
+means a *later* Judge pass declined to touch the claim, not that the
+*original* claimant is still working. Before #4618, `COMMENTS_AFTER` counted
+every comment after the claim indiscriminately, so each stand-down comment
+satisfied the very freshness test the next pass ran, making the claim look
+eternally fresh even though nothing was actually happening (PR #4614: 3
+consecutive stand-down comments over 30+ minutes, never reclaimed). Every
+stand-down comment you post in the "Fresh" row above MUST end with the
+`<!-- loom:standdown claim=$CLAIMED_AT -->` marker so it is excluded from
+`COMMENTS_AFTER` on every subsequent pass, and counted in `STANDDOWN_COUNT`
+instead:
+
+```bash
+gh pr comment $N --body "Judge pass: PR still carries a fresh \`loom:reviewing\` claim (claimed $CLAIMED_AT) — standing down without reclaiming. Not stomping.
+<!-- loom:standdown claim=$CLAIMED_AT -->"
+```
+
+**Bounded fallback (AC3, #4618)**: `STANDDOWN_COUNT` is a hard cap
+independent of the marker-exclusion logic working correctly — it counts how
+many stand-down comments have accumulated against *this exact*
+`$CLAIMED_AT` (the marker embeds it, so a genuine reclaim — which changes
+`CLAIMED_AT` — resets the count to zero automatically). Once
+`LOOM_MAX_STANDDOWN_STREAK` marked comments have piled up against the same
+claim with no reclaim, force-reclaim regardless of age or `COMMENTS_AFTER`,
+using this reclaim comment:
+
+```bash
+gh pr edit $N --remove-label "loom:reviewing"
+gh pr comment $N --body "Reclaiming loom:reviewing claim: $STANDDOWN_COUNT consecutive stand-down comments have accumulated against claim $CLAIMED_AT with no actual review progress (bounded fallback, LOOM_MAX_STANDDOWN_STREAK=${LOOM_MAX_STANDDOWN_STREAK:-3}) — breaking the livelock."
+gh pr edit $N --add-label "loom:reviewing"
+# Continue to step 3 (Check merge state) and evaluate normally
+```
+
+**Reclaiming a stale claim** (the ordinary claim-age path):
 
 ```bash
 gh pr edit $N --remove-label "loom:reviewing"
@@ -348,18 +388,25 @@ gh pr edit $N --add-label "loom:reviewing"
 # Continue to step 3 (Check merge state) and evaluate normally
 ```
 
-**Env var**: `LOOM_STALE_REVIEWING_MINUTES` (default **30**) — named to
+**Env vars**: `LOOM_STALE_REVIEWING_MINUTES` (default **30**) — named to
 mirror `LOOM_STALE_BUILDING_HOURS` (`loom-daemon/src/claim_reconciliation.rs`,
 the analogous no-record staleness threshold for `loom:building` claims), but
 on a **minutes**, not hours, scale, since review turnaround (5–15 minutes) is
-two orders of magnitude faster than a build.
+two orders of magnitude faster than a build. `LOOM_MAX_STANDDOWN_STREAK`
+(default **3**) — the AC3 bounded-fallback cap described above.
 
-**Daemon backstop (#4367)**: this check is the fast path — it only fires when
-another Judge happens to revisit the same PR. `loom-daemon`'s
-`claim_reconciliation` pass now also reconciles `loom:reviewing` (and
-`loom:treating`, Doctor's equivalent) as an always-on backstop at startup and
-on its periodic tick, sharing this exact env var and default. See
-[`daemon-reference.md`'s "Stale-claim reconciliation" section](../../../docs/daemon-reference.md#pr-side-claim-labels-loomreviewing--loomtreating-4367).
+**Daemon backstop (#4367, freshness signal fixed by #4618)**: this check is
+the fast path — it only fires when another Judge happens to revisit the same
+PR. `loom-daemon`'s `claim_reconciliation` pass now also reconciles
+`loom:reviewing` (and `loom:treating`, Doctor's equivalent) as an always-on
+backstop at startup and on its periodic tick, sharing this exact
+`LOOM_STALE_REVIEWING_MINUTES`/`LOOM_STALE_TREATING_MINUTES` env vars and
+defaults — and, since #4618, deriving its own age gate from the claim
+label's own `labeled` timeline-event timestamp rather than the PR's
+aggregate `updatedAt`, for the identical reason the marker convention above
+exists (a stand-down comment self-refreshes `updatedAt` but not the label
+event). See [`daemon-reference.md`'s "Stale-claim reconciliation"
+section](../../../docs/daemon-reference.md#pr-side-claim-labels-loomreviewing--loomtreating-4367).
 
 **Applies everywhere a Judge claims a PR from a multi-PR pass** — not just
 this single-PR narrative. This same check-then-claim rule governs the batch

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1287,11 +1287,27 @@ weaker evidence:
   unconditional reclaim), a dead pid alone is never sufficient proof on the
   PR side: the branch-name join can be wrong (a Doctor may hold a PR whose
   sweep record belongs to a different phase), so `decide_pr` only reclaims
-  once the PR's `updatedAt` has *also* aged past the per-label threshold. A
+  once the claim's age has *also* aged past the per-label threshold. A
   **live** joined pid still short-circuits to `Keep` unconditionally — that
-  evidence is trustworthy either way. A missing/unparseable `updatedAt`
-  fails safe to `Keep`, same rationale as the issue side's total-absence
-  case.
+  evidence is trustworthy either way.
+
+**Freshness signal: `claim_labeled_at`, not `updatedAt` (#4618).** The age
+gate above originally used the PR's aggregate `updatedAt` — but GitHub bumps
+that on ANY comment, including a Judge/Doctor "standing down, not stomping"
+comment posted by a later pass that *declined* to reclaim. That made the
+check self-perpetuating: once a claim survived long enough for one stand-down
+comment to post, every subsequent pass saw a "recently updated" PR and never
+reclaimed it (PR #4614 — 3 consecutive stand-down comments, never reclaimed).
+`decide_pr` now prefers `ClaimedPr::claim_labeled_at` — the timestamp of the
+claim label's own most recent `labeled` timeline event, fetched via
+`fetch_claim_labeled_at` alongside `list_prs_with_label` — because posting a
+comment does not re-apply the label, so a stand-down comment cannot bump it.
+`updated_at` is kept only as the fail-open fallback for when the timeline
+fetch itself fails or returns nothing (mirroring the pre-#4618,
+missing/unparseable-`updatedAt`-fails-safe-to-`Keep` posture). See
+`claim_reconciliation.rs`'s `decide_pr` doc comment for the full rationale
+and its `decide_pr_reclaims_via_claim_labeled_at_despite_standdown_inflated_updated_at`
+regression test, which reproduces the PR #4614 shape directly.
 
 Thresholds are minutes-scale, not hours, and env-overridable:
 
@@ -1317,6 +1333,20 @@ Claim Check", sharing these exact env vars and defaults. doctor.md additionally
 carries a **pre-push head-SHA recheck** (capture `headRefOid` at claim time,
 re-compare before the final push) — the one race this pass structurally cannot
 cover, since it never hooks into an in-flight Doctor's push.
+
+**Agent-side stand-down marker convention + bounded fallback (#4618).** The
+same self-perpetuating-comment defect fixed on the daemon side above also
+existed in judge.md's and doctor.md's own `COMMENTS_AFTER` heuristic — the
+fast path shared the daemon backstop's blind spot exactly, since both read
+"any comment after the claim" as fresh. Both role prompts now (1) tag every
+stand-down comment they post with `<!-- loom:standdown claim=$CLAIMED_AT -->`
+and exclude marker-tagged comments from `COMMENTS_AFTER`, and (2) count
+marker-tagged comments in a separate `STANDDOWN_COUNT`, force-reclaiming once
+`STANDDOWN_COUNT >= LOOM_MAX_STANDDOWN_STREAK` (default **3**) regardless of
+claim age — a bounded fallback that holds even if the marker-exclusion logic
+above is somehow bypassed. `LOOM_MAX_STANDDOWN_STREAK` is shared by both role
+prompts, mirroring how `LOOM_STALE_REVIEWING_MINUTES`/`LOOM_STALE_TREATING_MINUTES`
+are already shared.
 
 ## Stacked-PR dependency — #3729 (v1), #3747 (v2 item 1)
 

--- a/loom-daemon/src/claim_reconciliation.rs
+++ b/loom-daemon/src/claim_reconciliation.rs
@@ -67,12 +67,25 @@
 //!   wrong (a Doctor may hold a PR whose sweep record belongs to a different
 //!   phase, or the branch may simply not follow the convention), a dead pid
 //!   alone is not treated as proof here — [`decide_pr`] only reclaims once
-//!   the PR's `updatedAt` is also stale (per-label threshold,
+//!   the claim's age is also stale (per-label threshold,
 //!   [`resolve_stale_reviewing_minutes`] / [`resolve_stale_treating_minutes`]).
 //!   A **live** joined pid still short-circuits to `Keep` unconditionally,
 //!   exactly like the issue side — that evidence is trustworthy either way.
-//!   A missing/unparseable `updatedAt` fails safe to `Keep`, same rationale
-//!   as the issue side's total-absence-of-evidence case.
+//!   A missing age signal fails safe to `Keep`, same rationale as the issue
+//!   side's total-absence-of-evidence case.
+//! - **Freshness signal (Issue #4618): `claim_labeled_at`, not `updated_at`.**
+//!   The age gate prefers [`ClaimedPr::claim_labeled_at`] — the timestamp of
+//!   the claim label's own most recent `labeled` timeline event — over
+//!   [`ClaimedPr::updated_at`] (the PR's aggregate "last modified"
+//!   timestamp). GitHub bumps `updated_at` on ANY comment, including a
+//!   Judge/Doctor stand-down comment posted by a *later* pass that declined
+//!   to reclaim; using it as the sole freshness signal made the check
+//!   self-perpetuating (PR #4614: 3 consecutive stand-down comments kept the
+//!   claim looking "recently updated" for 30+ minutes with no actual review
+//!   progress, and it was never reclaimed). Posting a comment never
+//!   re-applies the label, so `claim_labeled_at` cannot be bumped that way.
+//!   `updated_at` remains the fail-open fallback for when the timeline fetch
+//!   failed or found nothing.
 //!
 //! Reclaiming removes only the stale claim label (the state label restores
 //! discoverability by itself); as a safety net, if the PR is then left
@@ -509,8 +522,23 @@ impl PrClaimKind {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ClaimedPr {
     pub number: u32,
-    /// Parsed `updatedAt` timestamp, when available.
+    /// Parsed `updatedAt` timestamp, when available. Kept as a fallback
+    /// freshness signal only — see [`Self::claim_labeled_at`] for why it is
+    /// no longer the primary one (Issue #4618).
     pub updated_at: Option<DateTime<Utc>>,
+    /// Timestamp of the most recent `labeled <claim-label>` timeline event
+    /// for this PR's currently-held claim label (Issue #4618), when
+    /// resolvable. Unlike [`Self::updated_at`] — GitHub's aggregate
+    /// "last modified" timestamp, which a plain comment (including a Judge's
+    /// or Doctor's own "standing down, not stomping" note) bumps just as
+    /// readily as genuine progress — this timestamp changes ONLY when the
+    /// claim label is re-applied (i.e. an actual reclaim). A stand-down
+    /// comment can therefore never self-refresh it, which is what makes it
+    /// safe to use as the primary age-gate signal in [`decide_pr`]. `None`
+    /// when the timeline fetch failed or returned no matching event — callers
+    /// then fall back to [`Self::updated_at`], preserving pre-#4618 behavior
+    /// for that fail-open case.
+    pub claim_labeled_at: Option<DateTime<Utc>>,
     /// The PR's head branch name, when available — the only join key to an
     /// issue number this pass has (see [`parse_issue_from_branch`]).
     pub head_ref_name: Option<String>,
@@ -567,6 +595,21 @@ pub fn parse_issue_from_branch(head_ref_name: &str) -> Option<u32> {
 ///
 /// `run_registry_pid` is the caller's join result, consulted only when
 /// `journal_entry` is absent, exactly like [`decide`].
+///
+/// **Age-gate freshness signal (Issue #4618)**: the age gate below prefers
+/// `pr.claim_labeled_at` (the claim label's own most recent `labeled`
+/// timeline event) over `pr.updated_at` (the PR's aggregate "last modified"
+/// timestamp). Before this fix, `updated_at` was the sole signal, and GitHub
+/// bumps it on ANY comment — including a Judge/Doctor "standing down, not
+/// stomping" comment posted by a later pass declining to reclaim. That made
+/// the check perpetually self-refreshing: each stand-down comment satisfied
+/// the very freshness test the next pass ran, so a claim could survive past
+/// the staleness window once and then never be reclaimed again (PR #4614).
+/// `claim_labeled_at` cannot be bumped that way — it only changes when the
+/// label is genuinely re-applied — so it is used whenever resolvable, with
+/// `updated_at` kept only as the fail-open fallback for when the timeline
+/// fetch itself failed or returned nothing (same fail-safe posture as the
+/// pre-#4618 `None` branch below).
 #[must_use]
 pub fn decide_pr(
     pr: &ClaimedPr,
@@ -597,9 +640,14 @@ pub fn decide_pr(
     // journal / no run-registry entry). A dead pid alone is never sufficient
     // proof here: the PR->issue join is heuristic, so only *aged* absence (or
     // aged dead-pid evidence) triggers a reclaim.
-    match pr.updated_at {
-        Some(updated) => {
-            let age_minutes = (now - updated).num_seconds() as f64 / 60.0;
+    //
+    // Prefer claim_labeled_at (Issue #4618) -- it cannot be self-refreshed by
+    // a stand-down comment the way updated_at can. Only fall back to
+    // updated_at when claim_labeled_at is unavailable (timeline fetch
+    // failure/partial response), matching the pre-#4618 fail-open posture.
+    match pr.claim_labeled_at.or(pr.updated_at) {
+        Some(freshness_at) => {
+            let age_minutes = (now - freshness_at).num_seconds() as f64 / 60.0;
             if age_minutes >= stale_minutes {
                 PrReconcileAction::Reclaim(
                     dead_pid_reason.unwrap_or(PrReclaimReason::Aged { age_minutes }),
@@ -866,6 +914,7 @@ pub mod forge {
     };
     use crate::sweep_journal;
     use anyhow::{anyhow, Context, Result};
+    use chrono::{DateTime, Utc};
     use serde::Deserialize;
     use std::path::Path;
     use std::process::{Command, Stdio};
@@ -1125,16 +1174,63 @@ pub mod forge {
             serde_json::from_slice(&out.stdout).context("parse gh pr list JSON")?;
         Ok(rows
             .into_iter()
-            .map(|r| ClaimedPr {
-                number: r.number,
-                updated_at: r
-                    .updated_at
-                    .as_deref()
-                    .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-                    .map(|dt| dt.with_timezone(&chrono::Utc)),
-                head_ref_name: r.head_ref_name,
+            .map(|r| {
+                let claim_labeled_at = fetch_claim_labeled_at(gh_bin, root, r.number, label);
+                ClaimedPr {
+                    number: r.number,
+                    updated_at: r
+                        .updated_at
+                        .as_deref()
+                        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                        .map(|dt| dt.with_timezone(&chrono::Utc)),
+                    claim_labeled_at,
+                    head_ref_name: r.head_ref_name,
+                }
             })
             .collect())
+    }
+
+    /// Best-effort fetch of the most recent `labeled <label>` timeline event
+    /// for `pr_number` (Issue #4618) — the freshness signal [`decide_pr`]
+    /// prefers over the PR's aggregate `updatedAt`, since a stand-down
+    /// comment bumps the latter but never re-applies the label. Mirrors
+    /// [`crate::quarantine_reconciliation::forge::fetch_last_blocked_labeled_at`]'s
+    /// shape. Returns `None` on any failure/timeout/unparseable-output or
+    /// when the label was never applied — callers fall back to `updatedAt`
+    /// in that case, the same fail-open posture used elsewhere in this
+    /// module.
+    fn fetch_claim_labeled_at(
+        gh_bin: &Path,
+        root: &Path,
+        pr_number: u32,
+        label: &str,
+    ) -> Option<DateTime<Utc>> {
+        let mut cmd = Command::new(gh_bin);
+        cmd.arg("api")
+            .arg(format!("repos/{{owner}}/{{repo}}/issues/{pr_number}/timeline"))
+            .arg("--paginate")
+            .arg("--jq")
+            .arg(format!(
+                r#"[.[] | select(.event == "labeled" and .label.name == "{label}") | .created_at] | max // empty"#
+            ));
+        cmd.current_dir(root);
+        if let Ok(repo) = std::env::var("LOOM_REPO") {
+            cmd.arg("--repo").arg(repo);
+        }
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let out = cmd.output().ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let raw = String::from_utf8_lossy(&out.stdout);
+        let trimmed = raw.trim();
+        if trimmed.is_empty() || trimmed == "null" {
+            return None;
+        }
+        let unquoted = trimmed.trim_matches('"');
+        chrono::DateTime::parse_from_rfc3339(unquoted)
+            .ok()
+            .map(|dt| dt.with_timezone(&chrono::Utc))
     }
 
     /// The PR's currently-applied state labels (a best-effort subset of
@@ -2276,9 +2372,14 @@ exit 0
         updated_at: Option<DateTime<Utc>>,
         head_ref_name: Option<&str>,
     ) -> ClaimedPr {
+        // claim_labeled_at intentionally left unset here so every existing
+        // caller of this helper keeps exercising the pre-#4618
+        // updated_at-only fallback path unchanged; the #4618 regression test
+        // below constructs `ClaimedPr` directly to set it.
         ClaimedPr {
             number,
             updated_at,
+            claim_labeled_at: None,
             head_ref_name: head_ref_name.map(ToString::to_string),
         }
     }
@@ -2390,6 +2491,85 @@ exit 0
         let pr = claimed_pr(108, None, Some("feature/issue-42"));
         let action = decide_pr(&pr, Some(&entry), Some(999), &|pid| pid == 111, 30.0, now);
         assert_eq!(action, PrReconcileAction::Keep);
+    }
+
+    // ------------------------------------------------------------------
+    // decide_pr: claim_labeled_at freshness signal (Issue #4618 — PR #4614
+    // stand-down-comment livelock regression coverage)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn decide_pr_reclaims_via_claim_labeled_at_despite_standdown_inflated_updated_at() {
+        // Reproduces the exact PR #4614 shape: the claim label itself was
+        // applied 35 minutes ago (well past the 30-minute reviewing
+        // threshold) and never re-applied since, but 2+ "standing down, not
+        // stomping" comments posted by later Judge passes bumped the PR's
+        // aggregate `updatedAt` to a few seconds ago -- each stand-down
+        // comment self-refreshing the very signal the pre-#4618 code used to
+        // decide freshness. `claim_labeled_at` is immune to that: it only
+        // moves when the label is genuinely re-applied, so the reclaim now
+        // fires correctly despite the inflated `updated_at`.
+        let now = Utc::now();
+        let claimed_at = now - Duration::minutes(35);
+        let standdown_inflated = now - Duration::seconds(5);
+        let pr = ClaimedPr {
+            number: 4614,
+            updated_at: Some(standdown_inflated),
+            claim_labeled_at: Some(claimed_at),
+            head_ref_name: Some("some-doctor-branch".to_string()),
+        };
+        let action = decide_pr(&pr, None, None, &|_| true, 30.0, now);
+        match action {
+            PrReconcileAction::Reclaim(PrReclaimReason::Aged { age_minutes }) => {
+                assert!(
+                    age_minutes >= 30.0,
+                    "expected age derived from claim_labeled_at (~35m), got {age_minutes}"
+                );
+            }
+            other => panic!(
+                "expected an Aged reclaim driven by claim_labeled_at, got {other:?} \
+                 (stand-down-comment-inflated updated_at must not mask staleness)"
+            ),
+        }
+    }
+
+    #[test]
+    fn decide_pr_keeps_when_claim_labeled_at_is_fresh_even_if_updated_at_is_old() {
+        // The inverse of the case above, for completeness: a fresh
+        // claim_labeled_at (recent reclaim) must read as fresh even when
+        // updated_at happens to be stale (e.g. a partial/lagging API field),
+        // confirming claim_labeled_at is genuinely primary, not just an
+        // additional condition.
+        let now = Utc::now();
+        let recent_claim = now - Duration::minutes(1);
+        let stale_updated_at = now - Duration::minutes(90);
+        let pr = ClaimedPr {
+            number: 4615,
+            updated_at: Some(stale_updated_at),
+            claim_labeled_at: Some(recent_claim),
+            head_ref_name: None,
+        };
+        let action = decide_pr(&pr, None, None, &|_| true, 30.0, now);
+        assert_eq!(action, PrReconcileAction::Keep);
+    }
+
+    #[test]
+    fn decide_pr_falls_back_to_updated_at_when_claim_labeled_at_unresolvable() {
+        // When the timeline fetch failed/returned nothing (claim_labeled_at
+        // is None), decide_pr must fall back to updated_at exactly like the
+        // pre-#4618 behavior -- this is the fail-open case, not a second
+        // route to the bug: a caller-side fetch failure should never be
+        // amplified into either a spurious reclaim or a permanently-fresh
+        // claim.
+        let now = Utc::now();
+        let old = now - Duration::minutes(60);
+        let pr = claimed_pr(4616, Some(old), None);
+        assert!(pr.claim_labeled_at.is_none());
+        let action = decide_pr(&pr, None, None, &|_| true, 30.0, now);
+        match action {
+            PrReconcileAction::Reclaim(PrReclaimReason::Aged { .. }) => {}
+            other => panic!("expected fallback-to-updated_at Aged reclaim, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Both the agent-side Judge/Doctor stale-claim freshness checks and the daemon's `decide_pr` reconciliation treated a "standing down, not stomping" comment as evidence of active work, when it is actually evidence of NO activity — a *later* pass declining to touch the claim, not the *original* claimant still working. This created an unbreakable livelock: once one stand-down comment posted, every subsequent pass saw a "recently active" claim (either via `COMMENTS_AFTER > 0` on the agent side, or a self-bumped `updatedAt` on the daemon side) and could never reclaim it (observed live on PR #4614: 3 consecutive stand-down comments over 30+ minutes, never reclaimed).

## Changes

- **`defaults/.claude/commands/loom/judge.md`** (`loom:reviewing` check) and **`defaults/.claude/commands/loom/doctor.md`** (`loom:treating` check):
  - Every stand-down comment posted by the "Fresh — do not stomp" path is now tagged with a `<!-- loom:standdown claim=$CLAIMED_AT -->` marker.
  - `COMMENTS_AFTER` now excludes marker-tagged comments (AC1) — a genuine, non-stand-down comment still counts as freshness evidence.
  - New `STANDDOWN_COUNT` counts marker-tagged comments citing the current claim; once it reaches `LOOM_MAX_STANDDOWN_STREAK` (default **3**) the claim is force-reclaimed regardless of age or `COMMENTS_AFTER` — a bounded fallback (AC3) that holds even if the marker-exclusion logic is somehow bypassed, and resets automatically on a genuine reclaim (since that changes `$CLAIMED_AT`).
- **`loom-daemon/src/claim_reconciliation.rs`**:
  - Added `ClaimedPr::claim_labeled_at` — the claim label's own most recent `labeled` timeline-event timestamp, fetched by the new `fetch_claim_labeled_at` helper (mirrors `quarantine_reconciliation.rs`'s existing `fetch_last_blocked_labeled_at` pattern).
  - `decide_pr` now prefers `claim_labeled_at` over the PR's aggregate `updated_at` for its age gate (AC2) — a stand-down comment cannot re-apply the label, so it cannot self-refresh this signal, unlike `updated_at` which GitHub bumps on any comment. `updated_at` remains the fail-open fallback for when the timeline fetch is unavailable, preserving pre-#4618 behavior for that case.
  - Added regression tests reproducing the PR #4614 shape directly (claim + stand-down-comment-inflated `updated_at`, aged `claim_labeled_at` → now correctly `Reclaim`), plus a fresh-`claim_labeled_at`-wins-over-stale-`updated_at` test and a fallback-when-unresolvable test. All prior `decide_pr` tests pass unmodified (live joined pid still short-circuits to `Keep`; the existing `updated_at`-only tests exercise the fallback path since `claim_labeled_at` defaults to `None` in the shared test helper).
- **`defaults/docs/daemon-reference.md`**: documents the new `claim_labeled_at` freshness signal and the agent-side marker convention + bounded fallback, cross-referenced from both role files.

Sibling copies under `quickstarts/*/.loom/roles/judge.md` were checked and are pre-existing, independently-drifted quickstart templates (last touched in 2022-era PRs, entirely different content from `defaults/`) — not part of the resync loop, so left untouched. The installed `.claude/commands/loom/judge.md` / `doctor.md` copies in this repo's own checkout are refreshed by the periodic `chore: resync installed Loom surfaces` commit after merge, per `CLAUDE.md`'s guidance — not hand-edited here.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| AC1: judge.md/doctor.md no longer treat a prior stand-down comment as evidence of active work | ✅ | `COMMENTS_AFTER` now excludes comments matching the `<!-- loom:standdown claim=... -->` marker before the `>0` test; verified the `jq` filter logic locally against a synthetic 3-comment fixture (1 genuine, 2 marked) — genuine count 1, stand-down count 2. |
| AC2: `decide_pr` no longer relies solely on the PR's aggregate `updated_at` | ✅ | `decide_pr` now uses `pr.claim_labeled_at.or(pr.updated_at)`; new unit test `decide_pr_reclaims_via_claim_labeled_at_despite_standdown_inflated_updated_at` reproduces PR #4614's exact shape and asserts `Reclaim`. |
| AC3: bounded fallback caps consecutive stand-down comments regardless of AC1/AC2 | ✅ | `STANDDOWN_COUNT >= LOOM_MAX_STANDDOWN_STREAK` (default 3) forces a reclaim unconditionally in both judge.md and doctor.md, independent of claim age or the marker-exclusion path. |
| AC4: regression coverage for the PR #4614 shape + existing tests still pass | ✅ | `cargo test --lib claim_reconciliation` — 59/59 passed, including 3 new tests and all pre-existing `decide_pr` tests (live-pid short-circuit, dead-pid+stale, non-joinable-branch, no-updatedAt fail-safe, etc.) unmodified. |
| Existing `decide_pr` tests continue to pass | ✅ | Same test run — 0 failures, 0 pre-existing tests touched (only the shared `claimed_pr` test helper gained a doc comment; its behavior is unchanged). |

## Test Plan

- `cd loom-daemon && cargo check --lib` — clean.
- `cd loom-daemon && cargo clippy --lib --tests` — no warnings.
- `cd loom-daemon && cargo fmt -- --check` — clean.
- `cd loom-daemon && cargo test --lib claim_reconciliation` — 59/59 passed (3 new regression tests for #4618; all prior tests including `reconcile_pr_claims_reclaims_stale_reviewing_and_backfills_state_label` / `reconcile_pr_claims_keeps_fresh_pr` integration tests, which don't stub the new `gh api .../timeline` call and correctly fall back to `updated_at`).
- Manual `jq` dry-run of the marker-exclusion filter (see Changes) against a synthetic 3-comment fixture matching PR #4614's shape — correctly separates 1 genuine comment from 2 stand-down comments.

Closes #4618
