### PR TITLE
fix: never serialize an empty status for never-used token accounts

### DIFF
--- a/loom-daemon/src/capacity.rs
+++ b/loom-daemon/src/capacity.rs
@@ -621,6 +621,26 @@ mod tests {
     }
 
     #[test]
+    fn read_ranking_at_counts_never_used_account_as_healthy() {
+        // Regression test for issue #4645: the monitor writer used to emit a
+        // malformed `name|` row (empty status) for a manifest account with no
+        // usage history (e.g. freshly bootstrapped/never-used). The fixed
+        // writer (`tokens_pool::monitor::build_monitor_accounts`) now emits
+        // `name|available` for such accounts, so the daemon's healthy count
+        // must include them rather than silently dropping the row as
+        // malformed (a no-`|` row) or counting it unhealthy.
+        let tmp = tempfile::tempdir().unwrap();
+        write_ranking_at(tmp.path(), "agent4-2amlogic|exhausted|0.18\nagent6-2amlogic|available\n");
+        let snap = read_ranking_at(tmp.path()).unwrap();
+        assert_eq!(snap.total, 2);
+        assert_eq!(
+            snap.available, 1,
+            "the never-used account's `available` row must count healthy"
+        );
+        assert_eq!(snap.exhausted, 1);
+    }
+
+    #[test]
     fn read_ranking_at_parses_three_field_format() {
         // #4243/#4344 primary bug: writers emit `name|status|5h_util` whenever
         // 5h utilization is known (which on the live host is always). The

--- a/loom-daemon/src/tokens_pool/monitor.rs
+++ b/loom-daemon/src/tokens_pool/monitor.rs
@@ -240,14 +240,20 @@ pub fn build_monitor_accounts(
         }
     }
 
