### PR TITLE
feat(worktree): add snapshot verb — patch-file WIP capture without git stash

### DIFF
--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -86,3 +86,4 @@ test-worktree-remove.sh
 test-worktree-root-override.sh
 test-worktree-sentinel-reinvoke.sh
 test-worktree-sentinel.sh
+test-worktree-snapshot.sh

--- a/defaults/scripts/tests/test-worktree-snapshot.sh
+++ b/defaults/scripts/tests/test-worktree-snapshot.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# test-worktree-snapshot.sh - Tests for the `worktree.sh snapshot <N>` verb (#4778)
+#
+# Verifies the worktree-scoped WIP snapshot verb:
+#   1. A snapshot captures tracked-file modifications WITHOUT touching
+#      `git stash` (stash list identical before/after).
+#   2. The patch file lands at the documented deterministic path
+#      (<worktree-root>/.snapshots/issue-<N>-<timestamp>.patch).
+#   3. `git apply` of the produced patch against a fresh checkout of the same
+#      branch reproduces the original diff.
+#   4. --include-untracked folds untracked files into the patch; without the
+#      flag, untracked files are NOT captured.
+#   5. A worktree with no uncommitted changes still succeeds (empty patch,
+#      not an error).
+#   6. snapshot on a non-existent worktree fails cleanly.
+#   7. LOOM_WORKTREE_ROOT override redirects the snapshot location along
+#      with the worktree itself (not the hardcoded default).
+#   8. --json emits a single parseable success document.
+#   9. Loom runtime markers are excluded even with --include-untracked.
+#
+# Follows the throwaway-repo harness pattern in test-worktree-remove.sh: a
+# bare origin remote + a working repo, with worktree.sh + its lib/ helpers
+# copied into a temp tree, then the script driven directly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPTS_DIR/../.." && pwd)"
+
+WORKTREE_SH="$SCRIPTS_DIR/worktree.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+# --- Throwaway repo setup ---------------------------------------------------
+TMP=$(mktemp -d /tmp/loom-snapshot-test.XXXXXX)
+trap 'rm -rf "$TMP"; cd "$REPO_ROOT" 2>/dev/null || true' EXIT
+
+git init -q -b main "$TMP/origin.git" --bare
+git init -q -b main "$TMP/repo"
+cd "$TMP/repo"
+git config user.email t@t
+git config user.name t
+echo "tracked file" > tracked.txt
+git add tracked.txt
+git commit --allow-empty -q -m init
+git remote add origin "$TMP/origin.git"
+git push -q origin main
+
+mkdir -p .loom/scripts/lib
+cp "$WORKTREE_SH" .loom/scripts/worktree.sh
+if [[ -d "$SCRIPTS_DIR/lib" ]]; then
+    cp -R "$SCRIPTS_DIR"/lib/* .loom/scripts/lib/ 2>/dev/null || true
+fi
+chmod +x .loom/scripts/worktree.sh
+
+REPO="$TMP/repo"
+
+# Helper: create a fresh managed worktree for an issue number.
+make_worktree() {
+    local n="$1"
+    cd "$REPO"
+    ./.loom/scripts/worktree.sh "$n" >/dev/null 2>&1
+}
+
+# --- Test 1: snapshot captures tracked changes without touching git stash --
+echo "Test 1: snapshot captures tracked-file changes without touching git stash"
+make_worktree 201
+cd "$REPO"
+echo "modified content" >> ".loom/worktrees/issue-201/tracked.txt"
+stash_before="$(git stash list)"
+if ./.loom/scripts/worktree.sh snapshot 201 >/tmp/snap-out1.$$ 2>&1; then
+    pass "snapshot exited 0 for a dirty worktree"
+else
+    fail "snapshot exited non-zero (see /tmp/snap-out1.$$)"
+fi
+stash_after="$(git stash list)"
+if [[ "$stash_before" == "$stash_after" ]]; then
+    pass "git stash list is unchanged by snapshot"
+else
+    fail "git stash list changed — snapshot touched the shared stash"
+fi
+
+# --- Test 2: patch lands at the documented deterministic path --------------
+echo ""
+echo "Test 2: patch file lands at <worktree-root>/.snapshots/issue-<N>-<ts>.patch"
+patch1="$(find ".loom/worktrees/.snapshots" -name "issue-201-*.patch" 2>/dev/null | head -1)"
+if [[ -n "$patch1" && -f "$patch1" ]]; then
+    pass "patch file found at documented location: $patch1"
+else
+    fail "no patch file found under .loom/worktrees/.snapshots/issue-201-*.patch"
+fi
+
+# --- Test 3: git apply reproduces the original diff on a fresh checkout ----
+echo ""
+echo "Test 3: git apply of the snapshot reproduces the diff on a fresh checkout"
+FRESH="$TMP/fresh-checkout"
+git clone -q "$REPO" "$FRESH" >/dev/null 2>&1
+# `git -C <dir> apply <path>` resolves a RELATIVE <path> against <dir>, not
+# the shell's cwd — pass an absolute path so this check is robust regardless
+# of where $patch1 was discovered relative to.
+patch1_abs="$(cd "$(dirname "$patch1")" && pwd)/$(basename "$patch1")"
+if [[ -n "$patch1" ]] && git -C "$FRESH" apply --check "$patch1_abs" 2>/tmp/snap-apply-check.$$; then
+    pass "git apply --check succeeds against a fresh checkout"
+    git -C "$FRESH" apply "$patch1_abs"
+    if grep -q "modified content" "$FRESH/tracked.txt"; then
+        pass "applied patch reproduces the original change"
+    else
+        fail "applied patch did not reproduce the original change"
+    fi
+else
+    fail "git apply --check failed (see /tmp/snap-apply-check.$$)"
+fi
+
+# --- Test 4: --include-untracked folds in untracked files ------------------
+echo ""
+echo "Test 4: --include-untracked folds untracked files into the patch; default omits them"
+make_worktree 202
+cd "$REPO"
+echo "brand new file" > ".loom/worktrees/issue-202/untracked.txt"
+./.loom/scripts/worktree.sh snapshot 202 >/tmp/snap-out4a.$$ 2>&1
+patch_no_untracked="$(find ".loom/worktrees/.snapshots" -name "issue-202-*.patch" 2>/dev/null | sort | tail -1)"
+if [[ -n "$patch_no_untracked" ]] && ! grep -q "untracked.txt" "$patch_no_untracked"; then
+    pass "default snapshot omits untracked files"
+else
+    fail "default snapshot unexpectedly included untracked files"
+fi
+sleep 1.1  # ensure a distinct timestamp for the second snapshot
+./.loom/scripts/worktree.sh snapshot 202 --include-untracked >/tmp/snap-out4b.$$ 2>&1
+patch_with_untracked="$(find ".loom/worktrees/.snapshots" -name "issue-202-*.patch" 2>/dev/null | sort | tail -1)"
+if [[ -n "$patch_with_untracked" ]] && grep -q "untracked.txt" "$patch_with_untracked" && grep -q "brand new file" "$patch_with_untracked"; then
+    pass "--include-untracked folds the untracked file's content into the patch"
+else
+    fail "--include-untracked did not include the untracked file"
+fi
+# The untracked file must remain untracked (not staged) after the snapshot.
+if git -C ".loom/worktrees/issue-202" status --porcelain -- untracked.txt | grep -q '^??'; then
+    pass "untracked file remains untracked after --include-untracked snapshot"
+else
+    fail "untracked file was left staged/tracked after snapshot"
+fi
+
+# --- Test 5: no uncommitted changes still succeeds (empty patch) -----------
+echo ""
+echo "Test 5: a clean worktree still succeeds, writing an empty snapshot"
+make_worktree 203
+cd "$REPO"
+if ./.loom/scripts/worktree.sh snapshot 203 >/tmp/snap-out5.$$ 2>&1; then
+    pass "snapshot exited 0 for a clean worktree"
+else
+    fail "snapshot exited non-zero for a clean worktree (see /tmp/snap-out5.$$)"
+fi
+patch5="$(find ".loom/worktrees/.snapshots" -name "issue-203-*.patch" 2>/dev/null | head -1)"
+if [[ -n "$patch5" && -f "$patch5" ]]; then
+    pass "empty snapshot patch file was still created"
+else
+    fail "no patch file created for a clean worktree"
+fi
+
+# --- Test 6: snapshot on a non-existent worktree fails cleanly -------------
+echo ""
+echo "Test 6: snapshot refuses a non-existent issue worktree"
+cd "$REPO"
+if ./.loom/scripts/worktree.sh snapshot 999999 >/tmp/snap-out6.$$ 2>&1; then
+    fail "snapshot succeeded for a non-existent worktree (should have failed)"
+else
+    pass "snapshot exited non-zero for a non-existent worktree"
+fi
+
+# --- Test 7: LOOM_WORKTREE_ROOT override redirects the snapshot location ---
+echo ""
+echo "Test 7: LOOM_WORKTREE_ROOT override redirects .snapshots along with the worktree"
+EXT_ROOT="$TMP/external-root"
+mkdir -p "$EXT_ROOT"
+cd "$REPO"
+LOOM_WORKTREE_ROOT="$EXT_ROOT" ./.loom/scripts/worktree.sh 204 >/tmp/snap-out7-create.$$ 2>&1 || true
+echo "override content" >> "$EXT_ROOT/$(basename "$REPO")/issue-204/tracked.txt"
+if LOOM_WORKTREE_ROOT="$EXT_ROOT" ./.loom/scripts/worktree.sh snapshot 204 >/tmp/snap-out7.$$ 2>&1; then
+    if find "$EXT_ROOT/$(basename "$REPO")/.snapshots" -name "issue-204-*.patch" 2>/dev/null | grep -q .; then
+        pass "snapshot under LOOM_WORKTREE_ROOT lands under the overridden root, not the default"
+    else
+        fail "no snapshot found under the overridden LOOM_WORKTREE_ROOT"
+    fi
+    if [[ ! -d ".loom/worktrees/.snapshots" ]] || ! find ".loom/worktrees/.snapshots" -name "issue-204-*.patch" 2>/dev/null | grep -q .; then
+        pass "no stray snapshot written to the default .loom/worktrees/.snapshots path"
+    else
+        fail "snapshot leaked into the default path despite LOOM_WORKTREE_ROOT override"
+    fi
+else
+    fail "snapshot failed under LOOM_WORKTREE_ROOT override (see /tmp/snap-out7.$$)"
+fi
+
+# --- Test 8: --json emits a single parseable success document --------------
+echo ""
+echo "Test 8: snapshot --json emits a single parseable JSON document"
+make_worktree 205
+cd "$REPO"
+echo "json test" >> ".loom/worktrees/issue-205/tracked.txt"
+if ./.loom/scripts/worktree.sh snapshot 205 --json >/tmp/snap-out8.$$ 2>/tmp/snap-err8.$$; then
+    if grep -q '"success": true' /tmp/snap-out8.$$ && grep -q '"hasChanges": true' /tmp/snap-out8.$$ && grep -q '"patchPath"' /tmp/snap-out8.$$; then
+        pass "--json emits success=true, hasChanges=true, patchPath on stdout"
+    else
+        fail "--json output missing expected fields (see /tmp/snap-out8.$$)"
+    fi
+else
+    fail "snapshot --json exited non-zero (see /tmp/snap-out8.$$ /tmp/snap-err8.$$)"
+fi
+
+# --- Test 9: Loom runtime markers are excluded even with --include-untracked
+echo ""
+echo "Test 9: Loom runtime markers are never captured, even with --include-untracked"
+make_worktree 206
+cd "$REPO"
+touch ".loom/worktrees/issue-206/.loom-in-use" ".loom/worktrees/issue-206/.loom-checkpoint"
+echo "real wip" > ".loom/worktrees/issue-206/real-wip.txt"
+if ./.loom/scripts/worktree.sh snapshot 206 --include-untracked >/tmp/snap-out9.$$ 2>&1; then
+    patch9="$(find ".loom/worktrees/.snapshots" -name "issue-206-*.patch" 2>/dev/null | head -1)"
+    if [[ -n "$patch9" ]] && grep -q "real-wip.txt" "$patch9" && ! grep -q "\.loom-managed" "$patch9" && ! grep -q "\.loom-in-use" "$patch9" && ! grep -q "\.loom-checkpoint" "$patch9"; then
+        pass "runtime markers excluded from the patch; real WIP included"
+    else
+        fail "runtime markers leaked into the patch, or real WIP was missing (see $patch9)"
+    fi
+else
+    fail "snapshot --include-untracked exited non-zero (see /tmp/snap-out9.$$)"
+fi
+
+# --- Summary ----------------------------------------------------------------
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+[[ $TESTS_FAILED -eq 0 ]] || exit 1

--- a/defaults/scripts/worktree.sh
+++ b/defaults/scripts/worktree.sh
@@ -9,6 +9,11 @@
 #   pnpm worktree <issue-number> --sparse <paths...>   # Cone-mode sparse checkout
 #   pnpm worktree <issue-number> --full                # Convert sparse worktree to full
 #   pnpm worktree remove <issue-number> [--keep-branch] [--force]  # Remove one managed worktree
+#   pnpm worktree snapshot <issue-number> [--include-untracked] [--json]
+#     # Write a patch file capturing the worktree's uncommitted diff to
+#     # <worktree-root>/.snapshots/issue-<N>-<UTC-timestamp>.patch — WITHOUT
+#     # touching `git stash` (which is repo-global and can be clobbered by a
+#     # concurrent builder in another worktree). Replay with `git apply`.
 #   pnpm worktree --check                              # Check if currently in a worktree
 #   pnpm worktree --json <issue-number>                # Machine-readable output
 #   pnpm worktree --return-to <dir> <issue-number>     # Store return directory
@@ -560,6 +565,176 @@ remove_worktree_command() {
 }
 
 # --------------------------------------------------------------------------
+# Worktree-scoped snapshot (issue #4778)
+# --------------------------------------------------------------------------
+#
+# `worktree.sh snapshot <N>` captures a worktree's uncommitted WIP as a
+# standalone patch file WITHOUT touching `git stash` at all. `git stash` is
+# repo-global across worktrees — one shared stash list for the whole repo —
+# so two builders stashing around the same time in different `issue-<N>`
+# worktrees can pop/clobber each other's WIP (documented cross-worktree
+# contamination class). A patch file is inherently per-invocation and
+# per-path: there is no shared mutable list to collide on.
+#
+# Deterministic, discoverable location — resolved through the SAME
+# loom_worktree_root() the rest of this script uses, so an overridden
+# LOOM_WORKTREE_ROOT / worktree.root config redirects snapshots along with
+# worktrees rather than falling back to a hardcoded `.loom/worktrees` path:
+#
+#   $(loom_worktree_root <repo_root>)/.snapshots/issue-<N>-<UTC-timestamp>.patch
+#
+# This is deliberately the same family as check-main-clean.sh's --quarantine
+# rescue path: both produce a "replay this diff inside your worktree"
+# artifact, and both are named/labeled by issue for attribution. They differ
+# in mechanism on purpose: check-main-clean.sh rescues contamination that
+# leaked into the shared MAIN checkout (its whole point is a repo-global
+# stash ref, because the dirt itself is repo-global); `snapshot` rescues one
+# worktree's own WIP (its whole point is per-path isolation, because the
+# thing it's defending against IS the shared stash list). Replay contract for
+# both is the same: `git apply <patch>` against a fresh checkout reproduces
+# the captured diff.
+snapshot_worktree_command() {
+    local issue_number="" json=false include_untracked=false
+    local usage="Usage: pnpm worktree snapshot <issue-number> [--include-untracked] [--json]"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --include-untracked) include_untracked=true; shift ;;
+            --json)               json=true; shift ;;
+            --*)
+                print_error "Unknown flag for snapshot: $1"
+                echo ""
+                echo "$usage"
+                return 1
+                ;;
+            *)
+                if [[ -z "$issue_number" ]]; then
+                    issue_number="$1"; shift
+                else
+                    print_error "Unexpected argument: $1"
+                    return 1
+                fi
+                ;;
+        esac
+    done
+
+    if [[ -z "$issue_number" ]]; then
+        print_error "snapshot requires an issue number"
+        echo ""
+        echo "$usage"
+        return 1
+    fi
+    if ! [[ "$issue_number" =~ ^[0-9]+$ ]]; then
+        print_error "Issue number must be numeric (got: '$issue_number')"
+        echo ""
+        echo "$usage"
+        return 1
+    fi
+
+    # Mirrors remove_worktree_command's stdout-purity split: in --json mode
+    # human-readable status goes to stderr so stdout carries only the final
+    # JSON document.
+    _snap_info()    { if [[ "$json" == true ]]; then echo -e "${BLUE}ℹ $*${NC}" >&2; else print_info "$*"; fi; }
+    _snap_success() { if [[ "$json" == true ]]; then echo -e "${GREEN}✓ $*${NC}" >&2; else print_success "$*"; fi; }
+    _snap_json() {
+        # $1=success(bool) $2=patchPath $3=hasChanges(bool) $4=bytes
+        [[ "$json" == true ]] || return 0
+        printf '{"success": %s, "issueNumber": %s, "patchPath": "%s", "hasChanges": %s, "bytes": %s}\n' \
+            "$1" "$issue_number" "$2" "$3" "$4"
+    }
+
+    # Resolve the repo root even when invoked from inside a worktree: the git
+    # common dir's parent is always the main workspace.
+    local git_common repo_root
+    if ! git_common=$(git rev-parse --git-common-dir 2>/dev/null); then
+        print_error "Not inside a git repository"
+        return 1
+    fi
+    repo_root=$(cd "$(dirname "$git_common")" 2>/dev/null && pwd) || repo_root="$(pwd)"
+
+    local worktree_root_dir worktree_path
+    worktree_root_dir="$(loom_worktree_root "$repo_root")"
+    worktree_path="$worktree_root_dir/issue-$issue_number"
+
+    if [[ ! -d "$worktree_path" ]]; then
+        print_error "No worktree found at $worktree_path — nothing to snapshot"
+        _snap_json false "" false 0
+        return 1
+    fi
+    if ! git -C "$worktree_path" rev-parse --git-dir >/dev/null 2>&1; then
+        print_error "$worktree_path is not a git working tree"
+        _snap_json false "" false 0
+        return 1
+    fi
+
+    local snapshot_dir="$worktree_root_dir/.snapshots"
+    if ! mkdir -p "$snapshot_dir" 2>/dev/null; then
+        print_error "Could not create snapshot directory: $snapshot_dir"
+        _snap_json false "" false 0
+        return 1
+    fi
+
+    local ts
+    ts="$(date -u +%Y%m%dT%H%M%SZ)"
+    local patch_path="$snapshot_dir/issue-$issue_number-$ts.patch"
+
+    # Optionally fold untracked files into the same patch via a temporary
+    # intent-to-add (`git add -N`), which makes `git diff HEAD` render them as
+    # new-file hunks WITHOUT staging their content. Reverted immediately after
+    # the diff is captured so the worktree ends in its exact prior state
+    # (still untracked, nothing left staged) — this never touches the index
+    # any longer than the single `git diff` call below. Loom runtime markers
+    # (.loom-managed et al) are excluded, same filter as _worktree_dirty_lines,
+    # so a snapshot never captures noise every managed worktree carries.
+    local -a added_for_diff=()
+    if [[ "$include_untracked" == true ]]; then
+        local untracked
+        untracked="$(git -C "$worktree_path" ls-files --others --exclude-standard 2>/dev/null | \
+            grep -vE '(^|/)\.loom-managed$|(^|/)\.loom-in-use$|(^|/)\.loom-checkpoint$|(^|/)\.no-changes-needed$' || true)"
+        if [[ -n "$untracked" ]]; then
+            while IFS= read -r f; do
+                [[ -n "$f" ]] || continue
+                if git -C "$worktree_path" add -N -- "$f" >/dev/null 2>&1; then
+                    added_for_diff+=("$f")
+                fi
+            done <<< "$untracked"
+        fi
+    fi
+
+    # A plain `git diff` (no --exit-code) always exits 0 unless a real error
+    # occurred (bad HEAD, corrupt worktree, etc.) — it does not use exit code
+    # to signal "has changes", so any nonzero here is a genuine failure.
+    local diff_status=0
+    git -C "$worktree_path" diff HEAD > "$patch_path" 2>/dev/null || diff_status=$?
+
+    if [[ ${#added_for_diff[@]} -gt 0 ]]; then
+        git -C "$worktree_path" reset -- "${added_for_diff[@]}" >/dev/null 2>&1 || true
+    fi
+
+    if [[ $diff_status -ne 0 ]]; then
+        rm -f "$patch_path" 2>/dev/null || true
+        print_error "git diff failed for $worktree_path (exit $diff_status)"
+        _snap_json false "" false 0
+        return 1
+    fi
+
+    local bytes has_changes=false
+    bytes=$(wc -c < "$patch_path" 2>/dev/null | tr -d ' ')
+    bytes="${bytes:-0}"
+    [[ "$bytes" -gt 0 ]] && has_changes=true
+
+    if [[ "$has_changes" == true ]]; then
+        _snap_success "Snapshot written: $patch_path ($bytes bytes)"
+    else
+        _snap_info "No uncommitted changes — wrote an empty snapshot: $patch_path"
+    fi
+    _snap_info "Replay into a fresh worktree with: git apply $patch_path"
+
+    _snap_json true "$patch_path" "$has_changes" "$bytes"
+    return 0
+}
+
+# --------------------------------------------------------------------------
 # Sparse-checkout helpers
 # --------------------------------------------------------------------------
 #
@@ -701,6 +876,8 @@ Usage:
   pnpm worktree <issue-number> --sparse <paths...>      Cone-mode sparse checkout
   pnpm worktree <issue-number> --full                   Convert sparse worktree to full
   pnpm worktree remove <N> [--keep-branch] [--force]    Remove one managed worktree
+  pnpm worktree snapshot <N> [--include-untracked] [--json]
+                                                         Save uncommitted WIP as a patch file
   pnpm worktree --check                                 Check if in a worktree
   pnpm worktree --json <issue-number>                   Machine-readable JSON output
   pnpm worktree --return-to <dir> <issue-number>        Store return directory
@@ -748,6 +925,28 @@ Examples:
     found, and print how to preserve the work (commit / save a patch / stash).
     Loom runtime markers (.loom-managed, .loom-in-use, .loom-checkpoint,
     .no-changes-needed) never count as uncommitted work.
+
+  pnpm worktree snapshot 42
+    Writes the worktree's uncommitted diff (tracked-file changes: staged +
+    unstaged, via 'git diff HEAD') to a patch file at:
+      <worktree-root>/.snapshots/issue-42-<UTC-timestamp>.patch
+    Does NOT touch 'git stash' — unlike stash, which is repo-global across
+    every worktree in the repo, this patch file is scoped to this one
+    invocation and this one path, so concurrent snapshots from other
+    'issue-<N>' worktrees can never collide or clobber each other. Replay
+    into a fresh worktree for the same issue with:
+      git -C .loom/worktrees/issue-42 apply <patch-path>
+    A worktree with no uncommitted changes still succeeds, writing an empty
+    patch file rather than erroring.
+
+  pnpm worktree snapshot 42 --include-untracked
+    Same as above, but also folds untracked files into the patch (via a
+    temporary 'git add -N' intent-to-add that is reverted immediately after
+    the diff is captured — the worktree's index ends unchanged). Loom runtime
+    markers are excluded even with this flag.
+
+  pnpm worktree snapshot 42 --json
+    Output: {"success": true, "issueNumber": 42, "patchPath": "/path/to/.snapshots/issue-42-...patch", "hasChanges": true, "bytes": 1234}
 
   pnpm worktree --check
     Shows current worktree status
@@ -858,6 +1057,16 @@ if [[ "$1" == "remove" || "$1" == "--remove" ]]; then
     shift
     # Left of && so set -e does not abort on a non-zero return from the handler.
     remove_worktree_command "$@" && exit 0
+    exit 1
+fi
+
+# Worktree-scoped WIP snapshot verb (issue #4778). Dispatched HERE, before the
+# generic numeric-issue-number validation below, for the same reason `remove`
+# is: `snapshot <N>` must not be rejected as "Issue number must be numeric".
+if [[ "$1" == "snapshot" ]]; then
+    shift
+    # Left of && so set -e does not abort on a non-zero return from the handler.
+    snapshot_worktree_command "$@" && exit 0
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Adds `worktree.sh snapshot <issue-number> [--include-untracked] [--json]`, which writes the worktree's uncommitted diff to a deterministic patch file, without touching `git stash` at all.
- `git stash` is repo-global across worktrees (one shared stash list for the whole repo), so concurrent builders stashing around the same time in different `issue-<N>` worktrees can clobber each other's WIP. A patch file has no shared mutable state to collide on.

## Changes

- `defaults/scripts/worktree.sh` (installed copy `.loom/scripts/worktree.sh` is a symlink to this file in this repo, so no separate sync step is needed):
  - New `snapshot_worktree_command()` — dispatched via `snapshot <N>` alongside the existing `remove`/`--check`/`--json` verbs (before the generic numeric-issue-number validation, same pattern as `remove`).
  - Writes `git -C <worktree> diff HEAD` to `$(loom_worktree_root <repo_root>)/.snapshots/issue-<N>-<UTC-timestamp>.patch` — resolved through the same `loom_worktree_root()` helper the rest of the script uses, so an overridden `LOOM_WORKTREE_ROOT` / `worktree.root` config redirects snapshots along with worktrees (not a hardcoded `.loom/worktrees` path).
  - `--include-untracked` folds untracked files into the same patch via a temporary `git add -N` (intent-to-add), reverted immediately after the diff is captured — the worktree's index ends unchanged (still untracked). Loom runtime markers (`.loom-managed`, `.loom-in-use`, `.loom-checkpoint`, `.no-changes-needed`) are always excluded, even with this flag.
  - `--json` emits `{"success", "issueNumber", "patchPath", "hasChanges", "bytes"}` on stdout (human-readable status on stderr, matching `remove`'s stdout-purity pattern).
  - A worktree with no uncommitted changes still succeeds, writing an empty patch file rather than erroring.
  - Usage header + `--help` text updated with the new verb, examples, and the replay contract (`git apply <patch-path>`).
- `defaults/scripts/tests/test-worktree-snapshot.sh` — new suite (9 scenarios): stash-list untouched by a snapshot, patch lands at the documented path, `git apply` against a fresh checkout reproduces the original diff, `--include-untracked` on/off behavior (and the untracked file staying untracked afterward), empty-diff success on a clean worktree, clean failure on a non-existent worktree, `LOOM_WORKTREE_ROOT` override redirects the snapshot location, `--json` emits a parseable success document, and Loom runtime markers are excluded even with `--include-untracked`.
- `defaults/scripts/tests/ci-wired.txt` — wires the new suite in (required by `check-ci-suite-manifest.sh`'s wired/excluded partition invariant).

## Acceptance Criteria Verification

- [x] `worktree.sh snapshot <issue-number>` writes a patch file capturing the worktree's current uncommitted diff, without touching `git stash` — verified by test 1 (`git stash list` unchanged before/after).
- [x] The patch file's location is deterministic/discoverable (documented in `worktree.sh`'s usage header/help text) — `$(loom_worktree_root <repo_root>)/.snapshots/issue-<N>-<UTC-timestamp>.patch`, documented in both the top-of-file usage comment and `show_help()`.
- [x] A snapshot can be replayed with a plain `git apply` against a fresh worktree for the same issue — verified by test 3 (clone + `git apply --check` + `git apply` reproduces the change).

## Test Plan

- `bash defaults/scripts/tests/test-worktree-snapshot.sh` — 15/15 passed.
- `bash defaults/scripts/tests/check-ci-suite-manifest.sh` — invariant holds (83 suites: 79 wired, 4 excluded).
- Re-ran the full `test-worktree-*.sh` family (`base-override`, `concurrency`, `hookspath`, `json-purity`, `nested-symlinks`, `remove`, `root-override`, `sentinel`, `sentinel-reinvoke`, `snapshot`) — all green, confirming no regression to the existing verbs.
- `bash -n defaults/scripts/worktree.sh` — syntax check passes.

Closes #4778