### PR TITLE
fix(roles): add --limit 500 to unbounded gh issue list / gh pr list discovery queries

### DIFF
--- a/defaults/.claude/commands/loom/architect-reference.md
+++ b/defaults/.claude/commands/loom/architect-reference.md
@@ -36,7 +36,7 @@ This file contains detailed reference documentation for the Architect role, incl
 
 ```bash
 # Check if there are already open proposals (don't spam)
-gh issue list --label="loom:architect" --state=open
+gh issue list --label="loom:architect" --state=open --limit 500
 
 # Create new proposal
 gh issue create --title "..." --body "..."

--- a/defaults/.claude/commands/loom/auditor.md
+++ b/defaults/.claude/commands/loom/auditor.md
@@ -260,8 +260,8 @@ else
 fi
 
 # Alternative: manual search
-gh issue list --state open --label "loom:auditor-capability-request" --json number,title --jq '.[] | "#\(.number): \(.title)"'
-gh issue list --state open --label "loom:auditor-capability-request" --search "screenshot" --json number,title
+gh issue list --state open --label "loom:auditor-capability-request" --limit 500 --json number,title --jq '.[] | "#\(.number): \(.title)"'
+gh issue list --state open --label "loom:auditor-capability-request" --search "screenshot" --limit 500 --json number,title
 ```
 
 If a similar request exists, add a comment instead of creating a duplicate.
@@ -428,8 +428,8 @@ else
 fi
 
 # Alternative: manual search
-gh issue list --state open --json number,title --jq '.[] | "#\(.number): \(.title)"' | head -20
-gh issue list --state open --search "build failure" --json number,title
+gh issue list --state open --limit 500 --json number,title --jq '.[] | "#\(.number): \(.title)"' | head -20
+gh issue list --state open --search "build failure" --limit 500 --json number,title
 ```
 
 **When duplicates are found:**

--- a/defaults/.claude/commands/loom/builder-worktree.md
+++ b/defaults/.claude/commands/loom/builder-worktree.md
@@ -311,7 +311,7 @@ while true; do
   fi
 
   # Find available issues
-  ISSUES=$(gh issue list --label="loom:issue" --state=open --json number --jq '.[].number')
+  ISSUES=$(gh issue list --label="loom:issue" --state=open --limit 500 --json number --jq '.[].number')
 
   for ISSUE_NUMBER in $ISSUES; do
     # Try atomic claim

--- a/defaults/.claude/commands/loom/champion-epic.md
+++ b/defaults/.claude/commands/loom/champion-epic.md
@@ -160,6 +160,7 @@ PHASE=1
 PHASE_ISSUES=$(gh issue list \
   --label="loom:epic-phase" \
   --state=all \
+  --limit=500 \
   --search="loom:epic:$EPIC_NUMBER:phase:$PHASE in:body" \
   --json number,state \
   --jq '.')

--- a/defaults/.claude/commands/loom/champion-pr-merge.md
+++ b/defaults/.claude/commands/loom/champion-pr-merge.md
@@ -504,7 +504,7 @@ echo "Checking for issues blocked by #$CLOSED_ISSUE..."
 # Find issues with loom:blocked that reference the closed issue.
 # Tolerant of markdown emphasis/colon between the phrase and #N (e.g.
 # "**Blocked by:** #1 (reason)") — #4508.
-BLOCKED_ISSUES=$(gh issue list --label "loom:blocked" --state open --json number,body \
+BLOCKED_ISSUES=$(gh issue list --label "loom:blocked" --state open --limit 500 --json number,body \
   --jq ".[] | select(.body | test(\"(Blocked by|Depends on|Requires)[*_:[:space:]]*#$CLOSED_ISSUE\"; \"i\")) | .number")
 
 if [ -z "$BLOCKED_ISSUES" ]; then
@@ -688,7 +688,7 @@ fi
 # ============================================
 
 # Search for existing follow-on issues from this PR
-EXISTING_ISSUE=$(gh issue list --state open --search "Follow-on from PR #$PR_NUMBER" --json number --jq '.[0].number // empty')
+EXISTING_ISSUE=$(gh issue list --state open --search "Follow-on from PR #$PR_NUMBER" --limit 500 --json number --jq '.[0].number // empty')
 
 if [ -n "$EXISTING_ISSUE" ]; then
   echo "Follow-on issue already exists: #$EXISTING_ISSUE - skipping creation"
@@ -925,6 +925,7 @@ gh pr list \
   --label "loom:blocked" \
   --label "loom:changes-requested" \
   --state open \
+  --limit 500 \
   --json number,title,updatedAt,labels \
   --jq '.[] | "#\(.number) \(.title)"'
 ```

