### PR TITLE
ci: build and test loom-daemon with --features otlp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,29 @@ jobs:
       - name: Run doctests
         run: cargo test --workspace --doc
 
+  backend-otlp-feature:
+    name: Rust OTLP Feature Build & Test
+    needs: changes
+    if: always() && (github.event_name == 'push' || needs.changes.outputs.backend == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      # The `otlp` feature (#4858, Epic #4702 Phase 4) is off by default, so
+      # the default-feature jobs above never compile or run it — confirmed
+      # during Judge review of PR #4879 that CI had zero `--features otlp` /
+      # `--all-features` coverage anywhere (#4905). --all-targets is required
+      # here (unlike backend-lint-and-check's default job) so the feature's
+      # own unit tests (`otlp/mod.rs`, `otlp/mapping.rs`) are linted too, not
+      # just its non-test code paths.
+      - run: cargo clippy --package loom-daemon --features otlp --all-targets -- -D warnings -A clippy::cast_precision_loss -A clippy::cast_possible_truncation -A clippy::cast_sign_loss -A clippy::too_many_lines -A clippy::panic -A clippy::unwrap_used -A clippy::nonminimal_bool -A clippy::redundant_closure -A clippy::redundant_closure_for_method_calls -A clippy::format_push_string -A clippy::uninlined_format_args
+      - uses: taiki-e/install-action@nextest
+      - name: Run tests (otlp feature)
+        run: cargo nextest run --package loom-daemon --features otlp --profile ci
+
   mcp-build:
     name: MCP Server Build
     needs: changes

--- a/loom-daemon/src/terminal.rs
+++ b/loom-daemon/src/terminal.rs
@@ -2587,7 +2587,7 @@ mod tests {
             "a terminal whose tmux session does not exist must be pruned from list_terminals()"
         );
         assert!(
-            tm.terminals.get("ghost").is_none(),
+            !tm.terminals.contains_key("ghost"),
             "the dead entry must also be removed from the underlying registry, not just filtered on read"
         );
     }


### PR DESCRIPTION
## Summary

CI never compiled or ran the ~1,800 lines PR #4879 added under `loom-daemon/src/observability/otlp/` (`mod.rs` + `mapping.rs`, including ~20 unit tests), because `.github/workflows/ci.yml` had no job passing `--features otlp` or `--all-features` to any `cargo build`/`cargo clippy`/`cargo nextest` invocation. A future refactor of shared surface the OTLP module depends on (`Exporter` trait, `ExportError`, `TelemetryEnvelope`/`TelemetryRecord`) could silently break the feature with zero CI signal.

- Adds a `backend-otlp-feature` job to `.github/workflows/ci.yml`, mirroring `backend-lint-and-check` / `backend-tests` but scoped to `--features otlp`:
  - `cargo clippy --package loom-daemon --features otlp --all-targets -- -D warnings ...` (same lint allowlist as the existing default job; `--all-targets` is needed here so the feature's own test modules are linted, not just its non-test code)
  - `cargo nextest run --package loom-daemon --features otlp --profile ci`
  - Gated on the same `changes.outputs.backend` condition as the other backend jobs.
- Fixes one pre-existing, unrelated clippy lint in `loom-daemon/src/terminal.rs` test code (`get("ghost").is_none()` → `!contains_key("ghost")`), surfaced by `--all-targets` (the existing default clippy job never passes `--all-targets`, so it was never caught).

Verified locally: `cargo clippy --package loom-daemon --features otlp --all-targets` and `cargo nextest run --package loom-daemon --features otlp --profile ci` both pass (21/21 otlp-scoped tests). No `protoc` install step needed — `opentelemetry-proto`'s `gen-tonic-messages` feature builds from vendored/pre-generated code.

Note: a full `cargo nextest run --workspace` on this build host shows 4 unrelated failures in `work_finder::tests::*` — these are caused by a machine-level `~/.local/share/loom/config/defaults.json` (this fleet host's shared daemon config) leaking into tests that assume an empty environment, and reproduce identically with or without `--features otlp`. They won't occur on a clean GitHub Actions runner and are out of scope for this issue.

Closes #4905

## Test plan

- [x] `cargo clippy --package loom-daemon --features otlp --all-targets -- -D warnings ...` passes
- [x] `cargo nextest run --package loom-daemon --features otlp --profile ci` passes (21 otlp tests)
- [x] `cargo fmt --all -- --check` passes
- [x] Confirmed the new clippy fix doesn't change behavior (mechanical `is_none()` → `!contains_key()` rewrite)
- [ ] CI green on this PR (will confirm once checks run)