### PR TITLE
fix(scripts): anchor complexity-marker extraction to canonical <!-- --> form

### DIFF
--- a/defaults/scripts/require-complexity-marker.sh
+++ b/defaults/scripts/require-complexity-marker.sh
@@ -46,7 +46,18 @@ else
   echo "BLOCKED: could not fetch issue $REPO#$ISSUE body (both GraphQL and REST failed — likely GitHub API quota exhaustion). Retry or check quota; this is not a curation defect." >&2
   exit 2
 fi
-tier="$(printf '%s' "$body" | grep -o 'loom:complexity=[a-z]*' | head -1 | cut -d= -f2)"
+# Anchor to the canonical HTML-comment marker form (`<!-- loom:complexity=<tier>
+# -->`) rather than a bare `loom:complexity=[a-z]*` substring, and take the LAST
+# such match (#4840). A bare substring match also fires on prose that merely
+# *discusses* the marker syntax — e.g. an issue about the complexity-marker
+# feature itself quoting `` `<!-- loom:complexity=<tier> -->` `` as literal
+# example text. There the `<` right after `=` matches zero `[a-z]` chars,
+# producing an empty match that `head -1` picked over the real marker later in
+# the body, making a validly-marked issue look unmarked. Anchoring to the full
+# `<!-- ... -->` comment form excludes that placeholder text (the literal `<`
+# breaks the `-->` anchor), and `tail -1` picks the marker nearest the end of
+# the body, matching where the marker is conventionally placed.
+tier="$(printf '%s' "$body" | grep -oE '<!--[[:space:]]*loom:complexity=[a-z]*[[:space:]]*-->' | tail -1 | sed -E 's/.*complexity=([a-z]*).*/\1/')"
 
 case "$tier" in
   mechanical|routine|complex)

--- a/defaults/scripts/resolve-tier-model.sh
+++ b/defaults/scripts/resolve-tier-model.sh
@@ -68,7 +68,18 @@ else
   echo "$REPO#$ISSUE: could not fetch body (GraphQL+REST failed — likely API quota) -> routine" >&2
   body=""
 fi
-tier="$(printf '%s' "$body" | grep -o 'loom:complexity=[a-z]*' | head -1 | cut -d= -f2)"
+# Anchor to the canonical HTML-comment marker form (`<!-- loom:complexity=<tier>
+# -->`) rather than a bare `loom:complexity=[a-z]*` substring, and take the LAST
+# such match (#4840). A bare substring match also fires on prose that merely
+# *discusses* the marker syntax — e.g. an issue about the complexity-marker
+# feature itself quoting `` `<!-- loom:complexity=<tier> -->` `` as literal
+# example text. There the `<` right after `=` matches zero `[a-z]` chars,
+# producing an empty match that `head -1` picked over the real marker later in
+# the body, silently resolving to `routine` with no error surfaced. Anchoring
+# to the full `<!-- ... -->` comment form excludes that placeholder text (the
+# literal `<` breaks the `-->` anchor), and `tail -1` picks the marker nearest
+# the end of the body, matching where the marker is conventionally placed.
+tier="$(printf '%s' "$body" | grep -oE '<!--[[:space:]]*loom:complexity=[a-z]*[[:space:]]*-->' | tail -1 | sed -E 's/.*complexity=([a-z]*).*/\1/')"
 # Two distinct fall-through cases (#4448): an absent marker is the expected
 # default for issues curated before the marker existed (or before it became
 # mandatory) and stays a quiet info line; an out-of-vocabulary value (a

--- a/defaults/scripts/tests/test-require-complexity-marker.sh
+++ b/defaults/scripts/tests/test-require-complexity-marker.sh
@@ -88,6 +88,8 @@ trap cleanup EXIT
 #   9004 = GraphQL FAILS, REST returns a valid marker (fallback path)
 #   9005 = both GraphQL and REST FAIL (fetch error)
 #   9006 = GraphQL succeeds but returns an EMPTY body (successful fetch, no marker)
+#   9007 = body has prose mentioning the marker syntax BEFORE the real marker
+#          (#4840) -- the real marker must still be found
 FAKE_BIN="$WORKDIR/bin"
 mkdir -p "$FAKE_BIN"
 cat > "$FAKE_BIN/gh" <<'FAKEGH'
@@ -108,6 +110,12 @@ if [[ "$1" == "issue" && "$2" == "view" ]]; then
         9004) exit 1 ;;   # GraphQL quota exhausted -> forces REST fallback
         9005) exit 1 ;;   # GraphQL fails ...
         9006) echo "" ; exit 0 ;;
