### PR TITLE
fix(daemon): de-duplicate watchdog's inline bounded_run against lib/bounded-run.sh

### DIFF
--- a/defaults/scripts/cli/loom-daemon-watchdog.sh
+++ b/defaults/scripts/cli/loom-daemon-watchdog.sh
@@ -156,9 +156,12 @@
 #                                (default: LOOM_DAEMON_STARTUP_GRACE_SECS, else 90).
 #   LOOM_WATCHDOG_IPC_PROBE_STATE  #4398: path to the consecutive-failure counter
 #                                (default <loom dir>/.watchdog-probe-fail-count).
-#   LOOM_WATCHDOG_FORCE_PORTABLE_TIMEOUT  #4398: 1 forces the built-in bounded
-#                                runner instead of `timeout(1)` (test seam for
-#                                the default macOS no-`timeout` shape).
+#   LOOM_FORCE_PORTABLE_TIMEOUT    #4398, renamed from the watchdog-local
+#                                LOOM_WATCHDOG_FORCE_PORTABLE_TIMEOUT by #4832
+#                                when bounded_run() moved to the shared
+#                                lib/bounded-run.sh: 1 forces the built-in
+#                                bounded runner instead of `timeout(1)` (test
+#                                seam for the default macOS no-`timeout` shape).
 #   LOOM_DAEMON_BIN               Explicit loom-daemon binary for the IPC probe
 #                                (same resolution order as loom-daemon-start.sh).
 
@@ -181,6 +184,16 @@ _LOOM_LAUNCHD_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" 2>/dev/null 
 if [[ -r "$_LOOM_LAUNCHD_LIB_DIR/launchd-domain.sh" ]]; then
     # shellcheck source=../lib/launchd-domain.sh
     source "$_LOOM_LAUNCHD_LIB_DIR/launchd-domain.sh"
+fi
+# bounded_run() (#4398, shared with loom-daemon-start.sh's print_calibrate_hint,
+# de-duplicated from this script's own former inline copy by #4832) — the IPC
+# probe's hard wall-clock budget. Unlike the start script's advisory hint, the
+# probe below is NOT optional, so run_ipc_probe() checks explicitly for a
+# missing `bounded_run` rather than letting an undefined-function call degrade
+# silently.
+if [[ -r "$_LOOM_LAUNCHD_LIB_DIR/bounded-run.sh" ]]; then
+    # shellcheck source=../lib/bounded-run.sh
+    source "$_LOOM_LAUNCHD_LIB_DIR/bounded-run.sh"
 fi
 
 VERBOSE=false
@@ -354,50 +367,17 @@ locate_daemon_bin() {
     return 1
 }
 
