### PR TITLE
fix(daemon): warn on silent autonomy downgrade in loom-daemon-start.sh (#4693)

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -3914,6 +3914,33 @@ fault). When no loom dir resolves at all the `Protection:` line is omitted and
 and its exit codes are unchanged. `fleet status`'s local-host row carries the
 same `protection` field, since it shares the `status --json` payload builder.
 
+**Marker-vs-non-autonomous-daemon mismatch (#4693).** `ProtectionState` above
+answers "would we notice a future DEATH?" — but a daemon can be perfectly
+`protected` by that definition (marker present, watchdog provisioned) while
+having **silently stopped dispatching**, because a plain `loom-daemon-start.sh`
+re-render is FLAGS-OFF by default (#3911) even on a host that was previously
+autonomous. This was the exact 2026-07-30 incident: `status` reported a
+healthy, protected daemon while 23 ready issues sat queued for ~3h. The `--json`
+`protection` object therefore also carries `autonomy_mismatch: bool` — `true`
+only when the marker is present **and** this reachable daemon's own
+`work_finder` (a sibling top-level object, `{"enabled": bool|null}`, resolved
+daemon-side from `work_finder::resolve_enabled` — the daemon's own env/config,
+never the CLI client's) reads `false`. `null`/absent `work_finder.enabled`
+(a pre-#4693 daemon binary) degrades to `autonomy_mismatch: false` — never a
+false positive. The human `Protection:` block prints a loud `WARNING:` with the
+`--work-finder` / `--from-config` remediation when it fires.
+
+`loom-daemon-start.sh` closes the writing side of the same gap: before
+re-rendering the plist/unit, it compares the new render's `LOOM_WORK_FINDER` /
+`LOOM_MAIN_HEALTH_GATE` against the **prior installed** plist/unit's value (or,
+absent a readable prior value, the autonomy-desired marker alone) and prints a
+loud, non-blocking `WARNING: autonomy downgrade — <key>: 1 -> 0` when a plain
+(no-flags, non-`--from-config`) start would downgrade a previously-autonomous
+host — naming the `--from-config` / `--work-finder` remediation. This never
+reverses the FLAGS-OFF-by-default policy for a start with no prior-autonomy
+signal at all (#3911) — it only closes the *silent* part of an actual
+autonomous → FLAGS-OFF transition.
+
 ### macOS session-bootstrap hazard (#3972)
 
 **Incident (2026-07-26).** The daemon was started at 21:48 via

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -1297,12 +1297,35 @@ fi
 # Left empty on the nohup fallback tier (no rendered file exists there) -- the
 # autonomy-desired marker alone is the only available signal in that case
 # (see check_autonomy_downgrade_key above).
+#
+# The mechanism this comparison targets is chosen by the INVOCATION, not by the
+# host OS: --print-plist / --print-unit are pure inspection modes that render
+# (and inspect) their mechanism's file regardless of the platform running them,
+# exactly like the pre-existing --print-plist PATH-drift (#4172) and
+# dropped-env-key (#4522) checks below, which read
+# $HOME/Library/LaunchAgents/<label>.plist unconditionally. Gating this
+# resolution on USE_LAUNCHD (Darwin-only) instead made the whole downgrade
+# warning silently unreachable under --print-plist on any Linux host -- the
+# exact silence this check exists to eliminate. Only when NEITHER inspection
+# flag is set does platform detection pick the mechanism, which keeps the real
+# install path (and its nohup-tier "leave empty" contract) byte-identical.
+PRIOR_AUTONOMY_MECH=""
+if [[ "$PRINT_PLIST" == "true" ]]; then
+    PRIOR_AUTONOMY_MECH="launchd"
+elif [[ "$PRINT_UNIT" == "true" ]]; then
+    PRIOR_AUTONOMY_MECH="systemd"
+elif [[ "$USE_LAUNCHD" == "true" ]]; then
+    PRIOR_AUTONOMY_MECH="launchd"
+elif [[ "$IS_LINUX_SYSTEMD" == "true" ]]; then
+    PRIOR_AUTONOMY_MECH="systemd"
+fi
+
 PRIOR_AUTONOMY_FILE=""
 PRIOR_AUTONOMY_EXTRACTOR=""
-if [[ "$USE_LAUNCHD" == "true" ]]; then
+if [[ "$PRIOR_AUTONOMY_MECH" == "launchd" ]]; then
     PRIOR_AUTONOMY_FILE="$HOME/Library/LaunchAgents/$(resolve_launchd_label).plist"
     PRIOR_AUTONOMY_EXTRACTOR="extract_plist_env_value"
-elif [[ "$IS_LINUX_SYSTEMD" == "true" ]] && declare -f resolve_systemd_unit_path >/dev/null 2>&1; then
+elif [[ "$PRIOR_AUTONOMY_MECH" == "systemd" ]] && declare -f resolve_systemd_unit_path >/dev/null 2>&1; then
     PRIOR_AUTONOMY_FILE="$(resolve_systemd_unit_path 2>/dev/null || true)"
     PRIOR_AUTONOMY_EXTRACTOR="extract_systemd_env_value"
 fi

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -300,6 +300,45 @@ extract_systemd_env_keys() {
     sed -n 's/^Environment=\([^=]*\)=.*/\1/p' "$unit_file"
 }
 
+# ---------- installed-plist/unit VALUE extraction (#4693) ----------
+# Single-key siblings of extract_plist_env_keys / extract_systemd_env_keys
+# above (which list every key present -- these read the VALUE of one named
+# key). Used by the silent-autonomy-downgrade check below to read what
+# LOOM_WORK_FINDER / LOOM_MAIN_HEALTH_GATE the PRIOR installed plist/unit
+# actually carried, before it gets overwritten by this invocation's render.
+
+# extract_plist_env_value <plist_file> <key> — the <string> value paired with
+# <key>KEY</key> inside the EnvironmentVariables dict, or empty when the file
+# or the key is absent.
+extract_plist_env_value() {
+    local plist_file="$1" want_key="$2"
+    [[ -f "$plist_file" ]] || return 1
+    awk -v want="$want_key" '
+        /<key>EnvironmentVariables<\/key>/ { in_env=1; next }
+        in_env && /<\/dict>/ { exit }
+        in_env && found && /<string>/ {
+            line=$0
+            sub(/^[ \t]*<string>/, "", line); sub(/<\/string>[ \t]*$/, "", line)
+            print line
+            exit
+        }
+        in_env && /<key>/ {
+            line=$0
+            sub(/^[ \t]*<key>/, "", line); sub(/<\/key>.*$/, "", line)
+            found = (line == want) ? 1 : 0
+        }
+    ' "$plist_file"
+}
+
+# extract_systemd_env_value <unit_file> <key> — the value of a
+# `Environment=KEY=...` line for a specific key, or empty when the file or the
+# key is absent.
+extract_systemd_env_value() {
+    local unit_file="$1" want_key="$2"
+    [[ -f "$unit_file" ]] || return 1
+    sed -n "s/^Environment=${want_key}=\\(.*\\)\$/\\1/p" "$unit_file" | head -n1
+}
+
 # warn_dropped_env_keys <old_file> <new_file> <extractor_function_name> — compare
 # the env-var KEY sets (not values) between an already-installed plist/unit and
 # a freshly-rendered replacement; warn (listing the keys) when the replacement
@@ -348,6 +387,86 @@ warn_dropped_env_keys() {
     done
     warn "This usually means this invocation ran without the operator's exported env (a watchdog / automated re-render / a bare re-run from a different shell)."
     warn "Pass --force-env to acknowledge an intentional narrowing and suppress this warning."
+}
+
+# ---------- silent autonomy-downgrade detection (#4693) ----------
+# Incident 2026-07-30: a routine loom-daemon-start.sh run (no flags) silently
+# re-rendered the plist with LOOM_WORK_FINDER=0 -- downgrading a previously
+# autonomous daemon to FLAGS-OFF with NO warning. ~3h of dispatch outage (23
+# ready issues sat queued, "work availability is the limiter") before the
+# missing "work_finder: starting" log line was traced back to the plist env.
+#
+# The FLAGS-OFF default for a PLAIN start (#3911) is correct and stays
+# unchanged -- this only closes the SILENT part of a transition FROM
+# autonomous TO FLAGS-OFF. Advisory only, exactly like warn_dropped_env_keys
+# above: it never blocks the start.
+#
+# Signals consulted (either alone is sufficient to flag a downgrade):
+#   1. the PRIOR installed plist/unit had the key ON (=1) -- direct evidence
+#      this daemon was running autonomously a moment ago.
+#   2. the autonomy-desired marker (#4011) is present but no prior plist/unit
+#      value could be read (e.g. the first Darwin start after a nohup-only
+#      history) -- the marker alone is recorded operator intent, and the
+#      issue explicitly calls this combination out.
+# When the prior value was already "0" (no transition) this stays silent --
+# a standing marker-vs-FLAGS-OFF mismatch with no fresh transition is
+# `loom-daemon status`'s job to flag (AC3), not this one-shot start-time check.
+#
+# Deliberately NOT triggered by:
+#   - --from-config (control is explicitly handed to .loom/config.json --
+#     not a silent default; see the FROM_CONFIG guard in the caller),
+#   - an explicit --no-work-finder / --no-health-gate THIS invocation (an
+#     explicit ask is not silent),
+#   - an operator-exported LOOM_WORK_FINDER=0 / LOOM_MAIN_HEALTH_GATE=0 in the
+#     calling shell (also an explicit, non-default signal -- "Respected when
+#     already exported", see the Environment section in the help banner).
+check_autonomy_downgrade_key() {
+    local key="$1" new_val="$2" want_flag="$3" pre_exported="$4"
+    [[ "$new_val" == "0" ]] || return 0
+    [[ "$want_flag" == "off" ]] && return 0
+    [[ -n "$pre_exported" ]] && return 0
+
+    local old_val=""
+    if [[ -n "${PRIOR_AUTONOMY_FILE:-}" && -f "$PRIOR_AUTONOMY_FILE" ]]; then
+        old_val="$("$PRIOR_AUTONOMY_EXTRACTOR" "$PRIOR_AUTONOMY_FILE" "$key" 2>/dev/null || true)"
+    fi
+
+    local marker_present=false
+    [[ -f "$INTENT_MARKER" ]] && marker_present=true
+
+    if [[ "$old_val" == "1" ]]; then
+        warn ""
+        warn "WARNING: autonomy downgrade -- $key: 1 -> 0"
+        warn "  The previously installed daemon had $key=1 (autonomous); this plain start"
+        warn "  renders it OFF -- matching the FLAGS-OFF-by-default contract for a start with"
+        warn "  no explicit flags (#3911), but SILENTLY from an operator's point of view."
+        warn "  Remediation: pass --from-config (drive from .loom/config.json -> autonomous)"
+        warn "  or --work-finder / --health-gate to keep autonomy on."
+        return 0
+    fi
+
+    if [[ -z "$old_val" && "$marker_present" == "true" ]]; then
+        warn ""
+        warn "WARNING: autonomy downgrade -- $key renders 0 this start, and no prior plist/unit"
+        warn "  value could be read -- but the autonomy-desired marker ($INTENT_MARKER) is"
+        warn "  present, meaning this host previously ran loom-daemon autonomously."
+        warn "  Remediation: pass --from-config (drive from .loom/config.json -> autonomous)"
+        warn "  or --work-finder / --health-gate to keep autonomy on."
+        return 0
+    fi
+}
+
+# warn_autonomy_downgrade — evaluate both autonomy loops. Called once
+# PRIOR_AUTONOMY_FILE/PRIOR_AUTONOMY_EXTRACTOR and INTENT_MARKER are resolved
+# (after platform detection, before the plist/unit gets overwritten -- and
+# also from the read-only --print-plist/--print-unit inspection paths, so an
+# operator sees the warning before committing to a real start too).
+warn_autonomy_downgrade() {
+    # --from-config hands control to .loom/config.json deliberately -- not a
+    # silent default -- so it is exempt from this check entirely.
+    [[ "$FROM_CONFIG" == "true" ]] && return 0
+    check_autonomy_downgrade_key "LOOM_WORK_FINDER" "$LOOM_WORK_FINDER" "$WANT_WORK_FINDER" "$PRE_EXPORTED_WORK_FINDER"
+    check_autonomy_downgrade_key "LOOM_MAIN_HEALTH_GATE" "$LOOM_MAIN_HEALTH_GATE" "$WANT_HEALTH_GATE" "$PRE_EXPORTED_MAIN_HEALTH_GATE"
 }
 
 # render_launchd_plist <label> <daemon_bin> <workdir> <log_path>
@@ -909,6 +1028,15 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Snapshot whatever the CALLING SHELL already exported, BEFORE the
+# autonomous-mode env block below applies the FLAGS-OFF default (#3911). The
+# silent-autonomy-downgrade check (#4693) needs to tell "this invocation's
+# own default logic produced 0" (worth a warning if it downgrades a
+# previously-autonomous host) apart from "the operator explicitly exported 0
+# themselves" (an explicit, non-default signal -- never silent).
+PRE_EXPORTED_WORK_FINDER="${LOOM_WORK_FINDER:-}"
+PRE_EXPORTED_MAIN_HEALTH_GATE="${LOOM_MAIN_HEALTH_GATE:-}"
+
 REPO_ROOT=$(find_repo_root)
 
 # ---------- machine-mode resolution (Epic #3835 Phase 3b, #4229) ----------
@@ -1160,6 +1288,29 @@ if [[ "$USE_LAUNCHD" != "true" ]] \
         warn "For a supervised, reboot-surviving daemon, run: loginctl enable-linger \"\$USER\" and retry."
     fi
 fi
+
+# ---------- prior installed plist/unit (autonomy-downgrade check, #4693) ----------
+# Resolved once here, now that platform detection has picked the mechanism
+# this invocation would use -- the SAME label/unit-path helpers the real
+# install below (and --print-plist/--print-unit) use, so "prior" always means
+# "whatever is installed under the identifier THIS invocation would overwrite".
+# Left empty on the nohup fallback tier (no rendered file exists there) -- the
+# autonomy-desired marker alone is the only available signal in that case
+# (see check_autonomy_downgrade_key above).
+PRIOR_AUTONOMY_FILE=""
+PRIOR_AUTONOMY_EXTRACTOR=""
+if [[ "$USE_LAUNCHD" == "true" ]]; then
+    PRIOR_AUTONOMY_FILE="$HOME/Library/LaunchAgents/$(resolve_launchd_label).plist"
+    PRIOR_AUTONOMY_EXTRACTOR="extract_plist_env_value"
+elif [[ "$IS_LINUX_SYSTEMD" == "true" ]] && declare -f resolve_systemd_unit_path >/dev/null 2>&1; then
+    PRIOR_AUTONOMY_FILE="$(resolve_systemd_unit_path 2>/dev/null || true)"
+    PRIOR_AUTONOMY_EXTRACTOR="extract_systemd_env_value"
+fi
+
+# Run BEFORE any of --print-plist / --print-unit / the real install below, so
+# an operator sees the warning whether they are just inspecting or actually
+# starting -- and before the prior file gets overwritten either way.
+warn_autonomy_downgrade
 
 # ---------- --print-plist: pure inspection, no side effects ----------
 if [[ "$PRINT_PLIST" == "true" ]]; then

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -1057,6 +1057,207 @@ else
 fi
 rm -rf "$SH5_HOME"
 
+# ---------- silent autonomy-downgrade detection (#4693) ----------
+# Incident 2026-07-30: a plain `loom-daemon-start.sh` run silently re-rendered
+# the plist with LOOM_WORK_FINDER=0, downgrading a previously autonomous
+# daemon to FLAGS-OFF with no warning. check_autonomy_downgrade_key /
+# warn_autonomy_downgrade close the SILENT part of that transition (the
+# FLAGS-OFF-by-default policy for a start with NO prior-autonomy signal, #3911,
+# stays unchanged -- these tests assert that too).
+
+# ---------- launchd (plist) path -- exercised read-only via --print-plist,
+# same technique as the #4522 dropped-env-key tests above.
+AD_HOME="$(mktemp -d)"
+mkdir -p "$AD_HOME/Library/LaunchAgents"
+AD_LABEL="com.rjwalters.loom-daemon-ad-test"
+AD_LIVE_PLIST="$AD_HOME/Library/LaunchAgents/${AD_LABEL}.plist"
+
+# AD1. Prior plist had LOOM_WORK_FINDER=1; a plain re-render (no flags) warns
+#      and names the exact transition. This is the issue's required test case:
+#      "prior-plist-had-work-finder + plain restart -> warning emitted".
+env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE HOME="$AD_HOME" LOOM_LAUNCHD_LABEL="$AD_LABEL" \
+    LOOM_WORK_FINDER=1 LOOM_DAEMON_BIN="$FAKE_BIN" \
+    bash "$START_SCRIPT" --print-plist > "$AD_LIVE_PLIST" 2>/dev/null
+
+ad1_out=$( env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    HOME="$AD_HOME" LOOM_LAUNCHD_LABEL="$AD_LABEL" LOOM_DAEMON_BIN="$FAKE_BIN" \
+    bash "$START_SCRIPT" --print-plist 2>&1 >/dev/null )
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$ad1_out" | grep -qi 'autonomy downgrade' && echo "$ad1_out" | grep -q 'LOOM_WORK_FINDER: 1 -> 0'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} autonomy downgrade (plist): prior-plist-had-work-finder + plain restart warns and names the transition (#4693)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} autonomy downgrade (plist): prior-plist-had-work-finder + plain restart warns and names the transition"
+    echo "  output: $ad1_out"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$ad1_out" | grep -qi -- '--from-config' && echo "$ad1_out" | grep -qi -- '--work-finder'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} autonomy downgrade (plist): warning names the --from-config / --work-finder remediation (#4693)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} autonomy downgrade (plist): warning names the --from-config / --work-finder remediation"
+    echo "  output: $ad1_out"
+fi
+
+# AD2. --from-config is exempt entirely -- control is deliberately handed to
+#      .loom/config.json, so re-rendering FLAGS-OFF-equivalent (both vars left
+#      unset) after a WORK_FINDER=1 prior install must NOT warn.
+ad2_out=$( env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    HOME="$AD_HOME" LOOM_LAUNCHD_LABEL="$AD_LABEL" LOOM_DAEMON_BIN="$FAKE_BIN" \
+    bash "$START_SCRIPT" --print-plist --from-config 2>&1 >/dev/null )
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! echo "$ad2_out" | grep -qi 'autonomy downgrade'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} autonomy downgrade (plist): --from-config is exempt (control explicitly handed to config, #4693)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} autonomy downgrade (plist): --from-config is exempt"
+    echo "  output: $ad2_out"
+fi
+
+# AD3. An explicit --no-work-finder THIS invocation is not silent -- no warning.
+ad3_out=$( env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    HOME="$AD_HOME" LOOM_LAUNCHD_LABEL="$AD_LABEL" LOOM_DAEMON_BIN="$FAKE_BIN" \
+    bash "$START_SCRIPT" --print-plist --no-work-finder 2>&1 >/dev/null )
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! echo "$ad3_out" | grep -qi 'autonomy downgrade'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} autonomy downgrade (plist): explicit --no-work-finder is not silent -- no warning (#4693)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} autonomy downgrade (plist): explicit --no-work-finder is not silent"
+    echo "  output: $ad3_out"
+fi
+
+# AD4. An operator-exported LOOM_WORK_FINDER=0 in the calling shell is also an
+#      explicit, non-default signal -- no warning.
+ad4_out=$( env -u LOOM_MAIN_HEALTH_GATE LOOM_WORK_FINDER=0 \
+    HOME="$AD_HOME" LOOM_LAUNCHD_LABEL="$AD_LABEL" LOOM_DAEMON_BIN="$FAKE_BIN" \
+    bash "$START_SCRIPT" --print-plist 2>&1 >/dev/null )
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! echo "$ad4_out" | grep -qi 'autonomy downgrade'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} autonomy downgrade (plist): a pre-exported LOOM_WORK_FINDER=0 is not silent -- no warning (#4693)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} autonomy downgrade (plist): a pre-exported LOOM_WORK_FINDER=0 is not silent"
+    echo "  output: $ad4_out"
+fi
+rm -rf "$AD_HOME"
+
+# AD5. No transition (prior plist already had LOOM_WORK_FINDER=0) -> no
+#      warning at start time; a STANDING marker-vs-FLAGS-OFF mismatch with no
+#      fresh transition is `loom-daemon status`'s job (AC3), not this check's.
+AD5_HOME="$(mktemp -d)"
+mkdir -p "$AD5_HOME/Library/LaunchAgents"
+AD5_LABEL="com.rjwalters.loom-daemon-ad5-test"
+AD5_LIVE_PLIST="$AD5_HOME/Library/LaunchAgents/${AD5_LABEL}.plist"
+env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE HOME="$AD5_HOME" LOOM_LAUNCHD_LABEL="$AD5_LABEL" \
+    LOOM_WORK_FINDER=0 LOOM_DAEMON_BIN="$FAKE_BIN" \
+    bash "$START_SCRIPT" --print-plist > "$AD5_LIVE_PLIST" 2>/dev/null
+ad5_out=$( env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    HOME="$AD5_HOME" LOOM_LAUNCHD_LABEL="$AD5_LABEL" LOOM_DAEMON_BIN="$FAKE_BIN" \
+    bash "$START_SCRIPT" --print-plist 2>&1 >/dev/null )
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! echo "$ad5_out" | grep -qi 'autonomy downgrade'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} autonomy downgrade (plist): no warning when the prior value was already 0 (no fresh transition, #4693)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} autonomy downgrade (plist): no warning when the prior value was already 0"
+    echo "  output: $ad5_out"
+fi
+rm -rf "$AD5_HOME"
+
+# AD6. No prior plist AND no marker (clean first-ever install) -> no warning.
+AD6_HOME="$(mktemp -d)"
+mkdir -p "$AD6_HOME/Library/LaunchAgents"
+ad6_out=$( env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    HOME="$AD6_HOME" LOOM_LAUNCHD_LABEL="com.rjwalters.loom-daemon-ad6-test" LOOM_DAEMON_BIN="$FAKE_BIN" \
+    bash "$START_SCRIPT" --print-plist 2>&1 >/dev/null )
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! echo "$ad6_out" | grep -qi 'autonomy downgrade'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} autonomy downgrade (plist): clean first-ever install (no prior plist, no marker) never warns (#4693)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} autonomy downgrade (plist): clean first-ever install never warns"
+    echo "  output: $ad6_out"
+fi
+rm -rf "$AD6_HOME"
+
+# AD7. Marker present but no prior plist/unit value could be read (e.g. the
+#      first Darwin start after a nohup-only history) -- the marker ALONE is
+#      sufficient to flag the downgrade (the issue's explicit "or the
+#      autonomy-desired marker is present" clause).
+AD7_HOME="$(mktemp -d)"
+mkdir -p "$AD7_HOME/Library/LaunchAgents" "$AD7_HOME/.loom"
+: > "$AD7_HOME/.loom/autonomy-desired"
+ad7_out=$( env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    HOME="$AD7_HOME" LOOM_LAUNCHD_LABEL="com.rjwalters.loom-daemon-ad7-test" LOOM_DAEMON_BIN="$FAKE_BIN" \
+    LOOM_AUTONOMY_MARKER="$AD7_HOME/.loom/autonomy-desired" \
+    bash "$START_SCRIPT" --print-plist 2>&1 >/dev/null )
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$ad7_out" | grep -qi 'autonomy downgrade' && echo "$ad7_out" | grep -q 'autonomy-desired marker'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} autonomy downgrade (plist): marker present + no readable prior value still warns (#4693)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} autonomy downgrade (plist): marker present + no readable prior value still warns"
+    echo "  output: $ad7_out"
+fi
+rm -rf "$AD7_HOME"
+
+# ---------- systemd (unit) path -- exercised through the REAL install site,
+# reusing the LOOM_SYSTEMD_FORCE + stub systemctl seam (SD_BIN / make_sd_stub,
+# defined above at S2) so this covers the actual overwrite code path, not just
+# a read-only render.
+AD_SD_UNIT="loom-daemon-ad-test-$$.service"
+AD8_HOME="$(mktemp -d)"; mkdir -p "$AD8_HOME/.loom/logs"
+AD8_LOG="$WORKDIR/ad8-install.log"; : > "$AD8_LOG"
+
+# Install the "prior" unit with LOOM_WORK_FINDER=1.
+sleep 30 & AD8_SLEEP_PID1=$!
+make_sd_stub "$AD8_LOG" "$AD8_SLEEP_PID1"
+env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    PATH="$SD_BIN:$PATH" HOME="$AD8_HOME" LOOM_SYSTEMD_FORCE=1 LOOM_SYSTEMD_UNIT="$AD_SD_UNIT" \
+    LOOM_WORK_FINDER=1 LOOM_DAEMON_BIN="$FAKE_BIN" \
+    LOOM_SOCKET_PATH="$AD8_HOME/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$AD8_HOME/.loom/autonomy-desired" \
+    bash "$START_SCRIPT" --no-launchd >/dev/null 2>&1
+kill "$AD8_SLEEP_PID1" 2>/dev/null || true
+rm -f "$AD8_HOME/.loom/.daemon.pid"
+
+# AD8. A plain re-install (no flags) both warns AND still actually
+#      installs/starts (advisory only, never blocks -- matching the #4522
+#      dropped-env-key precedent). This is the issue's required test case:
+#      "prior-plist-had-work-finder + plain restart -> warning emitted",
+#      systemd sibling.
+sleep 30 & AD8_SLEEP_PID2=$!
+make_sd_stub "$AD8_LOG" "$AD8_SLEEP_PID2"
+ad8_out=$( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    PATH="$SD_BIN:$PATH" HOME="$AD8_HOME" LOOM_SYSTEMD_FORCE=1 LOOM_SYSTEMD_UNIT="$AD_SD_UNIT" \
+    LOOM_DAEMON_BIN="$FAKE_BIN" \
+    LOOM_SOCKET_PATH="$AD8_HOME/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$AD8_HOME/.loom/autonomy-desired" \
+    bash "$START_SCRIPT" --no-launchd 2>&1 )
+ad8_rc=$?
+assert_eq "0" "$ad8_rc" "autonomy downgrade (systemd): the WARNED downgrade still actually installs/starts (warn, don't block, #4693)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$ad8_out" | grep -qi 'autonomy downgrade' && echo "$ad8_out" | grep -q 'LOOM_WORK_FINDER: 1 -> 0'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} autonomy downgrade (systemd): prior-unit-had-work-finder + plain restart warns and names the transition (#4693)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} autonomy downgrade (systemd): prior-unit-had-work-finder + plain restart warns and names the transition"
+    echo "  output: $ad8_out"
+fi
+kill "$AD8_SLEEP_PID2" 2>/dev/null || true
+rm -f "$AD8_HOME/.loom/.daemon.pid"
+rm -rf "$AD8_HOME"
+
 # ---------- summary ----------
 echo
 echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -1101,6 +1101,29 @@ else
     echo "  output: $ad1_out"
 fi
 
+# AD1b. Platform-independence regression (#4709 review): --print-plist is a pure
+#       INSPECTION mode, so the prior-plist comparison must resolve regardless of
+#       whether this host would actually use launchd -- exactly like the
+#       pre-existing --print-plist PATH-drift (#4172) / dropped-env-key (#4522)
+#       checks, which read $HOME/Library/LaunchAgents/<label>.plist
+#       unconditionally. LOOM_DAEMON_LAUNCHD=0 forces USE_LAUNCHD=false, which is
+#       the permanent state on every Linux host (incl. the CI runner): when the
+#       resolution was gated on USE_LAUNCHD, the whole warning was silently
+#       unreachable there -- the exact silence this feature exists to eliminate.
+ad1b_out=$( env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+    HOME="$AD_HOME" LOOM_LAUNCHD_LABEL="$AD_LABEL" LOOM_DAEMON_BIN="$FAKE_BIN" \
+    LOOM_DAEMON_LAUNCHD=0 \
+    bash "$START_SCRIPT" --print-plist 2>&1 >/dev/null )
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$ad1b_out" | grep -qi 'autonomy downgrade' && echo "$ad1b_out" | grep -q 'LOOM_WORK_FINDER: 1 -> 0'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} autonomy downgrade (plist): --print-plist warns even when this host would NOT use launchd (platform-independent, #4693)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} autonomy downgrade (plist): --print-plist warns even when this host would NOT use launchd"
+    echo "  output: $ad1b_out"
+fi
+
 # AD2. --from-config is exempt entirely -- control is deliberately handed to
 #      .loom/config.json, so re-rendering FLAGS-OFF-equivalent (both vars left
 #      unset) after a WORK_FINDER=1 prior install must NOT warn.

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1664,6 +1664,12 @@ pub fn build_daemon_status(
         // `start_safehouse_narration`/`start_peer_coordination` spawn, and
         // read back here on every status call (no second connection).
         safehouse: Some(workspace_pool.safehouse_status()),
+        // Whether the work-finder loop is enabled for THIS running daemon
+        // process (#4693) — read from this process's own env/config, the same
+        // `wf_config` already resolved above for the dynamic-cap fields, so it
+        // costs no extra config read. Mirrors `main_health_gate_enabled`'s
+        // `Some(resolve...)` shape.
+        work_finder_enabled: Some(crate::work_finder::resolve_enabled(&wf_config)),
     }
 }
 
@@ -5343,6 +5349,7 @@ exit 0
                 room: Some("fleet".to_string()),
                 reason: None,
             }),
+            work_finder_enabled: Some(true),
         };
         let resp = Response::DaemonStatus(Box::new(report));
         let json = serde_json::to_string(&resp).expect("serialize response");
