### PR TITLE
fix(daemon-cli): find ~/.local/bin/loom-daemon under a minimal, non-login PATH

### DIFF
--- a/defaults/.loom/bin/loom
+++ b/defaults/.loom/bin/loom
@@ -105,20 +105,30 @@ case "${1:-help}" in
         shift
         # The former Python daemon-diagnostic CLI was removed in epic #4081
         # phase 3 (#4274). Daemon/registry health is now reported natively by
-        # `loom-daemon status` (Issue #3891). Resolve the binary the same way the
-        # daemon update wrapper does: PATH first, then the local build outputs.
+        # `loom-daemon status` (Issue #3891). Resolve the binary via the
+        # shared loom_locate_daemon_bin() (lib/locate-daemon-bin.sh, #4875) so
+        # this command, loom-daemon-start.sh, loom-daemon-watchdog.sh,
+        # loom-daemon-update.sh and loom-status.sh all agree on which binary
+        # is "the" daemon CLI -- including the LOOM_DAEMON_BIN override (this
+        # branch previously had none) and the machine-level ~/.local/bin
+        # fallback (needed under a non-interactive `ssh host 'cmd'`, which
+        # never sources the login profile that would otherwise put
+        # ~/.local/bin on PATH).
+        _LOOM_LOCATE_BIN_LIB="$REPO_ROOT/.loom/scripts/lib/locate-daemon-bin.sh"
         loom_daemon_bin=""
-        if command -v loom-daemon &>/dev/null; then
-            loom_daemon_bin="$(command -v loom-daemon)"
-        elif [[ -x "$REPO_ROOT/loom-daemon/target/release/loom-daemon" ]]; then
-            loom_daemon_bin="$REPO_ROOT/loom-daemon/target/release/loom-daemon"
-        elif [[ -x "$REPO_ROOT/loom-daemon/target/debug/loom-daemon" ]]; then
-            loom_daemon_bin="$REPO_ROOT/loom-daemon/target/debug/loom-daemon"
+        if [[ -r "$_LOOM_LOCATE_BIN_LIB" ]]; then
+            # shellcheck source=/dev/null
+            source "$_LOOM_LOCATE_BIN_LIB"
+            loom_daemon_bin="$(loom_locate_daemon_bin "$REPO_ROOT")"
         fi
         if [[ -n "$loom_daemon_bin" ]]; then
             exec "$loom_daemon_bin" status "$@"
         else
-            echo -e "${RED}Error: health command requires the loom-daemon binary (build loom-daemon or add it to PATH)${NC}" >&2
+            echo -e "${RED}Error: health command requires the loom-daemon binary. Checked:${NC}" >&2
+            if [[ -r "$_LOOM_LOCATE_BIN_LIB" ]]; then
+                loom_daemon_bin_search_paths "$REPO_ROOT" | sed 's/^/  - /' >&2
+            fi
+            echo -e "${RED}Build it (cargo build --release -p loom-daemon), install it to one of the paths above, or set LOOM_DAEMON_BIN=/path/to/loom-daemon${NC}" >&2
             exit 1
         fi
         ;;

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -155,24 +155,21 @@ find_repo_root() {
 }
 
 # ---------- locate the daemon binary ----------
-locate_daemon_bin() {
-    local root="$1"
-    if [[ -n "${LOOM_DAEMON_BIN:-}" && -x "${LOOM_DAEMON_BIN}" ]]; then
-        echo "${LOOM_DAEMON_BIN}"; return 0
-    fi
-    if command -v loom-daemon >/dev/null 2>&1; then
-        command -v loom-daemon; return 0
-    fi
-    local candidate
-    for candidate in \
-        "$root/loom-daemon/target/release/loom-daemon" \
-        "$root/loom-daemon/target/debug/loom-daemon" \
-        "$root/target/release/loom-daemon" \
-        "$root/target/debug/loom-daemon"; do
-        if [[ -x "$candidate" ]]; then echo "$candidate"; return 0; fi
-    done
-    echo ""
-}
+# Shared with loom-daemon-watchdog.sh / loom-daemon-update.sh / loom-status.sh
+# / `.loom/bin/loom health` via lib/locate-daemon-bin.sh (#4875) so all five
+# never disagree about which binary is "the" daemon CLI, and a new candidate
+# path only needs to be added in that one file. Includes the machine-level
+# ~/.local/bin fallback so a non-interactive `ssh host 'cmd'` (which never
+# sources the login profile, so ~/.local/bin is not on PATH) still finds the
+# epic #3835 Phase 3a machine-level install.
+_LOOM_LOCATE_BIN_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" 2>/dev/null && pwd)"
+if [[ -r "$_LOOM_LOCATE_BIN_LIB_DIR/locate-daemon-bin.sh" ]]; then
+    # shellcheck source=../lib/locate-daemon-bin.sh
+    source "$_LOOM_LOCATE_BIN_LIB_DIR/locate-daemon-bin.sh"
+else
+    err "locate-daemon-bin.sh not found at $_LOOM_LOCATE_BIN_LIB_DIR — this checkout is missing an expected lib file."
+    exit 1
+fi
 
 # ---------- launchd plist rendering (#3972) ----------
 # Pure string rendering -- safe to call on ANY platform (used by
