### PR TITLE
docs(skills): route sweep/judge/champion hot forge polls through gh-cached

### DIFF
--- a/defaults/.claude/commands/loom/champion-pr-merge.md
+++ b/defaults/.claude/commands/loom/champion-pr-merge.md
@@ -12,6 +12,66 @@ The Champion acts as the final step in the PR pipeline, merging PRs that have pa
 
 ---
 
+## Cached forge reads (`gh-cached`, #4667)
+
+Champion runs on a 10-minute cron alongside concurrent Judges and sweeps, all
+sharing **one** personal `gh` rate-limit budget (#4665). Its repeated
+*observation* reads — idempotency-marker comment greps, backlog scans,
+duplicate searches — go through the short-TTL cache wrapper. Its
+*merge-gating* reads do not: this skill performs the single most irreversible
+action in the pipeline, so every read a merge decision rests on must observe
+current state unconditionally.
+
+Resolve the wrapper **once**, at the start of the pass:
+
+```bash
+# Degrades to plain `gh` when absent or when its Python runtime is broken —
+# the same probe merge-pr.sh uses. Nothing here depends on the cache existing.
+GH_READ="gh"
+_ghc="$(git rev-parse --show-toplevel 2>/dev/null)/.loom/scripts/gh-cached"
+if [[ -x "$_ghc" ]] && "$_ghc" --version >/dev/null 2>&1; then GH_READ="$_ghc"; fi
+```
+
+**Route through `$GH_READ` (cached, 30s TTL):**
+
+- Idempotency-marker comment greps (`--json comments` reads for the
+  verdict-janitor, hold, stale-PR, park, close, and prior-grant markers).
+  These only answer "did I already post this?"; the cache is invalidated by
+  your own `--clear-cache` after you post (see below).
+- The `loom:blocked` unblock scan (`gh issue list --label "loom:blocked"`) and
+  its per-issue body/state reads.
+- The follow-on-issue duplicate search (`gh issue list --search …`).
+- The parked-PR listing (`gh pr list --label …`).
+
+**Keep on plain `gh` (deliberately uncached — do NOT wrap these):**
+
+| Call site | Why it must be live |
+|---|---|
+| Verdict-State Janitor's label read | Decides whether the PR is eligible to merge at all |
+| All 6 safety criteria (labels, `mergeable`, `updatedAt`, `gh pr checks`) | **Merge gating** — the last reads before an irreversible merge; a cached green can predate the push that broke the build |
+| Criterion #3's paginated changed-file list (`gh api …/files --paginate`) | #4613 requires this loop to run fresh against the full list in *this* pass — a cached answer is exactly the "asserted from a stale read" failure that incident was |
+| Step 2's pre-merge comment data gathering | Every bullet is a claim about a criterion's result in this pass; restating from a cached read reintroduces #4613 |
+
+`gh pr checks` is passthrough inside the wrapper regardless, so that carve-out
+holds even if wrapped by accident; the rest rely on this list.
+
+**Writes stay literal `gh`.** Never wrap `gh pr comment` / `gh pr edit` /
+`gh issue edit` in `"$GH_READ"` — the destructive-command guard hooks
+pattern-match the literal command text and a wrapped form slips past them.
+After a mutation you made in this pass (a marker comment, a label change, a
+merge), drop the cache instead so a later marker grep cannot return pre-write
+state:
+
+```bash
+gh pr comment "$PR_NUMBER" --body "…"
+"$GH_READ" --clear-cache   # local /tmp sweep — zero API cost
+```
+
+Full policy, TTL/invalidation semantics, and manual verification steps:
+`.loom/docs/gh-cached.md` (source: `defaults/docs/gh-cached.md`).
+
+---
+
 ## Verdict-State Janitor (run FIRST, before the 6 safety criteria)
 
 **Every `loom:pr` PR must pass this janitor step before any of the 6 safety
@@ -32,6 +92,8 @@ before Step 1 of the 6 criteria below):
 
 ```bash
 PR_NUMBER=<number>
+# Plain `gh` — NOT "$GH_READ": this label read decides whether the PR is
+# eligible to merge, so it must be live (see "Cached forge reads").
 LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | join(",")')
 
 if echo "$LABELS" | grep -qw "loom:changes-requested"; then
@@ -39,7 +101,9 @@ if echo "$LABELS" | grep -qw "loom:changes-requested"; then
   # Idempotency guard — mirrors the stale-PR notice pattern below: only
   # comment + relabel once per contradictory episode, so a 10-minute cron
   # tick doesn't re-post while the contradiction is being resolved.
-  if gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -qF "$JANITOR_MARKER"; then
+  # Cached ("$GH_READ") — a marker grep only answers "did I already post
+  # this?", and your own `--clear-cache` after posting keeps it honest.
+  if "$GH_READ" pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -qF "$JANITOR_MARKER"; then
     echo "Verdict-janitor notice already posted for #$PR_NUMBER — skipping (still not eligible to merge)"
   else
     gh pr comment "$PR_NUMBER" --body "$JANITOR_MARKER
@@ -52,6 +116,7 @@ Resolving fail-safe: \`loom:changes-requested\` wins. Removing \`loom:pr\` so th
 ---
 *Automated by Champion role*"
     gh pr edit "$PR_NUMBER" --remove-label "loom:pr"
+    "$GH_READ" --clear-cache   # your own write must not be masked by your own cache
     echo "Resolved contradictory verdict state on #$PR_NUMBER (loom:pr removed) — skipping merge"
   fi
   # Skip this PR entirely for this pass — do not proceed to the 6 safety
@@ -76,7 +141,9 @@ For each `loom:pr` PR, verify ALL 6 safety criteria. If ANY criterion fails, do 
 
 **Verification command**:
 ```bash
-# Get all labels for the PR
+# Get all labels for the PR. Plain `gh` — NOT "$GH_READ": all 6 safety
+# criteria are merge-gating and must observe current state (see "Cached
+# forge reads").
 LABELS=$(gh pr view <number> --json labels --jq '.labels[].name' | tr '\n' ' ')
 
 # Check for loom:pr label
@@ -115,6 +182,8 @@ PR_NUMBER=<number>
 # REST endpoint, not `gh pr view --json files` — that field silently
 # truncates at 100 files with no error (see criterion #3 below and #4613),
 # which on a 100+ file PR would hide files from this risk read too.
+# Plain `gh` — NOT "$GH_READ": #4613 requires this list to be fetched fresh in
+# THIS pass, never answered from a cache (see "Cached forge reads").
 gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/files" --paginate --jq '.[] | "\(.additions)+/\(.deletions)- \(.filename)"'
 
 # The actual diff (read it — the load-bearing hunks are what you are judging)
@@ -152,7 +221,8 @@ HOLD_MARKER="<!-- champion:merge-risk-hold -->"
 # silently re-evaluated each tick and merges as soon as the concern is resolved
 # (a follow-up push that narrows the blast radius, a deeper Judge re-review, or
 # `loom:auto-merge-ok` applied by a human).
-if gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -qF "$HOLD_MARKER"; then
+# Cached ("$GH_READ") — idempotency-marker grep; see "Cached forge reads".
+if "$GH_READ" pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -qF "$HOLD_MARKER"; then
   echo "Merge-risk hold already posted for #$PR_NUMBER — re-evaluating silently"
 else
   gh pr comment "$PR_NUMBER" --body "$HOLD_MARKER
@@ -214,6 +284,11 @@ fi
 # `.github/workflows/gitea-integration.yml` was skipped in one Champion
 # instance's evaluation over a 117-file PR. `--paginate` walks every page of
 # the REST response regardless of file count.
+#
+# Plain `gh` — NOT "$GH_READ". #4613's lesson is that this criterion must be
+# asserted from a list fetched in THIS pass; a cached answer is the same class
+# of failure as restating the result from a prior pass (see "Cached forge
+# reads").
 FILES=$(gh api "repos/{owner}/{repo}/pulls/<number>/files" --paginate --jq '.[].filename')
 
 # Define critical patterns (extend as needed)
@@ -258,7 +333,8 @@ This criterion is deliberately kept **in addition to** the merge-risk judgment i
 
 **Verification command**:
 ```bash
-# Check merge status
+# Check merge status. Plain `gh` — NOT "$GH_READ": merge-gating (see
+# "Cached forge reads").
 MERGEABLE=$(gh pr view <number> --json mergeable --jq '.mergeable')
 
 # Verify mergeable state
@@ -282,7 +358,7 @@ echo "PASS: No merge conflicts"
 
 **Verification command**:
 ```bash
-# Get PR last update time
+# Get PR last update time. Plain `gh` — NOT "$GH_READ": merge-gating.
 UPDATED_AT=$(gh pr view <number> --json updatedAt --jq '.updatedAt')
 
 # Convert to Unix timestamp
@@ -322,6 +398,9 @@ echo "PASS: Recently updated ($HOURS_AGO hours ago)"
 # Capture stdout ONLY: when a PR has no checks, gh prints "no checks reported..."
 # to STDERR and exits non-zero with EMPTY stdout, so an empty result is the
 # robust no-checks signal (do not grep error text).
+# Plain `gh` — NOT "$GH_READ": CI status is the read the merge is gated on,
+# and a cached green can predate the push that broke the build. (`gh pr checks`
+# is passthrough inside the wrapper anyway; this is belt-and-suspenders.)
 CHECKS=$(gh pr checks <number> --json bucket,name 2>/dev/null)
 
 # Handle case where no checks exist (empty stdout, or an empty JSON array)
