### PR TITLE
fix(tokens): refuse ~/.loom/tokens default fallback under cfg(test)

### DIFF
--- a/loom-daemon/src/tokens.rs
+++ b/loom-daemon/src/tokens.rs
@@ -42,6 +42,15 @@ const SHARED_TOKENS_DIR_ENV: &str = "LOOM_SHARED_TOKENS_DIR";
 /// Kept in lock-step with the Python resolver (`loom_tools.tokens.paths.
 /// shared_tokens_dir`) so the daemon's concurrency accounting and the
 /// spawn-time selector agree on where the shared pool lives.
+///
+/// Under `cfg(test)` the "unset -> `~/.loom/tokens`" default is refused (see
+/// the twin resolver's doc comment at
+/// [`crate::tokens_pool::paths::shared_tokens_dir`] for the full rationale,
+/// issue #4657): this function reads the same process-global
+/// `LOOM_SHARED_TOKENS_DIR` env var that module's tests (and `ipc.rs`,
+/// `capacity.rs`, `tokens_pool/bad_tokens.rs`) mutate in the same
+/// multi-threaded test binary, so it is equally exposed to the transient
+/// unset window that leaked test fixtures into the real pool.
 #[must_use]
 fn shared_tokens_dir() -> Option<PathBuf> {
     match std::env::var(SHARED_TOKENS_DIR_ENV) {
@@ -53,6 +62,9 @@ fn shared_tokens_dir() -> Option<PathBuf> {
                 Some(PathBuf::from(trimmed))
             }
         }
+        #[cfg(test)]
+        Err(_) => None,
+        #[cfg(not(test))]
         Err(_) => dirs::home_dir().map(|h| h.join(".loom").join("tokens")),
     }
 }

--- a/loom-daemon/src/tokens_pool/paths.rs
+++ b/loom-daemon/src/tokens_pool/paths.rs
@@ -45,7 +45,26 @@ pub fn per_repo_tokens_dir(workspace: &Path) -> PathBuf {
 /// Resolution precedence (highest first):
 ///   1. `LOOM_SHARED_TOKENS_DIR` env var — non-empty names the dir (`~`
 ///      expanded); explicitly empty disables the shared fallback.
-///   2. Default: `~/.loom/tokens`.
+///   2. Default: `~/.loom/tokens` — **except under `cfg(test)`** (see below).
+///
+/// # Why the default is refused under `cfg(test)` (issue #4657)
+///
+/// `LOOM_SHARED_TOKENS_DIR` is a process-global env var, and every `#[test]`
+/// in this crate's `src/` links into one multi-threaded test binary. Several
+/// modules (`tokens.rs`, `ipc.rs`, `capacity.rs`, `tokens_pool/bad_tokens.rs`,
+/// this module) `set_var`/`remove_var` it — `#[serial]` only serializes
+/// serial-tagged tests against *each other*, so a transient window always
+/// exists where a concurrent, non-serial (or differently-keyed) test observes
+/// the var absent. In that window this function used to silently fall back to
+/// the *real* `~/.loom/tokens`, and a test workspace with no per-repo pool
+/// (e.g. `mark_bad`'s dir-missing test) would resolve straight to the
+/// operator's live machine-level pool and write test fixtures into it
+/// (confirmed: `agent-1`/`agent-10` fixture lines observed in a live
+/// `~/.loom/tokens/.bad_tokens`). Per-test `set_var("")` guards cannot close
+/// this class — the race is in *other* tests' windows, not this one's own
+/// call. Refusing the default under `cfg(test)` closes it structurally: tests
+/// that want to exercise the real fallback behavior must opt in explicitly via
+/// `LOOM_SHARED_TOKENS_DIR=<tmp path>`, same as they already do today.
 #[must_use]
 pub fn shared_tokens_dir() -> Option<PathBuf> {
     match std::env::var(SHARED_TOKENS_DIR_ENV) {
@@ -57,6 +76,9 @@ pub fn shared_tokens_dir() -> Option<PathBuf> {
                 Some(expand_tilde(trimmed))
             }
         }
+        #[cfg(test)]
+        Err(_) => None,
+        #[cfg(not(test))]
         Err(_) => dirs::home_dir().map(|h| h.join(".loom").join("tokens")),
     }
 }
