### PR TITLE
ci: wire tests/hooks/* guard suites into the hermetic shell-suite job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
             scripts:
               - 'scripts/**'
               - 'defaults/**'
+              - 'tests/hooks/**'
               - '.github/workflows/ci.yml'
 
   backend-lint-and-check:
@@ -207,6 +208,12 @@ jobs:
     # with-a-reason, so a new suite cannot silently join an unwired pool.
     # Measured runtime: ~3 min (72 suites; run-ci-suites.sh prints per-suite
     # timing and a total). Kept sequential for deterministic ordering.
+    #
+    # Since #4769 ci-wired.txt also covers the tests/hooks/ Claude-path guard
+    # suites (repo root, not defaults/scripts/tests/ — previously unwired
+    # entirely). tests/hooks/test-guard-destructive.sh alone adds several
+    # minutes (531 assertions); run-ci-suites.sh's per-suite timeout was
+    # raised accordingly (see its header comment).
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/defaults/scripts/tests/check-ci-suite-manifest.sh
+++ b/defaults/scripts/tests/check-ci-suite-manifest.sh
@@ -11,13 +11,20 @@
 # must consciously wire it or exclude-it-with-a-reason. The `lib/` helper
 # directory is intentionally ignored — only `test-*.sh` files are suites.
 #
+# Since #4769 the invariant also covers tests/hooks/ (repo root) — the
+# Claude-path guard suites. Those entries are qualified with their path
+# relative to the repo root (e.g. `tests/hooks/test-guard-destructive.sh`) so
+# they can't collide with a same-named suite in this directory.
+#
 # Exit 0 = invariant holds; exit 1 = violation (details printed to stderr).
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 WIRED_MANIFEST="$SCRIPT_DIR/ci-wired.txt"
 EXCLUDED_MANIFEST="$SCRIPT_DIR/ci-excluded.txt"
+HOOKS_TEST_DIR="$REPO_ROOT/tests/hooks"
 
 fail=0
 err() { printf 'ERROR: %s\n' "$1" >&2; fail=1; }
@@ -34,7 +41,13 @@ manifest_names() { # <manifest-file>
 }
 
 # --- Collect the three sets --------------------------------------------------
-mapfile -t actual < <(cd "$SCRIPT_DIR" && for f in test-*.sh; do [[ -e "$f" ]] && printf '%s\n' "$f"; done | sort)
+mapfile -t actual_local < <(cd "$SCRIPT_DIR" && for f in test-*.sh; do [[ -e "$f" ]] && printf '%s\n' "$f"; done)
+mapfile -t actual_hooks < <(
+    if [[ -d "$HOOKS_TEST_DIR" ]]; then
+        cd "$HOOKS_TEST_DIR" && for f in test-*.sh; do [[ -e "$f" ]] && printf 'tests/hooks/%s\n' "$f"; done
+    fi
+)
+mapfile -t actual < <(printf '%s\n' "${actual_local[@]}" "${actual_hooks[@]}" | sort)
 mapfile -t wired < <(manifest_names "$WIRED_MANIFEST" | sort)
 mapfile -t excluded < <(manifest_names "$EXCLUDED_MANIFEST" | sort)
 
@@ -60,10 +73,17 @@ both="$(comm -12 <(printf '%s\n' "${wired[@]}") <(printf '%s\n' "${excluded[@]}"
 [[ -z "$both" ]] || err "suite(s) listed in BOTH manifests: $(tr '\n' ' ' <<<"$both")"
 
 # --- No manifest entry may reference a nonexistent file ----------------------
+# A `/`-containing entry is a path relative to the repo root (tests/hooks/…,
+# #4769); a bare filename is resolved against this directory as before.
 listed="$(printf '%s\n' "${wired[@]}" "${excluded[@]}" | sort -u)"
 while IFS= read -r name; do
     [[ -n "$name" ]] || continue
-    [[ -f "$SCRIPT_DIR/$name" ]] || err "manifest references nonexistent suite: $name"
+    if [[ "$name" == */* ]]; then
+        suite_path="$REPO_ROOT/$name"
+    else
+        suite_path="$SCRIPT_DIR/$name"
+    fi
+    [[ -f "$suite_path" ]] || err "manifest references nonexistent suite: $name"
 done <<<"$listed"
 
 # --- Every actual test-*.sh must be listed in exactly one manifest -----------

