### PR TITLE
ci: run mcp-loom vitest suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
           node-version: "20"
       - name: Build unified MCP server
         run: cd mcp-loom && npm install && npm run build
+      - name: Run MCP server test suite
+        run: cd mcp-loom && npm test
       - name: Verify build output
         run: test -f mcp-loom/dist/index.js
 


### PR DESCRIPTION
## Summary
- The "MCP Server Build" CI job type-checked `mcp-loom/src/**` via `tsc --noEmit` (part of `npm run build`) but never ran `npm test`, so vitest assertions in the 3 `*.test.ts` files never executed in CI.
- Adds a `Run MCP server test suite` step (`cd mcp-loom && npm test`) after the existing build step, gated by the same job-level `if: needs.changes.outputs.mcp == 'true'` condition already applied to the whole job — no per-step gating needed since the job itself is gated.

## Test plan
- [x] `cd mcp-loom && npm install && npm test` locally — 5 test files, 51 tests, all passing.
- [x] `cd mcp-loom && npm run build` still succeeds and produces `dist/index.js`.
- [x] Diff limited to the single new step in `.github/workflows/ci.yml`.

Closes #4603

🤖 Generated with [Claude Code](https://claude.com/claude-code)