### PR TITLE
fix(daemon): KillMode=mixed so a self-update relaunch survives the systemd timeout-vs-success race

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -4268,6 +4268,7 @@ disable-on-stop. The contract mirrors launchd point-for-point:
 |---|---|
 | `RunAtLoad=true` + `launchctl enable` (#3972) | `[Install] WantedBy=default.target` + `systemctl --user enable` |
 | `KeepAlive:{SuccessfulExit:true}` — relaunch only on a clean exit `0` (#4054) | `Restart=on-success` — relaunch only on a clean exit `0` (exact analog; a crash / operator SIGTERM/SIGINT exits non-zero and stays down) |
+| (no cgroup-timeout reclassification of a clean exit — not applicable) | `KillMode=mixed` (#4862) — without it, a clean exit(0) with lingering cgroup children (in-flight `claude`/`tee`/`sleep` sweep workers) gets reclassified `Result=timeout` by the default `control-group` mode once `TimeoutStopSec` elapses, and `Restart=on-success` does not match `timeout` — so the relaunch silently never fires. `mixed` escalates the leftover-process SIGKILL sweep on the *main process's own exit*, not after `TimeoutStopSec`, so the unit's `Result` tracks the main process's exit status |
 | `launchctl bootout` on operator stop | `systemctl --user disable --now <unit>` |
 | plist `EnvironmentVariables` (`LOOM_DAEMON_SUPERVISOR=launchd`, forwarded `LOOM_*`/tokens, deterministic PATH #4172) | `Environment=` lines (`LOOM_DAEMON_SUPERVISOR=systemd`, same forwarded env + PATH) |
 | `WorkingDirectory` = checkout in machine mode (#4229), else repo root | `WorkingDirectory=` — same resolution |
@@ -4310,7 +4311,11 @@ disable-on-stop. The contract mirrors launchd point-for-point:
   On a systemd host it is delivered by the `<unit>-watchdog.timer` +
   `Type=oneshot` `.service` pair (#4260 sub-issue D, "Autonomy-loss watchdog +
   heartbeat" above), mirroring the macOS `StartInterval` autonomy-loss watchdog
-  (#4011) — the watchdog *reports* divergence, it does not restart the daemon.
+  (#4011) — the watchdog mostly *reports* divergence, except for the narrow
+  #4232/#4862 auto-remediation gates (unit LOADED + not running + a clean
+  `ExecMainStatus=0`, mirroring `launchctl kickstart`), which run `systemctl
+  --user reset-failed <unit> && systemctl --user start <unit>` — never for a
+  crash or an operator stop.
 
 ### macOS TCC hygiene under launchd (#3980)
 

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -581,6 +581,15 @@ render_launchd_plist() {
     # KeepAlive:SuccessfulExit=true (#4054): relaunch ONLY on a clean exit 0 (the
     # RestartDaemon primitive). A crash/SIGTERM/SIGINT exits non-zero and is NOT
     # respawned -- preserving the pre-#4054 no-crash-loop semantics of KeepAlive=false.
+    # #4862 NOTE: launchd's KeepAlive:{SuccessfulExit:true} has the SAME "was the
+    # exit clean" dependency as systemd's Restart=on-success (see
+    # render_systemd_unit's KillMode=mixed fix above), but launchd has no
+    # documented cgroup-timeout reclassification of a clean exit into a
+    # failure -- there is no launchd analog of systemd's kill(5) Result=timeout
+    # escalation. Not reproduced/fixed here (#4862 scoped its systemd-only
+    # incident); if a launchd analog ever surfaces, audit whether lingering
+    # `claude`/`tee`/`sleep` children under this job's ProcessType=Background
+    # can flip SuccessfulExit's observed exit status before filing a follow-up.
     printf '    <key>KeepAlive</key>\n    <dict>\n        <key>SuccessfulExit</key>\n        <true/>\n    </dict>\n'
     printf '    <key>ProcessType</key>\n    <string>Background</string>\n'
     printf '    <key>StandardOutPath</key>\n    <string>%s</string>\n' "$(xml_escape "$log_path")"
@@ -603,6 +612,26 @@ render_launchd_plist() {
 #     semantics while making the one deliberate clean exit the only relaunch
 #     trigger. Crash relaunch (Restart=always/on-failure) is deliberately NOT set
 #     here -- that is watchdog territory (sub-issue D of #4260).
+#   * KillMode=mixed (#4862): a self-update relaunch calls exit(0) while the
+#     daemon's own `claude`/`tee`/`sleep` worker children (spawned sweeps, in
+#     the SAME cgroup) may still be running. Under the default KillMode=
+#     control-group, systemd's kill(5) escalates to SIGKILLing those leftover
+#     processes only after the FULL TimeoutStopSec deadline elapses -- and a
+#     forced-timeout SIGKILL sets the UNIT's Result to 'timeout', which
+#     Restart=on-success does NOT match (only 'success' does -- see the
+#     Restart= table in systemd.service(5)), so the relaunch never fires and
+#     the daemon sits dead. Empirically verified (see #4862): a clean exit(0)
+#     with lingering cgroup children reproduces Result=timeout under
+#     control-group and Result=success (Restart=on-success DOES fire) under
+#     mixed. Per kill(5): "If set to mixed, the SIGTERM signal is sent to the
+#     main process while the subsequent SIGKILL signal is sent to all
+#     remaining processes... after: the main process of a unit has exited
+#     (applies to KillMode=: mixed)" -- i.e. mixed escalates to SIGKILL
+#     IMMEDIATELY on the main process's own exit, never waiting out
+#     TimeoutStopSec, so the unit's Result tracks the main process's own exit
+#     status. This does not change genuine-crash semantics (still Result=
+#     exit-code / signal, still refused by on-success) -- verified with both
+#     shapes in test-loom-daemon-start.sh.
 #   * [Install] WantedBy=default.target + `systemctl --user enable` is the
 #     RunAtLoad=true analog: the service comes up on login (and, with
 #     `loginctl enable-linger`, after a reboot).
@@ -654,6 +683,12 @@ render_systemd_unit() {
     # clean exit 0 (the RestartDaemon primitive) trips a relaunch; a crash / an
     # operator SIGTERM/SIGINT exits non-zero and stays down.
     printf 'Restart=on-success\n'
+    # KillMode=mixed (#4862): see the render_systemd_unit doc comment above for
+    # the full kill(5)-sourced rationale -- without this, a clean exit(0) with
+    # lingering `claude`/`tee`/`sleep` worker children in the cgroup gets
+    # reclassified as Result=timeout (control-group's default forced-SIGKILL-
+    # after-TimeoutStopSec path) and Restart=on-success never fires.
+    printf 'KillMode=mixed\n'
     printf '%b' "$env_lines"
     printf 'StandardOutput=append:%s\n' "$log_path"
     printf 'StandardError=append:%s\n' "$log_path"
@@ -671,9 +706,14 @@ render_systemd_unit() {
 # reads it to decide whether a missing daemon is a silent failure (marker present
 # ⇒ report) or a deliberate stop (marker absent ⇒ stay silent). Records the paths
 # and label the watchdog needs so it can probe reality without re-deriving them.
-# Args: <use_launchd true|false> <launchd_label>
+# Args: <use_launchd true|false> <launchd_label> [use_systemd true|false] [systemd_unit]
+# #4862: use_systemd/systemd_unit are new, OPTIONAL trailing fields (default
+# false/"") so the watchdog can tell a systemd-supervised daemon apart from the
+# plain-nohup fallback -- both previously wrote identical `use_launchd=false`
+# markers, leaving the watchdog with no way to probe `systemctl --user` for the
+# #4232-style bounded auto-remediation gate (see loom-daemon-watchdog.sh).
 write_intent_marker() {
-    local use_launchd="$1" label="$2"
+    local use_launchd="$1" label="$2" use_systemd="${3:-false}" systemd_unit="${4:-}"
     mkdir -p "$LOOM_DIR" 2>/dev/null || true
     (
         umask 077
@@ -690,6 +730,8 @@ heartbeat_file=$HEARTBEAT_FILE
 heartbeat_interval_secs=$HEARTBEAT_INTERVAL_SECS
 use_launchd=$use_launchd
 launchd_label=$label
+use_systemd=$use_systemd
+systemd_unit=$systemd_unit
 socket_path=$SOCKET_PATH
 EOF
     )
@@ -886,11 +928,30 @@ provision_watchdog_job_launchd() {
     wd_interval="${LOOM_WATCHDOG_INTERVAL_SECS:-300}"
     wd_log="$LOOM_DIR/logs/daemon-watchdog.log"
     mkdir -p "$HOME/Library/LaunchAgents" "$LOOM_DIR/logs" 2>/dev/null || true
-    if ! render_watchdog_plist "$wd_label" "$script" "$REPO_ROOT" "$wd_log" "$wd_interval" > "$wd_plist" 2>/dev/null; then
+    local wd_plist_new; wd_plist_new="$(mktemp "${TMPDIR:-/tmp}/loom-watchdog-plist.XXXXXX" 2>/dev/null)" || wd_plist_new=""
+    if [[ -z "$wd_plist_new" ]] || ! render_watchdog_plist "$wd_label" "$script" "$REPO_ROOT" "$wd_log" "$wd_interval" > "$wd_plist_new" 2>/dev/null; then
         warn "watchdog: could not write $wd_plist — skipping."
+        rm -f "$wd_plist_new" 2>/dev/null || true
         return 0
     fi
-    if launchctl print "$wd_service" >/dev/null 2>&1; then
+    local wd_job_loaded=false
+    launchctl print "$wd_service" >/dev/null 2>&1 && wd_job_loaded=true
+    # #4862 double-fire fix: RunAtLoad=true means EVERY bootout+bootstrap cycle
+    # fires an extra immediate run, on top of the regular StartInterval cadence.
+    # provision_watchdog_job_launchd runs on EVERY loom-daemon-start.sh
+    # invocation (every daemon start, restart, AND self-update relaunch) -- so
+    # unconditionally re-bootstrapping here duplicated a run each time,
+    # independent of the watchdog's own schedule. Skip the reload cycle
+    # entirely when the job is already loaded and the rendered plist is
+    # byte-identical to what's installed -- nothing to apply, so no reason to
+    # trigger RunAtLoad again.
+    if [[ "$wd_job_loaded" == "true" ]] && cmp -s "$wd_plist_new" "$wd_plist" 2>/dev/null; then
+        rm -f "$wd_plist_new" 2>/dev/null || true
+        echo "Watchdog:       $wd_label (StartInterval ${wd_interval}s) → $wd_log (unchanged, already loaded — skipped reload)"
+        return 0
+    fi
+    mv -f "$wd_plist_new" "$wd_plist" 2>/dev/null || { warn "watchdog: could not install $wd_plist — skipping."; rm -f "$wd_plist_new" 2>/dev/null || true; return 0; }
+    if [[ "$wd_job_loaded" == "true" ]]; then
         launchctl bootout "$wd_service" >/dev/null 2>&1 || true
     fi
     if launchctl bootstrap "$wd_domain" "$wd_plist" >/dev/null 2>&1; then
@@ -982,6 +1043,14 @@ provision_watchdog_job_systemd() {
         warn "watchdog: could not write $timer_path — skipping."
         return 0
     fi
+    # #4862: unlike the launchd branch above (which must guard against
+    # re-provisioning triggering an extra RunAtLoad run), `systemctl --user
+    # enable --now` on an ALREADY ACTIVE timer is a no-op job that does NOT
+    # re-trigger OnBootSec/re-run the service -- empirically verified (#4862):
+    # two consecutive `enable --now` calls against the same active timer with
+    # an already-elapsed OnBootSec produced exactly one execution, not two. So
+    # re-running this on every daemon start/relaunch is safe as-is; no
+    # unchanged-content guard needed here.
     systemctl --user daemon-reload >/dev/null 2>&1 || true
     if systemctl --user enable --now "$timer_unit" >/dev/null 2>&1; then
         echo "Watchdog:       $timer_unit (OnUnitActiveSec ${wd_interval}s) → $wd_log"
@@ -1607,8 +1676,10 @@ if [[ "$IS_LINUX_SYSTEMD" == "true" ]]; then
     # both write: same path, same pid, and the daemon's write is atomic.
     echo "$daemon_pid" > "$PID_FILE"
     # Record operator intent + arm the systemd-timer autonomy-loss watchdog
-    # (#4011, #4260 sub-issue D).
-    write_intent_marker "false" ""
+    # (#4011, #4260 sub-issue D). use_systemd=true + the resolved unit name
+    # (#4862) let the watchdog probe `systemctl --user` for its own bounded
+    # auto-remediation gate, mirroring the launchd job_loaded/kickstart path.
+    write_intent_marker "false" "" "true" "$SYSTEMD_UNIT"
     provision_watchdog_job_systemd
     ok "loom-daemon started under systemd (pid $daemon_pid, unit $SYSTEMD_UNIT)."
     echo "PID file: $PID_FILE"

--- a/defaults/scripts/cli/loom-daemon-watchdog.sh
+++ b/defaults/scripts/cli/loom-daemon-watchdog.sh
@@ -106,11 +106,21 @@
 #   report-only, exactly as before: no crash-loop revival, no reviving a
 #   deliberate stop.
 #
-# EXIT CODES (a StartInterval job's exit code does not affect relaunch — these
-# exist for testability and for a human running it by hand):
+#   #4862 adds the systemd --user mirror of this gate: a clean main-process
+#   exit (ExecMainCode=exited, ExecMainStatus=0) with the unit LOADED but not
+#   running auto-runs 'systemctl --user reset-failed <unit> && systemctl
+#   --user start <unit>' — the systemd analog of 'launchctl kickstart', for
+#   the exact "Restart=on-success didn't fire" incident #4862 reported (and
+#   the render_systemd_unit KillMode=mixed fix in loom-daemon-start.sh
+#   addresses at the source). Same narrow construction: an operator stop, a
+#   genuine crash, or a never-installed unit cannot produce this signature.
+#
+# EXIT CODES (a StartInterval/OnUnitActiveSec job's exit code does not affect
+# relaunch — these exist for testability and for a human running it by hand):
 #   0  no divergence — daemon healthy, OR no daemon expected AND none running
-#      (marker absent + nothing alive), OR the #4232 bounded auto-remediation
-#      (see above) successfully relaunched it via 'launchctl kickstart'
+#      (marker absent + nothing alive), OR the #4232/#4862 bounded
+#      auto-remediation (see above) successfully relaunched it via
+#      'launchctl kickstart' / 'systemctl --user start'
 #   1  DIVERGENCE / state mismatch reported — a daemon is expected but is not
 #      running (and either the #4232 remediation gate did not apply, or it fired
 #      but the daemon is still not confirmed running), or is running but its
@@ -136,8 +146,15 @@
 #   LOOM_LAUNCHD_DOMAIN          macOS: pin the launchd domain (gui/<uid> or user/<uid>);
 #                                else auto-resolved gui→user (#4130), matching the start
 #   LOOM_DAEMON_LAUNCHD          0/false/no: treat as a non-launchd (nohup) daemon; check the pid file only
-#   LOOM_WATCHDOG_KICKSTART_RECHECK_ATTEMPTS  #4232: how many times to re-check
-#                                for a live pid after the auto-kickstart fallback
+#   LOOM_SYSTEMD_UNIT             #4862: the systemd --user unit to probe (default
+#                                loom-daemon.service, else the marker's systemd_unit)
+#   LOOM_WATCHDOG_SYSTEMD_PROBE   #4862: 1/true/yes: opt in to the systemd --user
+#                                probe (default: per the marker's use_systemd
+#                                field, else OFF -- `systemctl` merely being on
+#                                PATH is not proof of a systemd-managed daemon).
+#                                0/false/no forces it off regardless of the marker.
+#   LOOM_WATCHDOG_KICKSTART_RECHECK_ATTEMPTS  #4232/#4862: how many times to re-check
+#                                for a live pid after the auto-kickstart / systemctl-start fallback
 #                                (default 3).
 #   LOOM_WATCHDOG_KICKSTART_RECHECK_INTERVAL  #4232: seconds between re-checks
 #                                (default 1; may be fractional).
@@ -250,12 +267,15 @@ report() {
 
 # ---------- reality probe (shared) ----------
 # Determine whether the expected daemon is actually alive. Reads the resolved
-# USE_LAUNCHD / LABEL / PID_FILE and sets four globals the callers branch on:
+# USE_LAUNCHD / USE_SYSTEMD / LABEL / SYSTEMD_UNIT / PID_FILE and sets globals
+# the callers branch on:
 #   daemon_alive     true|false
 #   liveness_detail  human-readable string (mirrored into status/log messages)
-#   job_loaded       true|false — launchd job in the table but with no live pid
-#                    (feeds the #4232 bounded auto-remediation gate)
+#   job_loaded       true|false — launchd job / systemd unit known but with no
+#                    live pid (feeds the #4232 / #4862 bounded auto-remediation
+#                    gates)
 #   launchd_service  <domain>/<label> for the launchd path (else empty)
+#   systemd_service  <unit> for the systemd path (else empty)
 # Factored out (#4331) so the no-marker state-mismatch check below and the
 # marker-present path below run the IDENTICAL liveness logic — they can never
 # diverge on what "alive" means.
@@ -264,6 +284,7 @@ detect_daemon_liveness() {
     liveness_detail=""
     job_loaded=false
     launchd_service=""
+    systemd_service=""
     live_pid=""
     if [[ "$USE_LAUNCHD" == "true" ]] && command -v launchctl >/dev/null 2>&1; then
         # Resolve the domain (gui/<uid> ↦ user/<uid>, #4130) the same way the
@@ -282,8 +303,29 @@ detect_daemon_liveness() {
         else
             liveness_detail="launchd job $launchd_service is not loaded/alive"
         fi
+    elif [[ "$USE_SYSTEMD" == "true" ]] && command -v systemctl >/dev/null 2>&1; then
+        # systemd --user path (#4862): mirrors the launchd branch above so the
+        # #4232-style auto-remediation gate below has an equivalent signal on
+        # Linux. `show -p X --value` against an unknown unit answers cleanly
+        # (LoadState=not-found) rather than erroring, so no separate rc check
+        # is needed the way launchd's print exit code is used above.
+        systemd_service="$SYSTEMD_UNIT"
+        systemd_main_pid="$(systemctl --user show -p MainPID --value "$systemd_service" 2>/dev/null)"
+        if [[ -n "$systemd_main_pid" && "$systemd_main_pid" != "0" ]] && kill -0 "$systemd_main_pid" 2>/dev/null; then
+            daemon_alive=true
+            liveness_detail="systemd unit $systemd_service alive (pid $systemd_main_pid)"
+            live_pid="$systemd_main_pid"
+        else
+            systemd_load_state="$(systemctl --user show -p LoadState --value "$systemd_service" 2>/dev/null)"
+            if [[ "$systemd_load_state" == "loaded" ]]; then
+                job_loaded=true
+                liveness_detail="systemd unit $systemd_service is LOADED but NOT running (no live MainPID)"
+            else
+                liveness_detail="systemd unit $systemd_service is not loaded/alive"
+            fi
+        fi
     else
-        # Non-launchd (nohup / Linux) path: the pid file is the only signal.
+        # Non-launchd, non-systemd (nohup) path: the pid file is the only signal.
         if [[ -n "$PID_FILE" && -f "$PID_FILE" ]]; then
             pid="$(cat "$PID_FILE" 2>/dev/null || true)"
             if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
@@ -521,6 +563,20 @@ if [[ ! -f "$MARKER" ]]; then
     fi
     [[ "$(uname -s)" == "Darwin" ]] || USE_LAUNCHD=false
     LABEL="${LOOM_LAUNCHD_LABEL:-com.rjwalters.loom-daemon}"
+    # #4862: with no marker to read use_systemd/systemd_unit from, there is no
+    # reliable signal that THIS host's daemon is systemd-managed rather than a
+    # bystander user session with `systemctl` merely on PATH (every dev/test
+    # host in this suite has that) -- so, unlike USE_LAUNCHD above (which is
+    # genuinely platform-derived), the systemd probe stays OFF here unless
+    # explicitly requested via LOOM_WATCHDOG_SYSTEMD_PROBE=1. The marker-present path
+    # below (the common case — a daemon just started) gets it from the
+    # use_systemd field loom-daemon-start.sh's systemd branch now writes.
+    USE_SYSTEMD=false
+    if [[ "$USE_LAUNCHD" != "true" ]] && [[ "$(uname -s)" != "Darwin" ]] \
+        && [[ "${LOOM_WATCHDOG_SYSTEMD_PROBE:-}" =~ ^(1|true|yes)$ ]] && command -v systemctl >/dev/null 2>&1; then
+        USE_SYSTEMD=true
+    fi
+    SYSTEMD_UNIT="${LOOM_SYSTEMD_UNIT:-loom-daemon.service}"
     PID_FILE="$LOOM_DIR/.daemon.pid"
     detect_daemon_liveness
     if [[ "$daemon_alive" == "true" ]]; then
@@ -546,6 +602,8 @@ HEARTBEAT_FILE="$(marker_get heartbeat_file)"
 HEARTBEAT_INTERVAL_SECS="$(marker_get heartbeat_interval_secs)"
 MARKER_USE_LAUNCHD="$(marker_get use_launchd)"
 MARKER_LABEL="$(marker_get launchd_label)"
+MARKER_USE_SYSTEMD="$(marker_get use_systemd)"
+MARKER_SYSTEMD_UNIT="$(marker_get systemd_unit)"
 PID_FILE="$(marker_get pid_file)"
 
 # Fallbacks when the marker predates a field or the value is empty.
@@ -561,6 +619,22 @@ if [[ "${LOOM_DAEMON_LAUNCHD:-}" =~ ^(0|false|no)$ ]]; then
 fi
 [[ "$(uname -s)" == "Darwin" ]] || USE_LAUNCHD=false
 LABEL="${LOOM_LAUNCHD_LABEL:-${MARKER_LABEL:-com.rjwalters.loom-daemon}}"
+
+# #4862: use_systemd/systemd_unit are new marker fields, written by
+# loom-daemon-start.sh's systemd branch (a marker from before this fix, or
+# from the launchd/nohup branches, has no use_systemd=true line). A blank
+# MARKER_USE_SYSTEMD stays OFF by default here -- same rationale as section 1
+# above: `systemctl` merely being on PATH is not proof THIS daemon is
+# systemd-managed, so no platform auto-detect. LOOM_WATCHDOG_SYSTEMD_PROBE=1 opts in
+# explicitly for a pre-#4862 marker that has not been rewritten yet.
+USE_SYSTEMD="${MARKER_USE_SYSTEMD:-false}"
+if [[ "${LOOM_WATCHDOG_SYSTEMD_PROBE:-}" =~ ^(1|true|yes)$ ]]; then
+    USE_SYSTEMD=true
+elif [[ "${LOOM_WATCHDOG_SYSTEMD_PROBE:-}" =~ ^(0|false|no)$ ]]; then
+    USE_SYSTEMD=false
+fi
+[[ "$(uname -s)" == "Darwin" ]] && USE_SYSTEMD=false
+SYSTEMD_UNIT="${LOOM_SYSTEMD_UNIT:-${MARKER_SYSTEMD_UNIT:-loom-daemon.service}}"
 
 # ---------- 2. reality: is the expected daemon actually alive? ----------
 # Shared probe (#4331): sets daemon_alive / liveness_detail / job_loaded /
@@ -619,6 +693,48 @@ if [[ "$daemon_alive" != "true" ]]; then
             fi
             report DIVERGENCE \
                 "Auto-remediation attempted ('launchctl kickstart ${launchd_service}') but the daemon is STILL not confirmed running. Escalate manually: launchctl print ${launchd_service}  (or ./.loom/scripts/cli/loom-daemon-start.sh [flags])."
+            exit 1
+        fi
+    fi
+
+    # ---------- bounded auto-remediation, systemd (#4862) ----------
+    # The Linux mirror of the #4232 launchd gate above, closing the exact gap
+    # #4862 reported: on a systemd host the watchdog previously only LOGGED a
+    # clean-exit-turned-timeout divergence, never acted on it. Narrow by the
+    # SAME construction as the launchd gate: fires ONLY for "unit LOADED
+    # (systemd still knows about it) + NOT running + main process's own last
+    # exit was a clean status 0" (ExecMainCode=exited, ExecMainStatus=0). An
+    # operator stop (loom-daemon-stop.sh) disables the unit outright; a genuine
+    # crash leaves a non-zero/signal ExecMainStatus; a never-installed unit
+    # fails LoadState=loaded (job_loaded=false). None of those can produce
+    # "loaded, down, ExecMainStatus=0" — only a restart-primitive exit that
+    # Restart=on-success failed to honor can (e.g. a pre-#4862 unit still
+    # missing KillMode=mixed). Every other divergence falls through unchanged.
+    if [[ "$job_loaded" == "true" && -n "$systemd_service" ]] && command -v systemctl >/dev/null 2>&1; then
+        exec_main_code="$(systemctl --user show -p ExecMainCode --value "$systemd_service" 2>/dev/null)"
+        exec_main_status="$(systemctl --user show -p ExecMainStatus --value "$systemd_service" 2>/dev/null)"
+        if [[ "$exec_main_code" == "exited" && "$exec_main_status" == "0" ]]; then
+            report DIVERGENCE \
+                "A daemon is EXPECTED (autonomy-desired marker present, started $(marker_get started_at)) but is NOT running: ${liveness_detail}. Main process's last exit was clean (status 0) — the restart-primitive's own exit-0 contract (#4054/#4077) — which Restart=on-success failed to honor (likely a unit-result reclassification, #4862). Auto-remediating with 'systemctl --user reset-failed ${systemd_service} && systemctl --user start ${systemd_service}'."
+            systemctl --user reset-failed "$systemd_service" >/dev/null 2>&1 || true
+            systemctl --user start "$systemd_service" >/dev/null 2>&1
+            RECHECK_ATTEMPTS="${LOOM_WATCHDOG_KICKSTART_RECHECK_ATTEMPTS:-3}"
+            RECHECK_INTERVAL="${LOOM_WATCHDOG_KICKSTART_RECHECK_INTERVAL:-1}"
+            recheck_pid=""
+            for _ in $(seq 1 "$RECHECK_ATTEMPTS"); do
+                recheck_pid="$(systemctl --user show -p MainPID --value "$systemd_service" 2>/dev/null)"
+                if [[ -n "$recheck_pid" && "$recheck_pid" != "0" ]] && kill -0 "$recheck_pid" 2>/dev/null; then
+                    break
+                fi
+                recheck_pid=""
+                sleep "$RECHECK_INTERVAL"
+            done
+            if [[ -n "$recheck_pid" ]]; then
+                report OK "auto-remediation succeeded: 'systemctl --user start' relaunched ${systemd_service} (new pid ${recheck_pid})."
+                exit 0
+            fi
+            report DIVERGENCE \
+                "Auto-remediation attempted ('systemctl --user start ${systemd_service}') but the daemon is STILL not confirmed running. Escalate manually: systemctl --user status ${systemd_service}  (or ./.loom/scripts/cli/loom-daemon-start.sh [flags])."
             exit 1
         fi
     fi

--- a/defaults/scripts/cli/loom-daemon-watchdog.sh
+++ b/defaults/scripts/cli/loom-daemon-watchdog.sh
@@ -627,13 +627,25 @@ LABEL="${LOOM_LAUNCHD_LABEL:-${MARKER_LABEL:-com.rjwalters.loom-daemon}}"
 # above: `systemctl` merely being on PATH is not proof THIS daemon is
 # systemd-managed, so no platform auto-detect. LOOM_WATCHDOG_SYSTEMD_PROBE=1 opts in
 # explicitly for a pre-#4862 marker that has not been rewritten yet.
+#
+# Deliberately NO platform clobber here. An earlier revision ended this block
+# with `[[ "$(uname -s)" == "Darwin" ]] && USE_SYSTEMD=false`, which ran after
+# the opt-in and silently overrode both the marker and the documented
+# LOOM_WATCHDOG_SYSTEMD_PROBE=1 escape hatch -- contradicting the comment above
+# and making the whole #4862 systemd remediation path unreachable (and
+# untestable) on a Darwin host.
+#
+# It was also redundant for the case it appeared to protect: the marker is the
+# authority, and only loom-daemon-start.sh's systemd branch writes
+# `use_systemd=true`. The launchd branch calls `write_intent_marker "true"
+# "$LAUNCHD_LABEL"` with no third argument, so a real Darwin host's marker
+# carries `use_systemd=false` and this resolves to false on its own.
 USE_SYSTEMD="${MARKER_USE_SYSTEMD:-false}"
 if [[ "${LOOM_WATCHDOG_SYSTEMD_PROBE:-}" =~ ^(1|true|yes)$ ]]; then
     USE_SYSTEMD=true
 elif [[ "${LOOM_WATCHDOG_SYSTEMD_PROBE:-}" =~ ^(0|false|no)$ ]]; then
     USE_SYSTEMD=false
 fi
-[[ "$(uname -s)" == "Darwin" ]] && USE_SYSTEMD=false
 SYSTEMD_UNIT="${LOOM_SYSTEMD_UNIT:-${MARKER_SYSTEMD_UNIT:-loom-daemon.service}}"
 
 # ---------- 2. reality: is the expected daemon actually alive? ----------

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -294,18 +294,19 @@ rm -rf "$MACHINE_HOME" "$MACHINE_CHECKOUT" "$NON_REPO_DIR"
 SD_UNIT="loom-daemon-test-$$.service"
 
 # S1. --print-unit renders the unit with NO side effects (no systemctl, no file
-#     write). Assert the four load-bearing fields from the issue's test plan:
-#     Restart=on-success, WantedBy=default.target, the baked
-#     Environment=LOOM_DAEMON_SUPERVISOR=systemd, and WorkingDirectory=<repo>.
+#     write). Assert the five load-bearing fields from the issue's test plan:
+#     Restart=on-success, KillMode=mixed (#4862), WantedBy=default.target, the
+#     baked Environment=LOOM_DAEMON_SUPERVISOR=systemd, and WorkingDirectory=<repo>.
 unit_out=$( ( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
     LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --print-unit 2>/dev/null ) )
 TESTS_RUN=$((TESTS_RUN + 1))
 if echo "$unit_out" | grep -qx 'Restart=on-success' \
+    && echo "$unit_out" | grep -qx 'KillMode=mixed' \
     && echo "$unit_out" | grep -qx 'WantedBy=default.target' \
     && echo "$unit_out" | grep -qx 'Environment=LOOM_DAEMON_SUPERVISOR=systemd' \
     && echo "$unit_out" | grep -qx "WorkingDirectory=$WORKDIR"; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
-    echo -e "${GREEN}✓${NC} --print-unit renders Restart=on-success, WantedBy=default.target, LOOM_DAEMON_SUPERVISOR=systemd, WorkingDirectory=<repo>"
+    echo -e "${GREEN}✓${NC} --print-unit renders Restart=on-success, KillMode=mixed, WantedBy=default.target, LOOM_DAEMON_SUPERVISOR=systemd, WorkingDirectory=<repo>"
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "${RED}✗${NC} --print-unit renders the expected unit fields"
@@ -371,12 +372,13 @@ fi
 rm -f "$WORKDIR/.loom/.daemon.pid"
 TESTS_RUN=$((TESTS_RUN + 1))
 if [[ -f "$SD_HOME/.config/systemd/user/$SD_UNIT" ]] \
-    && grep -qx 'Restart=on-success' "$SD_HOME/.config/systemd/user/$SD_UNIT"; then
+    && grep -qx 'Restart=on-success' "$SD_HOME/.config/systemd/user/$SD_UNIT" \
+    && grep -qx 'KillMode=mixed' "$SD_HOME/.config/systemd/user/$SD_UNIT"; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
-    echo -e "${GREEN}✓${NC} systemd path: renders the unit file under ~/.config/systemd/user with Restart=on-success"
+    echo -e "${GREEN}✓${NC} systemd path: renders the unit file under ~/.config/systemd/user with Restart=on-success + KillMode=mixed (#4862)"
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))
-    echo -e "${RED}✗${NC} systemd path: renders the unit file under ~/.config/systemd/user with Restart=on-success"
+    echo -e "${RED}✗${NC} systemd path: renders the unit file under ~/.config/systemd/user with Restart=on-success + KillMode=mixed"
 fi
 TESTS_RUN=$((TESTS_RUN + 1))
 if echo "$sd_out" | grep -qi 'enable-linger'; then
@@ -1306,6 +1308,132 @@ fi
 kill "$AD8_SLEEP_PID2" 2>/dev/null || true
 rm -f "$AD8_HOME/.loom/.daemon.pid"
 rm -rf "$AD8_HOME"
+
+# ---------- KillMode=mixed real-systemd regression (#4862) ----------
+# The stub-based systemd tests above assert the RENDERED TEXT of the unit
+# (Restart=on-success, KillMode=mixed present) but never exercise a real
+# `systemd --user` manager, so they cannot catch a regression in what those
+# fields actually DO. This block drives the ACTUAL production-rendered unit
+# (via --print-unit, only ExecStart/WorkingDirectory substituted) against a
+# real `systemctl --user` when one is reachable, proving BOTH halves of the
+# issue's acceptance criteria in one shot:
+#   MX1. a clean exit(0) with a SIGTERM-ignoring lingering child (standing in
+#        for an in-flight claude/tee/sleep sweep worker) still causes
+#        Restart=on-success to fire — the #4862 fix.
+#   MX2. a crash exit(1) does NOT get restarted — the #4054 no-crash-loop
+#        property must survive the #4862 change (KillMode=mixed touches only
+#        HOW leftover cgroup members are reaped, never the crash/on-success
+#        exit-code contract).
+# Skips cleanly (not a failure) when no reachable `systemd --user` manager
+# exists — e.g. a Darwin CI runner, or a sandboxed host with no user
+# session/bus. Real unit files land under the ACTUAL $HOME (systemd --user
+# cannot be redirected via an env HOME override the way the stub-based tests
+# above redirect it), uniquely named with $$ so a leftover from an
+# interrupted run cannot collide with a later one.
+MX_HAVE_SYSTEMD=false
+if command -v systemctl >/dev/null 2>&1 && [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
+    mx_state="$(systemctl --user is-system-running 2>/dev/null)"
+    [[ "$mx_state" != "offline" && -n "$mx_state" ]] && MX_HAVE_SYSTEMD=true
+fi
+if [[ "$MX_HAVE_SYSTEMD" == "true" ]]; then
+    MX_UNIT_MIXED="loom-daemon-test-mx-mixed-$$.service"
+    MX_UNIT_CRASH="loom-daemon-test-mx-crash-$$.service"
+    MX_UNIT_DIR="$HOME/.config/systemd/user"
+    MX_SCRIPT_DIR="$WORKDIR/mx-scripts"
+    mkdir -p "$MX_UNIT_DIR" "$MX_SCRIPT_DIR"
+
+    mx_cleanup() {
+        systemctl --user stop "$MX_UNIT_MIXED" "$MX_UNIT_CRASH" >/dev/null 2>&1 || true
+        rm -f "$MX_UNIT_DIR/$MX_UNIT_MIXED" "$MX_UNIT_DIR/$MX_UNIT_CRASH"
+        systemctl --user daemon-reload >/dev/null 2>&1 || true
+        systemctl --user reset-failed "$MX_UNIT_MIXED" "$MX_UNIT_CRASH" >/dev/null 2>&1 || true
+    }
+    # Extend the suite-wide traps (not replace) so an interruption mid-MX-block
+    # still tears down these REAL systemd units, not just $WORKDIR.
+    trap 'mx_cleanup; bg_proc_reap; [ -n "$WORKDIR" ] && pkill -f "$WORKDIR" >/dev/null 2>&1; rm -rf "$WORKDIR"' EXIT
+    trap 'mx_cleanup; bg_proc_reap; [ -n "$WORKDIR" ] && pkill -f "$WORKDIR" >/dev/null 2>&1; rm -rf "$WORKDIR"; exit 1' INT TERM
+    mx_cleanup
+
+    # mx-main.sh: forks a SIGTERM-ignoring child (stand-in for a lingering
+    # claude/tee/sleep sweep worker in the SAME cgroup), then exits 0 quickly
+    # — mirrors the incident's "clean main-process exit, children still
+    # running" shape.
+    cat > "$MX_SCRIPT_DIR/mx-main.sh" <<'MXEOF'
+#!/bin/bash
+trap '' TERM
+(trap '' TERM; sleep 30) &
+sleep 1
+exit 0
+MXEOF
+    chmod +x "$MX_SCRIPT_DIR/mx-main.sh"
+    cat > "$MX_SCRIPT_DIR/mx-crash.sh" <<'MXEOF'
+#!/bin/bash
+sleep 1
+exit 1
+MXEOF
+    chmod +x "$MX_SCRIPT_DIR/mx-crash.sh"
+
+    # Render via the ACTUAL production code path, then retarget ExecStart/
+    # WorkingDirectory at the tiny fixture script above -- proves the SHIPPED
+    # unit shape (not a hand-rolled duplicate) reproduces the fix.
+    mx_render() {
+        local exec_script="$1"
+        ( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
+            LOOM_DAEMON_BIN="$exec_script" bash "$START_SCRIPT" --print-unit 2>/dev/null ) \
+            | sed -e "s|^ExecStart=.*|ExecStart=/bin/bash $exec_script|" \
+                  -e "s|^WorkingDirectory=.*|WorkingDirectory=$MX_SCRIPT_DIR|"
+    }
+    mx_render "$MX_SCRIPT_DIR/mx-main.sh" > "$MX_UNIT_DIR/$MX_UNIT_MIXED"
+    mx_render "$MX_SCRIPT_DIR/mx-crash.sh" > "$MX_UNIT_DIR/$MX_UNIT_CRASH"
+    systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+    # MX1. Clean exit + lingering child -> Restart=on-success fires (NRestarts
+    # climbs above 0 within a few restart cycles). Poll up to ~8s.
+    systemctl --user start "$MX_UNIT_MIXED" >/dev/null 2>&1
+    mx1_restarts=0
+    for _ in 1 2 3 4 5 6 7 8; do
+        mx1_restarts="$(systemctl --user show -p NRestarts --value "$MX_UNIT_MIXED" 2>/dev/null)"
+        [[ "$mx1_restarts" =~ ^[0-9]+$ ]] && (( mx1_restarts > 0 )) && break
+        sleep 1
+    done
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$mx1_restarts" =~ ^[0-9]+$ ]] && (( mx1_restarts > 0 )); then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} real systemd (#4862): clean exit + lingering child -> Restart=on-success fires (NRestarts=$mx1_restarts)"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} real systemd (#4862): clean exit + lingering child -> Restart=on-success fires"
+        echo "  systemctl --user status ${MX_UNIT_MIXED}:"
+        systemctl --user status "$MX_UNIT_MIXED" --no-pager -l 2>&1 | sed 's/^/    /'
+    fi
+    systemctl --user stop "$MX_UNIT_MIXED" >/dev/null 2>&1 || true
+
+    # MX2. Crash exit(1) -> stays down (the #4054 no-crash-loop property).
+    # Wait past the fixture's own 1s sleep + a restart-cycle margin, then
+    # assert BOTH that it never restarted and that it is in a failed/inactive
+    # (not activating/running) state.
+    systemctl --user start "$MX_UNIT_CRASH" >/dev/null 2>&1
+    sleep 3
+    mx2_restarts="$(systemctl --user show -p NRestarts --value "$MX_UNIT_CRASH" 2>/dev/null)"
+    mx2_active="$(systemctl --user show -p ActiveState --value "$MX_UNIT_CRASH" 2>/dev/null)"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$mx2_restarts" == "0" ]] && [[ "$mx2_active" != "active" && "$mx2_active" != "activating" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} real systemd (#4862): crash exit(1) does NOT restart (#4054 no-crash-loop preserved; ActiveState=$mx2_active)"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} real systemd (#4862): crash exit(1) does NOT restart"
+        echo "  NRestarts=$mx2_restarts ActiveState=$mx2_active"
+        systemctl --user status "$MX_UNIT_CRASH" --no-pager -l 2>&1 | sed 's/^/    /'
+    fi
+
+    mx_cleanup
+    # Restore the plain (non-MX) suite-wide traps for the remainder of the run.
+    trap 'bg_proc_reap; [ -n "$WORKDIR" ] && pkill -f "$WORKDIR" >/dev/null 2>&1; rm -rf "$WORKDIR"' EXIT
+    trap 'bg_proc_reap; [ -n "$WORKDIR" ] && pkill -f "$WORKDIR" >/dev/null 2>&1; rm -rf "$WORKDIR"; exit 1' INT TERM
+else
+    echo "  (skipping real-systemd #4862 regression: no reachable 'systemctl --user' manager on this host)"
+fi
 
 # ---------- summary ----------
 echo

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -1923,12 +1923,13 @@ write_fixture_unit_pre4267 "$UNIT_PATH31" "$INSTALLED31"
     bash "$UPDATE_SCRIPT" --relaunch >/dev/null 2>&1 )
 TESTS_RUN=$((TESTS_RUN + 1))
 if grep -q 'LOOM_DAEMON_SUPERVISOR=systemd' "$UNIT_PATH31" 2>/dev/null \
-    && grep -qx 'Restart=on-success' "$UNIT_PATH31" 2>/dev/null; then
+    && grep -qx 'Restart=on-success' "$UNIT_PATH31" 2>/dev/null \
+    && grep -qx 'KillMode=mixed' "$UNIT_PATH31" 2>/dev/null; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
-    echo -e "${GREEN}✓${NC} --relaunch re-renders the unit with Restart=on-success + LOOM_DAEMON_SUPERVISOR=systemd"
+    echo -e "${GREEN}✓${NC} --relaunch re-renders the unit with Restart=on-success + KillMode=mixed (#4862) + LOOM_DAEMON_SUPERVISOR=systemd"
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))
-    echo -e "${RED}✗${NC} --relaunch re-renders the unit with Restart=on-success + LOOM_DAEMON_SUPERVISOR=systemd"
+    echo -e "${RED}✗${NC} --relaunch re-renders the unit with Restart=on-success + KillMode=mixed + LOOM_DAEMON_SUPERVISOR=systemd"
     echo "  unit: $(cat "$UNIT_PATH31" 2>/dev/null)"
 fi
 

--- a/defaults/scripts/tests/test-loom-daemon-watchdog.sh
+++ b/defaults/scripts/tests/test-loom-daemon-watchdog.sh
@@ -543,6 +543,128 @@ else
 fi
 
 # ===================================================================
+# 10a/10b. systemd mirror of tests 9/10 (#4862): a stubbed `systemctl` (not a
+# real systemd --user manager — deterministic and portable to a Darwin
+# runner, same technique as the launchctl stubs above) proves the auto-
+# remediation gate fires for the EXACT #4862 signature (unit LOADED + NOT
+# running + ExecMainCode=exited + ExecMainStatus=0) and stays report-only for
+# a genuine crash (ExecMainStatus=1).
+# ===================================================================
+STUB10A="$WORKDIR/stub10a"
+mkdir -p "$STUB10A"
+STATE10A="$WORKDIR/state10a"   # empty -> "not running"; a pid -> "running"
+LOG10A="$WORKDIR/systemctl10a.log"
+: > "$STATE10A" "$LOG10A"
+UNIT10A="loom-daemon-test-remediate-$$.service"
+sleep 60 >/dev/null 2>&1 &
+NEW_PID10A=$!
+bg_proc_track "$NEW_PID10A"
+cat > "$STUB10A/systemctl" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$LOG10A"
+if [[ "\${1:-}" == "--user" ]]; then shift; fi
+case "\${1:-}" in
+  show)
+    case "\$*" in
+      *"-p MainPID"*)         pid="\$(cat "$STATE10A" 2>/dev/null)"; echo "\${pid:-0}" ;;
+      *"-p LoadState"*)       echo "loaded" ;;
+      *"-p ExecMainCode"*)    echo "exited" ;;
+      *"-p ExecMainStatus"*)  echo "0" ;;
+      *)                      echo "" ;;
+    esac
+    ;;
+  reset-failed) exit 0 ;;
+  start)
+    echo "$NEW_PID10A" > "$STATE10A"
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$STUB10A/systemctl"
+cat > "$MARKER" <<EOF
+started_at=2026-07-27T00:00:00Z
+heartbeat_file=$HEARTBEAT
+heartbeat_interval_secs=60
+use_launchd=false
+use_systemd=true
+systemd_unit=$UNIT10A
+socket_path=$WORKDIR/loom-daemon.sock
+EOF
+: > "$WDLOG" "$OUT"
+env PATH="$STUB10A:$PATH" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
+    LOOM_WATCHDOG_KICKSTART_RECHECK_ATTEMPTS=5 LOOM_WATCHDOG_KICKSTART_RECHECK_INTERVAL=0.2 \
+    bash "$WATCHDOG" > "$OUT" 2>&1
+rc10a=$?
+kill "$NEW_PID10A" 2>/dev/null || true
+assert_rc 0 "$rc10a" "systemd exit-0-and-down (#4862): auto-remediation relaunches the unit -> exits 0"
+if grep -q -- '--user start ' "$LOG10A"; then
+    pass "systemd exit-0-and-down: auto-remediation invokes 'systemctl --user start'"
+else
+    fail "systemd exit-0-and-down: auto-remediation invokes 'systemctl --user start' (log: $(cat "$LOG10A" 2>/dev/null))"
+fi
+if grep -q -- '--user reset-failed ' "$LOG10A"; then
+    pass "systemd exit-0-and-down: auto-remediation clears the failed state first ('reset-failed')"
+else
+    fail "systemd exit-0-and-down: auto-remediation clears the failed state first"
+fi
+if log_hasi 'remediat'; then
+    pass "systemd exit-0-and-down: watchdog log records the remediation"
+else
+    fail "systemd exit-0-and-down: watchdog log records the remediation"
+fi
+
+# 10b. ExecMainStatus=1 (crash) — the auto-remediation gate must NEVER fire.
+STUB10B="$WORKDIR/stub10b"
+mkdir -p "$STUB10B"
+LOG10B="$WORKDIR/systemctl10b.log"
+: > "$LOG10B"
+UNIT10B="loom-daemon-test-noremediate-$$.service"
+cat > "$STUB10B/systemctl" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$LOG10B"
+if [[ "\${1:-}" == "--user" ]]; then shift; fi
+case "\${1:-}" in
+  show)
+    case "\$*" in
+      *"-p MainPID"*)         echo "0" ;;
+      *"-p LoadState"*)       echo "loaded" ;;
+      *"-p ExecMainCode"*)    echo "exited" ;;
+      *"-p ExecMainStatus"*)  echo "1" ;;
+      *)                      echo "" ;;
+    esac
+    ;;
+  reset-failed) exit 0 ;;
+  start)
+    # If this were ever wrongly invoked it would show up in the log below —
+    # the assertion is that 'start' never appears at all.
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$STUB10B/systemctl"
+cat > "$MARKER" <<EOF
+started_at=2026-07-27T00:00:00Z
+heartbeat_file=$HEARTBEAT
+heartbeat_interval_secs=60
+use_launchd=false
+use_systemd=true
+systemd_unit=$UNIT10B
+socket_path=$WORKDIR/loom-daemon.sock
+EOF
+: > "$WDLOG" "$OUT"
+env PATH="$STUB10B:$PATH" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
+    bash "$WATCHDOG" > "$OUT" 2>&1
+rc10b=$?
+assert_rc 1 "$rc10b" "systemd exit-1-and-down: stays report-only (no auto-remediation) -> exits 1 (#4054 no-crash-loop preserved)"
+if grep -q -- '--user start ' "$LOG10B"; then
+    fail "systemd exit-1-and-down: 'systemctl --user start' is NEVER invoked (no crash-loop revival)"
+else
+    pass "systemd exit-1-and-down: 'systemctl --user start' is NEVER invoked (no crash-loop revival)"
+fi
+
+# ===================================================================
 # 11. --help works and documents the marker + StartInterval design.
 # ===================================================================
 help_out=$(bash "$WATCHDOG" --help 2>/dev/null)


