### PR TITLE
fix: untrack and gitignore the .no-changes-needed builder marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Thumbs.db
 .loom-in-use
 .loom-checkpoint
 .loom-managed
+.no-changes-needed
 .loom/.daemon.pid
 .loom/.daemon.log
 .loom/daemon.sock

--- a/.no-changes-needed
+++ b/.no-changes-needed
@@ -1,1 +1,0 @@
-Tests for the pr-body.md happy path in _build_direct_completion_pr_body (builder.py) and _build_recovery_pr_body (validate_phase.py) were already implemented and merged in PR #2966 (commit 4810f21). All 6 tests in TestBuildDirectCompletionPrBody and 6 tests in TestRateLimitedBuilderExit covering the recovery pr body pass. No additional changes are needed.

--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -43,13 +43,14 @@ git checkout -- <out-of-scope-file>
 
 **No Loom runtime markers staged.** `worktree.sh` drops a `.loom-managed` sentinel
 into every issue worktree, and other flows may leave `.loom-in-use` /
-`.loom-checkpoint`. These are gitignored by a correctly-installed repo, but a stale
-or pre-#3838 `.gitignore` may not cover them — so a blanket `git add -A` can sweep
-them into your commit. Before committing, confirm none are staged:
+`.loom-checkpoint` / the `.no-changes-needed` no-changes signal (see "Signaling
+No Changes Needed" below). These are gitignored by a correctly-installed repo, but
+a stale or pre-#3838 `.gitignore` may not cover them — so a blanket `git add -A`
+can sweep them into your commit. Before committing, confirm none are staged:
 
 ```bash
 git -C "$WORKTREE_ABS" diff --cached --name-only \
-  | grep -E '(^|/)\.loom-managed$|(^|/)\.loom-in-use$|(^|/)\.loom-checkpoint$' \
+  | grep -E '(^|/)\.loom-managed$|(^|/)\.loom-in-use$|(^|/)\.loom-checkpoint$|(^|/)\.no-changes-needed$' \
   && echo "ERROR: unstage the Loom runtime marker above (git rm --cached <file>)" \
   || echo "OK: no Loom runtime markers staged"
 ```

--- a/loom-daemon/src/init/post_init.rs
+++ b/loom-daemon/src/init/post_init.rs
@@ -117,6 +117,11 @@ pub const EPHEMERAL_PATTERNS: &[&str] = &[
     // Worktree sentinel dropped by worktree.sh into each issue worktree; must be
     // ignored so a builder's `git add -A` doesn't sweep it into a commit (#3778).
     ".loom-managed",
+    // Builder "no changes needed" marker (builder.md § "Signaling No Changes
+    // Needed"). Must stay untracked/gitignored so it is born absent in every
+    // fresh worktree and a deliberate write doesn't get swept into a commit by
+    // `git add -A` — a tracked copy on main defeated the signal entirely (#4635).
+    ".no-changes-needed",
     ".loom/.daemon.pid",
     ".loom/.daemon.log",
     ".loom/daemon.sock",
@@ -576,6 +581,10 @@ mod tests {
         assert!(contents.contains(".loom/spawn-loop.pid"));
         assert!(contents.contains(".loom/stop-spawn-loop"));
 
+        // #4635: the builder "no changes needed" marker must be ignored so it
+        // is born absent in every fresh worktree.
+        assert!(contents.contains(".no-changes-needed"));
+
         // Retired daemon-brain patterns must NOT be emitted (Phase 3.5, #3402)
         assert!(!contents.contains(".loom/daemon-state.json"));
         assert!(!contents.contains(".loom/[0-9][0-9]-daemon-state.json"));
@@ -629,6 +638,9 @@ mod tests {
         assert_eq!(contents.matches(".loom/locks/").count(), 1);
         // #4280: `.loom/worktrees-local/` must not duplicate across runs.
         assert_eq!(contents.matches(".loom/worktrees-local/").count(), 1);
+        // #4635: the builder "no changes needed" marker must not duplicate
+        // across runs either.
+        assert_eq!(contents.matches(".no-changes-needed").count(), 1);
     }
 
     #[test]
@@ -647,6 +659,9 @@ mod tests {
             // #3838: the worktree sentinel worktree.sh drops into each issue
             // worktree must be ignored, else a builder's `git add -A` commits it.
             ".loom-managed",
+            // #4635: builder "no changes needed" marker (builder.md § "Signaling
+            // No Changes Needed") must stay untracked/gitignored.
+            ".no-changes-needed",
             ".loom/.daemon.pid",
             ".loom/.daemon.log",
             ".loom/daemon.sock",


### PR DESCRIPTION
## Summary

`.no-changes-needed` was accidentally tracked on `main` (PR #2985), carrying
stale content from an old builder note. Because it was tracked (and not
gitignored), every issue worktree was born with the builder no-changes signal
already stuck on, and a `git add -A` could sweep a builder's rationale write
into a commit — defeating `builder.md` § "Signaling No Changes Needed" entirely.

## Changes

- `git rm .no-changes-needed` — delete the stale tracked file from `main`.
- `loom-daemon/src/init/post_init.rs`: add `.no-changes-needed` to
  `EPHEMERAL_PATTERNS` (the canonical gitignore-block source refreshed on every
  init/update), with a provenance comment matching neighboring entries; extend
  the spot-check assertions (`creates_gitignore_with_all_patterns_when_none_exists`,
  `covers_all_source_repo_gitignore_patterns`) and the no-duplicate-on-rerun
  assertion (`does_not_duplicate_patterns_on_repeated_runs`).
- `.gitignore`: hand-add `.no-changes-needed` to this repo's own
  `# >>> loom-managed >>>` block so `main` isn't broken until the next
  init/update cycle refreshes it from the daemon source.
- `defaults/.claude/commands/loom/builder.md`: extend the pre-commit marker
  grep from `.loom-managed` / `.loom-in-use` / `.loom-checkpoint` to also match
  `.no-changes-needed`, and mention the marker in the surrounding prose.

Out of scope (per the curated issue): adding code that actually *reads* the
marker off disk during sweep orchestration (deliberately deferred as a
separate follow-up); `scripts/uninstall-loom.sh`'s legacy-file list;
`scripts/install/local-mode.sh`'s separate gitignore block;
`defaults/scripts/worktree.sh`'s `_worktree_dirty_lines` (already filters this
marker, #4449); `loom-daemon/src/script_helpers/validate_phase.rs` (already
special-cases the committed marker) — both left untouched.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `git ls-files --error-unmatch .no-changes-needed` exits non-zero | ✅ | Ran on branch; exits 1 with "did not match any file(s) known to git" |
| `git check-ignore .no-changes-needed` exits 0 at repo root and in a fresh worktree | ✅ | `git check-ignore -v .no-changes-needed` → `.gitignore:37:.no-changes-needed .no-changes-needed`, exit 0; the same pattern is now emitted by `update_gitignore` into every fresh worktree via the daemon's `EPHEMERAL_PATTERNS` source |
| `EPHEMERAL_PATTERNS` includes `.no-changes-needed`; post_init.rs gitignore tests updated and passing (incl. no-duplicate-on-rerun) | ✅ | `cargo test -p loom-daemon post_init` → 26 passed, 0 failed |
| Extended builder.md pre-commit grep flags a force-staged `.no-changes-needed` | ✅ | Manually force-staged the file and ran the extended grep — matched and printed the error line |
| Fresh worktree born without the marker; writing it afterward leaves `git status --porcelain` empty | ✅ | Verified via the `covers_all_source_repo_gitignore_patterns` / rerun-idempotency tests exercising the same `update_gitignore` codepath `worktree.sh` relies on |
| No-change sites (worktree.sh filter, validate_phase.rs recovery, build-gate docs) left untouched | ✅ | `git diff --stat` confirms only the 4 in-scope files changed |

## Test Plan

```
cargo test -p loom-daemon post_init
# test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 2544 filtered out
cargo fmt -p loom-daemon -- --check   # clean
cargo clippy -p loom-daemon --lib -- -D warnings   # clean
```

Closes #4635