### PR TITLE
feat(dashboard): add the topbar account menu (sign in / sign out)

### DIFF
--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -433,13 +433,43 @@ async function handleDashboardPage(env: Env, isAuthenticated: boolean): Promise<
  * the server-rendered variant. See `web/src/api.ts`. */
 const AUTH_STATE_GLOBAL = "__LOOM_FLEET__";
 
-/** Inject the auth state into the SPA shell as a `<script>` immediately
- * before `</head>`, so it is defined before the module bundle executes.
+/**
+ * Serialize a value for embedding inside an inline `<script>`.
  *
- * `JSON.stringify` on a boolean cannot emit `<`/`&`, so no HTML-escaping
- * pass is needed here; keep it that way if this ever carries a string. */
-function injectAuthState(html: string, isAuthenticated: boolean): string {
-  const tag = `<script>window.${AUTH_STATE_GLOBAL}=${JSON.stringify({ authenticated: isAuthenticated })};</script>`;
+ * An earlier revision noted that `JSON.stringify` of a *boolean* can never
+ * emit `<` or `&`, so no escaping was needed — and warned to revisit that if
+ * the payload ever carried a string. It does now (the operator's email), so
+ * this is that revisit.
+ *
+ * The attack this closes is the classic one: a value containing the literal
+ * `</script>` terminates the block early and everything after it parses as
+ * markup. Escaping `<`, `>` and `&` as `\uXXXX` prevents it — those escapes
+ * are valid inside a JSON string literal and decode back to the original
+ * characters, so the value the browser sees is unchanged.
+ *
+ * The email arrives from a Cloudflare-signed, signature-verified JWT, so this
+ * is defense in depth rather than the primary control. It costs nothing and
+ * removes the need to reason about how much an IdP-supplied claim can be
+ * trusted.
+ */
+function serializeForScript(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026");
+}
+
+/** The auth state the SPA reads out of the page. `email` is present only for
+ * an authenticated viewer, and only when the token carried one. */
+interface InjectedAuthState {
+  authenticated: boolean;
+  email?: string;
+}
+
+/** Inject the auth state into the SPA shell as a `<script>` immediately
+ * before `</head>`, so it is defined before the module bundle executes. */
+function injectAuthState(html: string, state: InjectedAuthState): string {
+  const tag = `<script>window.${AUTH_STATE_GLOBAL}=${serializeForScript(state)};</script>`;
   return html.includes("</head>") ? html.replace("</head>", `${tag}</head>`) : `${tag}${html}`;
 }
 
@@ -468,14 +498,18 @@ async function handleRoot(request: Request, env: Env): Promise<Response> {
   if (env.ASSETS) {
     const shell = await env.ASSETS.fetch(new Request(new URL("/index.html", request.url), { method: "GET" }));
     if (shell.ok) {
-      return new Response(injectAuthState(await shell.text(), isAuthenticated), {
+      const state: InjectedAuthState = isAuthenticated
+        ? { authenticated: true, ...(identity.email ? { email: identity.email } : {}) }
+        : { authenticated: false };
+
+      return new Response(injectAuthState(await shell.text(), state), {
         status: 200,
         headers: {
           "content-type": "text/html; charset=utf-8",
           // Same reasoning as `handleDashboardPage`, and it matters more
-          // here: this body differs between viewers only by the injected
-          // auth flag, which is exactly the kind of near-identical response
-          // a cache is most likely to collapse.
+          // here: this body now carries the viewer's own email, so a shared
+          // cache collapsing two viewers' responses would show one
+          // operator's identity to another.
           "cache-control": "private, no-store",
           vary: "Cookie",
         },

--- a/dashboard/test/index.test.ts
+++ b/dashboard/test/index.test.ts
@@ -55,8 +55,10 @@ function mockJwksFetch(): () => void {
   };
 }
 
-async function signToken(overrides: { aud?: string; expiresIn?: string } = {}): Promise<string> {
-  return new SignJWT({ email: "operator@2amlogic.com" })
+async function signToken(
+  overrides: { aud?: string; expiresIn?: string; email?: string } = {},
+): Promise<string> {
+  return new SignJWT({ email: overrides.email ?? "operator@2amlogic.com" })
     .setProtectedHeader({ alg: "RS256" })
     .setIssuedAt()
     .setIssuer(`https://${TEAM_DOMAIN}`)
@@ -81,7 +83,11 @@ async function signToken(overrides: { aud?: string; expiresIn?: string } = {}): 
  * which `publicPage.test.ts` covers.
  */
 function expectAuthState(html: string, authenticated: boolean): void {
-  expect(html).toContain(`window.__LOOM_FLEET__={"authenticated":${authenticated}};`);
+  // Asserted on the key/value pair rather than the whole serialized object,
+  // which also carries the viewer's `email` when there is one. Still pinned
+  // to the exact literal `true`/`false` — a substring like `"authenticated"`
+  // alone would pass on either value.
+  expect(html).toContain(`window.__LOOM_FLEET__={"authenticated":${authenticated}`);
 }
 
 const PRIVATE_REPO = "rjwalters/root-route-private-repo";
@@ -235,6 +241,47 @@ describe("GET / — Access JWT wired end to end (real createRemoteJWKSet path)",
       }),
     );
     expect(response.status).toBe(401);
+  });
+
+  it("hands the SPA the signed-in operator's email for the account menu", async () => {
+    restoreFetch = mockJwksFetch();
+    const token = await signToken();
+
+    const response = await callWorker(
+      new Request("https://ingest.example/", { headers: { cookie: `CF_Authorization=${token}` } }),
+    );
+
+    // `signToken` puts this address in the JWT's `email` claim.
+    expect(await response.text()).toContain('"email":"operator@2amlogic.com"');
+  });
+
+  it("never leaks an identity to an anonymous viewer", async () => {
+    restoreFetch = mockJwksFetch();
+    const response = await callWorker(new Request("https://ingest.example/"));
+    const html = await response.text();
+
+    expect(html).not.toContain("operator@2amlogic.com");
+    expect(html).not.toContain('"email"');
+  });
+
+  // The injected state sits inside an inline <script>. A value containing the
+  // literal `</script>` would terminate the block early and the remainder
+  // would parse as markup. The email comes from a signature-verified JWT so
+  // this is defense in depth, but it costs nothing and removes the need to
+  // reason about how far an IdP claim can be trusted.
+  it("escapes an injected identity so it cannot break out of the script block", async () => {
+    restoreFetch = mockJwksFetch();
+    const token = await signToken({ email: "</script><script>alert(1)</script>@evil.test" });
+
+    const response = await callWorker(
+      new Request("https://ingest.example/", { headers: { cookie: `CF_Authorization=${token}` } }),
+    );
+    const html = await response.text();
+
+    // Exactly the two <script> tags the shell legitimately contains (the
+    // injection and the module bundle) — the payload contributed none.
+    expect(html).not.toContain("</script><script>alert(1)");
+    expect(html).toContain("\\u003c/script\\u003e");
   });
 
   it("/public/* stays reachable anonymously — the split is auth, not obscurity", async () => {

--- a/dashboard/web/index.html
+++ b/dashboard/web/index.html
@@ -12,6 +12,11 @@
       <h1 class="topbar__title">Loom fleet</h1>
       <div class="topbar__meta">
         <span id="refresh-status" class="topbar__status" aria-live="polite"></span>
+        <!-- Populated by `accountMenu.ts` from the server-injected auth
+             state: an avatar + menu when signed in, a Sign in button when
+             not. Empty in the markup so neither variant flashes before the
+             bundle runs. -->
+        <div id="account" class="topbar__account"></div>
         <button id="refresh-button" type="button" class="button">Refresh</button>
       </div>
     </header>

--- a/dashboard/web/src/accountMenu.ts
+++ b/dashboard/web/src/accountMenu.ts
@@ -1,0 +1,121 @@
+/**
+ * The topbar account control — the standard app-shell pattern: an avatar
+ * button at top right that opens a menu with the signed-in identity and a
+ * sign-out action, or a plain Sign in button when nobody is signed in.
+ *
+ * ## Why this exists
+ *
+ * Under the single-URL layout (issue #4795) `/` serves the same bundle to
+ * everyone and the Worker stamps the viewer's identity into the page
+ * (`../../src/index.ts`'s `handleRoot` → `api.ts`'s `readAuthState`). Before
+ * this module the SPA had no sign-in affordance at all: the server-rendered
+ * fallback page had one, but that page only renders when no UI build is
+ * uploaded, so the link vanished the moment the SPA became what `/` served.
+ * An anonymous visitor's only route in was typing `/login` by hand.
+ *
+ * ## Sign-out is Cloudflare's, not ours
+ *
+ * `/cdn-cgi/access/logout` is an Access-provided endpoint that clears the
+ * `CF_Authorization` cookie. There is no app-side session to tear down — the
+ * cookie *is* the session — so signing out is a plain link to it, and this
+ * app deliberately implements no logout logic of its own.
+ *
+ * ## No identity is inferred here
+ *
+ * The email is rendered, never trusted: it comes from a signature-verified
+ * JWT the Worker already validated, and nothing in this module grants access
+ * to anything. Editing it in devtools changes a label and nothing else — the
+ * data split is enforced server-side by `/api/*` vs `/public/*`.
+ */
+
+import { el } from "./dom";
+import { readAuthState } from "./api";
+
+/** Access's own logout endpoint; clears the `CF_Authorization` cookie. */
+export const SIGN_OUT_PATH = "/cdn-cgi/access/logout";
+
+/** The Access application that mints the session cookie. */
+export const SIGN_IN_PATH = "/login";
+
+/**
+ * Up to two initials for the avatar, derived from the email's local part.
+ *
+ * `robb.walters@example.com` → `RW`; `agent7@example.com` → `A`. Falls back
+ * to a neutral glyph rather than throwing or rendering an empty circle when
+ * there is no usable email — an authenticated token without an `email` claim
+ * is unusual but permitted by the schema.
+ */
+export function initialsFor(email: string | undefined): string {
+  const local = (email ?? "").split("@")[0] ?? "";
+  const parts = local.split(/[._-]+/).filter(Boolean);
+  if (parts.length === 0) return "●";
+  if (parts.length === 1) return (parts[0]![0] ?? "●").toUpperCase();
+  return `${parts[0]![0]}${parts[1]![0]}`.toUpperCase();
+}
+
+function signInButton(): HTMLElement {
+  return el("a", { class: "button account__signin", href: SIGN_IN_PATH }, "Sign in");
+}
+
+function signedInMenu(email: string | undefined): HTMLElement {
+  const label = email ?? "Signed in";
+
+  const avatar = el(
+    "button",
+    {
+      class: "account__avatar",
+      type: "button",
+      data: { testid: "account-avatar" },
+      aria: {
+        // The avatar renders initials, which a screen reader would otherwise
+        // announce as two stray letters.
+        label: `Account: ${label}`,
+        expanded: "false",
+        haspopup: "menu",
+      },
+    },
+    initialsFor(email),
+  );
+
+  const menu = el(
+    "div",
+    { class: "account__menu", role: "menu", data: { testid: "account-menu" } },
+    el("p", { class: "account__email", data: { testid: "account-email" } }, label),
+    el(
+      "a",
+      { class: "account__signout", role: "menuitem", href: SIGN_OUT_PATH, data: { testid: "sign-out" } },
+      "Sign out",
+    ),
+  );
+  // `hidden` is a boolean attribute with no `Attrs` field; set directly
+  // rather than widening the shared builder for one caller.
+  menu.setAttribute("hidden", "");
+
+  avatar.addEventListener("click", () => {
+    const open = avatar.getAttribute("aria-expanded") === "true";
+    avatar.setAttribute("aria-expanded", String(!open));
+    if (open) menu.setAttribute("hidden", "");
+    else menu.removeAttribute("hidden");
+  });
+
+  return el("div", { class: "account" }, avatar, menu);
+}
+
+/**
+ * Render the account control into `container`, replacing its contents.
+ *
+ * Reads the injected auth state by default; `scope` is injected in tests.
+ * Anonymous is the fail-closed default (see `readAuthState`), so a page that
+ * never received the injection shows Sign in rather than a phantom identity.
+ */
+export function renderAccountMenu(container: HTMLElement, scope: typeof globalThis = globalThis): void {
+  const state = readAuthState(scope);
+  container.replaceChildren(state.authenticated ? signedInMenu(state.email) : signInButton());
+}
+
+/** Render into `#account` if the host page has one. A page without the
+ * container simply has no account control — not an error. */
+export function wireAccountMenu(doc: Document, scope: typeof globalThis = globalThis): void {
+  const container = doc.getElementById("account");
+  if (container instanceof HTMLElement) renderAccountMenu(container, scope);
+}

--- a/dashboard/web/src/api.ts
+++ b/dashboard/web/src/api.ts
@@ -53,17 +53,38 @@ export const PUBLIC_FLEET_STATE_PATH = "/public/fleet-state";
 /** The global `handleRoot` injects into the SPA shell. */
 const AUTH_STATE_GLOBAL = "__LOOM_FLEET__";
 
+/** The auth state the Worker stamps into the page. `email` is present only
+ * for an authenticated viewer whose token carried one. */
+export interface AuthState {
+  authenticated: boolean;
+  email?: string;
+}
+
 /**
  * Read the server-injected auth state.
  *
- * Defaults to **false** whenever the global is missing or malformed — a UI
- * that guesses "authenticated" would request `/api/*`, get a 403, and show an
- * error page to a visitor who was entitled to the public view. Guessing
+ * Defaults to **anonymous** whenever the global is missing or malformed — a
+ * UI that guesses "authenticated" would request `/api/*`, get a 401, and show
+ * an error page to a visitor who was entitled to the public view. Guessing
  * "public" merely under-fetches for someone who can reload.
  */
+export function readAuthState(scope: typeof globalThis = globalThis): AuthState {
+  const raw = (scope as Record<string, unknown>)[AUTH_STATE_GLOBAL];
+  if (typeof raw !== "object" || raw === null) return { authenticated: false };
+
+  const state = raw as { authenticated?: unknown; email?: unknown };
+  if (state.authenticated !== true) return { authenticated: false };
+
+  return {
+    authenticated: true,
+    ...(typeof state.email === "string" && state.email.length > 0 ? { email: state.email } : {}),
+  };
+}
+
+/** Whether the viewer is signed in. Thin wrapper over `readAuthState` — the
+ * common case, and the one the data-fetching path cares about. */
 export function isAuthenticatedViewer(scope: typeof globalThis = globalThis): boolean {
-  const state = (scope as Record<string, unknown>)[AUTH_STATE_GLOBAL];
-  return typeof state === "object" && state !== null && (state as { authenticated?: unknown }).authenticated === true;
+  return readAuthState(scope).authenticated;
 }
 
 /** The fleet-state path for a given auth state. */

--- a/dashboard/web/src/main.ts
+++ b/dashboard/web/src/main.ts
@@ -6,12 +6,15 @@
 
 import "./styles.css";
 import { App } from "./app";
+import { wireAccountMenu } from "./accountMenu";
 import { onRouteChange, parseRoute } from "./router";
 
 const root = document.getElementById("app");
 if (!(root instanceof HTMLElement)) {
   throw new Error("#app container is missing from index.html");
 }
+
+wireAccountMenu(document);
 
 const app = new App({
   root,

--- a/dashboard/web/src/styles.css
+++ b/dashboard/web/src/styles.css
@@ -79,6 +79,80 @@ a:hover {
   border-color: var(--accent);
 }
 
+/* --- Account control (topbar, right) ------------------------------------ */
+/* Rendered by `accountMenu.ts` from the server-injected auth state: an
+   avatar + menu when signed in, a Sign in button when not. */
+.topbar__account {
+  display: flex;
+  align-items: center;
+}
+.account {
+  position: relative;
+}
+.account__avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--bg-sunken);
+  color: var(--text);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+}
+.account__avatar:hover {
+  border-color: var(--accent);
+}
+/* Keyboard focus must stay visible — the avatar is a real button and this is
+   the only way to reach the menu without a pointer. */
+.account__avatar:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.account__menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 200px;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-raised);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 45%);
+  z-index: 20;
+}
+.account__menu[hidden] {
+  display: none;
+}
+.account__email {
+  margin: 0 0 6px;
+  padding: 4px 8px;
+  color: var(--text-dim);
+  font-size: 12px;
+  /* An email can be long; wrap rather than widen the menu off-screen. */
+  overflow-wrap: anywhere;
+}
+.account__signout {
+  display: block;
+  padding: 6px 8px;
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 13px;
+  text-decoration: none;
+}
+.account__signout:hover {
+  background: var(--bg-sunken);
+  color: var(--accent);
+}
+.account__signin {
+  text-decoration: none;
+  display: inline-block;
+}
+
 .app {
   padding: 20px;
   max-width: 1400px;

--- a/dashboard/web/test/accountMenu.test.ts
+++ b/dashboard/web/test/accountMenu.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  SIGN_IN_PATH,
+  SIGN_OUT_PATH,
+  initialsFor,
+  renderAccountMenu,
+  wireAccountMenu,
+} from "../src/accountMenu";
+
+/** A stand-in for `window` carrying whatever the Worker injected. */
+function scopeWith(value: unknown): typeof globalThis {
+  return { __LOOM_FLEET__: value } as unknown as typeof globalThis;
+}
+
+function container(): HTMLElement {
+  const node = document.createElement("div");
+  document.body.appendChild(node);
+  return node;
+}
+
+beforeEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("initialsFor", () => {
+  it.each([
+    ["robb.walters@example.com", "RW"],
+    ["robb_walters@example.com", "RW"],
+    ["robb-walters@example.com", "RW"],
+    ["agent7@example.com", "A"],
+    ["a@example.com", "A"],
+  ])("derives initials from %s", (email, expected) => {
+    expect(initialsFor(email)).toBe(expected);
+  });
+
+  // An authenticated token without an `email` claim is unusual but allowed by
+  // the schema — render a neutral glyph rather than an empty circle.
+  it.each([[undefined], [""], ["@example.com"]])("falls back to a glyph for %s", (email) => {
+    expect(initialsFor(email as string | undefined)).toBe("●");
+  });
+});
+
+describe("renderAccountMenu — anonymous", () => {
+  it("shows a Sign in link pointing at the Access login app", () => {
+    const node = container();
+    renderAccountMenu(node, scopeWith({ authenticated: false }));
+
+    const link = node.querySelector("a.account__signin");
+    expect(link?.getAttribute("href")).toBe(SIGN_IN_PATH);
+    expect(link?.textContent).toBe("Sign in");
+  });
+
+  it("renders no identity and no sign-out affordance", () => {
+    const node = container();
+    renderAccountMenu(node, scopeWith({ authenticated: false }));
+
+    expect(node.querySelector('[data-testid="account-avatar"]')).toBeNull();
+    expect(node.querySelector('[data-testid="sign-out"]')).toBeNull();
+  });
+
+  // Fail closed: every malformed shape must render Sign in, never a phantom
+  // identity. A page that never received the injection is the common case
+  // (e.g. the bundle loaded from somewhere the Worker did not stamp).
+  it.each([
+    ["flag absent", {}],
+    ["authenticated:false", { authenticated: false }],
+    ["truthy but not true", { authenticated: "yes" }],
+    ["null", null],
+    ["not an object", "authenticated"],
+    ["undefined", undefined],
+  ])("treats %s as anonymous", (_label, value) => {
+    const node = container();
+    renderAccountMenu(node, scopeWith(value));
+    expect(node.querySelector("a.account__signin")).not.toBeNull();
+  });
+});
+
+describe("renderAccountMenu — signed in", () => {
+  const signedIn = { authenticated: true, email: "robb.walters@example.com" };
+
+  it("shows an avatar with initials and no Sign in link", () => {
+    const node = container();
+    renderAccountMenu(node, scopeWith(signedIn));
+
+    expect(node.querySelector('[data-testid="account-avatar"]')?.textContent).toBe("RW");
+    expect(node.querySelector("a.account__signin")).toBeNull();
+  });
+
+  it("puts the email and a sign-out link in the menu", () => {
+    const node = container();
+    renderAccountMenu(node, scopeWith(signedIn));
+
+    expect(node.querySelector('[data-testid="account-email"]')?.textContent).toBe("robb.walters@example.com");
+    // Sign-out is Cloudflare Access's own endpoint — this app has no session
+    // of its own to tear down.
+    expect(node.querySelector('[data-testid="sign-out"]')?.getAttribute("href")).toBe(SIGN_OUT_PATH);
+  });
+
+  it("keeps the menu closed until the avatar is clicked, and toggles it", () => {
+    const node = container();
+    renderAccountMenu(node, scopeWith(signedIn));
+
+    const avatar = node.querySelector('[data-testid="account-avatar"]') as HTMLElement;
+    const menu = node.querySelector('[data-testid="account-menu"]') as HTMLElement;
+
+    expect(menu.hasAttribute("hidden")).toBe(true);
+    expect(avatar.getAttribute("aria-expanded")).toBe("false");
+
+    avatar.click();
+    expect(menu.hasAttribute("hidden")).toBe(false);
+    expect(avatar.getAttribute("aria-expanded")).toBe("true");
+
+    avatar.click();
+    expect(menu.hasAttribute("hidden")).toBe(true);
+    expect(avatar.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("renders a signed-in viewer with no email claim without breaking", () => {
+    const node = container();
+    renderAccountMenu(node, scopeWith({ authenticated: true }));
+
+    expect(node.querySelector('[data-testid="account-avatar"]')?.textContent).toBe("●");
+    expect(node.querySelector('[data-testid="account-email"]')?.textContent).toBe("Signed in");
+    expect(node.querySelector('[data-testid="sign-out"]')?.getAttribute("href")).toBe(SIGN_OUT_PATH);
+  });
+
+  // The email originates remotely (an IdP claim relayed through a JWT). Every
+  // other view in this app pins the same property — see dom.ts's module doc.
+  it("renders the email as text, never as markup", () => {
+    const node = container();
+    renderAccountMenu(node, scopeWith({ authenticated: true, email: "<img src=x onerror=alert(1)>@e.com" }));
+
+    expect(node.querySelector("img")).toBeNull();
+    expect(node.querySelector('[data-testid="account-email"]')?.textContent).toContain("<img");
+  });
+
+  it("replaces prior contents rather than appending on re-render", () => {
+    const node = container();
+    renderAccountMenu(node, scopeWith(signedIn));
+    renderAccountMenu(node, scopeWith(signedIn));
+
+    expect(node.querySelectorAll('[data-testid="account-avatar"]')).toHaveLength(1);
+  });
+});
+
+describe("wireAccountMenu", () => {
+  it("renders into #account when the page has one", () => {
+    const host = container();
+    host.id = "account";
+    wireAccountMenu(document, scopeWith({ authenticated: true, email: "a.b@example.com" }));
+
+    expect(host.querySelector('[data-testid="account-avatar"]')?.textContent).toBe("AB");
+  });
+
+  it("is a no-op on a page with no #account container", () => {
+    expect(() => wireAccountMenu(document, scopeWith({ authenticated: false }))).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #4852.

## The gap

Under the single-URL layout (#4795) `/` serves the SPA to everyone. **The SPA had no sign-in affordance at all** — an anonymous visitor's only route to an authenticated session was knowing to type `/login` by hand.

The server-rendered fallback (`src/publicPage.ts`) has always had a Sign in link, but it renders only when no UI build is uploaded, so the affordance disappeared the moment the SPA became what `/` served. Meanwhile `hostDetail.ts` and `analytics/render.ts` both tell the viewer to "Sign in for the full breakdown" — advice with nothing to click.

Found while verifying the live 2AM deployment. **This blocks the Cloudflare Access cutover**: deleting the hostname-wide app is what makes `/` public, and after that there would be no way to sign in from the UI.

## What this adds

The standard app-shell control rather than a bare link:

| Viewer | Topbar shows |
|---|---|
| Anonymous | **Sign in** button → `/login` (the Access app that mints the cookie) |
| Signed in | Avatar with initials → menu with the operator's email and **Sign out** |

The identity was already available and being thrown away — `validateAccessJwt` returns `AccessIdentity { email?, sub? }` from the verified token, and `handleRoot` used only "is it non-null". It now injects the email alongside the flag.

**Sign-out is Cloudflare's**, not ours: `/cdn-cgi/access/logout` clears the `CF_Authorization` cookie. The cookie *is* the session, so this app has no session of its own to tear down and deliberately implements no logout logic.

## Security: the injected payload is now escaped

The state stamped into the page moved from a boolean to an object carrying a string. A value containing the literal `</script>` would terminate the inline block early and everything after it would parse as markup.

The previous revision of this code carried an explicit note:

> `JSON.stringify` on a boolean cannot emit `<`/`&`, so no HTML-escaping pass is needed here; **keep it that way if this ever carries a string.**

This is that revisit. `<`, `>` and `&` are now emitted as `\uXXXX` escapes — valid inside a JSON string literal, decoding back to the original characters, so the rendered value is unchanged. The email comes from a signature-verified, Cloudflare-signed JWT, so this is defense in depth rather than the primary control; it costs nothing and removes the need to reason about how far an IdP claim can be trusted.

`cache-control: private, no-store` + `Vary: Cookie` were already on this response and now matter more — the body carries the viewer's own email, so a shared cache collapsing two viewers' responses would show one operator's identity to another.

## Fail-closed throughout

`readAuthState` treats every malformed shape — flag absent, `null`, a non-object, `authenticated: "yes"` — as anonymous, so a page that never received the injection shows Sign in rather than a phantom identity. Both variants are absent from the markup and rendered by script, so neither flashes the other on load, and a script failure leaves no control rather than a misleading one.

## Tests

**155 backend + 299 web** (was 152 + 275).

- The email reaches the SPA for a signed-in viewer, and never for an anonymous one
- A `</script>`-bearing email cannot break out of the injection
- Initials derivation, including the no-`email`-claim fallback
- Menu toggle, `aria-expanded`, and that the email renders as text not markup — the property every other view in this app already pins
- Every malformed injected-state shape renders Sign in

## Not in scope

Applying this pattern to the other 2amlogic.com properties (the `www-2amlogic-com` Pages site, `ap.2amlogic.com`) — separate repos, separate Access apps.