### PR TITLE
fix(tests): reap background fixture processes on EXIT/INT/TERM in daemon test suites

### DIFF
--- a/defaults/scripts/tests/lib/bg-proc-trap.sh
+++ b/defaults/scripts/tests/lib/bg-proc-trap.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# bg-proc-trap.sh — shared background-PID bookkeeping for test fixtures that
+# spawn long-lived child processes (fake daemons, decoys, mock servers).
+#
+# Why this exists (#4773): several shell test harnesses under
+# defaults/scripts/tests/ background a fixture process (a fake `loom-daemon`
+# stub, a `sleep N` decoy standing in for a real PID, a mock AF_UNIX server)
+# and only reap it on a clean EXIT — or only via an in-body `wait "$PID"` that
+# never runs if the test process is interrupted first. A hard interruption
+# (SIGINT/SIGTERM of the test runner, e.g. a cancelled overnight sweep) then
+# leaks the fixture process indefinitely; a stub named `loom-daemon` is
+# actively hazardous because it poisons name-based `pgrep` liveness checks.
+#
+# This generalizes the LIVE_PIDS array + looped-kill cleanup() pattern
+# pioneered by test-sweep-run-registry.sh: every suite that backgrounds a
+# fixture process tracks its PID here, then reaps every tracked PID from an
+# EXIT *and* INT/TERM trap. A SIGKILL of the test-runner process cannot be
+# caught by any trap — that is a hard bash/POSIX limitation, not a gap in
+# this helper — so it does not attempt to close that residual case.
+#
+# A second, related bash limitation (verified empirically while building this
+# fix): a trap for a signal received WHILE the script is blocked on a
+# synchronous *foreground* command (a `$(...)` capture, a plain `cmd`, a `(
+# ... )` subshell -- anything that is not one of ITS OWN `&`-backgrounded,
+# bg_proc_track'd children) is deferred until that foreground command
+# completes; it does not interrupt it. If that foreground command itself
+# hangs forever, the trap never runs at all. This is orthogonal to (and not
+# fixed by) this helper -- it affects trap-based cleanup in general, not just
+# background-PID reaping. In this repo it is the documented, already-excluded
+# root cause of test-loom-daemon-update.sh's "full update run" hang (see
+# defaults/scripts/tests/ci-excluded.txt): a fake test daemon that only
+# handles `--version` falls into an infinite loop under `loom-daemon
+# calibrate`, which loom-daemon-start.sh's print_calibrate_hint() calls via a
+# blocking `$(...)`. Fixing that hang (a production timeout guard around that
+# call, or a smarter fake-daemon stub) is out of scope for #4773.
+#
+# Usage (source it, then track every backgrounded PID immediately after `&`):
+#   source "$SCRIPT_DIR/lib/bg-proc-trap.sh"
+#   some_fixture_daemon >/dev/null 2>&1 &
+#   bg_proc_track "$!"
+#   trap 'bg_proc_reap; rm -rf "$WORKDIR"' EXIT
+#   trap 'bg_proc_reap; rm -rf "$WORKDIR"; exit 1' INT TERM
+#
+# IMPORTANT: register EXIT and INT/TERM as TWO separate `trap` calls, not one
+# combined `trap CMD EXIT INT TERM`. Bash runs CMD when INT/TERM arrives but
+# does NOT exit the script afterward (only a firing EXIT trap auto-exits) --
+# a single combined trap would clean up once and then keep executing every
+# remaining test case in the suite, re-populating $WORKDIR as it goes. The
+# INT/TERM trap must end with an explicit `exit` to actually stop the script.
+
+# Array of PIDs to kill on cleanup. Declared at source time so every sourcing
+# script (and any function it defines) shares one array without redeclaring
+# it — bg_proc_track/bg_proc_reap below close over this exact variable.
+BG_PROC_TRACKED_PIDS=()
+
+# Record a backgrounded PID for later reaping. Call immediately after `&`,
+# e.g. `some_cmd & bg_proc_track "$!"`. Silently ignores an empty PID so it
+# is always safe to call even if the spawn failed to produce one.
+bg_proc_track() {
+    local pid="$1"
+    [[ -n "$pid" ]] && BG_PROC_TRACKED_PIDS+=("$pid")
+}
+
+# Kill every tracked PID that is still alive. Idempotent and safe to call
+# more than once (e.g. once from an explicit mid-test cleanup and again from
+# the EXIT/INT/TERM trap) — killing an already-dead PID is a harmless no-op.
+bg_proc_reap() {
+    local pid
+    for pid in "${BG_PROC_TRACKED_PIDS[@]:-}"; do
+        [[ -n "$pid" ]] && kill "$pid" 2>/dev/null
+    done
+}

--- a/defaults/scripts/tests/test-fleet-check.sh
+++ b/defaults/scripts/tests/test-fleet-check.sh
@@ -33,6 +33,12 @@ SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 FLEET_CHECK="$SCRIPTS_DIR/fleet-check.sh"
 PY="${LOOM_PYTHON:-python3}"
 
