### PR TITLE
feat(daemon): loom-daemon health — one-shot consolidated fleet vitals

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1238,6 +1238,88 @@ managed repo, fetched *after* the IPC round-trip completes:
 - **Why opt-in** — six `gh` calls per managed repo is too slow to bundle into
   the default view (which is used for frequent, low-latency operator checks);
   `--pipeline` trades that latency for the queue-depth picture on demand.
+- **Metric mask (#4761)** — `GhPipelineSource::with_metrics(PipelineMetrics)`
+  selects which of the six counts to fetch (each is one `gh` call, run
+  sequentially within a repo). `PipelineMetrics::ALL` is the default and what
+  `status --pipeline` / the dashboard use; `PipelineMetrics::HEALTH` (queued +
+  merged) is what `loom-daemon health` uses to stay inside its latency budget.
+  `with_merge_window(Duration)` widens/narrows the merge-throughput window from
+  its 24h default. A masked-off metric is left `None`; a caller that masks a
+  metric off simply must not read it.
+
+## One-shot fleet vitals (`loom-daemon health`, #4761)
+
+```
+loom-daemon health [--since 30m] [--json]
+```
+
+One consolidated, structured vitals report with an **exit-code contract** so a
+watch loop (human, cron, dashboard, or the `loom:watch` skill) can branch
+without parsing anything:
+
+| exit | meaning |
+|------|---------|
+| `0` | every section green |
+| `1` | degraded — at least one section is non-green, **including "could not determine"** |
+| `2` | the daemon is genuinely dead |
+
+Six sections, one line each (or the full structured payload with `--json`):
+
+| section | what it reports | source |
+|---------|-----------------|--------|
+| `liveness` | trusted liveness verdict | `daemon_install_state::probe()` + `pgrep_daemon_pids()` + the IPC round-trip |
+| `dispatch` | in-flight vs dynamic cap, plus the last work-finder tick's dispatch/skip-reason summary | `DaemonStatusReport` + `work_finder::last_tick_summary()` |
+| `tokens` | healthy/total, exhausted count, `.ranking` staleness | `CapacityReport` + the resolved pool's `.ranking` mtime |
+| `roles` | **persistent** role-tick failures (transient ones are a count only) | `role_runner::role_tick_records()` |
+| `queues` | per-root ready (`loom:issue`) counts | `pipeline_snapshot` (`PipelineMetrics::HEALTH`) |
+| `throughput` | merges across managed repos inside the window | `pipeline_snapshot` (`PipelineMetrics::HEALTH`) |
+
+### Liveness precedence: pgrep + pid-file first, launchd NEVER alone
+
+This is the load-bearing rule. #4694's launchd domain probe twice declared a
+live, *dispatching* daemon dead during an overnight watch; the daemon's
+singleton guard was the only thing that prevented a sweep-killing restart. So
+`health` declares DEAD only on **positive evidence of absence**, in this order:
+
+1. **IPC answered** ⇒ alive, unconditionally. No local probe overrules a daemon
+   that just answered a round-trip.
+2. **`daemon_install_state` says the process is alive** — that classification is
+   itself launchd probe → skipped-domain cross-check → pid-file cross-check, so
+   it already refuses to trust a lone launchd negative ⇒ DEGRADED
+   (alive-but-unresponsive / still-starting), never DEAD.
+3. **`pgrep -x loom-daemon` finds a live process** ⇒ still DEGRADED. The third
+   independent signal, for a daemon started outside the managed wrapper or one
+   whose pid file was removed by hand.
+4. Only when **all three** are negative is the verdict DEAD (exit `2`).
+
+An *undiagnosable* probe (no loom dir resolvable, `pgrep` absent) is `UNKNOWN`
+(exit `1`) — "I could not tell" — never exit `2`.
+
+### Transient vs persistent role ticks
+
+The role-runner loop appends every `(root, role)` tick outcome to a bounded
+process-global ring (`role_runner::ROLE_TICK_RING_CAPACITY`), carried verbatim in
+`DaemonStatusReport::role_tick_records`. The *classifier* is client-side
+(`health::summarize_role_ticks`) because the window is the operator's choice:
+inside `--since`, a `(root, role)` pair whose **latest** record is a failure is
+**persistent** (surfaces, DEGRADED); one that failed but whose latest record is a
+success is **transient** (reported as a count only). Recording happens *before*
+the log-dedup decision, so #4349's DEBUG-downgraded repeat failures are still
+fully visible to a health check.
+
+### One collector, three consumers
+
+`health::assess(&HealthInputs) -> HealthReport` is pure — no daemon, no forge, no
+subprocess — and is the *only* place any verdict rule lives:
+
+- `loom-daemon health` (`cli::health`) collects the inputs and exits with
+  `HealthReport::exit_code()`.
+- The dashboard's `GET /api/health` (`serve.rs`) calls the same `assess` over the
+  same cached `/api/pipeline` `gh` batch. An unreachable daemon there answers
+  **200 with `overall: "dead"` / `exit_code: 2`**, not 503 — "the daemon is dead"
+  is a health *report*, not a transport failure.
+- `loom-daemon status` keeps its own (unchanged) rendering; `fleet status`
+  reuse is a follow-up (it would need a `health --json` fan-out over ssh).
 
 ## Reaper task
 

--- a/loom-daemon/src/cli/health.rs
+++ b/loom-daemon/src/cli/health.rs
@@ -1,0 +1,185 @@
+//! `loom-daemon health` — the I/O half of the one-shot fleet-vitals command
+//! (Issue #4761).
+//!
+//! Everything opinionated (every verdict rule, the #4694 liveness precedence,
+//! the transient-vs-persistent role classifier, the exit-code contract) lives
+//! in the pure [`loom_daemon::health`] collector. This module only *collects*:
+//! one IPC round-trip, one local install-state probe, one `pgrep`, one
+//! `.ranking` stat, and one bounded forge fan-out — then hands the result to
+//! [`loom_daemon::health::assess`] and renders.
+//!
+//! # Why every probe here is best-effort
+//!
+//! A health command that fails to produce a report is worse than useless to
+//! the watch loop it exists for. Every collection step degrades to "could not
+//! determine" (which the collector renders as a non-green `UNKNOWN` section,
+//! exit `1`) rather than aborting — the *only* thing that can stop this
+//! command from printing a report is a panic.
+
+use anyhow::Result;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use loom_daemon::daemon_install_state;
+use loom_daemon::health::{self, HealthInputs, HealthReport};
+use loom_daemon::pipeline_snapshot::{self, GhPipelineSource, PipelineMetrics};
+use loom_daemon::types::{DaemonStatusReport, Request, Response};
+
+use super::common::{query_daemon_bounded, resolve_socket_path};
+
+/// Bound on the IPC round-trip. Shorter than `status`'s 5s: `health` advertises
+/// a "< 5s typical" total budget across *all* sections, and a daemon that
+/// cannot answer within 2s is already a finding this command should report
+/// (as `alive-but-unresponsive`) rather than wait on.
+const IPC_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Handle `loom-daemon health [--since 30m] [--json]`.
+///
+/// Never returns `Err` for a *health* problem — an unhealthy fleet is a
+/// successful report with a non-zero exit code. `Err` is reserved for the
+/// command being unable to run at all (e.g. an unparseable `--since`).
+pub(crate) async fn handle_health_command(since: Option<String>, json: bool) -> Result<()> {
+    let window = match since.as_deref() {
+        Some(raw) => health::parse_since(raw).map_err(|e| anyhow::anyhow!(e))?,
+        None => Duration::from_secs(health::DEFAULT_WINDOW_SECS),
+    };
+
+    let report = collect(window).await;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print!("{}", report.render_human());
+    }
+    std::io::Write::flush(&mut std::io::stdout()).ok();
+    std::process::exit(report.exit_code());
+}
+
+/// Collect every input and assess. Split out of [`handle_health_command`] so
+/// the exit-code path is the only thing that call site adds.
+async fn collect(window: Duration) -> HealthReport {
+    // 1. The IPC round-trip — the only source for the dispatch/tokens/roles
+    //    sections, and the strongest liveness signal there is.
+    let (status, ipc_error) = query_status().await;
+
+    // 2. Local liveness probes. Both are cheap, bounded, and run regardless of
+    //    whether IPC succeeded: the collector records them either way so a
+    //    `--json` consumer can see the corroborating evidence.
+    let install_state = daemon_install_state::probe();
+    let pgrep_pids = daemon_install_state::pgrep_daemon_pids();
+
+    // 3. `.ranking` staleness, against the pool directory the DAEMON resolved
+    //    (#4292) rather than one re-derived from this CLI process's own cwd —
+    //    the same rule `status`'s client-side token probe follows.
+    let (ranking_present, ranking_age_secs) = probe_ranking(status.as_ref());
+
+    // 4. The forge fan-out for queue depth + throughput. Only the two metrics
+    //    those sections need (#4761's `PipelineMetrics::HEALTH`), over the
+    //    requested window, across the roots the daemon reported. Skipped
+    //    entirely when the daemon is unreachable: without its root list there
+    //    is nothing to query, and the sections honestly report "not collected".
+    let pipeline = match &status {
+        Some(report) => {
+            let roots = report
+                .per_repo
+                .iter()
+                .map(|r| r.root.clone())
+                .collect::<Vec<_>>();
+            let source = Arc::new(
+                GhPipelineSource::new()
+                    .with_metrics(PipelineMetrics::HEALTH)
+                    .with_merge_window(
+                        chrono::Duration::from_std(window)
+                            .unwrap_or_else(|_| chrono::Duration::hours(24)),
+                    ),
+            );
+            Some(pipeline_snapshot::collect_pipeline_snapshots(source, roots).await)
+        }
+        None => None,
+    };
+
+    health::assess(&HealthInputs {
+        at: chrono::Utc::now(),
+        window,
+        status,
+        ipc_error,
+        install_state,
+        pgrep_pids,
+        ranking_present,
+        ranking_age_secs,
+        pipeline,
+    })
+}
+
+/// One bounded `DaemonStatus` round-trip, collapsed to
+/// `(Some(report), None)` / `(None, Some(why))`.
+async fn query_status() -> (Option<DaemonStatusReport>, Option<String>) {
+    let socket_path = match resolve_socket_path() {
+        Ok(p) => p,
+        Err(e) => return (None, Some(format!("could not resolve socket path: {e}"))),
+    };
+    match query_daemon_bounded(&socket_path, &Request::DaemonStatus, IPC_TIMEOUT).await {
+        Ok(Response::DaemonStatus(report)) => (Some(*report), None),
+        Ok(Response::Error { message }) => (None, Some(format!("daemon error: {message}"))),
+        Ok(other) => (None, Some(format!("unexpected response: {other:?}"))),
+        Err(e) => (None, Some(e.to_string())),
+    }
+}
+
+/// Stat the resolved pool's `.ranking`: `(present, age_secs)`.
+///
+/// The pool directory comes from the daemon's own
+/// [`DaemonStatusReport::token_pool_dir`] (#4292) when available, falling back
+/// to this process's cwd resolution only for a pre-#4292 daemon or an
+/// unreachable one.
+fn probe_ranking(status: Option<&DaemonStatusReport>) -> (bool, Option<u64>) {
+    let dir = match status.and_then(|r| r.token_pool_dir.clone()) {
+        Some(dir) => dir,
+        None => {
+            let Ok(ws) = super::tokens::resolve_tokens_workspace(".") else {
+                return (false, None);
+            };
+            loom_daemon::tokens_pool::paths::resolve_tokens_dir(&ws)
+        }
+    };
+    ranking_state(&dir)
+}
+
+/// `(present, age_secs)` for `<dir>/.ranking`. Extracted (and pure w.r.t. the
+/// filesystem argument) so the age computation is unit-testable.
+fn ranking_state(dir: &Path) -> (bool, Option<u64>) {
+    let path = dir.join(".ranking");
+    let Ok(meta) = std::fs::metadata(&path) else {
+        return (false, None);
+    };
+    let age = meta
+        .modified()
+        .ok()
+        .and_then(|m| m.elapsed().ok())
+        .map(|d| d.as_secs());
+    (true, age)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ranking_state_reports_absent_when_there_is_no_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (present, age) = ranking_state(tmp.path());
+        assert!(!present);
+        assert_eq!(age, None);
+    }
+
+    #[test]
+    fn ranking_state_reports_present_and_fresh_for_a_just_written_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(".ranking"), "a|available|0.1\n").unwrap();
+        let (present, age) = ranking_state(tmp.path());
+        assert!(present);
+        assert!(age.unwrap() < 60, "a file just written should read as fresh");
+    }
+}

--- a/loom-daemon/src/cli/mod.rs
+++ b/loom-daemon/src/cli/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod accounts;
 pub(crate) mod cleanup_ops;
 pub(crate) mod common;
 pub(crate) mod dispatch;
+pub(crate) mod health;
 pub(crate) mod legacy_script_cmds;
 pub(crate) mod misc_cmds;
 pub(crate) mod quarantine;

--- a/loom-daemon/src/cli/status.rs
+++ b/loom-daemon/src/cli/status.rs
@@ -659,6 +659,8 @@ pub(crate) mod status_client_tests {
             rate_limit_breaker: None,
             safehouse: None,
             work_finder_enabled: Some(true),
+            last_work_finder_tick: None,
+            role_tick_records: vec![],
         }
     }
 

--- a/loom-daemon/src/daemon_install_state.rs
+++ b/loom-daemon/src/daemon_install_state.rs
@@ -448,6 +448,52 @@ fn pid_alive(pid: u32) -> bool {
     probe_output(cmd, PROBE_TIMEOUT).is_some_and(|o| o.status.success())
 }
 
