### PR TITLE
fix(daemon): anchor decide_pr's age gate on max(claim_labeled_at, genuine comment activity)

### DIFF
--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -424,8 +424,18 @@ stand-down comments:
 
 ```bash
 N=<pr-number>
+# `--paginate` re-invokes `--jq` once per response page and concatenates the
+# per-page results rather than applying the filter across the combined
+# timeline (#4637) — a timeline spanning more than one page (>100 events)
+# would otherwise yield a multi-line CLAIMED_AT that corrupts MARKER and
+# every comparison below. `// empty` drops the no-match-on-this-page line
+# entirely (not a literal "null"), and `sort | tail -n 1` collapses the
+# remaining per-page timestamps to the single latest one — RFC3339 UTC
+# timestamps (the `Z`-suffixed form the GitHub API returns) sort correctly
+# as plain strings, so this needs no minimum `gh` version.
 CLAIMED_AT=$(gh api "repos/{owner}/{repo}/issues/$N/timeline" --paginate \
-  --jq '[.[] | select(.event=="labeled" and .label.name=="loom:treating")] | last | .created_at')
+  --jq '[.[] | select(.event=="labeled" and .label.name=="loom:treating")] | last | .created_at // empty' \
+  | sort | tail -n 1)
 MARKER="<!-- loom:standdown claim=$CLAIMED_AT -->"
 COMMENTS_JSON=$(gh api "repos/{owner}/{repo}/issues/$N/comments" \
   | jq --arg t "$CLAIMED_AT" '[.[] | select(.created_at > $t)]')

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -341,8 +341,18 @@ stand-down comments:
 
 ```bash
 N=<pr-number>
+# `--paginate` re-invokes `--jq` once per response page and concatenates the
+# per-page results rather than applying the filter across the combined
+# timeline (#4637) — a timeline spanning more than one page (>100 events)
+# would otherwise yield a multi-line CLAIMED_AT that corrupts MARKER and
+# every comparison below. `// empty` drops the no-match-on-this-page line
+# entirely (not a literal "null"), and `sort | tail -n 1` collapses the
+# remaining per-page timestamps to the single latest one — RFC3339 UTC
+# timestamps (the `Z`-suffixed form the GitHub API returns) sort correctly
+# as plain strings, so this needs no minimum `gh` version.
 CLAIMED_AT=$(gh api "repos/{owner}/{repo}/issues/$N/timeline" --paginate \
-  --jq '[.[] | select(.event=="labeled" and .label.name=="loom:reviewing")] | last | .created_at')
+  --jq '[.[] | select(.event=="labeled" and .label.name=="loom:reviewing")] | last | .created_at // empty' \
+  | sort | tail -n 1)
 MARKER="<!-- loom:standdown claim=$CLAIMED_AT -->"
 COMMENTS_JSON=$(gh api "repos/{owner}/{repo}/issues/$N/comments" \
   | jq --arg t "$CLAIMED_AT" '[.[] | select(.created_at > $t)]')

--- a/loom-daemon/src/claim_reconciliation.rs
+++ b/loom-daemon/src/claim_reconciliation.rs
@@ -86,6 +86,25 @@
 //!   re-applies the label, so `claim_labeled_at` cannot be bumped that way.
 //!   `updated_at` remains the fail-open fallback for when the timeline fetch
 //!   failed or found nothing.
+//! - **Genuine comment activity also refreshes the anchor (Issue #4638).**
+//!   Anchoring solely on `claim_labeled_at` fixed #4618's self-perpetuating
+//!   livelock, but it also removed the only protection a claim previously had
+//!   when it is *not* pid-joinable (no journal entry, no run-registry join,
+//!   and a `headRefName` that doesn't match `feature/issue-<N>`) — a
+//!   claimant genuinely reviewing/fixing for 35+ minutes while posting real
+//!   progress comments would have its claim reclaimed out from under it,
+//!   because `claim_labeled_at` itself only moves on a label re-application.
+//!   [`decide_pr`]'s age gate therefore anchors on
+//!   `max(claim_labeled_at, most_recent_substantive_comment_at)`
+//!   ([`ClaimedPr::most_recent_substantive_comment_at`]) — a genuine (i.e.
+//!   non-marker) comment posted after the claim refreshes the anchor exactly
+//!   like a real re-claim would, while a marker-tagged stand-down comment
+//!   (`<!-- loom:standdown claim=... -->`, [`STANDDOWN_MARKER_PREFIX`]) is
+//!   excluded from that signal the same way judge.md/doctor.md's own
+//!   `COMMENTS_AFTER` check excludes it — so the #4618 fix is preserved
+//!   (marked stand-down comments still cannot self-refresh the anchor) while
+//!   a genuinely live, non-pid-joinable claimant is no longer reclaimed out
+//!   from under it.
 //!
 //! Reclaiming removes only the stale claim label (the state label restores
 //! discoverability by itself); as a safety net, if the PR is then left
@@ -600,6 +619,15 @@ impl PrClaimKind {
     }
 }
 
+/// Marker (Issue #4636/#4618) tagging a Judge/Doctor "standing down, not
+/// stomping" comment — evidence of *no* progress (a later pass declining to
+/// reclaim), not genuine activity. A comment containing this substring is
+/// excluded from [`ClaimedPr::most_recent_substantive_comment_at`] (Issue
+/// #4638), mirroring `judge.md`/`doctor.md`'s own `COMMENTS_AFTER` exclusion
+/// (a substring match, not an exact marker+claim-timestamp match, so any
+/// stand-down comment for any claim generation is excluded).
+pub const STANDDOWN_MARKER_PREFIX: &str = "<!-- loom:standdown claim=";
+
 /// An open PR carrying a `loom:reviewing`/`loom:treating` claim label,
 /// trimmed to the fields the reconciliation decision needs.
 #[derive(Debug, Clone, PartialEq)]
