### PR TITLE
fix(dashboard): key token burn curves by account, not (host, account)

### DIFF
--- a/dashboard/web/src/analytics/analytics.css
+++ b/dashboard/web/src/analytics/analytics.css
@@ -219,3 +219,11 @@
 .status--insufficient-data {
   color: var(--analytics-muted);
 }
+
+/* Same local name, contradictory readings across hosts (#4898) — the merge
+   should not be trusted for this account. */
+.badge--divergent {
+  background: color-mix(in srgb, var(--warn, #e6b95c) 18%, transparent);
+  color: var(--warn, #e6b95c);
+  border: 1px solid color-mix(in srgb, var(--warn, #e6b95c) 45%, transparent);
+}

--- a/dashboard/web/src/analytics/burn.ts
+++ b/dashboard/web/src/analytics/burn.ts
@@ -2,14 +2,27 @@
  * Per-account burn curves: `usage_fraction` over time, reconstructed from
  * `tokens.snapshot` history (Epic #4702, Phase 3, issue #4752).
  *
- * ## Series identity is `hostId` + `account`, not `account` alone
+ * ## Series identity is the `account`; `hostId` is provenance (#4898)
  *
- * The token pool is a **per-host** resource (`.loom/tokens/` lives on the
- * machine running `loom-daemon`), and `tokens.snapshot` carries no repo but
- * does arrive under a `hostId` envelope. Two hosts can legitimately have
- * accounts with the same name — pooling them into one series would interleave
- * two independent usage clocks and produce a sawtooth that describes neither.
- * So one curve is one `(hostId, account)` pair.
+ * This used to key on `(hostId, account)`, reasoning that two hosts could
+ * legitimately hold same-named but distinct accounts, so pooling them would
+ * interleave "two independent usage clocks". For a shared token pool that is
+ * backwards: `usage_fraction` is the account's **server-side** consumption,
+ * not the reporting host's contribution to it, so several hosts holding one
+ * account are not two clocks — they are one clock read N times.
+ *
+ * Keying on the pair therefore rendered the same account once per host: on a
+ * three-host fleet, 39 near-identical curves for 13 accounts, and one
+ * exhaustion forecast per copy. Readings are now merged by `account`, and the
+ * contributing hosts are carried as `hostIds` for provenance.
+ *
+ * The old concern is not dismissed, only relocated: nothing guarantees two
+ * operators' `.loom/tokens/` use disjoint local names. That case is now
+ * *detected* rather than assumed — see `divergentHosts` below.
+ *
+ * Merging is safe against ordering because `at` is the daemon's `captured_at`
+ * (the probe instant), not the push time, so a merged series is still in true
+ * chronological order and still monotonically non-decreasing within a window.
  *
  * ## Limit windows, and why the curve is segmented
  *
@@ -50,13 +63,36 @@
 
 import type { AccountReading, PoolSample, TokenSample } from "./types.js";
 
-/** A usage drop smaller than this is float noise, not a window rollover. */
-const USAGE_DROP_EPSILON = 1e-9;
+/**
+ * How far usage must fall to count as a window rollover.
+ *
+ * Was `1e-9` — appropriate when a series came from one host, where the only
+ * sub-threshold movement was float noise. A merged multi-host series (#4898)
+ * also carries small legitimate wobble: hosts probe on independent schedules
+ * and their clocks are not synchronised, so two readings of the same value can
+ * land marginally out of order. At `1e-9` any such pair fabricated a
+ * "window-reset" and shattered the curve into meaningless segments.
+ *
+ * A genuine rollover resets usage toward zero — a drop of most of the range,
+ * never hundredths. `0.02` clears the observed cross-host spread (~0.01) with
+ * room to spare while remaining far below any real reset. Rollovers from a
+ * usage below this are not interesting: an account resetting from 0.01 to 0
+ * has nothing to plot either way.
+ */
+const USAGE_DROP_EPSILON = 0.02;
 
 /** Default telemetry-gap tolerance: samples more than 60 minutes apart start a
  * new segment. The daemon's snapshot cadence is minutes, so an hour-wide hole
  * is a reporting outage, not a slow poll. */
 export const DEFAULT_MAX_SAMPLE_GAP_MS = 60 * 60 * 1000;
+
+/**
+ * Two readings closer together than this are "the same moment" for the
+ * purpose of comparing hosts (`findDivergentHosts`). Comfortably under the
+ * daemon's snapshot cadence, so it pairs cross-host observations without
+ * pairing a host's own consecutive samples.
+ */
+const CONCURRENT_READING_WINDOW_MS = 90 * 1000;
 
 export interface BurnPoint {
   /** Epoch ms. */
@@ -80,7 +116,14 @@ export interface BurnSegment {
 }
 
 export interface AccountBurnCurve {
-  hostId: string;
+  /** Every host that reported this account, first-seen order. Provenance,
+   * not identity — the account is the thing with a quota (#4898). */
+  hostIds: string[];
+  /** Hosts whose readings disagreed materially with a near-simultaneous
+   * reading from another host — i.e. the same local name plausibly refers to
+   * different upstream accounts. Empty in the normal shared-pool case;
+   * non-empty means the merge should not be trusted for this account. */
+  divergentHosts: string[];
   account: string;
   /** Newest known pool rank (lower = preferred by the selector). */
   rank?: number;
@@ -111,9 +154,10 @@ function clampFraction(value: number): number {
 }
 
 interface Series {
-  hostId: string;
   account: string;
-  readings: Array<{ at: number; reading: AccountReading }>;
+  /** Every host that reported this account, in first-seen order. */
+  hostIds: string[];
+  readings: Array<{ at: number; hostId: string; reading: AccountReading }>;
 }
 
 /**
@@ -134,27 +178,29 @@ export function buildBurnCurves(
   const series = new Map<string, Series>();
   for (const sample of samples) {
     for (const reading of sample.accounts) {
-      const key = `${sample.hostId}\u0000${reading.account}`;
-      let entry = series.get(key);
+      let entry = series.get(reading.account);
       if (!entry) {
-        entry = { hostId: sample.hostId, account: reading.account, readings: [] };
-        series.set(key, entry);
+        entry = { account: reading.account, hostIds: [], readings: [] };
+        series.set(reading.account, entry);
       }
-      entry.readings.push({ at: sample.at, reading });
+      if (!entry.hostIds.includes(sample.hostId)) entry.hostIds.push(sample.hostId);
+      entry.readings.push({ at: sample.at, hostId: sample.hostId, reading });
     }
   }
 
   const curves: AccountBurnCurve[] = [];
   for (const entry of series.values()) {
-    entry.readings.sort((a, b) => a.at - b.at);
+    // Stable across hosts: probe time, then host name, so two readings sharing
+    // a `captured_at` second do not reorder between runs.
+    entry.readings.sort((a, b) => a.at - b.at || a.hostId.localeCompare(b.hostId));
     curves.push(buildCurve(entry, maxSampleGapMs));
   }
 
-  // Stable, operator-meaningful ordering: host, then pool rank (the selector's
-  // own preference order), then name. Rank-less accounts sort last.
+  // Stable, operator-meaningful ordering: pool rank (the selector's own
+  // preference order), then name. Rank-less accounts sort last. No longer
+  // grouped by host — one curve now spans every host that reported it.
   curves.sort(
     (a, b) =>
-      a.hostId.localeCompare(b.hostId) ||
       (a.rank ?? Number.MAX_SAFE_INTEGER) - (b.rank ?? Number.MAX_SAFE_INTEGER) ||
       a.account.localeCompare(b.account),
   );
@@ -196,7 +242,8 @@ function buildCurve(entry: Series, maxSampleGapMs: number): AccountBurnCurve {
 
   const lastReading = entry.readings.at(-1);
   return {
-    hostId: entry.hostId,
+    hostIds: entry.hostIds,
+    divergentHosts: findDivergentHosts(entry),
     account: entry.account,
     rank: newestDefinedRank(entry),
     points,
@@ -225,6 +272,44 @@ function segmentBreak(
     return "window-reset";
   }
   return undefined;
+}
+
+/**
+ * Hosts whose reading of this account contradicts another host's at nearly the
+ * same instant.
+ *
+ * This is the safeguard for the case the old `(hostId, account)` keying
+ * assumed was universal: two operators' pools can legitimately use one local
+ * name for different upstream accounts, and merging those would average two
+ * unrelated quotas into a line describing neither.
+ *
+ * Detected rather than assumed. For a genuinely shared account every host
+ * observes the same server-side value, so near-simultaneous readings agree to
+ * within probe timing. A disagreement wider than `USAGE_DROP_EPSILON` between
+ * readings closer together than the probe cadence is not timing — it is two
+ * different accounts.
+ */
+function findDivergentHosts(entry: Series): string[] {
+  const divergent = new Set<string>();
+
+  for (let i = 1; i < entry.readings.length; i += 1) {
+    const previous = entry.readings[i - 1];
+    const current = entry.readings[i];
+    if (!previous || !current) continue;
+    if (previous.hostId === current.hostId) continue;
+    if (current.at - previous.at > CONCURRENT_READING_WINDOW_MS) continue;
+
+    const a = previous.reading.usageFraction;
+    const b = current.reading.usageFraction;
+    if (a === undefined || b === undefined) continue;
+
+    if (Math.abs(a - b) > USAGE_DROP_EPSILON) {
+      divergent.add(previous.hostId);
+      divergent.add(current.hostId);
+    }
+  }
+
+  return [...divergent].sort();
 }
 
 function newestDefinedRank(entry: Series): number | undefined {

--- a/dashboard/web/src/analytics/forecast.ts
+++ b/dashboard/web/src/analytics/forecast.ts
@@ -52,7 +52,8 @@ export type ForecastStatus =
   | "insufficient-data";
 
 export interface AccountForecast {
-  hostId: string;
+  /** Hosts that reported the account this forecast covers (#4898). */
+  hostIds: string[];
   account: string;
   status: ForecastStatus;
   /** Points that fed the fit (live segment only). */
@@ -94,7 +95,7 @@ export function forecastAccount(curve: AccountBurnCurve, options: ForecastOption
   const limitWindowResetAt = segment?.limitWindowResetAt ?? latest?.limitWindowResetAt;
 
   const base: AccountForecast = {
-    hostId: curve.hostId,
+    hostIds: curve.hostIds,
     account: curve.account,
     status: "insufficient-data",
     sampleCount: points.length,

--- a/dashboard/web/src/analytics/render.ts
+++ b/dashboard/web/src/analytics/render.ts
@@ -216,16 +216,34 @@ function renderBurnCurves(curves: readonly AccountBurnCurve[]): HTMLElement {
   return block;
 }
 
+/** "studio" for one host, "studio +2" beyond that — the card has room for a
+ * name, not a list, and the full set is on `data-hosts`. */
+function formatHosts(hostIds: readonly string[]): string {
+  if (hostIds.length === 0) return "—";
+  const [first] = hostIds;
+  return hostIds.length === 1 ? String(first) : `${first} +${hostIds.length - 1}`;
+}
+
 function renderBurnCard(curve: AccountBurnCurve): HTMLElement {
   const exhausted = curve.exhausted;
   const card = el("article", `burn-card${exhausted ? " burn-card--exhausted" : ""}`);
   card.setAttribute("data-account", curve.account);
-  card.setAttribute("data-host", curve.hostId);
+  card.setAttribute("data-hosts", curve.hostIds.join(","));
   card.setAttribute("data-exhausted", String(exhausted));
 
   const head = el("header", "burn-card__head");
   head.appendChild(el("span", "burn-card__account", curve.account));
-  head.appendChild(el("span", "burn-card__host", curve.hostId));
+  // Provenance, not identity: one account, however many hosts reported it.
+  head.appendChild(el("span", "burn-card__host", formatHosts(curve.hostIds)));
+  if (curve.divergentHosts.length > 0) {
+    // Same local name, contradictory readings — plausibly different upstream
+    // accounts merged into one series. Say so rather than quietly averaging
+    // two unrelated quotas (see burn.ts's findDivergentHosts).
+    const warn = el("span", "badge badge--divergent", "CONFLICTING");
+    warn.setAttribute("data-testid", "divergent-hosts");
+    warn.title = `Hosts disagree on this account's usage: ${curve.divergentHosts.join(", ")}. It may name different accounts on different hosts.`;
+    head.appendChild(warn);
+  }
   if (exhausted) {
     // The distinct visual flag AC4 requires: a badge, a card modifier class,
     // and a machine-readable data attribute — belt, braces, and a test hook.
@@ -502,7 +520,7 @@ function renderForecasts(forecasts: readonly AccountForecast[], now: number): HT
       row.className = "row--at-risk";
     }
     cell(row, forecast.account, "cell--account");
-    cell(row, forecast.hostId, "cell--host");
+    cell(row, formatHosts(forecast.hostIds), "cell--host");
     cell(row, formatRatePerHour(forecast.slopePerHour));
     cell(row, formatPercent(forecast.latestUsageFraction));
     cell(

--- a/dashboard/web/test/burn.test.ts
+++ b/dashboard/web/test/burn.test.ts
@@ -43,18 +43,73 @@ describe("buildBurnCurves", () => {
     expect(curves.map((curve) => curve.account)).toEqual(["zeta", "mid", "alpha"]);
   });
 
-  it("keeps identically-named accounts on different hosts as separate curves", () => {
+  // #4898: one account is one curve, however many hosts report it —
+  // `usage_fraction` is the account's server-side consumption, so N hosts are
+  // one clock read N times, not N clocks.
+  it("merges one account reported by several hosts into a single curve", () => {
+    const curves = buildBurnCurves(
+      parseTokenSamples([
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.5 }], "host-a"),
+        tokensSnapshot(T0 + MINUTE, [{ account: "agent-1", usage: 0.5 }], "host-b"),
+        tokensSnapshot(T0 + 2 * MINUTE, [{ account: "agent-1", usage: 0.51 }], "host-c"),
+      ]),
+    );
+
+    expect(curves).toHaveLength(1);
+    expect(curves[0]?.account).toBe("agent-1");
+    expect(curves[0]?.hostIds).toEqual(["host-a", "host-b", "host-c"]);
+    // Agreeing hosts are the normal shared-pool case, not a conflict.
+    expect(curves[0]?.divergentHosts).toEqual([]);
+    // One continuous series, not three fragments.
+    expect(curves[0]?.segments).toHaveLength(1);
+    expect(curves[0]?.points).toHaveLength(3);
+  });
+
+  // Cross-host wobble (independent probe schedules, unsynchronised clocks)
+  // must not read as a limit-window rollover. At the old 1e-9 threshold any
+  // such pair shattered the curve into meaningless segments.
+  it("does not treat sub-threshold cross-host wobble as a window reset", () => {
+    const curves = buildBurnCurves(
+      parseTokenSamples([
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.74 }], "host-a"),
+        tokensSnapshot(T0 + MINUTE, [{ account: "agent-1", usage: 0.735 }], "host-b"),
+        tokensSnapshot(T0 + 2 * MINUTE, [{ account: "agent-1", usage: 0.75 }], "host-a"),
+      ]),
+    );
+
+    expect(curves).toHaveLength(1);
+    expect(curves[0]?.segments).toHaveLength(1);
+    expect(curves[0]?.segments[0]?.startedBy).toBe("initial");
+  });
+
+  // The old keying assumed this case was universal; it is now detected
+  // instead. Two hosts reporting wildly different usage for one name at the
+  // same instant are plausibly different upstream accounts.
+  it("flags hosts that disagree materially about the same account name", () => {
     const curves = buildBurnCurves(
       parseTokenSamples([
         tokensSnapshot(T0, [{ account: "agent-1", usage: 0.1 }], "host-a"),
         tokensSnapshot(T0, [{ account: "agent-1", usage: 0.9 }], "host-b"),
       ]),
     );
-    expect(curves).toHaveLength(2);
-    expect(curves.map((curve) => `${curve.hostId}:${curve.points[0]?.usageFraction}`)).toEqual([
-      "host-a:0.1",
-      "host-b:0.9",
-    ]);
+
+    expect(curves).toHaveLength(1);
+    expect(curves[0]?.divergentHosts).toEqual(["host-a", "host-b"]);
+  });
+
+  // A real rollover is a drop of most of the range — still detected, and not
+  // confused with the wobble case above.
+  it("still detects a genuine window rollover after merging", () => {
+    const curves = buildBurnCurves(
+      parseTokenSamples([
+        tokensSnapshot(T0, [{ account: "agent-1", usage: 0.95 }], "host-a"),
+        tokensSnapshot(T0 + MINUTE, [{ account: "agent-1", usage: 0.03 }], "host-b"),
+      ]),
+    );
+
+    expect(curves).toHaveLength(1);
+    expect(curves[0]?.segments).toHaveLength(2);
+    expect(curves[0]?.segments[1]?.startedBy).toBe("window-reset");
   });
 
   it("starts a new segment at a limit-window rollover (usage drops)", () => {


### PR DESCRIPTION
Closes #4898.

The Tokens tab rendered **39 burn curves for 13 accounts** — every shared account once per host, each with its own near-identical exhaustion forecast.

## The premise was inverted

`buildBurnCurves` keyed series on `(hostId, account)`, with this rationale in the module doc:

> Two hosts can legitimately have accounts with the same name — pooling them into one series would interleave two independent usage clocks and produce a sawtooth that describes neither.

For a shared token pool that is backwards. `usage_fraction` is the account's **server-side** consumption, not the reporting host's contribution to it. Several hosts holding one account are not two clocks — they are one clock read N times.

Verified before changing anything. `tokens check --ranking` on two hosts at the same moment:

| account | studio | worker-1 |
|---|---|---|
| `agent5-2amlogic` | 0.53 | 0.53 |
| `agent6-2amlogic` | 0.64 | 0.64 |
| `agent7-2amlogic` | 0.74 | 0.75 |
| `robb-2amlogic` | 1.00 | 1.00 |

Agreement within rounding is what one shared upstream quota looks like, and the opposite of what the keying defended against.

## The old concern is relocated, not dismissed

Nothing guarantees two operators' `.loom/tokens/` use disjoint local names. That case is now **detected** instead of assumed: `findDivergentHosts` flags accounts whose near-simultaneous cross-host readings disagree materially, and the card shows a `CONFLICTING` badge rather than quietly averaging two unrelated quotas.

## The subtle part: `USAGE_DROP_EPSILON` 1e-9 → 0.02

Merging is order-safe because `at` is the daemon's `captured_at` (probe instant), not push time — so a merged series stays chronological and monotonically non-decreasing within a window.

But at `1e-9`, **any** cross-host wobble — independent probe schedules, unsynchronised clocks — fabricated a `window-reset` and shattered every merged curve into meaningless segments. A genuine rollover resets usage toward zero, a drop of most of the range, so `0.02` clears the observed spread (~0.01) while staying far below any real reset.

This matters more than it looks: `limit_window_reset_at` is never populated (#4874), so the drop heuristic is currently the *only* rollover signal. A test pins that a real rollover (0.95 → 0.03) is still detected.

## Not touched

`buildPoolBurnCurves` keeps one curve per host with no account key — correct there, since it describes a host's *pool* rather than an account. Its tests still assert `hostId` and still pass.

## Verification

Against fleet-shaped data (3 hosts, overlapping pools, agreeing values with jitter): **17 (host, account) pairs collapse to 7 curves**, one segment each, zero false divergence, provenance intact.

The test that pinned the old behaviour is replaced by four covering the new contract: merge across hosts, sub-threshold wobble is not a reset, material disagreement is flagged, genuine rollovers still segment.

**160 backend + 401 web tests pass.**