--- a/defaults/.claude/commands/loom/champion-reference.md
+++ b/defaults/.claude/commands/loom/champion-reference.md
@@ -116,7 +116,7 @@ fi
 ```bash
 # Parked set (gh ANDs repeated --label values). Skip any that also carry
 # loom:operator-only — already routed to a human.
-gh pr list --label "loom:blocked" --label "loom:changes-requested" --state open \
+gh pr list --label "loom:blocked" --label "loom:changes-requested" --state open --limit 500 \
   --json number,title,labels --jq '.[] | "#\(.number) \(.title)"'
 
 # Decide from the FULL history, not the last comment alone.
@@ -291,7 +291,7 @@ NOTES=$(gh api repos/.../pulls/$PR_NUMBER/comments --jq '...')
 # - Otherwise -> skip (too noisy)
 
 # Stage 5: Duplicate detection
-EXISTING=$(gh issue list --search "Follow-on from PR #$PR_NUMBER")
+EXISTING=$(gh issue list --search "Follow-on from PR #$PR_NUMBER" --limit 500)
 
 # Stage 6: Create issue with proper linking
 gh issue create --title "Follow-on: Work identified in PR #$PR_NUMBER" --label "$LABEL"
@@ -391,7 +391,7 @@ gh pr view <number> --json state,mergeable,statusCheckRollup
 gh pr view <number> --json closingIssuesReferences --jq '.closingIssuesReferences[].number'
 
 # List blocked issues
-gh issue list --label "loom:blocked" --state open
+gh issue list --label "loom:blocked" --state open --limit 500
 
 # Check API rate limit
 gh api rate_limit

--- a/defaults/.claude/commands/loom/champion.md
+++ b/defaults/.claude/commands/loom/champion.md
@@ -29,6 +29,7 @@ Find Judge-approved PRs ready for merge:
 gh pr list \
   --label="loom:pr" \
   --state=open \
+  --limit=500 \
   --json number,title,additions,deletions,mergeable,updatedAt,files,statusCheckRollup,labels \
   --jq '.[] | "#\(.number) \(.title)"'
 ```
@@ -43,6 +44,7 @@ If no PRs need merging, check for curated issues:
 gh issue list \
   --label="loom:curated" \
   --state=open \
+  --limit=500 \
   --json number,title,body,labels,comments \
   --jq '.[] | "#\(.number) \(.title)"'
 ```
@@ -58,6 +60,7 @@ If no curated issues need promotion, check for well-formed proposals:
 gh issue list \
   --label="loom:architect" \
   --state=open \
+  --limit=500 \
   --json number,title,body,labels,comments \
   --jq '.[] | "#\(.number) \(.title) [architect]"'
 
@@ -65,6 +68,7 @@ gh issue list \
 gh issue list \
   --label="loom:hermit" \
   --state=open \
+  --limit=500 \
   --json number,title,body,labels,comments \
   --jq '.[] | "#\(.number) \(.title) [hermit]"'
 
@@ -72,6 +76,7 @@ gh issue list \
 gh issue list \
   --label="loom:auditor" \
   --state=open \
+  --limit=500 \
   --json number,title,body,labels,comments \
   --jq '.[] | "#\(.number) \(.title) [auditor]"'
 ```
@@ -89,6 +94,7 @@ If no individual proposals need promotion, check for epic proposals:
 gh issue list \
   --label="loom:epic" \
   --state=open \
+  --limit=500 \
   --json number,title,body,labels,comments \
   --jq '.[] | "#\(.number) \(.title) [epic]"'
 ```
@@ -105,6 +111,7 @@ gh pr list \
   --label="loom:blocked" \
   --label="loom:changes-requested" \
   --state=open \
+  --limit=500 \
   --json number,title,updatedAt,labels \
   --jq '.[] | "#\(.number) \(.title)"'
 ```

--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -122,7 +122,7 @@ Use a **priority-based search** to find the highest-value curation opportunity:
 Issues with `loom:issue` (human-approved) but missing `loom:curated`:
 
 ```bash
-gh issue list --label="loom:issue" --state=open --json number,title,labels \
+gh issue list --label="loom:issue" --state=open --limit 500 --json number,title,labels \
   --jq '.[] | select(([.labels[].name] | contains(["loom:curated"]) | not) and ([.labels[].name] | contains(["external"]) | not)) |
   "#\(.number): \(.title)"'
 ```
