### PR TITLE
fix(mcp): heartbeat/list_terminals reflect the live daemon, not the retired desktop-app log

### DIFF
--- a/loom-daemon/src/terminal.rs
+++ b/loom-daemon/src/terminal.rs
@@ -1684,7 +1684,69 @@ impl TerminalManager {
                 log::warn!("Failed to restore terminals from tmux: {e}");
             }
         }
+
+        // Issue #4794: garbage-collect registry entries whose backing tmux
+        // session no longer exists. Without this, a terminal that was
+        // registered by a since-crashed daemon, or whose tmux session was
+        // reaped externally (e.g. the whole `loom` tmux socket losing its
+        // server), sticks around in `self.terminals` forever and is reported
+        // to every `list_terminals` caller (including the MCP `list_terminals`
+        // tool) as an "active" terminal indefinitely.
+        if !no_restore {
+            self.prune_dead_terminals();
+        }
+
         self.terminals.values().cloned().collect()
+    }
+
+    /// Remove registry entries whose `tmux_session` no longer has a live tmux
+    /// session backing it (Issue #4794).
+    ///
+    /// A single `tmux -L loom list-sessions` call is used to build the live-session
+    /// set rather than one `has-session` call per terminal, so this stays cheap
+    /// even with many registered terminals. Any failure to query tmux at all
+    /// (including "no server running", the exact symptom reported in #4794)
+    /// is treated as "zero live sessions" — conservatively correct, since a
+    /// terminal cannot be alive without a session to back it.
+    ///
+    /// Skipped when the registry is empty (nothing to prune) so this never
+    /// pays for a `tmux` invocation on the common empty-registry path.
+    fn prune_dead_terminals(&mut self) {
+        if self.terminals.is_empty() {
+            return;
+        }
+
+        let output = Command::new("tmux")
+            .args(["-L", "loom"])
+            .args(["list-sessions", "-F", "#{session_name}"])
+            .output();
+
+        let live_sessions: std::collections::HashSet<String> = match output {
+            Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
+                .lines()
+                .map(str::to_string)
+                .collect(),
+            // Any other outcome — nonzero exit (e.g. "no server running", the
+            // #4794 symptom), or the `tmux` command failing to spawn at all —
+            // means there are no live tmux sessions right now.
+            _ => std::collections::HashSet::new(),
+        };
+
+        let dead_ids: Vec<TerminalId> = self
+            .terminals
+            .iter()
+            .filter(|(_, info)| !live_sessions.contains(&info.tmux_session))
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        for id in dead_ids {
+            if let Some(info) = self.terminals.remove(&id) {
+                log::info!(
+                    "Pruning dead terminal registry entry '{id}': backing tmux session '{}' no longer exists",
+                    info.tmux_session
+                );
+            }
+        }
     }
 
     pub fn set_worktree_path(&mut self, id: &TerminalId, worktree_path: &str) -> Result<()> {
@@ -2481,6 +2543,74 @@ mod tests {
     fn test_terminal_manager_new_is_empty() {
         let tm = TerminalManager::new();
         assert!(tm.terminals.is_empty());
+    }
+
+    // ===== prune_dead_terminals tests (Issue #4794) =====
+    //
+    // A registry entry whose `tmux_session` has no live backing session (the
+    // session died, was reaped externally, or the whole `loom` tmux socket
+    // has no server at all) must not be reported forever by `list_terminals()`
+    // as "active" — see #4794's reported symptom (`ID: test / Restored: ...`
+    // surviving as the sole "active" terminal on a host with no `loom` tmux
+    // server running at all).
+
+    fn fake_terminal(id: &str, tmux_session: &str) -> TerminalInfo {
+        TerminalInfo {
+            id: id.to_string(),
+            name: format!("fake-{id}"),
+            tmux_session: tmux_session.to_string(),
+            working_dir: None,
+            created_at: chrono::Utc::now().timestamp(),
+            role: None,
+            worktree_path: None,
+            agent_pid: None,
+            agent_status: crate::types::AgentStatus::default(),
+            last_interval_run: None,
+        }
+    }
+
+    #[test]
+    fn test_list_terminals_prunes_entries_with_no_live_tmux_session() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("LOOM_NO_RESTORE");
+
+        let mut tm = TerminalManager::new();
+        // A session name that cannot possibly be a real, live tmux session.
+        let ghost_session = format!("loom-ghost-{}", uuid::Uuid::new_v4());
+        tm.terminals
+            .insert("ghost".to_string(), fake_terminal("ghost", &ghost_session));
+
+        let terminals = tm.list_terminals();
+
+        assert!(
+            terminals.iter().all(|t| t.id != "ghost"),
+            "a terminal whose tmux session does not exist must be pruned from list_terminals()"
+        );
+        assert!(
+            tm.terminals.get("ghost").is_none(),
+            "the dead entry must also be removed from the underlying registry, not just filtered on read"
+        );
+    }
+
+    #[test]
+    fn test_list_terminals_skips_pruning_under_loom_no_restore() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("LOOM_NO_RESTORE", "1");
+
+        let mut tm = TerminalManager::new();
+        let ghost_session = format!("loom-ghost-{}", uuid::Uuid::new_v4());
+        tm.terminals
+            .insert("ghost".to_string(), fake_terminal("ghost", &ghost_session));
+
+        let terminals = tm.list_terminals();
+
+        std::env::remove_var("LOOM_NO_RESTORE");
+
+        assert!(
+            terminals.iter().any(|t| t.id == "ghost"),
+            "LOOM_NO_RESTORE=1 must also suppress pruning, matching its existing \
+             'skip all tmux server interaction' contract used by tests"
+        );
     }
 
     // ===== worktree ownership-model guard tests (#3540) =====

