### PR TITLE
feat(dashboard): visibility classification + redaction policy layer (Epic #4702 Phase 2)

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -10,12 +10,15 @@ the read-side query API + live tail (issue #4726) the Phase 3 dashboard UI
 consumes.
 
 Wire format reference: [`.loom/docs/telemetry-schema.md`](../.loom/docs/telemetry-schema.md).
-Query API reference: [`docs/query-api.md`](docs/query-api.md).
+Query API reference: [`docs/query-api.md`](docs/query-api.md) — includes the
+`/api/*` (authenticated) vs. `/public/*` (redacted) route split and the
+visibility-based redaction policy (issue #4727).
 
-**Out of scope for this repo**: Worker-side Cloudflare Access JWT verification
-(the [Access guide](docs/cloudflare-access.md) covers gating via the edge
-proxy instead), and visibility-based redaction beyond faithfully storing the
-`visibility` tag (#4727, which wraps the query API added here).
+**Out of scope for this repo**: Worker-side Cloudflare Access JWT
+verification — the [Access guide](docs/cloudflare-access.md) covers gating
+`/api/*` via the edge proxy instead; the Worker only decides *what a request
+sees* (via the route it reached), never *whether it should have reached
+here*.
 
 ## Architecture
 
@@ -115,12 +118,18 @@ asserts the `ADMIN_TOKEN` secret exists on the deployed Worker.
 | `POST /admin/hosts/:hostId/revoke` | `Authorization: Bearer <ADMIN_TOKEN>` | Revoke a host's key. |
 | `POST /admin/retention/run` | `Authorization: Bearer <ADMIN_TOKEN>` | Run the retention sweep on demand (also runs hourly via `[triggers] crons`). |
 | `GET /admin/fleet-state` | `Authorization: Bearer <ADMIN_TOKEN>` | Read the Durable Object's live snapshot (operator introspection/manual verification). |
-| `GET /api/fleet-state` | none (unclassified — see #4727) | Phase 3 query API: current state of every known host/sweep. |
-| `GET /api/history` | none (unclassified — see #4727) | Phase 3 query API: filterable, paginated D1 history query. |
-| `GET /api/events` | none (unclassified — see #4727) | Phase 3 query API: SSE live tail of newly-ingested telemetry. |
+| `GET /api/fleet-state` | none in-Worker — put behind Cloudflare Access (see below) | Authenticated query API: current state of every known host/sweep, full detail. |
+| `GET /api/history` | none in-Worker — put behind Cloudflare Access | Authenticated query API: filterable, paginated D1 history query, full detail. |
+| `GET /api/events` | none in-Worker — put behind Cloudflare Access | Authenticated query API: SSE live tail of newly-ingested telemetry, full detail. |
+| `GET /public/fleet-state` | none (always public) | Public query API: same data as `/api/fleet-state`, redacted per record `visibility` (issue #4727). |
+| `GET /public/history` | none (always public) | Public query API: same data as `/api/history`, redacted. |
+| `GET /public/events` | none (always public) | Public query API: same data as `/api/events`, redacted. |
 
-Full request/response shapes for the `/api/*` routes:
-[`docs/query-api.md`](docs/query-api.md).
+Full request/response shapes for the `/api/*` and `/public/*` routes,
+including the exact redaction policy per record kind:
+[`docs/query-api.md`](docs/query-api.md). Cloudflare Access setup to actually
+gate `/api/*` at the edge (this backend never verifies auth itself):
+[`docs/cloudflare-access.md`](docs/cloudflare-access.md).
 
 ## Design decisions worth knowing
 
@@ -146,3 +155,12 @@ Full request/response shapes for the `/api/*` routes:
   mirroring the Rust daemon's decode rule: only the exact string
   `"public"` is public, everything else (missing, unknown label, wrong
   type, `null`) is private.
+- **Redaction is a per-kind field allowlist, not a blocklist.**
+  `src/redaction.ts` names, per record `kind`, exactly which fields survive
+  into a private/public response — a future schema field (e.g. an issue
+  title, once one exists on the wire) is dropped by default until this
+  table is deliberately updated, rather than leaking by accident because no
+  one thought to add it to a blocklist. `/api/*` vs `/public/*` is a
+  route-based auth split (no JWT/header parsing in this Worker, per the
+  epic's "no auth code in the dashboard itself" constraint) — see
+  `docs/query-api.md` for the full rationale.

--- a/dashboard/docs/query-api.md
+++ b/dashboard/docs/query-api.md
@@ -1,27 +1,61 @@
-# Query API + live tail (Epic #4702, Phase 2 — issue #4726)
+# Query API + live tail (Epic #4702, Phase 2 — issues #4726 + #4727)
 
 The read side of the Phase-2 Workers backend: the query API and live event
 tail the Phase-3 dashboard UI consumes. Builds on the D1 history store +
 `FleetState` Durable Object issue #4725 introduced (`src/index.ts` /
-`src/fleetState.ts`) — this issue adds read paths only, no new storage.
+`src/fleetState.ts`) — these issues add read paths only, no new storage.
 
-**Unclassified surface.** Every route below returns full record detail
-regardless of the stored `visibility` tag, and requires no authentication.
-Visibility-based redaction (a public view vs. an authenticated view with full
-detail) is issue #4727's job, as a wrapper in front of these routes — not
-implemented here. Do not point an untrusted public client at these routes
-directly until #4727 lands.
+## Authenticated vs. public: two route surfaces, one redaction policy
+
+Every route below exists **twice** — once under `/api/*` and once under
+`/public/*` — returning the same underlying data through two different
+policies:
+
+| Prefix | Who reaches it | Visibility-tagged (`private`) data |
+|---|---|---|
+| `/api/*` | **Authenticated** — the surface an operator's Cloudflare Access policy is expected to gate (see [`cloudflare-access.md`](cloudflare-access.md)'s route map: everything not explicitly Bypassed is Allow-gated) | Full detail, unredacted |
+| `/public/*` | **Public** — always reachable, no login | Redacted per record kind (see below); `public`-visibility data is always full detail on either prefix |
+
+**This is a route-based split, not an in-Worker one.** Per the epic's
+explicit constraint ("no auth code in the dashboard itself"), the Worker
+never parses a JWT or any other credential — `isAuthenticated` in
+`src/index.ts` is set purely by which path matched. The `/public` prefix is
+the same path `cloudflare-access.md` already reserves as a Bypass
+application (§2 of that guide, added ahead of the Phase-3 public page); the
+existing `/api/*` prefix is left as the "everything else" Allow-gated
+surface that guide already documents. Putting an operator's Access policy in
+front of `/api/*` (and leaving `/public/*` bypassed) is what actually makes
+the split enforceable end to end — **the Worker's own redaction is a
+defense-in-depth control, not a substitute for that edge configuration.**
+
+**Redaction is one policy layer, one enforcement point.**
+[`src/redaction.ts`](../src/redaction.ts) wraps every `/api/*` and
+`/public/*` handler as a post-processing step over `src/query.ts`'s results
+— `query.ts` itself is unmodified and still returns full detail for every
+kind (its own "unclassified surface" module doc is unchanged and accurate).
+The redaction policy is a **per-kind field allowlist** (not a blocklist): a
+private, unauthenticated response for a given `kind` includes only the
+fields that module's table explicitly lists as safe (lifecycle/timing/
+model/rate fields) — every other field, known or not-yet-invented, is
+dropped by default. See that module's doc comment for the full policy,
+including the explicit decision on `tokens.snapshot`/`host.health` (host-level
+kinds with no `repo` reference — passed through unredacted on both
+surfaces).
 
 Implementation: [`src/query.ts`](../src/query.ts) (filter parsing, the D1
-query, and the live-tail stream) plus the route handlers in
-[`src/index.ts`](../src/index.ts). Tests:
-[`test/query.test.ts`](../test/query.test.ts).
+query, and the live-tail stream — unclassified), [`src/redaction.ts`](../src/redaction.ts)
+(the policy layer) plus the route handlers in [`src/index.ts`](../src/index.ts).
+Tests: [`test/query.test.ts`](../test/query.test.ts) (data access),
+[`test/redaction.test.ts`](../test/redaction.test.ts) (the adversarial
+redaction suite — every record kind × visibility × auth combination).
 
-## `GET /api/fleet-state`
+## `GET /api/fleet-state` / `GET /public/fleet-state`
 
 Current state of every host/sweep known to the `FleetState` Durable Object —
-the unclassified equivalent of the operator-only `GET /admin/fleet-state`
-(same underlying snapshot, no `ADMIN_TOKEN` required).
+the query-API equivalent of the operator-only `GET /admin/fleet-state` (same
+underlying snapshot, no `ADMIN_TOKEN` required). `/public/fleet-state`
+redacts each `activeSweeps` entry per the visibility policy above; `/api/fleet-state`
+always returns full detail.
 
 **Response** (`200`, camelCase — mirrors the Durable Object's own JSON, see
 `src/fleetState.ts`'s `FleetSnapshot`):
@@ -56,10 +90,18 @@ A completed sweep is not present in `activeSweeps` (removed on
 `sweep.completed` — see `src/fleetState.ts`'s module doc); its full record
 lives in D1 and is queryable via `GET /api/history`.
 
-## `GET /api/history`
+On `GET /public/fleet-state`, a `visibility: "private"` entry in
+`activeSweeps` has `repo`/`issue`/`sweepId` omitted entirely (not
+null-valued — `JSON.stringify` drops the key) rather than the shape above;
+`phase`/timing/`model`/`effort`/`hostId` survive unchanged. A
+`visibility: "public"` entry is identical on both routes.
+
+## `GET /api/history` / `GET /public/history`
 
 Filterable, paginated query over the D1 `records` table — one row per
-ingested telemetry record (see `migrations/0001_init.sql`).
+ingested telemetry record (see `migrations/0001_init.sql`). `/public/history`
+applies the same filter/pagination contract below; only the shape of each
+*returned record* differs (see "Redaction" below the response shape).
 
 ### Query parameters (all optional)
 
@@ -111,13 +153,23 @@ non-integer), or `cursor` (non-positive or non-integer) returns `400` with a
 - `record` is the full, verbatim JSON payload that was ingested (the same
   object the wire envelope's `record` field carried) — so any field the
   schema doc documents (`.loom/docs/telemetry-schema.md`) is available, not
-  just the columns this backend indexes.
+  just the columns this backend indexes. **On `/api/history`** this is
+  always true, for every record. **On `/public/history`**, this is true only
+  for `visibility: "public"` records; a `visibility: "private"` record has
+  `repo`/`issue`/`sweepId` nulled at the top level and `record` reduced to a
+  per-`kind` field allowlist (see `src/redaction.ts`) — e.g. a private
+  `sweep.outcome` keeps `model`/`effort`/`config`/`phase_durations`/
+  `total_duration_sec`/`result` but never `repo`/`issue`/`sweep_id`/
+  `pr_number`. `tokens.snapshot`/`host.health` records (host-level, no
+  `repo` reference) are never redacted on either route.
 
-## `GET /api/events`
+## `GET /api/events` / `GET /public/events`
 
 Server-Sent Events (`text/event-stream`) live tail of newly-ingested
 telemetry — delivers only records ingested **after** the connection opens;
-replaying prior history is `GET /api/history`'s job.
+replaying prior history is `GET /api/history`'s job. `/public/events`
+applies the same per-`kind` field allowlist `/public/history` uses (above),
+per frame, as each record is ingested.
 
 ### Query parameters (optional)
 
@@ -143,7 +195,17 @@ is parameterized by issue number and a browser cannot `addEventListener` for
 a dynamic topic): `topic` is the record's own `kind` — already exactly
 `sweep.started`/`sweep.phase`/`sweep.completed` for the three that overlap
 the frozen per-issue taxonomy — and `event` carries the multi-host extension
-(`hostId`) plus the envelope fields, verbatim.
+(`hostId`) plus the envelope fields, verbatim (`/api/events`) or redacted
+per `event.record.visibility` (`/public/events`). The same `sweep.phase`
+record above, `visibility: "private"`, arrives on `/public/events` as:
+
+```
+data: {"topic":"sweep.phase","event":{"hostId":"host-abc","emittedAt":"2026-07-30T12:03:20Z","schemaVersion":1,"record":{"kind":"sweep.phase","phase":"builder","entered_at":"2026-07-30T12:03:20Z"}}}
+
+```
+
+— `repo`/`visibility`/`issue`/`sweep_id` dropped from `event.record`, every
+other field (`hostId`, `topic`/`kind`, timing) unchanged.
 
 A connection also receives:
 
@@ -153,21 +215,29 @@ A connection also receives:
 - A `: keepalive` comment roughly every 15s when no new records have arrived,
   so intermediaries never reap an idle connection.
 
+Neither the preamble nor the keepalive comment ever carries record data, so
+`/public/events` passes both through unchanged — only `data:` frames are
+inspected for redaction.
+
 ### Delivery model
 
 Implemented as a short poll loop over D1 (default cadence ~1s) scoped to the
 stream's own lifetime, not a Durable-Object-side socket registry — see
 `src/query.ts`'s `createLiveTailStream` doc comment for why. The stream
 closes when the client disconnects (`Request.signal` aborts) or the consumer
-cancels its reader.
+cancels its reader. `/public/events` pipes the same stream through a
+`TransformStream` that redacts each `data:` frame in place before it reaches
+the client (`src/redaction.ts`'s `redactLiveTailStream`) — the underlying
+poll loop and D1 query are identical to `/api/events`.
 
 ## Not implemented here (later issues)
 
-- **Visibility-based redaction** (#4727) — this API always returns full
-  detail; #4727 wraps it with a public view that redacts/aggregates private
-  records instead of omitting the field entirely.
 - **`model`/`result` server-side filtering on the live tail** — `/api/events`
-  only supports `host`/`repo` filters today; a client wanting to filter by
-  model/result filters client-side on the streamed frames.
-- **Cloudflare Access / any authentication** on the `/api/*` routes — see the
-  "Unclassified surface" note above.
+  and `/public/events` only support `host`/`repo` filters today; a client
+  wanting to filter by model/result filters client-side on the streamed
+  frames.
+- **In-Worker Cloudflare Access JWT verification** — the `/api/*` vs
+  `/public/*` split (above) relies entirely on the Cloudflare Access edge
+  policy an operator configures per [`cloudflare-access.md`](cloudflare-access.md);
+  the Worker itself does not verify a signed Access header. See that guide's
+  §5 for the tradeoff and what a future hardening pass would add.

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -19,35 +19,47 @@
  *                                      the actual Phase 3 dashboard query
  *                                      API).
  *
- *   GET  /api/fleet-state           — Phase 3 query API: current state of
- *                                      every known host/sweep (issue #4726).
- *   GET  /api/history               — Phase 3 query API: filterable,
- *                                      paginated D1 history query (issue
- *                                      #4726).
- *   GET  /api/events                — Phase 3 query API: SSE live tail of
- *                                      newly-ingested telemetry (issue
- *                                      #4726).
+ *   GET  /api/fleet-state            — authenticated query API: current
+ *                                      state of every known host/sweep,
+ *                                      full detail regardless of visibility
+ *                                      (issue #4726 built the data access;
+ *                                      #4727 added the auth/redaction split
+ *                                      below).
+ *   GET  /api/history                — authenticated: filterable, paginated
+ *                                      D1 history query, full detail.
+ *   GET  /api/events                 — authenticated: SSE live tail of
+ *                                      newly-ingested telemetry, full
+ *                                      detail.
+ *   GET  /public/fleet-state         — public: same query, redacted —
+ *                                      private-visibility data is
+ *                                      summarized (see `./redaction.ts`).
+ *   GET  /public/history             — public: same query, redacted.
+ *   GET  /public/events              — public: same live tail, redacted.
  *
  * All `/admin/*` routes require `Authorization: Bearer <ADMIN_TOKEN>`
- * (a `wrangler secret`, never committed) — see README.md. The `/api/*`
- * routes are deliberately **not** admin-gated: they are the unclassified
- * query surface issue #4726 defines, returning full record detail.
- * Visibility-based redaction (public vs. authenticated views) is issue
- * #4727's job, as a wrapper in front of these routes — not implemented here.
+ * (a `wrangler secret`, never committed) — see README.md.
  *
- * Scope boundary (per the issue): ingest + storage, plus the query API and
- * live tail added by #4726. Cloudflare Access auth / redaction are later
- * epic phases (#4727).
+ * **`/api/*` vs `/public/*` is a route-based authentication split, not an
+ * in-Worker one** (issue #4727; full rationale in `./redaction.ts`'s module
+ * doc and `docs/cloudflare-access.md`): `/api/*` is the surface an
+ * operator's Cloudflare Access policy is expected to gate (the "everything
+ * else… Allow" rule the Access guide already documents), `/public/*` is
+ * always unauthenticated and always redacted, mirroring the `/public` path
+ * that guide already reserves as a Bypass application. Neither route
+ * verifies a JWT or any other credential in-Worker — per the epic's
+ * constraint, that verification lives entirely at the Cloudflare Access
+ * edge layer.
  */
 
 import { extractBearerToken, authenticateHost, hashIngestKey } from "./auth";
-import { FleetState } from "./fleetState";
+import { FleetState, type FleetSnapshot } from "./fleetState";
 import {
   createLiveTailStream,
   parseHistoryQuery,
   queryHistory,
   type LiveTailFilter,
 } from "./query";
+import { redactFleetSnapshot, redactHistoryQueryResult, redactLiveTailStream } from "./redaction";
 import { parseRetentionConfig, runRetentionSweep } from "./retention";
 import { validateEnvelope, extractRecordFields, type TelemetryEnvelope } from "./telemetry";
 
@@ -267,41 +279,50 @@ async function handleAdmin(request: Request, env: Env, url: URL): Promise<Respon
 }
 
 // ---------------------------------------------------------------------------
-// /api/* — Phase 3 dashboard query API (issue #4726)
+// /api/* (authenticated) + /public/* (redacted) — issues #4726 + #4727
 // ---------------------------------------------------------------------------
 
-/** `GET /api/fleet-state` — the unclassified equivalent of
- * `GET /admin/fleet-state`: same Durable Object snapshot, no admin token
- * required. This is the route the Phase 3 dashboard UI actually consumes;
- * `/admin/fleet-state` remains for operator introspection/verification. */
-async function handleFleetStateQuery(env: Env): Promise<Response> {
+/** `GET /api/fleet-state` (authenticated) / `GET /public/fleet-state`
+ * (public, redacted) — the query-API equivalent of `GET /admin/fleet-state`:
+ * same Durable Object snapshot, no admin token required. `isAuthenticated`
+ * is purely a function of which route matched (see the module doc); the
+ * response is redacted via `./redaction.ts` when it is `false`. */
+async function handleFleetStateQuery(env: Env, isAuthenticated: boolean): Promise<Response> {
   const response = await fleetStateStub(env).fetch("https://fleet-state/snapshot");
-  return new Response(response.body, { status: response.status, headers: JSON_HEADERS });
+  const snapshot = (await response.json()) as FleetSnapshot;
+  const body = isAuthenticated ? snapshot : redactFleetSnapshot(snapshot, isAuthenticated);
+  return new Response(JSON.stringify(body), { status: response.status, headers: JSON_HEADERS });
 }
 
-/** `GET /api/history` — filterable, paginated D1 history query. See
- * `query.ts`'s `parseHistoryQuery`/`queryHistory` doc comments for the full
- * filter/pagination contract. */
-async function handleHistoryQuery(env: Env, url: URL): Promise<Response> {
+/** `GET /api/history` (authenticated) / `GET /public/history` (public,
+ * redacted) — filterable, paginated D1 history query. See `query.ts`'s
+ * `parseHistoryQuery`/`queryHistory` doc comments for the full
+ * filter/pagination contract; `./redaction.ts`'s `redactHistoryQueryResult`
+ * for the redaction applied when `isAuthenticated` is `false`. */
+async function handleHistoryQuery(env: Env, url: URL, isAuthenticated: boolean): Promise<Response> {
   const filter = parseHistoryQuery(url.searchParams);
   if ("error" in filter) {
     return jsonError(400, filter.error);
   }
   const result = await queryHistory(env.DB, filter);
-  return new Response(JSON.stringify(result), { status: 200, headers: JSON_HEADERS });
+  const body = redactHistoryQueryResult(result, isAuthenticated);
+  return new Response(JSON.stringify(body), { status: 200, headers: JSON_HEADERS });
 }
 
-/** `GET /api/events` — SSE live tail of newly-ingested telemetry. See
- * `query.ts`'s `createLiveTailStream` doc comment for the framing/polling
- * contract. */
-function handleLiveTail(request: Request, env: Env, url: URL): Response {
+/** `GET /api/events` (authenticated) / `GET /public/events` (public,
+ * redacted) — SSE live tail of newly-ingested telemetry. See `query.ts`'s
+ * `createLiveTailStream` doc comment for the framing/polling contract;
+ * `./redaction.ts`'s `redactLiveTailStream` for the per-frame redaction
+ * applied when `isAuthenticated` is `false`. */
+function handleLiveTail(request: Request, env: Env, url: URL, isAuthenticated: boolean): Response {
   const filter: LiveTailFilter = {};
   const host = url.searchParams.get("host");
   if (host) filter.host = host;
   const repo = url.searchParams.get("repo");
   if (repo) filter.repo = repo;
 
-  const stream = createLiveTailStream(env.DB, filter, { signal: request.signal });
+  const rawStream = createLiveTailStream(env.DB, filter, { signal: request.signal });
+  const stream = redactLiveTailStream(rawStream, isAuthenticated);
   return new Response(stream, {
     status: 200,
     headers: {
@@ -328,16 +349,25 @@ export default {
       return handleAdmin(request, env, url);
     }
     if (request.method === "GET" && url.pathname === "/api/fleet-state") {
-      return handleFleetStateQuery(env);
+      return handleFleetStateQuery(env, /* isAuthenticated */ true);
+    }
+    if (request.method === "GET" && url.pathname === "/public/fleet-state") {
+      return handleFleetStateQuery(env, /* isAuthenticated */ false);
     }
     if (request.method === "GET" && url.pathname === "/api/history") {
-      return handleHistoryQuery(env, url);
+      return handleHistoryQuery(env, url, /* isAuthenticated */ true);
+    }
+    if (request.method === "GET" && url.pathname === "/public/history") {
+      return handleHistoryQuery(env, url, /* isAuthenticated */ false);
     }
     if (request.method === "GET" && url.pathname === "/api/events") {
-      return handleLiveTail(request, env, url);
+      return handleLiveTail(request, env, url, /* isAuthenticated */ true);
+    }
+    if (request.method === "GET" && url.pathname === "/public/events") {
+      return handleLiveTail(request, env, url, /* isAuthenticated */ false);
     }
     if (request.method === "GET" && url.pathname === "/") {
-      return new Response("loom-observability-ingest: see /ingest, /admin/*, /api/*", { status: 200 });
+      return new Response("loom-observability-ingest: see /ingest, /admin/*, /api/*, /public/*", { status: 200 });
     }
     return jsonError(404, "not found");
   },

--- a/dashboard/src/redaction.ts
+++ b/dashboard/src/redaction.ts
@@ -1,0 +1,326 @@
+/**
+ * Visibility-based response redaction — the single policy layer between the
+ * unclassified query API (`src/query.ts`, issue #4726) and any client (Epic
+ * #4702, Phase 2, issue #4727).
+ *
+ * **The single enforcement point.** Every `/api/*` (authenticated) and
+ * `/public/*` (public) route handler in `src/index.ts` calls into this
+ * module as a post-processing step over `query.ts`'s already-unclassified
+ * results — `query.ts` itself is intentionally unmodified (still returns
+ * full detail for every kind, per its own module doc) so there is exactly
+ * one place that decides what a viewer is allowed to see. Nothing else in
+ * this backend — the D1 queries, the Durable Object, the live-tail poll
+ * loop — implements any redaction of its own.
+ *
+ * ## How "authenticated" is determined
+ *
+ * Route-based split (see `docs/query-api.md` and `docs/cloudflare-access.md`
+ * for the full rationale): the existing unprefixed `/api/*` routes are the
+ * **authenticated** surface — an operator's Cloudflare Access policy is
+ * expected to gate everything except the paths `docs/cloudflare-access.md`
+ * already documents as Bypass (`/ingest`, `/public`, `/admin/*`). The new
+ * `/public/*` routes mirror `/api/*` 1:1 and are always redacted, matching
+ * the `/public` path Cloudflare Access's Bypass policy already reserves.
+ * `src/index.ts` passes a plain `isAuthenticated: boolean` into every
+ * function here based purely on *which route matched* — there is no
+ * JWT/header parsing anywhere in this Worker (the epic's explicit
+ * constraint: "no auth code in the dashboard itself"). The Worker trusts
+ * "this request reached this path" as the authentication signal, exactly as
+ * it already trusts a Custom Domain request having traversed Access at all
+ * (see `docs/cloudflare-access.md` §5 — even signature verification of the
+ * injected `Cf-Access-Jwt-Assertion` header is explicitly deferred, "not
+ * implemented today").
+ *
+ * ## Redaction policy: per-kind field allowlist, not a blocklist
+ *
+ * For a **private**-visibility record viewed **without** authentication, the
+ * policy is an **allowlist** of fields known today to be safe (counts,
+ * rates, durations, lifecycle metadata) — never a blocklist of fields known
+ * today to be unsafe. This is deliberate defense-in-depth: a blocklist only
+ * protects against leak vectors this module's author thought of; an
+ * allowlist protects against every leak vector too, including a future
+ * schema field (e.g. an issue title, once one exists on the wire) that gets
+ * added to `.loom/docs/telemetry-schema.md` without this module being
+ * updated in lockstep. An unrecognized `kind` (forward-compatible per the
+ * schema doc's `schema_version` contract) gets the most conservative
+ * allowlist of all: `kind` only.
+ *
+ * ## `tokens.snapshot` / `host.health` are host-level, not repo-level
+ *
+ * These two kinds carry no `repo`/`visibility` field at all — Phase 1's
+ * `decodeVisibility` (`src/telemetry.ts`) therefore stores them as
+ * `visibility: "private"` by its fail-safe-default rule (a **storage**
+ * classification, not a statement that their content is repo-identifying).
+ * Every field either kind defines today is host/fleet-operational detail
+ * (CPU/uptime/token-pool state) with no reference to a repository, issue,
+ * branch, or PR — the four leak vectors this issue's acceptance criteria
+ * name. Decision (flagged as open by the Curator, resolved here): these two
+ * kinds' allowlists intentionally include every field the schema defines,
+ * so they pass through unchanged for both authenticated and public viewers.
+ * This is still enforced through the same allowlist mechanism as every other
+ * kind (not a special-cased bypass), so a future field added to either kind
+ * is dropped by default until this table is deliberately updated — the
+ * fail-safe direction never flips silently.
+ */
+
+import type { RepoVisibility } from "./telemetry";
+import { decodeVisibility } from "./telemetry";
+import type { HistoryQueryResult, HistoryRecord } from "./query";
+import type { ActiveSweepState, FleetSnapshot } from "./fleetState";
+
+// ---------------------------------------------------------------------------
+// Per-kind field allowlist for the nested `record` payload
+// ---------------------------------------------------------------------------
+
+/** The nested-payload fields that survive into a public, unauthenticated
+ * response for a **private**-visibility record of this `kind`. Every field
+ * omitted here is a deliberate redaction, not an oversight — see the module
+ * doc for the allowlist-not-blocklist rationale. Keep this table in sync
+ * with `.loom/docs/telemetry-schema.md`'s "Record kinds" section: a new
+ * field on an existing kind does NOT appear in a public response until it is
+ * added here on purpose. */
+const RECORD_FIELD_ALLOWLIST: Readonly<Record<string, readonly string[]>> = {
+  "sweep.started": ["kind", "started_at", "model", "effort"],
+  "sweep.phase": ["kind", "phase", "entered_at"],
+  "sweep.completed": ["kind", "completed_at", "result"],
+  "sweep.outcome": ["kind", "model", "effort", "config", "phase_durations", "total_duration_sec", "result"],
+  // Host-level kinds: no repo/issue/branch/PR reference exists on either —
+  // see the module doc's "tokens.snapshot / host.health" section. Every
+  // field the schema defines today is listed explicitly (not "pass
+  // everything") so the allowlist mechanism stays the single source of
+  // truth even for these two kinds.
+  "tokens.snapshot": ["kind", "captured_at", "accounts"],
+  "host.health": [
+    "kind",
+    "captured_at",
+    "daemon_version",
+    "uptime_sec",
+    "logical_cpus",
+    "cpu_idle_fraction",
+    "load_per_core",
+    "worktree_root_free_gb",
+  ],
+};
+
+/** The fail-safe allowlist for a `kind` this table does not (yet) recognize
+ * — an unknown, forward-compatible record kind (per the schema doc's
+ * `schema_version` contract) reveals only its own `kind` string until this
+ * module is updated to classify it deliberately. */
+const DEFAULT_ALLOWLIST: readonly string[] = ["kind"];
+
+/** Project `payload` down to the fields `kind`'s allowlist permits. Used for
+ * every nested `record` payload this module redacts — history records, live
+ * tail SSE frames, and the Durable Object's per-host health/tokens entries
+ * alike, so there is exactly one allowlist table for the whole backend. */
+export function redactPayload(kind: string, payload: Record<string, unknown>): Record<string, unknown> {
+  const allowlist = RECORD_FIELD_ALLOWLIST[kind] ?? DEFAULT_ALLOWLIST;
+  const redacted: Record<string, unknown> = {};
+  for (const field of allowlist) {
+    if (field in payload) {
+      redacted[field] = payload[field];
+    }
+  }
+  return redacted;
+}
+
+function isPrivateAndUnauthenticated(visibility: RepoVisibility, isAuthenticated: boolean): boolean {
+  return !isAuthenticated && visibility === "private";
+}
+
+// ---------------------------------------------------------------------------
+// `GET /api/history` / `GET /public/history`
+// ---------------------------------------------------------------------------
+
+/** Redact one `HistoryRecord` for the given auth state. An authenticated
+ * viewer or a `public`-visibility record is returned unchanged (same
+ * top-level shape query.ts already produces); a private record viewed
+ * without authentication has every repo/issue/sweep-identifying field
+ * nulled and its nested `record` payload projected through
+ * `redactPayload`. */
+export function redactHistoryRecord(record: HistoryRecord, isAuthenticated: boolean): HistoryRecord {
+  if (!isPrivateAndUnauthenticated(decodeVisibility(record.visibility), isAuthenticated)) {
+    return record;
+  }
+  return {
+    id: record.id,
+    schemaVersion: record.schemaVersion,
+    emittedAt: record.emittedAt,
+    hostId: record.hostId,
+    kind: record.kind,
+    // The three leak vectors AC2 names by field: repo name, issue number,
+    // and the sweep id (which embeds the issue number, e.g.
+    // "sweep-issue-4703-0" — see `.loom/docs/telemetry-schema.md`).
+    repo: null,
+    visibility: record.visibility,
+    issue: null,
+    sweepId: null,
+    ingestedAt: record.ingestedAt,
+    record: redactPayload(record.kind, record.record),
+  };
+}
+
+/** Redact every record in a `queryHistory` result, preserving pagination
+ * metadata unchanged (the cursor is an opaque row id, not itself
+ * identifying). */
+export function redactHistoryQueryResult(
+  result: HistoryQueryResult,
+  isAuthenticated: boolean,
+): HistoryQueryResult {
+  return {
+    records: result.records.map((record) => redactHistoryRecord(record, isAuthenticated)),
+    nextCursor: result.nextCursor,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// `GET /api/fleet-state` / `GET /public/fleet-state`
+// ---------------------------------------------------------------------------
+
+/** The shape a redacted `ActiveSweepState` is returned as. `sweepId` is
+ * `string` (required) on the wire type this backend accepts internally, but
+ * a redacted private/public entry omits it entirely (not nulled) —
+ * `JSON.stringify` drops an `undefined` property, so the field is simply
+ * absent from the response rather than present-but-null. */
+export interface PublicActiveSweep {
+  hostId: string;
+  visibility: "public" | "private";
+  repo?: string;
+  issue?: number;
+  sweepId?: string;
+  phase?: string;
+  startedAt?: string;
+  enteredPhaseAt?: string;
+  model?: string;
+  effort?: string;
+  updatedAt: string;
+}
+
+/** Redact one `ActiveSweepState` (the Durable Object's live per-sweep
+ * entry). Mirrors `redactHistoryRecord`'s field selection: repo/issue/sweep
+ * id are stripped for a private, unauthenticated view; every other field
+ * (phase, timing, model/effort) is aggregate/lifecycle metadata, not
+ * repo-identifying, and survives. */
+export function redactActiveSweep(sweep: ActiveSweepState, isAuthenticated: boolean): PublicActiveSweep {
+  if (!isPrivateAndUnauthenticated(sweep.visibility, isAuthenticated)) {
+    return sweep;
+  }
+  return {
+    hostId: sweep.hostId,
+    visibility: sweep.visibility,
+    phase: sweep.phase,
+    startedAt: sweep.startedAt,
+    enteredPhaseAt: sweep.enteredPhaseAt,
+    model: sweep.model,
+    effort: sweep.effort,
+    updatedAt: sweep.updatedAt,
+  };
+}
+
+export interface RedactedFleetSnapshot {
+  hosts: FleetSnapshot["hosts"];
+  activeSweeps: PublicActiveSweep[];
+}
+
+/** Redact a full `FleetSnapshot`: every host's `health`/`tokens` entry is
+ * projected through `redactPayload` (a no-op in practice today — see the
+ * module doc — but kept on the same single mechanism as every other kind),
+ * and every `activeSweeps` entry through `redactActiveSweep`. */
+export function redactFleetSnapshot(snapshot: FleetSnapshot, isAuthenticated: boolean): RedactedFleetSnapshot {
+  const hosts: FleetSnapshot["hosts"] = {};
+  for (const [hostId, entry] of Object.entries(snapshot.hosts)) {
+    hosts[hostId] = {
+      ...(entry.health && {
+        health: { record: redactPayload("host.health", entry.health.record), updatedAt: entry.health.updatedAt },
+      }),
+      ...(entry.tokens && {
+        tokens: { record: redactPayload("tokens.snapshot", entry.tokens.record), updatedAt: entry.tokens.updatedAt },
+      }),
+    };
+  }
+  return {
+    hosts,
+    activeSweeps: snapshot.activeSweeps.map((sweep) => redactActiveSweep(sweep, isAuthenticated)),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// `GET /api/events` / `GET /public/events` — live tail SSE frames
+// ---------------------------------------------------------------------------
+
+const SSE_DATA_PREFIX = "data: ";
+const SSE_FRAME_SUFFIX = "\n\n";
+
+interface LiveTailFramePayload {
+  topic: string;
+  event: {
+    hostId: string;
+    emittedAt: string;
+    schemaVersion: number;
+    record: Record<string, unknown>;
+  };
+}
+
+/**
+ * Redact one already-framed SSE chunk from `query.ts`'s `createLiveTailStream`
+ * (`src/index.ts` pipes every stream chunk through this before it reaches
+ * the client). A non-`data:` frame (the leading `retry:`/comment preamble,
+ * or a `: keepalive` comment) carries no record and passes through
+ * unchanged. A malformed/unexpected `data:` frame also passes through
+ * unchanged rather than throwing — this function must never crash a live
+ * connection; `query.ts`'s own frames are always well-formed in practice, so
+ * this is a defensive fallback, not the primary control.
+ */
+export function redactSseFrame(frameText: string, isAuthenticated: boolean): string {
+  if (isAuthenticated || !frameText.startsWith(SSE_DATA_PREFIX) || !frameText.endsWith(SSE_FRAME_SUFFIX)) {
+    return frameText;
+  }
+
+  const jsonText = frameText.slice(SSE_DATA_PREFIX.length, -SSE_FRAME_SUFFIX.length);
+  let payload: LiveTailFramePayload;
+  try {
+    payload = JSON.parse(jsonText) as LiveTailFramePayload;
+  } catch {
+    return frameText;
+  }
+  if (!payload || typeof payload !== "object" || !payload.event || typeof payload.event !== "object") {
+    return frameText;
+  }
+
+  const visibility = decodeVisibility(payload.event.record?.visibility);
+  if (visibility === "public") return frameText;
+
+  const redacted: LiveTailFramePayload = {
+    topic: payload.topic,
+    event: {
+      hostId: payload.event.hostId,
+      emittedAt: payload.event.emittedAt,
+      schemaVersion: payload.event.schemaVersion,
+      record: redactPayload(payload.topic, payload.event.record ?? {}),
+    },
+  };
+  return `${SSE_DATA_PREFIX}${JSON.stringify(redacted)}${SSE_FRAME_SUFFIX}`;
+}
+
+/** Wrap a live-tail `ReadableStream<Uint8Array>` so every SSE frame is
+ * redacted before it reaches the client. Relies on the stream's own framing
+ * discipline (`createLiveTailStream` enqueues one complete `data: ...\n\n`
+ * — or `retry:`/`: keepalive` — string per chunk, never a partial frame or
+ * multiple frames in one chunk), which the Streams spec preserves 1:1
+ * through a `TransformStream` (no chunk coalescing on the writable→readable
+ * path). */
+export function redactLiveTailStream(
+  stream: ReadableStream<Uint8Array>,
+  isAuthenticated: boolean,
+): ReadableStream<Uint8Array> {
+  if (isAuthenticated) return stream;
+
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  const transform = new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      const frameText = decoder.decode(chunk, { stream: true });
+      controller.enqueue(encoder.encode(redactSseFrame(frameText, isAuthenticated)));
+    },
+  });
+  return stream.pipeThrough(transform);
+}

--- a/dashboard/test/redaction.test.ts
+++ b/dashboard/test/redaction.test.ts
@@ -1,0 +1,515 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import worker from "../src/index";
+import {
+  redactActiveSweep,
+  redactFleetSnapshot,
+  redactHistoryQueryResult,
+  redactHistoryRecord,
+  redactPayload,
+  redactSseFrame,
+} from "../src/redaction";
+import type { HistoryRecord } from "../src/query";
+import type { ActiveSweepState, FleetSnapshot } from "../src/fleetState";
+import {
+  hostHealthEnvelope,
+  seedHost,
+  sweepCompletedEnvelope,
+  sweepOutcomeEnvelope,
+  sweepPhaseEnvelope,
+  sweepStartedEnvelope,
+  tokensSnapshotEnvelope,
+} from "./testHelpers";
+
+// ---------------------------------------------------------------------------
+// Adversarial redaction test suite (issue #4727).
+//
+// Covers every record kind from the Phase-1 schema
+// (`.loom/docs/telemetry-schema.md`) across visibility × auth, asserting
+// field-level absence (not just "doesn't crash") of the four leak vectors
+// the acceptance criteria name: repo names, issue numbers, sweep/branch
+// identifiers, and PR links (`pr_number`).
+// ---------------------------------------------------------------------------
+
+async function callWorker(request: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(request as Request<unknown, IncomingRequestCfProperties>, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
+function ingestRequest(body: unknown, authHeader = "Bearer abc-ingest-key"): Request {
+  return new Request("https://ingest.example/ingest", {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: authHeader },
+    body: JSON.stringify(body),
+  });
+}
+
+async function ingest(envelopes: unknown[]): Promise<Response> {
+  return callWorker(ingestRequest(envelopes));
+}
+
+beforeEach(async () => {
+  await seedHost(env.DB, "host-abc", "abc-ingest-key");
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: `redactPayload` (the per-kind field allowlist), one fixture
+// per record kind the schema defines. Each fixture is private-visibility
+// (or, for the host-level kinds, has no visibility at all) with every field
+// the schema documents, plus adversarial extras (`branch`, `issue_title`)
+// that are NOT part of today's schema — the allowlist must drop unknown
+// fields by default, exactly the "future field leaks by accident" scenario
+// the module doc calls out.
+// ---------------------------------------------------------------------------
+
+describe("redactPayload — per-kind field allowlist", () => {
+  it("sweep.started: keeps lifecycle/model fields, strips repo/issue/sweep_id and any unknown field", () => {
+    const redacted = redactPayload("sweep.started", {
+      kind: "sweep.started",
+      repo: "rjwalters/loom",
+      visibility: "private",
+      issue: 4703,
+      sweep_id: "sweep-issue-4703-0",
+      started_at: "2026-07-30T12:00:00Z",
+      model: "opus",
+      effort: "high",
+      branch: "feature/issue-4703",
+      issue_title: "Fix the thing",
+    });
+    expect(redacted).toEqual({
+      kind: "sweep.started",
+      started_at: "2026-07-30T12:00:00Z",
+      model: "opus",
+      effort: "high",
+    });
+  });
+
+  it("sweep.phase: keeps phase/entered_at, strips repo/issue/sweep_id", () => {
+    const redacted = redactPayload("sweep.phase", {
+      kind: "sweep.phase",
+      repo: "rjwalters/loom",
+      visibility: "private",
+      issue: 4703,
+      sweep_id: "sweep-issue-4703-0",
+      phase: "builder",
+      entered_at: "2026-07-30T12:03:20Z",
+      branch: "feature/issue-4703",
+    });
+    expect(redacted).toEqual({ kind: "sweep.phase", phase: "builder", entered_at: "2026-07-30T12:03:20Z" });
+  });
+
+  it("sweep.completed: keeps completed_at/result, strips repo/issue/sweep_id", () => {
+    const redacted = redactPayload("sweep.completed", {
+      kind: "sweep.completed",
+      repo: "rjwalters/loom",
+      visibility: "private",
+      issue: 4703,
+      sweep_id: "sweep-issue-4703-0",
+      completed_at: "2026-07-30T12:08:32Z",
+      result: "success",
+    });
+    expect(redacted).toEqual({ kind: "sweep.completed", completed_at: "2026-07-30T12:08:32Z", result: "success" });
+  });
+
+  it("sweep.outcome: keeps model/config/phase_durations/result, strips repo/issue/sweep_id/pr_number (the PR link vector)", () => {
+    const redacted = redactPayload("sweep.outcome", {
+      kind: "sweep.outcome",
+      repo: "rjwalters/loom",
+      visibility: "private",
+      issue: 4703,
+      sweep_id: "sweep-issue-4703-0",
+      model: "opus",
+      effort: "high",
+      config: { runtime: "claude" },
+      phase_durations: [{ phase: "builder", duration_sec: 340 }],
+      total_duration_sec: 512,
+      result: "success",
+      pr_number: 4710,
+    });
+    expect(redacted).toEqual({
+      kind: "sweep.outcome",
+      model: "opus",
+      effort: "high",
+      config: { runtime: "claude" },
+      phase_durations: [{ phase: "builder", duration_sec: 340 }],
+      total_duration_sec: 512,
+      result: "success",
+    });
+    expect(redacted).not.toHaveProperty("pr_number");
+  });
+
+  it("tokens.snapshot: host-level, no repo/issue reference — passes through unchanged (documented decision)", () => {
+    const payload = {
+      kind: "tokens.snapshot",
+      captured_at: "2026-07-30T12:00:00Z",
+      accounts: [{ account: "agent-1", rank: 0, usage_fraction: 0.42, exhausted: false }],
+    };
+    expect(redactPayload("tokens.snapshot", payload)).toEqual(payload);
+  });
+
+  it("host.health: host-level, no repo/issue reference — passes through unchanged (documented decision)", () => {
+    const payload = {
+      kind: "host.health",
+      captured_at: "2026-07-30T12:00:00Z",
+      daemon_version: "0.16.0",
+      uptime_sec: 86400,
+      logical_cpus: 28,
+      cpu_idle_fraction: 0.83,
+    };
+    expect(redactPayload("host.health", payload)).toEqual(payload);
+  });
+
+  it("an unrecognized (forward-compatible) kind reveals only `kind`", () => {
+    const redacted = redactPayload("future.kind", {
+      kind: "future.kind",
+      repo: "rjwalters/loom",
+      some_new_field: "unexpected",
+    });
+    expect(redacted).toEqual({ kind: "future.kind" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: `redactHistoryRecord` / `redactHistoryQueryResult`
+// ---------------------------------------------------------------------------
+
+function historyRecordFixture(overrides: Partial<HistoryRecord> = {}): HistoryRecord {
+  return {
+    id: 1,
+    schemaVersion: 1,
+    emittedAt: "2026-07-30T12:00:00Z",
+    hostId: "host-abc",
+    kind: "sweep.started",
+    repo: "rjwalters/loom",
+    visibility: "private",
+    issue: 4703,
+    sweepId: "sweep-issue-4703-0",
+    ingestedAt: "2026-07-30T12:00:01Z",
+    record: {
+      kind: "sweep.started",
+      repo: "rjwalters/loom",
+      visibility: "private",
+      issue: 4703,
+      sweep_id: "sweep-issue-4703-0",
+      started_at: "2026-07-30T12:00:00Z",
+      model: "opus",
+    },
+    ...overrides,
+  };
+}
+
+describe("redactHistoryRecord", () => {
+  it("authenticated viewer sees full detail regardless of visibility", () => {
+    const record = historyRecordFixture();
+    expect(redactHistoryRecord(record, true)).toBe(record);
+  });
+
+  it("public-visibility record is returned unchanged even without authentication", () => {
+    const record = historyRecordFixture({ visibility: "public" });
+    expect(redactHistoryRecord(record, false)).toBe(record);
+  });
+
+  it("private + unauthenticated: repo/issue/sweepId nulled at the top level, payload allowlisted", () => {
+    const record = historyRecordFixture();
+    const redacted = redactHistoryRecord(record, false);
+    expect(redacted.repo).toBeNull();
+    expect(redacted.issue).toBeNull();
+    expect(redacted.sweepId).toBeNull();
+    expect(redacted.hostId).toBe("host-abc"); // host id is not repo-identifying
+    expect(redacted.record).toEqual({ kind: "sweep.started", started_at: "2026-07-30T12:00:00Z", model: "opus" });
+    // Adversarial: the serialized JSON must never contain the repo name,
+    // issue number, or sweep id anywhere, not just at the fields we checked.
+    const serialized = JSON.stringify(redacted);
+    expect(serialized).not.toContain("rjwalters/loom");
+    expect(serialized).not.toContain("4703");
+    expect(serialized).not.toContain("sweep-issue-4703-0");
+  });
+
+  it("a missing/invalid visibility value fails safe to private (never accidentally decodes to public)", () => {
+    const record = historyRecordFixture({ visibility: "not-a-real-value" });
+    const redacted = redactHistoryRecord(record, false);
+    expect(redacted.repo).toBeNull();
+  });
+});
+
+describe("redactHistoryQueryResult", () => {
+  it("redacts every record and preserves the pagination cursor unchanged", () => {
+    const result = redactHistoryQueryResult(
+      { records: [historyRecordFixture({ id: 1 }), historyRecordFixture({ id: 2, visibility: "public" })], nextCursor: 1 },
+      false,
+    );
+    expect(result.nextCursor).toBe(1);
+    expect(result.records[0]?.repo).toBeNull();
+    expect(result.records[1]?.repo).toBe("rjwalters/loom"); // public record untouched
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: `redactActiveSweep` / `redactFleetSnapshot`
+// ---------------------------------------------------------------------------
+
+function activeSweepFixture(overrides: Partial<ActiveSweepState> = {}): ActiveSweepState {
+  return {
+    hostId: "host-abc",
+    sweepId: "sweep-issue-4703-0",
+    repo: "rjwalters/loom",
+    visibility: "private",
+    issue: 4703,
+    phase: "builder",
+    startedAt: "2026-07-30T12:00:00Z",
+    enteredPhaseAt: "2026-07-30T12:03:20Z",
+    model: "opus",
+    effort: "high",
+    updatedAt: "2026-07-30T12:03:20Z",
+    ...overrides,
+  };
+}
+
+describe("redactActiveSweep", () => {
+  it("private + unauthenticated: sweepId/repo/issue are entirely absent (not just null)", () => {
+    const redacted = redactActiveSweep(activeSweepFixture(), false);
+    expect(redacted).not.toHaveProperty("sweepId");
+    expect(redacted).not.toHaveProperty("repo");
+    expect(redacted).not.toHaveProperty("issue");
+    expect(redacted.phase).toBe("builder");
+    expect(redacted.model).toBe("opus");
+    const serialized = JSON.stringify(redacted);
+    expect(serialized).not.toContain("rjwalters/loom");
+    expect(serialized).not.toContain("4703");
+    expect(serialized).not.toContain("sweep-issue-4703-0");
+  });
+
+  it("public visibility or authenticated: unchanged", () => {
+    const sweep = activeSweepFixture({ visibility: "public" });
+    expect(redactActiveSweep(sweep, false)).toBe(sweep);
+    const privateSweep = activeSweepFixture();
+    expect(redactActiveSweep(privateSweep, true)).toBe(privateSweep);
+  });
+});
+
+describe("redactFleetSnapshot", () => {
+  it("redacts private activeSweeps entries and leaves host health/tokens intact", () => {
+    const snapshot: FleetSnapshot = {
+      hosts: {
+        "host-abc": {
+          health: { record: { kind: "host.health", uptime_sec: 100 }, updatedAt: "2026-07-30T12:00:00Z" },
+          tokens: { record: { kind: "tokens.snapshot", accounts: [] }, updatedAt: "2026-07-30T12:00:00Z" },
+        },
+      },
+      activeSweeps: [activeSweepFixture()],
+    };
+    const redacted = redactFleetSnapshot(snapshot, false);
+    expect(redacted.hosts["host-abc"]?.health?.record).toEqual({ kind: "host.health", uptime_sec: 100 });
+    expect(redacted.activeSweeps[0]).not.toHaveProperty("sweepId");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: `redactSseFrame` (live tail)
+// ---------------------------------------------------------------------------
+
+describe("redactSseFrame", () => {
+  it("passes non-data frames through unchanged (retry/comment preamble, keepalive)", () => {
+    const preamble = "retry: 3000\n: connected to loom fleet telemetry live tail\n\n";
+    expect(redactSseFrame(preamble, false)).toBe(preamble);
+    const keepalive = ": keepalive\n\n";
+    expect(redactSseFrame(keepalive, false)).toBe(keepalive);
+  });
+
+  it("passes an authenticated frame through unchanged regardless of visibility", () => {
+    const frame = `data: ${JSON.stringify({
+      topic: "sweep.started",
+      event: {
+        hostId: "host-abc",
+        emittedAt: "2026-07-30T12:00:00Z",
+        schemaVersion: 1,
+        record: { kind: "sweep.started", repo: "rjwalters/loom", visibility: "private", sweep_id: "sweep-issue-4703-0" },
+      },
+    })}\n\n`;
+    expect(redactSseFrame(frame, true)).toBe(frame);
+  });
+
+  it("passes a public-visibility frame through unchanged", () => {
+    const frame = `data: ${JSON.stringify({
+      topic: "sweep.started",
+      event: {
+        hostId: "host-abc",
+        emittedAt: "2026-07-30T12:00:00Z",
+        schemaVersion: 1,
+        record: { kind: "sweep.started", repo: "rjwalters/loom", visibility: "public", sweep_id: "sweep-issue-4703-0" },
+      },
+    })}\n\n`;
+    expect(redactSseFrame(frame, false)).toBe(frame);
+  });
+
+  it("redacts a private-visibility frame's record payload, unauthenticated", () => {
+    const frame = `data: ${JSON.stringify({
+      topic: "sweep.started",
+      event: {
+        hostId: "host-abc",
+        emittedAt: "2026-07-30T12:00:00Z",
+        schemaVersion: 1,
+        record: {
+          kind: "sweep.started",
+          repo: "rjwalters/loom",
+          visibility: "private",
+          issue: 4703,
+          sweep_id: "sweep-issue-4703-0",
+          started_at: "2026-07-30T12:00:00Z",
+        },
+      },
+    })}\n\n`;
+    const redacted = redactSseFrame(frame, false);
+    expect(redacted).not.toContain("rjwalters/loom");
+    expect(redacted).not.toContain("4703");
+    expect(redacted).not.toContain("sweep-issue-4703-0");
+    expect(redacted).toContain("sweep.started"); // topic + kind survive
+    const parsed = JSON.parse(redacted.slice("data: ".length, -2)) as { event: { record: Record<string, unknown> } };
+    expect(parsed.event.record).toEqual({ kind: "sweep.started", started_at: "2026-07-30T12:00:00Z" });
+  });
+
+  it("never throws on a malformed data frame — passes it through unchanged", () => {
+    const malformed = "data: {not valid json\n\n";
+    expect(redactSseFrame(malformed, false)).toBe(malformed);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: the actual `/api/*` vs `/public/*` routes end to end,
+// covering every record kind × private visibility, plus a spot-check that
+// public-visibility data is NOT over-redacted on the public route.
+// ---------------------------------------------------------------------------
+
+const PRIVATE_ENVELOPE_BUILDERS: [string, () => Record<string, unknown>][] = [
+  ["sweep.started", () => sweepStartedEnvelope({ visibility: "private" })],
+  ["sweep.phase", () => sweepPhaseEnvelope({ visibility: "private" })],
+  ["sweep.completed", () => sweepCompletedEnvelope({ visibility: "private" })],
+  ["sweep.outcome", () => sweepOutcomeEnvelope({ visibility: "private" })],
+];
+
+describe("GET /public/history vs GET /api/history — end-to-end redaction", () => {
+  for (const [kind, buildEnvelope] of PRIVATE_ENVELOPE_BUILDERS) {
+    it(`${kind}: the public route never leaks repo/issue/sweep_id/pr_number; the authenticated route does`, async () => {
+      await ingest([buildEnvelope()]);
+
+      const publicResponse = await callWorker(new Request("https://ingest.example/public/history"));
+      const publicText = await publicResponse.text();
+      expect(publicText).not.toContain("rjwalters/loom");
+      expect(publicText).not.toContain("4703");
+      expect(publicText).not.toContain("sweep-issue-4703-0");
+      if (kind === "sweep.outcome") {
+        expect(publicText).not.toContain("4710"); // pr_number
+      }
+
+      const authResponse = await callWorker(new Request("https://ingest.example/api/history"));
+      const authText = await authResponse.text();
+      expect(authText).toContain("rjwalters/loom");
+      expect(authText).toContain("sweep-issue-4703-0");
+    });
+  }
+
+  it("tokens.snapshot and host.health (host-level, no repo/visibility) pass through unredacted on the public route", async () => {
+    await ingest([tokensSnapshotEnvelope(), hostHealthEnvelope()]);
+
+    const publicResponse = await callWorker(new Request("https://ingest.example/public/history"));
+    const body = (await publicResponse.json()) as {
+      records: { kind: string; record: Record<string, unknown> }[];
+    };
+    const tokensRecord = body.records.find((r) => r.kind === "tokens.snapshot");
+    const healthRecord = body.records.find((r) => r.kind === "host.health");
+    expect(tokensRecord?.record).toMatchObject({ accounts: [{ account: "agent-1" }] });
+    expect(healthRecord?.record).toMatchObject({ daemon_version: "0.16.0", uptime_sec: 100 });
+  });
+
+  it("a public-visibility record is returned in full on the public route (no over-redaction)", async () => {
+    await ingest([sweepStartedEnvelope({ visibility: "public" })]);
+
+    const publicResponse = await callWorker(new Request("https://ingest.example/public/history"));
+    const publicText = await publicResponse.text();
+    expect(publicText).toContain("rjwalters/loom");
+    expect(publicText).toContain("sweep-issue-4703-0");
+  });
+
+  it("an adversarial future field on a private record never survives to the public route", async () => {
+    await ingest([
+      sweepStartedEnvelope({
+        visibility: "private",
+        branch: "feature/issue-4703",
+        issue_title: "Fix the private thing",
+      }),
+    ]);
+
+    const publicResponse = await callWorker(new Request("https://ingest.example/public/history"));
+    const publicText = await publicResponse.text();
+    expect(publicText).not.toContain("feature/issue-4703");
+    expect(publicText).not.toContain("Fix the private thing");
+  });
+});
+
+describe("GET /public/fleet-state vs GET /api/fleet-state — end-to-end redaction", () => {
+  it("a private in-flight sweep's repo/issue/sweepId never appear on the public route", async () => {
+    await ingest([sweepStartedEnvelope({ visibility: "private" })]);
+
+    const publicResponse = await callWorker(new Request("https://ingest.example/public/fleet-state"));
+    const publicBody = (await publicResponse.json()) as { activeSweeps: { hostId: string; phase?: string }[] };
+    const publicText = JSON.stringify(publicBody);
+    expect(publicText).not.toContain("rjwalters/loom");
+    expect(publicText).not.toContain("sweep-issue-4703-0");
+    expect(publicBody.activeSweeps).toHaveLength(1);
+    expect(publicBody.activeSweeps[0]?.hostId).toBe("host-abc");
+
+    const authResponse = await callWorker(new Request("https://ingest.example/api/fleet-state"));
+    const authText = await authResponse.text();
+    expect(authText).toContain("rjwalters/loom");
+    expect(authText).toContain("sweep-issue-4703-0");
+  });
+});
+
+describe("GET /public/events vs GET /api/events — live tail redaction", () => {
+  it("a private record's live-tail frame is redacted on the public route", async () => {
+    const response = await callWorker(new Request("https://ingest.example/public/events"));
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("expected a readable stream body");
+    const decoder = new TextDecoder();
+    let buffer = "";
+    buffer += decoder.decode((await reader.read()).value);
+
+    await ingest([sweepStartedEnvelope({ visibility: "private", sweep_id: "sweep-live-private" })]);
+
+    const deadline = Date.now() + 8_000;
+    while (!buffer.includes("sweep.started") && Date.now() < deadline) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      if (chunk.value) buffer += decoder.decode(chunk.value);
+    }
+
+    expect(buffer).toContain("sweep.started");
+    expect(buffer).not.toContain("rjwalters/loom");
+    expect(buffer).not.toContain("sweep-live-private");
+    await reader.cancel();
+  }, 15_000);
+
+  it("a public record's live-tail frame is delivered unredacted on the public route", async () => {
+    const response = await callWorker(new Request("https://ingest.example/public/events"));
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("expected a readable stream body");
+    const decoder = new TextDecoder();
+    let buffer = "";
+    buffer += decoder.decode((await reader.read()).value);
+
+    await ingest([sweepStartedEnvelope({ visibility: "public", sweep_id: "sweep-live-public" })]);
+
+    const deadline = Date.now() + 8_000;
+    while (!buffer.includes("sweep-live-public") && Date.now() < deadline) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      if (chunk.value) buffer += decoder.decode(chunk.value);
+    }
+
+    expect(buffer).toContain("rjwalters/loom");
+    expect(buffer).toContain("sweep-live-public");
+    await reader.cancel();
+  }, 15_000);
+});

--- a/dashboard/test/testHelpers.ts
+++ b/dashboard/test/testHelpers.ts
@@ -48,3 +48,81 @@ export function hostHealthEnvelope(overrides: Partial<Record<string, unknown>> =
     },
   };
 }
+
+/** Build a minimal, valid `sweep.phase` envelope for a batch fixture. */
+export function sweepPhaseEnvelope(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    emitted_at: "2026-07-30T12:03:20Z",
+    host_id: "host-abc",
+    record: {
+      kind: "sweep.phase",
+      repo: "rjwalters/loom",
+      visibility: "public",
+      issue: 4703,
+      sweep_id: "sweep-issue-4703-0",
+      phase: "builder",
+      entered_at: "2026-07-30T12:03:20Z",
+      ...overrides,
+    },
+  };
+}
+
+/** Build a minimal, valid `sweep.completed` envelope for a batch fixture. */
+export function sweepCompletedEnvelope(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    emitted_at: "2026-07-30T12:08:32Z",
+    host_id: "host-abc",
+    record: {
+      kind: "sweep.completed",
+      repo: "rjwalters/loom",
+      visibility: "public",
+      issue: 4703,
+      sweep_id: "sweep-issue-4703-0",
+      completed_at: "2026-07-30T12:08:32Z",
+      result: "success",
+      ...overrides,
+    },
+  };
+}
+
+/** Build a minimal, valid `sweep.outcome` envelope for a batch fixture. */
+export function sweepOutcomeEnvelope(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    emitted_at: "2026-07-30T12:08:32Z",
+    host_id: "host-abc",
+    record: {
+      kind: "sweep.outcome",
+      repo: "rjwalters/loom",
+      visibility: "public",
+      issue: 4703,
+      sweep_id: "sweep-issue-4703-0",
+      model: "opus",
+      effort: "high",
+      config: { runtime: "claude" },
+      phase_durations: [{ phase: "builder", duration_sec: 340 }],
+      total_duration_sec: 512,
+      result: "success",
+      pr_number: 4710,
+      ...overrides,
+    },
+  };
+}
+
+/** Build a minimal, valid `tokens.snapshot` envelope for a batch fixture
+ * (host-level — no `repo`/`visibility`). */
+export function tokensSnapshotEnvelope(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    emitted_at: "2026-07-30T12:00:00Z",
+    host_id: "host-abc",
+    record: {
+      kind: "tokens.snapshot",
+      captured_at: "2026-07-30T12:00:00Z",
+      accounts: [{ account: "agent-1", rank: 0, usage_fraction: 0.42, exhausted: false }],
+      ...overrides,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Implements the server-side visibility-classification/redaction policy layer that sits in front of the query API (#4726), per the epic's (#4702) explicitly-called-out risk mitigation ("Private-data leakage via the public view").

- **New `dashboard/src/redaction.ts`** — the single enforcement point. A per-record-`kind` **field allowlist** (not a blocklist) decides what survives into a private + unauthenticated response: lifecycle/timing/model/rate fields only, never `repo`/`issue`/`sweep_id`/`pr_number`. An unrecognized (forward-compatible) `kind` reveals only its own `kind` string. `tokens.snapshot`/`host.health` (host-level, no repo reference) pass through unredacted on both surfaces — a documented decision, not an oversight.
- **Auth split, route-based, no in-Worker auth code** (per the epic's constraint): every `/api/*` route now has a `/public/*` mirror (`GET /public/fleet-state`, `GET /public/history`, `GET /public/events`). `/api/*` is the surface an operator's Cloudflare Access policy is expected to gate (matches the "everything else → Allow" rule `docs/cloudflare-access.md` already documents); `/public/*` is always reachable and always redacted, mirroring the `/public` path that guide already reserves as a Bypass application. `src/index.ts` sets `isAuthenticated` purely from which path matched — no JWT/header parsing anywhere in the Worker.
- **`src/query.ts` is unmodified** — it stays the "unclassified" data-access layer; redaction is a post-processing wrapper in `src/index.ts`'s handlers, exactly per the issue's scope boundary.
- **Adversarial redaction test suite** (`dashboard/test/redaction.test.ts`, 30 new tests): unit tests for every record kind's allowlist (including a synthetic future-field/branch-name adversarial case), plus end-to-end `/api/*` vs `/public/*` tests (history, fleet-state, live tail) asserting field-level absence of repo names, issue numbers, sweep ids, and PR links.
- **Docs**: `dashboard/docs/query-api.md` documents the `/api/*` vs `/public/*` split and the exact per-route/per-kind redaction shape (replacing the "not yet implemented" caveats); `dashboard/README.md`'s routes table and design-decisions section updated.

## Design decision (flagged by the Curator for this issue)

Chose **route-based split** over header-presence checking: `/public/*` mirrors the `/public` path prefix `docs/cloudflare-access.md` (merged in #4747) already reserves as a Cloudflare Access Bypass application for the Phase-3 public page, so this lands without contradicting already-shipped deploy docs. Full rationale is in `src/redaction.ts`'s module doc and `docs/query-api.md`.

## Test plan

```bash
cd dashboard
npm run check   # tsc --noEmit + vitest run (Miniflare, real Workers runtime) — 83 passed
```

Closes #4727