### PR TITLE
docs: state that fleet rate-limit protections are loom-daemon-internal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,7 +268,9 @@ missing/exhausted pool exits `78` (`EX_CONFIG`). Full reference:
 ## Forge Authentication & Releasing
 
 - **GitHub** — Loom uses the `gh` CLI (the `gh auth login` credential; scope to
-  one repo with `export GH_TOKEN=…`). See [`.loom/docs/github-authentication.md`](.loom/docs/github-authentication.md).
+  one repo with `export GH_TOKEN=…`). Fleet rate-limit protections (breaker, ETag
+  cache, App tokens — epic #4432) are `loom-daemon`-internal; hand-rolled parallel
+  `claude-wrapper.sh` loops get none. See [`.loom/docs/github-authentication.md`](.loom/docs/github-authentication.md).
 - **Gitea** — set `GITEA_TOKEN` or `FORGE_TOKEN` (repository read/write). See
   [`.loom/docs/forge-authentication.md`](.loom/docs/forge-authentication.md).
 - **Releasing** — `scripts/version.sh` keeps all 5 version-bearing files in sync

--- a/defaults/docs/github-authentication.md
+++ b/defaults/docs/github-authentication.md
@@ -297,6 +297,80 @@ before starting the daemon — see "Headless and SSH-only daemon operation"
 above) for that workload, or expect to restart a sweep that 401s mid-run past
 the ~1h mark.
 