+/// The process-name pattern [`pgrep_daemon_pids`] matches. Matched against the
+/// process *name* (`pgrep -x`), never the full command line, so an operator's
+/// `grep loom-daemon` shell or an editor buffer can never be mistaken for a
+/// running daemon.
+const DAEMON_PROCESS_NAME: &str = "loom-daemon";
+
+/// Live `loom-daemon` pids owned by the current user, via `pgrep -x -u <uid>`
+/// (Issue #4761) — a third liveness signal, wholly independent of both launchd
+/// and the pid file.
+///
+/// This exists for the same reason #4694's pid-file cross-check does: a
+/// negative from one probe must never be enough to declare the daemon dead.
+/// The launchd domain probe has already produced two false "dead" verdicts
+/// against a live, dispatching daemon; the pid file closes most of that gap,
+/// but it is itself absent/stale for a daemon started outside the managed
+/// wrapper. `pgrep` covers that last case.
+///
+/// Deliberately NOT wired into [`check_liveness`]: it is weaker evidence than
+/// the other two (it cannot tell *this* installation's daemon from a second one
+/// an operator started in a worktree), so it is exposed for consumers that want
+/// an explicit "do not declare dead without positive evidence" tier —
+/// [`crate::health`] — rather than silently changing `status`'s existing
+/// classification. Bounded by [`PROBE_TIMEOUT`]; an absent/hung `pgrep`
+/// degrades to an empty vec, i.e. "no answer", never "definitely dead".
+#[must_use]
+pub fn pgrep_daemon_pids() -> Vec<u32> {
+    let mut cmd = Command::new("pgrep");
+    match current_uid() {
+        Some(uid) => cmd.args(["-x", "-u", &uid, DAEMON_PROCESS_NAME]),
+        // No uid available: still worth asking, just unscoped.
+        None => cmd.args(["-x", DAEMON_PROCESS_NAME]),
+    };
+    let Some(output) = probe_output(cmd, PROBE_TIMEOUT) else {
+        return Vec::new();
+    };
+    // `pgrep` exits 1 when nothing matched — a legitimate "no processes", not a
+    // probe failure, and its stdout is empty either way.
+    let Ok(stdout) = String::from_utf8(output.stdout) else {
+        return Vec::new();
+    };
+    stdout
+        .lines()
+        .filter_map(|line| line.trim().parse::<u32>().ok())
+        .collect()
+}
+
 /// Current uid via `id -u`. Bounded by [`PROBE_TIMEOUT`]; a hung `id` degrades
 /// to `None`, exactly like an absent one (#4548).
 fn current_uid() -> Option<String> {

--- a/loom-daemon/src/daemon_service.rs
+++ b/loom-daemon/src/daemon_service.rs
@@ -119,6 +119,12 @@ pub(crate) async fn run_daemon() -> Result<()> {
             // `status` connects to the running daemon over its Unix socket, so
             // it needs the async runtime (unlike the other sync subcommands).
             Commands::Status { json, pipeline } => handle_status_command(json, pipeline).await,
+            // `health` (#4761) needs the async runtime for the same reason
+            // `status` does — one IPC round-trip — plus a bounded forge fan-out
+            // for the queue-depth/throughput sections.
+            Commands::Health { since, json } => {
+                cli::health::handle_health_command(since, json).await
+            }
             // `quarantine` connects to the running daemon over its Unix socket
             // (the quarantine state is in-memory), so it needs the async runtime.
             Commands::Quarantine { action } => handle_quarantine_command(action).await,

--- a/loom-daemon/src/health.rs
+++ b/loom-daemon/src/health.rs
@@ -1,0 +1,1507 @@
+//! `loom-daemon health` — one-shot consolidated fleet vitals (Issue #4761).
+//!
+//! # Why this module exists
+//!
+//! During the 2026-07-30→31 overnight fleet watch, 21 manual health ticks each
+//! re-ran the same five-check battery by hand (4–6 shell commands per tick).
+//! This module is that battery, collected once, structured, with an exit-code
+//! contract a `watch` loop can branch on without parsing:
+//!
+//! | code | meaning |
+//! |------|---------|
+//! | `0`  | every section green |
+//! | `1`  | degraded — at least one section is non-green (including "could not determine") |
+//! | `2`  | the daemon is **genuinely** dead |
+//!
+//! # This module is a *collector*, not a set of new probes
+//!
+//! Every input comes from a source that already existed; nothing here invents a
+//! second way to ask the same question:
+//!
+//! | section | source |
+//! |---------|--------|
+//! | liveness | [`crate::daemon_install_state`] (`probe()` + [`crate::daemon_install_state::pgrep_daemon_pids`]) plus the caller's IPC round-trip result |
+//! | dispatch | [`crate::types::DaemonStatusReport`] + [`crate::work_finder::last_tick_summary`] |
+//! | tokens | [`crate::types::CapacityReport`] + the resolved pool's `.ranking` mtime |
+//! | roles | [`crate::role_runner::role_tick_records`] |
+//! | queues | [`crate::pipeline_snapshot`] (`queued`) |
+//! | throughput | [`crate::pipeline_snapshot`] (`merged_24h`, over the requested window) |
+//!
+//! [`assess`] itself is **pure** — it takes an already-collected
+//! [`HealthInputs`] and returns a [`HealthReport`] — so every verdict rule
+//! (including the #4694 liveness precedence) is unit-testable with no daemon,
+//! no forge, and no subprocess. The I/O side lives in `cli::health`, and the
+//! dashboard's `GET /api/health` route calls this same [`assess`] rather than
+//! re-deriving a verdict of its own.
+//!
+//! # Liveness precedence: pgrep + pid-file first, launchd NEVER alone (#4694)
+//!
+//! The single most important rule in this module. #4694's launchd domain probe
+//! twice declared a live, *dispatching* daemon dead during the night watch; the
+//! singleton guard was the only thing preventing a sweep-killing restart. So
+//! [`assess_liveness`] declares [`Verdict::Dead`] only on **positive** evidence
+//! of absence, in this order:
+//!
+//! 1. **IPC answered** ⇒ alive. Unconditionally. No local probe can overrule a
+//!    daemon that just answered a round-trip.
+//! 2. **`daemon_install_state` says the process is alive** (that classification
+//!    is itself launchd-probe → skipped-domain cross-check → pid-file
+//!    cross-check, i.e. it already refuses to trust a lone launchd negative)
+//!    ⇒ alive-but-unresponsive: [`Verdict::Degraded`], never dead.
+//! 3. **`pgrep -x loom-daemon` finds a live process** ⇒ still not dead:
+//!    [`Verdict::Degraded`]. This is the third independent signal, for the case
+//!    where both launchd *and* the pid file are uninformative (a daemon started
+//!    outside the managed wrapper, or a pid file removed by hand).
+//! 4. Only when all three are negative is the verdict [`Verdict::Dead`] (exit
+//!    `2`).
+//!
+//! An *undiagnosable* probe (no loom dir resolvable, `pgrep` absent) is
+//! [`Verdict::Unknown`] — exit `1`, "I could not tell" — never `2`.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use crate::daemon_install_state::{InstallState, InstallStateReport};
+use crate::pipeline_snapshot::RepoPipelineSnapshot;
+use crate::types::{DaemonStatusReport, RoleTickRecord};
+
+// ============================================================================
+// Exit-code contract
+// ============================================================================
+
+/// Every section green.
+pub const EXIT_HEALTHY: i32 = 0;
+/// At least one section is non-green (degraded or undeterminable).
+pub const EXIT_DEGRADED: i32 = 1;
+/// The daemon is genuinely dead — all three independent liveness signals agree.
+pub const EXIT_DEAD: i32 = 2;
+
+/// Default report window (`--since`), used for the role-tick and throughput
+/// sections.
+pub const DEFAULT_WINDOW_SECS: u64 = 30 * 60;
+
+/// How old the resolved pool's `.ranking` may be before the tokens section
+/// reports it stale.
+///
+/// Six times the default refresh cadence
+/// ([`crate::token_ranking_refresh::DEFAULT_TOKEN_RANKING_REFRESH_INTERVAL_SECS`],
+/// 600s): generous enough that a couple of skipped refreshes (a rate-limit
+/// cooldown, a slow probe) never cries wolf, tight enough that a refresh loop
+/// that has actually stopped is caught within the hour — which matters because
+/// a stale ranking silently pins the dynamic cap's token axis to a snapshot of
+/// the past.
+pub const RANKING_STALE_SECS: u64 = 6 * 600;
+
+// ============================================================================
+// Verdicts
+// ============================================================================
+
+/// One section's health verdict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Verdict {
+    /// Healthy.
+    Green,
+    /// Non-green for a *known* reason.
+    Degraded,
+    /// Could not be determined (missing data, failed probe). Non-green — a
+    /// watcher must never read "I could not tell" as "fine".
+    Unknown,
+    /// The daemon is genuinely not running. Only ever produced by
+    /// [`assess_liveness`].
+    Dead,
+}
+
+impl Verdict {
+    /// The rendered label.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Verdict::Green => "GREEN",
+            Verdict::Degraded => "DEGRADED",
+            Verdict::Unknown => "UNKNOWN",
+            Verdict::Dead => "DEAD",
+        }
+    }
+
+    /// Whether this verdict is healthy.
+    #[must_use]
+    pub fn is_green(self) -> bool {
+        matches!(self, Verdict::Green)
+    }
+}
+
+/// One rendered section of the report.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct HealthSection {
+    /// Stable machine key (`liveness`, `dispatch`, `tokens`, `roles`,
+    /// `queues`, `throughput`).
+    pub key: &'static str,
+    /// This section's verdict.
+    pub verdict: Verdict,
+    /// The one-line human summary.
+    pub summary: String,
+    /// Machine-readable specifics for `--json` consumers.
+    pub detail: serde_json::Value,
+}
+
+impl HealthSection {
+    fn new(
+        key: &'static str,
+        verdict: Verdict,
+        summary: impl Into<String>,
+        detail: serde_json::Value,
+    ) -> Self {
+        Self {
+            key,
+            verdict,
+            summary: summary.into(),
+            detail,
+        }
+    }
+}
+
+/// The consolidated report.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct HealthReport {
+    /// When the report was collected.
+    pub at: DateTime<Utc>,
+    /// The `--since` window in seconds (role-tick + throughput sections).
+    pub window_secs: u64,
+    /// The rolled-up verdict.
+    pub overall: Verdict,
+    /// One entry per section, in render order.
+    pub sections: Vec<HealthSection>,
+}
+
+impl HealthReport {
+    /// The process exit code for this report — the whole point of the command.
+    #[must_use]
+    pub fn exit_code(&self) -> i32 {
+        match self.overall {
+            Verdict::Green => EXIT_HEALTHY,
+            Verdict::Dead => EXIT_DEAD,
+            Verdict::Degraded | Verdict::Unknown => EXIT_DEGRADED,
+        }
+    }
+
+    /// Look up a section by key (convenience for tests and consumers).
+    #[must_use]
+    pub fn section(&self, key: &str) -> Option<&HealthSection> {
+        self.sections.iter().find(|s| s.key == key)
+    }
+
+    /// Render the human report: one line per section plus a trailing overall
+    /// line.
+    #[must_use]
+    pub fn render_human(&self) -> String {
+        let mut out = String::new();
+        for section in &self.sections {
+            out.push_str(&format!(
+                "{:<11} {:<9} {}\n",
+                section.key,
+                section.verdict.as_str(),
+                section.summary
+            ));
+        }
+        out.push_str(&format!(
+            "{:<11} {:<9} exit {} (window {})\n",
+            "overall",
+            self.overall.as_str(),
+            self.exit_code(),
+            format_window(self.window_secs)
+        ));
+        out
+    }
+}
+
+/// Render a window in the same compact form `--since` accepts (`30m`, `2h`,
+/// `90s`).
+#[must_use]
+pub fn format_window(secs: u64) -> String {
+    if secs >= 3600 && secs.is_multiple_of(3600) {
+        format!("{}h", secs / 3600)
+    } else if secs >= 60 && secs.is_multiple_of(60) {
+        format!("{}m", secs / 60)
+    } else {
+        format!("{secs}s")
+    }
+}
+
+/// Parse a `--since` value: a bare integer (seconds) or `<n>[smhd]`.
+///
+/// # Errors
+/// Returns a message naming the rejected input when it is not a positive
+/// duration in one of those forms.
+pub fn parse_since(raw: &str) -> Result<Duration, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("--since requires a value (e.g. 30m, 2h, 90s)".to_string());
+    }
+    let (digits, mult) = match trimmed.chars().last() {
+        Some('s') => (&trimmed[..trimmed.len() - 1], 1_u64),
+        Some('m') => (&trimmed[..trimmed.len() - 1], 60),
+        Some('h') => (&trimmed[..trimmed.len() - 1], 3600),
+        Some('d') => (&trimmed[..trimmed.len() - 1], 86400),
+        _ => (trimmed, 1),
+    };
+    let n: u64 = digits
+        .parse()
+        .map_err(|_| format!("could not parse --since {raw:?}; expected e.g. 30m, 2h, 90s"))?;
+    if n == 0 {
+        return Err(format!("--since {raw:?} must be a positive duration"));
+    }
+    n.checked_mul(mult)
+        .map(Duration::from_secs)
+        .ok_or_else(|| format!("--since {raw:?} overflows"))
+}
+
+// ============================================================================
+// Inputs
+// ============================================================================
+
+/// Everything [`assess`] needs, already collected. Keeping this a plain data
+/// struct is what makes every verdict rule testable without a daemon, a forge,
+/// or a subprocess.
+#[derive(Debug, Clone, Default)]
+pub struct HealthInputs {
+    /// Collection time (all ages/windows are measured from here).
+    pub at: DateTime<Utc>,
+    /// The `--since` window.
+    pub window: Duration,
+    /// The daemon's IPC status report, when the round-trip succeeded.
+    pub status: Option<DaemonStatusReport>,
+    /// Why the IPC round-trip failed, when it did.
+    pub ipc_error: Option<String>,
+    /// The local install-state classification (launchd + pid-file, #4694).
+    /// `None` when no loom dir could be resolved at all — undiagnosable.
+    pub install_state: Option<InstallStateReport>,
+    /// Live `loom-daemon` pids from `pgrep` — the third liveness signal.
+    pub pgrep_pids: Vec<u32>,
+    /// Whether a `.ranking` file was found in the resolved pool.
+    pub ranking_present: bool,
+    /// Age of the resolved pool's `.ranking` in seconds, when readable.
+    pub ranking_age_secs: Option<u64>,
+    /// Per-repo forge snapshot (`queued` + merged-in-window), when collected.
+    pub pipeline: Option<Vec<RepoPipelineSnapshot>>,
+}
+
+// ============================================================================
+// Role-tick classification (transient vs persistent)
+// ============================================================================
+
+/// One `(root, role)` pair's failure state inside the window.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RoleFailure {
+    /// The workspace root.
+    pub root: PathBuf,
+    /// The role name.
+    pub role: String,
+    /// How many ticks failed for this pair inside the window.
+    pub failures: usize,
+    /// When the most recent record for this pair landed.
+    pub last_at: DateTime<Utc>,
+    /// The most recent failure detail.
+    pub detail: Option<String>,
+}
+
+impl RoleFailure {
+    /// `<role> @ <root>` — the label rendered in the summary line.
+    #[must_use]
+    pub fn label(&self) -> String {
+        format!(
+            "{} @ {}",
+            self.role,
+            self.root.file_name().map_or_else(
+                || self.root.display().to_string(),
+                |n| n.to_string_lossy().into_owned()
+            )
+        )
+    }
+}
+
+/// The windowed role-tick picture.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct RoleTickSummary {
+    /// Total tick records inside the window.
+    pub total: usize,
+    /// Successful tick records inside the window.
+    pub ok: usize,
+    /// `(root, role)` pairs whose **latest** record in the window is a failure
+    /// — the only ones that surface as degraded.
+    pub persistent: Vec<RoleFailure>,
+    /// `(root, role)` pairs that failed at least once but whose latest record
+    /// in the window is a success — self-recovered, reported as a count only.
+    pub transient: Vec<RoleFailure>,
+}
+
+/// Classify a role-tick window into persistent vs transient failures (#4761).
+///
+/// The rule, stated in the issue: *transient = self-recovered within the same
+/// root's next tick; only persistent ones surface*. Concretely, for each
+/// `(root, role)` pair inside the window: if its **most recent** record is a
+/// failure, the pair is persistent; if it failed at some point but its most
+/// recent record is a success, it is transient. A pair that never failed
+/// appears in neither list.
+///
+/// This is deliberately a *client-side* classifier over raw records rather than
+/// a daemon-side verdict: which window an operator cares about is their choice,
+/// and the daemon's own log-dedup state (#4349's fail-edge/repeat map) is about
+/// keeping the log quiet, not about health.
+///
+/// Records at or after `since` are considered; the rest are ignored. Both
+/// output lists are sorted by `(root, role)` for stable rendering.
+#[must_use]
+pub fn summarize_role_ticks(records: &[RoleTickRecord], since: DateTime<Utc>) -> RoleTickSummary {
+    // BTreeMap keyed by (root, role) so the output order is deterministic.
+    let mut by_pair: BTreeMap<(PathBuf, String), Vec<&RoleTickRecord>> = BTreeMap::new();
+    let mut total = 0_usize;
+    let mut ok = 0_usize;
+    for record in records.iter().filter(|r| r.at >= since) {
+        total += 1;
+        if record.ok {
+            ok += 1;
+        }
+        by_pair
+            .entry((record.root.clone(), record.role.clone()))
+            .or_default()
+            .push(record);
+    }
+
+    let mut summary = RoleTickSummary {
+        total,
+        ok,
+        ..Default::default()
+    };
+    for ((root, role), mut entries) in by_pair {
+        entries.sort_by_key(|r| r.at);
+        let failures = entries.iter().filter(|r| !r.ok).count();
+        if failures == 0 {
+            continue;
+        }
+        // `entries` is non-empty (it exists because at least one record was
+        // pushed) and now sorted oldest-first, so the last element is the
+        // pair's latest record in the window.
+        let Some(latest) = entries.last() else {
+            continue;
+        };
+        let detail = entries
+            .iter()
+            .rev()
+            .find(|r| !r.ok)
+            .and_then(|r| r.detail.clone());
+        let failure = RoleFailure {
+            root,
+            role,
+            failures,
+            last_at: latest.at,
+            detail,
+        };
+        if latest.ok {
+            summary.transient.push(failure);
+        } else {
+            summary.persistent.push(failure);
+        }
+    }
+    summary
+}
+
+// ============================================================================
+// Section assessments
+// ============================================================================
+
+/// Assess the liveness section — the #4694-pinned precedence (see module docs).
+#[must_use]
+pub fn assess_liveness(inputs: &HealthInputs) -> HealthSection {
+    // 1. A daemon that just answered IPC is alive. No local probe overrules it.
+    if inputs.status.is_some() {
+        let pid = inputs.install_state.as_ref().and_then(|r| r.pid);
+        return HealthSection::new(
+            "liveness",
+            Verdict::Green,
+            match pid {
+                Some(p) => format!("daemon alive — IPC round-trip ok (pid {p})"),
+                None => "daemon alive — IPC round-trip ok".to_string(),
+            },
+            serde_json::json!({
+                "signal": "ipc",
+                "ipc_reachable": true,
+                "pid": pid,
+                "pgrep_pids": inputs.pgrep_pids,
+            }),
+        );
+    }
+
+    let ipc_error = inputs
+        .ipc_error
+        .clone()
+        .unwrap_or_else(|| "unreachable".to_string());
+
+    // 2. The install-state classification already refuses to trust a lone
+    //    launchd negative (launchd → skipped-domain cross-check → pid file).
+    if let Some(report) = &inputs.install_state {
+        let detail = report.liveness_detail.clone().unwrap_or_default();
+        match report.state {
+            InstallState::AliveStarting => {
+                return HealthSection::new(
+                    "liveness",
+                    Verdict::Degraded,
+                    format!(
+                        "process alive, still STARTING (age {}s) — IPC not bound yet: {ipc_error}",
+                        report.process_age_secs.unwrap_or_default()
+                    ),
+                    liveness_detail_json("install-state", report, inputs, false),
+                );
+            }
+            InstallState::AliveButUnresponsive => {
+                return HealthSection::new(
+                    "liveness",
+                    Verdict::Degraded,
+                    format!(
+                        "process ALIVE but not answering IPC — NOT dead ({detail}); ipc: {ipc_error}"
+                    ),
+                    liveness_detail_json("install-state", report, inputs, false),
+                );
+            }
+            InstallState::ExpectedButDead | InstallState::NotExpected => {
+                // 3. Both launchd domains and the pid file came back negative.
+                //    One more independent signal before declaring death.
+                if !inputs.pgrep_pids.is_empty() {
+                    return HealthSection::new(
+                        "liveness",
+                        Verdict::Degraded,
+                        format!(
+                            "no launchd/pid-file evidence ({detail}), but pgrep finds live \
+                             loom-daemon pid(s) {:?} — NOT declaring dead; ipc: {ipc_error}",
+                            inputs.pgrep_pids
+                        ),
+                        liveness_detail_json("pgrep", report, inputs, false),
+                    );
+                }
+                let summary = if report.state == InstallState::NotExpected {
+                    format!(
+                        "daemon DEAD — no autonomy-desired marker, no live pid file, no \
+                         loom-daemon process (deliberately stopped?); ipc: {ipc_error}"
+                    )
+                } else {
+                    format!(
+                        "daemon DEAD — marker present (started {}) but {detail}, and no \
+                         loom-daemon process; ipc: {ipc_error}",
+                        report.started_at.as_deref().unwrap_or("unknown")
+                    )
+                };
+                return HealthSection::new(
+                    "liveness",
+                    Verdict::Dead,
+                    summary,
+                    liveness_detail_json("all-negative", report, inputs, true),
+                );
+            }
+        }
+    }
+
+    // 4. Undiagnosable: no install-state classification at all. `pgrep` is the
+    //    only remaining signal, and its absence is not evidence of death.
+    if inputs.pgrep_pids.is_empty() {
+        HealthSection::new(
+            "liveness",
+            Verdict::Unknown,
+            format!(
+                "could not classify liveness (no loom dir resolvable) and no loom-daemon \
+                 process found — NOT declaring dead without a marker/pid-file verdict; ipc: \
+                 {ipc_error}"
+            ),
+            serde_json::json!({
+                "signal": "undiagnosable",
+                "ipc_reachable": false,
+                "ipc_error": ipc_error,
+                "pgrep_pids": inputs.pgrep_pids,
+            }),
+        )
+    } else {
+        HealthSection::new(
+            "liveness",
+            Verdict::Degraded,
+            format!(
+                "could not classify liveness (no loom dir resolvable), but pgrep finds live \
+                 loom-daemon pid(s) {:?}; ipc: {ipc_error}",
+                inputs.pgrep_pids
+            ),
+            serde_json::json!({
+                "signal": "pgrep",
+                "ipc_reachable": false,
+                "ipc_error": ipc_error,
+                "pgrep_pids": inputs.pgrep_pids,
+            }),
+        )
+    }
+}
+
+fn liveness_detail_json(
+    signal: &str,
+    report: &InstallStateReport,
+    inputs: &HealthInputs,
+    dead: bool,
+) -> serde_json::Value {
+    serde_json::json!({
+        "signal": signal,
+        "ipc_reachable": false,
+        "ipc_error": inputs.ipc_error,
+        "install_state": report.state.as_str(),
+        "liveness_detail": report.liveness_detail,
+        "pid": report.pid,
+        "process_age_secs": report.process_age_secs,
+        "pgrep_pids": inputs.pgrep_pids,
+        "declared_dead": dead,
+    })
+}
+
+/// Assess the dispatch section: in-flight occupancy against the dynamic cap,
+/// plus the last work-finder tick's dispatch/skip-reason summary.
+#[must_use]
+pub fn assess_dispatch(inputs: &HealthInputs) -> HealthSection {
+    let Some(status) = &inputs.status else {
+        return unknown_section("dispatch", "no daemon status (IPC unreachable)");
+    };
+
+    let in_flight = status.in_flight.len();
+    let cap = status.dynamic_cap;
+    let mut degraded: Vec<String> = Vec::new();
+
+    if status.work_finder_enabled == Some(false) {
+        degraded.push("work finder DISABLED — no autonomous dispatch".to_string());
+    }
+    if status.main_health_gate_halted {
+        degraded.push("main-health gate HALTED".to_string());
+    }
+    if status.draining {
+        degraded.push("DRAINING".to_string());
+    }
+    if status.host_breaker.as_ref().is_some_and(|b| b.suppressed) {
+        degraded.push("host-distress breaker TRIPPED".to_string());
+    }
+    if status
+        .rate_limit_breaker
+        .as_ref()
+        .is_some_and(|b| b.suppressed)
+    {
+        degraded.push("GitHub rate-limit breaker TRIPPED".to_string());
+    }
+    if status.preflight_advisory_active {
+        degraded.push(
+            status
+                .preflight_advisory_message
+                .clone()
+                .unwrap_or_else(|| "claude-wrapper preflight tripwire active".to_string()),
+        );
+    }
+
+    let tick_line = match &status.last_work_finder_tick {
+        Some(tick) => {
+            if tick.errors > 0 {
+                degraded.push(format!("{} dispatch error(s) last tick", tick.errors));
+            }
+            format!(
+                "last tick {} ago: {}",
+                format_age((inputs.at - tick.at).num_seconds()),
+                tick.reason_summary()
+            )
+        }
+        None => {
+            // Only a fault when the loop is supposed to be running.
+            if status.work_finder_enabled != Some(false) {
+                degraded.push("no work-finder tick observed in this daemon process".to_string());
+            }
+            "no work-finder tick observed".to_string()
+        }
+    };
+
+    let summary = if degraded.is_empty() {
+        format!("{in_flight} in-flight / cap {cap}; {tick_line}")
+    } else {
+        format!("{in_flight} in-flight / cap {cap}; {}; {tick_line}", degraded.join("; "))
+    };
+    let verdict = if degraded.is_empty() {
+        Verdict::Green
+    } else {
+        Verdict::Degraded
+    };
+    HealthSection::new(
+        "dispatch",
+        verdict,
+        summary,
+        serde_json::json!({
+            "in_flight": in_flight,
+            "dynamic_cap": cap,
+            "capacity_bound": status.capacity_bound,
+            "work_finder_enabled": status.work_finder_enabled,
+            "halted": status.main_health_gate_halted,
+            "draining": status.draining,
+            "last_tick": status.last_work_finder_tick,
+            "issues": degraded,
+        }),
+    )
+}
+
+/// Assess the token-pool section: healthy/total, exhausted count, and
+/// `.ranking` staleness.
+#[must_use]
+pub fn assess_tokens(inputs: &HealthInputs) -> HealthSection {
+    let Some(status) = &inputs.status else {
+        return unknown_section("tokens", "no daemon status (IPC unreachable)");
+    };
+    let cap = &status.capacity;
+    let mut degraded: Vec<String> = Vec::new();
+
+    if cap.total_accounts == 0 {
+        degraded.push("EMPTY token pool".to_string());
+    } else if cap.healthy_accounts == 0 {
+        degraded.push("ZERO healthy accounts — dispatch is token-starved".to_string());
+    }
+    if !inputs.ranking_present {
+        degraded.push("no .ranking — token axis falls back to the raw pool size".to_string());
+    } else if let Some(age) = inputs.ranking_age_secs {
+        if age > RANKING_STALE_SECS {
+            degraded.push(format!(
+                ".ranking STALE ({} old, threshold {})",
+                format_age(age.try_into().unwrap_or(i64::MAX)),
+                format_age(RANKING_STALE_SECS.try_into().unwrap_or(i64::MAX))
+            ));
+        }
+    }
+
+    let ranking_age = match (inputs.ranking_present, inputs.ranking_age_secs) {
+        (true, Some(age)) => {
+            format!("ranking {} old", format_age(age.try_into().unwrap_or(i64::MAX)))
+        }
+        (true, None) => "ranking present (age unknown)".to_string(),
+        (false, _) => "no ranking".to_string(),
+    };
+    let base = format!(
+        "{}/{} healthy ({} exhausted), {ranking_age}",
+        cap.healthy_accounts, cap.total_accounts, cap.exhausted_accounts
+    );
+    let (verdict, summary) = if degraded.is_empty() {
+        (Verdict::Green, base)
+    } else {
+        (Verdict::Degraded, format!("{base}; {}", degraded.join("; ")))
+    };
+    HealthSection::new(
+        "tokens",
+        verdict,
+        summary,
+        serde_json::json!({
+            "healthy": cap.healthy_accounts,
+            "total": cap.total_accounts,
+            "exhausted": cap.exhausted_accounts,
+            "token_axis_limit": cap.token_axis_limit,
+            "token_bound": cap.token_bound,
+            "ranking_present": inputs.ranking_present,
+            "ranking_age_secs": inputs.ranking_age_secs,
+            "ranking_stale_threshold_secs": RANKING_STALE_SECS,
+            "issues": degraded,
+        }),
+    )
+}
+
+/// Assess the role-tick section: only *persistent* failures surface; transient
+/// (self-recovered) ones are reported as a count so they are visible without
+/// being alarming.
+#[must_use]
+pub fn assess_roles(inputs: &HealthInputs) -> HealthSection {
+    let Some(status) = &inputs.status else {
+        return unknown_section("roles", "no daemon status (IPC unreachable)");
+    };
+    let since = inputs.at
+        - chrono::Duration::from_std(inputs.window).unwrap_or_else(|_| chrono::Duration::zero());
+    let summary = summarize_role_ticks(&status.role_tick_records, since);
+
+    if summary.total == 0 {
+        return HealthSection::new(
+            "roles",
+            Verdict::Green,
+            "no role ticks in window (role runner idle or disabled)",
+            serde_json::json!({ "total": 0, "ok": 0, "persistent": [], "transient": [] }),
+        );
+    }
+
+    let transient_note = if summary.transient.is_empty() {
+        String::new()
+    } else {
+        format!("; {} transient (self-recovered)", summary.transient.len())
+    };
+    let (verdict, line) = if summary.persistent.is_empty() {
+        (
+            Verdict::Green,
+            format!("{}/{} ticks ok{transient_note}", summary.ok, summary.total),
+        )
+    } else {
+        let names: Vec<String> = summary
+            .persistent
+            .iter()
+            .map(|f| {
+                let detail = f.detail.as_deref().unwrap_or("failed");
+                format!("{} ({} ticks, {detail})", f.label(), f.failures)
+            })
+            .collect();
+        (
+            Verdict::Degraded,
+            format!(
+                "{}/{} ticks ok; {} PERSISTENT failure(s): {}{transient_note}",
+                summary.ok,
+                summary.total,
+                summary.persistent.len(),
+                names.join(", ")
+            ),
+        )
+    };
+    HealthSection::new(
+        "roles",
+        verdict,
+        line,
+        serde_json::to_value(&summary).unwrap_or(serde_json::Value::Null),
+    )
+}
+
+/// Assess the queue-depth section: per-root ready (`loom:issue`) counts.
+#[must_use]
+pub fn assess_queues(inputs: &HealthInputs) -> HealthSection {
+    let Some(pipeline) = &inputs.pipeline else {
+        return unknown_section("queues", "forge snapshot not collected");
+    };
+    if pipeline.is_empty() {
+        return HealthSection::new(
+            "queues",
+            Verdict::Green,
+            "no managed repos",
+            serde_json::json!({ "repos": [] }),
+        );
+    }
+
+    let mut parts: Vec<String> = Vec::with_capacity(pipeline.len());
+    let mut total = 0_usize;
+    let mut failed: Vec<String> = Vec::new();
+    for snap in pipeline {
+        let name = repo_label(&snap.root);
+        match snap.queued {
+            Some(n) => {
+                total += n;
+                parts.push(format!("{name} {n}"));
+            }
+            None => {
+                parts.push(format!("{name} ?"));
+                failed.push(name);
+            }
+        }
+    }
+    let (verdict, summary) = if failed.is_empty() {
+        (
+            Verdict::Green,
+            format!("{total} ready across {} repo(s) ({})", pipeline.len(), parts.join(", ")),
+        )
+    } else {
+        (
+            Verdict::Unknown,
+            format!(
+                "{total}+ ready across {} repo(s) ({}); forge query FAILED for: {}",
+                pipeline.len(),
+                parts.join(", "),
+                failed.join(", ")
+            ),
+        )
+    };
+    HealthSection::new(
+        "queues",
+        verdict,
+        summary,
+        serde_json::json!({
+            "total_ready": total,
+            "repos": pipeline
+                .iter()
+                .map(|s| serde_json::json!({
+                    "root": s.root,
+                    "ready": s.queued,
+                    "error": s.error,
+                }))
+                .collect::<Vec<_>>(),
+        }),
+    )
+}
+
+/// Assess the throughput section: merges across managed repos inside the
+/// window.
+///
+/// A *zero* merge count is deliberately **green**: an idle window (an empty
+/// backlog, a quiet 4am hour) is not a fault, and a health check that cries
+/// wolf on it teaches a watcher to ignore it. Only a failed forge query is
+/// non-green here.
+#[must_use]
+pub fn assess_throughput(inputs: &HealthInputs) -> HealthSection {
+    let Some(pipeline) = &inputs.pipeline else {
+        return unknown_section("throughput", "forge snapshot not collected");
+    };
+    if pipeline.is_empty() {
+        return HealthSection::new(
+            "throughput",
+            Verdict::Green,
+            "no managed repos",
+            serde_json::json!({ "repos": [] }),
+        );
+    }
+
+    let window = format_window(inputs.window.as_secs());
+    let mut total = 0_usize;
+    let mut failed: Vec<String> = Vec::new();
+    for snap in pipeline {
+        match snap.merged_24h {
+            Some(n) => total += n,
+            None => failed.push(repo_label(&snap.root)),
+        }
+    }
+    let (verdict, summary) = if failed.is_empty() {
+        (
+            Verdict::Green,
+            format!("{total} merged in {window} across {} repo(s)", pipeline.len()),
+        )
+    } else {
+        (
+            Verdict::Unknown,
+            format!(
+                "{total}+ merged in {window} across {} repo(s); forge query FAILED for: {}",
+                pipeline.len(),
+                failed.join(", ")
+            ),
+        )
+    };
+    HealthSection::new(
+        "throughput",
+        verdict,
+        summary,
+        serde_json::json!({
+            "window_secs": inputs.window.as_secs(),
+            "merged": total,
+            "repos": pipeline
+                .iter()
+                .map(|s| serde_json::json!({
+                    "root": s.root,
+                    "merged": s.merged_24h,
+                    "error": s.error,
+                }))
+                .collect::<Vec<_>>(),
+        }),
+    )
+}
+
+// ============================================================================
+// Roll-up
+// ============================================================================
+
+/// Assemble the full report from already-collected inputs (pure).
+///
+/// A [`Verdict::Dead`] liveness verdict short-circuits: the remaining sections
+/// are reported as [`Verdict::Unknown`] (they are all downstream of an IPC
+/// round-trip that could not happen), and the overall verdict is `Dead` so the
+/// exit code is `2` rather than a misleading `1`.
+#[must_use]
+pub fn assess(inputs: &HealthInputs) -> HealthReport {
+    let liveness = assess_liveness(inputs);
+    let dead = liveness.verdict == Verdict::Dead;
+    let sections = vec![
+        liveness,
+        assess_dispatch(inputs),
+        assess_tokens(inputs),
+        assess_roles(inputs),
+        assess_queues(inputs),
+        assess_throughput(inputs),
+    ];
+    let overall = if dead {
+        Verdict::Dead
+    } else if sections.iter().all(|s| s.verdict.is_green()) {
+        Verdict::Green
+    } else if sections.iter().any(|s| s.verdict == Verdict::Degraded) {
+        Verdict::Degraded
+    } else {
+        Verdict::Unknown
+    };
+    HealthReport {
+        at: inputs.at,
+        window_secs: inputs.window.as_secs(),
+        overall,
+        sections,
+    }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn unknown_section(key: &'static str, why: &str) -> HealthSection {
+    HealthSection::new(
+        key,
+        Verdict::Unknown,
+        why.to_string(),
+        serde_json::json!({ "unavailable": why }),
+    )
+}
+
+/// The short repo label rendered in the queue/throughput lines — the root's
+/// final path component, which is the repo name for every managed workspace.
+fn repo_label(root: &std::path::Path) -> String {
+    root.file_name()
+        .map_or_else(|| root.display().to_string(), |n| n.to_string_lossy().into_owned())
+}
+
+/// Render an age in seconds compactly (`43s`, `7m`, `2h`, `3d`). Negative ages
+/// (a clock skew between the daemon's stamp and this process) render as `0s`
+/// rather than a nonsensical negative.
+#[must_use]
+pub fn format_age(secs: i64) -> String {
+    let s = secs.max(0);
+    if s < 90 {
+        format!("{s}s")
+    } else if s < 5400 {
+        format!("{}m", s / 60)
+    } else if s < 172_800 {
+        format!("{}h", s / 3600)
+    } else {
+        format!("{}d", s / 86400)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::daemon_install_state::HeartbeatFreshness;
+
+    fn now() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-07-31T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn install_report(state: InstallState) -> InstallStateReport {
+        InstallStateReport {
+            state,
+            started_at: Some("2026-07-30T00:00:00Z".to_string()),
+            pid: matches!(state, InstallState::AliveStarting | InstallState::AliveButUnresponsive)
+                .then_some(4321),
+            liveness_detail: Some("launchd job gui/501/com.loom.daemon alive".to_string()),
+            heartbeat_freshness: Some(HeartbeatFreshness::Fresh),
+            heartbeat_age_secs: Some(5),
+            heartbeat_stale_threshold_secs: Some(120),
+            process_age_secs: Some(9),
+            startup_grace_threshold_secs: Some(45),
+            watchdog_log_path: PathBuf::from("/tmp/watchdog.log"),
+        }
+    }
+
+    fn healthy_status() -> DaemonStatusReport {
+        let mut status = DaemonStatusReport {
+            capacity: crate::types::CapacityReport {
+                ranking_present: true,
+                total_accounts: 8,
+                healthy_accounts: 6,
+                exhausted_accounts: 2,
+                token_axis_limit: 6,
+                token_bound: false,
+            },
+            dynamic_cap: 7,
+            work_finder_enabled: Some(true),
+            ..Default::default()
+        };
+        status.last_work_finder_tick = Some(crate::types::WorkFinderTickSummary {
+            at: now() - chrono::Duration::seconds(30),
+            max_concurrent: 7,
+            seen: 12,
+            dispatched: 2,
+            skipped_in_flight: 10,
+            ..Default::default()
+        });
+        status
+    }
+
+    fn healthy_inputs() -> HealthInputs {
+        HealthInputs {
+            at: now(),
+            window: Duration::from_secs(DEFAULT_WINDOW_SECS),
+            status: Some(healthy_status()),
+            ipc_error: None,
+            install_state: Some(install_report(InstallState::AliveButUnresponsive)),
+            pgrep_pids: vec![4321],
+            ranking_present: true,
+            ranking_age_secs: Some(240),
+            pipeline: Some(vec![RepoPipelineSnapshot {
+                root: PathBuf::from("/repos/loom"),
+                queued: Some(5),
+                merged_24h: Some(3),
+                ..Default::default()
+            }]),
+        }
+    }
+
+    // ===================================================================
+    // #4694 regression pins — liveness precedence
+    // ===================================================================
+
+    /// The single most important assertion in this file: a reachable daemon is
+    /// GREEN even when the local install-state probe reports it dead. This is
+    /// the #4694 false negative — the launchd domain probe declaring a live,
+    /// dispatching daemon dead — and it must never be able to override an
+    /// answered IPC round-trip.
+    #[test]
+    fn ipc_reachable_beats_a_dead_launchd_verdict() {
+        let mut inputs = healthy_inputs();
+        inputs.install_state = Some(install_report(InstallState::ExpectedButDead));
+        let section = assess_liveness(&inputs);
+        assert_eq!(section.verdict, Verdict::Green);
+        assert_eq!(section.detail["signal"], "ipc");
+    }
+
+    /// The launchd domain probe alone can never produce a DEAD verdict: with
+    /// IPC unreachable and the install-state classification negative, a live
+    /// `pgrep` pid still holds the verdict at DEGRADED.
+    #[test]
+    fn pgrep_blocks_a_dead_verdict_when_launchd_and_pidfile_are_negative() {
+        let mut inputs = healthy_inputs();
+        inputs.status = None;
+        inputs.ipc_error = Some("connect failed".to_string());
+        inputs.install_state = Some(install_report(InstallState::ExpectedButDead));
+        inputs.pgrep_pids = vec![9911];
+        let section = assess_liveness(&inputs);
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert_eq!(section.detail["signal"], "pgrep");
+        assert_eq!(section.detail["declared_dead"], false);
+    }
+
+    /// An install-state classification of "alive but unresponsive" is DEGRADED,
+    /// never DEAD — the daemon is running, it is just not answering.
+    #[test]
+    fn alive_but_unresponsive_is_degraded_not_dead() {
+        let mut inputs = healthy_inputs();
+        inputs.status = None;
+        inputs.ipc_error = Some("round-trip timed out".to_string());
+        inputs.pgrep_pids = vec![];
+        let section = assess_liveness(&inputs);
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(section.summary.contains("NOT dead"));
+    }
+
+    #[test]
+    fn alive_starting_is_degraded_not_dead() {
+        let mut inputs = healthy_inputs();
+        inputs.status = None;
+        inputs.ipc_error = Some("connect failed".to_string());
+        inputs.install_state = Some(install_report(InstallState::AliveStarting));
+        inputs.pgrep_pids = vec![];
+        let section = assess_liveness(&inputs);
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(section.summary.contains("STARTING"));
+    }
+
+    /// Only when *all three* signals are negative is the daemon declared dead.
+    #[test]
+    fn all_three_signals_negative_declares_dead() {
+        let mut inputs = healthy_inputs();
+        inputs.status = None;
+        inputs.ipc_error = Some("connect failed".to_string());
+        inputs.install_state = Some(install_report(InstallState::ExpectedButDead));
+        inputs.pgrep_pids = vec![];
+        let section = assess_liveness(&inputs);
+        assert_eq!(section.verdict, Verdict::Dead);
+        assert_eq!(section.detail["signal"], "all-negative");
+    }
+
+    /// An undiagnosable probe is UNKNOWN (exit 1), never DEAD (exit 2).
+    #[test]
+    fn undiagnosable_is_unknown_never_dead() {
+        let mut inputs = healthy_inputs();
+        inputs.status = None;
+        inputs.ipc_error = Some("connect failed".to_string());
+        inputs.install_state = None;
+        inputs.pgrep_pids = vec![];
+        let section = assess_liveness(&inputs);
+        assert_eq!(section.verdict, Verdict::Unknown);
+        assert_eq!(assess(&inputs).exit_code(), EXIT_DEGRADED);
+    }
+
+    // ===================================================================
+    // Exit-code contract
+    // ===================================================================
+
+    #[test]
+    fn healthy_inputs_exit_zero() {
+        let report = assess(&healthy_inputs());
+        assert_eq!(report.overall, Verdict::Green, "{}", report.render_human());
+        assert_eq!(report.exit_code(), EXIT_HEALTHY);
+    }
+
+    #[test]
+    fn any_degraded_section_exits_one() {
+        let mut inputs = healthy_inputs();
+        inputs.status.as_mut().unwrap().capacity.healthy_accounts = 0;
+        let report = assess(&inputs);
+        assert_eq!(report.overall, Verdict::Degraded);
+        assert_eq!(report.exit_code(), EXIT_DEGRADED);
+    }
+
+    #[test]
+    fn dead_daemon_exits_two_and_marks_other_sections_unknown() {
+        let mut inputs = healthy_inputs();
+        inputs.status = None;
+        inputs.ipc_error = Some("connect failed".to_string());
+        inputs.install_state = Some(install_report(InstallState::ExpectedButDead));
+        inputs.pgrep_pids = vec![];
+        let report = assess(&inputs);
+        assert_eq!(report.overall, Verdict::Dead);
+        assert_eq!(report.exit_code(), EXIT_DEAD);
+        assert_eq!(report.section("dispatch").unwrap().verdict, Verdict::Unknown);
+        assert_eq!(report.section("tokens").unwrap().verdict, Verdict::Unknown);
+    }
+
+    #[test]
+    fn report_always_has_all_six_sections() {
+        let report = assess(&healthy_inputs());
+        let keys: Vec<&str> = report.sections.iter().map(|s| s.key).collect();
+        assert_eq!(
+            keys,
+            vec![
+                "liveness",
+                "dispatch",
+                "tokens",
+                "roles",
+                "queues",
+                "throughput"
+            ]
+        );
+    }
+
+    #[test]
+    fn render_human_is_one_line_per_section_plus_overall() {
+        let report = assess(&healthy_inputs());
+        let rendered = report.render_human();
+        let lines: Vec<&str> = rendered.lines().collect();
+        assert_eq!(lines.len(), 7);
+        assert!(lines[6].starts_with("overall"));
+    }
+
+    #[test]
+    fn json_serialization_round_trips() {
+        let report = assess(&healthy_inputs());
+        let value = serde_json::to_value(&report).unwrap();
+        assert_eq!(value["overall"], "green");
+        assert_eq!(value["sections"].as_array().unwrap().len(), 6);
+    }
+
+    // ===================================================================
+    // Dispatch section
+    // ===================================================================
+
+    #[test]
+    fn dispatch_reports_last_tick_reason_summary() {
+        let section = assess_dispatch(&healthy_inputs());
+        assert_eq!(section.verdict, Verdict::Green);
+        assert!(section
+            .summary
+            .contains("12 seen, 2 dispatched, 10 in-flight-skip"));
+    }
+
+    #[test]
+    fn dispatch_missing_tick_is_degraded_when_work_finder_is_enabled() {
+        let mut inputs = healthy_inputs();
+        inputs.status.as_mut().unwrap().last_work_finder_tick = None;
+        let section = assess_dispatch(&inputs);
+        assert_eq!(section.verdict, Verdict::Degraded);
+    }
+
+    #[test]
+    fn dispatch_missing_tick_is_green_when_work_finder_is_disabled_and_nothing_else_is_wrong() {
+        let mut inputs = healthy_inputs();
+        let status = inputs.status.as_mut().unwrap();
+        status.last_work_finder_tick = None;
+        status.work_finder_enabled = Some(false);
+        // The DISABLED work finder is itself the (single) degradation.
+        let section = assess_dispatch(&inputs);
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(section.summary.contains("DISABLED"));
+        assert!(!section
+            .summary
+            .contains("no work-finder tick observed in this daemon process"));
+    }
+
+    #[test]
+    fn dispatch_flags_a_halted_gate() {
+        let mut inputs = healthy_inputs();
+        inputs.status.as_mut().unwrap().main_health_gate_halted = true;
+        let section = assess_dispatch(&inputs);
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(section.summary.contains("HALTED"));
+    }
+
+    #[test]
+    fn dispatch_flags_tick_errors() {
+        let mut inputs = healthy_inputs();
+        inputs
+            .status
+            .as_mut()
+            .unwrap()
+            .last_work_finder_tick
+            .as_mut()
+            .unwrap()
+            .errors = 3;
+        let section = assess_dispatch(&inputs);
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(section.summary.contains("3 dispatch error(s)"));
+    }
+
+    // ===================================================================
+    // Tokens section
+    // ===================================================================
+
+    #[test]
+    fn tokens_green_when_healthy_and_ranking_fresh() {
+        let section = assess_tokens(&healthy_inputs());
+        assert_eq!(section.verdict, Verdict::Green);
+        assert!(section.summary.starts_with("6/8 healthy (2 exhausted)"));
+    }
+
+    #[test]
+    fn tokens_degraded_when_all_exhausted() {
+        let mut inputs = healthy_inputs();
+        let cap = &mut inputs.status.as_mut().unwrap().capacity;
+        cap.healthy_accounts = 0;
+        cap.exhausted_accounts = 8;
+        let section = assess_tokens(&inputs);
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(section.summary.contains("token-starved"));
+    }
+
+    #[test]
+    fn tokens_degraded_when_ranking_is_stale() {
+        let mut inputs = healthy_inputs();
+        inputs.ranking_age_secs = Some(RANKING_STALE_SECS + 1);
+        let section = assess_tokens(&inputs);
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(section.summary.contains("STALE"));
+    }
+
+    #[test]
+    fn tokens_degraded_when_ranking_is_absent() {
+        let mut inputs = healthy_inputs();
+        inputs.ranking_present = false;
+        inputs.ranking_age_secs = None;
+        let section = assess_tokens(&inputs);
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(section.summary.contains("no .ranking"));
+    }
+
+    #[test]
+    fn tokens_degraded_on_an_empty_pool() {
+        let mut inputs = healthy_inputs();
+        let cap = &mut inputs.status.as_mut().unwrap().capacity;
+        cap.total_accounts = 0;
+        cap.healthy_accounts = 0;
+        cap.exhausted_accounts = 0;
+        let section = assess_tokens(&inputs);
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(section.summary.contains("EMPTY token pool"));
+    }
+
+    // ===================================================================
+    // Role-tick classification
+    // ===================================================================
+
+    fn record(role: &str, root: &str, ago_secs: i64, ok: bool) -> RoleTickRecord {
+        RoleTickRecord {
+            root: PathBuf::from(root),
+            role: role.to_string(),
+            at: now() - chrono::Duration::seconds(ago_secs),
+            ok,
+            detail: (!ok).then(|| "boom".to_string()),
+        }
+    }
+
+    #[test]
+    fn a_failure_followed_by_a_success_is_transient() {
+        let records = vec![
+            record("curator", "/r/loom", 600, false),
+            record("curator", "/r/loom", 300, true),
+        ];
+        let summary = summarize_role_ticks(&records, now() - chrono::Duration::seconds(1800));
+        assert!(summary.persistent.is_empty());
+        assert_eq!(summary.transient.len(), 1);
+        assert_eq!(summary.transient[0].failures, 1);
+    }
+
+    #[test]
+    fn a_failure_that_is_still_the_latest_record_is_persistent() {
+        let records = vec![
+            record("champion", "/r/loom", 600, true),
+            record("champion", "/r/loom", 300, false),
+            record("champion", "/r/loom", 60, false),
+        ];
+        let summary = summarize_role_ticks(&records, now() - chrono::Duration::seconds(1800));
+        assert_eq!(summary.persistent.len(), 1);
+        assert_eq!(summary.persistent[0].failures, 2);
+        assert_eq!(summary.persistent[0].detail.as_deref(), Some("boom"));
+        assert!(summary.transient.is_empty());
+    }
+
+    #[test]
+    fn each_root_role_pair_is_classified_independently() {
+        let records = vec![
+            record("curator", "/r/loom", 300, false),
+            record("curator", "/r/anvil", 300, false),
+            record("curator", "/r/anvil", 100, true),
+        ];
+        let summary = summarize_role_ticks(&records, now() - chrono::Duration::seconds(1800));
+        assert_eq!(summary.persistent.len(), 1);
+        assert_eq!(summary.persistent[0].root, PathBuf::from("/r/loom"));
+        assert_eq!(summary.transient.len(), 1);
+        assert_eq!(summary.transient[0].root, PathBuf::from("/r/anvil"));
+    }
+
+    #[test]
+    fn records_outside_the_window_are_ignored() {
+        let records = vec![record("guide", "/r/loom", 7200, false)];
+        let summary = summarize_role_ticks(&records, now() - chrono::Duration::seconds(1800));
+        assert_eq!(summary.total, 0);
+        assert!(summary.persistent.is_empty());
+    }
+
+    #[test]
+    fn only_persistent_failures_make_the_roles_section_degraded() {
+        let mut inputs = healthy_inputs();
+        inputs.status.as_mut().unwrap().role_tick_records = vec![
+            record("curator", "/r/loom", 600, false),
+            record("curator", "/r/loom", 300, true),
+        ];
+        let section = assess_roles(&inputs);
+        assert_eq!(section.verdict, Verdict::Green);
+        assert!(section.summary.contains("1 transient (self-recovered)"));
+
+        inputs.status.as_mut().unwrap().role_tick_records =
+            vec![record("curator", "/r/loom", 60, false)];
+        let section = assess_roles(&inputs);
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(section.summary.contains("PERSISTENT"));
+        assert!(section.summary.contains("curator @ loom"));
+    }
+
+    #[test]
+    fn no_role_ticks_in_window_is_green() {
+        let section = assess_roles(&healthy_inputs());
+        assert_eq!(section.verdict, Verdict::Green);
+        assert!(section.summary.contains("no role ticks in window"));
+    }
+
+    // ===================================================================
+    // Queues + throughput
+    // ===================================================================
+
+    #[test]
+    fn queues_sum_ready_counts_per_repo() {
+        let mut inputs = healthy_inputs();
+        inputs.pipeline = Some(vec![
+            RepoPipelineSnapshot {
+                root: PathBuf::from("/r/loom"),
+                queued: Some(4),
+                merged_24h: Some(1),
+                ..Default::default()
+            },
+            RepoPipelineSnapshot {
+                root: PathBuf::from("/r/anvil"),
+                queued: Some(2),
+                merged_24h: Some(0),
+                ..Default::default()
+            },
+        ]);
+        let section = assess_queues(&inputs);
+        assert_eq!(section.verdict, Verdict::Green);
+        assert!(section.summary.contains("6 ready across 2 repo(s)"));
+        assert!(section.summary.contains("loom 4"));
+        assert!(section.summary.contains("anvil 2"));
+    }
+
+    #[test]
+    fn a_failed_queue_query_is_unknown_not_green() {
+        let mut inputs = healthy_inputs();
+        inputs.pipeline = Some(vec![RepoPipelineSnapshot {
+            root: PathBuf::from("/r/loom"),
+            queued: None,
+            merged_24h: Some(1),
+            error: Some("rate limited".to_string()),
+            ..Default::default()
+        }]);
+        let section = assess_queues(&inputs);
+        assert_eq!(section.verdict, Verdict::Unknown);
+        assert_eq!(assess(&inputs).exit_code(), EXIT_DEGRADED);
+    }
+
+    #[test]
+    fn zero_merges_in_window_is_green() {
+        let mut inputs = healthy_inputs();
+        inputs.pipeline.as_mut().unwrap()[0].merged_24h = Some(0);
+        let section = assess_throughput(&inputs);
+        assert_eq!(section.verdict, Verdict::Green);
+        assert!(section.summary.contains("0 merged in 30m"));
+    }
+
+    #[test]
+    fn a_failed_throughput_query_is_unknown() {
+        let mut inputs = healthy_inputs();
+        inputs.pipeline.as_mut().unwrap()[0].merged_24h = None;
+        let section = assess_throughput(&inputs);
+        assert_eq!(section.verdict, Verdict::Unknown);
+    }
+
+    #[test]
+    fn an_empty_fleet_is_green_not_unknown() {
+        let mut inputs = healthy_inputs();
+        inputs.pipeline = Some(vec![]);
+        assert_eq!(assess_queues(&inputs).verdict, Verdict::Green);
+        assert_eq!(assess_throughput(&inputs).verdict, Verdict::Green);
+        assert_eq!(assess(&inputs).exit_code(), EXIT_HEALTHY);
+    }
+
+    // ===================================================================
+    // --since parsing / formatting
+    // ===================================================================
+
+    #[test]
+    fn parse_since_accepts_suffixed_and_bare_values() {
+        assert_eq!(parse_since("30m").unwrap(), Duration::from_secs(1800));
+        assert_eq!(parse_since("2h").unwrap(), Duration::from_secs(7200));
+        assert_eq!(parse_since("90s").unwrap(), Duration::from_secs(90));
+        assert_eq!(parse_since("1d").unwrap(), Duration::from_secs(86400));
+        assert_eq!(parse_since(" 45 ").unwrap(), Duration::from_secs(45));
+    }
+
+    #[test]
+    fn parse_since_rejects_junk_and_zero() {
+        assert!(parse_since("").is_err());
+        assert!(parse_since("later").is_err());
+        assert!(parse_since("0m").is_err());
+        assert!(parse_since("-5m").is_err());
+    }
+
+    #[test]
+    fn format_window_round_trips_common_values() {
+        assert_eq!(format_window(1800), "30m");
+        assert_eq!(format_window(7200), "2h");
+        assert_eq!(format_window(45), "45s");
+    }
+
+    #[test]
+    fn format_age_is_compact_and_never_negative() {
+        assert_eq!(format_age(-10), "0s");
+        assert_eq!(format_age(43), "43s");
+        assert_eq!(format_age(600), "10m");
+        assert_eq!(format_age(7200), "2h");
+        assert_eq!(format_age(400_000), "4d");
+    }
+}

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1670,6 +1670,16 @@ pub fn build_daemon_status(
         // costs no extra config read. Mirrors `main_health_gate_enabled`'s
         // `Some(resolve...)` shape.
         work_finder_enabled: Some(crate::work_finder::resolve_enabled(&wf_config)),
+        // Last completed work-finder tick + the role-tick ring (#4761) — both
+        // process-global slots the respective loops publish to each tick, read
+        // back here for the same reason the auto-update/host-breaker snapshots
+        // above are: they are the only cross-process view of *why* dispatch and
+        // the role cadence are (or are not) making progress, and
+        // `loom-daemon health` must not have to scrape the daemon log for them.
+        // Unset globals (loop never spawned) read as `None` / empty — honestly
+        // "no tick observed", never "nothing happened".
+        last_work_finder_tick: crate::work_finder::last_tick_summary(),
+        role_tick_records: crate::role_runner::role_tick_records(),
     }
 }
 
@@ -5350,6 +5360,21 @@ exit 0
                 reason: None,
             }),
             work_finder_enabled: Some(true),
