### PR TITLE
fix(fleet): supervise fleet workers with LOOM_DAEMON_SUPERVISOR and Restart=on-success

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -505,10 +505,13 @@ the plan/ordering/checklist; the per-phase shell is rendered in
 6. **workspace-clone** — `gh repo clone` each `--repo` + `loom-daemon init`
    (installs the `/loom:sweep` command, #4027).
 7. **workspace-register** — `loom-daemon workspace add` each repo at `--priority`.
-8. **daemon-unit** — a systemd `--user` unit (`Restart=on-failure`,
-   `loginctl enable-linger`). `WorkingDirectory=` is pinned to a workspace clone
-   as the **#4292** token-pool-cwd workaround — the rendered unit carries a
-   `#4292` marker so it is removed when that lands.
+8. **daemon-unit** — a systemd `--user` unit (`Restart=on-success`,
+   `Environment=LOOM_DAEMON_SUPERVISOR=systemd`, `loginctl enable-linger`) —
+   mirroring the canonical `render_systemd_unit()` policy in
+   `loom-daemon-start.sh` (#4268) so `restart --drain` (#4090) works on fleet
+   workers (#4640). `WorkingDirectory=` is pinned to a workspace clone as the
+   **#4292** token-pool-cwd workaround — the rendered unit carries a `#4292`
+   marker so it is removed when that lands.
 9. **idle-shutdown** (optional, `--idle-shutdown-minutes N`) — a cron guard that
    powers the host off after N idle minutes. This is stage 2:
    `autonomous.idleExit` is stage 1. On daemon-managed hosts use a short guard
@@ -539,6 +542,25 @@ operator otherwise tracks by hand: `provider_instance_id`, `tailnet_name`,
 `added_by`, and a lifecycle `state` (`fleet drain`'s `"draining"` sentinel,
 #4343) — all `#[serde(default)]`/`Option`, so an older registry file keeps
 parsing.
+
+**Retrofitting a worker provisioned before #4640**: an older `daemon-unit` step
+rendered `Restart=on-failure` with no `LOOM_DAEMON_SUPERVISOR` at all, so
+`loom-daemon restart --drain` refuses on it ("no supervisor detected") even
+though systemd IS managing it. Either re-run `fleet add-worker` against the
+host (the `daemon-unit` step overwrites the unit unconditionally via `cat >`,
+so a re-run fully re-syncs it), or apply a drop-in by hand over ssh without a
+full re-provision:
+
+```bash
+mkdir -p ~/.config/systemd/user/loom-daemon.service.d
+printf '[Service]\nEnvironment=LOOM_DAEMON_SUPERVISOR=systemd\nRestart=on-success\n' \
+  > ~/.config/systemd/user/loom-daemon.service.d/supervisor.conf
+systemctl --user daemon-reload
+```
+
+A systemd drop-in's `Environment=` is additive and its `Restart=` overrides the
+base unit, so this one file fixes both defects (the missing supervisor env and
+the wrong restart policy) without touching the rendered base unit.
 
 ### `fleet status [--json]` (#4342)
 
@@ -2332,10 +2354,14 @@ recovery do. On either trigger the daemon writes
 `<loom-dir>/idle-exit.json`, publishes `daemon.idle_exit`, removes its socket,
 and exits 0. It never calls `shutdown`, `sudo`, or a provider API.
 
-The fleet add-worker systemd unit uses `Restart=on-failure`, so exit 0 stays
-down. macOS launchd uses `KeepAlive:SuccessfulExit`, so exit 0 relaunches the
-daemon; idle exit is meaningful only under on-failure-style supervision. A
-loud warning is logged when it is enabled under launchd.
+The fleet add-worker systemd unit uses `Restart=on-success` (#4640, matching
+`loom-daemon-start.sh`'s canonical unit), so exit 0 relaunches — same as macOS
+launchd's `KeepAlive:SuccessfulExit`. Idle exit is only meaningful under
+on-failure-style supervision (e.g. a non-systemd/nohup Linux host); enabling it
+on a fleet worker or under launchd defeats its own purpose, since the
+supervisor immediately relaunches the daemon it just exited. A loud warning is
+logged when it is enabled under launchd; the same caveat applies to any
+systemd-supervised daemon (fleet workers included).
 
 ### Daemon log path override (`LOOM_DAEMON_LOG`, #4010)
 

--- a/loom-daemon/src/fleet/add_worker.rs
+++ b/loom-daemon/src/fleet/add_worker.rs
@@ -483,10 +483,10 @@ pub fn build_plan(config: &AddWorkerConfig, secrets: &Secrets) -> Plan {
         render_workspace_register(&config.repos, config.priority),
     ));
 
-    // 8. Start the daemon under a systemd --user unit (Restart=on-failure, linger).
+    // 8. Start the daemon under a systemd --user unit (Restart=on-success, linger).
     plan.push_step(Step::new(
         "daemon-unit",
-        "install + enable the loom-daemon systemd --user unit (linger, Restart=on-failure)",
+        "install + enable the loom-daemon systemd --user unit (linger, Restart=on-success, LOOM_DAEMON_SUPERVISOR=systemd)",
         Some("systemctl --user is-enabled loom-daemon.service >/dev/null 2>&1".to_string()),
         render_daemon_unit(&primary_rel),
     ));
@@ -871,6 +871,19 @@ export PATH="$HOME/.local/bin:$PATH"
 fn render_daemon_unit(primary_rel: &str) -> String {
     // WorkingDirectory pinned to a workspace clone is the #4292 token-pool cwd
     // workaround — REMOVE once #4292 lands (token pool no longer cwd-coupled).
+    //
+    // Restart=on-success + Environment=LOOM_DAEMON_SUPERVISOR=systemd mirror the
+    // canonical systemd --user unit rendered by `render_systemd_unit()` in
+    // `loom-daemon-start.sh` (#4268) — the same supervised-restart contract
+    // documented in `ipc.rs` (`detect_supervisor` / `EXIT_RESTART` /
+    // `EXIT_SIGINT` / `EXIT_SHUTDOWN`, #4054). `LOOM_DAEMON_SUPERVISOR=systemd`
+    // lets the daemon prove it is supervised before `restart --drain` exits it
+    // (#4640); `Restart=on-success` relaunches ONLY on the clean `EXIT_RESTART`
+    // (exit 0) the restart primitive uses, and leaves the daemon down on
+    // `EXIT_SIGINT` (130) / `EXIT_SHUTDOWN` (143) / a crash — deliberately NOT
+    // `Restart=on-failure`, which would do the opposite (never relaunch a
+    // requested restart, but crash-loop-relaunch is watchdog territory the
+    // fleet unit does not attempt).
     format!(
         r#"set -e
 export PATH="$HOME/.local/bin:$PATH"
@@ -889,9 +902,15 @@ Type=simple
 # lands.
 WorkingDirectory=%h/{primary_rel}
 ExecStart=%h/.local/bin/loom-daemon
-Restart=on-failure
-RestartSec=5
+# Restart=on-success == the launchd KeepAlive:{{SuccessfulExit:true}} analog
+# (#4054, mirrored from loom-daemon-start.sh's render_systemd_unit): only the
+# clean EXIT_RESTART (0) relaunches; EXIT_SIGINT (130) / EXIT_SHUTDOWN (143) /
+# a crash all exit non-zero and stay down.
+Restart=on-success
 Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+# Lets detect_supervisor() (ipc.rs) prove this daemon is supervised so
+# `restart --drain` will actually exit for a relaunch instead of refusing.
+Environment=LOOM_DAEMON_SUPERVISOR=systemd
 
 [Install]
 WantedBy=default.target
@@ -1706,8 +1725,49 @@ mod tests {
             .apply
             .contains("WorkingDirectory=%h/loom-workspaces/anvil"));
         assert!(step.apply.contains("#4292"), "workaround must be marked with #4292");
-        assert!(step.apply.contains("Restart=on-failure"));
+        assert!(step.apply.contains("Restart=on-success"));
         assert!(step.apply.contains("enable-linger"));
+    }
+
+    #[test]
+    fn daemon_unit_sets_supervisor_env_and_correct_restart_policy() {
+        // #4640: without LOOM_DAEMON_SUPERVISOR=systemd, detect_supervisor()
+        // (ipc.rs) can't tell the fleet daemon is systemd-supervised, so
+        // `restart --drain` refuses on every fleet worker. Restart=on-failure
+        // additionally inverts the exit-code contract: it never relaunches on
+        // the restart primitive's clean exit 0, and (had it been changed to
+        // `always` instead) would incorrectly relaunch on EXIT_SHUTDOWN (143).
+        // Restart=on-success mirrors the canonical `render_systemd_unit()` in
+        // loom-daemon-start.sh (#4268) and gets both right.
+        let config = base_config();
+        let plan = build_plan(&config, &Secrets::default());
+        let step = plan
+            .entries
+            .iter()
+            .find_map(|e| match e {
+                super::super::PlanEntry::Step(s) if s.name == "daemon-unit" => Some(s),
+                _ => None,
+            })
+            .unwrap();
+        assert!(
+            step.apply
+                .contains("Environment=LOOM_DAEMON_SUPERVISOR=systemd"),
+            "rendered unit must set LOOM_DAEMON_SUPERVISOR=systemd so detect_supervisor() \
+             recognizes the fleet daemon as supervised"
+        );
+        assert!(
+            step.apply.contains("Restart=on-success"),
+            "rendered unit must use Restart=on-success (the EXIT_RESTART/EXIT_SIGINT/\
+             EXIT_SHUTDOWN contract), not Restart=on-failure or Restart=always"
+        );
+        assert!(
+            !step.apply.contains("Restart=on-failure"),
+            "the old Restart=on-failure policy must be fully replaced"
+        );
+        assert!(
+            step.summary.contains("Restart=on-success"),
+            "step summary must match the rendered policy"
+        );
     }
 
     #[test]

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -144,7 +144,13 @@ pub fn build_restart_decision() -> (Response, bool) {
                     (LOOM_DAEMON_SUPERVISOR unset). This daemon was not started under \
                     a recognized supervisor (nohup / Linux / --foreground), so nothing \
                     would relaunch it if it exited. Leaving it running. Restart it \
-                    manually with loom-daemon-stop.sh && loom-daemon-start.sh."
+                    manually with loom-daemon-stop.sh && loom-daemon-start.sh. If this IS \
+                    a systemd --user service (e.g. a fleet worker provisioned before #4640), \
+                    retrofit it instead of restarting manually: mkdir -p \
+                    ~/.config/systemd/user/loom-daemon.service.d && printf \
+                    '[Service]\\nEnvironment=LOOM_DAEMON_SUPERVISOR=systemd\\nRestart=on-success\\n' \
+                    > ~/.config/systemd/user/loom-daemon.service.d/supervisor.conf && \
+                    systemctl --user daemon-reload."
                     .to_string(),
             },
             false,
@@ -505,7 +511,12 @@ pub fn handle_drain_request(
                         (LOOM_DAEMON_SUPERVISOR unset). This daemon was not started under \
                         a recognized supervisor, so nothing would relaunch it after a drain. \
                         Dispatch was NOT paused. Restart manually with loom-daemon-stop.sh && \
-                        loom-daemon-start.sh."
+                        loom-daemon-start.sh. If this IS a systemd --user service (e.g. a \
+                        fleet worker provisioned before #4640), retrofit it instead: mkdir -p \
+                        ~/.config/systemd/user/loom-daemon.service.d && printf \
+                        '[Service]\\nEnvironment=LOOM_DAEMON_SUPERVISOR=systemd\\nRestart=on-success\\n' \
+                        > ~/.config/systemd/user/loom-daemon.service.d/supervisor.conf && \
+                        systemctl --user daemon-reload."
                         .to_string(),
                     then_exit,
                 };
@@ -5282,10 +5293,21 @@ exit 0
             Response::DaemonRestart {
                 scheduled,
                 supervisor,
-                ..
+                message,
             } => {
                 assert!(!scheduled);
                 assert!(supervisor.is_none());
+                // #4640: the refusal must mention the systemd retrofit for a
+                // fleet worker provisioned before the fix (missing
+                // LOOM_DAEMON_SUPERVISOR despite being systemd-supervised).
+                assert!(
+                    message.contains("LOOM_DAEMON_SUPERVISOR=systemd"),
+                    "restart refusal must mention the systemd retrofit: {message}"
+                );
+                assert!(
+                    message.contains("Restart=on-success"),
+                    "restart refusal retrofit hint must include the corrected Restart= policy: {message}"
+                );
             }
             other => panic!("Expected DaemonRestart, got: {other:?}"),
         }
@@ -6366,10 +6388,22 @@ exit 0
             Response::DaemonDrain {
                 accepted,
                 supervisor,
+                message,
                 ..
             } => {
                 assert!(!accepted, "unsupervised host must refuse the drain");
                 assert!(supervisor.is_none());
+                // #4640: the refusal must mention the systemd retrofit for a
+                // fleet worker provisioned before the fix (missing
+                // LOOM_DAEMON_SUPERVISOR despite being systemd-supervised).
+                assert!(
+                    message.contains("LOOM_DAEMON_SUPERVISOR=systemd"),
+                    "drain refusal must mention the systemd retrofit: {message}"
+                );
+                assert!(
+                    message.contains("Restart=on-success"),
+                    "drain refusal retrofit hint must include the corrected Restart= policy: {message}"
+                );
             }
             other => panic!("expected DaemonDrain, got {other:?}"),
         }


### PR DESCRIPTION
## Summary
`fleet add-worker`'s rendered systemd `--user` unit never set `LOOM_DAEMON_SUPERVISOR=systemd`, so `detect_supervisor()` (`ipc.rs`) could not recognize a fleet worker as supervised and `loom-daemon restart --drain` always refused with "no supervisor detected" — even though systemd genuinely manages the daemon via `Restart=`. Simply adding the env var without also fixing the `Restart=` policy would have converted this into a worse failure mode: the unit used `Restart=on-failure`, which never relaunches on a clean exit 0 (the restart primitive's `EXIT_RESTART`), so a granted drain would silently kill the fleet worker for good.

## Changes
- `loom-daemon/src/fleet/add_worker.rs` (`render_daemon_unit`): unit now sets `Environment=LOOM_DAEMON_SUPERVISOR=systemd` and `Restart=on-success` (dropping the incorrect `Restart=on-failure` + its `RestartSec=5`), mirroring the canonical `render_systemd_unit()` policy already used by `loom-daemon-start.sh` (#4268) — so only the clean `EXIT_RESTART` (0) relaunches, and `EXIT_SIGINT` (130) / `EXIT_SHUTDOWN` (143) / a crash all stay down, matching the exit-code contract documented in `ipc.rs`.
- Updated the `daemon-unit` step's summary string and the `#4292`-workaround test assertion to match the new policy; added a new test (`daemon_unit_sets_supervisor_env_and_correct_restart_policy`) asserting both the env var and the corrected `Restart=` line are present and the old `on-failure` policy is gone.
- `loom-daemon/src/ipc.rs`: extended both unsupervised-refusal messages (`build_restart_decision`'s restart refusal, `handle_drain_request`'s drain refusal) with a systemd retrofit hint (drop-in unit + `daemon-reload`) for hosts provisioned before this fix; added assertions on both existing tests (`test_build_restart_decision_supervisor_gated`, `test_drain_request_unsupervised_refuses_without_pausing`) that the retrofit hint text is present.
- `defaults/docs/daemon-reference.md`: updated the `fleet add-worker` step list and idle-exit interaction paragraph to describe the corrected `Restart=on-success` policy, and added a "Retrofitting a worker provisioned before #4640" subsection documenting the drop-in one-liner (or a full re-run of `fleet add-worker`, which overwrites the unit unconditionally) for already-provisioned hosts.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `render_daemon_unit()` emits `Environment=LOOM_DAEMON_SUPERVISOR=systemd` | ✅ | New test asserts `step.apply.contains("Environment=LOOM_DAEMON_SUPERVISOR=systemd")` |
| `Restart=` policy corrected to match the canonical `on-success` contract (exit 0 relaunches; 130/143 stay down) | ✅ | Rendered unit uses `Restart=on-success`; new + updated tests assert `on-success` present and `on-failure` fully removed |
| Step description / existing unit test updated to match | ✅ | `daemon-unit` step summary string updated; `daemon_unit_pins_workingdirectory_with_4292_marker` assertion changed to `on-success` |
| Both unsupervised-refusal messages (restart + drain) mention the systemd retrofit for pre-fix hosts | ✅ | Both messages in `ipc.rs` extended with the drop-in one-liner; both existing tests assert the retrofit text is present |
| Retrofit path documented for existing workers | ✅ | New subsection in `defaults/docs/daemon-reference.md` with the drop-in `.conf` one-liner + `daemon-reload`, and the "re-run `fleet add-worker`" full-resync alternative |
| `cargo test` in `loom-daemon/` passes, including a test asserting both the supervisor env line and the corrected `Restart=` line | ✅ | Full `cargo test -p loom-daemon` run: all suites green (unit + integration + doc tests), no failures |

## Test Plan
- `cargo check -p loom-daemon` — clean.
- `cargo clippy -p loom-daemon --all-targets` — clean.
- `cargo fmt -- --check` — clean (after `cargo fmt`).
- `cargo test -p loom-daemon` (full suite, unit + integration + doc tests) — all green, no failures.
- Manually inspected the rendered unit heredoc and the two refusal-message strings for correctness against the exit-code contract in `ipc.rs` (`EXIT_RESTART=0`, `EXIT_SIGINT=130`, `EXIT_SHUTDOWN=143`).

## Out of scope
- No new `fleet doctor`/resync subcommand was added — the curated issue explicitly scoped that out (none exists today).
- Did not touch `main.rs`'s `idle_exit` launchd-only warning gap (it does not check for `systemd`) — that gap already exists today for any host started via `loom-daemon-start.sh`'s existing `Restart=on-success` systemd path, independent of this fleet-specific fix, so extending it is a separate follow-up rather than part of this PR's scope.

Closes #4640