@@ -5387,6 +5394,7 @@ exit 0
                         .map(|c| c.mechanism.as_str()),
                     Some("test-fixture")
                 );
+                assert_eq!(r.work_finder_enabled, Some(true));
             }
             other => panic!("Expected DaemonStatus, got: {other:?}"),
         }

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -5064,6 +5064,15 @@ fn build_status_json_value(
             "deferred_reason": report.main_health_gate_deferred_reason,
             "verdict_tier": report.main_health_gate_verdict_tier,
         },
+        // Whether the autonomous work-finder loop is enabled for THIS running
+        // daemon process (#4693), resolved daemon-side (env > config > default,
+        // the same precedence `loom-daemon-start.sh` bakes into the plist/unit).
+        // `null` only from a pre-#4693 daemon binary that never computed one —
+        // never misread as `false`. See `protection.autonomy_mismatch` below
+        // for the marker-vs-non-autonomous-daemon cross-check this feeds.
+        "work_finder": {
+            "enabled": report.work_finder_enabled,
+        },
         // Startup forge-credential preflight (#4005) — resolved once at
         // daemon boot, before the daemon's first `gh` consumer. Never
         // contains a token value; `null` only from a pre-#4005 daemon binary
@@ -5191,6 +5200,14 @@ fn build_status_json_value(
             // launchctl/systemctl, or an unreachable `systemctl --user` bus).
             "watchdog_provisioned": p.watchdog_provisioned,
             "detail": p.detail,
+            // Marker-vs-non-autonomous-daemon mismatch (#4693, AC3): `true`
+            // only when the marker is present AND this reachable daemon's own
+            // `work_finder_enabled` reads `Some(false)` — a healthy,
+            // "protected" (crash-detectable) daemon that has nonetheless
+            // silently stopped dispatching. `false` when work-finder IS on, or
+            // when `work_finder_enabled` is `null` (pre-#4693 daemon binary —
+            // never a false positive).
+            "autonomy_mismatch": p.marker_present && report.work_finder_enabled == Some(false),
         })),
     })
 }
