### PR TITLE
fix: make --paginate timestamp parsing line-aware across 4 call sites (#4637)

### DIFF
--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -424,8 +424,18 @@ stand-down comments:
 
 ```bash
 N=<pr-number>
+# `--paginate` re-invokes `--jq` once per response page and concatenates the
+# per-page results rather than applying the filter across the combined
+# timeline (#4637) — a timeline spanning more than one page (>100 events)
+# would otherwise yield a multi-line CLAIMED_AT that corrupts MARKER and
+# every comparison below. `// empty` drops the no-match-on-this-page line
+# entirely (not a literal "null"), and `sort | tail -n 1` collapses the
+# remaining per-page timestamps to the single latest one — RFC3339 UTC
+# timestamps (the `Z`-suffixed form the GitHub API returns) sort correctly
+# as plain strings, so this needs no minimum `gh` version.
 CLAIMED_AT=$(gh api "repos/{owner}/{repo}/issues/$N/timeline" --paginate \
-  --jq '[.[] | select(.event=="labeled" and .label.name=="loom:treating")] | last | .created_at')
+  --jq '[.[] | select(.event=="labeled" and .label.name=="loom:treating")] | last | .created_at // empty' \
+  | sort | tail -n 1)
 MARKER="<!-- loom:standdown claim=$CLAIMED_AT -->"
 COMMENTS_JSON=$(gh api "repos/{owner}/{repo}/issues/$N/comments" \
   | jq --arg t "$CLAIMED_AT" '[.[] | select(.created_at > $t)]')

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -341,8 +341,18 @@ stand-down comments:
 
 ```bash
 N=<pr-number>
+# `--paginate` re-invokes `--jq` once per response page and concatenates the
+# per-page results rather than applying the filter across the combined
+# timeline (#4637) — a timeline spanning more than one page (>100 events)
+# would otherwise yield a multi-line CLAIMED_AT that corrupts MARKER and
+# every comparison below. `// empty` drops the no-match-on-this-page line
+# entirely (not a literal "null"), and `sort | tail -n 1` collapses the
+# remaining per-page timestamps to the single latest one — RFC3339 UTC
+# timestamps (the `Z`-suffixed form the GitHub API returns) sort correctly
+# as plain strings, so this needs no minimum `gh` version.
 CLAIMED_AT=$(gh api "repos/{owner}/{repo}/issues/$N/timeline" --paginate \
-  --jq '[.[] | select(.event=="labeled" and .label.name=="loom:reviewing")] | last | .created_at')
+  --jq '[.[] | select(.event=="labeled" and .label.name=="loom:reviewing")] | last | .created_at // empty' \
+  | sort | tail -n 1)
 MARKER="<!-- loom:standdown claim=$CLAIMED_AT -->"
 COMMENTS_JSON=$(gh api "repos/{owner}/{repo}/issues/$N/comments" \
   | jq --arg t "$CLAIMED_AT" '[.[] | select(.created_at > $t)]')

