### PR TITLE
fix(daemon): resolve roles/runtimes independently and provision .loom/runtimes/

### DIFF
--- a/defaults/scripts/resync-installed.sh
+++ b/defaults/scripts/resync-installed.sh
@@ -23,6 +23,7 @@
 #   .loom/scripts/          <- defaults/scripts/          (recursive)
 #   .loom/roles/            <- defaults/roles/            (recursive)
 #   .loom/docs/             <- defaults/docs/             (recursive; symlinks skipped)
+#   .loom/runtimes/         <- defaults/runtimes/         (recursive; BACKFILLED if absent, #4688)
 #   .loom/bin/              <- defaults/.loom/bin/        (recursive; live consumer CLI)
 #   .claude/commands/loom/  <- defaults/.claude/commands/loom/ (recursive)
 #
@@ -682,6 +683,18 @@ fi
 if [[ -d "$REPO_ROOT/.loom/docs" ]]; then
     resync_tree "$DEFAULTS_DIR/docs" "$REPO_ROOT/.loom/docs" "docs" "docs"
 fi
+# `.loom/runtimes/` is deliberately UNCONDITIONAL, unlike the surfaces above
+# (#4688): every one of the gated blocks only backfills a surface the
+# consumer already opted into (destination pre-exists). `runtimes/` is not
+# an opt-in surface — it is a provisioning gap that both the Rust-native
+# `loom-daemon init` path and this script itself failed to populate before
+# this fix, so a host resynced any number of times has NO other path to ever
+# obtain the directory. `resync_tree`'s per-file `sync_one` already creates
+# `$dst_dir` via `mkdir -p` as it copies (skipped harmlessly under
+# `--dry-run`, which only reports "would create"), so this call alone is
+# sufficient to both create `.loom/runtimes/` on hosts that never had it and
+# keep it fresh on hosts that already do.
+resync_tree "$DEFAULTS_DIR/runtimes" "$REPO_ROOT/.loom/runtimes" "runtimes" "runtimes"
 if [[ -d "$REPO_ROOT/.loom/bin" ]]; then
     resync_tree "$DEFAULTS_DIR/.loom/bin" "$REPO_ROOT/.loom/bin" "bin" ".loom/bin"
 fi
