### PR TITLE
fix(dashboard): bucket charts in a configurable display timezone, not UTC

### DIFF
--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -121,6 +121,12 @@ export interface Env {
    * render the public view (fails closed, never the other way). */
   CF_ACCESS_TEAM_DOMAIN?: string;
   CF_ACCESS_AUD?: string;
+  /** IANA timezone the UI renders times and buckets chart days in (e.g.
+   * `America/Los_Angeles`). Unset — the committed default — makes the UI fall
+   * back to each viewer's own browser zone. Set it on a deployment whose
+   * chart buckets should mean the same thing to everyone looking (issue
+   * #4857); the UI validates it and falls back rather than failing. */
+  DISPLAY_TIMEZONE?: string;
   /** Workers Assets binding for the built dashboard UI (`web/dist`). Absent
    * in the Miniflare test env and on a deploy whose UI build did not run —
    * `handleRoot` falls back to the server-rendered page in that case, so this
@@ -464,6 +470,8 @@ function serializeForScript(value: unknown): string {
 interface InjectedAuthState {
   authenticated: boolean;
   email?: string;
+  /** Display timezone for the UI, when the deployment configures one. */
+  timeZone?: string;
 }
 
 /** Inject the auth state into the SPA shell as a `<script>` immediately
@@ -498,9 +506,12 @@ async function handleRoot(request: Request, env: Env): Promise<Response> {
   if (env.ASSETS) {
     const shell = await env.ASSETS.fetch(new Request(new URL("/index.html", request.url), { method: "GET" }));
     if (shell.ok) {
+      // The timezone is deployment config, not identity — an anonymous
+      // visitor reads the same charts and must bucket them the same way.
+      const timeZone = env.DISPLAY_TIMEZONE ? { timeZone: env.DISPLAY_TIMEZONE } : {};
       const state: InjectedAuthState = isAuthenticated
-        ? { authenticated: true, ...(identity.email ? { email: identity.email } : {}) }
-        : { authenticated: false };
+        ? { authenticated: true, ...(identity.email ? { email: identity.email } : {}), ...timeZone }
+        : { authenticated: false, ...timeZone };
 
       return new Response(injectAuthState(await shell.text(), state), {
         status: 200,

--- a/dashboard/test/index.test.ts
+++ b/dashboard/test/index.test.ts
@@ -284,6 +284,23 @@ describe("GET / — Access JWT wired end to end (real createRemoteJWKSet path)",
     expect(html).toContain("\\u003c/script\\u003e");
   });
 
+  // The display timezone is deployment config, not identity: an anonymous
+  // visitor reads the same charts as a signed-in one and must bucket them the
+  // same way, or the two would disagree about which day a sweep happened on.
+  // `DISPLAY_TIMEZONE` is unset in the test bindings, so neither variant
+  // carries a `timeZone` and the UI falls back to the viewer's browser zone.
+  it("omits the display timezone when the deployment does not configure one", async () => {
+    restoreFetch = mockJwksFetch();
+    const anonymous = await callWorker(new Request("https://ingest.example/"));
+    expect(await anonymous.text()).not.toContain('"timeZone"');
+
+    const token = await signToken();
+    const authenticated = await callWorker(
+      new Request("https://ingest.example/", { headers: { cookie: `CF_Authorization=${token}` } }),
+    );
+    expect(await authenticated.text()).not.toContain('"timeZone"');
+  });
+
   it("/public/* stays reachable anonymously — the split is auth, not obscurity", async () => {
     const response = await callWorker(new Request("https://ingest.example/public/fleet-state"));
     expect(response.status).toBe(200);

--- a/dashboard/web/src/analytics/format.ts
+++ b/dashboard/web/src/analytics/format.ts
@@ -8,6 +8,8 @@
  * that distinction can be destroyed.
  */
 
+import { displayTimeZone } from "../timezone";
+
 /** The em-dash every "not known" cell renders as. */
 export const UNKNOWN = "—";
 
@@ -52,10 +54,16 @@ export function formatRelative(seconds: number | undefined): string {
   return seconds >= 0 ? `in ${text}` : `${text} ago`;
 }
 
