### PR TITLE
fix: preserve loom:operator-only reroute during crash-path claim restore

### DIFF
--- a/loom-daemon/src/sweep_registry/guards.rs
+++ b/loom-daemon/src/sweep_registry/guards.rs
@@ -532,19 +532,31 @@ impl SweepRegistry {
 
     /// Restore a crashed/orphaned claim's `loom:building` back to
     /// `loom:issue` — UNLESS the issue currently carries `loom:blocked`
-    /// (Issue #4206) OR the target number actually resolves to a pull
-    /// request (Issue #4653). A deliberate operator park (applied by hand,
-    /// possibly while the now-dead sweep was still `loom:building`) must
-    /// never be clobbered into the illegal `loom:blocked` + `loom:issue`
-    /// combo by the crash-recovery path, and a PR number must never be
-    /// handed a `loom:issue` label meant for issues — that reproduces the
-    /// stray-label symptom from #4653's incident report, reached whenever the
-    /// 2.5 dispatch guard's fail-open window lets a PR number through and the
-    /// sweep is later cancelled or crash-recovered. Both checks are
-    /// best-effort and fail-open: an unverifiable read falls back to the
-    /// pre-#4206 unconditional restore (re-adding `loom:issue`), since a
-    /// stranded `loom:building` claim is the more common failure mode this
-    /// path exists to fix. Either carve-out only skips the `loom:issue`
+    /// (Issue #4206), `loom:operator-only` (Issue #4887), OR the target
+    /// number actually resolves to a pull request (Issue #4653). A
+    /// deliberate operator park (applied by hand, possibly while the now-dead
+    /// sweep was still `loom:building`) must never be clobbered into an
+    /// illegal `loom:blocked`/`loom:operator-only` + `loom:issue` combo by
+    /// the crash-recovery path, and a PR number must never be handed a
+    /// `loom:issue` label meant for issues — that reproduces the stray-label
+    /// symptom from #4653's incident report, reached whenever the 2.5
+    /// dispatch guard's fail-open window lets a PR number through and the
+    /// sweep is later cancelled or crash-recovered.
+    ///
+    /// The `loom:operator-only` carve-out closes the #4887 race: a Builder
+    /// that aborts mid-build (e.g. missing OAuth scope, or an operator RETIRE
+    /// decision) correctly re-routes the issue `loom:building` ->
+    /// `loom:operator-only` itself, then exits; when the reaper later notices
+    /// the dead child and calls this restore, an unconditional restore would
+    /// re-add `loom:issue` on top of that reroute ~25-30s later with no
+    /// accompanying comment, leaving the issue in the illegal
+    /// `loom:operator-only` + `loom:issue` combo and re-queuing it for the
+    /// exact same blocker.
+    ///
+    /// All checks are best-effort and fail-open: an unverifiable read falls
+    /// back to the pre-#4206 unconditional restore (re-adding `loom:issue`),
+    /// since a stranded `loom:building` claim is the more common failure mode
+    /// this path exists to fix. Every carve-out only skips the `loom:issue`
     /// re-add — the stale `loom:building` claim is always removed.
     pub(crate) fn restore_label_to_ready(&self, issue: u32) -> Result<()> {
         let gh = self
@@ -553,10 +565,14 @@ impl SweepRegistry {
             .clone()
             .unwrap_or_else(|| PathBuf::from("gh"));
         let blocked = self.issue_has_blocked_label(issue);
-        // Only probe PR-ness when the blocked carve-out doesn't already
-        // decide the outcome — avoids a redundant `gh` call on the (more
+        // Only probe `loom:operator-only` when `loom:blocked` doesn't already
+        // decide the outcome — avoids a redundant `gh` call in the (more
         // common) blocked path.
-        let is_pr = !blocked && self.issue_is_pull_request(issue).unwrap_or(false);
+        let operator_only = !blocked && self.issue_has_operator_only_label(issue);
+        let parked = blocked || operator_only;
+        // Only probe PR-ness when a park carve-out doesn't already decide the
+        // outcome — avoids a redundant `gh` call on the parked path.
+        let is_pr = !parked && self.issue_is_pull_request(issue).unwrap_or(false);
         let mut cmd = Command::new(&gh);
         cmd.arg("issue")
             .arg("edit")
@@ -568,6 +584,13 @@ impl SweepRegistry {
                 "sweep_registry: restore_label_to_ready for #{issue} found `loom:blocked` \
                  already present — preserving the operator's park by removing the stale \
                  `loom:building` claim only, NOT re-adding `loom:issue` (#4206)"
+            );
+        } else if operator_only {
+            log::info!(
+                "sweep_registry: restore_label_to_ready for #{issue} found \
+                 `loom:operator-only` already present — preserving the authoritative \
+                 reroute by removing the stale `loom:building` claim only, NOT re-adding \
+                 `loom:issue` (#4887)"
             );
         } else if is_pr {
             log::info!(
@@ -855,6 +878,68 @@ exit 0
         );
     }
 
+    /// Issue #4887 regression: simulates the claim-abort race from #4607/#4608
+    /// — a Builder claims `loom:issue` -> `loom:building`, then correctly
+    /// aborts mid-build and reroutes `loom:building` -> `loom:operator-only`
+    /// itself (missing OAuth scope / an operator RETIRE decision), then its
+    /// process exits. When the reaper later notices the dead child and calls
+    /// `restore_label_to_ready` as crash-path cleanup, it must NOT re-add
+    /// `loom:issue` on top of that reroute — that would leave the issue in
+    /// the illegal `loom:operator-only` + `loom:issue` combo and re-queue it
+    /// for the exact same blocker (an infinite reclaim loop). The stale
+    /// `loom:building` claim (already gone in the live incident, but the
+    /// restore always issues the removal defensively) is still requested.
+    #[test]
+    fn restore_label_to_ready_does_not_add_loom_issue_when_operator_only() {
+        let dir = tempdir().unwrap();
+        let gh_log = dir.path().join("gh-invocations.log");
+        let fake_gh = dir.path().join("fake-gh.sh");
+        // The `loom:blocked` pre-check (first `gh issue view --json labels`
+        // call) reports false; the `loom:operator-only` follow-up check
+        // (second `gh issue view --json labels` call) reports true. Any `gh
+        // issue edit` call is recorded and always succeeds.
+        let script = format!(
+            r#"#!/usr/bin/env bash
+printf '%s\n' "$*" >> "{log}"
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  case "$*" in
+    *loom:blocked*) echo "false" ;;
+    *loom:operator-only*) echo "true" ;;
+    *) echo "false" ;;
+  esac
+  exit 0
+fi
+exit 0
+"#,
+            log = gh_log.display(),
+        );
+        std::fs::write(&fake_gh, &script).unwrap();
+        let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_gh, perms).unwrap();
+        if let Ok(f) = std::fs::File::open(&fake_gh) {
+            let _ = f.sync_all();
+        }
+
+        let mut config = SweepRegistryConfig::new(dir.path().to_path_buf());
+        config.gh_bin = Some(fake_gh);
+        config.skip_label_flip = false; // exercise the real restore path
+        let registry = SweepRegistry::new(config);
+
+        registry.restore_label_to_ready(4607).unwrap();
+
+        let gh_calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            gh_calls.contains("issue edit 4607 --remove-label loom:building"),
+            "expected the stale loom:building claim to still be removed; got: {gh_calls:?}"
+        );
+        assert!(
+            !gh_calls.contains("--add-label loom:issue"),
+            "must NOT re-add loom:issue while loom:operator-only is present (illegal combo, \
+             #4887 — reproduces the #4607/#4608 claim-abort race); got: {gh_calls:?}"
+        );
+    }
+
     /// Issue #4653: the crash-path label restore must NEVER add `loom:issue`
     /// when the target number resolves to a pull request. This covers the
     /// #4123-fail-open window where the 2.5 dispatch guard (`gh` outage) lets
