### PR TITLE
feat(dashboard): add historical-charting data layer for fleet observability

### DIFF
--- a/dashboard/web/README.md
+++ b/dashboard/web/README.md
@@ -1,21 +1,27 @@
 # loom-fleet-dashboard-web
 
 Frontend for the Loom fleet observability dashboard
-([Epic #4702](https://github.com/rjwalters/loom/issues/4702), Phase 3):
-a live event feed panel and a per-sweep timeline view over the Phase 2
-query API (`dashboard/src/query.ts`, documented in
-[`../docs/query-api.md`](../docs/query-api.md)).
+([Epic #4702](https://github.com/rjwalters/loom/issues/4702), Phase 3), built
+on the Phase 2 query API (`dashboard/src/query.ts`, documented in
+[`../docs/query-api.md`](../docs/query-api.md)):
+
+- **Live view** ([#4750](https://github.com/rjwalters/loom/issues/4750)) — a
+  live event feed panel and a per-sweep timeline view over `GET /api/events`.
+- **Historical charts** ([#4751](https://github.com/rjwalters/loom/issues/4751))
+  — sweep outcomes over time, success-rate trends, and duration percentiles
+  over `GET /api/history` / `GET /public/history`.
 
 This is a minimal, self-contained scaffold — plain TypeScript, no UI
-framework — sufficient to implement and test the two Phase 3 components
-described in issue #4750. It is expected to be merged/rebased against
-whatever scaffold the sibling Fleet-overview issue (#4749) introduces for
-`dashboard/web/`; the logic modules here (`sseFeedClient.ts`,
-`timelineBuilder.ts`) are framework-independent and the two view modules
-(`liveFeedPanel.ts`, `sweepTimelineView.ts`) use plain DOM APIs so they can
-be adapted into whatever component model #4749 lands with.
+framework — sufficient to implement and test the Phase 3 logic. It is
+expected to be merged/rebased against whatever scaffold the sibling
+Fleet-overview issue ([#4749](https://github.com/rjwalters/loom/issues/4749))
+introduces for `dashboard/web/`; the logic modules here are
+framework-independent and the view modules use plain DOM APIs, so they can be
+adapted into whatever component model #4749 lands with.
 
 ## Modules
+
+### Live event feed + per-sweep timeline (#4750)
 
 - `src/sseFeedClient.ts` — `SseStreamParser` (incremental SSE frame
   parsing: `retry:` directives, `:`-comments, `data:` frames) and
@@ -33,9 +39,69 @@ be adapted into whatever component model #4749 lands with.
   timeline, including the terminal `result` and PR link derived from
   `sweep.outcome`'s `pr_number`.
 
+### Historical-charting data layer (#4751)
+
+- `src/historyClient.ts` — pages through `/api/history` (or
+  `/public/history`) via the keyset `nextCursor`, accumulating every record.
+  Takes the route's base path as a parameter
+  (`fetchAllHistory("/api/history", filter)` vs.
+  `fetchAllHistory("/public/history", filter)`) — one function, both routes,
+  no duplication (the last acceptance criterion of #4751).
+- `src/charts/correlate.ts` — joins `sweep.completed` and `sweep.outcome`
+  records by `sweepId` into one merged view per sweep (result + model +
+  phase/total durations), since those are two separate telemetry events for
+  the same sweep.
+- `src/charts/timeBuckets.ts` — UTC daily/weekly bucketing helper.
+- `src/charts/outcomes.ts` — outcomes-over-time: sweep counts by `result`,
+  bucketed daily or weekly.
+- `src/charts/successRate.ts` — success-rate trend, derived from the
+  outcomes-over-time buckets (not re-queried independently, so the two charts
+  can never disagree with each other).
+- `src/charts/durations.ts` — p50/p90/p99 duration percentiles, overall and
+  broken down by phase.
+
+**What's deliberately not here (yet):** rendered chart components
+(SVG/canvas/a charting library) and filter UI for the historical charts.
+Those depend on #4749's framework/build-tooling choice. Once that scaffold
+exists, wire a chart component to call `fetchAllHistory` + the relevant
+`charts/*` transform and render the result; every function in the chart layer
+takes and returns plain data, so it needs no adapter.
+
+## Filters
+
+`HistoryQueryFilter` (`src/historyClient.ts`) matches `GET /api/history`'s
+query parameters exactly: `host`, `repo`, `model`, `result`, `since`,
+`until`, `limit` (`cursor` is handled internally by `fetchAllHistory`'s
+pagination loop, not exposed to callers).
+
+## Usage
+
+```ts
+import {
+  fetchAllHistory,
+  buildOutcomesOverTime,
+  buildSuccessRateTrend,
+  buildDurationPercentiles,
+} from "./src/index.js";
+
+const records = await fetchAllHistory("/api/history", {
+  repo: "rjwalters/loom",
+  since: "2026-07-01T00:00:00Z",
+});
+
+const outcomeBuckets = buildOutcomesOverTime(records, "daily");
+const successRate = buildSuccessRateTrend(outcomeBuckets);
+const durationPercentiles = buildDurationPercentiles(records);
+```
+
+The exact same call with `"/public/history"` in place of `"/api/history"`
+works unchanged against the redacted public dataset — every transform
+tolerates the reduced `record` shape `/public/history` returns for
+`visibility: "private"` rows (see `HistoryRecord`'s doc in `src/types.ts`).
+
 ## Development
 
 ```bash
 npm install
-npm run check   # typecheck + vitest run
+npm run check   # typecheck (tsc --noEmit) + vitest run
 ```

--- a/dashboard/web/package.json
+++ b/dashboard/web/package.json
@@ -2,7 +2,7 @@
   "name": "loom-fleet-dashboard-web",
   "version": "0.1.0",
   "private": true,
-  "description": "Frontend for the Loom fleet observability dashboard (Epic #4702, Phase 3): live event feed + per-sweep timeline view over the Phase 2 query API (dashboard/src/query.ts).",
+  "description": "Frontend for the Loom fleet observability dashboard (Epic #4702, Phase 3): live event feed + per-sweep timeline view, and the historical-charting data layer (outcomes over time, success-rate trend, duration percentiles), over the Phase 2 query API (dashboard/src/query.ts).",
   "type": "module",
   "scripts": {
     "test": "vitest run",

--- a/dashboard/web/src/charts/correlate.ts
+++ b/dashboard/web/src/charts/correlate.ts
@@ -1,0 +1,150 @@
+/**
+ * Correlates `sweep.completed` and `sweep.outcome` records by `sweepId` into
+ * one merged view per sweep — the join issue #4751's implementation
+ * guidance calls for: `result` is authoritative on `sweep.completed` (the
+ * terminal-state event), while `phase_durations`/`total_duration_sec`/
+ * `model` only ever appear on `sweep.outcome` (see
+ * `.loom/docs/telemetry-schema.md`'s two record shapes). Both charts below
+ * (outcomes-over-time/success-rate and duration percentiles) build on this
+ * single merged representation rather than re-deriving the join themselves.
+ */
+
+import type { HistoryRecord, SweepResult, TelemetryRecord } from "../types.js";
+import { isSweepResult } from "../types.js";
+
+/** One phase's duration on a correlated sweep — the camelCased chart-layer
+ * counterpart of the wire-shape `SweepPhaseDuration` in `types.ts` (whose
+ * `duration_sec` is the verbatim ingested field name). */
+export interface PhaseDuration {
+  phase: string;
+  durationSec: number;
+}
+
+export interface CorrelatedSweep {
+  sweepId: string;
+  /** The canonical event time for this sweep, used for time-bucketing:
+   * `sweep.completed`'s `emittedAt` when present (the terminal-state
+   * moment), falling back to `sweep.outcome`'s otherwise. */
+  emittedAt: string;
+  result?: SweepResult;
+  model?: string;
+  totalDurationSec?: number;
+  phaseDurations: PhaseDuration[];
+}
+
+interface MutableCorrelatedSweep extends CorrelatedSweep {
+  /** Tracks whether `emittedAt` was set from a `sweep.completed` record yet
+   * (so a later `sweep.outcome` record for the same sweep, processed after
+   * the `sweep.completed`, never clobbers it — see `mergeSweepRecord`). */
+  emittedAtFromCompleted: boolean;
+}
+
+/**
+ * Read a record's `record` payload as an opaque key/value bag.
+ *
+ * `HistoryRecord.record` is typed as the `TelemetryRecord` discriminated
+ * union, but `/public/history` serves *redacted* payloads whose fields are a
+ * per-`kind` allowlist subset (see `dashboard/src/redaction.ts`), so the
+ * declared shape is an upper bound, not a guarantee. Every field below is
+ * therefore read defensively through `asString`/`asNumber` rather than off
+ * the union — which is also why this correlation works identically against
+ * `/api/history` and `/public/history`.
+ */
+function payloadOf(record: TelemetryRecord): Record<string, unknown> {
+  return record as Record<string, unknown>;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function parsePhaseDurations(value: unknown): PhaseDuration[] {
+  if (!Array.isArray(value)) return [];
+  const result: PhaseDuration[] = [];
+  for (const entry of value) {
+    if (entry && typeof entry === "object") {
+      const phase = asString((entry as Record<string, unknown>).phase);
+      const durationSec = asNumber((entry as Record<string, unknown>).duration_sec);
+      if (phase !== undefined && durationSec !== undefined) {
+        result.push({ phase, durationSec });
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Merge a batch of `HistoryRecord`s (any mix of kinds — non-sweep records
+ * are ignored) into one `CorrelatedSweep` per distinct `sweepId`.
+ *
+ * Idempotent and order-independent: calling this once over the full
+ * paginated set (from `fetchAllHistory`) or incrementally over successive
+ * pages and merging the resulting maps produces the same result, since each
+ * field is only ever set once matching data for it is seen and later,
+ * duplicate observations of the same field are no-ops (see
+ * `mergeInto`) — records missing `sweepId` (should not happen for these two
+ * kinds per the schema, but redaction never nulls it since `sweepId` is only
+ * omitted for `visibility: "private"` records, which drop the whole
+ * correlatable identity) are skipped.
+ */
+export function correlateSweeps(records: HistoryRecord[]): Map<string, CorrelatedSweep> {
+  const bySweepId = new Map<string, MutableCorrelatedSweep>();
+
+  for (const record of records) {
+    if (record.kind !== "sweep.completed" && record.kind !== "sweep.outcome") continue;
+    if (!record.sweepId) continue;
+
+    let entry = bySweepId.get(record.sweepId);
+    if (!entry) {
+      entry = {
+        sweepId: record.sweepId,
+        emittedAt: record.emittedAt,
+        phaseDurations: [],
+        emittedAtFromCompleted: false,
+      };
+      bySweepId.set(record.sweepId, entry);
+    }
+
+    mergeInto(entry, record);
+  }
+
+  // Strip the internal-only tracking field before handing back to callers.
+  const result = new Map<string, CorrelatedSweep>();
+  for (const [sweepId, entry] of bySweepId) {
+    const { emittedAtFromCompleted: _unused, ...rest } = entry;
+    result.set(sweepId, rest);
+  }
+  return result;
+}
+
+function mergeInto(entry: MutableCorrelatedSweep, record: HistoryRecord): void {
+  const payload = payloadOf(record.record);
+
+  if (record.kind === "sweep.completed") {
+    // sweep.completed is the terminal-state moment; always trust its
+    // emittedAt/result as authoritative once seen.
+    entry.emittedAt = record.emittedAt;
+    entry.emittedAtFromCompleted = true;
+    const result = asString(payload.result);
+    if (isSweepResult(result)) entry.result = result;
+  } else {
+    // sweep.outcome: only use its emittedAt as a fallback (never overwrite
+    // an already-seen sweep.completed timestamp), but its model/duration
+    // fields have no other source.
+    if (!entry.emittedAtFromCompleted) entry.emittedAt = record.emittedAt;
+    if (entry.result === undefined) {
+      const result = asString(payload.result);
+      if (isSweepResult(result)) entry.result = result;
+    }
+    const model = asString(payload.model);
+    if (model !== undefined) entry.model = model;
+    const totalDurationSec = asNumber(payload.total_duration_sec);
+    if (totalDurationSec !== undefined) entry.totalDurationSec = totalDurationSec;
+    const phaseDurations = parsePhaseDurations(payload.phase_durations);
+    if (phaseDurations.length > 0) entry.phaseDurations = phaseDurations;
+  }
+}

--- a/dashboard/web/src/charts/durations.ts
+++ b/dashboard/web/src/charts/durations.ts
@@ -1,0 +1,88 @@
+/**
+ * Duration percentile chart (issue #4751, AC3): p50/p90/p99 for
+ * `total_duration_sec`, plus a breakdown by phase from `phase_durations`.
+ * Built on `correlateSweeps` (`total_duration_sec`/`phase_durations` only
+ * ever appear on `sweep.outcome` records — see that module's doc).
+ */
+
+import type { HistoryRecord } from "../types.js";
+import { correlateSweeps } from "./correlate.js";
+
+export type PercentileRank = 50 | 90 | 99;
+
+export const DEFAULT_PERCENTILES: readonly PercentileRank[] = [50, 90, 99] as const;
+
+/** One entry per requested percentile rank, e.g. `{50: 12.5, 90: 40, 99:
+ * 88}`. */
+export type PercentileResult = Partial<Record<PercentileRank, number>>;
+
+/**
+ * Nearest-rank percentile over a (not-necessarily-sorted) set of values.
+ * `values` must be non-empty; callers should skip percentile computation
+ * entirely for an empty set rather than call this (see
+ * `buildDurationPercentiles`, which does exactly that).
+ *
+ * Nearest-rank (as opposed to linear interpolation) is used because it
+ * always returns an actually-observed duration value — useful for a metric
+ * like sweep duration, where "the 90th-percentile sweep took this long" is a
+ * more meaningful statement than an interpolated value between two
+ * durations that never happened.
+ */
+export function computePercentiles(values: number[], ranks: readonly PercentileRank[] = DEFAULT_PERCENTILES): PercentileResult {
+  if (values.length === 0) {
+    throw new Error("computePercentiles: values must be non-empty");
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const result: PercentileResult = {};
+  for (const rank of ranks) {
+    // Nearest-rank: index = ceil(rank/100 * N) - 1, clamped into range.
+    const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil((rank / 100) * sorted.length) - 1));
+    result[rank] = sorted[index];
+  }
+  return result;
+}
+
+export interface DurationPercentiles {
+  /** Percentiles over `total_duration_sec` across every correlated sweep
+   * that has one. `undefined` when no sweep in the input has a known total
+   * duration. */
+  overall: PercentileResult | undefined;
+  /** Percentiles over each phase's `duration_sec`, across every sweep that
+   * recorded that phase — e.g. `{curator: {50: 12, ...}, builder: {50: 340,
+   * ...}}`. A phase absent from every sweep in the input is simply absent
+   * from this map. */
+  byPhase: Record<string, PercentileResult>;
+}
+
+export function buildDurationPercentiles(
+  records: HistoryRecord[],
+  ranks: readonly PercentileRank[] = DEFAULT_PERCENTILES,
+): DurationPercentiles {
+  const sweeps = [...correlateSweeps(records).values()];
+
+  const totalDurations = sweeps
+    .map((sweep) => sweep.totalDurationSec)
+    .filter((value): value is number => value !== undefined);
+
+  const byPhaseDurations = new Map<string, number[]>();
+  for (const sweep of sweeps) {
+    for (const phaseDuration of sweep.phaseDurations) {
+      const existing = byPhaseDurations.get(phaseDuration.phase);
+      if (existing) {
+        existing.push(phaseDuration.durationSec);
+      } else {
+        byPhaseDurations.set(phaseDuration.phase, [phaseDuration.durationSec]);
+      }
+    }
+  }
+
+  const byPhase: Record<string, PercentileResult> = {};
+  for (const [phase, durations] of byPhaseDurations) {
+    byPhase[phase] = computePercentiles(durations, ranks);
+  }
+
+  return {
+    overall: totalDurations.length > 0 ? computePercentiles(totalDurations, ranks) : undefined,
+    byPhase,
+  };
+}

--- a/dashboard/web/src/charts/outcomes.ts
+++ b/dashboard/web/src/charts/outcomes.ts
@@ -1,0 +1,52 @@
+/**
+ * Outcomes-over-time chart data (issue #4751, AC1): count of sweeps by
+ * `result`, bucketed by time. Built on `correlateSweeps` — a sweep only
+ * contributes to a bucket once it has a known `result` (i.e. once its
+ * `sweep.completed` or `sweep.outcome` record has been observed); a sweep
+ * still in flight (no terminal record yet) is simply absent, not counted as
+ * any result.
+ */
+
+import type { HistoryRecord, SweepResult } from "../types.js";
+import { correlateSweeps } from "./correlate.js";
+import { type BucketGranularity, groupByTimeBucket } from "./timeBuckets.js";
+
+export const SWEEP_RESULTS: readonly SweepResult[] = ["success", "failure", "cancelled", "blocked"] as const;
+
+export interface OutcomeBucket {
+  bucketKey: string;
+  counts: Record<SweepResult, number>;
+  total: number;
+}
+
+function emptyCounts(): Record<SweepResult, number> {
+  return { success: 0, failure: 0, cancelled: 0, blocked: 0 };
+}
+
+/**
+ * Build the outcomes-over-time series from a set of `HistoryRecord`s (any
+ * mix of kinds; only `sweep.completed`/`sweep.outcome` contribute). Buckets
+ * are returned in ascending (chronological) key order; a time range with no
+ * completed sweeps produces an empty array, not a zero-filled range —
+ * dense/zero-filled axes are a rendering-layer concern once real chart
+ * components exist (blocked on the frontend scaffold, issue #4749).
+ */
+export function buildOutcomesOverTime(
+  records: HistoryRecord[],
+  granularity: BucketGranularity = "daily",
+): OutcomeBucket[] {
+  const sweeps = [...correlateSweeps(records).values()].filter((sweep) => sweep.result !== undefined);
+  const buckets = groupByTimeBucket(sweeps, (sweep) => sweep.emittedAt, granularity);
+
+  const result: OutcomeBucket[] = [];
+  for (const [key, bucketSweeps] of buckets) {
+    const counts = emptyCounts();
+    for (const sweep of bucketSweeps) {
+      // Guaranteed defined by the filter above; narrow for the type checker.
+      const outcomeResult = sweep.result;
+      if (outcomeResult) counts[outcomeResult] += 1;
+    }
+    result.push({ bucketKey: key, counts, total: bucketSweeps.length });
+  }
+  return result;
+}

--- a/dashboard/web/src/charts/successRate.ts
+++ b/dashboard/web/src/charts/successRate.ts
@@ -1,0 +1,26 @@
+/**
+ * Success-rate trend chart (issue #4751, AC2) — "derived from the same
+ * data" as the outcomes-over-time chart, per the acceptance criteria: this
+ * module takes `OutcomeBucket[]` (from `outcomes.ts`) rather than
+ * re-querying/re-correlating raw records, so the two charts are always
+ * consistent with each other by construction.
+ */
+
+import type { OutcomeBucket } from "./outcomes.js";
+
+export interface SuccessRatePoint {
+  bucketKey: string;
+  /** `success / total`, in `[0, 1]`. `null` when the bucket has zero
+   * completed sweeps — a rate is undefined for an empty bucket, and a chart
+   * should render a gap there rather than a misleading `0`. */
+  successRate: number | null;
+  total: number;
+}
+
+export function buildSuccessRateTrend(buckets: OutcomeBucket[]): SuccessRatePoint[] {
+  return buckets.map((bucket) => ({
+    bucketKey: bucket.bucketKey,
+    successRate: bucket.total > 0 ? bucket.counts.success / bucket.total : null,
+    total: bucket.total,
+  }));
+}

--- a/dashboard/web/src/charts/timeBuckets.ts
+++ b/dashboard/web/src/charts/timeBuckets.ts
@@ -1,0 +1,61 @@
+/**
+ * Time-bucketing helper shared by the outcomes-over-time and success-rate
+ * charts (issue #4751). Buckets are computed in UTC so the same input
+ * produces the same bucket key regardless of the caller's local timezone —
+ * `emittedAt` is always an RFC 3339 UTC timestamp (see
+ * `.loom/docs/telemetry-schema.md`).
+ */
+
+export type BucketGranularity = "daily" | "weekly";
+
+/** `YYYY-MM-DD` for `daily` (the UTC calendar day `emittedAt` falls in), or
+ * the `YYYY-MM-DD` of that UTC week's Monday for `weekly` (ISO-8601 week
+ * start) — a stable, sortable string key either way. */
+export function bucketKey(emittedAt: string, granularity: BucketGranularity): string {
+  const date = new Date(emittedAt);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`bucketKey: invalid emittedAt timestamp: ${emittedAt}`);
+  }
+
+  if (granularity === "daily") {
+    return isoDateUtc(date);
+  }
+
+  // Weekly: normalize to that week's Monday (ISO-8601 week start). UTC day
+  // 0 = Sunday ... 6 = Saturday; shift so Monday = 0.
+  const dayOfWeek = (date.getUTCDay() + 6) % 7;
+  const monday = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() - dayOfWeek),
+  );
+  return isoDateUtc(monday);
+}
+
+function isoDateUtc(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/** Group items into buckets keyed by `bucketKey(getTimestamp(item),
+ * granularity)`, returning buckets in ascending (chronological) key order.
+ * Buckets with no items in the input are never synthesized — callers who
+ * need a dense/zero-filled time axis (e.g. for a chart with no gaps) should
+ * fill missing keys themselves once they know the desired date range. */
+export function groupByTimeBucket<T>(
+  items: T[],
+  getTimestamp: (item: T) => string,
+  granularity: BucketGranularity,
+): Map<string, T[]> {
+  const buckets = new Map<string, T[]>();
+  for (const item of items) {
+    const key = bucketKey(getTimestamp(item), granularity);
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.push(item);
+    } else {
+      buckets.set(key, [item]);
+    }
+  }
+  return new Map([...buckets.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)));
+}

--- a/dashboard/web/src/historyClient.ts
+++ b/dashboard/web/src/historyClient.ts
@@ -1,0 +1,146 @@
+/**
+ * `GET /api/history` / `GET /public/history` client, with keyset-cursor
+ * pagination baked in — see `dashboard/docs/query-api.md`'s "`GET
+ * /api/history`" section for the wire contract this mirrors.
+ *
+ * **One client, two routes, no duplication** (issue #4751's last acceptance
+ * criterion): every function here takes the route's `basePath` as a plain
+ * string argument (`"/api/history"` or `"/public/history"`, or a fully
+ * qualified URL if the dashboard is served from a different origin than the
+ * Worker) — nothing here special-cases which one it is. The two routes
+ * return the exact same page/pagination shape; `/public/history` merely
+ * returns redacted `record` payloads for `visibility: "private"` rows (see
+ * `types.ts`'s `HistoryRecord` doc), which every downstream chart transform
+ * already tolerates.
+ */
+
+import type { HistoryQueryResult } from "./types.js";
+
+/** Every filter `GET /api/history` accepts, matching
+ * `dashboard/src/query.ts`'s `HistoryFilter` param-for-param (host, repo,
+ * model, result, since, until, limit) — see `dashboard/docs/query-api.md`.
+ * `cursor` is deliberately omitted here: pagination is `fetchAllHistory`'s
+ * job below, not something a chart-data caller should manage by hand. */
+export interface HistoryQueryFilter {
+  host?: string;
+  repo?: string;
+  model?: string;
+  result?: string;
+  /** RFC 3339 datetime — inclusive lower bound on `emittedAt`. */
+  since?: string;
+  /** RFC 3339 datetime — exclusive upper bound on `emittedAt`. */
+  until?: string;
+  /** Page size passed to the API (server caps at 500 regardless). Defaults
+   * to the server's own default (50) when omitted. Callers paging via
+   * `fetchAllHistory` generally want this at or near the 500 cap to
+   * minimize round trips. */
+  limit?: number;
+}
+
+/** Minimal shape of the subset of the `fetch` API this client needs — lets
+ * tests substitute a stub without pulling in a DOM/undici `Response`
+ * implementation, and lets a consumer pass any `fetch`-compatible
+ * implementation (native, a polyfill, an instrumented wrapper, ...). */
+export type FetchLike = (input: string, init?: { signal?: AbortSignal }) => Promise<{
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+}>;
+
+export class HistoryApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = "HistoryApiError";
+  }
+}
+
+function buildUrl(basePath: string, filter: HistoryQueryFilter, cursor: number | undefined): string {
+  const params = new URLSearchParams();
+  if (filter.host) params.set("host", filter.host);
+  if (filter.repo) params.set("repo", filter.repo);
+  if (filter.model) params.set("model", filter.model);
+  if (filter.result) params.set("result", filter.result);
+  if (filter.since) params.set("since", filter.since);
+  if (filter.until) params.set("until", filter.until);
+  if (filter.limit !== undefined) params.set("limit", String(filter.limit));
+  if (cursor !== undefined) params.set("cursor", String(cursor));
+
+  const query = params.toString();
+  return query ? `${basePath}?${query}` : basePath;
+}
+
+/** Fetch a single page. Thin wrapper — most callers want `fetchAllHistory`
+ * below instead; this is exposed for callers that want to manage
+ * pagination themselves (e.g. infinite-scroll UIs). */
+export async function fetchHistoryPage(
+  basePath: string,
+  filter: HistoryQueryFilter,
+  cursor?: number,
+  fetchImpl: FetchLike = fetch as unknown as FetchLike,
+  signal?: AbortSignal,
+): Promise<HistoryQueryResult> {
+  const url = buildUrl(basePath, filter, cursor);
+  const res = await fetchImpl(url, { signal });
+  const body = (await res.json()) as HistoryQueryResult | { error: string };
+  if (!res.ok) {
+    const message = "error" in body ? body.error : `history query failed with status ${res.status}`;
+    throw new HistoryApiError(message, res.status);
+  }
+  return body as HistoryQueryResult;
+}
+
+export interface FetchAllHistoryOptions {
+  fetchImpl?: FetchLike;
+  signal?: AbortSignal;
+  /** Safety cap on the number of pages fetched, so a server bug that never
+   * emits a `null` `nextCursor` cannot spin this loop forever. 10,000 pages
+   * at the 500-row max page size is 5,000,000 records — comfortably beyond
+   * any real chart's date range. */
+  maxPages?: number;
+}
+
+const DEFAULT_MAX_PAGES = 10_000;
+
+/**
+ * Page through `GET /api/history` (or `/public/history`) via `nextCursor`
+ * until the result set is exhausted, accumulating every record along the
+ * way. This is the pagination loop issue #4751's acceptance criteria call
+ * for: chart datasets must not assume a single unpaginated response covers
+ * the full requested range, since the API caps `limit` at 500.
+ *
+ * Ordering is preserved exactly as the API returns it (newest-first, by
+ * `id` descending) — each page's records are appended in the order received,
+ * and pages are fetched in strict `nextCursor` sequence, so no record is
+ * ever dropped or duplicated across the boundary between two pages.
+ */
+export async function fetchAllHistory(
+  basePath: string,
+  filter: HistoryQueryFilter,
+  options: FetchAllHistoryOptions = {},
+): Promise<HistoryQueryResult["records"]> {
+  const { fetchImpl = fetch as unknown as FetchLike, signal, maxPages = DEFAULT_MAX_PAGES } = options;
+
+  const records: HistoryQueryResult["records"] = [];
+  let cursor: number | undefined;
+  let pages = 0;
+
+  for (;;) {
+    const page = await fetchHistoryPage(basePath, filter, cursor, fetchImpl, signal);
+    records.push(...page.records);
+    pages += 1;
+
+    if (page.nextCursor === null) break;
+    if (pages >= maxPages) {
+      throw new Error(
+        `fetchAllHistory: exceeded maxPages=${maxPages} without reaching the end of the result set ` +
+          `(server never returned a null nextCursor) — aborting to avoid an unbounded fetch loop`,
+      );
+    }
+    cursor = page.nextCursor;
+  }
+
+  return records;
+}

--- a/dashboard/web/src/index.ts
+++ b/dashboard/web/src/index.ts
@@ -1,5 +1,28 @@
+/**
+ * Public entry point for `loom-fleet-dashboard-web` (Epic #4702, Phase 3).
+ *
+ * Two feature areas share one package because they share one wire contract
+ * (`types.ts`, mirroring `dashboard/src/query.ts`):
+ *  - **Live view** (#4750) — SSE feed client, timeline builder, and the panel
+ *    /timeline view components over `GET /api/events`.
+ *  - **Historical charts** (#4751) — a keyset-paginating `GET /api/history` /
+ *    `GET /public/history` client plus framework-agnostic transforms that turn
+ *    those records into chart-ready datasets.
+ */
+
+// Shared wire-format types.
 export * from "./types.js";
+
+// Live event feed + per-sweep timeline (#4750).
 export * from "./sseFeedClient.js";
 export * from "./timelineBuilder.js";
 export * from "./liveFeedPanel.js";
 export * from "./sweepTimelineView.js";
+
+// Historical-charting data layer (#4751).
+export * from "./historyClient.js";
+export * from "./charts/timeBuckets.js";
+export * from "./charts/correlate.js";
+export * from "./charts/outcomes.js";
+export * from "./charts/successRate.js";
+export * from "./charts/durations.js";

--- a/dashboard/web/src/types.ts
+++ b/dashboard/web/src/types.ts
@@ -10,7 +10,16 @@
  * `schema_version` semantics section).
  */
 
+/** The terminal results `sweep.completed`/`sweep.outcome`'s `result` field
+ * takes on (`dashboard/docs/query-api.md`'s `result` query-param table). */
 export type SweepResult = "success" | "failure" | "cancelled" | "blocked";
+
+/** Runtime narrowing for `SweepResult`, used by transforms that read `result`
+ * out of a `record` payload (which is verbatim ingested JSON, so its `result`
+ * arrives as an unvalidated `unknown`). */
+export function isSweepResult(value: unknown): value is SweepResult {
+  return value === "success" || value === "failure" || value === "cancelled" || value === "blocked";
+}
 
 export type SweepPhaseName = "curator" | "builder" | "judge" | "doctor" | "merge";
 
@@ -101,7 +110,17 @@ export interface LiveTailFrame {
   event: LiveTailEvent;
 }
 
-/** A single row from `GET /api/history`'s `records` array. */
+/**
+ * A single row from `GET /api/history`'s (or `GET /public/history`'s)
+ * `records` array, camelCased exactly as the API returns it.
+ *
+ * On `/public/history`, a `visibility: "private"` row has `repo`/`issue`/
+ * `sweepId` nulled and `record` reduced to a per-`kind` field allowlist —
+ * see `dashboard/src/redaction.ts`. Transforms over these rows must
+ * therefore tolerate missing fields rather than trust `record`'s declared
+ * shape, so that the same code works against either route with no
+ * redaction-awareness of its own.
+ */
 export interface HistoryRecord {
   id: number;
   schemaVersion: number;
@@ -114,4 +133,13 @@ export interface HistoryRecord {
   sweepId?: string | null;
   ingestedAt: string;
   record: TelemetryRecord;
+}
+
+/** One page of `GET /api/history` / `GET /public/history` — mirrors
+ * `dashboard/src/query.ts`'s `HistoryQueryResult`. */
+export interface HistoryQueryResult {
+  records: HistoryRecord[];
+  /** `id` of the last record on this page, or `null` at the end of the
+   * matching result set. Pass back as `?cursor=` to fetch the next page. */
+  nextCursor: number | null;
 }

--- a/dashboard/web/test/correlate.test.ts
+++ b/dashboard/web/test/correlate.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { correlateSweeps } from "../src/charts/correlate.js";
+import { makeCompletedSweepPair, makeSweepCompleted, makeSweepOutcome, resetFixtureIds } from "./fixtures.js";
+
+beforeEach(() => {
+  resetFixtureIds();
+});
+
+describe("correlateSweeps", () => {
+  it("merges a sweep.completed + sweep.outcome pair by sweepId", () => {
+    const records = makeCompletedSweepPair({
+      sweepId: "sweep-1",
+      emittedAt: "2026-07-30T12:08:32Z",
+      result: "success",
+      model: "opus",
+      totalDurationSec: 512,
+      phaseDurations: [
+        { phase: "curator", duration_sec: 12 },
+        { phase: "builder", duration_sec: 340 },
+      ],
+    });
+
+    const correlated = correlateSweeps(records);
+    expect(correlated.size).toBe(1);
+    const sweep = correlated.get("sweep-1");
+    expect(sweep).toEqual({
+      sweepId: "sweep-1",
+      emittedAt: "2026-07-30T12:08:32Z",
+      result: "success",
+      model: "opus",
+      totalDurationSec: 512,
+      phaseDurations: [
+        { phase: "curator", durationSec: 12 },
+        { phase: "builder", durationSec: 340 },
+      ],
+    });
+  });
+
+  it("is order-independent (outcome before completed, or vice versa)", () => {
+    const pairA = makeCompletedSweepPair({
+      sweepId: "sweep-1",
+      emittedAt: "2026-07-30T12:08:32Z",
+      result: "failure",
+      model: "sonnet",
+      totalDurationSec: 100,
+      phaseDurations: [{ phase: "builder", duration_sec: 100 }],
+    });
+    const reversed = [...pairA].reverse();
+
+    const forward = correlateSweeps(pairA);
+    const backward = correlateSweeps(reversed);
+    expect(backward.get("sweep-1")).toEqual(forward.get("sweep-1"));
+  });
+
+  it("handles a sweep.completed record with no matching sweep.outcome (still in-flight telemetry)", () => {
+    const record = makeSweepCompleted({
+      sweepId: "sweep-only-completed",
+      emittedAt: "2026-07-30T12:00:00Z",
+      result: "cancelled",
+    });
+    const correlated = correlateSweeps([record]);
+    const sweep = correlated.get("sweep-only-completed");
+    expect(sweep?.result).toBe("cancelled");
+    expect(sweep?.totalDurationSec).toBeUndefined();
+    expect(sweep?.phaseDurations).toEqual([]);
+  });
+
+  it("handles a sweep.outcome record with no matching sweep.completed", () => {
+    const record = makeSweepOutcome({
+      sweepId: "sweep-only-outcome",
+      emittedAt: "2026-07-30T12:00:00Z",
+      result: "success",
+      model: "opus",
+      totalDurationSec: 42,
+      phaseDurations: [{ phase: "judge", duration_sec: 42 }],
+    });
+    const correlated = correlateSweeps([record]);
+    const sweep = correlated.get("sweep-only-outcome");
+    expect(sweep?.result).toBe("success");
+    expect(sweep?.totalDurationSec).toBe(42);
+    expect(sweep?.emittedAt).toBe("2026-07-30T12:00:00Z");
+  });
+
+  it("prefers sweep.completed's emittedAt/result over sweep.outcome's when both are present", () => {
+    const outcome = makeSweepOutcome({
+      sweepId: "sweep-1",
+      emittedAt: "2026-07-30T11:55:00Z",
+      result: "success",
+      model: "opus",
+      totalDurationSec: 200,
+    });
+    const completed = makeSweepCompleted({
+      sweepId: "sweep-1",
+      emittedAt: "2026-07-30T12:00:00Z",
+      result: "success",
+    });
+    const correlated = correlateSweeps([outcome, completed]);
+    expect(correlated.get("sweep-1")?.emittedAt).toBe("2026-07-30T12:00:00Z");
+  });
+
+  it("ignores unrelated record kinds", () => {
+    const unrelated = makeSweepCompleted({ sweepId: "sweep-1", emittedAt: "2026-07-30T12:00:00Z", result: "success" });
+    unrelated.kind = "sweep.started";
+    const correlated = correlateSweeps([unrelated]);
+    expect(correlated.size).toBe(0);
+  });
+
+  it("skips records with a null sweepId (fully redacted private rows)", () => {
+    const record = makeSweepCompleted({ sweepId: "sweep-1", emittedAt: "2026-07-30T12:00:00Z", result: "success" });
+    record.sweepId = null;
+    const correlated = correlateSweeps([record]);
+    expect(correlated.size).toBe(0);
+  });
+
+  it("is idempotent when the same record appears twice (e.g. an overlapping page boundary)", () => {
+    const records = makeCompletedSweepPair({
+      sweepId: "sweep-1",
+      emittedAt: "2026-07-30T12:00:00Z",
+      result: "success",
+      model: "opus",
+      totalDurationSec: 10,
+      phaseDurations: [{ phase: "builder", duration_sec: 10 }],
+    });
+    const duplicated = [...records, ...records];
+    const correlated = correlateSweeps(duplicated);
+    expect(correlated.size).toBe(1);
+    expect(correlated.get("sweep-1")?.phaseDurations).toEqual([{ phase: "builder", durationSec: 10 }]);
+  });
+});

--- a/dashboard/web/test/durations.test.ts
+++ b/dashboard/web/test/durations.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { buildDurationPercentiles, computePercentiles } from "../src/charts/durations.js";
+import { makeCompletedSweepPair, makeSweepCompleted, resetFixtureIds } from "./fixtures.js";
+
+beforeEach(() => {
+  resetFixtureIds();
+});
+
+describe("computePercentiles", () => {
+  it("computes nearest-rank percentiles over a known 10-element set", () => {
+    // 10 values, 10..100 step 10. Nearest-rank: index = ceil(rank/100*10)-1.
+    const values = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+    const result = computePercentiles(values, [50, 90, 99]);
+    // p50 -> ceil(5)-1 = 4 -> values[4] = 50
+    expect(result[50]).toBe(50);
+    // p90 -> ceil(9)-1 = 8 -> values[8] = 90
+    expect(result[90]).toBe(90);
+    // p99 -> ceil(9.9)-1 = 9 -> values[9] = 100
+    expect(result[99]).toBe(100);
+  });
+
+  it("is insensitive to input order", () => {
+    const sorted = [1, 2, 3, 4, 5];
+    const shuffled = [5, 1, 4, 2, 3];
+    expect(computePercentiles(shuffled)).toEqual(computePercentiles(sorted));
+  });
+
+  it("handles a single-element set (all percentiles equal the one value)", () => {
+    const result = computePercentiles([42]);
+    expect(result).toEqual({ 50: 42, 90: 42, 99: 42 });
+  });
+
+  it("throws on an empty set", () => {
+    expect(() => computePercentiles([])).toThrow(/non-empty/);
+  });
+});
+
+describe("buildDurationPercentiles", () => {
+  it("computes overall total-duration percentiles and a per-phase breakdown", () => {
+    const records = [
+      ...makeCompletedSweepPair({
+        sweepId: "s1",
+        emittedAt: "2026-07-28T00:00:00Z",
+        result: "success",
+        model: "opus",
+        totalDurationSec: 100,
+        phaseDurations: [
+          { phase: "curator", duration_sec: 10 },
+          { phase: "builder", duration_sec: 90 },
+        ],
+      }),
+      ...makeCompletedSweepPair({
+        sweepId: "s2",
+        emittedAt: "2026-07-28T01:00:00Z",
+        result: "failure",
+        model: "opus",
+        totalDurationSec: 200,
+        phaseDurations: [
+          { phase: "curator", duration_sec: 20 },
+          { phase: "builder", duration_sec: 180 },
+        ],
+      }),
+    ];
+
+    const result = buildDurationPercentiles(records);
+    expect(result.overall).toEqual(computePercentiles([100, 200]));
+    expect(result.byPhase.curator).toEqual(computePercentiles([10, 20]));
+    expect(result.byPhase.builder).toEqual(computePercentiles([90, 180]));
+  });
+
+  it("omits `overall` when no sweep has a known total duration", () => {
+    const record = makeSweepCompleted({ sweepId: "s1", emittedAt: "2026-07-28T00:00:00Z", result: "success" });
+    const result = buildDurationPercentiles([record]);
+    expect(result.overall).toBeUndefined();
+    expect(result.byPhase).toEqual({});
+  });
+
+  it("only includes a phase that appears in at least one sweep", () => {
+    const records = makeCompletedSweepPair({
+      sweepId: "s1",
+      emittedAt: "2026-07-28T00:00:00Z",
+      result: "success",
+      model: "opus",
+      totalDurationSec: 10,
+      phaseDurations: [{ phase: "judge", duration_sec: 10 }],
+    });
+    const result = buildDurationPercentiles(records);
+    expect(Object.keys(result.byPhase)).toEqual(["judge"]);
+  });
+
+  it("returns an empty result for no records", () => {
+    const result = buildDurationPercentiles([]);
+    expect(result.overall).toBeUndefined();
+    expect(result.byPhase).toEqual({});
+  });
+});

--- a/dashboard/web/test/fixtures.ts
+++ b/dashboard/web/test/fixtures.ts
@@ -1,0 +1,109 @@
+import type { HistoryRecord } from "../src/types.js";
+
+let nextId = 1;
+
+/** Reset the fixture id counter between tests that care about exact `id`
+ * values (most don't). */
+export function resetFixtureIds(): void {
+  nextId = 1;
+}
+
+export function makeSweepCompleted(overrides: {
+  sweepId: string;
+  emittedAt: string;
+  result: string;
+  repo?: string;
+  hostId?: string;
+  id?: number;
+}): HistoryRecord {
+  return {
+    id: overrides.id ?? nextId++,
+    schemaVersion: 1,
+    emittedAt: overrides.emittedAt,
+    hostId: overrides.hostId ?? "host-a",
+    kind: "sweep.completed",
+    repo: overrides.repo ?? "rjwalters/loom",
+    visibility: "public",
+    issue: 1000,
+    sweepId: overrides.sweepId,
+    ingestedAt: overrides.emittedAt,
+    record: {
+      kind: "sweep.completed",
+      repo: overrides.repo ?? "rjwalters/loom",
+      visibility: "public",
+      issue: 1000,
+      sweep_id: overrides.sweepId,
+      completed_at: overrides.emittedAt,
+      result: overrides.result,
+    },
+  };
+}
+
+export function makeSweepOutcome(overrides: {
+  sweepId: string;
+  emittedAt: string;
+  result?: string;
+  model?: string;
+  totalDurationSec?: number;
+  phaseDurations?: { phase: string; duration_sec: number }[];
+  repo?: string;
+  hostId?: string;
+  id?: number;
+}): HistoryRecord {
+  return {
+    id: overrides.id ?? nextId++,
+    schemaVersion: 1,
+    emittedAt: overrides.emittedAt,
+    hostId: overrides.hostId ?? "host-a",
+    kind: "sweep.outcome",
+    repo: overrides.repo ?? "rjwalters/loom",
+    visibility: "public",
+    issue: 1000,
+    sweepId: overrides.sweepId,
+    ingestedAt: overrides.emittedAt,
+    record: {
+      kind: "sweep.outcome",
+      repo: overrides.repo ?? "rjwalters/loom",
+      visibility: "public",
+      issue: 1000,
+      sweep_id: overrides.sweepId,
+      model: overrides.model,
+      phase_durations: overrides.phaseDurations ?? [],
+      total_duration_sec: overrides.totalDurationSec,
+      result: overrides.result,
+    },
+  };
+}
+
+/** A full "sweep" fixture: paired `sweep.completed` + `sweep.outcome`
+ * records for one sweepId, the common case charts correlate. */
+export function makeCompletedSweepPair(args: {
+  sweepId: string;
+  emittedAt: string;
+  result: string;
+  model: string;
+  totalDurationSec: number;
+  phaseDurations: { phase: string; duration_sec: number }[];
+  repo?: string;
+  hostId?: string;
+}): HistoryRecord[] {
+  return [
+    makeSweepOutcome({
+      sweepId: args.sweepId,
+      emittedAt: args.emittedAt,
+      result: args.result,
+      model: args.model,
+      totalDurationSec: args.totalDurationSec,
+      phaseDurations: args.phaseDurations,
+      repo: args.repo,
+      hostId: args.hostId,
+    }),
+    makeSweepCompleted({
+      sweepId: args.sweepId,
+      emittedAt: args.emittedAt,
+      result: args.result,
+      repo: args.repo,
+      hostId: args.hostId,
+    }),
+  ];
+}

--- a/dashboard/web/test/historyClient.test.ts
+++ b/dashboard/web/test/historyClient.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchAllHistory, fetchHistoryPage, HistoryApiError, type FetchLike } from "../src/historyClient.js";
+import type { HistoryQueryResult, HistoryRecord } from "../src/types.js";
+
+function record(id: number): HistoryRecord {
+  return {
+    id,
+    schemaVersion: 1,
+    emittedAt: "2026-07-30T12:00:00Z",
+    hostId: "host-a",
+    kind: "sweep.completed",
+    repo: "rjwalters/loom",
+    visibility: "public",
+    issue: 1000,
+    sweepId: `sweep-${id}`,
+    ingestedAt: "2026-07-30T12:00:01Z",
+    record: { kind: "sweep.completed", result: "success" },
+  };
+}
+
+/** Build a `FetchLike` stub backed by an in-memory map of pages, keyed by
+ * the `cursor` query param (`"none"` for the first page). Records every URL
+ * it was called with so tests can assert on query-string construction. */
+function stubFetch(pages: Record<string, HistoryQueryResult>): { fetchImpl: FetchLike; calls: string[] } {
+  const calls: string[] = [];
+  const fetchImpl: FetchLike = async (url: string) => {
+    calls.push(url);
+    const parsed = new URL(url, "http://example.test");
+    const cursor = parsed.searchParams.get("cursor") ?? "none";
+    const page = pages[cursor];
+    if (!page) throw new Error(`stubFetch: no page registered for cursor=${cursor} (url=${url})`);
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return page;
+      },
+    };
+  };
+  return { fetchImpl, calls };
+}
+
+describe("fetchHistoryPage", () => {
+  it("builds the query string with the documented filter params", async () => {
+    const { fetchImpl, calls } = stubFetch({
+      none: { records: [record(1)], nextCursor: null },
+    });
+    await fetchHistoryPage(
+      "/api/history",
+      { host: "host-a", repo: "rjwalters/loom", model: "opus", result: "success", since: "2026-07-01T00:00:00Z", until: "2026-08-01T00:00:00Z", limit: 500 },
+      undefined,
+      fetchImpl,
+    );
+    expect(calls).toHaveLength(1);
+    const url = new URL(calls[0] ?? "", "http://example.test");
+    expect(url.pathname).toBe("/api/history");
+    expect(Object.fromEntries(url.searchParams.entries())).toEqual({
+      host: "host-a",
+      repo: "rjwalters/loom",
+      model: "opus",
+      result: "success",
+      since: "2026-07-01T00:00:00Z",
+      until: "2026-08-01T00:00:00Z",
+      limit: "500",
+    });
+  });
+
+  it("includes cursor when paginating", async () => {
+    const { fetchImpl, calls } = stubFetch({
+      "42": { records: [record(1)], nextCursor: null },
+    });
+    await fetchHistoryPage("/api/history", {}, 42, fetchImpl);
+    const url = new URL(calls[0] ?? "", "http://example.test");
+    expect(url.searchParams.get("cursor")).toBe("42");
+  });
+
+  it("works unchanged against /public/history", async () => {
+    const { fetchImpl, calls } = stubFetch({
+      none: { records: [record(1)], nextCursor: null },
+    });
+    await fetchHistoryPage("/public/history", { repo: "rjwalters/loom" }, undefined, fetchImpl);
+    expect(calls[0]).toMatch(/^\/public\/history\?/);
+  });
+
+  it("throws HistoryApiError with the server's error message on a non-ok response", async () => {
+    const fetchImpl: FetchLike = async () => ({
+      ok: false,
+      status: 400,
+      async json() {
+        return { error: "since must be an RFC 3339 datetime" };
+      },
+    });
+    await expect(fetchHistoryPage("/api/history", { since: "bad" }, undefined, fetchImpl)).rejects.toThrow(
+      HistoryApiError,
+    );
+    await expect(fetchHistoryPage("/api/history", { since: "bad" }, undefined, fetchImpl)).rejects.toThrow(
+      "since must be an RFC 3339 datetime",
+    );
+  });
+});
+
+describe("fetchAllHistory", () => {
+  it("accumulates records across multiple nextCursor pages without dropping or duplicating", async () => {
+    const { fetchImpl, calls } = stubFetch({
+      none: { records: [record(30), record(29), record(28)], nextCursor: 28 },
+      "28": { records: [record(27), record(26)], nextCursor: 26 },
+      "26": { records: [record(25)], nextCursor: null },
+    });
+
+    const records = await fetchAllHistory("/api/history", {}, { fetchImpl });
+
+    expect(records.map((r) => r.id)).toEqual([30, 29, 28, 27, 26, 25]);
+    expect(calls).toHaveLength(3);
+  });
+
+  it("stops after a single page when nextCursor is null immediately", async () => {
+    const { fetchImpl, calls } = stubFetch({
+      none: { records: [record(1)], nextCursor: null },
+    });
+    const records = await fetchAllHistory("/api/history", {}, { fetchImpl });
+    expect(records.map((r) => r.id)).toEqual([1]);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("returns an empty array when the first page has no records", async () => {
+    const { fetchImpl } = stubFetch({ none: { records: [], nextCursor: null } });
+    const records = await fetchAllHistory("/api/history", {}, { fetchImpl });
+    expect(records).toEqual([]);
+  });
+
+  it("propagates the caller's filter to every page request", async () => {
+    const calls: string[] = [];
+    const fetchImpl: FetchLike = async (url: string) => {
+      calls.push(url);
+      const parsed = new URL(url, "http://example.test");
+      const cursor = parsed.searchParams.get("cursor");
+      if (cursor === null) return { ok: true, status: 200, async json() { return { records: [record(2)], nextCursor: 2 }; } };
+      return { ok: true, status: 200, async json() { return { records: [record(1)], nextCursor: null }; } };
+    };
+    await fetchAllHistory("/api/history", { repo: "rjwalters/loom", model: "opus" }, { fetchImpl });
+    for (const url of calls) {
+      const parsed = new URL(url, "http://example.test");
+      expect(parsed.searchParams.get("repo")).toBe("rjwalters/loom");
+      expect(parsed.searchParams.get("model")).toBe("opus");
+    }
+  });
+
+  it("aborts with a clear error instead of looping forever if the server never returns a null nextCursor", async () => {
+    let callCount = 0;
+    const fetchImpl: FetchLike = async () => {
+      callCount += 1;
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          // Always claims there's a next page, at a cursor that never
+          // changes meaningfully — simulates a buggy/misbehaving server.
+          return { records: [record(callCount)], nextCursor: 1 } satisfies HistoryQueryResult;
+        },
+      };
+    };
+    await expect(fetchAllHistory("/api/history", {}, { fetchImpl, maxPages: 5 })).rejects.toThrow(/maxPages=5/);
+    expect(callCount).toBe(5);
+  });
+
+  it("uses vi.fn() as a drop-in FetchLike for simple single-page cases", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ records: [record(1)], nextCursor: null }),
+    }));
+    const records = await fetchAllHistory("/api/history", {}, { fetchImpl });
+    expect(records).toHaveLength(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/dashboard/web/test/outcomes.test.ts
+++ b/dashboard/web/test/outcomes.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { buildOutcomesOverTime } from "../src/charts/outcomes.js";
+import { makeCompletedSweepPair, makeSweepCompleted, resetFixtureIds } from "./fixtures.js";
+
+beforeEach(() => {
+  resetFixtureIds();
+});
+
+describe("buildOutcomesOverTime", () => {
+  it("counts sweeps by result, bucketed daily", () => {
+    const records = [
+      ...makeCompletedSweepPair({
+        sweepId: "s1",
+        emittedAt: "2026-07-28T10:00:00Z",
+        result: "success",
+        model: "opus",
+        totalDurationSec: 100,
+        phaseDurations: [],
+      }),
+      ...makeCompletedSweepPair({
+        sweepId: "s2",
+        emittedAt: "2026-07-28T14:00:00Z",
+        result: "failure",
+        model: "opus",
+        totalDurationSec: 50,
+        phaseDurations: [],
+      }),
+      ...makeCompletedSweepPair({
+        sweepId: "s3",
+        emittedAt: "2026-07-29T09:00:00Z",
+        result: "success",
+        model: "sonnet",
+        totalDurationSec: 200,
+        phaseDurations: [],
+      }),
+    ];
+
+    const buckets = buildOutcomesOverTime(records, "daily");
+    expect(buckets).toEqual([
+      {
+        bucketKey: "2026-07-28",
+        counts: { success: 1, failure: 1, cancelled: 0, blocked: 0 },
+        total: 2,
+      },
+      {
+        bucketKey: "2026-07-29",
+        counts: { success: 1, failure: 0, cancelled: 0, blocked: 0 },
+        total: 1,
+      },
+    ]);
+  });
+
+  it("buckets weekly when requested", () => {
+    const records = [
+      makeSweepCompleted({ sweepId: "s1", emittedAt: "2026-07-27T00:00:00Z", result: "success" }),
+      makeSweepCompleted({ sweepId: "s2", emittedAt: "2026-07-30T00:00:00Z", result: "blocked" }),
+      makeSweepCompleted({ sweepId: "s3", emittedAt: "2026-08-03T00:00:00Z", result: "cancelled" }),
+    ];
+    const buckets = buildOutcomesOverTime(records, "weekly");
+    expect(buckets.map((b) => b.bucketKey)).toEqual(["2026-07-27", "2026-08-03"]);
+    expect(buckets[0]?.total).toBe(2);
+    expect(buckets[0]?.counts).toEqual({ success: 1, failure: 0, cancelled: 0, blocked: 1 });
+    expect(buckets[1]?.counts).toEqual({ success: 0, failure: 0, cancelled: 1, blocked: 0 });
+  });
+
+  it("excludes sweeps with no known result yet", () => {
+    // A sweep.outcome-only record with no result set at all (still running,
+    // hypothetically) should not appear in any bucket.
+    const inFlight = makeSweepCompleted({ sweepId: "s1", emittedAt: "2026-07-28T00:00:00Z", result: "success" });
+    inFlight.record = { ...inFlight.record, result: undefined };
+    const buckets = buildOutcomesOverTime([inFlight], "daily");
+    expect(buckets).toEqual([]);
+  });
+
+  it("returns an empty array for no records", () => {
+    expect(buildOutcomesOverTime([], "daily")).toEqual([]);
+  });
+
+  it("defaults to daily granularity", () => {
+    const record = makeSweepCompleted({ sweepId: "s1", emittedAt: "2026-07-28T00:00:00Z", result: "success" });
+    expect(buildOutcomesOverTime([record])).toEqual([
+      { bucketKey: "2026-07-28", counts: { success: 1, failure: 0, cancelled: 0, blocked: 0 }, total: 1 },
+    ]);
+  });
+});

--- a/dashboard/web/test/successRate.test.ts
+++ b/dashboard/web/test/successRate.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildSuccessRateTrend } from "../src/charts/successRate.js";
+import type { OutcomeBucket } from "../src/charts/outcomes.js";
+
+describe("buildSuccessRateTrend", () => {
+  it("computes success rate per bucket from outcome counts", () => {
+    const buckets: OutcomeBucket[] = [
+      { bucketKey: "2026-07-28", counts: { success: 3, failure: 1, cancelled: 0, blocked: 0 }, total: 4 },
+      { bucketKey: "2026-07-29", counts: { success: 0, failure: 2, cancelled: 0, blocked: 0 }, total: 2 },
+    ];
+    expect(buildSuccessRateTrend(buckets)).toEqual([
+      { bucketKey: "2026-07-28", successRate: 0.75, total: 4 },
+      { bucketKey: "2026-07-29", successRate: 0, total: 2 },
+    ]);
+  });
+
+  it("uses null (not 0) for an empty bucket, so a chart can render a gap", () => {
+    const buckets: OutcomeBucket[] = [
+      { bucketKey: "2026-07-28", counts: { success: 0, failure: 0, cancelled: 0, blocked: 0 }, total: 0 },
+    ];
+    expect(buildSuccessRateTrend(buckets)).toEqual([{ bucketKey: "2026-07-28", successRate: null, total: 0 }]);
+  });
+
+  it("returns an empty array for no buckets", () => {
+    expect(buildSuccessRateTrend([])).toEqual([]);
+  });
+});

--- a/dashboard/web/test/timeBuckets.test.ts
+++ b/dashboard/web/test/timeBuckets.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { bucketKey, groupByTimeBucket } from "../src/charts/timeBuckets.js";
+
+describe("bucketKey", () => {
+  it("buckets daily to the UTC calendar day", () => {
+    expect(bucketKey("2026-07-30T23:59:59Z", "daily")).toBe("2026-07-30");
+    expect(bucketKey("2026-07-30T00:00:00Z", "daily")).toBe("2026-07-30");
+  });
+
+  it("buckets weekly to the ISO week's Monday", () => {
+    // 2026-07-30 is a Thursday.
+    expect(bucketKey("2026-07-30T12:00:00Z", "weekly")).toBe("2026-07-27");
+    // Monday itself maps to its own date.
+    expect(bucketKey("2026-07-27T00:00:00Z", "weekly")).toBe("2026-07-27");
+    // Sunday maps to the *preceding* Monday (still that ISO week).
+    expect(bucketKey("2026-08-02T23:00:00Z", "weekly")).toBe("2026-07-27");
+    // The following Monday starts a new bucket.
+    expect(bucketKey("2026-08-03T00:00:00Z", "weekly")).toBe("2026-08-03");
+  });
+
+  it("throws on an invalid timestamp", () => {
+    expect(() => bucketKey("not-a-date", "daily")).toThrow(/invalid emittedAt/);
+  });
+});
+
+describe("groupByTimeBucket", () => {
+  it("groups items into ascending chronological bucket order", () => {
+    const items = [
+      { id: "c", ts: "2026-07-30T00:00:00Z" },
+      { id: "a", ts: "2026-07-28T00:00:00Z" },
+      { id: "b", ts: "2026-07-28T12:00:00Z" },
+    ];
+    const buckets = groupByTimeBucket(items, (item) => item.ts, "daily");
+    expect([...buckets.keys()]).toEqual(["2026-07-28", "2026-07-30"]);
+    expect(buckets.get("2026-07-28")?.map((item) => item.id)).toEqual(["a", "b"]);
+    expect(buckets.get("2026-07-30")?.map((item) => item.id)).toEqual(["c"]);
+  });
+
+  it("returns an empty map for empty input", () => {
+    const buckets = groupByTimeBucket<{ ts: string }>([], (item) => item.ts, "daily");
+    expect(buckets.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the chart **data layer** for Epic #4702 Phase 3's historical charts (issue #4751): paginating `GET /api/history` (or `/public/history`) via the keyset `nextCursor`, correlating `sweep.completed`/`sweep.outcome` records by `sweepId`, and transforming the result into chart-ready datasets (outcomes-over-time, success-rate trend, duration percentiles).

**Packaging note (rebased 2026-07-31).** This PR originally created `dashboard/web/` as its own package (`loom-observability-web`), because that directory did not exist on `main` when the work started. PR #4756 has since merged and **established** `dashboard/web/` as `loom-fleet-dashboard-web` (live event feed + per-sweep timeline). This PR has been rebased so its history/chart modules live **inside that existing package** rather than shipping a second, competing scaffold at the same path. Concretely:

- **Dropped** this PR's duplicate `package.json`, `package-lock.json`, `tsconfig.json`, and `vitest.config.ts` — #4756's versions are the only ones in the tree. The sole `package.json` change is a one-line `description` update covering both feature areas.
- **Removed** `src/historyTypes.ts`. Its `HistoryRecord` and `SweepResult` were duplicates of declarations already in #4756's `src/types.ts`; its genuinely new pieces (`HistoryQueryResult`, `isSweepResult`) moved into `src/types.ts`, and the chart-layer-only `PhaseDuration` moved into `src/charts/correlate.ts` alongside its only consumer. `src/types.ts` is now the single source of truth for the wire contract for both feature areas.
- **Merged** the two `README.md`s and `src/index.ts` export surfaces into one, organized by feature area.
- `correlate.ts` reads the `record` payload through a documented `payloadOf()` accessor, since `types.ts` types it as the `TelemetryRecord` union while `/public/history` serves *redacted* payloads whose fields are a per-`kind` allowlist subset — the declared shape is an upper bound, so fields are still read defensively via `asString`/`asNumber`.

**Why a partial increment, not a full close**: #4751's sibling issue #4749 (Fleet overview + multi-host drill-down) is the issue that establishes the shared frontend *rendering* scaffold — framework choice, build tooling, deploy target. It has not merged. #4751's own Dependencies section calls that dependency explicitly soft ("otherwise independently implementable"). So this PR ships the framework-agnostic data-transformation layer only — the part that is fully testable without a framework decision. Rendered chart components / UI wiring remain follow-up work once that scaffold exists (consistent with the issue's own note that rendering cannot be verified by an automated builder anyway).

## Changes

All under the existing `dashboard/web/` package (`loom-fleet-dashboard-web`):

- `src/historyClient.ts` — `fetchHistoryPage`/`fetchAllHistory`: pages through the API via `nextCursor` until exhausted, accumulating every record; one function works against `/api/history` or `/public/history` via a `basePath` parameter (no duplication); a `maxPages` safety cap guards against a server bug that never returns a `null` `nextCursor`.
- `src/charts/timeBuckets.ts` — UTC daily/weekly bucketing helper.
- `src/charts/correlate.ts` — joins `sweep.completed` + `sweep.outcome` records by `sweepId` into one merged view (result/model/phase+total durations); idempotent and order-independent.
- `src/charts/outcomes.ts` — outcomes-over-time: sweep counts by `result`, bucketed daily/weekly.
- `src/charts/successRate.ts` — success-rate trend, derived from the outcomes-over-time buckets (not re-queried independently, so the two can't disagree).
- `src/charts/durations.ts` — nearest-rank p50/p90/p99 percentiles over `total_duration_sec`, overall and broken down by phase from `phase_durations`.
- `src/types.ts` — extended with `HistoryQueryResult` + `isSweepResult`, and `HistoryRecord`'s doc now records the `/public/history` redaction contract.
- `src/index.ts`, `README.md` — merged export surface and docs covering both #4750's live view and #4751's charts.
- 39 new vitest tests across 6 files covering bucketing, correlation (including order-independence, idempotency, missing-counterpart records, redacted/null-`sweepId` rows), outcome counting, success-rate derivation, percentile computation, and the pagination loop (multi-page accumulation, filter propagation, error surfacing, the `maxPages` guard).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Outcomes-over-time chart: count of sweeps by `result`, bucketed daily/weekly | ✅ (data layer) | `buildOutcomesOverTime` + `test/outcomes.test.ts` |
| Success-rate trend chart derived from the same data | ✅ (data layer) | `buildSuccessRateTrend` takes `OutcomeBucket[]` directly, `test/successRate.test.ts` |
| Duration percentile chart (p50/p90/p99) with phase breakdown | ✅ (data layer) | `buildDurationPercentiles`/`computePercentiles` + `test/durations.test.ts` |
| Filters: `host`, `repo`, `model`, `since`/`until` — matching `GET /api/history`'s params exactly | ✅ | `HistoryQueryFilter` in `historyClient.ts` matches param-for-param; `test/historyClient.test.ts`'s query-string assertions |
| Pagination via keyset cursor rather than a single unpaginated response | ✅ | `fetchAllHistory` loops on `nextCursor`; `test/historyClient.test.ts`'s multi-page accumulation test |
| Same component points at `/public/history` without code duplication | ✅ | `basePath` parameter, exercised against both routes in `test/historyClient.test.ts` |
| Rendered chart UI / visual components | ⏸️ deferred | Blocked on #4749's frontend rendering scaffold; this PR ships only the framework-agnostic data layer feeding it |
| Manual verification: seed a realistic dataset, confirm charts render | ⏸️ not applicable yet | No renderer exists until #4749 lands; the issue itself notes this isn't something a builder subagent can do |

## Test Plan

```bash
cd dashboard/web
npm install
npm run check   # tsc --noEmit + vitest run
```

`69 passed (69)` across 10 files — this PR's 39 tests plus #4756's 30, all green in the single reconciled package. `tsc --noEmit` is clean.

Part of #4751