@@ -168,7 +168,7 @@ enhancement") is the entry point, so **target it first**:
 
 ```bash
 # Newly filed issues awaiting Curator enhancement
-gh issue list --label="loom:triage" --state=open --json number,title,labels \
+gh issue list --label="loom:triage" --state=open --limit 500 --json number,title,labels \
   --jq '.[] | select(([.labels[].name] | contains(["external"]) | not)) |
   "#\(.number) \(.title)"'
 ```
@@ -179,7 +179,7 @@ exclusion set must match CLAUDE.md's own curator discovery query so an autonomou
 Curator never "curates" an issue being built or awaiting evaluation:
 
 ```bash
-gh issue list --state=open --json number,title,labels \
+gh issue list --state=open --limit 500 --json number,title,labels \
   --jq '.[] | select(
     ([.labels[].name] | contains(["loom:curated"]) | not) and
     ([.labels[].name] | contains(["loom:curating"]) | not) and

--- a/defaults/.claude/commands/loom/imagine.md
+++ b/defaults/.claude/commands/loom/imagine.md
@@ -236,7 +236,7 @@ Install Loom into the new repository:
 sleep 2
 
 # Find and merge the installation PR
-PR_NUMBER=$(gh pr list --label "loom:review-requested" --json number --jq '.[0].number')
+PR_NUMBER=$(gh pr list --label "loom:review-requested" --limit 500 --json number --jq '.[0].number')
 
 if [ -n "$PR_NUMBER" ]; then
   echo "Merging Loom installation PR #$PR_NUMBER..."

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -172,7 +172,7 @@ If no argument is provided, use the normal finding work workflow below.
 
 **Find PRs ready for evaluation (green badges):**
 ```bash
-gh pr list --label="loom:review-requested" --state=open
+gh pr list --label="loom:review-requested" --state=open --limit 500
 ```
 
 **Before either command below, run the Verdict-Time CAS Recheck** (see "Verdict-Time CAS Recheck" under Evaluation Process) — abort instead of writing if the recheck finds your claim lost or another Judge's verdict already landed.
@@ -294,7 +294,7 @@ fi
 
 ### Primary Queue (Priority)
 
-1. **Find work**: `gh pr list --label="loom:review-requested" --state=open`
+1. **Find work**: `gh pr list --label="loom:review-requested" --state=open --limit 500`
 2. **Claim PR** (staleness-aware — see "Stale `loom:reviewing` Claim Check" immediately below before running this): `gh pr edit <number> --add-label "loom:reviewing"` to signal you're working on it
 3. **Check merge state**: Check for conflicts and attempt automated rebase if DIRTY (see Automated Rebase for DIRTY PRs below)
    ```bash
@@ -501,7 +501,7 @@ If no PRs have the `loom:review-requested` label, the Judge can proactively eval
 **Fallback search**:
 ```bash
 # Find PRs without any loom: labels
-gh pr list --state=open --json number,title,labels \
+gh pr list --state=open --limit 500 --json number,title,labels \
   --jq '.[] | select(([.labels[].name | select(startswith("loom:"))] | length) == 0) | "#\(.number) \(.title)"'
 ```
 
@@ -542,7 +542,7 @@ Pre-Iteration Environment Check (gh repo view)
 **Example fallback workflow**:
 ```bash
 # 1. Check primary queue
-LABELED_PRS=$(gh pr list --label="loom:review-requested" --json number --jq 'length' 2>/dev/null)
+LABELED_PRS=$(gh pr list --label="loom:review-requested" --limit 500 --json number --jq 'length' 2>/dev/null)
 
 # Guard: an empty string (not "0") means the gh command itself failed. Re-run the
 # Pre-Iteration Environment Check above; if it fails, exit 1 (never claim "no work").
@@ -560,7 +560,7 @@ else
   echo "No loom:review-requested PRs found, checking unlabeled PRs..."
 
   # 2. Check fallback queue
-  UNLABELED_PR=$(gh pr list --state=open --json number,labels \
+  UNLABELED_PR=$(gh pr list --state=open --limit 500 --json number,labels \
     --jq '.[] | select(([.labels[].name | select(startswith("loom:"))] | length) == 0) | .number' \
     | head -n 1)
 
@@ -1229,7 +1229,7 @@ For minor documentation issues in PR descriptions (not code), Judges are empower
 
 ```bash
 # Search for issues related to the PR
-gh issue list --search "keyword from PR title"
+gh issue list --search "keyword from PR title" --limit 500
 
 # View the PR to confirm issue number
 gh pr view <number>