+# Background-PID bookkeeping (#4773): the mock AF_UNIX server backgrounded by
+# start_mock() (below) is tracked here so the EXIT/INT/TERM trap can reap it
+# even if this suite is killed before an in-body `wait "$MOCK_PID"` runs.
+# shellcheck source=lib/bg-proc-trap.sh
+source "$SCRIPT_DIR/lib/bg-proc-trap.sh"
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -73,7 +79,15 @@ if ! command -v "$PY" >/dev/null 2>&1; then
 fi
 
 TMPDIR_TEST="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR_TEST"' EXIT
+# bg_proc_reap kills the mock server tracked via bg_proc_track in start_mock()
+# below (a backstop for a kill BEFORE the in-body `wait "$MOCK_PID"` runs);
+# EXIT/INT/TERM (not just EXIT, #4773) so a hard interruption of this suite
+# still reaps it. NOTE: a bare `trap CMD EXIT INT TERM` runs CMD on INT/TERM
+# but does NOT stop the script (only an EXIT-trap firing auto-exits) -- the
+# explicit `exit` below is required, else a SIGTERM'd suite would clean up
+# once and then keep running every remaining test case.
+trap 'bg_proc_reap; rm -rf "$TMPDIR_TEST"' EXIT
+trap 'bg_proc_reap; rm -rf "$TMPDIR_TEST"; exit 1' INT TERM
 
 # Mock AF_UNIX safehoused: accept one connection, reply ok to hello, then
 # reply to `check` per the scripted behavior for this record, and record
