### PR TITLE
feat(dashboard): chart the pool-level token aggregate on the public surface

### DIFF
--- a/dashboard/docs/token-analytics.md
+++ b/dashboard/docs/token-analytics.md
@@ -81,50 +81,76 @@ tests at and around their boundaries.
   footnote under the table exists so a reader can see which they are looking
   at.
 
-## 2. Public-exposure decision: authenticated surface only
+## 2. Public-exposure decision: pool-level aggregate, not per-account detail
 
-**Decision: the token/cost analytics render on the authenticated route only.**
+**Original decision (issue #4752, pre-#4795):** the token/cost analytics
+rendered on the authenticated route only — the whole panel was withheld from
+the public surface.
 
-Phase 2's redaction policy ([`../src/redaction.ts`](../src/redaction.ts))
-passes `tokens.snapshot` through **unredacted on both `/api` and `/public`** —
-the kind has no `repo` to key visibility off, so the private/public split has
-nothing to act on. That remains correct backend behavior and **this issue
-changes nothing in `redaction.ts`**. But "the API returns it" is not "the page
-should show it", and this is where that distinction is drawn:
+**Current decision (2026-07-31, issue #4847): the signed-in dashboard shows
+per-account token detail; the public view shows pool-level aggregate stats
+instead of a withheld notice.** Phase 2's redaction policy
+([`../src/redaction.ts`](../src/redaction.ts)) already drew the line this
+panel now follows: `/public/history`'s `tokens.snapshot` carries no
+`accounts[]` at all — `deriveTokenPoolAggregate` replaces it with a
+non-identifying `account_count` / `exhausted_count` / `mean_usage_fraction` /
+`max_usage_fraction` / `next_limit_window_reset_at` summary. A public render
+built from that shape can never surface an account identifier; the work this
+issue added was a **new pool-level computation** (a burn series over the
+aggregate, segmented at rollovers the same way the per-account curves are —
+see [`web/src/analytics/burn.ts`](../web/src/analytics/burn.ts)'s
+`buildPoolBurnCurves`), not a redaction change.
+
+What still does **not** render publicly, and why:
 
 1. **Per-repo attribution is a repo-name table by construction.** Its entire
    output is "which repositories consumed the fleet's quota" — and repo names
    are precisely what Phase 2 strips from `/public/history` for
    private-visibility sweeps. Publishing this panel would reconstruct, by
-   inference from timing, the exact fact the redaction layer removes.
-2. **Account identifiers are operator infrastructure.** `agent-3` +
-   `usage_fraction` + `limit_window_reset_at` is a live capacity map of the
-   operator's account pool: how many accounts exist, which are near their cap,
-   and when each recovers.
-3. **Exhaustion forecasts are a scheduling signal.** "This fleet runs dry in 40
-   minutes" should be a deliberate publication choice, not a side effect of
-   which route happens to permit it.
+   inference from timing, the exact fact the redaction layer removes. Also
+   noted in [`render.ts`](../web/src/analytics/render.ts)'s module doc:
+   attributing usage to time windows can reconstruct private-sweep timing by
+   inference even without repo names — a second, independent reason both the
+   table and the sweep-window join stay behind the Access gate.
+2. **Per-account exhaustion forecasts are a scheduling signal keyed to an
+   identity.** "This fleet runs dry in 40 minutes" is one thing; "*agent-3*
+   runs dry in 40 minutes" ties that to operator infrastructure. The
+   pool-level summary reports the same risk signal (`exhausted_count`,
+   `max_usage_fraction`) without naming which account it is — and,
+   deliberately, without projecting an ETA from it either: a pool-wide mean
+   can sit comfortably mid-range while one account is a sample away from
+   exhaustion, so a trend line through the mean would be actively misleading.
+   See [`web/src/analytics/forecast.ts`](../web/src/analytics/forecast.ts)'s
+   `summarizePoolHealth`.
 
 ### How it is enforced
 
-Two independent UI-layer points, neither of which is a redaction change:
+Two independent points, neither of which is a redaction change:
 
 - [`web/src/analytics/render.ts`](../web/src/analytics/render.ts) —
-  `renderTokenAnalytics` / `mountTokenAnalytics` refuse to render on a
-  `"public"` surface and show a short "withheld" notice instead. On the public
-  surface `mountTokenAnalytics` **makes no request at all**; it does not fetch
-  and then hide.
-- [`web/src/analytics/api.ts`](../web/src/analytics/api.ts) — the fetch prefix
-  is the constant `/api`, not a parameter, so the view cannot be repointed at
-  `/public` by configuration.
+  `renderTokenAnalytics` renders the pool-level burn/health blocks on a
+  `"public"` surface (never the per-account burn curves, forecast table, or
+  attribution table), with a short notice naming only the two blocks that
+  stay operator-only.
+- [`web/src/analytics/api.ts`](../web/src/analytics/api.ts) — `fetchHistory`'s
+  `surface` option selects `/api/history` or `/public/history` explicitly;
+  `mountTokenAnalytics` always passes the same surface it renders with, so a
+  public render can only ever have requested `/public`. Even if a caller got
+  that wrong, the backend does not trust the client's choice of prefix:
+  `/public/history` redacts `tokens.snapshot` down to the aggregate
+  server-side regardless, so per-account detail cannot reach the browser
+  through this path no matter which surface a caller asks for.
 
-The surface itself is derived from the served path
-(`bootstrap.ts`'s `surfaceFromPath`), mirroring the backend's own route-based
-auth split — so a link cannot talk the panel into rendering publicly.
+The surface itself is derived from the server-injected auth state
+(`bootstrap.ts`'s `currentSurface`, issue #4795), mirroring the backend's own
+route-based auth split — so a link cannot talk the panel into requesting
+`/api` publicly.
 
 ### Coordination with the public view page (#4753)
 
-The public page should **not** embed these widgets. If a public capacity
-summary is wanted later, the right shape is a purpose-built aggregate (e.g.
-"fleet capacity: healthy / degraded") carrying no account names, no repo names,
-and no per-account timing — a new component, not a flag on this one.
+The public page **should** embed this panel — the pool-level burn/health
+blocks are the purpose-built, non-identifying aggregate the original
+`token-analytics.md` speculated about ("fleet capacity: healthy / degraded",
+carrying no account names, no repo names, no per-account timing). It should
+**not** embed per-repo attribution or per-account forecasts; those remain
+authenticated-only per the decision above.

--- a/dashboard/web/src/analytics/analytics.css
+++ b/dashboard/web/src/analytics/analytics.css
@@ -144,6 +144,15 @@
   stroke: var(--analytics-danger);
 }
 
+/* The pool-level card (public surface, #4847) draws two lines: peak usage
+ * (solid, the default `.sparkline__line`) and mean usage (dashed, muted) —
+ * distinguishable without relying on the exhausted-only red/green pairing
+ * above, which this second line does not participate in. */
+.sparkline__line--mean {
+  stroke: var(--analytics-muted);
+  stroke-dasharray: 3 2;
+}
+
 /* --- Tables -------------------------------------------------------------- */
 
 .table {

--- a/dashboard/web/src/analytics/api.ts
+++ b/dashboard/web/src/analytics/api.ts
@@ -15,22 +15,34 @@
  * A server-side `kind` filter would be a strict improvement and is the obvious
  * follow-up, but it is a backend change — out of scope for this UI issue.
  *
- * ## `/api` only, never `/public`
+ * ## `/api` or `/public`, chosen explicitly by the caller
  *
- * `API_PREFIX` is a constant, not a parameter. Per this issue's
- * public-exposure decision (see `render.ts` and
- * `../../docs/token-analytics.md`), the token/cost analytics are an
- * authenticated-surface feature: the fetch path is pinned to `/api` so the
- * view cannot be repointed at `/public` by configuration, and `render.ts`
- * independently refuses to render on a public surface. Two enforcement points,
- * because "the API technically returns it" is not the same as "the page should
- * show it".
+ * Issue #4752 pinned this to `/api` unconditionally, on the premise that the
+ * whole panel was authenticated-only. Issue #4847 revisited that: the public
+ * surface now gets a pool-level panel built from `/public/history`'s
+ * non-identifying `tokens.snapshot` aggregate (`../../docs/query-api.md`),
+ * so the fetch prefix is a `surface` option instead of a constant.
+ *
+ * This is *not* a weaker guarantee than the old constant. `render.ts`'s
+ * `mountTokenAnalytics` is the only caller, and it always passes the same
+ * `surface` it renders with — so a public-surface render can only ever have
+ * requested `/public`. And even if a caller got that wrong, the backend does
+ * not trust the client's choice of prefix at all: `/public/history` redacts
+ * `tokens.snapshot` down to the aggregate server-side
+ * (`../../src/redaction.ts`) regardless of what the requester intended, so
+ * per-account detail cannot reach the browser through this path no matter
+ * which `surface` is passed here.
  */
 
 import type { HistoryEnvelope } from "./types.js";
 
-/** Authenticated surface only — see the module doc. */
-const API_PREFIX = "/api";
+/** Which route surface a history fetch targets — see the module doc. */
+export type HistorySurface = "authenticated" | "public";
+
+const HISTORY_PATH_BY_SURFACE: Readonly<Record<HistorySurface, string>> = {
+  authenticated: "/api/history",
+  public: "/public/history",
+};
 
 /** The API's own cap (`docs/query-api.md`: "Default 50, capped at 500"). */
 const MAX_PAGE_SIZE = 500;
@@ -49,6 +61,9 @@ export interface FetchHistoryOptions {
   host?: string;
   /** Page-walk cap. Default 10 pages (up to 5000 records). */
   maxPages?: number;
+  /** Which route to query. Default `"authenticated"` (`/api/history`) — see
+   * the module doc. */
+  surface?: HistorySurface;
   /** Injectable for tests; defaults to the global `fetch`. */
   fetchImpl?: typeof fetch;
   signal?: AbortSignal;
@@ -64,6 +79,7 @@ export interface FetchHistoryOptions {
 export async function fetchHistory(options: FetchHistoryOptions = {}): Promise<HistoryEnvelope[]> {
   const doFetch = options.fetchImpl ?? globalThis.fetch;
   const maxPages = options.maxPages ?? 10;
+  const path = HISTORY_PATH_BY_SURFACE[options.surface ?? "authenticated"];
   const collected: HistoryEnvelope[] = [];
   let cursor: number | null = null;
 
@@ -75,12 +91,12 @@ export async function fetchHistory(options: FetchHistoryOptions = {}): Promise<H
     if (options.host !== undefined) params.set("host", options.host);
     if (cursor !== null) params.set("cursor", String(cursor));
 
-    const response = await doFetch(`${API_PREFIX}/history?${params.toString()}`, {
+    const response = await doFetch(`${path}?${params.toString()}`, {
       signal: options.signal,
       headers: { accept: "application/json" },
     });
     if (!response.ok) {
-      throw new Error(`GET ${API_PREFIX}/history returned ${response.status}`);
+      throw new Error(`GET ${path} returned ${response.status}`);
     }
 
     const parsed = await parsePage(response);

--- a/dashboard/web/src/analytics/bootstrap.ts
+++ b/dashboard/web/src/analytics/bootstrap.ts
@@ -40,7 +40,9 @@ import type { DashboardSurface } from "./render.js";
  *
  * Fails closed to `"public"`: `isAuthenticatedViewer` treats a missing or
  * malformed flag as anonymous, so a page that never got the injection renders
- * the withheld notice rather than firing an authenticated request.
+ * the pool-level public panel (`render.ts`) and fetches from `/public/history`
+ * rather than firing an authenticated request it has no evidence it is
+ * entitled to.
  */
 export function currentSurface(scope: typeof globalThis = globalThis): DashboardSurface {
   return isAuthenticatedViewer(scope) ? "authenticated" : "public";

--- a/dashboard/web/src/analytics/burn.ts
+++ b/dashboard/web/src/analytics/burn.ts
@@ -37,9 +37,18 @@
  * `exhausted` flag, which the schema documents as always present: an account
  * can be known-exhausted while its numeric usage is unknown, and that must
  * still light up the UI.
+ *
+ * ## Pool-level curves (issue #4847)
+ *
+ * `buildPoolBurnCurves` (bottom of this file) is the public-surface
+ * counterpart: one curve per `hostId` (no account key — the aggregate names
+ * none), built from `/public/history`'s `mean_usage_fraction` /
+ * `max_usage_fraction` / `exhausted_count` instead of a per-account
+ * `usage_fraction`. Same segmentation rules, same "unknown != zero" contract,
+ * different input shape (`PoolSample`, not `TokenSample`).
  */
 
-import type { AccountReading, TokenSample } from "./types.js";
+import type { AccountReading, PoolSample, TokenSample } from "./types.js";
 
 /** A usage drop smaller than this is float noise, not a window rollover. */
 const USAGE_DROP_EPSILON = 1e-9;
@@ -222,6 +231,174 @@ function newestDefinedRank(entry: Series): number | undefined {
   for (let i = entry.readings.length - 1; i >= 0; i -= 1) {
     const rank = entry.readings[i]?.reading.rank;
     if (rank !== undefined) return rank;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Pool-level burn curves (`/public/history`'s aggregate — issue #4847)
+// ---------------------------------------------------------------------------
+
+/**
+ * One reading of the pool aggregate, mirroring {@link BurnPoint} but keyed on
+ * the whole pool rather than one account: `usage_fraction` becomes a pair
+ * (mean/peak across every account that reported one) and there is an
+ * `exhaustedCount`/`accountCount` instead of a boolean flag.
+ */
+export interface PoolBurnPoint {
+  /** Epoch ms. */
+  at: number;
+  /** Mean/peak `usage_fraction` across the pool, clamped to `[0, 1]`. Absent
+   * — never `0` — when no account reported one in this sample. */
+  meanUsageFraction?: number;
+  maxUsageFraction?: number;
+  accountCount: number;
+  exhaustedCount: number;
+  /** Epoch ms of this reading's `next_limit_window_reset_at`, when known. */
+  nextLimitWindowResetAt?: number;
+}
+
+export interface PoolBurnSegment {
+  /** Chronological, at least one point. */
+  points: PoolBurnPoint[];
+  /** The `next_limit_window_reset_at` in force for this segment (the newest
+   * one observed in it), when any reading reported one. */
+  nextLimitWindowResetAt?: number;
+  startedBy: "initial" | "window-reset" | "gap";
+}
+
+/** One host's token pool over time. There is one curve per `hostId` — unlike
+ * {@link AccountBurnCurve} there is no per-account key, because the aggregate
+ * carries no account identity to key on. */
+export interface PoolBurnCurve {
+  hostId: string;
+  /** Every usable point across every segment, chronological. */
+  points: PoolBurnPoint[];
+  segments: PoolBurnSegment[];
+  /** The live segment — the tail of `segments`, or `undefined` when no
+   * sample in range reported a usage figure at all. */
+  currentSegment?: PoolBurnSegment;
+  /** Newest reading of any kind (including one with no usage figure). */
+  latestAt: number;
+  /** Pool size / exhausted count as of the newest reading. */
+  accountCount: number;
+  exhaustedCount: number;
+}
+
+interface PoolSeries {
+  hostId: string;
+  samples: PoolSample[];
+}
+
+/**
+ * Build one pool burn curve per `hostId` from a chronological
+ * `/public/history` page. Segmentation mirrors {@link buildBurnCurves}
+ * exactly — a rollover (peak usage dropping, or the pool's next reset
+ * advancing) or a telemetry gap starts a new segment — because the same
+ * "sawtooth would wreck a trend read" problem applies to the pool's peak
+ * usage as it does to any one account's.
+ *
+ * `samples` is expected oldest-first ({@link parsePoolSamples} guarantees
+ * this); re-sorted defensively per host, same as {@link buildBurnCurves}.
+ */
+export function buildPoolBurnCurves(
+  samples: readonly PoolSample[],
+  options: BurnCurveOptions = {},
+): PoolBurnCurve[] {
+  const maxSampleGapMs = options.maxSampleGapMs ?? DEFAULT_MAX_SAMPLE_GAP_MS;
+
+  const byHost = new Map<string, PoolSeries>();
+  for (const sample of samples) {
+    let entry = byHost.get(sample.hostId);
+    if (!entry) {
+      entry = { hostId: sample.hostId, samples: [] };
+      byHost.set(sample.hostId, entry);
+    }
+    entry.samples.push(sample);
+  }
+
+  const curves: PoolBurnCurve[] = [];
+  for (const entry of byHost.values()) {
+    entry.samples.sort((a, b) => a.at - b.at);
+    curves.push(buildPoolCurve(entry, maxSampleGapMs));
+  }
+  curves.sort((a, b) => a.hostId.localeCompare(b.hostId));
+  return curves;
+}
+
+function buildPoolCurve(entry: PoolSeries, maxSampleGapMs: number): PoolBurnCurve {
+  const segments: PoolBurnSegment[] = [];
+  const points: PoolBurnPoint[] = [];
+  let previous: PoolBurnPoint | undefined;
+
+  for (const sample of entry.samples) {
+    // A sample with no usage figure at all contributes no plottable point —
+    // same "unknown != zero" rule as a per-account reading — but the loop
+    // below still uses `entry.samples.at(-1)` (not `points.at(-1)`) for the
+    // curve's latest account/exhausted counts, so that summary never depends
+    // on whether the newest sample happened to carry a usage figure.
+    if (sample.meanUsageFraction === undefined && sample.maxUsageFraction === undefined) continue;
+
+    const point: PoolBurnPoint = {
+      at: sample.at,
+      meanUsageFraction: sample.meanUsageFraction === undefined ? undefined : clampFraction(sample.meanUsageFraction),
+      maxUsageFraction: sample.maxUsageFraction === undefined ? undefined : clampFraction(sample.maxUsageFraction),
+      accountCount: sample.accountCount,
+      exhaustedCount: sample.exhaustedCount,
+      nextLimitWindowResetAt: sample.nextLimitWindowResetAt,
+    };
+    points.push(point);
+
+    const startedBy = poolSegmentBreak(previous, point, maxSampleGapMs);
+    const current = segments.at(-1);
+    if (startedBy === undefined && current) {
+      current.points.push(point);
+      if (point.nextLimitWindowResetAt !== undefined) current.nextLimitWindowResetAt = point.nextLimitWindowResetAt;
+    } else {
+      segments.push({
+        points: [point],
+        nextLimitWindowResetAt: point.nextLimitWindowResetAt,
+        startedBy: startedBy ?? "initial",
+      });
+    }
+    previous = point;
+  }
+
+  const lastSample = entry.samples.at(-1);
+  return {
+    hostId: entry.hostId,
+    points,
+    segments,
+    currentSegment: segments.at(-1),
+    latestAt: lastSample?.at ?? 0,
+    accountCount: lastSample?.accountCount ?? 0,
+    exhaustedCount: lastSample?.exhaustedCount ?? 0,
+  };
+}
+
+/** `undefined` when `point` continues `previous`'s segment. Mirrors
+ * {@link segmentBreak}, reading the pool's peak usage where that reads one
+ * account's `usage_fraction`. */
+function poolSegmentBreak(
+  previous: PoolBurnPoint | undefined,
+  point: PoolBurnPoint,
+  maxSampleGapMs: number,
+): PoolBurnSegment["startedBy"] | undefined {
+  if (previous === undefined) return "initial";
+  if (point.at - previous.at > maxSampleGapMs) return "gap";
+  if (
+    previous.maxUsageFraction !== undefined &&
+    point.maxUsageFraction !== undefined &&
+    previous.maxUsageFraction - point.maxUsageFraction > USAGE_DROP_EPSILON
+  ) {
+    return "window-reset";
+  }
+  if (
+    previous.nextLimitWindowResetAt !== undefined &&
+    point.nextLimitWindowResetAt !== undefined &&
+    point.nextLimitWindowResetAt > previous.nextLimitWindowResetAt
+  ) {
+    return "window-reset";
   }
   return undefined;
 }

--- a/dashboard/web/src/analytics/forecast.ts
+++ b/dashboard/web/src/analytics/forecast.ts
@@ -37,7 +37,7 @@
  * than an invented window length.
  */
 
-import type { AccountBurnCurve, BurnPoint } from "./burn.js";
+import type { AccountBurnCurve, BurnPoint, PoolBurnCurve } from "./burn.js";
 
 export type ForecastStatus =
   /** The daemon reports the account as exhausted right now. */
@@ -186,4 +186,68 @@ function leastSquares(points: readonly BurnPoint[]): LinearFit {
   const slopePerMs = sxx === 0 ? 0 : sxy / sxx;
   const relativeIntercept = meanY - slopePerMs * meanX;
   return { slopePerMs, intercept: relativeIntercept - slopePerMs * t0 };
+}
+
+// ---------------------------------------------------------------------------
+// Pool-level "forecast": a deliberate decision not to project (issue #4847)
+// ---------------------------------------------------------------------------
+
+/**
+ * The public surface gets a pool-wide `tokens.snapshot` aggregate
+ * (`mean_usage_fraction` / `max_usage_fraction` / `exhausted_count`), not a
+ * per-account series — see `../../docs/token-analytics.md`. Fitting the same
+ * least-squares projection above to `mean_usage_fraction` was considered and
+ * rejected: a pool-wide mean can sit comfortably mid-range while one account
+ * in the pool is a single sample away from exhaustion, so a trend line
+ * through the mean would read as reassuring exactly when it should not.
+ * Averaging the input away is not a smaller version of the per-account
+ * forecast, it is a different, misleading question — "will the average
+ * account run dry", when the actual risk is "will *any* account run dry".
+ *
+ * So there is no `projectedExhaustionAt` here. Instead this reports the
+ * pool's exhaustion state *as measured*, right now: how many of its accounts
+ * are exhausted, and how loaded its busiest one is — both `exhausted_count`
+ * and `max_usage_fraction` are already the honest, non-averaged answer to
+ * "how much trouble is this pool in" that a mean-based ETA would only
+ * obscure. `render.ts` renders this instead of a chart, and says why the
+ * chart is missing rather than leaving a silent gap.
+ */
+export interface PoolHealthSummary {
+  hostId: string;
+  /** Pool size / exhausted count as of the newest sample. */
+  accountCount: number;
+  exhaustedCount: number;
+  /** `exhaustedCount / accountCount`, or `undefined` when the pool is empty
+   * (never a misleading `0`). */
+  exhaustedFraction?: number;
+  /** The newest sample's peak/mean usage across the pool, when reported. */
+  maxUsageFraction?: number;
+  meanUsageFraction?: number;
+  /** Epoch ms of the earliest limit-window reset across the pool, when
+   * known — "capacity returns at" names no account, unlike a per-account
+   * `limitWindowResetAt`, so it is safe to show alongside this summary even
+   * though no ETA is projected from it. */
+  nextLimitWindowResetAt?: number;
+}
+
+/** Summarize one host's pool curve. Reads the curve's own latest-sample
+ * fields for account/exhausted counts (present even when no usage figure was
+ * reported that sample) and the newest plottable point for the usage
+ * figures (absent when none was). */
+export function summarizePoolHealth(curve: PoolBurnCurve): PoolHealthSummary {
+  const latest = curve.points[curve.points.length - 1];
+  return {
+    hostId: curve.hostId,
+    accountCount: curve.accountCount,
+    exhaustedCount: curve.exhaustedCount,
+    exhaustedFraction: curve.accountCount > 0 ? curve.exhaustedCount / curve.accountCount : undefined,
+    maxUsageFraction: latest?.maxUsageFraction,
+    meanUsageFraction: latest?.meanUsageFraction,
+    nextLimitWindowResetAt: latest?.nextLimitWindowResetAt,
+  };
+}
+
+/** Summarize every pool curve, preserving `buildPoolBurnCurves`' ordering. */
+export function summarizePoolHealths(curves: readonly PoolBurnCurve[]): PoolHealthSummary[] {
+  return curves.map(summarizePoolHealth);
 }

--- a/dashboard/web/src/analytics/parse.ts
+++ b/dashboard/web/src/analytics/parse.ts
@@ -1,6 +1,7 @@
 /**
- * Narrowing layer: raw `GET /api/history` JSON → the domain shapes in
- * `types.ts` (Epic #4702, Phase 3, issue #4752).
+ * Narrowing layer: raw `GET /api/history` / `GET /public/history` JSON → the
+ * domain shapes in `types.ts` (Epic #4702, Phase 3, issue #4752; the
+ * `/public/history` aggregate shape added in issue #4847).
  *
  * Every function here is total: it never throws on malformed input, it drops
  * what it cannot understand. That is a deliberate contract, not laziness —
@@ -12,12 +13,21 @@
  * measurement stays absent.** It is never coerced to `0`, because `0` means
  * "measured, and it is zero" everywhere downstream (a `usage_fraction` of 0 is
  * a fresh limit window; an unknown one must not be drawn as one).
+ *
+ * `tokens.snapshot` has two disjoint wire shapes depending on which route
+ * served it (`../../docs/query-api.md`): `/api/history` sends per-account
+ * rows (`parseTokenSample`), `/public/history` sends the non-identifying
+ * pool aggregate (`parsePoolSample`). A page is never a mix of the two, but
+ * both parsers are safe to run over any page regardless — each recognizes
+ * only the shape it owns and returns `undefined` for the other.
  */
 
 import type {
   AccountReading,
   HistoryEnvelope,
+  PoolSample,
   SweepWindow,
+  TokenPoolAggregatePayload,
   TokenSample,
   TokensSnapshotPayload,
 } from "./types.js";
@@ -78,6 +88,54 @@ export function parseTokenSamples(envelopes: readonly HistoryEnvelope[]): TokenS
   const withOrder: Array<{ sample: TokenSample; id: number }> = [];
   for (const envelope of envelopes) {
     const sample = parseTokenSample(envelope);
+    if (sample) withOrder.push({ sample, id: envelope.id });
+  }
+  withOrder.sort((a, b) => a.sample.at - b.sample.at || a.id - b.id);
+  return withOrder.map((entry) => entry.sample);
+}
+
+/**
+ * Narrow one `tokens.snapshot` history record shaped as
+ * {@link TokenPoolAggregatePayload} — the `/public/history` form
+ * (`../../docs/query-api.md`), with no per-account detail at all (issue
+ * #4847).
+ *
+ * Returns `undefined` when the record has no usable timestamp, **or when it
+ * is not the aggregate shape** (no numeric `account_count`) — that is
+ * exactly what an authenticated `accounts[]`-carrying record looks like, and
+ * `parseTokenSample` above owns that shape. The two parsers are total and
+ * disjoint on purpose: a caller can run both over the same page and each
+ * only claims the records it understands, never throwing on the other's.
+ */
+export function parsePoolSample(envelope: HistoryEnvelope): PoolSample | undefined {
+  if (envelope.kind !== "tokens.snapshot") return undefined;
+  const payload = envelope.record as TokenPoolAggregatePayload;
+  const at = parseTimestamp(payload?.captured_at) ?? parseTimestamp(envelope.emittedAt);
+  if (at === undefined) return undefined;
+
+  const accountCount = parseFiniteNumber(payload?.account_count);
+  if (accountCount === undefined) return undefined;
+
+  return {
+    hostId: envelope.hostId,
+    at,
+    accountCount,
+    // `exhausted_count` is a count the backend always computes (defaulting to
+    // 0), never an unmeasured probe — unlike the usage fractions below, an
+    // absent/malformed value here reads as 0, not "unknown".
+    exhaustedCount: parseFiniteNumber(payload?.exhausted_count) ?? 0,
+    meanUsageFraction: parseFiniteNumber(payload?.mean_usage_fraction),
+    maxUsageFraction: parseFiniteNumber(payload?.max_usage_fraction),
+    nextLimitWindowResetAt: parseTimestamp(payload?.next_limit_window_reset_at),
+  };
+}
+
+/** Narrow every `tokens.snapshot` in a history page as pool aggregates,
+ * oldest-first — the pool-level counterpart of {@link parseTokenSamples}. */
+export function parsePoolSamples(envelopes: readonly HistoryEnvelope[]): PoolSample[] {
+  const withOrder: Array<{ sample: PoolSample; id: number }> = [];
+  for (const envelope of envelopes) {
+    const sample = parsePoolSample(envelope);
     if (sample) withOrder.push({ sample, id: envelope.id });
   }
   withOrder.sort((a, b) => a.sample.at - b.sample.at || a.id - b.id);

--- a/dashboard/web/src/analytics/render.ts
+++ b/dashboard/web/src/analytics/render.ts
@@ -2,17 +2,23 @@
  * The token/cost analytics panel: burn curves, limit-window forecasts, and
  * per-repo attribution (Epic #4702, Phase 3, issue #4752).
  *
- * ## Public-exposure decision: authenticated surface only
+ * ## Public-exposure decision: pool-level aggregate, not per-account detail
  *
- * Phase 2's redaction policy (`../../src/redaction.ts`) passes
- * `tokens.snapshot` through **unredacted on both `/api` and `/public`** — the
- * kind carries no `repo`, so the private/public visibility split has nothing
- * to key on. That is a correct backend decision and this issue does not change
- * it. It is nonetheless *not* a decision that these widgets belong on the
- * public page, and this module resolves that question the other way:
+ * Operator decision (2026-07-31, issue #4847): **the signed-in dashboard
+ * shows per-account token detail; the public view shows pool-level aggregate
+ * stats instead of nothing.** This supersedes issue #4752's original
+ * decision, which withheld the whole panel from the public surface. Phase
+ * 2's redaction policy (`../../src/redaction.ts`) already draws the line
+ * this module now follows: `/public/history`'s `tokens.snapshot` carries no
+ * `accounts[]` at all — `deriveTokenPoolAggregate` replaces it with a
+ * non-identifying `account_count` / `exhausted_count` / `mean_usage_fraction`
+ * / `max_usage_fraction` / `next_limit_window_reset_at` summary — so a public
+ * render of that data can never surface an account identifier; there is
+ * nothing here to redact in the UI layer, only something to compute (a
+ * pool-level burn series, `burn.ts`'s `buildPoolBurnCurves`) that the
+ * original per-account modules cannot produce.
  *
- * **`mountTokenAnalytics` refuses to render on a `"public"` surface.** Three
- * reasons, in descending order of force:
+ * What still does not render publicly, and why each one stays that way:
  *
  * 1. **Per-repo attribution is a repo-name table by construction.** The whole
  *    output of `attribution.ts` is "which repositories consumed the fleet's
@@ -20,40 +26,43 @@
  *    `/public/history` for private-visibility sweeps. Rendering this panel
  *    publicly would reconstruct, by inference from timing, the exact fact the
  *    redaction layer removes.
- * 2. **Account identifiers are operator infrastructure.** `agent-3` +
- *    `usage_fraction` + `limit_window_reset_at` is a live capacity map of the
- *    operator's account pool: it says how many accounts exist, which are near
- *    their cap, and when each recovers. That is useful to an operator and
- *    useful to nobody else in a way that benefits the operator.
- * 3. **Exhaustion forecasts are a scheduling signal.** "This fleet runs dry in
- *    40 minutes" is exactly the sort of operational state a public status page
- *    should be a deliberate choice to publish, not a side effect of which API
- *    route happens to permit it.
+ * 2. **Per-account forecasts are a scheduling signal keyed to an identity.**
+ *    "This fleet runs dry in 40 minutes" is one thing; "*agent-3* runs dry in
+ *    40 minutes" ties that to operator infrastructure. The pool-level summary
+ *    below reports the same risk (`exhausted_count`, `max_usage_fraction`)
+ *    without naming which account it is — see `forecast.ts`'s
+ *    `summarizePoolHealth` for why this is a summary and not a projection.
  *
- * This is a **UI-layer** decision, enforced here and (independently) by
- * `api.ts` pinning its fetch to `/api`. It changes no redaction behavior. If a
- * future operator wants a public capacity summary, the right shape is a
- * purpose-built aggregate (e.g. "fleet capacity: healthy") with no account or
- * repo names — a new component, not a flag on this one. Coordinated with the
+ * `renderTokenAnalytics` renders the pool-level blocks in place of the
+ * withheld notice on a `"public"` surface, and keeps the notice only for the
+ * two blocks above. `mountTokenAnalytics` fetches from `/public/history`
+ * (never `/api/*`) on that surface — see `api.ts`'s module doc for why that
+ * is still a real boundary and not merely cosmetic. Coordinated with the
  * public view page (#4753) via `../../docs/token-analytics.md`.
  */
 
-import type { AccountBurnCurve, BurnSegment } from "./burn.js";
-import { buildBurnCurves } from "./burn.js";
-import type { AccountForecast, ForecastStatus } from "./forecast.js";
-import { forecastAccounts } from "./forecast.js";
+import type { AccountBurnCurve, BurnSegment, PoolBurnCurve, PoolBurnPoint, PoolBurnSegment } from "./burn.js";
+import { buildBurnCurves, buildPoolBurnCurves } from "./burn.js";
+import type { AccountForecast, ForecastStatus, PoolHealthSummary } from "./forecast.js";
+import { forecastAccounts, summarizePoolHealths } from "./forecast.js";
 import type { AttributionResult } from "./attribution.js";
 import { attributeUsageToRepos } from "./attribution.js";
-import { parseSweepWindows, parseTokenSamples } from "./parse.js";
-import type { HistoryEnvelope, SweepWindow, TokenSample } from "./types.js";
+import { parsePoolSamples, parseSweepWindows, parseTokenSamples } from "./parse.js";
+import type { HistoryEnvelope, PoolSample, SweepWindow, TokenSample } from "./types.js";
 import { fetchHistory } from "./api.js";
 import { formatDuration, formatInstant, formatPercent, formatRatePerHour, formatRelative, UNKNOWN } from "./format.js";
 
 /** Which route surface the panel is being rendered on. */
 export type DashboardSurface = "authenticated" | "public";
 
-/** The only surface this panel renders on — see the module doc. */
-export const REQUIRED_SURFACE: DashboardSurface = "authenticated";
+/** The surface a caller gets when it does not specify one. Authenticated,
+ * not fail-safe-to-public: every real caller (`bootstrap.ts`'s
+ * `startTokenAnalytics`) always passes an explicit surface derived from the
+ * server-injected auth state, so this default only matters to a test or a
+ * future caller that forgot to — and both surfaces now render real content
+ * (see the module doc), so there is no "withheld by default" safety margin
+ * this default used to buy. */
+export const DEFAULT_SURFACE: DashboardSurface = "authenticated";
 
 export interface TokenAnalytics {
   curves: AccountBurnCurve[];
@@ -61,6 +70,13 @@ export interface TokenAnalytics {
   attribution: AttributionResult;
   samples: TokenSample[];
   sweeps: SweepWindow[];
+  /** Pool-level counterparts of `samples`/`curves`, built from the
+   * `/public/history` aggregate shape (issue #4847). Populated from whichever
+   * `tokens.snapshot` shape the input records actually carry — empty when
+   * every record was the per-account shape, and vice versa. */
+  poolSamples: PoolSample[];
+  poolCurves: PoolBurnCurve[];
+  poolHealth: PoolHealthSummary[];
 }
 
 export interface ComputeOptions {
@@ -68,22 +84,28 @@ export interface ComputeOptions {
   now?: number;
 }
 
-/** Partition a history page into the two record families and run all three
- * analytics over them. Pure — no DOM, no network — so the whole computation is
- * unit-testable from fixtures. */
+/** Partition a history page into its record families and run every analytic
+ * over them — both the per-account family and the pool-aggregate family, so
+ * this one function serves either surface. Pure — no DOM, no network — so the
+ * whole computation is unit-testable from fixtures. */
 export function computeTokenAnalytics(
   records: readonly HistoryEnvelope[],
   options: ComputeOptions = {},
 ): TokenAnalytics {
   const samples = parseTokenSamples(records);
+  const poolSamples = parsePoolSamples(records);
   const sweeps = parseSweepWindows(records);
   const curves = buildBurnCurves(samples);
+  const poolCurves = buildPoolBurnCurves(poolSamples);
   return {
     curves,
     forecasts: forecastAccounts(curves, { now: options.now }),
     attribution: attributeUsageToRepos(samples, sweeps, { now: options.now }),
     samples,
     sweeps,
+    poolSamples,
+    poolCurves,
+    poolHealth: summarizePoolHealths(poolCurves),
   };
 }
 
@@ -129,28 +151,32 @@ export interface RenderOptions extends ComputeOptions {
 /**
  * Render the panel into `container` (replacing its contents).
  *
- * Returns `false` without rendering any analytics when the surface is not the
- * authenticated one — the enforcement point for this issue's public-exposure
- * decision (see the module doc). The container instead gets a short notice, so
- * a public page shows an intentional "withheld" state rather than an empty
- * hole that looks like a bug.
+ * Always renders `true` — every surface gets real content now (see the
+ * module doc). On a `"public"` surface it renders the pool-level blocks
+ * (`analytics.poolCurves` / `analytics.poolHealth`) plus a short notice
+ * naming the two blocks that stay operator-only, instead of the per-account
+ * burn curves, forecasts and attribution table an authenticated surface gets.
  */
 export function renderTokenAnalytics(
   container: HTMLElement,
   analytics: TokenAnalytics,
   options: RenderOptions = {},
 ): boolean {
-  const surface = options.surface ?? REQUIRED_SURFACE;
+  const surface = options.surface ?? DEFAULT_SURFACE;
   container.replaceChildren();
-
-  if (surface !== REQUIRED_SURFACE) {
-    container.appendChild(renderWithheldNotice());
-    return false;
-  }
 
   const now = options.now ?? Date.now();
   const section = el("section", "analytics");
   section.appendChild(el("h2", "analytics__title", "Token & cost analytics"));
+
+  if (surface === "public") {
+    section.appendChild(renderPoolBurn(analytics.poolCurves));
+    section.appendChild(renderPoolHealth(analytics.poolHealth));
+    section.appendChild(renderOperatorOnlyNotice());
+    container.appendChild(section);
+    return true;
+  }
+
   section.appendChild(renderBurnCurves(analytics.curves));
   section.appendChild(renderForecasts(analytics.forecasts, now));
   section.appendChild(renderAttribution(analytics.attribution));
@@ -158,20 +184,17 @@ export function renderTokenAnalytics(
   return true;
 }
 
-function renderWithheldNotice(): HTMLElement {
-  const notice = el("section", "analytics analytics--withheld");
-  notice.setAttribute("data-testid", "analytics-withheld");
-  notice.appendChild(el("h2", "analytics__title", "Token & cost analytics"));
-  notice.appendChild(
-    el(
-      "p",
-      "analytics__note",
-      "Per-account detail is operator-only: account identifiers, per-repo attribution and " +
-        "per-account exhaustion forecasts are not shown in the public view. Fleet-level " +
-        "pool load (accounts in use, how many are exhausted, peak usage) is on the host " +
-        "cards above. Sign in for the full breakdown.",
-    ),
+/** The block that replaces `analytics--withheld`'s old full-panel notice: the
+ * public surface now renders real content above this, so the notice only has
+ * to explain the two blocks that are still missing (see the module doc). */
+function renderOperatorOnlyNotice(): HTMLElement {
+  const notice = el(
+    "p",
+    "analytics__note analytics__note--withheld",
+    "Per-repo attribution and per-account exhaustion forecasts are operator-only — they name " +
+      "repositories and individual accounts. Sign in for the full breakdown.",
   );
+  notice.setAttribute("data-testid", "analytics-operator-only-notice");
   return notice;
 }
 
@@ -279,6 +302,170 @@ function renderSegmentLine(
     points.map((point) => `${x(point.at).toFixed(2)},${y(point.usageFraction).toFixed(2)}`).join(" "),
   );
   return line;
+}
+
+// --- Pool-level burn (public surface — issue #4847) -------------------------
+
+/** The public-surface counterpart of `renderBurnCurves`: one card per host,
+ * built from the pool aggregate rather than per-account curves — see the
+ * module doc for what "pool-level" means here and why it names no account. */
+function renderPoolBurn(curves: readonly PoolBurnCurve[]): HTMLElement {
+  const block = el("div", "analytics__block");
+  block.setAttribute("data-testid", "pool-burn");
+  block.appendChild(el("h3", "analytics__heading", "Fleet token-pool load"));
+
+  if (curves.length === 0) {
+    block.appendChild(el("p", "analytics__note", "No tokens.snapshot history in range."));
+    return block;
+  }
+
+  const list = el("div", "burn-grid");
+  for (const curve of curves) list.appendChild(renderPoolBurnCard(curve));
+  block.appendChild(list);
+  block.appendChild(
+    el(
+      "p",
+      "analytics__note",
+      "Mean and peak usage across every account in this host's pool — never any one account's. " +
+        "Peak usage is the solid line, mean usage the dashed one.",
+    ),
+  );
+  return block;
+}
+
+function renderPoolBurnCard(curve: PoolBurnCurve): HTMLElement {
+  const exhausted = curve.exhaustedCount > 0;
+  const card = el("article", `burn-card${exhausted ? " burn-card--exhausted" : ""}`);
+  card.setAttribute("data-host", curve.hostId);
+  card.setAttribute("data-exhausted-count", String(curve.exhaustedCount));
+  card.setAttribute("data-account-count", String(curve.accountCount));
+
+  const head = el("header", "burn-card__head");
+  head.appendChild(el("span", "burn-card__account", curve.hostId));
+  if (exhausted) {
+    const badge = el("span", "badge badge--exhausted", `${curve.exhaustedCount}/${curve.accountCount} exhausted`);
+    badge.setAttribute("data-testid", "pool-exhausted-badge");
+    badge.setAttribute("role", "status");
+    head.appendChild(badge);
+  }
+  card.appendChild(head);
+
+  card.appendChild(renderPoolSparkline(curve));
+
+  const latest = curve.points[curve.points.length - 1];
+  const foot = el("footer", "burn-card__foot");
+  foot.appendChild(el("span", "burn-card__usage", `peak ${formatPercent(latest?.maxUsageFraction)}`));
+  foot.appendChild(el("span", "burn-card__usage", `mean ${formatPercent(latest?.meanUsageFraction)}`));
+  foot.appendChild(el("span", "burn-card__at", formatInstant(curve.latestAt || undefined)));
+  card.appendChild(foot);
+  return card;
+}
+
+/** Pool-level counterpart of `renderSparkline`: two lines per segment (peak,
+ * mean) instead of one, same `[0, 1]`-pinned y-axis and per-segment breaks. */
+function renderPoolSparkline(curve: PoolBurnCurve): SVGSVGElement {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("class", "sparkline");
+  svg.setAttribute("viewBox", `0 0 ${SPARK_WIDTH} ${SPARK_HEIGHT}`);
+  svg.setAttribute("role", "img");
+  svg.setAttribute("preserveAspectRatio", "none");
+  const latest = curve.points[curve.points.length - 1];
+  svg.setAttribute(
+    "aria-label",
+    `${curve.hostId} pool usage over time, latest peak ${formatPercent(latest?.maxUsageFraction)}, ` +
+      `mean ${formatPercent(latest?.meanUsageFraction)}`,
+  );
+
+  const first = curve.points[0];
+  const last = curve.points[curve.points.length - 1];
+  if (!first || !last) return svg;
+
+  const span = Math.max(last.at - first.at, 1);
+  const x = (at: number): number => ((at - first.at) / span) * SPARK_WIDTH;
+  const y = (usage: number): number => SPARK_HEIGHT - usage * SPARK_HEIGHT;
+
+  for (const segment of curve.segments) {
+    svg.appendChild(renderPoolSegmentLine(segment, x, y, (point) => point.maxUsageFraction, "sparkline__line"));
+    svg.appendChild(
+      renderPoolSegmentLine(segment, x, y, (point) => point.meanUsageFraction, "sparkline__line sparkline__line--mean"),
+    );
+  }
+  return svg;
+}
+
+function renderPoolSegmentLine(
+  segment: PoolBurnSegment,
+  x: (at: number) => number,
+  y: (usage: number) => number,
+  select: (point: PoolBurnPoint) => number | undefined,
+  className: string,
+): SVGPolylineElement {
+  const line = document.createElementNS(SVG_NS, "polyline");
+  line.setAttribute("class", className);
+
+  const usable: Array<{ at: number; value: number }> = [];
+  for (const point of segment.points) {
+    const value = select(point);
+    if (value !== undefined) usable.push({ at: point.at, value });
+  }
+  // A single usable point has no line to draw; duplicating it renders a
+  // visible dot rather than silently vanishing (mirrors `renderSegmentLine`).
+  const only = usable[0];
+  const points = usable.length === 1 && only ? [only, only] : usable;
+  line.setAttribute("points", points.map((point) => `${x(point.at).toFixed(2)},${y(point.value).toFixed(2)}`).join(" "));
+  return line;
+}
+
+/** The public-surface counterpart of `renderForecasts`: pool exhaustion state
+ * *as measured*, never projected — see `forecast.ts`'s `summarizePoolHealth`
+ * module doc for why a mean-based ETA is not drawn here. */
+function renderPoolHealth(summaries: readonly PoolHealthSummary[]): HTMLElement {
+  const block = el("div", "analytics__block");
+  block.setAttribute("data-testid", "pool-health");
+  block.appendChild(el("h3", "analytics__heading", "Pool exhaustion"));
+
+  if (summaries.length === 0) {
+    block.appendChild(el("p", "analytics__note", "No accounts observed in range."));
+    return block;
+  }
+
+  const table = el("table", "table table--pool-health");
+  table.appendChild(headerRow(["Host", "Accounts", "Exhausted", "Peak usage", "Mean usage", "Capacity returns"]));
+  const tbody = document.createElement("tbody");
+
+  for (const summary of summaries) {
+    const row = document.createElement("tr");
+    row.setAttribute("data-host", summary.hostId);
+    if (summary.exhaustedFraction !== undefined && summary.exhaustedFraction > 0) row.className = "row--at-risk";
+    cell(row, summary.hostId, "cell--host");
+    cell(row, String(summary.accountCount));
+    cell(
+      row,
+      summary.exhaustedFraction === undefined
+        ? UNKNOWN
+        : `${summary.exhaustedCount} (${formatPercent(summary.exhaustedFraction)})`,
+    );
+    cell(row, formatPercent(summary.maxUsageFraction));
+    cell(row, formatPercent(summary.meanUsageFraction));
+    // "Capacity returns" names no account — the earliest reset across the
+    // whole pool — so it is safe on the public surface even though no
+    // per-account forecast is drawn (see the note below the table).
+    cell(row, formatInstant(summary.nextLimitWindowResetAt));
+    tbody.appendChild(row);
+  }
+
+  table.appendChild(tbody);
+  block.appendChild(table);
+  const note = el(
+    "p",
+    "analytics__note",
+    "No exhaustion timing is projected here: a pool-wide mean can sit comfortably mid-range while one " +
+      "account is a sample away from running dry, and averaging that away would make a forecast actively " +
+      "misleading. Sign in for a per-account burn-rate projection.",
+  );
+  note.setAttribute("data-testid", "pool-forecast-decision");
+  block.appendChild(note);
+  return block;
 }
 
 // --- Forecasts -------------------------------------------------------------
@@ -439,19 +626,16 @@ const DEFAULT_LOOKBACK_MS = 24 * 60 * 60 * 1000;
 /**
  * Fetch, compute and render the panel. The one call an app shell needs.
  *
- * On a non-authenticated surface it renders the withheld notice and **makes no
- * request at all** — the panel does not merely hide data it already fetched.
+ * Fetches from `/public/history` on a `"public"` surface, `/api/history`
+ * otherwise (`api.ts`'s `surface` option) — never the other route, on either
+ * surface. Both surfaces render real content (see the module doc); there is
+ * no longer a surface that renders without fetching.
  */
 export async function mountTokenAnalytics(
   container: HTMLElement,
   options: MountOptions = {},
 ): Promise<TokenAnalytics | undefined> {
-  const surface = options.surface ?? REQUIRED_SURFACE;
-  if (surface !== REQUIRED_SURFACE) {
-    container.replaceChildren(renderWithheldNotice());
-    return undefined;
-  }
-
+  const surface = options.surface ?? DEFAULT_SURFACE;
   const now = options.now ?? Date.now();
   container.replaceChildren(el("p", "analytics__note", "Loading token analytics…"));
 
@@ -461,6 +645,7 @@ export async function mountTokenAnalytics(
       since: now - (options.lookbackMs ?? DEFAULT_LOOKBACK_MS),
       fetchImpl: options.fetchImpl,
       signal: options.signal,
+      surface,
     });
   } catch (error) {
     container.replaceChildren(

--- a/dashboard/web/src/analytics/types.ts
+++ b/dashboard/web/src/analytics/types.ts
@@ -45,6 +45,24 @@ export interface TokensSnapshotPayload {
   accounts?: TokenAccountPayload[];
 }
 
+/**
+ * The shape `/public/history` sends in place of `TokensSnapshotPayload`'s
+ * `accounts` array (`../../src/redaction.ts`'s `deriveTokenPoolAggregate`,
+ * documented in `../../docs/query-api.md`'s "GET /api/history /
+ * /public/history" section). Non-identifying by construction: it names no
+ * account, only how loaded the pool is as a whole (issue #4847).
+ */
+export interface TokenPoolAggregatePayload {
+  kind?: string;
+  captured_at?: string;
+  account_count?: number;
+  exhausted_count?: number;
+  /** `null` — never `0` — when no account reported a `usage_fraction`. */
+  mean_usage_fraction?: number | null;
+  max_usage_fraction?: number | null;
+  next_limit_window_reset_at?: string | null;
+}
+
 /** The subset of the `HistoryRecord` envelope this view reads. Fields the
  * backend nulls for a redacted record (`repo`, `issue`, `sweepId`) are
  * `null`-able here for exactly that reason. */
@@ -84,6 +102,24 @@ export interface AccountReading {
   /** Epoch ms of `limit_window_reset_at`, when known. */
   limitWindowResetAt?: number;
   exhausted: boolean;
+}
+
+/** One `tokens.snapshot` narrowed from {@link TokenPoolAggregatePayload}: a
+ * host, an instant, and the pool-wide stats — no account identity anywhere.
+ * The public-surface counterpart of {@link TokenSample} (issue #4847). */
+export interface PoolSample {
+  hostId: string;
+  /** Epoch ms — same fallback rule as {@link TokenSample.at}. */
+  at: number;
+  accountCount: number;
+  exhaustedCount: number;
+  /** Mean/peak `usage_fraction` across the accounts that reported one.
+   * Absent — never `0` — when none did. */
+  meanUsageFraction?: number;
+  maxUsageFraction?: number;
+  /** Epoch ms of the earliest limit-window reset across the pool, when any
+   * account reported one. */
+  nextLimitWindowResetAt?: number;
 }
 
 /** A sweep's active window, reconstructed from its lifecycle records. This is

--- a/dashboard/web/test/analyticsApi.test.ts
+++ b/dashboard/web/test/analyticsApi.test.ts
@@ -59,6 +59,32 @@ describe("fetchHistory", () => {
     await expect(fetchHistory({ fetchImpl })).rejects.toThrow("401");
   });
 
+  it("requests the public prefix when surface is public", async () => {
+    const calls: string[] = [];
+    const fetchImpl = vi.fn(async (url: string) => {
+      calls.push(url);
+      return jsonResponse({ records: [], nextCursor: null });
+    }) as unknown as typeof fetch;
+
+    await fetchHistory({ since: T0, surface: "public", fetchImpl });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("/public/history?");
+    expect(calls[0]).not.toContain("/api/");
+  });
+
+  it("defaults to the authenticated prefix when surface is omitted", async () => {
+    const calls: string[] = [];
+    const fetchImpl = vi.fn(async (url: string) => {
+      calls.push(url);
+      return jsonResponse({ records: [], nextCursor: null });
+    }) as unknown as typeof fetch;
+
+    await fetchHistory({ fetchImpl });
+
+    expect(calls[0]).toContain("/api/history?");
+  });
+
   it("drops rows missing the fields every consumer needs", async () => {
     const good = tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]);
     const fetchImpl = vi.fn(async () =>

--- a/dashboard/web/test/analyticsFixtures.ts
+++ b/dashboard/web/test/analyticsFixtures.ts
@@ -84,6 +84,45 @@ export function tokensSnapshot(
   };
 }
 
+export interface PoolFixture {
+  accountCount: number;
+  exhaustedCount?: number;
+  meanUsage?: number;
+  maxUsage?: number;
+  nextResetAt?: number;
+}
+
+/**
+ * One `tokens.snapshot` history envelope in the `/public/history` aggregate
+ * shape (`../../docs/query-api.md`'s "GET /api/history / /public/history"
+ * section) — no `accounts[]` at all, only the pool-wide summary
+ * `../src/redaction.ts`'s `deriveTokenPoolAggregate` computes. `meanUsage` /
+ * `maxUsage` / `nextResetAt` are omitted (serialized as `null`, matching the
+ * backend's own "measured but none reported" contract) when undefined, the
+ * aggregate counterpart of `tokensSnapshot`'s "omit when unknown" convention.
+ */
+export function poolTokensSnapshot(at: number, pool: PoolFixture, hostId = "host-a"): HistoryEnvelope {
+  return {
+    id: nextId++,
+    emittedAt: new Date(at).toISOString(),
+    hostId,
+    kind: "tokens.snapshot",
+    repo: null,
+    visibility: "private",
+    issue: null,
+    sweepId: null,
+    record: {
+      kind: "tokens.snapshot",
+      captured_at: new Date(at).toISOString(),
+      account_count: pool.accountCount,
+      exhausted_count: pool.exhaustedCount ?? 0,
+      mean_usage_fraction: pool.meanUsage ?? null,
+      max_usage_fraction: pool.maxUsage ?? null,
+      next_limit_window_reset_at: pool.nextResetAt !== undefined ? new Date(pool.nextResetAt).toISOString() : null,
+    },
+  };
+}
+
 export interface SweepFixture {
   sweepId: string;
   repo: string;

--- a/dashboard/web/test/analyticsParse.test.ts
+++ b/dashboard/web/test/analyticsParse.test.ts
@@ -1,8 +1,25 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { parseSweepWindows, parseTimestamp, parseTokenSample, parseTokenSamples } from "../src/analytics/parse.js";
+import {
+  parsePoolSample,
+  parsePoolSamples,
+  parseSweepWindows,
+  parseTimestamp,
+  parseTokenSample,
+  parseTokenSamples,
+} from "../src/analytics/parse.js";
 import type { HistoryEnvelope } from "../src/analytics/types.js";
-import { HOUR, MINUTE, T0, at, newestFirst, resetIds, sweepRecords, tokensSnapshot } from "./analyticsFixtures.js";
+import {
+  HOUR,
+  MINUTE,
+  T0,
+  at,
+  newestFirst,
+  poolTokensSnapshot,
+  resetIds,
+  sweepRecords,
+  tokensSnapshot,
+} from "./analyticsFixtures.js";
 
 beforeEach(resetIds);
 
@@ -74,6 +91,75 @@ describe("parseTokenSamples", () => {
       tokensSnapshot(T0 + 2 * MINUTE, [{ account: "agent-1", usage: 0.3 }]),
     ]);
     expect(parseTokenSamples(records).map((sample) => sample.at)).toEqual([T0, T0 + MINUTE, T0 + 2 * MINUTE]);
+  });
+});
+
+describe("parsePoolSample", () => {
+  it("narrows a documented /public/history aggregate payload", () => {
+    const sample = parsePoolSample(
+      poolTokensSnapshot(T0, { accountCount: 13, exhaustedCount: 5, meanUsage: 0.3246, maxUsage: 0.91, nextResetAt: T0 + 6 * HOUR }),
+    );
+
+    expect(sample).toEqual({
+      hostId: "host-a",
+      at: T0,
+      accountCount: 13,
+      exhaustedCount: 5,
+      meanUsageFraction: 0.3246,
+      maxUsageFraction: 0.91,
+      nextLimitWindowResetAt: T0 + 6 * HOUR,
+    });
+  });
+
+  it("keeps null mean/max/reset absent rather than zero", () => {
+    const sample = parsePoolSample(poolTokensSnapshot(T0, { accountCount: 3 }));
+    expect(sample?.meanUsageFraction).toBeUndefined();
+    expect(sample?.maxUsageFraction).toBeUndefined();
+    expect(sample?.nextLimitWindowResetAt).toBeUndefined();
+    expect(sample?.exhaustedCount).toBe(0);
+  });
+
+  it("ignores the per-account shape — it is not the aggregate one", () => {
+    const envelope = tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]);
+    expect(parsePoolSample(envelope)).toBeUndefined();
+  });
+
+  it("ignores non-tokens.snapshot kinds", () => {
+    expect(parsePoolSample(at(sweepRecords({ sweepId: "s1", repo: "o/r", startedAt: T0 }), 0))).toBeUndefined();
+  });
+
+  it("falls back to emittedAt when captured_at is missing", () => {
+    const envelope = poolTokensSnapshot(T0, { accountCount: 1 });
+    delete (envelope.record as Record<string, unknown>).captured_at;
+    expect(parsePoolSample(envelope)?.at).toBe(T0);
+  });
+
+  it("returns undefined for a malformed account_count", () => {
+    const envelope = poolTokensSnapshot(T0, { accountCount: 1 });
+    (envelope.record as Record<string, unknown>).account_count = "nope";
+    expect(parsePoolSample(envelope)).toBeUndefined();
+  });
+
+  it("treats account_count: 0 as a valid, empty aggregate — not malformed", () => {
+    const sample = parsePoolSample(poolTokensSnapshot(T0, { accountCount: 0 }));
+    expect(sample?.accountCount).toBe(0);
+    expect(sample?.exhaustedCount).toBe(0);
+  });
+});
+
+describe("parsePoolSamples", () => {
+  it("returns chronological order even from the API's newest-first pages", () => {
+    const records = newestFirst([
+      poolTokensSnapshot(T0, { accountCount: 2, meanUsage: 0.1 }),
+      poolTokensSnapshot(T0 + MINUTE, { accountCount: 2, meanUsage: 0.2 }),
+      poolTokensSnapshot(T0 + 2 * MINUTE, { accountCount: 2, meanUsage: 0.3 }),
+    ]);
+    expect(parsePoolSamples(records).map((sample) => sample.at)).toEqual([T0, T0 + MINUTE, T0 + 2 * MINUTE]);
+  });
+
+  it("does not pick up per-account-shaped records from a mixed page", () => {
+    const records = [tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }]), poolTokensSnapshot(T0 + MINUTE, { accountCount: 4 })];
+    expect(parsePoolSamples(records)).toHaveLength(1);
   });
 });
 

--- a/dashboard/web/test/burn.test.ts
+++ b/dashboard/web/test/burn.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { buildBurnCurves } from "../src/analytics/burn.js";
-import { parseTokenSamples } from "../src/analytics/parse.js";
-import { HOUR, MINUTE, T0, at, newestFirst, resetIds, tokensSnapshot } from "./analyticsFixtures.js";
+import { buildBurnCurves, buildPoolBurnCurves } from "../src/analytics/burn.js";
+import { parsePoolSamples, parseTokenSamples } from "../src/analytics/parse.js";
+import { HOUR, MINUTE, T0, at, newestFirst, poolTokensSnapshot, resetIds, tokensSnapshot } from "./analyticsFixtures.js";
 
 beforeEach(resetIds);
 
@@ -133,5 +133,83 @@ describe("buildBurnCurves", () => {
       parseTokenSamples([tokensSnapshot(T0, [{ account: "agent-1", usage: 1.4 }])]),
     );
     expect(curves[0]?.points[0]?.usageFraction).toBe(1);
+  });
+});
+
+describe("buildPoolBurnCurves", () => {
+  it("builds one chronological curve per host from the aggregate shape", () => {
+    const curves = buildPoolBurnCurves(
+      parsePoolSamples(
+        newestFirst([
+          poolTokensSnapshot(T0, { accountCount: 5, exhaustedCount: 1, meanUsage: 0.2, maxUsage: 0.5 }),
+          poolTokensSnapshot(T0 + 10 * MINUTE, { accountCount: 5, exhaustedCount: 1, meanUsage: 0.25, maxUsage: 0.55 }),
+        ]),
+      ),
+    );
+
+    expect(curves.map((curve) => curve.hostId)).toEqual(["host-a"]);
+    expect(curves[0]?.points.map((point) => point.meanUsageFraction)).toEqual([0.2, 0.25]);
+    expect(curves[0]?.points.map((point) => point.maxUsageFraction)).toEqual([0.5, 0.55]);
+    expect(curves[0]?.segments).toHaveLength(1);
+    expect(curves[0]?.currentSegment?.startedBy).toBe("initial");
+    expect(curves[0]?.accountCount).toBe(5);
+    expect(curves[0]?.exhaustedCount).toBe(1);
+  });
+
+  it("keeps each host as a separate curve, ordered by hostId", () => {
+    const curves = buildPoolBurnCurves(
+      parsePoolSamples([
+        poolTokensSnapshot(T0, { accountCount: 3, maxUsage: 0.4 }, "host-b"),
+        poolTokensSnapshot(T0, { accountCount: 8, maxUsage: 0.9 }, "host-a"),
+      ]),
+    );
+    expect(curves.map((curve) => curve.hostId)).toEqual(["host-a", "host-b"]);
+  });
+
+  it("starts a new segment at a rollover (peak usage drops)", () => {
+    const curves = buildPoolBurnCurves(
+      parsePoolSamples([
+        poolTokensSnapshot(T0, { accountCount: 4, maxUsage: 0.8, nextResetAt: T0 + HOUR }),
+        poolTokensSnapshot(T0 + 30 * MINUTE, { accountCount: 4, maxUsage: 0.95, nextResetAt: T0 + HOUR }),
+        poolTokensSnapshot(T0 + 70 * MINUTE, { accountCount: 4, maxUsage: 0.05, nextResetAt: T0 + 6 * HOUR }),
+      ]),
+    );
+
+    const curve = at(curves, 0);
+    expect(curve.segments).toHaveLength(2);
+    expect(curve.segments[1]?.startedBy).toBe("window-reset");
+    expect(curve.currentSegment?.points.map((point) => point.maxUsageFraction)).toEqual([0.05]);
+  });
+
+  it("breaks the series across a telemetry gap rather than interpolating it", () => {
+    const curves = buildPoolBurnCurves(
+      parsePoolSamples([
+        poolTokensSnapshot(T0, { accountCount: 4, maxUsage: 0.1 }),
+        poolTokensSnapshot(T0 + 5 * HOUR, { accountCount: 4, maxUsage: 0.6 }),
+      ]),
+    );
+    expect(curves[0]?.segments.map((segment) => segment.startedBy)).toEqual(["initial", "gap"]);
+  });
+
+  it("drops a sample with no usage figure from the plotted points but still tracks the newest account/exhausted counts", () => {
+    const curves = buildPoolBurnCurves(
+      parsePoolSamples([
+        poolTokensSnapshot(T0, { accountCount: 4, exhaustedCount: 0, maxUsage: 0.5 }),
+        poolTokensSnapshot(T0 + 10 * MINUTE, { accountCount: 4, exhaustedCount: 2 }),
+      ]),
+    );
+
+    expect(curves[0]?.points).toHaveLength(1);
+    expect(curves[0]?.exhaustedCount).toBe(2);
+    expect(curves[0]?.accountCount).toBe(4);
+    expect(curves[0]?.latestAt).toBe(T0 + 10 * MINUTE);
+  });
+
+  it("honours a caller-supplied gap tolerance", () => {
+    const samples = parsePoolSamples([
+      poolTokensSnapshot(T0, { accountCount: 2, maxUsage: 0.1 }),
+      poolTokensSnapshot(T0 + 5 * HOUR, { accountCount: 2, maxUsage: 0.6 }),
+    ]);
+    expect(buildPoolBurnCurves(samples, { maxSampleGapMs: 6 * HOUR })[0]?.segments).toHaveLength(1);
   });
 });

--- a/dashboard/web/test/forecast.test.ts
+++ b/dashboard/web/test/forecast.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { buildBurnCurves } from "../src/analytics/burn.js";
-import { forecastAccount, forecastAccounts } from "../src/analytics/forecast.js";
-import { parseTokenSamples } from "../src/analytics/parse.js";
+import { buildBurnCurves, buildPoolBurnCurves } from "../src/analytics/burn.js";
+import { forecastAccount, forecastAccounts, summarizePoolHealth, summarizePoolHealths } from "../src/analytics/forecast.js";
+import { parsePoolSamples, parseTokenSamples } from "../src/analytics/parse.js";
 import type { HistoryEnvelope } from "../src/analytics/types.js";
-import { HOUR, MINUTE, T0, resetIds, tokensSnapshot } from "./analyticsFixtures.js";
+import { HOUR, MINUTE, T0, poolTokensSnapshot, resetIds, tokensSnapshot } from "./analyticsFixtures.js";
 
 beforeEach(resetIds);
 
@@ -214,5 +214,67 @@ describe("forecastAccounts", () => {
     const forecasts = forecastAccounts(curves, { now: T0 + HOUR });
     expect(forecasts.map((forecast) => forecast.account)).toEqual(["agent-1", "agent-2"]);
     expect(forecasts.map((forecast) => forecast.status)).toEqual(["resets-first", "exhausted"]);
+  });
+});
+
+describe("summarizePoolHealth", () => {
+  it("reports the newest sample's counts and usage figures — no projection", () => {
+    const curves = buildPoolBurnCurves(
+      parsePoolSamples([
+        poolTokensSnapshot(T0, { accountCount: 10, exhaustedCount: 1, meanUsage: 0.2, maxUsage: 0.4, nextResetAt: T0 + 4 * HOUR }),
+        poolTokensSnapshot(T0 + HOUR, { accountCount: 10, exhaustedCount: 2, meanUsage: 0.3, maxUsage: 0.6, nextResetAt: T0 + 4 * HOUR }),
+      ]),
+    );
+    const summary = summarizePoolHealth(curves[0]!);
+
+    expect(summary).toEqual({
+      hostId: "host-a",
+      accountCount: 10,
+      exhaustedCount: 2,
+      exhaustedFraction: 0.2,
+      maxUsageFraction: 0.6,
+      meanUsageFraction: 0.3,
+      nextLimitWindowResetAt: T0 + 4 * HOUR,
+    });
+    expect(summary).not.toHaveProperty("projectedExhaustionAt");
+  });
+
+  it("leaves nextLimitWindowResetAt undefined when no sample reported one", () => {
+    const curves = buildPoolBurnCurves(
+      parsePoolSamples([poolTokensSnapshot(T0, { accountCount: 2, maxUsage: 0.3 })]),
+    );
+    expect(summarizePoolHealth(curves[0]!).nextLimitWindowResetAt).toBeUndefined();
+  });
+
+  it("reports exhaustedFraction as undefined, not a divide-by-zero 0, for an empty pool", () => {
+    const curves = buildPoolBurnCurves(parsePoolSamples([poolTokensSnapshot(T0, { accountCount: 0 })]));
+    expect(summarizePoolHealth(curves[0]!).exhaustedFraction).toBeUndefined();
+  });
+
+  it("renders sensibly when exhausted_count is 0", () => {
+    const curves = buildPoolBurnCurves(
+      parsePoolSamples([poolTokensSnapshot(T0, { accountCount: 8, exhaustedCount: 0, maxUsage: 0.3 })]),
+    );
+    const summary = summarizePoolHealth(curves[0]!);
+    expect(summary.exhaustedCount).toBe(0);
+    expect(summary.exhaustedFraction).toBe(0);
+  });
+
+  it("renders sensibly when exhausted_count is close to account_count", () => {
+    const curves = buildPoolBurnCurves(
+      parsePoolSamples([poolTokensSnapshot(T0, { accountCount: 8, exhaustedCount: 7, maxUsage: 1 })]),
+    );
+    const summary = summarizePoolHealth(curves[0]!);
+    expect(summary.exhaustedFraction).toBeCloseTo(0.875, 10);
+  });
+
+  it("summarizePoolHealths preserves curve ordering", () => {
+    const curves = buildPoolBurnCurves(
+      parsePoolSamples([
+        poolTokensSnapshot(T0, { accountCount: 3, maxUsage: 0.4 }, "host-b"),
+        poolTokensSnapshot(T0, { accountCount: 8, maxUsage: 0.9 }, "host-a"),
+      ]),
+    );
+    expect(summarizePoolHealths(curves).map((summary) => summary.hostId)).toEqual(["host-a", "host-b"]);
   });
 });

--- a/dashboard/web/test/render.test.ts
+++ b/dashboard/web/test/render.test.ts
@@ -2,13 +2,23 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   computeTokenAnalytics,
+  DEFAULT_SURFACE,
   mountTokenAnalytics,
   renderTokenAnalytics,
-  REQUIRED_SURFACE,
 } from "../src/analytics/render.js";
 import { currentSurface } from "../src/analytics/bootstrap.js";
 import type { HistoryEnvelope } from "../src/analytics/types.js";
-import { HOUR, MINUTE, T0, at, newestFirst, resetIds, sweepRecords, tokensSnapshot } from "./analyticsFixtures.js";
+import {
+  HOUR,
+  MINUTE,
+  T0,
+  at,
+  newestFirst,
+  poolTokensSnapshot,
+  resetIds,
+  sweepRecords,
+  tokensSnapshot,
+} from "./analyticsFixtures.js";
 
 beforeEach(() => {
   resetIds();
@@ -78,6 +88,24 @@ describe("computeTokenAnalytics", () => {
       "rjwalters/loom",
     ]);
     expect(analytics.sweeps).toHaveLength(2);
+    // The per-account page carries none of the aggregate shape.
+    expect(analytics.poolSamples).toEqual([]);
+    expect(analytics.poolCurves).toEqual([]);
+    expect(analytics.poolHealth).toEqual([]);
+  });
+
+  it("produces pool curves and health from a /public/history-shaped page, and no per-account curves", () => {
+    const records = newestFirst([
+      poolTokensSnapshot(T0, { accountCount: 4, exhaustedCount: 1, meanUsage: 0.3, maxUsage: 0.6 }),
+      poolTokensSnapshot(T0 + 10 * MINUTE, { accountCount: 4, exhaustedCount: 2, meanUsage: 0.4, maxUsage: 0.8 }),
+    ]);
+    const analytics = computeTokenAnalytics(records, { now: NOW });
+
+    expect(analytics.poolCurves.map((curve) => curve.hostId)).toEqual(["host-a"]);
+    expect(analytics.poolHealth).toEqual([
+      { hostId: "host-a", accountCount: 4, exhaustedCount: 2, exhaustedFraction: 0.5, maxUsageFraction: 0.8, meanUsageFraction: 0.4 },
+    ]);
+    expect(analytics.curves).toEqual([]);
   });
 });
 
@@ -196,41 +224,141 @@ describe("renderTokenAnalytics (authenticated surface)", () => {
   });
 });
 
-describe("public-exposure decision", () => {
-  it("defaults to the authenticated surface", () => {
-    expect(REQUIRED_SURFACE).toBe("authenticated");
-  });
+/** The wire shape `/public/history` actually returns for `tokens.snapshot` —
+ * the non-identifying pool aggregate, no `accounts[]` anywhere — plus the
+ * sweep records a public visitor would also see. Mirrors `fixturePage()`'s
+ * two-account, two-repo story so the two surfaces are easy to compare. */
+function publicFixturePage(): HistoryEnvelope[] {
+  return newestFirst([
+    poolTokensSnapshot(T0, { accountCount: 2, exhaustedCount: 0, meanUsage: 0.575, maxUsage: 0.95, nextResetAt: T0 + 8 * HOUR }),
+    poolTokensSnapshot(T0 + 10 * MINUTE, { accountCount: 2, exhaustedCount: 1, meanUsage: 0.605, maxUsage: 1, nextResetAt: T0 + 8 * HOUR }),
+    poolTokensSnapshot(T0 + 20 * MINUTE, { accountCount: 2, exhaustedCount: 1, meanUsage: 0.61, maxUsage: 1, nextResetAt: T0 + 8 * HOUR }),
+  ]);
+}
 
-  it("renders nothing but a withheld notice on the public surface", () => {
+describe("renderTokenAnalytics (public surface)", () => {
+  it("renders the pool-level blocks and the operator-only notice, not the per-account ones", () => {
     const container = mount();
-    const rendered = renderTokenAnalytics(container, computeTokenAnalytics(fixturePage(), { now: NOW }), {
+    const rendered = renderTokenAnalytics(container, computeTokenAnalytics(publicFixturePage(), { now: NOW }), {
       surface: "public",
       now: NOW,
     });
 
-    expect(rendered).toBe(false);
-    expect(container.querySelector('[data-testid="analytics-withheld"]')).not.toBeNull();
+    expect(rendered).toBe(true);
+    expect(container.querySelector('[data-testid="pool-burn"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="pool-health"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="analytics-operator-only-notice"]')).not.toBeNull();
+
     expect(container.querySelector('[data-testid="burn-curves"]')).toBeNull();
     expect(container.querySelector('[data-testid="forecasts"]')).toBeNull();
     expect(container.querySelector('[data-testid="attribution"]')).toBeNull();
-
-    // Neither account identifiers nor repo names reach the DOM.
-    const text = container.textContent ?? "";
-    expect(text).not.toContain("agent-1");
-    expect(text).not.toContain("agent-2");
-    expect(text).not.toContain("rjwalters/loom");
-    expect(text).not.toContain("rjwalters/anvil");
   });
 
-  it("does not even fetch history on the public surface", async () => {
+  it("draws one host card with peak and mean lines from the pool aggregate", () => {
     const container = mount();
-    const fetchImpl = fetchReturning(fixturePage());
+    renderTokenAnalytics(container, computeTokenAnalytics(publicFixturePage(), { now: NOW }), {
+      surface: "public",
+      now: NOW,
+    });
+
+    const card = container.querySelector('.burn-card[data-host="host-a"]');
+    expect(card).not.toBeNull();
+    expect(card?.getAttribute("data-account-count")).toBe("2");
+    expect(card?.getAttribute("data-exhausted-count")).toBe("1");
+    expect(card?.querySelector('[data-testid="pool-exhausted-badge"]')?.textContent).toContain("1/2");
+    // Both lines are drawn: the solid peak line and the dashed mean line.
+    expect(card?.querySelectorAll(".sparkline__line")).toHaveLength(2);
+    expect(card?.querySelectorAll(".sparkline__line--mean")).toHaveLength(1);
+  });
+
+  it("reports pool exhaustion as measured, with no exhaustion ETA anywhere in the DOM", () => {
+    const container = mount();
+    renderTokenAnalytics(container, computeTokenAnalytics(publicFixturePage(), { now: NOW }), {
+      surface: "public",
+      now: NOW,
+    });
+
+    const row = container.querySelector('[data-testid="pool-health"] tr[data-host="host-a"]');
+    expect(row?.textContent).toContain("1 (50.0%)");
+    expect(container.querySelector('[data-testid="pool-forecast-decision"]')?.textContent).toContain(
+      "No exhaustion timing is projected",
+    );
+    // The per-account forecast's vocabulary ("Will exhaust", "Resets first",
+    // a margin) never appears on the public surface.
+    expect(container.textContent).not.toContain("Will exhaust");
+    expect(container.textContent).not.toContain("Resets first");
+    // "Capacity returns" is populated — it names no account, so it is safe
+    // to show even though no per-account ETA is projected.
+    const cells = row?.querySelectorAll("td") ?? [];
+    expect(cells[cells.length - 1]?.textContent).not.toBe("—");
+  });
+
+  it("renders sensibly when exhausted_count is 0", () => {
+    const container = mount();
+    const records = [poolTokensSnapshot(T0, { accountCount: 6, exhaustedCount: 0, maxUsage: 0.3 })];
+    renderTokenAnalytics(container, computeTokenAnalytics(records, { now: NOW }), { surface: "public", now: NOW });
+
+    const row = container.querySelector('[data-testid="pool-health"] tr[data-host="host-a"]');
+    expect(row?.textContent).toContain("0 (0.0%)");
+    expect(row?.classList.contains("row--at-risk")).toBe(false);
+  });
+
+  it("renders sensibly when exhausted_count is close to account_count", () => {
+    const container = mount();
+    const records = [poolTokensSnapshot(T0, { accountCount: 8, exhaustedCount: 7, maxUsage: 1 })];
+    renderTokenAnalytics(container, computeTokenAnalytics(records, { now: NOW }), { surface: "public", now: NOW });
+
+    const row = container.querySelector('[data-testid="pool-health"] tr[data-host="host-a"]');
+    expect(row?.textContent).toContain("7 (87.5%)");
+    expect(row?.classList.contains("row--at-risk")).toBe(true);
+  });
+
+  it("renders an empty-state note instead of an empty pool panel", () => {
+    const container = mount();
+    renderTokenAnalytics(container, computeTokenAnalytics([], { now: NOW }), { surface: "public", now: NOW });
+
+    expect(container.querySelector('[data-testid="pool-burn"]')?.textContent).toContain(
+      "No tokens.snapshot history in range.",
+    );
+    expect(container.querySelector('[data-testid="pool-health"]')?.textContent).toContain("No accounts observed");
+  });
+
+  // Mirrors `redaction.test.ts`'s "no account identifier survives, at any
+  // depth" assertion, but against the rendered public panel's DOM rather
+  // than the wire payload.
+  it("no account identifier reaches the DOM on the public surface, at any depth", () => {
+    const container = mount();
+    const records = newestFirst([
+      poolTokensSnapshot(T0, { accountCount: 2, exhaustedCount: 1, meanUsage: 0.5, maxUsage: 0.95 }),
+      ...sweepRecords({ sweepId: "sweep-issue-1-0", repo: "rjwalters/loom", startedAt: T0, issue: 1 }),
+    ]);
+    renderTokenAnalytics(container, computeTokenAnalytics(records, { now: NOW }), { surface: "public", now: NOW });
+
+    const serialized = container.innerHTML;
+    for (const identifier of ["agent-1", "agent-2", "agent5-2amlogic", "rjwalters/loom", "rjwalters/anvil"]) {
+      expect(serialized).not.toContain(identifier);
+    }
+  });
+});
+
+describe("public-exposure decision", () => {
+  it("defaults to the authenticated surface", () => {
+    expect(DEFAULT_SURFACE).toBe("authenticated");
+  });
+
+  it("issues no request to /api/* when mounting on the public surface", async () => {
+    const container = mount();
+    const fetchImpl = fetchReturning(publicFixturePage());
 
     const analytics = await mountTokenAnalytics(container, { surface: "public", now: NOW, fetchImpl });
 
-    expect(analytics).toBeUndefined();
-    expect(fetchImpl).not.toHaveBeenCalled();
-    expect(container.querySelector('[data-testid="analytics-withheld"]')).not.toBeNull();
+    expect(analytics).toBeDefined();
+    const calls = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(1);
+    const url = String(at(at(calls, 0) as unknown[], 0));
+    expect(url.startsWith("/public/history?")).toBe(true);
+    expect(url).not.toContain("/api/");
+    expect(container.querySelector('[data-testid="pool-burn"]')).not.toBeNull();
   });
 
   it("derives the surface from the server-injected auth state", () => {


### PR DESCRIPTION
## Summary

Implements #4847: the public token/cost analytics panel used to render a
"withheld" notice and make no request at all. Per the 2026-07-31 operator
decision, the signed-in dashboard keeps its per-account detail unchanged;
the public view now charts the pool-level aggregate (`/public/history`'s
non-identifying `tokens.snapshot` shape — `account_count` /
`exhausted_count` / `mean_usage_fraction` / `max_usage_fraction` /
`next_limit_window_reset_at`) instead of hiding the whole panel.

- `analytics/types.ts` / `analytics/parse.ts` — new `TokenPoolAggregatePayload`
  / `PoolSample` shapes and a `parsePoolSample`/`parsePoolSamples` narrowing
  pair, disjoint from and coexisting with the existing per-account parser.
- `analytics/burn.ts` — `buildPoolBurnCurves`: one curve per host (no
  account key — the aggregate names none), mean/peak usage over time,
  segmented at rollovers and telemetry gaps the same way the per-account
  curves are.
- `analytics/forecast.ts` — `summarizePoolHealth`: a deliberate decision
  **not** to project an exhaustion ETA from the pool mean (a mean can hide
  one account about to exhaust); instead reports exhaustion state as
  measured (`exhausted_count`, `max_usage_fraction`, `next reset`).
- `analytics/render.ts` — renders the pool-level burn/health blocks on a
  `"public"` surface instead of the old full-panel withheld notice; a
  smaller notice now names only the two blocks that stay operator-only
  (per-repo attribution, per-account forecasts — unchanged, out of scope).
- `analytics/api.ts` — `fetchHistory` takes an explicit `surface` option
  (`/api/history` vs `/public/history`); `mountTokenAnalytics` always
  requests the surface it renders, so the public panel never hits `/api/*`.
- `docs/token-analytics.md` — public-exposure section updated to record the
  new decision and its rationale.

## Test plan

- [x] `analyticsParse.test.ts` — `parsePoolSample`/`parsePoolSamples`: wire
  narrowing, "unknown != zero", disjoint from the per-account shape.
- [x] `burn.test.ts` — `buildPoolBurnCurves`: per-host curves, rollover/gap
  segmentation, "unknown != zero" for a sample with no usage figure.
- [x] `forecast.test.ts` — `summarizePoolHealth`: no projection field,
  `exhaustedCount: 0` and "close to accountCount" edge cases,
  `exhaustedFraction: undefined` for an empty pool.
- [x] `render.test.ts` — new `renderTokenAnalytics (public surface)` suite:
  pool blocks render instead of per-account ones; a redaction-style test
  walks the rendered DOM's `innerHTML` and asserts no account identifier
  survives at any depth; `mountTokenAnalytics` on the public surface issues
  exactly one request, to `/public/history`, never `/api/*`.
- [x] `npx tsc --noEmit` and `npx vitest run` pass in both `dashboard/` and
  `dashboard/web/` (371 web tests, 156 backend tests — backend untouched,
  confirmed green).
- [ ] Manual: the panel is not yet wired into `index.html`/`app.ts` (that
  wiring belongs to #4749/#4753, out of scope here per the issue's
  "Affected files" list) — verified at the module/render level instead.

Closes #4847