+            last_work_finder_tick: Some(crate::types::WorkFinderTickSummary {
+                at: chrono::Utc::now(),
+                max_concurrent: 3,
+                seen: 9,
+                dispatched: 1,
+                skipped_in_flight: 8,
+                ..Default::default()
+            }),
+            role_tick_records: vec![crate::types::RoleTickRecord {
+                root: std::path::PathBuf::from("/repo/a"),
+                role: "champion".to_string(),
+                at: chrono::Utc::now(),
+                ok: true,
+                detail: None,
+            }],
         };
         let resp = Response::DaemonStatus(Box::new(report));
         let json = serde_json::to_string(&resp).expect("serialize response");

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -161,6 +161,7 @@ pub mod forge_listing;
 pub mod forge_parser;
 pub mod git_parser;
 pub mod git_utils;
+pub mod health;
 pub mod health_monitor;
 pub mod host_breaker;
 pub mod idle_exit;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -130,6 +130,30 @@ enum Commands {
         pipeline: bool,
     },
 
+    /// One-shot consolidated fleet vitals with an exit-code contract for watch
+    /// loops (Issue #4761): trusted liveness, dispatch state, token pool,
+    /// role-tick health, queue depth, and merge throughput — one structured
+    /// line per section, or `--json` for machine consumers.
+    ///
+    /// Exit codes: `0` healthy, `1` degraded (any section non-green, including
+    /// "could not determine"), `2` the daemon is genuinely dead. A watch loop
+    /// can therefore branch without parsing anything.
+    ///
+    /// The liveness verdict is **pgrep + pid-file first** — the launchd domain
+    /// probe is never trusted alone (#4694: it twice declared a live,
+    /// dispatching daemon dead). A DEAD verdict requires all three independent
+    /// signals (IPC, launchd/pid-file classification, `pgrep`) to agree.
+    Health {
+        /// Window for the role-tick and throughput sections: `30m` (default),
+        /// `2h`, `90s`, `1d`, or a bare number of seconds.
+        #[arg(long, value_name = "WINDOW")]
+        since: Option<String>,
+
+        /// Emit the machine-readable JSON report instead of the section lines.
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Measure the host and the currently-resolved concurrency knobs (issue
     /// #4390; measurement-only since #4512). Prints the same `min(token axis,
     /// disk, maxConcurrent)` cap breakdown `status` uses, which term binds, and
@@ -1980,6 +2004,12 @@ fn handle_cli_command(command: Commands) -> Result<()> {
             // Routed directly in `main()` (it needs the async runtime for the
             // socket round-trip), never dispatched through this sync handler.
             unreachable!("Status is handled in main() before handle_cli_command")
+        }
+        Commands::Health { .. } => {
+            // Routed directly in `main()` (it needs the async runtime for the
+            // socket round-trip + forge fan-out), never dispatched through this
+            // sync handler.
+            unreachable!("Health is handled in main() before handle_cli_command")
         }
         Commands::Quarantine { .. } => {
             // Routed directly in `main()` (it needs the async runtime for the

--- a/loom-daemon/src/pipeline_snapshot.rs
+++ b/loom-daemon/src/pipeline_snapshot.rs
@@ -92,22 +92,86 @@ struct NumberRow {
     number: u64,
 }
 
-/// A `gh`-backed [`PipelineSource`]. Runs six `gh` invocations per repo (one
-/// per counted metric) scoped to that repo's own working directory so `gh`
-/// auto-detects the remote — same convention as
+/// Which of the six counted metrics a [`GhPipelineSource`] fetches (Issue
+/// #4761).
+///
+/// Each metric costs one `gh` invocation, and they run *sequentially* within a
+/// repo, so the mask is what keeps a consumer that needs two of them from
+/// paying for six. A metric that is masked off is left `None` — a caller that
+/// masks a metric off must simply not read it (every existing caller uses
+/// [`Self::ALL`], for which `None` keeps its original "this query failed"
+/// meaning).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PipelineMetrics {
+    /// Open issues labeled `loom:issue`.
+    pub queued: bool,
+    /// Open issues labeled `loom:building`.
+    pub building: bool,
+    /// Open PRs labeled `loom:review-requested`.
+    pub review_requested: bool,
+    /// Open PRs labeled `loom:changes-requested`.
+    pub changes_requested: bool,
+    /// Open PRs labeled `loom:pr`.
+    pub approved: bool,
+    /// PRs merged inside the configured window.
+    pub merged: bool,
+}
+
+impl PipelineMetrics {
+    /// Every metric — the historical (and default) behavior.
+    pub const ALL: Self = Self {
+        queued: true,
+        building: true,
+        review_requested: true,
+        changes_requested: true,
+        approved: true,
+        merged: true,
+    };
+
+    /// The two metrics `loom-daemon health` needs: queue depth and merge
+    /// throughput. Two `gh` calls per repo instead of six keeps the one-shot
+    /// health command inside its "< 5s typical" budget on a multi-repo fleet.
+    pub const HEALTH: Self = Self {
+        queued: true,
+        building: false,
+        review_requested: false,
+        changes_requested: false,
+        approved: false,
+        merged: true,
+    };
+}
+
+impl Default for PipelineMetrics {
+    fn default() -> Self {
+        Self::ALL
+    }
+}
+
+/// The default merge-throughput window — the 24h the `merged_24h` field is
+/// named for, and what every pre-#4761 caller gets.
+pub const DEFAULT_MERGE_WINDOW_HOURS: i64 = 24;
+
+/// A `gh`-backed [`PipelineSource`]. Runs up to six `gh` invocations per repo
+/// (one per requested metric — see [`PipelineMetrics`]) scoped to that repo's
+/// own working directory so `gh` auto-detects the remote — same convention as
 /// [`crate::work_finder::forge::GhWorkSource::for_root`]. `--limit 500` is
 /// generous headroom over the default `gh` page size of 30, which would
 /// otherwise silently undercount a busy repo's queue.
 pub struct GhPipelineSource {
     gh_bin: PathBuf,
+    metrics: PipelineMetrics,
+    merge_window: chrono::Duration,
 }
 
 impl GhPipelineSource {
-    /// Construct a source using `gh` from `PATH`.
+    /// Construct a source using `gh` from `PATH`, fetching every metric over
+    /// the default 24h merge window.
     #[must_use]
     pub fn new() -> Self {
         Self {
             gh_bin: PathBuf::from("gh"),
+            metrics: PipelineMetrics::ALL,
+            merge_window: chrono::Duration::hours(DEFAULT_MERGE_WINDOW_HOURS),
         }
     }
 
@@ -115,6 +179,26 @@ impl GhPipelineSource {
     #[must_use]
     pub fn with_gh_bin(mut self, bin: PathBuf) -> Self {
         self.gh_bin = bin;
+        self
+    }
+
+    /// Restrict which metrics are fetched (Issue #4761). Unrequested metrics
+    /// are left `None`.
+    #[must_use]
+    pub fn with_metrics(mut self, metrics: PipelineMetrics) -> Self {
+        self.metrics = metrics;
+        self
+    }
+
+    /// Override the merge-throughput window (Issue #4761) — the window
+    /// [`RepoPipelineSnapshot::merged_24h`] is counted over. A non-positive
+    /// window is ignored (the default 24h is kept) rather than producing a
+    /// `merged:>=<future>` query that always returns zero.
+    #[must_use]
+    pub fn with_merge_window(mut self, window: chrono::Duration) -> Self {
+        if window > chrono::Duration::zero() {
+            self.merge_window = window;
+        }
         self
     }
 
@@ -139,10 +223,10 @@ impl GhPipelineSource {
         Ok(rows.len())
     }
 
-    /// The `merged:>=<RFC3339>` search qualifier for "merged in the last 24h",
+    /// The `merged:>=<RFC3339>` search qualifier for "merged inside `window`",
     /// computed from `now`. A separate function so tests can pin the clock.
-    fn merged_since_query(now: chrono::DateTime<chrono::Utc>) -> String {
-        let since = now - chrono::Duration::hours(24);
+    fn merged_since_query(now: chrono::DateTime<chrono::Utc>, window: chrono::Duration) -> String {
+        let since = now - window;
         format!("merged:>={}", since.format("%Y-%m-%dT%H:%M:%SZ"))
     }
 }
@@ -172,82 +256,94 @@ impl PipelineSource for GhPipelineSource {
             }
         };
 
-        snap.queued = record(self.count(
-            root,
-            &[
-                "issue",
-                "list",
-                "--state",
-                "open",
-                "--label",
-                "loom:issue",
-                "--json",
-                "number",
-                "--limit",
-                "500",
-            ],
-        ));
-        snap.building = record(self.count(
-            root,
-            &[
-                "issue",
-                "list",
-                "--state",
-                "open",
-                "--label",
-                "loom:building",
-                "--json",
-                "number",
-                "--limit",
-                "500",
-            ],
-        ));
-        snap.review_requested = record(self.count(
-            root,
-            &[
-                "pr",
-                "list",
-                "--state",
-                "open",
-                "--label",
-                "loom:review-requested",
-                "--json",
-                "number",
-                "--limit",
-                "500",
-            ],
-        ));
-        snap.changes_requested = record(self.count(
-            root,
-            &[
-                "pr",
-                "list",
-                "--state",
-                "open",
-                "--label",
-                "loom:changes-requested",
-                "--json",
-                "number",
-                "--limit",
-                "500",
-            ],
-        ));
-        snap.approved = record(self.count(
-            root,
-            &[
-                "pr", "list", "--state", "open", "--label", "loom:pr", "--json", "number",
-                "--limit", "500",
-            ],
-        ));
+        if self.metrics.queued {
+            snap.queued = record(self.count(
+                root,
+                &[
+                    "issue",
+                    "list",
+                    "--state",
+                    "open",
+                    "--label",
+                    "loom:issue",
+                    "--json",
+                    "number",
+                    "--limit",
+                    "500",
+                ],
+            ));
+        }
+        if self.metrics.building {
+            snap.building = record(self.count(
+                root,
+                &[
+                    "issue",
+                    "list",
+                    "--state",
+                    "open",
+                    "--label",
+                    "loom:building",
+                    "--json",
+                    "number",
+                    "--limit",
+                    "500",
+                ],
+            ));
+        }
+        if self.metrics.review_requested {
+            snap.review_requested = record(self.count(
+                root,
+                &[
+                    "pr",
+                    "list",
+                    "--state",
+                    "open",
+                    "--label",
+                    "loom:review-requested",
+                    "--json",
+                    "number",
+                    "--limit",
+                    "500",
+                ],
+            ));
+        }
+        if self.metrics.changes_requested {
+            snap.changes_requested = record(self.count(
+                root,
+                &[
+                    "pr",
+                    "list",
+                    "--state",
+                    "open",
+                    "--label",
+                    "loom:changes-requested",
+                    "--json",
+                    "number",
+                    "--limit",
+                    "500",
+                ],
+            ));
+        }
+        if self.metrics.approved {
+            snap.approved = record(self.count(
+                root,
+                &[
+                    "pr", "list", "--state", "open", "--label", "loom:pr", "--json", "number",
+                    "--limit", "500",
+                ],
+            ));
+        }
 
-        let search = Self::merged_since_query(chrono::Utc::now());
-        snap.merged_24h = record(self.count(
-            root,
-            &[
-                "pr", "list", "--state", "merged", "--search", &search, "--json", "number",
-                "--limit", "500",
-            ],
-        ));
+        if self.metrics.merged {
+            let search = Self::merged_since_query(chrono::Utc::now(), self.merge_window);
+            snap.merged_24h = record(self.count(
+                root,
+                &[
+                    "pr", "list", "--state", "merged", "--search", &search, "--json", "number",
+                    "--limit", "500",
+                ],
+            ));
+        }
 
         snap.error = first_err;
         snap
@@ -580,7 +676,61 @@ esac
         let now = chrono::DateTime::parse_from_rfc3339("2026-07-27T12:00:00Z")
             .unwrap()
             .with_timezone(&chrono::Utc);
-        let query = GhPipelineSource::merged_since_query(now);
+        let query = GhPipelineSource::merged_since_query(now, chrono::Duration::hours(24));
         assert_eq!(query, "merged:>=2026-07-26T12:00:00Z");
+    }
+
+    #[test]
+    fn merged_since_query_honors_a_custom_window() {
+        let now = chrono::DateTime::parse_from_rfc3339("2026-07-27T12:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let query = GhPipelineSource::merged_since_query(now, chrono::Duration::minutes(30));
+        assert_eq!(query, "merged:>=2026-07-27T11:30:00Z");
+    }
+
+    #[test]
+    fn a_non_positive_merge_window_keeps_the_default() {
+        let source = GhPipelineSource::new().with_merge_window(chrono::Duration::zero());
+        assert_eq!(source.merge_window, chrono::Duration::hours(24));
+        let source = GhPipelineSource::new().with_merge_window(chrono::Duration::minutes(-5));
+        assert_eq!(source.merge_window, chrono::Duration::hours(24));
+    }
+
+    /// The #4761 cost control: the HEALTH mask must issue exactly the two `gh`
+    /// calls it needs, not all six — the whole reason the mask exists.
+    #[test]
+    #[serial]
+    fn health_metrics_mask_fetches_only_queued_and_merged() {
+        let tmp = tempfile::tempdir().unwrap();
+        let calls = tmp.path().join("calls.log");
+        let gh = write_fake_gh(
+            tmp.path(),
+            &format!("echo \"$*\" >> {}\necho '[{{\"number\":1}}]'", calls.display()),
+        );
+
+        let source = GhPipelineSource::new()
+            .with_gh_bin(gh)
+            .with_metrics(PipelineMetrics::HEALTH);
+        let snap = source.fetch(tmp.path());
+
+        assert_eq!(snap.queued, Some(1));
+        assert_eq!(snap.merged_24h, Some(1));
+        assert_eq!(snap.building, None);
+        assert_eq!(snap.review_requested, None);
+        assert_eq!(snap.changes_requested, None);
+        assert_eq!(snap.approved, None);
+        assert!(snap.is_complete());
+
+        let log = std::fs::read_to_string(&calls).unwrap();
+        assert_eq!(log.lines().count(), 2, "exactly two gh calls, got:\n{log}");
+        assert!(log.contains("loom:issue"));
+        assert!(log.contains("--state merged"));
+        assert!(!log.contains("loom:building"));
+    }
+
+    #[test]
+    fn default_metrics_mask_is_all() {
+        assert_eq!(PipelineMetrics::default(), PipelineMetrics::ALL);
     }
 }

--- a/loom-daemon/src/role_runner.rs
+++ b/loom-daemon/src/role_runner.rs
@@ -76,14 +76,15 @@
 //! `claude` sessions at once rather than settling into the steady-state
 //! cadence.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, PoisonError};
+use std::sync::{Arc, Mutex, OnceLock, PoisonError};
 use std::time::{Duration, Instant};
 
 use crate::sweep_registry::{self, SweepRegistryConfig};
+use crate::types::RoleTickRecord;
 use crate::workspace_registry::{filter_missing_roots, WorkspaceRegistry};
 
 // ============================================================================
@@ -245,6 +246,96 @@ impl RoleTickOutcome {
     pub fn is_success(&self) -> bool {
         matches!(self, Self::Success)
     }
+}
+
+// ============================================================================
+// Role-tick health ring (Issue #4761)
+// ============================================================================
+
+/// How many `(root, role)` tick outcomes the process-global ring retains.
+///
+/// The ring is carried verbatim over IPC in
+/// [`crate::types::DaemonStatusReport::role_tick_records`], so the bound is
+/// really a *payload* bound: at ~150 bytes a record this is well under 20 KB
+/// even when full, which a 5s-interval dashboard poll can afford. It is also
+/// generously larger than any window `loom-daemon health --since` would ask
+/// for in practice (5 roles × a 5-minute cadence fills ~60 entries an hour).
+pub const ROLE_TICK_RING_CAPACITY: usize = 128;
+
+/// Process-global newest-last ring of role-runner tick outcomes.
+///
+/// Same "loop publishes, status reads" discipline as
+/// [`crate::work_finder::last_tick_summary`]: the role-runner loop appends one
+/// record per completed `(root, role)` invocation, and `build_daemon_status`
+/// hands the window to clients, which apply their own
+/// transient-vs-persistent classifier ([`crate::health::summarize_role_ticks`]).
+/// The daemon deliberately stores *raw outcomes*, not a verdict — the window an
+/// operator cares about is a client-side choice.
+static ROLE_TICKS: OnceLock<Mutex<VecDeque<RoleTickRecord>>> = OnceLock::new();
+
+fn role_tick_ring() -> &'static Mutex<VecDeque<RoleTickRecord>> {
+    ROLE_TICKS.get_or_init(|| Mutex::new(VecDeque::with_capacity(ROLE_TICK_RING_CAPACITY)))
+}
+
+/// Append one `(root, role)` tick outcome to the process-global ring, stamped
+/// at `at` (Issue #4761). Oldest entries are evicted past
+/// [`ROLE_TICK_RING_CAPACITY`].
+pub fn record_role_tick_at(
+    role: &str,
+    root: &Path,
+    outcome: &RoleTickOutcome,
+    at: chrono::DateTime<chrono::Utc>,
+) {
+    let (ok, detail) = match outcome {
+        RoleTickOutcome::Success => (true, None),
+        RoleTickOutcome::Failure(reason) => (false, Some(reason.clone())),
+        RoleTickOutcome::RuntimeRejected(rejection) => {
+            (false, Some(format!("runtime-rejected: {}", rejection.reason)))
+        }
+        // #4642's permanent no-pool state is recorded as NOT ok on purpose: a
+        // role that cannot run at all is exactly what a health check must
+        // surface, and the persistent-vs-transient classifier will (correctly)
+        // never clear it until a pool is provisioned.
+        RoleTickOutcome::NoTokenPool => (false, Some("no-token-pool".to_string())),
+    };
+    let mut ring = role_tick_ring()
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
+    if ring.len() >= ROLE_TICK_RING_CAPACITY {
+        ring.pop_front();
+    }
+    ring.push_back(RoleTickRecord {
+        root: root.to_path_buf(),
+        role: role.to_string(),
+        at,
+        ok,
+        detail,
+    });
+}
+
+/// [`record_role_tick_at`] stamped with the current wall clock.
+pub fn record_role_tick(role: &str, root: &Path, outcome: &RoleTickOutcome) {
+    record_role_tick_at(role, root, outcome, chrono::Utc::now());
+}
+
+/// Snapshot the role-tick ring, oldest first (Issue #4761).
+#[must_use]
+pub fn role_tick_records() -> Vec<RoleTickRecord> {
+    role_tick_ring()
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .iter()
+        .cloned()
+        .collect()
+}
+
+/// Test-only reset of the process-global role-tick ring.
+#[cfg(test)]
+fn reset_role_tick_ring() {
+    role_tick_ring()
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .clear();
 }
 
 /// Runs one role invocation. Abstracted behind a trait so the loop is
@@ -1649,6 +1740,11 @@ fn log_outcome_for_root_deduped(
     failing: &mut HashMap<PathBuf, bool>,
     no_token_pool: &mut HashMap<PathBuf, bool>,
 ) {
+    // Record the raw outcome BEFORE the log-dedup decision (#4761): the
+    // edge/repeat dedup exists to keep the *log* quiet, but a health check needs
+    // every tick — a persistently-failing root logs at DEBUG after its first
+    // WARN, which is exactly the case that must still surface as degraded.
+    record_role_tick(role, root, outcome);
     let was_failing = failing.get(root).copied().unwrap_or(false);
     let was_no_token_pool = no_token_pool.get(root).copied().unwrap_or(false);
     let action = classify_root_tick_log(outcome, elapsed, was_failing, was_no_token_pool);
@@ -3567,5 +3663,93 @@ mod tests {
         handle.abort();
 
         std::env::remove_var(crate::workspace_registry::REGISTRY_PATH_ENV);
+    }
+
+    // ===================================================================
+    // Role-tick health ring (#4761)
+    // ===================================================================
+
+    #[test]
+    #[serial(role_tick_ring)]
+    fn recording_a_tick_makes_it_readable_cross_process() {
+        reset_role_tick_ring();
+        let at = chrono::Utc::now();
+        record_role_tick_at("curator", Path::new("/r/loom"), &RoleTickOutcome::Success, at);
+
+        let records = role_tick_records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].role, "curator");
+        assert_eq!(records[0].root, PathBuf::from("/r/loom"));
+        assert_eq!(records[0].at, at);
+        assert!(records[0].ok);
+        assert_eq!(records[0].detail, None);
+    }
+
+    #[test]
+    #[serial(role_tick_ring)]
+    fn a_failure_records_its_reason() {
+        reset_role_tick_ring();
+        record_role_tick(
+            "champion",
+            Path::new("/r/loom"),
+            &RoleTickOutcome::Failure("mcp preflight failed".to_string()),
+        );
+        let records = role_tick_records();
+        assert!(!records[0].ok);
+        assert_eq!(records[0].detail.as_deref(), Some("mcp preflight failed"));
+    }
+
+    /// #4642's permanent no-pool state must surface as NOT-ok — a role that
+    /// cannot run at all is precisely what a health check exists to report.
+    #[test]
+    #[serial(role_tick_ring)]
+    fn a_missing_token_pool_records_as_not_ok() {
+        reset_role_tick_ring();
+        record_role_tick("guide", Path::new("/r/loom"), &RoleTickOutcome::NoTokenPool);
+        let records = role_tick_records();
+        assert!(!records[0].ok);
+        assert_eq!(records[0].detail.as_deref(), Some("no-token-pool"));
+    }
+
+    #[test]
+    #[serial(role_tick_ring)]
+    fn the_ring_is_bounded_and_keeps_the_newest_entries() {
+        reset_role_tick_ring();
+        for _ in 0..(ROLE_TICK_RING_CAPACITY + 10) {
+            record_role_tick("curator", Path::new("/r/loom"), &RoleTickOutcome::Success);
+        }
+        record_role_tick(
+            "curator",
+            Path::new("/r/loom"),
+            &RoleTickOutcome::Failure("newest".to_string()),
+        );
+        let records = role_tick_records();
+        assert_eq!(records.len(), ROLE_TICK_RING_CAPACITY);
+        assert_eq!(records.last().unwrap().detail.as_deref(), Some("newest"));
+    }
+
+    /// The log-dedup path (#4349) downgrades a *repeat* failure to DEBUG, but
+    /// the health ring must still see every one of them — otherwise a
+    /// persistently-broken root would look quiet to a health check.
+    #[test]
+    #[serial(role_tick_ring)]
+    fn repeat_failures_are_all_recorded_even_though_the_log_dedups_them() {
+        reset_role_tick_ring();
+        let mut failing = HashMap::new();
+        let mut no_pool = HashMap::new();
+        let root = PathBuf::from("/r/loom");
+        for _ in 0..3 {
+            log_outcome_for_root_deduped(
+                "curator",
+                &root,
+                &RoleTickOutcome::Failure("boom".to_string()),
+                Duration::from_secs(30),
+                &mut failing,
+                &mut no_pool,
+            );
+        }
+        let records = role_tick_records();
+        assert_eq!(records.len(), 3, "every tick is recorded, not just the fail edge");
+        assert!(records.iter().all(|r| !r.ok));
     }
 }

