### PR TITLE
feat(dashboard): add fleet query API + SSE live tail to Workers backend

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,18 +1,21 @@
 # loom-observability-backend
 
-Cloudflare Workers reference backend — **ingest + storage only** — for the
-Loom fleet observability epic ([#4702](https://github.com/rjwalters/loom/issues/4702),
-Phase 2). Accepts the telemetry batches `loom-daemon`'s `HttpsExporter`
+Cloudflare Workers reference backend for the Loom fleet observability epic
+([#4702](https://github.com/rjwalters/loom/issues/4702), Phase 2). Accepts
+the telemetry batches `loom-daemon`'s `HttpsExporter`
 (`loom-daemon/src/observability/exporter.rs`, Phase 1 — #4705) pushes,
-authenticates the sending host, persists durable history to D1, and
-maintains a live "what is running right now" snapshot in a Durable Object.
+authenticates the sending host, persists durable history to D1, maintains a
+live "what is running right now" snapshot in a Durable Object, and exposes
+the read-side query API + live tail (issue #4726) the Phase 3 dashboard UI
+consumes.
 
 Wire format reference: [`.loom/docs/telemetry-schema.md`](../.loom/docs/telemetry-schema.md).
+Query API reference: [`docs/query-api.md`](docs/query-api.md).
 
-**Out of scope for this issue** (later Phase-2 sibling issues / Phase 3):
-a dashboard read/query API, Cloudflare Access auth, visibility-based
-redaction beyond faithfully storing the `visibility` tag, and a polished
-one-click deploy/hosting template (tracked separately — #4728).
+**Out of scope for this repo** (later epic phases): Cloudflare Access auth,
+visibility-based redaction beyond faithfully storing the `visibility` tag
+(#4727, which wraps the query API added here), and a polished one-click
+deploy/hosting template (tracked separately — #4728).
 
 ## Architecture
 
@@ -100,7 +103,13 @@ above are the minimum needed to stand up a working instance.
 | `POST /admin/hosts` | `Authorization: Bearer <ADMIN_TOKEN>` | Provision a host + ingest key (`{"host_id": "..."}`, optional `"key"` to bring your own). |
 | `POST /admin/hosts/:hostId/revoke` | `Authorization: Bearer <ADMIN_TOKEN>` | Revoke a host's key. |
 | `POST /admin/retention/run` | `Authorization: Bearer <ADMIN_TOKEN>` | Run the retention sweep on demand (also runs hourly via `[triggers] crons`). |
-| `GET /admin/fleet-state` | `Authorization: Bearer <ADMIN_TOKEN>` | Read the Durable Object's live snapshot (introspection/manual verification — not the Phase-3 dashboard query API). |
+| `GET /admin/fleet-state` | `Authorization: Bearer <ADMIN_TOKEN>` | Read the Durable Object's live snapshot (operator introspection/manual verification). |
+| `GET /api/fleet-state` | none (unclassified — see #4727) | Phase 3 query API: current state of every known host/sweep. |
+| `GET /api/history` | none (unclassified — see #4727) | Phase 3 query API: filterable, paginated D1 history query. |
+| `GET /api/events` | none (unclassified — see #4727) | Phase 3 query API: SSE live tail of newly-ingested telemetry. |
+
+Full request/response shapes for the `/api/*` routes:
+[`docs/query-api.md`](docs/query-api.md).
 
 ## Design decisions worth knowing
 

--- a/dashboard/docs/query-api.md
+++ b/dashboard/docs/query-api.md
@@ -1,0 +1,173 @@
+# Query API + live tail (Epic #4702, Phase 2 — issue #4726)
+
+The read side of the Phase-2 Workers backend: the query API and live event
+tail the Phase-3 dashboard UI consumes. Builds on the D1 history store +
+`FleetState` Durable Object issue #4725 introduced (`src/index.ts` /
+`src/fleetState.ts`) — this issue adds read paths only, no new storage.
+
+**Unclassified surface.** Every route below returns full record detail
+regardless of the stored `visibility` tag, and requires no authentication.
+Visibility-based redaction (a public view vs. an authenticated view with full
+detail) is issue #4727's job, as a wrapper in front of these routes — not
+implemented here. Do not point an untrusted public client at these routes
+directly until #4727 lands.
+
+Implementation: [`src/query.ts`](../src/query.ts) (filter parsing, the D1
+query, and the live-tail stream) plus the route handlers in
+[`src/index.ts`](../src/index.ts). Tests:
+[`test/query.test.ts`](../test/query.test.ts).
+
+## `GET /api/fleet-state`
+
+Current state of every host/sweep known to the `FleetState` Durable Object —
+the unclassified equivalent of the operator-only `GET /admin/fleet-state`
+(same underlying snapshot, no `ADMIN_TOKEN` required).
+
+**Response** (`200`, camelCase — mirrors the Durable Object's own JSON, see
+`src/fleetState.ts`'s `FleetSnapshot`):
+
+```json
+{
+  "hosts": {
+    "host-abc": {
+      "health": { "record": { "kind": "host.health", "...": "..." }, "updatedAt": "2026-07-30T12:00:00Z" },
+      "tokens": { "record": { "kind": "tokens.snapshot", "...": "..." }, "updatedAt": "2026-07-30T12:00:00Z" }
+    }
+  },
+  "activeSweeps": [
+    {
+      "hostId": "host-abc",
+      "sweepId": "sweep-issue-4703-0",
+      "repo": "rjwalters/loom",
+      "visibility": "public",
+      "issue": 4703,
+      "phase": "builder",
+      "startedAt": "2026-07-30T12:00:00Z",
+      "enteredPhaseAt": "2026-07-30T12:03:20Z",
+      "model": "opus",
+      "effort": "high",
+      "updatedAt": "2026-07-30T12:03:20Z"
+    }
+  ]
+}
+```
+
+A completed sweep is not present in `activeSweeps` (removed on
+`sweep.completed` — see `src/fleetState.ts`'s module doc); its full record
+lives in D1 and is queryable via `GET /api/history`.
+
+## `GET /api/history`
+
+Filterable, paginated query over the D1 `records` table — one row per
+ingested telemetry record (see `migrations/0001_init.sql`).
+
+### Query parameters (all optional)
+
+| Param | Type | Matches |
+|---|---|---|
+| `host` | string | `records.host_id` (exact match) |
+| `repo` | string | `records.repo` (exact match) |
+| `model` | string | `record.model`, extracted from the JSON payload (present on `sweep.started`/`sweep.outcome`) |
+| `result` | string | `record.result`, extracted from the JSON payload (present on `sweep.completed`/`sweep.outcome`; one of `success`/`failure`/`cancelled`/`blocked`) |
+| `since` | RFC 3339 datetime | `emitted_at >= since` (inclusive) |
+| `until` | RFC 3339 datetime | `emitted_at < until` (exclusive) |
+| `limit` | positive integer | Page size. Default `50`, capped at `500`. |
+| `cursor` | positive integer | Keyset pagination cursor — pass the previous page's `nextCursor`. |
+
+An invalid `since`/`until` (unparseable datetime), `limit` (non-positive or
+non-integer), or `cursor` (non-positive or non-integer) returns `400` with a
+`{"error": "..."}` body naming the first invalid param.
+
+### Response (`200`)
+
+```json
+{
+  "records": [
+    {
+      "id": 42,
+      "schemaVersion": 1,
+      "emittedAt": "2026-07-30T12:00:00Z",
+      "hostId": "host-abc",
+      "kind": "sweep.outcome",
+      "repo": "rjwalters/loom",
+      "visibility": "public",
+      "issue": 4703,
+      "sweepId": "sweep-issue-4703-0",
+      "ingestedAt": "2026-07-30T12:00:01Z",
+      "record": { "kind": "sweep.outcome", "model": "opus", "result": "success", "...": "..." }
+    }
+  ],
+  "nextCursor": 41
+}
+```
+
+- **Ordering**: always newest-first, by `id` descending.
+- **Pagination**: `nextCursor` is the `id` of the last record on this page,
+  or `null` when this page reached the end of the matching result set. Pass
+  it back as `?cursor=` to fetch the next page. This is keyset pagination
+  (`WHERE id < cursor`) — O(1) per page, and stable under concurrent inserts
+  (a new row never shifts an already-issued cursor's meaning), unlike
+  `OFFSET`-based paging.
+- `record` is the full, verbatim JSON payload that was ingested (the same
+  object the wire envelope's `record` field carried) — so any field the
+  schema doc documents (`.loom/docs/telemetry-schema.md`) is available, not
+  just the columns this backend indexes.
+
+## `GET /api/events`
+
+Server-Sent Events (`text/event-stream`) live tail of newly-ingested
+telemetry — delivers only records ingested **after** the connection opens;
+replaying prior history is `GET /api/history`'s job.
+
+### Query parameters (optional)
+
+| Param | Matches |
+|---|---|
+| `host` | Only stream records from this `host_id`. |
+| `repo` | Only stream records for this `repo`. |
+
+### Frame shape
+
+Every event arrives as a default (`message`-typed, no `event:` field) SSE
+frame:
+
+```
+data: {"topic":"sweep.phase","event":{"hostId":"host-abc","emittedAt":"2026-07-30T12:03:20Z","schemaVersion":1,"record":{"kind":"sweep.phase","repo":"rjwalters/loom","visibility":"public","issue":4703,"sweep_id":"sweep-issue-4703-0","phase":"builder","entered_at":"2026-07-30T12:03:20Z"}}}
+
+```
+
+This deliberately mirrors the shape `loom-daemon`'s own frozen `sweep.*` SSE
+bridge emits (`loom-daemon/src/serve.rs`'s `sse_frame` —
+`data: {"topic": ..., "event": {...}}\n\n`, no `event:` field since the topic
+is parameterized by issue number and a browser cannot `addEventListener` for
+a dynamic topic): `topic` is the record's own `kind` — already exactly
+`sweep.started`/`sweep.phase`/`sweep.completed` for the three that overlap
+the frozen per-issue taxonomy — and `event` carries the multi-host extension
+(`hostId`) plus the envelope fields, verbatim.
+
+A connection also receives:
+
+- A `retry: 3000` directive plus a leading `: connected to loom fleet
+  telemetry live tail` comment immediately on connect (mirrors the daemon
+  bridge's reconnect-delay convention).
+- A `: keepalive` comment roughly every 15s when no new records have arrived,
+  so intermediaries never reap an idle connection.
+
+### Delivery model
+
+Implemented as a short poll loop over D1 (default cadence ~1s) scoped to the
+stream's own lifetime, not a Durable-Object-side socket registry — see
+`src/query.ts`'s `createLiveTailStream` doc comment for why. The stream
+closes when the client disconnects (`Request.signal` aborts) or the consumer
+cancels its reader.
+
+## Not implemented here (later issues)
+
+- **Visibility-based redaction** (#4727) — this API always returns full
+  detail; #4727 wraps it with a public view that redacts/aggregates private
+  records instead of omitting the field entirely.
+- **`model`/`result` server-side filtering on the live tail** — `/api/events`
+  only supports `host`/`repo` filters today; a client wanting to filter by
+  model/result filters client-side on the streamed frames.
+- **Cloudflare Access / any authentication** on the `/api/*` routes — see the
+  "Unclassified surface" note above.

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -15,20 +15,39 @@
  *                                      the same sweep hourly).
  *   GET  /admin/fleet-state         — read the Durable Object's live
  *                                      snapshot (introspection/verification
- *                                      only — NOT the Phase 3 dashboard
- *                                      query API, which is a separate,
- *                                      unauthenticated-by-admin-token,
- *                                      out-of-scope-for-this-issue route).
+ *                                      only — the `/api/*` routes below are
+ *                                      the actual Phase 3 dashboard query
+ *                                      API).
+ *
+ *   GET  /api/fleet-state           — Phase 3 query API: current state of
+ *                                      every known host/sweep (issue #4726).
+ *   GET  /api/history               — Phase 3 query API: filterable,
+ *                                      paginated D1 history query (issue
+ *                                      #4726).
+ *   GET  /api/events                — Phase 3 query API: SSE live tail of
+ *                                      newly-ingested telemetry (issue
+ *                                      #4726).
  *
  * All `/admin/*` routes require `Authorization: Bearer <ADMIN_TOKEN>`
- * (a `wrangler secret`, never committed) — see README.md.
+ * (a `wrangler secret`, never committed) — see README.md. The `/api/*`
+ * routes are deliberately **not** admin-gated: they are the unclassified
+ * query surface issue #4726 defines, returning full record detail.
+ * Visibility-based redaction (public vs. authenticated views) is issue
+ * #4727's job, as a wrapper in front of these routes — not implemented here.
  *
- * Scope boundary (per the issue): ingest + storage only. No dashboard read
- * API, no Cloudflare Access auth — those are later epic phases.
+ * Scope boundary (per the issue): ingest + storage, plus the query API and
+ * live tail added by #4726. Cloudflare Access auth / redaction are later
+ * epic phases (#4727).
  */
 
 import { extractBearerToken, authenticateHost, hashIngestKey } from "./auth";
 import { FleetState } from "./fleetState";
+import {
+  createLiveTailStream,
+  parseHistoryQuery,
+  queryHistory,
+  type LiveTailFilter,
+} from "./query";
 import { parseRetentionConfig, runRetentionSweep } from "./retention";
 import { validateEnvelope, extractRecordFields, type TelemetryEnvelope } from "./telemetry";
 
@@ -248,6 +267,53 @@ async function handleAdmin(request: Request, env: Env, url: URL): Promise<Respon
 }
 
 // ---------------------------------------------------------------------------
+// /api/* — Phase 3 dashboard query API (issue #4726)
+// ---------------------------------------------------------------------------
+
+/** `GET /api/fleet-state` — the unclassified equivalent of
+ * `GET /admin/fleet-state`: same Durable Object snapshot, no admin token
+ * required. This is the route the Phase 3 dashboard UI actually consumes;
+ * `/admin/fleet-state` remains for operator introspection/verification. */
+async function handleFleetStateQuery(env: Env): Promise<Response> {
+  const response = await fleetStateStub(env).fetch("https://fleet-state/snapshot");
+  return new Response(response.body, { status: response.status, headers: JSON_HEADERS });
+}
+
+/** `GET /api/history` — filterable, paginated D1 history query. See
+ * `query.ts`'s `parseHistoryQuery`/`queryHistory` doc comments for the full
+ * filter/pagination contract. */
+async function handleHistoryQuery(env: Env, url: URL): Promise<Response> {
+  const filter = parseHistoryQuery(url.searchParams);
+  if ("error" in filter) {
+    return jsonError(400, filter.error);
+  }
+  const result = await queryHistory(env.DB, filter);
+  return new Response(JSON.stringify(result), { status: 200, headers: JSON_HEADERS });
+}
+
+/** `GET /api/events` — SSE live tail of newly-ingested telemetry. See
+ * `query.ts`'s `createLiveTailStream` doc comment for the framing/polling
+ * contract. */
+function handleLiveTail(request: Request, env: Env, url: URL): Response {
+  const filter: LiveTailFilter = {};
+  const host = url.searchParams.get("host");
+  if (host) filter.host = host;
+  const repo = url.searchParams.get("repo");
+  if (repo) filter.repo = repo;
+
+  const stream = createLiveTailStream(env.DB, filter, { signal: request.signal });
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache, no-store",
+      "x-accel-buffering": "no",
+      connection: "keep-alive",
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Entrypoint
 // ---------------------------------------------------------------------------
 
@@ -261,8 +327,17 @@ export default {
     if (url.pathname.startsWith("/admin/")) {
       return handleAdmin(request, env, url);
     }
+    if (request.method === "GET" && url.pathname === "/api/fleet-state") {
+      return handleFleetStateQuery(env);
+    }
+    if (request.method === "GET" && url.pathname === "/api/history") {
+      return handleHistoryQuery(env, url);
+    }
+    if (request.method === "GET" && url.pathname === "/api/events") {
+      return handleLiveTail(request, env, url);
+    }
     if (request.method === "GET" && url.pathname === "/") {
-      return new Response("loom-observability-ingest: see /ingest, /admin/*", { status: 200 });
+      return new Response("loom-observability-ingest: see /ingest, /admin/*, /api/*", { status: 200 });
     }
     return jsonError(404, "not found");
   },

--- a/dashboard/src/query.ts
+++ b/dashboard/src/query.ts
@@ -1,0 +1,401 @@
+/**
+ * Read-side query API + live tail (Epic #4702, Phase 2 — issue #4726).
+ *
+ * Builds on the D1 history store and `FleetState` Durable Object #4725
+ * maintains (`src/index.ts` / `src/fleetState.ts`) — this module adds no new
+ * storage, only read paths over what already exists:
+ *
+ *   - `queryHistory` — filterable, paginated queries over the `records`
+ *     table (host/repo/model/result/time-range), the data source for the
+ *     Phase-3 dashboard's historical charts and token/cost analytics.
+ *   - `createLiveTailStream` — an SSE stream of newly-ingested records,
+ *     framed the same way the frozen daemon `sweep.*` SSE topics are
+ *     (`data: {"topic": ..., "event": {...}}\n\n`, see
+ *     `loom-daemon/src/serve.rs`'s `sse_frame`) — extended here with a
+ *     `hostId` on every event, since this is a multi-host fleet tail rather
+ *     than a single daemon's own bus.
+ *
+ * **Unclassified surface, by design**: everything here returns full record
+ * detail regardless of the stored `visibility` tag. Visibility-based
+ * redaction (public vs. authenticated views) is issue #4727's job, as a
+ * wrapper in front of this API — this module deliberately does not
+ * implement it, matching the issue's stated scope boundary.
+ */
+
+// ---------------------------------------------------------------------------
+// History query (`GET /api/history`)
+// ---------------------------------------------------------------------------
+
+/** Parsed, validated filter for a `queryHistory` call. `limit` always has a
+ * value (defaulted); every other field is present only when the caller
+ * supplied it. */
+export interface HistoryFilter {
+  host?: string;
+  repo?: string;
+  model?: string;
+  result?: string;
+  /** Inclusive lower bound on `emitted_at` (RFC 3339). */
+  since?: string;
+  /** Exclusive upper bound on `emitted_at` (RFC 3339). */
+  until?: string;
+  limit: number;
+  /** Keyset pagination cursor — the `id` of the last record from the
+   * previous page; this page returns rows with `id` strictly less than it
+   * (rows are always ordered newest-first, by `id` descending). */
+  cursor?: number;
+}
+
+/** A decoded `records` row, camelCased and with `payload` parsed back into
+ * `record` — matches the convention `fleetState.ts`'s `FleetSnapshot` JSON
+ * already uses (camelCase), not the snake_case ingest wire format. */
+export interface HistoryRecord {
+  id: number;
+  schemaVersion: number;
+  emittedAt: string;
+  hostId: string;
+  kind: string;
+  repo: string | null;
+  visibility: string;
+  issue: number | null;
+  sweepId: string | null;
+  ingestedAt: string;
+  record: Record<string, unknown>;
+}
+
+export interface HistoryQueryResult {
+  records: HistoryRecord[];
+  /** The `cursor` value to pass for the next page, or `null` when this page
+   * reached the end of the matching result set. */
+  nextCursor: number | null;
+}
+
+export interface HistoryQueryError {
+  error: string;
+}
+
+/** Default/maximum page size for `GET /api/history`. A caller may request
+ * fewer via `?limit=`, never more than `MAX_HISTORY_LIMIT` — an unbounded
+ * `limit` would let one request force a full-table-scan-sized response. */
+export const DEFAULT_HISTORY_LIMIT = 50;
+export const MAX_HISTORY_LIMIT = 500;
+
+/** Parse+validate `GET /api/history`'s query-string params into a
+ * `HistoryFilter`, or a `{ error }` describing the first invalid param. Every
+ * filter param is optional; an absent one simply omits that predicate. */
+export function parseHistoryQuery(params: URLSearchParams): HistoryFilter | HistoryQueryError {
+  const filter: HistoryFilter = { limit: DEFAULT_HISTORY_LIMIT };
+
+  const host = params.get("host");
+  if (host) filter.host = host;
+
+  const repo = params.get("repo");
+  if (repo) filter.repo = repo;
+
+  const model = params.get("model");
+  if (model) filter.model = model;
+
+  const result = params.get("result");
+  if (result) filter.result = result;
+
+  const since = params.get("since");
+  if (since !== null) {
+    if (Number.isNaN(Date.parse(since))) return { error: "since must be an RFC 3339 datetime" };
+    filter.since = since;
+  }
+
+  const until = params.get("until");
+  if (until !== null) {
+    if (Number.isNaN(Date.parse(until))) return { error: "until must be an RFC 3339 datetime" };
+    filter.until = until;
+  }
+
+  const limitParam = params.get("limit");
+  if (limitParam !== null) {
+    const parsed = Number.parseInt(limitParam, 10);
+    if (!Number.isInteger(parsed) || parsed <= 0) return { error: "limit must be a positive integer" };
+    filter.limit = Math.min(parsed, MAX_HISTORY_LIMIT);
+  }
+
+  const cursorParam = params.get("cursor");
+  if (cursorParam !== null) {
+    const parsed = Number.parseInt(cursorParam, 10);
+    if (!Number.isInteger(parsed) || parsed <= 0) return { error: "cursor must be a positive integer record id" };
+    filter.cursor = parsed;
+  }
+
+  return filter;
+}
+
+/** Raw shape of one `records` row as D1 returns it (snake_case column
+ * names) — see `migrations/0001_init.sql`. */
+interface RawRecordRow {
+  id: number;
+  schema_version: number;
+  emitted_at: string;
+  host_id: string;
+  kind: string;
+  repo: string | null;
+  visibility: string;
+  issue: number | null;
+  sweep_id: string | null;
+  payload: string;
+  ingested_at: string;
+}
+
+function rowToHistoryRecord(row: RawRecordRow): HistoryRecord {
+  let record: Record<string, unknown>;
+  try {
+    record = JSON.parse(row.payload) as Record<string, unknown>;
+  } catch {
+    // The `payload` column is only ever written by `handleIngest` (always
+    // `JSON.stringify` of a validated object) — this branch should be
+    // unreachable, but a query surface must never 500 on a bad row.
+    record = {};
+  }
+  return {
+    id: row.id,
+    schemaVersion: row.schema_version,
+    emittedAt: row.emitted_at,
+    hostId: row.host_id,
+    kind: row.kind,
+    repo: row.repo,
+    visibility: row.visibility,
+    issue: row.issue,
+    sweepId: row.sweep_id,
+    ingestedAt: row.ingested_at,
+    record,
+  };
+}
+
+/**
+ * Run a filtered, paginated query over the `records` table.
+ *
+ * `model`/`result` are not indexed columns (they live inside the
+ * free-form `payload` JSON — see `.loom/docs/telemetry-schema.md`'s
+ * `sweep.started`/`sweep.completed`/`sweep.outcome` shapes) so those two
+ * predicates use D1's `json_extract` (SQLite's JSON1 extension, which D1
+ * supports) rather than a dedicated column. `host`/`repo`/the time range use
+ * the indexed columns `idx_records_host_time` / `idx_records_repo_time` /
+ * `idx_records_ingested_at` migration already provides.
+ *
+ * Pagination is keyset-based on `id` (rows are always returned newest-first):
+ * pass the previous page's `nextCursor` back as `cursor` to continue. This is
+ * O(1) per page (no `OFFSET` scan) and stable under concurrent inserts (a new
+ * row never shifts an already-issued cursor's meaning).
+ */
+export async function queryHistory(db: D1Database, filter: HistoryFilter): Promise<HistoryQueryResult> {
+  const clauses: string[] = [];
+  const bindings: unknown[] = [];
+
+  if (filter.host) {
+    clauses.push("host_id = ?");
+    bindings.push(filter.host);
+  }
+  if (filter.repo) {
+    clauses.push("repo = ?");
+    bindings.push(filter.repo);
+  }
+  if (filter.model) {
+    clauses.push("json_extract(payload, '$.model') = ?");
+    bindings.push(filter.model);
+  }
+  if (filter.result) {
+    clauses.push("json_extract(payload, '$.result') = ?");
+    bindings.push(filter.result);
+  }
+  if (filter.since) {
+    clauses.push("emitted_at >= ?");
+    bindings.push(filter.since);
+  }
+  if (filter.until) {
+    clauses.push("emitted_at < ?");
+    bindings.push(filter.until);
+  }
+  if (filter.cursor !== undefined) {
+    clauses.push("id < ?");
+    bindings.push(filter.cursor);
+  }
+
+  const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+  // Fetch one extra row beyond the page size — its presence (or absence)
+  // tells us whether a next page exists without a separate COUNT query.
+  const limitPlusOne = filter.limit + 1;
+  const { results } = await db
+    .prepare(`SELECT * FROM records ${where} ORDER BY id DESC LIMIT ?`)
+    .bind(...bindings, limitPlusOne)
+    .all<RawRecordRow>();
+
+  const hasMore = results.length > filter.limit;
+  const page = hasMore ? results.slice(0, filter.limit) : results;
+  const records = page.map(rowToHistoryRecord);
+  const lastRecord = records[records.length - 1];
+  const nextCursor = hasMore && lastRecord ? lastRecord.id : null;
+
+  return { records, nextCursor };
+}
+
+// ---------------------------------------------------------------------------
+// Live tail (`GET /api/events`)
+// ---------------------------------------------------------------------------
+
+/** Optional filters for a live-tail connection — a subset of
+ * `HistoryFilter`'s predicates (the ones cheap to apply per-poll against the
+ * indexed columns; `model`/`result` filtering on a live tail is left to the
+ * client for now, same as the reference daemon SSE bridge does no
+ * server-side payload filtering beyond topic prefix). */
+export interface LiveTailFilter {
+  host?: string;
+  repo?: string;
+}
+
+export interface LiveTailOptions {
+  /** How often to poll D1 for rows ingested since the last poll. */
+  pollIntervalMs?: number;
+  /** How often to emit a `: keepalive` comment when no new rows arrive —
+   * mirrors `loom-daemon serve`'s `SSE_HEARTBEAT_INTERVAL` so intermediaries
+   * never reap an idle connection. */
+  heartbeatIntervalMs?: number;
+  /** Aborted when the client disconnects (`Request.signal`) — stops the
+   * poll loop and closes the stream. */
+  signal?: AbortSignal;
+}
+
+/** Reconnect delay advertised via the SSE `retry:` field — same value the
+ * daemon's `/api/events` bridge uses (`loom-daemon/src/serve.rs`). */
+export const LIVE_TAIL_RETRY_MS = 3_000;
+
+/** Default poll interval — the "low latency" AC without needing a
+ * Durable-Object-side socket fan-out: at this cadence a newly-ingested
+ * record reaches connected clients within ~1s. */
+export const LIVE_TAIL_DEFAULT_POLL_INTERVAL_MS = 1_000;
+
+/** Default heartbeat cadence when no new rows are flowing. */
+export const LIVE_TAIL_DEFAULT_HEARTBEAT_INTERVAL_MS = 15_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Render one `records` row as an SSE frame, in the same
+ * `data: {"topic": ..., "event": {...}}\n\n` shape
+ * `loom-daemon/src/serve.rs`'s `sse_frame` emits for the frozen `sweep.*`
+ * topics — `topic` is the record's own `kind` (already exactly `sweep.
+ * started`/`sweep.phase`/`sweep.completed` for the topics that overlap the
+ * frozen taxonomy), and `event` carries the multi-host extension
+ * (`hostId`) alongside the envelope fields. */
+function sseFrameForRecord(row: HistoryRecord): string {
+  const payload = {
+    topic: row.kind,
+    event: {
+      hostId: row.hostId,
+      emittedAt: row.emittedAt,
+      schemaVersion: row.schemaVersion,
+      record: row.record,
+    },
+  };
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+/**
+ * Build an SSE `ReadableStream` that tails newly-ingested `records` rows.
+ *
+ * Implementation note: rather than a Durable-Object-side socket registry
+ * (which would need the WebSocket Hibernation API to survive DO eviction
+ * across a long-lived connection), this tails D1 directly via a short poll
+ * loop scoped to *this* stream's lifetime — simpler, and D1's `id` is
+ * already a strictly-increasing cursor with an index
+ * (`idx_records_ingested_at` for the underlying insert order), so the query
+ * cost per poll is a small indexed range scan, not a table scan. Only rows
+ * inserted **after** the stream opens are delivered — replaying prior
+ * history is `GET /api/history`'s job, not this one's.
+ */
+export function createLiveTailStream(
+  db: D1Database,
+  filter: LiveTailFilter,
+  options: LiveTailOptions = {},
+): ReadableStream<Uint8Array> {
+  const pollIntervalMs = options.pollIntervalMs ?? LIVE_TAIL_DEFAULT_POLL_INTERVAL_MS;
+  const heartbeatIntervalMs = options.heartbeatIntervalMs ?? LIVE_TAIL_DEFAULT_HEARTBEAT_INTERVAL_MS;
+  const encoder = new TextEncoder();
+  // Shared mutable state between `start` (the polling loop) and `cancel`
+  // (invoked when the client disconnects) — `cancel` cannot reach into
+  // `start`'s local scope directly, so both close over this instead.
+  const state = { closed: false };
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const onAbort = () => {
+        state.closed = true;
+      };
+      options.signal?.addEventListener("abort", onAbort);
+      // A function, not a re-narrowed inline expression: TS's control-flow
+      // narrowing otherwise treats `options.signal?.aborted` as unable to
+      // change back to `true` once compared against inside the loop below,
+      // even though the underlying `AbortSignal` is genuinely mutable.
+      const isAborted = (): boolean => options.signal?.aborted === true;
+
+      const enqueue = (chunk: string): boolean => {
+        try {
+          controller.enqueue(encoder.encode(chunk));
+          return true;
+        } catch {
+          // The consumer has gone away and the controller can no longer
+          // accept data — stop the loop rather than throwing out of `start`.
+          return false;
+        }
+      };
+
+      enqueue(`retry: ${LIVE_TAIL_RETRY_MS}\n: connected to loom fleet telemetry live tail\n\n`);
+
+      const maxRow = await db.prepare("SELECT MAX(id) AS maxId FROM records").first<{ maxId: number | null }>();
+      let lastId = maxRow?.maxId ?? 0;
+      let lastActivityAt = Date.now();
+
+      while (!state.closed && !isAborted()) {
+        await sleep(pollIntervalMs);
+        if (state.closed || isAborted()) break;
+
+        const clauses = ["id > ?"];
+        const bindings: unknown[] = [lastId];
+        if (filter.host) {
+          clauses.push("host_id = ?");
+          bindings.push(filter.host);
+        }
+        if (filter.repo) {
+          clauses.push("repo = ?");
+          bindings.push(filter.repo);
+        }
+
+        const { results } = await db
+          .prepare(`SELECT * FROM records WHERE ${clauses.join(" AND ")} ORDER BY id ASC LIMIT 200`)
+          .bind(...bindings)
+          .all<RawRecordRow>();
+
+        if (results.length > 0) {
+          for (const row of results) {
+            if (!enqueue(sseFrameForRecord(rowToHistoryRecord(row)))) {
+              state.closed = true;
+              break;
+            }
+          }
+          const lastRow = results[results.length - 1];
+          if (lastRow) lastId = lastRow.id;
+          lastActivityAt = Date.now();
+        } else if (Date.now() - lastActivityAt >= heartbeatIntervalMs) {
+          if (!enqueue(": keepalive\n\n")) state.closed = true;
+          lastActivityAt = Date.now();
+        }
+      }
+
+      options.signal?.removeEventListener("abort", onAbort);
+      try {
+        controller.close();
+      } catch {
+        // Already closed (e.g. the consumer cancelled first) — nothing to do.
+      }
+    },
+    cancel() {
+      state.closed = true;
+    },
+  });
+}

--- a/dashboard/test/query.test.ts
+++ b/dashboard/test/query.test.ts
@@ -1,0 +1,275 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import worker from "../src/index";
+import { seedHost, sweepStartedEnvelope } from "./testHelpers";
+
+async function callWorker(request: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(request as Request<unknown, IncomingRequestCfProperties>, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
+function ingestRequest(body: unknown, authHeader: string): Request {
+  return new Request("https://ingest.example/ingest", {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: authHeader },
+    body: JSON.stringify(body),
+  });
+}
+
+async function ingest(envelopes: unknown[], authHeader = "Bearer abc-ingest-key"): Promise<Response> {
+  return callWorker(ingestRequest(envelopes, authHeader));
+}
+
+function outcomeEnvelope(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    emitted_at: "2026-07-30T12:05:00Z",
+    host_id: "host-abc",
+    record: {
+      kind: "sweep.outcome",
+      repo: "rjwalters/loom",
+      visibility: "public",
+      issue: 4703,
+      sweep_id: "sweep-issue-4703-0",
+      model: "opus",
+      result: "success",
+      total_duration_sec: 512,
+      ...overrides,
+    },
+  };
+}
+
+beforeEach(async () => {
+  await seedHost(env.DB, "host-abc", "abc-ingest-key");
+});
+
+describe("GET /api/fleet-state", () => {
+  it("returns the fleet snapshot with no admin token required", async () => {
+    await ingest([sweepStartedEnvelope()]);
+
+    const response = await callWorker(new Request("https://ingest.example/api/fleet-state"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      hosts: Record<string, unknown>;
+      activeSweeps: { sweepId: string; hostId: string }[];
+    };
+    expect(body.activeSweeps).toHaveLength(1);
+    expect(body.activeSweeps[0]).toMatchObject({ sweepId: "sweep-issue-4703-0", hostId: "host-abc" });
+  });
+});
+
+describe("GET /api/history — filtering", () => {
+  it("filters by host", async () => {
+    await seedHost(env.DB, "host-xyz", "xyz-ingest-key");
+    await ingest([sweepStartedEnvelope({ sweep_id: "sweep-abc" })], "Bearer abc-ingest-key");
+    await ingest(
+      [{ ...sweepStartedEnvelope({ sweep_id: "sweep-xyz" }), host_id: "host-xyz" }],
+      "Bearer xyz-ingest-key",
+    );
+
+    const response = await callWorker(new Request("https://ingest.example/api/history?host=host-abc"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { records: { hostId: string }[] };
+    expect(body.records).toHaveLength(1);
+    expect(body.records[0]?.hostId).toBe("host-abc");
+  });
+
+  it("filters by repo", async () => {
+    await ingest([
+      sweepStartedEnvelope({ sweep_id: "sweep-loom", repo: "rjwalters/loom" }),
+      sweepStartedEnvelope({ sweep_id: "sweep-anvil", repo: "rjwalters/anvil" }),
+    ]);
+
+    const response = await callWorker(
+      new Request("https://ingest.example/api/history?repo=rjwalters/anvil"),
+    );
+    const body = (await response.json()) as { records: { repo: string | null }[] };
+    expect(body.records).toHaveLength(1);
+    expect(body.records[0]?.repo).toBe("rjwalters/anvil");
+  });
+
+  it("filters by model (extracted from the payload JSON)", async () => {
+    await ingest([
+      outcomeEnvelope({ sweep_id: "sweep-opus", model: "opus" }),
+      outcomeEnvelope({ sweep_id: "sweep-sonnet", model: "sonnet" }),
+    ]);
+
+    const response = await callWorker(new Request("https://ingest.example/api/history?model=sonnet"));
+    const body = (await response.json()) as { records: { record: { model?: string } }[] };
+    expect(body.records).toHaveLength(1);
+    expect(body.records[0]?.record.model).toBe("sonnet");
+  });
+
+  it("filters by result (extracted from the payload JSON)", async () => {
+    await ingest([
+      outcomeEnvelope({ sweep_id: "sweep-ok", result: "success" }),
+      outcomeEnvelope({ sweep_id: "sweep-bad", result: "failure" }),
+    ]);
+
+    const response = await callWorker(new Request("https://ingest.example/api/history?result=failure"));
+    const body = (await response.json()) as { records: { record: { result?: string } }[] };
+    expect(body.records).toHaveLength(1);
+    expect(body.records[0]?.record.result).toBe("failure");
+  });
+
+  it("filters by a since/until time range over emitted_at", async () => {
+    await ingest([
+      sweepStartedEnvelope({ sweep_id: "sweep-early" }), // emitted_at 2026-07-30T12:00:00Z (fixture default)
+    ]);
+    await ingest([
+      { ...outcomeEnvelope({ sweep_id: "sweep-late" }), emitted_at: "2026-08-01T00:00:00Z" },
+    ]);
+
+    const response = await callWorker(
+      new Request("https://ingest.example/api/history?since=2026-07-31T00:00:00Z"),
+    );
+    const body = (await response.json()) as { records: { sweepId: string | null }[] };
+    expect(body.records).toHaveLength(1);
+    expect(body.records[0]?.sweepId).toBe("sweep-late");
+
+    const untilResponse = await callWorker(
+      new Request("https://ingest.example/api/history?until=2026-07-31T00:00:00Z"),
+    );
+    const untilBody = (await untilResponse.json()) as { records: { sweepId: string | null }[] };
+    expect(untilBody.records).toHaveLength(1);
+    expect(untilBody.records[0]?.sweepId).toBe("sweep-early");
+  });
+
+  it("rejects an unparseable since/until/limit/cursor with 400", async () => {
+    const badSince = await callWorker(new Request("https://ingest.example/api/history?since=not-a-date"));
+    expect(badSince.status).toBe(400);
+
+    const badLimit = await callWorker(new Request("https://ingest.example/api/history?limit=0"));
+    expect(badLimit.status).toBe(400);
+
+    const badCursor = await callWorker(new Request("https://ingest.example/api/history?cursor=abc"));
+    expect(badCursor.status).toBe(400);
+  });
+});
+
+describe("GET /api/history — pagination", () => {
+  it("paginates newest-first with a stable keyset cursor", async () => {
+    // Five distinct records, ingested in one batch so ordering by `id` is
+    // deterministic (insertion order within the batch).
+    const envelopes = Array.from({ length: 5 }, (_, i) =>
+      sweepStartedEnvelope({ sweep_id: `sweep-${i}` }),
+    );
+    await ingest(envelopes);
+
+    const firstPage = await callWorker(new Request("https://ingest.example/api/history?limit=2"));
+    const firstBody = (await firstPage.json()) as {
+      records: { sweepId: string | null }[];
+      nextCursor: number | null;
+    };
+    expect(firstBody.records).toHaveLength(2);
+    expect(firstBody.nextCursor).not.toBeNull();
+    // Newest-first: the last-ingested envelope (sweep-4) comes first.
+    expect(firstBody.records[0]?.sweepId).toBe("sweep-4");
+
+    const secondPage = await callWorker(
+      new Request(`https://ingest.example/api/history?limit=2&cursor=${firstBody.nextCursor}`),
+    );
+    const secondBody = (await secondPage.json()) as {
+      records: { sweepId: string | null }[];
+      nextCursor: number | null;
+    };
+    expect(secondBody.records).toHaveLength(2);
+    expect(secondBody.records.map((r) => r.sweepId)).toEqual(["sweep-2", "sweep-1"]);
+
+    const thirdPage = await callWorker(
+      new Request(`https://ingest.example/api/history?limit=2&cursor=${secondBody.nextCursor}`),
+    );
+    const thirdBody = (await thirdPage.json()) as {
+      records: { sweepId: string | null }[];
+      nextCursor: number | null;
+    };
+    expect(thirdBody.records).toHaveLength(1);
+    expect(thirdBody.records[0]?.sweepId).toBe("sweep-0");
+    expect(thirdBody.nextCursor).toBeNull();
+  });
+});
+
+describe("GET /api/events — live tail", () => {
+  it("streams a newly-ingested record to a connected client", async () => {
+    // The live-tail poll loop runs at its production default cadence
+    // (`LIVE_TAIL_DEFAULT_POLL_INTERVAL_MS`, 1s) — this test's own timeout
+    // below gives it several polls' worth of headroom.
+    const response = await callWorker(
+      new Request("https://ingest.example/api/events", {
+        headers: { accept: "text/event-stream" },
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+
+    const reader = response.body?.getReader();
+    expect(reader).toBeDefined();
+    if (!reader) throw new Error("expected a readable stream body");
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    // Drain the initial `retry:`/comment preamble.
+    const preamble = await reader.read();
+    if (preamble.value) buffer += decoder.decode(preamble.value);
+    expect(buffer).toContain("retry:");
+
+    // Ingest a fresh record now that the stream is open.
+    await ingest([sweepStartedEnvelope({ sweep_id: "sweep-live-tail" })]);
+
+    // Poll the stream, reading chunks as they arrive, until the frame for
+    // our new record shows up.
+    const deadline = Date.now() + 8_000;
+    while (!buffer.includes("sweep-live-tail") && Date.now() < deadline) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      if (chunk.value) buffer += decoder.decode(chunk.value);
+    }
+
+    expect(buffer).toContain("sweep-live-tail");
+    const dataLine = buffer.split("\n\n").find((frame) => frame.includes("sweep-live-tail"));
+    expect(dataLine).toBeDefined();
+    const json = JSON.parse((dataLine ?? "").replace(/^data: /, "")) as {
+      topic: string;
+      event: { hostId: string; record: { sweep_id?: string } };
+    };
+    expect(json.topic).toBe("sweep.started");
+    expect(json.event.hostId).toBe("host-abc");
+    expect(json.event.record.sweep_id).toBe("sweep-live-tail");
+
+    await reader.cancel();
+  }, 15_000);
+
+  it("filters the live tail by host", async () => {
+    await seedHost(env.DB, "host-xyz", "xyz-ingest-key");
+
+    const response = await callWorker(new Request("https://ingest.example/api/events?host=host-xyz"));
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("expected a readable stream body");
+    const decoder = new TextDecoder();
+    let buffer = "";
+    buffer += decoder.decode((await reader.read()).value);
+
+    // A record from host-abc must NOT show up on a host-xyz-filtered tail.
+    await ingest([sweepStartedEnvelope({ sweep_id: "sweep-wrong-host" })], "Bearer abc-ingest-key");
+    // A record from host-xyz must show up.
+    await ingest(
+      [{ ...sweepStartedEnvelope({ sweep_id: "sweep-right-host" }), host_id: "host-xyz" }],
+      "Bearer xyz-ingest-key",
+    );
+
+    const deadline = Date.now() + 8_000;
+    while (!buffer.includes("sweep-right-host") && Date.now() < deadline) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      if (chunk.value) buffer += decoder.decode(chunk.value);
+    }
+
+    expect(buffer).toContain("sweep-right-host");
+    expect(buffer).not.toContain("sweep-wrong-host");
+
+    await reader.cancel();
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary

Adds the read-side query API + live tail for the Cloudflare Workers fleet
observability backend — the surface Phase 3's dashboard UI (Epic #4702)
will consume. Builds entirely on the D1 history store + `FleetState`
Durable Object #4725 already introduced; no new storage is added.

## Changes

- `dashboard/src/query.ts` (new): filter parsing + D1 query
  (`parseHistoryQuery` / `queryHistory`) and the SSE live-tail stream
  builder (`createLiveTailStream`).
- `dashboard/src/index.ts`: wires up three new unauthenticated routes:
  - `GET /api/fleet-state` — current state of every host/sweep, the
    unclassified equivalent of the operator-only `GET /admin/fleet-state`.
  - `GET /api/history` — filterable (`host`/`repo`/`model`/`result`/
    `since`/`until`) and paginated (keyset `cursor`, newest-first) D1
    history query. `model`/`result` are extracted from the JSON payload
    via `json_extract` (they aren't dedicated columns).
  - `GET /api/events` — SSE live tail of newly-ingested telemetry, framed
    identically to `loom-daemon/src/serve.rs`'s frozen `sweep.*` SSE
    bridge (`data: {"topic": ..., "event": {...}}\n\n`), extended with a
    `hostId` field for the multi-host fleet case. Implemented as a short
    D1 poll loop (~1s cadence) scoped to the connection's own lifetime
    rather than a Durable-Object socket registry — see the doc comment on
    `createLiveTailStream` for the tradeoff.
- `dashboard/docs/query-api.md` (new): full endpoint list + request/response
  shapes for Phase 3 to consume.
- `dashboard/README.md`: routes table + pointer to the new doc.

As the issue specifies, this is the **unclassified** query surface —
every route returns full record detail regardless of the `visibility` tag.
Visibility-based redaction (public vs. authenticated views) is #4727's job,
as a wrapper in front of this API, and is deliberately not implemented here.

## Acceptance Criteria Verification

- [x] Fleet snapshot endpoint returns current state for every host/sweep
      known to the Durable Object — `GET /api/fleet-state`, covered by
      `GET /api/fleet-state` test in `test/query.test.ts`.
- [x] History query endpoint supports filtering by host/repo/model/result
      and a time range, with pagination — `GET /api/history`, covered by
      the filtering + keyset-pagination tests in `test/query.test.ts`.
- [x] Live tail (SSE) streams newly ingested telemetry events to connected
      clients with low latency — `GET /api/events`, ~1s poll cadence,
      covered by the live-tail tests (including host filtering).
- [x] API surface is documented (endpoint list, request/response shapes)
      for the Phase 3 UI to consume — `dashboard/docs/query-api.md`.
- [x] Test coverage for query filtering/pagination correctness and
      live-tail delivery — `dashboard/test/query.test.ts` (10 new tests).

## Test Plan

```bash
cd dashboard
npm run check   # tsc --noEmit + vitest run (Miniflare, real Workers runtime)
```

All 53 tests pass (43 pre-existing + 10 new), including the two live-tail
SSE tests which open a stream, ingest a record, and assert the frame
arrives (~1s).

Closes #4726