### PR TITLE
docs(judge): forbid ending the turn on a background CI monitor

### DIFF
--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -1094,6 +1094,37 @@ if gh pr checks <PR_NUMBER> | grep -qE "(pending|queued|in_progress)"; then
 fi
 ```
 
+### CRITICAL: Never End Your Turn on a Background CI Monitor
+
+**A CI-gated verdict must be settled in-turn — either via the skip-and-continue path above, or via a foreground poll loop. It must NEVER be settled by starting a background monitor (a `Monitor`/`ScheduleWakeup` timer, a `run_in_background` Bash watcher, or any other "I'll check back once it finishes" narration) and ending your turn while your verdict is still pending on it.**
+
+This mirrors the orchestrator-level guardrail already documented in `sweep.md` ("ending your turn IS the kill signal", issue #4257) — restated here explicitly for Judge because the failure has already recurred in this exact role. **Incident (issue #4883, 2026-07-31, kicad-tools workspace, headless `/loom:sweep all`):** a Judge subagent finished its static review, started a background CI monitor, and ended its turn narrating *"The background monitor will notify me when it completes, at which point I'll issue the verdict. Awaiting that result."* In an interactive session a human can nudge the agent back to life; in a headless `claude -p` sweep there is no such recovery — ending the turn **terminates the process**, the monitor dies with it, no verdict is ever issued, and the PR is left claimed (`loom:reviewing`) with nobody left to release it.
+
+**There are exactly two safe paths when CI is pending and you cannot approve on a guess:**
+
+1. **Batch mode (there is a next PR to move to): skip and continue.** Use the "When CI is Pending" procedure above — release `loom:reviewing`, leave `loom:review-requested` in place, move on to the next PR. This is not a fallback of last resort; it is the correct default whenever a next PR exists, because a later tick re-evaluates this one.
+2. **Single-PR / manual invocation (there is no next PR — you were dispatched to judge exactly this one PR and a verdict is expected before your turn ends): block-poll in the foreground.** Loop **inside this same turn** — check `gh pr checks <PR_NUMBER>`, `sleep` a fixed interval, repeat — until the checks resolve or you hit an explicit, bounded cap. This is an ordinary shell loop that runs to completion and returns control to you before you write your final message; nothing about it depends on a future turn.
+
+```bash
+# Foreground block-poll — single-PR Judge invocation, no batch to fall back to.
+# Bounded: MAX_WAIT caps total wait time; never loop unboundedly.
+MAX_WAIT=1800   # 30 min cap — tune to the repo's typical CI duration
+INTERVAL=60
+ELAPSED=0
+while gh pr checks <PR_NUMBER> | grep -qE "(pending|queued|in_progress)"; do
+  if [[ "$ELAPSED" -ge "$MAX_WAIT" ]]; then
+    echo "CI still pending after ${MAX_WAIT}s — falling back to a conditional verdict."
+    break
+  fi
+  sleep "$INTERVAL"
+  ELAPSED=$((ELAPSED + INTERVAL))
+done
+```
+
+**If the cap is reached and CI is still pending, do not extend the wait and do not reach for a background watcher instead.** Post a conditional-verdict comment stating plainly that the code review passed but CI had not settled after the bounded wait, then — since there is no batch to hand this off to — release `loom:reviewing` and leave `loom:review-requested` in place, exactly as the skip-and-continue path does, so a later Judge invocation (the next cron tick, or a fresh manual dispatch) can re-evaluate once CI has settled.
+
+**Never substitute an armed `Monitor`/`ScheduleWakeup` timer or a `run_in_background` watcher for either path above.** A timer or background task that is still armed when you end your turn is not "waiting" — in headless `-p` mode it is simply killed along with the process, and the PR is orphaned with a stale claim and no verdict. If you have not personally observed the CI result (via a `gh pr checks` call whose output you read in this turn), you have not verified it, and you MUST NOT write a final message that implies the verdict is settled or "in progress elsewhere."
+
 ### Example CI Verification Workflow
 
 ```bash


### PR DESCRIPTION
## Summary

