### PR TITLE
feat(dashboard): serve public view at / with Access-JWT sign-in fallback

### DIFF
--- a/dashboard/.dev.vars.example
+++ b/dashboard/.dev.vars.example
@@ -10,3 +10,12 @@
 # Bearer token gating every /admin/* route. While unset, those routes answer
 # 503. Generate a real one with: openssl rand -hex 32
 ADMIN_TOKEN="local-dev-admin-token"
+
+# NOTE: CF_ACCESS_TEAM_DOMAIN / CF_ACCESS_AUD (single-URL dashboard root —
+# see docs/cloudflare-access.md) are NOT secrets, so their home is the
+# `[vars]` block in wrangler.toml (which `wrangler dev` already reads),
+# alongside RETENTION_DAYS/MAX_RECORDS — not this file. Uncomment them there
+# to exercise the authenticated `/` branch locally. (`.dev.vars` does
+# override `[vars]` in dev, so putting them here would also work; keeping
+# non-secrets out of the secrets template is simply the convention this repo
+# follows.)

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -14,11 +14,16 @@ Query API reference: [`docs/query-api.md`](docs/query-api.md) — includes the
 `/api/*` (authenticated) vs. `/public/*` (redacted) route split and the
 visibility-based redaction policy (issue #4727).
 
-**Out of scope for this repo**: Worker-side Cloudflare Access JWT
-verification — the [Access guide](docs/cloudflare-access.md) covers gating
-`/api/*` via the edge proxy instead; the Worker only decides *what a request
-sees* (via the route it reached), never *whether it should have reached
-here*.
+**`/api/*` vs. `/public/*` remains a route-based auth split, not an
+in-Worker one**: the [Access guide](docs/cloudflare-access.md) covers gating
+`/api/*` via the edge proxy; the Worker decides what a `/api/*`/`/public/*`
+request sees purely by which route matched, never by verifying a credential
+itself. **The one exception is the dashboard root `/`** (issue
+[#4795](https://github.com/rjwalters/loom/issues/4795)): it validates the
+visitor's Cloudflare Access JWT in-Worker (`src/accessAuth.ts`) so a single
+URL can serve both an anonymous public view and, for an allowed identity, the
+full dashboard — see the Access guide's §5 for exactly what that check
+covers and its fail-closed contract.
 
 ## Architecture
 
@@ -124,12 +129,15 @@ asserts the `ADMIN_TOKEN` secret exists on the deployed Worker.
 | `GET /public/fleet-state` | none (always public) | Public query API: same data as `/api/fleet-state`, redacted per record `visibility` (issue #4727). |
 | `GET /public/history` | none (always public) | Public query API: same data as `/api/history`, redacted. |
 | `GET /public/events` | none (always public) | Public query API: same data as `/api/events`, redacted. |
-| `GET /public` | none (always public) | The public dashboard page itself (issue #4753) — server-rendered fleet overview + history from the same redacted data above, plus a live feed over `/public/events`. Read-only; never calls `/api/*`. |
+| `GET /` | **in-Worker** Access JWT check (`src/accessAuth.ts`) — the only route that verifies a credential itself | The dashboard page (issues #4753, #4795). A valid, correctly-audienced `CF_Authorization` cookie renders the full unredacted view (live feed over `/api/events`); **anything else** — no cookie, malformed/expired/wrong-`aud` token, JWKS fetch failure — falls back to the redacted public view with a Sign in link (live feed over `/public/events`). Never a 302, never a 500. Read-only. |
+| `GET /login` | none in-Worker — **must** be behind Cloudflare Access | Bare 302 back to `/`. Its whole purpose is to make Access run the SSO round trip and mint the `CF_Authorization` cookie that `/` then validates. |
+| `GET /public` | none (always public) | 301 → `/` (issue #4795 merged the public page into the root; kept for old bookmarks). |
 
 Full request/response shapes for the `/api/*` and `/public/*` routes,
 including the exact redaction policy per record kind:
-[`docs/query-api.md`](docs/query-api.md). Cloudflare Access setup to actually
-gate `/api/*` at the edge (this backend never verifies auth itself):
+[`docs/query-api.md`](docs/query-api.md). Cloudflare Access setup to gate
+`/login`, `/api/*`, and `/admin/*` at the edge — and to leave `/` ungated so
+its in-Worker fallback can run:
 [`docs/cloudflare-access.md`](docs/cloudflare-access.md).
 
 ## Design decisions worth knowing

--- a/dashboard/docs/cloudflare-access.md
+++ b/dashboard/docs/cloudflare-access.md
@@ -1,13 +1,21 @@
 # Gating the dashboard with Cloudflare Access
 
-How to put zero-trust SSO in front of the **authenticated** fleet view while
-leaving the **public** view and the machine-to-machine `/ingest` endpoint
-reachable without a login.
+How to wire zero-trust SSO into the **single-URL dashboard** (issue
+[#4795](https://github.com/rjwalters/loom/issues/4795)): one hostname,
+`dashboard.example.com`, where an anonymous visitor to `/` sees the
+redacted public view and an allowed identity sees the full view — no second
+URL, no dead-end login wall — plus the machine-to-machine `/ingest` endpoint
+and the `/admin/*` management routes, both reachable without a browser login.
 
-This is the Cloudflare-side configuration only. Phase 3 of epic
-[#4702](https://github.com/rjwalters/loom/issues/4702) builds the actual
-public-view page; the Access policies that distinguish the two routes are set
-up here, at the edge, and are what make that split enforceable.
+**This is a Worker-code-plus-config split, not config alone.** Cloudflare
+Access cannot itself express "try to authenticate, otherwise serve something
+else" — an Access **Allow** application always forces a login, full stop.
+The single-URL fallback works because `src/index.ts`'s root `/` handler does
+its own in-Worker Access-JWT check (`src/accessAuth.ts`) and falls back to
+the public view when it finds no valid one; Access itself only gates the
+narrow `/login` path that mints the session cookie the root handler reads.
+This doc covers the Cloudflare-side configuration that makes that split
+correct; the code side is `src/accessAuth.ts` and `src/index.ts`.
 
 Prerequisite: a deployed backend — see
 [`deploy-runbook.md`](deploy-runbook.md).
@@ -61,23 +69,60 @@ So, before any Access configuration:
 
 ## 2. Route map: what to gate and what to leave open
 
+This is the **single-URL fallback layout** (issue #4795) — the reference
+layout as of this writing. See §2a below for the split-path layout this
+replaced, kept only as a variant note for deployments that haven't
+re-plumbed yet.
+
 | Path | Access decision | Why |
 |---|---|---|
 | `/ingest` | **Bypass** | Machine-to-machine. `loom-daemon` sends `Authorization: Bearer <ingest_key>`, not an SSO cookie — an Access challenge here breaks every push in your fleet. Already authenticated by the per-host key (`src/auth.ts`). |
-| `/public` *(Phase 3)* | **Bypass** | The deliberately public, redacted fleet view. Reserve the path now so the policy is in place before the page exists. |
-| `/admin/*` | **Allow** (+ optional service-token policy) | Host-key management. Already gated by the `ADMIN_TOKEN` bearer secret; Access in front of it is defense in depth. |
-| everything else (`/`, the authenticated view) | **Allow** | The private fleet view: your identities only. |
+| `/healthz` | **Bypass** | Cloudflare-level health check, no Worker route behind it — unrelated to this Worker's own auth, just needs to stay reachable without a login. |
+| `/login` | **Allow** | The *only* path this reference layout gates. Its sole purpose is to force the SSO round trip and mint the `CF_Authorization` session cookie, then bounce back to `/` (`src/index.ts`'s `/login` route is a bare redirect — Access has already done the real work by the time the Worker sees the request). |
+| `/admin/*` | **Allow** (+ service-token policy) | Host-key management. Already gated by the `ADMIN_TOKEN` bearer secret; Access in front of it is defense in depth. Its own application now (previously the service-token policy lived on the hostname-wide app) — scripted admin never touches `/login`, so giving it a dedicated app keeps the two identity policies from tangling. |
+| `/api/*` | **Allow** | The authenticated JSON query API (`docs/query-api.md`). Kept on its own dedicated app with the same identity policy `/login` uses — narrowing the old hostname-wide app to `/login` only would otherwise leave `/api/*` matched by **no** application at all, i.e. wide open, which is not this issue's intent. |
+| `/`, `/public`, everything else | **No Access application at all** (not even Bypass — simply unmatched) | `/` does its own in-Worker JWT check (`src/accessAuth.ts`) and falls back to the public view on anything but a fully valid, correctly-audienced token; `/public` is a bare 301 to `/`. Neither needs an edge policy. |
 
 Cloudflare evaluates the **most specific matching application** — a
-path-scoped app (`loom-dashboard.example.com/ingest`) wins over a
-hostname-wide app (`loom-dashboard.example.com`). That precedence is what
-lets one hostname host both gated and ungated routes.
+path-scoped app (`dashboard.example.com/login`) wins over a hostname-wide
+one. With this layout there is no hostname-wide application left at all: every
+gated path (`/login`, `/admin/*`, `/api/*`) gets its own narrowly-scoped app,
+and everything else (chiefly `/`) is simply never matched by any Access
+application, which is equivalent to Bypass but doesn't need to be declared
+as one.
 
-**Create the Bypass applications before the hostname-wide Allow
-application.** In the window between "hostname is gated" and "`/ingest` is
-bypassed", every daemon push gets an Access redirect instead of a 2xx and
-backs off. Nothing is lost (the daemon's durable queue retries), but you will
-watch your fleet go quiet for no reason.
+**Create `/ingest` and `/healthz` Bypass applications (if you deploy any at
+all — most reference deployments don't need an explicit Bypass app for a
+path no Access application would otherwise match) before the `/login`,
+`/admin/*`, or `/api/*` Allow applications.** In the window between "an
+Allow app exists" and "the matching Bypass app exists", a request to the
+not-yet-bypassed path gets an Access redirect instead of reaching the
+Worker. This mostly matters if you widen an Allow app's path prefix by
+mistake (e.g. accidentally scoping `/admin/*`'s app to `/` during a config
+edit) — with the narrow, path-scoped apps this layout uses, it should not
+come up in normal operation.
+
+### 2a. Variant: the split-path layout (legacy, pre-#4795)
+
+Before issue #4795, this backend had no in-Worker JWT verification: `/`
+itself was Access-gated (Allow, hostname-wide) and `/public` was a
+separately-Bypassed page with its own content. That layout is still valid
+Cloudflare configuration — Access doesn't care what the Worker does — but it
+dead-ends an anonymous visitor to `/` at the SSO login wall instead of
+falling back to the public view, which is the exact UX gap #4795 closed. If
+you're running that older layout:
+
+| Path | Access decision | Why |
+|---|---|---|
+| `/ingest` | **Bypass** | Same as above. |
+| `/public` | **Bypass** | The public, redacted fleet view — a separate path from `/`. |
+| `/admin/*` | **Allow** (+ optional service-token policy) | Same as above, but the service-token policy could also live on the hostname-wide app below. |
+| everything else (`/`, the authenticated view) | **Allow, hostname-wide** | The private fleet view — anonymous visitors get an SSO redirect, full stop. |
+
+Migrating from this to the single-URL layout is a Worker deploy (this
+issue's code) plus the Access-app changes in §2/§3 above/below — no data
+migration, no downtime beyond a brief window while you swap the
+applications over.
 
 ---
 
@@ -92,7 +137,7 @@ Cloudflare dashboard → **Zero Trust** → **Access** → **Applications**.
 GitHub / Okta / any OIDC or SAML provider works the same way from Access's
 point of view.
 
-### 3b. Bypass application for `/ingest`
+### 3b. Bypass applications for `/ingest` (and `/healthz`, if you use one)
 
 **Add an application → Self-hosted**
 
@@ -110,18 +155,20 @@ Policy:
 | Action | **Bypass** |
 | Include | **Everyone** |
 
-Repeat for path `public` (`loom-dashboard public view (bypass)`), so the
-Phase-3 public page is ungated the day it lands.
+Repeat for path `healthz` if your uptime checker needs one — there is no
+Worker route behind it today (see the Curator note in issue #4795), so this
+is purely a Cloudflare-level health-check path, unrelated to anything the
+Worker itself does.
 
-### 3c. Allow application for the authenticated view
+### 3c. Allow application for `/login` — the single-URL fallback's SSO bounce
 
 **Add an application → Self-hosted**
 
 | Field | Value |
 |---|---|
-| Application name | `loom-dashboard (private)` |
-| Session duration | 24 hours (your call) |
-| Public hostname | `loom-dashboard.example.com` (no path — covers everything not matched by a more specific app) |
+| Application name | `loom-dashboard login` |
+| Session duration | 24 hours (your call — this is how long the `CF_Authorization` cookie the root handler reads stays valid) |
+| Public hostname | `loom-dashboard.example.com`, path `login` |
 
 Policy:
 
@@ -129,15 +176,33 @@ Policy:
 |---|---|
 | Policy name | `fleet operators` |
 | Action | **Allow** |
-| Include | **Emails** → your addresses (or **Emails ending in** `@yourcompany.com`, or an Access group) |
+| Include | **Emails ending in** `2amlogic.com` (or **Emails** → specific addresses, e.g. add `rjwalters@gmail.com` as a second Include rule for an external operator identity, or an Access group) |
 
-### 3d. Optional: a service token for scripted `/admin` calls
+Note the **Application Audience (AUD) tag** shown on this app's overview
+page once created — that value goes in `CF_ACCESS_AUD` in `wrangler.toml`'s
+`[vars]` block (see §5 below, which also explains why you list the `/api/*`
+app's tag alongside it). `src/accessAuth.ts` pins every JWT it verifies to
+that allowlist, so a token minted for an Access app you did not list will
+not unlock the dashboard root even though it comes from the same
+team/identity provider.
 
-Once `/admin/*` sits behind Access, an interactive login is required — which
-breaks `curl`-driven host provisioning. Two options:
+### 3d. Allow application for `/admin/*` — its own app, with the service token
+
+**Add an application → Self-hosted**
+
+| Field | Value |
+|---|---|
+| Application name | `loom-dashboard admin` |
+| Session duration | 24 hours |
+| Public hostname | `loom-dashboard.example.com`, path `admin` |
+
+Once `/admin/*` sits behind its own Access application, an interactive login
+is required for a human — which breaks `curl`-driven host provisioning.
+Attach a **second** policy for scripted callers:
 
 **Service token (recommended).** **Access → Service Auth → Create service
-token**, then add a second policy on the private application:
+token**, then add this policy alongside the human `fleet operators` policy
+from §3c (reuse the same Include rule, or restrict to specific admins):
 
 | Field | Value |
 |---|---|
@@ -164,20 +229,49 @@ cloudflared access curl https://loom-dashboard.example.com/admin/fleet-state \
   -H "authorization: Bearer $ADMIN_TOKEN"
 ```
 
-**Or** add a third Bypass application scoped to `admin` and rely solely on
+**Or** skip the Access app for `/admin/*` entirely and rely solely on
 `ADMIN_TOKEN`. That is a real, defensible choice — the routes are already
 authenticated — but it drops the second factor; prefer the service token.
 
+### 3e. Allow application for `/api/*` — keeps the JSON query API edge-gated
+
+Narrowing the old hostname-wide app down to `/login` (§3c) would otherwise
+leave `/api/*` matched by no Access application at all — wide open, full
+unredacted fleet data, to anyone who finds the URL. Give it its own app so
+its protection level is unchanged from before this issue:
+
+**Add an application → Self-hosted**
+
+| Field | Value |
+|---|---|
+| Application name | `loom-dashboard api` |
+| Session duration | 24 hours |
+| Public hostname | `loom-dashboard.example.com`, path `api` |
+
+Policy: the same `fleet operators` policy as §3c (same Include rule — one
+identity, two apps).
+
 ---
 
-## 4. Verify the split
+## 4. Verify the layout
 
 ```bash
 BASE=https://loom-dashboard.example.com
 
-# Gated: an unauthenticated browser request is redirected to the Access login.
-curl -sS -o /dev/null -w '%{http_code} %{redirect_url}\n' "$BASE/"
+# The single-URL fallback: an anonymous request to / renders the public
+# view directly — 200, no redirect, never a login wall.
+curl -sS -o /dev/null -w '%{http_code}\n' "$BASE/"
+# expect 200 — a 302 here means an Access app is still covering / (check
+# for a leftover hostname-wide app from the split-path layout, §2a)
+
+# The only gated path: an unauthenticated browser request to /login is
+# redirected to the Access login.
+curl -sS -o /dev/null -w '%{http_code} %{redirect_url}\n' "$BASE/login"
 # expect 302 → https://<your-team>.cloudflareaccess.com/cdn-cgi/access/login/...
+
+# /public is a bare redirect back to /, unauthenticated.
+curl -sS -o /dev/null -w '%{http_code} %{redirect_url}\n' "$BASE/public"
+# expect 301 → https://loom-dashboard.example.com/
 
 # Ungated machine path: reaches the Worker, which answers with ITS OWN 401
 # (not an Access redirect) when the key is missing/bad.
@@ -198,29 +292,71 @@ npx wrangler d1 execute loom-observability --remote \
   --command "SELECT max(ingested_at) FROM records"
 ```
 
-**The 401-vs-302 distinction on `/ingest` is the single most useful check
-here** — a 302 means Access is intercepting the daemon's pushes.
+Finally, verify the actual SSO round trip as an allowed identity in a
+browser: visit `$BASE/`, click **Sign in**, complete the login flow at
+`/login`, and confirm you land back on `/` with the full (unredacted)
+dashboard — no separate URL to remember.
+
+**The 401-vs-302 distinction on `/ingest` is the single most useful
+machine-path check here** — a 302 means Access is intercepting the daemon's
+pushes. For the human-facing side, **`/` returning 200 (not 302) is the
+single most useful check** — a 302 there means the old split-path layout's
+hostname-wide app is still active and this issue's UX fix isn't live yet.
 
 ---
 
-## 5. Optional hardening: verify the Access JWT in the Worker
+## 5. Verify the Access JWT in the Worker (src/accessAuth.ts)
 
-Access injects a signed `CF-Access-Jwt-Assertion` header on every request it
-lets through. Verifying it inside the Worker closes the gap where someone
-finds a way to reach the Worker without traversing Access (a leftover
-workers.dev route, a `[[routes]]` pattern on another hostname).
+Unlike the rest of this backend, the dashboard root `/` **does** carry its
+own in-Worker credential check (issue #4795) — this is what makes the
+single-URL fallback possible at all, since Access itself cannot express
+"try to authenticate, else serve something else". `src/accessAuth.ts`
+validates the `CF_Authorization` session cookie Access sets after a
+successful `/login` round trip (not the `CF-Access-Jwt-Assertion` header —
+see that module's doc comment for why: `/` isn't traversing an Access
+application, so Access never injects that header there).
 
-**This is not implemented today** — the Worker trusts the edge. It is a
-sensible Phase-3 addition, and the ingredients are:
+The ingredients, both configured as plain (non-secret) `[vars]` in
+`wrangler.toml`:
 
-- JWKS: `https://<your-team>.cloudflareaccess.com/cdn-cgi/access/certs`
-- Expected `aud`: the application's **Application Audience (AUD) tag** (shown
-  on the app's overview page).
-- Verify signature, `aud`, `iss`, and expiry before serving the private view;
-  skip the check on the Bypass paths (Access sends no JWT there).
+- `CF_ACCESS_TEAM_DOMAIN` — your team's Cloudflare Access domain, e.g.
+  `yourteam.cloudflareaccess.com`. Used to build the JWKS URL
+  (`https://<team domain>/cdn-cgi/access/certs`, fetched and cached per
+  Worker isolate) and the expected `iss` claim.
+- `CF_ACCESS_AUD` — the **Application Audience (AUD) tag** of the `/login`
+  application (§3c above shows where to find it on that app's overview
+  page). Every verified token's `aud` claim is pinned to this allowlist, so
+  a token minted for an Access app you did *not* list — anyone else's app on
+  your zone — cannot unlock the dashboard root.
 
-Until then, the belt-and-braces controls that *are* live are `workers_dev =
-false` (§1) and the `ADMIN_TOKEN` bearer on `/admin/*`.
+  **List the `/api/*` app's AUD here too, comma-separated.** Access names
+  the session cookie `CF_Authorization` per *hostname* but mints the token
+  per *application*, so once the authenticated page opens its `/api/events`
+  live tail the browser can be holding the `/api/*` app's token instead of
+  `/login`'s. Pin to `/login` alone and an operator who just signed in flaps
+  back to the public view on their next page load:
+
+  ```toml
+  CF_ACCESS_AUD = "<login app AUD>,<api app AUD>"
+  ```
+
+  This is still a pin, not a loophole — only tags you enumerated are
+  accepted, and a blank/whitespace-only value is treated as *unconfigured*
+  (i.e. `/` renders the public view), never as "accept anything".
+
+Signature, `aud`, `iss`, and expiry are all verified before serving the full
+view; **any failure — missing cookie, malformed token, wrong aud/iss,
+expired, or even a JWKS fetch failure — falls back to the public view,
+never a 500 and never the full view on a doubtful token.** This fail-closed
+contract is covered by automated tests in `test/accessAuth.test.ts` and
+`test/index.test.ts`; if you're auditing this code path, that fail-closed
+guarantee (not merely "does a valid token work") is the property to verify.
+
+Leaving `CF_ACCESS_TEAM_DOMAIN`/`CF_ACCESS_AUD` unset is a supported
+configuration too — `/` then always renders the public view, useful for a
+deployment that doesn't want the authenticated dashboard at all yet. The
+belt-and-braces controls that are *always* live regardless are
+`workers_dev = false` (§1) and the `ADMIN_TOKEN` bearer on `/admin/*`.
 
 ---
 
@@ -228,9 +364,12 @@ false` (§1) and the `ADMIN_TOKEN` bearer on `/admin/*`.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Every daemon push suddenly fails / fleet goes quiet | `/ingest` is covered by the hostname-wide Allow app | Add the `/ingest` Bypass app (§3b) — it takes precedence |
+| Every daemon push suddenly fails / fleet goes quiet | `/ingest` is covered by a wider Allow app | Add the `/ingest` Bypass app (§3b) — the more specific path wins |
+| `/` redirects to the Access login instead of showing the public view | A leftover hostname-wide Allow app from the split-path layout (§2a) is still covering `/` | Remove/narrow that app so nothing but `/login`, `/admin/*`, and `/api/*` are gated (§2/§3) |
 | Access login works but the Worker 404s | Custom domain route not deployed | `wrangler deploy` after adding `[[routes]]` |
-| The private view is reachable without logging in | workers.dev still enabled, or another route/hostname points at the Worker | `workers_dev = false`, redeploy, and audit `wrangler deployments list` / your zone's routes |
+| `/` always shows the public view even for an allowed identity that just logged in | `CF_ACCESS_TEAM_DOMAIN`/`CF_ACCESS_AUD` unset or wrong, or the identity's browser isn't sending the `CF_Authorization` cookie back to `/` (check it isn't scoped to `/login` only — Access sets it zone-wide by default) | Check the `[vars]` values against the `/login` app's own overview page; check the cookie in browser devtools |
+| `/` shows the full view right after sign-in, then flips back to the public view on the next load | The browser's one `CF_Authorization` cookie was re-minted by a *different* app on the hostname (typically `/api/*`, once the page opened its live tail), and its `aud` is not in `CF_ACCESS_AUD` | Add that app's AUD tag to `CF_ACCESS_AUD` — it takes a comma-separated list precisely for this (§5) |
+| The `/api/*` query API is reachable without logging in | The `/api/*` Allow app (§3e) is missing — narrowing the old hostname-wide app to `/login` alone leaves `/api/*` unmatched by any application | Add the dedicated `/api/*` app from §3e |
 | Scripts against `/admin` get an HTML login page | No Service Auth policy | §3d |
 | `cloudflared access curl` prompts repeatedly | Session expired | `cloudflared access login <url>` again |
 | Policy edits appear to do nothing | Existing Access session cookie | Test in a private window, or `cloudflared access logout` |

--- a/dashboard/docs/deploy-runbook.md
+++ b/dashboard/docs/deploy-runbook.md
@@ -156,9 +156,18 @@ Wrangler prints the deployed URL —
 it:
 
 ```bash
-curl https://loom-observability-ingest.<your-subdomain>.workers.dev/
-# loom-observability-ingest: see /ingest, /admin/*
+curl -sS -o /dev/null -w '%{http_code} %{content_type}\n' \
+  https://loom-observability-ingest.<your-subdomain>.workers.dev/
+# 200 text/html; charset=utf-8
 ```
+
+`/` serves the dashboard page itself (issue #4795): the **redacted public
+view**, with a Sign in link, for any request without a valid Cloudflare
+Access session — which is every request at this point, since Access is not
+configured yet and `CF_ACCESS_TEAM_DOMAIN`/`CF_ACCESS_AUD` are unset in
+`wrangler.toml`. A `200` here (never a redirect, never a 500) is the whole
+smoke test; wiring the authenticated variant is
+[`cloudflare-access.md`](cloudflare-access.md)'s job.
 
 ## 7. Set the admin token
 

--- a/dashboard/docs/query-api.md
+++ b/dashboard/docs/query-api.md
@@ -13,20 +13,30 @@ policies:
 
 | Prefix | Who reaches it | Visibility-tagged (`private`) data |
 |---|---|---|
-| `/api/*` | **Authenticated** — the surface an operator's Cloudflare Access policy is expected to gate (see [`cloudflare-access.md`](cloudflare-access.md)'s route map: everything not explicitly Bypassed is Allow-gated) | Full detail, unredacted |
+| `/api/*` | **Authenticated** — the surface an operator's Cloudflare Access policy is expected to gate (see [`cloudflare-access.md`](cloudflare-access.md) §3e: `/api/*` gets its own Allow application) | Full detail, unredacted |
 | `/public/*` | **Public** — always reachable, no login | Redacted per record kind (see below); `public`-visibility data is always full detail on either prefix |
 
-**This is a route-based split, not an in-Worker one.** Per the epic's
-explicit constraint ("no auth code in the dashboard itself"), the Worker
-never parses a JWT or any other credential — `isAuthenticated` in
-`src/index.ts` is set purely by which path matched. The `/public` prefix is
-the same path `cloudflare-access.md` already reserves as a Bypass
-application (§2 of that guide, added ahead of the Phase-3 public page); the
-existing `/api/*` prefix is left as the "everything else" Allow-gated
-surface that guide already documents. Putting an operator's Access policy in
-front of `/api/*` (and leaving `/public/*` bypassed) is what actually makes
-the split enforceable end to end — **the Worker's own redaction is a
-defense-in-depth control, not a substitute for that edge configuration.**
+**For these two prefixes this is a route-based split, not an in-Worker
+one.** The Worker does not parse a JWT or any other credential on `/api/*`
+or `/public/*` — `isAuthenticated` in `src/index.ts` is set purely by which
+path matched. Putting an operator's Access policy in front of `/api/*` (and
+leaving `/public/*` ungated) is what actually makes the split enforceable
+end to end — **the Worker's own redaction is a defense-in-depth control, not
+a substitute for that edge configuration.** In particular, since issue #4795
+narrowed the old hostname-wide Access application down to `/login`, `/api/*`
+needs its **own** Access application or it is matched by none at all: see
+[`cloudflare-access.md`](cloudflare-access.md) §3e, and the pitfalls table
+row "The `/api/*` query API is reachable without logging in".
+
+**The dashboard root `/` is the one exception** (issue #4795): it verifies
+the visitor's Access JWT in-Worker ([`src/accessAuth.ts`](../src/accessAuth.ts))
+and picks the redacted or unredacted variant of the same page accordingly,
+so a single URL can serve both audiences without dead-ending an anonymous
+visitor at an SSO wall. That check is fail-closed by construction — a
+missing/malformed/expired/wrong-`aud` token, or an unreachable JWKS
+endpoint, all render the public variant. It does **not** change anything
+about the `/api/*` vs. `/public/*` contract described here; the page's own
+live feed simply points at whichever prefix matches the variant it rendered.
 
 **Redaction is one policy layer, one enforcement point.**
 [`src/redaction.ts`](../src/redaction.ts) wraps every `/api/*` and
@@ -236,8 +246,16 @@ poll loop and D1 query are identical to `/api/events`.
   and `/public/events` only support `host`/`repo` filters today; a client
   wanting to filter by model/result filters client-side on the streamed
   frames.
-- **In-Worker Cloudflare Access JWT verification** — the `/api/*` vs
-  `/public/*` split (above) relies entirely on the Cloudflare Access edge
-  policy an operator configures per [`cloudflare-access.md`](cloudflare-access.md);
-  the Worker itself does not verify a signed Access header. See that guide's
-  §5 for the tradeoff and what a future hardening pass would add.
+- **In-Worker Cloudflare Access JWT verification _on these query routes_** —
+  the `/api/*` vs `/public/*` split (above) still relies entirely on the
+  Cloudflare Access edge policy an operator configures per
+  [`cloudflare-access.md`](cloudflare-access.md); neither prefix's handler
+  verifies a credential itself. (The dashboard root `/` **does**, as of issue
+  #4795 — see that guide's §5 and [`src/accessAuth.ts`](../src/accessAuth.ts)
+  — but extending the same check to `/api/*` as defense in depth is
+  deliberately *not* done here: `/api/*` is also reached non-interactively
+  with an Access **service token**, whose JWT carries the `/api/*`
+  application's own `aud`, so a single pinned-`aud` check would reject
+  exactly the callers it must not break. Doing it properly means accepting
+  the `Cf-Access-Jwt-Assertion` header with a per-application `aud`
+  allowlist — a separate change.)

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "loom-observability-backend",
       "version": "0.1.0",
+      "dependencies": {
+        "jose": "^6.2.6"
+      },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "0.10.15",
         "@cloudflare/workers-types": "^4.20251210.0",
@@ -1981,6 +1984,15 @@
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jose": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.6.tgz",
+      "integrity": "sha512-HwMtbJjMw8rC8dUTwCNilHJD+fxTeKM3JV1eprSmTjS41qwXSSt6exJXgyPK1QOu0jB9eDYLESRDkB3qaT3jnw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -13,6 +13,9 @@
     "typecheck": "tsc --noEmit",
     "check": "npm run typecheck && npm run test"
   },
+  "dependencies": {
+    "jose": "^6.2.6"
+  },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "0.10.15",
     "@cloudflare/workers-types": "^4.20251210.0",

--- a/dashboard/src/accessAuth.ts
+++ b/dashboard/src/accessAuth.ts
@@ -1,0 +1,176 @@
+/**
+ * Cloudflare Access JWT validation for the single-URL dashboard root (issue
+ * #4795, Epic #4702). This is the Worker's first cryptographic-verification
+ * code path — kept deliberately separate from `./auth.ts` (per-host
+ * *ingest-key* auth: a SHA-256 hash comparison against D1, a completely
+ * different trust boundary) rather than folding into it.
+ *
+ * ## Where the token comes from
+ *
+ * The re-plumbed Access layout (see `docs/cloudflare-access.md`) covers only
+ * `/login` with an Access application — the dashboard root `/` deliberately
+ * bypasses Access so anonymous visitors land on the public view instead of
+ * an SSO wall. That means Access does **not** inject its
+ * `Cf-Access-Jwt-Assertion` header on requests to `/` (it only does that for
+ * requests that traversed an Access-gated app). What it *does* do, after a
+ * successful `/login` round trip, is set a `CF_Authorization` session cookie
+ * scoped to the whole zone — the browser keeps sending that cookie on every
+ * subsequent request to `/`, gated or not. So this module reads the JWT out
+ * of the **cookie**, not the header.
+ *
+ * ## Fail-closed, always
+ *
+ * Every error path here — missing config, missing/malformed cookie, network
+ * failure fetching the JWKS, bad signature, wrong `aud`, wrong `iss`,
+ * expired token — resolves to `null`, never throws. Callers MUST treat
+ * `null` as "no valid identity" and fall back to rendering the public view.
+ * This is the load-bearing security property of this module: a subtle bug
+ * that turned any of the above into a fail-*open* branch would be a real
+ * auth bypass that a superficial test pass could still look correct.
+ *
+ * ## AUD pinning
+ *
+ * `env.CF_ACCESS_AUD` is checked against the token's `aud` claim on every
+ * verification. Without this, a JWT minted for a *different* Access
+ * application on the same zone (e.g. someone else's app sharing the same
+ * team/JWKS) would also validate here — the AUD tag scopes acceptance to
+ * tokens issued specifically for this app. Neither the team domain nor the
+ * AUD tag is a secret (both are shown on the Access app's own dashboard
+ * page), so both are plain `[vars]`, not `wrangler secret`s.
+ *
+ * `CF_ACCESS_AUD` accepts a **comma-separated list** of AUD tags, and this
+ * is not incidental. Access names the session cookie `CF_Authorization` for
+ * the whole *hostname*, but mints its token per *application* — so on a
+ * hostname running several path-scoped apps (this layout runs `/login`,
+ * `/api/*`, and `/admin/*`), the single cookie the browser holds can carry
+ * whichever app's `aud` was issued most recently. A visitor who signs in at
+ * `/login` and whose dashboard page then opens the `/api/events` live tail
+ * can end up holding an `/api`-app token; pinning to the `/login` AUD alone
+ * would bounce that already-authenticated operator back to the public view
+ * on their next page load. Listing every app AUD on the hostname whose
+ * session should count as signed-in fixes that without weakening the pin:
+ * acceptance is still an explicit allowlist of tags this operator
+ * configured, never "any token from this team".
+ */
+
+import { createRemoteJWKSet, jwtVerify, type JWTVerifyGetKey } from "jose";
+
+export interface AccessAuthEnv {
+  CF_ACCESS_TEAM_DOMAIN?: string;
+  /** One AUD tag, or several comma-separated — see the module doc's AUD
+   * pinning section for why a list is the right shape here. */
+  CF_ACCESS_AUD?: string;
+}
+
+export interface AccessIdentity {
+  /** The Access-authenticated user's email, when the token carries one. */
+  email?: string;
+  /** The token's `sub` claim, if present. */
+  sub?: string;
+}
+
+const COOKIE_NAME = "CF_Authorization";
+
+/** Cloudflare Access signs its application tokens with RS256, and its
+ * `/cdn-cgi/access/certs` JWKS serves RSA public keys only. Pinning the
+ * accepted algorithm here is defense in depth against algorithm-confusion:
+ * `jose` already refuses `alg: none` outright and would fail to match an
+ * `HS256` token against an RSA JWK, but stating the expected algorithm
+ * explicitly means a future JWKS that also published, say, a symmetric or
+ * weaker key could not silently widen what this Worker accepts. */
+const ACCEPTED_ALGORITHMS = ["RS256"];
+
+/** Extract the `CF_Authorization` cookie's value from a `Cookie` request
+ * header, or `null` if the header is absent or the cookie is not present.
+ * Deliberately tolerant of extra cookies / odd spacing — a `Cookie` header
+ * is a semicolon-separated list the browser controls, not a value this
+ * Worker should be strict about parsing beyond finding its own cookie. */
+export function extractAccessCookie(cookieHeader: string | null): string | null {
+  if (!cookieHeader) return null;
+  for (const part of cookieHeader.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    const name = part.slice(0, eq).trim();
+    if (name !== COOKIE_NAME) continue;
+    const value = part.slice(eq + 1).trim();
+    return value.length > 0 ? value : null;
+  }
+  return null;
+}
+
+// One JWKS resolver per team domain per isolate. `createRemoteJWKSet` already
+// caches the fetched keys internally (and re-fetches on a `kid` miss / after
+// its own cache duration), so this map only avoids constructing a new
+// resolver — and therefore a cold cache — on every single request.
+const remoteJwksCache = new Map<string, JWTVerifyGetKey>();
+
+function remoteJwks(teamDomain: string): JWTVerifyGetKey {
+  let resolver = remoteJwksCache.get(teamDomain);
+  if (!resolver) {
+    resolver = createRemoteJWKSet(new URL(`https://${teamDomain}/cdn-cgi/access/certs`));
+    remoteJwksCache.set(teamDomain, resolver);
+  }
+  return resolver;
+}
+
+/** Split `CF_ACCESS_AUD` into the allowlist of accepted AUD tags, dropping
+ * empty entries so a trailing comma or a stray space cannot smuggle in an
+ * empty-string audience. An all-blank value yields an empty list, which the
+ * caller treats as "not configured" — i.e. fails closed, not open. */
+export function parseAcceptedAudiences(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+/**
+ * Validate the Access JWT carried in `cookieHeader` against
+ * `env.CF_ACCESS_TEAM_DOMAIN`'s JWKS, pinning `aud` to one of
+ * `env.CF_ACCESS_AUD`'s tags and `iss` to the team domain. Returns the
+ * decoded identity on success, `null` on absolutely any failure (see the
+ * module doc — this function never throws).
+ *
+ * `jwksResolver` is an injection point for tests (a local, in-memory JWKS
+ * signed with a test key pair) — production callers should omit it and get
+ * the real Cloudflare-hosted JWKS, cached per team domain.
+ */
+export async function validateAccessJwt(
+  cookieHeader: string | null,
+  env: AccessAuthEnv,
+  jwksResolver: (teamDomain: string) => JWTVerifyGetKey = remoteJwks,
+): Promise<AccessIdentity | null> {
+  const teamDomain = env.CF_ACCESS_TEAM_DOMAIN;
+  const audiences = parseAcceptedAudiences(env.CF_ACCESS_AUD);
+  if (!teamDomain || audiences.length === 0) return null;
+
+  const token = extractAccessCookie(cookieHeader);
+  if (!token) return null;
+
+  try {
+    const jwks = jwksResolver(teamDomain);
+    const { payload } = await jwtVerify(token, jwks, {
+      issuer: `https://${teamDomain}`,
+      // `jose` accepts the token when its `aud` matches ANY entry here — an
+      // explicit allowlist, never a wildcard.
+      audience: audiences,
+      algorithms: ACCEPTED_ALGORITHMS,
+      // No `clockTolerance`: an expired token is expired. `jose`'s default is
+      // zero tolerance and this comment exists so nobody "helpfully" adds
+      // slack to it later.
+    });
+    return {
+      email: typeof payload.email === "string" ? payload.email : undefined,
+      sub: typeof payload.sub === "string" ? payload.sub : undefined,
+    };
+  } catch {
+    // Signature failure, expired/not-yet-valid token, wrong aud/iss, a JWKS
+    // fetch that threw (network error, non-2xx, malformed JSON) — every one
+    // of these lands here and fails closed. Deliberately not logging the
+    // token or the raw error: this path runs on every anonymous request to
+    // `/`, and a malformed/garbage cookie is expected, unremarkable input,
+    // not an incident to record.
+    return null;
+  }
+}

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -35,13 +35,35 @@
  *                                      summarized (see `./redaction.ts`).
  *   GET  /public/history             — public: same query, redacted.
  *   GET  /public/events              — public: same live tail, redacted.
- *   GET  /public                     — public: the Phase-3 dashboard page
- *                                      itself (issue #4753), server-rendered
- *                                      from the same redacted data the three
- *                                      routes above return. See
- *                                      `./publicPage.ts` for the rendering +
- *                                      the token/cost-widget exposure
- *                                      decision.
+ *   GET  /public                     — 301s to `/` (issue #4795 — the
+ *                                      single-URL fallback layout replaced
+ *                                      the separate public path; kept as a
+ *                                      redirect only so old bookmarks/links
+ *                                      still work).
+ *   GET  /                            — single-URL dashboard root (issue
+ *                                      #4795): validates the visitor's
+ *                                      Cloudflare Access JWT, carried as the
+ *                                      `CF_Authorization` cookie (see
+ *                                      `./accessAuth.ts`). A valid,
+ *                                      correctly-audienced token renders the
+ *                                      full authenticated dashboard (same
+ *                                      page as the old `/public`, but with
+ *                                      unredacted data + `/api/*` live
+ *                                      feed); anything else — no cookie, a
+ *                                      malformed/expired/wrong-aud token, a
+ *                                      JWKS fetch failure — fails CLOSED to
+ *                                      the redacted public view with a
+ *                                      "Sign in" link, exactly like the old
+ *                                      `/public` page. Never a 500, never
+ *                                      the full view on a doubtful token.
+ *   GET  /login                      — Access-gated at the edge (config,
+ *                                      not code — see
+ *                                      `docs/cloudflare-access.md`): the
+ *                                      only job of this route, once Access
+ *                                      lets a request through, is to bounce
+ *                                      back to `/` so the freshly-minted
+ *                                      `CF_Authorization` cookie is
+ *                                      re-validated there.
  *
  * All `/admin/*` routes require `Authorization: Bearer <ADMIN_TOKEN>`
  * (a `wrangler secret`, never committed) — see README.md.
@@ -53,12 +75,15 @@
  * else… Allow" rule the Access guide already documents), `/public/*` is
  * always unauthenticated and always redacted, mirroring the `/public` path
  * that guide already reserves as a Bypass application. Neither route
- * verifies a JWT or any other credential in-Worker — per the epic's
- * constraint, that verification lives entirely at the Cloudflare Access
- * edge layer.
+ * verifies a JWT or any other credential in-Worker. **The dashboard root `/`
+ * is the one exception** (issue #4795): it is the Worker's first in-Worker
+ * credential check, added specifically so a single URL can serve both
+ * audiences — see `./accessAuth.ts`'s module doc for the full fail-closed
+ * contract.
  */
 
 import { extractBearerToken, authenticateHost, hashIngestKey } from "./auth";
+import { validateAccessJwt } from "./accessAuth";
 import { FleetState, type FleetSnapshot } from "./fleetState";
 import { renderPublicPage } from "./publicPage";
 import {
@@ -80,6 +105,11 @@ export interface Env {
   RETENTION_DAYS?: string;
   MAX_RECORDS?: string;
   ADMIN_TOKEN?: string;
+  /** Single-URL dashboard root (issue #4795) — see `./accessAuth.ts`. Both
+   * are plain, non-secret `[vars]`; leaving either unset makes `/` always
+   * render the public view (fails closed, never the other way). */
+  CF_ACCESS_TEAM_DOMAIN?: string;
+  CF_ACCESS_AUD?: string;
 }
 
 /** A single global Durable Object instance holds fleet-wide live state —
@@ -343,23 +373,54 @@ function handleLiveTail(request: Request, env: Env, url: URL, isAuthenticated: b
   });
 }
 
-/** `GET /public` (issue #4753) — the unauthenticated dashboard page itself.
- * Sources its data by calling `fleetStateStub`/`queryHistory` directly, the
- * same in-process calls `handleFleetStateQuery`/`handleHistoryQuery` make,
- * then redacts with `isAuthenticated: false` before handing off to
- * `./publicPage.ts` for rendering — there is no HTTP round-trip through
- * `/api/*` anywhere in this path, so this route cannot accidentally source
- * unredacted data. */
-async function handlePublicPage(env: Env): Promise<Response> {
+/** The single-URL dashboard root's page body (issue #4795; originally issue
+ * #4753's `/public` page, generalized here to serve both variants). Sources
+ * its data by calling `fleetStateStub`/`queryHistory` directly, the same
+ * in-process calls `handleFleetStateQuery`/`handleHistoryQuery` make.
+ *
+ * `isAuthenticated: false` (the `/` fallback / old `/public`) redacts before
+ * handing off to `./publicPage.ts` — there is no HTTP round-trip through
+ * `/api/*` anywhere in this path, so this branch cannot accidentally source
+ * unredacted data. `isAuthenticated: true` (a validated Access identity)
+ * passes the raw snapshot/history straight through instead — the caller
+ * (the root route below) has already confirmed the JWT via
+ * `./accessAuth.ts` before reaching here. */
+async function handleDashboardPage(env: Env, isAuthenticated: boolean): Promise<Response> {
   const stateResponse = await fleetStateStub(env).fetch("https://fleet-state/snapshot");
   const snapshot = (await stateResponse.json()) as FleetSnapshot;
-  const redactedSnapshot = redactFleetSnapshot(snapshot, /* isAuthenticated */ false);
+  const displaySnapshot = isAuthenticated ? snapshot : redactFleetSnapshot(snapshot, false);
 
   const historyResult = await queryHistory(env.DB, { limit: DEFAULT_HISTORY_LIMIT });
-  const redactedHistory = redactHistoryQueryResult(historyResult, /* isAuthenticated */ false);
+  const displayHistory = isAuthenticated ? historyResult : redactHistoryQueryResult(historyResult, false);
 
-  const html = renderPublicPage(redactedSnapshot, redactedHistory);
-  return new Response(html, { status: 200, headers: { "content-type": "text/html; charset=utf-8" } });
+  const html = renderPublicPage(displaySnapshot, displayHistory, { isAuthenticated });
+  return new Response(html, {
+    status: 200,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      // One URL, two bodies, keyed on a cookie: any shared cache that stored
+      // the authenticated variant and replayed it to an anonymous visitor
+      // would be a data leak that no amount of in-Worker verification could
+      // catch. Worker responses are not edge-cached by default, but a zone
+      // cache rule or an intermediary proxy could change that — so state the
+      // requirement rather than rely on the default. `Vary: Cookie` is
+      // belt-and-braces for any cache that ignores `private`/`no-store`.
+      "cache-control": "private, no-store",
+      vary: "Cookie",
+    },
+  });
+}
+
+/** `GET /` (issue #4795) — validate the visitor's Access JWT (the
+ * `CF_Authorization` cookie; see `./accessAuth.ts`'s module doc for why this
+ * is a cookie, not the `Cf-Access-Jwt-Assertion` header) and serve the
+ * matching dashboard variant. Fails CLOSED to the public variant on
+ * anything but a fully valid, correctly-audienced token — never a 500,
+ * never the full view on a doubtful token (this issue's core acceptance
+ * criterion). */
+async function handleRoot(request: Request, env: Env): Promise<Response> {
+  const identity = await validateAccessJwt(request.headers.get("cookie"), env);
+  return handleDashboardPage(env, identity !== null);
 }
 
 // ---------------------------------------------------------------------------
@@ -395,10 +456,22 @@ export default {
       return handleLiveTail(request, env, url, /* isAuthenticated */ false);
     }
     if (request.method === "GET" && url.pathname === "/public") {
-      return handlePublicPage(env);
+      // Issue #4795: the single-URL fallback layout replaced the separate
+      // public path — `/` now serves the same content (redacted, for an
+      // unauthenticated visitor). A permanent redirect keeps old
+      // bookmarks/links working without a second route to maintain.
+      return Response.redirect(new URL("/", request.url).toString(), 301);
+    }
+    if (request.method === "GET" && url.pathname === "/login") {
+      // Access-gated at the edge (config, not code — see
+      // docs/cloudflare-access.md). By the time this Worker code runs,
+      // Access has already minted the `CF_Authorization` session cookie;
+      // this route's only job is to bounce back to `/`, where that cookie
+      // gets validated.
+      return Response.redirect(new URL("/", request.url).toString(), 302);
     }
     if (request.method === "GET" && url.pathname === "/") {
-      return new Response("loom-observability-ingest: see /ingest, /admin/*, /api/*, /public/*", { status: 200 });
+      return handleRoot(request, env);
     }
     return jsonError(404, "not found");
   },

--- a/dashboard/src/publicPage.ts
+++ b/dashboard/src/publicPage.ts
@@ -1,17 +1,27 @@
 /**
- * The `/public` route's HTML page (Epic #4702, Phase 3, issue #4753).
+ * The dashboard HTML page (Epic #4702, Phase 3, issue #4753), rendered by
+ * `src/index.ts`'s root `/` handler in one of two variants (issue #4795 made
+ * `/` single-URL: the same route serves both, chosen by whether
+ * `accessAuth.ts` validated a visitor's Access JWT):
  *
- * Server-rendered from the exact same redacted data `GET /public/fleet-state`
- * and `GET /public/history` return — `src/index.ts`'s `handlePublicPage`
- * calls `redactFleetSnapshot`/`redactHistoryQueryResult` directly, in-process
- * (not over HTTP), so there is no code path by which this page could
- * accidentally source data from the authenticated `/api/*` surface. The
- * page's own inline script tails `GET /public/events` for live updates —
- * never `/api/*`. See `./redaction.ts`'s module doc for the redaction policy
- * this page renders faithfully rather than reimplements: this module MUST
- * NOT re-derive private/public status or attempt to reconstruct a stripped
+ * - **Public** (`options.isAuthenticated` falsy, the default): sourced from
+ *   the exact same redacted data `GET /public/fleet-state` and
+ *   `GET /public/history` return — the caller calls
+ *   `redactFleetSnapshot`/`redactHistoryQueryResult` directly, in-process
+ *   (not over HTTP), before handing data to this module, so there is no code
+ *   path by which this variant could accidentally source data from the
+ *   authenticated `/api/*` surface. Its inline script tails
+ *   `GET /public/events` for live updates.
+ * - **Authenticated** (`options.isAuthenticated: true`): the caller passes
+ *   the raw, unredacted snapshot/history straight through instead — see
+ *   `renderPublicPage`'s own doc for the exact contract. Its inline script
+ *   tails `GET /api/events` (full detail) instead.
+ *
+ * See `./redaction.ts`'s module doc for the redaction policy the public
+ * variant renders faithfully rather than reimplements: this module MUST NOT
+ * re-derive private/public status or attempt to reconstruct a stripped
  * field — it only ever formats fields that are already present on the
- * redacted objects it is handed.
+ * objects it is handed.
  *
  * ## Display allowlist: narrower than the wire allowlist, on purpose
  *
@@ -43,8 +53,8 @@
  * ## Read-only
  *
  * This page contains no `<form>`, no mutating `fetch`/`EventSource` call,
- * and no reference to `/admin/*` or `/ingest` — it only ever reads
- * `/public/*`.
+ * and no reference to `/admin/*` or `/ingest` — the public variant only ever
+ * reads `/public/*`; the authenticated variant only ever reads `/api/*`.
  */
 
 import type { HistoryQueryResult, HistoryRecord } from "./query";
@@ -195,7 +205,7 @@ export function renderHistoryTable(history: HistoryQueryResult): string {
  * the client never has to keep a hand-written allowlist in sync with this
  * module's. A `topic` (== record `kind`) missing from this object is
  * dropped by the `onmessage` handler before touching the DOM. */
-function renderLiveFeedScript(): string {
+function renderLiveFeedScript(eventsPath: string): string {
   const displayFields = JSON.stringify(PUBLIC_PAGE_DISPLAY_FIELDS);
   return `<script>
     (function () {
@@ -237,9 +247,9 @@ function renderLiveFeedScript(): string {
       if (!feed || typeof EventSource === "undefined") return;
 
       // Read-only: this is the ONLY network call the live feed makes — a GET
-      // against the public live-tail route, never the authenticated surface
-      // and never a mutation.
-      var source = new EventSource("/public/events");
+      // against the live-tail route matching this page's own auth state
+      // (never a mutation).
+      var source = new EventSource(${JSON.stringify(eventsPath)});
       source.onmessage = function (evt) {
         var payload;
         try {
@@ -283,31 +293,68 @@ const PAGE_STYLE = `
   section { margin-bottom: 2.5rem; }
 `;
 
+/** Options for {@link renderPublicPage} distinguishing the two callers that
+ * share this rendering: the always-public `/public` history (redirected
+ * from, pre-#4795) and the single-URL dashboard root `/` (issue #4795),
+ * which renders this same page in either its public or authenticated
+ * variant depending on whether `accessAuth.ts` validated a JWT. */
+export interface RenderPageOptions {
+  /** `true` once the caller has already verified the visitor's Access JWT
+   * (`src/accessAuth.ts`) — changes only the heading/subtitle copy below;
+   * it does NOT change what this function renders. The caller is entirely
+   * responsible for choosing redacted vs. unredacted `snapshot`/`history`
+   * to match this flag (see the function doc). */
+  isAuthenticated?: boolean;
+  /** Where the "Sign in" link (shown only when `isAuthenticated` is falsy)
+   * points. Defaults to `/login` (issue #4795's new Access-gated route). */
+  loginPath?: string;
+}
+
 /**
- * Render the full `/public` HTML document from already-redacted data.
- * `snapshot`/`history` MUST already have passed through
- * `redactFleetSnapshot`/`redactHistoryQueryResult` with `isAuthenticated:
- * false` — this function performs no redaction itself, only formatting, per
- * the module doc's single-enforcement-point rule (`redaction.ts` owns
- * redaction; this module owns display).
+ * Render the full dashboard HTML document — the public, redacted view when
+ * `options.isAuthenticated` is falsy/absent, or the full authenticated view
+ * when it is `true`. This function performs no redaction itself, only
+ * formatting, per the module doc's single-enforcement-point rule
+ * (`redaction.ts` owns redaction; this module owns display) — **callers are
+ * entirely responsible for the data/flag pairing**:
+ *
+ * - Public (`isAuthenticated` falsy): `snapshot`/`history` MUST already have
+ *   passed through `redactFleetSnapshot`/`redactHistoryQueryResult` with
+ *   `isAuthenticated: false`.
+ * - Authenticated (`isAuthenticated: true`): pass the raw, unredacted
+ *   snapshot/history straight from `fleetStateStub`/`queryHistory` — do NOT
+ *   redact first, or an authenticated operator would see the public view's
+ *   data despite the "Dashboard" heading.
  */
-export function renderPublicPage(snapshot: RedactedFleetSnapshot, history: HistoryQueryResult): string {
+export function renderPublicPage(
+  snapshot: RedactedFleetSnapshot,
+  history: HistoryQueryResult,
+  options: RenderPageOptions = {},
+): string {
+  const isAuthenticated = options.isAuthenticated ?? false;
+  const loginPath = options.loginPath ?? "/login";
+
+  const heading = isAuthenticated ? "Loom Fleet — Dashboard" : "Loom Fleet — Public View";
+  const subtitle = isAuthenticated
+    ? `<p class="subtitle">Signed in — full, unredacted fleet detail.</p>`
+    : `<p class="subtitle">
+    Unauthenticated, redacted snapshot of fleet activity. Private-repository
+    records show only aggregate lifecycle/timing detail — never a repo name,
+    issue, branch, or PR link.
+    <a href="${escapeHtml(loginPath)}">Sign in</a> for the full view.
+  </p>`;
+
   return `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Loom Fleet — Public View</title>
+  <title>${heading}</title>
   <style>${PAGE_STYLE}</style>
 </head>
 <body>
-  <h1>Loom Fleet — Public View</h1>
-  <p class="subtitle">
-    Unauthenticated, redacted snapshot of fleet activity. Private-repository
-    records show only aggregate lifecycle/timing detail — never a repo name,
-    issue, branch, or PR link. Data sourced exclusively from
-    <code>/public/*</code>.
-  </p>
+  <h1>${heading}</h1>
+  ${subtitle}
 
   ${renderFleetOverview(snapshot)}
   ${renderHistoryTable(history)}
@@ -320,7 +367,7 @@ export function renderPublicPage(snapshot: RedactedFleetSnapshot, history: Histo
     </table>
   </section>
 
-  ${renderLiveFeedScript()}
+  ${renderLiveFeedScript(isAuthenticated ? "/api/events" : "/public/events")}
 </body>
 </html>`;
 }

--- a/dashboard/test/accessAuth.test.ts
+++ b/dashboard/test/accessAuth.test.ts
@@ -1,0 +1,248 @@
+import { createLocalJWKSet, exportJWK, generateKeyPair, SignJWT, type JWTVerifyGetKey } from "jose";
+import { beforeAll, describe, expect, it } from "vitest";
+import { extractAccessCookie, parseAcceptedAudiences, validateAccessJwt } from "../src/accessAuth";
+
+const TEAM_DOMAIN = "test-team.cloudflareaccess.com";
+const AUD = "test-login-app-aud-tag";
+
+describe("extractAccessCookie", () => {
+  it("extracts the cookie's value from a well-formed Cookie header", () => {
+    expect(extractAccessCookie("CF_Authorization=abc.def.ghi")).toBe("abc.def.ghi");
+  });
+
+  it("finds the cookie among several others, in any position", () => {
+    expect(extractAccessCookie("foo=bar; CF_Authorization=the-token; baz=qux")).toBe("the-token");
+    expect(extractAccessCookie("CF_Authorization=the-token; foo=bar")).toBe("the-token");
+  });
+
+  it("returns null for a missing header", () => {
+    expect(extractAccessCookie(null)).toBeNull();
+  });
+
+  it("returns null when the cookie is absent", () => {
+    expect(extractAccessCookie("foo=bar; baz=qux")).toBeNull();
+  });
+
+  it("returns null for an empty cookie value", () => {
+    expect(extractAccessCookie("CF_Authorization=")).toBeNull();
+  });
+
+  it("tolerates irregular spacing", () => {
+    expect(extractAccessCookie("  CF_Authorization=the-token  ;  foo=bar")).toBe("the-token");
+  });
+});
+
+describe("parseAcceptedAudiences", () => {
+  it("parses one tag, several tags, and tolerates spacing", () => {
+    expect(parseAcceptedAudiences("aud-one")).toEqual(["aud-one"]);
+    expect(parseAcceptedAudiences("aud-one,aud-two")).toEqual(["aud-one", "aud-two"]);
+    expect(parseAcceptedAudiences(" aud-one , aud-two ")).toEqual(["aud-one", "aud-two"]);
+  });
+
+  it("yields an empty list — never an empty-string audience — for blank input", () => {
+    // An empty-string entry slipping into the allowlist would be a token
+    // with no `aud` matching the pin, i.e. a fail-open.
+    expect(parseAcceptedAudiences(undefined)).toEqual([]);
+    expect(parseAcceptedAudiences("")).toEqual([]);
+    expect(parseAcceptedAudiences("   ")).toEqual([]);
+    expect(parseAcceptedAudiences(",,")).toEqual([]);
+    expect(parseAcceptedAudiences("aud-one,,")).toEqual(["aud-one"]);
+  });
+});
+
+describe("validateAccessJwt", () => {
+  let privateKey: CryptoKey;
+  let jwksResolver: (teamDomain: string) => JWTVerifyGetKey;
+  let unreachableResolver: (teamDomain: string) => JWTVerifyGetKey;
+
+  beforeAll(async () => {
+    const keyPair = await generateKeyPair("RS256");
+    privateKey = keyPair.privateKey;
+    const jwk = await exportJWK(keyPair.publicKey);
+    const localJwks = createLocalJWKSet({ keys: [{ ...jwk, alg: "RS256" }] });
+    jwksResolver = () => localJwks;
+    // Simulates a JWKS endpoint that is unreachable (network failure) — the
+    // resolver itself throws synchronously, same failure shape a thrown
+    // fetch rejection inside `createRemoteJWKSet`'s resolver would produce.
+    unreachableResolver = () => {
+      throw new Error("simulated JWKS fetch failure");
+    };
+  });
+
+  async function signToken(overrides: {
+    aud?: string;
+    iss?: string;
+    expiresIn?: string;
+    email?: string;
+  } = {}): Promise<string> {
+    return new SignJWT({ email: overrides.email ?? "operator@2amlogic.com" })
+      .setProtectedHeader({ alg: "RS256" })
+      .setIssuedAt()
+      .setIssuer(overrides.iss ?? `https://${TEAM_DOMAIN}`)
+      .setAudience(overrides.aud ?? AUD)
+      .setExpirationTime(overrides.expiresIn ?? "10m")
+      .sign(privateKey);
+  }
+
+  const env = { CF_ACCESS_TEAM_DOMAIN: TEAM_DOMAIN, CF_ACCESS_AUD: AUD };
+
+  it("accepts a validly signed token with the correct aud/iss, resolving the identity", async () => {
+    const token = await signToken();
+    const result = await validateAccessJwt(`CF_Authorization=${token}`, env, jwksResolver);
+    expect(result).toEqual({ email: "operator@2amlogic.com", sub: undefined });
+  });
+
+  it("rejects (falls back to public — returns null) a token with the wrong aud", async () => {
+    const token = await signToken({ aud: "some-other-apps-aud-tag" });
+    const result = await validateAccessJwt(`CF_Authorization=${token}`, env, jwksResolver);
+    expect(result).toBeNull();
+  });
+
+  it("rejects a token with the wrong issuer", async () => {
+    const token = await signToken({ iss: "https://someone-elses-team.cloudflareaccess.com" });
+    const result = await validateAccessJwt(`CF_Authorization=${token}`, env, jwksResolver);
+    expect(result).toBeNull();
+  });
+
+  it("rejects an expired token", async () => {
+    const token = await signToken({ expiresIn: "-10m" });
+    const result = await validateAccessJwt(`CF_Authorization=${token}`, env, jwksResolver);
+    expect(result).toBeNull();
+  });
+
+  it("rejects a malformed/garbage cookie value without throwing", async () => {
+    await expect(
+      validateAccessJwt("CF_Authorization=not-a-jwt-at-all", env, jwksResolver),
+    ).resolves.toBeNull();
+  });
+
+  it("rejects a missing cookie", async () => {
+    const result = await validateAccessJwt(null, env, jwksResolver);
+    expect(result).toBeNull();
+    const resultNoCookieHeader = await validateAccessJwt("foo=bar", env, jwksResolver);
+    expect(resultNoCookieHeader).toBeNull();
+  });
+
+  it("fails closed (null, not a throw) when the JWKS endpoint is unreachable", async () => {
+    const token = await signToken();
+    await expect(
+      validateAccessJwt(`CF_Authorization=${token}`, env, unreachableResolver),
+    ).resolves.toBeNull();
+  });
+
+  it("fails closed when CF_ACCESS_TEAM_DOMAIN is not configured", async () => {
+    const token = await signToken();
+    const result = await validateAccessJwt(`CF_Authorization=${token}`, { CF_ACCESS_AUD: AUD }, jwksResolver);
+    expect(result).toBeNull();
+  });
+
+  it("fails closed when CF_ACCESS_AUD is not configured", async () => {
+    const token = await signToken();
+    const result = await validateAccessJwt(
+      `CF_Authorization=${token}`,
+      { CF_ACCESS_TEAM_DOMAIN: TEAM_DOMAIN },
+      jwksResolver,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("accepts a token audienced for any tag in a comma-separated CF_ACCESS_AUD", async () => {
+    // One hostname, several path-scoped Access apps, one cookie name: the
+    // browser can hold a token minted by whichever app it most recently
+    // traversed. Both configured tags must unlock the root.
+    const multiAudEnv = { CF_ACCESS_TEAM_DOMAIN: TEAM_DOMAIN, CF_ACCESS_AUD: `${AUD},api-app-aud-tag` };
+
+    const loginToken = await signToken();
+    await expect(validateAccessJwt(`CF_Authorization=${loginToken}`, multiAudEnv, jwksResolver)).resolves.toEqual({
+      email: "operator@2amlogic.com",
+      sub: undefined,
+    });
+
+    const apiToken = await signToken({ aud: "api-app-aud-tag" });
+    await expect(validateAccessJwt(`CF_Authorization=${apiToken}`, multiAudEnv, jwksResolver)).resolves.toEqual({
+      email: "operator@2amlogic.com",
+      sub: undefined,
+    });
+  });
+
+  it("still rejects a tag that is NOT in the configured list", async () => {
+    const multiAudEnv = { CF_ACCESS_TEAM_DOMAIN: TEAM_DOMAIN, CF_ACCESS_AUD: `${AUD},api-app-aud-tag` };
+    const token = await signToken({ aud: "somebody-elses-app-aud-tag" });
+    await expect(validateAccessJwt(`CF_Authorization=${token}`, multiAudEnv, jwksResolver)).resolves.toBeNull();
+  });
+
+  it("fails closed when CF_ACCESS_AUD is present but blank", async () => {
+    const token = await signToken();
+    const result = await validateAccessJwt(
+      `CF_Authorization=${token}`,
+      { CF_ACCESS_TEAM_DOMAIN: TEAM_DOMAIN, CF_ACCESS_AUD: " , " },
+      jwksResolver,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("rejects a well-formed token signed by somebody else's key", async () => {
+    // Every claim is correct — issuer, audience, expiry — and only the
+    // signature is wrong. This is the check that proves verification is
+    // actually cryptographic and not just claim-shape inspection: forge a
+    // token with the right `aud` and it must still be refused.
+    const attackerKeys = await generateKeyPair("RS256");
+    const forged = await new SignJWT({ email: "attacker@example.com" })
+      .setProtectedHeader({ alg: "RS256" })
+      .setIssuedAt()
+      .setIssuer(`https://${TEAM_DOMAIN}`)
+      .setAudience(AUD)
+      .setExpirationTime("10m")
+      .sign(attackerKeys.privateKey);
+
+    const result = await validateAccessJwt(`CF_Authorization=${forged}`, env, jwksResolver);
+    expect(result).toBeNull();
+  });
+
+  it("rejects an unsigned (alg: none) token", async () => {
+    // `jose` refuses to *produce* an `alg: none` JWS, so hand-assemble one:
+    // header + payload + empty signature, the classic algorithm-confusion
+    // forgery. `validateAccessJwt` pins `algorithms: ["RS256"]` on top of
+    // jose's own refusal to accept `none`.
+    const b64 = (obj: unknown) =>
+      btoa(JSON.stringify(obj)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    const unsigned = `${b64({ alg: "none", typ: "JWT" })}.${b64({
+      email: "attacker@example.com",
+      iss: `https://${TEAM_DOMAIN}`,
+      aud: AUD,
+      exp: Math.floor(Date.now() / 1000) + 600,
+    })}.`;
+
+    await expect(validateAccessJwt(`CF_Authorization=${unsigned}`, env, jwksResolver)).resolves.toBeNull();
+  });
+
+  it("rejects a token whose header claims a symmetric algorithm (alg confusion)", async () => {
+    // HS256-signed with the RSA public key's raw bytes as the MAC secret —
+    // the textbook RS256→HS256 confusion attack. Must be refused both
+    // because the JWKS holds no symmetric key and because HS256 is not in
+    // the accepted-algorithms list.
+    const b64 = (obj: unknown) =>
+      btoa(JSON.stringify(obj)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    const confused = `${b64({ alg: "HS256", typ: "JWT" })}.${b64({
+      email: "attacker@example.com",
+      iss: `https://${TEAM_DOMAIN}`,
+      aud: AUD,
+      exp: Math.floor(Date.now() / 1000) + 600,
+    })}.bm90LWEtcmVhbC1tYWM`;
+
+    await expect(validateAccessJwt(`CF_Authorization=${confused}`, env, jwksResolver)).resolves.toBeNull();
+  });
+
+  it("resolves the sub claim when the token carries one", async () => {
+    const token = await new SignJWT({ email: "operator@2amlogic.com", sub: "user-123" })
+      .setProtectedHeader({ alg: "RS256" })
+      .setIssuedAt()
+      .setIssuer(`https://${TEAM_DOMAIN}`)
+      .setAudience(AUD)
+      .setExpirationTime("10m")
+      .setSubject("user-123")
+      .sign(privateKey);
+    const result = await validateAccessJwt(`CF_Authorization=${token}`, env, jwksResolver);
+    expect(result).toEqual({ email: "operator@2amlogic.com", sub: "user-123" });
+  });
+});

--- a/dashboard/test/index.test.ts
+++ b/dashboard/test/index.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Route-level integration tests for the single-URL dashboard root (issue
+ * #4795): `GET /` end to end through the real Worker, exercising the
+ * *production* `validateAccessJwt` wiring in `src/index.ts` — i.e. the
+ * default `createRemoteJWKSet`-backed resolver, not the injectable resolver
+ * `test/accessAuth.test.ts` uses for its unit coverage. The JWKS HTTP fetch
+ * itself is mocked (see `mockJwksFetch` below) so this suite never makes a
+ * real network call, but every other step (cookie parsing, signature/aud/
+ * iss/expiry verification, the route's authenticated-vs-public branch) runs
+ * for real.
+ */
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import worker from "../src/index";
+import { seedHost, sweepOutcomeEnvelope } from "./testHelpers";
+
+// Matches the `CF_ACCESS_TEAM_DOMAIN`/`CF_ACCESS_AUD` test bindings in
+// vitest.config.ts.
+const TEAM_DOMAIN = "test-team.cloudflareaccess.com";
+const AUD = "test-login-app-aud-tag";
+const CERTS_URL = `https://${TEAM_DOMAIN}/cdn-cgi/access/certs`;
+
+async function callWorker(request: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(request as Request<unknown, IncomingRequestCfProperties>, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
+let privateKey: CryptoKey;
+let jwks: { keys: Record<string, unknown>[] };
+
+beforeAll(async () => {
+  const keyPair = await generateKeyPair("RS256");
+  privateKey = keyPair.privateKey;
+  const jwk = await exportJWK(keyPair.publicKey);
+  jwks = { keys: [{ ...jwk, alg: "RS256" }] };
+});
+
+/** Intercept only the JWKS certs URL; every other fetch (D1/DO bindings
+ * don't go through `fetch`, so in practice nothing else calls this) passes
+ * through to the real global fetch. */
+function mockJwksFetch(): () => void {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (url === CERTS_URL) {
+      return new Response(JSON.stringify(jwks), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    return realFetch(input as never, init as never);
+  }) as typeof fetch;
+  return () => {
+    globalThis.fetch = realFetch;
+  };
+}
+
+async function signToken(overrides: { aud?: string; expiresIn?: string } = {}): Promise<string> {
+  return new SignJWT({ email: "operator@2amlogic.com" })
+    .setProtectedHeader({ alg: "RS256" })
+    .setIssuedAt()
+    .setIssuer(`https://${TEAM_DOMAIN}`)
+    .setAudience(overrides.aud ?? AUD)
+    .setExpirationTime(overrides.expiresIn ?? "10m")
+    .sign(privateKey);
+}
+
+/** The private-repo fixture below must never appear on the public variant of
+ * `/` and must appear on the authenticated one — that pairing is what proves
+ * the root route's branch actually swaps redacted for unredacted data, not
+ * just the page's heading. */
+const PRIVATE_REPO = "rjwalters/root-route-private-repo";
+const PRIVATE_SWEEP_ID = "sweep-issue-7777-0";
+
+async function ingestPrivateRecord(): Promise<void> {
+  const response = await callWorker(
+    new Request("https://ingest.example/ingest", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer root-route-ingest-key" },
+      body: JSON.stringify([
+        sweepOutcomeEnvelope({
+          visibility: "private",
+          repo: PRIVATE_REPO,
+          issue: 7777,
+          sweep_id: PRIVATE_SWEEP_ID,
+        }),
+      ]),
+    }),
+  );
+  expect(response.status).toBe(200);
+}
+
+describe("GET / — Access JWT wired end to end (real createRemoteJWKSet path)", () => {
+  let restoreFetch: () => void;
+
+  beforeEach(async () => {
+    await seedHost(env.DB, "host-abc", "root-route-ingest-key");
+  });
+
+  afterEach(() => {
+    restoreFetch?.();
+  });
+
+  // NOTE on ordering: `src/accessAuth.ts` caches one `createRemoteJWKSet`
+  // resolver **per team domain per isolate** (deliberately — see its module
+  // doc) so this file's tests share it across `it` blocks, same as
+  // production sharing it across requests. That means "the JWKS fetch
+  // fails" MUST run before any test that lets a fetch succeed for this team
+  // domain — a successful fetch caches valid keys for the resolver's
+  // `cacheMaxAge`, which would make a later simulated-failure fetch
+  // irrelevant (the resolver would just serve its already-cached keys,
+  // proving nothing). Run in this declared order (vitest runs an `it` block
+  // in declaration order by default; do not mark these `.concurrent`).
+  it("a JWKS fetch failure (simulated network error) fails closed to the public view, not a 500", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url === CERTS_URL) throw new Error("simulated network failure");
+      return realFetch(input as never);
+    }) as typeof fetch;
+    restoreFetch = () => {
+      globalThis.fetch = realFetch;
+    };
+    const token = await signToken();
+
+    const response = await callWorker(
+      new Request("https://ingest.example/", { headers: { cookie: `CF_Authorization=${token}` } }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("Public View");
+  });
+
+  it("a valid, correctly-audienced CF_Authorization cookie renders the authenticated dashboard", async () => {
+    restoreFetch = mockJwksFetch();
+    const token = await signToken();
+
+    const response = await callWorker(
+      new Request("https://ingest.example/", { headers: { cookie: `CF_Authorization=${token}` } }),
+    );
+
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain("Dashboard");
+    expect(html).not.toContain("Sign in");
+    expect(html).toContain("/api/events");
+  });
+
+  it("the authenticated variant serves UNREDACTED data the public variant withholds", async () => {
+    restoreFetch = mockJwksFetch();
+    await ingestPrivateRecord();
+
+    const anonymous = await callWorker(new Request("https://ingest.example/"));
+    const anonymousHtml = await anonymous.text();
+    expect(anonymousHtml).not.toContain(PRIVATE_REPO);
+    expect(anonymousHtml).not.toContain(PRIVATE_SWEEP_ID);
+
+    const token = await signToken();
+    const authenticated = await callWorker(
+      new Request("https://ingest.example/", { headers: { cookie: `CF_Authorization=${token}` } }),
+    );
+    const authenticatedHtml = await authenticated.text();
+    expect(authenticatedHtml).toContain(PRIVATE_REPO);
+  });
+
+  it("never lets a shared cache store either variant of / under one URL", async () => {
+    // `/` returns two different bodies for the same URL depending on a
+    // cookie. A cache that stored the authenticated body and replayed it to
+    // an anonymous visitor would leak private-repo data past every check in
+    // this file, so both variants must be explicitly uncacheable.
+    restoreFetch = mockJwksFetch();
+    const token = await signToken();
+
+    for (const request of [
+      new Request("https://ingest.example/"),
+      new Request("https://ingest.example/", { headers: { cookie: `CF_Authorization=${token}` } }),
+    ]) {
+      const response = await callWorker(request);
+      expect(response.headers.get("cache-control")).toBe("private, no-store");
+      expect(response.headers.get("vary")).toBe("Cookie");
+    }
+  });
+
+  it("a wrong-aud token still falls back to the public view (never the full view, never a 500)", async () => {
+    restoreFetch = mockJwksFetch();
+    const token = await signToken({ aud: "some-other-apps-aud-tag" });
+
+    const response = await callWorker(
+      new Request("https://ingest.example/", { headers: { cookie: `CF_Authorization=${token}` } }),
+    );
+
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain("Public View");
+    expect(html).toContain("Sign in");
+  });
+
+  it("an expired token falls back to the public view", async () => {
+    restoreFetch = mockJwksFetch();
+    const token = await signToken({ expiresIn: "-10m" });
+
+    const response = await callWorker(
+      new Request("https://ingest.example/", { headers: { cookie: `CF_Authorization=${token}` } }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("Public View");
+  });
+});

--- a/dashboard/test/publicPage.test.ts
+++ b/dashboard/test/publicPage.test.ts
@@ -276,8 +276,11 @@ describe("renderPublicPage — full document", () => {
 });
 
 // ---------------------------------------------------------------------------
-// End-to-end: the actual GET /public route, through the real Worker + D1 +
-// Durable Object, mirroring test/redaction.test.ts's integration style.
+// End-to-end: the actual GET / (and GET /public redirect) routes, through
+// the real Worker + D1 + Durable Object, mirroring test/redaction.test.ts's
+// integration style. Issue #4795 moved the always-rendered public page from
+// `/public` to `/` (with an authenticated variant alongside it, covered in
+// index.test.ts) — `/public` itself now only 301s.
 // ---------------------------------------------------------------------------
 
 async function callWorker(request: Request): Promise<Response> {
@@ -303,11 +306,36 @@ beforeEach(async () => {
   await seedHost(env.DB, "host-abc", "abc-ingest-key");
 });
 
-describe("GET /public — end to end", () => {
+describe("GET /public — redirects to /", () => {
+  it("301s to /", async () => {
+    const response = await callWorker(new Request("https://ingest.example/public", { redirect: "manual" }));
+    expect(response.status).toBe(301);
+    expect(response.headers.get("location")).toBe("https://ingest.example/");
+  });
+});
+
+describe("GET /login — bounces back to /", () => {
+  // Access itself gates this path at the edge (config, not code), so by the
+  // time the Worker sees the request the session cookie already exists —
+  // all the route owes the visitor is a trip back to `/`.
+  it("302s to /", async () => {
+    const response = await callWorker(new Request("https://ingest.example/login", { redirect: "manual" }));
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("https://ingest.example/");
+  });
+});
+
+describe("GET / — end to end (anonymous, public fallback)", () => {
   it("serves an HTML page reachable without authentication", async () => {
-    const response = await callWorker(new Request("https://ingest.example/public"));
+    const response = await callWorker(new Request("https://ingest.example/"));
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("text/html");
+  });
+
+  it("includes a Sign in link pointing at /login", async () => {
+    const response = await callWorker(new Request("https://ingest.example/"));
+    const html = await response.text();
+    expect(html).toContain('href="/login"');
   });
 
   it("a private sweep.outcome record's repo/issue/sweep_id never appear on the rendered page", async () => {
@@ -320,7 +348,7 @@ describe("GET /public — end to end", () => {
       }),
     ]);
 
-    const response = await callWorker(new Request("https://ingest.example/public"));
+    const response = await callWorker(new Request("https://ingest.example/"));
     const html = await response.text();
     expect(html).not.toContain("rjwalters/e2e-private-repo");
     expect(html).not.toContain("sweep-issue-8888-0");
@@ -330,7 +358,7 @@ describe("GET /public — end to end", () => {
   it("a public sweep.started record's repo/issue appear on the rendered page (full detail)", async () => {
     await ingest([sweepStartedEnvelope({ visibility: "public", repo: "rjwalters/loom", issue: 4703 })]);
 
-    const response = await callWorker(new Request("https://ingest.example/public"));
+    const response = await callWorker(new Request("https://ingest.example/"));
     const html = await response.text();
     expect(html).toContain("rjwalters/loom");
     expect(html).toContain("#4703");
@@ -339,8 +367,17 @@ describe("GET /public — end to end", () => {
   it("tokens.snapshot's account identifiers never appear on the rendered page", async () => {
     await ingest([tokensSnapshotEnvelope({ accounts: [{ account: "e2e-secret-account", rank: 0, usage_fraction: 0.5, exhausted: false }] })]);
 
-    const response = await callWorker(new Request("https://ingest.example/public"));
+    const response = await callWorker(new Request("https://ingest.example/"));
     const html = await response.text();
     expect(html).not.toContain("e2e-secret-account");
+  });
+
+  it("a garbage CF_Authorization cookie still falls back to the public view, never a 500", async () => {
+    const response = await callWorker(
+      new Request("https://ingest.example/", { headers: { cookie: "CF_Authorization=not-a-real-jwt" } }),
+    );
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain("Public View");
   });
 });

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -24,6 +24,13 @@ export default defineWorkersConfig(async () => {
               // runtime so admin-route tests have something deterministic
               // to authenticate against.
               ADMIN_TOKEN: "test-admin-token",
+              // Single-URL dashboard root (issue #4795, src/accessAuth.ts).
+              // Fixed test-only values so `GET /` integration tests can
+              // exercise the authenticated branch — see test/index.test.ts,
+              // which signs a JWT for this exact team domain/aud and mocks
+              // the JWKS fetch to this exact team domain's certs URL.
+              CF_ACCESS_TEAM_DOMAIN: "test-team.cloudflareaccess.com",
+              CF_ACCESS_AUD: "test-login-app-aud-tag",
             },
           },
         },

--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -97,6 +97,31 @@ new_sqlite_classes = ["FleetState"]
 RETENTION_DAYS = "90"
 MAX_RECORDS = "500000"
 
+# CHANGE ME (both, together) — required only if you want the single-URL
+# fallback layout (docs/cloudflare-access.md): anonymous visitors to `/` see
+# the public view, a `2amlogic.com`-style Access identity sees the full
+# dashboard. Leave both commented out to run `/` as always-public (the
+# Worker fails closed — no team domain/AUD configured means every request is
+# treated as unauthenticated, never the other way around).
+#
+#   CF_ACCESS_TEAM_DOMAIN — your team's Cloudflare Access domain, e.g.
+#     "yourteam.cloudflareaccess.com" (Zero Trust dashboard → Settings →
+#     Custom Pages, or any Access app's overview page shows it). Used to
+#     build the JWKS URL (".../cdn-cgi/access/certs") and the expected `iss`.
+#   CF_ACCESS_AUD — the Application Audience (AUD) tag of the `/login`
+#     Access application, shown on that app's overview page. Pins JWT
+#     acceptance to tokens minted for apps you named here — neither value is
+#     a secret. Accepts a COMMA-SEPARATED LIST: Access names the session
+#     cookie per hostname but mints the token per application, so a browser
+#     on a hostname running several path-scoped apps may hold the `/api/*`
+#     app's token instead of `/login`'s. List every app on this hostname
+#     whose session should count as signed-in (typically `/login` and
+#     `/api/*`) or an already-signed-in operator flaps back to the public
+#     view — see src/accessAuth.ts's module doc.
+#
+# CF_ACCESS_TEAM_DOMAIN = "REPLACE_WITH_YOUR_TEAM.cloudflareaccess.com"
+# CF_ACCESS_AUD = "REPLACE_WITH_YOUR_LOGIN_APP_AUD_TAG,REPLACE_WITH_YOUR_API_APP_AUD_TAG"
+
 # Runs the retention sweep hourly. `wrangler dev` does not fire this on a
 # real clock; trigger it directly in tests / via the admin endpoint instead
 # (see src/index.ts `/admin/retention/run`).


### PR DESCRIPTION
## Summary

Cloudflare Access cannot express "try to authenticate, otherwise serve
something else" — an Allow application always forces a login. So the deployed
layout split the dashboard into a hard-gated root (`/` → SSO wall, dead-ending
non-org visitors) and a separate open `/public` path. This moves the decision
into the Worker: **one URL**, where an allowed identity sees the full dashboard
and everyone else falls back to the redacted public view with a Sign in link.

This is the Worker's first cryptographic-verification code path, so the
load-bearing property is **fail-closed**: every failure mode — no cookie,
malformed/garbage token, wrong `aud`, wrong `iss`, expired, forged signature,
`alg: none`, alg confusion, unreachable JWKS — renders the public view. Never a
500, never the full view on a doubtful token.

Related: #4801 (reference-deployment Access layout doc) — write it against this
layout, which is now the primary one documented in `cloudflare-access.md`.

## Changes

- **`dashboard/src/accessAuth.ts` (new)** — validates the `CF_Authorization`
  cookie against `https://<team>/cdn-cgi/access/certs` via `jose`, pinning
  `iss`, `alg` (RS256 only), and `aud`. Returns an identity or `null`; never
  throws. JWKS resolver cached per team domain per isolate. Kept separate from
  `src/auth.ts` (per-host ingest-key hashing — a different trust boundary).
- **`GET /`** — full unredacted dashboard for a validated identity, redacted
  public page with a Sign in link otherwise. 200 either way, no redirect.
  `Cache-Control: private, no-store` + `Vary: Cookie` so no shared cache can
  replay the authenticated body to an anonymous visitor.
- **`GET /login`** — 302 back to `/` (Access does the real work at the edge).
  **`GET /public`** — 301 to `/` for old bookmarks.
- **`dashboard/src/publicPage.ts`** — renders either variant from the same
  code; tails `/api/events` when authenticated, `/public/events` when not.
  Redaction still happens entirely in `redaction.ts` at the caller.
- **`CF_ACCESS_TEAM_DOMAIN` / `CF_ACCESS_AUD`** — new non-secret `[vars]`.
  Both unset ⇒ `/` is always public (fails closed).
- **Docs** — `cloudflare-access.md` rewritten around the single-URL layout
  (§2/§2a/§3b–§3e/§4/§5/§6), split-path layout demoted to a variant note;
  `README.md`, `docs/query-api.md`, `docs/deploy-runbook.md` corrected where
  they claimed in-Worker Access JWT verification was out of scope or showed the
  old static-text root response.

`/ingest` and `/admin/*` handlers are untouched.

### Two security findings the design surfaced (worth a reviewer's attention)

1. **Narrowing the root Access app to `/login` alone would leave `/api/*`
   matched by no Access application** — i.e. the full unredacted query API
   would become world-readable. The re-plumb therefore gives `/api/*` its own
   Allow application (§3e), with a pitfalls-table row and a `query-api.md`
   cross-reference so nobody replays the naive version of the config change.
2. **`CF_ACCESS_AUD` accepts a comma-separated allowlist.** Access names the
   session cookie `CF_Authorization` per *hostname* but mints the token per
   *application*, so once the authenticated page opens its `/api/events` live
   tail the browser can be holding the `/api/*` app's token. Pinning to the
   `/login` AUD alone would flap a just-signed-in operator back to the public
   view. This is still a pin — only enumerated tags are accepted, and a
   blank/whitespace-only value is treated as *unconfigured* (public view), never
   as "accept anything".

## Acceptance Criteria Verification

- [x] **Anonymous `/` renders the redacted public view (200, no redirect) with a
  Sign in link** — `test/publicPage.test.ts`: 200 + `text/html`, `href="/login"`
  present, private repo/sweep-id/account identifiers absent.
- [x] **`/login` → SSO → redirect to `/` renders the full view for an allowed
  identity** — `/login` 302→`/` covered by test; the authenticated render is
  covered end to end in `test/index.test.ts` (valid token ⇒ "Dashboard" heading,
  no Sign in link, `/api/events` feed, and the private-repo fixture *visible*,
  proving the branch really serves unredacted data). The live SSO bounce itself
  is edge config — operator verification, see below.
- [x] **Wrong aud / expired / garbage cookie falls back to public (never 500,
  never full view)** — covered at both levels: unit (`test/accessAuth.test.ts`)
  and route (`test/index.test.ts`), plus forged-signature, `alg: none`,
  alg-confusion, unreachable-JWKS, and unconfigured-vars cases.
- [x] **`/ingest` + `/admin` behavior byte-identical** — no handler changes;
  existing `ingest.test.ts` / `admin.test.ts` suites pass unmodified.
- [x] **`/public` 301s to `/`** — asserted with `redirect: "manual"`, including
  the exact `Location`.
- [x] **Access-app changes documented in `dashboard/docs/cloudflare-access.md`
  as the new reference layout** — single-URL layout is §2 (primary); split-path
  layout is §2a (variant note).
- [ ] **Deployed to the reference account and verified live** — *operator
  action, deliberately not done from this PR.* The reference deployment's
  Cloudflare credentials are machine-local (per #4801) and this code is not yet
  reviewed/merged; deploying unreviewed auth code to a live deployment is the
  wrong order. Post-merge checklist is in `cloudflare-access.md` §4 (`/` ⇒ 200
  not 302, `/public` ⇒ 301, `/ingest` ⇒ 401 not 302, plus the operator's own SSO
  round trip).

## Test Plan

```
$ npx vitest run test/accessAuth.test.ts test/index.test.ts test/publicPage.test.ts
 ✓ test/index.test.ts (6 tests)
 ✓ test/publicPage.test.ts (21 tests)
 ✓ test/accessAuth.test.ts (24 tests)
 Test Files  3 passed (3)
      Tests  51 passed (51)

$ npm run typecheck      # tsc --noEmit — clean
$ npx wrangler deploy --dry-run
 Total Upload: 81.50 KiB / gzip: 20.46 KiB    # jose bundles for workerd fine
```

**Pre-existing failures, not caused by this PR**: `npm test` at the dashboard
root also picks up `dashboard/web/test/*` (a separate package with its own
jsdom vitest config), where 19 tests fail with `ReferenceError: document is not
defined`. Verified identical on unmodified `main` (`npx vitest run
web/test/outcomesChartView.test.ts` fails the same way there). Backend suite
totals went 186 → 192 passing with the same 19 pre-existing failures.

`npm run preflight` reports its usual template-placeholder error
(`database_id` is the committed all-zeros placeholder) — also pre-existing and
by design for the template; the `wrangler deploy --dry-run` step within it
passes.

Closes #4795
