### PR TITLE
feat(dashboard): add token burn-curve, forecast and per-repo attribution UI

### DIFF
--- a/dashboard/docs/token-analytics.md
+++ b/dashboard/docs/token-analytics.md
@@ -1,0 +1,130 @@
+# Token/cost analytics (Epic #4702, Phase 3 — issue #4752)
+
+Burn curves, limit-window forecasting, and per-repo attribution for the fleet
+dashboard UI. Implementation: [`../web/src/analytics/`](../web/src/analytics/)
+(`burn.ts`, `forecast.ts`, `attribution.ts`, `render.ts`); tests:
+[`../web/test/`](../web/test/).
+
+This document records the two questions the issue explicitly left open, and
+the answers this implementation commits to.
+
+## 1. Per-repo attribution: the join
+
+`tokens.snapshot` has **no `repo` field**. It is fleet-wide token-pool state
+(`.loom/docs/telemetry-schema.md`: "host-level — no `repo` / `visibility`"),
+so "which repo burned this quota" is not read off a record — it is *derived*,
+by joining the token history against the `sweep.*` records, which are the only
+ones carrying `repo`.
+
+### Join key: `hostId` + time overlap
+
+| Component | Kind | Why |
+|---|---|---|
+| `hostId` | **Hard key** (exact match) | A token pool is a per-host resource (`.loom/tokens/` lives on the machine running `loom-daemon`). Usage observed on host A can only have been spent by sweeps on host A. |
+| Time overlap | **Soft key** (interval overlap, not instant equality) | Nothing links a pool account to a sweep directly; co-occurrence in time is the only available evidence. |
+| `account` | **Dimension, not a key** | `tokens.snapshot` accounts have no `model`, and no `sweep.*` record has an `account`. The account a delta came from is known exactly, so it is reported as a breakdown — but it cannot narrow *which sweep* spent it. |
+| `model` | **Dimension, not a key** | Same reason, from the other side: `sweep.started.model` has no account to match against. `byModel` inherits whatever proportional split the sweeps got. |
+
+The issue sketched a "per account/model" join. That is not derivable from the
+telemetry as it exists — implementing it would mean inventing a correlation —
+so both fields are carried as *breakdowns of an already-computed attribution*
+instead.
+
+### The unit of attribution is an interval, not an instant
+
+Each consecutive pair of `tokens.snapshot` samples on one host defines a
+**usage interval** `[prev.captured_at, next.captured_at)` and, per account, a
+**usage delta** `next.usage_fraction - prev.usage_fraction`. That delta is the
+fleet's measured consumption over exactly that interval. Attribution is the
+question of who was running during it.
+
+For each interval, with all same-host sweep windows that overlap it:
+
+1. **Coverage** — the *union* of the overlapping windows (clipped to the
+   interval) decides how much of the delta is attributable at all. Usage is
+   assumed uniform across the interval, so an interval only 20% covered by
+   sweeps yields 20% attributable usage. Union, not sum: two concurrent sweeps
+   cover the same seconds once.
+2. **Split** — the attributable portion is divided among the overlapping
+   sweeps *in proportion to each sweep's own overlap duration* (sweep-seconds),
+   then summed per repo. Two sweeps covering the whole interval split it 50/50.
+3. **Remainder** — the uncovered share goes to **`unattributed`**.
+
+### Tolerances
+
+| Knob | Default | Rationale |
+|---|---|---|
+| `edgeToleranceMs` | **60 s** | Sweep windows are widened by this on both ends before overlap is tested. `captured_at` (pool sampler) and `started_at` (sweep) are independent daemon timestamps; without slack a sweep starting moments after a snapshot loses its first interval outright. Because coverage is proportional (above), a sweep that only touches an interval through this tolerance claims only those 60 seconds' worth — the slack cannot swallow a whole interval. |
+| `maxSampleGapMs` | **60 min** | A pair of snapshots further apart than this is dropped entirely (counted as `droppedIntervals`). The usage in between is real but unobserved; smearing an hours-wide delta across whatever sweeps happen to overlap it would be fiction. |
+| `openSweepMaxDurationMs` | **6 h** | A sweep with `sweep.started` but no terminal record is capped at this past its start (and at `now`), so one crashed sweep that never emitted `sweep.completed` cannot absorb the fleet's usage indefinitely. |
+
+All three are parameters of `attributeUsageToRepos`, defaulted, and covered by
+tests at and around their boundaries.
+
+### What the model deliberately does not claim
+
+- **A negative delta is a limit-window rollover, not negative usage.** That
+  interval is skipped for that account (`rolloverIntervals`), never attributed
+  and never subtracted.
+- **Unattributed usage is reported, never redistributed.** Support-role crons
+  (Judge/Champion/Curator), manual sessions, and anything else that does not
+  emit `sweep.*` telemetry burn real tokens. Spreading that across the repos
+  that *did* run sweeps would inflate every number on the page. A large
+  unattributed row is the signal that the attribution is not to be trusted —
+  which is exactly what it should be.
+- **Units are limit-window fractions**, not tokens or dollars: `1.00` = one
+  account's entire limit window. No absolute token count or price exists
+  anywhere in the telemetry, so none is synthesized.
+- **Attribution is evidential, not causal.** It says "these sweeps were running
+  while this quota was consumed", weighted by time. It is a good estimate at
+  fleet scale and a poor one for a single short interval; the coverage
+  footnote under the table exists so a reader can see which they are looking
+  at.
+
+## 2. Public-exposure decision: authenticated surface only
+
+**Decision: the token/cost analytics render on the authenticated route only.**
+
+Phase 2's redaction policy ([`../src/redaction.ts`](../src/redaction.ts))
+passes `tokens.snapshot` through **unredacted on both `/api` and `/public`** —
+the kind has no `repo` to key visibility off, so the private/public split has
+nothing to act on. That remains correct backend behavior and **this issue
+changes nothing in `redaction.ts`**. But "the API returns it" is not "the page
+should show it", and this is where that distinction is drawn:
+
+1. **Per-repo attribution is a repo-name table by construction.** Its entire
+   output is "which repositories consumed the fleet's quota" — and repo names
+   are precisely what Phase 2 strips from `/public/history` for
+   private-visibility sweeps. Publishing this panel would reconstruct, by
+   inference from timing, the exact fact the redaction layer removes.
+2. **Account identifiers are operator infrastructure.** `agent-3` +
+   `usage_fraction` + `limit_window_reset_at` is a live capacity map of the
+   operator's account pool: how many accounts exist, which are near their cap,
+   and when each recovers.
+3. **Exhaustion forecasts are a scheduling signal.** "This fleet runs dry in 40
+   minutes" should be a deliberate publication choice, not a side effect of
+   which route happens to permit it.
+
+### How it is enforced
+
+Two independent UI-layer points, neither of which is a redaction change:
+
+- [`web/src/analytics/render.ts`](../web/src/analytics/render.ts) —
+  `renderTokenAnalytics` / `mountTokenAnalytics` refuse to render on a
+  `"public"` surface and show a short "withheld" notice instead. On the public
+  surface `mountTokenAnalytics` **makes no request at all**; it does not fetch
+  and then hide.
+- [`web/src/analytics/api.ts`](../web/src/analytics/api.ts) — the fetch prefix
+  is the constant `/api`, not a parameter, so the view cannot be repointed at
+  `/public` by configuration.
+
+The surface itself is derived from the served path
+(`bootstrap.ts`'s `surfaceFromPath`), mirroring the backend's own route-based
+auth split — so a link cannot talk the panel into rendering publicly.
+
+### Coordination with the public view page (#4753)
+
+The public page should **not** embed these widgets. If a public capacity
+summary is wanted later, the right shape is a purpose-built aggregate (e.g.
+"fleet capacity: healthy / degraded") carrying no account names, no repo names,
+and no per-account timing — a new component, not a flag on this one.

--- a/dashboard/web/README.md
+++ b/dashboard/web/README.md
@@ -179,6 +179,33 @@ await panel.refresh();
 await panel.refresh({ since: "2026-07-01T00:00:00Z" });
 ```
 
+### Token/cost analytics (issue #4752)
+
+`src/analytics/` — burn curves, exhaustion forecasting, and per-repo
+attribution:
+
+| Module | Responsibility |
+|---|---|
+| `types.ts` | Analytics-specific wire + domain shapes, layered on the shared `src/types.ts` envelope |
+| `parse.ts` | Total, never-throwing narrowing of `GET /api/history` JSON |
+| `burn.ts` | Per-account burn curves, segmented at limit-window rollovers and telemetry gaps |
+| `forecast.ts` | Least-squares projection to exhaustion vs. `limit_window_reset_at` |
+| `attribution.ts` | The `tokens.snapshot` × `sweep.*` join that produces per-repo usage |
+| `render.ts` | DOM rendering, and the authenticated-surface-only enforcement point |
+| `api.ts` | Paginated `/api/history` fetch (the API has no `kind` filter, so kinds are partitioned client-side) |
+| `format.ts` | Formatting helpers ("unknown renders as `—`, never `0`") |
+| `bootstrap.ts` | `surfaceFromPath` + `startTokenAnalytics` — the hook an app shell calls. Deliberately not self-executing: the barrel re-exports it, and the barrel must stay importable under the `node` test environment. |
+| `analytics.css` | Stylesheet for the class names `render.ts` emits. Not imported by any module (there is no bundler to resolve a CSS import); an app shell links it, and it stands alone via `:root` custom-property fallbacks so it renders legibly either way. |
+
+The join strategy and the public-exposure decision are documented in
+[`../docs/token-analytics.md`](../docs/token-analytics.md).
+
+Integration point for the app shell: `mountTokenAnalytics(container, opts)`,
+or `startTokenAnalytics(document)` which resolves the surface from
+`window.location.pathname` and wires an optional `#refresh-button`. The
+panel renders on the **authenticated surface only** — on `/public` it
+refuses to render and makes no history request at all.
+
 ## Setup
 
 ```bash

--- a/dashboard/web/package.json
+++ b/dashboard/web/package.json
@@ -2,7 +2,7 @@
   "name": "loom-observability-web",
   "version": "0.1.0",
   "private": true,
-  "description": "Fleet observability dashboard UI (Epic #4702, Phase 3). Vite + vanilla TypeScript single-page app served as Workers Assets by the sibling loom-observability-ingest Worker: fleet overview + multi-host drill-down (#4749), live event feed + per-sweep timeline (#4750), and the historical-charting data layer — outcomes over time, success-rate trend, duration percentiles (#4751) — over the Phase 2 query API (dashboard/src/query.ts).",
+  "description": "Fleet observability dashboard UI (Epic #4702, Phase 3). Vite + vanilla TypeScript single-page app served as Workers Assets by the sibling loom-observability-ingest Worker: fleet overview + multi-host drill-down (#4749), live event feed + per-sweep timeline (#4750), the historical-charting data layer — outcomes over time, success-rate trend, duration percentiles (#4751) — and token/cost analytics — burn curves, forecasting, per-repo attribution (#4752) — over the Phase 2 query API (dashboard/src/query.ts).",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/dashboard/web/src/analytics/analytics.css
+++ b/dashboard/web/src/analytics/analytics.css
@@ -1,0 +1,212 @@
+/*
+ * Styles for the token/cost analytics panel (Epic #4702, Phase 3, #4752).
+ *
+ * Scoped to this panel's own class names so the app shell's layout styles and
+ * these can land independently. Colors come from CSS custom properties with
+ * fallbacks, so a shell that defines a palette wins and one that does not still
+ * renders legibly.
+ *
+ * The exhausted state is deliberately encoded three ways — a red border, a
+ * badge, and a strikethrough-free but high-contrast label — so it survives a
+ * grayscale display and a color-vision deficiency. Color alone is never the
+ * only signal (AC4).
+ */
+
+:root {
+  --analytics-fg: #e6e6e6;
+  --analytics-muted: #9aa0a6;
+  --analytics-bg: #14161a;
+  --analytics-panel: #1c1f24;
+  --analytics-line: #2b2f36;
+  --analytics-ok: #4ade80;
+  --analytics-warn: #fbbf24;
+  --analytics-danger: #f87171;
+}
+
+.analytics {
+  color: var(--analytics-fg);
+  font: 14px/1.45 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.analytics__title {
+  font-size: 1.1rem;
+  margin: 0 0 0.75rem;
+}
+
+.analytics__block {
+  margin: 0 0 1.75rem;
+}
+
+.analytics__heading {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+}
+
+.analytics__note {
+  color: var(--analytics-muted);
+  font-size: 0.8rem;
+  margin: 0.5rem 0 0;
+  max-width: 70ch;
+}
+
+.analytics__error {
+  color: var(--analytics-danger);
+  font-size: 0.85rem;
+}
+
+.analytics--withheld .analytics__note {
+  max-width: 60ch;
+}
+
+/* --- Burn curves --------------------------------------------------------- */
+
+.burn-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+}
+
+.burn-card {
+  background: var(--analytics-panel);
+  border: 1px solid var(--analytics-line);
+  border-radius: 6px;
+  padding: 0.6rem 0.7rem;
+}
+
+.burn-card--exhausted {
+  border-color: var(--analytics-danger);
+  box-shadow: inset 3px 0 0 0 var(--analytics-danger);
+}
+
+.burn-card__head {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-start;
+}
+
+.burn-card__account {
+  font-weight: 600;
+}
+
+.burn-card__host,
+.burn-card__at {
+  color: var(--analytics-muted);
+  font-size: 0.75rem;
+}
+
+.burn-card__foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.burn-card__usage {
+  font-size: 1.05rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.badge {
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  margin-left: auto;
+  padding: 0.1rem 0.45rem;
+}
+
+.badge--exhausted {
+  background: var(--analytics-danger);
+  color: #1a0000;
+}
+
+.badge--recovered {
+  border: 1px solid var(--analytics-warn);
+  color: var(--analytics-warn);
+}
+
+.sparkline {
+  display: block;
+  height: 48px;
+  margin: 0.4rem 0;
+  width: 100%;
+}
+
+.sparkline__line {
+  fill: none;
+  stroke: var(--analytics-ok);
+  stroke-width: 1.5;
+  vector-effect: non-scaling-stroke;
+}
+
+.burn-card--exhausted .sparkline__line {
+  stroke: var(--analytics-danger);
+}
+
+/* --- Tables -------------------------------------------------------------- */
+
+.table {
+  border-collapse: collapse;
+  font-size: 0.82rem;
+  width: 100%;
+}
+
+.table th {
+  border-bottom: 1px solid var(--analytics-line);
+  color: var(--analytics-muted);
+  font-weight: 600;
+  padding: 0.35rem 0.5rem;
+  text-align: left;
+}
+
+.table td {
+  border-bottom: 1px solid var(--analytics-line);
+  font-variant-numeric: tabular-nums;
+  padding: 0.35rem 0.5rem;
+  vertical-align: top;
+}
+
+.cell--account,
+.cell--repo {
+  font-variant-numeric: normal;
+  font-weight: 600;
+}
+
+.cell--host {
+  color: var(--analytics-muted);
+}
+
+.cell--negative {
+  color: var(--analytics-danger);
+}
+
+.row--at-risk {
+  background: rgb(248 113 113 / 8%);
+}
+
+.row--unattributed td {
+  color: var(--analytics-muted);
+  font-style: italic;
+}
+
+.status {
+  font-weight: 600;
+}
+
+.status--exhausted {
+  color: var(--analytics-danger);
+}
+
+.status--projected-exhaustion {
+  color: var(--analytics-warn);
+}
+
+.status--resets-first {
+  color: var(--analytics-ok);
+}
+
+.status--flat,
+.status--insufficient-data {
+  color: var(--analytics-muted);
+}

--- a/dashboard/web/src/analytics/api.ts
+++ b/dashboard/web/src/analytics/api.ts
@@ -1,0 +1,140 @@
+/**
+ * History fetching for the token/cost analytics view (Epic #4702, Phase 3,
+ * issue #4752).
+ *
+ * ## Why this paginates and filters client-side
+ *
+ * `GET /api/history` (`../../docs/query-api.md`) supports `host`/`repo`/
+ * `model`/`result`/`since`/`until`/`limit`/`cursor` — but **not `kind`**. The
+ * analytics need two record families (`tokens.snapshot` and the `sweep.*`
+ * lifecycle records), so the client pulls the time range it wants at the
+ * maximum page size and partitions by `kind` locally. `maxPages` caps the walk
+ * so a very busy fleet degrades to "the most recent N records" (the API
+ * returns newest-first) instead of hanging the page.
+ *
+ * A server-side `kind` filter would be a strict improvement and is the obvious
+ * follow-up, but it is a backend change — out of scope for this UI issue.
+ *
+ * ## `/api` only, never `/public`
+ *
+ * `API_PREFIX` is a constant, not a parameter. Per this issue's
+ * public-exposure decision (see `render.ts` and
+ * `../../docs/token-analytics.md`), the token/cost analytics are an
+ * authenticated-surface feature: the fetch path is pinned to `/api` so the
+ * view cannot be repointed at `/public` by configuration, and `render.ts`
+ * independently refuses to render on a public surface. Two enforcement points,
+ * because "the API technically returns it" is not the same as "the page should
+ * show it".
+ */
+
+import type { HistoryEnvelope } from "./types.js";
+
+/** Authenticated surface only — see the module doc. */
+const API_PREFIX = "/api";
+
+/** The API's own cap (`docs/query-api.md`: "Default 50, capped at 500"). */
+const MAX_PAGE_SIZE = 500;
+
+export interface HistoryPage {
+  records: HistoryEnvelope[];
+  nextCursor: number | null;
+}
+
+export interface FetchHistoryOptions {
+  /** Inclusive lower bound on `emitted_at` (epoch ms). */
+  since?: number;
+  /** Exclusive upper bound on `emitted_at` (epoch ms). */
+  until?: number;
+  /** Only this host. */
+  host?: string;
+  /** Page-walk cap. Default 10 pages (up to 5000 records). */
+  maxPages?: number;
+  /** Injectable for tests; defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+}
+
+/**
+ * Walk `GET /api/history` newest-first and return every record fetched.
+ *
+ * Throws on a non-2xx response (the caller renders the message); a malformed
+ * body yields an empty page rather than an exception, since one bad page
+ * should not discard the pages already collected.
+ */
+export async function fetchHistory(options: FetchHistoryOptions = {}): Promise<HistoryEnvelope[]> {
+  const doFetch = options.fetchImpl ?? globalThis.fetch;
+  const maxPages = options.maxPages ?? 10;
+  const collected: HistoryEnvelope[] = [];
+  let cursor: number | null = null;
+
+  for (let page = 0; page < maxPages; page += 1) {
+    const params = new URLSearchParams();
+    params.set("limit", String(MAX_PAGE_SIZE));
+    if (options.since !== undefined) params.set("since", new Date(options.since).toISOString());
+    if (options.until !== undefined) params.set("until", new Date(options.until).toISOString());
+    if (options.host !== undefined) params.set("host", options.host);
+    if (cursor !== null) params.set("cursor", String(cursor));
+
+    const response = await doFetch(`${API_PREFIX}/history?${params.toString()}`, {
+      signal: options.signal,
+      headers: { accept: "application/json" },
+    });
+    if (!response.ok) {
+      throw new Error(`GET ${API_PREFIX}/history returned ${response.status}`);
+    }
+
+    const parsed = await parsePage(response);
+    collected.push(...parsed.records);
+    if (parsed.nextCursor === null || parsed.records.length === 0) break;
+    cursor = parsed.nextCursor;
+  }
+
+  return collected;
+}
+
+async function parsePage(response: Response): Promise<HistoryPage> {
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return { records: [], nextCursor: null };
+  }
+  if (typeof body !== "object" || body === null) return { records: [], nextCursor: null };
+
+  const raw = (body as { records?: unknown }).records;
+  const records: HistoryEnvelope[] = [];
+  if (Array.isArray(raw)) {
+    for (const entry of raw) {
+      const envelope = narrowEnvelope(entry);
+      if (envelope) records.push(envelope);
+    }
+  }
+  const nextCursorRaw = (body as { nextCursor?: unknown }).nextCursor;
+  const nextCursor = typeof nextCursorRaw === "number" && Number.isFinite(nextCursorRaw) ? nextCursorRaw : null;
+  return { records, nextCursor };
+}
+
+/** Keep only rows with the three fields every downstream consumer requires
+ * (`id`, `hostId`, `kind`); anything else is a row this build cannot place. */
+function narrowEnvelope(value: unknown): HistoryEnvelope | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const row = value as Record<string, unknown>;
+  if (typeof row.id !== "number" || typeof row.hostId !== "string" || typeof row.kind !== "string") {
+    return undefined;
+  }
+  const record =
+    typeof row.record === "object" && row.record !== null && !Array.isArray(row.record)
+      ? (row.record as Record<string, unknown>)
+      : {};
+  return {
+    id: row.id,
+    emittedAt: typeof row.emittedAt === "string" ? row.emittedAt : "",
+    hostId: row.hostId,
+    kind: row.kind,
+    repo: typeof row.repo === "string" ? row.repo : null,
+    visibility: typeof row.visibility === "string" ? row.visibility : null,
+    issue: typeof row.issue === "number" ? row.issue : null,
+    sweepId: typeof row.sweepId === "string" ? row.sweepId : null,
+    record,
+  };
+}

--- a/dashboard/web/src/analytics/attribution.ts
+++ b/dashboard/web/src/analytics/attribution.ts
@@ -1,0 +1,362 @@
+/**
+ * Per-repo attribution of fleet-wide token usage (Epic #4702, Phase 3,
+ * issue #4752).
+ *
+ * ## The problem this module exists to solve
+ *
+ * `tokens.snapshot` has **no `repo` field** — it is fleet-wide token-pool
+ * state (`.loom/docs/telemetry-schema.md`: "host-level — no `repo` /
+ * `visibility`"). Nothing on the wire ever says "this account spent these
+ * tokens on that repository". The only records that carry `repo` are the
+ * `sweep.*` family. Attribution is therefore a **join**, and the join has to
+ * be stated explicitly rather than implied by a chart.
+ *
+ * ## The join, precisely
+ *
+ * **Join key: `hostId` + time overlap. Nothing else.**
+ *
+ * - `hostId` is a hard key: a token pool is a per-host resource, so usage
+ *   observed on host A can only have been spent by sweeps on host A.
+ * - Time overlap is the soft key, and it is applied to *intervals*, never to
+ *   instants. Each consecutive pair of `tokens.snapshot` samples on a host
+ *   defines a **usage interval** `[prev.captured_at, next.captured_at)` and,
+ *   per account, a **usage delta** `next.usage_fraction -
+ *   prev.usage_fraction`. That delta is the fleet's measured consumption over
+ *   exactly that interval — attributing it is the whole job.
+ * - Every sweep window on the same host that overlaps the interval is a
+ *   candidate consumer. Usage is assumed uniform across the interval, so:
+ *   - The **union** of all overlapping sweep windows (clipped to the interval)
+ *     decides how much of the delta is attributable at all. An interval only
+ *     10% covered by sweeps yields 10% attributable usage; the other 90% is
+ *     unattributed, because nothing was running for it.
+ *   - That attributable portion is then split across the overlapping sweeps
+ *     **in proportion to each sweep's overlap duration** (sweep-seconds) and
+ *     summed per repo. Two sweeps running the whole interval split it 50/50.
+ *
+ * **`account` and `model` are dimensions, not join keys.** The issue's
+ * original sketch proposed joining "per account/model". That is not derivable
+ * from the telemetry: `tokens.snapshot` accounts have no `model`, and
+ * `sweep.started`'s `model` (`opus`/`sonnet`) has no account field — no record
+ * anywhere links a pool account to a sweep. Pretending otherwise would invent
+ * a correlation. So both are carried through as *breakdowns* of an
+ * already-computed attribution (`byAccount` is exact — the delta genuinely
+ * came from that account; `byModel` inherits the proportional split of the
+ * sweeps that claimed it) rather than as keys that narrow the join.
+ *
+ * ## Tolerances (all configurable, all defaulted conservatively)
+ *
+ * | Knob | Default | Why |
+ * |---|---|---|
+ * | `edgeToleranceMs` | 60 s | Sweep windows are widened by this on both ends before overlap is tested. `captured_at` (pool sampler clock) and `started_at` (sweep clock) are independent daemon timestamps; without slack, a sweep that starts moments after a snapshot loses its first interval outright. |
+ * | `maxSampleGapMs` | 60 min | A pair of snapshots further apart than this is **dropped entirely** (counted in `droppedIntervals`). The usage in between is real but unobserved — smearing an hours-wide delta over whatever sweeps happen to overlap it would be fiction. |
+ * | `openSweepMaxDurationMs` | 6 h | A sweep with `sweep.started` but no terminal record is capped at this past its start (and at `now`), so one crashed sweep that never emitted `sweep.completed` cannot absorb the fleet's usage forever. |
+ *
+ * ## What is deliberately *not* claimed
+ *
+ * - **A negative delta is a limit-window rollover, not negative usage.** That
+ *   interval is dropped for that account (the pre-rollover portion of the burn
+ *   is unobservable), never attributed and never subtracted.
+ * - **Usage with no overlapping sweep goes to `unattributed`** — including the
+ *   uncovered *portion* of a partially-covered interval. Support roles
+ *   (Judge/Champion/Curator crons), manual sessions, and any consumer that
+ *   does not emit `sweep.*` telemetry all burn real tokens. Silently
+ *   redistributing that onto the repos that *did* run sweeps would inflate
+ *   every number on the page. The unattributed share is reported as a
+ *   first-class row, and a large one means the attribution is not to be
+ *   trusted.
+ * - **Units are account-window fractions**, not dollars or tokens:
+ *   `1.0` = one account's entire limit window. `tokens.snapshot` reports a
+ *   fraction of a quota, and no cost or absolute token count exists anywhere
+ *   in the telemetry — so no cost figure is synthesized here.
+ */
+
+import type { SweepWindow, TokenSample } from "./types.js";
+
+export const DEFAULT_EDGE_TOLERANCE_MS = 60 * 1000;
+export const DEFAULT_MAX_SAMPLE_GAP_MS = 60 * 60 * 1000;
+export const DEFAULT_OPEN_SWEEP_MAX_DURATION_MS = 6 * 60 * 60 * 1000;
+
+export interface AttributionOptions {
+  /** Reference instant (epoch ms) used to cap still-open sweep windows.
+   * Injectable so tests are deterministic. */
+  now?: number;
+  /** See the tolerance table in the module doc. */
+  edgeToleranceMs?: number;
+  maxSampleGapMs?: number;
+  openSweepMaxDurationMs?: number;
+}
+
+export interface NamedUsage {
+  name: string;
+  usage: number;
+}
+
+export interface RepoAttribution {
+  repo: string;
+  /** Attributed usage in account-window fractions. */
+  usage: number;
+  /** Fraction of `AttributionResult.totalUsage` (0..1). */
+  share: number;
+  /** Distinct sweeps that contributed. */
+  sweepCount: number;
+  /** Exact: the accounts whose deltas were attributed here. */
+  byAccount: NamedUsage[];
+  /** Inherited from the claiming sweeps' `model` (`"unknown"` when a sweep
+   * reported none). */
+  byModel: NamedUsage[];
+}
+
+export interface AttributionResult {
+  repos: RepoAttribution[];
+  /** Observed usage in intervals no sweep overlapped — crons, manual
+   * sessions, and any non-sweep consumer. */
+  unattributedUsage: number;
+  /** `sum(repos.usage) + unattributedUsage`. */
+  totalUsage: number;
+  /** Consecutive-snapshot pairs skipped because they straddled a telemetry
+   * gap wider than `maxSampleGapMs`. A high count means thin coverage. */
+  droppedIntervals: number;
+  /** Consecutive-snapshot/account pairs skipped because usage fell (a limit-
+   * window rollover). */
+  rolloverIntervals: number;
+  /** Intervals that carried usage and were fully attributed to sweeps. */
+  attributedIntervals: number;
+  /** Bounds of the analyzed history (epoch ms), when any sample was seen. */
+  rangeStart?: number;
+  rangeEnd?: number;
+}
+
+interface Accumulator {
+  usage: number;
+  sweeps: Set<string>;
+  byAccount: Map<string, number>;
+  byModel: Map<string, number>;
+}
+
+/** Effective window of a sweep, with open windows capped and edges widened. */
+interface EffectiveWindow {
+  window: SweepWindow;
+  start: number;
+  end: number;
+}
+
+/**
+ * Join `tokens.snapshot` history against sweep windows to produce per-repo
+ * usage attribution. See the module doc for the exact join and its tolerances.
+ */
+export function attributeUsageToRepos(
+  samples: readonly TokenSample[],
+  sweeps: readonly SweepWindow[],
+  options: AttributionOptions = {},
+): AttributionResult {
+  const now = options.now ?? Date.now();
+  const edgeToleranceMs = options.edgeToleranceMs ?? DEFAULT_EDGE_TOLERANCE_MS;
+  const maxSampleGapMs = options.maxSampleGapMs ?? DEFAULT_MAX_SAMPLE_GAP_MS;
+  const openSweepMaxDurationMs = options.openSweepMaxDurationMs ?? DEFAULT_OPEN_SWEEP_MAX_DURATION_MS;
+
+  const windowsByHost = new Map<string, EffectiveWindow[]>();
+  for (const sweep of sweeps) {
+    const end = sweep.endedAt ?? Math.min(now, sweep.startedAt + openSweepMaxDurationMs);
+    const list = windowsByHost.get(sweep.hostId) ?? [];
+    list.push({
+      window: sweep,
+      start: sweep.startedAt - edgeToleranceMs,
+      end: Math.max(end, sweep.startedAt) + edgeToleranceMs,
+    });
+    windowsByHost.set(sweep.hostId, list);
+  }
+
+  const samplesByHost = new Map<string, TokenSample[]>();
+  for (const sample of samples) {
+    const list = samplesByHost.get(sample.hostId) ?? [];
+    list.push(sample);
+    samplesByHost.set(sample.hostId, list);
+  }
+
+  const byRepo = new Map<string, Accumulator>();
+  let unattributedUsage = 0;
+  let droppedIntervals = 0;
+  let rolloverIntervals = 0;
+  let attributedIntervals = 0;
+  let rangeStart: number | undefined;
+  let rangeEnd: number | undefined;
+
+  for (const [hostId, hostSamples] of samplesByHost) {
+    hostSamples.sort((a, b) => a.at - b.at);
+    const hostWindows = windowsByHost.get(hostId) ?? [];
+
+    for (const sample of hostSamples) {
+      rangeStart = rangeStart === undefined ? sample.at : Math.min(rangeStart, sample.at);
+      rangeEnd = rangeEnd === undefined ? sample.at : Math.max(rangeEnd, sample.at);
+    }
+
+    for (let i = 1; i < hostSamples.length; i += 1) {
+      const previous = hostSamples[i - 1];
+      const current = hostSamples[i];
+      /* c8 ignore next -- both indices are in range by the loop bounds; the
+         guard exists only to satisfy `noUncheckedIndexedAccess`. */
+      if (!previous || !current) continue;
+      const intervalStart = previous.at;
+      const intervalEnd = current.at;
+      if (intervalEnd <= intervalStart) continue; // duplicate snapshot instant
+      if (intervalEnd - intervalStart > maxSampleGapMs) {
+        droppedIntervals += 1;
+        continue;
+      }
+
+      const deltas = accountDeltas(previous, current);
+      if (deltas.rollovers > 0) rolloverIntervals += deltas.rollovers;
+      if (deltas.byAccount.size === 0) continue;
+
+      const overlaps = overlappingSweeps(hostWindows, intervalStart, intervalEnd);
+      const totalOverlap = overlaps.reduce((sum, entry) => sum + entry.overlapMs, 0);
+      // Usage is assumed uniform across the interval, so the share that is
+      // attributable at all is the share of the interval covered by *some*
+      // sweep — the union, not the sum (two concurrent sweeps cover the same
+      // seconds once). The remainder is genuinely unattributable: no sweep was
+      // running for it.
+      const coveredMs = unionLength(overlaps);
+      const coveredFraction = Math.min(coveredMs / (intervalEnd - intervalStart), 1);
+
+      if (totalOverlap <= 0 || coveredFraction <= 0) {
+        for (const usage of deltas.byAccount.values()) unattributedUsage += usage;
+        continue;
+      }
+
+      attributedIntervals += 1;
+      for (const [account, usage] of deltas.byAccount) {
+        const attributable = usage * coveredFraction;
+        unattributedUsage += usage - attributable;
+        for (const { window, overlapMs } of overlaps) {
+          const attributed = (attributable * overlapMs) / totalOverlap;
+          if (attributed <= 0) continue;
+          const bucket = accumulatorFor(byRepo, window.repo);
+          bucket.usage += attributed;
+          bucket.sweeps.add(`${window.hostId} ${window.sweepId}`);
+          addTo(bucket.byAccount, account, attributed);
+          addTo(bucket.byModel, window.model ?? "unknown", attributed);
+        }
+      }
+    }
+  }
+
+  const attributedTotal = [...byRepo.values()].reduce((sum, bucket) => sum + bucket.usage, 0);
+  const totalUsage = attributedTotal + unattributedUsage;
+
+  const repos: RepoAttribution[] = [...byRepo.entries()]
+    .map(([repo, bucket]) => ({
+      repo,
+      usage: bucket.usage,
+      share: totalUsage > 0 ? bucket.usage / totalUsage : 0,
+      sweepCount: bucket.sweeps.size,
+      byAccount: toSortedUsage(bucket.byAccount),
+      byModel: toSortedUsage(bucket.byModel),
+    }))
+    .sort((a, b) => b.usage - a.usage || a.repo.localeCompare(b.repo));
+
+  return {
+    repos,
+    unattributedUsage,
+    totalUsage,
+    droppedIntervals,
+    rolloverIntervals,
+    attributedIntervals,
+    rangeStart,
+    rangeEnd,
+  };
+}
+
+/** Positive per-account usage deltas between two consecutive snapshots.
+ * Accounts absent from either snapshot, or with unknown usage in either, are
+ * skipped — there is no delta to compute. A negative delta is a limit-window
+ * rollover: counted, never attributed. */
+function accountDeltas(
+  previous: TokenSample,
+  current: TokenSample,
+): { byAccount: Map<string, number>; rollovers: number } {
+  const previousUsage = new Map<string, number>();
+  for (const reading of previous.accounts) {
+    if (reading.usageFraction !== undefined) previousUsage.set(reading.account, reading.usageFraction);
+  }
+
+  const byAccount = new Map<string, number>();
+  let rollovers = 0;
+  for (const reading of current.accounts) {
+    if (reading.usageFraction === undefined) continue;
+    const before = previousUsage.get(reading.account);
+    if (before === undefined) continue;
+    const delta = reading.usageFraction - before;
+    if (delta < 0) {
+      rollovers += 1;
+      continue;
+    }
+    if (delta === 0) continue;
+    byAccount.set(reading.account, delta);
+  }
+  return { byAccount, rollovers };
+}
+
+interface Overlap {
+  window: SweepWindow;
+  overlapMs: number;
+  /** The overlapping span itself, clipped to the interval — needed for the
+   * union, which the per-sweep durations alone cannot reconstruct. */
+  start: number;
+  end: number;
+}
+
+function overlappingSweeps(
+  windows: readonly EffectiveWindow[],
+  intervalStart: number,
+  intervalEnd: number,
+): Overlap[] {
+  const overlaps: Overlap[] = [];
+  for (const candidate of windows) {
+    const start = Math.max(candidate.start, intervalStart);
+    const end = Math.min(candidate.end, intervalEnd);
+    if (end > start) overlaps.push({ window: candidate.window, overlapMs: end - start, start, end });
+  }
+  return overlaps;
+}
+
+/** Total length of the union of a set of spans (overlapping spans counted
+ * once). Classic sweep-line: sort by start, merge as you go. */
+function unionLength(spans: readonly Overlap[]): number {
+  const sorted = [...spans].sort((a, b) => a.start - b.start);
+  let total = 0;
+  let currentStart: number | undefined;
+  let currentEnd = 0;
+  for (const span of sorted) {
+    if (currentStart === undefined) {
+      currentStart = span.start;
+      currentEnd = span.end;
+    } else if (span.start > currentEnd) {
+      total += currentEnd - currentStart;
+      currentStart = span.start;
+      currentEnd = span.end;
+    } else if (span.end > currentEnd) {
+      currentEnd = span.end;
+    }
+  }
+  if (currentStart === undefined) return 0; // no spans at all
+  return total + (currentEnd - currentStart);
+}
+
+function accumulatorFor(byRepo: Map<string, Accumulator>, repo: string): Accumulator {
+  let bucket = byRepo.get(repo);
+  if (!bucket) {
+    bucket = { usage: 0, sweeps: new Set(), byAccount: new Map(), byModel: new Map() };
+    byRepo.set(repo, bucket);
+  }
+  return bucket;
+}
+
+function addTo(map: Map<string, number>, key: string, amount: number): void {
+  map.set(key, (map.get(key) ?? 0) + amount);
+}
+
+function toSortedUsage(map: ReadonlyMap<string, number>): NamedUsage[] {
+  return [...map.entries()]
+    .map(([name, usage]) => ({ name, usage }))
+    .sort((a, b) => b.usage - a.usage || a.name.localeCompare(b.name));
+}

--- a/dashboard/web/src/analytics/bootstrap.ts
+++ b/dashboard/web/src/analytics/bootstrap.ts
@@ -1,0 +1,99 @@
+/**
+ * Entry point for the token/cost analytics view (Epic #4702, Phase 3,
+ * issue #4752).
+ *
+ * Intentionally thin: it resolves the surface, mounts the panel, and wires the
+ * refresh button. All logic lives in the sibling modules so it is testable
+ * without a browser.
+ *
+ * **Surface resolution** is the one non-obvious bit, and issue #4795 changed
+ * its basis. This module originally derived the surface from the URL: a page
+ * under `/public` was the public surface, anything else authenticated. That
+ * held while the two audiences had two URLs. Under the single-URL layout they
+ * share one — `/public` is now a 301 to `/`, and `/` serves both audiences —
+ * so `surfaceFromPath("/")` would answer "authenticated" for *every* visitor,
+ * and an anonymous one would render the full panel, request `/api/history`,
+ * and get a 403.
+ *
+ * The surface now comes from the auth state the Worker injects into the page
+ * after validating the Cloudflare Access JWT (`../api.js`'s
+ * `isAuthenticatedViewer`, stamped by `../../../src/index.ts`'s `handleRoot`).
+ * That is still a server-side decision the page cannot talk itself out of;
+ * the flag only decides which dataset to *ask* for, and both routes stay
+ * enforced server-side regardless of what the browser claims.
+ *
+ * **Nothing runs at import time.** This package has no bundler and no HTML
+ * entry point yet; `src/index.ts` is a barrel that the `node`-environment
+ * tests import, so a module that touched `document` on load would break them.
+ * An app shell (issue #4749) calls `startTokenAnalytics` explicitly instead.
+ * For the same reason the panel's stylesheet, `analytics.css`, is *not*
+ * imported here — a CSS import is a bundler affordance, so the shell links the
+ * file itself.
+ */
+
+import { isAuthenticatedViewer } from "../api.js";
+import { mountTokenAnalytics } from "./render.js";
+import type { DashboardSurface } from "./render.js";
+
+/**
+ * The surface for the current viewer, from the server-injected auth state.
+ *
+ * Fails closed to `"public"`: `isAuthenticatedViewer` treats a missing or
+ * malformed flag as anonymous, so a page that never got the injection renders
+ * the withheld notice rather than firing an authenticated request.
+ */
+export function currentSurface(scope: typeof globalThis = globalThis): DashboardSurface {
+  return isAuthenticatedViewer(scope) ? "authenticated" : "public";
+}
+
+/**
+ * @deprecated Superseded by {@link currentSurface}. Issue #4795 collapsed the
+ * two audiences onto one URL, so a pathname no longer identifies the viewer —
+ * `/` serves both, and this function answers `"authenticated"` for it. Kept
+ * only so the rename is a separate, reviewable change; it has no callers.
+ */
+export function surfaceFromPath(pathname: string): DashboardSurface {
+  return pathname === "/public" || pathname.startsWith("/public/") ? "public" : "authenticated";
+}
+
+/** Options for {@link startTokenAnalytics}. */
+export interface StartTokenAnalyticsOptions {
+  /** Element id the panel mounts into. Default `"token-analytics"`. */
+  containerId?: string;
+  /** Element id of an optional refresh button. Default `"refresh-button"`. */
+  refreshButtonId?: string;
+  /**
+   * Overrides the surface derived from the injected auth state. Provided only
+   * so a shell that already knows the viewer need not re-derive it, and for
+   * tests; omit it and {@link currentSurface} decides.
+   */
+  surface?: DashboardSurface;
+}
+
+/**
+ * Mounts the analytics panel into `doc` and wires the refresh button.
+ *
+ * Returns the `refresh` callback (also invoked once immediately) so a caller
+ * can re-render on its own schedule, or `undefined` when the container is
+ * absent — a shell that does not host this panel is not an error.
+ */
+export function startTokenAnalytics(
+  doc: Document,
+  options: StartTokenAnalyticsOptions = {},
+): (() => void) | undefined {
+  const containerId = options.containerId ?? "token-analytics";
+  const refreshButtonId = options.refreshButtonId ?? "refresh-button";
+
+  const container = doc.getElementById(containerId);
+  if (!container) return undefined;
+
+  const surface = options.surface ?? currentSurface();
+
+  const refresh = (): void => {
+    void mountTokenAnalytics(container, { surface });
+  };
+
+  doc.getElementById(refreshButtonId)?.addEventListener("click", refresh);
+  refresh();
+  return refresh;
+}

--- a/dashboard/web/src/analytics/burn.ts
+++ b/dashboard/web/src/analytics/burn.ts
@@ -1,0 +1,227 @@
+/**
+ * Per-account burn curves: `usage_fraction` over time, reconstructed from
+ * `tokens.snapshot` history (Epic #4702, Phase 3, issue #4752).
+ *
+ * ## Series identity is `hostId` + `account`, not `account` alone
+ *
+ * The token pool is a **per-host** resource (`.loom/tokens/` lives on the
+ * machine running `loom-daemon`), and `tokens.snapshot` carries no repo but
+ * does arrive under a `hostId` envelope. Two hosts can legitimately have
+ * accounts with the same name — pooling them into one series would interleave
+ * two independent usage clocks and produce a sawtooth that describes neither.
+ * So one curve is one `(hostId, account)` pair.
+ *
+ * ## Limit windows, and why the curve is segmented
+ *
+ * `usage_fraction` is monotonically non-decreasing **within a limit window**
+ * and drops back toward 0 when the window rolls over at
+ * `limit_window_reset_at`. A single unsegmented series therefore contains
+ * sawtooth discontinuities that would wreck any trend fit (`forecast.ts`) and
+ * mislead the eye. `buildBurnCurves` splits each series into segments at:
+ *
+ * 1. **A window rollover** — `limit_window_reset_at` changed to a later
+ *    instant, or usage fell (by more than `USAGE_DROP_EPSILON`, which absorbs
+ *    float noise in a value the daemon computes as a ratio).
+ * 2. **A telemetry gap** — consecutive samples further apart than
+ *    `maxSampleGapMs`. The host was down, offline, or not reporting; whatever
+ *    happened in between is unobserved, and joining across it would draw a
+ *    straight line through data nobody collected.
+ *
+ * The **last** segment is the live one — the only one `forecast.ts` may
+ * extrapolate from.
+ *
+ * ## Unknown is not zero
+ *
+ * A reading whose `usage_fraction` the daemon omitted contributes no point to
+ * the curve (per the "unknown != zero" contract). It still contributes its
+ * `exhausted` flag, which the schema documents as always present: an account
+ * can be known-exhausted while its numeric usage is unknown, and that must
+ * still light up the UI.
+ */
+
+import type { AccountReading, TokenSample } from "./types.js";
+
+/** A usage drop smaller than this is float noise, not a window rollover. */
+const USAGE_DROP_EPSILON = 1e-9;
+
+/** Default telemetry-gap tolerance: samples more than 60 minutes apart start a
+ * new segment. The daemon's snapshot cadence is minutes, so an hour-wide hole
+ * is a reporting outage, not a slow poll. */
+export const DEFAULT_MAX_SAMPLE_GAP_MS = 60 * 60 * 1000;
+
+export interface BurnPoint {
+  /** Epoch ms. */
+  at: number;
+  /** `usage_fraction` as reported, clamped to `[0, 1]`. */
+  usageFraction: number;
+  exhausted: boolean;
+  /** Epoch ms of this reading's `limit_window_reset_at`, when known. */
+  limitWindowResetAt?: number;
+}
+
+export interface BurnSegment {
+  /** Chronological, at least one point. */
+  points: BurnPoint[];
+  /** The `limit_window_reset_at` in force for this segment (the newest one
+   * observed in it), when any reading reported one. */
+  limitWindowResetAt?: number;
+  /** Why this segment starts where it does — `"initial"` for the first,
+   * `"window-reset"` for a rollover, `"gap"` for a telemetry hole. */
+  startedBy: "initial" | "window-reset" | "gap";
+}
+
+export interface AccountBurnCurve {
+  hostId: string;
+  account: string;
+  /** Newest known pool rank (lower = preferred by the selector). */
+  rank?: number;
+  /** Every usable point across every segment, chronological. */
+  points: BurnPoint[];
+  segments: BurnSegment[];
+  /** The live segment — the tail of `segments`, or `undefined` when the
+   * account reported no numeric usage at all in the window queried. */
+  currentSegment?: BurnSegment;
+  /** Newest reading of any kind (including one with unknown usage). */
+  latestAt: number;
+  /** `exhausted` as of the newest reading. */
+  exhausted: boolean;
+  /** `exhausted` on any reading in range — an account that was exhausted and
+   * has since rolled over is still worth flagging in a fleet view. */
+  everExhausted: boolean;
+}
+
+export interface BurnCurveOptions {
+  /** See `DEFAULT_MAX_SAMPLE_GAP_MS`. */
+  maxSampleGapMs?: number;
+}
+
+function clampFraction(value: number): number {
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+interface Series {
+  hostId: string;
+  account: string;
+  readings: Array<{ at: number; reading: AccountReading }>;
+}
+
+/**
+ * Build one burn curve per `(hostId, account)` pair from a chronological
+ * `tokens.snapshot` history.
+ *
+ * `samples` is expected oldest-first (`parse.ts`'s `parseTokenSamples`
+ * guarantees this); it is re-sorted defensively per series anyway so a caller
+ * passing raw newest-first API order still gets correct curves rather than a
+ * silently reversed one.
+ */
+export function buildBurnCurves(
+  samples: readonly TokenSample[],
+  options: BurnCurveOptions = {},
+): AccountBurnCurve[] {
+  const maxSampleGapMs = options.maxSampleGapMs ?? DEFAULT_MAX_SAMPLE_GAP_MS;
+
+  const series = new Map<string, Series>();
+  for (const sample of samples) {
+    for (const reading of sample.accounts) {
+      const key = `${sample.hostId}\u0000${reading.account}`;
+      let entry = series.get(key);
+      if (!entry) {
+        entry = { hostId: sample.hostId, account: reading.account, readings: [] };
+        series.set(key, entry);
+      }
+      entry.readings.push({ at: sample.at, reading });
+    }
+  }
+
+  const curves: AccountBurnCurve[] = [];
+  for (const entry of series.values()) {
+    entry.readings.sort((a, b) => a.at - b.at);
+    curves.push(buildCurve(entry, maxSampleGapMs));
+  }
+
+  // Stable, operator-meaningful ordering: host, then pool rank (the selector's
+  // own preference order), then name. Rank-less accounts sort last.
+  curves.sort(
+    (a, b) =>
+      a.hostId.localeCompare(b.hostId) ||
+      (a.rank ?? Number.MAX_SAFE_INTEGER) - (b.rank ?? Number.MAX_SAFE_INTEGER) ||
+      a.account.localeCompare(b.account),
+  );
+  return curves;
+}
+
+function buildCurve(entry: Series, maxSampleGapMs: number): AccountBurnCurve {
+  const segments: BurnSegment[] = [];
+  const points: BurnPoint[] = [];
+  let previous: BurnPoint | undefined;
+  let everExhausted = false;
+
+  for (const { at, reading } of entry.readings) {
+    if (reading.exhausted) everExhausted = true;
+    if (reading.usageFraction === undefined) continue;
+
+    const point: BurnPoint = {
+      at,
+      usageFraction: clampFraction(reading.usageFraction),
+      exhausted: reading.exhausted,
+      limitWindowResetAt: reading.limitWindowResetAt,
+    };
+    points.push(point);
+
+    const startedBy = segmentBreak(previous, point, maxSampleGapMs);
+    const current = segments.at(-1);
+    if (startedBy === undefined && current) {
+      current.points.push(point);
+      if (point.limitWindowResetAt !== undefined) current.limitWindowResetAt = point.limitWindowResetAt;
+    } else {
+      segments.push({
+        points: [point],
+        limitWindowResetAt: point.limitWindowResetAt,
+        startedBy: startedBy ?? "initial",
+      });
+    }
+    previous = point;
+  }
+
+  const lastReading = entry.readings.at(-1);
+  return {
+    hostId: entry.hostId,
+    account: entry.account,
+    rank: newestDefinedRank(entry),
+    points,
+    segments,
+    currentSegment: segments.at(-1),
+    latestAt: lastReading?.at ?? 0,
+    exhausted: lastReading?.reading.exhausted ?? false,
+    everExhausted,
+  };
+}
+
+/** `undefined` when `point` continues `previous`'s segment. */
+function segmentBreak(
+  previous: BurnPoint | undefined,
+  point: BurnPoint,
+  maxSampleGapMs: number,
+): BurnSegment["startedBy"] | undefined {
+  if (previous === undefined) return "initial";
+  if (point.at - previous.at > maxSampleGapMs) return "gap";
+  if (previous.usageFraction - point.usageFraction > USAGE_DROP_EPSILON) return "window-reset";
+  if (
+    previous.limitWindowResetAt !== undefined &&
+    point.limitWindowResetAt !== undefined &&
+    point.limitWindowResetAt > previous.limitWindowResetAt
+  ) {
+    return "window-reset";
+  }
+  return undefined;
+}
+
+function newestDefinedRank(entry: Series): number | undefined {
+  for (let i = entry.readings.length - 1; i >= 0; i -= 1) {
+    const rank = entry.readings[i]?.reading.rank;
+    if (rank !== undefined) return rank;
+  }
+  return undefined;
+}

--- a/dashboard/web/src/analytics/forecast.ts
+++ b/dashboard/web/src/analytics/forecast.ts
@@ -1,0 +1,189 @@
+/**
+ * Limit-window forecasting: will this account burn through its quota before
+ * its window resets? (Epic #4702, Phase 3, issue #4752.)
+ *
+ * ## Method: ordinary least squares over the live segment only
+ *
+ * The forecast fits a straight line to `usage_fraction` vs. time across the
+ * points of the **current** burn segment (`burn.ts` — the run since the last
+ * window rollover or telemetry gap) and extrapolates it to `usage_fraction =
+ * 1`. Deliberately the simplest defensible model:
+ *
+ * - **Least squares, not last-two-points.** A single noisy sample would
+ *   otherwise swing the projection wildly; the fit averages the run.
+ * - **Current segment only.** Fitting across a rollover would average a
+ *   descending sawtooth edge into the trend and under-predict every time.
+ * - **No smoothing/decay parameters.** Nothing here is tuned; there is no
+ *   hidden constant an operator would have to learn about to read the number.
+ *   If the trend is not linear, the honest output is a rough ETA, not a
+ *   confident wrong one — which is why the UI renders this as an ETA band,
+ *   never as a promise.
+ *
+ * ## The verdict
+ *
+ * The projected exhaustion instant is compared against the window's own
+ * `limit_window_reset_at`. Whichever comes first decides the status:
+ * `resets-first` (the quota survives the window — the healthy case) or
+ * `projected-exhaustion` (the account runs dry first, and `marginSec` says by
+ * how much). An account the daemon already reports as `exhausted` short-
+ * circuits to `exhausted` — a measured fact always outranks a projection.
+ *
+ * ## Unknowns stay unknown
+ *
+ * Fewer than two points in the live segment yields `insufficient-data`, not a
+ * guess. A non-positive slope yields `flat` — no burn is observable, so no
+ * exhaustion is projected — rather than an "infinity" ETA. A missing
+ * `limit_window_reset_at` yields a projection with an undefined margin rather
+ * than an invented window length.
+ */
+
+import type { AccountBurnCurve, BurnPoint } from "./burn.js";
+
+export type ForecastStatus =
+  /** The daemon reports the account as exhausted right now. */
+  | "exhausted"
+  /** Projected to hit `usage_fraction = 1` before the window resets. */
+  | "projected-exhaustion"
+  /** The limit window resets before the projection reaches exhaustion. */
+  | "resets-first"
+  /** No measurable burn (flat or decreasing trend). */
+  | "flat"
+  /** Fewer than two usable points in the live segment. */
+  | "insufficient-data";
+
+export interface AccountForecast {
+  hostId: string;
+  account: string;
+  status: ForecastStatus;
+  /** Points that fed the fit (live segment only). */
+  sampleCount: number;
+  /** Fitted burn rate, `usage_fraction` per hour. Present whenever the fit ran
+   * (including a non-positive slope, so the UI can show "0.00/h"). */
+  slopePerHour?: number;
+  /** Newest observed `usage_fraction` in the live segment. */
+  latestUsageFraction?: number;
+  /** Epoch ms at which the fitted line reaches `usage_fraction = 1`. Never in
+   * the past: a line already past 1 is reported as "now". */
+  projectedExhaustionAt?: number;
+  /** Seconds from `now` to `projectedExhaustionAt`. */
+  secondsUntilExhaustion?: number;
+  /** Epoch ms of the window rollover this account is racing. */
+  limitWindowResetAt?: number;
+  /** Seconds from `now` to `limitWindowResetAt`. Negative when the reported
+   * reset instant is already in the past (a stale snapshot). */
+  secondsUntilReset?: number;
+  /** `limitWindowResetAt - projectedExhaustionAt`, in seconds. Positive means
+   * the window resets with room to spare; negative means the account runs dry
+   * that many seconds before relief arrives. */
+  marginSec?: number;
+}
+
+export interface ForecastOptions {
+  /** Reference instant (epoch ms). Injectable so tests are deterministic. */
+  now?: number;
+}
+
+const MS_PER_HOUR = 60 * 60 * 1000;
+
+/** Forecast one account from its burn curve. */
+export function forecastAccount(curve: AccountBurnCurve, options: ForecastOptions = {}): AccountForecast {
+  const now = options.now ?? Date.now();
+  const segment = curve.currentSegment;
+  const points = segment?.points ?? [];
+  const latest: BurnPoint | undefined = points[points.length - 1];
+  const limitWindowResetAt = segment?.limitWindowResetAt ?? latest?.limitWindowResetAt;
+
+  const base: AccountForecast = {
+    hostId: curve.hostId,
+    account: curve.account,
+    status: "insufficient-data",
+    sampleCount: points.length,
+    latestUsageFraction: latest?.usageFraction,
+    limitWindowResetAt,
+    secondsUntilReset:
+      limitWindowResetAt === undefined ? undefined : Math.round((limitWindowResetAt - now) / 1000),
+  };
+
+  // A measured fact outranks any projection: if the pool says the account is
+  // exhausted, that is the status regardless of what the trend suggests.
+  if (curve.exhausted) return { ...base, status: "exhausted" };
+
+  if (points.length < 2) return base;
+
+  const fit = leastSquares(points);
+  const slopePerHour = fit.slopePerMs * MS_PER_HOUR;
+  const withFit: AccountForecast = { ...base, slopePerHour };
+
+  if (!(fit.slopePerMs > 0)) return { ...withFit, status: "flat" };
+
+  // Extrapolate the fitted line — not the raw last reading — to
+  // `usage_fraction = 1`. For a two-point segment the fit passes exactly
+  // through both points, so this degenerates to the obvious answer.
+  const rawExhaustionAt = (1 - fit.intercept) / fit.slopePerMs;
+  const projectedExhaustionAt = Math.max(Math.round(rawExhaustionAt), now);
+  const secondsUntilExhaustion = Math.round((projectedExhaustionAt - now) / 1000);
+  const marginSec =
+    limitWindowResetAt === undefined
+      ? undefined
+      : Math.round((limitWindowResetAt - projectedExhaustionAt) / 1000);
+
+  const status: ForecastStatus =
+    limitWindowResetAt !== undefined && limitWindowResetAt <= projectedExhaustionAt
+      ? "resets-first"
+      : "projected-exhaustion";
+
+  return { ...withFit, status, projectedExhaustionAt, secondsUntilExhaustion, marginSec };
+}
+
+/** Forecast every curve, preserving `buildBurnCurves`' ordering. */
+export function forecastAccounts(
+  curves: readonly AccountBurnCurve[],
+  options: ForecastOptions = {},
+): AccountForecast[] {
+  return curves.map((curve) => forecastAccount(curve, options));
+}
+
+interface LinearFit {
+  /** `usage_fraction` per millisecond. */
+  slopePerMs: number;
+  /** `usage_fraction` at epoch 0, in the same units the caller passes in. */
+  intercept: number;
+}
+
+/**
+ * Ordinary least squares of `usageFraction` on `at`.
+ *
+ * The fit is computed against time **relative to the first point** and the
+ * intercept translated back to absolute epoch afterwards. Fitting raw epoch
+ * milliseconds directly would square numbers around 1.7e12 — enough to lose
+ * most of a float64's mantissa to cancellation and produce a visibly wrong
+ * slope for a short, shallow segment.
+ */
+function leastSquares(points: readonly BurnPoint[]): LinearFit {
+  // `forecastAccount` returns early below two points, so index 0 always
+  // exists; `?? 0` is only here to satisfy `noUncheckedIndexedAccess`.
+  const t0 = points[0]?.at ?? 0;
+  const n = points.length;
+  let sumX = 0;
+  let sumY = 0;
+  for (const point of points) {
+    sumX += point.at - t0;
+    sumY += point.usageFraction;
+  }
+  const meanX = sumX / n;
+  const meanY = sumY / n;
+
+  let sxx = 0;
+  let sxy = 0;
+  for (const point of points) {
+    const dx = point.at - t0 - meanX;
+    sxx += dx * dx;
+    sxy += dx * (point.usageFraction - meanY);
+  }
+
+  // All points share one instant (a duplicated snapshot): no slope is
+  // derivable, report flat rather than dividing by zero.
+  const slopePerMs = sxx === 0 ? 0 : sxy / sxx;
+  const relativeIntercept = meanY - slopePerMs * meanX;
+  return { slopePerMs, intercept: relativeIntercept - slopePerMs * t0 };
+}

--- a/dashboard/web/src/analytics/format.ts
+++ b/dashboard/web/src/analytics/format.ts
@@ -1,0 +1,64 @@
+/**
+ * Display formatting for the token/cost analytics view (Epic #4702, Phase 3,
+ * issue #4752).
+ *
+ * One rule runs through all of it: **an unknown value renders as `—`, never as
+ * `0`, `0%`, or `never`.** The daemon's telemetry contract makes an
+ * unmeasurable probe *absent* rather than zero, and the UI is the last place
+ * that distinction can be destroyed.
+ */
+
+/** The em-dash every "not known" cell renders as. */
+export const UNKNOWN = "—";
+
+/** `0.4237` → `"42.4%"`; `undefined` → `"—"`. */
+export function formatPercent(fraction: number | undefined, digits = 1): string {
+  if (fraction === undefined || !Number.isFinite(fraction)) return UNKNOWN;
+  return `${(fraction * 100).toFixed(digits)}%`;
+}
+
+/** Burn rate as a percentage of the limit window per hour. */
+export function formatRatePerHour(fractionPerHour: number | undefined): string {
+  if (fractionPerHour === undefined || !Number.isFinite(fractionPerHour)) return UNKNOWN;
+  return `${(fractionPerHour * 100).toFixed(1)}%/h`;
+}
+
+/**
+ * A signed, coarse duration: `"2h 5m"`, `"in 40m"`, `"12m ago"`.
+ *
+ * Coarse on purpose — a forecast accurate to the second would imply a
+ * precision a two-point linear fit does not have.
+ */
+export function formatDuration(seconds: number | undefined): string {
+  if (seconds === undefined || !Number.isFinite(seconds)) return UNKNOWN;
+  const magnitude = Math.abs(Math.round(seconds));
+  const days = Math.floor(magnitude / 86400);
+  const hours = Math.floor((magnitude % 86400) / 3600);
+  const minutes = Math.floor((magnitude % 3600) / 60);
+
+  let text: string;
+  if (days > 0) text = `${days}d ${hours}h`;
+  else if (hours > 0) text = `${hours}h ${minutes}m`;
+  else if (minutes > 0) text = `${minutes}m`;
+  else text = `${magnitude}s`;
+  return text;
+}
+
+/** `formatDuration` with a direction: future → `"in 40m"`, past → `"40m ago"`. */
+export function formatRelative(seconds: number | undefined): string {
+  if (seconds === undefined || !Number.isFinite(seconds)) return UNKNOWN;
+  const text = formatDuration(seconds);
+  if (Math.abs(Math.round(seconds)) < 30) return "now";
+  return seconds >= 0 ? `in ${text}` : `${text} ago`;
+}
+
+/** Short local wall-clock time for an epoch-ms instant. */
+export function formatInstant(at: number | undefined): string {
+  if (at === undefined || !Number.isFinite(at)) return UNKNOWN;
+  return new Date(at).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/dashboard/web/src/analytics/parse.ts
+++ b/dashboard/web/src/analytics/parse.ts
@@ -1,0 +1,180 @@
+/**
+ * Narrowing layer: raw `GET /api/history` JSON → the domain shapes in
+ * `types.ts` (Epic #4702, Phase 3, issue #4752).
+ *
+ * Every function here is total: it never throws on malformed input, it drops
+ * what it cannot understand. That is a deliberate contract, not laziness —
+ * the telemetry schema is additive and multi-version by design (hosts on
+ * different daemon builds report into the same backend), so a single
+ * wrong-typed field from one host must not blank the whole dashboard.
+ *
+ * The one rule every narrowing function obeys: **an absent or unparseable
+ * measurement stays absent.** It is never coerced to `0`, because `0` means
+ * "measured, and it is zero" everywhere downstream (a `usage_fraction` of 0 is
+ * a fresh limit window; an unknown one must not be drawn as one).
+ */
+
+import type {
+  AccountReading,
+  HistoryEnvelope,
+  SweepWindow,
+  TokenSample,
+  TokensSnapshotPayload,
+} from "./types.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Parse an RFC 3339 datetime to epoch ms, or `undefined` if absent/invalid. */
+export function parseTimestamp(value: unknown): number | undefined {
+  if (typeof value !== "string" || value === "") return undefined;
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
+function parseFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/** Narrow one `tokens.snapshot` history record. Returns `undefined` when the
+ * record has no usable timestamp or no account array at all. */
+export function parseTokenSample(envelope: HistoryEnvelope): TokenSample | undefined {
+  if (envelope.kind !== "tokens.snapshot") return undefined;
+  const payload = envelope.record as TokensSnapshotPayload;
+  // `captured_at` is the daemon's own clock; `emittedAt` is the envelope's.
+  // Prefer the former (it is when the pool was actually sampled) and fall back
+  // to the latter so a snapshot missing `captured_at` still plots.
+  const at = parseTimestamp(payload?.captured_at) ?? parseTimestamp(envelope.emittedAt);
+  if (at === undefined) return undefined;
+  const rawAccounts = Array.isArray(payload?.accounts) ? payload.accounts : [];
+
+  const accounts: AccountReading[] = [];
+  for (const raw of rawAccounts) {
+    if (!isRecord(raw)) continue;
+    const account = typeof raw.account === "string" && raw.account !== "" ? raw.account : undefined;
+    if (account === undefined) continue; // an unnamed account cannot be a series key
+    const usageFraction = parseFiniteNumber(raw.usage_fraction);
+    accounts.push({
+      account,
+      rank: parseFiniteNumber(raw.rank),
+      usageFraction,
+      limitWindowResetAt: parseTimestamp(raw.limit_window_reset_at),
+      // `exhausted` is documented as always present; a missing/wrong-typed one
+      // is read as "not exhausted" so a partial record never invents an alarm.
+      exhausted: raw.exhausted === true,
+    });
+  }
+  return { hostId: envelope.hostId, at, accounts };
+}
+
+/** Narrow every `tokens.snapshot` in a history page, oldest-first.
+ *
+ * `GET /api/history` returns newest-first (`id` descending); every consumer in
+ * this directory wants chronological order, so sorting here means no caller
+ * has to remember. Ties on `at` are broken by envelope `id` so the ordering is
+ * total and stable even for two snapshots that share a `captured_at` second. */
+export function parseTokenSamples(envelopes: readonly HistoryEnvelope[]): TokenSample[] {
+  const withOrder: Array<{ sample: TokenSample; id: number }> = [];
+  for (const envelope of envelopes) {
+    const sample = parseTokenSample(envelope);
+    if (sample) withOrder.push({ sample, id: envelope.id });
+  }
+  withOrder.sort((a, b) => a.sample.at - b.sample.at || a.id - b.id);
+  return withOrder.map((entry) => entry.sample);
+}
+
+/**
+ * Reconstruct sweep windows from `sweep.started` / `sweep.completed` /
+ * `sweep.outcome` records.
+ *
+ * Keyed by `hostId` + `sweep_id`: a sweep id embeds the issue number
+ * (`sweep-issue-4703-0`) and is unique per host, but two hosts could in
+ * principle mint the same id, and attribution must never fuse two hosts'
+ * sweeps into one window.
+ *
+ * A record whose `repo` is absent or `null` is skipped — that is exactly what
+ * a redacted `/public/history` response looks like for a private repo, and
+ * attributing usage to a repo you are not allowed to see is the failure mode
+ * this drop prevents. (The view is authenticated-only anyway; this is
+ * defense-in-depth in the parse layer.)
+ *
+ * **Two passes, deliberately.** `GET /api/history` returns records
+ * newest-first, so a sweep's `sweep.completed` arrives *before* its
+ * `sweep.started`. A single-pass fold would drop every terminal record as "no
+ * matching start" and leave every window open — which `attribution.ts` would
+ * then cap at hours long and let absorb the fleet's usage. Starts are
+ * collected first and terminal records applied second, so the result is
+ * identical for any input ordering.
+ */
+export function parseSweepWindows(envelopes: readonly HistoryEnvelope[]): SweepWindow[] {
+  const windows = new Map<string, SweepWindow>();
+
+  // Pass 1 — `sweep.started` defines the window and its repo/model/issue.
+  for (const envelope of envelopes) {
+    if (envelope.kind !== "sweep.started") continue;
+    const payload = isRecord(envelope.record) ? envelope.record : {};
+    const sweepId = readSweepId(envelope, payload);
+    const repo = readRepo(envelope, payload);
+    if (sweepId === undefined || repo === undefined) continue;
+
+    const startedAt = parseTimestamp(payload.started_at) ?? parseTimestamp(envelope.emittedAt);
+    if (startedAt === undefined) continue;
+
+    const key = `${envelope.hostId} ${sweepId}`;
+    const existing = windows.get(key);
+    windows.set(key, {
+      hostId: envelope.hostId,
+      sweepId,
+      repo,
+      model: typeof payload.model === "string" && payload.model !== "" ? payload.model : existing?.model,
+      issue: parseFiniteNumber(payload.issue) ?? parseFiniteNumber(envelope.issue) ?? existing?.issue,
+      // A duplicate start (a retried sweep reusing its id) keeps the earliest
+      // instant, so the window still covers everything that sweep could burn.
+      startedAt: existing === undefined ? startedAt : Math.min(existing.startedAt, startedAt),
+      endedAt: existing?.endedAt,
+    });
+  }
+
+  // Pass 2 — terminal records close a window pass 1 opened. A terminal record
+  // with no matching start (the start fell outside the queried range) cannot
+  // define a window on its own: there is no start instant to attribute from,
+  // and inventing one would invent usage.
+  for (const envelope of envelopes) {
+    if (envelope.kind !== "sweep.completed" && envelope.kind !== "sweep.outcome") continue;
+    const payload = isRecord(envelope.record) ? envelope.record : {};
+    const sweepId = readSweepId(envelope, payload);
+    if (sweepId === undefined) continue;
+
+    const existing = windows.get(`${envelope.hostId} ${sweepId}`);
+    if (!existing) continue;
+
+    // `sweep.outcome` carries no completion instant of its own (see the schema
+    // doc), so its envelope `emittedAt` is the best available proxy.
+    const endedAt =
+      envelope.kind === "sweep.completed"
+        ? (parseTimestamp(payload.completed_at) ?? parseTimestamp(envelope.emittedAt))
+        : parseTimestamp(envelope.emittedAt);
+    if (endedAt !== undefined) {
+      const clamped = Math.max(endedAt, existing.startedAt);
+      existing.endedAt = existing.endedAt === undefined ? clamped : Math.max(existing.endedAt, clamped);
+    }
+    if (existing.model === undefined && typeof payload.model === "string" && payload.model !== "") {
+      existing.model = payload.model;
+    }
+  }
+
+  return [...windows.values()].sort((a, b) => a.startedAt - b.startedAt);
+}
+
+function readSweepId(envelope: HistoryEnvelope, payload: Record<string, unknown>): string | undefined {
+  if (typeof payload.sweep_id === "string" && payload.sweep_id !== "") return payload.sweep_id;
+  if (typeof envelope.sweepId === "string" && envelope.sweepId !== "") return envelope.sweepId;
+  return undefined;
+}
+
+function readRepo(envelope: HistoryEnvelope, payload: Record<string, unknown>): string | undefined {
+  if (typeof payload.repo === "string" && payload.repo !== "") return payload.repo;
+  if (typeof envelope.repo === "string" && envelope.repo !== "") return envelope.repo;
+  return undefined;
+}

--- a/dashboard/web/src/analytics/render.ts
+++ b/dashboard/web/src/analytics/render.ts
@@ -1,0 +1,475 @@
+/**
+ * The token/cost analytics panel: burn curves, limit-window forecasts, and
+ * per-repo attribution (Epic #4702, Phase 3, issue #4752).
+ *
+ * ## Public-exposure decision: authenticated surface only
+ *
+ * Phase 2's redaction policy (`../../src/redaction.ts`) passes
+ * `tokens.snapshot` through **unredacted on both `/api` and `/public`** — the
+ * kind carries no `repo`, so the private/public visibility split has nothing
+ * to key on. That is a correct backend decision and this issue does not change
+ * it. It is nonetheless *not* a decision that these widgets belong on the
+ * public page, and this module resolves that question the other way:
+ *
+ * **`mountTokenAnalytics` refuses to render on a `"public"` surface.** Three
+ * reasons, in descending order of force:
+ *
+ * 1. **Per-repo attribution is a repo-name table by construction.** The whole
+ *    output of `attribution.ts` is "which repositories consumed the fleet's
+ *    quota", and repo names are precisely what Phase 2 redacts from
+ *    `/public/history` for private-visibility sweeps. Rendering this panel
+ *    publicly would reconstruct, by inference from timing, the exact fact the
+ *    redaction layer removes.
+ * 2. **Account identifiers are operator infrastructure.** `agent-3` +
+ *    `usage_fraction` + `limit_window_reset_at` is a live capacity map of the
+ *    operator's account pool: it says how many accounts exist, which are near
+ *    their cap, and when each recovers. That is useful to an operator and
+ *    useful to nobody else in a way that benefits the operator.
+ * 3. **Exhaustion forecasts are a scheduling signal.** "This fleet runs dry in
+ *    40 minutes" is exactly the sort of operational state a public status page
+ *    should be a deliberate choice to publish, not a side effect of which API
+ *    route happens to permit it.
+ *
+ * This is a **UI-layer** decision, enforced here and (independently) by
+ * `api.ts` pinning its fetch to `/api`. It changes no redaction behavior. If a
+ * future operator wants a public capacity summary, the right shape is a
+ * purpose-built aggregate (e.g. "fleet capacity: healthy") with no account or
+ * repo names — a new component, not a flag on this one. Coordinated with the
+ * public view page (#4753) via `../../docs/token-analytics.md`.
+ */
+
+import type { AccountBurnCurve, BurnSegment } from "./burn.js";
+import { buildBurnCurves } from "./burn.js";
+import type { AccountForecast, ForecastStatus } from "./forecast.js";
+import { forecastAccounts } from "./forecast.js";
+import type { AttributionResult } from "./attribution.js";
+import { attributeUsageToRepos } from "./attribution.js";
+import { parseSweepWindows, parseTokenSamples } from "./parse.js";
+import type { HistoryEnvelope, SweepWindow, TokenSample } from "./types.js";
+import { fetchHistory } from "./api.js";
+import { formatDuration, formatInstant, formatPercent, formatRatePerHour, formatRelative, UNKNOWN } from "./format.js";
+
+/** Which route surface the panel is being rendered on. */
+export type DashboardSurface = "authenticated" | "public";
+
+/** The only surface this panel renders on — see the module doc. */
+export const REQUIRED_SURFACE: DashboardSurface = "authenticated";
+
+export interface TokenAnalytics {
+  curves: AccountBurnCurve[];
+  forecasts: AccountForecast[];
+  attribution: AttributionResult;
+  samples: TokenSample[];
+  sweeps: SweepWindow[];
+}
+
+export interface ComputeOptions {
+  /** Reference instant (epoch ms); injectable for deterministic tests. */
+  now?: number;
+}
+
+/** Partition a history page into the two record families and run all three
+ * analytics over them. Pure — no DOM, no network — so the whole computation is
+ * unit-testable from fixtures. */
+export function computeTokenAnalytics(
+  records: readonly HistoryEnvelope[],
+  options: ComputeOptions = {},
+): TokenAnalytics {
+  const samples = parseTokenSamples(records);
+  const sweeps = parseSweepWindows(records);
+  const curves = buildBurnCurves(samples);
+  return {
+    curves,
+    forecasts: forecastAccounts(curves, { now: options.now }),
+    attribution: attributeUsageToRepos(samples, sweeps, { now: options.now }),
+    samples,
+    sweeps,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DOM helpers — textContent only, never innerHTML
+// ---------------------------------------------------------------------------
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  className?: string,
+  text?: string,
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  // Repo names, account names and model strings all originate from remote
+  // telemetry. They are written as text nodes, never parsed as markup.
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+function cell(row: HTMLTableRowElement, text: string, className?: string): HTMLTableCellElement {
+  const td = el("td", className, text);
+  row.appendChild(td);
+  return td;
+}
+
+function headerRow(labels: readonly string[]): HTMLTableSectionElement {
+  const thead = document.createElement("thead");
+  const tr = document.createElement("tr");
+  for (const label of labels) tr.appendChild(el("th", undefined, label));
+  thead.appendChild(tr);
+  return thead;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+export interface RenderOptions extends ComputeOptions {
+  surface?: DashboardSurface;
+}
+
+/**
+ * Render the panel into `container` (replacing its contents).
+ *
+ * Returns `false` without rendering any analytics when the surface is not the
+ * authenticated one — the enforcement point for this issue's public-exposure
+ * decision (see the module doc). The container instead gets a short notice, so
+ * a public page shows an intentional "withheld" state rather than an empty
+ * hole that looks like a bug.
+ */
+export function renderTokenAnalytics(
+  container: HTMLElement,
+  analytics: TokenAnalytics,
+  options: RenderOptions = {},
+): boolean {
+  const surface = options.surface ?? REQUIRED_SURFACE;
+  container.replaceChildren();
+
+  if (surface !== REQUIRED_SURFACE) {
+    container.appendChild(renderWithheldNotice());
+    return false;
+  }
+
+  const now = options.now ?? Date.now();
+  const section = el("section", "analytics");
+  section.appendChild(el("h2", "analytics__title", "Token & cost analytics"));
+  section.appendChild(renderBurnCurves(analytics.curves));
+  section.appendChild(renderForecasts(analytics.forecasts, now));
+  section.appendChild(renderAttribution(analytics.attribution));
+  container.appendChild(section);
+  return true;
+}
+
+function renderWithheldNotice(): HTMLElement {
+  const notice = el("section", "analytics analytics--withheld");
+  notice.setAttribute("data-testid", "analytics-withheld");
+  notice.appendChild(el("h2", "analytics__title", "Token & cost analytics"));
+  notice.appendChild(
+    el(
+      "p",
+      "analytics__note",
+      "Per-account detail is operator-only: account identifiers, per-repo attribution and " +
+        "per-account exhaustion forecasts are not shown in the public view. Fleet-level " +
+        "pool load (accounts in use, how many are exhausted, peak usage) is on the host " +
+        "cards above. Sign in for the full breakdown.",
+    ),
+  );
+  return notice;
+}
+
+// --- Burn curves -----------------------------------------------------------
+
+function renderBurnCurves(curves: readonly AccountBurnCurve[]): HTMLElement {
+  const block = el("div", "analytics__block");
+  block.setAttribute("data-testid", "burn-curves");
+  block.appendChild(el("h3", "analytics__heading", "Per-account burn curves"));
+
+  if (curves.length === 0) {
+    block.appendChild(el("p", "analytics__note", "No tokens.snapshot history in range."));
+    return block;
+  }
+
+  const list = el("div", "burn-grid");
+  for (const curve of curves) list.appendChild(renderBurnCard(curve));
+  block.appendChild(list);
+  return block;
+}
+
+function renderBurnCard(curve: AccountBurnCurve): HTMLElement {
+  const exhausted = curve.exhausted;
+  const card = el("article", `burn-card${exhausted ? " burn-card--exhausted" : ""}`);
+  card.setAttribute("data-account", curve.account);
+  card.setAttribute("data-host", curve.hostId);
+  card.setAttribute("data-exhausted", String(exhausted));
+
+  const head = el("header", "burn-card__head");
+  head.appendChild(el("span", "burn-card__account", curve.account));
+  head.appendChild(el("span", "burn-card__host", curve.hostId));
+  if (exhausted) {
+    // The distinct visual flag AC4 requires: a badge, a card modifier class,
+    // and a machine-readable data attribute — belt, braces, and a test hook.
+    const badge = el("span", "badge badge--exhausted", "EXHAUSTED");
+    badge.setAttribute("data-testid", "exhausted-badge");
+    badge.setAttribute("role", "status");
+    head.appendChild(badge);
+  } else if (curve.everExhausted) {
+    head.appendChild(el("span", "badge badge--recovered", "recovered"));
+  }
+  card.appendChild(head);
+
+  card.appendChild(renderSparkline(curve));
+
+  const latest = curve.points[curve.points.length - 1];
+  const foot = el("footer", "burn-card__foot");
+  foot.appendChild(el("span", "burn-card__usage", formatPercent(latest?.usageFraction)));
+  foot.appendChild(el("span", "burn-card__at", formatInstant(curve.latestAt || undefined)));
+  card.appendChild(foot);
+  return card;
+}
+
+const SPARK_WIDTH = 240;
+const SPARK_HEIGHT = 48;
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+/**
+ * An inline SVG sparkline of `usage_fraction` over time.
+ *
+ * The y-axis is pinned to `[0, 1]` (not auto-scaled to the data): the whole
+ * point of a burn curve is distance from the cap, and an auto-scaled axis makes
+ * a 2%-to-4% wobble look identical to a 40%-to-80% sprint. Each burn segment
+ * is drawn as its own polyline so a limit-window rollover shows as a break, not
+ * as a diagonal plunge that never happened.
+ */
+function renderSparkline(curve: AccountBurnCurve): SVGSVGElement {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("class", "sparkline");
+  svg.setAttribute("viewBox", `0 0 ${SPARK_WIDTH} ${SPARK_HEIGHT}`);
+  svg.setAttribute("role", "img");
+  svg.setAttribute("preserveAspectRatio", "none");
+  svg.setAttribute(
+    "aria-label",
+    `${curve.account} usage over time, latest ${formatPercent(curve.points[curve.points.length - 1]?.usageFraction)}`,
+  );
+
+  const first = curve.points[0];
+  const last = curve.points[curve.points.length - 1];
+  if (!first || !last) return svg;
+
+  const span = Math.max(last.at - first.at, 1);
+  const x = (at: number): number => ((at - first.at) / span) * SPARK_WIDTH;
+  const y = (usage: number): number => SPARK_HEIGHT - usage * SPARK_HEIGHT;
+
+  for (const segment of curve.segments) {
+    svg.appendChild(renderSegmentLine(segment, x, y));
+  }
+  return svg;
+}
+
+function renderSegmentLine(
+  segment: BurnSegment,
+  x: (at: number) => number,
+  y: (usage: number) => number,
+): SVGPolylineElement {
+  const line = document.createElementNS(SVG_NS, "polyline");
+  line.setAttribute("class", "sparkline__line");
+  // A one-point segment has no line to draw; duplicating the point renders a
+  // visible dot instead of silently vanishing.
+  const only = segment.points[0];
+  const points = segment.points.length === 1 && only ? [only, only] : segment.points;
+  line.setAttribute(
+    "points",
+    points.map((point) => `${x(point.at).toFixed(2)},${y(point.usageFraction).toFixed(2)}`).join(" "),
+  );
+  return line;
+}
+
+// --- Forecasts -------------------------------------------------------------
+
+const STATUS_LABEL: Readonly<Record<ForecastStatus, string>> = {
+  exhausted: "Exhausted",
+  "projected-exhaustion": "Will exhaust",
+  "resets-first": "Resets first",
+  flat: "Idle",
+  "insufficient-data": "No data",
+};
+
+function renderForecasts(forecasts: readonly AccountForecast[], now: number): HTMLElement {
+  const block = el("div", "analytics__block");
+  block.setAttribute("data-testid", "forecasts");
+  block.appendChild(el("h3", "analytics__heading", "Limit-window forecast"));
+
+  if (forecasts.length === 0) {
+    block.appendChild(el("p", "analytics__note", "No accounts observed in range."));
+    return block;
+  }
+
+  const table = el("table", "table table--forecast");
+  table.appendChild(
+    headerRow(["Account", "Host", "Burn rate", "Usage", "Exhausts", "Window resets", "Margin", "Status"]),
+  );
+  const tbody = document.createElement("tbody");
+
+  for (const forecast of forecasts) {
+    const row = document.createElement("tr");
+    row.setAttribute("data-account", forecast.account);
+    row.setAttribute("data-status", forecast.status);
+    if (forecast.status === "exhausted" || forecast.status === "projected-exhaustion") {
+      row.className = "row--at-risk";
+    }
+    cell(row, forecast.account, "cell--account");
+    cell(row, forecast.hostId, "cell--host");
+    cell(row, formatRatePerHour(forecast.slopePerHour));
+    cell(row, formatPercent(forecast.latestUsageFraction));
+    cell(
+      row,
+      forecast.projectedExhaustionAt === undefined
+        ? UNKNOWN
+        : `${formatRelative(forecast.secondsUntilExhaustion)} (${formatInstant(forecast.projectedExhaustionAt)})`,
+    );
+    cell(
+      row,
+      forecast.limitWindowResetAt === undefined
+        ? UNKNOWN
+        : `${formatRelative(forecast.secondsUntilReset)} (${formatInstant(forecast.limitWindowResetAt)})`,
+    );
+    cell(
+      row,
+      forecast.marginSec === undefined
+        ? UNKNOWN
+        : forecast.marginSec >= 0
+          ? `+${formatDuration(forecast.marginSec)}`
+          : `-${formatDuration(forecast.marginSec)}`,
+      forecast.marginSec !== undefined && forecast.marginSec < 0 ? "cell--negative" : undefined,
+    );
+    const status = cell(row, STATUS_LABEL[forecast.status], `status status--${forecast.status}`);
+    status.setAttribute("data-testid", `status-${forecast.account}`);
+    tbody.appendChild(row);
+  }
+
+  table.appendChild(tbody);
+  block.appendChild(table);
+  block.appendChild(
+    el(
+      "p",
+      "analytics__note",
+      `Projections are a least-squares fit over each account's current limit window, evaluated at ${formatInstant(now)}. ` +
+        "They assume the observed burn rate continues unchanged.",
+    ),
+  );
+  return block;
+}
+
+// --- Attribution -----------------------------------------------------------
+
+function renderAttribution(attribution: AttributionResult): HTMLElement {
+  const block = el("div", "analytics__block");
+  block.setAttribute("data-testid", "attribution");
+  block.appendChild(el("h3", "analytics__heading", "Per-repo attribution"));
+
+  if (attribution.totalUsage <= 0) {
+    block.appendChild(el("p", "analytics__note", "No usage observed in range."));
+    return block;
+  }
+
+  const table = el("table", "table table--attribution");
+  table.appendChild(headerRow(["Repository", "Usage", "Share", "Sweeps", "Models", "Accounts"]));
+  const tbody = document.createElement("tbody");
+
+  for (const repo of attribution.repos) {
+    const row = document.createElement("tr");
+    row.setAttribute("data-repo", repo.repo);
+    cell(row, repo.repo, "cell--repo");
+    cell(row, formatPercent(repo.usage, 2));
+    cell(row, formatPercent(repo.share, 1));
+    cell(row, String(repo.sweepCount));
+    cell(row, repo.byModel.map((entry) => `${entry.name} ${formatPercent(entry.usage, 2)}`).join(", ") || UNKNOWN);
+    cell(row, repo.byAccount.map((entry) => `${entry.name} ${formatPercent(entry.usage, 2)}`).join(", ") || UNKNOWN);
+    tbody.appendChild(row);
+  }
+
+  if (attribution.unattributedUsage > 0) {
+    const row = document.createElement("tr");
+    row.className = "row--unattributed";
+    row.setAttribute("data-repo", "(unattributed)");
+    cell(row, "(unattributed)", "cell--repo");
+    cell(row, formatPercent(attribution.unattributedUsage, 2));
+    cell(row, formatPercent(attribution.unattributedUsage / attribution.totalUsage, 1));
+    cell(row, UNKNOWN);
+    cell(row, UNKNOWN);
+    cell(row, UNKNOWN);
+    tbody.appendChild(row);
+  }
+
+  table.appendChild(tbody);
+  block.appendChild(table);
+  block.appendChild(
+    el(
+      "p",
+      "analytics__note",
+      "Usage is in limit-window fractions (1.00 = one account's full window), not tokens or dollars — " +
+        "the telemetry reports no absolute counts. tokens.snapshot carries no repo, so usage is joined to " +
+        "sweeps by host and time overlap and split across concurrent sweeps in proportion to overlap " +
+        "duration. Usage during intervals with no running sweep (crons, manual sessions) is reported as " +
+        "unattributed rather than redistributed.",
+    ),
+  );
+  block.appendChild(
+    el(
+      "p",
+      "analytics__note",
+      `Coverage: ${attribution.attributedIntervals} attributed intervals, ` +
+        `${attribution.droppedIntervals} dropped across telemetry gaps, ` +
+        `${attribution.rolloverIntervals} limit-window rollovers skipped.`,
+    ),
+  );
+  return block;
+}
+
+// ---------------------------------------------------------------------------
+// Mount
+// ---------------------------------------------------------------------------
+
+export interface MountOptions extends RenderOptions {
+  /** How far back to pull history. Default 24 h. */
+  lookbackMs?: number;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+}
+
+const DEFAULT_LOOKBACK_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Fetch, compute and render the panel. The one call an app shell needs.
+ *
+ * On a non-authenticated surface it renders the withheld notice and **makes no
+ * request at all** — the panel does not merely hide data it already fetched.
+ */
+export async function mountTokenAnalytics(
+  container: HTMLElement,
+  options: MountOptions = {},
+): Promise<TokenAnalytics | undefined> {
+  const surface = options.surface ?? REQUIRED_SURFACE;
+  if (surface !== REQUIRED_SURFACE) {
+    container.replaceChildren(renderWithheldNotice());
+    return undefined;
+  }
+
+  const now = options.now ?? Date.now();
+  container.replaceChildren(el("p", "analytics__note", "Loading token analytics…"));
+
+  let records: HistoryEnvelope[];
+  try {
+    records = await fetchHistory({
+      since: now - (options.lookbackMs ?? DEFAULT_LOOKBACK_MS),
+      fetchImpl: options.fetchImpl,
+      signal: options.signal,
+    });
+  } catch (error) {
+    container.replaceChildren(
+      el("p", "analytics__error", `Could not load token analytics: ${(error as Error).message}`),
+    );
+    return undefined;
+  }
+
+  const analytics = computeTokenAnalytics(records, { now });
+  renderTokenAnalytics(container, analytics, { surface, now });
+  return analytics;
+}