@@ -387,7 +466,10 @@ list.
 ```bash
 PR_NUMBER=$1
 
-# Gather verification data
+# Gather verification data. Plain `gh` throughout this block — NOT "$GH_READ":
+# every bullet in the comment below is a claim about a criterion's result in
+# THIS pass, and answering from cache is the same failure as restating it from
+# memory (#4613; see "Cached forge reads").
 PR_DATA=$(gh pr view "$PR_NUMBER" --json additions,deletions,updatedAt)
 ADDITIONS=$(echo "$PR_DATA" | jq -r '.additions')
 DELETIONS=$(echo "$PR_DATA" | jq -r '.deletions')
@@ -478,7 +560,9 @@ if [ -z "$LINKED_ISSUES" ]; then
   exit 0
 fi
 
-# Check each linked issue
+# Check each linked issue. Plain `gh` — NOT "$GH_READ": this runs immediately
+# after your own merge and gates a write (`gh issue close`), so it must observe
+# post-merge state (see "Cached forge reads").
 for issue in $LINKED_ISSUES; do
   ISSUE_STATE=$(gh issue view "$issue" --json state --jq '.state' 2>&1)
 
@@ -504,7 +588,8 @@ echo "Checking for issues blocked by #$CLOSED_ISSUE..."
 # Find issues with loom:blocked that reference the closed issue.
 # Tolerant of markdown emphasis/colon between the phrase and #N (e.g.
 # "**Blocked by:** #1 (reason)") — #4508.
-BLOCKED_ISSUES=$(gh issue list --label "loom:blocked" --state open --limit 500 --json number,body \
+# Cached ("$GH_READ") — a backlog scan, not a merge gate.
+BLOCKED_ISSUES=$("$GH_READ" issue list --label "loom:blocked" --state open --limit 500 --json number,body \
   --jq ".[] | select(.body | test(\"(Blocked by|Depends on|Requires)[*_:[:space:]]*#$CLOSED_ISSUE\"; \"i\")) | .number")
 
 if [ -z "$BLOCKED_ISSUES" ]; then
@@ -516,7 +601,7 @@ for blocked in $BLOCKED_ISSUES; do
   echo "Checking if #$blocked can be unblocked..."
 
   # Get the issue body to check ALL dependencies
-  BLOCKED_BODY=$(gh issue view "$blocked" --json body --jq '.body')
+  BLOCKED_BODY=$("$GH_READ" issue view "$blocked" --json body --jq '.body')
 
   # Extract all referenced dependencies. Two-stage (#4508): stage 1 selects
   # lines declaring a dependency phrase, tolerant of markdown emphasis/colon
@@ -528,6 +613,8 @@ for blocked in $BLOCKED_ISSUES; do
 
   # Check if ALL dependencies are now closed
   ALL_RESOLVED=true
+  # Plain `gh` — NOT "$GH_READ": a stale CLOSED here removes `loom:blocked`
+  # from a still-blocked issue, the highest-severity failure mode in this block.
   for dep in $ALL_DEPS; do
     DEP_STATE=$(gh issue view "$dep" --json state --jq '.state' 2>/dev/null)
     if [ "$DEP_STATE" != "CLOSED" ]; then
@@ -688,7 +775,8 @@ fi
 # ============================================
 
 # Search for existing follow-on issues from this PR
-EXISTING_ISSUE=$(gh issue list --state open --search "Follow-on from PR #$PR_NUMBER" --limit 500 --json number --jq '.[0].number // empty')
+# Cached ("$GH_READ") — duplicate search, not a merge gate.
+EXISTING_ISSUE=$("$GH_READ" issue list --state open --search "Follow-on from PR #$PR_NUMBER" --limit 500 --json number --jq '.[0].number // empty')
 
 if [ -n "$EXISTING_ISSUE" ]; then
   echo "Follow-on issue already exists: #$EXISTING_ISSUE - skipping creation"
@@ -888,7 +976,8 @@ STALE_MARKER="<!-- champion:stale-pr-notice -->"
 
 # Idempotency guard: only comment + relabel once. If a prior tick already
 # posted the stale notice, do nothing (prevents per-tick comment spam).
-if gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -qF "$STALE_MARKER"; then
+# Cached ("$GH_READ") — idempotency-marker grep.
+if "$GH_READ" pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -qF "$STALE_MARKER"; then
   echo "Stale-PR notice already posted for #$PR_NUMBER — skipping"
 else
   gh pr comment "$PR_NUMBER" --body "$STALE_MARKER
@@ -921,7 +1010,9 @@ This pass **never merges anything and never closes anything**. For each parked P
 `gh pr list` ANDs repeated `--label` values, so this returns exactly the parked set:
 
 ```bash
-gh pr list \
+# Cached ("$GH_READ") — queue discovery; each parked PR is re-read live
+# before any action is taken on it.
+"$GH_READ" pr list \
   --label "loom:blocked" \
   --label "loom:changes-requested" \
   --state open \
@@ -952,7 +1043,7 @@ Read the **whole** thread — that complete post-mortem view is the entire reaso
 
 ```bash
 # How many extra cycles this pass has already granted (0 for a first-time decision).
-PRIOR_GRANTS=$(gh pr view "$PR_NUMBER" --json comments \
+PRIOR_GRANTS=$("$GH_READ" pr view "$PR_NUMBER" --json comments \
   --jq '[.comments[] | select(.body | contains("champion:capped-pr-grant"))] | length')
 ```
 