-# Run a command under a HARD wall-clock budget, returning 124 on timeout exactly
-# like GNU `timeout` does. macOS ships no `timeout(1)`, and for this probe an
-# unbounded fallback is not acceptable — "the CLI never returns" is precisely the
-# failure mode being detected (#4381's hung stub) — so the no-`timeout` path is a
-# real bounded implementation, not a degrade-to-unbounded.
-#
-# `-k 2` is load-bearing on the `timeout(1)` path: a non-interactive bash that is
-# blocked in a foreground command defers SIGTERM, so without the KILL escalation
-# `timeout` itself would wait indefinitely for a child that ignores the TERM —
-# reintroducing the very unbounded wait this helper exists to prevent.
-# LOOM_WATCHDOG_FORCE_PORTABLE_TIMEOUT=1 forces the fallback path, so the
-# no-`timeout(1)` behavior (the default macOS shape) is testable on any host.
-bounded_run() { # <timeout_secs> <cmd> [args...]
-    local secs="$1"; shift
-    if [[ ! "${LOOM_WATCHDOG_FORCE_PORTABLE_TIMEOUT:-}" =~ ^(1|true|yes)$ ]]; then
-        if command -v timeout >/dev/null 2>&1; then
-            timeout -k 2 "$secs" "$@"
-            return $?
-        fi
-        if command -v gtimeout >/dev/null 2>&1; then
-            gtimeout -k 2 "$secs" "$@"
-            return $?
-        fi
-    fi
-    # Portable fallback: run the command in the background and pair it with a
-    # killer subshell that TERM/KILLs it once the budget elapses.
-    "$@" &
-    local cmd_pid=$!
-    (
-        sleep "$secs"
-        kill -TERM "$cmd_pid" 2>/dev/null
-        sleep 2
-        kill -KILL "$cmd_pid" 2>/dev/null
-    ) >/dev/null 2>&1 &
-    local killer_pid=$! rc=0
-    wait "$cmd_pid" 2>/dev/null || rc=$?
-    kill "$killer_pid" 2>/dev/null
-    wait "$killer_pid" 2>/dev/null
-    # Normalize a killed-by-the-budget exit (128+TERM / 128+KILL) to `timeout`'s
-    # own 124 so the caller has ONE code to branch on regardless of which
-    # implementation ran.
-    case "$rc" in 143|137) rc=124 ;; esac
-    return "$rc"
-}
+# bounded_run() — a HARD wall-clock budget around a command, returning 124 on
+# timeout exactly like GNU `timeout` does. Sourced from the shared
+# lib/bounded-run.sh (#4807 extracted this watchdog's own inline copy so
+# loom-daemon-start.sh's print_calibrate_hint() could reuse it, #4799); see
+# that file for the full implementation notes (the `-k 2` KILL escalation,
+# the portable no-`timeout(1)` fallback for macOS, the 143/137 -> 124
+# normalization). The lib is sourced just below (near launchd-domain.sh); if
+# sourcing failed for any reason, `bounded_run` is simply undefined and
+# run_ipc_probe() below detects that explicitly and skips the probe with a
+# clear diagnostic — never a raw `command not found` on a scheduled tick
+# (#4832).
 
 # Read the consecutive-failure tally for <pid> from the state file. The tally is
 # KEYED TO THE PID: a relaunched daemon is a different process and must start