--- a/mcp-loom/src/tools/terminals.test.ts
+++ b/mcp-loom/src/tools/terminals.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Tests for `buildTerminalListFallbackNote` (Issue #4794).
+ *
+ * The daemon-side registry (`TerminalManager::prune_dead_terminals`,
+ * `loom-daemon/src/terminal.rs`) garbage-collects terminals whose backing
+ * tmux session no longer exists on every `ListTerminals` request, so the
+ * `"daemon"`-sourced path is always tmux-verified. The `.loom/state.json`
+ * fallback path (used only when the daemon itself is unreachable) has no
+ * such verification, so `list_terminals` must flag it rather than present a
+ * possibly-stale snapshot as confirmed-live.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildTerminalListFallbackNote } from "./terminals.js";
+
+describe("buildTerminalListFallbackNote", () => {
+  it("is empty for the tmux-verified daemon source", () => {
+    expect(buildTerminalListFallbackNote("daemon")).toBe("");
+  });
+
+  it("flags the state-file fallback as unverified against live tmux sessions", () => {
+    const note = buildTerminalListFallbackNote("state-fallback");
+    expect(note).toContain("UNVERIFIED");
+    expect(note).toContain("loom-daemon did not respond");
+    expect(note.toLowerCase()).toContain("tmux");
+  });
+});

