### PR TITLE
fix(daemon): isolate 3 loom-daemon tests from ambient LOOM_RUNTIME

### DIFF
--- a/loom-daemon/src/role_runner.rs
+++ b/loom-daemon/src/role_runner.rs
@@ -1741,11 +1741,38 @@ mod tests {
         fs::write(root.join(".loom").join("config.json"), contents).unwrap();
     }
 
+    /// RAII guard that clears the ambient `LOOM_RUNTIME` env var for the
+    /// scope of a test and restores whatever value (if any) it previously
+    /// had — including across a mid-test assertion panic, since Rust
+    /// unwinds through `Drop`. Some host/dev-container shells export
+    /// `LOOM_RUNTIME` (as the `spawn-worker.sh` runtime selector), and
+    /// without this guard that ambient value silently outranks the
+    /// `runtimes.roles` config precedence this test exercises (#4739).
+    struct ClearedLoomRuntimeEnv(Option<String>);
+
+    impl ClearedLoomRuntimeEnv {
+        fn new() -> Self {
+            let prior = std::env::var("LOOM_RUNTIME").ok();
+            std::env::remove_var("LOOM_RUNTIME");
+            Self(prior)
+        }
+    }
+
+    impl Drop for ClearedLoomRuntimeEnv {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(v) => std::env::set_var("LOOM_RUNTIME", v),
+                None => std::env::remove_var("LOOM_RUNTIME"),
+            }
+        }
+    }
+
     #[test]
     #[serial]
     fn mixed_runtime_role_launch_is_admitted_and_pinned_before_spawn() {
         use std::os::unix::fs::PermissionsExt;
 
+        let _env_guard = ClearedLoomRuntimeEnv::new();
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         for sub in [

--- a/loom-daemon/src/runtime_admission.rs
+++ b/loom-daemon/src/runtime_admission.rs
@@ -413,6 +413,33 @@ mod tests {
     use super::*;
     use std::process::Command;
 
+    /// RAII guard that clears the ambient `LOOM_RUNTIME` env var for the
+    /// scope of a test and restores whatever value (if any) it previously
+    /// had — including across a mid-test assertion panic, since Rust
+    /// unwinds through `Drop`. Some host/dev-container shells export
+    /// `LOOM_RUNTIME` (as the `spawn-worker.sh` runtime selector), and
+    /// without this guard that ambient value silently outranks the
+    /// `runtimes.default` / `runtimes.roles` config precedence this test
+    /// exercises (#4739).
+    struct ClearedLoomRuntimeEnv(Option<String>);
+
+    impl ClearedLoomRuntimeEnv {
+        fn new() -> Self {
+            let prior = std::env::var("LOOM_RUNTIME").ok();
+            std::env::remove_var("LOOM_RUNTIME");
+            Self(prior)
+        }
+    }
+
+    impl Drop for ClearedLoomRuntimeEnv {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(v) => std::env::set_var("LOOM_RUNTIME", v),
+                None => std::env::remove_var("LOOM_RUNTIME"),
+            }
+        }
+    }
+
     fn fixture() -> tempfile::TempDir {
         let d = tempfile::tempdir().unwrap();
         for sub in ["defaults/roles", "defaults/runtimes", "defaults/scripts"] {
@@ -671,6 +698,7 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn unknown_configured_role_keys_fail_closed() {
+        let _env_guard = ClearedLoomRuntimeEnv::new();
         let d = fixture();
         let write_config = |contents: &str| {
             fs::create_dir_all(d.path().join(".loom")).unwrap();

--- a/loom-daemon/src/sweep_registry/dispatch.rs
+++ b/loom-daemon/src/sweep_registry/dispatch.rs
@@ -1514,9 +1514,36 @@ mod tests {
     use std::time::SystemTime;
     use tempfile::tempdir;
 
+    /// RAII guard that clears the ambient `LOOM_RUNTIME` env var for the
+    /// scope of a test and restores whatever value (if any) it previously
+    /// had — including across a mid-test assertion panic, since Rust
+    /// unwinds through `Drop`. Some host/dev-container shells export
+    /// `LOOM_RUNTIME` (as the `spawn-worker.sh` runtime selector), and
+    /// without this guard that ambient value silently outranks the
+    /// `runtimes.default` config precedence this test exercises (#4739).
+    struct ClearedLoomRuntimeEnv(Option<String>);
+
+    impl ClearedLoomRuntimeEnv {
+        fn new() -> Self {
+            let prior = std::env::var("LOOM_RUNTIME").ok();
+            std::env::remove_var("LOOM_RUNTIME");
+            Self(prior)
+        }
+    }
+
+    impl Drop for ClearedLoomRuntimeEnv {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(v) => std::env::set_var("LOOM_RUNTIME", v),
+                None => std::env::remove_var("LOOM_RUNTIME"),
+            }
+        }
+    }
+
     #[test]
     #[serial]
     fn runtime_rejection_precedes_every_dispatch_side_effect() {
+        let _env_guard = ClearedLoomRuntimeEnv::new();
         let dir = tempdir().unwrap();
         let workspace = dir.path();
         touch_sweep_command(workspace);


### PR DESCRIPTION
## Summary

Fixes the 3 remaining pre-existing `loom-daemon` unit test failures documented in
#4739 (2 of the original 5 were already fixed on `main`; the clippy `--all-targets`
error was also already fixed on `main` by #4740). Root cause: an ambient
`LOOM_RUNTIME` env var (present in some dev/CI shells — this build host has one
set to `claude`) outranks the `runtimes.default` / `runtimes.roles` config
precedence these tests exercise, because `runtime_admission::resolve_and_admit`'s
`choose_runtime` ranks `GlobalEnvironment` above `RoleConfig`/`DefaultConfig`. The
tests never accounted for that ambient value leaking in.

## Changes

- `loom-daemon/src/runtime_admission.rs` — clear `LOOM_RUNTIME` for the scope of
  `unknown_configured_role_keys_fail_closed` via an RAII guard.
- `loom-daemon/src/role_runner.rs` — same guard for
  `mixed_runtime_role_launch_is_admitted_and_pinned_before_spawn`.
- `loom-daemon/src/sweep_registry/dispatch.rs` — same guard for
  `runtime_rejection_precedes_every_dispatch_side_effect` (working off the
  post-#4738 module-split file layout).

Each guard captures the prior `LOOM_RUNTIME` value (if any) on entry, clears it,
and restores it on `Drop` — so isolation holds even if a mid-test assertion
panics, mirroring the `set_var`/`remove_var` isolation pattern already used in
`config_resolver.rs`. Test-only change, no production code touched.

**CI clippy-scope decision (acceptance criterion)**: `cargo clippy --all-targets
--package loom-daemon --package loom-api -- -D warnings <same allow-flags CI
uses>` is clean today (verified locally). I attempted to add `--all-targets` to
CI's clippy step per the issue's suggestion, but this environment's git-push
credential lacks the `workflow` OAuth scope required to push a change to
`.github/workflows/ci.yml` (GitHub rejects it: "refusing to allow a Personal
Access Token to create or update workflow ... without `workflow` scope"), so
that one-line addition is left as a fast-follow for a token/human with that
scope rather than blocking this fix. Recording this here satisfies the issue's
"OR a comment explaining why not" acceptance branch.

**Unrelated observation (not in scope, not fixed here)**: `cargo test -p
loom-daemon --lib` (full suite, parallel, default thread count) intermittently
fails 1 of `tokens_pool::bad_tokens::tests::blocking_entry_reports_exhaustion_class_and_cooldown_remaining`
or `forge_listing::tests::caches_etag_and_serves_304_from_cache` on this
(heavily loaded) build host — both pass reliably in isolation and are unrelated
to `LOOM_RUNTIME`/this issue's 3 named tests. Looks like host-load-driven test
flakiness, not a regression from this PR.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `cargo test -p loom-daemon` is green on a clean checkout of `main` | ✅ | `cargo test -p loom-daemon --lib -- --test-threads=1 runtime_admission:: role_runner:: sweep_registry::` → 398 passed, 0 failed (previously 3 failed here). Full-suite run: 2806/2807 or 2807/2807 passed across repeated runs, with only the pre-existing unrelated flake noted above (confirmed passes in isolation both times). |
| `cargo clippy --all-targets -p loom-daemon` is clean | ✅ | Ran locally, zero warnings/errors. |
| CI clippy scope decision recorded | ✅ | See "CI clippy-scope decision" note above — verified clean, blocked from landing by token `workflow` scope, recorded here as the fast-follow. |

## Test Plan

- `cargo test -p loom-daemon --lib -- --test-threads=1 runtime_admission:: role_runner:: sweep_registry::` — 398 passed, 0 failed (both with and without ambient `LOOM_RUNTIME=claude` set in the shell).
- `cargo test -p loom-daemon --lib` (full suite) — green modulo the pre-existing unrelated flake noted above.
- `cargo clippy --all-targets -p loom-daemon` — clean.
- `cargo clippy --all-targets --package loom-daemon --package loom-api -- -D warnings <CI's allow-flags>` — clean.
- `cargo fmt --all -- --check` — clean.

Closes #4739