### PR TITLE
fix(tests): bg-proc-trap.sh polish — empty-PID no-op + guarded pkill backstop

### DIFF
--- a/defaults/scripts/tests/lib/bg-proc-trap.sh
+++ b/defaults/scripts/tests/lib/bg-proc-trap.sh
@@ -47,6 +47,19 @@
 # a single combined trap would clean up once and then keep executing every
 # remaining test case in the suite, re-populating $WORKDIR as it goes. The
 # INT/TERM trap must end with an explicit `exit` to actually stop the script.
+#
+# Two documented contracts (PR #4790 judge nits, #4800):
+#   1. bg_proc_track ALWAYS returns 0, even when called with an empty/absent
+#      PID (e.g. a failed spawn produced no `$!`). This is a tolerated no-op,
+#      not an error, so the call is safe to make under `set -e` — a future
+#      `set -e` suite sourcing this helper will not abort on a benign empty
+#      capture.
+#   2. A few suites add a path-pattern `pkill -f "$WORKDIR"` backstop (on top
+#      of bg_proc_reap) to catch fixture processes whose argv references a
+#      scratch directory rather than a tracked PID. If `mktemp -d` ever fails,
+#      $WORKDIR is empty and `pkill -f ""` matches (and kills) EVERY process
+#      visible to the caller — any suite adding such a backstop MUST guard it
+#      with `[ -n "$WORKDIR" ] && pkill -f "$WORKDIR" ...` first.
 
 # Array of PIDs to kill on cleanup. Declared at source time so every sourcing
 # script (and any function it defines) shares one array without redeclaring
@@ -54,11 +67,13 @@
 BG_PROC_TRACKED_PIDS=()
 
 # Record a backgrounded PID for later reaping. Call immediately after `&`,
-# e.g. `some_cmd & bg_proc_track "$!"`. Silently ignores an empty PID so it
-# is always safe to call even if the spawn failed to produce one.
+# e.g. `some_cmd & bg_proc_track "$!"`. Contract: an empty/absent PID is a
+# tolerated no-op that always returns 0 (success) — never 1 — so it is safe
+# to call under `set -e` even if the spawn failed to produce a PID.
 bg_proc_track() {
     local pid="$1"
     [[ -n "$pid" ]] && BG_PROC_TRACKED_PIDS+=("$pid")
+    return 0
 }
 
 # Kill every tracked PID that is still alive. Idempotent and safe to call

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -62,8 +62,8 @@ WORKDIR="$(mktemp -d)"
 # the script (only an EXIT-trap firing auto-exits) -- the explicit `exit`
 # below is required, else a SIGTERM'd suite would clean up once and then keep
 # running every remaining test case (re-populating $WORKDIR as it goes).
-trap 'bg_proc_reap; pkill -f "$WORKDIR" >/dev/null 2>&1; rm -rf "$WORKDIR"' EXIT
-trap 'bg_proc_reap; pkill -f "$WORKDIR" >/dev/null 2>&1; rm -rf "$WORKDIR"; exit 1' INT TERM
+trap 'bg_proc_reap; [ -n "$WORKDIR" ] && pkill -f "$WORKDIR" >/dev/null 2>&1; rm -rf "$WORKDIR"' EXIT
+trap 'bg_proc_reap; [ -n "$WORKDIR" ] && pkill -f "$WORKDIR" >/dev/null 2>&1; rm -rf "$WORKDIR"; exit 1' INT TERM
 mkdir -p "$WORKDIR/.loom/logs"
 
 FAKE_BIN="$WORKDIR/fake-loom-daemon"

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -546,8 +546,8 @@ bg_proc_track "$DECOY_PID"
 # untrapped-exit version of this trap let a SIGTERM'd run limp all the way to
 # a later scenario, which then hit a real, un-stubbed `cargo build --release`
 # once its own fixture dir had already been rm -rf'd out from under it).
-trap 'bg_proc_reap; pkill -f "$BASE_WORKDIR" >/dev/null 2>&1; rm -rf "$BASE_WORKDIR" "$DECOY_DIR"' EXIT
-trap 'bg_proc_reap; pkill -f "$BASE_WORKDIR" >/dev/null 2>&1; rm -rf "$BASE_WORKDIR" "$DECOY_DIR"; exit 1' INT TERM
+trap 'bg_proc_reap; [ -n "$BASE_WORKDIR" ] && pkill -f "$BASE_WORKDIR" >/dev/null 2>&1; rm -rf "$BASE_WORKDIR" "$DECOY_DIR"' EXIT
+trap 'bg_proc_reap; [ -n "$BASE_WORKDIR" ] && pkill -f "$BASE_WORKDIR" >/dev/null 2>&1; rm -rf "$BASE_WORKDIR" "$DECOY_DIR"; exit 1' INT TERM
 
 FAKE_BIN_DIR="$BASE_WORKDIR/fakebin"
 mkdir -p "$FAKE_BIN_DIR"


### PR DESCRIPTION
## Summary
Two non-blocking nits from the PR #4790 judge on the shared test helper `defaults/scripts/tests/lib/bg-proc-trap.sh`:

1. `bg_proc_track` now always returns `0`, even when called with an empty/absent PID — previously it returned `1` in that case (a benign no-op, tolerated today only because current consumers don't run `set -e` through it, but the helper is shared).
2. `test-loom-daemon-start.sh`'s and `test-loom-daemon-update.sh`'s `pkill -f "$WORKDIR"` / `pkill -f "$BASE_WORKDIR"` backstops now guard `[ -n "$WORKDIR" ]` / `[ -n "$BASE_WORKDIR" ]` first, so a failed `mktemp -d` (leaving the var empty) can never degenerate into `pkill -f ""`, which matches (and would kill) every process visible to the caller.

Audited the other 5 suites that source `bg-proc-trap.sh` (`test-fleet-send.sh`, `test-fleet-check.sh`, `test-loom-daemon-stop.sh`, `test-loom-daemon-watchdog.sh`, `test-loom-daemon-launchd-plist.sh`) — none add a `pkill -f` backstop, only a plain `rm -rf "$WORKDIR"` (harmless no-op on an empty string), so no further changes were needed there.

Both contracts are now documented in `bg-proc-trap.sh`'s header comment.

## Test plan
- [x] `bash defaults/scripts/tests/test-loom-daemon-start.sh` — 72/72 passed
- [x] `bash defaults/scripts/tests/test-loom-daemon-stop.sh` — 37/37 passed
- [x] `bash -n` syntax check on all 3 modified files
- [x] `test-loom-daemon-update.sh` is documented (`ci-excluded.txt`) as non-hermetic/hangs past 120s locally — not run to completion, but `bash -n` confirms syntax validity and the change is a mechanical one-line guard addition mirroring the already-verified fix in `test-loom-daemon-start.sh`.

Closes #4800