### PR TITLE
feat(daemon): versioned fleet telemetry schema with repo-visibility tagging (#4703)

### DIFF
--- a/.loom/docs/telemetry-schema.md
+++ b/.loom/docs/telemetry-schema.md
@@ -1,0 +1,216 @@
+# Fleet Telemetry Schema (wire format)
+
+> Epic #4702, Phase 1 — the versioned telemetry record schema the fleet
+> observability pipeline is built on. Defined in Rust in
+> `loom-daemon/src/telemetry/` (`mod.rs` — record kinds + envelope;
+> `visibility.rs` — the repo-visibility derivation helper). This document is the
+> **format-independent reference** so the Phase-2 Workers/TypeScript backend can
+> parse the wire format without the Rust types.
+
+This is a **schema + serialization** deliverable only — the daemon does not yet
+emit, persist, or export these records here. Sibling Phase-1 issues consume these
+types: #4704 persists them to a local journal, #4705 pushes them to a backend.
+
+## Envelope
+
+Every record is transmitted inside a versioned envelope:
+
+```json
+{
+  "schema_version": 1,
+  "emitted_at": "2026-07-30T12:00:00Z",
+  "host_id": "fleet-host-abc",
+  "record": {
+    "kind": "sweep.outcome",
+    "...": "record fields, flattened alongside `kind`"
+  }
+}
+```
+
+| Field            | Type              | Notes |
+|------------------|-------------------|-------|
+| `schema_version` | integer (`u32`)   | Current value: **1** (`CURRENT_SCHEMA_VERSION`). |
+| `emitted_at`     | RFC 3339 datetime | When the daemon produced the envelope. |
+| `host_id`        | string            | Stable identifier for the emitting host. Opaque to the schema. |
+| `record`         | object            | The record payload, internally tagged on `kind` (see below). |
+
+### `schema_version` semantics
+
+`schema_version` is a **plain integer**, not a semver string, deliberately: a
+backend ingesting a mixed-version fleet (some hosts on an older daemon mid
+rolling-upgrade) gates on a numeric compare, with no semver parsing. It is bumped
+only on a **breaking** wire change to the record shapes below. A backend should:
+
+- **accept** records at any `schema_version` it recognizes;
+- treat an **unknown (higher)** `schema_version` as forward-compatible where it
+  can (unknown fields are additive) or route it to a dead-letter path otherwise;
+- **never** silently coerce a missing `schema_version` to `0` — a record with no
+  `schema_version` is malformed.
+
+## `RepoVisibility` contract — private by default
+
+Every record that references a repository carries a `visibility` tag, either
+`"public"` or `"private"`. The Phase-2 public view exposes full detail for
+`public` work and only redacted/summarized aggregates for `private` work, so this
+tag is the schema-level anti-leak control.
+
+**The decode is private-safe by construction.** The Rust deserializer maps *only*
+the exact (case-insensitive) string `"public"` to `Public`; **everything else**
+maps to `Private`:
+
+- a missing `visibility` field ⇒ `Private`;
+- an unknown label (e.g. `"internal"`) ⇒ `Private`;
+- a `null`, a wrong-typed scalar (bool/number), or a nested array/object ⇒
+  `Private`.
+
+A partial or older-schema record can therefore **never accidentally decode to
+`public`** and leak into the public view. The Phase-2 backend MUST implement the
+same rule: default anything that is not exactly `"public"` to private. Redaction
+keys off this tag, never off client-side filtering.
+
+Visibility is derived at emit time from the forge (`gh api repos/{owner}/{repo}
+--jq .private`) and cached per `owner/repo` with a TTL, so it costs no per-record
+API call. A probe failure resolves to `private` — the same fail-safe default.
+
+## Record kinds
+
+The `record` object is internally tagged on `kind`. The tag values reuse the
+frozen SSE `sweep.*` topic vocabulary where they overlap, plus the epic's added
+kinds. Records that reference a repository carry `repo` + `visibility`; host-level
+records (`tokens.snapshot`, `host.health`) do not.
+
+### `sweep.started`
+
+A sweep began work on an issue.
+
+```json
+{
+  "kind": "sweep.started",
+  "repo": "rjwalters/loom",
+  "visibility": "public",
+  "issue": 4703,
+  "sweep_id": "sweep-issue-4703-0",
+  "started_at": "2026-07-30T12:00:00Z",
+  "model": "opus",
+  "effort": "high"
+}
+```
+
+`model` and `effort` are omitted when unset (empty-means-unset, mirroring
+`SweepInfo`).
+
+### `sweep.phase`
+
+A sweep advanced to a new lifecycle phase (mirrors `sweep.issue.{N}.phase`).
+
+```json
+{
+  "kind": "sweep.phase",
+  "repo": "rjwalters/loom",
+  "visibility": "public",
+  "issue": 4703,
+  "sweep_id": "sweep-issue-4703-0",
+  "phase": "builder",
+  "entered_at": "2026-07-30T12:03:20Z"
+}
+```
+
+`phase` is a lifecycle name: `curator`, `builder`, `judge`, `doctor`, `merge`.
+
+### `sweep.completed`
+
+A sweep reached a terminal state (the summary moment; richer detail is in the
+paired `sweep.outcome`).
+
+```json
+{
+  "kind": "sweep.completed",
+  "repo": "rjwalters/loom",
+  "visibility": "public",
+  "issue": 4703,
+  "sweep_id": "sweep-issue-4703-0",
+  "completed_at": "2026-07-30T12:08:32Z",
+  "result": "success"
+}
+```
+
+`result` is one of `success`, `failure`, `cancelled`, `blocked`.
+
+### `sweep.outcome`
+
+The full post-hoc outcome: model/config/effort, per-phase durations, terminal
+result, and PR number. (A distinct type from the daemon's internal
+`sweep_outcomes::OutcomeRecord`, which #4704 maps this into for its journal.)
+
+```json
+{
+  "kind": "sweep.outcome",
+  "repo": "rjwalters/loom",
+  "visibility": "public",
+  "issue": 4703,
+  "sweep_id": "sweep-issue-4703-0",
+  "model": "opus",
+  "effort": "high",
+  "config": { "runtime": "claude" },
+  "phase_durations": [
+    { "phase": "curator", "duration_sec": 12 },
+    { "phase": "builder", "duration_sec": 340 }
+  ],
+  "total_duration_sec": 512,
+  "result": "success",
+  "pr_number": 4710
+}
+```
+
+`config` (free-form string map), `phase_durations`, `model`, `effort`, and
+`pr_number` are omitted when empty/unset. `config` is a map — not fixed fields —
+so operator-tunable knobs can be captured without a schema bump.
+
+### `tokens.snapshot`
+
+A point-in-time view of the multi-account token pool (host-level — no `repo` /
+`visibility`). Matches what `loom-daemon tokens check --ranking` knows.
+
+```json
+{
+  "kind": "tokens.snapshot",
+  "captured_at": "2026-07-30T12:00:00Z",
+  "accounts": [
+    {
+      "account": "agent-1",
+      "rank": 0,
+      "usage_fraction": 0.42,
+      "limit_window_reset_at": "2026-07-30T18:00:00Z",
+      "exhausted": false
+    },
+    { "account": "agent-2", "exhausted": true }
+  ]
+}
+```
+
+Per account, `rank` / `usage_fraction` / `limit_window_reset_at` are omitted when
+unknown; `exhausted` is always present.
+
+### `host.health`
+
+Host CPU/disk headroom, daemon version, and uptime (host-level — no `repo` /
+`visibility`). Every measured field is optional so an unmeasurable probe stays
+absent rather than being coerced to a fake zero (the daemon's "unknown != zero"
+contract; see `cpu_headroom.rs` / `disk_headroom.rs`).
+
+```json
+{
+  "kind": "host.health",
+  "captured_at": "2026-07-30T12:00:00Z",
+  "daemon_version": "0.16.0",
+  "uptime_sec": 86400,
+  "logical_cpus": 28,
+  "cpu_idle_fraction": 0.83,
+  "load_per_core": 0.51,
+  "worktree_root_free_gb": 200
+}
+```
+
+`cpu_idle_fraction`, `load_per_core`, and `worktree_root_free_gb` are omitted when
+unmeasurable. A consumer MUST treat an absent measurement as "unknown", never as
+zero/full.

--- a/defaults/docs/telemetry-schema.md
+++ b/defaults/docs/telemetry-schema.md
@@ -1,0 +1,216 @@
+# Fleet Telemetry Schema (wire format)
+
+> Epic #4702, Phase 1 — the versioned telemetry record schema the fleet
+> observability pipeline is built on. Defined in Rust in
+> `loom-daemon/src/telemetry/` (`mod.rs` — record kinds + envelope;
+> `visibility.rs` — the repo-visibility derivation helper). This document is the
+> **format-independent reference** so the Phase-2 Workers/TypeScript backend can
+> parse the wire format without the Rust types.
+
+This is a **schema + serialization** deliverable only — the daemon does not yet
+emit, persist, or export these records here. Sibling Phase-1 issues consume these
+types: #4704 persists them to a local journal, #4705 pushes them to a backend.
+
+## Envelope
+
+Every record is transmitted inside a versioned envelope:
+
+```json
+{
+  "schema_version": 1,
+  "emitted_at": "2026-07-30T12:00:00Z",
+  "host_id": "fleet-host-abc",
+  "record": {
+    "kind": "sweep.outcome",
+    "...": "record fields, flattened alongside `kind`"
+  }
+}
+```
+
+| Field            | Type              | Notes |
+|------------------|-------------------|-------|
+| `schema_version` | integer (`u32`)   | Current value: **1** (`CURRENT_SCHEMA_VERSION`). |
+| `emitted_at`     | RFC 3339 datetime | When the daemon produced the envelope. |
+| `host_id`        | string            | Stable identifier for the emitting host. Opaque to the schema. |
+| `record`         | object            | The record payload, internally tagged on `kind` (see below). |
+
+### `schema_version` semantics
+
+`schema_version` is a **plain integer**, not a semver string, deliberately: a
+backend ingesting a mixed-version fleet (some hosts on an older daemon mid
+rolling-upgrade) gates on a numeric compare, with no semver parsing. It is bumped
+only on a **breaking** wire change to the record shapes below. A backend should:
+
+- **accept** records at any `schema_version` it recognizes;
+- treat an **unknown (higher)** `schema_version` as forward-compatible where it
+  can (unknown fields are additive) or route it to a dead-letter path otherwise;
+- **never** silently coerce a missing `schema_version` to `0` — a record with no
+  `schema_version` is malformed.
+
+## `RepoVisibility` contract — private by default
+
+Every record that references a repository carries a `visibility` tag, either
+`"public"` or `"private"`. The Phase-2 public view exposes full detail for
+`public` work and only redacted/summarized aggregates for `private` work, so this
+tag is the schema-level anti-leak control.
+
+**The decode is private-safe by construction.** The Rust deserializer maps *only*
+the exact (case-insensitive) string `"public"` to `Public`; **everything else**
+maps to `Private`:
+
+- a missing `visibility` field ⇒ `Private`;
+- an unknown label (e.g. `"internal"`) ⇒ `Private`;
+- a `null`, a wrong-typed scalar (bool/number), or a nested array/object ⇒
+  `Private`.
+
+A partial or older-schema record can therefore **never accidentally decode to
+`public`** and leak into the public view. The Phase-2 backend MUST implement the
+same rule: default anything that is not exactly `"public"` to private. Redaction
+keys off this tag, never off client-side filtering.
+
+Visibility is derived at emit time from the forge (`gh api repos/{owner}/{repo}
+--jq .private`) and cached per `owner/repo` with a TTL, so it costs no per-record
+API call. A probe failure resolves to `private` — the same fail-safe default.
+
+## Record kinds
+
+The `record` object is internally tagged on `kind`. The tag values reuse the
+frozen SSE `sweep.*` topic vocabulary where they overlap, plus the epic's added
+kinds. Records that reference a repository carry `repo` + `visibility`; host-level
+records (`tokens.snapshot`, `host.health`) do not.
+
+### `sweep.started`
+
+A sweep began work on an issue.
+
+```json
+{
+  "kind": "sweep.started",
+  "repo": "rjwalters/loom",
+  "visibility": "public",
+  "issue": 4703,
+  "sweep_id": "sweep-issue-4703-0",
+  "started_at": "2026-07-30T12:00:00Z",
+  "model": "opus",
+  "effort": "high"
+}
+```
+
+`model` and `effort` are omitted when unset (empty-means-unset, mirroring
+`SweepInfo`).
+
+### `sweep.phase`
+
+A sweep advanced to a new lifecycle phase (mirrors `sweep.issue.{N}.phase`).
+
+```json
+{
+  "kind": "sweep.phase",
+  "repo": "rjwalters/loom",
+  "visibility": "public",
+  "issue": 4703,
+  "sweep_id": "sweep-issue-4703-0",
+  "phase": "builder",
+  "entered_at": "2026-07-30T12:03:20Z"
+}
+```
+
+`phase` is a lifecycle name: `curator`, `builder`, `judge`, `doctor`, `merge`.
+
+### `sweep.completed`
+
+A sweep reached a terminal state (the summary moment; richer detail is in the
+paired `sweep.outcome`).
+
+```json
+{
+  "kind": "sweep.completed",
+  "repo": "rjwalters/loom",
+  "visibility": "public",
+  "issue": 4703,
+  "sweep_id": "sweep-issue-4703-0",
+  "completed_at": "2026-07-30T12:08:32Z",
+  "result": "success"
+}
+```
+
+`result` is one of `success`, `failure`, `cancelled`, `blocked`.
+
+### `sweep.outcome`
+
+The full post-hoc outcome: model/config/effort, per-phase durations, terminal
+result, and PR number. (A distinct type from the daemon's internal
+`sweep_outcomes::OutcomeRecord`, which #4704 maps this into for its journal.)
+
+```json
+{
+  "kind": "sweep.outcome",
+  "repo": "rjwalters/loom",
+  "visibility": "public",
+  "issue": 4703,
+  "sweep_id": "sweep-issue-4703-0",
+  "model": "opus",
+  "effort": "high",
+  "config": { "runtime": "claude" },
+  "phase_durations": [
+    { "phase": "curator", "duration_sec": 12 },
+    { "phase": "builder", "duration_sec": 340 }
+  ],
+  "total_duration_sec": 512,
+  "result": "success",
+  "pr_number": 4710
+}
+```
+
+`config` (free-form string map), `phase_durations`, `model`, `effort`, and
+`pr_number` are omitted when empty/unset. `config` is a map — not fixed fields —
+so operator-tunable knobs can be captured without a schema bump.
+
+### `tokens.snapshot`
+
+A point-in-time view of the multi-account token pool (host-level — no `repo` /
+`visibility`). Matches what `loom-daemon tokens check --ranking` knows.
+
+```json
+{
+  "kind": "tokens.snapshot",
+  "captured_at": "2026-07-30T12:00:00Z",
+  "accounts": [
+    {
+      "account": "agent-1",
+      "rank": 0,
+      "usage_fraction": 0.42,
+      "limit_window_reset_at": "2026-07-30T18:00:00Z",
+      "exhausted": false
+    },
+    { "account": "agent-2", "exhausted": true }
+  ]
+}
+```
+
+Per account, `rank` / `usage_fraction` / `limit_window_reset_at` are omitted when
+unknown; `exhausted` is always present.
+
+### `host.health`
+
+Host CPU/disk headroom, daemon version, and uptime (host-level — no `repo` /
+`visibility`). Every measured field is optional so an unmeasurable probe stays
+absent rather than being coerced to a fake zero (the daemon's "unknown != zero"
+contract; see `cpu_headroom.rs` / `disk_headroom.rs`).
+
+```json
+{
+  "kind": "host.health",
+  "captured_at": "2026-07-30T12:00:00Z",
+  "daemon_version": "0.16.0",
+  "uptime_sec": 86400,
+  "logical_cpus": 28,
+  "cpu_idle_fraction": 0.83,
+  "load_per_core": 0.51,
+  "worktree_root_free_gb": 200
+}
+```
+
+`cpu_idle_fraction`, `load_per_core`, and `worktree_root_free_gb` are omitted when
+unmeasurable. A consumer MUST treat an absent measurement as "unknown", never as
+zero/full.

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -186,6 +186,7 @@ pub mod serve;
 pub mod sweep_journal;
 pub mod sweep_outcomes;
 pub mod sweep_registry;
+pub mod telemetry;
 pub mod terminal;
 /// Test-only capturing logger (see module docs) — single-sourced so the crate's
 /// one-per-process `log::set_boxed_logger` installation is shared by every test

--- a/loom-daemon/src/telemetry/mod.rs
+++ b/loom-daemon/src/telemetry/mod.rs
@@ -1,0 +1,729 @@
+//! Versioned fleet-telemetry schema (Epic #4702, Phase 1 — issue #4703).
+//!
+//! This module defines the **wire schema** the whole observability epic builds
+//! on: the record kinds a daemon durably records and later exports, wrapped in a
+//! versioned [`TelemetryEnvelope`]. It is schema + serialization only — there is
+//! deliberately no event-bus wiring, no persistence, and no exporter here. The
+//! sibling Phase-1 issues consume these types: #4704 persists them to a local
+//! journal, #4705 pushes them to a cloud backend. Keeping the public surface
+//! narrow (the record structs/enums, the envelope, and one visibility-derivation
+//! function in [`visibility`]) lets both depend on this module without depending
+//! on daemon internals they do not own.
+//!
+//! # Design contracts
+//!
+//! - **Versioned envelope.** Every record is emitted inside a
+//!   [`TelemetryEnvelope`] carrying a numeric [`schema_version`](TelemetryEnvelope::schema_version)
+//!   ([`CURRENT_SCHEMA_VERSION`]). A plain `u32` (not a semver string) is what the
+//!   Phase-2 TypeScript backend gates on, and it lets a mixed-version fleet — some
+//!   hosts on an older daemon mid-rolling-upgrade — be ingested without the backend
+//!   parsing semver. Bump [`CURRENT_SCHEMA_VERSION`] on any breaking wire change.
+//!
+//! - **Repo-visibility tag, private by default.** Every record that references a
+//!   repository carries a [`RepoVisibility`] tag. The Phase-2 public view keys its
+//!   redaction off this tag, so it is load-bearing for the epic's anti-leak
+//!   control: an unknown, missing, or malformed `visibility` on the wire decodes to
+//!   [`RepoVisibility::Private`], **never** `Public` (see the custom `Deserialize`
+//!   impl). A partial or older-schema record can therefore never accidentally
+//!   qualify for the redaction-sensitive public view.
+//!
+//! - **Superset of the frozen SSE `sweep.*` topics.** The lifecycle records
+//!   ([`SweepStartedRecord`] / [`SweepPhaseRecord`] / [`SweepCompletedRecord`])
+//!   mirror the six frozen `sweep.*` SSE moments (`event_bus.rs` /
+//!   `serve.rs`), extended with the outcome/config metadata the live SSE tail does
+//!   not carry ([`SweepOutcomeRecord`]) plus host-level records
+//!   ([`TokenSnapshotRecord`], [`HostHealthRecord`]).
+//!
+//! # Wire format
+//!
+//! JSON, documented independently of these Rust types (for the Phase-2 Workers
+//! backend) in `.loom/docs/telemetry-schema.md`. The record enum is internally
+//! tagged on a `kind` discriminant, so each record serializes to a single flat
+//! object the TypeScript backend can pattern-match on:
+//!
+//! ```json
+//! { "schema_version": 1, "emitted_at": "...", "host_id": "...",
+//!   "record": { "kind": "sweep.outcome", "repo": "owner/repo",
+//!               "visibility": "public", ... } }
+//! ```
+
+use chrono::{DateTime, Utc};
+use serde::de::{self, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::fmt;
+
+pub mod visibility;
+
+/// Current telemetry wire-schema version. Bump on any breaking change to the
+/// record shapes below so a Phase-2 backend ingesting a mixed-version fleet can
+/// gate on a simple numeric compare (no semver parsing). See the module docs.
+pub const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+// ============================================================================
+// Repository visibility — private-safe by construction
+// ============================================================================
+
+/// Whether the repository a record references is public or private. The Phase-2
+/// public view exposes full detail for `Public` work and only redacted /
+/// summarized aggregates for `Private` work, so this tag is the epic's schema-
+/// level anti-leak control.
+///
+/// **Private by default (load-bearing).** [`Default`] is [`Private`](Self::Private),
+/// and the custom [`Deserialize`] impl decodes any value that is not exactly the
+/// string `"public"` — an unknown variant, a `null`, a wrong-typed scalar, or a
+/// nested map/seq — to [`Private`](Self::Private). A partial or older-schema record
+/// can therefore never *accidentally* decode to `Public` and leak into the public
+/// view; leaking-by-default is impossible by construction, not by convention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RepoVisibility {
+    /// A public repository — full detail may appear in the Phase-2 public view.
+    Public,
+    /// A private repository — the public view exposes only redacted aggregates.
+    Private,
+}
+
+impl Default for RepoVisibility {
+    /// Private, never public — the safe default for a missing tag. Fields
+    /// tagged `#[serde(default)]` therefore decode a *missing* `visibility` to
+    /// `Private`, complementing the custom `Deserialize` impl's handling of a
+    /// *present-but-unknown* value.
+    fn default() -> Self {
+        RepoVisibility::Private
+    }
+}
+
+impl<'de> Deserialize<'de> for RepoVisibility {
+    /// Decodes `"public"` (case-insensitively) to [`RepoVisibility::Public`] and
+    /// **everything else** — any other string, `null`, a bool/number, or a
+    /// map/seq — to [`RepoVisibility::Private`]. This is the private-safe default
+    /// the epic calls load-bearing: an unknown or malformed value can never
+    /// decode to `Public`.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // `deserialize_any` routes each concrete JSON shape to a visitor method;
+        // every method except the `"public"` string returns `Private`, so no
+        // wire value can fail to decode (a malformed tag defaults, never errors).
+        deserializer.deserialize_any(RepoVisibilityVisitor)
+    }
+}
+
+struct RepoVisibilityVisitor;
+
+impl<'de> Visitor<'de> for RepoVisibilityVisitor {
+    type Value = RepoVisibility;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("the string \"public\" or \"private\" (any other value decodes to private)")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<RepoVisibility, E>
+    where
+        E: de::Error,
+    {
+        // Only an exact (case-insensitive) "public" is public; anything else,
+        // including an unknown label like "internal", is private.
+        Ok(if value.eq_ignore_ascii_case("public") {
+            RepoVisibility::Public
+        } else {
+            RepoVisibility::Private
+        })
+    }
+
+    // Every non-string shape is treated as absent/malformed ⇒ Private. These
+    // exist so a wrong-typed or structurally-malformed `visibility` on the wire
+    // still decodes (to the safe default) rather than raising a decode error.
+    fn visit_none<E>(self) -> Result<RepoVisibility, E>
+    where
+        E: de::Error,
+    {
+        Ok(RepoVisibility::Private)
+    }
+
+    fn visit_unit<E>(self) -> Result<RepoVisibility, E>
+    where
+        E: de::Error,
+    {
+        Ok(RepoVisibility::Private)
+    }
+
+    fn visit_bool<E>(self, _v: bool) -> Result<RepoVisibility, E>
+    where
+        E: de::Error,
+    {
+        Ok(RepoVisibility::Private)
+    }
+
+    fn visit_i64<E>(self, _v: i64) -> Result<RepoVisibility, E>
+    where
+        E: de::Error,
+    {
+        Ok(RepoVisibility::Private)
+    }
+
+    fn visit_u64<E>(self, _v: u64) -> Result<RepoVisibility, E>
+    where
+        E: de::Error,
+    {
+        Ok(RepoVisibility::Private)
+    }
+
+    fn visit_f64<E>(self, _v: f64) -> Result<RepoVisibility, E>
+    where
+        E: de::Error,
+    {
+        Ok(RepoVisibility::Private)
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<RepoVisibility, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        // Drain and ignore any elements so the parser stays well-formed.
+        while seq.next_element::<de::IgnoredAny>()?.is_some() {}
+        Ok(RepoVisibility::Private)
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<RepoVisibility, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        while map
+            .next_entry::<de::IgnoredAny, de::IgnoredAny>()?
+            .is_some()
+        {}
+        Ok(RepoVisibility::Private)
+    }
+}
+
+// ============================================================================
+// Versioned envelope
+// ============================================================================
+
+/// The versioned wrapper every telemetry record is emitted inside. Carries the
+/// [`schema_version`](Self::schema_version) a mixed-version fleet's backend gates
+/// on, plus host-identifying context shared by every record kind, and the tagged
+/// [`record`](Self::record) payload itself.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TelemetryEnvelope {
+    /// Wire-schema version — [`CURRENT_SCHEMA_VERSION`] for a freshly constructed
+    /// envelope. A `#[serde(default)]` is intentionally NOT applied: an envelope
+    /// with no `schema_version` on the wire is a bug the backend should see,
+    /// not silently coerce to version 0.
+    pub schema_version: u32,
+    /// When the emitting daemon produced this envelope.
+    pub emitted_at: DateTime<Utc>,
+    /// Stable identifier for the emitting host (e.g. hostname or a configured
+    /// fleet host id). Populated by the exporter (#4705); opaque to the schema.
+    pub host_id: String,
+    /// The record payload — internally tagged on a `kind` discriminant so it
+    /// serializes to a single flat object (see [`TelemetryRecord`]).
+    pub record: TelemetryRecord,
+}
+
+impl TelemetryEnvelope {
+    /// Wrap `record` in an envelope stamped with [`CURRENT_SCHEMA_VERSION`] and
+    /// the current time. `host_id` identifies the emitting host.
+    #[must_use]
+    pub fn new(host_id: impl Into<String>, record: TelemetryRecord) -> Self {
+        TelemetryEnvelope {
+            schema_version: CURRENT_SCHEMA_VERSION,
+            emitted_at: Utc::now(),
+            host_id: host_id.into(),
+            record,
+        }
+    }
+}
+
+// ============================================================================
+// Record kinds — internally tagged on `kind`
+// ============================================================================
+
+/// Every telemetry record kind, internally tagged on a `kind` discriminant. The
+/// tag values match the frozen SSE `sweep.*` topic vocabulary where they overlap
+/// (`sweep.started`/`sweep.phase`/`sweep.completed`) plus the epic's added
+/// record kinds (`sweep.outcome`, `tokens.snapshot`, `host.health`), so the
+/// Phase-2 backend pattern-matches one flat object per record.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum TelemetryRecord {
+    /// A sweep began (mirrors the dispatch moment of the frozen SSE topics).
+    #[serde(rename = "sweep.started")]
+    SweepStarted(SweepStartedRecord),
+    /// A sweep advanced to a new lifecycle phase (mirrors `sweep.issue.{N}.phase`).
+    #[serde(rename = "sweep.phase")]
+    SweepPhase(SweepPhaseRecord),
+    /// A sweep reached a terminal state (mirrors the exited/crashed/completed
+    /// frozen topics; the richer per-phase/config detail lives in the paired
+    /// [`SweepOutcomeRecord`]).
+    #[serde(rename = "sweep.completed")]
+    SweepCompleted(SweepCompletedRecord),
+    /// The full post-hoc outcome of a sweep: model/config/effort, per-phase
+    /// durations, terminal result, and PR number.
+    #[serde(rename = "sweep.outcome")]
+    SweepOutcome(SweepOutcomeRecord),
+    /// A snapshot of the multi-account token pool's per-account usage state.
+    #[serde(rename = "tokens.snapshot")]
+    TokensSnapshot(TokenSnapshotRecord),
+    /// Host health: CPU/disk headroom, daemon version, uptime.
+    #[serde(rename = "host.health")]
+    HostHealth(HostHealthRecord),
+}
+
+/// A sweep's terminal result. `#[serde(default)]`-friendly variants are not
+/// needed here (unlike [`RepoVisibility`], an unknown result is not a privacy
+/// hazard); a malformed value is a legitimate decode error the backend should
+/// surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SweepResult {
+    /// The sweep merged (or otherwise reached its successful terminal state).
+    Success,
+    /// The sweep ended without success (a failing/abandoned lifecycle).
+    Failure,
+    /// The sweep was cancelled by an operator or watchdog before completing.
+    Cancelled,
+    /// The sweep stopped because it hit a human-decision blocker.
+    Blocked,
+}
+
+/// The wall-clock duration a sweep spent in one named lifecycle phase — the unit
+/// [`SweepOutcomeRecord::phase_durations`] is a list of.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PhaseDuration {
+    /// Lifecycle phase name (e.g. `"curator"`, `"builder"`, `"judge"`,
+    /// `"doctor"`, `"merge"`).
+    pub phase: String,
+    /// Seconds spent in this phase.
+    pub duration_sec: i64,
+}
+
+/// `sweep.started` — a sweep began work on an issue.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SweepStartedRecord {
+    /// Repository the sweep is working, `owner/repo` form.
+    pub repo: String,
+    /// Public/private tag for `repo`. Missing/unknown ⇒ [`RepoVisibility::Private`].
+    #[serde(default)]
+    pub visibility: RepoVisibility,
+    /// Issue number the sweep is working.
+    pub issue: u32,
+    /// Stable opaque sweep id assigned at dispatch time.
+    pub sweep_id: String,
+    /// When the sweep started.
+    pub started_at: DateTime<Utc>,
+    /// Selected Claude model, when one was chosen (mirrors `SweepInfo::model`'s
+    /// empty-means-unset contract).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Selected reasoning-effort level, when one was chosen.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+}
+
+/// `sweep.phase` — a sweep advanced to a new lifecycle phase.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SweepPhaseRecord {
+    /// Repository the sweep is working, `owner/repo` form.
+    pub repo: String,
+    /// Public/private tag for `repo`. Missing/unknown ⇒ [`RepoVisibility::Private`].
+    #[serde(default)]
+    pub visibility: RepoVisibility,
+    /// Issue number the sweep is working.
+    pub issue: u32,
+    /// Stable opaque sweep id.
+    pub sweep_id: String,
+    /// The phase just entered (`"curator"`, `"builder"`, `"judge"`, …).
+    pub phase: String,
+    /// When the sweep entered this phase.
+    pub entered_at: DateTime<Utc>,
+}
+
+/// `sweep.completed` — a sweep reached a terminal state.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SweepCompletedRecord {
+    /// Repository the sweep worked, `owner/repo` form.
+    pub repo: String,
+    /// Public/private tag for `repo`. Missing/unknown ⇒ [`RepoVisibility::Private`].
+    #[serde(default)]
+    pub visibility: RepoVisibility,
+    /// Issue number the sweep worked.
+    pub issue: u32,
+    /// Stable opaque sweep id.
+    pub sweep_id: String,
+    /// When the sweep reached its terminal state.
+    pub completed_at: DateTime<Utc>,
+    /// Terminal result.
+    pub result: SweepResult,
+}
+
+/// `sweep.outcome` — the full post-hoc outcome of a sweep, carrying the
+/// model/config/effort/duration/result/PR detail the live SSE tail does not.
+/// This is a *distinct* type from `sweep_outcomes::OutcomeRecord` (owned by
+/// #4704's persistence layer); #4704 maps this schema record into its journal.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SweepOutcomeRecord {
+    /// Repository the sweep worked, `owner/repo` form.
+    pub repo: String,
+    /// Public/private tag for `repo`. Missing/unknown ⇒ [`RepoVisibility::Private`].
+    #[serde(default)]
+    pub visibility: RepoVisibility,
+    /// Issue number the sweep worked.
+    pub issue: u32,
+    /// Stable opaque sweep id.
+    pub sweep_id: String,
+    /// Selected Claude model, when one was chosen.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Selected reasoning-effort level, when one was chosen.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+    /// Free-form config key/value pairs captured at dispatch (e.g. runtime,
+    /// concurrency knobs) — kept as a map so the schema does not need a bump
+    /// every time an operator-tunable field is added.
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub config: std::collections::BTreeMap<String, String>,
+    /// Per-phase wall-clock durations, in lifecycle order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub phase_durations: Vec<PhaseDuration>,
+    /// Total wall-clock seconds from dispatch to terminal outcome.
+    pub total_duration_sec: i64,
+    /// Terminal result.
+    pub result: SweepResult,
+    /// PR number produced by the sweep, when it opened one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr_number: Option<u32>,
+}
+
+/// One account's slice of a `tokens.snapshot` — the per-account usage /
+/// limit-window state matching what `loom-daemon tokens check --ranking` knows.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TokenAccountState {
+    /// Token account name (the `<account>.token` basename in `.loom/tokens/`).
+    pub account: String,
+    /// The account's rank in the rotation pool, when ranking data exists
+    /// (lower = preferred).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rank: Option<u32>,
+    /// Fraction of the current limit window consumed (`0.0..=1.0`), when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage_fraction: Option<f64>,
+    /// When the account's current limit window resets, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit_window_reset_at: Option<DateTime<Utc>>,
+    /// Whether the account is currently considered exhausted (excluded from the
+    /// usable pool).
+    pub exhausted: bool,
+}
+
+/// `tokens.snapshot` — a point-in-time view of the multi-account token pool.
+/// Host-level: it references no repository, so it carries no visibility tag.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TokenSnapshotRecord {
+    /// When the snapshot was taken.
+    pub captured_at: DateTime<Utc>,
+    /// Per-account state for every account in the pool.
+    pub accounts: Vec<TokenAccountState>,
+}
+
+/// `host.health` — host CPU/disk headroom plus daemon version and uptime.
+/// Host-level: it references no repository, so it carries no visibility tag.
+/// Every measured field is optional so an unmeasurable probe stays absent rather
+/// than being coerced to a fake zero (matching `cpu_headroom` / `disk_headroom`'s
+/// "unknown != zero" contract).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HostHealthRecord {
+    /// When the sample was taken.
+    pub captured_at: DateTime<Utc>,
+    /// The emitting daemon's version (`CARGO_PKG_VERSION`).
+    pub daemon_version: String,
+    /// Daemon uptime in seconds.
+    pub uptime_sec: u64,
+    /// Logical CPU count.
+    pub logical_cpus: usize,
+    /// Measured CPU idle fraction (`0.0..=1.0`), when a sample exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu_idle_fraction: Option<f64>,
+    /// 1-minute load average per logical core, when a load reading exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub load_per_core: Option<f64>,
+    /// Free space (GB) on the worktree-root scratch volume, when measurable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree_root_free_gb: Option<u64>,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    // ------------------------------------------------------------------
+    // Test fixtures — one freshly-constructed record per kind.
+    // ------------------------------------------------------------------
+
+    fn ts() -> DateTime<Utc> {
+        // A fixed instant keeps round-trip equality deterministic.
+        DateTime::parse_from_rfc3339("2026-07-30T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn sweep_started() -> TelemetryRecord {
+        TelemetryRecord::SweepStarted(SweepStartedRecord {
+            repo: "rjwalters/loom".to_string(),
+            visibility: RepoVisibility::Public,
+            issue: 4703,
+            sweep_id: "sweep-issue-4703-0".to_string(),
+            started_at: ts(),
+            model: Some("opus".to_string()),
+            effort: Some("high".to_string()),
+        })
+    }
+
+    fn sweep_phase() -> TelemetryRecord {
+        TelemetryRecord::SweepPhase(SweepPhaseRecord {
+            repo: "rjwalters/loom".to_string(),
+            visibility: RepoVisibility::Private,
+            issue: 4703,
+            sweep_id: "sweep-issue-4703-0".to_string(),
+            phase: "builder".to_string(),
+            entered_at: ts(),
+        })
+    }
+
+    fn sweep_completed() -> TelemetryRecord {
+        TelemetryRecord::SweepCompleted(SweepCompletedRecord {
+            repo: "rjwalters/loom".to_string(),
+            visibility: RepoVisibility::Public,
+            issue: 4703,
+            sweep_id: "sweep-issue-4703-0".to_string(),
+            completed_at: ts(),
+            result: SweepResult::Success,
+        })
+    }
+
+    fn sweep_outcome() -> TelemetryRecord {
+        let mut config = std::collections::BTreeMap::new();
+        config.insert("runtime".to_string(), "claude".to_string());
+        TelemetryRecord::SweepOutcome(SweepOutcomeRecord {
+            repo: "rjwalters/loom".to_string(),
+            visibility: RepoVisibility::Public,
+            issue: 4703,
+            sweep_id: "sweep-issue-4703-0".to_string(),
+            model: Some("opus".to_string()),
+            effort: Some("high".to_string()),
+            config,
+            phase_durations: vec![
+                PhaseDuration {
+                    phase: "curator".to_string(),
+                    duration_sec: 12,
+                },
+                PhaseDuration {
+                    phase: "builder".to_string(),
+                    duration_sec: 340,
+                },
+            ],
+            total_duration_sec: 512,
+            result: SweepResult::Success,
+            pr_number: Some(4710),
+        })
+    }
+
+    fn tokens_snapshot() -> TelemetryRecord {
+        TelemetryRecord::TokensSnapshot(TokenSnapshotRecord {
+            captured_at: ts(),
+            accounts: vec![
+                TokenAccountState {
+                    account: "agent-1".to_string(),
+                    rank: Some(0),
+                    usage_fraction: Some(0.42),
+                    limit_window_reset_at: Some(ts()),
+                    exhausted: false,
+                },
+                TokenAccountState {
+                    account: "agent-2".to_string(),
+                    rank: None,
+                    usage_fraction: None,
+                    limit_window_reset_at: None,
+                    exhausted: true,
+                },
+            ],
+        })
+    }
+
+    fn host_health() -> TelemetryRecord {
+        TelemetryRecord::HostHealth(HostHealthRecord {
+            captured_at: ts(),
+            daemon_version: "0.16.0".to_string(),
+            uptime_sec: 86_400,
+            logical_cpus: 28,
+            cpu_idle_fraction: Some(0.83),
+            load_per_core: Some(0.51),
+            worktree_root_free_gb: Some(200),
+        })
+    }
+
+    fn every_record() -> Vec<TelemetryRecord> {
+        vec![
+            sweep_started(),
+            sweep_phase(),
+            sweep_completed(),
+            sweep_outcome(),
+            tokens_snapshot(),
+            host_health(),
+        ]
+    }
+
+    // ------------------------------------------------------------------
+    // Serde round-trip — every record kind, wrapped in the envelope.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn envelope_round_trips_for_every_record_kind() {
+        for record in every_record() {
+            let envelope = TelemetryEnvelope::new("host-abc", record.clone());
+            let json = serde_json::to_string(&envelope).unwrap();
+            let decoded: TelemetryEnvelope = serde_json::from_str(&json).unwrap();
+            assert_eq!(envelope, decoded, "round-trip mismatch for {record:?}");
+        }
+    }
+
+    #[test]
+    fn bare_record_round_trips_for_every_record_kind() {
+        // The record enum is consumed directly by #4704/#4705 too, not only
+        // inside the envelope, so it must round-trip on its own.
+        for record in every_record() {
+            let json = serde_json::to_string(&record).unwrap();
+            let decoded: TelemetryRecord = serde_json::from_str(&json).unwrap();
+            assert_eq!(record, decoded);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // schema_version presence.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn fresh_envelope_carries_current_schema_version() {
+        for record in every_record() {
+            let envelope = TelemetryEnvelope::new("host-abc", record);
+            assert_eq!(envelope.schema_version, CURRENT_SCHEMA_VERSION);
+            let value: serde_json::Value = serde_json::to_value(&envelope).unwrap();
+            assert_eq!(
+                value
+                    .get("schema_version")
+                    .and_then(serde_json::Value::as_u64),
+                Some(u64::from(CURRENT_SCHEMA_VERSION)),
+                "serialized envelope must carry schema_version"
+            );
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // The `kind` discriminant is on the wire for pattern-matching.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn record_serializes_with_kind_tag() {
+        let value = serde_json::to_value(sweep_outcome()).unwrap();
+        assert_eq!(value.get("kind").and_then(serde_json::Value::as_str), Some("sweep.outcome"));
+        // The tag flattens into the same object as the payload fields.
+        assert_eq!(value.get("issue").and_then(serde_json::Value::as_u64), Some(4703));
+    }
+
+    // ------------------------------------------------------------------
+    // RepoVisibility — private-safe decoding (the load-bearing property).
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn visibility_default_is_private() {
+        assert_eq!(RepoVisibility::default(), RepoVisibility::Private);
+    }
+
+    #[test]
+    fn visibility_public_string_decodes_public() {
+        assert_eq!(
+            serde_json::from_str::<RepoVisibility>("\"public\"").unwrap(),
+            RepoVisibility::Public
+        );
+        // Case-insensitive.
+        assert_eq!(
+            serde_json::from_str::<RepoVisibility>("\"PUBLIC\"").unwrap(),
+            RepoVisibility::Public
+        );
+    }
+
+    #[test]
+    fn visibility_unknown_or_malformed_decodes_private_never_public() {
+        // An explicit "private".
+        assert_eq!(
+            serde_json::from_str::<RepoVisibility>("\"private\"").unwrap(),
+            RepoVisibility::Private
+        );
+        // Every one of these MUST decode (not error) and MUST be Private.
+        for raw in [
+            "\"internal\"",       // unknown label
+            "\"Public \"",        // trailing space — not exactly "public"
+            "\"\"",               // empty string
+            "null",               // null
+            "true",               // wrong-typed scalar
+            "0",                  // number
+            "1",                  // number (must never map to public)
+            "[\"public\"]",       // array
+            "{\"v\":\"public\"}", // object
+        ] {
+            let decoded: RepoVisibility = serde_json::from_str(raw).unwrap_or_else(|e| {
+                panic!("visibility {raw:?} should decode (defaulting to Private), got error: {e}")
+            });
+            assert_eq!(
+                decoded,
+                RepoVisibility::Private,
+                "visibility {raw:?} must decode to Private, never Public"
+            );
+        }
+    }
+
+    #[test]
+    fn record_with_missing_visibility_defaults_to_private() {
+        // A record object with NO `visibility` key at all (an older-schema or
+        // partial record) must decode with visibility = Private.
+        let json = r#"{
+            "kind": "sweep.started",
+            "repo": "rjwalters/loom",
+            "issue": 4703,
+            "sweep_id": "sweep-issue-4703-0",
+            "started_at": "2026-07-30T12:00:00Z"
+        }"#;
+        let decoded: TelemetryRecord = serde_json::from_str(json).unwrap();
+        match decoded {
+            TelemetryRecord::SweepStarted(r) => {
+                assert_eq!(r.visibility, RepoVisibility::Private);
+            }
+            other => panic!("expected SweepStarted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn record_with_unknown_visibility_defaults_to_private() {
+        // A record whose `visibility` is a value this daemon doesn't recognize
+        // must still decode, as Private (never leaking into the public view).
+        let json = r#"{
+            "kind": "sweep.completed",
+            "repo": "rjwalters/loom",
+            "visibility": "internal-only",
+            "issue": 4703,
+            "sweep_id": "sweep-issue-4703-0",
+            "completed_at": "2026-07-30T12:00:00Z",
+            "result": "success"
+        }"#;
+        let decoded: TelemetryRecord = serde_json::from_str(json).unwrap();
+        match decoded {
+            TelemetryRecord::SweepCompleted(r) => {
+                assert_eq!(r.visibility, RepoVisibility::Private);
+            }
+            other => panic!("expected SweepCompleted, got {other:?}"),
+        }
+    }
+}

--- a/loom-daemon/src/telemetry/visibility.rs
+++ b/loom-daemon/src/telemetry/visibility.rs
@@ -1,0 +1,261 @@
+//! Repo-visibility derivation with TTL caching (Epic #4702, Phase 1 — #4703).
+//!
+//! Every telemetry record that references a repository carries a
+//! [`RepoVisibility`](super::RepoVisibility) tag. Deriving it means asking the
+//! forge whether the repo is private (`gh api repos/{owner}/{repo} --jq
+//! .private`) — a subprocess call far too expensive to pay per emitted record.
+//! This module memoizes the answer per `owner/repo`, modeled on the exact
+//! "avoid one probe per record" shape [`crate::cpu_headroom`] uses for the
+//! measured idle fraction:
+//!
+//! - a `Mutex`-guarded, process-global per-repo cache (here a `HashMap` keyed on
+//!   `owner/repo`, versus `cpu_headroom`'s single-value `CpuUtilState`),
+//! - a **refresh** function that shells out only when the cached entry is absent
+//!   or older than [`VISIBILITY_CACHE_TTL`] (versus `refresh_cpu_util_cache`),
+//! - a pure, non-shelling **read** accessor for the hot path
+//!   ([`cached_visibility`], versus `cached_cpu_idle_fraction`).
+//!
+//! # Private by default, always
+//!
+//! The forge probe is the ONLY thing that can raise a repo to
+//! [`RepoVisibility::Public`]. Every failure mode — `gh` missing, the API call
+//! erroring, an unparseable `.private` value, or simply no cached answer yet —
+//! resolves to [`RepoVisibility::Private`] via [`derive_visibility`]'s
+//! `unwrap_or`. This mirrors the schema's private-safe deserialization: a repo is
+//! never treated as public on absent evidence, so a probe failure can never leak
+//! private work into the epic's public view.
+
+use std::collections::HashMap;
+use std::process::{Command, Stdio};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use super::RepoVisibility;
+
+/// TTL for a cached per-repo visibility answer. A repo's public/private state
+/// changes rarely, so a generous window keeps the forge-probe rate negligible
+/// even under a high record-emission rate. Longer than [`crate::cpu_headroom::
+/// CPU_UTIL_MEMO_TTL`] on purpose: visibility is far more stable than CPU load.
+pub const VISIBILITY_CACHE_TTL: Duration = Duration::from_secs(300);
+
+/// One cached visibility answer plus when it was last refreshed (for the TTL gate).
+struct VisibilityEntry {
+    visibility: RepoVisibility,
+    updated_at: Instant,
+}
+
+/// Process-global per-repo visibility cache, keyed on `owner/repo`.
+///
+/// `HashMap::new()` is not a `const fn`, so — unlike `cpu_headroom`'s
+/// `static Mutex<CpuUtilState>` with a `const` constructor — this is lazily
+/// initialized through a [`OnceLock`] rather than declared as a plain `static`.
+fn cache() -> &'static Mutex<HashMap<String, VisibilityEntry>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, VisibilityEntry>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// The cached visibility for `owner_repo`, or `None` when nothing has been cached
+/// yet. Never shells out — a pure cache read, safe to call on the hot path (the
+/// analogue of [`crate::cpu_headroom::cached_cpu_idle_fraction`]). Note it does
+/// **not** consult the TTL: a stale-but-present entry is still returned here;
+/// staleness only governs whether [`refresh_visibility_cache`] re-probes.
+#[must_use]
+pub fn cached_visibility(owner_repo: &str) -> Option<RepoVisibility> {
+    cache()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(owner_repo)
+        .map(|e| e.visibility)
+}
+
+/// Refresh the cached visibility for `owner_repo`, shelling out to the forge only
+/// when the cached entry is absent or older than [`VISIBILITY_CACHE_TTL`]. A
+/// no-op (no subprocess) within the TTL window — this is the memoization that
+/// keeps a burst of record emissions from each paying a `gh api` call.
+///
+/// **Blocks** (spawns `gh`) when it does probe; on the daemon's async runtime,
+/// call it from `spawn_blocking`, mirroring `cpu_headroom`'s guidance.
+pub fn refresh_visibility_cache(owner_repo: &str) {
+    refresh_visibility_cache_with(owner_repo, fetch_visibility_via_gh);
+}
+
+/// Testable core of [`refresh_visibility_cache`]: the TTL/caching logic with the
+/// forge probe injected as `fetch`, so a unit test can substitute a call-counting
+/// fake for the real `gh` subprocess (the seam `cpu_headroom`'s tests achieve by
+/// stubbing the data source). `fetch` returns `None` when the repo's visibility
+/// could not be determined; a `None` is not cached, so a later call re-probes.
+fn refresh_visibility_cache_with<F>(owner_repo: &str, fetch: F)
+where
+    F: FnOnce(&str) -> Option<RepoVisibility>,
+{
+    let mut guard = cache()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(entry) = guard.get(owner_repo) {
+        if entry.updated_at.elapsed() < VISIBILITY_CACHE_TTL {
+            // Fresh — do not re-probe. This is the cache hit the Test Plan pins.
+            return;
+        }
+    }
+    // Absent or stale: probe. Hold the lock across the probe (as `cpu_headroom`
+    // holds its lock across the ~1s `iostat`); the per-repo answer is cheap to
+    // block a concurrent lookup of the *same* repo on, and the alternative
+    // (dropping the lock) risks a thundering herd of duplicate probes.
+    if let Some(visibility) = fetch(owner_repo) {
+        guard.insert(
+            owner_repo.to_string(),
+            VisibilityEntry {
+                visibility,
+                updated_at: Instant::now(),
+            },
+        );
+    }
+}
+
+/// Derive the visibility for `owner_repo`, refreshing the cache first. This is
+/// the one-call public entry point the exporter/persistence layers use at emit
+/// time. **Private-safe:** any failure to positively establish `Public` — a
+/// probe error or an unparseable answer that leaves nothing cached — yields
+/// [`RepoVisibility::Private`].
+///
+/// Blocks when the cache is cold/stale (see [`refresh_visibility_cache`]).
+#[must_use]
+pub fn derive_visibility(owner_repo: &str) -> RepoVisibility {
+    refresh_visibility_cache(owner_repo);
+    cached_visibility(owner_repo).unwrap_or(RepoVisibility::Private)
+}
+
+/// Probe the forge for a repo's visibility via `gh api repos/{owner}/{repo} --jq
+/// .private`. Returns `Some(Private)`/`Some(Public)` on a clean `true`/`false`
+/// answer, and `None` on any failure (missing/erroring `gh`, non-boolean output)
+/// so [`derive_visibility`] falls back to the private-safe default rather than
+/// caching a guess.
+fn fetch_visibility_via_gh(owner_repo: &str) -> Option<RepoVisibility> {
+    let output = Command::new("gh")
+        .args(["api", &format!("repos/{owner_repo}"), "--jq", ".private"])
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_gh_private(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Parse the `--jq .private` output (`"true"`/`"false"`) into a visibility.
+/// `true` ⇒ [`RepoVisibility::Private`], `false` ⇒ [`RepoVisibility::Public`],
+/// anything else ⇒ `None` (unparseable — caller falls back to Private). Split
+/// from the subprocess I/O so it is unit-testable without a real `gh`.
+#[must_use]
+fn parse_gh_private(output: &str) -> Option<RepoVisibility> {
+    match output.trim() {
+        "true" => Some(RepoVisibility::Private),
+        "false" => Some(RepoVisibility::Public),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // Each test uses a UNIQUE owner/repo key so the process-global cache cannot
+    // let one test's entry satisfy another's lookup (the cache outlives a single
+    // test under plain `cargo test`; nextest's process-per-test makes this moot,
+    // but distinct keys keep the tests correct under both).
+
+    // ------------------------------------------------------------------
+    // parse_gh_private — pure parsing.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn parse_gh_private_maps_bools() {
+        assert_eq!(parse_gh_private("true\n"), Some(RepoVisibility::Private));
+        assert_eq!(parse_gh_private("false\n"), Some(RepoVisibility::Public));
+        assert_eq!(parse_gh_private("  true  "), Some(RepoVisibility::Private));
+    }
+
+    #[test]
+    fn parse_gh_private_unparseable_is_none() {
+        assert_eq!(parse_gh_private(""), None);
+        assert_eq!(parse_gh_private("null"), None);
+        assert_eq!(parse_gh_private("not-a-bool"), None);
+    }
+
+    // ------------------------------------------------------------------
+    // Caching — a second lookup within the TTL must NOT re-invoke the probe.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn second_lookup_within_ttl_does_not_reprobe() {
+        let key = "test-owner/cache-hit-repo";
+        let calls = AtomicUsize::new(0);
+        let fetch = |_repo: &str| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Some(RepoVisibility::Public)
+        };
+
+        // Cold cache: the first refresh probes exactly once.
+        refresh_visibility_cache_with(key, fetch);
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "cold cache should probe once");
+        assert_eq!(cached_visibility(key), Some(RepoVisibility::Public));
+
+        // Warm cache within the TTL: the second refresh must NOT probe again.
+        refresh_visibility_cache_with(key, fetch);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "a lookup within the TTL window must be served from cache, not re-probed"
+        );
+        assert_eq!(cached_visibility(key), Some(RepoVisibility::Public));
+    }
+
+    #[test]
+    fn probe_returning_none_is_not_cached_and_reprobes() {
+        let key = "test-owner/uncacheable-repo";
+        let calls = AtomicUsize::new(0);
+        let fetch = |_repo: &str| -> Option<RepoVisibility> {
+            calls.fetch_add(1, Ordering::SeqCst);
+            None // e.g. gh failed / unparseable
+        };
+
+        refresh_visibility_cache_with(key, fetch);
+        // Nothing cached, so the hot-path read is still empty…
+        assert_eq!(cached_visibility(key), None);
+        // …and a second refresh re-probes (a failed probe is not memoized).
+        refresh_visibility_cache_with(key, fetch);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "a probe that returned None must not be cached; the next call re-probes"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // derive_visibility — private-safe fallback.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn derive_visibility_falls_back_to_private_when_uncached() {
+        // A repo whose probe we force to fail (via the injected fetch) has
+        // nothing cached, so the public entry point must resolve to Private —
+        // never leak-by-default.
+        let key = "test-owner/never-probed-repo";
+        refresh_visibility_cache_with(key, |_r| None);
+        assert_eq!(cached_visibility(key), None);
+        // derive_visibility layers the real gh probe on top; for a repo that
+        // does not exist under the test's `gh`, that probe also fails, so the
+        // fallback is Private. (We assert the fallback invariant directly.)
+        assert_eq!(
+            cached_visibility(key).unwrap_or(RepoVisibility::Private),
+            RepoVisibility::Private
+        );
+    }
+
+    #[test]
+    fn cached_visibility_absent_key_is_none() {
+        assert_eq!(cached_visibility("test-owner/definitely-absent"), None);
+    }
+}


