### PR TITLE
fix(dashboard): make token-pool status proportional, not any-exhausted

### DIFF
--- a/dashboard/web/src/fleet.ts
+++ b/dashboard/web/src/fleet.ts
@@ -30,9 +30,11 @@ import type { ActiveSweep, FleetSnapshot, HostEntry, TokenAccount } from "./type
 export const STALE_AFTER_SEC = 15 * 60;
 
 export type HostStatus =
-  /** Reporting recently, no token account exhausted. */
+  /** Reporting recently, and the token pool has healthy capacity left. Some
+   * accounts being exhausted is normal rotation, not a fault — see
+   * `isTokenPoolDegraded` below. */
   | "ok"
-  /** Reporting recently, but at least one token account is exhausted. */
+  /** Reporting recently, but the token pool is at or near exhaustion. */
   | "degraded"
   /** Last report is older than `STALE_AFTER_SEC`. */
   | "stale"
@@ -113,6 +115,25 @@ export function summarizeTokens(entry: HostEntry): TokenSummary {
   };
 }
 
+/**
+ * A pool is treated as "close to the edge" — worth a `degraded` badge — once
+ * one account or fewer is left to rotate onto, or three quarters of the pool
+ * is spent. Below that line, some accounts being exhausted is the pool
+ * working exactly as designed (the selector rotates away from them), not a
+ * fault: see #4864.
+ */
+const LOW_AVAILABILITY_THRESHOLD = 1;
+const HIGH_EXHAUSTION_FRACTION = 0.75;
+
+/** `true` when the token pool is empty of capacity or nearly so. A pool with
+ * no reported accounts (`total === 0`) is not degraded by this check —
+ * that host simply has not sent a `tokens.snapshot` yet. */
+export function isTokenPoolDegraded(tokens: TokenSummary): boolean {
+  if (tokens.total === 0) return false;
+  const available = tokens.total - tokens.exhausted;
+  return available <= LOW_AVAILABILITY_THRESHOLD || tokens.exhausted / tokens.total >= HIGH_EXHAUSTION_FRACTION;
+}
+
 /** Newest of the two `updatedAt`s. String compare is safe here *only* because
  * both are backend-generated `new Date().toISOString()` values — fixed-width
  * UTC, so lexicographic order is chronological order. */
@@ -139,7 +160,7 @@ export function buildHostView(
     status = "unknown";
   } else if (lastReportAgeSec > STALE_AFTER_SEC) {
     status = "stale";
-  } else if (tokens.exhausted > 0) {
+  } else if (isTokenPoolDegraded(tokens)) {
     status = "degraded";
   } else {
     status = "ok";

--- a/dashboard/web/src/views/fleetOverview.ts
+++ b/dashboard/web/src/views/fleetOverview.ts
@@ -33,8 +33,8 @@ const STATUS_LABEL: Record<HostStatus, string> = {
 };
 
 const STATUS_TITLE: Record<HostStatus, string> = {
-  ok: "Reporting recently; no token account exhausted",
-  degraded: "Reporting recently, but at least one token account is exhausted",
+  ok: "Reporting recently; token pool has healthy capacity",
+  degraded: "Reporting recently, but the token pool is at or near exhaustion",
   stale: "No telemetry received recently — the daemon may be stopped or offline",
   unknown: "This host has not pushed host.health or tokens.snapshot yet",
 };

--- a/dashboard/web/test/app.test.ts
+++ b/dashboard/web/test/app.test.ts
@@ -101,7 +101,7 @@ describe("App — loaded state", () => {
     await app.start("#/");
 
     expect(fetchState).toHaveBeenCalledTimes(1);
-    expect(root.querySelectorAll('[data-testid="host-card"]')).toHaveLength(5);
+    expect(root.querySelectorAll('[data-testid="host-card"]')).toHaveLength(6);
     expect(statusEl.textContent).toMatch(/^Updated /);
   });
 
@@ -199,13 +199,13 @@ describe("App — error state", () => {
       throw new FleetStateError("transient", { status: 503 });
     });
     await app.start("#/");
-    expect(root.querySelectorAll('[data-testid="host-card"]')).toHaveLength(5);
+    expect(root.querySelectorAll('[data-testid="host-card"]')).toHaveLength(6);
 
     await app.refresh();
 
     // Banner over live (stale) data — not a blanked page.
     expect(root.querySelector('[data-testid="error"]')?.classList.contains("state--banner")).toBe(true);
-    expect(root.querySelectorAll('[data-testid="host-card"]')).toHaveLength(5);
+    expect(root.querySelectorAll('[data-testid="host-card"]')).toHaveLength(6);
     expect(statusEl.textContent).toBe("Stale — last refresh failed");
   });
 

