### PR TITLE
feat(safehouse): add opt-in claims room to route peer-claim heartbeats off the signal room

### DIFF
--- a/.loom/docs/safehouse.md
+++ b/.loom/docs/safehouse.md
@@ -839,6 +839,12 @@ per-repo firehose:
   (signal / per-repo firehose) keeps using `signal_room()`/`RoomRouter` exactly
   as before. Only the peer-claim coordination connection
   (`run_coordination`/`spawn_peer_coordination`) resolves `claims_room()`.
+  This holds even for a **claims-only** map (`rooms.claims` set with no
+  `rooms.signal`/`rooms.byRepo`): attention-class narration routing gates on a
+  narration target (`signal` and/or `byRepo`), so a claims-only map keeps
+  narration in byte-identical single-room mode — never lazily creating per-repo
+  firehose rooms as a side effect. `rooms.claims` and narration routing are
+  independent knobs.
 - The inbound reader is unchanged and remains **room-agnostic**: it folds any
   parseable `loom_claim` line regardless of which room delivered it, so this
   change is purely about which room this daemon *writes into* — receipt-side

--- a/.loom/docs/safehouse.md
+++ b/.loom/docs/safehouse.md
@@ -66,6 +66,7 @@ Env overrides (each wins over config for that key):
 | `LOOM_SAFEHOUSE_PERSONA` | `persona` |
 | `LOOM_SAFEHOUSE_ROOM_SIGNAL` | `rooms.signal` (#4225) |
 | `LOOM_SAFEHOUSE_ROOMS_BY_REPO` | `rooms.byRepo`, as `repo=room[,repo=room…]` (#4225) |
+| `LOOM_SAFEHOUSE_ROOM_CLAIMS` | `rooms.claims` — dedicated peer-claim coordination room (#4713) |
 
 **Socket resolution**: configured `socket` → `$LOOM_SAFEHOUSE_SOCKET` →
 `$SAFEHOUSED_SOCKET`. If none resolves, narration logs one `warn!` and stays off.
@@ -89,6 +90,9 @@ class first, repo second**:
       "loom": "!DeF…:example.org",
       "vibesql": "!GhI…:example.org"
     }
+    // "claims": "!JkL…:example.org"         // optional: dedicated peer-claim
+                                               // coordination room (#4713) —
+                                               // see "Which room claim ads ride" below
   }
 }
 ```
@@ -153,8 +157,10 @@ alias it asked for).
   `signal` id (or leave a real `room` for it to fall back to) — otherwise
   narration stops with the send-rejected status described below, which names the
   fix. See the troubleshooting entry.
-- **Peer-claim ads stay on the signal room** — the one deliberate exception to
-  "signal-only". See the peer-claim section below for why.
+- **Peer-claim ads default to the signal room** — the one deliberate exception
+  to "signal-only" — unless an operator opts into a dedicated `rooms.claims`
+  room (#4713). See the peer-claim section below for why, and for the
+  cross-host provisioning requirement that comes with opting in.
 
 New template keys reach existing consumer configs via the installer deep-merge
 (template is the base, existing values win) — no migration needed. The tier
@@ -766,11 +772,12 @@ coordination shrinks that window:
 - **Event taxonomy.** The internal pub/sub topic taxonomy is frozen; peer claims
   add **no new bus topic** — they travel entirely over the safehouse room.
 
-### Which room claim ads ride: the signal room (#4225's resolved open question)
+### Which room claim ads ride: the signal room by default, opt-in dedicated room (#4225, #4713)
 
 A claim ad is a `task` envelope carrying per-repo machine chatter, so the
-attention-class table would put it in the repo firehose. It stays on the **signal
-room** instead — the one deliberate exception to "the signal room is signal-only":
+attention-class table would put it in the repo firehose. By default it rides the
+**signal room** instead — the one deliberate exception to "the signal room is
+signal-only":
 
 1. **The signal room is the only room with guaranteed common membership.** Firehose
    rooms are created **lazily** by whichever host narrates that repo first, and
@@ -781,17 +788,64 @@ room** instead — the one deliberate exception to "the signal room is signal-on
    host's bot is already in the signal room.
 2. **Dedup is correctness; room hygiene is cosmetics.** A missed ad costs a
    duplicate cross-host sweep (wasted tokens, two PRs for one issue); a little
-   machine JSON in the signal room costs some scroll. Correctness wins, and ads
-   are low volume (one per dispatch / terminal outcome, plus the #4431 re-ad).
+   machine JSON in the signal room costs some scroll. Correctness wins, and this
+   is why the dedicated-room escape hatch below is opt-in rather than the new
+   default.
 3. **The reader agrees with the writer by construction.** The coordination task's
    inbound handler is unfiltered — it folds *any* inbound line with a parseable
-   `loom_claim` body into the view — so keeping the write side on the signal room
-   makes the pair trivially consistent instead of dependent on which rooms this
-   host's bot happens to have joined.
+   `loom_claim` body into the view — so keeping the write side and the read side
+   on the same resolved room makes the pair trivially consistent instead of
+   dependent on which rooms this host's bot happens to have joined.
 
-A dedicated coordination room (a third tier) is the clean long-term fix and is
-left as a follow-up: like the tier-3 Matrix Space, it needs cross-host
-*provisioning*, not just routing.
+**The volume problem (#4713).** Ads are low volume per dispatch/terminal outcome,
+but `sweep_registry::readvertise_peer_claims` re-publishes every **live** sweep's
+claim on every 30-second reaper tick — deliberately, to stay under the
+peer-claim TTL; this is a liveness requirement, not a bug, so it cannot simply be
+slowed down. At fleet scale (several sweeps in flight) that heartbeat cadence is
+enough to flood the human-facing signal room with near-identical machine
+messages, burying genuine sweep-lifecycle narration.
+
+**The fix: `rooms.claims` (opt-in, default-unchanged).** An operator who finds
+the heartbeat traffic disruptive can set `rooms.claims` (or
+`LOOM_SAFEHOUSE_ROOM_CLAIMS`) to route claim advertise/retract traffic into a
+**dedicated coordination room**, separate from both the signal room and the
+per-repo firehose:
+
+```jsonc
+"safehouse": {
+  "enabled": true,
+  "rooms": {
+    "signal": "!AbC…:example.org",
+    "claims": "!JkL…:example.org"   // peer-claim heartbeats route here instead
+  }
+}
+```
+
+- **Resolution**: `rooms.claims` when set, else `rooms.signal` (which itself
+  falls back to the legacy scalar `room`) — `SafehouseConfig::claims_room()`
+  mirrors `signal_room()`'s own fallback chain one level down.
+- **Absent (the default) is byte-identical to pre-#4713 behavior**: claim ads
+  keep riding the signal room exactly as before. This is not merely convenient —
+  it is the safe default, because of the provisioning caveat below.
+- **This is provisioning, not just routing** — the reason #4225 deferred this in
+  the first place. Setting `rooms.claims` to a room only some hosts' bots have
+  joined reproduces the exact silent cross-host dedup failure reason 1 above
+  exists to avoid: a host whose bot is not a member of the configured claims
+  room silently stops seeing peers' advertisements, with no error anywhere.
+  **Before setting `rooms.claims`, ensure every host's safehoused bot is already
+  joined to that room** — the identical requirement already documented for
+  `rooms.signal`.
+- The narration sink is unaffected: `run_sink`'s attention-class routing
+  (signal / per-repo firehose) keeps using `signal_room()`/`RoomRouter` exactly
+  as before. Only the peer-claim coordination connection
+  (`run_coordination`/`spawn_peer_coordination`) resolves `claims_room()`.
+- The inbound reader is unchanged and remains **room-agnostic**: it folds any
+  parseable `loom_claim` line regardless of which room delivered it, so this
+  change is purely about which room this daemon *writes into* — receipt-side
+  filtering (teaching the separate `rjwalters/safehouse` server to mark
+  `loom_claim` envelopes as ephemeral coordination traffic that never surfaces
+  in a human-facing feed) is tracked as a **separate, out-of-scope, cross-repo
+  follow-up**, not implemented here.
 
 ### Soft claim, NOT a mutex (the load-bearing caveat)
 

--- a/loom-daemon/src/safehouse.rs
+++ b/loom-daemon/src/safehouse.rs
@@ -72,6 +72,14 @@ const PERSONA_ENV: &str = "LOOM_SAFEHOUSE_PERSONA";
 const ROOM_SIGNAL_ENV: &str = "LOOM_SAFEHOUSE_ROOM_SIGNAL";
 const ROOMS_BY_REPO_ENV: &str = "LOOM_SAFEHOUSE_ROOMS_BY_REPO";
 
+/// The dedicated peer-claim coordination room (#4713): when set, claim
+/// advertise/retract traffic rides this room instead of the signal room, so a
+/// human watching the signal room no longer sees the 30-second heartbeat
+/// cadence `sweep_registry::readvertise_peer_claims` re-publishes. Absent ⇒
+/// falls back to [`SafehouseConfig::signal_room`] — see
+/// [`SafehouseConfig::claims_room`].
+const ROOM_CLAIMS_ENV: &str = "LOOM_SAFEHOUSE_ROOM_CLAIMS";
+
 /// Alias prefix for a lazily-created per-repo firehose room (#4225): the
 /// `vibesql` workspace's firehose is `fleet-vibesql`. Deliberately **not** the
 /// signal room's own name (`loom-fleet`) — the prefix reads as "the fleet's view
@@ -198,6 +206,16 @@ pub struct RoomMap {
     /// map is created lazily as `fleet-<repo>` on first narration (see
     /// [`RoomRouter`]). `BTreeMap` for deterministic iteration in tests/logs.
     pub by_repo: std::collections::BTreeMap<String, String>,
+    /// The dedicated peer-claim coordination room (#4713), opt-in. `None` ⇒
+    /// fall back to [`signal`](Self::signal) (see
+    /// [`SafehouseConfig::claims_room`]) — the same "absent means
+    /// unchanged-default" contract `signal` itself has against the legacy
+    /// [`SafehouseConfig::room`] scalar. Setting this splits the machine-cadence
+    /// claim advertise/retract heartbeat out of the human-facing signal room
+    /// into its own coordination room; an operator who does this **must**
+    /// ensure every host's safehoused bot is joined to it (the same
+    /// cross-host-provisioning requirement documented for `signal`).
+    pub claims: Option<String>,
 }
 
 impl RoomMap {
@@ -205,7 +223,7 @@ impl RoomMap {
     /// callers normalize it to `None` (single-room mode).
     #[must_use]
     fn is_empty(&self) -> bool {
-        self.signal.is_none() && self.by_repo.is_empty()
+        self.signal.is_none() && self.by_repo.is_empty() && self.claims.is_none()
     }
 }
 
@@ -258,6 +276,21 @@ impl SafehouseConfig {
             .as_ref()
             .and_then(|rooms| rooms.signal.as_deref())
             .or(self.room.as_deref())
+    }
+
+    /// The room peer-claim advertise/retract traffic goes to (#4713):
+    /// `rooms.claims` when the map configures one, else falls back to
+    /// [`signal_room`](Self::signal_room) — which itself falls back to the
+    /// legacy scalar [`room`](Self::room). This chain is what keeps existing
+    /// deployments (no `rooms.claims` configured) byte-identical to pre-#4713
+    /// behavior: claim ads keep riding the signal room exactly as
+    /// [`run_coordination`]'s doc comment describes.
+    #[must_use]
+    pub fn claims_room(&self) -> Option<&str> {
+        self.rooms
+            .as_ref()
+            .and_then(|rooms| rooms.claims.as_deref())
+            .or_else(|| self.signal_room())
     }
 
     /// Whether attention-class routing is active (a `rooms` map resolved).
@@ -329,6 +362,11 @@ fn rooms_from_value(block: Option<&Value>) -> Option<RoomMap> {
             }
         }
     }
+    if let Some(claims) = rooms.get("claims").and_then(Value::as_str) {
+        if !claims.trim().is_empty() {
+            map.claims = Some(claims.trim().to_owned());
+        }
+    }
     (!map.is_empty()).then_some(map)
 }
 
@@ -356,25 +394,30 @@ fn apply_env_overrides(mut cfg: SafehouseConfig) -> SafehouseConfig {
 /// default**:
 ///
 /// - `LOOM_SAFEHOUSE_ROOM_SIGNAL` overrides `rooms.signal` alone.
+/// - `LOOM_SAFEHOUSE_ROOM_CLAIMS` (#4713) overrides `rooms.claims` alone.
 /// - `LOOM_SAFEHOUSE_ROOMS_BY_REPO` (`repo=room,repo=room…`) replaces the
 ///   **whole** `byRepo` map rather than merging into it, so an operator can
 ///   override a stale committed map from the environment without editing config
 ///   (the same wholesale-replacement semantics `LOOM_SAFEHOUSE_WORKER_PERSONAS`
 ///   uses for its list).
-/// - Either env var alone is enough to *enable* routing on a config that has no
-///   `rooms` block at all.
-/// - Neither set ⇒ the config-layer map is returned untouched (so the absent-map
+/// - Any one of these env vars alone is enough to *enable* routing on a config
+///   that has no `rooms` block at all.
+/// - None set ⇒ the config-layer map is returned untouched (so the absent-map
 ///   single-room default stays byte-identical).
 #[must_use]
 fn apply_room_env_overrides(rooms: Option<RoomMap>) -> Option<RoomMap> {
     let signal = env_nonempty(ROOM_SIGNAL_ENV);
+    let claims = env_nonempty(ROOM_CLAIMS_ENV);
     let by_repo = env_nonempty(ROOMS_BY_REPO_ENV).map(|raw| parse_by_repo_env(&raw));
-    if signal.is_none() && by_repo.is_none() {
+    if signal.is_none() && claims.is_none() && by_repo.is_none() {
         return rooms;
     }
     let mut map = rooms.unwrap_or_default();
     if let Some(signal) = signal {
         map.signal = Some(signal);
+    }
+    if let Some(claims) = claims {
+        map.claims = Some(claims);
     }
     if let Some(by_repo) = by_repo {
         map.by_repo = by_repo;
@@ -2934,12 +2977,14 @@ pub fn spawn_peer_coordination(
 /// outbound claim ads (→ socket). Any I/O failure degrades to a reconnect — it
 /// never blocks or fails a dispatch. Returns when all outbound senders drop.
 ///
-/// # Room routing: claim ads stay on the signal room (#4225, resolved in-PR)
+/// # Room routing: claim ads default to the signal room, opt-in dedicated room (#4225, #4713)
 ///
 /// Attention-class routing sends `task` envelopes to the per-repo firehose, and a
 /// claim ad *is* a per-repo `task` envelope — yet this connection deliberately
-/// advertises into (and reads from) the **signal room**, the one deliberate
-/// exception to "signal-only". Why:
+/// advertises into (and reads from) [`SafehouseConfig::claims_room`], **not**
+/// the per-repo firehose. By default (`rooms.claims` unset) `claims_room()`
+/// resolves to the **signal room**, the one deliberate exception to
+/// "signal-only" #4225 established. Why the signal room is the *default*:
 ///
 /// 1. **The signal room is the only room with guaranteed common membership.**
 ///    Rooms are per-repo and created **lazily** by whichever host narrates that
@@ -2953,18 +2998,27 @@ pub fn spawn_peer_coordination(
 /// 2. **Dedup is correctness, room hygiene is cosmetics.** A missed claim ad
 ///    costs a duplicate cross-host sweep (wasted tokens, two PRs for one issue).
 ///    A little machine JSON in the signal room costs the operator some scroll.
-///    When those trade off, correctness wins.
+///    When those trade off, correctness wins — which is exactly why the
+///    dedicated-room escape hatch below is opt-in, not the new default.
 /// 3. **The reader must agree with the writer.** This task's inbound handler is
 ///    unfiltered — it folds *any* inbound line carrying a parseable `loom_claim`
 ///    body into the view — so it consumes ads from whatever rooms safehoused
-///    pushes to it. Keeping the write side on the signal room keeps the pair
-///    trivially consistent instead of depending on which rooms this host's bot
-///    happens to have joined.
+///    pushes to it. Keeping the write side and the read side on the same
+///    resolved room keeps the pair trivially consistent instead of depending on
+///    which rooms this host's bot happens to have joined.
 ///
-/// Ads are low volume (one per dispatch / terminal outcome). A dedicated
-/// coordination room (a third tier) is the clean long-term fix and is left as a
-/// follow-up — it needs cross-host *provisioning*, not just routing, which is the
-/// same reason tier 3 (the Matrix Space) is out of scope here.
+/// Ads are low volume per dispatch / terminal outcome, but
+/// `sweep_registry::readvertise_peer_claims` re-publishes every live sweep's
+/// claim each 30s reaper tick (deliberately under the peer-claim TTL — the
+/// liveness contract requires the repetition), so at fleet scale the cadence is
+/// enough to flood the human-visible signal room (#4713). An operator who finds
+/// that disruptive may set `rooms.claims` (or `LOOM_SAFEHOUSE_ROOM_CLAIMS`) to
+/// route claim ads into a dedicated coordination room instead, keeping the
+/// signal room for sweep-lifecycle narration. **This is provisioning, not just
+/// routing**: every host's safehoused bot must already be joined to that room
+/// before it is configured, or that host silently stops seeing peers' claims —
+/// the exact cross-host dedup failure class reason 1 above exists to avoid.
+/// `rooms.claims` absent (the default) is byte-identical to pre-#4713 behavior.
 async fn run_coordination(
     config: SafehouseConfig,
     socket: PathBuf,
@@ -2976,9 +3030,11 @@ async fn run_coordination(
 ) {
     let mut backoff = min_backoff;
     let mut warned = false;
-    // The signal room (see the routing rationale above). In single-room mode this
-    // *is* `config.room`, so the pre-#4225 behavior is byte-identical.
-    let signal_room = config.signal_room().map(ToOwned::to_owned);
+    // The claims room (see the routing rationale above): `rooms.claims` when
+    // configured (#4713), else the signal room. In single-room mode (no `rooms`
+    // block at all) this *is* `config.room`, so the pre-#4225/#4713 behavior is
+    // byte-identical.
+    let claims_room = config.claims_room().map(ToOwned::to_owned);
     loop {
         set_state(
             &state,
@@ -2986,7 +3042,7 @@ async fn run_coordination(
                 socket: socket.clone(),
             },
         );
-        let client = match SafehouseClient::connect(&socket, &config.persona, signal_room.clone())
+        let client = match SafehouseClient::connect(&socket, &config.persona, claims_room.clone())
             .await
         {
             Ok(client) => {
@@ -2999,7 +3055,7 @@ async fn run_coordination(
                     &state,
                     SafehouseState::Connected {
                         socket: socket.clone(),
-                        room: signal_room.clone(),
+                        room: claims_room.clone(),
                     },
                 );
                 client
@@ -3423,6 +3479,7 @@ mod tests {
                 by_repo: [("loom".to_owned(), "!fleet-loom:example.org".to_owned())]
                     .into_iter()
                     .collect(),
+                claims: None,
             }),
             ..SafehouseConfig::default()
         }
@@ -3432,6 +3489,11 @@ mod tests {
     /// every envelope of every kind resolves to the single configured `room`,
     /// exactly as before — including the `None` "let safehoused resolve its sole
     /// room" form, which must still serialize with no `room` key at all.
+    ///
+    /// Also covers #4713: with no `rooms` map (and so no `rooms.claims`),
+    /// [`SafehouseConfig::claims_room`] must resolve to the exact same single
+    /// `room` — the claim-ad routing path must be byte-identical to pre-#4713
+    /// behavior too, not just the narration path.
     #[test]
     fn absent_rooms_map_is_byte_identical_single_room_behavior() {
         for room in [Some("loom-fleet".to_owned()), None] {
@@ -3441,6 +3503,11 @@ mod tests {
                 ..SafehouseConfig::default()
             };
             assert!(!cfg.routes_by_attention());
+            assert_eq!(
+                cfg.claims_room(),
+                room.as_deref(),
+                "with no rooms map, claim ads must resolve to the same single room as narration"
+            );
             let router = RoomRouter::new(&cfg);
             for kind in KNOWN_TYPES {
                 for repo in [Some("/home/x/GitHub/vibesql"), None] {
@@ -3477,6 +3544,7 @@ mod tests {
                 by_repo: [("loom".to_owned(), "!fleet-loom:example.org".to_owned())]
                     .into_iter()
                     .collect(),
+                claims: None,
             }),
             ..SafehouseConfig::default()
         };
@@ -3488,6 +3556,42 @@ mod tests {
         );
         // …and `rooms.signal`, when set, wins over the legacy scalar.
         assert_eq!(routing_config().signal_room(), Some("!signal:example.org"));
+    }
+
+    /// #4713: `claims_room()` falls back to `signal_room()` — which itself may
+    /// fall back further to the legacy scalar `room` — when `rooms.claims` is
+    /// absent, mirroring `signal_room`'s own fallback chain one level down.
+    #[test]
+    fn claims_room_falls_back_to_signal_room_when_absent() {
+        // rooms.claims absent, rooms.signal present ⇒ claims_room is the signal room.
+        let cfg = routing_config();
+        assert!(cfg.rooms.as_ref().unwrap().claims.is_none());
+        assert_eq!(cfg.claims_room(), Some("!signal:example.org"));
+        assert_eq!(cfg.claims_room(), cfg.signal_room());
+
+        // rooms.claims present ⇒ it wins over the signal room.
+        let cfg_with_claims = SafehouseConfig {
+            rooms: Some(RoomMap {
+                claims: Some("!claims:example.org".to_owned()),
+                ..cfg.rooms.clone().unwrap()
+            }),
+            ..cfg
+        };
+        assert_eq!(cfg_with_claims.claims_room(), Some("!claims:example.org"));
+        assert_eq!(
+            cfg_with_claims.signal_room(),
+            Some("!signal:example.org"),
+            "narration routing (signal_room) must be unaffected by rooms.claims"
+        );
+
+        // No rooms map at all ⇒ claims_room falls all the way back to the
+        // legacy scalar `room`, exactly like `signal_room` does.
+        let legacy = SafehouseConfig {
+            enabled: true,
+            room: Some("!legacy:example.org".to_owned()),
+            ..SafehouseConfig::default()
+        };
+        assert_eq!(legacy.claims_room(), Some("!legacy:example.org"));
     }
 
     #[test]
@@ -3581,6 +3685,7 @@ mod tests {
                 by_repo: [("loom".to_owned(), "!fleet-loom:example.org".to_owned())]
                     .into_iter()
                     .collect(),
+                claims: None,
             }),
             ..SafehouseConfig::default()
         };
@@ -3628,7 +3733,8 @@ mod tests {
             "enabled": true,
             "rooms": {
                 "signal": "!signal:example.org",
-                "byRepo": {"loom": "!fleet-loom:example.org", "vibesql": "!fleet-vibesql:example.org"}
+                "byRepo": {"loom": "!fleet-loom:example.org", "vibesql": "!fleet-vibesql:example.org"},
+                "claims": "!claims:example.org"
             }
         });
         let cfg = config_from_value(Some(&block));
@@ -3639,6 +3745,32 @@ mod tests {
             rooms.by_repo.get("vibesql").map(String::as_str),
             Some("!fleet-vibesql:example.org")
         );
+        assert_eq!(rooms.claims.as_deref(), Some("!claims:example.org"));
+    }
+
+    /// #4713: `rooms.claims` parses independently of `rooms.signal`/`byRepo` —
+    /// an operator can set only the claims room and leave narration routing
+    /// entirely on the legacy single-room scalar.
+    #[test]
+    fn config_parses_the_rooms_claims_field_alone() {
+        let block = json!({
+            "enabled": true,
+            "room": "loom-fleet",
+            "rooms": {"claims": "!claims:example.org"}
+        });
+        let cfg = config_from_value(Some(&block));
+        assert_eq!(cfg.claims_room(), Some("!claims:example.org"));
+        assert_eq!(
+            cfg.signal_room(),
+            Some("loom-fleet"),
+            "narration keeps using the legacy scalar room when only rooms.claims is set"
+        );
+        let rooms = cfg
+            .rooms
+            .expect("rooms.claims alone must still produce a non-empty map");
+        assert!(rooms.signal.is_none());
+        assert!(rooms.by_repo.is_empty());
+        assert_eq!(rooms.claims.as_deref(), Some("!claims:example.org"));
     }
 
     #[test]
@@ -3652,6 +3784,7 @@ mod tests {
             json!({"enabled": true, "rooms": {"signal": "  ", "byRepo": {}}}),
             json!({"enabled": true, "rooms": {"byRepo": {"loom": ""}}}),
             json!({"enabled": true, "rooms": {"byRepo": ["loom"]}}),
+            json!({"enabled": true, "rooms": {"claims": "  "}}),
         ] {
             let cfg = config_from_value(Some(&block));
             assert!(
@@ -3667,13 +3800,15 @@ mod tests {
     #[serial]
     fn env_overrides_config_for_the_rooms_map() {
         std::env::set_var(ROOM_SIGNAL_ENV, "!env-signal:example.org");
+        std::env::set_var(ROOM_CLAIMS_ENV, "!env-claims:example.org");
         std::env::set_var(ROOMS_BY_REPO_ENV, "loom=!env-loom:example.org, anvil=!env-anvil:x");
 
         let cfg = apply_env_overrides(config_from_value(Some(&json!({
             "enabled": true,
             "rooms": {
                 "signal": "!cfg-signal:example.org",
-                "byRepo": {"loom": "!cfg-loom:example.org", "vibesql": "!cfg-vibesql:example.org"}
+                "byRepo": {"loom": "!cfg-loom:example.org", "vibesql": "!cfg-vibesql:example.org"},
+                "claims": "!cfg-claims:example.org"
             }
         }))));
         let rooms = cfg.rooms.expect("env must keep the map present");
@@ -3684,8 +3819,10 @@ mod tests {
             !rooms.by_repo.contains_key("vibesql"),
             "the byRepo env override replaces the whole map rather than merging into it"
         );
+        assert_eq!(rooms.claims.as_deref(), Some("!env-claims:example.org"));
 
         std::env::remove_var(ROOM_SIGNAL_ENV);
+        std::env::remove_var(ROOM_CLAIMS_ENV);
         std::env::remove_var(ROOMS_BY_REPO_ENV);
     }
 
@@ -3697,6 +3834,17 @@ mod tests {
         let cfg = apply_env_overrides(config_from_value(Some(&json!({"enabled": true}))));
         assert_eq!(cfg.signal_room(), Some("!env-signal:example.org"));
         std::env::remove_var(ROOM_SIGNAL_ENV);
+
+        // `LOOM_SAFEHOUSE_ROOM_CLAIMS` alone (#4713) is likewise enough to
+        // enable routing from env, with no `rooms.signal` present at all.
+        std::env::set_var(ROOM_CLAIMS_ENV, "!env-claims:example.org");
+        let cfg = apply_env_overrides(config_from_value(Some(&json!({"enabled": true}))));
+        assert_eq!(cfg.claims_room(), Some("!env-claims:example.org"));
+        assert!(
+            cfg.signal_room().is_none(),
+            "rooms.claims alone must not affect the (unset) signal room"
+        );
+        std::env::remove_var(ROOM_CLAIMS_ENV);
 
         // Neither env var set ⇒ the config layer's map is returned untouched, so
         // the absent-map single-room default stays byte-identical. (`room` itself
@@ -3712,6 +3860,11 @@ mod tests {
             config_from_value(Some(&json!({"enabled": true, "room": "loom-fleet"}))).signal_room(),
             Some("loom-fleet"),
             "with no rooms map the signal room IS the legacy scalar room"
+        );
+        assert_eq!(
+            config_from_value(Some(&json!({"enabled": true, "room": "loom-fleet"}))).claims_room(),
+            Some("loom-fleet"),
+            "with no rooms map the claims room IS also the legacy scalar room"
         );
 
         // A garbage byRepo env value degrades to the pairs it can parse (here:
@@ -4571,6 +4724,7 @@ mod tests {
                 rooms: Some(RoomMap {
                     signal: Some("!signal:example.org".to_owned()),
                     by_repo: std::collections::BTreeMap::new(),
+                    claims: None,
                 }),
                 ..SafehouseConfig::default()
             },
@@ -6487,6 +6641,7 @@ mod tests {
                     by_repo: [("loom".to_owned(), "!fleet-loom:example.org".to_owned())]
                         .into_iter()
                         .collect(),
+                    claims: None,
                 }),
                 ..SafehouseConfig::default()
             },
@@ -6513,6 +6668,91 @@ mod tests {
             json!("!signal:example.org"),
             "claim ads ride the signal room, NOT the repo firehose (documented exception)"
         );
+        task.abort();
+    }
+
+    /// #4713: when `rooms.claims` is configured, claim ads route into that
+    /// dedicated coordination room instead of the signal room — the opt-in
+    /// escape hatch `run_coordination`'s doc comment describes. The signal room
+    /// stays reserved for sweep-lifecycle narration.
+    #[tokio::test]
+    async fn coordination_advertises_claim_ads_into_a_dedicated_claims_room_when_configured() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("safehoused.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read_half, mut write_half) = stream.into_split();
+            let mut lines = BufReader::new(read_half).lines();
+            let hello: Value =
+                serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+            assert_eq!(hello["op"], json!("hello"));
+            write_half
+                .write_all(b"{\"ok\":true,\"id\":0}\n")
+                .await
+                .unwrap();
+            let ad: Value =
+                serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+            let reply = json!({"ok": true, "id": ad["id"].clone()});
+            write_half
+                .write_all(format!("{reply}\n").as_bytes())
+                .await
+                .unwrap();
+            ad
+        });
+
+        let view = Arc::new(Mutex::new(PeerClaimView::new("me".into(), Duration::from_secs(120))));
+        let sink: Arc<dyn InboundEventSink> = Arc::new(PeerClaimSink::new(view));
+        let (tx, rx) = tokio::sync::mpsc::channel::<ClaimAd>(8);
+        let state = new_shared_state();
+
+        let task = tokio::spawn(run_coordination(
+            SafehouseConfig {
+                enabled: true,
+                socket: Some(socket.clone()),
+                room: None,
+                rooms: Some(RoomMap {
+                    signal: Some("!signal:example.org".to_owned()),
+                    by_repo: [("loom".to_owned(), "!fleet-loom:example.org".to_owned())]
+                        .into_iter()
+                        .collect(),
+                    claims: Some("!claims:example.org".to_owned()),
+                }),
+                ..SafehouseConfig::default()
+            },
+            socket,
+            sink,
+            rx,
+            Duration::from_millis(20),
+            Duration::from_millis(80),
+            state.clone(),
+        ));
+
+        tx.send(ClaimAd::advertise(4713, "loom".into(), "maple".into(), 7, "ts".into()))
+            .await
+            .unwrap();
+
+        let ad = tokio::time::timeout(Duration::from_secs(2), server)
+            .await
+            .expect("the stub must receive the claim ad")
+            .unwrap();
+        assert_eq!(ad["op"], json!("send"));
+        assert_eq!(ad["type"], json!("task"));
+        assert_eq!(
+            ad["room"],
+            json!("!claims:example.org"),
+            "with rooms.claims configured, claim ads ride the dedicated claims room, \
+             not the signal room and not the repo firehose"
+        );
+        // The connection state (#4345) reflects the room this connection
+        // actually advertises into.
+        match snapshot_state(&state) {
+            SafehouseState::Connected { room, .. } => {
+                assert_eq!(room.as_deref(), Some("!claims:example.org"));
+            }
+            other => panic!("expected Connected, got {other:?}"),
+        }
         task.abort();
     }
 

--- a/loom-daemon/src/safehouse.rs
+++ b/loom-daemon/src/safehouse.rs
@@ -193,6 +193,12 @@ const DEFAULT_MAX_BACKOFF: Duration = Duration::from_secs(60);
 /// back to `None` by [`rooms_from_value`] / [`apply_room_env_overrides`]: an
 /// operator who leaves `"rooms": {}` in config gets the unchanged single-room
 /// behavior rather than a routing mode with nothing to route to.
+///
+/// A **claims-only** map (`claims` set, no `signal`, no `byRepo`) is kept — so
+/// [`SafehouseConfig::claims_room`] resolves — but it does **not** activate
+/// attention-class narration routing: [`routes_narration`](Self::routes_narration)
+/// gates narration on a narration target, keeping `claims` an independent knob
+/// (#4713's "opt-in, default-unchanged" contract).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RoomMap {
     /// The everyone/signal room (`loom-fleet`): operator ↔ fleet conversation,
@@ -224,6 +230,17 @@ impl RoomMap {
     #[must_use]
     fn is_empty(&self) -> bool {
         self.signal.is_none() && self.by_repo.is_empty() && self.claims.is_none()
+    }
+
+    /// Whether this map carries a **narration** routing target (`signal` and/or
+    /// a `byRepo` entry). A claims-only map does **not**: `claims` redirects the
+    /// peer-claim coordination connection only (#4713) and must never flip the
+    /// narration sink out of its byte-identical single-room mode as a side
+    /// effect. Both [`SafehouseConfig::routes_by_attention`] and
+    /// [`RoomRouter::resolve`] gate on this, keeping the two knobs independent.
+    #[must_use]
+    fn routes_narration(&self) -> bool {
+        self.signal.is_some() || !self.by_repo.is_empty()
     }
 }
 
@@ -267,9 +284,10 @@ impl SafehouseConfig {
     /// single-room mode this **is** `room`, which is what keeps the absent-map
     /// path byte-identical.
     ///
-    /// Doubles as the room the peer-claim coordination connection advertises
-    /// into — see [`run_coordination`] for why claim ads deliberately stay on
-    /// the signal room.
+    /// Also the **fallback** for the peer-claim coordination connection: since
+    /// #4713 [`run_coordination`] resolves [`claims_room`](Self::claims_room),
+    /// which lands here only while `rooms.claims` is unset — see
+    /// [`run_coordination`] for why claim ads default to the signal room.
     #[must_use]
     pub fn signal_room(&self) -> Option<&str> {
         self.rooms
@@ -293,10 +311,15 @@ impl SafehouseConfig {
             .or_else(|| self.signal_room())
     }
 
-    /// Whether attention-class routing is active (a `rooms` map resolved).
+    /// Whether attention-class **narration** routing is active: the `rooms` map
+    /// configures a narration target (`signal` and/or `byRepo`). A claims-only
+    /// map deliberately does **not** activate it — `rooms.claims` is an
+    /// independent knob that only redirects the peer-claim coordination
+    /// connection ([`claims_room`](Self::claims_room)); narration stays in
+    /// single-room mode, byte-identical (#4713).
     #[must_use]
     pub fn routes_by_attention(&self) -> bool {
-        self.rooms.is_some()
+        self.rooms.as_ref().is_some_and(RoomMap::routes_narration)
     }
 }
 
@@ -1071,8 +1094,12 @@ impl RoomRouter {
     pub fn resolve(&self, kind: &str, repo: Option<&str>) -> RoomDecision {
         // Absent `rooms` map ⇒ the pre-#4225 behavior, byte-identical: one room
         // for everything, `None` included. This is the migration default and the
-        // single most important invariant of this change.
-        let Some(map) = self.map.as_ref() else {
+        // single most important invariant of this change. A map with no
+        // narration target (claims-only, #4713) is deliberately treated the
+        // same: `rooms.claims` redirects the peer-claim coordination connection
+        // only, and must not switch narration into attention-class routing —
+        // per-repo lazy firehose creation included — as a side effect.
+        let Some(map) = self.map.as_ref().filter(|map| map.routes_narration()) else {
             return RoomDecision::Send(self.single.clone());
         };
         // An unparseable kind cannot reach the wire (`build_send_request` refuses
@@ -3592,6 +3619,47 @@ mod tests {
             ..SafehouseConfig::default()
         };
         assert_eq!(legacy.claims_room(), Some("!legacy:example.org"));
+    }
+
+    /// #4713's "opt-in, default-unchanged" contract, claims-only edition:
+    /// setting `rooms.claims` **alone** (no `signal`, no `byRepo`) redirects
+    /// the peer-claim coordination connection and nothing else. Narration must
+    /// stay in single-room mode — byte-identical to the absent-map case —
+    /// rather than silently activating attention-class routing (per-repo lazy
+    /// firehose creation) as a side effect of an unrelated knob.
+    #[test]
+    fn claims_only_map_does_not_activate_attention_class_narration_routing() {
+        for room in [Some("loom-fleet".to_owned()), None] {
+            let cfg = SafehouseConfig {
+                enabled: true,
+                room: room.clone(),
+                rooms: Some(RoomMap {
+                    signal: None,
+                    by_repo: std::collections::BTreeMap::new(),
+                    claims: Some("!claims:example.org".to_owned()),
+                }),
+                ..SafehouseConfig::default()
+            };
+            // The claims knob works…
+            assert_eq!(cfg.claims_room(), Some("!claims:example.org"));
+            // …and narration routing does not notice it.
+            assert!(
+                !cfg.routes_by_attention(),
+                "a claims-only rooms map must not enable attention-class narration routing"
+            );
+            let router = RoomRouter::new(&cfg);
+            assert_eq!(router.signal_room(), room.clone());
+            for kind in KNOWN_TYPES {
+                for repo in [Some("/home/x/GitHub/vibesql"), None] {
+                    assert_eq!(
+                        router.resolve(kind, repo),
+                        RoomDecision::Send(room.clone()),
+                        "claims-only map: {kind:?} (repo={repo:?}) must stay in \
+                         single-room mode, never Create a firehose room"
+                    );
+                }
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`sweep_registry::readvertise_peer_claims` re-publishes every live sweep's soft
claim on each 30-second reaper tick (deliberately under the peer-claim TTL —
the liveness contract requires the repetition), which at fleet scale floods
the human-visible safehouse signal room with near-identical machine
heartbeats. This adds an opt-in `rooms.claims` field (mirroring the existing
`rooms.signal`/`rooms.by_repo` pattern) so an operator can route claim
advertise/retract traffic into a dedicated coordination room, with a
default-unchanged fallback to the signal room.

## Changes

- `loom-daemon/src/safehouse.rs`:
  - Add `RoomMap::claims: Option<String>` and fold it into `RoomMap::is_empty`.
  - Add `SafehouseConfig::claims_room()`, mirroring `signal_room()`:
    `rooms.claims` when set, else falls back to `signal_room()` (which itself
    falls back to the legacy `room` scalar).
  - Extend `rooms_from_value` to parse `rooms.claims` from config JSON.
  - Add `LOOM_SAFEHOUSE_ROOM_CLAIMS` env const and wire it through
    `apply_room_env_overrides` (same precedence/enable-alone semantics as
    `LOOM_SAFEHOUSE_ROOM_SIGNAL`).
  - Switch `run_coordination`'s claim-ad connection/publish room resolution
    from `config.signal_room()` to `config.claims_room()`; update the doc
    comment to describe the new opt-in room and restate the cross-host
    bot-membership provisioning requirement. `run_sink` (narration) is
    untouched — it keeps using `signal_room()`/`RoomRouter` exactly as before.
  - Extend `mod tests` with parsing, fallback, env-override, and
    `run_coordination` routing cases for the new field (see Test Plan).
- `.loom/docs/safehouse.md`: update the "Which room claim ads ride" section to
  document `rooms.claims`/`LOOM_SAFEHOUSE_ROOM_CLAIMS`, its default-unchanged
  fallback, the cross-host provisioning caveat, and explicitly note that
  marker-based suppression (teaching `rjwalters/safehouse` to filter
  `loom_claim` envelopes) is a separate, out-of-scope, cross-repo follow-up.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| A human watching the signal room sees sweep-lifecycle narration but not 30s claim heartbeats, when `rooms.claims`/`LOOM_SAFEHOUSE_ROOM_CLAIMS` is configured to a distinct room | ✅ | `coordination_advertises_claim_ads_into_a_dedicated_claims_room_when_configured` asserts the outbound ad's `room` field is the configured claims room, not the signal room |
| Peer-claim liveness semantics unchanged (re-advertisement still every reaper tick under TTL; retracts still propagate) | ✅ | No change to `sweep_registry::readvertise_peer_claims` or `ClaimAd` semantics — only which room `run_coordination` writes into/reads from changed |
| No `rooms.claims` config and no `LOOM_SAFEHOUSE_ROOM_CLAIMS` ⇒ byte-identical to today (claim ads on signal room) | ✅ | `absent_rooms_map_is_byte_identical_single_room_behavior` extended to assert `claims_room() == room`; `coordination_advertises_claim_ads_into_the_signal_room` (existing test, still passing) covers the `rooms.signal`-set/`rooms.claims`-absent case |
| `SafehouseConfig::claims_room()` falls back to `signal_room()` when `rooms.claims` is absent | ✅ | `claims_room_falls_back_to_signal_room_when_absent` |
| `PeerClaimSink::on_event` unchanged — still room-agnostic on receipt | ✅ | No changes to `PeerClaimSink`/`on_event`; only the write-side room resolution changed |
| `.loom/docs/safehouse.md` updated with the new field and the provisioning caveat | ✅ | "Which room claim ads ride" section rewritten; env table and config example updated |
| Marker-based suppression noted as out of scope (not silently dropped) | ✅ | Explicit paragraph in the doc's "Which room claim ads ride" section |

## Test Plan

- `cargo test -p loom-daemon --lib safehouse::` — 97 passed, 0 failed (includes
  8 new/extended cases: `config_parses_the_rooms_map` extended,
  `config_parses_the_rooms_claims_field_alone`,
  `config_without_a_rooms_map_stays_in_single_room_mode` extended,
  `claims_room_falls_back_to_signal_room_when_absent`,
  `absent_rooms_map_is_byte_identical_single_room_behavior` extended,
  `env_overrides_config_for_the_rooms_map` extended,
  `env_alone_can_enable_routing_and_absent_env_changes_nothing` extended,
  `coordination_advertises_claim_ads_into_a_dedicated_claims_room_when_configured`).
- `cargo test -p loom-daemon --lib` (full crate) — 2745/2749 passed; the 4
  unrelated failures (`role_runner`, `runtime_admission`,
  `sweep_registry::runtime_rejection_precedes_every_dispatch_side_effect`,
  `tokens_pool::bad_tokens`) are pre-existing/environment-dependent — confirmed
  via `git diff --stat origin/main` that none of those files are touched by
  this PR.
- `cargo check -p loom-daemon --tests` and `cargo clippy -p loom-daemon --lib --tests -- -D warnings` scoped to `safehouse.rs` — clean (a pre-existing clippy
  failure in `observability/exporter.rs`, an untouched file, is unrelated).
- `cargo fmt -p loom-daemon -- --check` — clean.

## Pre-existing Issues (Not Addressed)

- `loom-daemon/src/observability/exporter.rs` fails `clippy::manual_split_once`
  under `-D warnings`; file is untouched by this PR.
- 4 flaky/environment-dependent test failures in `role_runner.rs`,
  `runtime_admission.rs`, `sweep_registry.rs`, `tokens_pool/bad_tokens.rs`
  (all unrelated files, zero diff vs `origin/main`).

Closes #4713