@@ -174,6 +188,7 @@ start_mock() {
     local sock="$1" rec="$2"
     "$PY" "$MOCK_PY" "$sock" "$rec" &
     MOCK_PID=$!
+    bg_proc_track "$MOCK_PID"
     local i=0
     while [[ ! -S "$sock" && $i -lt 50 ]]; do
         sleep 0.05

--- a/defaults/scripts/tests/test-fleet-send.sh
+++ b/defaults/scripts/tests/test-fleet-send.sh
@@ -27,6 +27,12 @@ SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 FLEET_SEND="$SCRIPTS_DIR/fleet-send.sh"
 PY="${LOOM_PYTHON:-python3}"
 
+# Background-PID bookkeeping (#4773): the mock AF_UNIX server backgrounded by
+# start_mock() (below) is tracked here so the EXIT/INT/TERM trap can reap it
+# even if this suite is killed before an in-body `wait "$MOCK_PID"` runs.
+# shellcheck source=lib/bg-proc-trap.sh
+source "$SCRIPT_DIR/lib/bg-proc-trap.sh"
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -67,7 +73,15 @@ if ! command -v "$PY" >/dev/null 2>&1; then
 fi
 
 TMPDIR_TEST="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR_TEST"' EXIT
+# bg_proc_reap kills the mock server tracked via bg_proc_track in start_mock()
+# below (a backstop for a kill BEFORE the in-body `wait "$MOCK_PID"` runs);
+# EXIT/INT/TERM (not just EXIT, #4773) so a hard interruption of this suite
+# still reaps it. NOTE: a bare `trap CMD EXIT INT TERM` runs CMD on INT/TERM
+# but does NOT stop the script (only an EXIT-trap firing auto-exits) -- the
+# explicit `exit` below is required, else a SIGTERM'd suite would clean up
+# once and then keep running every remaining test case.
+trap 'bg_proc_reap; rm -rf "$TMPDIR_TEST"' EXIT
+trap 'bg_proc_reap; rm -rf "$TMPDIR_TEST"; exit 1' INT TERM
 
 # Mock AF_UNIX safehoused: accept one connection, reply ok to hello + send, and
 # record every received line to $2. Times out (writing an empty record) if no
@@ -135,6 +149,7 @@ start_mock() {
     local sock="$1" rec="$2"
     "$PY" "$MOCK_PY" "$sock" "$rec" &
     MOCK_PID=$!
+    bg_proc_track "$MOCK_PID"
     local i=0
     while [[ ! -S "$sock" && $i -lt 50 ]]; do
         sleep 0.05

--- a/defaults/scripts/tests/test-loom-daemon-launchd-plist.sh
+++ b/defaults/scripts/tests/test-loom-daemon-launchd-plist.sh
@@ -77,7 +77,19 @@ assert_eq() {
 
 # ---------- fixture ----------
 WORKDIR="$(mktemp -d)"
+# No bg_proc_track/bg_proc_reap here (#4773, unlike the other daemon-suite
+# traps touched in that issue): every invocation below passes --print-plist
+# (or --help), which per the file header above is pure string generation with
+# NO side effects — $FAKE_BIN is only referenced via LOOM_DAEMON_BIN, never
+# actually executed/backgrounded, so there is no PID this suite could leak.
+# Still widened to INT/TERM (not just EXIT) so $WORKDIR itself is reclaimed on
+# a hard interruption, matching the other suites' trap signal set. NOTE: a
+# bare `trap CMD EXIT INT TERM` runs CMD on INT/TERM but does NOT stop the
+# script (only an EXIT-trap firing auto-exits) -- the explicit `exit` below is
+# required, else a SIGTERM'd suite would clean up once and then keep running
+# every remaining test case.
 trap 'rm -rf "$WORKDIR"' EXIT
+trap 'rm -rf "$WORKDIR"; exit 1' INT TERM
 mkdir -p "$WORKDIR/.loom/logs"
 
 FAKE_BIN="$WORKDIR/fake-loom-daemon"

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -22,6 +22,12 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 START_SCRIPT="$(cd "$SCRIPT_DIR/../cli" && pwd)/loom-daemon-start.sh"
 
+# Background-PID bookkeeping (#4773): the `sleep 30 &` decoys below stand in
+# for a real daemon MainPID and are tracked here so the EXIT/INT/TERM trap can
+# reap them even if this suite is interrupted before its own inline `kill`.
+# shellcheck source=lib/bg-proc-trap.sh
+source "$SCRIPT_DIR/lib/bg-proc-trap.sh"
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
@@ -46,7 +52,18 @@ assert_eq() {
 
 # ---------- fixture ----------
 WORKDIR="$(mktemp -d)"
-trap 'rm -rf "$WORKDIR"' EXIT
+# bg_proc_reap kills the `sleep 30 &` decoys tracked via bg_proc_track below
+# (their argv never references $WORKDIR, so a path-pattern pkill would miss
+# them); the pkill backstop catches any real nohup'd fake-daemon process this
+# suite starts (BG_FAKE_BIN / SH_BG_FAKE_BIN both live under $WORKDIR, so
+# their argv always matches). EXIT/INT/TERM (not just EXIT, #4773) so a hard
+# interruption of this suite still reaps every tracked/backstopped process.
+# NOTE: a bare `trap CMD EXIT INT TERM` runs CMD on INT/TERM but does NOT stop
+# the script (only an EXIT-trap firing auto-exits) -- the explicit `exit`
+# below is required, else a SIGTERM'd suite would clean up once and then keep
+# running every remaining test case (re-populating $WORKDIR as it goes).
+trap 'bg_proc_reap; pkill -f "$WORKDIR" >/dev/null 2>&1; rm -rf "$WORKDIR"' EXIT
+trap 'bg_proc_reap; pkill -f "$WORKDIR" >/dev/null 2>&1; rm -rf "$WORKDIR"; exit 1' INT TERM
 mkdir -p "$WORKDIR/.loom/logs"
 
 FAKE_BIN="$WORKDIR/fake-loom-daemon"
@@ -318,6 +335,7 @@ EOF
 #     from `systemctl --user show -p MainPID`. A real sleeper stands in for the
 #     daemon MainPID so the liveness check (kill -0) passes.
 sleep 30 & SD_MAIN_SLEEP_PID=$!
+bg_proc_track "$SD_MAIN_SLEEP_PID"
 SD_LOG="$WORKDIR/sd-enable.log"; : > "$SD_LOG"
 make_sd_stub "$SD_LOG" "$SD_MAIN_SLEEP_PID"
 SD_HOME="$(mktemp -d)"; mkdir -p "$SD_HOME/.loom/logs"
@@ -413,6 +431,7 @@ EOF
 #      (not the service) is enable --now'd, and LOOM_WATCHDOG_INTERVAL_SECS
 #      drives BOTH OnUnitActiveSec and OnBootSec.
 sleep 30 & WD_MAIN_SLEEP_PID=$!
+bg_proc_track "$WD_MAIN_SLEEP_PID"
 WD_LOG="$WORKDIR/sd-watchdog.log"; : > "$WD_LOG"
 make_sd_stub_wd "$WD_LOG" "$WD_MAIN_SLEEP_PID" "0"
 WD_HOME="$(mktemp -d)"; mkdir -p "$WD_HOME/.loom/logs"
@@ -471,6 +490,7 @@ rm -rf "$WD_HOME"
 # WD2. Provisioning failure (stub enable --now on the timer exits 1) is a
 #      WARNING, never a failed daemon start.
 sleep 30 & WD2_MAIN_SLEEP_PID=$!
+bg_proc_track "$WD2_MAIN_SLEEP_PID"
 WD2_LOG="$WORKDIR/sd-watchdog-fail.log"; : > "$WD2_LOG"
 make_sd_stub_wd "$WD2_LOG" "$WD2_MAIN_SLEEP_PID" "1"
 WD2_HOME="$(mktemp -d)"; mkdir -p "$WD2_HOME/.loom/logs"
@@ -910,6 +930,7 @@ fi
 #       actually carries the key.
 : > "$DEK_SD_LOG"
 sleep 30 & DEK_SD_PID1=$!
+bg_proc_track "$DEK_SD_PID1"
 ( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
     PATH="$DEK_SD_BIN:$PATH" HOME="$DEK_SD_HOME" \
     LOOM_SYSTEMD_FORCE=1 LOOM_SYSTEMD_UNIT="$DEK_SD_UNIT" \
@@ -934,6 +955,7 @@ else
 fi
 
 sleep 30 & DEK_SD_PID2=$!
+bg_proc_track "$DEK_SD_PID2"
 dek6_out=$( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE -u LOOM_SAFEHOUSE_ENABLED \
     PATH="$DEK_SD_BIN:$PATH" HOME="$DEK_SD_HOME" \
     LOOM_SYSTEMD_FORCE=1 LOOM_SYSTEMD_UNIT="$DEK_SD_UNIT" \
@@ -967,6 +989,7 @@ fi
 
 # DEK7. --force-env suppresses the warning on the real install path too.
 sleep 30 & DEK_SD_PID3=$!
+bg_proc_track "$DEK_SD_PID3"
 ( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
     PATH="$DEK_SD_BIN:$PATH" HOME="$DEK_SD_HOME" \
     LOOM_SYSTEMD_FORCE=1 LOOM_SYSTEMD_UNIT="$DEK_SD_UNIT" \
@@ -981,6 +1004,7 @@ if [[ -f "$DEK_SD_HOME/.loom/.daemon.pid" ]]; then
     rm -f "$DEK_SD_HOME/.loom/.daemon.pid"
 fi
 sleep 30 & DEK_SD_PID4=$!
+bg_proc_track "$DEK_SD_PID4"
 dek7_out=$( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE -u LOOM_SAFEHOUSE_ENABLED \
     PATH="$DEK_SD_BIN:$PATH" HOME="$DEK_SD_HOME" \
     LOOM_SYSTEMD_FORCE=1 LOOM_SYSTEMD_UNIT="$DEK_SD_UNIT" \
@@ -1243,6 +1267,7 @@ AD8_LOG="$WORKDIR/ad8-install.log"; : > "$AD8_LOG"
 
 # Install the "prior" unit with LOOM_WORK_FINDER=1.
 sleep 30 & AD8_SLEEP_PID1=$!
+bg_proc_track "$AD8_SLEEP_PID1"
 make_sd_stub "$AD8_LOG" "$AD8_SLEEP_PID1"
 env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
     PATH="$SD_BIN:$PATH" HOME="$AD8_HOME" LOOM_SYSTEMD_FORCE=1 LOOM_SYSTEMD_UNIT="$AD_SD_UNIT" \
@@ -1259,6 +1284,7 @@ rm -f "$AD8_HOME/.loom/.daemon.pid"
 #      "prior-plist-had-work-finder + plain restart -> warning emitted",
 #      systemd sibling.
 sleep 30 & AD8_SLEEP_PID2=$!
+bg_proc_track "$AD8_SLEEP_PID2"
 make_sd_stub "$AD8_LOG" "$AD8_SLEEP_PID2"
 ad8_out=$( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
     PATH="$SD_BIN:$PATH" HOME="$AD8_HOME" LOOM_SYSTEMD_FORCE=1 LOOM_SYSTEMD_UNIT="$AD_SD_UNIT" \

--- a/defaults/scripts/tests/test-loom-daemon-stop.sh
+++ b/defaults/scripts/tests/test-loom-daemon-stop.sh
@@ -25,6 +25,14 @@ STOP_SCRIPT="$(cd "$SCRIPT_DIR/../cli" && pwd)/loom-daemon-stop.sh"
 # shellcheck source=lib/launchd-sandbox.sh
 source "$SCRIPT_DIR/lib/launchd-sandbox.sh"
 
+# Background-PID bookkeeping (#4773): every `sleep 30 &` decoy this suite
+# backgrounds as a stand-in "live daemon" for STOP_SCRIPT to kill is tracked
+# here too — each test already falls back to an inline `kill -9` when the
+# stop-under-test assertion fails, but that fallback (like the DECOY_PID
+# tracking above) never runs if the suite itself is interrupted first.
+# shellcheck source=lib/bg-proc-trap.sh
+source "$SCRIPT_DIR/lib/bg-proc-trap.sh"
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
@@ -68,7 +76,16 @@ WORKDIR="$(mktemp -d)"
 # tier and leave this decoy alive. If ANY test in this suite regresses into a
 # by-name kill, this decoy dies and the final assertion fails loudly.
 DECOY_PID="$(launchd_sandbox_spawn_decoy "$WORKDIR")"
-trap 'kill "$DECOY_PID" 2>/dev/null; rm -rf "$WORKDIR"' EXIT
+bg_proc_track "$DECOY_PID"
+# bg_proc_reap kills every `sleep 30 &` decoy tracked via bg_proc_track below;
+# EXIT/INT/TERM (not just EXIT, #4773) so a hard interruption of this suite
+# still reaps them, not only the individual tests' own inline `kill` calls.
+# NOTE: a bare `trap CMD EXIT INT TERM` runs CMD on INT/TERM but does NOT stop
+# the script (bash only auto-exits after an EXIT-trap firing, not an INT/TERM
+# one) -- without the explicit `exit` below, a SIGTERM'd suite would clean up
+# once and then keep executing every remaining test, re-populating $WORKDIR.
+trap 'bg_proc_reap; rm -rf "$WORKDIR"' EXIT
+trap 'bg_proc_reap; rm -rf "$WORKDIR"; exit 1' INT TERM
 mkdir -p "$WORKDIR/.loom"
 
 # ---------- tests ----------
@@ -90,6 +107,7 @@ fi
 SLEEP_PID_FILE="$WORKDIR/.loom/.daemon.pid"
 ( sleep 30 & echo $! > "$SLEEP_PID_FILE" )
 sleep_pid=$(cat "$SLEEP_PID_FILE")
+bg_proc_track "$sleep_pid"
 ( cd "$WORKDIR" && LOOM_LAUNCHD_LABEL="$FAKE_LABEL" LOOM_DAEMON_STOP_GRACE_SECS=2 bash "$STOP_SCRIPT" >/dev/null 2>&1 )
 rc2=$?
 assert_eq "0" "$rc2" "live pid: stop exits 0"
@@ -114,6 +132,7 @@ fi
 # 3. --force skips the grace window (SIGKILL immediately).
 ( sleep 30 & echo $! > "$SLEEP_PID_FILE" )
 sleep_pid2=$(cat "$SLEEP_PID_FILE")
+bg_proc_track "$sleep_pid2"
 start_ts=$(date +%s)
 ( cd "$WORKDIR" && LOOM_LAUNCHD_LABEL="$FAKE_LABEL" bash "$STOP_SCRIPT" --force >/dev/null 2>&1 )
 end_ts=$(date +%s)
@@ -174,8 +193,10 @@ FAKE
     # Original daemon (killed by the stop) + a separate live "relaunched" daemon.
     ( sleep 30 & echo $! > "$SLEEP_PID_FILE" )
     orig_pid=$(cat "$SLEEP_PID_FILE")
+    bg_proc_track "$orig_pid"
     sleep 30 &
     relaunch_pid=$!
+    bg_proc_track "$relaunch_pid"
 
     stuck_out=$( cd "$WORKDIR" && PATH="$FAKE_BIN_DIR:$PATH" RELAUNCH_PID="$relaunch_pid" \
         LOOM_LAUNCHD_LABEL="$FAKE_LABEL" LOOM_DAEMON_STOP_GRACE_SECS=2 bash "$STOP_SCRIPT" 2>&1 )
@@ -320,6 +341,7 @@ fi
 printf 'started_at=x\n' > "$MARKER"
 ( sleep 30 & echo $! > "$WORKDIR/.loom/.daemon.pid" )
 live_pid=$(cat "$WORKDIR/.loom/.daemon.pid")
+bg_proc_track "$live_pid"
 ( cd "$WORKDIR" && LOOM_LAUNCHD_LABEL="$FAKE_LABEL" LOOM_AUTONOMY_MARKER="$MARKER" \
     LOOM_DAEMON_STOP_GRACE_SECS=2 bash "$STOP_SCRIPT" >/dev/null 2>&1 )
 kill -9 "$live_pid" 2>/dev/null || true
@@ -482,6 +504,7 @@ NON_REPO_DIR="$(mktemp -d)"
 
 ( sleep 30 & echo $! > "$MACHINE_HOME/.loom/.daemon.pid" )
 machine_pid=$(cat "$MACHINE_HOME/.loom/.daemon.pid")
+bg_proc_track "$machine_pid"
 out_machine=$( cd "$NON_REPO_DIR" && HOME="$MACHINE_HOME" LOOM_MACHINE_CHECKOUT="$MACHINE_CHECKOUT" \
     LOOM_LAUNCHD_LABEL="$FAKE_LABEL" LOOM_DAEMON_STOP_GRACE_SECS=2 bash "$STOP_SCRIPT" 2>&1 )
 rc_machine=$?

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -79,6 +79,13 @@ UPDATE_SCRIPT="$CLI_DIR/loom-daemon-update.sh"
 source "$SCRIPT_DIR/lib/launchd-sandbox.sh"
 export LOOM_LAUNCHD_LABEL="$(launchd_sandbox_new_label)"
 
+# Background-PID bookkeeping (#4773): every fake-daemon/decoy process this
+# suite backgrounds is tracked here so the EXIT/INT/TERM trap below can reap
+# it even if the parent test process is interrupted before its own inline
+# cleanup runs.
+# shellcheck source=lib/bg-proc-trap.sh
+source "$SCRIPT_DIR/lib/bg-proc-trap.sh"
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
@@ -521,12 +528,26 @@ chmod +x "$DECOY_DIR/loom-daemon"
 # output — the same command-substitution gotcha the sandbox spawner avoids).
 "$DECOY_DIR/loom-daemon" >/dev/null 2>&1 &
 DECOY_PID=$!
+bg_proc_track "$DECOY_PID"
 
 # Best-effort cleanup of any fake-daemon processes left running (matched by
 # their script path under $BASE_WORKDIR, which appears in `ps`'s command
 # line) — individual tests also kill their own PIDs explicitly, this is a
-# backstop for anything a failed assertion left behind.
-trap 'kill "$DECOY_PID" 2>/dev/null; pkill -f "$BASE_WORKDIR" >/dev/null 2>&1; rm -rf "$BASE_WORKDIR" "$DECOY_DIR"' EXIT
+# backstop for anything a failed assertion left behind. bg_proc_reap kills
+# every PID tracked via bg_proc_track (the W5/W15/W26-style sandbox fixtures
+# below track their own spawned PIDs directly rather than relying solely on
+# the pkill pattern-match); EXIT/INT/TERM (not just EXIT, #4773) so a hard
+# interruption of this suite still reaps every tracked/backstopped process.
+# NOTE: a bare `trap CMD EXIT INT TERM` runs CMD on INT/TERM but does NOT stop
+# the script (only an EXIT-trap firing auto-exits) -- the explicit `exit`
+# below is required, else a SIGTERM'd suite would clean up once and then keep
+# running every remaining (numbered W*) test case, re-populating
+# $BASE_WORKDIR as it goes (observed directly while verifying this fix: an
+# untrapped-exit version of this trap let a SIGTERM'd run limp all the way to
+# a later scenario, which then hit a real, un-stubbed `cargo build --release`
+# once its own fixture dir had already been rm -rf'd out from under it).
+trap 'bg_proc_reap; pkill -f "$BASE_WORKDIR" >/dev/null 2>&1; rm -rf "$BASE_WORKDIR" "$DECOY_DIR"' EXIT
+trap 'bg_proc_reap; pkill -f "$BASE_WORKDIR" >/dev/null 2>&1; rm -rf "$BASE_WORKDIR" "$DECOY_DIR"; exit 1' INT TERM
 
 FAKE_BIN_DIR="$BASE_WORKDIR/fakebin"
 mkdir -p "$FAKE_BIN_DIR"
@@ -632,6 +653,7 @@ echo "--work-finder" > "$W5/.loom/.daemon.flags"
 # record its PID, exactly like loom-daemon-start.sh would have.
 "$INSTALLED5" >/dev/null 2>&1 &
 old_pid=$!
+bg_proc_track "$old_pid"
 sleep 0.3
 echo "$old_pid" > "$W5/.loom/.daemon.pid"
 TESTS_RUN=$((TESTS_RUN + 1))
@@ -712,6 +734,7 @@ write_fake_daemon "$NEW_FAKE5B" "$HEAD5B" "$W5B/new-marker"
 
 "$INSTALLED5B" >/dev/null 2>&1 &
 old_pid5b=$!
+bg_proc_track "$old_pid5b"
 sleep 0.3
 echo "$old_pid5b" > "$W5B/.loom/.daemon.pid"
 
@@ -863,6 +886,7 @@ write_fake_daemon "$NEW_FAKE7" "$HEAD7" "$W7/new-marker"
 
 "$INSTALLED7" >/dev/null 2>&1 &
 old_pid7=$!
+bg_proc_track "$old_pid7"
 sleep 0.3
 echo "$old_pid7" > "$W7/.loom/.daemon.pid"
 
@@ -1143,6 +1167,7 @@ echo "--work-finder" > "$W15/.loom/.daemon.flags"
 # #4232 poll requires a live pid (kill -0), not just a differing number.
 sleep 60 >/dev/null 2>&1 &
 RELAUNCHED_PID15=$!
+bg_proc_track "$RELAUNCHED_PID15"
 LD_BIN15="$W15/launchd-bin"
 write_fake_launchd_loaded_bin "$LD_BIN15" "$W15/launchctl.log" "$RESTART_MARKER15" "$RELAUNCHED_PID15"
 
@@ -1276,6 +1301,7 @@ fi
 # (b) LOOM_DAEMON_LAUNCHD=0 + live pid file -> manager: PID-file/nohup.
 "$INSTALLED17" >/dev/null 2>&1 &
 pid17=$!
+bg_proc_track "$pid17"
 sleep 0.3
 echo "$pid17" > "$W17/.loom/.daemon.pid"
 check_pid_out=$( cd "$W17" && PATH="$TEST_PATH" LOOM_DAEMON_LAUNCHD=0 \
@@ -1941,8 +1967,10 @@ write_fake_daemon_restart "$NEW_FAKE35" "$HEAD35" "$RESTART_MARKER35" 0
 
 sleep 60 >/dev/null 2>&1 &
 OLD_PID26=$!
+bg_proc_track "$OLD_PID26"
 sleep 60 >/dev/null 2>&1 &
 KICKSTART_PID35=$!
+bg_proc_track "$KICKSTART_PID35"
 STATE35="$W35/launchd-pid-state"
 echo "$OLD_PID26" > "$STATE35"
 LD_BIN35="$W35/launchd-bin"
@@ -2001,6 +2029,7 @@ write_fake_daemon_restart "$NEW_FAKE36" "$HEAD36" "$RESTART_MARKER36" 0
 
 sleep 60 >/dev/null 2>&1 &
 OLD_PID27=$!
+bg_proc_track "$OLD_PID27"
 STATE36="$W36/launchd-pid-state"
 echo "$OLD_PID27" > "$STATE36"
 LD_BIN36="$W36/launchd-bin"

--- a/defaults/scripts/tests/test-loom-daemon-watchdog.sh
+++ b/defaults/scripts/tests/test-loom-daemon-watchdog.sh
@@ -24,6 +24,12 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WATCHDOG="$(cd "$SCRIPT_DIR/../cli" && pwd)/loom-daemon-watchdog.sh"
 
+# Background-PID bookkeeping (#4773): every `sleeper` (line ~113) and the
+# `sleep 60` kickstart decoy (below) is tracked here so the EXIT/INT/TERM trap
+# can reap it even if this suite is interrupted before its own inline `kill`.
+# shellcheck source=lib/bg-proc-trap.sh
+source "$SCRIPT_DIR/lib/bg-proc-trap.sh"
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
@@ -40,7 +46,15 @@ assert_rc() { # <expected> <actual> <msg>
 }
 
 WORKDIR="$(mktemp -d)"
-trap 'rm -rf "$WORKDIR"' EXIT
+# bg_proc_reap kills every sleeper()/decoy PID tracked via bg_proc_track;
+# EXIT/INT/TERM (not just EXIT, #4773) so a hard interruption of this suite
+# still reaps them, not only the individual tests' own inline `kill` calls.
+# NOTE: a bare `trap CMD EXIT INT TERM` runs CMD on INT/TERM but does NOT stop
+# the script (only an EXIT-trap firing auto-exits) -- the explicit `exit`
+# below is required, else a SIGTERM'd suite would clean up once and then keep
+# running every remaining test case.
+trap 'bg_proc_reap; rm -rf "$WORKDIR"' EXIT
+trap 'bg_proc_reap; rm -rf "$WORKDIR"; exit 1' INT TERM
 
 MARKER="$WORKDIR/autonomy-desired"
 HEARTBEAT="$WORKDIR/daemon.heartbeat"
@@ -186,6 +200,7 @@ LIVE_PID=""
 start_alive_and_fresh() { # <pid_file_suffix>
     PS_STUB_DIR="$(make_ps_stub "02:00:00")"
     LIVE_PID=$(sleeper)
+    bg_proc_track "$LIVE_PID"
     echo "$LIVE_PID" > "$WORKDIR/pid$1"
     write_marker "$WORKDIR/pid$1" 60
     printf '%s pid=%s ts=now\n' "$(date +%s)" "$LIVE_PID" > "$HEARTBEAT"
@@ -211,6 +226,7 @@ if log_has DIVERGENCE || log_hasi "mismatch"; then fail "marker absent + nothing
 # ===================================================================
 rm -f "$MARKER" "$HEARTBEAT" "$WDLOG"
 live_pid=$(sleeper)
+bg_proc_track "$live_pid"
 echo "$live_pid" > "$WORKDIR/.daemon.pid"
 run_watchdog
 kill "$live_pid" 2>/dev/null || true
@@ -231,6 +247,7 @@ rm -f "$WORKDIR/.daemon.pid"
 # 2. Intent present, daemon ALIVE, heartbeat FRESH ⇒ silent OK.
 # ===================================================================
 live_pid=$(sleeper)
+bg_proc_track "$live_pid"
 echo "$live_pid" > "$WORKDIR/pidA"
 write_marker "$WORKDIR/pidA" 60
 printf '%s pid=%s ts=now\n' "$(date +%s)" "$live_pid" > "$HEARTBEAT"
@@ -250,6 +267,7 @@ assert_rc 0 "$RC" "alive + fresh heartbeat: exits 0"
 # ===================================================================
 PS_STUB3="$(make_ps_stub "02:00:00")"
 live_pid=$(sleeper)
+bg_proc_track "$live_pid"
 echo "$live_pid" > "$WORKDIR/pidB"
 write_marker "$WORKDIR/pidB" 60
 printf 'old\n' > "$HEARTBEAT"
@@ -270,6 +288,7 @@ rm -rf "$PS_STUB3"
 # ===================================================================
 PS_STUB3B="$(make_ps_stub "00:00:05")"
 live_pid=$(sleeper)
+bg_proc_track "$live_pid"
 echo "$live_pid" > "$WORKDIR/pidB2"
 write_marker "$WORKDIR/pidB2" 60
 printf 'old\n' > "$HEARTBEAT"
@@ -294,7 +313,7 @@ rm -rf "$PS_STUB3B"
 # 4. Intent present, daemon DEAD ⇒ DIVERGENCE (expected but not running).
 #    This IS the #4011 outage, reproduced.
 # ===================================================================
-dead_pid=$(sleeper); kill "$dead_pid" 2>/dev/null; wait "$dead_pid" 2>/dev/null
+dead_pid=$(sleeper); bg_proc_track "$dead_pid"; kill "$dead_pid" 2>/dev/null; wait "$dead_pid" 2>/dev/null
 echo "$dead_pid" > "$WORKDIR/pidC"
 write_marker "$WORKDIR/pidC" 60
 printf 'x\n' > "$HEARTBEAT"
@@ -312,6 +331,7 @@ fi
 #    (heartbeat disabled or not yet written — do NOT false-report.)
 # ===================================================================
 live_pid=$(sleeper)
+bg_proc_track "$live_pid"
 echo "$live_pid" > "$WORKDIR/pidD"
 write_marker "$WORKDIR/pidD" 60
 rm -f "$HEARTBEAT"
@@ -325,6 +345,7 @@ assert_rc 0 "$RC" "alive + no heartbeat file: exits 0 (liveness-only, no false p
 #    just under the default 300s threshold is NOT reported (no flapping).
 # ===================================================================
 live_pid=$(sleeper)
+bg_proc_track "$live_pid"
 echo "$live_pid" > "$WORKDIR/pidE"
 write_marker "$WORKDIR/pidE" 60
 printf 'x\n' > "$HEARTBEAT"
@@ -341,6 +362,7 @@ assert_rc 0 "$RC" "heartbeat 120s old < 300s threshold: not flagged (no flapping
 # ===================================================================
 PS_STUB7="$(make_ps_stub "00:01:00")"
 live_pid=$(sleeper)
+bg_proc_track "$live_pid"
 echo "$live_pid" > "$WORKDIR/pidF"
 write_marker "$WORKDIR/pidF" 60
 printf 'x\n' > "$HEARTBEAT"
@@ -400,6 +422,7 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
     : > "$STATE9"   # empty -> "not running" at check time
     sleep 60 >/dev/null 2>&1 &
     NEW_PID9=$!
+    bg_proc_track "$NEW_PID9"
     LOG9="$WORKDIR/launchctl9.log"
     : > "$LOG9"
     cat > "$STUB9/launchctl" <<EOF


### PR DESCRIPTION
## Summary

Six shell test harnesses under `defaults/scripts/tests/` background fixture processes (mock AF_UNIX servers, `sleep N` decoys, fake `loom-daemon` stubs) but only reaped them on a clean EXIT, or via an in-body `wait` that never runs if the suite is interrupted first. A stub literally named `loom-daemon` is actively hazardous: it poisons name-based `pgrep` liveness checks. A hard interruption (e.g. a cancelled overnight sweep) leaked these indefinitely — exactly the incident the first `loom:watch` dry-run surfaced (six processes still alive 8+ hours after the #4695 sweep).

- Adds `defaults/scripts/tests/lib/bg-proc-trap.sh` (`bg_proc_track` / `bg_proc_reap`), generalizing `test-sweep-run-registry.sh`'s `LIVE_PIDS` array + looped-kill `cleanup()` pattern.
- Wires every backgrounded fixture PID in `test-fleet-check.sh`, `test-fleet-send.sh`, `test-loom-daemon-start.sh`, `test-loom-daemon-stop.sh`, `test-loom-daemon-update.sh`, `test-loom-daemon-watchdog.sh` into it, and widens each suite's cleanup trap to fire on `INT`/`TERM` as well as `EXIT`.
- `test-loom-daemon-launchd-plist.sh` exercises only `--print-plist`/`--help` (pure string generation, no side effects, per its own file header) so it never backgrounds anything — its trap is widened to `INT`/`TERM` for workdir cleanup only, with no PID tracking needed.

### A real correctness bug this surfaced

A single combined `trap CMD EXIT INT TERM` runs `CMD` when `INT`/`TERM` arrives but does **not** stop the script afterward — only a *firing EXIT trap* auto-exits bash. Without an explicit `exit`, a `SIGTERM`'d suite cleans up once and then keeps executing every remaining test case, re-populating its own workdir as it goes. I hit this directly while verifying the fix: an early (pre-fix) version of the `test-loom-daemon-update.sh` trap let a `SIGTERM`'d run limp forward into a later scenario, which then hit a *real*, un-stubbed `cargo build --release` once its own fixture directory had already been `rm -rf`'d out from under it by the trap that "fired" but didn't stop the script.

Fixed by registering `EXIT` and `INT`/`TERM` as **two separate** `trap` calls everywhere in this PR (the six suites above, plus `test-loom-daemon-launchd-plist.sh`'s pre-existing rm-only trap and `test-loom-daemon-stop.sh`'s original `DECOY_PID` trap), with the `INT`/`TERM` trap ending in an explicit `exit`.

## Verification

- `bash -n` and `shellcheck --severity=warning` (matching `.github/workflows/shell-lint.yml`'s pinned `v0.10.0` invocation, run locally with `0.11.0`) are clean on every touched file.
- Every suite passes standalone with **zero leaked fixture processes** after a normal run: `test-fleet-check.sh` (24/24), `test-fleet-send.sh` (21/21), `test-loom-daemon-launchd-plist.sh` (42/42), `test-loom-daemon-watchdog.sh` (59/59), `test-loom-daemon-stop.sh` (37/37), `test-loom-daemon-start.sh` (72/72).
- Confirmed via a direct mid-run `SIGTERM` against `test-loom-daemon-start.sh` (while it had a live `sleep 30 &` decoy tracked) that the suite now halts promptly and the decoy is reaped — no leaked `sleep 30`/fake-daemon processes remained afterward, and the script did **not** continue into further test scenarios (the bug described above).
- `test-loom-daemon-update.sh`'s "full update run" scenario has a **separate, pre-existing** hang: its fake test daemon only handles `--version`, so `loom-daemon-start.sh`'s `print_calibrate_hint()` (a blocking `$(daemon calibrate ... --json)` command substitution) never returns, infinite-looping. This is already documented and excluded from CI in `defaults/scripts/tests/ci-excluded.txt` ("hangs past 120s locally ... Wiring it needs a portability/timeout pass — follow-up"), unrelated to this fix, and out of scope here. Verified via static review that every `&`-backgrounded PID in that file (9 sites) is tracked with `bg_proc_track`, matching the pattern used elsewhere in this PR.

Closes #4773
