### PR TITLE
feat(dashboard): add live event feed + per-sweep timeline view

### DIFF
--- a/dashboard/web/README.md
+++ b/dashboard/web/README.md
@@ -1,0 +1,41 @@
+# loom-fleet-dashboard-web
+
+Frontend for the Loom fleet observability dashboard
+([Epic #4702](https://github.com/rjwalters/loom/issues/4702), Phase 3):
+a live event feed panel and a per-sweep timeline view over the Phase 2
+query API (`dashboard/src/query.ts`, documented in
+[`../docs/query-api.md`](../docs/query-api.md)).
+
+This is a minimal, self-contained scaffold — plain TypeScript, no UI
+framework — sufficient to implement and test the two Phase 3 components
+described in issue #4750. It is expected to be merged/rebased against
+whatever scaffold the sibling Fleet-overview issue (#4749) introduces for
+`dashboard/web/`; the logic modules here (`sseFeedClient.ts`,
+`timelineBuilder.ts`) are framework-independent and the two view modules
+(`liveFeedPanel.ts`, `sweepTimelineView.ts`) use plain DOM APIs so they can
+be adapted into whatever component model #4749 lands with.
+
+## Modules
+
+- `src/sseFeedClient.ts` — `SseStreamParser` (incremental SSE frame
+  parsing: `retry:` directives, `:`-comments, `data:` frames) and
+  `LiveFeedClient` (reconnecting client for `GET /api/events`: honors the
+  `retry: 3000` preamble, ignores `: keepalive` comments, dedups frames
+  across reconnects).
+- `src/timelineBuilder.ts` — `SweepTimelineBuilder` / `buildSweepTimeline`:
+  aggregates `sweep.phase` (+ `sweep.started` / `sweep.completed` /
+  `sweep.outcome`) records for one `sweep_id` into a phase-progression
+  timeline with computed per-phase durations.
+- `src/liveFeedPanel.ts` — `LiveFeedPanel`: renders the live feed, with
+  client-side `model`/`result` filtering (the live-tail endpoint only
+  supports `host`/`repo` server-side).
+- `src/sweepTimelineView.ts` — `SweepTimelineView`: renders one sweep's
+  timeline, including the terminal `result` and PR link derived from
+  `sweep.outcome`'s `pr_number`.
+
+## Development
+
+```bash
+npm install
+npm run check   # typecheck + vitest run
+```

--- a/dashboard/web/package-lock.json
+++ b/dashboard/web/package-lock.json
@@ -1,0 +1,2433 @@
+{
+  "name": "loom-fleet-dashboard-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "loom-fleet-dashboard-web",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "jsdom": "^25.0.1",
+        "typescript": "^5.7.2",
+        "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
+      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.3",
+        "@rollup/rollup-android-arm64": "4.62.3",
+        "@rollup/rollup-darwin-arm64": "4.62.3",
+        "@rollup/rollup-darwin-x64": "4.62.3",
+        "@rollup/rollup-freebsd-arm64": "4.62.3",
+        "@rollup/rollup-freebsd-x64": "4.62.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
+        "@rollup/rollup-linux-arm64-musl": "4.62.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
+        "@rollup/rollup-linux-loong64-musl": "4.62.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-musl": "4.62.3",
+        "@rollup/rollup-openbsd-x64": "4.62.3",
+        "@rollup/rollup-openharmony-arm64": "4.62.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
+        "@rollup/rollup-win32-x64-gnu": "4.62.3",
+        "@rollup/rollup-win32-x64-msvc": "4.62.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/dashboard/web/package.json
+++ b/dashboard/web/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "loom-fleet-dashboard-web",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Frontend for the Loom fleet observability dashboard (Epic #4702, Phase 3): live event feed + per-sweep timeline view over the Phase 2 query API (dashboard/src/query.ts).",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "check": "npm run typecheck && npm run test"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "jsdom": "^25.0.1",
+    "typescript": "^5.7.2",
+    "vitest": "^3.2.4"
+  }
+}

--- a/dashboard/web/src/index.ts
+++ b/dashboard/web/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./types.js";
+export * from "./sseFeedClient.js";
+export * from "./timelineBuilder.js";
+export * from "./liveFeedPanel.js";
+export * from "./sweepTimelineView.js";

--- a/dashboard/web/src/liveFeedPanel.ts
+++ b/dashboard/web/src/liveFeedPanel.ts
@@ -1,0 +1,97 @@
+/**
+ * Live event feed panel (issue #4750). A thin, framework-agnostic DOM
+ * renderer over `LiveFeedClient` — deliberately built with plain DOM APIs
+ * (no framework dependency yet) so it can be dropped into whatever
+ * scaffold the sibling Fleet-overview issue (#4749) lands with.
+ */
+
+import type { LiveTailFrame } from "./types.js";
+import { LiveFeedClient, type LiveFeedClientOptions } from "./sseFeedClient.js";
+
+/** Client-side filter over a frame's `record` — server doesn't filter model/result on the live tail. */
+export interface LiveFeedFilter {
+  model?: string;
+  result?: string;
+}
+
+function matchesFilter(frame: LiveTailFrame, filter: LiveFeedFilter): boolean {
+  const record = frame.event.record as Record<string, unknown>;
+  if (filter.model && record.model !== filter.model) return false;
+  if (filter.result && record.result !== filter.result) return false;
+  return true;
+}
+
+export function renderLiveFeedRow(frame: LiveTailFrame): HTMLLIElement {
+  const row = document.createElement("li");
+  row.className = "live-feed-row";
+  row.dataset.topic = frame.topic;
+
+  const time = document.createElement("span");
+  time.className = "live-feed-row__time";
+  time.textContent = frame.event.emittedAt;
+
+  const host = document.createElement("span");
+  host.className = "live-feed-row__host";
+  host.textContent = frame.event.hostId;
+
+  const topic = document.createElement("span");
+  topic.className = "live-feed-row__topic";
+  topic.textContent = frame.topic;
+
+  row.append(time, host, topic);
+  return row;
+}
+
+export interface LiveFeedPanelOptions extends Omit<LiveFeedClientOptions, "onEvent"> {
+  container: HTMLElement;
+  maxRows?: number;
+  filter?: LiveFeedFilter;
+}
+
+/**
+ * Owns a `LiveFeedClient` and renders each accepted frame as a row,
+ * newest-first, capped at `maxRows`. Filtering is client-side only — the
+ * live-tail endpoint only supports `host`/`repo` server-side (see
+ * `dashboard/docs/query-api.md`'s "Not implemented here" section).
+ */
+export class LiveFeedPanel {
+  private readonly container: HTMLElement;
+  private readonly maxRows: number;
+  private readonly client: LiveFeedClient;
+  private filter: LiveFeedFilter;
+
+  constructor(options: LiveFeedPanelOptions) {
+    this.container = options.container;
+    this.maxRows = options.maxRows ?? 200;
+    this.filter = options.filter ?? {};
+
+    const { container: _container, maxRows: _maxRows, filter: _filter, ...clientOptions } = options;
+    this.client = new LiveFeedClient({
+      ...clientOptions,
+      onEvent: (frame) => this.handleEvent(frame),
+    });
+  }
+
+  start(): void {
+    this.client.start();
+  }
+
+  stop(): void {
+    this.client.stop();
+  }
+
+  setFilter(filter: LiveFeedFilter): void {
+    this.filter = filter;
+  }
+
+  private handleEvent(frame: LiveTailFrame): void {
+    if (!matchesFilter(frame, this.filter)) return;
+
+    const row = renderLiveFeedRow(frame);
+    this.container.insertBefore(row, this.container.firstChild);
+
+    while (this.container.childElementCount > this.maxRows) {
+      this.container.lastElementChild?.remove();
+    }
+  }
+}

--- a/dashboard/web/src/sseFeedClient.ts
+++ b/dashboard/web/src/sseFeedClient.ts
@@ -1,0 +1,257 @@
+/**
+ * SSE frame parsing + reconnecting client for the live event feed
+ * (`GET /api/events`, see `dashboard/docs/query-api.md`).
+ *
+ * Two layers, deliberately separated so the wire-level parsing is testable
+ * without any network/stream plumbing:
+ *
+ * - `SseStreamParser` — a pure, incremental parser: feed it raw text chunks
+ *   (as they arrive from a `ReadableStream`), get back structured
+ *   `SseFrame`s (`retry` / `comment` / `data`). Handles partial frames split
+ *   across chunk boundaries.
+ * - `LiveFeedClient` — owns the reconnect loop (honoring the server's
+ *   `retry: 3000` preamble), skips `: keepalive` comments, and dedups
+ *   `data:` frames across reconnects so a browser tab never renders the same
+ *   telemetry record twice.
+ */
+
+import type { LiveTailFrame } from "./types.js";
+
+export type SseFrame =
+  | { type: "retry"; retryMs: number }
+  | { type: "comment"; text: string }
+  | { type: "data"; payload: string };
+
+/**
+ * Splits one blank-line-terminated SSE block into zero or more frames.
+ * Unknown fields (`event:`, `id:`, ...) are ignored — this API's frames
+ * only ever use `data:`, `retry:`, and bare comment lines (`:...`).
+ */
+function parseBlock(block: string): SseFrame[] {
+  const frames: SseFrame[] = [];
+  const dataLines: string[] = [];
+
+  for (const rawLine of block.split("\n")) {
+    if (rawLine === "") continue;
+
+    if (rawLine.startsWith(":")) {
+      frames.push({ type: "comment", text: rawLine.slice(1).trimStart() });
+      continue;
+    }
+
+    const colonIdx = rawLine.indexOf(":");
+    const field = colonIdx === -1 ? rawLine : rawLine.slice(0, colonIdx);
+    let value = colonIdx === -1 ? "" : rawLine.slice(colonIdx + 1);
+    if (value.startsWith(" ")) value = value.slice(1);
+
+    if (field === "retry") {
+      const ms = Number.parseInt(value, 10);
+      if (!Number.isNaN(ms)) frames.push({ type: "retry", retryMs: ms });
+    } else if (field === "data") {
+      dataLines.push(value);
+    }
+    // event:/id:/anything else: not used by this API, ignored.
+  }
+
+  if (dataLines.length > 0) {
+    frames.push({ type: "data", payload: dataLines.join("\n") });
+  }
+
+  return frames;
+}
+
+/**
+ * Incremental SSE parser. Feed it text chunks in arrival order; it buffers
+ * any trailing partial block (split across `read()` boundaries) until the
+ * terminating blank line arrives.
+ */
+export class SseStreamParser {
+  private buffer = "";
+
+  /** Parse a newly-arrived chunk, returning any complete frames it produced. */
+  feed(chunk: string): SseFrame[] {
+    // Normalize CRLF up front so a chunk boundary landing inside a "\r\n"
+    // pair is handled correctly (normalization runs over the full buffer,
+    // not just the new chunk).
+    this.buffer = (this.buffer + chunk).replace(/\r\n/g, "\n");
+
+    const frames: SseFrame[] = [];
+    let sepIndex: number;
+    while ((sepIndex = this.buffer.indexOf("\n\n")) !== -1) {
+      const block = this.buffer.slice(0, sepIndex);
+      this.buffer = this.buffer.slice(sepIndex + 2);
+      frames.push(...parseBlock(block));
+    }
+    return frames;
+  }
+}
+
+/** Stable identity for a live-tail frame, used for reconnect-safe dedup. */
+export function frameKey(frame: LiveTailFrame): string {
+  const record = frame.event.record as Record<string, unknown>;
+  const sweepId = typeof record.sweep_id === "string" ? record.sweep_id : "";
+  return `${frame.event.hostId}|${frame.event.emittedAt}|${frame.topic}|${sweepId}`;
+}
+
+export type ConnectionState = "connecting" | "open" | "closed";
+
+export interface LiveFeedClientOptions {
+  /** Base URL for the live tail endpoint, e.g. "/api/events" or a full origin. */
+  url: string;
+  /** Scope the stream to a single host (matches the API's `host` param). */
+  host?: string;
+  /** Scope the stream to a single repo (matches the API's `repo` param). */
+  repo?: string;
+  onEvent: (frame: LiveTailFrame) => void;
+  onConnectionChange?: (state: ConnectionState) => void;
+  onParseError?: (payload: string, error: unknown) => void;
+  /** Reconnect delay used before any `retry:` directive has been seen. */
+  defaultRetryMs?: number;
+  /** How many recently-seen frame keys to retain for cross-reconnect dedup. */
+  dedupWindow?: number;
+  /**
+   * Opens a connection and returns a byte reader. Defaults to
+   * `fetch(url).body.getReader()`; injectable for tests and for
+   * environments without a global `fetch`.
+   */
+  connect?: (url: string, signal: AbortSignal) => Promise<ReadableStreamDefaultReader<Uint8Array>>;
+  /** Injectable sleep, so tests don't wait on real reconnect timers. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+function buildUrl(base: string, host: string | undefined, repo: string | undefined): string {
+  const [path, existingQuery] = base.split("?", 2);
+  const params = new URLSearchParams(existingQuery ?? "");
+  if (host) params.set("host", host);
+  if (repo) params.set("repo", repo);
+  const query = params.toString();
+  return query ? `${path}?${query}` : path!;
+}
+
+async function defaultConnect(
+  url: string,
+  signal: AbortSignal,
+): Promise<ReadableStreamDefaultReader<Uint8Array>> {
+  const response = await fetch(url, { signal, headers: { accept: "text/event-stream" } });
+  if (!response.ok || !response.body) {
+    throw new Error(`live feed connect failed: ${response.status}`);
+  }
+  return response.body.getReader();
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Reconnecting SSE client for `GET /api/events`. Call `start()` once; it
+ * runs its own connect/read/reconnect loop until `stop()` is called.
+ */
+export class LiveFeedClient {
+  private readonly options: Required<
+    Pick<LiveFeedClientOptions, "url" | "onEvent" | "defaultRetryMs" | "dedupWindow" | "connect" | "sleep">
+  > &
+    LiveFeedClientOptions;
+  private stopped = true;
+  private abortController: AbortController | null = null;
+  private retryMs: number;
+  private readonly seenKeys = new Set<string>();
+  private readonly seenOrder: string[] = [];
+  private runPromise: Promise<void> | null = null;
+
+  constructor(options: LiveFeedClientOptions) {
+    this.options = {
+      defaultRetryMs: 3000,
+      dedupWindow: 500,
+      connect: defaultConnect,
+      sleep: defaultSleep,
+      ...options,
+    };
+    this.retryMs = this.options.defaultRetryMs;
+  }
+
+  start(): void {
+    if (!this.stopped) return;
+    this.stopped = false;
+    this.runPromise = this.runLoop();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.abortController?.abort();
+    this.options.onConnectionChange?.("closed");
+  }
+
+  /** Awaits the current run loop — mainly for tests to know a cycle settled. */
+  async whenIdle(): Promise<void> {
+    await this.runPromise;
+  }
+
+  private rememberKey(key: string): boolean {
+    if (this.seenKeys.has(key)) return false;
+    this.seenKeys.add(key);
+    this.seenOrder.push(key);
+    if (this.seenOrder.length > this.options.dedupWindow) {
+      const evicted = this.seenOrder.shift();
+      if (evicted !== undefined) this.seenKeys.delete(evicted);
+    }
+    return true;
+  }
+
+  private async runLoop(): Promise<void> {
+    const url = buildUrl(this.options.url, this.options.host, this.options.repo);
+
+    while (!this.stopped) {
+      this.options.onConnectionChange?.("connecting");
+      this.abortController = new AbortController();
+      const parser = new SseStreamParser();
+      const decoder = new TextDecoder();
+
+      try {
+        const reader = await this.options.connect(url, this.abortController.signal);
+        this.options.onConnectionChange?.("open");
+
+        while (!this.stopped) {
+          const { value, done } = await reader.read();
+          if (done) break;
+
+          const chunk = typeof value === "string" ? value : decoder.decode(value, { stream: true });
+          for (const frame of parser.feed(chunk)) {
+            this.handleFrame(frame);
+          }
+        }
+      } catch (err) {
+        if (this.stopped) break;
+        // Connection error — fall through to the reconnect delay below.
+        void err;
+      }
+
+      if (this.stopped) break;
+      this.options.onConnectionChange?.("closed");
+      await this.options.sleep(this.retryMs);
+    }
+  }
+
+  private handleFrame(frame: SseFrame): void {
+    if (frame.type === "retry") {
+      this.retryMs = frame.retryMs;
+      return;
+    }
+    if (frame.type === "comment") {
+      // Includes `: keepalive` and the connect preamble — never data.
+      return;
+    }
+
+    // frame.type === "data"
+    let parsed: LiveTailFrame;
+    try {
+      parsed = JSON.parse(frame.payload) as LiveTailFrame;
+    } catch (err) {
+      this.options.onParseError?.(frame.payload, err);
+      return;
+    }
+
+    const key = frameKey(parsed);
+    if (!this.rememberKey(key)) return; // duplicate across a reconnect — drop it
+    this.options.onEvent(parsed);
+  }
+}

--- a/dashboard/web/src/sweepTimelineView.ts
+++ b/dashboard/web/src/sweepTimelineView.ts
@@ -1,0 +1,105 @@
+/**
+ * Per-sweep timeline view (issue #4750): renders the phase progression
+ * (`curator` -> `builder` -> `judge` -> `doctor` -> `merge`) computed by
+ * `SweepTimelineBuilder`, plus the terminal result / PR link once the sweep
+ * completes. Framework-agnostic, plain-DOM rendering, matching
+ * `liveFeedPanel.ts`.
+ */
+
+import type { SweepTimeline, TimelinePhaseEntry } from "./timelineBuilder.js";
+import { SweepTimelineBuilder } from "./timelineBuilder.js";
+import type { TelemetryRecord } from "./types.js";
+
+function formatDuration(durationSec: number | undefined): string {
+  if (durationSec === undefined) return "…";
+  const total = Math.round(durationSec);
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
+}
+
+export function renderTimelinePhaseRow(entry: TimelinePhaseEntry): HTMLLIElement {
+  const row = document.createElement("li");
+  row.className = "sweep-timeline__phase";
+  row.dataset.phase = entry.phase;
+  if (entry.ongoing) row.classList.add("sweep-timeline__phase--ongoing");
+
+  const name = document.createElement("span");
+  name.className = "sweep-timeline__phase-name";
+  name.textContent = entry.phase;
+
+  const duration = document.createElement("span");
+  duration.className = "sweep-timeline__phase-duration";
+  duration.textContent = entry.ongoing ? "in progress" : formatDuration(entry.durationSec);
+
+  row.append(name, duration);
+  return row;
+}
+
+/** PR URL derived from `sweep.outcome`'s `pr_number`, when known. */
+export function prLinkFor(timeline: SweepTimeline, repo?: string): string | undefined {
+  if (timeline.prNumber === undefined) return undefined;
+  if (!repo) return `#${timeline.prNumber}`;
+  return `https://github.com/${repo}/pull/${timeline.prNumber}`;
+}
+
+export function renderSweepTimeline(container: HTMLElement, timeline: SweepTimeline, repo?: string): void {
+  container.innerHTML = "";
+  container.dataset.sweepId = timeline.sweepId;
+
+  const list = document.createElement("ol");
+  list.className = "sweep-timeline__phases";
+  for (const entry of timeline.phases) {
+    list.appendChild(renderTimelinePhaseRow(entry));
+  }
+  container.appendChild(list);
+
+  if (timeline.result) {
+    const result = document.createElement("div");
+    result.className = "sweep-timeline__result";
+    result.dataset.result = timeline.result;
+    result.textContent = `Result: ${timeline.result}`;
+    container.appendChild(result);
+
+    const prLink = prLinkFor(timeline, repo);
+    if (prLink) {
+      const link = document.createElement("a");
+      link.className = "sweep-timeline__pr-link";
+      link.href = prLink;
+      link.textContent = `PR #${timeline.prNumber}`;
+      container.appendChild(link);
+    }
+  }
+}
+
+/**
+ * Owns a `SweepTimelineBuilder` for one `sweepId` and re-renders into
+ * `container` on every ingested record — whether streamed live (feed a
+ * matching `LiveTailFrame.event.record`) or backfilled from
+ * `GET /api/history?...&limit=...` for phases the live feed missed.
+ */
+export class SweepTimelineView {
+  private readonly builder: SweepTimelineBuilder;
+  private readonly container: HTMLElement;
+  private readonly repo: string | undefined;
+
+  constructor(sweepId: string, container: HTMLElement, repo?: string) {
+    this.builder = new SweepTimelineBuilder(sweepId);
+    this.container = container;
+    this.repo = repo;
+  }
+
+  ingest(record: TelemetryRecord): void {
+    this.builder.addRecord(record);
+    this.render();
+  }
+
+  ingestAll(records: TelemetryRecord[]): void {
+    this.builder.addRecords(records);
+    this.render();
+  }
+
+  render(): void {
+    renderSweepTimeline(this.container, this.builder.getTimeline(), this.repo);
+  }
+}

--- a/dashboard/web/src/timelineBuilder.ts
+++ b/dashboard/web/src/timelineBuilder.ts
@@ -1,0 +1,157 @@
+/**
+ * Per-sweep timeline aggregation: turns a sequence of telemetry records for
+ * one `sweep_id` into the phase-progression view the timeline component
+ * renders (issue #4750, Epic #4702 Phase 3).
+ *
+ * Two data sources feed a timeline, and either is sufficient on its own
+ * (per the issue's "Implementation Guidance"):
+ *
+ * - `sweep.phase` records streamed live (or backfilled via
+ *   `GET /api/history?...`), from which per-phase durations are computed
+ *   client-side as the gap between consecutive `entered_at` timestamps.
+ * - `sweep.outcome`'s `phase_durations` — authoritative, server-computed
+ *   durations recorded once a sweep finishes (see
+ *   `.loom/docs/telemetry-schema.md`). When present, these supersede the
+ *   client-computed durations for phases that already ran.
+ */
+
+import type {
+  SweepCompletedRecord,
+  SweepOutcomeRecord,
+  SweepPhaseRecord,
+  SweepResult,
+  SweepStartedRecord,
+  TelemetryRecord,
+} from "./types.js";
+
+export interface TimelinePhaseEntry {
+  phase: string;
+  enteredAt: string;
+  /** Seconds spent in this phase, or `undefined` while still ongoing. */
+  durationSec?: number;
+  /** True only for the most recent phase of a sweep that hasn't completed. */
+  ongoing: boolean;
+}
+
+export interface SweepTimeline {
+  sweepId: string;
+  phases: TimelinePhaseEntry[];
+  result?: SweepResult;
+  prNumber?: number;
+  totalDurationSec?: number;
+  model?: string;
+  effort?: string;
+}
+
+function toEpochMs(rfc3339: string): number {
+  return new Date(rfc3339).getTime();
+}
+
+/**
+ * Accumulates records for a single sweep and produces its timeline view.
+ * Feed it records in any order (it sorts `sweep.phase` by `entered_at`);
+ * call `getTimeline()` at any point for the current best-known view.
+ */
+export class SweepTimelineBuilder {
+  readonly sweepId: string;
+  private readonly phaseRecords: SweepPhaseRecord[] = [];
+  private started: SweepStartedRecord | undefined;
+  private completed: SweepCompletedRecord | undefined;
+  private outcome: SweepOutcomeRecord | undefined;
+
+  constructor(sweepId: string) {
+    this.sweepId = sweepId;
+  }
+
+  /** Ignores records for a different `sweep_id` (or with none at all). */
+  addRecord(record: TelemetryRecord): void {
+    const sweepId = (record as { sweep_id?: unknown }).sweep_id;
+    if (sweepId !== this.sweepId) return;
+
+    switch (record.kind) {
+      case "sweep.started":
+        this.started = record as SweepStartedRecord;
+        break;
+      case "sweep.phase":
+        this.phaseRecords.push(record as SweepPhaseRecord);
+        break;
+      case "sweep.completed":
+        this.completed = record as SweepCompletedRecord;
+        break;
+      case "sweep.outcome":
+        this.outcome = record as SweepOutcomeRecord;
+        break;
+      default:
+        break;
+    }
+  }
+
+  addRecords(records: Iterable<TelemetryRecord>): void {
+    for (const record of records) this.addRecord(record);
+  }
+
+  /** Phase records sorted by `entered_at`, oldest first (stable on ties). */
+  private sortedPhases(): SweepPhaseRecord[] {
+    return [...this.phaseRecords].sort(
+      (a, b) => toEpochMs(a.entered_at) - toEpochMs(b.entered_at),
+    );
+  }
+
+  getTimeline(): SweepTimeline {
+    const phases = this.sortedPhases();
+
+    // Authoritative post-hoc durations, when available, take precedence —
+    // matched to the live-streamed phase entries positionally (a phase can
+    // legitimately repeat, e.g. the judge<->doctor cycle, so entries are
+    // matched by order, not deduped by name).
+    const outcomeDurations = this.outcome?.phase_durations;
+
+    const entries: TimelinePhaseEntry[] = phases.map((phaseRecord, index) => {
+      const nextPhase = phases[index + 1];
+      const isLast = index === phases.length - 1;
+
+      let durationSec: number | undefined;
+      const outcomeEntry = outcomeDurations?.[index];
+      if (outcomeEntry) {
+        durationSec = outcomeEntry.duration_sec;
+      } else if (nextPhase) {
+        durationSec = (toEpochMs(nextPhase.entered_at) - toEpochMs(phaseRecord.entered_at)) / 1000;
+      } else if (this.completed) {
+        durationSec =
+          (toEpochMs(this.completed.completed_at) - toEpochMs(phaseRecord.entered_at)) / 1000;
+      } else if (this.outcome) {
+        // Sweep finished (we have an outcome) but no per-phase duration was
+        // recorded for the trailing segment — leave it undefined rather
+        // than fabricating a value (mirrors the daemon's own "unattributed
+        // trailing segment" behavior documented in the telemetry schema).
+        durationSec = undefined;
+      }
+
+      return {
+        phase: phaseRecord.phase,
+        enteredAt: phaseRecord.entered_at,
+        durationSec,
+        ongoing: isLast && durationSec === undefined && !this.completed && !this.outcome,
+      };
+    });
+
+    const result = this.outcome?.result ?? this.completed?.result;
+
+    return {
+      sweepId: this.sweepId,
+      phases: entries,
+      result,
+      prNumber: this.outcome?.pr_number,
+      totalDurationSec: this.outcome?.total_duration_sec,
+      model: this.outcome?.model ?? this.started?.model,
+      effort: this.outcome?.effort ?? this.started?.effort,
+    };
+  }
+}
+
+/** Convenience: build a timeline from a flat, unordered record list. */
+export function buildSweepTimeline(sweepId: string, records: TelemetryRecord[]): SweepTimeline {
+  const builder = new SweepTimelineBuilder(sweepId);
+  builder.addRecords(records);
+  return builder.getTimeline();
+}

--- a/dashboard/web/src/types.ts
+++ b/dashboard/web/src/types.ts
@@ -1,0 +1,117 @@
+/**
+ * Shared wire-format types for the fleet dashboard frontend.
+ *
+ * Mirrors the envelope + record kinds documented in
+ * `.loom/docs/telemetry-schema.md` (Rust source of truth) and the SSE frame
+ * shape documented in `dashboard/docs/query-api.md`'s `GET /api/events`
+ * section. Kept intentionally loose (`Record<string, unknown>` plus known
+ * fields) since `record` is the verbatim ingested JSON payload and new
+ * fields are additive across schema versions (see that doc's
+ * `schema_version` semantics section).
+ */
+
+export type SweepResult = "success" | "failure" | "cancelled" | "blocked";
+
+export type SweepPhaseName = "curator" | "builder" | "judge" | "doctor" | "merge";
+
+/** The record kinds this frontend cares about (a subset of the full schema). */
+export type RecordKind =
+  | "sweep.started"
+  | "sweep.phase"
+  | "sweep.completed"
+  | "sweep.outcome"
+  | "tokens.snapshot"
+  | "host.health";
+
+export interface SweepStartedRecord {
+  kind: "sweep.started";
+  repo?: string;
+  visibility?: "public" | "private";
+  issue?: number;
+  sweep_id: string;
+  started_at: string;
+  model?: string;
+  effort?: string;
+}
+
+export interface SweepPhaseRecord {
+  kind: "sweep.phase";
+  repo?: string;
+  visibility?: "public" | "private";
+  issue?: number;
+  sweep_id: string;
+  phase: SweepPhaseName | string;
+  entered_at: string;
+}
+
+export interface SweepCompletedRecord {
+  kind: "sweep.completed";
+  repo?: string;
+  visibility?: "public" | "private";
+  issue?: number;
+  sweep_id: string;
+  completed_at: string;
+  result: SweepResult;
+}
+
+export interface SweepPhaseDuration {
+  phase: SweepPhaseName | string;
+  duration_sec: number;
+}
+
+export interface SweepOutcomeRecord {
+  kind: "sweep.outcome";
+  repo?: string;
+  visibility?: "public" | "private";
+  issue?: number;
+  sweep_id: string;
+  model?: string;
+  effort?: string;
+  config?: Record<string, string>;
+  phase_durations?: SweepPhaseDuration[];
+  total_duration_sec?: number;
+  result: SweepResult;
+  pr_number?: number;
+}
+
+/** Any record kind not modeled above — passed through opaquely. */
+export interface OtherRecord {
+  kind: string;
+  [key: string]: unknown;
+}
+
+export type TelemetryRecord =
+  | SweepStartedRecord
+  | SweepPhaseRecord
+  | SweepCompletedRecord
+  | SweepOutcomeRecord
+  | OtherRecord;
+
+/** The `event` object nested inside every `GET /api/events` SSE frame. */
+export interface LiveTailEvent {
+  hostId: string;
+  emittedAt: string;
+  schemaVersion: number;
+  record: TelemetryRecord;
+}
+
+/** One parsed `data:` frame from the live-tail SSE stream. */
+export interface LiveTailFrame {
+  topic: string;
+  event: LiveTailEvent;
+}
+
+/** A single row from `GET /api/history`'s `records` array. */
+export interface HistoryRecord {
+  id: number;
+  schemaVersion: number;
+  emittedAt: string;
+  hostId: string;
+  kind: string;
+  repo?: string | null;
+  visibility?: "public" | "private" | null;
+  issue?: number | null;
+  sweepId?: string | null;
+  ingestedAt: string;
+  record: TelemetryRecord;
+}

--- a/dashboard/web/test/liveFeedPanel.test.ts
+++ b/dashboard/web/test/liveFeedPanel.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { LiveFeedPanel } from "../src/liveFeedPanel.js";
+import type { LiveTailFrame } from "../src/types.js";
+
+function frame(
+  topic: string,
+  emittedAt: string,
+  recordOverrides: Record<string, unknown> = {},
+): LiveTailFrame {
+  return {
+    topic,
+    event: {
+      hostId: "host-abc",
+      emittedAt,
+      schemaVersion: 1,
+      record: { kind: topic, sweep_id: "sweep-issue-4703-0", ...recordOverrides },
+    },
+  };
+}
+
+function dataFrame(frameObj: LiveTailFrame): string {
+  return `data: ${JSON.stringify(frameObj)}\n\n`;
+}
+
+/** A fake reader that yields one already-encoded chunk, then ends. */
+function readerFor(text: string): ReadableStreamDefaultReader<Uint8Array> {
+  let served = false;
+  const encoder = new TextEncoder();
+  return {
+    async read() {
+      if (served) return { done: true, value: undefined } as ReadableStreamReadResult<Uint8Array>;
+      served = true;
+      return { done: false, value: encoder.encode(text) };
+    },
+    releaseLock() {},
+    cancel: async () => undefined,
+    closed: Promise.resolve(undefined),
+  } as unknown as ReadableStreamDefaultReader<Uint8Array>;
+}
+
+describe("LiveFeedPanel", () => {
+  it("renders an incoming frame as a row, newest first", async () => {
+    const container = document.createElement("ul");
+    const data = dataFrame(frame("sweep.phase", "2026-07-30T12:03:20Z"));
+
+    let panel!: LiveFeedPanel;
+    const connect = vi.fn(async () => readerFor(data));
+
+    panel = new LiveFeedPanel({
+      container,
+      url: "/api/events",
+      connect,
+      sleep: async () => {
+        panel.stop();
+      },
+    });
+    panel.start();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(container.childElementCount).toBe(1);
+    expect(container.firstElementChild?.getAttribute("data-topic")).toBe("sweep.phase");
+  });
+
+  it("applies a client-side model/result filter (the live-tail endpoint doesn't filter server-side)", async () => {
+    const container = document.createElement("ul");
+    const wrongModel = dataFrame(
+      frame("sweep.started", "2026-07-30T12:00:00Z", { model: "haiku" }),
+    );
+    const rightModel = dataFrame(
+      frame("sweep.started", "2026-07-30T12:00:01Z", { model: "opus" }),
+    );
+
+    let panel!: LiveFeedPanel;
+    const connect = vi.fn(async () => readerFor(wrongModel + rightModel));
+
+    panel = new LiveFeedPanel({
+      container,
+      url: "/api/events",
+      connect,
+      filter: { model: "opus" },
+      sleep: async () => {
+        panel.stop();
+      },
+    });
+    panel.start();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(container.childElementCount).toBe(1);
+  });
+
+  it("caps rendered rows at maxRows, dropping the oldest", async () => {
+    const container = document.createElement("ul");
+    const frames = Array.from({ length: 5 }, (_, i) =>
+      dataFrame(frame("sweep.phase", `2026-07-30T12:0${i}:00Z`)),
+    ).join("");
+
+    let panel!: LiveFeedPanel;
+    const connect = vi.fn(async () => readerFor(frames));
+
+    panel = new LiveFeedPanel({
+      container,
+      url: "/api/events",
+      connect,
+      maxRows: 3,
+      sleep: async () => {
+        panel.stop();
+      },
+    });
+    panel.start();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(container.childElementCount).toBe(3);
+  });
+});

--- a/dashboard/web/test/sseFeedClient.test.ts
+++ b/dashboard/web/test/sseFeedClient.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it, vi } from "vitest";
+import { LiveFeedClient, SseStreamParser, frameKey } from "../src/sseFeedClient.js";
+import type { LiveTailFrame } from "../src/types.js";
+
+function frame(overrides: Partial<LiveTailFrame["event"]> = {}, topic = "sweep.phase"): string {
+  const event = {
+    hostId: "host-abc",
+    emittedAt: "2026-07-30T12:03:20Z",
+    schemaVersion: 1,
+    record: { kind: topic, sweep_id: "sweep-issue-4703-0", phase: "builder", entered_at: "2026-07-30T12:03:20Z" },
+    ...overrides,
+  };
+  return `data: ${JSON.stringify({ topic, event })}\n\n`;
+}
+
+function parsedFrame(raw: string): LiveTailFrame {
+  return JSON.parse(raw.slice("data: ".length).trimEnd());
+}
+
+describe("SseStreamParser", () => {
+  it("parses a data frame delivered in a single chunk", () => {
+    const parser = new SseStreamParser();
+    const frames = parser.feed(frame());
+    expect(frames).toHaveLength(1);
+    expect(frames[0]?.type).toBe("data");
+  });
+
+  it("parses the retry + connect-comment preamble as two frames", () => {
+    const parser = new SseStreamParser();
+    const frames = parser.feed(
+      "retry: 3000\n: connected to loom fleet telemetry live tail\n\n",
+    );
+    expect(frames).toEqual([
+      { type: "retry", retryMs: 3000 },
+      { type: "comment", text: "connected to loom fleet telemetry live tail" },
+    ]);
+  });
+
+  it("parses a bare keepalive comment", () => {
+    const parser = new SseStreamParser();
+    const frames = parser.feed(": keepalive\n\n");
+    expect(frames).toEqual([{ type: "comment", text: "keepalive" }]);
+  });
+
+  it("buffers a frame split across multiple chunks", () => {
+    const parser = new SseStreamParser();
+    const whole = frame();
+    const splitPoint = Math.floor(whole.length / 2);
+
+    const firstHalf = parser.feed(whole.slice(0, splitPoint));
+    expect(firstHalf).toHaveLength(0); // no complete frame yet
+
+    const secondHalf = parser.feed(whole.slice(splitPoint));
+    expect(secondHalf).toHaveLength(1);
+    expect(secondHalf[0]?.type).toBe("data");
+  });
+
+  it("handles CRLF line endings the same as LF", () => {
+    const parser = new SseStreamParser();
+    const frames = parser.feed("retry: 3000\r\n: keepalive\r\n\r\n");
+    expect(frames).toEqual([
+      { type: "retry", retryMs: 3000 },
+      { type: "comment", text: "keepalive" },
+    ]);
+  });
+
+  it("parses multiple frames delivered in one chunk", () => {
+    const parser = new SseStreamParser();
+    const frames = parser.feed(frame() + ": keepalive\n\n" + frame({ emittedAt: "2026-07-30T12:03:21Z" }));
+    expect(frames.map((f) => f.type)).toEqual(["data", "comment", "data"]);
+  });
+});
+
+describe("frameKey", () => {
+  it("is stable for identical frames and distinct for differing ones", () => {
+    const a = parsedFrame(frame());
+    const b = parsedFrame(frame());
+    const c = parsedFrame(frame({ emittedAt: "2026-07-30T12:03:21Z" }));
+    expect(frameKey(a)).toBe(frameKey(b));
+    expect(frameKey(a)).not.toBe(frameKey(c));
+  });
+});
+
+/** A fake reader that yields a fixed script of string chunks, then ends the stream. */
+function scriptedReader(chunks: string[]): ReadableStreamDefaultReader<Uint8Array> {
+  let index = 0;
+  const encoder = new TextEncoder();
+  return {
+    async read() {
+      if (index >= chunks.length) {
+        return { done: true, value: undefined } as ReadableStreamReadResult<Uint8Array>;
+      }
+      const value = encoder.encode(chunks[index]!);
+      index += 1;
+      return { done: false, value };
+    },
+    releaseLock() {},
+    cancel: async () => undefined,
+    closed: Promise.resolve(undefined),
+  } as unknown as ReadableStreamDefaultReader<Uint8Array>;
+}
+
+describe("LiveFeedClient", () => {
+  it("emits parsed frames and ignores keepalive/preamble comments", async () => {
+    let client!: LiveFeedClient;
+    const connect = vi.fn(async () =>
+      scriptedReader([
+        "retry: 3000\n: connected to loom fleet telemetry live tail\n\n",
+        ": keepalive\n\n",
+        frame(),
+      ]),
+    );
+    const onEvent = vi.fn((f: LiveTailFrame) => {
+      void f;
+      client.stop(); // self-terminate once we've observed the one real event
+    });
+
+    client = new LiveFeedClient({ url: "/api/events", connect, onEvent, sleep: async () => undefined });
+    client.start();
+    await client.whenIdle();
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent.mock.calls[0]?.[0]?.topic).toBe("sweep.phase");
+  });
+
+  it("does not duplicate an event re-delivered across a reconnect", async () => {
+    const sameFrame = frame();
+    const newFrame = frame({ emittedAt: "2026-07-30T12:03:22Z" });
+    const connections = [
+      scriptedReader([sameFrame]), // connection 1: delivers one frame, then the stream ends
+      scriptedReader([sameFrame, newFrame]), // reconnect: server redelivers + adds one new frame
+    ];
+    const connect = vi.fn(async () => connections.shift()!);
+    const events: string[] = [];
+
+    // A manually-released gate stands in for the reconnect delay so the test
+    // controls exactly when the client reconnects, instead of racing a timer.
+    let releaseGate: (() => void) | undefined;
+    const gate = () => new Promise<void>((resolve) => (releaseGate = resolve));
+
+    const client = new LiveFeedClient({
+      url: "/api/events",
+      connect,
+      onEvent: (f) => events.push(f.event.emittedAt),
+      sleep: async () => gate(),
+    });
+
+    client.start();
+
+    await vi.waitFor(() => expect(events).toEqual(["2026-07-30T12:03:20Z"]));
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    releaseGate?.();
+    await vi.waitFor(() =>
+      expect(events).toEqual(["2026-07-30T12:03:20Z", "2026-07-30T12:03:22Z"]),
+    );
+    expect(connect).toHaveBeenCalledTimes(2);
+
+    client.stop();
+  });
+
+  it("honors a retry: directive for the reconnect delay", async () => {
+    let client!: LiveFeedClient;
+    const recordedDelays: number[] = [];
+    const connect = vi.fn(async () => scriptedReader(["retry: 9000\n: connected\n\n"]));
+    const sleep = vi.fn(async (ms: number) => {
+      recordedDelays.push(ms);
+      client.stop(); // stop right after observing the delay so the loop ends cleanly
+    });
+
+    client = new LiveFeedClient({ url: "/api/events", connect, onEvent: vi.fn(), sleep });
+    client.start();
+    await client.whenIdle();
+
+    expect(recordedDelays).toEqual([9000]);
+  });
+
+  it("reconnects using the default retry delay before any retry: directive arrives", async () => {
+    let client!: LiveFeedClient;
+    const recordedDelays: number[] = [];
+    const connect = vi.fn(async () => scriptedReader([]));
+    const sleep = vi.fn(async (ms: number) => {
+      recordedDelays.push(ms);
+      client.stop();
+    });
+
+    client = new LiveFeedClient({ url: "/api/events", connect, onEvent: vi.fn(), sleep });
+    client.start();
+    await client.whenIdle();
+
+    expect(recordedDelays).toEqual([3000]);
+  });
+
+  it("builds the connect URL with host/repo query params", async () => {
+    let client!: LiveFeedClient;
+    let calledUrl: string | undefined;
+    const connect = vi.fn(async (url: string) => {
+      calledUrl = url;
+      client.stop();
+      return scriptedReader([]);
+    });
+
+    client = new LiveFeedClient({
+      url: "/api/events",
+      host: "host-abc",
+      repo: "rjwalters/loom",
+      connect,
+      onEvent: vi.fn(),
+      sleep: async () => undefined,
+    });
+    client.start();
+    await client.whenIdle();
+
+    expect(calledUrl).toContain("host=host-abc");
+    expect(calledUrl).toContain("repo=rjwalters%2Floom");
+  });
+
+  it("reports a JSON parse error without throwing", async () => {
+    let client!: LiveFeedClient;
+    const connect = vi.fn(async () => scriptedReader(["data: {not json\n\n"]));
+    const onParseError = vi.fn((_payload: string, _err: unknown) => {
+      client.stop();
+    });
+
+    client = new LiveFeedClient({
+      url: "/api/events",
+      connect,
+      onEvent: vi.fn(),
+      onParseError,
+      sleep: async () => undefined,
+    });
+    client.start();
+    await client.whenIdle();
+
+    expect(onParseError).toHaveBeenCalledTimes(1);
+    expect(onParseError.mock.calls[0]?.[0]).toBe("{not json");
+  });
+});

--- a/dashboard/web/test/sweepTimelineView.test.ts
+++ b/dashboard/web/test/sweepTimelineView.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { SweepTimelineView, prLinkFor, renderSweepTimeline } from "../src/sweepTimelineView.js";
+import type { SweepPhaseRecord, SweepOutcomeRecord } from "../src/types.js";
+
+const SWEEP_ID = "sweep-issue-4703-0";
+
+function phase(phaseName: string, enteredAt: string): SweepPhaseRecord {
+  return {
+    kind: "sweep.phase",
+    repo: "rjwalters/loom",
+    visibility: "public",
+    issue: 4703,
+    sweep_id: SWEEP_ID,
+    phase: phaseName,
+    entered_at: enteredAt,
+  };
+}
+
+function outcome(overrides: Partial<SweepOutcomeRecord> = {}): SweepOutcomeRecord {
+  return {
+    kind: "sweep.outcome",
+    repo: "rjwalters/loom",
+    visibility: "public",
+    issue: 4703,
+    sweep_id: SWEEP_ID,
+    result: "success",
+    ...overrides,
+  };
+}
+
+describe("SweepTimelineView", () => {
+  it("renders one row per phase and updates as records are ingested", () => {
+    const container = document.createElement("div");
+    const view = new SweepTimelineView(SWEEP_ID, container, "rjwalters/loom");
+
+    view.ingest(phase("curator", "2026-07-30T12:00:00Z"));
+    expect(container.querySelectorAll(".sweep-timeline__phase")).toHaveLength(1);
+    expect(container.querySelector(".sweep-timeline__phase--ongoing")).not.toBeNull();
+
+    view.ingest(phase("builder", "2026-07-30T12:00:12Z"));
+    expect(container.querySelectorAll(".sweep-timeline__phase")).toHaveLength(2);
+
+    view.ingest(outcome({ pr_number: 4710, result: "success" }));
+    const result = container.querySelector(".sweep-timeline__result");
+    expect(result?.getAttribute("data-result")).toBe("success");
+
+    const link = container.querySelector<HTMLAnchorElement>(".sweep-timeline__pr-link");
+    expect(link?.getAttribute("href")).toBe("https://github.com/rjwalters/loom/pull/4710");
+  });
+
+  it("supports bulk backfill ingestion via ingestAll", () => {
+    const container = document.createElement("div");
+    const view = new SweepTimelineView(SWEEP_ID, container);
+    view.ingestAll([
+      phase("curator", "2026-07-30T12:00:00Z"),
+      phase("builder", "2026-07-30T12:00:12Z"),
+      phase("judge", "2026-07-30T12:05:52Z"),
+    ]);
+
+    expect(container.querySelectorAll(".sweep-timeline__phase")).toHaveLength(3);
+  });
+});
+
+describe("renderSweepTimeline", () => {
+  it("omits the result/PR sections while a sweep is still in progress", () => {
+    const container = document.createElement("div");
+    renderSweepTimeline(container, {
+      sweepId: SWEEP_ID,
+      phases: [{ phase: "builder", enteredAt: "2026-07-30T12:00:00Z", ongoing: true }],
+    });
+
+    expect(container.querySelector(".sweep-timeline__result")).toBeNull();
+    expect(container.querySelector(".sweep-timeline__pr-link")).toBeNull();
+  });
+});
+
+describe("prLinkFor", () => {
+  it("falls back to a bare PR reference when no repo is known", () => {
+    const link = prLinkFor({ sweepId: SWEEP_ID, phases: [], prNumber: 42 });
+    expect(link).toBe("#42");
+  });
+
+  it("returns undefined when there is no pr_number yet", () => {
+    const link = prLinkFor({ sweepId: SWEEP_ID, phases: [] }, "rjwalters/loom");
+    expect(link).toBeUndefined();
+  });
+});

--- a/dashboard/web/test/timelineBuilder.test.ts
+++ b/dashboard/web/test/timelineBuilder.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import { SweepTimelineBuilder, buildSweepTimeline } from "../src/timelineBuilder.js";
+import type {
+  SweepCompletedRecord,
+  SweepOutcomeRecord,
+  SweepPhaseRecord,
+  SweepStartedRecord,
+} from "../src/types.js";
+
+const SWEEP_ID = "sweep-issue-4703-0";
+
+function phase(phaseName: string, enteredAt: string): SweepPhaseRecord {
+  return {
+    kind: "sweep.phase",
+    repo: "rjwalters/loom",
+    visibility: "public",
+    issue: 4703,
+    sweep_id: SWEEP_ID,
+    phase: phaseName,
+    entered_at: enteredAt,
+  };
+}
+
+function started(startedAt: string, model = "opus", effort = "high"): SweepStartedRecord {
+  return {
+    kind: "sweep.started",
+    repo: "rjwalters/loom",
+    visibility: "public",
+    issue: 4703,
+    sweep_id: SWEEP_ID,
+    started_at: startedAt,
+    model,
+    effort,
+  };
+}
+
+function completed(completedAt: string, result: SweepCompletedRecord["result"] = "success"): SweepCompletedRecord {
+  return {
+    kind: "sweep.completed",
+    repo: "rjwalters/loom",
+    visibility: "public",
+    issue: 4703,
+    sweep_id: SWEEP_ID,
+    completed_at: completedAt,
+    result,
+  };
+}
+
+function outcome(overrides: Partial<SweepOutcomeRecord> = {}): SweepOutcomeRecord {
+  return {
+    kind: "sweep.outcome",
+    repo: "rjwalters/loom",
+    visibility: "public",
+    issue: 4703,
+    sweep_id: SWEEP_ID,
+    model: "opus",
+    effort: "high",
+    result: "success",
+    ...overrides,
+  };
+}
+
+describe("SweepTimelineBuilder", () => {
+  it("computes per-phase durations from consecutive entered_at gaps", () => {
+    const timeline = buildSweepTimeline(SWEEP_ID, [
+      phase("curator", "2026-07-30T12:00:00Z"),
+      phase("builder", "2026-07-30T12:00:12Z"),
+      phase("judge", "2026-07-30T12:05:52Z"),
+    ]);
+
+    expect(timeline.phases).toEqual([
+      { phase: "curator", enteredAt: "2026-07-30T12:00:00Z", durationSec: 12, ongoing: false },
+      { phase: "builder", enteredAt: "2026-07-30T12:00:12Z", durationSec: 340, ongoing: false },
+      { phase: "judge", enteredAt: "2026-07-30T12:05:52Z", durationSec: undefined, ongoing: true },
+    ]);
+  });
+
+  it("sorts out-of-order phase records by entered_at before computing durations", () => {
+    const timeline = buildSweepTimeline(SWEEP_ID, [
+      phase("builder", "2026-07-30T12:00:12Z"),
+      phase("curator", "2026-07-30T12:00:00Z"),
+    ]);
+
+    expect(timeline.phases.map((p) => p.phase)).toEqual(["curator", "builder"]);
+    expect(timeline.phases[0]?.durationSec).toBe(12);
+  });
+
+  it("closes the last phase's duration using sweep.completed when present", () => {
+    const timeline = buildSweepTimeline(SWEEP_ID, [
+      phase("merge", "2026-07-30T12:08:00Z"),
+      completed("2026-07-30T12:08:32Z", "success"),
+    ]);
+
+    expect(timeline.phases).toEqual([
+      { phase: "merge", enteredAt: "2026-07-30T12:08:00Z", durationSec: 32, ongoing: false },
+    ]);
+    expect(timeline.result).toBe("success");
+  });
+
+  it("keeps two entries in lifecycle order for a phase that repeats (judge <-> doctor cycle)", () => {
+    const timeline = buildSweepTimeline(SWEEP_ID, [
+      phase("judge", "2026-07-30T12:01:00Z"),
+      phase("doctor", "2026-07-30T12:02:00Z"),
+      phase("judge", "2026-07-30T12:04:00Z"),
+      phase("merge", "2026-07-30T12:05:00Z"),
+    ]);
+
+    expect(timeline.phases.map((p) => p.phase)).toEqual(["judge", "doctor", "judge", "merge"]);
+    expect(timeline.phases[0]?.durationSec).toBe(60);
+    expect(timeline.phases[2]?.durationSec).toBe(60);
+  });
+
+  it("prefers sweep.outcome's authoritative phase_durations over computed gaps", () => {
+    const timeline = buildSweepTimeline(SWEEP_ID, [
+      phase("curator", "2026-07-30T12:00:00Z"),
+      phase("builder", "2026-07-30T12:00:12Z"),
+      outcome({
+        phase_durations: [
+          { phase: "curator", duration_sec: 12 },
+          { phase: "builder", duration_sec: 500 }, // authoritative value differs from any computed gap
+        ],
+        total_duration_sec: 512,
+        pr_number: 4710,
+        result: "success",
+      }),
+    ]);
+
+    expect(timeline.phases[1]).toEqual({
+      phase: "builder",
+      enteredAt: "2026-07-30T12:00:12Z",
+      durationSec: 500,
+      ongoing: false,
+    });
+    expect(timeline.totalDurationSec).toBe(512);
+    expect(timeline.prNumber).toBe(4710);
+    expect(timeline.result).toBe("success");
+  });
+
+  it("reports result/prNumber/model/effort from sweep.outcome for a completed sweep", () => {
+    const timeline = buildSweepTimeline(SWEEP_ID, [
+      started("2026-07-30T12:00:00Z", "opus", "high"),
+      phase("curator", "2026-07-30T12:00:00Z"),
+      outcome({ result: "failure", pr_number: undefined }),
+    ]);
+
+    expect(timeline.result).toBe("failure");
+    expect(timeline.prNumber).toBeUndefined();
+    expect(timeline.model).toBe("opus");
+    expect(timeline.effort).toBe("high");
+  });
+
+  it("marks the sweep's most recent phase as ongoing while in flight", () => {
+    const timeline = buildSweepTimeline(SWEEP_ID, [phase("builder", "2026-07-30T12:00:00Z")]);
+    expect(timeline.phases[0]?.ongoing).toBe(true);
+    expect(timeline.result).toBeUndefined();
+  });
+
+  it("ignores records for a different sweep_id", () => {
+    const builder = new SweepTimelineBuilder(SWEEP_ID);
+    builder.addRecord(phase("curator", "2026-07-30T12:00:00Z"));
+    builder.addRecord({ ...phase("builder", "2026-07-30T12:00:12Z"), sweep_id: "some-other-sweep" });
+
+    const timeline = builder.getTimeline();
+    expect(timeline.phases).toHaveLength(1);
+    expect(timeline.phases[0]?.phase).toBe("curator");
+  });
+
+  it("supports incremental ingestion via addRecord, re-deriving on each call", () => {
+    const builder = new SweepTimelineBuilder(SWEEP_ID);
+    builder.addRecord(phase("curator", "2026-07-30T12:00:00Z"));
+    expect(builder.getTimeline().phases[0]?.ongoing).toBe(true);
+
+    builder.addRecord(phase("builder", "2026-07-30T12:00:12Z"));
+    const midTimeline = builder.getTimeline();
+    expect(midTimeline.phases[0]?.durationSec).toBe(12);
+    expect(midTimeline.phases[1]?.ongoing).toBe(true);
+
+    builder.addRecord(completed("2026-07-30T12:08:32Z", "success"));
+    const finalTimeline = builder.getTimeline();
+    expect(finalTimeline.phases[1]?.ongoing).toBe(false);
+    expect(finalTimeline.result).toBe("success");
+  });
+});

--- a/dashboard/web/tsconfig.json
+++ b/dashboard/web/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/dashboard/web/vitest.config.ts
+++ b/dashboard/web/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+// Default environment is plain `node` — the SSE client and timeline builder
+// are DOM-free logic modules. Component tests that touch `document` opt in
+// to jsdom per-file via a `// @vitest-environment jsdom` pragma, matching
+// vitest's documented per-test-file environment override.
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary

Implements the two Phase 3 (Epic #4702) frontend components described in
#4750: a reconnecting live event feed and a per-sweep phase-progression
timeline, over the Phase 2 query API (`dashboard/src/query.ts`).

No `dashboard/web/` scaffold existed on `main` yet from the sibling
Fleet-overview issue (#4749) at the time this worktree was created, so per
#4750's own guidance ("otherwise independently implementable") this PR adds
a minimal, self-contained, framework-free scaffold (`package.json`,
`tsconfig.json`, `vitest.config.ts`) sufficient to host and test the two
components. A merge conflict against #4749's eventual `dashboard/web/`
scaffold is expected and will be handled by the normal Judge/Doctor rebase
flow — the logic modules here are framework-independent and the two view
modules use plain DOM APIs so they can be adapted into whichever framework
#4749 lands with.

## Changes

- `dashboard/web/src/sseFeedClient.ts` — `SseStreamParser` (incremental SSE
  frame parsing: `retry:` directives, `:`-comments, `data:` frames) +
  `LiveFeedClient` (reconnecting client for `GET /api/events`): honors the
  `retry: 3000` preamble, ignores `: keepalive` comments, and dedups frames
  across reconnects via a bounded recently-seen key set.
- `dashboard/web/src/timelineBuilder.ts` — `SweepTimelineBuilder` /
  `buildSweepTimeline`: aggregates `sweep.phase` records for one `sweep_id`
  into per-phase durations (computed client-side from consecutive
  `entered_at` gaps), superseded by `sweep.outcome`'s authoritative
  `phase_durations` once a sweep completes; surfaces `result` and
  `pr_number`.
- `dashboard/web/src/liveFeedPanel.ts` — `LiveFeedPanel`: renders the feed
  with client-side `model`/`result` filtering (the live-tail endpoint only
  supports `host`/`repo` server-side, per `dashboard/docs/query-api.md`'s
  "Not implemented here" section).
- `dashboard/web/src/sweepTimelineView.ts` — `SweepTimelineView`: renders
  the phase list plus the terminal result and a PR link derived from
  `sweep.outcome`'s `pr_number`.
- `dashboard/web/{package.json,tsconfig.json,vitest.config.ts}` — minimal
  scaffold (TypeScript + vitest, no framework), matching the sibling
  `dashboard/` Workers project's conventions.

## Acceptance Criteria Verification

- [x] Live feed subscribes to `GET /api/events` (SSE) and renders incoming
      events (topic + record fields) as they arrive — `LiveFeedClient` +
      `LiveFeedPanel`, tested in `test/sseFeedClient.test.ts` and
      `test/liveFeedPanel.test.ts`.
- [x] Feed handles the SSE reconnect contract: honors `retry: 3000`,
      ignores `: keepalive` comments, no duplicate rendering on reconnect —
      `test/sseFeedClient.test.ts`'s "honors a retry: directive", "reports
      ... comments", and "does not duplicate an event re-delivered across a
      reconnect" cases.
- [x] Feed supports `host`/`repo` query params matching the API —
      `test/sseFeedClient.test.ts`'s "builds the connect URL" case.
- [x] Per-sweep timeline shows phase progression from `sweep.phase`
      (`phase`, `entered_at`) with computed per-phase durations —
      `test/timelineBuilder.test.ts`.
- [x] Completed sweeps show `result` and, when present, a PR link derived
      from `sweep.outcome`'s `pr_number` — `SweepTimelineView` /
      `prLinkFor`, tested in `test/sweepTimelineView.test.ts` and
      `test/timelineBuilder.test.ts`.
- [x] No server-side `model`/`result` filtering assumed on the live tail —
      `LiveFeedPanel`'s filter is client-side only.

## Test Plan

```bash
cd dashboard/web
npm install
npm run check   # tsc --noEmit && vitest run
```

- `tsc --noEmit`: clean.
- `vitest run`: 30/30 tests passing across 4 files (SSE parsing/reconnect/
  dedup/keepalive, timeline duration computation including the
  judge<->doctor repeat-phase case and the `sweep.outcome` override case,
  and jsdom-based component rendering for both views).
- Manual verification against a running `wrangler dev`/deployed backend
  was not performed (not required per the issue's test plan — automated
  tests are the bar).

Closes #4750