### PR TITLE
feat(dashboard): add Cloudflare Workers ingest + storage backend for fleet telemetry

### DIFF
--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.wrangler/
+.dev.vars
+.dev.vars.*
+dist/
+*.log

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,128 @@
+# loom-observability-backend
+
+Cloudflare Workers reference backend — **ingest + storage only** — for the
+Loom fleet observability epic ([#4702](https://github.com/rjwalters/loom/issues/4702),
+Phase 2). Accepts the telemetry batches `loom-daemon`'s `HttpsExporter`
+(`loom-daemon/src/observability/exporter.rs`, Phase 1 — #4705) pushes,
+authenticates the sending host, persists durable history to D1, and
+maintains a live "what is running right now" snapshot in a Durable Object.
+
+Wire format reference: [`.loom/docs/telemetry-schema.md`](../.loom/docs/telemetry-schema.md).
+
+**Out of scope for this issue** (later Phase-2 sibling issues / Phase 3):
+a dashboard read/query API, Cloudflare Access auth, visibility-based
+redaction beyond faithfully storing the `visibility` tag, and a polished
+one-click deploy/hosting template (tracked separately — #4728).
+
+## Architecture
+
+- **D1** (`records` table) — durable history of every accepted record, one
+  row per record, indexed for `host_id`/`repo`/time-range queries. Bounded
+  by the retention sweep (age + size caps — see `src/retention.ts`).
+- **Durable Object** (`FleetState`, singleton) — live per-host health/token
+  snapshots plus currently in-flight sweeps. Independent of D1; a
+  best-effort cache, not a source of truth (see `src/fleetState.ts`).
+- **`hosts` table** — per-host ingest key auth. Only a SHA-256 hash of each
+  key is stored; a key is only ever shown once, at creation time.
+
+## Local development
+
+```bash
+npm install
+npx wrangler d1 migrations apply loom-observability --local
+npm run dev          # wrangler dev — binds DB/FLEET_STATE locally
+```
+
+`wrangler dev` does not read `wrangler.toml`'s `[vars]`-declared secrets —
+set `ADMIN_TOKEN` for local testing via a `.dev.vars` file (gitignored,
+never commit it):
+
+```bash
+echo 'ADMIN_TOKEN="local-dev-admin-token"' > .dev.vars
+```
+
+Provision a host and push a batch exactly like the daemon does (bare JSON
+array body, `Authorization: Bearer <ingest_key>`):
+
+```bash
+curl -X POST http://localhost:8787/admin/hosts \
+  -H 'content-type: application/json' \
+  -H 'authorization: Bearer local-dev-admin-token' \
+  -d '{"host_id":"my-host"}'
+# => {"host_id":"my-host","ingest_key":"<shown once>"}
+
+curl -X POST http://localhost:8787/ingest \
+  -H 'content-type: application/json' \
+  -H 'authorization: Bearer <ingest_key from above>' \
+  -d '[{"schema_version":1,"emitted_at":"2026-07-30T12:00:00Z","host_id":"my-host",
+       "record":{"kind":"host.health","captured_at":"2026-07-30T12:00:00Z",
+                  "daemon_version":"0.16.0","uptime_sec":10,"logical_cpus":8}}]'
+
+curl http://localhost:8787/admin/fleet-state -H 'authorization: Bearer local-dev-admin-token'
+```
+
+## Tests
+
+```bash
+npm test          # vitest run, via @cloudflare/vitest-pool-workers (Miniflare)
+npm run typecheck # tsc --noEmit
+npm run check     # both
+```
+
+Every test runs inside the real Workers runtime (Miniflare) against an
+isolated in-memory D1 instance with `migrations/` applied — see
+`vitest.config.ts` / `test/apply-migrations.ts`.
+
+## Deploying your own instance
+
+1. `npx wrangler d1 create loom-observability` and paste the returned
+   `database_id` into `wrangler.toml`.
+2. `npx wrangler d1 migrations apply loom-observability --remote`.
+3. `npx wrangler secret put ADMIN_TOKEN` (generate one with e.g.
+   `openssl rand -hex 32` — this gates every `/admin/*` route).
+4. `npm run deploy`.
+5. Provision each fleet host: `POST /admin/hosts {"host_id": "..."}`, capture
+   the returned `ingest_key` (shown once), and configure it on that host's
+   daemon (`loom-daemon`'s observability exporter config — endpoint +
+   ingest key).
+6. Revoke a compromised/decommissioned host at any time:
+   `POST /admin/hosts/<host_id>/revoke` — other hosts' keys are unaffected.
+
+A full hosting template + turnkey runbook (one-click deploy button, DNS/
+custom-domain guidance, etc.) is a separate, later issue (#4728); the steps
+above are the minimum needed to stand up a working instance.
+
+## Routes
+
+| Route | Auth | Purpose |
+|---|---|---|
+| `POST /ingest` | `Authorization: Bearer <ingest_key>` | Accept a batch (bare JSON array of `TelemetryEnvelope`s). |
+| `POST /admin/hosts` | `Authorization: Bearer <ADMIN_TOKEN>` | Provision a host + ingest key (`{"host_id": "..."}`, optional `"key"` to bring your own). |
+| `POST /admin/hosts/:hostId/revoke` | `Authorization: Bearer <ADMIN_TOKEN>` | Revoke a host's key. |
+| `POST /admin/retention/run` | `Authorization: Bearer <ADMIN_TOKEN>` | Run the retention sweep on demand (also runs hourly via `[triggers] crons`). |
+| `GET /admin/fleet-state` | `Authorization: Bearer <ADMIN_TOKEN>` | Read the Durable Object's live snapshot (introspection/manual verification — not the Phase-3 dashboard query API). |
+
+## Design decisions worth knowing
+
+- **Whole-batch rejection.** `HttpsExporter` only acks (removes from its
+  durable queue) a batch on a 2xx response and otherwise retries the whole
+  batch with backoff. So a single malformed envelope in an otherwise-valid
+  batch rejects the *entire* batch (400, with the offending envelope's
+  index in the error message) rather than a partial accept/reject — the
+  simpler, correct choice given that retry contract (see `src/index.ts`'s
+  `handleIngest` doc comment).
+- **Authoritative host identity comes from the key, not the envelope.**
+  `envelope.host_id` is an opaque, client-supplied string per the schema;
+  the row persisted to D1 always uses the host id bound to the
+  authenticated ingest key, so one host's key can never write records
+  under another host's identity.
+- **The Durable Object update is best-effort.** The D1 write is the
+  durability boundary; if updating the live-state DO fails after a
+  successful D1 write, the response still succeeds (logging the DO
+  failure) rather than causing the exporter to retry and duplicate the
+  already-committed D1 rows.
+- **`visibility` fail-safe-to-private** is enforced in code
+  (`src/telemetry.ts`'s `decodeVisibility`) before every D1 write, exactly
+  mirroring the Rust daemon's decode rule: only the exact string
+  `"public"` is public, everything else (missing, unknown label, wrong
+  type, `null`) is private.

--- a/dashboard/migrations/0001_init.sql
+++ b/dashboard/migrations/0001_init.sql
@@ -1,0 +1,52 @@
+-- Loom fleet observability backend — initial schema (Epic #4702, Phase 2).
+--
+-- Two tables:
+--   hosts   — per-host ingest key auth (hashed keys, individually revocable).
+--   records — durable history of every accepted telemetry record, one row
+--             per record (envelopes with N records in a batch produce N rows).
+--
+-- The Durable Object (src/fleetState.ts) holds live/current state and is
+-- NOT backed by this schema — it is independent per-object SQLite/KV storage
+-- Cloudflare manages itself.
+
+CREATE TABLE hosts (
+  host_id    TEXT PRIMARY KEY,
+  key_hash   TEXT NOT NULL UNIQUE,
+  created_at TEXT NOT NULL,
+  revoked_at TEXT
+);
+
+-- Every ingest request authenticates by hashing the presented bearer token
+-- and looking it up here — this index makes that lookup O(log n) instead of
+-- a table scan.
+CREATE INDEX idx_hosts_key_hash ON hosts (key_hash);
+
+CREATE TABLE records (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  schema_version INTEGER NOT NULL,
+  emitted_at     TEXT NOT NULL,
+  host_id        TEXT NOT NULL,
+  kind           TEXT NOT NULL,
+  repo           TEXT,
+  -- Fail-safe default: mirrors the daemon's RepoVisibility decode contract
+  -- (.loom/docs/telemetry-schema.md) — anything that is not exactly the
+  -- string "public" must persist as "private". This column-level default
+  -- only covers a missing value at the SQL layer; the actual fail-safe
+  -- decision is made in code (src/telemetry.ts `decodeVisibility`) before
+  -- the INSERT, so this default is a defense-in-depth backstop, not the
+  -- primary control.
+  visibility     TEXT NOT NULL DEFAULT 'private',
+  issue          INTEGER,
+  sweep_id       TEXT,
+  -- The full envelope's record payload, verbatim, as JSON — so a
+  -- forward-compatible higher schema_version's extra fields are never lost
+  -- even though this migration only indexes the fields known today.
+  payload        TEXT NOT NULL,
+  ingested_at    TEXT NOT NULL
+);
+
+-- Query patterns from the AC ("queryable by host/repo/time range") plus the
+-- retention sweep's own access pattern (oldest-first eviction).
+CREATE INDEX idx_records_host_time ON records (host_id, emitted_at);
+CREATE INDEX idx_records_repo_time ON records (repo, emitted_at);
+CREATE INDEX idx_records_ingested_at ON records (ingested_at);

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,0 +1,3233 @@
+{
+  "name": "loom-observability-backend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "loom-observability-backend",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "0.10.15",
+        "@cloudflare/workers-types": "^4.20251210.0",
+        "typescript": "^5.7.2",
+        "vitest": "^3.2.4",
+        "wrangler": "4.54.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.1.tgz",
+      "integrity": "sha512-Nu8ahitGFFJztxUml9oD/DLb7Z28C8cd8F46IVQ7y5Btz575pvMY8AqZsXkX7Gds29eCKdMgIHjIvzskHgPSFg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.7.13",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.7.13.tgz",
+      "integrity": "sha512-NulO1H8R/DzsJguLC0ndMuk4Ufv0KSlN+E54ay9rn9ZCQo0kpAPwwh3LhgpZ96a3Dr6L9LqW57M4CqC34iLOvw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": "^1.20251202.0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.10.15",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.10.15.tgz",
+      "integrity": "sha512-eISef+JvqC5xr6WBv2+kc6WEjxuKSrZ1MdMuIwdb4vsh8olqw7WHW5pLBL/UzAhbLVlXaAL1uH9UyxIlFkJe7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "birpc": "0.2.14",
+        "cjs-module-lexer": "^1.2.3",
+        "devalue": "^5.3.2",
+        "miniflare": "4.20251210.0",
+        "semver": "^7.7.1",
+        "wrangler": "4.54.0",
+        "zod": "^3.22.3"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "2.0.x - 3.2.x",
+        "@vitest/snapshot": "2.0.x - 3.2.x",
+        "vitest": "2.0.x - 3.2.x"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20251210.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20251210.0.tgz",
+      "integrity": "sha512-Nn9X1moUDERA9xtFdCQ2XpQXgAS9pOjiCxvOT8sVx9UJLAiBLkfSCGbpsYdarODGybXCpjRlc77Yppuolvt7oQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20251210.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20251210.0.tgz",
+      "integrity": "sha512-Mg8iYIZQFnbevq/ls9eW/eneWTk/EE13Pej1MwfkY5et0jVpdHnvOLywy/o+QtMJFef1AjsqXGULwAneYyBfHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20251210.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20251210.0.tgz",
+      "integrity": "sha512-kjC2fCZhZ2Gkm1biwk2qByAYpGguK5Gf5ic8owzSCUw0FOUfQxTZUT9Lp3gApxsfTLbbnLBrX/xzWjywH9QR4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20251210.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20251210.0.tgz",
+      "integrity": "sha512-2IB37nXi7PZVQLa1OCuO7/6pNxqisRSO8DmCQ5x/3sezI5op1vwOxAcb1osAnuVsVN9bbvpw70HJvhKruFJTuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20251210.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20251210.0.tgz",
+      "integrity": "sha512-Uaz6/9XE+D6E7pCY4OvkCuJHu7HcSDzeGcCGY1HLhojXhHd7yL52c3yfiyJdS8hPatiAa0nn5qSI/42+aTdDSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260702.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.14.tgz",
+      "integrity": "sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
+      "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20251210.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20251210.0.tgz",
+      "integrity": "sha512-k6kIoXwGVqlPZb0hcn+X7BmnK+8BjIIkusQPY22kCo2RaQJ/LzAjtxHQdGXerlHSnJyQivDQsL6BJHMpQfUFyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "8.14.0",
+        "acorn-walk": "8.3.2",
+        "exit-hook": "2.2.1",
+        "glob-to-regexp": "0.4.1",
+        "sharp": "^0.33.5",
+        "stoppable": "1.1.0",
+        "undici": "7.14.0",
+        "workerd": "1.20251210.0",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10",
+        "zod": "3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/miniflare/node_modules/zod": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
+      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.3",
+        "@rollup/rollup-android-arm64": "4.62.3",
+        "@rollup/rollup-darwin-arm64": "4.62.3",
+        "@rollup/rollup-darwin-x64": "4.62.3",
+        "@rollup/rollup-freebsd-arm64": "4.62.3",
+        "@rollup/rollup-freebsd-x64": "4.62.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
+        "@rollup/rollup-linux-arm64-musl": "4.62.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
+        "@rollup/rollup-linux-loong64-musl": "4.62.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-musl": "4.62.3",
+        "@rollup/rollup-openbsd-x64": "4.62.3",
+        "@rollup/rollup-openharmony-arm64": "4.62.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
+        "@rollup/rollup-win32-x64-gnu": "4.62.3",
+        "@rollup/rollup-win32-x64-msvc": "4.62.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
+      "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20251210.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20251210.0.tgz",
+      "integrity": "sha512-9MUUneP1BnRE9XAYi94FXxHmiLGbO75EHQZsgWqSiOXjoXSqJCw8aQbIEPxCy19TclEl/kHUFYce8ST2W+Qpjw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20251210.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20251210.0",
+        "@cloudflare/workerd-linux-64": "1.20251210.0",
+        "@cloudflare/workerd-linux-arm64": "1.20251210.0",
+        "@cloudflare/workerd-windows-64": "1.20251210.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.54.0.tgz",
+      "integrity": "sha512-bANFsjDwJLbprYoBK+hUDZsVbUv2SqJd8QvArLIcZk+fPq4h/Ohtj5vkKXD3k0s2bD1DXLk08D+hYmeNH+xC6A==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.1",
+        "@cloudflare/unenv-preset": "2.7.13",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.0",
+        "miniflare": "4.20251210.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20251210.0"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20251210.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+      "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+      "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+      "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+      "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+      "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+      "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+      "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+      "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+      "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+      "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+      "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+      "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+      "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+      "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+      "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+      "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+      "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+      "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+      "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+      "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+      "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+      "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.0",
+        "@esbuild/android-arm": "0.27.0",
+        "@esbuild/android-arm64": "0.27.0",
+        "@esbuild/android-x64": "0.27.0",
+        "@esbuild/darwin-arm64": "0.27.0",
+        "@esbuild/darwin-x64": "0.27.0",
+        "@esbuild/freebsd-arm64": "0.27.0",
+        "@esbuild/freebsd-x64": "0.27.0",
+        "@esbuild/linux-arm": "0.27.0",
+        "@esbuild/linux-arm64": "0.27.0",
+        "@esbuild/linux-ia32": "0.27.0",
+        "@esbuild/linux-loong64": "0.27.0",
+        "@esbuild/linux-mips64el": "0.27.0",
+        "@esbuild/linux-ppc64": "0.27.0",
+        "@esbuild/linux-riscv64": "0.27.0",
+        "@esbuild/linux-s390x": "0.27.0",
+        "@esbuild/linux-x64": "0.27.0",
+        "@esbuild/netbsd-arm64": "0.27.0",
+        "@esbuild/netbsd-x64": "0.27.0",
+        "@esbuild/openbsd-arm64": "0.27.0",
+        "@esbuild/openbsd-x64": "0.27.0",
+        "@esbuild/openharmony-arm64": "0.27.0",
+        "@esbuild/sunos-x64": "0.27.0",
+        "@esbuild/win32-arm64": "0.27.0",
+        "@esbuild/win32-ia32": "0.27.0",
+        "@esbuild/win32-x64": "0.27.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "loom-observability-backend",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Cloudflare Workers reference backend (ingest + storage) for the Loom fleet observability epic (#4702, Phase 2). Accepts pushed telemetry batches from loom-daemon's HttpsExporter, authenticates per-host, persists durable history to D1, and maintains live fleet state in a Durable Object.",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "check": "npm run typecheck && npm run test"
+  },
+  "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "0.10.15",
+    "@cloudflare/workers-types": "^4.20251210.0",
+    "typescript": "^5.7.2",
+    "vitest": "^3.2.4",
+    "wrangler": "4.54.0"
+  }
+}

--- a/dashboard/src/auth.ts
+++ b/dashboard/src/auth.ts
@@ -1,0 +1,67 @@
+/**
+ * Per-host ingest key authentication (Epic #4702, Phase 2 AC: "each daemon's
+ * push is authenticated by a distinct key; a revoked key stops accepting
+ * new writes without affecting other hosts").
+ *
+ * Keys are never stored in plaintext — only a SHA-256 hex digest is
+ * persisted in D1 (`hosts.key_hash`), so a leaked database dump does not
+ * hand over live credentials. The bearer token presented on `/ingest`
+ * authenticates the *host identity* — the authoritative `host_id` for a
+ * request is the one bound to the matched key, not whatever `host_id`
+ * happens to be inside the envelope bodies (which is otherwise an opaque,
+ * client-supplied string per the schema doc) — this prevents one host's key
+ * from writing records under another host's identity.
+ */
+
+export interface HostAuthResult {
+  hostId: string;
+}
+
+/** SHA-256 hex digest of `key`, using the Workers runtime's native
+ * `crypto.subtle` (no extra dependency, no Node `Buffer`). */
+export async function hashIngestKey(key: string): Promise<string> {
+  const data = new TextEncoder().encode(key);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return toHex(digest);
+}
+
+function toHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** Extract the bearer token from an `Authorization` header value, or
+ * `null` if the header is absent or not a `Bearer` scheme. */
+export function extractBearerToken(authorizationHeader: string | null): string | null {
+  if (!authorizationHeader) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(authorizationHeader.trim());
+  return match?.[1] ? match[1].trim() : null;
+}
+
+/**
+ * Authenticate an ingest request's `Authorization` header against the
+ * `hosts` table. Returns the authoritative host id on success, or `null` on
+ * any failure (missing header, unknown key, revoked key) — the caller
+ * always responds 401 in every `null` case, deliberately not distinguishing
+ * "unknown key" from "revoked key" in the HTTP response (a distinguishable
+ * error would let an attacker enumerate which keys once existed).
+ */
+export async function authenticateHost(
+  db: D1Database,
+  authorizationHeader: string | null,
+): Promise<HostAuthResult | null> {
+  const token = extractBearerToken(authorizationHeader);
+  if (!token) return null;
+
+  const keyHash = await hashIngestKey(token);
+  const row = await db
+    .prepare("SELECT host_id, revoked_at FROM hosts WHERE key_hash = ?")
+    .bind(keyHash)
+    .first<{ host_id: string; revoked_at: string | null }>();
+
+  if (!row || row.revoked_at !== null) {
+    return null;
+  }
+  return { hostId: row.host_id };
+}

--- a/dashboard/src/fleetState.ts
+++ b/dashboard/src/fleetState.ts
@@ -1,0 +1,180 @@
+/**
+ * `FleetState` Durable Object — the live "what is running right now across
+ * every host" snapshot (Epic #4702, Phase 2 AC: "Durable Object holds
+ * current live fleet state (updated per ingested record), independent of
+ * D1 history"). Analogous to what `loom-daemon serve`'s in-process state
+ * provides for a single host today, but aggregated across the whole fleet.
+ *
+ * A single global instance is used (see `FLEET_STATE_ID` in `src/index.ts`)
+ * — the live-state working set (per-host health/tokens plus currently
+ * in-flight sweeps) is small enough that one Durable Object's storage is
+ * more than sufficient, and a singleton keeps "read the current fleet
+ * state" a single object lookup rather than a fan-out across N per-host
+ * objects.
+ *
+ * Storage layout (three key prefixes, iterated via `list({ prefix })` to
+ * build a snapshot):
+ *   `health:<hostId>`  → latest `host.health` record + when it was applied.
+ *   `tokens:<hostId>`  → latest `tokens.snapshot` record + when applied.
+ *   `sweep:<sweepId>`  → the in-flight sweep's current known state; removed
+ *                        entirely on `sweep.completed` (a finished sweep is
+ *                        not "live" — its full history lives in D1).
+ *
+ * This D1-vs-DO split is deliberate: D1 answers "what happened", the DO
+ * answers "what is happening right now", and the DO is never treated as a
+ * source of truth for history — see `src/index.ts`'s ingest handler, which
+ * always writes D1 first and treats a DO update failure as best-effort.
+ */
+
+export interface ActiveSweepState {
+  hostId: string;
+  sweepId: string;
+  repo?: string;
+  visibility: "public" | "private";
+  issue?: number;
+  phase?: string;
+  startedAt?: string;
+  enteredPhaseAt?: string;
+  model?: string;
+  effort?: string;
+  updatedAt: string;
+}
+
+export interface FleetSnapshot {
+  hosts: Record<
+    string,
+    {
+      health?: { record: Record<string, unknown>; updatedAt: string };
+      tokens?: { record: Record<string, unknown>; updatedAt: string };
+    }
+  >;
+  activeSweeps: ActiveSweepState[];
+}
+
+/** Body accepted by the internal `POST /update` route — one record's worth
+ * of live-state effect, already authenticated/validated by the Worker
+ * before it reaches the Durable Object. */
+export interface FleetStateUpdate {
+  hostId: string;
+  record: Record<string, unknown>;
+}
+
+export class FleetState implements DurableObject {
+  private readonly state: DurableObjectState;
+
+  constructor(state: DurableObjectState) {
+    this.state = state;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method === "POST" && url.pathname === "/update") {
+      const body = (await request.json()) as FleetStateUpdate;
+      await this.applyUpdate(body);
+      return new Response(null, { status: 204 });
+    }
+
+    if (request.method === "GET" && url.pathname === "/snapshot") {
+      const snapshot = await this.buildSnapshot();
+      return new Response(JSON.stringify(snapshot), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    return new Response("not found", { status: 404 });
+  }
+
+  private async applyUpdate({ hostId, record }: FleetStateUpdate): Promise<void> {
+    const kind = record.kind;
+    const now = new Date().toISOString();
+
+    switch (kind) {
+      case "host.health": {
+        await this.state.storage.put(`health:${hostId}`, { record, updatedAt: now });
+        break;
+      }
+      case "tokens.snapshot": {
+        await this.state.storage.put(`tokens:${hostId}`, { record, updatedAt: now });
+        break;
+      }
+      case "sweep.started": {
+        const sweepId = record.sweep_id;
+        if (typeof sweepId !== "string") return;
+        const entry: ActiveSweepState = {
+          hostId,
+          sweepId,
+          repo: typeof record.repo === "string" ? record.repo : undefined,
+          visibility: record.visibility === "public" ? "public" : "private",
+          issue: typeof record.issue === "number" ? record.issue : undefined,
+          startedAt: typeof record.started_at === "string" ? record.started_at : undefined,
+          model: typeof record.model === "string" ? record.model : undefined,
+          effort: typeof record.effort === "string" ? record.effort : undefined,
+          updatedAt: now,
+        };
+        await this.state.storage.put(`sweep:${sweepId}`, entry);
+        break;
+      }
+      case "sweep.phase": {
+        const sweepId = record.sweep_id;
+        if (typeof sweepId !== "string") return;
+        const existing = await this.state.storage.get<ActiveSweepState>(`sweep:${sweepId}`);
+        const entry: ActiveSweepState = {
+          hostId,
+          sweepId,
+          repo: existing?.repo ?? (typeof record.repo === "string" ? record.repo : undefined),
+          visibility:
+            existing?.visibility ?? (record.visibility === "public" ? "public" : "private"),
+          issue: existing?.issue ?? (typeof record.issue === "number" ? record.issue : undefined),
+          startedAt: existing?.startedAt,
+          phase: typeof record.phase === "string" ? record.phase : existing?.phase,
+          enteredPhaseAt: typeof record.entered_at === "string" ? record.entered_at : now,
+          model: existing?.model,
+          effort: existing?.effort,
+          updatedAt: now,
+        };
+        await this.state.storage.put(`sweep:${sweepId}`, entry);
+        break;
+      }
+      case "sweep.completed": {
+        const sweepId = record.sweep_id;
+        if (typeof sweepId !== "string") return;
+        // A completed sweep is no longer "live" — its full record already
+        // landed in D1 via the same ingest batch. Removing it here keeps
+        // the DO's working set bounded by concurrently-running sweeps only.
+        await this.state.storage.delete(`sweep:${sweepId}`);
+        break;
+      }
+      default:
+        // sweep.outcome and any forward-compatible unknown kind carry no
+        // additional live-state signal beyond what sweep.started/phase/
+        // completed already captured — D1 is the durable record of it.
+        break;
+    }
+  }
+
+  private async buildSnapshot(): Promise<FleetSnapshot> {
+    const hosts: FleetSnapshot["hosts"] = {};
+    const healthEntries = await this.state.storage.list<{ record: Record<string, unknown>; updatedAt: string }>({
+      prefix: "health:",
+    });
+    for (const [key, value] of healthEntries) {
+      const hostId = key.slice("health:".length);
+      hosts[hostId] ??= {};
+      hosts[hostId].health = value;
+    }
+    const tokenEntries = await this.state.storage.list<{ record: Record<string, unknown>; updatedAt: string }>({
+      prefix: "tokens:",
+    });
+    for (const [key, value] of tokenEntries) {
+      const hostId = key.slice("tokens:".length);
+      hosts[hostId] ??= {};
+      hosts[hostId].tokens = value;
+    }
+
+    const sweepEntries = await this.state.storage.list<ActiveSweepState>({ prefix: "sweep:" });
+    const activeSweeps = Array.from(sweepEntries.values());
+
+    return { hosts, activeSweeps };
+  }
+}

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -1,0 +1,277 @@
+/**
+ * Worker entrypoint — the Epic #4702 Phase 2 ingest endpoint + storage
+ * backend. Routes:
+ *
+ *   POST /ingest
+ *     The wire contract this route MUST satisfy is fixed by the already-
+ *     merged Phase-1 sender (`loom-daemon/src/observability/exporter.rs`):
+ *     a bare JSON array of `TelemetryEnvelope`s, `Authorization: Bearer
+ *     <ingest_key>`. See `handleIngest` below for the full contract.
+ *
+ *   POST /admin/hosts               — provision a new host + ingest key.
+ *   POST /admin/hosts/:hostId/revoke — revoke a host's key.
+ *   POST /admin/retention/run       — run the retention sweep on demand
+ *                                      (the cron `scheduled()` handler runs
+ *                                      the same sweep hourly).
+ *   GET  /admin/fleet-state         — read the Durable Object's live
+ *                                      snapshot (introspection/verification
+ *                                      only — NOT the Phase 3 dashboard
+ *                                      query API, which is a separate,
+ *                                      unauthenticated-by-admin-token,
+ *                                      out-of-scope-for-this-issue route).
+ *
+ * All `/admin/*` routes require `Authorization: Bearer <ADMIN_TOKEN>`
+ * (a `wrangler secret`, never committed) — see README.md.
+ *
+ * Scope boundary (per the issue): ingest + storage only. No dashboard read
+ * API, no Cloudflare Access auth — those are later epic phases.
+ */
+
+import { extractBearerToken, authenticateHost, hashIngestKey } from "./auth";
+import { FleetState } from "./fleetState";
+import { parseRetentionConfig, runRetentionSweep } from "./retention";
+import { validateEnvelope, extractRecordFields, type TelemetryEnvelope } from "./telemetry";
+
+export { FleetState };
+
+export interface Env {
+  DB: D1Database;
+  FLEET_STATE: DurableObjectNamespace;
+  RETENTION_DAYS?: string;
+  MAX_RECORDS?: string;
+  ADMIN_TOKEN?: string;
+}
+
+/** A single global Durable Object instance holds fleet-wide live state —
+ * see the module doc in `fleetState.ts` for why a singleton is sufficient. */
+const FLEET_STATE_ID_NAME = "fleet-singleton";
+
+const JSON_HEADERS = { "content-type": "application/json" };
+
+function jsonError(status: number, message: string): Response {
+  return new Response(JSON.stringify({ error: message }), { status, headers: JSON_HEADERS });
+}
+
+function fleetStateStub(env: Env): DurableObjectStub {
+  return env.FLEET_STATE.get(env.FLEET_STATE.idFromName(FLEET_STATE_ID_NAME));
+}
+
+// ---------------------------------------------------------------------------
+// /ingest
+// ---------------------------------------------------------------------------
+
+async function handleIngest(request: Request, env: Env): Promise<Response> {
+  const auth = await authenticateHost(env.DB, request.headers.get("authorization"));
+  if (!auth) {
+    return jsonError(401, "invalid or revoked ingest key");
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, "request body must be valid JSON");
+  }
+  if (!Array.isArray(body)) {
+    return jsonError(400, "request body must be a bare JSON array of telemetry envelopes");
+  }
+  if (body.length === 0) {
+    return new Response(JSON.stringify({ accepted: 0 }), { status: 200, headers: JSON_HEADERS });
+  }
+
+  // Whole-batch rejection on the first malformed envelope. Documented
+  // decision (see the issue's Implementation Guidance): the exporter only
+  // acks a batch on 2xx and otherwise retries the *entire* batch with
+  // backoff, so partial-accept/partial-reject would need per-record
+  // idempotency tracking on the exporter side that does not exist. Reject-
+  // whole-batch is simplest and correct given that retry contract — a
+  // single malformed envelope from a buggy client fails the same way every
+  // retry (never a silent partial success), and the response's error
+  // message identifies exactly which envelope index is at fault so the
+  // problem is visible in the daemon's own export-failure logs.
+  const envelopes: TelemetryEnvelope[] = [];
+  for (let i = 0; i < body.length; i++) {
+    const result = validateEnvelope(body[i], i);
+    if (!result.ok) {
+      return jsonError(400, `envelope ${result.error.index}: ${result.error.reason}`);
+    }
+    envelopes.push(result.envelope);
+  }
+
+  const nowIso = new Date().toISOString();
+  const statements = envelopes.map((envelope) => {
+    const fields = extractRecordFields(envelope.record);
+    return env.DB.prepare(
+      `INSERT INTO records
+         (schema_version, emitted_at, host_id, kind, repo, visibility, issue, sweep_id, payload, ingested_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).bind(
+      envelope.schema_version,
+      envelope.emitted_at,
+      // Authoritative host id from the authenticated key — NOT
+      // `envelope.host_id` (opaque/client-supplied; see auth.ts doc).
+      auth.hostId,
+      fields.kind,
+      fields.repo ?? null,
+      fields.visibility,
+      fields.issue ?? null,
+      fields.sweepId ?? null,
+      JSON.stringify(envelope.record),
+      nowIso,
+    );
+  });
+
+  try {
+    // `D1Database.batch()` runs all statements as a single all-or-nothing
+    // transaction — either every envelope in this batch is persisted, or
+    // none are (matching the whole-batch semantics above).
+    await env.DB.batch(statements);
+  } catch (error) {
+    return jsonError(500, `failed to persist batch: ${(error as Error).message}`);
+  }
+
+  // Best-effort live-state update. Deliberately NOT allowed to fail the
+  // response: the D1 write above already durably committed this batch, so
+  // failing the response here would make the exporter retry and duplicate
+  // those D1 rows. The Durable Object is a live-state cache, not the
+  // source of truth — see fleetState.ts's module doc.
+  try {
+    const stub = fleetStateStub(env);
+    for (const envelope of envelopes) {
+      await stub.fetch("https://fleet-state/update", {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ hostId: auth.hostId, record: envelope.record }),
+      });
+    }
+  } catch (error) {
+    console.error(`fleet state update failed (D1 write already committed): ${(error as Error).message}`);
+  }
+
+  return new Response(JSON.stringify({ accepted: envelopes.length }), {
+    status: 200,
+    headers: JSON_HEADERS,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// /admin/*
+// ---------------------------------------------------------------------------
+
+interface CreateHostBody {
+  host_id?: unknown;
+  key?: unknown;
+}
+
+function generateIngestKey(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function handleCreateHost(request: Request, env: Env): Promise<Response> {
+  let body: CreateHostBody;
+  try {
+    body = (await request.json()) as CreateHostBody;
+  } catch {
+    return jsonError(400, "request body must be valid JSON");
+  }
+  const hostId = body.host_id;
+  if (typeof hostId !== "string" || hostId.length === 0) {
+    return jsonError(400, "host_id is required");
+  }
+
+  const existing = await env.DB.prepare("SELECT host_id FROM hosts WHERE host_id = ?").bind(hostId).first();
+  if (existing) {
+    return jsonError(409, `host_id "${hostId}" already exists`);
+  }
+
+  const key = typeof body.key === "string" && body.key.length > 0 ? body.key : generateIngestKey();
+  const keyHash = await hashIngestKey(key);
+  await env.DB.prepare("INSERT INTO hosts (host_id, key_hash, created_at, revoked_at) VALUES (?, ?, ?, NULL)")
+    .bind(hostId, keyHash, new Date().toISOString())
+    .run();
+
+  // The plaintext key is returned exactly once, here — only its hash is
+  // ever persisted, so this response is the operator's only chance to
+  // capture it (for the daemon's `[observability].ingest_key` config).
+  return new Response(JSON.stringify({ host_id: hostId, ingest_key: key }), {
+    status: 201,
+    headers: JSON_HEADERS,
+  });
+}
+
+async function handleRevokeHost(env: Env, hostId: string): Promise<Response> {
+  const result = await env.DB.prepare("UPDATE hosts SET revoked_at = ? WHERE host_id = ? AND revoked_at IS NULL")
+    .bind(new Date().toISOString(), hostId)
+    .run();
+  if ((result.meta.changes ?? 0) === 0) {
+    return jsonError(404, `host_id "${hostId}" not found or already revoked`);
+  }
+  return new Response(JSON.stringify({ host_id: hostId, revoked: true }), {
+    status: 200,
+    headers: JSON_HEADERS,
+  });
+}
+
+async function handleAdmin(request: Request, env: Env, url: URL): Promise<Response> {
+  if (!env.ADMIN_TOKEN) {
+    return jsonError(503, "admin routes are not configured (ADMIN_TOKEN secret unset)");
+  }
+  const token = extractBearerToken(request.headers.get("authorization"));
+  if (token !== env.ADMIN_TOKEN) {
+    return jsonError(401, "invalid admin token");
+  }
+
+  if (request.method === "POST" && url.pathname === "/admin/hosts") {
+    return handleCreateHost(request, env);
+  }
+
+  const revokeMatch = /^\/admin\/hosts\/([^/]+)\/revoke$/.exec(url.pathname);
+  if (request.method === "POST" && revokeMatch?.[1]) {
+    return handleRevokeHost(env, decodeURIComponent(revokeMatch[1]));
+  }
+
+  if (request.method === "POST" && url.pathname === "/admin/retention/run") {
+    const config = parseRetentionConfig(env);
+    const result = await runRetentionSweep(env.DB, config);
+    return new Response(JSON.stringify(result), { status: 200, headers: JSON_HEADERS });
+  }
+
+  if (request.method === "GET" && url.pathname === "/admin/fleet-state") {
+    const response = await fleetStateStub(env).fetch("https://fleet-state/snapshot");
+    return new Response(response.body, { status: response.status, headers: JSON_HEADERS });
+  }
+
+  return jsonError(404, "not found");
+}
+
+// ---------------------------------------------------------------------------
+// Entrypoint
+// ---------------------------------------------------------------------------
+
+export default {
+  async fetch(request, env, _ctx) {
+    const url = new URL(request.url);
+
+    if (request.method === "POST" && url.pathname === "/ingest") {
+      return handleIngest(request, env);
+    }
+    if (url.pathname.startsWith("/admin/")) {
+      return handleAdmin(request, env, url);
+    }
+    if (request.method === "GET" && url.pathname === "/") {
+      return new Response("loom-observability-ingest: see /ingest, /admin/*", { status: 200 });
+    }
+    return jsonError(404, "not found");
+  },
+
+  async scheduled(_event, env) {
+    const config = parseRetentionConfig(env);
+    const result = await runRetentionSweep(env.DB, config);
+    console.log(
+      `retention sweep: deleted ${result.deletedByAge} by age, ${result.deletedBySize} by size cap`,
+    );
+  },
+} satisfies ExportedHandler<Env>;

--- a/dashboard/src/retention.ts
+++ b/dashboard/src/retention.ts
@@ -1,0 +1,86 @@
+/**
+ * Retention / eviction policy for the `records` table (Epic #4702, Phase 2
+ * AC: "Retention policy bounds D1 growth (age- or size-based
+ * eviction/rollup), documented and testable").
+ *
+ * Two independent bounds are enforced on every run, both configured via
+ * `wrangler.toml` `[vars]` (no code change needed to retune):
+ *
+ *   - **Age-based**: rows older than `RETENTION_DAYS` (by `ingested_at`,
+ *     the backend's own receive time — not the client-supplied
+ *     `emitted_at`, which a misbehaving/clock-skewed host could spoof) are
+ *     deleted. Mirrors the local JSONL rotation's age bound
+ *     (`sweep_outcomes.rs`'s 30-day window), sized up for a multi-host,
+ *     indefinitely-running backend (default 90 days).
+ *   - **Size-based**: if the table still exceeds `MAX_RECORDS` rows after
+ *     the age sweep, the oldest excess rows (by `id`, i.e. insertion order)
+ *     are deleted until the table is back at the cap. This bounds worst-case
+ *     storage even if a single very chatty host (or a burst of new hosts)
+ *     would blow the age-based bound's effective size before enough time
+ *     passes for it to kick in.
+ *
+ * Rollup (aggregating evicted rows into a coarser summary) is deliberately
+ * NOT implemented in this issue — eviction alone satisfies the AC
+ * ("age- or size-based eviction/**rollup**", not both), and a rollup
+ * schema is a design decision better made once Phase 3's query API defines
+ * what aggregate shape it actually needs.
+ */
+
+export interface RetentionConfig {
+  retentionDays: number;
+  maxRecords: number;
+}
+
+export interface RetentionResult {
+  deletedByAge: number;
+  deletedBySize: number;
+}
+
+/** Parse the `[vars]` string bindings into a validated numeric config,
+ * falling back to safe defaults if a var is absent or unparseable (a
+ * misconfigured cron var must never silently disable retention). */
+export function parseRetentionConfig(env: {
+  RETENTION_DAYS?: string;
+  MAX_RECORDS?: string;
+}): RetentionConfig {
+  const retentionDays = parsePositiveInt(env.RETENTION_DAYS, 90);
+  const maxRecords = parsePositiveInt(env.MAX_RECORDS, 500_000);
+  return { retentionDays, maxRecords };
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * Run one retention sweep against `db`. Age-based eviction runs first
+ * (cheap: an indexed range delete on `ingested_at`); size-based eviction
+ * only runs if the table is still over `maxRecords` afterward.
+ */
+export async function runRetentionSweep(
+  db: D1Database,
+  config: RetentionConfig,
+  now: Date = new Date(),
+): Promise<RetentionResult> {
+  const cutoff = new Date(now.getTime() - config.retentionDays * 24 * 60 * 60 * 1000).toISOString();
+
+  const ageResult = await db.prepare("DELETE FROM records WHERE ingested_at < ?").bind(cutoff).run();
+  const deletedByAge = ageResult.meta.changes ?? 0;
+
+  const countRow = await db.prepare("SELECT COUNT(*) AS count FROM records").first<{ count: number }>();
+  const remaining = countRow?.count ?? 0;
+
+  let deletedBySize = 0;
+  if (remaining > config.maxRecords) {
+    const excess = remaining - config.maxRecords;
+    const sizeResult = await db
+      .prepare("DELETE FROM records WHERE id IN (SELECT id FROM records ORDER BY id ASC LIMIT ?)")
+      .bind(excess)
+      .run();
+    deletedBySize = sizeResult.meta.changes ?? 0;
+  }
+
+  return { deletedByAge, deletedBySize };
+}

--- a/dashboard/src/telemetry.ts
+++ b/dashboard/src/telemetry.ts
@@ -1,0 +1,138 @@
+/**
+ * Wire-format types and decode helpers for the fleet telemetry schema
+ * (Epic #4702, Phase 1 — `.loom/docs/telemetry-schema.md`; Rust source of
+ * truth `loom-daemon/src/telemetry/mod.rs`).
+ *
+ * This module is intentionally loose/defensive rather than a 1:1 typed
+ * mirror of the Rust enum: the schema doc's `schema_version` contract
+ * requires accepting an *unrecognized higher* version where possible, which
+ * means a strict discriminated union that rejects unknown `kind`s would
+ * violate the forward-compatibility rule. Instead we validate only the
+ * envelope-level shape strictly (schema_version/emitted_at/host_id/record
+ * all present and well-typed) and extract record-level fields
+ * (`repo`/`visibility`/`issue`/`sweep_id`) defensively, whatever the `kind`.
+ */
+
+/** Current schema version this backend fully understands (mirrors the
+ * daemon's `CURRENT_SCHEMA_VERSION`). Envelopes above this are still
+ * accepted (forward-compatible) — see `validateEnvelope`. */
+export const CURRENT_SCHEMA_VERSION = 1;
+
+export type RepoVisibility = "public" | "private";
+
+/**
+ * Decode a `visibility` value using the exact fail-safe rule documented in
+ * `.loom/docs/telemetry-schema.md`: only the exact (case-insensitive)
+ * string `"public"` maps to public; a missing field, unknown label, wrong
+ * type, or `null` all map to private. This must mirror the Rust
+ * `RepoVisibility` custom `Deserialize` impl bit-for-bit — it is the
+ * schema's anti-leak control and MUST NOT be loosened.
+ */
+export function decodeVisibility(value: unknown): RepoVisibility {
+  if (typeof value === "string" && value.toLowerCase() === "public") {
+    return "public";
+  }
+  return "private";
+}
+
+/** A decoded, envelope-shape-valid telemetry envelope. `record` is kept as
+ * a loosely-typed object — see the module doc for why. */
+export interface TelemetryEnvelope {
+  schema_version: number;
+  emitted_at: string;
+  host_id: string;
+  record: Record<string, unknown>;
+}
+
+/** Fields this backend extracts from `record` for indexing/querying,
+ * regardless of `kind` (present on repo-referencing kinds; absent — left
+ * `undefined` — on host-level kinds like `tokens.snapshot`/`host.health`). */
+export interface ExtractedRecordFields {
+  kind: string;
+  repo: string | undefined;
+  visibility: RepoVisibility;
+  issue: number | undefined;
+  sweepId: string | undefined;
+}
+
+/** One envelope failed shape validation; `index` is its position in the
+ * ingested batch (for a clear per-record error message). */
+export interface EnvelopeValidationError {
+  index: number;
+  reason: string;
+}
+
+/**
+ * Validate the *envelope* shape of `raw` (does NOT validate `record`'s
+ * internal shape beyond requiring it to be an object with a string `kind` —
+ * see the module doc). Returns the decoded envelope on success, or a reason
+ * string on failure.
+ *
+ * Per the schema doc's `schema_version` semantics: a **missing** or
+ * non-integer `schema_version` is always malformed (reject), but an
+ * integer `schema_version` above `CURRENT_SCHEMA_VERSION` is accepted
+ * (forward-compatible) — the caller does not reject on version alone.
+ */
+export function validateEnvelope(
+  raw: unknown,
+  index: number,
+): { ok: true; envelope: TelemetryEnvelope } | { ok: false; error: EnvelopeValidationError } {
+  const fail = (reason: string) => ({ ok: false as const, error: { index, reason } });
+
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return fail("envelope must be a JSON object");
+  }
+  const obj = raw as Record<string, unknown>;
+
+  const schemaVersion = obj.schema_version;
+  if (typeof schemaVersion !== "number" || !Number.isInteger(schemaVersion)) {
+    // Covers both "missing" (undefined) and "present but wrong type" —
+    // the schema doc: "never silently coerce a missing schema_version to
+    // 0 — a record with no schema_version is malformed."
+    return fail("missing or non-integer schema_version");
+  }
+  if (schemaVersion < 1) {
+    return fail(`schema_version must be >= 1, got ${schemaVersion}`);
+  }
+
+  const emittedAt = obj.emitted_at;
+  if (typeof emittedAt !== "string" || Number.isNaN(Date.parse(emittedAt))) {
+    return fail("missing or unparseable emitted_at");
+  }
+
+  const hostId = obj.host_id;
+  if (typeof hostId !== "string" || hostId.length === 0) {
+    return fail("missing or empty host_id");
+  }
+
+  const record = obj.record;
+  if (typeof record !== "object" || record === null || Array.isArray(record)) {
+    return fail("missing or non-object record");
+  }
+  const recordObj = record as Record<string, unknown>;
+  if (typeof recordObj.kind !== "string" || recordObj.kind.length === 0) {
+    return fail("record.kind must be a non-empty string");
+  }
+
+  return {
+    ok: true,
+    envelope: {
+      schema_version: schemaVersion,
+      emitted_at: emittedAt,
+      host_id: hostId,
+      record: recordObj,
+    },
+  };
+}
+
+/** Extract the fields this backend indexes from a validated envelope's
+ * `record`, defensively (works for any `kind`, known or forward-compatible
+ * unknown). */
+export function extractRecordFields(record: Record<string, unknown>): ExtractedRecordFields {
+  const kind = record.kind as string;
+  const repo = typeof record.repo === "string" ? record.repo : undefined;
+  const visibility = decodeVisibility(record.visibility);
+  const issue = typeof record.issue === "number" && Number.isInteger(record.issue) ? record.issue : undefined;
+  const sweepId = typeof record.sweep_id === "string" ? record.sweep_id : undefined;
+  return { kind, repo, visibility, issue, sweepId };
+}

--- a/dashboard/test/apply-migrations.ts
+++ b/dashboard/test/apply-migrations.ts
@@ -1,0 +1,6 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+
+// Runs once before the test suite: applies migrations/0001_init.sql (and any
+// future migration) to the isolated in-memory D1 instance vitest-pool-workers
+// spins up per test file, so every test starts from the real schema.
+await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);

--- a/dashboard/test/auth.test.ts
+++ b/dashboard/test/auth.test.ts
@@ -1,0 +1,68 @@
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { authenticateHost, extractBearerToken, hashIngestKey } from "../src/auth";
+import { revokeHost, seedHost } from "./testHelpers";
+
+describe("extractBearerToken", () => {
+  it("extracts the token from a well-formed header", () => {
+    expect(extractBearerToken("Bearer abc123")).toBe("abc123");
+  });
+
+  it("is case-insensitive on the scheme", () => {
+    expect(extractBearerToken("bearer abc123")).toBe("abc123");
+  });
+
+  it("returns null for a missing header", () => {
+    expect(extractBearerToken(null)).toBeNull();
+  });
+
+  it("returns null for a non-Bearer scheme", () => {
+    expect(extractBearerToken("Basic abc123")).toBeNull();
+  });
+});
+
+describe("hashIngestKey", () => {
+  it("is deterministic and never returns the plaintext key", async () => {
+    const a = await hashIngestKey("top-secret-key");
+    const b = await hashIngestKey("top-secret-key");
+    expect(a).toBe(b);
+    expect(a).not.toContain("top-secret-key");
+    expect(a).toMatch(/^[0-9a-f]{64}$/); // SHA-256 hex digest
+  });
+
+  it("different keys hash differently", async () => {
+    const a = await hashIngestKey("key-one");
+    const b = await hashIngestKey("key-two");
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("authenticateHost", () => {
+  it("authenticates a valid, non-revoked key and resolves the authoritative host id", async () => {
+    await seedHost(env.DB, "host-alpha", "alpha-key");
+    const result = await authenticateHost(env.DB, "Bearer alpha-key");
+    expect(result).toEqual({ hostId: "host-alpha" });
+  });
+
+  it("rejects a missing Authorization header", async () => {
+    const result = await authenticateHost(env.DB, null);
+    expect(result).toBeNull();
+  });
+
+  it("rejects an unknown key", async () => {
+    const result = await authenticateHost(env.DB, "Bearer no-such-key");
+    expect(result).toBeNull();
+  });
+
+  it("rejects a revoked key while leaving other hosts' keys usable", async () => {
+    await seedHost(env.DB, "host-beta", "beta-key");
+    await seedHost(env.DB, "host-gamma", "gamma-key");
+    await revokeHost(env.DB, "host-beta");
+
+    const revoked = await authenticateHost(env.DB, "Bearer beta-key");
+    expect(revoked).toBeNull();
+
+    const stillGood = await authenticateHost(env.DB, "Bearer gamma-key");
+    expect(stillGood).toEqual({ hostId: "host-gamma" });
+  });
+});

--- a/dashboard/test/env.d.ts
+++ b/dashboard/test/env.d.ts
@@ -1,0 +1,11 @@
+// Declaration-merges this project's `Env` (src/index.ts) plus the
+// test-only `TEST_MIGRATIONS` binding (see vitest.config.ts) into
+// `cloudflare:test`'s `ProvidedEnv`, which is what `import { env } from
+// "cloudflare:test"` is typed against.
+import type { Env as WorkerEnv } from "../src/index";
+
+declare module "cloudflare:test" {
+  interface ProvidedEnv extends WorkerEnv {
+    TEST_MIGRATIONS: D1Migration[];
+  }
+}

--- a/dashboard/test/ingest.test.ts
+++ b/dashboard/test/ingest.test.ts
@@ -1,0 +1,267 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import worker from "../src/index";
+import { hostHealthEnvelope, revokeHost, seedHost, sweepStartedEnvelope } from "./testHelpers";
+
+function ingestRequest(body: unknown, authHeader?: string): Request {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (authHeader !== undefined) headers.authorization = authHeader;
+  return new Request("https://ingest.example/ingest", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+async function callWorker(request: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  // `new Request(...)` types as `Request<unknown, CfProperties>` (the
+  // outbound-fetch shape); the Worker's `fetch` handler expects the
+  // incoming-request shape `Request<unknown, IncomingRequestCfProperties>`.
+  // Both are the same Fetch-API `Request` at runtime — this cast only
+  // reconciles workers-types' two request-side/response-side `cf` typings.
+  const response = await worker.fetch(
+    request as Request<unknown, IncomingRequestCfProperties>,
+    env,
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
+async function recordsForHost(hostId: string): Promise<Record<string, unknown>[]> {
+  const { results } = await env.DB.prepare("SELECT * FROM records WHERE host_id = ? ORDER BY id").bind(hostId).all();
+  return results as Record<string, unknown>[];
+}
+
+beforeEach(async () => {
+  await seedHost(env.DB, "host-abc", "abc-ingest-key");
+});
+
+describe("POST /ingest — auth", () => {
+  it("rejects a request with no Authorization header", async () => {
+    const response = await callWorker(ingestRequest([sweepStartedEnvelope()]));
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects an unknown ingest key", async () => {
+    const response = await callWorker(ingestRequest([sweepStartedEnvelope()], "Bearer not-a-real-key"));
+    expect(response.status).toBe(401);
+  });
+
+  it("a revoked host's key stops accepting writes while other hosts keep working", async () => {
+    await seedHost(env.DB, "host-xyz", "xyz-ingest-key");
+    await revokeHost(env.DB, "host-abc");
+
+    const revokedResponse = await callWorker(ingestRequest([sweepStartedEnvelope()], "Bearer abc-ingest-key"));
+    expect(revokedResponse.status).toBe(401);
+
+    const stillWorksResponse = await callWorker(
+      ingestRequest([sweepStartedEnvelope({ sweep_id: "sweep-xyz-0" })], "Bearer xyz-ingest-key"),
+    );
+    expect(stillWorksResponse.status).toBe(200);
+    expect(await recordsForHost("host-xyz")).toHaveLength(1);
+  });
+
+  it("the persisted host_id is the authenticated identity, not the envelope's own host_id field", async () => {
+    // The envelope's host_id claims a different host than the key that
+    // authenticated the request — the authoritative identity must win.
+    const envelope = sweepStartedEnvelope();
+    (envelope as Record<string, unknown>).host_id = "some-other-claimed-host";
+    const response = await callWorker(ingestRequest([envelope], "Bearer abc-ingest-key"));
+    expect(response.status).toBe(200);
+
+    const rows = await recordsForHost("host-abc");
+    expect(rows).toHaveLength(1);
+    expect(await recordsForHost("some-other-claimed-host")).toHaveLength(0);
+  });
+});
+
+describe("POST /ingest — validation", () => {
+  it("accepts a valid batch and persists every record to D1", async () => {
+    const batch = [sweepStartedEnvelope(), hostHealthEnvelope()];
+    const response = await callWorker(ingestRequest(batch, "Bearer abc-ingest-key"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ accepted: 2 });
+
+    const rows = await recordsForHost("host-abc");
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.kind).sort()).toEqual(["host.health", "sweep.started"]);
+  });
+
+  it("rejects a non-array body", async () => {
+    const response = await callWorker(ingestRequest({ not: "an array" }, "Bearer abc-ingest-key"));
+    expect(response.status).toBe(400);
+  });
+
+  it("accepts an empty array batch as a no-op", async () => {
+    const response = await callWorker(ingestRequest([], "Bearer abc-ingest-key"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ accepted: 0 });
+  });
+
+  it("rejects the WHOLE batch when any one envelope is missing schema_version", async () => {
+    const good = sweepStartedEnvelope();
+    const bad = hostHealthEnvelope();
+    delete (bad as Record<string, unknown>).schema_version;
+
+    const response = await callWorker(ingestRequest([good, bad], "Bearer abc-ingest-key"));
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toMatch(/envelope 1/);
+
+    // Whole-batch rejection: the otherwise-valid envelope must NOT have
+    // been persisted either.
+    expect(await recordsForHost("host-abc")).toHaveLength(0);
+  });
+
+  it("accepts a batch whose schema_version is a recognized-higher (forward-compatible) version", async () => {
+    const envelope = { ...sweepStartedEnvelope(), schema_version: 2 };
+    const response = await callWorker(ingestRequest([envelope], "Bearer abc-ingest-key"));
+    expect(response.status).toBe(200);
+
+    const rows = await recordsForHost("host-abc");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.schema_version).toBe(2);
+  });
+});
+
+describe("POST /ingest — visibility fail-safe default", () => {
+  it("persists a record with missing/unknown/wrong-typed visibility as private, never public", async () => {
+    const missing = sweepStartedEnvelope({ sweep_id: "sweep-missing-vis" });
+    delete (missing.record as Record<string, unknown>).visibility;
+
+    const unknown = sweepStartedEnvelope({ sweep_id: "sweep-unknown-vis", visibility: "internal-only" });
+    const wrongType = sweepStartedEnvelope({ sweep_id: "sweep-wrong-type-vis", visibility: 1 });
+
+    const response = await callWorker(
+      ingestRequest([missing, unknown, wrongType], "Bearer abc-ingest-key"),
+    );
+    expect(response.status).toBe(200);
+
+    const rows = await recordsForHost("host-abc");
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      expect(row.visibility).toBe("private");
+    }
+  });
+
+  it("persists an explicit public visibility as public", async () => {
+    const response = await callWorker(
+      ingestRequest([sweepStartedEnvelope({ visibility: "public" })], "Bearer abc-ingest-key"),
+    );
+    expect(response.status).toBe(200);
+    const rows = await recordsForHost("host-abc");
+    expect(rows[0]?.visibility).toBe("public");
+  });
+});
+
+describe("POST /ingest — Durable Object live state", () => {
+  it("updates the fleet-state snapshot for an accepted batch", async () => {
+    const response = await callWorker(
+      ingestRequest([sweepStartedEnvelope(), hostHealthEnvelope()], "Bearer abc-ingest-key"),
+    );
+    expect(response.status).toBe(200);
+
+    const snapshotResponse = await callWorker(
+      new Request("https://ingest.example/admin/fleet-state", {
+        headers: { authorization: "Bearer test-admin-token" },
+      }),
+    );
+    expect(snapshotResponse.status).toBe(200);
+    const snapshot = (await snapshotResponse.json()) as {
+      hosts: Record<string, { health?: unknown }>;
+      activeSweeps: { sweepId: string; hostId: string }[];
+    };
+    expect(snapshot.hosts["host-abc"]?.health).toBeDefined();
+    expect(snapshot.activeSweeps).toHaveLength(1);
+    expect(snapshot.activeSweeps[0]).toMatchObject({ sweepId: "sweep-issue-4703-0", hostId: "host-abc" });
+  });
+
+  it("removes a sweep from live state once sweep.completed is ingested", async () => {
+    await callWorker(ingestRequest([sweepStartedEnvelope()], "Bearer abc-ingest-key"));
+
+    const completed = {
+      schema_version: 1,
+      emitted_at: "2026-07-30T12:10:00Z",
+      host_id: "host-abc",
+      record: {
+        kind: "sweep.completed",
+        repo: "rjwalters/loom",
+        visibility: "public",
+        issue: 4703,
+        sweep_id: "sweep-issue-4703-0",
+        completed_at: "2026-07-30T12:10:00Z",
+        result: "success",
+      },
+    };
+    await callWorker(ingestRequest([completed], "Bearer abc-ingest-key"));
+
+    const snapshotResponse = await callWorker(
+      new Request("https://ingest.example/admin/fleet-state", {
+        headers: { authorization: "Bearer test-admin-token" },
+      }),
+    );
+    const snapshot = (await snapshotResponse.json()) as { activeSweeps: unknown[] };
+    expect(snapshot.activeSweeps).toHaveLength(0);
+  });
+});
+
+describe("POST /admin/hosts — host provisioning", () => {
+  it("requires the admin token", async () => {
+    const response = await callWorker(
+      new Request("https://ingest.example/admin/hosts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ host_id: "host-new" }),
+      }),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("creates a host and returns a usable ingest key exactly once", async () => {
+    const createResponse = await callWorker(
+      new Request("https://ingest.example/admin/hosts", {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer test-admin-token" },
+        body: JSON.stringify({ host_id: "host-new" }),
+      }),
+    );
+    expect(createResponse.status).toBe(201);
+    const { ingest_key: ingestKey } = (await createResponse.json()) as { ingest_key: string };
+    expect(typeof ingestKey).toBe("string");
+    expect(ingestKey.length).toBeGreaterThan(0);
+
+    const ingestResponse = await callWorker(
+      ingestRequest([sweepStartedEnvelope({ sweep_id: "sweep-new-host" })], `Bearer ${ingestKey}`),
+    );
+    expect(ingestResponse.status).toBe(200);
+    expect(await recordsForHost("host-new")).toHaveLength(1);
+  });
+
+  it("rejects creating a duplicate host_id", async () => {
+    const response = await callWorker(
+      new Request("https://ingest.example/admin/hosts", {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer test-admin-token" },
+        body: JSON.stringify({ host_id: "host-abc" }),
+      }),
+    );
+    expect(response.status).toBe(409);
+  });
+});
+
+describe("POST /admin/hosts/:hostId/revoke", () => {
+  it("revokes a host's key", async () => {
+    const revokeResponse = await callWorker(
+      new Request("https://ingest.example/admin/hosts/host-abc/revoke", {
+        method: "POST",
+        headers: { authorization: "Bearer test-admin-token" },
+      }),
+    );
+    expect(revokeResponse.status).toBe(200);
+
+    const ingestResponse = await callWorker(ingestRequest([sweepStartedEnvelope()], "Bearer abc-ingest-key"));
+    expect(ingestResponse.status).toBe(401);
+  });
+});

--- a/dashboard/test/retention.test.ts
+++ b/dashboard/test/retention.test.ts
@@ -1,0 +1,78 @@
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { parseRetentionConfig, runRetentionSweep } from "../src/retention";
+
+async function insertRecord(db: D1Database, ingestedAt: string, kind = "host.health"): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO records
+         (schema_version, emitted_at, host_id, kind, repo, visibility, issue, sweep_id, payload, ingested_at)
+       VALUES (1, ?, 'host-abc', ?, NULL, 'private', NULL, NULL, '{}', ?)`,
+    )
+    .bind(ingestedAt, kind, ingestedAt)
+    .run();
+}
+
+async function countRecords(db: D1Database): Promise<number> {
+  const row = await db.prepare("SELECT COUNT(*) AS count FROM records").first<{ count: number }>();
+  return row?.count ?? 0;
+}
+
+describe("parseRetentionConfig", () => {
+  it("parses valid numeric vars", () => {
+    expect(parseRetentionConfig({ RETENTION_DAYS: "30", MAX_RECORDS: "1000" })).toEqual({
+      retentionDays: 30,
+      maxRecords: 1000,
+    });
+  });
+
+  it("falls back to safe defaults on missing or unparseable vars — never disables retention", () => {
+    expect(parseRetentionConfig({})).toEqual({ retentionDays: 90, maxRecords: 500_000 });
+    expect(parseRetentionConfig({ RETENTION_DAYS: "not-a-number", MAX_RECORDS: "-5" })).toEqual({
+      retentionDays: 90,
+      maxRecords: 500_000,
+    });
+  });
+});
+
+describe("runRetentionSweep — age-based eviction", () => {
+  it("deletes rows older than the retention window and keeps newer ones", async () => {
+    const now = new Date("2026-08-01T00:00:00Z");
+    const old = new Date(now.getTime() - 100 * 24 * 60 * 60 * 1000).toISOString(); // 100 days ago
+    const recent = new Date(now.getTime() - 1 * 24 * 60 * 60 * 1000).toISOString(); // 1 day ago
+    await insertRecord(env.DB, old);
+    await insertRecord(env.DB, recent);
+
+    const result = await runRetentionSweep(env.DB, { retentionDays: 90, maxRecords: 1_000_000 }, now);
+
+    expect(result.deletedByAge).toBe(1);
+    expect(await countRecords(env.DB)).toBe(1);
+  });
+});
+
+describe("runRetentionSweep — size-based eviction", () => {
+  it("evicts the oldest excess rows once the table exceeds maxRecords", async () => {
+    const now = new Date("2026-08-01T00:00:00Z");
+    // All rows are "recent" (age sweep is a no-op) but there are more than
+    // the configured cap.
+    for (let i = 0; i < 5; i++) {
+      await insertRecord(env.DB, new Date(now.getTime() - i * 1000).toISOString());
+    }
+
+    const result = await runRetentionSweep(env.DB, { retentionDays: 90, maxRecords: 3 }, now);
+
+    expect(result.deletedByAge).toBe(0);
+    expect(result.deletedBySize).toBe(2);
+    expect(await countRecords(env.DB)).toBe(3);
+  });
+
+  it("is a no-op when the table is within both bounds", async () => {
+    const now = new Date("2026-08-01T00:00:00Z");
+    await insertRecord(env.DB, now.toISOString());
+
+    const result = await runRetentionSweep(env.DB, { retentionDays: 90, maxRecords: 500_000 }, now);
+
+    expect(result).toEqual({ deletedByAge: 0, deletedBySize: 0 });
+    expect(await countRecords(env.DB)).toBe(1);
+  });
+});

--- a/dashboard/test/telemetry.test.ts
+++ b/dashboard/test/telemetry.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { decodeVisibility, extractRecordFields, validateEnvelope } from "../src/telemetry";
+import { hostHealthEnvelope, sweepStartedEnvelope } from "./testHelpers";
+
+describe("decodeVisibility — fail-safe-to-private (mirrors the Rust RepoVisibility decode)", () => {
+  it("maps exactly the string \"public\" (case-insensitive) to public", () => {
+    expect(decodeVisibility("public")).toBe("public");
+    expect(decodeVisibility("PUBLIC")).toBe("public");
+    expect(decodeVisibility("PuBlIc")).toBe("public");
+  });
+
+  it("maps every other shape to private, never public", () => {
+    const malformedInputs: unknown[] = [
+      undefined, // missing field
+      null,
+      "private",
+      "internal", // unknown label
+      "Public ", // trailing space — not exactly "public"
+      "",
+      true,
+      false,
+      0,
+      1,
+      ["public"],
+      { v: "public" },
+    ];
+    for (const value of malformedInputs) {
+      expect(decodeVisibility(value), `decodeVisibility(${JSON.stringify(value)})`).toBe("private");
+    }
+  });
+});
+
+describe("validateEnvelope", () => {
+  it("accepts a well-formed envelope", () => {
+    const result = validateEnvelope(sweepStartedEnvelope(), 0);
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a missing schema_version (never coerces to 0)", () => {
+    const envelope = sweepStartedEnvelope();
+    delete (envelope as Record<string, unknown>).schema_version;
+    const result = validateEnvelope(envelope, 2);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.index).toBe(2);
+      expect(result.error.reason).toMatch(/schema_version/);
+    }
+  });
+
+  it("rejects a non-integer schema_version", () => {
+    const envelope = { ...sweepStartedEnvelope(), schema_version: "1" };
+    const result = validateEnvelope(envelope, 0);
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepts an unrecognized HIGHER schema_version (forward-compatible)", () => {
+    const envelope = { ...sweepStartedEnvelope(), schema_version: 99 };
+    const result = validateEnvelope(envelope, 0);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.envelope.schema_version).toBe(99);
+    }
+  });
+
+  it("rejects a missing record", () => {
+    const envelope = sweepStartedEnvelope();
+    delete (envelope as Record<string, unknown>).record;
+    const result = validateEnvelope(envelope, 0);
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects a record with no kind", () => {
+    const envelope = sweepStartedEnvelope();
+    (envelope.record as Record<string, unknown>).kind = undefined;
+    const result = validateEnvelope(envelope, 0);
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects a non-object envelope (e.g. a bare string in the array)", () => {
+    const result = validateEnvelope("not-an-envelope", 0);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("extractRecordFields", () => {
+  it("extracts repo/visibility/issue/sweep_id for a repo-scoped record", () => {
+    const envelope = sweepStartedEnvelope();
+    const result = validateEnvelope(envelope, 0);
+    if (!result.ok) throw new Error("expected valid envelope");
+    const fields = extractRecordFields(result.envelope.record);
+    expect(fields).toEqual({
+      kind: "sweep.started",
+      repo: "rjwalters/loom",
+      visibility: "public",
+      issue: 4703,
+      sweepId: "sweep-issue-4703-0",
+    });
+  });
+
+  it("leaves repo/issue/sweep_id undefined for a host-level record", () => {
+    const result = validateEnvelope(hostHealthEnvelope(), 0);
+    if (!result.ok) throw new Error("expected valid envelope");
+    const fields = extractRecordFields(result.envelope.record);
+    expect(fields.kind).toBe("host.health");
+    expect(fields.repo).toBeUndefined();
+    expect(fields.issue).toBeUndefined();
+    expect(fields.sweepId).toBeUndefined();
+    // No visibility field at all on a host-level record — must still
+    // fail-safe to private, never left undefined/public.
+    expect(fields.visibility).toBe("private");
+  });
+});

--- a/dashboard/test/testHelpers.ts
+++ b/dashboard/test/testHelpers.ts
@@ -1,0 +1,50 @@
+import { hashIngestKey } from "../src/auth";
+
+/** Insert a host + hashed ingest key directly into D1, bypassing the
+ * `/admin/hosts` HTTP route — used by tests that only need a pre-existing
+ * host, not to exercise host provisioning itself. */
+export async function seedHost(db: D1Database, hostId: string, key: string): Promise<void> {
+  const keyHash = await hashIngestKey(key);
+  await db
+    .prepare("INSERT INTO hosts (host_id, key_hash, created_at, revoked_at) VALUES (?, ?, ?, NULL)")
+    .bind(hostId, keyHash, new Date().toISOString())
+    .run();
+}
+
+export async function revokeHost(db: D1Database, hostId: string): Promise<void> {
+  await db.prepare("UPDATE hosts SET revoked_at = ? WHERE host_id = ?").bind(new Date().toISOString(), hostId).run();
+}
+
+/** Build a minimal, valid `sweep.started` envelope for a batch fixture. */
+export function sweepStartedEnvelope(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    emitted_at: "2026-07-30T12:00:00Z",
+    host_id: "host-abc",
+    record: {
+      kind: "sweep.started",
+      repo: "rjwalters/loom",
+      visibility: "public",
+      issue: 4703,
+      sweep_id: "sweep-issue-4703-0",
+      started_at: "2026-07-30T12:00:00Z",
+      ...overrides,
+    },
+  };
+}
+
+export function hostHealthEnvelope(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    emitted_at: "2026-07-30T12:00:00Z",
+    host_id: "host-abc",
+    record: {
+      kind: "host.health",
+      captured_at: "2026-07-30T12:00:00Z",
+      daemon_version: "0.16.0",
+      uptime_sec: 100,
+      logical_cpus: 8,
+      ...overrides,
+    },
+  };
+}

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -1,0 +1,33 @@
+import path from "node:path";
+import { defineWorkersConfig, readD1Migrations } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersConfig(async () => {
+  // Load the same migrations `wrangler d1 migrations apply` would run
+  // against a real database, so tests exercise the real schema — see
+  // `test/apply-migrations.ts`.
+  const migrationsPath = path.join(__dirname, "migrations");
+  const migrations = await readD1Migrations(migrationsPath);
+
+  return {
+    test: {
+      setupFiles: ["./test/apply-migrations.ts"],
+      poolOptions: {
+        workers: {
+          wrangler: { configPath: "./wrangler.toml" },
+          miniflare: {
+            bindings: {
+              // Exposed to the test runtime as `env.TEST_MIGRATIONS`, applied
+              // in the setup file.
+              TEST_MIGRATIONS: migrations,
+              // `ADMIN_TOKEN` is a real deployment's `wrangler secret` (never
+              // committed) — this fixed value only exists in the test
+              // runtime so admin-route tests have something deterministic
+              // to authenticate against.
+              ADMIN_TOKEN: "test-admin-token",
+            },
+          },
+        },
+      },
+    },
+  };
+});

--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -1,0 +1,51 @@
+name = "loom-observability-ingest"
+main = "src/index.ts"
+compatibility_date = "2024-09-23"
+
+# --------------------------------------------------------------------------
+# D1 — durable history for every ingested telemetry record.
+#
+# `database_id` below is a placeholder. After running:
+#   wrangler d1 create loom-observability
+# paste the returned database_id here (or override per-environment in
+# `[env.<name>]` blocks — see README.md "Deploying your own instance").
+# --------------------------------------------------------------------------
+[[d1_databases]]
+binding = "DB"
+database_name = "loom-observability"
+database_id = "00000000-0000-0000-0000-000000000000"
+migrations_dir = "migrations"
+
+# --------------------------------------------------------------------------
+# Durable Object — live "what is running right now across every host" state,
+# independent of D1's durable history.
+# --------------------------------------------------------------------------
+[[durable_objects.bindings]]
+name = "FLEET_STATE"
+class_name = "FleetState"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["FleetState"]
+
+# --------------------------------------------------------------------------
+# Retention policy — see src/retention.ts. Both bounds are enforced on every
+# scheduled run; either alone is sufficient to cap D1 growth, but both are
+# applied for defense in depth (a burst of hosts could blow the row cap well
+# before the age cutoff, and a single very-chatty host could blow the age
+# cutoff's effective size before enough time passes).
+# --------------------------------------------------------------------------
+[vars]
+RETENTION_DAYS = "90"
+MAX_RECORDS = "500000"
+
+# Runs the retention sweep hourly. `wrangler dev` does not fire this on a
+# real clock; trigger it directly in tests / via the admin endpoint instead
+# (see src/index.ts `/admin/retention/run`).
+[triggers]
+crons = ["0 * * * *"]
+
+# --------------------------------------------------------------------------
+# Secrets (NOT committed — set via `wrangler secret put <NAME>`):
+#   ADMIN_TOKEN   — bearer token gating /admin/* host-key management routes.
+# --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a new greenfield `dashboard/` Cloudflare Workers app — the Epic #4702
Phase 2 ingest endpoint + storage backend. It receives the telemetry
batches `loom-daemon`'s Phase-1 `HttpsExporter`
(`loom-daemon/src/observability/exporter.rs`, #4705) pushes, authenticates
each host with its own revocable key, persists durable history to D1, and
mirrors live fleet state ("what is running right now") into a Durable
Object. Scope is **ingest + storage only** — no dashboard read/query API,
no Cloudflare Access auth, no hosting-template/deploy-runbook polish
(those are separate sibling issues: #4726, #4727, #4728).

## Changes

- `dashboard/wrangler.toml` + `dashboard/migrations/0001_init.sql` — D1
  schema (`hosts` for per-host hashed ingest keys, `records` for durable
  history), Durable Object binding, hourly retention cron trigger.
- `dashboard/src/telemetry.ts` — envelope-shape validation (`schema_version`
  accept-current/accept-higher-forward-compatible/reject-missing rules) and
  the `visibility` fail-safe-to-private decode, mirroring
  `.loom/docs/telemetry-schema.md` / the Rust `RepoVisibility` decoder
  bit-for-bit.
- `dashboard/src/auth.ts` — per-host ingest key auth: SHA-256-hashed keys
  in D1, bearer-token lookup, revocation. The authenticated key's host
  identity is authoritative for storage — never the envelope's own
  (opaque, client-supplied) `host_id` field.
- `dashboard/src/index.ts` — Worker entrypoint: `POST /ingest` (the
  daemon-facing route — bare JSON array body, `Authorization: Bearer
  <ingest_key>`, whole-batch rejection on any malformed envelope,
  best-effort Durable Object update so a DO hiccup never causes the
  already-D1-committed batch to be retried/duplicated) plus `/admin/*`
  routes (host provisioning/revocation, on-demand retention run, live
  fleet-state introspection) gated by an `ADMIN_TOKEN` secret.
- `dashboard/src/fleetState.ts` — the `FleetState` Durable Object: a
  singleton holding per-host latest `host.health`/`tokens.snapshot` plus
  currently in-flight sweeps (added on `sweep.started`/`sweep.phase`,
  removed on `sweep.completed`).
- `dashboard/src/retention.ts` — age-based (default 90 days) + size-based
  (default 500k rows) D1 eviction, both configurable via `wrangler.toml`
  `[vars]`, run hourly via a cron trigger and on-demand via
  `/admin/retention/run`.
- `dashboard/test/*` — 43 tests running inside the real Workers runtime
  (Miniflare, via `@cloudflare/vitest-pool-workers`) against an isolated
  D1 instance with migrations applied.
- `dashboard/README.md` — local dev, manual `curl` verification steps, and
  a minimal deploy runbook (a fuller hosting template is #4728).

### Documented implementation decision: whole-batch rejection

The exporter only acks (removes from its durable queue) a batch on 2xx and
otherwise retries the *entire* batch with backoff. A single malformed
envelope therefore rejects the whole request (400, with the offending
envelope's index in the error message) rather than a partial
accept/reject — simplest and correct given that retry contract. See the
doc comment on `handleIngest` in `src/index.ts`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Workers ingest endpoint accepts the Phase-1 envelope shape (all record kinds), validates `schema_version`, rejects malformed/unversioned payloads with a clear error | ✅ | `validateEnvelope` in `src/telemetry.ts`; `test/ingest.test.ts` "validation" suite; manual curl (bare array body) confirmed accepted/rejected as expected |
| Per-host ingest key auth; a revoked key stops accepting new writes without affecting other hosts | ✅ | `src/auth.ts` (hashed keys, revocation); `test/ingest.test.ts` "a revoked host's key stops accepting writes while other hosts keep working"; manual curl revoke-then-retry confirmed 401 |
| D1 schema stores full history for all record kinds, queryable by host/repo/time range | ✅ | `migrations/0001_init.sql` `records` table + `idx_records_host_time`/`idx_records_repo_time` indexes |
| Durable Object holds current live fleet state, updated per ingested record, independent of D1 history | ✅ | `src/fleetState.ts`; `test/ingest.test.ts` "Durable Object live state" suite; manual curl `/admin/fleet-state` confirmed live snapshot |
| Retention policy bounds D1 growth (age- or size-based eviction/rollup), documented and testable | ✅ | `src/retention.ts` (age + size caps, both applied); `test/retention.test.ts` |
| Local/emulated test coverage (`wrangler dev` + Miniflare or equivalent) for ingest validation, auth rejection, retention behavior | ✅ | `npm test` — 43 passing tests via `@cloudflare/vitest-pool-workers` (Miniflare) |

## Test Plan

- `npm run typecheck` (tsc --noEmit) — clean.
- `npm test` — 43/43 passing: envelope validation (schema_version
  accept/forward-compat/reject), visibility fail-safe-to-private (every
  malformed shape from the schema doc), per-host auth + revocation
  isolation, D1 persistence, Durable Object live-state transitions
  (sweep.started/phase/completed lifecycle), host provisioning/revocation
  admin routes, retention age + size eviction.
- Manual `wrangler dev` verification (per the issue's Test Plan): applied
  the D1 migration locally, provisioned a host via `/admin/hosts`, pushed
  a batch with the daemon's exact wire shape (bare JSON array,
  `Authorization: Bearer <ingest_key>`) via curl, confirmed it landed in
  D1 (`wrangler d1 execute --local`) and updated the Durable Object's live
  snapshot (`/admin/fleet-state`); confirmed a malformed batch (missing
  `schema_version`) is rejected 400 with a clear per-envelope error, and
  that revoking the host's key makes subsequent ingests 401.

## Deferred / out of scope

- Dashboard read/query API and live SSE tail — Phase 2 sibling issue #4726.
- Visibility-based redaction beyond faithfully storing the `visibility`
  tag — Phase 2 sibling issue #4727.
- A polished one-click-deploy hosting template — Phase 2 sibling issue
  #4728 (README.md documents the minimal manual deploy steps in the
  meantime).
- Exact-once/idempotent D1 writes: if the ingest response is lost in
  transit after a successful D1 write, the exporter's retry would
  duplicate those D1 rows — no idempotency key mechanism exists on the
  wire today. Noted as a known limitation, not fixed here (would need a
  Phase-1-side wire-contract change to add a request/batch id).
- `@cloudflare/vitest-pool-workers`/`wrangler`/`miniflare` are pinned to a
  slightly older but stable, well-documented combo (`0.10.15` /
  `wrangler@4.54.0`) rather than the newest `0.19.x`/vitest-4-plugin-based
  rewrite, which currently drops per-test D1 storage isolation in this
  project's testing (state leaked across `it()` blocks within a file).
  `npm audit` flags known `undici`/`ws` advisories in that pinned
  wrangler/miniflare dev-tooling chain (build-time only, not shipped in
  the deployed Worker) — revisiting the pin once the newer track
  stabilizes is left as follow-up, not blocking this issue.

Closes #4725