### PR TITLE
fix(guards): extend gh comment literal-@ deny to the edit subcommand

### DIFF
--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -1546,6 +1546,21 @@ if echo "$COMMAND" | grep -qiE "$GH_COMMENT_BODY_AT_PATTERN"; then
 fi
 
 # =============================================================================
+# `gh pr/issue edit --body @path` — same literal-@ silent data loss, different
+# subcommand (#4685). The #4523 rule above is hard-anchored to `comment`, so
+# `gh issue edit N --body @path` sailed through untouched and posted the
+# literal string as the issue/PR BODY (not a comment) — real-world evidence:
+# issue #4608's body was corrupted to the literal string
+# `@/tmp/issue4608_body_new.txt`. Deliberately a SEPARATE rule/regex, not a
+# widened GH_COMMENT_BODY_AT_PATTERN (#4577's additive-not-widened precedent),
+# so the two subcommands' patterns can be fixed/tuned independently.
+# =============================================================================
+GH_EDIT_BODY_AT_PATTERN="(^|[;&|[:space:]])gh[[:space:]]+(pr|issue)[[:space:]]+edit[^;&]*(-b|--body)[[:space:]]*=?[[:space:]]*[\"']?@[/.~]"
+if echo "$COMMAND" | grep -qiE "$GH_EDIT_BODY_AT_PATTERN"; then
+    deny "BLOCKED: 'gh pr edit'/'gh issue edit --body @path' does NOT expand the file — it writes the literal string '@path' as the issue/PR body (corrupted issue #4608's body this way). Use --body \"\$(cat <<'EOF' ... EOF)\", -F/--body-file <path>, or 'gh api ... -F body=@<path>' instead." "gh-edit-body-literal-at"
+fi
+
+# =============================================================================
 # The same literal-@ loss reached through SHELL-VARIABLE INDIRECTION (#4601)
 #
 # The #4523 rule above inspects only the STATIC text immediately following the
@@ -1611,6 +1626,24 @@ if [[ "$COMMAND" == *"@"* ]]; then
     fi
 
     # -------------------------------------------------------------------------
+    # Same shell-variable-indirection shape, `edit` subcommand (#4685). Kept as
+    # a separate parallel `if`/loop rather than folding `edit` into the
+    # `comment` subcommand regex above, for the identical #4577-precedent
+    # reason cited on GH_EDIT_BODY_AT_PATTERN.
+    # -------------------------------------------------------------------------
+    if echo "$COMMAND" | grep -qiE "(^|[;&|[:space:]])gh[[:space:]]+(pr|issue)[[:space:]]+edit"; then
+        _gh_at_path_vars_edit=$(printf '%s\n' "$COMMAND" \
+            | grep -oE "(^|[;&|(){}[:space:]])[A-Za-z_][A-Za-z0-9_]*=[\"']?$GH_AT_PATHISH" 2>/dev/null \
+            | grep -oE "[A-Za-z_][A-Za-z0-9_]*=" 2>/dev/null \
+            | tr -d '=' | sort -u)
+        for _gh_at_var in $_gh_at_path_vars_edit; do
+            if echo "$COMMAND" | grep -qiE "(-b|--body)[[:space:]]*=?[[:space:]]*[\"']?[\$]\{?${_gh_at_var}(\}|[^A-Za-z0-9_]|\$)"; then
+                deny "BLOCKED: '\$${_gh_at_var}' is assigned a path-shaped '@<path>' value and passed as --body — 'gh pr edit'/'gh issue edit' does NOT expand '@path' from a variable either; it writes the literal string as the issue/PR body (corrupted issue #4608's body this way). Use --body-file <path>, 'gh api ... -F body=@<path>', or --body \"\$(cat <<'EOF' ... EOF)\"." "gh-edit-body-literal-at-var"
+            fi
+        done
+    fi
+
+    # -------------------------------------------------------------------------
     # `gh api … -f/--raw-field body=@path` — the same silent literal-@ loss.
     #
     # On `gh api`, ONLY `-F`/`--field` gives `@<path>` its read-from-file
@@ -1624,10 +1657,18 @@ if [[ "$COMMAND" == *"@"* ]]; then
     # leading whitespace anchor before the flag is likewise load-bearing —
     # without it, `-f` matches inside `--field` (the long form of `-F`) and
     # denies that too. GH_AT_PATHISH keeps `-f body="@mention …"` prose allowed.