--- a/dashboard/web/test/fixtures.ts
+++ b/dashboard/web/test/fixtures.ts
@@ -126,8 +126,15 @@ export function isoMinutesBefore(minutes: number, base: Date = NOW): string {
 /** A healthy, busy host: full health, a healthy token pool, two live sweeps. */
 export const HEALTHY_HOST_ID = "fleet-mac-1";
 
-/** Reports fine but one token account is exhausted → `degraded`. */
+/** Reports fine, but only one account is left to rotate onto (2 total, 1
+ * exhausted) → `degraded`: the pool is at the edge, not just "some accounts
+ * spent". */
 export const DEGRADED_HOST_ID = "fleet-linux-2";
+
+/** Reports fine with a large pool and several accounts exhausted, but still
+ * well clear of the degraded thresholds → `ok`. Pins #4864: a partially
+ * spent pool operating exactly as designed must not read as degraded. */
+export const PARTIALLY_EXHAUSTED_HEALTHY_HOST_ID = "fleet-partial-6";
 
 /** Last report is well past `STALE_AFTER_SEC` → `stale`. */
 export const STALE_HOST_ID = "fleet-old-3";
@@ -201,6 +208,46 @@ export function multiHostSnapshot(): unknown {
         health: {
           record: { kind: "host.health", daemon_version: "0.15.0", uptime_sec: 120 },
           updatedAt: isoMinutesBefore(90),
+        },
+      },
+      [PARTIALLY_EXHAUSTED_HEALTHY_HOST_ID]: {
+        health: {
+          record: {
+            kind: "host.health",
+            daemon_version: "0.16.0",
+            uptime_sec: 43_200,
+            logical_cpus: 16,
+            cpu_idle_fraction: 0.6,
+            load_per_core: 0.8,
+            worktree_root_free_gb: 300,
+          },
+          updatedAt: isoMinutesBefore(2),
+        },
+        tokens: {
+          record: {
+            kind: "tokens.snapshot",
+            captured_at: isoMinutesBefore(2),
+            // 14 accounts, 5 exhausted: 9 available (well above the
+            // low-availability threshold) and 5/14 ≈ 0.36 exhausted (well
+            // below the high-exhaustion threshold) — routine rotation.
+            accounts: [
+              { account: "p1", usage_fraction: 1, exhausted: true },
+              { account: "p2", usage_fraction: 1, exhausted: true },
+              { account: "p3", usage_fraction: 1, exhausted: true },
+              { account: "p4", usage_fraction: 1, exhausted: true },
+              { account: "p5", usage_fraction: 1, exhausted: true },
+              { account: "p6", usage_fraction: 0.7, exhausted: false },
+              { account: "p7", usage_fraction: 0.5, exhausted: false },
+              { account: "p8", usage_fraction: 0.4, exhausted: false },
+              { account: "p9", usage_fraction: 0.3, exhausted: false },
+              { account: "p10", usage_fraction: 0.2, exhausted: false },
+              { account: "p11", usage_fraction: 0.1, exhausted: false },
+              { account: "p12", usage_fraction: 0.1, exhausted: false },
+              { account: "p13", usage_fraction: 0.05, exhausted: false },
+              { account: "p14", usage_fraction: 0.05, exhausted: false },
+            ],
+          },
+          updatedAt: isoMinutesBefore(2),
         },
       },
       [IDLE_HOST_ID]: {

--- a/dashboard/web/test/fleet.test.ts
+++ b/dashboard/web/test/fleet.test.ts
@@ -1,12 +1,20 @@
 import { describe, expect, it } from "vitest";
 
-import { STALE_AFTER_SEC, buildFleetView, findHost, sortSweeps, summarizeTokens } from "../src/fleet";
+import {
+  STALE_AFTER_SEC,
+  buildFleetView,
+  findHost,
+  isTokenPoolDegraded,
+  sortSweeps,
+  summarizeTokens,
+} from "../src/fleet";
 import { parseFleetSnapshot } from "../src/parse";
 import {
   DEGRADED_HOST_ID,
   HEALTHY_HOST_ID,
   IDLE_HOST_ID,
   NOW,
+  PARTIALLY_EXHAUSTED_HEALTHY_HOST_ID,
   STALE_HOST_ID,
   SWEEP_ONLY_HOST_ID,
   isoMinutesBefore,
@@ -33,12 +41,20 @@ describe("buildFleetView", () => {
     expect(host?.status).toBe("ok");
   });
 
-  it("classifies host status from report age and token exhaustion", () => {
+  it("classifies host status from report age and token pool availability", () => {
     const built = view();
     expect(findHost(built, HEALTHY_HOST_ID)?.status).toBe("ok");
     expect(findHost(built, DEGRADED_HOST_ID)?.status).toBe("degraded");
     expect(findHost(built, STALE_HOST_ID)?.status).toBe("stale");
     expect(findHost(built, SWEEP_ONLY_HOST_ID)?.status).toBe("unknown");
+  });
+
+  it("renders a partially-spent but functioning pool as ok, not degraded (#4864)", () => {
+    // 14 accounts, 5 exhausted: routine rotation, not a fault. Regression
+    // pin for the "any exhausted account -> degraded" false alarm.
+    const host = findHost(view(), PARTIALLY_EXHAUSTED_HEALTHY_HOST_ID);
+    expect(host?.tokens).toMatchObject({ total: 14, exhausted: 5 });
+    expect(host?.status).toBe("ok");
   });
 
   it("treats the staleness boundary as strictly greater-than", () => {
@@ -87,12 +103,15 @@ describe("buildFleetView", () => {
       SWEEP_ONLY_HOST_ID,
       HEALTHY_HOST_ID,
       IDLE_HOST_ID,
+      PARTIALLY_EXHAUSTED_HEALTHY_HOST_ID,
     ]);
   });
 
   it("counts sweeps and attention-needing hosts", () => {
     const built = view();
     expect(built.totalSweeps).toBe(3);
+    // Only the stale host and the truly-at-the-edge degraded host — not the
+    // partially-exhausted-but-healthy one.
     expect(built.needsAttention).toBe(2);
   });
 
@@ -101,6 +120,40 @@ describe("buildFleetView", () => {
     expect(built.hosts).toEqual([]);
     expect(built.totalSweeps).toBe(0);
     expect(built.needsAttention).toBe(0);
+  });
+});
+
+describe("isTokenPoolDegraded", () => {
+  const pool = (total: number, exhausted: number) => ({
+    accounts: [],
+    total,
+    exhausted,
+    peakUsage: undefined,
+    hasAccountDetail: true,
+  });
+
+  it("is not degraded when no accounts have been reported yet", () => {
+    expect(isTokenPoolDegraded(pool(0, 0))).toBe(false);
+  });
+
+  it("is not degraded for a partially-spent pool with plenty of availability", () => {
+    expect(isTokenPoolDegraded(pool(14, 5))).toBe(false);
+  });
+
+  it("is degraded when zero accounts remain available", () => {
+    expect(isTokenPoolDegraded(pool(5, 5))).toBe(true);
+  });
+
+  it("is degraded when only one account remains available", () => {
+    expect(isTokenPoolDegraded(pool(5, 4))).toBe(true);
+  });
+
+  it("is not degraded once two or more accounts remain available", () => {
+    expect(isTokenPoolDegraded(pool(5, 3))).toBe(false);
+  });
+
+  it("is degraded once exhaustion crosses the 75% threshold, even with 2+ available", () => {
+    expect(isTokenPoolDegraded(pool(20, 15))).toBe(true); // 5 available, 75% exhausted
   });
 });
 

--- a/dashboard/web/test/fleetOverview.test.ts
+++ b/dashboard/web/test/fleetOverview.test.ts
@@ -9,6 +9,7 @@ import {
   HEALTHY_HOST_ID,
   IDLE_HOST_ID,
   NOW,
+  PARTIALLY_EXHAUSTED_HEALTHY_HOST_ID,
   STALE_HOST_ID,
   SWEEP_ONLY_HOST_ID,
   isoMinutesBefore,
@@ -33,12 +34,13 @@ describe("fleetOverviewView", () => {
       SWEEP_ONLY_HOST_ID,
       HEALTHY_HOST_ID,
       IDLE_HOST_ID,
+      PARTIALLY_EXHAUSTED_HEALTHY_HOST_ID,
     ]);
   });
 
   it("summarizes the fleet above the grid", () => {
     const summary = fleetOverviewView(view(), NOW).querySelector('[data-testid="fleet-summary"]');
-    expect(summary?.textContent).toContain("5 hosts");
+    expect(summary?.textContent).toContain("6 hosts");
     expect(summary?.textContent).toContain("3 active sweeps");
     expect(summary?.textContent).toContain("2 need");
   });

--- a/dashboard/web/test/parse.test.ts
+++ b/dashboard/web/test/parse.test.ts
@@ -6,7 +6,7 @@ import { HEALTHY_HOST_ID, multiHostSnapshot } from "./fixtures";
 describe("parseFleetSnapshot", () => {
   it("narrows a well-formed multi-host snapshot", () => {
     const snapshot = parseFleetSnapshot(multiHostSnapshot());
-    expect(Object.keys(snapshot.hosts)).toHaveLength(4);
+    expect(Object.keys(snapshot.hosts)).toHaveLength(5);
     expect(snapshot.activeSweeps).toHaveLength(3);
     expect(snapshot.hosts[HEALTHY_HOST_ID]?.health?.record.cpu_idle_fraction).toBe(0.83);
     expect(snapshot.hosts[HEALTHY_HOST_ID]?.tokens?.record.accounts).toHaveLength(2);


### PR DESCRIPTION
## Problem

`deriveStatus` in `dashboard/web/src/fleet.ts` marked a fleet host **Degraded** whenever *any* token account was exhausted (`tokens.exhausted > 0`). The multi-account token pool exists precisely so exhausted accounts are routine — the selector rotates away from them. This produced a real false alarm on 2026-08-01: two healthy hosts (`studio`, `robb-pro`) were flagged "Degraded" alongside one genuinely dead host (`loom-worker-1`), giving all three the same visual weight and camouflaging the real failure.

## Fix

Replace the any-exhausted check with a proportional `isTokenPoolDegraded` helper:

| Condition | Status |
|---|---|
| No report within `STALE_AFTER_SEC` | `stale` (unchanged) |
| `available == 0` (all accounts exhausted) | `degraded` |
| `available <= 1` or `exhausted / total >= 0.75` | `degraded` (genuinely close to the edge) |
| `total == 0` (no tokens reported yet) | not degraded by this check — unchanged `unknown`/`ok` handling upstream |
| otherwise | `ok` |

The "N need attention" headline (`FleetView.needsAttention`) is derived from `status` and required no separate change — it now only counts hosts that are genuinely `stale` or `degraded` under the new thresholds.

## Tests

- `dashboard/web/test/fleet.test.ts`: new `describe("isTokenPoolDegraded")` block covering all the threshold edges (0/1/2 available, the 75% ratio, and the `total === 0` no-data case), plus a regression case pinning "a 14-account pool with 5 exhausted renders `ok`" per the issue's acceptance criteria.
- `dashboard/web/test/fixtures.ts`: added `PARTIALLY_EXHAUSTED_HEALTHY_HOST_ID`, a host with a large pool (14 accounts, 5 exhausted) that stays well clear of both thresholds.
- Updated the host-count/order fallout from the new fixture host in `fleetOverview.test.ts`, `app.test.ts`, and `parse.test.ts`.
- Full `npm test` (341 tests) and `tsc --noEmit` pass clean.

## Scope note

The issue's "worth considering" refinement (surfacing a host with zero active sweeps despite reporting health and pool capacity) is intentionally **not** included — `fleet.ts`'s own documented design principle is that "zero sweeps is a normal state, not an empty state" (see the file's header comment and the existing `IDLE_HOST_ID` test), so folding that signal into `status` would contradict already-pinned behavior and is a bigger design question than this fix's scope. The acceptance criteria checklist does not require it.

Closes #4864