@@ -1094,10 +1091,11 @@ else
     exit 1
 fi
 
-DAEMON_BIN=$(locate_daemon_bin "$REPO_ROOT")
+DAEMON_BIN=$(loom_locate_daemon_bin "$REPO_ROOT")
 if [[ -z "$DAEMON_BIN" ]]; then
-    err "loom-daemon binary not found."
-    echo "Build it (cargo build --release -p loom-daemon) or set LOOM_DAEMON_BIN=/path/to/loom-daemon" >&2
+    err "loom-daemon binary not found. Checked:"
+    loom_daemon_bin_search_paths "$REPO_ROOT" | sed 's/^/  - /' >&2
+    echo "Build it (cargo build --release -p loom-daemon), install it to one of the paths above, or set LOOM_DAEMON_BIN=/path/to/loom-daemon" >&2
     exit 1
 fi
 

--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -269,25 +269,22 @@ find_repo_root() {
     echo ""
 }
 
-# ---------- locate the daemon binary (mirrors loom-daemon-start.sh) ----------
-locate_daemon_bin() {
-    local root="$1"
-    if [[ -n "${LOOM_DAEMON_BIN:-}" && -x "${LOOM_DAEMON_BIN}" ]]; then
-        echo "${LOOM_DAEMON_BIN}"; return 0
-    fi
-    if command -v loom-daemon >/dev/null 2>&1; then
-        command -v loom-daemon; return 0
-    fi
-    local candidate
-    for candidate in \
-        "$root/loom-daemon/target/release/loom-daemon" \
-        "$root/loom-daemon/target/debug/loom-daemon" \
-        "$root/target/release/loom-daemon" \
-        "$root/target/debug/loom-daemon"; do
-        if [[ -x "$candidate" ]]; then echo "$candidate"; return 0; fi
-    done
-    echo ""
-}
+# ---------- locate the daemon binary ----------
+# Shared with loom-daemon-start.sh / loom-daemon-watchdog.sh / loom-status.sh
+# / `.loom/bin/loom health` via lib/locate-daemon-bin.sh (#4875) — includes
+# the machine-level $LOOM_DAEMON_BIN_DIR (default ~/.local/bin) fallback,
+# reusing the SAME variable this script's own --provision path already
+# writes to (see DEST_DIR below), so discovery and provisioning can never
+# point at different directories.
+_LOOM_LOCATE_BIN_LIB="$SCRIPT_DIR/../lib/locate-daemon-bin.sh"
+if [[ -r "$_LOOM_LOCATE_BIN_LIB" ]]; then
+    # shellcheck source=../lib/locate-daemon-bin.sh
+    source "$_LOOM_LOCATE_BIN_LIB"
+else
+    err "locate-daemon-bin.sh not found at $_LOOM_LOCATE_BIN_LIB — this checkout is missing an expected lib file."
+    exit 1
+fi
+locate_daemon_bin() { loom_locate_daemon_bin "$1"; }
 
 # Extract the short commit from `loom-daemon --version` output, e.g.
 # "loom-daemon 0.15.0 (commit ab12cd3, built 2026-07-26T12:00:00Z)" -> ab12cd3
@@ -705,7 +702,8 @@ fi
 
 UPDATE_NEEDED=false
 if [[ -z "$DAEMON_BIN" ]]; then
-    echo "No loom-daemon binary currently resolvable (LOOM_DAEMON_BIN / PATH / loom-daemon/target/release) — a build is needed."
+    echo "No loom-daemon binary currently resolvable — a build is needed. Checked:"
+    loom_daemon_bin_search_paths "$REPO_ROOT" | sed 's/^/  - /'
     UPDATE_NEEDED=true
 elif [[ "$INSTALLED_COMMIT" == "unknown" || "$SOURCE_COMMIT" == "unknown" ]]; then
     warn "Could not determine one or both commits (installed=$INSTALLED_COMMIT, source=$SOURCE_COMMIT) — staleness unknown; treating as needing a rebuild to be safe."

--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -1093,6 +1093,16 @@ if [[ "$FORCE" == "true" && "$UPDATE_NEEDED" == "false" ]]; then
 fi
 
 if [[ "$UPDATE_NEEDED" == "false" ]]; then
