### PR TITLE
feat(observability): detect host_id/key mismatch via ingest echo + exporter check

### DIFF
--- a/.loom/docs/observability.md
+++ b/.loom/docs/observability.md
@@ -102,6 +102,17 @@ second sink** (epic Phase 4, tracked separately in
 that issue is still open, so OTLP support has **not** landed; every host today
 speaks the native HTTPS/JSON wire format only.
 
+**The exporter verifies its own identity** (issue #4830). Each `/ingest`
+success response echoes the `host_id` the presented key is bound to; the
+exporter compares that against the identity this daemon resolved for itself
+(`$LOOM_HOST_ID` > `$HOSTNAME` > `hostname`). On a disagreement — the wrong
+host's key file installed on a machine, which silently mislabeled a whole
+night of telemetry on 2026-07-31 — it logs a WARN **once per daemon lifetime**
+and `loom-daemon health` reports an `observability DEGRADED` section (exit
+`1`). Nothing else changes: the batch is still acked, and the key's binding
+stays authoritative on the backend. Fix by installing the right key or setting
+`$LOOM_HOST_ID` to match, then restarting the daemon.
+
 ## 4. The backend: deploy your own Cloudflare Worker
 
 The Phase-2 backend is a Cloudflare Worker (D1 for durable history, a

--- a/.loom/docs/telemetry-schema.md
+++ b/.loom/docs/telemetry-schema.md
@@ -49,6 +49,43 @@ only on a **breaking** wire change to the record shapes below. A backend should:
 - **never** silently coerce a missing `schema_version` to `0` — a record with no
   `schema_version` is malformed.
 
+## `/ingest` response (the bound-`host_id` echo)
+
+A push is a bare JSON array of envelopes; the backend answers a **2xx with a
+JSON object**:
+
+```json
+{ "accepted": 50, "host_id": "fleet-host-abc" }
+```
+
+| Field      | Type    | Notes |
+|------------|---------|-------|
+| `accepted` | integer | How many envelopes from this batch were persisted. Whole-batch semantics: a batch is either fully accepted or rejected with a non-2xx. |
+| `host_id`  | string  | **The host id the authenticated ingest key is bound to** — i.e. the identity the batch's rows were actually filed under. Added by issue #4830. |
+
+`host_id` here is *not* echoed from the request. Every record is persisted
+under the identity bound to the presented key, never the envelope's own
+(client-supplied, opaque) `host_id` field — so this echo is what a host was
+actually recorded as, which is exactly the value that differs when the wrong
+host's key file has been installed on a machine.
+
+**How the exporter uses it.** `loom-daemon`'s exporter compares this value
+against the identity the daemon resolved for itself (`$LOOM_HOST_ID`, else
+`$HOSTNAME`, else `hostname`) and on a disagreement logs a WARN **once per
+daemon lifetime** and reports an `observability DEGRADED` section in
+`loom-daemon health`. Nothing about the export changes: the batch stays acked
+and the backend keeps filing under the key's binding, which remains
+authoritative. See `dashboard/docs/deploy-runbook.md` §8.
+
+**Compatibility.** The field is purely additive — no `schema_version` rev is
+involved (that integer versions the *record* envelope, not this response).
+Both directions are safe:
+
+- an exporter that ignores the response body behaves exactly as before;
+- a backend that does not send `host_id` (anything predating #4830) is treated
+  by the exporter as "no identity to verify" and is **silently** skipped — it
+  never produces a recurring "cannot verify" warning.
+
 ## `RepoVisibility` contract — private by default
 
 Every record that references a repository carries a `visibility` tag, either

--- a/dashboard/docs/deploy-runbook.md
+++ b/dashboard/docs/deploy-runbook.md
@@ -248,8 +248,33 @@ no way to read it back.
 Choose `host_id` to match what the daemon reports for that machine — it is
 `$LOOM_HOST_ID` if set, else `$HOSTNAME`, else the output of `hostname`
 (`loom-daemon/src/sweep_registry/mod.rs::host_identity`). The backend always
-records the host id **bound to the authenticated key**, so a mismatch is not
-a security problem, only a confusing one when you read the data back.
+records the host id **bound to the authenticated key**, so a mismatch is not a
+security problem — but it is no longer an *undetected* one either (issue
+#4830).
+
+**Mismatches are detected, on the daemon side.** The `/ingest` success response
+echoes the host id the authenticated key is bound to
+(`{"accepted":N,"host_id":"my-laptop"}`), and the exporter compares that echo
+against the identity the daemon resolved for itself. If they disagree — the
+classic symptom of the wrong host's key file being installed on a machine — the
+daemon:
+
+- logs a WARN naming **both** ids, **once per daemon lifetime** (not once per
+  flush, so a permanent misconfiguration does not flood the log), and
+- reports an `observability DEGRADED` line in `loom-daemon health` (exit `1`)
+  and an `observability_host_id_mismatch` field in `loom-daemon status --json`,
+  for as long as that daemon process runs.
+
+This was added after the 2026-07-31 incident in which a Mac Studio pushed its
+first hours of telemetry under `robb-pro`, because that host's key file had been
+installed on it; nothing anywhere warned, and diagnosis meant cross-referencing
+D1 contents against which physical machine held which key file.
+
+To fix a reported mismatch, either install the key provisioned for this host, or
+set `$LOOM_HOST_ID` on the host to match the key's binding — then restart the
+daemon (the detection is deliberately once-per-lifetime, so the note clears on
+restart, not mid-run). The already-ingested rows keep the old host id; the
+backend has no rewrite path for them.
 
 Bring-your-own-key is supported too — `{"host_id":"my-laptop","key":"…"}`.
 

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -168,7 +168,7 @@ async function handleIngest(request: Request, env: Env): Promise<Response> {
     return jsonError(400, "request body must be a bare JSON array of telemetry envelopes");
   }
   if (body.length === 0) {
-    return new Response(JSON.stringify({ accepted: 0 }), { status: 200, headers: JSON_HEADERS });
+    return ingestAck(0, auth.hostId);
   }
 
   // Whole-batch rejection on the first malformed envelope. Documented
@@ -240,7 +240,31 @@ async function handleIngest(request: Request, env: Env): Promise<Response> {
     console.error(`fleet state update failed (D1 write already committed): ${(error as Error).message}`);
   }
 
-  return new Response(JSON.stringify({ accepted: envelopes.length }), {
+  return ingestAck(envelopes.length, auth.hostId);
+}
+
+/**
+ * The `/ingest` success response (issue #4830).
+ *
+ * `host_id` echoes back the identity the *authenticated key* is bound to — the
+ * one this request's rows were actually filed under (see the INSERT above),
+ * which is not necessarily the `host_id` inside the envelopes. The exporter
+ * compares it against the daemon's own host identity and warns when they
+ * disagree.
+ *
+ * That echo exists because of a live 2026-07-31 incident: a Mac Studio spent
+ * hours pushing telemetry under `robb-pro` because the wrong host's key file
+ * had been installed on it. The backend cannot detect this — a key-bound
+ * host_id is authoritative here by design — and the exporter had no idea what
+ * its key was bound to, so nothing anywhere warned. Only the daemon holds both
+ * halves; this field is what hands it the second one.
+ *
+ * Purely additive: `accepted` is unchanged, no envelope `schema_version` rev is
+ * involved, and a pre-#4830 exporter that ignores the response body is
+ * unaffected.
+ */
+function ingestAck(accepted: number, hostId: string): Response {
+  return new Response(JSON.stringify({ accepted, host_id: hostId }), {
     status: 200,
     headers: JSON_HEADERS,
   });

--- a/dashboard/test/ingest.test.ts
+++ b/dashboard/test/ingest.test.ts
@@ -82,7 +82,7 @@ describe("POST /ingest — validation", () => {
     const batch = [sweepStartedEnvelope(), hostHealthEnvelope()];
     const response = await callWorker(ingestRequest(batch, "Bearer abc-ingest-key"));
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ accepted: 2 });
+    expect(await response.json()).toEqual({ accepted: 2, host_id: "host-abc" });
 
     const rows = await recordsForHost("host-abc");
     expect(rows).toHaveLength(2);
@@ -97,7 +97,7 @@ describe("POST /ingest — validation", () => {
   it("accepts an empty array batch as a no-op", async () => {
     const response = await callWorker(ingestRequest([], "Bearer abc-ingest-key"));
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ accepted: 0 });
+    expect(await response.json()).toEqual({ accepted: 0, host_id: "host-abc" });
   });
 
   it("rejects the WHOLE batch when any one envelope is missing schema_version", async () => {
@@ -123,6 +123,50 @@ describe("POST /ingest — validation", () => {
     const rows = await recordsForHost("host-abc");
     expect(rows).toHaveLength(1);
     expect(rows[0]?.schema_version).toBe(2);
+  });
+});
+
+describe("POST /ingest — bound host_id echo (issue #4830)", () => {
+  it("echoes the host_id the authenticated key is bound to", async () => {
+    const response = await callWorker(ingestRequest([sweepStartedEnvelope()], "Bearer abc-ingest-key"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ accepted: 1, host_id: "host-abc" });
+  });
+
+  it("echoes the KEY's host_id, not the one the envelope claims", async () => {
+    // The whole point of the echo: the exporter has to learn what its key is
+    // actually bound to, which is exactly the value that differs from what the
+    // daemon believes about itself when a wrong key file has been installed.
+    const envelope = sweepStartedEnvelope();
+    (envelope as Record<string, unknown>).host_id = "some-other-claimed-host";
+
+    const response = await callWorker(ingestRequest([envelope], "Bearer abc-ingest-key"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ accepted: 1, host_id: "host-abc" });
+  });
+
+  it("echoes each host's own binding when two keys are in play", async () => {
+    await seedHost(env.DB, "host-xyz", "xyz-ingest-key");
+
+    const abc = await callWorker(ingestRequest([sweepStartedEnvelope()], "Bearer abc-ingest-key"));
+    const xyz = await callWorker(
+      ingestRequest([sweepStartedEnvelope({ sweep_id: "sweep-xyz-0" })], "Bearer xyz-ingest-key"),
+    );
+
+    expect(await abc.json()).toEqual({ accepted: 1, host_id: "host-abc" });
+    expect(await xyz.json()).toEqual({ accepted: 1, host_id: "host-xyz" });
+  });
+
+  it("does not echo a host_id on a rejected request", async () => {
+    // A 401/400 must not become an identity oracle for an unauthenticated
+    // caller, and there is no authenticated identity to echo anyway.
+    const unauthorized = await callWorker(ingestRequest([sweepStartedEnvelope()], "Bearer not-a-real-key"));
+    expect(unauthorized.status).toBe(401);
+    expect(await unauthorized.json()).not.toHaveProperty("host_id");
+
+    const badBody = await callWorker(ingestRequest({ not: "an array" }, "Bearer abc-ingest-key"));
+    expect(badBody.status).toBe(400);
+    expect(await badBody.json()).not.toHaveProperty("host_id");
   });
 });
 

--- a/defaults/docs/observability.md
+++ b/defaults/docs/observability.md
@@ -102,6 +102,17 @@ second sink** (epic Phase 4, tracked separately in
 that issue is still open, so OTLP support has **not** landed; every host today
 speaks the native HTTPS/JSON wire format only.
 
+**The exporter verifies its own identity** (issue #4830). Each `/ingest`
+success response echoes the `host_id` the presented key is bound to; the
+exporter compares that against the identity this daemon resolved for itself
+(`$LOOM_HOST_ID` > `$HOSTNAME` > `hostname`). On a disagreement — the wrong
+host's key file installed on a machine, which silently mislabeled a whole
+night of telemetry on 2026-07-31 — it logs a WARN **once per daemon lifetime**
+and `loom-daemon health` reports an `observability DEGRADED` section (exit
+`1`). Nothing else changes: the batch is still acked, and the key's binding
+stays authoritative on the backend. Fix by installing the right key or setting
+`$LOOM_HOST_ID` to match, then restarting the daemon.
+
 ## 4. The backend: deploy your own Cloudflare Worker
 
 The Phase-2 backend is a Cloudflare Worker (D1 for durable history, a

--- a/defaults/docs/telemetry-schema.md
+++ b/defaults/docs/telemetry-schema.md
@@ -49,6 +49,43 @@ only on a **breaking** wire change to the record shapes below. A backend should:
 - **never** silently coerce a missing `schema_version` to `0` — a record with no
   `schema_version` is malformed.
 
+## `/ingest` response (the bound-`host_id` echo)
+
+A push is a bare JSON array of envelopes; the backend answers a **2xx with a
+JSON object**:
+
+```json
+{ "accepted": 50, "host_id": "fleet-host-abc" }
+```
+
+| Field      | Type    | Notes |
+|------------|---------|-------|
+| `accepted` | integer | How many envelopes from this batch were persisted. Whole-batch semantics: a batch is either fully accepted or rejected with a non-2xx. |
+| `host_id`  | string  | **The host id the authenticated ingest key is bound to** — i.e. the identity the batch's rows were actually filed under. Added by issue #4830. |
+
+`host_id` here is *not* echoed from the request. Every record is persisted
+under the identity bound to the presented key, never the envelope's own
+(client-supplied, opaque) `host_id` field — so this echo is what a host was
+actually recorded as, which is exactly the value that differs when the wrong
+host's key file has been installed on a machine.
+
+**How the exporter uses it.** `loom-daemon`'s exporter compares this value
+against the identity the daemon resolved for itself (`$LOOM_HOST_ID`, else
+`$HOSTNAME`, else `hostname`) and on a disagreement logs a WARN **once per
+daemon lifetime** and reports an `observability DEGRADED` section in
+`loom-daemon health`. Nothing about the export changes: the batch stays acked
+and the backend keeps filing under the key's binding, which remains
+authoritative. See `dashboard/docs/deploy-runbook.md` §8.
+
+**Compatibility.** The field is purely additive — no `schema_version` rev is
+involved (that integer versions the *record* envelope, not this response).
+Both directions are safe:
+
+- an exporter that ignores the response body behaves exactly as before;
+- a backend that does not send `host_id` (anything predating #4830) is treated
+  by the exporter as "no identity to verify" and is **silently** skipped — it
+  never produces a recurring "cannot verify" warning.
+
 ## `RepoVisibility` contract — private by default
 
 Every record that references a repository carries a `visibility` tag, either

--- a/loom-daemon/src/cli/status.rs
+++ b/loom-daemon/src/cli/status.rs
@@ -665,6 +665,7 @@ pub(crate) mod status_client_tests {
             pid_file: Some(std::path::PathBuf::from("/repo/a/.loom/.daemon.pid")),
             daemon_build_commit: Some("18887b5c".to_string()),
             work_finder_interval_secs: Some(60),
+            observability_host_id_mismatch: None,
         }
     }
 

--- a/loom-daemon/src/cli/status_render.rs
+++ b/loom-daemon/src/cli/status_render.rs
@@ -164,6 +164,11 @@ pub(crate) fn build_status_json_value(
         // silent-failure signature. `message` is `null` when not tripped.
         "preflight_advisory_active": report.preflight_advisory_active,
         "preflight_advisory_message": report.preflight_advisory_message,
+        // Observability host-identity mismatch (#4830): non-null means this
+        // host's ingest key is bound to a DIFFERENT host_id than the daemon
+        // reports for itself, so its telemetry is being filed under the wrong
+        // host. `null` in the common case (ids agree, or no exporter running).
+        "observability_host_id_mismatch": report.observability_host_id_mismatch,
         "dynamic_cap": {
             "token_pool_size": report.token_pool_size,
             // The directory the daemon resolved for the pool above (#4292) —
@@ -672,6 +677,20 @@ pub(crate) fn print_status_human(
         if let Some(msg) = &report.preflight_advisory_message {
             println!("\n{msg}");
         }
+    }
+
+    // Observability host-identity mismatch (#4830): printed alongside the
+    // tripwire above because it has the same character — a silent,
+    // config-level fault whose only symptom is that data goes somewhere
+    // unexpected. `loom-daemon health` reports the same condition as an
+    // `observability DEGRADED` section.
+    if let Some(mismatch) = &report.observability_host_id_mismatch {
+        println!(
+            "\nWARNING: telemetry is being filed under host_id {} — this host's ingest key is \
+             bound to that id, not to {}. Install the key provisioned for {}, or set \
+             $LOOM_HOST_ID to match the key's binding, then restart the daemon.",
+            mismatch.ingest_host_id, mismatch.daemon_host_id, mismatch.daemon_host_id
+        );
     }
 
     // Capacity figures resolved from a single source (fresh probe when
@@ -1835,6 +1854,31 @@ mod status_protection_tests {
         );
         assert_eq!(unknown["protection"]["state"], "unknown");
         assert!(unknown["protection"]["watchdog_provisioned"].is_null());
+    }
+
+    #[test]
+    fn observability_host_id_mismatch_is_null_when_the_ids_agree() {
+        // #4830: the common case — no exporter, or an exporter whose key is
+        // bound to this very host — is a null field, so `status` is unchanged
+        // for every daemon that is not actually misconfigured.
+        let value = build_status_json_value(&sample_report(), None, &no_update(), None, None);
+        assert!(value["observability_host_id_mismatch"].is_null());
+    }
+
+    #[test]
+    fn observability_host_id_mismatch_names_both_identities_in_json() {
+        let mut report = sample_report();
+        report.observability_host_id_mismatch =
+            Some(loom_daemon::types::ObservabilityHostIdMismatch {
+                daemon_host_id: "robb-studio".to_string(),
+                ingest_host_id: "robb-pro".to_string(),
+                first_seen_at: chrono::Utc::now(),
+            });
+        let value = build_status_json_value(&report, None, &no_update(), None, None);
+        let m = &value["observability_host_id_mismatch"];
+        assert_eq!(m["daemon_host_id"], "robb-studio");
+        assert_eq!(m["ingest_host_id"], "robb-pro");
+        assert!(m["first_seen_at"].is_string());
     }
 
     #[test]

--- a/loom-daemon/src/health.rs
+++ b/loom-daemon/src/health.rs
@@ -26,6 +26,7 @@
 //! | roles | [`crate::role_runner::role_tick_records`] |
 //! | queues | [`crate::pipeline_snapshot`] (`queued`) |
 //! | throughput | [`crate::pipeline_snapshot`] (`merged_24h`, over the requested window) |
+//! | observability *(only when non-green)* | [`crate::types::DaemonStatusReport::observability_host_id_mismatch`], published by [`crate::observability::HostIdStatus`] |
 //!
 //! [`assess`] itself is **pure** — it takes an already-collected
 //! [`HealthInputs`] and returns a [`HealthReport`] — so every verdict rule
@@ -159,7 +160,8 @@ impl Verdict {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct HealthSection {
     /// Stable machine key (`liveness`, `dispatch`, `tokens`, `roles`,
-    /// `queues`, `throughput`).
+    /// `queues`, `throughput`, and `observability` when a mismatch is present
+    /// — #4830).
     pub key: &'static str,
     /// This section's verdict.
     pub verdict: Verdict,
@@ -1202,6 +1204,59 @@ pub fn assess_throughput(inputs: &HealthInputs) -> HealthSection {
 }
 
 // ============================================================================
+// Observability section (Issue #4830) — conditional
+// ============================================================================
+
+/// Assess the observability exporter's host-identity check: `Some(DEGRADED)`
+/// when the daemon has confirmed that its ingest key is bound to a *different*
+/// `host_id` than the one it reports for itself, else `None`.
+///
+/// **Deliberately conditional**, unlike every other section. There is nothing
+/// to say when the exporter is disabled, keyless, or reporting under the right
+/// identity — which is all but a handful of daemons — so a permanent
+/// `observability GREEN — ok` line would be pure noise on a surface whose whole
+/// value is that every line printed is worth reading. When the note IS present
+/// the condition is real and confirmed by the backend's own echo, never
+/// inferred, so it is `Degraded`, never `Unknown`.
+///
+/// Read straight off [`DaemonStatusReport`] rather than through a dedicated
+/// [`HealthInputs`] field: the mismatch is *daemon-process* state (only the
+/// daemon holds both halves — its own identity and the backend's echo), and
+/// `health` runs in a separate CLI process, so the IPC status report is the
+/// only place it can come from. A parallel collector field would just copy it
+/// and add a way for the two to disagree.
+#[must_use]
+pub fn assess_observability(inputs: &HealthInputs) -> Option<HealthSection> {
+    let mismatch = inputs
+        .status
+        .as_ref()?
+        .observability_host_id_mismatch
+        .as_ref()?;
+    let age = inputs
+        .at
+        .signed_duration_since(mismatch.first_seen_at)
+        .num_seconds()
+        .max(0);
+    Some(HealthSection::new(
+        "observability",
+        Verdict::Degraded,
+        format!(
+            "telemetry is being filed under {} — the ingest key on this host is bound to that \
+             id, not to {} (first seen {} ago)",
+            mismatch.ingest_host_id,
+            mismatch.daemon_host_id,
+            format_window(u64::try_from(age).unwrap_or(0))
+        ),
+        serde_json::json!({
+            "daemon_host_id": mismatch.daemon_host_id,
+            "ingest_host_id": mismatch.ingest_host_id,
+            "first_seen_at": mismatch.first_seen_at,
+            "first_seen_age_secs": age,
+        }),
+    ))
+}
+
+// ============================================================================
 // Roll-up
 // ============================================================================
 
@@ -1211,11 +1266,15 @@ pub fn assess_throughput(inputs: &HealthInputs) -> HealthSection {
 /// are reported as [`Verdict::Unknown`] (they are all downstream of an IPC
 /// round-trip that could not happen), and the overall verdict is `Dead` so the
 /// exit code is `2` rather than a misleading `1`.
+///
+/// Every section is unconditional except `observability` (#4830), which is
+/// appended only when there is a mismatch to report — see
+/// [`assess_observability`].
 #[must_use]
 pub fn assess(inputs: &HealthInputs) -> HealthReport {
     let liveness = assess_liveness(inputs);
     let dead = liveness.verdict == Verdict::Dead;
-    let sections = vec![
+    let mut sections = vec![
         liveness,
         assess_dispatch(inputs),
         assess_tokens(inputs),
@@ -1223,6 +1282,7 @@ pub fn assess(inputs: &HealthInputs) -> HealthReport {
         assess_queues(inputs),
         assess_throughput(inputs),
     ];
+    sections.extend(assess_observability(inputs));
     let overall = if dead {
         Verdict::Dead
     } else if sections.iter().all(|s| s.verdict.is_green()) {
@@ -1722,6 +1782,83 @@ mod tests {
         assert_eq!(report.exit_code(), EXIT_DEAD);
         assert_eq!(report.section("dispatch").unwrap().verdict, Verdict::Unknown);
         assert_eq!(report.section("tokens").unwrap().verdict, Verdict::Unknown);
+    }
+
+    // ===================================================================
+    // Observability section (#4830)
+    // ===================================================================
+
+    /// An inputs fixture whose daemon has confirmed a host-identity mismatch —
+    /// the live 2026-07-31 shape (the Studio's key bound to `robb-pro`).
+    fn mismatched_inputs(age_secs: i64) -> HealthInputs {
+        let mut inputs = healthy_inputs();
+        inputs
+            .status
+            .as_mut()
+            .unwrap()
+            .observability_host_id_mismatch = Some(crate::types::ObservabilityHostIdMismatch {
+            daemon_host_id: "robb-studio".to_string(),
+            ingest_host_id: "robb-pro".to_string(),
+            first_seen_at: now() - chrono::Duration::seconds(age_secs),
+        });
+        inputs
+    }
+
+    #[test]
+    fn no_observability_section_when_the_host_ids_agree() {
+        // AC: "no behavior change when they match" — a healthy daemon's report
+        // is byte-for-byte what it was before #4830.
+        let report = assess(&healthy_inputs());
+        assert!(report.section("observability").is_none());
+        assert_eq!(report.overall, Verdict::Green);
+        assert_eq!(report.exit_code(), EXIT_HEALTHY);
+    }
+
+    #[test]
+    fn no_observability_section_for_a_disabled_or_keyless_exporter() {
+        // A disabled exporter never registers a status handle, so the field is
+        // `None` on the wire — indistinguishable, by design, from "enabled and
+        // correctly bound".
+        let mut inputs = healthy_inputs();
+        inputs
+            .status
+            .as_mut()
+            .unwrap()
+            .observability_host_id_mismatch = None;
+        assert!(assess_observability(&inputs).is_none());
+    }
+
+    #[test]
+    fn no_observability_section_when_the_daemon_is_unreachable() {
+        let mut inputs = healthy_inputs();
+        inputs.status = None;
+        assert!(assess_observability(&inputs).is_none());
+    }
+
+    #[test]
+    fn a_host_id_mismatch_is_a_degraded_observability_note() {
+        let report = assess(&mismatched_inputs(3600));
+        let section = report.section("observability").expect("section present");
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(
+            section.summary.contains("robb-pro") && section.summary.contains("robb-studio"),
+            "the note must name BOTH identities: {}",
+            section.summary
+        );
+        assert_eq!(section.detail["daemon_host_id"], "robb-studio");
+        assert_eq!(section.detail["ingest_host_id"], "robb-pro");
+        assert_eq!(section.detail["first_seen_age_secs"], 3600);
+        assert_eq!(report.overall, Verdict::Degraded);
+        assert_eq!(report.exit_code(), EXIT_DEGRADED);
+    }
+
+    #[test]
+    fn the_observability_section_is_appended_last_and_only_when_present() {
+        let with_mismatch = assess(&mismatched_inputs(60));
+        let keys: Vec<&str> = with_mismatch.sections.iter().map(|s| s.key).collect();
+        assert_eq!(keys.last(), Some(&"observability"));
+        assert_eq!(keys.len(), 7);
+        assert_eq!(assess(&healthy_inputs()).sections.len(), 6);
     }
 
     #[test]

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1698,6 +1698,10 @@ pub fn build_daemon_status(
         rate_limit_breaker: crate::rate_limit_breaker::global_snapshot()
             .map(crate::rate_limit_breaker::RateLimitSnapshot::into_status)
             .map(Box::new),
+        // Observability host-identity mismatch (#4830) — same process-global
+        // snapshot pattern again, registered only when the exporter actually
+        // starts, so a disabled/keyless exporter always reads `None`.
+        observability_host_id_mismatch: crate::observability::global_host_id_mismatch(),
         // Live safehouse connection state (#4345) — the pool's shared cell is
         // updated by the narration sink / peer-coordination tasks
         // `start_safehouse_narration`/`start_peer_coordination` spawn, and
@@ -5476,6 +5480,11 @@ exit 0
             pid_file: Some(std::path::PathBuf::from("/repo/a/.loom/.daemon.pid")),
             daemon_build_commit: Some("18887b5c".to_string()),
             work_finder_interval_secs: Some(60),
+            observability_host_id_mismatch: Some(crate::types::ObservabilityHostIdMismatch {
+                daemon_host_id: "robb-studio".to_string(),
+                ingest_host_id: "robb-pro".to_string(),
+                first_seen_at: chrono::Utc::now(),
+            }),
         };
         let resp = Response::DaemonStatus(Box::new(report));
         let json = serde_json::to_string(&resp).expect("serialize response");
@@ -5512,6 +5521,14 @@ exit 0
                 assert!(!r.per_repo[0].health_gate_not_evaluated);
                 assert_eq!(r.main_health_gate_enabled, Some(true));
                 assert!(r.main_health_gate_verdict_at.is_some());
+                // #4830: the host-identity mismatch survives the wire so a
+                // `health` client in another process can render the note.
+                let mismatch = r
+                    .observability_host_id_mismatch
+                    .as_ref()
+                    .expect("mismatch round-trips");
+                assert_eq!(mismatch.daemon_host_id, "robb-studio");
+                assert_eq!(mismatch.ingest_host_id, "robb-pro");
                 assert_eq!(r.per_repo[0].health_gate_enabled, Some(true));
                 assert!(r.per_repo[0].health_gate_verdict_at.is_some());
                 assert_eq!(

--- a/loom-daemon/src/observability/exporter.rs
+++ b/loom-daemon/src/observability/exporter.rs
@@ -13,9 +13,14 @@
 //! object; [`super::sender::spawn_task`] is generic over a single concrete
 //! `E: Exporter`, so no vtable/boxing is required.
 
-use serde::Serialize;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
 
 use crate::telemetry::TelemetryEnvelope;
+
+use super::HostIdStatus;
 
 /// A sink [`super::sender`]'s drain loop can push batches of
 /// [`TelemetryEnvelope`]s to. Implementations must never panic on a
@@ -74,12 +79,63 @@ impl std::error::Error for ExportError {}
 #[derive(Serialize)]
 struct BatchPayload<'a>(&'a [TelemetryEnvelope]);
 
+/// The subset of the `/ingest` success response this exporter reads
+/// (Issue #4830). Every other field is ignored, and a body that is not JSON —
+/// or is JSON without a `host_id` — deserializes to `host_id: None`, which is
+/// treated as "this backend does not echo an identity" and checked no further.
+/// That is what keeps a pre-#4830 backend (whose response was a bare
+/// `{"accepted": N}`) working unchanged.
+#[derive(Deserialize)]
+struct IngestAck {
+    #[serde(default)]
+    host_id: Option<String>,
+}
+
+/// How much of a success-response body is read before the host-identity echo
+/// is parsed out of it. The real response is a few dozen bytes
+/// (`{"accepted":50,"host_id":"…"}`); this bound exists only so a misconfigured
+/// endpoint that answers 200 with a huge body cannot be buffered into memory
+/// just to read one diagnostic field out of it.
+const MAX_ACK_BODY_BYTES: usize = 4096;
+
+/// Read at most `limit` bytes of `response`'s body, discarding the rest.
+///
+/// Streams chunk-by-chunk rather than using `Response::text()`, which would
+/// buffer the *whole* body first and make [`MAX_ACK_BODY_BYTES`] a post-hoc
+/// truncation rather than a real bound. A read error mid-body is not an error
+/// here: the batch is already acked, so whatever was read so far is simply
+/// parsed (and a truncated/partial body just fails to parse, which is handled
+/// as "no identity to compare").
+async fn read_bounded_body(mut response: reqwest::Response, limit: usize) -> String {
+    let mut buf: Vec<u8> = Vec::new();
+    while buf.len() < limit {
+        match response.chunk().await {
+            Ok(Some(chunk)) => buf.extend_from_slice(&chunk),
+            Ok(None) | Err(_) => break,
+        }
+    }
+    buf.truncate(limit);
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
 /// The native JSON-over-HTTPS push [`Exporter`]. POSTs each batch as a JSON
 /// array to `endpoint` with `Authorization: Bearer <ingest_key>`.
 pub struct HttpsExporter {
     client: reqwest::Client,
     endpoint: String,
     ingest_key: String,
+    /// This daemon's own identity — [`crate::sweep_registry::host_identity`],
+    /// resolved once by [`super::spawn_task`] and shared with the collector so
+    /// this is literally the id stamped on the envelopes being pushed.
+    host_id: String,
+    /// WARN-once-per-daemon-lifetime guard (Issue #4830). The exporter is
+    /// constructed once per process, so instance scope *is* lifetime scope;
+    /// this is what keeps a permanent misconfiguration from re-logging on every
+    /// flush for the life of the daemon.
+    mismatch_warned: AtomicBool,
+    /// Where a confirmed mismatch is published for `loom-daemon status` /
+    /// `health` to read.
+    host_id_status: Arc<HostIdStatus>,
 }
 
 /// Per-request timeout — generous enough for a slow mobile/tethered fleet
@@ -91,9 +147,17 @@ const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 
 impl HttpsExporter {
     /// Build an exporter posting to `endpoint`, authenticating with
-    /// `ingest_key`. Fails only if the underlying `reqwest::Client` cannot be
-    /// constructed (e.g. no usable TLS backend) — never touches the network.
-    pub fn new(endpoint: String, ingest_key: String) -> Result<Self, ExportError> {
+    /// `ingest_key`, and verifying every success response's echoed `host_id`
+    /// against `host_id` (this daemon's own identity), publishing any mismatch
+    /// to `host_id_status`. Fails only if the underlying `reqwest::Client`
+    /// cannot be constructed (e.g. no usable TLS backend) — never touches the
+    /// network.
+    pub fn new(
+        endpoint: String,
+        ingest_key: String,
+        host_id: String,
+        host_id_status: Arc<HostIdStatus>,
+    ) -> Result<Self, ExportError> {
         let client = reqwest::Client::builder()
             .timeout(REQUEST_TIMEOUT)
             .build()
@@ -102,7 +166,55 @@ impl HttpsExporter {
             client,
             endpoint,
             ingest_key,
+            host_id,
+            mismatch_warned: AtomicBool::new(false),
+            host_id_status,
         })
+    }
+
+    /// Compare the `host_id` a `/ingest` success response echoed against this
+    /// daemon's own identity, WARNing **once per daemon lifetime** and
+    /// publishing to [`HostIdStatus`] on a mismatch (Issue #4830).
+    ///
+    /// Never returns an error and never affects the export result: a batch the
+    /// backend accepted stays accepted, whatever it says the key is bound to.
+    /// The only thing a mismatch changes is that the operator now finds out.
+    fn check_host_identity(&self, body: &str) {
+        let Ok(ack) = serde_json::from_str::<IngestAck>(body) else {
+            // Not JSON at all (a proxy's HTML 200, an empty body). The batch was
+            // still acked; there is simply no identity to compare.
+            return;
+        };
+        let Some(ingest_host_id) = ack
+            .host_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        else {
+            // A pre-#4830 backend, which echoes no identity. Nothing to check —
+            // deliberately silent, so pointing a daemon at an older backend does
+            // not produce a recurring "cannot verify" line.
+            return;
+        };
+        if ingest_host_id == self.host_id {
+            return;
+        }
+        // `record_mismatch` and the WARN guard are independent (the status
+        // handle may be shared with a future second exporter) but both are
+        // once-per-process, so the log line and the published record always
+        // describe the same first observation.
+        self.host_id_status
+            .record_mismatch(&self.host_id, ingest_host_id);
+        if !self.mismatch_warned.swap(true, Ordering::SeqCst) {
+            log::warn!(
+                "observability: ingest key is bound to host_id {ingest_host_id:?} but this daemon \
+                 identifies as {:?} — every record pushed from this host is being filed under \
+                 {ingest_host_id:?}. Install the key provisioned for {:?}, or set $LOOM_HOST_ID to \
+                 match the key's binding. (This warning is logged once per daemon lifetime.)",
+                self.host_id,
+                self.host_id,
+            );
+        }
     }
 }
 
@@ -117,6 +229,12 @@ impl Exporter for HttpsExporter {
             .await
             .map_err(|error| ExportError::Transport(error.to_string()))?;
         if response.status().is_success() {
+            // The batch is already acked at this point — reading the body is a
+            // pure self-diagnostic (Issue #4830), so a body that fails to read
+            // is ignored rather than turned into a spurious export failure that
+            // would re-send records the backend has already durably stored.
+            let body = read_bounded_body(response, MAX_ACK_BODY_BYTES).await;
+            self.check_host_identity(&body);
             return Ok(());
         }
         let status = response.status().as_u16();
@@ -153,6 +271,10 @@ mod tests {
         addr: SocketAddr,
         requests: Arc<Mutex<Vec<MockRequest>>>,
         respond_with: Arc<Mutex<u16>>,
+        /// The success-response body (Issue #4830 — the real `/ingest` echoes
+        /// `{"accepted":N,"host_id":"…"}`). Empty by default so the pre-#4830
+        /// "no echo" backend is what the untouched tests below exercise.
+        respond_body: Arc<Mutex<String>>,
         shutdown: Arc<std::sync::atomic::AtomicBool>,
         handle: Option<std::thread::JoinHandle<()>>,
     }
@@ -170,17 +292,20 @@ mod tests {
             let addr = listener.local_addr().unwrap();
             let requests = Arc::new(Mutex::new(Vec::new()));
             let respond_with = Arc::new(Mutex::new(200u16));
+            let respond_body = Arc::new(Mutex::new(String::new()));
             let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
             let handle = spawn_accept_loop(
                 listener,
                 requests.clone(),
                 respond_with.clone(),
+                respond_body.clone(),
                 shutdown.clone(),
             );
             MockSink {
                 addr,
                 requests,
                 respond_with,
+                respond_body,
                 shutdown,
                 handle: Some(handle),
             }
@@ -196,6 +321,11 @@ mod tests {
 
         fn set_status(&self, status: u16) {
             *self.respond_with.lock().unwrap() = status;
+        }
+
+        /// Answer every subsequent request with this body (Issue #4830).
+        fn set_body(&self, body: &str) {
+            *self.respond_body.lock().unwrap() = body.to_string();
         }
 
         /// Simulate the sink going offline: stop accepting new connections.
@@ -222,17 +352,20 @@ mod tests {
             let listener = TcpListener::bind(addr).unwrap();
             listener.set_nonblocking(true).unwrap();
             let respond_with = Arc::new(Mutex::new(200u16));
+            let respond_body = Arc::new(Mutex::new(String::new()));
             let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
             let handle = spawn_accept_loop(
                 listener,
                 requests.clone(),
                 respond_with.clone(),
+                respond_body.clone(),
                 shutdown.clone(),
             );
             MockSink {
                 addr,
                 requests,
                 respond_with,
+                respond_body,
                 shutdown,
                 handle: Some(handle),
             }
@@ -253,6 +386,7 @@ mod tests {
         listener: TcpListener,
         requests: Arc<Mutex<Vec<MockRequest>>>,
         respond_with: Arc<Mutex<u16>>,
+        respond_body: Arc<Mutex<String>>,
         shutdown: Arc<std::sync::atomic::AtomicBool>,
     ) -> std::thread::JoinHandle<()> {
         std::thread::spawn(move || {
@@ -262,7 +396,8 @@ mod tests {
                         stream.set_nonblocking(false).ok();
                         if let Some(request) = read_request(&mut stream) {
                             let status = *respond_with.lock().unwrap();
-                            let _ = write_response(&mut stream, status);
+                            let body = respond_body.lock().unwrap().clone();
+                            let _ = write_response(&mut stream, status, &body);
                             requests.lock().unwrap().push(request);
                         }
                     }
@@ -321,10 +456,16 @@ mod tests {
         Some(MockRequest { auth_header, body })
     }
 
-    fn write_response(stream: &mut std::net::TcpStream, status: u16) -> std::io::Result<()> {
+    fn write_response(
+        stream: &mut std::net::TcpStream,
+        status: u16,
+        body: &str,
+    ) -> std::io::Result<()> {
         let reason = if status < 300 { "OK" } else { "Error" };
-        let response =
-            format!("HTTP/1.1 {status} {reason}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+        let response = format!(
+            "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
         stream.write_all(response.as_bytes())
     }
 
@@ -332,6 +473,31 @@ mod tests {
         haystack
             .windows(needle.len())
             .position(|window| window == needle)
+    }
+
+    /// The identity these tests' daemon reports for itself — matched against
+    /// the `host_id` a mock sink echoes.
+    const TEST_HOST_ID: &str = "host-test";
+
+    /// An exporter with a throwaway (unregistered) status handle: nothing here
+    /// touches the process-global, so tests never leak mismatch state into each
+    /// other or into `ipc::build_daemon_status`.
+    fn test_exporter(endpoint: String, key: &str) -> HttpsExporter {
+        HttpsExporter::new(
+            endpoint,
+            key.to_string(),
+            TEST_HOST_ID.to_string(),
+            Arc::new(HostIdStatus::default()),
+        )
+        .unwrap()
+    }
+
+    fn test_exporter_with_status(
+        endpoint: String,
+        host_id: &str,
+        status: Arc<HostIdStatus>,
+    ) -> HttpsExporter {
+        HttpsExporter::new(endpoint, "key".to_string(), host_id.to_string(), status).unwrap()
     }
 
     fn one_envelope() -> TelemetryEnvelope {
@@ -352,7 +518,7 @@ mod tests {
     #[tokio::test]
     async fn emit_batch_posts_the_batch_with_bearer_auth() {
         let sink = MockSink::start();
-        let exporter = HttpsExporter::new(sink.url(), "s3cr3t-ingest-key".to_string()).unwrap();
+        let exporter = test_exporter(sink.url(), "s3cr3t-ingest-key");
         let batch = vec![one_envelope(), one_envelope()];
         exporter.emit_batch(&batch).await.unwrap();
 
@@ -367,7 +533,7 @@ mod tests {
     async fn non_2xx_status_is_reported_as_rejected() {
         let sink = MockSink::start();
         sink.set_status(500);
-        let exporter = HttpsExporter::new(sink.url(), "key".to_string()).unwrap();
+        let exporter = test_exporter(sink.url(), "key");
         let batch = vec![one_envelope()];
         let error = exporter.emit_batch(&batch).await.unwrap_err();
         match error {
@@ -382,8 +548,7 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
         drop(listener);
-        let exporter =
-            HttpsExporter::new(format!("http://{addr}/ingest"), "key".to_string()).unwrap();
+        let exporter = test_exporter(format!("http://{addr}/ingest"), "key");
         let batch = vec![one_envelope()];
         let error = exporter.emit_batch(&batch).await.unwrap_err();
         assert!(matches!(error, ExportError::Transport(_)));
@@ -394,11 +559,8 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
         drop(listener);
-        let exporter = HttpsExporter::new(
-            format!("http://{addr}/ingest"),
-            "top-secret-ingest-key-value".to_string(),
-        )
-        .unwrap();
+        let exporter =
+            test_exporter(format!("http://{addr}/ingest"), "top-secret-ingest-key-value");
         let batch = vec![one_envelope()];
         let error = exporter.emit_batch(&batch).await.unwrap_err();
         let rendered = error.to_string();
@@ -413,17 +575,130 @@ mod tests {
         // Exercises the mock sink helper itself (the drain-loop-level
         // kill/revive integration test lives in `super::super::sender`).
         let sink = MockSink::start();
-        let exporter = HttpsExporter::new(sink.url(), "key".to_string()).unwrap();
+        let exporter = test_exporter(sink.url(), "key");
         exporter.emit_batch(&[one_envelope()]).await.unwrap();
         let (addr, requests) = sink.kill();
-        assert!(HttpsExporter::new(format!("http://{addr}/ingest"), "key".to_string())
-            .unwrap()
+        assert!(test_exporter(format!("http://{addr}/ingest"), "key")
             .emit_batch(&[one_envelope()])
             .await
             .is_err());
         let revived = MockSink::revive(addr, requests);
-        let exporter2 = HttpsExporter::new(revived.url(), "key".to_string()).unwrap();
+        let exporter2 = test_exporter(revived.url(), "key");
         exporter2.emit_batch(&[one_envelope()]).await.unwrap();
         assert_eq!(revived.requests().len(), 2);
+    }
+
+    // ------------------------------------------------------------------
+    // host_id echo verification (Issue #4830)
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn matching_echoed_host_id_publishes_no_mismatch() {
+        let sink = MockSink::start();
+        sink.set_body(r#"{"accepted":1,"host_id":"host-test"}"#);
+        let status = Arc::new(HostIdStatus::default());
+        let exporter = test_exporter_with_status(sink.url(), TEST_HOST_ID, status.clone());
+
+        exporter.emit_batch(&[one_envelope()]).await.unwrap();
+
+        assert!(status.snapshot().is_none(), "ids agree ⇒ nothing published, nothing warned");
+    }
+
+    #[tokio::test]
+    async fn mismatched_echoed_host_id_is_published_with_both_identities() {
+        // The live 2026-07-31 incident: the Studio's key was bound to
+        // `robb-pro`, so every record it pushed was filed under that host.
+        let sink = MockSink::start();
+        sink.set_body(r#"{"accepted":1,"host_id":"robb-pro"}"#);
+        let status = Arc::new(HostIdStatus::default());
+        let exporter = test_exporter_with_status(sink.url(), "robb-studio", status.clone());
+
+        exporter.emit_batch(&[one_envelope()]).await.unwrap();
+
+        let mismatch = status.snapshot().expect("mismatch must be published");
+        assert_eq!(mismatch.daemon_host_id, "robb-studio");
+        assert_eq!(mismatch.ingest_host_id, "robb-pro");
+    }
+
+    #[tokio::test]
+    async fn a_mismatch_warns_once_per_lifetime_not_once_per_flush() {
+        let sink = MockSink::start();
+        sink.set_body(r#"{"accepted":1,"host_id":"robb-pro"}"#);
+        let status = Arc::new(HostIdStatus::default());
+        let exporter = test_exporter_with_status(sink.url(), "robb-studio", status.clone());
+
+        // Ten flushes, one warning: `mismatch_warned` latches on the first, and
+        // `record_mismatch` returns `false` for every subsequent flush — which
+        // is exactly the "not per flush" guarantee, observed through the same
+        // once-only guard the WARN is gated on.
+        for _ in 0..10 {
+            exporter.emit_batch(&[one_envelope()]).await.unwrap();
+        }
+        assert_eq!(sink.requests().len(), 10, "all ten batches were pushed");
+
+        let first_seen = status.snapshot().expect("published").first_seen_at;
+        assert!(
+            !status.record_mismatch("robb-studio", "robb-pro"),
+            "the exporter already consumed the one-shot; a later caller gets false"
+        );
+        assert_eq!(
+            status.snapshot().expect("published").first_seen_at,
+            first_seen,
+            "first_seen_at is the age of the condition, never re-stamped per flush"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_backend_that_echoes_no_host_id_is_not_a_mismatch() {
+        // A pre-#4830 backend answers `{"accepted":N}` — unverifiable, not
+        // wrong. Must stay silent rather than cry wolf on every flush.
+        let sink = MockSink::start();
+        sink.set_body(r#"{"accepted":1}"#);
+        let status = Arc::new(HostIdStatus::default());
+        let exporter = test_exporter_with_status(sink.url(), "robb-studio", status.clone());
+
+        exporter.emit_batch(&[one_envelope()]).await.unwrap();
+
+        assert!(status.snapshot().is_none());
+    }
+
+    #[tokio::test]
+    async fn a_non_json_success_body_never_fails_the_export() {
+        // A proxy answering 200 with HTML must not turn an acked batch into a
+        // retry (which would duplicate rows the backend already stored).
+        let sink = MockSink::start();
+        sink.set_body("<html>hello</html>");
+        let status = Arc::new(HostIdStatus::default());
+        let exporter = test_exporter_with_status(sink.url(), "robb-studio", status.clone());
+
+        exporter.emit_batch(&[one_envelope()]).await.unwrap();
+
+        assert!(status.snapshot().is_none());
+    }
+
+    #[tokio::test]
+    async fn an_oversized_success_body_is_bounded_and_never_fails_the_export() {
+        // The identity echo is worth a few dozen bytes, not an unbounded read:
+        // past MAX_ACK_BODY_BYTES the body is cut off, the truncated JSON fails
+        // to parse, and the whole thing degrades to "nothing to compare".
+        let sink = MockSink::start();
+        let padding = "x".repeat(2 * MAX_ACK_BODY_BYTES);
+        sink.set_body(&format!(r#"{{"accepted":1,"host_id":"robb-pro","pad":"{padding}"}}"#));
+        let status = Arc::new(HostIdStatus::default());
+        let exporter = test_exporter_with_status(sink.url(), "robb-studio", status.clone());
+
+        exporter.emit_batch(&[one_envelope()]).await.unwrap();
+
+        assert!(status.snapshot().is_none());
+    }
+
+    #[test]
+    fn host_id_status_defaults_to_no_mismatch_and_keeps_the_first_one() {
+        let status = HostIdStatus::default();
+        assert!(status.snapshot().is_none(), "a disabled exporter publishes nothing");
+        assert!(status.record_mismatch("a", "b"), "first write wins");
+        assert!(!status.record_mismatch("a", "c"), "second write is refused");
+        let snapshot = status.snapshot().unwrap();
+        assert_eq!(snapshot.ingest_host_id, "b", "the first observation is kept");
     }
 }

--- a/loom-daemon/src/observability/mod.rs
+++ b/loom-daemon/src/observability/mod.rs
@@ -31,8 +31,17 @@
 //!
 //! This module only ever originates outbound HTTP POSTs
 //! ([`exporter::HttpsExporter::emit_batch`]); nothing here parses a response
-//! body for anything but a batch-accepted/rejected status, and no daemon
-//! state is ever mutated from data received over this channel.
+//! body for anything but a batch-accepted/rejected status **plus the
+//! self-diagnostic host-identity echo below**, and no daemon *behavior* is
+//! ever driven by data received over this channel.
+//!
+//! The one thing read out of a response body (Issue #4830) is the `host_id`
+//! the backend echoes for the key it authenticated. It is compared against
+//! this daemon's own [`crate::sweep_registry::host_identity`] and, on a
+//! mismatch, published to [`HostIdStatus`] + logged once — it never selects an
+//! endpoint, never changes what is exported, and is never written into a
+//! record. A hostile/broken sink can therefore, at worst, make this daemon
+//! report a mismatch that is not real; it cannot steer the daemon.
 //!
 //! # Ingest key handling
 //!
@@ -198,6 +207,78 @@ pub fn resolve_queue_capacity(config: &ObservabilityConfig) -> usize {
         .unwrap_or(DEFAULT_QUEUE_CAPACITY)
 }
 
+// ============================================================================
+// Host-identity mismatch status (Issue #4830)
+// ============================================================================
+
+/// Shared, thread-safe handle the exporter publishes a confirmed host-identity
+/// mismatch to, and [`crate::ipc::build_daemon_status`] reads back — mirroring
+/// [`crate::auto_update::AutoUpdateStatus`]'s process-global pattern rather than
+/// threading an `Arc` through the whole IPC server.
+///
+/// **Write-once per process.** The first mismatch observed wins and is never
+/// overwritten or cleared: the WARN is once-per-daemon-lifetime by AC, so the
+/// published record has to be too, or `first_seen_at` would silently become
+/// "last flush" and the two surfaces would disagree.
+#[derive(Debug, Default)]
+pub struct HostIdStatus {
+    inner: std::sync::Mutex<Option<crate::types::ObservabilityHostIdMismatch>>,
+}
+
+// Allow expect_used: a poisoned status mutex means another thread panicked while
+// holding it — unrecoverable, matching the crash-on-poison policy `auto_update`
+// and `ipc` already use for their status mutexes.
+#[allow(clippy::expect_used)]
+impl HostIdStatus {
+    /// Record the first observed mismatch. Returns `true` when this call is the
+    /// one that recorded it (i.e. the caller owes exactly one WARN), `false`
+    /// when a mismatch was already published this process.
+    pub fn record_mismatch(&self, daemon_host_id: &str, ingest_host_id: &str) -> bool {
+        let mut guard = self
+            .inner
+            .lock()
+            .expect("observability host-id status mutex poisoned");
+        if guard.is_some() {
+            return false;
+        }
+        *guard = Some(crate::types::ObservabilityHostIdMismatch {
+            daemon_host_id: daemon_host_id.to_string(),
+            ingest_host_id: ingest_host_id.to_string(),
+            first_seen_at: chrono::Utc::now(),
+        });
+        true
+    }
+
+    /// The published mismatch, or `None` when the ids have agreed on every
+    /// acked batch so far (the common case).
+    #[must_use]
+    pub fn snapshot(&self) -> Option<crate::types::ObservabilityHostIdMismatch> {
+        self.inner
+            .lock()
+            .expect("observability host-id status mutex poisoned")
+            .clone()
+    }
+}
+
+/// Process-global status handle, registered by [`spawn_task`] when — and only
+/// when — the exporter actually starts. Unset (observability disabled, keyless,
+/// or under-configured) reads as `None`, so a disabled exporter contributes
+/// nothing to `status`/`health`.
+static GLOBAL_HOST_ID_STATUS: std::sync::OnceLock<Arc<HostIdStatus>> = std::sync::OnceLock::new();
+
+/// Register the exporter's status handle as the process-global. Idempotent:
+/// only the first registration wins (there is exactly one exporter per process).
+pub fn register_global_host_id_status(status: Arc<HostIdStatus>) {
+    let _ = GLOBAL_HOST_ID_STATUS.set(status);
+}
+
+/// The process-global host-identity mismatch, or `None` when none has been
+/// observed (or the exporter never started).
+#[must_use]
+pub fn global_host_id_mismatch() -> Option<crate::types::ObservabilityHostIdMismatch> {
+    GLOBAL_HOST_ID_STATUS.get().and_then(|s| s.snapshot())
+}
+
 /// Read `path` and return its trimmed contents as the ingest key. Every
 /// failure (missing file, unreadable, empty after trimming) is logged
 /// **by path only** — the key itself never reaches a log line — and yields
@@ -259,7 +340,21 @@ pub fn spawn_task(
         return None;
     };
     let ingest_key = read_ingest_key(&key_file)?;
-    let exporter = match HttpsExporter::new(endpoint.clone(), ingest_key) {
+    // Resolved ONCE and threaded into both consumers below (Issue #4830): the
+    // collector stamps it on every envelope and the exporter checks the backend's
+    // echo against it. Two independent `host_identity()` calls could not disagree
+    // today, but a single value makes that structurally true rather than
+    // incidentally so — and the whole point of the check is that the two halves
+    // being compared are the *same* identity the records are filed under.
+    let host_id = crate::sweep_registry::host_identity();
+    let host_id_status = Arc::new(HostIdStatus::default());
+    register_global_host_id_status(host_id_status.clone());
+    let exporter = match HttpsExporter::new(
+        endpoint.clone(),
+        ingest_key,
+        host_id.clone(),
+        host_id_status,
+    ) {
         Ok(exporter) => exporter,
         Err(error) => {
             log::warn!("observability: failed to construct HTTPS exporter for {endpoint}: {error} — export off");
@@ -277,7 +372,6 @@ pub fn spawn_task(
         flush_interval.as_secs()
     );
     let queue = Arc::new(DurableQueue::open(queue_path, capacity));
-    let host_id = crate::sweep_registry::host_identity();
 
     let collector_handle = collector::spawn_task(
         bus,

--- a/loom-daemon/src/serve.rs
+++ b/loom-daemon/src/serve.rs
@@ -1223,6 +1223,7 @@ mod tests {
             pid_file: None,
             daemon_build_commit: None,
             work_finder_interval_secs: None,
+            observability_host_id_mismatch: None,
         }
     }
 

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -1332,6 +1332,47 @@ pub struct DaemonStatusReport {
     /// `#[serde(default)]` keeps older wire data compatible.
     #[serde(default)]
     pub work_finder_interval_secs: Option<u64>,
+    /// An observability-exporter host-identity mismatch detected this process
+    /// (Issue #4830): the ingest key installed on this host is bound to a
+    /// *different* `host_id` than the one this daemon reports for itself, so
+    /// every record it pushes is filed under the wrong host.
+    ///
+    /// `None` in the overwhelmingly common case — the ids agree, the exporter
+    /// is disabled/keyless, or no batch has been acked yet this process — and
+    /// for a pre-#4830 wire payload. Published by
+    /// [`crate::observability::HostIdStatus`] and read here via
+    /// [`crate::observability::global_host_id_mismatch`]. `#[serde(default)]`
+    /// keeps older wire data / older clients compatible.
+    #[serde(default)]
+    pub observability_host_id_mismatch: Option<ObservabilityHostIdMismatch>,
+}
+
+/// A confirmed disagreement between the host identity this daemon resolves for
+/// itself and the `host_id` the ingest backend echoes back for the key it
+/// authenticated (Issue #4830).
+///
+/// Filed as a *data* type on the status wire rather than a log-only condition
+/// because the 2026-07-31 incident it exists for was invisible for hours: a Mac
+/// Studio pushed its whole first night of telemetry under another host's id
+/// because the wrong key file had been installed on it, and neither side had any
+/// way to notice. The backend cannot notice (a key-bound id is authoritative by
+/// design), so the *daemon* is the only party that holds both halves.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ObservabilityHostIdMismatch {
+    /// What this daemon calls itself —
+    /// [`crate::sweep_registry::host_identity`], resolved with the precedence
+    /// `$LOOM_HOST_ID`, then `$HOSTNAME`, then the `hostname` binary, then
+    /// `"unknown-host"`. The same value it stamps on every outgoing envelope.
+    pub daemon_host_id: String,
+    /// The `host_id` the `/ingest` response echoed — the identity the
+    /// authenticated key is bound to, i.e. the host every pushed record is
+    /// actually being filed under.
+    pub ingest_host_id: String,
+    /// When the mismatch was first observed this daemon process. Never
+    /// re-stamped on subsequent flushes: the WARN and this record are both
+    /// once-per-lifetime, so this is the age of the condition, not of the last
+    /// flush.
+    pub first_seen_at: DateTime<Utc>,
 }
 
 /// One work-finder tick's dispatch/skip tally, stamped with the wall-clock


### PR DESCRIPTION
Closes #4830

## What

Live incident 2026-07-31: a Mac Studio spent its first hours of telemetry
reporting under `robb-pro` — an ingest key bound to the wrong host_id had
been installed on it — and nothing anywhere warned. The backend records the
key-bound host_id as authoritative (deploy-runbook §8: "a mismatch is not a
security problem, only a confusing one"), and the exporter had no idea what
its key was bound to.

This closes the loop: the backend now echoes the bound identity, and the
exporter checks it against its own.

- **`/ingest` response** (`dashboard/src/index.ts`) now echoes the
  authenticated key's bound `host_id`:
  `{"accepted": N, "host_id": "..."}`. Purely additive — no `schema_version`
  rev, `accepted` unchanged, a pre-#4830 exporter that ignores the response
  body is unaffected. **The server-side `/ingest` handler was found in this
  repo** (`dashboard/src/index.ts`, the Cloudflare Worker backend) and
  modified directly — no cross-repo gap here.
- **Exporter** (`loom-daemon/src/observability/exporter.rs`): reads a
  bounded slice (4 KiB) of every success response, compares the echoed
  `host_id` against this daemon's own identity
  (`sweep_registry::host_identity` — `$LOOM_HOST_ID` > `$HOSTNAME` >
  `hostname`), and on a mismatch:
  - logs a `WARN` naming both identities, **once per daemon lifetime** (an
    `AtomicBool` latch on the exporter instance, which is one-per-process),
    not once per flush;
  - publishes the mismatch (first-seen timestamp + both ids) to a new
    `HostIdStatus` process-global, mirroring the existing `AutoUpdateStatus`
    pattern.
  - A backend that doesn't echo `host_id` (pre-#4830), a non-JSON body, or
    an oversized body are all treated as "nothing to compare" — silent, not
    a recurring warning.
- **`loom-daemon health`** (`health.rs`): new **conditional** `observability`
  section, `DEGRADED`, only appended when a mismatch has been observed —
  absent entirely when ids agree, the exporter is disabled/keyless, or the
  daemon is unreachable, so a healthy daemon's report is byte-for-byte
  unchanged.
- **`loom-daemon status`**: `observability_host_id_mismatch` field in
  `status --json` (`types.rs`, `ipc.rs`, `cli/status_render.rs`) plus a
  human-readable `WARNING:` line in `status` text output.
- **Docs**: `.loom/docs/observability.md` + `.loom/docs/telemetry-schema.md`
  (and their `defaults/docs/` mirrors) document the echo + comparison;
  `dashboard/docs/deploy-runbook.md` §8 rewritten — the mismatch is now
  *detected*, not just "confusing".

## Acceptance criteria

- [x] `/ingest` response echoes the bound `host_id` (additive field)
- [x] Exporter compares echoed `host_id` against its own identity (same
      resolution as `sweep_registry::host_identity`), WARNs once per daemon
      lifetime on mismatch
- [x] `loom-daemon health` surfaces the mismatch as a degraded-observability
      section when present
- [x] Runbook §8 updated: mismatch is now detected, not just "confusing"
- [x] No behavior change when they match; a keyless/disabled exporter is
      unaffected (verified by tests — `no_observability_section_for_a_disabled_or_keyless_exporter`,
      `a_backend_that_echoes_no_host_id_is_not_a_mismatch`)

## Tests

- `loom-daemon/src/observability/exporter.rs`: 8 new tests — matching ids
  publish nothing, mismatched ids publish both identities, WARN fires once
  across 10 flushes (`a_mismatch_warns_once_per_lifetime_not_once_per_flush`),
  a pre-#4830 backend (no echo) is silent, a non-JSON success body never
  fails the export, an oversized body is bounded and never fails the export.
- `loom-daemon/src/health.rs`: 6 new tests covering the conditional
  `observability` section (absent when healthy/disabled/unreachable, present
  and `DEGRADED` with both ids + age on a confirmed mismatch, appended last).
- `loom-daemon/src/ipc.rs`, `cli/status.rs`, `cli/status_render.rs`: wire
  round-trip + JSON rendering tests for the new
  `observability_host_id_mismatch` field.
- `dashboard/test/ingest.test.ts`: 4 new tests for the `/ingest` echo
  (echoes the key's binding not the envelope's claimed host, per-key
  echoes when two keys are in play, no echo on a rejected/unauthenticated
  request).

Results: `cargo test --lib --bin loom-daemon` — 2967 passed, 0 failures
outside a **pre-existing, environment-specific** cluster of 7
`work_finder`/`auto_update` config-resolution tests that leak this
sandbox's real `~/.local/share/loom/config/defaults.json` machine-level
config (an Epic #3835 Phase 3 tier this host has installed) into a
tempdir-scoped test — confirmed unrelated to this change: those tests fail
identically with `LOOM_CONFIG_DEFAULTS_FILE=""` isolating the root cause to
a tier neither this PR nor its target modules touch, and the failure count
drops from 10 to 7 once that tier is disabled (the remaining 7 are a
separate pre-existing `work_finder` config-resolution gap, also untouched
by this diff). All `observability::*`, `health::*`, `ipc::*`,
`cli::status*` tests pass cleanly (51 + 76 + 81 + 31 respectively).
`dashboard`: `npx vitest run` — 160/160 passed, `npx tsc --noEmit` clean.
`cargo fmt --check` and `cargo clippy --lib --bin loom-daemon --all-features
-- -D warnings` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)