### PR TITLE
fix(scripts): fall back to $HOME/.cargo/bin when cargo is absent from PATH in loom-daemon-update.sh

### DIFF
--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -1091,8 +1091,24 @@ if [[ "$DRY_RUN" == "true" ]]; then
 fi
 
 # ---------- rebuild ----------
+# Non-interactive SSH sessions (the fleet remote-update path, #4695) don't
+# source a login shell's profile, so a rustup-installed cargo living at the
+# default `~/.cargo/bin` is invisible to `command -v cargo` even though it IS
+# installed. Fall back the same way loom-daemon-start.sh:233 already does for
+# launchd/systemd's non-login-shell PATH: prefer sourcing rustup's own
+# `~/.cargo/env` (the canonical PATH-setup snippet rustup writes), and fall
+# back to prepending `~/.cargo/bin` directly if that script isn't present but
+# the binary still is (e.g. a non-rustup or partially-cleaned install).
 if ! command -v cargo >/dev/null 2>&1; then
-    err "cargo not found on PATH — cannot rebuild loom-daemon."
+    if [[ -f "$HOME/.cargo/env" ]]; then
+        # shellcheck disable=SC1091
+        source "$HOME/.cargo/env"
+    elif [[ -x "$HOME/.cargo/bin/cargo" ]]; then
+        export PATH="$HOME/.cargo/bin:$PATH"
+    fi
+fi
+if ! command -v cargo >/dev/null 2>&1; then
+    err "cargo not found on PATH (checked \$HOME/.cargo/bin too) — cannot rebuild loom-daemon. Install Rust via rustup: https://rustup.rs"
     exit 1
 fi
 

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -709,6 +709,83 @@ if [[ -f "$W5B/.loom/.daemon.pid" ]]; then
 fi
 
 # ============================================================
+# 5c. Non-interactive-SSH cargo fallback (#4695): cargo is absent from PATH
+#     entirely (the exact non-login-shell-SSH symptom), but present at
+#     rustup's default $HOME/.cargo/bin -- the update must still find it via
+#     the fallback and rebuild successfully.
+# ============================================================
+W5C="$BASE_WORKDIR/w5c"
+new_fixture "$W5C"
+HEAD5C="$(cd "$W5C" && git rev-parse --short HEAD)"
+INSTALLED5C="$W5C/installed/loom-daemon"
+mkdir -p "$W5C/installed"
+write_fake_daemon "$INSTALLED5C" "deadbee" "$W5C/old-marker"
+NEW_FAKE5C="$W5C/new-fake-daemon"
+write_fake_daemon "$NEW_FAKE5C" "$HEAD5C" "$W5C/new-marker"
+# No .loom/.daemon.pid -> WAS_RUNNING resolves false, so this test exercises
+# only the rebuild+provision path (the cargo-fallback code under test)
+# without needing a background process to restart.
+
+# A PATH carrying the same launchd-sandbox stubs (launchctl/pgrep) as every
+# other test, but deliberately WITHOUT cargo anywhere on it.
+NO_CARGO_BIN_DIR5C="$BASE_WORKDIR/w5c-no-cargo-bin"
+NO_CARGO_LOG_DIR5C="$BASE_WORKDIR/w5c-no-cargo-log"
+launchd_sandbox_install_stubs "$NO_CARGO_BIN_DIR5C" "$NO_CARGO_LOG_DIR5C"
+TEST_PATH_NO_CARGO5C="$NO_CARGO_BIN_DIR5C:$MINIMAL_PATH"
+
+# The fake cargo lives ONLY under a scratch $HOME's rustup-default location,
+# simulating a non-interactive SSH shell that never sourced the profile line
+# rustup's installer adds.
+HOME5C="$BASE_WORKDIR/w5c-home"
+mkdir -p "$HOME5C/.cargo/bin"
+write_fake_cargo "$HOME5C/.cargo/bin/cargo"
+
+out5c=$( cd "$W5C" && PATH="$TEST_PATH_NO_CARGO5C" HOME="$HOME5C" \
+    LOOM_DAEMON_BIN="$INSTALLED5C" NEW_FAKE_BIN_SRC="$NEW_FAKE5C" \
+    bash "$UPDATE_SCRIPT" 2>&1 )
+rc5c=$?
+assert_eq "0" "$rc5c" "update succeeds when cargo is absent from PATH but present at \$HOME/.cargo/bin (#4695)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -x "$INSTALLED5C" ]] && "$INSTALLED5C" --version 2>/dev/null | grep -q "$HEAD5C"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} \$HOME/.cargo/bin fallback cargo actually rebuilt+provisioned the fresh binary"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} \$HOME/.cargo/bin fallback cargo actually rebuilt+provisioned the fresh binary"
+    echo "  output: $out5c"
+fi
+
+# ============================================================
+# 5d. cargo genuinely absent (not on PATH, not under $HOME/.cargo/bin either)
+#     -> exit 1 with a failure message that suggests installing via rustup,
+#     not just "not found" (#4695 AC).
+# ============================================================
+W5D="$BASE_WORKDIR/w5d"
+new_fixture "$W5D"
+HOME5D="$BASE_WORKDIR/w5d-home"
+mkdir -p "$HOME5D" # deliberately no .cargo/bin at all
+NO_CARGO_BIN_DIR5D="$BASE_WORKDIR/w5d-no-cargo-bin"
+NO_CARGO_LOG_DIR5D="$BASE_WORKDIR/w5d-no-cargo-log"
+launchd_sandbox_install_stubs "$NO_CARGO_BIN_DIR5D" "$NO_CARGO_LOG_DIR5D"
+TEST_PATH_NO_CARGO5D="$NO_CARGO_BIN_DIR5D:$MINIMAL_PATH"
+
+out5d=$( cd "$W5D" && PATH="$TEST_PATH_NO_CARGO5D" HOME="$HOME5D" \
+    bash "$UPDATE_SCRIPT" 2>&1 )
+rc5d=$?
+assert_eq "1" "$rc5d" "update exits 1 when cargo is genuinely absent (no PATH, no \$HOME/.cargo/bin)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out5d" | grep -qi 'rustup'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} genuinely-absent-cargo error message suggests installing via rustup"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} genuinely-absent-cargo error message suggests installing via rustup"
+    echo "  output: $out5d"
+fi
+
+# ============================================================
 # 6. Stale binary but daemon was NOT running -> rebuild+provision
 #    happen, but the daemon is NOT started (never widen FLAGS-OFF
 #    by starting autonomy — or anything — that wasn't already up).