+    # UPDATE_NEEDED compares the installed binary against the CURRENT HEAD. When
+    # the checkout is behind origin, a real run fast-forwards first, so HEAD --
+    # and therefore that comparison -- would change before anything is built.
+    # Reporting a bare "Nothing to do" here would hide the pending ff-sync from
+    # exactly the mode whose job is to print the plan, so --dry-run surfaces it
+    # before exiting.
+    if [[ "$DRY_RUN" == "true" && "$ALLOW_STALE" != "true" \
+          && -n "$DEFAULT_BRANCH" && "$ORIGIN_BEHIND_COUNT" -gt 0 ]]; then
+        echo "[dry-run] Plan includes fast-forwarding local ${DEFAULT_BRANCH} to origin/${DEFAULT_BRANCH} (${ORIGIN_BEHIND_COUNT} commit(s) behind) before building; the up-to-date check below is against the CURRENT HEAD and may change once that ff-merge applies."
+    fi
     ok "loom-daemon binary is already up to date with source HEAD (${SOURCE_COMMIT}). Nothing to do."
     print_final_installed_line "$SOURCE_COMMIT"
     exit 0

--- a/defaults/scripts/cli/loom-daemon-watchdog.sh
+++ b/defaults/scripts/cli/loom-daemon-watchdog.sh
@@ -195,6 +195,15 @@ if [[ -r "$_LOOM_LAUNCHD_LIB_DIR/bounded-run.sh" ]]; then
     # shellcheck source=../lib/bounded-run.sh
     source "$_LOOM_LAUNCHD_LIB_DIR/bounded-run.sh"
 fi
