### PR TITLE
fix(daemon): exit the process on startup failure instead of unwinding through Runtime::drop

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -3480,6 +3480,17 @@ its launchd label) that no daemon is still alive after the stop and exits non-ze
 if one is, closing the silent-success hole where a failed bootout could leave a
 relaunched daemon dispatching.
 
+**Startup failures end the process directly (#4531).** A daemon that cannot start
+— most visibly the singleton guard's "another loom-daemon is already listening …
+— refusing to start" refusal (#3806) — prints that error to stderr and calls
+`std::process::exit(1)` itself rather than returning `Err` out of `main`. The
+message and the exit code are exactly what `Termination for Result` used to
+produce; what changes is that termination is now *immediate*. Returning `Err`
+made `#[tokio::main]` drop its `Runtime`, which blocks until every in-flight
+`spawn_blocking` task finishes — so a refusing second daemon kept running its
+already-spawned periodic loops for ~10s after announcing it would not start, long
+enough to look like a hang under any short timeout.
+
 ### Autonomy-loss watchdog + heartbeat (#4011)
 
 **The failure this closes.** On 2026-07-26 the `loom-daemon` launchd job took a

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -42,6 +42,7 @@ const LIVENESS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
 //   | SIGTERM (operator stop)       | 143 EXIT_SIGTERM| NO relaunch       |
 //   | SIGINT  (interactive Ctrl-C)  | 130 EXIT_SIGINT | NO relaunch       |
 //   | IPC Shutdown request          | 143 EXIT_SHUTDOWN| NO relaunch      |
+//   | startup failure (e.g. #3806)  | 1 EXIT_STARTUP_FAILURE | NO relaunch |
 //   | crash / panic                 | non-zero        | NO relaunch       |
 //
 // This is Curator Finding 1's remedy: because a SIGTERM'd daemon now exits
@@ -63,6 +64,22 @@ pub const EXIT_SIGINT: i32 = 130;
 /// Exit code for an explicit IPC `Shutdown` request. Non-zero — an explicit
 /// shutdown means "stay down", so launchd must not relaunch.
 pub const EXIT_SHUTDOWN: i32 = 143;
+/// Exit code for a startup failure the daemon reports and terminates on itself
+/// (#4531) — most visibly the singleton guard's "another loom-daemon is already
+/// listening" refusal below.
+///
+/// Deliberately `1`, the exact value `std::process::ExitCode::FAILURE` carries:
+/// `main` previously let such errors propagate out of `#[tokio::main]` and relied
+/// on `Termination for Result` to print `Error: {err:?}` and exit `1`. That path
+/// is correct but **not prompt** — the generated wrapper drops the `Runtime`
+/// after `block_on` returns, and `Runtime::drop` blocks until every in-flight
+/// `spawn_blocking` task finishes, which on a host with real work configured
+/// stalled the refusing process for ~10s (and looked like an indefinite hang
+/// under a shorter timeout). `main` now prints the same message and exits with
+/// this code directly, so the observable contract (message + status) is
+/// unchanged while termination becomes immediate. Non-zero ⇒ launchd does not
+/// relaunch, which is what a refusal wants.
+pub const EXIT_STARTUP_FAILURE: i32 = 1;
 
 /// Detect the daemon's process supervisor from the environment (#4054, #4267).
 ///
@@ -5229,6 +5246,11 @@ exit 0
         assert_ne!(EXIT_SIGTERM, 0, "SIGTERM stop must be non-zero (no relaunch)");
         assert_ne!(EXIT_SIGINT, 0, "SIGINT/Ctrl-C must be non-zero (no relaunch)");
         assert_ne!(EXIT_SHUTDOWN, 0, "explicit Shutdown must be non-zero (no relaunch)");
+        // #4531: the self-reported startup-failure exit must stay non-zero (no
+        // relaunch) AND keep the value `ExitCode::FAILURE` used to produce, so
+        // callers that only knew the old `Termination`-driven exit see no change.
+        assert_ne!(EXIT_STARTUP_FAILURE, 0, "startup failure must be non-zero (no relaunch)");
+        assert_eq!(EXIT_STARTUP_FAILURE, 1, "startup failure must match ExitCode::FAILURE");
 
         // Supervised: scheduled + do_exit.
         std::env::set_var("LOOM_DAEMON_SUPERVISOR", "launchd");

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -1691,8 +1691,45 @@ mod gh_token_guard_tests {
     }
 }
 