--- a/loom-daemon/src/claim_reconciliation.rs
+++ b/loom-daemon/src/claim_reconciliation.rs
@@ -1344,15 +1344,35 @@ pub mod forge {
         if !out.status.success() {
             return None;
         }
-        let raw = String::from_utf8_lossy(&out.stdout);
-        let trimmed = raw.trim();
-        if trimmed.is_empty() || trimmed == "null" {
-            return None;
-        }
-        let unquoted = trimmed.trim_matches('"');
-        chrono::DateTime::parse_from_rfc3339(unquoted)
-            .ok()
-            .map(|dt| dt.with_timezone(&chrono::Utc))
+        parse_max_timestamp(&out.stdout)
+    }
+
+    /// Parse a `gh api --paginate --jq '... | max // empty'` result into the
+    /// maximum RFC-3339 timestamp across every line of output. `--paginate`
+    /// re-invokes the `--jq` filter once per page and concatenates the
+    /// per-page results rather than applying the filter across the combined
+    /// set (Issue #4637) — on a timeline spanning more than one page (>100
+    /// events) this yields one `max`-per-page line, not a single overall
+    /// max. Each non-empty/non-`null` line (bare or JSON-quoted) is parsed
+    /// independently and the maximum across all lines is returned; a
+    /// single-line result (the common case) is handled identically to
+    /// before. Returns `None` when there is no parseable timestamp on any
+    /// line — the same fail-open contract as the pre-#4637 single-line
+    /// parse.
+    pub(crate) fn parse_max_timestamp(stdout: &[u8]) -> Option<DateTime<Utc>> {
+        let raw = String::from_utf8_lossy(stdout);
+        raw.lines()
+            .filter_map(|line| {
+                let trimmed = line.trim();
+                if trimmed.is_empty() || trimmed == "null" {
+                    return None;
+                }
+                let unquoted = trimmed.trim_matches('"');
+                chrono::DateTime::parse_from_rfc3339(unquoted)
+                    .ok()
+                    .map(|dt| dt.with_timezone(&chrono::Utc))
+            })
+            .max()
     }
 
     /// The PR's currently-applied state labels (a best-effort subset of
@@ -3100,5 +3120,59 @@ exit 0
         std::env::remove_var(sweep_journal::JOURNAL_PATH_ENV);
         std::env::remove_var(STALE_REVIEWING_MINUTES_ENV);
         std::env::remove_var(STALE_TREATING_MINUTES_ENV);
+    }
+
+    // Issue #4637: `gh api --paginate --jq` re-invokes the `--jq` filter once
+    // per page and concatenates the per-page results, so a `max // empty`
+    // filter against a timeline spanning more than one page (>100 events)
+    // yields one line per page rather than a single overall max.
+    // `parse_max_timestamp` must resolve the true max across every line.
+
+    #[test]
+    fn parse_max_timestamp_single_line_bare() {
+        let stdout = b"2026-01-01T00:00:00Z\n";
+        let parsed = forge::parse_max_timestamp(stdout).unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-01-01T00:00:00+00:00");
+    }
+
+    #[test]
+    fn parse_max_timestamp_multi_page_picks_max_out_of_order() {
+        // Three pages' worth of per-page `max` lines, deliberately not in
+        // chronological order, mirroring what `--paginate` concatenation
+        // actually produces.
+        let stdout = b"2026-01-01T00:00:00Z\n2026-03-15T12:30:00Z\n2026-02-01T00:00:00Z\n";
+        let parsed = forge::parse_max_timestamp(stdout).unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-03-15T12:30:00+00:00");
+    }
+
+    #[test]
+    fn parse_max_timestamp_multi_page_skips_empty_and_null_lines() {
+        // A page with no matching event emits an empty line (the `// empty`
+        // fallback) or a literal `null`; both must be ignored, not treated
+        // as "no timestamp anywhere".
+        let stdout = b"\n2026-05-05T05:05:05Z\nnull\n";
+        let parsed = forge::parse_max_timestamp(stdout).unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-05-05T05:05:05+00:00");
+    }
+
+    #[test]
+    fn parse_max_timestamp_returns_none_for_empty_output() {
+        assert!(forge::parse_max_timestamp(b"").is_none());
+        assert!(forge::parse_max_timestamp(b"\n\n").is_none());
+        assert!(forge::parse_max_timestamp(b"null\n").is_none());
+        assert!(forge::parse_max_timestamp(b"null\nnull\n").is_none());
+    }
+
+    #[test]
+    fn parse_max_timestamp_returns_none_for_garbage() {
+        assert!(forge::parse_max_timestamp(b"not-a-timestamp\n").is_none());
+        assert!(forge::parse_max_timestamp(b"not-a-timestamp\nalso-not-one\n").is_none());
+    }
+
+    #[test]
+    fn parse_max_timestamp_handles_json_quoted_lines() {
+        let stdout = b"\"2026-01-01T00:00:00Z\"\n\"2026-06-06T06:06:06Z\"\n";
+        let parsed = forge::parse_max_timestamp(stdout).unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-06-06T06:06:06+00:00");
     }
 }

