### PR TITLE
fix(daemon): scope test-only tmux cleanup to TEST_PREFIX where safe

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -75,9 +75,12 @@ status-level = "fail"
 # isolation can separate:
 #
 #   * the dedicated `tmux -L loom` server (sessions are host-global),
-#   * `cleanup_all_loom_sessions()` in each suite's `setup()`, which kills EVERY
-#     `loom-*` session — including sessions owned by a concurrently running test
-#     in another process,
+#   * `cleanup_all_loom_sessions()` in two of the four suites' `setup()`
+#     (`integration_security.rs`, `integration_factory_reset.rs` — a reviewed,
+#     commented exception, see issue #4622 and `tests/common/mod.rs`), which
+#     kills EVERY `loom-*` session — including sessions owned by a
+#     concurrently running test in another process. The other two suites use
+#     the `TEST_PREFIX`-scoped `cleanup_test_sessions()`,
 #   * a real `loom-daemon` child per test, which binds a socket and writes an
 #     activity DB.
 #

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -90,12 +90,20 @@
 //! An audit of every `#[serial]` test in this crate (#4385) found exactly one such
 //! resource: the host-global `tmux -L loom` server, reached by the
 //! `integration_*` binaries in `loom-daemon/tests/`. Each spawns real
-//! `loom-daemon` children and calls `cleanup_all_loom_sessions()`, which kills
-//! **every** `loom-*` session on that server, not just its own. They are therefore
-//! placed in the `daemon-integration` test group (`max-threads = 1`), so at most
-//! one is ever in flight. Everything else those tests touch is per-test
-//! (`tempfile::TempDir` roots, ephemeral ports, per-binary session prefixes).
-//! Confirm group membership rather than assuming it:
+//! `loom-daemon` children against it, and two of the four
+//! (`integration_security.rs`, `integration_factory_reset.rs`) call
+//! `cleanup_all_loom_sessions()`, which kills **every** `loom-*` session on
+//! that server, not just its own — a deliberate, commented exception for
+//! suites whose hardcoded/unprefixed terminal IDs a scoped cleanup cannot see
+//! (issue #4622; see the doc comment on `cleanup_all_loom_sessions()` in
+//! `tests/common/mod.rs`). The other two use the `TEST_PREFIX`-scoped
+//! `cleanup_test_sessions()`. All four are nonetheless placed in the
+//! `daemon-integration` test group (`max-threads = 1`), so at most one is ever
+//! in flight — they still share the same host-global tmux server and spawn
+//! real daemons against it, and two of them retain the host-wide kill.
+//! Everything else those tests touch is per-test (`tempfile::TempDir` roots,
+//! ephemeral ports, per-binary session prefixes). Confirm group membership
+//! rather than assuming it:
 //!
 //! ```text
 //! cargo nextest show-config test-groups --profile ci
@@ -107,8 +115,9 @@
 //!   override declared only on `default` silently does not apply to
 //!   `--profile ci`. Declare it on both.
 //! * **The group bounds one nextest run, not the host.** A `cargo test` in another
-//!   checkout on the same machine runs `cleanup_all_loom_sessions()` too and will
-//!   destroy this run's tmux sessions. If the `integration_*` suites fail with
+//!   checkout on the same machine can still run `cleanup_all_loom_sessions()`
+//!   (from `integration_security.rs`/`integration_factory_reset.rs`) and destroy
+//!   this run's tmux sessions. If the `integration_*` suites fail with
 //!   "session ... does not exist" or daemon-startup timeouts, check for a sibling
 //!   test run before suspecting your change — the same failures reproduce under
 //!   plain `cargo test`.

--- a/loom-daemon/tests/README.md
+++ b/loom-daemon/tests/README.md
@@ -24,13 +24,17 @@ cargo test -- --test-threads=1
 > **Isolation**: under `cargo nextest run --workspace` every test gets its own
 > process (see the crate-level "Test isolation convention" docs in
 > `loom-daemon/src/lib.rs`, issue #4385). These `integration_*` suites touch the
-> host-global `tmux -L loom` server — `setup()` calls `cleanup_all_loom_sessions()`,
-> which kills *every* `loom-*` session, not just its own — and spawn real daemons,
-> so `.config/nextest.toml` puts them in the `daemon-integration` test group with
+> host-global `tmux -L loom` server and spawn real daemons, so
+> `.config/nextest.toml` puts them in the `daemon-integration` test group with
 > `max-threads = 1`: at most one is in flight at a time, which is the exclusion
-> `cargo test` provided implicitly by running one test binary at a time. The filter
-> is `binary(/^integration_/)`, so a new `integration_*` suite is covered
-> automatically. Verify with
+> `cargo test` provided implicitly by running one test binary at a time. Two of
+> the four suites (`integration_security.rs`, `integration_factory_reset.rs`)
+> additionally call `cleanup_all_loom_sessions()` in `setup()`, which kills
+> *every* `loom-*` session, not just its own — a reviewed, commented exception
+> for hardcoded/unprefixed terminal IDs a scoped cleanup can't see (issue
+> #4622; see `tests/common/mod.rs`). The other two use the `TEST_PREFIX`-scoped
+> `cleanup_test_sessions()`. The filter is `binary(/^integration_/)`, so a new
+> `integration_*` suite is covered automatically. Verify with
 > `cargo nextest show-config test-groups --profile ci`.
 >
 > That group bounds one nextest run, not the machine. A `cargo test` in another

--- a/loom-daemon/tests/common/mod.rs
+++ b/loom-daemon/tests/common/mod.rs
@@ -437,7 +437,27 @@ pub fn get_loom_tmux_sessions() -> Vec<String> {
     }
 }
 