@@ -432,6 +412,15 @@ run_ipc_probe() { # <live_pid> <proc_age_or_empty>
 
     if [[ "${LOOM_WATCHDOG_IPC_PROBE:-}" =~ ^(0|false|no)$ ]]; then
         probe_detail="IPC probe disabled via LOOM_WATCHDOG_IPC_PROBE"
+        return 0
+    fi
+
+    # #4832: bounded_run is defined by sourcing lib/bounded-run.sh above. A
+    # missing/unreadable lib file leaves it undefined -- without this explicit
+    # check, the invocation below would fail as a raw shell "command not
+    # found" (rc 127) on every scheduled tick instead of a diagnosed skip.
+    if ! command -v bounded_run >/dev/null 2>&1; then
+        probe_detail="bounded_run is undefined -- lib/bounded-run.sh failed to source (missing or unreadable)"
         return 0
     fi
 

--- a/defaults/scripts/tests/test-loom-daemon-watchdog.sh
+++ b/defaults/scripts/tests/test-loom-daemon-watchdog.sh
@@ -822,14 +822,16 @@ rm -rf "$PS_STUB_DIR" "$STUB20"
 
 # ===================================================================
 # 21. The bound holds with NO `timeout(1)` on the host (the default macOS
-#     shape): LOOM_WATCHDOG_FORCE_PORTABLE_TIMEOUT=1 exercises the built-in
-#     bounded runner against a never-returning binary.
+#     shape): LOOM_FORCE_PORTABLE_TIMEOUT=1 (the shared lib/bounded-run.sh
+#     seam, #4832 -- previously the watchdog-local
+#     LOOM_WATCHDOG_FORCE_PORTABLE_TIMEOUT) exercises the built-in bounded
+#     runner against a never-returning binary.
 # ===================================================================
 STUB21="$(make_daemon_stub hang)"
 start_alive_and_fresh 21
 t0=$(date +%s)
 run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
-    LOOM_WATCHDOG_FORCE_PORTABLE_TIMEOUT=1 \
+    LOOM_FORCE_PORTABLE_TIMEOUT=1 \
     LOOM_DAEMON_BIN="$STUB21/loom-daemon" \
     LOOM_WATCHDOG_STATUS_PROBE_TIMEOUT_SECS=2 \
     LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD=3
@@ -842,6 +844,40 @@ else
     fail "no timeout(1) available: watchdog took ${elapsed}s — the portable bound did not hold"
 fi
 rm -rf "$PS_STUB_DIR" "$STUB21"
+
+# ===================================================================
+# 22. #4832: a missing/unreadable lib/bounded-run.sh must degrade to a
+#     clearly-diagnosed skip, never a raw "command not found" (rc 127) on a
+#     scheduled tick. Simulate by temporarily renaming the shared lib file
+#     the watchdog sources bounded_run() from.
+# ===================================================================
+# NOTE: deliberately does NOT register its own EXIT trap for the restore —
+# the suite already owns a single combined EXIT trap (line ~56, `bg_proc_reap;
+# rm -rf "$WORKDIR"`), and `trap ... EXIT` REPLACES rather than stacks, so
+# adding a second one here would silently disable that cleanup for every test
+# after this one. Restore inline instead, immediately after the probing run.
+BOUNDED_RUN_LIB="$(cd "$SCRIPT_DIR/../lib" && pwd)/bounded-run.sh"
+BOUNDED_RUN_LIB_BAK="${BOUNDED_RUN_LIB}.test-disabled-4832"
+mv "$BOUNDED_RUN_LIB" "$BOUNDED_RUN_LIB_BAK"
+
+STUB22="$(make_daemon_stub unreachable)"
+start_alive_and_fresh 22
+run_watchdog_verbose PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
+    LOOM_DAEMON_BIN="$STUB22/loom-daemon"
+kill "$LIVE_PID" 2>/dev/null || true
+mv "$BOUNDED_RUN_LIB_BAK" "$BOUNDED_RUN_LIB"
+assert_rc 0 "$RC" "missing lib/bounded-run.sh: degrades to a skip, not a hard failure (exit 0)"
+if log_hasi 'bounded_run is undefined'; then
+    pass "missing lib/bounded-run.sh: clearly-diagnosed skip in the log"
+else
+    fail "missing lib/bounded-run.sh: expected a clear diagnostic ($(cat "$WDLOG" 2>/dev/null))"
+fi
+if grep -qi 'command not found' "$OUT" "$WDLOG" 2>/dev/null; then
+    fail "missing lib/bounded-run.sh: raw 'command not found' leaked instead of the diagnosed skip"
+else
+    pass "missing lib/bounded-run.sh: no raw 'command not found' surfaced"
+fi
+rm -rf "$PS_STUB_DIR" "$STUB22"
 
 echo
 echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"


### PR DESCRIPTION
## Summary

- `loom-daemon-watchdog.sh` carried its own inline copy of `bounded_run()`, byte-identical to `defaults/scripts/lib/bounded-run.sh` apart from the seam env var name, since #4807 deliberately left it untouched to keep that PR's blast radius zero on an already-CI-wired production script.
- Replaced the inline copy with a `source` of the shared lib (same pattern `loom-daemon-start.sh` already uses), and migrated the one watchdog-local `LOOM_WATCHDOG_FORCE_PORTABLE_TIMEOUT` test seam to the shared `LOOM_FORCE_PORTABLE_TIMEOUT`.
- Because the watchdog's IPC probe is not optional (unlike `print_calibrate_hint()`'s advisory use), `run_ipc_probe()` now explicitly checks for a missing `bounded_run` and skips the tick with a clear diagnostic — never a raw `command not found` on a scheduled tick.

Closes #4832

## Test plan

- [x] `shellcheck --severity=warning` clean on `loom-daemon-watchdog.sh`, `lib/bounded-run.sh`, and the test suite
- [x] `defaults/scripts/tests/test-loom-daemon-watchdog.sh` — 62 assertions (59 pre-existing + 3 new for the missing-lib diagnostic), all pass
- [x] `defaults/scripts/tests/test-bounded-run.sh` — 18 assertions, all pass
- [x] `defaults/scripts/tests/test-loom-daemon-update.sh` — passes unaffected (only copies `bounded-run.sh` into a fixture)
- [x] `grep -rn '^bounded_run()' defaults/scripts/` confirms exactly one definition
- [x] Manually verified: renaming `lib/bounded-run.sh` away produces a clear `bounded_run is undefined -- lib/bounded-run.sh failed to source` skip, not a hard failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)