--- a/loom-daemon/src/quarantine_reconciliation.rs
+++ b/loom-daemon/src/quarantine_reconciliation.rs
@@ -296,17 +296,30 @@ pub mod forge {
 
     /// Parse a `gh --jq` scalar result that is either a bare RFC-3339
     /// timestamp or a JSON-quoted one, tolerating an empty/`null` result
-    /// (no match).
-    fn parse_timestamp(stdout: &[u8]) -> Option<DateTime<Utc>> {
+    /// (no match). Also tolerates multi-line output: `gh api --paginate`
+    /// re-invokes `--jq` once per page and concatenates the per-page
+    /// results, so a filter like `max // empty` run against a timeline
+    /// spanning more than one page (>100 events, as
+    /// [`fetch_last_blocked_labeled_at`] queries) yields one `max`-per-page
+    /// line rather than a single overall max (Issue #4637). Each
+    /// non-empty/non-`null` line is parsed independently and the maximum
+    /// across all lines is returned; a single-line result (e.g. from
+    /// [`fetch_last_quarantine_comment_at`]'s non-paginated `gh issue view`)
+    /// is handled identically to before.
+    pub(crate) fn parse_timestamp(stdout: &[u8]) -> Option<DateTime<Utc>> {
         let raw = String::from_utf8_lossy(stdout);
-        let trimmed = raw.trim();
-        if trimmed.is_empty() || trimmed == "null" {
-            return None;
-        }
-        let unquoted = trimmed.trim_matches('"');
-        DateTime::parse_from_rfc3339(unquoted)
-            .ok()
-            .map(|dt| dt.with_timezone(&Utc))
+        raw.lines()
+            .filter_map(|line| {
+                let trimmed = line.trim();
+                if trimmed.is_empty() || trimmed == "null" {
+                    return None;
+                }
+                let unquoted = trimmed.trim_matches('"');
+                DateTime::parse_from_rfc3339(unquoted)
+                    .ok()
+                    .map(|dt| dt.with_timezone(&Utc))
+            })
+            .max()
     }
 
     /// Best-effort, single-issue check of whether `issue`'s current
@@ -711,5 +724,55 @@ exit 0
         let (checked, released) = forge::reconcile_workspace(&fake_gh, &repo_root);
         assert_eq!(checked, 0);
         assert_eq!(released, 0);
+    }
+
+    // Issue #4637: `gh api --paginate --jq` re-invokes the `--jq` filter once
+    // per page and concatenates the per-page results, so a `max // empty`
+    // filter against `fetch_last_blocked_labeled_at`'s paginated timeline
+    // query yields one line per page (>100 events) rather than a single
+    // overall max. `parse_timestamp` must resolve the true max across every
+    // line, while still handling the single-line result
+    // `fetch_last_quarantine_comment_at`'s non-paginated query always
+    // produces.
+
+    #[test]
+    fn parse_timestamp_single_line_bare() {
+        let parsed = forge::parse_timestamp(b"2026-01-01T00:00:00Z\n").unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-01-01T00:00:00+00:00");
+    }
+
+    #[test]
+    fn parse_timestamp_multi_page_picks_max_out_of_order() {
+        let stdout = b"2026-01-01T00:00:00Z\n2026-03-15T12:30:00Z\n2026-02-01T00:00:00Z\n";
+        let parsed = forge::parse_timestamp(stdout).unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-03-15T12:30:00+00:00");
+    }
+
+    #[test]
+    fn parse_timestamp_multi_page_skips_empty_and_null_lines() {
+        let stdout = b"\n2026-05-05T05:05:05Z\nnull\n";
+        let parsed = forge::parse_timestamp(stdout).unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-05-05T05:05:05+00:00");
+    }
+
+    #[test]
+    fn parse_timestamp_returns_none_for_empty_output() {
+        assert!(forge::parse_timestamp(b"").is_none());
+        assert!(forge::parse_timestamp(b"\n\n").is_none());
+        assert!(forge::parse_timestamp(b"null\n").is_none());
+        assert!(forge::parse_timestamp(b"null\nnull\n").is_none());
+    }
+
+    #[test]
+    fn parse_timestamp_returns_none_for_garbage() {
+        assert!(forge::parse_timestamp(b"not-a-timestamp\n").is_none());
+        assert!(forge::parse_timestamp(b"not-a-timestamp\nalso-not-one\n").is_none());
+    }
+
+    #[test]
+    fn parse_timestamp_handles_json_quoted_lines() {
+        let stdout = b"\"2026-01-01T00:00:00Z\"\n\"2026-06-06T06:06:06Z\"\n";
+        let parsed = forge::parse_timestamp(stdout).unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-06-06T06:06:06+00:00");
     }
 }