### PR DESCRIPTION
## Summary

On a systemd host, `loom-daemon.service` can exit cleanly (`status=0/SUCCESS`) after a self-update relaunch, but its `claude`/`tee`/`sleep` worker children (in-flight sweep workers, same cgroup) don't exit within `TimeoutStopSec` — systemd SIGKILLs them and marks the **unit** result `timeout`, not `success`. `Restart=on-success` only matches `Result=success`, so the supervised relaunch silently never fires and the daemon sits dead (observed: worker-1 idle 1h20m).

Root cause and fix verified **empirically against a real `systemd --user` manager** in this sandbox (not just read from docs):

- Reproduced the bug: a clean `exit(0)` with a lingering SIGTERM-ignoring child, under the default `KillMode=control-group`, produces `Active: failed (Result: timeout)` with `Main PID ... status=0/SUCCESS` — exactly the incident.
- Verified the fix: the same scenario under `KillMode=mixed` produces `Result: success` and `Restart=on-success` actually fires (`Active: activating (auto-restart)`).
- Verified the no-crash-loop property survives: a genuine crash (`exit 1`) still stays `failed (Result: exit-code)` under `KillMode=mixed` — Restart=on-success does not fire.

Per `kill(5)`: `mixed` sends SIGTERM to the main process only, and escalates the SIGKILL sweep of remaining cgroup members on **the main process's own exit** — not after waiting out `TimeoutStopSec` — so the unit's `Result` tracks the main process's exit status rather than getting reclassified by a slow-to-die cgroup.

