### PR TITLE
ci: switch backend-tests to cargo nextest (#4559)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -25,21 +25,6 @@
 # See `loom-daemon/src/lib.rs` (crate-level "Test isolation convention" docs) for
 # the author-facing version of this contract.
 #
-# ONE OPERATOR STEP STILL OUTSTANDING -> #4559 (2026-07-30, #4385)
-#
-# The `backend-tests` job in `.github/workflows/ci.yml` still invokes plain
-# `cargo test --workspace`, so CI is still exposed to the race described above and
-# this file is live for local `cargo nextest run` only. Flipping the job could not
-# be committed with #4385: GitHub refuses any push *or* Contents-API write that
-# touches `.github/workflows/**` unless the credential carries the `workflow` scope
-# (fine-grained PAT: "Workflows: write"), and the automation account's token does
-# not (both paths were tried and rejected — see #4559 for the transcripts and the
-# exact two-hunk replacement). A maintainer with `gh auth refresh -s workflow`
-# applies it in one commit.
-#
-# When that lands, delete this block *and* the matching `<div class="warning">`
-# note in `loom-daemon/src/lib.rs`'s crate docs in the same commit.
-#
 # A SECOND FAILURE CLASS THIS FILE ALSO CLOSES -> #4561 (2026-07-30)
 #
 # A #4494 Doctor verification pass on PR #4543 hit a Tokio-runtime-context test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
+              - '.config/nextest.toml'
               - '.github/workflows/ci.yml'
             mcp:
               - 'mcp-loom/**'
@@ -67,7 +68,23 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --workspace
+      # Per-test process isolation (#4385). The daemon suite mutates the process
+      # environment at ~774 call sites while other tests in the same binary
+      # `Command::spawn` children; `Command::spawn` reads the environ
+      # non-atomically, so those two classes raced and produced intermittent
+      # failures in hermetic, untouched tests (2026-07-29: pipeline_snapshot on
+      # PR #4305, then quarantine_reconciliation on PR #4320). `#[serial]` only
+      # serializes *marked* tests against each other, so it never closed that
+      # window. nextest runs each test in its own process, which closes it by
+      # construction. Tests whose shared state is genuinely cross-process (the
+      # host-global `tmux -L loom` server) are serialized by the
+      # `daemon-integration` test group in `.config/nextest.toml`.
+      - uses: taiki-e/install-action@nextest
+      - name: Run tests (process-per-test)
+        run: cargo nextest run --workspace --profile ci
+      # nextest does not run doctests, so libtest still owns those (#4385).
+      - name: Run doctests
+        run: cargo test --workspace --doc
 
   mcp-build:
     name: MCP Server Build

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -41,16 +41,6 @@
 //! a separate `cargo test --workspace --doc` invocation, since nextest does not
 //! run them.
 //!
-//! <div class="warning">
-//!
-//! The `backend-tests` CI job has **not** been switched over yet: the workflow
-//! edit needs a credential with GitHub's `workflow` scope, which the automation
-//! account lacks. Tracked in #4559, with the rationale at the top of
-//! `.config/nextest.toml` (#4385). Treat the rules below as the standing
-//! convention regardless — they are what makes the switch a no-op when it lands.
-//!
-//! </div>
-//!
 //! ## What you should do
 //!
 //! * **Prefer `cargo nextest run` for full-suite local runs.** Plain `cargo


### PR DESCRIPTION
## Summary

Deferred operator step from #4385 (PR #4560/dd89e0c2) — everything nextest-related was implemented and merged except the actual CI workflow flip, which required a credential with GitHub's `workflow` OAuth scope. That scope is now present on the automation account's token, so this closes the gap.

- `.github/workflows/ci.yml`:
  - `changes` job's `backend` paths filter now includes `.config/nextest.toml`.
  - `backend-tests` job installs `taiki-e/install-action@nextest` and runs `cargo nextest run --workspace --profile ci`, plus a separate `cargo test --workspace --doc` step (nextest doesn't run doctests).
- `.config/nextest.toml`: deleted the "ONE OPERATOR STEP STILL OUTSTANDING -> #4559" comment block (now resolved).
- `loom-daemon/src/lib.rs`: deleted the matching `<div class="warning">` doc-comment block noting the CI job hadn't switched over yet.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML well-formed
- [x] `cargo check --workspace` — passes
- [x] `cargo doc --workspace --no-deps` — builds clean (only pre-existing unrelated warnings)
- [x] `cargo nextest --version` available locally (0.9.140)
- [x] Verified no remaining `#4559` references in the three edited files
- [x] This PR's own CI run on `backend-tests` will be the first live exercise of `cargo nextest run --workspace --profile ci` in Actions

Closes #4559