### PR TITLE
feat(daemon): thread per-issue complexity marker into model-cost experiment dispatch

### DIFF
--- a/loom-daemon/src/epic_supervisor.rs
+++ b/loom-daemon/src/epic_supervisor.rs
@@ -1460,9 +1460,25 @@ pub mod forge {
             // forced arm model when the workspace resolves to `experiment` mode
             // (CANARY-gated) — see `work_finder::dispatch` for the full
             // rationale; `off`/`observe` modes are unaffected.
+            //
+            // Issue #4827: unlike the work finder, the epic supervisor has no
+            // cached issue body to read the `<!-- loom:complexity=... -->`
+            // stratum from, so it fetches one — but LAZILY, inside
+            // `resolve_autonomous_dispatch_model_lazy`'s `experiment` branch,
+            // so `off`/`observe` dispatch still makes zero extra `gh` calls.
+            // A failed fetch resolves to `None` (the unchanged `routine`
+            // stratum) and never fails the dispatch.
             let repo_root = reg.config().workspace_root.clone();
-            let resolved =
-                crate::sweep_registry::resolve_autonomous_dispatch_model(&repo_root, child);
+            let gh_bin = reg
+                .config()
+                .gh_bin
+                .clone()
+                .unwrap_or_else(|| PathBuf::from("gh"));
+            let resolved = crate::sweep_registry::resolve_autonomous_dispatch_model_lazy(
+                &repo_root,
+                child,
+                || crate::sweep_registry::fetch_issue_complexity(&gh_bin, &repo_root, child),
+            );
             match resolved.arm {
                 Some(arm) => log::info!(
                     "epic_supervisor: dispatching child #{child} for epic #{_epic} with \

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -2864,10 +2864,29 @@ fn handle_request(
             // considers the model-cost A/B experiment's forced arm — mirroring
             // the autonomous work-finder / epic-supervisor dispatch paths —
             // before falling back to `autonomous.model` / the shipped default.
+            //
+            // Issue #4827: the arm is stratified by the issue's real
+            // `<!-- loom:complexity=... -->` marker. Like the epic supervisor
+            // (and unlike the work finder, which carries the body on its
+            // `WorkItem`), this handler has no cached body — so the fetch is
+            // LAZY, running only inside the `experiment` branch. `off` /
+            // `observe` dispatches make zero extra `gh` calls, and a failed
+            // fetch degrades to the unchanged `routine` stratum.
+            let gh_bin = sr
+                .config()
+                .gh_bin
+                .clone()
+                .unwrap_or_else(|| std::path::PathBuf::from("gh"));
             let (resolved_model, model_source_label, arm) = match (&kind, model.as_deref()) {
                 (crate::types::SweepKind::Issue(issue), None) => {
-                    let resolved = crate::sweep_registry::resolve_autonomous_dispatch_model(
-                        &repo_root, *issue,
+                    let resolved = crate::sweep_registry::resolve_autonomous_dispatch_model_lazy(
+                        &repo_root,
+                        *issue,
+                        || {
+                            crate::sweep_registry::fetch_issue_complexity(
+                                &gh_bin, &repo_root, *issue,
+                            )
+                        },
                     );
                     (resolved.model, resolved.source_label, resolved.arm)
                 }

--- a/loom-daemon/src/script_helpers/sweep_experiment.rs
+++ b/loom-daemon/src/script_helpers/sweep_experiment.rs
@@ -217,6 +217,110 @@ pub fn resolve_effective_mode_default(
 // Deterministic, resume-safe, stratified arm assignment
 // --------------------------------------------------------------------------
 
+/// The marker's key inside the `<!-- ... -->` comment, including the `=`.
+const COMPLEXITY_MARKER_KEY: &str = "loom:complexity=";
+/// The opening delimiter of the canonical HTML-comment marker form.
+const COMMENT_OPEN: &str = "<!--";
+/// The closing delimiter of the canonical HTML-comment marker form.
+const COMMENT_CLOSE: &str = "-->";
+
+/// Extract the Curator's `<!-- loom:complexity=<tier> -->` tier from an issue
+/// body (issues #3702/#4238/#4448), so a dispatch-time caller can hand a REAL
+/// stratum to [`assign_arm`] instead of the `None` → `routine` default (#4827).
+///
+/// Mirrors `resolve-tier-model.sh` / `require-complexity-marker.sh`'s extraction
+/// as of #4845:
+/// `grep -oE '<!--[[:space:]]*loom:complexity=[a-z]*[[:space:]]*-->' | tail -1`.
+/// Two properties matter and are both reproduced here:
+///
+/// 1. **Anchored to the canonical `<!-- ... -->` comment form.** A bare
+///    `loom:complexity=` substring also fires on prose that merely *discusses*
+///    the marker syntax — e.g. this very issue (#4827) quotes
+///    `` `<!-- loom:complexity=<tier> -->` `` as literal example text. The `<`
+///    after `=` breaks the `-->` anchor, so such mentions are skipped rather
+///    than yielding an empty match (#4840).
+/// 2. **The LAST match wins**, matching where the real marker is conventionally
+///    placed (at the end of the body).
+///
+/// Like `grep`, matching is line-oriented: a marker split across a newline is
+/// not recognized by either implementation. An empty tier
+/// (`<!-- loom:complexity= -->`) yields `None`, matching the shell's empty-`tier`
+/// fall-through to `routine`.
+///
+/// Deliberately does NOT validate against the closed
+/// `mechanical|routine|complex` vocabulary: [`normalize_complexity`] already
+/// folds every out-of-vocabulary value to `routine`, so an extra check here
+/// would only duplicate that behavior (and could drift from it).
+#[must_use]
+pub fn extract_complexity_marker(body: &str) -> Option<&str> {
+    // `tail -1` over `grep`'s document-order match stream: scan lines back to
+    // front, and within a line take that line's last match.
+    body.lines().rev().find_map(last_marker_in_line)
+}
+
+/// The last `<!-- loom:complexity=<tier> -->` tier on a single line, if any.
+///
+/// Scans left to right (as `grep -o` does, over non-overlapping matches) and
+/// keeps the final hit, so a line carrying several markers resolves to the
+/// rightmost one.
+fn last_marker_in_line(line: &str) -> Option<&str> {
+    let mut found = None;
+    let mut cursor = 0;
+    while let Some(rel) = line[cursor..].find(COMMENT_OPEN) {
+        let open = cursor + rel;
+        let after_open = open + COMMENT_OPEN.len();
+        match parse_marker_body(&line[after_open..]) {
+            // A well-formed marker: record it and resume after its `-->` so
+            // matches stay non-overlapping. An empty tier still counts as a
+            // match for cursor purposes (grep consumed it) but yields no
+            // stratum — the shell's `case` folds it to `routine` too.
+            Some((tier, consumed)) => {
+                if !tier.is_empty() {
+                    found = Some(tier);
+                }
+                cursor = after_open + consumed;
+            }
+            // Not a marker comment (prose, an unrelated HTML comment, a
+            // `<tier>` placeholder): resume just past this `<!--`.
+            None => cursor = after_open,
+        }
+    }
+    found
+}
+
+/// Parse `[[:space:]]*loom:complexity=[a-z]*[[:space:]]*-->` at the start of
+/// `rest`, returning the tier (possibly empty, since the regex's `[a-z]*` is a
+/// *star*) plus the number of bytes consumed through the closing `-->`.
+/// `None` means the text is not a marker comment at all.
+fn parse_marker_body(rest: &str) -> Option<(&str, usize)> {
+    let after_ws = rest.len() - rest.trim_start_matches(is_marker_space).len();
+    let rest_after_ws = &rest[after_ws..];
+    let after_key = after_ws + COMPLEXITY_MARKER_KEY.len();
+    if !rest_after_ws.starts_with(COMPLEXITY_MARKER_KEY) {
+        return None;
+    }
+
+    let value = &rest[after_key..];
+    let tier_len = value
+        .find(|c: char| !c.is_ascii_lowercase())
+        .unwrap_or(value.len());
+    let tier = &value[..tier_len];
+
+    let tail = &value[tier_len..];
+    let tail_ws = tail.len() - tail.trim_start_matches(is_marker_space).len();
+    if !tail[tail_ws..].starts_with(COMMENT_CLOSE) {
+        return None;
+    }
+    let consumed = after_key + tier_len + tail_ws + COMMENT_CLOSE.len();
+    Some((tier, consumed))
+}
+
+/// POSIX `[[:space:]]` for the marker regex. `lines()` has already stripped
+/// `\n`, so this is the intra-line subset (`grep` never matches across lines).
+fn is_marker_space(c: char) -> bool {
+    matches!(c, ' ' | '\t' | '\r' | '\x0b' | '\x0c')
+}
+
 /// Normalize the #3702 marker to `complex` | `routine` (default `routine`).
 #[must_use]
 pub fn normalize_complexity(complexity: Option<&str>) -> &'static str {
@@ -1148,6 +1252,130 @@ mod tests {
         // An absent/unknown marker is `routine`.
         assert_eq!(assign_arm(100, None), "A");
         assert_eq!(assign_arm(100, Some("mystery")), "A");
+    }
+
+    // ===== `<!-- loom:complexity=... -->` extraction (#4827) =====
+
+    /// The happy path for all three in-vocabulary tiers, in the exact HTML
+    /// comment form the Curator writes.
+    #[test]
+    fn extracts_complexity_marker_from_issue_body() {
+        for tier in ["mechanical", "routine", "complex"] {
+            let body = format!("## Context\n\nSome text.\n\n<!-- loom:complexity={tier} -->\n");
+            assert_eq!(extract_complexity_marker(&body), Some(tier));
+        }
+    }
+
+    /// No marker at all (a pre-marker issue) → `None`, which
+    /// [`normalize_complexity`] folds to the unchanged `routine` default.
+    #[test]
+    fn extracts_nothing_when_no_marker_present() {
+        assert_eq!(extract_complexity_marker("no marker here"), None);
+        assert_eq!(extract_complexity_marker(""), None);
+        assert_eq!(normalize_complexity(extract_complexity_marker("nope")), "routine");
+    }
+
+    /// `tail -1` semantics (#4845): the LAST canonical marker wins, whether the
+    /// competing markers are on separate lines or share one — matching
+    /// `resolve-tier-model.sh`'s "last marker wins" test.
+    #[test]
+    fn extracts_last_marker_when_several_present() {
+        let body = "<!-- loom:complexity=complex -->\n<!-- loom:complexity=mechanical -->";
+        assert_eq!(extract_complexity_marker(body), Some("mechanical"));
+        // Several on one line: the rightmost wins (grep -o + tail -1).
+        let one_line = "<!-- loom:complexity=complex --> <!-- loom:complexity=routine -->";
+        assert_eq!(extract_complexity_marker(one_line), Some("routine"));
+    }
+
+    /// The #4840 regression, in the exact shape that triggered it: a body that
+    /// *discusses* the marker syntax in prose (quoting
+    /// `<!-- loom:complexity=<tier> -->` as literal example text) before the
+    /// real marker. The `<` after `=` breaks the `-->` anchor, so the prose
+    /// mention must be skipped rather than shadowing the real marker.
+    ///
+    /// This is not hypothetical — issue #4827 itself is such a body.
+    #[test]
+    fn extraction_ignores_prose_that_merely_mentions_the_marker_syntax() {
+        let body = "Meta issue about the complexity-marker feature, which quotes the \
+                    syntax as literal example text: `<!-- loom:complexity=<tier> -->`.\n\
+                    \n<!-- loom:complexity=mechanical -->\n";
+        assert_eq!(extract_complexity_marker(body), Some("mechanical"));
+
+        // A prose mention with NO real marker anywhere resolves to `None` (the
+        // `routine` stratum) rather than an empty-string tier.
+        assert_eq!(
+            extract_complexity_marker("see `<!-- loom:complexity=<tier> -->` for the form"),
+            None
+        );
+    }
+
+    /// Anchoring semantics (#4845): only the full `<!-- ... -->` comment form
+    /// counts. A bare `loom:complexity=` substring — the pre-#4845 match — is
+    /// no longer a marker.
+    #[test]
+    fn extraction_requires_the_canonical_comment_form() {
+        // Bare substring, no comment delimiters: not a marker.
+        assert_eq!(extract_complexity_marker("loom:complexity=complex"), None);
+        // Opening delimiter but no closing one.
+        assert_eq!(extract_complexity_marker("<!-- loom:complexity=complex"), None);
+        // Closing delimiter but no opening one.
+        assert_eq!(extract_complexity_marker("loom:complexity=complex -->"), None);
+        // `[[:space:]]*` is a star on both sides: no padding is still valid.
+        assert_eq!(extract_complexity_marker("<!--loom:complexity=complex-->"), Some("complex"));
+        // ...and generous padding (including tabs) is too.
+        assert_eq!(
+            extract_complexity_marker("<!--\t  loom:complexity=complex \t -->"),
+            Some("complex")
+        );
+    }
+
+    /// `[a-z]*` semantics: the value is the maximal run of ASCII lowercase
+    /// after the `=`, and anything that leaves the `-->` unreachable — or
+    /// leaves the tier empty — is `None` (the `routine` stratum).
+    #[test]
+    fn extraction_matches_the_shell_character_class() {
+        // A non-`[a-z]` char inside the value truncates the run, which then
+        // fails to reach `-->` — so the whole comment is not a marker.
+        assert_eq!(extract_complexity_marker("<!-- loom:complexity=comp1ex -->"), None);
+        assert_eq!(extract_complexity_marker("<!-- loom:complexity=Complex -->"), None);
+        // A well-formed but valueless marker: `[a-z]*` matches zero chars, and
+        // the shell's `case` folds the empty tier to `routine` just as this
+        // `None` does.
+        assert_eq!(extract_complexity_marker("<!-- loom:complexity= -->"), None);
+        assert_eq!(
+            normalize_complexity(extract_complexity_marker("<!-- loom:complexity= -->")),
+            "routine"
+        );
+        // An empty-tier marker does not shadow a real one later in the body.
+        assert_eq!(
+            extract_complexity_marker(
+                "<!-- loom:complexity= -->\n<!-- loom:complexity=complex -->"
+            ),
+            Some("complex")
+        );
+    }
+
+    /// `grep` is line-oriented, so a marker split across a newline is not a
+    /// match in either implementation.
+    #[test]
+    fn extraction_does_not_match_across_lines() {
+        assert_eq!(extract_complexity_marker("<!-- loom:complexity=complex\n-->"), None);
+        assert_eq!(extract_complexity_marker("<!--\nloom:complexity=complex -->"), None);
+    }
+
+    /// Extraction composes with [`assign_arm`] to give the two strata an
+    /// independent A/B split — the whole point of #4827.
+    #[test]
+    fn extracted_marker_shifts_the_assigned_arm() {
+        let complex = "<!-- loom:complexity=complex -->";
+        let routine = "<!-- loom:complexity=routine -->";
+        assert_eq!(assign_arm(100, extract_complexity_marker(complex)), "B");
+        assert_eq!(assign_arm(100, extract_complexity_marker(routine)), "A");
+        // Unicode-safe: a multi-byte char before the marker must not panic.
+        assert_eq!(
+            extract_complexity_marker("— é ☃ <!-- loom:complexity=complex -->"),
+            Some("complex")
+        );
     }
 
     #[test]

--- a/loom-daemon/src/sweep_registry/model.rs
+++ b/loom-daemon/src/sweep_registry/model.rs
@@ -268,13 +268,39 @@ pub struct ExperimentDispatchModel {
 /// `explicit = None`, matching every existing autonomous dispatch site).
 ///
 /// The arm itself is [`crate::script_helpers::sweep_experiment::assign_arm`]
-/// — a pure function of `issue` (+ an optional complexity stratum, currently
-/// always `None` here; real per-issue `<!-- loom:complexity=... -->`
-/// extraction at dispatch time is deferred — see issue #4809's PR
-/// description), so the SAME issue resolves to the SAME arm across a
-/// dispatch resume — no re-roll.
+/// — a pure function of `issue` and the `complexity` stratum — so the SAME
+/// issue resolves to the SAME arm across a dispatch resume (no re-roll).
+///
+/// `complexity` is the Curator's `<!-- loom:complexity=<tier> -->` tier for
+/// this issue (#4827), which gives the `complex` and `routine` strata an
+/// independent ~50/50 A/B balance instead of stratifying the whole population
+/// as `routine`. `None` (no marker, or an unavailable body) keeps the
+/// pre-#4827 `routine` default — never an error.
 #[must_use]
-pub fn resolve_autonomous_dispatch_model(repo_root: &Path, issue: u32) -> ExperimentDispatchModel {
+pub fn resolve_autonomous_dispatch_model(
+    repo_root: &Path,
+    issue: u32,
+    complexity: Option<&str>,
+) -> ExperimentDispatchModel {
+    resolve_autonomous_dispatch_model_lazy(repo_root, issue, || complexity.map(str::to_owned))
+}
+
+/// [`resolve_autonomous_dispatch_model`] with the complexity stratum supplied
+/// by a **lazily-invoked** closure (#4827).
+///
+/// For call sites that have no issue body in hand (the epic supervisor's
+/// child dispatch, the `dispatch_sweep` MCP handler) the stratum costs a forge
+/// round-trip. Deferring it behind `FnOnce` means that round-trip happens ONLY
+/// when the workspace actually resolves to `experiment` mode — so `off` /
+/// `observe` dispatches (the overwhelming majority, and the modes whose
+/// no-behavior-change contract #4809 established) issue zero extra `gh` calls
+/// and add zero rate-limit pressure (epic #4432).
+#[must_use]
+pub fn resolve_autonomous_dispatch_model_lazy(
+    repo_root: &Path,
+    issue: u32,
+    complexity: impl FnOnce() -> Option<String>,
+) -> ExperimentDispatchModel {
     use crate::script_helpers::sweep_experiment as se;
 
     let config = crate::config_resolver::resolve_effective_config(repo_root);
@@ -292,7 +318,8 @@ pub fn resolve_autonomous_dispatch_model(repo_root: &Path, issue: u32) -> Experi
     }
 
     if mode == "experiment" {
-        let arm = se::assign_arm(i64::from(issue), None);
+        let complexity = complexity();
+        let arm = se::assign_arm(i64::from(issue), complexity.as_deref());
         let model = se::resolved_arm_model(arm, &config);
         return ExperimentDispatchModel {
             model,
@@ -309,6 +336,74 @@ pub fn resolve_autonomous_dispatch_model(repo_root: &Path, issue: u32) -> Experi
         arm: None,
         source_label: source.as_str(),
     }
+}
+
+/// Best-effort fetch of an issue's `<!-- loom:complexity=<tier> -->` stratum
+/// straight from the forge (#4827), for dispatch paths that have no cached
+/// issue body (the epic supervisor's child dispatch, the `dispatch_sweep` MCP
+/// handler — unlike the work finder, which already carries the body on its
+/// [`crate::work_finder::WorkItem`]).
+///
+/// **Never fails the dispatch.** A spawn failure, timeout, non-zero exit,
+/// unparseable payload, or absent marker all resolve to `None` — the unchanged
+/// pre-#4827 `routine` stratum. Mirrors `resolve-tier-model.sh`'s
+/// GraphQL-then-REST fallback (#4472): `gh issue view` is a GraphQL call, and
+/// GraphQL quota exhausts independently of REST under fleet load (epic #4432).
+///
+/// Only ever called from inside [`resolve_autonomous_dispatch_model_lazy`]'s
+/// `experiment` branch, so `off` / `observe` dispatch is untouched.
+#[must_use]
+pub fn fetch_issue_complexity(gh_bin: &Path, workspace_root: &Path, issue: u32) -> Option<String> {
+    use crate::script_helpers::sweep_experiment as se;
+
+    let timeout = super::reaper::reap_gh_timeout();
+    let repo = std::env::var("LOOM_REPO").ok();
+
+    // 1. GraphQL (`gh issue view`) — the same call `resolve-tier-model.sh` tries first.
+    let mut view = Command::new(gh_bin);
+    view.arg("issue")
+        .arg("view")
+        .arg(issue.to_string())
+        .arg("--json")
+        .arg("body")
+        .arg("--jq")
+        .arg(".body");
+    view.current_dir(workspace_root);
+    if let Some(ref r) = repo {
+        view.arg("--repo").arg(r);
+    }
+    if let Ok(Some(out)) = super::reaper::output_with_timeout(view, timeout) {
+        if out.status.success() {
+            let body = String::from_utf8_lossy(&out.stdout);
+            if let Some(tier) = se::extract_complexity_marker(&body) {
+                return Some(tier.to_owned());
+            }
+            // A successful read with no marker is authoritative — do not spend
+            // a second (REST) round-trip re-confirming an absent marker.
+            return None;
+        }
+    }
+
+    // 2. REST fallback — a separate quota bucket from GraphQL (#4472).
+    let path = repo.map_or_else(
+        || format!("repos/{{owner}}/{{repo}}/issues/{issue}"),
+        |r| format!("repos/{r}/issues/{issue}"),
+    );
+    let mut api = Command::new(gh_bin);
+    api.arg("api").arg(&path).arg("--jq").arg(".body");
+    api.current_dir(workspace_root);
+    if let Ok(Some(out)) = super::reaper::output_with_timeout(api, timeout) {
+        if out.status.success() {
+            let body = String::from_utf8_lossy(&out.stdout);
+            return se::extract_complexity_marker(&body).map(str::to_owned);
+        }
+    }
+
+    log::debug!(
+        "sweep-experiment: could not fetch issue #{issue} body for complexity stratification \
+         (GraphQL+REST failed) — falling back to the routine stratum (#4827)"
+    );
+    None
 }
 
 #[cfg(test)]
@@ -537,7 +632,7 @@ mod tests {
     fn autonomous_dispatch_off_by_default_is_byte_identical() {
         clear_experiment_env();
         let dir = tempdir().unwrap();
-        let resolved = resolve_autonomous_dispatch_model(dir.path(), 100);
+        let resolved = resolve_autonomous_dispatch_model(dir.path(), 100, None);
         clear_experiment_env();
 
         assert_eq!(resolved.mode, "off");
@@ -556,7 +651,7 @@ mod tests {
         clear_experiment_env();
         std::env::set_var("LOOM_MODEL_EXPERIMENT", "experiment");
         let dir = tempdir().unwrap();
-        let resolved = resolve_autonomous_dispatch_model(dir.path(), 100);
+        let resolved = resolve_autonomous_dispatch_model(dir.path(), 100, None);
         clear_experiment_env();
 
         assert_eq!(resolved.mode, "observe");
@@ -574,7 +669,7 @@ mod tests {
         std::env::set_var("LOOM_MODEL_EXPERIMENT_CANARY", "1");
         let dir = tempdir().unwrap();
         // Issue 100, no complexity ⇒ arm A (see `assign_arm`'s parity table).
-        let resolved = resolve_autonomous_dispatch_model(dir.path(), 100);
+        let resolved = resolve_autonomous_dispatch_model(dir.path(), 100, None);
         clear_experiment_env();
 
         assert_eq!(resolved.mode, "experiment");
@@ -587,10 +682,89 @@ mod tests {
         clear_experiment_env();
         std::env::set_var("LOOM_MODEL_EXPERIMENT", "experiment");
         std::env::set_var("LOOM_MODEL_EXPERIMENT_CANARY", "1");
-        let resolved_b = resolve_autonomous_dispatch_model(dir.path(), 101);
+        let resolved_b = resolve_autonomous_dispatch_model(dir.path(), 101, None);
         clear_experiment_env();
         assert_eq!(resolved_b.arm, Some("B"));
         assert_eq!(resolved_b.model, "sonnet");
+    }
+
+    /// Issue #4827: a REAL per-issue complexity stratum reaches `assign_arm`
+    /// and shifts the parity, so the `complex` and `routine` strata each get an
+    /// independent ~50/50 A/B balance instead of the pooled population being
+    /// stratified as `routine`.
+    #[test]
+    #[serial]
+    fn autonomous_dispatch_stratifies_the_arm_by_per_issue_complexity() {
+        clear_experiment_env();
+        std::env::set_var("LOOM_MODEL_EXPERIMENT", "experiment");
+        std::env::set_var("LOOM_MODEL_EXPERIMENT_CANARY", "1");
+        let dir = tempdir().unwrap();
+
+        // Issue 100 with NO marker is arm A (the pre-#4827 behavior)...
+        let routine = resolve_autonomous_dispatch_model(dir.path(), 100, None);
+        assert_eq!(routine.arm, Some("A"));
+        assert_eq!(routine.model, "claude-opus-5");
+
+        // ...but the SAME issue marked `complex` flips to arm B — proof the
+        // stratum is threaded through, not discarded.
+        let complex = resolve_autonomous_dispatch_model(dir.path(), 100, Some("complex"));
+        assert_eq!(complex.arm, Some("B"));
+        assert_eq!(complex.model, "sonnet");
+
+        // An explicit `routine` marker is identical to no marker at all.
+        let explicit_routine = resolve_autonomous_dispatch_model(dir.path(), 100, Some("routine"));
+        assert_eq!(explicit_routine.arm, Some("A"));
+
+        // An out-of-vocabulary tier folds to `routine` (never an error).
+        let unknown = resolve_autonomous_dispatch_model(dir.path(), 100, Some("mystery"));
+        assert_eq!(unknown.arm, Some("A"));
+
+        clear_experiment_env();
+    }
+
+    /// The lazy form (#4827) is the one the epic supervisor / MCP handler use.
+    /// In `off` / `observe` mode the closure must NOT run — that is what keeps
+    /// those paths from paying a `gh` round-trip per dispatch. In `experiment`
+    /// mode it runs exactly once and its value reaches `assign_arm`.
+    #[test]
+    #[serial]
+    fn autonomous_dispatch_lazy_complexity_is_only_fetched_in_experiment_mode() {
+        use std::cell::Cell;
+
+        clear_experiment_env();
+        let dir = tempdir().unwrap();
+
+        // `off` (default): closure never invoked.
+        let calls = Cell::new(0_u32);
+        let resolved = resolve_autonomous_dispatch_model_lazy(dir.path(), 100, || {
+            calls.set(calls.get() + 1);
+            Some("complex".to_string())
+        });
+        assert_eq!(resolved.mode, "off");
+        assert_eq!(calls.get(), 0, "off mode must not pay the body fetch");
+
+        // `observe`: still never invoked.
+        std::env::set_var("LOOM_MODEL_EXPERIMENT", "observe");
+        let calls = Cell::new(0_u32);
+        let resolved = resolve_autonomous_dispatch_model_lazy(dir.path(), 100, || {
+            calls.set(calls.get() + 1);
+            Some("complex".to_string())
+        });
+        assert_eq!(resolved.mode, "observe");
+        assert_eq!(calls.get(), 0, "observe mode must not pay the body fetch");
+
+        // `experiment` + canary: invoked exactly once, and the value is used.
+        std::env::set_var("LOOM_MODEL_EXPERIMENT", "experiment");
+        std::env::set_var("LOOM_MODEL_EXPERIMENT_CANARY", "1");
+        let calls = Cell::new(0_u32);
+        let resolved = resolve_autonomous_dispatch_model_lazy(dir.path(), 100, || {
+            calls.set(calls.get() + 1);
+            Some("complex".to_string())
+        });
+        clear_experiment_env();
+        assert_eq!(resolved.mode, "experiment");
+        assert_eq!(calls.get(), 1);
+        assert_eq!(resolved.arm, Some("B"), "the fetched stratum must reach assign_arm");
     }
 
     /// Deterministic assignment: repeated calls for the same issue (a
@@ -602,8 +776,8 @@ mod tests {
         std::env::set_var("LOOM_MODEL_EXPERIMENT", "experiment");
         std::env::set_var("LOOM_MODEL_EXPERIMENT_CANARY", "1");
         let dir = tempdir().unwrap();
-        let first = resolve_autonomous_dispatch_model(dir.path(), 4242);
-        let second = resolve_autonomous_dispatch_model(dir.path(), 4242);
+        let first = resolve_autonomous_dispatch_model(dir.path(), 4242, None);
+        let second = resolve_autonomous_dispatch_model(dir.path(), 4242, None);
         clear_experiment_env();
         assert_eq!(first.arm, second.arm);
         assert_eq!(first.model, second.model);
@@ -624,7 +798,7 @@ mod tests {
         std::fs::create_dir_all(dir.path().join(".loom")).unwrap();
         std::fs::write(dir.path().join(".loom").join("CANARY"), "").unwrap();
 
-        let resolved = resolve_autonomous_dispatch_model(dir.path(), 100);
+        let resolved = resolve_autonomous_dispatch_model(dir.path(), 100, None);
         clear_experiment_env();
 
         assert_eq!(resolved.mode, "experiment");
@@ -640,7 +814,7 @@ mod tests {
         std::env::set_var("LOOM_MODEL_EXPERIMENT", "observe");
         let dir = tempdir().unwrap();
         write_config(dir.path(), r#"{"autonomous": {"model": "opus"}}"#);
-        let resolved = resolve_autonomous_dispatch_model(dir.path(), 100);
+        let resolved = resolve_autonomous_dispatch_model(dir.path(), 100, None);
         clear_experiment_env();
 
         assert_eq!(resolved.mode, "observe");

--- a/loom-daemon/src/sweep_registry/outcome_journal.rs
+++ b/loom-daemon/src/sweep_registry/outcome_journal.rs
@@ -179,8 +179,10 @@ impl SweepRegistry {
         // model — see `resolve_autonomous_dispatch_model`) is attributed
         // identically without needing a separate stored "explicit arm" field.
         // Kept in the free-form `config` map (not a new top-level schema field)
-        // so this is additive per #4703 with no schema-version bump. Per-issue
-        // complexity stratification is deferred — see the #4809 PR description.
+        // so this is additive per #4703 with no schema-version bump. Inference
+        // stays faithful under #4827's per-issue complexity stratification: the
+        // stratum only shifts WHICH arm an issue lands in, never the arm →
+        // model mapping this reads back.
         if let Some(arm) =
             crate::script_helpers::sweep_experiment::infer_arm_from_model(model.as_deref())
         {

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -261,6 +261,14 @@ pub struct WorkItem {
     /// output / a synthetic item) sorts *after* any dated item and falls back to
     /// the issue number as a monotonic-with-creation age proxy.
     pub created_at: Option<String>,
+    /// The issue's markdown body, when the listing supplied it (#4827).
+    ///
+    /// The ETag-cached REST listing already returns it at zero extra cost, and
+    /// dispatch reads the Curator's `<!-- loom:complexity=<tier> -->` marker out
+    /// of it (see [`Self::complexity`]) to stratify the model-cost A/B
+    /// experiment's arm assignment per issue. `None` (a synthetic item, or a
+    /// listing without bodies) simply falls back to the `routine` stratum.
+    pub body: Option<String>,
 }
 
 impl WorkItem {
@@ -272,6 +280,7 @@ impl WorkItem {
             number,
             labels,
             created_at: None,
+            body: None,
         }
     }
 
@@ -282,7 +291,28 @@ impl WorkItem {
             number,
             labels,
             created_at,
+            body: None,
         }
+    }
+
+    /// Builder-style setter for the issue body (#4827).
+    #[must_use]
+    pub fn with_body(mut self, body: Option<String>) -> Self {
+        self.body = body;
+        self
+    }
+
+    /// The Curator's `<!-- loom:complexity=<tier> -->` stratum for this issue,
+    /// extracted from [`Self::body`] (#4827).
+    ///
+    /// `None` when no body was fetched or no marker is present — which
+    /// [`crate::script_helpers::sweep_experiment::assign_arm`] treats as the
+    /// `routine` stratum, exactly as before this field existed.
+    #[must_use]
+    pub fn complexity(&self) -> Option<&str> {
+        self.body
+            .as_deref()
+            .and_then(crate::script_helpers::sweep_experiment::extract_complexity_marker)
     }
 
     /// True when the issue carries any [`SKIP_LABELS`] entry.
@@ -319,6 +349,11 @@ pub struct PriorityCandidate {
     pub created_at: Option<String>,
     /// The issue number (dispatch target + final deterministic tiebreak).
     pub number: u32,
+    /// The issue's `<!-- loom:complexity=<tier> -->` stratum (#4827), carried
+    /// from its [`WorkItem`] so pass 2's `dispatch()` can stratify the
+    /// model-cost A/B arm assignment without re-fetching the body. Not part of
+    /// the ordering keys — [`candidate_cmp`] ignores it.
+    pub complexity: Option<String>,
 }
 
 /// Total ordering over dispatch candidates (#3946): **(workspace priority asc,
@@ -444,11 +479,17 @@ pub trait WorkDispatcher {
     /// was started, `false` when the dispatch was an idempotency no-op (a sweep
     /// with the same key was already running).
     ///
+    /// `complexity` is the issue's `<!-- loom:complexity=<tier> -->` stratum
+    /// (#4827), already extracted from the listing's issue body by the caller —
+    /// the dispatcher never re-fetches it. Used ONLY to stratify the model-cost
+    /// A/B experiment's arm assignment; `None` (no marker / no body) keeps the
+    /// pre-#4827 `routine` stratum and is never an error.
+    ///
     /// # Errors
     ///
     /// Returns an error when the dispatch fails (e.g. a claim-lock collision).
     /// The caller logs and counts it; it is never fatal.
-    fn dispatch(&mut self, issue: u32) -> Result<bool>;
+    fn dispatch(&mut self, issue: u32, complexity: Option<&str>) -> Result<bool>;
 
     /// Count of in-flight sweeps that occupy the work-finder's concurrency
     /// budget (Issue #4003).
@@ -765,7 +806,7 @@ pub fn tick_with_admission_cap(
         }
         // 4. Dispatch. The registry's idempotency key + claim lock make a
         //    double-dispatch of an already-running issue a no-op / loud error.
-        match dispatcher.dispatch(item.number) {
+        match dispatcher.dispatch(item.number, item.complexity()) {
             Ok(true) => {
                 report.dispatched += 1;
                 occupancy += 1;
@@ -1087,6 +1128,7 @@ pub fn tick_multi_with_admission_cap<S: WorkSource, D: WorkDispatcher>(
                 workspace_idx: idx,
                 workspace_priority,
                 urgent: item.is_urgent(),
+                complexity: item.complexity().map(str::to_owned),
                 created_at: item.created_at,
                 number: item.number,
             });
@@ -1119,7 +1161,7 @@ pub fn tick_multi_with_admission_cap<S: WorkSource, D: WorkDispatcher>(
             continue;
         }
         let dispatcher = &mut workspaces[cand.workspace_idx].1;
-        match dispatcher.dispatch(cand.number) {
+        match dispatcher.dispatch(cand.number, cand.complexity.as_deref()) {
             Ok(true) => {
                 report.dispatched += 1;
                 occupancy += 1;
@@ -2312,7 +2354,13 @@ pub mod forge {
             Ok(rows
                 .into_iter()
                 .filter(|r| !r.is_pull_request)
-                .map(|r| WorkItem::with_created_at(r.number, r.labels, r.created_at))
+                // The REST listing already returns `body` (#4827) — carrying it
+                // onto the item costs no extra request and lets dispatch read
+                // the `<!-- loom:complexity=... -->` stratum without a
+                // per-issue `gh issue view`.
+                .map(|r| {
+                    WorkItem::with_created_at(r.number, r.labels, r.created_at).with_body(r.body)
+                })
                 .collect())
         }
     }
@@ -2420,7 +2468,7 @@ pub mod forge {
             }
         }
 
-        fn dispatch(&mut self, issue: u32) -> Result<bool> {
+        fn dispatch(&mut self, issue: u32, complexity: Option<&str>) -> Result<bool> {
             let mut reg = self
                 .registry
                 .lock()
@@ -2438,13 +2486,22 @@ pub mod forge {
             // for the sweep.md prose instrumentation, which never executed in a
             // headless child and was in any case overridden by this very
             // default-pin precedence. `off`/`observe` modes are unaffected.
+            //
+            // Issue #4827: `complexity` is the issue's real
+            // `<!-- loom:complexity=... -->` stratum, read from the body the
+            // ETag-cached REST listing already returned — so the experiment's
+            // `complex` and `routine` strata each get an independent ~50/50 A/B
+            // balance instead of the whole population being stratified as
+            // `routine`. No extra forge call: the body arrives with the listing.
             let repo_root = reg.config().workspace_root.clone();
-            let resolved =
-                crate::sweep_registry::resolve_autonomous_dispatch_model(&repo_root, issue);
+            let resolved = crate::sweep_registry::resolve_autonomous_dispatch_model(
+                &repo_root, issue, complexity,
+            );
             match resolved.arm {
                 Some(arm) => log::info!(
-                    "work_finder: dispatching issue #{issue} with arm={arm} model={} \
-                     (source={})",
+                    "work_finder: dispatching issue #{issue} with arm={arm} \
+                     (complexity={}) model={} (source={})",
+                    complexity.unwrap_or("routine"),
                     resolved.model,
                     resolved.source_label
                 ),
@@ -2579,6 +2636,10 @@ mod tests {
         /// `in_flight()` cannot see it (a reverted label, a released lock, or a
         /// second daemon instance on the same host).
         live_claim_issues: HashSet<u32>,
+        /// Every `(issue, complexity)` pair `dispatch` was called with (#4827),
+        /// so a test can assert the REAL per-issue complexity stratum reached
+        /// the dispatcher rather than the pre-#4827 `None`.
+        dispatched_complexity: Vec<(u32, Option<String>)>,
     }
 
     impl WorkDispatcher for RecordingDispatcher {
@@ -2597,7 +2658,9 @@ mod tests {
         fn peer_claimed(&self) -> HashSet<u32> {
             self.peer_claimed.clone()
         }
-        fn dispatch(&mut self, issue: u32) -> Result<bool> {
+        fn dispatch(&mut self, issue: u32, complexity: Option<&str>) -> Result<bool> {
+            self.dispatched_complexity
+                .push((issue, complexity.map(str::to_owned)));
             if self.backoff_refuse_issues.contains(&issue) {
                 return Err(DispatchBackoffError {
                     issue,
@@ -2639,6 +2702,81 @@ mod tests {
 
     fn issue(n: u32) -> WorkItem {
         WorkItem::new(n, vec!["loom:issue".to_string()])
+    }
+
+    // ===================================================================
+    // Per-issue complexity threading (#4827)
+    // ===================================================================
+
+    /// A ready issue whose body carries the Curator's `<!-- loom:complexity=... -->`
+    /// marker — the shape `GhWorkSource::list_ready_issues` now materializes
+    /// from the REST listing's `body` field.
+    fn issue_with_complexity(n: u32, tier: &str) -> WorkItem {
+        issue(n).with_body(Some(format!(
+            "## Context\n\nSome body text.\n\n<!-- loom:complexity={tier} -->\n"
+        )))
+    }
+
+    /// `WorkItem::complexity()` reads the marker out of the carried body, and
+    /// degrades to `None` (the unchanged `routine` stratum) when the listing
+    /// supplied no body or the body carries no marker.
+    #[test]
+    fn work_item_extracts_complexity_from_its_body() {
+        assert_eq!(issue_with_complexity(1, "complex").complexity(), Some("complex"));
+        assert_eq!(issue_with_complexity(1, "mechanical").complexity(), Some("mechanical"));
+        // No body at all (a synthetic item / a listing without bodies).
+        assert_eq!(issue(1).complexity(), None);
+        // A body with no marker (a pre-marker issue).
+        assert_eq!(issue(1).with_body(Some("no marker".into())).complexity(), None);
+    }
+
+    /// The core #4827 acceptance criterion for the single-workspace path: the
+    /// issue's REAL complexity stratum reaches `dispatch()` instead of the
+    /// pre-#4827 hardcoded `None`.
+    #[test]
+    fn tick_threads_per_issue_complexity_into_dispatch() {
+        let mut source = FakeSource::once(vec![
+            issue_with_complexity(10, "complex"),
+            issue_with_complexity(11, "mechanical"),
+            issue(12), // no body → None → `routine`, unchanged
+        ]);
+        let mut dispatcher = RecordingDispatcher::default();
+        let report = tick(&mut source, &mut dispatcher, 10, false).unwrap();
+
+        assert_eq!(report.dispatched, 3);
+        assert_eq!(
+            dispatcher.dispatched_complexity,
+            vec![
+                (10, Some("complex".to_string())),
+                (11, Some("mechanical".to_string())),
+                (12, None),
+            ]
+        );
+    }
+
+    /// The same criterion for the multi-workspace path, where the stratum
+    /// travels on `PriorityCandidate` from pass 1 (listing) to pass 2
+    /// (dispatch) — it must survive the global priority sort.
+    #[test]
+    fn tick_multi_threads_per_issue_complexity_into_dispatch() {
+        let mut workspaces = vec![
+            (
+                FakeSource::once(vec![issue_with_complexity(20, "complex")]),
+                RecordingDispatcher::default(),
+            ),
+            (
+                FakeSource::once(vec![issue_with_complexity(21, "routine"), issue(22)]),
+                RecordingDispatcher::default(),
+            ),
+        ];
+        let report = tick_multi(&mut workspaces, &[0, 0], 10, &[false, false]);
+
+        assert_eq!(report.dispatched, 3);
+        assert_eq!(workspaces[0].1.dispatched_complexity, vec![(20, Some("complex".to_string()))]);
+        assert_eq!(
+            workspaces[1].1.dispatched_complexity,
+            vec![(21, Some("routine".to_string())), (22, None)]
+        );
     }
 
     // ===================================================================
@@ -2706,7 +2844,9 @@ exit 0
 
         let (mut dispatcher, _dir, record_log) = setup_registry_dispatcher_in_tempdir();
 
-        let was_new = dispatcher.dispatch(3964).expect("dispatch should succeed");
+        let was_new = dispatcher
+            .dispatch(3964, None)
+            .expect("dispatch should succeed");
         assert!(was_new, "expected a fresh dispatch, not an idempotency no-op");
 
         let start = std::time::Instant::now();
@@ -3814,6 +3954,7 @@ exit 0
             workspace_idx: idx,
             workspace_priority: prio,
             urgent,
+            complexity: None,
             created_at: created.map(str::to_string),
             number: num,
         };


### PR DESCRIPTION
## Summary

Follow-up to #4809, which moved model-cost A/B experiment arm assignment into the
daemon but always called `assign_arm(issue, None)` — stratifying the entire
population as `routine`. Assignment stayed deterministic and resume-safe, but the
`complex` and `routine` strata did not each get an independent ~50/50 A/B balance;
only the pooled population did.

This threads the Curator's `<!-- loom:complexity=<tier> -->` marker through to all
three `resolve_autonomous_dispatch_model` call sites.

## What changed

**`work_finder.rs`** — `WorkItem` gains `body: Option<String>`, populated from
`RestIssue::body` in `GhWorkSource::list_ready_issues`. The ETag-cached REST
listing already returns the body, so this costs **zero extra requests**.
`WorkItem::complexity()` extracts the tier, and it rides `PriorityCandidate`
through the multi-workspace global priority sort so pass 2's `dispatch()` has it
without re-fetching. `WorkDispatcher::dispatch` grows a `complexity: Option<&str>`
parameter.

**`epic_supervisor.rs`** and **`ipc.rs`**'s `dispatch_sweep` MCP handler — neither
has a cached issue body, so both fetch one via the new `fetch_issue_complexity`
(GraphQL `gh issue view`, REST fallback per #4472, mirroring
`resolve-tier-model.sh`). The fetch is **lazy**: the new
`resolve_autonomous_dispatch_model_lazy` invokes the closure only inside its
`experiment` branch, so `off`/`observe` dispatch — the default, and the
no-behavior-change contract #4809 established — makes zero extra `gh` calls and
adds zero rate-limit pressure (epic #4432). A failed fetch degrades to
`None`/`routine` and **never fails a dispatch**.

## Marker extraction and #4845

`extract_complexity_marker` mirrors the shell extraction **as of #4845** (which
landed on main while this was in progress): anchored to the canonical
`<!-- ... -->` comment form, last-match-wins, line-oriented like `grep`.

That anchoring is load-bearing here rather than incidental: **issue #4827's own
body** quotes `` `<!-- loom:complexity=<tier> -->` `` as literal example text, and
the pre-#4845 bare-substring match would have picked that empty match over the
real marker — exactly the bug #4840 reported.

Extraction was differential-checked against the shell one-liner
(`grep -oE '<!--[[:space:]]*loom:complexity=[a-z]*[[:space:]]*-->' | tail -1 | sed …`)
across the canonical, no-delimiter, half-delimiter, non-`[a-z]`, `[A-Z]`,
empty-tier, multi-marker-one-line, multi-marker-multi-line, and prose-mention
cases — all 10 agree.

## Item 2 (`SweepInfo.arm`) — deliberately deferred

The issue marks it optional/lower-priority, and it is **not** done here. Inference
from the dispatched model stays faithful under this change: the complexity stratum
only shifts *which* arm an issue lands in, never the arm → model mapping that
`infer_arm_from_model` reads back. Doing it would require touching ~40
`SweepInfo { .. }` struct-literal call sites for no behavioral gain today. Left as
a follow-up for if/when a config override makes the forced model ambiguous between
arms.

## Testing

- `cargo test` in `loom-daemon/`: **2955 passed**. The existing `assign_arm`
  determinism/stratification tests pass **unmodified** (AC #3).
- New coverage: marker extraction (canonical form, anchoring, `[a-z]*` class,
  empty tier, last-match-wins, prose-mention/#4840 regression, no cross-line
  match, Unicode safety); `WorkItem::complexity()`; complexity reaching
  `dispatch()` on both the single- and multi-workspace tick paths; the stratum
  shifting the resolved arm; and the laziness contract (closure never invoked in
  `off`/`observe`, invoked exactly once in `experiment`).
- `cargo clippy --lib` clean, `cargo fmt --check` clean.

### Pre-existing failures on main (not introduced here)

- `tokens_pool::bootstrap::bootstrap_partial_triple_warns_without_aborting` fails
  only under the full parallel run and **passes in isolation** — an env-var
  parallelism race. This branch touches nothing in `tokens_pool`.
- `cargo clippy --all-targets` errors on `unnecessary_get_then_check` in
  `terminal.rs:2590` (test code, from #4808 / commit `df116564`), untouched here.
  `cargo clippy --lib` — all production code including these changes — is clean.

Closes #4827

🤖 Generated with [Claude Code](https://claude.com/claude-code)