@@ -968,12 +1053,13 @@ exit 0
         let cwds: Vec<_> = recorded.lines().filter(|l| !l.is_empty()).collect();
         assert_eq!(
             cwds.len(),
-            4,
+            5,
             "expected the flip (1 call) + restore (Issue #4206's pre-check `loom:blocked` \
-             probe, Issue #4653's `is_pr` probe's `resolve_owner_repo` lookup — which bails \
-             before the second `gh api` call since the fake `gh` prints nothing for `repo \
-             view` — then the edit — 3 calls) to invoke gh four times total; got cwds: \
-             {cwds:?}"
+             probe, Issue #4887's follow-up `loom:operator-only` probe — the fake `gh` prints \
+             nothing so both park probes read as absent, Issue #4653's `is_pr` probe's \
+             `resolve_owner_repo` lookup — which bails before the second `gh api` call since \
+             the fake `gh` prints nothing for `repo view` — then the edit — 4 calls) to invoke \
+             gh five times total; got cwds: {cwds:?}"
         );
         for cwd in &cwds {
             let got = std::fs::canonicalize(cwd).unwrap();

--- a/loom-daemon/src/sweep_registry/stacking.rs
+++ b/loom-daemon/src/sweep_registry/stacking.rs
@@ -62,6 +62,31 @@ impl SweepRegistry {
     /// fixtures), or when `gh` is unavailable — a conservative default that
     /// never blocks a child on an unverifiable parent state.
     pub(crate) fn issue_has_blocked_label(&self, issue: u32) -> bool {
+        self.issue_has_label_via_graphql(issue, "loom:blocked")
+    }
+
+    /// Best-effort check of whether `issue` currently carries the
+    /// `loom:operator-only` label on the forge (Issue #4887). Used by
+    /// [`restore_label_to_ready`](super::guards::SweepRegistry::restore_label_to_ready)
+    /// alongside [`Self::issue_has_blocked_label`] so the crash-path claim
+    /// restore never re-adds `loom:issue` on top of either park label.
+    ///
+    /// Returns `false` on any error, when label flips are skipped (test
+    /// fixtures), or when `gh` is unavailable — the same fail-open default as
+    /// [`Self::issue_has_blocked_label`].
+    pub(crate) fn issue_has_operator_only_label(&self, issue: u32) -> bool {
+        self.issue_has_label_via_graphql(issue, "loom:operator-only")
+    }
+
+    /// Shared GraphQL-backed (`gh issue view --json labels`) probe for a single
+    /// label's presence on `issue`, factored out of
+    /// [`Self::issue_has_blocked_label`] so [`Self::issue_has_operator_only_label`]
+    /// (#4887) does not duplicate the command-building/timeout plumbing.
+    ///
+    /// Fails closed (`false`) on any read failure, exactly like the two
+    /// callers it backs — never block a cascade, or claim a park label is
+    /// present, on an unverifiable read.
+    fn issue_has_label_via_graphql(&self, issue: u32, label: &str) -> bool {
         if self.config.skip_label_flip {
             return false;
         }
@@ -77,17 +102,17 @@ impl SweepRegistry {
             .arg("--json")
             .arg("labels")
             .arg("--jq")
-            .arg(r#"[.labels[].name] | index("loom:blocked") != null"#);
-        // Scope the blocked-label probe to the registry's workspace so it
-        // resolves against the right repo in a multi-workspace daemon (#3937).
+            .arg(format!(r#"[.labels[].name] | index("{label}") != null"#));
+        // Scope the label probe to the registry's workspace so it resolves
+        // against the right repo in a multi-workspace daemon (#3937).
         cmd.current_dir(&self.config.workspace_root);
         if let Ok(repo) = std::env::var("LOOM_REPO") {
             cmd.arg("--repo").arg(repo);
         }
         // Bounded so a wedged `gh` on the `ListSweeps` / `GetSweepStatus` read
         // path (this runs inside `reap_liveness`) cannot block the registry read
-        // indefinitely (Issue #3973). A timeout is treated as not-blocked — the
-        // same conservative default as any other `gh` failure here.
+        // indefinitely (Issue #3973). A timeout is treated as absent — the same
+        // conservative default as any other `gh` failure here.
         let timeout = reap_gh_timeout();
         match output_with_timeout(cmd, timeout) {
             Ok(Some(out)) if out.status.success() => {
@@ -95,8 +120,8 @@ impl SweepRegistry {
             }
             Ok(None) => {
                 log::warn!(
-                    "sweep_registry: issue_has_blocked_label gh for #{issue} exceeded {}s \
-                     and was killed; treating as not-blocked (#3973)",
+                    "sweep_registry: issue_has_label_via_graphql({label}) gh for #{issue} \
+                     exceeded {}s and was killed; treating as absent (#3973)",
                     timeout.as_secs()
                 );
                 false


### PR DESCRIPTION
## Summary

Fixes a claim-abort race where a Builder that correctly reroutes an issue
`loom:building` -> `loom:operator-only` (e.g. missing OAuth scope, or an
operator RETIRE decision) then exits, and ~25-31s later the reaper's
crash-recovery path re-adds `loom:issue` — leaving the issue in the illegal
`loom:operator-only` + `loom:issue` combo and re-queuing it for the exact
same blocker (an infinite reclaim loop).

## Root Cause

`SweepRegistry::restore_label_to_ready()` in
`loom-daemon/src/sweep_registry/guards.rs` is the reaper's crash-path
cleanup for a dead sweep child — it removes the stale `loom:building` claim
and restores `loom:issue`. It already had a carve-out for `loom:blocked`
(#4206) and PR-number targets (#4653), but had no carve-out for
`loom:operator-only`. When a Builder aborts and applies
`loom:operator-only` itself just before exiting, the reaper's later
crash-recovery call to `restore_label_to_ready()` raced that reroute and
unconditionally re-added `loom:issue` on top of it — exactly matching the
~25-31s gap and no-accompanying-comment pattern observed in #4607 and
#4608.

## Changes

- `loom-daemon/src/sweep_registry/stacking.rs`: factored the existing
  `issue_has_blocked_label` GraphQL probe into a shared
  `issue_has_label_via_graphql(issue, label)` helper, and added
  `issue_has_operator_only_label` on top of it (same fail-open-to-`false`
  semantics as the existing blocked probe).
- `loom-daemon/src/sweep_registry/guards.rs`: `restore_label_to_ready()` now
  probes `loom:operator-only` (only when `loom:blocked` doesn't already
  decide the outcome, to avoid a redundant `gh` call) and skips the
  `loom:issue` re-add when it is present — the stale `loom:building` claim
  is still removed unconditionally in every case.
- Added a regression test,
  `restore_label_to_ready_does_not_add_loom_issue_when_operator_only`,
  simulating the exact #4607/#4608 race (claim -> abort-to-operator-only ->
  crash-path unclaim) and asserting `loom:issue` is never re-added while
  `loom:building` is still removed.
- Updated `label_flips_run_in_registry_workspace_root`'s expected `gh`
  invocation count (4 -> 5) to account for the new probe call.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Root cause identified | Yes | `restore_label_to_ready()` in `guards.rs` — reaper's crash-path claim restore, called from `reaper.rs` (dead/orphaned child cleanup) and `dispatch.rs` (2.5 dispatch-guard fail path) |
| Fix: skip re-adding `loom:issue` when `loom:operator-only`/`loom:blocked` present | Yes | New `operator_only` probe added alongside the existing `blocked` probe; `restore_label_to_ready()` now short-circuits on either |
| Regression test for the exact race | Yes | `restore_label_to_ready_does_not_add_loom_issue_when_operator_only` — fake `gh` reports `loom:blocked=false`, `loom:operator-only=true`; asserts the `--add-label loom:issue` call never happens and the `--remove-label loom:building` call still does |
| Work-finder defense-in-depth for `loom:operator-only` | Already present | `loom-daemon/src/work_finder.rs`'s `PARK_LABELS`/`SKIP_LABELS` already hard-skip a candidate carrying `loom:operator-only` even if `loom:issue` is also present (covered by existing test at `work_finder.rs` around `WorkItem::new(3, vec!["loom:issue".into(), "loom:operator-only".into()])` / `is_skipped()`) — no change needed here |

## Test Plan

- `cargo test --lib sweep_registry::guards` — 14 passed, 0 failed (includes the new regression test and the updated `label_flips_run_in_registry_workspace_root`)
- `cargo test --lib sweep_registry::stacking` — 2 passed, 0 failed
- `cargo test --lib sweep_registry::reaper` — 44 passed, 0 failed
- `cargo test --lib sweep_registry::dispatch` — 76 passed, 0 failed
- `cargo check --lib` — clean
- `cargo clippy --lib -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Closes #4887