### PR TITLE
docs(codex): close out #4478 sandbox-posture decision — role-hint correction + cross-refs

### DIFF
--- a/defaults/docs/guardrail-parity-codex.md
+++ b/defaults/docs/guardrail-parity-codex.md
@@ -526,6 +526,15 @@ already requires an explicit `LOOM_CODEX_SANDBOX=workspace-write` +
 decision here is deliberately *not* the same as promoting capability: promotion
 still waits on items 1–3, which are technical evidence, not posture.
 
+Builder-role-only scope means `suggestedWorkerType: "codex"` belongs only on
+`defaults/roles/builder.json` — the hints that previously sat on
+`judge.json`/`curator.json` (read-and-comment roles) predated this decision and
+have been corrected to `"claude"` accordingly. `suggestedWorkerType` is a
+dispatch *preference* hint only (see `runtime-adapters.md` § "Daemon runtime
+binding and admission"); actual admission still runs through
+`runtimeRequirements` + this document's promotion gate above, so the hint
+correction changes no enforced behavior on its own.
+
 When items 1–3 are satisfied, promote **only** the capabilities the evidence
 proves, append the evidence links to this document, and leave `mcp`,
 `subagents`, and `skills` untouched. `subagents` stays `no` regardless — native

--- a/defaults/roles/builder.json
+++ b/defaults/roles/builder.json
@@ -5,7 +5,7 @@
   "defaultInterval": 0,
   "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Development Worker who implements `loom:issue` issues (human-approved work). Priority system: (1) Check `gh issue list --label=\"loom:issue\" --label=\"loom:urgent\"` for critical issues. (2) If none urgent, check `gh issue list --label=\"loom:issue\"` (oldest first, FIFO) and claim new work. After creating a PR with `loom:review-requested`, move on to the next issue - the Doctor agent will handle any review feedback. You can work on multiple issues concurrently using worktrees.",
   "autonomousRecommended": false,
-  "suggestedWorkerType": "claude",
+  "suggestedWorkerType": "codex",
   "runtimeRequirements": ["worktreeIsolation", "mcp"],
   "stuckThresholds": {
     "maxNoOutput": 1800000,

--- a/defaults/roles/curator.json
+++ b/defaults/roles/curator.json
@@ -5,5 +5,5 @@
   "defaultInterval": 300000,
   "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are an Issue Curator who enhances issues. Use `gh issue list --state=open --json number,title,labels --jq '.[] | select(any(.labels[].name; . == \"loom:architect\" or . == \"loom:hermit\" or . == \"loom:curated\" or . == \"loom:curating\" or . == \"loom:triage\" or . == \"loom:issue\" or . == \"loom:building\" or . == \"loom:blocked\") | not) | \"#\\(.number) \\(.title)\"'` to find unlabeled issues needing curation (zero-label issues are included; already-labeled/in-flight issues are excluded). For each issue: (1) Check if well-formed (clear problem, acceptance criteria, test plan), (2) If yes, mark `loom:curated` immediately, (3) If no, enhance with missing details then mark `loom:curated`. CRITICAL: Do NOT add `loom:issue` yourself — promotion ownership is documented in curator.md ('Who promotes loom:curated -> loom:issue'). Always verify dependencies are met before adding `loom:curated` label.",
   "autonomousRecommended": true,
-  "suggestedWorkerType": "codex"
+  "suggestedWorkerType": "claude"
 }

--- a/defaults/roles/judge.json
+++ b/defaults/roles/judge.json
@@ -5,7 +5,7 @@
   "defaultInterval": 300000,
   "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Code Review Specialist. Check `gh pr list --label=\"loom:review-requested\"` for PRs needing review. Process ALL PRs in the queue before exiting \u2014 evaluate each PR, post feedback with `gh pr comment`, and update labels (approve: add `loom:pr`, remove `loom:review-requested`; or add `loom:changes-requested`, remove `loom:review-requested`). Do NOT use `gh pr review --approve` (fails with self-review restriction). Do NOT call /clear between PRs \u2014 only clear after draining the full queue.",
   "autonomousRecommended": true,
-  "suggestedWorkerType": "codex",
+  "suggestedWorkerType": "claude",
   "runtimeRequirements": ["mcp"],
   "stuckThresholds": {
     "maxNoOutput": 600000,

--- a/defaults/scripts/spawn-codex.sh
+++ b/defaults/scripts/spawn-codex.sh
@@ -21,6 +21,12 @@
 # `pre_tool_use` event, but Loom does not wire into it yet (see gap 1 in that
 # doc), so Loom's guard hooks do not fire for a Codex worker today.
 #
+# Production sandbox posture (issue #4478, decided 2026-07-31): read-only
+# default, with Builder-role-only escalation to workspace-write (+
+# LOOM_CODEX_NETWORK=1 for push access) — no fleet-wide danger-full-access.
+# See guardrail-parity-codex.md § "Promotion gate" for the full decision and
+# its relationship to the hooks/worktreeIsolation evidence gate above.
+#
 # ---------------------------------------------------------------------------
 # Minimum supported Codex CLI version: 0.146.0
 #


### PR DESCRIPTION
## Summary

Closes out the last loose end on #4478 (production sandbox posture for
daemon-dispatched Codex workers). The substantive operator decision —
**Path 1-then-2**: read-only default, Builder-role-only escalation to
`workspace-write` (+ `LOOM_CODEX_NETWORK=1` for push access), no fleet-wide
`danger-full-access` — was already recorded in
`defaults/docs/guardrail-parity-codex.md` and `defaults/runtimes/codex.json`'s
`capabilityGate` note by #4495.

What was still stale: `judge.json` and `curator.json` hinted
`suggestedWorkerType: "codex"` for read-and-comment roles the decision
explicitly excludes ("Codex scope narrows to the BUILDER stage only"), while
`builder.json` — the role actually in scope — still said `"claude"`.

## Changes

- `defaults/roles/judge.json`, `defaults/roles/curator.json`:
  `suggestedWorkerType` `codex` → `claude`
- `defaults/roles/builder.json`: `suggestedWorkerType` `claude` → `codex`
- `defaults/docs/guardrail-parity-codex.md`: note the role-hint correction
  next to the existing `DECIDED 2026-07-31` section
- `defaults/scripts/spawn-codex.sh`: cross-reference the decision from the
  adapter header comment

`suggestedWorkerType` is a dispatch *preference* hint only
(`runtime-adapters.md` § "Daemon runtime binding and admission") — actual
daemon admission runs through `runtimeRequirements` + the codex.json
capability gate (`worktreeIsolation`/`hooks` still `partial`, pending the
real-CLI canary evidence tracked separately), so this PR changes no enforced
dispatch behavior on its own. `.loom/config.json` in this repo has no
`runtimes` block, so live admission is unaffected either way.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` on all three edited role JSONs
- [x] `bash -n defaults/scripts/spawn-codex.sh`
- [x] `defaults/scripts/tests/test-check-runtime-capabilities.sh` — 27/27 pass
- [x] `defaults/scripts/tests/test-spawn-codex.sh` — identical pass/fail
      counts (32 pre-existing failures, environment-dependent on local Codex
      hook-trust state) between unmodified `main` and this branch, confirming
      no regression
- [x] `check-main-clean.sh` clean after builder work

Closes #4478