--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -7,6 +7,16 @@
 # See ci-excluded.txt for the excluded suites and their reasons.
 # check-ci-suite-manifest.sh enforces that every test-*.sh is in exactly one
 # of these two files. Blank lines and lines beginning with `#` are ignored.
+#
+# Since #4769 this manifest also covers the Claude-path guard suites under
+# tests/hooks/ (repo root, NOT defaults/scripts/tests/ — Repo Skills' guard
+# tests live there, one directory per guard family they test). Entries for
+# suites outside this directory are qualified with their path relative to the
+# repo root (e.g. `tests/hooks/test-guard-destructive.sh`); run-ci-suites.sh
+# and check-ci-suite-manifest.sh both resolve a `/`-containing entry against
+# the repo root instead of this directory. They were confirmed hermetic (no
+# live forge/network calls — the `gh`/`curl` strings in them are guard-input
+# fixtures, never executed) before being wired in here.
 
 test-archive-transcripts.sh
 test-blame-issue.sh
@@ -87,3 +97,8 @@ test-worktree-root-override.sh
 test-worktree-sentinel-reinvoke.sh
 test-worktree-sentinel.sh
 test-worktree-snapshot.sh
+
+# tests/hooks/ (repo root) — Claude-path guard suites, wired since #4769.
+tests/hooks/test-guard-destructive-dispatcher.sh
+tests/hooks/test-guard-destructive.sh
+tests/hooks/test-guard-loom-workflow.sh

--- a/defaults/scripts/tests/run-ci-suites.sh
+++ b/defaults/scripts/tests/run-ci-suites.sh
@@ -10,15 +10,24 @@
 #
 # Usage:
 #   run-ci-suites.sh                 # run the whole wired set
-#   LOOM_CI_SUITE_TIMEOUT=180 …      # per-suite timeout in seconds (default 120)
+#   LOOM_CI_SUITE_TIMEOUT=180 …      # per-suite timeout in seconds (default 1200)
+#
+# A manifest entry containing a `/` is a suite outside this directory,
+# resolved relative to the repo root (tests/hooks/…, #4769) rather than
+# SCRIPT_DIR; its log file name has the `/` replaced with `_` so it stays a
+# flat /tmp path. The default per-suite timeout was raised from 120s to 1200s
+# in #4769 to cover tests/hooks/test-guard-destructive.sh (531 assertions,
+# observed up to ~14 min / 850s wall-clock on a loaded dev machine — still
+# hermetic, just large — so the ceiling keeps real headroom above that peak).
 #
 # Exit 0 = all wired suites passed; 1 = one or more failed / manifest invalid.
 
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 WIRED_MANIFEST="$SCRIPT_DIR/ci-wired.txt"
-PER_SUITE_TIMEOUT="${LOOM_CI_SUITE_TIMEOUT:-120}"
+PER_SUITE_TIMEOUT="${LOOM_CI_SUITE_TIMEOUT:-1200}"
 
 # 1) Fail fast if the manifest partition invariant is broken.
 if ! bash "$SCRIPT_DIR/check-ci-suite-manifest.sh"; then
@@ -45,16 +54,21 @@ printf '\n=== Running %d CI-wired shell suites (timeout %ss each) ===\n\n' \
     "${#suites[@]}" "$PER_SUITE_TIMEOUT"
 
 for suite in "${suites[@]}"; do
