### PR TITLE
feat(doctor): ingest inline PR review comments, not just top-level comments

### DIFF
--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -175,14 +175,32 @@ plus the `loom:changes-requested` label. Read it with:
 gh pr view <pr> --comments
 ```
 
-Focus on the Judge's most recent comments: look for specific file paths, line
-numbers, and what to change, then make the targeted fix before doing anything else.
+`gh pr view --comments` (and the Judge's own posting convention, `gh pr comment`
+per CLAUDE.md) only surfaces **top-level** PR comments. A human reviewer can
+separately leave **inline** review comments anchored to a specific diff hunk
+(the `#discussion_r...` links in the GitHub UI) — a different API surface that
+`gh pr view --comments` never includes. Fetch those too, every time you read
+feedback, so a reviewer's per-line note is never silently missed:
+
+```bash
+gh api "repos/{owner}/{repo}/pulls/<pr>/comments" \
+  --jq '.[] | "\(.path):\(.line // .original_line) — \(.user.login): \(.body)"'
+```
+
+Fold both sets of comments — top-level and inline — into the context you reason
+about before making a fix. An inline comment on one hunk is actionable feedback
+even if the reviewer never added a top-level summary comment.
+
+Focus on the most recent comments from either surface: look for specific file
+paths, line numbers, and what to change, then make the targeted fix before doing
+anything else.
 
 > **Note**: there is no `--test-fix` flag, no `--context` argument, and no
 > structured JSON feedback file dropped in the worktree. Those were part of the
 > Shepherd's test-fix protocol, which was removed in v0.10.0. `/loom:sweep` now
 > communicates with Doctor entirely through the PR's comments and labels — always
-> read the live feedback with `gh pr view <pr> --comments`.
+> read the live feedback with both `gh pr view <pr> --comments` (top-level) and
+> `gh api repos/{owner}/{repo}/pulls/<pr>/comments` (inline).
 
 If no argument is provided, use the normal "Finding Work" workflow below.
 
@@ -899,8 +917,13 @@ else
   cd ".loom/worktrees/pr-42"
 fi
 
-# See what reviewer said
+# See what reviewer said (top-level comments)
 gh pr view 42 --comments
+
+# See inline/per-line review comments too — anchored to a specific diff hunk
+# (#discussion_r... links), a separate API surface `gh pr view --comments` never includes
+gh api repos/{owner}/{repo}/pulls/42/comments \
+  --jq '.[] | "\(.path):\(.line // .original_line) — \(.user.login): \(.body)"'
 
 # Make your changes...
 # (edit files, add tests, fix bugs, resolve conflicts)


### PR DESCRIPTION
## Summary

Doctor's feedback-reading step (`.loom/roles/doctor.md`, sourced from
`defaults/.claude/commands/loom/doctor.md` — the three copies are symlinked to
the same file) only fetched **top-level** PR comments via `gh pr view <pr>
--comments`. GitHub's **inline/per-line review comments** (the
`pulls/{N}/comments` API surface, anchored to a diff hunk — the
`#discussion_r...` links in the GitHub UI) are a separate surface that nothing
in Doctor's role fetched, so a human reviewer's inline-only feedback on a Loom
PR was silently invisible to Doctor.

## Changes

- Added a `gh api repos/{owner}/{repo}/pulls/<pr>/comments` fetch alongside the
  existing `gh pr view <pr> --comments` fetch in the "How judge feedback
  reaches you" section, with an explanation of why both are needed and
  instructions to fold both into the pre-fix context.
- Mirrored the same addition into the "Example Commands" section's "See what
  reviewer said" step.
- No changes to Judge's own comment-posting convention — `gh pr comment`
  remains the required path per CLAUDE.md.

Since `defaults/roles/doctor.md`, `defaults/.claude/commands/loom/doctor.md`,
and `.loom/roles/doctor.md` are all symlinks to the same underlying file in
this repo, a single edit updates all three surfaces — no separate resync step
needed.

## Test plan

- [x] `bash scripts/check-claude-md-budget.sh` — OK (unaffected, doctor.md is
      not CLAUDE.md, but confirms doc tooling still runs cleanly)
- [x] `bash .loom/scripts/check-cas-recheck-consistency.sh` — OK, no
      regression in the CAS-recheck sections of doctor.md
- [x] Verified all three doctor.md paths remain byte-identical after the edit
      (they resolve through symlinks to one file)

Closes #4777