### PR TITLE
fix: reorder two remaining BSD-`stat -f`-first chains to GNU-first (#4631)

### DIFF
--- a/defaults/scripts/cli/loom-logs.sh
+++ b/defaults/scripts/cli/loom-logs.sh
@@ -111,7 +111,16 @@ list_logs() {
             local size
             size=$(du -h "$logfile" | cut -f1)
             local modified
-            modified=$(stat -f "%Sm" -t "%Y-%m-%d %H:%M" "$logfile" 2>/dev/null || stat -c "%y" "$logfile" 2>/dev/null | cut -d. -f1)
+            # GNU `stat -c` first (it is an illegal option on BSD/macOS, so it
+            # fails cleanly there), then BSD `stat -f %Sm`. The reverse order
+            # MISFIRES on GNU: `stat -f ... <path>` there means --file-system (a
+            # bare mode flag), which prints a multi-line filesystem report to
+            # STDOUT while exiting non-zero — `2>/dev/null || fallback` only
+            # silences stderr, so the report leaks into the displayed value.
+            # GNU `%y` is human-readable with fractional seconds (hence the
+            # `cut`); the BSD `-t` format is already trimmed, so it is not cut.
+            modified=$(stat -c "%y" "$logfile" 2>/dev/null | cut -d. -f1)
+            [[ -n "$modified" ]] || modified=$(stat -f "%Sm" -t "%Y-%m-%d %H:%M" "$logfile" 2>/dev/null)
             echo -e "  ${GREEN}$name${NC}  ${GRAY}($size, modified $modified)${NC}"
         fi
     done

--- a/tests/install/test-provision-daemon.sh
+++ b/tests/install/test-provision-daemon.sh
@@ -69,6 +69,20 @@ trap 'rm -rf "$WORKDIR"' EXIT
 # exercise the gate itself with the bypass explicitly unset.
 export LOOM_PROVISION_ALLOW_SCRIPT=1
 
+# Portable mtime (epoch secs). GNU `stat -c` first (it is an illegal option on
+# BSD/macOS, so it fails cleanly there), then BSD `stat -f %m`. The reverse
+# order MISFIRES on GNU: `stat -f %m <path>` there means --file-system (a bare
+# mode flag), which prints a multi-line filesystem report to STDOUT while
+# exiting non-zero — `2>/dev/null || fallback` only silences stderr, so the
+# report leaks into the captured value and corrupts the comparison below.
+file_mtime() {
+  local v
+  v="$(stat -c %Y "$1" 2>/dev/null || true)"
+  [[ "$v" =~ ^[0-9]+$ ]] || v="$(stat -f %m "$1" 2>/dev/null || true)"
+  [[ "$v" =~ ^[0-9]+$ ]] || v=""
+  printf '%s\n' "$v"
+}
+
 # Build a fake loom-daemon binary that prints $1 as its --version.
 make_fake_bin() {
   local path="$1" ver="$2"
@@ -95,11 +109,11 @@ assert_contains "fresh-install output names the destination" "$out1" "$DEST1/loo
 # ---------- test 2: idempotent — same version is a no-op copy ----------
 # Record mtime, run again, assert it did not re-copy (mtime unchanged) and it
 # reports "already current".
-before_mtime=$(stat -f %m "$DEST1/loom-daemon" 2>/dev/null || stat -c %Y "$DEST1/loom-daemon")
+before_mtime=$(file_mtime "$DEST1/loom-daemon")
 sleep 1
 out2=$(LOOM_DAEMON_BIN_DIR="$DEST1" provision_machine_daemon "$SRC1" 2>&1)
 rc2=$?
-after_mtime=$(stat -f %m "$DEST1/loom-daemon" 2>/dev/null || stat -c %Y "$DEST1/loom-daemon")
+after_mtime=$(file_mtime "$DEST1/loom-daemon")
 assert_eq "idempotent run returns 0" "0" "$rc2"
 assert_eq "idempotent run does NOT re-copy (mtime unchanged)" "$before_mtime" "$after_mtime"
 assert_contains "idempotent run reports already current" "$out2" "already current"


### PR DESCRIPTION
Closes #4631

Follow-on to PR #4628 (which closed #4565), fixing the last two in-repo instances of the same bug class.

## The bug

On Linux, GNU `stat -f` is not a format flag — it is a bare `--file-system` mode flag. It prints a **multi-line filesystem report to STDOUT** and exits non-zero. So a `stat -f ... 2>/dev/null || stat -c ...` chain only silences *stderr*; the polluted stdout leaks through and is concatenated with the real fallback value.

Demonstrated on this Linux host with the pre-change code:

```
$ before_mtime=$(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f")
  File: "/tmp/tmp.7jkT7tiCp0"
    ID: 40d63931afa99d0c Namelen: 255     Type: ext2/ext3
Block size: 4096       Fundamental block size: 4096
Blocks: Total: 25119164   Free: 6682557    Available: 6678461
Inodes: Total: 12976128   Free: 11834394
1785433310            <- 6 lines captured, not 1
```

## Changes

**`tests/install/test-provision-daemon.sh`** (was lines 98, 102) — extracted a `file_mtime` helper that tries GNU `stat -c %Y` first and **validates the result is numeric** before falling back to BSD `stat -f %m`, mirroring `_loom_build_slot_age_secs` in `defaults/scripts/lib/build-slot.sh` and the guard form in `archive-transcripts.sh`. The `assert_eq "idempotent run does NOT re-copy (mtime unchanged)"` comparison was previously comparing two 6-line filesystem reports that embed *mutable* counters (free blocks / free inodes) — meaningless as an mtime check, and potentially flaky. Post-change the captured value is a single clean integer.

**`defaults/scripts/cli/loom-logs.sh`** (was line 114) — GNU-first with per-branch formatting preserved: the `| cut -d. -f1` stays bound **only** to the GNU branch (`%y` is human-readable with fractional seconds), while the BSD `-t "%Y-%m-%d %H:%M"` output is already trimmed and is not piped through `cut`. Display-only, but the same class — `loom logs --list` previously rendered the filesystem report inline in the "modified" column on Linux.

**`defaults/scripts/claude-wrapper.sh` deliberately untouched.** The Judge's original PR #4628 note flagged lines ~704/~1530 there, but the Curator re-verified (and I confirmed) that both sites branch on `[[ "$(uname)" == "Darwin" ]]` and use the correct stat flavor per branch — there is no ordering fallback chain to fix, and "fixing" them would replace working uname-branched code.

## Verification (Linux, so the GNU path is exercised directly)

- `bash tests/install/test-provision-daemon.sh` → **40/40 pass**, 0 failures.
- Confirmed the mtime capture is now a clean single-line integer (old form returned 6 lines; new returns `1785433310`, `lines=1`).
- `loom logs --list` driven against a temp log dir now prints `modified 2026-07-30 17:42:02` instead of an inline filesystem dump.
- `bash -n` clean on both files; shellcheck clean on `loom-logs.sh`. The three SC2034 warnings shellcheck reports in the test file are pre-existing and on untouched lines (`out11`/`out13`/`out15`).
- No installed duplicate of `loom-logs.sh` to resync (`.loom/scripts` is a symlink; `defaults/scripts/cli/loom-logs.sh` is the only copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)