### PR TITLE
fix(docs): drop invalid --jq -r sub-flag from gh commands in champion docs

### DIFF
--- a/defaults/.claude/commands/loom/champion-pr-merge.md
+++ b/defaults/.claude/commands/loom/champion-pr-merge.md
@@ -115,7 +115,7 @@ PR_NUMBER=<number>
 # REST endpoint, not `gh pr view --json files` — that field silently
 # truncates at 100 files with no error (see criterion #3 below and #4613),
 # which on a 100+ file PR would hide files from this risk read too.
-gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/files" --paginate --jq -r '.[] | "\(.additions)+/\(.deletions)- \(.filename)"'
+gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/files" --paginate --jq '.[] | "\(.additions)+/\(.deletions)- \(.filename)"'
 
 # The actual diff (read it — the load-bearing hunks are what you are judging)
 gh pr diff "$PR_NUMBER"
@@ -214,7 +214,7 @@ fi
 # `.github/workflows/gitea-integration.yml` was skipped in one Champion
 # instance's evaluation over a 117-file PR. `--paginate` walks every page of
 # the REST response regardless of file count.
-FILES=$(gh api "repos/{owner}/{repo}/pulls/<number>/files" --paginate --jq -r '.[].filename')
+FILES=$(gh api "repos/{owner}/{repo}/pulls/<number>/files" --paginate --jq '.[].filename')
 
 # Define critical patterns (extend as needed)
 CRITICAL_PATTERNS=(
@@ -259,7 +259,7 @@ This criterion is deliberately kept **in addition to** the merge-risk judgment i
 **Verification command**:
 ```bash
 # Check merge status
-MERGEABLE=$(gh pr view <number> --json mergeable --jq -r '.mergeable')
+MERGEABLE=$(gh pr view <number> --json mergeable --jq '.mergeable')
 
 # Verify mergeable state
 if [ "$MERGEABLE" != "MERGEABLE" ]; then
@@ -283,7 +283,7 @@ echo "PASS: No merge conflicts"
 **Verification command**:
 ```bash
 # Get PR last update time
-UPDATED_AT=$(gh pr view <number> --json updatedAt --jq -r '.updatedAt')
+UPDATED_AT=$(gh pr view <number> --json updatedAt --jq '.updatedAt')
 
 # Convert to Unix timestamp
 UPDATED_TS=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED_AT" +%s 2>/dev/null || \
@@ -480,7 +480,7 @@ fi
 
 # Check each linked issue
 for issue in $LINKED_ISSUES; do
-  ISSUE_STATE=$(gh issue view "$issue" --json state --jq -r '.state' 2>&1)
+  ISSUE_STATE=$(gh issue view "$issue" --json state --jq '.state' 2>&1)
 
   if [ "$ISSUE_STATE" = "CLOSED" ]; then
     echo "Issue #$issue is closed (auto-closed by PR merge)"
@@ -516,7 +516,7 @@ for blocked in $BLOCKED_ISSUES; do
   echo "Checking if #$blocked can be unblocked..."
 
   # Get the issue body to check ALL dependencies
-  BLOCKED_BODY=$(gh issue view "$blocked" --json body --jq -r '.body')
+  BLOCKED_BODY=$(gh issue view "$blocked" --json body --jq '.body')
 
   # Extract all referenced dependencies. Two-stage (#4508): stage 1 selects
   # lines declaring a dependency phrase, tolerant of markdown emphasis/colon
@@ -529,7 +529,7 @@ for blocked in $BLOCKED_ISSUES; do
   # Check if ALL dependencies are now closed
   ALL_RESOLVED=true
   for dep in $ALL_DEPS; do
-    DEP_STATE=$(gh issue view "$dep" --json state --jq -r '.state' 2>/dev/null)
+    DEP_STATE=$(gh issue view "$dep" --json state --jq '.state' 2>/dev/null)
     if [ "$DEP_STATE" != "CLOSED" ]; then
       echo "  Still blocked: dependency #$dep is still open"
       ALL_RESOLVED=false
@@ -625,7 +625,7 @@ echo "Found $TOTAL_TODOS TODOs ($CRITICAL_COUNT critical, $STANDARD_COUNT standa
 # Stage 2: Parse PR Body Sections
 # ============================================
 
-PR_BODY=$(gh pr view "$PR_NUMBER" --json body --jq -r '.body // ""')
+PR_BODY=$(gh pr view "$PR_NUMBER" --json body --jq '.body // ""')
 
 # Extract follow-on sections (case-insensitive matching)
 FOLLOWON_SECTION=""
@@ -701,11 +701,11 @@ fi
 
 # Get original issue title if available
 if [ -n "$ORIGINAL_ISSUE" ]; then
-  ORIGINAL_TITLE=$(gh issue view "$ORIGINAL_ISSUE" --json title --jq -r '.title' 2>/dev/null || echo "")
+  ORIGINAL_TITLE=$(gh issue view "$ORIGINAL_ISSUE" --json title --jq '.title' 2>/dev/null || echo "")
   PARENT_REF="Follow-on from PR #$PR_NUMBER which closed #$ORIGINAL_ISSUE"
   CONTEXT_LINE="**$ORIGINAL_TITLE** was implemented in PR #$PR_NUMBER."
 else
-  PR_TITLE=$(gh pr view "$PR_NUMBER" --json title --jq -r '.title')
+  PR_TITLE=$(gh pr view "$PR_NUMBER" --json title --jq '.title')
   PARENT_REF="Follow-on from PR #$PR_NUMBER"
   CONTEXT_LINE="**$PR_TITLE** was merged in PR #$PR_NUMBER."
 fi

--- a/defaults/.claude/commands/loom/champion-reference.md
+++ b/defaults/.claude/commands/loom/champion-reference.md
@@ -71,7 +71,7 @@ fi
 
 **Handling**:
 ```bash
-MERGEABLE=$(gh pr view "$PR_NUMBER" --json mergeable --jq -r '.mergeable')
+MERGEABLE=$(gh pr view "$PR_NUMBER" --json mergeable --jq '.mergeable')
 if [ "$MERGEABLE" != "MERGEABLE" ]; then
   echo "FAIL: Merge conflicts detected"
   # Add comment explaining conflict
@@ -180,7 +180,7 @@ LINKED_ISSUES=$(forge_pr_close_targets "$PR_NUMBER")
 
 # Verify each issue closed after merge
 for issue in $LINKED_ISSUES; do
-  STATE=$(gh issue view "$issue" --json state --jq -r '.state')
+  STATE=$(gh issue view "$issue" --json state --jq '.state')
   if [ "$STATE" != "CLOSED" ]; then
     echo "Warning: Issue #$issue not auto-closed, closing manually"
     gh issue close "$issue" --comment "Closed by PR #$PR_NUMBER (auto-merged by Champion)"

--- a/defaults/scripts/tests/test-champion-critical-file-check.sh
+++ b/defaults/scripts/tests/test-champion-critical-file-check.sh
@@ -175,11 +175,11 @@ echo
 echo "--- Doc pins: shipped markdown uses the paginated REST endpoint, not the truncating gh pr view field ---"
 
 assert_doc_contains "$CHAMPION_MD" \
-    'FILES=$(gh api "repos/{owner}/{repo}/pulls/<number>/files" --paginate --jq -r '"'"'.[].filename'"'"')' \
+    'FILES=$(gh api "repos/{owner}/{repo}/pulls/<number>/files" --paginate --jq '"'"'.[].filename'"'"')' \
     "criterion #3 FILES command ships the paginated REST endpoint"
 
 assert_doc_contains "$CHAMPION_MD" \
-    'gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/files" --paginate --jq -r' \
+    'gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/files" --paginate --jq' \
     "criterion #2 evidence-gathering command ships the paginated REST endpoint"
 
 assert_doc_lacks "$CHAMPION_MD" \


### PR DESCRIPTION
## Summary

`gh`'s own `--jq` flag already emits raw (unquoted) output by default and does not accept a `-r` sub-flag (that's a real `jq` CLI flag, not a `gh api`/`gh pr view`/`gh issue view` one). Multiple documented commands in `champion-pr-merge.md` and `champion-reference.md` used the invalid `gh ... --jq -r '...'` pattern, which errors with `accepts at most 1 arg(s), received 2` if run verbatim, and can silently produce an empty captured variable for a safety-relevant check (mergeable state, issue state, critical-file exclusion) if the error is suppressed.

## Changes

- `defaults/.claude/commands/loom/champion-pr-merge.md` — dropped the invalid `-r` from all 10 `gh ... --jq -r '...'` occurrences (lines 118, 217, 262, 286, 483, 519, 532, 628, 704, 708 as of `origin/main`).
- `defaults/.claude/commands/loom/champion-reference.md` — dropped the invalid `-r` from both occurrences (lines 74, 183).
- `defaults/scripts/tests/test-champion-critical-file-check.sh` — updated the two `assert_doc_contains` literal-string pins (criterion #3 `FILES=...` and criterion #2 evidence-gathering command) to match the corrected doc text. The `assert_doc_lacks` calls and the `#4613` `assert_doc_contains` were left untouched — they reference an unrelated (truncating `gh pr view --json files`) pattern, not the `--jq -r` mis-pairing.

## Acceptance Criteria Verification

- [x] Every `gh <subcommand> ... --jq -r '...'` / `gh api ... --jq -r '...'` occurrence in `champion-pr-merge.md` corrected to `--jq '...'` — verified via `grep -n -- '--jq -r' defaults/.claude/commands/loom/champion-pr-merge.md` returns zero hits after the fix.
- [x] Same correction applied to `champion-reference.md` — verified with the same grep, zero hits.
- [x] The two `assert_doc_contains` calls in `test-champion-critical-file-check.sh` updated to the corrected (`--jq` without `-r`) text; the `assert_doc_lacks` calls and the unrelated `#4613` `assert_doc_contains` left untouched.
- [x] Repo-wide grep for `gh` immediately followed by `--jq -r` returns zero hits under `defaults/`, except the intentional `assert_doc_lacks` literal pin (an unrelated truncating pattern, out of scope by design). Bare `jq -r` piped from a separate `jq` invocation (not a `gh` flag) is untouched — confirmed unchanged in the diff.
- [x] `defaults/scripts/tests/test-champion-critical-file-check.sh` passes: 9/9 assertions pass.

## Test Plan

- Ran `bash defaults/scripts/tests/test-champion-critical-file-check.sh` — 9/9 passed.
- Ran `bash defaults/scripts/tests/check-ci-suite-manifest.sh` — OK, no manifest entries affected.
- Manually verified `gh pr view <number> --json mergeable --jq '.mergeable'` (one of the corrected forms) runs without the `accepts at most 1 arg(s), received 2` error against a live PR.
- Grepped the diff to confirm no bare `jq -r` (not preceded by `gh`) was accidentally altered.

Closes #4632