--- a/dashboard/web/src/analytics/types.ts
+++ b/dashboard/web/src/analytics/types.ts
@@ -1,0 +1,103 @@
+/**
+ * Wire + domain types for the token/cost analytics view (Epic #4702, Phase 3,
+ * issue #4752).
+ *
+ * **Source of truth is the backend, not this file.** The record payloads below
+ * are re-declarations of `.loom/docs/telemetry-schema.md`'s `tokens.snapshot`
+ * / `sweep.started` / `sweep.completed` / `sweep.outcome` sections, and the
+ * envelope mirrors `../../src/query.ts`'s `HistoryRecord` as documented in
+ * `../../docs/query-api.md`. They are re-declared rather than imported across
+ * the package boundary because the backend modules compile against
+ * `@cloudflare/workers-types` (they reference `D1Database` /
+ * `DurableObjectState` globals), which a browser bundle has no business
+ * depending on.
+ *
+ * Everything the daemon may omit is optional here. The telemetry schema is
+ * explicitly additive/forward-compatible: an older daemon omits fields a newer
+ * one sends, and a newer daemon sends fields this build has never heard of.
+ * `parse.ts` narrows the wire JSON field by field and drops anything
+ * wrong-typed, so a partial or future record degrades to "unknown" rather than
+ * throwing — and every computation in this directory treats an absent field as
+ * unknown, never as zero.
+ */
+
+// ---------------------------------------------------------------------------
+// Wire shapes (`GET /api/history`)
+// ---------------------------------------------------------------------------
+
+/** One account inside a `tokens.snapshot`. Only `exhausted` is always sent;
+ * `rank` / `usage_fraction` / `limit_window_reset_at` are omitted when the
+ * daemon does not know them. */
+export interface TokenAccountPayload {
+  account?: string;
+  rank?: number;
+  usage_fraction?: number;
+  limit_window_reset_at?: string;
+  exhausted?: boolean;
+}
+
+/** `tokens.snapshot` — point-in-time view of the multi-account token pool.
+ * Host-level: it carries no `repo`, which is the whole reason per-repo
+ * attribution needs the join in `attribution.ts`. */
+export interface TokensSnapshotPayload {
+  kind?: string;
+  captured_at?: string;
+  accounts?: TokenAccountPayload[];
+}
+
+/** The subset of the `HistoryRecord` envelope this view reads. Fields the
+ * backend nulls for a redacted record (`repo`, `issue`, `sweepId`) are
+ * `null`-able here for exactly that reason. */
+export interface HistoryEnvelope {
+  id: number;
+  emittedAt: string;
+  hostId: string;
+  kind: string;
+  repo?: string | null;
+  visibility?: string | null;
+  issue?: number | null;
+  sweepId?: string | null;
+  record: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Domain shapes (post-`parse.ts`)
+// ---------------------------------------------------------------------------
+
+/** One `tokens.snapshot` narrowed to what the analytics need: a host, an
+ * instant (epoch ms), and the per-account readings at that instant. */
+export interface TokenSample {
+  hostId: string;
+  /** Epoch ms of the record's own `captured_at` (daemon clock), falling back
+   * to the envelope's `emittedAt` when `captured_at` is absent/unparseable. */
+  at: number;
+  accounts: AccountReading[];
+}
+
+export interface AccountReading {
+  account: string;
+  rank?: number;
+  /** `usage_fraction` in `[0, 1]`. Absent when the daemon could not measure
+   * it — treated as unknown (the sample is skipped for burn/forecast), never
+   * as `0`. */
+  usageFraction?: number;
+  /** Epoch ms of `limit_window_reset_at`, when known. */
+  limitWindowResetAt?: number;
+  exhausted: boolean;
+}
+
+/** A sweep's active window, reconstructed from its lifecycle records. This is
+ * the only record family that carries `repo`/`model`, so it is the sole
+ * bridge between fleet-wide token usage and a repository. */
+export interface SweepWindow {
+  hostId: string;
+  sweepId: string;
+  repo: string;
+  model?: string;
+  issue?: number;
+  /** Epoch ms — `sweep.started.started_at`. */
+  startedAt: number;
+  /** Epoch ms — `sweep.completed.completed_at`, or `undefined` while the
+   * sweep is still in flight (see `attribution.ts`'s open-window cap). */
+  endedAt?: number;
+}

--- a/dashboard/web/src/index.ts
+++ b/dashboard/web/src/index.ts
@@ -30,3 +30,39 @@ export * from "./charts/outcomesChartView.js";
 export * from "./charts/successRateChartView.js";
 export * from "./charts/durationsChartView.js";
 export * from "./historicalChartsPanel.js";
+
+// Token/cost analytics (issue #4752). `types.js` is exported first above, so
+// the analytics modules are re-exported individually rather than via a nested
+// barrel — `analytics/types.js` deliberately layers its own domain shapes on
+// the shared wire types and only the domain shapes belong on this surface.
+export type {
+  AccountReading,
+  HistoryEnvelope,
+  SweepWindow,
+  TokenAccountPayload,
+  TokenSample,
+  TokensSnapshotPayload,
+} from "./analytics/types.js";
+export * from "./analytics/parse.js";
+export * from "./analytics/burn.js";
+export * from "./analytics/forecast.js";
+export * from "./analytics/format.js";
+// `attribution.ts` and `burn.ts` each own a `DEFAULT_MAX_SAMPLE_GAP_MS`. They
+// are genuinely two independent knobs — one decides where a burn curve is cut
+// into segments, the other decides which snapshot pairs are too far apart to
+// attribute at all — so they are not merged; the barrel disambiguates instead.
+export {
+  attributeUsageToRepos,
+  DEFAULT_EDGE_TOLERANCE_MS,
+  DEFAULT_MAX_SAMPLE_GAP_MS as DEFAULT_ATTRIBUTION_MAX_SAMPLE_GAP_MS,
+  DEFAULT_OPEN_SWEEP_MAX_DURATION_MS,
+} from "./analytics/attribution.js";
+export type {
+  AttributionOptions,
+  AttributionResult,
+  NamedUsage,
+  RepoAttribution,
+} from "./analytics/attribution.js";
+export * from "./analytics/api.js";
+export * from "./analytics/render.js";
+export * from "./analytics/bootstrap.js";

--- a/dashboard/web/test/analyticsApi.test.ts
+++ b/dashboard/web/test/analyticsApi.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchHistory } from "../src/analytics/api.js";
+import { T0, resetIds, tokensSnapshot } from "./analyticsFixtures.js";
+
+beforeEach(resetIds);
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+describe("fetchHistory", () => {
+  it("requests the authenticated prefix at the API's maximum page size", async () => {
+    const calls: string[] = [];
+    const fetchImpl = vi.fn(async (url: string) => {
+      calls.push(url);
+      return jsonResponse({ records: [], nextCursor: null });
+    }) as unknown as typeof fetch;
+
+    await fetchHistory({ since: T0, fetchImpl });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("/api/history?");
+    expect(calls[0]).toContain("limit=500");
+    expect(calls[0]).toContain(encodeURIComponent(new Date(T0).toISOString()));
+  });
+
+  it("walks the keyset cursor until the API stops issuing one", async () => {
+    const pages = [
+      { records: [tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }])], nextCursor: 9 },
+      { records: [tokensSnapshot(T0, [{ account: "agent-1", usage: 0.2 }])], nextCursor: null },
+    ];
+    let index = 0;
+    const seen: string[] = [];
+    const fetchImpl = vi.fn(async (url: string) => {
+      seen.push(url);
+      return jsonResponse(pages[index++]);
+    }) as unknown as typeof fetch;
+
+    const records = await fetchHistory({ fetchImpl });
+
+    expect(records).toHaveLength(2);
+    expect(seen).toHaveLength(2);
+    expect(seen[1]).toContain("cursor=9");
+  });
+
+  it("stops at maxPages so a busy fleet cannot hang the page", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ records: [tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }])], nextCursor: 5 }),
+    ) as unknown as typeof fetch;
+
+    await fetchHistory({ fetchImpl, maxPages: 3 });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws on a non-2xx response", async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 401 }) as unknown as Response) as unknown as typeof fetch;
+    await expect(fetchHistory({ fetchImpl })).rejects.toThrow("401");
+  });
+
+  it("drops rows missing the fields every consumer needs", async () => {
+    const good = tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]);
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({
+        records: [good, { id: "not-a-number" }, { id: 2, hostId: "host-a" }, null, "nope"],
+        nextCursor: null,
+      }),
+    ) as unknown as typeof fetch;
+
+    const records = await fetchHistory({ fetchImpl });
+
+    expect(records).toHaveLength(1);
+    expect(records[0]?.kind).toBe("tokens.snapshot");
+  });
+
+  it("treats an unparseable body as an empty final page", async () => {
+    const fetchImpl = vi.fn(async () =>
+      ({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new Error("not json");
+        },
+      }) as unknown as Response,
+    ) as unknown as typeof fetch;
+
+    await expect(fetchHistory({ fetchImpl })).resolves.toEqual([]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/dashboard/web/test/analyticsFixtures.ts
+++ b/dashboard/web/test/analyticsFixtures.ts
@@ -1,0 +1,151 @@
+/**
+ * Fixture builders for the token/cost analytics suite (issue #4752).
+ *
+ * These produce `GET /api/history` envelopes in exactly the shape
+ * `../../docs/query-api.md` documents, with record payloads matching
+ * `.loom/docs/telemetry-schema.md` — so a test that passes here is a test
+ * against the documented contract, not against the parser's convenience.
+ *
+ * Every builder takes epoch ms and serializes to RFC 3339, because the wire
+ * format is a string and the parser's `Date.parse` handling is part of what is
+ * under test.
+ */
+
+import type { HistoryEnvelope } from "../src/analytics/types.js";
+
+/** A convenient, readable base instant: 2026-07-30T12:00:00Z. */
+export const T0 = Date.parse("2026-07-30T12:00:00Z");
+
+export const MINUTE = 60 * 1000;
+export const HOUR = 60 * MINUTE;
+
+let nextId = 1;
+
+/** Reset the monotonic envelope id counter between tests that assert on ids. */
+export function resetIds(): void {
+  nextId = 1;
+}
+
+/**
+ * Index into an array, asserting the element exists.
+ *
+ * `noUncheckedIndexedAccess` is on, so `items[0]` is `T | undefined`.
+ * Assertions that merely *read* a field use optional chaining (the convention
+ * the sibling suites use — see `test/timelineBuilder.test.ts`); this helper is
+ * for the handful of places where the element is a function argument or an
+ * assignment target, where a `?.` would quietly change what the test asserts.
+ */
+export function at<T>(items: readonly T[], index: number): T {
+  const value = items[index];
+  if (value === undefined) {
+    throw new Error(`expected an element at index ${index}, but the array has ${items.length}`);
+  }
+  return value;
+}
+
+export interface AccountFixture {
+  account: string;
+  rank?: number;
+  usage?: number;
+  resetAt?: number;
+  exhausted?: boolean;
+}
+
+/** One `tokens.snapshot` history envelope. `usage`/`rank`/`resetAt` are omitted
+ * from the payload when undefined — mirroring the daemon's "omit when unknown"
+ * contract, which is what makes "unknown != zero" testable. */
+export function tokensSnapshot(
+  at: number,
+  accounts: readonly AccountFixture[],
+  hostId = "host-a",
+): HistoryEnvelope {
+  return {
+    id: nextId++,
+    emittedAt: new Date(at).toISOString(),
+    hostId,
+    kind: "tokens.snapshot",
+    repo: null,
+    visibility: "private",
+    issue: null,
+    sweepId: null,
+    record: {
+      kind: "tokens.snapshot",
+      captured_at: new Date(at).toISOString(),
+      accounts: accounts.map((account) => ({
+        account: account.account,
+        ...(account.rank !== undefined && { rank: account.rank }),
+        ...(account.usage !== undefined && { usage_fraction: account.usage }),
+        ...(account.resetAt !== undefined && {
+          limit_window_reset_at: new Date(account.resetAt).toISOString(),
+        }),
+        exhausted: account.exhausted ?? false,
+      })),
+    },
+  };
+}
+
+export interface SweepFixture {
+  sweepId: string;
+  repo: string;
+  startedAt: number;
+  completedAt?: number;
+  model?: string;
+  issue?: number;
+  hostId?: string;
+}
+
+/** The `sweep.started` (+ optional `sweep.completed`) envelopes for one sweep. */
+export function sweepRecords(sweep: SweepFixture): HistoryEnvelope[] {
+  const hostId = sweep.hostId ?? "host-a";
+  const base = {
+    repo: sweep.repo,
+    visibility: "public" as const,
+    issue: sweep.issue ?? null,
+    sweepId: sweep.sweepId,
+  };
+
+  const records: HistoryEnvelope[] = [
+    {
+      id: nextId++,
+      emittedAt: new Date(sweep.startedAt).toISOString(),
+      hostId,
+      kind: "sweep.started",
+      ...base,
+      record: {
+        kind: "sweep.started",
+        repo: sweep.repo,
+        visibility: "public",
+        ...(sweep.issue !== undefined && { issue: sweep.issue }),
+        sweep_id: sweep.sweepId,
+        started_at: new Date(sweep.startedAt).toISOString(),
+        ...(sweep.model !== undefined && { model: sweep.model }),
+      },
+    },
+  ];
+
+  if (sweep.completedAt !== undefined) {
+    records.push({
+      id: nextId++,
+      emittedAt: new Date(sweep.completedAt).toISOString(),
+      hostId,
+      kind: "sweep.completed",
+      ...base,
+      record: {
+        kind: "sweep.completed",
+        repo: sweep.repo,
+        visibility: "public",
+        ...(sweep.issue !== undefined && { issue: sweep.issue }),
+        sweep_id: sweep.sweepId,
+        completed_at: new Date(sweep.completedAt).toISOString(),
+        result: "success",
+      },
+    });
+  }
+
+  return records;
+}
+
+/** Emulate the API's newest-first ordering, which every consumer must tolerate. */
+export function newestFirst(records: readonly HistoryEnvelope[]): HistoryEnvelope[] {
+  return [...records].sort((a, b) => b.id - a.id);
+}

--- a/dashboard/web/test/analyticsFormat.test.ts
+++ b/dashboard/web/test/analyticsFormat.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  UNKNOWN,
+  formatDuration,
+  formatPercent,
+  formatRatePerHour,
+  formatRelative,
+} from "../src/analytics/format.js";
+
+describe("format helpers", () => {
+  it("renders an unknown value as an em-dash, never as zero", () => {
+    expect(formatPercent(undefined)).toBe(UNKNOWN);
+    expect(formatRatePerHour(undefined)).toBe(UNKNOWN);
+    expect(formatDuration(undefined)).toBe(UNKNOWN);
+    expect(formatRelative(undefined)).toBe(UNKNOWN);
+    // ...while a genuine zero still renders as zero.
+    expect(formatPercent(0)).toBe("0.0%");
+    expect(formatRatePerHour(0)).toBe("0.0%/h");
+  });
+
+  it("formats fractions and rates", () => {
+    expect(formatPercent(0.4237)).toBe("42.4%");
+    expect(formatPercent(0.4237, 2)).toBe("42.37%");
+    expect(formatRatePerHour(0.125)).toBe("12.5%/h");
+  });
+
+  it("formats durations coarsely", () => {
+    expect(formatDuration(45)).toBe("45s");
+    expect(formatDuration(600)).toBe("10m");
+    expect(formatDuration(3 * 3600 + 300)).toBe("3h 5m");
+    expect(formatDuration(2 * 86400 + 3600)).toBe("2d 1h");
+  });
+
+  it("signs relative durations", () => {
+    expect(formatRelative(2400)).toBe("in 40m");
+    expect(formatRelative(-2400)).toBe("40m ago");
+    expect(formatRelative(5)).toBe("now");
+  });
+});

--- a/dashboard/web/test/analyticsParse.test.ts
+++ b/dashboard/web/test/analyticsParse.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { parseSweepWindows, parseTimestamp, parseTokenSample, parseTokenSamples } from "../src/analytics/parse.js";
+import type { HistoryEnvelope } from "../src/analytics/types.js";
+import { HOUR, MINUTE, T0, at, newestFirst, resetIds, sweepRecords, tokensSnapshot } from "./analyticsFixtures.js";
+
+beforeEach(resetIds);
+
+describe("parseTimestamp", () => {
+  it("parses RFC 3339 to epoch ms", () => {
+    expect(parseTimestamp("2026-07-30T12:00:00Z")).toBe(T0);
+  });
+
+  it("returns undefined for absent, empty, or unparseable values", () => {
+    expect(parseTimestamp(undefined)).toBeUndefined();
+    expect(parseTimestamp("")).toBeUndefined();
+    expect(parseTimestamp("not a date")).toBeUndefined();
+    expect(parseTimestamp(1234)).toBeUndefined();
+  });
+});
+
+describe("parseTokenSample", () => {
+  it("narrows a documented tokens.snapshot payload", () => {
+    const sample = parseTokenSample(
+      tokensSnapshot(T0, [
+        { account: "agent-1", rank: 0, usage: 0.42, resetAt: T0 + 6 * HOUR },
+        { account: "agent-2", exhausted: true },
+      ]),
+    );
+
+    expect(sample?.at).toBe(T0);
+    expect(sample?.hostId).toBe("host-a");
+    expect(sample?.accounts).toEqual([
+      { account: "agent-1", rank: 0, usageFraction: 0.42, limitWindowResetAt: T0 + 6 * HOUR, exhausted: false },
+      { account: "agent-2", rank: undefined, usageFraction: undefined, limitWindowResetAt: undefined, exhausted: true },
+    ]);
+  });
+
+  it("keeps an unmeasured usage_fraction absent rather than zero", () => {
+    const sample = parseTokenSample(tokensSnapshot(T0, [{ account: "agent-2", exhausted: true }]));
+    expect(sample?.accounts[0]?.usageFraction).toBeUndefined();
+    expect(sample?.accounts[0]?.usageFraction).not.toBe(0);
+  });
+
+  it("ignores non-tokens.snapshot kinds", () => {
+    expect(
+      parseTokenSample(at(sweepRecords({ sweepId: "s1", repo: "o/r", startedAt: T0 }), 0)),
+    ).toBeUndefined();
+  });
+
+  it("falls back to emittedAt when captured_at is missing", () => {
+    const envelope = tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]);
+    delete (envelope.record as Record<string, unknown>).captured_at;
+    expect(parseTokenSample(envelope)?.at).toBe(T0);
+  });
+
+  it("drops accounts with no name and survives a malformed accounts array", () => {
+    const envelope: HistoryEnvelope = {
+      id: 1,
+      emittedAt: new Date(T0).toISOString(),
+      hostId: "host-a",
+      kind: "tokens.snapshot",
+      record: { kind: "tokens.snapshot", captured_at: new Date(T0).toISOString(), accounts: ["nope", { rank: 1 }, null] },
+    };
+    expect(parseTokenSample(envelope)?.accounts).toEqual([]);
+  });
+});
+
+describe("parseTokenSamples", () => {
+  it("returns chronological order even from the API's newest-first pages", () => {
+    const records = newestFirst([
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]),
+      tokensSnapshot(T0 + MINUTE, [{ account: "agent-1", usage: 0.2 }]),
+      tokensSnapshot(T0 + 2 * MINUTE, [{ account: "agent-1", usage: 0.3 }]),
+    ]);
+    expect(parseTokenSamples(records).map((sample) => sample.at)).toEqual([T0, T0 + MINUTE, T0 + 2 * MINUTE]);
+  });
+});
+
+describe("parseSweepWindows", () => {
+  it("pairs sweep.started with sweep.completed into one window", () => {
+    const windows = parseSweepWindows(
+      newestFirst([
+        ...sweepRecords({
+          sweepId: "sweep-issue-1-0",
+          repo: "rjwalters/loom",
+          startedAt: T0,
+          completedAt: T0 + 30 * MINUTE,
+          model: "opus",
+          issue: 1,
+        }),
+      ]),
+    );
+
+    expect(windows).toHaveLength(1);
+    expect(windows[0]).toMatchObject({
+      hostId: "host-a",
+      sweepId: "sweep-issue-1-0",
+      repo: "rjwalters/loom",
+      model: "opus",
+      issue: 1,
+      startedAt: T0,
+      endedAt: T0 + 30 * MINUTE,
+    });
+  });
+
+  it("leaves an in-flight sweep's window open", () => {
+    const windows = parseSweepWindows(sweepRecords({ sweepId: "s1", repo: "o/r", startedAt: T0 }));
+    expect(windows[0]?.endedAt).toBeUndefined();
+  });
+
+  it("keeps same-id sweeps on different hosts separate", () => {
+    const windows = parseSweepWindows([
+      ...sweepRecords({ sweepId: "sweep-issue-1-0", repo: "o/a", startedAt: T0, hostId: "host-a" }),
+      ...sweepRecords({ sweepId: "sweep-issue-1-0", repo: "o/b", startedAt: T0, hostId: "host-b" }),
+    ]);
+    expect(windows).toHaveLength(2);
+    expect(windows.map((window) => window.hostId).sort()).toEqual(["host-a", "host-b"]);
+  });
+
+  it("skips a redacted record whose repo was nulled", () => {
+    const started = at(sweepRecords({ sweepId: "s1", repo: "o/r", startedAt: T0 }), 0);
+    started.repo = null;
+    delete (started.record as Record<string, unknown>).repo;
+    expect(parseSweepWindows([started])).toEqual([]);
+  });
+
+  it("ignores a terminal record with no matching start", () => {
+    const records = sweepRecords({ sweepId: "s1", repo: "o/r", startedAt: T0, completedAt: T0 + MINUTE });
+    expect(parseSweepWindows([at(records, 1)])).toEqual([]);
+  });
+});