Adds an explicit, prominent rule to `judge.md`'s CI Status Check guidance (`defaults/.claude/commands/loom/judge.md`, and its `defaults/roles/judge.md` symlink) forbidding a Judge subagent from ending its turn while a background CI monitor/watcher it started is the only pending signal for its verdict — the #4257-class headless kill hazard.

Incident this closes (from the issue body): during a 2026-07-31 `/loom:sweep all` in the kicad-tools workspace, a Judge subagent finished its static review, started a background CI monitor, and ended its turn narrating "The background monitor will notify me when it completes... Awaiting that result." In headless `claude -p` mode, ending the turn terminates the process, killing the monitor and leaving the PR claimed (`loom:reviewing`) with no verdict ever issued.

## Changes

- New `### CRITICAL: Never End Your Turn on a Background CI Monitor` section, inserted right after the existing "When CI is Pending" skip-and-continue procedure in the `## CI Status Check (REQUIRED Before Approval)` block.
- States the rule explicitly and prominently, modeled in tone on `sweep.md`'s existing "ending your turn IS the kill signal" guardrail (#4257/#4462/#4696) but written specifically for the Judge role rather than copied verbatim.
- Defines exactly two sanctioned paths for a CI-gated verdict that can't be settled immediately:
  1. **Batch mode** (a next PR exists): the existing skip-and-continue path — release `loom:reviewing`, leave `loom:review-requested`, move on.
  2. **Single-PR / manual invocation** (no next PR to fall back to): a bounded, in-turn foreground `gh pr checks` poll loop with an explicit `MAX_WAIT` cap, falling back to a conditional-verdict comment + claim release (mirroring skip-and-continue) if the cap is reached.
- Explicitly forbids substituting an armed `Monitor`/`ScheduleWakeup` timer or a `run_in_background` watcher for either path.

Only `defaults/.claude/commands/loom/judge.md` needed editing — `defaults/roles/judge.md` is a symlink to it (verified: `defaults/roles/judge.md -> ../.claude/commands/loom/judge.md`), so there is no second copy to keep in sync.

## Guard-hook coverage investigation (curated AC #3)

Per the curated acceptance criteria, I checked whether `guard-background-subagents.sh`'s armed-`Monitor`/background-Task detection (issues #4257/#4389/#4462/#4696) fires for a Task-dispatched **subagent's own session**, not just the top-level orchestrator session that dispatched it.

Finding: this is **inconclusive from static repo inspection alone**. The hook is wired as a project-scope `Stop` hook in `.claude/settings.json` and operates entirely on the `transcript_path` supplied in that session's Stop-hook payload — the detection logic itself (unresolved `Task` tool_use ids, unresolved `run_in_background` Bash dispatches, unretired `Monitor`/`ScheduleWakeup` timers) is transcript-shape-agnostic and would apply equally to any transcript it's handed. Whether a Task-dispatched subagent gets its own independent Stop-hook invocation (and therefore its own transcript checked before *its* turn can end), versus only the top-level orchestrator's session ever firing a Stop hook, is a Claude Code harness behavior not documented anywhere in this repo, and I don't have a way to verify it from a live or synthetic transcript in this environment.

Per the curated AC's own guidance ("if subagent sessions are not covered, file a fast-follow rather than silently expanding this issue's scope"), I'm not modifying `guard-background-subagents.sh` in this PR — the fix here is the doc-level rule, which applies regardless of whether the mechanical backstop also covers subagent sessions. I'd recommend a small fast-follow issue to verify this with a real transcript from a Judge subagent's own session, but didn't want to invent that verification result here.

## Test plan

- [x] Manual re-read of the updated `judge.md` CI-pending guidance: gives exactly two documented paths (skip-and-continue for batch, bounded foreground poll for single-PR), with an explicit prohibition on the background-monitor pattern in between.
- [x] Confirmed the existing "When CI is Pending" skip-and-continue procedure is unchanged (only content added after it) — no regression to the common batch-mode case.
- [x] `defaults/roles/judge.md` symlink confirmed to point at the edited file; no second copy needed updating.
- [N/A] No code/test changes — `guard-background-subagents.sh` untouched pending the fast-follow investigation above.

Closes #4883