### PR TITLE
docs(champion-pr-merge): correct REASON_KEY guard reappearance-detection claim

### DIFF
--- a/defaults/.claude/commands/loom/champion-pr-merge.md
+++ b/defaults/.claude/commands/loom/champion-pr-merge.md
@@ -1198,8 +1198,13 @@ identity** instead: the failing criterion (`$CRITERION_KEY`) *plus* a determinis
 `$REASON_KEY` built mechanically from the failure data — never freeform prose — so
 near-duplicate wording for the *same* underlying failure is recognized and
 suppressed, while a genuinely different failure (a different check name, a different
-set of missing labels, …) or the same check clearing and then failing again still
-produces a fresh comment:
+set of missing labels, …) produces a fresh comment. **Known limitation:** the guard
+only compares against the single most-recently-posted marker for the criterion, so
+it cannot represent "this criterion passed at some intervening tick" (a passing tick
+posts no marker) — if the identical `$REASON_KEY` reappears after clearing and
+re-failing, it is still treated as a duplicate and the comment is suppressed. This
+is accepted: it under-notifies on a re-flapped check rather than spamming, and
+doesn't affect merge/safety decisions (#4835):
 
 - **ci-status**: the sorted, comma-joined list of currently failing/cancelled check
   names (`echo "$FAILING_CHECKS" | sort | paste -sd, -`) — not the prose sentence
@@ -1227,9 +1232,13 @@ REASON="<SPECIFIC_REASON>"  # human-readable prose for the comment body — free
 # Idempotency guard: find the most recently posted rejection comment for this
 # criterion (any REASON_KEY) and compare its marker line, verbatim, against the
 # marker for the CURRENT failure. Skip re-commenting only when the identity is
-# unchanged — a different REASON_KEY (a different failing check, a different missing
-# label, …), or the same key reappearing after the criterion cleared and failed
-# again, always gets a fresh comment.
+# unchanged. A different REASON_KEY (a different failing check, a different missing
+# label, …) always gets a fresh comment. Known limitation: because this only looks
+# at the single most-recently-posted marker, a REASON_KEY that reappears after the
+# criterion cleared (passed) and then failed again with the same identity is
+# indistinguishable from "never cleared" and is still suppressed as a duplicate
+# (#4835) — acceptable since it under-notifies rather than spams and doesn't affect
+# merge/safety decisions.
 LAST_MARKER=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments' \
   | jq -r --arg prefix "<!-- champion:reject:$CRITERION_KEY:" \
   '[.[] | select(.body | startswith($prefix))] | last | .body // "" | split("\n")[0]')


### PR DESCRIPTION
## Summary

PR #4833 keyed the transient-rejection idempotency guard in
`defaults/.claude/commands/loom/champion-pr-merge.md` on a stable
`$REASON_KEY`, but the prose intro and the inline bash comment for the
guard overstated its behavior — claiming that "the same check clearing and
then failing again" always produces a fresh comment.

In reality, the guard only compares the current `$REJECT_MARKER` against
the single most-recently-posted marker for that criterion
(`LAST_MARKER`). It has no way to represent "the criterion passed at some
intervening tick," since a passing tick posts no comment/marker. So if a
check fails (marker A), then passes, then fails again with the identical
`$REASON_KEY`, the guard treats it as a duplicate and suppresses the
comment — the opposite of what the docs claimed.

This is a documentation-accuracy fix only (Option 1 from the issue): the
prose and bash comment now describe the guard's actual behavior — a
REASON_KEY reappearing after an intervening clear is still treated as a
duplicate (accepted limitation: under-notifies rather than spams, and
doesn't affect merge/safety decisions). No runtime logic changed.

Verified there is only one copy of this guard text in the repo (grepped
for `REASON_KEY` across all markdown) — no installed/synced counterpart
needed updating.

Closes #4835

## Test plan

- [x] Confirmed via grep that `defaults/.claude/commands/loom/champion-pr-merge.md` is the sole copy of this guard text (no `.loom/roles/` or other synced copy)
- [x] Prose-only change; no lint/build/test suite applies (no markdown-lint or docs-consistency checker found in repo)
- [x] Manually re-read the corrected section for internal consistency