+    #
+    # ENDPOINT SCOPE (#4685): this pattern was never anchored to a
+    # `/comments` endpoint — it matches `gh api <any-endpoint> ... -f
+    # body=@path` regardless of path — so it already covers `gh api
+    # repos/{o}/{r}/issues/{n}` (issue PATCH) and
+    # `repos/{o}/{r}/pulls/{n}` (PR PATCH) exactly as it covers
+    # `.../issues/{n}/comments`. Confirmed via the test suite's new
+    # non-comments-endpoint case; no widening was needed here.
     # -------------------------------------------------------------------------
     GH_API_RAWFIELD_BODY_AT_PATTERN="(^|[;&|[:space:]])gh[[:space:]]+api[^;&]*[[:space:]](-f|--raw-field)[[:space:]]*=?[[:space:]]*[\"']?body=[\"']?$GH_AT_PATHISH"
     if echo "$COMMAND" | grep -qE "$GH_API_RAWFIELD_BODY_AT_PATTERN"; then
-        deny "BLOCKED: 'gh api ... -f/--raw-field body=@<path>' does NOT read the file — only -F/--field gives '@<path>' its read-from-file meaning. As written this posts the literal string '@<path>' as the comment body (same silent data loss as PR #4457). Use '-F body=@<path>' instead." "gh-api-rawfield-body-literal-at"
+        deny "BLOCKED: 'gh api ... -f/--raw-field body=@<path>' does NOT read the file — only -F/--field gives '@<path>' its read-from-file meaning. As written this posts the literal string '@<path>' as the body (same silent data loss as PR #4457/issue #4608). Use '-F body=@<path>' instead." "gh-api-rawfield-body-literal-at"
     fi
 fi
 

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -1546,6 +1546,21 @@ if echo "$COMMAND" | grep -qiE "$GH_COMMENT_BODY_AT_PATTERN"; then
 fi
 
 # =============================================================================
+# `gh pr/issue edit --body @path` — same literal-@ silent data loss, different
+# subcommand (#4685). The #4523 rule above is hard-anchored to `comment`, so
+# `gh issue edit N --body @path` sailed through untouched and posted the
+# literal string as the issue/PR BODY (not a comment) — real-world evidence:
+# issue #4608's body was corrupted to the literal string
+# `@/tmp/issue4608_body_new.txt`. Deliberately a SEPARATE rule/regex, not a
+# widened GH_COMMENT_BODY_AT_PATTERN (#4577's additive-not-widened precedent),
+# so the two subcommands' patterns can be fixed/tuned independently.
+# =============================================================================
+GH_EDIT_BODY_AT_PATTERN="(^|[;&|[:space:]])gh[[:space:]]+(pr|issue)[[:space:]]+edit[^;&]*(-b|--body)[[:space:]]*=?[[:space:]]*[\"']?@[/.~]"
+if echo "$COMMAND" | grep -qiE "$GH_EDIT_BODY_AT_PATTERN"; then
+    deny "BLOCKED: 'gh pr edit'/'gh issue edit --body @path' does NOT expand the file — it writes the literal string '@path' as the issue/PR body (corrupted issue #4608's body this way). Use --body \"\$(cat <<'EOF' ... EOF)\", -F/--body-file <path>, or 'gh api ... -F body=@<path>' instead." "gh-edit-body-literal-at"
+fi
+
+# =============================================================================
 # The same literal-@ loss reached through SHELL-VARIABLE INDIRECTION (#4601)
 #
 # The #4523 rule above inspects only the STATIC text immediately following the
@@ -1611,6 +1626,24 @@ if [[ "$COMMAND" == *"@"* ]]; then
     fi
 
     # -------------------------------------------------------------------------
+    # Same shell-variable-indirection shape, `edit` subcommand (#4685). Kept as
+    # a separate parallel `if`/loop rather than folding `edit` into the
+    # `comment` subcommand regex above, for the identical #4577-precedent
+    # reason cited on GH_EDIT_BODY_AT_PATTERN.
+    # -------------------------------------------------------------------------
+    if echo "$COMMAND" | grep -qiE "(^|[;&|[:space:]])gh[[:space:]]+(pr|issue)[[:space:]]+edit"; then
+        _gh_at_path_vars_edit=$(printf '%s\n' "$COMMAND" \
+            | grep -oE "(^|[;&|(){}[:space:]])[A-Za-z_][A-Za-z0-9_]*=[\"']?$GH_AT_PATHISH" 2>/dev/null \
+            | grep -oE "[A-Za-z_][A-Za-z0-9_]*=" 2>/dev/null \
+            | tr -d '=' | sort -u)
+        for _gh_at_var in $_gh_at_path_vars_edit; do
+            if echo "$COMMAND" | grep -qiE "(-b|--body)[[:space:]]*=?[[:space:]]*[\"']?[\$]\{?${_gh_at_var}(\}|[^A-Za-z0-9_]|\$)"; then
+                deny "BLOCKED: '\$${_gh_at_var}' is assigned a path-shaped '@<path>' value and passed as --body — 'gh pr edit'/'gh issue edit' does NOT expand '@path' from a variable either; it writes the literal string as the issue/PR body (corrupted issue #4608's body this way). Use --body-file <path>, 'gh api ... -F body=@<path>', or --body \"\$(cat <<'EOF' ... EOF)\"." "gh-edit-body-literal-at-var"
+            fi
+        done
+    fi
+
+    # -------------------------------------------------------------------------
     # `gh api … -f/--raw-field body=@path` — the same silent literal-@ loss.
     #
     # On `gh api`, ONLY `-F`/`--field` gives `@<path>` its read-from-file
