### PR TITLE
feat(daemon): add optional OTLP exporter as a feature-flagged second sink

### DIFF
--- a/.loom/docs/observability.md
+++ b/.loom/docs/observability.md
@@ -116,7 +116,7 @@ resource/record attributes) is documented in
 `loom-daemon/src/observability/otlp/mod.rs`'s module doc comment, verified by
 `loom-daemon/src/observability/otlp/mapping.rs`'s unit tests.
 
-**The exporter verifies its own identity** (issue #4830). Each `/ingest`
+**The HTTPS exporter verifies its own identity** (issue #4830). Each `/ingest`
 success response echoes the `host_id` the presented key is bound to; the
 exporter compares that against the identity this daemon resolved for itself
 (`$LOOM_HOST_ID` > `$HOSTNAME` > `hostname`). On a disagreement — the wrong
@@ -126,6 +126,14 @@ and `loom-daemon health` reports an `observability DEGRADED` section (exit
 `1`). Nothing else changes: the batch is still acked, and the key's binding
 stays authoritative on the backend. Fix by installing the right key or setting
 `$LOOM_HOST_ID` to match, then restarting the daemon.
+
+This check is specific to the native ingest protocol, which is what defines
+the echo. OTLP/HTTP has no equivalent — a success response carries only
+`partial_success`, and a generic OTLP sink has no notion of a per-host key
+binding to disagree with — so under `exporter = "otlp"` no mismatch is ever
+published and the `observability` health section stays silent. Choosing OTLP
+therefore trades this particular misconfiguration guardrail away; keep the
+default `"https"` sink if you want it.
 
 ## 4. The backend: deploy your own Cloudflare Worker
 

--- a/.loom/docs/observability.md
+++ b/.loom/docs/observability.md
@@ -18,7 +18,7 @@ loom-daemon (per host)
   durable disk-backed queue (survives sink outage / sleep)
         │  drains via a jittered-retry loop
         ▼
-  exporter: HttpsExporter (JSON-over-HTTPS POST /ingest)   [OTLP: planned, #4858]
+  exporter: HttpsExporter (default) or OtlpExporter (opt-in, #4858)
         │
         ▼
 Cloudflare Worker backend (deploy-your-own, or the 2AM reference instance)
@@ -66,6 +66,7 @@ Precedence is **env > config > default**, the same rule every other
 | `batchSize` | `LOOM_OBSERVABILITY_BATCH_SIZE` | 50 |
 | `flushIntervalSecs` | `LOOM_OBSERVABILITY_FLUSH_INTERVAL_SECS` | 30 |
 | `queueCapacity` | `LOOM_OBSERVABILITY_QUEUE_CAPACITY` | 2000 |
+| `exporter` | `LOOM_OBSERVABILITY_EXPORTER` | `"https"` (or `"otlp"`, §3) |
 
 The ingest key is **never inline in config** — `ingestKeyFile` is a path the
 daemon reads once at startup and holds only in memory, sent solely as an
@@ -89,18 +90,31 @@ field-by-field reference, the `visibility` anti-leak contract, and the local
 exporter is configured**):
 [`.loom/docs/telemetry-schema.md`](telemetry-schema.md).
 
-## 3. Exporters: HTTPS today, OTLP planned
+## 3. Exporters: HTTPS (default) or OTLP (opt-in)
 
-The only shipped exporter is `HttpsExporter` — JSON-over-HTTPS `POST
-/ingest`, batched (`batchSize`), retried with jitter, backed by the durable
-disk queue so a sink outage or a sleeping host never silently drops data up
-to `queueCapacity`. The `Exporter` trait (`exporter.rs`) and the drain loop
-(`sender.rs`) are both deliberately generic so a second sink is a drop-in
-addition, not a rewrite: an **OTLP exporter is planned as a feature-flagged
-second sink** (epic Phase 4, tracked separately in
-[#4858](https://github.com/rjwalters/loom/issues/4858)) — as of this writing
-that issue is still open, so OTLP support has **not** landed; every host today
-speaks the native HTTPS/JSON wire format only.
+The default exporter is `HttpsExporter` — JSON-over-HTTPS `POST /ingest`,
+batched (`batchSize`), retried with jitter, backed by the durable disk queue
+so a sink outage or a sleeping host never silently drops data up to
+`queueCapacity`. The `Exporter` trait (`exporter.rs`) and the drain loop
+(`sender.rs`) are both deliberately generic, so a second sink is a drop-in
+addition rather than a rewrite: `OtlpExporter` (epic Phase 4, issue
+[#4858](https://github.com/rjwalters/loom/issues/4858)) translates the same
+`TelemetryEnvelope` batches into OTLP logs (`/v1/logs`) and metrics
+(`/v1/metrics`) requests for operators with an existing OpenTelemetry stack
+(a self-hosted collector, Grafana, Honeycomb, …), reusing `sender.rs`'s
+drain/retry loop unchanged.
+
+Select it with `observability.exporter = "otlp"`
+(`LOOM_OBSERVABILITY_EXPORTER` env override; **env > config > default**,
+default `"https"`). It is opt-in twice over: off unless explicitly selected,
+*and* gated behind the `otlp` Cargo feature — a default `loom-daemon` build
+never compiles in the `opentelemetry-proto` dependency, so choosing
+`HttpsExporter` costs nothing extra. The field-by-field
+`TelemetryEnvelope` → OTLP mapping (which record kinds become logs vs.
+metrics; how `host_id` / `emitted_at` / the repo-visibility tag map onto OTLP
+resource/record attributes) is documented in
+`loom-daemon/src/observability/otlp/mod.rs`'s module doc comment, verified by
+`loom-daemon/src/observability/otlp/mapping.rs`'s unit tests.
 
 **The exporter verifies its own identity** (issue #4830). Each `/ingest`
 success response echoes the `host_id` the presented key is bound to; the

--- a/.loom/docs/telemetry-schema.md
+++ b/.loom/docs/telemetry-schema.md
@@ -331,4 +331,26 @@ loom-daemon sweep-outcomes --json
 Purely file-based (like `loom-daemon calibrate`) — no running daemon required.
 `--workspace PATH` selects a different repo root (default `.`).
 
+## Alternative sinks: the OTLP exporter (Epic #4702, Phase 4 — issue #4858)
+
+The native JSON-over-HTTPS push (`exporter::HttpsExporter`, above) is the
+default sink and stays that way for backward compatibility. Operators with an
+existing OpenTelemetry stack (a self-hosted collector, Grafana, Honeycomb, …)
+can instead select `observability.exporter = "otlp"`
+(`$LOOM_OBSERVABILITY_EXPORTER=otlp` overrides; **env > config > default**,
+default `"https"`), which POSTs to `{observability.endpoint}/v1/logs` and
+`{observability.endpoint}/v1/metrics` using the same `observability.endpoint`
++ `observability.ingestKeyFile` + `Authorization: Bearer` convention as the
+HTTPS sink.
+
+This is opt-in twice over: off by default (`observability.enabled`) *and*
+gated behind the `otlp` Cargo feature — a default `loom-daemon` build never
+compiles in the `opentelemetry-proto` dependency, so choosing `HttpsExporter`
+costs nothing extra. The full `TelemetryEnvelope` → OTLP field mapping (which
+record kinds become OTLP logs vs. metrics, and how `host_id` / `emitted_at` /
+the repo-visibility tag map onto OTLP resource/record attributes) is
+documented at `loom-daemon/src/observability/otlp/mod.rs`'s module doc
+comment, not duplicated here — that Rust doc comment is the source of truth,
+verified by `loom-daemon/src/observability/otlp/mapping.rs`'s unit tests.
+
 [`TelemetryEnvelope`]: #envelope

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,8 +260,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "rand_core",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -371,6 +371,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +403,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -648,6 +669,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +698,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -680,6 +720,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
@@ -687,8 +739,8 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -1225,6 +1277,7 @@ dependencies = [
  "hex",
  "libc",
  "log",
+ "opentelemetry-proto",
  "regex",
  "reqwest",
  "rusqlite",
@@ -1323,6 +1376,43 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "js-sys",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "base64 0.22.1",
+ "const-hex",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "serde",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "option-ext"
@@ -1434,6 +1524,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,6 +1549,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1482,7 +1619,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.2",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -1520,9 +1657,25 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand"
@@ -1532,7 +1685,26 @@ checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1547,7 +1719,16 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1954,7 +2135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "digest",
 ]
 
@@ -2368,6 +2549,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"

--- a/defaults/docs/observability.md
+++ b/defaults/docs/observability.md
@@ -116,7 +116,7 @@ resource/record attributes) is documented in
 `loom-daemon/src/observability/otlp/mod.rs`'s module doc comment, verified by
 `loom-daemon/src/observability/otlp/mapping.rs`'s unit tests.
 
-**The exporter verifies its own identity** (issue #4830). Each `/ingest`
+**The HTTPS exporter verifies its own identity** (issue #4830). Each `/ingest`
 success response echoes the `host_id` the presented key is bound to; the
 exporter compares that against the identity this daemon resolved for itself
 (`$LOOM_HOST_ID` > `$HOSTNAME` > `hostname`). On a disagreement — the wrong
@@ -126,6 +126,14 @@ and `loom-daemon health` reports an `observability DEGRADED` section (exit
 `1`). Nothing else changes: the batch is still acked, and the key's binding
 stays authoritative on the backend. Fix by installing the right key or setting
 `$LOOM_HOST_ID` to match, then restarting the daemon.
+
+This check is specific to the native ingest protocol, which is what defines
+the echo. OTLP/HTTP has no equivalent — a success response carries only
+`partial_success`, and a generic OTLP sink has no notion of a per-host key
+binding to disagree with — so under `exporter = "otlp"` no mismatch is ever
+published and the `observability` health section stays silent. Choosing OTLP
+therefore trades this particular misconfiguration guardrail away; keep the
+default `"https"` sink if you want it.
 
 ## 4. The backend: deploy your own Cloudflare Worker
 

--- a/defaults/docs/observability.md
+++ b/defaults/docs/observability.md
@@ -18,7 +18,7 @@ loom-daemon (per host)
   durable disk-backed queue (survives sink outage / sleep)
         │  drains via a jittered-retry loop
         ▼
-  exporter: HttpsExporter (JSON-over-HTTPS POST /ingest)   [OTLP: planned, #4858]
+  exporter: HttpsExporter (default) or OtlpExporter (opt-in, #4858)
         │
         ▼
 Cloudflare Worker backend (deploy-your-own, or the 2AM reference instance)
@@ -66,6 +66,7 @@ Precedence is **env > config > default**, the same rule every other
 | `batchSize` | `LOOM_OBSERVABILITY_BATCH_SIZE` | 50 |
 | `flushIntervalSecs` | `LOOM_OBSERVABILITY_FLUSH_INTERVAL_SECS` | 30 |
 | `queueCapacity` | `LOOM_OBSERVABILITY_QUEUE_CAPACITY` | 2000 |
+| `exporter` | `LOOM_OBSERVABILITY_EXPORTER` | `"https"` (or `"otlp"`, §3) |
 
 The ingest key is **never inline in config** — `ingestKeyFile` is a path the
 daemon reads once at startup and holds only in memory, sent solely as an
@@ -89,18 +90,31 @@ field-by-field reference, the `visibility` anti-leak contract, and the local
 exporter is configured**):
 [`.loom/docs/telemetry-schema.md`](telemetry-schema.md).
 
-## 3. Exporters: HTTPS today, OTLP planned
+## 3. Exporters: HTTPS (default) or OTLP (opt-in)
 
-The only shipped exporter is `HttpsExporter` — JSON-over-HTTPS `POST
-/ingest`, batched (`batchSize`), retried with jitter, backed by the durable
-disk queue so a sink outage or a sleeping host never silently drops data up
-to `queueCapacity`. The `Exporter` trait (`exporter.rs`) and the drain loop
-(`sender.rs`) are both deliberately generic so a second sink is a drop-in
-addition, not a rewrite: an **OTLP exporter is planned as a feature-flagged
-second sink** (epic Phase 4, tracked separately in
-[#4858](https://github.com/rjwalters/loom/issues/4858)) — as of this writing
-that issue is still open, so OTLP support has **not** landed; every host today
-speaks the native HTTPS/JSON wire format only.
+The default exporter is `HttpsExporter` — JSON-over-HTTPS `POST /ingest`,
+batched (`batchSize`), retried with jitter, backed by the durable disk queue
+so a sink outage or a sleeping host never silently drops data up to
+`queueCapacity`. The `Exporter` trait (`exporter.rs`) and the drain loop
+(`sender.rs`) are both deliberately generic, so a second sink is a drop-in
+addition rather than a rewrite: `OtlpExporter` (epic Phase 4, issue
+[#4858](https://github.com/rjwalters/loom/issues/4858)) translates the same
+`TelemetryEnvelope` batches into OTLP logs (`/v1/logs`) and metrics
+(`/v1/metrics`) requests for operators with an existing OpenTelemetry stack
+(a self-hosted collector, Grafana, Honeycomb, …), reusing `sender.rs`'s
+drain/retry loop unchanged.
+
+Select it with `observability.exporter = "otlp"`
+(`LOOM_OBSERVABILITY_EXPORTER` env override; **env > config > default**,
+default `"https"`). It is opt-in twice over: off unless explicitly selected,
+*and* gated behind the `otlp` Cargo feature — a default `loom-daemon` build
+never compiles in the `opentelemetry-proto` dependency, so choosing
+`HttpsExporter` costs nothing extra. The field-by-field
+`TelemetryEnvelope` → OTLP mapping (which record kinds become logs vs.
+metrics; how `host_id` / `emitted_at` / the repo-visibility tag map onto OTLP
+resource/record attributes) is documented in
+`loom-daemon/src/observability/otlp/mod.rs`'s module doc comment, verified by
+`loom-daemon/src/observability/otlp/mapping.rs`'s unit tests.
 
 **The exporter verifies its own identity** (issue #4830). Each `/ingest`
 success response echoes the `host_id` the presented key is bound to; the

--- a/loom-daemon/Cargo.toml
+++ b/loom-daemon/Cargo.toml
@@ -26,6 +26,15 @@ hex = "0.4.3"
 # never touches.
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "rustls-native-certs", "json"] }
 libc = "0.2"
+# OTLP wire-format types for the optional `otlp` exporter (#4858, Epic #4702
+# Phase 4) — gated behind the `otlp` feature so a default (`HttpsExporter`-
+# only) build adds no new dependency. `gen-tonic-messages` generates the OTLP
+# request/record structs via `prost` (message types only); `with-serde` adds
+# JSON (de)serialization to those structs. `gen-tonic`/`tonic` themselves are
+# deliberately NOT enabled — `OtlpExporter` posts the JSON encoding over the
+# existing `reqwest` client (reusing `super::sender`'s drain/retry loop), so
+# no gRPC transport stack is pulled in.
+opentelemetry-proto = { version = "0.32.0", default-features = false, features = ["logs", "metrics", "gen-tonic-messages", "with-serde"], optional = true }
 
 [dev-dependencies]
 tempfile = "3.27"
@@ -36,3 +45,9 @@ criterion = "0.8"
 [[bench]]
 name = "terminal_benchmarks"
 harness = false
+
+[features]
+# Off by default — enabling it selects `OtlpExporter` (see
+# `observability.exporter = "otlp"`); a plain `cargo build`/`cargo test` never
+# pulls in `opentelemetry-proto`.
+otlp = ["dep:opentelemetry-proto"]

--- a/loom-daemon/src/observability/mod.rs
+++ b/loom-daemon/src/observability/mod.rs
@@ -768,10 +768,14 @@ mod tests {
     /// `exporter=otlp` in a build that does NOT have the `otlp` Cargo
     /// feature compiled in must degrade to disabled (never panic, never
     /// silently fall back to the HTTPS sink the operator did not ask for).
+    /// `#[tokio::test]`, not a plain `#[test]`: `spawn_task` calls
+    /// `collector::spawn_task` (which needs a Tokio reactor) *before* it
+    /// branches on `exporter_kind`, so even the returns-`None` path must run
+    /// inside a runtime — same as the `#[cfg(feature = "otlp")]` sibling below.
     #[cfg(not(feature = "otlp"))]
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn spawn_task_otlp_requested_without_the_feature_returns_none() {
+    async fn spawn_task_otlp_requested_without_the_feature_returns_none() {
         clear_env();
         let bus = EventBus::new();
         let dir = tempdir().unwrap();

--- a/loom-daemon/src/observability/mod.rs
+++ b/loom-daemon/src/observability/mod.rs
@@ -15,6 +15,11 @@
 //!   [`exporter::HttpsExporter`] JSON-over-HTTPS push implementation, and the
 //!   jittered-retry drain loop that pulls batches off the queue and pushes
 //!   them to the sink.
+//! - `otlp` (Epic #4702, Phase 4 — issue #4858, behind the `otlp` Cargo
+//!   feature) — a second [`exporter::Exporter`] implementation for operators
+//!   with an existing OpenTelemetry stack, selected via
+//!   `observability.exporter = "otlp"` ([`resolve_exporter`]). Off by
+//!   default; [`exporter::HttpsExporter`] stays the default sink.
 //!
 //! # Off by default (FLAGS-OFF posture)
 //!
@@ -43,6 +48,13 @@
 //! record. A hostile/broken sink can therefore, at worst, make this daemon
 //! report a mismatch that is not real; it cannot steer the daemon.
 //!
+//! That check is **specific to the native HTTPS ingest protocol**, which is
+//! what defines the echo: the `otlp` sink below has no equivalent (OTLP/HTTP
+//! success responses carry only `partial_success`), so under
+//! `observability.exporter = "otlp"` no [`HostIdStatus`] is registered and
+//! [`global_host_id_mismatch`] reads `None` — see the OTLP arm of
+//! [`spawn_task`] for the full rationale.
+//!
 //! # Ingest key handling
 //!
 //! The ingest key is read once at startup from `ingestKeyFile` (never
@@ -54,6 +66,8 @@
 
 pub mod collector;
 pub mod exporter;
+#[cfg(feature = "otlp")]
+pub mod otlp;
 pub mod queue;
 pub mod sender;
 
@@ -78,6 +92,8 @@ pub const BATCH_SIZE_ENV: &str = "LOOM_OBSERVABILITY_BATCH_SIZE";
 pub const FLUSH_INTERVAL_SECS_ENV: &str = "LOOM_OBSERVABILITY_FLUSH_INTERVAL_SECS";
 /// `observability.queueCapacity` env override.
 pub const QUEUE_CAPACITY_ENV: &str = "LOOM_OBSERVABILITY_QUEUE_CAPACITY";
+/// `observability.exporter` env override (#4858) — `"https"` or `"otlp"`.
+pub const EXPORTER_ENV: &str = "LOOM_OBSERVABILITY_EXPORTER";
 
 /// Default batch size (envelopes per HTTP POST) when unset at every tier.
 pub const DEFAULT_BATCH_SIZE: usize = 50;
@@ -101,6 +117,27 @@ pub struct ObservabilityConfig {
     pub batch_size: Option<usize>,
     pub flush_interval_secs: Option<u64>,
     pub queue_capacity: Option<usize>,
+    /// Raw `observability.exporter` string, resolved by [`resolve_exporter`]
+    /// (#4858) — not parsed to [`ExporterKind`] at read time so an unknown
+    /// value can be logged (and degraded to the default) at the single call
+    /// site that already owns exporter selection.
+    pub exporter: Option<String>,
+}
+
+/// Which [`exporter::Exporter`] implementation [`spawn_task`] selects.
+/// Resolved by [`resolve_exporter`] — **env > config > default**
+/// ([`ExporterKind::Https`]), matching every other `observability.*` knob's
+/// precedence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExporterKind {
+    /// Native JSON-over-HTTPS push ([`exporter::HttpsExporter`]) — the
+    /// default, for backward compatibility with every deployment predating
+    /// this issue.
+    Https,
+    /// OTLP/HTTP+JSON push (`otlp::OtlpExporter`, only compiled in behind the
+    /// `otlp` Cargo feature) — an escape hatch for an existing OpenTelemetry
+    /// stack.
+    Otlp,
 }
 
 /// Read the `observability` block from `root`'s resolved config
@@ -138,6 +175,11 @@ pub fn read_config(root: &Path) -> ObservabilityConfig {
             .and_then(serde_json::Value::as_u64)
             .and_then(|v| usize::try_from(v).ok())
             .filter(|v| *v > 0),
+        exporter: block
+            .get("exporter")
+            .and_then(serde_json::Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string),
     }
 }
 
@@ -279,6 +321,24 @@ pub fn global_host_id_mismatch() -> Option<crate::types::ObservabilityHostIdMism
     GLOBAL_HOST_ID_STATUS.get().and_then(|s| s.snapshot())
 }
 
+/// **env > config > default** ([`ExporterKind::Https`]). An unrecognized
+/// value at either tier (anything but a case-insensitive `"https"` or
+/// `"otlp"`) is logged and degrades to the default, the same "malformed
+/// input never panics/blocks startup" posture as the rest of this module —
+/// it is never a hard error.
+#[must_use]
+pub fn resolve_exporter(config: &ObservabilityConfig) -> ExporterKind {
+    let raw = env_nonempty(EXPORTER_ENV).or_else(|| config.exporter.clone());
+    match raw.as_deref().map(str::to_ascii_lowercase).as_deref() {
+        None | Some("https") => ExporterKind::Https,
+        Some("otlp") => ExporterKind::Otlp,
+        Some(other) => {
+            log::warn!("observability: unrecognized exporter {other:?} — falling back to https");
+            ExporterKind::Https
+        }
+    }
+}
+
 /// Read `path` and return its trimmed contents as the ingest key. Every
 /// failure (missing file, unreadable, empty after trimming) is logged
 /// **by path only** — the key itself never reaches a log line — and yields
@@ -340,35 +400,22 @@ pub fn spawn_task(
         return None;
     };
     let ingest_key = read_ingest_key(&key_file)?;
-    // Resolved ONCE and threaded into both consumers below (Issue #4830): the
-    // collector stamps it on every envelope and the exporter checks the backend's
-    // echo against it. Two independent `host_identity()` calls could not disagree
-    // today, but a single value makes that structurally true rather than
-    // incidentally so — and the whole point of the check is that the two halves
-    // being compared are the *same* identity the records are filed under.
+    // Resolved ONCE and threaded into every consumer below (Issue #4830): the
+    // collector stamps it on every envelope and the HTTPS exporter checks the
+    // backend's echo against it. Two independent `host_identity()` calls could
+    // not disagree today, but a single value makes that structurally true rather
+    // than incidentally so — and the whole point of the check is that the two
+    // halves being compared are the *same* identity the records are filed under.
     let host_id = crate::sweep_registry::host_identity();
-    let host_id_status = Arc::new(HostIdStatus::default());
-    register_global_host_id_status(host_id_status.clone());
-    let exporter = match HttpsExporter::new(
-        endpoint.clone(),
-        ingest_key,
-        host_id.clone(),
-        host_id_status,
-    ) {
-        Ok(exporter) => exporter,
-        Err(error) => {
-            log::warn!("observability: failed to construct HTTPS exporter for {endpoint}: {error} — export off");
-            return None;
-        }
-    };
+    let exporter_kind = resolve_exporter(config);
 
     let batch_size = resolve_batch_size(config);
     let flush_interval = Duration::from_secs(resolve_flush_interval_secs(config));
     let capacity = resolve_queue_capacity(config);
     let queue_path = queue::default_queue_path(&workspace_root);
     log::info!(
-        "observability: enabled (endpoint={endpoint}, batch_size={batch_size}, \
-         flush_interval={}s, queue_capacity={capacity})",
+        "observability: enabled (exporter={exporter_kind:?}, endpoint={endpoint}, \
+         batch_size={batch_size}, flush_interval={}s, queue_capacity={capacity})",
         flush_interval.as_secs()
     );
     let queue = Arc::new(DurableQueue::open(queue_path, capacity));
@@ -377,11 +424,90 @@ pub fn spawn_task(
         bus,
         queue.clone(),
         workspace_root,
-        host_id,
+        host_id.clone(),
         SNAPSHOT_INTERVAL,
         daemon_started_at,
     );
-    let sender_handle = sender::spawn_task(queue, exporter, batch_size, flush_interval);
+    // The two branches below construct different concrete `E: Exporter`
+    // types and each call `sender::spawn_task` with their own — no
+    // dyn/boxing needed, since both calls return the same
+    // `tokio::task::JoinHandle<()>` regardless of `E` (see `exporter.rs`'s
+    // module docs on why `Exporter` uses native `async fn` over
+    // `async-trait`).
+    let sender_handle = match exporter_kind {
+        ExporterKind::Https => {
+            // Host-identity mismatch detection (Issue #4830) is created and
+            // registered *inside* this arm, not before the dispatch: it is a
+            // property of the native ingest protocol, not of exporting in
+            // general (see the OTLP arm below). Registering it only when the
+            // HTTPS sink actually starts keeps `global_host_id_mismatch()`
+            // reading `None` under any other sink, which is exactly the
+            // "the exporter never started" semantics `status`/`health`
+            // already handle.
+            let host_id_status = Arc::new(HostIdStatus::default());
+            register_global_host_id_status(host_id_status.clone());
+            let exporter = match HttpsExporter::new(
+                endpoint.clone(),
+                ingest_key,
+                host_id,
+                host_id_status,
+            ) {
+                Ok(exporter) => exporter,
+                Err(error) => {
+                    log::warn!(
+                        "observability: failed to construct HTTPS exporter for {endpoint}: {error} — export off"
+                    );
+                    return None;
+                }
+            };
+            sender::spawn_task(queue, exporter, batch_size, flush_interval)
+        }
+        ExporterKind::Otlp => {
+            // No `HostIdStatus` wiring here, deliberately (Issue #4830 vs.
+            // #4858). The mismatch check is not a generic exporter concern
+            // that OTLP is missing out on — it is a *native-ingest protocol*
+            // feature: `HttpsExporter::check_host_identity` parses the
+            // Loom `/ingest` success body (`{"accepted":N,"host_id":"…"}`)
+            // and compares the backend's echoed `host_id` against this
+            // daemon's own, which is only meaningful because the Cloudflare
+            // backend binds each ingest key to exactly one host and reports
+            // that binding back.
+            //
+            // OTLP/HTTP has no such echo: a success response is an
+            // `ExportLogsServiceResponse`/`ExportMetricsServiceResponse`
+            // whose only payload is `partial_success`, and a generic OTLP
+            // sink (an OpenTelemetry Collector, Grafana, Honeycomb) has no
+            // concept of a per-host key binding to disagree with in the
+            // first place. Threading a `HostIdStatus` in here would hand the
+            // OTLP exporter a handle it could never write to — parity in the
+            // signature only, while `loom-daemon status`/`health` gained a
+            // field that is unconditionally `None` and indistinguishable
+            // from "checked, and they agree". Better to leave the surface
+            // honestly absent until an OTLP-side identity signal exists to
+            // check against.
+            #[cfg(feature = "otlp")]
+            {
+                let exporter = match otlp::OtlpExporter::new(endpoint.clone(), ingest_key) {
+                    Ok(exporter) => exporter,
+                    Err(error) => {
+                        log::warn!(
+                            "observability: failed to construct OTLP exporter for {endpoint}: {error} — export off"
+                        );
+                        return None;
+                    }
+                };
+                sender::spawn_task(queue, exporter, batch_size, flush_interval)
+            }
+            #[cfg(not(feature = "otlp"))]
+            {
+                log::warn!(
+                    "observability: exporter=otlp requested but this daemon build was not \
+                     compiled with the `otlp` Cargo feature — export off"
+                );
+                return None;
+            }
+        }
+    };
     Some(vec![collector_handle, sender_handle])
 }
 
@@ -399,6 +525,7 @@ mod tests {
         BATCH_SIZE_ENV,
         FLUSH_INTERVAL_SECS_ENV,
         QUEUE_CAPACITY_ENV,
+        EXPORTER_ENV,
     ];
 
     fn clear_env() {
@@ -424,6 +551,57 @@ mod tests {
         assert_eq!(resolve_batch_size(&config), DEFAULT_BATCH_SIZE);
         assert_eq!(resolve_flush_interval_secs(&config), DEFAULT_FLUSH_INTERVAL_SECS);
         assert_eq!(resolve_queue_capacity(&config), DEFAULT_QUEUE_CAPACITY);
+        assert_eq!(resolve_exporter(&config), ExporterKind::Https, "https is the default exporter");
+    }
+
+    // ------------------------------------------------------------------
+    // resolve_exporter — env > config > default("https"); unknown ⇒ https.
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn resolve_exporter_env_overrides_config() {
+        clear_env();
+        let config = ObservabilityConfig {
+            exporter: Some("otlp".to_string()),
+            ..Default::default()
+        };
+        std::env::set_var(EXPORTER_ENV, "https");
+        assert_eq!(resolve_exporter(&config), ExporterKind::Https);
+        clear_env();
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_exporter_config_wins_over_default_when_no_env_set() {
+        clear_env();
+        let config = ObservabilityConfig {
+            exporter: Some("otlp".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(resolve_exporter(&config), ExporterKind::Otlp);
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_exporter_is_case_insensitive() {
+        clear_env();
+        let config = ObservabilityConfig {
+            exporter: Some("OTLP".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(resolve_exporter(&config), ExporterKind::Otlp);
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_exporter_unknown_value_falls_back_to_https() {
+        clear_env();
+        let config = ObservabilityConfig {
+            exporter: Some("datadog".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(resolve_exporter(&config), ExporterKind::Https);
     }
 
     #[test]
@@ -472,7 +650,8 @@ mod tests {
                 "ingestKeyFile": "/etc/loom/ingest.key",
                 "batchSize": 25,
                 "flushIntervalSecs": 45,
-                "queueCapacity": 1000
+                "queueCapacity": 1000,
+                "exporter": "otlp"
             }}"#,
         )
         .unwrap();
@@ -485,6 +664,7 @@ mod tests {
         assert_eq!(config.batch_size, Some(25));
         assert_eq!(config.flush_interval_secs, Some(45));
         assert_eq!(config.queue_capacity, Some(1000));
+        assert_eq!(config.exporter.as_deref(), Some("otlp"));
     }
 
     #[test]
@@ -579,6 +759,59 @@ mod tests {
         };
         let handles = spawn_task(&config, dir.path().to_path_buf(), &bus, Instant::now());
         let handles = handles.expect("fully configured ⇒ spawn_task must return Some");
+        assert_eq!(handles.len(), 2, "collector + sender");
+        for handle in handles {
+            handle.abort();
+        }
+    }
+
+    /// `exporter=otlp` in a build that does NOT have the `otlp` Cargo
+    /// feature compiled in must degrade to disabled (never panic, never
+    /// silently fall back to the HTTPS sink the operator did not ask for).
+    #[cfg(not(feature = "otlp"))]
+    #[test]
+    #[serial]
+    fn spawn_task_otlp_requested_without_the_feature_returns_none() {
+        clear_env();
+        let bus = EventBus::new();
+        let dir = tempdir().unwrap();
+        let key_path = dir.path().join("ingest.key");
+        std::fs::write(&key_path, "s3cr3t\n").unwrap();
+        let config = ObservabilityConfig {
+            enabled: Some(true),
+            endpoint: Some("https://ingest.example.com/v1/telemetry".to_string()),
+            ingest_key_file: Some(key_path.to_string_lossy().to_string()),
+            exporter: Some("otlp".to_string()),
+            ..Default::default()
+        };
+        let handles = spawn_task(&config, dir.path().to_path_buf(), &bus, Instant::now());
+        assert!(handles.is_none());
+    }
+
+    /// The `otlp`-feature counterpart of
+    /// `spawn_task_fully_configured_spawns_two_tasks`: `exporter=otlp`
+    /// with the feature compiled in spawns the same collector+sender pair,
+    /// just wired to `otlp::OtlpExporter` instead of `HttpsExporter`.
+    #[cfg(feature = "otlp")]
+    #[tokio::test]
+    #[serial]
+    async fn spawn_task_otlp_exporter_spawns_two_tasks() {
+        clear_env();
+        let bus = EventBus::new();
+        let dir = tempdir().unwrap();
+        let key_path = dir.path().join("ingest.key");
+        std::fs::write(&key_path, "s3cr3t\n").unwrap();
+        let config = ObservabilityConfig {
+            enabled: Some(true),
+            endpoint: Some("https://collector.example.com".to_string()),
+            ingest_key_file: Some(key_path.to_string_lossy().to_string()),
+            exporter: Some("otlp".to_string()),
+            flush_interval_secs: Some(3600), // avoid a real network attempt during the test
+            ..Default::default()
+        };
+        let handles = spawn_task(&config, dir.path().to_path_buf(), &bus, Instant::now());
+        let handles =
+            handles.expect("fully configured otlp exporter ⇒ spawn_task must return Some");
         assert_eq!(handles.len(), 2, "collector + sender");
         for handle in handles {
             handle.abort();

--- a/loom-daemon/src/observability/otlp/mapping.rs
+++ b/loom-daemon/src/observability/otlp/mapping.rs
@@ -1,0 +1,911 @@
+//! Pure `TelemetryEnvelope` → OTLP record mapping (no network I/O). See the
+//! parent module's doc comment for the mapping table this file implements;
+//! this module is the field-by-field implementation plus its unit tests.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+use opentelemetry_proto::tonic::common::v1::{
+    any_value, AnyValue, ArrayValue, KeyValue, KeyValueList,
+};
+use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs, SeverityNumber};
+use opentelemetry_proto::tonic::metrics::v1::{
+    metric, number_data_point, Gauge, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics,
+};
+use opentelemetry_proto::tonic::resource::v1::Resource;
+
+use crate::telemetry::{RepoVisibility, SweepResult, TelemetryEnvelope, TelemetryRecord};
+
+// ============================================================================
+// Small AnyValue / KeyValue constructors
+// ============================================================================
+
+fn any_string(value: impl Into<String>) -> AnyValue {
+    AnyValue {
+        value: Some(any_value::Value::StringValue(value.into())),
+    }
+}
+
+fn kv(key: &str, value: AnyValue) -> KeyValue {
+    KeyValue {
+        key: key.to_string(),
+        value: Some(value),
+        ..Default::default()
+    }
+}
+
+fn kv_string(key: &str, value: impl Into<String>) -> KeyValue {
+    kv(key, any_string(value))
+}
+
+fn kv_int(key: &str, value: i64) -> KeyValue {
+    kv(
+        key,
+        AnyValue {
+            value: Some(any_value::Value::IntValue(value)),
+        },
+    )
+}
+
+/// UNIX-epoch nanoseconds for `ts`, floored at 0 — `chrono`'s
+/// `timestamp_nanos_opt` only returns `None` far outside any timestamp this
+/// daemon ever produces (year ~1677 or ~2262), so the floor is unreachable in
+/// practice and exists only to avoid a panic/wraparound on the conversion.
+fn nanos(ts: DateTime<Utc>) -> u64 {
+    ts.timestamp_nanos_opt()
+        .and_then(|n| u64::try_from(n).ok())
+        .unwrap_or(0)
+}
+
+fn visibility_str(visibility: RepoVisibility) -> &'static str {
+    match visibility {
+        RepoVisibility::Public => "public",
+        RepoVisibility::Private => "private",
+    }
+}
+
+fn result_str(result: SweepResult) -> &'static str {
+    match result {
+        SweepResult::Success => "success",
+        SweepResult::Failure => "failure",
+        SweepResult::Cancelled => "cancelled",
+        SweepResult::Blocked => "blocked",
+    }
+}
+
+/// `Failure` → `Error`, `Blocked` → `Warn`, everything else → `Info` — the
+/// only two `SweepResult` variants that represent something worth a reader's
+/// elevated attention.
+fn severity_for_result(result: SweepResult) -> SeverityNumber {
+    match result {
+        SweepResult::Failure => SeverityNumber::Error,
+        SweepResult::Blocked => SeverityNumber::Warn,
+        SweepResult::Success | SweepResult::Cancelled => SeverityNumber::Info,
+    }
+}
+
+fn severity_text(severity: SeverityNumber) -> &'static str {
+    match severity {
+        SeverityNumber::Error => "ERROR",
+        SeverityNumber::Warn => "WARN",
+        _ => "INFO",
+    }
+}
+
+/// A `Resource` describing the emitting daemon host. `daemon_version` is only
+/// known from a `host.health` record, so it is threaded in separately rather
+/// than read off `envelope.record` — see [`build_metrics_request`].
+fn resource_for_host(host_id: &str, daemon_version: Option<&str>) -> Resource {
+    let mut attributes = vec![
+        kv_string("service.name", "loom-daemon"),
+        kv_string("service.instance.id", host_id),
+        kv_string("host.id", host_id),
+    ];
+    if let Some(version) = daemon_version {
+        attributes.push(kv_string("service.version", version));
+    }
+    Resource {
+        attributes,
+        ..Default::default()
+    }
+}
+
+// ============================================================================
+// Logs — the four sweep-lifecycle record kinds
+// ============================================================================
+
+/// Maps one lifecycle-kind envelope to a `LogRecord`. Returns `None` for the
+/// two host-level record kinds (`tokens.snapshot`, `host.health`) — those
+/// become metrics instead (see [`metric_samples_for`]).
+fn log_record_for(envelope: &TelemetryEnvelope) -> Option<LogRecord> {
+    let time_unix_nano = nanos(envelope.emitted_at);
+    let (event_name, severity, body, attributes) = match &envelope.record {
+        TelemetryRecord::SweepStarted(r) => {
+            let mut attributes = vec![
+                kv_string("loom.repo", r.repo.clone()),
+                kv_string("loom.repo.visibility", visibility_str(r.visibility)),
+                kv_int("loom.issue", i64::from(r.issue)),
+                kv_string("loom.sweep_id", r.sweep_id.clone()),
+            ];
+            if let Some(model) = &r.model {
+                attributes.push(kv_string("loom.model", model.clone()));
+            }
+            if let Some(effort) = &r.effort {
+                attributes.push(kv_string("loom.effort", effort.clone()));
+            }
+            (
+                "sweep.started",
+                SeverityNumber::Info,
+                format!("sweep started: {} issue #{}", r.repo, r.issue),
+                attributes,
+            )
+        }
+        TelemetryRecord::SweepPhase(r) => (
+            "sweep.phase",
+            SeverityNumber::Info,
+            format!("sweep phase {}: {} issue #{}", r.phase, r.repo, r.issue),
+            vec![
+                kv_string("loom.repo", r.repo.clone()),
+                kv_string("loom.repo.visibility", visibility_str(r.visibility)),
+                kv_int("loom.issue", i64::from(r.issue)),
+                kv_string("loom.sweep_id", r.sweep_id.clone()),
+                kv_string("loom.phase", r.phase.clone()),
+            ],
+        ),
+        TelemetryRecord::SweepCompleted(r) => (
+            "sweep.completed",
+            severity_for_result(r.result),
+            format!("sweep completed ({}): {} issue #{}", result_str(r.result), r.repo, r.issue),
+            vec![
+                kv_string("loom.repo", r.repo.clone()),
+                kv_string("loom.repo.visibility", visibility_str(r.visibility)),
+                kv_int("loom.issue", i64::from(r.issue)),
+                kv_string("loom.sweep_id", r.sweep_id.clone()),
+                kv_string("loom.result", result_str(r.result)),
+            ],
+        ),
+        TelemetryRecord::SweepOutcome(r) => {
+            let mut attributes = vec![
+                kv_string("loom.repo", r.repo.clone()),
+                kv_string("loom.repo.visibility", visibility_str(r.visibility)),
+                kv_int("loom.issue", i64::from(r.issue)),
+                kv_string("loom.sweep_id", r.sweep_id.clone()),
+                kv_string("loom.result", result_str(r.result)),
+                kv_int("loom.total_duration_sec", r.total_duration_sec),
+            ];
+            if let Some(model) = &r.model {
+                attributes.push(kv_string("loom.model", model.clone()));
+            }
+            if let Some(effort) = &r.effort {
+                attributes.push(kv_string("loom.effort", effort.clone()));
+            }
+            if let Some(pr_number) = r.pr_number {
+                attributes.push(kv_int("loom.pr_number", i64::from(pr_number)));
+            }
+            for (key, value) in &r.config {
+                attributes.push(kv_string(&format!("loom.config.{key}"), value.clone()));
+            }
+            if !r.phase_durations.is_empty() {
+                let entries = r
+                    .phase_durations
+                    .iter()
+                    .map(|phase_duration| AnyValue {
+                        value: Some(any_value::Value::KvlistValue(KeyValueList {
+                            values: vec![
+                                kv_string("phase", phase_duration.phase.clone()),
+                                kv_int("duration_sec", phase_duration.duration_sec),
+                            ],
+                        })),
+                    })
+                    .collect();
+                attributes.push(kv(
+                    "loom.phase_durations",
+                    AnyValue {
+                        value: Some(any_value::Value::ArrayValue(ArrayValue { values: entries })),
+                    },
+                ));
+            }
+            (
+                "sweep.outcome",
+                severity_for_result(r.result),
+                format!(
+                    "sweep outcome ({}): {} issue #{}, {}s total",
+                    result_str(r.result),
+                    r.repo,
+                    r.issue,
+                    r.total_duration_sec
+                ),
+                attributes,
+            )
+        }
+        TelemetryRecord::TokensSnapshot(_) | TelemetryRecord::HostHealth(_) => return None,
+    };
+    Some(LogRecord {
+        time_unix_nano,
+        observed_time_unix_nano: time_unix_nano,
+        severity_number: severity as i32,
+        severity_text: severity_text(severity).to_string(),
+        body: Some(any_string(body)),
+        attributes,
+        event_name: event_name.to_string(),
+        ..Default::default()
+    })
+}
+
+/// Groups every lifecycle-kind envelope in `envelopes` into one
+/// `ExportLogsServiceRequest`, one `ResourceLogs` entry per distinct
+/// `host_id`. Returns `None` when the batch carries no lifecycle-kind
+/// envelope at all (e.g. an all-metrics batch), so the caller can skip the
+/// `/v1/logs` POST entirely.
+pub(super) fn build_logs_request(
+    envelopes: &[TelemetryEnvelope],
+) -> Option<ExportLogsServiceRequest> {
+    let mut by_host: BTreeMap<&str, Vec<LogRecord>> = BTreeMap::new();
+    for envelope in envelopes {
+        if let Some(log_record) = log_record_for(envelope) {
+            by_host
+                .entry(envelope.host_id.as_str())
+                .or_default()
+                .push(log_record);
+        }
+    }
+    if by_host.is_empty() {
+        return None;
+    }
+    let resource_logs = by_host
+        .into_iter()
+        .map(|(host_id, log_records)| ResourceLogs {
+            resource: Some(resource_for_host(host_id, None)),
+            scope_logs: vec![ScopeLogs {
+                log_records,
+                ..Default::default()
+            }],
+            ..Default::default()
+        })
+        .collect();
+    Some(ExportLogsServiceRequest { resource_logs })
+}
+
+// ============================================================================
+// Metrics — the two host-level record kinds
+// ============================================================================
+
+/// One measured field, ready to become a `Gauge` `NumberDataPoint` once
+/// grouped by (`host_id`, `name`) in [`build_metrics_request`].
+struct MetricSample {
+    name: &'static str,
+    description: &'static str,
+    unit: &'static str,
+    attributes: Vec<KeyValue>,
+    value: number_data_point::Value,
+    time_unix_nano: u64,
+}
+
+/// Maps one host-level envelope to zero or more [`MetricSample`]s. Returns an
+/// empty `Vec` for the four lifecycle-kind records (those become log
+/// records instead — see [`log_record_for`]) and for any optional field left
+/// unmeasured on this sample (the daemon's "unknown != zero" contract: an
+/// absent measurement produces no data point, never a fabricated zero).
+fn metric_samples_for(envelope: &TelemetryEnvelope) -> Vec<MetricSample> {
+    let time_unix_nano = nanos(envelope.emitted_at);
+    match &envelope.record {
+        TelemetryRecord::HostHealth(r) => {
+            let mut samples = vec![
+                MetricSample {
+                    name: "loom.host.uptime_seconds",
+                    description: "Daemon uptime.",
+                    unit: "s",
+                    attributes: Vec::new(),
+                    value: number_data_point::Value::AsInt(
+                        i64::try_from(r.uptime_sec).unwrap_or(i64::MAX),
+                    ),
+                    time_unix_nano,
+                },
+                MetricSample {
+                    name: "loom.host.logical_cpus",
+                    description: "Logical CPU count.",
+                    unit: "{cpu}",
+                    attributes: Vec::new(),
+                    value: number_data_point::Value::AsInt(
+                        i64::try_from(r.logical_cpus).unwrap_or(i64::MAX),
+                    ),
+                    time_unix_nano,
+                },
+            ];
+            if let Some(cpu_idle_fraction) = r.cpu_idle_fraction {
+                samples.push(MetricSample {
+                    name: "loom.host.cpu_idle_fraction",
+                    description: "Measured CPU idle fraction (0..1).",
+                    unit: "1",
+                    attributes: Vec::new(),
+                    value: number_data_point::Value::AsDouble(cpu_idle_fraction),
+                    time_unix_nano,
+                });
+            }
+            if let Some(load_per_core) = r.load_per_core {
+                samples.push(MetricSample {
+                    name: "loom.host.load_per_core",
+                    description: "1-minute load average per logical core.",
+                    unit: "1",
+                    attributes: Vec::new(),
+                    value: number_data_point::Value::AsDouble(load_per_core),
+                    time_unix_nano,
+                });
+            }
+            if let Some(worktree_root_free_gb) = r.worktree_root_free_gb {
+                samples.push(MetricSample {
+                    name: "loom.host.worktree_root_free_gb",
+                    description: "Free space on the worktree-root scratch volume.",
+                    unit: "GBy",
+                    attributes: Vec::new(),
+                    value: number_data_point::Value::AsInt(
+                        i64::try_from(worktree_root_free_gb).unwrap_or(i64::MAX),
+                    ),
+                    time_unix_nano,
+                });
+            }
+            samples
+        }
+        TelemetryRecord::TokensSnapshot(r) => {
+            let mut samples = Vec::new();
+            for account in &r.accounts {
+                let mut attributes = vec![kv_string("account", account.account.clone())];
+                if let Some(rank) = account.rank {
+                    attributes.push(kv_int("rank", i64::from(rank)));
+                }
+                if let Some(usage_fraction) = account.usage_fraction {
+                    samples.push(MetricSample {
+                        name: "loom.tokens.usage_fraction",
+                        description: "Fraction of the current limit window consumed (0..1).",
+                        unit: "1",
+                        attributes: attributes.clone(),
+                        value: number_data_point::Value::AsDouble(usage_fraction),
+                        time_unix_nano,
+                    });
+                }
+                samples.push(MetricSample {
+                    name: "loom.tokens.exhausted",
+                    description: "Whether the account is currently excluded from the usable pool (1 = exhausted).",
+                    unit: "1",
+                    attributes,
+                    value: number_data_point::Value::AsInt(i64::from(account.exhausted)),
+                    time_unix_nano,
+                });
+            }
+            samples
+        }
+        TelemetryRecord::SweepStarted(_)
+        | TelemetryRecord::SweepPhase(_)
+        | TelemetryRecord::SweepCompleted(_)
+        | TelemetryRecord::SweepOutcome(_) => Vec::new(),
+    }
+}
+
+/// Groups every host-level envelope in `envelopes` into one
+/// `ExportMetricsServiceRequest`, one `ResourceMetrics` entry per distinct
+/// `host_id` and one `Gauge` `Metric` per distinct metric name within that
+/// host. Returns `None` when the batch carries no host-level envelope at all
+/// (e.g. an all-lifecycle-events batch), so the caller can skip the
+/// `/v1/metrics` POST entirely.
+pub(super) fn build_metrics_request(
+    envelopes: &[TelemetryEnvelope],
+) -> Option<ExportMetricsServiceRequest> {
+    let mut daemon_version_by_host: BTreeMap<&str, &str> = BTreeMap::new();
+    for envelope in envelopes {
+        if let TelemetryRecord::HostHealth(r) = &envelope.record {
+            daemon_version_by_host.insert(envelope.host_id.as_str(), r.daemon_version.as_str());
+        }
+    }
+
+    // (description, unit, data points), keyed by metric name, within each host.
+    type MetricsForHost =
+        BTreeMap<&'static str, (&'static str, &'static str, Vec<NumberDataPoint>)>;
+    let mut by_host: BTreeMap<&str, MetricsForHost> = BTreeMap::new();
+    for envelope in envelopes {
+        let samples = metric_samples_for(envelope);
+        if samples.is_empty() {
+            continue;
+        }
+        let host_metrics = by_host.entry(envelope.host_id.as_str()).or_default();
+        for sample in samples {
+            let (_, _, data_points) = host_metrics.entry(sample.name).or_insert((
+                sample.description,
+                sample.unit,
+                Vec::new(),
+            ));
+            data_points.push(NumberDataPoint {
+                attributes: sample.attributes,
+                time_unix_nano: sample.time_unix_nano,
+                value: Some(sample.value),
+                ..Default::default()
+            });
+        }
+    }
+    if by_host.is_empty() {
+        return None;
+    }
+    let resource_metrics = by_host
+        .into_iter()
+        .map(|(host_id, metrics)| {
+            let metrics = metrics
+                .into_iter()
+                .map(|(name, (description, unit, data_points))| Metric {
+                    name: name.to_string(),
+                    description: description.to_string(),
+                    unit: unit.to_string(),
+                    data: Some(metric::Data::Gauge(Gauge { data_points })),
+                    ..Default::default()
+                })
+                .collect();
+            ResourceMetrics {
+                resource: Some(resource_for_host(
+                    host_id,
+                    daemon_version_by_host.get(host_id).copied(),
+                )),
+                scope_metrics: vec![ScopeMetrics {
+                    metrics,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }
+        })
+        .collect();
+    Some(ExportMetricsServiceRequest { resource_metrics })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::telemetry::{
+        HostHealthRecord, PhaseDuration, SweepCompletedRecord, SweepOutcomeRecord,
+        SweepPhaseRecord, SweepStartedRecord, TokenAccountState, TokenSnapshotRecord,
+    };
+
+    fn ts() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-07-30T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn envelope(host_id: &str, record: TelemetryRecord) -> TelemetryEnvelope {
+        let mut envelope = TelemetryEnvelope::new(host_id, record);
+        envelope.emitted_at = ts();
+        envelope
+    }
+
+    fn sweep_started_envelope() -> TelemetryEnvelope {
+        envelope(
+            "host-a",
+            TelemetryRecord::SweepStarted(SweepStartedRecord {
+                repo: "rjwalters/loom".to_string(),
+                visibility: RepoVisibility::Public,
+                issue: 4858,
+                sweep_id: "sweep-issue-4858-0".to_string(),
+                started_at: ts(),
+                model: Some("opus".to_string()),
+                effort: Some("high".to_string()),
+            }),
+        )
+    }
+
+    fn sweep_phase_envelope() -> TelemetryEnvelope {
+        envelope(
+            "host-a",
+            TelemetryRecord::SweepPhase(SweepPhaseRecord {
+                repo: "rjwalters/loom".to_string(),
+                visibility: RepoVisibility::Private,
+                issue: 4858,
+                sweep_id: "sweep-issue-4858-0".to_string(),
+                phase: "builder".to_string(),
+                entered_at: ts(),
+            }),
+        )
+    }
+
+    fn sweep_completed_envelope(result: SweepResult) -> TelemetryEnvelope {
+        envelope(
+            "host-a",
+            TelemetryRecord::SweepCompleted(SweepCompletedRecord {
+                repo: "rjwalters/loom".to_string(),
+                visibility: RepoVisibility::Public,
+                issue: 4858,
+                sweep_id: "sweep-issue-4858-0".to_string(),
+                completed_at: ts(),
+                result,
+            }),
+        )
+    }
+
+    fn sweep_outcome_envelope() -> TelemetryEnvelope {
+        let mut config = std::collections::BTreeMap::new();
+        config.insert("runtime".to_string(), "claude".to_string());
+        envelope(
+            "host-a",
+            TelemetryRecord::SweepOutcome(SweepOutcomeRecord {
+                repo: "rjwalters/loom".to_string(),
+                visibility: RepoVisibility::Public,
+                issue: 4858,
+                sweep_id: "sweep-issue-4858-0".to_string(),
+                model: Some("opus".to_string()),
+                effort: Some("high".to_string()),
+                config,
+                phase_durations: vec![
+                    PhaseDuration {
+                        phase: "curator".to_string(),
+                        duration_sec: 12,
+                    },
+                    PhaseDuration {
+                        phase: "builder".to_string(),
+                        duration_sec: 340,
+                    },
+                ],
+                total_duration_sec: 512,
+                result: SweepResult::Success,
+                pr_number: Some(4861),
+            }),
+        )
+    }
+
+    fn tokens_snapshot_envelope() -> TelemetryEnvelope {
+        envelope(
+            "host-b",
+            TelemetryRecord::TokensSnapshot(TokenSnapshotRecord {
+                captured_at: ts(),
+                accounts: vec![
+                    TokenAccountState {
+                        account: "agent-1".to_string(),
+                        rank: Some(0),
+                        usage_fraction: Some(0.42),
+                        limit_window_reset_at: Some(ts()),
+                        exhausted: false,
+                    },
+                    TokenAccountState {
+                        account: "agent-2".to_string(),
+                        rank: None,
+                        usage_fraction: None,
+                        limit_window_reset_at: None,
+                        exhausted: true,
+                    },
+                ],
+            }),
+        )
+    }
+
+    fn host_health_envelope() -> TelemetryEnvelope {
+        envelope(
+            "host-b",
+            TelemetryRecord::HostHealth(HostHealthRecord {
+                captured_at: ts(),
+                daemon_version: "0.17.0".to_string(),
+                uptime_sec: 86_400,
+                logical_cpus: 28,
+                cpu_idle_fraction: Some(0.83),
+                load_per_core: Some(0.51),
+                worktree_root_free_gb: Some(200),
+            }),
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // Logs
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn lifecycle_records_become_log_records_with_the_kind_tag_as_event_name() {
+        let batch = vec![
+            sweep_started_envelope(),
+            sweep_phase_envelope(),
+            sweep_completed_envelope(SweepResult::Success),
+            sweep_outcome_envelope(),
+        ];
+        let request =
+            build_logs_request(&batch).expect("lifecycle batch must produce a logs request");
+        assert_eq!(request.resource_logs.len(), 1, "single host_id ⇒ one ResourceLogs");
+        let resource_logs = &request.resource_logs[0];
+        let log_records = &resource_logs.scope_logs[0].log_records;
+        assert_eq!(log_records.len(), 4);
+        let event_names: Vec<&str> = log_records.iter().map(|r| r.event_name.as_str()).collect();
+        assert_eq!(
+            event_names,
+            vec![
+                "sweep.started",
+                "sweep.phase",
+                "sweep.completed",
+                "sweep.outcome"
+            ]
+        );
+    }
+
+    #[test]
+    fn host_id_becomes_resource_attributes() {
+        let batch = vec![sweep_started_envelope()];
+        let request = build_logs_request(&batch).unwrap();
+        let resource = request.resource_logs[0].resource.as_ref().unwrap();
+        let get = |key: &str| {
+            resource
+                .attributes
+                .iter()
+                .find(|kv| kv.key == key)
+                .and_then(|kv| kv.value.as_ref())
+                .and_then(|v| v.value.as_ref())
+        };
+        assert_eq!(
+            get("service.instance.id"),
+            Some(&any_value::Value::StringValue("host-a".to_string()))
+        );
+        assert_eq!(get("host.id"), Some(&any_value::Value::StringValue("host-a".to_string())));
+    }
+
+    #[test]
+    fn emitted_at_becomes_the_log_record_timestamp() {
+        let batch = vec![sweep_started_envelope()];
+        let request = build_logs_request(&batch).unwrap();
+        let log_record = &request.resource_logs[0].scope_logs[0].log_records[0];
+        assert_eq!(log_record.time_unix_nano, nanos(ts()));
+        assert_eq!(log_record.observed_time_unix_nano, nanos(ts()));
+    }
+
+    #[test]
+    fn repo_visibility_tag_becomes_a_log_record_attribute_not_a_resource_attribute() {
+        let batch = vec![sweep_started_envelope(), sweep_phase_envelope()];
+        let request = build_logs_request(&batch).unwrap();
+        // Not on the shared Resource — a batch can mix repos/visibilities
+        // under one host_id, so visibility cannot be a Resource-level tag.
+        let resource = request.resource_logs[0].resource.as_ref().unwrap();
+        assert!(resource
+            .attributes
+            .iter()
+            .all(|kv| kv.key != "loom.repo.visibility"));
+
+        let log_records = &request.resource_logs[0].scope_logs[0].log_records;
+        let get_visibility = |record: &LogRecord| {
+            record
+                .attributes
+                .iter()
+                .find(|kv| kv.key == "loom.repo.visibility")
+                .and_then(|kv| kv.value.as_ref())
+                .and_then(|v| v.value.clone())
+        };
+        assert_eq!(
+            get_visibility(&log_records[0]),
+            Some(any_value::Value::StringValue("public".to_string()))
+        );
+        assert_eq!(
+            get_visibility(&log_records[1]),
+            Some(any_value::Value::StringValue("private".to_string()))
+        );
+    }
+
+    #[test]
+    fn sweep_outcome_flattens_config_and_nests_phase_durations() {
+        let batch = vec![sweep_outcome_envelope()];
+        let request = build_logs_request(&batch).unwrap();
+        let log_record = &request.resource_logs[0].scope_logs[0].log_records[0];
+        let get = |key: &str| {
+            log_record
+                .attributes
+                .iter()
+                .find(|kv| kv.key == key)
+                .and_then(|kv| kv.value.as_ref())
+                .and_then(|v| v.value.clone())
+        };
+        assert_eq!(
+            get("loom.config.runtime"),
+            Some(any_value::Value::StringValue("claude".to_string()))
+        );
+        assert_eq!(get("loom.pr_number"), Some(any_value::Value::IntValue(4861)));
+        match get("loom.phase_durations") {
+            Some(any_value::Value::ArrayValue(array)) => {
+                assert_eq!(array.values.len(), 2);
+            }
+            other => panic!("expected loom.phase_durations to be an ArrayValue, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn failure_and_blocked_results_raise_severity() {
+        let failure = sweep_completed_envelope(SweepResult::Failure);
+        let request = build_logs_request(std::slice::from_ref(&failure)).unwrap();
+        let log_record = &request.resource_logs[0].scope_logs[0].log_records[0];
+        assert_eq!(log_record.severity_number, SeverityNumber::Error as i32);
+
+        let blocked = sweep_completed_envelope(SweepResult::Blocked);
+        let request = build_logs_request(std::slice::from_ref(&blocked)).unwrap();
+        let log_record = &request.resource_logs[0].scope_logs[0].log_records[0];
+        assert_eq!(log_record.severity_number, SeverityNumber::Warn as i32);
+
+        let success = sweep_completed_envelope(SweepResult::Success);
+        let request = build_logs_request(std::slice::from_ref(&success)).unwrap();
+        let log_record = &request.resource_logs[0].scope_logs[0].log_records[0];
+        assert_eq!(log_record.severity_number, SeverityNumber::Info as i32);
+    }
+
+    #[test]
+    fn host_level_records_produce_no_log_records() {
+        let batch = vec![tokens_snapshot_envelope(), host_health_envelope()];
+        assert!(
+            build_logs_request(&batch).is_none(),
+            "an all-metrics batch must not produce a (empty) logs request"
+        );
+    }
+
+    #[test]
+    fn empty_batch_produces_no_logs_request() {
+        assert!(build_logs_request(&[]).is_none());
+    }
+
+    // ------------------------------------------------------------------
+    // Metrics
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn host_health_becomes_gauge_metrics() {
+        let batch = vec![host_health_envelope()];
+        let request =
+            build_metrics_request(&batch).expect("host.health must produce a metrics request");
+        assert_eq!(request.resource_metrics.len(), 1);
+        let metrics = &request.resource_metrics[0].scope_metrics[0].metrics;
+        let names: Vec<&str> = metrics.iter().map(|m| m.name.as_str()).collect();
+        for expected in [
+            "loom.host.uptime_seconds",
+            "loom.host.logical_cpus",
+            "loom.host.cpu_idle_fraction",
+            "loom.host.load_per_core",
+            "loom.host.worktree_root_free_gb",
+        ] {
+            assert!(names.contains(&expected), "missing metric {expected} in {names:?}");
+        }
+    }
+
+    #[test]
+    fn daemon_version_becomes_a_resource_attribute_not_a_metric() {
+        let batch = vec![host_health_envelope()];
+        let request = build_metrics_request(&batch).unwrap();
+        let resource = request.resource_metrics[0].resource.as_ref().unwrap();
+        let version = resource
+            .attributes
+            .iter()
+            .find(|kv| kv.key == "service.version")
+            .and_then(|kv| kv.value.as_ref())
+            .and_then(|v| v.value.clone());
+        assert_eq!(version, Some(any_value::Value::StringValue("0.17.0".to_string())));
+        let metrics = &request.resource_metrics[0].scope_metrics[0].metrics;
+        assert!(
+            metrics
+                .iter()
+                .all(|m| m.name != "service.version" && !m.name.contains("daemon_version")),
+            "daemon_version must not also appear as a metric"
+        );
+    }
+
+    #[test]
+    fn unmeasured_optional_fields_produce_no_data_point() {
+        let mut record = HostHealthRecord {
+            captured_at: ts(),
+            daemon_version: "0.17.0".to_string(),
+            uptime_sec: 10,
+            logical_cpus: 4,
+            cpu_idle_fraction: None,
+            load_per_core: None,
+            worktree_root_free_gb: None,
+        };
+        let batch = vec![envelope(
+            "host-c",
+            TelemetryRecord::HostHealth(record.clone()),
+        )];
+        let request = build_metrics_request(&batch).unwrap();
+        let names: Vec<&str> = request.resource_metrics[0].scope_metrics[0]
+            .metrics
+            .iter()
+            .map(|m| m.name.as_str())
+            .collect();
+        assert!(!names.contains(&"loom.host.cpu_idle_fraction"));
+        assert!(!names.contains(&"loom.host.load_per_core"));
+        assert!(!names.contains(&"loom.host.worktree_root_free_gb"));
+
+        // Sanity: setting the field produces the data point.
+        record.cpu_idle_fraction = Some(0.5);
+        let batch = vec![envelope("host-c", TelemetryRecord::HostHealth(record))];
+        let request = build_metrics_request(&batch).unwrap();
+        let names: Vec<&str> = request.resource_metrics[0].scope_metrics[0]
+            .metrics
+            .iter()
+            .map(|m| m.name.as_str())
+            .collect();
+        assert!(names.contains(&"loom.host.cpu_idle_fraction"));
+    }
+
+    #[test]
+    fn tokens_snapshot_becomes_per_account_gauge_metrics() {
+        let batch = vec![tokens_snapshot_envelope()];
+        let request = build_metrics_request(&batch).unwrap();
+        let metrics = &request.resource_metrics[0].scope_metrics[0].metrics;
+        let usage_metric = metrics
+            .iter()
+            .find(|m| m.name == "loom.tokens.usage_fraction")
+            .expect("usage_fraction metric must exist");
+        let exhausted_metric = metrics
+            .iter()
+            .find(|m| m.name == "loom.tokens.exhausted")
+            .expect("exhausted metric must exist");
+
+        // Only agent-1 has a known usage_fraction (agent-2's is None ⇒ no
+        // data point for that account, per the "unknown != zero" contract).
+        let usage_points = match &usage_metric.data {
+            Some(metric::Data::Gauge(gauge)) => &gauge.data_points,
+            other => panic!("expected Gauge, got {other:?}"),
+        };
+        assert_eq!(usage_points.len(), 1);
+        let account_attr = |point: &NumberDataPoint| {
+            point
+                .attributes
+                .iter()
+                .find(|kv| kv.key == "account")
+                .and_then(|kv| kv.value.as_ref())
+                .and_then(|v| v.value.clone())
+        };
+        assert_eq!(
+            account_attr(&usage_points[0]),
+            Some(any_value::Value::StringValue("agent-1".to_string()))
+        );
+        assert_eq!(usage_points[0].value, Some(number_data_point::Value::AsDouble(0.42)));
+
+        // Every account (both) has an exhausted data point.
+        let exhausted_points = match &exhausted_metric.data {
+            Some(metric::Data::Gauge(gauge)) => &gauge.data_points,
+            other => panic!("expected Gauge, got {other:?}"),
+        };
+        assert_eq!(exhausted_points.len(), 2);
+    }
+
+    #[test]
+    fn metrics_are_grouped_by_host_id() {
+        let batch = vec![host_health_envelope(), sweep_started_envelope()];
+        // host_health_envelope is host-b, sweep_started_envelope is host-a —
+        // but sweep_started is a lifecycle record and contributes no metric
+        // sample, so only host-b should appear in the metrics request.
+        let request = build_metrics_request(&batch).unwrap();
+        assert_eq!(request.resource_metrics.len(), 1);
+        let resource = request.resource_metrics[0].resource.as_ref().unwrap();
+        let host_id = resource
+            .attributes
+            .iter()
+            .find(|kv| kv.key == "host.id")
+            .and_then(|kv| kv.value.as_ref())
+            .and_then(|v| v.value.clone());
+        assert_eq!(host_id, Some(any_value::Value::StringValue("host-b".to_string())));
+    }
+
+    #[test]
+    fn lifecycle_records_produce_no_metrics() {
+        let batch = vec![
+            sweep_started_envelope(),
+            sweep_phase_envelope(),
+            sweep_completed_envelope(SweepResult::Success),
+            sweep_outcome_envelope(),
+        ];
+        assert!(
+            build_metrics_request(&batch).is_none(),
+            "an all-lifecycle batch must not produce a (empty) metrics request"
+        );
+    }
+
+    #[test]
+    fn empty_batch_produces_no_metrics_request() {
+        assert!(build_metrics_request(&[]).is_none());
+    }
+
+    #[test]
+    fn mixed_batch_produces_both_a_logs_and_a_metrics_request() {
+        let batch = vec![
+            sweep_started_envelope(),
+            host_health_envelope(),
+            tokens_snapshot_envelope(),
+        ];
+        assert!(build_logs_request(&batch).is_some());
+        assert!(build_metrics_request(&batch).is_some());
+    }
+}

--- a/loom-daemon/src/observability/otlp/mod.rs
+++ b/loom-daemon/src/observability/otlp/mod.rs
@@ -1,0 +1,363 @@
+//! OTLP exporter (Epic #4702, Phase 4 — issue #4858): a drop-in second
+//! [`super::exporter::Exporter`] implementation translating
+//! [`crate::telemetry::TelemetryEnvelope`] batches into the OTLP wire format,
+//! for operators with an existing OpenTelemetry stack (a self-hosted
+//! collector, Grafana, Honeycomb, …) who want to skip the native Cloudflare
+//! backend entirely. Selected via `observability.exporter = "otlp"`
+//! (`observability::resolve_exporter`) — [`super::exporter::HttpsExporter`]
+//! stays the default (`"https"`).
+//!
+//! Gated behind the `otlp` Cargo feature (see `loom-daemon/Cargo.toml`): a
+//! default build never compiles `opentelemetry_proto` in, so choosing this
+//! sink costs nothing for operators who stick with the HTTPS exporter.
+//!
+//! # Transport, not the OTel SDK
+//!
+//! This is deliberately a thin translator, not an embedding of the
+//! `opentelemetry-otlp` SDK exporter: [`OtlpExporter::emit_batch`] posts the
+//! mapped OTLP request(s) over the *same kind* of `reqwest` client
+//! [`super::exporter::HttpsExporter`] already depends on, and
+//! [`super::sender`]'s drain/retry/backoff loop — generic over any
+//! `E: `[`super::exporter::Exporter`] — governs retries exactly as it does
+//! for the HTTPS sink. **No OTLP-specific retry/backoff logic exists here.**
+//! `opentelemetry-proto`'s `gen-tonic-messages` feature buys only the
+//! generated message *types* (`prost`-derived structs); `tonic`/gRPC
+//! transport is deliberately never enabled, so this feature adds no gRPC
+//! stack — just JSON-serializable Rust structs for the OTLP wire shapes.
+//!
+//! # `TelemetryEnvelope` → OTLP mapping
+//!
+//! | Envelope field | OTLP destination |
+//! |---|---|
+//! | `host_id` | `Resource` attribute `service.instance.id` (and `host.id`) — one `ResourceLogs`/`ResourceMetrics` entry per distinct `host_id` in a batch |
+//! | `emitted_at` | `LogRecord.time_unix_nano` / `.observed_time_unix_nano`, or `NumberDataPoint.time_unix_nano` |
+//! | a record's repo-visibility tag (when present) | **not** a `Resource` attribute — a `Resource` describes the emitting *host*, and one host's batch can reference many repos, so visibility is a per-`LogRecord` attribute `loom.repo.visibility` (alongside `loom.repo`) instead |
+//!
+//! [`TelemetryRecord`](crate::telemetry::TelemetryRecord) kinds split into
+//! two OTLP signals:
+//!
+//! - **Logs** (`ExportLogsServiceRequest`, one `LogRecord` per envelope): the
+//!   four sweep-lifecycle records — `sweep.started`, `sweep.phase`,
+//!   `sweep.completed`, `sweep.outcome` — become `LogRecord`s. Each record's
+//!   own `kind` tag is carried as `LogRecord.event_name`, its fields flatten
+//!   into `LogRecord.attributes` under a `loom.` prefix (`sweep.outcome`'s
+//!   `config` map becomes `loom.config.<key>` attributes and its
+//!   `phase_durations` becomes a nested `loom.phase_durations` array
+//!   attribute), and `severity_number` reflects `SweepResult` where one is
+//!   present (`Failure` → `Error`, `Blocked` → `Warn`, else `Info`).
+//! - **Metrics** (`ExportMetricsServiceRequest`, one `Gauge` `Metric` per
+//!   distinct name, one `NumberDataPoint` per envelope/account that measured
+//!   it): the two host-level records — `tokens.snapshot`, `host.health` —
+//!   become `Gauge` metrics (`loom.host.*`, `loom.tokens.*`). An unmeasured
+//!   optional field (e.g. `cpu_idle_fraction: None`) produces **no** data
+//!   point — the schema's "unknown != zero" contract carries through to the
+//!   OTLP mapping. `host.health`'s `daemon_version` becomes the `Resource`
+//!   attribute `service.version`, not a metric, since it describes the
+//!   emitting entity rather than a measurement.
+//!
+//! See [`mapping`] for the field-by-field implementation and its unit tests
+//! (fixture envelopes for every record kind, verifying the log/metric split
+//! and every attribute above).
+
+mod mapping;
+
+use std::time::Duration;
+
+use serde::Serialize;
+
+use super::exporter::{ExportError, Exporter};
+use crate::telemetry::TelemetryEnvelope;
+
+/// Per-request timeout — same rationale and value as
+/// [`super::exporter::HttpsExporter`]'s.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// The OTLP/HTTP+JSON [`Exporter`]. POSTs mapped logs/metrics batches to
+/// `{base_endpoint}/v1/logs` and `{base_endpoint}/v1/metrics` respectively —
+/// the standard OTLP/HTTP path suffixes — each with `Authorization: Bearer
+/// <ingest_key>`, the same auth convention [`super::exporter::HttpsExporter`]
+/// uses, so `observability.ingestKeyFile` is shared across both sinks.
+pub struct OtlpExporter {
+    client: reqwest::Client,
+    logs_endpoint: String,
+    metrics_endpoint: String,
+    ingest_key: String,
+}
+
+impl OtlpExporter {
+    /// Build an exporter posting to `{base_endpoint}/v1/logs` and
+    /// `{base_endpoint}/v1/metrics` (a trailing slash on `base_endpoint` is
+    /// tolerated and stripped), authenticating with `ingest_key`. Fails only
+    /// if the underlying `reqwest::Client` cannot be constructed — never
+    /// touches the network.
+    pub fn new(base_endpoint: String, ingest_key: String) -> Result<Self, ExportError> {
+        let client = reqwest::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .map_err(|error| ExportError::Transport(error.to_string()))?;
+        let base = base_endpoint.trim_end_matches('/');
+        Ok(OtlpExporter {
+            client,
+            logs_endpoint: format!("{base}/v1/logs"),
+            metrics_endpoint: format!("{base}/v1/metrics"),
+            ingest_key,
+        })
+    }
+
+    async fn post<T: Serialize + Sync>(&self, endpoint: &str, body: &T) -> Result<(), ExportError> {
+        let response = self
+            .client
+            .post(endpoint)
+            .bearer_auth(&self.ingest_key)
+            .json(body)
+            .send()
+            .await
+            .map_err(|error| ExportError::Transport(error.to_string()))?;
+        if response.status().is_success() {
+            return Ok(());
+        }
+        let status = response.status().as_u16();
+        let body_snippet = response
+            .text()
+            .await
+            .unwrap_or_default()
+            .chars()
+            .take(200)
+            .collect();
+        Err(ExportError::Rejected {
+            status,
+            body_snippet,
+        })
+    }
+}
+
+impl Exporter for OtlpExporter {
+    /// Maps `envelopes` into an OTLP logs request and/or an OTLP metrics
+    /// request (see the module docs) and POSTs whichever are non-empty —
+    /// skipping either POST entirely when the batch contains no envelope of
+    /// the corresponding signal.
+    ///
+    /// **Not atomic across the two requests**: if the logs POST succeeds but
+    /// the metrics POST then fails, this returns `Err` and
+    /// [`super::sender`] leaves the *whole* batch queued for retry — the
+    /// already-accepted log records will be POSTed again next attempt. This
+    /// is the same at-least-once tradeoff every sink in this module makes at
+    /// the single-request granularity; telemetry ingestion is expected to
+    /// tolerate duplicates, never data loss.
+    async fn emit_batch(&self, envelopes: &[TelemetryEnvelope]) -> Result<(), ExportError> {
+        if let Some(request) = mapping::build_logs_request(envelopes) {
+            self.post(&self.logs_endpoint, &request).await?;
+        }
+        if let Some(request) = mapping::build_metrics_request(envelopes) {
+            self.post(&self.metrics_endpoint, &request).await?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::telemetry::{HostHealthRecord, SweepStartedRecord, TelemetryRecord};
+    use std::io::{Read, Write};
+    use std::net::{SocketAddr, TcpListener};
+    use std::sync::{Arc, Mutex};
+
+    /// A minimal two-path mock sink: records every request's path + body so
+    /// tests can assert `OtlpExporter` posts to `/v1/logs` and `/v1/metrics`
+    /// separately. Deliberately smaller than `exporter::tests::MockSink`
+    /// (single status code, no kill/revive) — the retry/backoff behavior is
+    /// already covered end-to-end for any `Exporter` by `sender.rs`'s tests.
+    struct MockSink {
+        addr: SocketAddr,
+        requests: Arc<Mutex<Vec<(String, Vec<u8>)>>>,
+        shutdown: Arc<std::sync::atomic::AtomicBool>,
+        handle: Option<std::thread::JoinHandle<()>>,
+    }
+
+    impl MockSink {
+        fn start() -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.set_nonblocking(true).unwrap();
+            let addr = listener.local_addr().unwrap();
+            let requests = Arc::new(Mutex::new(Vec::new()));
+            let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let handle = {
+                let requests = requests.clone();
+                let shutdown = shutdown.clone();
+                std::thread::spawn(move || {
+                    while !shutdown.load(std::sync::atomic::Ordering::SeqCst) {
+                        match listener.accept() {
+                            Ok((mut stream, _)) => {
+                                stream.set_nonblocking(false).ok();
+                                if let Some((path, body)) = read_request(&mut stream) {
+                                    let _ = write_response(&mut stream);
+                                    requests.lock().unwrap().push((path, body));
+                                }
+                            }
+                            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                                std::thread::sleep(std::time::Duration::from_millis(10));
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                })
+            };
+            MockSink {
+                addr,
+                requests,
+                shutdown,
+                handle: Some(handle),
+            }
+        }
+
+        fn base_url(&self) -> String {
+            format!("http://{}", self.addr)
+        }
+
+        fn requests(&self) -> Vec<(String, Vec<u8>)> {
+            self.requests.lock().unwrap().clone()
+        }
+    }
+
+    impl Drop for MockSink {
+        fn drop(&mut self) {
+            self.shutdown
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            if let Some(handle) = self.handle.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+
+    fn read_request(stream: &mut std::net::TcpStream) -> Option<(String, Vec<u8>)> {
+        stream
+            .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+            .ok();
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 4096];
+        let header_end;
+        loop {
+            let n = stream.read(&mut chunk).ok()?;
+            if n == 0 {
+                return None;
+            }
+            buf.extend_from_slice(&chunk[..n]);
+            if let Some(pos) = buf.windows(4).position(|window| window == b"\r\n\r\n") {
+                header_end = pos + 4;
+                break;
+            }
+        }
+        let header_text = String::from_utf8_lossy(&buf[..header_end]).to_string();
+        let path = header_text
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .unwrap_or("")
+            .to_string();
+        let content_length: usize = header_text
+            .lines()
+            .find(|line| line.to_ascii_lowercase().starts_with("content-length:"))
+            .and_then(|line| line.split_once(':').map(|x| x.1))
+            .and_then(|v| v.trim().parse().ok())
+            .unwrap_or(0);
+        while buf.len() < header_end + content_length {
+            let n = stream.read(&mut chunk).ok()?;
+            if n == 0 {
+                break;
+            }
+            buf.extend_from_slice(&chunk[..n]);
+        }
+        let body = buf[header_end..(header_end + content_length).min(buf.len())].to_vec();
+        Some((path, body))
+    }
+
+    fn write_response(stream: &mut std::net::TcpStream) -> std::io::Result<()> {
+        stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+    }
+
+    fn sweep_started_envelope() -> TelemetryEnvelope {
+        TelemetryEnvelope::new(
+            "host-otlp-test",
+            TelemetryRecord::SweepStarted(SweepStartedRecord {
+                repo: "rjwalters/loom".to_string(),
+                visibility: crate::telemetry::RepoVisibility::Public,
+                issue: 4858,
+                sweep_id: "sweep-issue-4858-0".to_string(),
+                started_at: chrono::Utc::now(),
+                model: None,
+                effort: None,
+            }),
+        )
+    }
+
+    fn host_health_envelope() -> TelemetryEnvelope {
+        TelemetryEnvelope::new(
+            "host-otlp-test",
+            TelemetryRecord::HostHealth(HostHealthRecord {
+                captured_at: chrono::Utc::now(),
+                daemon_version: "0.17.0".to_string(),
+                uptime_sec: 10,
+                logical_cpus: 8,
+                cpu_idle_fraction: None,
+                load_per_core: None,
+                worktree_root_free_gb: None,
+            }),
+        )
+    }
+
+    #[tokio::test]
+    async fn emit_batch_posts_logs_and_metrics_to_their_own_paths_with_bearer_auth() {
+        let sink = MockSink::start();
+        let exporter = OtlpExporter::new(sink.base_url(), "s3cr3t-ingest-key".to_string()).unwrap();
+        let batch = vec![sweep_started_envelope(), host_health_envelope()];
+        exporter.emit_batch(&batch).await.unwrap();
+
+        let requests = sink.requests();
+        assert_eq!(requests.len(), 2, "one lifecycle + one host-level envelope ⇒ two POSTs");
+        let paths: Vec<&str> = requests.iter().map(|(path, _)| path.as_str()).collect();
+        assert!(paths.contains(&"/v1/logs"));
+        assert!(paths.contains(&"/v1/metrics"));
+    }
+
+    #[tokio::test]
+    async fn emit_batch_skips_the_metrics_post_for_an_all_lifecycle_batch() {
+        let sink = MockSink::start();
+        let exporter = OtlpExporter::new(sink.base_url(), "key".to_string()).unwrap();
+        exporter
+            .emit_batch(&[sweep_started_envelope()])
+            .await
+            .unwrap();
+
+        let requests = sink.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].0, "/v1/logs");
+    }
+
+    #[test]
+    fn base_endpoint_trailing_slash_is_tolerated() {
+        let exporter =
+            OtlpExporter::new("https://collector.example.com/".to_string(), "key".to_string())
+                .unwrap();
+        assert_eq!(exporter.logs_endpoint, "https://collector.example.com/v1/logs");
+        assert_eq!(exporter.metrics_endpoint, "https://collector.example.com/v1/metrics");
+    }
+
+    #[tokio::test]
+    async fn non_2xx_status_from_either_endpoint_is_a_rejected_error() {
+        // Bind-then-drop to get a loopback port nothing is listening on —
+        // reuses `exporter.rs`'s unreachable-sink pattern for the transport
+        // error path (rejected-status is already covered by
+        // `HttpsExporter`'s own tests at the `post` granularity).
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let exporter = OtlpExporter::new(format!("http://{addr}"), "key".to_string()).unwrap();
+        let error = exporter
+            .emit_batch(&[sweep_started_envelope()])
+            .await
+            .unwrap_err();
+        assert!(matches!(error, ExportError::Transport(_)));
+    }
+}

--- a/loom-daemon/src/observability/otlp/mod.rs
+++ b/loom-daemon/src/observability/otlp/mod.rs
@@ -164,6 +164,12 @@ mod tests {
     use std::net::{SocketAddr, TcpListener};
     use std::sync::{Arc, Mutex};
 
+    /// Every request the mock sink saw, as `(path, body)` — shared between the
+    /// accept-loop thread and the asserting test. Aliased rather than written
+    /// inline so `clippy::type_complexity` stays satisfied under
+    /// `--all-targets --features otlp`.
+    type RecordedRequests = Arc<Mutex<Vec<(String, Vec<u8>)>>>;
+
     /// A minimal two-path mock sink: records every request's path + body so
     /// tests can assert `OtlpExporter` posts to `/v1/logs` and `/v1/metrics`
     /// separately. Deliberately smaller than `exporter::tests::MockSink`
@@ -171,7 +177,7 @@ mod tests {
     /// already covered end-to-end for any `Exporter` by `sender.rs`'s tests.
     struct MockSink {
         addr: SocketAddr,
-        requests: Arc<Mutex<Vec<(String, Vec<u8>)>>>,
+        requests: RecordedRequests,
         shutdown: Arc<std::sync::atomic::AtomicBool>,
         handle: Option<std::thread::JoinHandle<()>>,
     }


### PR DESCRIPTION
## Summary

Epic #4702 Phase 4: implements the OTLP exporter the Phase 1 `Exporter` trait
was deliberately designed to support as a drop-in second sink. `OtlpExporter`
translates `TelemetryEnvelope` batches into OTLP/HTTP+JSON logs and metrics
requests for operators with an existing OpenTelemetry stack (a self-hosted
collector, Grafana, Honeycomb, …), as an alternative to the native
`HttpsExporter` → Cloudflare Worker pipeline.

## Changes

- `loom-daemon/src/observability/otlp/mod.rs` — `OtlpExporter`, implementing
  `observability::exporter::Exporter` (same `emit_batch`/`flush` shape as
  `HttpsExporter`). POSTs mapped OTLP requests to `{endpoint}/v1/logs` and
  `{endpoint}/v1/metrics` with `Authorization: Bearer <ingest_key>`, the same
  auth convention as `HttpsExporter`, over the same kind of `reqwest` client
  — no gRPC/tonic transport stack.
- `loom-daemon/src/observability/otlp/mapping.rs` — pure, network-free
  `TelemetryEnvelope` → OTLP record mapping. The four sweep-lifecycle record
  kinds (`sweep.started`, `sweep.phase`, `sweep.completed`, `sweep.outcome`)
  become `LogRecord`s (kind as `event_name`, fields flattened under a `loom.`
  attribute prefix, severity derived from `SweepResult`); the two host-level
  kinds (`tokens.snapshot`, `host.health`) become `Gauge` metrics
  (`loom.host.*`, `loom.tokens.*`). `host_id` maps to `Resource` attributes
  (`service.instance.id`, `host.id`, plus `service.version` from
  `host.health`'s `daemon_version`); the repo-visibility tag stays a
  per-`LogRecord` attribute (`loom.repo.visibility`), not a `Resource`
  attribute, since one host's batch can span multiple repos.
- `loom-daemon/src/observability/mod.rs` — `ExporterKind` enum +
  `resolve_exporter()` (env `LOOM_OBSERVABILITY_EXPORTER` > config
  `observability.exporter` > default `"https"`, matching the existing
  `LOOM_OBSERVABILITY_*` precedence pattern), wired into `spawn_task` so the
  drain/retry/backoff loop in `sender.rs` is reused unchanged for either
  exporter — no OTLP-specific retry logic.
- `loom-daemon/Cargo.toml` — new optional `otlp` Cargo feature
  (`opentelemetry-proto`, `gen-tonic-messages` + `with-serde` only, no
  `tonic`/gRPC), off by default so a plain `cargo build`/`cargo test` never
  pulls it in.
- `.loom/docs/observability.md`, `defaults/docs/observability.md`,
  `.loom/docs/telemetry-schema.md` — document the new exporter, config key,
  and mapping (updates the "OTLP planned" language from the Phase-3
  observability doc that just landed on main).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `OtlpExporter` implements `Exporter` (same `emit_batch`/`flush` shape as `HttpsExporter`) | ✅ | `otlp/mod.rs` `impl Exporter for OtlpExporter` |
| Selected via `observability.exporter`, env > config > default (`"https"`) | ✅ | `resolve_exporter()` + `EXPORTER_ENV`; unit tests `resolve_exporter_env_overrides_config`, `resolve_exporter_config_wins_over_default_when_no_env_set`, `resolve_exporter_unknown_value_falls_back_to_https` |
| `TelemetryEnvelope` → OTLP mapping documented | ✅ | `otlp/mod.rs` module doc (mapping table + log/metric split), `.loom/docs/observability.md` §3, `.loom/docs/telemetry-schema.md` |
| Off by default; no new required dependency for HTTPS-only users | ✅ | `otlp` Cargo feature is `optional`, not in default features; `cargo build`/`cargo check` (no `--features otlp`) confirmed to not pull in `opentelemetry-proto` |
| Reuses `sender.rs`'s drain/retry/backoff loop unchanged | ✅ | `spawn_task` calls `sender::spawn_task(queue, exporter, ...)` for both `ExporterKind` branches; no OTLP-specific retry code exists |
| Unit tests for envelope → OTLP mapping against fixture envelopes | ✅ | `otlp/mapping.rs` — 16 tests covering all 6 record kinds, resource attributes, severity mapping, config/phase_durations flattening, unmeasured-field omission, host grouping |

## Test Plan

- `cargo check` (default features) — passes, confirms `opentelemetry-proto` is not compiled into a default build.
- `cargo check --features otlp` — passes.
- `cargo test --features otlp` (observability module only) — 69 passed, 0 failed, including all 16 `otlp::mapping` tests, 4 `otlp` exporter integration tests (mock HTTP sink), and the `resolve_exporter`/`spawn_task` config tests.
- `cargo clippy --all-targets -- -D warnings` (default features) — clean.
- `cargo clippy --all-targets --features otlp -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `cargo test --lib --bins --features otlp` (full crate, matching the local build-gate's Rust scope) — 2980 passed, 1 pre-existing failure (`config_resolver::tests::test_resolve_nested_autonomous_block_merges_across_tiers`) unrelated to this change — reproduces identically on a clean worktree with no `otlp`-related edits, caused by a host-local private-defaults file leaking into that specific test's isolation (a known, previously-documented host artifact, not a regression from this PR).

Closes #4858