--- a/dashboard/web/test/attribution.test.ts
+++ b/dashboard/web/test/attribution.test.ts
@@ -1,0 +1,452 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { attributeUsageToRepos } from "../src/analytics/attribution.js";
+import { parseSweepWindows, parseTokenSamples } from "../src/analytics/parse.js";
+import type { HistoryEnvelope } from "../src/analytics/types.js";
+import { HOUR, MINUTE, T0, at, newestFirst, resetIds, sweepRecords, tokensSnapshot } from "./analyticsFixtures.js";
+
+beforeEach(resetIds);
+
+/** Run the full join over a mixed history page, as the view does. */
+function attribute(records: readonly HistoryEnvelope[], options: Parameters<typeof attributeUsageToRepos>[2] = {}) {
+  const page = newestFirst(records);
+  return attributeUsageToRepos(parseTokenSamples(page), parseSweepWindows(page), { now: T0 + 24 * HOUR, ...options });
+}
+
+describe("attributeUsageToRepos — the join", () => {
+  it("attributes an interval's delta to the one sweep covering it", () => {
+    const result = attribute([
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]),
+      tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.2 }]),
+      ...sweepRecords({
+        sweepId: "sweep-issue-1-0",
+        repo: "rjwalters/loom",
+        startedAt: T0 - 5 * MINUTE,
+        completedAt: T0 + 15 * MINUTE,
+        model: "opus",
+      }),
+    ]);
+
+    expect(result.repos).toHaveLength(1);
+    expect(result.repos[0]?.repo).toBe("rjwalters/loom");
+    expect(result.repos[0]?.usage).toBeCloseTo(0.1, 10);
+    expect(result.repos[0]?.share).toBeCloseTo(1, 10);
+    expect(result.repos[0]?.sweepCount).toBe(1);
+    expect(result.repos[0]?.byModel).toEqual([{ name: "opus", usage: expect.closeTo(0.1, 10) }]);
+    expect(result.repos[0]?.byAccount).toEqual([{ name: "agent-1", usage: expect.closeTo(0.1, 10) }]);
+    expect(result.unattributedUsage).toBe(0);
+    expect(result.attributedIntervals).toBe(1);
+  });
+
+  it("splits an interval evenly between two fully-overlapping sweeps", () => {
+    const result = attribute(
+      [
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]),
+        tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.2 }]),
+        ...sweepRecords({
+          sweepId: "s-alpha",
+          repo: "org/alpha",
+          startedAt: T0 - MINUTE,
+          completedAt: T0 + 11 * MINUTE,
+        }),
+        ...sweepRecords({
+          sweepId: "s-beta",
+          repo: "org/beta",
+          startedAt: T0 - MINUTE,
+          completedAt: T0 + 11 * MINUTE,
+        }),
+      ],
+      { edgeToleranceMs: 0 },
+    );
+
+    expect(result.repos.map((repo) => repo.repo).sort()).toEqual(["org/alpha", "org/beta"]);
+    for (const repo of result.repos) expect(repo.usage).toBeCloseTo(0.05, 10);
+    expect(result.totalUsage).toBeCloseTo(0.1, 10);
+  });
+
+  it("splits in proportion to overlap duration for partially-overlapping sweeps", () => {
+    // Interval is 10 minutes. `long` covers all 10; `short` covers the last 5.
+    // Overlap-weighted split is therefore 10:5 → two thirds / one third.
+    const result = attribute(
+      [
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0 }]),
+        tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.3 }]),
+        ...sweepRecords({
+          sweepId: "s-long",
+          repo: "org/long",
+          startedAt: T0 - HOUR,
+          completedAt: T0 + HOUR,
+        }),
+        ...sweepRecords({
+          sweepId: "s-short",
+          repo: "org/short",
+          startedAt: T0 + 5 * MINUTE,
+          completedAt: T0 + 10 * MINUTE,
+        }),
+      ],
+      { edgeToleranceMs: 0 },
+    );
+
+    const byRepo = new Map(result.repos.map((repo) => [repo.repo, repo.usage]));
+    expect(byRepo.get("org/long")).toBeCloseTo(0.2, 10);
+    expect(byRepo.get("org/short")).toBeCloseTo(0.1, 10);
+    expect(result.unattributedUsage).toBe(0);
+  });
+
+  it("attributes only the covered share of a partially-covered interval", () => {
+    // The sweep runs for 2 of the interval's 10 minutes. Usage is assumed
+    // uniform, so it claims a fifth — not all of it merely for being the only
+    // sweep in sight.
+    const result = attribute(
+      [
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0 }]),
+        tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.5 }]),
+        ...sweepRecords({
+          sweepId: "s-brief",
+          repo: "org/brief",
+          startedAt: T0,
+          completedAt: T0 + 2 * MINUTE,
+        }),
+      ],
+      { edgeToleranceMs: 0 },
+    );
+
+    expect(result.repos[0]?.usage).toBeCloseTo(0.1, 10);
+    expect(result.unattributedUsage).toBeCloseTo(0.4, 10);
+    expect(result.totalUsage).toBeCloseTo(0.5, 10);
+  });
+
+  it("counts overlapping sweeps' shared seconds once when measuring coverage", () => {
+    // Two sweeps each cover the same half of the interval. Coverage is 50%,
+    // not 100% — the union, not the sum — and the covered half is then split
+    // evenly between them.
+    const result = attribute(
+      [
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0 }]),
+        tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.4 }]),
+        ...sweepRecords({ sweepId: "s-1", repo: "org/one", startedAt: T0, completedAt: T0 + 5 * MINUTE }),
+        ...sweepRecords({ sweepId: "s-2", repo: "org/two", startedAt: T0, completedAt: T0 + 5 * MINUTE }),
+      ],
+      { edgeToleranceMs: 0 },
+    );
+
+    for (const repo of result.repos) expect(repo.usage).toBeCloseTo(0.1, 10);
+    expect(result.unattributedUsage).toBeCloseTo(0.2, 10);
+  });
+
+  it("reports usage with no overlapping sweep as unattributed, not redistributed", () => {
+    const result = attribute([
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]),
+      tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.2 }]),
+      // A sweep that ran well after the observed interval — a cron or manual
+      // session burned the tokens in between.
+      ...sweepRecords({
+        sweepId: "s-later",
+        repo: "org/later",
+        startedAt: T0 + 30 * MINUTE,
+        completedAt: T0 + 40 * MINUTE,
+      }),
+    ]);
+
+    expect(result.repos).toEqual([]);
+    expect(result.unattributedUsage).toBeCloseTo(0.1, 10);
+    expect(result.totalUsage).toBeCloseTo(0.1, 10);
+    expect(result.attributedIntervals).toBe(0);
+  });
+
+  it("mixes attributed and unattributed intervals in one run", () => {
+    const result = attribute(
+      [
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]),
+        tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.2 }]),
+        tokensSnapshot(T0 + 20 * MINUTE, [{ account: "agent-1", usage: 0.5 }]),
+        ...sweepRecords({
+          sweepId: "s-first",
+          repo: "org/first",
+          startedAt: T0,
+          completedAt: T0 + 10 * MINUTE,
+        }),
+      ],
+      { edgeToleranceMs: 0 },
+    );
+
+    expect(result.repos).toHaveLength(1);
+    expect(result.repos[0]?.usage).toBeCloseTo(0.1, 10);
+    expect(result.repos[0]?.share).toBeCloseTo(0.25, 10);
+    expect(result.unattributedUsage).toBeCloseTo(0.3, 10);
+  });
+
+  it("never attributes across hosts", () => {
+    const result = attribute([
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }], "host-a"),
+      tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.2 }], "host-a"),
+      ...sweepRecords({
+        sweepId: "s-elsewhere",
+        repo: "org/elsewhere",
+        startedAt: T0 - MINUTE,
+        completedAt: T0 + 11 * MINUTE,
+        hostId: "host-b",
+      }),
+    ]);
+
+    expect(result.repos).toEqual([]);
+    expect(result.unattributedUsage).toBeCloseTo(0.1, 10);
+  });
+
+  it("keeps per-host usage on its own host when both are busy", () => {
+    const result = attribute([
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }], "host-a"),
+      tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.2 }], "host-a"),
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 0.4 }], "host-b"),
+      tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.7 }], "host-b"),
+      ...sweepRecords({
+        sweepId: "s-a",
+        repo: "org/on-a",
+        startedAt: T0 - MINUTE,
+        completedAt: T0 + 11 * MINUTE,
+        hostId: "host-a",
+      }),
+      ...sweepRecords({
+        sweepId: "s-b",
+        repo: "org/on-b",
+        startedAt: T0 - MINUTE,
+        completedAt: T0 + 11 * MINUTE,
+        hostId: "host-b",
+      }),
+    ]);
+
+    const byRepo = new Map(result.repos.map((repo) => [repo.repo, repo.usage]));
+    expect(byRepo.get("org/on-a")).toBeCloseTo(0.1, 10);
+    expect(byRepo.get("org/on-b")).toBeCloseTo(0.3, 10);
+  });
+});
+
+describe("attributeUsageToRepos — tolerances", () => {
+  it("claims an interval a sweep starts just after, within the edge tolerance", () => {
+    const records = [
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]),
+      tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.2 }]),
+      // Starts 30s after the interval closes — clock skew between the pool
+      // sampler and the sweep, not a genuinely later sweep.
+      ...sweepRecords({
+        sweepId: "s-skewed",
+        repo: "org/skewed",
+        startedAt: T0 + 10 * MINUTE + 30 * 1000,
+        completedAt: T0 + 20 * MINUTE,
+      }),
+    ];
+
+    expect(attribute(records).repos.map((repo) => repo.repo)).toEqual(["org/skewed"]);
+    expect(attribute(records, { edgeToleranceMs: 0 }).repos).toEqual([]);
+  });
+
+  it("drops an interval that straddles a telemetry gap", () => {
+    const result = attribute([
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]),
+      tokensSnapshot(T0 + 5 * HOUR, [{ account: "agent-1", usage: 0.6 }]),
+      ...sweepRecords({
+        sweepId: "s-long",
+        repo: "org/long",
+        startedAt: T0 - MINUTE,
+        completedAt: T0 + 6 * HOUR,
+      }),
+    ]);
+
+    expect(result.droppedIntervals).toBe(1);
+    expect(result.repos).toEqual([]);
+    expect(result.totalUsage).toBe(0);
+  });
+
+  it("attributes across a wide gap when the caller widens the tolerance", () => {
+    const records = [
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]),
+      tokensSnapshot(T0 + 5 * HOUR, [{ account: "agent-1", usage: 0.6 }]),
+      ...sweepRecords({
+        sweepId: "s-long",
+        repo: "org/long",
+        startedAt: T0 - MINUTE,
+        completedAt: T0 + 6 * HOUR,
+      }),
+    ];
+
+    const result = attribute(records, { maxSampleGapMs: 6 * HOUR });
+    expect(result.droppedIntervals).toBe(0);
+    expect(result.repos[0]?.usage).toBeCloseTo(0.5, 10);
+  });
+
+  it("caps an in-flight sweep so it cannot absorb the whole day", () => {
+    const records = [
+      // Inside the 6h cap.
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]),
+      tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.2 }]),
+      // Well past it — the sweep never emitted a terminal record.
+      tokensSnapshot(T0 + 8 * HOUR, [{ account: "agent-1", usage: 0.3 }]),
+      tokensSnapshot(T0 + 8 * HOUR + 10 * MINUTE, [{ account: "agent-1", usage: 0.45 }]),
+      ...sweepRecords({ sweepId: "s-stuck", repo: "org/stuck", startedAt: T0 - MINUTE }),
+    ];
+
+    const result = attribute(records);
+    expect(result.repos[0]?.repo).toBe("org/stuck");
+    expect(result.repos[0]?.usage).toBeCloseTo(0.1, 10);
+    expect(result.unattributedUsage).toBeCloseTo(0.15, 10);
+  });
+
+  it("lets a still-open sweep claim right up to now", () => {
+    const result = attribute(
+      [
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]),
+        tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.2 }]),
+        ...sweepRecords({ sweepId: "s-running", repo: "org/running", startedAt: T0 - MINUTE }),
+      ],
+      { now: T0 + 20 * MINUTE },
+    );
+
+    expect(result.repos[0]?.repo).toBe("org/running");
+    expect(result.repos[0]?.usage).toBeCloseTo(0.1, 10);
+  });
+});
+
+describe("attributeUsageToRepos — usage semantics", () => {
+  it("treats a usage drop as a limit-window rollover, never as negative usage", () => {
+    const result = attribute([
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 0.9 }]),
+      tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.05 }]),
+      tokensSnapshot(T0 + 20 * MINUTE, [{ account: "agent-1", usage: 0.15 }]),
+      ...sweepRecords({
+        sweepId: "s-1",
+        repo: "org/one",
+        startedAt: T0 - MINUTE,
+        completedAt: T0 + 30 * MINUTE,
+      }),
+    ]);
+
+    expect(result.rolloverIntervals).toBe(1);
+    // Only the post-rollover climb (0.05 → 0.15) is attributable.
+    expect(result.repos[0]?.usage).toBeCloseTo(0.1, 10);
+    expect(result.totalUsage).toBeCloseTo(0.1, 10);
+  });
+
+  it("sums several accounts' deltas and breaks them down exactly", () => {
+    const result = attribute([
+      tokensSnapshot(T0, [
+        { account: "agent-1", usage: 0.1 },
+        { account: "agent-2", usage: 0.5 },
+      ]),
+      tokensSnapshot(T0 + 10 * MINUTE, [
+        { account: "agent-1", usage: 0.2 },
+        { account: "agent-2", usage: 0.55 },
+      ]),
+      ...sweepRecords({
+        sweepId: "s-1",
+        repo: "org/one",
+        startedAt: T0 - MINUTE,
+        completedAt: T0 + 11 * MINUTE,
+      }),
+    ]);
+
+    expect(result.repos[0]?.usage).toBeCloseTo(0.15, 10);
+    expect(result.repos[0]?.byAccount.map((entry) => entry.name)).toEqual(["agent-1", "agent-2"]);
+    expect(result.repos[0]?.byAccount[0]?.usage).toBeCloseTo(0.1, 10);
+    expect(result.repos[0]?.byAccount[1]?.usage).toBeCloseTo(0.05, 10);
+  });
+
+  it("ignores an account whose usage is unknown on either side of an interval", () => {
+    const result = attribute([
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }, { account: "agent-2" }]),
+      tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.2 }, { account: "agent-2", exhausted: true }]),
+      ...sweepRecords({
+        sweepId: "s-1",
+        repo: "org/one",
+        startedAt: T0 - MINUTE,
+        completedAt: T0 + 11 * MINUTE,
+      }),
+    ]);
+
+    expect(result.repos[0]?.usage).toBeCloseTo(0.1, 10);
+    expect(result.repos[0]?.byAccount.map((entry) => entry.name)).toEqual(["agent-1"]);
+  });
+
+  it("carries model through as a breakdown, inheriting the overlap split", () => {
+    const result = attribute(
+      [
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0 }]),
+        tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.2 }]),
+        ...sweepRecords({
+          sweepId: "s-opus",
+          repo: "org/one",
+          startedAt: T0 - MINUTE,
+          completedAt: T0 + 11 * MINUTE,
+          model: "opus",
+        }),
+        ...sweepRecords({
+          sweepId: "s-sonnet",
+          repo: "org/one",
+          startedAt: T0 - MINUTE,
+          completedAt: T0 + 11 * MINUTE,
+          model: "sonnet",
+        }),
+      ],
+      { edgeToleranceMs: 0 },
+    );
+
+    expect(result.repos).toHaveLength(1);
+    expect(result.repos[0]?.sweepCount).toBe(2);
+    expect(result.repos[0]?.byModel.map((entry) => entry.name).sort()).toEqual(["opus", "sonnet"]);
+    for (const entry of at(result.repos, 0).byModel) expect(entry.usage).toBeCloseTo(0.1, 10);
+  });
+
+  it("labels a sweep with no reported model as unknown rather than dropping it", () => {
+    const result = attribute([
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 0 }]),
+      tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.2 }]),
+      ...sweepRecords({
+        sweepId: "s-1",
+        repo: "org/one",
+        startedAt: T0 - MINUTE,
+        completedAt: T0 + 11 * MINUTE,
+      }),
+    ]);
+
+    expect(result.repos[0]?.byModel).toEqual([{ name: "unknown", usage: expect.closeTo(0.2, 10) }]);
+  });
+
+  it("ranks repos by attributed usage, descending", () => {
+    const result = attribute(
+      [
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0 }]),
+        tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.3 }]),
+        tokensSnapshot(T0 + 20 * MINUTE, [{ account: "agent-1", usage: 0.4 }]),
+        ...sweepRecords({
+          sweepId: "s-big",
+          repo: "org/big",
+          startedAt: T0,
+          completedAt: T0 + 10 * MINUTE,
+        }),
+        ...sweepRecords({
+          sweepId: "s-small",
+          repo: "org/small",
+          startedAt: T0 + 10 * MINUTE,
+          completedAt: T0 + 20 * MINUTE,
+        }),
+      ],
+      { edgeToleranceMs: 0 },
+    );
+
+    expect(result.repos.map((repo) => repo.repo)).toEqual(["org/big", "org/small"]);
+    expect(result.repos[0]?.share).toBeCloseTo(0.75, 10);
+    expect(result.repos[1]?.share).toBeCloseTo(0.25, 10);
+  });
+
+  it("reports the analyzed range and an empty result for an empty history", () => {
+    const empty = attributeUsageToRepos([], [], { now: T0 });
+    expect(empty).toMatchObject({ repos: [], unattributedUsage: 0, totalUsage: 0, droppedIntervals: 0 });
+    expect(empty.rangeStart).toBeUndefined();
+
+    const populated = attribute([
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]),
+      tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.2 }]),
+    ]);
+    expect(populated.rangeStart).toBe(T0);
+    expect(populated.rangeEnd).toBe(T0 + 10 * MINUTE);
+  });
+});

