### PR TITLE
ci: wire defaults/hooks/tests/ guard suites into shell-suite-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
               - 'scripts/**'
               - 'defaults/**'
               - 'tests/hooks/**'
+              # .loom/hooks/** is git-tracked (self-install dogfooding) and
+              # several defaults/hooks/tests/*.sh + tests/hooks/*.sh suites
+              # assert it's byte-identical to defaults/hooks/** (#4451) — a
+              # drift here without a matching defaults/ change should still
+              # re-run shell-suite-tests on the PR, not just on push to main.
+              - '.loom/hooks/**'
               - '.github/workflows/ci.yml'
 
   backend-lint-and-check:
@@ -233,6 +239,15 @@ jobs:
     # entirely). tests/hooks/test-guard-destructive.sh alone adds several
     # minutes (531 assertions); run-ci-suites.sh's per-suite timeout was
     # raised accordingly (see its header comment).
+    #
+    # Since #4451 ci-wired.txt also covers defaults/hooks/tests/ — the last
+    # unwired guard-hook location (background-subagents, loom-workspace,
+    # worktree-paths, methodology-inject, skill-router; 128 assertions across
+    # the 5 suites). Measured ~1m43s combined on a loaded macOS dev machine
+    # (this repo's only prior execution environment); ubuntu-latest is
+    # expected to be faster (no per-exec Gatekeeper/codesign overhead, cheaper
+    # fork/exec) but this is the suites' first CI run — watch the actual
+    # ubuntu wall-clock here and tighten LOOM_CI_SUITE_TIMEOUT only if needed.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/defaults/scripts/tests/check-ci-suite-manifest.sh
+++ b/defaults/scripts/tests/check-ci-suite-manifest.sh
@@ -12,9 +12,13 @@
 # directory is intentionally ignored — only `test-*.sh` files are suites.
 #
 # Since #4769 the invariant also covers tests/hooks/ (repo root) — the
-# Claude-path guard suites. Those entries are qualified with their path
-# relative to the repo root (e.g. `tests/hooks/test-guard-destructive.sh`) so
-# they can't collide with a same-named suite in this directory.
+# Claude-path guard suites. Since #4451 it also covers defaults/hooks/tests/
+# (the Repo Skills' own guard-hook suites — background-subagents,
+# loom-workspace, worktree-paths, methodology-inject, skill-router). Entries
+# for either external directory are qualified with their path relative to the
+# repo root (e.g. `tests/hooks/test-guard-destructive.sh`,
+# `defaults/hooks/tests/test-skill-router.sh`) so they can't collide with a
+# same-named suite in this directory.
 #
 # Exit 0 = invariant holds; exit 1 = violation (details printed to stderr).
 
@@ -24,7 +28,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 WIRED_MANIFEST="$SCRIPT_DIR/ci-wired.txt"
 EXCLUDED_MANIFEST="$SCRIPT_DIR/ci-excluded.txt"
-HOOKS_TEST_DIR="$REPO_ROOT/tests/hooks"
+# Directories of suites outside defaults/scripts/tests/ that this manifest
+# also governs, each relative to the repo root (#4769, #4451).
+EXTERNAL_TEST_DIRS=("tests/hooks" "defaults/hooks/tests")
 
 fail=0
 err() { printf 'ERROR: %s\n' "$1" >&2; fail=1; }
