### PR TITLE
feat(dashboard): mount the Phase-3 panels behind hash routes

### DIFF
--- a/dashboard/web/index.html
+++ b/dashboard/web/index.html
@@ -10,6 +10,12 @@
   <body>
     <header class="topbar">
       <h1 class="topbar__title">Loom fleet</h1>
+      <nav class="topbar__nav" aria-label="Views">
+        <a class="topbar__navlink" href="#/">Fleet</a>
+        <a class="topbar__navlink" href="#/charts">Charts</a>
+        <a class="topbar__navlink" href="#/tokens">Tokens</a>
+        <a class="topbar__navlink" href="#/feed">Feed</a>
+      </nav>
       <div class="topbar__meta">
         <span id="refresh-status" class="topbar__status" aria-live="polite"></span>
         <!-- Populated by `accountMenu.ts` from the server-injected auth

--- a/dashboard/web/src/app.ts
+++ b/dashboard/web/src/app.ts
@@ -18,7 +18,8 @@ import { fetchFleetState } from "./api";
 import { replaceChildren } from "./dom";
 import { buildFleetView, findHost, type FleetView } from "./fleet";
 import { formatClock } from "./format";
-import { OVERVIEW, parseRoute, type Route } from "./router";
+import { OVERVIEW, isPanelRoute, parseRoute, type PanelRouteName, type Route } from "./router";
+import { PANEL_STATUS, mountPanel } from "./panels";
 import type { FleetSnapshot } from "./types";
 import { fleetOverviewView } from "./views/fleetOverview";
 import { hostDetailView } from "./views/hostDetail";