--- a/dashboard/web/test/burn.test.ts
+++ b/dashboard/web/test/burn.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { buildBurnCurves } from "../src/analytics/burn.js";
+import { parseTokenSamples } from "../src/analytics/parse.js";
+import { HOUR, MINUTE, T0, at, newestFirst, resetIds, tokensSnapshot } from "./analyticsFixtures.js";
+
+beforeEach(resetIds);
+
+describe("buildBurnCurves", () => {
+  it("builds one chronological series per account", () => {
+    const curves = buildBurnCurves(
+      parseTokenSamples(
+        newestFirst([
+          tokensSnapshot(T0, [
+            { account: "agent-1", rank: 0, usage: 0.1 },
+            { account: "agent-2", rank: 1, usage: 0.5 },
+          ]),
+          tokensSnapshot(T0 + 10 * MINUTE, [
+            { account: "agent-1", rank: 0, usage: 0.2 },
+            { account: "agent-2", rank: 1, usage: 0.55 },
+          ]),
+        ]),
+      ),
+    );
+
+    expect(curves.map((curve) => curve.account)).toEqual(["agent-1", "agent-2"]);
+    expect(curves[0]?.points.map((point) => point.usageFraction)).toEqual([0.1, 0.2]);
+    expect(curves[0]?.points.map((point) => point.at)).toEqual([T0, T0 + 10 * MINUTE]);
+    expect(curves[0]?.segments).toHaveLength(1);
+    expect(curves[0]?.currentSegment?.startedBy).toBe("initial");
+  });
+
+  it("orders curves by pool rank, then name", () => {
+    const curves = buildBurnCurves(
+      parseTokenSamples([
+        tokensSnapshot(T0, [
+          { account: "zeta", rank: 0, usage: 0.1 },
+          { account: "alpha", rank: 2, usage: 0.1 },
+          { account: "mid", rank: 1, usage: 0.1 },
+        ]),
+      ]),
+    );
+    expect(curves.map((curve) => curve.account)).toEqual(["zeta", "mid", "alpha"]);
+  });
+
+  it("keeps identically-named accounts on different hosts as separate curves", () => {
+    const curves = buildBurnCurves(
+      parseTokenSamples([
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }], "host-a"),
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.9 }], "host-b"),
+      ]),
+    );
+    expect(curves).toHaveLength(2);
+    expect(curves.map((curve) => `${curve.hostId}:${curve.points[0]?.usageFraction}`)).toEqual([
+      "host-a:0.1",
+      "host-b:0.9",
+    ]);
+  });
+
+  it("starts a new segment at a limit-window rollover (usage drops)", () => {
+    const curves = buildBurnCurves(
+      parseTokenSamples([
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.8, resetAt: T0 + HOUR }]),
+        tokensSnapshot(T0 + 30 * MINUTE, [{ account: "agent-1", usage: 0.95, resetAt: T0 + HOUR }]),
+        tokensSnapshot(T0 + 70 * MINUTE, [{ account: "agent-1", usage: 0.02, resetAt: T0 + 6 * HOUR }]),
+        tokensSnapshot(T0 + 90 * MINUTE, [{ account: "agent-1", usage: 0.06, resetAt: T0 + 6 * HOUR }]),
+      ]),
+    );
+
+    const curve = at(curves, 0);
+    expect(curve.segments).toHaveLength(2);
+    expect(curve.segments[1]?.startedBy).toBe("window-reset");
+    expect(curve.currentSegment?.points.map((point) => point.usageFraction)).toEqual([0.02, 0.06]);
+    expect(curve.currentSegment?.limitWindowResetAt).toBe(T0 + 6 * HOUR);
+  });
+
+  it("starts a new segment when limit_window_reset_at advances without a usage drop", () => {
+    const curves = buildBurnCurves(
+      parseTokenSamples([
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.4, resetAt: T0 + HOUR }]),
+        tokensSnapshot(T0 + 30 * MINUTE, [{ account: "agent-1", usage: 0.4, resetAt: T0 + 7 * HOUR }]),
+      ]),
+    );
+    expect(curves[0]?.segments.map((segment) => segment.startedBy)).toEqual(["initial", "window-reset"]);
+  });
+
+  it("breaks the series across a telemetry gap rather than interpolating it", () => {
+    const curves = buildBurnCurves(
+      parseTokenSamples([
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]),
+        tokensSnapshot(T0 + 5 * HOUR, [{ account: "agent-1", usage: 0.6 }]),
+      ]),
+    );
+    expect(curves[0]?.segments.map((segment) => segment.startedBy)).toEqual(["initial", "gap"]);
+    expect(curves[0]?.currentSegment?.points).toHaveLength(1);
+  });
+
+  it("honours a caller-supplied gap tolerance", () => {
+    const samples = parseTokenSamples([
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]),
+      tokensSnapshot(T0 + 5 * HOUR, [{ account: "agent-1", usage: 0.6 }]),
+    ]);
+    expect(buildBurnCurves(samples, { maxSampleGapMs: 6 * HOUR })[0]?.segments).toHaveLength(1);
+  });
+
+  it("drops unknown usage from the curve but still tracks exhaustion", () => {
+    const curves = buildBurnCurves(
+      parseTokenSamples([
+        tokensSnapshot(T0, [{ account: "agent-2", usage: 0.9 }]),
+        tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-2", exhausted: true }]),
+      ]),
+    );
+
+    expect(curves[0]?.points).toHaveLength(1);
+    expect(curves[0]?.exhausted).toBe(true);
+    expect(curves[0]?.everExhausted).toBe(true);
+    expect(curves[0]?.latestAt).toBe(T0 + 10 * MINUTE);
+  });
+
+  it("distinguishes currently-exhausted from recovered-after-exhaustion", () => {
+    const curves = buildBurnCurves(
+      parseTokenSamples([
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 1, exhausted: true }]),
+        tokensSnapshot(T0 + 30 * MINUTE, [{ account: "agent-1", usage: 0.05 }]),
+      ]),
+    );
+    expect(curves[0]?.exhausted).toBe(false);
+    expect(curves[0]?.everExhausted).toBe(true);
+  });
+
+  it("clamps an out-of-range usage_fraction into [0, 1]", () => {
+    const curves = buildBurnCurves(
+      parseTokenSamples([tokensSnapshot(T0, [{ account: "agent-1", usage: 1.4 }])]),
+    );
+    expect(curves[0]?.points[0]?.usageFraction).toBe(1);
+  });
+});

