### PR TITLE
feat(runtimes): tier-3 generic passthrough adapter for unverified CLI coverage

### DIFF
--- a/.loom/runtimes/aider.json
+++ b/.loom/runtimes/aider.json
@@ -1,0 +1,13 @@
+{
+  "runtime": "aider",
+  "tier": 3,
+  "tierLabel": "generic passthrough (unverified)",
+  "capabilities": {
+    "mcp": "no",
+    "subagents": "no",
+    "hooks": "no",
+    "skills": "no",
+    "worktreeIsolation": "no"
+  },
+  "note": "Tier-3 generic passthrough adapter (issue #4780). worktreeIsolation is declared 'no' EXPLICITLY, not 'partial' -- it is flatly unverified, not 'close but gapped'. This refuses Builder and Doctor (both require worktreeIsolation) by the same mechanism that already keeps Codex's 'partial' out of Builder; check-runtime-capabilities.sh needed no code change to enforce this. No guardrail-parity document exists or is required for tier-3 -- see defaults/docs/runtime-adapters.md's tier-3 section for why that is safe."
+}

--- a/defaults/docs/runtime-adapters.md
+++ b/defaults/docs/runtime-adapters.md
@@ -37,6 +37,18 @@ The contract exists to *generalize* Loom, not to demote Claude Code.
   ownership** — ongoing maintenance of its adapter, its parity doc, and its CI
   leg. Tier is a *maintainership* statement, not a capability statement: a
   perfectly capable runtime stays tier-2 until an owner signs up.