+        9007) echo "Meta issue about the complexity-marker feature itself, which
+legitimately quotes the marker syntax as literal example text before the real
+marker appears (#4840): \`<!-- loom:complexity=<tier> -->\`.
+
+<!-- loom:complexity=mechanical -->
+" ; exit 0 ;;
         *) echo "" ; exit 0 ;;
     esac
 fi
@@ -184,6 +192,20 @@ out="$(run_marker 9006 2>&1)"; rc=$?
 assert_eq "1" "$rc" "empty-but-successful fetch exits 1 (missing marker), not 2"
 assert_contains "BLOCKED: issue has no complexity marker" "$out" "empty-but-successful fetch prints the BLOCKED-missing text"
 assert_not_contains "could not fetch" "$out" "empty-but-successful fetch is not a fetch error"
+
+# -------- Test 8: prose mentioning the marker syntax before the real marker
+# -------- is ignored -> exit 0 (#4840) --------
+# The bug this issue reports: a body that *discusses* the marker syntax in
+# prose before the real marker (e.g. a meta issue about the complexity-marker
+# feature itself, quoting `<!-- loom:complexity=<tier> -->` as literal example
+# text) used to produce an empty first match that `head -1` picked over the
+# real marker later in the body, false-positively reporting BLOCKED even
+# though a valid marker was present.
+echo "Test 8: prose that mentions the marker syntax before the real marker is ignored -> exit 0"
+out="$(run_marker 9007 2>&1)"; rc=$?
+assert_eq "0" "$rc" "real marker found despite preceding prose mentions -> exit 0"
+assert_contains "is tagged mechanical" "$out" "real marker (mechanical) is reported, not the empty prose match"
+assert_not_contains "BLOCKED" "$out" "prose mention never triggers BLOCKED"
 
 # -------- Summary --------
 echo ""

--- a/defaults/scripts/tests/test-resolve-tier-model.sh
+++ b/defaults/scripts/tests/test-resolve-tier-model.sh
@@ -2,13 +2,14 @@
 # test-resolve-tier-model.sh - Tests for resolve-tier-model.sh's complexity-tier
 # parsing (#4448).
 #
-# resolve-tier-model.sh's `grep -o 'loom:complexity=[a-z]*' | case` layer had no
+# resolve-tier-model.sh's `grep -oE '<!-- ... -->' | case` layer had no
 # shell-level test coverage — only the Python `--tier` lookup behind it
 # (loom-tools/tests/test_model_tiers.py) was exercised. This harness targets
 # that layer: valid marker, absent marker, out-of-vocabulary marker (the drift
 # bug #4448 was filed for — curators emitting `trivial`/`large`/`moderate`
-# instead of the closed `mechanical|routine|complex` enum), and first-marker-
-# wins when a body carries more than one marker.
+# instead of the closed `mechanical|routine|complex` enum), last-marker-wins
+# when a body carries more than one canonical marker, and prose that merely
+# discusses the marker syntax before the real marker appears (#4840).
 #
 # Style matches test-blame-issue.sh: a fake `gh` stub on PATH answers the
 # `gh issue view <issue> -R <repo> --json body -q .body` invocation the script
@@ -86,13 +87,19 @@ More text." ;;
 
 <!-- loom:complexity=trivial -->
 " ;;
-        9004) echo "Body with two markers -- first one wins.
+        9004) echo "Body with two markers -- last one wins.
 
 <!-- loom:complexity=complex -->
 <!-- loom:complexity=mechanical -->
 " ;;
         9005) exit 1 ;;   # GraphQL quota exhausted -> forces REST fallback (#4472)
         9006) exit 1 ;;   # GraphQL fails ...
+        9007) echo "Meta issue about the complexity-marker feature itself, which
+legitimately quotes the marker syntax as literal example text before the real
+marker appears (#4840): \`<!-- loom:complexity=<tier> -->\`.
+
+<!-- loom:complexity=mechanical -->
+" ;;
         *) echo "" ;;
     esac
     exit 0
@@ -158,11 +165,11 @@ err="$(run_resolve 9003 2>&1 1>/dev/null)"
 assert_contains "invalid complexity tier 'trivial' -> routine" "$err" "invalid marker warning names the offending value"
 assert_not_contains "no complexity marker" "$err" "invalid marker is not conflated with the absent-marker message"
 