@@ -622,6 +650,22 @@ pub struct ClaimedPr {
     /// then fall back to [`Self::updated_at`], preserving pre-#4618 behavior
     /// for that fail-open case.
     pub claim_labeled_at: Option<DateTime<Utc>>,
+    /// Timestamp of the most recent **substantive** (non-stand-down) comment
+    /// posted since [`Self::claim_labeled_at`] (Issue #4638), when
+    /// resolvable. A comment whose body contains [`STANDDOWN_MARKER_PREFIX`]
+    /// is excluded — it evidences a later pass declining to reclaim, not
+    /// activity by the claimant. [`decide_pr`] anchors its age gate on
+    /// `max(claim_labeled_at, most_recent_substantive_comment_at)`, so a
+    /// claimant that is not pid-joinable but is genuinely posting progress
+    /// comments is not reclaimed out from under it purely because
+    /// `claim_labeled_at` itself has aged. `None` when there is no
+    /// `claim_labeled_at` to compare against, the comment fetch failed, or
+    /// every comment since the claim was a marker-tagged stand-down note —
+    /// callers then fall back to `claim_labeled_at`/`updated_at` alone,
+    /// preserving pre-#4638 behavior for that case (including the #4618
+    /// regression guard: a claim with only stand-down comments since must
+    /// still be reclaimed once stale).
+    pub most_recent_substantive_comment_at: Option<DateTime<Utc>>,
     /// The PR's head branch name, when available — the only join key to an
     /// issue number this pass has (see [`parse_issue_from_branch`]).
     pub head_ref_name: Option<String>,
@@ -679,19 +723,28 @@ pub fn parse_issue_from_branch(head_ref_name: &str) -> Option<u32> {
 /// `run_registry_pid` is the caller's join result, consulted only when
 /// `journal_entry` is absent, exactly like [`decide`].
 ///
-/// **Age-gate freshness signal (Issue #4618)**: the age gate below prefers
-/// `pr.claim_labeled_at` (the claim label's own most recent `labeled`
-/// timeline event) over `pr.updated_at` (the PR's aggregate "last modified"
-/// timestamp). Before this fix, `updated_at` was the sole signal, and GitHub
-/// bumps it on ANY comment — including a Judge/Doctor "standing down, not
-/// stomping" comment posted by a later pass declining to reclaim. That made
-/// the check perpetually self-refreshing: each stand-down comment satisfied
-/// the very freshness test the next pass ran, so a claim could survive past
-/// the staleness window once and then never be reclaimed again (PR #4614).
-/// `claim_labeled_at` cannot be bumped that way — it only changes when the
-/// label is genuinely re-applied — so it is used whenever resolvable, with
-/// `updated_at` kept only as the fail-open fallback for when the timeline
-/// fetch itself failed or returned nothing (same fail-safe posture as the
+/// **Age-gate freshness signal (Issue #4618, refined by #4638)**: the age
+/// gate below anchors on
+/// `max(pr.claim_labeled_at, pr.most_recent_substantive_comment_at)`,
+/// falling back to `pr.updated_at` only when BOTH are unavailable.
+/// `claim_labeled_at` (the claim label's own most recent `labeled` timeline
+/// event) replaced `updated_at` as the primary signal in #4618: before that
+/// fix, `updated_at` was the sole signal, and GitHub bumps it on ANY comment
+/// — including a Judge/Doctor "standing down, not stomping" comment posted
+/// by a later pass declining to reclaim. That made the check perpetually
+/// self-refreshing: each stand-down comment satisfied the very freshness
+/// test the next pass ran, so a claim could survive past the staleness
+/// window once and then never be reclaimed again (PR #4614). But anchoring
+/// solely on `claim_labeled_at` also removed the only protection a claim had
+/// when it is not pid-joinable: a claimant genuinely working for 35+ minutes
+/// while posting real progress comments would be reclaimed anyway, since
+/// `claim_labeled_at` itself only moves on a label re-application (#4638).
+/// `most_recent_substantive_comment_at` restores that protection — a
+/// genuine (non-marker) comment posted after the claim refreshes the anchor
+/// — while marker-tagged stand-down comments remain excluded from it, so the
+/// #4618 fix holds (a claim with only stand-down comments since still ages
+/// out and is reclaimed). `updated_at` remains the final fail-open fallback
+/// for when neither signal is available (same fail-safe posture as the
 /// pre-#4618 `None` branch below).
 #[must_use]
 pub fn decide_pr(
@@ -724,11 +777,20 @@ pub fn decide_pr(
     // proof here: the PR->issue join is heuristic, so only *aged* absence (or
     // aged dead-pid evidence) triggers a reclaim.
     //
-    // Prefer claim_labeled_at (Issue #4618) -- it cannot be self-refreshed by
-    // a stand-down comment the way updated_at can. Only fall back to
-    // updated_at when claim_labeled_at is unavailable (timeline fetch
-    // failure/partial response), matching the pre-#4618 fail-open posture.
-    match pr.claim_labeled_at.or(pr.updated_at) {
+    // Anchor on max(claim_labeled_at, most_recent_substantive_comment_at)
+    // (Issue #4638) -- neither can be self-refreshed by a marker-tagged
+    // stand-down comment the way updated_at can, but a genuine comment DOES
+    // refresh the anchor, restoring the protection a non-pid-joinable but
+    // genuinely live claimant needs. Only fall back to updated_at when BOTH
+    // are unavailable (timeline fetch failure/partial response, or no
+    // comment evidence at all), matching the pre-#4618 fail-open posture.
+    let anchor = match (pr.claim_labeled_at, pr.most_recent_substantive_comment_at) {
+        (Some(a), Some(b)) => Some(a.max(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => pr.updated_at,
+    };
+    match anchor {
         Some(freshness_at) => {
             let age_minutes = (now - freshness_at).num_seconds() as f64 / 60.0;
             if age_minutes >= stale_minutes {
@@ -1016,7 +1078,7 @@ pub mod forge {
     use super::{
         plan, plan_pr, resolve_no_progress_grace_minutes, resolve_stale_hours, BuildingIssue,
         ClaimedPr, NoProgressEvidence, PrClaimKind, PrReclaimReason, PrReconcileAction,
-        ReclaimReason, ReconcileAction, MAX_ISSUES_PER_WORKSPACE,
+        ReclaimReason, ReconcileAction, MAX_ISSUES_PER_WORKSPACE, STANDDOWN_MARKER_PREFIX,
     };
     use crate::sweep_journal;
     use anyhow::{anyhow, Context, Result};
@@ -1298,6 +1360,13 @@ pub mod forge {
             .into_iter()
             .map(|r| {
                 let claim_labeled_at = fetch_claim_labeled_at(gh_bin, root, r.number, label);
+                // Issue #4638: only worth fetching when there is a
+                // claim_labeled_at to compare against -- with no anchor at
+                // all, decide_pr falls back to updated_at, which GitHub
+                // already keeps at least as fresh as any comment.
+                let most_recent_substantive_comment_at = claim_labeled_at.and_then(|since| {
+                    fetch_most_recent_substantive_comment_at(gh_bin, root, r.number, since)
+                });
                 ClaimedPr {
                     number: r.number,
                     updated_at: r
@@ -1306,6 +1375,7 @@ pub mod forge {
                         .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
                         .map(|dt| dt.with_timezone(&chrono::Utc)),
                     claim_labeled_at,
+                    most_recent_substantive_comment_at,
                     head_ref_name: r.head_ref_name,
                 }
             })
@@ -1334,6 +1404,55 @@ pub mod forge {
             .arg("--jq")
             .arg(format!(
                 r#"[.[] | select(.event == "labeled" and .label.name == "{label}") | .created_at] | max // empty"#
+            ));
+        cmd.current_dir(root);
+        if let Ok(repo) = std::env::var("LOOM_REPO") {
+            cmd.arg("--repo").arg(repo);
+        }
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let out = cmd.output().ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let raw = String::from_utf8_lossy(&out.stdout);
+        let trimmed = raw.trim();
+        if trimmed.is_empty() || trimmed == "null" {
+            return None;
+        }
+        let unquoted = trimmed.trim_matches('"');
+        chrono::DateTime::parse_from_rfc3339(unquoted)
+            .ok()
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+    }
+
+    /// Best-effort fetch of the most recent **substantive** (non-stand-down)
+    /// comment posted on `pr_number` after `since` (Issue #4638) —
+    /// [`ClaimedPr::most_recent_substantive_comment_at`], the evidence
+    /// [`decide_pr`]'s age gate uses alongside `claim_labeled_at` to avoid
+    /// reclaiming a genuinely live, non-pid-joinable claimant. A comment
+    /// whose body contains [`STANDDOWN_MARKER_PREFIX`] is excluded — mirrors
+    /// judge.md/doctor.md's own `COMMENTS_AFTER` marker exclusion. Returns
+    /// `None` on any failure/timeout/unparseable-output, or when every
+    /// comment since `since` was marker-tagged (or there were none) —
+    /// callers then fall back to `claim_labeled_at`/`updated_at` alone,
+    /// preserving the #4618 regression guard (a claim with only stand-down
+    /// comments since must still age out and be reclaimed).
+    fn fetch_most_recent_substantive_comment_at(
+        gh_bin: &Path,
+        root: &Path,
+        pr_number: u32,
+        since: DateTime<Utc>,
+    ) -> Option<DateTime<Utc>> {
+        let since_iso = since.to_rfc3339();
+        let mut cmd = Command::new(gh_bin);
+        cmd.arg("pr")
+            .arg("view")
+            .arg(pr_number.to_string())
+            .arg("--json")
+            .arg("comments")
+            .arg("--jq")
+            .arg(format!(
+                r#"[.comments[] | select(.createdAt > "{since_iso}") | select(.body | contains("{STANDDOWN_MARKER_PREFIX}") | not) | .createdAt] | max // empty"#
             ));
         cmd.current_dir(root);
         if let Ok(repo) = std::env::var("LOOM_REPO") {
@@ -2668,14 +2787,16 @@ exit 0
         updated_at: Option<DateTime<Utc>>,
         head_ref_name: Option<&str>,
     ) -> ClaimedPr {
-        // claim_labeled_at intentionally left unset here so every existing
-        // caller of this helper keeps exercising the pre-#4618
-        // updated_at-only fallback path unchanged; the #4618 regression test
-        // below constructs `ClaimedPr` directly to set it.
+        // claim_labeled_at/most_recent_substantive_comment_at intentionally
+        // left unset here so every existing caller of this helper keeps
+        // exercising the pre-#4618 updated_at-only fallback path unchanged;
+        // the #4618/#4638 regression tests below construct `ClaimedPr`
+        // directly to set them.
         ClaimedPr {
             number,
             updated_at,
             claim_labeled_at: None,
+            most_recent_substantive_comment_at: None,
             head_ref_name: head_ref_name.map(ToString::to_string),
         }
     }
@@ -2812,6 +2933,7 @@ exit 0
             number: 4614,
             updated_at: Some(standdown_inflated),
             claim_labeled_at: Some(claimed_at),
+            most_recent_substantive_comment_at: None,
             head_ref_name: Some("some-doctor-branch".to_string()),
         };
         let action = decide_pr(&pr, None, None, &|_| true, 30.0, now);
@@ -2843,6 +2965,7 @@ exit 0
             number: 4615,
             updated_at: Some(stale_updated_at),
             claim_labeled_at: Some(recent_claim),
+            most_recent_substantive_comment_at: None,
             head_ref_name: None,
         };
         let action = decide_pr(&pr, None, None, &|_| true, 30.0, now);
@@ -2865,6 +2988,67 @@ exit 0
         match action {
             PrReconcileAction::Reclaim(PrReclaimReason::Aged { .. }) => {}
             other => panic!("expected fallback-to-updated_at Aged reclaim, got {other:?}"),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // decide_pr: most_recent_substantive_comment_at anchor (Issue #4638 —
+    // restoring protection for a genuinely live, non-pid-joinable claimant
+    // after #4618 anchored solely on claim_labeled_at)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn decide_pr_keeps_when_old_claim_labeled_at_but_recent_genuine_comment() {
+        // The exact #4638 shape: claim_labeled_at is 35 minutes old (past the
+        // 30-minute threshold) and the PR is not pid-joinable (no journal
+        // entry, no run-registry pid), but a genuine (non-marker) progress
+        // comment was posted 1 minute ago -- most_recent_substantive_comment_at
+        // must refresh the anchor and the claim must be kept, not reclaimed
+        // out from under a still-working claimant.
+        let now = Utc::now();
+        let claimed_at = now - Duration::minutes(35);
+        let recent_genuine_comment = now - Duration::minutes(1);
+        let pr = ClaimedPr {
+            number: 4638,
+            updated_at: Some(claimed_at),
+            claim_labeled_at: Some(claimed_at),
+            most_recent_substantive_comment_at: Some(recent_genuine_comment),
+            head_ref_name: Some("pr-worktree-review-branch".to_string()),
+        };
+        let action = decide_pr(&pr, None, None, &|_| true, 30.0, now);
+        assert_eq!(
+            action,
+            PrReconcileAction::Keep,
+            "a genuine recent comment must refresh the anchor and prevent reclaim"
+        );
+    }
+
+    #[test]
+    fn decide_pr_reclaims_when_old_claim_labeled_at_and_only_standdown_comments_since() {
+        // Regression guard for #4618: the caller-side comment fetch excludes
+        // marker-tagged stand-down comments, so a claim whose only comments
+        // since the claim are stand-down notes surfaces
+        // most_recent_substantive_comment_at == None here (exactly like no
+        // comments at all) -- the anchor must fall back to claim_labeled_at
+        // alone and the stale claim must still be reclaimed. This is the
+        // #4618 livelock this fix must not reopen.
+        let now = Utc::now();
+        let claimed_at = now - Duration::minutes(35);
+        let pr = ClaimedPr {
+            number: 4618,
+            updated_at: Some(now - Duration::seconds(5)),
+            claim_labeled_at: Some(claimed_at),
+            most_recent_substantive_comment_at: None,
+            head_ref_name: Some("some-doctor-branch".to_string()),
+        };
+        let action = decide_pr(&pr, None, None, &|_| true, 30.0, now);
+        match action {
+            PrReconcileAction::Reclaim(PrReclaimReason::Aged { age_minutes }) => {
+                assert!(age_minutes >= 30.0);
+            }
+            other => panic!(
+                "expected Aged reclaim -- marker-only comments must not refresh the anchor, got {other:?}"
+            ),
         }
     }
 

--- a/loom-daemon/src/claim_reconciliation.rs
+++ b/loom-daemon/src/claim_reconciliation.rs
@@ -1400,15 +1400,35 @@ pub mod forge {
         if !out.status.success() {
             return None;
         }
-        let raw = String::from_utf8_lossy(&out.stdout);
-        let trimmed = raw.trim();
-        if trimmed.is_empty() || trimmed == "null" {
-            return None;
-        }
-        let unquoted = trimmed.trim_matches('"');
-        chrono::DateTime::parse_from_rfc3339(unquoted)
-            .ok()
-            .map(|dt| dt.with_timezone(&chrono::Utc))
+        parse_max_timestamp(&out.stdout)
+    }
+
+    /// Parse a `gh api --paginate --jq '... | max // empty'` result into the
+    /// maximum RFC-3339 timestamp across every line of output. `--paginate`
+    /// re-invokes the `--jq` filter once per page and concatenates the
+    /// per-page results rather than applying the filter across the combined
+    /// set (Issue #4637) — on a timeline spanning more than one page (>100
+    /// events) this yields one `max`-per-page line, not a single overall
+    /// max. Each non-empty/non-`null` line (bare or JSON-quoted) is parsed
+    /// independently and the maximum across all lines is returned; a
+    /// single-line result (the common case) is handled identically to
+    /// before. Returns `None` when there is no parseable timestamp on any
+    /// line — the same fail-open contract as the pre-#4637 single-line
+    /// parse.
+    pub(crate) fn parse_max_timestamp(stdout: &[u8]) -> Option<DateTime<Utc>> {
+        let raw = String::from_utf8_lossy(stdout);
+        raw.lines()
+            .filter_map(|line| {
+                let trimmed = line.trim();
+                if trimmed.is_empty() || trimmed == "null" {
+                    return None;
+                }
+                let unquoted = trimmed.trim_matches('"');
+                chrono::DateTime::parse_from_rfc3339(unquoted)
+                    .ok()
+                    .map(|dt| dt.with_timezone(&chrono::Utc))
+            })
+            .max()
     }
 
     /// The PR's currently-applied state labels (a best-effort subset of
@@ -3207,5 +3227,59 @@ exit 0
         std::env::remove_var(sweep_journal::JOURNAL_PATH_ENV);
         std::env::remove_var(STALE_REVIEWING_MINUTES_ENV);
         std::env::remove_var(STALE_TREATING_MINUTES_ENV);
+    }
+
+    // Issue #4637: `gh api --paginate --jq` re-invokes the `--jq` filter once
+    // per page and concatenates the per-page results, so a `max // empty`
+    // filter against a timeline spanning more than one page (>100 events)
+    // yields one line per page rather than a single overall max.
+    // `parse_max_timestamp` must resolve the true max across every line.
+
+    #[test]
+    fn parse_max_timestamp_single_line_bare() {
+        let stdout = b"2026-01-01T00:00:00Z\n";
+        let parsed = forge::parse_max_timestamp(stdout).unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-01-01T00:00:00+00:00");
+    }
+
+    #[test]
+    fn parse_max_timestamp_multi_page_picks_max_out_of_order() {
+        // Three pages' worth of per-page `max` lines, deliberately not in
+        // chronological order, mirroring what `--paginate` concatenation
+        // actually produces.
+        let stdout = b"2026-01-01T00:00:00Z\n2026-03-15T12:30:00Z\n2026-02-01T00:00:00Z\n";
+        let parsed = forge::parse_max_timestamp(stdout).unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-03-15T12:30:00+00:00");
+    }
+
+    #[test]
+    fn parse_max_timestamp_multi_page_skips_empty_and_null_lines() {
+        // A page with no matching event emits an empty line (the `// empty`
+        // fallback) or a literal `null`; both must be ignored, not treated
+        // as "no timestamp anywhere".
+        let stdout = b"\n2026-05-05T05:05:05Z\nnull\n";
+        let parsed = forge::parse_max_timestamp(stdout).unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-05-05T05:05:05+00:00");
+    }
+
+    #[test]
+    fn parse_max_timestamp_returns_none_for_empty_output() {
+        assert!(forge::parse_max_timestamp(b"").is_none());
+        assert!(forge::parse_max_timestamp(b"\n\n").is_none());
+        assert!(forge::parse_max_timestamp(b"null\n").is_none());
+        assert!(forge::parse_max_timestamp(b"null\nnull\n").is_none());
+    }
+
+    #[test]
+    fn parse_max_timestamp_returns_none_for_garbage() {
+        assert!(forge::parse_max_timestamp(b"not-a-timestamp\n").is_none());
+        assert!(forge::parse_max_timestamp(b"not-a-timestamp\nalso-not-one\n").is_none());
+    }
+
+    #[test]
+    fn parse_max_timestamp_handles_json_quoted_lines() {
+        let stdout = b"\"2026-01-01T00:00:00Z\"\n\"2026-06-06T06:06:06Z\"\n";
+        let parsed = forge::parse_max_timestamp(stdout).unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-06-06T06:06:06+00:00");
     }
 }

--- a/loom-daemon/src/claim_reconciliation.rs
+++ b/loom-daemon/src/claim_reconciliation.rs
@@ -86,6 +86,25 @@
 //!   re-applies the label, so `claim_labeled_at` cannot be bumped that way.
 //!   `updated_at` remains the fail-open fallback for when the timeline fetch
 //!   failed or found nothing.
+//! - **Genuine comment activity also refreshes the anchor (Issue #4638).**
+//!   Anchoring solely on `claim_labeled_at` fixed #4618's self-perpetuating
+//!   livelock, but it also removed the only protection a claim previously had
+//!   when it is *not* pid-joinable (no journal entry, no run-registry join,
+//!   and a `headRefName` that doesn't match `feature/issue-<N>`) — a
+//!   claimant genuinely reviewing/fixing for 35+ minutes while posting real
+//!   progress comments would have its claim reclaimed out from under it,
+//!   because `claim_labeled_at` itself only moves on a label re-application.
+//!   [`decide_pr`]'s age gate therefore anchors on
+//!   `max(claim_labeled_at, most_recent_substantive_comment_at)`
+//!   ([`ClaimedPr::most_recent_substantive_comment_at`]) — a genuine (i.e.
+//!   non-marker) comment posted after the claim refreshes the anchor exactly
+//!   like a real re-claim would, while a marker-tagged stand-down comment
+//!   (`<!-- loom:standdown claim=... -->`, [`STANDDOWN_MARKER_PREFIX`]) is
+//!   excluded from that signal the same way judge.md/doctor.md's own
+//!   `COMMENTS_AFTER` check excludes it — so the #4618 fix is preserved
+//!   (marked stand-down comments still cannot self-refresh the anchor) while
+//!   a genuinely live, non-pid-joinable claimant is no longer reclaimed out
+//!   from under it.
 //!
 //! Reclaiming removes only the stale claim label (the state label restores
 //! discoverability by itself); as a safety net, if the PR is then left
@@ -631,6 +650,15 @@ impl PrClaimKind {
     }
 }
 
+/// Marker (Issue #4636/#4618) tagging a Judge/Doctor "standing down, not
+/// stomping" comment — evidence of *no* progress (a later pass declining to
+/// reclaim), not genuine activity. A comment containing this substring is
+/// excluded from [`ClaimedPr::most_recent_substantive_comment_at`] (Issue
+/// #4638), mirroring `judge.md`/`doctor.md`'s own `COMMENTS_AFTER` exclusion
+/// (a substring match, not an exact marker+claim-timestamp match, so any
+/// stand-down comment for any claim generation is excluded).
+pub const STANDDOWN_MARKER_PREFIX: &str = "<!-- loom:standdown claim=";
+
 /// An open PR carrying a `loom:reviewing`/`loom:treating` claim label,
 /// trimmed to the fields the reconciliation decision needs.
 #[derive(Debug, Clone, PartialEq)]
@@ -653,6 +681,22 @@ pub struct ClaimedPr {
     /// then fall back to [`Self::updated_at`], preserving pre-#4618 behavior
     /// for that fail-open case.
     pub claim_labeled_at: Option<DateTime<Utc>>,
+    /// Timestamp of the most recent **substantive** (non-stand-down) comment
+    /// posted since [`Self::claim_labeled_at`] (Issue #4638), when
+    /// resolvable. A comment whose body contains [`STANDDOWN_MARKER_PREFIX`]
+    /// is excluded — it evidences a later pass declining to reclaim, not
+    /// activity by the claimant. [`decide_pr`] anchors its age gate on
+    /// `max(claim_labeled_at, most_recent_substantive_comment_at)`, so a
+    /// claimant that is not pid-joinable but is genuinely posting progress
+    /// comments is not reclaimed out from under it purely because
+    /// `claim_labeled_at` itself has aged. `None` when there is no
+    /// `claim_labeled_at` to compare against, the comment fetch failed, or
+    /// every comment since the claim was a marker-tagged stand-down note —
+    /// callers then fall back to `claim_labeled_at`/`updated_at` alone,
+    /// preserving pre-#4638 behavior for that case (including the #4618
+    /// regression guard: a claim with only stand-down comments since must
+    /// still be reclaimed once stale).
+    pub most_recent_substantive_comment_at: Option<DateTime<Utc>>,
     /// The PR's head branch name, when available — the only join key to an
     /// issue number this pass has (see [`parse_issue_from_branch`]).
     pub head_ref_name: Option<String>,
@@ -710,19 +754,28 @@ pub fn parse_issue_from_branch(head_ref_name: &str) -> Option<u32> {
 /// `run_registry_pid` is the caller's join result, consulted only when
 /// `journal_entry` is absent, exactly like [`decide`].
 ///
-/// **Age-gate freshness signal (Issue #4618)**: the age gate below prefers
-/// `pr.claim_labeled_at` (the claim label's own most recent `labeled`
-/// timeline event) over `pr.updated_at` (the PR's aggregate "last modified"
-/// timestamp). Before this fix, `updated_at` was the sole signal, and GitHub
-/// bumps it on ANY comment — including a Judge/Doctor "standing down, not
-/// stomping" comment posted by a later pass declining to reclaim. That made
-/// the check perpetually self-refreshing: each stand-down comment satisfied
-/// the very freshness test the next pass ran, so a claim could survive past
-/// the staleness window once and then never be reclaimed again (PR #4614).
-/// `claim_labeled_at` cannot be bumped that way — it only changes when the
-/// label is genuinely re-applied — so it is used whenever resolvable, with
-/// `updated_at` kept only as the fail-open fallback for when the timeline
-/// fetch itself failed or returned nothing (same fail-safe posture as the
+/// **Age-gate freshness signal (Issue #4618, refined by #4638)**: the age
+/// gate below anchors on
+/// `max(pr.claim_labeled_at, pr.most_recent_substantive_comment_at)`,
+/// falling back to `pr.updated_at` only when BOTH are unavailable.
+/// `claim_labeled_at` (the claim label's own most recent `labeled` timeline
+/// event) replaced `updated_at` as the primary signal in #4618: before that
+/// fix, `updated_at` was the sole signal, and GitHub bumps it on ANY comment
+/// — including a Judge/Doctor "standing down, not stomping" comment posted
+/// by a later pass declining to reclaim. That made the check perpetually
+/// self-refreshing: each stand-down comment satisfied the very freshness
+/// test the next pass ran, so a claim could survive past the staleness
+/// window once and then never be reclaimed again (PR #4614). But anchoring
+/// solely on `claim_labeled_at` also removed the only protection a claim had
+/// when it is not pid-joinable: a claimant genuinely working for 35+ minutes
+/// while posting real progress comments would be reclaimed anyway, since
+/// `claim_labeled_at` itself only moves on a label re-application (#4638).
+/// `most_recent_substantive_comment_at` restores that protection — a
+/// genuine (non-marker) comment posted after the claim refreshes the anchor
+/// — while marker-tagged stand-down comments remain excluded from it, so the
+/// #4618 fix holds (a claim with only stand-down comments since still ages
+/// out and is reclaimed). `updated_at` remains the final fail-open fallback
+/// for when neither signal is available (same fail-safe posture as the
 /// pre-#4618 `None` branch below).
 #[must_use]
 pub fn decide_pr(
@@ -755,11 +808,20 @@ pub fn decide_pr(
     // proof here: the PR->issue join is heuristic, so only *aged* absence (or
     // aged dead-pid evidence) triggers a reclaim.
     //
-    // Prefer claim_labeled_at (Issue #4618) -- it cannot be self-refreshed by
-    // a stand-down comment the way updated_at can. Only fall back to
-    // updated_at when claim_labeled_at is unavailable (timeline fetch
-    // failure/partial response), matching the pre-#4618 fail-open posture.
-    match pr.claim_labeled_at.or(pr.updated_at) {
+    // Anchor on max(claim_labeled_at, most_recent_substantive_comment_at)
+    // (Issue #4638) -- neither can be self-refreshed by a marker-tagged
+    // stand-down comment the way updated_at can, but a genuine comment DOES
+    // refresh the anchor, restoring the protection a non-pid-joinable but
+    // genuinely live claimant needs. Only fall back to updated_at when BOTH
+    // are unavailable (timeline fetch failure/partial response, or no
+    // comment evidence at all), matching the pre-#4618 fail-open posture.
+    let anchor = match (pr.claim_labeled_at, pr.most_recent_substantive_comment_at) {
+        (Some(a), Some(b)) => Some(a.max(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => pr.updated_at,
+    };
+    match anchor {
         Some(freshness_at) => {
             let age_minutes = (now - freshness_at).num_seconds() as f64 / 60.0;
             if age_minutes >= stale_minutes {
@@ -1048,7 +1110,7 @@ pub mod forge {
         apply_live_claim_veto, plan, plan_pr, resolve_no_progress_grace_minutes,
         resolve_stale_hours, BuildingIssue, ClaimedPr, NoProgressEvidence, PrClaimKind,
         PrReclaimReason, PrReconcileAction, ReclaimReason, ReconcileAction,
-        MAX_ISSUES_PER_WORKSPACE,
+        MAX_ISSUES_PER_WORKSPACE, STANDDOWN_MARKER_PREFIX,
     };
     use crate::sweep_journal;
     use anyhow::{anyhow, Context, Result};
@@ -1354,6 +1416,13 @@ pub mod forge {
             .into_iter()
             .map(|r| {
                 let claim_labeled_at = fetch_claim_labeled_at(gh_bin, root, r.number, label);
+                // Issue #4638: only worth fetching when there is a
+                // claim_labeled_at to compare against -- with no anchor at
+                // all, decide_pr falls back to updated_at, which GitHub
+                // already keeps at least as fresh as any comment.
+                let most_recent_substantive_comment_at = claim_labeled_at.and_then(|since| {
+                    fetch_most_recent_substantive_comment_at(gh_bin, root, r.number, since)
+                });
                 ClaimedPr {
                     number: r.number,
                     updated_at: r
@@ -1362,6 +1431,7 @@ pub mod forge {
                         .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
                         .map(|dt| dt.with_timezone(&chrono::Utc)),
                     claim_labeled_at,
+                    most_recent_substantive_comment_at,
                     head_ref_name: r.head_ref_name,
                 }
             })
@@ -1429,6 +1499,55 @@ pub mod forge {
                     .map(|dt| dt.with_timezone(&chrono::Utc))
             })
             .max()
+    }
+
+    /// Best-effort fetch of the most recent **substantive** (non-stand-down)
+    /// comment posted on `pr_number` after `since` (Issue #4638) —
+    /// [`ClaimedPr::most_recent_substantive_comment_at`], the evidence
+    /// [`decide_pr`]'s age gate uses alongside `claim_labeled_at` to avoid
+    /// reclaiming a genuinely live, non-pid-joinable claimant. A comment
+    /// whose body contains [`STANDDOWN_MARKER_PREFIX`] is excluded — mirrors
+    /// judge.md/doctor.md's own `COMMENTS_AFTER` marker exclusion. Returns
+    /// `None` on any failure/timeout/unparseable-output, or when every
+    /// comment since `since` was marker-tagged (or there were none) —
+    /// callers then fall back to `claim_labeled_at`/`updated_at` alone,
+    /// preserving the #4618 regression guard (a claim with only stand-down
+    /// comments since must still age out and be reclaimed).
+    fn fetch_most_recent_substantive_comment_at(
+        gh_bin: &Path,
+        root: &Path,
+        pr_number: u32,
+        since: DateTime<Utc>,
+    ) -> Option<DateTime<Utc>> {
+        let since_iso = since.to_rfc3339();
+        let mut cmd = Command::new(gh_bin);
+        cmd.arg("pr")
+            .arg("view")
+            .arg(pr_number.to_string())
+            .arg("--json")
+            .arg("comments")
+            .arg("--jq")
+            .arg(format!(
+                r#"[.comments[] | select(.createdAt > "{since_iso}") | select(.body | contains("{STANDDOWN_MARKER_PREFIX}") | not) | .createdAt] | max // empty"#
+            ));
+        cmd.current_dir(root);
+        if let Ok(repo) = std::env::var("LOOM_REPO") {
+            cmd.arg("--repo").arg(repo);
+        }
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let out = cmd.output().ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let raw = String::from_utf8_lossy(&out.stdout);
+        let trimmed = raw.trim();
+        if trimmed.is_empty() || trimmed == "null" {
+            return None;
+        }
+        let unquoted = trimmed.trim_matches('"');
+        chrono::DateTime::parse_from_rfc3339(unquoted)
+            .ok()
+            .map(|dt| dt.with_timezone(&chrono::Utc))
     }
 
     /// The PR's currently-applied state labels (a best-effort subset of
@@ -2795,14 +2914,16 @@ exit 0
         updated_at: Option<DateTime<Utc>>,
         head_ref_name: Option<&str>,
     ) -> ClaimedPr {
-        // claim_labeled_at intentionally left unset here so every existing
-        // caller of this helper keeps exercising the pre-#4618
-        // updated_at-only fallback path unchanged; the #4618 regression test
-        // below constructs `ClaimedPr` directly to set it.
+        // claim_labeled_at/most_recent_substantive_comment_at intentionally
+        // left unset here so every existing caller of this helper keeps
+        // exercising the pre-#4618 updated_at-only fallback path unchanged;
+        // the #4618/#4638 regression tests below construct `ClaimedPr`
+        // directly to set them.
         ClaimedPr {
             number,
             updated_at,
             claim_labeled_at: None,
+            most_recent_substantive_comment_at: None,
             head_ref_name: head_ref_name.map(ToString::to_string),
         }
     }
@@ -2939,6 +3060,7 @@ exit 0
             number: 4614,
             updated_at: Some(standdown_inflated),
             claim_labeled_at: Some(claimed_at),
+            most_recent_substantive_comment_at: None,
             head_ref_name: Some("some-doctor-branch".to_string()),
         };
         let action = decide_pr(&pr, None, None, &|_| true, 30.0, now);
@@ -2970,6 +3092,7 @@ exit 0
             number: 4615,
             updated_at: Some(stale_updated_at),
             claim_labeled_at: Some(recent_claim),
+            most_recent_substantive_comment_at: None,
             head_ref_name: None,
         };
         let action = decide_pr(&pr, None, None, &|_| true, 30.0, now);
@@ -2992,6 +3115,67 @@ exit 0
         match action {
             PrReconcileAction::Reclaim(PrReclaimReason::Aged { .. }) => {}
             other => panic!("expected fallback-to-updated_at Aged reclaim, got {other:?}"),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // decide_pr: most_recent_substantive_comment_at anchor (Issue #4638 —
+    // restoring protection for a genuinely live, non-pid-joinable claimant
+    // after #4618 anchored solely on claim_labeled_at)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn decide_pr_keeps_when_old_claim_labeled_at_but_recent_genuine_comment() {
+        // The exact #4638 shape: claim_labeled_at is 35 minutes old (past the
+        // 30-minute threshold) and the PR is not pid-joinable (no journal
+        // entry, no run-registry pid), but a genuine (non-marker) progress
+        // comment was posted 1 minute ago -- most_recent_substantive_comment_at
+        // must refresh the anchor and the claim must be kept, not reclaimed
+        // out from under a still-working claimant.
+        let now = Utc::now();
+        let claimed_at = now - Duration::minutes(35);
+        let recent_genuine_comment = now - Duration::minutes(1);
+        let pr = ClaimedPr {
+            number: 4638,
+            updated_at: Some(claimed_at),
+            claim_labeled_at: Some(claimed_at),
+            most_recent_substantive_comment_at: Some(recent_genuine_comment),
+            head_ref_name: Some("pr-worktree-review-branch".to_string()),
+        };
+        let action = decide_pr(&pr, None, None, &|_| true, 30.0, now);
+        assert_eq!(
+            action,
+            PrReconcileAction::Keep,
+            "a genuine recent comment must refresh the anchor and prevent reclaim"
+        );
+    }
+
+    #[test]
+    fn decide_pr_reclaims_when_old_claim_labeled_at_and_only_standdown_comments_since() {
+        // Regression guard for #4618: the caller-side comment fetch excludes
+        // marker-tagged stand-down comments, so a claim whose only comments
+        // since the claim are stand-down notes surfaces
+        // most_recent_substantive_comment_at == None here (exactly like no
+        // comments at all) -- the anchor must fall back to claim_labeled_at
+        // alone and the stale claim must still be reclaimed. This is the
+        // #4618 livelock this fix must not reopen.
+        let now = Utc::now();
+        let claimed_at = now - Duration::minutes(35);
+        let pr = ClaimedPr {
+            number: 4618,
+            updated_at: Some(now - Duration::seconds(5)),
+            claim_labeled_at: Some(claimed_at),
+            most_recent_substantive_comment_at: None,
+            head_ref_name: Some("some-doctor-branch".to_string()),
+        };
+        let action = decide_pr(&pr, None, None, &|_| true, 30.0, now);
+        match action {
+            PrReconcileAction::Reclaim(PrReclaimReason::Aged { age_minutes }) => {
+                assert!(age_minutes >= 30.0);
+            }
+            other => panic!(
+                "expected Aged reclaim -- marker-only comments must not refresh the anchor, got {other:?}"
+            ),
         }
     }
 

--- a/loom-daemon/src/claim_reconciliation.rs
+++ b/loom-daemon/src/claim_reconciliation.rs
@@ -1519,7 +1519,13 @@ pub mod forge {
         pr_number: u32,
         since: DateTime<Utc>,
     ) -> Option<DateTime<Utc>> {
-        let since_iso = since.to_rfc3339();
+        // Render `since` in exactly the shape the forge emits for `createdAt`
+        // (`...Z`, second precision) so the jq `>` comparison — which is a raw
+        // *string* comparison — orders correctly. `to_rfc3339()` would render
+        // the same instant with a `+00:00` offset suffix, which sorts *before*
+        // a `Z`-suffixed timestamp of the identical second and so would
+        // misclassify a comment posted in the same second as the claim label.
+        let since_iso = since.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
         let mut cmd = Command::new(gh_bin);
         cmd.arg("pr")
             .arg("view")

--- a/loom-daemon/src/quarantine_reconciliation.rs
+++ b/loom-daemon/src/quarantine_reconciliation.rs
@@ -296,17 +296,30 @@ pub mod forge {
 
     /// Parse a `gh --jq` scalar result that is either a bare RFC-3339
     /// timestamp or a JSON-quoted one, tolerating an empty/`null` result
-    /// (no match).
-    fn parse_timestamp(stdout: &[u8]) -> Option<DateTime<Utc>> {
+    /// (no match). Also tolerates multi-line output: `gh api --paginate`
+    /// re-invokes `--jq` once per page and concatenates the per-page
+    /// results, so a filter like `max // empty` run against a timeline
+    /// spanning more than one page (>100 events, as
+    /// [`fetch_last_blocked_labeled_at`] queries) yields one `max`-per-page
+    /// line rather than a single overall max (Issue #4637). Each
+    /// non-empty/non-`null` line is parsed independently and the maximum
+    /// across all lines is returned; a single-line result (e.g. from
+    /// [`fetch_last_quarantine_comment_at`]'s non-paginated `gh issue view`)
+    /// is handled identically to before.
+    pub(crate) fn parse_timestamp(stdout: &[u8]) -> Option<DateTime<Utc>> {
         let raw = String::from_utf8_lossy(stdout);
-        let trimmed = raw.trim();
-        if trimmed.is_empty() || trimmed == "null" {
-            return None;
-        }
-        let unquoted = trimmed.trim_matches('"');
-        DateTime::parse_from_rfc3339(unquoted)
-            .ok()
-            .map(|dt| dt.with_timezone(&Utc))
+        raw.lines()
+            .filter_map(|line| {
+                let trimmed = line.trim();
+                if trimmed.is_empty() || trimmed == "null" {
+                    return None;
+                }
+                let unquoted = trimmed.trim_matches('"');
+                DateTime::parse_from_rfc3339(unquoted)
+                    .ok()
+                    .map(|dt| dt.with_timezone(&Utc))
+            })
+            .max()
     }
 
     /// Best-effort, single-issue check of whether `issue`'s current
@@ -711,5 +724,55 @@ exit 0
         let (checked, released) = forge::reconcile_workspace(&fake_gh, &repo_root);
         assert_eq!(checked, 0);
         assert_eq!(released, 0);
+    }
+
+    // Issue #4637: `gh api --paginate --jq` re-invokes the `--jq` filter once
+    // per page and concatenates the per-page results, so a `max // empty`
+    // filter against `fetch_last_blocked_labeled_at`'s paginated timeline
+    // query yields one line per page (>100 events) rather than a single
+    // overall max. `parse_timestamp` must resolve the true max across every
+    // line, while still handling the single-line result
+    // `fetch_last_quarantine_comment_at`'s non-paginated query always
+    // produces.
+
+    #[test]
+    fn parse_timestamp_single_line_bare() {
+        let parsed = forge::parse_timestamp(b"2026-01-01T00:00:00Z\n").unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-01-01T00:00:00+00:00");
+    }
+
+    #[test]
+    fn parse_timestamp_multi_page_picks_max_out_of_order() {
+        let stdout = b"2026-01-01T00:00:00Z\n2026-03-15T12:30:00Z\n2026-02-01T00:00:00Z\n";
+        let parsed = forge::parse_timestamp(stdout).unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-03-15T12:30:00+00:00");
+    }
+
+    #[test]
+    fn parse_timestamp_multi_page_skips_empty_and_null_lines() {
+        let stdout = b"\n2026-05-05T05:05:05Z\nnull\n";
+        let parsed = forge::parse_timestamp(stdout).unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-05-05T05:05:05+00:00");
+    }
+
+    #[test]
+    fn parse_timestamp_returns_none_for_empty_output() {
+        assert!(forge::parse_timestamp(b"").is_none());
+        assert!(forge::parse_timestamp(b"\n\n").is_none());
+        assert!(forge::parse_timestamp(b"null\n").is_none());
+        assert!(forge::parse_timestamp(b"null\nnull\n").is_none());
+    }
+
+    #[test]
+    fn parse_timestamp_returns_none_for_garbage() {
+        assert!(forge::parse_timestamp(b"not-a-timestamp\n").is_none());
+        assert!(forge::parse_timestamp(b"not-a-timestamp\nalso-not-one\n").is_none());
+    }
+
+    #[test]
+    fn parse_timestamp_handles_json_quoted_lines() {
+        let stdout = b"\"2026-01-01T00:00:00Z\"\n\"2026-06-06T06:06:06Z\"\n";
+        let parsed = forge::parse_timestamp(stdout).unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-06-06T06:06:06+00:00");
     }
 }


### PR DESCRIPTION
## Summary

`decide_pr`'s freshness/age gate (PR #4636, fixing #4618) anchors solely on
`pr.claim_labeled_at.or(pr.updated_at)`. That correctly broke the
self-perpetuating stand-down-comment livelock, but it also removed the only
protection a genuinely live claimant had when the PR is not pid-joinable (no
journal entry, no run-registry join, and a `headRefName` that isn't
`feature/issue-<N>`, e.g. a `pr-worktree.sh` review branch): `claim_labeled_at`
only moves when the claim label is re-applied, so a claimant actively
reviewing/fixing for 35+ minutes while posting real progress comments would be
reclaimed out from under it, purely because the label itself has aged.

This PR anchors the age gate on
`max(claim_labeled_at, most_recent_substantive_comment_at)`, where the new
`most_recent_substantive_comment_at` signal excludes marker-tagged stand-down
comments (`<!-- loom:standdown claim=... -->`, from #4636) the same way
`judge.md`/`doctor.md`'s own `COMMENTS_AFTER` check excludes them. A genuine
comment refreshes the anchor (restoring the pre-#4618 protection); a
stand-down-only comment stream still ages out and is reclaimed (preserving the
#4618 fix).

## Changes

- `loom-daemon/src/claim_reconciliation.rs`
  - Added `STANDDOWN_MARKER_PREFIX` constant (the marker string from #4636).
  - Added `ClaimedPr::most_recent_substantive_comment_at: Option<DateTime<Utc>>`.
  - `decide_pr`'s age gate now anchors on
    `max(claim_labeled_at, most_recent_substantive_comment_at)`, falling back
    to `updated_at` only when both are unavailable.
  - `forge::list_prs_with_label` fetches the new signal via
    `fetch_most_recent_substantive_comment_at` (a `gh pr view --json comments
    --jq ...` call, run only when `claim_labeled_at` resolved — one extra call
    per claim-labeled PR), which filters out marker-tagged comments and
    comments before the claim.
  - Updated module docs and existing test fixtures/constructions for the new
    field.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Age gate anchors on `max(claim_labeled_at, most_recent_substantive_comment)` | ✅ | `decide_pr` now computes this max before comparing against `stale_minutes` |
| "Substantive" excludes stand-down/reclaim marker comments | ✅ | `fetch_most_recent_substantive_comment_at`'s jq filter excludes any comment body containing `STANDDOWN_MARKER_PREFIX` |
| #4618 fix preserved (age still grows monotonically for marker-only comment streams) | ✅ | New regression test `decide_pr_reclaims_when_old_claim_labeled_at_and_only_standdown_comments_since` |
| Genuinely live non-pid-joinable claimant is no longer reclaimed | ✅ | New test `decide_pr_keeps_when_old_claim_labeled_at_but_recent_genuine_comment` |
| Existing `decide_pr`/`reconcile_pr_claims` tests pass unmodified | ✅ | Full `cargo test` run — 2572 passed, 0 failed |

## Test Plan

- [x] Unit test: a claim with old `claim_labeled_at` but a recent genuine
      (non-marker) comment is *not* reclaimed —
      `decide_pr_keeps_when_old_claim_labeled_at_but_recent_genuine_comment`.
- [x] Unit test: a claim with old `claim_labeled_at` and only marker-tagged
      stand-down comments since *is* reclaimed (regression guard for #4618) —
      `decide_pr_reclaims_when_old_claim_labeled_at_and_only_standdown_comments_since`.
- [x] Existing `decide_pr`/`reconcile_pr_claims` tests continue to pass
      unmodified — ran `cargo test --lib` in `loom-daemon`: 2572 passed, 0
      failed. `cargo clippy --all-targets` and `cargo fmt -- --check` clean.

Closes #4638