### PR TITLE
docs: repo hygiene pass — fix stale MCP docs, READMEs, resync re-stamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Dependencies
-node_modules
 node_modules/
 target/
 
@@ -39,7 +38,6 @@ Thumbs.db
 .loom-in-use
 .loom-checkpoint
 .loom-managed
-.no-changes-needed
 .loom/.daemon.pid
 .loom/.daemon.log
 .loom/daemon.sock
@@ -79,7 +77,6 @@ Thumbs.db
 .loom/*.log
 .loom/*.sock
 .loom/*.tmp
-.loom/*.bak
 .loom/logs/
 # <<< loom-managed <<<
 .loom-test-failure-context.json

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ stateDiagram-v2
 **Developer Experience**
 - Git worktree isolation per issue
 - Simple slash command: `/loom:sweep 42` runs a single issue end-to-end
-- MCP integration for programmatic control (19 tools)
+- MCP integration for programmatic control (30 tools)
 - Crash-safe checkpoints: restart `/loom:sweep N` to resume from the last completed phase
 
 ## Forge Support

--- a/assets/tarot-cards/README.md
+++ b/assets/tarot-cards/README.md
@@ -8,12 +8,13 @@ Each agent role has a corresponding tarot card image that represents its archety
 
 | Role | Archetype | File | Description |
 |------|-----------|------|-------------|
-| **Builder** | The Magician | `worker.svg` | Transforms ideas into reality through manifestation and creative energy |
+| **Builder** | The Magician | `builder.svg` | Transforms ideas into reality through manifestation and creative energy |
 | **Curator** | The High Priestess | `curator.svg` | Refines chaos into clarity through intuition and knowledge organization |
 | **Architect** | The Emperor | `architect.svg` | Envisions structure and design through systematic vision and authority |
-| **Judge** | Justice | `reviewer.svg` | Maintains quality through impartial discernment and balanced judgment |
-| **Hermit** | The Hermit | `critic.svg` | Questions to find truth through introspective wisdom and skepticism |
-| **Doctor** | The Hanged Man | `fixer.svg` | Heals what is broken through patient transformation and perspective shifts |
+| **Champion** | Strength | `champion.svg` | Promotes quality work and merges what is ready through steady resolve |
+| **Judge** | Justice | `judge.svg` | Maintains quality through impartial discernment and balanced judgment |
+| **Hermit** | The Hermit | `hermit.svg` | Questions to find truth through introspective wisdom and skepticism |
+| **Doctor** | The Hanged Man | `doctor.svg` | Heals what is broken through patient transformation and perspective shifts |
 | **Guide** | The Star | `guide.svg` | Illuminates priorities through focused guidance and clarity |
 | **Driver** | The Chariot | `driver.svg` | Masters direct action through willpower and human agency |
 
@@ -26,23 +27,23 @@ Each agent role has a corresponding tarot card image that represents its archety
 
 ## Usage
 
-These assets are used throughout the Loom UI:
+These are brand assets; nothing in the codebase consumes them today. They are
+available for:
 
-- **Terminal Settings Modal**: Display role card when selecting agent role
-- **Role Selection Dropdown**: Icon preview for each role option
-- **Documentation**: Visual reference in README and WORKFLOWS
-- **About/Help**: Explain archetypal system to users
+- **Documentation**: Visual reference in READMEs and workflow docs
+- **UI surfaces**: Role pickers, settings modals, about/help pages
+- **External use**: Presentations, articles, and other Loom branding
 
 ## Implementation
 
-To use a tarot card image in the UI:
+To use a tarot card image in a UI:
 
 ```typescript
 // Import the SVG
-import workerCard from '@/assets/tarot-cards/worker.svg';
+import builderCard from '@/assets/tarot-cards/builder.svg';
 
 // Use in component
-<img src={workerCard} alt="Worker - The Magician" class="w-32 h-48" />
+<img src={builderCard} alt="Builder - The Magician" class="w-32 h-48" />
 ```
 
 ## Attribution

--- a/defaults/README.md
+++ b/defaults/README.md
@@ -4,14 +4,21 @@ This directory contains default configuration files and templates for Loom works
 
 ## Structure
 
-- `config.json` - Default configuration for new workspaces
-- `roles/` - System prompt templates for different terminal roles
-- `CLAUDE.md` - AI development context template (copied to workspace root)
+- `config.json` - Default configuration for new workspaces (version 2 schema)
+- `config/` - Additional config data (e.g. `skill-routes.json`)
+- `roles/` - Role definitions (`<role>.md` prompt + `<role>.json` metadata)
+- `docs/` - Reference docs installed to `.loom/docs/`
+- `scripts/` - Helper scripts installed to `.loom/scripts/`
+- `hooks/` - Guard hooks installed to `.loom/hooks/`
+- `runtimes/` - Runtime adapter manifests
+- `optional/` - Opt-in extras (e.g. GitHub workflow templates)
+- `.loom/CLAUDE.md` - AI development context template (copied to workspace root as `CLAUDE.md`)
 - `.claude/` - Claude Code configuration template (copied to workspace root)
 - `.github/` - GitHub labels and issue templates (copied to workspace root)
   - `ISSUE_TEMPLATE/task.yml` - Development task template
   - `ISSUE_TEMPLATE/config.yml` - Issue template configuration
 - `.loom-README.md` - README template for `.loom/` directory
+- `loom.sh` / `package.json` / `.loom-internal.list` - Install plumbing
 
 ## Purpose
 
@@ -105,89 +112,20 @@ This is intentional: defaults/ are distribution templates, the root files are th
 
 ### `config.json`
 
-```json
-{
-  "nextAgentNumber": 4,
-  "agents": [
-    {
-      "id": "1",
-      "name": "Shell",
-      "status": "idle",
-      "isPrimary": true
-    },
-    {
-      "id": "2",
-      "name": "Worker 1",
-      "status": "idle",
-      "isPrimary": false,
-      "role": "claude-code-worker",
-      "roleConfig": {
-        "workerType": "claude",
-        "roleFile": "worker.md",
-        "targetInterval": 300000,
-        "intervalPrompt": "Continue working on open tasks"
-      }
-    }
-  ]
-}
-```
+`config.json` uses the version 2 daemon schema: top-level blocks for `forge`,
+`runtimes`, `safehouse`, `health_monitoring`, `reflection`, `autonomous`, and
+friends, plus the `terminals` array (per-agent role/model). The committed
+`defaults/config.json` is the authoritative example of the structure; the full
+reference for the `autonomous` block and daemon behavior is
+[`.loom/docs/daemon-reference.md`](docs/daemon-reference.md), and `buildGate` /
+`runtimes` / guard-hook options are documented in the docs linked from the root
+`CLAUDE.md` Configuration section.
 
-#### Top-level Fields
+### Role Prompts
 
-- `nextAgentNumber` (number): Counter for naming new agents (Worker 1, Worker 2, etc.)
-  - Increments with each new agent
-  - Persists across app restarts
-  - Independent per workspace
-
-- `agents` (array): List of terminal configurations
-  - Each agent represents a terminal with its configuration
-  - IDs are unique identifiers (can be UUIDs or simple numbers)
-  - One agent should have `isPrimary: true` (the default selected terminal)
-
-#### Agent Fields
-
-**Required:**
-- `id` (string): Unique identifier for the terminal
-- `name` (string): Display name shown in UI
-- `status` (string): Current terminal status - "idle" | "busy" | "needs_input" | "error" | "stopped"
-- `isPrimary` (boolean): Whether this is the default terminal shown on workspace load
-
-**Optional (for worker terminals):**
-- `role` (string): Worker type - `undefined` (plain shell) | "claude-code-worker" | "codex-worker"
-- `roleConfig` (object): Configuration specific to the worker role
-
-#### Role Configuration (`roleConfig`)
-
-When `role` is set to "claude-code-worker" or "codex-worker", the following fields are available:
-
-- `workerType` (string): AI provider - "claude" | "codex"
-  - "claude": Uses Claude Code (Anthropic)
-  - "codex": Uses OpenAI Codex
-
-- `roleFile` (string): Filename of the system prompt in `.loom/roles/`
-  - Example: "worker.md", "issues.md", "reviewer.md"
-  - Prompt files support `{{workspace}}` template variable (replaced with workspace path)
-  - See `roles/` directory for available prompt templates
-
-- `targetInterval` (number): Milliseconds between autonomous worker invocations
-  - `0`: Autonomous mode disabled (manual interaction only)
-  - `300000`: Worker runs every 5 minutes (recommended default)
-  - Must be > 0 to enable autonomous operation
-
-- `intervalPrompt` (string): Message sent to worker at each interval
-  - Only used when `targetInterval > 0`
-  - Example: "Continue working on open tasks"
-  - Can be a simple nudge or specific instruction
-
-### System Prompts
-
-System prompts are stored as markdown files in `.loom/roles/`:
-
-- **`default.md`** - Plain shell environment
-- **`worker.md`** - General development worker
-- **`issues.md`** - GitHub issue creation specialist
-- **`reviewer.md`** - Code review specialist
-- **`architect.md`** - System architecture and design
-- **`curator.md`** - Issue maintenance and enhancement
-
-You can create custom prompt files by adding `.md` files to `.loom/roles/` in your workspace. All prompt files will automatically appear in the Terminal Settings dropdown.
+Role prompts live as markdown files in `roles/` (installed to `.loom/roles/`),
+one `<role>.md` prompt plus an optional `<role>.json` metadata file per role:
+Builder, Judge, Champion, Curator, Architect, Hermit, Doctor, Guide, Driver,
+Auditor, and the `loom.md` daemon-operator surface. See `roles/README.md` for
+the catalog and how to add a custom role (`.loom/roles/<name>.md` in a
+workspace).

--- a/defaults/docs/safehouse.md
+++ b/defaults/docs/safehouse.md
@@ -1,0 +1,1023 @@
+# Safehouse fleet-comms narration (phase 1, #3997)
+
+Loom coordinates through forge labels — that is unchanged and remains the sole
+source of truth. **Safehouse** ([`rjwalters/safehouse`](https://github.com/rjwalters/safehouse))
+adds an optional, additive **narration** side-channel: an end-to-end-encrypted
+Matrix room a human watches in Element to follow a multi-host agent fleet in
+real time, instead of polling `gh` or tailing daemon logs.
+
+Phase 1 **narration** is daemon-side and emit-only: the `loom-daemon` subscribes
+its existing in-process event bus and narrates sweep-lifecycle transitions into
+the room, adding no new event topics and no new publish call sites. On top of
+that, **peer-claim coordination (#4028) makes the room bidirectional** — a
+dedicated read task consumes inbound peer advertisements so daemons on a shared
+backlog back off before the non-atomic `loom:building` label flip would let them
+race. See [Peer-claim coordination](#peer-claim-coordination-cross-host-soft-claim-4028)
+below.
+
+> **Out of scope** (tracked separately): per-worker personas (`loom_builder_42`)
+> and `SAFEHOUSE_PERSONA` forwarding to workers → **#3999**; inbound **human**
+> steering (reading `@`-mentions back to agents) → follow-up (it reuses the same
+> inbound read task #4028 adds); carrying the judge verdict value in an event
+> payload (needs a frozen-taxonomy amendment) → follow-up; the **atomic
+> cross-host claim authority** (a real CAS behind the soft claim) → Phase 2 of
+> #4028. Cloud-host provisioning of `safehoused` (formerly tracked here as
+> **#3998**) has landed — see
+> [Fleet provisioning: cloud workers](#fleet-provisioning-cloud-workers-fleet-add-worker---safehouse-3998)
+> below.
+
+## The degradation contract (read this first)
+
+Safehouse is a **best-effort side-channel with no hard dependency** — it mirrors
+the claude-monitor optional-integration pattern. **Loom never blocks a sweep on
+safehouse.** Concretely:
+
+- `safehouse.enabled` false/absent ⇒ **byte-for-byte no-op**: the daemon does
+  not subscribe to the bus and makes zero socket syscalls.
+- Enabled but the socket is missing/refused, the persona is rejected, or the
+  peer restarts mid-run ⇒ every failure degrades to a single `warn!` (one per
+  outage, not per event) and the sweep proceeds unaffected. The sink reconnects
+  lazily with capped exponential backoff; dropped narration is never retried
+  into a hot loop and never fails a sweep.
+
+## Configuration
+
+An optional `safehouse` block in `.loom/config.json` (shipped in
+`defaults/config.json`), resolved with precedence **env > config >
+default(disabled)**:
+
+```jsonc
+"safehouse": {
+  "enabled": false,       // default off — additive, opt-in
+  "socket": null,         // default: $SAFEHOUSED_SOCKET
+  "room": null,           // omit only if safehoused joined exactly one room
+  "persona": "loom_daemon"
+  // "rooms": { … }       // optional attention-class routing — see below (#4225)
+}
+```
+
+Env overrides (each wins over config for that key):
+
+| Env var | Overrides |
+|---|---|
+| `LOOM_SAFEHOUSE_ENABLED` | `enabled` (`1`/`true`/`yes`/`on` ⇒ on; `0`/`false`/`no`/`off`/`""` ⇒ off) |
+| `LOOM_SAFEHOUSE_SOCKET` | `socket` |
+| `LOOM_SAFEHOUSE_ROOM` | `room` |
+| `LOOM_SAFEHOUSE_PERSONA` | `persona` |
+| `LOOM_SAFEHOUSE_ROOM_SIGNAL` | `rooms.signal` (#4225) |
+| `LOOM_SAFEHOUSE_ROOMS_BY_REPO` | `rooms.byRepo`, as `repo=room[,repo=room…]` (#4225) |
+| `LOOM_SAFEHOUSE_ROOM_CLAIMS` | `rooms.claims` — dedicated peer-claim coordination room (#4713) |
+
+**Socket resolution**: configured `socket` → `$LOOM_SAFEHOUSE_SOCKET` →
+`$SAFEHOUSED_SOCKET`. If none resolves, narration logs one `warn!` and stays off.
+
+### Room routing by attention class (`safehouse.rooms`, #4225)
+
+One room carrying everything — operator conversation, human-must-act handoffs,
+*and* the full narration firehose — drowns the signal it exists to deliver: at
+full concurrency the operator's primary interface (phone, notifications on) takes
+hundreds of messages a night. The optional `rooms` map routes by **attention
+class first, repo second**:
+
+```jsonc
+"safehouse": {
+  "enabled": true,
+  "socket": "/run/safehoused.sock",
+  "persona": "loom_daemon",
+  "rooms": {
+    "signal": "!AbC…:example.org",           // tier 1: loom-fleet, notifications ON
+    "byRepo": {                                // tier 2: per-repo firehose, muted
+      "loom": "!DeF…:example.org",
+      "vibesql": "!GhI…:example.org"
+    }
+    // "claims": "!JkL…:example.org"         // optional: dedicated peer-claim
+                                               // coordination room (#4713) —
+                                               // see "Which room claim ads ride" below
+  }
+}
+```
+
+| Tier | Room | Carries | Volume / notifications |
+|---|---|---|---|
+| 1 | `rooms.signal` (`loom-fleet`) | operator ↔ fleet conversation, every `handoff`, terminal `ack` / `completion`, future wave digests (#4217) | low, notifications **on**, cross-repo by design |
+| 2 | `rooms.byRepo[<repo>]` (`fleet-<repo>`) | `task` (dispatch + phase transitions) and `chat` (worker chatter) | high, **muted** by default, opened while actively watching a repo |
+
+A Matrix **Space** ("2AM Fleet") grouping these rooms is tracked separately in the
+safehouse repo — Loom creates no Space.
+
+**Routing rules**
+
+- **Severity routes, never duplicates.** Every message lands in exactly **one**
+  room; nothing is mirrored.
+- The kind → tier table is the whole routing decision:
+  | Envelope `type` | Room |
+  |---|---|
+  | `handoff`, `ack`, `completion` | signal |
+  | `task`, `chat` | repo firehose |
+  It is written as a **compile-time-exhaustive `match`** over an `EnvelopeKind`
+  enum (`safehouse.rs`), with no wildcard arm, so a future sixth envelope type
+  fails to compile (and a type added to only one of `KNOWN_TYPES` /
+  `EnvelopeKind` fails a test) rather than silently defaulting into the wrong
+  room.
+- **Rooms are per-repo, not per-host.** Host attribution already rides the Matrix
+  sender (per-host bot accounts), so a second host working the same repo posts
+  into the same room.
+- The repo key is the **workspace-root basename** — the same narration convention
+  #4201 uses for `task_id`/body prefixes (`/Users/x/GitHub/vibesql` ⇒ `vibesql`).
+- **`rooms.signal` falls back to the scalar `room`**, so the migration step "add a
+  `byRepo` map, leave `room` as it is" keeps the existing room as the signal room.
+- Workers follow the same map via `fleet-comms.md`: worker `chat`/`task` posts go
+  to the repo room, worker `handoff` to the signal room.
+
+**Lazy room creation.** A repo absent from `byRepo` gets its firehose created on
+its **first narration** (never eagerly for every managed repo): the sink issues a
+socket `create_room` op for the alias `fleet-<repo>` and remembers the resulting
+id for the rest of the daemon's run. If creation is **refused**, that repo
+degrades to the signal room with **one** `warn!` for the whole run (never one per
+message) and the sweep is unaffected — after fixing permissions, restart the
+daemon. A creation that fails at the *transport* layer (a dropped connection) is
+not held against the room: it is retried after the reconnect. As with
+`safehouse.mcpCommand`, the exact `create_room` request/reply shape lives in the
+external `rjwalters/safehouse` repo and is not verifiable from here, so the client
+is lenient (it names the room with both `name` and `alias`, accepts the room id
+under any of the plausible reply keys, and falls back to addressing sends by the
+alias it asked for).
+
+**Migration notes**
+
+- **Absent `rooms` map ⇒ nothing changes.** Every envelope goes to the single
+  `room` exactly as before (including `room: null` ⇒ no `room` key on the wire).
+  This is the default, and it is covered by explicit regression tests. A
+  present-but-empty `"rooms": {}` (or one whose entries are all blank) normalizes
+  back to single-room mode rather than to a routing mode with nowhere to route.
+- **Once the map exists and the bot is in several rooms, explicit ids are
+  required.** The `room: null` convenience only resolves while safehoused has
+  joined *exactly one* room; a multi-room bot rejects every roomless `send` with
+  `'room' required: N rooms joined`. So when you adopt `rooms`, give it a real
+  `signal` id (or leave a real `room` for it to fall back to) — otherwise
+  narration stops with the send-rejected status described below, which names the
+  fix. See the troubleshooting entry.
+- **Peer-claim ads default to the signal room** — the one deliberate exception
+  to "signal-only" — unless an operator opts into a dedicated `rooms.claims`
+  room (#4713). See the peer-claim section below for why, and for the
+  cross-host provisioning requirement that comes with opting in.
+
+New template keys reach existing consumer configs via the installer deep-merge
+(template is the base, existing values win) — no migration needed. The tier
+ownership of the block is noted in
+[`docs/design/config-resolution-tiers.md`](../../docs/design/config-resolution-tiers.md).
+
+## Operator setup: provisioning the persona (requires a safehoused restart)
+
+`safehoused` reads its `personas` allowlist **once at boot** — a plain TOML
+array with **no runtime registration, no glob/prefix matching, and no SIGHUP
+reload**. So the persona Loom narrates as must be added to safehoused's config
+and **safehoused must be restarted** before it will accept the connection:
+
+1. Add the persona to safehoused's config (default `loom_daemon`):
+   ```toml
+   personas = ["loom_daemon"]
+   ```
+2. **Restart `safehoused`** — the allowlist is not hot-reloaded.
+3. Enable Loom narration (`safehouse.enabled = true`, or
+   `LOOM_SAFEHOUSE_ENABLED=1`) and ensure the socket path resolves.
+4. Run a sweep; the room shows `loom-daemon → everyone · task` lines, threaded
+   per **repo-qualified** issue (`<repo>_<issue>`, issue #4201) so two managed
+   repos' identically-numbered issues never collide into one thread.
+
+This static, operator-provisioned model is a phase-1 constraint. Per-issue
+personas (`loom_builder_42`) are blocked upstream until safehoused grows prefix
+support and are tracked in #3999 — do not attempt to register personas at
+dispatch time; there is no such path.
+
+## Connection status: not configured / unreachable / connected / send-rejected (#4345, #4464)
+
+Before #4345, `safehouse.enabled` false/absent, enabled-but-unreachable, and
+enabled-and-connected all looked identical to an operator — silence. Two
+surfaces now report the live state:
+
+- **`loom-daemon status`** (and `status --json`) prints a `Safehouse:` line
+  (a `safehouse` object in JSON) with one of three states, self-reported by
+  the daemon's own live connection — never a second, status-time connection
+  attempt (a CLI-side probe could not know "room joined" the way the daemon's
+  own connection can):
+  - `not configured` — no `safehouse` block, `enabled: false`/absent, or
+    enabled with no socket path resolving at all (nothing to even try). No
+    connection has been attempted.
+  - `configured, unreachable` — enabled, a socket path resolved, but the most
+    recent connect attempt failed, was refused, or dropped. The resolved
+    socket path is included.
+  - `connected` — the most recent connect attempt completed the `hello`
+    handshake. The configured room name is included when one was configured
+    (`safehouse.room` unset is valid only when safehoused joined exactly one
+    room, resolved server-side — the daemon is never told that resolved name,
+    so the line omits it rather than guessing).
+  - `connected, sends rejected: <reason>` (#4464) — the `hello` handshake
+    succeeds (the socket is reachable) but every `send` is rejected at the
+    protocol layer, so nothing reaches the room. The canonical cause is a
+    **multi-room safehoused with `safehouse.room` unset**: safehoused replies
+    `'room' required: N rooms joined` and the fix is to set `safehouse.room`
+    (see the troubleshooting entry below). This state is **sticky** — a
+    reconnect whose `hello` succeeds does not clear it; only a `send` that is
+    actually accepted returns the line to `connected`. Distinct from
+    `unreachable` on purpose: "unreachable" would send an operator chasing the
+    socket/persona instead of the config.
+- **`loom-daemon-start.sh`** prints a cheaper, **static**, pre-connect check at
+  start time (`ok`/`warn` colored, one line): it runs *before* the daemon
+  connects, so it can only distinguish "not configured" from "configured" —
+  proving "connected" needs the daemon's own live socket, which is what
+  `loom-daemon status` is for. Concretely: no `safehouse` block/disabled ⇒
+  `not configured`; enabled with no socket resolving ⇒ `configured,
+  unreachable`; enabled with a socket path that exists as a socket on disk ⇒
+  `configured (socket present)`; enabled with a socket path that does not
+  exist yet ⇒ `configured, unreachable` (the path is included either way).
+
+Implementation: `loom-daemon/src/safehouse.rs`'s `SafehouseState` is a shared
+`Arc<Mutex<..>>` cell (the same injection shape [`PeerClaimView`] already
+uses) updated by both the narration sink ([`run_sink`]) and the peer-claim
+coordination task ([`run_coordination`]) on every connect/disconnect
+transition; `workspace_pool.rs`'s `WorkspacePool` owns one cell per daemon and
+`ipc.rs`'s `build_daemon_status` reads it into a new optional
+`DaemonStatusReport.safehouse` field (`#[serde(default)]`, so an older
+daemon's wire payload — missing the field entirely — still parses).
+`loom-daemon-start.sh`'s static check reuses the same env>config>default
+resolvers `lib/mcp-config.sh` already defines for the safehouse-mcp worker
+injection (phase 2, below) rather than re-deriving them.
+
+### Troubleshooting: `'room' required` rejection (multi-room host) (#4464)
+
+**Symptom.** `loom-daemon status` shows `Safehouse: connected, sends rejected:
+'room' required: N rooms joined`, and the daemon log carries
+`[WARN] safehouse: narration rejected — set safehouse.room — safehoused
+rejected send: 'room' required: …`. Sweeps proceed normally (the degradation
+contract holds), but the room shows nothing from this host and peer-claim dedup
+(#4028/#4431) is silently disabled here.
+
+**Cause.** Omitting `safehouse.room` is valid **only when safehoused joined
+exactly one room** — safehoused then resolves the sole room server-side. Once
+safehoused joins two or more rooms it can no longer guess, so it rejects every
+`send` that does not name a `room`.
+
+**Fix.** Set `safehouse.room` in `.loom/config.json` (or `LOOM_SAFEHOUSE_ROOM`)
+to the room this host should narrate into, then restart the daemon
+(`loom-daemon restart`). The status line returns to `connected` on the first
+accepted send. `loom-daemon-start.sh` also prints a static caveat at start time
+whenever a socket is configured but `safehouse.room` is unset.
+
+**With attention-class routing (#4225)** this is the same failure with one more
+place to look: adopting a `rooms` map *guarantees* a multi-room bot, so the
+roomless convenience stops working for good. Set `rooms.signal` (or
+`LOOM_SAFEHOUSE_ROOM_SIGNAL`) to a real id — or leave `safehouse.room` set, which
+`rooms.signal` falls back to — and give each actively-watched repo a
+`rooms.byRepo` entry (unset repos are created lazily as `fleet-<repo>`, and a
+refused creation degrades that repo to the signal room with one `warn!`).
+
+## New-host onboarding (#4345, #4346)
+
+The path from a fresh interactive host (no `safehoused`, no `safehouse` config
+block anywhere) to `loom-daemon status` reading `connected`. Step 3 registers
+`safehoused` as a **supervised service** (launchd LaunchAgent on macOS,
+`systemd --user` on Linux) via `safehoused-service.sh` (#4346); running it by
+hand is still documented as the debug fallback.
+
+1. **Bot account + credentials.** Provision (or reuse) a Matrix account for
+   the `loom_daemon` persona in the target safehouse deployment — this is an
+   operator-side step in the external `rjwalters/safehouse` repo/deployment,
+   not something this repo automates. Note the account's credentials and the
+   room the fleet uses.
+2. **Build/install `safehoused`.** Build from the `rjwalters/safehouse`
+   checkout per that repo's own instructions. Confirm the `personas` allowlist
+   in its config includes `loom_daemon` (or whichever persona you assign this
+   host, per "Operator setup" above) — the allowlist is boot-time and
+   restart-only, no hot reload.
+3. **Register `safehoused` as a supervised service.** Use
+   [`safehoused-service.sh`](#supervised-service-wrapper-safehoused-servicesh-4346) —
+   it renders and installs a launchd LaunchAgent (macOS) or `systemd --user`
+   unit (Linux) that starts `safehoused` at login and keeps it up
+   (`KeepAlive`/`Restart=always`, so it survives a crash or reboot), mirroring
+   `loom-daemon-start.sh`'s own supervised-service pattern:
+   ```bash
+   # Preview the service definition first (no side effects):
+   ./.loom/scripts/cli/safehoused-service.sh --print-plist   # macOS
+   ./.loom/scripts/cli/safehoused-service.sh --print-unit    # Linux
+   # Then install + start (point --bin at your built safehoused; the socket is
+   # resolved from the same safehouse.socket / $SAFEHOUSED_SOCKET chain the
+   # daemon uses, or pass --socket explicitly):
+   ./.loom/scripts/cli/safehoused-service.sh install --bin "$(command -v safehoused)"
+   ```
+   On a headless Linux host, run `loginctl enable-linger "$USER"` once so the
+   `systemd --user` unit survives a reboot. **Fallback (debug only):** start it
+   by hand under any supervisor — `nohup safehoused &`, a tmux pane, a personal
+   plist. Either way, note the socket path safehoused binds (its own config
+   controls this) for the next step.
+4. **Socket env or config.** Either export `SAFEHOUSED_SOCKET=<path>` (the
+   convention safehoused's own clients read) machine-wide, or set
+   `safehouse.socket` explicitly in this host's `.loom/config.json` — see
+   [Socket resolution](#configuration) above for the full precedence.
+5. **Enable the `safehouse` config block** in `.loom/config.json` (per
+   workspace, since it lives in the per-repo config tier) or export
+   `LOOM_SAFEHOUSE_ENABLED=1` machine-wide:
+   ```jsonc
+   "safehouse": {
+     "enabled": true,
+     "socket": null,      // omit to rely on $SAFEHOUSED_SOCKET
+     "room": null,         // omit only if safehoused joined exactly one room
+     "persona": "loom_daemon"
+   }
+   ```
+6. **Start/restart `loom-daemon`** (`loom-daemon-start.sh`). Its startup
+   banner prints the static `Safehouse:` line described above — confirm it
+   reads `configured (socket present ...)`, not `not configured` or
+   `configured, unreachable`, before moving on.
+7. **Verify with `loom-daemon status`.** Give it a few seconds for the
+   narration sink / peer-coordination task to complete their first connect
+   (the sink connects lazily on the first narrated bus event; the
+   peer-coordination task connects eagerly at daemon startup, so it is
+   usually first to show `connected`). Confirm the `Safehouse:` line reads
+   `connected` with the expected room, then run a sweep and confirm the room
+   shows the `loom-daemon → everyone · task` dispatch line.
+
+If the line sticks at `configured, unreachable`: confirm `safehoused` is
+actually running and bound to the exact path `loom-daemon status` reports,
+that the persona is in safehoused's allowlist (a rejected `hello` also
+degrades to `unreachable` — check the daemon log for `safehoused rejected
+persona`), and that the daemon process can reach the socket path (permissions,
+same-host, no stale socket file from a crashed prior run).
+
+### Supervised service wrapper: `safehoused-service.sh` (#4346)
+
+`defaults/scripts/cli/safehoused-service.sh` (installed as
+`.loom/scripts/cli/safehoused-service.sh`) registers `safehoused` as a
+supervised service so it starts at login and comes back after a crash or
+reboot — the interactive-host counterpart to the cloud-host provisioning path
+(#3998). It mirrors `loom-daemon-start.sh`'s supervised-service pattern
+(launchd LaunchAgent on macOS / `systemd --user` on Linux) including the
+`--print-plist` / `--print-unit` preview modes.
+
+| Command | Effect |
+|---|---|
+| `--print-plist` / `--print-unit` | Print the launchd plist / systemd unit that *would* be installed, no side effects (any platform). |
+| `install` | Render + install + enable + start the service. |
+| `uninstall` | Stop + disable + remove the service definition. |
+| `status` | Report whether the supervised service is loaded / running. |
+
+Parameters (precedence **flag > env > config > default**): `--bin`
+(`SAFEHOUSED_BIN`, else `command -v safehoused`); `--exec "<argv>"`
+(`SAFEHOUSED_EXEC`) for a full ExecStart override when safehoused needs flags;
+`--socket` (else the shared `safehouse.socket` → `$LOOM_SAFEHOUSE_SOCKET` →
+`$SAFEHOUSED_SOCKET` chain the daemon resolves); `--config`
+(`SAFEHOUSED_CONFIG`); `--log` (default `~/.loom/logs/safehoused.log`);
+`--label` / `--unit` for the launchd label / systemd unit name.
+
+**Supervision policy differs from `loom-daemon`'s on purpose.** `loom-daemon`
+uses `KeepAlive:{SuccessfulExit:true}` / `Restart=on-success` because it has a
+clean-exit restart *primitive* (exit 0 == intentional relaunch, the
+`RestartDaemon` path). `safehoused` has no such primitive — it is a persistent
+connection daemon that should simply stay up — so the wrapper renders
+`KeepAlive=true` (launchd) / `Restart=always` + `RestartSec=5` (systemd).
+
+**Ownership decision (recorded here per #4346's acceptance criteria):** this
+wrapper is deliberately **safehoused-agnostic** and lives in *this* repo, while
+the **authoritative** service definition (safehoused's real argv, config
+schema, and key-backup / steady-state teardown semantics) is owned by the
+external `rjwalters/safehouse` repo. loom does not vendor safehoused's binary
+invocation — that would rot the moment the external repo changes it — so the
+wrapper only supervises an operator-supplied binary and bakes a minimal,
+non-secret environment (`SAFEHOUSED_SOCKET` / `SAFEHOUSED_CONFIG` when
+provided; never a forwarded token). If the safehouse repo ships its own service
+files, point the runbook at those and treat this generator as the fallback.
+
+## Fleet provisioning: cloud workers (`fleet add-worker --safehouse`, #3998)
+
+The onboarding runbook above is for an interactive host an operator sets up by
+hand. `loom-daemon fleet add-worker <ssh-host> --repo <owner/name> --safehouse
+<inputs>` (epic #4340, `loom-daemon/src/fleet/add_worker.rs`) is the same
+onboarding **encoded as an ordered, idempotent plan** that a cloud worker's
+spin-up runs unattended over SSH — no cloud-init fragment, no cloud CLI, no
+Tailscale API call from loom itself (epic #4340's boundary: a VM comes from
+`repo:remote`, loom only consumes "a reachable box + an SSH alias").
+
+### What the plan does
+
+With `--safehouse`, `fleet add-worker` appends seven steps after the plain
+worker's bootstrap (each following the same check/apply contract as the rest
+of the plan, so a re-run against an already-provisioned host reports every one
+`AlreadyDone`):
+
+1. **`safehouse-tailscale-install`** — installs the `tailscale` apt package.
+2. **`safehouse-tailscale-join`** — `tailscale up --auth-key=file:<path>` with
+   the operator-minted key (below). No `--advertise-tags`: the tag is baked
+   into the key server-side.
+3. **`safehouse-build`** — `cargo build --release -p safehoused` from a fresh
+   `rjwalters/safehouse` checkout.
+4. **`safehouse-config`** — writes `~/.loom/safehoused/config.toml` (`0600`):
+   homeserver URL, the per-host Matrix account, fresh store/recovery
+   passphrases, and the persona allowlist. **Must precede step 6** — the
+   allowlist is boot-time-only (no reload), and the plan's step order enforces
+   this (asserted in `add_worker.rs`'s tests).
+5. **`safehouse-room-invite`** — joins the fleet room via
+   [safehouse#39](https://github.com/rjwalters/safehouse/issues/39)'s
+   daemon-side `invite` op — never raw CS-API temporary devices. loom does not
+   vendor this invocation (owned by the external repo); override it with
+   `--safehouse-invite-exec "<argv>"` if it changes upstream.
+6. **`safehouse-supervise`** — installs `safehoused` under `systemd --user` via
+   [`safehoused-service.sh`](#supervised-service-wrapper-safehoused-servicesh-4346)
+   (the same script the interactive runbook uses) and enables lingering.
+7. **`safehouse-daemon-restart`** — wires `LOOM_SAFEHOUSE_ENABLED` /
+   `_SOCKET` / `_ROOM` into the worker's own `loom-daemon` systemd unit and
+   restarts it — env-only, per #3997's decision (no worker-side
+   `.loom/config.json` edit).
+
+**Without `--safehouse`, behavior is byte-for-byte unchanged**: a single
+`safehouse` skip-with-notice entry, a plain worker, zero safehouse
+provisioning.
+
+### Inputs the operator must mint
+
+Every secret travels the same way `AddWorkerConfig`'s existing `--pat-file` /
+`--accounts-env` do: read locally at preflight, transferred to the worker only
+over **ssh stdin**, landing only in `0600` files. None of these ever appear on
+a command line, in the rendered `--dry-run` plan text, in a daemon log at any
+level, or in the fleet registry.
+
+| Flag | Contents | Notes |
+|---|---|---|
+| `--safehouse-tailnet-auth-key-file PATH` | A Tailscale auth key | **Operator-minted, ephemeral + `tag:loom-worker`** — loom never calls the Tailscale API. Ephemeral means a dead VM auto-deregisters from the tailnet with no fleet-roster bookkeeping. |
+| `--safehouse-secrets-file PATH` | `KEY=VALUE` lines: `SAFEHOUSE_MATRIX_USER_ID`, `SAFEHOUSE_MATRIX_PASSWORD`, `SAFEHOUSE_STORE_PASSPHRASE`, `SAFEHOUSE_RECOVERY_PASSPHRASE` | The Matrix account is **operator-created** on the homeserver (the [safehouse#25 verified sequence](#operator-setup-provisioning-the-persona-requires-a-safehoused-restart)) — `fleet add-worker` never needs homeserver admin credentials, only the resulting account. Passphrases are freshly generated per host. |
+| `--safehouse-homeserver-url URL` | Not secret | Must resolve inside the tailnet. |
+| `--safehouse-room ROOM` | Not secret | The fleet room this host joins. |
+| `--safehouse-persona NAME` (repeatable) | Not secret | Mirrors the studio host's allowlist (#3999) — at least one required. |
+| `--safehouse-repo-url URL` | Not secret | Defaults to `rjwalters/safehouse`. |
+| `--safehouse-invite-exec "ARGV"` | Not secret | Overrides the default `safehoused invite --config <path>` if safehouse#39's CLI surface changes upstream. |
+
+`--safehouse` with any of the first five omitted fails **preflight** — before
+any SSH connection — with a message naming exactly which flag is missing (no
+half-joined host).
+
+### Required tailnet ACL
+
+The auth key's `tag:loom-worker` is expected to carry an ACL restricting
+workers to reaching only the homeserver's `443`, not the rest of the tailnet.
+loom documents this requirement; it does not manage the tailnet ACL itself
+(epic #4340's boundary — no Tailscale API call from this repo).
+
+### Teardown: `fleet drain`'s flush verification
+
+`fleet drain <ssh-host>`'s `flush-safehouse` phase (`loom-daemon/src/fleet/drain.rs`)
+is the spin-up's counterpart: it stops the worker's `safehoused` unit over SSH
+(`systemctl --user stop safehoused`) — a supervised stop **is** the flush,
+since safehoused's SIGTERM/ctrl-c shutdown path calls
+`client.encryption().backups().wait_for_steady_state()` and prints
+`"safehoused: room-key backup flushed; bye"` before exiting — then verifies via
+the journal line, falling back to the unit's `ExecMainStatus` when the journal
+has rotated. The verdict maps onto drain's existing contract:
+
+- `safehouse.enabled == false` — `Skipped`, no room keys in play, exit `0`.
+- Flush verified — `Changed`, eligible for "safe to power off", exit `0`.
+- Flush **not** verified (nonzero remote exit, or the host was unreachable) —
+  `Unverified`; the drain still completes (workspace/roster cleanup proceed —
+  loom never refuses to retire a box over this), but the report withholds
+  "safe to power off" and exits `3` so an operator/monitor treats it as a flag,
+  not a clean success.
+
+## What gets narrated
+
+The sink maps the **existing frozen event taxonomy** (`event_bus.rs`,
+`types.rs`) to envelope-v1 messages. All are broadcast (`to: "*"`). Which **room**
+each one lands in is decided by its envelope `type` — see
+[Room routing by attention class](#room-routing-by-attention-class-safehouserooms-4225):
+`task` lines (dispatch/phase) go to that repo's firehose, while `handoff` /
+`ack` / `completion` (blockers, crashes, terminal outcomes) go to the signal room.
+With no `rooms` map configured they all go to the one `room`, as before.
+
+### Repo qualification (issue #4201)
+
+The daemon manages multiple workspaces (loom, vibesql, anvil, kicad-tools, …)
+behind a **single shared event bus** (`workspace_pool.rs`), so a bare issue
+number is not unique across them — loom `#4201` and vibesql `#4201` would
+otherwise thread into the *same* Matrix room thread. Every narrated event's
+`task_id` and body prefix are therefore **repo-qualified**:
+
+- **Convention**: the repo name is the **basename of the workspace-root
+  filesystem path** stamped onto the event's `repo` field by
+  `SweepRegistry::emit_event` (Issue #3929's pattern) — e.g.
+  `/Users/x/GitHub/vibesql` → `vibesql`. This is a path-derived directory name,
+  not a forge `owner/repo` slug: it needs no network call, and the daemon's
+  workspace registry already guarantees at most one managed registry per path.
+- **`task_id`**: `<repo>_<issue>` (e.g. `vibesql_6173`), with any character
+  outside the `[A-Za-z0-9_]` charset (`build_send_request` enforces this)
+  folded to `_` — so `kicad-tools` becomes `kicad_tools`.
+- **Body prefix**: `<repo>#<issue>` (e.g. `vibesql#6173`), used verbatim since
+  the body is free text with no charset restriction.
+- **Fallback**: an event with no `repo` known (a synthetic/test event, or one
+  from an era before this field existed) narrates with the pre-#4201
+  unqualified form — bare `<issue>` for `task_id`, bare `#<issue>` for the body
+  prefix — rather than erroring.
+
+`SweepGlobalDispatch` needed a small additive amendment (`repo: Option<String>`)
+to carry this — it was the one sweep-scoped event that had not yet been stamped
+with `repo`, unlike `SweepPhase`/`SweepBlocker`/`SweepExited`/`SweepCrashed`.
+
+### Body grammar (issue #4201)
+
+Every narrated body follows `<repo>#<issue> · <phase/status> [· <detail>] [—
+<commentary>]` — informal by design (there is no single rigid 4-field parse),
+but consistently repo-qualified and consistently favoring one line of
+actionable detail over the previous terse `issue #N …` phrasing:
+
+| Bus event | Envelope `type` | Body |
+|---|---|---|
+| `SweepGlobalDispatch` (Issue) | `task` | `<repo>#N · dispatch` — the sink best-effort appends ` — "<issue title>"` (see below) |
+| `SweepPhase` | `task` | `<repo>#N · <phase>` (+ ` · PR #M open` when present) |
+| `SweepBlocker` | `handoff` | `<repo>#N · BLOCKED — <reason>` (a human must act) |
+| `SweepExited` (exit 0) | `ack` | `<repo>#N · done ✓ · <dur>` (e.g. `6m55s`) |
+| `SweepExited` (exit ≠ 0) | `ack` | `<repo>#N · failed ✗ · exit <code>[ (decoded)] · <dur>` — exit `78` decodes to `(EX_CONFIG: token pool)`; every other code prints raw (no attempt at a full sysexits table) |
+| `SweepCrashed` | `handoff` | `<repo>#N · crashed ✗ at <checkpoint_phase> — resumable (checkpoint kept)` |
+| `SweepExited` **whose PR merged** (#4426) | `completion` | `<repo>#N · merged ✓ · PR #M · <dur>` — emitted *in addition to* the `ack`, carrying the `completion-v1` `meta` (see below) |
+
+**Dispatch-line title (AC3)**: the operator's highest-value ask was seeing the
+issue title on the dispatch line (the single most common message in the room —
+33 of 60 messages in the first night's history were bare dispatch roots). The
+payload-amendment route (threading the title through `SweepGlobalDispatch`)
+was judged too heavy for this bug-fix issue, unlike the small `repo` amendment
+above (which fixes an actual collision bug). Instead the **sink** fetches it at
+narration time — one `gh issue view --json title --jq .title` in the event's
+workspace root, bounded by a 5s timeout, with a 10-minute cache keyed by
+`(workspace_root, issue)` so a re-dispatch of the same issue (e.g. after a
+Doctor cycle) does not re-shell to `gh`. Every failure (missing `gh`, no
+network, unauthenticated, timeout) degrades to narrating the dispatch line
+**without** a title — this never blocks narration or the sweep itself.
+
+`SweepGlobalCompleted` is intentionally **not** narrated: it carries only a
+`sweep_id` (no issue number), and `SweepExited` already emits the completion
+`ack` with richer data — narrating both would double-post per completion.
+
+### Completion envelopes → the public fleet feed (#4426)
+
+safehoused's egress subsystem mirrors well-formed **`completion`** envelopes out
+of allowlisted rooms — redacted and delay-buffered — to a `sink_url`; that is
+what feeds the public fleet feed on 2amlogic.com. Loom is the producer:
+
+- **Emit point (two, since #4583)**:
+  1. The narration sink, on `SweepExited`. Exit status alone proves nothing, so
+     the sink checks **forge truth** (`gh pr list --head feature/issue-N
+     --state merged`, in the event's workspace root, 10s timeout) and emits
+     the `completion` only when that issue's PR actually merged — the `ack`
+     still goes out either way. Chosen over having the sweep child publish a
+     post-merge phase event because it is daemon-only (no skill edit), has the
+     sweep timing to hand, and verifies rather than trusts.
+  2. **Periodic merge reconciliation** (`reconcile_recent_merges`, #4583): the
+     `SweepExited` path only ever fires while a sweep process is alive to exit
+     — it structurally cannot see a PR that merges *after* the sweep already
+     exited, which is the **common steady-state path**: builder opens a PR,
+     judge approves, the sweep exits, and champion merges it minutes-to-hours
+     later on its own cron tick. On a fixed cadence (5 minutes;
+     `LOOM_SAFEHOUSE_RECONCILE_INTERVAL_MS` overrides it, primarily a test
+     seam), the sink round-robins one workspace at a time — drawn from the
+     union of every repo it has observed a stamped-`repo` event for and the
+     on-disk `WorkspaceRegistry` — and runs one **bulk**, branch-unfiltered
+     `gh pr list --state merged --json
+     number,headRefName,url,mergedAt,createdAt,title,additions,deletions
+     --limit 30`. Each row's issue number is recovered from `headRefName` via
+     the `feature/issue-<N>` convention
+     (`worktree_ops::naming::issue_from_branch`); rows that do not match are
+     skipped (not every merged PR is an issue sweep). A row with no sweep clock
+     available uses the PR's own `createdAt`/`mergedAt` pair as the
+     `started_at`/`completed_at` proxy instead of the reaper's clock. Both
+     paths funnel through the same envelope-build/dedup-insert core
+     (`build_and_narrate_completion`), so "exactly one completion per merge"
+     holds regardless of which path observes it first.
+     - **Lookback window**: rows merged more than **7 days** ago are dropped
+       before the dedup check (`LOOM_SAFEHOUSE_RECONCILE_MAX_AGE_SECS`
+       overrides; garbage/negative values fall back to the default). `--limit
+       30` bounds a burst's *size*, not its *age* — without the window, a pass
+       on a host with no persisted dedup set (fresh install, the upgrade to
+       this version, a lost/corrupt completions file) would backfill the feed
+       with the last 30 merges however old they are, which in a low-traffic
+       workspace means narrating months-old PRs as if they just landed. Seven
+       days is far beyond any plausible daemon outage, so the daemon-was-down
+       case below still recovers.
+     - **Seed-only first pass per workspace (#4649)**: the lookback window
+       alone still allowed a *burst* — up to 30 genuinely-in-window merges
+       narrated in one tick — the very first time a workspace was reconciled
+       on a host with no reliable persisted dedup state (absent, corrupt, or
+       unreadable `~/.loom/safehouse-completed.json`; a legitimately empty but
+       valid file, e.g. a host that already reconciled to zero, does **not**
+       count as fresh). In that case each workspace's first-ever reconciliation
+       tick after startup inserts every in-window `(workspace, issue)` into the
+       dedup set and persists it, but drops the resulting envelopes instead of
+       narrating them. The same workspace's next tick — and every tick on a
+       host whose dedup file was not fresh to begin with — narrates normally.
+       Trade-off: a merge that landed just before a fresh install is silently
+       never narrated, which is acceptable since nothing was watching the feed
+       at install time anyway.
+- **`meta` (`completion-v1`)**: `{schema, agent, repo, ref, result, started_at,
+  completed_at}` required, plus optional `issue`/`tokens`/`title`/`additions`/
+  `deletions` (envelope-v1 preserves unknown `meta` keys, so no schema rev is
+  needed for extensions). `body` stays required human prose — a room reader sees
+  a sentence, `meta` is the machine view.
+- **`repo` is the forge `owner/repo` slug** (`gh repo view --json
+  nameWithOwner`, cached per workspace for the daemon's lifetime), deliberately
+  **not** the path-basename convention above: the feed links `ref` (the PR URL)
+  and displays the forge identity.
+- **Display fields (#4497)** feed the site's row format
+  `<repo>#<issue>: <title> +A −D · <dur> · <tokens> tok`, i.e. the
+  development-cost-of-quality-code view:
+  - `title`/`additions`/`deletions` come out of the **same** `gh pr list` call
+    that verifies the merge (`--json number,url,mergedAt,title,additions,deletions`),
+    so they cost **zero** extra forge round-trips. Each degrades independently:
+    a row that omits one still publishes the completion without that key. A `gh`
+    too old to know a field rejects the whole request, so that one case retries
+    the pre-#4497 `number,url,mergedAt` set rather than losing the completion.
+  - Unlike `tokens`, a real **`0`** additions/deletions is a fact about the merge
+    (an empty-diff merge, a pure revert) and is published as `0`; a blank `title`
+    is omitted.
+  - `tokens` is a best-effort per-issue total from **two** sources, tried in
+    order, each on the blocking pool with its own 5s cap:
+    1. The in-process activity DB's per-issue rollup
+       (`ActivityDb::get_cost_by_issue`) — **input + output**.
+    2. **The sweep's own on-disk Claude Code transcripts** (#4699) — all four
+       usage counters (`input`, `output`, `cache_read`, `cache_creation`), i.e.
+       total tokens processed.
+
+    **Attribution is knowingly imperfect** for both. The rollup keys on a bare
+    issue number (no repo column, so a multi-repo daemon conflates identical
+    numbers across repos) and only counts token samples linked to the issue
+    through `agent_inputs`, making the figure a floor. That is a deliberate
+    operator call: for a cost *trend*, imperfect-but-consistent beats absent.
+    Both sources coming up empty omits the key rather than charting free work.
+
+    > **Operational gotcha — why the DB rollup is silent on a fleet host
+    > (#4699).** The `resource_usage` and `prompt_github` rows the rollup joins
+    > are written from exactly **one** place: the IPC `GetTerminalOutput` handler
+    > scraping a *managed terminal's* scrollback. `dispatch_sweep` spawns a
+    > detached `claude -p` via `spawn-worker.sh` and reaps the OS process — it
+    > issues no `SendInput`/`GetTerminalOutput` round trips — so on any host whose
+    > work arrives by dispatch (i.e. every host that publishes to the feed) both
+    > tables are empty **forever**, not merely "until the prompt↔usage linkage is
+    > established". Measured on the reference host 2026-07-31: 0 rows in each,
+    > across 76 published completions, every one of them `tokens: null`. Source 2
+    > exists because of this; do not diagnose a `tokens: null` feed record by
+    > looking for missing rollup rows.
+
+    The transcript source locates a sweep's session by content, since nothing
+    records a sweep-id → session-uuid mapping: a sweep runs `claude -p
+    "/loom:sweep <issue> …"` with cwd = the workspace root, so Claude Code writes
+    `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/<cwd-slug>/<uuid>.jsonl` (plus
+    `<uuid>/subagents/agent-*.jsonl`, one per phase), and the parent session's
+    first `user` record carries the slash command verbatim. Candidates are
+    narrowed by file mtime against the completion's own time window (±2h slack)
+    before any file is read, and a re-dispatched issue's several sessions are all
+    summed. Because the project directory is keyed by the workspace path, this
+    source *is* repo-qualified — it does not share the rollup's cross-repo
+    issue-number conflation. Cache reads are included because they dominate a
+    sweep both by volume (~99%) and — priced at ~10% of base — by cost, so an
+    input+output-only figure under-reports spend by well over an order of
+    magnitude and unevenly between sweeps. Set
+    `LOOM_SAFEHOUSE_TRANSCRIPT_TOKENS=0` to opt out of the transcript scan
+    entirely (the key is then simply omitted on dispatch-driven hosts).
+  - Absent `tokens`/`title`/`additions`/`deletions` ⇒ the envelope is identical
+    to the pre-#4497 one; none of the four can block or fail an emission.
+
+  > **A `null` field on 2amlogic.com is not evidence of a producer bug (#4699).**
+  > The public feed applies its **own** server-side redaction on read: entries
+  > whose `repo` is not on the site's linked-repo allowlist are served with
+  > `ref` and `title` forced to `null`, keeping the sellable columns
+  > (`repo#issue`, diff stats, timing) while withholding the outbound link. So a
+  > mix of linked and unlinked repos in one feed response legitimately shows
+  > `title: null` next to a populated `additions`. Loom itself cannot emit a
+  > null/absent `ref` at all — it is in `COMPLETION_REQUIRED_KEYS`, so
+  > `validate_completion_meta` rejects the envelope before it can be sent (and
+  > the site's `/api/ingest` validator independently rejects such a payload with
+  > a `400`). **Before filing a producer bug, check the feed record's `repo`
+  > against the site's allowlist and compare against a linked repo's record from
+  > the same tick.**
+- **Timestamps** come from the reaper's clock (`started_at = exit − duration_sec`,
+  `completed_at = exit`), so the pair is always self-consistent.
+- **`result: "failure"` is out of scope for v1**: `completion-v1` requires a
+  `ref`, and a sweep with no merged PR has no meaningful one (an open PR is
+  unfinished, not failed, and is usually resumed). The wire support exists
+  (`CompletionResult::Failure`) for a follow-up that identifies a genuinely
+  terminal negative outcome.
+- **At most one per merge**, deduped on `(workspace, issue)` — shared by
+  **both** emit points above, so a resumed sweep's second `SweepExited` does
+  not double-post, and the periodic reconciliation pass does not re-post a
+  merge the `SweepExited` path already narrated (in either order — whichever
+  path observes the merge first wins; the other becomes a no-op dedup check).
+  This dedup set is **persisted** to `~/.loom/safehouse-completed.json`
+  (`LOOM_SAFEHOUSE_COMPLETIONS_PATH` overrides the path) and reloaded at
+  startup — the in-memory set alone would not survive a daemon restart, which
+  would otherwise either re-post every prior completion (if reconciliation's
+  lookback window still covered them) or silently drop a merge that happened
+  while the daemon was down. It is written atomically (temp file + rename) and
+  every failure to read or write it is best-effort — a corrupt or unwritable
+  file degrades to "no reliable prior state", never to a crash, which (#4649)
+  now routes through the seed-only first pass above rather than re-narrating a
+  potential backlog outright. It grows by one `["<workspace>", <issue>]` pair (~32 bytes)
+  per narrated completion and is never pruned; at Loom's own merge rate that is
+  a couple of MB per decade, so no compaction is implemented. Downstream ingest
+  is additionally idempotent on `event_id`.
+- **Strict client-side construction.** safehoused **silently degrades a
+  malformed `meta` to `chat`** — the event then vanishes from the feed with no
+  error anywhere — so `build_send_request` refuses to send a `completion` unless
+  `validate_completion_meta` accepts it (all required fields present and
+  non-empty, `schema == "completion-v1"`, `agent` a valid persona, `repo` an
+  `owner/repo` slug, `ref` an absolute http(s) URL, `result` ∈
+  {`success`,`failure`}, both timestamps RFC3339 with `completed_at >=
+  started_at`, `issue`/`tokens`/`additions`/`deletions` non-negative integers
+  when present, `title` a non-empty string when present). Nothing here relies on
+  server-side validation.
+- **Redaction is downstream.** Every `meta` string — `title` included — is
+  published as an ordinary JSON string, so safehoused's egress deny-pattern pass
+  redacts it exactly like `repo`/`ref`. Loom applies no bespoke encoding that
+  could let a value slip past that pass.
+- **Same degradation contract**: a failing/absent/slow `gh`, an unreachable
+  safehoused, or a rejected envelope drops the completion silently and never
+  affects the sweep.
+
+## Wire protocol (envelope v1)
+
+- `AF_UNIX`, **newline-delimited JSON**, one object per line, bidirectional.
+- Mandatory first request: `{"id":0,"op":"hello","persona":"<name>"}`.
+- `send` carries `to`/`type`/`body` and optional `task_id`/`room`/`meta`. `type`
+  is a closed enum `{chat,task,handoff,ack,completion}` owned by the safehouse
+  repo (loom invents no members); `task_id` must be `[A-Za-z0-9_]`; `meta` is
+  valid **only** on a `completion`, which in turn **requires** it (see above) —
+  all validated before sending. The daemon **stamps `from`** from the socket
+  identity — the client never sends one (no impersonation).
+- Replies echo the request `id`. **Async push lines are interleaved on the same
+  connection, carry an `event` key, and have no `id`** — the client
+  demultiplexes by skipping any line with an `event` key. The **narration**
+  connection is emit-only and discards inbound pushes; the **peer-claim
+  coordination** connection (#4028) instead routes each inbound `event` line to a
+  handler (see below).
+
+## Implementation
+
+- `loom-daemon/src/safehouse.rs` — config resolver, envelope-v1 client, the
+  event→envelope mapping, the reconnecting bus-subscriber narration sink, and
+  (#4028) the peer-claim coordination task + `InboundEventSink`. Also (#4225) the
+  attention-class routing layer: `RoomMap` (config/env), `EnvelopeKind` +
+  `AttentionClass` (the exhaustive kind → tier table), `RoomRouter` (per-envelope
+  room resolution, lazy `fleet-<repo>` creation, warn-once degradation) and
+  `SafehouseClient::send_to` / `create_room`.
+- `loom-daemon/src/transcript_tokens.rs` — (#4699) the on-disk token source
+  behind the completion envelope's `tokens` field: Claude Code's project-slug
+  mangling, the `/loom:sweep <issue>` session match, mtime windowing and the
+  parent+subagents usage sum. Pure filesystem code with no safehouse dependency,
+  so it is unit-testable on its own; `safehouse.rs` wraps it in the timeout and
+  the `LOOM_SAFEHOUSE_TRANSCRIPT_TOKENS` opt-out.
+- `loom-daemon/src/peer_claims.rs` — the pure, socket-free peer-claim view
+  (TTL expiry, self-claim recognition, retraction, `ClaimAd` parse/serialize).
+- `loom-daemon/src/workspace_pool.rs` — `start_safehouse_narration()` and
+  `start_peer_coordination()` subscribe/attach the shared `Arc<EventBus>` /
+  `PeerClaimView` and spawn on the daemon runtime; both no-ops when disabled.
+  Also (#4345) owns the `SharedSafehouseState` cell and exposes
+  `safehouse_status()` for `ipc::build_daemon_status`.
+- `loom-daemon/src/types.rs` — `DaemonStatusReport.safehouse` /
+  `SafehouseStatus` (#4345), the wire shape for the connection-state line.
+- `loom-daemon/src/ipc.rs` / `loom-daemon/src/main.rs` — (#4345)
+  `build_daemon_status` reads the pool's `safehouse_status()`; `main.rs`
+  renders the `Safehouse:` human line and the `safehouse` JSON object.
+- `defaults/scripts/cli/loom-daemon-start.sh` — (#4345) the static
+  pre-connect `Safehouse:` line, via `lib/mcp-config.sh`'s existing
+  `loom_mcp_safehouse_enabled`/`loom_mcp_safehouse_socket` resolvers.
+- Tests: `safehouse.rs`'s `mod tests` (state-cell + wire-rendering cases),
+  `workspace_pool.rs`'s `mod tests` (pool wiring), `ipc.rs`'s
+  `test_build_daemon_status_reports_halt_and_in_flight` (report field),
+  `defaults/scripts/tests/test-loom-daemon-start.sh` (start-wrapper line).
+
+## Peer-claim coordination: cross-host soft claim (#4028)
+
+On a multi-host deployment the only cross-host claim signal is the forge label,
+whose `loom:issue → loom:building` flip is **not** compare-and-swap
+(`SweepRegistry::flip_label_to_building` is an unconditional
+`--remove-label`/`--add-label`) — two hosts can both read `loom:issue` and
+dispatch before either flip propagates, producing duplicate sweeps. Peer-claim
+coordination shrinks that window:
+
+- **Advertise.** At the dispatch decision point — right after the local claim
+  lock, **before** the label flip — the daemon publishes a claim advertisement
+  over the room: issue number, [repo slug](#), host identity, PID, and a
+  wall-clock timestamp, carried as a **`task`** envelope (the `type` enum is
+  closed and owned by the safehouse repo, so a claim rides `task` with the bare
+  issue number as `task_id` — **no fifth type is invented**) whose `body` is the
+  structured JSON payload (marked `loom_claim`).
+- **Consume.** A **dedicated inbound read task** — separate from the narration
+  sink — drains the socket continuously via `select!`, so an **idle** daemon that
+  emits no narration still observes peer claims promptly (the narration
+  connection only reads while it is emitting). Each inbound claim is folded into a
+  shared `PeerClaimView`.
+- **Back off.** The work-finder skips any issue with a live peer claim, counted
+  under its **own** distinct `peer-claim-skip` reason on the per-tick summary line
+  (never folded into #4085's collision count).
+- **TTL.** Every peer claim expires after **`safehouse.peerClaimTtlSecs`
+  (default 120s = 2× the 60s work-finder interval)**, so a crashed peer cannot
+  permanently starve an issue. The TTL clock is the **local receipt `Instant`**,
+  never the advertiser's wall clock (clock skew is not comparable across hosts).
+  A peer also **retracts** its claim early when its sweep exits/crashes (a
+  `retract`-kind ad emitted from the reaper), freeing the issue before the TTL.
+- **Host identity.** loom's single, explicit host-identity concept is
+  `sweep_registry::host_identity()` (`LOOM_HOST_ID` > `$HOSTNAME` > the `hostname`
+  binary > `unknown-host`) — derived, not a new config block, and stable across
+  restarts. safehoused stamps the socket `from` from the *persona* (all daemons
+  share `loom_daemon`), which cannot distinguish hosts, so the identity travels in
+  the claim body and is what powers self-claim recognition: **a daemon never backs
+  off on its own advertisement.**
+- **Event taxonomy.** The internal pub/sub topic taxonomy is frozen; peer claims
+  add **no new bus topic** — they travel entirely over the safehouse room.
+
+### Which room claim ads ride: the signal room by default, opt-in dedicated room (#4225, #4713)
+
+A claim ad is a `task` envelope carrying per-repo machine chatter, so the
+attention-class table would put it in the repo firehose. By default it rides the
+**signal room** instead — the one deliberate exception to "the signal room is
+signal-only":
+
+1. **The signal room is the only room with guaranteed common membership.** Firehose
+   rooms are created **lazily** by whichever host narrates that repo first, and
+   each host runs its **own bot account**. Host A creating `fleet-loom` does not
+   join host B's bot to it, so an ad posted there is invisible to B until an
+   operator invites it — silently disabling cross-host dedup with no error
+   anywhere (exactly the failure class #4464 had to add a status state for). Every
+   host's bot is already in the signal room.
+2. **Dedup is correctness; room hygiene is cosmetics.** A missed ad costs a
+   duplicate cross-host sweep (wasted tokens, two PRs for one issue); a little
+   machine JSON in the signal room costs some scroll. Correctness wins, and this
+   is why the dedicated-room escape hatch below is opt-in rather than the new
+   default.
+3. **The reader agrees with the writer by construction.** The coordination task's
+   inbound handler is unfiltered — it folds *any* inbound line with a parseable
+   `loom_claim` body into the view — so keeping the write side and the read side
+   on the same resolved room makes the pair trivially consistent instead of
+   dependent on which rooms this host's bot happens to have joined.
+
+**The volume problem (#4713).** Ads are low volume per dispatch/terminal outcome,
+but `sweep_registry::readvertise_peer_claims` re-publishes every **live** sweep's
+claim on every 30-second reaper tick — deliberately, to stay under the
+peer-claim TTL; this is a liveness requirement, not a bug, so it cannot simply be
+slowed down. At fleet scale (several sweeps in flight) that heartbeat cadence is
+enough to flood the human-facing signal room with near-identical machine
+messages, burying genuine sweep-lifecycle narration.
+
+**The fix: `rooms.claims` (opt-in, default-unchanged).** An operator who finds
+the heartbeat traffic disruptive can set `rooms.claims` (or
+`LOOM_SAFEHOUSE_ROOM_CLAIMS`) to route claim advertise/retract traffic into a
+**dedicated coordination room**, separate from both the signal room and the
+per-repo firehose:
+
+```jsonc
+"safehouse": {
+  "enabled": true,
+  "rooms": {
+    "signal": "!AbC…:example.org",
+    "claims": "!JkL…:example.org"   // peer-claim heartbeats route here instead
+  }
+}
+```
+
+- **Resolution**: `rooms.claims` when set, else `rooms.signal` (which itself
+  falls back to the legacy scalar `room`) — `SafehouseConfig::claims_room()`
+  mirrors `signal_room()`'s own fallback chain one level down.
+- **Absent (the default) is byte-identical to pre-#4713 behavior**: claim ads
+  keep riding the signal room exactly as before. This is not merely convenient —
+  it is the safe default, because of the provisioning caveat below.
+- **This is provisioning, not just routing** — the reason #4225 deferred this in
+  the first place. Setting `rooms.claims` to a room only some hosts' bots have
+  joined reproduces the exact silent cross-host dedup failure reason 1 above
+  exists to avoid: a host whose bot is not a member of the configured claims
+  room silently stops seeing peers' advertisements, with no error anywhere.
+  **Before setting `rooms.claims`, ensure every host's safehoused bot is already
+  joined to that room** — the identical requirement already documented for
+  `rooms.signal`.
+- The narration sink is unaffected: `run_sink`'s attention-class routing
+  (signal / per-repo firehose) keeps using `signal_room()`/`RoomRouter` exactly
+  as before. Only the peer-claim coordination connection
+  (`run_coordination`/`spawn_peer_coordination`) resolves `claims_room()`.
+  This holds even for a **claims-only** map (`rooms.claims` set with no
+  `rooms.signal`/`rooms.byRepo`): attention-class narration routing gates on a
+  narration target (`signal` and/or `byRepo`), so a claims-only map keeps
+  narration in byte-identical single-room mode — never lazily creating per-repo
+  firehose rooms as a side effect. `rooms.claims` and narration routing are
+  independent knobs.
+- The inbound reader is unchanged and remains **room-agnostic**: it folds any
+  parseable `loom_claim` line regardless of which room delivered it, so this
+  change is purely about which room this daemon *writes into* — receipt-side
+  filtering (teaching the separate `rjwalters/safehouse` server to mark
+  `loom_claim` envelopes as ephemeral coordination traffic that never surfaces
+  in a human-facing feed) is tracked as a **separate, out-of-scope, cross-repo
+  follow-up**, not implemented here.
+
+### Soft claim, NOT a mutex (the load-bearing caveat)
+
+A room broadcast is eventually consistent, so this is a **fast backoff, not a
+lock**: two hosts advertising near-simultaneously still race. Advertisement
+*shrinks* the collision window; it does not close it. The atomic authority for
+the final claim — a real cross-host CAS (e.g. a `git push` to a claim ref) — is
+**Phase 2 of #4028**, deliberately out of scope here.
+
+### Fail-open (never a liveness dependency)
+
+Coordination is best-effort end to end: an unreachable/refusing/timing-out
+`safehoused` socket, a malformed inbound envelope, or a full outbound channel is
+logged (once) and **dispatch proceeds normally**. The outbound advertisement is a
+bounded, non-blocking `try_send` off the dispatch path; a `Full`/`Closed` channel
+drops the ad. `safehouse.enabled` false/absent is a **byte-for-byte no-op**: no
+view, no channel, no coordination task, no socket.
+
+# Phase 2 — worker-side `safehouse-mcp` injection (#3999)
+
+Phase 1 lets the daemon *narrate*. Phase 2 gives each **worker** session a
+two-way handle: when the `safehouse` block is enabled, Loom injects the
+`safehouse-mcp` stdio MCP server (`rjwalters/safehouse`, tools `safehouse_send` /
+`safehouse_read` / `safehouse_create_room` / `safehouse_list_rooms`; env
+`SAFEHOUSED_SOCKET` + `SAFEHOUSE_PERSONA`) into the worker's MCP config, so a
+Builder can ask a question in the room mid-task and read the human's answer
+instead of only signalling through labels. The MCP server holds no keys — the
+socket path is the only credential-adjacent value written.
+
+## Per-worker persona: a bounded pre-registered pool (design decision)
+
+safehoused's persona allowlist is a **static boot-time TOML array** with no
+runtime registration, no glob/prefix matching, and no SIGHUP reload (see phase-1
+note above). So a literal per-issue name like `loom_builder_42` **cannot** be
+minted at dispatch time — safehoused would reject the `hello` for a name not in
+its boot allowlist, and it cannot restart per worker.
+
+Loom therefore assigns each worker a persona from a **bounded pool the operator
+pre-registers** in safehoused's allowlist ahead of time — the same "fixed pool,
+rotate per slot" shape as the token pool. Configure the pool in the `safehouse`
+block and add the identical names to safehoused's `personas`:
+
+```jsonc
+"safehouse": {
+  "enabled": true,
+  "socket": "/run/safehoused.sock",
+  "persona": "loom_daemon",                     // scalar fallback (daemon + no-pool workers)
+  "workerPersonas": ["loom_builder_1",          // the pre-registered worker pool
+                     "loom_builder_2",
+                     "loom_builder_3",
+                     "loom_builder_4"],
+  "mcpCommand": "safehouse-mcp"                  // launcher for the stdio MCP server
+}
+```
+
+```toml
+# safehoused config — restart required after editing (allowlist read once at boot)
+personas = ["loom_daemon", "loom_builder_1", "loom_builder_2", "loom_builder_3", "loom_builder_4"]
+```
+
+Each worker is assigned `workerPersonas[issue_number % pool_size]` (round-robin
+by worktree slot — the issue number comes from `LOOM_SWEEP_CLAIM_OWNED`). Two
+**concurrently-running** workers (distinct issue numbers) get distinct personas
+whenever the pool is at least as large as the concurrency level and the numbers
+do not collide mod N — so size the pool to your max concurrent workers. With **no
+`workerPersonas`** configured, every worker falls back to the scalar `persona`
+(workspace-wide, no per-worker attribution) — the feature degrades, never fails.
+
+Env overrides (each wins over config): `LOOM_SAFEHOUSE_WORKER_PERSONAS`
+(comma-separated pool), `LOOM_SAFEHOUSE_MCP_COMMAND`, plus the phase-1
+`LOOM_SAFEHOUSE_ENABLED` / `LOOM_SAFEHOUSE_SOCKET` / `LOOM_SAFEHOUSE_PERSONA`.
+
+## Delivery: session-scoped `--mcp-config` at spawn time
+
+Injection happens in `spawn-claude.sh` (the mandatory agent spawn path), not by
+rewriting the workspace `.mcp.json`. Concurrent sweeps **share** the workspace
+root, so a per-worker persona cannot live in that shared file; instead
+spawn-claude generates a **session-scoped** MCP config (persona substituted for
+this worker) and passes it via `claude --mcp-config <file>`. The file lists the
+`loom` server FIRST (so it is self-contained even when the session cwd has no
+project `.mcp.json`) and appends `safehouse` second.
+
+`scripts/setup-mcp.sh` (the workspace-root generator, reached inside worktrees
+via the `.mcp.json` symlink `worktree.sh` creates) **also** learns to append the
+`safehouse` server when enabled — but with the scalar `persona`, since it is not
+per-worker. Both writers keep `loom` first and unchanged so
+`claude-wrapper.sh`'s MCP pre-flight (which keys off the first server with args)
+still resolves the loom entry point.
+
+## Degradation contract (unchanged from phase 1)
+
+- `safehouse.enabled` false/absent ⇒ **byte-for-byte no-op**: spawn-claude
+  appends no `--mcp-config`, and setup-mcp emits the identical loom-only file.
+- Enabled but the launch command is missing, or no socket resolves ⇒ one
+  `warn`, **injection skipped**, the `loom` MCP server unaffected and the worker
+  starts normally.
+- Socket configured but not yet present at spawn ⇒ one `warn`, injected anyway
+  (best-effort — `safehouse-mcp` connects lazily and never blocks the worker).
+- A persona absent from safehoused's boot allowlist is rejected by safehoused at
+  `hello` with a clear message — provision the whole pool before enabling.
+
+## Implementation (phase 2)
+
+- `defaults/scripts/lib/mcp-config.sh` — shared resolvers (env > config >
+  default, mirroring `safehouse.rs`), the pool round-robin persona picker, and
+  the `loom`-first `.mcp.json` emitter.
+- `defaults/scripts/spawn-claude.sh` — per-worker injection via `--mcp-config`.
+- `scripts/setup-mcp.sh` — workspace-root two-server generation when enabled.
+- Tests: `defaults/scripts/tests/test-mcp-config.sh`.
+
+> The exact `safehouse-mcp` binary/protocol lives in the external
+> `rjwalters/safehouse` repo and is not verifiable from this repo, so the
+> launcher is configurable (`safehouse.mcpCommand`) and a missing command
+> degrades to a logged skip rather than a broken server entry.

--- a/defaults/docs/token-pool.md
+++ b/defaults/docs/token-pool.md
@@ -1,0 +1,673 @@
+# Multi-Account Token Pool & Rotation
+
+Loom can rotate among multiple Claude OAuth accounts so load spreads across
+accounts and a single weekly limit does not stall the pipeline. This document is
+the full reference for provisioning, importing, health-probing, selecting, and
+operating the token pool. `CLAUDE.md` carries only the operating summary and
+points here.
+
+## Provider-aware account inventory
+
+The legacy `.loom/tokens` pool remains Loom's Claude compatibility backend:
+its files, selection order, state formats, `SelectedToken` API, and
+`loom-daemon tokens ...` commands are unchanged.
+
+Provider-aware callers identify accounts by `(provider, name)`, so
+`claude/alice` and `codex/alice` are separate identities. Claude inventory
+continues to prefer a repo-local `.loom/tokens` pool and otherwise falls back
+to `LOOM_SHARED_TOKENS_DIR` (default `~/.loom/tokens`).
+
+Codex inventory uses named directories below `LOOM_CODEX_PROFILE_ROOT`
+(default `~/.loom/codex-profiles`). With no repo metadata, each direct child
+directory is an enabled shared profile. A repository may restrict or rename
+eligible profiles with `.loom/accounts.json`:
+
+```json
+{
+  "version": 1,
+  "accounts": [
+    {
+      "provider": "codex",
+      "name": "build",
+      "credential_kind": "codex_home",
+      "credential_reference": "team-primary",
+      "enabled": true
+    }
+  ]
+}
+```
+
+This file is metadata only. `credential_reference` is one logical directory
+name, never an absolute or relative path, and resolves only beneath the
+machine profile root. Loom rejects traversal, separators, symlink escapes,
+non-directory targets, and a profile root located inside the repository.
+Codex owns `<profile>/auth.json` and may refresh it in place; Loom's registry
+does not open, parse, copy, serialize, or log that file. Operators should keep
+profile directories `0700` and `auth.json` `0600`.
+
+Selected accounts expose the non-secret observability identity
+`LOOM_ACCOUNT_PROVIDER` and `LOOM_ACCOUNT_NAME`. Claude selections also retain
+`LOOM_TOKEN_NAME`; Codex selections bind `CODEX_HOME` and never expose an
+equivalent credential variable. Raw provider capacity counts enabled inventory
+candidates only. Quota health, cooldown, ranking, and failover are layered on
+later and do not alter this inventory contract.
+
+> **Secrets**: `~/.claude-monitor/accounts.env`, the opt-in `~/.loom/accounts.env`,
+> and the repo-local `.loom/accounts.env` all hold raw OAuth keys. The repo-local
+> file and `.loom/tokens/` are gitignored (installer- and `loom-daemon init`–managed);
+> keep any home-level master `0600` and outside any repo.
+
+## Bootstrapping the pool
+
+For environments that rotate among multiple Claude OAuth accounts, Loom can
+bootstrap a per-account token pool at `.loom/tokens/` from numbered
+`ACCOUNT_EMAIL_N` / `ACCOUNT_KEY_N` / `ACCOUNT_TOKEN_FILE_N` triples:
+
+```env
+ACCOUNT_EMAIL_1=user1@example.com
+ACCOUNT_KEY_1=sk-ant-oat01-...
+ACCOUNT_TOKEN_FILE_1=user1.token
+```
+
+Run `loom-daemon tokens bootstrap` to materialize the pool:
+
+```bash
+loom-daemon tokens bootstrap            # Idempotent — only writes new/missing tokens.
+loom-daemon tokens bootstrap --dry-run  # Preview + print the effective merged account set.
+loom-daemon tokens bootstrap --force    # Overwrite on-disk tokens that have drifted from source.
+loom-daemon tokens bootstrap --shared   # Provision the shared machine-level pool at ~/.loom/tokens
+```
+
+Each account becomes `.loom/tokens/<file>.token` (mode `0600`). An `index.json`
+manifest is written alongside with sha256 fingerprints (8 chars) for drift
+detection plus each account's `source` (home/repo) — **no secret material is
+stored in the manifest**. Numbering gaps are allowed; partial triples are skipped
+with a warning.
+
+`.loom/tokens/` is gitignored. The pool is consumed by external rotation logic
+(e.g. a `claude-wrapper.sh` that picks the least-used token); only the bootstrap
+step is provided here.
+
+## Account sources: claude-monitor-first + per-repo (#3695, #3698, #3704)
+
+Rather than re-declaring the same account triples in every repo's `.env`, declare
+them **once** in the shared claude-monitor master and let each workspace add or
+override on top of it. Sources are merged by account email in precedence order:
+
+| Source | Default location | Override |
+|--------|------------------|----------|
+| **claude-monitor master** (primary) | `~/.claude-monitor/accounts.env` | `LOOM_CLAUDE_MONITOR_DIR` env var (directory) |
+| **Repo-local** | `<repo>/.loom/accounts.env` if present, else legacy `<repo>/.env` | `--env <path>` on `bootstrap` |
+| **Home master** (opt-in only, #3704) | *no default location* — read **only** when explicitly pointed at | `LOOM_ACCOUNTS_ENV` env var (a path enables it, `""` disables); `--home-env <path>` / `--no-home` on `bootstrap` |
+
+**Default resolution is claude-monitor → repo `.env`.** The `~/.loom/accounts.env`
+home master is **no longer auto-read** (#3704 retired the default location): it is
+consulted only when an operator opts in via `LOOM_ACCOUNTS_ENV=<path>`
+(conventionally `~/.loom/accounts.env`) or `--home-env <path>`. This retires the
+default *location*, not the *capability*.
+
+`loom-daemon tokens bootstrap` reads the available sources and **merges them by account
+email** (`ACCOUNT_EMAIL`), with the higher-precedence source winning:
+
+- An email present **only in a lower-precedence source** is inherited into the pool.
+- An email present **only in a higher-precedence source** is added.
+- An email present in **both** → the higher-precedence entry overrides (e.g. to
+  rotate a key or repoint the token file).
+
+To *exclude* an inherited account from one repo, pin the subset you want with
+`loom-daemon tokens pin` — the merge only ever adds/overrides, never subtracts. The
+effective merged set (and where each account came from) is printed by `bootstrap`
+and `bootstrap --dry-run`. A repo with only a legacy `.env` and no other source
+behaves exactly as before.
+
+## Importing live tokens from claude-monitor (#4006)
+
+`accounts.env` is a **snapshot** — a file someone wrote by hand at some point.
+claude-monitor keeps the **live** credentials in its SQLite store
+(`~/.claude-monitor/usage.db` → `oauth_credentials`) and refreshes them as
+accounts are re-authenticated. The two drift, and the drift is silent and total:
+
+```text
+401 {"type":"authentication_error","message":"OAuth access token has been revoked."}
+```
+
+When that happens to every account at once, `loom-daemon tokens check` reports all
+accounts `blocked`, the daemon's dynamic concurrency cap collapses to
+`min(healthy 0 × per-token N, …) = 0`, and dispatch stops entirely. Crucially
+**`bootstrap --force` does not fix it** — it faithfully rewrites the same revoked
+tokens, because the snapshot itself is what went stale.
+
+**`bootstrap` now detects this condition (#4030).** When `usage.db` is present and
+the tokens `bootstrap` is about to write disagree with the live store (same email,
+different fingerprint), it prints a warning naming the diverging accounts and
+pointing at `import-from-monitor` — so the stale snapshot is caught automatically
+instead of by hand-comparing fingerprints. The check is read-only, warns but never
+auto-switches sources, and is silent when no `usage.db` is present or it is
+unreadable; it prints emails and 8-char fingerprints only, never secret material.
+
+`loom-daemon tokens import-from-monitor` reads the live store directly and is **the
+standard way to populate a new host's pool** (it replaces hand-copying a pool
+between machines):
+
+```bash
+loom-daemon tokens import-from-monitor                  # into <repo>/.loom/tokens
+loom-daemon tokens import-from-monitor --shared         # into the machine-level pool (#3938)
+loom-daemon tokens import-from-monitor --force          # apply ROLLED tokens (see below)
+loom-daemon tokens import-from-monitor --dry-run        # preview
+loom-daemon tokens import-from-monitor --prune          # drop accounts the monitor no longer reports
+```
+
+**`--force` is what applies a token roll.** Every rolled token legitimately
+differs from what is on disk, so without `--force` each one is reported as drift
+and left alone — deliberately, so a hand-pinned token is never silently clobbered.
+The command exits `2` when drift was found and not applied, so a script can detect
+"pool is still stale". After importing, refresh the ranking so the daemon sees the
+recovered capacity:
+
+```bash
+loom-daemon tokens import-from-monitor --force && loom-daemon tokens check --ranking
+```
+
+Behavior notes:
+
+- **Read-only** on `usage.db` (opened `mode=ro`) — the store belongs to
+  claude-monitor; Loom never writes or migrates it.
+- Only `is_active = 1` rows are imported; `expires_at` is **not** used as a filter
+  (observed rows carry stale timestamps while still authenticating — health comes
+  from `loom-daemon tokens check`).
+- Token filenames use the same derivation as `bootstrap` (`robb@2amlogic.com` →
+  `robb-2amlogic.token`), so an account keeps one identity across both paths and
+  re-importing overwrites in place.
+- Idempotent: unchanged tokens are left untouched. `index.json` records
+  `source: monitor-db` (distinct from the `monitor` snapshot) and, as always,
+  fingerprints only — never secret material.
+- `--prune` removes only `*.token` files; pool state (`.ranking`, `.bad_tokens`,
+  `.failure_counts`, `.allowlist`) is never touched.
+- The importer takes **claude-monitor as authoritative for pool membership**, so
+  it imports every active account — including any that `accounts.env` omitted. Use
+  `loom-daemon tokens pin` to restrict which accounts the selector may actually pick.
+- Absent claude-monitor, an absent `usage.db`, or an older schema without
+  `oauth_credentials` all exit `1` with a message naming the path tried.
+
+## Account health probe + ranking
+
+Once bootstrapped, `loom-daemon tokens check` probes each account for current rate-limit
+headers and (optionally) writes a JSON ranking that the spawn-time selector can
+consume:
+
+```bash
+loom-daemon tokens check                  # Probe + print human table
+loom-daemon tokens check --ranking        # Probe + write .loom/tokens/.ranking atomically
+loom-daemon tokens check --json           # Emit full JSON report to stdout
+loom-daemon tokens check --json    # Native Rust equivalent (issue #4108)
+./.loom/scripts/probe-tokens.sh    # Cron-friendly wrapper for periodic invocation
+```
+
+**`probe-tokens.sh` delegates to `loom-daemon tokens check`, not Python (#4080).**
+It resolves a `loom-daemon` binary (`$LOOM_DAEMON_BIN` → `loom-daemon` on PATH →
+build-output-relative candidates under the repo), capability-probes it with
+`tokens check --help` to detect a stale pre-#4108 binary, and `exec`s `tokens
+check "$@"` on success — the flags and exit codes above are unchanged either
+way.
+
+**It has no fallback tier at all** (epic #4081 Phase 4, #4557). Both historical
+fallbacks are gone: the bare `python3 -m loom_tools.tokens.cli` tier went in
+#4080, and the `loom-tokens`-console-script-on-PATH tier went when #4557 deleted
+the Python package that shipped it. A `loom-tokens` still on PATH after that
+deletion is by definition a stale editable-install leftover (the #4079 shadowing
+incident), so dispatching to it would run frozen, months-old token logic against
+the live pool. When no capable daemon binary resolves, `probe-tokens.sh` exits
+`1` with an actionable message naming `loom-daemon-update.sh` /
+`loom-daemon-start.sh` / `cargo build` — a loud failure, never a silent
+degradation.
+
+The probe sends a minimal `POST /v1/messages` request (1 input, 1 output token)
+and parses rate-limit response headers. The header parser matches by **suffix**
+(`-5h-utilization`, `-7d-utilization`, `-7d-reset`) so future renames of the
+`anthropic-ratelimit-tokens-*` prefix still work; the full header set is logged on
+the first probe of each run.
+
+Status assignment: `available` (utilizations < 95%), `exhausted`
+(`7d_utilization >= 0.95`), `rate_limited` (current 429), `blocked` (401 auth
+failure or token listed in `.bad_tokens`). Probe failures (network, timeout, 5xx)
+are logged and skipped — one bad account does not abort the run.
+
+OAuth tokens shaped `sk-ant-oat01-*` are sent with `Authorization: Bearer` +
+`anthropic-beta: oauth-2025-04-20`; plain API keys use `x-api-key`.
+
+**The running `loom-daemon` self-refreshes `.ranking` (#3969)** — it invokes
+**its own binary** (`std::env::current_exe()`) with `tokens check --ranking
+--workspace <repo_root>` on its own periodic loop (default every 10 minutes,
+`autonomous.tokenRankingRefresh` / `LOOM_TOKEN_RANKING_REFRESH*`, on by default
+since it is read-only probing with no dispatch side effect) — as of #4080 this
+is a direct daemon-to-daemon subcommand invocation, not a shell out to
+`probe-tokens.sh`, so a standing cron for this is no longer required when the
+daemon is running. See
+[Token-ranking self-refresh](daemon-reference.md#token-ranking-self-refresh-3969)
+for the config knobs.
+
+A cron entry is now only needed as a **fallback for setups that don't run
+`loom-daemon`** (e.g. pure `/loom:sweep` subagent dispatch with no daemon
+process). Cron example (probe every 10 minutes):
+
+```cron
+*/10 * * * * cd /path/to/repo && ./.loom/scripts/probe-tokens.sh --ranking >> .loom/logs/probe-tokens.log 2>&1
+```
+
+## Token rotation setup (per-task spawn)
+
+For Pro/Max plans, Loom supports rotating between multiple Claude Code OAuth
+tokens. This spreads load across accounts and recovers automatically when a single
+token hits its weekly limit.
+
+1. Declare account credentials in a default source — the shared claude-monitor
+   master `~/.claude-monitor/accounts.env` (primary) or per-repo in
+   `<repo>/.loom/accounts.env` (falls back to legacy `<repo>/.env`). The
+   `~/.loom/accounts.env` home master is **opt-in only** since #3704 (no longer
+   auto-read); point `LOOM_ACCOUNTS_ENV=~/.loom/accounts.env` (or `--home-env
+   <path>`) at it to enable:
+   ```env
+   ACCOUNT_EMAIL_1=account-one@example.com
+   ACCOUNT_KEY_1=sk-ant-oat01-...
+   ACCOUNT_TOKEN_FILE_1=account-one.token
+   ACCOUNT_EMAIL_2=account-two@example.com
+   ACCOUNT_KEY_2=sk-ant-oat01-...
+   ACCOUNT_TOKEN_FILE_2=account-two.token
+   ```
+   The claude-monitor, repo-local, and (opt-in) home sources are **merged by
+   email**, with the higher-precedence source overriding/adding. Keep any
+   home-level master `0600` and outside any repo.
+2. Run `loom-daemon tokens bootstrap` to materialize the merged set into per-account
+   `.token` files in `.loom/tokens/` (mode 0600, parent dir 0700). See issues
+   #3234, #3695. **If claude-monitor runs on this host, prefer `loom-daemon tokens
+   import-from-monitor`** — it reads claude-monitor's live credential store instead
+   of the `accounts.env` snapshot, so a new host needs no account file of its own
+   and a token roll is picked up automatically (add `--force` to apply rolled
+   tokens).
+3. Spawn agents through `.loom/scripts/spawn-claude.sh` instead of invoking
+   `claude` directly. The wrapper selects a token using a 3-tier algorithm
+   (ranking → allowlist → random), exports `CLAUDE_CODE_OAUTH_TOKEN`, then `exec`s
+   `claude` (or pass `--use-wrapper` to layer on top of `claude-wrapper.sh` for
+   retry behavior).
+
+## Selection algorithm (`loom-daemon tokens select`)
+
+Three tiers, falling through to the next when the current tier yields nothing.
+Native Rust (`loom-daemon/src/tokens_pool/select.rs`), invoked directly by
+`spawn-claude.sh` / `claude-wrapper.sh` as of issue #4228 (epic #4081 Phase 2) —
+byte-compatible with the historical `loom_tools.tokens.select` implementation,
+which stays in-tree as reference/conformance material (`loom-tools/tests/tokens/`)
+but is no longer on the runtime path:
+
+1. **Ranking** — `.loom/tokens/.ranking` (pipe-delimited `name|status|5h_util`,
+   refreshed every <10 min). A persistent rotation cursor spreads consecutive
+   dispatches one-per-account across the eligible accounts (#3909;
+   `LOOM_TOKEN_SPREAD_TOP_N` / `tokens.spreadTopN` optionally caps the window).
+2. **Allowlist** — `.loom/tokens/.allowlist` (one name per line). Random pick from
+   allowed accounts.
+3. **Random** — uniform pick from all `*.token` files.
+
+Tokens marked bad in `.loom/tokens/.bad_tokens` are skipped at every tier.
+`loom-daemon tokens select --export` emits shell-evalable `export
+CLAUDE_CODE_OAUTH_TOKEN=...` / `export LOOM_TOKEN_NAME=...` lines (plus a
+non-exported `LOOM_TOKEN_MODE=...`) so callers `eval` the output directly
+instead of round-tripping through a JSON parser; `--auto-unpin` runs the
+pinned-account auto-recovery pre-flight (see below) before selecting.
+
+### Ranking format: 5h-load field + soft gate (issue #4195)
+
+The `.ranking` line format is `name|status|5h_util`, where the **third field**
+is the account's 5h-window utilization (a fraction `0.0`–`1.0`, fixed at 2
+decimals). It is **optional**: a legacy 2-field `name|status` line still parses,
+and an account with no measured 5h utilization is written in the 2-field form
+(the value is left off, never faked as `0.0`). All four ranking writers emit it
+— the Python probe (`check.py`) and monitor (`monitor.py`) paths and their
+byte-identical Rust ports (`tokens_pool::check` / `tokens_pool::monitor`).
+
+The ranked tier layers a **soft load gate** on top of the rotation cursor: in
+the preferred pass an account **at/above** the 5h threshold is excluded (so the
+cursor rotates only across the lightly-loaded accounts), and the fallback pass
+readmits them — the pool never hard-fails on load alone. A **missing or
+unparseable** utilization is treated as *unknown* → never gated. The threshold
+defaults to `0.70` and is overridable via the `LOOM_TOKEN_5H_LOAD_GATE` env var
+(a value `> 1.0` disables the gate); it follows the `LOOM_TOKEN_SPREAD_TOP_N`
+precedent and is honored identically by the Python selector (`select.py`) and
+the Rust port (`tokens_pool::select`). This is the Option-A reconciliation of
+the gpeyton-fork load-aware selection proposal (fork commits `283de8e3`,
+`20961dd9`) with upstream's existing rotation-cursor spread — a load-aware gate
+*layered on* #3909, not the fork's waterfall-fill replacement.
+
+## Bad-token tracking (`loom-daemon tokens mark-bad`)
+
+When a token returns `TOKEN_EXPIRED` or `TOKEN_EXHAUSTED`, callers append an entry
+to `.loom/tokens/.bad_tokens` via `loom-daemon tokens mark-bad <name> --reason
+<text>` (native Rust, `loom-daemon/src/tokens_pool/bad_tokens.rs`, exposed as a
+CLI subcommand in #4228 — the historical Python `loom_tools.tokens.bad_tokens`
+module was library-only, with no CLI of its own). Writes are guarded with a
+`mkdir`-based lock (POSIX-atomic, macOS-compatible — `flock` is **not** used
+because it isn't available on stock macOS). Reads use word-boundary regex so
+`agent-1` and `agent-10` don't collide. The reason field's embedded
+newlines/carriage-returns are sanitized to spaces so every `.bad_tokens` record
+is exactly one line — byte-compatible with the Python implementation, and
+conformance-tested against it in `loom-tools/tests/tokens/test_rust_conformance.py`.
+
+How long an entry keeps blocking (auth = permanent, exhaustion = 6h TTL) and how
+long it survives on disk (24h / 30d) are two different clocks — see
+[Permanence: auth vs exhaustion](#permanence-auth-vs-exhaustion-at-read-time-and-on-disk)
+below.
+
+## Error classification (`.loom/scripts/lib/classify-error.sh`)
+
+The `classify_error <output> <exit_code>` function returns one of `SUCCESS`,
+`TIMEOUT`, `CWD_DELETED`, `TOKEN_EXPIRED`, `TOKEN_EXHAUSTED`, `RECOVERABLE`.
+Critical fix from #3233: exit code is checked **before** output substring
+matching — clean exits (`exit_code == 0`) always return `SUCCESS` regardless of
+stdout content.
+
+## Worktree handling
+
+When invoked from a worktree, `spawn-claude.sh` resolves the canonical repo root
+via `git rev-parse --git-common-dir` and locates `.loom/tokens/` there — never in
+the worktree's path. This avoids each worktree maintaining its own bad-tokens
+list.
+
+## Shared machine-level pool fallback (#3938)
+
+Token selection resolves the effective pool as: the **per-repo** pool
+`<repo>/.loom/tokens/` when it holds `*.token` files, else the **shared
+machine-level pool** `~/.loom/tokens/` (override `LOOM_SHARED_TOKENS_DIR`; set it
+empty to disable the fallback). This lets a consumer repo the daemon dispatches
+into — which has no pool of its own — spawn against the shared pool instead of
+hard-failing with `EX_CONFIG`. Crucially, the pool **state** files (`.bad_tokens`,
+`.failure_counts`, `.ranking`, `.allowlist`) are read/written in whichever pool was
+selected, so state is **never forked per repo** (token-capacity backpressure sees
+one truth). Provision the shared pool once per machine with `loom-daemon tokens bootstrap
+--shared`. See [daemon-reference.md → Token pool provisioning for managed
+repos](daemon-reference.md#token-pool-provisioning-for-managed-repos-3938).
+
+**Native selection, zero Python package-path resolution needed (#4228)**: `#3938`
+fixed the pool *location*; as of #4228 (epic #4081 Phase 2) token *selection*
+itself is native too — `spawn-claude.sh` / `claude-wrapper.sh` shell out to
+`loom-daemon tokens select` (resolved via `$LOOM_DAEMON_BIN` -> `loom-daemon` on
+PATH -> build-output-relative candidates under the repo; see
+`.loom/scripts/lib/locate-daemon-bin.sh`) instead of `python3 -m
+loom_tools.tokens.select`. This retires the `LOOM_PACKAGE_PATH` bridge entirely
+(script-side resolution AND the daemon-side `spawn_child`/role-runner forwarding
+that used to derive it from the source tree the running binary was compiled
+from) — a consumer repo with no loom checkout now selects a token successfully
+with zero manual configuration and no Python package to locate at all.
+
+### Full anchoring precedence, and machine-level daemon startup (#4292)
+
+Everything above resolves the pool for a caller whose **workspace root is
+already known** to be a real repo checkout (an explicit `--workspace`, a
+worktree's own root, or a per-request-resolved dispatch target). A
+machine-level daemon (#3835/#3926) is different: at startup its own primary
+workspace is seeded from `LOOM_WORKSPACE` or, absent that, its **own process
+cwd** — and under `systemd` with no `WorkingDirectory=` override that cwd
+defaults to `$HOME`, which is not a repo checkout at all.
+
+Feeding a non-workspace cwd straight into the `#3938` per-repo/shared fallback
+is worse than "no tokens": the **default** shared pool is *also*
+`~/.loom/tokens`, so `workspace_root == $HOME` makes the per-repo and shared
+probes coincidentally check the exact same (usually empty) directory — masking
+wherever the pool was actually bootstrapped (e.g. a per-repo pool at the
+daemon's real, differently-located checkout) behind a plausible-looking but
+wrong "no tokens found" warning.
+
+The full precedence, in order, for every consumer (`loom-daemon status`, the
+daemon's own dispatch-capacity accounting, `tokens check --ranking`'s
+default-`--workspace` case, and the daemon's autonomous ranking-refresh loop):
+
+1. **Explicit `--workspace <path>`** (a CLI flag naming a real, possibly
+   unregistered, repo) — always wins outright, resolved via the per-repo/shared
+   precedence above. Never redirected, so pointing at a specific repo is never
+   silently overridden.
+2. **Default (`--workspace` omitted / `.` / the daemon's own seeded cwd) and
+   the candidate root falls under a registered workspace** — either because
+   `loom-daemon workspace add` was never run at all (an empty registry trusts
+   the candidate unconditionally, preserving `#3938`'s byte-for-byte
+   single-workspace behavior for every repo-local install), or because the
+   candidate matches a registered root — resolved via the same per-repo/shared
+   precedence, anchored at the registered root when the candidate is a
+   subdirectory of it.
+3. **Default and the candidate matches no registered workspace** — the
+   machine-level-daemon-at-`$HOME` case — skips the per-repo probe entirely and
+   resolves straight to the shared machine-level pool (`~/.loom/tokens`,
+   override `LOOM_SHARED_TOKENS_DIR`). Falls back to per-repo(candidate) only
+   when the shared pool is itself disabled (`LOOM_SHARED_TOKENS_DIR=""`).
+
+**Operational contract**: for step 3 to actually find tokens, a machine-level
+daemon's pool must be bootstrapped at the shared location —
+`loom-daemon tokens bootstrap --shared` (or `import-from-monitor --shared`) — rather
+than per-repo at whatever directory happens to be the daemon's own checkout.
+Registering the daemon's own checkout as a workspace
+(`loom-daemon workspace add <checkout>`) is the alternative: that makes step 2
+apply instead, so a per-repo pool bootstrapped there (without `--shared`) is
+found too.
+
+**No `WorkingDirectory=` needed**: with the pool bootstrapped per the
+contract above, a `systemd`-managed daemon started with the unit's default
+`$HOME` cwd (or any other non-workspace directory) now finds its token pool —
+and reports accurate dispatch capacity — without an operator having to
+discover and set an explicit `WorkingDirectory=` override (`.loom/docs/daemon-reference.md`
+covers `#4268`/`#4319`/`#4321`, which already set `WorkingDirectory=` as
+first-class in *generated* systemd units; this section is for bare/unmanaged
+daemon startups and ad hoc CLI invocations from arbitrary cwds — the generated
+units already cover the managed case).
+
+Implementation: [`resolve_tokens_dir_anchored()`](../../loom-daemon/src/tokens_pool/paths.rs)
+delegates step 2/3's "is this candidate a recognized Loom workspace" question
+to the same registry-membership check `#4299` established for CLI
+`--workspace` defaulting (`workspace_registry::resolve_client_workspace_default`)
+rather than a second, parallel detection path.
+
+## Hard-fail on missing pool
+
+`spawn-claude.sh` exits `78` (`EX_CONFIG`) with a message instructing the user to
+run `loom-daemon tokens bootstrap` (or `loom-daemon tokens bootstrap --shared` for the
+machine-level pool) when **neither** the per-repo nor the shared pool has usable
+tokens (absent, empty, or all bad). It does **not** silently fall back to
+keychain — that path belongs in `loom-daemon` (#3236), and only when token
+rotation has not been configured at all.
+
+The `loom-daemon` role runner (`autonomous.roleRunner`, see
+[daemon-reference.md](daemon-reference.md)) pre-checks
+[`tokens::token_pool_size`](../../loom-daemon/src/tokens.rs) for exactly this
+condition **before** it ever spawns `spawn-claude.sh` (issue #4642): a repo
+with neither pool provisioned skips the doomed spawn entirely instead of
+hitting this hard-fail on every single tick forever. The skip is logged once
+(`WARN`) per root per role, then downgraded to `DEBUG` on repeats — grep a
+role's log for `no token pool available` — and is re-checked every tick, so
+provisioning either pool later resumes ticking with no daemon restart needed.
+
+## Per-repo pool vs. shared machine-level pool: which to provision (#4642)
+
+A newly-managed repo (added via `loom-daemon workspace add`, or picked up by
+the multi-workspace role runner / work finder) starts with **neither** pool
+provisioned, and stays that way until an operator deliberately runs one of the
+two bootstrap commands below — this is an operator/billing decision, not
+something Loom auto-applies, because it changes **whose usage counts against
+which weekly ceiling**:
+
+- **Per-repo pool** (`loom-daemon tokens bootstrap` from inside the repo,
+  populating `<repo>/.loom/tokens/`): this repo's sweeps and role ticks draw
+  from accounts dedicated to it alone. Usage against each account's weekly
+  limit is isolated to this one repo — the right choice when a repo has its
+  own budget/accounts, or when you want one repo's activity to never compete
+  with another's for the same account's rotation slot.
+- **Shared machine-level pool** (`loom-daemon tokens bootstrap --shared`,
+  populating `~/.loom/tokens/` or the `LOOM_SHARED_TOKENS_DIR` override,
+  resolved by [step 3 of the fallback chain](#shared-machine-level-pool-fallback-3938)
+  above): every repo on the host that has **no per-repo pool of its own**
+  falls back to this one pool and shares its accounts. This is convenient for
+  low-traffic repos (e.g. the canary chip repos that motivated #4642 — several
+  small repos, none busy enough on its own to justify dedicated accounts) but
+  means **every one of those repos' sweeps and role ticks now compete for the
+  same weekly ceiling** — a burst of activity in one consumer repo can exhaust
+  accounts another consumer repo also depends on. A repo with a per-repo pool
+  is never affected by this (the per-repo pool always wins when it holds
+  tokens, `token_pool_size_resolved`'s precedence).
+
+**Rule of thumb**: provision a per-repo pool for any repo whose activity level
+or billing owner is distinct enough to want isolated usage accounting; use the
+shared pool for a cluster of low-traffic repos willing to accept a shared
+ceiling in exchange for zero per-repo token administration. Both can coexist
+on one host — the fallback chain is per-repo-first, so adding a per-repo pool
+to a repo previously riding the shared pool is a strictly additive, safe
+change (it simply stops that one repo from drawing on the shared ceiling, with
+no reconfiguration needed on the shared side).
+
+## Operator CLI (`loom-daemon tokens pin/unpin/unblock`)
+
+Operators can restrict the rotation pool to a subset of accounts (an "allowlist")
+and manually un-blacklist accounts marked bad. Auto-recovery prevents pin-induced
+lockouts.
+
+```bash
+loom-daemon tokens pin agent-3 agent-7   # Set allowlist to exactly these
+loom-daemon tokens pin add agent-2       # Append (idempotent)
+loom-daemon tokens pin remove agent-3    # Remove
+loom-daemon tokens pin status            # Show current allowlist
+loom-daemon tokens unpin                 # Delete allowlist (back to full pool)
+
+loom-daemon tokens unblock agent-1              # Drop agent-1's AUTH entries only
+loom-daemon tokens unblock agent-1 --all-reasons  # Also drop its exhausted/rate-limited entries
+```
+
+**Validation**: `pin` accepts only exact bootstrapped account names —
+substring/fuzzy matches are rejected. The allowlist is sorted, deduplicated, and
+`mkdir`-lock guarded so concurrent operator commands don't drop entries.
+
+**`unblock` default scope fails loudly on left-behind entries (#4212)**: the
+default scope removes only `auth` entries (a broken credential); transient
+`exhausted`/`rate-limited` entries clear themselves. When the named account has
+*only* a non-auth entry, the default scope leaves it in place — and rather than
+print "No matching entries removed" and exit `0` (the pre-#4212 silent no-op that
+let an operator dispatch onto a still-poisoned pool), `unblock` now **names the
+still-blocked accounts and exits `3`**. Re-run with `--all-reasons` to drop them,
+or wait for the cooldown to expire them automatically.
+
+### Permanence: auth vs exhaustion, at read time and on disk
+
+There are **two independent clocks**, and conflating them is what made the
+2026-07-30 incident (#4643) hard to read. The table is the contract the error
+text, the CLI, and this document all agree on:
+
+| Reason class | Blocks selection until | Pruned from `.bad_tokens` after |
+|---|---|---|
+| `auth` (401 / OAuth / expired / blocked) | `loom-daemon tokens unblock <name>` — **never expires** | 30d (`AUTH_ENTRY_MIN_RETENTION_SECS`), a garbage-collection floor, *not* an expiry |
+| non-auth (`exhausted` / `rate-limited`) | the **exhaustion cooldown** — `LOOM_TOKEN_EXHAUSTION_COOLDOWN_SECS`, default `21600` (6h) | 24h (`DEFAULT_CLEANUP_MAX_AGE_SECS`) |
+| unparseable timestamp | never (**fail-closed** — a malformed line never silently un-blocks a token) | never (malformed lines are always retained) |
+
+**Read time** (`bad_tokens::is_bad` / `blocking_entry`, enforced by the selector
+on every tier): a non-auth entry stops blocking once it ages past the cooldown,
+so a recovered account re-enters rotation with **no operator action** even
+before the line is pruned from disk (#4122). Auth entries are exempt from that
+TTL by design — a broken credential does not heal on a timer.
+
+**On disk** (`bad_tokens::cleanup_bad_tokens`, wired in #4643 into `tokens
+select` and `tokens check`): entries older than the max-age policy above are
+dropped. The auth floor is deliberately far longer than the routine 24h policy,
+because pruning an auth line *would* silently readmit a broken credential —
+the on-disk clock must never become a back-door expiry for the permanent class.
+Cleanup is best-effort and takes **no lock at all** when nothing is prunable, so
+a burst of concurrent spawns never serializes on `.bad_tokens`. Before #4643
+`cleanup_bad_tokens` had zero callers anywhere in the tree and pools accumulated
+entries indefinitely.
+
+**The oldest visible entry is usually not the deciding one.** Every failed spawn
+appends a *new* line, so an account with a genuinely long-lived limit (e.g.
+`hit your weekly limit`, which outlasts the 6h cooldown by days) is
+continuously re-marked: the 13h-old lines at the top of the file expired long
+ago, while a fresh line further down is what actually blocks. `blocking_entry`
+reports the deciding line, and the empty-pool error prints its timestamp — read
+that, not the head of the file.
+
+### Empty-pool error detail (#4643)
+
+When every account is excluded, `tokens select` no longer prints a bare "All N
+tokens … are marked bad or empty". It enumerates, per account, the exclusion
+cause, the reason class and its permanence, the deciding entry's own timestamp,
+and the cooldown remaining — plus the **identity of the binary that decided**
+(version, build commit, build timestamp):
+
+```
+error: All 2 tokens in ~/.loom/tokens are marked bad or empty.
+  - agent-1: bad-marked [exhaustion, TTL] at 2026-07-30T16:58:32Z — "exhausted: hit your weekly limit"; clears in 5h48m
+  - agent-2: bad-marked [auth, permanent] at 2026-07-29T21:33:41Z — "401 unauthorized"; needs `loom-daemon tokens unblock agent-2`
+  deciding binary: loom-daemon 0.16.0 (commit 105f9c12, built 2026-07-30T05:23:19Z)
+  exhaustion cooldown: 21600s (override LOOM_TOKEN_EXHAUSTION_COOLDOWN_SECS); auth entries never expire …
+```
+
+`spawn-claude.sh` additionally logs the resolved daemon binary path and its
+`--version` at token-selection time, on every spawn:
+
+```
+spawn-claude: token-selection binary: /home/you/.local/bin/loom-daemon (loom-daemon 0.16.0 (commit 105f9c12, built 2026-07-30T05:23:19Z))
+```
+
+Both exist because the selection binary is resolved by `spawn-claude.sh` itself
+(`$LOOM_DAEMON_BIN` → PATH → build-output candidates), **independently of any
+running daemon** — so a long-running daemon can hand a sweep child a binary that
+predates the last merged selection fix. That "stale binary at the selection
+site" hypothesis is now answerable straight from `.loom/logs/sweep-issue-<N>.log`
+instead of by reading Rust source. (For the 2026-07-30 incident itself the
+hypothesis was **refuted** — the host's resolvable binaries were all descendants
+of the cooldown fix — but confirming that required inspecting the host's
+installed binaries after the fact, which is exactly the forensics this log line
+removes.)
+
+**Auto-unpin** (`failure_counts`): the wrapper tracks consecutive
+`TOKEN_EXHAUSTED` failures per account in `.loom/tokens/.failure_counts` (JSON).
+When **every** account in the allowlist hits the threshold (default 5), the
+wrapper auto-clears `.allowlist` and `.failure_counts` with a loud stderr log
+line. Operators can re-pin afterwards. The threshold is `>= 5`, so a 6th failure
+does not silently exceed; it still triggers (idempotent at-or-above).
+
+Counters are reset on:
+- a successful spawn for that account, or
+- any operator allowlist mutation (`pin`, `unpin`, `add`, `remove`).
+
+**Empty-pool guard**: if the selector finds the allowlist minus `.bad_tokens` is
+empty, `spawn-claude.sh` exits `78` (`EX_CONFIG`) with operator instructions. It
+refuses to silently auto-clear `.bad_tokens` — that masks real auth problems.
+
+## Tests
+
+```bash
+PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -v
+bash .loom/scripts/tests/test-spawn-claude.sh
+```
+
+## Codex provider health
+
+Codex profiles use a separate, provider-aware health file at
+`.loom/account-health.json`. Loom never rewrites Claude's `.ranking`,
+`.bad_tokens`, `.failure_counts`, allowlist, or rotation cursor for Codex.
+The health file contains account names and stable reason categories only—never
+`auth.json`, credential contents, or raw child output—and is written atomically
+under a sibling `mkdir` lock.
+
+For managed headless runs, `spawn-codex.sh` asks the native selector for an
+eligible profile and exports that profile as `CODEX_HOME`. Selection excludes
+disabled profiles, persistent `reauth_required` holds, and unexpired cooldowns;
+then prefers fewer recent transient failures and round-robins equal candidates.
+If none are healthy, selection exits closed rather than using ambient
+`~/.codex`.
+
+Terminal policy is intentionally conservative:
+
+- `TOKEN_EXPIRED` requires an explicit verified-reauth clear and never expires
+  merely because time passed or an ordinary success was observed.
+- `TOKEN_EXHAUSTED` cools down for
+  `LOOM_CODEX_EXHAUSTED_COOLDOWN_SECS` (default five hours).
+- `RECOVERABLE` and `SESSION_LIMIT` apply short temporary backoffs.
+- Success records freshness and clears transient counters.
+- Timeouts, fatal/configuration failures, refusals, and deleted-cwd outcomes do
+  not poison account health.
+
+Codex exposes no trustworthy quota-headroom percentage here. Status/capacity
+therefore reports raw, enabled, healthy, cooldown, and reauth-required counts;
+transcript token totals remain observability and are never presented as
+remaining quota. Claude's existing global daemon concurrency cap is unchanged.

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -1,91 +1,79 @@
 # Loom MCP Server
 
-Loom provides a unified Model Context Protocol (MCP) server (`mcp-loom`) that enables AI agents like Claude Code to interact with the Loom application, access logs, and control terminals programmatically.
+Loom provides a unified Model Context Protocol (MCP) server (`mcp-loom`) that enables AI agents like Claude Code to interact with the Loom application, dispatch sweeps on the Rust `loom-daemon`, and control terminals programmatically.
 
 ## Overview
 
 MCP (Model Context Protocol) is a standard protocol for connecting AI agents to external tools and data sources. Loom's MCP server exposes Loom's capabilities through a standardized interface that AI agents can use for:
 
-- **Testing and Debugging**: Verify factory reset, monitor agent launches, check terminal state
+- **Orchestration**: Dispatch and monitor `/loom:sweep` runs on the Tier 2 daemon
 - **Automation**: Trigger workspace operations, send commands to terminals
-- **Monitoring**: Read logs, check app health, track agent activity
+- **Monitoring**: Stream sweep-lifecycle events, register durable watches, check app health
 - **Development**: Build tools and workflows on top of Loom
 
 ## Available Tools
 
-The unified `mcp-loom` package provides all Loom MCP tools in a single server. Tools are organized into three categories:
+The unified `mcp-loom` package provides all 30 Loom MCP tools in a single server,
+organized into four categories. The authoritative per-tool tables live in
+[`mcp-loom/README.md`](../../mcp-loom/README.md#available-tools-30-total) — the
+summary below is an orientation map, not a second source of truth.
 
-### Log Tools
+### UI/Engine Control (6 tools)
 
-**Purpose**: Access Loom's various log files (daemon, terminal output)
+**Purpose**: Start/stop the engine and inspect app-level state
 
-- `tail_daemon_log` - Read daemon logs (backend activity)
-- `list_terminal_logs` - Find available terminal logs
-- `tail_terminal_log` - Read specific terminal output
+`trigger_start`, `trigger_force_start`, `trigger_force_factory_reset`,
+`get_heartbeat`, `stop_engine`, `get_ui_state`
 
 **When to Use**:
-- Debugging daemon IPC issues
-- Monitoring terminal output
-- Investigating backend errors
-- Verifying agent launch sequences
+- Checking application health (`get_heartbeat`)
+- Starting or stopping the engine, with or without confirmation
+- Reading comprehensive workspace/config/terminal state (`get_ui_state`)
 
 ---
 
-### UI Tools
-
-**Purpose**: Interact with the Loom UI, console logs, and workspace state
-
-- `read_console_log` - Read browser console output
-- `read_state_file` - Check terminal state
-- `read_config_file` - Read terminal configurations
-- `get_heartbeat` - Check if app is running
-- `get_ui_state` - Get comprehensive UI state
-- `trigger_start` - Start workspace with existing config
-- `trigger_force_start` - Start without confirmation
-- `trigger_factory_reset` - Reset config to defaults
-- `trigger_force_factory_reset` - Reset without confirmation
-- `trigger_restart_terminal` - Restart a specific terminal
-- `stop_engine` - Stop all terminals
-- `trigger_run_now` - Execute interval prompt immediately
-- `get_random_file` - Get random file from workspace
-
-**When to Use**:
-- Monitoring UI state and console logs
-- Triggering workspace operations
-- Checking application health
-- Debugging frontend issues
-
----
-
-### Terminal Tools
+### Terminal Management (13 tools)
 
 **Purpose**: Interact with terminal sessions via daemon IPC and control autonomous mode
 
-- `list_terminals` - List active terminals with metadata
-- `get_terminal_output` - Read terminal output
-- `get_selected_terminal` - Get currently selected terminal
-- `send_terminal_input` - Send commands to terminals
-- `create_terminal` - Create a new terminal session
-- `delete_terminal` - Delete a terminal session
-- `restart_terminal` - Restart a terminal preserving config
-- `configure_terminal` - Update terminal settings
-- `set_primary_terminal` - Set primary terminal in UI
-- `clear_terminal_history` - Clear terminal scrollback
-- `check_tmux_server_health` - Check tmux server status
-- `get_tmux_server_info` - Get tmux server details
-- `toggle_tmux_verbose_logging` - Enable tmux debug logging
-- `start_autonomous_mode` - Start interval prompts for all terminals
-- `stop_autonomous_mode` - Stop all interval prompts
-- `launch_interval` - Manually trigger interval prompt for a terminal
-- `get_agent_metrics` - Get agent performance metrics
+`list_terminals`, `get_terminal_output`, `get_selected_terminal`,
+`send_terminal_input`, `create_terminal`, `delete_terminal`, `restart_terminal`,
+`configure_terminal`, `set_primary_terminal`, `start_autonomous_mode`,
+`stop_autonomous_mode`, `launch_interval`, `get_agent_metrics`
 
 **When to Use**:
 - Sending commands to agent terminals
 - Monitoring agent activity in real-time
-- Interactive terminal sessions
 - Automating terminal workflows
 - Controlling autonomous agent execution
-- Testing autonomous mode behavior
+
+See the [Terminal Tools Reference](./loom-terminals.md) for detailed parameters.
+
+---
+
+### Sweep Dispatch (8 tools)
+
+**Purpose**: Drive the Rust `loom-daemon` (Tier 2) over its Unix-socket IPC —
+dispatch single-issue sweeps and observe the event bus. Requires a running
+`loom-daemon`.
+
+`dispatch_sweep`, `list_sweeps`, `get_sweep_status`, `tail_sweep_log`,
+`cancel_sweep`, `publish_event`, `subscribe_to_events`, `tail_event_bus`
+
+**When to Use**:
+- Dispatching `/loom:sweep <N>` with multi-account token rotation
+- Inspecting or cancelling in-flight sweeps
+- Streaming sweep-lifecycle events
+
+---
+
+### Durable Watches (3 tools)
+
+**Purpose**: Register machine-level watches on issue/PR terminal state (#3971)
+that survive the registering session's death and daemon restarts. Resolutions
+append to `~/.loom/logs/watch-results.log`.
+
+`register_watch`, `list_watches`, `remove_watch`
 
 ---
 
@@ -138,9 +126,6 @@ cd mcp-loom && npm install && npm run build
 MCP tools are available with the `mcp__loom__` prefix:
 
 ```typescript
-// Read console logs
-mcp__loom__read_console_log({ lines: 50 })
-
 // List terminals
 mcp__loom__list_terminals()
 
@@ -150,82 +135,51 @@ mcp__loom__get_terminal_output({
   lines: 100
 })
 
-// Trigger factory reset
-mcp__loom__trigger_factory_reset()
+// Dispatch a sweep for issue #123
+mcp__loom__dispatch_sweep({ kind: { Issue: 123 } })
 
-// View daemon logs
-mcp__loom__tail_daemon_log({ lines: 50 })
+// Check on it
+mcp__loom__get_sweep_status({ sweep_id: "sweep-..." })
 ```
 
 ---
 
 ## Common Workflows
 
-### Testing Factory Reset
+### Dispatching and Monitoring a Sweep
 
-**Goal**: Verify factory reset creates all terminals and launches agents successfully
+**Goal**: Run a full issue lifecycle on the daemon and watch it complete
 
 ```typescript
-// 1. Check app is running
-const heartbeat = await mcp__loom__get_heartbeat();
-if (heartbeat.status !== "healthy") {
-  // App needs to be started
-}
+// 1. Check the daemon is reachable and see what's already running
+const sweeps = await mcp__loom__list_sweeps();
 
-// 2. Trigger factory reset
-await mcp__loom__trigger_factory_reset();
+// 2. Dispatch the issue
+const dispatch = await mcp__loom__dispatch_sweep({ kind: { Issue: 123 } });
 
-// 3. Force start without confirmation
-await mcp__loom__trigger_force_start();
+// 3. Poll status (or subscribe to events instead)
+const status = await mcp__loom__get_sweep_status({ sweep_id: dispatch.sweep_id });
 
-// 4. Wait for terminals to be created
-await new Promise(resolve => setTimeout(resolve, 5000));
+// 4. Tail the per-sweep log if something looks stuck
+const log = await mcp__loom__tail_sweep_log({ sweep_id: dispatch.sweep_id, lines: 50 });
 
-// 5. Verify terminals exist
-const terminals = await mcp__loom__list_terminals();
-// Should show 8 terminals (terminal-1 through terminal-8)
-
-// 6. Check each agent terminal launched successfully
-for (const terminalId of ["terminal-2", "terminal-3", "terminal-4"]) {
-  const output = await mcp__loom__get_terminal_output({
-    terminal_id: terminalId,
-    lines: 50
-  });
-  // Look for "Claude Code" or "Codex" startup message
-}
-
-// 7. Read console logs for any errors
-const consoleLogs = await mcp__loom__read_console_log({ lines: 200 });
-// Check for error messages
+// 5. Cancel if needed (SIGTERM → grace → SIGKILL)
+await mcp__loom__cancel_sweep({ sweep_id: dispatch.sweep_id });
 ```
 
-### Debugging Agent Launch Failures
+### Watching an Issue/PR to Resolution
 
-**Goal**: Investigate why an agent didn't start correctly
+**Goal**: Get durable notification when an issue or PR reaches terminal state,
+even if this session dies
 
 ```typescript
-// 1. Read console logs for launch sequence
-const consoleLogs = await mcp__loom__read_console_log({ lines: 100 });
-// Look for [launchAgentInTerminal] messages
+// Register the watch (idempotent; cross-repo via repo/workspace_root)
+await mcp__loom__register_watch({ kind: "pr", number: 456 });
 
-// 2. Check daemon logs for IPC issues
-const daemonLogs = await mcp__loom__tail_daemon_log({ lines: 100 });
-// Look for CreateTerminal and SendInput messages
+// List active watches
+const watches = await mcp__loom__list_watches();
 
-// 3. Check terminal output
-const terminalOutput = await mcp__loom__get_terminal_output({
-  terminal_id: "terminal-3",
-  lines: 50
-});
-// Look for errors or stuck prompts
-
-// 4. Check state file for worktree paths
-const state = await mcp__loom__read_state_file();
-// Verify worktreePath is set
-
-// 5. Check config for role settings
-const config = await mcp__loom__read_config_file();
-// Verify roleFile and workerType are correct
+// Resolutions land in ~/.loom/logs/watch-results.log
 ```
 
 ### Monitoring Agent Activity
@@ -290,45 +244,38 @@ const output = await mcp__loom__get_terminal_output({
          │ MCP Protocol (stdio)
          │
          ▼
-┌─────────────────┐
-│    mcp-loom     │  (Unified MCP Server)
-│                 │
-│  ┌───────────┐  │
-│  │ Log Tools │  │
-│  ├───────────┤  │
-│  │ UI Tools  │  │
-│  ├───────────┤  │
-│  │Term Tools │  │
-│  └───────────┘  │
-└────────┬────────┘
-         │
+┌──────────────────┐
+│     mcp-loom     │  (Unified MCP Server)
+│                  │
+│  ┌────────────┐  │
+│  │ UI/Engine  │  │
+│  ├────────────┤  │
+│  │ Terminals  │  │
+│  ├────────────┤  │
+│  │  Sweeps    │  │
+│  ├────────────┤  │
+│  │  Watches   │  │
+│  └────────────┘  │
+└────────┬─────────┘
+         │ Unix-socket IPC
          ▼
 ┌──────────────────────────────────┐
 │           loom-daemon            │
 │  Orchestration + IPC server      │
 └──────────────────────────────────┘
-         │                │
-         ▼                ▼
-    ~/.loom/          /tmp/
-    daemon.log        loom-daemon.sock
-    state.json        loom-*.out
-    config.json
 ```
 
 ### File System
 
-**Loom Directory** (`~/.loom/`):
+**Machine-level Loom Directory** (`~/.loom/`):
+- `loom-daemon.sock` - Unix socket for daemon IPC (override with `LOOM_SOCKET_PATH`)
 - `daemon.log` - Daemon activity logs
-- `mcp-command.json` - File-based IPC commands
+- `watches.json` - Durable watch registry
+- `logs/watch-results.log` - Terminal resolutions of watches
 
 **Workspace Directory** (`{workspace}/.loom/`):
-- `state.json` - Current terminal state
-- `config.json` - Terminal configurations
+- `config.json` - Terminal/role configurations
 - `worktrees/` - Git worktrees for agents
-
-**Temporary Directory** (`/tmp/`):
-- `loom-daemon.sock` - Unix socket for IPC
-- `loom-terminal-*.out` - Terminal output logs
 
 ---
 
@@ -339,9 +286,9 @@ const output = await mcp__loom__get_terminal_output({
 **1. Add tool to the unified server** (`mcp-loom/src/tools/*.ts`):
 
 Choose the appropriate file based on tool category:
-- `logs.ts` - Log monitoring tools
-- `ui.ts` - UI control and state tools
+- `ui.ts` - UI/engine control and state tools
 - `terminals.ts` - Terminal management tools
+- `sweeps.ts` - Sweep dispatch, event bus, and durable watch tools
 
 ```typescript
 // In the appropriate tools file, add to the tools array
@@ -377,7 +324,8 @@ async function myNewToolImpl(param1: string): Promise<string> {
 }
 ```
 
-**3. Document in API reference** (`docs/mcp/*.md`)
+**3. Document it** — update the tool table in `mcp-loom/README.md` (the
+authoritative list) and, for terminal tools, `docs/mcp/loom-terminals.md`
 
 **4. Rebuild and test**:
 
@@ -403,10 +351,9 @@ node mcp-loom/dist/index.js
 **Integration Testing** (from Claude Code):
 ```typescript
 // Test tools from unified server
-const logs = await mcp__loom__read_console_log();
-const state = await mcp__loom__read_state_file();
+const heartbeat = await mcp__loom__get_heartbeat();
 const terminals = await mcp__loom__list_terminals();
-const daemonLog = await mcp__loom__tail_daemon_log();
+const sweeps = await mcp__loom__list_sweeps();
 ```
 
 ### Debugging
@@ -465,11 +412,10 @@ if (heartbeat.status === "not_running") {
 
 ## API Reference
 
-For detailed tool documentation by category, see:
+For detailed tool documentation, see:
 
-- **[Terminal Tools Reference](./loom-terminals.md)** - tools for terminal and autonomous mode control
-
-Log and UI tools are described inline in the top of this document.
+- **[`mcp-loom/README.md`](../../mcp-loom/README.md)** - authoritative table of all 30 tools
+- **[Terminal Tools Reference](./loom-terminals.md)** - detailed parameters for terminal and autonomous-mode tools
 
 ---
 
@@ -478,10 +424,10 @@ Log and UI tools are described inline in the top of this document.
 When adding new MCP capabilities:
 
 1. **Add tool to mcp-loom package** - All tools go in the unified `mcp-loom/src/tools/` directory
-2. **Choose the right category** - Add to `logs.ts`, `ui.ts`, or `terminals.ts`
+2. **Choose the right category** - Add to `ui.ts`, `terminals.ts`, or `sweeps.ts`
 3. **Write comprehensive documentation** - Include parameters, returns, examples, and error conditions
 4. **Test thoroughly** - Verify tool works from Claude Code
-5. **Update this README** - Add to tool list and workflows if applicable
+5. **Update the tool tables** - `mcp-loom/README.md` first; this overview only if a category changes
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -118,7 +118,7 @@ See [../docs/workflows.md](../docs/workflows.md) for complete workflow documenta
 ### Workers not finding issues?
 - Install GitHub CLI: `brew install gh` (macOS) or equivalent
 - Authenticate: `gh auth login`
-- Create issues with `loom:ready` label
+- Create issues with `loom:issue` label
 
 ### Configuration not loading?
 - Ensure `.loom/config.json` has valid JSON

--- a/loom-daemon/README.md
+++ b/loom-daemon/README.md
@@ -1,0 +1,42 @@
+# loom-daemon
+
+The Rust daemon at the core of Loom: the Tier 2 orchestration backend that
+dispatches and supervises `/loom:sweep` runs across managed repos, plus a large
+family of native CLI subcommands that replaced Loom's earlier Python tooling
+(epic #4081).
+
+One daemon runs per machine (launchd/systemd-supervised), managing every repo
+registered in `~/.loom/workspaces.json`. Clients — the `mcp-loom` MCP server,
+`loom-daemon dispatch`, the fleet dashboard — talk to it over a Unix-socket IPC
+protocol (default `~/.loom/loom-daemon.sock`).
+
+## What lives here
+
+- **Daemon runtime** — work finder, role runner, epic supervisor, event bus,
+  sweep registry, health monitor, host/GitHub circuit breakers, capacity model
+  (token pool × disk × CPU headroom).
+- **Operator CLI** — `status`, `health`, `dispatch`, `watch`, `fleet`,
+  `tokens`, `clean`, `recover-orphans`, `forge`, and more. Run
+  `loom-daemon --help` for the full annotated list; each subcommand's help text
+  is the authoritative reference.
+- **Embedded dashboard** — `loom-daemon serve` hosts a read-only status page
+  (`src/dashboard.html`) over the same IPC snapshot the CLI uses.
+
+## Build & test
+
+```bash
+cargo build --package loom-daemon --release   # or: pnpm run daemon:build
+cargo test --package loom-daemon              # or: pnpm run daemon:test
+```
+
+Dev workflow wrappers (`pnpm run daemon:dev`, `daemon:headless`, `daemon:stop`)
+are documented in [`scripts/README.md`](../scripts/README.md).
+
+## Documentation
+
+- [`.loom/docs/daemon-reference.md`](../.loom/docs/daemon-reference.md) — MCP
+  surface, event taxonomy, autonomous configuration, operability
+- [`CLAUDE.md`](../CLAUDE.md) — orchestration architecture and usage modes
+- [`docs/adr/`](../docs/adr) — architecture decision records (ADR-0009 covers
+  the shepherd deprecation; epic #3449 rebuilt the daemon surface as this crate)
+- [`tests/README.md`](tests/README.md) — integration test layout

--- a/mcp-loom/README.md
+++ b/mcp-loom/README.md
@@ -75,9 +75,9 @@ You can still register per-repo if needed (e.g. Claude Desktop), but set
 | `LOOM_WORKSPACE` | Path to the Loom workspace (bypasses CWD discovery) | CWD-based repo-root discovery; **no** `~/GitHub/loom` fallback |
 | `LOOM_SOCKET_PATH` | Path to daemon socket | `~/.loom/loom-daemon.sock` |
 
-## Available Tools (27 total)
+## Available Tools (30 total)
 
-The MCP server provides 27 tools organized by function.
+The MCP server provides 30 tools organized by function.
 
 ### UI/Engine Control (6 tools)
 

--- a/quickstarts/README.md
+++ b/quickstarts/README.md
@@ -22,27 +22,29 @@ cd ~/projects/my-app
 pnpm install && pnpm dev
 ```
 
-## Coming Soon
+### [desktop](./desktop/)
 
-### desktop (planned)
+Desktop application with Tauri 2.0, React, and system integration.
 
-Desktop application with Tauri, React, and system integration.
+**Stack:** Tauri 2.0, React 19, TypeScript, Tailwind CSS 4, shadcn/ui, SQLite (tauri-plugin-sql), Vite
 
-**Planned features:**
-- Native menu integration
-- Auto-updates
-- System tray
-- Local storage
+```bash
+cp -r quickstarts/desktop ~/projects/my-app
+cd ~/projects/my-app
+pnpm install && pnpm dev
+```
 
-### api (planned)
+### [api](./api/)
 
 API-first backend with Cloudflare Workers and Hono.
 
-**Planned features:**
-- Auth middleware
-- Rate limiting
-- OpenAPI documentation
-- KV/D1 integration
+**Stack:** Hono (zod-openapi), Cloudflare Workers, D1 + KV, Zod validation, OpenAPI/Swagger UI
+
+```bash
+cp -r quickstarts/api ~/projects/my-app
+cd ~/projects/my-app
+pnpm install && pnpm dev
+```
 
 ## Using Templates
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -88,17 +88,17 @@ These scripts are used by the pnpm commands in `package.json`:
 
 ## Files Created
 
-These scripts create files in the project root (all gitignored):
+These scripts create files under `.loom/` (all gitignored):
 
-- `.daemon.pid` - Process ID of running daemon
-- `.daemon.log` - Daemon stdout/stderr output
+- `.loom/.daemon.pid` - Process ID of running daemon
+- `.loom/.daemon.log` - Daemon stdout/stderr output
 
 ## Troubleshooting
 
 ### Daemon won't start
 Check the log file:
 ```bash
-cat .daemon.log
+cat .loom/.daemon.log
 ```
 
 Common issues:
@@ -116,14 +116,14 @@ ps aux | grep loom-daemon
 kill -9 <PID>
 
 # Clean up
-rm -f .daemon.pid
+rm -f .loom/.daemon.pid
 ```
 
 ### Stale PID file
-If `.daemon.pid` exists but daemon isn't running:
+If `.loom/.daemon.pid` exists but daemon isn't running:
 ```bash
-rm .daemon.pid
-pnpm run daemon:start
+rm .loom/.daemon.pid
+pnpm run daemon:dev
 ```
 
 The stop script handles this automatically by checking if the PID is still alive.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -40,8 +40,6 @@ Starts the daemon in the background silently and stores its PID.
 Usage:
 ```bash
 ./scripts/start-daemon.sh
-# or
-pnpm run daemon:start
 ```
 
 ### stop-daemon.sh
@@ -74,8 +72,6 @@ sleep 1
 Usage:
 ```bash
 ./scripts/restart-daemon.sh
-# or
-pnpm run daemon:restart
 ```
 
 ## Integration with pnpm


### PR DESCRIPTION
Repo hygiene pass (/repo:all) — lands three local hygiene commits that had accumulated on this host plus today's fixes.

## What's in here

- **docs/mcp/README.md**: rewritten against the actual 30-tool mcp-loom surface — the old version listed 14 removed tools (`tail_daemon_log`, `read_console_log`, `trigger_factory_reset`, …) as current and omitted the Sweep Dispatch and Durable Watches categories entirely. Per-tool tables now defer to `mcp-loom/README.md` as the single source of truth.
- **mcp-loom/README.md**: tool count 27 → 30 (matches its own section sums: 6 UI + 13 terminal + 8 sweep + 3 watch, verified against `src/tools/*.ts`).
- **README.md**: MCP tool count 19 → 30.
- **scripts/README.md**: `.daemon.pid`/`.daemon.log` paths corrected to `.loom/` (where the scripts actually write), and nonexistent `pnpm run daemon:start` → `daemon:dev`.
- **assets/tarot-cards/README.md**: filenames corrected to the real SVGs (`worker.svg`/`reviewer.svg`/`critic.svg`/`fixer.svg` never existed), missing Champion (Strength) row added, and the claim that these assets are wired into the Loom UI removed (nothing consumes them).
- **loom-daemon/README.md**: new orientation README for the core crate (was the largest browsable dir with none).
- Earlier session's doc fixes (defaults/quickstarts/examples READMEs, safehouse + token-pool docs) and resync re-stamps.

## Verification

- All MCP tool names/params in the rewritten doc checked against `mcp-loom/src/tools/*.ts` schemas (`dispatch_sweep` takes `kind: {Issue: N}`, watch tools take `number`/`kind`/`repo`).
- Internal links validated by a full-repo link scan (0 broken).
- Docs-only + install-metadata stamp; no runtime code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)