### PR TITLE
fix(champion): replace gh --jq --arg with jq-piped filter in idempotency guard

### DIFF
--- a/defaults/.claude/commands/loom/champion-pr-merge.md
+++ b/defaults/.claude/commands/loom/champion-pr-merge.md
@@ -1188,9 +1188,9 @@ REASON="<SPECIFIC_REASON>"  # exact reason text that will go in the comment body
 # Skip re-commenting only when the reason is unchanged — a PR that still fails
 # the same criterion but for a *different* specific reason (e.g. CI now fails a
 # different check) still gets a fresh comment.
-LAST_COMMENT=$(gh pr view "$PR_NUMBER" --json comments \
-  --jq --arg marker "$REJECT_MARKER" \
-  '[.comments[] | select(.body | contains($marker))] | last | .body // ""')
+LAST_COMMENT=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments' \
+  | jq --arg marker "$REJECT_MARKER" \
+  '[.[] | select(.body | contains($marker))] | last | .body // ""')
 
 if [ -n "$LAST_COMMENT" ] && echo "$LAST_COMMENT" | grep -qF "$REASON"; then
   echo "Rejection reason for $CRITERION_KEY unchanged since last comment on #$PR_NUMBER — skipping duplicate comment"


### PR DESCRIPTION
## Summary
The transient-failure idempotency guard in `champion-pr-merge.md` used `gh pr view ... --json comments --jq --arg marker "$REJECT_MARKER" '...'`. `gh`'s built-in `--jq`/`-q` flag only accepts a single filter argument — it does not support jq's `--arg` option. Because the command ran inside `$(...)`, the failure (`accepts at most 1 arg(s), received 4`) was silently swallowed and `LAST_COMMENT` was always empty, so the "reason unchanged, skip duplicate comment" branch never triggered — Champion re-posted the rejection comment on every tick for a PR stuck on a static failing criterion. This is a regression of #4586.

## Changes
- `defaults/.claude/commands/loom/champion-pr-merge.md`: replaced the broken `gh --jq --arg` invocation with `gh pr view ... --json comments --jq '.comments' | jq --arg marker "$REJECT_MARKER" '...'` — `gh`'s `--jq` now takes only the plain `.comments` filter (no `--arg`), and the `--arg` binding happens in the piped, standalone `jq` binary where it's actually supported.
- No other occurrences of the `gh ... --jq --arg` anti-pattern were found in `champion-pr-merge.md` or `champion-reference.md` (defaults source; the installed `.claude/commands/loom/` copies are untracked/dogfood-linked in this repo, so no separate resync commit is needed here — see `chore: resync installed Loom surfaces` history).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `gh pr view ... --jq --arg ...` pattern removed from `defaults/.claude/commands/loom/champion-pr-merge.md` (installed copy re-synced) | ✅ | Only occurrence fixed in `defaults/`; the installed `.claude/commands/loom/` tree in this repo is gitignored/dogfood-linked (not a tracked copy to hand-sync — confirmed via `git check-ignore -v` and `.gitignore` comment at line ~134) |
| Replacement verified to actually suppress a duplicate comment logic | ✅ | Bench-tested the exact filter against real `gh pr view --json comments --jq '.comments'` output piped into `jq --arg marker ... '[.[] | select(.body | contains($marker))] | last | .body // ""'` — correctly returns the matching comment body (or `""` when absent), exit code 0. Also reproduced the original bug (`gh pr view ... --jq --arg marker ...` → `accepts at most 1 arg(s), received 4`, exit 1) to confirm root cause. |
| Grepped `champion-pr-merge.md` and `champion-reference.md` (defaults + installed) for the same anti-pattern | ✅ | `grep -n -- "--jq"` across both files; only the one now-fixed occurrence used `--arg`. `champion-reference.md` has no `--jq --arg` occurrences. The installed copies mirror `defaults/` via the repo's own dogfood-commands linkage, not tracked git content. |

## Test Plan
- Ran the fixed filter (`gh pr view <real PR> --json comments --jq '.comments' | jq --arg marker ... '...'`) against a live PR in this repo — exits 0, returns the expected `""` for an absent marker.
- Reproduced the original broken invocation against the same PR to confirm the exact `accepts at most 1 arg(s), received 4` failure described in the issue.
- Constructed a synthetic multi-comment JSON fixture and confirmed the fixed filter correctly picks the *last* matching comment by marker.

Closes #4754