### PR TITLE
docs: add .loom/docs/observability.md as the fleet-observability end-to-end reference

### DIFF
--- a/.loom/docs/observability.md
+++ b/.loom/docs/observability.md
@@ -1,0 +1,157 @@
+# Fleet Observability: end-to-end reference
+
+> Epic [#4702](https://github.com/rjwalters/loom/issues/4702), Phase 4
+> (#4860). This is the single entry point tying the whole pipeline together —
+> **daemon config → wire schema → exporter → Cloudflare backend → dashboard
+> views** — matching the map-plus-links pattern `daemon-reference.md` and
+> `token-pool.md` already use. It is an operating summary, not a duplicate:
+> every claim below has a canonical detail doc linked next to it, and this
+> page should stay a map even as those detail docs grow.
+
+## The pipeline, in one picture
+
+```
+loom-daemon (per host)
+  observability.* config block (opt-in, off by default)
+        │  collector: EventBus subscriber -> TelemetryEnvelope
+        ▼
+  durable disk-backed queue (survives sink outage / sleep)
+        │  drains via a jittered-retry loop
+        ▼
+  exporter: HttpsExporter (JSON-over-HTTPS POST /ingest)   [OTLP: planned, #4858]
+        │
+        ▼
+Cloudflare Worker backend (deploy-your-own, or the 2AM reference instance)
+  D1 (durable history) + Durable Object (live "what's running now")
+        │
+        ├── /api/*     authenticated, full detail   (Cloudflare Access)
+        └── /public/*  unauthenticated, redacted     (always reachable)
+        │
+        ▼
+Dashboard UI (served by the same Worker) — authenticated + public views
+```
+
+Nothing here is mandatory: with no `observability` block (or `enabled:
+false`), the daemon does none of the above — no subscription, no queue file,
+no HTTP client, zero extra syscalls. Loom never phones home; every hop in
+this pipeline is infrastructure **you** deploy and point your own daemons at.
+
+## 1. Enable telemetry on a daemon
+
+Add the `observability` block to that host's `.loom/config.json`:
+
+```json
+{
+  "observability": {
+    "enabled": true,
+    "endpoint": "https://<your-worker>.workers.dev/ingest",
+    "ingestKeyFile": "/etc/loom/observability-ingest.key",
+    "batchSize": 50,
+    "flushIntervalSecs": 30,
+    "queueCapacity": 2000
+  }
+}
+```
+
+Precedence is **env > config > default**, the same rule every other
+`autonomous.*`-style daemon subsystem follows
+(`loom-daemon/src/config_resolver.rs`). Every key has a
+`LOOM_OBSERVABILITY_*` env override:
+
+| Config key | Env override | Default |
+|---|---|---|
+| `enabled` | `LOOM_OBSERVABILITY_ENABLED` | `false` |
+| `endpoint` | `LOOM_OBSERVABILITY_ENDPOINT` | unset (disables export) |
+| `ingestKeyFile` | `LOOM_OBSERVABILITY_INGEST_KEY_FILE` | unset (disables export) |
+| `batchSize` | `LOOM_OBSERVABILITY_BATCH_SIZE` | 50 |
+| `flushIntervalSecs` | `LOOM_OBSERVABILITY_FLUSH_INTERVAL_SECS` | 30 |
+| `queueCapacity` | `LOOM_OBSERVABILITY_QUEUE_CAPACITY` | 2000 |
+
+The ingest key is **never inline in config** — `ingestKeyFile` is a path the
+daemon reads once at startup and holds only in memory, sent solely as an
+`Authorization: Bearer` header. A misconfigured block (missing endpoint or
+key file) degrades to off; it does not crash the daemon. Source of truth:
+`loom-daemon/src/observability/mod.rs`'s module doc (config resolution,
+FLAGS-OFF posture, read-only invariant) and its `collector.rs` / `queue.rs` /
+`exporter.rs` / `sender.rs` siblings (collector, durable queue, exporter
+trait + HTTPS implementation, retry-drain loop).
+
+## 2. What gets sent: the wire schema
+
+Every push is a batch of versioned `TelemetryEnvelope`s
+(`schema_version`, `emitted_at`, `host_id`, `record`). Record kinds:
+`sweep.started`, `sweep.phase`, `sweep.completed`, `sweep.outcome`
+(repo-scoped, each carrying a `visibility: public|private` tag derived from
+the forge, private-by-default and private-safe-by-construction),
+`tokens.snapshot`, `host.health` (host-level, no repo/visibility). Full
+field-by-field reference, the `visibility` anti-leak contract, and the local
+`sweep-outcome-telemetry.jsonl` journal (kept **regardless of whether any
+exporter is configured**):
+[`.loom/docs/telemetry-schema.md`](telemetry-schema.md).
+
+## 3. Exporters: HTTPS today, OTLP planned
+
+The only shipped exporter is `HttpsExporter` — JSON-over-HTTPS `POST
+/ingest`, batched (`batchSize`), retried with jitter, backed by the durable
+disk queue so a sink outage or a sleeping host never silently drops data up
+to `queueCapacity`. The `Exporter` trait (`exporter.rs`) and the drain loop
+(`sender.rs`) are both deliberately generic so a second sink is a drop-in
+addition, not a rewrite: an **OTLP exporter is planned as a feature-flagged
+second sink** (epic Phase 4, tracked separately in
+[#4858](https://github.com/rjwalters/loom/issues/4858)) — as of this writing
+that issue is still open, so OTLP support has **not** landed; every host today
+speaks the native HTTPS/JSON wire format only.
+
+## 4. The backend: deploy your own Cloudflare Worker
+
+The Phase-2 backend is a Cloudflare Worker (D1 for durable history, a
+Durable Object for live "what's running now" state, an hourly retention
+cron) that also serves the dashboard UI as static assets. Full deploy
+runbook — Wrangler setup, D1 migrations, admin token, per-host ingest key
+provisioning, verifying telemetry lands — is
+[`dashboard/docs/deploy-runbook.md`](../../dashboard/docs/deploy-runbook.md).
+This is **your own infrastructure**; nothing in Loom points at a shared
+backend by default.
+
+## 5. Authenticated vs. public: two views, one redaction policy
+
+Every query route exists twice — `/api/*` (authenticated, full detail) and
+`/public/*` (unauthenticated, always reachable, redacted per record kind) —
+enforced both at the edge (a Cloudflare Access policy in front of `/api/*`
+only) and in the Worker itself (a per-kind field allowlist, defense in
+depth). The dashboard root `/` is a single URL for both audiences: it
+verifies the visitor's Access session in-Worker and falls back to the
+redacted public variant on any failure (missing/expired/wrong-audience
+token, even a JWKS fetch failure) — fail-closed by construction, never a
+dead-end login wall for an anonymous visitor.
+
+- Gating setup (custom domain requirement, route map, Access application
+  config, the single-URL fallback mechanics):
+  [`dashboard/docs/cloudflare-access.md`](../../dashboard/docs/cloudflare-access.md)
+- Query API + live event tail, request/response shapes, pagination:
+  [`dashboard/docs/query-api.md`](../../dashboard/docs/query-api.md)
+- Token/cost analytics (burn curves, forecasting, per-repo attribution, and
+  why that surface is authenticated-only): `dashboard/docs/token-analytics.md`
+
+## 6. The 2AM reference instance
+
+`dashboard.2amlogic.com` is a live, operator-owned deployment of this same
+backend (not a shared Loom service — every fleet deploys its own). Its
+specific account/database IDs, Access application layout, credential file
+locations, and cutover history (the hostname-wide Access app was retired in
+favor of the single-URL `/login`-scoped layout on 2026-07-31) are recorded
+in [`dashboard/docs/reference-deployment.md`](../../dashboard/docs/reference-deployment.md)
+— useful as a concrete filled-in example of every value the deploy runbook
+asks you to supply, not as a second copy of the how-to.
+
+## Map of every detail doc
+
+| Doc | Covers |
+|---|---|
+| [`.loom/docs/telemetry-schema.md`](telemetry-schema.md) | Wire envelope, record kinds, visibility contract, local journal |
+| `dashboard/docs/deploy-runbook.md` | Deploy your own Cloudflare backend end to end |
+| `dashboard/docs/cloudflare-access.md` | Gating the authenticated view behind SSO; single-URL fallback |
+| `dashboard/docs/query-api.md` | `/api/*` vs `/public/*` routes, redaction policy, live tail |
+| `dashboard/docs/token-analytics.md` | Burn curves, forecasting, per-repo attribution |
+| `dashboard/docs/reference-deployment.md` | The 2AM instance specifically — concrete IDs, current state |
+| `loom-daemon/src/observability/mod.rs` | Config resolution, collector/queue/exporter/sender source of truth |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,7 @@ Configuration lives in `.loom/config.json` (committed for team sharing): a
   user scope (`scripts/install-loom.sh`, refreshed by `loom update`); `setup-mcp.sh`
   is demoted to a bundle-rebuild/legacy-migration tool. See the mcp-loom README.
 - **Fleet dashboard** (`loom-daemon serve`, opt-in, read-only, loopback by default): [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) §Fleet dashboard.
+- **Fleet observability** (`observability` config block: daemon → Cloudflare backend → dashboard) — [`.loom/docs/observability.md`](.loom/docs/observability.md).
 
 ### Multi-Account Token Pool (operating summary)
 

--- a/defaults/docs/observability.md
+++ b/defaults/docs/observability.md
@@ -1,0 +1,157 @@
+# Fleet Observability: end-to-end reference
+
+> Epic [#4702](https://github.com/rjwalters/loom/issues/4702), Phase 4
+> (#4860). This is the single entry point tying the whole pipeline together —
+> **daemon config → wire schema → exporter → Cloudflare backend → dashboard
+> views** — matching the map-plus-links pattern `daemon-reference.md` and
+> `token-pool.md` already use. It is an operating summary, not a duplicate:
+> every claim below has a canonical detail doc linked next to it, and this
+> page should stay a map even as those detail docs grow.
+
+## The pipeline, in one picture
+
+```
+loom-daemon (per host)
+  observability.* config block (opt-in, off by default)
+        │  collector: EventBus subscriber -> TelemetryEnvelope
+        ▼
+  durable disk-backed queue (survives sink outage / sleep)
+        │  drains via a jittered-retry loop
+        ▼
+  exporter: HttpsExporter (JSON-over-HTTPS POST /ingest)   [OTLP: planned, #4858]
+        │
+        ▼
+Cloudflare Worker backend (deploy-your-own, or the 2AM reference instance)
+  D1 (durable history) + Durable Object (live "what's running now")
+        │
+        ├── /api/*     authenticated, full detail   (Cloudflare Access)
+        └── /public/*  unauthenticated, redacted     (always reachable)
+        │
+        ▼
+Dashboard UI (served by the same Worker) — authenticated + public views
+```
+
+Nothing here is mandatory: with no `observability` block (or `enabled:
+false`), the daemon does none of the above — no subscription, no queue file,
+no HTTP client, zero extra syscalls. Loom never phones home; every hop in
+this pipeline is infrastructure **you** deploy and point your own daemons at.
+
+## 1. Enable telemetry on a daemon
+
+Add the `observability` block to that host's `.loom/config.json`:
+
+```json
+{
+  "observability": {
+    "enabled": true,
+    "endpoint": "https://<your-worker>.workers.dev/ingest",
+    "ingestKeyFile": "/etc/loom/observability-ingest.key",
+    "batchSize": 50,
+    "flushIntervalSecs": 30,
+    "queueCapacity": 2000
+  }
+}
+```
+
+Precedence is **env > config > default**, the same rule every other
+`autonomous.*`-style daemon subsystem follows
+(`loom-daemon/src/config_resolver.rs`). Every key has a
+`LOOM_OBSERVABILITY_*` env override:
+
+| Config key | Env override | Default |
+|---|---|---|
+| `enabled` | `LOOM_OBSERVABILITY_ENABLED` | `false` |
+| `endpoint` | `LOOM_OBSERVABILITY_ENDPOINT` | unset (disables export) |
+| `ingestKeyFile` | `LOOM_OBSERVABILITY_INGEST_KEY_FILE` | unset (disables export) |
+| `batchSize` | `LOOM_OBSERVABILITY_BATCH_SIZE` | 50 |
+| `flushIntervalSecs` | `LOOM_OBSERVABILITY_FLUSH_INTERVAL_SECS` | 30 |
+| `queueCapacity` | `LOOM_OBSERVABILITY_QUEUE_CAPACITY` | 2000 |
+
+The ingest key is **never inline in config** — `ingestKeyFile` is a path the
+daemon reads once at startup and holds only in memory, sent solely as an
+`Authorization: Bearer` header. A misconfigured block (missing endpoint or
+key file) degrades to off; it does not crash the daemon. Source of truth:
+`loom-daemon/src/observability/mod.rs`'s module doc (config resolution,
+FLAGS-OFF posture, read-only invariant) and its `collector.rs` / `queue.rs` /
+`exporter.rs` / `sender.rs` siblings (collector, durable queue, exporter
+trait + HTTPS implementation, retry-drain loop).
+
+## 2. What gets sent: the wire schema
+
+Every push is a batch of versioned `TelemetryEnvelope`s
+(`schema_version`, `emitted_at`, `host_id`, `record`). Record kinds:
+`sweep.started`, `sweep.phase`, `sweep.completed`, `sweep.outcome`
+(repo-scoped, each carrying a `visibility: public|private` tag derived from
+the forge, private-by-default and private-safe-by-construction),
+`tokens.snapshot`, `host.health` (host-level, no repo/visibility). Full
+field-by-field reference, the `visibility` anti-leak contract, and the local
+`sweep-outcome-telemetry.jsonl` journal (kept **regardless of whether any
+exporter is configured**):
+[`.loom/docs/telemetry-schema.md`](telemetry-schema.md).
+
+## 3. Exporters: HTTPS today, OTLP planned
+
+The only shipped exporter is `HttpsExporter` — JSON-over-HTTPS `POST
+/ingest`, batched (`batchSize`), retried with jitter, backed by the durable
+disk queue so a sink outage or a sleeping host never silently drops data up
+to `queueCapacity`. The `Exporter` trait (`exporter.rs`) and the drain loop
+(`sender.rs`) are both deliberately generic so a second sink is a drop-in
+addition, not a rewrite: an **OTLP exporter is planned as a feature-flagged
+second sink** (epic Phase 4, tracked separately in
+[#4858](https://github.com/rjwalters/loom/issues/4858)) — as of this writing
+that issue is still open, so OTLP support has **not** landed; every host today
+speaks the native HTTPS/JSON wire format only.
+
+## 4. The backend: deploy your own Cloudflare Worker
+
+The Phase-2 backend is a Cloudflare Worker (D1 for durable history, a
+Durable Object for live "what's running now" state, an hourly retention
+cron) that also serves the dashboard UI as static assets. Full deploy
+runbook — Wrangler setup, D1 migrations, admin token, per-host ingest key
+provisioning, verifying telemetry lands — is
+[`dashboard/docs/deploy-runbook.md`](../../dashboard/docs/deploy-runbook.md).
+This is **your own infrastructure**; nothing in Loom points at a shared
+backend by default.
+
+## 5. Authenticated vs. public: two views, one redaction policy
+
+Every query route exists twice — `/api/*` (authenticated, full detail) and
+`/public/*` (unauthenticated, always reachable, redacted per record kind) —
+enforced both at the edge (a Cloudflare Access policy in front of `/api/*`
+only) and in the Worker itself (a per-kind field allowlist, defense in
+depth). The dashboard root `/` is a single URL for both audiences: it
+verifies the visitor's Access session in-Worker and falls back to the
+redacted public variant on any failure (missing/expired/wrong-audience
+token, even a JWKS fetch failure) — fail-closed by construction, never a
+dead-end login wall for an anonymous visitor.
+
+- Gating setup (custom domain requirement, route map, Access application
+  config, the single-URL fallback mechanics):
+  [`dashboard/docs/cloudflare-access.md`](../../dashboard/docs/cloudflare-access.md)
+- Query API + live event tail, request/response shapes, pagination:
+  [`dashboard/docs/query-api.md`](../../dashboard/docs/query-api.md)
+- Token/cost analytics (burn curves, forecasting, per-repo attribution, and
+  why that surface is authenticated-only): `dashboard/docs/token-analytics.md`
+
+## 6. The 2AM reference instance
+
+`dashboard.2amlogic.com` is a live, operator-owned deployment of this same
+backend (not a shared Loom service — every fleet deploys its own). Its
+specific account/database IDs, Access application layout, credential file
+locations, and cutover history (the hostname-wide Access app was retired in
+favor of the single-URL `/login`-scoped layout on 2026-07-31) are recorded
+in [`dashboard/docs/reference-deployment.md`](../../dashboard/docs/reference-deployment.md)
+— useful as a concrete filled-in example of every value the deploy runbook
+asks you to supply, not as a second copy of the how-to.
+
+## Map of every detail doc
+
+| Doc | Covers |
+|---|---|
+| [`.loom/docs/telemetry-schema.md`](telemetry-schema.md) | Wire envelope, record kinds, visibility contract, local journal |
+| `dashboard/docs/deploy-runbook.md` | Deploy your own Cloudflare backend end to end |
+| `dashboard/docs/cloudflare-access.md` | Gating the authenticated view behind SSO; single-URL fallback |
+| `dashboard/docs/query-api.md` | `/api/*` vs `/public/*` routes, redaction policy, live tail |
+| `dashboard/docs/token-analytics.md` | Burn curves, forecasting, per-repo attribution |
+| `dashboard/docs/reference-deployment.md` | The 2AM instance specifically — concrete IDs, current state |
+| `loom-daemon/src/observability/mod.rs` | Config resolution, collector/queue/exporter/sender source of truth |


### PR DESCRIPTION
## Summary

Epic #4702 Phase 4. Adds `.loom/docs/observability.md` — a single entry
point tying the fleet-observability pipeline together end to end (daemon
`observability` config block → telemetry wire schema → exporter → Cloudflare
Worker backend → authenticated/public dashboard views), following the
map-plus-links operating-summary style of `.loom/docs/daemon-reference.md`
and `.loom/docs/token-pool.md` rather than duplicating the detail docs it
links out to:

- `.loom/docs/telemetry-schema.md`
- `dashboard/docs/deploy-runbook.md`
- `dashboard/docs/cloudflare-access.md`
- `dashboard/docs/query-api.md`
- `dashboard/docs/token-analytics.md`
- `dashboard/docs/reference-deployment.md`

Shipped from `defaults/docs/observability.md` (identical content) per the
`docs-defaults-parity` guard (#4848/#4841) — every existing `.loom/docs/*.md`
file with a real counterpart follows the same "canonical in defaults/docs/,
mirrored in .loom/docs/" pattern (verified against `telemetry-schema.md`,
which already round-trips this way).

Verified #4858 (OTLP exporter) is **still open** as of this writing, so the
doc describes OTLP as planned/feature-flagged, not shipped — the only live
exporter is the native HTTPS/JSON `HttpsExporter`. The 2AM cutover section
reflects the completed 2026-07-31 cutover documented in
`dashboard/docs/reference-deployment.md`.

Added a one-line pointer in CLAUDE.md's Configuration section, matching the
existing `daemon-reference.md` / `build-gate.md` / `runtime-adapters.md`
bullet style. `scripts/check-claude-md-budget.sh` passes (318/320 lines).

## Test plan

- [x] `./scripts/check-claude-md-budget.sh` — OK, 318/320 lines
- [x] `./scripts/check-docs-defaults-parity.sh` — no new violations from
      `observability.md` (pre-existing `safehouse.md`/`token-pool.md`
      orphans are unrelated, tracked separately)
- [x] Manually verified every relative link in the new doc resolves to a
      real file (`telemetry-schema.md` same-dir sibling; the three
      `../../dashboard/docs/*.md` cross-directory links)
- [x] Confirmed #4858 (OTLP exporter) is open, not merged, before writing
      its status into the doc
- [x] Read `loom-daemon/src/observability/mod.rs` and its `collector.rs` /
      `queue.rs` / `exporter.rs` / `sender.rs` siblings to confirm the
      config/env-override table and pipeline description are accurate

Closes #4860

🤖 Generated with [Claude Code](https://claude.com/claude-code)