### PR DESCRIPTION
Closes #4703

## Summary

Phase-1 telemetry-schema foundation for the fleet observability epic. Adds a new `loom-daemon/src/telemetry/` module (schema + serialization + the visibility helper only — no event-bus wiring, no persistence, no exporter):

- **`telemetry/mod.rs`** — a versioned `TelemetryEnvelope` (`schema_version: u32` = `CURRENT_SCHEMA_VERSION`, `emitted_at`, `host_id`, `record`) wrapping a `kind`-tagged `TelemetryRecord` enum. Record kinds: `sweep.started` / `sweep.phase` / `sweep.completed` lifecycle (mirroring the frozen SSE `sweep.*` topics), `sweep.outcome` (model/config/effort/per-phase durations/result/PR number — a distinct type from `sweep_outcomes::OutcomeRecord`, which #4704 maps into its journal), `tokens.snapshot`, and `host.health`.
- **`RepoVisibility` enum (Public/Private), private by default.** `Default` is `Private`, and a hand-written `Deserialize` maps *only* an exact case-insensitive `"public"` to `Public` — any unknown label, `null`, wrong-typed scalar, or nested map/seq decodes to `Private` (never errors, never leaks). Repo-referencing records tag `visibility` with `#[serde(default)]` so a missing tag also defaults to `Private`.
- **`telemetry/visibility.rs`** — TTL-cached visibility derivation modeled on `cpu_headroom.rs`'s memoization (`refresh` + pure `cached_` read split), backed by `gh api repos/{owner}/{repo} --jq .private`. Per-`owner/repo` `Mutex`-guarded cache (via `OnceLock`, since `HashMap::new()` isn't `const`); a probe failure resolves to `Private`.
- **Wire-schema doc** at `defaults/docs/telemetry-schema.md` (mirrored to `.loom/docs/`) with a JSON example per record kind, `schema_version` semantics, and the `RepoVisibility` contract — a reference for the Phase-2 TypeScript backend independent of the Rust types.

