### PR TITLE
feat: pluggable telemetry exporter with offline queue and observability config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -82,7 +82,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -102,6 +102,29 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "axum"
@@ -157,6 +180,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
@@ -201,14 +230,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
 
 [[package]]
 name = "chrono"
@@ -292,16 +346,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -422,8 +505,25 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -467,7 +567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -514,6 +614,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -566,8 +672,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -577,10 +685,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
+ "rand_core",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -714,6 +825,22 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -722,13 +849,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -756,10 +891,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -772,6 +1010,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -816,6 +1060,60 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
 ]
 
 [[package]]
@@ -875,6 +1173,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,7 +1206,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
 ]
@@ -912,7 +1216,7 @@ name = "loom-daemon"
 version = "0.16.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.23.0",
  "chrono",
  "clap",
  "criterion",
@@ -921,6 +1225,7 @@ dependencies = [
  "hex",
  "log",
  "regex",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
@@ -931,6 +1236,12 @@ dependencies = [
  "tokio-test",
  "uuid",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -967,7 +1278,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -976,7 +1287,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1005,6 +1316,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -1107,6 +1424,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,6 +1452,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,6 +1522,32 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "rayon"
@@ -1177,7 +1586,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1210,13 +1619,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "reqwest"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http 0.6.11",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rsqlite-vfs"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1235,6 +1696,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,7 +1711,82 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1269,10 +1811,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1427,7 +2001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1443,10 +2017,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1475,6 +2061,20 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "tempfile"
@@ -1486,7 +2086,16 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -1495,7 +2104,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1519,6 +2139,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1527,6 +2157,21 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1542,7 +2187,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1554,6 +2199,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1592,6 +2247,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -1684,6 +2357,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,6 +2379,30 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1741,6 +2444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1775,6 +2487,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1854,6 +2576,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,7 +2616,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1945,12 +2686,151 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -2047,6 +2927,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,6 +2969,66 @@ name = "zerocopy-derive"
 version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -4479,6 +4479,97 @@ throwaway issue from `loom:triage` → Curator → `loom:issue` → work-finder
 dispatch → PR → merge, with a scripted label-transition assertion, and confirms
 the operator only ever created the issue.
 
+## Observability exporter (`observability`, #4705, epic #4702 Phase 1)
+
+An **opt-in, off-by-default** telemetry exporter that pushes fleet telemetry
+(sweep lifecycle/outcome, token-pool snapshots, host health) to a configured
+HTTP(S) sink. This is the daemon-side half of epic #4702's rich fleet
+dashboard; the Phase-2 Cloudflare Workers backend (the first real sink) is a
+separate, later issue — this issue ships value standalone, with no cloud
+dependency: a disabled or under-configured `observability` block is a
+zero-syscall no-op, exactly like `autonomous.idleExit` above.
+
+### Config surface (`.loom/config.json → observability`)
+
+```json
+{
+  "observability": {
+    "enabled": false,
+    "endpoint": "https://ingest.example.com/v1/telemetry",
+    "ingestKeyFile": "/etc/loom/observability-ingest.key",
+    "batchSize": 50,
+    "flushIntervalSecs": 30,
+    "queueCapacity": 2000
+  }
+}
+```
+
+Precedence is **env > config > default**, same convention as every other
+`autonomous.*`-style block: `LOOM_OBSERVABILITY_ENABLED` /
+`LOOM_OBSERVABILITY_ENDPOINT` / `LOOM_OBSERVABILITY_INGEST_KEY_FILE` /
+`LOOM_OBSERVABILITY_BATCH_SIZE` / `LOOM_OBSERVABILITY_FLUSH_INTERVAL_SECS` /
+`LOOM_OBSERVABILITY_QUEUE_CAPACITY` override the matching config key, which
+overrides the built-in default (`false` / *(none)* / *(none)* / `50` / `30` /
+`2000`). The **ingest key is never inline in config** — `ingestKeyFile` names
+a path the daemon reads once at startup; the key contents never appear in a
+log line or error message (only the *path* does), and requests authenticate
+via an `Authorization: Bearer <key>` header. `loom-daemon` refuses to export
+(logs a `WARN` and skips both background tasks) when enabled without a
+resolvable `endpoint` or a readable, non-empty `ingestKeyFile` — treated the
+same as "not configured", not a startup failure.
+
+### Architecture
+
+Two background tasks, spawned together (`observability::spawn_task`,
+`loom-daemon/src/observability/`) alongside the `idle_exit`/`auto_update`
+wiring in `main.rs`:
+
+- **Collector** (`observability::collector`) — a pure [`EventBus`](#event-taxonomy-frozen-for-v0100)
+  subscriber (`sweep.global.dispatch` + `sweep.issue.*`, adding **no new emit
+  call sites** anywhere else in the daemon, the same design
+  [safehouse](#completion-narration--public-fleet-feed-4426) narration
+  uses) that maps lifecycle events to the versioned
+  `loom-daemon/src/telemetry/` schema (#4703) — `sweep.started` /
+  `sweep.phase` / `sweep.completed` / `sweep.outcome` — resolves the emitting
+  repo's `owner/repo` slug and public/private visibility tag
+  (`telemetry::visibility`, an existing `gh api repos/{owner}/{repo}
+  --jq .private` TTL-cached probe, private-by-default on any failure), and
+  every 5 minutes additionally samples host-level `tokens.snapshot` (from the
+  resolved token pool's `.ranking` file) and `host.health` (CPU idle
+  fraction, load-per-core, logical CPU count, worktree-root free space,
+  daemon version/uptime) records, which have no corresponding bus event.
+- **Sender** (`observability::sender`) — drains the queue on a jittered
+  `flushIntervalSecs` timer via `observability::exporter::HttpsExporter`
+  (`reqwest`, JSON array POST per batch), retrying a failed batch with
+  jittered exponential backoff (5s floor, 5 minute ceiling) — jitter comes
+  from this crate's existing dependency-free `tokens_pool::rng::Rng`, not a
+  new `rand` dependency.
+
+Between them sits `observability::queue::DurableQueue` — a bounded,
+disk-backed FIFO (`<workspace>/.loom/logs/observability-queue.jsonl`,
+override `LOOM_OBSERVABILITY_QUEUE_PATH`) that survives a clean daemon
+restart across host sleep/idle-shutdown (#4467/#4697): every push/ack
+atomically rewrites the file (temp-file + rename, mirroring
+`idle_exit::write_marker`). Once `queueCapacity` is reached, the **oldest**
+queued record is dropped and a running `dropped_total` counter is logged —
+bounded growth, never an unbounded queue, and never a silent loss.
+
+### Exporter trait boundary (Phase 4 forward-compat, no OTel dependency yet)
+
+`observability::exporter::Exporter` is a two-method trait (`emit_batch`,
+`flush`) `observability::sender`'s drain loop is generic over — `HttpsExporter`
+is its only implementation today. This issue adds **no OTel dependency**; the
+trait boundary exists so epic #4702 Phase 4's optional OTLP exporter (for
+operators with an existing Grafana/Honeycomb/self-hosted-collector stack) can
+be a second `impl Exporter` later without touching the queue or sender.
+
+### Read-only invariant
+
+The exporter only ever originates outbound HTTP POSTs; it never parses a
+response body for anything beyond a batch-accepted/rejected status, and
+nothing received over this channel ever mutates daemon state — steering
+(dispatch/cancel/pause) stays with MCP, per the epic's explicit scope.
+
 ## Fleet dashboard (`loom-daemon serve`)
 
 `loom-daemon serve` (#4329 phases 1-3: #4391 status snapshot, #4392 SSE event

--- a/loom-daemon/Cargo.toml
+++ b/loom-daemon/Cargo.toml
@@ -19,6 +19,12 @@ regex = "1.12"
 clap = { version = "4.6", features = ["derive"] }
 sha2 = "0.11.0"
 hex = "0.4.3"
+# Minimal async HTTP client for the observability exporter (#4705): JSON-over-
+# HTTPS push only, no TLS-backend duplication with other tooling in this repo.
+# `rustls-tls` avoids an OpenSSL system dependency; `default-features = false`
+# drops reqwest's default blocking/cookie/multipart surface this exporter
+# never touches.
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "rustls-native-certs", "json"] }
 
 [dev-dependencies]
 tempfile = "3.27"

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -170,6 +170,7 @@ pub mod issue_creation_mutex;
 pub mod live_claim;
 pub mod main_health_gate;
 pub mod metrics_collector;
+pub mod observability;
 pub mod peer_claims;
 pub mod phase_join;
 pub mod pipeline_snapshot;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -13,6 +13,7 @@ use loom_daemon::idle_exit;
 use loom_daemon::ipc::IpcServer;
 use loom_daemon::main_health_gate;
 use loom_daemon::metrics_collector;
+use loom_daemon::observability;
 use loom_daemon::quarantine_reconciliation;
 use loom_daemon::rate_limit_breaker;
 use loom_daemon::role_collision;
@@ -2860,6 +2861,21 @@ async fn run_daemon() -> Result<()> {
         log::debug!("idle_exit: disabled (opt in with autonomous.idleExit.enabled=true)");
         None
     };
+
+    // Pluggable telemetry exporter (#4705, epic #4702 Phase 1). Off by
+    // default (FLAGS-OFF, `observability.enabled=true` to opt in) — a bus
+    // subscriber plus a queue-drain sender, mirroring the idle_exit wiring
+    // immediately above. `Instant::now()` here approximates daemon uptime for
+    // the periodic `host.health` sample; see `observability::spawn_task`'s
+    // doc comment for why an exact daemon-start timestamp is not threaded
+    // through for this.
+    let observability_config = observability::read_config(&sweep_workspace);
+    let _observability_handles = observability::spawn_task(
+        &observability_config,
+        sweep_workspace.clone(),
+        &event_bus,
+        std::time::Instant::now(),
+    );
 
     // Start IPC server. `workspace_health_states` is threaded in so the
     // `DaemonStatus` request can report each registered repo's own halt state

--- a/loom-daemon/src/observability/collector.rs
+++ b/loom-daemon/src/observability/collector.rs
@@ -1,0 +1,701 @@
+//! Bus-subscriber telemetry collector (Epic #4702, Phase 1 — issue #4705).
+//!
+//! Mirrors [`crate::safehouse`]'s "subscribe to the existing bus, add no new
+//! call sites" design: this module adds **zero** new emit sites anywhere
+//! else in the daemon. It subscribes to the already-frozen `sweep.global.
+//! dispatch` / `sweep.issue.*` topics (`event_bus.rs`'s taxonomy), maps each
+//! relevant event to the [`crate::telemetry`] schema's record types, resolves
+//! the emitting repo's `owner/repo` slug + [`RepoVisibility`], and pushes the
+//! resulting [`TelemetryEnvelope`]s onto the [`DurableQueue`] for
+//! [`super::sender`] to drain. It also periodically samples host-level
+//! records (`tokens.snapshot`, `host.health`) that have no corresponding bus
+//! event.
+//!
+//! # Best-effort, in-memory correlation
+//!
+//! [`Event::SweepPhase`] / [`Event::SweepExited`] / [`Event::SweepCrashed`]
+//! carry an `issue` number but not the `sweep_id` the schema's lifecycle
+//! records require, so this module tracks a small in-memory `issue ->
+//! (sweep_id, started_at)` map ([`DispatchState`]), populated on
+//! `sweep.global.dispatch` and consulted (then cleared) on the terminal
+//! event. Like every other in-process daemon tracker (e.g.
+//! `work_finder`'s per-root state maps), this resets across a daemon
+//! restart: a sweep already in flight when the collector starts emits
+//! `sweep.phase`/`sweep.completed`/`sweep.outcome` records with a
+//! synthesized `unknown-issue-{N}` sweep id and a zero `total_duration_sec`
+//! rather than failing to emit at all — a degraded record beats a silently
+//! dropped one for a telemetry pipeline.
+//!
+//! # Terminal outcome: `SweepExited`/`SweepCrashed` only
+//!
+//! The reaper always emits `Event::SweepGlobalCompleted` alongside
+//! `SweepExited`/`SweepCrashed` for the same terminal transition
+//! (`sweep_registry.rs`) — `SweepGlobalCompleted` carries no `issue` number
+//! and would double-emit the same outcome, so this collector does not
+//! subscribe to `sweep.global.completed` at all.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+
+use crate::event_bus::{EventBus, RecvError};
+use crate::telemetry::{
+    visibility::derive_visibility, HostHealthRecord, PhaseDuration, RepoVisibility, SweepResult,
+    SweepStartedRecord, TelemetryEnvelope, TelemetryRecord, TokenAccountState, TokenSnapshotRecord,
+};
+use crate::types::{Event, SweepKind};
+
+use super::queue::DurableQueue;
+
+/// Timeout on the `gh repo view` slug lookup — generous but bounded so a
+/// wedged `gh` cannot stall the collector loop indefinitely.
+const SLUG_FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// In-flight sweep state tracked purely in memory (see module docs).
+#[derive(Debug, Clone)]
+struct DispatchState {
+    sweep_id: String,
+    started_at: DateTime<Utc>,
+}
+
+/// Spawn the collector task on the shared daemon runtime. Subscribes to the
+/// frozen `sweep.global.dispatch` / `sweep.issue.*` topics and periodically
+/// (every `snapshot_interval`) samples host-level records. `daemon_started_at`
+/// is used only to compute `host.health`'s `uptime_sec` (approximated as this
+/// task's own uptime — see [`super::spawn_task`]'s doc comment).
+pub fn spawn_task(
+    bus: &EventBus,
+    queue: Arc<DurableQueue>,
+    workspace_root: PathBuf,
+    host_id: String,
+    snapshot_interval: Duration,
+    daemon_started_at: Instant,
+) -> tokio::task::JoinHandle<()> {
+    let subscription = bus.subscribe(["sweep.global.dispatch", "sweep.issue"]);
+    tokio::spawn(run_collector(
+        subscription,
+        queue,
+        workspace_root,
+        host_id,
+        snapshot_interval,
+        daemon_started_at,
+    ))
+}
+
+async fn run_collector(
+    mut subscription: crate::event_bus::Subscription,
+    queue: Arc<DurableQueue>,
+    workspace_root: PathBuf,
+    host_id: String,
+    snapshot_interval: Duration,
+    daemon_started_at: Instant,
+) {
+    let mut dispatches: HashMap<u32, DispatchState> = HashMap::new();
+    let mut slug_cache: HashMap<String, String> = HashMap::new();
+    let mut snapshot_timer = tokio::time::interval(snapshot_interval);
+    snapshot_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            biased;
+
+            recv_result = subscription.recv() => {
+                match recv_result {
+                    Ok(event) => {
+                        handle_event(
+                            event,
+                            &queue,
+                            &workspace_root,
+                            &host_id,
+                            &mut dispatches,
+                            &mut slug_cache,
+                        )
+                        .await;
+                    }
+                    Err(RecvError::Closed) => {
+                        log::debug!("observability: event bus closed; collector stopping");
+                        break;
+                    }
+                    Err(_) => {}
+                }
+            }
+
+            _ = snapshot_timer.tick() => {
+                sample_snapshots(&queue, &workspace_root, &host_id, daemon_started_at).await;
+            }
+        }
+    }
+}
+
+async fn handle_event(
+    event: Event,
+    queue: &DurableQueue,
+    default_workspace_root: &Path,
+    host_id: &str,
+    dispatches: &mut HashMap<u32, DispatchState>,
+    slug_cache: &mut HashMap<String, String>,
+) {
+    let Some(issue) = event_issue(&event) else {
+        return;
+    };
+    let workspace_path = event_repo_path(&event)
+        .unwrap_or_else(|| default_workspace_root.to_string_lossy().to_string());
+    let Some(slug) = resolve_repo_slug_cached(slug_cache, &workspace_path).await else {
+        log::debug!(
+            "observability: could not resolve a repo slug for {workspace_path}; dropping \
+             record(s) for issue #{issue}"
+        );
+        return;
+    };
+    let visibility = resolve_visibility(&slug).await;
+    for record in map_event_to_records(&event, issue, &slug, visibility, dispatches) {
+        queue.push(TelemetryEnvelope::new(host_id, record));
+    }
+}
+
+/// The issue this event concerns, or `None` for an event kind this collector
+/// does not translate into a telemetry record (e.g. `SweepBlocker`, a
+/// PR-set dispatch).
+fn event_issue(event: &Event) -> Option<u32> {
+    match event {
+        Event::SweepGlobalDispatch {
+            kind: SweepKind::Issue(issue),
+            ..
+        } => Some(*issue),
+        Event::SweepPhase { issue, .. }
+        | Event::SweepExited { issue, .. }
+        | Event::SweepCrashed { issue, .. } => Some(*issue),
+        _ => None,
+    }
+}
+
+/// The owning workspace-root path stamped on the event, when present (Issue
+/// #3929's `repo` field — a filesystem path, not a forge `owner/repo` slug;
+/// [`resolve_repo_slug_cached`] converts it).
+fn event_repo_path(event: &Event) -> Option<String> {
+    match event {
+        Event::SweepGlobalDispatch { repo, .. }
+        | Event::SweepPhase { repo, .. }
+        | Event::SweepExited { repo, .. }
+        | Event::SweepCrashed { repo, .. } => repo.clone(),
+        _ => None,
+    }
+}
+
+/// Pure event -> telemetry-record mapping (no I/O), given an already-resolved
+/// `repo` slug and `visibility`. Returns zero, one, or two records — a
+/// terminal event yields both a `sweep.completed` record (mirrors the frozen
+/// SSE moment) and the richer `sweep.outcome` record.
+fn map_event_to_records(
+    event: &Event,
+    issue: u32,
+    repo: &str,
+    visibility: RepoVisibility,
+    dispatches: &mut HashMap<u32, DispatchState>,
+) -> Vec<TelemetryRecord> {
+    match event {
+        Event::SweepGlobalDispatch {
+            kind: SweepKind::Issue(_),
+            sweep_id,
+            ..
+        } => {
+            let started_at = Utc::now();
+            dispatches.insert(
+                issue,
+                DispatchState {
+                    sweep_id: sweep_id.clone(),
+                    started_at,
+                },
+            );
+            vec![TelemetryRecord::SweepStarted(SweepStartedRecord {
+                repo: repo.to_string(),
+                visibility,
+                issue,
+                sweep_id: sweep_id.clone(),
+                started_at,
+                model: None,
+                effort: None,
+            })]
+        }
+        Event::SweepGlobalDispatch { .. } => Vec::new(),
+        Event::SweepPhase { phase, .. } => {
+            let sweep_id = dispatches
+                .get(&issue)
+                .map(|d| d.sweep_id.clone())
+                .unwrap_or_else(|| unknown_sweep_id(issue));
+            vec![TelemetryRecord::SweepPhase(
+                crate::telemetry::SweepPhaseRecord {
+                    repo: repo.to_string(),
+                    visibility,
+                    issue,
+                    sweep_id,
+                    phase: phase.clone(),
+                    entered_at: Utc::now(),
+                },
+            )]
+        }
+        Event::SweepExited {
+            exit_code,
+            duration_sec,
+            ..
+        } => {
+            let dispatch = dispatches.remove(&issue);
+            let sweep_id = dispatch
+                .as_ref()
+                .map(|d| d.sweep_id.clone())
+                .unwrap_or_else(|| unknown_sweep_id(issue));
+            let result = if *exit_code == Some(0) {
+                SweepResult::Success
+            } else {
+                SweepResult::Failure
+            };
+            terminal_records(repo, visibility, issue, sweep_id, result, *duration_sec, None)
+        }
+        Event::SweepCrashed { .. } => {
+            let dispatch = dispatches.remove(&issue);
+            let sweep_id = dispatch
+                .as_ref()
+                .map(|d| d.sweep_id.clone())
+                .unwrap_or_else(|| unknown_sweep_id(issue));
+            let duration_sec = dispatch
+                .as_ref()
+                .map(|d| (Utc::now() - d.started_at).num_seconds().max(0))
+                .unwrap_or(0);
+            terminal_records(
+                repo,
+                visibility,
+                issue,
+                sweep_id,
+                SweepResult::Failure,
+                duration_sec,
+                None,
+            )
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn unknown_sweep_id(issue: u32) -> String {
+    format!("unknown-issue-{issue}")
+}
+
+/// Build the paired `sweep.completed` + `sweep.outcome` records a terminal
+/// event yields.
+fn terminal_records(
+    repo: &str,
+    visibility: RepoVisibility,
+    issue: u32,
+    sweep_id: String,
+    result: SweepResult,
+    total_duration_sec: i64,
+    pr_number: Option<u32>,
+) -> Vec<TelemetryRecord> {
+    let completed_at = Utc::now();
+    vec![
+        TelemetryRecord::SweepCompleted(crate::telemetry::SweepCompletedRecord {
+            repo: repo.to_string(),
+            visibility,
+            issue,
+            sweep_id: sweep_id.clone(),
+            completed_at,
+            result,
+        }),
+        TelemetryRecord::SweepOutcome(crate::telemetry::SweepOutcomeRecord {
+            repo: repo.to_string(),
+            visibility,
+            issue,
+            sweep_id,
+            model: None,
+            effort: None,
+            config: std::collections::BTreeMap::new(),
+            phase_durations: Vec::<PhaseDuration>::new(),
+            total_duration_sec,
+            result,
+            pr_number,
+        }),
+    ]
+}
+
+/// [`fetch_repo_slug`] with a process-lifetime cache keyed by workspace root
+/// path (a repo's slug does not change while the daemon runs — same
+/// rationale as [`crate::safehouse`]'s own `slug_cache`).
+async fn resolve_repo_slug_cached(
+    cache: &mut HashMap<String, String>,
+    workspace_root: &str,
+) -> Option<String> {
+    if let Some(slug) = cache.get(workspace_root) {
+        return Some(slug.clone());
+    }
+    let slug = fetch_repo_slug(Path::new(workspace_root)).await?;
+    cache.insert(workspace_root.to_string(), slug.clone());
+    Some(slug)
+}
+
+/// Best-effort `gh repo view --json nameWithOwner --jq .nameWithOwner` lookup
+/// for the forge `owner/repo` slug. Every failure (missing/erroring `gh`, a
+/// timeout, an empty/malformed answer) degrades to `None` — the caller drops
+/// the record rather than emitting a fabricated repo identity.
+async fn fetch_repo_slug(workspace_root: &Path) -> Option<String> {
+    let run = tokio::process::Command::new("gh")
+        .arg("repo")
+        .arg("view")
+        .arg("--json")
+        .arg("nameWithOwner")
+        .arg("--jq")
+        .arg(".nameWithOwner")
+        .current_dir(workspace_root)
+        .output();
+    let output = tokio::time::timeout(SLUG_FETCH_TIMEOUT, run)
+        .await
+        .ok()?
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let slug = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!slug.is_empty() && slug.contains('/')).then_some(slug)
+}
+
+/// [`derive_visibility`] blocks on a `gh api` probe, so it is dispatched
+/// through `spawn_blocking` per its own doc guidance; a join failure degrades
+/// to the private-safe default rather than propagating.
+async fn resolve_visibility(slug: &str) -> RepoVisibility {
+    let owned = slug.to_string();
+    tokio::task::spawn_blocking(move || derive_visibility(&owned))
+        .await
+        .unwrap_or(RepoVisibility::Private)
+}
+
+/// Sample the two host-level record kinds that have no corresponding bus
+/// event and push them onto `queue`.
+async fn sample_snapshots(
+    queue: &DurableQueue,
+    workspace_root: &Path,
+    host_id: &str,
+    daemon_started_at: Instant,
+) {
+    let token_record = sample_token_snapshot(workspace_root);
+    queue.push(TelemetryEnvelope::new(host_id, TelemetryRecord::TokensSnapshot(token_record)));
+    let health_record = sample_host_health(workspace_root, daemon_started_at).await;
+    queue.push(TelemetryEnvelope::new(host_id, TelemetryRecord::HostHealth(health_record)));
+}
+
+/// Read the resolved rotation-ranking file for `workspace_root` into a
+/// [`TokenSnapshotRecord`]. `rank` is the account's position in the ranking
+/// file (lower = preferred); an unreadable/missing/empty ranking yields an
+/// empty `accounts` list rather than an error — mirrors
+/// [`crate::capacity::read_ranking_at`]'s soft-fail contract.
+fn sample_token_snapshot(workspace_root: &Path) -> TokenSnapshotRecord {
+    let pool_dir = crate::tokens_pool::paths::resolve_tokens_dir(workspace_root);
+    let ranking_path = pool_dir.join(".ranking");
+    let mut accounts = Vec::new();
+    if let Ok(contents) = std::fs::read_to_string(&ranking_path) {
+        for (index, line) in contents.lines().enumerate() {
+            if !line.contains('|') {
+                continue;
+            }
+            let Some((account, status, usage_fraction)) =
+                crate::tokens_pool::select::parse_ranking_line(line)
+            else {
+                continue;
+            };
+            let exhausted = !crate::capacity::AccountHealth::parse(&status).is_healthy();
+            accounts.push(TokenAccountState {
+                account,
+                rank: Some(u32::try_from(index).unwrap_or(u32::MAX)),
+                usage_fraction,
+                limit_window_reset_at: None,
+                exhausted,
+            });
+        }
+    }
+    TokenSnapshotRecord {
+        captured_at: Utc::now(),
+        accounts,
+    }
+}
+
+/// Sample host CPU/disk headroom into a [`HostHealthRecord`]. Every measured
+/// field is `Option` — an unmeasurable probe stays absent rather than a fake
+/// zero (mirrors `cpu_headroom`/`disk_headroom`'s own contract).
+async fn sample_host_health(workspace_root: &Path, started_at: Instant) -> HostHealthRecord {
+    // CPU idle refresh can block ~1s on macOS (`iostat`) — dispatched through
+    // `spawn_blocking` per the exact pattern `work_finder`'s dynamic-cap tick
+    // already uses.
+    let _ = tokio::task::spawn_blocking(crate::cpu_headroom::refresh_cpu_util_cache).await;
+    HostHealthRecord {
+        captured_at: Utc::now(),
+        daemon_version: env!("CARGO_PKG_VERSION").to_string(),
+        uptime_sec: started_at.elapsed().as_secs(),
+        logical_cpus: crate::cpu_headroom::logical_cpu_count(),
+        cpu_idle_fraction: crate::cpu_headroom::cached_cpu_idle_fraction(),
+        load_per_core: crate::cpu_headroom::load_per_core(),
+        worktree_root_free_gb: crate::disk_headroom::worktree_root_free_gb(workspace_root),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn dispatch_event(issue: u32, sweep_id: &str) -> Event {
+        Event::SweepGlobalDispatch {
+            sweep_id: sweep_id.to_string(),
+            kind: SweepKind::Issue(issue),
+            runtime: None,
+            runtime_source: None,
+            repo: Some("/repos/loom".to_string()),
+        }
+    }
+
+    fn phase_event(issue: u32, phase: &str) -> Event {
+        Event::SweepPhase {
+            issue,
+            phase: phase.to_string(),
+            pr_number: None,
+            repo: Some("/repos/loom".to_string()),
+        }
+    }
+
+    fn exited_event(issue: u32, exit_code: Option<i32>, duration_sec: i64) -> Event {
+        Event::SweepExited {
+            issue,
+            exit_code,
+            duration_sec,
+            no_progress: false,
+            death_class: None,
+            repo: Some("/repos/loom".to_string()),
+        }
+    }
+
+    fn crashed_event(issue: u32) -> Event {
+        Event::SweepCrashed {
+            issue,
+            checkpoint_phase: Some("builder".to_string()),
+            classification: None,
+            death_class: None,
+            repo: Some("/repos/loom".to_string()),
+        }
+    }
+
+    #[test]
+    fn dispatch_emits_sweep_started_and_tracks_state() {
+        let mut dispatches = HashMap::new();
+        let records = map_event_to_records(
+            &dispatch_event(42, "sweep-issue-42-0"),
+            42,
+            "rjwalters/loom",
+            RepoVisibility::Public,
+            &mut dispatches,
+        );
+        assert_eq!(records.len(), 1);
+        match &records[0] {
+            TelemetryRecord::SweepStarted(r) => {
+                assert_eq!(r.issue, 42);
+                assert_eq!(r.sweep_id, "sweep-issue-42-0");
+                assert_eq!(r.repo, "rjwalters/loom");
+                assert_eq!(r.visibility, RepoVisibility::Public);
+            }
+            other => panic!("expected SweepStarted, got {other:?}"),
+        }
+        assert!(dispatches.contains_key(&42));
+    }
+
+    #[test]
+    fn phase_after_dispatch_carries_the_tracked_sweep_id() {
+        let mut dispatches = HashMap::new();
+        map_event_to_records(
+            &dispatch_event(42, "sweep-issue-42-0"),
+            42,
+            "rjwalters/loom",
+            RepoVisibility::Private,
+            &mut dispatches,
+        );
+        let records = map_event_to_records(
+            &phase_event(42, "builder"),
+            42,
+            "rjwalters/loom",
+            RepoVisibility::Private,
+            &mut dispatches,
+        );
+        match &records[0] {
+            TelemetryRecord::SweepPhase(r) => {
+                assert_eq!(r.sweep_id, "sweep-issue-42-0");
+                assert_eq!(r.phase, "builder");
+            }
+            other => panic!("expected SweepPhase, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn phase_without_a_tracked_dispatch_uses_a_synthesized_sweep_id() {
+        // Simulates a daemon restart mid-sweep: no SweepGlobalDispatch was
+        // observed in this process's lifetime for issue 99.
+        let mut dispatches = HashMap::new();
+        let records = map_event_to_records(
+            &phase_event(99, "judge"),
+            99,
+            "rjwalters/loom",
+            RepoVisibility::Private,
+            &mut dispatches,
+        );
+        match &records[0] {
+            TelemetryRecord::SweepPhase(r) => assert_eq!(r.sweep_id, "unknown-issue-99"),
+            other => panic!("expected SweepPhase, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clean_exit_zero_maps_to_success_and_clears_dispatch_state() {
+        let mut dispatches = HashMap::new();
+        map_event_to_records(
+            &dispatch_event(7, "sweep-issue-7-0"),
+            7,
+            "rjwalters/loom",
+            RepoVisibility::Public,
+            &mut dispatches,
+        );
+        let records = map_event_to_records(
+            &exited_event(7, Some(0), 120),
+            7,
+            "rjwalters/loom",
+            RepoVisibility::Public,
+            &mut dispatches,
+        );
+        assert_eq!(records.len(), 2, "a terminal event yields completed + outcome");
+        match &records[0] {
+            TelemetryRecord::SweepCompleted(r) => assert_eq!(r.result, SweepResult::Success),
+            other => panic!("expected SweepCompleted, got {other:?}"),
+        }
+        match &records[1] {
+            TelemetryRecord::SweepOutcome(r) => {
+                assert_eq!(r.result, SweepResult::Success);
+                assert_eq!(r.total_duration_sec, 120);
+                assert_eq!(r.sweep_id, "sweep-issue-7-0");
+            }
+            other => panic!("expected SweepOutcome, got {other:?}"),
+        }
+        assert!(!dispatches.contains_key(&7), "terminal event must clear tracked state");
+    }
+
+    #[test]
+    fn nonzero_exit_maps_to_failure() {
+        let mut dispatches = HashMap::new();
+        let records = map_event_to_records(
+            &exited_event(8, Some(1), 30),
+            8,
+            "rjwalters/loom",
+            RepoVisibility::Private,
+            &mut dispatches,
+        );
+        match &records[0] {
+            TelemetryRecord::SweepCompleted(r) => assert_eq!(r.result, SweepResult::Failure),
+            other => panic!("expected SweepCompleted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn crash_maps_to_failure_with_duration_from_tracked_dispatch() {
+        let mut dispatches = HashMap::new();
+        dispatches.insert(
+            5,
+            DispatchState {
+                sweep_id: "sweep-issue-5-0".to_string(),
+                started_at: Utc::now() - chrono::Duration::seconds(60),
+            },
+        );
+        let records = map_event_to_records(
+            &crashed_event(5),
+            5,
+            "rjwalters/loom",
+            RepoVisibility::Private,
+            &mut dispatches,
+        );
+        match &records[1] {
+            TelemetryRecord::SweepOutcome(r) => {
+                assert_eq!(r.result, SweepResult::Failure);
+                assert!(r.total_duration_sec >= 59, "duration should reflect elapsed time");
+            }
+            other => panic!("expected SweepOutcome, got {other:?}"),
+        }
+        assert!(!dispatches.contains_key(&5));
+    }
+
+    #[test]
+    fn blocker_event_yields_no_records() {
+        let mut dispatches = HashMap::new();
+        let event = Event::SweepBlocker {
+            issue: 1,
+            reason: "human decision".to_string(),
+            label_added: "loom:blocked".to_string(),
+            repo: None,
+        };
+        let records = map_event_to_records(
+            &event,
+            1,
+            "rjwalters/loom",
+            RepoVisibility::Private,
+            &mut dispatches,
+        );
+        assert!(records.is_empty());
+    }
+
+    #[test]
+    fn event_issue_ignores_pr_set_dispatch() {
+        let event = Event::SweepGlobalDispatch {
+            sweep_id: "sweep-prs-0".to_string(),
+            kind: SweepKind::PrSet(vec![1, 2]),
+            runtime: None,
+            runtime_source: None,
+            repo: None,
+        };
+        assert_eq!(event_issue(&event), None);
+    }
+
+    #[test]
+    fn event_repo_path_reads_the_stamped_workspace_root() {
+        let event = phase_event(1, "curator");
+        assert_eq!(event_repo_path(&event).as_deref(), Some("/repos/loom"));
+    }
+
+    // ------------------------------------------------------------------
+    // Host-level snapshot samplers — no `gh` dependency, safe in CI.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn token_snapshot_reads_a_ranking_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".loom/tokens")).unwrap();
+        std::fs::write(
+            dir.path().join(".loom/tokens/.ranking"),
+            "agent-1|available|0.42\nagent-2|exhausted|0.99\n",
+        )
+        .unwrap();
+        let record = sample_token_snapshot(dir.path());
+        assert_eq!(record.accounts.len(), 2);
+        assert_eq!(record.accounts[0].account, "agent-1");
+        assert_eq!(record.accounts[0].rank, Some(0));
+        assert!(!record.accounts[0].exhausted);
+        assert_eq!(record.accounts[1].account, "agent-2");
+        assert!(record.accounts[1].exhausted);
+    }
+
+    #[test]
+    fn token_snapshot_missing_ranking_is_empty_not_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = sample_token_snapshot(dir.path());
+        assert!(record.accounts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn host_health_sample_populates_daemon_version_and_uptime() {
+        let dir = tempfile::tempdir().unwrap();
+        let started = Instant::now();
+        let record = sample_host_health(dir.path(), started).await;
+        assert_eq!(record.daemon_version, env!("CARGO_PKG_VERSION"));
+        assert!(record.logical_cpus >= 1);
+    }
+}

--- a/loom-daemon/src/observability/exporter.rs
+++ b/loom-daemon/src/observability/exporter.rs
@@ -1,0 +1,423 @@
+//! Exporter trait + native JSON-over-HTTPS push implementation (Epic #4702,
+//! Phase 1 — issue #4705).
+//!
+//! [`Exporter`] is deliberately narrow — "emit a batch, optionally flush" —
+//! so a later OTLP exporter (Phase 4 of the epic) is a drop-in second
+//! implementation rather than a rewrite of [`super::sender`]'s drain loop,
+//! which is generic over `E: Exporter` and never sees a concrete transport.
+//! **No OTel dependency is added in this issue** — [`HttpsExporter`] is the
+//! only implementation, and it depends on nothing but `reqwest`.
+//!
+//! Native `async fn` in a trait (stable since Rust 1.75) is used instead of
+//! the `async-trait` crate — nothing here needs a `dyn Exporter` trait
+//! object; [`super::sender::spawn_task`] is generic over a single concrete
+//! `E: Exporter`, so no vtable/boxing is required.
+
+use serde::Serialize;
+
+use crate::telemetry::TelemetryEnvelope;
+
+/// A sink [`super::sender`]'s drain loop can push batches of
+/// [`TelemetryEnvelope`]s to. Implementations must never panic on a
+/// transport failure — they return [`ExportError`] and the caller retries.
+pub trait Exporter: Send + Sync {
+    /// Push `envelopes` to the sink. `envelopes` is never empty (the caller
+    /// only invokes this with a non-empty batch).
+    fn emit_batch(
+        &self,
+        envelopes: &[TelemetryEnvelope],
+    ) -> impl std::future::Future<Output = Result<(), ExportError>> + Send;
+
+    /// Best-effort flush of any transport-level buffering. The default no-op
+    /// is correct for [`HttpsExporter`] (every [`Exporter::emit_batch`] call
+    /// is already a complete, synchronous-from-the-caller's-perspective HTTP
+    /// request/response round trip) and for any sink with no internal
+    /// buffer.
+    fn flush(&self) -> impl std::future::Future<Output = Result<(), ExportError>> + Send {
+        async { Ok(()) }
+    }
+}
+
+/// An export failure. [`std::fmt::Display`] **never** includes the ingest
+/// key — [`HttpsExporter`] sends it only as an `Authorization: Bearer` header
+/// value, which `reqwest::Error`'s `Display` does not print (it surfaces the
+/// request URL and failure kind, not headers), and this type's own variants
+/// carry no credential material either. This is the AC's "ingest key …
+/// absent from logs and error messages" guarantee.
+#[derive(Debug)]
+pub enum ExportError {
+    /// The HTTP request itself failed (connect refused, DNS, TLS, timeout).
+    Transport(String),
+    /// The sink responded, but with a non-2xx status.
+    Rejected { status: u16, body_snippet: String },
+}
+
+impl std::fmt::Display for ExportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExportError::Transport(message) => write!(f, "transport error: {message}"),
+            ExportError::Rejected {
+                status,
+                body_snippet,
+            } => {
+                write!(f, "sink rejected batch: HTTP {status} — {body_snippet}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ExportError {}
+
+/// Request body: a batch push is a bare JSON array of envelopes — no
+/// wrapping object, so the Phase-2 backend's ingest endpoint can decode the
+/// request body directly as `TelemetryEnvelope[]`.
+#[derive(Serialize)]
+struct BatchPayload<'a>(&'a [TelemetryEnvelope]);
+
+/// The native JSON-over-HTTPS push [`Exporter`]. POSTs each batch as a JSON
+/// array to `endpoint` with `Authorization: Bearer <ingest_key>`.
+pub struct HttpsExporter {
+    client: reqwest::Client,
+    endpoint: String,
+    ingest_key: String,
+}
+
+/// Per-request timeout — generous enough for a slow mobile/tethered fleet
+/// host, short enough that a wedged sink cannot pin the sender loop
+/// indefinitely (the loop would otherwise wait a full request timeout before
+/// the next scheduled flush tick anyway, but an explicit bound avoids ever
+/// depending on the underlying TCP stack's own timeout behavior).
+const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+
+impl HttpsExporter {
+    /// Build an exporter posting to `endpoint`, authenticating with
+    /// `ingest_key`. Fails only if the underlying `reqwest::Client` cannot be
+    /// constructed (e.g. no usable TLS backend) — never touches the network.
+    pub fn new(endpoint: String, ingest_key: String) -> Result<Self, ExportError> {
+        let client = reqwest::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .map_err(|error| ExportError::Transport(error.to_string()))?;
+        Ok(HttpsExporter {
+            client,
+            endpoint,
+            ingest_key,
+        })
+    }
+}
+
+impl Exporter for HttpsExporter {
+    async fn emit_batch(&self, envelopes: &[TelemetryEnvelope]) -> Result<(), ExportError> {
+        let response = self
+            .client
+            .post(&self.endpoint)
+            .bearer_auth(&self.ingest_key)
+            .json(&BatchPayload(envelopes))
+            .send()
+            .await
+            .map_err(|error| ExportError::Transport(error.to_string()))?;
+        if response.status().is_success() {
+            return Ok(());
+        }
+        let status = response.status().as_u16();
+        let body_snippet = response
+            .text()
+            .await
+            .unwrap_or_default()
+            .chars()
+            .take(200)
+            .collect();
+        Err(ExportError::Rejected {
+            status,
+            body_snippet,
+        })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::telemetry::{HostHealthRecord, TelemetryRecord};
+    use std::io::{Read, Write};
+    use std::net::{SocketAddr, TcpListener};
+    use std::sync::{Arc, Mutex};
+
+    /// A tiny hand-rolled HTTP/1.1 mock sink: no framework dependency, just
+    /// enough parsing to read one request's headers + body off a
+    /// `std::net::TcpListener` connection and answer with a fixed status.
+    /// Runs on a blocking thread (the daemon's tests are not all async), so
+    /// [`HttpsExporter`] — an async `reqwest::Client` — talks to it over a
+    /// real loopback socket exactly as it would talk to a real sink.
+    struct MockSink {
+        addr: SocketAddr,
+        requests: Arc<Mutex<Vec<MockRequest>>>,
+        respond_with: Arc<Mutex<u16>>,
+        shutdown: Arc<std::sync::atomic::AtomicBool>,
+        handle: Option<std::thread::JoinHandle<()>>,
+    }
+
+    #[derive(Debug, Clone)]
+    struct MockRequest {
+        auth_header: Option<String>,
+        body: Vec<u8>,
+    }
+
+    impl MockSink {
+        fn start() -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.set_nonblocking(true).unwrap();
+            let addr = listener.local_addr().unwrap();
+            let requests = Arc::new(Mutex::new(Vec::new()));
+            let respond_with = Arc::new(Mutex::new(200u16));
+            let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let handle = spawn_accept_loop(
+                listener,
+                requests.clone(),
+                respond_with.clone(),
+                shutdown.clone(),
+            );
+            MockSink {
+                addr,
+                requests,
+                respond_with,
+                shutdown,
+                handle: Some(handle),
+            }
+        }
+
+        fn url(&self) -> String {
+            format!("http://{}/ingest", self.addr)
+        }
+
+        fn requests(&self) -> Vec<MockRequest> {
+            self.requests.lock().unwrap().clone()
+        }
+
+        fn set_status(&self, status: u16) {
+            *self.respond_with.lock().unwrap() = status;
+        }
+
+        /// Simulate the sink going offline: stop accepting new connections.
+        /// Existing in-flight requests are unaffected; a *new* POST from the
+        /// exporter will hit connection-refused once the listener itself is
+        /// dropped in [`Self::kill`].
+        fn kill(mut self) -> (SocketAddr, Arc<Mutex<Vec<MockRequest>>>) {
+            self.shutdown
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            if let Some(handle) = self.handle.take() {
+                let _ = handle.join();
+            }
+            // `requests` is cloned (both point at the same underlying data —
+            // it is an `Arc`) rather than moved, because `Self` implements
+            // `Drop` and cannot be partially moved out of.
+            (self.addr, self.requests.clone())
+        }
+
+        /// Revive a killed sink on the **same** address (rebinding a plain
+        /// TCP listening socket with no established connections is safe
+        /// immediately after close — no TIME_WAIT is incurred on a
+        /// never-accepted listener).
+        fn revive(addr: SocketAddr, requests: Arc<Mutex<Vec<MockRequest>>>) -> Self {
+            let listener = TcpListener::bind(addr).unwrap();
+            listener.set_nonblocking(true).unwrap();
+            let respond_with = Arc::new(Mutex::new(200u16));
+            let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let handle = spawn_accept_loop(
+                listener,
+                requests.clone(),
+                respond_with.clone(),
+                shutdown.clone(),
+            );
+            MockSink {
+                addr,
+                requests,
+                respond_with,
+                shutdown,
+                handle: Some(handle),
+            }
+        }
+    }
+
+    impl Drop for MockSink {
+        fn drop(&mut self) {
+            self.shutdown
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            if let Some(handle) = self.handle.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+
+    fn spawn_accept_loop(
+        listener: TcpListener,
+        requests: Arc<Mutex<Vec<MockRequest>>>,
+        respond_with: Arc<Mutex<u16>>,
+        shutdown: Arc<std::sync::atomic::AtomicBool>,
+    ) -> std::thread::JoinHandle<()> {
+        std::thread::spawn(move || {
+            while !shutdown.load(std::sync::atomic::Ordering::SeqCst) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        stream.set_nonblocking(false).ok();
+                        if let Some(request) = read_request(&mut stream) {
+                            let status = *respond_with.lock().unwrap();
+                            let _ = write_response(&mut stream, status);
+                            requests.lock().unwrap().push(request);
+                        }
+                    }
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(10));
+                    }
+                    Err(_) => break,
+                }
+            }
+        })
+    }
+
+    fn read_request(stream: &mut std::net::TcpStream) -> Option<MockRequest> {
+        stream
+            .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+            .ok();
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 4096];
+        let header_end;
+        loop {
+            let n = stream.read(&mut chunk).ok()?;
+            if n == 0 {
+                return None;
+            }
+            buf.extend_from_slice(&chunk[..n]);
+            if let Some(pos) = find_subslice(&buf, b"\r\n\r\n") {
+                header_end = pos + 4;
+                break;
+            }
+        }
+        let header_text = String::from_utf8_lossy(&buf[..header_end]).to_string();
+        let auth_header = header_text
+            .lines()
+            .find(|line| line.to_ascii_lowercase().starts_with("authorization:"))
+            .map(|line| line.splitn(2, ':').nth(1).unwrap_or("").trim().to_string());
+        let content_length: usize = header_text
+            .lines()
+            .find(|line| line.to_ascii_lowercase().starts_with("content-length:"))
+            .and_then(|line| line.splitn(2, ':').nth(1))
+            .and_then(|v| v.trim().parse().ok())
+            .unwrap_or(0);
+        while buf.len() < header_end + content_length {
+            let n = stream.read(&mut chunk).ok()?;
+            if n == 0 {
+                break;
+            }
+            buf.extend_from_slice(&chunk[..n]);
+        }
+        let body = buf[header_end..(header_end + content_length).min(buf.len())].to_vec();
+        Some(MockRequest { auth_header, body })
+    }
+
+    fn write_response(stream: &mut std::net::TcpStream, status: u16) -> std::io::Result<()> {
+        let reason = if status < 300 { "OK" } else { "Error" };
+        let response =
+            format!("HTTP/1.1 {status} {reason}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+        stream.write_all(response.as_bytes())
+    }
+
+    fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+        haystack
+            .windows(needle.len())
+            .position(|window| window == needle)
+    }
+
+    fn one_envelope() -> TelemetryEnvelope {
+        TelemetryEnvelope::new(
+            "host-test",
+            TelemetryRecord::HostHealth(HostHealthRecord {
+                captured_at: chrono::Utc::now(),
+                daemon_version: "0.16.0".to_string(),
+                uptime_sec: 10,
+                logical_cpus: 8,
+                cpu_idle_fraction: None,
+                load_per_core: None,
+                worktree_root_free_gb: None,
+            }),
+        )
+    }
+
+    #[tokio::test]
+    async fn emit_batch_posts_the_batch_with_bearer_auth() {
+        let sink = MockSink::start();
+        let exporter = HttpsExporter::new(sink.url(), "s3cr3t-ingest-key".to_string()).unwrap();
+        let batch = vec![one_envelope(), one_envelope()];
+        exporter.emit_batch(&batch).await.unwrap();
+
+        let requests = sink.requests();
+        assert_eq!(requests.len(), 1, "one batch ⇒ one HTTP request");
+        assert_eq!(requests[0].auth_header.as_deref(), Some("Bearer s3cr3t-ingest-key"));
+        let decoded: Vec<TelemetryEnvelope> = serde_json::from_slice(&requests[0].body).unwrap();
+        assert_eq!(decoded.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn non_2xx_status_is_reported_as_rejected() {
+        let sink = MockSink::start();
+        sink.set_status(500);
+        let exporter = HttpsExporter::new(sink.url(), "key".to_string()).unwrap();
+        let batch = vec![one_envelope()];
+        let error = exporter.emit_batch(&batch).await.unwrap_err();
+        match error {
+            ExportError::Rejected { status, .. } => assert_eq!(status, 500),
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unreachable_sink_is_a_transport_error_never_a_panic() {
+        // Bind-then-drop to get a loopback port nothing is listening on.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let exporter =
+            HttpsExporter::new(format!("http://{addr}/ingest"), "key".to_string()).unwrap();
+        let batch = vec![one_envelope()];
+        let error = exporter.emit_batch(&batch).await.unwrap_err();
+        assert!(matches!(error, ExportError::Transport(_)));
+    }
+
+    #[tokio::test]
+    async fn export_error_display_never_includes_the_ingest_key() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let exporter = HttpsExporter::new(
+            format!("http://{addr}/ingest"),
+            "top-secret-ingest-key-value".to_string(),
+        )
+        .unwrap();
+        let batch = vec![one_envelope()];
+        let error = exporter.emit_batch(&batch).await.unwrap_err();
+        let rendered = error.to_string();
+        assert!(
+            !rendered.contains("top-secret-ingest-key-value"),
+            "ExportError::Display leaked the ingest key: {rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn kill_and_revive_round_trip_still_talks_to_the_same_exporter() {
+        // Exercises the mock sink helper itself (the drain-loop-level
+        // kill/revive integration test lives in `super::super::sender`).
+        let sink = MockSink::start();
+        let exporter = HttpsExporter::new(sink.url(), "key".to_string()).unwrap();
+        exporter.emit_batch(&[one_envelope()]).await.unwrap();
+        let (addr, requests) = sink.kill();
+        assert!(HttpsExporter::new(format!("http://{addr}/ingest"), "key".to_string())
+            .unwrap()
+            .emit_batch(&[one_envelope()])
+            .await
+            .is_err());
+        let revived = MockSink::revive(addr, requests);
+        let exporter2 = HttpsExporter::new(revived.url(), "key".to_string()).unwrap();
+        exporter2.emit_batch(&[one_envelope()]).await.unwrap();
+        assert_eq!(revived.requests().len(), 2);
+    }
+}

--- a/loom-daemon/src/observability/mod.rs
+++ b/loom-daemon/src/observability/mod.rs
@@ -258,9 +258,7 @@ pub fn spawn_task(
         );
         return None;
     };
-    let Some(ingest_key) = read_ingest_key(&key_file) else {
-        return None;
-    };
+    let ingest_key = read_ingest_key(&key_file)?;
     let exporter = match HttpsExporter::new(endpoint.clone(), ingest_key) {
         Ok(exporter) => exporter,
         Err(error) => {

--- a/loom-daemon/src/observability/mod.rs
+++ b/loom-daemon/src/observability/mod.rs
@@ -1,0 +1,495 @@
+//! Pluggable telemetry exporter + `observability` config block (Epic #4702,
+//! Phase 1 — issue #4705).
+//!
+//! Wires three additive pieces together, on top of the versioned schema
+//! [`crate::telemetry`] already defines (issue #4703):
+//!
+//! - [`collector`] — a pure [`crate::event_bus::EventBus`] subscriber (adds
+//!   no new emit call sites anywhere else in the daemon, mirroring
+//!   [`crate::safehouse`]'s design) that maps sweep-lifecycle events plus
+//!   periodic host/token samples into [`crate::telemetry::TelemetryEnvelope`]s.
+//! - [`queue`] — a bounded, disk-backed offline queue those envelopes land in,
+//!   so a sink outage (or a sleeping/idle-shut-down host, #4467/#4697) never
+//!   silently loses data up to `queueCapacity`.
+//! - [`exporter`] + [`sender`] — the [`exporter::Exporter`] trait, its
+//!   [`exporter::HttpsExporter`] JSON-over-HTTPS push implementation, and the
+//!   jittered-retry drain loop that pulls batches off the queue and pushes
+//!   them to the sink.
+//!
+//! # Off by default (FLAGS-OFF posture)
+//!
+//! Mirrors every other `autonomous.*`-style daemon subsystem
+//! (`config_resolver.rs`'s documented precedence): **env > config > default**,
+//! default `enabled = false`. [`spawn_task`] returns `None` — no
+//! subscription, no queue file, no HTTP client construction, zero syscalls —
+//! whenever the resolved config is disabled or under-configured (no endpoint,
+//! no readable ingest key file). This is the same "disabled means truly
+//! inert" contract [`crate::safehouse::spawn_sink`] and
+//! [`crate::idle_exit::spawn_task`]'s callers already rely on.
+//!
+//! # Read-only invariant
+//!
+//! This module only ever originates outbound HTTP POSTs
+//! ([`exporter::HttpsExporter::emit_batch`]); nothing here parses a response
+//! body for anything but a batch-accepted/rejected status, and no daemon
+//! state is ever mutated from data received over this channel.
+//!
+//! # Ingest key handling
+//!
+//! The ingest key is read once at startup from `ingestKeyFile` (never
+//! accepted inline in config) and held only in memory as an
+//! [`exporter::HttpsExporter`] field, sent solely as an `Authorization:
+//! Bearer` HTTP header value. Every log line and [`exporter::ExportError`]
+//! variant in this module tree names the *file path*, never the key
+//! contents.
+
+pub mod collector;
+pub mod exporter;
+pub mod queue;
+pub mod sender;
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::event_bus::EventBus;
+
+use exporter::HttpsExporter;
+use queue::DurableQueue;
+
+/// `observability.enabled` env override.
+pub const ENABLED_ENV: &str = "LOOM_OBSERVABILITY_ENABLED";
+/// `observability.endpoint` env override.
+pub const ENDPOINT_ENV: &str = "LOOM_OBSERVABILITY_ENDPOINT";
+/// `observability.ingestKeyFile` env override.
+pub const INGEST_KEY_FILE_ENV: &str = "LOOM_OBSERVABILITY_INGEST_KEY_FILE";
+/// `observability.batchSize` env override.
+pub const BATCH_SIZE_ENV: &str = "LOOM_OBSERVABILITY_BATCH_SIZE";
+/// `observability.flushIntervalSecs` env override.
+pub const FLUSH_INTERVAL_SECS_ENV: &str = "LOOM_OBSERVABILITY_FLUSH_INTERVAL_SECS";
+/// `observability.queueCapacity` env override.
+pub const QUEUE_CAPACITY_ENV: &str = "LOOM_OBSERVABILITY_QUEUE_CAPACITY";
+
+/// Default batch size (envelopes per HTTP POST) when unset at every tier.
+pub const DEFAULT_BATCH_SIZE: usize = 50;
+/// Default flush interval when unset at every tier.
+pub const DEFAULT_FLUSH_INTERVAL_SECS: u64 = 30;
+/// Default queue capacity when unset at every tier.
+pub const DEFAULT_QUEUE_CAPACITY: usize = 2000;
+/// How often the collector samples `tokens.snapshot` / `host.health` — not
+/// operator-tunable in this issue's config surface (only the six documented
+/// `observability.*` keys are), so this is a fixed, generous cadence.
+pub const SNAPSHOT_INTERVAL: Duration = Duration::from_secs(5 * 60);
+
+/// The `.loom/config.json` `observability` block, read but not yet resolved
+/// against env/defaults (see the `resolve_*` functions below, mirroring
+/// [`crate::idle_exit::IdleExitConfig`]'s split).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ObservabilityConfig {
+    pub enabled: Option<bool>,
+    pub endpoint: Option<String>,
+    pub ingest_key_file: Option<String>,
+    pub batch_size: Option<usize>,
+    pub flush_interval_secs: Option<u64>,
+    pub queue_capacity: Option<usize>,
+}
+
+/// Read the `observability` block from `root`'s resolved config
+/// (`config_resolver::resolve_effective_config`), same pattern as
+/// [`crate::idle_exit::read_config`].
+#[must_use]
+pub fn read_config(root: &Path) -> ObservabilityConfig {
+    let config = crate::config_resolver::resolve_effective_config(root);
+    let Some(block) = crate::config_resolver::get_path(&config, "observability") else {
+        return ObservabilityConfig::default();
+    };
+    ObservabilityConfig {
+        enabled: block.get("enabled").and_then(serde_json::Value::as_bool),
+        endpoint: block
+            .get("endpoint")
+            .and_then(serde_json::Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string),
+        ingest_key_file: block
+            .get("ingestKeyFile")
+            .and_then(serde_json::Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string),
+        batch_size: block
+            .get("batchSize")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|v| usize::try_from(v).ok())
+            .filter(|v| *v > 0),
+        flush_interval_secs: block
+            .get("flushIntervalSecs")
+            .and_then(serde_json::Value::as_u64)
+            .filter(|v| *v > 0),
+        queue_capacity: block
+            .get("queueCapacity")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|v| usize::try_from(v).ok())
+            .filter(|v| *v > 0),
+    }
+}
+
+fn env_bool(name: &str) -> Option<bool> {
+    std::env::var(name).ok().map(|value| {
+        matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on")
+    })
+}
+
+fn env_nonempty(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// **env > config > default** (`false`).
+#[must_use]
+pub fn resolve_enabled(config: &ObservabilityConfig) -> bool {
+    env_bool(ENABLED_ENV).or(config.enabled).unwrap_or(false)
+}
+
+/// **env > config**, no built-in default — a missing endpoint means "not
+/// configured", handled by [`spawn_task`] as a degrade-to-disabled case.
+#[must_use]
+pub fn resolve_endpoint(config: &ObservabilityConfig) -> Option<String> {
+    env_nonempty(ENDPOINT_ENV).or_else(|| config.endpoint.clone())
+}
+
+/// **env > config**, no built-in default — same "not configured" handling as
+/// [`resolve_endpoint`].
+#[must_use]
+pub fn resolve_ingest_key_file(config: &ObservabilityConfig) -> Option<String> {
+    env_nonempty(INGEST_KEY_FILE_ENV).or_else(|| config.ingest_key_file.clone())
+}
+
+/// **env > config > default** ([`DEFAULT_BATCH_SIZE`]).
+#[must_use]
+pub fn resolve_batch_size(config: &ObservabilityConfig) -> usize {
+    std::env::var(BATCH_SIZE_ENV)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|v: &usize| *v > 0)
+        .or(config.batch_size)
+        .unwrap_or(DEFAULT_BATCH_SIZE)
+}
+
+/// **env > config > default** ([`DEFAULT_FLUSH_INTERVAL_SECS`]).
+#[must_use]
+pub fn resolve_flush_interval_secs(config: &ObservabilityConfig) -> u64 {
+    std::env::var(FLUSH_INTERVAL_SECS_ENV)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|v: &u64| *v > 0)
+        .or(config.flush_interval_secs)
+        .unwrap_or(DEFAULT_FLUSH_INTERVAL_SECS)
+}
+
+/// **env > config > default** ([`DEFAULT_QUEUE_CAPACITY`]).
+#[must_use]
+pub fn resolve_queue_capacity(config: &ObservabilityConfig) -> usize {
+    std::env::var(QUEUE_CAPACITY_ENV)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|v: &usize| *v > 0)
+        .or(config.queue_capacity)
+        .unwrap_or(DEFAULT_QUEUE_CAPACITY)
+}
+
+/// Read `path` and return its trimmed contents as the ingest key. Every
+/// failure (missing file, unreadable, empty after trimming) is logged
+/// **by path only** — the key itself never reaches a log line — and yields
+/// `None`, which [`spawn_task`] treats as "not configured".
+fn read_ingest_key(path: &str) -> Option<String> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => {
+            let key = contents.trim().to_string();
+            if key.is_empty() {
+                log::warn!("observability: ingest key file {path} is empty — export disabled");
+                None
+            } else {
+                Some(key)
+            }
+        }
+        Err(error) => {
+            log::warn!(
+                "observability: could not read ingest key file {path}: {error} — export disabled"
+            );
+            None
+        }
+    }
+}
+
+/// Spawn the observability subsystem's background tasks (the collector and
+/// the sender — see the module docs) on the shared daemon runtime, or return
+/// `None` without any side effect when disabled or under-configured.
+///
+/// `daemon_started_at` feeds `host.health.uptime_sec`; passing
+/// `Instant::now()` at daemon startup (as [`crate::main`] does for the
+/// sibling `idle_exit`/`auto_update` wiring) makes it track true daemon
+/// uptime. If this task is spawned some time after the daemon's own start
+/// (e.g. after a slow credential-preflight step), `uptime_sec` under-reports
+/// by that startup delay — an accepted approximation for Phase 1 host-health
+/// telemetry, not a correctness requirement of the exporter itself.
+#[must_use]
+pub fn spawn_task(
+    config: &ObservabilityConfig,
+    workspace_root: PathBuf,
+    bus: &EventBus,
+    daemon_started_at: Instant,
+) -> Option<Vec<tokio::task::JoinHandle<()>>> {
+    if !resolve_enabled(config) {
+        log::debug!("observability: disabled (set observability.enabled=true to opt in)");
+        return None;
+    }
+    let Some(endpoint) = resolve_endpoint(config) else {
+        log::warn!(
+            "observability: enabled but no endpoint configured \
+             (set observability.endpoint or $LOOM_OBSERVABILITY_ENDPOINT) — export off"
+        );
+        return None;
+    };
+    let Some(key_file) = resolve_ingest_key_file(config) else {
+        log::warn!(
+            "observability: enabled but no ingestKeyFile configured \
+             (set observability.ingestKeyFile or $LOOM_OBSERVABILITY_INGEST_KEY_FILE) — export off"
+        );
+        return None;
+    };
+    let Some(ingest_key) = read_ingest_key(&key_file) else {
+        return None;
+    };
+    let exporter = match HttpsExporter::new(endpoint.clone(), ingest_key) {
+        Ok(exporter) => exporter,
+        Err(error) => {
+            log::warn!("observability: failed to construct HTTPS exporter for {endpoint}: {error} — export off");
+            return None;
+        }
+    };
+
+    let batch_size = resolve_batch_size(config);
+    let flush_interval = Duration::from_secs(resolve_flush_interval_secs(config));
+    let capacity = resolve_queue_capacity(config);
+    let queue_path = queue::default_queue_path(&workspace_root);
+    log::info!(
+        "observability: enabled (endpoint={endpoint}, batch_size={batch_size}, \
+         flush_interval={}s, queue_capacity={capacity})",
+        flush_interval.as_secs()
+    );
+    let queue = Arc::new(DurableQueue::open(queue_path, capacity));
+    let host_id = crate::sweep_registry::host_identity();
+
+    let collector_handle = collector::spawn_task(
+        bus,
+        queue.clone(),
+        workspace_root,
+        host_id,
+        SNAPSHOT_INTERVAL,
+        daemon_started_at,
+    );
+    let sender_handle = sender::spawn_task(queue, exporter, batch_size, flush_interval);
+    Some(vec![collector_handle, sender_handle])
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use tempfile::tempdir;
+
+    const ALL_ENV_VARS: &[&str] = &[
+        ENABLED_ENV,
+        ENDPOINT_ENV,
+        INGEST_KEY_FILE_ENV,
+        BATCH_SIZE_ENV,
+        FLUSH_INTERVAL_SECS_ENV,
+        QUEUE_CAPACITY_ENV,
+    ];
+
+    fn clear_env() {
+        for var in ALL_ENV_VARS {
+            std::env::remove_var(var);
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn absent_config_resolves_to_documented_defaults() {
+        // #[serial] + an explicit clear (matching every other test in this
+        // module that reads these env vars): without it, this test races
+        // `env_overrides_config` / `config_wins_over_default_when_no_env_set`
+        // on the same process-global env vars and intermittently observes a
+        // leaked `LOOM_OBSERVABILITY_*` value from a concurrently-running
+        // test (#4705 flake, caught in review).
+        clear_env();
+        let config = ObservabilityConfig::default();
+        assert!(!resolve_enabled(&config), "off by default (FLAGS-OFF posture)");
+        assert_eq!(resolve_endpoint(&config), None);
+        assert_eq!(resolve_ingest_key_file(&config), None);
+        assert_eq!(resolve_batch_size(&config), DEFAULT_BATCH_SIZE);
+        assert_eq!(resolve_flush_interval_secs(&config), DEFAULT_FLUSH_INTERVAL_SECS);
+        assert_eq!(resolve_queue_capacity(&config), DEFAULT_QUEUE_CAPACITY);
+    }
+
+    #[test]
+    #[serial]
+    fn env_overrides_config() {
+        clear_env();
+        let config = ObservabilityConfig {
+            enabled: Some(false),
+            endpoint: Some("https://config.example.com/ingest".to_string()),
+            batch_size: Some(10),
+            ..Default::default()
+        };
+        std::env::set_var(ENABLED_ENV, "true");
+        std::env::set_var(ENDPOINT_ENV, "https://env.example.com/ingest");
+        std::env::set_var(BATCH_SIZE_ENV, "99");
+        assert!(resolve_enabled(&config));
+        assert_eq!(resolve_endpoint(&config).as_deref(), Some("https://env.example.com/ingest"));
+        assert_eq!(resolve_batch_size(&config), 99);
+        clear_env();
+    }
+
+    #[test]
+    #[serial]
+    fn config_wins_over_default_when_no_env_set() {
+        clear_env();
+        let config = ObservabilityConfig {
+            enabled: Some(true),
+            flush_interval_secs: Some(120),
+            queue_capacity: Some(500),
+            ..Default::default()
+        };
+        assert!(resolve_enabled(&config));
+        assert_eq!(resolve_flush_interval_secs(&config), 120);
+        assert_eq!(resolve_queue_capacity(&config), 500);
+    }
+
+    #[test]
+    fn read_config_parses_every_field_from_the_observability_block() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".loom")).unwrap();
+        std::fs::write(
+            dir.path().join(".loom/config.json"),
+            r#"{"observability": {
+                "enabled": true,
+                "endpoint": "https://ingest.example.com/v1/telemetry",
+                "ingestKeyFile": "/etc/loom/ingest.key",
+                "batchSize": 25,
+                "flushIntervalSecs": 45,
+                "queueCapacity": 1000
+            }}"#,
+        )
+        .unwrap();
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let config = read_config(dir.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(config.enabled, Some(true));
+        assert_eq!(config.endpoint.as_deref(), Some("https://ingest.example.com/v1/telemetry"));
+        assert_eq!(config.ingest_key_file.as_deref(), Some("/etc/loom/ingest.key"));
+        assert_eq!(config.batch_size, Some(25));
+        assert_eq!(config.flush_interval_secs, Some(45));
+        assert_eq!(config.queue_capacity, Some(1000));
+    }
+
+    #[test]
+    fn missing_observability_block_is_the_documented_default() {
+        let dir = tempdir().unwrap();
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let config = read_config(dir.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(config, ObservabilityConfig::default());
+    }
+
+    // ------------------------------------------------------------------
+    // spawn_task degrade-to-disabled paths — every one must return `None`
+    // with zero side effects (no queue file created).
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn spawn_task_disabled_returns_none() {
+        clear_env();
+        let bus = EventBus::new();
+        let dir = tempdir().unwrap();
+        let config = ObservabilityConfig::default();
+        let handles = spawn_task(&config, dir.path().to_path_buf(), &bus, Instant::now());
+        assert!(handles.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn spawn_task_enabled_without_endpoint_returns_none() {
+        clear_env();
+        let bus = EventBus::new();
+        let dir = tempdir().unwrap();
+        let config = ObservabilityConfig {
+            enabled: Some(true),
+            ..Default::default()
+        };
+        let handles = spawn_task(&config, dir.path().to_path_buf(), &bus, Instant::now());
+        assert!(handles.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn spawn_task_enabled_without_ingest_key_file_returns_none() {
+        clear_env();
+        let bus = EventBus::new();
+        let dir = tempdir().unwrap();
+        let config = ObservabilityConfig {
+            enabled: Some(true),
+            endpoint: Some("https://ingest.example.com/v1/telemetry".to_string()),
+            ..Default::default()
+        };
+        let handles = spawn_task(&config, dir.path().to_path_buf(), &bus, Instant::now());
+        assert!(handles.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn spawn_task_enabled_with_unreadable_ingest_key_file_returns_none() {
+        clear_env();
+        let bus = EventBus::new();
+        let dir = tempdir().unwrap();
+        let config = ObservabilityConfig {
+            enabled: Some(true),
+            endpoint: Some("https://ingest.example.com/v1/telemetry".to_string()),
+            ingest_key_file: Some(
+                dir.path()
+                    .join("does-not-exist.key")
+                    .to_string_lossy()
+                    .to_string(),
+            ),
+            ..Default::default()
+        };
+        let handles = spawn_task(&config, dir.path().to_path_buf(), &bus, Instant::now());
+        assert!(handles.is_none());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn spawn_task_fully_configured_spawns_two_tasks() {
+        clear_env();
+        let bus = EventBus::new();
+        let dir = tempdir().unwrap();
+        let key_path = dir.path().join("ingest.key");
+        std::fs::write(&key_path, "s3cr3t\n").unwrap();
+        let config = ObservabilityConfig {
+            enabled: Some(true),
+            endpoint: Some("https://ingest.example.com/v1/telemetry".to_string()),
+            ingest_key_file: Some(key_path.to_string_lossy().to_string()),
+            flush_interval_secs: Some(3600), // avoid a real network attempt during the test
+            ..Default::default()
+        };
+        let handles = spawn_task(&config, dir.path().to_path_buf(), &bus, Instant::now());
+        let handles = handles.expect("fully configured ⇒ spawn_task must return Some");
+        assert_eq!(handles.len(), 2, "collector + sender");
+        for handle in handles {
+            handle.abort();
+        }
+    }
+}

--- a/loom-daemon/src/observability/queue.rs
+++ b/loom-daemon/src/observability/queue.rs
@@ -1,0 +1,351 @@
+//! Durable, bounded, disk-backed offline queue for [`TelemetryEnvelope`]
+//! records (Epic #4702, Phase 1 — issue #4705).
+//!
+//! Fleet hosts sleep and idle-shutdown (#4467/#4697), so an in-memory-only
+//! queue would silently lose every unsent record across a host's downtime
+//! window. This queue instead mirrors its in-memory state to a single JSONL
+//! file (`<workspace>/.loom/logs/observability-queue.jsonl`, override via
+//! [`QUEUE_PATH_ENV`]) on every mutation, using the same create-temp +
+//! atomic-rename write pattern [`crate::idle_exit::write_marker`] and
+//! [`crate::sweep_outcomes::append_outcome`] already use elsewhere in this
+//! crate. [`DurableQueue::open`] replays that file at startup, so a record
+//! enqueued just before a clean daemon exit (the idle-exit path never kills
+//! `-9`) is still there to drain on the next boot.
+//!
+//! **Bounded, drop-oldest.** [`DurableQueue::push`] never grows the queue
+//! past `capacity`: once full, the oldest queued envelope is discarded and
+//! [`DurableQueue::dropped_total`] increments — logged once per drop, never a
+//! silent loss and never unbounded growth (per the issue's AC).
+//!
+//! **Peek-then-ack, not pop.** The sender ([`super::sender`]) reads a batch
+//! via [`DurableQueue::peek_batch`] without removing it, attempts the export,
+//! and only calls [`DurableQueue::ack`] on success — a failed export leaves
+//! the batch queued for the next retry rather than losing it.
+//!
+//! This whole-file rewrite on every mutation is `O(queue length)` per push/ack,
+//! not an append-only journal — deliberately simple for Phase 1's expected
+//! queue sizes (hundreds to a few thousand envelopes, per
+//! `queueCapacity`'s default). A future phase can switch to an append+compact
+//! journal (mirroring [`crate::sweep_outcomes`]'s rotation) if profiling ever
+//! shows this matters.
+
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use crate::telemetry::TelemetryEnvelope;
+
+/// Env var overriding the queue file path (test seam), mirroring
+/// [`crate::sweep_outcomes::OUTCOMES_JOURNAL_PATH_ENV`].
+pub const QUEUE_PATH_ENV: &str = "LOOM_OBSERVABILITY_QUEUE_PATH";
+
+/// Default filename under `<workspace_root>/.loom/logs/`.
+pub const QUEUE_FILENAME: &str = "observability-queue.jsonl";
+
+/// Resolve the default queue path: [`QUEUE_PATH_ENV`] override (non-empty),
+/// else `<workspace_root>/.loom/logs/observability-queue.jsonl`.
+#[must_use]
+pub fn default_queue_path(workspace_root: &Path) -> PathBuf {
+    if let Ok(path) = std::env::var(QUEUE_PATH_ENV) {
+        if !path.is_empty() {
+            return PathBuf::from(path);
+        }
+    }
+    workspace_root
+        .join(".loom")
+        .join("logs")
+        .join(QUEUE_FILENAME)
+}
+
+struct QueueState {
+    items: VecDeque<TelemetryEnvelope>,
+    dropped_total: u64,
+}
+
+/// A bounded, disk-backed FIFO queue of [`TelemetryEnvelope`]s.
+pub struct DurableQueue {
+    path: PathBuf,
+    capacity: usize,
+    state: Mutex<QueueState>,
+}
+
+impl DurableQueue {
+    /// Open (or create) the queue at `path`, replaying any envelopes left
+    /// over from a prior process (best-effort — a missing, unreadable, or
+    /// partially-corrupt file degrades to an empty queue rather than
+    /// erroring; a corrupt individual line is skipped, matching
+    /// [`crate::sweep_outcomes::read_all`]'s soft-fail contract). `capacity`
+    /// is clamped to at least 1.
+    #[must_use]
+    pub fn open(path: PathBuf, capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        let mut items = load_existing(&path);
+        // A capacity that shrank since the file was last written (e.g. a
+        // config edit between restarts) must not resurrect more than the
+        // new bound allows.
+        while items.len() > capacity {
+            items.pop_front();
+        }
+        DurableQueue {
+            path,
+            capacity,
+            state: Mutex::new(QueueState {
+                items,
+                dropped_total: 0,
+            }),
+        }
+    }
+
+    /// Enqueue `envelope`, dropping the oldest queued envelope first if the
+    /// queue is already at `capacity`. Persists the new state to disk
+    /// best-effort — a write failure is logged and swallowed (matches
+    /// [`crate::sweep_outcomes::append_outcome`]'s "never block the caller on
+    /// a journal-write failure" contract) so a full/unwritable disk degrades
+    /// this queue to in-memory-only rather than crashing the collector.
+    pub fn push(&self, envelope: TelemetryEnvelope) {
+        let mut state = self.lock();
+        if state.items.len() >= self.capacity {
+            state.items.pop_front();
+            state.dropped_total += 1;
+            log::warn!(
+                "observability: queue at capacity ({}); dropped oldest record \
+                 (dropped_total={})",
+                self.capacity,
+                state.dropped_total
+            );
+        }
+        state.items.push_back(envelope);
+        self.persist(&state.items);
+    }
+
+    /// Current queue length.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.lock().items.len()
+    }
+
+    /// True when the queue holds no envelopes.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Total envelopes dropped (oldest-first) over this queue's lifetime for
+    /// having arrived while already at capacity.
+    #[must_use]
+    pub fn dropped_total(&self) -> u64 {
+        self.lock().dropped_total
+    }
+
+    /// Clone up to `n` envelopes from the front of the queue **without**
+    /// removing them — the sender only removes a batch after a confirmed
+    /// successful export, via [`Self::ack`].
+    #[must_use]
+    pub fn peek_batch(&self, n: usize) -> Vec<TelemetryEnvelope> {
+        self.lock().items.iter().take(n).cloned().collect()
+    }
+
+    /// Remove the front `n` envelopes (clamped to the current length) after a
+    /// successful export, persisting the drained state to disk.
+    pub fn ack(&self, n: usize) {
+        let mut state = self.lock();
+        let n = n.min(state.items.len());
+        state.items.drain(0..n);
+        self.persist(&state.items);
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, QueueState> {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn persist(&self, items: &VecDeque<TelemetryEnvelope>) {
+        if let Err(error) = persist_to(&self.path, items) {
+            log::warn!(
+                "observability: failed to persist queue to {}: {error}",
+                self.path.display()
+            );
+        }
+    }
+}
+
+fn load_existing(path: &Path) -> VecDeque<TelemetryEnvelope> {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return VecDeque::new();
+    };
+    contents
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect()
+}
+
+/// Atomically rewrite `path` to contain exactly `items`, one JSON object per
+/// line — a temp-file-then-rename, mirroring
+/// [`crate::idle_exit::write_marker`].
+fn persist_to(path: &Path, items: &VecDeque<TelemetryEnvelope>) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let temporary = path.with_extension(format!("jsonl.tmp-{}", std::process::id()));
+    let mut buffer = String::new();
+    for item in items {
+        if let Ok(line) = serde_json::to_string(item) {
+            buffer.push_str(&line);
+            buffer.push('\n');
+        }
+    }
+    std::fs::write(&temporary, buffer)?;
+    std::fs::rename(temporary, path)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::telemetry::{RepoVisibility, SweepStartedRecord, TelemetryRecord};
+    use serial_test::serial;
+    use tempfile::tempdir;
+
+    fn envelope(issue: u32) -> TelemetryEnvelope {
+        TelemetryEnvelope::new(
+            "host-test",
+            TelemetryRecord::SweepStarted(SweepStartedRecord {
+                repo: "rjwalters/loom".to_string(),
+                visibility: RepoVisibility::Public,
+                issue,
+                sweep_id: format!("sweep-issue-{issue}-0"),
+                started_at: chrono::Utc::now(),
+                model: None,
+                effort: None,
+            }),
+        )
+    }
+
+    #[test]
+    fn push_and_peek_round_trips_in_order() {
+        let dir = tempdir().unwrap();
+        let queue = DurableQueue::open(dir.path().join("q.jsonl"), 10);
+        queue.push(envelope(1));
+        queue.push(envelope(2));
+        queue.push(envelope(3));
+        assert_eq!(queue.len(), 3);
+        let batch = queue.peek_batch(2);
+        assert_eq!(batch.len(), 2);
+        match &batch[0].record {
+            TelemetryRecord::SweepStarted(r) => assert_eq!(r.issue, 1),
+            other => panic!("unexpected record {other:?}"),
+        }
+        // peek does not remove.
+        assert_eq!(queue.len(), 3);
+    }
+
+    #[test]
+    fn ack_removes_only_the_front_n() {
+        let dir = tempdir().unwrap();
+        let queue = DurableQueue::open(dir.path().join("q.jsonl"), 10);
+        for i in 1..=3 {
+            queue.push(envelope(i));
+        }
+        queue.ack(2);
+        assert_eq!(queue.len(), 1);
+        let remaining = queue.peek_batch(10);
+        match &remaining[0].record {
+            TelemetryRecord::SweepStarted(r) => assert_eq!(r.issue, 3),
+            other => panic!("unexpected record {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ack_clamps_to_queue_length() {
+        let dir = tempdir().unwrap();
+        let queue = DurableQueue::open(dir.path().join("q.jsonl"), 10);
+        queue.push(envelope(1));
+        queue.ack(100); // must not panic
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn bounded_capacity_drops_oldest_and_counts_it() {
+        let dir = tempdir().unwrap();
+        let queue = DurableQueue::open(dir.path().join("q.jsonl"), 2);
+        queue.push(envelope(1));
+        queue.push(envelope(2));
+        queue.push(envelope(3)); // over capacity: drops issue 1
+        assert_eq!(queue.len(), 2);
+        assert_eq!(queue.dropped_total(), 1);
+        let batch = queue.peek_batch(10);
+        match &batch[0].record {
+            TelemetryRecord::SweepStarted(r) => assert_eq!(r.issue, 2),
+            other => panic!("unexpected record {other:?}"),
+        }
+        queue.push(envelope(4));
+        queue.push(envelope(5));
+        assert_eq!(queue.dropped_total(), 3, "never grows unbounded — every overflow is counted");
+        assert_eq!(queue.len(), 2);
+    }
+
+    #[test]
+    fn survives_reopen_across_a_simulated_restart() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("q.jsonl");
+        {
+            let queue = DurableQueue::open(path.clone(), 10);
+            queue.push(envelope(1));
+            queue.push(envelope(2));
+        }
+        // Fresh queue instance over the same path — simulates a daemon
+        // restart across host sleep/idle-shutdown (#4467/#4697).
+        let reopened = DurableQueue::open(path, 10);
+        assert_eq!(reopened.len(), 2);
+        let batch = reopened.peek_batch(10);
+        match &batch[0].record {
+            TelemetryRecord::SweepStarted(r) => assert_eq!(r.issue, 1),
+            other => panic!("unexpected record {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_file_opens_as_an_empty_queue() {
+        let dir = tempdir().unwrap();
+        let queue = DurableQueue::open(dir.path().join("does-not-exist.jsonl"), 10);
+        assert!(queue.is_empty());
+        assert_eq!(queue.dropped_total(), 0);
+    }
+
+    #[test]
+    fn shrunk_capacity_on_reopen_drops_from_the_front() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("q.jsonl");
+        {
+            let queue = DurableQueue::open(path.clone(), 10);
+            for i in 1..=5 {
+                queue.push(envelope(i));
+            }
+        }
+        let reopened = DurableQueue::open(path, 2);
+        assert_eq!(reopened.len(), 2);
+        let batch = reopened.peek_batch(10);
+        match &batch[0].record {
+            TelemetryRecord::SweepStarted(r) => assert_eq!(r.issue, 4),
+            other => panic!("unexpected record {other:?}"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn default_queue_path_env_override_wins() {
+        std::env::set_var(QUEUE_PATH_ENV, "/tmp/custom-observability-queue.jsonl");
+        let path = default_queue_path(Path::new("/repos/loom"));
+        std::env::remove_var(QUEUE_PATH_ENV);
+        assert_eq!(path, PathBuf::from("/tmp/custom-observability-queue.jsonl"));
+    }
+
+    #[test]
+    #[serial]
+    fn default_queue_path_falls_back_to_workspace_logs_dir() {
+        std::env::remove_var(QUEUE_PATH_ENV);
+        let path = default_queue_path(Path::new("/repos/loom"));
+        assert_eq!(path, PathBuf::from("/repos/loom/.loom/logs/observability-queue.jsonl"));
+    }
+}

--- a/loom-daemon/src/observability/sender.rs
+++ b/loom-daemon/src/observability/sender.rs
@@ -1,0 +1,292 @@
+//! Queue-drain sender loop with jittered retry/backoff (Epic #4702, Phase 1
+//! — issue #4705).
+//!
+//! Generic over `E: `[`Exporter`] so a future OTLP exporter (epic Phase 4)
+//! plugs into this same loop unchanged. Every `flush_interval` (jittered) the
+//! loop drains as many full batches as are currently queued; a failed export
+//! backs off exponentially (also jittered) before the next attempt, capped at
+//! [`MAX_BACKOFF`], and resets to [`MIN_BACKOFF`] on the next success. Jitter
+//! uses [`crate::tokens_pool::rng::Rng`] — this crate's existing dependency-
+//! free PRNG (`tokens_pool::rng`'s doc: "none [external `rand` crate] exists
+//! anywhere in this workspace's `Cargo.toml` today") rather than adding a
+//! `rand` dependency.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::tokens_pool::rng::Rng;
+
+use super::exporter::Exporter;
+use super::queue::DurableQueue;
+
+/// Starting backoff after a failed export attempt.
+pub const MIN_BACKOFF: Duration = Duration::from_secs(5);
+/// Backoff ceiling — an unreachable sink never waits longer than this
+/// between retries.
+pub const MAX_BACKOFF: Duration = Duration::from_secs(5 * 60);
+
+/// Outcome of one [`try_flush`] attempt, for the caller's retry/backoff
+/// decision.
+#[derive(Debug, PartialEq, Eq)]
+pub enum FlushOutcome {
+    /// The queue was empty — nothing to send.
+    Empty,
+    /// A batch of this many envelopes was exported and acked.
+    Sent(usize),
+    /// The export attempt failed; the batch remains queued for retry.
+    Failed,
+}
+
+/// Attempt to send one batch (up to `batch_size` envelopes, peeked from the
+/// front of `queue`) via `exporter`. Only acks (removes) the batch from
+/// `queue` on a confirmed successful export — a failure leaves the queue
+/// untouched so the same envelopes are retried next time.
+pub async fn try_flush<E: Exporter>(
+    queue: &DurableQueue,
+    exporter: &E,
+    batch_size: usize,
+) -> FlushOutcome {
+    let batch = queue.peek_batch(batch_size);
+    if batch.is_empty() {
+        return FlushOutcome::Empty;
+    }
+    match exporter.emit_batch(&batch).await {
+        Ok(()) => {
+            let sent = batch.len();
+            queue.ack(sent);
+            FlushOutcome::Sent(sent)
+        }
+        Err(error) => {
+            log::warn!(
+                "observability: export failed, {} record(s) remain queued \
+                 (dropped_total={}): {error}",
+                queue.len(),
+                queue.dropped_total()
+            );
+            FlushOutcome::Failed
+        }
+    }
+}
+
+/// Spawn the sender loop on the shared daemon runtime.
+pub fn spawn_task<E>(
+    queue: Arc<DurableQueue>,
+    exporter: E,
+    batch_size: usize,
+    flush_interval: Duration,
+) -> tokio::task::JoinHandle<()>
+where
+    E: Exporter + Send + Sync + 'static,
+{
+    tokio::spawn(run_sender(queue, exporter, batch_size, flush_interval))
+}
+
+async fn run_sender<E: Exporter>(
+    queue: Arc<DurableQueue>,
+    exporter: E,
+    batch_size: usize,
+    flush_interval: Duration,
+) {
+    let mut rng = Rng::from_entropy();
+    let mut backoff = MIN_BACKOFF;
+    loop {
+        tokio::time::sleep(jittered(flush_interval, &mut rng)).await;
+        // Drain every currently-queued batch before sleeping again, so a
+        // burst that arrived between ticks does not wait a full extra
+        // `flush_interval` per batch.
+        loop {
+            match try_flush(&queue, &exporter, batch_size).await {
+                FlushOutcome::Empty => {
+                    backoff = MIN_BACKOFF;
+                    break;
+                }
+                FlushOutcome::Sent(_) => {
+                    backoff = MIN_BACKOFF;
+                    // Loop again immediately — more may still be queued.
+                }
+                FlushOutcome::Failed => {
+                    tokio::time::sleep(jittered(backoff, &mut rng)).await;
+                    backoff = backoff.saturating_mul(2).min(MAX_BACKOFF);
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Apply +/-20% jitter to `base`, floored at zero. A `base` of zero (or
+/// small enough that the jitter window rounds to zero) returns `base`
+/// unchanged rather than dividing by zero.
+fn jittered(base: Duration, rng: &mut Rng) -> Duration {
+    let base_ms = u64::try_from(base.as_millis()).unwrap_or(u64::MAX);
+    let window_ms = base_ms / 5; // 20%
+    if window_ms == 0 {
+        return base;
+    }
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    let offset_ms = rng.gen_range((window_ms * 2 + 1) as usize) as i64 - window_ms as i64;
+    let jittered_ms = (i64::try_from(base_ms).unwrap_or(i64::MAX) + offset_ms).max(0);
+    Duration::from_millis(u64::try_from(jittered_ms).unwrap_or(0))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::observability::exporter::ExportError;
+    use crate::telemetry::{HostHealthRecord, TelemetryEnvelope, TelemetryRecord};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    fn envelope() -> TelemetryEnvelope {
+        TelemetryEnvelope::new(
+            "host-test",
+            TelemetryRecord::HostHealth(HostHealthRecord {
+                captured_at: chrono::Utc::now(),
+                daemon_version: "0.16.0".to_string(),
+                uptime_sec: 1,
+                logical_cpus: 4,
+                cpu_idle_fraction: None,
+                load_per_core: None,
+                worktree_root_free_gb: None,
+            }),
+        )
+    }
+
+    /// A toggleable in-memory exporter: [`FakeExporter::set_up`] flips
+    /// between "sink reachable" and "sink down" without any real network I/O
+    /// — this is the sender-loop-level analogue of `exporter::tests::
+    /// MockSink`'s kill/revive, exercised at the [`try_flush`] granularity.
+    struct FakeExporter {
+        up: AtomicBool,
+        received: Mutex<Vec<crate::telemetry::TelemetryEnvelope>>,
+        call_count: AtomicUsize,
+    }
+
+    impl FakeExporter {
+        fn new(up: bool) -> Self {
+            FakeExporter {
+                up: AtomicBool::new(up),
+                received: Mutex::new(Vec::new()),
+                call_count: AtomicUsize::new(0),
+            }
+        }
+
+        fn set_up(&self, up: bool) {
+            self.up.store(up, Ordering::SeqCst);
+        }
+    }
+
+    impl Exporter for FakeExporter {
+        async fn emit_batch(&self, envelopes: &[TelemetryEnvelope]) -> Result<(), ExportError> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            if !self.up.load(Ordering::SeqCst) {
+                return Err(ExportError::Transport("sink down".to_string()));
+            }
+            self.received.lock().unwrap().extend_from_slice(envelopes);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn try_flush_on_empty_queue_is_a_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let queue = DurableQueue::open(dir.path().join("q.jsonl"), 10);
+        let exporter = FakeExporter::new(true);
+        let outcome = try_flush(&queue, &exporter, 10).await;
+        assert_eq!(outcome, FlushOutcome::Empty);
+    }
+
+    #[tokio::test]
+    async fn try_flush_sends_and_acks_on_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let queue = DurableQueue::open(dir.path().join("q.jsonl"), 10);
+        queue.push(envelope());
+        queue.push(envelope());
+        let exporter = FakeExporter::new(true);
+        let outcome = try_flush(&queue, &exporter, 10).await;
+        assert_eq!(outcome, FlushOutcome::Sent(2));
+        assert!(queue.is_empty());
+        assert_eq!(exporter.received.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn try_flush_leaves_the_queue_intact_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let queue = DurableQueue::open(dir.path().join("q.jsonl"), 10);
+        queue.push(envelope());
+        let exporter = FakeExporter::new(false);
+        let outcome = try_flush(&queue, &exporter, 10).await;
+        assert_eq!(outcome, FlushOutcome::Failed);
+        assert_eq!(queue.len(), 1, "a failed export must not lose the batch");
+    }
+
+    #[tokio::test]
+    async fn kill_and_revive_drains_once_the_sink_is_reachable_again() {
+        // The AC's "verified by a test that kills and revives the mock sink"
+        // requirement, at the sender's own granularity.
+        let dir = tempfile::tempdir().unwrap();
+        let queue = DurableQueue::open(dir.path().join("q.jsonl"), 10);
+        queue.push(envelope());
+        queue.push(envelope());
+        queue.push(envelope());
+        let exporter = FakeExporter::new(false); // sink starts "killed"
+
+        assert_eq!(try_flush(&queue, &exporter, 10).await, FlushOutcome::Failed);
+        assert_eq!(queue.len(), 3, "still queued while the sink is down");
+
+        exporter.set_up(true); // "revive" the sink
+        assert_eq!(try_flush(&queue, &exporter, 10).await, FlushOutcome::Sent(3));
+        assert!(queue.is_empty());
+        assert_eq!(exporter.received.lock().unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn respects_batch_size_across_repeated_flushes() {
+        let dir = tempfile::tempdir().unwrap();
+        let queue = DurableQueue::open(dir.path().join("q.jsonl"), 10);
+        for _ in 0..5 {
+            queue.push(envelope());
+        }
+        let exporter = FakeExporter::new(true);
+        assert_eq!(try_flush(&queue, &exporter, 2).await, FlushOutcome::Sent(2));
+        assert_eq!(queue.len(), 3);
+        assert_eq!(try_flush(&queue, &exporter, 2).await, FlushOutcome::Sent(2));
+        assert_eq!(queue.len(), 1);
+        assert_eq!(try_flush(&queue, &exporter, 2).await, FlushOutcome::Sent(1));
+        assert!(queue.is_empty());
+    }
+
+    // ------------------------------------------------------------------
+    // jitter
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn jitter_stays_within_twenty_percent_of_base() {
+        let mut rng = Rng::seeded(11);
+        let base = Duration::from_secs(30);
+        for _ in 0..50 {
+            let jittered_value = jittered(base, &mut rng);
+            let low = Duration::from_millis((base.as_millis() as u64) * 4 / 5);
+            let high = Duration::from_millis((base.as_millis() as u64) * 6 / 5);
+            assert!(
+                jittered_value >= low && jittered_value <= high,
+                "{jittered_value:?} out of [{low:?}, {high:?}] for base {base:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn jitter_of_zero_base_is_zero() {
+        let mut rng = Rng::seeded(1);
+        assert_eq!(jittered(Duration::ZERO, &mut rng), Duration::ZERO);
+    }
+
+    #[test]
+    fn jitter_is_deterministic_for_a_seeded_rng() {
+        let mut a = Rng::seeded(99);
+        let mut b = Rng::seeded(99);
+        let base = Duration::from_secs(10);
+        assert_eq!(jittered(base, &mut a), jittered(base, &mut b));
+    }
+}


### PR DESCRIPTION
## Summary

Adds the daemon-side telemetry exporter for Epic #4702 Phase 1: a pluggable
`Exporter` trait with a native JSON-over-HTTPS implementation, a bounded
disk-backed offline queue, a jittered-retry sender drain loop, and an
`EventBus`-subscribing collector — all wired behind a new `observability`
config block that's off by default.

## Changes

- **`loom-daemon/src/observability/mod.rs`** — `ObservabilityConfig` +
  `read_config`/`resolve_*` helpers (env `LOOM_OBSERVABILITY_*` > config
  `observability.*` > default), `spawn_task` that degrades to a `None`
  no-op (zero syscalls) when disabled or under-configured.
- **`loom-daemon/src/observability/exporter.rs`** — `Exporter` trait
  (native `async fn` in trait, no `async-trait`/OTel dependency) +
  `HttpsExporter` (`reqwest`, JSON array POST, `Authorization: Bearer`).
- **`loom-daemon/src/observability/queue.rs`** — `DurableQueue`: bounded,
  disk-backed (JSONL, atomic temp-file+rename), drop-oldest with a
  `dropped_total` counter, peek-then-ack semantics so a failed export
  never loses a batch.
- **`loom-daemon/src/observability/sender.rs`** — queue-drain loop with
  jittered flush interval + jittered exponential backoff (5s floor, 5m
  ceiling) on failure, using the crate's existing dependency-free
  `tokens_pool::rng::Rng` (no new `rand` dependency).
- **`loom-daemon/src/observability/collector.rs`** — pure `EventBus`
  subscriber (`sweep.global.dispatch` + `sweep.issue.*`, no new emit call
  sites elsewhere) mapping lifecycle events to the #4703 telemetry schema's
  records, plus a periodic (5 min) `tokens.snapshot` / `host.health` sample.
- **`loom-daemon/Cargo.toml`** — add `reqwest` (rustls, no default
  features) for the HTTPS exporter only.
- **`loom-daemon/src/lib.rs` / `main.rs`** — register the module; spawn its
  background tasks alongside the `idle_exit`/`auto_update` wiring.
- **`defaults/docs/daemon-reference.md`** — new "Observability exporter"
  section documenting the config surface, architecture, and read-only
  invariant.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|---------------|
| Exporter trait + HTTPS-push implementation, wired to emit sweep lifecycle, outcome, token-snapshot, and host-health records | ✅ | `exporter::Exporter`/`HttpsExporter`; `collector.rs` maps `SweepGlobalDispatch`/`SweepPhase`/`SweepExited`/`SweepCrashed` to `SweepStarted`/`SweepPhase`/`SweepCompleted`/`SweepOutcome`, plus periodic `TokensSnapshot`/`HostHealth` samples |
| Durable offline queue with bounded capacity, drop-oldest accounting, and retry with backoff — verified by a test that kills and revives the mock sink | ✅ | `queue::DurableQueue` (bounded/drop-oldest/disk-backed tests); `sender::tests::kill_and_revive_drains_once_the_sink_is_reachable_again` and `exporter::tests::kill_and_revive_round_trip_still_talks_to_the_same_exporter` (hand-rolled TCP mock sink, killed then revived on the same port) |
| `observability` config block with env > config > default precedence, off by default; documented in the daemon reference | ✅ | `resolve_enabled`/`resolve_endpoint`/etc. + tests; `defaults/docs/daemon-reference.md` § "Observability exporter" |
| Ingest key sourced from file, absent from logs and error messages | ✅ | `read_ingest_key` reads `ingestKeyFile` once at startup; every log line/`ExportError` variant names the path only; `export_error_display_never_includes_the_ingest_key` test |
| Tests pass for new functionality | ✅ | `cargo test -p loom-daemon observability::` → 44 passed, 0 failed |

## Test Plan

- `cargo check -p loom-daemon --all-targets` — clean (this workspace's
  `.cargo/config.toml` runs clippy under the hood; no warnings).
- `cargo fmt --all -- --check` — clean.
- `cargo test -p loom-daemon observability::` — 44 passed, 0 failed,
  including the mock-sink kill/revive offline-queue drain test.

Part of epic #4702, Phase 1. Consumes #4703's telemetry schema (merged via
#4707).

Closes #4705