--- a/loom-daemon/src/serve.rs
+++ b/loom-daemon/src/serve.rs
@@ -110,6 +110,9 @@ const TOKENS_PATH: &str = "/api/tokens";
 /// Path the configured peer-daemon list endpoint answers (Issue #4393).
 const PEERS_PATH: &str = "/api/peers";
 
+/// Path the consolidated health-verdict endpoint answers (Issue #4761).
+const HEALTH_PATH: &str = "/api/health";
+
 /// Every route this listener answers (used for the 404 dispatch check).
 const KNOWN_PATHS: &[&str] = &[
     ROOT_PATH,
@@ -118,6 +121,7 @@ const KNOWN_PATHS: &[&str] = &[
     PIPELINE_PATH,
     TOKENS_PATH,
     PEERS_PATH,
+    HEALTH_PATH,
 ];
 
 /// The embedded dashboard page (Issue #4393). Plain HTML/CSS/vanilla JS, no
@@ -527,6 +531,22 @@ async fn handle_pipeline(
     };
     let roots: Vec<PathBuf> = report.per_repo.iter().map(|r| r.root.clone()).collect();
 
+    let rows = pipeline_rows_cached(source, roots, cache).await;
+
+    let body = serde_json::to_string(&rows)?;
+    write_json_response(stream, "200 OK", &body).await
+}
+
+/// Read the shared pipeline rows, recomputing only past [`PIPELINE_CACHE_TTL`].
+///
+/// Extracted (#4761) so `/api/health` shares the *same* cached `gh` batch
+/// `/api/pipeline` already pays for, instead of firing a second subprocess
+/// fan-out per dashboard poll.
+async fn pipeline_rows_cached(
+    source: Arc<dyn PipelineSource + Send + Sync>,
+    roots: Vec<PathBuf>,
+    cache: &PipelineCache,
+) -> Vec<PipelineRow> {
     let mut guard = cache.lock().await;
     let fresh = guard
         .as_ref()
@@ -535,13 +555,101 @@ async fn handle_pipeline(
         let rows = build_pipeline_rows(source, roots).await;
         *guard = Some((Instant::now(), rows));
     }
-    let rows = guard
+    guard
         .as_ref()
-        .map_or_else(Vec::new, |(_, rows)| rows.clone());
-    drop(guard);
+        .map_or_else(Vec::new, |(_, rows)| rows.clone())
+}
 
