### PR TITLE
feat(tokens): report when an exhausted account's limit window resets

### DIFF
--- a/.loom/docs/telemetry-schema.md
+++ b/.loom/docs/telemetry-schema.md
@@ -230,6 +230,23 @@ A point-in-time view of the multi-account token pool (host-level — no `repo` /
 Per account, `rank` / `usage_fraction` / `limit_window_reset_at` are omitted when
 unknown; `exhausted` is always present.
 
+Every field is read out of the pool's `.ranking` file, so each maps to one of its
+pipe-delimited columns (`name|status|5h_util|limit_reset` — see
+[`token-pool.md`](token-pool.md)): `rank` is the row's position, `usage_fraction`
+is `5h_util`, `exhausted` is derived from `status`, and `limit_window_reset_at`
+is `limit_reset`.
+
+`limit_window_reset_at` is the instant the window **currently gating that
+account** rolls over — the 7-day window for an `exhausted` account (when it
+regains capacity), the 5-hour window otherwise (the rollover `usage_fraction` is
+racing). The daemon resolves which one before writing, so a consumer never has to
+know: it is always "when this account's constraint lifts". It is also the only
+per-account field here that survives public redaction, aggregated across the pool
+into `next_limit_window_reset_at` (the earliest reset, naming no account). A row
+whose reset is absent or unparseable reports no reset at all rather than a
+fabricated instant, so consumers must treat `null`/absent as *unknown* — never as
+"resets now".
+
 ### `host.health`
 
 Host CPU/disk headroom, daemon version, and uptime (host-level — no `repo` /

--- a/.loom/docs/token-pool.md
+++ b/.loom/docs/token-pool.md
@@ -322,8 +322,9 @@ byte-compatible with the historical `loom_tools.tokens.select` implementation,
 which stays in-tree as reference/conformance material (`loom-tools/tests/tokens/`)
 but is no longer on the runtime path:
 
-1. **Ranking** — `.loom/tokens/.ranking` (pipe-delimited `name|status|5h_util`,
-   refreshed every <10 min). A persistent rotation cursor spreads consecutive
+1. **Ranking** — `.loom/tokens/.ranking` (pipe-delimited
+   `name|status|5h_util|limit_reset`, refreshed every <10 min). A persistent
+   rotation cursor spreads consecutive
    dispatches one-per-account across the eligible accounts (#3909;
    `LOOM_TOKEN_SPREAD_TOP_N` / `tokens.spreadTopN` optionally caps the window).
 2. **Allowlist** — `.loom/tokens/.allowlist` (one name per line). Random pick from
@@ -339,8 +340,8 @@ pinned-account auto-recovery pre-flight (see below) before selecting.
 
 ### Ranking format: 5h-load field + soft gate (issue #4195)
 
-The `.ranking` line format is `name|status|5h_util`, where the **third field**
-is the account's 5h-window utilization (a fraction `0.0`–`1.0`, fixed at 2
+The `.ranking` line format is `name|status|5h_util|limit_reset`, where the **third
+field** is the account's 5h-window utilization (a fraction `0.0`–`1.0`, fixed at 2
 decimals). It is **optional**: a legacy 2-field `name|status` line still parses,
 and an account with no measured 5h utilization is written in the 2-field form
 (the value is left off, never faked as `0.0`). All four ranking writers emit it
@@ -359,6 +360,58 @@ the Rust port (`tokens_pool::select`). This is the Option-A reconciliation of
 the gpeyton-fork load-aware selection proposal (fork commits `283de8e3`,
 `20961dd9`) with upstream's existing rotation-cursor spread — a load-aware gate
 *layered on* #3909, not the fork's waterfall-fill replacement.
+
+### Ranking format: limit-reset field (issue #4874)
+
+The **fourth field** is the instant the account's **binding** limit window
+resets — the answer to "when can I dispatch to this account again?" — written as
+`%Y-%m-%dT%H:%M:%SZ`. Like `5h_util` it is **optional and additive**: a legacy
+2- or 3-field line still parses, with the reset read back as *unknown*
+(`None`) — never a fabricated date.
+
+**Which window is binding depends on the status** (`check::limit_reset` is the
+single place this is decided, and both writers call it):
+
+| Status | Reset written | Why |
+|---|---|---|
+| `exhausted` | 7d | `exhausted` *is* 7d utilization ≥ `EXHAUSTED_THRESHOLD`; the 5h window rolling over releases nothing. |
+| `rate_limited` | 5h | A 429 with 7d utilization below the threshold — the 5h window is what tripped. |
+| anything else | 5h | Not gated at all; the 5h rollover is what the reported `5h_util` is racing. |
+
+Reporting the 7d reset unconditionally would be *worse than an empty column*:
+on a live host a `rate_limited` account had a 5h reset ~1.6h out and a 7d reset
+**six days** out, so a 7d countdown would have told the operator the fleet was
+stalled until Saturday. When the binding window's instant is unknown it is left
+absent — never substituted with the other window's, because an absent countdown
+reads as "unknown" and a wrong one reads as a fact.
+
+Both ranking backends populate it:
+
+- The **claude-monitor backend** (`tokens_pool::monitor`) reads
+  `accounts[].resets["5h"]` and `["7d"]` from `~/.claude-monitor/ranking.json`
+  and normalizes them to the instant format. It previously reported no reset at
+  all, which is why the CLI's reset column was empty on every monitor-sourced
+  run even though the data was on disk the whole time.
+- The **native probe** (`tokens_pool::check`) parses the
+  `anthropic-ratelimit-…-7d-reset` header (it already did, only to discard the
+  value at the writer) plus `-5h-reset` opportunistically — the API does not
+  always send the latter, in which case a `rate_limited` row carries no
+  countdown rather than a misleading one.
+
+`loom-daemon tokens check --ranking`'s table shows this same value in a
+`Resets at` column that names its window, e.g. `2026-08-02T03:00:00Z (7d)`.
+
+**Field-position rule**: a row that knows its reset but *not* its utilization
+writes an empty third field (`name|status||limit_reset`) so the reset stays in
+position 4. The reader parses that empty utilization back to `None`, never to
+`0.0`. A reset containing a `|` or `#` (either would make the line unparseable)
+is dropped rather than written — an absent reset beats a mangled row.
+
+Selection **ignores** this field: it is telemetry, not an input to the tiered
+pick, so adding it cannot perturb which account is chosen. Its consumer is
+`tokens.snapshot`'s `limit_window_reset_at` (see `telemetry-schema.md`), which
+feeds the dashboard's per-account reset countdown, its burn-curve segmentation
+and forecasts, and the pool-level "capacity returns at" aggregate.
 
 ## Bad-token tracking (`loom-daemon tokens mark-bad`)
 

--- a/dashboard/docs/query-api.md
+++ b/dashboard/docs/query-api.md
@@ -202,6 +202,12 @@ non-integer), or `cursor` (non-positive or non-integer) returns `400` with a
   How loaded the pool is, and when capacity returns, without naming an
   account or exposing any single account's burn. The two usage figures are
   `null` — never `0` — when no account reported a `usage_fraction`.
+  `next_limit_window_reset_at` is the **earliest** per-account
+  `limit_window_reset_at` in the pool, and is likewise `null` — never a
+  fabricated instant — when no account reported one. Each account's
+  `limit_window_reset_at` is the reset of whichever window is gating *that*
+  account (7d once exhausted, 5h otherwise; the daemon resolves it before
+  export), so the aggregate reads as "the first moment any account frees up".
 
 ## `GET /api/events` / `GET /public/events`
 

--- a/dashboard/test/redaction.test.ts
+++ b/dashboard/test/redaction.test.ts
@@ -159,7 +159,17 @@ describe("redactPayload — per-kind field allowlist", () => {
       accounts: [
         { account: "agent-1", rank: 0, usage_fraction: 0.42, exhausted: false },
         { account: "agent-2", rank: 1, usage_fraction: 0.9, exhausted: false },
-        { account: "agent-3", rank: 2, usage_fraction: 0, exhausted: true },
+        // Shaped like a real daemon push post-#4874: an exhausted account
+        // carries the instant its 7d window resets, so the public view's
+        // fleet-level "capacity returns at" is a real time rather than the
+        // permanent `null` it was while the daemon hardcoded the field away.
+        {
+          account: "agent-3",
+          rank: 2,
+          usage_fraction: 0,
+          limit_window_reset_at: "2026-08-02T03:00:00Z",
+          exhausted: true,
+        },
       ],
     });
 
@@ -170,8 +180,33 @@ describe("redactPayload — per-kind field allowlist", () => {
       exhausted_count: 1,
       mean_usage_fraction: 0.44,
       max_usage_fraction: 0.9,
-      next_limit_window_reset_at: null,
+      next_limit_window_reset_at: "2026-08-02T03:00:00Z",
     });
