### PR TITLE
docs(builder): mandate formatter/linter on changed files before commit

### DIFF
--- a/defaults/.claude/commands/loom/builder-pr.md
+++ b/defaults/.claude/commands/loom/builder-pr.md
@@ -252,6 +252,7 @@ Root cause verification (for process/behavior issues):
 
 Local verification:
 - [ ] The project's check command passes (see `buildGate.command` in `.loom/config.json`, or the repo's documented CI command, e.g. `pnpm check:ci`)
+- [ ] Formatter + linter run on changed files (see "Format and Lint Changed Files" below) — a format-only CI failure is a guaranteed Judge rejection
 - [ ] Commits are signed off if required (`commit.signoff: true` in `.loom/config.json`, or a DCO/`sign-off` requirement — `git commit --signoff`; see "DCO sign-off" above)
 - [ ] Relevant tests pass
 - [ ] Each criterion has explicit verification (not "I think it works")
@@ -290,6 +291,52 @@ Closes #123
 | Test passes | `pnpm test -- <pattern>` |
 | File exists/content | `cat <file>` or `grep <pattern> <file>` |
 | Config changes | Read file and verify expected content |
+
+### Format and Lint Changed Files: MANDATORY Before Committing
+
+**Run the project's formatter and linter on your changed files before every
+commit, not just before opening the PR.** A format-only CI failure (e.g. `cargo
+fmt --check` / `ruff format --check` / `biome format --check` catching an
+unformatted file with otherwise-correct code) is a **guaranteed Judge
+rejection** — Judge never approves with a failing required check (see "PR
+Creation Checklist" below), so a one-command mechanical fix costs a full
+Doctor -> Judge cycle (an extra dispatch, re-review, and CI wait). This
+happened repeatedly in production (kicad-tools PRs #4532/#4533/#4535, #4882):
+otherwise approve-ready PRs rejected solely on `ruff format --check`.
+
+**Discover the commands from repo convention** — don't skip this because the
+language or toolchain is unfamiliar:
+
+1. Check `buildGate.command` in `.loom/config.json` (may already run
+   format+lint as part of the project check command).
+2. Check `CONTRIBUTING.md`, `package.json` scripts, a `Makefile`, or the CI
+   workflow (`.github/workflows/*.yml`) for the documented format/lint
+   commands.
+3. Fall back to the language's standard tool:
+
+| Language | Format | Lint |
+|----------|--------|------|
+| Rust | `cargo fmt` | `cargo clippy` |
+| Python | `ruff format <files>` (or `black <files>`) | `ruff check <files>` |
+| TypeScript/JavaScript | `biome format --write <files>` / `prettier --write <files>` | `biome check <files>` / `eslint <files>` |
+| Go | `gofmt -w <files>` | `go vet ./...` |
+| Shell | — | `shellcheck <file>` |
+
+**Scope to your changed files** (same pattern as "Handling Pre-existing
+Lint/Build Failures" below) so you don't pull unrelated files into your PR:
+
+```bash
+# Example: Python project
+git diff --name-only origin/main -- '*.py' | xargs -r uv run ruff format
+git diff --name-only origin/main -- '*.py' | xargs -r uv run ruff check
+```
+
+Add to your pre-PR checklist:
+```markdown
+Local verification:
+- [ ] Formatter run on changed files (no remaining diff / `--check` passes)
+- [ ] Linter run on changed files (0 errors)
+```
 
 ### Language-Specific Verification
 
@@ -668,7 +715,7 @@ When creating a PR, verify:
 3. PR description references the issue: `Closes #X` for a full implementation, or `Part of #X` for a declared partial increment (not "Issue #X" or "Addresses #X") — same reference in the commit message
 4. Issue number is correct
 5. PR has `loom:review-requested` label
-6. All CI checks pass locally (the project's check command — `buildGate.command` in `.loom/config.json`, e.g. `pnpm check:ci`)
+6. All CI checks pass locally (the project's check command — `buildGate.command` in `.loom/config.json`, e.g. `pnpm check:ci`) — **including the formatter/linter on changed files** (see "Format and Lint Changed Files" above); a format-only failure is a guaranteed Judge rejection, not a warning
 7. PR description includes verification table for each criterion
 8. Tests added/updated as needed
 9. Commits carry a `Signed-off-by:` trailer if required (`commit.signoff: true` in `.loom/config.json`, or a DCO/`sign-off` check — see "DCO sign-off")

--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -860,6 +860,7 @@ For additional PR quality guidelines, see **builder-pr.md**.
 - **Verify ALL acceptance criteria** from the issue (checkboxes, numbered items, "must"/"should" statements)
 - Verify each criterion explicitly with concrete checks (not "I think it works")
 - Run the project's check command (see `buildGate.command` in `.loom/config.json`, or the repo's documented CI command, e.g. `pnpm check:ci`) before creating PR
+- **Run the project's formatter + linter on your changed files before committing** — discover the commands from repo convention (`buildGate.command`, `CONTRIBUTING.md`, CI workflow, or the language's standard tool, e.g. `ruff format`/`ruff check` for Python, `cargo fmt`/`cargo clippy` for Rust). A format-only CI failure is a **guaranteed Judge rejection** that costs a full Doctor cycle for a one-command fix — see **builder-pr.md § "Format and Lint Changed Files"**
 
 ### MANDATORY: Derive Titles From Your Diff, Not the Issue
 

--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -858,6 +858,16 @@ $ sleep 60 && gh pr checks 1448
 - Type errors or compilation issues
 - Unused imports or variables
 
+**Format-only rejections don't need a bigger model.** If the *only* Judge
+complaint is a formatter/linter CI check (e.g. `cargo fmt --check` / `ruff
+format --check`) with no substantive code issue, the fix is a single
+mechanical command (`cargo fmt` / `ruff format <files>`, etc.) — it is not
+evidence the PR needs deeper reasoning. `sweep.md`'s Judge-rejection
+escalation ladder (#3481) is orchestrator-level and dispatch-time, not
+something you control from inside a Doctor session; this note is for a human
+choosing a Doctor model in manual mode — don't reach for a stronger model on a
+purely mechanical format fix (#4882).
+
 ### Medium Complexity (Usually Handle)
 - Refactoring to improve clarity
 - Adding edge case handling


### PR DESCRIPTION
## Summary
Format-only Judge rejections burn a full Doctor -> Judge cycle for a one-command mechanical fix. During a 2026-07-31 `/loom:sweep all` in the kicad-tools workspace, 3 of the first 8 Builder PRs (kicad-tools #4532, #4533, #4535) were rejected by Judge solely for `ruff format --check` CI failures — the code was otherwise approve-ready. This PR moves that discipline from ad-hoc prompt engineering into the role definition itself.

## Changes
- `defaults/.claude/commands/loom/builder-pr.md`: new "Format and Lint Changed Files: MANDATORY Before Committing" section — instructs discovering the project's format/lint commands from repo convention (`buildGate.command` in `.loom/config.json`, `CONTRIBUTING.md`/`package.json`/`Makefile`/CI workflow, or the language's standard tool — table covers Rust/Python/TS-JS/Go/Shell), scoped to changed files only. Adds a checklist item to "Pre-PR Verification Checklist" and a note on the "PR Creation Checklist" that a format-only CI failure is a guaranteed Judge rejection, not a warning.
- `defaults/.claude/commands/loom/builder.md`: adds a corresponding bullet to the "PR Creation" section (the primary role entry point) cross-referencing the new builder-pr.md section.
- `defaults/.claude/commands/loom/doctor.md`: notes under "Quick Fixes (Always Handle)" that a format-only Judge rejection is a purely mechanical fix and doesn't warrant escalating to a stronger Doctor model.

This is a documentation/role-definition change only — no application code touched. `defaults/roles/*.md` and `.loom/roles/*.md` are symlinks into `defaults/.claude/commands/loom/*.md`, so editing the canonical files here is sufficient (no installed-copy resync needed per CLAUDE.md).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|---------------|
| builder.md + builder skill checklist instruct running formatter+linter on changed files before commit, discovered from repo convention | ✅ | New "Format and Lint Changed Files" section in builder-pr.md + cross-referencing bullet in builder.md's PR Creation section |
| Pre-PR quality checklist mentions a format-only CI failure is a guaranteed Judge rejection | ✅ | Added to both the "Pre-PR Verification Checklist" (Step 3) and "PR Creation Checklist" in builder-pr.md |
| (Optional) Doctor role notes format-only fixes should not escalate the model ladder | ✅ | Added under "Quick Fixes (Always Handle)" in doctor.md |

## Test Plan
- This is a docs-only change to markdown role/skill files; no code paths execute this content directly.
- Confirmed no markdown formatter/linter is configured in this repo (checked `package.json` scripts, `.github/workflows/`, `CONTRIBUTING.md` — only `cargo fmt`/`clippy` for Rust, `test:python` for Python; nothing markdown-specific to run).
- Ran `./scripts/check-claude-md-budget.sh` (unaffected, still passes — 318/320 lines) to confirm the touched files don't interact with that gate.
- Reviewed the full diff for consistency with the existing terse imperative "MUST"/"before committing" prose style and issue-number cross-referencing convention used throughout these files.

Closes #4882