### PR TITLE
feat(fleet): warn at update time and classify expected idle-shutdown power-offs in fleet status

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -516,6 +516,40 @@ the plan/ordering/checklist; the per-phase shell is rendered in
    powers the host off after N idle minutes. This is stage 2:
    `autonomous.idleExit` is stage 1. On daemon-managed hosts use a short guard
    window (typically 15–30 minutes); the running-daemon veto remains.
+
+   **This is a real power-off, not a suspend** — the box goes fully dark (no
+   SSH, no tailnet, nothing) until an operator brings it back (#4697). Wake
+   path:
+   - **Power the host back on** via the provider's own console or CLI. Loom
+     deliberately never calls a cloud CLI itself here (the "Boundary" note
+     above/epic #4340's scope) — this is an operator (or `repo:remote`) action,
+     not something `loom-daemon` automates.
+   - **Tailnet identity**: a Tailscale node's identity/key is stored on local
+     disk (`/var/lib/tailscale` or the equivalent state dir), not tied to the
+     instance being *running* — a plain power-off/power-on (not a
+     re-image/re-provision) preserves it, and the host reappears on the
+     tailnet under its existing name/IP once `tailscaled` starts again at
+     boot, typically within a minute or two of the power-on. A re-imaged or
+     freshly-reprovisioned replacement host does **not** inherit this and
+     needs its own `tailscale up` (a fresh ephemeral auth key if the prior one
+     already expired/was revoked).
+   - **Re-registration**: none needed for a simple power-cycle of the same
+     box — the fleet registry (`~/.loom/fleet.json`) keys on the SSH alias/
+     host, which is unchanged, and `loom-daemon` + the idle-shutdown cron
+     guard restart on boot exactly as they did before the power-off (the
+     systemd `--user` unit + `loginctl enable-linger` from step 8 survive a
+     reboot by design). Re-run `fleet add-worker` against the host only if the
+     box was actually replaced/re-imaged (a fresh OS install has none of the
+     prior bootstrap state).
+   - **Operator visibility**: `fleet status` (#4342, extended by #4697)
+     distinguishes a host that is silently past its configured
+     `--idle-shutdown-minutes` window — reported as `POWERED OFF (EXPECTED)`,
+     not a bare `UNREACHABLE` — from one whose silence doesn't yet explain
+     itself, which stays `UNREACHABLE` (genuinely worth investigating). This
+     classification is read from the registry's persisted
+     `idle_shutdown_minutes` + `last_seen_up_at` fields; it is advisory
+     (still counts as non-`Up` for `fleet status`'s exit-code policy) and
+     never suppresses the row.
 10. **safehouse** (optional, `--safehouse`) — **skip-with-notice** until #3998
     (the safehoused provisioning fragment) lands.
 11. **verify** — `loom-daemon status` sane from the workspace cwd, ranking
@@ -579,7 +613,27 @@ format was needed.
   - `UP` — the host answered with a well-formed status payload.
   - `DAEMON DOWN` — the host answered, but its own daemon reports the #4069
     unreachable-daemon payload (still valid JSON, carries an `error` key).
-  - `UNREACHABLE` — SSH/connect failure, or the per-host timeout elapsed.
+  - `UNREACHABLE` — SSH/connect failure, or the per-host timeout elapsed, AND
+    (#4697) either no idle-shutdown guard is configured for this host or its
+    silence hasn't yet reached the configured window — genuinely worth
+    investigating.
+  - `POWERED OFF (EXPECTED)` (#4697) — the host is `Unreachable` by every
+    signal available (SSH/connect failure or timeout — an idle-shutdown
+    power-off looks no different over the wire than a genuinely dead host),
+    **but** it has a configured idle-shutdown window
+    (`WorkerRecord.idle_shutdown_minutes`, populated at `fleet add-worker
+    --idle-shutdown-minutes` time) and its elapsed silence since the last
+    confirmed-`Up` poll (`WorkerRecord.last_seen_up_at`, refreshed by `fleet
+    status` itself on every poll that observes the host `Up`) has already
+    reached that window. Read as "likely powered off as designed, not a
+    failure" — still counts as non-`Up` for the exit-code policy below (it is
+    not confirmed-alive), but is loudly distinguished from a genuine outage so
+    an operator doesn't chase a phantom incident. Deliberately conservative:
+    either input missing (no guard configured, or the host has never been
+    observed `Up` by `fleet status` yet) leaves the host `UNREACHABLE`, the
+    pre-#4697 default — a false "expected, don't worry" reading on a
+    genuinely dead host is worse than an occasional false alarm. See the
+    `fleet add-worker` idle-shutdown step above for the wake path.
   - `PARSE ERROR` — the payload could not be parsed as JSON at all (severe
     version skew). Parsing is otherwise **lenient**: the remote payload is kept
     as a raw JSON value, so an older/newer remote binary's reduced/extended
@@ -593,13 +647,14 @@ format was needed.
 - **Empty roster**: never renders as empty output — prints an explicit "no
   fleet workers registered" notice alongside the local host's row.
 - **Exit code**: `0` only when every roster host is `UP`; non-zero otherwise
-  (a monitor/CI check should treat any non-zero exit as "go look").
+  (a monitor/CI check should treat any non-zero exit as "go look" — including
+  a `POWERED OFF (EXPECTED)` host, since it is still not confirmed-alive).
 - **`--json`** schema: `{ "hosts": [ { "alias", "state", "tailnet_name"?,
   "provider_instance_id"?, "added_by"?, "is_local", "workspaces", "status"?,
   "detail"?, "safehoused" } ], "summary": { "total", "up", "daemon_down",
-  "unreachable", "parse_error", "draining", "empty_roster" } }` — treat this as
-  a consumed interface (the #4329 dashboard's multi-host phase reads it over
-  the tailnet).
+  "unreachable", "powered_off", "parse_error", "draining", "empty_roster" } }`
+  — treat this as a consumed interface (the #4329 dashboard's multi-host phase
+  reads it over the tailnet).
 
 ### `fleet drain <ssh-host> [--timeout N] [--force-after-timeout] [--json]` (#4343)
 
@@ -2362,6 +2417,17 @@ on a fleet worker or under launchd defeats its own purpose, since the
 supervisor immediately relaunches the daemon it just exited. A loud warning is
 logged when it is enabled under launchd; the same caveat applies to any
 systemd-supervised daemon (fleet workers included).
+
+**This is stage 1 only — it never powers off the host.** `autonomous.idleExit`
+above just makes `loom-daemon` itself exit; under `Restart=on-success`
+supervision (the fleet-worker default) the supervisor immediately relaunches
+it, so the *host* stays running and reachable throughout. The actual
+host-power-off mechanism is stage 2: the separate `fleet add-worker
+--idle-shutdown-minutes` cron guard (`render_idle_shutdown()`) documented in
+the `fleet add-worker` step 9 above — that is the one an operator needs a wake
+path for (provider console/CLI restart, tailnet-identity survival,
+re-registration), documented in full at that step, along with the #4697
+`fleet status` "expected power-off" classification.
 
 ### Daemon log path override (`LOOM_DAEMON_LOG`, #4010)
 

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -543,7 +543,7 @@ the plan/ordering/checklist; the per-phase shell is rendered in
      prior bootstrap state).
    - **Operator visibility**: `fleet status` (#4342, extended by #4697)
      distinguishes a host that is silently past its configured
-     `--idle-shutdown-minutes` window — reported as `POWERED OFF (EXPECTED)`,
+     `--idle-shutdown-minutes` window — reported as `POWERED OFF`,
      not a bare `UNREACHABLE` — from one whose silence doesn't yet explain
      itself, which stays `UNREACHABLE` (genuinely worth investigating). This
      classification is read from the registry's persisted
@@ -617,7 +617,7 @@ format was needed.
     (#4697) either no idle-shutdown guard is configured for this host or its
     silence hasn't yet reached the configured window — genuinely worth
     investigating.
-  - `POWERED OFF (EXPECTED)` (#4697) — the host is `Unreachable` by every
+  - `POWERED OFF` (#4697) — the host is `Unreachable` by every
     signal available (SSH/connect failure or timeout — an idle-shutdown
     power-off looks no different over the wire than a genuinely dead host),
     **but** it has a configured idle-shutdown window
@@ -628,7 +628,10 @@ format was needed.
     reached that window. Read as "likely powered off as designed, not a
     failure" — still counts as non-`Up` for the exit-code policy below (it is
     not confirmed-alive), but is loudly distinguished from a genuine outage so
-    an operator doesn't chase a phantom incident. Deliberately conservative:
+    an operator doesn't chase a phantom incident. The "expected, not a
+    failure" qualifier and the wake pointer ride on the row's `->` detail line
+    and the `N powered-off (expected)` summary tally rather than the STATE
+    cell, which stays inside the table's column width. Deliberately conservative:
     either input missing (no guard configured, or the host has never been
     observed `Up` by `fleet status` yet) leaves the host `UNREACHABLE`, the
     pre-#4697 default — a false "expected, don't worry" reading on a
@@ -648,7 +651,7 @@ format was needed.
   fleet workers registered" notice alongside the local host's row.
 - **Exit code**: `0` only when every roster host is `UP`; non-zero otherwise
   (a monitor/CI check should treat any non-zero exit as "go look" — including
-  a `POWERED OFF (EXPECTED)` host, since it is still not confirmed-alive).
+  a `POWERED OFF` host, since it is still not confirmed-alive).
 - **`--json`** schema: `{ "hosts": [ { "alias", "state", "tailnet_name"?,
   "provider_instance_id"?, "added_by"?, "is_local", "workspaces", "status"?,
   "detail"?, "safehoused" } ], "summary": { "total", "up", "daemon_down",

--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -129,6 +129,12 @@
 #                          forwarded to provision-daemon.sh.
 #   LOOM_SKIP_STALE_ENTRY_POINT_CHECK  1/true/yes suppresses the advisory
 #                          stale-`loom-*`-entry-point warning described below.
+#   LOOM_SKIP_IDLE_SHUTDOWN_NOTICE  1/true/yes suppresses the advisory
+#                          post-update idle-shutdown cron-guard notice (#4697):
+#                          "this host will power itself off after N idle
+#                          minutes" when a `fleet add-worker
+#                          --idle-shutdown-minutes` guard is installed. Silent
+#                          (no notice at all) when no such guard exists.
 #   LOOM_DAEMON_LAUNCHD    macOS only: 0/false/no disables ALL launchd interaction
 #                          (ownership detection + launchd restart), symmetric with
 #                          loom-daemon-start.sh / loom-daemon-stop.sh. A daemon
@@ -713,12 +719,55 @@ fi
 # entry point is invisible precisely when the daemon looks healthy (#4079).
 warn_stale_entry_points "$DAEMON_BIN"
 
+# ---------- idle-shutdown cron-guard post-update notice (#4697) ----------
+#
+# THE INCIDENT THIS EXISTS FOR: a remote worker was updated via this script —
+# the rebuild + supervised restart succeeded onto the new binary — and ~15
+# minutes later the host powered itself off. Nothing in the update flow
+# warned that the "successful" update was landing on a host about to
+# evaporate: the STAGE-2 cron guard `fleet add-worker --idle-shutdown-minutes`
+# installs (`render_idle_shutdown()` in loom-daemon/src/fleet/add_worker.rs,
+# NOT `autonomous.idleExit` stage 1 — that daemon-level exit is self-defeating
+# under `Restart=on-success` systemd/launchd supervision, since the supervisor
+# immediately relaunches it) fired once the freshly-relaunched, idle daemon
+# crossed the configured window, and powered the WHOLE HOST off — SSH,
+# tailnet, everything.
+#
+# This is purely advisory: it never disables/touches the guard, never changes
+# this script's exit code, and is silent when no guard is installed
+# (LOOM_SKIP_IDLE_SHUTDOWN_NOTICE=1 also suppresses it for scripted/quiet
+# use). The idle-shutdown guard's own design (#3998/#4477) is correct and out
+# of scope here — the gap this closes is purely operator awareness at the
+# moment a "successful" update is reported.
+IDLE_SHUTDOWN_GUARD_SCRIPT="$HOME/.local/bin/loom-idle-shutdown.sh"
+
+idle_shutdown_notice() {
+    [[ "${LOOM_SKIP_IDLE_SHUTDOWN_NOTICE:-0}" =~ ^(1|true|yes)$ ]] && return 0
+    command -v crontab >/dev/null 2>&1 || return 0
+    crontab -l 2>/dev/null | grep -q 'loom-idle-shutdown' || return 0
+
+    local minutes=""
+    if [[ -r "$IDLE_SHUTDOWN_GUARD_SCRIPT" ]]; then
+        minutes="$(grep -oE 'LIMIT=[0-9]+' "$IDLE_SHUTDOWN_GUARD_SCRIPT" 2>/dev/null \
+            | head -n1 | cut -d= -f2)"
+    fi
+
+    if [[ -n "$minutes" ]]; then
+        warn "Heads up: this host has an idle-shutdown cron guard installed (fleet add-worker --idle-shutdown-minutes ${minutes}) — after ~${minutes} idle minute(s) it POWERS THE WHOLE HOST OFF (SSH/tailnet included), not just this daemon. This is expected/by-design (#3998/#4477), not a fault in this update. Wake path (provider console/CLI restart; Loom never calls a cloud CLI itself) and tailnet-identity/re-registration notes: defaults/docs/daemon-reference.md, 'fleet add-worker' step 9 (idle-shutdown)."
+    else
+        warn "Heads up: this host has an idle-shutdown cron guard installed (crontab holds a loom-idle-shutdown entry, but the configured window could not be read from $IDLE_SHUTDOWN_GUARD_SCRIPT) — it WILL power the whole host off after some idle window. This is expected/by-design (#3998/#4477), not a fault in this update. See defaults/docs/daemon-reference.md, 'fleet add-worker' step 9 (idle-shutdown), for the wake path."
+    fi
+}
+
 # print_final_installed_line <commit> — the AC4 "final installed line": states
 # the built/installed commit AND whether it matches origin/<default-branch> at
 # build time. Uses ORIGIN_COMMIT resolved by sync_with_origin above (no
 # re-fetch). Prints an honest "unknown" comparison when the default branch or
 # origin commit could not be resolved (offline, no origin remote, etc.) rather
-# than silently omitting the currency claim.
+# than silently omitting the currency claim. Also where the #4697 idle-shutdown
+# notice fires — every successful/"already up to date" exit path funnels
+# through this one function, so the notice is reported consistently without
+# duplicating the call at each of this script's several exit points.
 print_final_installed_line() {
     local commit="$1"
     if [[ -z "$DEFAULT_BRANCH" || "$ORIGIN_COMMIT" == "unknown" ]]; then
@@ -728,6 +777,7 @@ print_final_installed_line() {
     else
         echo "Installed: ${commit} (origin/${DEFAULT_BRANCH} is at ${ORIGIN_COMMIT} — does NOT match; built from a checkout that was behind or diverged, e.g. --allow-stale)"
     fi
+    idle_shutdown_notice
 }
 
 # ---------- launchd ownership detection (macOS, mirrors loom-daemon-stop.sh #4042) ----------

--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -753,9 +753,9 @@ idle_shutdown_notice() {
     fi
 
     if [[ -n "$minutes" ]]; then
-        warn "Heads up: this host has an idle-shutdown cron guard installed (fleet add-worker --idle-shutdown-minutes ${minutes}) — after ~${minutes} idle minute(s) it POWERS THE WHOLE HOST OFF (SSH/tailnet included), not just this daemon. This is expected/by-design (#3998/#4477), not a fault in this update. Wake path (provider console/CLI restart; Loom never calls a cloud CLI itself) and tailnet-identity/re-registration notes: defaults/docs/daemon-reference.md, 'fleet add-worker' step 9 (idle-shutdown)."
+        warn "Heads up: this host has an idle-shutdown cron guard installed (fleet add-worker --idle-shutdown-minutes ${minutes}) — after ~${minutes} idle minute(s) it POWERS THE WHOLE HOST OFF (SSH/tailnet included), not just this daemon. This is expected/by-design (#3998/#4477), not a fault in this update. Wake path (provider console/CLI restart; Loom never calls a cloud CLI itself) and tailnet-identity/re-registration notes: daemon-reference.md, 'fleet add-worker' step 9 (idle-shutdown)."
     else
-        warn "Heads up: this host has an idle-shutdown cron guard installed (crontab holds a loom-idle-shutdown entry, but the configured window could not be read from $IDLE_SHUTDOWN_GUARD_SCRIPT) — it WILL power the whole host off after some idle window. This is expected/by-design (#3998/#4477), not a fault in this update. See defaults/docs/daemon-reference.md, 'fleet add-worker' step 9 (idle-shutdown), for the wake path."
+        warn "Heads up: this host has an idle-shutdown cron guard installed (crontab holds a loom-idle-shutdown entry, but the configured window could not be read from $IDLE_SHUTDOWN_GUARD_SCRIPT) — it WILL power the whole host off after some idle window. This is expected/by-design (#3998/#4477), not a fault in this update. See daemon-reference.md, 'fleet add-worker' step 9 (idle-shutdown), for the wake path."
     fi
 }
 

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -439,6 +439,32 @@ EOF
     chmod +x "$path"
 }
 
+# Fake `crontab` (#4697): the update script's idle-shutdown-notice check runs
+# `crontab -l` unconditionally on every invocation, so without this stub every
+# test in this suite would shell out to the REAL system `crontab` for
+# whichever account runs the suite — reading (never writing, but still a real
+# information leak/hang risk on a host with no cron daemon configured) actual
+# operator state, exactly the class of hazard the launchd/systemd sandboxing
+# above exists to prevent. `-l` echoes the contents of
+# $FAKE_CRONTAB_CONTENTS_FILE when set+readable, else exits 1 with no output
+# (mirrors the common "no crontab for this user" case — silence, not an
+# error the caller need alarm on). Any other invocation is a no-op success.
+write_fake_crontab() {
+    local path="$1"
+    cat > "$path" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-l" ]]; then
+    if [[ -n "${FAKE_CRONTAB_CONTENTS_FILE:-}" && -r "${FAKE_CRONTAB_CONTENTS_FILE:-}" ]]; then
+        cat "$FAKE_CRONTAB_CONTENTS_FILE"
+        exit 0
+    fi
+    exit 1
+fi
+exit 0
+EOF
+    chmod +x "$path"
+}
+
 MINIMAL_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
 BASE_WORKDIR="$(mktemp -d)"
@@ -505,6 +531,7 @@ trap 'kill "$DECOY_PID" 2>/dev/null; pkill -f "$BASE_WORKDIR" >/dev/null 2>&1; r
 FAKE_BIN_DIR="$BASE_WORKDIR/fakebin"
 mkdir -p "$FAKE_BIN_DIR"
 write_fake_cargo "$FAKE_BIN_DIR/cargo"
+write_fake_crontab "$FAKE_BIN_DIR/crontab"
 # Stub launchctl/pgrep onto the front of every test PATH (FAKE_BIN_DIR is the
 # first entry of TEST_PATH and TEST_PATH_NO_CODESIGN), recording invocations to
 # $SANDBOX_LOG_DIR so the suite can assert no production label was ever named.
@@ -2356,6 +2383,95 @@ else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "${RED}✗${NC} LOOM_SKIP_STALE_ENTRY_POINT_CHECK=1 suppresses the advisory"
     echo "  output: $out48"
+fi
+
+# ============================================================
+# 49-52. Idle-shutdown cron-guard post-update notice (#4697): the update
+#     script should warn, post-update, that this host will power itself off
+#     after N idle minutes when the stage-2 `fleet add-worker
+#     --idle-shutdown-minutes` cron guard is installed — and stay silent
+#     when it is not. Uses --check (fast, no rebuild) exactly like the
+#     stale-entry-point block above; a sandboxed $HOME49 keeps the
+#     `$HOME/.local/bin/loom-idle-shutdown.sh` lookup off the real operator
+#     account (belt-and-braces alongside the fake `crontab` stub above).
+# ============================================================
+W49="$BASE_WORKDIR/w49"
+new_fixture "$W49"
+HEAD49="$(cd "$W49" && git rev-parse --short HEAD)"
+write_fake_daemon "$W49/resolved-daemon" "$HEAD49" "$W49/marker49"
+
+HOME49="$BASE_WORKDIR/home49"
+mkdir -p "$HOME49/.local/bin"
+cat > "$HOME49/.local/bin/loom-idle-shutdown.sh" <<'GUARD'
+#!/usr/bin/env bash
+set -euo pipefail
+LIMIT=45
+GUARD
+chmod +x "$HOME49/.local/bin/loom-idle-shutdown.sh"
+
+CRONFIX49="$BASE_WORKDIR/cron49-with-guard"
+echo "*/5 * * * * $HOME49/.local/bin/loom-idle-shutdown.sh >/dev/null 2>&1" > "$CRONFIX49"
+
+# 49. Guard installed + configured window readable -> notice names "45".
+out49=$( cd "$W49" && PATH="$TEST_PATH" HOME="$HOME49" \
+    LOOM_DAEMON_BIN="$W49/resolved-daemon" \
+    FAKE_CRONTAB_CONTENTS_FILE="$CRONFIX49" \
+    bash "$UPDATE_SCRIPT" --check 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out49" | grep -q 'idle-shutdown cron guard installed' \
+   && echo "$out49" | grep -q -- '--idle-shutdown-minutes 45)'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} idle-shutdown guard installed -> post-update notice names the configured minutes (#4697)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} idle-shutdown guard installed -> post-update notice names the configured minutes (#4697)"
+    echo "  output: $out49"
+fi
+
+# 50. No guard installed (empty crontab fixture) -> completely silent.
+CRONFIX50="$BASE_WORKDIR/cron50-empty"
+: > "$CRONFIX50"
+out50=$( cd "$W49" && PATH="$TEST_PATH" HOME="$HOME49" \
+    LOOM_DAEMON_BIN="$W49/resolved-daemon" \
+    FAKE_CRONTAB_CONTENTS_FILE="$CRONFIX50" \
+    bash "$UPDATE_SCRIPT" --check 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! echo "$out50" | grep -qi 'idle-shutdown'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} no idle-shutdown guard installed -> no notice at all (#4697)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} no idle-shutdown guard installed -> no notice at all (#4697)"
+    echo "  output: $out50"
+fi
+
+# 51. LOOM_SKIP_IDLE_SHUTDOWN_NOTICE=1 suppresses it even with the guard present.
+out51=$( cd "$W49" && PATH="$TEST_PATH" HOME="$HOME49" \
+    LOOM_DAEMON_BIN="$W49/resolved-daemon" \
+    FAKE_CRONTAB_CONTENTS_FILE="$CRONFIX49" \
+    LOOM_SKIP_IDLE_SHUTDOWN_NOTICE=1 \
+    bash "$UPDATE_SCRIPT" --check 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! echo "$out51" | grep -qi 'idle-shutdown'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} LOOM_SKIP_IDLE_SHUTDOWN_NOTICE=1 suppresses the notice"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} LOOM_SKIP_IDLE_SHUTDOWN_NOTICE=1 suppresses the notice"
+    echo "  output: $out51"
+fi
+
+# 52. The notice never changes the exit code (still exit 0 -- up to date).
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out49" | grep -q . && ( cd "$W49" && PATH="$TEST_PATH" HOME="$HOME49" \
+    LOOM_DAEMON_BIN="$W49/resolved-daemon" \
+    FAKE_CRONTAB_CONTENTS_FILE="$CRONFIX49" \
+    bash "$UPDATE_SCRIPT" --check >/dev/null 2>&1 ); then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} the idle-shutdown notice never changes the exit code"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} the idle-shutdown notice never changes the exit code"
 fi
 
 # ============================================================

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -2386,7 +2386,7 @@ else
 fi
 
 # ============================================================
-# 49-52. Idle-shutdown cron-guard post-update notice (#4697): the update
+# 49-53. Idle-shutdown cron-guard post-update notice (#4697): the update
 #     script should warn, post-update, that this host will power itself off
 #     after N idle minutes when the stage-2 `fleet add-worker
 #     --idle-shutdown-minutes` cron guard is installed — and stay silent
@@ -2472,6 +2472,28 @@ if echo "$out49" | grep -q . && ( cd "$W49" && PATH="$TEST_PATH" HOME="$HOME49" 
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "${RED}✗${NC} the idle-shutdown notice never changes the exit code"
+fi
+
+# 53. Guard entry present in cron but the guard SCRIPT (and thus its LIMIT=)
+#     unreadable -- e.g. a hand-installed or relocated guard. The notice must
+#     still fire (the host still powers itself off) with the honest
+#     "window unknown" wording rather than silently degrading to nothing or
+#     inventing a minutes value. $HOME53 has no .local/bin/loom-idle-shutdown.sh.
+HOME53="$BASE_WORKDIR/home53"
+mkdir -p "$HOME53/.local/bin"
+out53=$( cd "$W49" && PATH="$TEST_PATH" HOME="$HOME53" \
+    LOOM_DAEMON_BIN="$W49/resolved-daemon" \
+    FAKE_CRONTAB_CONTENTS_FILE="$CRONFIX49" \
+    bash "$UPDATE_SCRIPT" --check 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out53" | grep -q 'idle-shutdown cron guard installed' \
+   && echo "$out53" | grep -q 'could not be read from'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} unreadable guard script -> notice still fires with an honest unknown window (#4697)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} unreadable guard script -> notice still fires with an honest unknown window (#4697)"
+    echo "  output: $out53"
 fi
 
 # ============================================================

--- a/loom-daemon/src/fleet/add_worker.rs
+++ b/loom-daemon/src/fleet/add_worker.rs
@@ -637,6 +637,58 @@ fn push_safehouse_steps(
     ));
 }
 
+/// Build the [`WorkerRecord`] a fully-successful bootstrap upserts into the
+/// fleet registry. Pure (every ambient input — the config, the `verify` step's
+/// outcome, and the clock — is a parameter) so the field mapping is unit
+/// testable without an SSH host; [`run`] is the only production caller.
+///
+/// `verify_ok` is `None` when the plan carried no `verify` report at all,
+/// `Some(false)` when it ran without confirming.
+fn build_worker_record(
+    config: &AddWorkerConfig,
+    verify_ok: Option<bool>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> WorkerRecord {
+    let now_str = now.to_rfc3339();
+    WorkerRecord {
+        ssh_host: config.ssh_host.clone(),
+        repos: config.repos.clone(),
+        priority: config.priority,
+        bootstrapped_at: now_str.clone(),
+        last_verify: verify_ok.map(|ok| VerifyResult {
+            ok,
+            at: now_str.clone(),
+            summary: if ok {
+                "daemon reachable, ranking fresh, workspace registered".to_string()
+            } else {
+                "verify step did not confirm".to_string()
+            },
+        }),
+        // #4342's extended roster fields (provider/instance id, tailnet
+        // name, added-by) are not yet collected by `add-worker` — left
+        // absent here rather than guessed; `fleet status` renders them as
+        // "–" until a future pass wires them (e.g. from `--tailnet-name`/
+        // `--provider-instance-id` flags or a cloud-metadata probe).
+        provider_instance_id: None,
+        tailnet_name: None,
+        added_by: None,
+        state: None,
+        drain_phase: None,
+        drain_captured: Vec::new(),
+        // Populate the new #4697 fields from this run: the operator's
+        // `--idle-shutdown-minutes` (absent => no guard installed, mirrors
+        // the `render_idle_shutdown()` gate above), and `last_seen_up_at`
+        // — a full bootstrap only reaches this branch when every step
+        // (including `verify`) succeeded over SSH, so the host was
+        // observably up moments ago; this seeds `fleet status`'s
+        // expected-power-off heuristic with a reference point from the
+        // very first poll, rather than leaving it `None` until some later
+        // `fleet status` run happens to observe the host `Up`.
+        idle_shutdown_minutes: config.idle_shutdown_minutes,
+        last_seen_up_at: Some(now_str),
+    }
+}
+
 /// Top-level orchestration for `loom-daemon fleet add-worker`.
 ///
 /// Preflight → build plan → (dry-run: print + return) → execute over ssh →
@@ -665,43 +717,7 @@ pub fn run(config: &AddWorkerConfig) -> Result<()> {
         .map(|r| matches!(r.status, StepStatus::Changed));
 
     if all_succeeded(&reports, &plan) {
-        let record = WorkerRecord {
-            ssh_host: config.ssh_host.clone(),
-            repos: config.repos.clone(),
-            priority: config.priority,
-            bootstrapped_at: chrono::Utc::now().to_rfc3339(),
-            last_verify: verify_ok.map(|ok| VerifyResult {
-                ok,
-                at: chrono::Utc::now().to_rfc3339(),
-                summary: if ok {
-                    "daemon reachable, ranking fresh, workspace registered".to_string()
-                } else {
-                    "verify step did not confirm".to_string()
-                },
-            }),
-            // #4342's extended roster fields (provider/instance id, tailnet
-            // name, added-by) are not yet collected by `add-worker` — left
-            // absent here rather than guessed; `fleet status` renders them as
-            // "–" until a future pass wires them (e.g. from `--tailnet-name`/
-            // `--provider-instance-id` flags or a cloud-metadata probe).
-            provider_instance_id: None,
-            tailnet_name: None,
-            added_by: None,
-            state: None,
-            drain_phase: None,
-            drain_captured: Vec::new(),
-            // Populate the new #4697 fields from this run: the operator's
-            // `--idle-shutdown-minutes` (absent => no guard installed, mirrors
-            // the `render_idle_shutdown()` gate above), and `last_seen_up_at`
-            // — a full bootstrap only reaches this branch when every step
-            // (including `verify`) succeeded over SSH, so the host was
-            // observably up moments ago; this seeds `fleet status`'s
-            // expected-power-off heuristic with a reference point from the
-            // very first poll, rather than leaving it `None` until some later
-            // `fleet status` run happens to observe the host `Up`.
-            idle_shutdown_minutes: config.idle_shutdown_minutes,
-            last_seen_up_at: Some(chrono::Utc::now().to_rfc3339()),
-        };
+        let record = build_worker_record(config, verify_ok, chrono::Utc::now());
         let path = default_fleet_registry_path()?;
         let mut registry = FleetRegistry::load(&path)?;
         let replaced = registry.upsert(record);
@@ -1772,6 +1788,71 @@ mod tests {
             })
             .unwrap();
         assert!(step.apply.contains("LIMIT=45"));
+    }
+
+    // ---- build_worker_record / #4697 registry fields ----------------------
+
+    #[test]
+    fn worker_record_carries_configured_idle_shutdown_window() {
+        // #4697 AC 3's prerequisite: `fleet status` can only tell an EXPECTED
+        // power-off from an outage if the window the guard was installed with
+        // is persisted on the record at bootstrap time.
+        let mut config = base_config();
+        config.idle_shutdown_minutes = Some(45);
+        let now = chrono::Utc::now();
+
+        let record = build_worker_record(&config, Some(true), now);
+        assert_eq!(record.idle_shutdown_minutes, Some(45));
+        // A successful bootstrap observed the host up over SSH moments ago, so
+        // the heuristic has a reference point from the very first poll.
+        assert_eq!(record.last_seen_up_at.as_deref(), Some(now.to_rfc3339()).as_deref());
+    }
+
+    #[test]
+    fn worker_record_leaves_idle_shutdown_absent_when_not_configured() {
+        // Mirrors `render_idle_shutdown()`'s gate: no --idle-shutdown-minutes
+        // => no guard installed => nothing for the heuristic to compare
+        // against, so the host stays UNREACHABLE (never "expected") when
+        // silent.
+        let config = base_config();
+        assert!(config.idle_shutdown_minutes.is_none());
+        let record = build_worker_record(&config, Some(true), chrono::Utc::now());
+        assert_eq!(record.idle_shutdown_minutes, None);
+    }
+
+    #[test]
+    fn worker_record_roundtrips_idle_shutdown_fields_through_the_registry() {
+        // The registry file is the only carrier between `add-worker` (write)
+        // and a LATER `fleet status` process (read), so the #4697 fields must
+        // survive a real save/load — and a record written before they existed
+        // must still load (the `#[serde(default)]` backward-compat pattern).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fleet.json");
+
+        let mut config = base_config();
+        config.idle_shutdown_minutes = Some(30);
+        let record = build_worker_record(&config, Some(true), chrono::Utc::now());
+        let expected_last_seen = record.last_seen_up_at.clone();
+
+        let mut registry = FleetRegistry::default();
+        registry.upsert(record);
+        registry.save(&path).unwrap();
+
+        let loaded = FleetRegistry::load(&path).unwrap();
+        let w = loaded.get(&config.ssh_host).unwrap();
+        assert_eq!(w.idle_shutdown_minutes, Some(30));
+        assert_eq!(w.last_seen_up_at, expected_last_seen);
+
+        // Pre-#4697 record: both fields absent from the JSON entirely.
+        std::fs::write(
+            &path,
+            r#"{ "version": 1, "workers": [ { "ssh_host": "legacy", "bootstrapped_at": "t" } ] }"#,
+        )
+        .unwrap();
+        let legacy = FleetRegistry::load(&path).unwrap();
+        let w = legacy.get("legacy").unwrap();
+        assert_eq!(w.idle_shutdown_minutes, None);
+        assert_eq!(w.last_seen_up_at, None);
     }
 
     #[test]

--- a/loom-daemon/src/fleet/add_worker.rs
+++ b/loom-daemon/src/fleet/add_worker.rs
@@ -690,6 +690,17 @@ pub fn run(config: &AddWorkerConfig) -> Result<()> {
             state: None,
             drain_phase: None,
             drain_captured: Vec::new(),
+            // Populate the new #4697 fields from this run: the operator's
+            // `--idle-shutdown-minutes` (absent => no guard installed, mirrors
+            // the `render_idle_shutdown()` gate above), and `last_seen_up_at`
+            // — a full bootstrap only reaches this branch when every step
+            // (including `verify`) succeeded over SSH, so the host was
+            // observably up moments ago; this seeds `fleet status`'s
+            // expected-power-off heuristic with a reference point from the
+            // very first poll, rather than leaving it `None` until some later
+            // `fleet status` run happens to observe the host `Up`.
+            idle_shutdown_minutes: config.idle_shutdown_minutes,
+            last_seen_up_at: Some(chrono::Utc::now().to_rfc3339()),
         };
         let path = default_fleet_registry_path()?;
         let mut registry = FleetRegistry::load(&path)?;

--- a/loom-daemon/src/fleet/drain.rs
+++ b/loom-daemon/src/fleet/drain.rs
@@ -1181,6 +1181,8 @@ mod tests {
             state: None,
             drain_phase: None,
             drain_captured: Vec::new(),
+            idle_shutdown_minutes: None,
+            last_seen_up_at: None,
         }
     }
 

--- a/loom-daemon/src/fleet/mod.rs
+++ b/loom-daemon/src/fleet/mod.rs
@@ -1095,4 +1095,61 @@ mod tests {
         assert_eq!(w.added_by.as_deref(), Some("operator"));
         assert_eq!(w.state.as_deref(), Some("draining"));
     }
+
+    #[test]
+    fn registry_roundtrips_4697_idle_shutdown_fields() {
+        // #4697: `fleet status`'s expected-power-off heuristic reads both
+        // fields out of the registry in a LATER process than the one that
+        // wrote them, so a real save/load must preserve them exactly.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fleet.json");
+
+        let mut w = record("worker-1");
+        w.idle_shutdown_minutes = Some(30);
+        w.last_seen_up_at = Some("2026-07-30T12:00:00+00:00".to_string());
+        let mut reg = FleetRegistry::default();
+        reg.upsert(w);
+        reg.save(&path).unwrap();
+
+        let loaded = FleetRegistry::load(&path).unwrap();
+        let got = loaded.get("worker-1").unwrap();
+        assert_eq!(got.idle_shutdown_minutes, Some(30));
+        assert_eq!(got.last_seen_up_at.as_deref(), Some("2026-07-30T12:00:00+00:00"));
+    }
+
+    #[test]
+    fn registry_record_without_4697_fields_parses_as_absent() {
+        // Backward-compat: every record written before #4697 lacks both keys.
+        // They must load as `None` (not error, not a bogus default that would
+        // make a live host read as an "expected" power-off).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fleet.json");
+        std::fs::write(
+            &path,
+            r#"{ "version": 1, "workers": [ {
+                "ssh_host": "pre-4697",
+                "bootstrapped_at": "2026-07-29T00:00:00Z"
+            } ] }"#,
+        )
+        .unwrap();
+        let reg = FleetRegistry::load(&path).unwrap();
+        let w = reg.get("pre-4697").unwrap();
+        assert_eq!(w.idle_shutdown_minutes, None);
+        assert_eq!(w.last_seen_up_at, None);
+    }
+
+    #[test]
+    fn registry_omits_absent_4697_fields_from_serialized_json() {
+        // `skip_serializing_if` keeps the registry file unchanged for the
+        // overwhelmingly common no-idle-shutdown worker — a merge/diff of
+        // fleet.json shouldn't churn with null keys after this upgrade.
+        let reg = {
+            let mut r = FleetRegistry::default();
+            r.upsert(record("plain-worker"));
+            r
+        };
+        let json = serde_json::to_string(&reg).unwrap();
+        assert!(!json.contains("idle_shutdown_minutes"));
+        assert!(!json.contains("last_seen_up_at"));
+    }
 }

--- a/loom-daemon/src/fleet/mod.rs
+++ b/loom-daemon/src/fleet/mod.rs
@@ -550,6 +550,25 @@ pub struct WorkerRecord {
     /// #758, cites). Empty on a record with no drain in progress.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub drain_captured: Vec<drain::CapturedClaim>,
+    /// The idle-shutdown guard's configured window (minutes), when installed
+    /// via `fleet add-worker --idle-shutdown-minutes` (the stage-2 cron guard
+    /// `add_worker::render_idle_shutdown()` renders). `None` means no guard is
+    /// installed — including every record written before this field existed.
+    /// `fleet status` (#4697) uses this together with [`Self::last_seen_up_at`]
+    /// to distinguish an EXPECTED power-off (the host idle-shut itself down,
+    /// by design — #3998/#4477) from a genuinely UNEXPECTED outage when a host
+    /// stops answering.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_shutdown_minutes: Option<u32>,
+    /// RFC3339 timestamp of the most recent `fleet status` poll that observed
+    /// this host [`crate::fleet::status::HostState::Up`]. Written by `fleet
+    /// status` itself (#4697) on every poll that sees the host up; `None`
+    /// until the first such observation (a freshly-bootstrapped worker whose
+    /// first poll hasn't run yet, or a record predating this field). This is
+    /// the reference point the idle-shutdown "expected vs unexpected"
+    /// heuristic measures elapsed silence from.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_seen_up_at: Option<String>,
 }
 
 /// The machine-level set of bootstrapped workers, persisted at
@@ -950,6 +969,8 @@ mod tests {
             state: None,
             drain_phase: None,
             drain_captured: Vec::new(),
+            idle_shutdown_minutes: None,
+            last_seen_up_at: None,
         }
     }
 

--- a/loom-daemon/src/fleet/status.rs
+++ b/loom-daemon/src/fleet/status.rs
@@ -25,18 +25,22 @@
 //! # Loud, distinct per-host states
 //!
 //! Silence must never read as idle (the #3979 pilot's monitoring lesson). Each
-//! host renders one of five distinct [`HostState`]s: [`HostState::Up`],
+//! host renders one of six distinct [`HostState`]s: [`HostState::Up`],
 //! [`HostState::DaemonDown`] (the host answered, but its daemon reports the
 //! #4069 unreachable-daemon payload), [`HostState::Unreachable`] (SSH/connect
-//! failure or a per-host timeout), [`HostState::ParseError`] (severe version
-//! skew — the payload could not be parsed as JSON at all), and
-//! [`HostState::Draining`] (registry `state: "draining"`, written by `fleet
-//! drain`'s first phase, #4343 — rendered distinctly rather than treated as an
-//! unrecognized/parse-error registry state). An empty roster never renders as
-//! empty output: [`FleetStatusReport::render_human`] always prints an explicit
-//! "no fleet workers registered" notice alongside the local host's row.
+//! failure or a per-host timeout), [`HostState::PoweredOff`] (#4697: an
+//! `Unreachable` host with a configured idle-shutdown window whose silence has
+//! already exceeded that window — likely an EXPECTED power-off, not a
+//! failure), [`HostState::ParseError`] (severe version skew — the payload
+//! could not be parsed as JSON at all), and [`HostState::Draining`] (registry
+//! `state: "draining"`, written by `fleet drain`'s first phase, #4343 —
+//! rendered distinctly rather than treated as an unrecognized/parse-error
+//! registry state). An empty roster never renders as empty output:
+//! [`FleetStatusReport::render_human`] always prints an explicit "no fleet
+//! workers registered" notice alongside the local host's row.
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
 use serde::Serialize;
 use std::process::{Command, Stdio};
 use std::sync::Arc;
@@ -75,6 +79,15 @@ pub enum HostState {
     DaemonDown,
     /// SSH/connect failure, or the per-host collection timed out.
     Unreachable,
+    /// An `Unreachable` host with a configured idle-shutdown window
+    /// ([`WorkerRecord::idle_shutdown_minutes`]) whose observed silence has
+    /// already exceeded that window (#4697) — likely the host's own
+    /// idle-shutdown guard powering it off as designed (#3998/#4477), not a
+    /// failure. Still not `Up` (the exit-code policy, AC 3, treats it as
+    /// unhealthy like every other non-`Up` state), but rendered + labeled
+    /// distinctly so an operator does not mistake "expected, by design" for
+    /// "outage, investigate".
+    PoweredOff,
     /// The host responded, but the payload could not be parsed as JSON at all
     /// (severe version skew) — distinct from `DaemonDown`, whose payload is
     /// still well-formed JSON (#4069).
@@ -92,6 +105,7 @@ impl HostState {
             HostState::Up => "UP",
             HostState::DaemonDown => "DAEMON DOWN",
             HostState::Unreachable => "UNREACHABLE",
+            HostState::PoweredOff => "POWERED OFF (EXPECTED)",
             HostState::ParseError => "PARSE ERROR",
             HostState::Draining => "DRAINING",
         }
@@ -366,6 +380,53 @@ fn classify_status_output(
     }
 }
 
+/// Attempt to reclassify an already-`Unreachable` host as [`HostState::PoweredOff`]
+/// (#4697): an EXPECTED power-off from the host's own idle-shutdown guard
+/// (design correct, #3998/#4477 — out of scope here), rather than a genuinely
+/// unexpected outage. Only ever called on a host `classify_status_output`/the
+/// timeout path already resolved to `Unreachable` — idle-shutdown powers the
+/// WHOLE host off (SSH included), so anything that still answers SSH (even a
+/// `DaemonDown`/`ParseError` payload) is definitionally not this case.
+///
+/// Deliberately conservative (a false "expected, don't worry" reading on a
+/// genuinely dead host is worse than an occasional false alarm, per #4697's
+/// acceptance criteria): reclassifies ONLY when both
+/// [`WorkerRecord::idle_shutdown_minutes`] is configured AND
+/// [`WorkerRecord::last_seen_up_at`] is a parseable past timestamp whose
+/// elapsed silence has already reached that configured window. Either input
+/// missing (no guard configured, or the host has never been observed `Up` by
+/// `fleet status` yet — a freshly-added record, or one predating these
+/// fields) leaves the host `Unreachable`, the pre-#4697,
+/// unexpected-until-proven-otherwise default. Returns `None` to mean "leave
+/// the state alone".
+#[must_use]
+fn classify_expected_power_off(
+    worker: &WorkerRecord,
+    now: DateTime<Utc>,
+) -> Option<(HostState, String)> {
+    let minutes = worker.idle_shutdown_minutes?;
+    let last_seen_raw = worker.last_seen_up_at.as_deref()?;
+    let last_seen_at = DateTime::parse_from_rfc3339(last_seen_raw)
+        .ok()?
+        .with_timezone(&Utc);
+    let elapsed_minutes = now.signed_duration_since(last_seen_at).num_minutes();
+    if elapsed_minutes < i64::from(minutes) {
+        // Silent, but not yet past the configured window — too early to call
+        // this "expected"; stay Unreachable (unexpected-until-proven).
+        return None;
+    }
+    Some((
+        HostState::PoweredOff,
+        format!(
+            "unreachable for {elapsed_minutes}m — past the configured idle-shutdown window \
+             ({minutes}m, last confirmed up at {last_seen_raw}). Likely an EXPECTED power-off \
+             (the host's own idle-shutdown guard), not a failure. Wake it via the provider \
+             console/CLI (Loom never calls a cloud CLI itself — see daemon-reference.md's \
+             `fleet add-worker` idle-shutdown wake-path notes for re-registration steps)."
+        ),
+    ))
+}
+
 fn tail_stderr_or(stderr: &str, fallback: &str) -> String {
     let line = stderr
         .lines()
@@ -415,6 +476,19 @@ pub async fn collect_remote_host(
         }
     };
 
+    // #4697: an Unreachable host may actually be an EXPECTED power-off from
+    // its own idle-shutdown guard rather than a genuine outage — see
+    // classify_expected_power_off's doc comment for the conservative
+    // conditions this requires.
+    let (state, detail) = if state == HostState::Unreachable {
+        match classify_expected_power_off(&worker, Utc::now()) {
+            Some((new_state, new_detail)) => (new_state, Some(new_detail)),
+            None => (state, detail),
+        }
+    } else {
+        (state, detail)
+    };
+
     let safehoused = {
         let src = source.clone();
         let host = alias.clone();
@@ -458,6 +532,11 @@ pub struct FleetStatusSummary {
     pub up: usize,
     pub daemon_down: usize,
     pub unreachable: usize,
+    /// #4697: `Unreachable` hosts reclassified as a likely EXPECTED
+    /// power-off (see [`HostState::PoweredOff`]) — counted separately from
+    /// `unreachable` so a monitor can tell "N unexpected outages" from "N
+    /// hosts probably just idle-shut-down as designed" at a glance.
+    pub powered_off: usize,
     pub parse_error: usize,
     pub draining: usize,
     /// `true` when the fleet registry itself had zero remote workers
@@ -512,12 +591,50 @@ pub async fn collect_fleet_report(
     FleetStatusReport { hosts, summary }
 }
 
+/// After a `fleet status` poll, refresh [`WorkerRecord::last_seen_up_at`] for
+/// every REMOTE host (the local host has no registry record) this poll
+/// observed [`HostState::Up`]. Returns `true` when at least one record
+/// changed, so the caller only re-saves the registry file when something
+/// actually moved.
+///
+/// This is the write side of the #4697 "expected power-off" heuristic
+/// ([`classify_expected_power_off`]): a LATER poll that finds the host
+/// `Unreachable` needs some persisted "last known up" reference point to
+/// measure elapsed silence against, and `fleet status` is the only thing that
+/// ever observes a host's liveness — so it is the one that must persist it
+/// (there is no separate continuous heartbeat/monitor in this design).
+pub fn update_last_seen_up_at(
+    registry: &mut FleetRegistry,
+    report: &FleetStatusReport,
+    now: DateTime<Utc>,
+) -> bool {
+    let now_str = now.to_rfc3339();
+    let mut changed = false;
+    for host in &report.hosts {
+        if host.is_local || host.state != HostState::Up {
+            continue;
+        }
+        if let Some(worker) = registry
+            .workers
+            .iter_mut()
+            .find(|w| w.ssh_host == host.alias)
+        {
+            if worker.last_seen_up_at.as_deref() != Some(now_str.as_str()) {
+                worker.last_seen_up_at = Some(now_str.clone());
+                changed = true;
+            }
+        }
+    }
+    changed
+}
+
 fn summarize(hosts: &[HostReport], empty_roster: bool) -> FleetStatusSummary {
     let mut summary = FleetStatusSummary {
         total: hosts.len(),
         up: 0,
         daemon_down: 0,
         unreachable: 0,
+        powered_off: 0,
         parse_error: 0,
         draining: 0,
         empty_roster,
@@ -527,6 +644,7 @@ fn summarize(hosts: &[HostReport], empty_roster: bool) -> FleetStatusSummary {
             HostState::Up => summary.up += 1,
             HostState::DaemonDown => summary.daemon_down += 1,
             HostState::Unreachable => summary.unreachable += 1,
+            HostState::PoweredOff => summary.powered_off += 1,
             HostState::ParseError => summary.parse_error += 1,
             HostState::Draining => summary.draining += 1,
         }
@@ -586,11 +704,12 @@ impl FleetStatusReport {
             }
         }
         out.push_str(&format!(
-            "\n{} host(s): {} up, {} daemon-down, {} unreachable, {} parse-error, {} draining.\n",
+            "\n{} host(s): {} up, {} daemon-down, {} unreachable, {} powered-off (expected), {} parse-error, {} draining.\n",
             self.summary.total,
             self.summary.up,
             self.summary.daemon_down,
             self.summary.unreachable,
+            self.summary.powered_off,
             self.summary.parse_error,
             self.summary.draining,
         ));
@@ -700,6 +819,8 @@ mod tests {
             state: None,
             drain_phase: None,
             drain_captured: Vec::new(),
+            idle_shutdown_minutes: None,
+            last_seen_up_at: None,
         }
     }
 
@@ -756,6 +877,100 @@ mod tests {
         assert!(detail.unwrap().contains("Connection refused"));
     }
 
+    // ---- classify_expected_power_off (#4697) ------------------------------
+
+    #[test]
+    fn expected_power_off_when_silence_exceeds_idle_shutdown_window() {
+        let mut w = worker("worker-1");
+        w.idle_shutdown_minutes = Some(30);
+        let last_seen = Utc::now() - chrono::Duration::minutes(45);
+        w.last_seen_up_at = Some(last_seen.to_rfc3339());
+
+        let result = classify_expected_power_off(&w, Utc::now());
+        let (state, detail) = result.expect("45m silence should exceed a 30m window");
+        assert_eq!(state, HostState::PoweredOff);
+        assert!(detail.contains("30m"));
+        assert!(detail.contains("EXPECTED power-off"));
+    }
+
+    #[test]
+    fn stays_unreachable_when_silence_well_within_idle_shutdown_window() {
+        let mut w = worker("worker-1");
+        w.idle_shutdown_minutes = Some(30);
+        let last_seen = Utc::now() - chrono::Duration::minutes(5);
+        w.last_seen_up_at = Some(last_seen.to_rfc3339());
+
+        // Silent for only 5m against a 30m window — too early to call this
+        // "expected"; the conservative default (None => leave state alone).
+        assert!(classify_expected_power_off(&w, Utc::now()).is_none());
+    }
+
+    #[test]
+    fn stays_unreachable_when_no_idle_shutdown_configured() {
+        let mut w = worker("worker-1");
+        w.idle_shutdown_minutes = None;
+        w.last_seen_up_at = Some((Utc::now() - chrono::Duration::minutes(999)).to_rfc3339());
+        assert!(classify_expected_power_off(&w, Utc::now()).is_none());
+    }
+
+    #[test]
+    fn stays_unreachable_when_last_seen_up_at_unknown() {
+        let mut w = worker("worker-1");
+        w.idle_shutdown_minutes = Some(30);
+        w.last_seen_up_at = None;
+        assert!(classify_expected_power_off(&w, Utc::now()).is_none());
+    }
+
+    // ---- update_last_seen_up_at (#4697) ------------------------------------
+
+    #[test]
+    fn update_last_seen_up_at_touches_only_up_remote_hosts() {
+        let mut registry = FleetRegistry::default();
+        registry.upsert(worker("up-host"));
+        registry.upsert(worker("down-host"));
+
+        let report = FleetStatusReport {
+            hosts: vec![
+                HostReport::local_up(serde_json::json!({})),
+                HostReport {
+                    alias: "up-host".to_string(),
+                    tailnet_name: None,
+                    provider_instance_id: None,
+                    added_by: None,
+                    is_local: false,
+                    state: HostState::Up,
+                    workspaces: Vec::new(),
+                    status: None,
+                    detail: None,
+                    safehoused: SafehousedProbe::Unknown,
+                },
+                HostReport {
+                    alias: "down-host".to_string(),
+                    tailnet_name: None,
+                    provider_instance_id: None,
+                    added_by: None,
+                    is_local: false,
+                    state: HostState::Unreachable,
+                    workspaces: Vec::new(),
+                    status: None,
+                    detail: None,
+                    safehoused: SafehousedProbe::Unknown,
+                },
+            ],
+            summary: summarize(&[], false),
+        };
+
+        let now = Utc::now();
+        let changed = update_last_seen_up_at(&mut registry, &report, now);
+        assert!(changed);
+        assert_eq!(registry.get("up-host").unwrap().last_seen_up_at, Some(now.to_rfc3339()));
+        assert_eq!(registry.get("down-host").unwrap().last_seen_up_at, None);
+
+        // A second call at the exact same timestamp is a no-op (nothing new
+        // to persist).
+        assert!(!update_last_seen_up_at(&mut registry, &report, now));
+    }
+
     // ---- collect_remote_host / collect_fleet_report -----------------------
 
     #[tokio::test]
@@ -795,6 +1010,52 @@ mod tests {
         assert_eq!(report.summary.unreachable, 1);
         assert_eq!(report.summary.parse_error, 1);
         assert!(!report.summary.empty_roster);
+    }
+
+    /// #4697: end-to-end through `collect_fleet_report`, an idle-shutdown-
+    /// configured host silent past its window classifies as `PoweredOff`, and
+    /// one silent well within its window stays `Unreachable`.
+    #[tokio::test]
+    async fn idle_shutdown_configured_host_past_window_is_powered_off_not_unreachable() {
+        // Both hosts fail to answer SSH at all (a genuinely powered-off host
+        // answers no differently than a genuinely dead one — the ONLY signal
+        // available is elapsed silence vs. the configured window).
+        let responses = HashMap::new();
+        let source: Arc<dyn HostStatusSource> = Arc::new(MockSource::new(responses));
+
+        let mut registry = FleetRegistry::default();
+
+        let mut past_window = worker("past-window-host");
+        past_window.idle_shutdown_minutes = Some(30);
+        past_window.last_seen_up_at =
+            Some((Utc::now() - chrono::Duration::minutes(45)).to_rfc3339());
+        registry.upsert(past_window);
+
+        let mut within_window = worker("within-window-host");
+        within_window.idle_shutdown_minutes = Some(30);
+        within_window.last_seen_up_at =
+            Some((Utc::now() - chrono::Duration::minutes(5)).to_rfc3339());
+        registry.upsert(within_window);
+
+        let local = HostReport::local_up(serde_json::json!({}));
+        let report = collect_fleet_report(source, registry, local, Duration::from_secs(5)).await;
+
+        let by_alias = |alias: &str| report.hosts.iter().find(|h| h.alias == alias).unwrap();
+        let past = by_alias("past-window-host");
+        assert_eq!(past.state, HostState::PoweredOff);
+        assert!(past.detail.as_ref().unwrap().contains("EXPECTED power-off"));
+
+        let within = by_alias("within-window-host");
+        assert_eq!(within.state, HostState::Unreachable);
+
+        assert_eq!(report.summary.powered_off, 1);
+        assert_eq!(report.summary.unreachable, 1);
+        // Still not a healthy fleet — an expected power-off is not "up".
+        assert_ne!(report.exit_code(), 0);
+
+        let rendered = report.render_human();
+        assert!(rendered.contains("POWERED OFF (EXPECTED)"));
+        assert!(rendered.contains("1 powered-off (expected)"));
     }
 
     #[tokio::test]

--- a/loom-daemon/src/fleet/status.rs
+++ b/loom-daemon/src/fleet/status.rs
@@ -105,7 +105,11 @@ impl HostState {
             HostState::Up => "UP",
             HostState::DaemonDown => "DAEMON DOWN",
             HostState::Unreachable => "UNREACHABLE",
-            HostState::PoweredOff => "POWERED OFF (EXPECTED)",
+            // Kept to 11 chars, matching the longest pre-existing label, so
+            // it still fits `render_human`'s `{:<12}` STATE column — the
+            // "expected, not a failure" qualifier rides on the per-row detail
+            // line and the summary tally instead of blowing the table apart.
+            HostState::PoweredOff => "POWERED OFF",
             HostState::ParseError => "PARSE ERROR",
             HostState::Draining => "DRAINING",
         }
@@ -1054,8 +1058,12 @@ mod tests {
         assert_ne!(report.exit_code(), 0);
 
         let rendered = report.render_human();
-        assert!(rendered.contains("POWERED OFF (EXPECTED)"));
+        assert!(rendered.contains("POWERED OFF"));
         assert!(rendered.contains("1 powered-off (expected)"));
+        // The STATE label must not overflow render_human's {:<12} column, or
+        // every remaining cell on that row shifts right and the table stops
+        // being scannable.
+        assert!(HostState::PoweredOff.label().len() <= 11);
     }
 
     #[tokio::test]

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -4726,26 +4726,41 @@ async fn handle_fleet_status_command(json: bool) -> Result<()> {
     };
     use loom_daemon::fleet::FleetRegistry;
 
-    // Kept separate from `registry` below: `collect_fleet_report` consumes
-    // its registry argument (it owns each `WorkerRecord` into the concurrent
-    // per-host collection), so a clone is fanned out while the original stays
-    // available afterward to receive the #4697 `last_seen_up_at` write-back.
-    let registry_for_collection = FleetRegistry::load_default()?;
-    let mut registry = registry_for_collection.clone();
+    // `collect_fleet_report` consumes its registry argument (it owns each
+    // `WorkerRecord` into the concurrent per-host collection).
+    let registry = FleetRegistry::load_default()?;
     let local = collect_local_fleet_report().await;
     let source: Arc<dyn loom_daemon::fleet::status::HostStatusSource> =
         Arc::new(SshStatusSource::new());
     let timeout = Duration::from_secs(loom_daemon::fleet::status::DEFAULT_TIMEOUT_SECS);
-    let report = collect_fleet_report(source, registry_for_collection, local, timeout).await;
+    let report = collect_fleet_report(source, registry, local, timeout).await;
 
     // #4697: persist "last observed Up" so a LATER poll that finds this host
     // Unreachable can measure elapsed silence against its configured
     // idle-shutdown window (the expected-power-off heuristic in
-    // `loom_daemon::fleet::status`). Best-effort: a failure to persist must
-    // never block reporting/exiting on the status the operator asked for.
-    if update_last_seen_up_at(&mut registry, &report, chrono::Utc::now()) {
-        if let Err(e) = registry.save_default() {
-            eprintln!("warning: could not persist fleet registry last-seen-up timestamp(s): {e}");
+    // `loom_daemon::fleet::status`).
+    //
+    // Deliberately RE-LOADS the registry rather than mutating the copy fanned
+    // out above: the SSH collection can take up to DEFAULT_TIMEOUT_SECS, and
+    // `fleet status` is now a writer of a file other commands (`add-worker`,
+    // `drain`) also write. Saving the pre-collection snapshot would silently
+    // clobber anything they committed during that window; re-loading narrows
+    // the lost-update window to the few milliseconds between here and `save`.
+    //
+    // Best-effort throughout: neither a failed re-load nor a failed save may
+    // block reporting/exiting on the status the operator actually asked for.
+    match FleetRegistry::load_default() {
+        Ok(mut fresh) => {
+            if update_last_seen_up_at(&mut fresh, &report, chrono::Utc::now()) {
+                if let Err(e) = fresh.save_default() {
+                    eprintln!(
+                        "warning: could not persist fleet registry last-seen-up timestamp(s): {e}"
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("warning: could not re-read the fleet registry to record last-seen-up: {e}");
         }
     }
 

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -4721,15 +4721,33 @@ fn print_status_unreachable_json(
 /// [`loom_daemon::fleet::status`]; only the local-host collection (which needs
 /// this binary's own socket/install-state machinery) lives here.
 async fn handle_fleet_status_command(json: bool) -> Result<()> {
-    use loom_daemon::fleet::status::{collect_fleet_report, SshStatusSource};
+    use loom_daemon::fleet::status::{
+        collect_fleet_report, update_last_seen_up_at, SshStatusSource,
+    };
     use loom_daemon::fleet::FleetRegistry;
 
-    let registry = FleetRegistry::load_default()?;
+    // Kept separate from `registry` below: `collect_fleet_report` consumes
+    // its registry argument (it owns each `WorkerRecord` into the concurrent
+    // per-host collection), so a clone is fanned out while the original stays
+    // available afterward to receive the #4697 `last_seen_up_at` write-back.
+    let registry_for_collection = FleetRegistry::load_default()?;
+    let mut registry = registry_for_collection.clone();
     let local = collect_local_fleet_report().await;
     let source: Arc<dyn loom_daemon::fleet::status::HostStatusSource> =
         Arc::new(SshStatusSource::new());
     let timeout = Duration::from_secs(loom_daemon::fleet::status::DEFAULT_TIMEOUT_SECS);
-    let report = collect_fleet_report(source, registry, local, timeout).await;
+    let report = collect_fleet_report(source, registry_for_collection, local, timeout).await;
+
+    // #4697: persist "last observed Up" so a LATER poll that finds this host
+    // Unreachable can measure elapsed silence against its configured
+    // idle-shutdown window (the expected-power-off heuristic in
+    // `loom_daemon::fleet::status`). Best-effort: a failure to persist must
+    // never block reporting/exiting on the status the operator asked for.
+    if update_last_seen_up_at(&mut registry, &report, chrono::Utc::now()) {
+        if let Err(e) = registry.save_default() {
+            eprintln!("warning: could not persist fleet registry last-seen-up timestamp(s): {e}");
+        }
+    }
 
     if json {
         println!("{}", serde_json::to_string_pretty(&report)?);


### PR DESCRIPTION
## Summary

Closes the operator-UX gap around the stage-2 idle-shutdown cron guard: an update
could report success on a host that powered itself off minutes later, with no
warning, no documented wake path, and a `fleet status` that could not tell an
expected power-off from a real outage.

The idle-shutdown guard's own behavior is untouched — #3998/#4477's
evaporate-when-idle design is correct and explicitly out of scope. Everything
here is advisory/observability.

## Changes

**`defaults/scripts/cli/loom-daemon-update.sh`** — post-update idle-shutdown notice
- Detects the installed stage-2 guard by the two things `render_idle_shutdown()`
  actually writes: a `loom-idle-shutdown` crontab entry and `LIMIT=<n>` inside
  `$HOME/.local/bin/loom-idle-shutdown.sh`.
- Warns that the host powers itself **fully** off (SSH/tailnet included) after
  ~N idle minutes, that this is by design and not a fault in the update, and
  points at the wake path.
- Hooked into `print_final_installed_line()`, which every success /
  "already up to date" exit path funnels through, so it is reported once and
  consistently rather than duplicated at eight call sites.
- Silent when no guard is installed; suppressible with
  `LOOM_SKIP_IDLE_SHUTDOWN_NOTICE=1`; never changes the exit code.

**`defaults/docs/daemon-reference.md`** — wake path + new state
- `fleet add-worker` step 9 gains a "this is a real power-off, not a suspend"
  block covering: provider console/CLI restart (Loom deliberately never calls a
  cloud CLI), tailnet identity survival across a plain power-cycle vs. a
  re-image, when re-registration is and is not needed, and operator visibility.
- The `fleet status` state list documents `POWERED OFF`, the exit-code policy
  note, and the `powered_off` addition to the `--json` summary schema.
- The "Idle exit for remote hosts" section now says explicitly that
  `autonomous.idleExit` is stage 1 and never powers the host off, pointing at
  step 9 for the mechanism that does.

**`loom-daemon/src/fleet/mod.rs`** — `WorkerRecord` schema
- New `idle_shutdown_minutes: Option<u32>` and `last_seen_up_at: Option<String>`,
  both `#[serde(default, skip_serializing_if = "Option::is_none")]` so pre-#4697
  registries load unchanged and no-idle-shutdown workers serialize unchanged.

**`loom-daemon/src/fleet/add_worker.rs`** — populate at bootstrap
- Extracted `build_worker_record(config, verify_ok, now)` out of `run()` so the
  field mapping is pure and unit testable without an SSH host.
- Populates `idle_shutdown_minutes` from `--idle-shutdown-minutes` and seeds
  `last_seen_up_at` — a fully-successful bootstrap observed the host up over SSH
  moments earlier, so the heuristic has a reference point from the very first poll.

**`loom-daemon/src/fleet/status.rs`** — expected-vs-unexpected classification
- New `HostState::PoweredOff` + `summary.powered_off`.
- `classify_expected_power_off()` reclassifies an already-`Unreachable` host only
  when **both** a window is configured **and** a parseable `last_seen_up_at` shows
  silence that has already reached that window. Either input missing leaves the
  host `UNREACHABLE` — the deliberately conservative default, since a false
  "expected, don't worry" on a genuinely dead host is worse than a false alarm.
- `update_last_seen_up_at()` is the write side: `fleet status` is the only thing
  that ever observes host liveness, so it persists "last confirmed up" for later
  polls to measure against.
- The state label is kept to 11 chars (`POWERED OFF`) so it fits `render_human`'s
  `{:<12}` STATE column; the "expected, not a failure" qualifier and the wake
  pointer ride on the row's `->` detail line and the summary tally.

**`loom-daemon/src/main.rs`** — wiring
- `handle_fleet_status_command` **re-loads** the registry before writing
  `last_seen_up_at` rather than saving its pre-collection snapshot: the SSH
  collection can take up to `DEFAULT_TIMEOUT_SECS`, and `fleet status` is now a
  writer of a file `add-worker`/`drain` also write. Best-effort throughout — a
  failed re-load or save warns and never blocks the status the operator asked for.

## Acceptance Criteria Verification

- [x] **`loom-daemon-update.sh` detects the guard post-update and names the
      configured idle-minutes window** — verified against the real script:
      notice reads `--idle-shutdown-minutes 45)` for a `LIMIT=45` guard; silent
      with an empty crontab; suppressed by `LOOM_SKIP_IDLE_SHUTDOWN_NOTICE=1`;
      exit code unchanged; honest "window unknown" wording when the guard script
      itself is unreadable.
- [x] **Wake path documented in the `fleet add-worker` runbook section** —
      provider console/CLI restart, tailnet ephemeral-state survival, and the
      "no re-registration for a power-cycle, re-run `add-worker` only if the box
      was replaced/re-imaged" rule.
- [x] **`fleet status` distinguishes expected power-off from unexpected
      unreachability, using a window recorded on the `WorkerRecord`** — new
      `POWERED OFF` state driven by the persisted `idle_shutdown_minutes` +
      `last_seen_up_at`, counted separately in the summary and the `--json` schema.
- [x] **No behavior change to the idle-shutdown guard itself** —
      `render_idle_shutdown()` is byte-identical and the diff touches no
      guard/power-off logic. The only `LIMIT=` line anywhere in the diff is an
      unchanged context line from the pre-existing
      `idle_shutdown_step_present_only_when_configured` assertion.

## Test Plan

Automated (all run and passing locally):

- `cargo test -p loom-daemon --lib fleet::` → **109 passed, 0 failed**, including
  the new cases:
  - `expected_power_off_when_silence_exceeds_idle_shutdown_window`
  - `stays_unreachable_when_silence_well_within_idle_shutdown_window`
  - `stays_unreachable_when_no_idle_shutdown_configured`
  - `stays_unreachable_when_last_seen_up_at_unknown`
  - `update_last_seen_up_at_touches_only_up_remote_hosts`
  - `idle_shutdown_configured_host_past_window_is_powered_off_not_unreachable`
    (end-to-end through `collect_fleet_report`, both hosts silent, only the
    past-window one reclassifies; also asserts the label fits the STATE column)
  - `worker_record_carries_configured_idle_shutdown_window`
  - `worker_record_leaves_idle_shutdown_absent_when_not_configured`
  - `worker_record_roundtrips_idle_shutdown_fields_through_the_registry`
  - `registry_roundtrips_4697_idle_shutdown_fields`
  - `registry_record_without_4697_fields_parses_as_absent`
  - `registry_omits_absent_4697_fields_from_serialized_json`
- `cargo fmt --all -- --check` clean; `cargo clippy -p loom-daemon --lib --bins` clean.
- `shellcheck -S warning` clean on both modified shell files; `bash -n` clean.
- `defaults/scripts/tests/test-loom-daemon-update.sh` gains cases 49-53 for the
  notice, plus a `crontab` stub so **no** test in that suite shells out to the
  real operator crontab (the same sandboxing rationale as the existing
  launchd/systemd stubs).

Verified manually but **not** by a full suite run: the host was saturated by
concurrent builders (two other worktrees running this same suite plus a docker
job), and the full `test-loom-daemon-update.sh` did not finish in a usable
window. The five #4697 cases were instead exercised in isolation against the
**real** `loom-daemon-update.sh` with the same fixtures the suite uses — all
five pass. Case 53's fallback wording was likewise confirmed live before being
committed.

Not feasible in this sandbox (noted per the issue's Test Plan): the two
live-host verifications — running the update on an actual guard-installed host,
and letting a provisioned fleet worker power off and reading `fleet status`.
The automated coverage above stands in for the logic; the live checks remain an
operator confirmation.

Pre-existing and unrelated: `cargo clippy --all-targets` fails with two
`manual_split_once` errors in `loom-daemon/src/observability/exporter.rs`
(introduced by #4710 on main, in test code, untouched here).

Closes #4697

🤖 Generated with [Claude Code](https://claude.com/claude-code)
