### PR TITLE
feat(tokens): explain empty-pool failures per token and wire .bad_tokens cleanup

### DIFF
--- a/.loom/docs/token-pool.md
+++ b/.loom/docs/token-pool.md
@@ -351,6 +351,11 @@ newlines/carriage-returns are sanitized to spaces so every `.bad_tokens` record
 is exactly one line — byte-compatible with the Python implementation, and
 conformance-tested against it in `loom-tools/tests/tokens/test_rust_conformance.py`.
 
+How long an entry keeps blocking (auth = permanent, exhaustion = 6h TTL) and how
+long it survives on disk (24h / 30d) are two different clocks — see
+[Permanence: auth vs exhaustion](#permanence-auth-vs-exhaustion-at-read-time-and-on-disk)
+below.
+
 ## Error classification (`.loom/scripts/lib/classify-error.sh`)
 
 The `classify_error <output> <exit_code>` function returns one of `SUCCESS`,
@@ -543,16 +548,75 @@ let an operator dispatch onto a still-poisoned pool), `unblock` now **names the
 still-blocked accounts and exits `3`**. Re-run with `--all-reasons` to drop them,
 or wait for the cooldown to expire them automatically.
 
-**Reason-aware bad-token TTL**: bad-tokens entries whose reason is `auth` (401 /
-OAuth / expired / blocked) persist until `loom-daemon tokens unblock`. Non-auth
-("exhausted"/"rate-limited") entries stop blocking selection once they age past
-the exhaustion cooldown (`LOOM_TOKEN_EXHAUSTION_COOLDOWN_SECS`, default 21600s =
-6h) — enforced at selection time in **both** the Rust daemon and the live Python
-spawn path (`is_bad`), so a recovered account re-enters the pool with no operator
-action even before `cleanup_bad_tokens` prunes the line from disk. Before #4212
-only the Rust path honored the cooldown, so on the live Python spawn path a stale
-`exhausted` marker outlived its rate-limit reset and wedged the account until a
-manual `unblock`.
+### Permanence: auth vs exhaustion, at read time and on disk
+
+There are **two independent clocks**, and conflating them is what made the
+2026-07-30 incident (#4643) hard to read. The table is the contract the error
+text, the CLI, and this document all agree on:
+
+| Reason class | Blocks selection until | Pruned from `.bad_tokens` after |
+|---|---|---|
+| `auth` (401 / OAuth / expired / blocked) | `loom-daemon tokens unblock <name>` — **never expires** | 30d (`AUTH_ENTRY_MIN_RETENTION_SECS`), a garbage-collection floor, *not* an expiry |
+| non-auth (`exhausted` / `rate-limited`) | the **exhaustion cooldown** — `LOOM_TOKEN_EXHAUSTION_COOLDOWN_SECS`, default `21600` (6h) | 24h (`DEFAULT_CLEANUP_MAX_AGE_SECS`) |
+| unparseable timestamp | never (**fail-closed** — a malformed line never silently un-blocks a token) | never (malformed lines are always retained) |
+
+**Read time** (`bad_tokens::is_bad` / `blocking_entry`, enforced by the selector
+on every tier): a non-auth entry stops blocking once it ages past the cooldown,
+so a recovered account re-enters rotation with **no operator action** even
+before the line is pruned from disk (#4122). Auth entries are exempt from that
+TTL by design — a broken credential does not heal on a timer.
+
+**On disk** (`bad_tokens::cleanup_bad_tokens`, wired in #4643 into `tokens
+select` and `tokens check`): entries older than the max-age policy above are
+dropped. The auth floor is deliberately far longer than the routine 24h policy,
+because pruning an auth line *would* silently readmit a broken credential —
+the on-disk clock must never become a back-door expiry for the permanent class.
+Cleanup is best-effort and takes **no lock at all** when nothing is prunable, so
+a burst of concurrent spawns never serializes on `.bad_tokens`. Before #4643
+`cleanup_bad_tokens` had zero callers anywhere in the tree and pools accumulated
+entries indefinitely.
+
+**The oldest visible entry is usually not the deciding one.** Every failed spawn
+appends a *new* line, so an account with a genuinely long-lived limit (e.g.
+`hit your weekly limit`, which outlasts the 6h cooldown by days) is
+continuously re-marked: the 13h-old lines at the top of the file expired long
+ago, while a fresh line further down is what actually blocks. `blocking_entry`
+reports the deciding line, and the empty-pool error prints its timestamp — read
+that, not the head of the file.
+
+### Empty-pool error detail (#4643)
+
+When every account is excluded, `tokens select` no longer prints a bare "All N
+tokens … are marked bad or empty". It enumerates, per account, the exclusion
+cause, the reason class and its permanence, the deciding entry's own timestamp,
+and the cooldown remaining — plus the **identity of the binary that decided**
+(version, build commit, build timestamp):
+
+```
+error: All 2 tokens in ~/.loom/tokens are marked bad or empty.
+  - agent-1: bad-marked [exhaustion, TTL] at 2026-07-30T16:58:32Z — "exhausted: hit your weekly limit"; clears in 5h48m
+  - agent-2: bad-marked [auth, permanent] at 2026-07-29T21:33:41Z — "401 unauthorized"; needs `loom-daemon tokens unblock agent-2`
+  deciding binary: loom-daemon 0.16.0 (commit 105f9c12, built 2026-07-30T05:23:19Z)
+  exhaustion cooldown: 21600s (override LOOM_TOKEN_EXHAUSTION_COOLDOWN_SECS); auth entries never expire …
+```
+
+`spawn-claude.sh` additionally logs the resolved daemon binary path and its
+`--version` at token-selection time, on every spawn:
+
+```
+spawn-claude: token-selection binary: /home/you/.local/bin/loom-daemon (loom-daemon 0.16.0 (commit 105f9c12, built 2026-07-30T05:23:19Z))
+```
+
+Both exist because the selection binary is resolved by `spawn-claude.sh` itself
+(`$LOOM_DAEMON_BIN` → PATH → build-output candidates), **independently of any
+running daemon** — so a long-running daemon can hand a sweep child a binary that
+predates the last merged selection fix. That "stale binary at the selection
+site" hypothesis is now answerable straight from `.loom/logs/sweep-issue-<N>.log`
+instead of by reading Rust source. (For the 2026-07-30 incident itself the
+hypothesis was **refuted** — the host's resolvable binaries were all descendants
+of the cooldown fix — but confirming that required inspecting the host's
+installed binaries after the fact, which is exactly the forensics this log line
+removes.)
 
 **Auto-unpin** (`failure_counts`): the wrapper tracks consecutive
 `TOKEN_EXHAUSTED` failures per account in `.loom/tokens/.failure_counts` (JSON).

--- a/defaults/scripts/spawn-claude.sh
+++ b/defaults/scripts/spawn-claude.sh
@@ -369,6 +369,20 @@ if [[ -z "${LOOM_SPAWN_NO_EXPORT:-}" && -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; th
         exit 78  # EX_CONFIG
     fi
 
+    # --- Binary provenance at the selection site (issue #4643) ---
+    # The binary that decides token selection is resolved HERE, independently
+    # of any running daemon ($LOOM_DAEMON_BIN -> PATH -> build-output
+    # candidates), so a long-running daemon can hand a sweep child a binary
+    # older than the last merged selection fix. That staleness was the leading
+    # hypothesis for the 2026-07-30 incident (13h-old exhaustion entries
+    # appearing to block every spawn); refuting it took out-of-band forensics
+    # on the host's installed binaries, because NOTHING in the sweep log
+    # recorded which binary ran. Log path + version on every spawn so the next
+    # occurrence is answerable straight from `.loom/logs/sweep-issue-<N>.log`.
+    # Best-effort: a binary too old to support `--version` still logs its path.
+    _daemon_version="$("$_daemon_bin" --version 2>/dev/null | head -1)"
+    log_info "spawn-claude: token-selection binary: $_daemon_bin (${_daemon_version:-version unknown})"
+
     _select_args=(tokens select --workspace "$WORKSPACE" --export)
     # Pre-flight: auto-unpin if every allowlisted account has hit the
     # consecutive-failure threshold (default 5). Without this, an

--- a/defaults/scripts/tests/test-spawn-claude.sh
+++ b/defaults/scripts/tests/test-spawn-claude.sh
@@ -438,6 +438,15 @@ assert_contains "stub-claude args=-p ping" "$output" \
 assert_contains "OAuth account 'alpha'" "$output" \
     "spawn-claude logs the chosen account"
 
+# Test: binary provenance at the selection site (issue #4643). The daemon
+# binary that decides token selection is resolved by spawn-claude.sh itself,
+# so a stale one is invisible unless it is logged. Assert both the resolved
+# path and a version string land in the sweep log.
+assert_contains "spawn-claude: token-selection binary: $DAEMON_BIN" "$output" \
+    "spawn-claude logs the resolved daemon binary path at token selection (#4643)"
+assert_contains "(loom-daemon " "$output" \
+    "spawn-claude logs the daemon binary's --version at token selection (#4643)"
+
 # Test: spawn-claude disables the print-mode background-task wait ceiling
 # (issue #3943) so a daemon-dispatched sweep child's long-running Builder/Judge
 # subagents are not reaped at the 600s ceiling. Default = 0 (no cap).
@@ -516,6 +525,33 @@ assert_contains "tokens bootstrap" "$output" \
 assert_not_contains "loom-tokens bootstrap" "$output" \
     "empty pool error does NOT advise the retired loom-tokens binary (#4557)"
 rm -rf "$EMPTY_WS"
+
+# Test: an all-bad pool reports PER-TOKEN exclusion detail plus the deciding
+# binary (issue #4643). Diagnosing the 2026-07-30 incident required reading
+# Rust source because "All N tokens ... are marked bad or empty" said nothing
+# about why each account was out or which binary decided. The whole point is
+# that this is answerable from the sweep log, so assert it at the spawn layer.
+BAD_WS="$(mktemp -d)"
+mkdir -p "$BAD_WS/.loom/tokens"
+echo -n "fake-token-exh" > "$BAD_WS/.loom/tokens/exh.token"
+echo -n "fake-token-auth" > "$BAD_WS/.loom/tokens/auth.token"
+_now_ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+{
+    echo "$_now_ts exh exhausted: hit your session limit"
+    echo "$_now_ts auth 401 unauthorized"
+} > "$BAD_WS/.loom/tokens/.bad_tokens"
+output=$(LOOM_WORKSPACE="$BAD_WS" LOOM_SHARED_TOKENS_DIR="" \
+    LOOM_DAEMON_BIN="$DAEMON_BIN" PATH="$STUB_DIR:$PATH" \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+assert_contains "exh: bad-marked [exhaustion, TTL]" "$output" \
+    "all-bad pool error names the exhaustion entry's class and TTL (#4643)"
+assert_contains "auth: bad-marked [auth, permanent]" "$output" \
+    "all-bad pool error names the auth entry as permanent (#4643)"
+assert_contains "clears in " "$output" \
+    "all-bad pool error reports the cooldown remaining (#4643)"
+assert_contains "deciding binary: loom-daemon " "$output" \
+    "all-bad pool error names the deciding binary (#4643)"
+rm -rf "$BAD_WS"
 
 # Test that spawn-claude.sh exits 78 on missing tokens (shared fallback off).
 set +e

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -53,15 +53,11 @@ use tokio::net::UnixStream;
 // fresh ones and cause hard-to-diagnose install regressions (#3287 class).
 // `LOOM_DAEMON_GIT_COMMIT` and `LOOM_DAEMON_BUILD_TIME` are populated by
 // `build.rs`; both fall back to "unknown" when the build host lacks the
-// tooling, which is loud but harmless.
-#[command(version = concat!(
-    env!("CARGO_PKG_VERSION"),
-    " (commit ",
-    env!("LOOM_DAEMON_GIT_COMMIT"),
-    ", built ",
-    env!("LOOM_DAEMON_BUILD_TIME"),
-    ")"
-))]
+// tooling, which is loud but harmless. The composed string lives in the lib
+// crate (`self_update::BUILD_IDENTITY`) so library code that must name the
+// deciding binary — e.g. the empty-token-pool error (#4643) — reports exactly
+// what `--version` reports.
+#[command(version = loom_daemon::self_update::BUILD_IDENTITY)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
@@ -7244,6 +7240,15 @@ fn handle_tokens_command(action: TokensAction) -> Result<()> {
                     eprintln!("{msg}");
                 }
             }
+            // Routine `.bad_tokens` hygiene (#4643). `cleanup_bad_tokens` had
+            // zero callers in the whole tree, so pools accumulated expired
+            // exhaustion entries forever (the live shared pool still held
+            // days-old lines). Selection is the routine path every spawn takes,
+            // and pruning is behavior-neutral — `is_bad` already ignores
+            // aged-out entries — so this only bounds the file. Best-effort:
+            // never let a cleanup failure block a spawn, and no lock is taken
+            // at all when there is nothing to prune.
+            let _ = bad_tokens::cleanup_bad_tokens(&ws, bad_tokens::DEFAULT_CLEANUP_MAX_AGE_SECS);
             match select::select_token(&ws, None) {
                 Ok(sel) => {
                     if export {
@@ -7486,6 +7491,26 @@ fn handle_tokens_command(action: TokensAction) -> Result<()> {
                      workspace; anchoring to the shared machine-level pool at {} (issue #4292)",
                     tokens_dir.display()
                 );
+            }
+
+            // Routine `.bad_tokens` hygiene (#4643) — the second wired path.
+            // `tokens check` is the low-frequency periodic probe (the daemon's
+            // ranking refresh runs it on a cadence), so it prunes the pool the
+            // check is actually anchored to, which may be the shared
+            // machine-level pool rather than `resolve_tokens_dir(workspace)`.
+            match bad_tokens::cleanup_bad_tokens_in_dir(
+                &tokens_dir,
+                bad_tokens::DEFAULT_CLEANUP_MAX_AGE_SECS,
+            ) {
+                Ok(outcome) if outcome.removed > 0 => eprintln!(
+                    "note: pruned {} expired .bad_tokens entr{} older than {}h ({} retained)",
+                    outcome.removed,
+                    if outcome.removed == 1 { "y" } else { "ies" },
+                    bad_tokens::DEFAULT_CLEANUP_MAX_AGE_SECS / 3600,
+                    outcome.kept,
+                ),
+                Ok(_) => {}
+                Err(e) => eprintln!("warning: .bad_tokens cleanup skipped: {e}"),
             }
 
             let source_flag = match source {

--- a/loom-daemon/src/self_update.rs
+++ b/loom-daemon/src/self_update.rs
@@ -28,6 +28,23 @@ use std::process::Command;
 /// (e.g. a release-tarball build with no `.git` present).
 pub const BUILT_COMMIT: &str = env!("LOOM_DAEMON_GIT_COMMIT");
 
+/// The full build identity of this binary — `"<version> (commit <sha>, built
+/// <ts>)"` — as shown by `loom-daemon --version`.
+///
+/// Lives here (the lib crate) rather than inline in `main.rs` so library code
+/// can stamp it into operator-facing failures too: the empty-token-pool error
+/// names the deciding binary (#4643) precisely because "which binary made this
+/// decision?" was unanswerable from the 2026-07-30 incident logs. `main.rs`'s
+/// clap `--version` string is this same constant, so the two can never drift.
+pub const BUILD_IDENTITY: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (commit ",
+    env!("LOOM_DAEMON_GIT_COMMIT"),
+    ", built ",
+    env!("LOOM_DAEMON_BUILD_TIME"),
+    ")"
+);
+
 /// This crate's own directory in the source tree it was compiled from, baked
 /// in at compile time via `CARGO_MANIFEST_DIR` — the same
 /// compiled-from-source-tree technique the (retired in #4228)

--- a/loom-daemon/src/tokens_pool/bad_tokens.rs
+++ b/loom-daemon/src/tokens_pool/bad_tokens.rs
@@ -29,6 +29,29 @@ pub const DEFAULT_EXHAUSTION_COOLDOWN_SECS: i64 = 6 * 3600;
 /// [`DEFAULT_EXHAUSTION_COOLDOWN_SECS`].
 pub const EXHAUSTION_COOLDOWN_ENV: &str = "LOOM_TOKEN_EXHAUSTION_COOLDOWN_SECS";
 
+/// On-disk retention for **non-auth** (exhaustion) entries on the routine
+/// cleanup path (#4643).
+///
+/// 24h = 4× the default 6h read-time cooldown: an exhaustion line stays on
+/// disk long after it stopped blocking selection (so an operator debugging the
+/// previous night's incident still sees it), but `.bad_tokens` can no longer
+/// grow without bound — the live shared pool had accumulated entries for days
+/// because [`cleanup_bad_tokens`] had **zero callers** before #4643.
+pub const DEFAULT_CLEANUP_MAX_AGE_SECS: i64 = 24 * 3600;
+
+/// Floor retention for **auth** entries on the cleanup path (#4643).
+///
+/// Auth entries are permanent *at read time* ([`is_bad`] never expires them),
+/// so pruning one on the routine 24h schedule would silently readmit a broken
+/// credential into rotation — exactly the failure mode the auth/exhaustion
+/// split exists to prevent. Cleanup therefore never drops an auth entry that
+/// is younger than 30 days, regardless of the `max_age_seconds` it was called
+/// with; only genuinely ancient auth lines (a credential retired a month ago)
+/// are reclaimed. The permanence contract is: **exhaustion entries clear
+/// themselves, auth entries clear only via `loom-daemon tokens unblock`** —
+/// the 30d floor is garbage collection, not expiry.
+pub const AUTH_ENTRY_MIN_RETENTION_SECS: i64 = 30 * 24 * 3600;
+
 /// Resolve the exhaustion-entry cooldown: the [`EXHAUSTION_COOLDOWN_ENV`]
 /// override (whole seconds, `> 0`) or [`DEFAULT_EXHAUSTION_COOLDOWN_SECS`].
 #[must_use]
@@ -99,7 +122,69 @@ pub fn mark_bad(workspace: &Path, token_name: &str, reason: &str) -> Result<(), 
     Ok(())
 }
 
-/// Return `true` if `token_name` is currently bad-marked.
+/// Why a `.bad_tokens` entry blocks selection — the reason class an operator
+/// needs in order to know whether the block clears itself (#4643).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BadReasonClass {
+    /// Auth reason (401 / OAuth / expired / blocked) — permanent at read time,
+    /// clears only via `loom-daemon tokens unblock <name>`.
+    Auth,
+    /// Non-auth ("exhausted" / "rate-limited") — expires by itself once the
+    /// entry ages past [`exhaustion_cooldown_secs`] (#4122).
+    Exhaustion,
+    /// The entry's timestamp did not parse. Fail-closed: treated as permanent,
+    /// because we never silently un-block a token on a malformed line.
+    MalformedTimestamp,
+}
+
+impl BadReasonClass {
+    /// Short class label used in operator-facing output.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Auth => "auth",
+            Self::Exhaustion => "exhaustion",
+            Self::MalformedTimestamp => "malformed-timestamp",
+        }
+    }
+
+    /// Whether entries of this class ever clear without operator action.
+    #[must_use]
+    pub fn permanence(self) -> &'static str {
+        match self {
+            Self::Auth => "permanent",
+            Self::Exhaustion => "TTL",
+            Self::MalformedTimestamp => "permanent (fail-closed)",
+        }
+    }
+}
+
+/// The `.bad_tokens` entry that is currently keeping a token out of rotation,
+/// as returned by [`blocking_entry`] (#4643). Everything an operator needs to
+/// tell "this clears itself in 12 minutes" apart from "this needs `unblock`".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockingEntry {
+    /// Raw first field of the line (the ISO-8601 UTC timestamp, or whatever
+    /// unparseable text stood in its place).
+    pub timestamp: String,
+    /// Free-form reason text as recorded by [`mark_bad`].
+    pub reason: String,
+    /// Auth (permanent) vs exhaustion (TTL) vs malformed (fail-closed).
+    pub class: BadReasonClass,
+    /// Seconds until this entry stops blocking selection. `Some` only for
+    /// [`BadReasonClass::Exhaustion`]; `None` means "never, without operator
+    /// action".
+    pub cooldown_remaining_secs: Option<i64>,
+}
+
+/// Return the `.bad_tokens` entry currently blocking `token_name`, or `None`
+/// when the token is selectable.
+///
+/// This is the single scan that decides bad-ness: [`is_bad`] is defined as
+/// `blocking_entry(..).is_some()`, so the boolean the selector acts on and the
+/// detail the operator reads can never de-sync (#4643 — diagnosing the
+/// 2026-07-30 incident required reading Rust source precisely because the
+/// selector's decision was unexplained).
 ///
 /// Auth-reason entries (a broken credential — matched by [`auth_reason_regex`])
 /// block permanently. Non-auth ("exhaustion") entries block only until they age