@@ -250,6 +272,49 @@ mod tests {
         std::env::set_var(SHARED_TOKENS_DIR_ENV, "/tmp/loom-shared-xyz");
         assert_eq!(shared_tokens_dir(), Some(PathBuf::from("/tmp/loom-shared-xyz")));
         std::env::remove_var(SHARED_TOKENS_DIR_ENV);
+    }
+
+    /// Regression test for #4657: a populated, `HOME`-overridden fake
+    /// `~/.loom/tokens` (mimicking a real operator machine's live pool) must
+    /// be byte-identical before and after exercising `shared_tokens_dir()`
+    /// and `mark_bad()` with `LOOM_SHARED_TOKENS_DIR` unset — the exact
+    /// combination (unset env var + real-looking home pool) that used to
+    /// silently fall back to the default `~/.loom/tokens` and let test
+    /// fixtures leak into it.
+    #[test]
+    #[serial]
+    fn shared_tokens_dir_never_touches_a_populated_fake_home_under_test() {
+        let fake_home = tempfile::tempdir().unwrap();
+        let fake_shared_pool = fake_home.path().join(".loom").join("tokens");
+        write_pool(&fake_shared_pool, &["real-account.token"]);
+        let bad_tokens_file = fake_shared_pool.join(".bad_tokens");
+        fs::write(&bad_tokens_file, "2026-01-01T00:00:00Z real-account auth\n").unwrap();
+        let before = fs::read(&bad_tokens_file).unwrap();
+
+        let prev_home = std::env::var_os("HOME");
+        std::env::remove_var(SHARED_TOKENS_DIR_ENV);
+        std::env::set_var("HOME", fake_home.path());
+
+        // The env var is unset — under `cfg(test)` this must NOT fall back to
+        // `~/.loom/tokens` (fake or real), unlike production behavior.
+        assert_eq!(shared_tokens_dir(), None);
+
+        // A workspace with no per-repo pool must fail closed (dir missing)
+        // rather than silently resolving to the fake home's shared pool.
+        let workspace = tempfile::tempdir().unwrap();
+        let err = crate::tokens_pool::bad_tokens::mark_bad(workspace.path(), "agent-1", "x");
+        assert!(err.is_err(), "mark_bad must fail closed, not fall back to a live pool");
+
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+
+        let after = fs::read(&bad_tokens_file).unwrap();
+        assert_eq!(
+            before, after,
+            "the fake ~/.loom/tokens/.bad_tokens must be byte-identical before/after"
+        );
     }
 
     // =====================================================================


### PR DESCRIPTION
## Summary

Test-fixture entries from `loom-daemon/src/tokens_pool/bad_tokens.rs` unit tests were leaking into the live machine-level `~/.loom/tokens/.bad_tokens` pool. Root cause: the shared-tier fallback in `shared_tokens_dir()` (`tokens_pool/paths.rs`, plus a twin private resolver in `tokens.rs`) resolved to the real `~/.loom/tokens` whenever `LOOM_SHARED_TOKENS_DIR` was unset. That env var is process-global, and multiple test modules (`tokens.rs`, `ipc.rs`, `capacity.rs`, `tokens_pool/bad_tokens.rs`) mutate it via `set_var`/`remove_var` inside one multi-threaded test binary — `#[serial]` only serializes serial-tagged tests against each other, so a transient window always exists where a concurrently-running test observes the var absent and falls through to the real pool.

## Changes

- `loom-daemon/src/tokens_pool/paths.rs`: `shared_tokens_dir()` now refuses the `~/.loom/tokens` default under `cfg(test)` — it returns `None` when the env var is unset in a test binary. The explicit env override still works unchanged, so fallback-behavior tests opt in via `LOOM_SHARED_TOKENS_DIR=<tmp path>` exactly as they already do.
- `loom-daemon/src/tokens.rs`: applied the identical `cfg(test)` guard to the twin, capacity-sizing-only `shared_tokens_dir()` resolver that `token_pool_size` uses — it reads the same env var/default and was equally exposed to the race.
- Added a regression test (`tokens_pool::paths::tests::shared_tokens_dir_never_touches_a_populated_fake_home_under_test`) that populates a fake `~/.loom/tokens` (via a `HOME` env override) with a seeded `.token` file and a `.bad_tokens` entry, then asserts `shared_tokens_dir()` returns `None` and `mark_bad()` fails closed (rather than falling back to the fake pool) with the env var unset — and that the fake pool's `.bad_tokens` file is byte-identical before and after.