+  });
+
+  it("tokens.snapshot: a reset instant survives redaction without naming the account it came from", () => {
+    // Issue #4874's aggregate half: the reset is the one per-account field the
+    // public view is allowed to keep, precisely because "capacity returns at
+    // 03:00Z" describes the pool, not who is in it. Guard that the row it was
+    // lifted from still does not survive alongside it.
+    const serialized = JSON.stringify(
+      redactPayload("tokens.snapshot", {
+        kind: "tokens.snapshot",
+        captured_at: "2026-07-30T12:00:00Z",
+        accounts: [
+          { account: "agent5-2amlogic", rank: 4, limit_window_reset_at: "2026-08-04T11:00:00Z", exhausted: true },
+          { account: "robb-2amlogic", rank: 0, limit_window_reset_at: "2026-08-02T03:00:00Z", exhausted: true },
+        ],
+      }),
+    );
+    // The *earliest* reset across the pool, not the first row's.
+    expect(JSON.parse(serialized).next_limit_window_reset_at).toBe("2026-08-02T03:00:00Z");
+    expect(serialized).not.toContain("agent5-2amlogic");
+    expect(serialized).not.toContain("robb-2amlogic");
+    expect(serialized).not.toContain("accounts");
+    // The per-account field itself is gone — only the derived aggregate key
+    // (`next_limit_window_reset_at`) remains.
+    expect(serialized).not.toContain('"limit_window_reset_at"');
   });
 
   it("tokens.snapshot: no account identifier survives, at any depth", () => {

--- a/dashboard/web/src/analytics/burn.ts
+++ b/dashboard/web/src/analytics/burn.ts
@@ -34,7 +34,12 @@
  *
  * 1. **A window rollover** — `limit_window_reset_at` changed to a later
  *    instant, or usage fell (by more than `USAGE_DROP_EPSILON`, which absorbs
- *    float noise in a value the daemon computes as a ratio).
+ *    float noise in a value the daemon computes as a ratio). While an account
+ *    is healthy that reset tracks the same 5h window `usage_fraction` measures,
+ *    so the two rollover signals agree; when an account goes `exhausted` the
+ *    daemon switches it to the 7d instant (the one that says when the account
+ *    comes back), which reads here as a jump to a later reset — a real regime
+ *    change, and exactly where a new segment belongs.
  * 2. **A telemetry gap** — consecutive samples further apart than
  *    `maxSampleGapMs`. The host was down, offline, or not reporting; whatever
  *    happened in between is unobserved, and joining across it would draw a

--- a/dashboard/web/src/types.ts
+++ b/dashboard/web/src/types.ts
@@ -44,7 +44,12 @@ export interface HostHealthRecord {
 
 /** One account inside a `tokens.snapshot`. Only `exhausted` is always sent;
  * `rank` / `usage_fraction` / `limit_window_reset_at` are omitted when the
- * daemon does not know them. */
+ * daemon does not know them.
+ *
+ * `limit_window_reset_at` is the instant the window *currently gating* the
+ * account rolls over — the 7d window once it is `exhausted`, the 5h window
+ * (the one `usage_fraction` measures) otherwise. The daemon resolves which,
+ * so this side reads it as one thing: when the account's constraint lifts. */
 export interface TokenAccount {
   account?: string;
   rank?: number;

--- a/dashboard/web/test/fixtures.ts
+++ b/dashboard/web/test/fixtures.ts
@@ -197,7 +197,17 @@ export function multiHostSnapshot(): unknown {
           record: {
             kind: "tokens.snapshot",
             accounts: [
-              { account: "agent-3", usage_fraction: 1, exhausted: true },
+              // An exhausted account that reports when its 7d window resets —
+              // the case the whole countdown column exists for ("when does
+              // this exhausted account come back?", issue #4874). Days out,
+              // not hours: that is the distinction between "capacity returns
+              // shortly" and "this host is spent until Saturday".
+              {
+                account: "agent-3",
+                usage_fraction: 1,
+                limit_window_reset_at: "2026-08-02T03:00:00Z",
+                exhausted: true,
+              },
               { account: "agent-4", exhausted: false },
             ],
           },

--- a/dashboard/web/test/hostDetail.test.ts
+++ b/dashboard/web/test/hostDetail.test.ts
@@ -86,6 +86,20 @@ describe("hostDetailView — token panel", () => {
     expect(cells(rows[1]!)[4]).toBe("available");
   });
 
+  it("counts down to an exhausted account's reset instead of showing a dash", () => {
+    // Issue #4874: the daemon never populated `limit_window_reset_at`, so this
+    // column was permanently `—` for exactly the accounts an operator needs it
+    // for. With the field fed, an exhausted account answers "when does
+    // capacity return?" — a multi-day countdown, not a clamped "just now".
+    const rows = [...detail(DEGRADED_HOST_ID).querySelectorAll('[data-testid="token-account"]')];
+    expect(cells(rows[0]!)[4]).toBe("exhausted");
+    expect(cells(rows[0]!)[3]).toBe("in 2d 14h");
+    expect(cells(rows[0]!)[3]).not.toBe(UNKNOWN);
+    // The absolute instant is still available as the tooltip for a bug report.
+    const resetCell = rows[0]!.querySelectorAll("td")[3];
+    expect(resetCell?.getAttribute("title")).toBeTruthy();
+  });
+
   it("clamps the usage meter to the track", () => {
     const built = buildFleetView(
       parseFleetSnapshot({

--- a/defaults/docs/telemetry-schema.md
+++ b/defaults/docs/telemetry-schema.md
@@ -245,6 +245,23 @@ A point-in-time view of the multi-account token pool (host-level — no `repo` /
 Per account, `rank` / `usage_fraction` / `limit_window_reset_at` are omitted when
 unknown; `exhausted` is always present.
 
+Every field is read out of the pool's `.ranking` file, so each maps to one of its
+pipe-delimited columns (`name|status|5h_util|limit_reset` — see
+[`token-pool.md`](token-pool.md)): `rank` is the row's position, `usage_fraction`
+is `5h_util`, `exhausted` is derived from `status`, and `limit_window_reset_at`
+is `limit_reset`.
+
+`limit_window_reset_at` is the instant the window **currently gating that
+account** rolls over — the 7-day window for an `exhausted` account (when it
+regains capacity), the 5-hour window otherwise (the rollover `usage_fraction` is
+racing). The daemon resolves which one before writing, so a consumer never has to
+know: it is always "when this account's constraint lifts". It is also the only
+per-account field here that survives public redaction, aggregated across the pool
+into `next_limit_window_reset_at` (the earliest reset, naming no account). A row
+whose reset is absent or unparseable reports no reset at all rather than a
+fabricated instant, so consumers must treat `null`/absent as *unknown* — never as
+"resets now".
+
 ### `host.health`
 
 Host CPU/disk headroom, daemon version, and uptime (host-level — no `repo` /

--- a/defaults/docs/token-pool.md
+++ b/defaults/docs/token-pool.md
@@ -299,8 +299,9 @@ byte-compatible with the historical `loom_tools.tokens.select` implementation,
 which stays in-tree as reference/conformance material (`loom-tools/tests/tokens/`)
 but is no longer on the runtime path:
 
-1. **Ranking** — `.loom/tokens/.ranking` (pipe-delimited `name|status|5h_util`,
-   refreshed every <10 min). A persistent rotation cursor spreads consecutive
+1. **Ranking** — `.loom/tokens/.ranking` (pipe-delimited
+   `name|status|5h_util|limit_reset`, refreshed every <10 min). A persistent
+   rotation cursor spreads consecutive
    dispatches one-per-account across the eligible accounts (#3909;
    `LOOM_TOKEN_SPREAD_TOP_N` / `tokens.spreadTopN` optionally caps the window).
 2. **Allowlist** — `.loom/tokens/.allowlist` (one name per line). Random pick from
@@ -316,8 +317,8 @@ pinned-account auto-recovery pre-flight (see below) before selecting.
 
 ### Ranking format: 5h-load field + soft gate (issue #4195)
 
-The `.ranking` line format is `name|status|5h_util`, where the **third field**
-is the account's 5h-window utilization (a fraction `0.0`–`1.0`, fixed at 2
+The `.ranking` line format is `name|status|5h_util|limit_reset`, where the **third
+field** is the account's 5h-window utilization (a fraction `0.0`–`1.0`, fixed at 2
 decimals). It is **optional**: a legacy 2-field `name|status` line still parses,
 and an account with no measured 5h utilization is written in the 2-field form
 (the value is left off, never faked as `0.0`). All four ranking writers emit it
@@ -336,6 +337,58 @@ the Rust port (`tokens_pool::select`). This is the Option-A reconciliation of
 the gpeyton-fork load-aware selection proposal (fork commits `283de8e3`,
 `20961dd9`) with upstream's existing rotation-cursor spread — a load-aware gate
 *layered on* #3909, not the fork's waterfall-fill replacement.
+
+### Ranking format: limit-reset field (issue #4874)
+
+The **fourth field** is the instant the account's **binding** limit window
+resets — the answer to "when can I dispatch to this account again?" — written as
+`%Y-%m-%dT%H:%M:%SZ`. Like `5h_util` it is **optional and additive**: a legacy
+2- or 3-field line still parses, with the reset read back as *unknown*
+(`None`) — never a fabricated date.
+
+**Which window is binding depends on the status** (`check::limit_reset` is the
+single place this is decided, and both writers call it):
+
+| Status | Reset written | Why |
+|---|---|---|
+| `exhausted` | 7d | `exhausted` *is* 7d utilization ≥ `EXHAUSTED_THRESHOLD`; the 5h window rolling over releases nothing. |
+| `rate_limited` | 5h | A 429 with 7d utilization below the threshold — the 5h window is what tripped. |
+| anything else | 5h | Not gated at all; the 5h rollover is what the reported `5h_util` is racing. |
+
+Reporting the 7d reset unconditionally would be *worse than an empty column*:
+on a live host a `rate_limited` account had a 5h reset ~1.6h out and a 7d reset
+**six days** out, so a 7d countdown would have told the operator the fleet was
+stalled until Saturday. When the binding window's instant is unknown it is left
+absent — never substituted with the other window's, because an absent countdown
+reads as "unknown" and a wrong one reads as a fact.
+
+Both ranking backends populate it:
+
+- The **claude-monitor backend** (`tokens_pool::monitor`) reads
+  `accounts[].resets["5h"]` and `["7d"]` from `~/.claude-monitor/ranking.json`
+  and normalizes them to the instant format. It previously reported no reset at
+  all, which is why the CLI's reset column was empty on every monitor-sourced
+  run even though the data was on disk the whole time.
+- The **native probe** (`tokens_pool::check`) parses the
+  `anthropic-ratelimit-…-7d-reset` header (it already did, only to discard the
+  value at the writer) plus `-5h-reset` opportunistically — the API does not
+  always send the latter, in which case a `rate_limited` row carries no
+  countdown rather than a misleading one.
+
+`loom-daemon tokens check --ranking`'s table shows this same value in a
+`Resets at` column that names its window, e.g. `2026-08-02T03:00:00Z (7d)`.
+
+**Field-position rule**: a row that knows its reset but *not* its utilization
+writes an empty third field (`name|status||limit_reset`) so the reset stays in
+position 4. The reader parses that empty utilization back to `None`, never to
+`0.0`. A reset containing a `|` or `#` (either would make the line unparseable)
+is dropped rather than written — an absent reset beats a mangled row.
+
+Selection **ignores** this field: it is telemetry, not an input to the tiered
+pick, so adding it cannot perturb which account is chosen. Its consumer is
+`tokens.snapshot`'s `limit_window_reset_at` (see `telemetry-schema.md`), which
+feeds the dashboard's per-account reset countdown, its burn-curve segmentation
+and forecasts, and the pool-level "capacity returns at" aggregate.
 
 ## Bad-token tracking (`loom-daemon tokens mark-bad`)
 

--- a/loom-daemon/src/capacity.rs
+++ b/loom-daemon/src/capacity.rs
@@ -157,10 +157,12 @@ impl RankingSnapshot {
 /// files, so callers that have their own resolved directory (or want to probe
 /// a specific one directly, e.g. in tests) can bypass re-resolution.
 ///
-/// The file is the pipe-delimited `name|status|5h_util` format written by
-/// `loom-daemon tokens check --ranking` (one account per line, issue #4195), where the
-/// status is the **second** field and the trailing 5h-utilization field is
-/// optional (legacy `name|status` lines omit it). Returns `None` when the file
+/// The file is the pipe-delimited `name|status|5h_util|7d_reset` format written
+/// by `loom-daemon tokens check --ranking` (one account per line, issues #4195 /
+/// #4874), where the status is the **second** field and the trailing
+/// 5h-utilization and 7d-reset fields are optional (legacy `name|status` lines
+/// omit both). Capacity only classifies the status, so the trailing fields are
+/// ignored here. Returns `None` when the file
 /// is absent, unreadable, or contains no parseable rows — the signal that no
 /// probe data exists, in which case callers fall back to the raw token-pool size
 /// (byte-for-byte the pre-#3902 behavior). Blank lines, `#` comments, and
@@ -168,7 +170,7 @@ impl RankingSnapshot {
 /// parsed via [`AccountHealth::parse`].
 ///
 /// Parsing goes through [`crate::tokens_pool::select::parse_ranking_line`] — the
-/// **same** triple parser the spawn-time selector uses — so this reader and the
+/// **same** row parser the spawn-time selector uses — so this reader and the
 /// selector can never de-sync on the field layout (the #4243/#4344 drift, where
 /// this function took the *last* field as the status and mis-read every 3-field
 /// row's `5h_util` — e.g. `agent3-2amlogic|available|0.09` → `"0.09"` →
@@ -189,12 +191,11 @@ pub fn read_ranking_at(pool_dir: &Path) -> Option<RankingSnapshot> {
         if !line.contains('|') {
             continue;
         }
-        let Some((_name, status, _util_5h)) = crate::tokens_pool::select::parse_ranking_line(line)
-        else {
+        let Some(row) = crate::tokens_pool::select::parse_ranking_line(line) else {
             continue;
         };
         snap.total += 1;
-        match AccountHealth::parse(&status) {
+        match AccountHealth::parse(&row.status) {
             AccountHealth::Available => snap.available += 1,
             AccountHealth::Exhausted => snap.exhausted += 1,
             AccountHealth::RateLimited => snap.rate_limited += 1,
@@ -737,50 +738,60 @@ mod tests {
         use crate::tokens_pool::check::ranking_line;
         use crate::tokens_pool::select::parse_ranking_line;
 
-        // (name, status, util) fixtures spanning every health class plus the
-        // optional / absent util field.
-        let accounts: [(&str, &str, Option<f64>); 5] = [
-            ("agent3-2amlogic", "available", Some(0.09)),
-            ("robb-2amlogic", "available", None), // legacy 2-field line
-            ("rjwalters-gmail", "exhausted", Some(0.00)),
-            ("agent2", "rate_limited", Some(0.88)),
-            ("agent4", "blocked", None),
+        // (name, status, util, reset) fixtures spanning every health class plus
+        // every combination of the two optional trailing fields — including the
+        // reset-without-util row (issue #4874), which is the one layout that
+        // needs a placeholder to keep the reset in field 4.
+        let accounts: [(&str, &str, Option<f64>, Option<&str>); 6] = [
+            ("agent3-2amlogic", "available", Some(0.09), None),
+            ("robb-2amlogic", "available", None, None), // legacy 2-field line
+            ("rjwalters-gmail", "exhausted", Some(0.00), Some("2026-08-02T03:00:00Z")),
+            ("agent2", "rate_limited", Some(0.88), Some("2026-08-01T07:00:00Z")),
+            ("agent4", "blocked", None, None),
+            // Reset known, utilization unknown: `name|status||reset`.
+            ("agent5", "exhausted", None, Some("2026-08-04T11:00:00Z")),
         ];
 
         // Render the file exactly as the writer would.
         let body: String = accounts
             .iter()
-            .map(|(name, status, util)| ranking_line(name, status, *util) + "\n")
+            .map(|(name, status, util, reset)| ranking_line(name, status, *util, *reset) + "\n")
             .collect();
 
-        // (2) vs (3): the selector's parser must recover the same name/status
-        // the writer put in, from the writer's own output.
-        for ((name, status, util), line) in accounts.iter().zip(body.lines()) {
-            let (pname, pstatus, putil) =
+        // (2) vs (3): the selector's parser must recover the same
+        // name/status/util/reset the writer put in, from the writer's own output.
+        for ((name, status, util, reset), line) in accounts.iter().zip(body.lines()) {
+            let row =
                 parse_ranking_line(line).expect("writer output must be parseable by the selector");
-            assert_eq!(&pname, name);
+            assert_eq!(&row.name, name);
             assert_eq!(
-                &pstatus, status,
+                &row.status, status,
                 "selector parser must recover the writer's status field, not the util"
             );
             match util {
                 Some(u) => {
-                    let p = putil.expect("a 3-field line must yield a util");
+                    let p = row.util_5h.expect("a line with a util must yield a util");
                     assert_eq!(format!("{p:.2}"), format!("{u:.2}"));
                 }
-                None => assert_eq!(putil, None, "a 2-field line must yield no util"),
+                None => assert_eq!(row.util_5h, None, "an absent util must not become 0.0"),
             }
+            assert_eq!(
+                row.limit_reset.as_deref(),
+                *reset,
+                "selector parser must recover the writer's reset field verbatim (#4874)"
+            );
         }
 
         // (1) → (2): capacity's reader must classify that same file into the
-        // writer's intended statuses — 2 available, 1 exhausted, 1
-        // rate_limited, 1 blocked, and crucially 0 unknown.
+        // writer's intended statuses — 2 available, 2 exhausted, 1
+        // rate_limited, 1 blocked, and crucially 0 unknown. A trailing reset
+        // field must not shift the status column for this reader either.
         let tmp = tempfile::tempdir().unwrap();
         write_ranking_at(tmp.path(), &body);
         let snap = read_ranking_at(tmp.path()).unwrap();
-        assert_eq!(snap.total, 5);
+        assert_eq!(snap.total, 6);
         assert_eq!(snap.available, 2);
-        assert_eq!(snap.exhausted, 1);
+        assert_eq!(snap.exhausted, 2);
         assert_eq!(snap.rate_limited, 1);
         assert_eq!(snap.blocked, 1);
         assert_eq!(

--- a/loom-daemon/src/observability/collector.rs
+++ b/loom-daemon/src/observability/collector.rs
@@ -390,11 +390,36 @@ async fn sample_snapshots(
     queue.push(TelemetryEnvelope::new(host_id, TelemetryRecord::HostHealth(health_record)));
 }
 
+/// Parse a `.ranking` row's binding-window reset text into the typed instant
+/// `tokens.snapshot` carries (issue #4874). The writers emit a canonical
+/// `%Y-%m-%dT%H:%M:%SZ` instant, but this is the trust boundary between an
+/// on-disk file and the pushed telemetry, so an unparseable value degrades to
+/// `None` ("unknown") rather than propagating junk to the dashboard's
+/// countdown — the same "unknown, not a fabricated date" contract the
+/// host-detail view already holds on the rendering side.
+fn parse_reset_instant(raw: Option<&str>) -> Option<DateTime<Utc>> {
+    let raw = raw?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    DateTime::parse_from_rfc3339(raw)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
 /// Read the resolved rotation-ranking file for `workspace_root` into a
 /// [`TokenSnapshotRecord`]. `rank` is the account's position in the ranking
 /// file (lower = preferred); an unreadable/missing/empty ranking yields an
 /// empty `accounts` list rather than an error — mirrors
 /// [`crate::capacity::read_ranking_at`]'s soft-fail contract.
+///
+/// `limit_window_reset_at` comes from the ranking row's optional reset field
+/// (issue #4874) — the instant the window *currently gating that account*
+/// rolls over (7d for an `exhausted` account, 5h otherwise; the writer resolves
+/// this via [`crate::tokens_pool::check::limit_reset`]). Before that field
+/// existed this was hardcoded `None`, which is why every exhausted account
+/// fleet-wide reported no reset instant and the dashboard's countdown column
+/// was permanently `—`.
 fn sample_token_snapshot(workspace_root: &Path) -> TokenSnapshotRecord {
     let pool_dir = crate::tokens_pool::paths::resolve_tokens_dir(workspace_root);
     let ranking_path = pool_dir.join(".ranking");
@@ -404,17 +429,15 @@ fn sample_token_snapshot(workspace_root: &Path) -> TokenSnapshotRecord {
             if !line.contains('|') {
                 continue;
             }
-            let Some((account, status, usage_fraction)) =
-                crate::tokens_pool::select::parse_ranking_line(line)
-            else {
+            let Some(row) = crate::tokens_pool::select::parse_ranking_line(line) else {
                 continue;
             };
-            let exhausted = !crate::capacity::AccountHealth::parse(&status).is_healthy();
+            let exhausted = !crate::capacity::AccountHealth::parse(&row.status).is_healthy();
             accounts.push(TokenAccountState {
-                account,
+                account: row.name,
                 rank: Some(u32::try_from(index).unwrap_or(u32::MAX)),
-                usage_fraction,
-                limit_window_reset_at: None,
+                usage_fraction: row.util_5h,
+                limit_window_reset_at: parse_reset_instant(row.limit_reset.as_deref()),
                 exhausted,
             });
         }
@@ -696,6 +719,113 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let record = sample_token_snapshot(dir.path());
         assert!(record.accounts.is_empty());
+    }
+
+    #[test]
+    fn token_snapshot_populates_limit_window_reset_at_from_the_ranking() {
+        // Issue #4874: this field was hardcoded `None`, so every exhausted
+        // account fleet-wide pushed `limit_window_reset_at: null` and the
+        // dashboard's countdown column was permanently `—`. An exhausted
+        // account with a reset in the ranking must now report it.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".loom/tokens")).unwrap();
+        std::fs::write(
+            dir.path().join(".loom/tokens/.ranking"),
+            "agent-1|available|0.42\n\
+             agent-2|exhausted|0.00|2026-08-02T03:00:00Z\n\
+             agent-3|exhausted||2026-08-04T11:00:00Z\n",
+        )
+        .unwrap();
+        let record = sample_token_snapshot(dir.path());
+        assert_eq!(record.accounts.len(), 3);
+
+        // No reset field -> unknown, not a fabricated date.
+        assert_eq!(record.accounts[0].limit_window_reset_at, None);
+
+        let expected = DateTime::parse_from_rfc3339("2026-08-02T03:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(record.accounts[1].limit_window_reset_at, Some(expected));
+        assert!(record.accounts[1].exhausted);
+        assert_eq!(record.accounts[1].usage_fraction, Some(0.00));
+
+        // Reset known, utilization unknown: the reset still lands, and the
+        // absent utilization is not coerced to 0.0.
+        assert_eq!(record.accounts[2].usage_fraction, None);
+        assert_eq!(
+            record.accounts[2].limit_window_reset_at,
+            Some(
+                DateTime::parse_from_rfc3339("2026-08-04T11:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc)
+            )
+        );
+    }
+
+    #[test]
+    fn token_snapshot_carries_the_writers_binding_reset_end_to_end() {
+        // The whole #4874 chain in one test: the *real* ranking writer renders
+        // the file, the collector reads it back, and the instant that lands in
+        // `tokens.snapshot` is the one the account is actually waiting on.
+        //
+        // The rate_limited row is the case that makes this more than plumbing.
+        // It is 7d-healthy and 5h-spent, so it returns at the 5h boundary
+        // (07:00Z) — writing its 7d reset (a week out) would tell the dashboard
+        // the fleet was stalled for six days when it recovers within the hour.
+        use crate::tokens_pool::check::{format_ranking_lines, AccountResult, ProbeReport};
+
+        let mut spent = AccountResult::new("agent-1", "exhausted");
+        spent.s5h_utilization = Some(0.0);
+        spent.s5h_reset = Some("2026-08-01T05:20:00Z".into());
+        spent.s7d_reset = Some("2026-08-02T03:00:00Z".into());
+        let mut limited = AccountResult::new("agent-2", "rate_limited");
+        limited.s5h_utilization = Some(1.0);
+        limited.s5h_reset = Some("2026-08-01T07:00:00Z".into());
+        limited.s7d_reset = Some("2026-08-07T01:00:00Z".into());
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".loom/tokens")).unwrap();
+        std::fs::write(
+            dir.path().join(".loom/tokens/.ranking"),
+            format_ranking_lines(&ProbeReport {
+                ranked_at: "2026-08-01T05:22:00Z".into(),
+                accounts: vec![spent, limited],
+            }),
+        )
+        .unwrap();
+
+        let record = sample_token_snapshot(dir.path());
+        let at = |iso: &str| {
+            Some(
+                DateTime::parse_from_rfc3339(iso)
+                    .unwrap()
+                    .with_timezone(&Utc),
+            )
+        };
+        assert_eq!(record.accounts[0].limit_window_reset_at, at("2026-08-02T03:00:00Z"));
+        assert!(record.accounts[0].exhausted);
+        assert_eq!(
+            record.accounts[1].limit_window_reset_at,
+            at("2026-08-01T07:00:00Z"),
+            "a 5h-limited account must report the 5h boundary it actually returns at"
+        );
+    }
+
+    #[test]
+    fn token_snapshot_unparseable_reset_degrades_to_unknown() {
+        // The on-disk file is a trust boundary: junk in the reset field must
+        // not propagate to the pushed telemetry as a bogus instant.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".loom/tokens")).unwrap();
+        std::fs::write(
+            dir.path().join(".loom/tokens/.ranking"),
+            "agent-1|exhausted|0.00|not-a-timestamp\n",
+        )
+        .unwrap();
+        let record = sample_token_snapshot(dir.path());
+        assert_eq!(record.accounts.len(), 1, "a bad reset must not drop the whole row");
+        assert_eq!(record.accounts[0].limit_window_reset_at, None);
+        assert!(record.accounts[0].exhausted);
     }
 
     #[tokio::test]

--- a/loom-daemon/src/serve.rs
+++ b/loom-daemon/src/serve.rs
@@ -693,8 +693,8 @@ pub struct TokenAccountRow {
     pub util_5h: Option<f64>,
 }
 
-/// Read every account row from `{pool_dir}/.ranking`, via the **same** triple
-/// parser (`name|status|5h_util`) the spawn-time selector and
+/// Read every account row from `{pool_dir}/.ranking`, via the **same** row
+/// parser (`name|status|5h_util|7d_reset`) the spawn-time selector and
 /// [`crate::capacity::read_ranking_at`]'s aggregation both use
 /// ([`crate::tokens_pool::select::parse_ranking_line`]) — so this panel can
 /// never disagree with the aggregate counts on `/api/status` about what a row
@@ -712,10 +712,10 @@ pub fn read_token_rows(pool_dir: &Path) -> Vec<TokenAccountRow> {
     contents
         .lines()
         .filter_map(crate::tokens_pool::select::parse_ranking_line)
-        .map(|(name, status, util_5h)| TokenAccountRow {
-            name,
-            status,
-            util_5h,
+        .map(|row| TokenAccountRow {
+            name: row.name,
+            status: row.status,
+            util_5h: row.util_5h,
         })
         .collect()
 }

--- a/loom-daemon/src/telemetry/mod.rs
+++ b/loom-daemon/src/telemetry/mod.rs
@@ -407,10 +407,16 @@ pub struct TokenAccountState {
     /// (lower = preferred).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rank: Option<u32>,
-    /// Fraction of the current limit window consumed (`0.0..=1.0`), when known.
+    /// Fraction of the 5h limit window consumed (`0.0..=1.0`), when known.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage_fraction: Option<f64>,
-    /// When the account's current limit window resets, when known.
+    /// When the window **currently gating this account** resets, when known —
+    /// the 7d window for an `exhausted` account (the instant it regains
+    /// capacity), the 5h window otherwise (the rollover `usage_fraction` is
+    /// racing). The producer resolves which one, so a consumer reads this as
+    /// the single answer to "when does this account's constraint lift?"
+    /// (`tokens_pool::check::limit_reset`, issue #4874). Absent means
+    /// *unknown*, never "resets now".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit_window_reset_at: Option<DateTime<Utc>>,
     /// Whether the account is currently considered exhausted (excluded from the

--- a/loom-daemon/src/tokens_pool/check.rs
+++ b/loom-daemon/src/tokens_pool/check.rs
@@ -19,12 +19,14 @@
 //! # Header resilience
 //!
 //! Rate-limit headers are matched by **suffix**, case-insensitively
-//! (`-5h-utilization`, `-7d-utilization`, `-7d-reset`), so any rename of the
-//! `anthropic-ratelimit-*` prefix segment still maps to our internal fields.
+//! (`-5h-utilization`, `-7d-utilization`, `-7d-reset`, `-5h-reset`), so any
+//! rename of the `anthropic-ratelimit-*` prefix segment still maps to our
+//! internal fields.
 //!
 //! # Byte-compatible `.ranking`
 //!
-//! `.ranking` is pipe-delimited `name|status`, one account per line, trailing
+//! `.ranking` is pipe-delimited `name|status|5h_util|limit_reset` (the last two
+//! fields optional, issues #4195 / #4874), one account per line, trailing
 //! newline (empty report yields an empty string), ordered by
 //! [`STATUS_RANK`] then `7d_reset` ascending with an absent-reset sentinel.
 //! **Every** status is written — no status is filtered at write time (see the
@@ -64,6 +66,12 @@ pub const EXHAUSTED_THRESHOLD: f64 = 0.95;
 const HEADER_SUFFIX_5H_UTIL: &str = "-5h-utilization";
 const HEADER_SUFFIX_7D_UTIL: &str = "-7d-utilization";
 const HEADER_SUFFIX_7D_RESET: &str = "-7d-reset";
+/// The 5h counterpart of `-7d-reset`. Anthropic does not currently send it on
+/// every response, so it is looked up opportunistically: when it is absent a
+/// `rate_limited` account reports **no** reset rather than borrowing the 7d
+/// one, which would claim a days-out return for an account that comes back
+/// within the hour (issue #4874).
+const HEADER_SUFFIX_5H_RESET: &str = "-5h-reset";
 const HEADER_SUFFIX_5H_STATUS: &str = "-5h-status";
 
 // ---------------------------------------------------------------------------
@@ -79,19 +87,36 @@ pub struct AccountResult {
     pub s5h_utilization: Option<f64>,
     pub s7d_utilization: Option<f64>,
     pub s7d_reset: Option<String>,
+    /// When the account's **5h** window rolls over. Populated by the
+    /// claude-monitor backend (`resets["5h"]`) and, when the API sends the
+    /// header, by the native probe. It is the reset that matters for a
+    /// `rate_limited` account — and for the 5h `usage_fraction` the dashboard
+    /// charts (issue #4874). See [`limit_reset`].
+    pub s5h_reset: Option<String>,
     pub error: Option<String>,
 }
 
 impl AccountResult {
-    fn new(name: impl Into<String>, status: impl Into<String>) -> Self {
+    /// A result with only the identity fields set; every measurement is
+    /// "unknown" until a probe (or the monitor backend) fills it in.
+    #[must_use]
+    pub fn new(name: impl Into<String>, status: impl Into<String>) -> Self {
         Self {
             name: name.into(),
             status: status.into(),
             s5h_utilization: None,
             s7d_utilization: None,
             s7d_reset: None,
+            s5h_reset: None,
             error: None,
         }
+    }
+
+    /// [`limit_reset`] for this result — the instant the window currently
+    /// gating this account rolls over.
+    #[must_use]
+    pub fn limit_reset(&self) -> Option<&str> {
+        limit_reset(&self.status, self.s5h_reset.as_deref(), self.s7d_reset.as_deref())
     }
 
     /// JSON shape matching `check.AccountResult.to_dict`.
@@ -106,6 +131,19 @@ impl AccountResult {
             self.s7d_reset
                 .clone()
                 .map_or(serde_json::Value::Null, serde_json::Value::String),
+        );
+        obj.insert(
+            "5h_reset".into(),
+            self.s5h_reset
+                .clone()
+                .map_or(serde_json::Value::Null, serde_json::Value::String),
+        );
+        // The window that is actually gating this account right now — the one
+        // `.ranking` carries and the dashboard counts down to (issue #4874).
+        obj.insert(
+            "limit_reset".into(),
+            self.limit_reset()
+                .map_or(serde_json::Value::Null, |r| serde_json::Value::String(r.to_string())),
         );
         if let Some(err) = &self.error {
             obj.insert("error".into(), serde_json::Value::String(err.clone()));
@@ -365,6 +403,7 @@ struct RateLimitFields {
     s5h_utilization: Option<f64>,
     s7d_utilization: Option<f64>,
     s7d_reset: Option<String>,
+    s5h_reset: Option<String>,
     #[allow(dead_code)]
     s5h_status: Option<String>,
 }
@@ -378,7 +417,46 @@ fn parse_rate_limit_headers(headers: &[(String, String)]) -> RateLimitFields {
             find_header_by_suffix(headers, HEADER_SUFFIX_7D_UTIL).as_deref(),
         ),
         s7d_reset: epoch_to_iso(find_header_by_suffix(headers, HEADER_SUFFIX_7D_RESET).as_deref()),
+        s5h_reset: epoch_to_iso(find_header_by_suffix(headers, HEADER_SUFFIX_5H_RESET).as_deref()),
         s5h_status: find_header_by_suffix(headers, HEADER_SUFFIX_5H_STATUS),
+    }
+}
+
+/// The instant this account's **binding** limit window resets — i.e. the answer
+/// to "when can I dispatch to it again?" (issue #4874).
+///
+/// The pool tracks two independent windows, and which one is holding an
+/// account back depends on its status:
+///
+/// - `exhausted` is derived from **7d** utilization clearing
+///   [`EXHAUSTED_THRESHOLD`], so the 5h window rolling over changes nothing —
+///   the 7d reset is the release.
+/// - `rate_limited` is a 429 whose 7d utilization is *below* the threshold, so
+///   the **5h** window is what tripped and the 5h reset is the release. Naming
+///   the 7d reset here would be actively misleading: on a live host a
+///   `rate_limited` account had a 5h reset ~1.6h out and a 7d reset **six days**
+///   out, and the dashboard would have counted down to the wrong one.
+/// - Anything else (`available`, `blocked`, `error`, …) is not gated by a
+///   window at all. Report the 5h reset, which is the rollover the reported
+///   `5h_utilization` — the `usage_fraction` the dashboard charts and forecasts
+///   against — is actually racing.
+///
+/// Returns `None` when the relevant instant is unknown. It is never
+/// substituted with the other window's: an absent countdown reads as "unknown",
+/// a wrong one reads as a fact.
+///
+/// Takes the three values rather than an [`AccountResult`] so the
+/// claude-monitor writer — which has its own account struct — picks the window
+/// through this same function instead of re-deriving the rule.
+#[must_use]
+pub fn limit_reset<'a>(
+    status: &str,
+    reset_5h: Option<&'a str>,
+    reset_7d: Option<&'a str>,
+) -> Option<&'a str> {
+    match status {
+        "exhausted" => reset_7d,
+        _ => reset_5h,
     }
 }
 
@@ -471,6 +549,7 @@ pub fn probe_account(
             s5h_utilization: parsed.s5h_utilization,
             s7d_utilization: parsed.s7d_utilization,
             s7d_reset: parsed.s7d_reset,
+            s5h_reset: parsed.s5h_reset,
             error: None,
         };
     }
@@ -491,6 +570,7 @@ pub fn probe_account(
         s5h_utilization: parsed.s5h_utilization,
         s7d_utilization: parsed.s7d_utilization,
         s7d_reset: parsed.s7d_reset,
+        s5h_reset: parsed.s5h_reset,
         error: None,
     }
 }
@@ -540,23 +620,43 @@ fn now_iso() -> String {
     chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
 }
 
-/// Format one `.ranking` line, emitting the optional 5h-utilization field
-/// (issue #4195): `name|status|5h_util` when the 5h utilization is known, else
-/// the legacy `name|status` (backward compatible: a `None` utilization is left
-/// unwritten rather than faked as `0.0`). The float is fixed at 2 decimals so
-/// the probe and monitor writers stay byte-identical with the Python port
-/// (`check._ranking_line`). Shared with `monitor::format_ranking_lines`.
-pub(crate) fn ranking_line(name: &str, status: &str, util_5h: Option<f64>) -> String {
-    match util_5h {
-        Some(u) => format!("{name}|{status}|{u:.2}"),
-        None => format!("{name}|{status}"),
+/// Format one `.ranking` line, emitting the optional 5h-utilization (issue
+/// #4195) and binding-limit-reset (issue #4874) fields:
+/// `name|status|5h_util|limit_reset`, truncated to the shortest form that
+/// carries every known value — `name|status` when neither is known,
+/// `name|status|util` when only the utilization is. A row that knows its reset
+/// but not its utilization writes an **empty** third field
+/// (`name|status||limit_reset`) so the reset stays in position 4; the reader
+/// parses an empty utilization back to `None` rather than a fabricated `0.0`.
+/// The float is fixed at 2 decimals so the probe and monitor writers stay
+/// byte-identical.
+///
+/// `limit_reset` is whichever window is actually gating the account — see
+/// [`limit_reset`], which both writers call to pick it. It is written verbatim
+/// minus surrounding whitespace, and is **dropped** if it contains a `|` or `#`
+/// — either would make the line unparseable (field split / comment strip), and
+/// a silently mangled row is worse than an absent reset.
+pub(crate) fn ranking_line(
+    name: &str,
+    status: &str,
+    util_5h: Option<f64>,
+    limit_reset: Option<&str>,
+) -> String {
+    let reset = limit_reset
+        .map(str::trim)
+        .filter(|r| !r.is_empty() && !r.contains('|') && !r.contains('#'));
+    match (util_5h, reset) {
+        (Some(u), Some(r)) => format!("{name}|{status}|{u:.2}|{r}"),
+        (Some(u), None) => format!("{name}|{status}|{u:.2}"),
+        (None, Some(r)) => format!("{name}|{status}||{r}"),
+        (None, None) => format!("{name}|{status}"),
     }
 }
 
-/// Serialize a report to the selector's `name|status|5h_util` format (trailing
-/// newline, empty report -> empty string). The 5h utilization is an optional
-/// third field, emitted when measured (issue #4195). Mirrors
-/// `check.format_ranking_lines`.
+/// Serialize a report to the selector's `name|status|5h_util|limit_reset`
+/// format (trailing newline, empty report -> empty string). The 5h utilization
+/// (issue #4195) and the binding-window reset instant (issue #4874) are
+/// optional trailing fields, emitted when known.
 #[must_use]
 pub fn format_ranking_lines(report: &ProbeReport) -> String {
     if report.accounts.is_empty() {
@@ -564,7 +664,7 @@ pub fn format_ranking_lines(report: &ProbeReport) -> String {
     }
     let mut out = String::new();
     for a in &report.accounts {
-        out.push_str(&ranking_line(&a.name, &a.status, a.s5h_utilization));
+        out.push_str(&ranking_line(&a.name, &a.status, a.s5h_utilization, a.limit_reset()));
         out.push('\n');
     }
     out
@@ -703,18 +803,24 @@ pub fn run_check(
     report
 }
 
-/// Human-readable status table (best accounts first). Mirrors
-/// `check.format_table`.
+/// Human-readable status table (best accounts first).
+///
+/// The reset column reports the **binding** window ([`limit_reset`]) and names
+/// which one it is, e.g. `2026-08-02T03:00:00Z (7d)`. It was labelled
+/// `7d resets` and fed from `s7d_reset` alone until issue #4874, which was
+/// wrong twice over: on the claude-monitor backend it was never populated at
+/// all (a permanent `-`), and on the probe backend a `rate_limited` account
+/// showed its 7d reset — days away — when the 5h window was the one holding it.
 #[must_use]
 pub fn format_table(report: &ProbeReport) -> String {
     let mut lines: Vec<String> = Vec::new();
     lines.push(format!("Token pool ranking (probed at {})", report.ranked_at));
-    lines.push("=".repeat(78));
+    lines.push("=".repeat(84));
     lines.push(format!(
-        "{:<28} {:>9} {:>9} {:<13} {:<22}",
-        "Account", "5h util", "7d util", "Status", "7d resets"
+        "{:<28} {:>9} {:>9} {:<13} {:<25}",
+        "Account", "5h util", "7d util", "Status", "Resets at"
     ));
-    lines.push("-".repeat(78));
+    lines.push("-".repeat(84));
     for a in &report.accounts {
         let s5 = a
             .s5h_utilization
@@ -722,8 +828,11 @@ pub fn format_table(report: &ProbeReport) -> String {
         let s7 = a
             .s7d_utilization
             .map_or_else(|| "-".to_string(), |v| format!("{v:.2}"));
-        let reset = a.s7d_reset.clone().unwrap_or_else(|| "-".to_string());
-        lines.push(format!("{:<28} {:>9} {:>9} {:<13} {:<22}", a.name, s5, s7, a.status, reset));
+        let window = if a.status == "exhausted" { "7d" } else { "5h" };
+        let reset = a
+            .limit_reset()
+            .map_or_else(|| "-".to_string(), |r| format!("{r} ({window})"));
+        lines.push(format!("{:<28} {:>9} {:>9} {:<13} {:<25}", a.name, s5, s7, a.status, reset));
     }
     let mut counts: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
     for a in &report.accounts {
@@ -1026,6 +1135,139 @@ mod tests {
             accounts: vec![loaded, AccountResult::new("b-2", "available")],
         };
         assert_eq!(format_ranking_lines(&report), "a-1|available|0.42\nb-2|available\n");
+    }
+
+    #[test]
+    fn format_ranking_lines_emits_the_binding_reset_fourth_field() {
+        // Issue #4874: the probe already parses `anthropic-ratelimit-...-
+        // 7d-reset`; it now survives into `.ranking` as the optional fourth
+        // field instead of being discarded at the writer.
+        let mut a = AccountResult::new("a-1", "exhausted");
+        a.s5h_utilization = Some(0.0);
+        a.s7d_reset = Some("2026-08-02T03:00:00Z".into());
+        let report = ProbeReport {
+            ranked_at: "x".into(),
+            accounts: vec![a],
+        };
+        assert_eq!(format_ranking_lines(&report), "a-1|exhausted|0.00|2026-08-02T03:00:00Z\n");
+    }
+
+    #[test]
+    fn limit_reset_picks_the_window_that_is_actually_gating() {
+        // `exhausted` is derived from 7d utilization, so the 7d reset is the
+        // release; `rate_limited` is the 5h window tripping with 7d still
+        // healthy, so the 5h reset is. Reporting the 7d reset for a
+        // rate_limited account would claim a days-out return for an account
+        // that is back within the hour.
+        let five = Some("2026-08-01T07:00:00Z");
+        let seven = Some("2026-08-07T01:00:00Z");
+        assert_eq!(limit_reset("exhausted", five, seven), seven);
+        assert_eq!(limit_reset("rate_limited", five, seven), five);
+        // Not gated by a window at all: report the rollover the 5h
+        // `usage_fraction` is racing, which is what the dashboard charts.
+        assert_eq!(limit_reset("available", five, seven), five);
+        assert_eq!(limit_reset("blocked", five, seven), five);
+    }
+
+    #[test]
+    fn limit_reset_never_substitutes_the_other_window() {
+        // An unknown binding reset stays unknown. Falling back to the window
+        // that *is* known would turn "I do not know" into a confident wrong
+        // answer — the failure mode this whole field exists to avoid.
+        assert_eq!(limit_reset("exhausted", Some("2026-08-01T07:00:00Z"), None), None);
+        assert_eq!(limit_reset("rate_limited", None, Some("2026-08-07T01:00:00Z")), None);
+    }
+
+    #[test]
+    fn format_ranking_lines_writes_the_5h_reset_for_a_rate_limited_account() {
+        // The writer must go through `limit_reset`, not reach for `s7d_reset`.
+        let mut a = AccountResult::new("b-2", "rate_limited");
+        a.s5h_utilization = Some(1.0);
+        a.s7d_reset = Some("2026-08-07T01:00:00Z".into());
+        a.s5h_reset = Some("2026-08-01T07:00:00Z".into());
+        let report = ProbeReport {
+            ranked_at: "x".into(),
+            accounts: vec![a],
+        };
+        assert_eq!(format_ranking_lines(&report), "b-2|rate_limited|1.00|2026-08-01T07:00:00Z\n");
+    }
+
+    #[test]
+    fn probe_parses_the_5h_reset_header_when_the_api_sends_one() {
+        // The API does not always send a 5h reset header. When it does, the
+        // probe backend picks it up by the same suffix match as every other
+        // rate-limit header; when it does not, the account simply has no 5h
+        // reset (and a rate_limited row carries no countdown at all).
+        let headers = vec![
+            ("anthropic-ratelimit-unified-5h-utilization".to_string(), "1.0".to_string()),
+            ("anthropic-ratelimit-unified-7d-utilization".to_string(), "0.6".to_string()),
+            ("anthropic-ratelimit-unified-7d-reset".to_string(), "1786000000".to_string()),
+            ("anthropic-ratelimit-unified-5h-reset".to_string(), "1785567600".to_string()),
+        ];
+        let parsed = parse_rate_limit_headers(&headers);
+        assert_eq!(parsed.s5h_reset.as_deref(), Some("2026-08-01T07:00:00Z"));
+        assert!(parsed.s7d_reset.is_some());
+
+        let without = parse_rate_limit_headers(&headers[..3]);
+        assert_eq!(without.s5h_reset, None, "an absent header is unknown, not borrowed from 7d");
+    }
+
+    #[test]
+    fn table_names_which_window_the_reset_belongs_to() {
+        // A bare instant in the reset column is ambiguous between the two
+        // windows, and the operator's next action differs a lot depending on
+        // which it is. The column says so explicitly.
+        let mut exhausted = AccountResult::new("a-1", "exhausted");
+        exhausted.s7d_reset = Some("2026-08-02T03:00:00Z".into());
+        exhausted.s5h_reset = Some("2026-08-01T05:20:00Z".into());
+        let mut limited = AccountResult::new("b-2", "rate_limited");
+        limited.s7d_reset = Some("2026-08-07T01:00:00Z".into());
+        limited.s5h_reset = Some("2026-08-01T07:00:00Z".into());
+        let unknown = AccountResult::new("c-3", "error");
+        let table = format_table(&ProbeReport {
+            ranked_at: "x".into(),
+            accounts: vec![exhausted, limited, unknown],
+        });
+        assert!(table.contains("Resets at"), "{table}");
+        assert!(table.contains("2026-08-02T03:00:00Z (7d)"), "{table}");
+        assert!(table.contains("2026-08-01T07:00:00Z (5h)"), "{table}");
+        assert!(
+            !table.contains("2026-08-07T01:00:00Z"),
+            "the 7d reset of a 5h-limited account must not be shown: {table}"
+        );
+        let unknown_row = table.lines().find(|l| l.starts_with("c-3")).unwrap();
+        assert!(
+            unknown_row.trim_end().ends_with('-'),
+            "unknown renders as a dash: {unknown_row:?}"
+        );
+    }
+
+    #[test]
+    fn ranking_line_reset_without_util_keeps_field_position() {
+        // A row that knows its reset but not its utilization must write an
+        // empty third field so the reset stays in position 4 — otherwise the
+        // reader would read the reset as the utilization.
+        assert_eq!(
+            ranking_line("a-1", "exhausted", None, Some("2026-08-02T03:00:00Z")),
+            "a-1|exhausted||2026-08-02T03:00:00Z"
+        );
+    }
+
+    #[test]
+    fn ranking_line_drops_reset_containing_delimiters() {
+        // A `|` or `#` in the reset text would make the line unparseable
+        // (field split / comment strip). Dropping the reset degrades to
+        // "unknown"; writing it would silently mangle the whole row.
+        assert_eq!(
+            ranking_line("a-1", "exhausted", Some(0.5), Some("2026|08")),
+            "a-1|exhausted|0.50"
+        );
+        assert_eq!(
+            ranking_line("a-1", "exhausted", Some(0.5), Some("2026#08")),
+            "a-1|exhausted|0.50"
+        );
+        // Whitespace-only is "unknown", not an empty trailing field.
+        assert_eq!(ranking_line("a-1", "exhausted", Some(0.5), Some("   ")), "a-1|exhausted|0.50");
     }
 
     #[test]

--- a/loom-daemon/src/tokens_pool/monitor.rs
+++ b/loom-daemon/src/tokens_pool/monitor.rs
@@ -40,6 +40,15 @@ pub struct MonitorAccount {
     pub status: String,
     pub util_7d: Option<f64>,
     pub util_5h: Option<f64>,
+    /// When the account's 7d window resets (`accounts[].resets["7d"]` in
+    /// `ranking.json`), normalized to `%Y-%m-%dT%H:%M:%SZ`. `None` when the
+    /// monitor did not report one — never a fabricated instant (issue #4874).
+    pub reset_7d: Option<String>,
+    /// When the account's 5h window resets (`accounts[].resets["5h"]`), same
+    /// normalization. This is the release instant for a `rate_limited`
+    /// account, and the rollover the 5h utilization is racing for every other
+    /// status — see [`super::check::limit_reset`].
+    pub reset_5h: Option<String>,
 }
 
 /// Resolve the claude-monitor directory: `$LOOM_CLAUDE_MONITOR_DIR` (tilde
@@ -161,6 +170,16 @@ fn coerce_float(value: Option<&serde_json::Value>) -> Option<f64> {
     }
 }
 
+/// Normalize a monitor-reported reset instant to the canonical
+/// `%Y-%m-%dT%H:%M:%SZ` text the `.ranking` writer emits (issue #4874).
+/// Anything unparseable as a timestamp yields `None` — an account with no
+/// usable reset stays "unknown" rather than carrying junk downstream to the
+/// dashboard's countdown.
+fn coerce_reset(value: Option<&serde_json::Value>) -> Option<String> {
+    let raw = value?.as_str()?;
+    parse_iso8601(Some(raw)).map(|dt| dt.format("%Y-%m-%dT%H:%M:%SZ").to_string())
+}
+
 fn order_key(a: &MonitorAccount) -> (i32, f64, f64) {
     (
         status_rank(&a.status),
@@ -243,11 +262,24 @@ pub fn build_monitor_accounts(
                 }
                 _ => (None, None),
             };
+            // `accounts[].resets` is the sibling of `utilization` that
+            // claude-monitor already publishes (`{"5h": "...", "7d": "..."}`).
+            // Both windows are read: which one is *binding* depends on the
+            // status, and `check::limit_reset` makes that call at write time
+            // (issue #4874).
+            let (reset_7d, reset_5h) = match entry.get("resets") {
+                Some(serde_json::Value::Object(resets)) => {
+                    (coerce_reset(resets.get("7d")), coerce_reset(resets.get("5h")))
+                }
+                _ => (None, None),
+            };
             let candidate = MonitorAccount {
                 name: name.clone(),
                 status,
                 util_7d,
                 util_5h,
+                reset_7d,
+                reset_5h,
             };
             if let Some(&idx) = index_by_name.get(&name) {
                 if status_rank(&candidate.status) > status_rank(&accounts[idx].status) {
@@ -285,6 +317,8 @@ pub fn build_monitor_accounts(
                 status: "available".to_string(),
                 util_7d: None,
                 util_5h: None,
+                reset_7d: None,
+                reset_5h: None,
             });
         }
     }
@@ -301,10 +335,12 @@ pub fn build_monitor_accounts(
     Some(accounts)
 }
 
-/// Serialize ordered accounts to the selector's `name|status|5h_util` format
-/// (trailing newline; empty -> empty string). The 5h utilization is an optional
-/// third field, emitted when known (issue #4195); byte-identical with the probe
-/// writer (`check::ranking_line`). Mirrors `monitor.format_ranking_lines`.
+/// Serialize ordered accounts to the selector's
+/// `name|status|5h_util|limit_reset` format (trailing newline; empty -> empty
+/// string). The 5h utilization (issue #4195) and the binding-window reset
+/// (issue #4874) are optional trailing fields, emitted when known;
+/// byte-identical with the probe writer (`check::ranking_line`), including the
+/// [`super::check::limit_reset`] choice of *which* window to report.
 #[must_use]
 pub fn format_ranking_lines(accounts: &[MonitorAccount]) -> String {
     if accounts.is_empty() {
@@ -312,7 +348,12 @@ pub fn format_ranking_lines(accounts: &[MonitorAccount]) -> String {
     }
     let mut out = String::new();
     for a in accounts {
-        out.push_str(&super::check::ranking_line(&a.name, &a.status, a.util_5h));
+        out.push_str(&super::check::ranking_line(
+            &a.name,
+            &a.status,
+            a.util_5h,
+            super::check::limit_reset(&a.status, a.reset_5h.as_deref(), a.reset_7d.as_deref()),
+        ));
         out.push('\n');
     }
     out
@@ -369,7 +410,11 @@ pub fn run_monitor_check(
             status: a.status.clone(),
             s5h_utilization: a.util_5h,
             s7d_utilization: a.util_7d,
-            s7d_reset: None,
+            // Issue #4874: the monitor path used to hardcode `None` for both
+            // resets, so the CLI's reset column was empty on every
+            // monitor-sourced run even though `ranking.json` carries them.
+            s7d_reset: a.reset_7d.clone(),
+            s5h_reset: a.reset_5h.clone(),
             error: None,
         })
         .collect();
@@ -631,6 +676,8 @@ mod tests {
             status: String::new(),
             util_7d: None,
             util_5h: None,
+            reset_7d: None,
+            reset_5h: None,
         }];
         assert_eq!(format_ranking_lines(&accounts), "acct-z|\n");
     }
@@ -645,15 +692,70 @@ mod tests {
                 status: "available".into(),
                 util_7d: Some(0.20),
                 util_5h: Some(0.90),
+                reset_7d: None,
+                reset_5h: None,
             },
             MonitorAccount {
                 name: "b".into(),
                 status: "available".into(),
                 util_7d: Some(0.10),
                 util_5h: None,
+                reset_7d: None,
+                reset_5h: None,
             },
         ];
         assert_eq!(format_ranking_lines(&accounts), "a|available|0.90\nb|available\n");
+    }
+
+    #[test]
+    fn format_ranking_lines_emits_the_binding_window_reset_fourth_field() {
+        // Issue #4874: the monitor backend now carries a reset instant it reads
+        // from `ranking.json` into the `.ranking` file's fourth field,
+        // byte-identically with the probe writer — and it writes the reset of
+        // whichever window is *binding*, not always the 7d one.
+        let exhausted = vec![MonitorAccount {
+            name: "a".into(),
+            status: "exhausted".into(),
+            util_7d: Some(1.0),
+            util_5h: Some(0.0),
+            reset_7d: Some("2026-08-02T03:00:00Z".into()),
+            reset_5h: Some("2026-08-01T05:20:00Z".into()),
+        }];
+        assert_eq!(
+            format_ranking_lines(&exhausted),
+            "a|exhausted|0.00|2026-08-02T03:00:00Z\n",
+            "an exhausted account is held by the 7d window"
+        );
+
+        // The live-host case that made "always write the 7d reset" wrong:
+        // `r.j.walters@gmail.com` was `rate_limited` with a 5h reset ~1.6h out
+        // and a 7d reset SIX DAYS out. Counting down to the 7d one would have
+        // told the operator the fleet was stalled until Saturday.
+        let rate_limited = vec![MonitorAccount {
+            name: "b".into(),
+            status: "rate_limited".into(),
+            util_7d: Some(0.60),
+            util_5h: Some(1.0),
+            reset_7d: Some("2026-08-07T01:00:00Z".into()),
+            reset_5h: Some("2026-08-01T07:00:00Z".into()),
+        }];
+        assert_eq!(
+            format_ranking_lines(&rate_limited),
+            "b|rate_limited|1.00|2026-08-01T07:00:00Z\n",
+            "a rate_limited account is held by the 5h window, not the 7d one"
+        );
+
+        // A healthy account reports the rollover its 5h utilization — the
+        // `usage_fraction` the dashboard charts — is actually racing.
+        let available = vec![MonitorAccount {
+            name: "c".into(),
+            status: "available".into(),
+            util_7d: Some(0.30),
+            util_5h: Some(0.12),
+            reset_7d: Some("2026-08-04T23:00:00Z".into()),
+            reset_5h: Some("2026-08-01T06:50:00Z".into()),
+        }];
+        assert_eq!(format_ranking_lines(&available), "c|available|0.12|2026-08-01T06:50:00Z\n");
     }
 
     #[test]
@@ -706,5 +808,124 @@ mod tests {
         assert_eq!(coerce_float(Some(&serde_json::json!(true))), None);
         assert_eq!(coerce_float(Some(&serde_json::json!("bad"))), None);
         assert_eq!(coerce_float(None), None);
+    }
+
+    #[test]
+    fn coerce_reset_variants() {
+        // Normalized to the canonical `.ranking` instant format; anything not
+        // a parseable timestamp is "unknown", never carried through as junk.
+        assert_eq!(
+            coerce_reset(Some(&serde_json::json!("2026-08-02T03:00:00Z"))),
+            Some("2026-08-02T03:00:00Z".to_string())
+        );
+        // An offset instant is normalized to UTC `Z`.
+        assert_eq!(
+            coerce_reset(Some(&serde_json::json!("2026-08-01T23:00:00-04:00"))),
+            Some("2026-08-02T03:00:00Z".to_string())
+        );
+        assert_eq!(coerce_reset(Some(&serde_json::json!("not-a-date"))), None);
+        assert_eq!(coerce_reset(Some(&serde_json::json!(""))), None);
+        assert_eq!(coerce_reset(Some(&serde_json::json!(1_754_103_600))), None);
+        assert_eq!(coerce_reset(None), None);
+    }
+
+    #[test]
+    fn build_monitor_accounts_surfaces_both_resets_when_present() {
+        // Fixture is a verbatim reduction of this host's real
+        // `~/.claude-monitor/ranking.json` (issue #4874): `resets` is a sibling
+        // of `utilization`, keyed by window, and both windows are reported.
+        let tmp = tempfile::tempdir().unwrap();
+        let tokens_dir = tmp.path().join("tokens");
+        let monitor_dir = tmp.path().join("monitor");
+        write_index(&tokens_dir, &[("acct-a", "a@example.com"), ("acct-b", "b@example.com")]);
+        let now = fresh_now();
+        write_ranking_json(
+            &monitor_dir,
+            &iso(now),
+            serde_json::json!([
+                {
+                    "email": "a@example.com",
+                    "status": "exhausted",
+                    "utilization": {"5h": 0.0, "7d": 1.0},
+                    "resets": {"5h": "2026-08-01T05:20:00Z", "7d": "2026-08-02T03:00:00Z"},
+                },
+                // No `resets` at all — must stay `None`, not inherit a sibling's.
+                {"email": "b@example.com", "status": "available", "utilization": {"7d": 0.30}},
+            ]),
+        );
+        let accounts =
+            build_monitor_accounts(&tokens_dir, Some(&monitor_dir), Some(now)).expect("fresh");
+
+        let a = accounts.iter().find(|a| a.name == "acct-a").unwrap();
+        assert_eq!(
+            a.reset_7d.as_deref(),
+            Some("2026-08-02T03:00:00Z"),
+            "the 7d reset must not pick up the 5h one"
+        );
+        assert_eq!(
+            a.reset_5h.as_deref(),
+            Some("2026-08-01T05:20:00Z"),
+            "the 5h reset is read too — it is the release instant for a rate_limited account"
+        );
+        let b = accounts.iter().find(|a| a.name == "acct-b").unwrap();
+        assert_eq!(b.reset_7d, None, "an account with no resets block stays unknown");
+        assert_eq!(b.reset_5h, None);
+    }
+
+    #[test]
+    fn run_monitor_check_reports_and_writes_the_binding_reset() {
+        // End-to-end for the monitor backend (issue #4874): the CLI table
+        // (`ProbeReport`) and the written `.ranking` must BOTH carry the reset,
+        // and both must name the *binding* window. Before this,
+        // `run_monitor_check` hardcoded `s7d_reset: None`, so the reset column
+        // was empty on every monitor-sourced run even though `ranking.json` had
+        // the instants all along.
+        let tmp = tempfile::tempdir().unwrap();
+        let tokens_dir = tmp.path().join("tokens");
+        let monitor_dir = tmp.path().join("monitor");
+        write_index(&tokens_dir, &[("acct-a", "a@example.com"), ("acct-b", "b@example.com")]);
+        let now = fresh_now();
+        write_ranking_json(
+            &monitor_dir,
+            &iso(now),
+            serde_json::json!([
+                {
+                    "email": "a@example.com",
+                    "status": "exhausted",
+                    "utilization": {"5h": 0.0, "7d": 1.0},
+                    "resets": {"5h": "2026-08-01T05:20:00Z", "7d": "2026-08-02T03:00:00Z"},
+                },
+                {
+                    "email": "b@example.com",
+                    "status": "rate_limited",
+                    "utilization": {"5h": 1.0, "7d": 0.60},
+                    "resets": {"5h": "2026-08-01T07:00:00Z", "7d": "2026-08-07T01:00:00Z"},
+                },
+            ]),
+        );
+        std::env::set_var(CLAUDE_MONITOR_DIR_VAR, &monitor_dir);
+        let report = run_monitor_check(&tokens_dir, true, || "2026-01-01T00:00:00Z".to_string());
+        std::env::remove_var(CLAUDE_MONITOR_DIR_VAR);
+
+        let report = report.unwrap();
+        let a = report.accounts.iter().find(|a| a.name == "acct-a").unwrap();
+        assert_eq!(a.s7d_reset.as_deref(), Some("2026-08-02T03:00:00Z"));
+        assert_eq!(a.limit_reset(), Some("2026-08-02T03:00:00Z"));
+        let b = report.accounts.iter().find(|a| a.name == "acct-b").unwrap();
+        assert_eq!(
+            b.limit_reset(),
+            Some("2026-08-01T07:00:00Z"),
+            "rate_limited returns at the 5h boundary, not six days out at the 7d one"
+        );
+
+        let ranking = fs::read_to_string(tokens_dir.join(".ranking")).unwrap();
+        assert!(
+            ranking.contains("acct-a|exhausted|0.00|2026-08-02T03:00:00Z\n"),
+            "unexpected .ranking body: {ranking:?}"
+        );
+        assert!(
+            ranking.contains("acct-b|rate_limited|1.00|2026-08-01T07:00:00Z\n"),
+            "unexpected .ranking body: {ranking:?}"
+        );
     }
 }

--- a/loom-daemon/src/tokens_pool/select.rs
+++ b/loom-daemon/src/tokens_pool/select.rs
@@ -202,13 +202,36 @@ fn parse_util(field: &str) -> Option<f64> {
     field.parse::<f64>().ok()
 }
 
-/// Parse a single `.ranking` line into a `(name, status, util_5h)` triple.
+/// One parsed `.ranking` row.
 ///
-/// This is the **shared** triple parser for the `name|status|5h_util` format
-/// (issue #4195): `status` is the *second* pipe-delimited field and the third
-/// (5h utilization) is optional, so a legacy `name|status` line yields
-/// `util_5h = None` (backward compatible). `#` comments are stripped; a
-/// blank/comment-only line, or one whose name is empty, yields `None`.
+/// A struct rather than a tuple (it grew a 4th field in issue #4874): every
+/// reader names the fields it wants, so adding a 5th cannot silently shift a
+/// positional binding the way the #4243/#4344 drift did.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RankingRow {
+    pub name: String,
+    pub status: String,
+    /// 5h-window utilization (issue #4195), when the row carries one.
+    pub util_5h: Option<f64>,
+    /// When the account's **binding** limit window resets (issue #4874), when
+    /// the row carries one. Which window that is depends on the row's status —
+    /// the writer already resolved it via
+    /// [`crate::tokens_pool::check::limit_reset`]. Kept as the raw ISO-8601
+    /// text the writer emitted; this parser does no time arithmetic.
+    pub limit_reset: Option<String>,
+}
+
+/// Parse a single `.ranking` line into a [`RankingRow`].
+///
+/// This is the **shared** parser for the `name|status|5h_util|limit_reset`
+/// format: `status` is the *second* pipe-delimited field, the third (5h
+/// utilization, issue #4195) and fourth (binding-window reset instant, issue
+/// #4874) are optional, so a legacy `name|status` or `name|status|5h_util` line
+/// still parses with the absent fields as `None` (backward compatible). A row
+/// that knows its reset but not its utilization writes an empty third field
+/// (`name|status||limit_reset`), which parses back to `util_5h = None` — never
+/// coerced to `0.0`. `#` comments are stripped; a blank/comment-only line, or
+/// one whose name is empty, yields `None`.
 ///
 /// Both the selector ([`read_ranking`]) and the daemon's capacity reader
 /// ([`crate::capacity::read_ranking_at`]) consume the ranking through this one
@@ -217,31 +240,59 @@ fn parse_util(field: &str) -> Option<f64> {
 /// and mis-read every 3-field row's `5h_util` as the status word. A
 /// format-drift conformance test (`capacity::tests`) pins them together.
 #[must_use]
-pub(crate) fn parse_ranking_line(line: &str) -> Option<(String, String, Option<f64>)> {
+pub(crate) fn parse_ranking_line(line: &str) -> Option<RankingRow> {
     let stripped = strip_comment(line);
     if stripped.is_empty() {
         return None;
     }
-    let mut parts = stripped.splitn(3, '|');
+    // `splitn(4, ..)` — NOT `splitn(3, ..)`: with a 3-way split a 4th segment
+    // is swallowed into the utilization field and silently fails to parse as a
+    // float, which is exactly how the reset instant would have been lost.
+    let mut parts = stripped.splitn(4, '|');
     let name = parts.next().unwrap_or("").trim().to_string();
     let status = parts.next().unwrap_or("").trim().to_string();
-    let util = parts.next().and_then(parse_util);
+    let util_5h = parts.next().and_then(parse_util);
+    let limit_reset = parts.next().and_then(parse_reset);
     if name.is_empty() {
         return None;
     }
-    Some((name, status, util))
+    Some(RankingRow {
+        name,
+        status,
+        util_5h,
+        limit_reset,
+    })
+}
+
+/// Parse a ranking line's optional reset field (issue #4874). An empty
+/// field yields `None` ("unknown") — the row is never given a fabricated
+/// reset instant. The text is not date-validated here; the writer emits a
+/// canonical `%Y-%m-%dT%H:%M:%SZ` instant and consumers that need a real
+/// `DateTime` (the telemetry collector) parse it themselves and drop it on
+/// failure.
+fn parse_reset(field: &str) -> Option<String> {
+    let field = field.trim();
+    if field.is_empty() {
+        return None;
+    }
+    Some(field.to_string())
 }
 
 /// Yield `(name, status, util_5h)` triples from the ranking file, one per
 /// parseable line via the shared [`parse_ranking_line`] parser. Format:
-/// `name|status|5h_util` per line (issue #4195); the third field is optional,
-/// so a legacy `name|status` line yields `util_5h = None` (backward
+/// `name|status|5h_util|limit_reset` per line; the third and fourth fields are
+/// optional, so a legacy `name|status` line yields `util_5h = None` (backward
 /// compatible). Malformed/empty lines are skipped; `status` defaults to `""`.
+/// Selection ignores the reset instant — it is telemetry, not an input to the
+/// tiered pick — so this projects the row down to the triple selection uses.
 fn read_ranking(ranking_file: &Path) -> Vec<(String, String, Option<f64>)> {
     let Ok(text) = std::fs::read_to_string(ranking_file) else {
         return Vec::new();
     };
-    text.lines().filter_map(parse_ranking_line).collect()
+    text.lines()
+        .filter_map(parse_ranking_line)
+        .map(|row| (row.name, row.status, row.util_5h))
+        .collect()
 }
 
 fn read_allowlist_lines(allowlist_file: &Path) -> Vec<String> {
@@ -897,6 +948,66 @@ mod tests {
         assert_eq!(rows[0], ("a".to_string(), "available".to_string(), Some(0.70)));
         assert_eq!(rows[1], ("b".to_string(), "available".to_string(), None));
         assert_eq!(rows[2], ("c".to_string(), "available".to_string(), None));
+    }
+
+    // ---- limit-reset field (issue #4874) -----------------------------
+
+    #[test]
+    fn parse_ranking_line_reads_optional_limit_reset_field() {
+        // A 4-field row surfaces the reset verbatim; the 2- and 3-field legacy
+        // layouts still parse with `limit_reset = None` (backward compatible).
+        let full = parse_ranking_line("a|exhausted|0.00|2026-08-02T03:00:00Z").unwrap();
+        assert_eq!(full.name, "a");
+        assert_eq!(full.status, "exhausted");
+        assert_eq!(full.util_5h, Some(0.00));
+        assert_eq!(full.limit_reset.as_deref(), Some("2026-08-02T03:00:00Z"));
+
+        assert_eq!(parse_ranking_line("b|available|0.70").unwrap().limit_reset, None);
+        assert_eq!(parse_ranking_line("c|available").unwrap().limit_reset, None);
+    }
+
+    #[test]
+    fn parse_ranking_line_reset_without_util_does_not_fabricate_zero() {
+        // `name|status||reset` — the reset-known/util-unknown layout. The empty
+        // third field must parse back to `None`, never to `0.0`, or a fully
+        // idle account would look like a measured-zero-load one.
+        let row = parse_ranking_line("a|exhausted||2026-08-04T11:00:00Z").unwrap();
+        assert_eq!(row.status, "exhausted");
+        assert_eq!(row.util_5h, None);
+        assert_eq!(row.limit_reset.as_deref(), Some("2026-08-04T11:00:00Z"));
+    }
+
+    #[test]
+    fn parse_ranking_line_4th_field_does_not_swallow_the_util() {
+        // Regression guard for the `splitn(3, ..)` hazard the curator flagged:
+        // with a 3-way split the 4th segment is swallowed into the utilization
+        // field, so `0.00|2026-...` fails to parse as a float and the
+        // utilization silently becomes `None`.
+        let row = parse_ranking_line("a|exhausted|0.42|2026-08-02T03:00:00Z").unwrap();
+        assert_eq!(row.util_5h, Some(0.42), "the 4th field must not swallow the util");
+    }
+
+    #[test]
+    fn parse_ranking_line_reset_is_comment_stripped_and_trimmed() {
+        // `#` comments are stripped before splitting, and surrounding
+        // whitespace is trimmed off the reset like every other field.
+        let row = parse_ranking_line("a|exhausted|0.00| 2026-08-02T03:00:00Z  # probed").unwrap();
+        assert_eq!(row.limit_reset.as_deref(), Some("2026-08-02T03:00:00Z"));
+        // An empty 4th field is "unknown", not an empty string.
+        assert_eq!(parse_ranking_line("a|exhausted|0.00|").unwrap().limit_reset, None);
+    }
+
+    #[test]
+    fn read_ranking_ignores_the_reset_field_for_selection() {
+        // Selection consumes the projected triple: a 4-field row must behave
+        // exactly like the same row without a reset, so adding the field
+        // cannot perturb which account gets picked.
+        let tmp = tempfile::tempdir().unwrap();
+        let ranking = tmp.path().join(".ranking");
+        fs::write(&ranking, "a|available|0.70|2026-08-02T03:00:00Z\nb|available|0.70\n").unwrap();
+        let rows = read_ranking(&ranking);
+        assert_eq!(rows[0], ("a".to_string(), "available".to_string(), Some(0.70)));
+        assert_eq!(rows[1], ("b".to_string(), "available".to_string(), Some(0.70)));
     }
 
     #[test]


### PR DESCRIPTION
Closes #4874

## Root cause

`limit_window_reset_at` was a defined `tokens.snapshot` field with a fully built consumer chain — `formatCountdown`, the host-detail reset column, `deriveTokenPoolAggregate`'s `next_limit_window_reset_at` — that **nothing ever fed**. It was parsed and then dropped, in three places:

1. **`.ranking` had nowhere to put it.** The pipe format was `name|status|5h_util`, so `check::ranking_line` discarded the `anthropic-ratelimit-…-7d-reset` value the probe had *already parsed* and threaded all the way to the CLI table. `.ranking` is the only channel between the probe and everything downstream, so the value died at the writer.
2. **The claude-monitor backend never looked.** `build_monitor_accounts` read `email`/`status`/`utilization` from `~/.claude-monitor/ranking.json` and hardcoded `s7d_reset: None` — even though that file carries `accounts[].resets.{5h,7d}` for every account. This is why the CLI's reset column was empty on every monitor-sourced run: not missing data, unread data.
3. **The collector hardcoded `None`.** `sample_token_snapshot` built every `TokenAccountState` with `limit_window_reset_at: None`.

## Fix

`.ranking` grows an **optional fourth field**, following the `5h_util` precedent from #4195 — legacy 2- and 3-field lines still parse, and an absent value stays *unknown* rather than being fabricated. Both writers populate it; the collector parses it into the telemetry record. `parse_ranking_line` becomes `splitn(4, '|')` and returns a named `RankingRow`, so a future fifth field cannot silently shift a positional binding the way the #4243/#4344 drift did.

### The field is the *binding* window's reset, not always the 7d one

This is the part that turned out to be more than plumbing. `check::limit_reset` is the single place the choice is made:

| Status | Reset written | Why |
|---|---|---|
| `exhausted` | 7d | `exhausted` *is* 7d utilization ≥ threshold; the 5h window rolling over releases nothing. |
| `rate_limited` | 5h | A 429 with 7d utilization *below* threshold — the 5h window is what tripped. |
| anything else | 5h | Not gated at all; the 5h rollover is what the reported `usage_fraction` is racing. |

Always writing the 7d reset would have answered the countdown's own question wrongly, in the direction that makes the fleet look dead. Live proof from this host's probe — `agent7-2amlogic` is `rate_limited` at 7d util 0.79, so its 7d reset is days out, but it actually comes back in ~20 minutes:

```
Account                        5h util   7d util Status        Resets at
agent6-2amlogic                   0.75      0.73 available     2026-08-01T09:50:00Z (5h)
agent7-2amlogic                   1.00      0.79 rate_limited  2026-08-01T08:50:00Z (5h)
robb-2amlogic                     0.00      1.00 exhausted     2026-08-02T03:00:00Z (7d)
robb-integratedplasmonics         0.00      1.00 exhausted     2026-08-04T11:00:00Z (7d)
agent3-2amlogic                   0.00      1.00 exhausted     2026-08-04T23:00:00Z (7d)
```

Choosing the binding window also keeps the value coherent with `usage_fraction` (which is 5h utilization) for `burn.ts`'s segmentation and `forecast.ts`'s margins, which both assume the reset is the rollover that drops the charted fraction. When the binding window's instant is unknown it stays absent — never substituted with the other window's, because an absent countdown reads as "unknown" and a wrong one reads as a fact.

The CLI's reset column now reports that same value and **names its window** (`2026-08-02T03:00:00Z (7d)`), replacing a `7d resets` header that was empty on every monitor-sourced run.

## Acceptance criteria

- [x] An exhausted account reports a `limit_window_reset_at` — verified live (table above), and the written `.ranking` carries `robb-2amlogic|exhausted|0.00|2026-08-02T03:00:00Z`.
- [x] `deriveTokenPoolAggregate`'s `next_limit_window_reset_at` is non-null when any account reports one — now exercised end-to-end through `redactPayload`, not just the unit.
- [x] The host-detail reset column shows a real countdown for an exhausted account — `in 2d 14h`, asserted in `hostDetail.test.ts`.
- [x] `formatCountdown`'s future-value path is driven by a real value — the `multiHostSnapshot` fixture's exhausted account now carries a reset.

## Testing

- `cargo test --lib` — **2988 passed, 0 failed**.
- `cargo clippy --package loom-daemon` (CI's invocation) clean; `cargo fmt --all --check` clean; `cargo check --workspace --all-targets` clean.
- `dashboard` Miniflare suite — **161 passed**; `dashboard/web` happy-dom suite — **372 passed**; both `npm run typecheck`s clean.

New coverage: writer/parser round-trips for all four field layouts including the `name|status||reset` placeholder case; `limit_reset`'s window selection *and* its never-substitute rule; the probe's opportunistic `-5h-reset` header (present and absent); the monitor backend against a fixture reduced from this host's real `ranking.json`; a writer → file → `sample_token_snapshot` end-to-end asserting a `rate_limited` account lands on its 5h boundary; and the dashboard tests above. The existing "unknown, not a fabricated date" contract at `hostDetail.test.ts:76` is untouched and still passing.

## Rollout note

The format change is backward compatible in both directions, verified live: the **currently installed** (pre-change) `loom-daemon` reads a new 4-field `.ranking` fine and still selects via the `ranked` tier. Its only degradation is that `splitn(3, '|')` swallows the 4th field into the utilization, so `util_5h` reads as *unknown* — which the #4195 load gate already treats as "never gated". Status (field 2) is unaffected, so capacity counting and selection are unchanged until the daemon rolls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