@@ -107,16 +192,17 @@ pub fn mark_bad(workspace: &Path, token_name: &str, reason: &str) -> Result<(), 
 /// transient, so a stale exhaustion line no longer keeps an otherwise-healthy
 /// account out of rotation even before [`cleanup_bad_tokens`] prunes it from
 /// disk. A line whose timestamp cannot be parsed is treated as permanent
-/// (fail-closed — we never silently un-block a token on a malformed entry).
+/// (fail-closed). An *expired* entry does not short-circuit the scan — a later
+/// line for the same account may still block (this is the common live shape:
+/// every retry appends a fresh line, so the newest entry, not the oldest
+/// visible one, is the one that matters).
 ///
 /// Reads are unsynchronized — readers see a consistent file because writers
 /// only ever append whole lines.
 #[must_use]
-pub fn is_bad(workspace: &Path, token_name: &str) -> bool {
+pub fn blocking_entry(workspace: &Path, token_name: &str) -> Option<BlockingEntry> {
     let bad_file = bad_tokens_path(&tokens_dir(workspace));
-    let Ok(text) = std::fs::read_to_string(&bad_file) else {
-        return false;
-    };
+    let text = std::fs::read_to_string(&bad_file).ok()?;
     let pattern = name_pattern(token_name);
     let cooldown = exhaustion_cooldown_secs();
     let now = Utc::now().timestamp();
@@ -132,48 +218,89 @@ pub fn is_bad(workspace: &Path, token_name: &str) -> bool {
         let reason = parts.next().unwrap_or("");
         // Auth entries never expire.
         if auth_reason_regex().is_match(reason) {
-            return true;
+            return Some(BlockingEntry {
+                timestamp: ts_str.to_string(),
+                reason: reason.to_string(),
+                class: BadReasonClass::Auth,
+                cooldown_remaining_secs: None,
+            });
         }
         // Non-auth (exhaustion) entries expire after the cooldown. A
-        // malformed/missing timestamp fails closed (permanent). An expired
-        // entry does NOT short-circuit — a later line may still block.
+        // malformed/missing timestamp fails closed (permanent).
         match chrono::NaiveDateTime::parse_from_str(ts_str, "%Y-%m-%dT%H:%M:%SZ") {
-            Ok(naive) if now - naive.and_utc().timestamp() < cooldown => return true,
-            Ok(_) => {}
-            Err(_) => return true,
+            Ok(naive) => {
+                let age = now - naive.and_utc().timestamp();
+                if age < cooldown {
+                    return Some(BlockingEntry {
+                        timestamp: ts_str.to_string(),
+                        reason: reason.to_string(),
+                        class: BadReasonClass::Exhaustion,
+                        cooldown_remaining_secs: Some(cooldown - age),
+                    });
+                }
+            }
+            Err(_) => {
+                return Some(BlockingEntry {
+                    timestamp: ts_str.to_string(),
+                    reason: reason.to_string(),
+                    class: BadReasonClass::MalformedTimestamp,
+                    cooldown_remaining_secs: None,
+                })
+            }
         }
     }
-    false
+    None
 }
 
-/// Drop bad_tokens entries older than `max_age_seconds`. Returns the number
-/// of entries retained after pruning.
+/// Return `true` if `token_name` is currently bad-marked.
 ///
-/// # Errors
-/// Returns an error if the lock cannot be acquired.
-pub fn cleanup_bad_tokens(workspace: &Path, max_age_seconds: i64) -> Result<usize, String> {
-    let dir = tokens_dir(workspace);
-    let bad_file = bad_tokens_path(&dir);
-    if !bad_file.is_file() {
-        return Ok(0);
-    }
+/// Thin boolean projection of [`blocking_entry`] — see there for the
+/// auth-vs-exhaustion permanence rules.
+#[must_use]
+pub fn is_bad(workspace: &Path, token_name: &str) -> bool {
+    blocking_entry(workspace, token_name).is_some()
+}
 
-    let cutoff = Utc::now().timestamp() - max_age_seconds;
+/// Outcome of a [`cleanup_bad_tokens_in_dir`] pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CleanupOutcome {
+    /// Entries still on disk after the pass.
+    pub kept: usize,
+    /// Entries dropped by this pass (`0` ⇒ the file was not rewritten).
+    pub removed: usize,
+}
 
-    let _lock = MkdirLock::acquire(&lock_path(&dir))?;
-    let text = std::fs::read_to_string(&bad_file).map_err(|e| e.to_string())?;
+/// Split `text` into (retained lines, removed count) under the reason-aware
+/// max-age policy. Pure — no I/O — so the lock-free pre-check and the
+/// under-lock rewrite in [`cleanup_bad_tokens_in_dir`] apply identical rules.
+fn partition_by_age(text: &str, max_age_seconds: i64, now: i64) -> (Vec<String>, usize) {
+    let cutoff = now - max_age_seconds;
+    // Auth entries are permanent at read time, so they get a much longer floor
+    // (see [`AUTH_ENTRY_MIN_RETENTION_SECS`]): never dropped before 30 days,
+    // no matter how aggressive the requested max age is.
+    let auth_cutoff = now - max_age_seconds.max(AUTH_ENTRY_MIN_RETENTION_SECS);
     let mut kept: Vec<String> = Vec::new();
+    let mut removed = 0usize;
     for line in text.lines() {
         let stripped = line.trim();
         if stripped.is_empty() {
             continue;
         }
-        let ts_str = stripped.split(' ').next().unwrap_or("");
+        let mut parts = stripped.splitn(3, ' ');
+        let ts_str = parts.next().unwrap_or("");
+        let _name = parts.next();
+        let reason = parts.next().unwrap_or("");
+        let entry_cutoff = if auth_reason_regex().is_match(reason) {
+            auth_cutoff
+        } else {
+            cutoff
+        };
         match chrono::NaiveDateTime::parse_from_str(ts_str, "%Y-%m-%dT%H:%M:%SZ") {
             Ok(naive) => {
-                let ts_epoch = naive.and_utc().timestamp();
-                if ts_epoch >= cutoff {
+                if naive.and_utc().timestamp() >= entry_cutoff {
                     kept.push(line.to_string());
+                } else {
+                    removed += 1;
                 }
             }
             Err(_) => {
@@ -181,6 +308,54 @@ pub fn cleanup_bad_tokens(workspace: &Path, max_age_seconds: i64) -> Result<usiz
                 kept.push(line.to_string());
             }
         }
+    }
+    (kept, removed)
+}
+
+/// Drop `.bad_tokens` entries in `dir` older than `max_age_seconds`, with
+/// **auth** entries held for at least [`AUTH_ENTRY_MIN_RETENTION_SECS`]
+/// (#4643). Malformed lines are always retained.
+///
+/// The common case (nothing prunable) costs one unsynchronized read and takes
+/// **no lock at all** — this runs on the `tokens select` hot path, where a
+/// burst of concurrent spawns must not serialize on the `.bad_tokens` lock.
+/// The file is re-read and re-partitioned under the lock before any rewrite,
+/// so a line appended between the pre-check and the lock is never lost.
+///
+/// # Errors
+/// Returns an error if the lock cannot be acquired or the file cannot be
+/// read/written.
+pub fn cleanup_bad_tokens_in_dir(
+    dir: &Path,
+    max_age_seconds: i64,
+) -> Result<CleanupOutcome, String> {
+    let bad_file = bad_tokens_path(dir);
+    if !bad_file.is_file() {
+        return Ok(CleanupOutcome {
+            kept: 0,
+            removed: 0,
+        });
+    }
+
+    // Lock-free pre-check: bail out without touching the lock when there is
+    // nothing to prune (the steady state on a healthy pool).
+    let text = std::fs::read_to_string(&bad_file).map_err(|e| e.to_string())?;
+    let (kept, removed) = partition_by_age(&text, max_age_seconds, Utc::now().timestamp());
+    if removed == 0 {
+        return Ok(CleanupOutcome {
+            kept: kept.len(),
+            removed: 0,
+        });
+    }
+
+    let _lock = MkdirLock::acquire(&lock_path(dir))?;
+    let text = std::fs::read_to_string(&bad_file).map_err(|e| e.to_string())?;
+    let (kept, removed) = partition_by_age(&text, max_age_seconds, Utc::now().timestamp());
+    if removed == 0 {
+        return Ok(CleanupOutcome {
+            kept: kept.len(),
+            removed: 0,
+        });
     }
 
     let tmp = bad_file.with_extension("tmp");
@@ -192,7 +367,19 @@ pub fn cleanup_bad_tokens(workspace: &Path, max_age_seconds: i64) -> Result<usiz
     std::fs::write(&tmp, body).map_err(|e| e.to_string())?;
     std::fs::rename(&tmp, &bad_file).map_err(|e| e.to_string())?;
 
-    Ok(kept.len())
+    Ok(CleanupOutcome {
+        kept: kept.len(),
+        removed,
+    })
+}
+
+/// Workspace-anchored [`cleanup_bad_tokens_in_dir`]. Returns the number of
+/// entries retained after pruning.
+///
+/// # Errors
+/// Returns an error if the lock cannot be acquired.
+pub fn cleanup_bad_tokens(workspace: &Path, max_age_seconds: i64) -> Result<usize, String> {
+    cleanup_bad_tokens_in_dir(&tokens_dir(workspace), max_age_seconds).map(|o| o.kept)
 }
 
 /// Outcome of [`unblock`]. `excluded` names the accounts that still have a
@@ -352,8 +539,88 @@ mod tests {
         // Exhaustion entry has aged out — token is selectable again even though
         // the line is still on disk (cleanup has not run yet).
         assert!(!is_bad(tmp.path(), "agent-exh"));
+        assert_eq!(blocking_entry(tmp.path(), "agent-exh"), None);
         // Auth entry is permanent — unaffected by the TTL.
         assert!(is_bad(tmp.path(), "agent-auth"));
+        // #4643: the same scan now also explains itself. The auth entry is
+        // reported as permanent with no cooldown remaining.
+        let entry = blocking_entry(tmp.path(), "agent-auth").expect("auth entry blocks");
+        assert_eq!(entry.class, BadReasonClass::Auth);
+        assert_eq!(entry.class.permanence(), "permanent");
+        assert_eq!(entry.cooldown_remaining_secs, None);
+        assert_eq!(entry.reason, "401 unauthorized");
+        assert_eq!(entry.timestamp, old);
+    }
+
+    /// #4643: a *fresh* exhaustion entry reports its class, its own timestamp,
+    /// and how long is left on the cooldown — the detail the empty-pool error
+    /// renders per token.
+    #[test]
+    fn blocking_entry_reports_exhaustion_class_and_cooldown_remaining() {
+        let tmp = make_pool();
+        let dir = pool_dir(tmp.path());
+        // 1h old → 5h of the 6h default cooldown remain.
+        let ts = (Utc::now() - chrono::Duration::seconds(3600))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string();
+        fs::write(
+            dir.join(".bad_tokens"),
+            format!("{ts} agent-1 exhausted: hit your session limit\n"),
+        )
+        .unwrap();
+        let entry = blocking_entry(tmp.path(), "agent-1").expect("fresh entry blocks");
+        assert_eq!(entry.class, BadReasonClass::Exhaustion);
+        assert_eq!(entry.class.label(), "exhaustion");
+        assert_eq!(entry.class.permanence(), "TTL");
+        assert_eq!(entry.timestamp, ts);
+        assert_eq!(entry.reason, "exhausted: hit your session limit");
+        let remaining = entry
+            .cooldown_remaining_secs
+            .expect("TTL entry has a remaining");
+        assert!(
+            (4 * 3600..=5 * 3600).contains(&remaining),
+            "expected ~5h remaining, got {remaining}"
+        );
+    }
+
+    /// #4643: the incident shape — an account whose *oldest* visible entry has
+    /// long expired but which was re-marked recently is still blocked, and the
+    /// entry reported is the deciding (fresh) one, not the stale one an
+    /// operator would see at the top of the file.
+    #[test]
+    fn blocking_entry_reports_the_deciding_fresh_line_not_the_stale_one() {
+        let tmp = make_pool();
+        let dir = pool_dir(tmp.path());
+        let old = (Utc::now() - chrono::Duration::seconds(13 * 3600))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string();
+        let fresh = (Utc::now() - chrono::Duration::seconds(600))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string();
+        fs::write(
+            dir.join(".bad_tokens"),
+            format!(
+                "{old} agent-1 exhausted: hit your limit\n\
+                 {fresh} agent-1 exhausted: hit your weekly limit\n"
+            ),
+        )
+        .unwrap();
+        let entry = blocking_entry(tmp.path(), "agent-1").expect("re-marked account blocks");
+        assert_eq!(entry.timestamp, fresh);
+        assert_eq!(entry.reason, "exhausted: hit your weekly limit");
+    }
+
+    /// #4643: an unparseable timestamp is reported as fail-closed permanent,
+    /// matching [`is_bad`]'s long-standing behavior.
+    #[test]
+    fn blocking_entry_classifies_malformed_timestamp_as_permanent() {
+        let tmp = make_pool();
+        let dir = pool_dir(tmp.path());
+        fs::write(dir.join(".bad_tokens"), "not-a-timestamp agent-1 exhausted\n").unwrap();
+        let entry = blocking_entry(tmp.path(), "agent-1").expect("malformed line fails closed");
+        assert_eq!(entry.class, BadReasonClass::MalformedTimestamp);
+        assert_eq!(entry.cooldown_remaining_secs, None);
+        assert!(entry.class.permanence().starts_with("permanent"));
     }
 
     /// #4122: a fresh exhaustion entry still blocks (the cooldown only expires
@@ -387,6 +654,41 @@ mod tests {
         assert_eq!(exhaustion_cooldown_secs(), DEFAULT_EXHAUSTION_COOLDOWN_SECS);
         std::env::remove_var(EXHAUSTION_COOLDOWN_ENV);
         assert_eq!(exhaustion_cooldown_secs(), DEFAULT_EXHAUSTION_COOLDOWN_SECS);
+    }
+
+    /// #4643: the *reported* cooldown remaining tracks the
+    /// [`EXHAUSTION_COOLDOWN_ENV`] override, not just the default — otherwise
+    /// the empty-pool error would tell an operator who shortened the cooldown
+    /// to wait hours that do not apply.
+    #[test]
+    #[serial]
+    fn blocking_entry_cooldown_remaining_honors_env_override() {
+        let tmp = make_pool();
+        let dir = pool_dir(tmp.path());
+        // 10 minutes old.
+        let ts = (Utc::now() - chrono::Duration::seconds(600))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string();
+        fs::write(
+            dir.join(".bad_tokens"),
+            format!("{ts} agent-1 exhausted: hit your session limit\n"),
+        )
+        .unwrap();
+
+        // 30-minute cooldown → ~20 minutes left (default 6h would report ~5h50m).
+        std::env::set_var(EXHAUSTION_COOLDOWN_ENV, "1800");
+        let entry = blocking_entry(tmp.path(), "agent-1").expect("still inside a 30m cooldown");
+        let remaining = entry.cooldown_remaining_secs.expect("TTL entry");
+        // 15-minute cooldown → already expired, so the token is selectable.
+        std::env::set_var(EXHAUSTION_COOLDOWN_ENV, "300");
+        let expired = blocking_entry(tmp.path(), "agent-1");
+        std::env::remove_var(EXHAUSTION_COOLDOWN_ENV);
+
+        assert!(
+            (1100..=1200).contains(&remaining),
+            "expected ~20m remaining under the override, got {remaining}s"
+        );
+        assert_eq!(expired, None, "a 300s cooldown should have expired a 600s-old entry");
     }
 
     #[test]
@@ -444,6 +746,109 @@ mod tests {
     fn cleanup_no_file_is_noop() {
         let tmp = make_pool();
         assert_eq!(cleanup_bad_tokens(tmp.path(), 100).unwrap(), 0);
+    }
+
+    /// #4643: the wired path — exactly the call `loom-daemon tokens select`
+    /// makes — prunes an over-age exhaustion entry off disk while leaving a
+    /// recent one alone. Before #4643 `cleanup_bad_tokens` had zero callers, so
+    /// pools accumulated expired entries indefinitely.
+    #[test]
+    fn wired_cleanup_prunes_over_age_exhaustion_entry() {
+        let tmp = make_pool();
+        let dir = pool_dir(tmp.path());
+        let ancient = (Utc::now() - chrono::Duration::seconds(DEFAULT_CLEANUP_MAX_AGE_SECS + 3600))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string();
+        let recent = (Utc::now() - chrono::Duration::seconds(600))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string();
+        fs::write(
+            dir.join(".bad_tokens"),
+            format!(
+                "{ancient} agent-old exhausted: hit your session limit\n\
+                 {recent} agent-new exhausted: hit your session limit\n"
+            ),
+        )
+        .unwrap();
+
+        let kept = cleanup_bad_tokens(tmp.path(), DEFAULT_CLEANUP_MAX_AGE_SECS).unwrap();
+        assert_eq!(kept, 1);
+        let text = fs::read_to_string(dir.join(".bad_tokens")).unwrap();
+        assert!(!text.contains("agent-old"), "over-age entry still on disk: {text}");
+        assert!(text.contains("agent-new"));
+        assert!(is_bad(tmp.path(), "agent-new"));
+    }
+
+    /// #4643: auth entries are held for [`AUTH_ENTRY_MIN_RETENTION_SECS`]
+    /// regardless of the requested max age — pruning one early would silently
+    /// readmit a broken credential, since `is_bad` treats auth as permanent.
+    #[test]
+    fn cleanup_holds_auth_entries_past_the_requested_max_age() {
+        let tmp = make_pool();
+        let dir = pool_dir(tmp.path());
+        // Older than the routine 24h policy, far younger than the 30d floor.
+        let old = (Utc::now() - chrono::Duration::seconds(3 * 24 * 3600))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string();
+        fs::write(
+            dir.join(".bad_tokens"),
+            format!(
+                "{old} agent-auth 401 unauthorized\n\
+                 {old} agent-exh exhausted: hit your session limit\n"
+            ),
+        )
+        .unwrap();
+
+        let outcome = cleanup_bad_tokens_in_dir(&dir, DEFAULT_CLEANUP_MAX_AGE_SECS).unwrap();
+        assert_eq!(outcome.removed, 1);
+        assert_eq!(outcome.kept, 1);
+        let text = fs::read_to_string(dir.join(".bad_tokens")).unwrap();
+        assert!(text.contains("agent-auth"), "auth entry was pruned early: {text}");
+        assert!(!text.contains("agent-exh"));
+        // Read-time semantics are unchanged: auth still blocks, and the
+        // pruned exhaustion entry had already stopped blocking.
+        assert!(is_bad(tmp.path(), "agent-auth"));
+        assert!(!is_bad(tmp.path(), "agent-exh"));
+    }
+
+    /// #4643: an auth entry past the 30d floor is finally reclaimed (garbage
+    /// collection of a credential retired a month ago), not held forever.
+    #[test]
+    fn cleanup_reclaims_auth_entries_past_the_retention_floor() {
+        let tmp = make_pool();
+        let dir = pool_dir(tmp.path());
+        let ancient = (Utc::now()
+            - chrono::Duration::seconds(AUTH_ENTRY_MIN_RETENTION_SECS + 24 * 3600))
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string();
+        fs::write(dir.join(".bad_tokens"), format!("{ancient} agent-auth 401 unauthorized\n"))
+            .unwrap();
+        let outcome = cleanup_bad_tokens_in_dir(&dir, DEFAULT_CLEANUP_MAX_AGE_SECS).unwrap();
+        assert_eq!(outcome.removed, 1);
+        assert_eq!(outcome.kept, 0);
+    }
+
+    /// #4643: nothing prunable ⇒ no rewrite at all (the `tokens select` hot
+    /// path must not serialize a spawn burst on the `.bad_tokens` lock).
+    #[test]
+    fn cleanup_does_not_rewrite_when_nothing_is_prunable() {
+        let tmp = make_pool();
+        let dir = pool_dir(tmp.path());
+        mark_bad(tmp.path(), "agent-1", "exhausted: hit your session limit").unwrap();
+        let before = fs::metadata(dir.join(".bad_tokens"))
+            .unwrap()
+            .modified()
+            .unwrap();
+        let outcome = cleanup_bad_tokens_in_dir(&dir, DEFAULT_CLEANUP_MAX_AGE_SECS).unwrap();
+        assert_eq!(outcome.removed, 0);
+        assert_eq!(outcome.kept, 1);
+        let after = fs::metadata(dir.join(".bad_tokens"))
+            .unwrap()
+            .modified()
+            .unwrap();
+        assert_eq!(before, after, "file was rewritten with nothing to prune");
+        // No lock directory was left behind either.
+        assert!(!dir.join(".bad_tokens.lock").exists());
     }
 
     #[test]

--- a/loom-daemon/src/tokens_pool/select.rs
+++ b/loom-daemon/src/tokens_pool/select.rs
@@ -25,7 +25,9 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use super::bad_tokens::is_bad;
+use super::bad_tokens::{
+    blocking_entry, exhaustion_cooldown_secs, is_bad, EXHAUSTION_COOLDOWN_ENV,
+};
 use super::paths::{resolve_tokens_dir, shared_tokens_dir};
 use super::rng::Rng;
 use super::rotation::next_rotation_index;
@@ -83,6 +85,66 @@ impl std::fmt::Display for EmptyTokenPoolError {
 }
 
 impl std::error::Error for EmptyTokenPoolError {}
+
+/// Identity of the binary that evaluated this selection — version, build
+/// commit, and build timestamp (#4643).
+///
+/// The 2026-07-30 incident (13h-old exhaustion entries appearing to block
+/// every spawn) could not be diagnosed from the sweep log because the failure
+/// text never said *which* binary decided. `spawn-claude.sh` resolves the
+/// daemon binary independently of any running daemon (`$LOOM_DAEMON_BIN` →
+/// PATH → build-output candidates), so a stale binary at the selection site is
+/// a real, recurring hypothesis — and now a directly checkable one: this string
+/// is stamped into the empty-pool error itself.
+#[must_use]
+pub fn deciding_binary_identity() -> String {
+    format!("loom-daemon {}", crate::self_update::BUILD_IDENTITY)
+}
+
+/// Render a whole-second duration compactly (`5h48m`, `48m12s`, `12s`) for
+/// the cooldown-remaining field of the empty-pool detail.
+fn format_secs(secs: i64) -> String {
+    let secs = secs.max(0);
+    let (h, m, s) = (secs / 3600, (secs % 3600) / 60, secs % 60);
+    if h > 0 {
+        format!("{h}h{m:02}m")
+    } else if m > 0 {
+        format!("{m}m{s:02}s")
+    } else {
+        format!("{s}s")
+    }
+}
+
+/// One line of per-token exclusion detail for the empty-pool error (#4643):
+/// account name, exclusion cause, reason class (auth = permanent vs
+/// exhaustion = TTL), the entry's own timestamp, and the cooldown remaining.
+///
+/// Computed in the error path by re-walking the pool rather than threading
+/// state through the three tier functions: reaching this point means every
+/// tier — including the fail-safe retry that drops the stale-`.ranking`
+/// advisory exclusions — came up empty, so the surviving causes are exactly
+/// "bad-marked", "empty", and "unreadable", all of which are re-derivable
+/// per token without disturbing the selection hot path.
+fn describe_exclusion(workspace: &Path, token_file: &Path) -> String {
+    let name = stem(token_file);
+    if let Some(entry) = blocking_entry(workspace, &name) {
+        let class = entry.class.label();
+        let permanence = entry.class.permanence();
+        let clears = match entry.cooldown_remaining_secs {
+            Some(remaining) => format!("clears in {}", format_secs(remaining)),
+            None => format!("needs `loom-daemon tokens unblock {name}`"),
+        };
+        return format!(
+            "{name}: bad-marked [{class}, {permanence}] at {} — \"{}\"; {clears}",
+            entry.timestamp, entry.reason
+        );
+    }
+    match read_token_file(token_file) {
+        Ok(key) if key.is_empty() => format!("{name}: empty .token file"),
+        Ok(_) => format!("{name}: no usable tier admitted it (not bad-marked, key non-empty)"),
+        Err(e) => format!("{name}: unreadable .token file ({e})"),
+    }
+}
 
 fn shared_pool_hint() -> String {
     match shared_tokens_dir() {
@@ -473,11 +535,24 @@ pub fn select_token(
         }
     }
 
+    // Per-token exclusion detail (#4643): say WHY each account was excluded and
+    // WHICH binary decided, so a recurrence is diagnosable from the sweep log
+    // alone instead of by reading this source file.
+    let detail: String = all_tokens
+        .iter()
+        .map(|f| format!("\n  - {}", describe_exclusion(workspace, f)))
+        .collect();
     Err(EmptyTokenPoolError(format!(
-        "All {} tokens in {} are marked bad or empty. Inspect .bad_tokens or run \
-         `loom-daemon tokens bootstrap --force`.",
+        "All {} tokens in {} are marked bad or empty.{detail}\n  \
+         deciding binary: {}\n  \
+         exhaustion cooldown: {}s (override {EXHAUSTION_COOLDOWN_ENV}); auth entries never \
+         expire — clear them with `loom-daemon tokens unblock <name>` \
+         (add --all-reasons to drop non-auth entries too).\n  \
+         Inspect .bad_tokens or run `loom-daemon tokens bootstrap --force`.",
         all_tokens.len(),
-        tokens_dir.display()
+        tokens_dir.display(),
+        deciding_binary_identity(),
+        exhaustion_cooldown_secs(),
     )))
 }
 
@@ -640,6 +715,92 @@ mod tests {
         let mut rng = Rng::seeded(1);
         let err = select_token(tmp.path(), Some(&mut rng)).unwrap_err();
         assert!(err.0.contains("marked bad"));
+    }
+
+    // ---- empty-pool error detail (issue #4643) ------------------------
+
+    #[test]
+    fn format_secs_renders_compact_durations() {
+        assert_eq!(format_secs(5 * 3600 + 48 * 60), "5h48m");
+        assert_eq!(format_secs(48 * 60 + 12), "48m12s");
+        assert_eq!(format_secs(12), "12s");
+        assert_eq!(format_secs(-5), "0s");
+    }
+
+    /// #4643: the empty-pool error names every excluded account, its exclusion
+    /// cause, the reason class (auth = permanent vs exhaustion = TTL), the
+    /// entry's own timestamp, the cooldown remaining, and the deciding binary.
+    #[test]
+    fn empty_pool_error_enumerates_per_token_exclusion_detail() {
+        let tmp = make_pool(&["exh", "auth"]);
+        let ts = (chrono::Utc::now() - chrono::Duration::seconds(3600))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string();
+        fs::write(
+            pool_dir(tmp.path()).join(".bad_tokens"),
+            format!(
+                "{ts} exh exhausted: hit your session limit\n\
+                 {ts} auth 401 unauthorized\n"
+            ),
+        )
+        .unwrap();
+
+        let mut rng = Rng::seeded(1);
+        let err = select_token(tmp.path(), Some(&mut rng)).unwrap_err();
+        let text = err.0;
+
+        // Per-token lines, with class + permanence + timestamp + reason.
+        assert!(text.contains("exh: bad-marked [exhaustion, TTL]"), "{text}");
+        assert!(text.contains("auth: bad-marked [auth, permanent]"), "{text}");
+        assert!(text.contains(&ts), "{text}");
+        assert!(text.contains("exhausted: hit your session limit"), "{text}");
+        assert!(text.contains("401 unauthorized"), "{text}");
+        // Cooldown remaining for the TTL entry (~5h of the 6h default left),
+        // and the operator action for the permanent one.
+        assert!(text.contains("clears in 4h") || text.contains("clears in 5h"), "{text}");
+        assert!(text.contains("needs `loom-daemon tokens unblock auth`"), "{text}");
+        // Deciding binary + the cooldown knob.
+        assert!(text.contains("deciding binary: loom-daemon "), "{text}");
+        assert!(text.contains(crate::self_update::BUILT_COMMIT), "{text}");
+        assert!(text.contains(EXHAUSTION_COOLDOWN_ENV), "{text}");
+    }
+
+    /// #4643: a token whose file is present but empty is reported as such,
+    /// not lumped in with the bad-marked ones.
+    #[test]
+    #[serial]
+    fn empty_pool_error_distinguishes_empty_token_files() {
+        let tmp = make_pool(&["blank"]);
+        fs::write(pool_dir(tmp.path()).join("blank.token"), "   \n").unwrap();
+        std::env::set_var(super::super::paths::SHARED_TOKENS_DIR_ENV, "");
+        let mut rng = Rng::seeded(1);
+        let err = select_token(tmp.path(), Some(&mut rng)).unwrap_err();
+        std::env::remove_var(super::super::paths::SHARED_TOKENS_DIR_ENV);
+        assert!(err.0.contains("blank: empty .token file"), "{}", err.0);
+    }
+
+    /// #4643: a malformed `.bad_tokens` timestamp shows up as fail-closed
+    /// permanent in the detail rather than as a TTL entry with a bogus clock.
+    #[test]
+    fn empty_pool_error_shows_malformed_entry_as_permanent() {
+        let tmp = make_pool(&["a"]);
+        fs::write(pool_dir(tmp.path()).join(".bad_tokens"), "garbage a exhausted\n").unwrap();
+        let mut rng = Rng::seeded(1);
+        let err = select_token(tmp.path(), Some(&mut rng)).unwrap_err();
+        assert!(
+            err.0
+                .contains("a: bad-marked [malformed-timestamp, permanent (fail-closed)]"),
+            "{}",
+            err.0
+        );
+    }
+
+    #[test]
+    fn deciding_binary_identity_names_version_and_commit() {
+        let id = deciding_binary_identity();
+        assert!(id.starts_with("loom-daemon "), "{id}");
+        assert!(id.contains(env!("CARGO_PKG_VERSION")), "{id}");
+        assert!(id.contains(crate::self_update::BUILT_COMMIT), "{id}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Selecting from an all-excluded token pool used to fail with one opaque line — `All N tokens in <dir> are marked bad or empty` — that said neither **why** each account was excluded nor **which binary** decided. This PR makes that failure self-explaining, wires the previously dead `cleanup_bad_tokens` into a routine path with a documented reason-aware max-age policy, logs the deciding binary's provenance on every spawn, and brings the docs into agreement with actual behavior.

Per the Curator's rescope, this does **not** re-implement the #4122 read-time cooldown, the #4212 `unblock` warning, or the `exhaustion_entry_expires_after_cooldown_auth_stays` regression test — all three already exist on main and were verified present before starting.

## Root cause of the 13h persistence — **stale-binary hypothesis REFUTED**

AC 1 asked for the leading hypothesis (a long-running daemon handing sweep children a pre-`b3dc860f` binary whose `is_bad` had no cooldown) to be confirmed or refuted. **Refuted**, on two independent lines of evidence:

**1. Every binary resolvable at the selection site on the incident host contains the cooldown.**

| Path | `--version` | Built |
|---|---|---|
| `~/.local/bin/loom-daemon` (PATH — what `loom_locate_daemon_bin` picks) | `0.16.0 (commit 105f9c12)` | 2026-07-30T05:23:19Z |
| `<repo>/target/release/loom-daemon` | `0.16.0 (commit 105f9c12)` | 2026-07-30T05:24:02Z |
| `<repo>/target/debug/loom-daemon` | `0.16.0 (commit cd685955)` | 2026-07-30T15:47:04Z |

`git merge-base --is-ancestor b3dc860f 105f9c12` → **true**. `b3dc860f` (#4122 / PR #4128, the cooldown) merged 2026-07-27; `105f9c12` is 2026-07-29. Every candidate binary present at 16:59Z on 2026-07-30 had the cooldown compiled in.

**2. The entries that were actually blocking were *minutes* old, not 13 hours.** The live `~/.loom/tokens/.bad_tokens` is append-only and, before this PR, **never pruned** — so its head still carried lines from 2026-07-29T19:45Z while its tail read:

```
2026-07-30T16:00:22Z rjwalters-gmail exhausted: hit your weekly limit
2026-07-30T16:58:32Z agent5-2amlogic exhausted: hit your weekly limit
2026-07-30T17:03:09Z agent2-2amlogic exhausted: hit your weekly limit
```

The dominant reason is **`hit your weekly limit`**, which does *not* reset within the 6h cooldown. So the loop is: line ages out → cooldown expires it → next spawn retries → the API returns the weekly limit again → a **fresh** line is appended. The account is continuously re-marked and correctly stays out of rotation. The cooldown worked exactly as designed; the pool was genuinely out of capacity.

**Conclusion: there was no expiry bug.** The "13h-old entries still blocking" reading was an artifact of an append-only file that nothing ever pruned (gap #2 in the issue) combined with a failure message that named no timestamps (gap #1). Both proximate causes of the *misdiagnosis* are what this PR fixes. Note that refuting the stale-binary hypothesis required inspecting the host's installed binaries by hand after the fact — nothing in the sweep log recorded which binary ran. That is precisely why the provenance logging below lands regardless.

Caveat on evidence completeness: the incident's exact `All 2 tokens` pool could not be located on this host (the shared pool holds 11 accounts today and no 2-token pool remains), and no `.loom/logs/*.log` retained the error text. The two findings above are drawn from the surviving `.bad_tokens` and binary inventory.

## Changes

- **`loom-daemon/src/tokens_pool/bad_tokens.rs`**
  - New `blocking_entry()` — the single scan that decides bad-ness — returns the *deciding* entry's timestamp, reason, `BadReasonClass` (`Auth` / `Exhaustion` / `MalformedTimestamp`) and cooldown remaining. `is_bad()` is now `blocking_entry().is_some()`, so the boolean the selector acts on and the detail the operator reads can never de-sync.
  - `cleanup_bad_tokens` gains a reason-aware max-age policy: `DEFAULT_CLEANUP_MAX_AGE_SECS` = 24h (4x the read-time cooldown) for exhaustion entries, `AUTH_ENTRY_MIN_RETENTION_SECS` = 30d floor for auth entries, malformed lines always retained. The auth floor is deliberate: auth entries are permanent at read time, so pruning one on a 24h schedule would silently readmit a broken credential — on-disk GC must never become a back-door expiry of the permanent class. New `cleanup_bad_tokens_in_dir` takes **no lock at all** when nothing is prunable, then re-reads and re-partitions under the lock before any rewrite.
- **`loom-daemon/src/tokens_pool/select.rs`** — `EmptyTokenPoolError` now enumerates one line per excluded account (name, cause, class + permanence, entry timestamp, reason text, and either the cooldown remaining or the exact `tokens unblock <name>` command), plus the deciding binary's version/commit/build-time and the active cooldown with its env override.
- **`loom-daemon/src/self_update.rs`** — hoist the `--version` string into `BUILD_IDENTITY` so library code stamps exactly what `--version` reports.
- **`loom-daemon/src/main.rs`** — clap's `version` now reads `BUILD_IDENTITY` (the two can't drift). `cleanup_bad_tokens` wired into **`tokens select`** (best-effort, silent, workspace-anchored) and **`tokens check`** (reports what it pruned, anchored to the pool the check itself resolved, which may be the shared machine-level one).
- **`defaults/scripts/spawn-claude.sh`** — logs the resolved daemon binary path and its `--version` at token-selection time.
- **`.loom/docs/token-pool.md`** — documents the **two independent clocks** (read-time blocking vs on-disk retention) as a table, the 6h cooldown + `LOOM_TOKEN_EXHAUSTION_COOLDOWN_SECS`, the auth-vs-exhaustion permanence contract, the worked example error output, and — from the root-cause finding above — why the oldest line in `.bad_tokens` is usually *not* the one blocking.

Example of the new failure output:

```
error: All 2 tokens in ~/.loom/tokens are marked bad or empty.
  - agent-1: bad-marked [exhaustion, TTL] at 2026-07-30T16:58:32Z — "exhausted: hit your weekly limit"; clears in 5h48m
  - agent-2: bad-marked [auth, permanent] at 2026-07-29T21:33:41Z — "401 unauthorized"; needs `loom-daemon tokens unblock agent-2`
  deciding binary: loom-daemon 0.16.0 (commit 105f9c12, built 2026-07-30T05:23:19Z)
  exhaustion cooldown: 21600s (override LOOM_TOKEN_EXHAUSTION_COOLDOWN_SECS); auth entries never expire …
```

## Acceptance Criteria Verification

- [x] **Root cause stated in the PR; #4122 cooldown not re-implemented.** Refuted with binary-ancestry and `.bad_tokens` evidence above. No change to the cooldown logic itself.
- [x] **`EmptyTokenPoolError` enumerates per-token exclusion detail + deciding binary version/commit.** `describe_exclusion()` + `deciding_binary_identity()` in `select.rs`; asserted by `empty_pool_error_enumerates_per_token_exclusion_detail`.
- [x] **`cleanup_bad_tokens` invoked on a routine path with a documented max-age policy.** Wired into `tokens select` and `tokens check`; policy documented in `token-pool.md` and in the constants' doc comments. Auth entries use a 30d floor rather than exemption, with the rationale documented.
- [x] **`spawn-claude.sh` logs the resolved daemon binary path and version at selection time.** Asserted at the spawn layer in `test-spawn-claude.sh`.
- [x] **`.loom/docs/token-pool.md` documents cooldown window, env override, auth-vs-exhaustion semantics.** New "Permanence: auth vs exhaustion" and "Empty-pool error detail" sections.
- [x] **Tests: per-token detail rendering; wired cleanup prunes an over-age exhaustion entry.** Added, **extending** (not replacing) `exhaustion_entry_expires_after_cooldown_auth_stays`, which now also asserts the new `blocking_entry` detail.

## Test Plan

- `cargo test -p loom-daemon --lib` — **2638 passed, 0 failed** (`tokens_pool` subset: 213 passed).
- `cargo clippy -p loom-daemon --all-targets` — clean, no warnings. `cargo fmt` applied.
- `bash defaults/scripts/tests/test-spawn-claude.sh` — 162/168 pass; all 6 new #4643 assertions pass. The 6 failures are **pre-existing and environmental** (#4233 nice/taskpolicy tests: `taskpolicy` is macOS-only and this Linux host is already re-niced) — verified by running the same suite on `main`, which fails the identical 6.
- New Rust tests: `blocking_entry_reports_exhaustion_class_and_cooldown_remaining`, `blocking_entry_reports_the_deciding_fresh_line_not_the_stale_one` (the incident shape), `blocking_entry_classifies_malformed_timestamp_as_permanent`, `blocking_entry_cooldown_remaining_honors_env_override`, `wired_cleanup_prunes_over_age_exhaustion_entry`, `cleanup_holds_auth_entries_past_the_requested_max_age`, `cleanup_reclaims_auth_entries_past_the_retention_floor`, `cleanup_does_not_rewrite_when_nothing_is_prunable`, `empty_pool_error_enumerates_per_token_exclusion_detail`, `empty_pool_error_distinguishes_empty_token_files`, `empty_pool_error_shows_malformed_entry_as_permanent`, `deciding_binary_identity_names_version_and_commit`, `format_secs_renders_compact_durations`.
- Edge cases covered per the Curator's test plan: malformed timestamp (fail-closed, shown as permanent) and `LOOM_TOKEN_EXHAUSTION_COOLDOWN_SECS` reflected in the reported remaining time.

Scope boundary respected: no daemon-side crash observability (#4644), no `.ranking` fresh-capacity work (#4645).

Closes #4643

🤖 Generated with [Claude Code](https://claude.com/claude-code)