### PR TITLE
fix(test): stop pinning Codex smoke test's READY_PROFILE install to defaults/ bridge

### DIFF
--- a/defaults/scripts/tests/test-spawn-codex.sh
+++ b/defaults/scripts/tests/test-spawn-codex.sh
@@ -894,8 +894,14 @@ run_preflight() {
 }
 
 READY_PROFILE="$(mk_hook_profile ready)"
+# No explicit --bridge here: production `install` never passes one either, so
+# this must resolve the bridge the exact same way spawn-codex.sh's `verify`
+# call does (via resolve_bridge()'s --workspace-relative candidate). Pinning
+# to $BRIDGE_SCRIPT (the defaults/ copy) would diverge from verify's
+# resolution whenever a workspace-local .loom/hooks/guard-codex-bridge.sh
+# copy also exists (see #4787), spuriously reporting hooks=not-ready.
 bash "$PROVISION_SCRIPT" install --codex-home "$READY_PROFILE" \
-    --workspace "$(pwd)" --bridge "$BRIDGE_SCRIPT" >/dev/null 2>&1
+    --workspace "$(pwd)" >/dev/null 2>&1
 printf 'hooks.state."loom".trusted_hash = "deadbeef"\n' > "$READY_PROFILE/config.toml"
 
 BARE_PROFILE="$(mk_hook_profile bare)"


### PR DESCRIPTION
## Summary

`test-spawn-codex.sh`'s `READY_PROFILE install` call pins `--bridge` explicitly
to the `defaults/hooks/guard-codex-bridge.sh` copy. `spawn-codex.sh`'s runtime
`verify` call never passes `--bridge`, so it always resolves via
`provision-codex-hooks.sh`'s `resolve_bridge()`, which prefers a
`$WORKSPACE/.loom/hooks/guard-codex-bridge.sh` copy when one is readable.

Before the resync commit `17dbf1b1` added `.loom/hooks/guard-codex-bridge.sh`
to the working tree, `resolve_bridge()` fell through to the same `defaults/`
path the test pinned, so `install` and `verify` happened to agree. Now that
the `.loom/` copy exists, `verify` resolves to a different absolute path than
what the test's `install` pinned, and `do_verify()`'s bridge-match check
correctly (but spuriously, for this fixture) reports
`hooks=not-ready` with reason `"the installed managed-hook entry points at a
different bridge than this workspace's"`. This fails 2 of the suite's
assertions and fails the "Codex Adapter Smoke (mocked)" CI job on `main`.

This is a test-fixture bug, not a production bug: real `install` invocations
never pass `--bridge` either, so production `install`/`verify` always resolve
through the same `resolve_bridge()` candidate order and stay in agreement.

## Fix

Drop the explicit `--bridge "$BRIDGE_SCRIPT"` from the `READY_PROFILE`
install call, letting it resolve via `--workspace "$(pwd)"` alone — matching
both how production `install` is actually invoked and how `spawn-codex.sh`
invokes `verify`. `resolve_bridge()` and `spawn-codex.sh`'s `verify` call
site are unchanged. The untrusted/stale profile install calls later in the
same block keep their explicit `--bridge` since they test unrelated negative
paths (untrusted config, tampered hook entry) and don't need to match
`verify`'s resolution.

## Test plan

- `bash defaults/scripts/tests/test-spawn-codex.sh` — 182/182 assertions pass
  (run from a plain, non-worktree clone matching `actions/checkout@v7`'s CI
  checkout; a linked worktree's `git rev-parse --git-common-dir` resolves to
  the *main* repo's `.git`, which makes `spawn-codex.sh`'s workspace
  resolution diverge from a worktree-local `$(pwd)` for reasons unrelated to
  this fix — this only affects local testing inside a Loom-managed worktree,
  not CI or a normal checkout)
- Confirmed the bare/untrusted/stale profile cases in the same
  "managed Codex hook readiness preflight" block still correctly report
  `hooks=not-ready` after the fix (no regression, no weakened preflight)
- `bash -n defaults/scripts/tests/test-spawn-codex.sh` passes

Closes #4787