### PR TITLE
docs(dashboard): add deploy-to-your-own-account template, runbook, and Access guide

### DIFF
--- a/dashboard/.dev.vars.example
+++ b/dashboard/.dev.vars.example
@@ -1,0 +1,12 @@
+# Template for `.dev.vars` — the secrets `wrangler dev` loads for LOCAL
+# development only. Copy it and fill in your own values:
+#
+#   cp .dev.vars.example .dev.vars
+#
+# `.dev.vars` is gitignored; this `.example` file is committed and must never
+# contain a real secret. A deployed Worker does NOT read this file — set its
+# secrets with `wrangler secret put <NAME>` (see docs/deploy-runbook.md § 7).
+
+# Bearer token gating every /admin/* route. While unset, those routes answer
+# 503. Generate a real one with: openssl rand -hex 32
+ADMIN_TOKEN="local-dev-admin-token"

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -2,5 +2,7 @@ node_modules/
 .wrangler/
 .dev.vars
 .dev.vars.*
+# ...but the committed, secret-free template is the point of the file.
+!.dev.vars.example
 dist/
 *.log

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -12,10 +12,10 @@ consumes.
 Wire format reference: [`.loom/docs/telemetry-schema.md`](../.loom/docs/telemetry-schema.md).
 Query API reference: [`docs/query-api.md`](docs/query-api.md).
 