@@ -1624,10 +1657,18 @@ if [[ "$COMMAND" == *"@"* ]]; then
     # leading whitespace anchor before the flag is likewise load-bearing —
     # without it, `-f` matches inside `--field` (the long form of `-F`) and
     # denies that too. GH_AT_PATHISH keeps `-f body="@mention …"` prose allowed.
+    #
+    # ENDPOINT SCOPE (#4685): this pattern was never anchored to a
+    # `/comments` endpoint — it matches `gh api <any-endpoint> ... -f
+    # body=@path` regardless of path — so it already covers `gh api
+    # repos/{o}/{r}/issues/{n}` (issue PATCH) and
+    # `repos/{o}/{r}/pulls/{n}` (PR PATCH) exactly as it covers
+    # `.../issues/{n}/comments`. Confirmed via the test suite's new
+    # non-comments-endpoint case; no widening was needed here.
     # -------------------------------------------------------------------------
     GH_API_RAWFIELD_BODY_AT_PATTERN="(^|[;&|[:space:]])gh[[:space:]]+api[^;&]*[[:space:]](-f|--raw-field)[[:space:]]*=?[[:space:]]*[\"']?body=[\"']?$GH_AT_PATHISH"
     if echo "$COMMAND" | grep -qE "$GH_API_RAWFIELD_BODY_AT_PATTERN"; then
-        deny "BLOCKED: 'gh api ... -f/--raw-field body=@<path>' does NOT read the file — only -F/--field gives '@<path>' its read-from-file meaning. As written this posts the literal string '@<path>' as the comment body (same silent data loss as PR #4457). Use '-F body=@<path>' instead." "gh-api-rawfield-body-literal-at"
+        deny "BLOCKED: 'gh api ... -f/--raw-field body=@<path>' does NOT read the file — only -F/--field gives '@<path>' its read-from-file meaning. As written this posts the literal string '@<path>' as the body (same silent data loss as PR #4457/issue #4608). Use '-F body=@<path>' instead." "gh-api-rawfield-body-literal-at"
     fi
 fi
 

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -546,6 +546,56 @@ assert_allow "#4601: Allow gh api --field body=@path (long form of -F, must not 
 assert_allow "#4601/#4577: Allow gh api -f body=\"@mention prose\" (not path-shaped)" \
     "gh api repos/o/r/issues/123/comments -f body=\"@rjwalters thanks for the review\""
 
+# --- #4685: the same literal-@ loss on the `edit` subcommand — real-world
+# evidence is issue #4608's body being corrupted to the literal string
+# `@/tmp/issue4608_body_new.txt`. The #4523/#4601 rules above are hard-anchored
+# to `comment`, so `gh issue edit`/`gh pr edit --body @path` sailed through
+# untouched. Mirrors the comment-subcommand cases above shape-for-shape.
+assert_deny "#4685: Block gh issue edit --body @path (unquoted)" \
+    "gh issue edit 4608 --body @/tmp/issue4608_body_new.txt"
+
+assert_deny "#4685: Block gh issue edit --body @path (double-quoted)" \
+    'gh issue edit 4608 --body "@/tmp/issue4608_body_new.txt"'
+
+assert_deny "#4685: Block gh issue edit --body @path (single-quoted)" \
+    "gh issue edit 4608 --body '@/tmp/issue4608_body_new.txt'"
+
+assert_deny "#4685: Block gh pr edit --body @path (unquoted)" \
+    "gh pr edit 123 --body @/tmp/review.md"
+
+assert_deny "#4685: Block gh issue edit -b @path (short flag)" \
+    "gh issue edit 4608 -b @/tmp/issue4608_body_new.txt"
+
+assert_deny "#4685: Block --body \"\$VAR\" where VAR is assigned an @path in the same command (edit)" \
+    'BODY_FILE="@/tmp/issue4608_body_new.txt"; gh issue edit 4608 --body "$BODY_FILE"'
+
+assert_deny "#4685: Block --body \$VAR (unquoted var, unquoted @path assignment, edit)" \
+    'BODY_FILE=@/tmp/issue4608_body_new.txt; gh issue edit 4608 --body $BODY_FILE'
+
+assert_deny "#4685: Block --body \"\${VAR}\" (braced expansion, edit)" \
+    'BODY_FILE="@/tmp/issue4608_body_new.txt"; gh issue edit 4608 --body "${BODY_FILE}"'
+
+assert_deny "#4685: Block gh pr edit -b \"\$VAR\" (short flag, && chain, single-quoted value)" \
+    "F='@/tmp/x.md' && gh pr edit 123 -b \"\$F\""
+
+assert_allow "#4685: Allow gh issue edit --body \"\$SUMMARY\" (no @path assigned anywhere)" \
+    'gh issue edit 4608 --body "$SUMMARY"'
+
+assert_allow "#4685: Allow gh issue edit --body \"\$VAR\" holding a bare @mention" \
+    'M=@rjwalters; gh issue edit 4608 --body "$M"'
+
+assert_allow "#4685: Allow a path in a variable expanded through \$(cat …) (edit, the correct pattern)" \
+    'BODY=/tmp/issue4608_body_new.txt; gh issue edit 4608 --body "$(cat $BODY)"'
+
+# `gh api` PATCH endpoint (issues/pulls, not /comments) with -f body=@path —
+# confirms the existing #4601 rule was never endpoint-scoped, so it already
+# covers the edit-equivalent PATCH surface without any widening.
+assert_deny "#4685: Block gh api -f body=@path against the issue PATCH endpoint (not /comments)" \
+    "gh api repos/o/r/issues/4608 -f body=@/tmp/issue4608_body_new.txt -X PATCH"
+
+assert_deny "#4685: Block gh api -f body=@path against the pulls PATCH endpoint" \
+    "gh api repos/o/r/pulls/123 -f body=@/tmp/review.md -X PATCH"
+
 echo ""
 
 # =========================================================================


