### PR TITLE
feat(dashboard): add unauthenticated /public dashboard page

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -124,6 +124,7 @@ asserts the `ADMIN_TOKEN` secret exists on the deployed Worker.
 | `GET /public/fleet-state` | none (always public) | Public query API: same data as `/api/fleet-state`, redacted per record `visibility` (issue #4727). |
 | `GET /public/history` | none (always public) | Public query API: same data as `/api/history`, redacted. |
 | `GET /public/events` | none (always public) | Public query API: same data as `/api/events`, redacted. |
+| `GET /public` | none (always public) | The public dashboard page itself (issue #4753) — server-rendered fleet overview + history from the same redacted data above, plus a live feed over `/public/events`. Read-only; never calls `/api/*`. |
 
 Full request/response shapes for the `/api/*` and `/public/*` routes,
 including the exact redaction policy per record kind:

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -35,6 +35,13 @@
  *                                      summarized (see `./redaction.ts`).
  *   GET  /public/history             — public: same query, redacted.
  *   GET  /public/events              — public: same live tail, redacted.
+ *   GET  /public                     — public: the Phase-3 dashboard page
+ *                                      itself (issue #4753), server-rendered
+ *                                      from the same redacted data the three
+ *                                      routes above return. See
+ *                                      `./publicPage.ts` for the rendering +
+ *                                      the token/cost-widget exposure
+ *                                      decision.
  *
  * All `/admin/*` routes require `Authorization: Bearer <ADMIN_TOKEN>`
  * (a `wrangler secret`, never committed) — see README.md.
@@ -53,8 +60,10 @@
 
 import { extractBearerToken, authenticateHost, hashIngestKey } from "./auth";
 import { FleetState, type FleetSnapshot } from "./fleetState";
+import { renderPublicPage } from "./publicPage";
 import {
   createLiveTailStream,
+  DEFAULT_HISTORY_LIMIT,
   parseHistoryQuery,
   queryHistory,
   type LiveTailFilter,
@@ -334,6 +343,25 @@ function handleLiveTail(request: Request, env: Env, url: URL, isAuthenticated: b
   });
 }
 
+/** `GET /public` (issue #4753) — the unauthenticated dashboard page itself.
+ * Sources its data by calling `fleetStateStub`/`queryHistory` directly, the
+ * same in-process calls `handleFleetStateQuery`/`handleHistoryQuery` make,
+ * then redacts with `isAuthenticated: false` before handing off to
+ * `./publicPage.ts` for rendering — there is no HTTP round-trip through
+ * `/api/*` anywhere in this path, so this route cannot accidentally source
+ * unredacted data. */
+async function handlePublicPage(env: Env): Promise<Response> {
+  const stateResponse = await fleetStateStub(env).fetch("https://fleet-state/snapshot");
+  const snapshot = (await stateResponse.json()) as FleetSnapshot;
+  const redactedSnapshot = redactFleetSnapshot(snapshot, /* isAuthenticated */ false);
+
+  const historyResult = await queryHistory(env.DB, { limit: DEFAULT_HISTORY_LIMIT });
+  const redactedHistory = redactHistoryQueryResult(historyResult, /* isAuthenticated */ false);
+
+  const html = renderPublicPage(redactedSnapshot, redactedHistory);
+  return new Response(html, { status: 200, headers: { "content-type": "text/html; charset=utf-8" } });
+}
+
 // ---------------------------------------------------------------------------
 // Entrypoint
 // ---------------------------------------------------------------------------
@@ -365,6 +393,9 @@ export default {
     }
     if (request.method === "GET" && url.pathname === "/public/events") {
       return handleLiveTail(request, env, url, /* isAuthenticated */ false);
+    }
+    if (request.method === "GET" && url.pathname === "/public") {
+      return handlePublicPage(env);
     }
     if (request.method === "GET" && url.pathname === "/") {
       return new Response("loom-observability-ingest: see /ingest, /admin/*, /api/*, /public/*", { status: 200 });

--- a/dashboard/src/publicPage.ts
+++ b/dashboard/src/publicPage.ts
@@ -1,0 +1,326 @@
+/**
+ * The `/public` route's HTML page (Epic #4702, Phase 3, issue #4753).
+ *
+ * Server-rendered from the exact same redacted data `GET /public/fleet-state`
+ * and `GET /public/history` return — `src/index.ts`'s `handlePublicPage`
+ * calls `redactFleetSnapshot`/`redactHistoryQueryResult` directly, in-process
+ * (not over HTTP), so there is no code path by which this page could
+ * accidentally source data from the authenticated `/api/*` surface. The
+ * page's own inline script tails `GET /public/events` for live updates —
+ * never `/api/*`. See `./redaction.ts`'s module doc for the redaction policy
+ * this page renders faithfully rather than reimplements: this module MUST
+ * NOT re-derive private/public status or attempt to reconstruct a stripped
+ * field — it only ever formats fields that are already present on the
+ * redacted objects it is handed.
+ *
+ * ## Display allowlist: narrower than the wire allowlist, on purpose
+ *
+ * `PUBLIC_PAGE_DISPLAY_FIELDS` below decides which record `kind`s and which
+ * of their fields this page renders at all. It is deliberately a *subset* of
+ * `redaction.ts`'s `RECORD_FIELD_ALLOWLIST` — most notably, it omits
+ * `tokens.snapshot` entirely (see the next section) — and, like that module,
+ * is itself an allowlist (a kind/field not listed is never rendered), so a
+ * future wire field never leaks into the page just because a maintainer
+ * forgot to update this table.
+ *
+ * ## Token/cost widget decision (resolves the open question in issue #4752)
+ *
+ * `tokens.snapshot` passes through `GET /public/fleet-state` and
+ * `GET /public/history` unredacted (see `redaction.ts`'s module doc) because
+ * its wire allowlist has no `repo` field to key the private/public split
+ * off. But its `accounts[].account` field is a per-account identifier (an
+ * operator's Claude account label) that is not one of the four leak vectors
+ * this epic's redaction guarantees cover (repo/issue/branch/PR) and is
+ * reasonably sensitive on its own — the exact concern issue #4752 flags and
+ * asks this issue to resolve. Decision: this page never renders
+ * `tokens.snapshot` — not in the fleet overview, not in history, not in the
+ * live feed — regardless of what the `/public/*` API technically returns.
+ * `PUBLIC_PAGE_DISPLAY_FIELDS` has no entry for it, so it is filtered out by
+ * construction rather than by a special-cased check; widening this later
+ * (e.g. an aggregate, non-identifying burn-rate widget) is a decision for
+ * whatever implements #4752, made explicit rather than defaulted into.
+ *
+ * ## Read-only
+ *
+ * This page contains no `<form>`, no mutating `fetch`/`EventSource` call,
+ * and no reference to `/admin/*` or `/ingest` — it only ever reads
+ * `/public/*`.
+ */
+
+import type { HistoryQueryResult, HistoryRecord } from "./query";
+import type { PublicActiveSweep, RedactedFleetSnapshot } from "./redaction";
+
+/** The record `kind`s this page renders, and — for each — the nested
+ * `record` payload fields it displays. A `kind` absent from this table
+ * (including `tokens.snapshot` — see the module doc) is never rendered by
+ * `renderHistoryTable` or the live-feed script, no matter what the
+ * `/public/*` API returns for it. */
+const PUBLIC_PAGE_DISPLAY_FIELDS: Readonly<Record<string, readonly string[]>> = {
+  "sweep.started": ["started_at", "model", "effort"],
+  "sweep.phase": ["phase", "entered_at"],
+  "sweep.completed": ["completed_at", "result"],
+  "sweep.outcome": ["model", "effort", "result", "total_duration_sec"],
+  "host.health": ["captured_at", "daemon_version", "uptime_sec", "logical_cpus", "cpu_idle_fraction"],
+};
+
+export function isPublicPageDisplayKind(kind: string): boolean {
+  return Object.prototype.hasOwnProperty.call(PUBLIC_PAGE_DISPLAY_FIELDS, kind);
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function formatFieldValue(value: unknown): string {
+  return typeof value === "object" && value !== null ? JSON.stringify(value) : String(value);
+}
+
+/** Render the `kind`-specific detail fields for one record's payload, per
+ * `PUBLIC_PAGE_DISPLAY_FIELDS` — a `kind` with no entry renders no detail
+ * (callers are expected to have already filtered it out via
+ * `isPublicPageDisplayKind`). */
+function formatDetails(kind: string, record: Record<string, unknown>): string {
+  const fields = PUBLIC_PAGE_DISPLAY_FIELDS[kind] ?? [];
+  const parts: string[] = [];
+  for (const field of fields) {
+    const value = record[field];
+    if (value !== undefined) {
+      parts.push(`${escapeHtml(field)}=${escapeHtml(formatFieldValue(value))}`);
+    }
+  }
+  return parts.join(", ");
+}
+
+/** Render a "repo #issue (sweepId)" cell, or a "private" placeholder when
+ * `repo` is absent/null — matching the already-redacted absence of those
+ * fields rather than re-deciding visibility itself. */
+function renderRepoCell(repo: string | null | undefined, issue: number | null | undefined, sweepId?: string | null): string {
+  if (!repo) return `<span class="muted">private</span>`;
+  const issuePart = issue ? ` #${escapeHtml(issue)}` : "";
+  const sweepPart = sweepId ? ` <span class="muted">(${escapeHtml(sweepId)})</span>` : "";
+  return `${escapeHtml(repo)}${issuePart}${sweepPart}`;
+}
+
+// ---------------------------------------------------------------------------
+// Fleet overview (`/public/fleet-state`)
+// ---------------------------------------------------------------------------
+
+function renderActiveSweepRow(sweep: PublicActiveSweep): string {
+  return `<tr>
+    <td>${escapeHtml(sweep.hostId)}</td>
+    <td>${escapeHtml(sweep.visibility)}</td>
+    <td>${renderRepoCell(sweep.repo, sweep.issue, sweep.sweepId)}</td>
+    <td>${escapeHtml(sweep.phase ?? "")}</td>
+    <td>${escapeHtml(sweep.model ?? "")}</td>
+    <td>${escapeHtml(sweep.effort ?? "")}</td>
+    <td>${escapeHtml(sweep.startedAt ?? "")}</td>
+    <td>${escapeHtml(sweep.updatedAt)}</td>
+  </tr>`;
+}
+
+function renderHostHealthRow(hostId: string, health?: { record: Record<string, unknown>; updatedAt: string }): string {
+  if (!health) return "";
+  return `<tr>
+    <td>${escapeHtml(hostId)}</td>
+    <td>${escapeHtml(health.updatedAt)}</td>
+    <td>${formatDetails("host.health", health.record)}</td>
+  </tr>`;
+}
+
+export function renderFleetOverview(snapshot: RedactedFleetSnapshot): string {
+  const hostIds = Object.keys(snapshot.hosts).sort();
+  const healthRows = hostIds
+    .map((id) => renderHostHealthRow(id, snapshot.hosts[id]?.health))
+    .filter((row) => row.length > 0)
+    .join("\n");
+  const sweepRows = snapshot.activeSweeps.map(renderActiveSweepRow).join("\n");
+
+  return `<section id="fleet-overview">
+    <h2>Fleet overview</h2>
+    <h3>Hosts (${hostIds.length})</h3>
+    <table>
+      <thead><tr><th>Host</th><th>Last health update</th><th>Detail</th></tr></thead>
+      <tbody>${healthRows || `<tr><td colspan="3" class="muted">No host health reported yet.</td></tr>`}</tbody>
+    </table>
+    <h3>Active sweeps (${snapshot.activeSweeps.length})</h3>
+    <table>
+      <thead>
+        <tr><th>Host</th><th>Visibility</th><th>Repo / Issue</th><th>Phase</th><th>Model</th><th>Effort</th><th>Started</th><th>Updated</th></tr>
+      </thead>
+      <tbody>${sweepRows || `<tr><td colspan="8" class="muted">No sweeps currently running.</td></tr>`}</tbody>
+    </table>
+  </section>`;
+}
+
+// ---------------------------------------------------------------------------
+// History (`/public/history`)
+// ---------------------------------------------------------------------------
+
+function renderHistoryRow(record: HistoryRecord): string {
+  return `<tr>
+    <td>${escapeHtml(record.emittedAt)}</td>
+    <td>${escapeHtml(record.hostId)}</td>
+    <td>${escapeHtml(record.kind)}</td>
+    <td>${renderRepoCell(record.repo, record.issue, record.sweepId)}</td>
+    <td>${escapeHtml(record.visibility)}</td>
+    <td>${formatDetails(record.kind, record.record)}</td>
+  </tr>`;
+}
+
+export function renderHistoryTable(history: HistoryQueryResult): string {
+  const visible = history.records.filter((record) => isPublicPageDisplayKind(record.kind));
+  const rows = visible.map(renderHistoryRow).join("\n");
+
+  return `<section id="history">
+    <h2>Recent history</h2>
+    <table>
+      <thead><tr><th>Emitted</th><th>Host</th><th>Kind</th><th>Repo / Issue</th><th>Visibility</th><th>Detail</th></tr></thead>
+      <tbody>${rows || `<tr><td colspan="6" class="muted">No history yet.</td></tr>`}</tbody>
+    </table>
+  </section>`;
+}
+
+// ---------------------------------------------------------------------------
+// Live feed (`/public/events`) — client-side only, vanilla JS
+// ---------------------------------------------------------------------------
+
+/** The live-feed script's own copy of the display allowlist, injected
+ * verbatim from `PUBLIC_PAGE_DISPLAY_FIELDS` at render time so there is a
+ * single source of truth for "which kinds/fields does this page show" —
+ * the client never has to keep a hand-written allowlist in sync with this
+ * module's. A `topic` (== record `kind`) missing from this object is
+ * dropped by the `onmessage` handler before touching the DOM. */
+function renderLiveFeedScript(): string {
+  const displayFields = JSON.stringify(PUBLIC_PAGE_DISPLAY_FIELDS);
+  return `<script>
+    (function () {
+      var DISPLAY_FIELDS = ${displayFields};
+      var MAX_ROWS = 50;
+      var feed = document.getElementById("live-feed-body");
+
+      function escapeHtml(value) {
+        return String(value == null ? "" : value)
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;")
+          .replace(/'/g, "&#39;");
+      }
+
+      function formatFieldValue(value) {
+        return typeof value === "object" && value !== null ? JSON.stringify(value) : String(value);
+      }
+
+      function formatDetails(kind, record) {
+        var fields = DISPLAY_FIELDS[kind] || [];
+        var parts = [];
+        for (var i = 0; i < fields.length; i++) {
+          var field = fields[i];
+          if (record[field] !== undefined) {
+            parts.push(escapeHtml(field) + "=" + escapeHtml(formatFieldValue(record[field])));
+          }
+        }
+        return parts.join(", ");
+      }
+
+      function repoCell(record) {
+        if (!record.repo) return '<span class="muted">private</span>';
+        var issuePart = record.issue ? " #" + escapeHtml(record.issue) : "";
+        return escapeHtml(record.repo) + issuePart;
+      }
+
+      if (!feed || typeof EventSource === "undefined") return;
+
+      // Read-only: this is the ONLY network call the live feed makes — a GET
+      // against the public live-tail route, never the authenticated surface
+      // and never a mutation.
+      var source = new EventSource("/public/events");
+      source.onmessage = function (evt) {
+        var payload;
+        try {
+          payload = JSON.parse(evt.data);
+        } catch (err) {
+          return;
+        }
+        var topic = payload && payload.topic;
+        if (!topic || !Object.prototype.hasOwnProperty.call(DISPLAY_FIELDS, topic)) return; // e.g. tokens.snapshot — never rendered
+        var event = payload.event || {};
+        var record = event.record || {};
+
+        var row = document.createElement("tr");
+        row.innerHTML =
+          "<td>" + escapeHtml(event.emittedAt) + "</td>" +
+          "<td>" + escapeHtml(event.hostId) + "</td>" +
+          "<td>" + escapeHtml(topic) + "</td>" +
+          "<td>" + repoCell(record) + "</td>" +
+          "<td>" + formatDetails(topic, record) + "</td>";
+        feed.insertBefore(row, feed.firstChild);
+        while (feed.children.length > MAX_ROWS) {
+          feed.removeChild(feed.lastChild);
+        }
+      };
+    })();
+  </script>`;
+}
+
+// ---------------------------------------------------------------------------
+// Full page
+// ---------------------------------------------------------------------------
+
+const PAGE_STYLE = `
+  body { font-family: system-ui, sans-serif; margin: 2rem; color: #1a1a1a; background: #fafafa; }
+  h1 { margin-bottom: 0.25rem; }
+  .subtitle { color: #555; margin-top: 0; }
+  table { border-collapse: collapse; width: 100%; margin-bottom: 1.5rem; background: #fff; }
+  th, td { border: 1px solid #ddd; padding: 0.4rem 0.6rem; text-align: left; font-size: 0.9rem; }
+  th { background: #f0f0f0; }
+  .muted { color: #999; font-style: italic; }
+  section { margin-bottom: 2.5rem; }
+`;
+
+/**
+ * Render the full `/public` HTML document from already-redacted data.
+ * `snapshot`/`history` MUST already have passed through
+ * `redactFleetSnapshot`/`redactHistoryQueryResult` with `isAuthenticated:
+ * false` — this function performs no redaction itself, only formatting, per
+ * the module doc's single-enforcement-point rule (`redaction.ts` owns
+ * redaction; this module owns display).
+ */
+export function renderPublicPage(snapshot: RedactedFleetSnapshot, history: HistoryQueryResult): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Loom Fleet — Public View</title>
+  <style>${PAGE_STYLE}</style>
+</head>
+<body>
+  <h1>Loom Fleet — Public View</h1>
+  <p class="subtitle">
+    Unauthenticated, redacted snapshot of fleet activity. Private-repository
+    records show only aggregate lifecycle/timing detail — never a repo name,
+    issue, branch, or PR link. Data sourced exclusively from
+    <code>/public/*</code>.
+  </p>
+
+  ${renderFleetOverview(snapshot)}
+  ${renderHistoryTable(history)}
+
+  <section id="live-feed">
+    <h2>Live feed</h2>
+    <table>
+      <thead><tr><th>Emitted</th><th>Host</th><th>Kind</th><th>Repo / Issue</th><th>Detail</th></tr></thead>
+      <tbody id="live-feed-body"><tr><td colspan="5" class="muted">Waiting for events&hellip;</td></tr></tbody>
+    </table>
+  </section>
+
+  ${renderLiveFeedScript()}
+</body>
+</html>`;
+}

--- a/dashboard/test/publicPage.test.ts
+++ b/dashboard/test/publicPage.test.ts
@@ -1,0 +1,346 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import worker from "../src/index";
+import { isPublicPageDisplayKind, renderFleetOverview, renderHistoryTable, renderPublicPage } from "../src/publicPage";
+import type { HistoryQueryResult, HistoryRecord } from "../src/query";
+import type { PublicActiveSweep, RedactedFleetSnapshot } from "../src/redaction";
+import { seedHost, sweepOutcomeEnvelope, sweepStartedEnvelope, tokensSnapshotEnvelope } from "./testHelpers";
+
+// ---------------------------------------------------------------------------
+// Redaction test suite for the `/public` page itself (issue #4753's AC:
+// "Automated redaction test/snapshot asserting the rendered public page
+// contains zero occurrences of repo names, issue titles, branch names, or PR
+// links for a private-repo fixture record").
+//
+// The fixtures below feed data through this page exactly the way the real
+// `/public` route does: pretend-redacted objects shaped the way
+// `redactFleetSnapshot`/`redactHistoryQueryResult` actually produce them
+// (private records have repo/issue/sweepId already nulled/absent, per-kind
+// payload already allowlisted) — `publicPage.ts`'s job is to format that
+// faithfully, not to redact, so these tests exercise the formatting layer
+// with adversarial leftover fields to catch a rendering-side leak.
+// ---------------------------------------------------------------------------
+
+const PRIVATE_REPO_NAME = "rjwalters/super-secret-repo";
+const PRIVATE_ISSUE_TITLE = "Fix the embarrassing private bug";
+const PRIVATE_BRANCH = "feature/issue-9999";
+const PRIVATE_SWEEP_ID = "sweep-issue-9999-0";
+const PRIVATE_PR_LINK = "https://github.com/rjwalters/super-secret-repo/pull/9999";
+
+const PUBLIC_REPO_NAME = "rjwalters/loom";
+
+function privateHistoryFixture(): HistoryRecord {
+  // Shaped exactly like `redactHistoryRecord`'s output for a private,
+  // unauthenticated record: repo/issue/sweepId nulled, payload reduced to
+  // the sweep.outcome allowlist — plus adversarial fields
+  // (`branch`/`issue_title`/`pr_link`) that must never survive even if a
+  // future bug reintroduces them into the payload upstream of this module.
+  return {
+    id: 1,
+    schemaVersion: 1,
+    emittedAt: "2026-07-31T12:00:00Z",
+    hostId: "host-abc",
+    kind: "sweep.outcome",
+    repo: null,
+    visibility: "private",
+    issue: null,
+    sweepId: null,
+    ingestedAt: "2026-07-31T12:00:01Z",
+    record: {
+      kind: "sweep.outcome",
+      model: "opus",
+      effort: "high",
+      result: "success",
+      total_duration_sec: 512,
+      // Adversarial: these fields should never appear on a real redacted
+      // payload, but if a bug ever put them there, this page must still not
+      // render them (formatDetails only reads its own display allowlist).
+      branch: PRIVATE_BRANCH,
+      issue_title: PRIVATE_ISSUE_TITLE,
+      pr_link: PRIVATE_PR_LINK,
+      repo: PRIVATE_REPO_NAME,
+      sweep_id: PRIVATE_SWEEP_ID,
+    },
+  };
+}
+
+function publicHistoryFixture(): HistoryRecord {
+  return {
+    id: 2,
+    schemaVersion: 1,
+    emittedAt: "2026-07-31T12:05:00Z",
+    hostId: "host-abc",
+    kind: "sweep.outcome",
+    repo: PUBLIC_REPO_NAME,
+    visibility: "public",
+    issue: 4703,
+    sweepId: "sweep-issue-4703-0",
+    ingestedAt: "2026-07-31T12:05:01Z",
+    record: {
+      kind: "sweep.outcome",
+      repo: PUBLIC_REPO_NAME,
+      visibility: "public",
+      issue: 4703,
+      sweep_id: "sweep-issue-4703-0",
+      model: "opus",
+      effort: "high",
+      result: "success",
+      total_duration_sec: 340,
+    },
+  };
+}
+
+function tokensHistoryFixture(): HistoryRecord {
+  // tokens.snapshot passes through the API unredacted (documented Phase-2
+  // decision) — this page must still never render it (issue #4753's
+  // resolution of the #4752 exposure question).
+  return {
+    id: 3,
+    schemaVersion: 1,
+    emittedAt: "2026-07-31T12:06:00Z",
+    hostId: "host-abc",
+    kind: "tokens.snapshot",
+    repo: null,
+    visibility: "private",
+    issue: null,
+    sweepId: null,
+    ingestedAt: "2026-07-31T12:06:01Z",
+    record: {
+      kind: "tokens.snapshot",
+      captured_at: "2026-07-31T12:06:00Z",
+      accounts: [{ account: "agent-9@2amlogic.com", rank: 0, usage_fraction: 0.42, exhausted: false }],
+    },
+  };
+}
+
+function privateActiveSweepFixture(): PublicActiveSweep {
+  // Shaped like `redactActiveSweep`'s output: repo/issue/sweepId entirely
+  // absent (not null), only lifecycle/model fields survive.
+  return {
+    hostId: "host-abc",
+    visibility: "private",
+    phase: "builder",
+    startedAt: "2026-07-31T12:00:00Z",
+    enteredPhaseAt: "2026-07-31T12:03:00Z",
+    model: "opus",
+    effort: "high",
+    updatedAt: "2026-07-31T12:03:00Z",
+  };
+}
+
+function publicActiveSweepFixture(): PublicActiveSweep {
+  return {
+    hostId: "host-abc",
+    visibility: "public",
+    repo: PUBLIC_REPO_NAME,
+    issue: 4703,
+    sweepId: "sweep-issue-4703-0",
+    phase: "builder",
+    startedAt: "2026-07-31T12:00:00Z",
+    enteredPhaseAt: "2026-07-31T12:03:00Z",
+    model: "opus",
+    effort: "high",
+    updatedAt: "2026-07-31T12:03:00Z",
+  };
+}
+
+function snapshotFixture(): RedactedFleetSnapshot {
+  return {
+    hosts: {
+      "host-abc": {
+        health: {
+          record: { kind: "host.health", captured_at: "2026-07-31T12:00:00Z", uptime_sec: 100, logical_cpus: 8 },
+          updatedAt: "2026-07-31T12:00:00Z",
+        },
+        // Present on the redacted snapshot exactly as the real API returns
+        // it (tokens.snapshot is unredacted at the API layer) — this page
+        // must still never render `accounts`.
+        tokens: {
+          record: {
+            kind: "tokens.snapshot",
+            captured_at: "2026-07-31T12:00:00Z",
+            accounts: [{ account: "agent-9@2amlogic.com", rank: 0, usage_fraction: 0.9, exhausted: false }],
+          },
+          updatedAt: "2026-07-31T12:00:00Z",
+        },
+      },
+    },
+    activeSweeps: [privateActiveSweepFixture(), publicActiveSweepFixture()],
+  };
+}
+
+function historyFixture(): HistoryQueryResult {
+  return {
+    records: [privateHistoryFixture(), publicHistoryFixture(), tokensHistoryFixture()],
+    nextCursor: null,
+  };
+}
+
+describe("renderFleetOverview — redaction", () => {
+  it("a private active sweep renders no repo/issue/sweepId; a public one renders full detail", () => {
+    const html = renderFleetOverview(snapshotFixture());
+    expect(html).toContain(PUBLIC_REPO_NAME);
+    expect(html).toContain("#4703");
+    expect(html).toContain("sweep-issue-4703-0");
+    // Private sweep still renders its safe lifecycle fields.
+    expect(html).toContain("builder");
+    expect(html).toContain("opus");
+  });
+
+  it("never renders tokens.snapshot account identifiers, even though the redacted snapshot carries them unredacted", () => {
+    const html = renderFleetOverview(snapshotFixture());
+    expect(html).not.toContain("agent-9@2amlogic.com");
+    expect(html).not.toContain("accounts");
+  });
+
+  it("renders host.health lifecycle detail", () => {
+    const html = renderFleetOverview(snapshotFixture());
+    expect(html).toContain("uptime_sec=100");
+  });
+});
+
+describe("renderHistoryTable — redaction", () => {
+  it("a private-repo record renders zero occurrences of the repo name, issue title, branch name, or PR link", () => {
+    const html = renderHistoryTable(historyFixture());
+    expect(html).not.toContain(PRIVATE_REPO_NAME);
+    expect(html).not.toContain(PRIVATE_ISSUE_TITLE);
+    expect(html).not.toContain(PRIVATE_BRANCH);
+    expect(html).not.toContain(PRIVATE_PR_LINK);
+    expect(html).not.toContain(PRIVATE_SWEEP_ID);
+    expect(html).not.toContain("9999");
+  });
+
+  it("a private-repo record renders only its per-kind allowlisted fields", () => {
+    const html = renderHistoryTable({ records: [privateHistoryFixture()], nextCursor: null });
+    expect(html).toContain("private</span>"); // repo cell placeholder
+    expect(html).toContain("model=opus");
+    expect(html).toContain("effort=high");
+    expect(html).toContain("result=success");
+    expect(html).toContain("total_duration_sec=512");
+  });
+
+  it("a public-repo record renders full detail: repo, issue, sweepId", () => {
+    const html = renderHistoryTable({ records: [publicHistoryFixture()], nextCursor: null });
+    expect(html).toContain(PUBLIC_REPO_NAME);
+    expect(html).toContain("#4703");
+    expect(html).toContain("sweep-issue-4703-0");
+  });
+
+  it("never renders tokens.snapshot rows at all", () => {
+    const html = renderHistoryTable(historyFixture());
+    expect(html).not.toContain("agent-9@2amlogic.com");
+    expect(html).not.toContain("tokens.snapshot");
+  });
+
+  it("isPublicPageDisplayKind excludes tokens.snapshot and includes the sweep.* / host.health kinds", () => {
+    expect(isPublicPageDisplayKind("tokens.snapshot")).toBe(false);
+    expect(isPublicPageDisplayKind("sweep.outcome")).toBe(true);
+    expect(isPublicPageDisplayKind("host.health")).toBe(true);
+    expect(isPublicPageDisplayKind("some.future.kind")).toBe(false);
+  });
+});
+
+describe("renderPublicPage — full document", () => {
+  const html = renderPublicPage(snapshotFixture(), historyFixture());
+
+  it("contains zero occurrences of the private repo name, issue title, branch name, sweep id, or PR link", () => {
+    expect(html).not.toContain(PRIVATE_REPO_NAME);
+    expect(html).not.toContain(PRIVATE_ISSUE_TITLE);
+    expect(html).not.toContain(PRIVATE_BRANCH);
+    expect(html).not.toContain(PRIVATE_SWEEP_ID);
+    expect(html).not.toContain(PRIVATE_PR_LINK);
+  });
+
+  it("contains zero occurrences of token account identifiers", () => {
+    expect(html).not.toContain("agent-9@2amlogic.com");
+  });
+
+  it("renders full detail for the public-repo record/sweep", () => {
+    expect(html).toContain(PUBLIC_REPO_NAME);
+    expect(html).toContain("sweep-issue-4703-0");
+  });
+
+  it("is read-only: no <form> elements and no mutating fetch/EventSource call", () => {
+    expect(html).not.toContain("<form");
+    expect(html.toLowerCase()).not.toContain('method="post"');
+    expect(html.toLowerCase()).not.toContain("method: \"post\"");
+    expect(html.toLowerCase()).not.toContain("method:'post'");
+  });
+
+  it("never references /api/*, /admin/*, or /ingest — only /public/*", () => {
+    expect(html).not.toContain("/api/");
+    expect(html).not.toContain("/admin/");
+    expect(html).not.toContain("/ingest");
+    expect(html).toContain("/public/events");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: the actual GET /public route, through the real Worker + D1 +
+// Durable Object, mirroring test/redaction.test.ts's integration style.
+// ---------------------------------------------------------------------------
+
+async function callWorker(request: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(request as Request<unknown, IncomingRequestCfProperties>, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
+function ingestRequest(body: unknown, authHeader = "Bearer abc-ingest-key"): Request {
+  return new Request("https://ingest.example/ingest", {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: authHeader },
+    body: JSON.stringify(body),
+  });
+}
+
+async function ingest(envelopes: unknown[]): Promise<Response> {
+  return callWorker(ingestRequest(envelopes));
+}
+
+beforeEach(async () => {
+  await seedHost(env.DB, "host-abc", "abc-ingest-key");
+});
+
+describe("GET /public — end to end", () => {
+  it("serves an HTML page reachable without authentication", async () => {
+    const response = await callWorker(new Request("https://ingest.example/public"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/html");
+  });
+
+  it("a private sweep.outcome record's repo/issue/sweep_id never appear on the rendered page", async () => {
+    await ingest([
+      sweepOutcomeEnvelope({
+        visibility: "private",
+        repo: "rjwalters/e2e-private-repo",
+        issue: 8888,
+        sweep_id: "sweep-issue-8888-0",
+      }),
+    ]);
+
+    const response = await callWorker(new Request("https://ingest.example/public"));
+    const html = await response.text();
+    expect(html).not.toContain("rjwalters/e2e-private-repo");
+    expect(html).not.toContain("sweep-issue-8888-0");
+    expect(html).not.toContain("8888");
+  });
+
+  it("a public sweep.started record's repo/issue appear on the rendered page (full detail)", async () => {
+    await ingest([sweepStartedEnvelope({ visibility: "public", repo: "rjwalters/loom", issue: 4703 })]);
+
+    const response = await callWorker(new Request("https://ingest.example/public"));
+    const html = await response.text();
+    expect(html).toContain("rjwalters/loom");
+    expect(html).toContain("#4703");
+  });
+
+  it("tokens.snapshot's account identifiers never appear on the rendered page", async () => {
+    await ingest([tokensSnapshotEnvelope({ accounts: [{ account: "e2e-secret-account", rank: 0, usage_fraction: 0.5, exhausted: false }] })]);
+
+    const response = await callWorker(new Request("https://ingest.example/public"));
+    const html = await response.text();
+    expect(html).not.toContain("e2e-secret-account");
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Phase-3 public view page for the fleet observability epic (#4702): an unauthenticated `GET /public` route, served by the Workers backend, that renders the redacted fleet dataset the already-merged Phase-2 `/public/*` API surface produces.

## Changes

- **`dashboard/src/publicPage.ts`** (new): pure rendering module.
  - `renderFleetOverview` — hosts' latest health, plus active sweeps (host, visibility, repo/issue when present, phase, model, effort, timing).
  - `renderHistoryTable` — recent history rows, filtered to a display allowlist (`PUBLIC_PAGE_DISPLAY_FIELDS`).
  - `renderPublicPage` — full HTML document, plus an inline vanilla-JS live feed that opens `new EventSource("/public/events")` and renders newly-arrived frames through the *same* display allowlist (injected into the script as JSON so there is one source of truth for "what does this page show").
  - No DOM/browser APIs in the server-side render functions — they're plain, unit-testable string builders.
- **`dashboard/src/index.ts`**: new `GET /public` route + `handlePublicPage`, which calls `fleetStateStub`/`queryHistory` directly (the same in-process calls the existing `/public/fleet-state` and `/public/history` handlers make) and redacts with `isAuthenticated: false` before rendering — there is no HTTP round-trip through `/api/*` anywhere in this path.
- **`dashboard/test/publicPage.test.ts`** (new): 17 tests — unit tests on the render functions with adversarial private-repo fixtures (repo name, issue title, branch, sweep id, PR link, token account identifier), plus end-to-end tests hitting the real `GET /public` route through the Workers test runtime (D1 + Durable Object).
- **`dashboard/README.md`**: added `GET /public` to the route table.

### Token/cost widget decision (resolves the open question from #4752)

`tokens.snapshot` passes through `/public/fleet-state` / `/public/history` unredacted at the API layer (documented, already-merged Phase-2 decision — it has no `repo` field to key the private/public split off). Its `accounts[].account` field is a per-account identifier that is not one of the epic's four named leak vectors (repo/issue/branch/PR) but is reasonably sensitive on its own.

**Decision made here**: this page never renders `tokens.snapshot` — not in the fleet overview, not in history, not in the live feed — regardless of what the API technically returns. `PUBLIC_PAGE_DISPLAY_FIELDS` simply has no entry for that kind, so it's excluded by construction (an allowlist, not a special case), and `isPublicPageDisplayKind("tokens.snapshot")` is `false`. This is documented in `publicPage.ts`'s module doc; a future authenticated-only or aggregate/non-identifying token widget is left to whatever implements #4752.

## Acceptance Criteria Verification

- [x] Public page served at `/public`, using only `/public/*` data — `handlePublicPage` calls the same in-process functions `/public/fleet-state` and `/public/history` use (not an HTTP fetch to `/api/*`); the live feed's only network call is `new EventSource("/public/events")`. Verified by a test asserting the rendered page contains `/public/events` and never `/api/`, `/admin/`, or `/ingest`.
- [x] Private-repo records render none of `repo`/`issue`/`sweepId`, only per-kind allowlisted fields — verified with adversarial fixtures (leftover `repo`/`branch`/`issue_title`/`pr_link`/`sweep_id` fields that must never survive formatting) at both the render-function level and the end-to-end route level.
- [x] Public-repo records render full detail (repo, issue, sweep id) — verified.
- [x] Automated redaction test/snapshot asserting zero occurrences of repo names, issue titles, branch names, or PR links for a private-repo fixture — `renderPublicPage`/`renderHistoryTable`/`renderFleetOverview` tests in `publicPage.test.ts`, plus an end-to-end `GET /public` test.
- [x] Token/account exposure question resolved — see above; tested (`agent-9@2amlogic.com` / `e2e-secret-account` fixtures never appear in rendered output, including via the DO's `tokens` field on the fleet snapshot).
- [x] Read-only — no `<form>`, no mutating call anywhere on the page; verified by a test. No in-Worker "am I authenticated" branch was added (route publicness stays an infrastructure property, per the issue's implementation guidance).

## Test Plan

- `npm run check` (typecheck + `vitest run`) — 100/100 tests pass across the whole `dashboard/` suite, including the 17 new `publicPage.test.ts` tests.
- Manual verification (deploy + Cloudflare Access config) is out of scope for this PR — the `/public` Bypass application was already documented as reserved ahead of this page in `docs/cloudflare-access.md` §3b.

Closes #4753