-    // Represent manifest accounts the monitor did not mention (unknown status,
-    // sorts last) so the selector still sees them.
+    // Represent manifest accounts the monitor did not mention (no usage rows
+    // yet — e.g. freshly bootstrapped/never-used accounts) as `available` so
+    // they are dispatchable: the table display, the written `.ranking` row,
+    // and the daemon's healthy-count reader all agree on this single status
+    // (issue #4645 — the empty-status writer bug that made fresh capacity
+    // dispatch-invisible). Their unknown utilization sorts them after
+    // known-utilization `available` accounts via `UTIL_SENTINEL`, but they
+    // still rank ahead of `rate_limited`/`exhausted` accounts.
     for (_, name) in &email_to_name {
         if !matched.contains(name) {
             matched.push(name.clone());
             accounts.push(MonitorAccount {
                 name: name.clone(),
-                status: String::new(),
+                status: "available".to_string(),
                 util_7d: None,
                 util_5h: None,
             });
@@ -323,17 +329,15 @@ pub fn run_monitor_check(
 ) -> Option<ProbeReport> {
     let accounts = build_monitor_accounts(tokens_dir, None, None)?;
 
-    // The in-memory report uses "available" for an empty status; the WRITER
-    // uses the raw status (empty stays empty) — matches check._run_monitor_check.
+    // Single source of truth: `build_monitor_accounts` already normalizes
+    // monitor-unmentioned accounts to `available` (issue #4645), so the
+    // in-memory report (used for the CLI table) and the `.ranking` writer
+    // below both serialize the exact same status — they cannot disagree.
     let results: Vec<AccountResult> = accounts
         .iter()
         .map(|a| AccountResult {
             name: a.name.clone(),
-            status: if a.status.is_empty() {
-                "available".to_string()
-            } else {
-                a.status.clone()
-            },
+            status: a.status.clone(),
             s5h_utilization: a.util_5h,
             s7d_utilization: a.util_7d,
             s7d_reset: None,
@@ -454,9 +458,11 @@ mod tests {
             ]),
         );
         let accounts = build_monitor_accounts(&tokens_dir, Some(&monitor_dir), Some(now)).unwrap();
-        // acct-z (unmentioned, empty status -> rank 99) sorts last.
+        // acct-z (unmentioned) is normalized to "available" (issue #4645) but
+        // its unknown utilization sorts it after acct-a's known 0.50 within
+        // the same `available` rank bucket.
         assert_eq!(accounts.last().unwrap().name, "acct-z");
-        assert_eq!(accounts.last().unwrap().status, "");
+        assert_eq!(accounts.last().unwrap().status, "available");
     }
 
     #[test]
@@ -505,7 +511,11 @@ mod tests {
     }
 
     #[test]
-    fn format_ranking_lines_manifest_only_has_empty_status() {
+    fn format_ranking_lines_passes_through_whatever_status_it_is_given() {
+        // `format_ranking_lines` is a pure formatter — it does not normalize an
+        // empty status. `build_monitor_accounts` is the seam responsible for
+        // never handing it one (issue #4645); this test documents the
+        // formatter's own (unopinionated) behavior in isolation.
         let accounts = vec![MonitorAccount {
             name: "acct-z".into(),
             status: String::new(),
@@ -537,7 +547,13 @@ mod tests {
     }
 
     #[test]
-    fn run_monitor_check_writes_raw_status_but_report_defaults_available() {
+    fn run_monitor_check_writes_available_for_unmentioned_manifest_account() {
+        // Regression test for issue #4645: a manifest account the monitor DB
+        // never mentions (e.g. freshly bootstrapped/never-used) must serialize
+        // as a parseable `name|available` row — never a malformed `name|` row
+        // — and the in-memory report (CLI table) must agree with what gets
+        // written, since both come from the same `build_monitor_accounts`
+        // output.
         let tmp = tempfile::tempdir().unwrap();
         let tokens_dir = tmp.path().join("tokens");
         let monitor_dir = tmp.path().join("monitor");
@@ -556,14 +572,21 @@ mod tests {
         std::env::remove_var(CLAUDE_MONITOR_DIR_VAR);
 
         let report = report.unwrap();
-        // In-memory report: acct-z's empty status becomes "available".
+        // In-memory report (table display): acct-z is "available".
         let z = report.accounts.iter().find(|a| a.name == "acct-z").unwrap();
         assert_eq!(z.status, "available");
 
-        // Written .ranking: acct-z keeps its RAW empty status.
+        // Written .ranking: acct-z is ALSO "available" — a parseable row, not
+        // a `name|` malformed one. Table and writer agree (single source).
         let ranking = fs::read_to_string(tokens_dir.join(".ranking")).unwrap();
-        assert!(ranking.contains("acct-z|\n"));
+        assert!(!ranking.contains("acct-z|\n"), "malformed empty-status row must not be written");
+        assert!(ranking.contains("acct-z|available\n"));
         assert!(ranking.contains("acct-a|available\n"));
+
+        // Capacity's healthy-count reader must count the never-used account.
+        let snap = crate::capacity::read_ranking_at(&tokens_dir).unwrap();
+        assert_eq!(snap.total, 2);
+        assert_eq!(snap.available, 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`loom-daemon/src/tokens_pool/monitor.rs` appended manifest accounts the
claude-monitor DB does not mention (never-used accounts with no usage
history) with `status: String::new()`. The `.ranking` writer serialized
that raw empty status verbatim, producing malformed `name|` rows. The CLI
table mapped empty -> `"available"` for display only, so the daemon's
healthy-count reader (`capacity.rs`, which treats any non-`"available"`
status as unhealthy) disagreed and read 0 healthy even when fresh accounts
were actually available — exactly when the daemon's own capacity advisory
tells the operator to add accounts.

## Changes

- `loom-daemon/src/tokens_pool/monitor.rs`: `build_monitor_accounts` now
  gives monitor-unmentioned manifest accounts the explicit status
  `"available"` (instead of an empty string) — the same value the table
  display already used. `run_monitor_check` no longer needs a separate
  empty -> `"available"` remap for its in-memory report, since the status
  used for the table and the status serialized to `.ranking` are now the
  single same value.
- `loom-daemon/src/capacity.rs`: added a reader-conformance regression test
  asserting a `name|available` row (the fixed writer's shape for a
  never-used account) is counted healthy.
- Updated existing `monitor.rs` unit tests (`build_accounts_appends_unmentioned_manifest_accounts_last`,
  and the renamed `run_monitor_check_writes_available_for_unmentioned_manifest_account`)
  to the corrected expectation; the pure-formatter test
  (`format_ranking_lines_passes_through_whatever_status_it_is_given`)
  documents that `format_ranking_lines` itself is not the normalization
  seam — `build_monitor_accounts` is.
- No changes to `check.rs` (`ranking_line`, `status_rank`), the
  `name|status|5h_util` format, or any reader/selector — this is a
  writer-seam-only fix per the issue's explicit guidance (avoiding the
  #4243/#4344 reader-drift regression class).
- `token_ranking_refresh.rs` was verified, not changed: it shells out to the
  daemon's own binary (`tokens check --ranking`), which routes through
  `check::run_check` -> `monitor::run_monitor_check` — the same fixed
  writer — so the self-refresh path cannot re-blank hand-patched rows.

## Acceptance Criteria Verification

- [x] A monitor-source `check --ranking` run serializes every manifest
  account with a non-empty status; a `name|` row can no longer be produced
  — verified by `run_monitor_check_writes_available_for_unmentioned_manifest_account`,
  which asserts the written `.ranking` does NOT contain `acct-z|\n` and DOES
  contain `acct-z|available\n`.
- [x] Table display and written `.ranking` row derive their status from a
  single shared value (they cannot disagree) — `run_monitor_check` now maps
  `AccountResult.status` directly from `MonitorAccount.status`, the same
  field the writer serializes.
- [x] The daemon's healthy count (`capacity.rs::read_ranking_at`) includes
  a never-used imported account after `check --ranking` — verified in both
  the same monitor.rs test (via `crate::capacity::read_ranking_at`) and a
  standalone `capacity.rs` conformance test.
- [x] The daemon's ranking self-refresh (`token_ranking_refresh.rs`) goes
  through the same fixed writer — verified by reading the code path
  (`current_exe() tokens check --ranking` -> `run_check` ->
  `run_monitor_check`); no changes needed there.
- [x] No changes to the `name|status|5h_util` format, the status
  vocabulary, or any reader — `check.rs`, `select.rs`, `capacity.rs`'s
  `AccountHealth`/`status_rank` vocabulary are untouched.
- [x] Regression test: bootstrap/import a token absent from the monitor DB
  -> the account-building/ranking-line-formatting logic emits
  `name|available` -> capacity read counts it healthy — see
  `run_monitor_check_writes_available_for_unmentioned_manifest_account`.

## Test Plan

- `cargo check --lib` — clean.
- `cargo clippy --lib -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `cargo test --lib` — 2622 passed, 0 failed (full `loom-daemon` crate suite,
  including the new/updated tests above).
- Manual on-host verification (against a real claude-monitor pairing) was
  not performed, per the issue's test plan — no monitor-paired host
  available in this environment.

Closes #4645