### PR TITLE
fix(resync): stage installed copies and rename them into place

### DIFF
--- a/defaults/docs/troubleshooting.md
+++ b/defaults/docs/troubleshooting.md
@@ -720,6 +720,21 @@ export `LOOM_RESYNC_ALLOW_WORKTREE=1`); it then proceeds with a warning naming t
 main-checkout target. Running from the main checkout — including any subdirectory
 of it — is unaffected.
 
+**It can safely update itself (#4669).** `resync-installed.sh` is one of the files
+under `defaults/scripts/`, so every run copies a newer version over the very path
+the running Bash process is still reading from. It used to do that with an
+in-place `cp`, which truncates and rewrites the destination: Bash then resumed
+reading its own (now shorter) script at a stale byte offset and either died with
+`syntax error near unexpected token` or fell off the end mid-run — leaving dozens
+of surfaces refreshed, the rest stale, and no summary saying so. Now every file
+is staged beside its destination and `rename(2)`-d into place (atomic; the
+already-open inode is left intact), and the self-copy is additionally **deferred
+until every other surface has settled**. If a file cannot be staged or renamed
+(read-only mount, permissions, no disk space) the run still finishes the
+remaining files and then prints an explicit **`PARTIAL REFRESH`** block naming
+every failed path and **exits `1`** — nothing is ever half-written, so fixing the
+cause and re-running completes the refresh.
+
 The intended flow is **"freshness warning says you're stale → run resync"**:
 
 ```bash

--- a/defaults/scripts/resync-installed.sh
+++ b/defaults/scripts/resync-installed.sh
@@ -60,6 +60,25 @@
 # (never a reason to skip the gate) but does not commit on the operator's
 # behalf.
 #
+# ATOMIC WRITES + DEFERRED SELF-UPDATE (#4669): every file is installed by
+# staging a copy NEXT TO its destination and rename(2)-ing it into place, never
+# by truncating and rewriting the destination in place. This matters most for
+# THIS script: resync-installed.sh is itself a file under defaults/scripts/, so
+# a resync copies it over the very path the running bash process is still
+# reading from. The old in-place `cp` let bash resume reading a half-rewritten
+# file at a now-meaningless byte offset — the reported `syntax error near
+# unexpected token` mid-run, which aborted the run and left dozens of surfaces
+# partially refreshed. A rename swaps the directory entry and leaves the
+# already-open inode intact, so the running process keeps reading the exact
+# bytes it started with. Belt-and-suspenders, the self-copy is also DEFERRED:
+# it is applied only after every other surface has settled.
+#
+# A file that cannot be staged or renamed is counted as a FAILURE: the run
+# still finishes the remaining files, then prints an explicit PARTIAL summary
+# naming every failed path and exits 1. No file is ever left half-written
+# (staging happens off to the side), so re-running after fixing the cause
+# completes the refresh — a partial refresh is never silent.
+#
 # EXPLICITLY OUT OF SCOPE (never touched by resync — updated by other mechanisms):
 #   .loom/config.json       - operator-owned; needs merge-semantics design
 #   CLAUDE.md               - repo-customized at install; needs managed-section markers
@@ -114,8 +133,9 @@
 #
 # Exit codes:
 #   0 - Success. Sync applied (or already in sync); or --dry-run found no drift.
-#   1 - Error (not in a git repo, the source tree could not be located, or
-#       invoked from a linked worktree without --allow-worktree).
+#   1 - Error (not in a git repo, the source tree could not be located,
+#       invoked from a linked worktree without --allow-worktree, or one or more
+#       files could not be synced — see the PARTIAL summary block, #4669).
 #   2 - --dry-run only: drift detected (one or more files WOULD be updated).
 #       Lets callers (e.g. the #3770 warning) use --dry-run as a cheap check.
 #
@@ -339,6 +359,65 @@ is_loom_internal() {
 N_UPDATED=0
 N_UNCHANGED=0
 N_SKIPPED=0
+# #4669: files that could not be staged/renamed into place. A non-empty list
+# means the refresh is PARTIAL and must be reported as such (exit 1), never
+# swallowed into a "success" summary.
+N_FAILED=0
+FAILED_RELS=()
+
+record_failure() {
+    N_FAILED=$((N_FAILED + 1))
+    FAILED_RELS+=("$1")
+}
+
+# ---------- atomic staging + self-update deferral (#4669) ----------
+
+# Physical absolute path of a FILE (abs_path above only resolves directories).
+abs_file_path() {
+    local p="$1" d b dir_abs
+    d="$(dirname "$p")"
+    b="$(basename "$p")"
+    dir_abs="$(abs_path "$d")"
+    [[ "$dir_abs" == "/" ]] && dir_abs=""
+    printf '%s/%s' "$dir_abs" "$b"
+}
+
+# Octal permission bits of a path, or "" when unavailable (GNU stat, then BSD).
+file_mode() {
+    local p="$1" m
+    m="$(stat -c '%a' "$p" 2>/dev/null)" || m=""
+    if [[ -z "$m" ]]; then
+        m="$(stat -f '%OLp' "$p" 2>/dev/null)" || m=""
+    fi
+    printf '%s' "$m"
+}
+
+# The file this bash process is executing. Its installed counterpart is synced
+# LAST (apply_deferred_self_sync), so nothing rewrites it mid-run.
+SELF_PATH=""
+SELF_BASE=""
+if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
+    SELF_PATH="$(abs_file_path "${BASH_SOURCE[0]}")"
+    SELF_BASE="${SELF_PATH##*/}"
+fi
+DEFER_SELF=1
+SELF_SRC=""
+SELF_DST=""
+SELF_REL=""
+
+# The staging file currently in flight, removed on any exit so a killed run
+# never leaves `.resync-stage.*` dirt behind in an installed surface directory.
+STAGED_TMP=""
+# shellcheck disable=SC2329  # invoked indirectly via the EXIT trap below
+cleanup_staged_tmp() {
+    [[ -n "$STAGED_TMP" && -e "$STAGED_TMP" ]] && rm -f "$STAGED_TMP" 2>/dev/null
+    STAGED_TMP=""
+    return 0
+}
+trap cleanup_staged_tmp EXIT
+trap 'cleanup_staged_tmp; exit 130' INT
+trap 'cleanup_staged_tmp; exit 143' TERM
+trap 'cleanup_staged_tmp; exit 129' HUP
 
 # ---------- per-file sync ----------
 #
@@ -347,8 +426,24 @@ N_SKIPPED=0
 #   installed file's executable bit expectation. Only files that exist in the
 #   source tree ever reach this function, so repo-specific installed files with
 #   no source counterpart are never touched.
+#
+#   The copy is ALWAYS staged beside the destination and renamed into place
+#   (#4669) — never written in place — so no reader can observe a partial file.
 sync_one() {
     local src="$1" dst="$2" rel="$3"
+
+    # #4669: never rewrite the script this process is executing while the rest
+    # of the run is still in flight. Record it and apply it once every other
+    # surface has settled (apply_deferred_self_sync). The basename test is a
+    # cheap pre-filter so the path resolution (two subshells) runs at most once
+    # per surface walk instead of once per file.
+    if [[ "$DEFER_SELF" -eq 1 && -n "$SELF_PATH" && "${dst##*/}" == "$SELF_BASE" && \
+          "$(abs_file_path "$dst")" == "$SELF_PATH" ]]; then
+        SELF_SRC="$src"
+        SELF_DST="$dst"
+        SELF_REL="$rel"
+        return 0
+    fi
 
     if is_ignored "$rel"; then
         note "  ${YELLOW}skipped${NC}   $rel ${YELLOW}(pinned in .loom/resync-ignore)${NC}"
@@ -373,7 +468,6 @@ sync_one() {
     fi
 
     # src and dst differ (or dst is missing) — this is an update.
-    N_UPDATED=$((N_UPDATED + 1))
     local verb_past="updated" verb_pres="update"
     if [[ ! -f "$dst" ]]; then
         verb_past="created"
@@ -381,21 +475,89 @@ sync_one() {
     fi
 
     if [[ "$DRY_RUN" -eq 1 ]]; then
+        N_UPDATED=$((N_UPDATED + 1))
         printf '%b\n' "  ${BOLD}would ${verb_pres}${NC} $rel"
         return 0
     fi
 
-    mkdir -p "$(dirname "$dst")"
-    if cp "$src" "$dst" 2>/dev/null; then
-        # Match the executable bit of the source (defaults/ scripts/hooks are +x).
-        if [[ -x "$src" ]]; then
-            chmod +x "$dst" 2>/dev/null || true
-        fi
-        printf '%b\n' "  ${GREEN}${verb_past}${NC}   $rel"
-    else
-        err "failed to copy $rel"
+    local dst_dir mode
+    dst_dir="$(dirname "$dst")"
+    mkdir -p "$dst_dir" 2>/dev/null
+
+    # #4669: stage beside the destination, then rename. rename(2) is atomic
+    # within a filesystem and replaces the DIRECTORY ENTRY rather than
+    # truncating the destination's inode, so a process that already has the
+    # destination open (most importantly: this script syncing itself) keeps
+    # reading intact bytes, and an interrupted run can never leave a truncated
+    # installed file behind.
+    STAGED_TMP="$(mktemp "$dst_dir/.resync-stage.XXXXXX" 2>/dev/null)" || STAGED_TMP=""
+    if [[ -z "$STAGED_TMP" ]]; then
+        err "failed to stage $rel (cannot create a temp file in $dst_dir)"
+        record_failure "$rel"
         return 1
     fi
+
+    if ! cp "$src" "$STAGED_TMP" 2>/dev/null; then
+        err "failed to copy $rel"
+        cleanup_staged_tmp
+        record_failure "$rel"
+        return 1
+    fi
+
+    # mktemp creates the staging file 0600, so the rename would otherwise change
+    # the installed file's permissions: restore the destination's current mode
+    # (or the source's, when creating a new file) before swapping it in...
+    mode="$(file_mode "$dst")"
+    [[ -n "$mode" ]] || mode="$(file_mode "$src")"
+    if [[ -n "$mode" ]]; then
+        chmod "$mode" "$STAGED_TMP" 2>/dev/null || true
+    fi
+    # ...then match the executable bit of the source (defaults/ scripts/hooks are +x).
+    if [[ -x "$src" ]]; then
+        chmod +x "$STAGED_TMP" 2>/dev/null || true
+    fi
+
+    if mv -f "$STAGED_TMP" "$dst" 2>/dev/null; then
+        STAGED_TMP=""
+        N_UPDATED=$((N_UPDATED + 1))
+        printf '%b\n' "  ${GREEN}${verb_past}${NC}   $rel"
+        return 0
+    fi
+
+    err "failed to install $rel (could not rename the staged copy into place)"
+    cleanup_staged_tmp
+    record_failure "$rel"
+    return 1
+}
+
+# ---------- deferred self-update (#4669) ----------
+#
+# Applied after every other surface has settled: at this point nothing else in
+# the run needs the old copy, and the atomic rename in sync_one leaves this
+# process's already-open inode untouched, so the remaining steps below
+# (metadata re-stamp, .gitignore refresh, audit, summary) still execute the
+# exact bytes this run started with.
+apply_deferred_self_sync() {
+    [[ -n "$SELF_DST" ]] || return 0
+    local src="$SELF_SRC" dst="$SELF_DST" rel="$SELF_REL" rc=0
+    SELF_SRC=""
+    SELF_DST=""
+    SELF_REL=""
+    DEFER_SELF=0
+
+    if ! is_ignored "$rel" && ! cmp -s "$src" "$dst" 2>/dev/null; then
+        note "  ${BLUE}(deferred to last: $rel is the script running this resync)${NC}"
+    fi
+
+    sync_one "$src" "$dst" "$rel" || rc=$?
+    DEFER_SELF=1
+
+    if [[ $rc -ne 0 ]]; then
+        err "The running resync script could NOT update itself: $rel"
+        err "  Other installed surfaces were refreshed, so this install is now MIXED."
+        err "  Recover with: cp '$src' '$dst'"
+    fi
+    return 0
 }
 
 # ---------- generic recursive surface resync (#4239) ----------
@@ -526,6 +688,12 @@ fi
 if [[ -d "$REPO_ROOT/.claude/commands/loom" ]]; then
     resync_tree "$DEFAULTS_DIR/.claude/commands/loom" "$REPO_ROOT/.claude/commands/loom" "commands/loom" ".claude/commands/loom"
 fi
+
+# ---------- install the deferred self-copy, now that every surface settled ----
+#
+# The scripts walk above records (rather than applies) a sync of the script this
+# process is executing; apply it here, last, via the same atomic staging path.
+apply_deferred_self_sync
 
 # ---------- targeted field edit: loom-workspace package.json version (#4285) ----------
 #
@@ -833,7 +1001,7 @@ suggest_commit_if_resync_only_dirt() {
     note "${BLUE}[resync] The tree is dirty with only resync output above — stage and commit it so the main-health gate doesn't skip on it:${NC}"
     printf '%b\n' "    ${BOLD}git add ${resync_paths[*]} && git commit -m 'chore: resync installed Loom surfaces'${NC}"
 }
-[[ "$DRY_RUN" -eq 1 ]] || suggest_commit_if_resync_only_dirt
+[[ "$DRY_RUN" -eq 1 || "$N_FAILED" -gt 0 ]] || suggest_commit_if_resync_only_dirt
 
 # ---------- summary ----------
 
@@ -846,6 +1014,22 @@ if [[ "$DRY_RUN" -eq 1 ]]; then
     fi
     printf '%b\n' "${GREEN}[resync] DRY RUN: already in sync (${N_UNCHANGED} unchanged, ${N_SKIPPED} skipped).${NC}"
     exit 0
+fi
+
+# A failed file makes the refresh PARTIAL — say so explicitly and exit non-zero
+# rather than folding it into a success summary (#4669). Nothing is ever left
+# half-written (every copy is staged off to the side and renamed), so the
+# recovery is simply "fix the cause, re-run".
+if [[ "$N_FAILED" -gt 0 ]]; then
+    printf '%b\n' "${RED}${BOLD}[resync] PARTIAL REFRESH: ${N_FAILED} file(s) could NOT be synced (${N_UPDATED} updated, ${N_UNCHANGED} unchanged, ${N_SKIPPED} skipped).${NC}"
+    printf '%b\n' "${RED}Failed to sync:${NC}"
+    for failed_rel in "${FAILED_RELS[@]}"; do
+        printf '%b\n' "${RED}    $failed_rel${NC}"
+    done
+    printf '%b\n' "${YELLOW}This install is now MIXED: the ${N_UPDATED} file(s) reported above are current, the failed ones are still stale.${NC}"
+    printf '%b\n' "${YELLOW}No file was left half-written (each copy is staged beside its destination and renamed atomically),${NC}"
+    printf '%b\n' "${YELLOW}so fixing the cause (permissions, disk space, read-only mount) and re-running completes the refresh.${NC}"
+    exit 1
 fi
 
 if [[ "$N_UPDATED" -gt 0 ]]; then

--- a/defaults/scripts/tests/test-resync-installed.sh
+++ b/defaults/scripts/tests/test-resync-installed.sh
@@ -26,6 +26,13 @@
 #   (q) invoked from a linked worktree -> non-zero exit, NOTHING written to main
 #   (r) --allow-worktree / LOOM_RESYNC_ALLOW_WORKTREE=1 -> permitted (warns)
 #   (s) main checkout (incl. a subdirectory of it)      -> unaffected, exit 0
+# Self-update safety (#4669):
+#   (t) the REAL script, installed as a padded "older" copy, resyncs itself from
+#       a substantially different newer source -> run completes, no mid-run
+#       syntax error, self-copy applied LAST, other surfaces fully refreshed
+#   (u) an updated file gets a new inode (staged + renamed, not truncated) with
+#       its permissions preserved, and leaves no .resync-stage.* dirt
+#   (v) an unsyncable file -> explicit PARTIAL REFRESH report + exit 1
 # Plus contract checks:
 #   - --help prints usage (documenting --allow-worktree), exit 0
 #   - unknown arg exits 1
@@ -791,6 +798,161 @@ if [[ "$(cat "$REPO/.loom/hooks/guard.sh")" == "A" ]]; then
     pass "(#4563) run from a main-checkout subdirectory still applies the resync"
 else
     fail "(#4563) run from a main-checkout subdirectory did not apply the resync"
+fi
+
+# --- (#4669) the resync must survive updating the script it is running -------
+#
+# resync-installed.sh is itself a file under defaults/scripts/, so every run
+# copies a newer version over the very path the running bash process is still
+# reading from. The old in-place `cp` truncated and rewrote that file, letting
+# bash resume reading the (shorter) new file at a stale byte offset -> `syntax
+# error near unexpected token`, aborting the run with dozens of surfaces
+# already partially refreshed.
+#
+# This drives the REAL script as the installed/running copy, padded so it
+# differs substantially in both content and byte offsets from the newer source
+# that replaces it mid-run — the exact reported scenario.
+echo "Test group 18: self-update is atomic + deferred; the run completes (#4669)"
+
+# Builds $1/.loom/scripts/resync-installed.sh as a padded "older" variant of the
+# real script, with the real script as the defaults/ source it will sync from.
+make_self_update_fixture() {
+    local repo="$1"
+    mkdir -p "$repo/defaults/scripts" "$repo/.loom/scripts"
+    cp "$SCRIPT" "$repo/defaults/scripts/resync-installed.sh"
+    chmod +x "$repo/defaults/scripts/resync-installed.sh"
+    {
+        head -n 1 "$SCRIPT"
+        awk 'BEGIN { for (i = 0; i < 6000; i++) print "# old-installed-version padding line " i }'
+        tail -n +2 "$SCRIPT"
+    } > "$repo/.loom/scripts/resync-installed.sh"
+    chmod +x "$repo/.loom/scripts/resync-installed.sh"
+}
+
+REPO="$(make_fixture)"
+make_self_update_fixture "$REPO"
+INSTALLED_RESYNC="$REPO/.loom/scripts/resync-installed.sh"
+RC=0; OUT="$(cd "$REPO" && bash "$INSTALLED_RESYNC" 2>&1)" || RC=$?
+if [[ $RC -eq 0 ]]; then
+    pass "(#4669) a self-updating run completes cleanly (exit 0)"
+else
+    fail "(#4669) a self-updating run did not exit 0 (got $RC)"
+fi
+if grep -qiE "syntax error|unexpected token|unexpected end of file" <<<"$OUT"; then
+    fail "(#4669) the running script observed a half-written copy of itself: $(grep -iE "syntax error|unexpected token|unexpected end of file" <<<"$OUT" | head -1)"
+else
+    pass "(#4669) no mid-run syntax error from the rewritten script"
+fi
+if cmp -s "$REPO/defaults/scripts/resync-installed.sh" "$INSTALLED_RESYNC"; then
+    pass "(#4669) the installed resync script was updated to match defaults/"
+else
+    fail "(#4669) the installed resync script was not updated"
+fi
+if [[ -x "$INSTALLED_RESYNC" ]] && bash -n "$INSTALLED_RESYNC" 2>/dev/null; then
+    pass "(#4669) the updated installed script is executable and syntactically whole"
+else
+    fail "(#4669) the updated installed script is not executable/parseable"
+fi
+# The self-update must not cost the rest of the refresh (the reported failure
+# left unrelated surfaces half-refreshed).
+if [[ "$(cat "$REPO/.loom/hooks/guard.sh")" == "A" && -f "$REPO/.loom/scripts/lib/bar.sh" && \
+      "$(cat "$REPO/.loom/roles/builder.md")" == "ROLE-NEW" && \
+      "$(cat "$REPO/.claude/commands/loom/builder.md")" == "CMD-NEW" ]]; then
+    pass "(#4669) every other surface was still fully refreshed in the same run"
+else
+    fail "(#4669) the self-updating run left other surfaces unrefreshed"
+fi
+# Deferral: the self-copy is applied only after every other surface settled.
+SELF_LINE="$(grep -n "scripts/resync-installed.sh" <<<"$OUT" | tail -1 | cut -d: -f1)"
+OTHER_LINE="$(grep -n "commands/loom/builder.md" <<<"$OUT" | tail -1 | cut -d: -f1)"
+if [[ -n "$SELF_LINE" && -n "$OTHER_LINE" && "$SELF_LINE" -gt "$OTHER_LINE" ]]; then
+    pass "(#4669) the self-copy is applied last, after the other surfaces"
+else
+    fail "(#4669) the self-copy was not deferred to the end (self=$SELF_LINE other=$OTHER_LINE)"
+fi
+# Rerunning the freshly-updated installed copy is a clean no-op.
+RC=0; OUT="$(cd "$REPO" && bash "$INSTALLED_RESYNC" 2>&1)" || RC=$?
+if [[ $RC -eq 0 ]] && grep -q "Already in sync" <<<"$OUT"; then
+    pass "(#4669) rerunning the updated installed copy is idempotent (already in sync)"
+else
+    fail "(#4669) rerunning the updated installed copy was not a clean no-op (rc=$RC)"
+fi
+# --dry-run must still preview the self-update without writing it.
+REPO="$(make_fixture)"
+make_self_update_fixture "$REPO"
+INSTALLED_RESYNC="$REPO/.loom/scripts/resync-installed.sh"
+cp "$INSTALLED_RESYNC" "$WORKDIR/self-before-dry-run"
+RC=0; OUT="$(cd "$REPO" && bash "$INSTALLED_RESYNC" --dry-run 2>&1)" || RC=$?
+if [[ $RC -eq 2 ]] && grep -q "scripts/resync-installed.sh" <<<"$OUT"; then
+    pass "(#4669) --dry-run previews the self-update (exit 2)"
+else
+    fail "(#4669) --dry-run did not preview the self-update (rc=$RC)"
+fi
+if cmp -s "$WORKDIR/self-before-dry-run" "$INSTALLED_RESYNC"; then
+    pass "(#4669) --dry-run left the running script byte-identical"
+else
+    fail "(#4669) --dry-run modified the running script"
+fi
+
+# --- (#4669) writes are staged + renamed, never done in place ----------------
+echo "Test group 19: installed files are replaced by atomic rename (#4669)"
+REPO="$(make_fixture)"
+INODE_BEFORE="$(ls -i "$REPO/.loom/hooks/guard.sh" | awk '{print $1}')"
+MODE_BEFORE="$(ls -l "$REPO/.loom/docs/troubleshooting.md" | awk '{print $1}')"
+(cd "$REPO" && bash "$SCRIPT" >/dev/null 2>&1)
+INODE_AFTER="$(ls -i "$REPO/.loom/hooks/guard.sh" | awk '{print $1}')"
+MODE_AFTER="$(ls -l "$REPO/.loom/docs/troubleshooting.md" | awk '{print $1}')"
+if [[ -n "$INODE_BEFORE" && "$INODE_BEFORE" != "$INODE_AFTER" ]]; then
+    pass "(#4669) an updated file gets a NEW inode (renamed into place, not truncated)"
+else
+    fail "(#4669) the updated file kept its inode (still rewritten in place)"
+fi
+if [[ "$MODE_BEFORE" == "$MODE_AFTER" ]]; then
+    pass "(#4669) the rename preserves the destination's permissions (not mktemp's 0600)"
+else
+    fail "(#4669) permissions changed across the rename ($MODE_BEFORE -> $MODE_AFTER)"
+fi
+STRAY_STAGE="$(find "$REPO" -name '.resync-stage.*' 2>/dev/null | wc -l | tr -d '[:space:]')"
+if [[ "$STRAY_STAGE" == "0" ]]; then
+    pass "(#4669) no staging temp files are left behind"
+else
+    fail "(#4669) $STRAY_STAGE staging temp file(s) left behind"
+fi
+
+# --- (#4669) a failed file is reported as a PARTIAL refresh, never swallowed --
+echo "Test group 20: an unsyncable file reports a PARTIAL refresh and exits 1 (#4669)"
+if [[ "$(id -u)" -eq 0 ]]; then
+    skip "(#4669) running as root — an unwritable destination cannot be simulated"
+else
+    REPO="$(make_fixture)"
+    chmod 500 "$REPO/.loom/scripts/lib"      # scripts/lib/bar.sh cannot be staged here
+    RC=0; OUT="$(cd "$REPO" && bash "$SCRIPT" 2>&1)" || RC=$?
+    chmod 700 "$REPO/.loom/scripts/lib"
+    if [[ $RC -eq 1 ]]; then
+        pass "(#4669) an unsyncable file exits 1"
+    else
+        fail "(#4669) an unsyncable file did not exit 1 (got $RC)"
+    fi
+    if grep -q "PARTIAL REFRESH" <<<"$OUT" && grep -q "scripts/lib/bar.sh" <<<"$OUT"; then
+        pass "(#4669) the summary names the partial state and the failed path"
+    else
+        fail "(#4669) the summary did not report the partial state / failed path"
+    fi
+    if grep -qi "re-running completes the refresh\|fixing the cause" <<<"$OUT"; then
+        pass "(#4669) the summary states the recovery action"
+    else
+        fail "(#4669) the summary does not state a recovery action"
+    fi
+    if [[ "$(cat "$REPO/.loom/hooks/guard.sh")" == "A" ]]; then
+        pass "(#4669) unrelated surfaces are still refreshed despite the failure"
+    else
+        fail "(#4669) the failure aborted the rest of the refresh"
+    fi
+    if grep -q "Already in sync\|file(s) updated," <<<"$OUT"; then
+        fail "(#4669) a partial refresh still printed a success summary"
+    else
+        pass "(#4669) no success summary is printed for a partial refresh"
+    fi
 fi
 
 # --- contract checks ---------------------------------------------------------


### PR DESCRIPTION
## Summary

`resync-installed.sh` syncs every file under `defaults/scripts/` — **including itself** — with an in-place `cp`, which truncates and rewrites the destination. When that destination is the very path the running bash process is still reading from, bash resumes at a now-meaningless byte offset in the newer, differently-sized file. The reporter saw `syntax error near unexpected token \`(\`` at line 389 (the `cp` call itself); in my reproduction the run instead falls silently off the end. Either way the run stops right after the scripts walk, leaving the roles/docs/bin/commands surfaces stale, the metadata unstamped, and no summary saying anything went wrong.

Reproduced against `origin/main` (padded "older" installed copy resyncing itself from the newer source):

```
Resyncing .loom/hooks/ ...
  updated   hooks/guard.sh
Resyncing .loom/scripts/ ...
  created   scripts/lib/bar.sh
  updated   scripts/resync-installed.sh
RC=0                                   <- run ends here, silently
--- roles/builder.md: ROLE-OLD         <- never refreshed
```

## Changes

- **`defaults/scripts/resync-installed.sh`**
  - `sync_one()` no longer writes the destination in place. Each copy is staged as `.resync-stage.XXXXXX` **beside** its destination and `mv`-ed into place: `rename(2)` is atomic within a filesystem and swaps the *directory entry*, so an already-open inode (this script's own) stays intact and no reader can ever observe a partial file. This also removes the pre-existing "killed mid-`cp` leaves a truncated installed file" hazard for every surface, not just the self case.
  - Permissions are preserved across the swap: `mktemp` creates the staging file `0600`, so the destination's existing mode (or the source's, for a newly created file) is restored before the rename, then the source's executable bit is honored exactly as before.
  - The self-copy is additionally **deferred**: the scripts walk records it (`SELF_PATH` vs. the resolved destination, behind a cheap basename pre-filter) and `apply_deferred_self_sync()` installs it *after every other surface has settled*.
  - A file that cannot be staged or renamed is now counted as a **failure**. The run finishes the remaining files and then prints an explicit `PARTIAL REFRESH` block naming every failed path, and **exits 1**, instead of folding a partial state into a success summary (the resync-only-dirt commit hint is suppressed in that state too). An `EXIT`/`INT`/`TERM`/`HUP` trap removes any in-flight staging file, so a killed run leaves no `.resync-stage.*` dirt behind.
  - Header comment + exit-code documentation updated (`--help` is derived from it).
- **`defaults/scripts/tests/test-resync-installed.sh`** — three new groups (17 assertions), described below.
- **`defaults/docs/troubleshooting.md`** — documents the self-update safety property and the new `PARTIAL REFRESH` / exit-1 state in the resync section.

## Acceptance Criteria Verification

- [x] **Never truncates/replaces the script the current process is reading from** — every write is `mktemp` + `mv`; the running process keeps its original inode. Test group 19 asserts an updated file gets a **new inode** (fails against pre-fix `cp`).
- [x] **Stage a newer self-copy atomically and defer installing it** — both: atomic staging for all files, plus `apply_deferred_self_sync()` after the surface walks. Test group 18 asserts the self-copy's report line comes *after* the last other-surface line. (Re-exec was deliberately not used: with rename semantics the running process is already safe, and a re-exec adds a restart/loop failure mode for no gain.)
- [x] **A self-update failure cannot silently leave unrelated surfaces partially refreshed** — failures are counted, named, and exit 1 with a stated recovery action; the deferred self-sync additionally prints an explicit "this install is now MIXED / recover with `cp <src> <dst>`" message. Test group 20.
- [x] **Regression test running an older resync script against a newer source with substantial changes to `resync-installed.sh` itself** — test group 18 installs the **real** script padded with 6000 lines as the running copy and resyncs it from the unpadded source. 8 of the 17 new assertions **fail against the pre-fix script** (verified by running the new suite against `git show origin/main:defaults/scripts/resync-installed.sh`).
- [x] **Dry-run and apply remain idempotent** — existing groups 2/4/7 plus new assertions: `--dry-run` previews the self-update (exit 2) and leaves the running script byte-identical; rerunning the freshly-updated installed copy reports "Already in sync". Verified on Bash 5.2 (this host) and at real scale (253-file full `defaults/` tree: 3 updated → rerun clean no-op, 0.5s, no staging dirt, mode `-rwxrwxr-x` preserved).
  - **Bash 3.2**: no 3.2 interpreter is available on this host, so this was verified by construction rather than execution — the new code uses only 3.2-safe constructs (`arr+=(x)` is 3.1+, `${BASH_SOURCE[0]:-}`, `${var##*/}`, `trap`), and the one `set -u` array hazard (`"${FAILED_RELS[@]}"` on an empty array, which errors in bash < 4.4) is guarded behind `N_FAILED -gt 0`. `mktemp <template-with-6-X>`, `stat -c` → `stat -f '%OLp'` fallback, and `mv -f` cover BSD/macOS userland. Flagging explicitly for the Judge.

## Test Plan

- [x] `bash -n` + `shellcheck --severity=warning` clean on both touched scripts.
- [x] `bash defaults/scripts/tests/test-resync-installed.sh` → **105/105 passed** (was 88; +17).
- [x] Same suite run against the **pre-fix** script → 97/105, **8 failures**, confirming the tests actually capture the bug.
- [x] Full-scale manual smoke test in a scratch repo with the real `defaults/` tree (self-update applied last, run completes through metadata re-stamp + `.gitignore` refresh + summary, idempotent rerun, `--dry-run` exit 0 when in sync).
- [x] `bash scripts/test-installer.sh` → 175 passed, **1 pre-existing failure** in `test-loom-dispatcher.sh` ("config-selected codex path does not touch the claude runner"), which reproduces identically on a pristine `origin/main` checkout (96/99 there) — unrelated to this change, not fixed here per scope discipline.

Closes #4669