### PR TITLE
fix(tests): guard --json command substitution in test-spawn-generic.sh

### DIFF
--- a/defaults/scripts/tests/test-spawn-generic.sh
+++ b/defaults/scripts/tests/test-spawn-generic.sh
@@ -388,7 +388,9 @@ assert_eq "0" "$auditor_rc" \
 # --json decision surface (#4494) reports the SAME set of unmet capabilities
 # for aider's 'no' that a 'partial' manifest would produce.
 if command -v jq >/dev/null 2>&1; then
+    set +e
     json_out="$(bash "$CHECK_SCRIPT" --role builder --runtime aider --dir "$DEFAULTS_DIR" --json 2>/dev/null)"
+    set -e
     assert_eq "reject" "$(jq -r '.decision' <<<"$json_out")" \
         "--json reports decision=reject for builder+aider"
     assert_contains "worktreeIsolation" "$(jq -rc '.unmet' <<<"$json_out")" \


### PR DESCRIPTION
## Summary

`defaults/scripts/tests/test-spawn-generic.sh` (added by #4802/#4803) was aborting before its "All tests passed" summary on every CI run, because the suite's `--json` decision-surface check captures an EXPECTED-non-zero exit (`check-runtime-capabilities.sh --json` correctly reports `decision: reject` for builder+aider, signaled via exit 78) in a direct command substitution assignment. Under `set -euo pipefail`, that non-zero exit aborts the script immediately -- before the `assert_eq`/`assert_contains` calls that validate the JSON body even run.

## Fix

Bracket the `--json` command substitution in `set +e` / `set -e`, matching the pattern already used a few dozen lines earlier in the same file for the non-`--json` reject-decision checks (`builder_rc`, `doctor_rc`, etc.).

```diff
 if command -v jq >/dev/null 2>&1; then
+    set +e
     json_out="$(bash "$CHECK_SCRIPT" --role builder --runtime aider --dir "$DEFAULTS_DIR" --json 2>/dev/null)"
+    set -e
     assert_eq "reject" "$(jq -r '.decision' <<<"$json_out")" \
         "--json reports decision=reject for builder+aider"
```

## Audit for the same anti-pattern

Per the issue's acceptance criteria, audited `defaults/scripts/tests/` for any other suite using an unguarded command substitution under `set -e` for a call expected to exit non-zero:

- Searched every file using `set -e`/`set -euo pipefail` for expected-non-zero markers (`78`, `EX_CONFIG`, `--json` decision-surface calls, `reject`/`admit`/`error` decision literals).
- Every other occurrence (`test-check-runtime-capabilities.sh`, `test-loom-dispatcher.sh`, `test-spawn-claude.sh`, `test-spawn-codex.sh`, `test-spawn-worker.sh`) already brackets the call in `set +e`/`set -e`, or uses the `cmd || rc=$?` idiom (which is exempt from `set -e` by construction), or the file doesn't use `set -e` at all (`test-loom-status.sh`, `test-check-duplicate.sh`, `test-provision-codex-hooks.sh` use `set -uo pipefail` / no `set -e`).
- No other instance of the bug found; no further fix needed.

## Test plan

Ran `bash defaults/scripts/tests/test-spawn-generic.sh` standalone 3 consecutive times after the fix:

- All 3 runs exit 0 and print `Tests run: 48 / Tests passed: 48 / All tests passed.`
- Confirmed the `--json` block's `assert_eq`/`assert_contains` assertions (`--json reports decision=reject for builder+aider`, `--json names worktreeIsolation as unmet for builder+aider`) show up as PASS in the output, not just a non-zero-exit-avoided smoke check.

Closes #4814