### PR TITLE
fix(daemon): daemon self-writes .daemon.pid at boot, readers cross-check it

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -3690,7 +3690,16 @@ process:
   — or, in **machine mode** (dispatcher-driven, `LOOM_MACHINE_CHECKOUT` set,
   #4229), at `$HOME/.loom/.daemon.pid` so the same machine-wide launchd
   singleton is tracked consistently no matter which repo `loom start` ran
-  from; see [`machine-dispatcher.md`](machine-dispatcher.md#the-pidflags-relocation-decision),
+  from; see [`machine-dispatcher.md`](machine-dispatcher.md#the-pidflags-relocation-decision).
+  Since **#4774 the daemon also writes this file itself**, immediately after its
+  socket bind succeeds, to the path the start script exports as `LOOM_PID_FILE`.
+  That is what keeps it correct across the relaunches this script is not part of
+  — launchd `KeepAlive`, systemd `Restart=`, the `RestartDaemon` primitive, the
+  self-update roll, `launchctl kickstart`. The write sits *after* the singleton
+  guard's bind on purpose: a daemon the guard refuses must never overwrite the
+  live incumbent's entry. `status` / `health` cross-check the recorded pid
+  against `daemon_pid` (the answering process's own `std::process::id()`) and
+  report a stale file rather than trusting it,
 - refuses a second start when the PID file points at a live process, and surfaces
   the daemon's own **singleton-guard** refusal (#3806) — if the backgrounded
   process exits immediately it prints the startup-log tail instead of leaving a

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -1085,6 +1085,15 @@ fi
 PLIST_PATH_VALUE="$(resolve_plist_path)"
 
 PID_FILE="$DAEMON_STATE_HOME/.daemon.pid"
+# Exported (#4774) so the daemon writes the SAME file this script does. Both
+# the plist and systemd-unit renderers harvest every exported LOOM_* var, so
+# the path chosen here is baked into the supervisor definition and every
+# supervisor-triggered relaunch resolves it identically -- which is the whole
+# point: those relaunches (launchd KeepAlive, systemd Restart=, the #4054
+# restart primitive, the self-update roll, `launchctl kickstart`) never re-run
+# this script, so before #4774 the file kept naming a long-dead pid. The daemon
+# now claims it itself right after its socket bind succeeds.
+export LOOM_PID_FILE="$PID_FILE"
 SOCKET_PATH="${LOOM_SOCKET_PATH:-$HOME/.loom/loom-daemon.sock}"
 START_LOG="$DAEMON_STATE_HOME/logs/daemon-start.log"
 mkdir -p "$DAEMON_STATE_HOME/logs"
@@ -1481,6 +1490,12 @@ if [[ "$USE_LAUNCHD" == "true" ]]; then
         exit 1
     fi
 
+    # Redundant since #4774 -- the daemon claims $PID_FILE itself immediately
+    # after its socket bind succeeds -- but kept deliberately. It costs nothing,
+    # it closes the window between "supervisor reports a pid" and "the daemon
+    # reaches its bind", and it is the only writer for a daemon binary older
+    # than #4774 (a start script and a daemon roll independently). Harmless if
+    # both write: same path, same pid, and the daemon's write is atomic.
     echo "$daemon_pid" > "$PID_FILE"
     # Record operator intent + arm the host-side autonomy-loss watchdog (#4011).
     write_intent_marker "true" "$LAUNCHD_LABEL"
@@ -1561,6 +1576,12 @@ if [[ "$IS_LINUX_SYSTEMD" == "true" ]]; then
         exit 1
     fi
 
+    # Redundant since #4774 -- the daemon claims $PID_FILE itself immediately
+    # after its socket bind succeeds -- but kept deliberately. It costs nothing,
+    # it closes the window between "supervisor reports a pid" and "the daemon
+    # reaches its bind", and it is the only writer for a daemon binary older
+    # than #4774 (a start script and a daemon roll independently). Harmless if
+    # both write: same path, same pid, and the daemon's write is atomic.
     echo "$daemon_pid" > "$PID_FILE"
     # Record operator intent + arm the systemd-timer autonomy-loss watchdog
     # (#4011, #4260 sub-issue D).
@@ -1599,6 +1620,12 @@ if ! kill -0 "$daemon_pid" 2>/dev/null; then
     exit 1
 fi
 
+# Redundant since #4774 -- the daemon claims $PID_FILE itself immediately
+# after its socket bind succeeds -- but kept deliberately. It costs nothing,
+# it closes the window between "supervisor reports a pid" and "the daemon
+# reaches its bind", and it is the only writer for a daemon binary older
+# than #4774 (a start script and a daemon roll independently). Harmless if
+# both write: same path, same pid, and the daemon's write is atomic.
 echo "$daemon_pid" > "$PID_FILE"
 # Record operator intent (#4011). This is the nohup fallback tier (non-systemd
 # Linux host, or --no-launchd/--no-systemd), so there is no scheduled checker to

--- a/loom-daemon/src/autonomy_marker.rs
+++ b/loom-daemon/src/autonomy_marker.rs
@@ -118,7 +118,12 @@ pub struct MarkerFields {
 /// `daemon_heartbeat` / `daemon_install_state` do: the parent of
 /// `LOOM_SOCKET_PATH` when set (so a test daemon pointed at a tempdir socket
 /// heals into that tempdir, never the operator's real `~/.loom`), else `~/.loom`.
-fn resolve_loom_dir() -> Option<PathBuf> {
+///
+/// `pub(crate)` since #4774: [`crate::daemon_pidfile`] resolves the pid file
+/// against the *same* loom dir this module records in the marker's `pid_file=`
+/// field, so a self-written pid file and a healed marker can never name
+/// different directories.
+pub(crate) fn resolve_loom_dir() -> Option<PathBuf> {
     if let Ok(path) = std::env::var("LOOM_SOCKET_PATH") {
         return PathBuf::from(path).parent().map(Path::to_path_buf);
     }

--- a/loom-daemon/src/cli/health.rs
+++ b/loom-daemon/src/cli/health.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use loom_daemon::daemon_install_state;
+use loom_daemon::daemon_pidfile;
 use loom_daemon::health::{self, HealthInputs, HealthReport};
 use loom_daemon::pipeline_snapshot::{self, GhPipelineSource, PipelineMetrics};
 use loom_daemon::types::{DaemonStatusReport, Request, Response};
@@ -69,6 +70,19 @@ async fn collect(window: Duration) -> HealthReport {
     let install_state = daemon_install_state::probe();
     let pgrep_pids = daemon_install_state::pgrep_daemon_pids();
 
+    // 2b. The pid file, observed against the path the DAEMON resolved (#4774)
+    //     when it answered — same rule as `.ranking` below and `status`'s token
+    //     probe (#4292): never re-derive from this CLI process's own cwd/env
+    //     when the daemon has told us which file it actually writes. Falling
+    //     back to a local resolution only for an unreachable / pre-#4774
+    //     daemon. Observed unconditionally so `--json` carries the corroborating
+    //     evidence either way; the collector decides what it means.
+    let pid_file = status
+        .as_ref()
+        .and_then(|r| r.pid_file.clone())
+        .or_else(daemon_pidfile::resolve_pid_file_path)
+        .map(|path| daemon_pidfile::observe(&path));
+
     // 3. `.ranking` staleness, against the pool directory the DAEMON resolved
     //    (#4292) rather than one re-derived from this CLI process's own cwd —
     //    the same rule `status`'s client-side token probe follows.
@@ -106,6 +120,7 @@ async fn collect(window: Duration) -> HealthReport {
         ipc_error,
         install_state,
         pgrep_pids,
+        pid_file,
         ranking_present,
         ranking_age_secs,
         pipeline,

--- a/loom-daemon/src/cli/status.rs
+++ b/loom-daemon/src/cli/status.rs
@@ -661,6 +661,8 @@ pub(crate) mod status_client_tests {
             work_finder_enabled: Some(true),
             last_work_finder_tick: None,
             role_tick_records: vec![],
+            daemon_pid: Some(99917),
+            pid_file: Some(std::path::PathBuf::from("/repo/a/.loom/.daemon.pid")),
         }
     }
 

--- a/loom-daemon/src/daemon_install_state.rs
+++ b/loom-daemon/src/daemon_install_state.rs
@@ -242,6 +242,13 @@ pub struct InstallStateReport {
     /// The watchdog log path to point an operator at (advisory only — never
     /// read by this module).
     pub watchdog_log_path: PathBuf,
+    /// #4774: an operator-facing note when the daemon pid file disagrees with
+    /// the pid this probe established independently (launchd's). Present only
+    /// for a *live* daemon whose pid file names someone else — the signature a
+    /// supervisor relaunch used to leave behind, and a booby trap for every
+    /// other consumer that reads the file. `None` in every non-anomalous case,
+    /// so callers can `if let Some(note) = …` and stay silent.
+    pub pid_file_stale_note: Option<String>,
 }
 
 impl InstallStateReport {
@@ -257,6 +264,7 @@ impl InstallStateReport {
             process_age_secs: None,
             startup_grace_threshold_secs: None,
             watchdog_log_path,
+            pid_file_stale_note: None,
         }
     }
 }
@@ -442,7 +450,10 @@ fn resolve_marker_fields(map: &HashMap<String, String>, loom_dir: &Path) -> Mark
 /// both "no such process" and "not owned by us", exactly like the shell
 /// script's `kill -0 "$pid" 2>/dev/null`. Bounded by [`PROBE_TIMEOUT`]; a hung
 /// `kill` degrades to `false`, exactly like an absent one (#4548).
-fn pid_alive(pid: u32) -> bool {
+/// `pub(crate)` since #4774 so [`crate::daemon_pidfile`]'s stale-detection
+/// observation uses the *same* bounded `kill -0` probe this module's liveness
+/// classification does, rather than a second implementation that could drift.
+pub(crate) fn pid_alive(pid: u32) -> bool {
     let mut cmd = Command::new("kill");
     cmd.args(["-0", &pid.to_string()]);
     probe_output(cmd, PROBE_TIMEOUT).is_some_and(|o| o.status.success())
@@ -545,15 +556,54 @@ struct Liveness {
     alive: bool,
     detail: String,
     pid: Option<u32>,
+    /// #4774: an advisory note when the pid file disagrees with the *authoritative*
+    /// liveness signal this probe used (launchd's own pid). `None` when the file
+    /// agrees, is absent, or was the signal itself — see [`pid_file_stale_note`].
+    pid_file_stale_note: Option<String>,
+}
+
+impl Liveness {
+    /// A liveness verdict with no pid-file anomaly to report — the common case,
+    /// and the only shape the pre-#4774 constructors had.
+    fn plain(alive: bool, detail: String, pid: Option<u32>) -> Self {
+        Liveness {
+            alive,
+            detail,
+            pid,
+            pid_file_stale_note: None,
+        }
+    }
+}
+
+/// The **local** half of #4774's stale-pid-file detection: cross-check the pid
+/// file against a pid this probe established *independently of the file itself*
+/// (launchd's `pid = …`).
+///
+/// This is deliberately weaker than [`crate::health`]'s check, which compares
+/// against `daemon_pid` — the answering process's own `std::process::id()` over
+/// IPC. Here there is no IPC, so launchd's pid is the best available ground
+/// truth; that is enough to catch the exact 2026-07-31 signature (a file naming
+/// a pid from two relaunches ago while launchd names the live one) without a
+/// round-trip, which matters because this probe is what runs when the daemon is
+/// *unreachable*.
+///
+/// `None` — no anomaly worth reporting — when the file is absent (an absent file
+/// makes no false claim) or names the same pid launchd does.
+fn pid_file_stale_note(pid_file: Option<&Path>, authoritative_pid: u32) -> Option<String> {
+    let path = pid_file?;
+    let observation = crate::daemon_pidfile::observe_with(path, pid_alive);
+    let state = crate::daemon_pidfile::classify(&observation, Some(authoritative_pid));
+    state.note(path)
 }
 
 /// Parse a pid file into its recorded pid — `None` when the file is missing,
 /// unreadable, or does not hold a bare integer. Says nothing about whether
 /// that pid is *alive*; see [`pid_file_alive_pid`].
+///
+/// Delegates to [`crate::daemon_pidfile::read_pid_file`] (#4774) so the module
+/// that *writes* the file and the modules that *read* it share one parser.
 fn read_pid_file(pid_file: &Path) -> Option<u32> {
-    std::fs::read_to_string(pid_file)
-        .ok()
-        .and_then(|s| s.trim().parse::<u32>().ok())
+    crate::daemon_pidfile::read_pid_file(pid_file)
 }
 
 /// The pid recorded in `pid_file`, iff that pid is currently alive — an
@@ -588,6 +638,9 @@ fn check_liveness(
                     alive: true,
                     detail: format!("launchd job {service} alive (pid {pid})"),
                     pid: Some(pid),
+                    // launchd's pid is established independently of the file, so
+                    // it can arbitrate against it (#4774).
+                    pid_file_stale_note: pid_file_stale_note(pid_file, pid),
                 };
             }
         }
@@ -609,6 +662,7 @@ fn check_liveness(
                         alive: true,
                         detail: format!("launchd job {check_domain}/{label} alive (pid {pid})"),
                         pid: Some(pid),
+                        pid_file_stale_note: pid_file_stale_note(pid_file, pid),
                     };
                 }
             }
@@ -625,48 +679,39 @@ fn check_liveness(
         // place.
         if let Some(pf) = pid_file {
             if let Some(pid) = pid_file_alive_pid(pf) {
-                return Liveness {
-                    alive: true,
-                    detail: format!(
+                // The pid file IS the signal here — nothing independent to
+                // arbitrate it against, so no #4774 staleness claim is made.
+                return Liveness::plain(
+                    true,
+                    format!(
                         "launchd job {service} not loaded, but pid file {} shows pid {pid} alive",
                         pf.display()
                     ),
-                    pid: Some(pid),
-                };
+                    Some(pid),
+                );
             }
         }
 
-        return Liveness {
-            alive: false,
-            detail: format!("launchd job {service} is not loaded/alive"),
-            pid: None,
-        };
+        return Liveness::plain(false, format!("launchd job {service} is not loaded/alive"), None);
     }
 
     // Non-launchd (nohup / Linux) path: the pid file is the only signal.
     match pid_file {
         Some(pf) => match read_pid_file(pf) {
-            Some(pid) if pid_alive(pid) => Liveness {
-                alive: true,
-                detail: format!("pid {pid} (from {}) alive", pf.display()),
-                pid: Some(pid),
-            },
-            Some(_) => Liveness {
-                alive: false,
-                detail: format!("pid file {} present but pid not alive", pf.display()),
-                pid: None,
-            },
-            None => Liveness {
-                alive: false,
-                detail: format!("no live pid file at {}", pf.display()),
-                pid: None,
-            },
+            // Every branch below derives its verdict *from* the pid file, so
+            // there is no independent signal to call it stale with (#4774); a
+            // dead/absent file is already reported by `detail` + `alive: false`.
+            Some(pid) if pid_alive(pid) => {
+                Liveness::plain(true, format!("pid {pid} (from {}) alive", pf.display()), Some(pid))
+            }
+            Some(_) => Liveness::plain(
+                false,
+                format!("pid file {} present but pid not alive", pf.display()),
+                None,
+            ),
+            None => Liveness::plain(false, format!("no live pid file at {}", pf.display()), None),
         },
-        None => Liveness {
-            alive: false,
-            detail: "no live pid file at <none>".to_string(),
-            pid: None,
-        },
+        None => Liveness::plain(false, "no live pid file at <none>".to_string(), None),
     }
 }
 
@@ -847,6 +892,10 @@ pub(crate) fn classify_with_process_age_fn(
             process_age_secs: None,
             startup_grace_threshold_secs: None,
             watchdog_log_path,
+            // A dead daemon's pid file is already fully described by
+            // `liveness_detail`; the #4774 note is reserved for the
+            // alive-but-misreported case.
+            pid_file_stale_note: None,
         };
     }
 
@@ -870,6 +919,7 @@ pub(crate) fn classify_with_process_age_fn(
                 process_age_secs: Some(age),
                 startup_grace_threshold_secs: Some(grace_threshold),
                 watchdog_log_path,
+                pid_file_stale_note: liveness.pid_file_stale_note,
             };
         }
     }
@@ -889,6 +939,7 @@ pub(crate) fn classify_with_process_age_fn(
         process_age_secs: process_age,
         startup_grace_threshold_secs: Some(grace_threshold),
         watchdog_log_path,
+        pid_file_stale_note: liveness.pid_file_stale_note,
     }
 }
 
@@ -2645,6 +2696,119 @@ mod tests {
         );
         assert_eq!(liveness.pid, Some(std::process::id()));
         assert!(liveness.detail.contains("pid file"), "{}", liveness.detail);
+    }
+
+    // ===================================================================
+    // #4774 — the pid file is cross-checked against launchd, not trusted
+    // ===================================================================
+
+    /// A pid that is guaranteed not to name a live process (the same value the
+    /// process-age tests use, for the same reason).
+    const DEAD_PID: u32 = i32::MAX as u32;
+
+    #[test]
+    fn no_pid_file_configured_yields_no_stale_note() {
+        assert_eq!(pid_file_stale_note(None, std::process::id()), None);
+    }
+
+    #[test]
+    fn an_absent_pid_file_yields_no_stale_note() {
+        // An absent file makes no false claim — silence, not a warning.
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("daemon.pid");
+        assert_eq!(pid_file_stale_note(Some(&missing), std::process::id()), None);
+    }
+
+    #[test]
+    fn a_pid_file_agreeing_with_launchd_yields_no_stale_note() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = write_pid_file(dir.path(), std::process::id());
+        assert_eq!(pid_file_stale_note(Some(&pid_file), std::process::id()), None);
+    }
+
+    #[test]
+    fn a_pid_file_naming_someone_other_than_launchds_pid_is_reported_stale() {
+        // The 2026-07-31 signature, caught with no IPC round-trip at all: the
+        // file names a pid from a previous generation while launchd names the
+        // live one.
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = write_pid_file(dir.path(), 13724);
+        let note = pid_file_stale_note(Some(&pid_file), std::process::id())
+            .expect("a disagreement with launchd's pid must be reported");
+        assert!(note.contains("13724"), "{note}");
+        assert!(note.contains(&std::process::id().to_string()), "{note}");
+        assert!(note.contains("#4774"), "the note must be traceable to its issue: {note}");
+    }
+
+    #[test]
+    fn a_pid_file_holding_garbage_is_reported_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("daemon.pid");
+        fs::write(&pid_file, "not-a-pid\n").unwrap();
+        assert!(pid_file_stale_note(Some(&pid_file), std::process::id()).is_some());
+    }
+
+    #[test]
+    fn a_pid_file_naming_a_dead_pid_is_reported_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = write_pid_file(dir.path(), DEAD_PID);
+        assert!(pid_file_stale_note(Some(&pid_file), std::process::id()).is_some());
+    }
+
+    #[test]
+    #[serial]
+    fn a_live_launchd_job_whose_pid_file_disagrees_carries_the_stale_note() {
+        // End-to-end through `check_liveness`: launchd reports THIS process
+        // alive, the pid file names someone else. The daemon is alive (the
+        // verdict must not waver) *and* the file is called out.
+        let uid = current_uid().expect("current_uid resolves in the test env");
+        let pid = std::process::id();
+        let stub_dir = tempfile::tempdir().unwrap();
+        write_stub(
+            stub_dir.path(),
+            "launchctl",
+            &format!(
+                "#!/bin/sh\n\
+                 target=\"$2\"\n\
+                 case \"$target\" in\n\
+                   gui/{uid}) exit 0 ;;\n\
+                   gui/{uid}/*) echo \"    pid = {pid}\"; exit 0 ;;\n\
+                   *) exit 1 ;;\n\
+                 esac\n"
+            ),
+        );
+        let pid_dir = tempfile::tempdir().unwrap();
+        let pid_file = write_pid_file(pid_dir.path(), 13724);
+
+        let liveness = with_path_prefix(stub_dir.path(), || {
+            check_liveness(true, DEFAULT_LAUNCHD_LABEL, Some(&pid_file), None)
+        });
+
+        assert!(liveness.alive, "launchd reports the job alive: {}", liveness.detail);
+        assert_eq!(liveness.pid, Some(pid));
+        let note = liveness
+            .pid_file_stale_note
+            .expect("a pid file disagreeing with launchd's live pid must be flagged");
+        assert!(note.contains("13724"), "{note}");
+    }
+
+    #[test]
+    #[serial]
+    fn a_pid_file_used_as_the_liveness_signal_is_never_called_stale_by_itself() {
+        // When launchd is negative and the pid file IS the evidence, there is
+        // nothing independent to arbitrate with — the module must not manufacture
+        // a staleness claim out of the very signal it just trusted.
+        let stub_dir = tempfile::tempdir().unwrap();
+        write_stub(stub_dir.path(), "launchctl", FAIL_STUB);
+        let pid_dir = tempfile::tempdir().unwrap();
+        let pid_file = write_pid_file(pid_dir.path(), std::process::id());
+
+        let liveness = with_path_prefix(stub_dir.path(), || {
+            check_liveness(true, DEFAULT_LAUNCHD_LABEL, Some(&pid_file), None)
+        });
+
+        assert!(liveness.alive);
+        assert_eq!(liveness.pid_file_stale_note, None);
     }
 
     #[test]

