### PR TITLE
fix(status): surface machine-daemon state instead of "No agents running"

### DIFF
--- a/defaults/scripts/cli/loom-status.sh
+++ b/defaults/scripts/cli/loom-status.sh
@@ -16,7 +16,20 @@
 #   - Flags agents configured in .loom/config.json that are NOT running (in red),
 #     so a crashed / never-started agent is easy to spot.
 #   - Shows a work-queue summary (open loom:issue / loom:review-requested /
-#     loom:pr counts) when `gh` is available on a GitHub forge.
+#     loom:pr / loom:architect / loom:hermit / loom:curated / loom:auditor
+#     counts) when `gh` is available on a GitHub forge.
+#   - Surfaces MACHINE-DAEMON state for this workspace (#4793): this script
+#     only ever inspected the LOCAL tmux agent pool, so a repo actively
+#     managed by a separate machine-level `loom-daemon` fleet (autonomous
+#     work finder / role runner dispatching sweeps with zero local tmux
+#     sessions) used to read as "No agents running" -- misleadingly implying
+#     nothing would pick up open issues. When a `loom-daemon` binary can be
+#     located, this queries `loom-daemon status --json` (the same IPC surface
+#     `./.loom/bin/loom health` delegates to) for daemon liveness, whether
+#     this repo is a registered/managed workspace, its dispatch-gate state,
+#     and its in-flight sweep count -- and the empty-agent-pool message names
+#     its own scope explicitly ("local agent pool: none") instead of reading
+#     as a bare, fleet-wide "No agents running".
 #
 # Exits 0 whether or not any agents are running (an empty pool is not an error).
 
@@ -54,6 +67,16 @@ if [[ -z "$REPO_ROOT" ]]; then
     echo "Error: Not in a Loom workspace (.loom directory not found)" >&2
     exit 1
 fi
+
+# Canonicalized (symlink-resolved) repo root, used ONLY to match this
+# workspace against the `root` paths `loom-daemon status --json` / the
+# `~/.loom/workspaces.json` registry report -- both normalize via Rust's
+# `std::fs::canonicalize` (`workspace_registry::normalize_path`), so a
+# non-canonical `REPO_ROOT` (e.g. a `/tmp` symlinked to `/private/tmp` on
+# macOS) would otherwise silently fail to match a repo the daemon DOES
+# manage. Falls back to the plain `REPO_ROOT` if canonicalization fails.
+REPO_ROOT_CANON="$(cd "$REPO_ROOT" 2>/dev/null && pwd -P 2>/dev/null)"
+[[ -n "$REPO_ROOT_CANON" ]] || REPO_ROOT_CANON="$REPO_ROOT"
 
 TMUX_SOCKET="loom"
 
@@ -125,8 +148,16 @@ ${YELLOW}OUTPUT:${NC}
     printed with their exact 'tmux -L loom kill-session' recovery command.
     Agents present in the config but not currently running are listed
     separately in ${RED}red${NC} so a crashed or never-started agent is easy to spot.
-    A Work Queue summary (open ${CYAN}loom:issue${NC} / ${CYAN}loom:review-requested${NC} /
-    ${CYAN}loom:pr${NC} counts) is shown when 'gh' is available on a GitHub forge.
+    A Machine Daemon section reports whether a separate machine-level
+    'loom-daemon' fleet manages this repo (liveness, registry membership,
+    dispatch-gate state, in-flight sweep count) -- since that daemon can be
+    actively dispatching work here even when the local agent pool above is
+    empty, shown when a 'loom-daemon' binary is resolvable (PATH or an
+    in-repo build). A Work Queue summary (open ${CYAN}loom:issue${NC} /
+    ${CYAN}loom:review-requested${NC} / ${CYAN}loom:pr${NC} counts, plus
+    pending-proposal counts for ${CYAN}loom:architect${NC} / ${CYAN}loom:hermit${NC} /
+    ${CYAN}loom:curated${NC} / ${CYAN}loom:auditor${NC}) is shown when 'gh' is
+    available on a GitHub forge.
 
 ${YELLOW}EXIT STATUS:${NC}
     Always 0 when the workspace resolves — an empty pool is not an error.