--- a/dashboard/web/test/forecast.test.ts
+++ b/dashboard/web/test/forecast.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { buildBurnCurves } from "../src/analytics/burn.js";
+import { forecastAccount, forecastAccounts } from "../src/analytics/forecast.js";
+import { parseTokenSamples } from "../src/analytics/parse.js";
+import type { HistoryEnvelope } from "../src/analytics/types.js";
+import { HOUR, MINUTE, T0, resetIds, tokensSnapshot } from "./analyticsFixtures.js";
+
+beforeEach(resetIds);
+
+function forecastOf(records: readonly HistoryEnvelope[], now: number, account = "agent-1") {
+  const curves = buildBurnCurves(parseTokenSamples(records));
+  const curve = curves.find((candidate) => candidate.account === account);
+  if (!curve) throw new Error(`no curve for ${account}`);
+  return forecastAccount(curve, { now });
+}
+
+describe("forecastAccount", () => {
+  it("projects exhaustion before the window resets", () => {
+    // 0.2 → 0.4 over an hour is 0.2/h; from 0.2 that reaches 1.0 four hours
+    // after T0, while the window does not reset until T0+10h.
+    const forecast = forecastOf(
+      [
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.2, resetAt: T0 + 10 * HOUR }]),
+        tokensSnapshot(T0 + HOUR, [{ account: "agent-1", usage: 0.4, resetAt: T0 + 10 * HOUR }]),
+      ],
+      T0 + HOUR,
+    );
+
+    expect(forecast.status).toBe("projected-exhaustion");
+    expect(forecast.slopePerHour).toBeCloseTo(0.2, 10);
+    // Instants derived from a division are compared to the millisecond within
+    // half a second, not bit-exactly.
+    expect(forecast.projectedExhaustionAt).toBeCloseTo(T0 + 4 * HOUR, -3);
+    expect(forecast.secondsUntilExhaustion).toBe(3 * 3600);
+    expect(forecast.limitWindowResetAt).toBe(T0 + 10 * HOUR);
+    expect(forecast.marginSec).toBe(6 * 3600);
+    expect(forecast.latestUsageFraction).toBe(0.4);
+    expect(forecast.sampleCount).toBe(2);
+  });
+
+  it("reports resets-first when the window rolls over before the projection lands", () => {
+    const forecast = forecastOf(
+      [
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.2, resetAt: T0 + 2 * HOUR }]),
+        tokensSnapshot(T0 + HOUR, [{ account: "agent-1", usage: 0.4, resetAt: T0 + 2 * HOUR }]),
+      ],
+      T0 + HOUR,
+    );
+
+    expect(forecast.status).toBe("resets-first");
+    expect(forecast.projectedExhaustionAt).toBeCloseTo(T0 + 4 * HOUR, -3);
+    // Negative margin: the window resets two hours *before* the projection.
+    expect(forecast.marginSec).toBe(-2 * 3600);
+  });
+
+  it("reports a measured exhaustion as exhausted regardless of the trend", () => {
+    // The classic "approaching, then crossing" series: a gentle climb that
+    // ends with the daemon reporting the account exhausted.
+    const forecast = forecastOf(
+      [
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.5, resetAt: T0 + 8 * HOUR }]),
+        tokensSnapshot(T0 + HOUR, [{ account: "agent-1", usage: 0.7, resetAt: T0 + 8 * HOUR }]),
+        tokensSnapshot(T0 + 2 * HOUR, [{ account: "agent-1", usage: 0.9, resetAt: T0 + 8 * HOUR }]),
+        tokensSnapshot(T0 + 3 * HOUR, [
+          { account: "agent-1", usage: 1, resetAt: T0 + 8 * HOUR, exhausted: true },
+        ]),
+      ],
+      T0 + 3 * HOUR,
+    );
+
+    expect(forecast.status).toBe("exhausted");
+    expect(forecast.limitWindowResetAt).toBe(T0 + 8 * HOUR);
+    expect(forecast.secondsUntilReset).toBe(5 * 3600);
+  });
+
+  it("crosses from resets-first to projected-exhaustion as the burn accelerates", () => {
+    const window = { resetAt: T0 + 6 * HOUR };
+    const slow: HistoryEnvelope[] = [
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1, ...window }]),
+      tokensSnapshot(T0 + HOUR, [{ account: "agent-1", usage: 0.2, ...window }]),
+    ];
+    expect(forecastOf(slow, T0 + HOUR).status).toBe("resets-first");
+
+    const accelerated: HistoryEnvelope[] = [
+      ...slow,
+      tokensSnapshot(T0 + 2 * HOUR, [{ account: "agent-1", usage: 0.55, ...window }]),
+    ];
+    expect(forecastOf(accelerated, T0 + 2 * HOUR).status).toBe("projected-exhaustion");
+  });
+
+  it("fits only the live segment, not across a limit-window rollover", () => {
+    const forecast = forecastOf(
+      [
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1, resetAt: T0 + 2 * HOUR }]),
+        tokensSnapshot(T0 + 2 * HOUR, [{ account: "agent-1", usage: 0.9, resetAt: T0 + 2 * HOUR }]),
+        tokensSnapshot(T0 + 150 * MINUTE, [{ account: "agent-1", usage: 0, resetAt: T0 + 26 * HOUR }]),
+        tokensSnapshot(T0 + 210 * MINUTE, [{ account: "agent-1", usage: 0.1, resetAt: T0 + 26 * HOUR }]),
+      ],
+      T0 + 210 * MINUTE,
+    );
+
+    // Pre-rollover burn was 0.4/h; the live window's is 0.1/h. Fitting the
+    // whole series would have predicted exhaustion hours too early.
+    expect(forecast.sampleCount).toBe(2);
+    expect(forecast.slopePerHour).toBeCloseTo(0.1, 10);
+    expect(forecast.projectedExhaustionAt).toBeCloseTo(T0 + 150 * MINUTE + 10 * HOUR, -3);
+    expect(forecast.limitWindowResetAt).toBe(T0 + 26 * HOUR);
+    // 12.5h to exhaustion vs. a 26h window: the fresh window still runs dry
+    // first, but ~13.5h later than the pre-rollover trend would have said.
+    expect(forecast.status).toBe("projected-exhaustion");
+    expect(forecast.marginSec).toBeCloseTo(13.5 * 3600, -1);
+  });
+
+  it("averages noise rather than tracking the last two points", () => {
+    // A jittery but clearly 0.1/h series; a last-two-points model would read
+    // the final flat step as 0.0/h and report "Idle".
+    const forecast = forecastOf(
+      [
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.0 }]),
+        tokensSnapshot(T0 + HOUR, [{ account: "agent-1", usage: 0.11 }]),
+        tokensSnapshot(T0 + 2 * HOUR, [{ account: "agent-1", usage: 0.19 }]),
+        tokensSnapshot(T0 + 3 * HOUR, [{ account: "agent-1", usage: 0.3 }]),
+        tokensSnapshot(T0 + 4 * HOUR, [{ account: "agent-1", usage: 0.3 }]),
+      ],
+      T0 + 4 * HOUR,
+    );
+
+    expect(forecast.status).toBe("projected-exhaustion");
+    expect(forecast.slopePerHour).toBeGreaterThan(0.06);
+    expect(forecast.slopePerHour).toBeLessThan(0.09);
+  });
+
+  it("reports flat when usage is not moving", () => {
+    const forecast = forecastOf(
+      [
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.3, resetAt: T0 + 5 * HOUR }]),
+        tokensSnapshot(T0 + HOUR, [{ account: "agent-1", usage: 0.3, resetAt: T0 + 5 * HOUR }]),
+      ],
+      T0 + HOUR,
+    );
+
+    expect(forecast.status).toBe("flat");
+    expect(forecast.slopePerHour).toBe(0);
+    expect(forecast.projectedExhaustionAt).toBeUndefined();
+    expect(forecast.secondsUntilReset).toBe(4 * 3600);
+  });
+
+  it("reports insufficient-data from a single point", () => {
+    const forecast = forecastOf([tokensSnapshot(T0, [{ account: "agent-1", usage: 0.3 }])], T0);
+    expect(forecast.status).toBe("insufficient-data");
+    expect(forecast.sampleCount).toBe(1);
+    expect(forecast.slopePerHour).toBeUndefined();
+  });
+
+  it("reports insufficient-data when usage was never measured", () => {
+    const forecast = forecastOf(
+      [
+        tokensSnapshot(T0, [{ account: "agent-1" }]),
+        tokensSnapshot(T0 + HOUR, [{ account: "agent-1" }]),
+      ],
+      T0 + HOUR,
+    );
+    expect(forecast.status).toBe("insufficient-data");
+    expect(forecast.sampleCount).toBe(0);
+    expect(forecast.latestUsageFraction).toBeUndefined();
+  });
+
+  it("never projects exhaustion into the past", () => {
+    // A steep run that the fitted line puts past 1.0 already; the projection
+    // clamps to `now` instead of reporting a negative ETA.
+    const forecast = forecastOf(
+      [
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.5 }]),
+        tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.99 }]),
+      ],
+      T0 + 2 * HOUR,
+    );
+
+    expect(forecast.projectedExhaustionAt).toBe(T0 + 2 * HOUR);
+    expect(forecast.secondsUntilExhaustion).toBe(0);
+  });
+
+  it("omits the margin when the window reset is unknown", () => {
+    const forecast = forecastOf(
+      [
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.2 }]),
+        tokensSnapshot(T0 + HOUR, [{ account: "agent-1", usage: 0.4 }]),
+      ],
+      T0 + HOUR,
+    );
+
+    expect(forecast.status).toBe("projected-exhaustion");
+    expect(forecast.marginSec).toBeUndefined();
+    expect(forecast.secondsUntilReset).toBeUndefined();
+  });
+});
+
+describe("forecastAccounts", () => {
+  it("preserves curve ordering and forecasts each account independently", () => {
+    const curves = buildBurnCurves(
+      parseTokenSamples([
+        tokensSnapshot(T0, [
+          { account: "agent-1", rank: 0, usage: 0.2, resetAt: T0 + 10 * HOUR },
+          { account: "agent-2", rank: 1, usage: 0.98, resetAt: T0 + 10 * HOUR },
+        ]),
+        tokensSnapshot(T0 + HOUR, [
+          { account: "agent-1", rank: 0, usage: 0.25, resetAt: T0 + 10 * HOUR },
+          { account: "agent-2", rank: 1, usage: 1, resetAt: T0 + 10 * HOUR, exhausted: true },
+        ]),
+      ]),
+    );
+
+    const forecasts = forecastAccounts(curves, { now: T0 + HOUR });
+    expect(forecasts.map((forecast) => forecast.account)).toEqual(["agent-1", "agent-2"]);
+    expect(forecasts.map((forecast) => forecast.status)).toEqual(["resets-first", "exhausted"]);
+  });
+});