### PR DESCRIPTION
## Summary

`gh api --paginate --jq '<filter>'` applies the jq filter **per page** and concatenates the outputs, rather than applying the filter to the combined result set. Several call sites assumed a single-line result but got silently corrupted/degraded once a PR/issue timeline spanned more than one page (>100 events):

1. `loom-daemon/src/claim_reconciliation.rs` — `fetch_claim_labeled_at`'s inline stdout parse treated the whole trimmed stdout as ONE RFC3339 timestamp, returning `None` on multi-page output (silently falling back to `updated_at`, the stand-down-inflatable signal #4618 exists to avoid).
2. `loom-daemon/src/quarantine_reconciliation.rs` — `parse_timestamp` (shared by `fetch_last_blocked_labeled_at`) had the same shape. `fetch_last_quarantine_comment_at` is unaffected/untouched — it uses a non-paginated `gh issue view` call, so its single-line output was never at risk.
3. `defaults/.claude/commands/loom/judge.md` `CLAIMED_AT` snippet — multi-line output corrupted the `MARKER` string and every downstream comparison.
4. `defaults/.claude/commands/loom/doctor.md` — same snippet shape.

## Changes

- **Rust (2 sites)**: made the timestamp parse line-aware — split stdout on newlines, parse each non-empty/non-`null` line as RFC3339, take the max. `claim_reconciliation.rs` gets a new `parse_max_timestamp` helper (mirroring `fetch_claim_labeled_at`'s previous inline logic); `quarantine_reconciliation.rs`'s existing `parse_timestamp` is updated in place. Both preserve the fail-open contract (unparseable/empty/`null`-only input -> `None`, no panic).
- **Doc snippets (2 sites)**: appended `// empty` to the jq filter (so an unmatched page emits nothing instead of a literal `"null"`) and piped through `sort | tail -n 1` to collapse multi-page output to the single latest RFC3339 timestamp — RFC3339 UTC timestamps sort correctly as plain strings, so this needs no minimum `gh` version (no bare `--slurp`).
- **Tests**: added unit tests in the existing `#[cfg(test)]` modules of both `.rs` files covering single-line, out-of-order multi-line (>=2 "pages"), empty, `null`-mixed, and garbage-line cases.

## Out of scope (per the curated issue — untouched)

`champion-pr-merge.md:118,217`, `blame-issue.sh:213`, `merge-pr.sh:536` (streaming filters, correct as-is), `sweep.md:1459`, `check-duplicate.sh:483` (cosmetic degradation only, deliberately deferred).

## Test plan

- [x] `cargo test -p loom-daemon --lib` — 2582 passed, 0 failed
- [x] `cargo clippy -p loom-daemon --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p loom-daemon -- --check` — clean
- [x] New unit tests: `parse_max_timestamp_*` (claim_reconciliation.rs) and `parse_timestamp_*` (quarantine_reconciliation.rs) — single-line, multi-page out-of-order max, empty/null-mixed, garbage, JSON-quoted lines
- [x] Manually verified the `sort | tail -n 1` doc-snippet fix against a simulated multi-page fixture (lexicographic sort correctly picks the latest RFC3339 UTC timestamp)

Closes #4637