@@ -205,17 +236,33 @@ count_label() {
 # Build the work-queue object as compact JSON, or "null" when gh/label counts
 # are unavailable (gh missing, unauthenticated, or a non-GitHub forge). Never
 # errors — a missing forge just yields null so the section is omitted.
+#
+# Includes the pending-proposal labels (loom:architect / loom:hermit /
+# loom:curated / loom:auditor, #4793) alongside the original three -- without
+# these a non-empty proposal pipeline still rendered as an all-zero work
+# queue, which read as "nothing pending" even when several proposals were
+# awaiting Champion review.
 work_queue_json() {
     command -v jq &>/dev/null || { echo "null"; return 0; }
-    local issue rr pr
+    local issue rr pr architect hermit curated auditor
     issue=$(count_label issue "loom:issue") || { echo "null"; return 0; }
     rr=$(count_label pr "loom:review-requested") || { echo "null"; return 0; }
     pr=$(count_label pr "loom:pr") || { echo "null"; return 0; }
+    architect=$(count_label issue "loom:architect") || { echo "null"; return 0; }
+    hermit=$(count_label issue "loom:hermit") || { echo "null"; return 0; }
+    curated=$(count_label issue "loom:curated") || { echo "null"; return 0; }
+    auditor=$(count_label issue "loom:auditor") || { echo "null"; return 0; }
     jq -nc \
         --argjson issue "$issue" \
         --argjson review_requested "$rr" \
         --argjson pr "$pr" \
-        '{"loom:issue":$issue, "loom:review-requested":$review_requested, "loom:pr":$pr}'
+        --argjson architect "$architect" \
+        --argjson hermit "$hermit" \
+        --argjson curated "$curated" \
+        --argjson auditor "$auditor" \
+        '{"loom:issue":$issue, "loom:review-requested":$review_requested, "loom:pr":$pr,
+          "loom:architect":$architect, "loom:hermit":$hermit, "loom:curated":$curated,
+          "loom:auditor":$auditor}'
 }
 
 # Read the configured terminals as compact JSON array (or "[]"), resolved