-    let body = serde_json::to_string(&rows)?;
-    write_json_response(stream, "200 OK", &body).await
+// ============================================================================
+// Consolidated health verdict (`GET /api/health`, Issue #4761)
+// ============================================================================
+
+/// The window `/api/health` reports role-tick and throughput over.
+///
+/// Fixed at 24h rather than exposed as a query parameter: this endpoint reuses
+/// the `/api/pipeline` cache, whose merge counts are computed over the source's
+/// own (24h default) window, so honoring an arbitrary `?since=` here would
+/// silently report a *different* window than the numbers actually cover. The
+/// CLI (`loom-daemon health --since 30m`) owns the variable-window story — it
+/// builds its own source with a matching
+/// [`pipeline_snapshot::GhPipelineSource::with_merge_window`].
+const HEALTH_WINDOW: Duration = Duration::from_secs(24 * 3600);
+
+/// Serve `GET /api/health`: the same consolidated verdict `loom-daemon health`
+/// renders, via the same [`crate::health::assess`] collector (Issue #4761 AC4).
+///
+/// This endpoint deliberately contains **no verdict logic of its own** — it
+/// collects the identical inputs (IPC report, install-state probe, `pgrep`,
+/// `.ranking` stat, the cached pipeline rows) and hands them to `assess`. A
+/// second implementation here is exactly the duplication AC4 forbids.
+///
+/// Unlike `/api/status`, an unreachable daemon is **200, not 503**: the whole
+/// point of a health verdict is that "the daemon is dead" is a *report*, not a
+/// transport failure. The payload's `overall` field carries `"dead"` and
+/// `exit_code` carries `2`, so a browser/curl consumer branches on the same
+/// contract the CLI's exit code encodes.
+async fn handle_health(
+    stream: &mut TcpStream,
+    socket_path: &Path,
+    source: Arc<dyn PipelineSource + Send + Sync>,
+    cache: &PipelineCache,
+) -> Result<()> {
+    let (report, ipc_error) = match fetch_report(socket_path).await {
+        Ok(r) => (Some(r), None),
+        Err(e) => (None, Some(e.to_string())),
+    };
+
+    let pipeline = match &report {
+        Some(r) => {
+            let roots: Vec<PathBuf> = r.per_repo.iter().map(|repo| repo.root.clone()).collect();
+            Some(
+                pipeline_rows_cached(source, roots, cache)
+                    .await
+                    .into_iter()
+                    .map(|row| row.snapshot)
+                    .collect::<Vec<_>>(),
+            )
+        }
+        None => None,
+    };
+
+    let (ranking_present, ranking_age_secs) = report
+        .as_ref()
+        .and_then(|r| r.token_pool_dir.clone())
+        .map_or((false, None), |dir| ranking_state(&dir));
+
+    let health = crate::health::assess(&crate::health::HealthInputs {
+        at: chrono::Utc::now(),
+        window: HEALTH_WINDOW,
+        status: report,
+        ipc_error,
+        install_state: crate::daemon_install_state::probe(),
+        pgrep_pids: crate::daemon_install_state::pgrep_daemon_pids(),
+        ranking_present,
+        ranking_age_secs,
+        pipeline,
+    });
+
+    let mut body = serde_json::to_value(&health)?;
+    // The exit code the CLI would return, so an HTTP consumer branches on the
+    // same 0/1/2 contract without re-deriving it from `overall`.
+    body["exit_code"] = serde_json::json!(health.exit_code());
+    write_json_response(stream, "200 OK", &serde_json::to_string(&body)?).await
+}
+
+/// `(present, age_secs)` for `<dir>/.ranking` — the tokens section's staleness
+/// input. Mirrors `cli::health`'s probe of the same file; kept local so the
+/// library crate does not depend on the binary's CLI module.
+fn ranking_state(dir: &Path) -> (bool, Option<u64>) {
+    let Ok(meta) = std::fs::metadata(dir.join(".ranking")) else {
+        return (false, None);
+    };
+    let age = meta
+        .modified()
+        .ok()
+        .and_then(|m| m.elapsed().ok())
+        .map(|d| d.as_secs());
+    (true, age)
 }
 
 // ============================================================================