-**Out of scope for this repo** (later epic phases): Cloudflare Access auth,
-visibility-based redaction beyond faithfully storing the `visibility` tag
-(#4727, which wraps the query API added here), and a polished one-click
-deploy/hosting template (tracked separately — #4728).
+**Out of scope for this repo**: Worker-side Cloudflare Access JWT verification
+(the [Access guide](docs/cloudflare-access.md) covers gating via the edge
+proxy instead), and visibility-based redaction beyond faithfully storing the
+`visibility` tag (#4727, which wraps the query API added here).
 
 ## Architecture
 
@@ -41,7 +41,7 @@ set `ADMIN_TOKEN` for local testing via a `.dev.vars` file (gitignored,
 never commit it):
 
 ```bash
-echo 'ADMIN_TOKEN="local-dev-admin-token"' > .dev.vars
+cp .dev.vars.example .dev.vars
 ```
 
 Provision a host and push a batch exactly like the daemon does (bare JSON
@@ -78,22 +78,33 @@ isolated in-memory D1 instance with `migrations/` applied — see
 
 ## Deploying your own instance
 
-1. `npx wrangler d1 create loom-observability` and paste the returned
-   `database_id` into `wrangler.toml`.
-2. `npx wrangler d1 migrations apply loom-observability --remote`.
-3. `npx wrangler secret put ADMIN_TOKEN` (generate one with e.g.
-   `openssl rand -hex 32` — this gates every `/admin/*` route).
-4. `npm run deploy`.
-5. Provision each fleet host: `POST /admin/hosts {"host_id": "..."}`, capture
-   the returned `ingest_key` (shown once), and configure it on that host's
-   daemon (`loom-daemon`'s observability exporter config — endpoint +
-   ingest key).
-6. Revoke a compromised/decommissioned host at any time:
-   `POST /admin/hosts/<host_id>/revoke` — other hosts' keys are unaffected.
+The short version:
 
-A full hosting template + turnkey runbook (one-click deploy button, DNS/
-custom-domain guidance, etc.) is a separate, later issue (#4728); the steps
-above are the minimum needed to stand up a working instance.
+```bash
+npx wrangler login
+npx wrangler d1 create loom-observability      # paste database_id into wrangler.toml
+npx wrangler d1 migrations apply loom-observability --remote
+npm run preflight                              # fails while any template placeholder remains
+npm run deploy
+npx wrangler secret put ADMIN_TOKEN            # gates every /admin/* route
+```
+
+Then provision each fleet host (`POST /admin/hosts {"host_id": "..."}`,
+capture the once-shown `ingest_key`) and point that host's daemon at the
+endpoint via its `observability` config block.
+
+**[`docs/deploy-runbook.md`](docs/deploy-runbook.md) is the full
+walkthrough** — API-token scopes, verification commands after each step, key
+rotation/revocation, retention tuning, teardown, and a troubleshooting
+table. To gate the authenticated view behind SSO, follow it with
+[`docs/cloudflare-access.md`](docs/cloudflare-access.md).
+
+`npm run preflight` (`scripts/check-deploy-config.sh`) is the guard rail: it
+refuses to pass while `wrangler.toml` still holds a template placeholder,
+warns when a custom domain is configured with `workers_dev` still enabled
+(an unauthenticated bypass around any Access policy), and finishes with
+`wrangler deploy --dry-run`. `npm run preflight -- --remote` additionally
+asserts the `ADMIN_TOKEN` secret exists on the deployed Worker.
 
 ## Routes
 

--- a/dashboard/docs/cloudflare-access.md
+++ b/dashboard/docs/cloudflare-access.md
@@ -1,0 +1,262 @@
+# Gating the dashboard with Cloudflare Access
+
+How to put zero-trust SSO in front of the **authenticated** fleet view while
+leaving the **public** view and the machine-to-machine `/ingest` endpoint
+reachable without a login.
+
+This is the Cloudflare-side configuration only. Phase 3 of epic
+[#4702](https://github.com/rjwalters/loom/issues/4702) builds the actual
+public-view page; the Access policies that distinguish the two routes are set
+up here, at the edge, and are what make that split enforceable.
+
+Prerequisite: a deployed backend — see
+[`deploy-runbook.md`](deploy-runbook.md).
+
+---
+
+## 1. The constraint that shapes everything: workers.dev cannot be gated
+
+Cloudflare Access protects **hostnames in a zone on your account**. A
+`*.workers.dev` URL is not in your zone, so **no Access policy can cover
+it**. If your Worker is reachable at both `dash.example.com` (gated) and
+`loom-observability-ingest.you.workers.dev` (not gated), the gate is
+decorative — anyone who guesses the workers.dev URL walks straight past it.
+
+So, before any Access configuration:
+
+1. Attach a custom domain in `wrangler.toml`:
+
+   ```toml
+   [[routes]]
+   pattern = "loom-dashboard.example.com"
+   custom_domain = true
+   ```
+
+   The zone (`example.com`) must already be active on the same Cloudflare
+   account. `custom_domain = true` lets Wrangler create and manage the DNS
+   record.
+
+2. **Disable workers.dev** in the same file:
+
+   ```toml
+   workers_dev = false
+   ```
+
+3. Redeploy and confirm the old URL is gone:
+
+   ```bash
+   npm run preflight     # warns if a route exists while workers_dev is still true
+   npm run deploy
+   curl -sS -o /dev/null -w '%{http_code}\n' \
+     https://loom-observability-ingest.<your-subdomain>.workers.dev/
+   # expect 404/530 — the workers.dev route must no longer serve this Worker
+   ```
+
+> Requests to a Worker **Custom Domain** traverse Cloudflare's security stack
+> (including Access) before reaching your Worker. Requests to a workers.dev
+> subdomain do not. That difference is the whole reason step 2 is mandatory
+> rather than cosmetic.
+
+---
+
+## 2. Route map: what to gate and what to leave open
+
+| Path | Access decision | Why |
+|---|---|---|
+| `/ingest` | **Bypass** | Machine-to-machine. `loom-daemon` sends `Authorization: Bearer <ingest_key>`, not an SSO cookie — an Access challenge here breaks every push in your fleet. Already authenticated by the per-host key (`src/auth.ts`). |
+| `/public` *(Phase 3)* | **Bypass** | The deliberately public, redacted fleet view. Reserve the path now so the policy is in place before the page exists. |
+| `/admin/*` | **Allow** (+ optional service-token policy) | Host-key management. Already gated by the `ADMIN_TOKEN` bearer secret; Access in front of it is defense in depth. |
+| everything else (`/`, the authenticated view) | **Allow** | The private fleet view: your identities only. |
+
+Cloudflare evaluates the **most specific matching application** — a
+path-scoped app (`loom-dashboard.example.com/ingest`) wins over a
+hostname-wide app (`loom-dashboard.example.com`). That precedence is what
+lets one hostname host both gated and ungated routes.
+
+**Create the Bypass applications before the hostname-wide Allow
+application.** In the window between "hostname is gated" and "`/ingest` is
+bypassed", every daemon push gets an Access redirect instead of a 2xx and
+backs off. Nothing is lost (the daemon's durable queue retries), but you will
+watch your fleet go quiet for no reason.
+
+---
+
+## 3. Configure it (Zero Trust dashboard)
+
+Cloudflare dashboard → **Zero Trust** → **Access** → **Applications**.
+
+### 3a. First-time setup: an identity provider
+
+**Settings → Authentication → Login methods**. The built-in **One-time PIN**
+(email) provider needs no configuration and is enough to start; Google /
+GitHub / Okta / any OIDC or SAML provider works the same way from Access's
+point of view.
+
+### 3b. Bypass application for `/ingest`
+
+**Add an application → Self-hosted**
+
+| Field | Value |
+|---|---|
+| Application name | `loom-dashboard ingest (bypass)` |
+| Session duration | *(irrelevant for bypass)* |
+| Public hostname | `loom-dashboard.example.com`, path `ingest` |
+
+Policy:
+
+| Field | Value |
+|---|---|
+| Policy name | `allow all — key-authenticated` |
+| Action | **Bypass** |
+| Include | **Everyone** |
+
+Repeat for path `public` (`loom-dashboard public view (bypass)`), so the
+Phase-3 public page is ungated the day it lands.
+
+### 3c. Allow application for the authenticated view
+
+**Add an application → Self-hosted**
+
+| Field | Value |
+|---|---|
+| Application name | `loom-dashboard (private)` |
+| Session duration | 24 hours (your call) |
+| Public hostname | `loom-dashboard.example.com` (no path — covers everything not matched by a more specific app) |
+
+Policy:
+
+| Field | Value |
+|---|---|
+| Policy name | `fleet operators` |
+| Action | **Allow** |
+| Include | **Emails** → your addresses (or **Emails ending in** `@yourcompany.com`, or an Access group) |
+
+### 3d. Optional: a service token for scripted `/admin` calls
+
+Once `/admin/*` sits behind Access, an interactive login is required — which
+breaks `curl`-driven host provisioning. Two options:
+
+**Service token (recommended).** **Access → Service Auth → Create service
+token**, then add a second policy on the private application:
+
+| Field | Value |
+|---|---|
+| Policy name | `admin automation` |
+| Action | **Service Auth** |
+| Include | **Service Token** → the token you created |
+
+Scripts then send both the Access headers and the app's own admin bearer:
+
+```bash
+curl -sS -X POST "https://loom-dashboard.example.com/admin/hosts" \
+  -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+  -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
+  -H "authorization: Bearer $ADMIN_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"host_id":"my-laptop"}'
+```
+
+**Or** use `cloudflared` for ad-hoc human use, which handles the SSO flow:
+
+```bash
+cloudflared access login https://loom-dashboard.example.com
+cloudflared access curl https://loom-dashboard.example.com/admin/fleet-state \
+  -H "authorization: Bearer $ADMIN_TOKEN"
+```
+
+**Or** add a third Bypass application scoped to `admin` and rely solely on
+`ADMIN_TOKEN`. That is a real, defensible choice — the routes are already
+authenticated — but it drops the second factor; prefer the service token.
+
+---
+
+## 4. Verify the split
+
+```bash
+BASE=https://loom-dashboard.example.com
+
+# Gated: an unauthenticated browser request is redirected to the Access login.
+curl -sS -o /dev/null -w '%{http_code} %{redirect_url}\n' "$BASE/"
+# expect 302 → https://<your-team>.cloudflareaccess.com/cdn-cgi/access/login/...
+
+# Ungated machine path: reaches the Worker, which answers with ITS OWN 401
+# (not an Access redirect) when the key is missing/bad.
+curl -sS -o /dev/null -w '%{http_code}\n' -X POST "$BASE/ingest" -d '[]'
+# expect 401 (from src/auth.ts) — a 302 here means the bypass app is missing
+
+# Ungated machine path with a valid key: 200.
+curl -sS -X POST "$BASE/ingest" -H "authorization: Bearer $INGEST_KEY" \
+  -H 'content-type: application/json' -d '[]'
+# => {"accepted":0}
+```
+
+Then confirm end to end that a real daemon still pushes: restart it and check
+that new rows land.
+
+```bash
+npx wrangler d1 execute loom-observability --remote \
+  --command "SELECT max(ingested_at) FROM records"
+```
+
+**The 401-vs-302 distinction on `/ingest` is the single most useful check
+here** — a 302 means Access is intercepting the daemon's pushes.
+
+---
+
+## 5. Optional hardening: verify the Access JWT in the Worker
+
+Access injects a signed `CF-Access-Jwt-Assertion` header on every request it
+lets through. Verifying it inside the Worker closes the gap where someone
+finds a way to reach the Worker without traversing Access (a leftover
+workers.dev route, a `[[routes]]` pattern on another hostname).
+
+**This is not implemented today** — the Worker trusts the edge. It is a
+sensible Phase-3 addition, and the ingredients are:
+
+- JWKS: `https://<your-team>.cloudflareaccess.com/cdn-cgi/access/certs`
+- Expected `aud`: the application's **Application Audience (AUD) tag** (shown
+  on the app's overview page).
+- Verify signature, `aud`, `iss`, and expiry before serving the private view;
+  skip the check on the Bypass paths (Access sends no JWT there).
+
+Until then, the belt-and-braces controls that *are* live are `workers_dev =
+false` (§1) and the `ADMIN_TOKEN` bearer on `/admin/*`.
+
+---
+
+## 6. Pitfalls
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Every daemon push suddenly fails / fleet goes quiet | `/ingest` is covered by the hostname-wide Allow app | Add the `/ingest` Bypass app (§3b) — it takes precedence |
+| Access login works but the Worker 404s | Custom domain route not deployed | `wrangler deploy` after adding `[[routes]]` |
+| The private view is reachable without logging in | workers.dev still enabled, or another route/hostname points at the Worker | `workers_dev = false`, redeploy, and audit `wrangler deployments list` / your zone's routes |
+| Scripts against `/admin` get an HTML login page | No Service Auth policy | §3d |
+| `cloudflared access curl` prompts repeatedly | Session expired | `cloudflared access login <url>` again |
+| Policy edits appear to do nothing | Existing Access session cookie | Test in a private window, or `cloudflared access logout` |
+
+---
+
+## 7. Appendix: configuring Access via the API
+
+The dashboard flow above is authoritative; this is a sketch for
+infrastructure-as-code setups. Cloudflare's Access API surface changes over
+time — check the current
+[Access applications API docs](https://developers.cloudflare.com/api/resources/zero_trust/subresources/access/subresources/applications/)
+before relying on these shapes.
+
+```bash
+CF_API="https://api.cloudflare.com/client/v4"
+AUTH=(-H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" -H 'content-type: application/json')
+
+# Bypass application for /ingest
+curl -sS -X POST "$CF_API/accounts/$CLOUDFLARE_ACCOUNT_ID/access/apps" "${AUTH[@]}" \
+  -d '{"name":"loom-dashboard ingest (bypass)","type":"self_hosted",
+       "domain":"loom-dashboard.example.com/ingest","session_duration":"24h"}'
+
+# ... then attach a Bypass/Everyone policy to the returned app id:
+curl -sS -X POST "$CF_API/accounts/$CLOUDFLARE_ACCOUNT_ID/access/apps/<APP_ID>/policies" "${AUTH[@]}" \
+  -d '{"name":"allow all — key-authenticated","decision":"bypass","include":[{"everyone":{}}]}'
+```
+
+The API token needs **Account → Access: Apps and Policies: Edit**.

--- a/dashboard/docs/deploy-runbook.md
+++ b/dashboard/docs/deploy-runbook.md
@@ -1,0 +1,383 @@
+# Deploy the fleet observability backend to your own Cloudflare account
+
+This is the deploy-to-your-own-account runbook for the Loom fleet
+observability backend (epic
+[#4702](https://github.com/rjwalters/loom/issues/4702), Phase 2). Follow it
+end to end and you will have your **own** telemetry backend — no dependency
+on anyone else's deployment — receiving pushes from one or more
+`loom-daemon` hosts.
+
+Companion documents:
+
+| Document | Covers |
+|---|---|
+| [`../wrangler.toml`](../wrangler.toml) | The deployment template itself — every value you must supply is tagged `CHANGE ME` |
+| [`cloudflare-access.md`](cloudflare-access.md) | Gating the authenticated view behind zero-trust SSO while leaving the public view ungated |
+| [`../README.md`](../README.md) | Architecture, routes, local development, tests |
+| [`../../.loom/docs/telemetry-schema.md`](../../.loom/docs/telemetry-schema.md) | The wire contract the daemon pushes |
+
+> **Everything here is your own infrastructure.** Loom never phones home:
+> the daemon's `observability` block is opt-in, off by default, and points
+> only at the endpoint you configure.
+
+---
+
+## 0. What you are deploying
+
+One Cloudflare Worker with three pieces of state:
+
+- **D1 database** — durable history (`records` table) plus per-host ingest
+  keys (`hosts` table, SHA-256 hashed, individually revocable).
+- **Durable Object** (`FleetState`) — a live "what is running right now"
+  snapshot. Created implicitly on first deploy; nothing to provision.
+- **Cron trigger** — hourly retention sweep bounded by `RETENTION_DAYS` and
+  `MAX_RECORDS`.
+
+### Prerequisites
+
+| Requirement | Notes |
+|---|---|
+| Cloudflare account | The free Workers plan is sufficient to start: it includes D1, cron triggers, and SQLite-backed Durable Objects (this Worker declares `new_sqlite_classes`, the free-plan-eligible storage backend — **not** the paid-only KV-backed classes). |
+| Node.js 20+ | `node --version` |
+| This repository | Only the `dashboard/` directory is needed. |
+| ~15 minutes | Steps 1-8 are the whole deploy. |
+
+Cost expectation for a small fleet (a handful of hosts): comfortably inside
+the free tier. Telemetry volume is dominated by sweep lifecycle events plus
+one `host.health` + one `tokens.snapshot` record per host per 5 minutes.
+
+---
+
+## 1. Install dependencies
+
+```bash
+cd dashboard
+npm install
+npm test          # 43 tests, all offline (Miniflare) — proves your checkout is sound
+```
+
+## 2. Authenticate Wrangler
+
+Interactive (easiest):
+
+```bash
+npx wrangler login
+npx wrangler whoami     # confirms the account (and shows the account id)
+```
+
+Non-interactive / CI — create an API token at
+**Cloudflare dashboard → My Profile → API Tokens** with these permissions,
+then export it:
+
+| Scope | Permission |
+|---|---|
+| Account | `Workers Scripts: Edit` |
+| Account | `D1: Edit` |
+| Account | `Workers KV Storage: Edit` (used for Wrangler's internal state) |
+| Zone (only if you use a custom domain) | `Zone: Read`, `DNS: Edit` |
+
+```bash
+export CLOUDFLARE_API_TOKEN="..."
+export CLOUDFLARE_ACCOUNT_ID="..."   # required if the token can see >1 account
+```
+
+> Setting `CLOUDFLARE_ACCOUNT_ID` in the environment is preferred over
+> uncommenting `account_id` in `wrangler.toml` — it keeps your account id out
+> of version control.
+
+## 3. Create the D1 database
+
+```bash
+npx wrangler d1 create loom-observability
+```
+
+Wrangler prints a config snippet containing a `database_id`. **Paste that id
+into `wrangler.toml`**, replacing the all-zeros placeholder:
+
+```toml
+[[d1_databases]]
+binding = "DB"
+database_name = "loom-observability"
+database_id = "PASTE-THE-ID-WRANGLER-PRINTED"   # <- was 00000000-0000-...
+migrations_dir = "migrations"
+```
+
+Leave `binding = "DB"` alone — `src/index.ts` reads `env.DB`.
+
+## 4. Apply the schema migrations
+
+```bash
+npx wrangler d1 migrations apply loom-observability --remote
+```
+
+Verify:
+
+```bash
+npx wrangler d1 execute loom-observability --remote \
+  --command "SELECT name FROM sqlite_master WHERE type='table'"
+# expect: hosts, records (plus sqlite internals)
+```
+
+`--local` runs the same migrations against the local Miniflare database used
+by `npm run dev`; `--remote` is the one that touches your real D1 instance.
+
+## 5. Preflight
+
+```bash
+npm run preflight
+```
+
+This fails while any template placeholder survives (all-zeros `database_id`,
+`REPLACE_WITH_*`, an `example.com` route), warns about the dangerous-but-silent
+misconfigurations, and finishes with a `wrangler deploy --dry-run` so a
+config or bundling error surfaces before you touch your account. Expected
+output at this point:
+
+```
+ok     no REPLACE_WITH_* placeholders remain
+ok     database_id is set (…)
+ok     wrangler deploy --dry-run succeeded (config parses, Worker bundles)
+
+PASSED: 0 errors, 0 warning(s)
+```
+
+Zero **errors** is the bar. One warning about `account_id` is expected and
+harmless if you authenticated with `wrangler login` on a single-account
+credential.
+
+## 6. Deploy
+
+```bash
+npm run deploy      # wrangler deploy
+```
+
+Wrangler prints the deployed URL —
+`https://loom-observability-ingest.<your-subdomain>.workers.dev`. Smoke test
+it:
+
+```bash
+curl https://loom-observability-ingest.<your-subdomain>.workers.dev/
+# loom-observability-ingest: see /ingest, /admin/*
+```
+
+## 7. Set the admin token
+
+`/admin/*` is gated by an `ADMIN_TOKEN` secret. **Until it is set, every
+`/admin/*` route answers `503`** and no host can be provisioned.
+
+```bash
+openssl rand -hex 32                       # generate; store it in your password manager
+npx wrangler secret put ADMIN_TOKEN        # paste it at the prompt
+```
+
+Secrets take effect immediately — no redeploy needed. Confirm:
+
+```bash
+npx wrangler secret list                   # ADMIN_TOKEN present
+npm run preflight -- --remote              # also asserts the secret exists
+```
+
+> If you run `wrangler secret put` *before* the first deploy, Wrangler offers
+> to create a draft Worker for the name; accepting that is fine, but deploying
+> first (step 6) is the simpler order.
+
+## 8. Provision an ingest key per host
+
+One key per fleet host, so any single host can be revoked without disturbing
+the others.
+
+```bash
+BASE="https://loom-observability-ingest.<your-subdomain>.workers.dev"
+ADMIN="<the ADMIN_TOKEN from step 7>"
+
+curl -sS -X POST "$BASE/admin/hosts" \
+  -H "authorization: Bearer $ADMIN" \
+  -H 'content-type: application/json' \
+  -d '{"host_id":"my-laptop"}'
+# => {"host_id":"my-laptop","ingest_key":"<64 hex chars — SHOWN ONLY ONCE>"}
+```
+
+**Capture the `ingest_key` now.** Only its SHA-256 hash is stored; there is
+no way to read it back.
+
+Choose `host_id` to match what the daemon reports for that machine — it is
+`$LOOM_HOST_ID` if set, else `$HOSTNAME`, else the output of `hostname`
+(`loom-daemon/src/sweep_registry/mod.rs::host_identity`). The backend always
+records the host id **bound to the authenticated key**, so a mismatch is not
+a security problem, only a confusing one when you read the data back.
+
+Bring-your-own-key is supported too — `{"host_id":"my-laptop","key":"…"}`.
+
+## 9. Point a daemon at your backend
+
+On each fleet host:
+
+**a. Write the ingest key to a file the daemon can read, and nothing else can.**
+The key is *never* inline in config — the daemon reads a path.
+
+```bash
+sudo install -d -m 700 /etc/loom
+printf '%s' '<the ingest_key from step 8>' | sudo tee /etc/loom/observability-ingest.key >/dev/null
+sudo chmod 600 /etc/loom/observability-ingest.key
+```
+
+A user-owned path (e.g. `~/.config/loom/observability-ingest.key`, mode
+`600`) works equally well; the daemon only needs to be able to read it.
+Trailing whitespace/newlines are trimmed.
+
+**b. Add the `observability` block to that host's `.loom/config.json`:**
+
+```json
+{
+  "observability": {
+    "enabled": true,
+    "endpoint": "https://loom-observability-ingest.<your-subdomain>.workers.dev/ingest",
+    "ingestKeyFile": "/etc/loom/observability-ingest.key",
+    "batchSize": 50,
+    "flushIntervalSecs": 30,
+    "queueCapacity": 2000
+  }
+}
+```
+
+Note the `/ingest` path on `endpoint` — the daemon POSTs the batch to exactly
+this URL. Every key also has an env override (**env > config > default**):
+`LOOM_OBSERVABILITY_ENABLED`, `LOOM_OBSERVABILITY_ENDPOINT`,
+`LOOM_OBSERVABILITY_INGEST_KEY_FILE`, `LOOM_OBSERVABILITY_BATCH_SIZE`,
+`LOOM_OBSERVABILITY_FLUSH_INTERVAL_SECS`, `LOOM_OBSERVABILITY_QUEUE_CAPACITY`.
+Full reference: `.loom/docs/daemon-reference.md` → "Observability exporter".
+
+**c. Restart the daemon and confirm it armed the exporter:**
+
+```bash
+./.loom/scripts/stop-daemon.sh && ./.loom/scripts/start-daemon.sh
+# or, on a supervised host: loom-daemon restart --drain
+
+grep observability .loom/logs/daemon.log | tail -5
+# observability: enabled (endpoint=https://…/ingest, batch_size=50, flush_interval=30s, queue_capacity=2000)
+```
+
+A misconfigured block **degrades to off, it does not crash the daemon** — if
+you see `observability: enabled but no endpoint configured` or
+`… no ingestKeyFile configured`, or nothing at all, re-check step 9b.
+
+## 10. Verify telemetry is landing
+
+Trigger some activity (dispatch a sweep, or just wait ≤5 minutes for the
+periodic `host.health` / `tokens.snapshot` sample), then:
+
+```bash
+npx wrangler d1 execute loom-observability --remote \
+  --command "SELECT host_id, kind, count(*) AS n FROM records GROUP BY host_id, kind ORDER BY n DESC"
+
+curl -sS "$BASE/admin/fleet-state" -H "authorization: Bearer $ADMIN"
+```
+
+You should see rows for your `host_id`, and the Durable Object snapshot
+should list the host. If `records` is empty, work the troubleshooting table
+below.
+
+---
+
+## Operations
+
+### Rotating an ingest key
+
+`POST /admin/hosts` refuses a `host_id` that already exists (`409`), so
+rotation is a two-move operation. Pick whichever fits:
+
+**A. Rolling rotation (no raw SQL, brief dual-identity window)** — provision a
+successor identity, cut the host over, then revoke the old one:
+
+```bash
+curl -sS -X POST "$BASE/admin/hosts" -H "authorization: Bearer $ADMIN" \
+  -H 'content-type: application/json' -d '{"host_id":"my-laptop-2"}'
+# update /etc/loom/observability-ingest.key on the host, restart the daemon, then:
+curl -sS -X POST "$BASE/admin/hosts/my-laptop/revoke" -H "authorization: Bearer $ADMIN"
+```
+
+Historical rows keep the old `host_id`; new rows use the new one.
+
+**B. In-place rotation (same `host_id`, needs one D1 statement)** — delete the
+host row, then re-provision the same id with a fresh key:
+
+```bash
+npx wrangler d1 execute loom-observability --remote \
+  --command "DELETE FROM hosts WHERE host_id = 'my-laptop'"
+curl -sS -X POST "$BASE/admin/hosts" -H "authorization: Bearer $ADMIN" \
+  -H 'content-type: application/json' -d '{"host_id":"my-laptop"}'
+```
+
+Between the delete and the daemon picking up the new key, that host's pushes
+get `401` — they are **not lost**: the daemon's durable queue retries with
+backoff and drains once the new key is in place (up to `queueCapacity`).
+
+### Revoking a host
+
+```bash
+curl -sS -X POST "$BASE/admin/hosts/<host_id>/revoke" -H "authorization: Bearer $ADMIN"
+```
+
+Takes effect on the next request. Other hosts are unaffected. Already-stored
+records are retained (revocation stops writes, it does not erase history).
+
+### Tuning retention
+
+`RETENTION_DAYS` and `MAX_RECORDS` in `wrangler.toml`'s `[vars]`; both are
+enforced on every hourly sweep. Change them and redeploy, then optionally
+force a sweep:
+
+```bash
+curl -sS -X POST "$BASE/admin/retention/run" -H "authorization: Bearer $ADMIN"
+# => {"deletedByAge":…,"deletedBySize":…}
+```
+
+### Custom domain and SSO
+
+A `*.workers.dev` URL cannot be protected by Cloudflare Access — Access only
+covers hostnames in a zone you own. To gate the authenticated view behind
+SSO, attach a custom domain (`[[routes]]` in `wrangler.toml`), set
+`workers_dev = false`, and follow
+[`cloudflare-access.md`](cloudflare-access.md). `npm run preflight` warns
+when a custom domain is configured while `workers_dev` is still enabled,
+because that leaves an unauthenticated bypass around the Access policy.
+
+### Tearing it all down
+
+```bash
+npx wrangler delete                                   # removes the Worker (and its Durable Object)
+npx wrangler d1 delete loom-observability             # removes all stored telemetry
+```
+
+Then set `observability.enabled` to `false` on every daemon host (or remove
+the block) and restart, so daemons stop queueing pushes to a dead endpoint.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `wrangler deploy` → "more than one account" | Credential spans several accounts | `export CLOUDFLARE_ACCOUNT_ID=…` (`wrangler whoami` lists them) |
+| Deploy fails on `database_id` | Placeholder never replaced | Step 3; `npm run preflight` catches this |
+| `/admin/*` returns `503` | `ADMIN_TOKEN` secret unset | Step 7 |
+| `/admin/*` returns `401` | Wrong admin token | Compare with what you stored; `wrangler secret put ADMIN_TOKEN` to reset |
+| `/ingest` returns `401` | Unknown or revoked ingest key | Re-provision (step 8); confirm the key file has no stray characters |
+| `/ingest` returns `400 envelope N: …` | Malformed batch — a whole batch is rejected on the first bad envelope | Version-skew between daemon and backend; check `.loom/docs/telemetry-schema.md` |
+| Daemon log shows nothing about observability | Block absent or `enabled` false | Step 9b, then restart |
+| `observability: enabled but no endpoint configured` | Missing/empty `endpoint` | Step 9b |
+| Records stop arriving after a host sleeps | Expected — the durable queue drains on wake | No action; check `observability-queue.jsonl` growth if it persists |
+| `records` grows without bound | Cron trigger not firing | `wrangler deployments list`; force with `POST /admin/retention/run` |
+
+---
+
+## Validation status
+
+The template and every command in this runbook were validated against the
+Wrangler CLI (`wrangler deploy --dry-run` for the default config, the
+commented `[[routes]]` custom-domain variant, and the commented
+`[env.staging]` variant) and against the backend's own 43-test Miniflare
+suite. **A live from-scratch deploy against a real Cloudflare account — steps
+2-10 end to end, including a real daemon push — has not been performed** and
+is recommended before treating this as fully proven. Please report any step
+that does not work as written.

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "wrangler dev",
+    "preflight": "bash scripts/check-deploy-config.sh",
     "deploy": "wrangler deploy",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/dashboard/scripts/check-deploy-config.sh
+++ b/dashboard/scripts/check-deploy-config.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# =============================================================================
+# check-deploy-config.sh — pre-deploy configuration check for the Loom fleet
+# observability Workers backend (epic #4702, Phase 2).
+#
+# `wrangler.toml` doubles as a template: it ships with obviously-fake
+# placeholders a deployer must replace with values from their own Cloudflare
+# account. This script is what stops a half-configured template from reaching
+# `wrangler deploy` — it fails on any surviving placeholder and warns about
+# the configuration mistakes that are silent but dangerous (chiefly: leaving
+# workers.dev enabled next to an Access-gated custom domain, which is a
+# wide-open bypass around the Access policy).
+#
+# Usage:
+#   npm run preflight                  # config checks + bundle dry run
+#   bash scripts/check-deploy-config.sh --skip-bundle
+#   bash scripts/check-deploy-config.sh --remote      # also checks secrets
+#
+# Exit codes: 0 = ready to deploy, 1 = at least one blocking error.
+# Full walkthrough: docs/deploy-runbook.md
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONFIG="${LOOM_DASHBOARD_WRANGLER_CONFIG:-$APP_DIR/wrangler.toml}"
+
+SKIP_BUNDLE=0
+CHECK_REMOTE=0
+WRANGLER_ENV=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --skip-bundle) SKIP_BUNDLE=1 ;;
+    --remote) CHECK_REMOTE=1 ;;
+    --env)
+      shift
+      WRANGLER_ENV="${1:-}"
+      [ -n "$WRANGLER_ENV" ] || { echo "--env requires a value" >&2; exit 2; }
+      ;;
+    -h | --help)
+      # The file header, up to the first line of actual code.
+      awk 'NR > 1 { if (/^#/) print; else exit }' "${BASH_SOURCE[0]}"
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1 (try --help)" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+errors=0
+warnings=0
+fail() {
+  printf 'ERROR  %s\n' "$1" >&2
+  errors=$((errors + 1))
+}
+warn() {
+  printf 'WARN   %s\n' "$1" >&2
+  warnings=$((warnings + 1))
+}
+pass() { printf 'ok     %s\n' "$1"; }
+
+# ---------------------------------------------------------------------------
+# Config file + "active" (non-comment) lines
+# ---------------------------------------------------------------------------
+if [ ! -f "$CONFIG" ]; then
+  fail "no wrangler config at $CONFIG"
+  exit 1
+fi
+pass "config file: $CONFIG"
+
+# Only uncommented lines are live configuration. Everything the template
+# leaves commented out (the account_id hint, the [[routes]] example, the
+# [env.staging] block) is documentation, not a misconfiguration.
+ACTIVE="$(grep -v '^[[:space:]]*#' "$CONFIG" | grep -v '^[[:space:]]*$' || true)"
+
+# ---------------------------------------------------------------------------
+# 1. No surviving template placeholders
+# ---------------------------------------------------------------------------
+if printf '%s\n' "$ACTIVE" | grep -q 'REPLACE_WITH_'; then
+  printf '%s\n' "$ACTIVE" | grep -n 'REPLACE_WITH_' >&2 || true
+  fail "template placeholder(s) above are still in $CONFIG — replace them with values from your own account"
+else
+  pass "no REPLACE_WITH_* placeholders remain"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. D1 database id was filled in
+# ---------------------------------------------------------------------------
+db_id="$(printf '%s\n' "$ACTIVE" |
+  grep -E '^[[:space:]]*database_id[[:space:]]*=' |
+  head -1 |
+  sed -E 's/.*=[[:space:]]*"?([^"]*)"?.*/\1/')"
+if [ -z "$db_id" ]; then
+  fail "no database_id found in $CONFIG — run 'wrangler d1 create loom-observability' and paste the id"
+elif [ "$db_id" = "00000000-0000-0000-0000-000000000000" ]; then
+  fail "database_id is still the all-zeros placeholder — run 'wrangler d1 create loom-observability' and paste the id it prints"
+else
+  pass "database_id is set ($db_id)"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Account id is resolvable (toml value, or the env var, or a single-account
+#    credential Wrangler can infer from — the last case is only a notice)
+# ---------------------------------------------------------------------------
+if printf '%s\n' "$ACTIVE" | grep -qE '^[[:space:]]*account_id[[:space:]]*='; then
+  pass "account_id is set in $CONFIG"
+elif [ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+  pass "account_id supplied via \$CLOUDFLARE_ACCOUNT_ID"
+else
+  warn "no account_id in $CONFIG and \$CLOUDFLARE_ACCOUNT_ID is unset — fine if your credential has exactly one account, otherwise wrangler will refuse to deploy ('wrangler whoami' lists them)"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Custom domain / workers.dev interaction (the Access-bypass trap)
+# ---------------------------------------------------------------------------
+has_route=0
+if printf '%s\n' "$ACTIVE" | grep -qE '^[[:space:]]*pattern[[:space:]]*='; then
+  has_route=1
+fi
+if [ "$has_route" -eq 1 ] && printf '%s\n' "$ACTIVE" | grep -qE 'pattern[[:space:]]*=[[:space:]]*"[^"]*example\.com"'; then
+  fail "route pattern still points at example.com — set your own hostname"
+fi
+
+workers_dev="$(printf '%s\n' "$ACTIVE" |
+  grep -E '^[[:space:]]*workers_dev[[:space:]]*=' |
+  head -1 |
+  sed -E 's/.*=[[:space:]]*([a-z]+).*/\1/')"
+if [ "$has_route" -eq 1 ] && [ "$workers_dev" != "false" ]; then
+  warn "a custom domain route is configured but workers_dev is not false — the *.workers.dev URL stays publicly reachable and bypasses any Cloudflare Access policy on the custom domain (docs/cloudflare-access.md)"
+elif [ "$has_route" -eq 1 ]; then
+  pass "custom domain route configured with workers_dev disabled"
+else
+  pass "workers.dev-only deployment (no custom domain route yet — required before Cloudflare Access)"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Source + migrations present
+# ---------------------------------------------------------------------------
+main_rel="$(printf '%s\n' "$ACTIVE" |
+  grep -E '^[[:space:]]*main[[:space:]]*=' |
+  head -1 |
+  sed -E 's/.*=[[:space:]]*"([^"]*)".*/\1/')"
+if [ -n "$main_rel" ] && [ -f "$APP_DIR/$main_rel" ]; then
+  pass "entrypoint exists ($main_rel)"
+else
+  fail "entrypoint '$main_rel' declared in $CONFIG does not exist"
+fi
+
+migrations_rel="$(printf '%s\n' "$ACTIVE" |
+  grep -E '^[[:space:]]*migrations_dir[[:space:]]*=' |
+  head -1 |
+  sed -E 's/.*=[[:space:]]*"([^"]*)".*/\1/')"
+migrations_rel="${migrations_rel:-migrations}"
+migration_count=0
+if [ -d "$APP_DIR/$migrations_rel" ]; then
+  migration_count="$(find "$APP_DIR/$migrations_rel" -maxdepth 1 -name '*.sql' | wc -l | tr -d ' ')"
+fi
+if [ "$migration_count" -gt 0 ]; then
+  pass "$migration_count migration(s) in $migrations_rel/ (apply with 'wrangler d1 migrations apply <db> --remote')"
+else
+  fail "no .sql migrations found in $APP_DIR/$migrations_rel"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Wrangler availability + bundle dry run
+# ---------------------------------------------------------------------------
+WRANGLER=""
+if [ -x "$APP_DIR/node_modules/.bin/wrangler" ]; then
+  WRANGLER="$APP_DIR/node_modules/.bin/wrangler"
+elif command -v wrangler >/dev/null 2>&1; then
+  WRANGLER="$(command -v wrangler)"
+fi
+
+if [ -z "$WRANGLER" ]; then
+  warn "wrangler not found (run 'npm install' in $APP_DIR) — skipping bundle and remote checks"
+  SKIP_BUNDLE=1
+  CHECK_REMOTE=0
+else
+  pass "wrangler: $WRANGLER"
+fi
+
+env_args=""
+[ -n "$WRANGLER_ENV" ] && env_args="--env $WRANGLER_ENV"
+
+if [ "$SKIP_BUNDLE" -eq 0 ]; then
+  outdir="$(mktemp -d)"
+  # shellcheck disable=SC2086
+  if bundle_output="$(cd "$APP_DIR" && "$WRANGLER" deploy --dry-run -c "$CONFIG" --outdir "$outdir" $env_args 2>&1)"; then
+    pass "wrangler deploy --dry-run succeeded (config parses, Worker bundles)"
+  else
+    printf '%s\n' "$bundle_output" >&2
+    fail "wrangler deploy --dry-run failed (see output above)"
+  fi
+  rm -rf "$outdir"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Optional remote check: is the ADMIN_TOKEN secret set on the deployed
+#    Worker? Without it every /admin/* route answers 503 and no host can be
+#    provisioned. Requires a working Cloudflare credential.
+# ---------------------------------------------------------------------------
+if [ "$CHECK_REMOTE" -eq 1 ]; then
+  # shellcheck disable=SC2086
+  if secret_output="$(cd "$APP_DIR" && "$WRANGLER" secret list -c "$CONFIG" $env_args 2>&1)"; then
+    if printf '%s\n' "$secret_output" | grep -q 'ADMIN_TOKEN'; then
+      pass "ADMIN_TOKEN secret is set on the deployed Worker"
+    else
+      fail "ADMIN_TOKEN secret is NOT set — run 'wrangler secret put ADMIN_TOKEN${env_args:+ $env_args}' (until then every /admin/* route answers 503; an empty list also means the Worker is not deployed yet)"
+    fi
+  else
+    warn "could not list secrets (not deployed yet, or no Cloudflare credential): $(printf '%s' "$secret_output" | tail -1)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+echo
+if [ "$errors" -gt 0 ]; then
+  printf 'FAILED: %d error(s), %d warning(s)\n' "$errors" "$warnings" >&2
+  exit 1
+fi
+printf 'PASSED: 0 errors, %d warning(s)\n' "$warnings"

--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -1,40 +1,98 @@
+# =============================================================================
+# loom-observability-ingest — Cloudflare Workers deployment template
+# =============================================================================
+# This file is BOTH the working config used by this repo's test suite AND the
+# template a third party copies to deploy the backend to their own Cloudflare
+# account.
+#
+# Every value you must supply is tagged `CHANGE ME` and carries an obviously
+# fake placeholder. `npm run preflight` fails while any placeholder survives,
+# so a half-configured deploy is caught before `wrangler deploy` runs.
+#
+#   Full deploy walkthrough .... docs/deploy-runbook.md
+#   SSO gate / public view ..... docs/cloudflare-access.md
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Worker identity
+# -----------------------------------------------------------------------------
+# `name` is the Worker's name in your account and the first label of its
+# workers.dev URL (https://<name>.<your-subdomain>.workers.dev). Keeping the
+# default is fine; change it only if one account hosts several instances.
 name = "loom-observability-ingest"
 main = "src/index.ts"
 compatibility_date = "2024-09-23"
 
-# --------------------------------------------------------------------------
-# D1 — durable history for every ingested telemetry record.
+# CHANGE ME — only if your Cloudflare credential can reach more than one
+# account. Wrangler infers the account when the credential has exactly one and
+# errors out otherwise. Find yours with `wrangler whoami`.
 #
-# `database_id` below is a placeholder. After running:
+# Preferred: leave this commented out and `export CLOUDFLARE_ACCOUNT_ID=...`
+# instead, so your account id never lands in git.
+# account_id = "REPLACE_WITH_YOUR_CLOUDFLARE_ACCOUNT_ID"
+
+# workers.dev gives you a public URL with zero DNS setup — right for the first
+# smoke test.
+#
+# CHANGE ME to `false` once you serve from a custom domain (`[[routes]]`
+# below). Cloudflare Access can only gate hostnames inside a zone you own, so a
+# still-enabled workers.dev URL is an unauthenticated bypass straight around
+# your Access policy — see docs/cloudflare-access.md.
+workers_dev = true
+
+# CHANGE ME — required before you can put Cloudflare Access in front of this
+# Worker, optional otherwise. The zone (`example.com`) must already be active
+# in the same Cloudflare account; `custom_domain = true` makes Wrangler create
+# and manage the DNS record for you.
+#
+# [[routes]]
+# pattern = "loom-dashboard.example.com"
+# custom_domain = true
+
+# -----------------------------------------------------------------------------
+# D1 — durable history for every ingested telemetry record.
+# -----------------------------------------------------------------------------
+# CHANGE ME — `database_id` below is an all-zeros placeholder. Create the
+# database in YOUR account and paste back the id it prints:
+#
 #   wrangler d1 create loom-observability
-# paste the returned database_id here (or override per-environment in
-# `[env.<name>]` blocks — see README.md "Deploying your own instance").
-# --------------------------------------------------------------------------
+#
+# `database_name` may be anything; `binding` is the name `src/index.ts` reads
+# off `Env` (`env.DB`) and must NOT be renamed without editing the source.
 [[d1_databases]]
 binding = "DB"
 database_name = "loom-observability"
 database_id = "00000000-0000-0000-0000-000000000000"
 migrations_dir = "migrations"
 
-# --------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Durable Object — live "what is running right now across every host" state,
 # independent of D1's durable history.
-# --------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# Nothing account-specific here: Durable Objects are created implicitly on the
+# first deploy, so there is no id to paste. `name` is the binding
+# `src/index.ts` reads (`env.FLEET_STATE`) and `class_name` must match the
+# class exported from `src/fleetState.ts` — renaming either requires a matching
+# source edit plus a new `[[migrations]]` tag below.
 [[durable_objects.bindings]]
 name = "FLEET_STATE"
 class_name = "FleetState"
 
+# Durable Object class migrations. `tag` is an append-only history: never edit
+# or delete a tag that has already been deployed — add a new one.
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["FleetState"]
 
-# --------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Retention policy — see src/retention.ts. Both bounds are enforced on every
 # scheduled run; either alone is sufficient to cap D1 growth, but both are
 # applied for defense in depth (a burst of hosts could blow the row cap well
 # before the age cutoff, and a single very-chatty host could blow the age
 # cutoff's effective size before enough time passes).
-# --------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# Tune to your fleet size and D1 plan limits. These are plain (non-secret)
+# vars, so `wrangler deploy` publishes exactly what is written here.
 [vars]
 RETENTION_DAYS = "90"
 MAX_RECORDS = "500000"
@@ -45,7 +103,43 @@ MAX_RECORDS = "500000"
 [triggers]
 crons = ["0 * * * *"]
 
-# --------------------------------------------------------------------------
-# Secrets (NOT committed — set via `wrangler secret put <NAME>`):
-#   ADMIN_TOKEN   — bearer token gating /admin/* host-key management routes.
-# --------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# Secrets — NEVER written into this file (it is committed). Set them with:
+#
+#   wrangler secret put ADMIN_TOKEN         # deployed Worker
+#   echo 'ADMIN_TOKEN="..."' > .dev.vars    # local `wrangler dev` (gitignored)
+#
+#   ADMIN_TOKEN — bearer token gating the /admin/* host-key management routes.
+#                 Generate with `openssl rand -hex 32`. While it is unset every
+#                 /admin/* route answers 503, so host provisioning is
+#                 impossible — set it before the first deploy.
+#
+# See .dev.vars.example.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Multiple environments (optional)
+# -----------------------------------------------------------------------------
+# A named environment deploys a separate Worker (`<name>-<env>`) with its own
+# bindings: `wrangler deploy --env staging`.
+#
+# IMPORTANT: `vars`, `d1_databases`, `durable_objects`, and `routes` are NOT
+# inherited from the top level — a named environment must redeclare each one it
+# needs, and needs its own `wrangler secret put --env staging ADMIN_TOKEN`.
+#
+# [env.staging]
+# workers_dev = true
+#
+# [[env.staging.d1_databases]]
+# binding = "DB"
+# database_name = "loom-observability-staging"
+# database_id = "REPLACE_WITH_YOUR_STAGING_D1_DATABASE_ID"
+# migrations_dir = "migrations"
+#
+# [[env.staging.durable_objects.bindings]]
+# name = "FLEET_STATE"
+# class_name = "FleetState"
+#
+# [env.staging.vars]
+# RETENTION_DAYS = "7"
+# MAX_RECORDS = "50000"

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -4580,10 +4580,20 @@ the operator only ever created the issue.
 An **opt-in, off-by-default** telemetry exporter that pushes fleet telemetry
 (sweep lifecycle/outcome, token-pool snapshots, host health) to a configured
 HTTP(S) sink. This is the daemon-side half of epic #4702's rich fleet
-dashboard; the Phase-2 Cloudflare Workers backend (the first real sink) is a
-separate, later issue — this issue ships value standalone, with no cloud
-dependency: a disabled or under-configured `observability` block is a
-zero-syscall no-op, exactly like `autonomous.idleExit` above.
+dashboard; the Phase-2 Cloudflare Workers backend (#4725) is the first real
+sink. The exporter ships value standalone, with no cloud dependency: a
+disabled or under-configured `observability` block is a zero-syscall no-op,
+exactly like `autonomous.idleExit` above.
+
+**Standing up your own sink**: the Workers backend is a deploy-to-your-own-
+account template — `wrangler.toml` plus a runbook that walks account/D1
+setup, migrations, ingest-key generation and rotation, and pointing the
+`observability` block below at the result, with a companion guide for gating
+the authenticated view behind Cloudflare Access. Both live beside the backend
+in the upstream Loom repo (not shipped to consumer installs):
+[`dashboard/docs/deploy-runbook.md`](https://github.com/rjwalters/loom/blob/main/dashboard/docs/deploy-runbook.md)
+and
+[`dashboard/docs/cloudflare-access.md`](https://github.com/rjwalters/loom/blob/main/dashboard/docs/cloudflare-access.md).
 
 ### Config surface (`.loom/config.json → observability`)
 


### PR DESCRIPTION
## Summary

Packages the Phase-2 Cloudflare Workers backend (#4725, merged as PR #4734) as a **deploy-to-your-own-account template**: a parameterized `wrangler.toml`, a step-by-step deploy runbook, a Cloudflare Access setup guide, and an executable preflight check that refuses to let a half-configured template reach `wrangler deploy`.

The epic's success criterion is "a third party can deploy the backend to their own Cloudflare account from the template + runbook alone" — so the deliverable is not just prose. `npm run preflight` is the structural half: it fails on any surviving placeholder, warns on the silent-but-dangerous misconfigurations, and ends with a real `wrangler deploy --dry-run`.

## Changes

- **`dashboard/wrangler.toml`** — restructured as a template. Every account-specific value carries an obviously-fake placeholder tagged `CHANGE ME`: `account_id` (commented, with the preferred `$CLOUDFLARE_ACCOUNT_ID` alternative so it never lands in git), the D1 `database_id`, and a commented custom-domain `[[routes]]` block. Adds an explicit `workers_dev` knob with the reason it must be turned off before Access, documents which bindings are safe to rename (none, without a source edit), and ships a commented `[env.staging]` example that spells out that `vars`/`d1_databases`/`durable_objects`/`routes` are **not** inherited by named environments.
- **`dashboard/scripts/check-deploy-config.sh`** + `npm run preflight` — blocking checks (surviving `REPLACE_WITH_*`, all-zeros `database_id`, `example.com` route, missing entrypoint/migrations, failed bundle) and warnings (no resolvable account id; **a custom domain configured while `workers_dev` is still true**, which is an unauthenticated bypass straight around any Access policy). `--remote` additionally asserts the `ADMIN_TOKEN` secret exists on the deployed Worker; `--skip-bundle` and `--env <name>` are supported.
- **`dashboard/docs/deploy-runbook.md`** — account setup and API-token scopes, D1 creation, migrations, preflight, deploy, `ADMIN_TOKEN`, per-host ingest-key provisioning, wiring a daemon's `observability` block (key-file permissions, the `/ingest` path on `endpoint`, restart + log verification, env overrides), **key rotation and revocation** (both the no-SQL rolling path and the in-place path, since `POST /admin/hosts` 409s on an existing `host_id`), retention tuning, custom-domain/SSO handoff, teardown, and a symptom→cause→fix troubleshooting table.
- **`dashboard/docs/cloudflare-access.md`** — leads with the constraint that shapes the whole design: Access can only cover hostnames in a zone you own, so a live `*.workers.dev` URL makes the gate decorative. Then the per-path application layout (Bypass `/ingest` and `/public`, Allow everything else), the ordering hazard (create the Bypass apps first or the fleet's pushes get redirected), service tokens for scripted `/admin` calls, a 401-vs-302 verification recipe, the `CF-Access-Jwt-Assertion` hardening path flagged as **not implemented today**, a pitfalls table, and an API appendix.
- **`dashboard/.dev.vars.example`** + a `.gitignore` negation so the secret-free local-dev template is committed while `.dev.vars` stays ignored.
- **`dashboard/README.md`** and **`defaults/docs/daemon-reference.md`** (observability exporter section) now point at both documents.

No backend source (`dashboard/src/**`) was touched.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `wrangler.toml` template with clearly marked placeholders (account id, D1 binding, Durable Object binding) | ✅ | Every deployer-supplied value is tagged `CHANGE ME`; `account_id` → `REPLACE_WITH_YOUR_CLOUDFLARE_ACCOUNT_ID` (commented + env-var alternative), `database_id` → all-zeros placeholder, `[[routes]]` → `example.com`. The DO binding is documented as having no account-specific id (created implicitly on first deploy) with an explicit note on what renaming it would require. `npm run preflight` fails on each surviving placeholder — demonstrated by running it against the committed file (fails on `database_id`) and against a filled-in copy (passes, 0 errors 0 warnings). |
| Runbook covers account setup, D1 + migrations, Worker deploy, ingest key generation/rotation, pointing a daemon at the backend via `observability` | ✅ | `dashboard/docs/deploy-runbook.md` §§1-10 plus the Operations section. The daemon wiring was written against the actual Phase-1 code (`loom-daemon/src/observability/mod.rs` for the six config keys, their `LOOM_OBSERVABILITY_*` env overrides, the key-file trim behavior and degrade-to-off warnings; `sweep_registry::host_identity` for how `host_id` is derived). Rotation is documented against the real constraint that `POST /admin/hosts` returns 409 for an existing `host_id`. |
| Cloudflare Access guide: gate the authenticated route, leave the public route ungated | ✅ | `dashboard/docs/cloudflare-access.md` §§1-4: the workers.dev prerequisite, the Bypass/Allow route map (with `/ingest` explicitly bypassed — the daemon sends a bearer ingest key, not an SSO cookie), the most-specific-path precedence rule that makes the split work, and a verification recipe that distinguishes a Worker 401 from an Access 302. |
| Runbook validated by an actual from-scratch deploy | ⚠️ partial — see below | Validated as far as this sandbox allows: `wrangler 4.54.0 deploy --dry-run` against the committed config **and** against uncommented copies of both the `[[routes]]` custom-domain block and the `[env.staging]` block (all three parse and bundle cleanly); the backend's 43-test Miniflare suite still passes against the rewritten `wrangler.toml` (the vitest pool reads it); `shellcheck --severity=warning` clean; preflight exercised on pass, fail, and `--remote` paths. **No live Cloudflare account was available**, so steps 2-10 have not been run end to end against real infrastructure. |
| Docs linked from the observability reference | ✅ | Pointer added to the "Observability exporter" section of `defaults/docs/daemon-reference.md` (the source of truth for the installed `.loom/docs/` copy), using absolute upstream URLs since `dashboard/` is not shipped to consumer installs — the same convention that section's existing `docs/autonomous-mode-e2e.md` reference uses. Not resynced into `.loom/docs/` here; that is the periodic resync commit's job. |

## Test Plan

```
cd dashboard
npm run check            # tsc --noEmit + vitest → 43/43 passing
npm run preflight        # fails on the committed all-zeros database_id, by design
shellcheck --severity=warning --format=gcc scripts/check-deploy-config.sh   # clean
npx wrangler deploy --dry-run                                   # config parses, bundles
```

Plus, out of band: a copy of `wrangler.toml` with the staging block uncommented dry-ran under `--env staging` (correct per-env bindings resolved), a copy with the custom-domain route uncommented and `workers_dev = false` dry-ran cleanly, and a fully-filled copy passed preflight with 0 errors / 0 warnings while a deliberately-broken copy produced exactly the two expected errors and the workers.dev warning.

## Note for the reviewer / operator

The issue's fourth criterion asks for validation by a real from-scratch deploy. That is not possible from this environment — there is no Cloudflare account to deploy into. Everything that could be validated offline was (config schema via three `--dry-run` variants, the test suite, the preflight script's own pass/fail paths), and the runbook's closing "Validation status" section states this limitation in the document itself rather than only in this PR. **A human operator running steps 2-10 once against a real account is still recommended** before treating the third-party-deployability criterion as fully proven.

Closes #4728
