### PR TITLE
feat(daemon): move model-cost A/B arm assignment + outcome attribution into daemon dispatch

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -649,6 +649,28 @@ Constraints that keep the exception from becoming an unbounded loop:
 
 ### Model-cost experiment mode (`sweep.modelExperiment` / `LOOM_MODEL_EXPERIMENT`, issue #3725)
 
+> **Fallback note (issue #4809).** For a **daemon-dispatched** sweep (the
+> normal `dispatch_sweep` / work-finder / epic-supervisor path), arm
+> assignment and the forced Builder model are now resolved **natively in the
+> daemon at dispatch time** (`sweep_registry::resolve_autonomous_dispatch_model`)
+> — the daemon computes the SAME deterministic arm this section describes and
+> passes the resolved model as the dispatch `--model`, so it wins the #4501
+> default-pin precedence instead of being silently overridden by it. Per-sweep
+> outcome telemetry (`sweep.outcome` records) is likewise attributed an `arm`
+> automatically from the dispatched model, with no action from this skill.
+> This is the fix for two compounding defects discovered in the 2026-07-31
+> canary rollout: (1) the deterministic per-phase instructions below are
+> **LLM-authored prose** and were observed to never execute in a headless
+> `-p` child — no banner, no `assign-arm`/`record` calls, zero rows in
+> `.loom/stats/sweep-model-stats.jsonl` across a full day of canary sweeps;
+> and (2) even when they *would* execute, the #4501 dispatch model pin is
+> tier-1 and structurally outranks a model only ever "forced" in prose. The
+> instructions below remain a **best-effort fallback** for non-daemon
+> contexts (a manual `/loom:sweep` run in an interactive session, or a
+> Task-tool in-session dispatch that never passes through `dispatch_sweep`) —
+> keep following them there — but they are no longer the primary data path
+> for a daemon-dispatched canary.
+
 This mode instruments a sweep to produce the balanced A/B evidence #3718 needs to decide the Builder `opus → sonnet` retune. **It is off by default and is byte-for-byte a no-op when unset** — every deterministic instruction below runs only when the mode resolves to `observe` or `experiment`. All the arithmetic (mode resolution, arm assignment, the durable append, the harvest) lives in `./.loom/scripts/sweep-experiment.sh` (a thin stub over `loom-daemon sweep-experiment`); this skill never computes a modulo by hand.
 
 **Tri-state resolution (read once at lifecycle entry, same point as `sweep.escalation`).** Resolve `./.loom/scripts/sweep-experiment.sh resolve-mode` → one of `off` | `observe` | `experiment`. Precedence follows the **string-valued** guard pattern (`guards.rmScope` / `guards.forceScope`), not the boolean one:

--- a/defaults/docs/model-selection.md
+++ b/defaults/docs/model-selection.md
@@ -76,7 +76,12 @@ The ladder is configured in `.loom/config.json`:
 > rung. So every consumer keeps naming `opus` and a **single indirection point**
 > maps the logical tier to the concrete ID the dispatch should use — the
 > `/loom:sweep` skill via `./.loom/scripts/resolve-model.sh`, `loom_tools` via
-> `model_tiers`, and `loom-daemon` via `resolve_dispatch_model`. The shipped map
+> `model_tiers`, and `loom-daemon` via `resolve_dispatch_model`. (Issue #4809:
+> a **daemon-dispatched** single-issue sweep resolves through the sibling
+> `resolve_autonomous_dispatch_model`, which inserts the model-cost A/B
+> experiment's forced arm — when resolved-`experiment` mode confirms a canary —
+> ahead of `resolve_dispatch_model`'s own config/default sub-tiers; an explicit
+> dispatch `model` param still wins over both.) The shipped map
 > pins only the stale tier (`opus → claude-opus-5`); `sonnet`/`fable` and pinned
 > IDs pass through unchanged. Repoint or drop a pin per-repo with an additive
 > `.loom/config.json` → `sweep.modelAliases` object (no code change):