@@ -1030,7 +1121,8 @@ LATEST_REJECTION_ID=$(gh pr view "$PR_NUMBER" --json comments \
         | last | .id // "none"')
 PARK_MARKER="<!-- champion:capped-pr-parked:$LATEST_REJECTION_ID -->"
 
-if gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -qF "$PARK_MARKER"; then
+# Cached ("$GH_READ") — idempotency-marker grep.
+if "$GH_READ" pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -qF "$PARK_MARKER"; then
   echo "Keep-parked verdict already posted for #$PR_NUMBER on this rejection — skipping"
 else
   gh pr comment "$PR_NUMBER" --body "$PARK_MARKER
@@ -1058,7 +1150,8 @@ Use this when the history shows the **approach itself** is not viable — repeat
 PR_NUMBER=<number>
 CLOSE_MARKER="<!-- champion:capped-pr-close-recommended -->"
 
-if gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -qF "$CLOSE_MARKER"; then
+# Cached ("$GH_READ") — idempotency-marker grep.
+if "$GH_READ" pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -qF "$CLOSE_MARKER"; then
   echo "Close recommendation already posted for #$PR_NUMBER — skipping"
 else
   gh pr comment "$PR_NUMBER" --body "$CLOSE_MARKER

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -172,8 +172,15 @@ If no argument is provided, use the normal finding work workflow below.
 
 **Find PRs ready for evaluation (green badges):**
 ```bash
-gh pr list --label="loom:review-requested" --state=open --limit 500
+"$GH_READ" pr list --label="loom:review-requested" --state=open --limit 500
 ```
+
+`$GH_READ` is the short-TTL cached-read wrapper resolved in "Cached Forge Reads
+(`gh-cached`)" under Evaluation Process — it degrades to plain `gh` when the
+wrapper is absent. Queue discovery is the hottest repeated read in this
+document (every cron tick, every concurrent Judge, the fallback queue), so it
+is cached; verdict-gating and claim-arbitration reads are **not** (see that
+section for the full carve-out list).
 
 **Before either command below, run the Verdict-Time CAS Recheck** (see "Verdict-Time CAS Recheck" under Evaluation Process) — abort instead of writing if the recheck finds your claim lost or another Judge's verdict already landed.
 
@@ -270,7 +277,9 @@ MCP server failures can silently corrupt the tool execution environment, causing
 Run this as **step 0** before any `gh pr list` commands:
 
 ```bash
-# Verify gh is functional — detects MCP server failure / corrupted environment
+# Verify gh is functional — detects MCP server failure / corrupted environment.
+# ALWAYS plain `gh`, never the cached wrapper: this is a liveness probe, and a
+# cached success from a healthy session would defeat it entirely.
 REPO_NAME=$(gh repo view --json name --jq '.name' 2>/dev/null)
 if [ -z "$REPO_NAME" ]; then
     echo "CRITICAL: gh commands appear non-functional (empty output from gh repo view)"
@@ -292,12 +301,67 @@ fi
 - Status bar shows `N MCP server failed · /mcp`
 - Multiple sequential `gh` commands all return empty
 
+### Cached Forge Reads (`gh-cached`)
+
+Concurrent Judges, sweep-dispatched Judges, and the 5-minute cron tick all
+share **one** personal `gh` rate-limit budget (#4665), and they re-poll the
+same queue listing over and over. Route those repeated reads through the
+short-TTL cache wrapper; leave every correctness-critical read on plain `gh`.
+
+Resolve the wrapper **once**, at the start of the session (immediately after
+the environment check above):
+
+```bash
+# Falls back to plain `gh` when the wrapper is absent or its Python runtime is
+# broken — the same probe merge-pr.sh uses. Nothing below depends on the cache
+# existing; it is a budget optimization, never a correctness mechanism.
+GH_READ="gh"
+_ghc="$(git rev-parse --show-toplevel 2>/dev/null)/.loom/scripts/gh-cached"
+if [[ -x "$_ghc" ]] && "$_ghc" --version >/dev/null 2>&1; then GH_READ="$_ghc"; fi
+```
+
+**Route through `$GH_READ` (cached, 30s TTL):**
+
+- `gh pr list --label="loom:review-requested" …` — the primary queue, at every
+  occurrence in this document (Label Workflow, Primary Queue step 1, the
+  fallback-queue example, Example Commands).
+- The fallback queue's unlabeled-PR listing (`gh pr list --state=open …`).
+- `gh issue list --search …` when repairing a PR description.
+
+**Writes stay literal `gh` — then clear the cache.** Never wrap
+`gh pr comment` / `gh pr edit` in `"$GH_READ"`: the destructive-command guard
+hooks pattern-match the *literal* command text (e.g. the hard deny on
+`gh pr comment --body @path`, added after that shape destroyed an entire Judge
+review on PR #4457), and a wrapped form slips past them. Instead, drop the cache right after your own mutation so your
+next cached read cannot return your own pre-write state:
+
+```bash
+gh pr comment "$N" --body "…" && gh pr edit "$N" --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:pr"
+"$GH_READ" --clear-cache   # local /tmp sweep — zero API cost
+```
+
+**Keep on plain `gh` (deliberately uncached — do NOT wrap these):**
+
+| Read | Why it must be live |
+|---|---|
+| Pre-Iteration Environment Check (`gh repo view`) | Liveness probe — a cached success hides a broken environment |
+| Stale `loom:reviewing` Claim Check (claim timeline + comment counts) | Claim arbitration — 30s of staleness is exactly the window a competing claim lands in |
+| **Verdict-Time CAS Recheck** (`gh pr view $N --json labels`) | The entire mechanism is "observe writes that landed *during* my review"; a cached label set defeats it |
+| `gh pr checks` + `gh pr view --json mergeStateStatus` before a verdict | Verdict gating — never approve on a stale green |
+
+`gh pr checks` and `gh repo view` are passthrough inside the wrapper anyway, so
+those two hold even if wrapped by accident; the rest rely on this list.
+
+Full policy, TTL/invalidation semantics, and the manual verification steps:
+`.loom/docs/gh-cached.md` (source: `defaults/docs/gh-cached.md`).
+
 ### Primary Queue (Priority)
 
-1. **Find work**: `gh pr list --label="loom:review-requested" --state=open --limit 500`
+1. **Find work**: `"$GH_READ" pr list --label="loom:review-requested" --state=open --limit 500` (cached — see "Cached Forge Reads")
 2. **Claim PR** (staleness-aware — see "Stale `loom:reviewing` Claim Check" immediately below before running this): `gh pr edit <number> --add-label "loom:reviewing"` to signal you're working on it
 3. **Check merge state**: Check for conflicts and attempt automated rebase if DIRTY (see Automated Rebase for DIRTY PRs below)
    ```bash
+   # Plain `gh` — merge state is verdict-gating and must be live (see "Cached Forge Reads")
    MERGE_STATE=$(gh pr view <number> --json mergeStateStatus --jq '.mergeStateStatus')
    if [ "$MERGE_STATE" = "DIRTY" ]; then
        # Attempt automated rebase (see detailed workflow in Rebase Check section)
@@ -341,6 +405,10 @@ stand-down comments:
 
 ```bash
 N=<pr-number>
+# All reads in this block are plain `gh` — NEVER "$GH_READ". This is claim
+# arbitration: a 30s-stale timeline or comment list is exactly the window in
+# which a competing Judge's claim (or its stand-down) lands, and answering from
+# cache would reintroduce the double-claim this check exists to prevent.
 # `--paginate` re-invokes `--jq` once per response page and concatenates the
 # per-page results rather than applying the filter across the combined
 # timeline (#4637) — a timeline spanning more than one page (>100 events)
@@ -464,6 +532,10 @@ approval, the minor-PR-description-fix approval, and the trivial-fix approval
 
 ```bash
 N=<pr-number>
+# MUST be plain `gh` — NEVER "$GH_READ", and never a value carried over from an
+# earlier read in this session. This recheck exists to observe label writes that
+# landed WHILE you were reviewing; answering it from a 30s-old cache entry (or
+# from memory) reinstates exactly the race it closes. See "Cached Forge Reads".
 CURRENT_LABELS=$(gh pr view $N --json labels --jq '[.labels[].name] | join(",")')
 ```
 
@@ -510,8 +582,8 @@ If no PRs have the `loom:review-requested` label, the Judge can proactively eval
 
 **Fallback search**:
 ```bash
-# Find PRs without any loom: labels
-gh pr list --state=open --limit 500 --json number,title,labels \
+# Find PRs without any loom: labels (cached — see "Cached Forge Reads")
+"$GH_READ" pr list --state=open --limit 500 --json number,title,labels \
   --jq '.[] | select(([.labels[].name | select(startswith("loom:"))] | length) == 0) | "#\(.number) \(.title)"'
 ```
 
@@ -551,8 +623,8 @@ Pre-Iteration Environment Check (gh repo view)
 
 **Example fallback workflow**:
 ```bash
-# 1. Check primary queue
-LABELED_PRS=$(gh pr list --label="loom:review-requested" --limit 500 --json number --jq 'length' 2>/dev/null)
+# 1. Check primary queue (cached — see "Cached Forge Reads")
+LABELED_PRS=$("$GH_READ" pr list --label="loom:review-requested" --limit 500 --json number --jq 'length' 2>/dev/null)
 
 # Guard: an empty string (not "0") means the gh command itself failed. Re-run the
 # Pre-Iteration Environment Check above; if it fails, exit 1 (never claim "no work").
@@ -569,8 +641,8 @@ if [ "$LABELED_PRS" -gt 0 ]; then
 else
   echo "No loom:review-requested PRs found, checking unlabeled PRs..."
 
-  # 2. Check fallback queue
-  UNLABELED_PR=$(gh pr list --state=open --limit 500 --json number,labels \
+  # 2. Check fallback queue (cached — see "Cached Forge Reads")
+  UNLABELED_PR=$("$GH_READ" pr list --state=open --limit 500 --json number,labels \
     --jq '.[] | select(([.labels[].name | select(startswith("loom:"))] | length) == 0) | .number' \
     | head -n 1)
 
@@ -899,6 +971,13 @@ FEEDBACK
 **CRITICAL: Never approve a PR until all CI checks pass.**
 
 Local tests passing is not sufficient - you MUST verify that GitHub Actions CI workflows have completed successfully. This prevents situations where a PR is approved while CI is still running or failing.
+
+**Every command in this section runs as plain `gh` — never `"$GH_READ"`.** CI
+status and merge state are the reads a verdict is gated on, so they must
+observe current state unconditionally; a cached green from 30 seconds ago can
+predate the push that broke the build. (`gh pr checks` is passthrough inside
+the wrapper regardless, so this is belt-and-suspenders for it and load-bearing
+for the `mergeStateStatus` reads.) See "Cached Forge Reads" for the full policy.
 
 ### How to Check CI Status
 
@@ -1238,8 +1317,8 @@ For minor documentation issues in PR descriptions (not code), Judges are empower
 **Step 1: Check if there's a related issue (and that this isn't an intentional partial increment)**
 
 ```bash
-# Search for issues related to the PR
-gh issue list --search "keyword from PR title" --limit 500
+# Search for issues related to the PR (cached — see "Cached Forge Reads")
+"$GH_READ" issue list --search "keyword from PR title" --limit 500
 
 # View the PR to confirm issue number
 gh pr view <number>
@@ -1596,8 +1675,8 @@ EOF
 ## Example Commands
 
 ```bash
-# Find PRs ready for evaluation (green badges)
-gh pr list --label="loom:review-requested" --state=open --limit 500
+# Find PRs ready for evaluation (green badges) — cached; see "Cached Forge Reads"
+"$GH_READ" pr list --label="loom:review-requested" --state=open --limit 500
 
 # Check out the PR (worktree-aware — see "PR Branch Isolation" above; this is
 # a simplified illustration, not a bare checkout in the current directory)

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -33,6 +33,8 @@ If **every** whitespace-separated non-flag token matches the regex `^#?\d+$` (a 
 
 Otherwise, treat `$ARGUMENTS` as an English description of which open issues to process. The orchestrator (Claude, this session) translates the description into one or more `gh issue list` invocations using the appropriate flags, surfaces the derived candidate set, awaits user confirmation, then proceeds with the rest of the lifecycle exactly as in Mode A.
 
+**Issue candidate-resolution and PR candidate-resolution queries below run as `"$GH_READ" issue list …` / `"$GH_READ" pr list …`** — the short-TTL cached-read wrapper resolved once at sweep start (see "Cached forge reads (`gh-cached`)" under the Execution Model; it degrades to plain `gh` when absent). The translation guides are written with the bare `gh issue list` / `gh pr list` flag names because the flags are identical either way; only the leading binary changes.
+
 **This is deliberately not a formal grammar.** There is no parser, no operator precedence, no fixed vocabulary. The orchestrator reads the description and picks reasonable `gh issue list` flags. The interpretation rules below are prose, not a spec.
 
 **Translation guide — common NL fragments to `gh issue list` flags** (verified against `gh` v2):
@@ -54,10 +56,10 @@ Combine flags as needed. Always pass `--state open` explicitly (default) unless 
 **Unknown-label guard.** Loom never invents labels (CLAUDE.md "Never create new GitHub labels" — that rule is about label *creation* via `gh label create`, which is separate from validating that a label the user already named actually exists on the repo). To validate label tokens in the user's description, query the **live repo label set** as the source of truth:
 
 ```bash
-gh label list -R <repo> --limit 200 --json name --jq '.[].name'
+"$GH_READ" label list -R <repo> --limit 200 --json name --jq '.[].name'
 ```
 
-Run this query **once at the start of Mode B label-token validation** and reuse the result for every subsequent token check within the same `/loom:sweep` invocation (at most one `gh label list` call per invocation, regardless of how many label tokens appear in the description). Pass `--limit 200` explicitly (do not rely on `gh`'s default of 30, matching the explicit-limit convention used elsewhere in this skill for `gh issue list`). Scope the query to the repo currently being swept.
+Run this query **once at the start of Mode B label-token validation** and reuse the result for every subsequent token check within the same `/loom:sweep` invocation (at most one `gh label list` call per invocation, regardless of how many label tokens appear in the description). `$GH_READ` is the cached-read wrapper resolved in "Cached forge reads (`gh-cached`)" under the Execution Model — the repo's label set is near-static, so a cross-session cache hit here is free; the wrapper degrades to plain `gh` when absent (the offline fallback below is unchanged either way). Pass `--limit 200` explicitly (do not rely on `gh`'s default of 30, matching the explicit-limit convention used elsewhere in this skill for `gh issue list`). Scope the query to the repo currently being swept.
 
 If a label token in the description is not in the repo's actual label set, **do not** silently fabricate a `--label <name>` filter — ask the user to clarify which existing label they meant, or supply explicit issue numbers.
 
@@ -158,9 +160,9 @@ Combine flags as needed. Always pass `--state open` explicitly (Mode C operates 
   - **Aggressive-mode flag**: resolving the candidate set via this sentinel sets the internal flag `SWEEP_ALL_AGGRESSIVE=true`, carried into the Wave Lifecycle. It **overrides the conservative pre-flight skip rules** (Wave Lifecycle step 1) with the recovery routing in the "Aggressive candidate taxonomy" table below. Mode A/B explicit-list and NL invocations never set this flag — their skip rules are unchanged.
   - **Candidate resolution (issues, `--prs` absent)** — one deterministic `gh issue list` call, **no label filter**, no LLM/NL translation:
     ```bash
-    gh issue list --state open --limit 100 --json number,title,labels,updatedAt
+    "$GH_READ" issue list --state open --limit 100 --json number,title,labels,updatedAt
     ```
-    Every open issue is a candidate regardless of label — promotion, unblocking, stale-claim recovery, and epic fan-out happen per-issue per the "Aggressive candidate taxonomy" table below, not by pre-filtering the query (`updatedAt` feeds the staleness rule). Pass `--limit 100` explicitly (never rely on gh's default of 30) and apply the existing **edge-case rules**: zero matches → print the resolved query + empty result and EXIT cleanly (edge case #1, do **not** fall through to any other mode); 100 candidates returned → warn about truncation and ask the operator to narrow (or deliberately raise `--limit`) before proceeding (edge case #2).
+    Every open issue is a candidate regardless of label — promotion, unblocking, stale-claim recovery, and epic fan-out happen per-issue per the "Aggressive candidate taxonomy" table below, not by pre-filtering the query (`updatedAt` feeds the staleness rule). `$GH_READ` is the cached-read wrapper (see "Cached forge reads (`gh-cached`)"); candidate resolution is a pure observation read — every claim decision is re-made from an **uncached** per-issue pre-flight read in Wave Lifecycle step 1, so a 30s-old listing cannot cause a stale claim. Pass `--limit 100` explicitly (never rely on gh's default of 30) and apply the existing **edge-case rules**: zero matches → print the resolved query + empty result and EXIT cleanly (edge case #1, do **not** fall through to any other mode); 100 candidates returned → warn about truncation and ask the operator to narrow (or deliberately raise `--limit`) before proceeding (edge case #2).
   - **Orphaned-claim recovery pass (run once, AFTER the confirmation gate, before per-issue pre-flight)** — reclaim `loom:building` labels left behind by dead workers so stale claims don't mask buildable issues:
     ```bash
     ./.loom/scripts/recover-orphaned-shepherds.sh --recover
@@ -168,7 +170,7 @@ Combine flags as needed. Always pass `--state open` explicitly (Mode C operates 
     Best-effort: a non-zero exit is logged and ignored (never abort the sweep). Any issue still labeled `loom:building` after this pass is re-checked inline by the staleness rule in the taxonomy table. **Ordering is load-bearing**: this pass mutates labels, so it runs *only after* the operator confirms the resolved plan at the mandatory confirmation gate — never before. It is **skipped entirely under `--dry-run`** (the dry-run gate is read-only and EXITs before any mutation). This preserves the file-wide "gate before mutation" invariant: nothing on disk or on the forge changes until the operator has confirmed (or `--dry-run` has printed and exited).
   - **Candidate resolution (PRs, `--prs` present)** — every open PR, handed to the Mode C PR-set lifecycle (subagent path):
     ```bash
-    gh pr list --state open --limit 100 --json number,title,labels
+    "$GH_READ" pr list --state open --limit 100 --json number,title,labels
     ```
     Mode C's C0 pre-flight already skips PRs with no actionable label, `loom:operator-only`, or `loom:blocked`, and routes the rest by current label (Judge / Doctor → Judge / Merge) — so grabbing every open PR and letting C0 filter matches the "get every in-flight PR over the finish line" intent. Same zero-match / truncation edge-case rules apply.
   - **Existing-PR routing (issues path)**: the sentinel adds **no** new PR-detection logic. Issues with an open linked PR are handed to the wave machinery, which routes an issue with one open linked PR to Judge (or Merge if the PR is already `loom:pr`) via the per-issue existing-PR probe (Wave Lifecycle step 1, #3359 + #3677 — the union of `closedByPullRequestsReferences` filtered to `state == OPEN` and timeline `cross-referenced` open-PR events, so a non-closing `Part of #N` PR is detected too). This is the single source of truth for existing-PR routing and **takes precedence over the label routing** in the taxonomy table (an issue with an open PR is driven to merge, never rebuilt).
@@ -639,6 +641,53 @@ The harvest parses each joined `agent-<id>.jsonl` transcript's `usage` blocks (i
 
 - **Do NOT write to `.loom/daemon-state.json`.** That file is owned by the standalone daemon. `/loom:sweep` runs independently and must not race with the daemon on shepherd-slot bookkeeping. Reading `daemon-state.json` for situational awareness is fine; writing is not.
 
+### Cached forge reads (`gh-cached`, #4667)
+
+Every concurrent sweep, Judge, and Champion on this host shares **one**
+personal `gh` rate-limit budget (#4665), and they re-issue the same candidate
+listings and candidate surveys independently. Route those repeated
+**observation** reads through the short-TTL cache wrapper; keep every
+**arbitration** and **merge-gating** read on plain `gh`.
+
+Resolve the wrapper **once**, at sweep start (alongside Step 0a's run id):
+
+```bash
+# Degrades to plain `gh` when the wrapper is absent or its Python runtime is
+# broken — the same probe merge-pr.sh uses. Nothing in this document depends on
+# the cache existing; it is a budget optimization, never a correctness mechanism.
+GH_READ="gh"
+_ghc="$(git rev-parse --show-toplevel 2>/dev/null)/.loom/scripts/gh-cached"
+if [[ -x "$_ghc" ]] && "$_ghc" --version >/dev/null 2>&1; then GH_READ="$_ghc"; fi
+```
+
+**Route through `$GH_READ` (cached, 30s TTL):**
+
+| Call site | Where |
+|---|---|
+| Mode B / Mode C candidate resolution (`gh issue list` / `gh pr list` translations) | Validation rules, Examples |
+| The `all` sentinel's whole-backlog `gh issue list --state open --limit 100` | Validation rules |
+| The one-per-invocation `gh label list --limit 200` token validation | Validation rules |
+| `--dry-run` Stage 0 per-candidate surveys (`gh issue view` / `gh pr view`) | Dry-run gate, Procedures |
+
+**Keep on plain `gh` (deliberately uncached — do NOT wrap these):**
+
+| Call site | Why it must be live |
+|---|---|
+| Per-issue pre-flight step 1 (`gh issue view N --json state,labels,closedByPullRequestsReferences`), the timeline existing-PR probe, and the follow-up `gh pr view` routing read | **Claim arbitration.** A 30s-stale `loom:building` / open-PR view is exactly the window a competing Builder's claim lands in — the failure mode is a duplicate builder on a claimed issue |
+| Mode C's C0 per-PR pre-flight (`--json number,state,labels,closingIssuesReferences`) | Same: routes a PR to Judge/Doctor/Merge; must see another session's just-written verdict |
+| Step 5's checkpoint-divergence recheck (`gh pr view <PR> --json labels`) | Its entire purpose is detecting that a concurrent process moved the PR on |
+| Step 7's overlap probe (`gh pr view X --json files`) and `mergeStateStatus` recheck | **Merge gating** — the last read before an irreversible merge |
+| The `--dry-run` "Verifying nothing mutates" before/after reads | **Differential check** — the identical command runs twice around the operation under test; a cache hit would return the "before" value and make the check vacuously pass |
+
+**Writes stay literal `gh`.** Never wrap `gh issue edit` / `gh pr comment` in
+`"$GH_READ"` — the destructive-command guard hooks pattern-match the literal
+command text and a wrapped form slips past them. After a mutation this sweep
+made, drop the cache instead: `"$GH_READ" --clear-cache` (a local `/tmp`
+sweep, zero API cost) so a later cached read cannot return pre-write state.
+
+Full policy, TTL/invalidation semantics, and manual verification steps:
+`.loom/docs/gh-cached.md` (source: `defaults/docs/gh-cached.md`).
+
 ## Sweep Run Identity + Peer-`/loom:sweep` Detection (#3768)
 
 Before **any** other stage — including Backend detection (Stage -1), the dry-run gate, and all wave lifecycles — establish a **stable identity for this sweep invocation** and probe for a concurrently-running peer `/loom:sweep`. This runs for **all modes (A, B, and C)** — it is *not* short-circuited by Mode C or `--no-daemon` (those only affect the Stage -1 backend probes below).
@@ -1083,9 +1132,9 @@ If `--dry-run` was supplied, **this stage runs before any mutation** and EXITs a
 
 1. **Survey each candidate (read-only).** For every deduplicated, validated issue number `N` in the candidate list:
    ```bash
-   gh issue view N --json number,title,labels,state --jq '{number, title, state, labels: [.labels[].name]}'
+   "$GH_READ" issue view N --json number,title,labels,state --jq '{number, title, state, labels: [.labels[].name]}'
    ```
-   This is a `gh issue view` read — it does not mutate anything. (If `gh` is unauthenticated or the issue is unreachable, log the error against that candidate and continue surveying the rest.)
+   This is a `gh issue view` read — it does not mutate anything. It runs through the cached-read wrapper (see "Cached forge reads (`gh-cached`)"): a dry-run survey is pure observation whose output is a printed plan, never a claim, so 30s of staleness costs nothing. The **live** path's per-issue pre-flight (step 1 of the Wave Lifecycle) deliberately does *not* use the wrapper. (If `gh` is unauthenticated or the issue is unreachable, log the error against that candidate and continue surveying the rest.)
 
    **Add `body` to this read unconditionally** (`gh issue view N --json number,title,labels,state,body ...`) — one extra `--json` field, **no extra API call** — and parse its `## Affected Files` section into the candidate's estimated file surface per "Overlap-aware wave partitioning" step 1. A missing / "To be determined" section leaves the surface *unknown* (that candidate is excluded from overlap analysis; never blocked). The `body` fetched here also feeds the `--auto-stack` edge-detection pass when that flag is set (see below), so it is read once and used for both.
 
@@ -1160,9 +1209,9 @@ When every overlapping group was separated by the reorder, print the moves witho
 
 1. **Survey each PR candidate (read-only).** For every deduplicated, validated PR number `P` in the candidate list:
    ```bash
-   gh pr view P --json number,title,labels,state --jq '{number, title, state, labels: [.labels[].name]}'
+   "$GH_READ" pr view P --json number,title,labels,state --jq '{number, title, state, labels: [.labels[].name]}'
    ```
-   This is a `gh pr view` read — it does not mutate anything. (If `gh` is unauthenticated or the PR is unreachable, log the error against that candidate and continue surveying the rest.)
+   This is a `gh pr view` read — it does not mutate anything. Cached, for the same reason as the Modes A/B survey above; Mode C's **live** C0 pre-flight is deliberately uncached. (If `gh` is unauthenticated or the PR is unreachable, log the error against that candidate and continue surveying the rest.)
 
 2. **Compute wave partition.** Mode C waves are size-1 (`--builders-per-wave` is ignored). Each PR is its own wave. Record `(pr, wave_index=N, total_waves=M)` for each candidate. Apply the same skip rules the live path uses (closed PRs, multiple-label conflicts, missing required label all tagged "would skip" in the plan but still listed for transparency).
 
@@ -1216,6 +1265,10 @@ Total: 1 would-judge, 1 would-doctor-then-judge, 1 would-merge, 2 would-skip. No
 **Verifying "nothing mutates":**
 
 ```bash
+# EVERY `gh` read below is plain `gh` — NEVER "$GH_READ". This is a
+# before/after differential check: the identical command runs twice around the
+# operation under test, so a cache hit on the "after" read would replay the
+# "before" value and make the check pass vacuously (#4667).
 # Before:
 LABELS_BEFORE=$(gh pr view P --json labels --jq '[.labels[].name]|sort')   # Mode C
 ISSUE_LABELS_BEFORE=$(gh issue view N --json labels --jq '[.labels[].name]|sort')  # Modes A/B
@@ -1238,6 +1291,9 @@ For each PR `P` in the candidate list, processed sequentially one PR per wave (s
 ### C0. Per-PR pre-flight (before any role dispatch)
 
 ```bash
+# Plain `gh` — NOT "$GH_READ". This read routes the PR to Judge / Doctor /
+# Merge, so it must observe a concurrent Judge's or Champion's just-written
+# label. See "Cached forge reads (`gh-cached`)" for the uncached carve-outs.
 gh pr view P --json number,state,labels,closingIssuesReferences \
   --jq '{number, state, labels: [.labels[].name], closes: [.closingIssuesReferences[].number]}'
 ```
@@ -1437,6 +1493,11 @@ For each issue `N` in the wave, before any role skill is invoked:
 
 1. **Verify the issue is open and not already in flight.**
    ```bash
+   # Plain `gh` — NOT "$GH_READ". This is claim arbitration: a 30s-stale label
+   # set is exactly the window in which a competing Builder's `loom:building`
+   # claim (or another sweep's freshly opened PR) lands, and answering from
+   # cache would dispatch a duplicate builder onto claimed work. Uncached by
+   # design — see "Cached forge reads (`gh-cached`)".
    gh issue view N --json state,labels,closedByPullRequestsReferences \
      --jq '{state, labels: [.labels[].name], linked_prs: [.closedByPullRequestsReferences[].url]}'
    ```
@@ -1456,6 +1517,9 @@ For each issue `N` in the wave, before any role skill is invoked:
      1. **Closing-keyword PRs (`closedByPullRequestsReferences`, unchanged since #3359).** The `linked_prs` from the `gh issue view` above. GitHub's native `Closes/Fixes/Resolves #N` parser — populated only by closing keywords.
      2. **Non-closing cross-reference PRs (timeline, #3677).** PRs that reference `N` with a **non-closing** phrase (`Part of #N` / `Contributes to #N`, the #3599 partial-increment convention — see `defaults/roles/builder-pr.md`) never appear in `closedByPullRequestsReferences` by design, so probe the issue's timeline for `cross-referenced` events whose source is a PR:
         ```bash
+        # Plain `gh` — NOT "$GH_READ": same claim-arbitration carve-out as the
+        # `gh issue view` read above (this probe decides whether to dispatch a
+        # Builder at all).
         gh api "repos/OWNER/REPO/issues/N/timeline" --paginate \
           --jq '[.[] | select(.event == "cross-referenced"
                               and .source.issue.pull_request != null
@@ -1467,6 +1531,7 @@ For each issue `N` in the wave, before any role skill is invoked:
 
      **Union + filter.** Merge the two source lists and dedupe by PR number. For any PR discovered only via source 1, filter to `state == "OPEN"` (uppercase — `closedByPullRequestsReferences` includes MERGED and CLOSED PRs, which are not the duplicate-builder hazard); source 2 is already filtered to open. For each surviving open PR, fetch its labels for routing:
      ```bash
+     # Plain `gh` — NOT "$GH_READ" (routing read; must be live).
      gh pr view <pr_number_or_url> --json state,labels --jq '{state, labels: [.labels[].name]}'
      ```
      Apply the routing rules below based on the count of distinct **open** linked PRs (from either source):
@@ -1747,6 +1812,8 @@ post_wave_integration_gate()                    # step 8 — buildGate-against-m
 - If `CHECKPOINT_PHASE == "doctor-done"`, Doctor has already addressed Judge's earlier feedback. **Re-run the Judge phase** for this PR — Judge has not yet evaluated the post-doctor diff in the current sweep run. (The previous Judge result that led to Doctor was `changes-requested`, not `judge-done`.)
 - If `CHECKPOINT_PHASE == "judge-rejected"`, an earlier sweep run's Judge already completed and requested changes on this PR — the sweep was killed before the inline Doctor cycle finished. **Do NOT re-run the initial Judge pass.** Route directly to the Doctor phase (step 6) for this PR. **Forge/checkpoint divergence guard:** before trusting this checkpoint, verify the PR still carries `loom:changes-requested`:
   ```bash
+  # Plain `gh` — NOT "$GH_READ": this recheck exists precisely to detect that a
+  # concurrent process moved the PR on, which a cached label set would hide.
   gh pr view <PR> --json labels --jq '[.labels[].name] | contains(["loom:changes-requested"])'
   ```
   If it does not (e.g. a concurrent process already merged, re-judged, or otherwise moved the PR on), the checkpoint and forge state have diverged — log a warning and fall back to running Judge normally instead of trusting the stale checkpoint.
@@ -1802,6 +1869,9 @@ Before calling `merge-pr.sh` for PR `#X`:
 
 1. **Cheap read-only overlap probe.** Fetch `#X`'s changed-file set and compare it against `WAVE_MERGED_FILES` (the union of paths already merged in this wave — see the step 5 loop):
    ```bash
+   # Plain `gh` — NOT "$GH_READ". Everything from here to the merge call is
+   # merge-gating: the last read before an irreversible action must observe
+   # current state unconditionally (#4667).
    gh pr view X --json files -q '.files[].path'
    ```
    - **Disjoint** (no path shared with `WAVE_MERGED_FILES`) → **keep the fast path**: fall straight through to the merge below. Two PRs touching disjoint files are safe (the issue confirms this), so no revalidation latency is added. This is the common case. *(Caveat: file-path granularity cannot see cross-file semantic coupling — e.g. a `to_dict()` in a source file vs. an exact-dict assertion in a test file, which are disjoint paths. That class is the step 8 integration gate's job, not this probe's.)*

--- a/defaults/docs/gh-cached.md
+++ b/defaults/docs/gh-cached.md
@@ -1,0 +1,190 @@
+# `gh-cached` — short-TTL caching for hot forge reads
+
+`defaults/scripts/gh-cached` (installed as `.loom/scripts/gh-cached`) is a
+drop-in `gh` wrapper that caches read-only responses in a file-backed TTL/LRU
+cache under `/tmp/gh-cache/`. Because the cache is on disk, it is shared
+**across processes on one host** — the N sweep / Judge / Champion sessions
+running concurrently against the same repo hit the same entries.
+
+This document is the policy reference for **which** reads in the
+`/loom:sweep`, `/loom:judge`, and Champion-PR-merge skills go through the
+wrapper and which are deliberately left uncached (#4667). The motivating
+problem is #4665: concurrent sessions share **one** personal `gh` rate-limit
+budget, and every session independently re-polling the same PR/issue listings
+burns that shared budget on identical answers.
+
+## Interface
+
+```bash
+# Resolve the wrapper once per session; fall back to plain `gh` when it is
+# absent or its Python runtime is broken (the same probe merge-pr.sh uses).
+GH_READ="gh"
+_ghc="$(git rev-parse --show-toplevel 2>/dev/null)/.loom/scripts/gh-cached"
+if [[ -x "$_ghc" ]] && "$_ghc" --version >/dev/null 2>&1; then GH_READ="$_ghc"; fi
+
+"$GH_READ" pr list --label "loom:review-requested" --state open --limit 500
+"$GH_READ" --no-cache pr view 4560 --json labels    # explicit bypass
+"$GH_READ" --cache-stats                            # hits/misses/bypasses/invalidations
+"$GH_READ" --clear-cache                            # drop every entry
+```
+
+The fallback matters: on a host without the wrapper (or with a broken
+`python3`), every documented `"$GH_READ" …` command degrades to the exact
+`gh …` command it replaced. **Nothing in the skills depends on the cache
+existing** — it is a budget optimization, never a correctness mechanism.
+
+`--no-cache` is a *wrapper* flag. Plain `gh` rejects it (#3547), which is why
+the carve-outs below are written as "run plain `gh`" rather than
+"run `$GH_READ --no-cache`" — the plain form is correct under either
+resolution.
+
+### What it caches
+
+| Command shape | Behavior | TTL |
+|---|---|---|
+| `gh issue view` / `issue list` | cached | 30s |
+| `gh pr view` / `pr list` | cached | 30s |
+| `gh label list`, `gh <x> search/status` | cached | 30s (default) |
+| `gh api` **without** `-X <non-GET>` / `-f` | cached | 30s |
+| `gh … edit/create/delete/close/reopen/merge/review/comment/label` | **bypassed**, and invalidates (but issue writes as literal `gh` — see below) | — |
+| `gh pr checks`, `gh pr diff`, `gh repo view`, `gh auth …` | **passthrough**, never cached | — |
+
+Only **successful** (`rc == 0`) responses are cached, so a transient forge
+error is never memoized. TTL knobs: `GH_CACHE_TTL` (default 30s),
+`GH_CACHE_MAX_SIZE` (256 entries, LRU), `GH_CACHE_DIR`, `GH_CACHE_DISABLE=1`
+(hard off), `GH_CACHE_DEBUG=1` (per-call HIT/MISS/INVALIDATE lines on stderr).
+
+### Mutation-triggered invalidation — and why writes still use plain `gh`
+
+On a successful mutation issued *through the wrapper*, it deletes every cached
+entry that references the mutated resource — matching first on the cached
+command's own argv, then falling back to a substring match on the cached
+response body (so a cached `pr list` containing `"number": 4560` is dropped
+when PR 4560 is edited). When it cannot identify a resource id, it clears the
+whole cache.
+
+**Skills must nevertheless keep issuing their writes as literal `gh …`, not
+`"$GH_READ" …`.** The destructive-command guard hooks pattern-match the
+*literal* command text — e.g. `guard-destructive-generic.sh`'s
+`gh[[:space:]]+(pr|issue)[[:space:]]+comment` rule that hard-denies
+`--body @path` (the anti-pattern that destroyed a Judge review in PR #4457,
+and recurred through variable indirection on PR #4600). A wrapped
+`"$GH_READ" pr comment …` does not match those patterns and would slip past
+the guard. Trading a *safety* guard for a *budget* optimization is never the
+right trade.
+
+**So close the loop explicitly instead:** after a mutation you made in this
+pass (verdict label, comment, merge), drop the cache before your next cached
+read:
+
+```bash
+gh pr edit "$N" --add-label "loom:pr"     # literal `gh` — guard hooks see it
+"$GH_READ" --clear-cache                  # local fs op, zero API cost
+```
+
+`--clear-cache` is a `/tmp` directory sweep — it costs no API calls, and the
+worst case for a concurrent session is one extra miss. This is what guarantees
+a skill never reads its own pre-write state back out of the cache (e.g. a
+Judge that labels `loom:pr` and then re-lists `loom:review-requested`).
+Skipping it bounds the staleness at one TTL (≤30s) rather than being
+unbounded, but do not rely on that — clear after your own writes.
+
+## The policy: cache observation, never arbitration
+
+Route a read through `$GH_READ` when it is a **repeated observation** whose
+worst case under 30s of staleness is a wasted pass or a re-poll:
+
+- broad candidate/queue discovery (`gh issue list`, `gh pr list`, `gh label list`)
+- read-only surveys of a candidate set that no decision mutates (dry-run plans)
+- idempotency-marker greps over a PR's comments
+
+Keep a read on plain `gh` (uncached) when a stale answer can cause an
+**incorrect irreversible action** — a duplicate builder, a stomped verdict, a
+merge that should not have happened, or a test that observes its own stale
+"before" value:
+
+- **claim arbitration** — reads that decide "is someone else already working
+  on this?" (`loom:building` / `loom:reviewing` label reads, claim timelines).
+  A 30s-stale label is exactly the window a competing claim lands in.
+- **verdict-time CAS rechecks** — the whole point is to observe writes that
+  landed *during* your review; a cached label set defeats the mechanism.
+- **merge gating** — the 6 Champion safety criteria, `mergeStateStatus` /
+  `mergeable`, `gh pr checks`, and the paginated changed-file list (#4613).
+  These are the last read before an irreversible action.
+- **liveness probes** — the Judge's `gh repo view` environment check must
+  observe the live environment, not a cached success from a healthy session.
+- **before/after differential checks** — e.g. sweep's `--dry-run`
+  "nothing mutated" verification, which runs the *identical* command twice
+  around the operation under test. A cache hit would return the "before"
+  value and make the check vacuously pass.
+
+`gh pr checks` and `gh repo view` are passthrough in the wrapper already, so
+those carve-outs hold even if a caller wraps them by accident. The rest are
+enforced by the skills documenting the plain `gh` form at those call sites.
+
+## Per-skill call-site inventory
+
+### `/loom:sweep` (`sweep.md`)
+
+| Cached | Uncached (and why) |
+|---|---|
+| Mode B/C candidate resolution (`gh issue list` / `gh pr list` translations, `all`-sentinel backlog query) | Per-issue pre-flight state/label read + existing-PR probe (timeline + `gh pr view`) — **claim arbitration** |
+| The one-per-invocation `gh label list --limit 200` token-validation query | Step 5 checkpoint-divergence label recheck — must see a concurrent process's verdict |
+| `--dry-run` Stage 0 per-candidate surveys (`gh issue view` / `gh pr view`) | Step 7 overlap probe (`--json files`) and `mergeStateStatus` recheck — **merge gating** |
+| | `--dry-run` "nothing mutates" before/after reads — **differential check** |
+
+### `/loom:judge` (`judge.md`)
+
+| Cached | Uncached (and why) |
+|---|---|
+| `gh pr list --label loom:review-requested` queue discovery (every occurrence) | Pre-Iteration Environment Check (`gh repo view`) — **liveness probe** |
+| Fallback-queue unlabeled-PR listing | Stale `loom:reviewing` claim check (timeline + comments) — **claim arbitration** |
+| `gh issue list --search` when repairing a PR description | Verdict-Time CAS Recheck (`gh pr view --json labels`) — **CAS** |
+| | `gh pr checks` + `mergeStateStatus` before a verdict — **verdict gating** |
+
+### Champion PR merge (`champion-pr-merge.md`)
+
+| Cached | Uncached (and why) |
+|---|---|
+| Idempotency-marker comment greps (janitor / hold / stale / park / close markers, prior grants) | All 6 safety criteria reads — **merge gating** |
+| `gh issue list --label loom:blocked` unblock scan and its per-issue **body** reads | Verdict-State Janitor label read — decides whether to merge |
+| Follow-on-issue duplicate search (`gh issue list --search`) | Paginated changed-file list (`gh api .../files --paginate`) — #4613 demands a fresh full read |
+| Parked-PR listing (`gh pr list --label …`) | Pre-merge comment's data gathering — must not restate a stale criterion result |
+| | Post-merge linked-issue **state** reads and the dependency-`state` loop — they gate `gh issue close` / removing `loom:blocked` |
+
+## Verification
+
+### Automated
+
+`defaults/scripts/tests/test-gh-cached.sh` (CI-wired) drives the wrapper with a
+stub `gh` on `PATH` and a temp `GH_CACHE_DIR`, asserting: repeated `pr list` /
+`issue list` / `pr view` reads hit the cache; `--no-cache` bypasses; `gh pr
+checks` and `gh repo view` are never cached; a wrapped `gh pr edit` /
+`gh pr comment` invalidates the cached reads of that PR (including the cached
+listing that contains it); and a state change is observed once the TTL expires.
+
+### Manual (inherently runtime — cannot be unit-tested)
+
+1. **Hit rate.** `"$GH_READ" --clear-cache`, run a Judge or sweep pass, then
+   `"$GH_READ" --cache-stats`. Expect a non-zero hit count with the misses
+   concentrated on first-touch reads. Repeating the same pass within 30s
+   should be nearly all hits. `GH_CACHE_DEBUG=1` prints per-call
+   `HIT`/`MISS`/`EXPIRED`/`INVALIDATE` lines if you need the call-by-call view.
+2. **State change within one TTL.** With a PR whose CI is pending, poll the
+   cached discovery read every few seconds while CI completes. The new state
+   must appear within one TTL window (≤30s by default) — not indefinitely
+   masked. (CI status itself is read through plain `gh pr checks`, which is
+   never cached; this checks the *listing* reads that surround it.)
+3. **Same-session mutation invalidation.** Read a PR through the wrapper
+   (`"$GH_READ" pr view <N> --json labels`), mutate it through the wrapper
+   (`"$GH_READ" pr edit <N> --add-label …`), then re-read immediately. The
+   re-read must show the new label — a cached pre-write answer here means the
+   write was issued through plain `gh` instead of the wrapper.
+
+## Scope note
+
+This is the *existing* Python/`/tmp`-backed wrapper, extended in adoption
+only. The forge-neutral `CachedForgeClient` (#3149) — which would also cover
+Gitea — remains unimplemented and is deliberately out of scope here; on Gitea
+`FORGE_TYPE`, every command above resolves to plain `gh`/`gitea_api` and this
+document is a no-op.

--- a/defaults/scripts/gh-cached
+++ b/defaults/scripts/gh-cached
@@ -39,13 +39,20 @@ MAX_CACHE_SIZE = int(os.environ.get("GH_CACHE_MAX_SIZE", "256"))
 CACHE_DISABLED = os.environ.get("GH_CACHE_DISABLE", "") == "1"
 DEBUG = os.environ.get("GH_CACHE_DEBUG", "") == "1"
 
-# TTL overrides by command type (seconds)
+# TTL overrides by command type (seconds).
+#
+# These are the hot polling shapes the sweep/judge/champion skills route through
+# this wrapper (#4667). They all track DEFAULT_TTL so that GH_CACHE_TTL is a real
+# knob: previously these were hard-coded 30s, which silently made GH_CACHE_TTL a
+# no-op for exactly the commands that matter (it only applied to the shapes that
+# fell through to the default). Unset GH_CACHE_TTL still yields 30s, so this is
+# behavior-identical unless an operator deliberately tunes the window.
 TTL_BY_COMMAND = {
-    ("issue", "view"):   30,
-    ("issue", "list"):   30,
-    ("pr", "view"):      30,
-    ("pr", "list"):      30,
-    ("api",):            30,
+    ("issue", "view"):   DEFAULT_TTL,
+    ("issue", "list"):   DEFAULT_TTL,
+    ("pr", "view"):      DEFAULT_TTL,
+    ("pr", "list"):      DEFAULT_TTL,
+    ("api",):            DEFAULT_TTL,
 }
 
 # Commands that are read-only and safe to cache

--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -29,6 +29,7 @@ test-disk-headroom.sh
 test-fleet-check.sh
 test-fleet-send.sh
 test-forge-helpers.sh
+test-gh-cached.sh
 test-github-app-token.sh
 test-gitignore-guard.sh
 test-guard-hook-schema.sh

--- a/defaults/scripts/tests/test-forge-helpers.sh
+++ b/defaults/scripts/tests/test-forge-helpers.sh
@@ -260,6 +260,65 @@ assert_eq "true" "$nc_cached_result" "forge_get_pr_nocache with gh-cached wrappe
 
 rm -rf "$NC_STUB_DIR"
 
+# --- Test CI-status helpers stay UNCACHED (issue #4667) ---
+# The sweep/judge/champion skills now route their hot discovery reads through
+# gh-cached, but CI status is explicitly carved out: it is the read a verdict
+# and a merge are gated on, so a cached green could predate the push that broke
+# the build. forge_get_check_runs / forge_get_commit_status must therefore keep
+# invoking plain `gh` from PATH — never a cache wrapper, and never with the
+# wrapper-only `--no-cache` flag (the #3547 failure shape). This locks the
+# carve-out in at the library level so a future "cache everything" pass has to
+# delete a failing test rather than silently weaken a merge gate.
+echo ""
+echo "Testing CI-status helpers are uncached (issue #4667)..."
+
+CI_STUB_DIR=$(mktemp -d)
+CI_ARGS_FILE="$CI_STUB_DIR/argv.txt"
+
+cat > "$CI_STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_CI_ARGS_FILE"
+for a in "$@"; do
+  if [[ "$a" == "--no-cache" ]]; then
+    echo "unknown flag: --no-cache" >&2
+    exit 1
+  fi
+done
+# `gh api ... --jq` filters server-side; the helpers ask for a reshaped object,
+# so just emit the already-shaped result the helper would have produced.
+case "$*" in
+  *check-runs*) printf '{"total_count":1,"check_runs":[{"name":"build","status":"completed","conclusion":"success","html_url":"u"}]}\n' ;;
+  *status*)     printf '{"state":"success","statuses":[]}\n' ;;
+  *)            exit 1 ;;
+esac
+exit 0
+STUB
+chmod +x "$CI_STUB_DIR/gh"
+
+# A `gh-cached` that must never be reached by these helpers.
+cat > "$CI_STUB_DIR/gh-cached" <<'STUB'
+#!/usr/bin/env bash
+echo "gh-cached must NOT be used for CI-status reads" >&2
+exit 1
+STUB
+chmod +x "$CI_STUB_DIR/gh-cached"
+
+FORGE_TYPE="github"
+: > "$CI_ARGS_FILE"
+
+cr_state=$(GH_CI_ARGS_FILE="$CI_ARGS_FILE" PATH="$CI_STUB_DIR:$PATH" \
+  forge_get_check_runs "owner/repo" "deadbeef" 2>/dev/null | jq -r '.check_runs[0].conclusion' 2>/dev/null || echo "")
+assert_eq "success" "$cr_state" "forge_get_check_runs reaches plain gh (no --no-cache, no wrapper)"
+
+cs_state=$(GH_CI_ARGS_FILE="$CI_ARGS_FILE" PATH="$CI_STUB_DIR:$PATH" \
+  forge_get_commit_status "owner/repo" "deadbeef" 2>/dev/null | jq -r '.state' 2>/dev/null || echo "")
+assert_eq "success" "$cs_state" "forge_get_commit_status reaches plain gh (no --no-cache, no wrapper)"
+
+nocache_hits=$(grep -c -- '--no-cache' "$CI_ARGS_FILE" || true)
+assert_eq "0" "$nocache_hits" "CI-status helpers never pass the wrapper-only --no-cache flag"
+
+rm -rf "$CI_STUB_DIR"
+
 # --- Test gitea_api auth-mode selection (issue #3297) ---
 # Use a `curl` shim on PATH that records its argv and returns a fake 200.
 echo ""

--- a/defaults/scripts/tests/test-gh-cached.sh
+++ b/defaults/scripts/tests/test-gh-cached.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# test-gh-cached.sh — behavioral tests for the gh-cached short-TTL read cache
+# as it is used by the sweep / judge / champion skills (issue #4667).
+#
+# These cover the properties those skills' documented command sequences now
+# depend on (`defaults/docs/gh-cached.md`):
+#
+#   1. Repeated hot discovery reads (`pr list` / `issue list` / `pr view`) are
+#      served from the cache within the TTL window.
+#   2. `--no-cache` bypasses the cache (the explicit-bypass escape hatch).
+#   3. Verdict/merge-gating shapes (`gh pr checks`) and the liveness probe
+#      (`gh repo view`) are NEVER cached — the deliberate carve-outs.
+#   4. A state change is observed once the TTL expires (no indefinite masking).
+#   5. A mutation issued through the wrapper invalidates cached reads of that
+#      resource — including the cached *listing* that contains it.
+#   6. `--clear-cache` drops every entry (the documented remedy after a write
+#      issued as literal `gh`, which is how the skills must issue writes so the
+#      destructive-command guard hooks still see them).
+#   7. Failed reads (non-zero exit) are never cached.
+#
+# Hermetic: a stub `gh` on PATH plus a temp GH_CACHE_DIR. No network, no forge,
+# no real `gh`. Requires python3 (the wrapper's runtime); skips cleanly without.
+#
+# Usage:
+#   ./defaults/scripts/tests/test-gh-cached.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GH_CACHED="$(cd "$SCRIPT_DIR/.." && pwd)/gh-cached"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected: '$expected'"
+        echo "    Actual:   '$actual'"
+    fi
+}
+
+if [[ ! -x "$GH_CACHED" ]]; then
+    echo "FAIL: gh-cached not found or not executable at $GH_CACHED" >&2
+    exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "SKIP: python3 not available — gh-cached cannot run on this host"
+    exit 0
+fi
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+STUB_DIR="$TMP_ROOT/bin"
+STATE_DIR="$TMP_ROOT/state"
+mkdir -p "$STUB_DIR" "$STATE_DIR"
+
+CALL_LOG="$TMP_ROOT/calls.log"
+: > "$CALL_LOG"
+
+# --- Stub `gh` -------------------------------------------------------------
+# Logs every invocation (so we can count real forge calls) and answers from
+# $STATE_DIR files, which the tests mutate to simulate forge-side changes.
+cat > "$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_STUB_CALL_LOG"
+
+case "$1 ${2:-}" in
+  "--version "*|"--version")
+    echo "gh version 2.99.0 (stub)"; exit 0 ;;
+esac
+
+case "$1" in
+  repo)   cat "$GH_STUB_STATE/repo.txt"; exit 0 ;;
+esac
+
+case "$1 ${2:-}" in
+  "pr list")     cat "$GH_STUB_STATE/pr-list.json"; exit 0 ;;
+  "pr view")     cat "$GH_STUB_STATE/pr-view.json"; exit 0 ;;
+  "pr checks")   cat "$GH_STUB_STATE/pr-checks.txt"; exit 0 ;;
+  "issue list")  cat "$GH_STUB_STATE/issue-list.json"; exit 0 ;;
+  "pr edit"|"pr comment"|"issue edit")
+    exit 0 ;;
+  "api "*|"api")
+    # A failing read: used to prove non-zero responses are never cached.
+    echo "stub api error" >&2; exit 1 ;;
+esac
+
+echo "stub: unhandled args: $*" >&2
+exit 64
+STUB
+chmod +x "$STUB_DIR/gh"
+
+export GH_STUB_CALL_LOG="$CALL_LOG"
+export GH_STUB_STATE="$STATE_DIR"
+
+echo '{"name":"loom"}'                          > "$STATE_DIR/repo.txt"
+echo '[{"number":4242,"labels":["loom:review-requested"]}]' > "$STATE_DIR/pr-list.json"
+echo '{"labels":["loom:review-requested"]}'     > "$STATE_DIR/pr-view.json"
+echo 'build  pass  1m0s'                        > "$STATE_DIR/pr-checks.txt"
+echo '[{"number":99,"title":"an issue"}]'       > "$STATE_DIR/issue-list.json"
+
+CACHE_DIR="$TMP_ROOT/cache"
+
+# Run gh-cached with a hermetic environment. Args are passed through verbatim.
+ghc() {
+    PATH="$STUB_DIR:$PATH" \
+    GH_CACHE_DIR="$CACHE_DIR" \
+    GH_CACHE_TTL="${TTL_OVERRIDE:-30}" \
+      "$GH_CACHED" "$@"
+}
+
+call_count() { wc -l < "$CALL_LOG" | tr -d ' '; }
+reset_calls() { : > "$CALL_LOG"; }
+reset_cache() { rm -rf "$CACHE_DIR"; reset_calls; }
+
+# --- 1. Hot discovery reads are cached -------------------------------------
+echo "Testing cache hits on hot discovery reads..."
+
+reset_cache
+out1=$(ghc pr list --label "loom:review-requested" --state open --limit 500)
+out2=$(ghc pr list --label "loom:review-requested" --state open --limit 500)
+assert_eq "1" "$(call_count)" "repeated 'pr list' issues ONE real gh call (2nd is a cache hit)"
+assert_eq "$out1" "$out2" "cached 'pr list' returns the identical payload"
+
+reset_cache
+ghc issue list --label "loom:issue" --state open --limit 100 >/dev/null
+ghc issue list --label "loom:issue" --state open --limit 100 >/dev/null
+assert_eq "1" "$(call_count)" "repeated 'issue list' issues ONE real gh call"
+
+reset_cache
+ghc pr view 4242 --json labels >/dev/null
+ghc pr view 4242 --json labels >/dev/null
+assert_eq "1" "$(call_count)" "repeated 'pr view --json labels' issues ONE real gh call"
+
+# Distinct arguments must be distinct cache keys (no cross-query bleed).
+reset_cache
+ghc pr list --label "loom:review-requested" --state open --limit 500 >/dev/null
+ghc pr list --label "loom:pr" --state open --limit 500 >/dev/null
+assert_eq "2" "$(call_count)" "a different --label is a different cache key"
+
+# --- 2. --no-cache bypasses ------------------------------------------------
+echo ""
+echo "Testing the explicit --no-cache bypass..."
+
+reset_cache
+ghc pr view 4242 --json labels >/dev/null
+ghc --no-cache pr view 4242 --json labels >/dev/null
+assert_eq "2" "$(call_count)" "--no-cache bypasses a warm cache entry"
+
+# --- 3. Deliberate carve-outs are never cached -----------------------------
+echo ""
+echo "Testing the uncached carve-outs (verdict/merge gating + liveness probe)..."
+
+reset_cache
+ghc pr checks 4242 >/dev/null 2>&1
+ghc pr checks 4242 >/dev/null 2>&1
+assert_eq "2" "$(call_count)" "'pr checks' (CI gate) is NEVER cached"
+
+reset_cache
+ghc repo view --json name >/dev/null 2>&1
+ghc repo view --json name >/dev/null 2>&1
+assert_eq "2" "$(call_count)" "'repo view' (liveness probe) is NEVER cached"
+
+# --- 4. A state change is observed once the TTL expires --------------------
+echo ""
+echo "Testing TTL expiry (a state change is not masked indefinitely)..."
+
+reset_cache
+TTL_OVERRIDE=1 ghc pr list --state open --limit 500 >/dev/null
+echo '[{"number":4242,"labels":["loom:pr"]}]' > "$STATE_DIR/pr-list.json"
+fresh_within_ttl=$(TTL_OVERRIDE=1 ghc pr list --state open --limit 500)
+assert_eq "1" "$(call_count)" "within the TTL window the changed state is still served from cache"
+case "$fresh_within_ttl" in
+  *loom:review-requested*) within_ok="stale" ;;
+  *) within_ok="fresh" ;;
+esac
+assert_eq "stale" "$within_ok" "…and that cached payload is the pre-change one (as designed)"
+
+sleep 2
+after_ttl=$(TTL_OVERRIDE=1 ghc pr list --state open --limit 500)
+assert_eq "2" "$(call_count)" "after the TTL expires the read hits the forge again"
+case "$after_ttl" in
+  *'"loom:pr"'*) after_ok="fresh" ;;
+  *) after_ok="stale" ;;
+esac
+assert_eq "fresh" "$after_ok" "…and the new state IS observed within one TTL window"
+
+# restore the baseline listing for the remaining tests
+echo '[{"number":4242,"labels":["loom:review-requested"]}]' > "$STATE_DIR/pr-list.json"
+
+# --- 5. Mutation-triggered invalidation ------------------------------------
+echo ""
+echo "Testing mutation-triggered invalidation (a skill's own write is never masked)..."
+
+reset_cache
+ghc pr view 4242 --json labels >/dev/null           # warm: 1 call
+echo '{"labels":["loom:pr"]}' > "$STATE_DIR/pr-view.json"
+ghc pr edit 4242 --add-label "loom:pr" >/dev/null    # mutation: 2 calls, invalidates
+after_edit=$(ghc pr view 4242 --json labels)         # re-read: 3 calls
+assert_eq "3" "$(call_count)" "a wrapped 'pr edit' invalidates the cached 'pr view' of that PR"
+case "$after_edit" in
+  *'"loom:pr"'*) mut_ok="fresh" ;;
+  *) mut_ok="stale" ;;
+esac
+assert_eq "fresh" "$mut_ok" "…so the re-read observes the skill's own write"
+
+# The cached LISTING containing that PR must be invalidated too (the stdout
+# fallback match) — otherwise a Judge that labels loom:pr could still see the
+# PR in its own loom:review-requested queue.
+reset_cache
+ghc pr list --label "loom:review-requested" --state open --limit 500 >/dev/null
+ghc pr edit 4242 --add-label "loom:pr" >/dev/null
+ghc pr list --label "loom:review-requested" --state open --limit 500 >/dev/null
+assert_eq "3" "$(call_count)" "a wrapped mutation also invalidates a cached listing containing that PR"
+
+reset_cache
+ghc pr view 4242 --json labels >/dev/null
+ghc pr comment 4242 --body "hello" >/dev/null
+ghc pr view 4242 --json labels >/dev/null
+assert_eq "3" "$(call_count)" "'pr comment' invalidates cached reads of that PR too"
+
+# --- 6. --clear-cache (the post-literal-`gh`-write remedy) -----------------
+echo ""
+echo "Testing --clear-cache (the documented remedy after a literal-gh write)..."
+
+reset_cache
+ghc pr list --label "loom:review-requested" --state open --limit 500 >/dev/null
+ghc --clear-cache >/dev/null 2>&1
+ghc pr list --label "loom:review-requested" --state open --limit 500 >/dev/null
+assert_eq "2" "$(call_count)" "--clear-cache drops the warm entry, forcing a fresh read"
+
+# --- 7. Failed reads are never cached --------------------------------------
+echo ""
+echo "Testing that failing reads are not memoized..."
+
+reset_cache
+ghc api "repos/o/r/commits/deadbeef/check-runs" >/dev/null 2>&1
+rc1=$?
+ghc api "repos/o/r/commits/deadbeef/check-runs" >/dev/null 2>&1
+assert_eq "2" "$(call_count)" "a non-zero read is retried, never served from cache"
+assert_eq "1" "$rc1" "the wrapper propagates the underlying gh exit code"
+
+# --- 8. The fallback contract ----------------------------------------------
+# Every skill resolves the wrapper with `"$GH_CACHED" --version` and falls back
+# to plain `gh` when it fails. Assert the probe the skills document works.
+echo ""
+echo "Testing the wrapper-resolution probe used by the skills..."
+
+reset_cache
+if ghc --version >/dev/null 2>&1; then probe_rc=0; else probe_rc=$?; fi
+assert_eq "0" "$probe_rc" "'gh-cached --version' succeeds (the skills' resolution probe)"
+
+# --- Summary ---------------------------------------------------------------
+echo ""
+echo "────────────────────────────────"
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

