### PR TITLE
fix(dashboard): show every in-flight sweep on the host card

### DIFF
--- a/dashboard/web/src/styles.css
+++ b/dashboard/web/src/styles.css
@@ -293,10 +293,6 @@ a:hover {
   font-size: 12px;
   margin-left: auto;
 }
-.card__sweep--more {
-  color: var(--text-dim);
-  font-size: 12px;
-}
 
 /* ---- badges + chips ------------------------------------------------------ */
 

--- a/dashboard/web/src/views/fleetOverview.ts
+++ b/dashboard/web/src/views/fleetOverview.ts
@@ -112,7 +112,11 @@ export function hostCard(host: HostView, now: Date = new Date()): HTMLElement {
       ? el(
           "ul",
           { class: "card__sweeps", data: { testid: "card-sweeps" } },
-          host.sweeps.slice(0, 3).map((sweep) =>
+          // Every in-flight sweep, not the first three (#4868). This card is
+          // the answer to "what is the fleet doing right now"; truncating to
+          // three made that answer "click into each host" — on a working
+          // fleet it hid 22 of 31 sweeps. The card grows instead.
+          host.sweeps.map((sweep) =>
             el(
               "li",
               { class: "card__sweep" },
@@ -125,9 +129,6 @@ export function hostCard(host: HostView, now: Date = new Date()): HTMLElement {
               sweep.repo ? el("span", { class: "card__sweep-repo" }, sweep.repo) : null,
             ),
           ),
-          sweepCount > 3
-            ? el("li", { class: "card__sweep card__sweep--more" }, `+${sweepCount - 3} more`)
-            : null,
         )
       : null,
   );

--- a/dashboard/web/test/fleetOverview.test.ts
+++ b/dashboard/web/test/fleetOverview.test.ts
@@ -117,22 +117,28 @@ describe("hostCard", () => {
     expect(idle.querySelector('[data-testid="card-sweeps"]')).toBeNull();
   });
 
-  it("truncates a long sweep list with a +N more row", () => {
+  // #4868: the card used to stop at three and append "+N more", which on a
+  // working fleet hid most of what the overview exists to show.
+  it("renders every in-flight sweep rather than truncating", () => {
     const built = buildFleetView(
       parseFleetSnapshot({
         hosts: {},
-        activeSweeps: Array.from({ length: 5 }, (_, index) => ({
+        activeSweeps: Array.from({ length: 14 }, (_, index) => ({
           hostId: "busy",
           sweepId: `sweep-${index}`,
           issue: 100 + index,
-          startedAt: isoMinutesBefore(10 - index),
+          startedAt: isoMinutesBefore(20 - index),
         })),
       }),
       NOW,
     );
     const card = hostCard(built.hosts[0]!, NOW);
-    expect(card.querySelectorAll(".card__sweep")).toHaveLength(4);
-    expect(card.querySelector(".card__sweep--more")?.textContent).toBe("+2 more");
+
+    expect(card.querySelectorAll(".card__sweep")).toHaveLength(14);
+    expect(card.querySelector(".card__sweep--more")).toBeNull();
+    // The count in the fields block and the number of rows must agree — they
+    // came from the same array, and a reader will compare them.
+    expect(fieldValue(card, "Active sweeps")).toBe("14");
   });
 
   it("says 'Never reported' instead of a fabricated timestamp", () => {


### PR DESCRIPTION
Closes #4868.

The card stopped at three sweeps and appended `+N more`. On a working fleet that hid most of what the overview exists to show — observed today: `+9 more`, `+8 more`, `+5 more`, so **22 of 31 in-flight sweeps were invisible**, and all three cards were the same height regardless of how much they had to say.

The overview is where you answer "what is the fleet doing right now". If the answer is always "click into each host", the card is not doing its job.

## Changes

- Render the full sweep list; the card grows to fit.
- `align-items: start` on the grid — without it, grid stretches every card in a row to the tallest, so a host with two sweeps inherits the whitespace of a host with fourteen.
- Column minimum `320px` → `360px`: the token-pool value (`5/14 exhausted · peak 84%`) was wrapping mid-value at the narrower width, which was the other half of the "truncated" complaint.
- Dropped the now-dead `.card__sweep--more` rule.

## Test

The old test pinned the truncation (`toHaveLength(4)`, `"+2 more"`). Replaced with one that pins the new contract at a realistic count — 14 sweeps → 14 rows, no `+N more` — and additionally asserts the rendered row count agrees with the `Active sweeps` field, since both come from the same array and a reader will compare them.

**341 web tests pass.**

## Note on the sibling fix

The `Degraded`-on-any-exhausted-account bug (#4864) is already fixed in `main` via PR #4866 — the badges are stale on the live dashboard only because the deployment predates it. Deploying this PR picks up both.