--- a/loom-daemon/src/epic_supervisor.rs
+++ b/loom-daemon/src/epic_supervisor.rs
@@ -1455,13 +1455,29 @@ pub mod forge {
             // non-premium model (`autonomous.model` config > shipped default) so
             // the epic child never inherits the operator's interactive CLI
             // default. No per-dispatch override tier here.
+            //
+            // Issue #4809: this ALSO inserts the model-cost A/B experiment's
+            // forced arm model when the workspace resolves to `experiment` mode
+            // (CANARY-gated) — see `work_finder::dispatch` for the full
+            // rationale; `off`/`observe` modes are unaffected.
             let repo_root = reg.config().workspace_root.clone();
-            let (model, source) = crate::sweep_registry::resolve_dispatch_model(&repo_root, None);
-            log::info!(
-                "epic_supervisor: dispatching child #{child} for epic #{_epic} with \
-                 model={model} (source={})",
-                source.as_str()
-            );
+            let resolved =
+                crate::sweep_registry::resolve_autonomous_dispatch_model(&repo_root, child);
+            match resolved.arm {
+                Some(arm) => log::info!(
+                    "epic_supervisor: dispatching child #{child} for epic #{_epic} with \
+                     arm={arm} model={} (source={})",
+                    resolved.model,
+                    resolved.source_label
+                ),
+                None => log::info!(
+                    "epic_supervisor: dispatching child #{child} for epic #{_epic} with \
+                     model={} (source={})",
+                    resolved.model,
+                    resolved.source_label
+                ),
+            }
+            let model = resolved.model;
             // Idempotency key + the registry's claim lock make a re-dispatch of
             // an already-running child a no-op.
             let key = format!("epic-child-{child}");

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -2846,13 +2846,29 @@ fn handle_request(
                 &kind,
             );
 
-            let (resolved_model, model_source) =
-                crate::sweep_registry::resolve_dispatch_model(&repo_root, model.as_deref());
+            // Issue #4809: an explicit `model` param always wins (unchanged
+            // precedence), but an ABSENT one for a single-issue dispatch also
+            // considers the model-cost A/B experiment's forced arm — mirroring
+            // the autonomous work-finder / epic-supervisor dispatch paths —
+            // before falling back to `autonomous.model` / the shipped default.
+            let (resolved_model, model_source_label, arm) = match (&kind, model.as_deref()) {
+                (crate::types::SweepKind::Issue(issue), None) => {
+                    let resolved = crate::sweep_registry::resolve_autonomous_dispatch_model(
+                        &repo_root, *issue,
+                    );
+                    (resolved.model, resolved.source_label, resolved.arm)
+                }
+                _ => {
+                    let (m, s) =
+                        crate::sweep_registry::resolve_dispatch_model(&repo_root, model.as_deref());
+                    (m, s.as_str(), None)
+                }
+            };
             log::info!(
-                "dispatch_sweep: {:?} with model={resolved_model} (source={}); headroom \
-                 occupancy={} dynamic_cap={} (disk={} tokens={})",
+                "dispatch_sweep: {:?} with{} model={resolved_model} (source={model_source_label}); \
+                 headroom occupancy={} dynamic_cap={} (disk={} tokens={})",
                 kind,
-                model_source.as_str(),
+                arm.map_or_else(String::new, |a| format!(" arm={a}")),
                 headroom.occupancy,
                 headroom.dynamic_cap,
                 headroom.disk_headroom,

--- a/loom-daemon/src/sweep_registry/model.rs
+++ b/loom-daemon/src/sweep_registry/model.rs
@@ -214,6 +214,103 @@ pub fn resolve_model_alias_from_config(config: &serde_json::Value, model: &str) 
     }
 }
 
