### PR TITLE
fix(dashboard): make token-exhaustion status proportional, not any-nonzero

### DIFF
--- a/dashboard/web/src/fleet.ts
+++ b/dashboard/web/src/fleet.ts
@@ -30,15 +30,27 @@ import type { ActiveSweep, FleetSnapshot, HostEntry, TokenAccount } from "./type
 export const STALE_AFTER_SEC = 15 * 60;
 
 export type HostStatus =
-  /** Reporting recently, no token account exhausted. */
+  /** Reporting recently, with a functioning token pool. Some accounts may be
+   * exhausted — the pool rotates away from them by design, so that alone is
+   * not a fault. */
   | "ok"
-  /** Reporting recently, but at least one token account is exhausted. */
+  /** Reporting recently, but the token pool cannot dispatch (no accounts
+   * available) or is close enough to that edge to warrant a look. */
   | "degraded"
   /** Last report is older than `STALE_AFTER_SEC`. */
   | "stale"
   /** Known only from `activeSweeps`, or from a `hosts` entry with neither
    * `health` nor `tokens` yet — nothing to assess. */
   | "unknown";
+
+/**
+ * A pool this close to its edge needs a look even though it is not literally
+ * at zero: one more exhaustion away from `available === 0`, or three
+ * quarters of the pool already spent. Picked to fire well before the pool
+ * actually stalls, without firing on ordinary rotation (see #4864).
+ */
+const DEGRADED_AVAILABLE_FLOOR = 1;
+const DEGRADED_EXHAUSTED_RATIO = 0.75;
 
 export interface TokenSummary {
   /** The per-account rows, or `[]` for a public viewer, who is sent an
@@ -113,6 +125,26 @@ export function summarizeTokens(entry: HostEntry): TokenSummary {
   };
 }
 
+/**
+ * Whether a token pool warrants a `degraded` status.
+ *
+ * A pool with some accounts exhausted is normal rotation, not a fault — see
+ * the module-level `HostStatus` doc and #4864. Only two shapes count as
+ * degraded: the pool cannot dispatch at all (`available === 0`), or it is
+ * close enough to that edge (`available <= 1`, or three quarters or more of
+ * the pool spent) that a human should look before it does.
+ *
+ * A pool with `total === 0` (no `tokens.snapshot` reported yet) is never
+ * flagged here — that host is `ok` on the tokens axis; a missing report
+ * shows up as `stale`/`unknown` via the liveness check instead.
+ */
+function isTokenPoolDegraded(tokens: TokenSummary): boolean {
+  if (tokens.total === 0) return false;
+  const available = tokens.total - tokens.exhausted;
+  if (available <= DEGRADED_AVAILABLE_FLOOR) return true;
+  return tokens.exhausted / tokens.total >= DEGRADED_EXHAUSTED_RATIO;
+}
+
 /** Newest of the two `updatedAt`s. String compare is safe here *only* because
  * both are backend-generated `new Date().toISOString()` values — fixed-width
  * UTC, so lexicographic order is chronological order. */
@@ -139,7 +171,7 @@ export function buildHostView(
     status = "unknown";
   } else if (lastReportAgeSec > STALE_AFTER_SEC) {
     status = "stale";
-  } else if (tokens.exhausted > 0) {
+  } else if (isTokenPoolDegraded(tokens)) {
     status = "degraded";
   } else {
     status = "ok";

--- a/dashboard/web/src/views/fleetOverview.ts
+++ b/dashboard/web/src/views/fleetOverview.ts
@@ -33,8 +33,8 @@ const STATUS_LABEL: Record<HostStatus, string> = {
 };
 
 const STATUS_TITLE: Record<HostStatus, string> = {
-  ok: "Reporting recently; no token account exhausted",
-  degraded: "Reporting recently, but at least one token account is exhausted",
+  ok: "Reporting recently; token pool has capacity (some accounts may be exhausted — that's normal rotation)",
+  degraded: "Reporting recently, but the token pool has no or almost no accounts available",
   stale: "No telemetry received recently — the daemon may be stopped or offline",
   unknown: "This host has not pushed host.health or tokens.snapshot yet",
 };

--- a/dashboard/web/test/app.test.ts
+++ b/dashboard/web/test/app.test.ts
@@ -101,7 +101,7 @@ describe("App — loaded state", () => {
     await app.start("#/");
 
     expect(fetchState).toHaveBeenCalledTimes(1);
-    expect(root.querySelectorAll('[data-testid="host-card"]')).toHaveLength(5);
+    expect(root.querySelectorAll('[data-testid="host-card"]')).toHaveLength(6);
     expect(statusEl.textContent).toMatch(/^Updated /);
   });
 
@@ -199,13 +199,13 @@ describe("App — error state", () => {
       throw new FleetStateError("transient", { status: 503 });
     });
     await app.start("#/");
-    expect(root.querySelectorAll('[data-testid="host-card"]')).toHaveLength(5);
+    expect(root.querySelectorAll('[data-testid="host-card"]')).toHaveLength(6);
 
     await app.refresh();
 
     // Banner over live (stale) data — not a blanked page.
     expect(root.querySelector('[data-testid="error"]')?.classList.contains("state--banner")).toBe(true);
-    expect(root.querySelectorAll('[data-testid="host-card"]')).toHaveLength(5);
+    expect(root.querySelectorAll('[data-testid="host-card"]')).toHaveLength(6);
     expect(statusEl.textContent).toBe("Stale — last refresh failed");
   });
 