@@ -5786,6 +5803,36 @@ fn print_status_human(
             // limitation on this host, not evidence of a fault, so steering the
             // operator into a restart for it would be the #4213 ghost-chase.
             _ => {}
+        }
+
+        // Marker-vs-non-autonomous-daemon mismatch (#4693): the sibling of the
+        // #4069 ExpectedButDead state above, but for the REACHABLE case — the
+        // daemon IS alive and answering (unlike ExpectedButDead, which only
+        // fires when IPC is unreachable), yet its work-finder loop is OFF
+        // while the marker records an operator's autonomy-desired intent. This
+        // is exactly the 2026-07-30 incident's end state: `loom-daemon status`
+        // reported a perfectly healthy, PROTECTED daemon (marker present,
+        // watchdog provisioned) while dispatch had silently stopped, because
+        // "protected" only ever asked "would we notice a DEATH", never "is
+        // this live daemon actually dispatching". `report.work_finder_enabled`
+        // is `None` only for a pre-#4693 daemon binary that never computed it
+        // — that degrades to no claim, never a false positive.
+        if p.marker_present && report.work_finder_enabled == Some(false) {
+            println!();
+            println!(
+                "WARNING: autonomy-desired marker present, but the work finder is OFF on this"
+            );
+            println!("         running, reachable daemon (LOOM_WORK_FINDER=0/unset) — autonomous");
+            println!("         dispatch is NOT happening, even though the daemon looks healthy.");
+            println!(
+                "         This is the #4693 silent-downgrade scenario (a plain \
+                 loom-daemon-start.sh"
+            );
+            println!("         run can re-render FLAGS-OFF over a previously-autonomous host).");
+            println!("         Re-enable with:");
+            println!("           ./.loom/scripts/cli/loom-daemon-start.sh --work-finder");
+            println!("         or drive from config:");
+            println!("           ./.loom/scripts/cli/loom-daemon-start.sh --from-config");
         }
     }
 