+# loom_locate_daemon_bin() (#4875, shared with loom-daemon-start.sh /
+# loom-daemon-update.sh / loom-status.sh / `.loom/bin/loom health`) — includes
+# the machine-level ~/.local/bin fallback so this watchdog (which runs from a
+# systemd/launchd timer with a minimal, non-login environment) still finds a
+# machine-level install even though $PATH never carries ~/.local/bin here.
+if [[ -r "$_LOOM_LAUNCHD_LIB_DIR/locate-daemon-bin.sh" ]]; then
+    # shellcheck source=../lib/locate-daemon-bin.sh
+    source "$_LOOM_LAUNCHD_LIB_DIR/locate-daemon-bin.sh"
+fi
 
 VERBOSE=false
 while [[ $# -gt 0 ]]; do
@@ -339,32 +348,21 @@ process_age_secs() {
 
 # ---------- bounded in-band IPC probe (#4398) ----------
 
-# Resolve the loom-daemon binary the probe should invoke, in the SAME order
-# loom-daemon-start.sh's `locate_daemon_bin` uses (LOOM_DAEMON_BIN override ->
-# PATH -> in-repo cargo targets) so the watchdog and the start path can never
-# disagree about which binary is "the" daemon CLI. Echoes nothing and returns 1
-# when nothing is resolvable — the caller must then SKIP the probe, never
-# report a divergence: a watchdog that pages because its own optional helper
-# is missing is worse than one that quietly keeps doing the other two checks.
+# Resolve the loom-daemon binary the probe should invoke, via the shared
+# loom_locate_daemon_bin() (lib/locate-daemon-bin.sh, sourced above) so this
+# watchdog, loom-daemon-start.sh, loom-daemon-update.sh, loom-status.sh and
+# `.loom/bin/loom health` can never disagree about which binary is "the"
+# daemon CLI. Preserves this function's original contract (thin wrapper):
+# echoes nothing and returns 1 when nothing is resolvable — the caller must
+# then SKIP the probe, never report a divergence: a watchdog that pages
+# because its own optional helper is missing is worse than one that quietly
+# keeps doing the other two checks.
 locate_daemon_bin() {
-    if [[ -n "${LOOM_DAEMON_BIN:-}" && -x "${LOOM_DAEMON_BIN}" ]]; then
-        echo "${LOOM_DAEMON_BIN}"; return 0
-    fi
-    if command -v loom-daemon >/dev/null 2>&1; then
-        command -v loom-daemon; return 0
-    fi
-    local root candidate
+    local root bin
     root="$(marker_get repo_root 2>/dev/null)"
-    if [[ -n "$root" ]]; then
-        for candidate in \
-            "$root/loom-daemon/target/release/loom-daemon" \
-            "$root/loom-daemon/target/debug/loom-daemon" \
-            "$root/target/release/loom-daemon" \
-            "$root/target/debug/loom-daemon"; do
-            if [[ -x "$candidate" ]]; then echo "$candidate"; return 0; fi
-        done
-    fi
-    return 1
+    bin="$(loom_locate_daemon_bin "$root")"
+    [[ -n "$bin" ]] || return 1
+    echo "$bin"
 }
 
 # bounded_run() — a HARD wall-clock budget around a command, returning 124 on

--- a/defaults/scripts/cli/loom-status.sh
+++ b/defaults/scripts/cli/loom-status.sh
@@ -38,6 +38,8 @@ set -euo pipefail
 _LOOM_STATUS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/config-resolver.sh
 source "$_LOOM_STATUS_SCRIPT_DIR/../lib/config-resolver.sh"
+# shellcheck source=../lib/locate-daemon-bin.sh
+source "$_LOOM_STATUS_SCRIPT_DIR/../lib/locate-daemon-bin.sh"
 
 # Find repository root
 find_repo_root() {
@@ -292,27 +294,29 @@ read_terminals() {
 #     check when the daemon itself is unreachable -- a static file read
 #     still answers "is this repo registered?" even while the daemon is down.
 
-# Resolve the loom-daemon binary: LOOM_DAEMON_BIN override -> PATH -> in-repo
-# cargo build outputs. Mirrors loom-daemon-watchdog.sh's locate_daemon_bin()
-# / `./.loom/bin/loom health`'s resolution order verbatim, so this script and
-# those two never disagree about which binary is "the" daemon CLI. Echoes
-# the resolved path and returns 0, or returns 1 with nothing echoed.
+# Resolve the loom-daemon binary via the shared loom_locate_daemon_bin()
+# (lib/locate-daemon-bin.sh, #4875) — includes the machine-level
+# $LOOM_DAEMON_BIN_DIR (default ~/.local/bin) fallback, so this script,
+# loom-daemon-start.sh, loom-daemon-watchdog.sh, loom-daemon-update.sh, and
+# `./.loom/bin/loom health` all agree on which binary is "the" daemon CLI.
+# Preserves this function's original contract (thin wrapper): echoes the
+# resolved path and returns 0, or returns 1 with nothing echoed -- INCLUDING
+# the pre-#4875 behavior that an explicitly-set-but-non-executable
+# LOOM_DAEMON_BIN is a hard "not found" (unlike the other four call sites,
+# which fall through to PATH/machine-level/in-repo candidates in that case).
+# This script's own test suite uses LOOM_DAEMON_BIN=<bogus path> as a
+# deterministic "force no binary resolvable" sentinel that must NOT then pick
+# up a real installed binary via PATH or ~/.local/bin, so that contract is
+# preserved here explicitly rather than delegated wholesale.
 locate_daemon_bin() {
     if [[ -n "${LOOM_DAEMON_BIN:-}" ]]; then
         [[ -x "${LOOM_DAEMON_BIN}" ]] && { echo "${LOOM_DAEMON_BIN}"; return 0; }
         return 1
     fi
-    if command -v loom-daemon &>/dev/null; then
-        command -v loom-daemon
-        return 0
-    fi
-    local candidate
-    for candidate in \
-        "$REPO_ROOT/loom-daemon/target/release/loom-daemon" \
-        "$REPO_ROOT/loom-daemon/target/debug/loom-daemon"; do
-        [[ -x "$candidate" ]] && { echo "$candidate"; return 0; }
-    done
-    return 1
+    local bin
+    bin="$(unset LOOM_DAEMON_BIN; loom_locate_daemon_bin "$REPO_ROOT")"
+    [[ -n "$bin" ]] || return 1
+    echo "$bin"
 }
 
 # Query `loom-daemon status --json`. Echoes the JSON payload on success --

--- a/defaults/scripts/lib/locate-daemon-bin.sh
+++ b/defaults/scripts/lib/locate-daemon-bin.sh
@@ -1,16 +1,27 @@
 #!/usr/bin/env bash
 # locate-daemon-bin.sh — Resolve the loom-daemon binary to invoke.
 #
-# Source this file (do not exec). Defines a single function:
+# Source this file (do not exec). Defines two functions:
 #
 #   loom_locate_daemon_bin <repo_root> -> echoes the absolute path to a
 #   loom-daemon binary on stdout, or an empty string if none could be
 #   resolved.
 #
+#   loom_daemon_bin_search_paths <repo_root> -> echoes the ordered list of
+#   locations that WOULD be checked (one per line, in precedence order),
+#   for use in "binary not found" error text. Does not touch the
+#   filesystem itself -- it just renders the same candidate list
+#   loom_locate_daemon_bin walks.
+#
 # Resolution precedence (first match wins):
 #   1. $LOOM_DAEMON_BIN — must be executable.
 #   2. `loom-daemon` on PATH.
-#   3. Build-output-relative candidates under <repo_root>:
+#   3. The machine-level install location: $LOOM_DAEMON_BIN_DIR (default
+#      $HOME/.local/bin) — this is where loom-daemon-update.sh's --provision
+#      path installs, and the location `ssh host 'cmd'` (a non-interactive
+#      shell that never sources the login profile, so $HOME/.local/bin is
+#      NOT on PATH) needs an explicit check for (#4875).
+#   4. Build-output-relative candidates under <repo_root>:
 #        loom-daemon/target/release/loom-daemon
 #        loom-daemon/target/debug/loom-daemon
 #        target/release/loom-daemon
@@ -18,7 +29,13 @@
 #
 # Extracted (issue #4080) from the identical inline copies in
 # loom-daemon-start.sh and loom-daemon-update.sh so probe-tokens.sh's
-# daemon-binary resolution does not add a fourth copy of this logic.
+# daemon-binary resolution does not add a fourth copy of this logic. #4875
+# added the machine-level install fallback (step 3) plus
+# loom_daemon_bin_search_paths(), and migrated the remaining inline copies in
+# loom-daemon-start.sh / loom-daemon-watchdog.sh / loom-daemon-update.sh /
+# loom-status.sh / .loom/bin/loom onto this single shared definition so a
+# future new candidate path never has to be ported by hand across six copies
+# again.
 
 loom_locate_daemon_bin() {
     local root="$1"
@@ -27,6 +44,10 @@ loom_locate_daemon_bin() {
     fi
     if command -v loom-daemon >/dev/null 2>&1; then
         command -v loom-daemon; return 0
+    fi
+    local machine_bin="${LOOM_DAEMON_BIN_DIR:-$HOME/.local/bin}/loom-daemon"
+    if [[ -x "$machine_bin" ]]; then
+        echo "$machine_bin"; return 0
     fi
     local candidate
     for candidate in \
@@ -37,4 +58,20 @@ loom_locate_daemon_bin() {
         if [[ -x "$candidate" ]]; then echo "$candidate"; return 0; fi
     done
     echo ""
+}
+
+# loom_daemon_bin_search_paths <repo_root> -- render the candidate list for
+# error messages. Mirrors loom_locate_daemon_bin's precedence exactly (kept
+# side by side in this same file so the two can never drift apart).
+loom_daemon_bin_search_paths() {
+    local root="$1"
+    if [[ -n "${LOOM_DAEMON_BIN:-}" ]]; then
+        echo "\$LOOM_DAEMON_BIN=${LOOM_DAEMON_BIN}"
+    fi
+    echo "loom-daemon on \$PATH"
+    echo "${LOOM_DAEMON_BIN_DIR:-$HOME/.local/bin}/loom-daemon"
+    echo "$root/loom-daemon/target/release/loom-daemon"
+    echo "$root/loom-daemon/target/debug/loom-daemon"
+    echo "$root/target/release/loom-daemon"
+    echo "$root/target/debug/loom-daemon"
 }

--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -58,6 +58,7 @@ test-install-pr-markers.sh
 test-install-source-guard.sh
 test-install-stash-scope.sh
 test-judge-fanout-experiment.sh
+test-locate-daemon-bin.sh
 test-loom-daemon-launchd-plist.sh
 test-loom-daemon-start.sh
 test-loom-daemon-stop.sh

--- a/defaults/scripts/tests/test-locate-daemon-bin.sh
+++ b/defaults/scripts/tests/test-locate-daemon-bin.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# test-locate-daemon-bin.sh — Tests for lib/locate-daemon-bin.sh's shared
+# loom_locate_daemon_bin() / loom_daemon_bin_search_paths() (Issue #4875).
+#
+# Focus: a non-interactive `ssh host 'cmd'` invocation does not source the
+# login profile, so `~/.local/bin` (the epic #3835 Phase 3a machine-level
+# install location) is NOT on $PATH. Before this fix, `loom-daemon-start.sh`
+# and its sibling scripts (loom-daemon-watchdog.sh, loom-daemon-update.sh,
+# loom-status.sh, `.loom/bin/loom health`) gave up in that exact scenario even
+# though a current binary sat at `~/.local/bin/loom-daemon`. This suite drives
+# the shared resolver directly (all five call sites now delegate to it) with
+# $PATH reduced to a minimal, non-interactive default and no $LOOM_DAEMON_BIN,
+# asserting the binary is still found.
+#
+# Style matches the other lib-focused suites — plain bash, hand-rolled
+# assertions, no Bats.
+#
+# Usage:
+#   ./defaults/scripts/tests/test-locate-daemon-bin.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$SCRIPT_DIR/../lib/locate-daemon-bin.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "${GREEN}✓${NC} $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "${RED}✗${NC} $1"; }
+
+assert_eq() { # <expected> <actual> <msg>
+    if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 (expected '$1', got '$2')"; fi
+}
+
+assert_contains() { # <needle> <haystack> <msg>
+    if [[ "$2" == *"$1"* ]]; then pass "$3"; else fail "$3 (expected to find '$1' in [$2])"; fi
+}
+
+if [[ ! -r "$LIB" ]]; then
+    echo -e "${RED}FATAL${NC}: $LIB not found" >&2
+    exit 1
+fi
+
+# A minimal, non-interactive-shell-like PATH: no ~/.local/bin, no repo-local
+# toolchain dirs, just the base system directories a non-login `ssh host
+# 'cmd'` session would inherit.
+MINIMAL_PATH="/usr/bin:/bin"
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/test-locate-daemon-bin.XXXXXX")"
+cleanup() { rm -rf "$WORKDIR" 2>/dev/null || true; }
+trap cleanup EXIT
+
+make_fake_bin() { # <path>
+    mkdir -p "$(dirname "$1")"
+    cat > "$1" <<'EOF'
+#!/usr/bin/env bash
+echo "fake-loom-daemon"
+EOF
+    chmod +x "$1"
+}
+
+# ---------- 1. $LOOM_DAEMON_BIN wins over everything, even a bogus PATH ----------
+BIN1="$WORKDIR/t1/explicit-loom-daemon"
+make_fake_bin "$BIN1"
+out=$( env -i PATH="$MINIMAL_PATH" HOME="$WORKDIR/t1-nohome" LOOM_DAEMON_BIN="$BIN1" \
+    bash -c "source '$LIB'; loom_locate_daemon_bin '$WORKDIR/t1-root'" )
+assert_eq "$BIN1" "$out" "LOOM_DAEMON_BIN override wins"
+
+# ---------- 2. LOOM_DAEMON_BIN set but NOT executable falls through (does not
+#               hard-fail) to the remaining candidates ----------
+BOGUS_BIN="$WORKDIR/t2/does-not-exist"
+BIN2_HOME="$WORKDIR/t2-home"
+BIN2="$BIN2_HOME/.local/bin/loom-daemon"
+make_fake_bin "$BIN2"
+out=$( env -i PATH="$MINIMAL_PATH" HOME="$BIN2_HOME" LOOM_DAEMON_BIN="$BOGUS_BIN" \
+    bash -c "source '$LIB'; loom_locate_daemon_bin '$WORKDIR/t2-root'" )
+assert_eq "$BIN2" "$out" "non-executable LOOM_DAEMON_BIN falls through to machine-level install, not a hard failure"
+
+# ---------- 3. `loom-daemon` on PATH is found (no LOOM_DAEMON_BIN needed) ----------
+PATH_BIN_DIR="$WORKDIR/t3/on-path"
+make_fake_bin "$PATH_BIN_DIR/loom-daemon"
+out=$( env -i PATH="$PATH_BIN_DIR:$MINIMAL_PATH" HOME="$WORKDIR/t3-nohome" \
+    bash -c "source '$LIB'; loom_locate_daemon_bin '$WORKDIR/t3-root'" )
+assert_eq "$PATH_BIN_DIR/loom-daemon" "$out" "loom-daemon on \$PATH is found"
+
+# ---------- 4. THE CORE FIX (#4875): PATH reduced to a minimal, non-login
+#               default (no ~/.local/bin, no LOOM_DAEMON_BIN) still finds the
+#               machine-level install under $HOME/.local/bin -- exactly the
+#               `ssh host 'loom-daemon-start.sh --from-config'` scenario. ----------
+SSH_HOME="$WORKDIR/t4-ssh-home"
+SSH_BIN="$SSH_HOME/.local/bin/loom-daemon"
+make_fake_bin "$SSH_BIN"
+out=$( env -i PATH="$MINIMAL_PATH" HOME="$SSH_HOME" \
+    bash -c "source '$LIB'; loom_locate_daemon_bin '$WORKDIR/t4-root'" )
+assert_eq "$SSH_BIN" "$out" "non-interactive-SSH-like minimal \$PATH + no LOOM_DAEMON_BIN still finds \$HOME/.local/bin/loom-daemon (#4875)"
+
+# ---------- 5. $LOOM_DAEMON_BIN_DIR overrides the default ~/.local/bin dir ----------
+CUSTOM_DIR="$WORKDIR/t5-custom-install-dir"
+CUSTOM_BIN="$CUSTOM_DIR/loom-daemon"
+make_fake_bin "$CUSTOM_BIN"
+DECOY_HOME="$WORKDIR/t5-decoy-home"
+mkdir -p "$DECOY_HOME"
+out=$( env -i PATH="$MINIMAL_PATH" HOME="$DECOY_HOME" LOOM_DAEMON_BIN_DIR="$CUSTOM_DIR" \
+    bash -c "source '$LIB'; loom_locate_daemon_bin '$WORKDIR/t5-root'" )
+assert_eq "$CUSTOM_BIN" "$out" "\$LOOM_DAEMON_BIN_DIR overrides the default ~/.local/bin install dir"
+
+# ---------- 6. in-repo build-output candidates are still the last resort ----------
+REPO6="$WORKDIR/t6-repo"
+make_fake_bin "$REPO6/target/release/loom-daemon"
+out=$( env -i PATH="$MINIMAL_PATH" HOME="$WORKDIR/t6-nohome" \
+    bash -c "source '$LIB'; loom_locate_daemon_bin '$REPO6'" )
+assert_eq "$REPO6/target/release/loom-daemon" "$out" "in-repo target/release/loom-daemon is still found when nothing else resolves"
+
+# ---------- 7. nothing resolvable -> empty output, no error ----------
+out=$( env -i PATH="$MINIMAL_PATH" HOME="$WORKDIR/t7-nohome" \
+    bash -c "source '$LIB'; loom_locate_daemon_bin '$WORKDIR/t7-root'" )
+assert_eq "" "$out" "nothing resolvable -> empty output (caller reports not-found itself)"
+
+# ---------- 8. loom_daemon_bin_search_paths() names the machine-level
+#               install location so a "not found" error can list it ----------
+paths_out=$( env -i PATH="$MINIMAL_PATH" HOME="$WORKDIR/t8-home" \
+    bash -c "source '$LIB'; loom_daemon_bin_search_paths '$WORKDIR/t8-root'" )
+assert_contains "$WORKDIR/t8-home/.local/bin/loom-daemon" "$paths_out" "search-paths summary names the machine-level ~/.local/bin install location"
+assert_contains "$WORKDIR/t8-root/target/release/loom-daemon" "$paths_out" "search-paths summary still names the in-repo build-output candidates"
+
+# ---------- summary ----------
+echo
+echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -185,6 +185,14 @@ new_fixture() {
     # its `calibrate` command substitution, so it must exist alongside the
     # fixture copy too.
     cp "$CLI_DIR/../lib/bounded-run.sh" "$root/.loom/scripts/lib/bounded-run.sh"
+    # Same for lib/locate-daemon-bin.sh (#4875): the fixture start script
+    # sources it relative to ITS OWN location to resolve the daemon binary
+    # under a minimal PATH, so every fixture flow that execs the copied
+    # loom-daemon-start.sh (restart, --relaunch, the full update run) needs it
+    # in the throwaway tree. Without it those flows abort with
+    # "locate-daemon-bin.sh not found at <fixture>/.loom/scripts/lib" before
+    # reaching the behaviour under test.
+    cp "$CLI_DIR/../lib/locate-daemon-bin.sh" "$root/.loom/scripts/lib/locate-daemon-bin.sh"
     cp "$LOOM_REPO_ROOT/scripts/install/provision-daemon.sh" "$root/scripts/install/provision-daemon.sh"
     cat > "$root/loom-daemon/Cargo.toml" <<'EOF'
 [package]

--- a/defaults/scripts/tests/test-loom-daemon-watchdog.sh
+++ b/defaults/scripts/tests/test-loom-daemon-watchdog.sh
@@ -690,12 +690,20 @@ rm -rf "$PS_STUB_DIR" "$STUB15"
 #     is skipped, NOT reported. The watchdog must never page because its own
 #     optional helper is missing. PATH is narrowed to the base system dirs so
 #     the host's real installed loom-daemon is not picked up, and the marker's
-#     repo_root ($WORKDIR) holds no cargo target either.
+#     repo_root ($WORKDIR) holds no cargo target either. HOME is also
+#     sandboxed to a directory with no .local/bin (#4875's machine-level
+#     install fallback in lib/locate-daemon-bin.sh checks
+#     $LOOM_DAEMON_BIN_DIR/loom-daemon, default $HOME/.local/bin/loom-daemon —
+#     without this override the suite would pick up this host's own real
+#     ~/.local/bin/loom-daemon instead of exercising the "nothing resolvable"
+#     path this test targets).
 # ===================================================================
 STUB16_PS="$(make_ps_stub "02:00:00")"
 start_alive_and_fresh 16
 rm -rf "$PS_STUB_DIR"
-run_watchdog_verbose PATH="$STUB16_PS:/usr/bin:/bin" LOOM_WATCHDOG_IPC_PROBE=1 \
+NO_HOME_16="$WORKDIR/no-home-16"
+mkdir -p "$NO_HOME_16"
+run_watchdog_verbose PATH="$STUB16_PS:/usr/bin:/bin" HOME="$NO_HOME_16" LOOM_WATCHDOG_IPC_PROBE=1 \
     LOOM_DAEMON_BIN="$WORKDIR/definitely-not-a-binary"
 kill "$LIVE_PID" 2>/dev/null || true
 assert_rc 0 "$RC" "no loom-daemon binary resolvable: exits 0 (graceful degrade)"


### PR DESCRIPTION
## Summary

`loom-daemon-start.sh --from-config` (and its sibling scripts) reported
"loom-daemon binary not found" over a non-interactive `ssh host 'cmd'`
invocation even though the binary was present and current at
`~/.local/bin/loom-daemon` (the epic #3835 Phase 3a machine-level install
location). A non-interactive SSH command never sources the login profile, so
`~/.local/bin` is not on `$PATH`, and none of the discovery functions checked
that install location explicitly. This defeats the script's stated job: its
own header documents backgrounding the daemon "so it can also be (re)started
headlessly over SSH" (#4130), and `loom-daemon status`'s own recovery hint
prints this exact broken command.

## Changes

- `lib/locate-daemon-bin.sh`'s shared `loom_locate_daemon_bin()` now falls
  back to `$LOOM_DAEMON_BIN_DIR` (default `$HOME/.local/bin`) after the
  `$LOOM_DAEMON_BIN` / `$PATH` lookups fail and before the in-repo
  `target/release|debug` build-output candidates.
- Added `loom_daemon_bin_search_paths()` so a "not found" error can list
  every location that was checked, not just suggest a rebuild.
- Migrated `loom-daemon-start.sh`, `loom-daemon-watchdog.sh`,
  `loom-daemon-update.sh`, `loom-status.sh`, and `.loom/bin/loom`'s `health`
  subcommand — which each carried a separate, near-identical inline copy of
  this resolution logic (exactly how a missing install-location check like
  this one goes unnoticed for four+ copies at once) — onto this single
  shared function, so a future new candidate path is added in exactly one
  place. `.loom/bin/loom health` also gained a `LOOM_DAEMON_BIN` override,
  which it previously lacked entirely.
- `loom-status.sh`'s wrapper preserves its pre-existing, stricter contract
  (an explicitly-set-but-non-executable `LOOM_DAEMON_BIN` is a hard "not
  found", unlike the other four call sites, which fall through to
  PATH/machine-level/in-repo candidates) — its own test suite uses a bogus
  `LOOM_DAEMON_BIN` as a deterministic "force not found" sentinel that must
  not then pick up a real installed binary.
- Added `test-locate-daemon-bin.sh`, a focused unit suite for the shared
  resolver (9 cases, including the core repro: a minimal, non-interactive
  `$PATH` with no `$LOOM_DAEMON_BIN` still finds `$HOME/.local/bin/loom-daemon`),
  wired into `ci-wired.txt`.
- Fixed a latent test-isolation gap in `test-loom-daemon-watchdog.sh`
  test 16 ("no resolvable binary") that never sandboxed `$HOME` — harmless
  before this fix (nothing checked `~/.local/bin`), but would otherwise now
  pick up this host's own real installed daemon and turn a "gracefully skip"
  assertion into a false IPC-probe failure.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `loom-daemon-start.sh` finds `~/.local/bin/loom-daemon` without `LOOM_DAEMON_BIN`/PATH pre-seeding, under `ssh host 'cmd'` | ✅ | Manually reproduced: `env -i PATH=/usr/bin:/bin HOME=<fixture> bash loom-daemon-start.sh --from-config --foreground` resolves and execs `<fixture>/.local/bin/loom-daemon` |
| Same fix applies to `loom-daemon-watchdog.sh`, `loom-daemon-update.sh` (`loom-daemon-stop.sh` confirmed out of scope — no binary resolution) | ✅ | Both migrated onto the shared resolver; suites green (72/72, 112/120 — same 8 pre-existing failures as baseline) |
| Not-found error names the paths searched, not just "build it from source" | ✅ | `loom_daemon_bin_search_paths()`; verified via manual `.loom/bin/loom health` smoke test with nothing resolvable |
| Test exercises discovery with `PATH` reduced to a minimal/non-interactive default | ✅ | `test-locate-daemon-bin.sh` case 4 ("THE CORE FIX") |
| (Curator-added) `loom-status.sh` and `.loom/bin/loom health` — same gap, missing from original enumeration | ✅ | Both migrated onto the shared resolver too |

## Test Plan

- `./defaults/scripts/tests/test-locate-daemon-bin.sh` — new suite, 9/9 passed
- `./defaults/scripts/tests/test-loom-daemon-start.sh` — 72/72 passed (no regression)
- `./defaults/scripts/tests/test-loom-daemon-update.sh` — 112/120 passed, identical to the unmodified baseline (same 8 pre-existing failures; the #4381 production-binary checksum regression guard passed)
- `./defaults/scripts/tests/test-loom-daemon-watchdog.sh` — 62/62 passed (after sandboxing `$HOME` in test 16, see Changes)
- `./defaults/scripts/tests/test-loom-status.sh` — 29/34 passed, identical to the unmodified baseline (same 5 pre-existing failures, unrelated to this change)
- `./defaults/scripts/tests/check-ci-suite-manifest.sh` — passes (new suite wired into `ci-wired.txt`)
- Manual repro of the issue's exact scenario against `loom-daemon-start.sh --from-config` and `.loom/bin/loom health`, both with a fixture `$HOME` holding only `~/.local/bin/loom-daemon` and a minimal `$PATH`

Closes #4875
