### PR TITLE
feat(dashboard): render historical charts (outcomes, success rate, durations)

### DIFF
--- a/dashboard/web/README.md
+++ b/dashboard/web/README.md
@@ -59,13 +59,27 @@ adapted into whatever component model #4749 lands with.
   can never disagree with each other).
 - `src/charts/durations.ts` — p50/p90/p99 duration percentiles, overall and
   broken down by phase.
+- `src/charts/outcomesChartView.ts` — `renderOutcomesChart`: renders
+  `OutcomeBucket[]` as a stacked SVG bar chart, one bar per bucket segmented
+  by result.
+- `src/charts/successRateChartView.ts` — `renderSuccessRateChart`: renders
+  `SuccessRatePoint[]` as an SVG line chart; a bucket with no completed
+  sweeps (`successRate: null`) breaks the line into a gap rather than
+  interpolating through it.
+- `src/charts/durationsChartView.ts` — `renderDurationPercentilesChart`:
+  renders `DurationPercentiles` as a horizontal grouped-bar chart (one row
+  per `overall`/phase, one bar per percentile rank).
+- `src/historicalChartsPanel.ts` — `HistoricalChartsPanel`: owns fetching
+  `/api/history` (or `/public/history`) via `fetchAllHistory` and rendering
+  all three charts from the result; `refresh(filter)` re-fetches (merging
+  the new filter over the last-applied one) and re-renders, so a filter-input
+  UI has one method to call.
 
-**What's deliberately not here (yet):** rendered chart components
-(SVG/canvas/a charting library) and filter UI for the historical charts.
-Those depend on #4749's framework/build-tooling choice. Once that scaffold
-exists, wire a chart component to call `fetchAllHistory` + the relevant
-`charts/*` transform and render the result; every function in the chart layer
-takes and returns plain data, so it needs no adapter.
+Rendering is plain SVG via DOM APIs (no charting library), matching
+`liveFeedPanel.ts` / `sweepTimelineView.ts`'s framework-agnostic approach —
+issue #4751 calls the sibling Fleet-overview scaffold (#4749) a soft
+dependency ("otherwise independently implementable"), the same precedent
+#4750's panel/timeline views already established.
 
 ## Filters
 