-/// Helper: Clean up all loom-* tmux sessions (for test teardown)
+/// Helper: Kill **every** `loom-*` tmux session on the shared `-L loom` server —
+/// not just this test binary's own sessions.
+///
+/// # Danger (issue #4622)
+///
+/// This is host-wide and unscoped: on a shared host it can destroy another
+/// user's sessions, a concurrently running (unrelated) test binary's sessions,
+/// or a live *production* `loom-daemon`'s real work sessions. **Prefer
+/// [`cleanup_test_sessions`] by default** — it is scoped to this binary's
+/// `TEST_PREFIX` and is safe for the overwhelming majority of tests.
+///
+/// Reach for this nuclear variant only when a suite provably creates tmux
+/// sessions whose names do **not** carry `TEST_PREFIX` (e.g. hardcoded/literal
+/// terminal IDs used to test injection handling or to mirror a fixed
+/// production naming scheme) — in which case `cleanup_test_sessions()` cannot
+/// see, and therefore cannot clean up, those sessions. Every such call site
+/// must carry a comment at the point of use explaining *why* the scoped helper
+/// is insufficient there (see `integration_security.rs` and
+/// `integration_factory_reset.rs` for examples). Do not use it just for
+/// convenience or as a "belt and suspenders" default — `cleanup_test_sessions()`
+/// is enough for any suite whose terminal IDs are TEST_PREFIX-scoped.
 #[allow(dead_code)]
 pub fn cleanup_all_loom_sessions() {
     for session in get_loom_tmux_sessions() {
@@ -460,9 +480,11 @@ pub fn get_test_tmux_sessions() -> Vec<String> {
 
 /// Helper: Clean up only tmux sessions belonging to the current test binary.
 ///
-/// Uses `TEST_PREFIX` to scope cleanup so that parallel test binaries don't
-/// destroy each other's sessions. Use `cleanup_all_loom_sessions()` for
-/// a nuclear cleanup (e.g., CI pre-test).
+/// Uses `TEST_PREFIX` to scope cleanup so that parallel test binaries — and
+/// anything else sharing the host's `-L loom` tmux server, including another
+/// user's sessions or a live production `loom-daemon` — are left untouched.
+/// This is the default cleanup helper; see [`cleanup_all_loom_sessions`] for
+/// the narrow, justified-only-per-call-site exception.
 #[allow(dead_code)]
 pub fn cleanup_test_sessions() {
     for session in get_test_tmux_sessions() {

--- a/loom-daemon/tests/integration_basic.rs
+++ b/loom-daemon/tests/integration_basic.rs
@@ -5,8 +5,8 @@
 mod common;
 
 use common::{
-    capture_terminal_output, cleanup_all_loom_sessions, cleanup_test_sessions, tmux_available,
-    tmux_session_exists, TestClient, TestDaemon,
+    capture_terminal_output, cleanup_test_sessions, tmux_available, tmux_session_exists,
+    TestClient, TestDaemon,
 };
 use serial_test::serial;
 
@@ -32,12 +32,17 @@ macro_rules! require_tmux {
     };
 }
 
-/// Cleanup helper to run before/after tests.
-/// Cleans ALL loom sessions to prevent the daemon from restoring orphan sessions
-/// from other test binaries or previous runs. This is necessary because the daemon
-/// calls `restore_from_tmux()` on startup which imports any existing loom-* sessions.
+/// Cleanup helper to run before each test.
+///
+/// Scoped to this binary's `TEST_PREFIX` (issue #4622) rather than a host-wide
+/// kill: `TestDaemon::start()` always sets `LOOM_NO_RESTORE=1`, so
+/// `restore_from_tmux()` never runs for these daemons and orphan-session
+/// import from other binaries/previous runs is not a concern here. Every
+/// terminal this suite creates goes through `create_terminal_with_unique_id`,
+/// which is itself `TEST_PREFIX`-scoped, so `cleanup_test_sessions()` sees and
+/// removes everything this binary could have left behind.
 fn setup() {
-    cleanup_all_loom_sessions();
+    cleanup_test_sessions();
 }
 
 /// Test 1.1: Basic Ping/Pong communication

--- a/loom-daemon/tests/integration_factory_reset.rs
+++ b/loom-daemon/tests/integration_factory_reset.rs
@@ -13,9 +13,25 @@ use tokio::time::{sleep, Duration};
 use uuid::Uuid;
 
 /// Ensure we always begin with a clean slate of tmux sessions.
-/// Cleans ALL loom sessions to prevent the daemon from restoring orphan sessions
-/// from other test binaries or previous runs. This is necessary because the daemon
-/// calls `restore_from_tmux()` on startup which imports any existing loom-* sessions.
+///
+/// Deliberately uses the host-wide `cleanup_all_loom_sessions()` rather than
+/// the `TEST_PREFIX`-scoped `cleanup_test_sessions()` (issue #4622). This is a
+/// reviewed exception, not an oversight: `create_workspace_terminals()` below
+/// mirrors the real workspace terminal-naming scheme with hardcoded,
+/// unprefixed config IDs (`terminal-1` .. `terminal-7`), on purpose — the test
+/// documents `docs/testing/factory-reset-loop.md`'s real session layout. Those
+/// IDs never carry `TEST_PREFIX`, so `cleanup_test_sessions()` cannot see or
+/// remove `loom-terminal-N-*` sessions a prior crashed/interrupted run of
+/// *this exact suite* may have left behind, and a stale identically-named
+/// session would collide with this run's `create_terminal_with_config` calls.
+/// (`restore_from_tmux()` itself is not the concern — `TestDaemon::start()`
+/// unconditionally sets `LOOM_NO_RESTORE=1`, so it never runs here.)
+///
+/// Known trade-off: on a genuinely shared host this can still kill another
+/// user's sessions or a live production `loom-daemon`'s real sessions. These
+/// `integration_*` suites are confined to the `daemon-integration` nextest
+/// test group (`max-threads = 1`, see `.config/nextest.toml` /
+/// `loom-daemon/src/lib.rs`) precisely because of hazards like this one.
 fn setup() {
     cleanup_all_loom_sessions();
 }

--- a/loom-daemon/tests/integration_security.rs
+++ b/loom-daemon/tests/integration_security.rs
@@ -7,9 +7,25 @@ mod common;
 use common::{cleanup_all_loom_sessions, TestClient, TestDaemon};
 use serial_test::serial;
 
-/// Cleanup helper to run before/after tests.
-/// Uses broad cleanup because security tests intentionally create terminals
-/// with hardcoded IDs (for injection testing) that don't match `TEST_PREFIX`.
+/// Cleanup helper to run before/after each test.
+///
+/// Deliberately uses the host-wide `cleanup_all_loom_sessions()` rather than
+/// the `TEST_PREFIX`-scoped `cleanup_test_sessions()` (issue #4622). This is a
+/// reviewed exception, not an oversight: several tests below intentionally
+/// pass hardcoded, unprefixed terminal IDs — `terminal-1`, `isolated-terminal`,
+/// `test-symlink`, `test-traversal`, `test-sensitive`, etc. — either as the
+/// injection payload under test, or to exercise "accept a valid ID" /
+/// isolation / symlink / traversal paths. `create_terminal` uses that ID as
+/// both `config_id` and the tmux session name (`loom-{id}-{role}-{instance}`),
+/// so those real sessions never carry `TEST_PREFIX` and `cleanup_test_sessions()`
+/// cannot see or remove them, leaving stale sessions that would collide with
+/// (or be silently reused by) a later run.
+///
+/// Known trade-off: on a genuinely shared host this can still kill another
+/// user's sessions or a live production `loom-daemon`'s real sessions. These
+/// `integration_*` suites are confined to the `daemon-integration` nextest
+/// test group (`max-threads = 1`, see `.config/nextest.toml` /
+/// `loom-daemon/src/lib.rs`) precisely because of hazards like this one.
 fn setup() {
     cleanup_all_loom_sessions();
 }

--- a/loom-daemon/tests/integration_singleton_guard.rs
+++ b/loom-daemon/tests/integration_singleton_guard.rs
@@ -10,7 +10,7 @@
 
 mod common;
 
-use common::{cleanup_all_loom_sessions, daemon_bin, TestClient, TestDaemon};
+use common::{cleanup_test_sessions, daemon_bin, TestClient, TestDaemon};
 use serial_test::serial;
 use std::io::BufRead;
 use std::os::unix::fs::FileTypeExt;
@@ -19,8 +19,12 @@ use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+/// Scoped to this binary's `TEST_PREFIX` (issue #4622) — a host-wide kill was
+/// never actually needed here: this suite tests socket/singleton behavior and
+/// never creates a named terminal/tmux session at all, so there is nothing for
+/// the broad cleanup to catch that the scoped helper would miss.
 fn setup() {
-    cleanup_all_loom_sessions();
+    cleanup_test_sessions();
 }
 
 /// How long to wait for a second daemon to notice the incumbent and exit.


### PR DESCRIPTION
## Summary

`cleanup_all_loom_sessions()` in `loom-daemon/tests/common/mod.rs` kills **every** `loom-*` tmux session on the shared `-L loom` server host-wide, not just the calling test's own sessions. On a shared host this can destroy another user's sessions, another concurrently running test binary's sessions, or a live production `loom-daemon`'s real work sessions. A `TEST_PREFIX`-scoped alternative (`cleanup_test_sessions()`) already existed in the same file but was unused by several per-test call sites.

## Changes

- **`integration_basic.rs`** and **`integration_singleton_guard.rs`**: switched their `setup()` from `cleanup_all_loom_sessions()` to the scoped `cleanup_test_sessions()`. Root-caused as safe:
  - `integration_basic.rs` creates every terminal via `create_terminal_with_unique_id`, which is itself `TEST_PREFIX`-scoped, so the scoped helper sees everything it could leave behind.
  - `integration_singleton_guard.rs` never creates a named terminal/tmux session at all — it tests socket/singleton refusal behavior — so there was nothing for the broad cleanup to catch that the scoped helper misses.
  - In both files, the previously-documented justification ("the daemon calls `restore_from_tmux()` on startup which imports any existing loom-* sessions") is stale: `TestDaemon::start()` already sets `LOOM_NO_RESTORE=1` unconditionally (added in a since-merged, unrelated PR ~2 minutes after the comment was written), so `restore_from_tmux()` never runs for these test daemons.
- **`integration_security.rs`** and **`integration_factory_reset.rs`**: kept `cleanup_all_loom_sessions()` as a deliberate, now-accurately-commented exception. Both suites intentionally create real tmux sessions with hardcoded/unprefixed terminal IDs (`terminal-1`, `isolated-terminal`, `test-symlink`, `test-traversal`, `test-sensitive`, `terminal-1`..`terminal-7`, etc. — either the injection payload under test or mirroring the real workspace terminal-naming scheme) that never carry `TEST_PREFIX`, so the scoped cleanup cannot see or remove them; a stale identically-named session from a prior crashed/interrupted run would collide with a fresh `create_terminal`/`create_terminal_with_config` call.
- **`tests/common/mod.rs`**: restricted `cleanup_all_loom_sessions()`'s doc comment to spell out the danger (issue #4622) and the narrow conditions under which it's the right tool, so new tests default to `cleanup_test_sessions()` instead of reaching for the nuclear variant by convenience.
- **`loom-daemon/src/lib.rs`**, **`.config/nextest.toml`**, **`tests/README.md`**: updated the cross-references that previously described *all four* `integration_*` suites as calling the unscoped cleanup — they now accurately say two of the four do, with a pointer to the justification, and two use the scoped helper. The `daemon-integration` nextest test group (`max-threads = 1`) itself is unchanged: all four suites still share the host-global tmux server and spawn real daemons against it, which independently justifies keeping them grouped.

## Acceptance Criteria Verification

- [x] No per-test call site of `cleanup_all_loom_sessions()` remains unscoped-and-unjustified in the four integration suites — `integration_basic.rs` and `integration_singleton_guard.rs` are now scoped via `cleanup_test_sessions()`; `integration_security.rs` and `integration_factory_reset.rs` carry an accurate comment justifying the deliberate host-wide exception.
- [x] `cleanup_all_loom_sessions()` is not removed (it has live, justified callers) but its doc comment now explicitly restricts it to the narrow case a scoped cleanup can't cover, rather than presenting it as an interchangeable teardown helper.
- [x] Daemon integration suites still pass: `cargo test -p loom-daemon --tests` — all 4 integration suites green (`integration_basic`: 9 passed, `integration_factory_reset`: 2 passed, `integration_security`: 14 passed, `integration_singleton_guard`: 2 passed), plus the full `-p loom-daemon --tests` run with no failures.
- [x] No behavior change for the common case of a single test binary running alone — verified by the full local test run above; no test assertions changed, only which cleanup helper each suite calls internally.

## Test Plan

```
cargo check -p loom-daemon --tests   # clean
cargo clippy -p loom-daemon --tests --no-deps   # clean
cargo fmt -p loom-daemon -- --check   # clean
cargo test -p loom-daemon --tests   # all green, including all 4 integration_* suites
tmux -L loom list-sessions   # no server running after the run — no leaked sessions
```

Closes #4622