@@ -965,6 +1073,16 @@ async fn handle_connection(mut stream: TcpStream, state: Arc<ServeState>) -> Res
         return handle_peers(&mut stream, &state.peers).await;
     }
 
+    if parsed.path == HEALTH_PATH {
+        return handle_health(
+            &mut stream,
+            &state.socket_path,
+            Arc::clone(&state.pipeline_source),
+            &state.pipeline_cache,
+        )
+        .await;
+    }
+
     match fetch_snapshot(&state.socket_path).await {
         Ok(snapshot) => {
             let body = serde_json::to_string(&snapshot)?;
@@ -1073,6 +1191,8 @@ mod tests {
             rate_limit_breaker: None,
             safehouse: None,
             work_finder_enabled: None,
+            last_work_finder_tick: None,
+            role_tick_records: vec![],
         }
     }
 
@@ -2422,5 +2542,110 @@ mod tests {
         assert_eq!(status, 404);
 
         server_task.abort();
+    }
+
+    // ========================================================================
+    // `/api/health` — the shared health collector (Issue #4761)
+    // ========================================================================
+
+    /// AC4: the dashboard must reuse the collector, so its payload has exactly
+    /// the shape (and the six sections) `loom-daemon health --json` renders.
+    #[tokio::test]
+    async fn health_route_serves_the_shared_collector_report() {
+        let mut report = empty_report();
+        report.dynamic_cap = 4;
+        report.work_finder_enabled = Some(true);
+        report.last_work_finder_tick = Some(crate::types::WorkFinderTickSummary {
+            at: chrono::Utc::now(),
+            max_concurrent: 4,
+            seen: 3,
+            dispatched: 1,
+            ..Default::default()
+        });
+        let socket_path = spawn_repeating_fake_daemon_socket(report).await;
+        let tcp_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("bind tcp");
+        let addr = tcp_listener.local_addr().expect("local addr");
+        let state = ServeState::new(socket_path)
+            .with_pipeline_source(Arc::new(pipeline_snapshot::GhPipelineSource::new()));
+        let server_task = tokio::spawn(run_with_state(tcp_listener, state));
+
+        let (status, body) = http_get(addr, "/api/health").await;
+        assert_eq!(status, 200);
+        let json: serde_json::Value = serde_json::from_str(&body).expect("valid JSON: {body}");
+        let keys: Vec<&str> = json["sections"]
+            .as_array()
+            .expect("sections array")
+            .iter()
+            .map(|s| s["key"].as_str().expect("key"))
+            .collect();
+        assert_eq!(
+            keys,
+            vec![
+                "liveness",
+                "dispatch",
+                "tokens",
+                "roles",
+                "queues",
+                "throughput"
+            ]
+        );
+        assert!(json["exit_code"].is_i64(), "payload must carry the 0/1/2 contract");
+        assert!(json["overall"].is_string());
+
+        server_task.abort();
+    }
+
+    /// An unreachable daemon is a *health finding*, not a transport failure:
+    /// the route answers 200 with `overall: dead` / `exit_code: 2` so a watch
+    /// loop branches on the same contract the CLI's exit code encodes.
+    #[tokio::test]
+    async fn health_route_reports_an_unreachable_daemon_as_200_not_503() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket_path = dir.path().join("nonexistent.sock");
+        let tcp_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("bind tcp");
+        let addr = tcp_listener.local_addr().expect("local addr");
+        let server_task = tokio::spawn(run(tcp_listener, socket_path));
+
+        let (status, body) = http_get(addr, "/api/health").await;
+        assert_eq!(status, 200, "body: {body}");
+        let json: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        // The liveness verdict itself depends on this host's real install
+        // state, so assert only the invariant: it is never GREEN when IPC
+        // failed, and the exit code is never 0.
+        let liveness = &json["sections"][0];
+        assert_eq!(liveness["key"], "liveness");
+        assert_ne!(liveness["verdict"], "green");
+        assert_ne!(json["exit_code"], 0);
+
+        server_task.abort();
+    }
+
+    #[tokio::test]
+    async fn health_route_carries_the_cors_header() {
+        let socket_path = spawn_repeating_fake_daemon_socket(empty_report()).await;
+        let tcp_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("bind tcp");
+        let addr = tcp_listener.local_addr().expect("local addr");
+        let server_task = tokio::spawn(run(tcp_listener, socket_path));
+
+        let (_status, head, _body) = http_get_full(addr, "/api/health").await;
+        assert!(head.contains(&format!("{CORS_ALLOW_ORIGIN_HEADER}\r\n")), "head: {head:?}");
+
+        server_task.abort();
+    }
+
+    #[test]
+    fn ranking_state_reports_absent_and_present() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert_eq!(ranking_state(tmp.path()), (false, None));
+        std::fs::write(tmp.path().join(".ranking"), "a|available|0.1\n").expect("write");
+        let (present, age) = ranking_state(tmp.path());
+        assert!(present);
+        assert!(age.expect("age") < 60);
     }
 }

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -891,7 +891,11 @@ fn default_sweep_runtime() -> String {
 /// prints is NOT included here — it is a slow per-account network probe the CLI
 /// collects client-side via `loom-tokens check --json` (mirroring
 /// `probe-tokens.sh`), so the IPC handler stays fast.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// `Default` (added with #4761) is the zero-workspaces / zero-in-flight shape a
+/// freshly-started daemon with no registered repos reports — it exists so test
+/// fixtures can spread `..Default::default()` instead of restating ~40 fields
+/// (and needing an edit every time one is added).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DaemonStatusReport {
     /// Sweeps in a non-terminal state (`Pending` / `Running`) at snapshot time.
     /// The full `SweepInfo` is carried so the CLI can render issue numbers,
@@ -1233,6 +1237,126 @@ pub struct DaemonStatusReport {
     /// compatible.
     #[serde(default)]
     pub work_finder_enabled: Option<bool>,
+    /// The most recent work-finder tick's dispatch/skip summary (Issue #4761),
+    /// published by the loop itself via
+    /// [`crate::work_finder::publish_tick_summary`] and read back here so a
+    /// cross-process consumer (`loom-daemon health`, the dashboard) can see
+    /// *why* a tick dispatched nothing without grepping the daemon log. `None`
+    /// when the loop has not completed a tick this process (or is disabled),
+    /// and for a pre-#4761 wire payload. `#[serde(default)]` keeps older wire
+    /// data / older clients compatible.
+    #[serde(default)]
+    pub last_work_finder_tick: Option<WorkFinderTickSummary>,
+    /// A bounded, newest-last window of per-(root, role) role-runner tick
+    /// outcomes (Issue #4761), published by the role-runner loop via
+    /// [`crate::role_runner::record_role_tick`]. Carried as raw records rather
+    /// than a pre-computed verdict so the *client* chooses the window
+    /// (`loom-daemon health --since 30m`) and applies the
+    /// transient-vs-persistent classifier
+    /// ([`crate::health::summarize_role_ticks`]) — the daemon has no opinion
+    /// about which window an operator cares about. Bounded to
+    /// [`crate::role_runner::ROLE_TICK_RING_CAPACITY`] entries so the payload
+    /// stays small enough for a 5s-interval dashboard poll. Empty when the
+    /// role runner is disabled or has not ticked. `#[serde(default)]` keeps
+    /// pre-#4761 wire data compatible.
+    #[serde(default)]
+    pub role_tick_records: Vec<RoleTickRecord>,
+}
+
+/// One work-finder tick's dispatch/skip tally, stamped with the wall-clock
+/// time it completed and the dynamic cap it ran under (Issue #4761).
+///
+/// A serializable projection of [`crate::work_finder::TickReport`] — the
+/// counters an operator reads off the `work_finder: tick — …` log line, made
+/// queryable over IPC so `loom-daemon health` can render the same one-line
+/// dispatch summary without log scraping. Deliberately a *separate* type from
+/// `TickReport`: that struct is the loop's internal per-tick accumulator and
+/// is free to change shape, whereas this is a wire contract.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkFinderTickSummary {
+    /// When the tick completed.
+    pub at: DateTime<Utc>,
+    /// The dynamic concurrency cap this tick ran under.
+    pub max_concurrent: usize,
+    /// Ready `loom:issue` rows the source returned this tick.
+    pub seen: usize,
+    /// Issues for which a new sweep was dispatched this tick.
+    pub dispatched: usize,
+    /// Issues skipped for carrying a park/skip label.
+    pub skipped_labeled: usize,
+    /// Issues skipped because a live sweep already exists for them.
+    pub skipped_in_flight: usize,
+    /// Issues skipped for an insta-crash quarantine.
+    pub skipped_quarantined: usize,
+    /// Issues skipped because they already have an open linked PR.
+    pub skipped_pr_open: usize,
+    /// Issues skipped because a peer host advertised a live soft claim.
+    pub skipped_peer_claim: usize,
+    /// Issues skipped inside a per-issue dispatch-backoff window.
+    pub skipped_backoff: usize,
+    /// Issues deferred because the concurrency cap was reached.
+    pub deferred_capacity: usize,
+    /// Issues deferred because the per-tick admission ramp cap was reached.
+    pub deferred_ramp_cap: usize,
+    /// Dispatch attempts that returned an error.
+    pub errors: usize,
+    /// Whether any workspace was gated by the main-health halt this tick.
+    pub halted: bool,
+}
+
+impl WorkFinderTickSummary {
+    /// The single-line skip-reason summary `loom-daemon health` renders —
+    /// only the non-zero terms, so a clean tick reads `12 seen, 2 dispatched`
+    /// rather than a wall of zeros.
+    #[must_use]
+    pub fn reason_summary(&self) -> String {
+        let mut parts = vec![
+            format!("{} seen", self.seen),
+            format!("{} dispatched", self.dispatched),
+        ];
+        for (n, label) in [
+            (self.skipped_labeled, "labeled-skip"),
+            (self.skipped_in_flight, "in-flight-skip"),
+            (self.skipped_quarantined, "quarantine-skip"),
+            (self.skipped_pr_open, "pr-open-skip"),
+            (self.skipped_peer_claim, "peer-claim-skip"),
+            (self.skipped_backoff, "backoff-skip"),
+            (self.deferred_capacity, "deferred-capacity"),
+            (self.deferred_ramp_cap, "deferred-ramp"),
+            (self.errors, "error"),
+        ] {
+            if n > 0 {
+                parts.push(format!("{n} {label}"));
+            }
+        }
+        if self.halted {
+            parts.push("HALTED".to_string());
+        }
+        parts.join(", ")
+    }
+}
+
+/// One role-runner tick outcome for one `(root, role)` pair (Issue #4761).
+///
+/// The raw evidence the transient-vs-persistent classifier
+/// ([`crate::health::summarize_role_ticks`]) consumes: a failure whose
+/// `(root, role)` later ticked successfully **within the same window** was
+/// self-recovered (transient) and is deliberately not surfaced; only a
+/// `(root, role)` whose *latest* record in the window is a failure is
+/// persistent.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RoleTickRecord {
+    /// The workspace root this tick ran for.
+    pub root: PathBuf,
+    /// The role name (`champion`, `curator`, …).
+    pub role: String,
+    /// When the tick completed.
+    pub at: DateTime<Utc>,
+    /// Whether the invocation succeeded.
+    pub ok: bool,
+    /// Short failure detail when `ok` is `false` (the failure reason / runtime
+    /// rejection / `no-token-pool` sentinel), else `None`.
+    pub detail: Option<String>,
 }
 
 /// Live safehouse connection status for `loom-daemon status` (Issue #4345).

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -90,7 +90,7 @@
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use anyhow::Result;
@@ -103,7 +103,7 @@ use crate::sweep_registry::{
     DispatchBackoffError, LiveClaimDispatchError, OpenPrDispatchError, ParkedIssueDispatchError,
 };
 use crate::tokens::{token_pool_size, token_pool_size_at_dir};
