### PR TITLE
fix(docs): correct broken daemon-reference.md link in installed judge.md/doctor.md

### DIFF
--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -519,7 +519,7 @@ stand-down comment self-refreshes `updatedAt` but not the label event). That
 pass runs on an interval (up to ~10 minutes of lag) and cannot see an
 *in-flight* Doctor, so it never substitutes for this check or the pre-push
 recheck below. See [`daemon-reference.md`'s "Stale-claim reconciliation"
-section](../../../docs/daemon-reference.md#pr-side-claim-labels-loomreviewing--loomtreating-4367).
+section](../../../.loom/docs/daemon-reference.md#stale-claim-reconciliation--the-sweep-journal-3953-fixed-3975-extended-to-pr-side-claims-4367).
 
 ### Pre-Push Head-SHA Recheck (Step 9)
 

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -499,7 +499,7 @@ label's own `labeled` timeline-event timestamp rather than the PR's
 aggregate `updatedAt`, for the identical reason the marker convention above
 exists (a stand-down comment self-refreshes `updatedAt` but not the label
 event). See [`daemon-reference.md`'s "Stale-claim reconciliation"
-section](../../../docs/daemon-reference.md#pr-side-claim-labels-loomreviewing--loomtreating-4367).
+section](../../../.loom/docs/daemon-reference.md#stale-claim-reconciliation--the-sweep-journal-3953-fixed-3975-extended-to-pr-side-claims-4367).
 
 **Applies everywhere a Judge claims a PR from a multi-PR pass** — not just
 this single-PR narrative. This same check-then-claim rule governs the batch


### PR DESCRIPTION
## Summary

Fixes a broken doc link in the installed `judge.md` and `doctor.md` command files (`defaults/.claude/commands/loom/`), reported in #4706's link audit.

Both files linked to `../../../docs/daemon-reference.md#pr-side-claim-labels-loomreviewing--loomtreating-4367`, which is broken in two ways when the file is copied into consumer repos:

1. **Path bug**: the real doc lives at `.loom/docs/daemon-reference.md`, not `docs/daemon-reference.md` — the `.loom/` path segment was missing. Compare to the correct pattern already used at `defaults/.claude/commands/loom/sweep.md:2085`.
2. **Anchor bug**: the guessed anchor `#pr-side-claim-labels-loomreviewing--loomtreating-4367` doesn't match any heading. The real heading is `## Stale-claim reconciliation & the sweep journal (#3953, fixed #3975, extended to PR-side claims #4367)`, which slugifies to `#stale-claim-reconciliation--the-sweep-journal-3953-fixed-3975-extended-to-pr-side-claims-4367`.

## Changes

- `defaults/.claude/commands/loom/judge.md` (line 502): fixed link
- `defaults/.claude/commands/loom/doctor.md` (line 522): fixed link

Both now correctly link to:
```
../../../.loom/docs/daemon-reference.md#stale-claim-reconciliation--the-sweep-journal-3953-fixed-3975-extended-to-pr-side-claims-4367
```

Per the issue, the installed mirrors (`.claude/commands/loom/judge.md`/`doctor.md`) are out of scope — they're regenerated from `defaults/` via `resync-installed.sh`. `defaults/docs/daemon-reference.md` / `.loom/docs/daemon-reference.md` are unchanged; the target heading already exists there under its real title.

## Verification

- `grep -rn '\.\./\.\./\.\./docs/daemon-reference' defaults/.claude/commands/loom/*.md` returns no matches — no other stale occurrences of this broken pattern remain in that directory.
- Confirmed the heading `## Stale-claim reconciliation & the sweep journal (#3953, fixed #3975, extended to PR-side claims #4367)` exists verbatim at `defaults/docs/daemon-reference.md:1202` (and the `.loom/docs/` mirror), matching the new anchor.

Documentation-only, mechanical two-file link fix. No code tests apply.

Closes #4706