--- a/loom-daemon/src/daemon_pidfile.rs
+++ b/loom-daemon/src/daemon_pidfile.rs
@@ -1,0 +1,596 @@
+//! Daemon-owned pid file (`<state home>/.daemon.pid`) — issue #4774.
+//!
+//! # Why the daemon must own this write
+//!
+//! Before #4774 the pid file was written in exactly one place:
+//! `loom-daemon-start.sh`, at *provisioning* time, from the shell that spawned
+//! the daemon (three write sites — launchd, systemd, bare-nohup). Every
+//! **supervisor-triggered relaunch** bypasses that script entirely:
+//!
+//! - launchd `KeepAlive:{SuccessfulExit:true}` respawning the job after the
+//!   `RestartDaemon` primitive (#4054) exits 0,
+//! - `systemd --user` `Restart=on-success` doing the same,
+//! - the in-daemon self-update loop (`loom-daemon-update.sh --no-restart` +
+//!   the restart primitive),
+//! - the #4232 `launchctl kickstart` path.
+//!
+//! All of them produce a **new daemon pid** while the pid file keeps naming
+//! the *old* one. Observed 2026-07-31: `.loom/.daemon.pid` held `13724` while
+//! the live daemon was `99917` — two relaunches stale. That poisons every
+//! liveness cross-check that consults it: `daemon_install_state`'s #4694
+//! pid-file fallback, the [`crate::health`] collector's liveness section, the
+//! `loom:watch` fallback battery, and manual operator debugging. On that same
+//! morning it compounded with a name-matched `pgrep` hitting a `/tmp` test
+//! stub — both quick liveness primitives lied at once.
+//!
+//! The fix is the same shape as #4331's marker healing: heal at **one startup
+//! choke point** that every relaunch path necessarily passes through. Here that
+//! point is [`crate::ipc::IpcServer::run`], immediately after
+//! `UnixListener::bind` succeeds — the exact instant this process is the
+//! confirmed *sole* owner of the daemon socket.
+//!
+//! # Why after the bind, not before the singleton guard
+//!
+//! #4331's marker healing runs in `daemon_service.rs` *before* the singleton
+//! guard is evaluated. Copying that call site verbatim would be a regression
+//! here: a daemon that is about to be **refused** (a live incumbent already
+//! answers on the socket) would first stomp the incumbent's legitimate pid file
+//! with its own doomed pid, then bail — turning the guard's "refuse, don't
+//! disturb the incumbent" contract into a data corruption. Writing after a
+//! successful `bind` makes that structurally impossible: a refused daemon never
+//! reaches the write.
+//!
+//! # Path resolution
+//!
+//! Mirrors `loom-daemon-start.sh`'s `PID_FILE="$DAEMON_STATE_HOME/.daemon.pid"`,
+//! in precedence order:
+//!
+//! 1. **`LOOM_PID_FILE`** — an explicit path. `loom-daemon-start.sh` exports
+//!    this before rendering the launchd plist / systemd unit, so the path the
+//!    start script chose is baked into the supervisor definition and every
+//!    relaunch resolves the *identical* file. This is the production path.
+//! 2. **Machine mode** (`LOOM_MACHINE_CHECKOUT` set, Epic #3835 Phase 3b):
+//!    `<loom_dir>/.daemon.pid`, where `<loom_dir>` is
+//!    [`crate::autonomy_marker::resolve_loom_dir`] (`LOOM_SOCKET_PATH`'s parent,
+//!    else `~/.loom`) — matching the start script's `DAEMON_STATE_HOME="$HOME/.loom"`
+//!    while still honoring a tempdir socket for test isolation.
+//! 3. **Repo mode** (`LOOM_WORKSPACE` set): `<workspace>/.loom/.daemon.pid`,
+//!    matching `DAEMON_STATE_HOME="$REPO_ROOT/.loom"`.
+//! 4. Otherwise `<loom_dir>/.daemon.pid`.
+//!
+//! Tiers 2-4 exist for daemons whose supervisor definition predates the
+//! `LOOM_PID_FILE` export (an already-provisioned plist keeps its render-time
+//! env until the next `loom-daemon-start.sh` run) and for direct/dev launches.
+//!
+//! # Never fatal
+//!
+//! Every failure mode here — unresolvable path, unwritable directory, a rename
+//! that loses a race — is logged and ignored. A daemon without a pid file is
+//! strictly better than no daemon, exactly as in [`crate::autonomy_marker`].
+
+use std::path::{Path, PathBuf};
+
+pub use crate::autonomy_marker::PID_FILENAME;
+
+/// Env override naming the pid file outright. Exported by
+/// `loom-daemon-start.sh` so the start script and the daemon can never disagree
+/// about where the file lives (see the module docs' precedence list).
+pub const PID_FILE_ENV: &str = "LOOM_PID_FILE";
+
+/// Resolve the pid file path from the process environment. `None` only when no
+/// loom dir can be resolved at all (no `LOOM_SOCKET_PATH`, no home directory)
+/// and no more specific override applies.
+#[must_use]
+pub fn resolve_pid_file_path() -> Option<PathBuf> {
+    resolve_pid_file_path_from(
+        std::env::var(PID_FILE_ENV).ok(),
+        std::env::var("LOOM_MACHINE_CHECKOUT").ok(),
+        std::env::var("LOOM_WORKSPACE").ok(),
+        crate::autonomy_marker::resolve_loom_dir(),
+    )
+}
+
+/// [`resolve_pid_file_path`]'s pure core: the precedence rules with every env
+/// lookup lifted into arguments, so tests drive each tier without mutating
+/// process-global env vars (which are shared across the whole test binary).
+#[must_use]
+pub fn resolve_pid_file_path_from(
+    pid_file_env: Option<String>,
+    machine_checkout: Option<String>,
+    workspace: Option<String>,
+    loom_dir: Option<PathBuf>,
+) -> Option<PathBuf> {
+    let non_empty = |s: Option<String>| s.filter(|v| !v.is_empty());
+
+    // 1. Explicit override — the production path (start script exports it).
+    if let Some(path) = non_empty(pid_file_env) {
+        return Some(PathBuf::from(path));
+    }
+    // 2. Machine mode: state lives under the machine-level loom dir.
+    if non_empty(machine_checkout).is_some() {
+        return loom_dir.map(|d| d.join(PID_FILENAME));
+    }
+    // 3. Repo mode: state lives under `<repo>/.loom`.
+    if let Some(ws) = non_empty(workspace) {
+        return Some(PathBuf::from(ws).join(".loom").join(PID_FILENAME));
+    }
+    // 4. Fall back to the machine-level loom dir.
+    loom_dir.map(|d| d.join(PID_FILENAME))
+}
+
+/// The outcome of the startup pid-file claim — one variant per branch so the
+/// caller logs precisely and tests assert on the decision, not the filesystem.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaimOutcome {
+    /// The pid file now names this process. Carries the path and the pid that
+    /// was previously recorded there (`None` ⇒ absent/unparseable), so the
+    /// caller can log a *stale-file corrected* event rather than a silent
+    /// overwrite.
+    Claimed {
+        path: PathBuf,
+        previous: Option<u32>,
+    },
+    /// No pid file path could be resolved at all (no `LOOM_PID_FILE`, no
+    /// workspace, no socket path, no home directory).
+    Unresolvable,
+    /// The write failed. Non-fatal — logged, and the daemon keeps running.
+    WriteFailed { path: PathBuf, error: String },
+}
+
+/// Claim the pid file for the *current* process. Call this once, at the single
+/// startup choke point every supervised relaunch passes through (after the
+/// daemon socket bind succeeds — see the module docs).
+#[must_use]
+pub fn claim_for_current_process() -> ClaimOutcome {
+    match resolve_pid_file_path() {
+        Some(path) => claim_at(&path, std::process::id()),
+        None => ClaimOutcome::Unresolvable,
+    }
+}
+
+/// [`claim_for_current_process`]'s side-effect-scoped core: write `pid` into
+/// `path`, reporting whatever pid the file named beforehand.
+#[must_use]
+pub fn claim_at(path: &Path, pid: u32) -> ClaimOutcome {
+    let previous = read_pid_file(path);
+    match write_pid_atomic(path, pid) {
+        Ok(()) => ClaimOutcome::Claimed {
+            path: path.to_path_buf(),
+            previous,
+        },
+        Err(error) => ClaimOutcome::WriteFailed {
+            path: path.to_path_buf(),
+            error,
+        },
+    }
+}
+
+/// Write `<pid>\n` via a temp file + atomic rename (the same convention the
+/// autonomy marker and the sweep checkpoints use), so a concurrent reader — the
+/// watchdog, `status`, `health` — never observes a truncated or empty file.
+///
+/// Mode `0o644`: the start script writes with the invoking shell's default
+/// umask, and unlike the autonomy marker (which records paths and is written
+/// under `umask 077`) a pid file carries nothing sensitive.
+fn write_pid_atomic(path: &Path, pid: u32) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            return Err(format!("could not create {}: {e}", parent.display()));
+        }
+    }
+    let tmp = path.with_extension(format!("pid.tmp.{}", uuid::Uuid::new_v4()));
+    let contents = format!("{pid}\n");
+
+    let write_result = {
+        #[cfg(unix)]
+        {
+            use std::io::Write as _;
+            use std::os::unix::fs::OpenOptionsExt as _;
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o644)
+                .open(&tmp)
+                .and_then(|mut f| f.write_all(contents.as_bytes()))
+        }
+        #[cfg(not(unix))]
+        {
+            std::fs::write(&tmp, contents.as_bytes())
+        }
+    };
+    if let Err(e) = write_result {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!("could not write temp pid file {}: {e}", tmp.display()));
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!("could not rename pid file into place {}: {e}", path.display()));
+    }
+    Ok(())
+}
+
+/// Parse a pid file into its recorded pid — `None` when the file is missing,
+/// unreadable, or does not hold a bare integer. Says nothing about whether that
+/// pid is alive.
+#[must_use]
+pub fn read_pid_file(path: &Path) -> Option<u32> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+}
+
+// ============================================================================
+// Stale detection (AC3)
+// ============================================================================
+
+/// A single host-local observation of the pid file: what is on disk, and
+/// whether the pid it names is currently a live process. Collected by the CLI
+/// (`status` / `health`) and handed to the pure [`classify`] rule below.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PidFileObservation {
+    /// The path observed.
+    pub path: PathBuf,
+    /// Whether a file exists at [`Self::path`] at observation time.
+    pub present: bool,
+    /// The pid it names, when present and parseable as a bare integer.
+    pub recorded_pid: Option<u32>,
+    /// Whether [`Self::recorded_pid`] is a live process (`false` when there is
+    /// no recorded pid at all).
+    pub recorded_pid_alive: bool,
+}
+
+/// Observe the pid file at `path` using the real `kill -0` liveness probe.
+#[must_use]
+pub fn observe(path: &Path) -> PidFileObservation {
+    observe_with(path, crate::daemon_install_state::pid_alive)
+}
+
+/// [`observe`]'s injectable variant — tests pin liveness instead of depending
+/// on which pids happen to exist on the host running them.
+#[must_use]
+pub fn observe_with(path: &Path, alive: impl Fn(u32) -> bool) -> PidFileObservation {
+    let present = path.exists();
+    let recorded_pid = read_pid_file(path);
+    PidFileObservation {
+        path: path.to_path_buf(),
+        present,
+        recorded_pid_alive: recorded_pid.is_some_and(alive),
+        recorded_pid,
+    }
+}
+
+/// The verdict on a pid file, cross-checked against the pid of the process that
+/// actually answered on the daemon socket.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PidFileState {
+    /// No pid file at the resolved path.
+    Absent,
+    /// A file exists but holds no parseable pid.
+    Unparseable,
+    /// The recorded pid names the process that answered IPC. Healthy.
+    Matches(u32),
+    /// The recorded pid is alive but no socket-owner pid was available to
+    /// cross-check against (an unreachable daemon, or one older than #4774's
+    /// `daemon_pid` status field). Not an anomaly — just unconfirmed.
+    Unverified(u32),
+    /// The recorded pid is **not a live process**. Stale.
+    Dead(u32),
+    /// The recorded pid is alive but is a *different* process than the one
+    /// answering on the socket — the exact 2026-07-31 signature (`13724` on
+    /// disk, `99917` answering). Stale.
+    Mismatch { recorded: u32, socket_owner: u32 },
+}
+
+impl PidFileState {
+    /// Whether this verdict means the file must not be trusted as a liveness
+    /// signal. [`PidFileState::Absent`] is deliberately **not** stale: an
+    /// absent file makes no false claim, and a daemon launched outside the
+    /// managed start path legitimately has none.
+    #[must_use]
+    pub fn is_stale(&self) -> bool {
+        matches!(
+            self,
+            PidFileState::Unparseable | PidFileState::Dead(_) | PidFileState::Mismatch { .. }
+        )
+    }
+
+    /// Machine-readable verdict for `--json` consumers.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PidFileState::Absent => "absent",
+            PidFileState::Unparseable => "unparseable",
+            PidFileState::Matches(_) => "matches",
+            PidFileState::Unverified(_) => "unverified",
+            PidFileState::Dead(_) => "dead",
+            PidFileState::Mismatch { .. } => "mismatch",
+        }
+    }
+
+    /// The operator-facing note for a *stale* verdict — `None` for the
+    /// non-anomalous ones, so callers can `if let Some(note) = …` and stay
+    /// silent when there is nothing wrong.
+    #[must_use]
+    pub fn note(&self, path: &Path) -> Option<String> {
+        match self {
+            PidFileState::Absent | PidFileState::Matches(_) | PidFileState::Unverified(_) => None,
+            PidFileState::Unparseable => Some(format!(
+                "STALE pid file {}: present but holds no parseable pid — do not trust it as a \
+                 liveness signal (#4774)",
+                path.display()
+            )),
+            PidFileState::Dead(pid) => Some(format!(
+                "STALE pid file {}: records pid {pid}, which is not a live process — do not trust \
+                 it as a liveness signal (#4774)",
+                path.display()
+            )),
+            PidFileState::Mismatch {
+                recorded,
+                socket_owner,
+            } => Some(format!(
+                "STALE pid file {}: records pid {recorded}, but the daemon answering the socket is \
+                 pid {socket_owner} — a supervisor relaunch left it behind (#4774); re-run \
+                 `loom-daemon-start.sh` or roll the daemon to a build that self-writes it",
+                path.display()
+            )),
+        }
+    }
+}
+
+/// The pure cross-check rule: an observation plus the pid of whoever answered
+/// the daemon socket (`None` when unreachable / pre-#4774 daemon).
+#[must_use]
+pub fn classify(obs: &PidFileObservation, socket_owner_pid: Option<u32>) -> PidFileState {
+    let Some(recorded) = obs.recorded_pid else {
+        return if obs.present {
+            PidFileState::Unparseable
+        } else {
+            PidFileState::Absent
+        };
+    };
+    match socket_owner_pid {
+        Some(owner) if owner == recorded => PidFileState::Matches(recorded),
+        Some(owner) => PidFileState::Mismatch {
+            recorded,
+            socket_owner: owner,
+        },
+        // No socket owner to compare against: aliveness is the only signal
+        // left. A dead recorded pid is still positive evidence of staleness.
+        None if obs.recorded_pid_alive => PidFileState::Unverified(recorded),
+        None => PidFileState::Dead(recorded),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    // ---------------- path resolution ----------------
+
+    #[test]
+    fn explicit_env_override_wins_over_every_other_tier() {
+        let resolved = resolve_pid_file_path_from(
+            Some("/explicit/loom.pid".to_string()),
+            Some("/machine/checkout".to_string()),
+            Some("/repo".to_string()),
+            Some(PathBuf::from("/home/.loom")),
+        );
+        assert_eq!(resolved, Some(PathBuf::from("/explicit/loom.pid")));
+    }
+
+    #[test]
+    fn empty_env_values_are_ignored_not_honored() {
+        // An exported-but-empty `LOOM_PID_FILE` must not resolve to `""`.
+        let resolved = resolve_pid_file_path_from(
+            Some(String::new()),
+            Some(String::new()),
+            Some("/repo".to_string()),
+            Some(PathBuf::from("/home/.loom")),
+        );
+        assert_eq!(resolved, Some(PathBuf::from("/repo/.loom/.daemon.pid")));
+    }
+
+    #[test]
+    fn machine_mode_resolves_under_the_machine_loom_dir() {
+        // Machine mode keeps runtime state in the machine-level loom dir even
+        // though a repo workspace is also set (start script's
+        // `DAEMON_STATE_HOME="$HOME/.loom"`).
+        let resolved = resolve_pid_file_path_from(
+            None,
+            Some("/machine/checkout".to_string()),
+            Some("/repo".to_string()),
+            Some(PathBuf::from("/home/.loom")),
+        );
+        assert_eq!(resolved, Some(PathBuf::from("/home/.loom/.daemon.pid")));
+    }
+
+    #[test]
+    fn repo_mode_resolves_under_the_workspace_loom_dir() {
+        let resolved = resolve_pid_file_path_from(
+            None,
+            None,
+            Some("/repo".to_string()),
+            Some(PathBuf::from("/home/.loom")),
+        );
+        assert_eq!(resolved, Some(PathBuf::from("/repo/.loom/.daemon.pid")));
+    }
+
+    #[test]
+    fn falls_back_to_the_loom_dir_when_nothing_else_is_set() {
+        let resolved =
+            resolve_pid_file_path_from(None, None, None, Some(PathBuf::from("/home/.loom")));
+        assert_eq!(resolved, Some(PathBuf::from("/home/.loom/.daemon.pid")));
+    }
+
+    #[test]
+    fn unresolvable_when_no_loom_dir_and_no_overrides() {
+        assert_eq!(resolve_pid_file_path_from(None, None, None, None), None);
+    }
+
+    // ---------------- claiming ----------------
+
+    #[test]
+    fn claim_writes_the_pid_and_reports_no_previous_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(PID_FILENAME);
+        let outcome = claim_at(&path, 4242);
+        assert_eq!(
+            outcome,
+            ClaimOutcome::Claimed {
+                path: path.clone(),
+                previous: None
+            }
+        );
+        assert_eq!(fs::read_to_string(&path).unwrap().trim(), "4242");
+    }
+
+    #[test]
+    fn claim_overwrites_a_stale_pid_and_reports_the_previous_one() {
+        // The core #4774 scenario: a supervisor relaunch finds the prior
+        // process's pid on disk and must replace it.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(PID_FILENAME);
+        fs::write(&path, "13724\n").unwrap();
+        let outcome = claim_at(&path, 99917);
+        assert_eq!(
+            outcome,
+            ClaimOutcome::Claimed {
+                path: path.clone(),
+                previous: Some(13724)
+            }
+        );
+        assert_eq!(fs::read_to_string(&path).unwrap().trim(), "99917");
+    }
+
+    #[test]
+    fn claim_creates_missing_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join(".loom").join(PID_FILENAME);
+        assert!(matches!(claim_at(&path, 7), ClaimOutcome::Claimed { .. }));
+        assert_eq!(read_pid_file(&path), Some(7));
+    }
+
+    #[test]
+    fn claim_leaves_no_temp_files_behind() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(PID_FILENAME);
+        assert!(matches!(claim_at(&path, 11), ClaimOutcome::Claimed { .. }));
+        let leftovers: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n != PID_FILENAME)
+            .collect();
+        assert!(leftovers.is_empty(), "atomic write leaked: {leftovers:?}");
+    }
+
+    #[test]
+    fn write_failure_is_reported_not_panicked() {
+        // A path whose parent cannot be created (a *file* stands where the
+        // directory would go) exercises the non-fatal error branch.
+        let dir = tempfile::tempdir().unwrap();
+        let blocker = dir.path().join("blocker");
+        fs::write(&blocker, "not a directory").unwrap();
+        let path = blocker.join(PID_FILENAME);
+        assert!(matches!(claim_at(&path, 5), ClaimOutcome::WriteFailed { .. }));
+    }
+
+    // ---------------- stale detection ----------------
+
+    fn obs(path: &Path, recorded: Option<u32>, alive: bool) -> PidFileObservation {
+        PidFileObservation {
+            path: path.to_path_buf(),
+            present: recorded.is_some(),
+            recorded_pid: recorded,
+            recorded_pid_alive: alive,
+        }
+    }
+
+    #[test]
+    fn observation_reads_disk_and_liveness() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(PID_FILENAME);
+        fs::write(&path, "321\n").unwrap();
+        let observed = observe_with(&path, |pid| pid == 321);
+        assert!(observed.present);
+        assert_eq!(observed.recorded_pid, Some(321));
+        assert!(observed.recorded_pid_alive);
+    }
+
+    #[test]
+    fn absent_file_is_not_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(PID_FILENAME);
+        let observed = observe_with(&path, |_| true);
+        let state = classify(&observed, Some(99917));
+        assert_eq!(state, PidFileState::Absent);
+        assert!(!state.is_stale());
+        assert_eq!(state.note(&path), None);
+    }
+
+    #[test]
+    fn garbage_contents_are_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(PID_FILENAME);
+        fs::write(&path, "not-a-pid").unwrap();
+        let state = classify(&observe_with(&path, |_| true), Some(1));
+        assert_eq!(state, PidFileState::Unparseable);
+        assert!(state.is_stale());
+        assert!(state.note(&path).is_some());
+    }
+
+    #[test]
+    fn matching_socket_owner_is_healthy() {
+        let path = PathBuf::from("/tmp/x/.daemon.pid");
+        let state = classify(&obs(&path, Some(99917), true), Some(99917));
+        assert_eq!(state, PidFileState::Matches(99917));
+        assert!(!state.is_stale());
+        assert_eq!(state.note(&path), None);
+    }
+
+    #[test]
+    fn different_socket_owner_is_a_mismatch() {
+        // The 2026-07-31 incident, exactly.
+        let path = PathBuf::from("/tmp/x/.daemon.pid");
+        let state = classify(&obs(&path, Some(13724), true), Some(99917));
+        assert_eq!(
+            state,
+            PidFileState::Mismatch {
+                recorded: 13724,
+                socket_owner: 99917
+            }
+        );
+        assert!(state.is_stale());
+        let note = state.note(&path).unwrap();
+        assert!(note.contains("13724") && note.contains("99917"), "note: {note}");
+    }
+
+    #[test]
+    fn a_mismatch_wins_even_when_the_recorded_pid_is_dead() {
+        // Both anomalies at once: the socket-owner comparison is the stronger
+        // statement, so it is what the operator is told.
+        let path = PathBuf::from("/tmp/x/.daemon.pid");
+        let state = classify(&obs(&path, Some(13724), false), Some(99917));
+        assert!(matches!(state, PidFileState::Mismatch { .. }));
+    }
+
+    #[test]
+    fn dead_recorded_pid_without_a_socket_owner_is_stale() {
+        let path = PathBuf::from("/tmp/x/.daemon.pid");
+        let state = classify(&obs(&path, Some(13724), false), None);
+        assert_eq!(state, PidFileState::Dead(13724));
+        assert!(state.is_stale());
+    }
+
+    #[test]
+    fn live_recorded_pid_without_a_socket_owner_is_unverified_not_stale() {
+        let path = PathBuf::from("/tmp/x/.daemon.pid");
+        let state = classify(&obs(&path, Some(13724), true), None);
+        assert_eq!(state, PidFileState::Unverified(13724));
+        assert!(!state.is_stale());
+        assert_eq!(state.note(&path), None);
+    }
+}