--- a/dashboard/web/test/fixtures.ts
+++ b/dashboard/web/test/fixtures.ts
@@ -126,7 +126,7 @@ export function isoMinutesBefore(minutes: number, base: Date = NOW): string {
 /** A healthy, busy host: full health, a healthy token pool, two live sweeps. */
 export const HEALTHY_HOST_ID = "fleet-mac-1";
 
-/** Reports fine but one token account is exhausted → `degraded`. */
+/** Reports fine but the pool has no accounts left to rotate to → `degraded`. */
 export const DEGRADED_HOST_ID = "fleet-linux-2";
 
 /** Last report is well past `STALE_AFTER_SEC` → `stale`. */
@@ -137,6 +137,10 @@ export const SWEEP_ONLY_HOST_ID = "fleet-new-4";
 
 /** Present in `hosts` with health but zero sweeps — the idle-host case. */
 export const IDLE_HOST_ID = "fleet-idle-5";
+
+/** A pool with some accounts exhausted but plenty of capacity left — normal
+ * rotation, not a fault → `ok` (see #4864). */
+export const PARTIALLY_EXHAUSTED_HOST_ID = "fleet-partial-6";
 
 export function multiHostSnapshot(): unknown {
   return {
@@ -189,12 +193,45 @@ export function multiHostSnapshot(): unknown {
         tokens: {
           record: {
             kind: "tokens.snapshot",
+            // 1 of 2 exhausted → available === 1, at the `available <= 1`
+            // floor: close enough to the edge to warrant a look, even though
+            // the ratio (50%) is under the 75% threshold.
             accounts: [
               { account: "agent-3", usage_fraction: 1, exhausted: true },
               { account: "agent-4", exhausted: false },
             ],
           },
           updatedAt: isoMinutesBefore(1),
+        },
+      },
+      [PARTIALLY_EXHAUSTED_HOST_ID]: {
+        health: {
+          record: {
+            kind: "host.health",
+            daemon_version: "0.16.0",
+            uptime_sec: 10_800,
+            logical_cpus: 16,
+            cpu_idle_fraction: 0.7,
+            load_per_core: 0.6,
+            worktree_root_free_gb: 300,
+          },
+          updatedAt: isoMinutesBefore(2),
+        },
+        tokens: {
+          record: {
+            kind: "tokens.snapshot",
+            // 1 of 5 exhausted: available === 4, well clear of both the
+            // `available <= 1` floor and the 75%-exhausted ratio — this is
+            // ordinary rotation, not a fault (see #4864).
+            accounts: [
+              { account: "agent-5", usage_fraction: 1, exhausted: true },
+              { account: "agent-6", usage_fraction: 0.3, exhausted: false },
+              { account: "agent-7", usage_fraction: 0.2, exhausted: false },
+              { account: "agent-8", usage_fraction: 0.1, exhausted: false },
+              { account: "agent-9", usage_fraction: 0.05, exhausted: false },
+            ],
+          },
+          updatedAt: isoMinutesBefore(2),
         },
       },
       [STALE_HOST_ID]: {

--- a/dashboard/web/test/fleet.test.ts
+++ b/dashboard/web/test/fleet.test.ts
@@ -7,6 +7,7 @@ import {
   HEALTHY_HOST_ID,
   IDLE_HOST_ID,
   NOW,
+  PARTIALLY_EXHAUSTED_HOST_ID,
   STALE_HOST_ID,
   SWEEP_ONLY_HOST_ID,
   isoMinutesBefore,
@@ -39,6 +40,81 @@ describe("buildFleetView", () => {
     expect(findHost(built, DEGRADED_HOST_ID)?.status).toBe("degraded");
     expect(findHost(built, STALE_HOST_ID)?.status).toBe("stale");
     expect(findHost(built, SWEEP_ONLY_HOST_ID)?.status).toBe("unknown");
+  });
+
+  it("pins: a partially-spent but functioning pool is healthy, not degraded", () => {
+    // 1 of 5 accounts exhausted is normal rotation — the pool still has 4
+    // available, nowhere near the `available <= 1` / 75%-exhausted edges.
+    // Exhausted-count-greater-than-zero alone must never flip this to
+    // `degraded` (the #4864 false-alarm bug).
+    const host = findHost(view(), PARTIALLY_EXHAUSTED_HOST_ID);
+    expect(host?.tokens.exhausted).toBeGreaterThan(0);
+    expect(host?.status).toBe("ok");
+  });
+
+  it("degrades a pool with no available accounts", () => {
+    const built = buildFleetView(
+      parseFleetSnapshot({
+        hosts: {
+          h: {
+            health: { record: {}, updatedAt: isoMinutesBefore(1) },
+            tokens: {
+              record: {
+                accounts: [
+                  { account: "a", exhausted: true },
+                  { account: "b", exhausted: true },
+                ],
+              },
+              updatedAt: isoMinutesBefore(1),
+            },
+          },
+        },
+        activeSweeps: [],
+      }),
+      NOW,
+    );
+    expect(findHost(built, "h")?.status).toBe("degraded");
+  });
+
+  it("degrades a pool at exactly one account available, even below the 75% ratio", () => {
+    // 1 of 4 exhausted is only 25% — well under the ratio threshold — but
+    // `available === 1` alone should still flip this to `degraded`.
+    const built = buildFleetView(
+      parseFleetSnapshot({
+        hosts: {
+          h: {
+            health: { record: {}, updatedAt: isoMinutesBefore(1) },
+            tokens: {
+              record: {
+                accounts: [
+                  { account: "a", exhausted: true },
+                  { account: "b", exhausted: true },
+                  { account: "c", exhausted: true },
+                  { account: "d", exhausted: false },
+                ],
+              },
+              updatedAt: isoMinutesBefore(1),
+            },
+          },
+        },
+        activeSweeps: [],
+      }),
+      NOW,
+    );
+    expect(findHost(built, "h")?.status).toBe("degraded");
+  });
+
+  it("does not degrade a host with no tokens.snapshot at all", () => {
+    // total === 0 means "never reported", not "pool exhausted" — the tokens
+    // axis must not manufacture a fault out of an absent report.
+    const built = buildFleetView(
+      parseFleetSnapshot({
+        hosts: { h: { health: { record: {}, updatedAt: isoMinutesBefore(1) } } },
+        activeSweeps: [],
+      }),
+      NOW,
+    );
+    expect(findHost(built, "h")?.status).toBe("ok");
   });
 
   it("treats the staleness boundary as strictly greater-than", () => {
@@ -87,12 +163,15 @@ describe("buildFleetView", () => {
       SWEEP_ONLY_HOST_ID,
       HEALTHY_HOST_ID,
       IDLE_HOST_ID,
+      PARTIALLY_EXHAUSTED_HOST_ID,
     ]);
   });
 
   it("counts sweeps and attention-needing hosts", () => {
     const built = view();
     expect(built.totalSweeps).toBe(3);
+    // Only the stale host and the fully-exhausted-pool host need attention —
+    // the partially-exhausted pool is healthy and must not inflate this count.
     expect(built.needsAttention).toBe(2);
   });
 

--- a/dashboard/web/test/fleetOverview.test.ts
+++ b/dashboard/web/test/fleetOverview.test.ts
@@ -9,6 +9,7 @@ import {
   HEALTHY_HOST_ID,
   IDLE_HOST_ID,
   NOW,
+  PARTIALLY_EXHAUSTED_HOST_ID,
   STALE_HOST_ID,
   SWEEP_ONLY_HOST_ID,
   isoMinutesBefore,
@@ -33,13 +34,15 @@ describe("fleetOverviewView", () => {
       SWEEP_ONLY_HOST_ID,
       HEALTHY_HOST_ID,
       IDLE_HOST_ID,
+      PARTIALLY_EXHAUSTED_HOST_ID,
     ]);
   });
 
   it("summarizes the fleet above the grid", () => {
     const summary = fleetOverviewView(view(), NOW).querySelector('[data-testid="fleet-summary"]');
-    expect(summary?.textContent).toContain("5 hosts");
+    expect(summary?.textContent).toContain("6 hosts");
     expect(summary?.textContent).toContain("3 active sweeps");
+    // The partially-exhausted host is healthy and must not inflate this count.
     expect(summary?.textContent).toContain("2 need");
   });
 

--- a/dashboard/web/test/parse.test.ts
+++ b/dashboard/web/test/parse.test.ts
@@ -6,7 +6,7 @@ import { HEALTHY_HOST_ID, multiHostSnapshot } from "./fixtures";
 describe("parseFleetSnapshot", () => {
   it("narrows a well-formed multi-host snapshot", () => {
     const snapshot = parseFleetSnapshot(multiHostSnapshot());
-    expect(Object.keys(snapshot.hosts)).toHaveLength(4);
+    expect(Object.keys(snapshot.hosts)).toHaveLength(5);
     expect(snapshot.activeSweeps).toHaveLength(3);
     expect(snapshot.hosts[HEALTHY_HOST_ID]?.health?.record.cpu_idle_fraction).toBe(0.83);
     expect(snapshot.hosts[HEALTHY_HOST_ID]?.tokens?.record.accounts).toHaveLength(2);


### PR DESCRIPTION
## Problem

`deriveStatus` in `dashboard/web/src/fleet.ts` marked a host `degraded` whenever *any* token account was exhausted (`tokens.exhausted > 0`). The multi-account token pool exists precisely so exhausted accounts are routine rotation — flagging that as degraded meant the fleet read "degraded" almost constantly, and on 2026-08-01 it masked a genuinely dead host (`loom-worker-1`, daemon exited, zero active sweeps) among two false positives.

## Fix

Replaced the any-nonzero check with a proportional `isTokenPoolDegraded` helper:

| Condition | Status |
|---|---|
| No report within `STALE_AFTER_SEC` | `stale` (unchanged) |
| `available === 0` | `degraded` — pool cannot dispatch |
| `available <= 1` or `exhausted / total >= 0.75` | `degraded` — genuinely close to the edge |
| otherwise | `ok` — some accounts spent is normal rotation |

Also updated the `ok`/`degraded` status-badge tooltip copy in `fleetOverview.ts` to match the new semantics.

## Scope note

The issue also floated surfacing "zero active sweeps despite a healthy pool" (the #4011 silent-autonomy-loss shape) as its own degraded condition. I left that out: the module's own documented invariant is "zero sweeps is a normal state, not an empty state" (an idle host is healthy), and the view model has no signal to distinguish a genuinely idle host from a silently-stalled one — that needs a different data source (e.g. queue depth) to avoid trading one false-positive class for another. Happy to file a follow-up issue if desired.

## Tests

- `dashboard/web/test/fleet.test.ts`: added a fixture-backed case pinning "partially exhausted pool renders `ok`", plus inline synthetic-snapshot cases for `available === 0`, `available === 1` (below the 75% ratio but still degraded), and "no tokens.snapshot at all stays `ok`".
- `dashboard/web/test/fixtures.ts`: added `PARTIALLY_EXHAUSTED_HOST_ID` (1 of 5 exhausted → `ok`).
- Updated collateral host-count/order assertions in `fleetOverview.test.ts`, `app.test.ts`, `parse.test.ts` for the new fixture host.
- `npm run check` (typecheck + `vitest run`, 338 tests) passes in `dashboard/web/`.

Closes #4864