### PR TITLE
fix(sweep): record an orchestrator PID for sweep-run liveness, not the one-shot tool shell

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -764,11 +764,13 @@ This section exists because `/loom:sweep` was originally hardened (#3373 checkpo
 Run this **exactly once**, before anything else:
 
 ```bash
-RUN_ID=$(./.loom/scripts/sweep-run-registry.sh new)
+RUN_ID=$(./.loom/scripts/sweep-run-registry.sh new --pid "$PPID")
 echo "sweep run id: $RUN_ID"
 ```
 
-`sweep-run-registry.sh new` generates a portable (macOS/Linux, no `uuidgen`) run id combining a UTC timestamp + PID + random suffix (e.g. `sweep-20260722T231500Z-84213-a3f9c1`), and registers it under `.loom/sweep-run/<RUN_ID>.json` (gitignored) with a liveness PID (the orchestrator `$PPID`) for peer detection.
+`sweep-run-registry.sh new` generates a portable (macOS/Linux, no `uuidgen`) run id combining a UTC timestamp + PID + random suffix (e.g. `sweep-20260722T231500Z-84213-a3f9c1`), and registers it under `.loom/sweep-run/<RUN_ID>.json` (gitignored) with a liveness PID for peer detection.
+
+**`--pid "$PPID"` is load-bearing, not decoration (#4691).** `$PPID` expanded *here* — in the tool-call shell — is the long-lived orchestrator (`claude -p /loom:sweep …`) that spans the whole sweep. The tool-call shell itself is a fresh one-shot `<shell> -c …` process that is reaped the moment this Bash block returns, so recording *it* would mark this run dead within seconds of registration; the very next peer scan would then prune this run's registry entry and delete its `main-clean-baseline-<RUN_ID>.txt` mid-sweep (and, because the entry vanishes before the baseline is written, orphan that baseline forever). Passing `$PPID` explicitly also makes the recovery lookup below — which matches on `$PPID` — actually find this entry. `sweep-run-registry.sh` resolves the same orchestrator PID itself when `--pid` is omitted, so an older installed copy of this skill still behaves correctly.
 
 **Treat the printed `RUN_ID` as a fixed literal for the entire rest of this sweep.** Thread it — as that literal string — into every `--task-id "$RUN_ID"` checkpoint write and into the main-clean baseline path below. Do **NOT** regenerate it per Bash tool call, and do **NOT** fall back to `sweep-$$` (that is the exact bug this fixes: `$$` is a fresh subshell PID on every tool call). If you ever lose track of the literal mid-sweep, recover it from the registry rather than minting a new one:
 
@@ -785,6 +787,8 @@ At sweep completion (or abort), remove this run's registry entry:
 `cleanup` removes **both** RUN_ID-keyed transients of this run: the registry entry `.loom/sweep-run/<RUN_ID>.json` and the main-clean baseline `.loom/sweep-checkpoint/main-clean-baseline-<RUN_ID>.txt` (#4450 — before that, baselines accumulated forever).
 
 This is best-effort cleanup — a dead run's entry *and* baseline are also pruned automatically by any later sweep's peer scan (dead-PID liveness check), so a crash that skips cleanup never leaves a permanent false-positive. The bulk backstop for a run whose peer scan never happens is `loom-daemon clean`, which prunes baselines of non-live runs older than 48h plus checkpoints of closed issues.
+
+Both pruners bias toward **keeping** a transient when liveness is ambiguous (#4691): a `kill(pid, 0)` that fails with `EPERM` means the process *exists* but is not signallable by the pruning caller, so only `ESRCH` ("no such process") authorizes deletion. A never-pruned baseline is a bounded, harmless leak; a baseline deleted under a live sweep silently disables the #3648 contamination-subtraction backstop for the rest of that run.
 
 ### Step 0b: Peer-`/loom:sweep` detection (loud, NON-BLOCKING)
 

--- a/defaults/scripts/sweep-run-registry.sh
+++ b/defaults/scripts/sweep-run-registry.sh
@@ -26,6 +26,15 @@
 # forever (200+ dead files observed). Bulk pruning of baselines left behind by a
 # SIGKILLed sweep is `loom-daemon clean`'s job.
 #
+# That reaping is only safe if "dead" is judged correctly. Before #4691 it was
+# not: the recorded PID was the script's literal `$PPID`, which under an agent
+# harness is the ONE-SHOT `<shell> -c …` process spawned for that single tool
+# call and reaped seconds later. Every registered run therefore looked dead to
+# the very next peer scan, which pruned a LIVE run's entry and deleted its
+# main-clean baseline mid-sweep — and, since the entry vanished before the
+# baseline was even written, left that baseline orphaned forever. One root cause,
+# both reported symptoms (over-eager prune + unbounded leak).
+#
 # The run id is portable (macOS/Linux, no `uuidgen`): a compact UTC timestamp, a
 # PID component, and a random suffix, e.g.
 #   sweep-20260722T231500Z-84213-a3f9c1
@@ -41,10 +50,11 @@
 #   }
 #
 # The "pid" is the LIVENESS handle for peer detection: `peers` treats an entry as
-# a live peer only when `kill -0 <pid>` succeeds, and prunes the entry otherwise —
-# the same pattern as the legacy `.loom/daemon-loop.pid` check. It defaults to the
-# invoking process's parent PID ($PPID, i.e. the long-lived orchestrator/session
-# process that outlives each ephemeral Bash tool call), overridable with `--pid`.
+# a live peer only when the PID is still alive, and prunes the entry otherwise —
+# the same pattern as the legacy `.loom/daemon-loop.pid` check. It must name the
+# long-lived orchestrator/session process that spans the WHOLE sweep, and is
+# overridable with `--pid`. The default is resolved by `resolve_liveness_pid`,
+# NOT taken as a bare `$PPID` — see the "Liveness (#4691)" section in the source.
 #
 # Usage:
 #   sweep-run-registry.sh new [--pid P]     # print a fresh RUN_ID, register it
@@ -62,8 +72,11 @@
 
 set -euo pipefail
 
+# Print the leading comment header (from line 3 to the first non-comment line) as
+# usage text. Derived, not a hard-coded line range, so editing the header can
+# never silently truncate `--help`.
 usage() {
-    sed -n '3,61p' "$0" | sed 's/^# \{0,1\}//'
+    awk 'NR < 3 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "$0"
     exit 1
 }
 
@@ -99,6 +112,78 @@ remove_run_artifacts() {
     rm -f "$(checkpoint_dir)/main-clean-baseline-${rid}.txt"
 }
 
+# ---------------------------------------------------------------------------
+# Liveness (#4691)
+# ---------------------------------------------------------------------------
+#
+# Is `$1` a one-shot `<shell> -c …` wrapper process?
+#
+# An agent harness (Claude Code's Bash tool, and any `bash -c`/`zsh -c` wrapper)
+# spawns a FRESH shell per tool call and reaps it the moment that call returns.
+# Such a process is never a valid liveness handle for a sweep that spans hundreds
+# of tool calls. An INTERACTIVE or login shell (no `-c`) is long-lived and IS a
+# valid handle, so the `-c` flag — not merely "is a shell" — is the discriminator.
+is_oneshot_shell() {
+    local pid="${1:-}" comm base args a0 a1
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
+    [[ -n "$comm" ]] || return 1
+    base="${comm##*/}"
+    base="${base#-}" # a login shell reports as "-zsh"
+    case "$base" in
+        sh | bash | zsh | dash | ksh | ksh93 | mksh) ;;
+        *) return 1 ;;
+    esac
+    args=$(ps -o args= -p "$pid" 2>/dev/null) || return 1
+    # argv[1] carries the flags; `-c`, `-lc`, `-ec` … all mean "run this string".
+    read -r a0 a1 _ <<< "$args"
+    [[ -n "$a0" ]] || return 1
+    [[ "${a1:-}" == -*c* ]]
+}
+
+# Resolve the PID to record as this run's liveness handle: walk up from $PPID
+# past every one-shot shell wrapper to the first ancestor that outlives a single
+# tool call (in practice the `claude -p /loom:sweep …` orchestrator). Falls back
+# to $PPID whenever `ps` is unavailable or the walk cannot proceed, which is
+# exactly the pre-#4691 behavior — never worse.
+resolve_liveness_pid() {
+    local pid="${PPID:-$$}" parent depth=0
+    while ((depth < 8)); do
+        is_oneshot_shell "$pid" || break
+        parent=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+        # Stop at an unreadable parent, or at pid 1 (init is not a sweep owner).
+        if ! [[ "$parent" =~ ^[0-9]+$ ]] || ((parent <= 1)); then
+            break
+        fi
+        pid="$parent"
+        depth=$((depth + 1))
+    done
+    echo "$pid"
+}
+
+# Is `$1` a live process, biased to fail SAFE (#4691)?
+#
+# POSIX `kill(2)` has two distinct failure modes and a bare `kill -0` conflates
+# them:
+#   ESRCH — no such process        → genuinely dead, safe to prune.
+#   EPERM — the process EXISTS but this caller may not signal it (different UID,
+#           sandbox, namespace)    → NOT dead; pruning it destroys live state.
+# `ps -p` answers "does this PID exist?" without needing signal permission, so it
+# separates the two without parsing locale-dependent errno strings. A zombie
+# (state `Z`) has exited and is only awaiting reaping, so it counts as dead.
+pid_is_live() {
+    local pid="${1:-}" state
+    if ! [[ "$pid" =~ ^[0-9]+$ ]] || ((pid <= 0)); then
+        return 1
+    fi
+    # Fast path: the signal would be deliverable ⇒ definitely alive.
+    kill -0 "$pid" 2>/dev/null && return 0
+    state=$(ps -o state= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+    [[ -n "$state" ]] || return 1        # ESRCH (or no usable `ps`): treat as dead.
+    [[ "${state:0:1}" == "Z" ]] && return 1
+    return 0 # EPERM and friends: the process exists — fail safe, treat as alive.
+}
+
 iso_now() {
     date -u +"%Y-%m-%dT%H:%M:%SZ"
 }
@@ -126,7 +211,8 @@ gen_run_id() {
 }
 
 cmd_new() {
-    local pid="${PPID:-$$}"
+    local pid
+    pid="$(resolve_liveness_pid)"
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --pid)
@@ -176,7 +262,7 @@ prune_dead() {
         rid=$(json_field "$file" run_id)
         [[ -n "$skip" && "$rid" == "$skip" ]] && continue
         pid=$(json_num "$file" pid)
-        if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
+        if ! pid_is_live "$pid"; then
             # Dead run: reap its baseline too, so a crashed sweep self-heals on
             # the next sweep's peer scan instead of waiting for the bulk path.
             remove_run_artifacts "$rid"
@@ -201,7 +287,7 @@ cmd_peers() {
         # Skip our own entry.
         [[ "$rid" == "$self" ]] && continue
         pid=$(json_num "$file" pid)
-        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+        if pid_is_live "$pid"; then
             ts=$(json_field "$file" timestamp)
             echo "$rid $pid $ts"
         else

--- a/defaults/scripts/tests/test-sweep-run-registry.sh
+++ b/defaults/scripts/tests/test-sweep-run-registry.sh
@@ -232,6 +232,77 @@ fi
 kill "$LIVE3" 2>/dev/null
 wait "$LIVE3" 2>/dev/null
 
+# --------------------------------------------------------------------------
+# #4691: the liveness PID must outlive the one-shot shell that ran `new`, and
+# "not signallable" must never be mistaken for "dead".
+# --------------------------------------------------------------------------
+
+# 9d. `new` (no --pid) skips the ephemeral `<shell> -c …` wrapper it was invoked
+#     from. An agent harness spawns one such shell PER TOOL CALL and reaps it
+#     immediately, so recording its PID (the pre-fix bare `$PPID`) made every run
+#     look dead to the very next peer scan. The trailing `:` keeps bash from
+#     exec-optimizing the wrapper away, so the wrapper is a real intermediate.
+EPH_FILE="$TMP_REPO/ephemeral.pid"
+RID_FILE="$TMP_REPO/default.rid"
+bash -c 'echo $$ > "$2"; "$1" new > "$3"; :' _ "$REG" "$EPH_FILE" "$RID_FILE"
+EPH_PID=$(cat "$EPH_FILE")
+RID_D=$(cat "$RID_FILE")
+REG_PID=$(sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' \
+    "$TMP_REPO/.loom/sweep-run/${RID_D}.json")
+
+if kill -0 "$EPH_PID" 2>/dev/null; then
+    echo "SKIP: invoking one-shot shell $EPH_PID outlived the call; cannot assert" >&2
+else
+    echo "PASS: the one-shot invoking shell is already dead (the pre-fix handle)"
+    PASS=$((PASS + 1))
+    if [[ "$REG_PID" != "$EPH_PID" ]]; then
+        echo "PASS: default liveness pid is not the ephemeral invoking shell"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: default liveness pid is the ephemeral invoking shell ($EPH_PID)" >&2
+        FAIL=$((FAIL + 1))
+    fi
+    if kill -0 "$REG_PID" 2>/dev/null; then
+        echo "PASS: default liveness pid ($REG_PID) is still alive after the call"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: default liveness pid $REG_PID is already dead after the call" >&2
+        FAIL=$((FAIL + 1))
+    fi
+fi
+"$REG" cleanup "$RID_D"
+
+# 9e. A PID that EXISTS but cannot be signalled by this caller (POSIX EPERM) is
+#     alive, not dead. PID 1 (launchd/init) is root-owned and always present, so
+#     `kill -0 1` fails with EPERM for an unprivileged test run — and simply
+#     succeeds when running as root, so the assertion holds either way.
+LIVE4=$(spawn_live); LIVE_PIDS+=("$LIVE4")
+RID_SELF=$("$REG" new --pid "$LIVE4")
+RID_EPERM=$("$REG" new --pid 1)
+: > "$BASELINE_DIR/main-clean-baseline-${RID_EPERM}.txt"
+out=$("$REG" peers "$RID_SELF")
+if echo "$out" | grep -q "^$RID_EPERM 1 "; then
+    echo "PASS: unsignallable-but-existing pid reported as a live peer"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: unsignallable-but-existing pid treated as dead, got: $out" >&2
+    FAIL=$((FAIL + 1))
+fi
+if [[ -f "$TMP_REPO/.loom/sweep-run/${RID_EPERM}.json" \
+    && -f "$BASELINE_DIR/main-clean-baseline-${RID_EPERM}.txt" ]]; then
+    echo "PASS: unsignallable run's entry + baseline survive a peer scan"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: unsignallable run's entry or baseline was pruned" >&2
+    FAIL=$((FAIL + 1))
+fi
+
+# Restore the empty-registry precondition the remaining cases assume.
+"$REG" cleanup "$RID_EPERM"
+"$REG" cleanup "$RID_SELF"
+kill "$LIVE4" 2>/dev/null
+wait "$LIVE4" 2>/dev/null
+
 # 10. peers on an empty/nonexistent registry is empty, exit 0 (single-sweep case).
 out=$("$REG" peers "sweep-nonexistent")
 assert_eq "peers empty when no registry entries" "" "$out"

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -8396,25 +8396,64 @@ pub fn spawn_watchdog_task(
 // Internal helpers
 // ============================================================================
 
-/// Liveness probe via `kill(pid, 0)`. Returns true when the signal would
-/// be deliverable (i.e. the process exists and is owned by us). PID 0 is
-/// always treated as dead.
+/// POSIX `EPERM`. Value 1 on every Loom target (Linux and macOS both fix it at
+/// 1 in `<sys/errno.h>`), so no `libc` dependency is needed to name it.
+#[cfg(unix)]
+pub(crate) const EPERM: i32 = 1;
+
+/// Liveness probe via `kill(pid, 0)`. Returns true when the process exists.
+/// PID 0 is always treated as dead.
+///
+/// **Fail-safe on `EPERM` (#4691).** `kill(2)` has two distinct failure modes
+/// and treating them alike is a correctness bug, not a nicety:
+///
+/// - `ESRCH` — no such process. Genuinely dead; callers may reap its state.
+/// - `EPERM` — the process **exists** but this caller may not signal it
+///   (different UID, sandbox, namespace). Reporting that as "dead" lets the
+///   reaper, [`crate::claim_reconciliation`], and `loom-daemon clean` destroy a
+///   *running* sweep's state — e.g. deleting a live run's
+///   `main-clean-baseline-<RUN_ID>.txt` out from under it.
+///
+/// Every consumer of this probe uses "dead" to authorize destruction, so the
+/// ambiguous case must resolve to *alive*.
 ///
 /// `pub(crate)` so [`crate::sweep_journal`] and [`crate::claim_reconciliation`]
 /// can reuse the exact same probe the reaper uses (Issue #3953) rather than
 /// duplicating the `kill(pid, 0)` dance.
 #[cfg(unix)]
 pub(crate) fn is_pid_alive(pid: u32) -> bool {
+    is_pid_alive_with(pid, |pid_t| {
+        // SAFETY: kill(pid, 0) is a documented liveness probe; signal 0 is not
+        // sent, just checked.
+        if libc_kill(pid_t, 0) == 0 {
+            Ok(())
+        } else {
+            // `errno` is only meaningful immediately after a failed call.
+            Err(std::io::Error::last_os_error().raw_os_error().unwrap_or(0))
+        }
+    })
+}
+
+/// Decision core of [`is_pid_alive`], parameterized over the raw `kill(pid, 0)`
+/// syscall so the `ESRCH`-vs-`EPERM` distinction is unit-testable without
+/// needing a real unsignallable process (#4691).
+///
+/// `probe` returns `Ok(())` when the signal would be deliverable, or
+/// `Err(errno)` with the raw `errno` from the failed `kill(2)`.
+#[cfg(unix)]
+pub(crate) fn is_pid_alive_with(pid: u32, probe: impl Fn(i32) -> Result<(), i32>) -> bool {
     if pid == 0 {
         return false;
     }
-    // SAFETY: kill(pid, 0) is a documented liveness probe; signal 0 is not
-    // sent, just checked.
     let pid_t: i32 = match pid.try_into() {
         Ok(p) => p,
         Err(_) => return false,
     };
-    libc_kill(pid_t, 0) == 0
+    match probe(pid_t) {
+        Ok(()) => true,
+        // EPERM proves existence just as well as success does.
+        Err(errno) => errno == EPERM,
+    }
 }
 
 #[cfg(not(unix))]
@@ -8562,6 +8601,46 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
     use std::time::SystemTime;
     use tempfile::tempdir;
+
+    // ---- is_pid_alive: ESRCH vs EPERM (#4691) ------------------------------
+
+    /// POSIX `ESRCH` ("no such process") — 3 on Linux and macOS alike.
+    const ESRCH: i32 = 3;
+
+    #[test]
+    fn is_pid_alive_reports_deliverable_signal_as_alive() {
+        assert!(is_pid_alive_with(4242, |_| Ok(())));
+    }
+
+    #[test]
+    fn is_pid_alive_reports_esrch_as_dead() {
+        // The only failure mode that actually proves the process is gone.
+        assert!(!is_pid_alive_with(4242, |_| Err(ESRCH)));
+    }
+
+    #[test]
+    fn is_pid_alive_treats_eperm_as_alive_not_dead() {
+        // #4691: `kill(pid, 0)` failing with EPERM means the process EXISTS but
+        // is not signallable by this caller. Conflating it with ESRCH lets the
+        // reaper / `loom-daemon clean` destroy a live sweep's state.
+        assert!(
+            is_pid_alive_with(4242, |_| Err(EPERM)),
+            "EPERM proves existence — must never be reported as dead"
+        );
+    }
+
+    #[test]
+    fn is_pid_alive_rejects_pid_zero_without_probing() {
+        // PID 0 addresses the caller's whole process group in kill(2); it is
+        // never a valid liveness handle, so it must short-circuit to dead.
+        assert!(!is_pid_alive_with(0, |_| panic!("must not probe pid 0")));
+    }
+
+    #[test]
+    fn is_pid_alive_of_self_is_true_through_the_real_syscall() {
+        // End-to-end sanity that the real probe still works after the refactor.
+        assert!(is_pid_alive(std::process::id()));
+    }
 
     #[test]
     #[serial]

--- a/loom-daemon/src/worktree_ops/clean.rs
+++ b/loom-daemon/src/worktree_ops/clean.rs
@@ -1404,6 +1404,72 @@ mod tests {
         assert_eq!(stats.kept_sweep_transients, 1);
     }
 
+    /// #4691: a run whose PID exists but cannot be signalled by this process
+    /// (`kill(2)` → `EPERM`) is LIVE. Wiring the real
+    /// [`crate::sweep_registry::is_pid_alive_with`] decision core in here — with
+    /// only the raw syscall mocked — proves the production `pid_alive` closure,
+    /// not just the test double, keeps such a baseline.
+    #[cfg(unix)]
+    #[test]
+    fn sweep_transients_keep_baseline_of_unsignallable_but_live_run() {
+        use crate::sweep_registry::{is_pid_alive_with, EPERM};
+
+        let (dir, ckpt) = sweep_fixture();
+        let baseline = ckpt.join("main-clean-baseline-sweep-eperm.txt");
+        std::fs::write(&baseline, "").unwrap();
+        register_run(dir.path(), "sweep-eperm", 4242);
+
+        let pid_alive = |pid: u32| is_pid_alive_with(pid, |_| Err(EPERM));
+        let issue_state = |_: u32| "UNKNOWN".to_string();
+        let mut stats = CleanupStats::default();
+        let env = SweepTransientEnv {
+            // 1000h old: only the liveness verdict can spare it.
+            now: SystemTime::now() + Duration::from_secs(1000 * HOUR),
+            min_age: Duration::from_secs(SWEEP_TRANSIENT_MIN_AGE_SECS),
+            pid_alive: &pid_alive,
+            issue_state: &issue_state,
+        };
+        clean_sweep_transients_with(dir.path(), &mut stats, false, &env);
+
+        assert!(
+            baseline.exists(),
+            "an unsignallable (EPERM) PID means the sweep is still running — \
+             its baseline must not be pruned"
+        );
+        assert_eq!(stats.cleaned_sweep_baselines, 0);
+        assert_eq!(stats.kept_sweep_transients, 1);
+    }
+
+    /// The ESRCH counterpart of the test above: the same wiring, but the raw
+    /// syscall reports "no such process" — the one failure mode that really does
+    /// authorize pruning. Guards against an over-broad #4691 fix that makes
+    /// every `kill(2)` failure mean "alive" and silently reinstates the leak.
+    #[cfg(unix)]
+    #[test]
+    fn sweep_transients_still_prune_baseline_when_pid_is_esrch() {
+        use crate::sweep_registry::is_pid_alive_with;
+        const ESRCH: i32 = 3;
+
+        let (dir, ckpt) = sweep_fixture();
+        let baseline = ckpt.join("main-clean-baseline-sweep-gone.txt");
+        std::fs::write(&baseline, "").unwrap();
+        register_run(dir.path(), "sweep-gone", 4242);
+
+        let pid_alive = |pid: u32| is_pid_alive_with(pid, |_| Err(ESRCH));
+        let issue_state = |_: u32| "UNKNOWN".to_string();
+        let mut stats = CleanupStats::default();
+        let env = SweepTransientEnv {
+            now: SystemTime::now() + Duration::from_secs(1000 * HOUR),
+            min_age: Duration::from_secs(SWEEP_TRANSIENT_MIN_AGE_SECS),
+            pid_alive: &pid_alive,
+            issue_state: &issue_state,
+        };
+        clean_sweep_transients_with(dir.path(), &mut stats, false, &env);
+
+        assert!(!baseline.exists(), "ESRCH means gone — prune must still fire");
+        assert_eq!(stats.cleaned_sweep_baselines, 1);
+    }
+
     #[test]
     fn sweep_transients_prunes_registered_but_dead_pid_baseline() {
         let (dir, ckpt) = sweep_fixture();


### PR DESCRIPTION
## Summary

The EPERM/ESRCH hypothesis in the curator update is **not** the mechanism behind the "live baseline pruned mid-sweep" report. Per AC 5, I diagnosed first and found a different, directly-observable root cause — then fixed that, and folded in the EPERM hardening as defence-in-depth since it lives in the same primitive.

### What the investigation found

`sweep-run-registry.sh new` recorded the script's literal `$PPID` as the run's liveness handle. Under an agent harness that is **not** the long-lived orchestrator the header comment claimed — it is the **one-shot `<shell> -c …` process spawned for that single tool call**, which is reaped the moment the call returns.

Captured live on this host, mid-sweep:

```
1 launchd
└─ 13724 loom-daemon
    └─ 17816 /bin/bash claude-wrapper.sh -p /loom:sweep 4691 …
        └─ 18235 claude -p /loom:sweep 4691 …          ← the actual sweep owner
            └─ 34025 /bin/zsh -c <one tool call>       ← EPHEMERAL, reaped per call
                └─ 34048 sweep-run-registry.sh          ← its $PPID is 34025
```

```
$ cat .loom/sweep-run/sweep-20260731T045820Z-19001-046221bd.json
{ "run_id": "…", "pid": 18998, "timestamp": "2026-07-31T04:58:21Z" }
$ kill -0 18998   →  "no such process"        # ESRCH, not EPERM
```

That entry belonged to **this very sweep, still running**, and its registered PID was already gone. All sweeps here run as the same UID, so `kill -0` between them can never return `EPERM` — the observed failure is a plain `ESRCH` on a PID that genuinely no longer exists. The `kill -0` check was answering correctly; it was being asked about the wrong process.

One defect explains **both** reported symptoms:

1. **Over-eager prune** — a peer's `peers`/`cleanup` scan sees the entry as dead within seconds and calls `remove_run_artifacts`, deleting a live run's `main-clean-baseline-<RUN_ID>.txt` and silently disabling the #3648 contamination-subtraction backstop for the rest of that run.
2. **Unbounded leak** — the prune lands *before* the baseline is written (Step 0a registers; the baseline is snapshotted at wave 1). The entry is gone, the baseline appears later, and nothing is left to reap it. That is why baselines accumulated even though #4520's reaping works.

Corroborating evidence that the intent was always the orchestrator PID: `sweep.md:771` documents the value as "the orchestrator `$PPID`", and the RUN_ID recovery lookup at `sweep.md:776` matches on `$PPID` — a lookup that could never match, because `new` stored a different process's PID.

## Changes

- **`defaults/scripts/sweep-run-registry.sh`**
  - `resolve_liveness_pid` walks up from `$PPID` past one-shot `<shell> -c …` wrappers to the first ancestor that outlives a tool call. The `-c` flag — not "is a shell" — is the discriminator, so an interactive/login shell is a valid handle and manual invocations are unaffected. Falls back to `$PPID` when `ps` is unusable (never worse than before).
  - `pid_is_live` replaces the bare `kill -0` in `prune_dead` and `cmd_peers`. On failure it consults `ps -p`, which reports existence without needing signal permission — separating `ESRCH` (prune) from `EPERM` (keep) without parsing locale-dependent errno strings. A zombie (`Z`) still counts as dead.
  - `usage()` now derives the header range instead of hard-coding `sed -n '3,61p'`, so editing the header cannot silently truncate `--help`.
- **`loom-daemon/src/sweep_registry.rs`** — `is_pid_alive` inspects `errno` and treats `EPERM` as alive. `is_pid_alive_with` exposes the decision core with the raw syscall injectable. Every consumer (reaper, `sweep_journal`, `claim_reconciliation`, `clean.rs`) uses "dead" to authorize destruction, so the ambiguous case must resolve to alive.
- **`defaults/.claude/commands/loom/sweep.md`** — Step 0a passes `--pid "$PPID"` explicitly (expanded in the tool-call shell, so it *is* the orchestrator), which also repairs the `$PPID`-keyed recovery lookup. Prose explains why, and notes the fail-safe bias. The script-side default covers older installed copies of the skill.
- **`loom-daemon/src/worktree_ops/clean.rs`** — tests only; no production change.

## Acceptance Criteria Verification

- [x] **AC 1 — confirm or rule out EPERM/ESRCH before changing the liveness check.** Ruled out, with captured process-tree and registry evidence (above). Same-UID processes cannot produce `EPERM`; the observed prune was `ESRCH` against a genuinely-dead ephemeral shell.
- [x] **AC 2 — if confirmed, fix both languages.** Not the mechanism, but the conflation is a real fail-safe gap in the same primitive, so it is fixed consistently in both: `pid_is_live` (shell) and `is_pid_alive` (Rust).
- [x] **AC 3 — regression coverage for a PID that exists but is not signalable.** Shell: registers a run on PID 1 (root-owned, always present → `kill -0 1` is `EPERM` for an unprivileged run, and simply succeeds under root, so the assertion holds either way) and asserts the entry and baseline survive a peer scan. Rust: `is_pid_alive_with` with the syscall mocked to `EPERM`, plus a `clean_sweep_transients_with` pass wired to the real decision core.
- [x] **AC 4 — the three already-implemented behaviors keep passing unmodified.** No existing assertion was changed or removed. All 21 pre-existing shell cases and all pre-existing `worktree_ops::clean` unit tests pass.
- [x] **AC 5 — different root cause ⇒ document and scope the fix to it.** Done; the PID-resolution fix is the primary change.

## Test Plan

- [x] `./defaults/scripts/tests/test-sweep-run-registry.sh` — **25 passed, 0 failed** (21 pre-existing + 4 new).
- [x] **The new shell tests fail against the pre-fix script.** Running the new test file against `git show HEAD:defaults/scripts/sweep-run-registry.sh` gives **21 passed, 4 failed**:
  ```
  FAIL: default liveness pid is the ephemeral invoking shell (83411)
  FAIL: default liveness pid 83411 is already dead after the call
  FAIL: unsignallable-but-existing pid treated as dead, got:
  FAIL: unsignallable run's entry or baseline was pruned
  ```
- [x] `cargo test -p loom-daemon --lib worktree_ops::clean` — 19 passed, 0 failed (2 new).
- [x] `cargo test -p loom-daemon --lib is_pid_alive` — 5 passed, 0 failed (all new).
- [x] `cargo test -p loom-daemon --test sweep_md_doc_lint --test sweep_md_stage_minus_one_doc_lint` — 20 + 11 passed (sweep.md edits lint clean).
- [x] `cargo clippy -p loom-daemon --all-targets` clean; `cargo fmt --check` clean; `shellcheck -x` clean on both shell files.
- [x] `cargo build --workspace --lib --bins` succeeds (the buildGate compile check).

### Pre-existing failures (not caused by this PR)

`cargo test -p loom-daemon` shows 2677 passed / 5 failed locally. All 5 are pre-existing and untouched by this diff:

- `role_runner::…`, `runtime_admission::unknown_configured_role_keys_fail_closed`, `sweep_registry::runtime_rejection_precedes_every_dispatch_side_effect` — pass with `LOOM_RUNTIME` unset; they are sensitive to the `LOOM_RUNTIME=claude` this sweep inherits from its spawn env.
- `safehouse::run_sink_reconciliation_*` — a macOS-only `/var` vs `/private/var` symlink-canonicalization mismatch in the assertion (`safehouse.rs:5474`). Green on Linux CI; `safehouse.rs` contains no reference to `is_pid_alive`.

Main CI is independently red on `tokens_pool::bad_tokens::…` (run 30605077919), also unrelated.

## Notes for review

- The one behavior change worth a second look: `pid_is_live` treats "`kill -0` failed but `ps -p` sees the process" as alive. That intentionally biases toward a bounded, harmless leak over deleting a running sweep's state. The `ESRCH` path is covered by an explicit test so an over-broad reading ("any failure means alive") cannot silently reinstate the leak.
- I did not add a registration grace period (young entries immune to pruning). It would be a second layer of protection, but it would change `peers` semantics and break the existing "dead peer entry pruned immediately" assertion, which AC 4 requires to pass unmodified. The Rust bulk path already has an equivalent guard via `SWEEP_TRANSIENT_MIN_AGE_SECS`.
- Installed copies under `.loom/scripts/` and `.claude/commands/loom/` are deliberately untouched; that resync is a separate post-merge commit.

Closes #4691