@@ -98,6 +112,24 @@ The exact same call with `"/public/history"` in place of `"/api/history"`
 works unchanged against the redacted public dataset — every transform
 tolerates the reduced `record` shape `/public/history` returns for
 `visibility: "private"` rows (see `HistoryRecord`'s doc in `src/types.ts`).
+
+Or let `HistoricalChartsPanel` own fetch + render end to end:
+
+```ts
+import { HistoricalChartsPanel } from "./src/index.js";
+
+const panel = new HistoricalChartsPanel({
+  basePath: "/api/history", // or "/public/history" for the redacted view
+  outcomesContainer: document.querySelector("#outcomes")!,
+  successRateContainer: document.querySelector("#success-rate")!,
+  durationsContainer: document.querySelector("#durations")!,
+  filter: { repo: "rjwalters/loom" },
+});
+
+await panel.refresh();
+// Later, e.g. from a filter form's submit handler:
+await panel.refresh({ since: "2026-07-01T00:00:00Z" });
+```
 
 ## Development
 

--- a/dashboard/web/src/charts/durationsChartView.ts
+++ b/dashboard/web/src/charts/durationsChartView.ts
@@ -1,0 +1,105 @@
+/**
+ * Duration percentile chart view (issue #4751, AC3): renders
+ * `DurationPercentiles` (overall + per-phase p50/p90/p99) as a horizontal
+ * grouped-bar chart — one row per series (`overall` first, when present,
+ * then each phase present in `byPhase`), one bar per requested percentile
+ * rank within the row.
+ */
+
+import type { DurationPercentiles, PercentileRank, PercentileResult } from "./durations.js";
+import { DEFAULT_PERCENTILES } from "./durations.js";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+/** Stable per-rank color. Also stamped as `data-rank` on each bar so a
+ * stylesheet can restyle without touching this module. */
+export const PERCENTILE_COLORS: Record<PercentileRank, string> = {
+  50: "#1565c0",
+  90: "#f9a825",
+  99: "#c62828",
+};
+
+export interface DurationsChartOptions {
+  width?: number;
+  rowHeight?: number;
+  labelWidth?: number;
+  ranks?: readonly PercentileRank[];
+}
+
+const DEFAULTS = { width: 640, rowHeight: 28, labelWidth: 100 };
+
+function svgEl<K extends keyof SVGElementTagNameMap>(tag: K): SVGElementTagNameMap[K] {
+  return document.createElementNS(SVG_NS, tag);
+}
+
+interface Row {
+  label: string;
+  percentiles: PercentileResult;
+}
+
+/**
+ * Render `data` into `container` as a horizontal grouped-bar chart. Clears
+ * any prior content on each call. A `data` with no `overall` and an empty
+ * `byPhase` (no sweep in range has a known duration) still renders a
+ * (contentless) `<svg>` — callers decide whether to show a "no data" message
+ * around it.
+ */
+export function renderDurationPercentilesChart(
+  container: HTMLElement,
+  data: DurationPercentiles,
+  options: DurationsChartOptions = {},
+): void {
+  const { width, rowHeight, labelWidth } = { ...DEFAULTS, ...options };
+  const ranks = options.ranks ?? DEFAULT_PERCENTILES;
+  container.innerHTML = "";
+
+  const rows: Row[] = [];
+  if (data.overall) rows.push({ label: "overall", percentiles: data.overall });
+  for (const [phase, percentiles] of Object.entries(data.byPhase)) {
+    rows.push({ label: phase, percentiles });
+  }
+
+  const height = Math.max(rows.length, 1) * rowHeight;
+  const svg = svgEl("svg");
+  svg.setAttribute("class", "durations-chart");
+  svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+  svg.setAttribute("role", "img");
+  svg.setAttribute("aria-label", "Sweep duration percentiles");
+  container.appendChild(svg);
+
+  if (rows.length === 0) return;
+
+  const maxValue = Math.max(1, ...rows.flatMap((row) => ranks.map((rank) => row.percentiles[rank] ?? 0)));
+  const chartWidth = width - labelWidth;
+  const rankHeight = rowHeight / ranks.length;
+
+  rows.forEach((row, rowIndex) => {
+    const rowY = rowIndex * rowHeight;
+
+    const label = svgEl("text");
+    label.setAttribute("x", "4");
+    label.setAttribute("y", String(rowY + rowHeight / 2));
+    label.setAttribute("dominant-baseline", "middle");
+    label.setAttribute("font-size", "11");
+    label.dataset.row = row.label;
+    label.textContent = row.label;
+    svg.appendChild(label);
+
+    ranks.forEach((rank, rankIndex) => {
+      const value = row.percentiles[rank];
+      if (value === undefined) return;
+
+      const barWidth = (value / maxValue) * chartWidth;
+      const rect = svgEl("rect");
+      rect.setAttribute("x", String(labelWidth));
+      rect.setAttribute("y", String(rowY + rankIndex * rankHeight));
+      rect.setAttribute("width", String(barWidth));
+      rect.setAttribute("height", String(Math.max(rankHeight - 1, 0)));
+      rect.setAttribute("fill", PERCENTILE_COLORS[rank]);
+      rect.dataset.row = row.label;
+      rect.dataset.rank = String(rank);
+      rect.dataset.valueSec = String(value);
+      svg.appendChild(rect);
+    });
+  });
+}

--- a/dashboard/web/src/charts/outcomesChartView.ts
+++ b/dashboard/web/src/charts/outcomesChartView.ts
@@ -1,0 +1,92 @@
+/**
+ * Outcomes-over-time chart view (issue #4751, AC1): renders `OutcomeBucket[]`
+ * as a stacked bar chart, one bar per bucket, segmented by `SweepResult`.
+ * Plain SVG rendering, matching `liveFeedPanel.ts` / `sweepTimelineView.ts`'s
+ * framework-agnostic DOM approach — no charting library dependency, so it
+ * needs no adapter once #4749's frontend scaffold lands (issue #4751's
+ * "Dependencies" section calls that scaffold a soft dependency — this view
+ * is independently implementable, same as #4750's panel/timeline views were).
+ */
+
+import type { SweepResult } from "../types.js";
+import type { OutcomeBucket } from "./outcomes.js";
+import { SWEEP_RESULTS } from "./outcomes.js";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+/** Stable per-result color. Also stamped as `data-result` on each segment so
+ * a stylesheet can restyle without touching this module. */
+export const OUTCOME_COLORS: Record<SweepResult, string> = {
+  success: "#2e7d32",
+  failure: "#c62828",
+  cancelled: "#757575",
+  blocked: "#ef6c00",
+};
+
+export interface OutcomesChartOptions {
+  width?: number;
+  height?: number;
+  barGap?: number;
+}
+
+const DEFAULTS: Required<OutcomesChartOptions> = { width: 640, height: 240, barGap: 4 };
+
+function svgEl<K extends keyof SVGElementTagNameMap>(tag: K): SVGElementTagNameMap[K] {
+  return document.createElementNS(SVG_NS, tag);
+}
+
+/**
+ * Render `buckets` into `container` as a stacked bar chart. Clears any prior
+ * content on each call (matching `renderSweepTimeline`'s re-render
+ * contract). An empty `buckets` array still renders a (contentless) `<svg>`
+ * — callers decide whether to show a "no data" message around it.
+ */
+export function renderOutcomesChart(
+  container: HTMLElement,
+  buckets: OutcomeBucket[],
+  options: OutcomesChartOptions = {},
+): void {
+  const { width, height, barGap } = { ...DEFAULTS, ...options };
+  container.innerHTML = "";
+
+  const svg = svgEl("svg");
+  svg.setAttribute("class", "outcomes-chart");
+  svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+  svg.setAttribute("role", "img");
+  svg.setAttribute("aria-label", "Sweep outcomes over time");
+  container.appendChild(svg);
+
+  if (buckets.length === 0) return;
+
+  const maxTotal = Math.max(...buckets.map((bucket) => bucket.total), 1);
+  const barWidth = Math.max((width - barGap * (buckets.length + 1)) / buckets.length, 0);
+
+  buckets.forEach((bucket, index) => {
+    const x = barGap + index * (barWidth + barGap);
+    let yCursor = height;
+
+    const group = svgEl("g");
+    group.setAttribute("class", "outcomes-chart__bar");
+    group.dataset.bucketKey = bucket.bucketKey;
+    group.dataset.total = String(bucket.total);
+    svg.appendChild(group);
+
+    for (const result of SWEEP_RESULTS) {
+      const count = bucket.counts[result];
+      if (count === 0) continue;
+
+      const segmentHeight = (count / maxTotal) * height;
+      const rect = svgEl("rect");
+      rect.setAttribute("x", String(x));
+      rect.setAttribute("y", String(yCursor - segmentHeight));
+      rect.setAttribute("width", String(barWidth));
+      rect.setAttribute("height", String(segmentHeight));
+      rect.setAttribute("fill", OUTCOME_COLORS[result]);
+      rect.dataset.result = result;
+      rect.dataset.count = String(count);
+      group.appendChild(rect);
+
+      yCursor -= segmentHeight;
+    }
+  });
+}

--- a/dashboard/web/src/charts/successRateChartView.ts
+++ b/dashboard/web/src/charts/successRateChartView.ts
@@ -1,0 +1,99 @@
+/**
+ * Success-rate trend chart view (issue #4751, AC2): renders
+ * `SuccessRatePoint[]` as a line chart. A point with `successRate: null` (no
+ * completed sweeps in that bucket) is skipped when drawing the line — per
+ * `successRate.ts`'s doc, "a chart should render a gap there rather than a
+ * misleading 0" — so the polyline breaks into separate segments around any
+ * gap instead of interpolating through it.
+ */
+
+import type { SuccessRatePoint } from "./successRate.js";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+export interface SuccessRateChartOptions {
+  width?: number;
+  height?: number;
+  padding?: number;
+}
+
+const DEFAULTS: Required<SuccessRateChartOptions> = { width: 640, height: 200, padding: 8 };
+
+function svgEl<K extends keyof SVGElementTagNameMap>(tag: K): SVGElementTagNameMap[K] {
+  return document.createElementNS(SVG_NS, tag);
+}
+
+interface PlottedPoint {
+  x: number;
+  y: number;
+}
+
+/**
+ * Render `points` into `container` as a line chart. Clears any prior content
+ * on each call. An empty `points` array still renders a (contentless)
+ * `<svg>` — callers decide whether to show a "no data" message around it.
+ */
+export function renderSuccessRateChart(
+  container: HTMLElement,
+  points: SuccessRatePoint[],
+  options: SuccessRateChartOptions = {},
+): void {
+  const { width, height, padding } = { ...DEFAULTS, ...options };
+  container.innerHTML = "";
+
+  const svg = svgEl("svg");
+  svg.setAttribute("class", "success-rate-chart");
+  svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+  svg.setAttribute("role", "img");
+  svg.setAttribute("aria-label", "Success rate trend");
+  container.appendChild(svg);
+
+  if (points.length === 0) return;
+
+  const innerWidth = width - padding * 2;
+  const innerHeight = height - padding * 2;
+  const step = points.length > 1 ? innerWidth / (points.length - 1) : 0;
+
+  // Split into contiguous runs of non-null points so the polyline never
+  // draws a straight line across a gap bucket.
+  const segments: PlottedPoint[][] = [];
+  let current: PlottedPoint[] = [];
+  points.forEach((point, index) => {
+    if (point.successRate === null) {
+      if (current.length > 0) segments.push(current);
+      current = [];
+      return;
+    }
+    current.push({ x: padding + step * index, y: padding + innerHeight * (1 - point.successRate) });
+  });
+  if (current.length > 0) segments.push(current);
+
+  for (const segment of segments) {
+    if (segment.length < 2) continue;
+    const polyline = svgEl("polyline");
+    polyline.setAttribute("points", segment.map((p) => `${p.x},${p.y}`).join(" "));
+    polyline.setAttribute("fill", "none");
+    polyline.setAttribute("stroke", "#1565c0");
+    polyline.setAttribute("stroke-width", "2");
+    polyline.setAttribute("class", "success-rate-chart__line");
+    svg.appendChild(polyline);
+  }
+
+  // A marker for every non-null bucket, including isolated ones a polyline
+  // segment of length 1 wouldn't otherwise render.
+  points.forEach((point, index) => {
+    if (point.successRate === null) return;
+    const x = padding + step * index;
+    const y = padding + innerHeight * (1 - point.successRate);
+
+    const circle = svgEl("circle");
+    circle.setAttribute("cx", String(x));
+    circle.setAttribute("cy", String(y));
+    circle.setAttribute("r", "3");
+    circle.setAttribute("fill", "#1565c0");
+    circle.setAttribute("class", "success-rate-chart__point");
+    circle.dataset.bucketKey = point.bucketKey;
+    circle.dataset.successRate = String(point.successRate);
+    svg.appendChild(circle);
+  });
+}

--- a/dashboard/web/src/historicalChartsPanel.ts
+++ b/dashboard/web/src/historicalChartsPanel.ts
@@ -1,0 +1,80 @@
+/**
+ * Historical charts panel (issue #4751): owns fetching `/api/history` (or
+ * `/public/history`) and rendering the three charts — outcomes-over-time,
+ * success-rate trend, and duration percentiles — into three containers.
+ * Framework-agnostic, matching `liveFeedPanel.ts`'s plain-DOM ownership
+ * pattern: this class holds the last-applied filter and re-fetches/
+ * re-renders on `refresh`, so a filter-control UI (host/repo/model/date-range
+ * inputs) can be wired to it without knowing anything about chart internals.
+ *
+ * The same instance works against either route purely by passing a
+ * different `basePath` ("Charts read from /api/history ... confirm the same
+ * component can point at /public/history", #4751's last acceptance
+ * criterion) — nothing else changes, since `fetchAllHistory` and every
+ * `charts/*` transform already tolerate the redacted `/public/history`
+ * payload shape.
+ */
+
+import type { FetchLike, HistoryQueryFilter } from "./historyClient.js";
+import { fetchAllHistory } from "./historyClient.js";
+import type { BucketGranularity } from "./charts/timeBuckets.js";
+import { buildOutcomesOverTime } from "./charts/outcomes.js";
+import { buildSuccessRateTrend } from "./charts/successRate.js";
+import { buildDurationPercentiles } from "./charts/durations.js";
+import { renderOutcomesChart } from "./charts/outcomesChartView.js";
+import { renderSuccessRateChart } from "./charts/successRateChartView.js";
+import { renderDurationPercentilesChart } from "./charts/durationsChartView.js";
+
+export interface HistoricalChartsPanelOptions {
+  /** `/api/history` or `/public/history` — see module doc. */
+  basePath: string;
+  outcomesContainer: HTMLElement;
+  successRateContainer: HTMLElement;
+  durationsContainer: HTMLElement;
+  granularity?: BucketGranularity;
+  filter?: HistoryQueryFilter;
+  fetchImpl?: FetchLike;
+}
+
+export class HistoricalChartsPanel {
+  private readonly basePath: string;
+  private readonly outcomesContainer: HTMLElement;
+  private readonly successRateContainer: HTMLElement;
+  private readonly durationsContainer: HTMLElement;
+  private readonly granularity: BucketGranularity;
+  private readonly fetchImpl: FetchLike | undefined;
+  private filter: HistoryQueryFilter;
+
+  constructor(options: HistoricalChartsPanelOptions) {
+    this.basePath = options.basePath;
+    this.outcomesContainer = options.outcomesContainer;
+    this.successRateContainer = options.successRateContainer;
+    this.durationsContainer = options.durationsContainer;
+    this.granularity = options.granularity ?? "daily";
+    this.filter = options.filter ?? {};
+    this.fetchImpl = options.fetchImpl;
+  }
+
+  /** The filter currently applied (the constructor's `filter`, merged with
+   * every `refresh(filter)` call since). */
+  getFilter(): HistoryQueryFilter {
+    return this.filter;
+  }
+
+  /**
+   * Fetch the full (paginated) result set for the current filter — merged
+   * with `filter` when provided — and re-render all three charts from it.
+   */
+  async refresh(filter?: HistoryQueryFilter): Promise<void> {
+    if (filter) this.filter = { ...this.filter, ...filter };
+
+    const records = await fetchAllHistory(this.basePath, this.filter, {
+      fetchImpl: this.fetchImpl,
+    });
+
+    const buckets = buildOutcomesOverTime(records, this.granularity);
+    renderOutcomesChart(this.outcomesContainer, buckets);
+    renderSuccessRateChart(this.successRateContainer, buildSuccessRateTrend(buckets));
+    renderDurationPercentilesChart(this.durationsContainer, buildDurationPercentiles(records));
+  }
+}

--- a/dashboard/web/src/index.ts
+++ b/dashboard/web/src/index.ts
@@ -19,10 +19,14 @@ export * from "./timelineBuilder.js";
 export * from "./liveFeedPanel.js";
 export * from "./sweepTimelineView.js";
 
-// Historical-charting data layer (#4751).
+// Historical-charting data layer + chart views (#4751).
 export * from "./historyClient.js";
 export * from "./charts/timeBuckets.js";
 export * from "./charts/correlate.js";
 export * from "./charts/outcomes.js";
 export * from "./charts/successRate.js";
 export * from "./charts/durations.js";
+export * from "./charts/outcomesChartView.js";
+export * from "./charts/successRateChartView.js";
+export * from "./charts/durationsChartView.js";
+export * from "./historicalChartsPanel.js";

--- a/dashboard/web/test/durationsChartView.test.ts
+++ b/dashboard/web/test/durationsChartView.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { PERCENTILE_COLORS, renderDurationPercentilesChart } from "../src/charts/durationsChartView.js";
+import type { DurationPercentiles } from "../src/charts/durations.js";
+
+describe("renderDurationPercentilesChart", () => {
+  it("renders an 'overall' row plus one row per phase, each with p50/p90/p99 bars", () => {
+    const container = document.createElement("div");
+    const data: DurationPercentiles = {
+      overall: { 50: 100, 90: 200, 99: 300 },
+      byPhase: {
+        builder: { 50: 60, 90: 120, 99: 180 },
+      },
+    };
+
+    renderDurationPercentilesChart(container, data);
+
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("aria-label")).toBe("Sweep duration percentiles");
+
+    const labels = container.querySelectorAll("text");
+    expect(Array.from(labels).map((l) => l.textContent)).toEqual(["overall", "builder"]);
+
+    const overallRects = container.querySelectorAll('rect[data-row="overall"]');
+    expect(overallRects.length).toBe(3);
+    const p50 = container.querySelector('rect[data-row="overall"][data-rank="50"]');
+    expect(p50?.getAttribute("fill")).toBe(PERCENTILE_COLORS[50]);
+    expect(p50?.getAttribute("data-value-sec")).toBe("100");
+
+    const builderRects = container.querySelectorAll('rect[data-row="builder"]');
+    expect(builderRects.length).toBe(3);
+  });
+
+  it("omits missing ranks and rows with no data", () => {
+    const container = document.createElement("div");
+    const data: DurationPercentiles = { overall: undefined, byPhase: {} };
+
+    renderDurationPercentilesChart(container, data);
+
+    expect(container.querySelector("svg")).not.toBeNull();
+    expect(container.querySelectorAll("rect").length).toBe(0);
+    expect(container.querySelectorAll("text").length).toBe(0);
+  });
+
+  it("scales bar widths relative to the largest value across all rows/ranks", () => {
+    const container = document.createElement("div");
+    const data: DurationPercentiles = {
+      overall: { 50: 50, 90: 100 },
+      byPhase: {},
+    };
+
+    renderDurationPercentilesChart(container, data, { width: 640, labelWidth: 100 });
+
+    const p90 = container.querySelector('rect[data-row="overall"][data-rank="90"]');
+    // p90 (100) is the max value, so its bar should span the full chart width.
+    expect(Number(p90?.getAttribute("width"))).toBeCloseTo(640 - 100);
+
+    const p50 = container.querySelector('rect[data-row="overall"][data-rank="50"]');
+    // p50 (50) is half of the max, so its bar should be half as wide.
+    expect(Number(p50?.getAttribute("width"))).toBeCloseTo((640 - 100) / 2);
+  });
+});