@@ -228,6 +275,162 @@ read_terminals() {
     else
         echo "[]"
     fi
+}
+
+# ---- Machine daemon integration (#4793) ----------------------------------
+# This script only ever inspected the LOCAL tmux agent pool. The functions
+# below layer in the machine-level `loom-daemon` picture -- daemon liveness,
+# whether THIS repo is a registered/managed workspace, its dispatch-gate
+# state, and its in-flight sweep count -- by reusing the daemon's OWN
+# reporting surfaces rather than re-deriving any of that logic in bash:
+#   - `loom-daemon status --json` (the same IPC call `./.loom/bin/loom
+#     health` delegates to) is the primary source: when the daemon answers,
+#     its `install_state`/`per_repo` fields are authoritative.
+#   - `~/.loom/workspaces.json` (the on-disk registry `loom-daemon
+#     workspace add|remove|list` and the daemon itself read/write, override
+#     `LOOM_WORKSPACES_PATH`) is consulted ONLY as a fallback membership
+#     check when the daemon itself is unreachable -- a static file read
+#     still answers "is this repo registered?" even while the daemon is down.
+
+# Resolve the loom-daemon binary: LOOM_DAEMON_BIN override -> PATH -> in-repo
+# cargo build outputs. Mirrors loom-daemon-watchdog.sh's locate_daemon_bin()
+# / `./.loom/bin/loom health`'s resolution order verbatim, so this script and
+# those two never disagree about which binary is "the" daemon CLI. Echoes
+# the resolved path and returns 0, or returns 1 with nothing echoed.
+locate_daemon_bin() {
+    if [[ -n "${LOOM_DAEMON_BIN:-}" ]]; then
+        [[ -x "${LOOM_DAEMON_BIN}" ]] && { echo "${LOOM_DAEMON_BIN}"; return 0; }
+        return 1
+    fi
+    if command -v loom-daemon &>/dev/null; then
+        command -v loom-daemon
+        return 0
+    fi
+    local candidate
+    for candidate in \
+        "$REPO_ROOT/loom-daemon/target/release/loom-daemon" \
+        "$REPO_ROOT/loom-daemon/target/debug/loom-daemon"; do
+        [[ -x "$candidate" ]] && { echo "$candidate"; return 0; }
+    done
+    return 1
+}
+
+# Query `loom-daemon status --json`. Echoes the JSON payload on success --
+# either a full DaemonStatusReport (daemon reachable) or the #4069
+# unreachable-error object (daemon not reachable; still carries an
+# `install_state` liveness classification: NotExpected / ExpectedButDead /
+# AliveStarting / AliveButUnresponsive) -- and echoes nothing when no
+# loom-daemon binary can be located at all, or `jq` is unavailable to parse
+# the result. Never propagates the daemon CLI's own exit code (it exits
+# non-zero on the unreachable path by design) so callers never abort under
+# `set -e`.
+daemon_status_json() {
+    command -v jq &>/dev/null || return 0
+    local bin
+    bin="$(locate_daemon_bin)" || return 0
+    "$bin" status --json 2>/dev/null || true
+}
+
+# Best-effort machine-registry membership check via a direct read of
+# ~/.loom/workspaces.json (or $LOOM_WORKSPACES_PATH), used ONLY as a
+# fallback when the daemon itself is unreachable -- a live daemon's own
+# `per_repo` array (from daemon_status_json) is authoritative and takes
+# precedence over this. Returns 0 (repo present) or 1 (absent / no registry
+# / no jq) -- never errors under `set -e`.
+registry_has_repo() {
+    command -v jq &>/dev/null || return 1
+    local registry_path="${LOOM_WORKSPACES_PATH:-$HOME/.loom/workspaces.json}"
+    [[ -f "$registry_path" ]] || return 1
+    jq -e --arg root "$REPO_ROOT_CANON" \
+        '(.workspaces // []) | any(.root == $root)' \
+        "$registry_path" >/dev/null 2>&1
+}
+
+# Populate the daemon_* globals this section's callers (emit_human /
+# emit_json) branch on, from a single daemon_status_json() call:
+#   daemon_bin_found     true|false  -- a loom-daemon binary was located
+#   daemon_reachable     true|false  -- the IPC round-trip succeeded
+#   daemon_manages_repo  true|false  -- this repo is a managed/registered
+#                                       workspace (per_repo match, or the
+#                                       registry-file fallback)
+#   daemon_in_flight     count of non-terminal sweeps for this repo (per_repo
+#                        match only; "0" when reachable but unmatched, empty
+#                        when unreachable)
+#   daemon_gate_halted   true|false|"" -- per-repo main-health gate state
+#                        (per_repo match only; empty when unreachable/unmatched)
+#   daemon_install_state NotExpected|ExpectedButDead|AliveStarting|
+#                        AliveButUnresponsive|"" (unreachable path only)
+#   daemon_liveness_detail  human-readable detail string (unreachable path only)
+#   daemon_roles         space-separated distinct role names this repo's
+#                        role-runner has ticked recently ("" when none/unreachable)
+collect_daemon_state() {
+    daemon_bin_found=false
+    daemon_reachable=false
+    daemon_manages_repo=false
+    daemon_in_flight=""
+    daemon_gate_halted=""
+    daemon_install_state=""
+    daemon_liveness_detail=""
+    daemon_roles=""
+
+    command -v jq &>/dev/null || return 0
+    locate_daemon_bin >/dev/null 2>&1 && daemon_bin_found=true
+    [[ "$daemon_bin_found" == "true" ]] || return 0
+
+    local json
+    json="$(daemon_status_json)"
+    [[ -n "$json" ]] || return 0
+
+    if echo "$json" | jq -e 'has("error") | not' >/dev/null 2>&1; then
+        daemon_reachable=true
+        local repo_entry
+        repo_entry="$(echo "$json" | jq -c --arg root "$REPO_ROOT_CANON" \
+            '[(.per_repo // [])[] | select(.root == $root)] | .[0] // empty' 2>/dev/null)"
+        if [[ -n "$repo_entry" && "$repo_entry" != "null" ]]; then
+            daemon_manages_repo=true
+            daemon_in_flight="$(echo "$repo_entry" | jq -r '.in_flight_count // 0' 2>/dev/null)"
+            daemon_gate_halted="$(echo "$repo_entry" | jq -r '.health_gate_halted // false' 2>/dev/null)"
+        fi
+        daemon_roles="$(echo "$json" | jq -r --arg root "$REPO_ROOT_CANON" \
+            '[(.role_tick_records // [])[] | select(.root == $root) | .role] | unique | join(" ")' 2>/dev/null)"
+    else
+        daemon_install_state="$(echo "$json" | jq -r '.install_state.state // empty' 2>/dev/null)"
+        daemon_liveness_detail="$(echo "$json" | jq -r '.install_state.liveness_detail // empty' 2>/dev/null)"
+    fi
+
+    if [[ "$daemon_manages_repo" != "true" ]] && registry_has_repo; then
+        daemon_manages_repo=true
+    fi
+}
+
+# Compact JSON rendering of the daemon_* globals collect_daemon_state()
+# populates, for `emit_json`'s `daemon` key. Must be called AFTER
+# collect_daemon_state.
+daemon_state_json_obj() {
+    command -v jq &>/dev/null || { echo "null"; return 0; }
+    local roles_json="[]"
+    if [[ -n "$daemon_roles" ]]; then
+        roles_json="$(printf '%s\n' "$daemon_roles" | tr ' ' '\n' | jq -R . | jq -sc 'map(select(. != ""))')"
+    fi
+    jq -nc \
+        --argjson binary_found "$daemon_bin_found" \
+        --argjson reachable "$daemon_reachable" \
+        --argjson manages_repo "$daemon_manages_repo" \
+        --arg in_flight "$daemon_in_flight" \
+        --arg gate_halted "$daemon_gate_halted" \
+        --arg install_state "$daemon_install_state" \
+        --arg liveness_detail "$daemon_liveness_detail" \
+        --argjson roles "$roles_json" \
+        '{
+            binary_found: $binary_found,
+            reachable: $reachable,
+            manages_repo: $manages_repo,
+            in_flight: (if $in_flight == "" then null else ($in_flight | tonumber?) end),
+            gate_halted: (if $gate_halted == "" then null elif $gate_halted == "true" then true else false end),
+            install_state: (if $install_state == "" then null else $install_state end),
+            liveness_detail: (if $liveness_detail == "" then null else $liveness_detail end),
+            roles: $roles
+          }'
 }
 
 # ---- JSON output ---------------------------------------------------------