--- a/dashboard/web/test/render.test.ts
+++ b/dashboard/web/test/render.test.ts
@@ -1,0 +1,286 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  computeTokenAnalytics,
+  mountTokenAnalytics,
+  renderTokenAnalytics,
+  REQUIRED_SURFACE,
+} from "../src/analytics/render.js";
+import { currentSurface } from "../src/analytics/bootstrap.js";
+import type { HistoryEnvelope } from "../src/analytics/types.js";
+import { HOUR, MINUTE, T0, at, newestFirst, resetIds, sweepRecords, tokensSnapshot } from "./analyticsFixtures.js";
+
+beforeEach(() => {
+  resetIds();
+  document.body.replaceChildren();
+});
+
+const NOW = T0 + 20 * MINUTE;
+
+/** A realistic mixed page: a healthy account, an exhausted one, two repos. */
+function fixturePage(): HistoryEnvelope[] {
+  return newestFirst([
+    tokensSnapshot(T0, [
+      { account: "agent-1", rank: 0, usage: 0.2, resetAt: T0 + 8 * HOUR },
+      { account: "agent-2", rank: 1, usage: 0.95, resetAt: T0 + 8 * HOUR },
+    ]),
+    tokensSnapshot(T0 + 10 * MINUTE, [
+      { account: "agent-1", rank: 0, usage: 0.21, resetAt: T0 + 8 * HOUR },
+      { account: "agent-2", rank: 1, usage: 1, resetAt: T0 + 8 * HOUR, exhausted: true },
+    ]),
+    tokensSnapshot(T0 + 20 * MINUTE, [
+      { account: "agent-1", rank: 0, usage: 0.22, resetAt: T0 + 8 * HOUR },
+      { account: "agent-2", rank: 1, usage: 1, resetAt: T0 + 8 * HOUR, exhausted: true },
+    ]),
+    ...sweepRecords({
+      sweepId: "sweep-issue-1-0",
+      repo: "rjwalters/loom",
+      startedAt: T0,
+      completedAt: T0 + 10 * MINUTE,
+      model: "opus",
+      issue: 1,
+    }),
+    ...sweepRecords({
+      sweepId: "sweep-issue-2-0",
+      repo: "rjwalters/anvil",
+      startedAt: T0 + 10 * MINUTE,
+      completedAt: T0 + 20 * MINUTE,
+      model: "sonnet",
+      issue: 2,
+    }),
+  ]);
+}
+
+function mount(): HTMLElement {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  return container;
+}
+
+function fetchReturning(records: HistoryEnvelope[]): typeof fetch {
+  return vi.fn(async () =>
+    ({
+      ok: true,
+      status: 200,
+      json: async () => ({ records, nextCursor: null }),
+    }) as unknown as Response,
+  ) as unknown as typeof fetch;
+}
+
+describe("computeTokenAnalytics", () => {
+  it("produces curves, forecasts and attribution from one history page", () => {
+    const analytics = computeTokenAnalytics(fixturePage(), { now: NOW });
+
+    expect(analytics.curves.map((curve) => curve.account)).toEqual(["agent-1", "agent-2"]);
+    expect(analytics.forecasts.map((forecast) => forecast.status)).toEqual(["resets-first", "exhausted"]);
+    expect(analytics.attribution.repos.map((repo) => repo.repo).sort()).toEqual([
+      "rjwalters/anvil",
+      "rjwalters/loom",
+    ]);
+    expect(analytics.sweeps).toHaveLength(2);
+  });
+});
+
+describe("renderTokenAnalytics (authenticated surface)", () => {
+  it("renders all three analytics blocks", () => {
+    const container = mount();
+    const rendered = renderTokenAnalytics(container, computeTokenAnalytics(fixturePage(), { now: NOW }), {
+      surface: "authenticated",
+      now: NOW,
+    });
+
+    expect(rendered).toBe(true);
+    expect(container.querySelector('[data-testid="burn-curves"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="forecasts"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="attribution"]')).not.toBeNull();
+  });
+
+  it("draws one sparkline polyline per burn segment", () => {
+    const container = mount();
+    const records = newestFirst([
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 0.8 }]),
+      tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.95 }]),
+      // Rollover: a second segment, drawn as a break rather than a plunge.
+      tokensSnapshot(T0 + 20 * MINUTE, [{ account: "agent-1", usage: 0.05 }]),
+      tokensSnapshot(T0 + 30 * MINUTE, [{ account: "agent-1", usage: 0.1 }]),
+    ]);
+    renderTokenAnalytics(container, computeTokenAnalytics(records, { now: NOW }), { now: NOW });
+
+    expect(container.querySelectorAll(".sparkline__line")).toHaveLength(2);
+  });
+
+  it("flags an exhausted account distinctly from a healthy one", () => {
+    const container = mount();
+    renderTokenAnalytics(container, computeTokenAnalytics(fixturePage(), { now: NOW }), { now: NOW });
+
+    const healthy = container.querySelector('.burn-card[data-account="agent-1"]');
+    const exhausted = container.querySelector('.burn-card[data-account="agent-2"]');
+
+    expect(healthy?.getAttribute("data-exhausted")).toBe("false");
+    expect(healthy?.classList.contains("burn-card--exhausted")).toBe(false);
+    expect(healthy?.querySelector('[data-testid="exhausted-badge"]')).toBeNull();
+
+    expect(exhausted?.getAttribute("data-exhausted")).toBe("true");
+    expect(exhausted?.classList.contains("burn-card--exhausted")).toBe(true);
+    expect(exhausted?.querySelector('[data-testid="exhausted-badge"]')?.textContent).toBe("EXHAUSTED");
+
+    // ...and again in the forecast table, by status rather than by colour alone.
+    expect(container.querySelector('[data-testid="status-agent-2"]')?.textContent).toBe("Exhausted");
+    expect(container.querySelector('tr[data-account="agent-2"]')?.classList.contains("row--at-risk")).toBe(true);
+    expect(container.querySelector('tr[data-account="agent-1"]')?.classList.contains("row--at-risk")).toBe(false);
+  });
+
+  it("marks an account that was exhausted and has since rolled over as recovered", () => {
+    const container = mount();
+    const records = [
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 1, exhausted: true }]),
+      tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.05 }]),
+    ];
+    renderTokenAnalytics(container, computeTokenAnalytics(records, { now: NOW }), { now: NOW });
+
+    const card = container.querySelector(".burn-card");
+    expect(card?.classList.contains("burn-card--exhausted")).toBe(false);
+    expect(card?.querySelector(".badge--recovered")?.textContent).toBe("recovered");
+  });
+
+  it("lists each repo's attributed usage and an unattributed row", () => {
+    const container = mount();
+    // One sweep, then an idle stretch that still burns tokens.
+    const records = [
+      tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]),
+      tokensSnapshot(T0 + 10 * MINUTE, [{ account: "agent-1", usage: 0.2 }]),
+      tokensSnapshot(T0 + 20 * MINUTE, [{ account: "agent-1", usage: 0.3 }]),
+      ...sweepRecords({
+        sweepId: "s-1",
+        repo: "rjwalters/loom",
+        startedAt: T0,
+        completedAt: T0 + 10 * MINUTE,
+        model: "opus",
+      }),
+    ];
+    renderTokenAnalytics(container, computeTokenAnalytics(records, { now: NOW }), { now: NOW });
+
+    expect(container.querySelector('tr[data-repo="rjwalters/loom"] .cell--repo')?.textContent).toBe(
+      "rjwalters/loom",
+    );
+    expect(container.querySelector('tr[data-repo="(unattributed)"]')).not.toBeNull();
+  });
+
+  it("renders remote strings as text, never as markup", () => {
+    const container = mount();
+    const records = [
+      tokensSnapshot(T0, [{ account: "<img src=x onerror=alert(1)>", usage: 0.1 }]),
+      tokensSnapshot(T0 + 10 * MINUTE, [{ account: "<img src=x onerror=alert(1)>", usage: 0.2 }]),
+      ...sweepRecords({
+        sweepId: "s-1",
+        repo: "<script>evil()</script>",
+        startedAt: T0,
+        completedAt: T0 + 10 * MINUTE,
+      }),
+    ];
+    renderTokenAnalytics(container, computeTokenAnalytics(records, { now: NOW }), { now: NOW });
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.textContent).toContain("<script>evil()</script>");
+  });
+
+  it("renders an empty-state note instead of empty tables", () => {
+    const container = mount();
+    renderTokenAnalytics(container, computeTokenAnalytics([], { now: NOW }), { now: NOW });
+
+    expect(container.querySelector('[data-testid="burn-curves"]')?.textContent).toContain(
+      "No tokens.snapshot history in range.",
+    );
+    expect(container.querySelector('[data-testid="attribution"]')?.textContent).toContain("No usage observed");
+  });
+});
+
+describe("public-exposure decision", () => {
+  it("defaults to the authenticated surface", () => {
+    expect(REQUIRED_SURFACE).toBe("authenticated");
+  });
+
+  it("renders nothing but a withheld notice on the public surface", () => {
+    const container = mount();
+    const rendered = renderTokenAnalytics(container, computeTokenAnalytics(fixturePage(), { now: NOW }), {
+      surface: "public",
+      now: NOW,
+    });
+
+    expect(rendered).toBe(false);
+    expect(container.querySelector('[data-testid="analytics-withheld"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="burn-curves"]')).toBeNull();
+    expect(container.querySelector('[data-testid="forecasts"]')).toBeNull();
+    expect(container.querySelector('[data-testid="attribution"]')).toBeNull();
+
+    // Neither account identifiers nor repo names reach the DOM.
+    const text = container.textContent ?? "";
+    expect(text).not.toContain("agent-1");
+    expect(text).not.toContain("agent-2");
+    expect(text).not.toContain("rjwalters/loom");
+    expect(text).not.toContain("rjwalters/anvil");
+  });
+
+  it("does not even fetch history on the public surface", async () => {
+    const container = mount();
+    const fetchImpl = fetchReturning(fixturePage());
+
+    const analytics = await mountTokenAnalytics(container, { surface: "public", now: NOW, fetchImpl });
+
+    expect(analytics).toBeUndefined();
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="analytics-withheld"]')).not.toBeNull();
+  });
+
+  it("derives the surface from the server-injected auth state", () => {
+    const scope = (value: unknown) => ({ __LOOM_FLEET__: value }) as unknown as typeof globalThis;
+
+    expect(currentSurface(scope({ authenticated: true }))).toBe("authenticated");
+    expect(currentSurface(scope({ authenticated: false }))).toBe("public");
+  });
+
+  // The single-URL layout (#4795) is why this is no longer path-derived: `/`
+  // serves both audiences, so a pathname cannot identify the viewer. Failing
+  // closed matters most for the shapes that are not an explicit `false` — a
+  // page that never received the injection must not render the full panel.
+  it.each([
+    ["flag absent", {}],
+    ["malformed", "authenticated"],
+    ["null", null],
+    ["undefined", undefined],
+  ])("falls back to the public surface when the injected state is %s", (_label, value) => {
+    const scope = { __LOOM_FLEET__: value } as unknown as typeof globalThis;
+    expect(currentSurface(scope)).toBe("public");
+  });
+
+  it("falls back to the public surface when nothing was injected at all", () => {
+    expect(currentSurface({} as unknown as typeof globalThis)).toBe("public");
+  });
+});
+
+describe("mountTokenAnalytics (authenticated surface)", () => {
+  it("fetches from /api and renders the panel", async () => {
+    const container = mount();
+    const fetchImpl = fetchReturning(fixturePage());
+
+    const analytics = await mountTokenAnalytics(container, { now: NOW, fetchImpl });
+
+    expect(analytics?.curves).toHaveLength(2);
+    const calls = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const url = String(at(at(calls, 0) as unknown[], 0));
+    expect(url.startsWith("/api/history?")).toBe(true);
+    expect(url).not.toContain("/public");
+    expect(container.querySelector('[data-testid="attribution"]')).not.toBeNull();
+  });
+
+  it("shows an error state instead of throwing when the API fails", async () => {
+    const container = mount();
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 503 }) as unknown as Response) as unknown as typeof fetch;
+
+    const analytics = await mountTokenAnalytics(container, { now: NOW, fetchImpl });
+
+    expect(analytics).toBeUndefined();
+    expect(container.querySelector(".analytics__error")?.textContent).toContain("503");
+  });
+});