-use crate::types::Event;
+use crate::types::{Event, WorkFinderTickSummary};
 use crate::workspace_pool::WorkspacePool;
 use crate::workspace_registry::{filter_missing_roots, WorkspaceRegistry};
 
@@ -469,6 +469,80 @@ pub trait WorkDispatcher {
     fn occupancy(&self) -> usize {
         self.in_flight().len()
     }
+}
+
+// ============================================================================
+// Last-tick publication (Issue #4761)
+// ============================================================================
+
+/// Process-global slot holding the most recent completed tick's summary.
+///
+/// Mirrors the "loop publishes, status reads" discipline
+/// [`crate::auto_update::global_status_snapshot`] and
+/// [`crate::host_breaker::global_snapshot`] already use: the work-finder loop
+/// writes here at the end of every tick, and `build_daemon_status` reads it
+/// back so a cross-process consumer (`loom-daemon health`) can see the last
+/// tick's dispatch/skip breakdown without scraping the daemon log.
+///
+/// `None` (the initial value) honestly means "no tick has completed in this
+/// process yet" — never "nothing was dispatched".
+static LAST_TICK: OnceLock<Mutex<Option<WorkFinderTickSummary>>> = OnceLock::new();
+
+fn last_tick_slot() -> &'static Mutex<Option<WorkFinderTickSummary>> {
+    LAST_TICK.get_or_init(|| Mutex::new(None))
+}
+
+/// Publish `report` (as run under `max_concurrent`, completed at `at`) as the
+/// most recent work-finder tick (Issue #4761). Called by both the
+/// single-workspace and multi-workspace loops so the two can never diverge on
+/// what "the last tick" means.
+pub fn publish_tick_summary_at(
+    report: &TickReport,
+    max_concurrent: usize,
+    at: chrono::DateTime<chrono::Utc>,
+) {
+    let summary = WorkFinderTickSummary {
+        at,
+        max_concurrent,
+        seen: report.seen,
+        dispatched: report.dispatched,
+        skipped_labeled: report.skipped_labeled,
+        skipped_in_flight: report.skipped_in_flight,
+        skipped_quarantined: report.skipped_quarantined,
+        skipped_pr_open: report.skipped_pr_open,
+        skipped_peer_claim: report.skipped_peer_claim,
+        skipped_backoff: report.skipped_backoff,
+        deferred_capacity: report.deferred_capacity,
+        deferred_ramp_cap: report.deferred_ramp_cap,
+        errors: report.errors,
+        halted: report.halted,
+    };
+    *last_tick_slot()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(summary);
+}
+
+/// [`publish_tick_summary_at`] stamped with the current wall clock.
+pub fn publish_tick_summary(report: &TickReport, max_concurrent: usize) {
+    publish_tick_summary_at(report, max_concurrent, chrono::Utc::now());
+}
+
+/// Read back the most recently published tick summary, or `None` when no tick
+/// has completed in this process (Issue #4761).
+#[must_use]
+pub fn last_tick_summary() -> Option<WorkFinderTickSummary> {
+    last_tick_slot()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone()
+}
+
+/// Test-only reset of the process-global last-tick slot.
+#[cfg(test)]
+fn reset_last_tick_summary() {
+    *last_tick_slot()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
 }
 
 // ============================================================================