@@ -9191,6 +9238,7 @@ mod status_client_tests {
             host_breaker: None,
             rate_limit_breaker: None,
             safehouse: None,
+            work_finder_enabled: Some(true),
         }
     }
 
@@ -9420,5 +9468,75 @@ mod status_protection_tests {
             "install_state must stay on the unreachable path only"
         );
         assert!(value.get("protection").is_some());
+    }
+
+    // ---- marker-vs-non-autonomous-daemon mismatch (#4693, AC3) ----
+    // The sibling of #4069's ExpectedButDead state, but for the REACHABLE
+    // path: the daemon IS alive and answering, yet its work-finder loop is
+    // OFF while the marker records an operator's autonomy-desired intent —
+    // exactly the 2026-07-30 incident's end state (a "protected", healthy
+    // daemon that had silently stopped dispatching).
+
+    #[test]
+    fn autonomy_mismatch_true_when_marker_present_and_work_finder_off() {
+        let mut report = sample_report();
+        report.work_finder_enabled = Some(false);
+        let value = build_status_json_value(
+            &report,
+            None,
+            &no_update(),
+            None,
+            Some(&protection(ProtectionState::Protected, true, Some(true))),
+        );
+        assert_eq!(value["work_finder"]["enabled"], false);
+        assert_eq!(value["protection"]["autonomy_mismatch"], true);
+    }
+
+    #[test]
+    fn autonomy_mismatch_false_when_work_finder_is_on() {
+        let mut report = sample_report();
+        report.work_finder_enabled = Some(true);
+        let value = build_status_json_value(
+            &report,
+            None,
+            &no_update(),
+            None,
+            Some(&protection(ProtectionState::Protected, true, Some(true))),
+        );
+        assert_eq!(value["work_finder"]["enabled"], true);
+        assert_eq!(value["protection"]["autonomy_mismatch"], false);
+    }
+
+    #[test]
+    fn autonomy_mismatch_false_when_marker_absent_even_if_work_finder_off() {
+        // Work-finder off with NO marker is the ordinary, deliberate FLAGS-OFF
+        // reliability-daemon case (#3911) -- not a mismatch.
+        let mut report = sample_report();
+        report.work_finder_enabled = Some(false);
+        let value = build_status_json_value(
+            &report,
+            None,
+            &no_update(),
+            None,
+            Some(&protection(ProtectionState::NoMarker, false, Some(true))),
+        );
+        assert_eq!(value["protection"]["autonomy_mismatch"], false);
+    }
+
+    #[test]
+    fn autonomy_mismatch_false_when_work_finder_enabled_is_unknown() {
+        // A pre-#4693 daemon binary never computed `work_finder_enabled` —
+        // `null` must degrade to "no claim", never a false positive.
+        let mut report = sample_report();
+        report.work_finder_enabled = None;
+        let value = build_status_json_value(
+            &report,
+            None,
+            &no_update(),
+            None,
+            Some(&protection(ProtectionState::Protected, true, Some(true))),
+        );
+        assert!(value["work_finder"]["enabled"].is_null());
+        assert_eq!(value["protection"]["autonomy_mismatch"], false);
     }
 }