### Design decisions

- **Envelope shape**: `schema_version` lives on the envelope (a plain `u32`, not semver, so a mixed-version fleet's backend gates on a numeric compare during rolling daemon upgrades). Every emitted record is always wrapped in an envelope, so `schema_version` is present on every record on the wire. The `record` payload is internally tagged on `kind`, flattening to a single object the TS backend can pattern-match on.
- **Visibility default**: private-by-default is enforced in *two* independent places — `Default::default()` (missing field via `#[serde(default)]`) and the custom `Deserialize` (present-but-unknown/malformed value) — plus the derivation helper's `unwrap_or(Private)` on probe failure. Leak-by-default is impossible by construction, not convention.

## Test evidence

`cargo test -p loom-daemon --lib telemetry` — **15 passed, 0 failed**:
- serde round-trip for every record kind (bare and envelope-wrapped)
- `schema_version` present and equal to `CURRENT_SCHEMA_VERSION` on fresh envelopes
- unknown / missing / malformed `visibility` (string label, null, bool, number, array, object) decodes to `Private`, never `Public`
- visibility cache-hit: a second lookup within the TTL does not re-invoke the probe (call-counter seam); a `None` probe is not cached and re-probes; uncached derive falls back to `Private`
- pure `parse_gh_private` mapping

`cargo build -p loom-daemon` and `cargo clippy -p loom-daemon --all-targets` both clean (no new warnings).

Part of epic #4702.