### PR TITLE
fix(check-duplicate): stop routing REST fallback resolution through GraphQL

### DIFF
--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -428,7 +428,9 @@ gh issue close <number> --reason "not planned"
 
 ### Duplicate Detection
 
-**Check for potential duplicates during curation** using the duplicate detection script. Use `--include-merged-prs` to also catch issues that overlap with recently merged PRs or recently closed issues, and pass `--issue <number>` so the script also probes for **related open work** — see "Related Open Work (Cross-References)" immediately below, a different question from duplication:
+**Check for potential duplicates during curation** using the duplicate detection script. Use `--include-merged-prs` to also catch issues that overlap with recently merged PRs or recently closed issues, and pass `--issue <number>` so the script also probes for **related open work** — see "Related Open Work (Cross-References)" immediately below, a different question from duplication.
+
+**Distinguish exit 1 from exit 2** (issue #4659): exit 1 means the check *ran* and found a `DUPLICATE_FOUND` and/or `RELATED_OPEN_WORK` block — read it before curating. Exit 2 means the check **could not run at all** (e.g. GraphQL exhaustion with no working fallback) — there is no match list to read, and treating it the same as exit 1 falsely reports "potential duplicate detected" when nothing was actually checked. Do not let exit 2 block curation; log it and proceed, noting in your enhancement comment that the duplicate check was inconclusive:
 
 ```bash
 # Get issue title and body
@@ -437,10 +439,17 @@ BODY=$(gh issue view <number> --json body --jq .body)
 
 # Check for similar existing issues, merged PRs, closed issues, AND open
 # issues/PRs that cross-reference this one (--issue, issue #4162)
-if ! ./.loom/scripts/check-duplicate.sh --include-merged-prs --issue "<number>" "$TITLE" "$BODY"; then
+./.loom/scripts/check-duplicate.sh --include-merged-prs --issue "<number>" "$TITLE" "$BODY"
+CHECK_RC=$?
+if [[ $CHECK_RC -eq 1 ]]; then
     # DUPLICATE_FOUND and/or RELATED_OPEN_WORK found - read the full output
     # before marking curated
     echo "Potential duplicate or related open work detected - review before curating"
+elif [[ $CHECK_RC -eq 2 ]]; then
+    # Could not check at all (e.g. GraphQL exhaustion with no working
+    # fallback) - this is NOT "duplicate found". Don't block curation on it;
+    # note the inconclusive check in your enhancement comment instead.
+    echo "Duplicate check could not complete (forge error) - proceeding without a duplicate verdict"
 fi
 ```
 

--- a/defaults/scripts/check-duplicate.sh
+++ b/defaults/scripts/check-duplicate.sh
@@ -299,10 +299,39 @@ is_rate_limit_error() {
     return 1
 }
 
-# Resolve "owner/repo" via REST, for the REST fallback paths below. Mirrors
-# the resolution already used by search_cross_references() (#4162).
+# Resolve "owner/repo" from the local git remote, for the small number of
+# call sites (search_cross_references() below) that need the literal string
+# rather than just an API endpoint to hit. Deliberately NOT `gh repo view`
+# (#4659): that call is itself GraphQL-backed, so under GraphQL exhaustion it
+# fails before any REST fallback is even attempted -- the exact bug this
+# helper exists to avoid reintroducing. `git remote get-url origin` is a pure
+# local read (no network round-trip at all), so it survives total GraphQL AND
+# REST outages alike.
+#
+# The three REST-fallback call sites in search_similar_issues() /
+# search_merged_prs() / search_closed_issues() do NOT call this helper --
+# they hit `gh api "repos/{owner}/{repo}/..."` directly, letting `gh` resolve
+# the `{owner}/{repo}` placeholder locally from the same git remote with zero
+# API calls of its own (#4659).
 get_repo_nwo() {
-    gh repo view --json nameWithOwner --jq '.nameWithOwner'
+    local url
+    if ! url=$(git remote get-url origin 2>&1); then
+        echo "$url" >&2
+        return 1
+    fi
+    # Strip a trailing ".git" and/or "/", then take the final two "/"- or
+    # ":"-delimited path segments -- "owner/repo" -- which works for both the
+    # SSH ("git@host:owner/repo.git") and HTTPS ("https://host/owner/repo")
+    # remote URL forms.
+    url="${url%.git}"
+    url="${url%/}"
+    local nwo
+    nwo=$(printf '%s' "$url" | grep -oE '[^/:]+/[^/]+$') || true
+    if [[ -z "$nwo" ]]; then
+        echo "could not parse owner/repo from remote URL: $url" >&2
+        return 1
+    fi
+    echo "$nwo"
 }
 
 # Search for similar issues
@@ -326,14 +355,18 @@ search_similar_issues() {
     local rest_fallback=false
     if ! issues=$($FORGE issue list --state=open --limit=50 --json number,title,body 2>&1); then
         if is_rate_limit_error "$issues"; then
-            local repo_nwo rest_issues
-            if repo_nwo=$(get_repo_nwo 2>&1) && \
-               rest_issues=$(gh api "repos/${repo_nwo}/issues?state=open&per_page=50" 2>&1); then
+            # `gh api` resolves the "{owner}/{repo}" placeholder locally from
+            # the git remote -- no GraphQL (or any) API call, unlike the
+            # get_repo_nwo()-via-`gh repo view` round-trip this used to make
+            # (#4659), which itself failed under GraphQL exhaustion before
+            # REST was ever attempted.
+            local rest_issues
+            if rest_issues=$(gh api "repos/{owner}/{repo}/issues?state=open&per_page=50" 2>&1); then
                 # REST's /issues endpoint also returns PRs; exclude them.
                 issues=$(echo "$rest_issues" | jq -c '[.[] | select(.pull_request == null)]')
                 rest_fallback=true
             else
-                print_error "GraphQL rate-limited fetching open issues, and REST fallback also failed: ${rest_issues:-$repo_nwo}"
+                print_error "GraphQL rate-limited fetching open issues, and REST fallback also failed: ${rest_issues}"
                 return 2
             fi
         else
@@ -418,13 +451,14 @@ search_merged_prs() {
     local rest_fallback=false
     if ! prs=$($FORGE pr list --state=merged --limit=20 --json number,title,body 2>&1); then
         if is_rate_limit_error "$prs"; then
-            local repo_nwo rest_prs
-            if repo_nwo=$(get_repo_nwo 2>&1) && \
-               rest_prs=$(gh api "repos/${repo_nwo}/pulls?state=closed&per_page=20" 2>&1); then
+            # See the matching comment in search_similar_issues(): `gh api`
+            # resolves "{owner}/{repo}" locally, no GraphQL call (#4659).
+            local rest_prs
+            if rest_prs=$(gh api "repos/{owner}/{repo}/pulls?state=closed&per_page=20" 2>&1); then
                 prs=$(echo "$rest_prs" | jq -c '[.[] | select(.merged_at != null)]')
                 rest_fallback=true
             else
-                print_error "GraphQL rate-limited fetching merged PRs, and REST fallback also failed: ${rest_prs:-$repo_nwo}"
+                print_error "GraphQL rate-limited fetching merged PRs, and REST fallback also failed: ${rest_prs}"
                 return 2
             fi
         else
@@ -501,14 +535,15 @@ search_closed_issues() {
     local rest_fallback=false
     if ! issues=$($FORGE issue list --state=closed --limit=20 --json number,title,body 2>&1); then
         if is_rate_limit_error "$issues"; then
-            local repo_nwo rest_issues
-            if repo_nwo=$(get_repo_nwo 2>&1) && \
-               rest_issues=$(gh api "repos/${repo_nwo}/issues?state=closed&per_page=20" 2>&1); then
+            # See the matching comment in search_similar_issues(): `gh api`
+            # resolves "{owner}/{repo}" locally, no GraphQL call (#4659).
+            local rest_issues
+            if rest_issues=$(gh api "repos/{owner}/{repo}/issues?state=closed&per_page=20" 2>&1); then
                 # REST's /issues endpoint also returns PRs; exclude them.
                 issues=$(echo "$rest_issues" | jq -c '[.[] | select(.pull_request == null)]')
                 rest_fallback=true
             else
-                print_error "GraphQL rate-limited fetching closed issues, and REST fallback also failed: ${rest_issues:-$repo_nwo}"
+                print_error "GraphQL rate-limited fetching closed issues, and REST fallback also failed: ${rest_issues}"
                 return 2
             fi
         else
@@ -590,9 +625,12 @@ search_cross_references() {
         return 0
     fi
 
+    # Resolved from the local git remote (#4659), not `gh repo view` -- the
+    # literal "owner/repo" string is only needed below to filter the timeline
+    # to same-repo cross-references; it costs no API call either way.
     local repo_nwo
-    if ! repo_nwo=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>&1); then
-        print_warning "Failed to resolve repository for cross-reference probe (non-GitHub forge?): $repo_nwo"
+    if ! repo_nwo=$(get_repo_nwo 2>&1); then
+        print_warning "Failed to resolve repository for cross-reference probe (non-GitHub forge, or no git remote?): $repo_nwo"
         echo "[]"
         return 0
     fi

--- a/defaults/scripts/tests/test-check-duplicate.sh
+++ b/defaults/scripts/tests/test-check-duplicate.sh
@@ -107,24 +107,57 @@ exit 1
 STUB
 chmod +x "$STUB_DIR/loom-daemon"
 
+# --- Stub git on PATH ---
+#   git remote get-url origin -> "https://github.com/owner/repo.git" (or fail
+#                                 if $STUB_DIR/git-remote-fail exists). check-
+#                                 duplicate.sh's get_repo_nwo() (#4659) resolves
+#                                 "owner/repo" from this LOCAL read -- no `gh
+#                                 repo view` (GraphQL) round-trip -- so this stub
+#                                 never needs to simulate a rate limit for it.
+#   anything else              -> delegated to the real `git` binary (unused by
+#                                 check-duplicate.sh today; a safety net only).
+REAL_GIT_BIN="$(command -v git)"
+export REAL_GIT_BIN
+cat > "$STUB_DIR/git" <<'STUB'
+#!/usr/bin/env bash
+STUB_DIR_FROM_ENV="${LOOM_TEST_STUB_DIR:?stub git: LOOM_TEST_STUB_DIR not set}"
+if [[ "$1" == "remote" && "$2" == "get-url" && "$3" == "origin" ]]; then
+  if [[ -f "$STUB_DIR_FROM_ENV/git-remote-fail" ]]; then
+    echo "stub git: No such remote 'origin'" >&2
+    exit 1
+  fi
+  echo "https://github.com/owner/repo.git"
+  exit 0
+fi
+exec "$REAL_GIT_BIN" "$@"
+STUB
+chmod +x "$STUB_DIR/git"
+
 # --- Stub gh on PATH ---
 #   gh auth status                                     -> exit 0 (authenticated)
-#   gh repo view --json nameWithOwner --jq ...          -> "owner/repo" (or fail
-#                                                          if $STUB_DIR/repo-view-fail exists)
 #   gh issue list --state=open|closed ...               -> cat $STUB_DIR/issues-<state>.json (or [];
 #                                                           simulates a GraphQL rate-limit failure if
 #                                                           $STUB_DIR/issue-list-rate-limit-<state> exists)
 #   gh pr list --state=merged ...                        -> cat $STUB_DIR/prs-merged.json (or [];
 #                                                           simulates a GraphQL rate-limit failure if
 #                                                           $STUB_DIR/pr-list-rate-limit exists)
-#   gh api repos/OWNER/REPO/issues/N/timeline --paginate -> cat $STUB_DIR/timeline-N.json (or [];
+#   gh api repos/{owner}/{repo}/issues/N/timeline --paginate -> cat $STUB_DIR/timeline-N.json (or [];
 #                                                           fails if $STUB_DIR/timeline-fail exists)
-#   gh api repos/OWNER/REPO/issues?state=<state>&...     -> REST fallback (#4526): cat
+#   gh api repos/{owner}/{repo}/issues?state=<state>&... -> REST fallback (#4526): cat
 #                                                           $STUB_DIR/rest-issues-<state>.json (or [];
 #                                                           fails if $STUB_DIR/rest-issues-fail exists)
-#   gh api repos/OWNER/REPO/pulls?state=closed&...       -> REST fallback (#4526): cat
+#   gh api repos/{owner}/{repo}/pulls?state=closed&...   -> REST fallback (#4526): cat
 #                                                           $STUB_DIR/rest-prs.json (or [];
 #                                                           fails if $STUB_DIR/rest-prs-fail exists)
+#
+# Note (#4659): check-duplicate.sh no longer calls `gh repo view` anywhere --
+# repo resolution (get_repo_nwo(), used only by search_cross_references())
+# reads the git remote directly (see the `git` stub above), and the REST
+# fallback call sites hit `gh api "repos/{owner}/{repo}/..."` verbatim,
+# letting `gh` resolve the placeholder locally. So this stub deliberately has
+# no "repo" case left: a resurrected `gh repo view` call in production code
+# would fail this test suite with "unhandled args" rather than silently
+# passing, which is the point.
 cat > "$STUB_DIR/gh" <<'STUB'
 #!/usr/bin/env bash
 STUB_DIR_FROM_ENV="${LOOM_TEST_STUB_DIR:?stub gh: LOOM_TEST_STUB_DIR not set}"
@@ -147,14 +180,6 @@ rate_limit_message() {
 
 case "$1" in
   auth)
-    exit 0
-    ;;
-  repo)
-    if [[ -f "$STUB_DIR_FROM_ENV/repo-view-fail" ]]; then
-      echo "stub gh: repo view failed" >&2
-      exit 1
-    fi
-    echo "owner/repo"
     exit 0
     ;;
   issue)
@@ -239,7 +264,7 @@ export PATH="$STUB_DIR:$PATH"
 reset_state() {
     rm -f "$STUB_DIR"/issues-*.json "$STUB_DIR"/prs-merged.json "$STUB_DIR"/timeline-*.json
     rm -f "$STUB_DIR"/rest-issues-*.json "$STUB_DIR/rest-prs.json"
-    rm -f "$STUB_DIR/timeline-fail" "$STUB_DIR/repo-view-fail"
+    rm -f "$STUB_DIR/timeline-fail" "$STUB_DIR/git-remote-fail"
     rm -f "$STUB_DIR"/issue-list-rate-limit-* "$STUB_DIR/pr-list-rate-limit"
     rm -f "$STUB_DIR/rest-issues-fail" "$STUB_DIR/rest-prs-fail"
     rm -f "$STUB_DIR/rate-limit-message"
@@ -348,14 +373,15 @@ assert_eq "true" "$duplicate_found" "(f) --json duplicate_found is true when onl
 cross_num="$(echo "$OUT" | jq -r '.matches[] | select(.type == "cross_reference") | .number')"
 assert_eq "33" "$cross_num" "(f) --json cross_reference entry carries the correct issue number"
 
-# (g) Non-GitHub-forge-style failure (repo can't be resolved) degrades
-# gracefully: probe skipped, similarity check unaffected, no hard failure.
+# (g) Repo can't be resolved from the git remote (#4659: get_repo_nwo() reads
+# `git remote get-url origin`, not `gh repo view`) -> degrades gracefully:
+# probe skipped, similarity check unaffected, no hard failure.
 reset_state
-: > "$STUB_DIR/repo-view-fail"
+: > "$STUB_DIR/git-remote-fail"
 run_cds --issue 80 --title "Some issue title"
-assert_eq "0" "$RC" "(g) repo view failure -> exit code driven by similarity check alone"
-assert_not_contains "$OUT" "RELATED_OPEN_WORK" "(g) repo view failure -> probe result skipped"
-assert_contains "$ERR" "Failed to resolve repository" "(g) repo view failure -> stderr warning emitted"
+assert_eq "0" "$RC" "(g) git remote resolution failure -> exit code driven by similarity check alone"
+assert_not_contains "$OUT" "RELATED_OPEN_WORK" "(g) git remote resolution failure -> probe result skipped"
+assert_contains "$ERR" "Failed to resolve repository" "(g) git remote resolution failure -> stderr warning emitted"
 
 echo ""
 echo "Testing check-duplicate.sh keyword-similarity scoring (issue #4409)..."
@@ -545,6 +571,28 @@ assert_eq "1" "$RC" "(p) Rate-limited GraphQL open-issues search falls back to R
 assert_contains "$OUT" "DUPLICATE_FOUND (REST fallback" "(p) REST fallback output is labeled distinctly from a normal GraphQL match"
 assert_contains "$OUT" "#801: Alpha Bravo Charlie Delta (similarity: 100%)" "(p) REST fallback finds the matching issue"
 assert_not_contains "$OUT" "#802" "(p) REST fallback excludes PR entries returned by the /issues endpoint"
+
+# (p2) GLOBAL GraphQL exhaustion (issue #4659): not just the `issue list`
+# GraphQL call is rate-limited, but repo resolution is ALSO unavailable (here,
+# `git remote get-url origin` fails outright) -- modeling the real production
+# incident this issue is about, where get_repo_nwo() used to be `gh repo
+# view` (itself GraphQL-backed) and its failure short-circuited the REST
+# fallback via `&&` BEFORE `gh api` was ever attempted, reporting exit 2
+# ("could not check") and blaming REST for a failure REST never had. With the
+# fix, the REST-fallback call sites resolve "{owner}/{repo}" via `gh api`'s
+# own local placeholder substitution and never call get_repo_nwo()/git at
+# all, so this must still succeed with exit 1, not degrade to exit 2.
+reset_state
+: > "$STUB_DIR/issue-list-rate-limit-open"
+: > "$STUB_DIR/git-remote-fail"
+cat > "$STUB_DIR/rest-issues-open.json" <<'EOF'
+[{"number": 801, "title": "Alpha Bravo Charlie Delta", "body": "", "pull_request": null}]
+EOF
+run_cds --threshold 50 --title "Alpha Bravo Charlie Delta"
+assert_eq "1" "$RC" "(p2) Global GraphQL exhaustion (list AND repo resolution both down) -> REST fallback still completes, exit 1"
+assert_contains "$OUT" "DUPLICATE_FOUND (REST fallback" "(p2) REST fallback output labeled distinctly even under global exhaustion"
+assert_contains "$OUT" "#801: Alpha Bravo Charlie Delta (similarity: 100%)" "(p2) REST fallback still finds the matching issue"
+assert_not_contains "$ERR" "REST fallback also failed" "(p2) REST never actually failed -- must not be blamed for the repo-resolution outage"
 
 # (q) Open-issues GraphQL rate-limited AND the REST fallback also fails ->
 # exit 2 ("could not run at all"), not silently treated as no duplicates.


### PR DESCRIPTION
Closes #4659

## Problem

PR #4587 (issue #4526) added a REST fallback to `check-duplicate.sh` so the
three GraphQL-backed searches (open issues / merged PRs / closed issues)
survive GraphQL quota exhaustion. But the fallback's first step,
`get_repo_nwo()`, was itself a GraphQL call (`gh repo view --json
nameWithOwner`). Under GraphQL exhaustion, `get_repo_nwo()` failed first, the
`&&` short-circuited before REST was ever attempted, and the script reported
exit 2 blaming REST for a failure REST never had.

`search_cross_references()` had the same `gh repo view` dependency (there it
just degrades to a warning rather than exit 2, but same root cause).

## Fix

- **The three REST-fallback call sites** (`search_similar_issues`,
  `search_merged_prs`, `search_closed_issues`) now call `gh api
  "repos/{owner}/{repo}/..."` directly with the literal `{owner}/{repo}`
  placeholder — `gh` resolves it locally from the git remote, no API call at
  all. `get_repo_nwo()` is no longer called from these paths.
- **`get_repo_nwo()`** is kept (only `search_cross_references()` still needs
  the literal `"owner/repo"` string, to filter the timeline API response to
  same-repo cross-references) but rewritten to read `git remote get-url
  origin` — a pure local read — instead of round-tripping through `gh repo
  view`. Its error message no longer conflates repo-resolution failure with a
  REST failure.
- **`search_cross_references()`** now uses this git-remote-based
  `get_repo_nwo()` and the `{owner}/{repo}` placeholder for its `gh api`
  timeline call, so it no longer depends on any GraphQL call either.
- **`defaults/.claude/commands/loom/curator.md`** (symlinked from
  `defaults/roles/curator.md`) now distinguishes exit 1 (duplicate/related
  work found — review before curating) from exit 2 (check could not
  complete — log and proceed, don't block curation) at its
  `check-duplicate.sh` call site. Previously both were treated identically
  via `if ! check-duplicate.sh ...`, so a rate-limited curator pass falsely
  reported "potential duplicate detected" when nothing was actually checked.

## Tests

- Added a `git` stub to `test-check-duplicate.sh` (parallel to the existing
  `gh`/`loom-daemon` stubs) so tests can simulate `git remote get-url origin`
  failing.
- Added test (p2): models **global GraphQL exhaustion** — the `issue list`
  GraphQL call is rate-limited AND repo resolution (`git remote get-url
  origin`) fails outright, while `gh api` (REST) is healthy. Asserts exit 1
  with the `DUPLICATE_FOUND (REST fallback ...)` header and that "REST
  fallback also failed" is never emitted — this is the exact production
  condition (#4659) that used to incorrectly report exit 2.
- Reworked test (g) (repo-resolution failure degrades
  `search_cross_references()` gracefully) to trigger via the new
  `git-remote-fail` knob instead of the now-unused `gh repo view` stub case
  (production code no longer calls `gh repo view` at all).

`shellcheck` clean on both modified scripts. Full suite: **121/121 passed**
(117 original assertions + 4 new for test p2), confirmed via
`bash defaults/scripts/tests/test-check-duplicate.sh` and the CI-wired
manifest invariant check (`check-ci-suite-manifest.sh`).

## Acceptance criteria

- [x] The REST fallback in all three `check-duplicate.sh` search paths
      completes without any GraphQL call.
- [x] A test models global GraphQL exhaustion (list calls **and** `repo
      view`/git-remote resolution rate-limited/failed, `gh api` healthy) and
      asserts exit 1 with the REST-fallback-labeled header.
- [x] The "REST fallback also failed" message is only emitted when a REST
      call actually failed.
- [x] `search_cross_references()`'s repo resolution no longer depends on
      GraphQL.
- [x] `curator.md` distinguishes exit 1 from exit 2 at the
      `check-duplicate.sh` call site.
- [x] `shellcheck` clean; full suite green (121/121).