@@ -985,7 +998,7 @@ suggest_commit_if_resync_only_dirt() {
         path="${path%\"}"
         path="${path#\"}"
         case "$path" in
-            .loom/hooks/*|.loom/scripts/*|.loom/roles/*|.loom/docs/*|.loom/bin/*|.claude/commands/loom/*|.loom/install-metadata.json|.gitattributes)
+            .loom/hooks/*|.loom/scripts/*|.loom/roles/*|.loom/docs/*|.loom/runtimes/*|.loom/bin/*|.claude/commands/loom/*|.loom/install-metadata.json|.gitattributes)
                 resync_paths+=("$path")
                 ;;
             *)

--- a/defaults/scripts/tests/test-resync-installed.sh
+++ b/defaults/scripts/tests/test-resync-installed.sh
@@ -955,6 +955,71 @@ else
     fi
 fi
 
+# --- (w) .loom/runtimes/ backfill for a workspace that never had it (#4688) --
+echo "Test group 21: .loom/runtimes/ is backfilled when absent (#4688)"
+# Builds its own throwaway repo rather than reusing make_fixture(), so it can
+# deliberately NOT create .loom/runtimes/ at all — the exact live-incident
+# layout: .loom/roles/ (and the rest of a normal install) present, but
+# .loom/runtimes/ was never provisioned by any prior install/resync.
+RUNTIMES_REPO="$WORKDIR/runtimes-repo"
+rm -rf "$RUNTIMES_REPO"
+mkdir -p "$RUNTIMES_REPO/defaults/roles" "$RUNTIMES_REPO/defaults/runtimes" \
+         "$RUNTIMES_REPO/.loom/roles"
+git -C "$RUNTIMES_REPO" init -q
+printf 'ROLE\n' > "$RUNTIMES_REPO/defaults/roles/builder.md"
+printf 'ROLE\n' > "$RUNTIMES_REPO/.loom/roles/builder.md"
+printf '{"runtime":"claude","capabilities":{"mcp":"yes"}}\n' > "$RUNTIMES_REPO/defaults/runtimes/claude.json"
+printf '{\n  "loom_version": "0.0.0",\n  "loom_commit": "old",\n  "install_date": "2020-01-01",\n  "loom_source": "%s",\n  "installed_files": []\n}\n' \
+    "$RUNTIMES_REPO" > "$RUNTIMES_REPO/.loom/install-metadata.json"
+git -C "$RUNTIMES_REPO" add -A >/dev/null 2>&1
+git -C "$RUNTIMES_REPO" commit -qm "fixture" >/dev/null 2>&1
+
+if [[ ! -d "$RUNTIMES_REPO/.loom/runtimes" ]]; then
+    pass "(w) fixture precondition: .loom/runtimes/ absent before resync"
+else
+    fail "(w) fixture precondition: .loom/runtimes/ unexpectedly present before resync"
+fi
+
+# --dry-run must report the directory would be populated, without writing.
+OUT="$(cd "$RUNTIMES_REPO" && bash "$SCRIPT" --dry-run 2>&1)"
+if grep -q "runtimes/claude.json" <<<"$OUT"; then
+    pass "(w) --dry-run reports runtimes/claude.json would be created"
+else
+    fail "(w) --dry-run did not mention runtimes/claude.json"
+fi
+if [[ ! -d "$RUNTIMES_REPO/.loom/runtimes" ]]; then
+    pass "(w) --dry-run does not create .loom/runtimes/"
+else
+    fail "(w) --dry-run created .loom/runtimes/ (should be preview-only)"
+fi
+
+# apply: the directory must now exist and be populated from defaults/.
+OUT="$(cd "$RUNTIMES_REPO" && bash "$SCRIPT" 2>&1)"
+RC=$?
+if [[ $RC -eq 0 ]]; then
+    pass "(w) apply exits 0"
+else
+    fail "(w) apply did not exit 0 (got $RC)"
+fi
+if [[ -d "$RUNTIMES_REPO/.loom/runtimes" ]]; then
+    pass "(w) .loom/runtimes/ created by apply"
+else
+    fail "(w) .loom/runtimes/ was not created by apply"
+fi
+if [[ "$(cat "$RUNTIMES_REPO/.loom/runtimes/claude.json" 2>/dev/null)" == '{"runtime":"claude","capabilities":{"mcp":"yes"}}' ]]; then
+    pass "(w) .loom/runtimes/claude.json populated from defaults/runtimes/"
+else
+    fail "(w) .loom/runtimes/claude.json missing or content mismatch"
+fi
+# second run is a clean no-op.
+OUT="$(cd "$RUNTIMES_REPO" && bash "$SCRIPT" 2>&1)"
+RC=$?
+if [[ $RC -eq 0 ]] && grep -q "Already in sync" <<<"$OUT"; then
+    pass "(w) runtimes backfill is idempotent (second run already in sync)"
+else
+    fail "(w) runtimes backfill is not idempotent (rc=$RC)"
+fi
+
 # --- contract checks ---------------------------------------------------------
 echo "Test group 13: flag/contract checks"
 if bash "$SCRIPT" --help 2>&1 | grep -q "resync-installed.sh"; then

--- a/loom-daemon/src/init/mod.rs
+++ b/loom-daemon/src/init/mod.rs
@@ -186,6 +186,14 @@ pub fn initialize_workspace(
     // from issue #3333). Sync alongside other managed dirs so installed
     // repos always carry the latest copy.
     sync_managed_dir(&defaults, &loom_path, "docs", is_reinstall, &mut report)?;
+    // `runtimes` ships the per-runtime capability manifests consumed by
+    // `runtime_admission::roots()` (#4688). This directory was declared in
+    // the install manifest (scripts/install/manifest.sh) since #4183 but
+    // never actually synced by this Rust-native path — every fresh install
+    // and Rust-native reinstall left `.loom/runtimes/` unpopulated, which
+    // made the admission gate fall through to a nonexistent
+    // `defaults/runtimes/...` on every consumer dispatch.
+    sync_managed_dir(&defaults, &loom_path, "runtimes", is_reinstall, &mut report)?;
 
     // Sync `.loom/bin/` from `defaults/.loom/bin/`. The manifest generator
     // (scripts/install/manifest.sh) walks `defaults/.loom/` and registers
@@ -765,7 +773,7 @@ fn verify_all_copied_files(
     report: &mut InitReport,
 ) {
     // Verify .loom managed directories (no template substitution needed)
-    for dir_name in &["roles", "scripts", "hooks", "docs"] {
+    for dir_name in &["roles", "scripts", "hooks", "docs", "runtimes"] {
         let src = defaults.join(dir_name);
         let dst = loom_path.join(dir_name);
         let prefix = format!(".loom/{dir_name}");
@@ -1714,6 +1722,117 @@ mod tests {
     }
 
     #[test]
+    fn test_runtimes_subdirectory_copied_on_fresh_install() {
+        // Regression-guard for #4688: `.loom/runtimes/` (the per-runtime
+        // capability manifests `runtime_admission::roots()` reads) must be
+        // copied during initialization, mirroring the `docs` regression
+        // guard above (#3470). Before this fix `sync_managed_dir` was never
+        // called for "runtimes" at all, so every fresh `loom-daemon init`
+        // left `.loom/runtimes/` unpopulated and the admission gate fell
+        // through to a nonexistent `defaults/runtimes/...` on every
+        // dispatch.
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = temp_dir.path();
+        let defaults = temp_dir.path().join("defaults");
+
+        fs::create_dir(workspace.join(".git")).unwrap();
+
+        fs::create_dir_all(defaults.join("roles")).unwrap();
+        fs::create_dir_all(defaults.join("runtimes")).unwrap();
+        fs::write(defaults.join("config.json"), "{}").unwrap();
+        fs::write(defaults.join("roles").join("builder.md"), "builder").unwrap();
+        fs::write(
+            defaults.join("runtimes").join("claude.json"),
+            r#"{"runtime":"claude","capabilities":{"mcp":"yes"}}"#,
+        )
+        .unwrap();
+        fs::write(
+            defaults.join("runtimes").join("codex.json"),
+            r#"{"runtime":"codex","capabilities":{"mcp":"yes"}}"#,
+        )
+        .unwrap();
+
+        let result =
+            initialize_workspace(workspace.to_str().unwrap(), defaults.to_str().unwrap(), false);
+
+        assert!(result.is_ok(), "init failed: {:?}", result.err());
+        let report = result.unwrap();
+
+        let runtimes_dir = workspace.join(".loom").join("runtimes");
+        assert!(runtimes_dir.exists(), ".loom/runtimes/ directory should exist");
+        assert!(runtimes_dir.is_dir(), ".loom/runtimes/ should be a directory");
+
+        let claude_json = runtimes_dir.join("claude.json");
+        assert!(claude_json.exists(), ".loom/runtimes/claude.json should exist");
+        assert_eq!(
+            fs::read_to_string(&claude_json).unwrap(),
+            r#"{"runtime":"claude","capabilities":{"mcp":"yes"}}"#
+        );
+        assert!(
+            runtimes_dir.join("codex.json").exists(),
+            ".loom/runtimes/codex.json should exist (whole-directory copy)"
+        );
+
+        assert!(
+            report
+                .added
+                .contains(&".loom/runtimes/claude.json".to_string()),
+            "Report should include runtimes/claude.json, got: {:?}",
+            report.added
+        );
+        assert!(
+            report.verification_failures.is_empty(),
+            "Expected no verification failures, got: {:?}",
+            report.verification_failures
+        );
+    }
+
+    #[test]
+    fn test_runtimes_subdirectory_restored_on_reinstall() {
+        // Reinstall analog of test_runtimes_subdirectory_copied_on_fresh_install:
+        // stale runtime manifests must be cleaned and updated content copied
+        // fresh, and — critically — a workspace that NEVER had
+        // `.loom/runtimes/` at all (the exact #4688 incident layout) must
+        // have it backfilled by a reinstall, not silently skipped.
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = temp_dir.path();
+        let defaults = temp_dir.path().join("defaults");
+
+        fs::create_dir(workspace.join(".git")).unwrap();
+
+        fs::create_dir_all(defaults.join("roles")).unwrap();
+        fs::create_dir_all(defaults.join("runtimes")).unwrap();
+        fs::write(defaults.join("config.json"), "{}").unwrap();
+        fs::write(defaults.join("roles").join("builder.md"), "builder").unwrap();
+        fs::write(
+            defaults.join("runtimes").join("claude.json"),
+            r#"{"runtime":"claude","capabilities":{"mcp":"yes"}}"#,
+        )
+        .unwrap();
+
+        // Pre-existing install that predates #4688: `.loom/roles/` exists
+        // but `.loom/runtimes/` was never provisioned at all.
+        fs::create_dir_all(workspace.join(".loom").join("roles")).unwrap();
+        assert!(!workspace.join(".loom").join("runtimes").exists());
+
+        let result =
+            initialize_workspace(workspace.to_str().unwrap(), defaults.to_str().unwrap(), false);
+
+        assert!(result.is_ok(), "reinstall failed: {:?}", result.err());
+
+        let claude_json = workspace.join(".loom").join("runtimes").join("claude.json");
+        assert!(
+            claude_json.exists(),
+            ".loom/runtimes/claude.json should be backfilled by reinstall even though \
+             .loom/runtimes/ never existed before"
+        );
+        assert_eq!(
+            fs::read_to_string(&claude_json).unwrap(),
+            r#"{"runtime":"claude","capabilities":{"mcp":"yes"}}"#
+        );
+    }
+
+    #[test]
     fn test_real_defaults_tree_ships_docs_at_top_level() {
         // Regression guard for #3476 Bug 2. The tempdir tests above fabricate
         // a defaults/ layout, so they structurally cannot catch the failure
@@ -1737,7 +1856,7 @@ mod tests {
             "shipped defaults/ tree not found at {defaults:?} — did the repo layout change?"
         );
 
-        for dir_name in &["roles", "scripts", "hooks", "docs"] {
+        for dir_name in &["roles", "scripts", "hooks", "docs", "runtimes"] {
             let managed = defaults.join(dir_name);
             assert!(
                 managed.is_dir(),

--- a/loom-daemon/src/runtime_admission.rs
+++ b/loom-daemon/src/runtime_admission.rs
@@ -246,7 +246,17 @@ fn type_name_of(value: &serde_json::Value) -> &'static str {
 fn roots(root: &Path) -> (PathBuf, PathBuf, PathBuf) {
     let installed = root.join(".loom");
     let defaults = root.join("defaults");
-    let manifests = if installed.join("roles").is_dir() && installed.join("runtimes").is_dir() {
+    // Each subdirectory falls back to `defaults/` independently (#4688): a
+    // consumer repo can have `.loom/roles/` populated while `.loom/runtimes/`
+    // is still missing (a provisioning gap on older installs), and gating
+    // BOTH choices on a single combined boolean sent every dispatch on that
+    // host to a nonexistent `defaults/roles/...` path, rejecting all of them.
+    let roles = if installed.join("roles").is_dir() {
+        installed.clone()
+    } else {
+        defaults.clone()
+    };
+    let runtimes = if installed.join("runtimes").is_dir() {
         installed.clone()
     } else {
         defaults.clone()
@@ -256,7 +266,7 @@ fn roots(root: &Path) -> (PathBuf, PathBuf, PathBuf) {
     } else {
         defaults
     };
-    (manifests.join("roles"), manifests.join("runtimes"), scripts.join("scripts"))
+    (roles.join("roles"), runtimes.join("runtimes"), scripts.join("scripts"))
 }
 
 pub fn resolve_and_admit(
@@ -335,9 +345,33 @@ pub fn resolve_and_admit(
     let role_doc: RoleManifest = serde_json::from_slice(&role_data).map_err(|e| {
         reject(format!("malformed role manifest {}: {e}", role_manifest.display()), vec![])
     })?;
-    let runtime_data = fs::read(&runtime_manifest).map_err(|e| {
-        reject(format!("runtime manifest {}: {e}", runtime_manifest.display()), vec![])
-    })?;
+    let runtime_data = match fs::read(&runtime_manifest) {
+        Ok(data) => data,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound && runtime == BUILTIN_RUNTIME => {
+            // #4688: the builtin `claude` runtime is the zero-config default;
+            // its capability manifest is additive, not a hard dependency. A
+            // provisioning gap that leaves `.loom/runtimes/` (and any
+            // `defaults/runtimes/` fallback) without a `claude.json` must not
+            // fail closed for every dispatch on that host — admit with no
+            // capability constraints instead. Non-builtin runtimes keep
+            // failing closed below: their manifest is the only source of
+            // truth for what they can do.
+            return Ok(ResolvedRuntime {
+                role: canonical.to_string(),
+                runtime,
+                source,
+                adapter,
+                role_manifest,
+                runtime_manifest,
+            });
+        }
+        Err(e) => {
+            return Err(reject(
+                format!("runtime manifest {}: {e}", runtime_manifest.display()),
+                vec![],
+            ));
+        }
+    };
     let runtime_doc: RuntimeManifest = serde_json::from_slice(&runtime_data).map_err(|e| {
         reject(
             format!("malformed runtime manifest {}: {e}", runtime_manifest.display()),
@@ -717,6 +751,97 @@ mod tests {
         let rejected =
             resolve_and_admit(installed.path(), "sweep-lifecycle", Some("codex")).unwrap_err();
         assert_eq!(rejected.unmet_capabilities, vec!["worktreeIsolation"]);
+    }
+
+    /// `roots()` must resolve each subdirectory's source independently
+    /// (#4688): a workspace with `.loom/roles/` present but `.loom/runtimes/`
+    /// absent must still resolve `roles` from `.loom/roles`, not fall through
+    /// to `defaults/roles` just because `runtimes` is missing.
+    #[test]
+    fn roots_resolves_roles_and_runtimes_independently() {
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir_all(root.path().join(".loom/roles")).unwrap();
+        fs::create_dir_all(root.path().join("defaults/runtimes")).unwrap();
+        fs::create_dir_all(root.path().join("defaults/scripts")).unwrap();
+        // `.loom/roles` exists but `.loom/runtimes` and `.loom/scripts` do not.
+        let (roles, runtimes, scripts) = roots(root.path());
+        assert_eq!(roles, root.path().join(".loom/roles"));
+        assert_eq!(runtimes, root.path().join("defaults/runtimes"));
+        assert_eq!(scripts, root.path().join("defaults/scripts"));
+    }
+
+    /// #4688 regression: a consumer repo can have `.loom/roles/` fully
+    /// provisioned while `.loom/runtimes/` is still missing (the exact live
+    /// incident layout — a provisioning gap on installs that predate
+    /// `defaults/runtimes/`). The per-directory `roots()` fallback resolves
+    /// roles from `.loom/roles` even though runtimes falls through, and the
+    /// builtin `claude` runtime — whose manifest is absent from BOTH
+    /// `.loom/runtimes/` and any `defaults/runtimes/` fallback, since this
+    /// fixture has no `defaults/` at all — degrades open rather than
+    /// rejecting the dispatch.
+    #[test]
+    fn consumer_layout_missing_runtimes_dir_still_admits_claude() {
+        let root = tempfile::tempdir().unwrap();
+        let loom_roles = root.path().join(".loom/roles");
+        fs::create_dir_all(&loom_roles).unwrap();
+        fs::write(
+            loom_roles.join("builder.json"),
+            r#"{"runtimeRequirements":["worktreeIsolation","mcp"]}"#,
+        )
+        .unwrap();
+        let loom_scripts = root.path().join(".loom/scripts");
+        fs::create_dir_all(&loom_scripts).unwrap();
+        let adapter = loom_scripts.join("spawn-claude.sh");
+        fs::write(&adapter, "#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&adapter, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        // No `.loom/runtimes/` and no `defaults/` at all — the exact live
+        // incident layout.
+        assert!(!root.path().join(".loom/runtimes").exists());
+        assert!(!root.path().join("defaults").exists());
+
+        let admitted = resolve_and_admit(root.path(), "sweep-lifecycle", None).unwrap();
+        assert_eq!(admitted.runtime, "claude");
+        // Roles resolved from `.loom/roles` — the per-directory fallback
+        // means the absence of `.loom/runtimes/` does NOT drag roles down
+        // to `defaults/roles` too.
+        assert!(admitted
+            .role_manifest
+            .starts_with(root.path().join(".loom")));
+        // Runtimes independently fall through to `defaults/runtimes` (which
+        // does not exist in this fixture either) since `.loom/runtimes/` is
+        // absent — and admission still succeeds because the missing
+        // manifest degrades open for the builtin runtime instead of
+        // rejecting the dispatch.
+        assert!(admitted
+            .runtime_manifest
+            .starts_with(root.path().join("defaults/runtimes")));
+    }
+
+    /// The degrade-open behaviour is scoped to the builtin `claude` runtime
+    /// only. An explicit non-builtin runtime with a missing manifest must
+    /// still fail closed — a regression guard against over-widening the
+    /// #4688 fix beyond the zero-config default.
+    #[test]
+    fn consumer_layout_missing_runtimes_dir_non_builtin_still_fails_closed() {
+        let root = tempfile::tempdir().unwrap();
+        let loom_roles = root.path().join(".loom/roles");
+        fs::create_dir_all(&loom_roles).unwrap();
+        fs::write(loom_roles.join("judge.json"), "{}").unwrap();
+        let loom_scripts = root.path().join(".loom/scripts");
+        fs::create_dir_all(&loom_scripts).unwrap();
+        let adapter = loom_scripts.join("spawn-codex.sh");
+        fs::write(&adapter, "#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&adapter, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let rejected = resolve_and_admit(root.path(), "judge", Some("codex")).unwrap_err();
+        assert!(rejected.reason.contains("runtime manifest"), "{}", rejected.reason);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`roots()` in `runtime_admission.rs` gated the `.loom/`-vs-`defaults/` choice
on a single combined `installed.join("roles").is_dir() &&
installed.join("runtimes").is_dir()` boolean, so a consumer repo with
`.loom/roles/` but no `.loom/runtimes/` fell through entirely to a
nonexistent `defaults/roles/...` path and had **every** dispatch rejected
(the live 2026-07-30 incident: 21/21 rejected fleet-wide on the first
post-update tick). This was compounded by a second defect: `.loom/runtimes/`
was never actually provisioned by either provisioning path (Rust-native
`loom-daemon init`/reinstall, or the bash `resync-installed.sh`), even
though `scripts/install/manifest.sh` already declared the mapping — so no
host could ever obtain the directory short of a manual `mkdir + cp`.

## Changes

- `loom-daemon/src/runtime_admission.rs`: `roots()` now resolves the
  `roles`, `runtimes`, and `scripts` source directories **independently** —
  a workspace with `.loom/roles/` populated resolves roles from
  `.loom/roles` even when `.loom/runtimes/` is absent, instead of dragging
  both down to `defaults/`.
- `loom-daemon/src/runtime_admission.rs`: `resolve_and_admit()` now
  degrades open (admits with no capability constraints) when the resolved
  runtime is the builtin `claude` runtime and no runtime manifest file is
  found — the manifest is additive capability metadata, not a hard
  dependency of the zero-config default. Non-builtin runtimes still fail
  closed on a missing manifest (their manifest is the only source of truth
  for what they can do).
- `loom-daemon/src/init/mod.rs`: added `"runtimes"` to both the
  `sync_managed_dir` call list and the `verify_all_copied_files` `dir_name`
  list, so a fresh `loom-daemon init` (and Rust-native reinstall) actually
  provisions `.loom/runtimes/`.
- `defaults/scripts/resync-installed.sh`: added a `.loom/runtimes` resync
  block. Unlike the other widened-surface blocks (`roles`/`docs`/`bin`),
  this one is **unconditional** (not gated on the destination already
  existing) so it backfills hosts that never had the directory, not just
  keeps it fresh once present.
- Tests: new unit tests in `runtime_admission.rs` (`roots()` per-directory
  resolution, the consumer-layout degrade-open case, and a non-builtin
  fail-closed regression guard) and `init/mod.rs` (fresh-install and
  reinstall/backfill coverage for `runtimes`, plus the real-shipped-tree
  guard extended to include `runtimes`); a new bash test group in
  `test-resync-installed.sh` covering the unconditional backfill (dry-run
  preview, apply, idempotent rerun).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|---------------|
| `roots()` resolves roles/runtimes/scripts independently, with a unit test for "installed roles, missing runtimes" | ✅ | `roots_resolves_roles_and_runtimes_independently`, `consumer_layout_missing_runtimes_dir_still_admits_claude` |
| Missing runtime manifest for builtin `claude` degrades open; non-builtin stays strict | ✅ | `consumer_layout_missing_runtimes_dir_still_admits_claude` (admits), `consumer_layout_missing_runtimes_dir_non_builtin_still_fails_closed` (still rejects) |
| `defaults/runtimes/` added to install/resync so `.loom/runtimes/` is provisioned and kept fresh | ✅ | `sync_managed_dir(..., "runtimes", ...)` in `init/mod.rs`; unconditional `resync_tree` block in `resync-installed.sh` |
| Regression test: `.loom/roles/` + no `.loom/runtimes/` + no `defaults/` admits a claude sweep-lifecycle dispatch | ✅ | `consumer_layout_missing_runtimes_dir_still_admits_claude` calls `resolve_and_admit(root, "sweep-lifecycle", None)` and asserts `Ok` |

## Test Plan

- `cargo test --lib -- runtime_admission:: init::` in `loom-daemon/` — 165
  passed, 0 failed.
- Full `cargo test --lib` — 2676 passed, 2 pre-existing unrelated failures
  (`safehouse::tests::run_sink_reconciliation_*`, timing-sensitive, confirmed
  to fail identically on unmodified `main` with `-uLOOM_RUNTIME`, no files
  under `src/safehouse.rs` touched by this PR).
- `cargo fmt --check` and `cargo clippy --lib --all-targets` — clean.
- `bash defaults/scripts/tests/test-resync-installed.sh` — 112/112 passed
  (new group 21 covers the `.loom/runtimes/` backfill: dry-run preview,
  apply creates + populates, idempotent rerun).
- `cargo build --bin loom-daemon` — builds cleanly.

Closes #4688