@@ -263,10 +466,15 @@ emit_json() {
     local work_queue_json
     work_queue_json=$(work_queue_json)
 
+    collect_daemon_state
+    local daemon_json
+    daemon_json=$(daemon_state_json_obj)
+
     jq -nc \
         --argjson running "$running_json" \
         --argjson terminals "$terminals" \
         --argjson work_queue "$work_queue_json" \
+        --argjson daemon "$daemon_json" \
         '
         ($running | map(.id)) as $running_ids
         | {
@@ -293,7 +501,8 @@ emit_json() {
             unmanaged: ($running | map(select(.id as $rid
                 | ($terminals | map(.id) | index($rid)) | not))
                 | map({session: .session, id: .id, pid: .pid, uptime_seconds: .uptime_seconds, status: "unmanaged"})),
-            work_queue: $work_queue
+            work_queue: $work_queue,
+            daemon: $daemon
           }'
 }
 
@@ -338,9 +547,18 @@ emit_human() {
     local terminal_count
     terminal_count=$(echo "$terminals" | jq 'length' 2>/dev/null || echo 0)
 
+    # Machine-daemon state (#4793) -- collected up front so the "no local
+    # agents" branch below can name its own scope explicitly instead of
+    # reading as a bare, fleet-wide "No agents running".
+    collect_daemon_state
+
     # Running agents section
     if [[ ${#running_ids[@]} -eq 0 ]]; then
-        echo -e "${YELLOW}No agents running.${NC}"
+        if [[ "$daemon_manages_repo" == "true" ]]; then
+            echo -e "${YELLOW}local agent pool: none${NC} — ${CYAN}machine daemon manages this repo${NC} (see Machine Daemon below)"
+        else
+            echo -e "${YELLOW}No agents running.${NC}"
+        fi
     else
         echo -e "${GREEN}Running agents (${#running_ids[@]}):${NC}"
         echo ""
@@ -401,19 +619,58 @@ emit_human() {
         fi
     fi
 
+    # Machine Daemon section (#4793): the local tmux pool above is only ONE
+    # of two ways work gets picked up in this repo -- a separate
+    # machine-level `loom-daemon` fleet can independently dispatch sweeps
+    # here with zero local tmux sessions. Omitted entirely when no
+    # loom-daemon binary is resolvable at all (nothing to report, same
+    # graceful-degradation shape as the Work Queue section below).
+    if [[ "$daemon_bin_found" == "true" ]]; then
+        echo ""
+        echo -e "${BOLD}Machine Daemon:${NC}"
+        if [[ "$daemon_reachable" == "true" ]]; then
+            echo -e "  Daemon:    ${GREEN}alive${NC} (reachable over IPC)"
+            if [[ "$daemon_manages_repo" == "true" ]]; then
+                echo -e "  Registry:  ${GREEN}this repo is managed${NC} (in-flight sweeps: ${CYAN}${daemon_in_flight:-0}${NC})"
+                if [[ "$daemon_gate_halted" == "true" ]]; then
+                    echo -e "  Gate:      ${RED}HALTED${NC} (main-health gate is blocking dispatch for this repo)"
+                else
+                    echo -e "  Gate:      ${GREEN}open${NC} (dispatch not gated)"
+                fi
+                if [[ -n "$daemon_roles" ]]; then
+                    echo -e "  Roles:     ${CYAN}${daemon_roles// /, }${NC} (recently ticked by the role runner)"
+                fi
+            else
+                echo -e "  Registry:  ${YELLOW}this repo is NOT a registered/managed workspace${NC}"
+            fi
+        else
+            local state_desc="${daemon_install_state:-not running}"
+            echo -e "  Daemon:    ${YELLOW}unreachable${NC} (${state_desc}${daemon_liveness_detail:+: $daemon_liveness_detail})"
+            if [[ "$daemon_manages_repo" == "true" ]]; then
+                echo -e "  Registry:  ${CYAN}this repo IS registered${NC} in ~/.loom/workspaces.json, but the daemon is not answering — dispatch is currently NOT happening"
+            fi
+        fi
+        echo -e "  ${GRAY}(full detail: ./.loom/bin/loom health   or  loom-daemon status)${NC}"
+    fi
+
     # Work-queue depth section (open issue/PR counts by label). Omitted
     # entirely — never an error — when gh is unavailable or the forge is not
     # GitHub, so the script still exits 0 on any forge.
     local wq
     wq=$(work_queue_json)
     if [[ -n "$wq" && "$wq" != "null" ]]; then
-        local wq_issue wq_rr wq_pr
+        local wq_issue wq_rr wq_pr wq_architect wq_hermit wq_curated wq_auditor
         wq_issue=$(echo "$wq" | jq -r '."loom:issue"' 2>/dev/null)
         wq_rr=$(echo "$wq" | jq -r '."loom:review-requested"' 2>/dev/null)
         wq_pr=$(echo "$wq" | jq -r '."loom:pr"' 2>/dev/null)
+        wq_architect=$(echo "$wq" | jq -r '."loom:architect"' 2>/dev/null)
+        wq_hermit=$(echo "$wq" | jq -r '."loom:hermit"' 2>/dev/null)
+        wq_curated=$(echo "$wq" | jq -r '."loom:curated"' 2>/dev/null)
+        wq_auditor=$(echo "$wq" | jq -r '."loom:auditor"' 2>/dev/null)
         echo ""
         echo -e "${BOLD}Work Queue:${NC}"
         echo -e "  ${CYAN}loom:issue${NC} ${wq_issue}   ${CYAN}loom:review-requested${NC} ${wq_rr}   ${CYAN}loom:pr${NC} ${wq_pr}"
+        echo -e "  ${BOLD}Pending proposals:${NC} ${CYAN}loom:architect${NC} ${wq_architect}   ${CYAN}loom:hermit${NC} ${wq_hermit}   ${CYAN}loom:curated${NC} ${wq_curated}   ${CYAN}loom:auditor${NC} ${wq_auditor}"
     fi
 
     echo ""

--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -44,6 +44,7 @@ test-loom-daemon-start.sh
 test-loom-daemon-stop.sh
 test-loom-daemon-watchdog.sh
 test-loom-dispatcher.sh
+test-loom-status.sh
 test-mcp-config.sh
 test-merge-pr-auto-merge-disabled-fallback.sh
 test-merge-pr-auto-reconcile.sh

--- a/defaults/scripts/tests/test-loom-status.sh
+++ b/defaults/scripts/tests/test-loom-status.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# test-loom-status.sh — Tests for loom-status.sh's machine-daemon integration
+# and expanded work-queue label counting (Issue #4793).
+#
+# Before #4793, `loom status` inspected ONLY the local tmux agent pool: a repo
+# actively managed by a separate machine-level `loom-daemon` fleet (zero local
+# tmux sessions, autonomous work-finder / role-runner dispatching sweeps)
+# still printed a bare "No agents running" — misleadingly implying nothing
+# would pick up open issues. This suite drives loom-status.sh entirely from a
+# scratch workspace + a stubbed `loom-daemon` binary (pinned via
+# LOOM_DAEMON_BIN) and a stubbed `gh` (pinned via PATH) — no real daemon, no
+# real forge, no real tmux agent pool.
+#
+# Style matches the other CLI test suites (test-blame-issue.sh,
+# test-loom-daemon-watchdog.sh) — plain bash, hand-rolled assertions. Bats is
+# NOT used in this repository.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATUS_SCRIPT="$(cd "$SCRIPT_DIR/../cli" && pwd)/loom-status.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "${GREEN}✓${NC} $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "${RED}✗${NC} $1"; }
+
+assert_eq() { # <expected> <actual> <msg>
+    if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 (expected '$1', got '$2')"; fi
+}
+
+assert_contains() { # <needle> <haystack> <msg>
+    if [[ "$2" == *"$1"* ]]; then pass "$3"; else fail "$3 (expected to find '$1')"; fi
+}
+
+assert_not_contains() { # <needle> <haystack> <msg>
+    if [[ "$2" != *"$1"* ]]; then pass "$3"; else fail "$3 (did NOT expect to find '$1')"; fi
+}
+
+if [[ ! -x "$STATUS_SCRIPT" ]]; then
+    echo -e "${RED}FATAL${NC}: $STATUS_SCRIPT not found or not executable" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq not found on PATH -- skipping (loom-status.sh hard-requires jq for these code paths)"
+    exit 0
+fi
+
+# ---- Scratch workspace -------------------------------------------------------
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/test-loom-status.XXXXXX")"
+# shellcheck disable=SC2329  # invoked indirectly via the EXIT trap below
+cleanup() { rm -rf "$WORKDIR" 2>/dev/null || true; }
+trap cleanup EXIT
+
+REPO="$WORKDIR/repo"
+mkdir -p "$REPO/.loom"
+cat > "$REPO/.loom/config.json" <<'EOF'
+{"terminals": []}
+EOF
+
+# Canonical (symlink-resolved) repo root -- loom-status.sh matches against
+# THIS form (mirrors its own REPO_ROOT_CANON computation via `pwd -P`), so
+# every stub below must embed this exact path, not the raw $REPO.
+REPO_CANON="$(cd "$REPO" && pwd -P)"
+
+FAKE_BIN="$WORKDIR/bin"
+mkdir -p "$FAKE_BIN"
+
+# ---- Fake `gh` stub -----------------------------------------------------------
+# Answers `gh issue list --label <label> --state open --json number --jq length`
+# and the `pr` equivalent with a fixed count per label, driven by the
+# GH_LABEL_COUNTS env var (space-separated "label=count" pairs).
+cat > "$FAKE_BIN/gh" <<'FAKEGH'
+#!/usr/bin/env bash
+kind="$1"; shift
+label=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --label) label="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+for pair in $GH_LABEL_COUNTS; do
+    key="${pair%%=*}"
+    val="${pair#*=}"
+    if [[ "$key" == "$label" ]]; then
+        echo "$val"
+        exit 0
+    fi
+done
+echo "0"
+FAKEGH
+chmod +x "$FAKE_BIN/gh"
+
+# ---- Fake `loom-daemon` stub factory -------------------------------------------
+# Writes a `loom-daemon` binary at $WORKDIR/daemon-<mode>/loom-daemon that
+# answers `status --json` per the named scenario. Echoes the stub's path.
+make_daemon_stub() { # <mode>
+    local mode="$1"
+    local dir="$WORKDIR/daemon-$mode"
+    mkdir -p "$dir"
+    case "$mode" in
+        managed)
+            cat > "$dir/loom-daemon" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "status" && "\$2" == "--json" ]]; then
+  cat <<JSON
+{"per_repo":[{"root":"$REPO_CANON","priority":100,"in_flight_count":3,"health_gate_halted":false}],
+ "role_tick_records":[{"root":"$REPO_CANON","role":"champion","at":"2026-07-31T00:00:00Z","ok":true}],
+ "work_finder_enabled":true}
+JSON
+  exit 0
+fi
+exit 1
+EOF
+            ;;
+        managed-halted)
+            cat > "$dir/loom-daemon" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "status" && "\$2" == "--json" ]]; then
+  cat <<JSON
+{"per_repo":[{"root":"$REPO_CANON","priority":100,"in_flight_count":0,"health_gate_halted":true}],
+ "role_tick_records":[],"work_finder_enabled":true}
+JSON
+  exit 0
+fi
+exit 1
+EOF
+            ;;
+        unmanaged)
+            cat > "$dir/loom-daemon" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "status" && "$2" == "--json" ]]; then
+  echo '{"per_repo":[{"root":"/some/other/repo","priority":100,"in_flight_count":0,"health_gate_halted":false}],"role_tick_records":[],"work_finder_enabled":true}'
+  exit 0
+fi
+exit 1
+EOF
+            ;;
+        unreachable)
+            cat > "$dir/loom-daemon" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "status" && "$2" == "--json" ]]; then
+  echo '{"error":"could not reach loom-daemon at /tmp/x.sock: connect failed","install_state":{"state":"ExpectedButDead","started_at":"2026-07-30T00:00:00Z","pid":null,"liveness_detail":"no live pid file"}}'
+  exit 74
+fi
+exit 1
+EOF
+            ;;
+        *) echo "unknown stub mode $mode" >&2; return 1 ;;
+    esac
+    chmod +x "$dir/loom-daemon"
+    echo "$dir/loom-daemon"
+}
+
+# Run loom-status.sh from $REPO with the given extra env assignments (as
+# "KEY=VAL" args) and GH_LABEL_COUNTS pinned to a benign default (all zero).
+# Sets globals OUT (combined stdout) and RC.
+run_status() {
+    OUT="$( (cd "$REPO" && env PATH="$FAKE_BIN:$PATH" GH_LABEL_COUNTS="${GH_LABEL_COUNTS:-}" "$@" bash "$STATUS_SCRIPT") 2>&1 )"
+    RC=$?
+}
+
+run_status_json() {
+    OUT="$( (cd "$REPO" && env PATH="$FAKE_BIN:$PATH" GH_LABEL_COUNTS="${GH_LABEL_COUNTS:-}" "$@" bash "$STATUS_SCRIPT" --json) 2>&1 )"
+    RC=$?
+}
+
+TMUX_MISSING=false
+command -v tmux >/dev/null 2>&1 || TMUX_MISSING=true
+
+# ===================================================================
+# 1. Script sanity: executable, --help.
+# ===================================================================
+echo "Test 1: script exists and is executable"
+if [[ -x "$STATUS_SCRIPT" ]]; then pass "loom-status.sh is executable"; else fail "loom-status.sh is not executable"; fi
+
+echo "Test 2: --help exits 0 and documents the Machine Daemon section"
+OUT="$( (cd "$REPO" && bash "$STATUS_SCRIPT" --help) 2>&1 )"; RC=$?
+assert_eq 0 "$RC" "--help exits 0"
+assert_contains "Machine Daemon" "$OUT" "--help documents the Machine Daemon section"
+assert_contains "loom:architect" "$OUT" "--help documents the expanded work-queue labels"
+
+if [[ "$TMUX_MISSING" == "true" ]]; then
+    echo "tmux not found on PATH -- skipping tests 3-9 (loom-status.sh's daemon/work-queue sections run only past the tmux-availability check)"
+else
+
+# ===================================================================
+# 3. No loom-daemon binary resolvable at all: falls back to the ORIGINAL
+#    "No agents running." message, and the JSON `daemon` block reports
+#    binary_found:false. No Machine Daemon section is printed.
+# ===================================================================
+echo "Test 3: no loom-daemon binary resolvable -- original message, section omitted"
+run_status LOOM_DAEMON_BIN=/nonexistent LOOM_WORKSPACES_PATH="$WORKDIR/no-such-registry.json"
+assert_eq 0 "$RC" "no-binary case exits 0"
+assert_contains "No agents running." "$OUT" "no-binary case prints the ORIGINAL unscoped message"
+assert_not_contains "Machine Daemon:" "$OUT" "no-binary case omits the Machine Daemon section"
+
+run_status_json LOOM_DAEMON_BIN=/nonexistent LOOM_WORKSPACES_PATH="$WORKDIR/no-such-registry.json"
+assert_eq 0 "$RC" "no-binary --json case exits 0"
+bf="$(echo "$OUT" | jq -r '.daemon.binary_found' 2>/dev/null)"
+assert_eq "false" "$bf" "no-binary --json: daemon.binary_found is false"
+
+# ===================================================================
+# 4. Daemon reachable and this repo IS a managed workspace: the empty local
+#    pool is named explicitly (AC2), and the Machine Daemon section reports
+#    liveness + in-flight count + open gate.
+# ===================================================================
+echo "Test 4: daemon reachable, repo IS managed -- scoped message + daemon detail"
+bin="$(make_daemon_stub managed)"
+run_status LOOM_DAEMON_BIN="$bin" LOOM_WORKSPACES_PATH="$WORKDIR/no-such-registry.json"
+assert_eq 0 "$RC" "managed case exits 0"
+assert_contains "local agent pool: none" "$OUT" "managed case scopes the empty-pool message"
+assert_contains "machine daemon manages this repo" "$OUT" "managed case names the daemon explicitly"
+assert_contains "Machine Daemon:" "$OUT" "managed case prints the Machine Daemon section"
+assert_contains "in-flight sweeps: 3" "$OUT" "managed case reports the in-flight sweep count"
+assert_contains "champion" "$OUT" "managed case lists the recently-ticked role"
+
+run_status_json LOOM_DAEMON_BIN="$bin" LOOM_WORKSPACES_PATH="$WORKDIR/no-such-registry.json"
+manages="$(echo "$OUT" | jq -r '.daemon.manages_repo' 2>/dev/null)"
+in_flight="$(echo "$OUT" | jq -r '.daemon.in_flight' 2>/dev/null)"
+assert_eq "true" "$manages" "managed --json: daemon.manages_repo is true"
+assert_eq "3" "$in_flight" "managed --json: daemon.in_flight is 3"
+
+# ===================================================================
+# 5. Daemon reachable, gate HALTED for this repo.
+# ===================================================================
+echo "Test 5: daemon reachable, this repo's dispatch gate is HALTED"
+bin="$(make_daemon_stub managed-halted)"
+run_status LOOM_DAEMON_BIN="$bin" LOOM_WORKSPACES_PATH="$WORKDIR/no-such-registry.json"
+assert_contains "HALTED" "$OUT" "halted-gate case reports HALTED"
+
+# ===================================================================
+# 6. Daemon reachable but this repo is NOT a registered workspace: the
+#    original unscoped message is kept (nothing IS managing this repo).
+# ===================================================================
+echo "Test 6: daemon reachable, repo NOT managed -- original message kept"
+bin="$(make_daemon_stub unmanaged)"
+run_status LOOM_DAEMON_BIN="$bin" LOOM_WORKSPACES_PATH="$WORKDIR/no-such-registry.json"
+assert_contains "No agents running." "$OUT" "unmanaged case keeps the original unscoped message"
+assert_contains "NOT a registered/managed workspace" "$OUT" "unmanaged case names the gap explicitly"
+
+# ===================================================================
+# 7. Daemon UNREACHABLE, but the on-disk registry lists this repo: the
+#    registry-file fallback (#4793 AC) still surfaces "registered but not
+#    answering" instead of silently reporting nothing.
+# ===================================================================
+echo "Test 7: daemon unreachable, registry file lists this repo"
+bin="$(make_daemon_stub unreachable)"
+registry="$WORKDIR/workspaces.json"
+jq -n --arg root "$REPO_CANON" '{version:1, workspaces:[{root:$root, priority:100}]}' > "$registry"
+run_status LOOM_DAEMON_BIN="$bin" LOOM_WORKSPACES_PATH="$registry"
+assert_contains "unreachable" "$OUT" "unreachable case reports the daemon as unreachable"
+assert_contains "ExpectedButDead" "$OUT" "unreachable case surfaces the install_state classification"
+assert_contains "this repo IS registered" "$OUT" "unreachable case still reports registry membership"
+
+run_status_json LOOM_DAEMON_BIN="$bin" LOOM_WORKSPACES_PATH="$registry"
+manages="$(echo "$OUT" | jq -r '.daemon.manages_repo' 2>/dev/null)"
+reachable="$(echo "$OUT" | jq -r '.daemon.reachable' 2>/dev/null)"
+install_state="$(echo "$OUT" | jq -r '.daemon.install_state' 2>/dev/null)"
+assert_eq "true" "$manages" "unreachable --json: daemon.manages_repo is true via the registry fallback"
+assert_eq "false" "$reachable" "unreachable --json: daemon.reachable is false"
+assert_eq "ExpectedButDead" "$install_state" "unreachable --json: daemon.install_state is ExpectedButDead"
+
+# ===================================================================
+# 8. Work-queue label counting: the four proposal labels
+#    (loom:architect/hermit/curated/auditor) are counted and rendered
+#    alongside the original three, never all-zero when the fixture gh
+#    stub reports non-zero counts.
+# ===================================================================
+echo "Test 8: work queue counts + renders the proposal labels"
+GH_LABEL_COUNTS="loom:issue=1 loom:review-requested=2 loom:pr=3 loom:architect=4 loom:hermit=5 loom:curated=6 loom:auditor=7"
+run_status LOOM_DAEMON_BIN=/nonexistent LOOM_WORKSPACES_PATH="$WORKDIR/no-such-registry.json"
+assert_contains "Pending proposals:" "$OUT" "work queue prints the Pending proposals line"
+assert_contains "loom:architect 4" "$OUT" "work queue reports the loom:architect count"
+assert_contains "loom:hermit 5" "$OUT" "work queue reports the loom:hermit count"
+assert_contains "loom:curated 6" "$OUT" "work queue reports the loom:curated count"
+assert_contains "loom:auditor 7" "$OUT" "work queue reports the loom:auditor count"
+unset GH_LABEL_COUNTS
+
+run_status_json LOOM_DAEMON_BIN=/nonexistent LOOM_WORKSPACES_PATH="$WORKDIR/no-such-registry.json" GH_LABEL_COUNTS="loom:architect=9"
+architect="$(echo "$OUT" | jq -r '.work_queue."loom:architect"' 2>/dev/null)"
+assert_eq "9" "$architect" "work_queue --json includes loom:architect"
+
+# ===================================================================
+# 9. LOOM_DAEMON_BIN pointed at a non-executable path: treated identically
+#    to "no binary resolvable" (never errors, never crashes the script).
+# ===================================================================
+echo "Test 9: LOOM_DAEMON_BIN set but not executable -- degrades gracefully"
+run_status LOOM_DAEMON_BIN="$WORKDIR/does-not-exist" LOOM_WORKSPACES_PATH="$WORKDIR/no-such-registry.json"
+assert_eq 0 "$RC" "non-executable LOOM_DAEMON_BIN still exits 0"
+assert_contains "No agents running." "$OUT" "non-executable LOOM_DAEMON_BIN falls back to the original message"
+
+fi # TMUX_MISSING
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== $TESTS_PASSED/$TESTS_RUN tests passed ==="
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