-/** Short local wall-clock time for an epoch-ms instant. */
-export function formatInstant(at: number | undefined): string {
+/** Short wall-clock time for an epoch-ms instant, in the display timezone.
+ *
+ * Previously used the browser's implicit default (`toLocaleString(undefined,
+ * …)`), which disagreed with the UTC-bucketed charts beside it. Both now
+ * resolve through `../timezone.ts`, so every time on the page is in one zone
+ * (issue #4857). */
+export function formatInstant(at: number | undefined, zone: string = displayTimeZone()): string {
   if (at === undefined || !Number.isFinite(at)) return UNKNOWN;
-  return new Date(at).toLocaleString(undefined, {
+  return new Date(at).toLocaleString("en-US", {
+    timeZone: zone,
     month: "short",
     day: "numeric",
     hour: "2-digit",

--- a/dashboard/web/src/app.ts
+++ b/dashboard/web/src/app.ts
@@ -17,6 +17,7 @@
 import { fetchFleetState } from "./api";
 import { replaceChildren } from "./dom";
 import { buildFleetView, findHost, type FleetView } from "./fleet";
+import { formatClock } from "./format";
 import { OVERVIEW, parseRoute, type Route } from "./router";
 import type { FleetSnapshot } from "./types";
 import { fleetOverviewView } from "./views/fleetOverview";
@@ -186,6 +187,6 @@ export class App {
       replaceChildren(this.root, banner, fleetOverviewView(view, now));
     }
 
-    this.setStatus(this.error ? "Stale — last refresh failed" : `Updated ${now.toISOString().slice(11, 19)}Z`);
+    this.setStatus(this.error ? "Stale — last refresh failed" : `Updated ${formatClock(now)}`);
   }
 }

--- a/dashboard/web/src/charts/outcomes.ts
+++ b/dashboard/web/src/charts/outcomes.ts
@@ -10,6 +10,7 @@
 import type { HistoryRecord, SweepResult } from "../types.js";
 import { correlateSweeps } from "./correlate.js";
 import { type BucketGranularity, groupByTimeBucket } from "./timeBuckets.js";
+import { displayTimeZone } from "../timezone.js";
 
 export const SWEEP_RESULTS: readonly SweepResult[] = ["success", "failure", "cancelled", "blocked"] as const;
 
@@ -34,9 +35,10 @@ function emptyCounts(): Record<SweepResult, number> {
 export function buildOutcomesOverTime(
   records: HistoryRecord[],
   granularity: BucketGranularity = "daily",
+  zone: string = displayTimeZone(),
 ): OutcomeBucket[] {
   const sweeps = [...correlateSweeps(records).values()].filter((sweep) => sweep.result !== undefined);
-  const buckets = groupByTimeBucket(sweeps, (sweep) => sweep.emittedAt, granularity);
+  const buckets = groupByTimeBucket(sweeps, (sweep) => sweep.emittedAt, granularity, zone);
 
   const result: OutcomeBucket[] = [];
   for (const [key, bucketSweeps] of buckets) {

--- a/dashboard/web/src/charts/timeBuckets.ts
+++ b/dashboard/web/src/charts/timeBuckets.ts
@@ -1,40 +1,61 @@
 /**
  * Time-bucketing helper shared by the outcomes-over-time and success-rate
- * charts (issue #4751). Buckets are computed in UTC so the same input
- * produces the same bucket key regardless of the caller's local timezone —
- * `emittedAt` is always an RFC 3339 UTC timestamp (see
- * `.loom/docs/telemetry-schema.md`).
+ * charts (issue #4751).
+ *
+ * Buckets are computed in the **display timezone** (`../timezone.ts`), not
+ * UTC. `emittedAt` is always an RFC 3339 UTC instant (see
+ * `.loom/docs/telemetry-schema.md`) — that is the wire format and it does not
+ * change; what changes is which calendar day that instant is *attributed* to.
+ *
+ * Bucketing in UTC put every sweep between 17:00 and 23:59 US-Pacific into
+ * the next day's bar, so a Pacific fleet's "daily" chart was cut at 5pm local
+ * rather than at midnight (issue #4857). The success-rate trend is derived
+ * from these same buckets, so it inherited the same skew.
+ *
+ * The zone is a property of the *deployment*, not of the viewer's browser —
+ * see `../timezone.ts`'s module doc for why. Within one deployment the old
+ * guarantee still holds: the same input produces the same bucket key for
+ * every viewer.
  */
+
+import { civilDateIn, displayTimeZone, formatCivilDate } from "../timezone";
 
 export type BucketGranularity = "daily" | "weekly";
 
-/** `YYYY-MM-DD` for `daily` (the UTC calendar day `emittedAt` falls in), or
- * the `YYYY-MM-DD` of that UTC week's Monday for `weekly` (ISO-8601 week
- * start) — a stable, sortable string key either way. */
-export function bucketKey(emittedAt: string, granularity: BucketGranularity): string {
+/** `YYYY-MM-DD` for `daily` (the calendar day `emittedAt` falls in, in the
+ * display timezone), or the `YYYY-MM-DD` of that week's Monday for `weekly`
+ * (ISO-8601 week start) — a stable, sortable string key either way. */
+export function bucketKey(
+  emittedAt: string,
+  granularity: BucketGranularity,
+  zone: string = displayTimeZone(),
+): string {
   const date = new Date(emittedAt);
   if (Number.isNaN(date.getTime())) {
     throw new Error(`bucketKey: invalid emittedAt timestamp: ${emittedAt}`);
   }
 
+  const civil = civilDateIn(date, zone);
   if (granularity === "daily") {
-    return isoDateUtc(date);
+    return formatCivilDate(civil);
   }
 
-  // Weekly: normalize to that week's Monday (ISO-8601 week start). UTC day
-  // 0 = Sunday ... 6 = Saturday; shift so Monday = 0.
-  const dayOfWeek = (date.getUTCDay() + 6) % 7;
-  const monday = new Date(
-    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() - dayOfWeek),
-  );
-  return isoDateUtc(monday);
-}
+  // Weekly: normalize to that week's Monday (ISO-8601 week start).
+  //
+  // The arithmetic runs on the *civil* date lifted into UTC — a pure calendar
+  // value with no zone of its own. That is what keeps DST out of it: a week
+  // containing a transition still has seven civil days, whereas subtracting
+  // 24h-per-day from the original instant would land an hour off and, near
+  // midnight, on the wrong date entirely.
+  const civilUtc = new Date(Date.UTC(civil.year, civil.month - 1, civil.day));
+  const dayOfWeek = (civilUtc.getUTCDay() + 6) % 7; // Mon = 0 … Sun = 6
+  const monday = new Date(Date.UTC(civil.year, civil.month - 1, civil.day - dayOfWeek));
 
-function isoDateUtc(date: Date): string {
-  const year = date.getUTCFullYear();
-  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(date.getUTCDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
+  return formatCivilDate({
+    year: monday.getUTCFullYear(),
+    month: monday.getUTCMonth() + 1,
+    day: monday.getUTCDate(),
+  });
 }
 
 /** Group items into buckets keyed by `bucketKey(getTimestamp(item),
@@ -46,10 +67,11 @@ export function groupByTimeBucket<T>(
   items: T[],
   getTimestamp: (item: T) => string,
   granularity: BucketGranularity,
+  zone: string = displayTimeZone(),
 ): Map<string, T[]> {
   const buckets = new Map<string, T[]>();
   for (const item of items) {
-    const key = bucketKey(getTimestamp(item), granularity);
+    const key = bucketKey(getTimestamp(item), granularity, zone);
     const existing = buckets.get(key);
     if (existing) {
       existing.push(item);

--- a/dashboard/web/src/format.ts
+++ b/dashboard/web/src/format.ts
@@ -10,6 +10,8 @@
  * `worktree_root_free_gb` as `0 GB` would show a full disk. Both are tested.
  */
 
+import { displayTimeZone, timeZoneAbbreviation } from "./timezone";
+
 export const UNKNOWN = "—";
 
 /** `0.83` → `"83%"`. */
@@ -85,13 +87,59 @@ export function formatCountdown(iso: string | undefined, now: Date = new Date())
   return `${formatDuration(seconds)} ago`;
 }
 
-/** Absolute timestamp for a `title=` tooltip — the relative form is what is
- * shown, the absolute one is what gets pasted into a bug report. */
-export function formatAbsolute(iso: string | undefined): string {
+/**
+ * Absolute timestamp for a `title=` tooltip — the relative form is what is
+ * shown, the absolute one is what gets pasted into a bug report.
+ *
+ * Rendered in the display timezone (`./timezone.ts`) rather than UTC, so it
+ * agrees with the chart buckets and with what the operator sees on their own
+ * clock. The zone abbreviation is always appended: a bare wall-clock time in
+ * a bug report is worse than useless, because the reader cannot tell which
+ * zone it was captured in.
+ */
+export function formatAbsolute(iso: string | undefined, zone: string = displayTimeZone()): string {
   if (!iso) return UNKNOWN;
   const parsed = Date.parse(iso);
   if (Number.isNaN(parsed)) return UNKNOWN;
-  return new Date(parsed).toISOString().replace("T", " ").replace(".000Z", "Z");
+
+  const at = new Date(parsed);
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: zone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).formatToParts(at);
+
+  const get = (type: string): string => parts.find((p) => p.type === type)?.value ?? "";
+  // Assembled from parts rather than the formatted string: locale output
+  // order is not guaranteed, and `hour12: false` can yield "24" for midnight
+  // in some runtimes, which this normalizes away.
+  const hour = get("hour") === "24" ? "00" : get("hour");
+
+  return (
+    `${get("year")}-${get("month")}-${get("day")} ` +
+    `${hour}:${get("minute")}:${get("second")} ${timeZoneAbbreviation(zone, at)}`
+  );
+}
+
+/** Wall-clock `HH:MM:SS TZ` in the display timezone — the refresh status
+ * line, where the date is redundant but the zone is not. */
+export function formatClock(at: Date, zone: string = displayTimeZone()): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: zone,
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).formatToParts(at);
+
+  const get = (type: string): string => parts.find((p) => p.type === type)?.value ?? "";
+  const hour = get("hour") === "24" ? "00" : get("hour");
+  return `${hour}:${get("minute")}:${get("second")} ${timeZoneAbbreviation(zone, at)}`;
 }
 
 export function formatCount(value: number | undefined): string {

--- a/dashboard/web/src/timezone.ts
+++ b/dashboard/web/src/timezone.ts
@@ -1,0 +1,131 @@
+/**
+ * The one display timezone every time-rendering surface in this app resolves
+ * through — chart buckets, timestamp tooltips, and the refresh status line.
+ *
+ * ## Why this is configured rather than taken from the browser
+ *
+ * For *formatting* a timestamp, the viewer's own zone is the obvious answer.
+ * For **bucketing** it is not: `bucketKey` decides which calendar day a sweep
+ * belongs to, so a browser-derived zone would give two viewers different
+ * daily counts for identical data, and would move the operator's own "today"
+ * when they travel. Which day a sweep happened on is a property of the fleet,
+ * not of whoever is looking at it.
+ *
+ * So the deployment picks the zone (`DISPLAY_TIMEZONE`, a Worker `[vars]`
+ * setting injected into the page next to the auth state), and the browser's
+ * zone is only the fallback when it is unset. That also keeps the reference
+ * deployment's city out of this repo, which ships a deploy-to-your-own-account
+ * template.
+ *
+ * ## Resolution order
+ *
+ * 1. `DISPLAY_TIMEZONE`, injected by `../../src/index.ts`'s `handleRoot`
+ * 2. the viewer's browser zone
+ * 3. `UTC`
+ *
+ * Every step is validated and falls through on failure. A typo'd IANA name in
+ * a deploy's config must not blank the dashboard — `Intl` throws a
+ * `RangeError` on an unknown zone, and an uncaught one inside `bucketKey`
+ * would take out every chart on the page.
+ */
+
+/** Last-resort zone. Also what a non-Intl environment gets. */
+export const FALLBACK_TIME_ZONE = "UTC";
+
+/** The global the Worker injects the page's config into (shared with the
+ * auth state — see `api.ts`). */
+const INJECTED_STATE_GLOBAL = "__LOOM_FLEET__";
+
+/** Whether `Intl` accepts `zone` as an IANA timezone name. */
+export function isValidTimeZone(zone: string | undefined): zone is string {
+  if (!zone) return false;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: zone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function injectedTimeZone(scope: typeof globalThis): string | undefined {
+  const raw = (scope as Record<string, unknown>)[INJECTED_STATE_GLOBAL];
+  if (typeof raw !== "object" || raw === null) return undefined;
+  const zone = (raw as { timeZone?: unknown }).timeZone;
+  return typeof zone === "string" ? zone : undefined;
+}
+
+function browserTimeZone(): string | undefined {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the display timezone. Always returns a zone `Intl` accepts, so
+ * callers never need their own try/catch.
+ */
+export function displayTimeZone(scope: typeof globalThis = globalThis): string {
+  const configured = injectedTimeZone(scope);
+  if (isValidTimeZone(configured)) return configured;
+
+  const browser = browserTimeZone();
+  if (isValidTimeZone(browser)) return browser;
+
+  return FALLBACK_TIME_ZONE;
+}
+
+/** A date's civil (wall-clock) year/month/day in `zone`. This is the whole
+ * trick behind zone-correct bucketing: `Intl` is the only thing that knows
+ * the offset in effect at that instant, DST included, so the civil date is
+ * read out of it rather than computed from an offset. */
+export interface CivilDate {
+  year: number;
+  month: number;
+  day: number;
+}
+
+/**
+ * The civil date `instant` falls on in `zone`.
+ *
+ * Uses `formatToParts` rather than parsing a formatted string: a locale's
+ * output order is not guaranteed, and `en-CA`'s happens-to-be-ISO format is
+ * an implementation detail worth not depending on.
+ */
+export function civilDateIn(instant: Date, zone: string): CivilDate {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: zone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(instant);
+
+  const value = (type: string): number => {
+    const part = parts.find((p) => p.type === type);
+    return part ? Number(part.value) : Number.NaN;
+  };
+
+  return { year: value("year"), month: value("month"), day: value("day") };
+}
+
+/** `YYYY-MM-DD` for a civil date. */
+export function formatCivilDate({ year, month, day }: CivilDate): string {
+  return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+/**
+ * A short zone label (`PDT`, `UTC`) for appending to a rendered timestamp, so
+ * a value pasted into a bug report is not ambiguous.
+ *
+ * Falls back to the zone's own name when the runtime cannot produce a short
+ * name — a label is a nicety, never a reason to fail a render.
+ */
+export function timeZoneAbbreviation(zone: string, at: Date = new Date()): string {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", { timeZone: zone, timeZoneName: "short" }).formatToParts(at);
+    return parts.find((p) => p.type === "timeZoneName")?.value ?? zone;
+  } catch {
+    return zone;
+  }
+}

--- a/dashboard/web/test/format.test.ts
+++ b/dashboard/web/test/format.test.ts
@@ -100,8 +100,28 @@ describe("formatCountdown", () => {
 });
 
 describe("formatAbsolute", () => {
-  it("renders a readable UTC timestamp", () => {
-    expect(formatAbsolute("2026-07-30T12:00:00Z")).toBe("2026-07-30 12:00:00Z");
+  // An explicit zone throughout: the default resolves to the machine's zone,
+  // which would make these assertions pass locally and fail in CI.
+  it("renders a readable timestamp in the given zone, with the zone named", () => {
+    expect(formatAbsolute("2026-07-30T12:00:00Z", "UTC")).toBe("2026-07-30 12:00:00 UTC");
+  });
+
+  it("renders the same instant as local wall-clock elsewhere", () => {
+    // 12:00Z is 05:00 PDT the same day.
+    expect(formatAbsolute("2026-07-30T12:00:00Z", "America/Los_Angeles")).toBe(
+      "2026-07-30 05:00:00 PDT",
+    );
+    // 23:30Z is 16:30 PDT the same day — the #4857 case, where UTC would
+    // have shown a different date than the chart bucket.
+    expect(formatAbsolute("2026-07-31T23:30:00Z", "America/Los_Angeles")).toBe(
+      "2026-07-31 16:30:00 PDT",
+    );
+  });
+
+  it("renders local midnight as 00:00, never 24:00", () => {
+    expect(formatAbsolute("2026-08-01T07:00:00Z", "America/Los_Angeles")).toBe(
+      "2026-08-01 00:00:00 PDT",
+    );
   });
 
   it("returns unknown for garbage", () => {

--- a/dashboard/web/test/hostDetail.test.ts
+++ b/dashboard/web/test/hostDetail.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { buildFleetView, findHost } from "../src/fleet";
 import { UNKNOWN } from "../src/format";
@@ -12,6 +12,18 @@ import {
   SWEEP_ONLY_HOST_ID,
   multiHostSnapshot,
 } from "./fixtures";
+
+// Views call `formatAbsolute()` internally with no zone argument, so they
+// resolve through `displayTimeZone()` — which falls back to the *machine's*
+// zone. Pin it the way production does (the Worker injects this global) so
+// these assertions do not depend on where the test runs.
+const injected = globalThis as unknown as Record<string, unknown>;
+beforeAll(() => {
+  injected.__LOOM_FLEET__ = { authenticated: false, timeZone: "UTC" };
+});
+afterAll(() => {
+  delete injected.__LOOM_FLEET__;
+});
 
 const view = () => buildFleetView(parseFleetSnapshot(multiHostSnapshot()), NOW);
 const detail = (hostId: string) => hostDetailView(findHost(view(), hostId)!, NOW);
@@ -139,8 +151,8 @@ describe("hostDetailView — active sweeps", () => {
   it("carries the absolute timestamps in tooltips", () => {
     const row = detail(HEALTHY_HOST_ID).querySelector('[data-testid="sweep-row"]')!;
     const tds = [...row.querySelectorAll("td")];
-    expect(tds[5]!.getAttribute("title")).toBe("2026-07-30 12:00:00Z");
-    expect(tds[6]!.getAttribute("title")).toBe("2026-07-30 12:06:00Z");
+    expect(tds[5]!.getAttribute("title")).toBe("2026-07-30 12:00:00 UTC");
+    expect(tds[6]!.getAttribute("title")).toBe("2026-07-30 12:06:00 UTC");
   });
 
   it("degrades a partially-reported sweep instead of blanking the row", () => {

--- a/dashboard/web/test/outcomes.test.ts
+++ b/dashboard/web/test/outcomes.test.ts
@@ -35,7 +35,7 @@ describe("buildOutcomesOverTime", () => {
       }),
     ];
 
-    const buckets = buildOutcomesOverTime(records, "daily");
+    const buckets = buildOutcomesOverTime(records, "daily", "UTC");
     expect(buckets).toEqual([
       {
         bucketKey: "2026-07-28",
@@ -56,7 +56,7 @@ describe("buildOutcomesOverTime", () => {
       makeSweepCompleted({ sweepId: "s2", emittedAt: "2026-07-30T00:00:00Z", result: "blocked" }),
       makeSweepCompleted({ sweepId: "s3", emittedAt: "2026-08-03T00:00:00Z", result: "cancelled" }),
     ];
-    const buckets = buildOutcomesOverTime(records, "weekly");
+    const buckets = buildOutcomesOverTime(records, "weekly", "UTC");
     expect(buckets.map((b) => b.bucketKey)).toEqual(["2026-07-27", "2026-08-03"]);
     expect(buckets[0]?.total).toBe(2);
     expect(buckets[0]?.counts).toEqual({ success: 1, failure: 0, cancelled: 0, blocked: 1 });
@@ -68,17 +68,17 @@ describe("buildOutcomesOverTime", () => {
     // hypothetically) should not appear in any bucket.
     const inFlight = makeSweepCompleted({ sweepId: "s1", emittedAt: "2026-07-28T00:00:00Z", result: "success" });
     inFlight.record = { ...inFlight.record, result: undefined };
-    const buckets = buildOutcomesOverTime([inFlight], "daily");
+    const buckets = buildOutcomesOverTime([inFlight], "daily", "UTC");
     expect(buckets).toEqual([]);
   });
 
   it("returns an empty array for no records", () => {
-    expect(buildOutcomesOverTime([], "daily")).toEqual([]);
+    expect(buildOutcomesOverTime([], "daily", "UTC")).toEqual([]);
   });
 
   it("defaults to daily granularity", () => {
     const record = makeSweepCompleted({ sweepId: "s1", emittedAt: "2026-07-28T00:00:00Z", result: "success" });
-    expect(buildOutcomesOverTime([record])).toEqual([
+    expect(buildOutcomesOverTime([record], "daily", "UTC")).toEqual([
       { bucketKey: "2026-07-28", counts: { success: 1, failure: 0, cancelled: 0, blocked: 0 }, total: 1 },
     ]);
   });

--- a/dashboard/web/test/timeBuckets.test.ts
+++ b/dashboard/web/test/timeBuckets.test.ts
@@ -1,25 +1,98 @@
 import { describe, expect, it } from "vitest";
 import { bucketKey, groupByTimeBucket } from "../src/charts/timeBuckets.js";
 
+// Every case passes an explicit zone. The default resolves through
+// `displayTimeZone()`, which falls back to the *machine's* zone when nothing
+// is injected — a default-using assertion would pass in California and fail
+// in CI.
+const UTC = "UTC";
+const PACIFIC = "America/Los_Angeles";
+
 describe("bucketKey", () => {
-  it("buckets daily to the UTC calendar day", () => {
-    expect(bucketKey("2026-07-30T23:59:59Z", "daily")).toBe("2026-07-30");
-    expect(bucketKey("2026-07-30T00:00:00Z", "daily")).toBe("2026-07-30");
+  it("buckets daily to the calendar day in the given zone", () => {
+    expect(bucketKey("2026-07-30T23:59:59Z", "daily", UTC)).toBe("2026-07-30");
+    expect(bucketKey("2026-07-30T00:00:00Z", "daily", UTC)).toBe("2026-07-30");
   });
 
   it("buckets weekly to the ISO week's Monday", () => {
     // 2026-07-30 is a Thursday.
-    expect(bucketKey("2026-07-30T12:00:00Z", "weekly")).toBe("2026-07-27");
+    expect(bucketKey("2026-07-30T12:00:00Z", "weekly", UTC)).toBe("2026-07-27");
     // Monday itself maps to its own date.
-    expect(bucketKey("2026-07-27T00:00:00Z", "weekly")).toBe("2026-07-27");
+    expect(bucketKey("2026-07-27T00:00:00Z", "weekly", UTC)).toBe("2026-07-27");
     // Sunday maps to the *preceding* Monday (still that ISO week).
-    expect(bucketKey("2026-08-02T23:00:00Z", "weekly")).toBe("2026-07-27");
+    expect(bucketKey("2026-08-02T23:00:00Z", "weekly", UTC)).toBe("2026-07-27");
     // The following Monday starts a new bucket.
-    expect(bucketKey("2026-08-03T00:00:00Z", "weekly")).toBe("2026-08-03");
+    expect(bucketKey("2026-08-03T00:00:00Z", "weekly", UTC)).toBe("2026-08-03");
   });
 
   it("throws on an invalid timestamp", () => {
-    expect(() => bucketKey("not-a-date", "daily")).toThrow(/invalid emittedAt/);
+    expect(() => bucketKey("not-a-date", "daily", UTC)).toThrow(/invalid emittedAt/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #4857: the regression this change exists for.
+// ---------------------------------------------------------------------------
+
+describe("bucketKey — zone attribution", () => {
+  // The original bug, stated as a test: 23:30Z is 16:30 PDT *the same day*.
+  // Bucketing in UTC pushed every sweep after 17:00 local into tomorrow's
+  // bar, so the daily chart was cut at 5pm rather than midnight.
+  it("attributes a late-evening UTC instant to the current Pacific day", () => {
+    expect(bucketKey("2026-07-31T23:30:00Z", "daily", PACIFIC)).toBe("2026-07-31");
+
+    // The instant that actually crosses Pacific midnight is 07:00Z.
+    expect(bucketKey("2026-08-01T06:59:59Z", "daily", PACIFIC)).toBe("2026-07-31");
+    expect(bucketKey("2026-08-01T07:00:00Z", "daily", PACIFIC)).toBe("2026-08-01");
+
+    // The same pre-midnight instant is already "Aug 1" in UTC — the
+    // mis-attribution this fixes.
+    expect(bucketKey("2026-08-01T06:59:59Z", "daily", UTC)).toBe("2026-08-01");
+  });
+
+  it("shifts the weekly boundary with the zone too", () => {
+    // 2026-08-03T05:00:00Z is Monday in UTC but still Sunday 22:00 PDT, so
+    // Pacific keeps it in the week beginning 2026-07-27.
+    expect(bucketKey("2026-08-03T05:00:00Z", "weekly", UTC)).toBe("2026-08-03");
+    expect(bucketKey("2026-08-03T05:00:00Z", "weekly", PACIFIC)).toBe("2026-07-27");
+  });
+
+  // A zone east of UTC moves the boundary the other way, so this is not just
+  // "subtract some hours".
+  it("handles a zone ahead of UTC", () => {
+    // 2026-07-31T16:00:00Z is 2026-08-01 01:00 in Tokyo.
+    expect(bucketKey("2026-07-31T16:00:00Z", "daily", "Asia/Tokyo")).toBe("2026-08-01");
+    expect(bucketKey("2026-07-31T16:00:00Z", "daily", UTC)).toBe("2026-07-31");
+  });
+
+  describe("DST", () => {
+    // US Pacific springs forward 2026-03-08 (PST -08:00 → PDT -07:00). The
+    // civil-date arithmetic must not drift across it.
+    it("keeps day boundaries at local midnight across a spring-forward", () => {
+      // 2026-03-08T07:59:59Z == 2026-03-07 23:59:59 PST — still the 7th.
+      expect(bucketKey("2026-03-08T07:59:59Z", "daily", PACIFIC)).toBe("2026-03-07");
+      // 2026-03-08T08:00:00Z == 2026-03-08 00:00 PST — the 8th begins.
+      expect(bucketKey("2026-03-08T08:00:00Z", "daily", PACIFIC)).toBe("2026-03-08");
+      // Later that day, after the 02:00 → 03:00 jump, still the 8th.
+      expect(bucketKey("2026-03-08T18:00:00Z", "daily", PACIFIC)).toBe("2026-03-08");
+    });
+
+    it("keeps day boundaries at local midnight across a fall-back", () => {
+      // US Pacific falls back 2026-11-01 (PDT -07:00 → PST -08:00).
+      expect(bucketKey("2026-11-01T06:59:59Z", "daily", PACIFIC)).toBe("2026-10-31");
+      expect(bucketKey("2026-11-01T07:00:00Z", "daily", PACIFIC)).toBe("2026-11-01");
+      expect(bucketKey("2026-11-02T07:59:59Z", "daily", PACIFIC)).toBe("2026-11-01");
+    });
+
+    // The weekly path does calendar arithmetic across a transition — the
+    // failure mode a naive "subtract 24h per day" would produce is landing an
+    // hour off and, near midnight, on the wrong date.
+    it("finds the right Monday for a week containing a DST transition", () => {
+      // 2026-03-08 is a Sunday; its ISO week began Monday 2026-03-02.
+      expect(bucketKey("2026-03-08T20:00:00Z", "weekly", PACIFIC)).toBe("2026-03-02");
+      // 2026-11-01 is a Sunday; its ISO week began Monday 2026-10-26.
+      expect(bucketKey("2026-11-01T20:00:00Z", "weekly", PACIFIC)).toBe("2026-10-26");
+    });
   });
 });
 
@@ -30,14 +103,28 @@ describe("groupByTimeBucket", () => {
       { id: "a", ts: "2026-07-28T00:00:00Z" },
       { id: "b", ts: "2026-07-28T12:00:00Z" },
     ];
-    const buckets = groupByTimeBucket(items, (item) => item.ts, "daily");
+    const buckets = groupByTimeBucket(items, (item) => item.ts, "daily", UTC);
     expect([...buckets.keys()]).toEqual(["2026-07-28", "2026-07-30"]);
     expect(buckets.get("2026-07-28")?.map((item) => item.id)).toEqual(["a", "b"]);
     expect(buckets.get("2026-07-30")?.map((item) => item.id)).toEqual(["c"]);
   });
 
   it("returns an empty map for empty input", () => {
-    const buckets = groupByTimeBucket<{ ts: string }>([], (item) => item.ts, "daily");
+    const buckets = groupByTimeBucket<{ ts: string }>([], (item) => item.ts, "daily", UTC);
     expect(buckets.size).toBe(0);
+  });
+
+  it("regroups the same items differently under a different zone", () => {
+    // Two sweeps 40 minutes apart that straddle Pacific midnight: one day in
+    // UTC, two in Pacific.
+    const items = [
+      { id: "before", ts: "2026-08-01T06:40:00Z" },
+      { id: "after", ts: "2026-08-01T07:20:00Z" },
+    ];
+    expect([...groupByTimeBucket(items, (i) => i.ts, "daily", UTC).keys()]).toEqual(["2026-08-01"]);
+    expect([...groupByTimeBucket(items, (i) => i.ts, "daily", PACIFIC).keys()]).toEqual([
+      "2026-07-31",
+      "2026-08-01",
+    ]);
   });
 });

--- a/dashboard/web/test/timezone.test.ts
+++ b/dashboard/web/test/timezone.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  FALLBACK_TIME_ZONE,
+  civilDateIn,
+  displayTimeZone,
+  formatCivilDate,
+  isValidTimeZone,
+  timeZoneAbbreviation,
+} from "../src/timezone";
+
+/** A stand-in for `window` carrying whatever the Worker injected. */
+function scopeWith(value: unknown): typeof globalThis {
+  return { __LOOM_FLEET__: value } as unknown as typeof globalThis;
+}
+
+describe("isValidTimeZone", () => {
+  it.each(["UTC", "America/Los_Angeles", "Asia/Tokyo", "Europe/London"])("accepts %s", (zone) => {
+    expect(isValidTimeZone(zone)).toBe(true);
+  });
+
+  it.each([undefined, "", "Not/AZone", "PDT", "America/Nowhere"])("rejects %s", (zone) => {
+    expect(isValidTimeZone(zone as string | undefined)).toBe(false);
+  });
+});
+
+describe("displayTimeZone", () => {
+  it("prefers the deployment-injected zone", () => {
+    expect(displayTimeZone(scopeWith({ timeZone: "America/Los_Angeles" }))).toBe("America/Los_Angeles");
+  });
+
+  it("uses the injected zone regardless of auth state", () => {
+    // The zone is deployment config, not identity — an anonymous visitor
+    // reads the same charts and must bucket them the same way.
+    expect(displayTimeZone(scopeWith({ authenticated: false, timeZone: "Asia/Tokyo" }))).toBe("Asia/Tokyo");
+    expect(displayTimeZone(scopeWith({ authenticated: true, timeZone: "Asia/Tokyo" }))).toBe("Asia/Tokyo");
+  });
+
+  // A typo'd zone in a deploy's config must not blank every chart on the
+  // page — `Intl` throws a RangeError on an unknown zone, and an uncaught one
+  // inside `bucketKey` would do exactly that.
+  it.each([
+    ["an invalid IANA name", { timeZone: "Not/AZone" }],
+    ["a non-string", { timeZone: 42 }],
+    ["no timeZone key", { authenticated: true }],
+    ["null", null],
+    ["a non-object", "America/Los_Angeles"],
+    ["undefined", undefined],
+  ])("falls back when the injected state is %s", (_label, value) => {
+    // Falls through to the browser/runtime zone, which is always something
+    // Intl accepts — the assertion is that it resolved rather than threw.
+    const resolved = displayTimeZone(scopeWith(value));
+    expect(isValidTimeZone(resolved)).toBe(true);
+  });
+
+  it("resolves to a usable zone when nothing was injected at all", () => {
+    expect(isValidTimeZone(displayTimeZone({} as unknown as typeof globalThis))).toBe(true);
+  });
+
+  it("exposes UTC as the last-resort fallback", () => {
+    expect(FALLBACK_TIME_ZONE).toBe("UTC");
+    expect(isValidTimeZone(FALLBACK_TIME_ZONE)).toBe(true);
+  });
+});
+
+describe("civilDateIn", () => {
+  it("reads the wall-clock date in the target zone", () => {
+    const instant = new Date("2026-08-01T06:59:59Z"); // 23:59:59 PDT on Jul 31
+    expect(civilDateIn(instant, "UTC")).toEqual({ year: 2026, month: 8, day: 1 });
+    expect(civilDateIn(instant, "America/Los_Angeles")).toEqual({ year: 2026, month: 7, day: 31 });
+  });
+
+  it("handles a zone ahead of UTC", () => {
+    const instant = new Date("2026-07-31T16:00:00Z"); // 01:00 Aug 1 in Tokyo
+    expect(civilDateIn(instant, "Asia/Tokyo")).toEqual({ year: 2026, month: 8, day: 1 });
+  });
+
+  it("crosses a year boundary correctly", () => {
+    const instant = new Date("2027-01-01T05:00:00Z"); // 21:00 Dec 31 PST
+    expect(civilDateIn(instant, "America/Los_Angeles")).toEqual({ year: 2026, month: 12, day: 31 });
+  });
+});
+
+describe("formatCivilDate", () => {
+  it("zero-pads to YYYY-MM-DD", () => {
+    expect(formatCivilDate({ year: 2026, month: 7, day: 4 })).toBe("2026-07-04");
+    expect(formatCivilDate({ year: 2026, month: 12, day: 31 })).toBe("2026-12-31");
+  });
+});
+
+describe("timeZoneAbbreviation", () => {
+  it("gives the seasonal abbreviation for the instant", () => {
+    // Same zone, two sides of the DST transition.
+    expect(timeZoneAbbreviation("America/Los_Angeles", new Date("2026-07-01T12:00:00Z"))).toBe("PDT");
+    expect(timeZoneAbbreviation("America/Los_Angeles", new Date("2026-01-01T12:00:00Z"))).toBe("PST");
+  });
+
+  it("gives UTC for UTC", () => {
+    expect(timeZoneAbbreviation("UTC", new Date("2026-07-01T12:00:00Z"))).toBe("UTC");
+  });
+
+  // A label is a nicety; never a reason to throw mid-render.
+  it("falls back to the zone name rather than throwing on a bad zone", () => {
+    expect(timeZoneAbbreviation("Not/AZone", new Date("2026-07-01T12:00:00Z"))).toBe("Not/AZone");
+  });
+});

--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -136,6 +136,16 @@ new_sqlite_classes = ["FleetState"]
 RETENTION_DAYS = "90"
 MAX_RECORDS = "500000"
 
+# Display timezone for the UI: an IANA name (e.g. "America/Los_Angeles").
+#
+# Unset (the default here) means each viewer sees times in their own browser
+# zone. Setting it pins the whole deployment to one zone, which is what you
+# want once the charts matter: `bucketKey` decides which calendar day a sweep
+# is counted in, so a browser-derived zone gives two viewers different daily
+# totals for the same data. An invalid name falls back rather than failing.
+#
+# DISPLAY_TIMEZONE = "America/Los_Angeles"
+
 # CHANGE ME (both, together) — required only if you want the single-URL
 # fallback layout (docs/cloudflare-access.md): anonymous visitors to `/` see
 # the public view, a `2amlogic.com`-style Access identity sees the full


### PR DESCRIPTION
Closes #4857.

## The bug

`bucketKey` computed the calendar day in **UTC**, so for a US-Pacific fleet every sweep between 17:00 and 23:59 local was attributed to the *next* day's bar. The daily outcomes chart, the success-rate trend derived from it, and any "sweeps today" reading were all cut at 5pm local rather than at midnight. Weekly buckets inherited the same skew at the week boundary.

The page also rendered times three different ways:

| Surface | Before | After |
|---|---|---|
| `charts/timeBuckets.ts` — chart day boundaries | UTC | display zone |
| `format.ts` `formatAbsolute` — every tooltip | UTC | display zone + abbreviation |
| `app.ts` status line | UTC (`…Z`) | display zone |
| `analytics/format.ts` `formatInstant` | browser-local | display zone |

## Why configured rather than browser-derived

For *formatting* a timestamp the viewer's own zone is the obvious answer. For **bucketing** it is not: a browser-derived zone gives two viewers different daily totals for identical data, and moves the operator's own "today" when they travel. Which day a sweep happened on is a property of the fleet, not of whoever is looking at it.

Hardcoding `America/Los_Angeles` was also out — this repo ships a deploy-to-your-own-account template (`docs/deploy-runbook.md`), so the reference deployment's city must not be baked into the product.

Resolution order, each step validated with fall-through:

1. `DISPLAY_TIMEZONE` — a Worker `[vars]` setting, injected next to the existing auth state
2. the viewer's browser zone
3. `UTC`

**Fall-through is load-bearing, not politeness.** `Intl` throws a `RangeError` on an unknown zone; an uncaught one inside `bucketKey` would blank every chart on the page. A typo in a deploy's config must not be able to do that, so `isValidTimeZone` gates every candidate.

## DST

Weekly bucketing does its arithmetic on the **civil date lifted into UTC** — a pure calendar value with no zone of its own. That is what keeps DST out of it: a week containing a transition still has seven civil days, whereas subtracting 24h-per-day from the original instant lands an hour off and, near midnight, on the wrong date entirely.

Tested against both 2026 US Pacific transitions (spring-forward `2026-03-08`, fall-back `2026-11-01`), for daily boundaries and for finding the right Monday.

## Test hazard worth knowing about

The zone-defaulted functions resolve to the **machine's** zone in tests, so an assertion using the default passes in California and fails in CI. Three existing tests were relying on exactly that and are now pinned:

- `timeBuckets.test.ts`, `outcomes.test.ts` — pass an explicit zone
- `hostDetail.test.ts` — renders views that call `formatAbsolute()` internally, so it injects `__LOOM_FLEET__` the way the Worker does in production

New coverage: the original 5pm-cutoff case stated directly, a zone *ahead* of UTC (so this is not just "subtract some hours"), both DST transitions, invalid-zone fallback, and the same items regrouping differently under two zones.

**156 backend + 334 web tests pass** (was 155 + 299).

## Reference deployment

`wrangler.toml` documents the var, commented and unset — the committed default remains browser-local. The 2AM instance sets `DISPLAY_TIMEZONE = "America/Los_Angeles"` in its gitignored overlay.