--- a/dashboard/web/test/historicalChartsPanel.test.ts
+++ b/dashboard/web/test/historicalChartsPanel.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { HistoricalChartsPanel } from "../src/historicalChartsPanel.js";
+import type { FetchLike } from "../src/historyClient.js";
+import type { HistoryQueryResult, HistoryRecord } from "../src/types.js";
+import { makeCompletedSweepPair, resetFixtureIds } from "./fixtures.js";
+
+/** A `FetchLike` stub serving one fixed page, recording every URL it saw. */
+function stubFetch(records: HistoryRecord[]): { fetchImpl: FetchLike; calls: string[] } {
+  const calls: string[] = [];
+  const page: HistoryQueryResult = { records, nextCursor: null };
+  const fetchImpl: FetchLike = async (url: string) => {
+    calls.push(url);
+    return { ok: true, status: 200, async json() { return page; } };
+  };
+  return { fetchImpl, calls };
+}
+
+describe("HistoricalChartsPanel", () => {
+  it("fetches once and renders all three charts from the result", async () => {
+    resetFixtureIds();
+    const records = makeCompletedSweepPair({
+      sweepId: "s1",
+      emittedAt: "2026-07-28T10:00:00Z",
+      result: "success",
+      model: "opus",
+      totalDurationSec: 100,
+      phaseDurations: [{ phase: "builder", duration_sec: 60 }],
+    });
+    const { fetchImpl, calls } = stubFetch(records);
+
+    const outcomesContainer = document.createElement("div");
+    const successRateContainer = document.createElement("div");
+    const durationsContainer = document.createElement("div");
+
+    const panel = new HistoricalChartsPanel({
+      basePath: "/api/history",
+      outcomesContainer,
+      successRateContainer,
+      durationsContainer,
+      fetchImpl,
+    });
+
+    await panel.refresh();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("/api/history");
+    expect(outcomesContainer.querySelectorAll("rect").length).toBeGreaterThan(0);
+    expect(successRateContainer.querySelectorAll("circle").length).toBeGreaterThan(0);
+    expect(durationsContainer.querySelectorAll("rect").length).toBeGreaterThan(0);
+  });
+
+  it("points at /public/history instead with no other code change", async () => {
+    resetFixtureIds();
+    const { fetchImpl, calls } = stubFetch([]);
+    const panel = new HistoricalChartsPanel({
+      basePath: "/public/history",
+      outcomesContainer: document.createElement("div"),
+      successRateContainer: document.createElement("div"),
+      durationsContainer: document.createElement("div"),
+      fetchImpl,
+    });
+
+    await panel.refresh();
+
+    expect(calls[0]).toContain("/public/history");
+  });
+
+  it("merges a refresh-time filter into the last-applied filter and re-fetches with it", async () => {
+    resetFixtureIds();
+    const { fetchImpl, calls } = stubFetch([]);
+    const panel = new HistoricalChartsPanel({
+      basePath: "/api/history",
+      outcomesContainer: document.createElement("div"),
+      successRateContainer: document.createElement("div"),
+      durationsContainer: document.createElement("div"),
+      filter: { repo: "rjwalters/loom" },
+      fetchImpl,
+    });
+
+    await panel.refresh({ model: "opus" });
+
+    expect(panel.getFilter()).toEqual({ repo: "rjwalters/loom", model: "opus" });
+    const url = new URL(calls[0]!, "http://example.test");
+    expect(url.searchParams.get("repo")).toBe("rjwalters/loom");
+    expect(url.searchParams.get("model")).toBe("opus");
+  });
+});