@@ -1587,7 +1587,7 @@ EOF
 
 ```bash
 # Find PRs ready for evaluation (green badges)
-gh pr list --label="loom:review-requested" --state=open
+gh pr list --label="loom:review-requested" --state=open --limit 500
 
 # Check out the PR (worktree-aware — see "PR Branch Isolation" above; this is
 # a simplified illustration, not a bare checkout in the current directory)


### PR DESCRIPTION
## Summary

`gh issue list` / `gh pr list` default to a 30-item page when no `--limit` is
passed. Nearly every Loom role's discovery/search query in
`defaults/.claude/commands/loom/*.md` omitted `--limit`, so on a repo with more
than 30 open issues/PRs these queries silently truncated (confirmed live: this
repo currently has 39 open issues vs. the default 30-row page).

## Changes

Added `--limit 500` to every real (non-prose) `gh issue list` / `gh pr list`
invocation that iterates or filters a potentially-unbounded result set, across
the 10 files enumerated in the issue:

- `curator.md` — Priority 1/2 discovery queries + the CLAUDE.md-matching fallback exclusion query (3 sites)
- `champion.md` — PR auto-merge, issue-promotion, architect/hermit/auditor proposal, epic, and capped-PR-recovery searches (7 sites)
- `champion-reference.md` — capped-PR parked set, follow-on dedup search, blocked-issues list (3 sites)
- `champion-epic.md` — phase-issue enumeration (1 site)
- `champion-pr-merge.md` — blocked-issues-by-closed-dependency search, follow-on dedup search, capped-PR parked set (3 sites)
- `judge.md` — primary review-requested queue (2 call sites, same query used twice) + fallback unlabeled-PR queue + issue-search-by-keyword example (6 sites)
- `auditor.md` — capability-request and build-failure duplicate-detection searches (4 sites)
- `builder-worktree.md` — `loom:issue` enumeration in the worker-loop script (1 site)
- `architect-reference.md` — spam-prevention check for existing proposals (1 site)
- `imagine.md` — installation-PR lookup (single-result `.[0]` lookup, added for consistency per the issue's own guidance) (1 site)

Prose mentions, step-reference text, and command-name-only references (e.g.
`champion-pr-merge.md:772`, `:921`; `judge.md:270`, `:324`;
`architect-reference.md:222`) were left untouched, matching the issue's own
✅/📝 markers.

Scope note: a broader repo-wide grep also surfaces additional unbounded
`gh issue list` / `gh pr list` call sites in files the issue did **not**
enumerate (`architect.md`, `architect-patterns.md`, `builder.md`,
`champion-issue-promo.md`, `doctor.md`, `guide.md`, `hermit-patterns.md`,
`sweep.md`, plus a couple in `loom.md`/`epic.md`/`builder-pr.md`). Per the
issue's explicit "Affected Files" enumeration and CLAUDE.md's scope-discipline
guidance, this PR sticks to the 10 named files rather than expanding the diff;
a follow-up issue would be the right vehicle to extend the same mechanical fix
to those files.

Mirror note: this repo is the Loom source repo itself — `.claude/commands/loom`
is a symlink to `../../defaults/.claude/commands/loom` (confirmed via
`git check-ignore -v` + `readlink -f`), so there is no separate installed
mirror to resync here; editing `defaults/` is the complete fix for this repo.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|---------------|
| Every listed `gh issue list`/`gh pr list` invocation across the 10 enumerated files has an explicit `--limit` | ✅ | Re-ran `grep -n "gh issue list\|gh pr list" <file> \| grep -v -- '--limit'` per file; only prose/multi-line-continuation false positives remain (verified each continuation line carries `--limit` on a subsequent line) |
| Single-result lookups reviewed, not padded purely for padding's sake | ✅ | `imagine.md`/`champion-pr-merge.md:691` `.[0]` lookups got `--limit` per the issue's own "acceptable for consistency" guidance; no other unrelated call sites touched |
| CLAUDE.md curator discovery query mirror updated in lockstep | ✅ | Verified CLAUDE.md contains no duplicated copy of the curator fallback-exclusion jq query (only simplified one-line examples referencing `gh issue list --label="loom:issue"` / `gh pr list --label="loom:review-requested"` with no unbounded iteration) — nothing to update there |
| Follow-up sanity check: modified role's primary discovery command returns the full result set | ✅ | `gh issue list --state=open --json number --limit 1000 --jq 'length'` → 39; `gh issue list --state=open --json number --jq 'length'` (default) → 30, confirming the exact truncation the issue describes and that `--limit` fixes it |

## Test Plan

- Markdown/prose-only change — no unit tests apply (matches the issue's own Test Plan, which calls this N/A for automated tests)
- Manually re-ran the completeness grep across all 10 enumerated files after editing; confirmed no remaining un-limited executable call sites
- Manually confirmed the 39-vs-30 truncation gap on this live repo, matching the issue's reported symptom

Closes #4626