+- **Tier-3 is "generic passthrough": unverified, and refused for every
+  worktree-mutating role by construction.** Tier-2 is still a real bar — a
+  spawn smoke test, error classification, and a guardrail-parity document with
+  an explicit residual-gap section — which means Loom has exactly two admitted
+  runtimes against an ecosystem of many terminal-compatible coding CLIs. Tier-3
+  is the bounded, explicitly-lower-trust escape hatch: a single
+  `spawn-generic.sh` template (thin per-CLI wrappers instantiate it) that
+  satisfies only [contract point 1](#1-spawn) (Spawn) and the
+  generic-transient fallthrough half of [contract point 3](#3-error-classification)
+  (Error classification) — no custom pattern table, no sandbox mapping, no
+  parity doc. See [Tier 3: generic passthrough](#tier-3-generic-passthrough)
+  below for the full shape and why skipping the parity doc is safe.
 
 These are operator policy statements recorded on #4167; the contract encodes
 them but does not decide them.
@@ -47,7 +59,85 @@ them but does not decide them.
 |---------|---------|------|-----------|--------|-------|
 | Claude Code | `defaults/scripts/spawn-claude.sh` | **1** (default) | n/a — Loom's guards *are* the Claude implementation | the whole existing suite | Zero-regression default; no `LOOM_RUNTIME` needed. |
 | OpenAI Codex CLI | `defaults/scripts/spawn-codex.sh` | **2** | [`guardrail-parity-codex.md`](guardrail-parity-codex.md) | `codex-adapter-smoke` in `.github/workflows/ci.yml` (mocked; no live calls) | **Shipped** by epic #4167 Phase 2 (#4468), ported from the gpeyton fork. Requires Codex CLI ≥ 0.146.0. Capability manifest `defaults/runtimes/codex.json` declares `worktreeIsolation: partial`, so `check-runtime-capabilities.sh` fails Builder+codex closed while Judge+codex passes. |
-| Amp, oh-my-pi (omp), … | — | — | — | — | Not started. |
+| Amp, oh-my-pi (omp), … | — | — | — | — | Not started (tier-2 candidates; still need a parity doc + CI leg). |
+| Aider ([aider.chat](https://aider.chat)) | `defaults/scripts/spawn-aider.sh` (thin wrapper over `defaults/scripts/spawn-generic.sh`) | **3** (generic passthrough, unverified) | n/a — tier-3 does not require one | none (no CI leg is required for tier-3; the checker assertion below is a plain `test-*.sh`, not an adapter-admission gate) | **Worked example** for issue #4780 — proves the tier-3 mechanism end-to-end, not a vetted integration. Capability manifest `defaults/runtimes/aider.json` declares every capability `"no"`, including `worktreeIsolation: "no"` EXPLICITLY (not `"partial"`). |
+
+### Tier 3: generic passthrough
+
+A tier-3 adapter exists to try a low-trust CLI against a **read-only**
+role — Judge, Curator, Guide, Auditor — without first writing a full
+guardrail-parity document. It is deliberately a much thinner contract than
+tier-1/tier-2:
+
+- **Implements only contract points 1 and 3, and only partially.** Point 1
+  (Spawn) is the full interface — args passthrough, prompt delivery, a
+  runtime-missing exit code — but with no logical model-tier mapping, no
+  transcript, and no account/usage-pool integration (points 2 and 4 are
+  skipped outright). Point 3 (Error classification) is satisfied by the
+  **generic-transient fallthrough only**: a tier-3 runtime gets no bespoke
+  pattern table in `classify-error.sh`. Passing its name as the
+  `classify_error` provider argument is safe by construction — an
+  unregistered provider matches no table and resolves through the shared
+  engine's exit-code-first ordering and generic transients, exactly like any
+  genuinely unknown provider already does today.
+- **No guardrail-parity document (point 6) and no CI smoke leg are required.**
+  This is not a lowered bar for tier-1/tier-2 — those promotion criteria are
+  unchanged (see the issue's "Non-goals") — it is a *different* trust
+  boundary that does not need a documented residual gap, because the boundary
+  is enforced mechanically instead of by prose:
+- **The capability manifest (point 7) is what makes skipping the parity doc
+  safe.** A tier-3 runtime's `defaults/runtimes/<name>.json` declares
+  `worktreeIsolation: "no"` **explicitly** — not `"partial"`. There is no
+  ambiguity to record ("close but gapped"); it is flatly unverified. Because
+  Builder and Doctor both declare `runtimeRequirements: ["worktreeIsolation",
+  ...]`, `check-runtime-capabilities.sh --role builder --runtime <tier-3-name>`
+  fails closed with exit **78** (`EX_CONFIG`) by the exact same mechanism that
+  already keeps Codex's `worktreeIsolation: partial` out of Builder — **no
+  code change to the checker was needed**: it already treats any value other
+  than exactly `"yes"` as unmet, so `"no"` fails closed identically to
+  `"partial"`.
+- **Read-only admission is per-role, not automatic for the whole "read-only"
+  category.** `judge.json` declares `runtimeRequirements: ["mcp"]`, so a
+  tier-3 runtime with no MCP support (the honest default — see below) is
+  refused for Judge too, for the same reason it is refused for Builder: a
+  declared `"no"` is not a declared `"yes"`. `curator.json`, `guide.json`, and
+  `auditor.json` declare **no** `runtimeRequirements` today, so they are the
+  roles a no-MCP tier-3 runtime is actually admitted for (any runtime is
+  trivially compatible with a role that declares no requirements). A tier-3
+  runtime that *does* support MCP can declare `mcp: "yes"` and pick up Judge
+  too — the manifest is the single source of truth, not a hardcoded
+  runtime-vs-role table.
+
+**The shared template.** `defaults/scripts/spawn-generic.sh` is driven
+entirely by environment variables so one implementation backs many thin
+per-CLI wrappers instead of duplicating the Spawn interface per CLI:
+
+```bash
+#!/usr/bin/env bash
+LOOM_GENERIC_RUNTIME_NAME="aider" \
+LOOM_GENERIC_CLI_BIN="${LOOM_GENERIC_CLI_BIN:-aider}" \
+LOOM_GENERIC_PROMPT_FLAG="${LOOM_GENERIC_PROMPT_FLAG:---message}" \
+    exec "$(dirname "${BASH_SOURCE[0]}")/spawn-generic.sh" "$@"
+```
+
+`spawn-worker.sh` needed **no change** to dispatch a tier-3 runtime: it
+already resolves `spawn-<runtime>.sh` by name off disk, so
+`LOOM_RUNTIME=aider` (or `runtimes.default: "aider"`) reaches
+`spawn-aider.sh` → `spawn-generic.sh` through the exact same seam Codex uses.
+
+**Worked example (issue #4780).** `defaults/scripts/spawn-aider.sh` wires the
+[Aider](https://aider.chat) CLI as a tier-3 runtime end-to-end:
+`defaults/runtimes/aider.json` declares every capability `"no"`, so
+`check-runtime-capabilities.sh --role builder --runtime aider` exits 78 while
+`--role curator --runtime aider` exits 0. This is the *mechanism*, not a
+roster of new runtimes — onboarding any other specific CLI as tier-3 is a
+separate, per-CLI follow-up (see the issue's "Non-goals").
+
+**Promoting a tier-3 runtime to tier-2** means writing the guardrail-parity
+document, adding a CI smoke leg, and — critically — re-declaring its
+capabilities honestly (`"partial"` where a real, if incomplete, mechanism
+exists; `"yes"` only where it is fully proven). Promotion is a manifest edit
+plus the missing artifacts, not a rewrite of the adapter shape.
 
 ## The seven contract points
 
@@ -371,10 +461,13 @@ by the standalone checker and daemon admission:
   reads only `runtimeRequirements`.
 - **Matcher** — `defaults/scripts/check-runtime-capabilities.sh --role <name>
   --runtime <name>` loads both files and checks requirements ⊆ capabilities,
-  where a requirement is satisfied only by a declared `"yes"` (`"partial"` fails
-  closed). Exit 0 on match or no-requirements, exit 78 (`EX_CONFIG`) on mismatch
-  naming each unmet capability, non-zero with a distinct message on an
-  unknown/missing role or runtime file.
+  where a requirement is satisfied only by a declared `"yes"` (`"partial"` AND
+  `"no"` both fail closed identically — this is why a tier-3 manifest can
+  declare `"no"` explicitly instead of reusing `"partial"`'s "close but
+  gapped" connotation, with no change to the matcher itself). Exit 0 on match
+  or no-requirements, exit 78 (`EX_CONFIG`) on mismatch naming each unmet
+  capability, non-zero with a distinct message on an unknown/missing role or
+  runtime file.
 
 **Second manifest (#4468):** `defaults/runtimes/codex.json` declares
 `mcp: "yes"`, `subagents: "no"` (the fork PR #59 prohibition), `hooks: "partial"`,
@@ -384,6 +477,17 @@ while `--role judge --runtime codex` passes — the manifest mechanically encode
 the parity doc's residual gaps, and the CI leg asserts both outcomes. That is the
 intended relationship between points 6 and 7: the parity doc states the gap in
 prose, the manifest makes it enforceable.
+
+**Third manifest, tier-3 (#4780):** `defaults/runtimes/aider.json` declares
+**every** capability `"no"`, including `worktreeIsolation: "no"` **explicitly**
+rather than `"partial"` — there is no residual gap to record in prose because
+there is no parity doc for tier-3 at all (see
+[Tier 3: generic passthrough](#tier-3-generic-passthrough)). The same "any
+non-`yes` value fails closed" matcher rule that enforces Codex's `partial`
+enforces this `no` identically — `--role builder --runtime aider` and
+`--role judge --runtime aider` (judge requires `mcp`, declared `"no"` here)
+both exit 78, while `--role curator --runtime aider` exits 0 because
+`curator.json` declares no `runtimeRequirements` at all.
 
 **Why `hooks`/`worktreeIsolation` are still `partial` after #4495.** Loom *does*
 now wire Codex's `pre_tool_use` event (`defaults/hooks/guard-codex-bridge.sh`,
@@ -603,6 +707,14 @@ capability manifest at `defaults/runtimes/<runtime>.json` (point 7) at the same
 time — declaring a capability `"partial"` fails role matching closed, which is
 how Codex is correctly kept out of Builder dispatch.
 
+**Want to skip both of those for now?** That is exactly what
+[tier-3 generic passthrough](#tier-3-generic-passthrough) is for: instantiate
+`spawn-generic.sh` instead of writing a full adapter, declare every capability
+`"no"` (including `worktreeIsolation: "no"`, explicitly) in the manifest, and
+the runtime is refused for Builder/Doctor with no parity doc required. Use it
+to try a CLI against a read-only role first; write the tier-2 artifacts only
+once you are ready to trust it more broadly.
+
 ### Unknown-runtime failure (exit 78)
 
 If the resolved runtime has no matching `spawn-<runtime>.sh` runner, the
@@ -671,5 +783,10 @@ collaboration:
   guardrail-parity doc (contract point 6), including the `CODEX_HOME` profile
   layout / refresh / security-posture reference absorbed from #4469.
 - **#4468** — Codex adapter port (Phase 2). **#4470** — Codex canary runs.
+- **#4780** — tier-3 "generic passthrough" mechanism: `spawn-generic.sh`, the
+  `defaults/runtimes/aider.json` worked example, and the capability-manifest
+  gate this section documents. Adapted from a survey of
+  [stablyai/orca](https://github.com/stablyai/orca) (`.loom/docs/survey-orca-2026-07-31.md`,
+  idea 5), filed from #4775.
 - [ADR-0012: Multi-Runtime Worker Support via a Runtime Adapter Contract](../../docs/adr/0012-runtime-adapter-contract.md).
 - Fork: https://github.com/gpeyton/loom · `AGENTS.md` standard: https://agents.md

--- a/defaults/runtimes/aider.json
+++ b/defaults/runtimes/aider.json
@@ -1,0 +1,13 @@
+{
+  "runtime": "aider",
+  "tier": 3,
+  "tierLabel": "generic passthrough (unverified)",
+  "capabilities": {
+    "mcp": "no",
+    "subagents": "no",
+    "hooks": "no",
+    "skills": "no",
+    "worktreeIsolation": "no"
+  },
+  "note": "Tier-3 generic passthrough adapter (issue #4780). worktreeIsolation is declared 'no' EXPLICITLY, not 'partial' -- it is flatly unverified, not 'close but gapped'. This refuses Builder and Doctor (both require worktreeIsolation) by the same mechanism that already keeps Codex's 'partial' out of Builder; check-runtime-capabilities.sh needed no code change to enforce this. No guardrail-parity document exists or is required for tier-3 -- see defaults/docs/runtime-adapters.md's tier-3 section for why that is safe."
+}

--- a/defaults/scripts/spawn-aider.sh
+++ b/defaults/scripts/spawn-aider.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# spawn-aider.sh - Tier-3 "generic passthrough" adapter instantiation for the
+# Aider CLI (https://aider.chat), the worked example for issue #4780.
+#
+# This is deliberately the THINNEST possible adapter: it pins the two facts
+# `spawn-generic.sh` needs (the underlying binary name and its non-interactive
+# prompt flag) and execs the shared template. It does NOT reimplement any of
+# spawn-generic.sh's logic — see that file's header for the full contract
+# (points 1 and 3 only) and for everything a tier-3 adapter deliberately does
+# NOT implement.
+#
+# Aider is unverified by Loom: no guardrail-parity document, no CI smoke leg,
+# no sandbox mapping. Its capability manifest (`defaults/runtimes/aider.json`)
+# declares every capability "no", including `worktreeIsolation: "no"`
+# EXPLICITLY, so `check-runtime-capabilities.sh` refuses Builder and Doctor by
+# construction (see runtime-adapters.md's tier-3 section). It is admitted only
+# for roles with no `runtimeRequirements` (Curator, Guide, Auditor today).
+#
+# Usage:
+#   .loom/scripts/spawn-aider.sh -p "your prompt"
+#   LOOM_RUNTIME=aider .loom/scripts/spawn-worker.sh -p "your prompt"
+
+set -euo pipefail
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Aider's non-interactive headless mode is `aider --message "<prompt>" --yes-always`
+# (see https://aider.chat/docs/scripting.html). `--yes-always` auto-confirms
+# every prompt aider would otherwise ask interactively -- required for
+# unattended dispatch, same rationale as spawn-codex.sh's sandbox convention,
+# just with no sandbox to widen (aider has none; this is exactly the
+# "unverified" gap the capability manifest records).
+LOOM_GENERIC_RUNTIME_NAME="aider" \
+LOOM_GENERIC_CLI_BIN="${LOOM_GENERIC_CLI_BIN:-aider}" \
+LOOM_GENERIC_PROMPT_FLAG="${LOOM_GENERIC_PROMPT_FLAG:---message}" \
+    exec "${_SCRIPT_DIR}/spawn-generic.sh" --yes-always "$@"

--- a/defaults/scripts/spawn-generic.sh
+++ b/defaults/scripts/spawn-generic.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# spawn-generic.sh - Tier-3 "generic passthrough" runtime adapter TEMPLATE
+# (issue #4780, epic #4167).
+#
+# This is NOT a tier-1/tier-2 adapter. It is the shared shape a low-trust,
+# unverified CLI is wired through when the operator wants to try it against a
+# READ-ONLY role (Judge, Curator, Guide, Auditor) without first writing a full
+# guardrail-parity document. It satisfies only TWO of the seven contract
+# points in `defaults/docs/runtime-adapters.md`:
+#
+#   1. Spawn                 — headless prompt execution -> exit code.
+#   3. Error classification  — generic-transient FALLTHROUGH only; no
+#                               per-provider pattern table is written for a
+#                               tier-3 runtime (see classify-error.sh).
+#
+# Every other contract point (model mapping, usage accounting, instruction
+# format, permission/sandbox mapping, capability declaration) is deliberately
+# NOT implemented for tier-3 — that is what keeps it "unverified" rather than
+# "tier-2, gapped". The mechanism that makes this safe is contract point 7:
+# a tier-3 runtime's capability manifest (`defaults/runtimes/<name>.json`)
+# declares `worktreeIsolation: "no"` EXPLICITLY (not "partial" — there is no
+# ambiguity to record), so `check-runtime-capabilities.sh` fails closed for
+# every role whose `runtimeRequirements` includes `worktreeIsolation`
+# (Builder, Doctor) by the SAME mechanism that already keeps Codex's
+# `partial` out of Builder. No new enforcement code was needed for this: the
+# checker already treats anything other than exactly "yes" as unmet.
+#
+# This script is a TEMPLATE, not a single fixed adapter: it is driven
+# entirely by environment variables so one shared implementation backs many
+# thin per-CLI wrappers (`spawn-<cli>.sh`, e.g. `spawn-aider.sh`, the worked
+# example shipped alongside this file). A wrapper pins the underlying binary
+# name and prompt-delivery flag, then `exec`s this script:
+#
+#   #!/usr/bin/env bash
+#   LOOM_GENERIC_RUNTIME_NAME="aider" \
+#   LOOM_GENERIC_CLI_BIN="${LOOM_GENERIC_CLI_BIN:-aider}" \
+#   LOOM_GENERIC_PROMPT_FLAG="${LOOM_GENERIC_PROMPT_FLAG:---message}" \
+#       exec "$(dirname "${BASH_SOURCE[0]}")/spawn-generic.sh" "$@"
+#
+# `spawn-worker.sh` resolves `spawn-<runtime>.sh` by name and needs no change
+# to dispatch a tier-3 runtime — the dispatch seam already generalizes.
+#
+# Env vars:
+#   LOOM_GENERIC_RUNTIME_NAME  Required. The logical runtime name used in log
+#                              lines and as the `classify_error` provider
+#                              argument (which resolves to NO pattern table,
+#                              i.e. the generic-transient fallthrough).
+#   LOOM_GENERIC_CLI_BIN       Required. The underlying CLI binary to exec
+#                              (looked up on PATH).
+#   LOOM_GENERIC_PROMPT_FLAG   Optional. The flag the underlying CLI uses for
+#                              non-interactive prompt delivery (e.g.
+#                              `--message`). When unset, the prompt is
+#                              delivered as the final POSITIONAL argument
+#                              instead (no flag emitted).
+#   LOOM_GENERIC_MODEL_FLAG    Optional. The flag the underlying CLI uses for
+#                              model selection (e.g. `--model`). When unset,
+#                              `LOOM_MODEL` is silently NOT forwarded (the
+#                              contract's "omit, no error" facet — tier-3 has
+#                              no logical-tier mapping).
+#   LOOM_GENERIC_NO_EXEC       Test/CI hook: print the argv this script WOULD
+#                              run (prefixed `spawn-generic would-exec:`) and
+#                              exit 0. Never touches the real CLI.
+#   LOOM_SWEEP_NICE / LOOM_SWEEP_NICENESS / LOOM_SWEEP_TASKPOLICY_CLASS
+#                              Scheduling priority, applied the same way
+#                              spawn-claude.sh / spawn-codex.sh apply it
+#                              (issue #4233) — a runner-level re-exec covers
+#                              the whole tree with no double-apply.
+#
+# Usage:
+#   -p "your prompt" / --prompt "your prompt"   Deliver a headless prompt.
+#   Every other argument is forwarded to the underlying CLI verbatim.
+#
+# NOTE: this file's own basename makes `LOOM_RUNTIME=generic` resolve through
+# spawn-worker.sh's dispatch seam, same as any other spawn-<runtime>.sh. That
+# is expected but not directly useful: with neither env var pinned it exits
+# 78 immediately (see below). Always dispatch through a per-CLI wrapper (like
+# spawn-aider.sh) that pins both, not through `LOOM_RUNTIME=generic` directly.
+#
+# NOT implemented (by design — this is the point of tier-3):
+#   - No token pool / account rotation (usage accounting, contract point 4).
+#   - No transcript (cost fidelity degrades to `none`, per the usage-
+#     accounting contract's degraded-fidelity clause).
+#   - No sandbox/guard mapping (contract point 6) and therefore NO guardrail-
+#     parity document — refused for worktree-mutating roles by construction
+#     via the capability manifest instead of by a documented residual gap.
+#   - No custom error-classification pattern table (contract point 3 beyond
+#     the generic fallthrough) — a tier-3 runtime's failures resolve through
+#     `classify_error`'s exit-code-first engine and its unmatched-provider
+#     fallthrough (RECOVERABLE), same as any truly unknown provider today.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')]${NC} $*" >&2; }
+log_warn() { echo -e "${YELLOW}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] WARN${NC} $*" >&2; }
+log_error() { echo -e "${RED}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] ERROR${NC} $*" >&2; }
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' | sed '$d'
+    exit 0
+fi
+
+RUNTIME_NAME="${LOOM_GENERIC_RUNTIME_NAME:-}"
+CLI_BIN="${LOOM_GENERIC_CLI_BIN:-}"
+
+if [[ -z "$RUNTIME_NAME" ]]; then
+    log_error "LOOM_GENERIC_RUNTIME_NAME is required (a tier-3 wrapper must pin it before exec'ing this template)."
+    exit 78  # EX_CONFIG
+fi
+if [[ -z "$CLI_BIN" ]]; then
+    log_error "LOOM_GENERIC_CLI_BIN is required (a tier-3 wrapper must pin the underlying CLI binary name)."
+    exit 78  # EX_CONFIG
+fi
+
+# --- Sweep/role-runner scheduling priority (issue #4233) ---
+if [[ -z "${LOOM_SWEEP_NICED:-}" && "${LOOM_SWEEP_NICE:-1}" != "0" ]]; then
+    _sweep_niceness="${LOOM_SWEEP_NICENESS:-10}"
+    _sweep_taskpolicy_class="${LOOM_SWEEP_TASKPOLICY_CLASS:-}"
+    if [[ -n "$_sweep_taskpolicy_class" ]] && command -v taskpolicy >/dev/null 2>&1; then
+        taskpolicy -c "$_sweep_taskpolicy_class" -p $$ >/dev/null 2>&1 \
+            && log_info "spawn-generic($RUNTIME_NAME): applied taskpolicy -c $_sweep_taskpolicy_class (issue #4233)" \
+            || log_warn "spawn-generic($RUNTIME_NAME): taskpolicy -c $_sweep_taskpolicy_class failed (non-fatal)"
+    fi
+    if [[ "$_sweep_niceness" != "0" ]] && command -v nice >/dev/null 2>&1; then
+        export LOOM_SWEEP_NICED=1
+        exec nice -n "$_sweep_niceness" "$0" "$@"
+    fi
+fi
+
+log_info "spawn-generic: runtime=$RUNTIME_NAME bin=$CLI_BIN tier=3 LOOM_SWEEP_CLAIM_OWNED=${LOOM_SWEEP_CLAIM_OWNED:-unset}"
+
+# --- Argument parsing (contract point 1: args passthrough + prompt delivery) ---
+PROMPT=""
+HAS_PROMPT=false
+PASSTHROUGH_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -p|--prompt)
+            if [[ $# -lt 2 ]]; then
+                log_error "$1 requires a value"
+                exit 78  # EX_CONFIG
+            fi
+            PROMPT="$2"
+            HAS_PROMPT=true
+            shift 2
+            ;;
+        -p=*)
+            PROMPT="${1#-p=}"
+            HAS_PROMPT=true
+            shift
+            ;;
+        --prompt=*)
+            PROMPT="${1#--prompt=}"
+            HAS_PROMPT=true
+            shift
+            ;;
+        --dangerously-skip-permissions|--use-wrapper|--effort|--effort=*)
+            # Loom's runner-neutral conventions. A tier-3 template has no
+            # sandbox/effort mapping to translate them into, so they are
+            # CONSUMED (never forwarded) rather than passed through
+            # unrecognized to an underlying CLI that does not understand
+            # them. --effort takes a value; consume it too.
+            case "$1" in
+                --effort)
+                    if [[ $# -ge 2 ]]; then shift; fi
+                    ;;
+            esac
+            shift
+            ;;
+        --)
+            shift
+            PASSTHROUGH_ARGS+=("$@")
+            break
+            ;;
+        *)
+            PASSTHROUGH_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# --- Model mapping (contract point 2: minimalism, matches spawn-codex.sh) ---
+if [[ -n "${LOOM_GENERIC_MODEL_FLAG:-}" && -n "${LOOM_MODEL:-}" ]]; then
+    PASSTHROUGH_ARGS+=("$LOOM_GENERIC_MODEL_FLAG" "$LOOM_MODEL")
+    log_info "spawn-generic($RUNTIME_NAME): model=$LOOM_MODEL (via $LOOM_GENERIC_MODEL_FLAG)"
+else
+    log_info "spawn-generic($RUNTIME_NAME): model=default (no LOOM_GENERIC_MODEL_FLAG configured; LOOM_MODEL not forwarded)"
+fi
+
+# --- Prompt delivery: configured flag, else positional (last argv element) ---
+# The guarded ${arr[@]+"${arr[@]}"} expansion (matches spawn-codex.sh) avoids
+# an "unbound variable" error under `set -u` on bash 3.2 (macOS's default
+# /bin/bash) when PASSTHROUGH_ARGS is a declared-but-empty array.
+CLI_ARGS=(${PASSTHROUGH_ARGS[@]+"${PASSTHROUGH_ARGS[@]}"})
+if [[ "$HAS_PROMPT" == "true" ]]; then
+    if [[ -n "${LOOM_GENERIC_PROMPT_FLAG:-}" ]]; then
+        CLI_ARGS+=("$LOOM_GENERIC_PROMPT_FLAG" "$PROMPT")
+    else
+        CLI_ARGS+=("$PROMPT")
+    fi
+fi
+
+# --- Test/CI hook: surface the resolved argv without touching the real CLI ---
+if [[ -n "${LOOM_GENERIC_NO_EXEC:-}" ]]; then
+    echo "# LOOM_CLI_START runtime=$RUNTIME_NAME" >&2
+    echo "spawn-generic would-exec: $CLI_BIN ${CLI_ARGS[*]}"
+    exit 0
+fi
+
+# --- Runtime-missing failure (contract point 1) ---
+if ! command -v "$CLI_BIN" >/dev/null 2>&1; then
+    log_error "'$CLI_BIN' command not found in PATH."
+    log_error "Tier-3 runtime '$RUNTIME_NAME' has no Loom-managed install step — install it yourself and retry."
+    exit 127
+fi
+
+# --- Dispatch ---
+# Interactive (no prompt): a plain pid-preserving exec, stdin untouched.
+if [[ "$HAS_PROMPT" != "true" ]]; then
+    echo "# LOOM_CLI_START runtime=$RUNTIME_NAME" >&2
+    exec "$CLI_BIN" ${CLI_ARGS[@]+"${CLI_ARGS[@]}"}
+fi
+
+# Headless run: neutralize stdin (a dispatched worker's stdin is a pipe
+# nobody writes to; see spawn-codex.sh's "Neutralize stdin" adapter-author
+# lesson in runtime-adapters.md). Captured as a child (not `exec`) so the
+# exit code can still be classified below.
+#
+# Deliberate tier-3 simplification: stdout and stderr are COMBINED (2>&1)
+# before being replayed on this script's stdout. A verified tier-2 adapter
+# must empirically check its stream split (spawn-codex.sh's "Check which
+# stream your runtime's metadata is on" lesson) because a caller pipes its
+# stdout; a tier-3 template has no verified split to preserve, so it makes
+# the conservative choice of never silently dropping half the runtime's
+# output rather than guessing which stream carries what.
+set +e
+echo "# LOOM_CLI_START runtime=$RUNTIME_NAME" >&2
+_output="$("$CLI_BIN" ${CLI_ARGS[@]+"${CLI_ARGS[@]}"} </dev/null 2>&1)"
+_exit_code=$?
+set -e
+printf '%s\n' "$_output"
+
+# --- Error classification (contract point 3: generic-transient fallthrough
+# ONLY — a tier-3 runtime deliberately gets no bespoke pattern table). Passing
+# $RUNTIME_NAME as the provider is safe by construction: classify_error
+# matches no table for an unregistered provider and falls straight through to
+# the shared engine's exit-code-first ordering and generic transients. ---
+_classifier_lib="${_SCRIPT_DIR}/lib/classify-error.sh"
+if [[ -f "$_classifier_lib" ]]; then
+    # shellcheck source=./lib/classify-error.sh
+    source "$_classifier_lib"
+    _category="$(classify_error "$_output" "$_exit_code" "$RUNTIME_NAME")"
+    printf '# LOOM_TERMINAL_RESULT v=1 provider=%s account=unknown category=%s exit_code=%s\n' \
+        "$RUNTIME_NAME" "$_category" "$_exit_code" >&2
+fi
+
+exit "$_exit_code"

--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -68,6 +68,7 @@ test-require-complexity-marker.sh
 test-resolve-tier-model.sh
 test-resync-installed.sh
 test-safehoused-service.sh
+test-spawn-generic.sh
 test-spawn-worker.sh
 test-sweep-auto-stack.sh
 test-sweep-checkpoint.sh

--- a/defaults/scripts/tests/test-spawn-generic.sh
+++ b/defaults/scripts/tests/test-spawn-generic.sh
@@ -1,0 +1,410 @@
+#!/usr/bin/env bash
+# test-spawn-generic.sh — Tests for the tier-3 "generic passthrough" runtime
+# adapter mechanism (issue #4780, epic #4167).
+#
+# Style matches test-spawn-codex.sh / test-check-runtime-capabilities.sh —
+# plain bash, hand-rolled assertions, hermetic (no live CLI calls).
+#
+# Covers:
+#   1. syntax + --help
+#   2. argv assembly + prompt delivery (LOOM_GENERIC_NO_EXEC)
+#   3. required env vars (LOOM_GENERIC_RUNTIME_NAME / LOOM_GENERIC_CLI_BIN)
+#      missing -> exit 78
+#   4. missing binary -> exit 127
+#   5. mocked dispatch: exit-code passthrough, generic-transient
+#      classification fallthrough (no bespoke pattern table for a tier-3
+#      runtime name)
+#   6. LOOM_RUNTIME=aider resolves through spawn-worker.sh with NO changes to
+#      the dispatcher (the seam already generalizes)
+#   7. capability manifest gate: check-runtime-capabilities.sh fails closed
+#      for builder/doctor/judge + aider, and admits curator/guide/auditor
+#      (which declare no runtimeRequirements)
+#
+# Usage:
+#   ./.loom/scripts/tests/test-spawn-generic.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEFAULTS_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
+SPAWN_GENERIC="$SCRIPTS_DIR/spawn-generic.sh"
+SPAWN_AIDER="$SCRIPTS_DIR/spawn-aider.sh"
+CHECK_SCRIPT="$SCRIPTS_DIR/check-runtime-capabilities.sh"
+AIDER_MANIFEST="$DEFAULTS_DIR/runtimes/aider.json"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected: '$expected'"
+        echo "    Actual:   '$actual'"
+    fi
+}
+
+assert_contains() {
+    local needle="$1" haystack="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" == *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+assert_not_contains() {
+    local needle="$1" haystack="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" != *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Unexpected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+# ============================================================
+# Section 1: syntax + help
+# ============================================================
+
+echo "Testing spawn-generic.sh / spawn-aider.sh syntax and help..."
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if bash -n "$SPAWN_GENERIC" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: spawn-generic.sh passes bash -n"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: spawn-generic.sh fails bash -n"
+fi
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if bash -n "$SPAWN_AIDER" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: spawn-aider.sh passes bash -n"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: spawn-aider.sh fails bash -n"
+fi
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -x "$SPAWN_GENERIC" && -x "$SPAWN_AIDER" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: both scripts are executable"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: both scripts must be executable"
+fi
+
+set +e
+help_out="$(bash "$SPAWN_GENERIC" --help 2>&1)"
+help_rc=$?
+set -e
+assert_eq "0" "$help_rc" "--help exits 0"
+assert_contains "Tier-3" "$help_out" "--help renders the header docs"
+assert_not_contains "set -euo" "$help_out" "--help stops before the shebang body"
+
+# ============================================================
+# Section 2: argv assembly + prompt delivery (LOOM_GENERIC_NO_EXEC)
+# ============================================================
+
+echo ""
+echo "Testing spawn-generic.sh argv assembly + prompt delivery..."
+
+run_aider_argv() {
+    env -u LOOM_MODEL LOOM_SWEEP_NICE=0 LOOM_GENERIC_NO_EXEC=1 \
+        bash "$SPAWN_AIDER" "$@" 2>/dev/null || true
+}
+
+out="$(run_aider_argv -p "hello world")"
+assert_contains "spawn-generic would-exec: aider" "$out" \
+    "spawn-aider.sh pins bin=aider and delegates to the shared template"
+assert_contains "--yes-always" "$out" \
+    "spawn-aider.sh injects --yes-always for unattended dispatch"
+assert_contains "--message hello world" "$out" \
+    "the prompt is delivered via the configured LOOM_GENERIC_PROMPT_FLAG"
+
+out="$(run_aider_argv --prompt "alt-form")"
+assert_contains "--message alt-form" "$out" "--prompt is accepted as a synonym for -p"
+
+out="$(run_aider_argv -p=short-eq)"
+assert_contains "--message short-eq" "$out" "-p=VALUE is accepted"
+
+# No -p configured -> the generic template falls back to a positional prompt
+# when LOOM_GENERIC_PROMPT_FLAG is unset.
+out="$(env -u LOOM_MODEL LOOM_SWEEP_NICE=0 LOOM_GENERIC_NO_EXEC=1 \
+    LOOM_GENERIC_RUNTIME_NAME=positional-cli LOOM_GENERIC_CLI_BIN=somecli \
+    bash "$SPAWN_GENERIC" -p "positional-prompt" 2>/dev/null || true)"
+assert_contains "somecli positional-prompt" "$out" \
+    "with no LOOM_GENERIC_PROMPT_FLAG, the prompt is delivered as the final positional argv element"
+
+# Loom's runner-neutral conventions are CONSUMED, never forwarded (tier-3 has
+# no sandbox/effort mapping to translate them into).
+out="$(run_aider_argv -p x --dangerously-skip-permissions --use-wrapper --effort high)"
+assert_not_contains "--dangerously-skip-permissions" "$out" \
+    "--dangerously-skip-permissions is consumed, never forwarded"
+assert_not_contains "--use-wrapper" "$out" "--use-wrapper is consumed, never forwarded"
+assert_not_contains "--effort" "$out" "--effort (and its value) is consumed, never forwarded"
+
+# Unrecognized args pass through verbatim.
+out="$(run_aider_argv -p x --some-flag --color never)"
+assert_contains "--some-flag" "$out" "unrecognized flags pass through verbatim"
+assert_contains "--color never" "$out" "flag+value pairs pass through verbatim"
+
+# Model mapping: minimalism by default (no LOOM_GENERIC_MODEL_FLAG configured).
+out="$(env LOOM_MODEL=some-model LOOM_SWEEP_NICE=0 LOOM_GENERIC_NO_EXEC=1 \
+    bash "$SPAWN_AIDER" -p x 2>/dev/null || true)"
+assert_not_contains "some-model" "$out" \
+    "LOOM_MODEL is silently NOT forwarded with no LOOM_GENERIC_MODEL_FLAG configured (contract's 'omit, no error' facet)"
+
+out="$(env LOOM_MODEL=some-model LOOM_GENERIC_MODEL_FLAG=--model LOOM_SWEEP_NICE=0 \
+    LOOM_GENERIC_NO_EXEC=1 bash "$SPAWN_AIDER" -p x 2>/dev/null || true)"
+assert_contains "--model some-model" "$out" \
+    "LOOM_GENERIC_MODEL_FLAG + LOOM_MODEL together DO map to a model flag"
+
+# ============================================================
+# Section 3: required env vars -> exit 78 (EX_CONFIG)
+# ============================================================
+
+echo ""
+echo "Testing spawn-generic.sh required-env-var failures..."
+
+set +e
+noname_out="$(env -u LOOM_GENERIC_RUNTIME_NAME LOOM_GENERIC_CLI_BIN=foo \
+    LOOM_SWEEP_NICE=0 bash "$SPAWN_GENERIC" -p x 2>&1)"
+noname_rc=$?
+set -e
+assert_eq "78" "$noname_rc" "missing LOOM_GENERIC_RUNTIME_NAME exits 78"
+assert_contains "LOOM_GENERIC_RUNTIME_NAME is required" "$noname_out" \
+    "the missing-runtime-name message names the offending env var"
+
+set +e
+nobin_out="$(env -u LOOM_GENERIC_CLI_BIN LOOM_GENERIC_RUNTIME_NAME=foo \
+    LOOM_SWEEP_NICE=0 bash "$SPAWN_GENERIC" -p x 2>&1)"
+nobin_rc=$?
+set -e
+assert_eq "78" "$nobin_rc" "missing LOOM_GENERIC_CLI_BIN exits 78"
+assert_contains "LOOM_GENERIC_CLI_BIN is required" "$nobin_out" \
+    "the missing-cli-bin message names the offending env var"
+
+# -p / -m with no value are usage errors (EX_CONFIG), matching spawn-codex.sh.
+set +e
+noval_out="$(env LOOM_GENERIC_RUNTIME_NAME=foo LOOM_GENERIC_CLI_BIN=foo \
+    LOOM_SWEEP_NICE=0 bash "$SPAWN_GENERIC" -p 2>&1)"
+noval_rc=$?
+set -e
+assert_eq "78" "$noval_rc" "-p with no value exits 78 (EX_CONFIG)"
+assert_contains "requires a value" "$noval_out" "-p with no value says so"
+
+# ============================================================
+# Section 4: missing binary -> exit 127 (NOT 78)
+# ============================================================
+
+echo ""
+echo "Testing spawn-generic.sh missing-binary failure..."
+
+EMPTY_BIN="$TMPROOT/empty-bin"
+mkdir -p "$EMPTY_BIN"
+set +e
+missing_out="$(env LOOM_GENERIC_RUNTIME_NAME=aider LOOM_GENERIC_CLI_BIN=aider \
+    LOOM_SWEEP_NICE=0 PATH="$EMPTY_BIN:/usr/bin:/bin" \
+    bash "$SPAWN_GENERIC" -p x 2>&1)"
+missing_rc=$?
+set -e
+assert_eq "127" "$missing_rc" \
+    "a missing underlying binary exits 127, NOT 78 (78 is reserved for config errors)"
+assert_contains "'aider' command not found in PATH" "$missing_out" \
+    "the missing-binary message names the binary"
+
+# ============================================================
+# Section 5: mocked dispatch — exit-code passthrough + generic-transient
+# classification fallthrough (contract point 3, tier-3 minimalism)
+# ============================================================
+
+echo ""
+echo "Testing spawn-generic.sh mocked dispatch (fake aider on PATH)..."
+
+MOCK_BIN="$TMPROOT/mock-bin"
+mkdir -p "$MOCK_BIN"
+cat > "$MOCK_BIN/aider" <<'MOCK'
+#!/usr/bin/env bash
+_stdin="$(cat)"
+if [[ -n "$_stdin" ]]; then echo "MOCK-SAW-STDIN:$_stdin" >&2; fi
+echo "MOCK-OUTPUT: ${MOCK_MESSAGE:-ok}"
+exit "${MOCK_RC:-0}"
+MOCK
+chmod +x "$MOCK_BIN/aider"
+
+run_mock() {
+    local -a envs=()
+    while [[ $# -gt 0 && "$1" != "--" ]]; do envs+=("$1"); shift; done
+    shift || true
+    env LOOM_SWEEP_NICE=0 PATH="$MOCK_BIN:$PATH" \
+        ${envs[@]+"${envs[@]}"} \
+        bash "$SPAWN_AIDER" "$@"
+}
+
+set +e
+mock_stdout="$(run_mock -- -p "hi" 2>/dev/null)"
+mock_rc=$?
+set -e
+assert_eq "0" "$mock_rc" "a clean mock exit stays 0"
+assert_contains "MOCK-OUTPUT: ok" "$mock_stdout" "the mock's output reaches stdout"
+
+set +e
+mock_stderr="$({ run_mock -- -p "hi" >/dev/null; } 2>&1)"
+set -e
+assert_contains \
+    "# LOOM_TERMINAL_RESULT v=1 provider=aider account=unknown category=SUCCESS exit_code=0" \
+    "$mock_stderr" \
+    "a clean exit classifies as SUCCESS (exit-code-first, #3233) even with no pattern table"
+assert_not_contains "MOCK-SAW-STDIN" "$mock_stderr" \
+    "the child's stdin is /dev/null (no hang on a dispatched worker's unread pipe)"
+
+# Piped stdin from the caller must never reach the child either.
+mock_stderr="$(printf 'unwanted stdin payload\n' | { run_mock -- -p "hi" >/dev/null; } 2>&1)"
+assert_not_contains "MOCK-SAW-STDIN" "$mock_stderr" \
+    "piped caller stdin is NOT forwarded to the child"
+
+# Exit-code passthrough for a non-zero exit with UNRECOGNIZED output -> the
+# generic-transient fallthrough (RECOVERABLE), because a tier-3 runtime name
+# is deliberately unregistered in classify-error.sh's provider tables.
+set +e
+run_mock MOCK_RC=5 MOCK_MESSAGE="some transient network error" \
+    -- -p "hi" >/dev/null 2>&1
+mock_rc5=$?
+set -e
+assert_eq "5" "$mock_rc5" "the underlying CLI's exit code is passed through"
+
+mock_stderr="$({ run_mock MOCK_RC=5 MOCK_MESSAGE="some transient network error" \
+    -- -p "hi" >/dev/null; } 2>&1 || true)"
+assert_contains \
+    "# LOOM_TERMINAL_RESULT v=1 provider=aider account=unknown category=RECOVERABLE exit_code=5" \
+    "$mock_stderr" \
+    "an unmatched non-zero exit falls through to RECOVERABLE (generic-transient fallthrough, no bespoke pattern table)"
+
+# ============================================================
+# Section 6: LOOM_RUNTIME=aider resolves through spawn-worker.sh with NO
+# changes to the dispatcher itself (issue #4780's central claim)
+# ============================================================
+
+echo ""
+echo "Testing LOOM_RUNTIME=aider dispatch through spawn-worker.sh..."
+
+STAGE="$TMPROOT/stage"
+mkdir -p "$STAGE/lib"
+cp "$SCRIPTS_DIR/spawn-worker.sh" "$STAGE/spawn-worker.sh"
+cp "$SCRIPTS_DIR/lib/config-resolver.sh" "$STAGE/lib/config-resolver.sh"
+cp "$SPAWN_GENERIC" "$STAGE/spawn-generic.sh"
+cp "$SPAWN_AIDER" "$STAGE/spawn-aider.sh"
+cp "$SCRIPTS_DIR/lib/classify-error.sh" "$STAGE/lib/classify-error.sh"
+chmod +x "$STAGE"/spawn-*.sh
+
+out="$(env -u LOOM_RUNTIME LOOM_WORKSPACE="$TMPROOT/ws" \
+    LOOM_CONFIG_DEFAULTS_FILE="" LOOM_RUNTIME=aider LOOM_SWEEP_NICE=0 \
+    LOOM_GENERIC_NO_EXEC=1 bash "$STAGE/spawn-worker.sh" -p "routed" 2>&1 || true)"
+assert_contains "runtime=aider (from env (LOOM_RUNTIME))" "$out" \
+    "spawn-worker.sh resolves LOOM_RUNTIME=aider with no dispatcher changes"
+assert_contains "spawn-generic would-exec: aider" "$out" \
+    "spawn-worker.sh dispatches into spawn-aider.sh -> spawn-generic.sh"
+assert_contains "routed" "$out" "the prompt survives the dispatcher hop"
+
+# ============================================================
+# Section 7: capability manifest gate (contract point 7)
+# ============================================================
+
+echo ""
+echo "Testing the tier-3 capability manifest gate (check-runtime-capabilities.sh)..."
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if jq -e '.runtime == "aider" and (.capabilities | type == "object")' \
+    "$AIDER_MANIFEST" >/dev/null 2>&1; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: aider.json is valid JSON with the expected top-level shape"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: aider.json is valid JSON with the expected top-level shape"
+fi
+
+assert_eq "no" "$(jq -r '.capabilities.worktreeIsolation' "$AIDER_MANIFEST")" \
+    "aider.json declares worktreeIsolation EXPLICITLY as 'no' (not 'partial')"
+
+bad="$(jq -r '.capabilities | to_entries[]
+              | select(.value != "yes" and .value != "no" and .value != "partial")
+              | .key' "$AIDER_MANIFEST")"
+assert_eq "" "$bad" "every aider.json capability value is one of yes|no|partial"
+
+set +e
+bash "$CHECK_SCRIPT" --role builder --runtime aider --dir "$DEFAULTS_DIR" >/dev/null 2>&1
+builder_rc=$?
+bash "$CHECK_SCRIPT" --role doctor --runtime aider --dir "$DEFAULTS_DIR" >/dev/null 2>&1
+doctor_rc=$?
+bash "$CHECK_SCRIPT" --role judge --runtime aider --dir "$DEFAULTS_DIR" >/dev/null 2>&1
+judge_rc=$?
+bash "$CHECK_SCRIPT" --role curator --runtime aider --dir "$DEFAULTS_DIR" >/dev/null 2>&1
+curator_rc=$?
+bash "$CHECK_SCRIPT" --role guide --runtime aider --dir "$DEFAULTS_DIR" >/dev/null 2>&1
+guide_rc=$?
+bash "$CHECK_SCRIPT" --role auditor --runtime aider --dir "$DEFAULTS_DIR" >/dev/null 2>&1
+auditor_rc=$?
+set -e
+
+assert_eq "78" "$builder_rc" \
+    "builder + aider is refused (EX_CONFIG) -- worktreeIsolation='no' fails closed, same as Codex's 'partial'"
+assert_eq "78" "$doctor_rc" \
+    "doctor + aider is refused (EX_CONFIG) -- doctor also requires worktreeIsolation"
+assert_eq "78" "$judge_rc" \
+    "judge + aider is refused (EX_CONFIG) -- judge requires mcp, and aider declares mcp='no'"
+assert_eq "0" "$curator_rc" \
+    "curator + aider is admitted -- curator.json declares no runtimeRequirements"
+assert_eq "0" "$guide_rc" \
+    "guide + aider is admitted -- guide.json declares no runtimeRequirements"
+assert_eq "0" "$auditor_rc" \
+    "auditor + aider is admitted -- auditor.json declares no runtimeRequirements"
+
+# --json decision surface (#4494) reports the SAME set of unmet capabilities
+# for aider's 'no' that a 'partial' manifest would produce.
+if command -v jq >/dev/null 2>&1; then
+    json_out="$(bash "$CHECK_SCRIPT" --role builder --runtime aider --dir "$DEFAULTS_DIR" --json 2>/dev/null)"
+    assert_eq "reject" "$(jq -r '.decision' <<<"$json_out")" \
+        "--json reports decision=reject for builder+aider"
+    assert_contains "worktreeIsolation" "$(jq -rc '.unmet' <<<"$json_out")" \
+        "--json names worktreeIsolation as unmet for builder+aider"
+fi
+
+# ============================================================
+# Summary
+# ============================================================
+
+echo ""
+echo "==================================="
+echo "Tests run:    $TESTS_RUN"
+echo -e "Tests passed: ${GREEN}$TESTS_PASSED${NC}"
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    echo -e "Tests failed: ${RED}$TESTS_FAILED${NC}"
+    exit 1
+fi
+echo "All tests passed."


### PR DESCRIPTION
## Summary

Adds a **tier-3 "generic passthrough"** classification to Loom's runtime
adapter contract, alongside tier-1 (Claude, default) and tier-2 (Codex,
CI-gated). Tier-3 is a bounded, explicitly lower-trust escape hatch for
trying an unverified CLI against a **read-only** role (Judge, Curator,
Guide, Auditor) without first writing a full guardrail-parity document.

- **`defaults/scripts/spawn-generic.sh`** — a shared, env-var-driven template
  satisfying only contract point 1 (Spawn) and the generic-transient
  fallthrough half of contract point 3 (Error classification). No model
  mapping, no usage accounting, no sandbox mapping, no bespoke
  `classify-error.sh` pattern table.
- **`defaults/runtimes/aider.json`**` — the tier-3 capability manifest,
  declaring every capability `"no"`, including `worktreeIsolation: "no"`
  **explicitly** (not `"partial"`) — there is no residual gap to record in
  prose because there is no parity doc for tier-3 at all.
- **`defaults/scripts/spawn-aider.sh`** — the worked example: a thin wrapper
  pinning the [Aider](https://aider.chat) CLI's binary name and
  non-interactive prompt flag, then `exec`ing the shared template.
- **`defaults/docs/runtime-adapters.md`** — documents the tier-3 shape: a new
  tier-policy bullet, an adapter-status table row, a full "Tier 3: generic
  passthrough" section, and cross-references from contract points 6/7 and
  the "Adding a runtime adapter" walkthrough.

**No enforcement code changed.** `check-runtime-capabilities.sh` already
treats any capability value other than exactly `"yes"` as unmet, so a
manifest declaring `worktreeIsolation: "no"` fails closed for Builder/Doctor
identically to how Codex's `"partial"` already does — this is the same
mechanism, not a new one. `spawn-worker.sh` also needed no change: it
already resolves `spawn-<runtime>.sh` by name off disk, so
`LOOM_RUNTIME=aider` reaches `spawn-aider.sh` → `spawn-generic.sh` through
the exact seam Codex uses.

One nuance worth calling out: `judge.json` requires `mcp`, so a tier-3
runtime with no MCP support (the honest default) is refused for Judge too —
it is admitted only for roles that declare no `runtimeRequirements` at all
(`curator.json`, `guide.json`, `auditor.json` today). The doc documents this
explicitly rather than implying blanket "read-only role" admission.

This is the **mechanism**, not a roster of new runtimes — onboarding any
other specific CLI as tier-3 is a separate, per-CLI follow-up (per the
issue's "Non-goals"). `.loom/runtimes/aider.json` is included alongside
`defaults/runtimes/aider.json` because this repo's `.loom/runtimes/` is a
real (non-symlinked) committed mirror the daemon's own admission code reads
in this self-hosting repo — omitting it would fail
`runtime_admission::tests::native_and_shell_conformance_for_every_shipped_pair`
in CI (confirmed locally: it failed without the mirror, passes with it).

## Test plan

- [x] `bash defaults/scripts/tests/test-spawn-generic.sh` — new suite: syntax,
      `--help`, argv assembly/prompt delivery, required-env-var failures
      (78), missing-binary failure (127), mocked dispatch (exit-code
      passthrough + generic-transient classification fallthrough, stdin
      neutralization), `LOOM_RUNTIME=aider` dispatch through
      `spawn-worker.sh` with **no dispatcher changes**, and the
      `check-runtime-capabilities.sh` admission gate across
      builder/doctor/judge (refused, 78) and curator/guide/auditor
      (admitted, 0). All pass.
- [x] `bash defaults/scripts/tests/test-check-runtime-capabilities.sh` — no
      regression (27/27 passed).
- [x] `bash defaults/scripts/tests/test-spawn-worker.sh` — no regression
      (27/27 passed).
- [x] `bash defaults/scripts/tests/check-ci-suite-manifest.sh` — new suite
      wired into `ci-wired.txt`, manifest invariant holds.
- [x] `cargo test -p loom-daemon --lib
      runtime_admission::tests::native_and_shell_conformance_for_every_shipped_pair`
      — passes with the `.loom/runtimes/aider.json` mirror added (failed
      without it, confirming the mirror is required).
- [x] Manual end-to-end checks: `LOOM_RUNTIME=aider spawn-worker.sh` resolves
      through to `spawn-aider.sh` → `spawn-generic.sh`;
      `check-runtime-capabilities.sh --role builder --runtime aider` exits
      78; `--role curator --runtime aider` exits 0.

Closes #4780