### PR TITLE
fix(check-duplicate): exclude the probed issue from its own candidate pool

### DIFF
--- a/defaults/scripts/check-duplicate.sh
+++ b/defaults/scripts/check-duplicate.sh
@@ -339,6 +339,7 @@ search_similar_issues() {
     local title="$1"
     local body="${2:-}"
     local threshold="${3:-18}"
+    local self_issue="${4:-}"
 
     # Extract keywords from new issue
     local new_keywords
@@ -388,6 +389,14 @@ search_similar_issues() {
 
         # Skip if no number
         [[ -z "$num" || "$num" == "null" ]] && continue
+
+        # Skip the issue being curated/probed itself (#4662): it is always
+        # in the open-issues pool it's being checked against, and always
+        # scores ~100% similarity against its own title/body -- a guaranteed
+        # false DUPLICATE_FOUND on every curation pass of an existing issue.
+        # No-op when --issue was not given (self_issue empty).
+        [[ -n "$self_issue" && "$num" == "$self_issue" ]] && continue
+
         scanned=$((scanned + 1))
 
         # Extract keywords from existing issue
@@ -435,6 +444,7 @@ search_merged_prs() {
     local title="$1"
     local body="${2:-}"
     local threshold="${3:-18}"
+    local self_issue="${4:-}"
 
     # Extract keywords from new issue
     local new_keywords
@@ -480,6 +490,12 @@ search_merged_prs() {
 
         # Skip if no number
         [[ -z "$num" || "$num" == "null" ]] && continue
+
+        # Skip the probed issue's own linked PR, once merged (#4662) -- same
+        # self-match false positive as search_similar_issues(), reached via a
+        # different pool. No-op when --issue was not given.
+        [[ -n "$self_issue" && "$num" == "$self_issue" ]] && continue
+
         scanned=$((scanned + 1))
 
         # Extract keywords from existing PR
@@ -520,6 +536,7 @@ search_closed_issues() {
     local title="$1"
     local body="${2:-}"
     local threshold="${3:-18}"
+    local self_issue="${4:-}"
 
     # Extract keywords from new issue
     local new_keywords
@@ -565,6 +582,13 @@ search_closed_issues() {
 
         # Skip if no number
         [[ -z "$num" || "$num" == "null" ]] && continue
+
+        # Skip the probed issue itself, in case it (or a stale cache of it)
+        # shows up in the recently-closed pool (#4662) -- same self-match
+        # false positive as search_similar_issues(). No-op when --issue was
+        # not given.
+        [[ -n "$self_issue" && "$num" == "$self_issue" ]] && continue
+
         scanned=$((scanned + 1))
 
         # Extract keywords from existing issue
@@ -783,7 +807,7 @@ main() {
     # Search for similar issues
     local result
     local exit_code=0
-    result=$(search_similar_issues "$title" "$body" "$threshold") || exit_code=$?
+    result=$(search_similar_issues "$title" "$body" "$threshold" "$issue") || exit_code=$?
     if [[ $exit_code -eq 1 ]]; then
         duplicate_found=true
     elif [[ $exit_code -eq 2 ]]; then
@@ -796,8 +820,8 @@ main() {
     if $include_merged_prs; then
         local merged_exit_code=0
         local closed_exit_code=0
-        merged_result=$(search_merged_prs "$title" "$body" "$threshold") || merged_exit_code=$?
-        closed_result=$(search_closed_issues "$title" "$body" "$threshold") || closed_exit_code=$?
+        merged_result=$(search_merged_prs "$title" "$body" "$threshold" "$issue") || merged_exit_code=$?
+        closed_result=$(search_closed_issues "$title" "$body" "$threshold" "$issue") || closed_exit_code=$?
 
         # #4526: a GraphQL rate-limit that ALSO fails via REST means this
         # pool genuinely could not be checked. Record it; the final verdict

--- a/defaults/scripts/tests/test-check-duplicate.sh
+++ b/defaults/scripts/tests/test-check-duplicate.sh
@@ -553,6 +553,82 @@ assert_contains "$OUT" "#3550" "(o) Real historical duplicate pair (#3550/#3551)
 assert_contains "$OUT" "(similarity: 26%)" "(o) Real historical duplicate pair scores the expected 26% true-Jaccard"
 
 echo ""
+echo "Testing check-duplicate.sh self-match exclusion via --issue (issue #4662)..."
+
+# check-duplicate.sh never excluded the issue being curated from its own
+# similarity candidate pool: the curator workflow fetches the existing
+# issue's own title/body and passes them in, so the issue is in the
+# open-issues pool it's being checked against and matches itself at ~100%,
+# forcing a guaranteed false DUPLICATE_FOUND on every curation pass of an
+# already-filed issue. Threading the --issue number into the three
+# similarity-search functions and skipping that number in each candidate
+# loop fixes it; passing NO --issue (pre-filing checks, where the issue
+# doesn't exist yet) must remain byte-for-byte unchanged.
+
+# (aa) Candidate pool contains only the probed issue itself (same number,
+# identical title/body) -- the exact self-noise from #4662. With --issue <n>
+# passed, the self-candidate is excluded from the pool entirely (not just
+# scored below threshold): with nothing left to scan, the search reports "no
+# duplicates", not a self-match.
+reset_state
+cat > "$STUB_DIR/issues-open.json" <<'EOF'
+[{"number": 4659, "title": "check-duplicate.sh: REST fallback still dies", "body": "REST fallback dies under load"}]
+EOF
+run_cds --issue 4659 --title "check-duplicate.sh: REST fallback still dies" --body "REST fallback dies under load"
+assert_eq "0" "$RC" "(aa) Self-only candidate pool + --issue <n> -> exit 0, no self-match false positive"
+assert_not_contains "$OUT" "DUPLICATE_FOUND" "(aa) Self-match excluded, no DUPLICATE_FOUND"
+
+# (aa2) Same fixture WITHOUT --issue -> the self-match still surfaces. This is
+# the documented pre-existing behavior for pre-filing checks (Architect/Hermit/
+# Auditor calls, which never pass --issue because the issue doesn't exist yet)
+# -- there is no self number to exclude, so nothing changes for them.
+run_cds --title "check-duplicate.sh: REST fallback still dies" --body "REST fallback dies under load"
+assert_eq "1" "$RC" "(aa2) Same fixture without --issue -> self-match still surfaces (no self number to exclude)"
+assert_contains "$OUT" "DUPLICATE_FOUND" "(aa2) Without --issue, the match is reported (unchanged pre-existing behavior)"
+assert_contains "$OUT" "#4659" "(aa2) Without --issue, the (self) match is listed"
+
+# (ab) Self-candidate PLUS a genuinely different candidate in the same pool:
+# exclusion removes only the self entry -- a real duplicate elsewhere in the
+# pool is still found and reported.
+reset_state
+cat > "$STUB_DIR/issues-open.json" <<'EOF'
+[
+  {"number": 4659, "title": "Alpha Bravo Charlie Delta", "body": ""},
+  {"number": 4700, "title": "Alpha Bravo Charlie Delta", "body": ""}
+]
+EOF
+run_cds --issue 4659 --threshold 50 --title "Alpha Bravo Charlie Delta"
+assert_eq "1" "$RC" "(ab) Self plus a genuine duplicate candidate -> genuine duplicate still found"
+assert_contains "$OUT" "#4700: Alpha Bravo Charlie Delta (similarity: 100%)" "(ab) Genuine (non-self) duplicate reported"
+assert_not_contains "$OUT" "#4659:" "(ab) Self-candidate excluded from the match list"
+
+# (ac) Self-exclusion also threads through the closed-issues pool
+# (--include-merged-prs): a probed issue that shows up in the closed-issues
+# pool (e.g. it was briefly closed/reopened) must not match itself there.
+reset_state
+echo "[]" > "$STUB_DIR/issues-open.json"
+cat > "$STUB_DIR/issues-closed.json" <<'EOF'
+[{"number": 4659, "title": "Alpha Bravo Charlie Delta", "body": ""}]
+EOF
+run_cds --include-merged-prs --issue 4659 --threshold 50 --title "Alpha Bravo Charlie Delta"
+assert_eq "0" "$RC" "(ac) Self-match in the closed-issues pool excluded via --issue -> exit 0"
+assert_not_contains "$OUT" "DUPLICATE_FOUND" "(ac) No DUPLICATE_FOUND from the closed-issues self-match"
+
+# (ad) Self-exclusion threads through the merged-PRs pool identically. GitHub
+# issue/PR numbers share one sequence, so a genuine self-match can't occur
+# here in production -- this is a defensive-consistency check that the same
+# skip parameter doesn't misbehave (e.g. off-by-one, wrong variable) if a
+# candidate ever carries the probed issue's number.
+reset_state
+echo "[]" > "$STUB_DIR/issues-open.json"
+cat > "$STUB_DIR/prs-merged.json" <<'EOF'
+[{"number": 4659, "title": "Alpha Bravo Charlie Delta", "body": ""}]
+EOF
+run_cds --include-merged-prs --issue 4659 --threshold 50 --title "Alpha Bravo Charlie Delta"
+assert_eq "0" "$RC" "(ad) Self-numbered candidate in the merged-PRs pool excluded via --issue -> exit 0"
+assert_not_contains "$OUT" "DUPLICATE_FOUND" "(ad) No DUPLICATE_FOUND from the merged-PRs self-numbered match"
+
+echo ""
 echo "Testing check-duplicate.sh REST fallback on GraphQL rate limit (issue #4526)..."
 
 # (p) Open-issues GraphQL rate-limited -> REST fallback succeeds and is used.


### PR DESCRIPTION
## Summary

`check-duplicate.sh --issue N ...` never excluded issue N from its own similarity candidate pool, so curating an existing issue always matched the issue against itself at ~100% similarity and forced a guaranteed false `DUPLICATE_FOUND` / exit 1 on every curation pass. `search_cross_references()` already excluded the self number (`.source.issue.number != $self`); the three keyword-similarity searches did not.

## Changes

- Threaded a new 4th positional `self_issue` parameter into `search_similar_issues()`, `search_merged_prs()`, and `search_closed_issues()`, defaulting to empty (no-op) when unset.
- Added `[[ -n "$self_issue" && "$num" == "$self_issue" ]] && continue` in each candidate loop, before the `scanned` counter is incremented — the self-candidate is excluded from the pool entirely, not merely scored below threshold.
- `main()` now passes the already-parsed `$issue` (from `--issue`) into all three calls, in addition to the existing `search_cross_references "$issue"` call.
- No behavior change when `--issue` is not passed (Architect/Hermit/Auditor pre-filing checks, where the issue doesn't exist yet): `self_issue` is empty, so the skip check is always false.
- Added test coverage in `defaults/scripts/tests/test-check-duplicate.sh`: a self-only candidate pool excluded via `--issue` (exit 0), the same fixture without `--issue` still surfacing the match (regression guard for pre-filing checks), a self-candidate alongside a genuine duplicate (only the self entry is excluded), and the same exclusion threading through the closed-issues and merged-PRs pools.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--issue <n>` excludes issue `n` from open-issues, merged-PRs, and closed-issues candidate pools | ✅ | New tests (aa)-(ad) in `test-check-duplicate.sh` |
| No behavior change when `--issue` is absent | ✅ | Test (aa2): identical fixture without `--issue` still reports the match, exit 1 |
| Self-exclusion doesn't swallow a genuine duplicate elsewhere in the pool | ✅ | Test (ab) |
| Full test suite green | ✅ | `./defaults/scripts/tests/test-check-duplicate.sh` -> 133/133 passed |
| shellcheck clean on both modified files | ✅ | `shellcheck defaults/scripts/check-duplicate.sh defaults/scripts/tests/test-check-duplicate.sh` -> exit 0 |

## Test Plan

- `./defaults/scripts/tests/test-check-duplicate.sh` — 133/133 passed (12 new cases for this fix).
- `shellcheck defaults/scripts/check-duplicate.sh defaults/scripts/tests/test-check-duplicate.sh` — clean.
- `bash defaults/scripts/tests/check-ci-suite-manifest.sh` — confirms `test-check-duplicate.sh` remains CI-wired.

Closes #4662