### PR TITLE
fix(worktree): track existing origin/feature/issue-N branch instead of branching fresh off main

### DIFF
--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -74,6 +74,30 @@ fi
 
 Both worktree paths get a `.loom-managed` sentinel and are auto-cleaned by `merge-pr.sh` on merge.
 
+### Expected worktree state after setup (#4823)
+
+For a `feature/issue-<N>` branch, `worktree.sh <N>` fetches `origin/feature/issue-<N>`
+first: if that remote branch already exists (the normal case for a Doctor cycle —
+the Builder already pushed it and opened the PR), the worktree's local branch is
+created **tracking that remote branch**, not branched fresh from
+`origin/$DEFAULT_BRANCH`. So after `worktree.sh <ISSUE_NUM>` returns, the worktree
+HEAD should already equal the PR's current head commit:
+
+```bash
+git -C .loom/worktrees/issue-<ISSUE_NUM> rev-parse HEAD
+gh pr view <PR_NUMBER> --json headRefOid --jq '.headRefOid'
+# the two commit SHAs above should match
+```
+
+If they don't match, do **not** assume the worktree is simply stale and force-push
+over it — `git fetch && git reset --hard origin/feature/issue-<ISSUE_NUM>` first
+to align the local branch with the real PR history, then re-point the upstream
+(`git branch --set-upstream-to=origin/feature/issue-<ISSUE_NUM>`) before making any
+edits. A worktree whose HEAD does *not* match the PR's remote head is either
+running an older `worktree.sh` (pre-#4823) or a symptom of a genuinely diverged
+local state — either way, fixing review feedback on top of the wrong base produces
+a PR-clobbering force-push or a diff against the wrong parent.
+
 ## ⚠️ `--body @path` Does NOT Expand — It Posts the Literal String
 
 **If a comment you're posting (fix summary, clarifying question, conflict-only

--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -102,6 +102,7 @@ test-worktree-concurrency.sh
 test-worktree-hookspath.sh
 test-worktree-json-purity.sh
 test-worktree-nested-symlinks.sh
+test-worktree-remote-branch-tracking.sh
 test-worktree-remove.sh
 test-worktree-root-override.sh
 test-worktree-sentinel-reinvoke.sh

--- a/defaults/scripts/tests/test-worktree-remote-branch-tracking.sh
+++ b/defaults/scripts/tests/test-worktree-remote-branch-tracking.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# test-worktree-remote-branch-tracking.sh — Tests for remote-branch tracking on
+# worktree creation (#4823)
+#
+# Verifies that when `worktree.sh N` finds no LOCAL `refs/heads/feature/issue-N`
+# but origin already has a pushed `refs/remotes/origin/feature/issue-N` (e.g. an
+# existing PR branch from a prior Builder/Doctor cycle), it fetches and creates
+# the local branch tracking that remote ref — instead of silently branching a
+# fresh copy off origin/$DEFAULT_BRANCH, which diverges from the real PR history
+# and risks a PR-clobbering force-push or a diff against the wrong base.
+#
+# Coverage:
+#   1. Remote branch exists, no local branch: worktree.sh tracks origin/<branch>
+#      (the worktree HEAD carries the PR branch's unique commit), not a fresh
+#      branch off origin/main.
+#   2. Remote branch exists AND has diverged from the current base (main
+#      advanced past it after the PR branch was cut): worktree.sh still tracks
+#      origin/<branch> (prefers the remote, per the issue's acceptance
+#      criteria) and logs a line noting the divergence.
+#
+# Pattern follows test-worktree-base-override.sh: throwaway bare origin + repo
+# in a mktemp dir, copy worktree.sh + lib/, run.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKTREE_SH="$SCRIPTS_DIR/worktree.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+# Build a throwaway repo with an origin/main ref plus a pushed PR branch
+# (feature/issue-77) carrying one unique commit — but with NO local copy of
+# that branch (deleted after push), simulating a fresh clone / cleaned-up
+# worktree that never had it locally. When advance_main=true, origin/main is
+# advanced with an extra commit AFTER the PR branch was cut, so the PR branch
+# no longer contains all of main's history (the divergence case). Echoes the
+# working-tree path.
+setup_repo() {
+    local name="${1:-remoterepo}"
+    local advance_main="${2:-false}"
+    local tmp
+    tmp=$(mktemp -d /tmp/loom-wtremote.XXXXXX)
+    git init -q -b main "$tmp/origin.git" --bare
+    git init -q -b main "$tmp/$name"
+    (
+        cd "$tmp/$name"
+        git config user.email t@t
+        git config user.name t
+        git commit --allow-empty -q -m init
+        git remote add origin "$tmp/origin.git"
+        git push -q origin main
+        mkdir -p .loom/scripts/lib .loom/hooks
+        cp "$WORKTREE_SH" .loom/scripts/worktree.sh
+        if [[ -d "$SCRIPTS_DIR/lib" ]]; then
+            cp -R "$SCRIPTS_DIR"/lib/* .loom/scripts/lib/ 2>/dev/null || true
+        fi
+        chmod +x .loom/scripts/worktree.sh
+
+        # Create the "existing PR" branch, push it, then delete the LOCAL
+        # copy (origin keeps it) — this is the scenario the fix targets.
+        git checkout -q -b feature/issue-77
+        echo "pr-artifact" > pr-file.txt
+        git add pr-file.txt
+        git commit -q -m "pr: add artifact from existing PR branch"
+        git push -q origin feature/issue-77
+        git checkout -q main
+        git branch -q -D feature/issue-77
+
+        if [[ "$advance_main" == "true" ]]; then
+            echo "later-main-work" > later-main.txt
+            git add later-main.txt
+            git commit -q -m "main: advance past the PR branch"
+            git push -q origin main
+        fi
+    )
+    echo "$tmp/$name"
+}
+
+cleanup_repo() {
+    local repo="$1"
+    [[ -z "$repo" ]] && return 0
+    rm -rf "$(dirname "$repo")"
+}
+
+# --- Test 1: no local branch, remote PR branch exists -> tracks the remote ---
+echo "Test 1: no local branch + origin/feature/issue-77 exists -> worktree tracks the remote branch"
+REPO=$(setup_repo trackrepo false)
+OUT_LOG="/tmp/wtremote-track.$$"
+(
+    cd "$REPO"
+    ./.loom/scripts/worktree.sh 77 >"$OUT_LOG" 2>&1 || { echo "FAILED"; cat "$OUT_LOG"; }
+)
+if [[ -f "$REPO/.loom/worktrees/issue-77/pr-file.txt" ]]; then
+    pass "worktree contains the PR branch's unique artifact (tracked origin/feature/issue-77, not a fresh branch off main)"
+else
+    fail "worktree is missing the PR branch's artifact (silently branched off main instead of tracking origin/feature/issue-77)"
+fi
+WT_HEAD=$(git -C "$REPO/.loom/worktrees/issue-77" rev-parse HEAD 2>/dev/null || echo "")
+ORIGIN_HEAD=$(git -C "$REPO" rev-parse origin/feature/issue-77 2>/dev/null || echo "")
+if [[ -n "$WT_HEAD" && "$WT_HEAD" == "$ORIGIN_HEAD" ]]; then
+    pass "worktree HEAD equals origin/feature/issue-77's head commit"
+else
+    fail "worktree HEAD ($WT_HEAD) does not equal origin/feature/issue-77 ($ORIGIN_HEAD)"
+fi
+cleanup_repo "$REPO"
+rm -f "$OUT_LOG"
+
+# --- Test 2: remote branch has diverged from the current base -> still tracks it, with a log line ---
+echo ""
+echo "Test 2: origin/feature/issue-77 diverged from origin/main -> still tracks the remote, logs divergence"
+REPO=$(setup_repo divrepo true)
+OUT_LOG="/tmp/wtremote-div.$$"
+(
+    cd "$REPO"
+    ./.loom/scripts/worktree.sh 77 >"$OUT_LOG" 2>&1 || { echo "FAILED"; cat "$OUT_LOG"; }
+)
+if [[ -f "$REPO/.loom/worktrees/issue-77/pr-file.txt" ]]; then
+    pass "diverged case: worktree still contains the PR branch's artifact (prefers the remote)"
+else
+    fail "diverged case: worktree is missing the PR branch's artifact"
+fi
+if [[ -f "$REPO/.loom/worktrees/issue-77/later-main.txt" ]]; then
+    fail "diverged case: worktree unexpectedly contains main's post-divergence commit (branched off main instead of the PR branch)"
+else
+    pass "diverged case: worktree does NOT contain main's post-divergence commit"
+fi
+if grep -qi "diverged" "$OUT_LOG"; then
+    pass "diverged case: worktree.sh logs a line noting the divergence"
+else
+    fail "diverged case: no log line noting the divergence"
+    cat "$OUT_LOG"
+fi
+cleanup_repo "$REPO"
+rm -f "$OUT_LOG"
+
+# --- Summary ---
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+[[ $TESTS_FAILED -eq 0 ]] || exit 1

--- a/defaults/scripts/worktree.sh
+++ b/defaults/scripts/worktree.sh
@@ -1543,12 +1543,39 @@ if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
 
     CREATE_ARGS=("$WORKTREE_PATH" "$BRANCH_NAME")
 else
-    # Create new branch from the base ref (origin/$DEFAULT_BRANCH by default, or
-    # the --base override for a stacked child — #3729).
-    if [[ "$JSON_OUTPUT" != "true" ]]; then
-        print_info "Creating new branch from $BASE_DISPLAY"
+    # No local branch by this name. Before falling back to a fresh branch off
+    # BASE_REF, check whether origin already has a pushed branch of the exact
+    # same name — e.g. an existing PR branch from a prior Builder/Doctor cycle
+    # (#4823). Without this check, a Doctor fixing review feedback on an
+    # already-pushed PR would silently get a NEW branch created from
+    # origin/$DEFAULT_BRANCH instead of the real PR history, risking a
+    # PR-clobbering force-push or a diff against the wrong base. This is
+    # independent of --base (which only chooses the start point when we DO
+    # need to create a fresh branch, below).
+    git fetch origin "$BRANCH_NAME" 2>/dev/null || true
+    if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
+        if [[ "$JSON_OUTPUT" != "true" ]]; then
+            print_info "Remote branch 'origin/$BRANCH_NAME' already exists - creating a local branch tracking it (not branching from $BASE_DISPLAY)"
+        fi
+        # Informational only: the remote branch always wins here (it IS the
+        # PR history to continue), but note when it doesn't contain all of
+        # BASE_DISPLAY's history (e.g. pushed before recent main commits
+        # landed) so a caller reading the log understands why the worktree
+        # isn't rebased on top of the latest base.
+        if ! git merge-base --is-ancestor "$BASE_REF" "refs/remotes/origin/$BRANCH_NAME" 2>/dev/null; then
+            if [[ "$JSON_OUTPUT" != "true" ]]; then
+                print_warning "origin/$BRANCH_NAME has diverged from $BASE_DISPLAY (does not contain all of its history) - tracking origin/$BRANCH_NAME as-is"
+            fi
+        fi
+        CREATE_ARGS=("$WORKTREE_PATH" "-b" "$BRANCH_NAME" "origin/$BRANCH_NAME")
+    else
+        # Create new branch from the base ref (origin/$DEFAULT_BRANCH by default, or
+        # the --base override for a stacked child — #3729).
+        if [[ "$JSON_OUTPUT" != "true" ]]; then
+            print_info "Creating new branch from $BASE_DISPLAY"
+        fi
+        CREATE_ARGS=("$WORKTREE_PATH" "-b" "$BRANCH_NAME" "$BASE_REF")
     fi
-    CREATE_ARGS=("$WORKTREE_PATH" "-b" "$BRANCH_NAME" "$BASE_REF")
 fi
 
 # In sparse mode, defer file materialization until after we configure the cone.


### PR DESCRIPTION
## Summary
`worktree.sh N` resolved the branch base unconditionally to `origin/$DEFAULT_BRANCH` whenever no LOCAL `feature/issue-N` branch existed — it never checked whether `origin/feature/issue-N` was already pushed. A Doctor cycle fixing review feedback on an already-open PR (no local worktree left from the Builder session) got a fresh branch created off `origin/main`, diverging from the real PR history. This risks a PR-clobbering force-push or a diff against the wrong base.

## Changes
- `defaults/scripts/worktree.sh`: when no local `refs/heads/feature/issue-N` exists, fetch `origin/feature/issue-N` first. If it exists, create the local branch tracking that remote ref instead of branching from `BASE_REF`. Logs an informational warning when the remote branch has diverged from the current base (main advanced past it), while still preferring the remote per the issue's acceptance criteria.
- `defaults/.claude/commands/loom/doctor.md` (source of truth for `.loom/roles/doctor.md`): documents the expected post-`worktree.sh` state for a Doctor cycle — worktree HEAD should equal the PR's remote head commit — and what to do if it doesn't.
- `defaults/scripts/tests/test-worktree-remote-branch-tracking.sh`: new hermetic test suite (throwaway bare `origin` + repo in `mktemp`, following `test-worktree-base-override.sh`'s pattern) covering the tracking case and the diverged case.
- `defaults/scripts/tests/ci-wired.txt`: wired the new suite into `shell-suite-tests` CI (hermetic, no network/live-forge calls).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| When `origin/feature/issue-N` exists, `worktree.sh N` checks out a local branch tracking it instead of branching from the default branch | ✅ | New test 1 in `test-worktree-remote-branch-tracking.sh`: no local branch, `origin/feature/issue-77` pushed with a unique commit → resulting worktree HEAD equals `origin/feature/issue-77`'s head, not a fresh branch off main |
| When both exist and diverge, prefer the remote (with a log line) | ✅ | New test 2: `origin/main` advanced past `origin/feature/issue-77` after the branch was cut → worktree still tracks `origin/feature/issue-77` (not main's later commit) and `worktree.sh` prints a line noting the divergence |
| doctor.md documents the expected worktree state after setup | ✅ | Added "Expected worktree state after setup (#4823)" section to `defaults/.claude/commands/loom/doctor.md` (source of truth for `.loom/roles/doctor.md`) |

## Test Plan
- `bash defaults/scripts/tests/test-worktree-remote-branch-tracking.sh` — 5/5 assertions pass (new suite)
- `bash defaults/scripts/tests/test-worktree-base-override.sh` — 6/6 assertions pass (regression: no-`--base`, no-existing-remote-branch default path unchanged; `--base` stacked-child path unaffected)
- `bash defaults/scripts/tests/test-worktree-concurrency.sh` — 6/6 assertions pass (regression: lock/staleness handling unaffected)
- `bash defaults/scripts/tests/check-ci-suite-manifest.sh` — confirms the new suite is wired into CI, not orphaned
- `shellcheck defaults/scripts/worktree.sh` — only a pre-existing, unrelated SC2126 warning at a different line (`UNINIT_SUBMODULES` grep|wc -l)

Closes #4823