### PR TITLE
fix(codex): plumb admitted LOOM_ROLE explicitly to Codex spawn children

### DIFF
--- a/defaults/scripts/spawn-codex.sh
+++ b/defaults/scripts/spawn-codex.sh
@@ -185,6 +185,14 @@
 #                        Scheduling priority, applied by this runner exactly the
 #                        way spawn-claude.sh applies it (issue #4233 — priority
 #                        is a per-runner policy, never the dispatcher's).
+#   LOOM_ROLE            The acting role (builder/doctor/judge/... or their
+#                        development-worker/pr-fixer/sweep-lifecycle aliases),
+#                        used ONLY by the managed-hook mutable-role preflight
+#                        below. `loom-daemon` sets this for every admitted
+#                        dispatch (sweep child or role-runner tick, issue
+#                        #4768); an UNSET or unrecognized value is treated as
+#                        read-only, NOT fail-closed — see that preflight's
+#                        comments for why this is deliberate today.
 
 set -euo pipefail
 
@@ -623,6 +631,14 @@ _hook_role="$(printf '%s' "${LOOM_ROLE:-}" | tr '[:upper:]_' '[:lower:]-')"
 case "$_hook_role" in
     development-worker) _hook_role="builder" ;;
     pr-fixer)           _hook_role="doctor" ;;
+    # A full `/loom:sweep` dispatch is modelled daemon-side as one
+    # "sweep-lifecycle" launch, admitted against Builder's (strongest
+    # lifecycle) capability requirements (see loom-daemon's
+    # runtime_admission.rs module doc) — it runs the Builder/Doctor phases
+    # in-process, so it needs the same mutable-role hook-trust preflight
+    # `builder`/`doctor` get. `loom-daemon` sets `LOOM_ROLE=sweep-lifecycle`
+    # for every daemon-dispatched sweep child (issue #4768).
+    sweep-lifecycle)   _hook_role="builder" ;;
 esac
 
 _hook_role_is_mutable=false

--- a/defaults/scripts/tests/test-spawn-codex.sh
+++ b/defaults/scripts/tests/test-spawn-codex.sh
@@ -943,6 +943,12 @@ run_preflight 78 "development-worker (builder alias) -> exit 78" \
     LOOM_ROLE=development-worker CODEX_HOME="$BARE_PROFILE"
 run_preflight 78 "BUILDER (case-insensitive) -> exit 78" \
     LOOM_ROLE=BUILDER CODEX_HOME="$BARE_PROFILE"
+# Issue #4768: a daemon-dispatched sweep child is admitted against Builder's
+# requirements and gets LOOM_ROLE=sweep-lifecycle (never a bare "builder") —
+# it must get the SAME mutable-role fail-closed treatment, not the read-only
+# fallback an unrecognized role would silently take.
+run_preflight 78 "sweep-lifecycle (daemon sweep-child alias) -> exit 78" \
+    LOOM_ROLE=sweep-lifecycle CODEX_HOME="$BARE_PROFILE"
 
 # (6) Read-only roles keep the conservative fallback, with an explicit warning.
 run_preflight 0 "judge + unprovisioned profile -> proceeds (read-only role)" \

