### PR TITLE
feat(daemon): journal terminal sweep outcomes durably, force-trip pool-dead advisory

### DIFF
--- a/loom-daemon/src/event_bus.rs
+++ b/loom-daemon/src/event_bus.rs
@@ -72,6 +72,19 @@
 //! strings (`publish` does not reject unknown topics) so the publisher side
 //! stays open for future extension, but the documented taxonomy is the
 //! contract subscribers should rely on.
+//!
+//! # Durability (Issue #4644)
+//!
+//! This bus is **in-memory only** — a bounded [`tokio::sync::broadcast`]
+//! channel. A published event with no attached subscriber (or one that
+//! disconnects/lags past the buffer) is gone forever; nothing here persists
+//! across a daemon restart. For `sweep.issue.{N}.exited` / `.crashed`
+//! specifically, [`crate::sweep_outcomes`] closes that gap with a durable,
+//! append-only on-disk journal (`<workspace>/.loom/logs/sweep-outcomes.jsonl`)
+//! written at the same emit sites, additively — this bus's behavior and topic
+//! contract are unchanged. Consult that module when a terminal outcome needs
+//! to be queryable after the sweep registry's ~1h in-memory GC window, or
+//! after a daemon restart.
 
 use crate::types::Event;
 

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -184,6 +184,7 @@ pub mod script_helpers;
 pub mod self_update;
 pub mod serve;
 pub mod sweep_journal;
+pub mod sweep_outcomes;
 pub mod sweep_registry;
 pub mod terminal;
 pub mod token_ranking_refresh;

