### PR TITLE
docs: add docs/ index README and ignore Python tool caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@ dist-ssr/
 # Test outputs
 coverage/
 
+# Tool caches (regenerable)
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+
 # Env files
 .env
 .env.local

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,37 @@
+# Loom Documentation
+
+Reference documentation for the Loom repository. Operating instructions for
+agents live in [`CLAUDE.md`](../CLAUDE.md); runtime subsystem reference that
+ships to consumer repos lives in [`defaults/docs/`](../defaults/docs/) (installed
+as `.loom/docs/`).
+
+## Directories
+
+| Path | Contents |
+|------|----------|
+| [`adr/`](adr/) | Architecture Decision Records (0001–0013) plus a [template](adr/template.md). Start at the [ADR index](adr/README.md). |
+| [`api/`](api/) | API surface reference. |
+| [`design/`](design/) | Design notes for specific subsystems — config resolution tiers, the label state machine, the supervised restart primitive, Architect/Hermit cadence. |
+| [`guides/`](guides/) | How-to guides: getting started, quickstart tutorial, development, dev workflow, git workflow, testing, code quality, CI/CD setup, CLI reference, daemon dev mode, fork drift, troubleshooting, styling, TypeScript conventions, common tasks. |
+| [`mcp/`](mcp/) | MCP server documentation — see the [MCP README](mcp/README.md) and [loom-terminals](mcp/loom-terminals.md). |
+| [`migration/`](migration/) | Completed-migration history: the [v0.10.0 shepherd deprecation](migration/v0.10.0-shepherd-deprecation.md), the [v0.10.0 daemon rebuild](migration/v0.10.0-daemon-rebuild.md), and [daemon-state consumers](migration/daemon-state-consumers.md). |
+| [`notes/`](notes/) | Ad-hoc technical notes. |
+| [`philosophy/`](philosophy/) | Essays on agent archetypes, AI code smell, Loom intelligence, and working with AI. |
+| [`research/`](research/) | Evaluations and measurement runbooks — builder/judge fan-out, codecast, dynamic workflows. |
+
+## Top-level documents
+
+| File | Purpose |
+|------|---------|
+| [`agents.md`](agents.md) | Agent role overview. |
+| [`workflows.md`](workflows.md) | Workflow reference. |
+| [`autonomous-mode-e2e.md`](autonomous-mode-e2e.md) | End-to-end autonomous mode walkthrough. |
+| [`measure-est-cores-per-sweep.md`](measure-est-cores-per-sweep.md) | Method for measuring estimated cores per sweep. |
+| [`model-selection-retune.md`](model-selection-retune.md) | Model-selection retuning notes. |
+
+## Related
+
+- [`CLAUDE.md`](../CLAUDE.md) — the operating core for agents working in this repo
+- [`README.md`](../README.md) — project overview and installation
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — contribution workflow
+- [`CHANGELOG.md`](../CHANGELOG.md) — release history


### PR DESCRIPTION
Two findings from a `/repo:all` hygiene pass. Both are additive and low-risk.

## `docs/README.md` (new)

`docs/` had no README despite 9 browsable subdirectories and 5 top-level
documents, so GitHub rendered no index for anyone navigating there. Adds an
index table covering `adr/`, `api/`, `design/`, `guides/`, `mcp/`,
`migration/`, `notes/`, `philosophy/`, `research/`, plus the top-level docs,
and cross-links `CLAUDE.md` / `README.md` / `CONTRIBUTING.md` / `CHANGELOG.md`.

Every link was verified to resolve against the current tree.

## `.gitignore` — Python tool caches

No rules existed for the Python tool caches present on disk (`.pytest_cache/`,
`.ruff_cache/`). They self-ignore today via their own generated `.gitignore`
files, so nothing was ever at risk — this just makes the rule explicit
alongside the other build outputs. Verified that no tracked file becomes
ignored.

The added block sits above the `>>> loom-managed` region and does not touch it.

## Notes for the reviewer

- No overlap with open PR #4796 (`hygiene/repo-hygiene-20260731`), which covers
  `defaults/docs/safehouse.md` + `token-pool.md` and a different set of READMEs.
- An earlier revision of this change also added `__pycache__/` and `*.pyc`.
  Those two patterns disappeared from the working tree twice during the session
  and are deliberately omitted here. The cause is **unknown and was not
  reproduced** — the daemon's `update_gitignore` reconciler was investigated and
  ruled out (it only rewrites the `loom-managed` block, and
  `loom-daemon/src/init/post_init.rs:960` is a test asserting consumer
  `__pycache__/` rules are preserved). Omitting them is a conservative choice,
  not a diagnosis; add them separately if you want them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