--- a/loom-daemon/src/role_runner.rs
+++ b/loom-daemon/src/role_runner.rs
@@ -593,6 +593,12 @@ fn run_role_with_timeout(
         // Pin the already-admitted choice so spawn-worker cannot re-resolve a
         // different runtime after the pre-spawn decision.
         cmd.env("LOOM_RUNTIME", &admission.runtime);
+        // Issue #4768: pin the admitted role too, mirroring
+        // `sweep_registry::spawn_child`. Without it, a Codex-runtime role
+        // child (e.g. `LOOM_ROLE` unset for a champion/curator/judge/auditor/
+        // guide tick) reaches `spawn-codex.sh` with no role signal at all,
+        // which is indistinguishable from an unrecognized role there.
+        cmd.env("LOOM_ROLE", &admission.role);
         log::info!(
             "role_runner: admitted role={} runtime={} source={}",
             admission.role,

--- a/loom-daemon/src/sweep_registry/dispatch.rs
+++ b/loom-daemon/src/sweep_registry/dispatch.rs
@@ -1406,6 +1406,19 @@ impl SweepRegistry {
             .stderr(Stdio::from(log_clone));
         if let Some(admission) = runtime_admission {
             cmd.env("LOOM_RUNTIME", &admission.runtime);
+            // Issue #4768: pin the ALREADY-ADMITTED role alongside the runtime
+            // it was admitted for. Without this, a Codex-runtime sweep child
+            // reaches `spawn-codex.sh` with no `LOOM_ROLE` at all (bash env
+            // vars only propagate what the parent process actually set — this
+            // `Command` never set one), which `spawn-codex.sh` treats as an
+            // ambiguous/unknown role and silently takes the READ-ONLY
+            // sandbox-fallback path instead of the mutable-role hook-trust
+            // preflight. `admission.role` is always `"sweep-lifecycle"` here
+            // (a full sweep is modelled as one launch, admitted against
+            // Builder's requirements — see runtime_admission.rs's module
+            // doc), which `spawn-codex.sh` maps onto `builder` for its own
+            // mutable-role check.
+            cmd.env("LOOM_ROLE", &admission.role);
             log::info!(
                 "sweep_registry: admitted role={} runtime={} source={}",
                 admission.role,
@@ -3097,6 +3110,95 @@ exit 0
         assert!(
             recorded.contains(".loom/tokens/agent-1.token"),
             "expected TOKEN_SOURCE to point at .loom/tokens/; got: {recorded}"
+        );
+    }
+
+    /// Issue #4768: the sweep child must receive `LOOM_ROLE=sweep-lifecycle`
+    /// (the ALREADY-ADMITTED role), not just `LOOM_RUNTIME`. Without this, a
+    /// Codex-runtime sweep child reaches `spawn-codex.sh`'s mutable-role
+    /// hook-trust preflight with no role signal at all, which is
+    /// indistinguishable there from an unrecognized role and silently takes
+    /// the read-only fallback instead of failing closed.
+    #[test]
+    #[serial]
+    fn dispatch_sets_loom_role_from_admitted_role() {
+        let dir = tempdir().unwrap();
+        let workspace = dir.path();
+        // Installs the runtime-admission fixture (`.loom/roles/builder.json`
+        // + `.loom/runtimes/claude.json`, satisfied by the built-in `claude`
+        // runtime) AND the `/loom:sweep` command marker the 2.x guards
+        // require with `skip_label_flip = false`.
+        touch_sweep_command(workspace);
+
+        // A permissive fake `gh` so every dispatch-path guard (closed-issue,
+        // open-PR, park-label) passes and dispatch reaches `spawn_child`.
+        let fake_gh = workspace.join("fake-gh.sh");
+        let gh_script = format!(
+            "#!/usr/bin/env bash\n\
+             if [[ \"$1\" == \"api\" && \"$2\" == repos/* ]]; then\n\
+             printf '%s\\n' '{state}'\n\
+             exit 0\n\
+             fi\n\
+             if [[ \"$1\" == \"repo\" && \"$2\" == \"view\" ]]; then\n\
+             printf 'rjwalters/loom\\n'\n\
+             exit 0\n\
+             fi\n\
+             exit 0\n",
+            state = state_probe_json("open", false),
+        );
+        std::fs::write(&fake_gh, &gh_script).unwrap();
+        let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_gh, perms).unwrap();
+
+        // Overwrite the fixture's stub spawn-claude.sh with one that records
+        // LOOM_ROLE (and LOOM_RUNTIME, for good measure) to a log file.
+        let scripts_dir = workspace.join(".loom").join("scripts");
+        let fake_bin = scripts_dir.join("spawn-claude.sh");
+        let record_log = workspace.join("role-record.log");
+        let script = format!(
+            r#"#!/usr/bin/env bash
+{{
+  printf 'LOOM_ROLE=%s\n' "${{LOOM_ROLE:-unset}}"
+  printf 'LOOM_RUNTIME=%s\n' "${{LOOM_RUNTIME:-unset}}"
+}} >> "{rec}"
+exit 0
+"#,
+            rec = record_log.display()
+        );
+        std::fs::write(&fake_bin, script).unwrap();
+        let mut perms = std::fs::metadata(&fake_bin).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_bin, perms).unwrap();
+        if let Ok(f) = std::fs::File::open(&fake_bin) {
+            let _ = f.sync_all();
+        }
+
+        let mut config = SweepRegistryConfig::new(workspace.to_path_buf());
+        // Bypass the runtime-dispatch seam (`resolve_spawn_bin()` would
+        // otherwise find the REAL `defaults/scripts/spawn-worker.sh` and exec
+        // through to the real `spawn-claude.sh`): point `spawn_bin` directly
+        // at the recording fixture, exactly like every other fixture in this
+        // module.
+        config.spawn_bin = Some(fake_bin);
+        config.gh_bin = Some(fake_gh);
+        config.skip_label_flip = false;
+        config.journal_path = Some(workspace.join("test-sweeps-journal.json"));
+        let mut registry = SweepRegistry::new(config);
+
+        let outcome = registry
+            .dispatch(&SweepKind::Issue(4768), None, None, None, None)
+            .unwrap();
+        assert!(outcome.was_new);
+
+        let recorded = assert_child_wrote(&record_log, "LOOM_ROLE=");
+        assert!(
+            recorded.contains("LOOM_ROLE=sweep-lifecycle"),
+            "expected the admitted role (sweep-lifecycle) in the child env; got: {recorded}"
+        );
+        assert!(
+            recorded.contains("LOOM_RUNTIME=claude"),
+            "expected the admitted (built-in) runtime alongside it; got: {recorded}"
         );
     }
 


### PR DESCRIPTION
## Summary

Neither `sweep_registry::spawn_child` nor `role_runner`'s dispatch set `LOOM_ROLE` on the spawned `Command`, so a Codex-runtime child reached `spawn-codex.sh`'s mutable-role hook-trust preflight with no role signal at all. That preflight treats an unset/unrecognized role as read-only-safe rather than fail-closed, silently downgrading a Builder/Doctor-capable child to the read-only sandbox fallback — exactly the failure mode #4768 describes.

- Pin the already-admitted role (mirroring the existing `LOOM_RUNTIME` pin) on both the sweep-child dispatch path (`sweep_registry/dispatch.rs`) and the role-runner tick path (`role_runner.rs`).
- Teach `spawn-codex.sh`'s role-alias table about `sweep-lifecycle` — the role a full `/loom:sweep` dispatch is admitted under (it runs Builder/Doctor phases in-process, so it needs the same fail-closed treatment as a bare `builder`/`doctor`).
- Add a Rust dispatch test (`dispatch_sets_loom_role_from_admitted_role`) verifying the child env carries `LOOM_ROLE=sweep-lifecycle` alongside `LOOM_RUNTIME`, and a bash preflight case verifying `sweep-lifecycle` maps to the mutable-role fail-closed path (exit 78).

This is the daemon-side plumbing option from the issue's two suggested fixes — it sets the role explicitly at the point the daemon already knows the admitted role/runtime, rather than routing it generically through `spawn-worker.sh`.

## Test plan

- [x] `cargo build --lib` succeeds
- [x] `cargo test --lib dispatch_sets_loom_role_from_admitted_role` passes
- [x] `cargo fmt -- --check` clean
- [x] `bash defaults/scripts/tests/test-spawn-codex.sh` — 180/182 pass (the 2 failures are pre-existing/environmental, reproduced identically on unmodified `main`, 179/181)

Closes #4768