@@ -57,6 +58,15 @@ export class App {
   private inFlight = false;
   private timer: number | null = null;
   private stopped = false;
+
+  /** Which panel route is currently mounted, and how to tear it down.
+   *
+   * Panel routes (#4895) own their own fetching, so they must be mounted on a
+   * route *change* and not on every `render()` — `render()` runs on each poll
+   * tick, and remounting there would refetch and flicker the panel every
+   * `pollIntervalMs`. */
+  private mountedPanel: PanelRouteName | null = null;
+  private teardownPanel: (() => void) | null = null;
 
   constructor(options: AppOptions) {
     this.root = options.root;
@@ -129,6 +139,7 @@ export class App {
   }
 
   stop(): void {
+    this.unmountPanel();
     this.stopped = true;
     if (this.timer !== null) {
       this.scheduler.clearTimeout(this.timer);
@@ -153,8 +164,35 @@ export class App {
     return this.snapshot ? buildFleetView(this.snapshot, this.now()) : null;
   }
 
+  /** Mount `name`'s panel if it is not already the mounted one. Idempotent by
+   * design — `render()` calls this on every poll tick. */
+  private renderPanel(name: PanelRouteName): void {
+    if (this.mountedPanel === name) return;
+    this.unmountPanel();
+
+    this.root.setAttribute("aria-busy", "false");
+    this.teardownPanel = mountPanel(name, this.root);
+    this.mountedPanel = name;
+  }
+
+  private unmountPanel(): void {
+    this.teardownPanel?.();
+    this.teardownPanel = null;
+    this.mountedPanel = null;
+  }
+
   render(): void {
     const now = this.now();
+
+    // Panel routes short-circuit every snapshot-dependent branch below: they
+    // do not read the fleet snapshot at all, so a first paint before the first
+    // poll returns must not show the fleet's loading view.
+    if (isPanelRoute(this.route)) {
+      this.renderPanel(this.route.name);
+      this.setStatus(PANEL_STATUS[this.route.name]);
+      return;
+    }
+    this.unmountPanel();
 
     if (this.loading && !this.snapshot) {
       this.root.setAttribute("aria-busy", "true");

--- a/dashboard/web/src/main.ts
+++ b/dashboard/web/src/main.ts
@@ -7,7 +7,7 @@
 import "./styles.css";
 import { App } from "./app";
 import { wireAccountMenu } from "./accountMenu";
-import { onRouteChange, parseRoute } from "./router";
+import { onRouteChange, parseRoute, routeToHash } from "./router";
 
 const root = document.getElementById("app");
 if (!(root instanceof HTMLElement)) {
@@ -22,7 +22,23 @@ const app = new App({
   refreshButton: document.getElementById("refresh-button"),
 });
 
-onRouteChange((route) => app.navigate(route));
+/** Mark the nav link matching the active route, so the user can see where
+ * they are. Driven from the parsed route rather than the raw hash so an
+ * unrecognized hash highlights Fleet, matching where it actually lands. */
+function syncNav(doc: Document, hash: string): void {
+  const active = routeToHash(parseRoute(hash));
+  for (const link of doc.querySelectorAll<HTMLAnchorElement>(".topbar__navlink")) {
+    if (link.getAttribute("href") === active) link.setAttribute("aria-current", "page");
+    else link.removeAttribute("aria-current");
+  }
+}
+
+syncNav(document, window.location.hash);
+
+onRouteChange((route) => {
+  app.navigate(route);
+  syncNav(document, window.location.hash);
+});
 
 void app.start(window.location.hash).then(() => app.startPolling());
 

--- a/dashboard/web/src/panels.ts
+++ b/dashboard/web/src/panels.ts
@@ -1,0 +1,159 @@
+/**
+ * The app shell's mount points for the self-contained Phase-3 panels
+ * (issue #4895).
+ *
+ * ## Why this file exists
+ *
+ * `#4750` (live event feed + sweep timeline), `#4751` (historical charts) and
+ * `#4752` (token/cost analytics) were each built as standalone modules
+ * exposing an integration point for a shell that did not exist yet. The shell
+ * (`#4749`) then landed without calling any of them, so ~3,900 lines of
+ * working, tested code sat in the tree while Vite tree-shook every byte of it
+ * out of the bundle — green CI, invisible features. This module is the
+ * integration point that was missing.
+ *
+ * ## The contract
+ *
+ * Every panel here is mounted on a route *change* and torn down on the next
+ * one. `App.render()` runs on each poll tick, so a panel that remounted there
+ * would refetch and flicker on every tick; `App` guards that by tracking the
+ * mounted route, and each `mount*` returns a teardown so anything holding a
+ * live connection (the feed's `EventSource`) is released.
+ *
+ * Panels own their own data. None of them read the fleet snapshot the app
+ * polls — that is what lets a panel route paint before the first poll returns.
+ */
+
+import { el } from "./dom";
+import { isAuthenticatedViewer } from "./api";
+import { HistoricalChartsPanel } from "./historicalChartsPanel";
+import { LiveFeedPanel } from "./liveFeedPanel";
+import { currentSurface } from "./analytics/bootstrap";
+import { mountTokenAnalytics } from "./analytics/render";
+import type { PanelRouteName } from "./router";
+
+/** Status-line text per panel route. The fleet's "Updated HH:MM:SS" is
+ * meaningless here — these panels are not driven by the fleet poll. */
+export const PANEL_STATUS: Readonly<Record<PanelRouteName, string>> = {
+  charts: "Historical charts",
+  tokens: "Token & cost analytics",
+  feed: "Live event feed",
+};
+
+/** A mounted panel's teardown. Panels with no live resource return a no-op. */
+export type PanelTeardown = () => void;
+
+/**
+ * Render a mount failure into `container`.
+ *
+ * `void somePromise()` discards rejections, which surface as unhandled
+ * promise rejections and leave the panel blank — the panel tests catch
+ * exactly that. Every async mount below routes its failure here instead.
+ */
+function renderMountError(container: HTMLElement, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  container.replaceChildren(
+    el("p", { class: "panel-route__note", data: { testid: "panel-error" } }, `Could not load: ${message}`),
+  );
+}
+
+function section(title: string, ...children: (Node | null)[]): HTMLElement {
+  return el("section", { class: "panel-route" }, el("h2", { class: "panel-route__title" }, title), ...children);
+}
+
+/**
+ * Which dataset a panel should read.
+ *
+ * The same route serves both audiences (issue #4795), so this resolves from
+ * the server-injected auth state rather than the path. `/public/*` is redacted
+ * server-side, so an anonymous viewer gets real — if reduced — content rather
+ * than an error or an empty panel.
+ */
+function historyBasePath(): string {
+  return isAuthenticatedViewer() ? "/api/history" : "/public/history";
+}
+
+function mountCharts(root: HTMLElement): PanelTeardown {
+  const outcomes = el("div", { class: "chart-slot", data: { testid: "chart-outcomes" } });
+  const successRate = el("div", { class: "chart-slot", data: { testid: "chart-success-rate" } });
+  const durations = el("div", { class: "chart-slot", data: { testid: "chart-durations" } });
+
+  root.replaceChildren(
+    section(
+      "Historical charts",
+      el("p", { class: "panel-route__note" }, "Sweep outcomes, success rate and duration percentiles over time."),
+      outcomes,
+      successRate,
+      durations,
+    ),
+  );
+
+  const panel = new HistoricalChartsPanel({
+    basePath: historyBasePath(),
+    outcomesContainer: outcomes,
+    successRateContainer: successRate,
+    durationsContainer: durations,
+  });
+  panel.refresh().catch((error: unknown) => renderMountError(outcomes, error));
+
+  return () => {};
+}
+
+function mountTokens(root: HTMLElement): PanelTeardown {
+  const container = el("div", { data: { testid: "token-analytics" } });
+  root.replaceChildren(container);
+
+  // `currentSurface()` reads the injected auth state, NOT the path — under the
+  // single-URL layout both audiences share one URL, so a path check would call
+  // every visitor authenticated (see analytics/bootstrap.ts). Signed in gets
+  // per-account detail; anonymous gets the pool-level aggregate (#4870).
+  mountTokenAnalytics(container, { surface: currentSurface() }).catch((error: unknown) =>
+    renderMountError(container, error),
+  );
+
+  return () => {};
+}
+
+function mountFeed(root: HTMLElement): PanelTeardown {
+  const feed = el("div", { data: { testid: "live-feed" } });
+
+  root.replaceChildren(
+    section(
+      "Live event feed",
+      // Honest about the gap rather than rendering a silently-partial view:
+      // sweep.started/completed/outcome all flow today, but sweep.phase is
+      // never emitted (#4863), so phase transitions are missing and the
+      // per-sweep timeline has nothing to draw. Drop this note when #4863
+      // lands.
+      el(
+        "p",
+        { class: "panel-route__note", data: { testid: "feed-phase-caveat" } },
+        "Sweep lifecycle events as they arrive. Phase transitions are not shown yet — " +
+          "the daemon does not emit sweep.phase telemetry (see issue #4863).",
+      ),
+      feed,
+    ),
+  );
+
+  const panel = new LiveFeedPanel({
+    container: feed,
+    url: isAuthenticatedViewer() ? "/api/events" : "/public/events",
+  });
+  panel.start();
+
+  // The one panel that genuinely needs teardown: it holds an open SSE
+  // connection that would otherwise survive navigation and leak per route
+  // change.
+  return () => panel.stop();
+}
+
+const MOUNTERS: Readonly<Record<PanelRouteName, (root: HTMLElement) => PanelTeardown>> = {
+  charts: mountCharts,
+  tokens: mountTokens,
+  feed: mountFeed,
+};
+
+/** Mount `name` into `root`, replacing its contents. Returns the teardown. */
+export function mountPanel(name: PanelRouteName, root: HTMLElement): PanelTeardown {
+  return MOUNTERS[name](root);
+}

--- a/dashboard/web/src/router.ts
+++ b/dashboard/web/src/router.ts
@@ -1,5 +1,5 @@
 /**
- * Hash-based routing (`#/` and `#/hosts/<hostId>`).
+ * Hash-based routing (`#/`, `#/hosts/<hostId>`, `#/charts`, `#/tokens`, `#/feed`).
  *
  * Hash routing rather than the History API is a deliberate deploy-shape
  * decision, not laziness. The UI ships as Workers Assets on the *same* Worker
@@ -13,13 +13,38 @@
  * shareable.
  */
 
-export type Route = { name: "overview" } | { name: "host"; hostId: string };
+export type Route =
+  | { name: "overview" }
+  | { name: "host"; hostId: string }
+  | { name: "charts" }
+  | { name: "tokens" }
+  | { name: "feed" };
 
 export const OVERVIEW: Route = { name: "overview" };
 
+/** Routes that render a self-contained panel owning its own data fetching,
+ * rather than a view over the fleet snapshot the app polls (issue #4895). */
+export type PanelRouteName = "charts" | "tokens" | "feed";
+
+const PANEL_ROUTES: Readonly<Record<string, PanelRouteName>> = {
+  "/charts": "charts",
+  "/tokens": "tokens",
+  "/feed": "feed",
+};
+
+export function isPanelRoute(route: Route): route is { name: PanelRouteName } {
+  return route.name === "charts" || route.name === "tokens" || route.name === "feed";
+}
+
 export function parseRoute(hash: string): Route {
   const path = hash.replace(/^#/, "");
+
+  const panel = PANEL_ROUTES[path];
+  if (panel) return { name: panel };
+
   const match = /^\/hosts\/(.+)$/.exec(path);
+  // Anything unrecognized falls back to the overview rather than erroring —
+  // a hand-edited or stale bookmark should land somewhere useful.
   if (!match?.[1]) return OVERVIEW;
   try {
     return { name: "host", hostId: decodeURIComponent(match[1]) };
@@ -30,7 +55,9 @@ export function parseRoute(hash: string): Route {
 }
 
 export function routeToHash(route: Route): string {
-  return route.name === "overview" ? "#/" : `#/hosts/${encodeURIComponent(route.hostId)}`;
+  if (route.name === "host") return `#/hosts/${encodeURIComponent(route.hostId)}`;
+  if (isPanelRoute(route)) return `#/${route.name}`;
+  return "#/";
 }
 
 /** Subscribe to hash changes; returns an unsubscribe function. */

--- a/dashboard/web/src/styles.css
+++ b/dashboard/web/src/styles.css
@@ -1,3 +1,4 @@
+@import "./analytics/analytics.css";
 /* Fleet dashboard styling — one plain stylesheet, no preprocessor and no
    CSS-in-JS. The palette follows `loom-daemon/src/dashboard.html`'s dark
    scheme so the two surfaces do not look like different products during the
@@ -419,4 +420,39 @@ a:hover {
 .meter__label {
   color: var(--text-dim);
   font-size: 12px;
+}
+
+/* --- Topbar nav + panel routes (#4895) --------------------------------- */
+.topbar__nav {
+  display: flex;
+  gap: 4px;
+  margin-left: 18px;
+}
+.topbar__navlink {
+  color: var(--text-dim);
+  text-decoration: none;
+  font-size: 13px;
+  padding: 4px 10px;
+  border-radius: 6px;
+}
+.topbar__navlink:hover {
+  color: var(--text);
+  background: var(--bg-sunken);
+}
+.topbar__navlink[aria-current="page"] {
+  color: var(--text);
+  background: var(--bg-sunken);
+  box-shadow: inset 0 -2px 0 var(--accent);
+}
+.panel-route__title {
+  margin: 0 0 4px;
+  font-size: 16px;
+}
+.panel-route__note {
+  margin: 0 0 16px;
+  color: var(--text-dim);
+  font-size: 12px;
+}
+.chart-slot {
+  margin-bottom: 22px;
 }

--- a/dashboard/web/test/panels.test.ts
+++ b/dashboard/web/test/panels.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Shell-integration tests for the panel routes (#4895).
+ *
+ * These exist because every other suite in this package passes without them.
+ * #4750, #4751 and #4752 each shipped with thorough module-level tests, and
+ * all of them stayed green while the features were absent from the built
+ * bundle — nothing in the app shell imported them, so Vite tree-shook the lot.
+ * Module tests prove a panel *works*; only a shell test proves a user can
+ * reach it.
+ *
+ * So the assertions here are deliberately about *reachability and lifecycle*,
+ * not rendering fidelity — that is the sibling suites' job.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PANEL_STATUS, mountPanel } from "../src/panels";
+import type { PanelRouteName } from "../src/router";
+
+const PANEL_NAMES: PanelRouteName[] = ["charts", "tokens", "feed"];
+
+/** Panels fetch on mount. Nothing here asserts on the response — the point is
+ * that mounting reaches the network at all, and never throws when it fails. */
+function stubFetch(): ReturnType<typeof vi.fn> {
+  const impl = vi.fn(async () =>
+    new Response(JSON.stringify({ records: [], nextCursor: null }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+  globalThis.fetch = impl as unknown as typeof fetch;
+  return impl;
+}
+
+let root: HTMLElement;
+let realFetch: typeof fetch;
+
+beforeEach(() => {
+  realFetch = globalThis.fetch;
+  document.body.replaceChildren();
+  root = document.createElement("div");
+  document.body.appendChild(root);
+  stubFetch();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+});
+
+describe("mountPanel", () => {
+  it.each(PANEL_NAMES)("%s renders content into the root", (name) => {
+    mountPanel(name, root);
+    expect(root.childElementCount).toBeGreaterThan(0);
+  });
+
+  it.each(PANEL_NAMES)("%s returns a teardown that does not throw", (name) => {
+    const teardown = mountPanel(name, root);
+    expect(typeof teardown).toBe("function");
+    expect(() => teardown()).not.toThrow();
+  });
+
+  it.each(PANEL_NAMES)("%s replaces prior contents rather than appending", (name) => {
+    // Tag the pre-existing node so the assertion is about *that* element
+    // rather than any <p> a panel legitimately renders inside itself.
+    const stale = document.createElement("p");
+    stale.dataset.testid = "stale-content";
+    root.appendChild(stale);
+
+    mountPanel(name, root);
+
+    expect(root.querySelector('[data-testid="stale-content"]')).toBeNull();
+    expect(root.contains(stale)).toBe(false);
+  });
+
+  it("mounts the charts panel with its three chart slots", () => {
+    mountPanel("charts", root);
+    expect(root.querySelector('[data-testid="chart-outcomes"]')).not.toBeNull();
+    expect(root.querySelector('[data-testid="chart-success-rate"]')).not.toBeNull();
+    expect(root.querySelector('[data-testid="chart-durations"]')).not.toBeNull();
+  });
+
+  it("mounts the token analytics container", () => {
+    mountPanel("tokens", root);
+    expect(root.querySelector('[data-testid="token-analytics"]')).not.toBeNull();
+  });
+
+  it("mounts the live feed and states the sweep.phase gap", () => {
+    mountPanel("feed", root);
+    expect(root.querySelector('[data-testid="live-feed"]')).not.toBeNull();
+    // #4863: phase transitions are not emitted, so the panel says so rather
+    // than silently rendering a partial view. Remove with that issue.
+    expect(root.querySelector('[data-testid="feed-phase-caveat"]')?.textContent).toContain("sweep.phase");
+  });
+
+  it("hits the network on mount for the data-backed panels", () => {
+    const impl = stubFetch();
+    mountPanel("charts", root);
+    expect(impl).toHaveBeenCalled();
+  });
+
+  // A panel that throws on mount would blank the app. Every fetch path here is
+  // expected to swallow its own failure and render a state instead.
+  it.each(PANEL_NAMES)("%s survives a failing fetch", (name) => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    expect(() => mountPanel(name, root)).not.toThrow();
+  });
+});
+
+describe("PANEL_STATUS", () => {
+  it("covers every panel route", () => {
+    for (const name of PANEL_NAMES) {
+      expect(PANEL_STATUS[name]).toBeTruthy();
+    }
+  });
+});

--- a/dashboard/web/test/router.test.ts
+++ b/dashboard/web/test/router.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { OVERVIEW, parseRoute, routeToHash } from "../src/router";
+import { OVERVIEW, isPanelRoute, parseRoute, routeToHash } from "../src/router";
 
 describe("parseRoute", () => {
   it("treats an empty or root hash as the overview", () => {
@@ -25,5 +25,44 @@ describe("parseRoute", () => {
 
   it("renders the overview hash", () => {
     expect(routeToHash(OVERVIEW)).toBe("#/");
+  });
+});
+
+// #4895: the routes that make the Phase-3 panels reachable at all.
+describe("panel routes", () => {
+  it.each([
+    ["#/charts", "charts"],
+    ["#/tokens", "tokens"],
+    ["#/feed", "feed"],
+  ])("parses %s", (hash, name) => {
+    expect(parseRoute(hash)).toEqual({ name });
+  });
+
+  it("round-trips through routeToHash", () => {
+    for (const name of ["charts", "tokens", "feed"] as const) {
+      expect(routeToHash({ name })).toBe(`#/${name}`);
+      expect(parseRoute(routeToHash({ name }))).toEqual({ name });
+    }
+  });
+
+  it("identifies panel routes and excludes fleet routes", () => {
+    expect(isPanelRoute({ name: "charts" })).toBe(true);
+    expect(isPanelRoute({ name: "tokens" })).toBe(true);
+    expect(isPanelRoute({ name: "feed" })).toBe(true);
+    expect(isPanelRoute(OVERVIEW)).toBe(false);
+    expect(isPanelRoute({ name: "host", hostId: "h" })).toBe(false);
+  });
+
+  // A panel name that is not an exact path must not swallow a host id, and an
+  // unknown hash still lands somewhere useful rather than erroring.
+  it.each(["#/chartsy", "#/charts/extra", "#/tokens?x=1", "#/nonsense"])(
+    "falls back to the overview for %s",
+    (hash) => {
+      expect(parseRoute(hash)).toEqual(OVERVIEW);
+    },
+  );
+
+  it("still parses a host whose id resembles a panel name", () => {
+    expect(parseRoute("#/hosts/charts")).toEqual({ name: "host", hostId: "charts" });
   });
 });


### PR DESCRIPTION
Closes #4895.

Three of Phase 3's five features were built, tested, merged — and absent from the shipped bundle. Nothing in the app shell imported them, so Vite tree-shook every byte out.

Verified against the **deployed** bundle, not just a local build:

| Feature | Probe | Deployed |
|---|---|---|
| #4749 fleet overview | `"No hosts are reporting yet"` | shipped |
| #4750 live feed | `"live-feed-row"` | **absent** |
| #4751 historical charts | `"Sweep outcomes over time"` | **absent** |
| #4752 token analytics | `"Token & cost analytics"` | **absent** |

The built CSS had no `.burn-card` or `.sparkline` either — `analytics.css` was never imported.

## What changed

Adds `#/charts`, `#/tokens`, `#/feed` alongside `#/` and `#/hosts/<id>`, with a topbar nav and an `aria-current` active marker. `src/panels.ts` is the integration point that was missing.

Two details worth review attention:

- **Panels mount on route *change*, not on every render.** `App.render()` runs on each poll tick; mounting there would refetch and flicker the panel every interval. `App` tracks the mounted route and tears down on the way out.
- **The live feed's teardown is load-bearing.** It holds an open SSE connection that would otherwise leak one per route change. `App.stop()` tears it down too, so a hidden tab doesn't hold one open.

Panel routes short-circuit every snapshot-dependent branch in `render()`, since they own their data — that's what lets a panel paint before the first fleet poll returns rather than showing the fleet's loading view.

Both dataset splits are respected: charts and feed pick `/api/*` vs `/public/*` from the injected auth state, and the token panel passes `currentSurface()` so it shows per-account detail signed in and the pool-level aggregate anonymously (#4870). Never a path check — under the single-URL layout that would call every visitor authenticated.

## Honest about #4863

The feed states the gap in the UI rather than rendering a silently partial view: `sweep.started`/`completed`/`outcome` flow today, `sweep.phase` does not, so phase transitions are missing and the per-sweep timeline has nothing to draw. The note carries a `data-testid` and a test pins it, so it's easy to find and delete when #4863 lands.

## A defect the new tests caught

`void promise()` in both async mounts discarded fetch rejections — producing unhandled promise rejections and a blank panel on any network failure. Both now route failure through `renderMountError`. That surfaced only because the shell test exercises a failing fetch; no module-level suite would have.

## Tests

`test/panels.test.ts` asserts **reachability and lifecycle**, deliberately not rendering fidelity — the sibling suites already cover rendering and stayed green through all of this. Per-panel: mounts content, replaces prior contents, returns a non-throwing teardown, survives a failing fetch. Router tests cover the new routes, round-tripping, and that `#/chartsy` / `#/charts/extra` fall back to the overview rather than swallowing a host id.

**Bundle 22.0 kB → 61.5 kB, CSS 5.9 → 9.2 kB.** A byte-identical build after adding a feature was the exact signal missed here.

**160 backend + 398 web tests pass** (was 160 + 380).