### PR TITLE
docs(sweep): add REST fallback for Mode B/C discovery under GraphQL exhaustion

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -63,7 +63,54 @@ Run this query **once at the start of Mode B label-token validation** and reuse 
 
 If a label token in the description is not in the repo's actual label set, **do not** silently fabricate a `--label <name>` filter — ask the user to clarify which existing label they meant, or supply explicit issue numbers.
 
-**Offline fallback.** If `gh label list` fails (non-zero exit — network outage, auth failure, rate limit), fall back to consulting `.github/labels.yml` and log a warning to stderr (e.g., `warning: gh label list failed, falling back to .github/labels.yml (Loom-managed subset only)`). This keeps the skill functional in offline or restricted environments. Note that `.github/labels.yml` is only the Loom-managed subset, so the fallback may produce false "unknown-label" rejections for labels added via the GitHub UI, Dependabot, or other project conventions; this is the trade-off for offline operation.
+**Offline fallback.** If `gh label list` fails (non-zero exit — network outage, auth failure, rate limit), fall back to consulting `.github/labels.yml` and log a warning to stderr (e.g., `warning: gh label list failed, falling back to .github/labels.yml (Loom-managed subset only)`). This keeps the skill functional in offline or restricted environments. Note that `.github/labels.yml` is only the Loom-managed subset, so the fallback may produce false "unknown-label" rejections for labels added via the GitHub UI, Dependabot, or other project conventions; this is the trade-off for offline operation. **When the failure is specifically a rate-limit rejection, this is the *last* rung, not the first** — try the REST label read described under "GraphQL-exhaustion fallback" below and drop to `.github/labels.yml` only if REST fails too, so a healthy REST budget still yields the complete live label set.
+
+**GraphQL-exhaustion fallback (REST issue discovery, #4670).** `gh issue list`, `gh pr list`, and `gh label list` are **GraphQL**-backed; `gh api repos/{owner}/{repo}/…` is **REST**. The two draw on **independent quotas** — confirmed live during the #4526 incident and again in the `/loom:sweep` run that filed #4670, where GraphQL was exhausted while >4,500 REST core requests were still available. So a candidate-resolution failure that is *specifically* a rate-limit rejection must be re-issued over REST rather than aborting the sweep. The full degradation ladder for Mode B is **GraphQL → REST → (labels only) `.github/labels.yml`**.
+
+1. **Detect exhaustion — reuse the existing signature table, do not derive a new one.** Capture the failing call's output with stderr merged (`2>&1`), lowercase it, and treat the failure as quota exhaustion **only** when it contains one of these five signatures. This is exactly the table `defaults/scripts/check-duplicate.sh`'s `is_rate_limit_error()` implements, itself mirrored from `loom-daemon/src/rate_limit_breaker.rs`'s `RATE_LIMIT_SIGNATURES` — the repo's tested ground truth for what `gh` actually prints:
+
+   | Signature (match case-insensitively) | Seen as |
+   |---|---|
+   | `api rate limit exceeded` | REST: `HTTP 403: API rate limit exceeded for …` |
+   | `api rate limit already exceeded` | GraphQL: `GraphQL: API rate limit already exceeded for user ID …` |
+   | `secondary rate limit` | either transport, burst throttling |
+   | `abuse detection mechanism` | either transport, burst throttling |
+   | `was submitted too quickly` | either transport, burst throttling |
+
+   The GraphQL and REST phrasings are **not** substrings of each other — the word `already` breaks the contiguous `api rate limit exceeded` match — which is why both are listed. Matching one substring is not enough.
+
+   **Anything else is NOT exhaustion — keep today's fail-safe behavior.** An auth failure (`gh auth status` expired, missing `GH_TOKEN` scope), a DNS/network error, an HTTP 404 on a mistyped repo, a rejected flag: report the error verbatim, do **not** retry over REST, and EXIT without spawning any agent. A blind REST retry on an auth failure just fails again with a more confusing message and buries the real cause. Never infer exhaustion from a bare non-zero exit code.
+
+2. **Resolve the repository locally — never with another GraphQL call.** Do **not** call `gh repo view --json nameWithOwner` to learn owner/repo: that call is itself GraphQL-backed, so under GraphQL exhaustion it fails *before* any REST fallback is attempted (#4659 fixed this exact bug in `check-duplicate.sh`). Two supported forms, both free of API calls:
+   - Preferred: write the endpoint with the literal `{owner}/{repo}` placeholder — `gh api "repos/{owner}/{repo}/issues?…"` — and let `gh` expand it locally from the git remote.
+   - When the literal `owner/repo` string is needed (log lines, `-R` flags): parse `git remote get-url origin`, strip a trailing `.git` and/or `/`, and take the final two `/`- or `:`-delimited segments (works for both the SSH `git@host:owner/repo.git` and HTTPS `https://host/owner/repo` forms) — the same parse `check-duplicate.sh`'s `get_repo_nwo()` performs.
+
+3. **Re-issue the query as a paginated REST listing.** Translate the Mode B flags you had derived:
+
+   | `gh issue list` flag | REST equivalent on `repos/{owner}/{repo}/issues` |
+   |---|---|
+   | `--state open` (default) | `state=open` (`--state all` → `state=all`; `--state closed` → `state=closed`) |
+   | `--label loom:issue` (repeatable) | `labels=loom:issue,loom:curated` — comma-separated is AND, matching repeated `--label` |
+   | `--author rjwalters` | `creator=rjwalters` (`@me` → resolve the login first with `gh api user --jq .login`, itself REST) |
+   | `--assignee X` | `assignee=X` |
+   | `--limit 100` | `per_page=100` plus `--paginate`, then truncate client-side to the requested limit |
+   | `--json number,title,labels,updatedAt` | already present in the REST payload — project with `--jq` (`updatedAt` is `updated_at`) |
+   | `--search "…"` | **not expressible** on `/issues`; use `gh api "search/issues?q=repo:{owner}/{repo}+…"` (REST search, its own 30/min quota) or ask the operator to narrow to flags / explicit issue numbers |
+
+   ```bash
+   "$GH_READ" api --paginate "repos/{owner}/{repo}/issues?state=open&labels=loom:issue&per_page=100" \
+     --jq '[.[] | select(.pull_request == null) | {number, title, labels: [.labels[].name], updatedAt: .updated_at}]'
+   ```
+
+   Candidate resolution is an observation read, so the REST retry routes through `$GH_READ` exactly like the GraphQL call it replaces (the wrapper caches `gh api` GETs too and degrades to plain `gh api` when absent). The **uncached carve-outs** listed under "Cached forge reads (`gh-cached`)" — claim arbitration, Mode C's C0 pre-flight, merge gating — stay on plain `gh api` if they need this fallback.
+
+   **`/issues` returns pull requests too.** GitHub's REST issue endpoint includes PRs; drop them with `select(.pull_request == null)` (what `check-duplicate.sh` does) or Mode B will resolve PR numbers as issue candidates.
+
+4. **Preserve every Mode B safeguard — this is a transport substitution, not a policy change.** Deduplicate the resulting numbers (preserve first-seen order) and union them with any explicit numeric tokens exactly as on the GraphQL path; keep the **explicit limit** (never rely on REST's default `per_page=30`, mirroring this skill's explicit-`--limit` convention); and apply the same edge-case rules — zero matches → print the resolved REST query and its empty result, then EXIT cleanly (edge case #1); results at the cap → warn that the set was truncated and ask the operator to narrow before proceeding (edge case #2). Because `--paginate` walks past the cap, the truncation point is now a client-side decision: state the cap you applied in that warning.
+
+5. **Announce the degradation.** Log one warning to stderr (e.g. `warning: gh issue list rate-limited (GraphQL quota exhausted), falling back to REST via gh api`) and repeat it above the candidate set shown at the confirmation gate, so the operator knows the plan was resolved over the fallback path.
+
+6. **Label validation degrades on the same ladder.** `gh label list` is GraphQL-backed, so under exhaustion the unknown-label guard goes `gh label list` → `"$GH_READ" api --paginate "repos/{owner}/{repo}/labels?per_page=100" --jq '.[].name'` (the live, complete label set — preferred) → `.github/labels.yml` (the "Offline fallback" above; Loom-managed subset only, so false "unknown-label" rejections are possible). Drop to the YAML only when the REST read also fails. **The unknown-label safety rule is unchanged at every rung**: never fabricate a `--label <name>` filter for a label you could not verify — ask the operator to clarify or supply explicit issue numbers.
 
 ### Mode C — PR-set mode (back half of the lifecycle: Judge → Doctor → Merge)
 
@@ -100,6 +147,24 @@ When uncertain whether the description means issues or PRs (e.g., `/loom:sweep a
 | "in the last week" / "from the last N days" | `--search "created:>=YYYY-MM-DD"` (compute the date) |
 
 Combine flags as needed. Always pass `--state open` explicitly (Mode C operates exclusively on open PRs — closed/merged PRs are skipped). Default to `--limit 100` rather than the `gh` default of `30` to avoid silent truncation. The same **unknown-label guard** (one `gh label list` call per invocation, with `.github/labels.yml` offline fallback) applies to PR labels too — PR and issue labels are in the same repo-wide label set.
+
+**GraphQL-exhaustion fallback (REST PR discovery, #4670).** `gh pr list` is GraphQL-backed and fails under the same quota exhaustion as `gh issue list`. Mode C uses the **identical ladder** documented in Mode B's "GraphQL-exhaustion fallback" — same five-signature detection table (`api rate limit exceeded` / `api rate limit already exceeded` / `secondary rate limit` / `abuse detection mechanism` / `was submitted too quickly`, matched case-insensitively against `2>&1` output), same rule that **any other failure — auth, network, 404 — is not exhaustion** and must fail safe with the error reported and no agents spawned, and the same local repo resolution (`gh api "repos/{owner}/{repo}/…"` placeholder expansion, or parsing `git remote get-url origin`; **never** `gh repo view --json nameWithOwner`, which is itself GraphQL-backed — #4659). Only the endpoint and the flag mapping differ:
+
+| `gh pr list` flag | REST equivalent on `repos/{owner}/{repo}/pulls` |
+|---|---|
+| `--state open` (mandatory in Mode C) | `state=open` |
+| `--limit 100` | `per_page=100` plus `--paginate`, truncated client-side to the requested limit |
+| `--json number,title,labels` | `number`, `title`, and `labels[].name` are all in the list payload — project with `--jq` |
+| `--label loom:review-requested` | **no `labels=` parameter on `/pulls`** — filter client-side on the payload's `labels[].name` (below), or list via `repos/{owner}/{repo}/issues?labels=…&state=open` and keep only entries where `.pull_request != null` |
+| `--author rjwalters` / `@me` | no `creator=` parameter on `/pulls` either — filter client-side on `.user.login` (resolve `@me` with `gh api user --jq .login`) |
+| `--search "…"` | not expressible; use `gh api "search/issues?q=repo:{owner}/{repo}+is:pr+…"` or ask the operator for explicit PR numbers |
+
+```bash
+"$GH_READ" api --paginate "repos/{owner}/{repo}/pulls?state=open&per_page=100" \
+  --jq '[.[] | {number, title, labels: [.labels[].name]} | select(.labels | index("loom:review-requested"))]'
+```
+
+All Mode C safeguards carry over unchanged: deduplicate the resulting PR numbers (preserve first-seen order), keep the explicit limit (never REST's default `per_page=30`), apply the zero-match (print query + empty result, EXIT cleanly) and truncation-warning edge cases, **display the candidate set and await confirmation before spawning any agents**, and log the degradation to stderr (e.g. `warning: gh pr list rate-limited (GraphQL quota exhausted), falling back to REST via gh api`) plus above the confirmation-gate listing. The unknown-label guard degrades on the same GraphQL → REST (`repos/{owner}/{repo}/labels`) → `.github/labels.yml` ladder as Mode B. Note that only **candidate discovery** may be served from `$GH_READ`; Mode C's C0 per-PR pre-flight is a deliberately uncached live routing read (see "Cached forge reads (`gh-cached`)") — if it too hits GraphQL exhaustion, its REST equivalent is plain `gh api "repos/{owner}/{repo}/pulls/<N>"` (plus `repos/{owner}/{repo}/issues/<N>` for the label set), never a cached read.
 
 **Mode C validation rules:**
 
@@ -162,7 +227,7 @@ Combine flags as needed. Always pass `--state open` explicitly (Mode C operates 
     ```bash
     "$GH_READ" issue list --state open --limit 100 --json number,title,labels,updatedAt
     ```
-    Every open issue is a candidate regardless of label — promotion, unblocking, stale-claim recovery, and epic fan-out happen per-issue per the "Aggressive candidate taxonomy" table below, not by pre-filtering the query (`updatedAt` feeds the staleness rule). `$GH_READ` is the cached-read wrapper (see "Cached forge reads (`gh-cached`)"); candidate resolution is a pure observation read — every claim decision is re-made from an **uncached** per-issue pre-flight read in Wave Lifecycle step 1, so a 30s-old listing cannot cause a stale claim. Pass `--limit 100` explicitly (never rely on gh's default of 30) and apply the existing **edge-case rules**: zero matches → print the resolved query + empty result and EXIT cleanly (edge case #1, do **not** fall through to any other mode); 100 candidates returned → warn about truncation and ask the operator to narrow (or deliberately raise `--limit`) before proceeding (edge case #2).
+    Every open issue is a candidate regardless of label — promotion, unblocking, stale-claim recovery, and epic fan-out happen per-issue per the "Aggressive candidate taxonomy" table below, not by pre-filtering the query (`updatedAt` feeds the staleness rule). `$GH_READ` is the cached-read wrapper (see "Cached forge reads (`gh-cached`)"); candidate resolution is a pure observation read — every claim decision is re-made from an **uncached** per-issue pre-flight read in Wave Lifecycle step 1, so a 30s-old listing cannot cause a stale claim. Pass `--limit 100` explicitly (never rely on gh's default of 30) and apply the existing **edge-case rules**: zero matches → print the resolved query + empty result and EXIT cleanly (edge case #1, do **not** fall through to any other mode); 100 candidates returned → warn about truncation and ask the operator to narrow (or deliberately raise `--limit`) before proceeding (edge case #2). If this call fails with a rate-limit signature, re-issue it over REST per Mode B's "GraphQL-exhaustion fallback" (`repos/{owner}/{repo}/issues?state=open&per_page=100`, PRs filtered out) — the sentinel's query is a `gh issue list` like any other.
   - **Orphaned-claim recovery pass (run once, AFTER the confirmation gate, before per-issue pre-flight)** — reclaim `loom:building` labels left behind by dead workers so stale claims don't mask buildable issues:
     ```bash
     ./.loom/scripts/recover-orphaned-shepherds.sh --recover
@@ -172,7 +237,7 @@ Combine flags as needed. Always pass `--state open` explicitly (Mode C operates 
     ```bash
     "$GH_READ" pr list --state open --limit 100 --json number,title,labels
     ```
-    Mode C's C0 pre-flight already skips PRs with no actionable label, `loom:operator-only`, or `loom:blocked`, and routes the rest by current label (Judge / Doctor → Judge / Merge) — so grabbing every open PR and letting C0 filter matches the "get every in-flight PR over the finish line" intent. Same zero-match / truncation edge-case rules apply.
+    Mode C's C0 pre-flight already skips PRs with no actionable label, `loom:operator-only`, or `loom:blocked`, and routes the rest by current label (Judge / Doctor → Judge / Merge) — so grabbing every open PR and letting C0 filter matches the "get every in-flight PR over the finish line" intent. Same zero-match / truncation edge-case rules apply, and the same rate-limit fallback: on a rate-limit signature, re-issue over REST per Mode C's "GraphQL-exhaustion fallback" (`repos/{owner}/{repo}/pulls?state=open&per_page=100`).
   - **Existing-PR routing (issues path)**: the sentinel adds **no** new PR-detection logic. Issues with an open linked PR are handed to the wave machinery, which routes an issue with one open linked PR to Judge (or Merge if the PR is already `loom:pr`) via the per-issue existing-PR probe (Wave Lifecycle step 1, #3359 + #3677 — the union of `closedByPullRequestsReferences` filtered to `state == OPEN` and timeline `cross-referenced` open-PR events, so a non-closing `Part of #N` PR is detected too). This is the single source of truth for existing-PR routing and **takes precedence over the label routing** in the taxonomy table (an issue with an open PR is driven to merge, never rebuilt).
   - **Mandatory confirmation gate**: the sentinel path **always** displays the resolved candidate set (with the per-issue planned action from the taxonomy table) and awaits operator confirmation before spawning any agent — identical to Mode B/C's "display candidate set before spawning any agents" rule. A whole-backlog sweep must never auto-dispatch silently. Declining EXITs cleanly. **When the resolved plan has an unavoidable same-file overlap** (more overlapping candidates than waves to spread them across — see "Overlap-aware wave partitioning"), print the overlap warning **above** the candidate listing, naming the shared files and the specific candidates, so the operator can reorder or drop to `--builders-per-wave 1` before confirming.
   - **Flag composition**: `--dry-run` resolves the candidate set, prints the standard issue-set (or PR-set) dry-run plan with wave grouping + the aggressive per-issue actions, and EXITs with no mutation (the Stage-0 dry-run contract is backend-independent — the orphaned-claim recovery pass is skipped under `--dry-run`). `--builders-per-wave N` and `--no-daemon` compose with the wave / Stage -1 machinery exactly as for Mode A/B. Stage -1 backend detection is unchanged: after `all` resolves the issue set, the normal strict-AND daemon/pool probe decides daemon-dispatch vs subagent fallthrough; `all --prs` (Mode C) always routes to the subagent path per the existing Mode C short-circuit.

--- a/loom-daemon/tests/sweep_md_doc_lint.rs
+++ b/loom-daemon/tests/sweep_md_doc_lint.rs
@@ -554,6 +554,222 @@ fn sweep_md_documents_explicit_hold_check_in_blocked_taxonomy_row() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Issue #4670 — GraphQL-exhaustion REST fallback for Mode B issue discovery and
+// Mode C PR discovery. GraphQL (`gh issue list` / `gh pr list` / `gh label
+// list`) and REST (`gh api repos/{owner}/{repo}/…`) draw on independent quotas,
+// so an exhausted GraphQL budget must not strand candidate resolution while
+// thousands of REST requests remain. The fallback is orchestrator-executed
+// prose (no script backs Mode B/C candidate discovery), so this doc-lint is the
+// only mechanical guard against a future edit silently deleting it.
+//
+// Per #3877: the detection signatures, REST endpoints, jq filters, and the
+// local repo-resolution command are CONTRACT (pinned EXACT — they are the
+// literal strings an orchestrator must reproduce); section lead-ins and the
+// fail-safe/ladder semantics are PROSE (pinned structurally / via tolerant
+// phrasing sets).
+// ---------------------------------------------------------------------------
+
+/// #4670: BOTH Mode B (issue discovery) and Mode C (PR discovery) carry a
+/// GraphQL-exhaustion fallback section — one before the `### Mode C` heading,
+/// one after. A single shared section in only one mode is the regression this
+/// ordering check exists to catch.
+#[test]
+fn sweep_md_documents_graphql_exhaustion_fallback_in_both_mode_b_and_mode_c() {
+    let content = read_sweep_md();
+
+    // PROSE (structural presence): the bold lead-in name is the anchor; the
+    // trailing "(REST issue discovery, #4670)" / "(REST PR discovery, #4670)"
+    // qualifiers are editorial and deliberately not pinned.
+    let occurrences = content.matches("GraphQL-exhaustion fallback").count();
+    assert!(
+        occurrences >= 2,
+        "sweep.md must document a `GraphQL-exhaustion fallback` in BOTH the \
+         Mode B (issue discovery) and Mode C (PR discovery) sections (#4670); \
+         found {occurrences} occurrence(s)"
+    );
+
+    let mode_c_heading = content
+        .find("### Mode C — PR-set mode")
+        .expect("sweep.md is missing the `### Mode C — PR-set mode` heading");
+    let first_fallback = content
+        .find("GraphQL-exhaustion fallback")
+        .expect("checked non-empty above");
+    let last_fallback = content
+        .rfind("GraphQL-exhaustion fallback")
+        .expect("checked non-empty above");
+
+    assert!(
+        first_fallback < mode_c_heading,
+        "sweep.md's first `GraphQL-exhaustion fallback` (byte offset \
+         {first_fallback}) must sit in the Mode B section, i.e. BEFORE the \
+         `### Mode C — PR-set mode` heading (byte offset {mode_c_heading}) — \
+         #4670 requires issue discovery to have its own REST fallback"
+    );
+    assert!(
+        last_fallback > mode_c_heading,
+        "sweep.md's last `GraphQL-exhaustion fallback` (byte offset \
+         {last_fallback}) must sit in the Mode C section, i.e. AFTER the \
+         `### Mode C — PR-set mode` heading (byte offset {mode_c_heading}) — \
+         #4670 requires PR discovery to have its own REST fallback"
+    );
+}
+
+/// #4670: the exhaustion-detection signature table is pinned EXACT. It mirrors
+/// `defaults/scripts/check-duplicate.sh`'s `is_rate_limit_error()` (itself
+/// mirrored from `loom-daemon/src/rate_limit_breaker.rs`'s
+/// `RATE_LIMIT_SIGNATURES`) — deriving a new, subtly different signature set is
+/// exactly the drift this pins against. Note that `api rate limit exceeded` and
+/// `api rate limit already exceeded` are NOT substrings of each other (the word
+/// "already" breaks the contiguous match), so both must be present.
+#[test]
+fn sweep_md_pins_rate_limit_signature_table() {
+    let content = read_sweep_md();
+
+    // CONTRACT: the five signature strings. Keep EXACT.
+    let signatures: &[&str] = &[
+        "api rate limit exceeded",
+        "api rate limit already exceeded",
+        "secondary rate limit",
+        "abuse detection mechanism",
+        "was submitted too quickly",
+    ];
+    for signature in signatures {
+        assert!(
+            content.contains(signature),
+            "sweep.md's GraphQL-exhaustion detection is missing the rate-limit \
+             signature `{signature}` (#4670) — the table must mirror \
+             check-duplicate.sh's is_rate_limit_error() / \
+             rate_limit_breaker.rs's RATE_LIMIT_SIGNATURES, not a new one"
+        );
+    }
+
+    // CONTRACT: the provenance pointers keep future editors on the shared
+    // table instead of re-deriving one. Keep EXACT (file/symbol names).
+    for needle in ["is_rate_limit_error()", "RATE_LIMIT_SIGNATURES"] {
+        assert!(
+            content.contains(needle),
+            "sweep.md must cite `{needle}` as the source of the rate-limit \
+             signature table (#4670)"
+        );
+    }
+}
+
+/// #4670: the REST endpoints, pagination parameters, and the PR-exclusion jq
+/// filter that make the fallback actually executable.
+#[test]
+fn sweep_md_pins_rest_fallback_endpoints_and_pagination() {
+    let content = read_sweep_md();
+
+    // CONTRACT: REST paths, pagination flags/params, and the jq filter are
+    // literal strings the orchestrator reproduces. Keep EXACT.
+    let contract_needles: &[&str] = &[
+        "repos/{owner}/{repo}/issues",   // Mode B REST listing
+        "repos/{owner}/{repo}/pulls",    // Mode C REST listing
+        "repos/{owner}/{repo}/labels",   // unknown-label guard REST rung
+        "--paginate",                    // paginated listing
+        "per_page=100",                  // explicit limit (never REST's 30)
+        "select(.pull_request == null)", // /issues returns PRs too
+    ];
+    for needle in contract_needles {
+        assert!(
+            content.contains(needle),
+            "sweep.md's REST fallback is missing contract token `{needle}` \
+             (#4670) — update sweep.md or this test if the change is intentional"
+        );
+    }
+}
+
+/// #4670 (AC: no second GraphQL call to resolve the repo): owner/repo must be
+/// resolved locally, and `gh repo view --json nameWithOwner` must be explicitly
+/// called out as the anti-pattern (it is itself GraphQL-backed — #4659).
+#[test]
+fn sweep_md_forbids_graphql_repo_resolution_in_rest_fallback() {
+    let content = read_sweep_md();
+
+    // CONTRACT: the local resolution command. Keep EXACT — it is the whole
+    // point of the AC (zero API calls, survives total GraphQL outage).
+    assert!(
+        content.contains("git remote get-url origin"),
+        "sweep.md's REST fallback must resolve owner/repo locally from \
+         `git remote get-url origin` (#4670/#4659) — a GraphQL-backed lookup \
+         fails before the REST fallback is ever attempted"
+    );
+
+    // PROSE (structural / tolerant): the prohibition on the GraphQL-backed
+    // `gh repo view` lookup is stated twice with two phrasings (Mode B: "Do
+    // **not** call …"; Mode C: "**never** …"). Accept either so a reword of one
+    // survives while deleting BOTH — i.e. the warning truly gone — still fails.
+    let prohibition_phrases: &[&str] = &[
+        "Do **not** call `gh repo view --json nameWithOwner`",
+        "never** `gh repo view --json nameWithOwner`",
+        "not** call `gh repo view",
+        "NOT `gh repo view --json nameWithOwner`",
+    ];
+    assert!(
+        prohibition_phrases.iter().any(|p| content.contains(p)),
+        "sweep.md must warn against `gh repo view --json nameWithOwner` for \
+         repo resolution in the REST fallback (#4670/#4659) — asserted via a \
+         tolerant phrasing set"
+    );
+}
+
+/// #4670 (AC: non-rate-limit failures keep fail-safe behavior): auth/network
+/// errors must NOT be mistaken for quota exhaustion and silently retried.
+#[test]
+fn sweep_md_documents_non_rate_limit_failsafe() {
+    let content = read_sweep_md();
+
+    // PROSE (structural / tolerant): the "only a rate-limit signature triggers
+    // the fallback" semantic is wording; accept equivalent phrasings so a
+    // reword survives while a deletion of the guard still fails.
+    let failsafe_phrases: &[&str] = &[
+        "NOT exhaustion",
+        "not exhaustion",
+        "is not a rate limit",
+        "not be mistaken for quota exhaustion",
+    ];
+    assert!(
+        failsafe_phrases.iter().any(|p| content.contains(p)),
+        "sweep.md must state that non-rate-limit failures (auth, network, 404) \
+         are NOT exhaustion and must keep today's fail-safe behavior (#4670) — \
+         asserted via a tolerant phrasing set"
+    );
+}
+
+/// #4670 (AC: preserve the unknown-label safety rule): the label guard degrades
+/// GraphQL → REST → `.github/labels.yml`, with the YAML as the LAST rung, not
+/// the first.
+#[test]
+fn sweep_md_documents_label_guard_rest_before_yaml_ladder() {
+    let content = read_sweep_md();
+
+    // CONTRACT: the degraded-fallback file path stays exact (it is a real
+    // path the orchestrator reads).
+    assert!(
+        content.contains(".github/labels.yml"),
+        "sweep.md must retain `.github/labels.yml` as the degraded label \
+         fallback (#4670 keeps it, demoted to the last rung)"
+    );
+
+    // PROSE (structural / tolerant): the ordering semantic — REST is tried
+    // before the YAML subset — stated in both the Mode B offline-fallback
+    // paragraph and the fallback ladder item.
+    let ladder_phrases: &[&str] = &[
+        "only when the REST read also fails",
+        "only if REST fails too",
+        "last* rung",
+        "last rung",
+    ];
+    assert!(
+        ladder_phrases.iter().any(|p| content.contains(p)),
+        "sweep.md must document `.github/labels.yml` as the LAST rung of the \
+         GraphQL → REST → YAML label ladder (#4670): the live REST label set is \
+         preferred because the YAML is only the Loom-managed subset — asserted \
+         via a tolerant phrasing set"
+    );
+}
+
 /// #4505: the dry-run per-candidate planned-action enumeration documents the
 /// new `would skip (explicit hold: "<phrase>")` action alongside the other
 /// aggressive-mode `would ...` actions.


### PR DESCRIPTION
## Summary

`/loom:sweep`'s Mode B (issue) and Mode C (PR) candidate discovery run on `gh issue list` / `gh pr list`, which are **GraphQL**-backed. `gh api repos/{owner}/{repo}/…` is **REST**, and the two draw on independent quotas — during the `/loom:sweep` run that filed #4670, GraphQL was exhausted while >4,500 REST core requests remained, yet the sweep had no documented path to keep resolving candidates. `sweep.md` documented an offline `gh label list` → `.github/labels.yml` fallback but nothing equivalent for issue/PR discovery.

This adds that fallback prose to both modes, reusing the detection pattern already implemented in `defaults/scripts/check-duplicate.sh` rather than deriving a new one, and pins it with doc-lint assertions. `check-duplicate.sh` is unchanged (reference only, per the issue).

## Changes

**`defaults/.claude/commands/loom/sweep.md`**

- **Mode B — "GraphQL-exhaustion fallback (REST issue discovery)"** (new, after the existing `gh label list` offline-fallback paragraph):
  1. **Detection**: the exact five-signature table from `check-duplicate.sh`'s `is_rate_limit_error()` (mirrored from `loom-daemon/src/rate_limit_breaker.rs`'s `RATE_LIMIT_SIGNATURES`), including why the GraphQL (`…already exceeded`) and REST (`…exceeded`) phrasings are both required — neither contains the other. Plus an explicit **non-exhaustion fail-safe**: auth failures, network errors, 404s, rejected flags are reported verbatim and EXIT, never silently retried over REST, and exhaustion is never inferred from a bare non-zero exit.
  2. **Local repo resolution**: `gh api "repos/{owner}/{repo}/…"` placeholder expansion (zero API calls), or parsing `git remote get-url origin` — with an explicit prohibition on `gh repo view --json nameWithOwner`, which is itself GraphQL-backed (#4659 fixed the same anti-pattern in `check-duplicate.sh`; this lands on that same resolution approach).
  3. **Flag → REST parameter translation table** (`--state`, `--label`, `--author`/`@me`, `--assignee`, `--limit` → `per_page` + `--paginate`, `--json` field projection, and `--search` called out as not expressible on `/issues`), with a runnable example that filters PRs out of `/issues` via `select(.pull_request == null)`.
  4. **Safeguards preserved**: dedup + first-seen order, union with explicit numeric tokens, explicit limits (never REST's default `per_page=30`), and the existing zero-match / truncation edge cases.
  5. **Degradation announced** on stderr and above the confirmation-gate listing.
  6. **Unknown-label guard** now degrades GraphQL → REST (`repos/{owner}/{repo}/labels`) → `.github/labels.yml`; the YAML is demoted to the last rung (it is only the Loom-managed subset), and the never-fabricate-a-label rule is restated as unchanged at every rung.
- **Mode C — "GraphQL-exhaustion fallback (REST PR discovery)"** (new): same ladder, referencing Mode B for the shared detection/fail-safe/repo-resolution semantics, plus a `/pulls`-specific mapping that documents the endpoint's **missing `labels=` and `creator=` parameters** (client-side filtering instead) and a note that Mode C's C0 pre-flight is a deliberately uncached routing read, so its REST equivalent stays plain `gh api`, never `$GH_READ`.
- The `all` sentinel's two candidate queries gained a one-line pointer to the matching fallback section (they are the same `gh issue list` / `gh pr list` calls).

**`loom-daemon/tests/sweep_md_doc_lint.rs`** — six new tests following the file's PROSE vs. CONTRACT convention:

| Test | Class | Pins |
|---|---|---|
| `sweep_md_documents_graphql_exhaustion_fallback_in_both_mode_b_and_mode_c` | PROSE (structural + ordering) | ≥2 occurrences, one before and one after the `### Mode C` heading |
| `sweep_md_pins_rate_limit_signature_table` | CONTRACT | the five exact signatures + `is_rate_limit_error()` / `RATE_LIMIT_SIGNATURES` provenance |
| `sweep_md_pins_rest_fallback_endpoints_and_pagination` | CONTRACT | `/issues`, `/pulls`, `/labels` endpoints, `--paginate`, `per_page=100`, `select(.pull_request == null)` |
| `sweep_md_forbids_graphql_repo_resolution_in_rest_fallback` | CONTRACT + PROSE set | `git remote get-url origin`; the `gh repo view --json nameWithOwner` prohibition |
| `sweep_md_documents_non_rate_limit_failsafe` | PROSE set | auth/network/404 are not exhaustion |
| `sweep_md_documents_label_guard_rest_before_yaml_ladder` | CONTRACT + PROSE set | `.github/labels.yml` as the **last** rung |

## Acceptance Criteria Verification

- [x] **Detect GitHub's actual GraphQL-exhaustion signature, reusing the existing table** — the five signatures are transcribed from `check-duplicate.sh:289 is_rate_limit_error()` verbatim, with the provenance chain to `rate_limit_breaker.rs` cited in the prose and pinned by the doc-lint. No new signature derived.
- [x] **Resolve owner/name locally, no GraphQL call** — `{owner}/{repo}` placeholder expansion (preferred) or `git remote get-url origin` parsing; `gh repo view --json nameWithOwner` explicitly prohibited in both modes with the #4659 cross-reference, matching the approach already merged into `check-duplicate.sh`'s `get_repo_nwo()`.
- [x] **Paginated REST issue listing for Mode B preserving state/label filters, required fields, dedup, explicit limits, truncation warnings** — flag translation table + example + safeguard item 4.
- [x] **Paginated REST PR listing for Mode C with equivalent routing fields and safeguards** — `/pulls` table + example + the safeguards paragraph (routing fields `number`, `title`, `labels[].name`; confirmation gate retained).
- [x] **Unknown-label safety rule preserved; REST labels when available, `.github/labels.yml` only as the degraded fallback** — the three-rung ladder, with the never-fabricate rule restated at every rung.
- [x] **Non-rate-limit auth/network failures retain fail-safe behavior** — explicit "Anything else is NOT exhaustion" paragraph in Mode B, restated in Mode C.

## Test Plan

- [x] `cargo test -p loom-daemon --test sweep_md_doc_lint` — **20 passed**, 0 failed (14 pre-existing + 6 new).
- [x] `cargo fmt` + `cargo clippy -p loom-daemon --tests` — clean.
- [x] **Manual walkthrough with the stub-`gh` pattern** (per the issue's Test Plan, reusing `defaults/scripts/tests/test-check-duplicate.sh`'s approach): a `gh` shim that fails `issue list` / `pr list` / `label list` / `repo view` with the real GraphQL phrasing (`GraphQL: API rate limit already exceeded for user ID …`) while passing `gh api` through to the real binary. Walking the new prose end-to-end under that shim:
  - Mode B: `gh issue list` fails → signature matched → REST fallback resolved **19** open `loom:curated` candidates with PRs filtered out.
  - Mode C: `gh pr list` fails → REST fallback resolved the open-PR set with `labels[].name` intact for routing.
  - Label guard: `gh label list` fails → REST returned the full **39**-label live set (never reached the `.github/labels.yml` rung).
  - Repo resolution: `gh repo view --json nameWithOwner` fails under the shim (confirming the anti-pattern), while the local remote parse returns `rjwalters/loom`.
  - Fail-safe: a 404 message and a DNS-failure message both correctly do **not** match the signature table.
- [x] Endpoint/parameter claims verified against the live API before documenting them: `labels=a,b` is AND (2 results vs. 19/2 singly), `/pulls` has no `labels=`/`creator=` parameters, jq `index(...)` at position 0 is truthy, and the `--paginate` + `per_page=100` examples run as written.
- [ ] Full `bash .loom/scripts/build-gate.sh` did not complete locally — it blocked waiting on the host's single build slot (held by a concurrent sweep) and was killed twice by the harness timeout before acquiring it. The change is docs + one test file; the targeted `cargo test`/`clippy`/`fmt` above are green, and the orchestrator's post-Builder gate will run it.

Closes #4670