### PR TITLE
fix(docs): keep CONFIGURATION.md's file listing accurate and link it from CLAUDE.md

### DIFF
--- a/.github/CONFIGURATION.md
+++ b/.github/CONFIGURATION.md
@@ -4,17 +4,20 @@ This directory contains GitHub configuration templates that Loom installs into n
 
 ## Contents
 
-### Issue Templates
+Loom ships exactly these four files under `.github/` (installed by `scripts/install-loom.sh`'s
+defaults walk, which mirrors `defaults/.github/` into the workspace):
 
-**`ISSUE_TEMPLATE/task.yml`**
-- Single unified template for all development tasks
-- Supports: Bug Fix, Feature, Refactoring, Documentation, Testing, Infrastructure, Research, Improvement
-- Clearly explains that issues control the development process
-- Redirects discussions to GitHub Discussions
+- **`CONFIGURATION.md`** — this file
+- **`ISSUE_TEMPLATE/task.yml`** — single unified template for all development tasks (Bug Fix,
+  Feature, Refactoring, Documentation, Testing, Infrastructure, Research, Improvement); explains
+  that issues control the development process; redirects discussions to GitHub Discussions
+- **`ISSUE_TEMPLATE/config.yml`** — disables blank issues (forces template use) and links to
+  GitHub Discussions for non-task items
+- **`labels.yml`** — the authoritative label set for the label-based workflow (see below)
 
-**`ISSUE_TEMPLATE/config.yml`**
-- Disables blank issues (forces template use)
-- Links to GitHub Discussions for non-task items
+Everything else under a workspace's `.github/` (e.g. `workflows/`) is consumer-owned — Loom
+never installs, edits, or removes it. If you see a `.github/` file not in this list, it isn't
+from Loom.
 
 ## How It Works
 
@@ -23,7 +26,10 @@ This directory contains GitHub configuration templates that Loom installs into n
 1. Collaborator creates an issue (no auto-labeling)
 2. Issue starts with `loom:triage` label (from template)
 3. Enters the label-based workflow:
-   - Curator enhances → adds `loom:curated` (human approves → `loom:issue`)
+   - Curator enhances → adds `loom:curated`
+   - `loom:curated` → `loom:issue` promotion (human, Champion, or the `/loom:sweep`
+     orchestrator's approval gate — see `.loom/roles/curator.md` § "Who promotes
+     `loom:curated` → `loom:issue`" for the authoritative rule)
    - Builder implements → adds `loom:building`
    - Creates PR → adds `loom:review-requested`
    - Judge approves → adds `loom:pr`
@@ -31,12 +37,10 @@ This directory contains GitHub configuration templates that Loom installs into n
 
 ## Installation
 
-### Automatic Template Installation
-
-These templates are automatically copied to `<workspace>/.github/` during:
-- Initial workspace setup
-- Factory reset
-- New project creation
+These files are copied from `defaults/.github/` into `<workspace>/.github/` by
+`scripts/install-loom.sh`'s defaults-directory walk, and are re-synced on `loom update` /
+reinstall (they're on the Loom-shipped `.github/` allowlist, so a reinstall overwrites local
+edits to these four files — customize via `defaults/optional/` or a fork instead).
 
 ### Optional: External Issue Labeling Workflow
 
@@ -46,27 +50,15 @@ This workflow is not installed by default because it generates "No jobs were run
 
 ## Customization
 
-Workspaces can customize these templates after installation:
-- Modify issue template fields
-- Add additional workflows from `defaults/optional/`
-
-Changes to workspace `.github/` files don't affect the defaults.
+Workspaces can customize non-Loom-shipped `.github/` content freely (it's never touched by
+Loom). Customizing one of the four Loom-shipped files above will be clobbered on the next
+`loom update` / reinstall — instead add workflows from `defaults/optional/`, or fork.
 
 ## Label-Based Workflow
 
-The issue template integrates with Loom's label-based workflow coordination:
-
-| Label | Meaning | Who Sets It |
-|-------|---------|-------------|
-| `loom:triage` | New issue awaiting Curator enhancement | Issue template (automatic) |
-| `loom:curated` | Enhanced by Curator, awaiting human approval | Curator agent |
-| `loom:issue` | Approved for work, ready for Builder | Human (from curated) |
-| `loom:building` | Builder is implementing | Builder agent |
-| `loom:curating` | Curator is enhancing | Curator agent |
-| `loom:treating` | Doctor is fixing bug/PR feedback | Doctor agent |
-| `loom:review-requested` | PR needs review | Builder agent |
-| `loom:reviewing` | Judge is actively reviewing | Judge agent |
-| `loom:pr` | Approved for merge | Judge agent |
+The issue template integrates with Loom's label-based workflow coordination. `.github/labels.yml`
+is the authoritative label set (each label's `Applied by:` field states who sets it) — see that
+file rather than a table here, which would drift.
 
 See [WORKFLOWS.md](../docs/workflows.md) for complete workflow documentation.
 

--- a/defaults/.github/CONFIGURATION.md
+++ b/defaults/.github/CONFIGURATION.md
@@ -4,17 +4,20 @@ This directory contains GitHub configuration templates that Loom installs into n
 
 ## Contents
 
-### Issue Templates
+Loom ships exactly these four files under `.github/` (installed by `scripts/install-loom.sh`'s
+defaults walk, which mirrors `defaults/.github/` into the workspace):
 
-**`ISSUE_TEMPLATE/task.yml`**
-- Single unified template for all development tasks
-- Supports: Bug Fix, Feature, Refactoring, Documentation, Testing, Infrastructure, Research, Improvement
-- Clearly explains that issues control the development process
-- Redirects discussions to GitHub Discussions
+- **`CONFIGURATION.md`** — this file
+- **`ISSUE_TEMPLATE/task.yml`** — single unified template for all development tasks (Bug Fix,
+  Feature, Refactoring, Documentation, Testing, Infrastructure, Research, Improvement); explains
+  that issues control the development process; redirects discussions to GitHub Discussions
+- **`ISSUE_TEMPLATE/config.yml`** — disables blank issues (forces template use) and links to
+  GitHub Discussions for non-task items
+- **`labels.yml`** — the authoritative label set for the label-based workflow (see below)
 
-**`ISSUE_TEMPLATE/config.yml`**
-- Disables blank issues (forces template use)
-- Links to GitHub Discussions for non-task items
+Everything else under a workspace's `.github/` (e.g. `workflows/`) is consumer-owned — Loom
+never installs, edits, or removes it. If you see a `.github/` file not in this list, it isn't
+from Loom.
 
 ## How It Works
 
@@ -23,7 +26,10 @@ This directory contains GitHub configuration templates that Loom installs into n
 1. Collaborator creates an issue (no auto-labeling)
 2. Issue starts with `loom:triage` label (from template)
 3. Enters the label-based workflow:
-   - Curator enhances → adds `loom:curated` (human approves → `loom:issue`)
+   - Curator enhances → adds `loom:curated`
+   - `loom:curated` → `loom:issue` promotion (human, Champion, or the `/loom:sweep`
+     orchestrator's approval gate — see `.loom/roles/curator.md` § "Who promotes
+     `loom:curated` → `loom:issue`" for the authoritative rule)
    - Builder implements → adds `loom:building`
    - Creates PR → adds `loom:review-requested`
    - Judge approves → adds `loom:pr`
@@ -31,12 +37,10 @@ This directory contains GitHub configuration templates that Loom installs into n
 
 ## Installation
 
-### Automatic Template Installation
-
-These templates are automatically copied to `<workspace>/.github/` during:
-- Initial workspace setup
-- Factory reset
-- New project creation
+These files are copied from `defaults/.github/` into `<workspace>/.github/` by
+`scripts/install-loom.sh`'s defaults-directory walk, and are re-synced on `loom update` /
+reinstall (they're on the Loom-shipped `.github/` allowlist, so a reinstall overwrites local
+edits to these four files — customize via `defaults/optional/` or a fork instead).
 
 ### Optional: External Issue Labeling Workflow
 
@@ -46,27 +50,15 @@ This workflow is not installed by default because it generates "No jobs were run
 
 ## Customization
 
-Workspaces can customize these templates after installation:
-- Modify issue template fields
-- Add additional workflows from `defaults/optional/`
-
-Changes to workspace `.github/` files don't affect the defaults.
+Workspaces can customize non-Loom-shipped `.github/` content freely (it's never touched by
+Loom). Customizing one of the four Loom-shipped files above will be clobbered on the next
+`loom update` / reinstall — instead add workflows from `defaults/optional/`, or fork.
 
 ## Label-Based Workflow
 
-The issue template integrates with Loom's label-based workflow coordination:
-
-| Label | Meaning | Who Sets It |
-|-------|---------|-------------|
-| `loom:triage` | New issue awaiting Curator enhancement | Issue template (automatic) |
-| `loom:curated` | Enhanced by Curator, awaiting human approval | Curator agent |
-| `loom:issue` | Approved for work, ready for Builder | Human (from curated) |
-| `loom:building` | Builder is implementing | Builder agent |
-| `loom:curating` | Curator is enhancing | Curator agent |
-| `loom:treating` | Doctor is fixing bug/PR feedback | Doctor agent |
-| `loom:review-requested` | PR needs review | Builder agent |
-| `loom:reviewing` | Judge is actively reviewing | Judge agent |
-| `loom:pr` | Approved for merge | Judge agent |
+The issue template integrates with Loom's label-based workflow coordination. `.github/labels.yml`
+is the authoritative label set (each label's `Applied by:` field states who sets it) — see that
+file rather than a table here, which would drift.
 
 See [WORKFLOWS.md](https://github.com/rjwalters/loom/blob/main/docs/workflows.md) for complete workflow documentation.
 

--- a/defaults/.loom/CLAUDE.md
+++ b/defaults/.loom/CLAUDE.md
@@ -354,6 +354,7 @@ concurrency errors are covered in
 - **Configuration**: `.loom/config.json` (your local terminal setup)
 - **Scripts**: `.loom/scripts/` (worktree, merge, daemon, token-pool helpers)
 - **GitHub Labels**: `.github/labels.yml`
+- **Issue Template Workflow**: [`.github/CONFIGURATION.md`](.github/CONFIGURATION.md)
 - **Docs**: [daemon-reference](.loom/docs/daemon-reference.md) ·
   [build-gate](.loom/docs/build-gate.md) ·
   [troubleshooting](.loom/docs/troubleshooting.md) ·


### PR DESCRIPTION
Closes #4654

## Summary

`.github/CONFIGURATION.md` (installer-shipped, source of truth `defaults/.github/CONFIGURATION.md`) had gone stale in three ways and was an unreferenced doc island:

1. **Incomplete "Contents" listing** — enumerated only `ISSUE_TEMPLATE/task.yml` and `ISSUE_TEMPLATE/config.yml`, omitting `CONFIGURATION.md` itself and `labels.yml` even though Loom ships exactly four `.github/` files (verified against `git ls-files defaults/.github`).
2. **Stale promotion-rule claim** — lines 26/63 said `loom:curated` → `loom:issue` promotion is human-only, contradicting the settled rule (#4163: human, Champion, or the `/loom:sweep` orchestrator's approval gate).
3. **Drifting label table** — a partial snapshot of labels that omits states like `loom:changes-requested`/`loom:blocked`, duplicating `.github/labels.yml` instead of pointing at it.
4. **No inbound link** — nothing referenced the file, not CLAUDE.md, not the README.

## Changes (Option A per the curated issue's recommendation)

- `defaults/.github/CONFIGURATION.md` — replaced the static file listing with the actual four Loom-shipped files plus a "everything else under `.github/` is consumer-owned" disclaimer; pointed the promotion rule at `.loom/roles/curator.md`'s authoritative "Who promotes `loom:curated` → `loom:issue`" section instead of restating it; replaced the label table with a pointer to `labels.yml`; updated the "Installation" section to describe the actual `scripts/install-loom.sh` defaults-walk mechanism instead of pre-script-installer language.
- `.github/CONFIGURATION.md` — mirrored the same edits into this repo's own dogfood copy by hand (confirmed `resync-installed.sh` does not cover `.github/`), preserving its existing relative `../docs/workflows.md` link (this repo has `docs/workflows.md` locally; the template link to consumers stays an absolute GitHub URL since consumer repos don't ship that doc).
- `defaults/.loom/CLAUDE.md` — added an "Issue Template Workflow" pointer to `.github/CONFIGURATION.md` in the Resources section so it's discoverable.

No changes to the install/uninstall allowlists (`scripts/install-loom.sh:1353`, `scripts/uninstall-loom.sh:303`) — Option A keeps `CONFIGURATION.md` as a shipped file.

## Verification

- Confirmed the exact 4 shipped files via `git ls-files defaults/.github` before editing.
- `bash scripts/test-installer.sh` — 175 passed / 1 failed; the one failure (`test-loom-dispatcher.sh`'s "config-selected codex path" case) reproduces identically on unmodified `main` (confirmed by re-running it standalone in the main workspace) — pre-existing and unrelated to this change. Test 44/44b sections (the ones covering `.github/CONFIGURATION.md`'s allowlist/sweep behavior) all pass unchanged.
- `./.loom/scripts/verify-install.sh check-links` — no new dangling links introduced; the 2 reported in the worktree (`.claude/commands/loom/judge.md`/`doctor.md`) are gitignored local-only files absent from the worktree checkout, not from this change (confirmed clean on the main workspace).
- No `{{...}}` placeholder leaks or `defaults/`-prefixed markdown links introduced.

## Test plan

- [x] `defaults/.github/CONFIGURATION.md`'s file listing matches `git ls-files defaults/.github`
- [x] New CLAUDE.md-template link resolves relative to an installed consumer repo layout
- [x] `scripts/test-installer.sh` Test 44/44b + allowlist expectations pass unchanged
- [x] No `{{...}}` placeholder leaks; no `defaults/`-prefixed markdown links