### PR TITLE
feat(safehouse): source completion tokens from sweep transcripts when the activity DB is unreachable

### DIFF
--- a/.loom/docs/safehouse.md
+++ b/.loom/docs/safehouse.md
@@ -626,17 +626,66 @@ what feeds the public fleet feed on 2amlogic.com. Loom is the producer:
   - Unlike `tokens`, a real **`0`** additions/deletions is a fact about the merge
     (an empty-diff merge, a pure revert) and is published as `0`; a blank `title`
     is omitted.
-  - `tokens` is a best-effort **input + output** total from the in-process
-    activity DB's per-issue rollup (`ActivityDb::get_cost_by_issue`), read on the
-    blocking pool with a 5s cap. **Attribution is knowingly imperfect** — the
-    rollup keys on a bare issue number (no repo column, so a multi-repo daemon
-    conflates identical numbers across repos) and only counts token samples that
-    are linked to the issue through `agent_inputs`, making the figure a floor.
-    That is a deliberate operator call: for a cost *trend*,
-    imperfect-but-consistent beats absent. An empty or zero rollup omits the key
-    rather than charting free work.
+  - `tokens` is a best-effort per-issue total from **two** sources, tried in
+    order, each on the blocking pool with its own 5s cap:
+    1. The in-process activity DB's per-issue rollup
+       (`ActivityDb::get_cost_by_issue`) — **input + output**.
+    2. **The sweep's own on-disk Claude Code transcripts** (#4699) — all four
+       usage counters (`input`, `output`, `cache_read`, `cache_creation`), i.e.
+       total tokens processed.
+
+    **Attribution is knowingly imperfect** for both. The rollup keys on a bare
+    issue number (no repo column, so a multi-repo daemon conflates identical
+    numbers across repos) and only counts token samples linked to the issue
+    through `agent_inputs`, making the figure a floor. That is a deliberate
+    operator call: for a cost *trend*, imperfect-but-consistent beats absent.
+    Both sources coming up empty omits the key rather than charting free work.
+
+    > **Operational gotcha — why the DB rollup is silent on a fleet host
+    > (#4699).** The `resource_usage` and `prompt_github` rows the rollup joins
+    > are written from exactly **one** place: the IPC `GetTerminalOutput` handler
+    > scraping a *managed terminal's* scrollback. `dispatch_sweep` spawns a
+    > detached `claude -p` via `spawn-worker.sh` and reaps the OS process — it
+    > issues no `SendInput`/`GetTerminalOutput` round trips — so on any host whose
+    > work arrives by dispatch (i.e. every host that publishes to the feed) both
+    > tables are empty **forever**, not merely "until the prompt↔usage linkage is
+    > established". Measured on the reference host 2026-07-31: 0 rows in each,
+    > across 76 published completions, every one of them `tokens: null`. Source 2
+    > exists because of this; do not diagnose a `tokens: null` feed record by
+    > looking for missing rollup rows.
+
+    The transcript source locates a sweep's session by content, since nothing
+    records a sweep-id → session-uuid mapping: a sweep runs `claude -p
+    "/loom:sweep <issue> …"` with cwd = the workspace root, so Claude Code writes
+    `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/<cwd-slug>/<uuid>.jsonl` (plus
+    `<uuid>/subagents/agent-*.jsonl`, one per phase), and the parent session's
+    first `user` record carries the slash command verbatim. Candidates are
+    narrowed by file mtime against the completion's own time window (±2h slack)
+    before any file is read, and a re-dispatched issue's several sessions are all
+    summed. Because the project directory is keyed by the workspace path, this
+    source *is* repo-qualified — it does not share the rollup's cross-repo
+    issue-number conflation. Cache reads are included because they dominate a
+    sweep both by volume (~99%) and — priced at ~10% of base — by cost, so an
+    input+output-only figure under-reports spend by well over an order of
+    magnitude and unevenly between sweeps. Set
+    `LOOM_SAFEHOUSE_TRANSCRIPT_TOKENS=0` to opt out of the transcript scan
+    entirely (the key is then simply omitted on dispatch-driven hosts).
   - Absent `tokens`/`title`/`additions`/`deletions` ⇒ the envelope is identical
     to the pre-#4497 one; none of the four can block or fail an emission.
+
+  > **A `null` field on 2amlogic.com is not evidence of a producer bug (#4699).**
+  > The public feed applies its **own** server-side redaction on read: entries
+  > whose `repo` is not on the site's linked-repo allowlist are served with
+  > `ref` and `title` forced to `null`, keeping the sellable columns
+  > (`repo#issue`, diff stats, timing) while withholding the outbound link. So a
+  > mix of linked and unlinked repos in one feed response legitimately shows
+  > `title: null` next to a populated `additions`. Loom itself cannot emit a
+  > null/absent `ref` at all — it is in `COMPLETION_REQUIRED_KEYS`, so
+  > `validate_completion_meta` rejects the envelope before it can be sent (and
+  > the site's `/api/ingest` validator independently rejects such a payload with
+  > a `400`). **Before filing a producer bug, check the feed record's `repo`
+  > against the site's allowlist and compare against a linked repo's record from
+  > the same tick.**
 - **Timestamps** come from the reaper's clock (`started_at = exit − duration_sec`,
   `completed_at = exit`), so the pair is always self-consistent.
 - **`result: "failure"` is out of scope for v1**: `completion-v1` requires a
@@ -706,6 +755,12 @@ what feeds the public fleet feed on 2amlogic.com. Loom is the producer:
   `AttentionClass` (the exhaustive kind → tier table), `RoomRouter` (per-envelope
   room resolution, lazy `fleet-<repo>` creation, warn-once degradation) and
   `SafehouseClient::send_to` / `create_room`.
+- `loom-daemon/src/transcript_tokens.rs` — (#4699) the on-disk token source
+  behind the completion envelope's `tokens` field: Claude Code's project-slug
+  mangling, the `/loom:sweep <issue>` session match, mtime windowing and the
+  parent+subagents usage sum. Pure filesystem code with no safehouse dependency,
+  so it is unit-testable on its own; `safehouse.rs` wraps it in the timeout and
+  the `LOOM_SAFEHOUSE_TRANSCRIPT_TOKENS` opt-out.
 - `loom-daemon/src/peer_claims.rs` — the pure, socket-free peer-claim view
   (TTL expiry, self-claim recognition, retraction, `ClaimAd` parse/serialize).
 - `loom-daemon/src/workspace_pool.rs` — `start_safehouse_narration()` and

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -197,6 +197,7 @@ pub mod test_log_capture;
 pub mod token_ranking_refresh;
 pub mod tokens;
 pub mod tokens_pool;
+pub mod transcript_tokens;
 pub mod types;
 pub mod watch_registry;
 pub mod work_finder;

--- a/loom-daemon/src/safehouse.rs
+++ b/loom-daemon/src/safehouse.rs
@@ -1552,14 +1552,13 @@ async fn fetch_repo_slug_cached(
     Some(slug)
 }
 
-/// Best-effort per-issue token total for a `completion` envelope (#4497):
-/// `sum(input + output)` over the activity DB's per-issue cost rollup
-/// ([`ActivityDb::get_cost_by_issue`]). The DB is already in-process, so this
-/// needs no forge call and no new accounting.
+/// Best-effort per-issue token total from the activity DB's per-issue cost
+/// rollup ([`ActivityDb::get_cost_by_issue`]): `sum(input + output)`. The DB is
+/// already in-process, so this needs no forge call and no new accounting.
 ///
 /// **Attribution is imperfect, by explicit operator decision** — for a cost
-/// *trend*, imperfect-but-consistent beats absent. Two known limits, documented
-/// here rather than papered over:
+/// *trend*, imperfect-but-consistent beats absent. Three known limits,
+/// documented here rather than papered over:
 ///
 /// 1. **Not repo-qualified.** The activity DB's forge-correlation table keys on
 ///    a bare issue number with no repo column, so a daemon managing several
@@ -1567,14 +1566,22 @@ async fn fetch_repo_slug_cached(
 /// 2. **Only as good as the prompt↔usage linkage.** The rollup joins recorded
 ///    token samples to an issue through `agent_inputs`; samples recorded without
 ///    that link contribute nothing, so the figure is a **floor**, not a full
-///    accounting — and is empty on hosts where nothing has established the link
-///    yet, in which case the key is simply omitted.
+///    accounting.
+/// 3. **Unreachable from the dispatch path (#4699).** The `resource_usage` and
+///    `prompt_github` rows this rollup joins are written from exactly one place,
+///    the IPC `GetTerminalOutput` handler scraping a *managed terminal's*
+///    scrollback. `dispatch_sweep` spawns a detached `claude -p` and reaps the
+///    OS process — no `SendInput`/`GetTerminalOutput` round trips — so on a
+///    dispatch-driven host both tables stay empty forever and this returns
+///    `None` unconditionally. That is why [`fetch_issue_tokens`] falls back to
+///    the on-disk transcripts; this remains first only because it is the cheaper
+///    lookup on hosts that *do* drive managed terminals.
 ///
 /// Every failure — no DB handle, a poisoned mutex, a query error, a timeout, an
 /// empty rollup — degrades to `None`. A zero total is likewise indistinguishable
 /// from "accounting had nothing" and is filtered out downstream by
 /// [`CompletionMeta::to_meta_value`], so no bogus `0` reaches the feed.
-async fn fetch_issue_tokens(
+async fn fetch_activity_db_tokens(
     activity_db: Option<&Arc<Mutex<ActivityDb>>>,
     issue: u32,
 ) -> Option<u64> {
@@ -1600,6 +1607,70 @@ async fn fetch_issue_tokens(
         .await
         .ok()?
         .ok()?
+        .filter(|total| *total > 0)
+}
+
+/// Whether the on-disk transcript fallback is enabled. Opt **out** with
+/// `LOOM_SAFEHOUSE_TRANSCRIPT_TOKENS=0` (also `false`/`off`/`no`) on a host
+/// where scanning the Claude Code project directory is unwanted; any other
+/// value, or the variable being unset, leaves it on.
+fn transcript_tokens_enabled() -> bool {
+    match std::env::var("LOOM_SAFEHOUSE_TRANSCRIPT_TOKENS") {
+        Ok(v) => !matches!(v.trim().to_ascii_lowercase().as_str(), "0" | "false" | "off" | "no"),
+        Err(_) => true,
+    }
+}
+
+/// Per-issue token total from the sweep's own Claude Code transcripts — the
+/// source that the daemon **dispatch** path actually populates (#4699).
+///
+/// Delegates to [`crate::transcript_tokens`] (see that module for how a sweep's
+/// session is located and why the total includes cache tokens). Runs on the
+/// blocking pool under the same [`TOKEN_LOOKUP_TIMEOUT`] as the DB lookup, so a
+/// slow or pathological project directory can never delay a completion by more
+/// than the lookup budget; a timeout degrades to `None` like every other
+/// failure.
+async fn fetch_transcript_tokens(
+    workspace_root: &str,
+    issue: u32,
+    window: (DateTime<Utc>, DateTime<Utc>),
+) -> Option<u64> {
+    if !transcript_tokens_enabled() {
+        return None;
+    }
+    let projects = crate::transcript_tokens::claude_projects_dir()?;
+    let root = PathBuf::from(workspace_root);
+    let scan = tokio::task::spawn_blocking(move || {
+        crate::transcript_tokens::sum_sweep_tokens(&projects, &root, issue, Some(window))
+    });
+    tokio::time::timeout(TOKEN_LOOKUP_TIMEOUT, scan)
+        .await
+        .ok()?
+        .ok()?
+}
+
+/// Best-effort per-issue token total for a `completion` envelope (#4497,
+/// #4699): the activity DB rollup when the host has one, else the sweep's
+/// on-disk transcripts.
+///
+/// The two sources answer with different fidelity — the DB reports
+/// `input + output`, the transcripts report all four usage counters (cache reads
+/// included, which dominate a sweep both by volume and by cost). The DB is tried
+/// first purely because it is cheaper; on a dispatch-driven host it never
+/// answers at all (see [`fetch_activity_db_tokens`] limit 3), so in practice the
+/// transcript figure is what the fleet feed publishes. Both degrade to `None`
+/// independently, and a `None` omits the key rather than publishing a
+/// misleading `0`.
+async fn fetch_issue_tokens(
+    activity_db: Option<&Arc<Mutex<ActivityDb>>>,
+    issue: u32,
+    workspace_root: &str,
+    window: (DateTime<Utc>, DateTime<Utc>),
+) -> Option<u64> {
+    if let Some(total) = fetch_activity_db_tokens(activity_db, issue).await {
+        return Some(total);
+    }
+    fetch_transcript_tokens(workspace_root, issue, window).await
 }
 
 /// The Option-B emit point (#4426): on a `SweepExited`, verify against forge
@@ -1693,14 +1764,17 @@ async fn build_and_narrate_completion(
         return None;
     }
     let slug = fetch_repo_slug_cached(slug_cache, workspace_root).await?;
-    // Only reached once the merge is confirmed, so a completion is never delayed
-    // by a token lookup it would not have published.
-    let tokens = fetch_issue_tokens(activity_db, issue).await;
 
     // Timing comes from the one clock the caller had available, so the pair is
     // always self-consistent — mixing clocks across callers could render a
     // `completed_at` before `started_at`.
     let started_at = exited_at - chrono::Duration::seconds(duration_sec.max(0));
+    // Only reached once the merge is confirmed, so a completion is never delayed
+    // by a token lookup it would not have published. The window narrows the
+    // transcript fallback's candidate set to sessions that overlap this
+    // completion, so it must be computed before the lookup.
+    let tokens =
+        fetch_issue_tokens(activity_db, issue, workspace_root, (started_at, exited_at)).await;
     let meta = CompletionMeta {
         agent: persona.to_owned(),
         repo_slug: slug,
@@ -4956,15 +5030,60 @@ mod tests {
         assert!(build_send_request(&envelope, 1, None).is_ok());
     }
 
+    /// Point `CLAUDE_CONFIG_DIR` at an empty directory so the #4699 transcript
+    /// fallback is exercised hermetically rather than against whatever sweeps
+    /// the developer's real `~/.claude` happens to hold.
+    fn isolate_claude_config_dir(dir: &Path) -> PathBuf {
+        let config = dir.join("claude-config");
+        std::fs::create_dir_all(config.join("projects")).unwrap();
+        std::env::set_var("CLAUDE_CONFIG_DIR", &config);
+        config
+    }
+
+    /// Seed one `/loom:sweep <issue>` session transcript for `workspace_root`
+    /// under `config_dir`, laid out exactly as Claude Code writes it: the parent
+    /// `<uuid>.jsonl` plus one `<uuid>/subagents/agent-*.jsonl` phase file.
+    fn seed_sweep_transcript(config_dir: &Path, workspace_root: &Path, issue: u32) {
+        let project = config_dir
+            .join("projects")
+            .join(crate::transcript_tokens::project_slug(workspace_root));
+        std::fs::create_dir_all(project.join("uuid-1/subagents")).unwrap();
+        let head = format!(
+            "{{\"type\":\"user\",\"message\":{{\"content\":\
+             \"<command-name>/loom:sweep</command-name>\\n\
+             <command-args>{issue} --claim-owned {issue}</command-args>\"}}}}\n"
+        );
+        let usage = |input: u32, output: u32, read: u32, create: u32| {
+            format!(
+                "{{\"message\":{{\"usage\":{{\"input_tokens\":{input},\
+                 \"output_tokens\":{output},\"cache_read_input_tokens\":{read},\
+                 \"cache_creation_input_tokens\":{create}}}}}}}\n"
+            )
+        };
+        std::fs::write(
+            project.join("uuid-1.jsonl"),
+            format!("{head}{}", usage(1_000, 2_000, 30_000, 4_000)),
+        )
+        .unwrap();
+        std::fs::write(
+            project.join("uuid-1/subagents/agent-bld.jsonl"),
+            usage(100, 200, 3_000, 400),
+        )
+        .unwrap();
+    }
+
     #[tokio::test]
     #[serial]
     async fn completion_for_exit_omits_tokens_when_the_rollup_is_empty() {
         // "Omit rather than guess": an activity DB with no rollup for this issue
-        // must not publish a `0`, which the feed would chart as free work.
+        // must not publish a `0`, which the feed would chart as free work. With
+        // #4699 the transcript fallback must come up empty too — hence the
+        // isolated (and unseeded) `CLAUDE_CONFIG_DIR`.
         let dir = tempfile::tempdir().unwrap();
         let (fake_gh, _log) =
             write_fake_forge_gh(dir.path(), Some(MERGED_PR_JSON), Some("rjwalters/loom"));
         std::env::set_var(GH_BIN_ENV, &fake_gh);
+        isolate_claude_config_dir(dir.path());
 
         // Seeded for a *different* issue, so this issue's rollup is empty.
         let db = seed_activity_db_with_issue_tokens(dir.path(), 999, 12_345, 678);
@@ -4982,6 +5101,7 @@ mod tests {
         .await;
 
         std::env::remove_var(GH_BIN_ENV);
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
         let meta = envelope
             .as_ref()
             .and_then(|e| e.meta.as_ref())
@@ -4989,6 +5109,116 @@ mod tests {
         assert!(meta.get("tokens").is_none(), "an empty rollup ⇒ omitted, not 0");
         // The forge-sourced display fields are unaffected by the token miss.
         assert_eq!(meta["title"], json!("feat: enrich completion meta"));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn completion_for_exit_falls_back_to_sweep_transcripts_when_the_db_is_empty() {
+        // Regression for #4699: on a dispatch-driven host the activity DB's
+        // `resource_usage`/`prompt_github` tables have no writer at all, so the
+        // rollup is *structurally* empty and every published completion carried
+        // `tokens: null`. The sweep's own on-disk transcripts must supply the
+        // total instead — parent session + every subagent phase file, all four
+        // usage counters (cache reads included).
+        let dir = tempfile::tempdir().unwrap();
+        let (fake_gh, _log) =
+            write_fake_forge_gh(dir.path(), Some(MERGED_PR_JSON), Some("rjwalters/loom"));
+        std::env::set_var(GH_BIN_ENV, &fake_gh);
+        let config = isolate_claude_config_dir(dir.path());
+        seed_sweep_transcript(&config, dir.path(), 4426);
+
+        // No activity DB handle at all — the exact shape of the dispatch path.
+        let envelope = completion_for_exit(
+            "loom_daemon",
+            &dir.path().to_string_lossy(),
+            4426,
+            750,
+            Utc::now(),
+            &mut HashMap::new(),
+            &mut std::collections::HashSet::new(),
+            None,
+        )
+        .await;
+
+        std::env::remove_var(GH_BIN_ENV);
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
+        let envelope = envelope.expect("a merged PR must produce a completion envelope");
+        let meta = envelope.meta.as_ref().unwrap();
+        // parent 37_000 + subagent 3_700
+        assert_eq!(
+            meta["tokens"],
+            json!(40_700),
+            "tokens must come from the transcripts when the DB rollup is empty"
+        );
+        assert!(build_send_request(&envelope, 1, None).is_ok());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn completion_for_exit_prefers_the_activity_db_over_the_transcripts() {
+        // The DB is the cheaper lookup and stays authoritative on hosts that do
+        // drive managed terminals; the transcript scan is a fallback, not an
+        // override. Both sources are present here, so the DB figure must win.
+        let dir = tempfile::tempdir().unwrap();
+        let (fake_gh, _log) =
+            write_fake_forge_gh(dir.path(), Some(MERGED_PR_JSON), Some("rjwalters/loom"));
+        std::env::set_var(GH_BIN_ENV, &fake_gh);
+        let config = isolate_claude_config_dir(dir.path());
+        seed_sweep_transcript(&config, dir.path(), 4426);
+
+        let db = seed_activity_db_with_issue_tokens(dir.path(), 4426, 700_000, 91_000);
+
+        let envelope = completion_for_exit(
+            "loom_daemon",
+            &dir.path().to_string_lossy(),
+            4426,
+            750,
+            Utc::now(),
+            &mut HashMap::new(),
+            &mut std::collections::HashSet::new(),
+            Some(&db),
+        )
+        .await;
+
+        std::env::remove_var(GH_BIN_ENV);
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
+        let meta = envelope.as_ref().and_then(|e| e.meta.as_ref()).unwrap();
+        assert_eq!(meta["tokens"], json!(791_000), "the DB rollup wins when non-empty");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn the_transcript_fallback_can_be_disabled_by_env() {
+        // Escape hatch for an operator who does not want the completion path
+        // reading the Claude Code project directory at all.
+        let dir = tempfile::tempdir().unwrap();
+        let (fake_gh, _log) =
+            write_fake_forge_gh(dir.path(), Some(MERGED_PR_JSON), Some("rjwalters/loom"));
+        std::env::set_var(GH_BIN_ENV, &fake_gh);
+        let config = isolate_claude_config_dir(dir.path());
+        seed_sweep_transcript(&config, dir.path(), 4426);
+        std::env::set_var("LOOM_SAFEHOUSE_TRANSCRIPT_TOKENS", "0");
+
+        let envelope = completion_for_exit(
+            "loom_daemon",
+            &dir.path().to_string_lossy(),
+            4426,
+            750,
+            Utc::now(),
+            &mut HashMap::new(),
+            &mut std::collections::HashSet::new(),
+            None,
+        )
+        .await;
+
+        std::env::remove_var(GH_BIN_ENV);
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
+        std::env::remove_var("LOOM_SAFEHOUSE_TRANSCRIPT_TOKENS");
+        let meta = envelope
+            .as_ref()
+            .and_then(|e| e.meta.as_ref())
+            .expect("opting out of the fallback must not cost the completion");
+        assert!(meta.get("tokens").is_none(), "opted out ⇒ tokens omitted");
     }
 
     #[tokio::test]

--- a/loom-daemon/src/transcript_tokens.rs
+++ b/loom-daemon/src/transcript_tokens.rs
@@ -1,0 +1,404 @@
+//! On-disk transcript token accounting for the safehouse completion feed (#4699).
+//!
+//! # Why this module exists
+//!
+//! The `completion-v1` envelope's `tokens` field (#4497) was originally sourced
+//! **only** from the activity DB's per-issue cost rollup
+//! ([`crate::activity::db::ActivityDb::get_cost_by_issue`]), whose SQL joins
+//! `resource_usage -> agent_inputs -> prompt_github`. Every row in those two
+//! analytics tables is written from exactly one place — the IPC
+//! `GetTerminalOutput` handler, which scrapes a *managed terminal's* scrollback
+//! (`ipc.rs`, the MOM/terminal-manager path).
+//!
+//! Daemon-dispatched sweeps never traverse that path. `dispatch_sweep` spawns a
+//! detached `claude -p` through `spawn-worker.sh`/`spawn-claude.sh` and reaps the
+//! OS process; it issues no `SendInput`/`GetTerminalOutput` IPC round trips at
+//! all. So on any host whose work arrives via dispatch — i.e. every host that
+//! publishes completions to the fleet feed — the rollup is not "empty until the
+//! prompt↔usage linkage is established", it is **structurally empty forever**,
+//! and `tokens` was unconditionally `null`. Measured on the reference fleet host
+//! 2026-07-31: `resource_usage` 0 rows, `prompt_github` 0 rows, DB file untouched
+//! for two days across 76 published completions.
+//!
+//! The token data itself is on disk the whole time, in the sweep's own Claude
+//! Code transcripts. This module locates them and sums them, so `tokens` has a
+//! source that the dispatch path actually populates.
+//!
+//! # How a sweep's transcripts are located
+//!
+//! A sweep runs `claude -p "/loom:sweep <issue> …"` with cwd = the workspace
+//! root, so Claude Code writes its session under
+//! `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/<cwd-slug>/`:
+//!
+//! ```text
+//! <projects>/-Users-me-GitHub-loom/
+//!   <session-uuid>.jsonl            # parent session (the /loom:sweep turn)
+//!   <session-uuid>/subagents/
+//!     agent-<id>.jsonl              # one per phase (builder, judge, …)
+//! ```
+//!
+//! There is no sweep-id → session-uuid mapping recorded anywhere, so the join is
+//! done by content: the parent session's first `user` line carries the slash
+//! command verbatim (`<command-name>/loom:sweep</command-name>` plus
+//! `<command-args>4705 --claim-owned 4705</command-args>`). Candidates are first
+//! narrowed by file mtime against the completion's own time window, so a
+//! long-lived project directory is not head-read in full on every completion.
+//!
+//! # Fidelity
+//!
+//! The returned figure is the sum of **all four** usage counters
+//! (`input_tokens`, `output_tokens`, `cache_read_input_tokens`,
+//! `cache_creation_input_tokens`) across the parent session and every subagent
+//! transcript — total tokens processed. Cache reads dominate a sweep by volume
+//! (~99% on measured runs) and, priced at ~10% of base, still dominate it by
+//! cost, so an input+output-only figure would under-report actual spend by well
+//! over an order of magnitude and do so unevenly between sweeps. This differs
+//! from the activity-DB rollup's narrower `input + output`; the difference is
+//! documented in `.loom/docs/safehouse.md` and the DB path is left untouched.
+//!
+//! Re-dispatched sweeps produce several sessions for one issue; all matching
+//! sessions are summed, since the feed reports what the issue cost in total.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use chrono::{DateTime, Utc};
+
+use crate::script_helpers::sweep_experiment::sum_transcript_usage;
+
+/// Bytes of each candidate session file read when testing it for the
+/// `/loom:sweep <issue>` slash command. The command is in the first `user`
+/// record, a few hundred bytes in; 64 KiB is generous headroom for the
+/// `queue-operation` preamble without reading multi-megabyte transcripts.
+pub const HEAD_SCAN_BYTES: usize = 64 * 1024;
+
+/// Slack applied to both ends of the completion's time window when filtering
+/// candidate sessions by mtime. Covers clock skew, a session flushed after the
+/// reaper observed the exit, and `reconcile_recent_merges`' forge-derived
+/// (rather than sweep-derived) start time.
+pub const WINDOW_SLACK: Duration = Duration::from_secs(2 * 60 * 60);
+
+/// Per-file size ceiling. A transcript above this is skipped rather than read
+/// into memory: the summation helper reads whole files, and one pathological
+/// transcript must not be able to balloon the daemon's RSS on a code path whose
+/// entire output is an optional display field.
+pub const MAX_TRANSCRIPT_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Claude Code's project-directory slug: every character outside `[A-Za-z0-9-]`
+/// becomes `-`. `/Users/me/GitHub/lean-genius/.loom/worktrees/x` therefore maps
+/// to `-Users-me-GitHub-lean-genius--loom-worktrees-x` (the `/` and the `.`
+/// each contribute one `-`, hyphens already in a path component survive).
+#[must_use]
+pub fn project_slug(workspace_root: &Path) -> String {
+    workspace_root
+        .to_string_lossy()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+/// `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects`, or `None` when neither the
+/// override nor a home directory resolves.
+#[must_use]
+pub fn claude_projects_dir() -> Option<PathBuf> {
+    let base = std::env::var_os("CLAUDE_CONFIG_DIR")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".claude")))?;
+    Some(base.join("projects"))
+}
+
+/// Whether `head` — the leading bytes of a Claude Code session transcript —
+/// shows that session being launched as `/loom:sweep <issue> …`.
+///
+/// The slash command is recorded as JSON-escaped markup inside the first `user`
+/// record, so this matches on the two literal tags rather than parsing the line.
+/// The issue number must be the **first** whitespace-delimited argument, so
+/// `/loom:sweep 470 --claim-owned 470` is not mistaken for issue `4705`, and an
+/// unrelated later mention of the number cannot match.
+#[must_use]
+pub fn head_names_sweep_issue(head: &str, issue: u32) -> bool {
+    const NAME_TAG: &str = "<command-name>/loom:sweep</command-name>";
+    const ARGS_OPEN: &str = "<command-args>";
+
+    let Some(after_name) = head.find(NAME_TAG).map(|i| i + NAME_TAG.len()) else {
+        return false;
+    };
+    let Some(args_at) = head[after_name..].find(ARGS_OPEN).map(|i| after_name + i) else {
+        return false;
+    };
+    let args = &head[args_at + ARGS_OPEN.len()..];
+    // Stop at the closing tag if it is within the head slice; a truncated head
+    // still yields the first token, which is all that is inspected.
+    let args = args.split("</command-args>").next().unwrap_or(args);
+    args.split_whitespace()
+        .next()
+        .and_then(|tok| tok.parse::<u32>().ok())
+        == Some(issue)
+}
+
+/// Read at most [`HEAD_SCAN_BYTES`] from `path`, lossily decoded.
+fn read_head(path: &Path) -> Option<String> {
+    use std::io::Read as _;
+    let mut file = std::fs::File::open(path).ok()?;
+    let mut buf = vec![0_u8; HEAD_SCAN_BYTES];
+    let mut filled = 0;
+    while filled < buf.len() {
+        match file.read(&mut buf[filled..]) {
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            Err(_) => return None,
+        }
+    }
+    buf.truncate(filled);
+    Some(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// Whether `mtime` falls inside `[start - slack, end + slack]`. A file whose
+/// mtime cannot be read is kept (fail-open: a missed match costs a token total,
+/// a spurious one costs only a head read).
+fn mtime_in_window(path: &Path, window: Option<(DateTime<Utc>, DateTime<Utc>)>) -> bool {
+    let Some((start, end)) = window else {
+        return true;
+    };
+    let Ok(mtime) = std::fs::metadata(path).and_then(|m| m.modified()) else {
+        return true;
+    };
+    // `checked_*` rather than the panicking operators: an absurd timestamp
+    // (a zeroed/garbage `createdAt` reaching the reconciliation path) must
+    // widen the window, never abort the completion.
+    let lo = SystemTime::from(start).checked_sub(WINDOW_SLACK);
+    let hi = SystemTime::from(end).checked_add(WINDOW_SLACK);
+    lo.is_none_or(|lo| mtime >= lo) && hi.is_none_or(|hi| mtime <= hi)
+}
+
+/// Every transcript belonging to `session`: the parent `<uuid>.jsonl` plus each
+/// `<uuid>/subagents/*.jsonl`. Subagent records are not duplicated into the
+/// parent file (the parent carries no `isSidechain` records), so summing both
+/// does not double-count.
+fn session_transcripts(session_jsonl: &Path) -> Vec<PathBuf> {
+    let mut out = vec![session_jsonl.to_path_buf()];
+    let subagents = session_jsonl.with_extension("").join("subagents");
+    if let Ok(entries) = std::fs::read_dir(&subagents) {
+        let mut nested: Vec<PathBuf> = entries
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|e| e == "jsonl"))
+            .collect();
+        nested.sort();
+        out.extend(nested);
+    }
+    out
+}
+
+/// Total tokens processed by every `/loom:sweep <issue>` session under
+/// `projects_dir` for `workspace_root`, or `None` when nothing attributable was
+/// found.
+///
+/// Blocking file I/O — call from a blocking context. `None` (never `Some(0)`)
+/// is returned for "no attributable transcripts", matching the envelope
+/// contract that an absent total omits the key rather than publishing a
+/// misleading zero.
+#[must_use]
+pub fn sum_sweep_tokens(
+    projects_dir: &Path,
+    workspace_root: &Path,
+    issue: u32,
+    window: Option<(DateTime<Utc>, DateTime<Utc>)>,
+) -> Option<u64> {
+    let project = projects_dir.join(project_slug(workspace_root));
+    let entries = std::fs::read_dir(&project).ok()?;
+
+    let mut total: u64 = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_none_or(|e| e != "jsonl") {
+            continue;
+        }
+        if !mtime_in_window(&path, window) {
+            continue;
+        }
+        let Some(head) = read_head(&path) else {
+            continue;
+        };
+        if !head_names_sweep_issue(&head, issue) {
+            continue;
+        }
+        for transcript in session_transcripts(&path) {
+            let too_big =
+                std::fs::metadata(&transcript).is_ok_and(|m| m.len() > MAX_TRANSCRIPT_BYTES);
+            if too_big {
+                log::warn!(
+                    "safehouse: skipping oversized transcript {} for issue #{issue} token total",
+                    transcript.display()
+                );
+                continue;
+            }
+            let usage = sum_transcript_usage(&transcript);
+            let sum = usage
+                .input_tokens
+                .saturating_add(usage.output_tokens)
+                .saturating_add(usage.cache_read_input_tokens)
+                .saturating_add(usage.cache_creation_input_tokens);
+            total = total.saturating_add(u64::try_from(sum).unwrap_or(0));
+        }
+    }
+    (total > 0).then_some(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone as _;
+    use std::fs;
+
+    fn sweep_head(issue_args: &str) -> String {
+        format!(
+            "{{\"type\":\"queue-operation\"}}\n\
+             {{\"type\":\"user\",\"message\":{{\"role\":\"user\",\"content\":\
+             \"<command-message>loom:sweep</command-message>\\n\
+             <command-name>/loom:sweep</command-name>\\n\
+             <command-args>{issue_args}</command-args>\"}}}}\n"
+        )
+    }
+
+    fn usage_line(input: i64, output: i64, cache_read: i64, cache_create: i64) -> String {
+        format!(
+            "{{\"type\":\"assistant\",\"message\":{{\"model\":\"claude-sonnet-4-5\",\
+             \"usage\":{{\"input_tokens\":{input},\"output_tokens\":{output},\
+             \"cache_read_input_tokens\":{cache_read},\
+             \"cache_creation_input_tokens\":{cache_create}}}}}}}\n"
+        )
+    }
+
+    /// Build `<projects>/<slug>/<uuid>.jsonl` (+ optional subagents) for a
+    /// session launched as `/loom:sweep <issue_args>`.
+    fn seed_session(
+        projects: &Path,
+        workspace: &Path,
+        uuid: &str,
+        issue_args: &str,
+        parent_usage: &str,
+        subagent_usage: &[&str],
+    ) -> PathBuf {
+        let dir = projects.join(project_slug(workspace));
+        fs::create_dir_all(&dir).unwrap();
+        let session = dir.join(format!("{uuid}.jsonl"));
+        fs::write(&session, format!("{}{parent_usage}", sweep_head(issue_args))).unwrap();
+        if !subagent_usage.is_empty() {
+            let sub = dir.join(uuid).join("subagents");
+            fs::create_dir_all(&sub).unwrap();
+            for (i, body) in subagent_usage.iter().enumerate() {
+                fs::write(sub.join(format!("agent-{i}.jsonl")), body).unwrap();
+            }
+        }
+        session
+    }
+
+    #[test]
+    fn project_slug_matches_claude_codes_cwd_mangling() {
+        assert_eq!(project_slug(Path::new("/Users/me/GitHub/loom")), "-Users-me-GitHub-loom");
+        // A dot-directory contributes its own `-` on top of the separator's,
+        // and hyphens inside a component are preserved verbatim.
+        assert_eq!(
+            project_slug(Path::new("/Users/me/GitHub/lean-genius/.loom/worktrees/x")),
+            "-Users-me-GitHub-lean-genius--loom-worktrees-x"
+        );
+    }
+
+    #[test]
+    fn head_matches_only_the_sweeps_own_issue_number() {
+        let head = sweep_head("4705 --claim-owned 4705");
+        assert!(head_names_sweep_issue(&head, 4705));
+        // A prefix of the real number must not match (the guard against
+        // substring-style attribution).
+        assert!(!head_names_sweep_issue(&head, 470));
+        assert!(!head_names_sweep_issue(&head, 47050));
+        // A number that appears only as a later argument is not the subject.
+        assert!(!head_names_sweep_issue(&sweep_head("4705 --prs 999"), 999));
+    }
+
+    #[test]
+    fn head_ignores_sessions_that_are_not_sweeps() {
+        let other = "{\"type\":\"user\",\"message\":{\"content\":\
+             \"<command-name>/loom:builder</command-name>\\n\
+             <command-args>4705</command-args>\"}}";
+        assert!(!head_names_sweep_issue(other, 4705));
+        assert!(!head_names_sweep_issue("no markup here at all", 4705));
+    }
+
+    #[test]
+    fn sums_parent_and_subagent_usage_including_cache_tokens() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = Path::new("/Users/me/GitHub/loom");
+        seed_session(
+            dir.path(),
+            workspace,
+            "uuid-a",
+            "4699 --claim-owned 4699",
+            &usage_line(10, 20, 300, 40),
+            &[&usage_line(1, 2, 30, 4), &usage_line(100, 200, 3000, 400)],
+        );
+
+        // 370 (parent) + 37 (agent-0) + 3700 (agent-1)
+        assert_eq!(sum_sweep_tokens(dir.path(), workspace, 4699, None), Some(4107));
+    }
+
+    #[test]
+    fn sums_every_session_for_a_redispatched_issue_but_not_other_issues() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = Path::new("/Users/me/GitHub/loom");
+        seed_session(dir.path(), workspace, "uuid-a", "4699", &usage_line(1, 1, 1, 1), &[]);
+        seed_session(dir.path(), workspace, "uuid-b", "4699", &usage_line(2, 2, 2, 2), &[]);
+        seed_session(dir.path(), workspace, "uuid-c", "4242", &usage_line(9, 9, 9, 9), &[]);
+
+        assert_eq!(sum_sweep_tokens(dir.path(), workspace, 4699, None), Some(12));
+        assert_eq!(sum_sweep_tokens(dir.path(), workspace, 4242, None), Some(36));
+    }
+
+    #[test]
+    fn returns_none_for_an_unknown_issue_or_project() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = Path::new("/Users/me/GitHub/loom");
+        seed_session(dir.path(), workspace, "uuid-a", "4699", &usage_line(1, 1, 1, 1), &[]);
+
+        // Right project, no such sweep.
+        assert_eq!(sum_sweep_tokens(dir.path(), workspace, 1234, None), None);
+        // No project directory at all — the common case on a host that has
+        // never run a sweep from this workspace.
+        assert_eq!(sum_sweep_tokens(dir.path(), Path::new("/nope/nowhere"), 4699, None), None);
+    }
+
+    #[test]
+    fn a_transcript_with_no_usage_blocks_yields_none_not_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = Path::new("/Users/me/GitHub/loom");
+        seed_session(dir.path(), workspace, "uuid-a", "4699", "", &[]);
+
+        assert_eq!(sum_sweep_tokens(dir.path(), workspace, 4699, None), None);
+    }
+
+    #[test]
+    fn the_mtime_window_excludes_sessions_outside_the_completion() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = Path::new("/Users/me/GitHub/loom");
+        seed_session(dir.path(), workspace, "uuid-a", "4699", &usage_line(1, 1, 1, 1), &[]);
+
+        // Freshly written, so a window around "now" keeps it...
+        let now = Utc::now();
+        let live = Some((now - chrono::Duration::minutes(30), now));
+        assert_eq!(sum_sweep_tokens(dir.path(), workspace, 4699, live), Some(4));
+
+        // ...while a window in the distant past (well beyond WINDOW_SLACK)
+        // filters it out before the file is ever read.
+        let then = Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap();
+        let stale = Some((then, then + chrono::Duration::hours(1)));
+        assert_eq!(sum_sweep_tokens(dir.path(), workspace, 4699, stale), None);
+    }
+}


### PR DESCRIPTION
## Summary

Diagnosis-first issue. The live `2amlogic.com/api/feed` was re-checked from this
worktree; the three "null" fields turned out to have **three different** causes,
only one of which is a loom code bug — and that one is fixed here.

| Field | Live status now | Cause | Action |
|---|---|---|---|
| `title` | **populated** for `rjwalters/loom` | deployment lag — the fleet host's daemon predated #4553 when the issue was filed; it has since rolled | none needed (resolved by deploy) |
| `ref` | **populated** for `rjwalters/loom` | same | none needed |
| `title`/`ref` | still null for `rjwalters/claude-monitor` | **consumer-side, by design** — the site nulls both for repos outside its linked-repo allowlist | documented, not a loom bug |
| `tokens` | **null on every record, always** | **genuine loom code gap** | **fixed in this PR** |

### The genuine gap

`fetch_issue_tokens` had exactly one source: `ActivityDb::get_cost_by_issue`,
whose SQL joins `resource_usage -> agent_inputs -> prompt_github`. Rows in those
two analytics tables are written from exactly **one** place — the IPC
`GetTerminalOutput` handler scraping a *managed terminal's* scrollback
(`ipc.rs`, the MOM/terminal-manager path).

Daemon dispatch never traverses that path: `dispatch_sweep` spawns a detached
`claude -p` through `spawn-worker.sh` and reaps the OS process, issuing no
`SendInput`/`GetTerminalOutput` round trips at all. So on any host whose work
arrives by dispatch — i.e. **every host that publishes to the fleet feed** — the
rollup is not "empty until the prompt↔usage linkage is established" (the caveat
`fetch_issue_tokens`' doc comment offered), it is **structurally empty forever**.

Measured on the reference fleet host, 2026-07-31:

```
sqlite3 ~/.loom/activity.db 'select count(*) from resource_usage;'   -> 0
sqlite3 ~/.loom/activity.db 'select count(*) from prompt_github;'    -> 0
sqlite3 ~/.loom/activity.db 'select count(*) from agent_inputs;'     -> 26
ls -l  ~/.loom/activity.db   -> last written Jul 29, two days stale under continuous dispatch
```

…against a feed in which **every** record — `rjwalters/loom` and every canary
repo alike — carries `tokens: null`. This is why the curator's "not an empty
rollup" carve-out does not apply: the rollup is not transiently empty, it has no
writer on this deployment shape.

### The fix

The token data was on disk the whole time, in the sweep's own Claude Code
transcripts. New `loom-daemon/src/transcript_tokens.rs` locates a sweep's
sessions and sums them; `fetch_issue_tokens` tries the activity DB first
(cheaper, still authoritative on hosts that *do* drive managed terminals) and
falls back to the transcripts.

Session→issue attribution is by content, since nothing records a sweep-id →
session-uuid mapping. A sweep runs `claude -p "/loom:sweep <issue> …"` with
cwd = the workspace root, so Claude Code writes
`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/<cwd-slug>/<uuid>.jsonl` plus
`<uuid>/subagents/agent-*.jsonl`, and the parent session's first `user` record
carries the slash command verbatim. Verified against real on-disk transcripts on
this host:

- header markup is exactly `<command-name>/loom:sweep</command-name>` +
  `<command-args>4699 --claim-owned 4699</command-args>`;
- the slug mangling matches (`…/lean-genius/.loom/worktrees/x` →
  `-Users-…-lean-genius--loom-worktrees-x`, present verbatim under `projects/`);
- the parent transcript contains **0** `"isSidechain":true` records, so summing
  parent + subagents does not double-count;
- `agent-*.meta.json` siblings are excluded by the `.jsonl` extension filter.

The total sums all four usage counters rather than the rollup's narrower
input+output: cache reads dominate a sweep both by volume (~99%) and, priced at
~10% of base, by cost, so an input+output-only figure under-reports spend by
well over an order of magnitude and does so unevenly between sweeps. The
difference in fidelity between the two sources is documented rather than papered
over. Candidates are pre-narrowed by mtime against the completion's own window
(±2h slack) before any file is read, the scan runs on the blocking pool under
the existing 5s `TOKEN_LOOKUP_TIMEOUT`, and oversized transcripts are skipped —
so this can never delay or fail a completion. `LOOM_SAFEHOUSE_TRANSCRIPT_TOKENS=0`
opts out entirely.

### Why `ref: null` is NOT a loom bug

Worth recording, because it is the trap this issue was originally filed on. Loom
**cannot** emit a completion with a null/absent `ref`: it is in
`COMPLETION_REQUIRED_KEYS`, `to_meta_value` inserts it unconditionally,
`validate_completion_meta` rejects the envelope otherwise, and `fetch_merged_pr`
returns `None` (no completion at all) when the PR `url` is missing. The site's
own `/api/ingest` validator independently rejects such a payload with a `400`.
The null values in the live feed come from the **read** path: entries whose
`repo` is outside the site's linked-repo allowlist are served with `ref`/`title`
forced to `null`, keeping the sellable columns (`repo#issue`, diff stats,
timing) while withholding the outbound link. That is deliberate consumer-side
redaction, and both repos involved are public — so it is not a visibility leak
either. Recorded in `.loom/docs/safehouse.md` as a "check the allowlist before
filing a producer bug" note.

## Changes

- `loom-daemon/src/transcript_tokens.rs` (new) — project-slug mangling, the
  `/loom:sweep <issue>` session match, mtime windowing, parent+subagents usage
  sum. Pure filesystem code with no safehouse dependency, unit-testable alone.
- `loom-daemon/src/safehouse.rs` — `fetch_issue_tokens` split into
  `fetch_activity_db_tokens` (unchanged query, now filtering a `0` total so the
  fallback can run) + `fetch_transcript_tokens`, with the timeout and the
  `LOOM_SAFEHOUSE_TRANSCRIPT_TOKENS` opt-out; `build_and_narrate_completion`
  computes `started_at` before the lookup so the window can be passed down. The
  doc comment's "limits" list gains the dispatch-path limit as #3.
- `loom-daemon/src/lib.rs` — register the module.
- `.loom/docs/safehouse.md` — the two-source `tokens` description, the
  "DB rollup is silent on a fleet host" operational gotcha, and the
  "a null feed field is not a producer bug" note.

## Acceptance Criteria Verification

- [x] **Confirm the commit/version actually running on the publishing host** —
  `spawn-claude.sh` logs it per dispatch: `loom-daemon 0.16.0 (commit 31327370,
  built 2026-07-30T23:42:06Z)`, i.e. **after** `105f9c12` (#4553, merged
  2026-07-30 05:12 UTC). Corroborated by the live feed: loom records carry
  `title` and `additions`/`deletions`, all three of which #4553 introduced.
- [x] **If the running binary predates #4553** — it does not (any more). The
  issue's 2026-07-31 observation predates the roll; no redeploy needed.
- [x] **If current but fields still null: check the activity-DB rollup** — done,
  and it is the empty-rollup case *permanently*, for the structural reason
  above. `reconcile_recent_merges` is verifiably ticking (the daemon log shows
  its per-workspace seeding lines for six workspaces), so reconciliation
  liveness is not the cause.
- [x] **Only if a genuine code-level gap is found, fix it with a regression
  test** — found and fixed;
  `completion_for_exit_falls_back_to_sweep_transcripts_when_the_db_is_empty`
  sits alongside the existing
  `completion_for_exit_carries_tokens_from_the_activity_db_rollup` /
  `completion_for_exit_omits_tokens_when_the_rollup_is_empty` family, plus
  `completion_for_exit_prefers_the_activity_db_over_the_transcripts` and
  `the_transcript_fallback_can_be_disabled_by_env`.
- [ ] **One live completion verified end-to-end with all three non-null** —
  **not verifiable from a worktree**: it requires this PR to merge *and* the
  fleet host's daemon to self-update past it, then a subsequent sweep to merge.
  `title`/`ref` are already verified non-null live for linked repos (see the
  table above); `tokens` becomes verifiable one daemon roll after this merges.

## Test Plan

- `cargo test -p loom-daemon --lib transcript_tokens` — 8 passed, 0 failed.
- `cargo test -p loom-daemon --lib safehouse::tests::` — 95 passed, 2 failed;
  both failures **pre-existing and macOS-only** (see below).
- `cargo fmt -p loom-daemon -- --check` — clean.
- `cargo clippy -p loom-daemon --all-targets` — no findings in any file this PR
  touches (2 pre-existing `manual_split_once` errors in
  `loom-daemon/src/observability/exporter.rs`, untouched here).

### Pre-existing failures, not introduced by this PR

`run_sink_reconciliation_seeds_a_fresh_dedup_file_without_narrating_the_backlog`
and `run_sink_reconciliation_narrates_normally_once_the_dedup_file_is_no_longer_fresh`
(added by #4673) fail on macOS only. The assertion compares the persisted dedup
key against `dir.path()`, but the persisted key is canonicalized — on macOS
`/var` is a symlink to `/private/var`, so the test compares
`/var/folders/…/.tmpX` against the stored `/private/var/folders/…/.tmpX` and
never matches. CI (Linux) is green on `main`, and the mechanism has no
connection to this diff. Filed separately rather than fixed here, per scope
discipline.

Closes #4699