--- a/loom-daemon/src/sweep_outcomes.rs
+++ b/loom-daemon/src/sweep_outcomes.rs
@@ -1,0 +1,334 @@
+//! Durable, append-only journal of terminal sweep outcomes (Issue #4644).
+//!
+//! ## Problem
+//!
+//! The event bus ([`crate::event_bus`]) is an in-memory-only `tokio::sync::
+//! broadcast` channel: an `Event::SweepExited` / `Event::SweepCrashed`
+//! published with no attached subscriber is simply gone. The sweep registry's
+//! in-memory entries additionally GC ~1h after a terminal transition
+//! (`TERMINAL_RETENTION_SECS` in [`crate::sweep_registry`]). So the ONLY trace
+//! of a terminal sweep outcome that survives longer than an hour is prose
+//! inside the per-issue log file (`.loom/logs/sweep-issue-N.log`) — invisible
+//! to any tool and expensive for an operator to grep across many issues after
+//! the fact (the incident this issue documents: half of an 8-issue overnight
+//! batch died at token selection, in under a second each, with zero durable
+//! trace anywhere other than log prose).
+//!
+//! ## Fix
+//!
+//! [`SweepRegistry`](crate::sweep_registry::SweepRegistry) appends one JSON
+//! line ([`OutcomeRecord`]) to `<workspace>/.loom/logs/sweep-outcomes.jsonl`
+//! (override via [`OUTCOMES_JOURNAL_PATH_ENV`], mirroring
+//! [`crate::sweep_journal::JOURNAL_PATH_ENV`]) at every site that already
+//! emits a terminal `SweepExited`/`SweepCrashed` bus event for a single-issue
+//! sweep — the reaper's dead-child handling in `reap_once`, and the
+//! operator/watchdog-initiated `finish_cancel`. This is purely additive: the
+//! bus events are unchanged, and the write is best-effort (a failure is logged
+//! and swallowed, never allowed to block reaping — see the module doc on
+//! [`crate::sweep_journal`] for the same philosophy applied to the sibling
+//! liveness journal).
+//!
+//! Each line carries everything a post-hoc reader needs without touching log
+//! prose: `issue`, `sweep_id`, `outcome` (`"exited"`/`"crashed"`),
+//! `exit_code`, `death_class` (carries e.g. `preflight-token-selection-failed`
+//! for the token-selection-death shape this issue targets — see
+//! `sweep_registry::preflight_death_signatures`), `token_name`, and
+//! `duration_sec`.
+//!
+//! Unlike [`crate::sweep_journal`] (a machine-level, upsert-keyed *liveness*
+//! snapshot — one row per currently-tracked sweep, pruned as sweeps end), this
+//! is a per-workspace, **append-only history** — every terminal outcome gets
+//! its own line, forever (bounded by rotation, see below). The two journals
+//! answer different questions ("is this sweep still alive?" vs. "what
+//! happened to every sweep that has ever ended?") and are intentionally
+//! separate files.
+//!
+//! ## Rotation
+//!
+//! A daemon runs for weeks, so the journal is bounded: [`append_outcome`]
+//! rotates the current file to a single `.1` sibling (overwriting any
+//! previous backup) once it exceeds [`MAX_JOURNAL_BYTES`] OR its oldest
+//! (first) line is older than [`MAX_JOURNAL_AGE_DAYS`]. Rotation keeps at
+//! most one full generation of history beyond the live file — adequate for
+//! the "query recent terminal outcomes" use case this journal exists for,
+//! without unbounded growth.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::io::{BufRead, Write};
+use std::path::{Path, PathBuf};
+
+/// Environment override for the outcomes journal path (test seam), mirrors
+/// [`crate::sweep_journal::JOURNAL_PATH_ENV`].
+pub const OUTCOMES_JOURNAL_PATH_ENV: &str = "LOOM_SWEEP_OUTCOMES_JOURNAL_PATH";
+
+/// Default filename under `<workspace_root>/.loom/logs/`.
+pub const OUTCOMES_JOURNAL_FILENAME: &str = "sweep-outcomes.jsonl";
+
+/// Rotate the journal once it grows past this size — keeps the file bounded
+/// across a daemon that runs for weeks (#4644).
+pub const MAX_JOURNAL_BYTES: u64 = 5 * 1024 * 1024; // 5 MiB
+
+/// Rotate the journal once its oldest (first) recorded line is older than
+/// this many days, even if it never reached [`MAX_JOURNAL_BYTES`] (a
+/// low-traffic workspace should not carry multi-month-old lines forever).
+pub const MAX_JOURNAL_AGE_DAYS: i64 = 30;
+
+/// One append-only journal line: a single terminal sweep outcome, carrying
+/// everything a post-hoc reader needs to diagnose it without reading log
+/// prose (#4644 AC1/AC2).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OutcomeRecord {
+    /// When this outcome was recorded (reap/cancel time, not the original
+    /// spawn time — `duration_sec` carries the elapsed lifetime).
+    pub timestamp: DateTime<Utc>,
+    /// The owning workspace root, formatted identically to
+    /// [`crate::types::SweepInfo::repo`].
+    pub repo: String,
+    /// The GitHub/Gitea issue number this sweep was working.
+    pub issue: u32,
+    /// Stable opaque ID assigned at dispatch time.
+    pub sweep_id: String,
+    /// `"exited"` (clean/dirty process exit observed by the reaper, or an
+    /// operator/watchdog-initiated cancel) or `"crashed"` (the reaper found a
+    /// checkpoint, i.e. this run made some prior lifecycle progress before
+    /// dying).
+    pub outcome: String,
+    /// Process exit code, when known. `None` for a cancel (no code to report)
+    /// or an unrecoverable signal death.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    /// Machine-readable death classification, when the reaper's pre-flight
+    /// classifier matched — see `sweep_registry::classify_preflight_outcome`.
+    /// Carries `preflight-token-selection-failed` for the token-selection-death
+    /// shape this issue targets, distinguishable here without reading log
+    /// prose (#4644 AC2). `None` for a death that reached `# CLAUDE_CLI_START`,
+    /// an unreadable log, or a manual cancel.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub death_class: Option<String>,
+    /// Token account name selected by `spawn-claude.sh` for this run, or
+    /// `"unknown"` when never surfaced (mirrors `SweepInfo::token_name`).
+    pub token_name: String,
+    /// Elapsed wall-clock seconds from dispatch to this terminal outcome.
+    pub duration_sec: i64,
+}
+
+/// Resolve the default outcomes journal path: [`OUTCOMES_JOURNAL_PATH_ENV`]
+/// override (non-empty), else `<workspace_root>/.loom/logs/sweep-outcomes.jsonl`.
+#[must_use]
+pub fn default_outcomes_path(workspace_root: &Path) -> PathBuf {
+    if let Ok(path) = std::env::var(OUTCOMES_JOURNAL_PATH_ENV) {
+        if !path.is_empty() {
+            return PathBuf::from(path);
+        }
+    }
+    workspace_root
+        .join(".loom")
+        .join("logs")
+        .join(OUTCOMES_JOURNAL_FILENAME)
+}
+
+/// Append `record` as one JSON line to `path`, creating parent directories as
+/// needed and rotating the file first if it has grown oversized/stale (see
+/// [`rotate_if_needed`]).
+///
+/// Best-effort by contract: callers (`SweepRegistry::reap_once` /
+/// `finish_cancel`) log a warning on `Err` but never let a journal-write
+/// failure block reaping (#4644 — mirrors [`crate::sweep_journal`]'s
+/// philosophy). Deliberately NOT coupled to event-bus publish success: the two
+/// are independent best-effort side effects of the same terminal transition.
+pub fn append_outcome(path: &Path, record: &OutcomeRecord) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating outcomes journal dir {}", parent.display()))?;
+    }
+    rotate_if_needed(path)?;
+    let line = serde_json::to_string(record).context("serializing sweep outcome record")?;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("opening outcomes journal {}", path.display()))?;
+    writeln!(file, "{line}")
+        .with_context(|| format!("appending to outcomes journal {}", path.display()))?;
+    Ok(())
+}
+
+/// Rotate `path` to a single `.1` sibling (overwriting any previous backup)
+/// when it has grown past [`MAX_JOURNAL_BYTES`] OR its oldest recorded line is
+/// older than [`MAX_JOURNAL_AGE_DAYS`]. A missing file is neither oversized
+/// nor stale (no-op) — the common "first write ever" case.
+fn rotate_if_needed(path: &Path) -> Result<()> {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return Ok(());
+    };
+    let oversized = meta.len() >= MAX_JOURNAL_BYTES;
+    let stale = !oversized && is_stale(path);
+    if !oversized && !stale {
+        return Ok(());
+    }
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(OUTCOMES_JOURNAL_FILENAME);
+    let backup = path.with_file_name(format!("{file_name}.1"));
+    std::fs::rename(path, &backup)
+        .with_context(|| format!("rotating {} -> {}", path.display(), backup.display()))?;
+    Ok(())
+}
+
+/// Whether `path`'s oldest (first) line is older than [`MAX_JOURNAL_AGE_DAYS`].
+/// Any read/parse failure is treated as "not stale" — rotation is a bounded-
+/// growth nicety, not something a corrupt first line should trigger
+/// spuriously.
+fn is_stale(path: &Path) -> bool {
+    let Ok(file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let mut reader = std::io::BufReader::new(file);
+    let mut first_line = String::new();
+    if reader.read_line(&mut first_line).unwrap_or(0) == 0 {
+        return false;
+    }
+    let Ok(record) = serde_json::from_str::<OutcomeRecord>(first_line.trim()) else {
+        return false;
+    };
+    Utc::now() - record.timestamp > chrono::Duration::days(MAX_JOURNAL_AGE_DAYS)
+}
+
+/// Read every parseable [`OutcomeRecord`] line from `path`, in file order.
+/// Missing file yields an empty vec; a malformed line is skipped (best-effort
+/// reader, matching the writer's best-effort contract) rather than aborting
+/// the whole read.
+#[must_use]
+pub fn read_all(path: &Path) -> Vec<OutcomeRecord> {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    contents
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn record(issue: u32, outcome: &str) -> OutcomeRecord {
+        OutcomeRecord {
+            timestamp: Utc::now(),
+            repo: "/repo/a".to_string(),
+            issue,
+            sweep_id: format!("sweep-issue-{issue}-0"),
+            outcome: outcome.to_string(),
+            exit_code: Some(78),
+            death_class: Some("preflight-token-selection-failed".to_string()),
+            token_name: "agent-1".to_string(),
+            duration_sec: 1,
+        }
+    }
+
+    #[test]
+    fn append_then_read_all_round_trips() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sweep-outcomes.jsonl");
+
+        append_outcome(&path, &record(1, "crashed")).unwrap();
+        append_outcome(&path, &record(2, "exited")).unwrap();
+
+        let records = read_all(&path);
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].issue, 1);
+        assert_eq!(records[0].outcome, "crashed");
+        assert_eq!(records[0].death_class.as_deref(), Some("preflight-token-selection-failed"));
+        assert_eq!(records[1].issue, 2);
+        assert_eq!(records[1].outcome, "exited");
+    }
+
+    #[test]
+    fn append_creates_parent_dirs() {
+        let dir = tempdir().unwrap();
+        let path = dir
+            .path()
+            .join("nested")
+            .join("logs")
+            .join("sweep-outcomes.jsonl");
+        append_outcome(&path, &record(1, "crashed")).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn read_all_missing_file_is_empty() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sweep-outcomes.jsonl");
+        assert!(read_all(&path).is_empty());
+    }
+
+    #[test]
+    fn read_all_skips_malformed_lines() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sweep-outcomes.jsonl");
+        std::fs::write(&path, "{ not json }\n").unwrap();
+        append_outcome(&path, &record(1, "crashed")).unwrap();
+        let records = read_all(&path);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].issue, 1);
+    }
+
+    #[test]
+    fn rotate_on_oversized_journal_preserves_one_backup_generation() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sweep-outcomes.jsonl");
+
+        // Seed a file already past the size cap so the NEXT append rotates it
+        // before writing the new line.
+        let padding = "x".repeat(MAX_JOURNAL_BYTES as usize + 1);
+        std::fs::write(&path, format!("{padding}\n")).unwrap();
+
+        append_outcome(&path, &record(99, "crashed")).unwrap();
+
+        let backup = dir.path().join("sweep-outcomes.jsonl.1");
+        assert!(backup.exists(), "oversized journal should be rotated to a .1 backup");
+        assert!(std::fs::read_to_string(&backup).unwrap().contains(&padding));
+
+        // The live file now contains ONLY the fresh line, not the old padding.
+        let records = read_all(&path);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].issue, 99);
+    }
+
+    #[test]
+    fn rotate_on_stale_first_line_even_when_small() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sweep-outcomes.jsonl");
+
+        let mut stale = record(1, "crashed");
+        stale.timestamp = Utc::now() - chrono::Duration::days(MAX_JOURNAL_AGE_DAYS + 1);
+        std::fs::write(&path, format!("{}\n", serde_json::to_string(&stale).unwrap())).unwrap();
+
+        append_outcome(&path, &record(2, "exited")).unwrap();
+
+        let backup = dir.path().join("sweep-outcomes.jsonl.1");
+        assert!(backup.exists(), "a journal whose oldest line is stale should rotate");
+        let records = read_all(&path);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].issue, 2, "live file should only carry the fresh line post-rotation");
+    }
+
+    #[test]
+    fn default_outcomes_path_is_under_loom_logs() {
+        let workspace = Path::new("/workspace/repo");
+        let path = default_outcomes_path(workspace);
+        assert_eq!(
+            path,
+            workspace
+                .join(".loom")
+                .join("logs")
+                .join("sweep-outcomes.jsonl")
+        );
+    }
+}

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -51,10 +51,12 @@
 //! after a daemon restart wipes this in-memory registry. See
 //! [`crate::claim_reconciliation`] for the startup consumer.
 
