### PR TITLE
fix(safehouse): reconcile champion-driven merges the SweepExited emit point misses

### DIFF
--- a/.loom/docs/safehouse.md
+++ b/.loom/docs/safehouse.md
@@ -552,13 +552,35 @@ safehoused's egress subsystem mirrors well-formed **`completion`** envelopes out
 of allowlisted rooms — redacted and delay-buffered — to a `sink_url`; that is
 what feeds the public fleet feed on 2amlogic.com. Loom is the producer:
 
-- **Emit point**: the narration sink, on `SweepExited`. Exit status alone proves
-  nothing, so the sink checks **forge truth** (`gh pr list --head
-  feature/issue-N --state merged`, in the event's workspace root, 10s timeout)
-  and emits the `completion` only when that issue's PR actually merged — the
-  `ack` still goes out either way. Chosen over having the sweep child publish a
-  post-merge phase event because it is daemon-only (no skill edit), has the
-  sweep timing to hand, and verifies rather than trusts.
+- **Emit point (two, since #4583)**:
+  1. The narration sink, on `SweepExited`. Exit status alone proves nothing, so
+     the sink checks **forge truth** (`gh pr list --head feature/issue-N
+     --state merged`, in the event's workspace root, 10s timeout) and emits
+     the `completion` only when that issue's PR actually merged — the `ack`
+     still goes out either way. Chosen over having the sweep child publish a
+     post-merge phase event because it is daemon-only (no skill edit), has the
+     sweep timing to hand, and verifies rather than trusts.
+  2. **Periodic merge reconciliation** (`reconcile_recent_merges`, #4583): the
+     `SweepExited` path only ever fires while a sweep process is alive to exit
+     — it structurally cannot see a PR that merges *after* the sweep already
+     exited, which is the **common steady-state path**: builder opens a PR,
+     judge approves, the sweep exits, and champion merges it minutes-to-hours
+     later on its own cron tick. On a fixed cadence (`safehouse.reconcile
+     Interval`, default 5 minutes; `LOOM_SAFEHOUSE_RECONCILE_INTERVAL_MS`
+     overrides it, primarily a test seam), the sink round-robins one workspace
+     at a time — drawn from the union of every repo it has observed a
+     stamped-`repo` event for and the on-disk `WorkspaceRegistry` — and runs
+     one **bulk**, branch-unfiltered `gh pr list --state merged --json
+     number,headRefName,url,mergedAt,createdAt,title,additions,deletions
+     --limit 30`. Each row's issue number is recovered from `headRefName` via
+     the `feature/issue-<N>` convention
+     (`worktree_ops::naming::issue_from_branch`); rows that do not match are
+     skipped (not every merged PR is an issue sweep). A row with no sweep clock
+     available uses the PR's own `createdAt`/`mergedAt` pair as the
+     `started_at`/`completed_at` proxy instead of the reaper's clock. Both
+     paths funnel through the same envelope-build/dedup-insert core
+     (`build_and_narrate_completion`), so "exactly one completion per merge"
+     holds regardless of which path observes it first.
 - **`meta` (`completion-v1`)**: `{schema, agent, repo, ref, result, started_at,
   completed_at}` required, plus optional `issue`/`tokens`/`title`/`additions`/
   `deletions` (envelope-v1 preserves unknown `meta` keys, so no schema rev is
@@ -598,9 +620,18 @@ what feeds the public fleet feed on 2amlogic.com. Loom is the producer:
   unfinished, not failed, and is usually resumed). The wire support exists
   (`CompletionResult::Failure`) for a follow-up that identifies a genuinely
   terminal negative outcome.
-- **At most one per merge**, deduped on `(workspace, issue)` for the daemon's
-  lifetime, so a resumed sweep's second `SweepExited` does not double-post.
-  Downstream ingest is additionally idempotent on `event_id`.
+- **At most one per merge**, deduped on `(workspace, issue)` — shared by
+  **both** emit points above, so a resumed sweep's second `SweepExited` does
+  not double-post, and the periodic reconciliation pass does not re-post a
+  merge the `SweepExited` path already narrated (in either order — whichever
+  path observes the merge first wins; the other becomes a no-op dedup check).
+  This dedup set is **persisted** to `~/.loom/safehouse-completed.json`
+  (`LOOM_SAFEHOUSE_COMPLETIONS_PATH` overrides the path) and reloaded at
+  startup — the in-memory set alone would not survive a daemon restart, which
+  would otherwise either re-post every prior completion (if reconciliation's
+  lookback window still covered them) or silently drop a merge that happened
+  while the daemon was down. Downstream ingest is additionally idempotent on
+  `event_id`.
 - **Strict client-side construction.** safehoused **silently degrades a
   malformed `meta` to `chat`** — the event then vanishes from the feed with no
   error anywhere — so `build_send_request` refuses to send a `completion` unless

--- a/.loom/docs/safehouse.md
+++ b/.loom/docs/safehouse.md
@@ -565,12 +565,12 @@ what feeds the public fleet feed on 2amlogic.com. Loom is the producer:
      — it structurally cannot see a PR that merges *after* the sweep already
      exited, which is the **common steady-state path**: builder opens a PR,
      judge approves, the sweep exits, and champion merges it minutes-to-hours
-     later on its own cron tick. On a fixed cadence (`safehouse.reconcile
-     Interval`, default 5 minutes; `LOOM_SAFEHOUSE_RECONCILE_INTERVAL_MS`
-     overrides it, primarily a test seam), the sink round-robins one workspace
-     at a time — drawn from the union of every repo it has observed a
-     stamped-`repo` event for and the on-disk `WorkspaceRegistry` — and runs
-     one **bulk**, branch-unfiltered `gh pr list --state merged --json
+     later on its own cron tick. On a fixed cadence (5 minutes;
+     `LOOM_SAFEHOUSE_RECONCILE_INTERVAL_MS` overrides it, primarily a test
+     seam), the sink round-robins one workspace at a time — drawn from the
+     union of every repo it has observed a stamped-`repo` event for and the
+     on-disk `WorkspaceRegistry` — and runs one **bulk**, branch-unfiltered
+     `gh pr list --state merged --json
      number,headRefName,url,mergedAt,createdAt,title,additions,deletions
      --limit 30`. Each row's issue number is recovered from `headRefName` via
      the `feature/issue-<N>` convention
@@ -581,6 +581,16 @@ what feeds the public fleet feed on 2amlogic.com. Loom is the producer:
      paths funnel through the same envelope-build/dedup-insert core
      (`build_and_narrate_completion`), so "exactly one completion per merge"
      holds regardless of which path observes it first.
+     - **Lookback window**: rows merged more than **7 days** ago are dropped
+       before the dedup check (`LOOM_SAFEHOUSE_RECONCILE_MAX_AGE_SECS`
+       overrides; garbage/negative values fall back to the default). `--limit
+       30` bounds a burst's *size*, not its *age* — without the window, the
+       first pass on a host with no persisted dedup set (fresh install, the
+       upgrade to this version, a lost/corrupt completions file) would backfill
+       the feed with the last 30 merges however old they are, which in a
+       low-traffic workspace means narrating months-old PRs as if they just
+       landed. Seven days is far beyond any plausible daemon outage, so the
+       daemon-was-down case below still recovers.
 - **`meta` (`completion-v1`)**: `{schema, agent, repo, ref, result, started_at,
   completed_at}` required, plus optional `issue`/`tokens`/`title`/`additions`/
   `deletions` (envelope-v1 preserves unknown `meta` keys, so no schema rev is
@@ -630,8 +640,13 @@ what feeds the public fleet feed on 2amlogic.com. Loom is the producer:
   startup — the in-memory set alone would not survive a daemon restart, which
   would otherwise either re-post every prior completion (if reconciliation's
   lookback window still covered them) or silently drop a merge that happened
-  while the daemon was down. Downstream ingest is additionally idempotent on
-  `event_id`.
+  while the daemon was down. It is written atomically (temp file + rename) and
+  every failure to read or write it is best-effort — a corrupt or unwritable
+  file degrades to "the pre-#4583 behavior, plus a bounded re-narration window",
+  never to a crash. It grows by one `["<workspace>", <issue>]` pair (~32 bytes)
+  per narrated completion and is never pruned; at Loom's own merge rate that is
+  a couple of MB per decade, so no compaction is implemented. Downstream ingest
+  is additionally idempotent on `event_id`.
 - **Strict client-side construction.** safehoused **silently degrades a
   malformed `meta` to `chat`** — the event then vanishes from the feed with no
   error anywhere — so `build_send_request` refuses to send a `completion` unless

--- a/loom-daemon/src/safehouse.rs
+++ b/loom-daemon/src/safehouse.rs
@@ -1647,14 +1647,59 @@ async fn completion_for_exit(
         return None;
     }
     let merged = fetch_merged_pr(Path::new(workspace_root), issue).await?;
+    build_and_narrate_completion(
+        persona,
+        workspace_root,
+        issue,
+        merged,
+        duration_sec,
+        exited_at,
+        slug_cache,
+        already_narrated,
+        activity_db,
+    )
+    .await
+}
+
+/// Shared envelope-build/dedup-insert core behind **both** completion trigger
+/// paths (issue #4583): the `SweepExited` emit point above
+/// ([`completion_for_exit`]) and the periodic merge-reconciliation pass below
+/// ([`reconcile_recent_merges`]), which exists precisely because a
+/// champion-tick merge — landing well after the sweep process (and its one
+/// `SweepExited`) already exited — is never observed by the first path alone.
+///
+/// Every caller must have already confirmed the merge (a [`MergedPr`] in
+/// hand); this only re-checks and updates `already_narrated`, so the exactly-
+/// once invariant holds identically regardless of which path found the merge
+/// first. `duration_sec`/`exited_at` are caller-supplied rather than derived
+/// here because the two callers have different clocks available: a live
+/// sweep's reaper clock for [`completion_for_exit`], the forge's
+/// `createdAt`/`mergedAt` pair (no sweep clock exists) for
+/// [`reconcile_recent_merges`].
+#[allow(clippy::too_many_arguments)]
+async fn build_and_narrate_completion(
+    persona: &str,
+    workspace_root: &str,
+    issue: u32,
+    merged: MergedPr,
+    duration_sec: i64,
+    exited_at: DateTime<Utc>,
+    slug_cache: &mut HashMap<String, String>,
+    already_narrated: &mut std::collections::HashSet<(String, u32)>,
+    activity_db: Option<&Arc<Mutex<ActivityDb>>>,
+) -> Option<Envelope> {
+    let key = (workspace_root.to_owned(), issue);
+    if already_narrated.contains(&key) {
+        return None;
+    }
     let slug = fetch_repo_slug_cached(slug_cache, workspace_root).await?;
     // Only reached once the merge is confirmed, so a completion is never delayed
     // by a token lookup it would not have published.
     let tokens = fetch_issue_tokens(activity_db, issue).await;
 
-    // Sweep timing comes from the one clock that produced `duration_sec` (the
-    // reaper's), so the pair is always self-consistent — mixing in the forge's
-    // `mergedAt` could render a `completed_at` before `started_at`.
+    // Timing comes from the one clock the caller had available, so the pair is
+    // always self-consistent — mixing clocks across callers could render a
+    // `completed_at` before `started_at`.
     let started_at = exited_at - chrono::Duration::seconds(duration_sec.max(0));
     let meta = CompletionMeta {
         agent: persona.to_owned(),
@@ -1685,6 +1730,290 @@ async fn completion_for_exit(
             None
         }
     }
+}
+
+// ============================================================================
+// Periodic merge reconciliation (#4583) — catches champion-tick merges
+// ============================================================================
+
+/// One row from the bulk reconciliation query: everything
+/// [`build_and_narrate_completion`] needs, plus the PR's own creation time used
+/// as a `started_at` proxy (there is by definition no live sweep clock at
+/// reconciliation time).
+struct ReconciledMergedPr {
+    issue: u32,
+    merged: MergedPr,
+    created_at: DateTime<Utc>,
+    merged_at: DateTime<Utc>,
+}
+
+/// `gh pr list --json` fields the reconciliation pass requests. Distinct from
+/// [`MERGED_PR_FIELDS`] (the per-issue, branch-filtered lookup): this is a
+/// **bulk**, unfiltered-by-branch query, so it additionally needs `headRefName`
+/// (to recover the issue number via
+/// [`crate::worktree_ops::naming::issue_from_branch`]) and `createdAt` (the
+/// `started_at` proxy described above).
+const RECONCILE_PR_FIELDS: &str =
+    "number,headRefName,url,mergedAt,createdAt,title,additions,deletions";
+
+/// How many of the most-recently-merged PRs one reconciliation pass inspects
+/// per workspace. Bounded rather than time-windowed for simplicity — a repo
+/// merging more than this between two reconciliation ticks would need a
+/// smaller [`reconcile_interval`], not a larger limit.
+const RECONCILE_PR_LIMIT: u32 = 30;
+
+/// Best-effort bulk `gh pr list --state merged` lookup across **all** recently
+/// merged PRs in `workspace_root` (issue #4583) — unlike [`fetch_merged_pr`]
+/// this is not filtered to one issue's branch, which is exactly what lets it
+/// discover a merge the branch-scoped, `SweepExited`-triggered lookup never
+/// ran for (no sweep, no trigger). Every failure — missing `gh`, no network,
+/// unauthenticated, timeout, malformed JSON, an unparsable row — degrades that
+/// row (or the whole call) to being silently skipped; a best-effort
+/// reconciliation pass must never panic or block the sink.
+async fn fetch_recent_merged_prs(workspace_root: &Path) -> Vec<ReconciledMergedPr> {
+    let gh_bin = env_nonempty(GH_BIN_ENV).unwrap_or_else(|| "gh".to_owned());
+    let run = tokio::process::Command::new(&gh_bin)
+        .arg("pr")
+        .arg("list")
+        .arg("--state")
+        .arg("merged")
+        .arg("--json")
+        .arg(RECONCILE_PR_FIELDS)
+        .arg("--limit")
+        .arg(RECONCILE_PR_LIMIT.to_string())
+        .current_dir(workspace_root)
+        .output();
+    let Ok(Ok(output)) = tokio::time::timeout(MERGE_CHECK_TIMEOUT, run).await else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    let Ok(rows) = serde_json::from_slice::<Value>(&output.stdout) else {
+        return Vec::new();
+    };
+    let Some(array) = rows.as_array() else {
+        return Vec::new();
+    };
+    array
+        .iter()
+        .filter_map(|row| {
+            let head_ref = row.get("headRefName")?.as_str()?;
+            let issue = crate::worktree_ops::naming::issue_from_branch(head_ref)?;
+            let merged_at_str = row
+                .get("mergedAt")
+                .and_then(Value::as_str)
+                .filter(|s| !s.trim().is_empty())?;
+            let merged_at = DateTime::parse_from_rfc3339(merged_at_str)
+                .ok()?
+                .with_timezone(&Utc);
+            let created_at = row
+                .get("createdAt")
+                .and_then(Value::as_str)
+                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.with_timezone(&Utc))
+                // A missing/unparsable `createdAt` degrades to a zero-duration
+                // proxy rather than losing the whole row — the feed cares far
+                // more about the completion existing than about its duration
+                // figure being exact for a merge with no sweep clock anyway.
+                .unwrap_or(merged_at);
+            let number = u32::try_from(row.get("number")?.as_u64()?).ok()?;
+            let url = row.get("url")?.as_str()?.to_owned();
+            if url.is_empty() {
+                return None;
+            }
+            let title = row
+                .get("title")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|t| !t.is_empty())
+                .map(ToOwned::to_owned);
+            let additions = row.get("additions").and_then(Value::as_u64);
+            let deletions = row.get("deletions").and_then(Value::as_u64);
+            Some(ReconciledMergedPr {
+                issue,
+                merged: MergedPr {
+                    number,
+                    url,
+                    title,
+                    additions,
+                    deletions,
+                },
+                created_at,
+                merged_at,
+            })
+        })
+        .collect()
+}
+
+/// The periodic reconciliation pass itself (issue #4583): bulk-lists recently
+/// merged PRs for `workspace_root` and narrates a completion for any
+/// `(workspace, issue)` not already in `already_narrated` — sharing that exact
+/// dedup set with [`completion_for_exit`]'s `SweepExited` path is what keeps
+/// the two trigger paths from ever double-posting the same merge, in either
+/// direction (whichever path observes the merge first wins; the other becomes
+/// a no-op `contains` check).
+///
+/// This is the option the issue's curation explicitly favors over a new event
+/// topic/IPC verb: it needs no change to the frozen v0.10.0 event taxonomy,
+/// and — because it queries forge truth directly rather than depending on any
+/// daemon-emitted event — it also naturally covers a merge that happened while
+/// the daemon itself was down, **provided** the dedup set survives the
+/// restart; see [`load_persisted_completed`] / [`persist_completed_best_effort`]
+/// for that half of the story (the in-memory set alone does not survive one).
+async fn reconcile_recent_merges(
+    persona: &str,
+    workspace_root: &str,
+    slug_cache: &mut HashMap<String, String>,
+    already_narrated: &mut std::collections::HashSet<(String, u32)>,
+    activity_db: Option<&Arc<Mutex<ActivityDb>>>,
+) -> Vec<Envelope> {
+    let rows = fetch_recent_merged_prs(Path::new(workspace_root)).await;
+    let mut out = Vec::new();
+    for row in rows {
+        let duration_sec = (row.merged_at - row.created_at).num_seconds().max(0);
+        if let Some(envelope) = build_and_narrate_completion(
+            persona,
+            workspace_root,
+            row.issue,
+            row.merged,
+            duration_sec,
+            row.merged_at,
+            slug_cache,
+            already_narrated,
+            activity_db,
+        )
+        .await
+        {
+            out.push(envelope);
+        }
+    }
+    out
+}
+
+/// Reconciliation-pass cadence (issue #4583). Test/operator override mirrors
+/// the existing `GH_BIN_ENV` seam: milliseconds, so a test can drive a whole
+/// reconciliation cycle without a real wall-clock wait. Unset/unparsable falls
+/// back to [`DEFAULT_RECONCILE_INTERVAL`].
+const RECONCILE_INTERVAL_ENV: &str = "LOOM_SAFEHOUSE_RECONCILE_INTERVAL_MS";
+
+/// Production default cadence: frequent enough that a champion-tick merge
+/// (production evidence: the fleet feed went dark for 2+ hours) is caught
+/// within a few minutes, infrequent enough that a multi-workspace host issues
+/// at most one bulk `gh pr list` per workspace every few minutes.
+const DEFAULT_RECONCILE_INTERVAL: Duration = Duration::from_secs(300);
+
+fn reconcile_interval() -> Duration {
+    env_nonempty(RECONCILE_INTERVAL_ENV)
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_RECONCILE_INTERVAL)
+}
+
+/// Test/operator override for the persisted dedup file's path (issue #4583),
+/// mirroring [`crate::workspace_registry::REGISTRY_PATH_ENV`]'s pattern.
+const COMPLETIONS_PATH_ENV: &str = "LOOM_SAFEHOUSE_COMPLETIONS_PATH";
+
+/// Resolve the on-disk path for the persisted `(workspace, issue)` completion
+/// dedup set. `None` only when no home directory can be resolved at all (an
+/// exotic environment) — reconciliation still runs, it just cannot survive a
+/// daemon restart without double-checking already-narrated merges.
+fn default_completions_path() -> Option<PathBuf> {
+    if let Some(path) = env_nonempty(COMPLETIONS_PATH_ENV) {
+        return Some(PathBuf::from(path));
+    }
+    Some(
+        dirs::home_dir()?
+            .join(".loom")
+            .join("safehouse-completed.json"),
+    )
+}
+
+/// Load the persisted dedup set (issue #4583 AC3: a merge occurring while the
+/// daemon was down must be picked up after restart, which requires that
+/// *already*-narrated merges are **not** re-narrated just because the
+/// in-memory set reset). A missing/corrupt/unreadable file degrades to an
+/// empty set — the same "narrate it (again), never lose it" tradeoff every
+/// other best-effort lookup in this module makes, and no worse than the
+/// pre-#4583 behavior (which never persisted at all).
+fn load_persisted_completed(path: Option<&Path>) -> std::collections::HashSet<(String, u32)> {
+    let Some(path) = path else {
+        return std::collections::HashSet::new();
+    };
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return std::collections::HashSet::new();
+    };
+    serde_json::from_str::<Vec<(String, u32)>>(&contents)
+        .map(|pairs| pairs.into_iter().collect())
+        .unwrap_or_default()
+}
+
+/// Persist the dedup set atomically (temp file + rename, mirroring
+/// [`crate::workspace_registry::WorkspaceRegistry::save`]). Best-effort: a
+/// write failure (read-only home, disk full, permissions) is logged once at
+/// `debug` and otherwise swallowed — the in-memory set stays authoritative for
+/// the rest of this process's life either way, this only affects
+/// restart-survival.
+fn persist_completed_best_effort(
+    path: Option<&Path>,
+    completed: &std::collections::HashSet<(String, u32)>,
+) {
+    let Some(path) = path else {
+        return;
+    };
+    let pairs: Vec<&(String, u32)> = completed.iter().collect();
+    let Ok(json) = serde_json::to_string(&pairs) else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        if let Err(err) = std::fs::create_dir_all(parent) {
+            log::debug!(
+                "safehouse: could not create completions dir {} ({err:#}); \
+                 restart-recovery for merge reconciliation is degraded",
+                parent.display()
+            );
+            return;
+        }
+    }
+    let tmp = path.with_extension(format!("json.tmp.{}", std::process::id()));
+    if let Err(err) = std::fs::write(&tmp, json) {
+        log::debug!(
+            "safehouse: could not write completions file {} ({err:#}); \
+             restart-recovery for merge reconciliation is degraded",
+            tmp.display()
+        );
+        return;
+    }
+    if let Err(err) = std::fs::rename(&tmp, path) {
+        log::debug!(
+            "safehouse: could not install completions file {} ({err:#}); \
+             restart-recovery for merge reconciliation is degraded",
+            path.display()
+        );
+    }
+}
+
+/// Union of every workspace the reconciliation pass should scan (issue #4583):
+/// every repo the sink has *observed* a stamped-`repo` event for
+/// (`known_workspaces`, built up live as events flow through [`run_sink`]) plus
+/// every repo in the machine-level [`crate::workspace_registry::WorkspaceRegistry`]
+/// (which survives a daemon restart on disk, unlike `known_workspaces`) — the
+/// union is what lets a champion-driven merge in a registered-but-otherwise-
+/// quiet workspace still get reconciled promptly after a restart, before any
+/// new sweep event re-populates `known_workspaces`.
+///
+/// A `BTreeSet` gives deterministic round-robin ordering (both for tests and
+/// so a fixed number of workspaces cycle through predictably rather than by
+/// hash-order).
+fn reconciliation_targets(known_workspaces: &std::collections::HashSet<String>) -> Vec<String> {
+    let mut targets: std::collections::BTreeSet<String> =
+        known_workspaces.iter().cloned().collect();
+    if let Ok(registry) = crate::workspace_registry::WorkspaceRegistry::load_default() {
+        for root in registry.roots() {
+            targets.insert(root.to_string_lossy().into_owned());
+        }
+    }
+    targets.into_iter().collect()
 }
 
 // ============================================================================
@@ -2062,67 +2391,132 @@ async fn run_sink(
     // Forge `owner/repo` slugs, and the (workspace, issue) pairs already
     // narrated as completions — both process-lifetime (#4426).
     let mut slug_cache: HashMap<String, String> = HashMap::new();
-    let mut completed: std::collections::HashSet<(String, u32)> = std::collections::HashSet::new();
+    // Persisted dedup (#4583 AC3): loaded once at startup so a merge already
+    // narrated before a daemon restart is not re-posted just because the
+    // process-lifetime set below reset to empty.
+    let completions_path = default_completions_path();
+    let mut completed: std::collections::HashSet<(String, u32)> =
+        load_persisted_completed(completions_path.as_deref());
+    // Every workspace root observed on a stamped-`repo` event, live (#4583).
+    // Reconciliation also folds in the on-disk workspace registry (see
+    // `reconciliation_targets`) so a registered-but-quiet workspace is still
+    // scanned right after a restart, before any new event repopulates this set.
+    let mut known_workspaces: std::collections::HashSet<String> = std::collections::HashSet::new();
+    // Round-robins one workspace per reconciliation tick (see
+    // `reconciliation_targets`) rather than sweeping every known workspace in
+    // one tick, so one slow/offline `gh` cannot delay every other workspace's
+    // narration behind it.
+    let mut reconcile_cursor: usize = 0;
+    let mut reconcile_timer = tokio::time::interval(reconcile_interval());
+    reconcile_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // First tick fires immediately; skip it here so a freshly-started sink
+    // does not race its own first live events with an instant reconciliation
+    // pass over an empty `known_workspaces`/registry.
+    reconcile_timer.tick().await;
 
     loop {
-        let event = match subscription.recv().await {
-            Ok(event) => event,
-            Err(RecvError::Closed) => {
-                log::debug!("safehouse: event bus closed; narration sink stopping");
-                break;
-            }
-            // Empty/Lagged are surfaced as events by `recv`; only Closed ends it.
-            Err(_) => continue,
-        };
-
-        // One bus event can narrate more than one envelope: a `SweepExited`
-        // whose PR merged emits its `ack` **and** the public-feed `completion`
-        // (#4426), in that order.
+        // One iteration narrates the envelope(s) produced by exactly one bus
+        // event **or** one reconciliation tick — never both at once, so the
+        // `completed` dedup set is only ever touched from one place at a time
+        // (no cross-task race between the two trigger paths).
         let mut outbox: Vec<Envelope> = Vec::new();
+        let mut narrated_repo: Option<String> = None;
 
-        if let Some(mut envelope) = event_to_envelope(&event) {
-            // Best-effort dispatch-title enrichment (issue #4201, AC3). Only the
-            // dispatch event needs it, and only when a repo is known (needed to
-            // resolve the `gh` working directory) — every other event is narrated
-            // exactly as `event_to_envelope` built it.
-            if let Event::SweepGlobalDispatch {
-                kind: SweepKind::Issue(issue),
-                repo: Some(workspace_root),
-                ..
-            } = &event
-            {
-                if let Some(title) =
-                    fetch_title_cached(&mut title_cache, workspace_root, *issue).await
-                {
-                    envelope.body.push_str(&format!(" — \"{title}\""));
+        tokio::select! {
+            biased;
+
+            recv_result = subscription.recv() => {
+                let event = match recv_result {
+                    Ok(event) => event,
+                    Err(RecvError::Closed) => {
+                        log::debug!("safehouse: event bus closed; narration sink stopping");
+                        break;
+                    }
+                    // Empty/Lagged are surfaced as events by `recv`; only Closed ends it.
+                    Err(_) => continue,
+                };
+
+                if let Some(root) = event_repo(&event) {
+                    known_workspaces.insert(root.to_owned());
                 }
-            }
-            outbox.push(envelope);
-        }
 
-        // Public-feed completion (#4426). Needs the workspace root to resolve
-        // the `gh` working directory, so an event with no `repo` stamped
-        // narrates its `ack` only. Every failure inside degrades to `None`.
-        if let Event::SweepExited {
-            issue,
-            duration_sec,
-            repo: Some(workspace_root),
-            ..
-        } = &event
-        {
-            if let Some(completion) = completion_for_exit(
-                &config.persona,
-                workspace_root,
-                *issue,
-                *duration_sec,
-                Utc::now(),
-                &mut slug_cache,
-                &mut completed,
-                activity_db.as_ref(),
-            )
-            .await
-            {
-                outbox.push(completion);
+                // One bus event can narrate more than one envelope: a `SweepExited`
+                // whose PR merged emits its `ack` **and** the public-feed `completion`
+                // (#4426), in that order.
+                if let Some(mut envelope) = event_to_envelope(&event) {
+                    // Best-effort dispatch-title enrichment (issue #4201, AC3). Only the
+                    // dispatch event needs it, and only when a repo is known (needed to
+                    // resolve the `gh` working directory) — every other event is narrated
+                    // exactly as `event_to_envelope` built it.
+                    if let Event::SweepGlobalDispatch {
+                        kind: SweepKind::Issue(issue),
+                        repo: Some(workspace_root),
+                        ..
+                    } = &event
+                    {
+                        if let Some(title) =
+                            fetch_title_cached(&mut title_cache, workspace_root, *issue).await
+                        {
+                            envelope.body.push_str(&format!(" — \"{title}\""));
+                        }
+                    }
+                    outbox.push(envelope);
+                }
+
+                // Public-feed completion (#4426). Needs the workspace root to resolve
+                // the `gh` working directory, so an event with no `repo` stamped
+                // narrates its `ack` only. Every failure inside degrades to `None`.
+                if let Event::SweepExited {
+                    issue,
+                    duration_sec,
+                    repo: Some(workspace_root),
+                    ..
+                } = &event
+                {
+                    if let Some(completion) = completion_for_exit(
+                        &config.persona,
+                        workspace_root,
+                        *issue,
+                        *duration_sec,
+                        Utc::now(),
+                        &mut slug_cache,
+                        &mut completed,
+                        activity_db.as_ref(),
+                    )
+                    .await
+                    {
+                        outbox.push(completion);
+                        persist_completed_best_effort(completions_path.as_deref(), &completed);
+                    }
+                }
+
+                narrated_repo = event_repo(&event).map(ToOwned::to_owned);
+            }
+
+            _ = reconcile_timer.tick() => {
+                // Merge-reconciliation pass (#4583): covers a champion-tick
+                // merge, which has no live sweep — and so no `SweepExited` —
+                // to trigger the path above. One workspace per tick (see
+                // `reconcile_cursor`'s doc comment).
+                let targets = reconciliation_targets(&known_workspaces);
+                if let Some(workspace_root) = (!targets.is_empty())
+                    .then(|| targets[reconcile_cursor % targets.len()].clone())
+                {
+                    reconcile_cursor = reconcile_cursor.wrapping_add(1);
+                    let new_completions = reconcile_recent_merges(
+                        &config.persona,
+                        &workspace_root,
+                        &mut slug_cache,
+                        &mut completed,
+                        activity_db.as_ref(),
+                    )
+                    .await;
+                    if !new_completions.is_empty() {
+                        persist_completed_best_effort(completions_path.as_deref(), &completed);
+                    }
+                    outbox.extend(new_completions);
+                    narrated_repo = Some(workspace_root);
+                }
             }
         }
 
@@ -2189,8 +2583,9 @@ async fn run_sink(
         // Each envelope's room is resolved **per envelope** by attention class
         // (#4225), which is why one `SweepExited` can put its `ack` in the signal
         // room and (in a future taxonomy) chatter in the repo firehose — severity
-        // routes, and each message lands in exactly one room.
-        let narrated_repo = event_repo(&event).map(ToOwned::to_owned);
+        // routes, and each message lands in exactly one room. `narrated_repo` was
+        // captured above, inside whichever `select!` branch produced this
+        // iteration's `outbox` (a live event or a reconciliation tick).
         let mut send_failure: Option<SendError> = None;
         if let Some(connected) = client.as_mut() {
             for envelope in &outbox {
@@ -2669,6 +3064,38 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
     use std::sync::{Arc, Mutex};
     use tokio::net::UnixListener;
+
+    /// Test isolation guard (issue #4583). `run_sink` now reads/writes two
+    /// machine-level paths by default: the persisted merge-reconciliation
+    /// dedup file (`~/.loom/safehouse-completed.json`) and the workspace
+    /// registry (`~/.loom/workspaces.json`, consulted read-only as a
+    /// reconciliation-target source). A host actually running `loom-daemon`
+    /// has both populated with real state — without this guard, the test
+    /// suite would read/write that real state instead of a hermetic tempdir,
+    /// making both correctness (never touch a real daemon's files from a unit
+    /// test) and determinism (reconciliation's target set must not depend on
+    /// whatever repos happen to be registered on the machine running the
+    /// tests) fail silently. Every `run_sink` test holds one of these for its
+    /// duration; `Drop` restores the ambient (unset) env regardless of panic.
+    struct SafehouseTestPaths;
+
+    impl SafehouseTestPaths {
+        fn set(dir: &std::path::Path) -> Self {
+            std::env::set_var(COMPLETIONS_PATH_ENV, dir.join("safehouse-completed.json"));
+            std::env::set_var(
+                crate::workspace_registry::REGISTRY_PATH_ENV,
+                dir.join("workspaces.json"),
+            );
+            Self
+        }
+    }
+
+    impl Drop for SafehouseTestPaths {
+        fn drop(&mut self) {
+            std::env::remove_var(COMPLETIONS_PATH_ENV);
+            std::env::remove_var(crate::workspace_registry::REGISTRY_PATH_ENV);
+        }
+    }
 
     // ---- connection-state cell + wire rendering (#4345) ----
 
@@ -3972,6 +4399,7 @@ mod tests {
     #[serial]
     async fn run_sink_enriches_dispatch_body_with_title() {
         let dir = tempfile::tempdir().unwrap();
+        let _safehouse_test_paths = SafehouseTestPaths::set(dir.path());
         let (fake_gh, _log) = write_fake_gh(dir.path(), Some("Add repo-qualified task_id"));
         std::env::set_var(GH_BIN_ENV, &fake_gh);
 
@@ -4029,8 +4457,10 @@ mod tests {
     /// (blocker) line from the *same* repo lands in the signal room — one room per
     /// message, chosen by severity.
     #[tokio::test]
+    #[serial]
     async fn run_sink_routes_by_attention_class_and_creates_the_repo_room_lazily() {
         let dir = tempfile::tempdir().unwrap();
+        let _safehouse_test_paths = SafehouseTestPaths::set(dir.path());
         let repo = dir.path().to_string_lossy().into_owned();
         let repo_name = dir
             .path()
@@ -4105,8 +4535,10 @@ mod tests {
     /// the pre-#4225 one — one send per event addressed at the single configured
     /// room, and no `create_room` op ever.
     #[tokio::test]
+    #[serial]
     async fn run_sink_without_a_rooms_map_keeps_the_single_room_wire_shape() {
         let dir = tempfile::tempdir().unwrap();
+        let _safehouse_test_paths = SafehouseTestPaths::set(dir.path());
         let socket = dir.path().join("safehoused.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = tokio::spawn(stub_server(listener, false, 1));
@@ -4568,12 +5000,269 @@ mod tests {
         );
     }
 
+    // ---- periodic merge reconciliation: the champion-merge path (#4583) ----
+
+    /// A bulk `gh pr list --state merged` row shape (the reconciliation query):
+    /// carries `headRefName`/`createdAt` on top of the per-issue lookup's
+    /// fields, since the bulk query is not filtered to one issue's branch and
+    /// has no live sweep clock to borrow `started_at` from.
+    const RECONCILE_MERGED_PR_JSON: &str = r#"[{"number":4610,"headRefName":"feature/issue-4610","url":"https://github.com/rjwalters/loom/pull/4610","mergedAt":"2026-07-29T18:40:00Z","createdAt":"2026-07-29T18:10:00Z","title":"fix: champion-merge safehouse gap","additions":120,"deletions":18}]"#;
+
+    /// Two merged PRs in one bulk response: issue #4610 (already narrated
+    /// in-sweep) and issue #4611 (a distinct, not-yet-narrated champion merge).
+    const RECONCILE_TWO_MERGED_PRS_JSON: &str = r#"[
+        {"number":4610,"headRefName":"feature/issue-4610","url":"https://github.com/rjwalters/loom/pull/4610","mergedAt":"2026-07-29T18:40:00Z","createdAt":"2026-07-29T18:10:00Z","title":"fix: champion-merge safehouse gap","additions":120,"deletions":18},
+        {"number":4611,"headRefName":"feature/issue-4611","url":"https://github.com/rjwalters/loom/pull/4611","mergedAt":"2026-07-29T19:05:00Z","createdAt":"2026-07-29T18:50:00Z","title":"docs: unrelated cleanup","additions":4,"deletions":1}
+    ]"#;
+
+    #[tokio::test]
+    #[serial]
+    async fn reconcile_recent_merges_emits_completion_for_a_champion_driven_merge() {
+        // The AC1 case: no live sweep ever observed this merge (no `SweepExited`
+        // at merge time — the champion-tick steady state), so the only way it
+        // is discovered at all is the bulk reconciliation query.
+        let dir = tempfile::tempdir().unwrap();
+        let (fake_gh, _log) =
+            write_fake_forge_gh(dir.path(), Some(RECONCILE_MERGED_PR_JSON), Some("rjwalters/loom"));
+        std::env::set_var(GH_BIN_ENV, &fake_gh);
+
+        let root = dir.path().to_string_lossy().into_owned();
+        let mut slug_cache = HashMap::new();
+        let mut completed = std::collections::HashSet::new();
+        let envelopes =
+            reconcile_recent_merges("loom_daemon", &root, &mut slug_cache, &mut completed, None)
+                .await;
+
+        std::env::remove_var(GH_BIN_ENV);
+        assert_eq!(envelopes.len(), 1, "exactly one completion for the champion merge");
+        let meta = envelopes[0].meta.as_ref().unwrap();
+        assert_eq!(meta["schema"], json!("completion-v1"));
+        assert_eq!(meta["issue"], json!(4610));
+        assert_eq!(meta["result"], json!("success"));
+        assert_eq!(meta["title"], json!("fix: champion-merge safehouse gap"));
+        assert_eq!(meta["additions"], json!(120));
+        assert_eq!(meta["deletions"], json!(18));
+        assert!(
+            completed.contains(&(root, 4610)),
+            "the shared dedup set must record the reconciled merge"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn reconcile_recent_merges_skips_a_merge_already_narrated_in_sweep() {
+        // Regression (AC2): an in-sweep `SweepExited` narrates issue #4610
+        // first; the reconciliation pass then observes the *same* merge via
+        // its bulk query and must not double-post it — the two trigger paths
+        // share one dedup set.
+        let dir = tempfile::tempdir().unwrap();
+        let (fake_gh, log) =
+            write_fake_forge_gh(dir.path(), Some(RECONCILE_MERGED_PR_JSON), Some("rjwalters/loom"));
+        std::env::set_var(GH_BIN_ENV, &fake_gh);
+
+        let root = dir.path().to_string_lossy().into_owned();
+        let mut slug_cache = HashMap::new();
+        let mut completed = std::collections::HashSet::new();
+
+        let in_sweep = completion_for_exit(
+            "loom_daemon",
+            &root,
+            4610,
+            1800,
+            Utc::now(),
+            &mut slug_cache,
+            &mut completed,
+            None,
+        )
+        .await;
+        assert!(in_sweep.is_some(), "the in-sweep SweepExited path must narrate first");
+
+        let reconciled =
+            reconcile_recent_merges("loom_daemon", &root, &mut slug_cache, &mut completed, None)
+                .await;
+
+        std::env::remove_var(GH_BIN_ENV);
+        assert!(
+            reconciled.is_empty(),
+            "the reconciliation pass must not double-post a merge already narrated in-sweep"
+        );
+        let calls = std::fs::read_to_string(&log).unwrap_or_default();
+        assert_eq!(
+            calls.lines().filter(|l| l.starts_with("pr list")).count(),
+            2,
+            "both the per-issue lookup and the bulk reconciliation query must still run \
+             (the skip happens at the dedup check, not by avoiding the query); log: {calls:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn reconcile_recent_merges_narrates_distinct_issues_independently() {
+        // Edge case (AC4): two merges for different issues in the same
+        // workspace, one already narrated (in-sweep) and one not (champion-
+        // driven) — both must be handled independently with no cross-
+        // contamination of the dedup key.
+        let dir = tempfile::tempdir().unwrap();
+        let (fake_gh, _log) = write_fake_forge_gh(
+            dir.path(),
+            Some(RECONCILE_TWO_MERGED_PRS_JSON),
+            Some("rjwalters/loom"),
+        );
+        std::env::set_var(GH_BIN_ENV, &fake_gh);
+
+        let root = dir.path().to_string_lossy().into_owned();
+        let mut slug_cache = HashMap::new();
+        let mut completed = std::collections::HashSet::new();
+        // Issue #4610 was already narrated in-sweep before this reconciliation
+        // tick ever ran.
+        completed.insert((root.clone(), 4610));
+
+        let envelopes =
+            reconcile_recent_merges("loom_daemon", &root, &mut slug_cache, &mut completed, None)
+                .await;
+
+        std::env::remove_var(GH_BIN_ENV);
+        assert_eq!(envelopes.len(), 1, "only the not-yet-narrated issue produces a completion");
+        assert_eq!(envelopes[0].meta.as_ref().unwrap()["issue"], json!(4611));
+        assert!(completed.contains(&(root.clone(), 4610)));
+        assert!(completed.contains(&(root, 4611)));
+    }
+
+    #[test]
+    fn load_persisted_completed_round_trips_through_persist_completed_best_effort() {
+        // Building block for AC3 (restart survival): what one process wrote,
+        // the next process's startup load must read back identically.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("safehouse-completed.json");
+
+        let mut completed: std::collections::HashSet<(String, u32)> =
+            std::collections::HashSet::new();
+        completed.insert(("/home/x/GitHub/loom".to_owned(), 4610));
+        completed.insert(("/home/x/GitHub/loom".to_owned(), 4611));
+        completed.insert(("/home/x/GitHub/vibesql".to_owned(), 42));
+        persist_completed_best_effort(Some(&path), &completed);
+
+        let reloaded = load_persisted_completed(Some(&path));
+        assert_eq!(reloaded, completed);
+    }
+
+    #[test]
+    fn load_persisted_completed_degrades_to_empty_when_the_file_is_absent_or_corrupt() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            load_persisted_completed(Some(&dir.path().join("does-not-exist.json"))),
+            std::collections::HashSet::new()
+        );
+
+        let corrupt = dir.path().join("corrupt.json");
+        std::fs::write(&corrupt, "not valid json").unwrap();
+        assert_eq!(load_persisted_completed(Some(&corrupt)), std::collections::HashSet::new());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn run_sink_reconciliation_narrates_a_champion_merge_with_no_live_sweep() {
+        // End-to-end AC1: reconciliation alone — no `SweepExited` published at
+        // all — must still get the completion onto the wire, discovered
+        // purely from the registered workspace + the bulk `gh pr list` query.
+        let dir = tempfile::tempdir().unwrap();
+        let _safehouse_test_paths = SafehouseTestPaths::set(dir.path());
+        let (fake_gh, _log) =
+            write_fake_forge_gh(dir.path(), Some(RECONCILE_MERGED_PR_JSON), Some("rjwalters/loom"));
+        std::env::set_var(GH_BIN_ENV, &fake_gh);
+        // A fast reconciliation cadence so the test does not wait minutes.
+        std::env::set_var(RECONCILE_INTERVAL_ENV, "20");
+        // Register the workspace directly (mirrors what a real multi-repo
+        // daemon already has on disk) so reconciliation has a target with zero
+        // live events ever having flowed through the sink for it.
+        let mut registry = crate::workspace_registry::WorkspaceRegistry::default();
+        registry.add(dir.path(), None).unwrap();
+        registry
+            .save(&std::path::PathBuf::from(
+                std::env::var(crate::workspace_registry::REGISTRY_PATH_ENV).unwrap(),
+            ))
+            .unwrap();
+
+        let socket = dir.path().join("safehoused.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = tokio::spawn(stub_server(listener, false, 1));
+
+        let bus = Arc::new(EventBus::new());
+        let subscription = bus.subscribe(Vec::<String>::new());
+        let sink = tokio::spawn(run_sink(
+            SafehouseConfig {
+                enabled: true,
+                socket: Some(socket.clone()),
+                ..SafehouseConfig::default()
+            },
+            socket,
+            subscription,
+            Duration::from_millis(20),
+            Duration::from_millis(80),
+            new_shared_state(),
+            None,
+        ));
+
+        // No SweepExited is ever published — the only way this can reach the
+        // wire is the reconciliation pass.
+        let received = tokio::time::timeout(Duration::from_secs(5), server)
+            .await
+            .expect("reconciliation must narrate the champion merge without any live sweep")
+            .unwrap();
+
+        drop(bus);
+        let _ = tokio::time::timeout(Duration::from_secs(2), sink).await;
+        std::env::remove_var(GH_BIN_ENV);
+        std::env::remove_var(RECONCILE_INTERVAL_ENV);
+
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0]["type"], json!("completion"));
+        assert_eq!(received[0]["meta"]["issue"], json!(4610));
+        assert_eq!(received[0]["meta"]["result"], json!("success"));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn reconcile_recent_merges_does_not_repost_a_merge_loaded_from_a_persisted_restart_file()
+    {
+        // AC3, the other half: a merge already narrated by a *previous* daemon
+        // process must not be re-posted by a fresh process's reconciliation
+        // pass just because its in-memory `completed` set starts empty —
+        // `load_persisted_completed` (exactly what `run_sink` calls at
+        // startup) is what makes that survive the restart.
+        let dir = tempfile::tempdir().unwrap();
+        let (fake_gh, _log) =
+            write_fake_forge_gh(dir.path(), Some(RECONCILE_MERGED_PR_JSON), Some("rjwalters/loom"));
+        std::env::set_var(GH_BIN_ENV, &fake_gh);
+
+        let root = dir.path().to_string_lossy().into_owned();
+        let completions_path = dir.path().join("safehouse-completed.json");
+        let mut pre_seeded = std::collections::HashSet::new();
+        pre_seeded.insert((root.clone(), 4610));
+        persist_completed_best_effort(Some(&completions_path), &pre_seeded);
+
+        // Simulate the fresh process's startup load.
+        let mut completed = load_persisted_completed(Some(&completions_path));
+        let mut slug_cache = HashMap::new();
+        let envelopes =
+            reconcile_recent_merges("loom_daemon", &root, &mut slug_cache, &mut completed, None)
+                .await;
+
+        std::env::remove_var(GH_BIN_ENV);
+        assert!(
+            envelopes.is_empty(),
+            "a merge already narrated pre-restart must not be re-posted after loading the \
+             persisted dedup set"
+        );
+    }
+
     #[tokio::test]
     #[serial]
     async fn run_sink_narrates_exit_ack_then_completion() {
         // The emit-point mapping test: one `SweepExited` whose PR merged
         // produces the human `ack` and exactly one public-feed `completion`.
         let dir = tempfile::tempdir().unwrap();
+        let _safehouse_test_paths = SafehouseTestPaths::set(dir.path());
         let (fake_gh, _log) =
             write_fake_forge_gh(dir.path(), Some(MERGED_PR_JSON), Some("rjwalters/loom"));
         std::env::set_var(GH_BIN_ENV, &fake_gh);
@@ -4639,6 +5328,7 @@ mod tests {
     #[serial]
     async fn run_sink_narrates_only_the_ack_when_nothing_merged() {
         let dir = tempfile::tempdir().unwrap();
+        let _safehouse_test_paths = SafehouseTestPaths::set(dir.path());
         let (fake_gh, _log) = write_fake_forge_gh(dir.path(), Some("[]"), Some("rjwalters/loom"));
         std::env::set_var(GH_BIN_ENV, &fake_gh);
 
@@ -4876,8 +5566,10 @@ mod tests {
     /// `unreachable` when safehoused rejects the send, and clears back to
     /// `connected` once a send is accepted (config fixed + daemon restarted).
     #[tokio::test]
+    #[serial]
     async fn sink_send_rejection_reports_send_rejected_then_clears_on_success() {
         let dir = tempfile::tempdir().unwrap();
+        let _safehouse_test_paths = SafehouseTestPaths::set(dir.path());
         let socket = dir.path().join("safehoused.sock");
         let listener = UnixListener::bind(&socket).unwrap();
 
@@ -4968,8 +5660,10 @@ mod tests {
     /// fresh `hello` after a transport blip must NOT flash "connected"; only an
     /// accepted send clears it.
     #[tokio::test]
+    #[serial]
     async fn sink_send_rejected_survives_reconnect() {
         let dir = tempfile::tempdir().unwrap();
+        let _safehouse_test_paths = SafehouseTestPaths::set(dir.path());
         let socket = dir.path().join("safehoused.sock");
         let listener = UnixListener::bind(&socket).unwrap();
 
@@ -5107,10 +5801,12 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn absent_peer_degrades_without_blocking() {
         // enabled + nonexistent socket: the sink subscribes, but every connect
         // fails and is swallowed — publishing never blocks or errors.
         let dir = tempfile::tempdir().unwrap();
+        let _safehouse_test_paths = SafehouseTestPaths::set(dir.path());
         let socket = dir.path().join("does-not-exist.sock");
         let bus = Arc::new(EventBus::new());
         let subscription = bus.subscribe(Vec::<String>::new());
@@ -5158,8 +5854,10 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn reconnects_after_mid_run_disconnect() {
         let dir = tempfile::tempdir().unwrap();
+        let _safehouse_test_paths = SafehouseTestPaths::set(dir.path());
         let socket = dir.path().join("safehoused.sock");
 
         // First listener: serve one send, then drop (simulating a restart).

--- a/loom-daemon/src/safehouse.rs
+++ b/loom-daemon/src/safehouse.rs
@@ -1757,19 +1757,43 @@ const RECONCILE_PR_FIELDS: &str =
     "number,headRefName,url,mergedAt,createdAt,title,additions,deletions";
 
 /// How many of the most-recently-merged PRs one reconciliation pass inspects
-/// per workspace. Bounded rather than time-windowed for simplicity — a repo
-/// merging more than this between two reconciliation ticks would need a
-/// smaller [`reconcile_interval`], not a larger limit.
+/// per workspace. A repo merging more than this between two reconciliation
+/// ticks would need a smaller [`reconcile_interval`], not a larger limit.
 const RECONCILE_PR_LIMIT: u32 = 30;
+
+/// Test/operator override for the reconciliation lookback window, in seconds.
+const RECONCILE_MAX_AGE_ENV: &str = "LOOM_SAFEHOUSE_RECONCILE_MAX_AGE_SECS";
+
+/// How far back a reconciliation pass will narrate a merge it has never seen
+/// (issue #4583). [`RECONCILE_PR_LIMIT`] alone bounds a *burst* but not its
+/// *staleness*: the very first pass on a host that has never persisted a dedup
+/// set — a fresh install, an upgrade to this version, or a lost/corrupt
+/// completions file — would otherwise backfill the public feed with the last 30
+/// merges regardless of age, which in a low-traffic workspace means narrating
+/// months-old PRs as if they just landed. Seven days is well beyond any
+/// plausible daemon outage (the case AC3 asks us to recover), so a merge that
+/// happens while the daemon is down is still picked up on restart, while
+/// genuinely ancient history stays out of the feed.
+const DEFAULT_RECONCILE_MAX_AGE_SECS: i64 = 7 * 24 * 60 * 60;
+
+fn reconcile_max_age() -> chrono::Duration {
+    let secs = env_nonempty(RECONCILE_MAX_AGE_ENV)
+        .and_then(|s| s.parse::<i64>().ok())
+        .filter(|s| *s >= 0)
+        .unwrap_or(DEFAULT_RECONCILE_MAX_AGE_SECS);
+    chrono::Duration::seconds(secs)
+}
 
 /// Best-effort bulk `gh pr list --state merged` lookup across **all** recently
 /// merged PRs in `workspace_root` (issue #4583) — unlike [`fetch_merged_pr`]
 /// this is not filtered to one issue's branch, which is exactly what lets it
 /// discover a merge the branch-scoped, `SweepExited`-triggered lookup never
-/// ran for (no sweep, no trigger). Every failure — missing `gh`, no network,
-/// unauthenticated, timeout, malformed JSON, an unparsable row — degrades that
-/// row (or the whole call) to being silently skipped; a best-effort
-/// reconciliation pass must never panic or block the sink.
+/// ran for (no sweep, no trigger). Rows merged longer than
+/// [`reconcile_max_age`] ago are dropped here, so a first-ever pass cannot
+/// backfill stale history onto the feed. Every failure — missing `gh`, no
+/// network, unauthenticated, timeout, malformed JSON, an unparsable row —
+/// degrades that row (or the whole call) to being silently skipped; a
+/// best-effort reconciliation pass must never panic or block the sink.
 async fn fetch_recent_merged_prs(workspace_root: &Path) -> Vec<ReconciledMergedPr> {
     let gh_bin = env_nonempty(GH_BIN_ENV).unwrap_or_else(|| "gh".to_owned());
     let run = tokio::process::Command::new(&gh_bin)
@@ -1795,6 +1819,7 @@ async fn fetch_recent_merged_prs(workspace_root: &Path) -> Vec<ReconciledMergedP
     let Some(array) = rows.as_array() else {
         return Vec::new();
     };
+    let cutoff = Utc::now() - reconcile_max_age();
     array
         .iter()
         .filter_map(|row| {
@@ -1807,6 +1832,11 @@ async fn fetch_recent_merged_prs(workspace_root: &Path) -> Vec<ReconciledMergedP
             let merged_at = DateTime::parse_from_rfc3339(merged_at_str)
                 .ok()?
                 .with_timezone(&Utc);
+            // Outside the lookback window: never narrated, and now too old to
+            // start (see `DEFAULT_RECONCILE_MAX_AGE_SECS`).
+            if merged_at < cutoff {
+                return None;
+            }
             let created_at = row
                 .get("createdAt")
                 .and_then(Value::as_str)
@@ -5002,18 +5032,40 @@ mod tests {
 
     // ---- periodic merge reconciliation: the champion-merge path (#4583) ----
 
-    /// A bulk `gh pr list --state merged` row shape (the reconciliation query):
-    /// carries `headRefName`/`createdAt` on top of the per-issue lookup's
+    /// One bulk `gh pr list --state merged` row (the reconciliation query
+    /// shape): `headRefName`/`createdAt` on top of the per-issue lookup's
     /// fields, since the bulk query is not filtered to one issue's branch and
     /// has no live sweep clock to borrow `started_at` from.
-    const RECONCILE_MERGED_PR_JSON: &str = r#"[{"number":4610,"headRefName":"feature/issue-4610","url":"https://github.com/rjwalters/loom/pull/4610","mergedAt":"2026-07-29T18:40:00Z","createdAt":"2026-07-29T18:10:00Z","title":"fix: champion-merge safehouse gap","additions":120,"deletions":18}]"#;
+    ///
+    /// Timestamps are **relative to now** rather than literals: the pass drops
+    /// rows merged longer than [`reconcile_max_age`] ago, so hard-coded dates
+    /// would silently turn every reconciliation test into a no-op assertion
+    /// once wall-clock time drifted a week past them.
+    fn reconcile_pr_row(issue: u32, merged_minutes_ago: i64, title: &str) -> String {
+        let merged_at = Utc::now() - chrono::Duration::minutes(merged_minutes_ago);
+        let created_at = merged_at - chrono::Duration::minutes(30);
+        format!(
+            r#"{{"number":{issue},"headRefName":"feature/issue-{issue}","url":"https://github.com/rjwalters/loom/pull/{issue}","mergedAt":"{}","createdAt":"{}","title":"{title}","additions":120,"deletions":18}}"#,
+            merged_at.to_rfc3339(),
+            created_at.to_rfc3339(),
+        )
+    }
+
+    /// The single-row response used by most reconciliation tests: issue #4610,
+    /// merged well inside the lookback window.
+    fn reconcile_merged_pr_json() -> String {
+        format!("[{}]", reconcile_pr_row(4610, 20, "fix: champion-merge safehouse gap"))
+    }
 
     /// Two merged PRs in one bulk response: issue #4610 (already narrated
     /// in-sweep) and issue #4611 (a distinct, not-yet-narrated champion merge).
-    const RECONCILE_TWO_MERGED_PRS_JSON: &str = r#"[
-        {"number":4610,"headRefName":"feature/issue-4610","url":"https://github.com/rjwalters/loom/pull/4610","mergedAt":"2026-07-29T18:40:00Z","createdAt":"2026-07-29T18:10:00Z","title":"fix: champion-merge safehouse gap","additions":120,"deletions":18},
-        {"number":4611,"headRefName":"feature/issue-4611","url":"https://github.com/rjwalters/loom/pull/4611","mergedAt":"2026-07-29T19:05:00Z","createdAt":"2026-07-29T18:50:00Z","title":"docs: unrelated cleanup","additions":4,"deletions":1}
-    ]"#;
+    fn reconcile_two_merged_prs_json() -> String {
+        format!(
+            "[{},{}]",
+            reconcile_pr_row(4610, 20, "fix: champion-merge safehouse gap"),
+            reconcile_pr_row(4611, 5, "docs: unrelated cleanup"),
+        )
+    }
 
     #[tokio::test]
     #[serial]
@@ -5022,8 +5074,11 @@ mod tests {
         // at merge time — the champion-tick steady state), so the only way it
         // is discovered at all is the bulk reconciliation query.
         let dir = tempfile::tempdir().unwrap();
-        let (fake_gh, _log) =
-            write_fake_forge_gh(dir.path(), Some(RECONCILE_MERGED_PR_JSON), Some("rjwalters/loom"));
+        let (fake_gh, _log) = write_fake_forge_gh(
+            dir.path(),
+            Some(&reconcile_merged_pr_json()),
+            Some("rjwalters/loom"),
+        );
         std::env::set_var(GH_BIN_ENV, &fake_gh);
 
         let root = dir.path().to_string_lossy().into_owned();
@@ -5056,8 +5111,11 @@ mod tests {
         // its bulk query and must not double-post it — the two trigger paths
         // share one dedup set.
         let dir = tempfile::tempdir().unwrap();
-        let (fake_gh, log) =
-            write_fake_forge_gh(dir.path(), Some(RECONCILE_MERGED_PR_JSON), Some("rjwalters/loom"));
+        let (fake_gh, log) = write_fake_forge_gh(
+            dir.path(),
+            Some(&reconcile_merged_pr_json()),
+            Some("rjwalters/loom"),
+        );
         std::env::set_var(GH_BIN_ENV, &fake_gh);
 
         let root = dir.path().to_string_lossy().into_owned();
@@ -5105,7 +5163,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let (fake_gh, _log) = write_fake_forge_gh(
             dir.path(),
-            Some(RECONCILE_TWO_MERGED_PRS_JSON),
+            Some(&reconcile_two_merged_prs_json()),
             Some("rjwalters/loom"),
         );
         std::env::set_var(GH_BIN_ENV, &fake_gh);
@@ -5126,6 +5184,63 @@ mod tests {
         assert_eq!(envelopes[0].meta.as_ref().unwrap()["issue"], json!(4611));
         assert!(completed.contains(&(root.clone(), 4610)));
         assert!(completed.contains(&(root, 4611)));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn reconcile_recent_merges_ignores_merges_older_than_the_lookback_window() {
+        // The first pass on a host with no persisted dedup set (fresh install,
+        // upgrade, lost completions file) must not backfill the public feed
+        // with stale history: `RECONCILE_PR_LIMIT` bounds the burst size, the
+        // lookback window bounds its age. Here the older row is outside the
+        // window and the newer one is inside, with an empty dedup set — so only
+        // the recent merge may be narrated.
+        let dir = tempfile::tempdir().unwrap();
+        let rows = format!(
+            "[{},{}]",
+            reconcile_pr_row(4610, 240, "chore: merged long before this daemon started"),
+            reconcile_pr_row(4611, 5, "fix: just merged by a champion tick"),
+        );
+        let (fake_gh, _log) = write_fake_forge_gh(dir.path(), Some(&rows), Some("rjwalters/loom"));
+        std::env::set_var(GH_BIN_ENV, &fake_gh);
+        // One hour of lookback: the 240-minute-old row falls outside it.
+        std::env::set_var(RECONCILE_MAX_AGE_ENV, "3600");
+
+        let root = dir.path().to_string_lossy().into_owned();
+        let mut slug_cache = HashMap::new();
+        let mut completed = std::collections::HashSet::new();
+        let envelopes =
+            reconcile_recent_merges("loom_daemon", &root, &mut slug_cache, &mut completed, None)
+                .await;
+
+        std::env::remove_var(GH_BIN_ENV);
+        std::env::remove_var(RECONCILE_MAX_AGE_ENV);
+        assert_eq!(envelopes.len(), 1, "only the in-window merge may be narrated");
+        assert_eq!(envelopes[0].meta.as_ref().unwrap()["issue"], json!(4611));
+        assert!(
+            !completed.contains(&(root.clone(), 4610)),
+            "an out-of-window row is skipped before the dedup set, so a later in-window \
+             observation of it (e.g. a resumed sweep's SweepExited) can still narrate"
+        );
+        assert!(completed.contains(&(root, 4611)));
+    }
+
+    #[test]
+    #[serial]
+    fn reconcile_max_age_defaults_and_honours_its_env_override() {
+        std::env::remove_var(RECONCILE_MAX_AGE_ENV);
+        assert_eq!(reconcile_max_age(), chrono::Duration::seconds(DEFAULT_RECONCILE_MAX_AGE_SECS));
+
+        std::env::set_var(RECONCILE_MAX_AGE_ENV, "600");
+        assert_eq!(reconcile_max_age(), chrono::Duration::seconds(600));
+
+        // Garbage and negatives fall back to the default rather than degrading
+        // into a window that silently narrates nothing.
+        std::env::set_var(RECONCILE_MAX_AGE_ENV, "not-a-number");
+        assert_eq!(reconcile_max_age(), chrono::Duration::seconds(DEFAULT_RECONCILE_MAX_AGE_SECS));
+        std::env::set_var(RECONCILE_MAX_AGE_ENV, "-5");
+        assert_eq!(reconcile_max_age(), chrono::Duration::seconds(DEFAULT_RECONCILE_MAX_AGE_SECS));
+        std::env::remove_var(RECONCILE_MAX_AGE_ENV);
     }
 
     #[test]
@@ -5167,8 +5282,11 @@ mod tests {
         // purely from the registered workspace + the bulk `gh pr list` query.
         let dir = tempfile::tempdir().unwrap();
         let _safehouse_test_paths = SafehouseTestPaths::set(dir.path());
-        let (fake_gh, _log) =
-            write_fake_forge_gh(dir.path(), Some(RECONCILE_MERGED_PR_JSON), Some("rjwalters/loom"));
+        let (fake_gh, _log) = write_fake_forge_gh(
+            dir.path(),
+            Some(&reconcile_merged_pr_json()),
+            Some("rjwalters/loom"),
+        );
         std::env::set_var(GH_BIN_ENV, &fake_gh);
         // A fast reconciliation cadence so the test does not wait minutes.
         std::env::set_var(RECONCILE_INTERVAL_ENV, "20");
@@ -5231,8 +5349,11 @@ mod tests {
         // `load_persisted_completed` (exactly what `run_sink` calls at
         // startup) is what makes that survive the restart.
         let dir = tempfile::tempdir().unwrap();
-        let (fake_gh, _log) =
-            write_fake_forge_gh(dir.path(), Some(RECONCILE_MERGED_PR_JSON), Some("rjwalters/loom"));
+        let (fake_gh, _log) = write_fake_forge_gh(
+            dir.path(),
+            Some(&reconcile_merged_pr_json()),
+            Some("rjwalters/loom"),
+        );
         std::env::set_var(GH_BIN_ENV, &fake_gh);
 
         let root = dir.path().to_string_lossy().into_owned();


### PR DESCRIPTION
## Summary

Closes #4583.

The public-feed `completion` envelope had exactly one emit point: `run_sink`'s `Event::SweepExited` gate. That gate can only ever fire while a sweep process is alive to exit, so it structurally cannot observe the **common steady-state path** — builder opens a PR, judge approves, the sweep exits, and champion merges it minutes-to-hours later on its own role tick. Once champion-driven merging dominated, the feed starved silently (2+ hours dark across ~8 merged PRs).

**Option implemented: Option 2 — periodic reconciliation.** Rationale:

- **It sidesteps the frozen event taxonomy entirely.** `defaults/.claude/commands/loom/sweep.md` freezes the 6-topic vocabulary for v0.10.0, and `Event::from_published` / `try_typed_child_event` only upgrade the `.phase` / `.blocker` topics — anything else falls through to `Event::Generic`, which is never narrated. Option 1 as a new topic would violate that freeze and need its own follow-up issue; as a new IPC verb it would avoid the freeze but still only cover merges made through `merge-pr.sh` on a host whose daemon is up and reachable at that instant.
- **It is the only option that covers the daemon-down case**, which is one of the acceptance criteria. Reconciliation queries forge truth directly rather than depending on any daemon-emitted signal, so a merge that landed while the daemon was stopped is picked up on the next tick after restart.
- **It has no new coupling surface**: no protocol change, no script change, no role-prompt change. `merge-pr.sh` and champion are untouched, so there is no way for a notify call to be skipped, fail silently, or be issued by a version-skewed script.

The trade-off, stated explicitly: reconciliation is **not immediate**. A champion merge is narrated on the next tick for its workspace rather than at merge time — up to 5 minutes for a single-workspace host, and `interval × workspaces` on a multi-repo host, since one workspace is reconciled per tick. Option 1 would be sub-second. Given the feed is a monitoring surface with a delay buffer downstream, minutes of latency is a far better trade than the coverage gaps above; Option 1 remains available as a latency optimization layered on top (the shared dedup core is already the single gate that would keep the two from double-posting).

## Changes

**`loom-daemon/src/safehouse.rs`**

- Extracted `build_and_narrate_completion` — the shared envelope-build + dedup-insert core — out of `completion_for_exit`. Both trigger paths funnel through it, so "exactly one completion per merge" holds regardless of which path observes a merge first. It takes `duration_sec`/`exited_at` from the caller because the two paths have different clocks available (the reaper's for a live sweep; the forge's `createdAt`/`mergedAt` pair when no sweep clock exists).
- Added `reconcile_recent_merges` + `fetch_recent_merged_prs`: one **bulk**, branch-unfiltered `gh pr list --state merged --limit 30` per pass, with each row's issue number recovered from `headRefName` via `worktree_ops::naming::issue_from_branch` (non-matching branches are skipped — not every merged PR is an issue sweep). Every failure mode (missing `gh`, no network, timeout, malformed JSON, unparsable row) degrades to skipping that row or the whole pass; it can never panic or block the sink.
- Wired it into `run_sink` via `tokio::select!` on a 5-minute interval timer (`LOOM_SAFEHOUSE_RECONCILE_INTERVAL_MS` overrides, primarily a test seam). One iteration handles a bus event **or** a reconciliation tick, never both, so the dedup set is only ever touched from one place at a time. Targets are the union of workspaces observed on stamped-`repo` events and the on-disk `WorkspaceRegistry`, round-robinned one per tick so a slow/offline `gh` in one workspace cannot delay every other workspace's narration.
- **Persisted the dedup set** to `~/.loom/safehouse-completed.json` (`LOOM_SAFEHOUSE_COMPLETIONS_PATH` overrides), loaded once at startup and rewritten atomically (temp + rename) after each new completion. This is what makes the restart criterion work in both directions: a merge from while the daemon was down still emits, and a merge already narrated before the restart does not re-emit. Every read/write failure is best-effort and logged at `debug`.
- **Lookback window (7 days, `LOOM_SAFEHOUSE_RECONCILE_MAX_AGE_SECS`)**: `--limit 30` bounds a burst's *size* but not its *age*. Without a window, the first pass on a host with no persisted dedup set — fresh install, the upgrade to this version, a lost/corrupt completions file — would backfill the feed with the last 30 merges however old they were, which in a low-traffic workspace means narrating months-old PRs as if they had just landed. Out-of-window rows are dropped *before* the dedup check, so they are never recorded as narrated and a later in-window observation can still emit. Seven days is well beyond any plausible daemon outage, so daemon-down recovery is unaffected.
- Test isolation: `run_sink` now reads two machine-level paths (the completions file and the workspace registry). A `SafehouseTestPaths` RAII guard redirects both into a tempdir for every `run_sink` test, so the suite can never read or write a real daemon's state, and reconciliation targets do not depend on whatever repos happen to be registered on the host running the tests.

**`.loom/docs/safehouse.md`** — documents both emit points, the reconciliation cadence/query/window, and the now-shared, now-persisted dedup contract. Also corrects a cadence description that referenced a `safehouse.reconcileInterval` config key that does not exist.

## Acceptance Criteria Verification

- [x] **A champion-tick merge (no live sweep at merge time) produces exactly one completion with the #4553 meta.** `reconcile_recent_merges_emits_completion_for_a_champion_driven_merge` asserts one envelope carrying `schema`/`issue`/`result`/`title`/`additions`/`deletions`. `run_sink_reconciliation_narrates_a_champion_merge_with_no_live_sweep` proves it end-to-end on the wire with **no `SweepExited` ever published** — the workspace is discovered from the registry alone.
- [x] **In-sweep merges still emit exactly once; no double-post.** `reconcile_recent_merges_skips_a_merge_already_narrated_in_sweep` runs the `SweepExited` path first, then a reconciliation pass over the same merge, and asserts the second emits nothing — while also asserting both `gh` queries still ran, i.e. the skip happens at the shared dedup check rather than by accident. The pre-existing `run_sink_narrates_exit_ack_then_completion`, `run_sink_narrates_only_the_ack_when_nothing_merged` and `completion_for_exit_emits_at_most_once_per_merge` pass unmodified.
- [x] **A merge while the daemon was down is picked up after restart.** The persisted dedup set is the mechanism. `load_persisted_completed_round_trips_through_persist_completed_best_effort` covers the write/read contract, `load_persisted_completed_degrades_to_empty_when_the_file_is_absent_or_corrupt` the failure modes, and `reconcile_recent_merges_does_not_repost_a_merge_loaded_from_a_persisted_restart_file` simulates a fresh process loading a pre-restart file and confirms the already-narrated merge is not re-posted (the flip side: any merge *not* in that file, including one that landed during the outage, still emits).
- [x] **Two merges in quick succession for different issues emit independently.** `reconcile_recent_merges_narrates_distinct_issues_independently` puts one already-narrated (in-sweep) and one fresh (champion-driven) issue in the same bulk response for the same workspace, and asserts only the un-narrated one emits, with both keys ending up in the dedup set — no cross-contamination.

## Test Plan

- `cargo test` in `loom-daemon`: **2537 lib tests + all integration suites pass, 0 failed.** `cargo fmt --check` and `cargo clippy --all-targets --all-features` are clean.
- Seven new tests (five reconciliation behaviors, two persistence, one window + one window-config), all `#[serial]` since they drive process-global env seams.
- Reconciliation fixtures generate `Utc::now()`-relative timestamps rather than literal dates — with the lookback window in place, hard-coded dates would silently turn every reconciliation assertion into a no-op once wall-clock time drifted a week past them.

**Manual verification against `merge-pr.sh` with no active sweep** (not run here — it requires a live daemon with safehouse configured, which this worktree does not have): start `loom-daemon` with safehouse enabled and `LOOM_SAFEHOUSE_RECONCILE_INTERVAL_MS=15000`, confirm no sweep is running (`mcp__loom__list_sweeps`), then `./.loom/scripts/merge-pr.sh <PR>` on an approved PR. Within one interval exactly one `completion` envelope for that issue should appear in the room (and `~/.loom/safehouse-completed.json` should gain its `(workspace, issue)` pair). Re-running reconciliation, or publishing a late `SweepExited` for the same issue, must produce nothing further.

## Notes for the reviewer

- `merge-pr.sh`, `champion-pr-merge.md` and the event taxonomy are deliberately **untouched** — see the Option 2 rationale above.
- The completions file grows by one `["<workspace>", <issue>]` pair (~32 bytes) per completion and is never pruned. At Loom's own merge rate that is a couple of MB per decade, so compaction is not implemented; it is documented rather than engineered.
- The first commit on this branch was originally pushed by an earlier session that exited before opening a PR; it is rebased onto current main here, and the superseded pre-rebase commit is folded in with an `ours` merge so the push stayed fast-forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)