### PR TITLE
feat(daemon): add periodic worktree reaper for cross-host merged-PR cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,9 +163,9 @@ gh pr create --label "loom:review-requested"
 - **Never run `git worktree` directly** (the helper prevents nested worktrees) — to
   remove one managed worktree on demand use `./.loom/scripts/worktree.sh remove
   <issue-number>` (`loom-clean` is the bulk path).
-- Loom-managed worktrees (with the `.loom-managed` sentinel) are auto-removed when
-  their PR merges; user-provisioned worktrees are never removed — set
-  `LOOM_PRESERVE_WORKTREE=1` to disable cleanup for a session.
+- Loom-managed worktrees (with the `.loom-managed` sentinel) are auto-removed on
+  merge AND by the daemon's periodic reaper (#4876, catches merges made on another
+  host); user-provisioned worktrees are never removed — `LOOM_PRESERVE_WORKTREE=1`.
 
 ### Merging PRs
 

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -3281,6 +3281,94 @@ pool, gated by that repo's own config (an empty registry reduces to the single
 daemon workspace). See `loom-daemon/src/token_ranking_refresh.rs` for the
 implementation.
 
+### Merged-PR worktree reaper (#4876)
+
+CLAUDE.md states the contract: *"Loom-managed worktrees (with the
+`.loom-managed` sentinel) are auto-removed when their PR merges."* Through
+v0.17.0 that had exactly **one** implementation — `merge-pr.sh`'s
+`_remove_loom_worktree()`, a synchronous side effect of that script running —
+so the removal only happened when all three of these held:
+
+1. the merge went through `merge-pr.sh` (not the forge UI, `gh api`, or an
+   auto-merge queue), **and**
+2. it ran on the host holding the worktree, **and**
+3. it ran in the checkout holding the worktree (`find_main_repo_root()` walks up
+   from the invoking shell's cwd; there is no host-wide scan).
+
+A multi-host fleet violates (2) constantly: worker-1 builds issue #N, studio
+merges the PR, and worker-1's worktree has nobody to observe the merge. Nothing
+daemon-side covered the gap. Observed on 2026-08-01: **44** stale worktrees on
+`loom-worker-1` (54G under `.loom/`, disk at 81%) and 35 on studio — 16 on each
+were merged-PR worktrees eligible for removal.
+
+**What it does.** On a cadence (default 15 minutes) the daemon walks every
+registered workspace, enumerates `issue-<N>` directories under that repo's
+worktree root, and removes the ones whose issue is closed and whose PR merged
+outside the grace period. The decision comes from *forge state*, not from
+observing a merge event, so it does not matter which host merged or whether any
+merge script ran.
+
+**It can only ever remove a subset of `clean --safe`.** The gate chain is
+`worktree_ops::clean::classify_worktree` — the same function the interactive
+`loom-daemon clean` CLI uses, so there is no second copy to drift. The reaper
+runs it with `safe: true, force: false`, which preserves a worktree on any of:
+a live spawn-loop task or claim-lock, a `.loom-in-use` marker, a process whose
+cwd is inside it, an editable pip install pointing into it, an open issue, an
+open / unmerged / absent PR, an unreadable forge probe, a merge still inside the
+grace period, or any uncommitted change. It adds **one gate the CLI does not
+have**: the `.loom-managed` sentinel is *required*. An unattended remover has
+nobody at the keyboard to say no, so a user-provisioned worktree is never
+touched.
+
+**REST, not GraphQL.** The forge probes use `gh api repos/{owner}/{repo}/...`
+rather than `gh issue view` / `gh pr list`. GraphQL quota exhaustion under
+concurrent agents is a live failure mode, and an unattended cadence prober must
+not compete with interactive agents for the scarcer pool. A failed probe reads
+as `UNKNOWN`, which is always a *skip*.
+
+**Low-disk warning.** Each pass also reads `worktree_root_free_gb` (the metric
+the dashboard already renders but nothing acted on) and logs a `WARN` when free
+space on the worktree-root volume is under the floor. That converts "the disk
+filled and sweeps started failing with unrelated build errors" into an explicit
+signal. An unmeasurable probe is skipped, never treated as zero (#4164).
+
+**Default-on**, like the token-ranking refresh: it restores an
+already-documented behavior whose absence is a slow-motion outage (a full disk
+stops a host running sweeps at all).
+
+```json
+{
+  "autonomous": {
+    "worktreeReaper": {
+      "enabled": true,
+      "intervalSecs": 900,
+      "gracePeriodSecs": 600,
+      "diskWarnFreeGb": 20
+    }
+  }
+}
+```
+
+| Env var | Config key | Precedence | Default |
+|---------|-----------|------------|---------|
+| `LOOM_WORKTREE_REAPER` | `autonomous.worktreeReaper.enabled` | env > config > default | `true` (on) |
+| `LOOM_WORKTREE_REAPER_INTERVAL_SECS` | `autonomous.worktreeReaper.intervalSecs` | env > config > default | `900` (15 min) |
+| — | `autonomous.worktreeReaper.gracePeriodSecs` | config > default | `600` (10 min) |
+| `LOOM_WORKTREE_REAPER_DISK_WARN_GB` | `autonomous.worktreeReaper.diskWarnFreeGb` | env > config > default | `20` |
+
+**Not limited to the daemon's attached workspace.** The loop walks
+`WorkspaceRegistry::effective_roots()` each tick, so a daemon started from
+`~/GitHub/anvil` still reaps `~/GitHub/loom` as long as that repo is registered
+(`loom-daemon workspace add <path>`). A repo that is *not* registered is still
+not reaped — run `loom-daemon clean --safe --deep` there, or register it.
+
+**Idempotent and recoverable.** A missed pass costs nothing: the next tick
+re-evaluates from forge state, and a manual `loom-daemon clean --safe` remains a
+superset recovery path that reports zero errors when the loop already cleaned
+up. The first tick after daemon startup is deliberately skipped so in-flight
+sweeps can re-establish their `.loom-in-use` markers first. See
+`loom-daemon/src/worktree_reaper.rs`.
+
 ### Autonomous periodic support-role runner (#4015)
 
 Before this loop, the periodic **standalone** support roles — Champion,

--- a/loom-daemon/src/cli/cleanup_ops.rs
+++ b/loom-daemon/src/cli/cleanup_ops.rs
@@ -84,6 +84,10 @@ pub(crate) fn handle_clean_command(
         worktrees_only,
         branches_only,
         tmux_only,
+        // The interactive CLI keeps its historical behavior: an operator who
+        // typed the command is the authority on a sentinel-less worktree. Only
+        // the unattended reaper (#4876) requires the `.loom-managed` sentinel.
+        require_managed_sentinel: false,
     };
     let exit_code = clean::run_clean(&repo_root, &opts);
     if exit_code != 0 {

--- a/loom-daemon/src/daemon_service.rs
+++ b/loom-daemon/src/daemon_service.rs
@@ -30,6 +30,7 @@ use loom_daemon::token_ranking_refresh;
 use loom_daemon::watch_registry;
 use loom_daemon::work_finder;
 use loom_daemon::workspace_pool::WorkspacePool;
+use loom_daemon::worktree_reaper;
 use loom_daemon::{extract_configured_terminal_ids, rotate_log_file};
 
 use anyhow::{anyhow, Result};
@@ -1018,6 +1019,42 @@ pub(crate) async fn run_daemon() -> Result<()> {
             );
             None
         };
+
+    // Periodic merged-PR worktree reaper (Issue #4876). Before this loop the
+    // ONLY trigger for "auto-removed when their PR merges" (CLAUDE.md's stated
+    // contract) was `merge-pr.sh`'s synchronous `_remove_loom_worktree()` — so a
+    // PR merged on a different HOST, in a different CHECKOUT, through the forge
+    // UI/API, or while the daemon was down left its worktree behind forever.
+    // Across a three-host fleet that leaked 44 worktrees (81% disk) on one
+    // worker and 35 on the primary host. This loop makes every host reap its own
+    // worktrees from forge state on a cadence, independent of who merged.
+    //
+    // Multi-workspace like the health gate / ranking refresh: it walks
+    // `effective_roots()` each tick, so cleanup is NOT limited to the daemon's
+    // attached workspace (a daemon attached to `~/GitHub/anvil` still reaps
+    // `~/GitHub/loom` when that repo is registered).
+    //
+    // Default-ON (like the ranking refresh, unlike the work finder / gate): it
+    // restores an already-documented behavior, and its removal decision is
+    // `worktree_ops::clean::classify_worktree` under `--safe, !--force` PLUS a
+    // `.loom-managed` sentinel requirement the interactive CLI does not apply —
+    // i.e. a strict subset of what `loom-daemon clean --safe` would remove.
+    // Opt out with `LOOM_WORKTREE_REAPER=0` / `autonomous.worktreeReaper.enabled=false`.
+    let worktree_reaper_config = worktree_reaper::read_worktree_reaper_config(&sweep_workspace);
+    let _worktree_reaper_handle = if worktree_reaper::resolve_enabled(&worktree_reaper_config) {
+        let interval = worktree_reaper::resolve_interval(&worktree_reaper_config);
+        log::info!("worktree_reaper: enabled (multi-workspace, interval={}s)", interval.as_secs());
+        Some(worktree_reaper::spawn_multi_worktree_reaper_task(
+            sweep_workspace.clone(),
+            interval,
+        ))
+    } else {
+        log::debug!(
+            "worktree_reaper: disabled (set LOOM_WORKTREE_REAPER=0 or \
+             autonomous.worktreeReaper.enabled=false to opt out)"
+        );
+        None
+    };
 
     // Declared-cadence liveness heartbeat (Issue #4011): the daemon touches
     // `<loom_dir>/daemon.heartbeat` on a fixed cadence so a host-side watchdog

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -196,6 +196,7 @@ pub mod work_finder;
 pub mod workspace_pool;
 pub mod workspace_registry;
 pub mod worktree_ops;
+pub mod worktree_reaper;
 pub mod worktree_root;
 
 use std::collections::HashSet;

--- a/loom-daemon/src/worktree_ops/clean.rs
+++ b/loom-daemon/src/worktree_ops/clean.rs
@@ -17,7 +17,7 @@ use super::gh;
 use super::liveness::active_spawn_loop_issues;
 use super::naming::{self, BRANCH_PREFIX};
 use super::safety::{
-    check_uncommitted_changes, find_processes_using_directory, read_in_use_marker,
+    check_uncommitted_changes, find_processes_using_directory, read_in_use_marker, InUseMarker,
 };
 
 /// Default grace period after PR merge before a worktree is eligible for
@@ -78,6 +78,16 @@ pub struct CleanOptions {
     pub worktrees_only: bool,
     pub branches_only: bool,
     pub tmux_only: bool,
+    /// Require the `.loom-managed` sentinel before a worktree is eligible for
+    /// removal (issue #4876).
+    ///
+    /// The interactive `loom-daemon clean` CLI leaves this **false** to preserve
+    /// its historical behavior (an operator who typed the command and answered
+    /// the prompt is the authority). The daemon-side periodic reaper
+    /// ([`crate::worktree_reaper`]) sets it **true**: an unattended background
+    /// remover must honor CLAUDE.md's "user-provisioned worktrees are never
+    /// removed" contract, because nobody is there to say no.
+    pub require_managed_sentinel: bool,
 }
 
 impl Default for CleanOptions {
@@ -91,6 +101,7 @@ impl Default for CleanOptions {
             worktrees_only: false,
             branches_only: false,
             tmux_only: false,
+            require_managed_sentinel: false,
         }
     }
 }
@@ -175,6 +186,86 @@ pub fn check_pr_merged(repo_root: &Path, issue_num: u32) -> PrStatus {
         PrStatus::Open
     } else {
         PrStatus::Unknown
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct PrRowRest {
+    state: String,
+    #[serde(default)]
+    merged_at: Option<String>,
+}
+
+/// Resolve the repository owner via the **REST** API
+/// (`gh api repos/{owner}/{repo} --jq .owner.login`).
+///
+/// Used to build the `head=<owner>:<branch>` filter [`check_pr_merged_rest`]
+/// needs. Returns `None` on any failure so callers can fall back to the
+/// GraphQL-backed [`check_pr_merged`].
+#[must_use]
+pub fn repo_owner_rest(repo_root: &Path) -> Option<String> {
+    let out = Command::new("gh")
+        .args(["api", "repos/{owner}/{repo}", "--jq", ".owner.login"])
+        .current_dir(repo_root)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let owner = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if owner.is_empty() {
+        None
+    } else {
+        Some(owner)
+    }
+}
+
+/// REST variant of [`check_pr_merged`] (issue #4876).
+///
+/// `gh pr list` goes through GraphQL, whose quota is routinely exhausted on a
+/// host running several agents concurrently; the REST quota is separate and
+/// much less contended. The daemon-side reaper probes unattended on a cadence,
+/// so it must not compete with interactive agents for the scarcer pool.
+///
+/// Queries `repos/{owner}/{repo}/pulls?state=all&head=<owner>:<branch>`. Falls
+/// back to nothing on its own — the caller decides whether an `Unknown` should
+/// be retried through [`check_pr_merged`].
+#[must_use]
+pub fn check_pr_merged_rest(repo_root: &Path, owner: &str, issue_num: u32) -> PrStatus {
+    let branch = naming::branch_name(issue_num);
+    let path = format!("repos/{{owner}}/{{repo}}/pulls?state=all&head={owner}:{branch}&per_page=1");
+    let Ok(out) = Command::new("gh")
+        .args(["api", &path])
+        .current_dir(repo_root)
+        .output()
+    else {
+        return PrStatus::Unknown;
+    };
+    if !out.status.success() {
+        return PrStatus::Unknown;
+    }
+    let Ok(rows) = serde_json::from_slice::<Vec<PrRowRest>>(&out.stdout) else {
+        return PrStatus::Unknown;
+    };
+    let Some(row) = rows.into_iter().next() else {
+        return PrStatus::NoPr;
+    };
+    classify_pr_row(row.state.as_str(), row.merged_at.as_deref())
+}
+
+/// Map a REST pull-request `(state, merged_at)` pair onto a [`PrStatus`].
+/// Pure, so the REST probe's classification is unit-testable without `gh`.
+#[must_use]
+pub fn classify_pr_row(state: &str, merged_at: Option<&str>) -> PrStatus {
+    if let Some(merged_at) = merged_at.filter(|s| !s.is_empty()) {
+        return PrStatus::Merged {
+            merged_at: merged_at.to_string(),
+        };
+    }
+    match state.to_ascii_uppercase().as_str() {
+        "CLOSED" => PrStatus::ClosedNoMerge,
+        "OPEN" => PrStatus::Open,
+        _ => PrStatus::Unknown,
     }
 }
 
@@ -269,7 +360,216 @@ pub fn find_editable_pip_installs(worktree_path: &Path) -> Vec<String> {
     packages
 }
 
-fn cleanup_worktree(repo_root: &Path, worktree_path: &Path, issue_num: u32, dry_run: bool) -> bool {
+// ============================================================================
+// Removal decision (shared by the `clean` CLI and the daemon-side reaper)
+// ============================================================================
+
+/// Whether `worktree_path` carries the `.loom-managed` sentinel that
+/// `worktree.sh` drops into every Loom-provisioned worktree. A worktree
+/// without it is user-provisioned and must never be auto-removed (CLAUDE.md:
+/// "user-provisioned worktrees are never removed").
+#[must_use]
+pub fn is_loom_managed(worktree_path: &Path) -> bool {
+    worktree_path.join(".loom-managed").is_file()
+}
+
+/// The outcome of applying every worktree-removal safety gate to one worktree.
+///
+/// Extracted from [`clean_worktrees`] (issue #4876) so the **decision** has a
+/// single implementation shared by the interactive `loom-daemon clean` CLI and
+/// the daemon-side periodic reaper ([`crate::worktree_reaper`]). A second
+/// hand-rolled copy of these gates in the reaper is exactly the divergence that
+/// would let an unattended remover delete something the manual path preserves.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorktreeDecision {
+    /// Every gate passed — the worktree is eligible for removal.
+    Remove,
+    /// Held by a live spawn-loop task/claim-lock, a `.loom-in-use` marker, or a
+    /// process whose cwd is inside the worktree.
+    SkipInUse(String),
+    /// Editable pip install(s) point into the worktree (payload: the package list).
+    SkipEditable(String),
+    /// No `.loom-managed` sentinel and [`CleanOptions::require_managed_sentinel`]
+    /// is set — user-provisioned, never auto-removed.
+    SkipUnmanaged,
+    /// The issue is not `CLOSED` (payload: the observed state, e.g. `OPEN` /
+    /// `UNKNOWN`).
+    SkipIssueNotClosed(String),
+    /// The PR merged, but the post-merge grace period has not elapsed
+    /// (payload: seconds remaining).
+    SkipGrace(i64),
+    /// Uncommitted work in the worktree would be lost.
+    SkipUncommitted,
+    /// Closed issue whose PR did not merge, or that has no PR at all
+    /// (payload: which).
+    SkipNotMerged(String),
+    /// The PR is still open.
+    SkipPrOpen,
+    /// The PR status could not be determined (forge probe failed).
+    SkipUnknownPrStatus,
+    /// Non-`--safe` mode: the issue is closed and the caller decides
+    /// (interactive prompt, or `--force`).
+    ConfirmClosedIssue,
+}
+
+impl WorktreeDecision {
+    /// True only for [`WorktreeDecision::Remove`].
+    #[must_use]
+    pub fn is_remove(&self) -> bool {
+        matches!(self, Self::Remove)
+    }
+}
+
+/// Injected probes for [`classify_worktree`], so the safety decision is
+/// unit-testable without a live forge, process table, pip, or clock — the same
+/// dependency-injection shape [`SweepTransientEnv`] already uses in this module.
+pub struct WorktreeProbes<'a> {
+    /// Issues with a live spawn-loop task or claim-lock.
+    pub active_issues: &'a std::collections::HashSet<u32>,
+    /// Reads a worktree's `.loom-in-use` marker.
+    pub in_use_marker: &'a dyn Fn(&Path) -> Option<InUseMarker>,
+    /// PIDs whose cwd is inside the worktree.
+    pub processes_using: &'a dyn Fn(&Path) -> Vec<u32>,
+    /// Editable pip installs pointing into the worktree.
+    pub editable_installs: &'a dyn Fn(&Path) -> Vec<String>,
+    /// Whether the worktree carries the `.loom-managed` sentinel.
+    pub is_managed: &'a dyn Fn(&Path) -> bool,
+    /// Forge issue state (`"OPEN"` / `"CLOSED"` / `"UNKNOWN"`).
+    pub issue_state: &'a dyn Fn(u32) -> String,
+    /// Forge PR status for the issue's branch.
+    pub pr_status: &'a dyn Fn(u32) -> PrStatus,
+    /// Whether the worktree has uncommitted changes.
+    pub uncommitted: &'a dyn Fn(&Path) -> bool,
+    /// Wall clock the grace-period gate measures against.
+    pub now: DateTime<Utc>,
+}
+
+/// Apply every worktree-removal safety gate, in the order `clean.py` /
+/// [`clean_worktrees`] has always applied them, and report the outcome.
+///
+/// Pure decision logic: performs no removal, prints nothing, and mutates
+/// nothing. Callers map the returned [`WorktreeDecision`] onto their own
+/// reporting (stdout for the CLI, `log::` for the daemon reaper) and act only
+/// on [`WorktreeDecision::Remove`].
+#[must_use]
+pub fn classify_worktree(
+    worktree_path: &Path,
+    issue_num: u32,
+    opts: &CleanOptions,
+    probes: &WorktreeProbes<'_>,
+) -> WorktreeDecision {
+    if !opts.force && probes.active_issues.contains(&issue_num) {
+        return WorktreeDecision::SkipInUse(format!(
+            "issue #{issue_num} has a live spawn-loop task or claim-lock"
+        ));
+    }
+
+    if let Some(marker) = (probes.in_use_marker)(worktree_path) {
+        return WorktreeDecision::SkipInUse(format!(
+            "in use by shepherd (task: {}, pid: {})",
+            marker.task_id, marker.pid
+        ));
+    }
+
+    if !opts.force {
+        let active_pids = (probes.processes_using)(worktree_path);
+        if !active_pids.is_empty() {
+            return WorktreeDecision::SkipInUse(format!(
+                "active process(es) using worktree: {active_pids:?}"
+            ));
+        }
+    }
+
+    if !opts.force {
+        let editable_pkgs = (probes.editable_installs)(worktree_path);
+        if !editable_pkgs.is_empty() {
+            return WorktreeDecision::SkipEditable(editable_pkgs.join(", "));
+        }
+    }
+
+    // Sentinel gate (#4876): only the unattended reaper opts into this. It sits
+    // AFTER the in-use gates so a user-provisioned worktree that is also busy
+    // still reports the more specific "in use" reason.
+    if opts.require_managed_sentinel && !(probes.is_managed)(worktree_path) {
+        return WorktreeDecision::SkipUnmanaged;
+    }
+
+    let issue_state = (probes.issue_state)(issue_num);
+    if issue_state != "CLOSED" {
+        return WorktreeDecision::SkipIssueNotClosed(issue_state);
+    }
+
+    if !opts.safe {
+        return WorktreeDecision::ConfirmClosedIssue;
+    }
+
+    match (probes.pr_status)(issue_num) {
+        PrStatus::Merged { merged_at } => {
+            if !opts.force {
+                if let Ok(dt) = DateTime::parse_from_rfc3339(&merged_at) {
+                    let (passed, remaining) = check_grace_period(
+                        dt.with_timezone(&Utc),
+                        opts.grace_period_secs,
+                        probes.now,
+                    );
+                    if !passed {
+                        return WorktreeDecision::SkipGrace(remaining);
+                    }
+                }
+                if (probes.uncommitted)(worktree_path) {
+                    return WorktreeDecision::SkipUncommitted;
+                }
+            }
+            WorktreeDecision::Remove
+        }
+        PrStatus::ClosedNoMerge => {
+            WorktreeDecision::SkipNotMerged("PR closed without merge".to_string())
+        }
+        PrStatus::Open => WorktreeDecision::SkipPrOpen,
+        PrStatus::NoPr => {
+            WorktreeDecision::SkipNotMerged("no PR found for closed issue".to_string())
+        }
+        PrStatus::Unknown => WorktreeDecision::SkipUnknownPrStatus,
+    }
+}
+
+/// Build the production [`WorktreeProbes`] for `repo_root`, wiring each gate to
+/// its real implementation. Split from [`classify_worktree`] so tests can
+/// substitute scripted probes without touching the classifier.
+///
+/// The returned struct borrows `active_issues` and the caller-provided closures
+/// (`issue_state_fn` / `pr_status_fn` capture `repo_root`), which is why those
+/// two are parameters rather than being constructed here.
+#[must_use]
+pub fn production_probes<'a>(
+    active_issues: &'a std::collections::HashSet<u32>,
+    issue_state_fn: &'a dyn Fn(u32) -> String,
+    pr_status_fn: &'a dyn Fn(u32) -> PrStatus,
+    now: DateTime<Utc>,
+) -> WorktreeProbes<'a> {
+    WorktreeProbes {
+        active_issues,
+        in_use_marker: &read_in_use_marker,
+        processes_using: &find_processes_using_directory,
+        editable_installs: &find_editable_pip_installs,
+        is_managed: &is_loom_managed,
+        issue_state: issue_state_fn,
+        pr_status: pr_status_fn,
+        uncommitted: &check_uncommitted_changes,
+        now,
+    }
+}
+
+/// Remove a worktree and delete its feature branch.
+///
+/// Exposed (issue #4876) so the daemon-side reaper performs the *same*
+/// removal the CLI does, including the `git branch -d` → `-D` fallback.
+pub fn cleanup_worktree(
+    repo_root: &Path,
+    worktree_path: &Path,
+    issue_num: u32,
+    dry_run: bool,
+) -> bool {
     let branch_name = naming::branch_name(issue_num);
     if dry_run {
         println!("Would remove: {}", worktree_path.display());
@@ -327,6 +627,10 @@ pub fn clean_worktrees(repo_root: &Path, stats: &mut CleanupStats, opts: &CleanO
         .collect();
     worktree_dirs.sort_by_key(std::fs::DirEntry::path);
 
+    let issue_state_fn = |n: u32| gh::issue_state(repo_root, n);
+    let pr_status_fn = |n: u32| check_pr_merged(repo_root, n);
+    let probes = production_probes(&active_issues, &issue_state_fn, &pr_status_fn, Utc::now());
+
     for entry in worktree_dirs {
         let name = entry.file_name().to_string_lossy().to_string();
         let Some(issue_num) = naming::issue_from_worktree(&name) else {
@@ -336,118 +640,72 @@ pub fn clean_worktrees(repo_root: &Path, stats: &mut CleanupStats, opts: &CleanO
 
         println!("Checking worktree: issue-{issue_num}");
 
-        if !opts.force && active_issues.contains(&issue_num) {
-            println!("  Issue #{issue_num} has a live spawn-loop task or claim-lock - preserving");
-            stats.skipped_in_use += 1;
-            continue;
-        }
-
-        if let Some(marker) = read_in_use_marker(&worktree_path) {
-            println!(
-                "  Worktree in use by shepherd (task: {}, pid: {}) - preserving",
-                marker.task_id, marker.pid
-            );
-            stats.skipped_in_use += 1;
-            continue;
-        }
-
-        if !opts.force {
-            let active_pids = find_processes_using_directory(&worktree_path);
-            if !active_pids.is_empty() {
-                println!("  Active process(es) using worktree: {active_pids:?} - preserving");
+        match classify_worktree(&worktree_path, issue_num, opts, &probes) {
+            WorktreeDecision::SkipInUse(reason) => {
+                println!("  {reason} - preserving");
                 stats.skipped_in_use += 1;
-                continue;
             }
-        }
-
-        let editable_pkgs = find_editable_pip_installs(&worktree_path);
-        if !editable_pkgs.is_empty() {
-            let pkg_list = editable_pkgs.join(", ");
-            if opts.force {
-                println!(
-                    "  Editable pip install(s) found ({pkg_list}) - removing anyway (--force)"
-                );
-            } else {
+            WorktreeDecision::SkipEditable(pkg_list) => {
                 println!("  Editable pip install(s) found ({pkg_list}) - skipping");
                 stats.skipped_editable += 1;
-                continue;
             }
-        }
-
-        let issue_state = gh::issue_state(repo_root, issue_num);
-        if issue_state != "CLOSED" {
-            println!("  Issue #{issue_num} is {issue_state} - preserving");
-            stats.skipped_open += 1;
-            continue;
-        }
-
-        if opts.safe {
-            let pr_status = check_pr_merged(repo_root, issue_num);
-            match pr_status {
-                PrStatus::Merged { merged_at } => {
-                    if !opts.force {
-                        if let Ok(dt) = DateTime::parse_from_rfc3339(&merged_at) {
-                            let (passed, remaining) = check_grace_period(
-                                dt.with_timezone(&Utc),
-                                opts.grace_period_secs,
-                                Utc::now(),
-                            );
-                            if !passed {
-                                println!("  PR merged but grace period not passed ({remaining}s remaining)");
-                                stats.skipped_grace += 1;
-                                continue;
-                            }
-                        }
-                        if check_uncommitted_changes(&worktree_path) {
-                            println!("  Uncommitted changes detected - skipping");
-                            stats.skipped_uncommitted += 1;
-                            continue;
-                        }
-                    }
+            WorktreeDecision::SkipUnmanaged => {
+                println!("  No .loom-managed sentinel (user-provisioned) - preserving");
+                stats.skipped_in_use += 1;
+            }
+            WorktreeDecision::SkipIssueNotClosed(state) => {
+                println!("  Issue #{issue_num} is {state} - preserving");
+                stats.skipped_open += 1;
+            }
+            WorktreeDecision::SkipGrace(remaining) => {
+                println!("  PR merged but grace period not passed ({remaining}s remaining)");
+                stats.skipped_grace += 1;
+            }
+            WorktreeDecision::SkipUncommitted => {
+                println!("  Uncommitted changes detected - skipping");
+                stats.skipped_uncommitted += 1;
+            }
+            WorktreeDecision::SkipNotMerged(reason) => {
+                println!("  {reason} - skipping (may need investigation)");
+                stats.skipped_not_merged += 1;
+            }
+            WorktreeDecision::SkipPrOpen => {
+                println!("  PR still open - skipping");
+                stats.skipped_open += 1;
+            }
+            WorktreeDecision::SkipUnknownPrStatus => {
+                println!("  Unknown PR status - skipping");
+                stats.errors += 1;
+            }
+            WorktreeDecision::Remove => {
+                if cleanup_worktree(repo_root, &worktree_path, issue_num, opts.dry_run) {
+                    stats.cleaned_worktrees += 1;
+                } else {
+                    stats.errors += 1;
+                }
+            }
+            WorktreeDecision::ConfirmClosedIssue => {
+                println!("  Issue #{issue_num} is CLOSED");
+                if opts.dry_run {
+                    println!("  Would remove: {}", entry.path().display());
+                    stats.cleaned_worktrees += 1;
+                } else if opts.force {
+                    println!("  Auto-removing: {}", entry.path().display());
                     if cleanup_worktree(repo_root, &worktree_path, issue_num, opts.dry_run) {
                         stats.cleaned_worktrees += 1;
                     } else {
                         stats.errors += 1;
                     }
-                }
-                PrStatus::ClosedNoMerge => {
-                    println!("  PR closed without merge - skipping (may need investigation)");
-                    stats.skipped_not_merged += 1;
-                }
-                PrStatus::Open => {
-                    println!("  PR still open - skipping");
+                } else if confirm("  Force remove this worktree? [y/N] ") {
+                    if cleanup_worktree(repo_root, &worktree_path, issue_num, opts.dry_run) {
+                        stats.cleaned_worktrees += 1;
+                    } else {
+                        stats.errors += 1;
+                    }
+                } else {
+                    println!("  Skipping: {}", entry.path().display());
                     stats.skipped_open += 1;
                 }
-                PrStatus::NoPr => {
-                    println!("  No PR found for closed issue - skipping");
-                    stats.skipped_not_merged += 1;
-                }
-                PrStatus::Unknown => {
-                    println!("  Unknown PR status - skipping");
-                    stats.errors += 1;
-                }
-            }
-        } else {
-            println!("  Issue #{issue_num} is CLOSED");
-            if opts.dry_run {
-                println!("  Would remove: {}", entry.path().display());
-                stats.cleaned_worktrees += 1;
-            } else if opts.force {
-                println!("  Auto-removing: {}", entry.path().display());
-                if cleanup_worktree(repo_root, &worktree_path, issue_num, opts.dry_run) {
-                    stats.cleaned_worktrees += 1;
-                } else {
-                    stats.errors += 1;
-                }
-            } else if confirm("  Force remove this worktree? [y/N] ") {
-                if cleanup_worktree(repo_root, &worktree_path, issue_num, opts.dry_run) {
-                    stats.cleaned_worktrees += 1;
-                } else {
-                    stats.errors += 1;
-                }
-            } else {
-                println!("  Skipping: {}", entry.path().display());
-                stats.skipped_open += 1;
             }
         }
     }

--- a/loom-daemon/src/worktree_ops/mod.rs
+++ b/loom-daemon/src/worktree_ops/mod.rs
@@ -22,8 +22,8 @@
 pub mod aggressive;
 pub mod claim_file;
 pub mod clean;
-mod gh;
-mod liveness;
+pub(crate) mod gh;
+pub(crate) mod liveness;
 pub mod logs;
 pub(crate) mod naming;
 pub mod orphan_recovery;
@@ -34,3 +34,7 @@ mod spawn_loop_state;
 pub use claim_file::{
     has_valid_claim, is_abandoned as claim_is_abandoned, is_expired as claim_is_expired,
 };
+
+/// Re-exported (issue #4876) because it appears in the public signature of
+/// [`clean::WorktreeProbes`], which the daemon-side reaper constructs.
+pub use safety::InUseMarker;

--- a/loom-daemon/src/worktree_reaper.rs
+++ b/loom-daemon/src/worktree_reaper.rs
@@ -1,0 +1,994 @@
+//! Daemon-side periodic worktree reaper — restores CLAUDE.md's "auto-removed
+//! when their PR merges" contract for merges the merge script never observed
+//! (issue #4876).
+//!
+//! # Why this exists
+//!
+//! Before this module, worktree auto-removal had exactly **one** trigger:
+//! `defaults/scripts/merge-pr.sh`'s `_remove_loom_worktree()`, a *synchronous
+//! side effect* of that script running. That trigger only fires when
+//!
+//! 1. the merge goes through `merge-pr.sh` (not the forge UI, `gh api`, or an
+//!    auto-merge queue), **and**
+//! 2. it runs on the host that holds the worktree, **and**
+//! 3. it runs in the checkout that holds the worktree (`find_main_repo_root()`
+//!    walks up from the invoking shell's cwd — there is no host-wide scan).
+//!
+//! A three-host fleet violates (2) routinely: worker-1 builds issue #N, studio
+//! merges the PR, and worker-1's worktree has nobody to observe the merge.
+//! Nothing in `daemon_service.rs` covered the gap — none of the registered
+//! interval tasks (claim reconciliation, sweep reaper/watchdog, epic
+//! supervisor, work finder, main-health gate, token-ranking refresh,
+//! heartbeat, role runner) called into [`crate::worktree_ops::clean`]. The
+//! observed result: 44 stale worktrees on worker-1 (81% disk, 54G under
+//! `.loom/`) and 35 on studio, 16 of which were merged-PR worktrees eligible
+//! for removal on *each* host.
+//!
+//! This loop closes it: every host independently reaps **its own** worktrees
+//! from *forge state* (is the issue closed? did its PR merge? has the grace
+//! period elapsed?), so it does not matter which host performed the merge, or
+//! whether a merge script ran at all.
+//!
+//! # Safety: strictly a subset of what `clean --safe` would remove
+//!
+//! The decision is [`crate::worktree_ops::clean::classify_worktree`] — the
+//! *same* function the interactive `loom-daemon clean` CLI uses, so there is
+//! no second, drifting copy of the gates. The reaper runs it with
+//! `safe: true, force: false`, which means every one of these preserves a
+//! worktree: a live spawn-loop task or claim-lock, a `.loom-in-use` marker, a
+//! process whose cwd is inside it, an editable pip install pointing into it,
+//! an open issue, an open/unmerged/absent PR, a merge inside the grace period,
+//! and any uncommitted change.
+//!
+//! It adds **one gate the CLI does not have**:
+//! [`CleanOptions::require_managed_sentinel`]. An unattended remover must honor
+//! "user-provisioned worktrees are never removed" — nobody is at the keyboard
+//! to say no — so a worktree without the `.loom-managed` sentinel is skipped
+//! even when every other gate passes.
+//!
+//! Net: the reaper can only ever remove a strict subset of what an operator
+//! running `loom-daemon clean --safe` would remove, which is also what makes
+//! missed cleanups idempotently recoverable — a manual `clean --safe` after
+//! the loop already ran simply finds nothing to do.
+//!
+//! # REST, not GraphQL
+//!
+//! The probes use [`clean::check_pr_merged_rest`] /
+//! `gh::issue_state_rest` rather than the GraphQL-backed
+//! `gh issue view` / `gh pr list`. GraphQL quota exhaustion under concurrent
+//! agents is a live failure mode; an unattended cadence prober must not compete
+//! with interactive agents for the scarcer pool. A REST probe failure resolves
+//! to `UNKNOWN`, which is a *skip*, never a removal.
+//!
+//! # Disk headroom
+//!
+//! Each pass also probes [`crate::disk_headroom::worktree_root_free_gb`] and
+//! logs a `warn!` when free space on the worktree-root volume is below the
+//! configured floor — the metric the dashboard already renders but nothing
+//! acted on. That is the signal that turns "the disk filled and sweeps started
+//! failing with unrelated build errors" into "this host is low on disk".
+//!
+//! # Default-on
+//!
+//! Like [`crate::token_ranking_refresh`] and unlike the work finder /
+//! main-health gate, this loop is **default-on**: it restores a behavior
+//! CLAUDE.md already documents as the contract, and its absence is a
+//! slow-motion outage. Opt out with `LOOM_WORKTREE_REAPER=0` or
+//! `autonomous.worktreeReaper.enabled=false`.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use chrono::Utc;
+
+use crate::workspace_registry::WorkspaceRegistry;
+use crate::worktree_ops::clean::{
+    self, CleanOptions, WorktreeDecision, WorktreeProbes, DEFAULT_GRACE_PERIOD_SECS,
+};
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/// Master on/off env override. Default-on (see module docs): set to
+/// `0`/`false`/`no`/`off` to disable, `1`/`true`/`yes`/`on` to force-enable
+/// even when config disables it.
+pub const WORKTREE_REAPER_ENABLE_ENV: &str = "LOOM_WORKTREE_REAPER";
+
+/// Env override for the reap cadence (seconds).
+pub const WORKTREE_REAPER_INTERVAL_ENV: &str = "LOOM_WORKTREE_REAPER_INTERVAL_SECS";
+
+/// Env override for the low-disk warning floor (GB of free space on the
+/// worktree-root volume).
+pub const WORKTREE_REAPER_DISK_WARN_ENV: &str = "LOOM_WORKTREE_REAPER_DISK_WARN_GB";
+
+/// Default reap cadence (15 minutes). Slow enough that the forge probes are
+/// negligible next to normal sweep traffic, fast enough that a merged
+/// worktree's ~1G of build artifacts is reclaimed the same hour.
+pub const DEFAULT_WORKTREE_REAPER_INTERVAL_SECS: u64 = 900;
+
+/// Default low-disk warning floor (GB). Below this, a host is close enough to
+/// full that a sweep's build can fail with a confusing unrelated error.
+pub const DEFAULT_DISK_WARN_FREE_GB: u64 = 20;
+
+// ============================================================================
+// Config (.loom/config.json → autonomous.worktreeReaper)
+// ============================================================================
+
+/// The subset of `.loom/config.json → autonomous.worktreeReaper` this module
+/// consumes. Every field is `Option` so an absent key falls through to the
+/// env-var / built-in-default resolution — precedence **env > config >
+/// default**, matching every other `autonomous.*` surface.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WorktreeReaperConfig {
+    /// `autonomous.worktreeReaper.enabled` (default **true**).
+    pub enabled: Option<bool>,
+    /// `autonomous.worktreeReaper.intervalSecs` (a zero/invalid value drops to
+    /// `None`).
+    pub interval_secs: Option<u64>,
+    /// `autonomous.worktreeReaper.gracePeriodSecs` — how long after a PR merge
+    /// a worktree becomes eligible. Same knob as `clean --safe`'s
+    /// `--grace-period`.
+    pub grace_period_secs: Option<i64>,
+    /// `autonomous.worktreeReaper.diskWarnFreeGb` — free-GB floor below which
+    /// the pass logs a low-disk warning.
+    pub disk_warn_free_gb: Option<u64>,
+}
+
+/// Read `.loom/config.json → autonomous.worktreeReaper`, soft-failing every
+/// field to `None` (env/default resolution) on a missing file, malformed JSON,
+/// or a missing `autonomous` / `worktreeReaper` block.
+#[must_use]
+pub fn read_worktree_reaper_config(repo_root: &Path) -> WorktreeReaperConfig {
+    let effective = crate::config_resolver::resolve_effective_config(repo_root);
+    let Some(block) = crate::config_resolver::get_path(&effective, "autonomous.worktreeReaper")
+    else {
+        return WorktreeReaperConfig::default();
+    };
+
+    WorktreeReaperConfig {
+        enabled: block.get("enabled").and_then(serde_json::Value::as_bool),
+        interval_secs: block
+            .get("intervalSecs")
+            .and_then(serde_json::Value::as_u64)
+            .filter(|&s| s > 0),
+        grace_period_secs: block
+            .get("gracePeriodSecs")
+            .and_then(serde_json::Value::as_i64)
+            .filter(|&s| s >= 0),
+        disk_warn_free_gb: block
+            .get("diskWarnFreeGb")
+            .and_then(serde_json::Value::as_u64),
+    }
+}
+
+/// Resolve whether the loop runs — precedence **env > config > default(true)**.
+#[must_use]
+pub fn resolve_enabled(config: &WorktreeReaperConfig) -> bool {
+    if let Ok(v) = std::env::var(WORKTREE_REAPER_ENABLE_ENV) {
+        return matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on");
+    }
+    config.enabled.unwrap_or(true)
+}
+
+/// Resolve the reap cadence — precedence **env > config > default**. A zero or
+/// unparseable env value falls through rather than producing a busy loop.
+#[must_use]
+pub fn resolve_interval(config: &WorktreeReaperConfig) -> Duration {
+    std::env::var(WORKTREE_REAPER_INTERVAL_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .or(config.interval_secs)
+        .map_or_else(
+            || Duration::from_secs(DEFAULT_WORKTREE_REAPER_INTERVAL_SECS),
+            Duration::from_secs,
+        )
+}
+
+/// Resolve the post-merge grace period — precedence **config > default**
+/// (there is no dedicated env var; `clean --safe --grace-period` covers the
+/// manual path).
+#[must_use]
+pub fn resolve_grace_period(config: &WorktreeReaperConfig) -> i64 {
+    config
+        .grace_period_secs
+        .unwrap_or(DEFAULT_GRACE_PERIOD_SECS)
+}
+
+/// Resolve the low-disk warning floor — precedence **env > config > default**.
+#[must_use]
+pub fn resolve_disk_warn_free_gb(config: &WorktreeReaperConfig) -> u64 {
+    std::env::var(WORKTREE_REAPER_DISK_WARN_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .or(config.disk_warn_free_gb)
+        .unwrap_or(DEFAULT_DISK_WARN_FREE_GB)
+}
+
+/// The [`CleanOptions`] the reaper always uses: `--safe` semantics, never
+/// `--force`, never a dry run, and the sentinel gate the CLI does not apply.
+#[must_use]
+pub fn reaper_clean_options(grace_period_secs: i64) -> CleanOptions {
+    CleanOptions {
+        dry_run: false,
+        deep: false,
+        force: false,
+        safe: true,
+        grace_period_secs,
+        worktrees_only: true,
+        branches_only: false,
+        tmux_only: false,
+        require_managed_sentinel: true,
+    }
+}
+
+// ============================================================================
+// One reap pass
+// ============================================================================
+
+/// What one reap pass over one repo did.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReapReport {
+    /// `issue-<N>` worktree directories examined.
+    pub scanned: usize,
+    /// Issue numbers whose worktrees were removed.
+    pub removed: Vec<u32>,
+    /// Issue numbers whose removal was attempted but failed.
+    pub failed: Vec<u32>,
+    /// Worktrees a safety gate preserved, keyed by the gate's own wording.
+    pub skipped: Vec<(u32, String)>,
+    /// Free GB on the worktree-root volume, or `None` when unmeasurable
+    /// (#4164 — unknown is never treated as zero).
+    pub free_gb: Option<u64>,
+}
+
+impl ReapReport {
+    /// A compact one-line summary for the daemon log.
+    #[must_use]
+    pub fn summary(&self) -> String {
+        format!(
+            "scanned={} removed={} failed={} skipped={}",
+            self.scanned,
+            self.removed.len(),
+            self.failed.len(),
+            self.skipped.len()
+        )
+    }
+}
+
+/// Human-readable reason a decision preserved a worktree. `None` for
+/// [`WorktreeDecision::Remove`].
+#[must_use]
+fn skip_reason(decision: &WorktreeDecision) -> Option<String> {
+    match decision {
+        WorktreeDecision::Remove => None,
+        WorktreeDecision::SkipInUse(reason) => Some(reason.clone()),
+        WorktreeDecision::SkipEditable(pkgs) => Some(format!("editable pip install(s): {pkgs}")),
+        WorktreeDecision::SkipUnmanaged => {
+            Some("no .loom-managed sentinel (user-provisioned)".to_string())
+        }
+        WorktreeDecision::SkipIssueNotClosed(state) => Some(format!("issue is {state}")),
+        WorktreeDecision::SkipGrace(remaining) => {
+            Some(format!("grace period not passed ({remaining}s remaining)"))
+        }
+        WorktreeDecision::SkipUncommitted => Some("uncommitted changes".to_string()),
+        WorktreeDecision::SkipNotMerged(reason) => Some(reason.clone()),
+        WorktreeDecision::SkipPrOpen => Some("PR still open".to_string()),
+        WorktreeDecision::SkipUnknownPrStatus => Some("PR status unknown".to_string()),
+        // Unreachable with the reaper's `safe: true` options, but a
+        // non-`--safe` caller must never be interpreted as "remove it".
+        WorktreeDecision::ConfirmClosedIssue => {
+            Some("needs confirmation (non-safe mode)".to_string())
+        }
+    }
+}
+
+/// Enumerate `issue-<N>` worktrees under `repo_root`'s worktree root, classify
+/// each with [`clean::classify_worktree`], and remove the eligible ones via
+/// `remove`.
+///
+/// The probes and the remover are injected so the whole pass is unit-testable
+/// without a forge, a process table, or real `git worktree` state — production
+/// wiring lives in [`reap_repo`].
+pub fn reap_worktrees(
+    repo_root: &Path,
+    opts: &CleanOptions,
+    probes: &WorktreeProbes<'_>,
+    remove: &dyn Fn(&Path, u32) -> bool,
+) -> ReapReport {
+    let mut report = ReapReport::default();
+
+    let worktrees_dir = crate::worktree_root::worktree_root(repo_root);
+    let Ok(entries) = std::fs::read_dir(&worktrees_dir) else {
+        // No worktree root yet (or unreadable) — nothing to reap, not an error.
+        return report;
+    };
+
+    let mut worktree_dirs: Vec<_> = entries
+        .flatten()
+        .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
+        .collect();
+    worktree_dirs.sort_by_key(std::fs::DirEntry::path);
+
+    for entry in worktree_dirs {
+        let name = entry.file_name().to_string_lossy().to_string();
+        let Some(issue_num) = crate::worktree_ops::naming::issue_from_worktree(&name) else {
+            continue;
+        };
+        report.scanned += 1;
+
+        let worktree_path = entry.path().canonicalize().unwrap_or_else(|_| entry.path());
+        let decision = clean::classify_worktree(&worktree_path, issue_num, opts, probes);
+
+        if let Some(reason) = skip_reason(&decision) {
+            report.skipped.push((issue_num, reason));
+            continue;
+        }
+
+        if remove(&worktree_path, issue_num) {
+            report.removed.push(issue_num);
+        } else {
+            report.failed.push(issue_num);
+        }
+    }
+
+    report
+}
+
+/// Run one production reap pass over `repo_root`.
+///
+/// Wires the real probes (REST-first forge lookups — see the module docs) and
+/// the real remover ([`clean::cleanup_worktree`]), then layers the disk-headroom
+/// probe on top.
+pub fn reap_repo(repo_root: &Path, config: &WorktreeReaperConfig) -> ReapReport {
+    let opts = reaper_clean_options(resolve_grace_period(config));
+    let active_issues = crate::worktree_ops::liveness::active_spawn_loop_issues(repo_root);
+
+    // Resolved once per pass (one REST call), not once per worktree.
+    let owner = clean::repo_owner_rest(repo_root);
+
+    let issue_state_fn = |n: u32| crate::worktree_ops::gh::issue_state_rest(repo_root, n);
+    let pr_status_fn = |n: u32| match owner.as_deref() {
+        Some(owner) => clean::check_pr_merged_rest(repo_root, owner, n),
+        // No owner ⇒ no REST head filter is constructible; fall back to the
+        // GraphQL-backed probe rather than silently reporting Unknown forever.
+        None => clean::check_pr_merged(repo_root, n),
+    };
+
+    let probes =
+        clean::production_probes(&active_issues, &issue_state_fn, &pr_status_fn, Utc::now());
+    let remover = |path: &Path, issue: u32| clean::cleanup_worktree(repo_root, path, issue, false);
+
+    let mut report = reap_worktrees(repo_root, &opts, &probes, &remover);
+    report.free_gb = crate::disk_headroom::worktree_root_free_gb(repo_root);
+    report
+}
+
+/// Log a pass's outcome, including the low-disk warning (the acceptance
+/// criterion that a host approaching a disk threshold surfaces it).
+pub fn log_report(repo_root: &Path, report: &ReapReport, warn_below_gb: u64) {
+    if report.removed.is_empty() && report.failed.is_empty() {
+        log::debug!(
+            "worktree_reaper: {} nothing to reap ({})",
+            repo_root.display(),
+            report.summary()
+        );
+    } else {
+        log::info!(
+            "worktree_reaper: {} {} removed={:?}",
+            repo_root.display(),
+            report.summary(),
+            report.removed
+        );
+    }
+    for (issue, reason) in &report.skipped {
+        log::debug!("worktree_reaper: {} preserving issue-{issue}: {reason}", repo_root.display());
+    }
+    if !report.failed.is_empty() {
+        log::warn!(
+            "worktree_reaper: {} could not remove worktrees for {:?} — a manual \
+             `loom-daemon clean --safe` will retry idempotently",
+            repo_root.display(),
+            report.failed
+        );
+    }
+    match report.free_gb {
+        Some(free) if free < warn_below_gb => log::warn!(
+            "worktree_reaper: {} LOW DISK — {free}G free on the worktree-root volume \
+             (floor {warn_below_gb}G, {} worktree(s) still present). Sweeps on this host \
+             will start failing with unrelated build errors before they report \
+             'out of space'; run `loom-daemon clean --safe --deep` or raise \
+             autonomous.worktreeReaper.diskWarnFreeGb if this is expected.",
+            repo_root.display(),
+            report.scanned - report.removed.len()
+        ),
+        Some(free) => log::debug!(
+            "worktree_reaper: {} {free}G free on the worktree-root volume",
+            repo_root.display()
+        ),
+        None => log::debug!(
+            "worktree_reaper: {} worktree-root free space unmeasurable — skipping the \
+             low-disk check (unknown != zero)",
+            repo_root.display()
+        ),
+    }
+}
+
+// ============================================================================
+// Runtime wiring
+// ============================================================================
+
+/// Spawn the **multi-workspace** worktree reaper loop on the shared daemon
+/// runtime (mirrors [`crate::token_ranking_refresh::spawn_multi_token_ranking_refresh_task`]).
+///
+/// Every `interval` it re-reads [`WorkspaceRegistry::effective_roots`] against
+/// `fallback_root` (an empty registry ⇒ the single `fallback_root`) and reaps
+/// **every registered repo**, each gated by that repo's own
+/// `autonomous.worktreeReaper.enabled`. This is what makes cleanup independent
+/// of "the daemon's attached workspace": a host whose daemon is attached to
+/// `~/GitHub/anvil` still reaps `~/GitHub/loom` as long as that repo is a
+/// registered workspace.
+///
+/// Passes run **sequentially** per tick (like the health gate and the ranking
+/// refresh): each one shells out to `gh` and `git`, and bursting several repos'
+/// forge probes at once buys nothing.
+///
+/// The first tick is **skipped** (unlike the ranking refresh): a reap has a
+/// destructive side effect, and deferring it one cadence lets a just-restarted
+/// daemon's own in-flight sweeps re-establish their `.loom-in-use` markers and
+/// claim-locks before anything is evaluated for removal.
+pub fn spawn_multi_worktree_reaper_task(
+    fallback_root: PathBuf,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    log::info!(
+        "worktree_reaper: starting multi-workspace loop (interval={}s)",
+        interval.as_secs()
+    );
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // Skip the immediate first tick — see the doc comment.
+        ticker.tick().await;
+
+        loop {
+            ticker.tick().await;
+
+            let roots = WorkspaceRegistry::load_default()
+                .unwrap_or_else(|e| {
+                    log::warn!(
+                        "worktree_reaper: could not load workspace registry ({e}); using fallback"
+                    );
+                    WorkspaceRegistry::default()
+                })
+                .effective_roots(&fallback_root);
+
+            for root in roots {
+                let config = read_worktree_reaper_config(&root);
+                if !resolve_enabled(&config) {
+                    log::debug!(
+                        "worktree_reaper: {} disabled (autonomous.worktreeReaper.enabled=false \
+                         or LOOM_WORKTREE_REAPER unset-falsy) — skipping",
+                        root.display()
+                    );
+                    continue;
+                }
+                let warn_below_gb = resolve_disk_warn_free_gb(&config);
+                let root_for_task = root.clone();
+                let joined =
+                    tokio::task::spawn_blocking(move || reap_repo(&root_for_task, &config)).await;
+                match joined {
+                    Ok(report) => log_report(&root, &report, warn_below_gb),
+                    Err(e) => log::error!(
+                        "worktree_reaper: pass for {} panicked ({e}); continuing to the next repo",
+                        root.display()
+                    ),
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::worktree_ops::clean::PrStatus;
+    use crate::worktree_ops::InUseMarker;
+    use serial_test::serial;
+    use std::collections::HashSet;
+    use std::fs;
+    use std::sync::{Arc, Mutex};
+
+    // ===================================================================
+    // Test fixtures
+    // ===================================================================
+
+    /// Build a repo root with `.loom/worktrees/issue-<N>` directories, each
+    /// carrying a `.loom-managed` sentinel unless `managed` says otherwise.
+    fn make_repo(issues: &[(u32, bool)]) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        for (issue, managed) in issues {
+            let wt = tmp
+                .path()
+                .join(".loom/worktrees")
+                .join(format!("issue-{issue}"));
+            fs::create_dir_all(&wt).unwrap();
+            if *managed {
+                fs::write(wt.join(".loom-managed"), "").unwrap();
+            }
+        }
+        tmp
+    }
+
+    struct ProbeSpec {
+        active: HashSet<u32>,
+        issue_state: String,
+        pr_status: PrStatus,
+        uncommitted: bool,
+        in_use: bool,
+        editable: Vec<String>,
+    }
+
+    impl Default for ProbeSpec {
+        fn default() -> Self {
+            Self {
+                active: HashSet::new(),
+                issue_state: "CLOSED".to_string(),
+                pr_status: PrStatus::Merged {
+                    // Well outside any sane grace period.
+                    merged_at: "2020-01-01T00:00:00Z".to_string(),
+                },
+                uncommitted: false,
+                in_use: false,
+                editable: Vec::new(),
+            }
+        }
+    }
+
+    /// Run a full reap pass against `repo` with scripted probes, recording
+    /// which worktrees the (fake) remover was asked to delete.
+    fn run_pass(repo: &Path, spec: &ProbeSpec, opts: &CleanOptions) -> (ReapReport, Vec<u32>) {
+        let removed = Arc::new(Mutex::new(Vec::new()));
+        let in_use_marker = |_: &Path| {
+            spec.in_use.then(|| InUseMarker {
+                task_id: "t".to_string(),
+                pid: "1".to_string(),
+            })
+        };
+        let processes_using = |_: &Path| Vec::new();
+        let editable_installs = |_: &Path| spec.editable.clone();
+        let is_managed = |p: &Path| clean::is_loom_managed(p);
+        let issue_state = |_: u32| spec.issue_state.clone();
+        let pr_status = |_: u32| spec.pr_status.clone();
+        let uncommitted = |_: &Path| spec.uncommitted;
+
+        let probes = WorktreeProbes {
+            active_issues: &spec.active,
+            in_use_marker: &in_use_marker,
+            processes_using: &processes_using,
+            editable_installs: &editable_installs,
+            is_managed: &is_managed,
+            issue_state: &issue_state,
+            pr_status: &pr_status,
+            uncommitted: &uncommitted,
+            now: Utc::now(),
+        };
+
+        let recorder = removed.clone();
+        let remover = move |_: &Path, issue: u32| {
+            recorder.lock().unwrap().push(issue);
+            true
+        };
+
+        let report = reap_worktrees(repo, opts, &probes, &remover);
+        let removed = removed.lock().unwrap().clone();
+        (report, removed)
+    }
+
+    fn default_opts() -> CleanOptions {
+        reaper_clean_options(DEFAULT_GRACE_PERIOD_SECS)
+    }
+
+    // ===================================================================
+    // The core defect: a merged PR's worktree is reclaimed with no manual
+    // `clean` and no merge-pr.sh side effect on this host.
+    // ===================================================================
+
+    #[test]
+    fn test_merged_pr_worktree_is_reaped_without_a_manual_clean() {
+        let repo = make_repo(&[(100, true), (101, true)]);
+        let (report, removed) = run_pass(repo.path(), &ProbeSpec::default(), &default_opts());
+        assert_eq!(report.scanned, 2);
+        assert_eq!(removed, vec![100, 101]);
+        assert_eq!(report.removed, vec![100, 101]);
+        assert!(report.failed.is_empty());
+        assert!(report.skipped.is_empty());
+    }
+
+    #[test]
+    fn test_reap_is_idempotent_second_pass_finds_nothing() {
+        // The remover is a fake, so simulate the real effect by deleting the
+        // directory ourselves and re-running: a second pass must be a no-op
+        // and report zero failures (`clean --safe` idempotency, preserved).
+        let repo = make_repo(&[(100, true)]);
+        let (first, _) = run_pass(repo.path(), &ProbeSpec::default(), &default_opts());
+        assert_eq!(first.removed, vec![100]);
+
+        fs::remove_dir_all(repo.path().join(".loom/worktrees/issue-100")).unwrap();
+        let (second, removed) = run_pass(repo.path(), &ProbeSpec::default(), &default_opts());
+        assert_eq!(second.scanned, 0);
+        assert!(removed.is_empty());
+        assert!(second.failed.is_empty());
+    }
+
+    #[test]
+    fn test_missing_worktree_root_is_a_clean_no_op() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (report, removed) = run_pass(tmp.path(), &ProbeSpec::default(), &default_opts());
+        assert_eq!(report, ReapReport::default());
+        assert!(removed.is_empty());
+    }
+
+    // ===================================================================
+    // Safety gates — the reaper must never out-delete `clean --safe`
+    // ===================================================================
+
+    #[test]
+    fn test_unmanaged_worktree_is_never_reaped() {
+        // No `.loom-managed` sentinel ⇒ user-provisioned ⇒ preserved even
+        // though every other gate says "removable".
+        let repo = make_repo(&[(200, false)]);
+        let (report, removed) = run_pass(repo.path(), &ProbeSpec::default(), &default_opts());
+        assert!(removed.is_empty());
+        assert_eq!(report.skipped.len(), 1);
+        assert!(report.skipped[0].1.contains(".loom-managed"), "{:?}", report.skipped);
+    }
+
+    #[test]
+    fn test_open_pr_worktree_is_never_reaped() {
+        let repo = make_repo(&[(300, true)]);
+        let spec = ProbeSpec {
+            pr_status: PrStatus::Open,
+            ..ProbeSpec::default()
+        };
+        let (report, removed) = run_pass(repo.path(), &spec, &default_opts());
+        assert!(removed.is_empty());
+        assert_eq!(report.skipped[0].1, "PR still open");
+    }
+
+    #[test]
+    fn test_unmerged_and_absent_pr_worktrees_are_never_reaped() {
+        for (status, expect) in [
+            (PrStatus::ClosedNoMerge, "PR closed without merge"),
+            (PrStatus::NoPr, "no PR found for closed issue"),
+            (PrStatus::Unknown, "PR status unknown"),
+        ] {
+            let repo = make_repo(&[(301, true)]);
+            let spec = ProbeSpec {
+                pr_status: status,
+                ..ProbeSpec::default()
+            };
+            let (report, removed) = run_pass(repo.path(), &spec, &default_opts());
+            assert!(removed.is_empty(), "{expect}");
+            assert_eq!(report.skipped[0].1, expect);
+        }
+    }
+
+    #[test]
+    fn test_open_issue_worktree_is_never_reaped() {
+        let repo = make_repo(&[(302, true)]);
+        let spec = ProbeSpec {
+            issue_state: "OPEN".to_string(),
+            ..ProbeSpec::default()
+        };
+        let (_, removed) = run_pass(repo.path(), &spec, &default_opts());
+        assert!(removed.is_empty());
+    }
+
+    #[test]
+    fn test_uncommitted_changes_block_the_reap() {
+        let repo = make_repo(&[(303, true)]);
+        let spec = ProbeSpec {
+            uncommitted: true,
+            ..ProbeSpec::default()
+        };
+        let (report, removed) = run_pass(repo.path(), &spec, &default_opts());
+        assert!(removed.is_empty());
+        assert_eq!(report.skipped[0].1, "uncommitted changes");
+    }
+
+    #[test]
+    fn test_in_use_marker_blocks_the_reap() {
+        let repo = make_repo(&[(304, true)]);
+        let spec = ProbeSpec {
+            in_use: true,
+            ..ProbeSpec::default()
+        };
+        let (report, removed) = run_pass(repo.path(), &spec, &default_opts());
+        assert!(removed.is_empty());
+        assert!(report.skipped[0].1.contains("in use by shepherd"));
+    }
+
+    #[test]
+    fn test_live_claim_blocks_the_reap() {
+        let repo = make_repo(&[(305, true)]);
+        let spec = ProbeSpec {
+            active: HashSet::from([305]),
+            ..ProbeSpec::default()
+        };
+        let (report, removed) = run_pass(repo.path(), &spec, &default_opts());
+        assert!(removed.is_empty());
+        assert!(report.skipped[0]
+            .1
+            .contains("spawn-loop task or claim-lock"));
+    }
+
+    #[test]
+    fn test_editable_install_blocks_the_reap() {
+        let repo = make_repo(&[(306, true)]);
+        let spec = ProbeSpec {
+            editable: vec!["loom-tools".to_string()],
+            ..ProbeSpec::default()
+        };
+        let (report, removed) = run_pass(repo.path(), &spec, &default_opts());
+        assert!(removed.is_empty());
+        assert!(report.skipped[0].1.contains("loom-tools"));
+    }
+
+    #[test]
+    fn test_grace_period_defers_a_just_merged_pr() {
+        let repo = make_repo(&[(307, true)]);
+        let spec = ProbeSpec {
+            pr_status: PrStatus::Merged {
+                merged_at: Utc::now().to_rfc3339(),
+            },
+            ..ProbeSpec::default()
+        };
+        let (report, removed) = run_pass(repo.path(), &spec, &default_opts());
+        assert!(removed.is_empty());
+        assert!(report.skipped[0].1.contains("grace period not passed"));
+    }
+
+    #[test]
+    fn test_non_issue_directories_are_ignored() {
+        let repo = make_repo(&[(400, true)]);
+        fs::create_dir_all(repo.path().join(".loom/worktrees/scratch")).unwrap();
+        fs::create_dir_all(repo.path().join(".loom/worktrees/issue-abc")).unwrap();
+        let (report, removed) = run_pass(repo.path(), &ProbeSpec::default(), &default_opts());
+        assert_eq!(report.scanned, 1);
+        assert_eq!(removed, vec![400]);
+    }
+
+    #[test]
+    fn test_failed_removal_is_reported_not_silently_counted_as_removed() {
+        let repo = make_repo(&[(500, true)]);
+        let spec = ProbeSpec::default();
+        let opts = default_opts();
+        let active = HashSet::new();
+        let in_use_marker = |_: &Path| None;
+        let processes_using = |_: &Path| Vec::new();
+        let editable_installs = |_: &Path| Vec::new();
+        let is_managed = |p: &Path| clean::is_loom_managed(p);
+        let issue_state = |_: u32| spec.issue_state.clone();
+        let pr_status = |_: u32| spec.pr_status.clone();
+        let uncommitted = |_: &Path| false;
+        let probes = WorktreeProbes {
+            active_issues: &active,
+            in_use_marker: &in_use_marker,
+            processes_using: &processes_using,
+            editable_installs: &editable_installs,
+            is_managed: &is_managed,
+            issue_state: &issue_state,
+            pr_status: &pr_status,
+            uncommitted: &uncommitted,
+            now: Utc::now(),
+        };
+        let report = reap_worktrees(repo.path(), &opts, &probes, &|_, _| false);
+        assert!(report.removed.is_empty());
+        assert_eq!(report.failed, vec![500]);
+    }
+
+    // ===================================================================
+    // Reaper options — the invariant the safety argument rests on
+    // ===================================================================
+
+    #[test]
+    fn test_reaper_options_are_safe_never_forced_and_sentinel_gated() {
+        let opts = reaper_clean_options(DEFAULT_GRACE_PERIOD_SECS);
+        assert!(opts.safe, "the reaper must use --safe semantics");
+        assert!(!opts.force, "the reaper must never bypass the safety gates");
+        assert!(!opts.dry_run);
+        assert!(
+            opts.require_managed_sentinel,
+            "an unattended remover must honor the .loom-managed sentinel"
+        );
+        assert_eq!(opts.grace_period_secs, DEFAULT_GRACE_PERIOD_SECS);
+    }
+
+    // ===================================================================
+    // Config surface — autonomous.worktreeReaper
+    // ===================================================================
+
+    fn write_config(root: &Path, contents: &str) {
+        fs::create_dir_all(root.join(".loom")).unwrap();
+        fs::write(root.join(".loom").join("config.json"), contents).unwrap();
+    }
+
+    #[test]
+    fn test_config_missing_file_is_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(read_worktree_reaper_config(tmp.path()), WorktreeReaperConfig::default());
+    }
+
+    #[test]
+    fn test_config_malformed_json_is_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), "{not valid json");
+        assert_eq!(read_worktree_reaper_config(tmp.path()), WorktreeReaperConfig::default());
+    }
+
+    #[test]
+    fn test_config_missing_block_is_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"autonomous": {"workFinder": {"enabled": true}}}"#);
+        assert_eq!(read_worktree_reaper_config(tmp.path()), WorktreeReaperConfig::default());
+    }
+
+    #[test]
+    fn test_config_reads_every_knob() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(
+            tmp.path(),
+            r#"{"autonomous": {"worktreeReaper": {"enabled": false, "intervalSecs": 120,
+               "gracePeriodSecs": 30, "diskWarnFreeGb": 5}}}"#,
+        );
+        assert_eq!(
+            read_worktree_reaper_config(tmp.path()),
+            WorktreeReaperConfig {
+                enabled: Some(false),
+                interval_secs: Some(120),
+                grace_period_secs: Some(30),
+                disk_warn_free_gb: Some(5),
+            }
+        );
+    }
+
+    #[test]
+    fn test_config_zero_interval_is_dropped_to_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"autonomous": {"worktreeReaper": {"intervalSecs": 0}}}"#);
+        assert_eq!(read_worktree_reaper_config(tmp.path()).interval_secs, None);
+    }
+
+    // ===================================================================
+    // Precedence — env > config > default
+    // ===================================================================
+
+    #[test]
+    #[serial]
+    fn test_resolve_enabled_default_is_true() {
+        std::env::remove_var(WORKTREE_REAPER_ENABLE_ENV);
+        assert!(
+            resolve_enabled(&WorktreeReaperConfig::default()),
+            "the reaper restores a documented contract — absent config leaves it ON"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_enabled_env_overrides_config() {
+        std::env::set_var(WORKTREE_REAPER_ENABLE_ENV, "0");
+        assert!(!resolve_enabled(&WorktreeReaperConfig {
+            enabled: Some(true),
+            ..WorktreeReaperConfig::default()
+        }));
+        std::env::set_var(WORKTREE_REAPER_ENABLE_ENV, "1");
+        assert!(resolve_enabled(&WorktreeReaperConfig {
+            enabled: Some(false),
+            ..WorktreeReaperConfig::default()
+        }));
+        std::env::remove_var(WORKTREE_REAPER_ENABLE_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_enabled_config_can_disable() {
+        std::env::remove_var(WORKTREE_REAPER_ENABLE_ENV);
+        assert!(!resolve_enabled(&WorktreeReaperConfig {
+            enabled: Some(false),
+            ..WorktreeReaperConfig::default()
+        }));
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_interval_precedence() {
+        std::env::remove_var(WORKTREE_REAPER_INTERVAL_ENV);
+        assert_eq!(
+            resolve_interval(&WorktreeReaperConfig::default()),
+            Duration::from_secs(DEFAULT_WORKTREE_REAPER_INTERVAL_SECS)
+        );
+        let cfg = WorktreeReaperConfig {
+            interval_secs: Some(300),
+            ..WorktreeReaperConfig::default()
+        };
+        assert_eq!(resolve_interval(&cfg), Duration::from_secs(300));
+        std::env::set_var(WORKTREE_REAPER_INTERVAL_ENV, "45");
+        assert_eq!(resolve_interval(&cfg), Duration::from_secs(45));
+        // Zero/garbage env falls through to config, not to the default.
+        std::env::set_var(WORKTREE_REAPER_INTERVAL_ENV, "0");
+        assert_eq!(resolve_interval(&cfg), Duration::from_secs(300));
+        std::env::set_var(WORKTREE_REAPER_INTERVAL_ENV, "garbage");
+        assert_eq!(resolve_interval(&cfg), Duration::from_secs(300));
+        std::env::remove_var(WORKTREE_REAPER_INTERVAL_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_disk_warn_free_gb_precedence() {
+        std::env::remove_var(WORKTREE_REAPER_DISK_WARN_ENV);
+        assert_eq!(
+            resolve_disk_warn_free_gb(&WorktreeReaperConfig::default()),
+            DEFAULT_DISK_WARN_FREE_GB
+        );
+        let cfg = WorktreeReaperConfig {
+            disk_warn_free_gb: Some(7),
+            ..WorktreeReaperConfig::default()
+        };
+        assert_eq!(resolve_disk_warn_free_gb(&cfg), 7);
+        std::env::set_var(WORKTREE_REAPER_DISK_WARN_ENV, "3");
+        assert_eq!(resolve_disk_warn_free_gb(&cfg), 3);
+        std::env::remove_var(WORKTREE_REAPER_DISK_WARN_ENV);
+    }
+
+    #[test]
+    fn test_resolve_grace_period_default_and_config() {
+        assert_eq!(
+            resolve_grace_period(&WorktreeReaperConfig::default()),
+            DEFAULT_GRACE_PERIOD_SECS
+        );
+        assert_eq!(
+            resolve_grace_period(&WorktreeReaperConfig {
+                grace_period_secs: Some(42),
+                ..WorktreeReaperConfig::default()
+            }),
+            42
+        );
+    }
+
+    // ===================================================================
+    // Reporting
+    // ===================================================================
+
+    #[test]
+    fn test_summary_is_compact_and_complete() {
+        let report = ReapReport {
+            scanned: 5,
+            removed: vec![1, 2],
+            failed: vec![3],
+            skipped: vec![(4, "PR still open".to_string())],
+            free_gb: Some(10),
+        };
+        assert_eq!(report.summary(), "scanned=5 removed=2 failed=1 skipped=1");
+    }
+
+    #[test]
+    fn test_log_report_handles_every_disk_probe_shape() {
+        // Smoke: no panics on the warn / ok / unmeasurable branches (the
+        // low-disk warning is the only consumer of `free_gb`).
+        let tmp = tempfile::tempdir().unwrap();
+        for free_gb in [Some(1), Some(1000), None] {
+            log_report(
+                tmp.path(),
+                &ReapReport {
+                    scanned: 1,
+                    free_gb,
+                    ..ReapReport::default()
+                },
+                DEFAULT_DISK_WARN_FREE_GB,
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Restores CLAUDE.md's documented contract ("Loom-managed worktrees ... are auto-removed when their PR merges") for merges that the invoking `merge-pr.sh` never observed. Before this PR, worktree auto-removal had exactly one trigger: `merge-pr.sh`'s synchronous `_remove_loom_worktree()`, which only fires when the merge happens (1) via that script, (2) on the host holding the worktree, and (3) in the checkout holding the worktree. A three-host fleet violates this routinely — worker-1 builds issue #N, studio merges the PR, worker-1's worktree has nobody to observe the merge. Observed impact: 44 stale worktrees on `loom-worker-1` (81% disk, 54G) and 35 on the primary host (`studio`, 66G), 16 of which on each host were merged-PR worktrees eligible for removal.

## Root Cause

Confirmed by reading `daemon_service.rs`'s registered `tokio::spawn`/interval tasks (claim reconciliation, sweep reaper/watchdog, epic supervisor, work finder, main-health gate, token-ranking refresh, heartbeat, role runner): **none** call into `worktree_ops::clean`. Auto-removal only ever happens as a side effect of `merge-pr.sh` running in a given repo's checkout for that one PR. Any host/repo where merges happen without that script running (forge UI, `gh api`, an auto-merge queue) — or where the daemon itself was down during the merge window (#4862) — accumulates worktrees indefinitely, with no daemon-level fallback. This rules out the issue's leading hypothesis ("cleanup is scoped to the daemon's attached workspace") — the primary host's daemon *is* attached to the repo holding the leaked worktrees, and it still leaked.

## Changes

- **`loom-daemon/src/worktree_ops/clean.rs`**: extracted the worktree-removal safety-gate chain (live claim/spawn-loop lock, `.loom-in-use` marker, active process, editable pip install, issue-closed state, PR merge status, grace period, uncommitted changes) out of `clean_worktrees()` into a pure, injectable `classify_worktree()` / `WorktreeProbes` pair, so the decision has one implementation shared by the CLI and the new reaper. Added a REST-based PR-merge probe (`check_pr_merged_rest` / `repo_owner_rest`) as an alternative to the existing GraphQL-backed `check_pr_merged`, and a new `CleanOptions::require_managed_sentinel` gate.
- **`loom-daemon/src/worktree_reaper.rs`** (new): the daemon-side periodic reaper. On a 15-minute cadence (configurable) it walks every registered workspace (`WorkspaceRegistry::effective_roots`), enumerates `issue-<N>` worktrees, classifies each via the shared `classify_worktree` with `safe: true, force: false, require_managed_sentinel: true`, and removes eligible ones. Probes forge state via REST (not GraphQL) to avoid competing with interactive agents for the scarcer GraphQL quota. Logs a low-disk warning using the existing `worktree_root_free_gb()` metric. Default-on, configurable via `autonomous.worktreeReaper.{enabled,intervalSecs,gracePeriodSecs,diskWarnFreeGb}` and `LOOM_WORKTREE_REAPER*` env overrides.
- **`loom-daemon/src/daemon_service.rs`**: registers the new reaper as a `tokio::spawn` task alongside the other periodic loops.
- **`loom-daemon/src/cli/cleanup_ops.rs`**: interactive `loom-daemon clean` CLI keeps its historical behavior (`require_managed_sentinel: false`) — an operator who typed the command is the authority.
- **`loom-daemon/src/worktree_ops/mod.rs`**: visibility adjustments (`gh`/`liveness` now `pub(crate)`, `InUseMarker` re-exported) needed for the shared probe types.
- **`CLAUDE.md`** / **`defaults/docs/daemon-reference.md`**: documents the new reaper and its config surface.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| A merged sweep's worktree is removed without a manual `clean`, including when the merge is observed by a different host than the one holding the worktree | ✅ | The reaper decides purely from *forge state* (issue closed? PR merged? grace period elapsed?) via REST probes — it never depends on which host/process performed the merge. `test_merged_pr_worktree_is_reaped_without_a_manual_clean` covers this directly. |
| Cleanup is not limited to the daemon's attached workspace, or that limitation is documented and a periodic sweep covers the rest | ✅ | `spawn_multi_worktree_reaper_task` re-reads `WorkspaceRegistry::effective_roots()` every tick and reaps *every registered repo*, mirroring `token_ranking_refresh`'s existing multi-workspace pattern — a daemon attached to `~/GitHub/anvil` still reaps `~/GitHub/loom` if it's registered. Documented in `daemon-reference.md` (a repo that is not registered is still not reaped; that residual gap is called out explicitly). |
| A host approaching a disk threshold surfaces it (the dashboard already renders `worktree_root_free_gb`; nothing acts on it) | 🟡 Partial | Each reap pass now logs a `WARN` via `log_report()` when free space drops below `autonomous.worktreeReaper.diskWarnFreeGb` (default 20G), using the existing `worktree_root_free_gb()` metric. This makes the condition visible in the daemon log, which is a real improvement over silence — but it does **not** wire a dashboard-side alert/threshold on the already-rendered metric. That remains open; `daemon-reference.md` documents the gap. |
| Missed cleanups are recoverable idempotently — `clean --safe` already is; keep it that way | ✅ | The reaper's decision logic *is* `clean --safe`'s logic (same `classify_worktree` function), so a missed/failed reap pass is always recoverable by a manual `loom-daemon clean --safe`. `test_reap_is_idempotent_second_pass_finds_nothing` and `test_failed_removal_is_reported_not_silently_counted_as_removed` cover this. |

## Pre-existing Issues (Not Addressed)

`cargo clippy --all-targets -- -D warnings` fails on an unrelated, pre-existing lint in `loom-daemon/src/terminal.rs:2590` (`unnecessary_get_then_check`, predates this branch — confirmed via `git log`/`git blame`, not touched by this diff). Not fixed here to keep this PR scoped.

## Test Plan

- `cargo check --all-targets` — clean.
- `cargo test --lib worktree_reaper` — 28/28 passing, covering: the core defect (reap without manual clean), idempotency of a second pass, every safety gate (unmanaged sentinel, open PR, unmerged/absent PR, open issue, uncommitted changes, in-use marker, live claim, editable install, grace period), non-issue directories ignored, failed-removal reporting, the reaper's fixed `CleanOptions` invariants (safe/never-forced/sentinel-gated), config parsing (missing file/malformed JSON/missing block/every knob/zero-interval), env>config>default precedence for `enabled`/`intervalSecs`/`diskWarnFreeGb`, and `log_report`'s three disk-probe shapes.
- `cargo test --lib worktree_ops::clean` — 19/19 passing (pre-existing `clean` module tests, confirming the refactor didn't regress existing behavior).
- `cargo fmt --check` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean except the pre-existing unrelated failure noted above.

Closes #4876
