### PR TITLE
fix(guards): correct false stash-isolation claim + gate worktree-to-worktree stash collisions

### DIFF
--- a/defaults/.claude/commands/loom/builder-worktree.md
+++ b/defaults/.claude/commands/loom/builder-worktree.md
@@ -205,9 +205,16 @@ cd .loom/worktrees/issue-XX
 - Always use `./.loom/scripts/worktree.sh` to create branches
 - Prevents nested worktree issues
 
-**Don't run `git stash` in main and try to apply in worktrees**
-- Stash is local to the repository, not shared between worktrees
-- Each worktree has its own working directory
+**Don't use `git stash` for ad-hoc WIP handling in a worktree**
+- Stash (`refs/stash`) is **shared repo-wide across every linked worktree** —
+  the opposite of per-worktree isolation. Two parallel builders in different
+  worktrees can `git stash` and `git stash pop` each other's WIP, silently
+  swapping or overwriting uncommitted work (observed in production: kicad-tools
+  PRs #4524/#4526).
+- Use `./.loom/scripts/worktree.sh snapshot <issue-number>` instead — it
+  captures WIP as a patch file under
+  `<worktree-root>/.snapshots/issue-<N>-<timestamp>.patch`, scoped to your own
+  worktree, with no risk of collision with other builders' stashes.
 
 **Don't use `git push --force` without `--force-with-lease`**
 - `--force-with-lease` is safer - it fails if someone else pushed

--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -296,6 +296,27 @@ For detailed worktree workflows, see **builder-worktree.md**.
 - Use `./.loom/scripts/worktree.sh <issue-number>` to create worktrees
 - Work in `.loom/worktrees/issue-N` directories
 
+### Never use bare `git stash` for ad-hoc WIP (#4821)
+
+`refs/stash` is **one stack shared across every linked worktree of the
+repo** — not per-worktree. If you `git stash` / `git stash pop` /
+`git stash drop` to temporarily shelve WIP, a concurrent builder in a
+*different* worktree doing the same thing can pop or drop **your** stash
+entry (or you can pop theirs), silently swapping or discarding uncommitted
+work. This is not hypothetical — it happened in production (kicad-tools PRs
+#4524/#4526).
+
+**Use `./.loom/scripts/worktree.sh snapshot <issue-number>` instead** — it
+writes your WIP as a patch file under
+`<worktree-root>/.snapshots/issue-<N>-<timestamp>.patch`, scoped to your own
+worktree, so there is no shared stack to collide on.
+
+This does **not** apply to the `check-main-clean.sh --quarantine` recovery
+flow below (§"If it exits 3…") — that flow's use of `git stash` operates on
+the **main checkout**, is single-writer by construction (only one agent's
+mistaken edits land in main at a time), and is a distinct, legitimate use
+case (rescuing contamination, not shelving your own WIP).
+
 ## CRITICAL: Never Work on Main Branch
 
 **You MUST work in a worktree, never directly on main.**

--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -98,6 +98,21 @@ running an older `worktree.sh` (pre-#4823) or a symptom of a genuinely diverged
 local state — either way, fixing review feedback on top of the wrong base produces
 a PR-clobbering force-push or a diff against the wrong parent.
 
+### Never use bare `git stash` for ad-hoc WIP (#4821)
+
+`refs/stash` is **one stack shared across every linked worktree of the
+repo** — not per-worktree. If you `git stash` / `git stash pop` /
+`git stash drop` to temporarily shelve WIP while fixing a PR, a concurrent
+Builder or Doctor in a *different* worktree doing the same thing can pop or
+drop **your** stash entry (or you can pop theirs), silently swapping or
+discarding uncommitted work. This happened in production (kicad-tools PRs
+#4524/#4526).
+
+**Use `./.loom/scripts/worktree.sh snapshot <issue-number>` instead** — it
+writes your WIP as a patch file under
+`<worktree-root>/.snapshots/issue-<N>-<timestamp>.patch`, scoped to your own
+worktree, so there is no shared stack to collide on.
+
 ## ⚠️ `--body @path` Does NOT Expand — It Posts the Literal String
 
 **If a comment you're posting (fix summary, clarifying question, conflict-only

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -438,6 +438,15 @@ The subagent-path target is **soft** — there is no hard upper bound and the wa
 
 **Waves parallelize Builders only.** The reason a wave can safely fan out `N` agents at once is that each Builder works in an isolated git worktree and produces **exactly one PR at the end** — no shared mutable forge state is touched mid-run, so two concurrent Builders never collide. `/loom:sweep` itself only ever dispatches Builders (plus per-issue Curator/Judge/Doctor, which run **sequentially within a wave**), so today's wave loop is safe by construction.
 
+**Exception: the git stash stack (#4821).** `refs/stash` is shared across
+*every* linked worktree of the repo, not per-worktree — so if two
+concurrent Builders in a wave both use bare `git stash` for ad-hoc WIP
+handling, one can pop or drop the other's entry (observed in production:
+kicad-tools PRs #4524/#4526). This is the one piece of shared mutable state
+the isolated-worktree argument above does not cover. Builders must use
+`./.loom/scripts/worktree.sh snapshot <issue-number>` (a per-worktree patch
+file) instead of `git stash` for WIP — see `defaults/roles/builder.md`.
+
 **Never dispatch two or more issue-creating agents concurrently.** Agents that **create issues** — Architect proposals, Curator oversized-issue decomposition, Champion epic-phase creation — mutate the forge's **shared, server-assigned issue-number space** with no client-side coordination, transaction, or idempotency key. When two such agents run `gh issue create` bursts at the same time they **race on issue numbers and cross-contaminate bodies** (one epic's title paired with another's body), and any recovery/retry loop that PATCHes-by-title amplifies the damage by winning every write race against the other still-active filer. This is not hypothetical: it was observed 2026-07-21 on a 4-wide wave (1 builder + 3 architects) — 2 duplicate issues, 3 with mismatched title/body, and a corrupted roadmap comment, all needing manual reconciliation (#3707).
 
 Concrete rules for anyone extending this skill or hand-driving a wave:

--- a/defaults/docs/guard-hooks.md
+++ b/defaults/docs/guard-hooks.md
@@ -657,6 +657,22 @@ check does not parse `-C`: `git -C <main-checkout-path> stash pop` run from a
 worktree cwd is **not** caught today. If this bypass shows up in practice,
 extend the check to thread `-C` the same way `parse_force_ops` does.
 
+**Worktree-to-worktree collisions (#4821).** The main-checkout-only test above
+protects the *operator-owned* main-checkout stash stack, but `refs/stash` is
+actually a **single stack shared by every linked worktree of the repo**, not
+per-worktree — so two parallel Builders each in a *different* linked
+worktree (neither one the main checkout) can pop or drop each other's entry.
+This is exactly the incident category that motivated #4821 (kicad-tools PRs
+#4524/#4526): two builders in linked worktrees, not the main checkout, raced
+on the shared stash stack. The guard now additionally asks when cwd is a
+linked worktree **and** two or more `.loom-managed` worktrees currently
+exist under `<main>/.loom/worktrees/` (a single active worktree has no one
+else's entry to collide with, so it stays ungated). The prescribed
+prevention remains procedural, not just guard-enforced — prefer
+`./.loom/scripts/worktree.sh snapshot <issue-number>` (patch-file WIP
+capture, scoped to one worktree, no shared stack) over ad-hoc `git stash`
+for WIP handling (see `defaults/roles/builder.md` / `defaults/roles/doctor.md`).
+
 **Examples**:
 
 ```bash

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -2658,6 +2658,16 @@ fi
 # stash pop` run from a worktree cwd is not caught today. Track any observed
 # bypass via this path as a follow-up.
 #
+# WORKTREE-TO-WORKTREE COLLISION (#4821): refs/stash is a single stack shared
+# by EVERY linked worktree of the repo, not per-worktree — so two parallel
+# Builders each in a *different* linked worktree (neither one the main
+# checkout) can pop/drop each other's WIP, and the main-checkout-only check
+# above asks for neither side. Observed in production: kicad-tools PRs
+# #4524/#4526. Below, when cwd is a linked worktree (not the main checkout)
+# AND two or more `.loom-managed` worktrees currently exist under
+# `<main>/.loom/worktrees/`, we ask too — a single active worktree has no one
+# else's stash entry to collide with, so it stays ungated.
+#
 # Gated by stash_scope_guard_enabled() (guards.stashScope /
 # LOOM_GUARD_STASH_SCOPE, default on), invoked LAZILY only after the pattern
 # already matched, mirroring every other cold-path toggle in this file.
@@ -2679,6 +2689,21 @@ if echo "$COMMAND_ASK_SCAN" | grep -qE '(^|[;&|(]|[[:space:]])git[[:space:]]+sta
 
     if [[ -n "$_stash_toplevel" && -n "$_stash_common_parent" && "$_stash_toplevel" == "$_stash_common_parent" ]]; then
         ask "Command requires confirmation: $COMMAND (git stash pop/drop/clear in the MAIN checkout can destroy operator-preserved state — the main checkout's stash stack is operator-owned, not scratch space for an integration check. Run test-merges in an isolated worktree instead; set guards.stashScope:false / LOOM_GUARD_STASH_SCOPE=0 to disable this ask)" "stash-scope:main-checkout"
+    elif [[ -n "$_stash_toplevel" && -n "$_stash_common_parent" ]]; then
+        # cwd is a linked worktree, not the main checkout. Count OTHER
+        # `.loom-managed` worktrees under the main checkout's worktree root —
+        # a collision needs at least one other active worktree to race with.
+        _stash_worktree_count=0
+        if [[ -d "$_stash_common_parent/.loom/worktrees" ]]; then
+            while IFS= read -r _stash_wt_dir; do
+                [[ -f "$_stash_wt_dir/.loom-managed" ]] && \
+                    _stash_worktree_count=$((_stash_worktree_count + 1))
+            done < <(find "$_stash_common_parent/.loom/worktrees" -mindepth 1 -maxdepth 1 -type d 2>/dev/null)
+        fi
+
+        if [[ "$_stash_worktree_count" -ge 2 ]]; then
+            ask "Command requires confirmation: $COMMAND (git stash pop/drop/clear from a linked worktree can destroy ANOTHER builder's WIP — refs/stash is a single stack SHARED across every linked worktree of this repo, not per-worktree, and $_stash_worktree_count managed worktrees are currently active. Use './.loom/scripts/worktree.sh snapshot <issue-number>' instead of git stash for ad-hoc WIP; set guards.stashScope:false / LOOM_GUARD_STASH_SCOPE=0 to disable this ask)" "stash-scope:worktree-collision"
+        fi
     fi
 fi
 

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -2841,6 +2841,70 @@ rm -rf "$ST_REPO" "$ST_REPO_OFF"
 echo ""
 
 # =========================================================================
+echo -e "${YELLOW}--- Stash-stack scope: worktree-to-worktree collision (#4821) ---${NC}"
+# =========================================================================
+#
+# refs/stash is a SINGLE stack shared across every linked worktree of a repo
+# (not per-worktree, despite the intuitive naming) -- so two parallel
+# Builders each in a DIFFERENT linked worktree (neither one the main
+# checkout) can pop/drop each other's WIP. The main-checkout-only branch
+# above never asks in this configuration. With >=2 `.loom-managed`
+# worktrees active, a pop/drop/clear from ANY linked worktree cwd must ask;
+# with only ONE managed worktree (the existing block above), there is no
+# other worktree to collide with, so it stays ungated.
+
+make_wt_repo_two_linked() {
+    local dir
+    dir=$(make_wt_repo_linked)
+    git -C "$dir" worktree add -q "$dir/.loom/worktrees/issue-2" \
+        -b feature/issue-2 >/dev/null 2>&1
+    mkdir -p "$dir/.loom/worktrees/issue-2/src"
+    : > "$dir/.loom/worktrees/issue-2/.loom-managed"
+    echo "$dir"
+}
+
+ST2_REPO=$(make_wt_repo_two_linked)
+ST2_WT1_DIR="$ST2_REPO/.loom/worktrees/issue-1"
+ST2_WT2_DIR="$ST2_REPO/.loom/worktrees/issue-2"
+
+assert_ask "stash-scope: git stash pop from worktree-1 asks when >=2 managed worktrees exist (#4821)" \
+    "git stash pop" "$ST2_WT1_DIR"
+assert_ask "stash-scope: git stash drop from worktree-2 asks when >=2 managed worktrees exist (#4821)" \
+    "git stash drop" "$ST2_WT2_DIR"
+assert_ask "stash-scope: git stash clear from a linked worktree asks when >=2 managed worktrees exist (#4821)" \
+    "git stash clear" "$ST2_WT1_DIR"
+
+# Non-destructive subcommands remain ungated even with >=2 managed worktrees.
+assert_allow "stash-scope: git stash push from worktree stays ungated even with >=2 managed worktrees (#4821)" \
+    "git stash push -m wip" "$ST2_WT1_DIR"
+assert_allow "stash-scope: git stash apply from worktree stays ungated even with >=2 managed worktrees (#4821)" \
+    "git stash apply" "$ST2_WT1_DIR"
+assert_allow "stash-scope: git stash list from worktree stays ungated even with >=2 managed worktrees (#4821)" \
+    "git stash list" "$ST2_WT1_DIR"
+
+# The main checkout still asks via the original main-checkout branch,
+# independently of the worktree-collision branch (either condition alone
+# is sufficient to ask).
+assert_ask "stash-scope: git stash pop in main checkout still asks with >=2 managed worktrees (#4821)" \
+    "git stash pop" "$ST2_REPO"
+
+# Toggle opt-out also covers the worktree-collision branch. Config is
+# resolved from REPO_ROOT = `git rev-parse --show-toplevel` of the command's
+# CWD, which for a worktree CWD is the worktree's own root, NOT the main
+# checkout -- so the config file must live in the WORKTREE's own (nested)
+# `.loom/config.json`, mirroring how a real committed .loom/config.json
+# would appear in every checkout of the same tracked path.
+ST2_REPO_OFF=$(make_wt_repo_two_linked)
+mkdir -p "$ST2_REPO_OFF/.loom/worktrees/issue-1/.loom"
+printf '%s' '{"guards":{"stashScope":false}}' > "$ST2_REPO_OFF/.loom/worktrees/issue-1/.loom/config.json"
+assert_allow "stash-scope: guards.stashScope:false -> allow from worktree even with >=2 managed worktrees (#4821)" \
+    "git stash pop" "$ST2_REPO_OFF/.loom/worktrees/issue-1"
+
+rm -rf "$ST2_REPO" "$ST2_REPO_OFF"
+
+echo ""
+
+# =========================================================================
 echo -e "${YELLOW}--- Performance check ---${NC}"
 # =========================================================================
 


### PR DESCRIPTION
## Summary

`git stash`'s `refs/stash` is a single stack shared across **every** linked
worktree of a repository, not per-worktree. `builder-worktree.md` asserted
the opposite ("Stash is local to the repository, not shared between
worktrees"), and the existing `stashScope` guard (#4281) only asked when the
**main checkout's** stash stack was touched — leaving worktree-to-worktree
collisions between two parallel Builders/Doctors completely ungated. This is
exactly what happened in production: two kicad-tools builders in separate
linked worktrees each `git stash pop`'d the other's WIP (PRs #4524/#4526),
recovered only via dangling-commit rescue — a genuine data-loss near-miss.

## Changes

- **`defaults/.claude/commands/loom/builder-worktree.md`**: corrected the
  false "stash is local to the repository, not shared between worktrees"
  claim; added explicit prohibition on bare `git stash` for ad-hoc WIP and a
  pointer to `./.loom/scripts/worktree.sh snapshot <issue-number>` (patch-file
  WIP capture, already merged via #4792) as the safe alternative.
- **`defaults/.claude/commands/loom/builder.md`** / **`doctor.md`**: added the
  same stash prohibition + `worktree.sh snapshot` guidance near the
  worktree-workflow sections, explicitly distinguishing it from the existing,
  legitimate `check-main-clean.sh --quarantine` stash usage (main-checkout-only,
  single-writer, unaffected by this change).
- **`defaults/docs/guard-hooks.md`**: documented the worktree-to-worktree
  coverage gap in the "Stash-Stack Scope Guard" section, alongside the
  existing `-C` bypass known-limitation.
- **`defaults/hooks/guard-destructive-generic.sh`**: extended the stash guard
  so `git stash pop/drop/clear` from a linked worktree also asks for
  confirmation when 2+ `.loom-managed` worktrees are currently active under
  `.loom/worktrees/` (a single active worktree has no one else's entry to
  collide with, so it stays ungated). Non-destructive `push`/`apply`/`list`
  remain ungated everywhere, unchanged.
- **`defaults/.claude/commands/loom/sweep.md`**: noted the stash stack as the
  one documented exception to the "Only Builders parallelize... never
  collide" claim in the wave-dispatch section.
- **`tests/hooks/test-guard-destructive.sh`**: added coverage for the new
  worktree-collision branch (asks with 2+ managed worktrees from any linked
  worktree, stays ungated with only 1, main checkout still asks
  independently, config/env opt-out honored, non-destructive subcommands
  unaffected).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Fix false claim in `builder-worktree.md` (lines 208-210) | ✅ | Replaced with accurate shared-stack description + `worktree.sh snapshot` pointer |
| Builder/Doctor docs prohibit bare `git stash`/`pop`/`drop` for WIP | ✅ | Added to `builder.md` and `doctor.md`; existing quarantine-recovery stash usage explicitly preserved as a distinct, correct case |
| Document coverage gap in `guard-hooks.md`'s Stash-Stack Scope Guard section | ✅ | New "Worktree-to-worktree collisions (#4821)" paragraph added |
| (Optional) Extend `guard-destructive-generic.sh` to gate worktree-to-worktree collisions | ✅ | Implemented: asks when cwd is a linked worktree AND 2+ managed worktrees exist |
| Mention hazard + alternative in `sweep.md`'s "Only Builders parallelize" section | ✅ | Added as the documented exception to the "never collide" claim |

## Test Plan

- `bash defaults/hooks/guard-destructive-generic.sh` — syntax check (`bash -n`) passes
- `./tests/hooks/test-guard-destructive.sh` — full suite: **566/566 passed**, including the 8 new `#4821` worktree-collision assertions (ask with 2+ managed worktrees from either worktree, stays ungated with only 1 active worktree, main checkout still asks independently of the worktree branch, `guards.stashScope:false` opt-out honored, non-destructive `push`/`apply`/`list` remain ungated)
- Manual read-through confirming the corrected doc sections no longer contain the false "not shared between worktrees" claim and consistently point to `worktree.sh snapshot`

## Note on affected-file paths

The issue's "Affected Files" section named `defaults/roles/{builder,builder-worktree,doctor}.md` as the edit targets. `defaults/roles/*.md` are themselves symlinks to `defaults/.claude/commands/loom/*.md` (the actual single source of truth, per the 2026-era "Consolidate role definitions" commit), so this PR edits the real source files directly — `.loom/roles/*.md` (symlinked to `defaults/roles/`) and `.claude/commands/loom/*.md` (symlinked to `defaults/.claude/commands/loom/`) both resolve to the same updated content automatically, no separate edit needed.

Closes #4821