+// ----------------------------------------------------------------------------
+// Model-cost A/B experiment (#3725) — daemon-native arm assignment (#4809)
+// ----------------------------------------------------------------------------
+
+/// Outcome of [`resolve_autonomous_dispatch_model`] — the daemon-native
+/// replacement for the `sweep.md` "Model-cost experiment mode" prose
+/// instrumentation (issue #4809). That prose never executes in a headless
+/// `-p` child (the LLM-authored per-phase `sweep-experiment.sh record`/banner
+/// calls simply do not run), and even a perfectly-instrumented child was
+/// structurally defeated by the #4501 default-model pin's tier-1 precedence
+/// over a "forced" arm that only ever existed in prose. This resolves the
+/// experiment's arm assignment as PART of the daemon's own dispatch-model
+/// precedence chain, so a resolved `experiment` mode genuinely changes what
+/// model is dispatched.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExperimentDispatchModel {
+    /// The model to dispatch the child with.
+    pub model: String,
+    /// The effective experiment mode for this dispatch, AFTER the CANARY
+    /// guardrail (`"off"` | `"observe"` | `"experiment"`).
+    pub mode: String,
+    /// The deterministic arm assigned to this issue — `Some("A" | "B")` only
+    /// when `mode == "experiment"`. `observe`/`off` dispatches do not force a
+    /// model, so they carry no arm at DISPATCH time; the outcome-recording
+    /// path (`sweep_registry::outcome_journal`) still attributes an arm to
+    /// such a record after the fact via
+    /// [`crate::script_helpers::sweep_experiment::infer_arm_from_model`].
+    pub arm: Option<&'static str>,
+    /// A short label for the dispatch log line naming why `model` won:
+    /// `"experiment"` when the arm-forced model won, otherwise the
+    /// underlying [`ModelSource`] label (`param`/`config`/`default`) —
+    /// unchanged from [`resolve_dispatch_model`] for `off`/`observe`.
+    pub source_label: &'static str,
+}
+
+/// Issue #4809: resolve the model for an autonomous, per-`issue` sweep
+/// dispatch, inserting the model-cost A/B experiment's forced arm model
+/// ahead of the #3944/#4501 default-pin precedence chain when — and ONLY
+/// when — the workspace resolves to `experiment` mode. Mode resolution reads
+/// the SAME env vars (`LOOM_MODEL_EXPERIMENT` / `LOOM_MODEL_EXPERIMENT_CANARY`)
+/// and CANARY guardrail (an uncommitted env confirmation or a gitignored
+/// `.loom/CANARY` sentinel under `repo_root` — never the committed
+/// `sweep.modelExperimentCanary` flag, rejected in #3731) that
+/// `sweep-experiment.sh resolve-mode` uses — see
+/// [`crate::script_helpers::sweep_experiment::resolve_effective_mode_default`].
+///
+/// `off` and `observe` modes are BYTE-IDENTICAL to calling
+/// [`resolve_dispatch_model`] directly (the required no-behavior-change
+/// contract for both) — only `experiment` mode substitutes the arm-forced
+/// model, and an explicit dispatch `model` param is never seen at this
+/// call's `resolve_dispatch_model(repo_root, None)` fallback (callers pass
+/// `explicit = None`, matching every existing autonomous dispatch site).
+///
+/// The arm itself is [`crate::script_helpers::sweep_experiment::assign_arm`]
+/// — a pure function of `issue` (+ an optional complexity stratum, currently
+/// always `None` here; real per-issue `<!-- loom:complexity=... -->`
+/// extraction at dispatch time is deferred — see issue #4809's PR
+/// description), so the SAME issue resolves to the SAME arm across a
+/// dispatch resume — no re-roll.
+#[must_use]
+pub fn resolve_autonomous_dispatch_model(repo_root: &Path, issue: u32) -> ExperimentDispatchModel {
+    use crate::script_helpers::sweep_experiment as se;
+
+    let config = crate::config_resolver::resolve_effective_config(repo_root);
+    let env_mode = std::env::var("LOOM_MODEL_EXPERIMENT").ok();
+    let env_canary = std::env::var("LOOM_MODEL_EXPERIMENT_CANARY").ok();
+    let sentinel_path = repo_root.join(se::CANARY_SENTINEL);
+    let (mode, warnings) = se::resolve_effective_mode_default(
+        env_mode.as_deref(),
+        env_canary.as_deref(),
+        &config,
+        Some(&sentinel_path),
+    );
+    for w in &warnings {
+        log::warn!("sweep-experiment: {w}");
+    }
+
+    if mode == "experiment" {
+        let arm = se::assign_arm(i64::from(issue), None);
+        let model = se::resolved_arm_model(arm, &config);
+        return ExperimentDispatchModel {
+            model,
+            mode,
+            arm: Some(arm),
+            source_label: "experiment",
+        };
+    }
+
+    let (model, source) = resolve_dispatch_model(repo_root, None);
+    ExperimentDispatchModel {
+        model,
+        mode,
+        arm: None,
+        source_label: source.as_str(),
+    }
+}
+
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
@@ -420,6 +517,136 @@ mod tests {
                                                                                      // Higher-precedence (project) tier wins on the shared `sonnet` key.
         assert_eq!(aliases.get("sonnet").map(String::as_str), Some("project-sonnet"));
         assert_eq!(aliases.len(), 3);
+    }
+
+    // --- Issue #4809: daemon-native model-cost experiment dispatch --------- //
+
+    /// Clean slate for the experiment env vars this suite mutates — leaked
+    /// state from another test in the same process would make these false
+    /// pass/fail.
+    fn clear_experiment_env() {
+        std::env::remove_var("LOOM_MODEL_EXPERIMENT");
+        std::env::remove_var("LOOM_MODEL_EXPERIMENT_CANARY");
+    }
+
+    /// With no env/config/sentinel, mode resolves to `off` and the result is
+    /// byte-identical to calling `resolve_dispatch_model` directly — no arm,
+    /// `source_label` is the underlying `ModelSource` label.
+    #[test]
+    #[serial]
+    fn autonomous_dispatch_off_by_default_is_byte_identical() {
+        clear_experiment_env();
+        let dir = tempdir().unwrap();
+        let resolved = resolve_autonomous_dispatch_model(dir.path(), 100);
+        clear_experiment_env();
+
+        assert_eq!(resolved.mode, "off");
+        assert_eq!(resolved.arm, None);
+        assert_eq!(resolved.source_label, "default");
+        let (expected_model, expected_source) = resolve_dispatch_model(dir.path(), None);
+        assert_eq!(resolved.model, expected_model);
+        assert_eq!(resolved.source_label, expected_source.as_str());
+    }
+
+    /// `experiment` mode requested with NO canary confirmation downgrades to
+    /// `observe` (the #3731 guardrail) — no arm, model resolution unaffected.
+    #[test]
+    #[serial]
+    fn autonomous_dispatch_experiment_without_canary_downgrades_to_observe() {
+        clear_experiment_env();
+        std::env::set_var("LOOM_MODEL_EXPERIMENT", "experiment");
+        let dir = tempdir().unwrap();
+        let resolved = resolve_autonomous_dispatch_model(dir.path(), 100);
+        clear_experiment_env();
+
+        assert_eq!(resolved.mode, "observe");
+        assert_eq!(resolved.arm, None);
+        assert_eq!(resolved.model, DEFAULT_DISPATCH_MODEL, "observe must not force a model");
+    }
+
+    /// `experiment` mode + a confirmed canary forces the deterministic arm's
+    /// model, suppressing the #3944/#4501 default pin — the core #4809 fix.
+    #[test]
+    #[serial]
+    fn autonomous_dispatch_experiment_with_canary_forces_the_arm_model() {
+        clear_experiment_env();
+        std::env::set_var("LOOM_MODEL_EXPERIMENT", "experiment");
+        std::env::set_var("LOOM_MODEL_EXPERIMENT_CANARY", "1");
+        let dir = tempdir().unwrap();
+        // Issue 100, no complexity ⇒ arm A (see `assign_arm`'s parity table).
+        let resolved = resolve_autonomous_dispatch_model(dir.path(), 100);
+        clear_experiment_env();
+
+        assert_eq!(resolved.mode, "experiment");
+        assert_eq!(resolved.arm, Some("A"));
+        assert_eq!(resolved.model, "claude-opus-5", "Arm A resolves through the #3982 tier map");
+        assert_eq!(resolved.source_label, "experiment");
+
+        // Issue 101 ⇒ arm B (sonnet), still deterministic and un-pinned by
+        // the default.
+        clear_experiment_env();
+        std::env::set_var("LOOM_MODEL_EXPERIMENT", "experiment");
+        std::env::set_var("LOOM_MODEL_EXPERIMENT_CANARY", "1");
+        let resolved_b = resolve_autonomous_dispatch_model(dir.path(), 101);
+        clear_experiment_env();
+        assert_eq!(resolved_b.arm, Some("B"));
+        assert_eq!(resolved_b.model, "sonnet");
+    }
+
+    /// Deterministic assignment: repeated calls for the same issue (a
+    /// dispatch resume) land on the same arm — no re-roll.
+    #[test]
+    #[serial]
+    fn autonomous_dispatch_arm_assignment_is_deterministic_across_resumes() {
+        clear_experiment_env();
+        std::env::set_var("LOOM_MODEL_EXPERIMENT", "experiment");
+        std::env::set_var("LOOM_MODEL_EXPERIMENT_CANARY", "1");
+        let dir = tempdir().unwrap();
+        let first = resolve_autonomous_dispatch_model(dir.path(), 4242);
+        let second = resolve_autonomous_dispatch_model(dir.path(), 4242);
+        clear_experiment_env();
+        assert_eq!(first.arm, second.arm);
+        assert_eq!(first.model, second.model);
+    }
+
+    /// A committed `.loom/CANARY` (git-tracked) is refused exactly like the
+    /// underlying `sweep-experiment.sh` guardrail — this test only exercises
+    /// the untracked-sentinel confirmation path (the tracked-refusal path is
+    /// already covered directly against `evaluate_canary` in
+    /// `script_helpers::sweep_experiment`); here we confirm the SENTINEL path
+    /// (not just the env var) reaches the daemon dispatch resolver.
+    #[test]
+    #[serial]
+    fn autonomous_dispatch_confirms_canary_via_untracked_sentinel_file() {
+        clear_experiment_env();
+        std::env::set_var("LOOM_MODEL_EXPERIMENT", "experiment");
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".loom")).unwrap();
+        std::fs::write(dir.path().join(".loom").join("CANARY"), "").unwrap();
+
+        let resolved = resolve_autonomous_dispatch_model(dir.path(), 100);
+        clear_experiment_env();
+
+        assert_eq!(resolved.mode, "experiment");
+        assert_eq!(resolved.arm, Some("A"));
+    }
+
+    /// `observe` mode (explicit) never forces a model, matching #4809's "zero
+    /// behavior change" contract even with `autonomous.model` configured.
+    #[test]
+    #[serial]
+    fn autonomous_dispatch_observe_mode_honors_existing_config_precedence() {
+        clear_experiment_env();
+        std::env::set_var("LOOM_MODEL_EXPERIMENT", "observe");
+        let dir = tempdir().unwrap();
+        write_config(dir.path(), r#"{"autonomous": {"model": "opus"}}"#);
+        let resolved = resolve_autonomous_dispatch_model(dir.path(), 100);
+        clear_experiment_env();
+
+        assert_eq!(resolved.mode, "observe");
+        assert_eq!(resolved.arm, None);
+        assert_eq!(resolved.model, "claude-opus-5", "config tier still resolves through #3982");
+        assert_eq!(resolved.source_label, "config");
     }
 
     /// Ladder monotonicity: no rung of the shipped escalation ladder resolves to

--- a/loom-daemon/src/sweep_registry/outcome_journal.rs
+++ b/loom-daemon/src/sweep_registry/outcome_journal.rs
@@ -171,6 +171,21 @@ impl SweepRegistry {
             config.insert("runtime".to_string(), runtime);
         }
         config.insert("token_account".to_string(), token_name);
+        // Issue #4809: attribute this sweep to the model-cost A/B experiment's
+        // arm from its OWN dispatched model — the same inference the #3725
+        // harvest already applies to `observe`-mode records
+        // (`sweep_experiment::infer_arm_from_model`), reused here so a
+        // `experiment`-mode dispatch (which forces exactly an opus/sonnet-family
+        // model — see `resolve_autonomous_dispatch_model`) is attributed
+        // identically without needing a separate stored "explicit arm" field.
+        // Kept in the free-form `config` map (not a new top-level schema field)
+        // so this is additive per #4703 with no schema-version bump. Per-issue
+        // complexity stratification is deferred — see the #4809 PR description.
+        if let Some(arm) =
+            crate::script_helpers::sweep_experiment::infer_arm_from_model(model.as_deref())
+        {
+            config.insert("arm".to_string(), arm.to_string());
+        }
 
         // Per-phase breakdown from the transition history this registry
         // sampled while the sweep was alive (see `sample_phase_transition`).
@@ -516,6 +531,9 @@ mod tests {
         assert_eq!(record.model.as_deref(), Some("opus"));
         assert_eq!(record.effort.as_deref(), Some("high"));
         assert_eq!(record.config.get("token_account").map(String::as_str), Some("agent-4"));
+        // Issue #4809: an opus-family model is attributed to Arm A in the
+        // free-form `config` map — additive, no schema-version bump.
+        assert_eq!(record.config.get("arm").map(String::as_str), Some("A"));
         assert!(record.total_duration_sec >= 0);
         // skip_label_flip is set in the fixture registry, so the forge-probe
         // fields fall back to their private-safe / workspace-path defaults
@@ -566,6 +584,8 @@ mod tests {
             .expect("sweep.outcome telemetry record must be journaled on a merged lifecycle");
         assert_eq!(record.result, telemetry::SweepResult::Success);
         assert_eq!(record.model.as_deref(), Some("sonnet"));
+        // Issue #4809: sonnet-family attributes to Arm B.
+        assert_eq!(record.config.get("arm").map(String::as_str), Some("B"));
         assert_eq!(
             record
                 .phase_durations
@@ -574,6 +594,27 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["builder", "judge", "merge"]
         );
+    }
+
+    /// Issue #4809: a model that is neither arm (or no model at all) carries
+    /// NO `arm` key in the outcome record's `config` map — never a fabricated
+    /// attribution.
+    #[test]
+    fn telemetry_outcome_records_no_arm_for_an_unattributable_model() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _rec) = fixture_registry(dir.path());
+
+        let sweep_id =
+            insert_dead_running_with_log(&mut registry, 4809, 0, "agent-15", "clean run\n");
+        if let Some(info) = registry.entries.get_mut(&sweep_id) {
+            info.model = Some("claude-haiku-5".to_string());
+        }
+        registry.reap_once();
+
+        let path = registry.config().resolve_outcome_telemetry_path();
+        let records = sweep_outcomes::read_all_sweep_outcomes(&path);
+        let record = records.iter().find(|r| r.issue == 4809).unwrap();
+        assert_eq!(record.config.get("arm"), None);
     }
 
     /// A checkpoint-less death whose exit status was never observed is NOT

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -2431,12 +2431,30 @@ pub mod forge {
             // CLI default (which may be a premium tier that burns usage credits).
             // No dispatch-param tier here — the work finder has no per-issue
             // override — so `explicit = None`.
+            //
+            // Issue #4809: this resolution ALSO inserts the model-cost A/B
+            // experiment's forced arm model when the workspace resolves to
+            // `experiment` mode (CANARY-gated) — the daemon-native replacement
+            // for the sweep.md prose instrumentation, which never executed in a
+            // headless child and was in any case overridden by this very
+            // default-pin precedence. `off`/`observe` modes are unaffected.
             let repo_root = reg.config().workspace_root.clone();
-            let (model, source) = crate::sweep_registry::resolve_dispatch_model(&repo_root, None);
-            log::info!(
-                "work_finder: dispatching issue #{issue} with model={model} (source={})",
-                source.as_str()
-            );
+            let resolved =
+                crate::sweep_registry::resolve_autonomous_dispatch_model(&repo_root, issue);
+            match resolved.arm {
+                Some(arm) => log::info!(
+                    "work_finder: dispatching issue #{issue} with arm={arm} model={} \
+                     (source={})",
+                    resolved.model,
+                    resolved.source_label
+                ),
+                None => log::info!(
+                    "work_finder: dispatching issue #{issue} with model={} (source={})",
+                    resolved.model,
+                    resolved.source_label
+                ),
+            }
+            let model = resolved.model;
             // Idempotency key + the registry's claim lock make a re-dispatch of
             // an already-running issue a no-op (`was_new = false`) or a loud
             // lock-collision error.


### PR DESCRIPTION
## Summary

The model-cost A/B experiment (#3725) collected zero records across a full
day of canary sweeps (2026-07-31) because of two independent, compounding
defects: (1) `sweep.md`'s per-phase prose instrumentation (banner,
`assign-arm`/`record` calls) is LLM-authored and never executed in headless
`-p` children, and (2) the #4501 dispatch model pin is tier-1 and structurally
overrode a model that was only ever "forced" in prose. This PR moves arm
assignment and outcome attribution into the daemon, where the model dispatch
decision already lives, so the fix is mechanical instead of prose-dependent.

## Changes

- **`loom-daemon/src/sweep_registry/model.rs`**: new
  `resolve_autonomous_dispatch_model(repo_root, issue)` — resolves the
  CANARY-gated experiment mode (same env vars / config / sentinel guardrail as
  `sweep-experiment.sh resolve-mode`) and, when it resolves to `experiment`,
  computes the deterministic per-issue arm (`assign_arm`) and substitutes the
  arm-forced model (`resolved_arm_model`) ahead of the #3944/#4501
  config/default precedence chain. `off`/`observe` modes are byte-identical to
  the existing `resolve_dispatch_model` (verified by test).
- **`loom-daemon/src/work_finder.rs`**, **`loom-daemon/src/epic_supervisor.rs`**:
  wired the new resolver into the two autonomous, explicit-model-absent
  per-issue dispatch call sites (`work_finder::dispatch`,
  `epic_supervisor::SpawnDispatcher::dispatch_sweep`), logging `arm=A|B` in the
  dispatch line when the experiment fires.
- **`loom-daemon/src/ipc.rs`**: the `dispatch_sweep` MCP handler now also
  resolves through the experiment-aware path when it is a single-issue
  dispatch with no explicit `model` param (an explicit param still always
  wins — unchanged precedence).
- **`loom-daemon/src/sweep_registry/outcome_journal.rs`**: `sweep.outcome`
  telemetry records are attributed an `arm` (inferred from the sweep's own
  dispatched model via the existing `infer_arm_from_model`, the same
  inference the #3725 harvest already applies to `observe`-mode records) in
  the free-form `config` map — additive, no schema-version bump (#4703).
- **`defaults/.claude/commands/loom/sweep.md`**: demoted the per-phase prose
  instrumentation section to a documented best-effort fallback for non-daemon
  dispatch paths (manual/in-session sweeps), noting the daemon-native path is
  now authoritative for daemon-dispatched sweeps.
- **`defaults/docs/model-selection.md`**: documents the new
  `resolve_autonomous_dispatch_model` precedence insertion point alongside the
  existing `resolve_dispatch_model` reference.

## Deferred scope (follow-up: #4827)

- **Per-issue complexity stratification at dispatch time.** `assign_arm`
  accepts an optional complexity stratum to balance both `routine`/`complex`
  populations independently; none of the three dispatch call sites currently
  fetch the issue body, so arm assignment always uses the default `"routine"`
  stratum. This keeps assignment fully deterministic (still a pure function
  of the issue number) but does not yet stratify. Wiring the real
  `<!-- loom:complexity=... -->` marker requires plumbing the issue body
  (already fetched by the REST listing, just not threaded through
  `WorkItem`/`dispatch()`) — filed as #4827.
- **Explicit `arm` field on `SweepInfo`** instead of inferring it from the
  dispatched model at outcome-recording time. Inference is exactly equivalent
  to the explicit arm today (the daemon always forces exactly an
  opus/sonnet-family model in `experiment` mode) and avoids a ~40-call-site
  `SweepInfo { .. }` struct-literal migration; noted in #4827 as an optional
  future refinement if that equivalence ever breaks.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|---------------|
| Canary dispatch logs show `arm=A model=claude-opus-5` / `arm=B model=sonnet` with the #4501 pin suppressed only under resolved-experiment mode (CANARY required) | ✅ | New unit tests `autonomous_dispatch_experiment_with_canary_forces_the_arm_model`, `autonomous_dispatch_confirms_canary_via_untracked_sentinel_file`, `autonomous_dispatch_experiment_without_canary_downgrades_to_observe` in `sweep_registry/model.rs`; dispatch-site log lines format `arm=<A|B> model=<model>` when the experiment fires. |
| Outcome records carry arm/complexity; per-arm data queryable via the #4726 API | ✅ (arm) / deferred (complexity, see #4827) | New tests in `sweep_registry/outcome_journal.rs` assert `record.config.get("arm")` is `"A"`/`"B"`/absent depending on the dispatched model. Complexity stratification deferred to #4827 (still uses the existing, valid `"routine"` default). |
| Deterministic assignment property preserved (same issue → same arm across resumes) | ✅ | `autonomous_dispatch_arm_assignment_is_deterministic_across_resumes` — repeated calls for the same issue return the same arm+model; the underlying `assign_arm` is an unmodified pure function. |
| `observe` mode continues to add zero behavior change; `off` mode byte-identical | ✅ | `autonomous_dispatch_off_by_default_is_byte_identical` asserts the result matches calling `resolve_dispatch_model` directly; `autonomous_dispatch_observe_mode_honors_existing_config_precedence` and `autonomous_dispatch_experiment_without_canary_downgrades_to_observe` assert `observe` never forces a model. |
| The #3718 harvest inequality computable from the recorded fields alone | ✅ | `arm` is now populated on real `sweep.outcome` telemetry records (the existing per-arm cost/merge-rate/pass-rate rollup in `script_helpers::sweep_experiment::harvest` already consumes exactly this shape); complexity stratification is the one deferred refinement (#4827), not a blocker for the pooled inequality. |

## Test Plan

- `cargo test --lib sweep_registry::model::` — 19 passed (includes 6 new
  tests for `resolve_autonomous_dispatch_model`: off/observe byte-identity,
  experiment+canary arm forcing for both arms, determinism across resumes,
  untracked-sentinel canary confirmation, observe-mode config precedence).
- `cargo test --lib telemetry_outcome` — 9 passed (includes 3 new/extended
  tests asserting `arm` attribution on outcome records: opus→A, sonnet→B, and
  an unattributable model → no `arm` key).
- `cargo test --lib work_finder::` — 123 passed.
- `cargo test --lib epic_supervisor::` — 47 passed.
- `cargo test --lib dispatch_sweep` — 15 passed (ipc.rs MCP handler tests).
- `cargo test --test sweep_md_doc_lint` — 20 passed (sweep.md doc-lint
  assertions on the "Model-cost experiment mode" section still hold).
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test --lib` (full suite) — 2919/2920 passed. The one failure,
  `sweep_registry::guards::tests::restore_label_to_ready_does_not_add_loom_issue_when_target_is_pr`,
  is in a file this PR does not touch (`guards.rs`) and passes cleanly in
  isolation (`cargo test --lib restore_label_to_ready_does_not_add_loom_issue_when_target_is_pr`
  → 1 passed) — a pre-existing test-isolation flake under full-suite
  parallelism (the test mutates the global `LOOM_REPO` env var without
  `#[serial]`), unrelated to this change.

Closes #4809