## Audit of `loom-daemon/tests/` (integration tests)

Checked `loom-daemon/tests/*.rs` for any caller reaching `mark_bad`, `shared_tokens_dir`, or `resolve_tokens_dir` — there are none today (`grep -rl "mark_bad\|shared_tokens_dir\|LOOM_SHARED_TOKENS_DIR\|resolve_tokens_dir" loom-daemon/tests/` is empty). No guard needed there; this PR's `cfg(test)` gate only applies where it's needed (the `src/` unit-test binary that actually exhibits the race) and doesn't touch the integration-test binaries.

Also confirmed `src/main.rs` (the `loom-daemon` binary crate) consumes `loom_daemon` as an external lib dependency (`use loom_daemon::...`), so its own `#[cfg(test)]` modules (which also mutate `LOOM_SHARED_TOKENS_DIR`, e.g. `resolve_tokens_workspace_tests`) compile into a **separate** test binary/process from the lib's tests — no shared-process race with the modules fixed here.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Structural fix (not more per-test `set_var` guards) in `shared_tokens_dir()` (`paths.rs`), refusing the `~/.loom/tokens` default under `cfg(test)`, env override still works | ✅ | See `paths.rs` diff; `shared_dir_honors_explicit_path` and other explicit-override tests still pass unchanged |
| Fix (or unify) the twin resolver in `tokens.rs` (`resolve_effective_tokens_dir`/capacity-sizing) | ✅ | Same `cfg(test)` guard applied to `tokens.rs::shared_tokens_dir()`; `cargo test -p loom-daemon --lib tokens::` passes (5/5) |
| Audit `loom-daemon/tests/` (integration tests) separately | ✅ | No `mark_bad`/`shared_tokens_dir`/`resolve_tokens_dir` callers found there (see audit section above) |
| Regression test: populated fake `~/.loom/tokens` (HOME override), byte-identical before/after | ✅ | New test in `tokens_pool/paths.rs`; passes as part of `cargo test -p loom-daemon tokens_pool` (201/201) |
| Operator cleanup guidance in PR body | ✅ | See below |

## Operator Cleanup Guidance (one-time, manual)

If your `~/.loom/tokens/.bad_tokens` file contains the following fixture lines, they are safe to delete — they are leaked test artifacts, not real account state:

```
2026-07-27T21:05:44Z agent-1 x
2026-07-27T21:05:44Z agent-1 line1 line2
2026-07-27T21:05:44Z agent-10 auth
2026-07-27T21:06:35Z agent-1 x
2026-07-29T06:02:06Z agent-1 x
```

Names `agent-1`/`agent-10` with reasons `x`, `line1 line2`, `auth` and timestamps `2026-07-27`/`2026-07-29` — these never correspond to real rotated accounts. Note the `auth`-reason entries never expire on their own (unlike `exhausted:` entries, which age out after the cooldown), so they will persist indefinitely until manually removed. Edit the file directly (`$EDITOR ~/.loom/tokens/.bad_tokens`) and delete the matching lines, or run `loom-daemon tokens unblock --name agent-1 --name agent-10` if your installed version supports scoped unblock (falls back to manual edit otherwise).

## Test Plan

- `cargo check -p loom-daemon` — clean
- `cargo clippy -p loom-daemon --all-targets -- -D warnings` — clean
- `cargo fmt -- --check` — clean
- `cargo test -p loom-daemon tokens_pool` — 201 passed, 0 failed (includes new regression test)
- `cargo test -p loom-daemon --lib tokens::` — 5 passed, 0 failed
- `cargo test -p loom-daemon --lib capacity::` — 36 passed, 0 failed
- `cargo test -p loom-daemon --lib ipc::tests` — 76 passed, 0 failed
- Did not touch the real `~/.loom/tokens` at any point during development or verification (all manual checks used tempdir/HOME overrides)

Closes #4657