### PR TITLE
fix(daemon): publish Event::SweepPhase on sampled checkpoint phase transitions

### DIFF
--- a/defaults/docs/telemetry-schema.md
+++ b/defaults/docs/telemetry-schema.md
@@ -156,6 +156,21 @@ A sweep advanced to a new lifecycle phase (mirrors `sweep.issue.{N}.phase`).
 
 `phase` is a lifecycle name: `curator`, `builder`, `judge`, `doctor`, `merge`.
 
+**Source and cadence (#4863)**: `Event::SweepPhase` — the record's only upstream —
+is published by `SweepRegistry::sample_phase_transition`, which the reaper calls
+once per live sweep per `reap_once` tick (the 30s reaper timer, plus every
+read-path reap). It reads `.loom/sweep-checkpoint/issue-<N>.json` and publishes
+**only when the phase changed since the previous tick**, so a sweep sitting in a
+phase emits nothing further. The checkpoint's raw marker (`curator-done`,
+`judge-rejected`) is normalized to the lifecycle vocabulary above before it is
+published; an unrecognized marker passes through verbatim rather than being
+guessed at, so `phase` should be read as "one of the five names, or an unknown
+raw marker" — which is exactly how the dashboard types it
+(`SweepPhaseName | string`).
+
+Because the phase is polled rather than pushed, `entered_at` is the daemon's
+*observation* instant, an honest upper bound on the real transition time.
+
 ### `sweep.completed`
 
 A sweep reached a terminal state (the summary moment; richer detail is in the

--- a/loom-daemon/src/observability/collector.rs
+++ b/loom-daemon/src/observability/collector.rs
@@ -55,8 +55,10 @@ use super::queue::DurableQueue;
 const SLUG_FETCH_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// In-flight sweep state tracked purely in memory (see module docs).
+/// `pub(crate)` only because it appears in [`map_event_to_records`]'s signature
+/// (#4863) — it is not part of any cross-module contract.
 #[derive(Debug, Clone)]
-struct DispatchState {
+pub(crate) struct DispatchState {
     sweep_id: String,
     started_at: DateTime<Utc>,
 }
@@ -188,7 +190,13 @@ fn event_repo_path(event: &Event) -> Option<String> {
 /// `repo` slug and `visibility`. Returns zero, one, or two records — a
 /// terminal event yields both a `sweep.completed` record (mirrors the frozen
 /// SSE moment) and the richer `sweep.outcome` record.
-fn map_event_to_records(
+///
+/// `pub(crate)` so the registry's own emit-site tests (#4863) can drive a
+/// *genuinely emitted* [`Event::SweepPhase`] through this mapping end-to-end
+/// instead of asserting against a hand-built event fixture — the exact gap that
+/// let `sweep.phase` be defined, mapped, and unit-tested here while never being
+/// published by production code.
+pub(crate) fn map_event_to_records(
     event: &Event,
     issue: u32,
     repo: &str,

--- a/loom-daemon/src/sweep_registry/outcome_journal.rs
+++ b/loom-daemon/src/sweep_registry/outcome_journal.rs
@@ -306,6 +306,21 @@ impl SweepRegistry {
     /// terminal record carry the sweep's own PR **without** a forge round trip
     /// — including for a successful sweep, whose checkpoint is deleted before
     /// the record is written.
+    ///
+    /// # Bus emission (Issue #4863)
+    ///
+    /// Every *newly observed* transition also publishes [`Event::SweepPhase`]
+    /// on the attached bus — the only production emit site for that variant, and
+    /// therefore the only source of the `sweep.phase` telemetry record the
+    /// observability collector maps it to. It lives **here**, rather than in
+    /// [`overlay_live_phase`](Self::overlay_live_phase), precisely because this
+    /// function already dedupes against `phase_history`: the checkpoint is
+    /// re-read on every tick, so an unguarded emit would republish the same
+    /// phase for the whole time a sweep sits in it and flood the bus (and D1).
+    /// The published `phase` is the **normalized** lifecycle name
+    /// ([`phase_label`] — `"curator-done"` → `"curator"`), matching the
+    /// `sweep.phase` schema's documented `curator|builder|judge|doctor|merge`
+    /// vocabulary, while the stored [`PhaseObservation`] keeps the raw marker.
     pub(crate) fn sample_phase_transition(
         &mut self,
         sweep_id: &str,
@@ -342,9 +357,18 @@ impl SweepRegistry {
             return;
         }
         history.push(PhaseObservation {
-            phase,
+            phase: phase.clone(),
             at: Utc::now(),
             pr_number,
+        });
+        // Genuine transition — publish it (see the "Bus emission" doc section
+        // above). Ordered after the history push so the dedupe state is already
+        // committed even if a subscriber panics on delivery.
+        self.emit_event(Event::SweepPhase {
+            issue: *issue,
+            phase: phase_label(&phase).to_string(),
+            pr_number: pr_number.and_then(|n| i32::try_from(n).ok()),
+            repo: None, // stamped by emit_event (#3929)
         });
     }
 
@@ -930,5 +954,181 @@ mod tests {
         // No known suffix ⇒ passed through verbatim.
         assert_eq!(phase_label("some-future-phase"), "some-future-phase");
         assert_eq!(phase_label("curator"), "curator");
+    }
+
+    // ------------------------------------------------------------------------
+    // `Event::SweepPhase` bus emission (Issue #4863)
+    // ------------------------------------------------------------------------
+
+    /// Drive `n` reaper ticks and drain every `Event::SweepPhase` the registry
+    /// published, returning the phase strings in emission order.
+    async fn drain_phase_events(sub: &mut crate::event_bus::Subscription) -> Vec<String> {
+        let mut phases = Vec::new();
+        while let Ok(recv) = tokio::time::timeout(Duration::from_millis(250), sub.recv()).await {
+            match recv {
+                Ok(Event::SweepPhase { phase, .. }) => phases.push(phase),
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+        phases
+    }
+
+    /// AC (#4863): a live sweep advancing through phases publishes exactly ONE
+    /// `sweep.issue.{N}.phase` event per transition — and republishes nothing
+    /// on the ticks where it sits in the same phase. The dedupe matters as much
+    /// as the emission: `reap_once` re-reads the checkpoint every tick (every
+    /// 30s, plus every read-path reap), so an unguarded emit would republish
+    /// the same phase for the sweep's entire residence in it.
+    #[tokio::test]
+    async fn phase_transitions_publish_one_sweep_phase_event_each() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _rec) = fixture_registry(dir.path());
+        let bus = Arc::new(crate::event_bus::EventBus::new());
+        registry.set_event_bus(bus.clone());
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        let issue = 4863;
+        let started_at = Utc::now() - Duration::from_secs(60);
+        // A live-looking pid, so `reap_once` samples the phase without reaping
+        // the entry — the real shape of a mid-flight sweep.
+        let _sweep_id = insert_running_at(&mut registry, issue, 0, started_at);
+
+        write_checkpoint_with_mtime(&registry, issue, "curator-done", SystemTime::now());
+        registry.reap_once();
+        // Two more ticks with the checkpoint unchanged: the sweep is still in
+        // the same phase, so these must publish nothing.
+        registry.reap_once();
+        registry.reap_once();
+        write_checkpoint_with_mtime(&registry, issue, "builder-done", SystemTime::now());
+        registry.reap_once();
+        registry.reap_once();
+
+        assert_eq!(
+            drain_phase_events(&mut sub).await,
+            vec!["curator".to_string(), "builder".to_string()],
+            "one event per transition, none while the sweep sits in a phase"
+        );
+    }
+
+    /// AC (#4863): the emitted `phase` agrees with the `sweep.phase` schema's
+    /// vocabulary (`curator|builder|judge|doctor|merge`) rather than carrying
+    /// the raw checkpoint marker (`"judge-rejected"`), which is what the
+    /// dashboard's `SweepPhaseName` renders.
+    #[tokio::test]
+    async fn emitted_phase_uses_the_schema_lifecycle_vocabulary() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _rec) = fixture_registry(dir.path());
+        let bus = Arc::new(crate::event_bus::EventBus::new());
+        registry.set_event_bus(bus.clone());
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        let issue = 4864;
+        let started_at = Utc::now() - Duration::from_secs(60);
+        insert_running_at(&mut registry, issue, 0, started_at);
+
+        for marker in ["judge-rejected", "doctor-done", "merge-done"] {
+            write_checkpoint_with_mtime(&registry, issue, marker, SystemTime::now());
+            registry.reap_once();
+        }
+
+        assert_eq!(
+            drain_phase_events(&mut sub).await,
+            vec![
+                "judge".to_string(),
+                "doctor".to_string(),
+                "merge".to_string()
+            ]
+        );
+    }
+
+    /// AC (#4863), end-to-end: a REAL phase transition — not a hand-built
+    /// `Event::SweepPhase` fixture — produces a `sweep.phase` record on the
+    /// durable telemetry queue via the observability collector's own
+    /// event→record mapping. This is the link that was missing: every piece of
+    /// the pipeline below was already correct and unit-tested, but nothing
+    /// upstream ever published the event that feeds it.
+    #[tokio::test]
+    async fn a_real_phase_transition_reaches_the_telemetry_queue() {
+        use crate::observability::queue::DurableQueue;
+        use crate::telemetry::{RepoVisibility, TelemetryEnvelope, TelemetryRecord};
+
+        let dir = tempdir().unwrap();
+        let (mut registry, _rec) = fixture_registry(dir.path());
+        let bus = Arc::new(crate::event_bus::EventBus::new());
+        registry.set_event_bus(bus.clone());
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        let issue = 4865;
+        let started_at = Utc::now() - Duration::from_secs(60);
+        let sweep_id = insert_running_at(&mut registry, issue, 0, started_at);
+
+        write_checkpoint_with_mtime(&registry, issue, "builder-done", SystemTime::now());
+        registry.reap_once();
+
+        let event = loop {
+            let recv = tokio::time::timeout(Duration::from_secs(5), sub.recv())
+                .await
+                .expect("a phase transition must publish an event");
+            match recv.unwrap() {
+                ev @ Event::SweepPhase { .. } => break ev,
+                _ => continue,
+            }
+        };
+        // The registry stamps its owning workspace root (#3929) on the way out.
+        match &event {
+            Event::SweepPhase { repo, .. } => assert_eq!(
+                repo.as_deref(),
+                Some(
+                    registry
+                        .config()
+                        .workspace_root
+                        .display()
+                        .to_string()
+                        .as_str()
+                )
+            ),
+            other => panic!("expected SweepPhase, got {other:?}"),
+        }
+
+        // Same mapping the collector task applies to every bus event, with the
+        // dispatch state a live daemon would already hold for this sweep.
+        let mut dispatches = HashMap::new();
+        crate::observability::collector::map_event_to_records(
+            &Event::SweepGlobalDispatch {
+                sweep_id: sweep_id.clone(),
+                kind: SweepKind::Issue(issue),
+                runtime: None,
+                runtime_source: None,
+                repo: None,
+            },
+            issue,
+            "rjwalters/loom",
+            RepoVisibility::Public,
+            &mut dispatches,
+        );
+        let records = crate::observability::collector::map_event_to_records(
+            &event,
+            issue,
+            "rjwalters/loom",
+            RepoVisibility::Public,
+            &mut dispatches,
+        );
+
+        let queue = DurableQueue::open(dir.path().join("telemetry-queue.jsonl"), 64);
+        for record in records {
+            queue.push(TelemetryEnvelope::new("host-test", record));
+        }
+
+        assert_eq!(queue.len(), 1, "exactly one sweep.phase record queued");
+        match &queue.peek_batch(1)[0].record {
+            TelemetryRecord::SweepPhase(r) => {
+                assert_eq!(r.issue, issue);
+                assert_eq!(r.phase, "builder");
+                assert_eq!(r.sweep_id, sweep_id);
+                assert_eq!(r.repo, "rjwalters/loom");
+            }
+            other => panic!("expected a SweepPhase record on the queue, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

`Event::SweepPhase` had **no production construction site** — every occurrence in
the tree was a test fixture (`serve.rs:1516`/`1680`, `types.rs:2282`+). The
downstream pipeline was already complete and unit-tested (collector mapping,
`SweepPhaseRecord`, redaction allowlist, dashboard rendering), but because
nothing upstream ever published the event, `sweep.phase` was a permanently empty
stream: `activeSweeps[].phase` was always `null` and every dashboard sweep
rendered as "starting" forever, on every host.

The daemon *did* know the phase — `SweepRegistry::sample_phase_transition`
samples the on-disk sweep checkpoint once per live sweep per `reap_once` tick —
it just kept that knowledge in memory (`phase_history`, `loom-daemon status`,
the outcome journal) and never published it.

This PR publishes `Event::SweepPhase` from that sampler.

## Changes

- **`loom-daemon/src/sweep_registry/outcome_journal.rs`** — `sample_phase_transition`
  now publishes `Event::SweepPhase { issue, phase, pr_number, repo }` via
  `emit_event` on each **newly observed** transition.
  - **Emit site choice**: this function already dedupes against `phase_history`.
    The checkpoint is re-read on *every* tick (the 30s reaper timer plus every
    read-path reap via `ListSweeps`/`GetSweepStatus`), so emitting from
    `overlay_live_phase` — or unguarded here — would republish the same phase for
    a sweep's entire residence in it and flood the bus and D1. Ordered after the
    history push so the dedupe state is committed even if a subscriber panics.
  - **Vocabulary**: the published `phase` is normalized through the existing
    `phase_label` (`"curator-done"` -> `"curator"`, `"judge-rejected"` -> `"judge"`),
    so the wire value matches the schema's documented
    `curator|builder|judge|doctor|merge`. The stored `PhaseObservation` keeps the
    raw marker, so the `sweep.outcome` per-phase breakdown is unchanged.
  - `repo: None` — stamped by `emit_event` from `config.workspace_root` (#3929),
    which is what lets the collector resolve the emitting repo's slug.
  - `pr_number` is carried through as `Option<i32>` via a checked conversion.
- **`loom-daemon/src/observability/collector.rs`** — `map_event_to_records` and
  `DispatchState` widened to `pub(crate)` so the registry's emit-site test can
  drive a *genuinely emitted* event through the real mapping. No behavior change.
- **`defaults/docs/telemetry-schema.md`** — documents the emit source, the
  transition-only cadence, the normalization rule, and that `entered_at` is an
  observation instant (polled source), not the true transition time.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| One `sweep.phase` record per transition, no duplicates while sitting in a phase | Yes | New `phase_transitions_publish_one_sweep_phase_event_each`: 5 `reap_once` ticks over 2 checkpoint changes (with 3 no-change ticks interleaved) drain exactly `["curator", "builder"]` off the bus |
| `activeSweeps[].phase` tracks the sweep's real phase | Yes | The DO's `sweep.phase` handler (`dashboard/src/fleetState.ts:130`) sets `phase` from the record; the record now exists. End-to-end covered by `a_real_phase_transition_reaches_the_telemetry_queue` |
| Per-sweep timeline (#4750) shows real data | Yes | `timelineBuilder.ts` aggregates `sweep.phase` records for a `sweep_id`; the same test asserts the queued record carries the dispatch-correlated `sweep_id`, not just the synthesized fallback |
| Emitted `phase` agrees with the schema vocabulary | Yes | New `emitted_phase_uses_the_schema_lifecycle_vocabulary`: markers `judge-rejected`/`doctor-done`/`merge-done` publish as `judge`/`doctor`/`merge` |
| Redaction suite still retains a private sweep's phase while stripping repo/issue/sweep_id | Yes | `dashboard/test/redaction.test.ts` unchanged and green — 41/41 pass, including "sweep.phase: keeps phase/entered_at, strips repo/issue/sweep_id" |
| Integration test uses a real transition, not a synthetic event | Yes | `a_real_phase_transition_reaches_the_telemetry_queue` builds a live registry, writes a checkpoint, calls `reap_once`, receives the event **off the bus**, and pushes it through `map_event_to_records` onto a `DurableQueue` |

## Test Plan

- `cargo test -p loom-daemon --lib sweep_registry::outcome_journal` — 18/18 pass
  (15 pre-existing + 3 new).
- `cargo test -p loom-daemon --lib` — 2956 passed, 9 failed. All 9 failures are
  **pre-existing and environment-dependent** (`work_finder`/`auto_update`
  "missing config file" tests pick up this host's user-level `~/.loom/config.json`);
  verified identical failures on `origin/main` in the primary checkout. None
  touch the changed code.
- `cargo test -p loom-daemon --bins` (65 pass), `cargo test -p loom-api --bins` (4 pass).
- `cargo check`, `cargo clippy -p loom-daemon --lib`, `cargo fmt --all -- --check` — all clean.
- `npx vitest run test/redaction.test.ts` in `dashboard/` — 41/41 pass.

## Pre-existing Issues (Not Addressed)

- `cargo clippy --all-targets` fails on `loom-daemon/src/terminal.rs:2590`
  (`unnecessary_get_then_check` — `tm.terminals.get("ghost").is_none()`). Present
  on `origin/main`, unrelated to this change, left alone for scope.
- The collector's in-memory `issue -> sweep_id` correlation resets across a
  daemon restart (documented in its module header). A sweep already in flight
  when the daemon restarts will emit its phase records under the synthesized
  `unknown-issue-{N}` id, which the Durable Object keys as a separate active
  sweep. That is pre-existing collector behavior affecting `sweep.started` and
  `sweep.completed` equally; worth a follow-up issue rather than widening this PR.

Closes #4863