--- a/mcp-loom/src/tools/terminals.ts
+++ b/mcp-loom/src/tools/terminals.ts
@@ -61,35 +61,82 @@ function extractDaemonErrorMessage(response: {
 }
 
 /**
- * List all active terminals from the daemon
+ * Where a `listTerminalsWithSource()` result came from (Issue #4794).
+ *
+ * - `"daemon"`: the live `loom-daemon`'s registry, which the daemon itself
+ *   garbage-collects against actual tmux session liveness on every
+ *   `ListTerminals` request (see `TerminalManager::prune_dead_terminals` in
+ *   `loom-daemon/src/terminal.rs`) — entries here are verified live.
+ * - `"state-fallback"`: the daemon was unreachable, so this is the
+ *   last-written `.loom/state.json` snapshot with NO tmux verification —
+ *   it can include terminals whose sessions have since died.
  */
-async function listTerminals(): Promise<Terminal[]> {
+export type TerminalListSource = "daemon" | "state-fallback";
+
+export interface TerminalListResult {
+  terminals: Terminal[];
+  source: TerminalListSource;
+}
+
+/**
+ * List all active terminals from the daemon, reporting which source served
+ * the result (Issue #4794) so callers can flag an unverified fallback list.
+ */
+async function listTerminalsWithSource(): Promise<TerminalListResult> {
   try {
     const response = (await sendDaemonRequest({
       type: "ListTerminals",
     })) as { type: string; payload?: { terminals: Terminal[] } };
 
     if (response.type === "TerminalList" && response.payload?.terminals) {
-      return response.payload.terminals;
+      return { terminals: response.payload.terminals, source: "daemon" };
     }
 
-    return [];
+    return { terminals: [], source: "daemon" };
   } catch (_error) {
-    // If daemon is not running, fall back to state file
+    // If daemon is not running, fall back to state file. Unlike the daemon
+    // path, this is NOT cross-checked against live tmux sessions — the
+    // caller must treat it as unverified (Issue #4794).
     const state = await readStateFile();
-    if (!state) return [];
+    if (!state) return { terminals: [], source: "state-fallback" };
 
     // Map state file format to Terminal format
-    return state.terminals.map((t) => ({
-      id: t.id,
-      name: t.id, // State file doesn't have name
-      role: undefined,
-      working_dir: t.worktreePath,
-      tmux_session: `loom-${t.id}`,
-      created_at: 0,
-      isPrimary: t.isPrimary,
-    }));
+    return {
+      terminals: state.terminals.map((t) => ({
+        id: t.id,
+        name: t.id, // State file doesn't have name
+        role: undefined,
+        working_dir: t.worktreePath,
+        tmux_session: `loom-${t.id}`,
+        created_at: 0,
+        isPrimary: t.isPrimary,
+      })),
+      source: "state-fallback",
+    };
   }
+}
+
+/**
+ * List all active terminals from the daemon
+ */
+async function listTerminals(): Promise<Terminal[]> {
+  return (await listTerminalsWithSource()).terminals;
+}
+
+/**
+ * Build the operator-facing note appended to `list_terminals` output when
+ * the result did not come from the live, tmux-verified daemon path
+ * (Issue #4794). Returns `""` for the verified `"daemon"` source.
+ */
+export function buildTerminalListFallbackNote(source: TerminalListSource): string {
+  if (source !== "state-fallback") {
+    return "";
+  }
+  return (
+    "\n\nNote: loom-daemon did not respond, so this list was read from the last-written " +
+    "local state file (.loom/state.json) and is UNVERIFIED against live tmux sessions — " +
+    "it may include terminals whose sessions have since ended."
+  );
 }
 
 /**
@@ -839,13 +886,20 @@ export async function handleTerminalTool(
 ): Promise<{ type: "text"; text: string }[]> {
   switch (name) {
     case "list_terminals": {
-      const terminals = await listTerminals();
+      const { terminals, source } = await listTerminalsWithSource();
+
+      // Issue #4794: the daemon path is verified live (the daemon
+      // garbage-collects registry entries whose tmux session no longer
+      // exists on every `ListTerminals` request); the state-file fallback
+      // (daemon unreachable) is NOT — flag it explicitly rather than
+      // presenting a possibly-stale snapshot as if it were confirmed live.
+      const fallbackNote = buildTerminalListFallbackNote(source);
 
       if (terminals.length === 0) {
         return [
           {
             type: "text",
-            text: "No active terminals found. Either Loom hasn't been started yet, or all terminals have been closed.",
+            text: `No active terminals found. Either Loom hasn't been started yet, or all terminals have been closed.${fallbackNote}`,
           },
         ];
       }
@@ -868,7 +922,7 @@ export async function handleTerminalTool(
       return [
         {
           type: "text",
-          text: `=== Active Loom Terminals (${terminals.length}) ===\n\n${terminalList}`,
+          text: `=== Active Loom Terminals (${terminals.length}) ===\n\n${terminalList}${fallbackNote}`,
         },
       ];
     }

--- a/mcp-loom/src/tools/ui.test.ts
+++ b/mcp-loom/src/tools/ui.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for `classifyHeartbeat` (Issue #4794).
+ *
+ * Before this, `get_heartbeat` derived its entire status from the retired
+ * Electron desktop app's console log, so a perfectly healthy `loom-daemon`
+ * with a stale/absent desktop log was reported as `status: "stale"` — the
+ * wrong answer for "is the fleet running?" (observed: "Last log entry was
+ * 284857m ago" against a host with 8 in-flight sweeps under a healthy
+ * daemon). These tests pin the fixed behavior: a live daemon always wins.
+ */
+
+import { describe, expect, it } from "vitest";
+import { classifyHeartbeat, type DesktopLogStatus } from "./ui.js";
+
+const STALE_DESKTOP_LOG: DesktopLogStatus = {
+  status: "stale",
+  message: "Last log entry was 284857m ago",
+  lastLogTime: "2026-01-14T00:00:00.000Z",
+  logCount: 42,
+  recentLogs: ["Found browse button element"],
+};
+
+const ABSENT_DESKTOP_LOG: DesktopLogStatus = {
+  status: "not_running",
+  message: "Console log file not found - app is not running or console logging is disabled",
+  lastLogTime: null,
+  logCount: 0,
+};
+
+const HEALTHY_DESKTOP_LOG: DesktopLogStatus = {
+  status: "healthy",
+  message: "Last log entry was 3s ago",
+  lastLogTime: "2026-07-31T00:00:00.000Z",
+  logCount: 10,
+  recentLogs: ["ready"],
+};
+
+describe("classifyHeartbeat", () => {
+  it("reports daemon_healthy for a live daemon even when the desktop log is stale", () => {
+    const result = classifyHeartbeat({ alive: true, inFlightSweeps: 8 }, STALE_DESKTOP_LOG);
+
+    expect(result.status).toBe("daemon_healthy");
+    expect(result.status).not.toBe("stale");
+    expect(result.daemon).toEqual({ alive: true, inFlightSweeps: 8 });
+    expect(result.message).toContain("8 sweeps in flight");
+    // The legacy desktop signal must still be visible, just not authoritative.
+    expect(result.desktopApp).toEqual(STALE_DESKTOP_LOG);
+  });
+
+  it("reports daemon_healthy for a live daemon even when the desktop log is entirely absent", () => {
+    const result = classifyHeartbeat({ alive: true, inFlightSweeps: 0 }, ABSENT_DESKTOP_LOG);
+
+    expect(result.status).toBe("daemon_healthy");
+    expect(result.status).not.toBe("not_running");
+    expect(result.message).toContain("loom-daemon is responding on its Unix socket");
+  });
+
+  it("uses singular 'sweep' wording for exactly one in-flight sweep", () => {
+    const result = classifyHeartbeat({ alive: true, inFlightSweeps: 1 }, ABSENT_DESKTOP_LOG);
+    expect(result.message).toContain("1 sweep in flight");
+    expect(result.message).not.toContain("1 sweeps");
+  });
+
+  it("omits the sweep count entirely when DaemonStatus could not be queried", () => {
+    const result = classifyHeartbeat({ alive: true, inFlightSweeps: null }, ABSENT_DESKTOP_LOG);
+    expect(result.status).toBe("daemon_healthy");
+    expect(result.message).not.toContain("sweep");
+    expect(result.daemon.inFlightSweeps).toBeNull();
+  });
+
+  it("falls back to the desktop-log status when the daemon is unreachable, but says so explicitly", () => {
+    const result = classifyHeartbeat({ alive: false, inFlightSweeps: null }, STALE_DESKTOP_LOG);
+
+    expect(result.status).toBe("stale");
+    expect(result.message).toContain("did not respond");
+    expect(result.message).toContain("not fleet health");
+    expect(result.daemon).toEqual({ alive: false, inFlightSweeps: null });
+  });
+
+  it("preserves legacy top-level fields for backwards compatibility", () => {
+    const result = classifyHeartbeat({ alive: true, inFlightSweeps: 2 }, HEALTHY_DESKTOP_LOG);
+    expect(result.lastLogTime).toBe(HEALTHY_DESKTOP_LOG.lastLogTime);
+    expect(result.logCount).toBe(HEALTHY_DESKTOP_LOG.logCount);
+    expect(result.recentLogs).toEqual(HEALTHY_DESKTOP_LOG.recentLogs);
+  });
+});

--- a/mcp-loom/src/tools/ui.ts
+++ b/mcp-loom/src/tools/ui.ts
@@ -15,28 +15,44 @@ import { access, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { CONSOLE_LOG_PATH, getWorkspacePath, readConfigFile } from "../shared/config.js";
+import { sendDaemonRequest } from "../shared/daemon.js";
 import { writeMCPCommand } from "../shared/ipc.js";
 
 /**
- * Get app heartbeat - check if app is running and logging
+ * Desktop-app (retired Electron UI) console-log-derived signal — the ONLY
+ * signal `getHeartbeat` used before Issue #4794. `status` here is never
+ * surfaced verbatim as the top-level heartbeat status anymore (see
+ * {@link classifyHeartbeat}) — it is folded into `desktopApp` in the response
+ * so a healthy daemon with a stale/absent desktop log never reports
+ * top-level `stale`.
  */
-async function getHeartbeat(): Promise<string> {
+export interface DesktopLogStatus {
+  status: "healthy" | "active" | "idle" | "stale" | "unknown" | "not_running";
+  message: string;
+  lastLogTime: string | null;
+  logCount: number;
+  recentLogs?: string[];
+}
+
+/**
+ * Read the retired Electron desktop app's console log and classify its
+ * freshness. This is a legacy signal (the desktop app has been retired in
+ * favor of the Rust `loom-daemon`) — see {@link classifyHeartbeat} for how it
+ * is combined with actual daemon liveness.
+ */
+async function getDesktopLogStatus(): Promise<DesktopLogStatus> {
   try {
     await access(CONSOLE_LOG_PATH);
     const content = await readFile(CONSOLE_LOG_PATH, "utf-8");
     const lines = content.split("\n").filter(Boolean);
 
     if (lines.length === 0) {
-      return JSON.stringify(
-        {
-          status: "unknown",
-          message: "Console log is empty - app may not have started yet",
-          lastLogTime: null,
-          logCount: 0,
-        },
-        null,
-        2
-      );
+      return {
+        status: "unknown",
+        message: "Console log is empty - app may not have started yet",
+        lastLogTime: null,
+        logCount: 0,
+      };
     }
 
     // Get last log entry
@@ -46,7 +62,7 @@ async function getHeartbeat(): Promise<string> {
 
     // Calculate time since last log
     let timeSinceLastLog = "unknown";
-    let status = "unknown";
+    let status: DesktopLogStatus["status"] = "unknown";
     if (lastLogTime) {
       const lastLogDate = new Date(lastLogTime);
       const now = new Date();
@@ -70,32 +86,145 @@ async function getHeartbeat(): Promise<string> {
       }
     }
 
-    return JSON.stringify(
-      {
-        status,
-        message: `Last log entry was ${timeSinceLastLog}`,
-        lastLogTime,
-        logCount: lines.length,
-        recentLogs: lines.slice(-5),
-      },
-      null,
-      2
-    );
+    return {
+      status,
+      message: `Last log entry was ${timeSinceLastLog}`,
+      lastLogTime,
+      logCount: lines.length,
+      recentLogs: lines.slice(-5),
+    };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return JSON.stringify(
-        {
-          status: "not_running",
-          message: "Console log file not found - app is not running or console logging is disabled",
-          lastLogTime: null,
-          logCount: 0,
-        },
-        null,
-        2
-      );
+      return {
+        status: "not_running",
+        message: "Console log file not found - app is not running or console logging is disabled",
+        lastLogTime: null,
+        logCount: 0,
+      };
     }
     throw error;
   }
+}
+
+/**
+ * Best-effort daemon liveness/detail probe used by {@link getHeartbeat}.
+ *
+ * Uses the same Unix-socket IPC every other MCP tool uses
+ * (`sendDaemonRequest`), not the retired desktop app's console log. A `Ping`
+ * establishes bare liveness (bounded by `sendDaemonRequest`'s own timeout —
+ * see `shared/daemon.ts`); a best-effort `DaemonStatus` follow-up enriches
+ * the result with the in-flight sweep count when the daemon answers it, but
+ * never turns a working `Ping` into a failure if `DaemonStatus` itself
+ * errors or times out.
+ */
+export interface DaemonProbeResult {
+  alive: boolean;
+  inFlightSweeps: number | null;
+}
+
+async function probeDaemon(): Promise<DaemonProbeResult> {
+  let alive = false;
+  try {
+    const pingResponse = (await sendDaemonRequest({ type: "Ping" })) as { type?: string };
+    alive = pingResponse?.type === "Pong";
+  } catch {
+    return { alive: false, inFlightSweeps: null };
+  }
+
+  if (!alive) {
+    return { alive: false, inFlightSweeps: null };
+  }
+
+  let inFlightSweeps: number | null = null;
+  try {
+    const statusResponse = (await sendDaemonRequest({ type: "DaemonStatus" })) as {
+      type?: string;
+      payload?: { in_flight?: unknown[] };
+    };
+    if (statusResponse?.type === "DaemonStatus" && Array.isArray(statusResponse.payload?.in_flight)) {
+      inFlightSweeps = statusResponse.payload.in_flight.length;
+    }
+  } catch {
+    // Best-effort only — a live daemon that fails/times out on the richer
+    // DaemonStatus call is still reported as alive from the Ping above.
+  }
+
+  return { alive, inFlightSweeps };
+}
+
+/**
+ * Combine the daemon liveness probe with the (legacy) desktop-app log signal
+ * into the final heartbeat payload (Issue #4794).
+ *
+ * Before this, `get_heartbeat` derived its ENTIRE status from the retired
+ * Electron desktop app's console log, so a perfectly healthy `loom-daemon`
+ * with an ancient/absent desktop log (the common case now that the desktop
+ * app is retired) was reported as `status: "stale"` / `"not_running"` — the
+ * wrong answer for "is the fleet running?". Now:
+ *
+ * - A live daemon always yields a top-level `daemon_healthy` status,
+ *   regardless of desktop-log freshness — the daemon is the source of truth.
+ * - A dead/unreachable daemon falls back to the desktop-log-derived status
+ *   (preserving the original behavior for hosts that still run the legacy
+ *   desktop app, or as a last-resort diagnostic when neither is running).
+ * - The raw desktop-log signal is always included under `desktopApp` so
+ *   nothing is lost relative to the old response shape.
+ */
+export function classifyHeartbeat(
+  daemon: DaemonProbeResult,
+  desktopApp: DesktopLogStatus
+): {
+  status: string;
+  message: string;
+  daemon: { alive: boolean; inFlightSweeps: number | null };
+  desktopApp: DesktopLogStatus;
+  // Legacy top-level fields preserved for backwards compatibility with
+  // existing callers that read `lastLogTime` / `logCount` / `recentLogs`
+  // directly off the heartbeat response instead of `desktopApp.*`.
+  lastLogTime: string | null;
+  logCount: number;
+  recentLogs?: string[];
+} {
+  const legacyFields = {
+    lastLogTime: desktopApp.lastLogTime,
+    logCount: desktopApp.logCount,
+    recentLogs: desktopApp.recentLogs,
+  };
+
+  if (daemon.alive) {
+    const sweepNote =
+      daemon.inFlightSweeps === null
+        ? ""
+        : ` (${daemon.inFlightSweeps} sweep${daemon.inFlightSweeps === 1 ? "" : "s"} in flight)`;
+    return {
+      status: "daemon_healthy",
+      message: `loom-daemon is responding on its Unix socket${sweepNote}. Desktop app console log status: ${desktopApp.status} (${desktopApp.message}).`,
+      daemon,
+      desktopApp,
+      ...legacyFields,
+    };
+  }
+
+  // Daemon unreachable — fall back to the desktop-log-derived status, but
+  // make the daemon's absence explicit so "stale" never gets misread as
+  // "the fleet is down" when it may simply mean "no desktop app installed".
+  return {
+    status: desktopApp.status,
+    message: `${desktopApp.message} (loom-daemon did not respond on its Unix socket — this reflects the retired desktop app's log only, not fleet health)`,
+    daemon,
+    desktopApp,
+    ...legacyFields,
+  };
+}
+
+/**
+ * Get app heartbeat - check daemon liveness first (Issue #4794), falling
+ * back to the retired desktop app's console log only when the daemon itself
+ * is unreachable.
+ */
+async function getHeartbeat(): Promise<string> {
+  const [daemon, desktopApp] = await Promise.all([probeDaemon(), getDesktopLogStatus()]);
+  return JSON.stringify(classifyHeartbeat(daemon, desktopApp), null, 2);
 }
 
 /**
@@ -225,7 +354,7 @@ export const uiTools: Tool[] = [
   {
     name: "get_heartbeat",
     description:
-      "Get app heartbeat status - checks if Loom is running and actively logging. Returns status (healthy/active/idle/stale/not_running), last log time, and recent log entries",
+      "Get Loom's heartbeat status. Checks the running loom-daemon over its Unix socket FIRST (status 'daemon_healthy' whenever the daemon responds, with an in-flight sweep count) and only falls back to the retired Electron desktop app's console log (healthy/active/idle/stale/not_running) when the daemon itself is unreachable. Returns both signals: top-level status/message plus 'daemon' and 'desktopApp' detail objects.",
     inputSchema: {
       type: "object",
       properties: {},


### PR DESCRIPTION
## Summary

`mcp__loom__get_heartbeat` derived its entire status from the retired
Electron desktop app's `console.log`, so a perfectly healthy `loom-daemon`
with a stale/absent desktop log reported `status: "stale"` (observed:
`"Last log entry was 284857m ago"` on a host with 8 in-flight sweeps under a
healthy daemon). `mcp__loom__list_terminals` also reported terminals whose
backing tmux session had died (e.g. after the whole `loom` tmux socket lost
its server) as "active" forever.

- `get_heartbeat` now probes the daemon over its Unix socket first (`Ping`,
  then a best-effort `DaemonStatus` for the in-flight sweep count). A live
  daemon always yields `status: "daemon_healthy"`, regardless of desktop-log
  freshness. Only when the daemon itself is unreachable does it fall back to
  the desktop-log-derived status — with an explicit note that this reflects
  the retired desktop app's log only, not fleet health. The full response
  shape is preserved for backwards compatibility (`lastLogTime`, `logCount`,
  `recentLogs` at the top level, plus new `daemon` / `desktopApp` detail
  objects).
- `TerminalManager::list_terminals` (`loom-daemon/src/terminal.rs`) now
  garbage-collects registry entries whose `tmux_session` has no live backing
  session on every call (`prune_dead_terminals`), via a single `tmux -L loom
  list-sessions` call. Any failure to query tmux at all — including "no
  server running", the exact symptom from the issue — is treated as "zero
  live sessions", so the whole registry is correctly pruned rather than
  silently kept.
- The MCP `list_terminals` tool's rare state-file fallback path (used only
  when the daemon itself is unreachable) is NOT tmux-verified, so it is now
  flagged explicitly in the tool output (`buildTerminalListFallbackNote`)
  instead of being presented as a confirmed-live list.

## Test plan

- [x] `cargo test --lib terminal::` (loom-daemon) — 61 passed, including two
      new tests: a ghost terminal (fake `tmux_session`) is pruned from
      `list_terminals()` and removed from the registry; `LOOM_NO_RESTORE=1`
      suppresses pruning (matching its existing "skip all tmux interaction"
      contract used by other tests).
- [x] `cargo test --lib ipc::` — 81 passed (no regression in the existing
      `ListTerminals` IPC test).
- [x] `cargo clippy --package loom-daemon --lib -- -D warnings` — clean.
- [x] `cargo fmt --package loom-daemon -- --check` — clean.
- [x] `cd mcp-loom && npm run typecheck` — clean.
- [x] `cd mcp-loom && npm test` (vitest) — 51 passed, including new
      `classifyHeartbeat` tests (daemon-healthy wins over a stale/absent
      desktop log; falls back with an explicit note when the daemon is
      unreachable; preserves legacy top-level fields) and
      `buildTerminalListFallbackNote` tests.
- [x] `cd mcp-loom && npm run build` — bundle builds, `dist/index.js` present.

Closes #4794