### PR TITLE
fix(judge/doctor): join bounded-fallback streak count with a claim-age floor

### DIFF
--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -466,7 +466,7 @@ Then decide:
 
 | Condition | Verdict | Action |
 |-----------|---------|--------|
-| `STANDDOWN_COUNT >= LOOM_MAX_STANDDOWN_STREAK` (default **3**) | **Stale — bounded fallback** (see below) | Force-reclaim regardless of claim age or `COMMENTS_AFTER`. Breaks the livelock even if the marker/exclusion logic above is somehow bypassed. |
+| `STANDDOWN_COUNT >= LOOM_MAX_STANDDOWN_STREAK` (default **3**) AND claim age ≥ `LOOM_STALE_TREATING_MINUTES` (default **60**) | **Stale — bounded fallback** (see below) | Force-reclaim regardless of `COMMENTS_AFTER`. Breaks the livelock even if the marker/exclusion logic above is somehow bypassed — but the streak alone is never enough (#4790): it also requires the claim to have aged past the normal staleness threshold, so a high *peer arrival rate* (several concurrent Doctors each standing down within minutes) cannot force-reclaim a claim that is still genuinely fresh. |
 | Claim age < `LOOM_STALE_TREATING_MINUTES` (default **60**), OR `COMMENTS_AFTER > 0` | **Fresh** — a Doctor is actively fixing this PR | **Do not stomp the claim.** Post a marked stand-down comment (see below), then skip this PR and move to the next candidate in the queue. |
 | Claim age ≥ `LOOM_STALE_TREATING_MINUTES` AND `COMMENTS_AFTER == 0` | **Stale** — the claiming Doctor's process almost certainly died mid-fix | Reclaim (see below), then proceed with the normal fix from step 3. |
 | Timeline API call fails or returns empty (`CLAIMED_AT` unset) | **Unknown — fail safe** | Treat as **fresh**. Never stomp a claim on API failure or missing data. |
@@ -490,18 +490,31 @@ gh pr comment $N --body "Doctor pass: PR still carries a fresh \`loom:treating\`
 <!-- loom:standdown claim=$CLAIMED_AT -->"
 ```
 
-**Bounded fallback (AC3, #4618)**: `STANDDOWN_COUNT` is a hard cap
-independent of the marker-exclusion logic working correctly — it counts how
-many stand-down comments have accumulated against *this exact*
-`$CLAIMED_AT` (the marker embeds it, so a genuine reclaim — which changes
-`CLAIMED_AT` — resets the count to zero automatically). Once
-`LOOM_MAX_STANDDOWN_STREAK` marked comments have piled up against the same
-claim with no reclaim, force-reclaim regardless of age or `COMMENTS_AFTER`,
-using this reclaim comment:
+**Bounded fallback (AC3, #4618; age-floor join added by #4798)**:
+`STANDDOWN_COUNT` is a hard cap independent of the marker-exclusion logic
+working correctly — it counts how many stand-down comments have accumulated
+against *this exact* `$CLAIMED_AT` (the marker embeds it, so a genuine
+reclaim — which changes `CLAIMED_AT` — resets the count to zero
+automatically). But the streak count by itself measures **peer arrival
+rate** (how many other Doctors happened to revisit this exact PR), not claim
+liveness — a claim only minutes old can accumulate `LOOM_MAX_STANDDOWN_STREAK`
+stand-downs from that many concurrent Doctors without ever coming close to
+stale in the age sense (the `loom:reviewing` analog of this played out on
+PR #4790: a claim 17m36s old, well under the 30-minute default
+`LOOM_STALE_REVIEWING_MINUTES`, was force-reclaimed after 3 Judges each
+stood down within that same ~17m36s window — the identical defect shape
+applies here to `loom:treating`/`LOOM_STALE_TREATING_MINUTES`). So the
+fallback fires only once **both** hold: `LOOM_MAX_STANDDOWN_STREAK` marked
+comments have piled up against the same claim with no reclaim, **and** the
+claim's own age is ≥ `LOOM_STALE_TREATING_MINUTES` — reusing the same age
+floor the ordinary staleness row below already applies. This still
+force-reclaims regardless of `COMMENTS_AFTER` (the whole reason this
+fallback exists independent of the marker-exclusion logic), it just no
+longer overrides the age check too. Use this reclaim comment:
 
 ```bash
 gh pr edit $N --remove-label "loom:treating"
-gh pr comment $N --body "Reclaiming loom:treating claim: $STANDDOWN_COUNT consecutive stand-down comments have accumulated against claim $CLAIMED_AT with no actual fix progress (bounded fallback, LOOM_MAX_STANDDOWN_STREAK=${LOOM_MAX_STANDDOWN_STREAK:-3}) — breaking the livelock."
+gh pr comment $N --body "Reclaiming loom:treating claim: $STANDDOWN_COUNT consecutive stand-down comments have accumulated against claim $CLAIMED_AT (age ≥ ${LOOM_STALE_TREATING_MINUTES:-60}m) with no actual fix progress (bounded fallback, LOOM_MAX_STANDDOWN_STREAK=${LOOM_MAX_STANDDOWN_STREAK:-3}) — breaking the livelock."
 gh pr edit $N --add-label "loom:treating"
 CLAIM_HEAD_SHA=$(gh pr view $N --json headRefOid --jq '.headRefOid')
 # Continue to step 3 (Check PR details) and fix normally

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -433,7 +433,7 @@ Then decide:
 
 | Condition | Verdict | Action |
 |-----------|---------|--------|
-| `STANDDOWN_COUNT >= LOOM_MAX_STANDDOWN_STREAK` (default **3**) | **Stale — bounded fallback** (see below) | Force-reclaim regardless of claim age or `COMMENTS_AFTER`. Breaks the livelock even if the marker/exclusion logic above is somehow bypassed. |
+| `STANDDOWN_COUNT >= LOOM_MAX_STANDDOWN_STREAK` (default **3**) AND claim age ≥ `LOOM_STALE_REVIEWING_MINUTES` (default **30**) | **Stale — bounded fallback** (see below) | Force-reclaim regardless of `COMMENTS_AFTER`. Breaks the livelock even if the marker/exclusion logic above is somehow bypassed — but the streak alone is never enough (#4790): it also requires the claim to have aged past the normal staleness threshold, so a high *peer arrival rate* (several concurrent Judges each standing down within minutes) cannot force-reclaim a claim that is still genuinely fresh. |
 | Claim age < `LOOM_STALE_REVIEWING_MINUTES` (default **30**), OR `COMMENTS_AFTER > 0` | **Fresh** — a Judge is actively working this PR | **Do not stomp the claim.** Post a marked stand-down comment (see below), then skip this PR and continue the batch to the next candidate PR. |
 | Claim age ≥ `LOOM_STALE_REVIEWING_MINUTES` AND `COMMENTS_AFTER == 0` | **Stale** — the claiming Judge's process almost certainly died mid-review | Reclaim (see below), then proceed with the normal review from step 3. |
 | Timeline API call fails or returns empty (`CLAIMED_AT` unset) | **Unknown — fail safe** | Treat as **fresh**. Never stomp a claim on API failure or missing data. |
@@ -456,18 +456,29 @@ gh pr comment $N --body "Judge pass: PR still carries a fresh \`loom:reviewing\`
 <!-- loom:standdown claim=$CLAIMED_AT -->"
 ```
 
-**Bounded fallback (AC3, #4618)**: `STANDDOWN_COUNT` is a hard cap
-independent of the marker-exclusion logic working correctly — it counts how
-many stand-down comments have accumulated against *this exact*
-`$CLAIMED_AT` (the marker embeds it, so a genuine reclaim — which changes
-`CLAIMED_AT` — resets the count to zero automatically). Once
-`LOOM_MAX_STANDDOWN_STREAK` marked comments have piled up against the same
-claim with no reclaim, force-reclaim regardless of age or `COMMENTS_AFTER`,
-using this reclaim comment:
+**Bounded fallback (AC3, #4618; age-floor join added by #4798)**:
+`STANDDOWN_COUNT` is a hard cap independent of the marker-exclusion logic
+working correctly — it counts how many stand-down comments have accumulated
+against *this exact* `$CLAIMED_AT` (the marker embeds it, so a genuine
+reclaim — which changes `CLAIMED_AT` — resets the count to zero
+automatically). But the streak count by itself measures **peer arrival
+rate** (how many other Judges happened to revisit this exact PR), not claim
+liveness — a claim only minutes old can accumulate `LOOM_MAX_STANDDOWN_STREAK`
+stand-downs from that many concurrent Judges without ever coming close to
+stale in the age sense (#4790: a claim 17m36s old, well under the 30-minute
+default `LOOM_STALE_REVIEWING_MINUTES`, was force-reclaimed after 3 Judges
+each stood down within that same ~17m36s window). So the fallback fires only
+once **both** hold: `LOOM_MAX_STANDDOWN_STREAK` marked comments have piled up
+against the same claim with no reclaim, **and** the claim's own age is ≥
+`LOOM_STALE_REVIEWING_MINUTES` — reusing the same age floor the ordinary
+staleness row below already applies. This still force-reclaims regardless of
+`COMMENTS_AFTER` (the whole reason this fallback exists independent of the
+marker-exclusion logic), it just no longer overrides the age check too. Use
+this reclaim comment:
 
 ```bash
 gh pr edit $N --remove-label "loom:reviewing"
-gh pr comment $N --body "Reclaiming loom:reviewing claim: $STANDDOWN_COUNT consecutive stand-down comments have accumulated against claim $CLAIMED_AT with no actual review progress (bounded fallback, LOOM_MAX_STANDDOWN_STREAK=${LOOM_MAX_STANDDOWN_STREAK:-3}) — breaking the livelock."
+gh pr comment $N --body "Reclaiming loom:reviewing claim: $STANDDOWN_COUNT consecutive stand-down comments have accumulated against claim $CLAIMED_AT (age ≥ ${LOOM_STALE_REVIEWING_MINUTES:-30}m) with no actual review progress (bounded fallback, LOOM_MAX_STANDDOWN_STREAK=${LOOM_MAX_STANDDOWN_STREAK:-3}) — breaking the livelock."
 gh pr edit $N --add-label "loom:reviewing"
 # Continue to step 3 (Check merge state) and evaluate normally
 ```

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1496,19 +1496,30 @@ carries a **pre-push head-SHA recheck** (capture `headRefOid` at claim time,
 re-compare before the final push) — the one race this pass structurally cannot
 cover, since it never hooks into an in-flight Doctor's push.
 
-**Agent-side stand-down marker convention + bounded fallback (#4618).** The
-same self-perpetuating-comment defect fixed on the daemon side above also
-existed in judge.md's and doctor.md's own `COMMENTS_AFTER` heuristic — the
-fast path shared the daemon backstop's blind spot exactly, since both read
-"any comment after the claim" as fresh. Both role prompts now (1) tag every
-stand-down comment they post with `<!-- loom:standdown claim=$CLAIMED_AT -->`
-and exclude marker-tagged comments from `COMMENTS_AFTER`, and (2) count
-marker-tagged comments in a separate `STANDDOWN_COUNT`, force-reclaiming once
-`STANDDOWN_COUNT >= LOOM_MAX_STANDDOWN_STREAK` (default **3**) regardless of
-claim age — a bounded fallback that holds even if the marker-exclusion logic
-above is somehow bypassed. `LOOM_MAX_STANDDOWN_STREAK` is shared by both role
-prompts, mirroring how `LOOM_STALE_REVIEWING_MINUTES`/`LOOM_STALE_TREATING_MINUTES`
-are already shared.
+**Agent-side stand-down marker convention + bounded fallback (#4618, age-floor
+join added by #4798).** The same self-perpetuating-comment defect fixed on
+the daemon side above also existed in judge.md's and doctor.md's own
+`COMMENTS_AFTER` heuristic — the fast path shared the daemon backstop's blind
+spot exactly, since both read "any comment after the claim" as fresh. Both
+role prompts now (1) tag every stand-down comment they post with `<!--
+loom:standdown claim=$CLAIMED_AT -->` and exclude marker-tagged comments from
+`COMMENTS_AFTER`, and (2) count marker-tagged comments in a separate
+`STANDDOWN_COUNT`, force-reclaiming once `STANDDOWN_COUNT >=
+LOOM_MAX_STANDDOWN_STREAK` (default **3**) **AND** the claim's own age is ≥
+`LOOM_STALE_REVIEWING_MINUTES`/`LOOM_STALE_TREATING_MINUTES` — regardless of
+`COMMENTS_AFTER` — a bounded fallback that holds even if the marker-exclusion
+logic above is somehow bypassed. The age floor (#4798) was added after PR
+#4790 showed the streak count alone conflates **peer arrival rate** (several
+concurrent Judges/Doctors each standing down within minutes of each other)
+with **claim liveness**: a claim only 17m36s old — well under the 30-minute
+default — was force-reclaimed purely because 3 Judges happened to revisit it
+in quick succession, not because the claim itself had gone stale. Joining the
+streak condition with the same age floor the ordinary staleness row already
+uses vetoes that false positive while still catching the original #4614
+livelock (a claim genuinely idle for 30+ minutes). `LOOM_MAX_STANDDOWN_STREAK`
+is shared by both role prompts, mirroring how
+`LOOM_STALE_REVIEWING_MINUTES`/`LOOM_STALE_TREATING_MINUTES` are already
+shared.
 
 ## Stacked-PR dependency — #3729 (v1), #3747 (v2 item 1)
 


### PR DESCRIPTION
## Summary

`judge.md`'s and `doctor.md`'s bounded-fallback decision-table row force-reclaimed
`loom:reviewing`/`loom:treating` claims the moment `STANDDOWN_COUNT >=
LOOM_MAX_STANDDOWN_STREAK` (default 3) — **regardless of claim age or
`COMMENTS_AFTER`**. That condition measures **peer arrival rate** (how many
other Judges/Doctors happened to revisit the exact same claim), not **claim
liveness**. On PR #4790, three concurrent Judges each stood down within
~17m36s of a claim that was itself only 17m36s old (well under the 30-minute
`LOOM_STALE_REVIEWING_MINUTES` default) — the streak hit 3 and force-reclaimed
a genuinely healthy, actively-progressing claim, duplicating Judge #4790's
own review. This is the same shared mechanism in `doctor.md` (`loom:treating`
/ `LOOM_STALE_TREATING_MINUTES`), per `daemon-reference.md`'s documented
lockstep convention (past fix #4618 touched both files together).

## Changes

- **`defaults/.claude/commands/loom/judge.md`**: the bounded-fallback
  decision-table row now requires `STANDDOWN_COUNT >= LOOM_MAX_STANDDOWN_STREAK`
  **AND** claim age ≥ `LOOM_STALE_REVIEWING_MINUTES` (reusing the same age
  floor the ordinary staleness row already applies) before force-reclaiming.
  Updated the "Bounded fallback (AC3, #4618)" prose paragraph and the reclaim
  comment text to reflect the joined condition.
- **`defaults/.claude/commands/loom/doctor.md`**: identical change for
  `loom:treating` / `LOOM_STALE_TREATING_MINUTES`, kept in lockstep with
  `judge.md` (same substitutions, same structure).
- **`defaults/docs/daemon-reference.md`**: updated the shared-mechanism summary
  ("Agent-side stand-down marker convention + bounded fallback") to describe
  the age-floor join and reference both #4618 (original) and #4798 (this fix).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Bounded-fallback row no longer fires unconditionally on streak count alone | Done | Row now reads `STANDDOWN_COUNT >= LOOM_MAX_STANDDOWN_STREAK AND claim age >= LOOM_STALE_REVIEWING_MINUTES` (judge.md) / `LOOM_STALE_TREATING_MINUTES` (doctor.md) |
| `doctor.md` fixed in lockstep with `judge.md` | Done | Same table-row wording, same prose restructuring, same reclaim-comment update, with only the documented `loom:reviewing`/`loom:treating` + env-var substitutions differing (verified with a normalized `diff` of both sections — see Test Plan) |
| `daemon-reference.md`'s shared-mechanism summary updated | Done | "Agent-side stand-down marker convention + bounded fallback" section now describes the joined condition and the #4790 incident that motivated it |
| Fix does not regress the original #4614 livelock the streak cap was built to catch | Done | Hand-walked below — #4614's claim was 30+ minutes old, so the age floor is satisfied and the fallback still fires |
| Fix resolves the #4790 false positive | Done | Hand-walked below — #4790's claim was 17m36s old, under the 30-minute floor, so the fallback no longer fires; the claim instead correctly lands on "Fresh — do not stomp" |

## Test Plan (manual — no automated harness exists for this prose logic)

No mechanical/compiled helper implements this logic (verified: nothing under
`.loom/scripts/` or `defaults/scripts/tests/` references
`LOOM_MAX_STANDDOWN_STREAK` or `STANDDOWN_COUNT` — it's prose interpreted by
the reviewing agent). Verification is by hand-walking both incident timelines
through the revised decision table:

### Walkthrough 1 — PR #4790 (the bug this PR fixes)

- Claim (`loom:reviewing`) applied at `19:26:48Z`.
- Three stand-down comments accumulated by `19:44:18Z` — a span of **17m36s**.
- `STANDDOWN_COUNT = 3 >= LOOM_MAX_STANDDOWN_STREAK (3)` → true.
- **Before this fix**: row 1 (bounded fallback) fired unconditionally on the
  streak alone → force-reclaim. **This was the bug** — the claim was still
  well within its 30-minute freshness window.
- **After this fix**: row 1 now also requires `claim age >=
  LOOM_STALE_REVIEWING_MINUTES` (30m default). Claim age = 17m36s < 30m →
  row 1's condition is now **false** → falls through to row 2 ("Claim age <
  LOOM_STALE_REVIEWING_MINUTES, OR COMMENTS_AFTER > 0") → claim age 17m36s <
  30m is true → **Fresh — do not stomp.** Result: the claim survives, matching
  the correct outcome (the claiming Judge was genuinely still working).

### Walkthrough 2 — the original #4614 livelock (must not regress)

- Claim applied, then 3 consecutive stand-down comments accumulated over
  **30+ minutes** against a genuinely idle claim (the incident #4618's
  stand-down-marker + bounded-fallback mechanism was built to fix).
- `STANDDOWN_COUNT = 3 >= LOOM_MAX_STANDDOWN_STREAK (3)` → true.
- Claim age at the time of the 3rd stand-down was **>= 30 minutes** (per the
  incident's own timeline) → `claim age >= LOOM_STALE_REVIEWING_MINUTES` → true.
- **After this fix**: row 1's joined condition (`STANDDOWN_COUNT >= cap AND
  claim age >= floor`) is **true** → **Stale — bounded fallback still fires**
  → force-reclaim, regardless of `COMMENTS_AFTER`. Result: the original #4614
  livelock is still broken by this fallback — no regression.

### Walkthrough 3 — judge.md / doctor.md lockstep

Diffed the "Stale claim check" sections of both files after normalizing the
documented substitutions (`loom:reviewing`→`loom:treating`,
`LOOM_STALE_REVIEWING_MINUTES`→`LOOM_STALE_TREATING_MINUTES`,
`review`→`fix`, `Judge`→`Doctor`, `30`→`60` default). The joined-condition
table row, the "Bounded fallback" prose paragraph, and the reclaim-comment
text are structurally identical between the two files apart from those
substitutions — matching the existing lockstep convention. (The pre-existing,
unrelated asymmetries — `doctor.md`'s intro paragraph wording and its extra
`CLAIM_HEAD_SHA` pre-push-recheck lines — predate this change and are out of
scope here.)

## Why the age floor reuses `LOOM_STALE_REVIEWING_MINUTES`/`LOOM_STALE_TREATING_MINUTES` rather than a new env var

Reusing the existing staleness threshold (rather than introducing a third env
var, e.g. a fraction of it) is the minimum fix that provably satisfies both
walkthroughs above: #4790's claim age (17m36s) is comfortably under the
30-minute default, and #4614's claim age (30+ minutes) is at or above it — so
the single existing threshold cleanly separates the two cases without adding
new configuration surface. A fractional floor (e.g. half of the staleness
threshold, ~15m) would NOT have protected #4790 (17m36s > 15m), so it was
rejected in favor of reusing the full threshold.

Closes #4798