### PR TITLE
fix(daemon): replace splitn(2, ':').nth(1) with split_once in exporter

### DIFF
--- a/loom-daemon/src/observability/exporter.rs
+++ b/loom-daemon/src/observability/exporter.rs
@@ -297,11 +297,17 @@ mod tests {
         let auth_header = header_text
             .lines()
             .find(|line| line.to_ascii_lowercase().starts_with("authorization:"))
-            .map(|line| line.splitn(2, ':').nth(1).unwrap_or("").trim().to_string());
+            .map(|line| {
+                line.split_once(':')
+                    .map(|x| x.1)
+                    .unwrap_or("")
+                    .trim()
+                    .to_string()
+            });
         let content_length: usize = header_text
             .lines()
             .find(|line| line.to_ascii_lowercase().starts_with("content-length:"))
-            .and_then(|line| line.splitn(2, ':').nth(1))
+            .and_then(|line| line.split_once(':').map(|x| x.1))
             .and_then(|v| v.trim().parse().ok())
             .unwrap_or(0);
         while buf.len() < header_end + content_length {


### PR DESCRIPTION
## Summary
`cargo clippy -p loom-daemon --all-targets -- -D warnings` fails on unmodified main with `clippy::manual_split_once` at two call sites in `loom-daemon/src/observability/exporter.rs` (added by #4710). This replaces the manual `splitn(2, ':').nth(1)` pattern with the idiomatic `split_once(':').map(|x| x.1)` clippy suggests.

## Changes
- `loom-daemon/src/observability/exporter.rs`: replaced `line.splitn(2, ':').nth(1).unwrap_or("").trim().to_string()` with `line.split_once(':').map(|x| x.1).unwrap_or("").trim().to_string()` for the `Authorization` header parse.
- Same file: replaced `line.splitn(2, ':').nth(1)` with `line.split_once(':').map(|x| x.1)` for the `Content-Length` header parse.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Both `splitn(2, ':').nth(1)` call sites replaced with `split_once` equivalent | ✅ | `git diff` shows both call sites (former lines 300, 304) rewritten |
| Existing behavior preserved (`.unwrap_or("").trim().to_string()` chain, `.and_then(...)` shape) | ✅ | Chains are unchanged aside from the split mechanism itself |
| `cargo clippy -p loom-daemon --all-targets -- -D warnings` passes | ✅ | Ran locally; exits 0, no warnings |
| No test regressions | ✅ | `cargo test -p loom-daemon observability::exporter` — 5/5 passed |

## Test Plan
- `cargo fmt -p loom-daemon` (no-op diff)
- `cargo clippy -p loom-daemon --all-targets -- -D warnings` — passes clean
- `cargo test -p loom-daemon observability::exporter` — 5 passed, 0 failed

Closes #4737