### PR TITLE
feat(daemon): add REPO column to status in-flight sweep table

### DIFF
--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -5445,6 +5445,56 @@ fn gate_status_short_label(verdict: &GateVerdict) -> &'static str {
     }
 }
 
+/// Render `SweepInfo.repo` for the in-flight table's `REPO` column: the
+/// basename of the workspace-root path (e.g. `/repos/loom` -> `loom`), or
+/// the value itself when it has no path separator (an `owner/repo` slug
+/// such as `rjwalters/vibesql` from some call sites is left as-is since
+/// `Path::file_name` already returns the last component in that case).
+/// Falls back to `"-"` when `repo` is `None`, matching the existing `phase`
+/// fallback convention in this table (#4698).
+fn format_repo_column(repo: Option<&str>) -> &str {
+    match repo {
+        Some(r) => Path::new(r)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(r),
+        None => "-",
+    }
+}
+
+/// Render the in-flight-sweeps table body (header + separator + one row per
+/// sweep, or the `(none)` placeholder) as a `String` — split out from
+/// [`print_status_human`] so the `REPO` column (#4698) is unit-testable
+/// without capturing process stdout.
+fn render_in_flight_table(report: &DaemonStatusReport) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    if report.in_flight.is_empty() {
+        out.push_str("  (none)\n");
+    } else {
+        let _ = writeln!(
+            out,
+            "  {:<30} {:>7} {:>8}  {:<20} {:<16} PHASE",
+            "SWEEP", "ISSUE", "PID", "TOKEN", "REPO"
+        );
+        let _ = writeln!(out, "  {:-<91}", "");
+        for s in &report.in_flight {
+            let issue = match &s.kind {
+                SweepKind::Issue(n) => format!("#{n}"),
+                SweepKind::PrSet(_) => "prs".to_string(),
+            };
+            let repo = format_repo_column(s.repo.as_deref());
+            let phase = s.latest_phase.as_deref().unwrap_or("-");
+            let _ = writeln!(
+                out,
+                "  {:<30} {:>7} {:>8}  {:<20} {:<16} {}",
+                s.sweep_id, issue, s.pid, s.token_name, repo, phase
+            );
+        }
+    }
+    out
+}
+
 /// Emit the combined status as a human-readable table.
 fn print_status_human(
     report: &DaemonStatusReport,
@@ -5456,23 +5506,7 @@ fn print_status_human(
     println!("\n=== Loom Autonomous Daemon Status ===\n");
 
     println!("In-flight sweeps: {}", report.in_flight.len());
-    if report.in_flight.is_empty() {
-        println!("  (none)");
-    } else {
-        println!("  {:<30} {:>7} {:>8}  {:<20} PHASE", "SWEEP", "ISSUE", "PID", "TOKEN");
-        println!("  {:-<75}", "");
-        for s in &report.in_flight {
-            let issue = match &s.kind {
-                SweepKind::Issue(n) => format!("#{n}"),
-                SweepKind::PrSet(_) => "prs".to_string(),
-            };
-            let phase = s.latest_phase.as_deref().unwrap_or("-");
-            println!(
-                "  {:<30} {:>7} {:>8}  {:<20} {}",
-                s.sweep_id, issue, s.pid, s.token_name, phase
-            );
-        }
-    }
+    print!("{}", render_in_flight_table(report));
 
     // Live-locked-but-unregistered sweeps (#4214): a sweep whose per-issue lock
     // has a live `owner_pid` but no matching in-flight entry above. Non-empty
@@ -9350,6 +9384,115 @@ mod status_client_tests {
             elapsed < Duration::from_secs(2),
             "absent-socket path took too long: {elapsed:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod in_flight_repo_column_tests {
+    //! The in-flight table's `REPO` column (#4698): five different managed
+    //! repos' small issue numbers (each repo's own `#3`/`#4`/`#6`) used to
+    //! look like duplicate same-issue dispatches with no way to disambiguate
+    //! them from `loom-daemon status` output alone, even though `SweepInfo`
+    //! already carried the owning workspace root (`repo`, Issue #3929).
+    use super::status_client_tests::sample_report;
+    use super::{format_repo_column, render_in_flight_table};
+    use chrono::Utc;
+    use loom_daemon::types::{SweepInfo, SweepKind, SweepState};
+    use std::path::PathBuf;
+
+    /// A minimal in-flight entry for a given issue/repo pair, mirroring the
+    /// `mk()` helper pattern used by `sweep_registry.rs`'s own tests.
+    fn mk(issue: u32, repo: Option<&str>) -> SweepInfo {
+        SweepInfo {
+            sweep_id: format!("s{issue}"),
+            kind: SweepKind::Issue(issue),
+            pid: 4242,
+            token_name: "agent-1.token".to_string(),
+            runtime: "claude".to_string(),
+            runtime_source: None,
+            log_path: PathBuf::from(format!(".loom/logs/sweep-issue-{issue}.log")),
+            idempotency_key: None,
+            started_at: Utc::now(),
+            state: SweepState::Running,
+            latest_phase: Some("builder".to_string()),
+            pr_number: None,
+            model: None,
+            effort: None,
+            depends_on: None,
+            repo: repo.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn format_repo_column_takes_path_basename() {
+        assert_eq!(format_repo_column(Some("/repos/loom")), "loom");
+        assert_eq!(format_repo_column(Some("/home/user/gf180-canary-3")), "gf180-canary-3");
+    }
+
+    #[test]
+    fn format_repo_column_leaves_bare_value_as_is() {
+        // A bare `owner/repo` slug (e.g. from `loom-daemon/src/ipc.rs`'s
+        // `"rjwalters/vibesql"`) has no meaningful "directory" component
+        // beyond its own last segment — `Path::file_name` already reduces it
+        // to `vibesql`, matching the workspace-root basename convention.
+        assert_eq!(format_repo_column(Some("rjwalters/vibesql")), "vibesql");
+        assert_eq!(format_repo_column(Some("loom")), "loom");
+    }
+
+    #[test]
+    fn format_repo_column_falls_back_to_dash_when_none() {
+        assert_eq!(format_repo_column(None), "-");
+    }
+
+    #[test]
+    fn table_header_advertises_repo_column() {
+        let mut report = sample_report();
+        report.in_flight = vec![mk(3, Some("/repos/loom"))];
+        let table = render_in_flight_table(&report);
+        assert!(
+            table.lines().next().unwrap().contains("REPO"),
+            "expected REPO in the table header, got: {table}"
+        );
+    }
+
+    #[test]
+    fn distinguishes_same_issue_number_across_repos() {
+        // The #4698 scenario: two different repos each dispatching their own
+        // issue #3 must no longer look like the same duplicate dispatch.
+        let mut report = sample_report();
+        report.in_flight = vec![
+            mk(3, Some("/repos/loom")),
+            mk(3, Some("/repos/gf180-canary-2")),
+        ];
+        let table = render_in_flight_table(&report);
+        assert!(table.contains("loom"), "expected repo basename 'loom' in: {table}");
+        assert!(
+            table.contains("gf180-canary-2"),
+            "expected repo basename 'gf180-canary-2' in: {table}"
+        );
+    }
+
+    #[test]
+    fn missing_repo_renders_dash_without_panicking_or_misaligning() {
+        let mut report = sample_report();
+        report.in_flight = vec![mk(4, None)];
+        let table = render_in_flight_table(&report);
+        let row = table.lines().nth(2).expect("header + separator + row");
+        assert!(row.contains(" - "), "expected a lone '-' placeholder in row: {row}");
+    }
+
+    #[test]
+    fn single_repo_fleet_stays_readable() {
+        // AC3: with only one managed repo, every row just repeats the same
+        // basename — no conditional collapsing needed, alignment still holds.
+        let mut report = sample_report();
+        report.in_flight = vec![mk(1, Some("/repos/loom")), mk(2, Some("/repos/loom"))];
+        let table = render_in_flight_table(&report);
+        let lines: Vec<&str> = table.lines().collect();
+        assert_eq!(lines.len(), 4, "header + separator + 2 rows, got: {table}");
+        for row in &lines[2..] {
+            assert!(row.contains("loom"), "expected 'loom' in row: {row}");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

`loom-daemon status`'s in-flight table (`print_status_human` in
`loom-daemon/src/main.rs`) rendered `SWEEP / ISSUE / PID / TOKEN / PHASE`
columns but no `REPO` column, even though `SweepInfo` already carries a
`repo: Option<String>` field (#3929). Under multi-repo fleet operation,
different repos routinely have their own issue `#3`, `#4`, `#6`, etc., so
the `ISSUE` column alone read as duplicate same-issue dispatches (the
#4463 bug class) when it was actually normal multi-repo activity. This
brings the CLI table to parity with the dashboard's registry panel, which
already renders `sweep.repo`.

## Changes

- `format_repo_column()`: renders the basename of `SweepInfo.repo` (via
  `Path::file_name`), falling back to `"-"` when `repo` is `None`,
  matching the existing `phase` fallback convention in the same table. A
  bare `owner/repo` slug (no path separator) is left as its last segment
  since `Path::file_name` already reduces it that way.
- `render_in_flight_table()`: extracted the table-rendering body out of
  `print_status_human` into its own function returning a `String`, so the
  new `REPO` column is unit-testable without capturing process stdout.
  `print_status_human` now just prints the rendered string.
- Header gains a `REPO` column between `TOKEN` and `PHASE`; separator
  width increases from 75 to 91 dashes to match.
- Added `in_flight_repo_column_tests` covering: path-basename extraction,
  bare-slug pass-through, the `None -> "-"` fallback, the header
  advertising `REPO`, disambiguating the same issue number across two
  repos, a missing-repo row rendering `-` without panicking/misaligning,
  and single-repo-fleet readability.

No changes to `loom-daemon/src/dashboard.html` (already renders `repo`)
or `loom-daemon/src/fleet/status.rs` (no per-sweep rows to extend) — both
confirmed to stay as-is, per the curated issue's narrowing of the
original acceptance criteria.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `print_status_human`'s in-flight table gains a `REPO` column, rendering the basename of `SweepInfo.repo`, falling back to `"-"` on `None` | ✅ | `format_repo_column()` + header/row changes in `render_in_flight_table()`; `format_repo_column_takes_path_basename`, `format_repo_column_falls_back_to_dash_when_none` tests |
| Single-repo fleet stays readable, no conditional collapsing logic required | ✅ | `single_repo_fleet_stays_readable` test asserts alignment (4 lines: header + separator + 2 rows) with the same basename repeated |
| No change needed to `dashboard.html` or `fleet/status.rs`; both confirmed to stay as-is | ✅ | Only `loom-daemon/src/main.rs` touched (`git diff --stat`) |
| `loom-daemon status --json` output unaffected (human-table-rendering only) | ✅ | No changes to `DaemonStatusReport`/`SweepInfo` serialization; only the human-readable rendering functions were touched |

## Test Plan

- `cargo test --bin loom-daemon in_flight_repo_column_tests` — all 7 new tests pass:
  - `format_repo_column_takes_path_basename` — `/repos/loom` -> `loom`, `/home/user/gf180-canary-3` -> `gf180-canary-3`
  - `format_repo_column_leaves_bare_value_as_is` — `rjwalters/vibesql` -> `vibesql` (an `owner/repo` slug from `ipc.rs`)
  - `format_repo_column_falls_back_to_dash_when_none` — `None` -> `"-"`
  - `table_header_advertises_repo_column` — header line contains `REPO`
  - `distinguishes_same_issue_number_across_repos` — two entries both for issue `#3` (repos `/repos/loom` and `/repos/gf180-canary-2`) both appear distinguishably in the rendered table (the exact #4698 scenario)
  - `missing_repo_renders_dash_without_panicking_or_misaligning` — a `SweepInfo` with `repo: None` renders a lone `-` in its row
  - `single_repo_fleet_stays_readable` — two rows sharing the same repo basename, table stays 4 lines (header + separator + 2 rows)
- `cargo test --bin loom-daemon status_client_tests` — pre-existing status-rendering tests still pass (3/3), confirming no regression to the surrounding `print_status_human`/status-client code paths
- `cargo build --lib --bin loom-daemon` — compiles cleanly
- `cargo fmt` — clean
- Note: `cargo clippy --bin loom-daemon --tests` fails on a pre-existing, unrelated lint in `loom-daemon/src/observability/exporter.rs` (`manual_split_once`, from already-merged #4710) — not touched by this PR, confirmed via `git diff --stat` showing only `loom-daemon/src/main.rs` changed

Closes #4698