--- a/loom-daemon/src/health.rs
+++ b/loom-daemon/src/health.rs
@@ -282,6 +282,18 @@ pub struct HealthInputs {
     pub install_state: Option<InstallStateReport>,
     /// Live `loom-daemon` pids from `pgrep` — the third liveness signal.
     pub pgrep_pids: Vec<u32>,
+    /// A host-local observation of the daemon pid file (Issue #4774), taken
+    /// against the path the *daemon* reported ([`DaemonStatusReport::pid_file`])
+    /// when it was reachable, else this process's own resolution. `None` when
+    /// no path could be resolved at all.
+    ///
+    /// The pid file is **advisory input, cross-checked but not trusted** —
+    /// exactly the rule #4761's collector spec was refined to on 2026-07-31,
+    /// after a two-relaunch-stale file and a name-matched `pgrep` hit a `/tmp`
+    /// test stub in the same battery. [`assess_liveness`] never *derives*
+    /// liveness from this field; it only reports the file's disagreement with
+    /// the process that actually answered.
+    pub pid_file: Option<crate::daemon_pidfile::PidFileObservation>,
     /// Whether a `.ranking` file was found in the resolved pool.
     pub ranking_present: bool,
     /// Age of the resolved pool's `.ranking` in seconds, when readable.
@@ -418,22 +430,52 @@ pub fn summarize_role_ticks(records: &[RoleTickRecord], since: DateTime<Utc>) ->
 #[must_use]
 pub fn assess_liveness(inputs: &HealthInputs) -> HealthSection {
     // 1. A daemon that just answered IPC is alive. No local probe overrules it.
-    if inputs.status.is_some() {
-        let pid = inputs.install_state.as_ref().and_then(|r| r.pid);
-        return HealthSection::new(
-            "liveness",
-            Verdict::Green,
-            match pid {
-                Some(p) => format!("daemon alive — IPC round-trip ok (pid {p})"),
-                None => "daemon alive — IPC round-trip ok".to_string(),
-            },
-            serde_json::json!({
-                "signal": "ipc",
-                "ipc_reachable": true,
-                "pid": pid,
-                "pgrep_pids": inputs.pgrep_pids,
-            }),
-        );
+    if let Some(status) = &inputs.status {
+        // The pid the daemon itself reported (#4774) is authoritative — it is
+        // `std::process::id()` taken inside the answering process. Fall back to
+        // the install-state probe's pid only for a pre-#4774 daemon.
+        let socket_owner = status.daemon_pid;
+        let pid = socket_owner.or_else(|| inputs.install_state.as_ref().and_then(|r| r.pid));
+
+        // Cross-check the pid file against that owner (#4774 AC3). A daemon
+        // that is demonstrably alive with a pid file naming someone else is
+        // still GREEN on *liveness itself* — but the file is a booby trap for
+        // every other consumer that reads it (the watchdog, the #4694
+        // fallback, an operator's `cat`), so the section degrades and names it.
+        let pid_state = inputs
+            .pid_file
+            .as_ref()
+            .map(|obs| crate::daemon_pidfile::classify(obs, socket_owner));
+        // `note()` is `None` for every non-anomalous verdict, so it is the
+        // single gate on both the message and the degrade below — no separate
+        // `is_stale()` test that could drift out of step with it.
+        let stale_note = inputs
+            .pid_file
+            .as_ref()
+            .zip(pid_state.as_ref())
+            .and_then(|(obs, state)| state.note(&obs.path));
+
+        let base = match pid {
+            Some(p) => format!("daemon alive — IPC round-trip ok (pid {p})"),
+            None => "daemon alive — IPC round-trip ok".to_string(),
+        };
+        let detail = serde_json::json!({
+            "signal": "ipc",
+            "ipc_reachable": true,
+            "pid": pid,
+            "socket_owner_pid": socket_owner,
+            "pgrep_pids": inputs.pgrep_pids,
+            "pid_file": inputs.pid_file.as_ref().map(|o| o.path.display().to_string()),
+            "pid_file_recorded_pid": inputs.pid_file.as_ref().and_then(|o| o.recorded_pid),
+            "pid_file_state": pid_state.as_ref().map(crate::daemon_pidfile::PidFileState::as_str),
+        });
+
+        return match stale_note {
+            Some(note) => {
+                HealthSection::new("liveness", Verdict::Degraded, format!("{base}; {note}"), detail)
+            }
+            None => HealthSection::new("liveness", Verdict::Green, base, detail),
+        };
     }
 
     let ipc_error = inputs
@@ -451,8 +493,13 @@ pub fn assess_liveness(inputs: &HealthInputs) -> HealthSection {
                     "liveness",
                     Verdict::Degraded,
                     format!(
-                        "process alive, still STARTING (age {}s) — IPC not bound yet: {ipc_error}",
-                        report.process_age_secs.unwrap_or_default()
+                        "process alive, still STARTING (age {}s) — IPC not bound yet:                          {ipc_error}{}",
+                        report.process_age_secs.unwrap_or_default(),
+                        // A daemon that has not bound yet has not claimed the
+                        // pid file yet either (#4774 writes it after the bind),
+                        // so a disagreement here is expected-and-transient —
+                        // reported, but not dressed up as a fault.
+                        suffix_note(report.pid_file_stale_note.as_deref())
                     ),
                     liveness_detail_json("install-state", report, inputs, false),
                 );
@@ -462,7 +509,8 @@ pub fn assess_liveness(inputs: &HealthInputs) -> HealthSection {
                     "liveness",
                     Verdict::Degraded,
                     format!(
-                        "process ALIVE but not answering IPC — NOT dead ({detail}); ipc: {ipc_error}"
+                        "process ALIVE but not answering IPC — NOT dead ({detail}); ipc:                          {ipc_error}{}",
+                        suffix_note(report.pid_file_stale_note.as_deref())
                     ),
                     liveness_detail_json("install-state", report, inputs, false),
                 );
@@ -541,6 +589,13 @@ pub fn assess_liveness(inputs: &HealthInputs) -> HealthSection {
     }
 }
 
+/// Append an operator-facing pid-file note (#4774) to a summary line, or
+/// nothing at all when there is no anomaly — so the overwhelmingly common
+/// healthy case reads exactly as it did before this issue.
+fn suffix_note(note: Option<&str>) -> String {
+    note.map(|n| format!("; {n}")).unwrap_or_default()
+}
+
 fn liveness_detail_json(
     signal: &str,
     report: &InstallStateReport,
@@ -557,6 +612,14 @@ fn liveness_detail_json(
         "process_age_secs": report.process_age_secs,
         "pgrep_pids": inputs.pgrep_pids,
         "declared_dead": dead,
+        // #4774: the pid file as *evidence*, never as the verdict. On this
+        // unreachable path there is no `daemon_pid` to arbitrate with, so the
+        // note (when any) comes from the install-state probe's launchd
+        // cross-check, and the raw observation is carried for `--json`.
+        "pid_file": inputs.pid_file.as_ref().map(|o| o.path.display().to_string()),
+        "pid_file_recorded_pid": inputs.pid_file.as_ref().and_then(|o| o.recorded_pid),
+        "pid_file_recorded_pid_alive": inputs.pid_file.as_ref().map(|o| o.recorded_pid_alive),
+        "pid_file_stale_note": report.pid_file_stale_note,
     })
 }
 
@@ -997,6 +1060,7 @@ mod tests {
             process_age_secs: Some(9),
             startup_grace_threshold_secs: Some(45),
             watchdog_log_path: PathBuf::from("/tmp/watchdog.log"),
+            pid_file_stale_note: None,
         }
     }
 