+/// Process entry point.
+///
+/// The real body lives in [`run_daemon`]; this wrapper exists so a startup
+/// failure **terminates the process itself** instead of returning `Err` out of
+/// `#[tokio::main]` (#4531).
+///
+/// Returning `Err` is correct but not prompt: the `#[tokio::main]` wrapper drops
+/// its `Runtime` when `block_on` returns, and `Runtime::drop` blocks the calling
+/// thread until every in-flight `spawn_blocking` task finishes. By the time the
+/// singleton guard refuses to start (`IpcServer::run`, #3806), the daemon has
+/// already spawned its periodic loops, several of which do their work on the
+/// blocking pool — so the refusal message printed, then the process sat in
+/// `Runtime::drop` for ~10s before `Termination` ever ran. Under a shorter
+/// timeout that is indistinguishable from a hang, and it left a doomed second
+/// daemon alive (running role-runner/work-finder ticks) long after it had
+/// decided not to start.
+///
+/// The observable contract is deliberately unchanged: the message is the same
+/// `Error: {err:?}` line `Termination for Result` would have written to stderr,
+/// and [`loom_daemon::ipc::EXIT_STARTUP_FAILURE`] is `1`, the value
+/// `ExitCode::FAILURE` carries.
+/// Only the latency changes. stderr is explicitly flushed before
+/// `std::process::exit` so the refusal is never truncated (`exit` runs no
+/// destructors); the log file needs no such care because `env_logger` flushes
+/// each record as it writes it — the same assumption every other
+/// `std::process::exit` path in this daemon already makes.
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() {
+    if let Err(err) = run_daemon().await {
+        eprintln!("Error: {err:?}");
+        let _ = std::io::stderr().flush();
+        std::process::exit(loom_daemon::ipc::EXIT_STARTUP_FAILURE);
+    }
+}
+
+/// The daemon's real entry point: CLI dispatch, then full daemon startup ending
+/// in the IPC accept loop (which only returns on a startup failure — a running
+/// daemon leaves via one of the `std::process::exit` paths instead).
+async fn run_daemon() -> Result<()> {
     let cli = Cli::parse();
 
     // Handle CLI commands (init mode)

--- a/loom-daemon/tests/integration_singleton_guard.rs
+++ b/loom-daemon/tests/integration_singleton_guard.rs
@@ -12,8 +12,11 @@ mod common;
 
 use common::{cleanup_all_loom_sessions, daemon_bin, TestClient, TestDaemon};
 use serial_test::serial;
+use std::io::BufRead;
+use std::os::unix::fs::FileTypeExt;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 fn setup() {
@@ -26,31 +29,142 @@ fn setup() {
 /// latency assertion.
 const DAEMON_REFUSAL_WAIT: Duration = Duration::from_secs(60);
 
-/// Spawn a raw `loom-daemon` process pointed at `socket_path`, wait up to
-/// `wait` for it to exit, and return its exit status (or `None` if still
-/// running when the wait elapses). Captures no output beyond piping it away.
-fn spawn_daemon_and_wait(socket_path: &Path, wait: Duration) -> (std::process::Child, bool) {
-    let mut child = Command::new(daemon_bin())
-        .env("LOOM_SOCKET_PATH", socket_path)
+/// How long to wait for a daemon to reclaim a stale socket file and bind it.
+///
+/// Same liveness-bound reasoning as [`DAEMON_REFUSAL_WAIT`] (and the same size
+/// as `common`'s socket timeout): the poll loop returns as soon as the socket
+/// appears, so a generous bound costs a passing run nothing.
+const DAEMON_BIND_WAIT: Duration = Duration::from_secs(60);
+
+/// How long a refusing daemon may take to *end its process* after printing the
+/// refusal to stderr.
+///
+/// This is the #4531 regression bound, and it IS a latency assertion — but on a
+/// quantity with no legitimate reason to vary with load. Once the guard has
+/// decided to refuse, all that remains is writing one line and calling
+/// `std::process::exit`. Before #4531 the refusal instead returned `Err` out of
+/// `#[tokio::main]`, whose generated wrapper drops the `Runtime` before
+/// `Termination` prints anything — and `Runtime::drop` blocks until every
+/// in-flight `spawn_blocking` task finishes, which measured ~10s on a host with
+/// real work configured. The startup latency that genuinely does vary with load
+/// is excluded by measuring from the refusal line rather than from spawn.
+const REFUSAL_TO_EXIT_BUDGET: Duration = Duration::from_secs(5);
+
+/// Substring identifying the singleton guard's refusal on stderr.
+const REFUSAL_MARKER: &str = "refusing to start";
+
+/// Build a `loom-daemon` command for a raw (non-`TestDaemon`) spawn, pointed at
+/// `socket_path` and confined to `workspace`.
+///
+/// Mirrors `TestDaemon::start`'s fail-closed environment (#4573). It is not
+/// cosmetic here: without it a daemon spawned by these tests inherits this
+/// repo's real `.loom/config.json` (`autonomous.roleRunner.enabled: true`) and
+/// spends ~10s of startup doing live forge work *before* it ever reaches the
+/// singleton guard. That is both a side-effect hazard for a daemon meant to be
+/// inert and the main reason these tests were load-sensitive (#4531).
+fn daemon_command(socket_path: &Path, workspace: &Path) -> Command {
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("LOOM_SOCKET_PATH", socket_path)
         .env("RUST_LOG", "debug")
         .env("LOOM_NO_RESTORE", "1")
+        .env("LOOM_ROLE_RUNNER", "0")
+        .env("LOOM_WORK_FINDER", "0")
+        .env("LOOM_EPIC_SUPERVISOR", "0")
+        .env("LOOM_WORKSPACE", workspace)
+        .env("LOOM_WORKSPACES_PATH", workspace.join("workspaces.json"))
+        .env("LOOM_WORKTREE_ROOT", workspace.join("worktrees"))
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::piped());
+    cmd
+}
+
+/// What a refused start looked like from the outside.
+struct RefusedStart {
+    /// When the child was first observed to have exited (`None` ⇒ still running
+    /// when the wait budget elapsed).
+    exit_at: Option<Instant>,
+    /// When the refusal line first appeared on the child's stderr.
+    refusal_at: Option<Instant>,
+    /// Everything the child wrote to stderr (collected to EOF).
+    stderr: String,
+}
+
+/// Spawn a raw `loom-daemon` process pointed at `socket_path`, wait up to `wait`
+/// for it to exit, and report what happened.
+///
+/// Stderr is drained on a helper thread rather than after the fact so the moment
+/// the refusal is *printed* can be compared with the moment the process actually
+/// *ends* — the two events #4531 pulled ~10s apart.
+fn spawn_daemon_and_wait(
+    socket_path: &Path,
+    workspace: &Path,
+    wait: Duration,
+) -> (Child, RefusedStart) {
+    let mut child = daemon_command(socket_path, workspace)
         .spawn()
         .expect("Failed to spawn second daemon");
 
+    // (refusal timestamp, accumulated stderr)
+    let observed: Arc<Mutex<(Option<Instant>, String)>> =
+        Arc::new(Mutex::new((None, String::new())));
+    let reader_handle = child.stderr.take().map(|stderr| {
+        let observed = Arc::clone(&observed);
+        std::thread::spawn(move || {
+            for line in std::io::BufReader::new(stderr)
+                .lines()
+                .map_while(Result::ok)
+            {
+                let now = Instant::now();
+                let mut guard = observed.lock().expect("stderr mutex poisoned");
+                if guard.0.is_none() && line.contains(REFUSAL_MARKER) {
+                    guard.0 = Some(now);
+                }
+                guard.1.push_str(&line);
+                guard.1.push('\n');
+            }
+        })
+    });
+
     let start = Instant::now();
+    let mut exit_at = None;
     loop {
         match child.try_wait().expect("try_wait failed") {
-            Some(_status) => return (child, true),
+            Some(_status) => {
+                exit_at = Some(Instant::now());
+                break;
+            }
             None => {
                 if start.elapsed() > wait {
-                    return (child, false);
+                    break;
                 }
-                std::thread::sleep(Duration::from_millis(25));
+                std::thread::sleep(Duration::from_millis(10));
             }
         }
     }
+
+    // The write end closes when the child exits, so the reader thread ends on
+    // EOF. If the child is still running (the failure case) the pipe never
+    // closes — leave the thread detached rather than hanging the test here; the
+    // caller asserts on `exit_at` immediately and kills the child.
+    if exit_at.is_some() {
+        if let Some(handle) = reader_handle {
+            let _ = handle.join();
+        }
+    }
+
+    let (refusal_at, stderr) = {
+        let guard = observed.lock().expect("stderr mutex poisoned");
+        (guard.0, guard.1.clone())
+    };
+
+    (
+        child,
+        RefusedStart {
+            exit_at,
+            refusal_at,
+            stderr,
+        },
+    )
 }
 
 /// The core singleton-guard scenario: a live daemon owns the socket, a second
@@ -76,19 +190,49 @@ async fn test_second_daemon_refuses_and_first_survives() {
     // Attempt a second daemon on the SAME socket. It must refuse and exit
     // non-zero.
     //
-    // The bound is deliberately generous. The singleton guard's liveness probe
-    // itself is ~500ms, but it runs *after* the rest of daemon startup, and a
-    // 10s bound failed deterministically on a loaded 8-core host where spawn to
-    // refusal measured ~15s (#4385). The poll loop below returns as soon as the
-    // child exits, so a large bound costs nothing on a passing run — it only
-    // stops a saturated machine from turning a liveness check into a latency
-    // assertion.
-    let (mut child, exited) = spawn_daemon_and_wait(&socket_path, DAEMON_REFUSAL_WAIT);
-    assert!(exited, "second daemon should exit promptly after refusing to start");
+    // The spawn-to-exit bound is deliberately generous. The singleton guard's
+    // liveness probe itself is ~500ms, but it runs *after* the rest of daemon
+    // startup, and a 10s bound failed deterministically on a loaded 8-core host
+    // where spawn to refusal measured ~15s (#4385). The poll loop returns as
+    // soon as the child exits, so a large bound costs nothing on a passing run —
+    // it only stops a saturated machine from turning a liveness check into a
+    // latency assertion. The one genuine latency assertion (#4531) is made
+    // separately below, measured from the refusal line rather than from spawn.
+    let workspace = tempfile::TempDir::new().expect("temp dir for second daemon");
+    let (mut child, refused) =
+        spawn_daemon_and_wait(&socket_path, workspace.path(), DAEMON_REFUSAL_WAIT);
+    let Some(exit_at) = refused.exit_at else {
+        let _ = child.kill();
+        let _ = child.wait();
+        panic!(
+            "second daemon should exit promptly after refusing to start; stderr so far:\n{}",
+            refused.stderr
+        );
+    };
     let status = child.wait().expect("wait on second daemon");
     assert!(
         !status.success(),
         "second daemon must exit non-zero when a live daemon owns the socket; got {status:?}"
+    );
+
+    // The refusal must reach stderr — the operator-facing half of the contract,
+    // and the half an early `std::process::exit` could truncate.
+    assert!(
+        refused.stderr.contains(REFUSAL_MARKER),
+        "second daemon must print the refusal to stderr; got:\n{}",
+        refused.stderr
+    );
+
+    // …and having printed it, the process must actually end (#4531). Before the
+    // fix it printed and then sat in `Runtime::drop` for ~10s.
+    let refusal_at = refused
+        .refusal_at
+        .expect("refusal timestamp (the message was found on stderr)");
+    let lag = exit_at.saturating_duration_since(refusal_at);
+    assert!(
+        lag < REFUSAL_TO_EXIT_BUDGET,
+        "second daemon printed its refusal but took {lag:?} to exit (budget {REFUSAL_TO_EXIT_BUDGET:?}) — \
+         the refusal path must end the process, not unwind through a runtime shutdown that blocks"
     );
 
     // The socket must still be there and daemon A must still be answering —
@@ -116,18 +260,42 @@ async fn test_stale_socket_is_reclaimed() {
     // Simulate a crashed daemon's leftover: a regular file at the socket path.
     std::fs::write(&socket_path, b"").expect("write stale socket file");
 
-    // Deliberately still short: this only has to catch an *early exit*, and a
-    // longer wait would be paid on every (passing) run. The daemon's remaining
-    // startup latency — which grew once CI began running tests process-per-test
-    // (#4385) — is absorbed by `TestClient::connect`'s retry budget below.
-    let (mut child, exited_early) = spawn_daemon_and_wait(&socket_path, Duration::from_secs(2));
-    // It should still be running (successfully bound), not exited.
-    assert!(
-        !exited_early,
-        "daemon should start normally against a stale socket file, not exit early"
-    );
+    let mut child = daemon_command(&socket_path, temp_dir.path())
+        .spawn()
+        .expect("Failed to spawn daemon");
 
-    // Give it a moment and connect — it should be a live daemon now.
+    // Poll until the leftover regular file has been replaced by a real socket,
+    // instead of sleeping a fixed budget and hoping startup fits inside it. The
+    // old form waited a flat 2s purely to prove the daemon had NOT exited early;
+    // on a loaded host that is less than the daemon needs to bind (#4531), so
+    // the actual bind was silently left to `TestClient::connect`'s retry budget.
+    // This loop asserts both properties directly and returns the moment the
+    // socket exists.
+    let start = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait().expect("try_wait failed") {
+            panic!(
+                "daemon should start normally against a stale socket file, not exit early (got {status:?})"
+            );
+        }
+        let bound = std::fs::metadata(&socket_path)
+            .map(|m| m.file_type().is_socket())
+            .unwrap_or(false);
+        if bound {
+            break;
+        }
+        if start.elapsed() > DAEMON_BIND_WAIT {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!(
+                "daemon did not reclaim the stale socket within {}s",
+                DAEMON_BIND_WAIT.as_secs()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+
+    // It should be a live daemon now.
     let mut client = TestClient::connect(&socket_path)
         .await
         .expect("connect to daemon that reclaimed a stale socket");


### PR DESCRIPTION
## Summary

A second `loom-daemon` started against a socket a live daemon already owns
correctly detects the incumbent and prints the singleton-guard refusal
(`ipc::IpcServer::run`, #3806), but the process never exits — it hangs
indefinitely instead of exiting non-zero promptly.

## Root cause

The refusal path returns `Err` out of the `#[tokio::main]`-generated async
`main`. That wrapper drops its `Runtime` when `block_on` returns, and
`Runtime::drop` blocks the calling thread until every in-flight
`spawn_blocking` task on the runtime finishes. On a host with real subsystems
configured (role runner, work finder, GitHub App token refresh, etc.), those
tasks were already spawned before the guard check ran, so the refusing
daemon sat in `Runtime::drop` for ~10s before the process actually
terminated — indistinguishable from a hang under a shorter timeout. On a
pristine CI runner those subsystems no-op, so the wart was invisible there.

## Changes

- `loom-daemon/src/main.rs`: `main` is now a thin synchronous wrapper around
  a new `run_daemon()` async fn (the previous body of `main`). On `Err`,
  `main` prints the same `Error: {err:?}` line `Termination for Result` used
  to write, flushes stderr, and calls
  `std::process::exit(loom_daemon::ipc::EXIT_STARTUP_FAILURE)` directly —
  terminating the process immediately instead of waiting on runtime
  shutdown. This covers every startup `?`, not just the singleton guard.
- `loom-daemon/src/ipc.rs`: adds `EXIT_STARTUP_FAILURE = 1` (the same value
  `ExitCode::FAILURE` carried), documents the exit-code table, and extends
  the existing exit-code invariant test to assert it stays non-zero and
  equal to `1`.
- `loom-daemon/tests/integration_singleton_guard.rs`:
  - Raw daemons spawned by these tests now get the same fail-closed
    environment `TestDaemon::start` uses (`LOOM_NO_RESTORE`,
    `LOOM_ROLE_RUNNER=0`, `LOOM_WORK_FINDER=0`, `LOOM_EPIC_SUPERVISOR=0`,
    isolated workspace paths) so an inert test daemon doesn't spend ~10s
    doing live forge work before ever reaching the guard — the actual
    source of the tests' load-sensitivity.
  - `test_second_daemon_refuses_and_first_survives` now reads the child's
    stderr on a helper thread so it can time from "refusal printed" to
    "process exited" (a 5s regression budget, immune to startup latency)
    instead of asserting on wall-clock time from process spawn.
  - `test_stale_socket_is_reclaimed` replaces its fixed 2s "did not exit
    early" sleep with a poll for the leftover regular file becoming a real
    socket, removing the load-sensitive fixed wait entirely.
- `defaults/docs/daemon-reference.md`: documents the new
  immediate-exit-on-startup-failure behavior.

## Acceptance Criteria Verification

- [x] Second daemon refusing to start now exits promptly (non-zero) instead
      of hanging — verified via `test_second_daemon_refuses_and_first_survives`,
      which asserts exit lag after the refusal line is printed stays under a
      5s budget.
- [x] The refusal message is still printed to stderr before exit (message +
      exit-code contract preserved: `EXIT_STARTUP_FAILURE == 1 ==
      ExitCode::FAILURE`).
- [x] The first (surviving) daemon's behavior is unaffected — it still
      answers `Ping` on its socket after the second daemon's refused start.
- [x] `test_stale_socket_is_reclaimed`'s fixed 2s wait replaced with a
      generous polling budget so it isn't load-sensitive.

## Test Plan

- `cargo build -p loom-daemon --bin loom-daemon` — builds clean.
- `cargo test -p loom-daemon --test integration_singleton_guard -- --test-threads=1`
  — both tests pass:
  ```
  test test_second_daemon_refuses_and_first_survives ... ok
  test test_stale_socket_is_reclaimed ... ok
  ```
- `cargo test -p loom-daemon --lib ipc::` — 76 passed, 0 failed.
- `cargo test -p loom-daemon --bin loom-daemon` — 52 passed, 0 failed
  (includes the updated `EXIT_STARTUP_FAILURE` exit-code invariant test).
- `cargo clippy -p loom-daemon --bin loom-daemon --tests` — clean.
- `cargo fmt -p loom-daemon -- --check` — clean.

Closes #4531