-    path="$SCRIPT_DIR/$suite"
+    if [[ "$suite" == */* ]]; then
+        path="$REPO_ROOT/$suite"
+    else
+        path="$SCRIPT_DIR/$suite"
+    fi
+    log_name="${suite//\//_}"
     if [[ ! -f "$path" ]]; then
         echo "FAIL  $suite (missing file)"
         failed=$((failed + 1)); failed_names+=("$suite"); continue
     fi
     start=$(date +%s)
     if [[ -n "$timeout_cmd" ]]; then
-        "$timeout_cmd" "$PER_SUITE_TIMEOUT" bash "$path" >"/tmp/ci-suite-$suite.log" 2>&1
+        "$timeout_cmd" "$PER_SUITE_TIMEOUT" bash "$path" >"/tmp/ci-suite-$log_name.log" 2>&1
     else
-        bash "$path" >"/tmp/ci-suite-$suite.log" 2>&1
+        bash "$path" >"/tmp/ci-suite-$log_name.log" 2>&1
     fi
     rc=$?
     dur=$(( $(date +%s) - start ))
@@ -65,7 +79,7 @@ for suite in "${suites[@]}"; do
         printf 'FAIL  %-52s %3ss (exit %s)\n' "$suite" "$dur" "$rc"
         failed=$((failed + 1)); failed_names+=("$suite")
         echo "----- last 40 lines of $suite -----"
-        tail -40 "/tmp/ci-suite-$suite.log"
+        tail -40 "/tmp/ci-suite-$log_name.log"
         echo "----- end $suite -----"
     fi
 done


### PR DESCRIPTION
## Summary
`tests/hooks/test-guard-destructive.sh`, `tests/hooks/test-guard-destructive-dispatcher.sh`, and `tests/hooks/test-guard-loom-workflow.sh` previously had zero CI coverage — `ci-wired.txt` (consumed by `run-ci-suites.sh` in the "Shell Test Suites (hermetic)" CI job) only enumerated suites under `defaults/scripts/tests/`, so a regression in these guard hooks could ride to `main` invisibly. This extends the manifest/enforcement mechanism to also cover `tests/hooks/` (repo root) and wires all three suites in.

## Changes
- `defaults/scripts/tests/ci-wired.txt`: documents the new repo-root-relative entry convention and adds the three `tests/hooks/*.sh` suites.
- `defaults/scripts/tests/check-ci-suite-manifest.sh`: extends the wired/excluded partition invariant to also scan `tests/hooks/` for `test-*.sh` files, so a future suite added there can no longer silently ride unwired (mirrors the existing guarantee for `defaults/scripts/tests/`). A `/`-containing manifest entry resolves against the repo root instead of `defaults/scripts/tests/`.
- `defaults/scripts/tests/run-ci-suites.sh`: resolves `/`-containing entries against the repo root, flattens `/` to `_` in per-suite log filenames, and raises the default per-suite timeout from 120s to 1200s (`test-guard-destructive.sh` alone runs ~11-16 minutes with 531 assertions — still hermetic, just large).
- `.github/workflows/ci.yml`: adds `tests/hooks/**` to the path filter that decides whether the shell-suite job runs, and documents the timeout increase inline.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|---------------|
| All three suites execute in CI on every push/PR touching guard hooks | ✅ | Added to `ci-wired.txt`; `tests/hooks/**` added to the `ci.yml` path filter that gates the shell-suite job |
| A CI run fails if any of the three suites fails | ✅ | `run-ci-suites.sh` treats every wired-manifest entry uniformly — a non-zero exit from any suite (including the new `tests/hooks/*` entries) fails the whole job, same as existing suites |
| `check-ci-suite-manifest.sh` extended so a future `tests/hooks/` suite can't silently ride unwired | ✅ | `check-ci-suite-manifest.sh` now scans `tests/hooks/*.sh` in addition to `defaults/scripts/tests/*.sh` and requires every file to appear in exactly one manifest; verified locally (`bash defaults/scripts/tests/check-ci-suite-manifest.sh` → `OK: 86 suites (82 wired, 4 excluded)`) |
| No existing CI job's runtime materially regresses | ✅ | Raising the default timeout only changes the ceiling for suites that would otherwise fail/hang — passing suites are unaffected. Ran the full `run-ci-suites.sh` locally: 80/81 pre-existing suites still pass in line with their usual per-suite timings; only the new `test-guard-destructive.sh` run is materially longer (as expected and documented) |

## Test Plan
- `bash tests/hooks/test-guard-destructive.sh` — 531/531 assertions pass (hermetic, no live forge/network calls — the `gh`/`curl` strings are guard-input fixtures, never executed); ~11-16 min wall clock
- `bash tests/hooks/test-guard-destructive-dispatcher.sh` — 8/8 pass, ~2s
- `bash tests/hooks/test-guard-loom-workflow.sh` — 27/27 pass, ~9s
- `bash defaults/scripts/tests/check-ci-suite-manifest.sh` — passes, confirms the partition invariant now covers `tests/hooks/`
- Ran the full `defaults/scripts/tests/run-ci-suites.sh` locally: all 3 new suites pass; 80 of 81 pre-existing wired suites pass. The one pre-existing failure (`test-loom-dispatcher.sh`) is a known host-environment artifact unrelated to this change — this dev host has an ambient `LOOM_RUNTIME`/private tier-1 config-defaults file that leaks into that suite's "no env" test cases (reproduces identically on `origin/main` before this change; not something this PR touches or introduces)

Closes #4769