### PR DESCRIPTION
## Summary

Extends the #4523/#4601 `gh (pr|issue) comment --body @path` literal-@
silent-data-loss guard to also cover `gh (pr|issue) edit --body @path`, which
was completely uncovered and caused real-world corruption of #4608's issue
body (`@/tmp/issue4608_body_new.txt`) and one of its comments
(`@/tmp/issue4608_comment.txt`).

## Rules added (additive, not a rewrite — per #4577's precedent)

1. **`GH_EDIT_BODY_AT_PATTERN`** (static literal-@, sibling of
   `GH_COMMENT_BODY_AT_PATTERN`):
   ```
   (^|[;&|[:space:]])gh[[:space:]]+(pr|issue)[[:space:]]+edit[^;&]*(-b|--body)[[:space:]]*=?[[:space:]]*["']?@[/.~]
   ```
   Denies `gh issue edit N --body @path` / `gh pr edit N --body @path`
   (unquoted, single- or double-quoted), tag `gh-edit-body-literal-at`.

2. **Shell-variable-indirection sibling** of the #4601 comment-subcommand
   check: a new, separate `if`/loop block that fires when the same command
   both assigns a path-shaped `@…` value to a variable AND passes that
   variable as `--body`/`-b` to `gh (pr|issue) edit` — mirrors the existing
   `comment` logic exactly, just re-anchored to `edit`. Tag
   `gh-edit-body-literal-at-var`.

3. **`gh api -f/--raw-field body=@path` (#4601's sibling rule)**: verified
   this rule was never anchored to a `/comments` endpoint — it already
   matches `gh api repos/{o}/{r}/issues/{n}` and `.../pulls/{n}` (the PATCH
   endpoints `gh issue edit`/`gh pr edit` use under the hood) exactly as it
   matches `.../comments`. No widening needed; added a new test case
   confirming this and a doc comment explaining why.

Both `defaults/hooks/guard-destructive-generic.sh` and the installed
`.loom/hooks/guard-destructive-generic.sh` copy are updated identically,
matching how PR #4612 shipped the comment-subcommand rules (same file, both
locations, no symlink).

## Tests

Added 14 new cases to `tests/hooks/test-guard-destructive.sh` mirroring the
existing comment-subcommand tests shape-for-shape (literal quoted/unquoted,
short flag `-b`, variable indirection, braced expansion, `&&`-chained, plus
allow-cases for legitimate `--body "$VAR"` prose, bare `@mention`, and the
correct `$(cat path)` pattern). Full suite: **531/531 passing**
(`bash tests/hooks/test-guard-destructive.sh`), plus the dispatcher
(8/8) and workflow (27/27) suites still green — no regressions to the
existing `comment`-subcommand rules.

## #4608 restoration

While investigating, I found the `/tmp` files the corrupted `--body @path`
commands referenced (`/tmp/issue4608_body_new.txt`,
`/tmp/issue4608_comment.txt`) were **still present on disk**, containing
exactly the intended content. Restored both:

- Issue body: `gh issue edit 4608 --body-file /tmp/issue4608_body_new.txt`
- The corrupted `2026-07-30T09:09:10Z` comment can't be edited after the
  fact, so I posted a new comment reproducing its intended content verbatim,
  with a note explaining the restoration.

#4608 is now fully restored (body + comment) — no manual follow-up needed
there.

Closes #4685