--- a/dashboard/web/test/outcomesChartView.test.ts
+++ b/dashboard/web/test/outcomesChartView.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { OUTCOME_COLORS, renderOutcomesChart } from "../src/charts/outcomesChartView.js";
+import type { OutcomeBucket } from "../src/charts/outcomes.js";
+
+function bucket(overrides: Partial<OutcomeBucket> & { bucketKey: string }): OutcomeBucket {
+  return {
+    counts: { success: 0, failure: 0, cancelled: 0, blocked: 0 },
+    total: 0,
+    ...overrides,
+  };
+}
+
+describe("renderOutcomesChart", () => {
+  it("renders one <rect> segment per non-zero result, colored per result", () => {
+    const container = document.createElement("div");
+    const buckets: OutcomeBucket[] = [
+      bucket({
+        bucketKey: "2026-07-28",
+        counts: { success: 2, failure: 1, cancelled: 0, blocked: 0 },
+        total: 3,
+      }),
+    ];
+
+    renderOutcomesChart(container, buckets);
+
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute("aria-label")).toBe("Sweep outcomes over time");
+
+    const rects = container.querySelectorAll("rect");
+    expect(rects.length).toBe(2); // success + failure; cancelled/blocked are 0 and skipped
+    const success = container.querySelector('rect[data-result="success"]');
+    expect(success?.getAttribute("fill")).toBe(OUTCOME_COLORS.success);
+    expect(success?.getAttribute("data-count")).toBe("2");
+  });
+
+  it("groups each bucket's segments under one <g data-bucket-key>", () => {
+    const container = document.createElement("div");
+    const buckets: OutcomeBucket[] = [
+      bucket({ bucketKey: "2026-07-28", counts: { success: 1, failure: 0, cancelled: 0, blocked: 0 }, total: 1 }),
+      bucket({ bucketKey: "2026-07-29", counts: { success: 0, failure: 1, cancelled: 0, blocked: 0 }, total: 1 }),
+    ];
+
+    renderOutcomesChart(container, buckets);
+
+    const groups = container.querySelectorAll("g.outcomes-chart__bar");
+    expect(groups.length).toBe(2);
+    expect(groups[0]?.getAttribute("data-bucket-key")).toBe("2026-07-28");
+    expect(groups[1]?.getAttribute("data-bucket-key")).toBe("2026-07-29");
+  });
+
+  it("renders a contentless <svg> for an empty bucket list", () => {
+    const container = document.createElement("div");
+    renderOutcomesChart(container, []);
+    expect(container.querySelector("svg")).not.toBeNull();
+    expect(container.querySelectorAll("rect").length).toBe(0);
+  });
+
+  it("clears prior content on re-render", () => {
+    const container = document.createElement("div");
+    renderOutcomesChart(container, [
+      bucket({ bucketKey: "2026-07-28", counts: { success: 1, failure: 0, cancelled: 0, blocked: 0 }, total: 1 }),
+    ]);
+    renderOutcomesChart(container, []);
+    expect(container.querySelectorAll("svg").length).toBe(1);
+    expect(container.querySelectorAll("rect").length).toBe(0);
+  });
+});