@@ -1654,6 +1728,9 @@ where
                 max_admissions_per_tick,
             ) {
                 Ok(report) => {
+                    // Publish before any logging so `loom-daemon health` sees the
+                    // same tick the log line describes (#4761).
+                    publish_tick_summary(&report, max_concurrent);
                     if report.halted && !was_halted {
                         log::warn!(
                             "work_finder: main-health gate halted dispatch — {} ready issue(s) \
@@ -1964,6 +2041,10 @@ pub fn spawn_multi_work_finder_task(
                 &halted,
                 max_admissions_per_tick,
             );
+
+            // Publish before any logging so `loom-daemon health` sees the same
+            // tick the log line describes (#4761).
+            publish_tick_summary(&report, max_concurrent);
 
             if report.halted && !was_halted {
                 log::warn!(
@@ -4777,5 +4858,88 @@ exit 0
             vec![10],
             "sibling root with no gate in flight is unaffected"
         );
+    }
+
+    // ===================================================================
+    // Last-tick publication (#4761)
+    // ===================================================================
+
+    #[test]
+    #[serial(work_finder_last_tick)]
+    fn last_tick_summary_is_none_before_any_tick() {
+        reset_last_tick_summary();
+        assert!(last_tick_summary().is_none());
+    }
+
+    #[test]
+    #[serial(work_finder_last_tick)]
+    fn publishing_a_tick_makes_its_counters_readable_cross_process() {
+        reset_last_tick_summary();
+        let at = chrono::Utc::now();
+        let report = TickReport {
+            seen: 12,
+            dispatched: 2,
+            skipped_in_flight: 9,
+            skipped_pr_open: 1,
+            errors: 0,
+            halted: false,
+            ..TickReport::default()
+        };
+        publish_tick_summary_at(&report, 7, at);
+
+        let summary = last_tick_summary().expect("a published tick must be readable");
+        assert_eq!(summary.at, at);
+        assert_eq!(summary.max_concurrent, 7);
+        assert_eq!(summary.seen, 12);
+        assert_eq!(summary.dispatched, 2);
+        assert_eq!(summary.skipped_in_flight, 9);
+        assert_eq!(summary.skipped_pr_open, 1);
+        assert!(!summary.halted);
+    }
+
+    #[test]
+    #[serial(work_finder_last_tick)]
+    fn publishing_replaces_the_previous_tick() {
+        reset_last_tick_summary();
+        publish_tick_summary(
+            &TickReport {
+                seen: 1,
+                ..TickReport::default()
+            },
+            3,
+        );
+        publish_tick_summary(
+            &TickReport {
+                seen: 99,
+                ..TickReport::default()
+            },
+            4,
+        );
+        let summary = last_tick_summary().unwrap();
+        assert_eq!(summary.seen, 99);
+        assert_eq!(summary.max_concurrent, 4);
+    }
+
+    /// The rendered summary must show only the *non-zero* skip reasons, so an
+    /// operator reading one line is not scanning a wall of zeros.
+    #[test]
+    fn reason_summary_omits_zero_terms() {
+        let summary = crate::types::WorkFinderTickSummary {
+            seen: 12,
+            dispatched: 2,
+            skipped_in_flight: 10,
+            ..Default::default()
+        };
+        assert_eq!(summary.reason_summary(), "12 seen, 2 dispatched, 10 in-flight-skip");
+    }
+
+    #[test]
+    fn reason_summary_flags_a_halted_tick() {
+        let summary = crate::types::WorkFinderTickSummary {
+            seen: 5,
+            halted: true,
+            ..Default::default()
+        };
+        assert!(summary.reason_summary().ends_with("HALTED"));
     }
 }


### PR DESCRIPTION
## Summary

Adds `loom-daemon health [--since 30m] [--json]`: a single call that collects
the six-check battery a manual overnight health tick used to run by hand
(trusted liveness, dispatch state, token pool, role-tick health, queue depth,
merge throughput), renders one structured line per section, and exits with a
contract a watch loop can branch on without parsing:

| exit | meaning |
|------|---------|
| `0` | every section green |
| `1` | degraded — any section non-green, including "could not determine" |
| `2` | the daemon is genuinely dead |

**Liveness precedence (#4694, load-bearing):** IPC-answered ⇒ alive
unconditionally; else the install-state classification (launchd → skipped-domain
→ pid-file) ⇒ degraded, never dead; else a live `pgrep -x loom-daemon` ⇒ still
degraded; only when all three independent signals are negative is the verdict
`DEAD`. The launchd domain probe alone can never produce exit `2` — it twice
declared a live, dispatching daemon dead during the referenced overnight watch.

**Role-tick health:** the role-runner loop now appends every `(root, role)`
tick outcome to a bounded process-global ring, carried over IPC. The
transient-vs-persistent classifier is client-side: a pair whose *latest*
record in the window is a failure surfaces as degraded; one that failed but
later succeeded is reported as a count only (self-recovered).

**One collector, two consumers today:** `health::assess(&HealthInputs) ->
HealthReport` is pure (no daemon, no forge, no subprocess), so every verdict
rule is directly unit-tested. `cli::health` collects the inputs (one IPC
round-trip, one install-state probe, one `pgrep`, one `.ranking` stat, a
bounded forge fan-out using a new `PipelineMetrics::HEALTH` mask that fetches
only the 2 of 6 `gh` counts this command needs) and renders/exits. The
dashboard's `GET /api/health` (`serve.rs`) calls the *same* `assess` over the
*same* cached `/api/pipeline` batch — no second verdict implementation — and
answers `200` (not `503`) with `overall: "dead"` / `exit_code: 2` when the
daemon is unreachable, since "the daemon is dead" is itself a health finding,
not a transport failure.

**Scope note on `fleet status`:** the issue's suggested AC also names `fleet
status` as a consumer. `fleet status` answers a different question (a
multi-host UP/DOWN roster over SSH) and already reuses the same
`daemon_install_state::probe()` primitive `health::assess_liveness` is built
on — it does not invent a second liveness probe. Extending it to fan out
`health --json` over SSH per remote host is a larger, separable feature
(running a new remote command per roster host); the reference doc calls this
out explicitly as a deliberate follow-up rather than a silent gap.

## Verification performed

- `cargo build -p loom-daemon` and `cargo build --workspace`: clean.
- `cargo clippy -p loom-daemon --all-targets -- -D warnings`: clean (fixed two
  `manual_is_multiple_of` lints introduced by this change).
- `cargo test -p loom-daemon`: 2877 passed, 1 pre-existing unrelated failure
  (`config_resolver::tests::test_resolve_disjoint_keys_across_tiers_all_present`,
  which reads this host's live tier-1 private-defaults file — a known
  environment-only issue, not touched by this diff). All `health`-scoped tests
  (36 in `health.rs`, plus the `pipeline_snapshot`/`role_runner`/`work_finder`/
  `serve` additions) pass.
- `scripts/check-claude-md-budget.sh`, `scripts/check-agents-md-sync.sh`,
  `defaults/scripts/check-phantom-labels.sh`: all pass.
- Functional smoke test against the live daemon on this host: `--help` (exit
  0), the human-rendered report (exit 1, correctly flagging a tripped
  host-distress breaker), and `--json --since 5m` (valid structured payload,
  all six section keys present).

Closes #4761