--- a/loom-daemon/src/serve.rs
+++ b/loom-daemon/src/serve.rs
@@ -1072,6 +1072,7 @@ mod tests {
             host_breaker: None,
             rate_limit_breaker: None,
             safehouse: None,
+            work_finder_enabled: None,
         }
     }
 

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -1214,6 +1214,25 @@ pub struct DaemonStatusReport {
     /// computed one. `#[serde(default)]` keeps that wire data compatible.
     #[serde(default)]
     pub safehouse: Option<SafehouseStatus>,
+    /// Whether the autonomous work-finder loop is enabled for THIS running
+    /// daemon process (Issue #4693), via
+    /// [`crate::work_finder::resolve_enabled`] read from the daemon's own
+    /// environment/config at query time — the exact same precedence (env >
+    /// config > default) `loom-daemon-start.sh` used to bake `LOOM_WORK_FINDER`
+    /// into the plist/unit this process was launched from, so this field always
+    /// reflects the truth of the process actually answering, never a
+    /// re-derivation from the CLI client's own cwd. Mirrors
+    /// [`Self::main_health_gate_enabled`]'s shape and forward-compat contract:
+    /// `Some(true)` / `Some(false)` are resolved daemon-side; `None` only for a
+    /// pre-#4693 wire payload from an older daemon binary that never computed
+    /// one (never misread as `false`). Consumed by the `status` CLI to flag the
+    /// marker-vs-non-autonomous-daemon mismatch (AC3 of #4693): the
+    /// autonomy-desired marker (#4011) present while this reads `Some(false)`
+    /// means dispatch is silently not happening on an otherwise-healthy,
+    /// reachable daemon. `#[serde(default)]` keeps pre-#4693 wire data
+    /// compatible.
+    #[serde(default)]
+    pub work_finder_enabled: Option<bool>,
 }
 
 /// Live safehouse connection status for `loom-daemon status` (Issue #4345).