`defaults/scripts/gh-cached` (file-backed 30s TTL/LRU cache over `gh` reads at `/tmp/gh-cache/`, cross-process on one host) was wired into `merge-pr.sh` only. The actual hot-polling paths — the `/loom:sweep`, `/loom:judge`, and Champion-PR-merge skills — issued every `gh issue list` / `gh pr list` / per-candidate survey as a raw, uncached call, so N concurrent sessions each burned the one shared personal rate-limit budget on identical answers (#4665).

This PR extends **adoption** of the existing wrapper into those three skill docs. It does **not** build the forge-neutral `CachedForgeClient` (#3149) — explicitly out of scope.

The governing rule the docs now encode: **cache observation, never arbitration.** A read whose worst case under 30s of staleness is a wasted pass gets cached; a read whose stale answer can cause an incorrect irreversible action (duplicate builder, stomped verdict, wrong merge) stays on plain `gh` and is annotated as such *at its call site*.

## Changes

- **`defaults/docs/gh-cached.md` (new)** — the shared policy reference: wrapper interface + the `$GH_READ` resolver snippet, what it caches/passes through, mutation-invalidation semantics, the cached/uncached decision rule, a per-skill call-site inventory, and the manual verification steps.
- **`defaults/.claude/commands/loom/judge.md`** — new "Cached Forge Reads" section (resolver + cached/uncached tables). Queue discovery (`gh pr list --label loom:review-requested`, at all 5 occurrences), the fallback unlabeled-PR listing, and the PR-description-repair `gh issue list --search` now run as `"$GH_READ" …`. Annotated as **deliberately uncached**: the `gh repo view` liveness probe, the stale-`loom:reviewing` claim check (timeline + comments), the **Verdict-Time CAS Recheck**, and the whole CI Status Check section (`gh pr checks` + `mergeStateStatus`).
- **`defaults/.claude/commands/loom/sweep.md`** — new "Cached forge reads" section under the Execution Model. Cached: Mode B/C candidate resolution, the `all`-sentinel whole-backlog query, the one-per-invocation `gh label list`, and the `--dry-run` Stage 0 surveys. Annotated as **deliberately uncached**: per-issue pre-flight step 1 + the timeline existing-PR probe + its `gh pr view` routing read (claim arbitration → duplicate-builder hazard), Mode C's C0 pre-flight, step 5's checkpoint-divergence recheck, step 7's overlap probe / `mergeStateStatus`, and the `--dry-run` "nothing mutates" before/after reads (a cache hit there would replay the "before" value and make the check vacuously pass).
- **`defaults/.claude/commands/loom/champion-pr-merge.md`** — new "Cached forge reads" section. Cached: the idempotency-marker comment greps (janitor/hold/stale/park/close/prior-grants), the `loom:blocked` unblock scan + per-issue *body* reads, the follow-on-issue duplicate search, the parked-PR listing. Annotated as **deliberately uncached**: the janitor label read, **all 6 safety criteria**, criterion #3's paginated changed-file list (#4613 requires a fresh full read), step 2's pre-merge comment data gathering, and the post-merge issue-`state` / dependency-`state` reads that gate `gh issue close` / removing `loom:blocked`.
- **Writes stay literal `gh`** (all three skills). Wrapping `gh pr comment` / `gh pr edit` would slip past `guard-destructive-generic.sh`, whose rules pattern-match the *literal* command text (e.g. the `--body @path` hard deny added after PR #4457). Trading a safety guard for a budget optimization is the wrong trade, so criterion 5 is satisfied by `"$GH_READ" --clear-cache` after a skill's own mutation (a `/tmp` sweep, zero API cost) instead.
- **`defaults/scripts/gh-cached`** — one behavior-preserving fix: `TTL_BY_COMMAND` hard-coded `30` for `issue view/list`, `pr view/list`, and `api`, which silently made the documented `GH_CACHE_TTL` knob a no-op for exactly the shapes this PR now caches. Entries now track `DEFAULT_TTL` (unset env ⇒ still 30s). No cache-key or invalidation logic changed.
- **Tests** — new `defaults/scripts/tests/test-gh-cached.sh` (wired into `ci-wired.txt`), plus a CI-status carve-out guard in `test-forge-helpers.sh`.

## Acceptance Criteria Verification

1. **Hot call sites identified** — done per skill and enumerated in each doc's cached/uncached tables and in `defaults/docs/gh-cached.md`'s per-skill inventory.
2. **Routed through `gh-cached` with an appropriate TTL** — via the `$GH_READ` resolver, which reuses `merge-pr.sh`'s exact probe (`-x` + `--version`) and its default 30s TTL. `forge_get_check_runs`/`forge_get_commit_status` were **not** switched to the wrapper: contrary to the issue's premise they are not currently cached (`check-ci-status.sh` calls them through plain `gh`), and CI status is precisely the merge/verdict gate criterion 3 protects — so the correct action was to lock that in, not extend it.
3. **Correctness-critical reads left uncached, documented** — every carve-out above carries an inline `Plain gh — NOT "$GH_READ"` comment with its reason at the call site, plus a summary table per skill. No correctness-critical read was weakened.
4. **No regression on state changes** — `gh pr checks` and `gh repo view` are passthrough in the wrapper (never cached at all); everything else is bounded at one TTL. Covered by the automated TTL-expiry test below.
5. **Mutation invalidation still covers these skills' writes** — closed via the literal-`gh` write + `--clear-cache` pattern (see above), and the wrapper's own argv/stdout invalidation is regression-tested (including invalidating a cached *listing* that contains the mutated PR).

## Test Plan

**Automated** (`bash defaults/scripts/tests/test-gh-cached.sh` — 20/20 pass; hermetic stub `gh` + temp `GH_CACHE_DIR`):

- repeated `pr list` / `issue list` / `pr view` issue exactly ONE real `gh` call; distinct args are distinct keys
- `--no-cache` bypasses a warm entry
- `pr checks` (CI gate) and `repo view` (liveness probe) are **never** cached — the carve-outs
- TTL expiry: a state change is still cached *within* the window and **is** observed *after* it (no indefinite masking)
- a wrapped `pr edit` / `pr comment` invalidates both the cached `pr view` of that PR **and** the cached listing containing it
- `--clear-cache` drops the warm entry; failing reads (non-zero exit) are never memoized; the skills' `--version` resolution probe succeeds

`bash defaults/scripts/tests/test-forge-helpers.sh` — 39/39 pass, including 3 new assertions that `forge_get_check_runs` / `forge_get_commit_status` reach plain `gh` and never pass the wrapper-only `--no-cache` flag (so a future "cache everything" pass must delete a failing test rather than silently weaken a merge gate).

`bash defaults/scripts/tests/run-ci-suites.sh` — 74/76 wired suites pass. The 2 failures (`test-loom-dispatcher.sh`, `test-safehoused-service.sh`) **reproduce unchanged on `main`** and are unrelated to this PR. `shellcheck --severity=warning` clean on both touched suites; `check-ci-suite-manifest.sh` OK (80 suites accounted for).

**Manual verification is required and inherently cannot be unit-tested** — the assertions above use a stub `gh`, so they prove the wrapper's semantics but not the live hit rate. The three runtime checks are documented in `defaults/docs/gh-cached.md` § Verification → Manual, and should be run once against a live repo:

1. **Hit rate** — `"$GH_READ" --clear-cache`, run a Judge or sweep pass, then `"$GH_READ" --cache-stats`; expect non-zero hits with misses concentrated on first-touch reads (`GH_CACHE_DEBUG=1` for the call-by-call view).
2. **State change within one TTL** — poll the cached discovery reads while a PR's CI completes; the new state must appear within ≤30s, not be masked indefinitely.
3. **Same-session mutation invalidation** — read a PR through the wrapper, mutate it, re-read; a stale answer means the `--clear-cache` step was skipped.

## Notes

- `.loom/` installed copies are intentionally **not** resynced here (that is the periodic `chore: resync installed Loom surfaces` commit's job, made from the main checkout after merge). In this repo `.loom/scripts` is a symlink to `defaults/scripts`, so the wrapper path in the docs already resolves; `.loom/docs/gh-cached.md` appears at the next resync.
- On Gitea (`FORGE_TYPE=gitea`) every documented command resolves to plain `gh`/`gitea_api` — this change is a no-op there, as noted in the doc's scope section.

Closes #4667