+## Fleet rate-limit protections are `loom-daemon`-internal (#4432)
+
+Epic #4432 ("survive GitHub API rate limits at fleet scale") shipped real
+mitigations for the shared-budget problem stated at the top of the GitHub App
+section — a rate-limit circuit breaker, ETag-cached hot polls, per-installation
+App tokens, and moving claim coordination off label polling. **Every one of them
+lives inside the `loom-daemon` process.** None is wired into the spawn scripts:
+
+```bash
+grep -n 'rate_limit_breaker\|forge_listing\|github-app' \
+  .loom/scripts/spawn-claude.sh .loom/scripts/claude-wrapper.sh
+# → no matches
+```
+
+So an operator running the older hand-rolled per-issue pattern — one
+`claude-wrapper.sh --dangerously-skip-permissions "/loom:sweep <N>"` shell per
+in-flight issue, **with no `loom-daemon` running at all** — gets *zero* benefit
+from any of it. That is not an oversight awaiting a wrapper flag: the breaker's
+state, the ETag cache, and the minted-token refresh tick are all in-process
+state of one long-lived daemon, with no cross-process protocol for independent
+shells to join.
+
+| Mechanism | Implementation | Daemon-dispatched sweeps | Hand-rolled `claude-wrapper.sh` loop |
+|---|---|---|---|
+| Rate-limit circuit breaker (#4429 → #4440) | `loom-daemon/src/rate_limit_breaker.rs` | Governs the **daemon's own** forge polls (work finder, claim/quarantine reconciliation, role runner, epic supervisor) — pauses them until the window resets | **None** |
+| ETag-cached REST listings (#4428 → #4443) | `loom-daemon/src/forge_listing.rs` | Same scope — the daemon's hot polls; an unchanged poll returns 304 and costs no quota | **None** |
+| GitHub App installation tokens (#4430 → #4454, #4578) | daemon credential preflight + daemon-owned `GH_CONFIG_DIR` | Reaches spawned children too: they inherit the daemon's `GH_CONFIG_DIR`, so their `gh` calls draw on the **per-installation** bucket instead of the operator's personal 5,000/hr | **None** — every session uses whatever ambient `gh auth` / `GH_TOKEN` the operator's shell carries, i.e. one shared personal budget |
+| Claim/peer coordination off label polling (#4431) | safehouse ([`safehouse.md`](safehouse.md)) | Removes a whole class of repeated label reads from the poll path | **None** |
+
+**Read the middle column precisely.** The breaker and the ETag cache bound the
+daemon's *own* polling loops; they do **not** govern the `gh` calls a spawned
+Claude session makes while it works an issue. What bounds those is admission
+control — `autonomous.workFinder.maxConcurrent` and the token / disk / CPU terms
+folded into the same `min(...)` ceiling (see
+[`daemon-reference.md`](daemon-reference.md)) — which caps how many sessions
+exist at once on a host. A hand-rolled loop has no equivalent: N shells started
+by hand are N unbounded `gh` consumers, and nothing coordinates them across the
+other projects sharing the same machine and the same `gh auth` login.
+
+### Recommendation: dispatch through the daemon
+
+If you run several repos/projects concurrently on one machine under one GitHub
+login, migrate off the hand-rolled pattern and dispatch via `loom-daemon`
+(`mcp__loom__dispatch_sweep`) — one daemon per workspace, one admission ceiling
+per host, and the table's middle column instead of its right-hand one. This is
+also the already-documented direction of travel: `spawn-loop.sh`, the shipped
+version of that pattern, was **removed in v0.11.0** in favor of
+`mcp__loom__dispatch_sweep` (see `CLAUDE.md` → Migration History). Parallel
+hand-started `claude-wrapper.sh` sweeps are not a supported scaling story; they
+are the configuration reported in #4665 — 15+ concurrent sweep/judge sessions
+for a single project, multiplied across every other project on the box, with
+`loom-daemon status` confirming no daemon was running.
+
+Before scaling out, confirm which regime you are in:
+
+```bash
+loom-daemon status   # "Forge credential: OK — github-app (app … installation …)"
+                     #   ⇒ daemon-managed, per-installation bucket
+                     # no daemon running ⇒ none of the above protections apply
+gh api rate_limit --jq '.resources.core, .resources.graphql'
+```
+
+### Known limitation, even under daemon dispatch
+
+There is **no per-sweep credential re-resolution** in the spawn path. A
+dispatched sweep child works from whatever forge-credential reference was
+ambient at spawn time. Where that reference is the daemon's own `GH_CONFIG_DIR`,
+rotation does reach it (`gh` re-reads `hosts.yml` on every invocation — #4578);
+where it is an inherited `GH_TOKEN`/`GITHUB_TOKEN` env value, env outranks `gh`
+config and the value is **frozen for the life of the sweep**, so a sweep that
+outlives a ~1h App-token lifetime starts 401ing with no automatic fallback. See
+"Long-running sweep children and credential snapshots (#4458)" above for the
+mechanics and the workaround (a long-lived PAT for consistently long workloads).
+
 ## Troubleshooting
 
 ### Token not being picked up

--- a/defaults/docs/github-authentication.md
+++ b/defaults/docs/github-authentication.md
@@ -332,9 +332,10 @@ Claude session makes while it works an issue. What bounds those is admission
 control — `autonomous.workFinder.maxConcurrent` and the token / disk terms
 folded into the same `min(...)` ceiling (the fourth cpu/load term was deleted in
 #4512 — see [`daemon-reference.md`](daemon-reference.md)) — which caps how many
-sessions exist at once on a host. A hand-rolled loop has no equivalent: N shells started
-by hand are N unbounded `gh` consumers, and nothing coordinates them across the
-other projects sharing the same machine and the same `gh auth` login.
+sessions exist at once on a host. A hand-rolled loop has no equivalent: N
+shells started by hand are N unbounded `gh` consumers, and nothing
+coordinates them across the other projects sharing the same machine and the
+same `gh auth` login.
 
 ### Recommendation: dispatch through the daemon
 

--- a/defaults/docs/github-authentication.md
+++ b/defaults/docs/github-authentication.md
@@ -329,10 +329,10 @@ shells to join.
 **Read the middle column precisely.** The breaker and the ETag cache bound the
 daemon's *own* polling loops; they do **not** govern the `gh` calls a spawned
 Claude session makes while it works an issue. What bounds those is admission
-control — `autonomous.workFinder.maxConcurrent` and the token / disk / CPU terms
-folded into the same `min(...)` ceiling (see
-[`daemon-reference.md`](daemon-reference.md)) — which caps how many sessions
-exist at once on a host. A hand-rolled loop has no equivalent: N shells started
+control — `autonomous.workFinder.maxConcurrent` and the token / disk terms
+folded into the same `min(...)` ceiling (the fourth cpu/load term was deleted in
+#4512 — see [`daemon-reference.md`](daemon-reference.md)) — which caps how many
+sessions exist at once on a host. A hand-rolled loop has no equivalent: N shells started
 by hand are N unbounded `gh` consumers, and nothing coordinates them across the
 other projects sharing the same machine and the same `gh auth` login.
 


### PR DESCRIPTION
Closes #4668

## What

Documentation-only. Adds a new section — **"Fleet rate-limit protections are `loom-daemon`-internal (#4432)"** — to `defaults/docs/github-authentication.md` (surfaced as `.loom/docs/github-authentication.md`, which is a symlink to it), plus a one-line pointer from `CLAUDE.md`'s forge-auth bullet.

## Verified before writing

- `grep -n 'rate_limit_breaker\|forge_listing\|github-app' defaults/scripts/spawn-claude.sh defaults/scripts/claude-wrapper.sh` → **zero matches** (the issue's core claim still holds on current `main`).
- Breaker / ETag-cache implementations are `loom-daemon/src/rate_limit_breaker.rs` and `loom-daemon/src/forge_listing.rs`; `GH_CONFIG_DIR` delivery is `loom-daemon/src/credential_preflight.rs` + `main.rs`. All daemon-process-internal.
- Issue numbers checked via `gh issue view`: #4432 (epic, closed), #4428/#4429/#4430/#4431 (closed; #4431 COMPLETED), #4440/#4443/#4454/#4578 (merged), #4665 (closed NOT_PLANNED).
- `.loom/docs/github-authentication.md` is a **symlink** to `defaults/docs/…`, so one edit covers both copies (no resync drift).

## Section contents

- Per-mechanism table: breaker (#4429→#4440), ETag listings (#4428→#4443), App tokens (#4430→#4454, #4578), safehouse claim coordination (#4431) — with a **daemon-dispatched** vs **hand-rolled `claude-wrapper.sh` loop** column each; the right column is "None" for all four.
- A precision note that avoids over-claiming: the breaker and ETag cache bound the *daemon's own* polling loops, **not** the `gh` calls a spawned Claude session makes — what bounds those is admission control (`autonomous.workFinder.maxConcurrent` and the token/disk/CPU `min(...)` terms), which a hand-rolled loop has no equivalent of.
- Recommendation to migrate to `mcp__loom__dispatch_sweep`, anchored to the already-shipped v0.11.0 removal of `spawn-loop.sh` and to the #4665 report.
- A "check which regime you are in" snippet (`loom-daemon status`, `gh api rate_limit`).
- Known limitation under daemon dispatch: no per-sweep credential re-resolution. Phrased to be consistent with the existing #4458 section — `GH_CONFIG_DIR`-delivered rotation *does* reach children (`gh` re-reads `hosts.yml` per invocation, #4578), whereas an inherited `GH_TOKEN`/`GITHUB_TOKEN` env value is frozen for the life of the sweep and 401s past the ~1h App-token lifetime.

## Scope decision

Stayed documentation-only per the issue's default. The "warn when no daemon is detected" code guard in `claude-wrapper.sh` was considered and **not** taken: the wrapper is also the legitimate entry point for manual/MOM single-agent sessions, so a no-daemon warning would fire on the common correct case.

## Test plan

- `scripts/check-claude-md-budget.sh` → OK, 317/320 lines.
- Manual read-through of the new section against the greps above.
- No automated tests (docs-only).