### PR TITLE
fix(init): log every .loom/config.json rewrite branch and stop re-init on configured workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ Thumbs.db
 .loom/*.log
 .loom/*.sock
 .loom/*.tmp
+.loom/*.bak
 .loom/logs/
 # <<< loom-managed <<<
 .loom-test-failure-context.json

--- a/defaults/docs/troubleshooting.md
+++ b/defaults/docs/troubleshooting.md
@@ -259,6 +259,44 @@ Reaching for `loom:blocked` when you mean `loom:operator-only` conflates "waitin
 a dependency" with "needs a human action," which muddies the daemon/sweep skip
 semantics. Use `loom:operator-only` for the human-must-act-off-automation case.
 
+### An operator edit to `.loom/config.json` disappeared (#4641)
+
+`.loom/config.json` has exactly one production writer: `loom-daemon init` (run by
+`install.sh` reinstalls and by the `fleet add-worker` provisioning steps).
+`resync-installed.sh` and `loom-daemon calibrate --write` never touch it.
+
+`init`'s merge is **existing-wins** — consumer keys, including ones absent from the
+shipped template such as `autonomous.workFinder.maxConcurrent`, survive — so a
+tuned value vanishing means one of the other branches fired. Every `init` call now
+emits one greppable line naming the branch it took:
+
+```bash
+grep 'init: config.json:' ~/.loom/daemon.log
+```
+
+| Branch | Level | Meaning |
+|--------|-------|---------|
+| `fresh-write` | `info` | No config existed; the template was written verbatim. |
+| `merge-preserved` | `info` | Existing values kept. Carries a per-key diff (`+ added`, `~ changed`, `- dropped`) or "no effective config change". |
+| `template-invalid-skip` | `warn` | The shipped `defaults/config.json` is unparseable; your file was left untouched (and got no template updates). |
+| `invalid-JSON-fallback-overwrite` | `warn` | **Your config was replaced by the template.** The line names the discarded keys. |
+
+A `~` or `-` entry on `merge-preserved` is unexpected under existing-wins semantics
+and is worth investigating.
+
+The fallback branch only fires when the file on disk does not parse as a JSON
+object (a torn write from a concurrent writer, a hand-edit with a syntax error, or
+a top-level array). Before overwriting, `init` copies the unparseable bytes to
+`.loom/config.json.bak` — recover your tuned keys from there:
+
+```bash
+cat .loom/config.json.bak
+```
+
+`.loom/*.bak` is git-ignored, and `fleet add-worker` no longer re-runs
+`loom-daemon init` against a workspace that already has a `.loom/config.json`, so
+repeat provisioning passes cannot re-enter this path on a tuned host.
+
 ### Daemon won't start
 
 ```bash

--- a/loom-daemon/src/fleet/add_worker.rs
+++ b/loom-daemon/src/fleet/add_worker.rs
@@ -470,7 +470,7 @@ pub fn build_plan(config: &AddWorkerConfig, secrets: &Secrets) -> Plan {
     // 6. Clone + init workspace repos (init installs the /loom:sweep command, #4027).
     plan.push_step(Step::new(
         "workspace-clone",
-        "clone workspace repo(s) and run loom-daemon init (installs /loom:sweep)",
+        "clone workspace repo(s) and run loom-daemon init on unconfigured ones (installs /loom:sweep)",
         Some(render_workspace_clone_check(&config.repos)),
         render_workspace_clone(&config.repos),
     ));
@@ -819,6 +819,23 @@ fn render_workspace_clone_check(repos: &[String]) -> String {
     s
 }
 
+/// Render the workspace clone + first-time init step.
+///
+/// **`loom-daemon init` runs only on a workspace that is not yet configured**
+/// (issue #4641). It used to run unconditionally — unlike the `gh repo clone`
+/// above it, which has always been guarded by `[ ! -d .../.git ]` — so every
+/// re-run of `fleet add-worker` (or any idempotent self-heal pass over an
+/// existing host) re-entered `init`'s `.loom/config.json` merge on a workspace
+/// an operator had since hand-tuned. That merge is existing-wins and normally
+/// harmless, but its invalid-JSON fallback branch overwrites the file
+/// wholesale, which is a plausible cause of the observed silent reversion of
+/// `autonomous.workFinder.maxConcurrent` on `loom-worker-1`.
+///
+/// Provisioning only needs `init` to *establish* a workspace; keeping an
+/// already-established one up to date is `loom update` / the resync script's
+/// job, neither of which touches `.loom/config.json`. Gating on
+/// `.loom/config.json` (rather than on having just cloned) also self-heals a
+/// workspace that was cloned by a previous run whose `init` failed.
 fn render_workspace_clone(repos: &[String]) -> String {
     let mut s = String::from(
         r#"set -e
@@ -833,7 +850,11 @@ mkdir -p "$HOME/loom-workspaces"
             r#"if [ ! -d "$HOME/{rel}/.git" ]; then
   gh repo clone {repo} "$HOME/{rel}"
 fi
-loom-daemon init "$HOME/{rel}" --defaults "$LOOM_SRC/defaults" || true
+if [ ! -f "$HOME/{rel}/.loom/config.json" ]; then
+  loom-daemon init "$HOME/{rel}" --defaults "$LOOM_SRC/defaults" || true
+else
+  echo "skip init: $HOME/{rel} already configured (.loom/config.json present)"
+fi
 "#
         ));
     }
@@ -1300,6 +1321,41 @@ mod tests {
                 "safehouse",
                 "verify",
             ]
+        );
+    }
+
+    #[test]
+    fn workspace_clone_only_inits_an_unconfigured_workspace() {
+        // #4641: `loom-daemon init` used to run unconditionally here, so every
+        // re-run of provisioning re-entered the `.loom/config.json` merge on a
+        // workspace an operator had since hand-tuned. The init call must now sit
+        // behind a `.loom/config.json` existence guard, the same way the clone
+        // sits behind a `.git` guard.
+        let script = render_workspace_clone(&["rjwalters/anvil".to_string()]);
+
+        assert!(
+            script.contains(r#"if [ ! -f "$HOME/loom-workspaces/anvil/.loom/config.json" ]; then"#),
+            "init must be guarded on the workspace being unconfigured:\n{script}"
+        );
+
+        // The guard must actually enclose the init call: the only `loom-daemon
+        // init` line has to appear after the guard and before its `else`.
+        let guard = script
+            .find(r#"if [ ! -f "$HOME/loom-workspaces/anvil/.loom/config.json" ]"#)
+            .expect("guard present");
+        let init = script.find("loom-daemon init").expect("init present");
+        let else_branch = script.find("\nelse\n").expect("else present");
+        assert!(guard < init && init < else_branch, "init is outside the guard:\n{script}");
+        assert_eq!(
+            script.matches("loom-daemon init").count(),
+            1,
+            "no second, unguarded init call may remain:\n{script}"
+        );
+
+        // The clone itself stays guarded on .git (unchanged behavior).
+        assert!(
+            script.contains(r#"if [ ! -d "$HOME/loom-workspaces/anvil/.git" ]; then"#),
+            "clone guard regressed:\n{script}"
         );
     }
 

--- a/loom-daemon/src/init/mod.rs
+++ b/loom-daemon/src/init/mod.rs
@@ -302,13 +302,30 @@ fn copy_single_file(
 ///   conflict; keys new in the template are added, unknown consumer keys at any
 ///   depth are preserved. Written with deterministic pretty serialization so
 ///   repeat reinstalls are byte-idempotent. Recorded as `preserved`.
-/// - **Destination exists but is invalid JSON (or not an object)** → fall back
-///   to a template copy with a loud warning; the install does not abort.
-///   Recorded as `updated`.
+/// - **Destination exists but is invalid JSON (or not an object)** → the
+///   previous contents are first copied aside to `.loom/config.json.bak`, then
+///   the template replaces the file, with a loud `warn!`; the install does not
+///   abort. Recorded as `updated`.
 ///
 /// Byte-exact preservation of consumer formatting/comments is explicitly out of
 /// scope — deterministic re-serialization is acceptable as long as keys/values
 /// survive and repeat runs are stable.
+///
+/// # Observability (issue #4641)
+///
+/// Every call emits exactly one branch line through the `log` facade, tagged
+/// with a greppable branch name — `fresh-write`, `merge-preserved`,
+/// `template-invalid-skip`, or `invalid-JSON-fallback-overwrite` — prefixed
+/// `init: config.json:`. `merge-preserved` additionally carries a leaf-level
+/// diff of every key whose effective value changed, and the fallback branch
+/// logs at `warn!` naming the keys it discarded plus the rescue-copy path.
+///
+/// This exists because `loom-daemon init` is invoked unattended from
+/// provisioning scripts (`fleet::add_worker`, `install.sh` reinstalls), where a
+/// bare `eprintln!` disappears into a log nobody reads: an operator-tuned
+/// `autonomous.workFinder.maxConcurrent` was silently reverted on a fleet
+/// worker with no trace of which process rewrote the file. `warn!`/`info!` land
+/// in `daemon.log` and are greppable after the fact.
 fn merge_config_file(
     defaults: &Path,
     loom_path: &Path,
@@ -342,6 +359,11 @@ fn merge_config_file(
                 serialized.push('\n');
                 fs::write(&dst, serialized)
                     .map_err(|e| format!("Failed to write config.json: {e}"))?;
+                log::info!(
+                    "init: config.json: fresh-write {} — no existing file; wrote {} key(s) from the shipped template",
+                    dst.display(),
+                    top_level_key_count(&template_val)
+                );
             }
             Err(e) => {
                 // Template is invalid JSON — fall back to a raw copy rather than
@@ -349,6 +371,10 @@ fn merge_config_file(
                 eprintln!(
                     "Warning: defaults/config.json is not valid JSON ({e}); \
                      copying it verbatim to .loom/config.json"
+                );
+                log::warn!(
+                    "init: config.json: fresh-write {} — defaults/config.json is not valid JSON ({e}); copied verbatim",
+                    dst.display()
                 );
                 fs::copy(&src, &dst).map_err(|e| format!("Failed to copy config.json: {e}"))?;
             }
@@ -369,6 +395,10 @@ fn merge_config_file(
                 "Warning: defaults/config.json is not valid JSON ({e}); \
                  leaving existing .loom/config.json untouched"
             );
+            log::warn!(
+                "init: config.json: template-invalid-skip {} — defaults/config.json is not valid JSON ({e}); existing file left untouched",
+                dst.display()
+            );
             report.preserved.push(report_name.to_string());
             return Ok(());
         }
@@ -376,13 +406,42 @@ fn merge_config_file(
 
     // If the consumer file is missing/invalid/non-object, fall back to the
     // template copy with a loud warning. This must not abort the install.
+    //
+    // This is the ONE branch that can silently discard operator-tuned keys
+    // wholesale (#4641), so before overwriting we (a) copy the unparseable
+    // bytes aside to `.loom/config.json.bak` so nothing is truly lost, and (b)
+    // `warn!` with a best-effort list of the key names visible in the discarded
+    // text. A torn read caused by a concurrent writer is exactly the scenario
+    // this needs to leave evidence for.
     let existing_val: Value = match serde_json::from_str::<Value>(&existing_str) {
         Ok(v) if v.is_object() => v,
-        _ => {
+        parsed => {
+            let reason = match parsed {
+                Ok(_) => "valid JSON but not an object".to_string(),
+                Err(e) => format!("not valid JSON: {e}"),
+            };
+            let discarded = salvage_key_names(&existing_str);
+            let discarded_desc = if discarded.is_empty() {
+                "none recoverable from the unparseable text".to_string()
+            } else {
+                summarize_list(&discarded)
+            };
+            let backup = dst.with_extension("json.bak");
+            let backup_desc = match fs::write(&backup, &existing_str) {
+                Ok(()) => format!("previous contents saved to {}", backup.display()),
+                Err(e) => format!("FAILED to save previous contents to {}: {e}", backup.display()),
+            };
+
             eprintln!(
                 "Warning: existing .loom/config.json is not valid JSON; overwriting \
                  with the shipped template (previous contents were not preserved)"
             );
+            log::warn!(
+                "init: config.json: invalid-JSON-fallback-overwrite {} — existing file is {reason}; \
+                 overwriting with the shipped template. Discarded keys: {discarded_desc}. {backup_desc}",
+                dst.display()
+            );
+
             fs::copy(&src, &dst).map_err(|e| format!("Failed to copy config.json: {e}"))?;
             report.updated.push(report_name.to_string());
             return Ok(());
@@ -393,12 +452,163 @@ fn merge_config_file(
     let mut merged = template_val;
     deep_merge_existing_wins(&mut merged, &existing_val);
 
+    // Diff BEFORE writing, so the log describes the effective config change this
+    // call is about to make. With existing-wins semantics the expected shape is
+    // additions only (new template keys); a `~` or `-` entry here means a
+    // consumer value was overwritten or dropped and is worth investigating.
+    let changes = describe_config_changes(&existing_val, &merged);
+
     let mut serialized = serde_json::to_string_pretty(&merged)
         .map_err(|e| format!("Failed to serialize merged config.json: {e}"))?;
     serialized.push('\n');
     fs::write(&dst, serialized).map_err(|e| format!("Failed to write merged config.json: {e}"))?;
+
+    if changes.is_empty() {
+        log::info!(
+            "init: config.json: merge-preserved {} — no effective config change",
+            dst.display()
+        );
+    } else {
+        log::info!(
+            "init: config.json: merge-preserved {} — {} key(s) changed: {}",
+            dst.display(),
+            changes.len(),
+            summarize_list(&changes)
+        );
+    }
+
     report.preserved.push(report_name.to_string());
     Ok(())
+}
+
+/// Maximum number of individual entries spelled out in one log line before the
+/// remainder is elided as `… and N more`. Keeps a pathological config (or a
+/// fresh install merging a large template) from emitting a multi-kilobyte line.
+const MAX_LOGGED_ENTRIES: usize = 20;
+
+/// Number of top-level keys in a JSON value (0 for non-objects).
+fn top_level_key_count(value: &Value) -> usize {
+    value.as_object().map_or(0, |m| m.len())
+}
+
+/// Join `entries` for a log line, eliding past [`MAX_LOGGED_ENTRIES`].
+fn summarize_list(entries: &[String]) -> String {
+    if entries.len() <= MAX_LOGGED_ENTRIES {
+        entries.join("; ")
+    } else {
+        format!(
+            "{}; … and {} more",
+            entries[..MAX_LOGGED_ENTRIES].join("; "),
+            entries.len() - MAX_LOGGED_ENTRIES
+        )
+    }
+}
+
+/// Flatten a JSON value into `(dotted.path, compact-json-value)` leaf pairs.
+///
+/// Arrays are treated as leaves (compared wholesale), matching
+/// [`deep_merge_existing_wins`], which also replaces arrays wholesale rather
+/// than merging element-by-element.
+fn flatten_json_leaves(value: &Value, prefix: &str, out: &mut Vec<(String, String)>) {
+    match value {
+        Value::Object(map) if !map.is_empty() => {
+            for (key, child) in map {
+                let path = if prefix.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{prefix}.{key}")
+                };
+                flatten_json_leaves(child, &path, out);
+            }
+        }
+        leaf => out.push((prefix.to_string(), leaf.to_string())),
+    }
+}
+
+/// Describe the leaf-level differences between two configs as log-ready lines.
+///
+/// `+ path = value` (added), `- path (was value)` (dropped), and
+/// `~ path: old -> new` (changed). An empty result means the write is a no-op in
+/// effective-config terms.
+fn describe_config_changes(before: &Value, after: &Value) -> Vec<String> {
+    let mut before_leaves = Vec::new();
+    flatten_json_leaves(before, "", &mut before_leaves);
+    let mut after_leaves = Vec::new();
+    flatten_json_leaves(after, "", &mut after_leaves);
+
+    let before_map: std::collections::BTreeMap<&str, &str> = before_leaves
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+    let after_map: std::collections::BTreeMap<&str, &str> = after_leaves
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+
+    let mut changes = Vec::new();
+    for (path, new_val) in &after_leaves {
+        match before_map.get(path.as_str()) {
+            Some(old_val) if *old_val == new_val.as_str() => {}
+            Some(old_val) => changes.push(format!("~ {path}: {old_val} -> {new_val}")),
+            None => changes.push(format!("+ {path} = {new_val}")),
+        }
+    }
+    for (path, old_val) in &before_leaves {
+        if !after_map.contains_key(path.as_str()) {
+            changes.push(format!("- {path} (was {old_val})"));
+        }
+    }
+    changes
+}
+
+/// Best-effort recovery of key names from text that failed to parse as JSON.
+///
+/// Used only on the invalid-JSON fallback path, where `serde_json` gives us
+/// nothing to enumerate but the operator still needs to know *what* was
+/// discarded. Scans for `"…"` immediately followed (modulo whitespace) by `:`,
+/// deduplicating while preserving first-seen order. Deliberately naive: a key
+/// name appearing inside a string *value* may be reported too. Over-reporting a
+/// name in a warning is far cheaper than reporting nothing.
+fn salvage_key_names(raw: &str) -> Vec<String> {
+    let bytes = raw.as_bytes();
+    let mut keys = Vec::new();
+    let mut seen = HashSet::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'"' {
+            i += 1;
+            continue;
+        }
+        // Walk to the closing quote, honoring backslash escapes. Only ASCII
+        // bytes are inspected, so multi-byte UTF-8 inside the string is safe.
+        let start = i + 1;
+        let mut end = start;
+        let mut escaped = false;
+        while end < bytes.len() {
+            match bytes[end] {
+                b'\\' if !escaped => escaped = true,
+                b'"' if !escaped => break,
+                _ => escaped = false,
+            }
+            end += 1;
+        }
+        if end >= bytes.len() {
+            break; // unterminated string — nothing more to salvage
+        }
+        let mut after = end + 1;
+        while after < bytes.len() && bytes[after].is_ascii_whitespace() {
+            after += 1;
+        }
+        if after < bytes.len() && bytes[after] == b':' {
+            if let Ok(name) = std::str::from_utf8(&bytes[start..end]) {
+                if seen.insert(name.to_string()) {
+                    keys.push(name.to_string());
+                }
+            }
+        }
+        i = end + 1;
+    }
+    keys
 }
 
 /// Deep-merge `overlay` into `base` with **overlay values winning** on conflict.
@@ -2075,6 +2285,323 @@ mod tests {
             "fallback config.json should be reported updated, got: {:?}",
             report.updated
         );
+    }
+
+    // ------------------------------------------------------------------
+    // config.json rewrite observability + repeated-init safety (issue #4641)
+    //
+    // Context: an operator-tuned `autonomous.workFinder.maxConcurrent` was
+    // silently reverted on a fleet worker with no log line naming the writer.
+    // `merge_config_file` is the only production writer of `.loom/config.json`,
+    // and `fleet add-worker` re-invoked it on every provisioning re-run.
+    // ------------------------------------------------------------------
+
+    /// Collect only this module's `init: config.json:` lines from a capture.
+    fn config_log_lines(records: &[(log::Level, String)]) -> Vec<(log::Level, String)> {
+        records
+            .iter()
+            .filter(|(_, msg)| msg.contains("init: config.json:"))
+            .cloned()
+            .collect()
+    }
+
+    #[test]
+    fn test_operator_nested_key_survives_repeated_init() {
+        // AC3 (#4641): the reported loss was of a nested, operator-only knob on
+        // a host that runs provisioning repeatedly — so once is not enough.
+        // Five consecutive `init` passes must leave the tuned value intact and
+        // the file byte-stable.
+        let temp = TempDir::new().unwrap();
+        // The shipped template deliberately has NO maxConcurrent key — exactly
+        // the shape that makes a template-wins or fallback-copy bug show up as
+        // a silent revert to the built-in default.
+        let template = r#"{
+          "version": "2",
+          "autonomous": {"workFinder": {"enabled": true}}
+        }"#;
+        let (workspace, defaults) = setup_config_merge_repo(&temp, template);
+
+        let config_path = workspace.join(".loom").join("config.json");
+        fs::create_dir_all(workspace.join(".loom")).unwrap();
+        fs::write(
+            &config_path,
+            r#"{
+              "version": "2",
+              "autonomous": {"workFinder": {"enabled": true, "maxConcurrent": 10}}
+            }"#,
+        )
+        .unwrap();
+
+        let mut previous: Option<String> = None;
+        for pass in 1..=5 {
+            initialize_workspace(workspace.to_str().unwrap(), defaults.to_str().unwrap(), false)
+                .unwrap_or_else(|e| panic!("init pass {pass} failed: {e}"));
+
+            let raw = fs::read_to_string(&config_path).unwrap();
+            let merged: Value = serde_json::from_str(&raw).unwrap();
+            assert_eq!(
+                merged["autonomous"]["workFinder"]["maxConcurrent"],
+                serde_json::json!(10),
+                "operator-tuned maxConcurrent lost on init pass {pass}: {raw}"
+            );
+            // Sibling template keys still delivered, not clobbered by the merge.
+            assert_eq!(merged["autonomous"]["workFinder"]["enabled"], Value::Bool(true));
+
+            if let Some(prev) = &previous {
+                assert_eq!(
+                    prev, &raw,
+                    "config.json must be byte-stable from pass 2 onward (changed on pass {pass})"
+                );
+            }
+            previous = Some(raw);
+        }
+    }
+
+    #[test]
+    fn test_repeated_init_logs_merge_branch_and_no_effective_change() {
+        // AC1 (#4641): every call names its branch. A steady-state reinstall is
+        // a `merge-preserved` no-op and must say so, so an operator reading
+        // daemon.log can tell "init ran and changed nothing" apart from "init
+        // ran and rewrote your config".
+        let temp = TempDir::new().unwrap();
+        let template = r#"{"version": "2", "autonomous": {"workFinder": {"enabled": true}}}"#;
+        let (workspace, defaults) = setup_config_merge_repo(&temp, template);
+        fs::create_dir_all(workspace.join(".loom")).unwrap();
+        fs::write(
+            workspace.join(".loom").join("config.json"),
+            r#"{"version": "2", "autonomous": {"workFinder": {"enabled": true, "maxConcurrent": 10}}}"#,
+        )
+        .unwrap();
+
+        // Pass 1 delivers nothing new here (consumer is a superset), pass 2 is
+        // the steady state either way.
+        initialize_workspace(workspace.to_str().unwrap(), defaults.to_str().unwrap(), false)
+            .expect("first init");
+
+        let records = crate::test_log_capture::capture_logs(|| {
+            initialize_workspace(workspace.to_str().unwrap(), defaults.to_str().unwrap(), false)
+                .expect("second init");
+        });
+        let lines = config_log_lines(&records);
+        assert_eq!(lines.len(), 1, "exactly one config.json branch line expected, got {lines:?}");
+        let (level, msg) = &lines[0];
+        assert_eq!(*level, log::Level::Info, "a preserving merge is not a warning: {msg}");
+        assert!(msg.contains("merge-preserved"), "branch must be named: {msg}");
+        assert!(
+            msg.contains("no effective config change"),
+            "steady state must be explicit: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_merge_logs_diff_of_changed_keys() {
+        // AC1 (#4641): when the write actually changes effective config, the
+        // log carries a per-key diff — the artifact that was missing when the
+        // reported revert happened.
+        let temp = TempDir::new().unwrap();
+        let template = r#"{"version": "2", "newTemplateKey": "shipped", "nested": {"added": 7}}"#;
+        let (workspace, defaults) = setup_config_merge_repo(&temp, template);
+        fs::create_dir_all(workspace.join(".loom")).unwrap();
+        fs::write(workspace.join(".loom").join("config.json"), r#"{"version": "2"}"#).unwrap();
+
+        let records = crate::test_log_capture::capture_logs(|| {
+            initialize_workspace(workspace.to_str().unwrap(), defaults.to_str().unwrap(), false)
+                .expect("merge init");
+        });
+        let lines = config_log_lines(&records);
+        assert_eq!(lines.len(), 1, "exactly one config.json branch line expected, got {lines:?}");
+        let (level, msg) = &lines[0];
+        assert_eq!(*level, log::Level::Info);
+        assert!(msg.contains("merge-preserved"), "branch must be named: {msg}");
+        assert!(msg.contains("2 key(s) changed"), "change count must be reported: {msg}");
+        assert!(
+            msg.contains(r#"+ newTemplateKey = "shipped""#),
+            "added top-level key must appear in the diff: {msg}"
+        );
+        assert!(
+            msg.contains("+ nested.added = 7"),
+            "added nested key must appear with its dotted path: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_fresh_write_logs_branch() {
+        // AC1 (#4641): the fresh-install branch is distinguishable from a merge.
+        let temp = TempDir::new().unwrap();
+        let template = r#"{"version": "2", "offlineMode": false}"#;
+        let (workspace, defaults) = setup_config_merge_repo(&temp, template);
+
+        let records = crate::test_log_capture::capture_logs(|| {
+            initialize_workspace(workspace.to_str().unwrap(), defaults.to_str().unwrap(), false)
+                .expect("fresh init");
+        });
+        let lines = config_log_lines(&records);
+        assert_eq!(lines.len(), 1, "exactly one config.json branch line expected, got {lines:?}");
+        let (level, msg) = &lines[0];
+        assert_eq!(*level, log::Level::Info, "a fresh install is not a warning: {msg}");
+        assert!(msg.contains("fresh-write"), "branch must be named: {msg}");
+        assert!(msg.contains("2 key(s)"), "key count must be reported: {msg}");
+    }
+
+    #[test]
+    fn test_invalid_json_fallback_warns_and_names_discarded_keys() {
+        // AC4 (#4641): the one branch that discards operator config wholesale
+        // must log at warn! and name what it threw away. Presence alone is not
+        // enough — the level assertion is what stops a regression back to a
+        // bare eprintln!/debug! that never reaches daemon.log.
+        let temp = TempDir::new().unwrap();
+        let template = r#"{"version": "2", "offlineMode": false}"#;
+        let (workspace, defaults) = setup_config_merge_repo(&temp, template);
+        fs::create_dir_all(workspace.join(".loom")).unwrap();
+        // A torn/partial write: recognizable keys, unparseable overall.
+        let corrupt = r#"{"version": "2", "autonomous": {"workFinder": {"maxConcurrent": 10"#;
+        fs::write(workspace.join(".loom").join("config.json"), corrupt).unwrap();
+
+        let records = crate::test_log_capture::capture_logs(|| {
+            initialize_workspace(workspace.to_str().unwrap(), defaults.to_str().unwrap(), false)
+                .expect("init must not abort on invalid config");
+        });
+        let lines = config_log_lines(&records);
+        assert_eq!(lines.len(), 1, "exactly one config.json branch line expected, got {lines:?}");
+        let (level, msg) = &lines[0];
+        assert_eq!(*level, log::Level::Warn, "the clobbering branch must warn, not inform: {msg}");
+        assert!(msg.contains("invalid-JSON-fallback-overwrite"), "branch must be named: {msg}");
+        for key in ["version", "autonomous", "workFinder", "maxConcurrent"] {
+            assert!(msg.contains(key), "discarded key `{key}` must be named: {msg}");
+        }
+
+        // The discarded bytes are recoverable, not gone.
+        let backup = workspace.join(".loom").join("config.json.bak");
+        assert!(backup.exists(), "a rescue copy must be written before overwriting");
+        assert_eq!(fs::read_to_string(&backup).unwrap(), corrupt);
+        assert!(
+            msg.contains("config.json.bak"),
+            "the warning must point at the rescue copy: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_valid_json_but_not_an_object_hits_fallback_and_warns() {
+        // Edge case from the #4641 test plan: valid JSON, wrong shape (an
+        // array). It takes the same clobbering branch, so it needs the same
+        // warn-level evidence.
+        let temp = TempDir::new().unwrap();
+        let template = r#"{"version": "2", "offlineMode": false}"#;
+        let (workspace, defaults) = setup_config_merge_repo(&temp, template);
+        fs::create_dir_all(workspace.join(".loom")).unwrap();
+        fs::write(workspace.join(".loom").join("config.json"), r#"[{"maxConcurrent": 10}]"#)
+            .unwrap();
+
+        let records = crate::test_log_capture::capture_logs(|| {
+            initialize_workspace(workspace.to_str().unwrap(), defaults.to_str().unwrap(), false)
+                .expect("init must not abort on a non-object config");
+        });
+        let lines = config_log_lines(&records);
+        assert_eq!(lines.len(), 1, "exactly one config.json branch line expected, got {lines:?}");
+        let (level, msg) = &lines[0];
+        assert_eq!(*level, log::Level::Warn, "the clobbering branch must warn: {msg}");
+        assert!(msg.contains("invalid-JSON-fallback-overwrite"), "branch must be named: {msg}");
+        assert!(
+            msg.contains("valid JSON but not an object"),
+            "the reason must distinguish this case from a parse error: {msg}"
+        );
+        assert!(msg.contains("maxConcurrent"), "discarded key must be named: {msg}");
+        assert!(workspace.join(".loom").join("config.json.bak").exists());
+    }
+
+    #[test]
+    fn test_template_invalid_skip_warns_and_leaves_consumer_untouched() {
+        // AC1 (#4641): the fourth branch. A broken shipped template must not
+        // silently no-op — the consumer file survives, but the operator is told
+        // their install did not deliver template updates.
+        let temp = TempDir::new().unwrap();
+        let (workspace, defaults) = setup_config_merge_repo(&temp, "{ not json at all ,,,");
+        fs::create_dir_all(workspace.join(".loom")).unwrap();
+        let consumer = r#"{"version":"2","autonomous":{"workFinder":{"maxConcurrent":10}}}"#;
+        fs::write(workspace.join(".loom").join("config.json"), consumer).unwrap();
+
+        let records = crate::test_log_capture::capture_logs(|| {
+            initialize_workspace(workspace.to_str().unwrap(), defaults.to_str().unwrap(), false)
+                .expect("init must not abort on an invalid template");
+        });
+        let lines = config_log_lines(&records);
+        assert_eq!(lines.len(), 1, "exactly one config.json branch line expected, got {lines:?}");
+        let (level, msg) = &lines[0];
+        assert_eq!(*level, log::Level::Warn);
+        assert!(msg.contains("template-invalid-skip"), "branch must be named: {msg}");
+        assert_eq!(
+            fs::read_to_string(workspace.join(".loom").join("config.json")).unwrap(),
+            consumer,
+            "consumer config must be left byte-identical"
+        );
+    }
+
+    #[test]
+    fn test_describe_config_changes_unit() {
+        let before = serde_json::json!({
+            "kept": 1,
+            "changed": {"deep": "old"},
+            "dropped": true,
+            "arr": [1, 2]
+        });
+        let after = serde_json::json!({
+            "kept": 1,
+            "changed": {"deep": "new"},
+            "added": {"nested": 9},
+            "arr": [1, 2]
+        });
+        let changes = describe_config_changes(&before, &after);
+
+        assert!(
+            changes
+                .iter()
+                .any(|c| c == r#"~ changed.deep: "old" -> "new""#),
+            "changed leaf must render old -> new: {changes:?}"
+        );
+        assert!(
+            changes.iter().any(|c| c == "+ added.nested = 9"),
+            "added leaf must render with a dotted path: {changes:?}"
+        );
+        assert!(
+            changes.iter().any(|c| c == "- dropped (was true)"),
+            "dropped leaf must be reported: {changes:?}"
+        );
+        // Unchanged scalars and unchanged arrays produce no noise.
+        assert_eq!(changes.len(), 3, "unexpected extra changes: {changes:?}");
+        assert!(describe_config_changes(&before, &before).is_empty());
+    }
+
+    #[test]
+    fn test_salvage_key_names_unit() {
+        // Truncated mid-write — serde gives us nothing, so the scanner is the
+        // only source of "what did we just discard".
+        let keys = salvage_key_names(
+            r#"{"version": "2", "autonomous": {"workFinder": {"maxConcurrent": 10"#,
+        );
+        assert_eq!(keys, vec!["version", "autonomous", "workFinder", "maxConcurrent"]);
+
+        // Escaped quotes inside a value must not desynchronize the scan, and a
+        // repeated key is reported once.
+        let keys = salvage_key_names(r#"{"a": "he said \"hi\": not a key", "b": 1, "a": 2"#);
+        assert_eq!(keys, vec!["a", "b"]);
+
+        // No key-shaped text at all.
+        assert!(salvage_key_names("[1, 2, 3]").is_empty());
+        assert!(salvage_key_names("").is_empty());
+    }
+
+    #[test]
+    fn test_summarize_list_elides_past_cap() {
+        let short: Vec<String> = (0..3).map(|i| format!("k{i}")).collect();
+        assert_eq!(summarize_list(&short), "k0; k1; k2");
+
+        let long: Vec<String> = (0..MAX_LOGGED_ENTRIES + 5)
+            .map(|i| format!("k{i}"))
+            .collect();
+        let rendered = summarize_list(&long);
+        assert!(rendered.contains("k0"), "{rendered}");
+        assert!(rendered.ends_with("… and 5 more"), "{rendered}");
+        assert!(!rendered.contains("k24"), "entries past the cap must be elided: {rendered}");
     }
 
     #[test]

--- a/loom-daemon/src/init/post_init.rs
+++ b/loom-daemon/src/init/post_init.rs
@@ -176,6 +176,11 @@ pub const EPHEMERAL_PATTERNS: &[&str] = &[
     // untracked file that a consumer's `git add -A` swept into a commit. Defense
     // in depth: ignore the whole class rather than one filename.
     ".loom/*.tmp",
+    // Rescue copy written by `init::merge_config_file` before it overwrites an
+    // unparseable `.loom/config.json` with the shipped template (#4641). It
+    // exists so an operator can recover hand-tuned keys after a torn write, but
+    // it is machine-local salvage — never something to commit.
+    ".loom/*.bak",
     ".loom/logs/",
 ];
 

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -186,6 +186,11 @@ pub mod serve;
 pub mod sweep_journal;
 pub mod sweep_registry;
 pub mod terminal;
+/// Test-only capturing logger (see module docs) — single-sourced so the crate's
+/// one-per-process `log::set_boxed_logger` installation is shared by every test
+/// module that asserts on log severity.
+#[cfg(test)]
+pub mod test_log_capture;
 pub mod token_ranking_refresh;
 pub mod tokens;
 pub mod tokens_pool;

--- a/loom-daemon/src/main_health_gate.rs
+++ b/loom-daemon/src/main_health_gate.rs
@@ -3186,62 +3186,14 @@ mod tests {
     // Capturing logger (#4083) — a tiny `log::Log` impl so the green-path
     // severity can be asserted and cannot silently regress to `debug!`.
     //
-    // The global logger can only be installed once per process and tests run
-    // in parallel, so records are routed into a *thread-local* buffer that is
-    // only collected while `capture_logs` is active on the calling thread.
-    // Any log emitted by a concurrent test lands in that other thread's
-    // (inactive) buffer and is dropped — so capture is race-free without
-    // serializing the whole suite.
+    // The implementation moved to `crate::test_log_capture` (#4641) because
+    // `log::set_boxed_logger` succeeds only ONCE per process and every
+    // `#[cfg(test)]` module compiles into the same test binary: a second
+    // per-module logger would silently lose every record for whichever module
+    // lost the race. This alias keeps the `capture::capture_logs(...)` call
+    // sites below unchanged.
     // ===================================================================
-    mod capture {
-        use log::{Level, Log, Metadata, Record};
-        use std::cell::RefCell;
-        use std::sync::Once;
-
-        thread_local! {
-            static RECORDS: RefCell<Vec<(Level, String)>> = const { RefCell::new(Vec::new()) };
-            static ACTIVE: RefCell<bool> = const { RefCell::new(false) };
-        }
-
-        struct CaptureLogger;
-
-        impl Log for CaptureLogger {
-            fn enabled(&self, _: &Metadata) -> bool {
-                true
-            }
-            fn log(&self, record: &Record) {
-                ACTIVE.with(|a| {
-                    if *a.borrow() {
-                        RECORDS.with(|r| {
-                            r.borrow_mut()
-                                .push((record.level(), record.args().to_string()));
-                        });
-                    }
-                });
-            }
-            fn flush(&self) {}
-        }
-
-        static INIT: Once = Once::new();
-
-        /// Run `f`, returning every `(Level, message)` it logged on this thread.
-        pub fn capture_logs<F: FnOnce()>(f: F) -> Vec<(Level, String)> {
-            INIT.call_once(|| {
-                // `set_max_level(Trace)` is required — without it the log macros
-                // short-circuit before reaching the logger. Because it is set to
-                // the most permissive level, a regression of the green path from
-                // `info!` to `debug!` would still be *captured* (as `Debug`), so
-                // the level assertion — not mere presence — is what guards it.
-                let _ = log::set_boxed_logger(Box::new(CaptureLogger));
-                log::set_max_level(log::LevelFilter::Trace);
-            });
-            RECORDS.with(|r| r.borrow_mut().clear());
-            ACTIVE.with(|a| *a.borrow_mut() = true);
-            f();
-            ACTIVE.with(|a| *a.borrow_mut() = false);
-            RECORDS.with(|r| r.borrow_mut().clone())
-        }
-    }
+    use crate::test_log_capture as capture;
 
     // ===================================================================
     // Green-path log severity (#4083)

--- a/loom-daemon/src/test_log_capture.rs
+++ b/loom-daemon/src/test_log_capture.rs
@@ -1,0 +1,66 @@
+//! Test-only capturing `log::Log` implementation shared across the crate.
+//!
+//! Several test modules need to assert on the **severity** of a production log
+//! line (not merely that some side effect happened) — e.g. the main-health-gate
+//! green path (#4083) and `init::merge_config_file`'s config-rewrite branch
+//! logging (#4641).
+//!
+//! `log::set_boxed_logger` can only succeed **once per process**, and every
+//! `#[cfg(test)]` module in this crate compiles into the *same* test binary. If
+//! each module installed its own capturing logger, whichever module's test ran
+//! first would win and every other module's capture would silently return an
+//! empty record list — a flaky, order-dependent false pass. Single-sourcing the
+//! logger here guarantees exactly one installation for the whole binary.
+//!
+//! Records are routed into a **thread-local** buffer that is only collected
+//! while [`capture_logs`] is active on the calling thread, so logs emitted by a
+//! concurrently-running test land in that other thread's (inactive) buffer and
+//! are dropped. Capture is therefore race-free without serializing the suite.
+
+use log::{Level, Log, Metadata, Record};
+use std::cell::RefCell;
+use std::sync::Once;
+
+thread_local! {
+    static RECORDS: RefCell<Vec<(Level, String)>> = const { RefCell::new(Vec::new()) };
+    static ACTIVE: RefCell<bool> = const { RefCell::new(false) };
+}
+
+struct CaptureLogger;
+
+impl Log for CaptureLogger {
+    fn enabled(&self, _: &Metadata) -> bool {
+        true
+    }
+    fn log(&self, record: &Record) {
+        ACTIVE.with(|a| {
+            if *a.borrow() {
+                RECORDS.with(|r| {
+                    r.borrow_mut()
+                        .push((record.level(), record.args().to_string()));
+                });
+            }
+        });
+    }
+    fn flush(&self) {}
+}
+
+static INIT: Once = Once::new();
+
+/// Run `f`, returning every `(Level, message)` it logged on this thread.
+pub fn capture_logs<F: FnOnce()>(f: F) -> Vec<(Level, String)> {
+    INIT.call_once(|| {
+        // `set_max_level(Trace)` is required — without it the log macros
+        // short-circuit before reaching the logger. Because it is set to the
+        // most permissive level, a regression of a line from `warn!`/`info!`
+        // down to `debug!` is still *captured* (as `Debug`), so the level
+        // assertion — not mere presence — is what guards the severity.
+        let _ = log::set_boxed_logger(Box::new(CaptureLogger));
+        log::set_max_level(log::LevelFilter::Trace);
+    });
+    RECORDS.with(|r| r.borrow_mut().clear());
+    ACTIVE.with(|a| *a.borrow_mut() = true);
+    f();
+    ACTIVE.with(|a| *a.borrow_mut() = false);
+    RECORDS.with(|r| r.borrow_mut().clone())
+}


### PR DESCRIPTION
Closes #4641

## Root cause

`merge_config_file()` (`loom-daemon/src/init/mod.rs`) is the **only** production writer of `.loom/config.json` — the curated issue rules out `resync-installed.sh` (declares the file out of scope) and `calibrate --write` (inert since #4512), and this PR does not re-propose either.

Its deep merge is existing-wins, so a nested operator-only key like `autonomous.workFinder.maxConcurrent` survives normally. Two gaps made the reported silent reversion possible *and* undiagnosable:

1. **The fallback branch clobbers everything, quietly.** When the on-disk file does not parse as a JSON object (a torn write from a concurrent writer, a hand-edit syntax error, or a top-level array), the function `fs::copy`s the shipped template over it — discarding every consumer key behind a bare `eprintln!` that vanishes when `loom-daemon init` runs unattended inside a provisioning script.
2. **`fleet::add_worker::render_workspace_clone()` re-entered the merge on every run.** Its `loom-daemon init` call was unconditional — unlike the `gh repo clone` directly above it, which has always been guarded by `[ ! -d .../.git ]` — so any repeat `fleet add-worker` / self-heal pass re-ran the merge against a workspace an operator had since hand-tuned. The reporting host `loom-worker-1` was provisioned through exactly this path.

## Fix

**Observability (AC1).** Every call emits exactly one greppable line:

```
grep 'init: config.json:' ~/.loom/daemon.log
```

| Branch | Level | Meaning |
|---|---|---|
| `fresh-write` | `info` | No config existed; template written verbatim (with key count). |
| `merge-preserved` | `info` | Existing values kept. Carries a leaf-level diff or "no effective config change". |
| `template-invalid-skip` | `warn` | Shipped template unparseable; consumer file untouched (and got no updates). |
| `invalid-JSON-fallback-overwrite` | `warn` | **Config replaced by the template** — names the discarded keys and the rescue copy. |

The diff renders `+ path = value`, `~ path: old -> new`, `- path (was value)` with dotted paths, arrays compared wholesale (matching the merge primitive), elided past 20 entries so a large template cannot emit a multi-kilobyte line. Under existing-wins semantics only `+` entries are expected; a `~` or `-` is the signal that a consumer value was overwritten.

**Recoverability.** The clobbering branch now copies the unparseable bytes to `.loom/config.json.bak` *before* overwriting, and names the keys it discarded — salvaged by a small scanner, since `serde_json` can enumerate nothing from text that failed to parse. `.loom/*.bak` was added to `EPHEMERAL_PATTERNS` and `.gitignore` so salvage never gets committed.

**Re-entry (AC2).** `render_workspace_clone()` now gates `loom-daemon init` on `.loom/config.json` being absent. Provisioning only needs `init` to *establish* a workspace; keeping an established one current is `loom update` / resync's job, and neither touches `.loom/config.json`. Gating on the config file rather than on "we just cloned" still self-heals a workspace whose earlier `init` failed. The step's completion check (`test -d .git`) is unaffected.

## Tests

- **AC3** — `test_operator_nested_key_survives_repeated_init`: **five** consecutive `init` passes over an already-configured workspace keep `autonomous.workFinder.maxConcurrent = 10` and the file is byte-stable from pass 2 onward. The fixture template deliberately omits `maxConcurrent`, which is the exact shape that makes a template-wins or fallback-copy bug surface as a silent revert to the built-in default.
- **AC4** — `test_invalid_json_fallback_warns_and_names_discarded_keys`: asserts `log::Level::Warn` (not mere presence — a regression back to `eprintln!`/`debug!` fails), the branch name, all four discarded key names, and that the `.bak` rescue copy exists with the original bytes.
- Plus: the other three branches asserted by name and severity, valid-JSON-but-an-array taking the same clobbering path (the edge case from the issue's test plan), and unit coverage of the diff / salvage / elision helpers.

The capturing logger moved from `main_health_gate`'s test module to `crate::test_log_capture`: `log::set_boxed_logger` succeeds only **once per process** and every `#[cfg(test)]` module compiles into the same binary, so a second per-module logger would have silently returned empty records for whichever module lost the race — an order-dependent false pass. Call sites are unchanged via a `use ... as capture` alias.

## Verification

`cargo build`, `cargo fmt --all -- --check`, CI's exact `cargo clippy` invocation, `cargo test --workspace`, and `defaults/scripts/tests/test-install-reinstall-safety.sh` all pass.

Operator-facing behavior (the branch table, the `.bak` recovery path) is documented in a new troubleshooting subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)