### PR TITLE
fix(role_runner): tag pre-existing tests with serial(role_tick_ring)

### DIFF
--- a/loom-daemon/src/role_runner.rs
+++ b/loom-daemon/src/role_runner.rs
@@ -3489,6 +3489,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(role_tick_ring)]
     fn test_log_outcome_for_root_deduped_tracks_failing_state_across_ticks() {
         let root = PathBuf::from("/tmp/does-not-need-to-exist-for-this-test");
         let mut failing: HashMap<PathBuf, bool> = HashMap::new();
@@ -3544,6 +3545,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(role_tick_ring)]
     fn test_log_outcome_for_root_deduped_is_independent_per_root() {
         // A failure on one registered root must not affect another root's
         // failing state (each workspace's health is tracked independently).
@@ -3574,6 +3576,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(role_tick_ring)]
     fn test_log_outcome_for_root_deduped_no_token_pool_tracked_independently_of_failing() {
         // #4642: a NoTokenPool tick must never mark `failing` true, and a
         // real Failure tick must never mark `no_token_pool` true — the two


### PR DESCRIPTION
## Summary

Three pre-existing tests that call `log_outcome_for_root_deduped()` directly were not tagged `#[serial(role_tick_ring)]` when that function started unconditionally writing into the process-global `ROLE_TICKS` ring buffer (#4761).

`serial_test`'s `#[serial(name)]` only excludes tests sharing that exact tag — it does not block untagged tests from running concurrently. Since `loom-daemon`'s test module has no blanket serialization and CI does not pass `--test-threads=1`, these untagged tests could interleave with the `#[serial(role_tick_ring)]` ring-assertion tests (e.g. `the_ring_is_bounded_and_keeps_the_newest_entries`) and inject extra records into `ROLE_TICKS` mid-assertion, causing the exact-count assertions to fail nondeterministically.

## Fix

Added `#[serial(role_tick_ring)]` above the three affected tests, matching the existing convention in this file for other shared global state (e.g. `#[serial(loom_config_env)]`):

- `test_log_outcome_for_root_deduped_tracks_failing_state_across_ticks`
- `test_log_outcome_for_root_deduped_is_independent_per_root`
- `test_log_outcome_for_root_deduped_no_token_pool_tracked_independently_of_failing`

No production logic changed — this is a test-only fix.

## Test plan

- [x] `cargo build -p loom-daemon` — compiles cleanly
- [x] `cargo test -p loom-daemon --lib role_runner::tests -- --test-threads=4` — all 84 tests pass, including the three newly-tagged tests and the ring-assertion tests

Closes #4772