`loom status` (the repo-local `./.loom/bin/loom status` CLI, implemented in
`defaults/scripts/cli/loom-status.sh`) only ever inspected the LOCAL tmux agent
pool. A repo actively managed by a separate machine-level `loom-daemon` fleet
(autonomous work finder / role runner dispatching sweeps with zero local tmux
sessions running) misleadingly read as a bare `No agents running.` with an
all-zero-looking Work Queue — implying nothing would pick up open issues, even
while the daemon was actively dispatching sweeps for the repo.

## Changes

- **New "Machine Daemon" section** (human + `--json`): reuses `loom-daemon
  status --json` — the same IPC surface `./.loom/bin/loom health` already
  delegates to — to report daemon liveness, whether this repo is a
  registered/managed workspace (via the daemon's own `per_repo` array),
  its per-repo dispatch-gate state (`health_gate_halted`), its in-flight
  sweep count, and recently-ticked role-runner roles for this repo
  (`role_tick_records`). No daemon-liveness/registry logic is re-derived in
  bash — it's read straight from the daemon's own authoritative report.
- **Registry-file fallback**: when the daemon itself is unreachable, falls
  back to a direct read of `~/.loom/workspaces.json` (honoring
  `LOOM_WORKSPACES_PATH`) so "is this repo registered?" still answers even
  while the daemon is down.
- **Scoped empty-pool message**: when the local agent pool is empty AND the
  daemon manages this repo, prints `local agent pool: none — machine daemon
  manages this repo (see Machine Daemon below)` instead of the previous bare
  `No agents running.` (which is still printed verbatim when nothing —
  neither the local pool nor the daemon — manages this repo).
- **Expanded Work Queue labels**: `count_label`/`work_queue_json` now also
  count the pending-proposal labels `loom:architect` / `loom:hermit` /
  `loom:curated` / `loom:auditor`, rendered as a new "Pending proposals" line,
  so a non-empty proposal pipeline never reads as all-zero.
- Gracefully degrades to the pre-existing behavior (no Machine Daemon section
  at all) when no `loom-daemon` binary is resolvable (`LOOM_DAEMON_BIN`
  override → `PATH` → in-repo cargo build outputs, mirroring
  `loom-daemon-watchdog.sh`'s `locate_daemon_bin()` / `./.loom/bin/loom
  health`'s resolution order).

## Live verification

Running the updated script from this repo's own root (which the machine
daemon manages) now shows the exact fix in action:

```
local agent pool: none — machine daemon manages this repo (see Machine Daemon below)

Machine Daemon:
  Daemon:    alive (reachable over IPC)
  Registry:  this repo is managed (in-flight sweeps: 4)
  Gate:      open (dispatch not gated)
  (full detail: ./.loom/bin/loom health   or  loom-daemon status)

Work Queue:
  loom:issue 7   loom:review-requested 0   loom:pr 2
  Pending proposals: loom:architect 3   loom:hermit 0   loom:curated 21   loom:auditor 0
```

versus the previous (pre-fix) output from the same workspace:

```
No agents running.

Work Queue:
  loom:issue 7   loom:review-requested 0   loom:pr 2
```

## Test plan

- [x] New `defaults/scripts/tests/test-loom-status.sh` (34 assertions, wired
  into `ci-wired.txt`), covering: no-daemon-binary fallback, daemon
  reachable + repo managed (scoped message, in-flight count, gate state,
  roles), daemon reachable + repo NOT managed, daemon unreachable +
  registry-file fallback, expanded work-queue label counting, and a
  non-executable `LOOM_DAEMON_BIN` degrading gracefully — both human and
  `--json` output paths.
- [x] `shellcheck -x` clean on both the modified script and the new test.
- [x] `defaults/scripts/tests/check-ci-suite-manifest.sh` passes (new suite
  wired, not orphaned).
- [x] Manually verified against the live daemon managing this repo (see
  above) and against a repo the daemon does NOT manage.

Closes #4793