### PR TITLE
fix(guide,curator): gate loom:blocked unblock on superseding PR block

### DIFF
--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -667,7 +667,9 @@ This issue cannot proceed until dependencies are complete.
 
 **If Dependencies section exists:**
 1. Check if all task list boxes are checked (✅)
-2. **All checked** → Safe to mark `loom:curated`
+2. **All checked** → Also check for a superseding block first (see "When
+   Dependencies Complete" below) — only if that check clears too is it safe
+   to mark `loom:curated`
 3. **Any unchecked** → Add/keep `loom:blocked` label, do NOT mark `loom:curated`
 
 **If NO Dependencies section:**
@@ -692,7 +694,41 @@ gh issue edit <number> --add-label "loom:blocked"
 
 ### When Dependencies Complete
 
-GitHub automatically checks boxes when issues close. When you see all boxes checked:
+GitHub automatically checks boxes when issues close. **Before acting on all-boxes-checked, first check for a superseding block reason (#4634)** —
+`loom:blocked` can get re-applied later for a reason that has nothing to do
+with the body's original Dependencies section (e.g. this issue's own
+implementation PR later hit the Doctor-cycle cap and needs human review). A
+body dependency closing does NOT mean the label's *current* justification has
+cleared, and blindly trusting it caused a live flip-flop loop on #4492: three
+separate Curator passes each stripped `loom:blocked` citing "dependency
+resolved" while the real, current block (an open PR with
+`loom:changes-requested`) was still active, forcing Champion to keep manually
+re-blocking with the real reason each time.
+
+**Primary check (preferred, mechanical/testable) — run this first:**
+```bash
+# Any PR that would close this issue, still OPEN and carrying
+# loom:changes-requested or loom:blocked, is a superseding CURRENT block
+# reason — regardless of what the body's Dependencies section says.
+gh issue view <number> --json closedByPullRequestsReferences \
+  --jq '.closedByPullRequestsReferences[].number'
+# For each PR number returned:
+gh pr view <pr_number> --json state,labels
+# state == "OPEN" AND labels include loom:changes-requested or loom:blocked
+#   → a superseding block is active. Leave loom:blocked in place, do NOT mark
+#     loom:curated, and do NOT post an "unblocked"/"dependencies resolved"
+#     comment — even though the body's checklist is fully checked.
+```
+
+**Secondary heuristic (fragile, optional defense-in-depth, does NOT override
+the primary check above):** if there is no linked PR at all, scan recent
+issue comments for the most recent explicit `loom:blocked` justification
+(e.g. "doctor cycle exhausted", "Sweep coordination: blocking", "Champion:
+re-blocking") and confirm that specific condition has since cleared — not
+just that the body's stated dependency closed. When in doubt, leave
+`loom:blocked` in place.
+
+**Only once the superseding-block check clears**, proceed:
 1. Claim the issue if not already claimed: `gh issue edit <number> --add-label "loom:curating"`
 2. Remove `loom:blocked` label and add `loom:curated`: `gh issue edit <number> --remove-label "loom:blocked" --remove-label "loom:curating" --add-label "loom:curated"`
 3. Issue awaits `loom:issue` promotion (human, Champion, or a `/loom:sweep` orchestrator) before Workers can claim

--- a/defaults/.claude/commands/loom/guide.md
+++ b/defaults/.claude/commands/loom/guide.md
@@ -544,6 +544,61 @@ was_previously_approved() {
 }
 ```
 
+### Superseding Block Check (#4634)
+
+A body-declared "Depends on #N" can go stale once the issue moves further
+through the lifecycle after it was written — e.g. `loom:blocked` gets
+re-applied later for a completely different, *current* reason (an
+implementation PR hitting the Doctor-cycle cap, a fresh block comment) while
+the original body dependency has long since closed. Trusting only the body
+dependency caused a live flip-flop loop on #4492: three separate Curator
+passes each stripped `loom:blocked` citing "dependency #4491 resolved" —
+true, but not the reason the label was applied — while implementation PR
+#4519 sat open with `loom:changes-requested`, forcing Champion to keep
+manually re-blocking with the real, current reason each time.
+
+**Before unblocking on a resolved body dependency, always run this check
+first.** It is the primary, mechanical gate — not a heuristic — and it
+overrides a fully-resolved body dependency:
+
+```bash
+has_superseding_block() {
+  local number="$1"
+  # Any PR that would close this issue (Closes #N / closingIssuesReferences)
+  # still OPEN and carrying loom:changes-requested or loom:blocked is a
+  # superseding, CURRENT block reason — regardless of what the body's
+  # Dependencies section says. An open PR with no review-state label yet
+  # (still being built) is conservatively treated as NOT superseding here;
+  # `check_and_unblock` still applies its own gates afterward.
+  local pr_numbers
+  pr_numbers=$(gh issue view "$number" --json closedByPullRequestsReferences \
+    --jq '.closedByPullRequestsReferences[].number' 2>/dev/null)
+
+  for pr in $pr_numbers; do
+    local pr_json
+    pr_json=$(gh pr view "$pr" --json state,labels 2>/dev/null) || continue
+    local pr_state=$(echo "$pr_json" | jq -r '.state')
+    local pr_blocked=$(echo "$pr_json" | jq -r \
+      '[.labels[].name] | any(. == "loom:changes-requested" or . == "loom:blocked")')
+    if [ "$pr_state" = "OPEN" ] && [ "$pr_blocked" = "true" ]; then
+      echo "true"
+      return
+    fi
+  done
+
+  echo "false"
+}
+```
+
+**Secondary heuristic (fragile, optional defense-in-depth, does NOT override
+the primary gate above):** if the primary check found no linked PR at all,
+scan recent comments for the most recent explicit `loom:blocked`
+justification (e.g. "doctor cycle exhausted", "Sweep coordination: blocking",
+"Champion: re-blocking") and confirm that specific condition has since
+cleared — not just that the body's stated dependency closed. Treat this as a
+soft signal only; when in doubt, leave `loom:blocked` in place for a human or
+a later pass to sort out.
+
 ### Unblocking Logic
 
 ```bash
@@ -573,6 +628,14 @@ check_and_unblock() {
     done
 
     if [ "$all_resolved" = true ]; then
+      # Superseding-block gate (#4634): a resolved body dependency is NOT
+      # sufficient on its own — check whether a linked implementation PR is
+      # still open with a blocking review state before trusting it.
+      if [ "$(has_superseding_block "$number")" = "true" ]; then
+        echo "Skipped #$number (body dependency resolved, but a linked PR is still open and blocked — leaving loom:blocked): $title"
+        continue
+      fi
+
       # Label gate: only RESTORE loom:issue if the issue was approved before it
       # was blocked. An issue blocked pre-approval (e.g. Curator-blocked) must
       # NOT be promoted into the Builder queue — just clear loom:blocked and let
@@ -601,17 +664,27 @@ gh issue view 963 --json labels,body
 gh issue view 962 --json state
 # → state: CLOSED ✓
 
-# 3. Check whether #963 was approved before it was blocked
+# 3. Superseding-block gate (#4634): any linked PR still open and blocked?
+has_superseding_block 963
+# → false (no linked PR, or linked PR is merged/closed/not blocked)
+
+# 4. Check whether #963 was approved before it was blocked
 was_previously_approved 963
 # → true  (loom:issue appears in its label history)
 
-# 4a. Previously approved → RESTORE loom:issue
+# 5a. Previously approved → RESTORE loom:issue
 gh issue edit 963 --remove-label "loom:blocked" --add-label "loom:issue"
 gh issue comment 963 --body "🔓 **Unblocked**: Dependencies resolved (#962). Restored \`loom:issue\` (previously approved). Ready for implementation."
 
-# 4b. If it was NEVER approved (blocked pre-curation) → clear loom:blocked only
+# 5b. If it was NEVER approved (blocked pre-curation) → clear loom:blocked only
 # gh issue edit 963 --remove-label "loom:blocked"
 # gh issue comment 963 --body "🔓 **Unblocked**: Dependencies resolved (#962). Re-enters the curation/approval flow (no loom:issue added)."
+
+# Counter-example (#4492's exact sequence): body dependency #4491 is CLOSED,
+# but has_superseding_block finds linked PR #4519 still OPEN with
+# loom:changes-requested → stay blocked, do NOT strip loom:blocked or post
+# an "Unblocked" comment, no matter how stale the body's Dependencies text
+# looks.
 ```
 
 ### PR Dependencies
@@ -628,6 +701,10 @@ pr_state=$(gh pr view "$pr_number" --json state,mergedAt --jq '.state')
 
 - If no parseable dependencies found → Skip (may need manual review)
 - If any dependency is still OPEN → Keep blocked
+- **If a linked implementation PR is still OPEN with `loom:changes-requested` or
+  `loom:blocked` → Keep blocked, even if every body-declared dependency has
+  closed** (`has_superseding_block`, #4634) — the body dependency being
+  resolved is necessary but not sufficient
 - If issue was blocked for non-dependency reasons → Check comments for context
 
 ## Epic Progress Tracking


### PR DESCRIPTION
## Summary

`check_and_unblock()` in `guide.md` and the "When Dependencies Complete" step
in `curator.md` both strip `loom:blocked` as soon as every body-declared
dependency closes, with no check for a *later, current* block reason. This
caused a live flip-flop loop on #4492 (2026-07-30): the body dependency
(#4491) closed, but `loom:blocked` was later re-applied for a completely
different reason — implementation PR #4519 hit the Doctor-cycle cap and
needed human review. Three separate Curator passes each "resolved" the stale
dependency and stripped the label while PR #4519 sat open with
`loom:changes-requested`, forcing Champion to keep manually re-blocking with
the real, current reason each time.

Since both `defaults/roles/{guide,curator}.md` and `.loom/roles/{guide,curator}.md`
are now symlinks that resolve to the single canonical
`defaults/.claude/commands/loom/{guide,curator}.md`, editing those two files
is sufficient — every other path in the issue's "Affected Files" list already
resolves to the same file (verified with `realpath`), so there is nothing
left to keep in sync manually.

## Changes

- **`defaults/.claude/commands/loom/guide.md`**: added `has_superseding_block()`
  — a primary, mechanical gate that checks whether any PR referencing the
  issue (`closedByPullRequestsReferences`) is still `OPEN` and carries
  `loom:changes-requested` or `loom:blocked`. `check_and_unblock()` now calls
  this gate before acting on a fully-resolved body dependency, and skips
  (leaving `loom:blocked` untouched, no "Unblocked" comment) when it fires.
  Also documented an optional secondary comment-history heuristic that never
  overrides the primary gate, updated the worked example, and added a bullet
  to "When NOT to Unblock".
- **`defaults/.claude/commands/loom/curator.md`**: the "When Dependencies
  Complete" step now runs the identical primary check (via
  `gh issue view --json closedByPullRequestsReferences` + `gh pr view --json
  state,labels`) before removing `loom:blocked` and adding `loom:curated`,
  with the same secondary-heuristic caveat. "Decision Logic" step 2 now
  points at this gate instead of unconditionally declaring "all checked" safe.

## Test plan

- [x] Reconstructed #4492's exact sequence as a mocked scenario (body
  dependency closed, linked PR `OPEN` + `loom:changes-requested`) —
  `has_superseding_block` returns `true`, so the unblock is skipped.
- [x] Control case: linked PR `MERGED` — `has_superseding_block` returns
  `false`, unblock proceeds as before (no regression on the happy path).
- [x] Edge case: linked PR `OPEN` with no review-state label yet —
  conservatively treated as *not* superseding (documented explicitly in both
  files), matching the issue's suggested default.
- [x] `bash -n` + `shellcheck -x` on the extracted `has_superseding_block()`
  snippet — no new issues beyond the pre-existing `SC2155` style already
  present in the surrounding file.
- [x] Ran `.loom/scripts/tests/test-dependency-parse.sh` — unaffected
  (`parse_dependencies()` itself is untouched); its 4 pre-existing failures
  are a path-resolution bug in the test file itself, reproduced identically
  on `main` before this change, out of scope here.
- No automated test harness exists for these role-prompt bash snippets
  (confirmed no fixture directory covers `guide.md`/`curator.md` logic beyond
  `test-dependency-parse.sh`'s `parse_dependencies` pin), so verification is
  the manual/mocked reconstruction above per the issue's Test Plan.

Closes #4634