+use crate::capacity;
 use crate::event_bus::EventBus;
 use crate::peer_claims::{self, ClaimAd, PeerClaimView};
 use crate::quarantine_reconciliation;
 use crate::sweep_journal;
+use crate::sweep_outcomes;
 use crate::tokens_pool::bad_tokens;
 use crate::tokens_pool::{self, AccountId, AccountProvider, TerminalClassification};
 use crate::types::{Event, SweepId, SweepInfo, SweepKind, SweepOutcome, SweepState};
@@ -1840,14 +1842,35 @@ fn classify_account_exhaustion(log_tail: &str) -> Option<&'static str> {
 fn preflight_death_signatures() -> &'static [(&'static str, Regex)] {
     static SIGS: OnceLock<Vec<(&'static str, Regex)>> = OnceLock::new();
     SIGS.get_or_init(|| {
-        vec![(
-            "preflight-mcp-failed",
-            // Emitted by claude-wrapper.sh's MCP-init pre-flight check right
-            // before it bails without ever exec'ing the CLI. Case-sensitive:
-            // a literal sentinel token, not free-form prose (mirrors
-            // `RATE_LIMIT_ABORT` in `exhaustion_signatures`).
-            Regex::new(r"#\s*MCP_PREFLIGHT_FAILED").expect("valid static preflight regex"),
-        )]
+        vec![
+            (
+                "preflight-mcp-failed",
+                // Emitted by claude-wrapper.sh's MCP-init pre-flight check right
+                // before it bails without ever exec'ing the CLI. Case-sensitive:
+                // a literal sentinel token, not free-form prose (mirrors
+                // `RATE_LIMIT_ABORT` in `exhaustion_signatures`).
+                Regex::new(r"#\s*MCP_PREFLIGHT_FAILED").expect("valid static preflight regex"),
+            ),
+            (
+                // Issue #4644: `spawn-claude.sh`'s "Token selection" step exits
+                // 78 (`EX_CONFIG`) on any of three distinct failures — no
+                // `loom-daemon` binary supporting `tokens select`, the select
+                // subcommand itself failing (typically an empty/exhausted
+                // pool), or a selection that resolved to an empty key — before
+                // ever touching the CLI. Matching this exact prose gives the
+                // reaper a machine-readable `token_selection_failed`-shaped
+                // label distinct from the generic absence-based
+                // `preflight-no-cli-start` fallback below, so a durable
+                // journal reader (or an operator) can tell "the token pool
+                // itself is the problem" apart from other pre-flight causes
+                // (a stale `.mcp.json`, etc.) without reading log prose.
+                "preflight-token-selection-failed",
+                Regex::new(
+                    r"(?i)token selection failed|token selection returned an empty key|no loom-daemon binary supporting 'tokens select'",
+                )
+                .expect("valid static token-selection preflight regex"),
+            ),
+        ]
     })
 }
 
@@ -2081,6 +2104,15 @@ pub struct SweepRegistryConfig {
     /// tempdir path so `dispatch`/reap never touch the real machine-level
     /// file.
     pub journal_path: Option<PathBuf>,
+    /// Override the durable terminal-outcomes journal path (Issue #4644).
+    /// Defaults to [`sweep_outcomes::default_outcomes_path`]
+    /// (`<workspace_root>/.loom/logs/sweep-outcomes.jsonl`,
+    /// env-overridable via `LOOM_SWEEP_OUTCOMES_JOURNAL_PATH`). Tests set this
+    /// to a tempdir path so terminal-outcome recording never touches a real
+    /// workspace's log directory. Unlike [`journal_path`](Self::journal_path)
+    /// (a machine-level, upsert-keyed liveness snapshot), this is a per-
+    /// workspace, append-only history of every terminal sweep outcome.
+    pub outcomes_journal_path: Option<PathBuf>,
 }
 
 impl SweepRegistryConfig {
@@ -2093,6 +2125,7 @@ impl SweepRegistryConfig {
             gh_bin: None,
             skip_label_flip: false,
             journal_path: None,
+            outcomes_journal_path: None,
         }
     }
 
@@ -2103,6 +2136,16 @@ impl SweepRegistryConfig {
             return Ok(p.clone());
         }
         sweep_journal::default_journal_path()
+    }
+
+    /// Resolve the durable terminal-outcomes journal path (Issue #4644):
+    /// `outcomes_journal_path` explicit override, else
+    /// [`sweep_outcomes::default_outcomes_path`].
+    #[must_use]
+    pub fn resolve_outcomes_journal_path(&self) -> PathBuf {
+        self.outcomes_journal_path
+            .clone()
+            .unwrap_or_else(|| sweep_outcomes::default_outcomes_path(&self.workspace_root))
     }
 
     /// Resolve the spawn binary, preferring (in order):