### PR DESCRIPTION
## Summary

Implements Phase 3 token/cost analytics for the fleet dashboard (Epic #4702):
per-account burn curves, limit-window exhaustion forecasting, and per-repo
attribution, as a new `dashboard/web/` panel plus the pure, fixture-tested
modules behind it.

The issue flagged two open design questions. Both are resolved below and
recorded in the new `dashboard/docs/token-analytics.md`.

## Resolved design question 1 — the per-repo attribution join

`tokens.snapshot` has **no `repo` field**, so attribution is derived, not read.

**Join key: `hostId` (hard, exact) + time overlap (soft, interval-based).**
`account` and `model` are carried as **dimensions, not join keys** — the issue
sketched a "per account/model" join, but no telemetry record links a pool
account to a sweep (`tokens.snapshot` accounts have no `model`;
`sweep.started.model` has no `account`), so keying on them would invent a
correlation. They are reported as breakdowns of an already-computed
attribution instead (`byAccount` is exact; `byModel` inherits the split).

**Unit of attribution is an interval, not an instant.** Each consecutive pair
of snapshots on a host defines `[prev.captured_at, next.captured_at)` and a
per-account delta. For each interval:

1. **Coverage** — the *union* of overlapping same-host sweep windows (clipped
   to the interval) decides how much of the delta is attributable at all
   (usage assumed uniform). Union, not sum: two concurrent sweeps cover the
   same seconds once.
2. **Split** — the attributable portion is divided among overlapping sweeps in
   proportion to each sweep's own overlap duration, summed per repo.
3. **Remainder** — the uncovered share goes to a first-class `unattributed`
   row, never redistributed onto the repos that did run sweeps.

**Time-window tolerances** (all parameters, all defaulted, all tested at their
boundaries):

| Knob | Default | Why |
|---|---|---|
| `edgeToleranceMs` | **60 s** | Sweep windows widened both ends before overlap is tested — `captured_at` and `started_at` are independent daemon clocks. Because coverage is proportional, a sweep touching an interval only through this slack claims only those 60 s' worth. |
| `maxSampleGapMs` | **60 min** | A wider snapshot pair is dropped entirely (`droppedIntervals`); the usage in between is real but unobserved, and smearing it would be fiction. |
| `openSweepMaxDurationMs` | **6 h** | Caps a sweep with `sweep.started` but no terminal record, so one crashed sweep cannot absorb the fleet's usage. |

Also deliberate: a **negative delta is a limit-window rollover**, counted
(`rolloverIntervals`) but never attributed and never subtracted; **units are
limit-window fractions** (`1.00` = one account's full window), because no
absolute token count or price exists in the telemetry — no cost figure is
synthesized.

## Resolved design question 2 — public exposure

**Decision: these widgets render on the authenticated surface only.**

Phase 2's `redaction.ts` passes `tokens.snapshot` through unredacted on both
`/api` and `/public` (no `repo` to key on). That stays correct and **this PR
changes nothing in `redaction.ts`**. But per-repo attribution is a repo-name
table *by construction* — publishing it would reconstruct by timing inference
exactly what Phase 2 strips from `/public/history` for private sweeps — and
account identifiers plus exhaustion ETAs are a live capacity map of the
operator's pool.

Enforced at two independent UI-layer points:

- `render.ts` — `renderTokenAnalytics` / `mountTokenAnalytics` refuse a
  `"public"` surface and render a "withheld" notice; on public it **makes no
  request at all** (it does not fetch and then hide).
- `api.ts` — the fetch prefix is the constant `/api`, not a parameter.

The surface is derived from the served path (`surfaceFromPath`), mirroring the
backend's own route-based split. Coordination note for #4753: the public page
should not embed these; a public capacity summary would be a purpose-built
aggregate with no account/repo names, not a flag on this component.

## Changes

New `dashboard/web/` package (Vite + vanilla TS, matching the conventions the
sibling backend package uses):

| File | Responsibility |
|---|---|
| `src/analytics/types.ts` | Wire + domain shapes, re-declared rather than imported across the package boundary (backend compiles against `@cloudflare/workers-types`) |
| `src/analytics/parse.ts` | Total, never-throwing narrowing; two-pass sweep-window reconstruction so the API's newest-first ordering is handled correctly |
| `src/analytics/burn.ts` | Burn curves per `(hostId, account)`, segmented at rollovers and telemetry gaps |
| `src/analytics/forecast.ts` | Least-squares fit over the live segment only, raced against `limit_window_reset_at` |
| `src/analytics/attribution.ts` | The join described above |
| `src/analytics/render.ts` | DOM rendering (textContent only, never `innerHTML`) + the surface enforcement point |
| `src/analytics/api.ts` | Paginated `/api/history` walk (the API has no `kind` filter, so kinds are partitioned client-side) |
| `src/analytics/format.ts` | Formatting, with "unknown renders as `—`, never `0`" |
| `src/analytics/bootstrap.ts`, `index.html`, `analytics.css` | Entry point, shell, styles |
| `docs/token-analytics.md`, `web/README.md` | The two decisions above, and how to run it |

`exhausted` is flagged three ways — `burn-card--exhausted` modifier, an
`EXHAUSTED` badge, and a `data-exhausted` attribute — plus a distinct forecast
status, so the signal survives grayscale and colour-vision deficiency.

## Acceptance Criteria Verification

- [x] **Per-account burn curve from `tokens.snapshot` history** — `burn.ts`
  builds one series per `(hostId, account)` (same-named accounts on different
  hosts stay separate), rendered as a `[0,1]`-pinned SVG sparkline with one
  polyline per segment. Verified by `test/burn.test.ts` (10 tests) and
  `test/render.test.ts`'s "draws one sparkline polyline per burn segment".
- [x] **Limit-window forecasting** — `forecast.ts` returns
  `exhausted` / `projected-exhaustion` / `resets-first` / `flat` /
  `insufficient-data` with slope, ETA, reset instant and margin. Verified by
  `test/forecast.test.ts` (12 tests), including an account crossing into
  `exhausted` and a case that flips verdict as burn accelerates.
- [x] **Per-repo attribution** — `attribution.ts`, join documented above and in
  `dashboard/docs/token-analytics.md`. Verified by `test/attribution.test.ts`
  (21 tests) with overlapping, partially-overlapping, concurrent, and
  non-overlapping windows.
- [x] **`exhausted` accounts visually flagged distinctly** — verified by
  `test/render.test.ts`'s "flags an exhausted account distinctly from a healthy
  one" (asserts the healthy card has none of the three markers) and the
  recovered-after-rollover case.
- [x] **Public-exposure check** — resolved above; enforced in `render.ts` +
  `api.ts`, verified by four tests including "does not even fetch history on
  the public surface" and an assertion that no account or repo name reaches the
  DOM on the public surface. No change to `redaction.ts`.

## Test Plan

`npm run check` in `dashboard/web` (`tsc --noEmit && vitest run`): **80 tests,
7 files, all passing**. `npx vite build` also succeeds (18.3 kB JS).

```
 ✓ test/format.test.ts (4 tests)
 ✓ test/api.test.ts (6 tests)
 ✓ test/parse.test.ts (13 tests)
 ✓ test/burn.test.ts (10 tests)
 ✓ test/attribution.test.ts (21 tests)
 ✓ test/forecast.test.ts (12 tests)
 ✓ test/render.test.ts (14 tests)

 Test Files  7 passed (7)
      Tests  80 passed (80)
```

Fixtures (`test/fixtures.ts`) build `GET /api/history` envelopes in exactly the
documented shape (`docs/query-api.md` + `.loom/docs/telemetry-schema.md`),
including the API's newest-first ordering — which is how the single-pass
sweep-window bug was caught during development.

**Manual verification**: rendered the panel under happy-dom against a seeded
3-account / 3-repo / 6-snapshot history (one account crossing into
`exhausted`, one sweep still in flight) and checked the numbers by hand:

```
agent-1  54.0%/h  65.0%  exhausts in 38m   resets in 4h 10m  +3h 31m  Will exhaust
agent-2  12.0%/h  50.0%  exhausts in 4h10m resets in 4h 10m  +0s      Resets first
agent-3  —        100.0% —                 resets in 1h 10m  —        Exhausted

rjwalters/loom   32.35%  49.8%  1 sweep  opus    agent-1 20.56%, agent-3 7.23%, agent-2 4.57%
rjwalters/anvil  18.52%  28.5%  1 sweep  sonnet  agent-1 12.89%, agent-2 2.86%, agent-3 2.77%
rjwalters/repo   14.12%  21.7%  1 sweep  opus    agent-1 11.56%, agent-2 2.57%
Coverage: 5 attributed intervals, 0 dropped across telemetry gaps, 0 rollovers skipped.
```

Attributed total (0.3235 + 0.1852 + 0.1412 = 0.65) reconciles exactly with the
observed per-account deltas (0.45 + 0.10 + 0.10), and `agent-3` — exhausted, so
contributing no further deltas — correctly stops accruing after it crosses.

## Notes for review

- **Concurrent-PR overlap**: #4749 is building the fleet-overview shell in the
  same new `dashboard/web/` directory. This PR keeps every analytics module
  under `src/analytics/` and exports `mountTokenAnalytics(container, opts)` as
  the single integration point, so whichever lands second should only need to
  reconcile `index.html` / `package.json` and call that one function.
- A **server-side `kind` filter** on `GET /api/history` would let this drop its
  client-side partitioning; that is a backend change and out of scope here.

Closes #4752