@@ -1033,6 +1097,7 @@ mod tests {
             ipc_error: None,
             install_state: Some(install_report(InstallState::AliveButUnresponsive)),
             pgrep_pids: vec![4321],
+            pid_file: None,
             ranking_present: true,
             ranking_age_secs: Some(240),
             pipeline: Some(vec![RepoPipelineSnapshot {
@@ -1060,6 +1125,140 @@ mod tests {
         let section = assess_liveness(&inputs);
         assert_eq!(section.verdict, Verdict::Green);
         assert_eq!(section.detail["signal"], "ipc");
+    }
+
+    // ===================================================================
+    // #4774 regression pins — the pid file is advisory, cross-checked
+    // ===================================================================
+
+    /// Build a pid-file observation for the assess tests.
+    fn pid_obs(recorded: Option<u32>, alive: bool) -> crate::daemon_pidfile::PidFileObservation {
+        crate::daemon_pidfile::PidFileObservation {
+            path: PathBuf::from("/home/.loom/.daemon.pid"),
+            present: recorded.is_some(),
+            recorded_pid: recorded,
+            recorded_pid_alive: alive,
+        }
+    }
+
+    /// An inputs fixture whose daemon answered IPC and reported its own pid —
+    /// the post-#4774 wire shape every assertion below builds on.
+    fn reachable_inputs_with_socket_owner(pid: u32) -> HealthInputs {
+        let mut inputs = healthy_inputs();
+        let mut status = healthy_status();
+        status.daemon_pid = Some(pid);
+        inputs.status = Some(status);
+        inputs
+    }
+
+    /// The healthy case must be *unchanged* by #4774: a pid file naming the
+    /// process that answered adds no note and no verdict change.
+    #[test]
+    fn a_pid_file_matching_the_socket_owner_stays_green() {
+        let mut inputs = reachable_inputs_with_socket_owner(99917);
+        inputs.pid_file = Some(pid_obs(Some(99917), true));
+        let section = assess_liveness(&inputs);
+        assert_eq!(section.verdict, Verdict::Green);
+        assert_eq!(section.detail["pid_file_state"], "matches");
+        assert_eq!(section.detail["socket_owner_pid"], 99917);
+        assert!(!section.summary.contains("STALE"), "{}", section.summary);
+    }
+
+    /// THE #4774 pin. The 2026-07-31 incident, exactly: the file says 13724,
+    /// the daemon answering the socket says 99917. Liveness is not in doubt —
+    /// the daemon just answered — but the file is a booby trap for every other
+    /// consumer, so the section degrades and names both pids.
+    #[test]
+    fn a_pid_file_naming_a_different_process_degrades_and_is_named() {
+        let mut inputs = reachable_inputs_with_socket_owner(99917);
+        inputs.pid_file = Some(pid_obs(Some(13724), true));
+        let section = assess_liveness(&inputs);
+        assert_eq!(
+            section.verdict,
+            Verdict::Degraded,
+            "a stale pid file must not be reported as healthy: {}",
+            section.summary
+        );
+        assert_eq!(section.detail["pid_file_state"], "mismatch");
+        assert!(
+            section.summary.contains("13724") && section.summary.contains("99917"),
+            "the summary must name both the recorded and the real pid: {}",
+            section.summary
+        );
+        // Liveness itself is still positively established.
+        assert_eq!(section.detail["ipc_reachable"], true);
+    }
+
+    /// A reachable daemon whose pid file records a pid that is not a live
+    /// process at all — a relaunch after the old pid was recycled away.
+    #[test]
+    fn a_pid_file_naming_a_dead_process_degrades() {
+        let mut inputs = reachable_inputs_with_socket_owner(99917);
+        inputs.pid_file = Some(pid_obs(Some(13724), false));
+        let section = assess_liveness(&inputs);
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert_eq!(section.detail["pid_file_state"], "mismatch");
+    }
+
+    /// An absent pid file makes no false claim, so it is not an anomaly — a
+    /// daemon started outside the managed start path legitimately has none.
+    #[test]
+    fn an_absent_pid_file_does_not_degrade_a_reachable_daemon() {
+        let mut inputs = reachable_inputs_with_socket_owner(99917);
+        inputs.pid_file = Some(pid_obs(None, false));
+        let section = assess_liveness(&inputs);
+        assert_eq!(section.verdict, Verdict::Green);
+        assert_eq!(section.detail["pid_file_state"], "absent");
+    }
+
+    /// Backward compatibility: a **pre-#4774 daemon** answers without a
+    /// `daemon_pid`, so there is nothing to cross-check against. That must read
+    /// as "unverified", never as a mismatch — an upgrade-order false alarm would
+    /// be worse than the bug this issue fixes, since it would fire on every
+    /// fleet host until the last daemon rolled.
+    #[test]
+    fn a_pre_4774_daemon_never_produces_a_false_mismatch() {
+        let mut inputs = healthy_inputs();
+        let mut status = healthy_status();
+        status.daemon_pid = None;
+        inputs.status = Some(status);
+        inputs.pid_file = Some(pid_obs(Some(13724), true));
+        let section = assess_liveness(&inputs);
+        assert_eq!(section.verdict, Verdict::Green);
+        assert_eq!(section.detail["pid_file_state"], "unverified");
+        assert!(section.detail["socket_owner_pid"].is_null());
+    }
+
+    /// The daemon's self-reported pid outranks the install-state probe's pid
+    /// for the rendered `pid` — it is `std::process::id()` from inside the
+    /// answering process, versus a launchd/pid-file inference from outside.
+    #[test]
+    fn the_reported_pid_prefers_the_daemons_own_over_the_probes() {
+        // `install_report` pins the probe's pid at 4321.
+        let inputs = reachable_inputs_with_socket_owner(99917);
+        let section = assess_liveness(&inputs);
+        assert_eq!(section.detail["pid"], 99917);
+        assert!(section.summary.contains("99917"), "{}", section.summary);
+    }
+
+    /// On the *unreachable* path there is no `daemon_pid` to arbitrate with, so
+    /// the note comes from the install-state probe's own launchd cross-check —
+    /// and it must reach the operator-facing summary, not just the JSON.
+    #[test]
+    fn an_unreachable_daemons_stale_note_reaches_the_summary() {
+        let mut inputs = healthy_inputs();
+        inputs.status = None;
+        inputs.ipc_error = Some("round-trip timed out".to_string());
+        let mut report = install_report(InstallState::AliveButUnresponsive);
+        report.pid_file_stale_note = Some("STALE pid file /home/.loom/.daemon.pid: …".to_string());
+        inputs.install_state = Some(report);
+        let section = assess_liveness(&inputs);
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(
+            section.summary.contains("STALE pid file"),
+            "the install-state probe's #4774 note must be surfaced: {}",
+            section.summary
+        );
     }
 
     /// The launchd domain probe alone can never produce a DEAD verdict: with

--- a/loom-daemon/src/health.rs
+++ b/loom-daemon/src/health.rs
@@ -493,7 +493,7 @@ pub fn assess_liveness(inputs: &HealthInputs) -> HealthSection {
                     "liveness",
                     Verdict::Degraded,
                     format!(
-                        "process alive, still STARTING (age {}s) — IPC not bound yet:                          {ipc_error}{}",
+                        "process alive, still STARTING (age {}s) — IPC not bound yet: {ipc_error}{}",
                         report.process_age_secs.unwrap_or_default(),
                         // A daemon that has not bound yet has not claimed the
                         // pid file yet either (#4774 writes it after the bind),
@@ -509,7 +509,7 @@ pub fn assess_liveness(inputs: &HealthInputs) -> HealthSection {
                     "liveness",
                     Verdict::Degraded,
                     format!(
-                        "process ALIVE but not answering IPC — NOT dead ({detail}); ipc:                          {ipc_error}{}",
+                        "process ALIVE but not answering IPC — NOT dead ({detail}); ipc: {ipc_error}{}",
                         suffix_note(report.pid_file_stale_note.as_deref())
                     ),
                     liveness_detail_json("install-state", report, inputs, false),
@@ -1189,10 +1189,13 @@ mod tests {
         assert_eq!(section.detail["ipc_reachable"], true);
     }
 
-    /// A reachable daemon whose pid file records a pid that is not a live
-    /// process at all — a relaunch after the old pid was recycled away.
+    /// A reachable daemon whose pid file records a pid that is neither the
+    /// socket owner nor a live process at all — a relaunch after the old pid
+    /// was recycled away. `classify()` still calls this "mismatch" (a live
+    /// socket owner is known, so it always outranks the file's own liveness
+    /// check) — the name reflects the verdict actually produced, not "dead".
     #[test]
-    fn a_pid_file_naming_a_dead_process_degrades() {
+    fn a_pid_file_naming_a_mismatched_dead_process_degrades() {
         let mut inputs = reachable_inputs_with_socket_owner(99917);
         inputs.pid_file = Some(pid_obs(Some(13724), false));
         let section = assess_liveness(&inputs);
@@ -1259,6 +1262,10 @@ mod tests {
             "the install-state probe's #4774 note must be surfaced: {}",
             section.summary
         );
+        // Regression pin: a hand-joined literal + suffix_note() must not
+        // leave a double-space run in the operator-facing summary — fmt and
+        // clippy cannot see this class of bug, only a runtime assertion can.
+        assert!(!section.summary.contains("  "), "double space in summary: {}", section.summary);
     }
 
     /// The launchd domain probe alone can never produce a DEAD verdict: with
@@ -1288,6 +1295,9 @@ mod tests {
         let section = assess_liveness(&inputs);
         assert_eq!(section.verdict, Verdict::Degraded);
         assert!(section.summary.contains("NOT dead"));
+        // Regression pin: the hand-joined literal must not leave a double
+        // space before {ipc_error} — fmt/clippy cannot see this class of bug.
+        assert!(!section.summary.contains("  "), "double space in summary: {}", section.summary);
     }
 
     #[test]
@@ -1300,6 +1310,9 @@ mod tests {
         let section = assess_liveness(&inputs);
         assert_eq!(section.verdict, Verdict::Degraded);
         assert!(section.summary.contains("STARTING"));
+        // Regression pin: the hand-joined literal must not leave a double
+        // space before {ipc_error} — fmt/clippy cannot see this class of bug.
+        assert!(!section.summary.contains("  "), "double space in summary: {}", section.summary);
     }
 
     /// Only when *all three* signals are negative is the daemon declared dead.

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -963,6 +963,45 @@ impl IpcServer {
         let listener = UnixListener::bind(&self.socket_path)?;
         log::info!("IPC server listening at {}", self.socket_path.display());
 
+        // Claim the pid file (#4774). THIS is the correct choke point: the bind
+        // above just made this process the confirmed *sole* owner of the socket,
+        // and every supervised relaunch (launchd `KeepAlive:SuccessfulExit`,
+        // systemd `Restart=on-success`, the #4054 restart primitive, the
+        // in-daemon self-update loop, `launchctl kickstart`) reaches it —
+        // whereas none of them re-run `loom-daemon-start.sh`, which was the only
+        // writer before now. Deliberately NOT hoisted next to #4331's marker
+        // healing in `daemon_service.rs`: that call runs *before* the singleton
+        // guard, so a daemon about to be refused would stomp the live
+        // incumbent's pid file with its own doomed pid. Non-fatal in every
+        // branch — a daemon without a pid file beats no daemon.
+        match crate::daemon_pidfile::claim_for_current_process() {
+            crate::daemon_pidfile::ClaimOutcome::Claimed {
+                path,
+                previous: Some(previous),
+            } if previous != std::process::id() => log::warn!(
+                "daemon_pidfile: pid file {} named stale pid {previous} — rewrote it to this \
+                 daemon's pid {} (a supervisor relaunch does not re-run loom-daemon-start.sh, \
+                 #4774)",
+                path.display(),
+                std::process::id()
+            ),
+            crate::daemon_pidfile::ClaimOutcome::Claimed { path, .. } => log::info!(
+                "daemon_pidfile: claimed {} for pid {} (#4774)",
+                path.display(),
+                std::process::id()
+            ),
+            crate::daemon_pidfile::ClaimOutcome::Unresolvable => log::warn!(
+                "daemon_pidfile: could not resolve a pid file path (no LOOM_PID_FILE, \
+                 LOOM_WORKSPACE, LOOM_SOCKET_PATH, or home directory) — liveness cross-checks \
+                 that consult it will have no signal (#4774)"
+            ),
+            crate::daemon_pidfile::ClaimOutcome::WriteFailed { path, error } => log::warn!(
+                "daemon_pidfile: could not write {} — {error}. Continuing without a self-written \
+                 pid file (#4774)",
+                path.display()
+            ),
+        }
+
         loop {
             match listener.accept().await {
                 Ok((stream, _)) => {
@@ -1680,6 +1719,16 @@ pub fn build_daemon_status(
         // "no tick observed", never "nothing happened".
         last_work_finder_tick: crate::work_finder::last_tick_summary(),
         role_tick_records: crate::role_runner::role_tick_records(),
+        // The answering process's own pid + the pid file it claimed at startup
+        // (#4774). `std::process::id()` is deliberately taken HERE, in the
+        // daemon, rather than inferred by the client from a file: it is the
+        // only unforgeable statement of "who owns this socket", and it is what
+        // lets `status`/`health` call a stale `.daemon.pid` stale instead of
+        // trusting it. The path is re-resolved (not cached from the startup
+        // claim) so the report always names the file *this* daemon's
+        // environment points at.
+        daemon_pid: Some(std::process::id()),
+        pid_file: crate::daemon_pidfile::resolve_pid_file_path(),
     }
 }
 
@@ -5375,6 +5424,8 @@ exit 0
                 ok: true,
                 detail: None,
             }],
+            daemon_pid: Some(99917),
+            pid_file: Some(std::path::PathBuf::from("/repo/a/.loom/.daemon.pid")),
         };
         let resp = Response::DaemonStatus(Box::new(report));
         let json = serde_json::to_string(&resp).expect("serialize response");

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -150,6 +150,7 @@ pub mod cpu_headroom;
 pub mod credential_preflight;
 pub mod daemon_heartbeat;
 pub mod daemon_install_state;
+pub mod daemon_pidfile;
 pub mod disk_headroom;
 pub mod epic_state;
 pub mod epic_supervisor;

--- a/loom-daemon/src/serve.rs
+++ b/loom-daemon/src/serve.rs
@@ -618,6 +618,15 @@ async fn handle_health(
         .and_then(|r| r.token_pool_dir.clone())
         .map_or((false, None), |dir| ranking_state(&dir));
 
+    // Pid-file observation (#4774) against the path the daemon itself
+    // reported, falling back to a local resolution for an unreachable /
+    // pre-#4774 daemon — the same precedence `cli::health` uses.
+    let pid_file = report
+        .as_ref()
+        .and_then(|r| r.pid_file.clone())
+        .or_else(crate::daemon_pidfile::resolve_pid_file_path)
+        .map(|path| crate::daemon_pidfile::observe(&path));
+
     let health = crate::health::assess(&crate::health::HealthInputs {
         at: chrono::Utc::now(),
         window: HEALTH_WINDOW,
@@ -625,6 +634,7 @@ async fn handle_health(
         ipc_error,
         install_state: crate::daemon_install_state::probe(),
         pgrep_pids: crate::daemon_install_state::pgrep_daemon_pids(),
+        pid_file,
         ranking_present,
         ranking_age_secs,
         pipeline,
@@ -1193,6 +1203,8 @@ mod tests {
             work_finder_enabled: None,
             last_work_finder_tick: None,
             role_tick_records: vec![],
+            daemon_pid: None,
+            pid_file: None,
         }
     }
 

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -1261,6 +1261,34 @@ pub struct DaemonStatusReport {
     /// pre-#4761 wire data compatible.
     #[serde(default)]
     pub role_tick_records: Vec<RoleTickRecord>,
+    /// The **real OS pid of the process that answered this request** (Issue
+    /// #4774) — i.e. the daemon that actually owns the IPC socket, established
+    /// by `std::process::id()` inside the handler rather than read from any
+    /// file.
+    ///
+    /// This is the ground truth every pid-file consumer was missing. Before
+    /// #4774 the only "daemon pid" available to `status` / `health` came from
+    /// `<state home>/.daemon.pid`, which `loom-daemon-start.sh` wrote once at
+    /// provisioning time and no supervisor relaunch ever refreshed — so a
+    /// stale file was indistinguishable from a correct one. With this field a
+    /// client can cross-check the two ([`crate::daemon_pidfile::classify`])
+    /// and report a mismatch instead of silently trusting the file.
+    /// `#[serde(default)]` keeps pre-#4774 wire data / older daemons
+    /// compatible (an absent field parses as `None` ⇒ "cannot cross-check",
+    /// never a false mismatch).
+    #[serde(default)]
+    pub daemon_pid: Option<u32>,
+    /// The pid file path this daemon resolved and claimed at startup (Issue
+    /// #4774), via [`crate::daemon_pidfile::resolve_pid_file_path`]. `None`
+    /// when no path could be resolved, and for a pre-#4774 wire payload.
+    ///
+    /// Reported so a client cross-checks the file the **daemon** actually
+    /// writes rather than one re-derived from the CLI process's own
+    /// environment — the same rule [`Self::token_pool_dir`] (#4292) follows,
+    /// and for the same reason: `status` / `health` are routinely run from a
+    /// different cwd (and a different `LOOM_*` env) than the daemon.
+    #[serde(default)]
+    pub pid_file: Option<PathBuf>,
 }
 
 /// One work-finder tick's dispatch/skip tally, stamped with the wall-clock

--- a/loom-daemon/tests/integration_singleton_guard.rs
+++ b/loom-daemon/tests/integration_singleton_guard.rs
@@ -111,9 +111,14 @@ fn spawn_daemon_and_wait(
     workspace: &Path,
     wait: Duration,
 ) -> (Child, RefusedStart) {
-    let mut child = daemon_command(socket_path, workspace)
-        .spawn()
-        .expect("Failed to spawn second daemon");
+    spawn_and_wait(daemon_command(socket_path, workspace), wait)
+}
+
+/// [`spawn_daemon_and_wait`]'s core, taking an already-built [`Command`] so a
+/// caller can add env the standard fixture does not set (#4774's
+/// `LOOM_PID_FILE`) without duplicating the stderr-timing machinery.
+fn spawn_and_wait(mut cmd: Command, wait: Duration) -> (Child, RefusedStart) {
+    let mut child = cmd.spawn().expect("Failed to spawn second daemon");
 
     // (refusal timestamp, accumulated stderr)
     let observed: Arc<Mutex<(Option<Instant>, String)>> =
@@ -318,4 +323,216 @@ async fn test_stale_socket_is_reclaimed() {
     // Teardown.
     let _ = child.kill();
     let _ = child.wait();
+}
+
+// ============================================================================
+// Issue #4774 — the daemon owns its pid file write
+// ============================================================================
+//
+// These live in the singleton-guard suite on purpose: #4774's whole design
+// hinges on *where* the write sits relative to the guard. The pid file is
+// claimed immediately after `UnixListener::bind` succeeds, which makes the two
+// properties below structural rather than incidental — a daemon that binds has
+// necessarily passed the guard, and a daemon the guard refuses never reaches
+// the write at all. Testing them anywhere else would test the claim function
+// instead of the invariant.
+
+/// How long to wait for a pid file to name an expected pid. Same liveness-bound
+/// reasoning as [`DAEMON_BIND_WAIT`] — the poll returns the moment the file
+/// agrees, so a generous ceiling costs a passing run nothing.
+const PID_FILE_WAIT: Duration = Duration::from_secs(60);
+
+/// The pid recorded in `pid_file`, or `None` when it is missing/unparseable.
+fn recorded_pid(pid_file: &Path) -> Option<u32> {
+    std::fs::read_to_string(pid_file)
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+}
+
+/// Poll until `socket_path` is a *bound socket*, panicking if `child` exits
+/// first (a daemon that refused when it should have started) or the bind budget
+/// elapses. Mirrors `test_stale_socket_is_reclaimed`'s loop.
+fn wait_for_bind(child: &mut Child, socket_path: &Path, what: &str) {
+    let start = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait().expect("try_wait failed") {
+            panic!("{what} should have started and bound the socket, but exited ({status:?})");
+        }
+        let bound = std::fs::metadata(socket_path)
+            .map(|m| m.file_type().is_socket())
+            .unwrap_or(false);
+        if bound {
+            return;
+        }
+        if start.elapsed() > DAEMON_BIND_WAIT {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("{what} did not bind the socket within {}s", DAEMON_BIND_WAIT.as_secs());
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+/// Poll until `pid_file` records `expected`, returning whatever it actually held
+/// when the budget elapsed. The bind and the pid-file claim are separate
+/// statements in `IpcServer::run`, so the socket can exist a beat before the
+/// file is rewritten — this waits for the second event rather than racing it.
+fn wait_for_recorded_pid(pid_file: &Path, expected: u32) -> Option<u32> {
+    let start = Instant::now();
+    loop {
+        let observed = recorded_pid(pid_file);
+        if observed == Some(expected) || start.elapsed() > PID_FILE_WAIT {
+            return observed;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+/// AC4 regression: a **supervisor-style relaunch** — the same binary re-spawned
+/// with the same baked-in env, with `loom-daemon-start.sh` nowhere in the
+/// picture — must leave a pid file naming the *new* process.
+///
+/// This is the exact 2026-07-31 incident reduced to two processes. Before
+/// #4774 the pid file was written only by the start script at provisioning
+/// time, so every launchd `KeepAlive` respawn, `systemd Restart=`, restart
+/// primitive, and self-update roll left it naming a pid that no longer existed
+/// — and every liveness cross-check that consulted it inherited the lie.
+#[tokio::test]
+#[serial]
+async fn test_supervisor_style_relaunch_rewrites_the_pid_file() {
+    setup();
+
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let socket_path = temp_dir.path().join("daemon.sock");
+    let pid_file = temp_dir.path().join(".daemon.pid");
+
+    // Seed the incident's shape: a pid file left behind by an earlier
+    // generation, naming a pid this daemon will not have.
+    std::fs::write(&pid_file, "13724\n").expect("seed stale pid file");
+
+    // --- Generation 1: the daemon the start script provisioned. ---
+    let mut first = daemon_command(&socket_path, temp_dir.path())
+        .env("LOOM_PID_FILE", &pid_file)
+        .spawn()
+        .expect("spawn first daemon");
+    wait_for_bind(&mut first, &socket_path, "first daemon");
+    let first_pid = first.id();
+    assert_eq!(
+        wait_for_recorded_pid(&pid_file, first_pid),
+        Some(first_pid),
+        "a daemon that binds the socket must claim the pid file for itself, replacing the \
+         seeded stale pid 13724"
+    );
+
+    // --- The supervisor's trigger: an ungraceful death. --------------------
+    // `kill -9` specifically, not a graceful `Shutdown`: it is what a crash,
+    // an OOM kill, and the `RestartDaemon` primitive's teardown all look like
+    // to the file, and it leaves the socket behind as a stale regular entry
+    // for generation 2 to reclaim.
+    let _ = first.kill();
+    let _ = first.wait();
+    assert_eq!(
+        recorded_pid(&pid_file),
+        Some(first_pid),
+        "a killed daemon does not get to clean up — the file still names it, which is exactly \
+         the state the relaunch must correct"
+    );
+
+    // --- Generation 2: the relaunch. --------------------------------------
+    // Same binary, same socket, same `LOOM_PID_FILE`, no start script — a
+    // faithful stand-in for `KeepAlive`/`Restart=` re-exec'ing the plist/unit
+    // command with its render-time environment.
+    let mut second = daemon_command(&socket_path, temp_dir.path())
+        .env("LOOM_PID_FILE", &pid_file)
+        .spawn()
+        .expect("spawn relaunched daemon");
+    wait_for_bind(&mut second, &socket_path, "relaunched daemon");
+    let second_pid = second.id();
+    assert_ne!(
+        second_pid, first_pid,
+        "the relaunch must be a genuinely new process for this test to mean anything"
+    );
+
+    let observed = wait_for_recorded_pid(&pid_file, second_pid);
+    // Teardown before asserting, so a failure does not also leak a daemon.
+    let _ = second.kill();
+    let _ = second.wait();
+
+    assert_eq!(
+        observed,
+        Some(second_pid),
+        "THE #4774 REGRESSION: after a supervisor-style relaunch the pid file must name the new \
+         daemon ({second_pid}), not the dead one ({first_pid}). A stale value here means the \
+         daemon is once again relying on `loom-daemon-start.sh` to write a file no relaunch \
+         path re-runs it to write."
+    );
+}
+
+/// The AC edge case, and the reason the claim sits *after* the bind rather than
+/// beside #4331's marker healing: a daemon the singleton guard **refuses** must
+/// leave the live incumbent's pid file completely untouched.
+///
+/// Written as a hazard test, not a happy path. Hoisting the claim to
+/// `daemon_service.rs`'s pre-guard startup block — the obvious place, since
+/// that is where the autonomy-desired marker heals — would make the refused
+/// process stomp the incumbent's correct pid with its own doomed one on the way
+/// out, converting the guard's "refuse without disturbing the incumbent"
+/// contract into active corruption.
+#[tokio::test]
+#[serial]
+async fn test_a_refused_daemon_does_not_overwrite_the_incumbents_pid_file() {
+    setup();
+
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let socket_path = temp_dir.path().join("daemon.sock");
+    let pid_file = temp_dir.path().join(".daemon.pid");
+
+    // The incumbent binds the socket and claims the pid file.
+    let mut incumbent = daemon_command(&socket_path, temp_dir.path())
+        .env("LOOM_PID_FILE", &pid_file)
+        .spawn()
+        .expect("spawn incumbent daemon");
+    wait_for_bind(&mut incumbent, &socket_path, "incumbent daemon");
+    let incumbent_pid = incumbent.id();
+    assert_eq!(
+        wait_for_recorded_pid(&pid_file, incumbent_pid),
+        Some(incumbent_pid),
+        "incumbent must claim the pid file before the interloper is introduced"
+    );
+
+    // A second daemon on the SAME socket AND the same pid file — the strongest
+    // form of the hazard, since a pre-guard write would have nothing to miss.
+    let interloper_ws = tempfile::TempDir::new().expect("temp dir for interloper");
+    let mut cmd = daemon_command(&socket_path, interloper_ws.path());
+    cmd.env("LOOM_PID_FILE", &pid_file);
+    let (mut child, refused) = spawn_and_wait(cmd, DAEMON_REFUSAL_WAIT);
+
+    let exited = refused.exit_at.is_some();
+    if !exited {
+        let _ = child.kill();
+    }
+    let _ = child.wait();
+
+    // Read the file back BEFORE tearing the incumbent down.
+    let after_refusal = recorded_pid(&pid_file);
+    let _ = incumbent.kill();
+    let _ = incumbent.wait();
+
+    assert!(
+        exited,
+        "the interloper should have been refused and exited; stderr:\n{}",
+        refused.stderr
+    );
+    assert!(
+        refused.stderr.contains(REFUSAL_MARKER),
+        "the interloper should have printed the singleton refusal; stderr:\n{}",
+        refused.stderr
+    );
+    assert_eq!(
+        after_refusal,
+        Some(incumbent_pid),
+        "a REFUSED daemon must never touch the pid file — it still belongs to the live \
+         incumbent ({incumbent_pid}). Seeing the refused process's pid here means the claim was \
+         hoisted ahead of the singleton guard (#4774)."
+    );
 }


### PR DESCRIPTION
Closes #4774

## Problem

`.loom/.daemon.pid` was written in exactly one place: `loom-daemon-start.sh`, at *provisioning* time, from the shell that spawned the daemon (three write sites — launchd, systemd, bare-nohup).

Every **supervisor-triggered relaunch** bypasses that script entirely:

- launchd `KeepAlive:{SuccessfulExit:true}` respawning after the `RestartDaemon` primitive (#4054) exits 0
- `systemd --user` `Restart=on-success` doing the same
- the in-daemon self-update loop (`loom-daemon-update.sh --no-restart` + the restart primitive)
- the #4232 `launchctl kickstart` path

Each produces a **new daemon pid** while the file keeps naming the old one. Observed 2026-07-31: the file held `13724` while the live daemon was `99917` — two relaunches stale. That poisons every liveness cross-check that consults it (`daemon_install_state`'s #4694 pid-file fallback, the `health` collector, the `loom:watch` fallback battery, manual operator debugging). On the same morning it compounded with a name-matched `pgrep` hitting a `/tmp` test stub — both quick liveness primitives lied at once.

## Fix

Heal at **one startup choke point every relaunch necessarily passes through**, the same shape as #4331's marker healing.

### New `loom-daemon/src/daemon_pidfile.rs`

- `claim_for_current_process()` — writes `<pid>\n` via tmp + atomic rename (mode `0o644`), so a concurrent reader never observes a truncated file. Non-fatal in every branch: unresolvable path, unwritable dir, lost rename race are all logged and ignored. A daemon without a pid file beats no daemon.
- Path resolution mirrors the start script, in precedence order: `LOOM_PID_FILE` > machine mode (`LOOM_MACHINE_CHECKOUT`) > repo mode (`LOOM_WORKSPACE`) > the machine loom dir. `loom-daemon-start.sh` now **exports** `LOOM_PID_FILE`; both the plist and systemd-unit renderers harvest every exported `LOOM_*`, so the path is baked into the supervisor definition and every relaunch resolves the *identical* file.
- `classify()` — the pure stale rule, cross-checking an observation against whoever answered the socket: `absent` / `unparseable` / `matches` / `unverified` / `dead` / `mismatch`. **`Absent` is deliberately not stale** — an absent file makes no false claim, and a daemon started outside the managed path legitimately has none.

### Call site: after the bind, not before the guard

The claim lives in `IpcServer::run()` immediately after `UnixListener::bind` succeeds — the instant this process is the confirmed *sole* owner of the socket.

Deliberately **not** hoisted next to #4331's marker healing in `daemon_service.rs`, which is the obvious place but runs *before* the singleton guard is evaluated. A daemon about to be **refused** would first stomp the live incumbent's legitimate pid file with its own doomed pid, then bail — turning the guard's "refuse, don't disturb the incumbent" contract into data corruption. Writing after a successful bind makes that structurally impossible: a refused daemon never reaches the write.

### Readers gain cross-checks (AC3)

- **`types.rs`** — `DaemonStatusReport` gains `daemon_pid` (the answering process's own `std::process::id()`, taken inside the handler — the only unforgeable statement of who owns the socket) and `pid_file`. Both `#[serde(default)]`, so a pre-#4774 daemon parses as "cannot cross-check", never a false mismatch. This is the ground truth every pid-file consumer was missing.
- **`health.rs`** — `assess_liveness` degrades a reachable daemon whose pid file names someone else, naming *both* pids in the summary. Liveness itself stays positively established (the daemon just answered); the file is called out as the booby trap it is for every other consumer. Per #4761's refined spec, the pid file is **advisory input, cross-checked but never trusted** — `assess_liveness` never *derives* liveness from it.
- **`daemon_install_state.rs`** — the local half: when launchd reports a live pid and the file names a different one, that is detectable with **no IPC round-trip**, which matters because this probe is what runs when the daemon is *unreachable*. No staleness claim is made when the pid file was itself the liveness signal (nothing independent to arbitrate with). Surfaced as `InstallStateReport::pid_file_stale_note`, reaching both the summary line and `--json`.
- **`cli/health.rs`, `serve.rs`** — observe the pid file against the path the *daemon* reported, falling back to a local resolution only for an unreachable/pre-#4774 daemon (the same rule `.ranking` and #4292's token probe follow).

### Start script

The three write sites are **kept** (per AC — redundant but harmless): they close the window between "supervisor reports a pid" and "the daemon reaches its bind", and remain the only writer for a daemon binary older than #4774. Each is now annotated with why. Same path, same pid, and the daemon's write is atomic.

## Tests

**`integration_singleton_guard.rs`** (this suite on purpose — the design hinges on where the write sits relative to the guard, making both properties structural rather than incidental):

- `test_supervisor_style_relaunch_rewrites_the_pid_file` — the AC4 regression, the incident reduced to two processes. Seed a stale `13724`; generation 1 binds and claims it; `kill -9` (a crash/OOM/restart-primitive teardown, leaving a stale socket); generation 2 re-spawns with the same env and no start script, and must rewrite the file to its own pid.
- `test_a_refused_daemon_does_not_overwrite_the_incumbents_pid_file` — the AC edge case, written as a hazard test: the interloper shares the incumbent's socket *and* pid file, is refused, and must leave the file untouched.

**Unit coverage**: path precedence (all 4 tiers, empty-env handling, unresolvable), atomic write (overwrite reports the previous pid, parent creation, no temp leakage, write failure reported not panicked), every `classify` verdict, the health cross-check (match/mismatch/dead/absent, pre-#4774 backward compat, pid preference), and the install-state launchd cross-check.

## Verification

- `cargo test --workspace` — green (2912 lib tests + all integration suites, incl. 4/4 singleton guard)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `shellcheck --severity=warning` on the start script — clean
- `scripts/check-claude-md-budget.sh` — OK (317/320)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