@@ -42,12 +48,16 @@ manifest_names() { # <manifest-file>
 
 # --- Collect the three sets --------------------------------------------------
 mapfile -t actual_local < <(cd "$SCRIPT_DIR" && for f in test-*.sh; do [[ -e "$f" ]] && printf '%s\n' "$f"; done)
-mapfile -t actual_hooks < <(
-    if [[ -d "$HOOKS_TEST_DIR" ]]; then
-        cd "$HOOKS_TEST_DIR" && for f in test-*.sh; do [[ -e "$f" ]] && printf 'tests/hooks/%s\n' "$f"; done
-    fi
-)
-mapfile -t actual < <(printf '%s\n' "${actual_local[@]}" "${actual_hooks[@]}" | sort)
+actual_external=()
+for rel_dir in "${EXTERNAL_TEST_DIRS[@]}"; do
+    ext_dir="$REPO_ROOT/$rel_dir"
+    [[ -d "$ext_dir" ]] || continue
+    while IFS= read -r name; do
+        [[ -n "$name" ]] || continue
+        actual_external+=("$rel_dir/$name")
+    done < <(cd "$ext_dir" && for f in test-*.sh; do [[ -e "$f" ]] && printf '%s\n' "$f"; done)
+done
+mapfile -t actual < <(printf '%s\n' "${actual_local[@]}" "${actual_external[@]}" | sort)
 mapfile -t wired < <(manifest_names "$WIRED_MANIFEST" | sort)
 mapfile -t excluded < <(manifest_names "$EXCLUDED_MANIFEST" | sort)
 

--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -17,6 +17,14 @@
 # the repo root instead of this directory. They were confirmed hermetic (no
 # live forge/network calls — the `gh`/`curl` strings in them are guard-input
 # fixtures, never executed) before being wired in here.
+#
+# Since #4451 the manifest also covers defaults/hooks/tests/ — the remaining
+# unwired guard-hook suites (background-subagents, loom-workspace,
+# worktree-paths, methodology-inject, skill-router). Each copies its hook
+# under test into an isolated `mktemp -d` git tree and drives it purely via
+# stdin JSON + env vars (no live forge/network calls, no BSD-only sed/stat/
+# date flags), so they were confirmed hermetic and ubuntu-portable the same
+# way as the tests/hooks/ suites above before being wired in here.
 
 test-archive-transcripts.sh
 test-blame-issue.sh
@@ -104,3 +112,10 @@ test-worktree-snapshot.sh
 tests/hooks/test-guard-destructive-dispatcher.sh
 tests/hooks/test-guard-destructive.sh
 tests/hooks/test-guard-loom-workflow.sh
+
+# defaults/hooks/tests/ — remaining unwired guard-hook suites, wired since #4451.
+defaults/hooks/tests/test-guard-background-subagents.sh
+defaults/hooks/tests/test-guard-loom-workspace.sh
+defaults/hooks/tests/test-guard-worktree-paths.sh
+defaults/hooks/tests/test-methodology-inject.sh
+defaults/hooks/tests/test-skill-router.sh

--- a/defaults/scripts/tests/run-ci-suites.sh
+++ b/defaults/scripts/tests/run-ci-suites.sh
@@ -13,12 +13,13 @@
 #   LOOM_CI_SUITE_TIMEOUT=180 …      # per-suite timeout in seconds (default 1200)
 #
 # A manifest entry containing a `/` is a suite outside this directory,
-# resolved relative to the repo root (tests/hooks/…, #4769) rather than
-# SCRIPT_DIR; its log file name has the `/` replaced with `_` so it stays a
-# flat /tmp path. The default per-suite timeout was raised from 120s to 1200s
-# in #4769 to cover tests/hooks/test-guard-destructive.sh (531 assertions,
-# observed up to ~14 min / 850s wall-clock on a loaded dev machine — still
-# hermetic, just large — so the ceiling keeps real headroom above that peak).
+# resolved relative to the repo root (tests/hooks/…, #4769; defaults/hooks/
+# tests/…, #4451) rather than SCRIPT_DIR; its log file name has the `/`
+# replaced with `_` so it stays a flat /tmp path. The default per-suite
+# timeout was raised from 120s to 1200s in #4769 to cover
+# tests/hooks/test-guard-destructive.sh (531 assertions, observed up to ~14
+# min / 850s wall-clock on a loaded dev machine — still hermetic, just large
+# — so the ceiling keeps real headroom above that peak).
 #
 # Exit 0 = all wired suites passed; 1 = one or more failed / manifest invalid.
 


### PR DESCRIPTION
## Summary

Closes #4451.

The original filing found the whole `tests/hooks/*` + `defaults/hooks/tests/*` guard-hook suite population (8 suites total) unwired from CI. Since then, #4769 already wired the `tests/hooks/` location (3 suites: `test-guard-destructive.sh`, `test-guard-destructive-dispatcher.sh`, `test-guard-loom-workflow.sh`) into the existing `shell-suite-tests` job via `ci-wired.txt` + `run-ci-suites.sh` (the #4455 infrastructure), rather than via a separate job.

This PR closes the **remaining** gap: `defaults/hooks/tests/` (5 suites: `test-guard-background-subagents.sh`, `test-guard-loom-workspace.sh`, `test-guard-worktree-paths.sh`, `test-methodology-inject.sh`, `test-skill-router.sh`) was still entirely unwired.

## Changes

- `defaults/scripts/tests/check-ci-suite-manifest.sh`: generalized the single `HOOKS_TEST_DIR` into an `EXTERNAL_TEST_DIRS` list covering both `tests/hooks/` and `defaults/hooks/tests/`, so the wired/excluded partition invariant now accounts for all 93 suites (was 88) instead of silently ignoring the second directory.
- `defaults/scripts/tests/ci-wired.txt`: wired all 5 `defaults/hooks/tests/*.sh` suites, with a comment documenting the hermeticity/portability review (isolated `mktemp -d` git trees driven purely via stdin JSON + env vars; no BSD-only `sed -i`/`stat`/`date` flags found).
- `defaults/scripts/tests/run-ci-suites.sh`: updated the header comment (no code change — it already generically resolves any `/`-containing manifest entry against the repo root).
- `.github/workflows/ci.yml`: added `.loom/hooks/**` to the `scripts` paths-filter group. `.loom/hooks/` is git-tracked (self-install dogfooding) and several suites assert it's byte-identical to `defaults/hooks/**`, so a drift there without a matching `defaults/` change should still re-run `shell-suite-tests` on the PR itself, not just on push to `main`. Also extended the job's header comment with a runtime note for the 5 newly-wired suites.

## Why this approach instead of a separate `hook-tests` job

The issue's curated body suggested a standalone job with its own glob-discovery runner. By the time I picked this up, #4769 had already extended the `shell-suite-tests` / `ci-wired.txt` / `check-ci-suite-manifest.sh` machinery (built for #4455) to cover `tests/hooks/`. Reusing and extending that same machinery for `defaults/hooks/tests/` avoids two parallel "glob-discover shell suites and run them in CI" implementations with different manifest/exclusion semantics, and keeps a single enforced invariant (`check-ci-suite-manifest.sh`) covering every suite location in the repo.

## Acceptance criteria (from the curated issue body)

- [x] All suites in `tests/hooks/` AND `defaults/hooks/tests/` run in CI — via glob-free but manifest-enforced discovery (`ci-wired.txt` + `check-ci-suite-manifest.sh`'s unlisted-suite failure), which is a stronger guarantee than a bare glob: a new suite added to either directory that isn't consciously wired-or-excluded now fails the manifest check.
- [x] Path-filtered to `defaults/hooks/**`, `tests/hooks/**`, `.loom/hooks/**`, and `ci.yml` (via the shared `scripts` filter group); also runs on push to `main` (`if: always() && (push || ...)` on `shell-suite-tests`, unchanged).
- [x] Fails on any single suite's nonzero exit — `run-ci-suites.sh` already does this (pre-existing, unchanged): captures each suite's exit code, sets `failed`, and the job step fails if any suite failed.
- [x] All 8 suites verified locally; ubuntu-latest execution has never happened for any of them before, so it's confirmed by this PR's own CI run.
- [x] `timeout-minutes`: the per-suite timeout (`LOOM_CI_SUITE_TIMEOUT`, default 1200s in `run-ci-suites.sh`, set in #4769) already covers the largest suite (`test-guard-destructive.sh`, ~8min measured here) with headroom; documented the 5 newly-wired suites' combined macOS measurement (~1m43s) in the job's header comment.
- [x] Path filters documented in the workflow file (inline comments on both the `scripts` filter group and the `shell-suite-tests` job).

## Test plan

- [x] Local (macOS): all 8 guard-hook suites pass — `test-guard-destructive.sh` (531 assertions, ~8 min wall-clock), `test-guard-destructive-dispatcher.sh` (8 assertions, ~2s), `test-guard-loom-workflow.sh` (27 assertions, ~16s), and the 5 newly-wired `defaults/hooks/tests/*.sh` suites (126 assertions combined, ~1m43s).
- [x] `check-ci-suite-manifest.sh` passes: `OK: 93 suites (89 wired, 4 excluded) — every test-*.sh is accounted for.`
- [ ] CI on this PR itself: first-ever ubuntu-latest execution of all 8 suites — watching for GNU/BSD portability surprises despite the manual review (none found: no `sed -i`, `stat -f/-c`, `date -v`, or other BSD/GNU-divergent flags in any of the 5 newly-wired suites or their hooks-under-test).
- Not done (per issue's own guidance — local-only, not pushed): deliberate assertion-failure injection to confirm nonzero propagation. `run-ci-suites.sh`'s failure-propagation path is pre-existing (#4455/#4769) and unchanged by this PR, so it wasn't re-verified here.

## Out of scope (per curated issue)

- `defaults/scripts/tests/` wiring — separate issue #4455, not touched.
- Ruleset/branch-protection changes — none needed (confirmed by the issue's own curation).
- The optional `shell-lint.yml` extension to `defaults/hooks/**/*.sh` — left out to keep this PR focused; a spot-check found only one pre-existing unrelated warning (`defaults/hooks/guard-codex-bridge.sh:164` unused var) that would need fixing first, which is bundlable as a trivial follow-up rather than expanding this PR's blast radius.