### PR DESCRIPTION
## Summary

Live incident 2026-07-30: a routine `loom-daemon-start.sh` run (no flags,
run to re-provision the watchdog) silently re-rendered the launchd plist
with `LOOM_WORK_FINDER=0` — downgrading a previously-autonomous daemon to
a reliability-only daemon with no warning. Autonomous dispatch stopped for
~3 hours (23 ready issues sat queued) and took log archaeology to diagnose.

The FLAGS-OFF default for a *plain* start is deliberate (#3911) and stays
unchanged. This PR closes the *silent* part of the transition:

- **`loom-daemon-start.sh`** (write side): before re-rendering the
  plist/unit, compares the new render's `LOOM_WORK_FINDER` /
  `LOOM_MAIN_HEALTH_GATE` against the **prior installed** plist/unit's
  value (or, when no prior value is readable, the autonomy-desired marker
  #4011 alone) and prints a loud, non-blocking
  `WARNING: autonomy downgrade -- <key>: 1 -> 0` naming the
  `--from-config` / `--work-finder` remediation. Exempt when: control is
  explicitly handed to `--from-config`; the downgrade was itself an
  explicit `--no-work-finder` / `--no-health-gate` this invocation; or the
  operator pre-exported `LOOM_WORK_FINDER=0` themselves. Never blocks the
  start (advisory only, matching the #4522 dropped-env-key precedent).
- **`loom-daemon status`** (read side): the reachable-daemon sibling
  check. Adds `DaemonStatusReport.work_finder_enabled` (resolved
  daemon-side via `work_finder::resolve_enabled`, the same precedence the
  start script bakes into the plist), and surfaces
  `protection.autonomy_mismatch: bool` in `--json` (`true` only when the
  autonomy-desired marker is present **and** this reachable daemon's own
  work-finder reads disabled) plus a human `WARNING:` block with the same
  remediation.

AC2 from the issue ("default to `--from-config` behavior when the marker
is present and no explicit flags were passed") is explicitly marked
"Consider" in the issue and is a bigger behavioral change than an
advisory warning — left as a deliberate follow-up rather than folded into
this fix.

## Test plan

- [x] `defaults/scripts/tests/test-loom-daemon-start.sh`: 71/71 passed,
      including the issue's required case ("prior-plist-had-work-finder +
      plain restart -> warning emitted") for both the launchd (`--print-plist`)
      and systemd (real install) paths, plus the exemption cases
      (`--from-config`, explicit `--no-work-finder`, pre-exported env,
      no-transition, clean first install, marker-alone).
- [x] `cargo test --bin loom-daemon autonomy_mismatch` (4 new tests in
      `status_protection_tests`): marker+work-finder-off -> mismatch true;
      work-finder-on -> false; no-marker -> false; `work_finder_enabled:
      None` (pre-#4693 daemon) -> false, never a false positive.
- [x] `cargo build --lib` / `cargo build --bin loom-daemon` clean.
- [x] `cargo clippy --lib --bin loom-daemon -- -D warnings` clean.
- [x] `shellcheck -S warning defaults/scripts/cli/loom-daemon-start.sh` clean.
- [x] `cargo fmt --check` clean.

Closes #4693