-# -------- Test 5: first-marker-wins when multiple markers are present --------
-echo "Test 5: first marker wins when a body carries two"
+# -------- Test 5: last-marker-wins when multiple markers are present --------
+echo "Test 5: last marker wins when a body carries two"
 err="$(run_resolve 9004 2>&1 1>/dev/null)"
-assert_contains "tier=complex" "$err" "first marker (complex) wins over the second (mechanical)"
-assert_not_contains "tier=mechanical" "$err" "second marker is not the one resolved"
+assert_contains "tier=mechanical" "$err" "last marker (mechanical) wins over the first (complex)"
+assert_not_contains "tier=complex" "$err" "first marker is not the one resolved"
 
 # -------- Test 6: all four cases still exit 3 (unconfigured tierModels) --------
 # Confirms the resolution layer itself is unchanged -- only the diagnostics
@@ -195,6 +202,20 @@ echo "Test 8: total fetch failure degrades to routine with a diagnostic"
 err="$(run_resolve 9006 2>&1 1>/dev/null)"
 assert_contains "could not fetch body" "$err" "total fetch failure logs a fetch-error diagnostic"
 assert_contains "-> routine" "$err" "total fetch failure still degrades to routine"
+
+# -------- Test 9: prose mentioning the marker syntax before the real marker
+# -------- is ignored (#4840) --------
+# The bug this issue reports: a body that *discusses* the marker syntax in
+# prose before the real marker (e.g. a meta issue about the complexity-marker
+# feature itself, quoting `<!-- loom:complexity=<tier> -->` as literal example
+# text) used to produce an empty first match that `head -1` picked over the
+# real marker later in the body, silently resolving to `routine` instead of
+# the issue's actual `mechanical` tier.
+echo "Test 9: prose that mentions the marker syntax before the real marker is ignored"
+err="$(run_resolve 9007 2>&1 1>/dev/null)"
+assert_contains "tier=mechanical" "$err" "real marker (mechanical) is resolved despite preceding prose mentions"
+assert_not_contains "invalid complexity tier" "$err" "prose mention never triggers the invalid-tier warning"
+assert_not_contains "no complexity marker" "$err" "prose mention never triggers the absent-marker message"
 
 # -------- Summary --------
 echo ""


### PR DESCRIPTION
## Summary

`require-complexity-marker.sh` and `resolve-tier-model.sh` extracted the
complexity tier with:

```bash
tier="$(printf '%s' "$body" | grep -o 'loom:complexity=[a-z]*' | head -1 | cut -d= -f2)"
```

`head -1` takes the FIRST match in document order, but the real marker is
conventionally placed near the end of the issue body. If the body discusses
the marker syntax in prose before the real marker (e.g. an issue about the
complexity-marker feature itself that quotes `<!-- loom:complexity=<tier> -->`
as example text), the `<` after `=` matches zero `[a-z]*` characters,
producing an empty match that "wins" over the real marker later in the body —
causing `require-complexity-marker.sh` to false-positive "no marker" (blocking
`loom:curated`) and `resolve-tier-model.sh` to silently fall back to `routine`
instead of surfacing an error.

## Fix

Both scripts now anchor the extraction to the canonical
`<!-- loom:complexity=<tier> -->` HTML-comment form (excluding bare-word
mentions in prose/backticks that aren't a well-formed comment) and take the
**last** such match, matching the convention that the real marker sits near
the end of the body:

```bash
tier="$(printf '%s' "$body" | grep -oE '<!--[[:space:]]*loom:complexity=[a-z]*[[:space:]]*-->' | tail -1 | sed -E 's/.*complexity=([a-z]*).*/\1/')"
```

Searched the repo (`grep -rln "grep -o 'loom:complexity"`) — these are the
only two git-tracked copies of the extraction line; `.loom/scripts` is a
symlink to `defaults/scripts`, so no separate installed copy needs updating.

## Testing

- `defaults/scripts/tests/test-require-complexity-marker.sh` — 20/20 passed
  (added a new prose-before-marker fixture case, issue 9007)
- `defaults/scripts/tests/test-resolve-tier-model.sh` — 20/20 passed (added
  the same prose-before-marker case, and updated the existing multi-marker
  test to the new last-marker-wins semantics)
- `shellcheck` clean on all four changed files
- `defaults/scripts/tests/check-ci-suite-manifest.sh` — OK, both suites
  already wired into CI
- Spot-check against the real issue that triggered this bug:
  `./.loom/scripts/require-complexity-marker.sh 4827` now exits 0
  (`ok: rjwalters/loom#4827 is tagged routine`)

Closes #4840