### PR DESCRIPTION
## Summary

`./.loom/scripts/cli/loom-daemon-update.sh` failed with `cargo not found on PATH — cannot rebuild loom-daemon` when run over non-interactive SSH (`ssh host 'cd repo && ./.loom/scripts/cli/loom-daemon-update.sh'`). Non-interactive SSH sessions don't source the login shell profile, so a rustup-installed `cargo` at the default `~/.cargo/bin` is invisible to `command -v cargo` even though it is installed — exactly the shape of the fleet remote-update path (#4340).

## Changes

- `defaults/scripts/cli/loom-daemon-update.sh`: before failing on a missing `cargo`, the rebuild step now:
  1. Sources `$HOME/.cargo/env` (rustup's own canonical PATH-setup snippet) if present, or
  2. Prepends `$HOME/.cargo/bin` to `PATH` directly if that binary is executable but `.cargo/env` isn't present (non-rustup or partially-cleaned installs).
  3. Only then re-checks `command -v cargo`; if still absent, the failure message now reads `cargo not found on PATH (checked $HOME/.cargo/bin too) — cannot rebuild loom-daemon. Install Rust via rustup: https://rustup.rs` instead of a bare "not found".
- `defaults/scripts/tests/test-loom-daemon-update.sh`: two new regression tests:
  - **5c**: cargo absent from a stripped-down PATH but present at a scratch `$HOME/.cargo/bin` — asserts the update still succeeds and actually rebuilds+provisions the fresh binary.
  - **5d**: cargo genuinely absent (no PATH, no `$HOME/.cargo/bin`) — asserts exit 1 and that the failure message mentions rustup.

`.loom/scripts/cli/*` and `.loom/scripts/tests/*` are symlinks into `defaults/scripts/...` in this checkout, so no separate installed-copy edit is needed.

## Scope check

Audited every other `cargo`-invoking script on the daemon-rebuild path (`loom-daemon-start.sh`, `validate-toolchain.sh`, `provision-daemon.sh`, `scripts/install-loom.sh`) — none of them call `command -v cargo` themselves before shelling out to a build; `loom-daemon-update.sh` is the only script actually invoked by the SSH remote-update flow that gates a `cargo build` behind a PATH check, so it's the only site that needed this fallback.

## Test plan

- [x] `shellcheck --severity=warning defaults/scripts/cli/loom-daemon-update.sh` — clean.
- [x] Isolated the new PATH-fallback branch into a standalone snippet and exercised all 4 scenarios directly (cargo already on PATH / found via `$HOME/.cargo/env` / found via `$HOME/.cargo/bin/cargo` directly / genuinely absent) — all resolve/fail as expected, with the rustup-pointing message on genuine absence.
- [x] `defaults/scripts/tests/test-loom-daemon-update.sh` tests 1-5 (pre-existing) verified passing against this change during a partial run.
- [ ] Full `test-loom-daemon-update.sh` suite (49 fixture-heavy scenarios) run to completion — this suite is already flagged in `ci-excluded.txt` as "hangs past 120s locally" and this host is currently under very heavy concurrent-agent load (load avg ~50), so the full run did not finish within a reasonable wait; the standalone logic verification above covers the exact new code path.

Closes #4695