## Changes

- **`defaults/scripts/cli/loom-daemon-start.sh`**
  - `render_systemd_unit`: add `KillMode=mixed` (the core fix), with a doc comment citing the `kill(5)` mechanics and the empirical verification.
  - `render_launchd_plist`: note launchd's analogous "was the exit clean" dependency (`KeepAlive:{SuccessfulExit:true}`) for a follow-up — no known cgroup-timeout reclassification exists there, so it isn't reproduced/fixed in this PR.
  - `provision_watchdog_job_launchd`: fix the reported **watchdog double-firing bug**. This function unconditionally boots the watchdog job out and re-bootstraps it on *every* `loom-daemon-start.sh` invocation (every start/restart/self-update relaunch), and `RunAtLoad=true` fires an extra immediate run on every bootstrap — independent of the job's own `StartInterval` cadence. Now skipped when the rendered plist is byte-identical to what's installed and the job is already loaded. (Verified `systemd`'s `enable --now` is idempotent on an already-active timer — no analogous fix needed on that path.)
  - `write_intent_marker`: new optional `use_systemd`/`systemd_unit` marker fields so the watchdog can tell a systemd-supervised daemon apart from the nohup fallback (both previously wrote identical `use_launchd=false` markers).

- **`defaults/scripts/cli/loom-daemon-watchdog.sh`**
  - `detect_daemon_liveness`: new systemd branch (`systemctl --user show`) mirroring the existing launchd branch.
  - New systemd auto-remediation gate mirroring the existing `#4232` launchd `kickstart` gate: fires *only* for "unit LOADED + NOT running + main process's own last exit was `ExecMainCode=exited`/`ExecMainStatus=0`" — the exact signature a `Restart=on-success` failure produces, never for an operator stop or crash. Runs `systemctl --user reset-failed <unit> && systemctl --user start <unit>`.
  - New `LOOM_WATCHDOG_SYSTEMD_PROBE` env (opt-in, default off unless the marker says `use_systemd=true`) — deliberately does **not** auto-detect from mere `systemctl`-on-PATH presence, since that's not proof the daemon is systemd-managed.

- **Daemon shutdown logging** — investigated and found already satisfied: every `std::process::exit` path in the Rust daemon (SIGTERM/SIGINT, `RestartDaemon`, drain complete/timeout) already logs a clear reason before exiting. No code change needed for that acceptance criterion.

- **Tests** — `test-loom-daemon-start.sh`, `test-loom-daemon-update.sh`, `test-loom-daemon-watchdog.sh`: updated the existing `Restart=on-success` pinned assertions to also require `KillMode=mixed`, and added:
  - A **real-`systemd --user`** regression test (skips cleanly when no reachable user manager exists) exercising the actual production-rendered unit: clean exit + lingering child → restarts; crash → stays down.
  - Stub-based systemd auto-remediation tests mirroring the existing launchd `#4232` test pair.

- **`defaults/docs/daemon-reference.md`** — documented `KillMode=mixed` in the launchd/systemd parity table and the new watchdog auto-remediation gate.

## Test plan

- [x] `defaults/scripts/tests/test-loom-daemon-start.sh` — 74/74 passed (includes the two new real-systemd regression tests)
- [x] `defaults/scripts/tests/test-loom-daemon-watchdog.sh` — 64/64 passed (includes the two new systemd auto-remediation tests)
- [x] `defaults/scripts/tests/test-loom-daemon-update.sh` — 115/118 passed (3 pre-existing, unrelated failures reproduced identically on unmodified `main`: real-binary-changed / origin-drift flakiness from background self-update activity on this host, see `#4381`)
- [x] `defaults/scripts/tests/test-loom-daemon-stop.sh`, `test-loom-daemon-launchd-plist.sh` — all passing (one intermittent, pre-existing flake in `-stop.sh` reproduced identically on unmodified `main`)
- [x] `shellcheck -x` clean on all touched scripts (only pre-existing, unrelated `SC2317`/`SC2001`/`SC2002` info-level notices elsewhere in the files)

Closes #4862

🤖 Generated with [Claude Code](https://claude.com/claude-code)