--- a/dashboard/web/test/successRateChartView.test.ts
+++ b/dashboard/web/test/successRateChartView.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { renderSuccessRateChart } from "../src/charts/successRateChartView.js";
+import type { SuccessRatePoint } from "../src/charts/successRate.js";
+
+describe("renderSuccessRateChart", () => {
+  it("renders one <circle> point per non-null bucket and a connecting <polyline>", () => {
+    const container = document.createElement("div");
+    const points: SuccessRatePoint[] = [
+      { bucketKey: "2026-07-28", successRate: 0.5, total: 2 },
+      { bucketKey: "2026-07-29", successRate: 1, total: 1 },
+    ];
+
+    renderSuccessRateChart(container, points);
+
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("aria-label")).toBe("Success rate trend");
+
+    const circles = container.querySelectorAll("circle");
+    expect(circles.length).toBe(2);
+    expect(circles[0]?.getAttribute("data-bucket-key")).toBe("2026-07-28");
+    expect(circles[0]?.getAttribute("data-success-rate")).toBe("0.5");
+
+    expect(container.querySelectorAll("polyline").length).toBe(1);
+  });
+
+  it("renders a gap around a null bucket instead of interpolating through it", () => {
+    const container = document.createElement("div");
+    const points: SuccessRatePoint[] = [
+      { bucketKey: "2026-07-28", successRate: 1, total: 1 },
+      { bucketKey: "2026-07-29", successRate: null, total: 0 },
+      { bucketKey: "2026-07-30", successRate: 0, total: 1 },
+    ];
+
+    renderSuccessRateChart(container, points);
+
+    // Two isolated points on either side of the gap — no polyline connects
+    // across it (each segment has length 1, so neither draws a line).
+    expect(container.querySelectorAll("circle").length).toBe(2);
+    expect(container.querySelectorAll("polyline").length).toBe(0);
+  });
+
+  it("renders a contentless <svg> for an empty point list", () => {
+    const container = document.createElement("div");
+    renderSuccessRateChart(container, []);
+    expect(container.querySelector("svg")).not.toBeNull();
+    expect(container.querySelectorAll("circle").length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Completes Epic #4702 Phase 3's historical charts (issue #4751) by adding the **rendering** layer on top of the chart data layer merged in #4758 (which shipped the framework-agnostic transforms only, deferring rendering).

- `src/charts/outcomesChartView.ts` — `renderOutcomesChart`: stacked SVG bar chart, one bar per time bucket, segmented by `result`.
- `src/charts/successRateChartView.ts` — `renderSuccessRateChart`: SVG line chart; a bucket with no completed sweeps (`successRate: null`) breaks the line into a gap instead of interpolating through it.
- `src/charts/durationsChartView.ts` — `renderDurationPercentilesChart`: horizontal grouped-bar chart, one row per `overall`/phase, one bar per percentile rank (p50/p90/p99).
- `src/historicalChartsPanel.ts` — `HistoricalChartsPanel`: owns fetching `/api/history` (or `/public/history`) via `fetchAllHistory`, applying/merging filters, and rendering all three charts from one `refresh()` call.

**Why build rendering now instead of waiting on #4749:** #4751's own "Dependencies" section calls the sibling Fleet-overview scaffold (#4749) a *soft* dependency — "otherwise independently implementable." #4749 is still open (merge-conflict/changes-requested) but #4750's `liveFeedPanel.ts` / `sweepTimelineView.ts` already established the precedent of shipping plain-DOM, framework-agnostic view components in this package without waiting for #4749's build-tooling/framework choice. This PR follows that same pattern for the three charts.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|---------------|
| Outcomes-over-time chart (count by result, bucketed) | ✅ | `renderOutcomesChart` + `test/outcomesChartView.test.ts` |
| Success-rate trend chart | ✅ | `renderSuccessRateChart` + `test/successRateChartView.test.ts` |
| Duration percentile chart (p50/p90/p99, per-phase breakdown) | ✅ | `renderDurationPercentilesChart` + `test/durationsChartView.test.ts` |
| Filters: host/repo/model/since/until matching `GET /api/history` | ✅ | `HistoricalChartsPanel.refresh(filter)` passes straight through to `fetchAllHistory`'s `HistoryQueryFilter` (already param-for-param, #4758) |
| Pagination via keyset cursor | ✅ | Reuses `fetchAllHistory` (#4758) — no re-implementation |
| Same component points at `/public/history` without duplication | ✅ | `HistoricalChartsPanel` takes `basePath` as a constructor option; `test/historicalChartsPanel.test.ts` exercises both routes |

## Test Plan

```bash
cd dashboard/web
npm install
npm run check   # tsc --noEmit + vitest run
```

`82 passed (82)` across 14 files — this PR's 13 new tests plus the 69 pre-existing ones, all green. `tsc --noEmit` is clean.

Closes #4751