@@ -2663,7 +2706,11 @@ impl SweepRegistry {
 
     /// Current pre-flight-death advisory state (Issue #4386), for
     /// `DaemonStatusReport`: `(tripped, message)`. `message` is always `None`
-    /// when `tripped` is `false`.
+    /// when `tripped` is `false`. Issue #4644: when a live re-read of
+    /// `.ranking` still confirms zero healthy accounts, the message names
+    /// that specific whole-pool-dead cause instead of the generic streak
+    /// wording — so `loom-daemon status` never reads as a garden-variety
+    /// `.mcp.json` hint while the entire account pool is actually dead.
     #[must_use]
     pub fn preflight_advisory(&self) -> (bool, Option<String>) {
         if !self.preflight_advisory_tripped {
@@ -2673,11 +2720,7 @@ impl SweepRegistry {
             .preflight_death_last_marker
             .as_deref()
             .unwrap_or("unknown");
-        let message = format!(
-            "WARNING: last {} dispatches died at claude-wrapper pre-flight ({marker}) — check \
-             .mcp.json",
-            self.preflight_death_streak
-        );
+        let message = self.preflight_advisory_message(self.preflight_pool_exhausted_now(), marker);
         (true, Some(message))
     }
 
@@ -4136,6 +4179,54 @@ impl SweepRegistry {
         }
     }
 
+    /// Append one line to the durable terminal-outcomes journal (Issue #4644)
+    /// for a single-issue sweep's terminal transition. Called at every site
+    /// that already emits a terminal `SweepExited`/`SweepCrashed` bus event —
+    /// the reaper's dead-child handling in [`reap_once`](Self::reap_once) and
+    /// the operator/watchdog-initiated [`finish_cancel`](Self::finish_cancel)
+    /// — so the record outlives both the in-memory registry's ~1h GC window
+    /// and the in-memory-only event bus.
+    ///
+    /// Best-effort by contract, matching [`journal_remove_best_effort`](Self::journal_remove_best_effort):
+    /// a write failure is logged and swallowed, never allowed to block
+    /// reaping. Deliberately independent of the bus emission's own success —
+    /// the two are separate side effects of the same terminal transition (see
+    /// the `sweep_outcomes` module doc).
+    fn append_outcome_journal(
+        &self,
+        issue: u32,
+        sweep_id: &str,
+        outcome: &str,
+        exit_code: Option<i32>,
+        death_class: Option<String>,
+        duration_sec: i64,
+    ) {
+        let path = self.config.resolve_outcomes_journal_path();
+        let token_name = self
+            .entries
+            .get(sweep_id)
+            .map(|info| info.token_name.clone())
+            .unwrap_or_else(|| UNKNOWN_TOKEN_NAME.to_string());
+        let record = sweep_outcomes::OutcomeRecord {
+            timestamp: Utc::now(),
+            repo: self.config.workspace_root.display().to_string(),
+            issue,
+            sweep_id: sweep_id.to_string(),
+            outcome: outcome.to_string(),
+            exit_code,
+            death_class,
+            token_name,
+            duration_sec,
+        };
+        if let Err(e) = sweep_outcomes::append_outcome(&path, &record) {
+            log::warn!(
+                "sweep_outcomes: failed to append terminal-outcome journal entry for issue \
+                 #{issue} ({sweep_id}) at {}: {e} — best-effort, not blocking reap (#4644)",
+                path.display()
+            );
+        }
+    }
+
     // ------------------------------------------------------------------------
     // Cross-host collision detection (Issue #4085, Phase 0 of #4028)
     // ------------------------------------------------------------------------
@@ -4791,39 +4882,89 @@ impl SweepRegistry {
     /// same dedup discipline `daemon.capacity.advisory` /
     /// `daemon.dispatch.headroom_advisory` use, so this never fires every
     /// tick.
+    ///
+    /// Issue #4644: waiting for `threshold` *consecutive* pre-flight deaths
+    /// (the ordinary #4386 streak gate) is the wrong cadence for the "whole
+    /// account pool is dead" case — when `healthy_accounts == 0`, EVERY
+    /// future dispatch will die identically at token selection, so the very
+    /// FIRST such death already proves it. `pool_exhausted_now` force-trips
+    /// immediately (bypassing the streak/threshold check) whenever the live
+    /// `.ranking` snapshot confirms zero healthy accounts, so the operator
+    /// hears one aggregate signal on the first death rather than after N
+    /// per-issue error blocks accumulate silently.
     fn update_preflight_advisory(&mut self) {
         let threshold = self.preflight_tripwire_config.threshold.max(1);
-        let should_trip = self.preflight_death_streak >= threshold;
+        let pool_exhausted_now = self.preflight_pool_exhausted_now();
+        let should_trip = pool_exhausted_now || self.preflight_death_streak >= threshold;
         if should_trip == self.preflight_advisory_tripped {
             return;
         }
         self.preflight_advisory_tripped = should_trip;
         let marker = self.preflight_death_last_marker.clone().unwrap_or_default();
         let message = if should_trip {
-            format!(
-                "WARNING: last {} dispatches died at claude-wrapper pre-flight ({marker}) — check \
-                 .mcp.json",
-                self.preflight_death_streak
-            )
+            self.preflight_advisory_message(pool_exhausted_now, &marker)
         } else {
             "pre-flight advisory cleared — a recent dispatch reached claude-wrapper CLI start \
              (#4386)"
                 .to_string()
         };
-        log::warn!(
-            "sweep_registry: workspace {} pre-flight advisory {} (streak={}, threshold={}) \
-             (#4386)",
-            self.config.workspace_root.display(),
-            if should_trip { "TRIPPED" } else { "cleared" },
-            self.preflight_death_streak,
-            threshold
-        );
+        if pool_exhausted_now {
+            log::error!(
+                "sweep_registry: workspace {} pre-flight advisory TRIPPED — token pool exhausted \
+                 (0 healthy accounts), streak={} (#4644)",
+                self.config.workspace_root.display(),
+                self.preflight_death_streak
+            );
+        } else {
+            log::warn!(
+                "sweep_registry: workspace {} pre-flight advisory {} (streak={}, threshold={}) \
+                 (#4386)",
+                self.config.workspace_root.display(),
+                if should_trip { "TRIPPED" } else { "cleared" },
+                self.preflight_death_streak,
+                threshold
+            );
+        }
         self.emit_event(Event::PreflightAdvisory {
             workspace_root: self.config.workspace_root.display().to_string(),
             consecutive_deaths: self.preflight_death_streak,
             marker,
             message,
         });
+    }
+
+    /// Whether the live `.ranking` snapshot confirms zero healthy accounts
+    /// RIGHT NOW, given at least one pre-flight death has already been
+    /// observed this streak (Issue #4644). Shared by
+    /// [`update_preflight_advisory`](Self::update_preflight_advisory) (to
+    /// decide whether to force-trip) and
+    /// [`preflight_advisory`](Self::preflight_advisory) (so the status-surface
+    /// message text never drifts from the trip decision).
+    #[must_use]
+    fn preflight_pool_exhausted_now(&self) -> bool {
+        self.preflight_death_streak > 0
+            && capacity::read_ranking(&self.config.workspace_root)
+                .is_some_and(|snap| snap.total > 0 && snap.available == 0)
+    }
+
+    /// Render the operator-facing advisory message for the tripped state,
+    /// naming the specific whole-pool-dead cause (Issue #4644) when
+    /// `pool_exhausted_now` holds, else the ordinary #4386 streak wording.
+    #[must_use]
+    fn preflight_advisory_message(&self, pool_exhausted_now: bool, marker: &str) -> String {
+        if pool_exhausted_now {
+            format!(
+                "WARNING: token pool exhausted (0 healthy accounts) — every dispatch will die at \
+                 token selection ({marker}); add accounts (`loom-daemon tokens bootstrap`) or wait \
+                 for the pool to recover before re-dispatching (#4644)"
+            )
+        } else {
+            format!(
+                "WARNING: last {} dispatches died at claude-wrapper pre-flight ({marker}) — check \
+                 .mcp.json",
+                self.preflight_death_streak
+            )
+        }
     }
 
     /// Record a terminal sweep outcome against the insta-crash tally (#3939).
@@ -5786,6 +5927,10 @@ impl SweepRegistry {
                 let _ = self.restore_label_to_ready(*issue);
                 self.note_label_flip(*issue); // #4485 flap detection
             }
+            // Durable terminal-outcome record (Issue #4644) — a cancel is a
+            // deliberate terminal transition too, so it gets the same
+            // append-only journal line as a reaper-observed death.
+            self.append_outcome_journal(*issue, sweep_id, "exited", None, None, duration_sec);
             self.emit_event(Event::SweepExited {
                 issue: *issue,
                 exit_code: None,
@@ -5981,6 +6126,19 @@ impl SweepRegistry {
                                     info.latest_phase.clone_from(&checkpoint_phase);
                                 }
                             }
+                            // Durable terminal-outcome record (Issue #4644),
+                            // BEFORE the bus emission below moves `death_class`
+                            // — independent best-effort side effects of the
+                            // same terminal transition (never coupled to the
+                            // bus publish's own success).
+                            self.append_outcome_journal(
+                                issue,
+                                &sweep_id,
+                                "crashed",
+                                exit_code,
+                                death_class.clone(),
+                                duration_sec,
+                            );
                             events_to_emit.push(Event::SweepCrashed {
                                 issue,
                                 checkpoint_phase,
@@ -6280,6 +6438,18 @@ impl SweepRegistry {
                                 && exit_code != Some(0);
                             let death_class = self.record_preflight_streak(&sweep_id, insta_crash);
                             let is_preflight_death = death_class.is_some();
+                            // Durable terminal-outcome record (Issue #4644),
+                            // BEFORE the bus emission below moves
+                            // `death_class` — see the sibling call in the
+                            // Crashed branch above for the rationale.
+                            self.append_outcome_journal(
+                                issue,
+                                &sweep_id,
+                                "exited",
+                                exit_code,
+                                death_class.clone(),
+                                duration_sec,
+                            );
                             events_to_emit.push(Event::SweepExited {
                                 issue,
                                 exit_code,
@@ -8549,6 +8719,9 @@ exit 0
         // Confine the #3953 sweep journal to this test's tempdir — never the
         // real machine-level `~/.loom/sweeps.json`.
         config.journal_path = Some(workspace.join("test-sweeps-journal.json"));
+        // Confine the #4644 durable terminal-outcomes journal to this test's
+        // tempdir too, so tests can assert against a known path.
+        config.outcomes_journal_path = Some(workspace.join("test-sweep-outcomes.jsonl"));
         (SweepRegistry::new(config), record_log)
     }
 
@@ -11053,6 +11226,196 @@ exit 0
         assert!(registry
             .dispatch_backoff_remaining(4399, Utc::now())
             .is_some());
+    }
+
+    // ------------------------------------------------------------------------
+    // Durable terminal-outcome journal (Issue #4644)
+    // ------------------------------------------------------------------------
+
+    /// AC: a child that dies at `spawn-claude.sh`'s token-selection step
+    /// (exit 78, `EX_CONFIG`) is (a) classified with the specific
+    /// `preflight-token-selection-failed` death_class rather than the generic
+    /// `preflight-no-cli-start` fallback, (b) still arms the #4485 dispatch
+    /// backoff exactly like any other pre-flight death (confirming the
+    /// existing backoff machinery already covers this shape — no extension
+    /// needed), and (c) is written to the durable outcomes journal with the
+    /// exit code, death_class, token_name, and duration a post-hoc reader
+    /// needs, all without reading log prose.
+    #[test]
+    fn exit_78_token_selection_death_is_classified_backed_off_and_journaled() {
+        let dir = tempdir().unwrap();
+        let mut registry = backoff_registry(dir.path(), 60, 900);
+
+        // The exact prose `defaults/scripts/spawn-claude.sh` logs immediately
+        // before `exit 78` when `loom-daemon tokens select` itself fails
+        // (typically because every account is exhausted/blocked) — no
+        // `# CLAUDE_CLI_START` anywhere in the tail, because the CLI was
+        // never reached.
+        insert_dead_running_with_log(
+            &mut registry,
+            4644,
+            0,
+            "agent-9",
+            "==== loom-daemon dispatch: sweep-issue-4644-0 ====\n\
+             [2026-07-30T00:00:00Z] ERROR Token selection failed:\n\
+             [2026-07-30T00:00:00Z] ERROR Run 'loom-daemon tokens bootstrap' to populate \
+             <repo>/.loom/tokens/,\n",
+        );
+        registry.reap_once();
+
+        // (a) Specific death_class, not the generic fallback.
+        let path = registry.config().resolve_outcomes_journal_path();
+        let records = sweep_outcomes::read_all(&path);
+        let record = records
+            .iter()
+            .find(|r| r.issue == 4644)
+            .expect("terminal outcome must be journaled");
+        assert_eq!(
+            record.death_class.as_deref(),
+            Some("preflight-token-selection-failed"),
+            "exit-78 token-selection death must carry the specific #4644 death_class"
+        );
+        assert_eq!(record.token_name, "agent-9");
+        assert!(record.duration_sec >= 0);
+        assert_eq!(record.sweep_id, "sweep-issue-4644-0");
+
+        // (b) #4485 backoff already covers this shape — confirmed, not
+        // re-implemented.
+        assert_eq!(registry.insta_crash_count(4644), 0, "#4386 carve-out preserved");
+        assert_eq!(registry.dispatch_failure_count(4644), 1, "backoff still counts it");
+        assert!(registry
+            .dispatch_backoff_remaining(4644, Utc::now())
+            .is_some());
+    }
+
+    /// AC: the durable outcomes journal is written on BOTH terminal shapes —
+    /// a checkpoint-less `Exited` death (this test) and a checkpoint-present
+    /// `Crashed` death (the exit-78 test above, and the dedicated crashed-shape
+    /// test below) — at the same emit sites as the existing bus events.
+    #[test]
+    fn outcome_journal_records_exited_terminal_with_no_checkpoint() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _rec) = fixture_registry(dir.path());
+
+        insert_dead_running_with_log(&mut registry, 4645, 0, "agent-2", "clean run, no markers\n");
+        registry.reap_once();
+
+        let path = registry.config().resolve_outcomes_journal_path();
+        let records = sweep_outcomes::read_all(&path);
+        let record = records
+            .iter()
+            .find(|r| r.issue == 4645)
+            .expect("Exited terminal outcome must be journaled");
+        assert_eq!(record.outcome, "exited");
+        assert_eq!(record.repo, registry.config().workspace_root.display().to_string());
+    }
+
+    /// AC: the journal entry outlives `reap_once`'s in-memory GC of terminal
+    /// entries (the ~1h `TERMINAL_RETENTION_SECS` window) — it is the whole
+    /// point of a *durable* journal that it survives past the point the
+    /// in-memory registry has forgotten the sweep ever existed.
+    #[test]
+    fn outcome_journal_entry_survives_reap_once_gc() {
+        let dir = tempdir().unwrap();
+        let mut registry = backoff_registry(dir.path(), 60, 900);
+
+        let sweep_id = insert_dead_running_with_log(
+            &mut registry,
+            4646,
+            0,
+            "agent-3",
+            "==== loom-daemon dispatch: sweep-issue-4646-0 ====\nToken selection failed:\n",
+        );
+        registry.reap_once();
+
+        // Force this entry's terminal timestamp far enough in the past that
+        // the NEXT tick's GC pass drops it from the in-memory registry.
+        if let Some(info) = registry.entries.get_mut(&sweep_id) {
+            match &mut info.state {
+                SweepState::Exited { at, .. } | SweepState::Crashed { at } => {
+                    *at = Utc::now() - chrono::Duration::seconds(TERMINAL_RETENTION_SECS + 60);
+                }
+                other => panic!("expected a terminal state, got {other:?}"),
+            }
+        }
+        registry.reap_once();
+        assert!(
+            !registry.entries.contains_key(&sweep_id),
+            "in-memory entry should be GC'd by the retention-window pass"
+        );
+
+        let path = registry.config().resolve_outcomes_journal_path();
+        let records = sweep_outcomes::read_all(&path);
+        assert!(
+            records.iter().any(|r| r.issue == 4646),
+            "the durable journal entry must survive reap_once's in-memory GC"
+        );
+    }
+
+    /// AC: when the live `.ranking` snapshot shows zero healthy accounts, the
+    /// pre-flight advisory trips on the FIRST pre-flight death observed —
+    /// not after `threshold` (default 3) consecutive deaths accumulate — so
+    /// the operator gets one aggregate signal instead of N per-issue error
+    /// blocks while the pool is fully dead.
+    #[test]
+    fn preflight_advisory_trips_immediately_when_pool_is_fully_exhausted() {
+        let dir = tempdir().unwrap();
+        let mut registry = backoff_registry(dir.path(), 60, 900);
+        seed_token_pool(dir.path(), "agent-9"); // ensures the per-repo pool
+                                                // dir wins over any shared
+                                                // fallback
+        std::fs::write(
+            dir.path().join(".loom").join("tokens").join(".ranking"),
+            "agent-9|exhausted|0.99\nagent-10|blocked|0.00\n",
+        )
+        .unwrap();
+
+        assert!(!registry.preflight_advisory().0);
+
+        insert_dead_running_with_log(
+            &mut registry,
+            4647,
+            0,
+            "agent-9",
+            "==== loom-daemon dispatch: sweep-issue-4647-0 ====\nToken selection failed:\n",
+        );
+        registry.reap_once();
+
+        assert_eq!(registry.preflight_death_streak(), 1, "only ONE death observed so far");
+        assert!(
+            registry.preflight_advisory().0,
+            "healthy=0 must force an immediate trip, not wait for the streak threshold"
+        );
+    }
+
+    /// The symmetric negative: an ordinary pre-flight death against a pool
+    /// that still has a healthy account must NOT force-trip — it follows the
+    /// normal #4386 streak/threshold cadence.
+    #[test]
+    fn preflight_advisory_does_not_force_trip_when_pool_has_a_healthy_account() {
+        let dir = tempdir().unwrap();
+        let mut registry = backoff_registry(dir.path(), 60, 900);
+        seed_token_pool(dir.path(), "agent-9");
+        std::fs::write(
+            dir.path().join(".loom").join("tokens").join(".ranking"),
+            "agent-9|available|0.10\nagent-10|exhausted|0.99\n",
+        )
+        .unwrap();
+
+        insert_dead_running_with_log(
+            &mut registry,
+            4648,
+            0,
+            "agent-9",
+            "==== loom-daemon dispatch: sweep-issue-4648-0 ====\nspawn-claude: preflight failed\n",
+        );
+        registry.reap_once();
+
+        assert_eq!(registry.preflight_death_streak(), 1);
+        assert!(
+            !registry.preflight_advisory().0,
+            "a single death with a healthy account still in the pool must not force-trip"
+        );
     }
 
     /// A cold streak restarts at 1: a failure whose predecessor is older than


### PR DESCRIPTION
## Summary

The daemon's event bus is in-memory only and the sweep registry GC's terminal
entries after ~1h, so the only trace of a sweep death (e.g. a spawn-time
token-selection failure) that survives past that window is prose inside
`.loom/logs/sweep-issue-N.log`. This PR adds a durable, append-only journal of
terminal sweep outcomes, distinguishes token-selection deaths with their own
`death_class`, and makes the existing pre-flight advisory trip immediately
(instead of waiting for a streak) when the live token pool is confirmed fully
dead.

**Verify-first (per curator guidance)**: reproduced/confirmed against current
main (`728426cb`) before implementing. #4122 (account-exhaustion attribution),
#4386 (pre-flight classification + streak tripwire), and #4485 (dispatch
backoff) are all present and working as designed — none were re-implemented.
The exit-78 empty-token-pool shape already arms #4485's backoff via the
existing `insta_crash` window; confirmed by a new test rather than re-built.

## Changes

- **New `loom-daemon/src/sweep_outcomes.rs` module**: an append-only JSONL
  journal (`OutcomeRecord`: timestamp, repo, issue, sweep_id, outcome,
  exit_code, death_class, token_name, duration_sec) at
  `<workspace>/.loom/logs/sweep-outcomes.jsonl` (env-overridable via
  `LOOM_SWEEP_OUTCOMES_JOURNAL_PATH`), rotated to a single `.1` backup once it
  exceeds 5 MiB or its oldest line is >30 days old. Distinct from the existing
  `sweep_journal` (a machine-level, upsert-keyed *liveness* snapshot) — this is
  a per-workspace, append-only *history*.
- **`sweep_registry.rs`**: `SweepRegistry::append_outcome_journal` writes one
  line at every site that already emits a terminal `SweepExited`/`SweepCrashed`
  bus event for a single-issue sweep — the reaper's dead-child handling in
  `reap_once` (both the `Crashed` and `Exited` branches) and the
  operator/watchdog-initiated `finish_cancel`. Best-effort by contract (mirrors
  `sweep_journal`'s philosophy): a write failure is logged and swallowed, never
  blocking reaping, and is NOT coupled to the bus emission's own success.
- **New `preflight-token-selection-failed` death_class**: added to
  `preflight_death_signatures()`, matching the exact prose
  `defaults/scripts/spawn-claude.sh` logs before its three `exit 78`
  (`EX_CONFIG`) paths (no `loom-daemon` binary supporting `tokens select`; the
  select subcommand itself failing; an empty resolved key). Distinguishes this
  specific cause from the generic absence-based `preflight-no-cli-start`
  fallback, without reading log prose.
- **Pool-dead advisory force-trip**: `update_preflight_advisory` now also
  consults a live re-read of `.ranking` (`capacity::read_ranking`) and
  force-trips the existing `daemon.preflight.advisory` topic/event
  immediately — on the FIRST pre-flight death — when it confirms zero healthy
  accounts, instead of waiting for `threshold` (default 3) consecutive deaths.
  The advisory message and `loom-daemon status` surface (`preflight_advisory()`,
  already wired into `DaemonStatusReport` via `ipc.rs`) both name the specific
  cause via a shared `preflight_advisory_message` helper, so they can never
  drift from each other. Chose the existing log/event/status path over adding
  a new `main.rs` status branch, since `ipc.rs` already surfaces
  `preflight_advisory()` and this change only makes it fire sooner/more
  precisely — no new wiring needed.
- **`event_bus.rs`**: doc-comment-only addition documenting the durability
  relationship between the in-memory bus and the new journal. No behavior
  change.
- **`lib.rs`**: registers the new `sweep_outcomes` module.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Terminal outcomes appended to a durable, size/age-rotated on-disk journal at the same emit sites as `SweepExited`/`SweepCrashed` | ✅ | `sweep_outcomes.rs` (new module + rotation tests); wired into `reap_once`'s two branches and `finish_cancel` in `sweep_registry.rs` |
| Token-selection death distinguishable via `death_class` without reading log prose | ✅ | New `preflight-token-selection-failed` signature; `exit_78_token_selection_death_is_classified_backed_off_and_journaled` test asserts the journaled `death_class` |
| Aggregate, deduplicated, operator-visible signal on healthy=0 instead of N per-issue blocks | ✅ | `update_preflight_advisory` force-trips on the first death when `.ranking` confirms 0 healthy accounts; `preflight_advisory_trips_immediately_when_pool_is_fully_exhausted` / `preflight_advisory_does_not_force_trip_when_pool_has_a_healthy_account` tests |
| Confirm #4485 backoff already covers the exit-78 shape; extend only if a real hole found | ✅ | `exit_78_token_selection_death_is_classified_backed_off_and_journaled` confirms `dispatch_failure_count`/backoff arm on this shape — no extension needed (existing `preflight_death_arms_backoff_even_though_quarantine_is_carved_out` test already covered the generic pre-flight shape) |
| Tests: journal line on crashed/exited terminals; journal survives `reap_once`; healthy=0 advisory fires once, not per-issue | ✅ | `outcome_journal_records_exited_terminal_with_no_checkpoint`, `exit_78_...` (crashed), `outcome_journal_entry_survives_reap_once_gc`, the two `preflight_advisory_*` tests |

## Test Plan

- `cargo check` / `cargo clippy --all-targets` / `cargo fmt --all -- --check` — all clean
- `cargo test --lib` (full `loom-daemon` crate) — 2644 passed, 0 failed
- New tests added: 7 in `sweep_outcomes.rs`, 6 in `sweep_registry.rs` (listed above), all passing
- Manual read-through of the reaper's terminal-outcome handler confirmed the journal write sits before the event that moves `death_class`, using a `.clone()` so both paths get identical data

Closes #4644