### PR TITLE
feat(daemon): add saturation admission brake to hold new sweeps on a loaded host

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1762,7 +1762,11 @@ dynamic_cap = min(healthy-token count × per-token concurrency, disk headroom, c
 from live inputs, so pool/disk/backlog changes are honored without a daemon
 restart. A fourth **cpu/load headroom** term sat in this `min(...)` from #3978
 until **#4512 deleted it** — see [Why there is no CPU term in
-admission](#why-there-is-no-cpu-term-in-admission-4512) below.
+admission](#why-there-is-no-cpu-term-in-admission-4512) below. There is still no
+CPU term in the cap; since #4903 a separate
+[saturation admission brake](#saturation-admission-brake-4903) can *hold* new
+admissions when the host is measurably saturated, without resizing the cap or
+touching running work.
 
 | Input | Source | Bound it enforces |
 |-------|--------|-------------------|
@@ -1811,7 +1815,10 @@ actually is**:
 The **host-distress circuit breaker** (#4235) is unchanged and is what makes a
 hand-tuned knob safe to raise: a mis-set `maxConcurrent` trips a **measured**
 breaker (load-per-core), instead of melting the host on the strength of a
-mis-estimated constant.
+mis-estimated constant. #4903 added a third guard on the same measured signal —
+the point-in-time [saturation admission brake](#saturation-admission-brake-4903)
+— after a CPU-heavy (analog-simulation) workload reached 12× overcommit on a
+host whose `maxConcurrent` was never set.
 
 `cpu_headroom.rs` survives as a pure **measurement** module — logical core
 count, load average, measured idle fraction, and the `is_host_saturated`
@@ -1881,6 +1888,108 @@ daemon path while silently ignoring it on the sweep path — worse than today's
 consistent env-only behavior. Wiring the Bash `config-resolver.sh` into
 `disk-headroom.sh` too is a separate, larger change; file a follow-up if that
 cost is judged worth paying.
+
+#### Saturation admission brake (#4903)
+
+Deleting the CPU term left admission with **no term that reads the host at
+all**. That is correct for the workload #4512 measured, and wrong for a workload
+it did not anticipate. `loom-worker-1` (8 vCPU) was observed at **load average
+95** — `11.9` load/core, `0.07%` idle — from only **three** in-flight sweeps,
+because all three were analog-simulation repos (`gf180-*`) that had spawned 16
+`ngspice` processes between them. SPICE simulation is sustained CPU for tens of
+minutes, not API-wait, so for those repos a sweep is closer to a build than to a
+conversation. The daemon *measured* the saturation (`loadavg_1m` and
+`cpu_idle_fraction` are both in the dispatch headroom report) and did not act on
+it: `capacity_bound: false`, cap `12`, nine more slots nominally free.
+
+The fix is a **brake on admission, not a return to CPU-based sizing**. Once per
+work-finder tick the daemon asks `cpu_headroom::is_host_saturated` — the same
+predicate the build gate's load-aware deferral uses — whether load-per-core is
+at/over a hold threshold, and if so it **holds new admissions** for that tick
+and re-checks on the next one. It does not resize the cap, does not estimate
+per-sweep cores, and **never** touches work that is already running.
+
+| | Value |
+|---|---|
+| Config | `autonomous.workFinder.saturationBrake.enabled` / `.loadPerCoreHold` |
+| Env | `LOOM_ADMISSION_BRAKE` / `LOOM_ADMISSION_BRAKE_LOAD_PER_CORE` |
+| Default | **on**, hold at **4.0** load/core |
+| Precedence | env > config > default, resolved once at daemon startup |
+
+Properties that are load-bearing (and are pinned by tests):
+
+- **In-flight sweeps are never killed or preempted.** The brake is applied only
+  where *new* candidates are admitted, immediately before the concurrency-cap
+  check; it has no path to the reaper or to any running child. A held tick
+  dispatches nothing and returns, and the running sweeps drain normally — which
+  is precisely how the host recovers.
+- **A healthy host is unchanged.** Below the threshold the admission path is
+  byte-for-byte the pre-#4903 one, so an idle 8-core host still reaches its
+  configured cap. `4.0` is deliberately generous: a busy-but-fine host sits under
+  `1.0`, and the incident that motivated the brake was at `11.9`.
+- **Fail-safe on missing data.** No load-average source (or a zero CPU count)
+  ⇒ no hold. Absent evidence is never treated as load.
+- **Nothing latches.** The hold is re-evaluated every tick and releases the
+  moment load drops back under the threshold.
+
+**How this differs from the host-distress circuit breaker (#4235)** — the two
+read the same normalized ratio and are complements, not duplicates:
+
+| | Admission brake (#4903) | Host breaker (#4235) |
+|---|---|---|
+| Nature | point-in-time: one reading, one decision | stateful: trips only after N consecutive over-threshold ticks |
+| Default threshold | `4.0` load/core | `2.5` load/core |
+| Release | immediate, first tick under the line | after a 5-minute cool-down |
+| Explicit `dispatch_sweep` | never blocks it | hard-blocks unless `force` |
+| Purpose | stop *adding* to a full host | remember a *meltdown* so a load dip cannot re-admit a whole wave |
+
+The brake's threshold sits *above* the breaker's on purpose: it decides from a
+single reading, so it must be sure, whereas the breaker's lower bar is paid for
+by requiring the load to be sustained.
+
+**Visibility.** `loom-daemon status` prints an `Admission brake:` line
+(`HOLDING …` / `OK …` / `disabled`), `--json` carries an `admission_brake`
+object, and while the brake is holding the capacity block's
+"not capacity-bound … the limiter is work availability" line is **replaced** by
+an `⚠ ADMISSION BRAKE HOLDING` line naming the host as the limiter. Per-tick
+deferrals are counted as `deferred (host saturated)` in the work-finder tick log
+and as `deferred-saturation` in `loom-daemon health`. A host holding back says
+so; it no longer reads as idle.
+
+#### Sizing `maxConcurrent`: per-machine **and** per-workload (#4512, #4903)
+
+`autonomous.workFinder.maxConcurrent` is the only *policy* term in the cap, and
+it is **not** a fleet-wide constant. It is a property of one machine **running
+one kind of work**. Two hosts with identical core counts want very different
+values, and the same host wants a different value if you move a different repo
+onto it:
+
+| Workload | What a sweep actually does | Reasonable `maxConcurrent` on 8 cores |
+|---|---|---|
+| **Software repos** (Loom itself, most product repos) | Dominated by API-wait — curator/builder/judge conversations. The heavy phases (release builds, full test suites, the build gate) are a small fraction of wall-clock, and they already serialize on the [machine-wide build slot](#machine-wide-build-slot-4512). | **10+** — the host sits mostly idle at lower values (#4512 measured 95% idle at a cap of 2) |
+| **Analog / simulation repos** (`gf180-*` running `ngspice`) | Dominated by sustained CPU — one sweep spawns ~5 simulator processes, each near 50% of a core, for tens of minutes. A sweep here is closer to a build than to a conversation. | **2–3** — at 12 the host reaches 12× overcommit and every sweep's simulations contend, so wall-clock per sweep grows faster than concurrency adds |
+
+Consequences worth internalizing:
+
+- **Unset is not "safe".** An unset `maxConcurrent` contributes a *default*, not
+  an operator's judgement — which is exactly the input #4512's design depends on.
+  The `loom-worker-1` incident happened on a host where it was never set.
+- **Set it per machine, on the machine.** A repo's committed `.loom/config.json`
+  is shared by every host that clones it; the per-machine value belongs in the
+  machine-level tier (`~/.local/share/loom/config/defaults.json`) or in
+  `.loom/config.local.json`, which is why the resolver merges four tiers.
+- **Mixed hosts size to the heaviest tenant.** If analog and software repos share
+  a host, one sweep is not one unit of load — tune down to what the heavy repo
+  needs (per-repo weighting is deliberately *not* implemented; see #4903).
+- **Throughput inverts past the knee.** Beyond the point where sweeps contend,
+  adding concurrency makes everything slower. Raise the knob only while
+  `loom-daemon status` shows the ceiling binding *and* the host measurably idle
+  — that is exactly the pair
+  [`loom-daemon calibrate`](#sizing-a-host-loom-daemon-calibrate-4390-measurement-only-since-4512)
+  reports.
+- **The brake is a backstop, not a substitute.** A correctly-tuned
+  `maxConcurrent` should mean the saturation brake never engages. If it *is*
+  engaging, that is the signal to lower the knob for this machine's workload.
 
 #### Machine-wide build slot (#4512)
 
@@ -2436,8 +2545,10 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.model` | *(per-dispatch `dispatch_sweep` `model` param)* | `sonnet` | Model pinned on **every** daemon-dispatched child (work-finder, epic supervisor, and `dispatch_sweep` when its `model` param is absent). See below (#3944) |
 | `autonomous.workFinder.enabled` | `LOOM_WORK_FINDER` | `false` | Master on/off for the finder loop |
 | `autonomous.workFinder.intervalSecs` | `LOOM_WORK_FINDER_INTERVAL_SECS` | `60` | Zero/invalid → default |
-| `autonomous.workFinder.maxConcurrent` | `LOOM_WORK_FINDER_MAX_CONCURRENT` | `3` | **The** per-machine admission knob since #4512 — an operator ceiling, not a fixed target, tuned empirically from `loom-daemon calibrate` / `status`. Expect well above the shipped default on an API-bound worker (10+ on 8 cores) |
+| `autonomous.workFinder.maxConcurrent` | `LOOM_WORK_FINDER_MAX_CONCURRENT` | `3` | **The** per-machine admission knob since #4512 — an operator ceiling, not a fixed target, tuned empirically from `loom-daemon calibrate` / `status`. Per-machine **and workload-dependent** (#4903): ~10+ on an 8-core API-bound (software) worker, but **2–3** on the same 8 cores running analog/simulation sweeps. See [Sizing `maxConcurrent`](#sizing-maxconcurrent-per-machine-and-per-workload-4512-4903) below |
 | `autonomous.workFinder.maxAdmissionsPerTick` | `LOOM_WORK_FINDER_MAX_ADMISSIONS_PER_TICK` | `3` | Per-tick **ramp** cap (#4234) — bounds how many *new* sweeps one tick may admit, independent of `maxConcurrent`/the live dynamic cap. Zero/invalid → default; resolved once at startup, mirroring `maxConcurrent`. See [Per-tick admission (ramp) cap](#per-tick-admission-ramp-cap-4234) below |
+| `autonomous.workFinder.saturationBrake.enabled` | `LOOM_ADMISSION_BRAKE` | `true` | Saturation admission brake on/off (#4903). A safety backstop — **defaults on**. Holds *new* admissions while the host is already saturated; never preempts a running sweep. Env truthy (`1`/`true`/`yes`/`on`) enables, any other value disables; wins over config. See [Saturation admission brake](#saturation-admission-brake-4903) below |
+| `autonomous.workFinder.saturationBrake.loadPerCoreHold` | `LOOM_ADMISSION_BRAKE_LOAD_PER_CORE` | `4.0` | Load-per-core at/over which new admissions are held for that tick. `<= 0`/invalid → default. Deliberately above the host breaker's `2.5` trip: the brake decides from a single reading, the breaker from sustained ticks |
 | `autonomous.workFinder.quarantine.enabled` | `LOOM_WORK_FINDER_QUARANTINE` | `true` | Insta-crash quarantine on/off (#3939). A safety backstop — defaults on |
 | `autonomous.workFinder.quarantine.threshold` | `LOOM_WORK_FINDER_QUARANTINE_THRESHOLD` | `3` | Consecutive insta-crashes before an issue is quarantined. Zero/invalid → default |
 | `autonomous.workFinder.quarantine.ttlSecs` | `LOOM_WORK_FINDER_QUARANTINE_TTL_SECS` | `3600` | How long a quarantine entry persists before auto-release. Zero/invalid → default |

--- a/loom-daemon/src/admission_brake.rs
+++ b/loom-daemon/src/admission_brake.rs
@@ -1,0 +1,684 @@
+//! Saturation admission brake (Issue #4903).
+//!
+//! # Why this exists
+//!
+//! #4512 removed the CPU term from the dynamic concurrency cap
+//! ([`crate::work_finder::resolve_dynamic_max_concurrent`]) and that removal was
+//! right for the workload it measured: an issue→PR sweep is dominated by
+//! API-wait, so pricing every sweep as a build throttled the ~90% low-CPU
+//! majority to defend against the minority case. But it left admission with **no
+//! term at all** that reads the host: the cap is `min(token axis, disk headroom,
+//! configured_max)`, and when `maxConcurrent` is unset (or generously set for an
+//! API-bound repo) nothing bounds admission by observed load.
+//!
+//! A CPU-heavy workload then walks straight past it. `loom-worker-1` (8 vCPU) was
+//! observed at **load average 95** — `12×` overcommit, `0.07%` CPU idle — from
+//! only three in-flight sweeps, because all three were analog-simulation repos
+//! (`gf180-*`) that had spawned 16 `ngspice` processes between them. The daemon
+//! *measured* the saturation (`loadavg_1m` and `cpu_idle_fraction` are in the
+//! dispatch headroom report) and did not act on it: `capacity_bound: false`, cap
+//! `12`, nine more slots nominally free.
+//!
+//! This module is the missing backstop, and it is deliberately **not** a return
+//! to CPU-based sizing: it does not resize the cap, it does not estimate
+//! per-sweep cores, and it never touches work that is already running. It answers
+//! exactly one question, once per work-finder tick — *is this host already too
+//! full to take on more?* — and when the answer is yes it **holds new
+//! admissions** and re-checks on the next tick.
+//!
+//! # Distinction from the host-distress circuit breaker (#4235)
+//!
+//! Both read the same normalized ratio ([`crate::cpu_headroom::load_per_core`]),
+//! and they are complements, not duplicates:
+//!
+//! | | Admission brake (this module, #4903) | Host breaker ([`crate::host_breaker`], #4235) |
+//! |---|---|---|
+//! | Nature | **Point-in-time** — one reading, one decision | **Stateful** — trips only on N consecutive over-threshold ticks |
+//! | Default threshold | `4.0` load/core (see [`DEFAULT_ADMISSION_BRAKE_LOAD_PER_CORE`]) | `2.5` load/core |
+//! | Release | Immediate, the first tick load drops back under | After a 5-minute cool-down |
+//! | Explicit `dispatch_sweep` | **Never blocks it** (an operator asking by hand is not autonomous admission) | Hard-blocks unless `force` |
+//! | Purpose | Stop *adding* to a full host | Remember a *meltdown* so a load dip cannot re-admit a whole wave |
+//!
+//! So the brake is the cheap, fast-releasing guard that keeps a busy host from
+//! being handed more work this minute; the breaker is the slow, sticky guard that
+//! remembers genuine distress across minutes. The brake's threshold sits *above*
+//! the breaker's on purpose — it is a per-tick scheduling decision that must not
+//! fire on a healthy burst, whereas the breaker's lower bar is paid for by
+//! requiring the load to be sustained.
+//!
+//! # Fail-safe
+//!
+//! A missing load reading (`None` from [`crate::cpu_headroom::read_loadavg_1m`],
+//! or a zero CPU count) means **no hold** — [`crate::cpu_headroom::is_host_saturated`]
+//! returns `None` on absent evidence and this module treats that as "not
+//! saturated", exactly the contract the build gate's load-aware deferral (#4259)
+//! follows. Absent evidence must never look like load.
+//!
+//! # In-flight sweeps are never touched
+//!
+//! The brake is consulted only where *new* candidates are admitted
+//! ([`crate::work_finder::tick_with_admission_cap`] /
+//! [`crate::work_finder::tick_multi_with_admission_cap`], immediately before the
+//! concurrency-cap check). It has no path to the reaper, to `cancel_sweep`, or to
+//! any running child process. A held tick dispatches nothing and returns; the
+//! sweeps already running finish normally, which is what lets the host recover.
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+use chrono::{DateTime, Utc};
+
+// ============================================================================
+// Config surface (env > config > default, mirroring host_breaker + work_finder)
+// ============================================================================
+
+/// Env var toggling the saturation admission brake. `0`/`false`/`no`/`off`
+/// disables; anything truthy (`1`/`true`/`yes`/`on`) forces on. Overrides
+/// config. Defaults ON — a safety backstop, the same call
+/// [`crate::host_breaker::HOST_BREAKER_ENABLE_ENV`] makes.
+pub const ADMISSION_BRAKE_ENABLE_ENV: &str = "LOOM_ADMISSION_BRAKE";
+
+/// Env var overriding the load-per-core hold threshold. A `<= 0`/invalid value
+/// falls through to config/default.
+pub const ADMISSION_BRAKE_LOAD_PER_CORE_ENV: &str = "LOOM_ADMISSION_BRAKE_LOAD_PER_CORE";
+
+/// Default: the brake is enabled. It is a backstop, and like the host breaker
+/// it only acts on measured evidence and never kills running work, so a repo
+/// that never enables the work-finder sees zero behavior change (the finder loop
+/// is the brake's sole sampler) and a repo that does gets the guard for free.
+pub const DEFAULT_ADMISSION_BRAKE_ENABLED: bool = true;
+
+/// Default load-per-core ratio at/above which new admissions are held.
+///
+/// `4.0` is deliberately **generous**: four runnable threads per logical core is
+/// far above any healthy burst (a busy-but-fine host sits under `1.0`; the build
+/// gate defers its own build at `0.9`, [`crate::cpu_headroom::DEFAULT_GATE_LOAD_THRESHOLD`]),
+/// and far below the `12.0` overcommit that motivated this brake. The point is a
+/// backstop no reasonable workload trips, not a scheduler — an operator who wants
+/// tighter packing tunes `maxConcurrent`, which remains **the** admission knob.
+///
+/// It sits above [`crate::host_breaker::DEFAULT_HOST_BREAKER_LOAD_PER_CORE`]
+/// (`2.5`) on purpose: see the module docs' comparison table. The breaker fires
+/// lower because it demands *sustained* over-threshold ticks; the brake decides
+/// from a single reading, so it must be sure.
+pub const DEFAULT_ADMISSION_BRAKE_LOAD_PER_CORE: f64 = 4.0;
+
+/// Resolved brake parameters (env > config > default), captured once at daemon
+/// startup and held by [`SharedAdmissionBrake`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AdmissionBrakeConfig {
+    /// Whether the brake is active. When `false` it never holds and never
+    /// records a hold (byte-for-byte the pre-#4903 admission path).
+    pub enabled: bool,
+    /// Load-per-core at/above which new admissions are held this tick.
+    pub load_per_core_threshold: f64,
+}
+
+impl Default for AdmissionBrakeConfig {
+    fn default() -> Self {
+        Self {
+            enabled: DEFAULT_ADMISSION_BRAKE_ENABLED,
+            load_per_core_threshold: DEFAULT_ADMISSION_BRAKE_LOAD_PER_CORE,
+        }
+    }
+}
+
+/// The raw config half read from
+/// `.loom/config.json → autonomous.workFinder.saturationBrake` (each field
+/// `None` when absent/malformed), before env/default resolution.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct AdmissionBrakeConfigFile {
+    pub enabled: Option<bool>,
+    pub load_per_core_threshold: Option<f64>,
+}
+
+/// Read `.loom/config.json → autonomous.workFinder.saturationBrake`, soft-failing
+/// every field to `None` (env/default resolution) on a missing file, malformed
+/// JSON, or a missing block. Mirrors [`crate::host_breaker::read_host_breaker_config`].
+///
+/// Nested under `workFinder` rather than beside `hostBreaker` because the brake
+/// is part of the work-finder's **admission** policy — the same block that holds
+/// `maxConcurrent`, which it backstops.
+#[must_use]
+pub fn read_admission_brake_config(repo_root: &std::path::Path) -> AdmissionBrakeConfigFile {
+    let effective = crate::config_resolver::resolve_effective_config(repo_root);
+    let Some(autonomous) = crate::config_resolver::get_path(&effective, "autonomous") else {
+        return AdmissionBrakeConfigFile::default();
+    };
+    let brake = autonomous
+        .get("workFinder")
+        .and_then(|w| w.get("saturationBrake"));
+    AdmissionBrakeConfigFile {
+        enabled: brake
+            .and_then(|b| b.get("enabled"))
+            .and_then(serde_json::Value::as_bool),
+        load_per_core_threshold: brake
+            .and_then(|b| b.get("loadPerCoreHold"))
+            .and_then(serde_json::Value::as_f64)
+            .filter(|&f| f > 0.0),
+    }
+}
+
+/// Env override for [`ADMISSION_BRAKE_ENABLE_ENV`] — `Some(true/false)` when set
+/// to a recognized truthy/falsy value, `None` when unset (config/default decides).
+fn env_enabled() -> Option<bool> {
+    match std::env::var(ADMISSION_BRAKE_ENABLE_ENV) {
+        Ok(v) => {
+            Some(matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        }
+        Err(_) => None,
+    }
+}
+
+fn env_load_per_core() -> Option<f64> {
+    std::env::var(ADMISSION_BRAKE_LOAD_PER_CORE_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<f64>().ok())
+        .filter(|&f| f > 0.0)
+}
+
+/// Resolve the full [`AdmissionBrakeConfig`] with precedence **env > config >
+/// default** for every field independently.
+#[must_use]
+pub fn resolve_config(file: &AdmissionBrakeConfigFile) -> AdmissionBrakeConfig {
+    AdmissionBrakeConfig {
+        enabled: env_enabled()
+            .or(file.enabled)
+            .unwrap_or(DEFAULT_ADMISSION_BRAKE_ENABLED),
+        load_per_core_threshold: env_load_per_core()
+            .or(file.load_per_core_threshold)
+            .unwrap_or(DEFAULT_ADMISSION_BRAKE_LOAD_PER_CORE),
+    }
+}
+
+/// Convenience: read `repo_root`'s config and resolve it end-to-end.
+#[must_use]
+pub fn resolve_config_for(repo_root: &std::path::Path) -> AdmissionBrakeConfig {
+    resolve_config(&read_admission_brake_config(repo_root))
+}
+
+// ============================================================================
+// Pure decision
+// ============================================================================
+
+/// One tick's brake decision — the pure output of [`decide`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BrakeDecision {
+    /// Whether **new** admissions are held this tick. Always `false` when the
+    /// brake is disabled or the load reading is absent.
+    pub held: bool,
+    /// The observed load-per-core, or `None` when no load source was available.
+    pub load_per_core: Option<f64>,
+    /// The threshold the decision was taken against (echoed for the log/status
+    /// line so an operator never has to guess which knob was in force).
+    pub threshold: f64,
+}
+
+/// The pure decision function: is this host too saturated to admit new work?
+///
+/// Delegates the ratio and the comparison to
+/// [`crate::cpu_headroom::is_host_saturated`] so the brake, the build gate's
+/// load-aware deferral (#4259), and the host breaker (#4235) all agree on one
+/// definition of load-per-core.
+///
+/// Fail-safe in two directions:
+/// - `enabled: false` ⇒ never held (the reading is still reported, so the status
+///   surface stays honest about *why* nothing is being held).
+/// - Missing load / zero CPUs ⇒ `is_host_saturated` yields `None` ⇒ not held.
+///   Absent evidence is never treated as load.
+#[must_use]
+pub fn decide(
+    config: &AdmissionBrakeConfig,
+    loadavg_1m: Option<f64>,
+    ncpu: usize,
+) -> BrakeDecision {
+    let load_per_core = crate::cpu_headroom::load_per_core_from(loadavg_1m, ncpu);
+    let held = config.enabled
+        && crate::cpu_headroom::is_host_saturated(loadavg_1m, ncpu, config.load_per_core_threshold)
+            .unwrap_or(false);
+    BrakeDecision {
+        held,
+        load_per_core,
+        threshold: config.load_per_core_threshold,
+    }
+}
+
+// ============================================================================
+// Runtime state + transitions
+// ============================================================================
+
+/// The evolving brake state held by [`SharedAdmissionBrake`].
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct BrakeRuntime {
+    /// Whether the most recent observation held new admissions.
+    pub held: bool,
+    /// When the current hold streak began (`None` while not holding).
+    pub held_since: Option<DateTime<Utc>>,
+    /// How many consecutive ticks the current streak has held (`0` when not
+    /// holding).
+    pub held_ticks: u32,
+    /// The most recent load-per-core sample observed.
+    pub last_load_per_core: Option<f64>,
+}
+
+/// Which edge a [`Transition`] represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransitionKind {
+    /// Not holding → holding (the host crossed the threshold).
+    Engaged,
+    /// Holding → not holding (the host recovered).
+    Released,
+}
+
+impl TransitionKind {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TransitionKind::Engaged => "engaged",
+            TransitionKind::Released => "released",
+        }
+    }
+}
+
+/// A recorded hold/release edge — the payload for the operator log line. Emitted
+/// only on a real state change, never every tick.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Transition {
+    pub kind: TransitionKind,
+    pub reason: String,
+}
+
+// ============================================================================
+// A serializable snapshot for the status surface
+// ============================================================================
+
+/// A point-in-time snapshot of the brake for `loom-daemon status`. Maps to
+/// [`crate::types::AdmissionBrakeStatus`] via [`Self::into_status`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BrakeSnapshot {
+    pub enabled: bool,
+    pub held: bool,
+    pub load_per_core: Option<f64>,
+    pub load_per_core_threshold: f64,
+    pub held_since: Option<DateTime<Utc>>,
+    pub held_ticks: u32,
+}
+
+impl BrakeSnapshot {
+    /// Convert to the wire/status type in [`crate::types`].
+    #[must_use]
+    pub fn into_status(self) -> crate::types::AdmissionBrakeStatus {
+        crate::types::AdmissionBrakeStatus {
+            enabled: self.enabled,
+            held: self.held,
+            load_per_core: self.load_per_core,
+            load_per_core_threshold: self.load_per_core_threshold,
+            held_since: self.held_since,
+            held_ticks: self.held_ticks,
+        }
+    }
+}
+
+// ============================================================================
+// Shared runtime handle + process-global registration
+// ============================================================================
+
+/// Thread-safe brake handle: the work-finder loop [`observe`](Self::observe)s a
+/// fresh load sample into it each tick and acts on the returned decision; the
+/// IPC status path reads [`snapshot`](Self::snapshot). All decisions delegate to
+/// the pure [`decide`].
+#[derive(Debug)]
+pub struct SharedAdmissionBrake {
+    config: AdmissionBrakeConfig,
+    inner: Mutex<BrakeRuntime>,
+}
+
+// Allow expect_used: a poisoned brake mutex means another thread panicked while
+// holding it — unrecoverable, matching host_breaker / ipc.rs / auto_update.rs.
+#[allow(clippy::expect_used)]
+impl SharedAdmissionBrake {
+    #[must_use]
+    pub fn new(config: AdmissionBrakeConfig) -> Self {
+        Self {
+            config,
+            inner: Mutex::new(BrakeRuntime::default()),
+        }
+    }
+
+    #[must_use]
+    pub fn config(&self) -> AdmissionBrakeConfig {
+        self.config
+    }
+
+    /// Fold one load reading into the brake, returning the decision plus any
+    /// hold/release edge (the caller logs on `Some`).
+    ///
+    /// `loadavg_1m` / `ncpu` are passed in — never re-probed here — so the
+    /// reading that produced the decision is exactly the reading the caller
+    /// already sampled for the host breaker this tick. One read, one decision:
+    /// no window in which the brake and the breaker disagree about the host.
+    pub fn observe(
+        &self,
+        loadavg_1m: Option<f64>,
+        ncpu: usize,
+        now: DateTime<Utc>,
+    ) -> (BrakeDecision, Option<Transition>) {
+        let decision = decide(&self.config, loadavg_1m, ncpu);
+        let mut guard = self.inner.lock().expect("admission brake mutex poisoned");
+        let was_held = guard.held;
+        guard.held = decision.held;
+        guard.last_load_per_core = decision.load_per_core;
+        let load_str = decision
+            .load_per_core
+            .map_or_else(|| "n/a".to_string(), |l| format!("{l:.2}"));
+        let transition = if decision.held {
+            guard.held_ticks = guard.held_ticks.saturating_add(1);
+            if was_held {
+                None
+            } else {
+                guard.held_since = Some(now);
+                Some(Transition {
+                    kind: TransitionKind::Engaged,
+                    reason: format!(
+                        "host saturated (load {load_str}/core ≥ {:.2}) — holding NEW sweep \
+                         admissions; in-flight sweeps are untouched and will drain",
+                        decision.threshold
+                    ),
+                })
+            }
+        } else {
+            let ticks = guard.held_ticks;
+            guard.held_ticks = 0;
+            guard.held_since = None;
+            if was_held {
+                Some(Transition {
+                    kind: TransitionKind::Released,
+                    reason: format!(
+                        "host recovered (load {load_str}/core < {:.2} after {ticks} held tick(s)) \
+                         — resuming admissions",
+                        decision.threshold
+                    ),
+                })
+            } else {
+                None
+            }
+        };
+        (decision, transition)
+    }
+
+    /// Whether the brake is currently holding new admissions.
+    #[must_use]
+    pub fn is_holding(&self) -> bool {
+        if !self.config.enabled {
+            return false;
+        }
+        self.inner
+            .lock()
+            .expect("admission brake mutex poisoned")
+            .held
+    }
+
+    /// A snapshot for the status surface.
+    #[must_use]
+    pub fn snapshot(&self) -> BrakeSnapshot {
+        let guard = self.inner.lock().expect("admission brake mutex poisoned");
+        BrakeSnapshot {
+            enabled: self.config.enabled,
+            held: self.config.enabled && guard.held,
+            load_per_core: guard.last_load_per_core,
+            load_per_core_threshold: self.config.load_per_core_threshold,
+            held_since: guard.held_since,
+            held_ticks: guard.held_ticks,
+        }
+    }
+}
+
+/// Process-global brake handle. The daemon registers one at startup (alongside
+/// the host breaker) so [`crate::ipc::build_daemon_status`] can read it without
+/// threading an `Arc` through the IPC server. Unset (never registered) reads as
+/// "not holding", i.e. zero behavior change.
+static GLOBAL: OnceLock<Arc<SharedAdmissionBrake>> = OnceLock::new();
+
+/// Register the process-global brake handle. Idempotent: only the first
+/// registration wins (there is exactly one brake per daemon process).
+pub fn register_global(brake: Arc<SharedAdmissionBrake>) {
+    let _ = GLOBAL.set(brake);
+}
+
+/// The process-global brake handle, if one has been registered.
+#[must_use]
+pub fn global() -> Option<Arc<SharedAdmissionBrake>> {
+    GLOBAL.get().cloned()
+}
+
+/// Whether the process-global brake is currently holding new admissions.
+/// `false` when none is registered (zero behavior change).
+#[must_use]
+pub fn global_is_holding() -> bool {
+    GLOBAL.get().is_some_and(|b| b.is_holding())
+}
+
+/// Fold one load reading into the process-global brake and return whether new
+/// admissions are held this tick, logging any hold/release edge.
+///
+/// A no-op returning `false` when no brake is registered — the work-finder loop
+/// calls this unconditionally, exactly as it does
+/// [`crate::host_breaker::global_is_suppressed`].
+pub fn global_observe(loadavg_1m: Option<f64>, ncpu: usize, now: DateTime<Utc>) -> bool {
+    let Some(brake) = GLOBAL.get() else {
+        return false;
+    };
+    let (decision, transition) = brake.observe(loadavg_1m, ncpu, now);
+    if let Some(t) = transition {
+        match t.kind {
+            TransitionKind::Engaged => {
+                log::warn!("admission_brake: engaged — {}", t.reason);
+            }
+            TransitionKind::Released => {
+                log::info!("admission_brake: released — {}", t.reason);
+            }
+        }
+    }
+    decision.held
+}
+
+/// A snapshot of the process-global brake, or `None` when none is registered.
+#[must_use]
+pub fn global_snapshot() -> Option<BrakeSnapshot> {
+    GLOBAL.get().map(|b| b.snapshot())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::float_cmp)]
+mod tests {
+    use super::*;
+
+    fn cfg(enabled: bool, threshold: f64) -> AdmissionBrakeConfig {
+        AdmissionBrakeConfig {
+            enabled,
+            load_per_core_threshold: threshold,
+        }
+    }
+
+    fn t0() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-08-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    // ---- pure decision ----------------------------------------------------
+
+    #[test]
+    fn saturated_host_holds_new_admissions() {
+        // The reported incident: load 95 on 8 cores = 11.9/core, far over 4.0.
+        let d = decide(&cfg(true, 4.0), Some(95.29), 8);
+        assert!(d.held);
+        assert!((d.load_per_core.unwrap() - 11.911_25).abs() < 1e-6);
+        assert_eq!(d.threshold, 4.0);
+    }
+
+    #[test]
+    fn threshold_is_inclusive_at_the_boundary() {
+        // Exactly at the threshold holds (`is_host_saturated` uses `>=`).
+        assert!(decide(&cfg(true, 4.0), Some(32.0), 8).held);
+        // A hair under does not.
+        assert!(!decide(&cfg(true, 4.0), Some(31.9), 8).held);
+    }
+
+    #[test]
+    fn healthy_host_never_holds() {
+        // A busy-but-fine 8-core host: load 6 = 0.75/core.
+        assert!(!decide(&cfg(true, 4.0), Some(6.0), 8).held);
+        // Even a heavy burst well above 1.0/core stays under the generous bar.
+        assert!(!decide(&cfg(true, 4.0), Some(24.0), 8).held);
+        // An idle host, obviously.
+        assert!(!decide(&cfg(true, 4.0), Some(0.05), 8).held);
+    }
+
+    #[test]
+    fn missing_load_fails_safe_to_no_hold() {
+        let d = decide(&cfg(true, 4.0), None, 8);
+        assert!(!d.held, "absent evidence must never read as load");
+        assert_eq!(d.load_per_core, None);
+        // A zero CPU count is the other missing-data shape.
+        assert!(!decide(&cfg(true, 4.0), Some(95.0), 0).held);
+    }
+
+    #[test]
+    fn disabled_brake_never_holds_but_still_reports_the_reading() {
+        let d = decide(&cfg(false, 4.0), Some(95.29), 8);
+        assert!(!d.held);
+        assert!(d.load_per_core.is_some(), "status must stay honest when disabled");
+    }
+
+    #[test]
+    fn brake_default_threshold_sits_above_the_host_breaker_trip() {
+        // The two thresholds encode different policies; the ordering is
+        // load-bearing (see the module docs' comparison table), so pin it.
+        const {
+            assert!(
+                DEFAULT_ADMISSION_BRAKE_LOAD_PER_CORE
+                    > crate::host_breaker::DEFAULT_HOST_BREAKER_LOAD_PER_CORE
+            );
+        }
+        const {
+            assert!(
+                DEFAULT_ADMISSION_BRAKE_LOAD_PER_CORE
+                    > crate::cpu_headroom::DEFAULT_GATE_LOAD_THRESHOLD
+            );
+        }
+    }
+
+    // ---- shared handle / transitions --------------------------------------
+
+    #[test]
+    fn observe_reports_engage_and_release_edges_once_each() {
+        let brake = SharedAdmissionBrake::new(cfg(true, 4.0));
+        let now = t0();
+
+        // Tick 1: saturated → engage edge.
+        let (d, tr) = brake.observe(Some(95.0), 8, now);
+        assert!(d.held);
+        assert_eq!(tr.map(|t| t.kind), Some(TransitionKind::Engaged));
+        assert!(brake.is_holding());
+
+        // Tick 2: still saturated → no repeated edge (no per-tick log spam).
+        let (d, tr) = brake.observe(Some(90.0), 8, now + chrono::Duration::seconds(60));
+        assert!(d.held);
+        assert!(tr.is_none());
+        assert_eq!(brake.snapshot().held_ticks, 2);
+        assert_eq!(brake.snapshot().held_since, Some(now));
+
+        // Tick 3: recovered → release edge, streak state cleared.
+        let (d, tr) = brake.observe(Some(4.0), 8, now + chrono::Duration::seconds(120));
+        assert!(!d.held);
+        assert_eq!(tr.map(|t| t.kind), Some(TransitionKind::Released));
+        assert!(!brake.is_holding());
+        let snap = brake.snapshot();
+        assert_eq!(snap.held_ticks, 0);
+        assert_eq!(snap.held_since, None);
+
+        // Tick 4: still healthy → no edge.
+        let (_, tr) = brake.observe(Some(3.0), 8, now + chrono::Duration::seconds(180));
+        assert!(tr.is_none());
+    }
+
+    #[test]
+    fn a_transient_dip_releases_immediately_unlike_the_breaker_cooldown() {
+        // The brake is point-in-time by design: it re-checks every tick and does
+        // NOT hold through a cool-down (that is the host breaker's job).
+        let brake = SharedAdmissionBrake::new(cfg(true, 4.0));
+        brake.observe(Some(95.0), 8, t0());
+        assert!(brake.is_holding());
+        brake.observe(Some(1.0), 8, t0() + chrono::Duration::seconds(60));
+        assert!(!brake.is_holding());
+    }
+
+    #[test]
+    fn disabled_handle_never_holds_and_snapshot_says_so() {
+        let brake = SharedAdmissionBrake::new(cfg(false, 4.0));
+        let (d, tr) = brake.observe(Some(95.0), 8, t0());
+        assert!(!d.held);
+        assert!(tr.is_none());
+        assert!(!brake.is_holding());
+        let snap = brake.snapshot();
+        assert!(!snap.enabled);
+        assert!(!snap.held);
+        assert!(snap.load_per_core.is_some());
+    }
+
+    #[test]
+    fn snapshot_maps_onto_the_wire_status_type() {
+        let brake = SharedAdmissionBrake::new(cfg(true, 4.0));
+        brake.observe(Some(95.0), 8, t0());
+        let status = brake.snapshot().into_status();
+        assert!(status.enabled);
+        assert!(status.held);
+        assert_eq!(status.load_per_core_threshold, 4.0);
+        assert_eq!(status.held_ticks, 1);
+        assert_eq!(status.held_since, Some(t0()));
+    }
+
+    // ---- config resolution -------------------------------------------------
+
+    #[test]
+    fn config_defaults_when_no_block_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = read_admission_brake_config(tmp.path());
+        assert_eq!(file, AdmissionBrakeConfigFile::default());
+        let resolved = resolve_config(&file);
+        assert!(resolved.enabled);
+        assert_eq!(resolved.load_per_core_threshold, DEFAULT_ADMISSION_BRAKE_LOAD_PER_CORE);
+    }
+
+    #[test]
+    fn config_reads_the_work_finder_saturation_brake_block() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".loom")).unwrap();
+        std::fs::write(
+            tmp.path().join(".loom/config.json"),
+            r#"{"autonomous":{"workFinder":{"maxConcurrent":3,
+                 "saturationBrake":{"enabled":false,"loadPerCoreHold":2.75}}}}"#,
+        )
+        .unwrap();
+        let file = read_admission_brake_config(tmp.path());
+        assert_eq!(file.enabled, Some(false));
+        assert_eq!(file.load_per_core_threshold, Some(2.75));
+    }
+
+    #[test]
+    fn config_rejects_a_non_positive_threshold() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".loom")).unwrap();
+        std::fs::write(
+            tmp.path().join(".loom/config.json"),
+            r#"{"autonomous":{"workFinder":{"saturationBrake":{"loadPerCoreHold":0}}}}"#,
+        )
+        .unwrap();
+        // A zero/negative hold would freeze admission forever — treated as absent.
+        assert_eq!(read_admission_brake_config(tmp.path()).load_per_core_threshold, None);
+        assert_eq!(
+            resolve_config(&read_admission_brake_config(tmp.path())).load_per_core_threshold,
+            DEFAULT_ADMISSION_BRAKE_LOAD_PER_CORE
+        );
+    }
+}

--- a/loom-daemon/src/cli/status.rs
+++ b/loom-daemon/src/cli/status.rs
@@ -656,6 +656,7 @@ pub(crate) mod status_client_tests {
             auto_update_terminal_reason: None,
             auto_update_note: None,
             host_breaker: None,
+            admission_brake: None,
             rate_limit_breaker: None,
             safehouse: None,
             work_finder_enabled: Some(true),

--- a/loom-daemon/src/cli/status_render.rs
+++ b/loom-daemon/src/cli/status_render.rs
@@ -319,6 +319,18 @@ pub(crate) fn build_status_json_value(
             "sustain_ticks": h.sustain_ticks,
             "cooldown_secs": h.cooldown_secs,
         })),
+        // Saturation admission brake (#4903) — `null` when no brake is
+        // registered. `held` is the machine-readable form of "this host is
+        // refusing new sweeps because it is already saturated", which
+        // `capacity_bound` alone could never express.
+        "admission_brake": report.admission_brake.as_ref().map(|b| serde_json::json!({
+            "enabled": b.enabled,
+            "held": b.held,
+            "load_per_core": b.load_per_core,
+            "load_per_core_threshold": b.load_per_core_threshold,
+            "held_since": b.held_since,
+            "held_ticks": b.held_ticks,
+        })),
         "rate_limit_breaker": report.rate_limit_breaker.as_ref().map(|r| serde_json::json!({
             "enabled": r.enabled,
             "phase": r.phase,
@@ -604,6 +616,66 @@ fn format_repo_column(repo: Option<&str>) -> &str {
     }
 }
 
+/// The capacity-block line that **replaces** "the limiter is work availability"
+/// while the saturation admission brake is holding (#4903).
+///
+/// `None` when no brake is registered, it is disabled, or it is not currently
+/// holding — in which case the caller prints the generic line unchanged, so a
+/// healthy host's output is byte-for-byte what it was before #4903.
+///
+/// Split out from [`print_status_human`] (same rationale as
+/// [`render_in_flight_table`]) so the "a saturated host must not read as idle"
+/// contract is unit-testable without capturing process stdout.
+fn saturation_hold_note(report: &DaemonStatusReport, dispatch_cap: usize) -> Option<String> {
+    let b = report.admission_brake.as_ref()?;
+    if !(b.enabled && b.held) {
+        return None;
+    }
+    let load = b
+        .load_per_core
+        .map_or_else(|| "n/a".to_string(), |l| format!("{l:.2}"));
+    Some(format!(
+        "  \u{26a0} ADMISSION BRAKE HOLDING: {} in flight, cap {dispatch_cap}, but this host is \
+         saturated (load/core {load} \u{2265} {:.2}) — the limiter is the HOST, not work \
+         availability. New sweeps are held until load recovers; in-flight sweeps are untouched. \
+         Tune `autonomous.workFinder.maxConcurrent` for this machine's workload (#4903).",
+        report.in_flight.len(),
+        b.load_per_core_threshold,
+    ))
+}
+
+/// The standalone `Admission brake: …` status line (#4903), or `None` when no
+/// brake is registered (older daemon / never registered) — which renders
+/// nothing at all, the zero-behavior-change baseline the host breaker's line
+/// already uses.
+fn render_admission_brake_line(report: &DaemonStatusReport) -> Option<String> {
+    let b = report.admission_brake.as_ref()?;
+    let load = b
+        .load_per_core
+        .map_or_else(|| "n/a".to_string(), |l| format!("{l:.2}"));
+    if !b.enabled {
+        return Some("Admission brake: disabled".to_string());
+    }
+    if !b.held {
+        return Some(format!(
+            "Admission brake: OK (load/core {load}, hold \u{2265} {:.2})",
+            b.load_per_core_threshold
+        ));
+    }
+    let since = b.held_since.map_or_else(
+        || "unknown".to_string(),
+        |s| {
+            let secs = (Utc::now() - s).num_seconds().max(0);
+            format!("{secs}s ago ({s})")
+        },
+    );
+    Some(format!(
+        "Admission brake: HOLDING — host saturated (load/core {load} \u{2265} {:.2}); NEW sweep \
+         admissions held since {since} ({} tick(s)); in-flight sweeps are untouched and will drain",
+        b.load_per_core_threshold, b.held_ticks
+    ))
+}
+
 /// Render the in-flight-sweeps table body (header + separator + one row per
 /// sweep, or the `(none)` placeholder) as a `String` — split out from
 /// [`print_status_human`] so the `REPO` column (#4698) is unit-testable
@@ -786,6 +858,14 @@ pub(crate) fn print_status_human(
         && report.capacity.healthy_accounts == 0
         && rc.ranking_present
         && rc.healthy > 0;
+    // #4903: while the saturation admission brake is holding, "the limiter is
+    // work availability" is flatly wrong and is the exact misread the issue was
+    // filed on — a worker at 12× overcommit rendered as an idle host with nine
+    // free slots. The limiter is the HOST. Print the brake's diagnosis in place
+    // of the generic line (the same suppression shape #4386 uses for the
+    // pre-flight tripwire), so an operator reading the capacity block top-to-
+    // bottom cannot miss it.
+    let saturation_note: Option<String> = saturation_hold_note(report, dispatch_cap);
     if rc.ranking_present {
         let src = if rc.source == "probe" {
             "live probe: loom-daemon tokens check --json"
@@ -847,7 +927,10 @@ pub(crate) fn print_status_human(
                 // than "everything is crashing." The warning printed above
                 // already names the real cause, so suppress this line rather
                 // than let it stand uncontested.
-                if !report.preflight_advisory_active {
+                if let Some(note) = &saturation_note {
+                    // #4903: the host, not work availability, is the limiter.
+                    println!("{note}");
+                } else if !report.preflight_advisory_active {
                     println!(
                         "  not capacity-bound ({} in flight, cap {dispatch_cap} — the limiter is \
                          work availability, not tokens/disk/CPU)",
@@ -878,15 +961,20 @@ pub(crate) fn print_status_human(
              health basis)",
             report.token_pool_size
         );
-        if !capacity_bound && !report.preflight_advisory_active {
-            // #4386: same suppression as the ranking-present branch above —
-            // the warning printed at the top of `status` already names the
-            // real cause while the tripwire is active.
-            println!(
-                "  not capacity-bound ({} in flight, cap {dispatch_cap} — the limiter is work \
-                 availability, not tokens/disk/CPU)",
-                report.in_flight.len(),
-            );
+        if !capacity_bound {
+            if let Some(note) = &saturation_note {
+                // #4903: same substitution as the ranking-present branch above.
+                println!("{note}");
+            } else if !report.preflight_advisory_active {
+                // #4386: same suppression as the ranking-present branch above —
+                // the warning printed at the top of `status` already names the
+                // real cause while the tripwire is active.
+                println!(
+                    "  not capacity-bound ({} in flight, cap {dispatch_cap} — the limiter is work \
+                     availability, not tokens/disk/CPU)",
+                    report.in_flight.len(),
+                );
+            }
         }
     }
 
@@ -1110,6 +1198,17 @@ pub(crate) fn print_status_human(
             }
             other => println!("Host breaker: {other}"),
         }
+    }
+
+    // Saturation admission brake (#4903): a host that is holding new admissions
+    // because it is already saturated must SAY so. Before this line, a worker at
+    // 12× overcommit rendered as "3 sweeps, not capacity-bound" — visually
+    // indistinguishable from an idle host with free slots. Printed immediately
+    // after the host breaker so the two load-aware guards read together, and
+    // always stating that in-flight work is untouched (the operator's next
+    // question).
+    if let Some(line) = render_admission_brake_line(report) {
+        println!("{line}");
     }
 
     // GitHub rate-limit circuit breaker (#4429): one line while Closed, a
@@ -1978,5 +2077,154 @@ mod status_protection_tests {
         );
         assert!(value["work_finder"]["enabled"].is_null());
         assert_eq!(value["protection"]["autonomy_mismatch"], false);
+    }
+}
+
+#[cfg(test)]
+mod admission_brake_render_tests {
+    //! Saturation admission-brake surfacing (#4903, AC4).
+    //!
+    //! The reporting half of the issue: `loom-worker-1` sat at 12× overcommit
+    //! and `loom-daemon status` said `capacity_bound: false` — "3 sweeps, cap
+    //! 12, the limiter is work availability" — which is indistinguishable from
+    //! an idle host with nine free slots. These tests pin that a holding host
+    //! *says so*, on both the human and `--json` surfaces, and that a healthy
+    //! host's output is unchanged.
+    use super::{build_status_json_value, render_admission_brake_line, saturation_hold_note};
+    use crate::cli::status::status_client_tests::sample_report;
+    use chrono::Utc;
+    use loom_daemon::self_update::SelfUpdateStatus;
+    use loom_daemon::types::{AdmissionBrakeStatus, DaemonStatusReport};
+
+    fn no_update() -> SelfUpdateStatus {
+        SelfUpdateStatus {
+            built_commit: "abc".to_string(),
+            source_commit: None,
+            update_available: None,
+        }
+    }
+
+    fn brake(enabled: bool, held: bool, load: Option<f64>) -> AdmissionBrakeStatus {
+        AdmissionBrakeStatus {
+            enabled,
+            held,
+            load_per_core: load,
+            load_per_core_threshold: 4.0,
+            held_since: held.then(|| Utc::now() - chrono::Duration::seconds(120)),
+            held_ticks: u32::from(held) * 2,
+        }
+    }
+
+    fn report_with(brake: Option<AdmissionBrakeStatus>) -> DaemonStatusReport {
+        let mut r = sample_report();
+        r.admission_brake = brake;
+        r
+    }
+
+    // ---- human surface -----------------------------------------------------
+
+    #[test]
+    fn a_holding_host_says_so_instead_of_looking_idle() {
+        let note = saturation_hold_note(&report_with(Some(brake(true, true, Some(11.91)))), 12)
+            .expect("a holding brake must produce the substitute line");
+        assert!(note.contains("ADMISSION BRAKE HOLDING"), "got: {note}");
+        assert!(note.contains("11.91"), "the measured load must be shown: {note}");
+        assert!(
+            note.contains("the limiter is the HOST, not work availability"),
+            "the misleading diagnosis must be actively contradicted: {note}"
+        );
+        assert!(
+            note.contains("in-flight sweeps are untouched"),
+            "the operator's next question must be answered inline: {note}"
+        );
+    }
+
+    #[test]
+    fn a_healthy_host_keeps_the_generic_capacity_line() {
+        // AC3's reporting half: not holding ⇒ no substitution, so the pre-#4903
+        // "limiter is work availability" line still prints unchanged.
+        assert!(
+            saturation_hold_note(&report_with(Some(brake(true, false, Some(0.4)))), 12).is_none()
+        );
+        assert!(
+            saturation_hold_note(&report_with(Some(brake(false, true, Some(11.9)))), 12).is_none()
+        );
+        assert!(saturation_hold_note(&report_with(None), 12).is_none());
+    }
+
+    #[test]
+    fn brake_line_reports_held_ok_and_disabled_distinctly() {
+        let holding =
+            render_admission_brake_line(&report_with(Some(brake(true, true, Some(11.91)))))
+                .expect("line");
+        assert!(holding.starts_with("Admission brake: HOLDING"), "got: {holding}");
+        assert!(holding.contains("2 tick(s)"), "got: {holding}");
+
+        let ok = render_admission_brake_line(&report_with(Some(brake(true, false, Some(0.42)))))
+            .expect("line");
+        assert!(ok.starts_with("Admission brake: OK"), "got: {ok}");
+        assert!(ok.contains("0.42"), "got: {ok}");
+
+        let off = render_admission_brake_line(&report_with(Some(brake(false, false, None))))
+            .expect("line");
+        assert_eq!(off, "Admission brake: disabled");
+    }
+
+    #[test]
+    fn absent_brake_renders_nothing_at_all() {
+        // A pre-#4903 daemon reports `None`; the renderer must stay silent
+        // rather than invent a "brake OK" claim it has no evidence for.
+        assert!(render_admission_brake_line(&report_with(None)).is_none());
+    }
+
+    #[test]
+    fn missing_load_reading_renders_as_na_not_zero() {
+        let ok = render_admission_brake_line(&report_with(Some(brake(true, false, None))))
+            .expect("line");
+        assert!(ok.contains("n/a"), "absent evidence must not render as 0.00: {ok}");
+    }
+
+    // ---- --json surface ----------------------------------------------------
+
+    #[test]
+    fn json_carries_the_brake_hold_state() {
+        let value = build_status_json_value(
+            &report_with(Some(brake(true, true, Some(11.91)))),
+            None,
+            &no_update(),
+            None,
+            None,
+        );
+        let b = &value["admission_brake"];
+        assert_eq!(b["enabled"], true);
+        assert_eq!(b["held"], true);
+        assert_eq!(b["load_per_core_threshold"], 4.0);
+        assert_eq!(b["held_ticks"], 2);
+        assert!(b["held_since"].is_string());
+    }
+
+    #[test]
+    fn json_brake_is_null_when_no_brake_is_registered() {
+        let value = build_status_json_value(&report_with(None), None, &no_update(), None, None);
+        assert!(value["admission_brake"].is_null());
+    }
+
+    #[test]
+    fn admission_brake_field_survives_a_wire_round_trip_and_older_payloads() {
+        // Forward-compat contract: an absent field (pre-#4903 daemon) parses as
+        // `None`, never as a fabricated "not holding" brake.
+        let report = report_with(Some(brake(true, true, Some(11.91))));
+        let json = serde_json::to_string(&report).expect("serialize");
+        let back: DaemonStatusReport = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.admission_brake, report.admission_brake);
+
+        let mut stripped: serde_json::Value = serde_json::from_str(&json).expect("value");
+        stripped
+            .as_object_mut()
+            .expect("object")
+            .remove("admission_brake");
+        let older: DaemonStatusReport =
+            serde_json::from_value(stripped).expect("pre-#4903 payload must still parse");
+        assert!(older.admission_brake.is_none());
     }
 }

--- a/loom-daemon/src/daemon_service.rs
+++ b/loom-daemon/src/daemon_service.rs
@@ -6,6 +6,7 @@
 //! accept loop that only returns on a startup failure.
 
 use loom_daemon::activity::ActivityDb;
+use loom_daemon::admission_brake;
 use loom_daemon::auto_update;
 use loom_daemon::autonomy_marker;
 use loom_daemon::claim_reconciliation;
@@ -899,6 +900,24 @@ pub(crate) async fn run_daemon() -> Result<()> {
             host_breaker_config.load_per_core_threshold,
             host_breaker_config.sustain_ticks,
             host_breaker_config.cooldown_secs,
+        );
+        // Saturation admission brake (#4903): same startup-resolve +
+        // process-global-registration shape as the breaker above, and registered
+        // in the same place for the same reason — the work-finder loop is its
+        // sole sampler, so a daemon with no work-finder never engages it. The
+        // brake is the *point-in-time* half of the load-aware pair: it holds NEW
+        // admissions while the host is already saturated and releases the moment
+        // it recovers, where the breaker latches on sustained distress and holds
+        // through a cool-down. Neither ever touches a running sweep.
+        let admission_brake_config = admission_brake::resolve_config_for(&sweep_workspace);
+        admission_brake::register_global(std::sync::Arc::new(
+            admission_brake::SharedAdmissionBrake::new(admission_brake_config),
+        ));
+        log::info!(
+            "admission_brake: enabled={} (load_per_core_hold={:.2}; holds NEW sweep admissions \
+             only — in-flight sweeps are never preempted)",
+            admission_brake_config.enabled,
+            admission_brake_config.load_per_core_threshold,
         );
         log::info!(
             "work_finder: enabled (multi-workspace, interval={}s, configured_max={configured_max}, \

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1693,6 +1693,13 @@ pub fn build_daemon_status(
         host_breaker: crate::host_breaker::global_snapshot()
             .map(crate::host_breaker::BreakerSnapshot::into_status)
             .map(Box::new),
+        // Saturation admission brake (#4903) — same process-global snapshot
+        // pattern as the host breaker above. This is the field that answers the
+        // question `capacity_bound: false` could not: a host that is refusing new
+        // work because it is already saturated now says so instead of reading as
+        // idle with free slots.
+        admission_brake: crate::admission_brake::global_snapshot()
+            .map(crate::admission_brake::BrakeSnapshot::into_status),
         // GitHub rate-limit circuit breaker (#4429) — same process-global
         // snapshot pattern as the host breaker above.
         rate_limit_breaker: crate::rate_limit_breaker::global_snapshot()
@@ -5453,6 +5460,7 @@ exit 0
             auto_update_terminal_reason: None,
             auto_update_note: Some("within settle window".to_string()),
             host_breaker: None,
+            admission_brake: None,
             rate_limit_breaker: None,
             safehouse: Some(crate::types::SafehouseStatus {
                 state: "connected".to_string(),

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -128,6 +128,7 @@
 #![allow(clippy::missing_panics_doc)]
 
 pub mod activity;
+pub mod admission_brake;
 pub mod agent_session;
 pub mod auto_update;
 pub mod autonomy_marker;

--- a/loom-daemon/src/serve.rs
+++ b/loom-daemon/src/serve.rs
@@ -1214,6 +1214,7 @@ mod tests {
             auto_update_terminal_reason: None,
             auto_update_note: None,
             host_breaker: None,
+            admission_brake: None,
             rate_limit_breaker: None,
             safehouse: None,
             work_finder_enabled: None,

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -1200,6 +1200,16 @@ pub struct DaemonStatusReport {
     /// heap alloc on an already-rare, human-latency status round-trip).
     #[serde(default)]
     pub host_breaker: Option<Box<HostBreakerStatus>>,
+    /// Saturation admission-brake state (Issue #4903). `Some` once a brake has
+    /// been registered this process (the daemon registers one at startup
+    /// alongside the host breaker); `None` when none is active — which the
+    /// status renderer treats as "brake inactive", the zero-behavior-change
+    /// baseline. Answers the question `capacity_bound: false` could not: a host
+    /// that is refusing new work because it is already saturated now says so
+    /// instead of reading as idle. `#[serde(default)]` keeps pre-#4903 wire data
+    /// / older clients compatible (an absent field parses as `None`).
+    #[serde(default)]
+    pub admission_brake: Option<AdmissionBrakeStatus>,
     /// GitHub rate-limit circuit-breaker state (Issue #4429). `Some` once the
     /// breaker is registered at startup; `None` on older daemons.
     /// `#[serde(default)]` keeps pre-#4429 wire data / older clients compatible.
@@ -1410,10 +1420,23 @@ pub struct WorkFinderTickSummary {
     pub deferred_capacity: usize,
     /// Issues deferred because the per-tick admission ramp cap was reached.
     pub deferred_ramp_cap: usize,
+    /// Issues deferred because the saturation admission brake held new
+    /// admissions this tick (Issue #4903) — the host was already at/over the
+    /// configured load-per-core hold threshold. Distinct from
+    /// [`Self::deferred_capacity`]: the cap was not reached, the *host* was.
+    /// `#[serde(default)]` keeps pre-#4903 wire data / older clients compatible.
+    #[serde(default)]
+    pub deferred_saturation: usize,
     /// Dispatch attempts that returned an error.
     pub errors: usize,
     /// Whether any workspace was gated by the main-health halt this tick.
     pub halted: bool,
+    /// Whether the saturation admission brake was engaged for this tick (Issue
+    /// #4903). `true` even when nothing was deferred (an empty backlog on a
+    /// saturated host), so a consumer can tell "held, nothing waiting" from
+    /// "not held". `#[serde(default)]` keeps pre-#4903 wire data compatible.
+    #[serde(default)]
+    pub saturation_held: bool,
 }
 
 impl WorkFinderTickSummary {
@@ -1435,6 +1458,7 @@ impl WorkFinderTickSummary {
             (self.skipped_backoff, "backoff-skip"),
             (self.deferred_capacity, "deferred-capacity"),
             (self.deferred_ramp_cap, "deferred-ramp"),
+            (self.deferred_saturation, "deferred-saturation"),
             (self.errors, "error"),
         ] {
             if n > 0 {
@@ -1443,6 +1467,9 @@ impl WorkFinderTickSummary {
         }
         if self.halted {
             parts.push("HALTED".to_string());
+        }
+        if self.saturation_held {
+            parts.push("SATURATION-HELD".to_string());
         }
         parts.join(", ")
     }
@@ -1536,6 +1563,37 @@ pub struct HostBreakerStatus {
     pub sustain_ticks: u32,
     /// The configured cool-down window, in seconds.
     pub cooldown_secs: u64,
+}
+
+/// Saturation admission-brake snapshot for `loom-daemon status` (Issue #4903).
+/// Rendered from [`crate::admission_brake::BrakeSnapshot`].
+///
+/// Distinct from [`HostBreakerStatus`] on purpose: the brake is the
+/// **point-in-time** guard that holds new admissions while the host is already
+/// saturated and releases the moment it recovers, whereas the breaker is the
+/// stateful trip that remembers sustained distress across a cool-down. A host
+/// holding admissions must *say so* — before this field, a worker at 12×
+/// overcommit reported `capacity_bound: false` and read as idle.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct AdmissionBrakeStatus {
+    /// Whether the brake is enabled (default ON — a safety backstop).
+    pub enabled: bool,
+    /// Whether **new** sweep admissions are currently held. In-flight sweeps are
+    /// never affected by this flag: the brake has no path to running work.
+    pub held: bool,
+    /// The most recent load-per-core sample observed; `None` when no
+    /// load-average source is available (which fails safe to *not* holding).
+    #[serde(default)]
+    pub load_per_core: Option<f64>,
+    /// The configured load-per-core hold threshold.
+    pub load_per_core_threshold: f64,
+    /// When the current hold streak began; `None` while not holding.
+    #[serde(default)]
+    pub held_since: Option<DateTime<Utc>>,
+    /// How many consecutive ticks the current streak has held; `0` when not
+    /// holding.
+    #[serde(default)]
+    pub held_ticks: u32,
 }
 
 /// GitHub rate-limit circuit-breaker snapshot for `loom-daemon status` (Issue

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -56,6 +56,18 @@
 //! makes a hand-tuned ceiling safe: a mis-set knob trips a **measured** breaker
 //! instead of melting the host.
 //!
+//! **#4903 added a saturation brake on *admission* (not on the cap).** Removing
+//! the CPU term left the cap with no term that reads the host at all, so a
+//! CPU-heavy workload (analog simulation: minutes of sustained `ngspice`, not
+//! API-wait) could drive an 8-core worker to 12× overcommit while the daemon
+//! still believed it had nine free slots. [`crate::admission_brake`] closes that
+//! without resurrecting the formula: once per tick it asks
+//! [`crate::cpu_headroom::is_host_saturated`] at a generous default of `4.0`
+//! load/core and, when the answer is yes, holds **new** admissions
+//! ([`TickReport::deferred_saturation`]) until the host recovers. In-flight
+//! sweeps are never touched, and a healthy host's behavior is byte-for-byte
+//! unchanged.
+//!
 //! # Idempotency & fail-safe
 //!
 //! The finder never reimplements the claim/label/dedup machinery — it reuses
@@ -555,8 +567,10 @@ pub fn publish_tick_summary_at(
         skipped_backoff: report.skipped_backoff,
         deferred_capacity: report.deferred_capacity,
         deferred_ramp_cap: report.deferred_ramp_cap,
+        deferred_saturation: report.deferred_saturation,
         errors: report.errors,
         halted: report.halted,
+        saturation_held: report.saturation_held,
     };
     *last_tick_slot()
         .lock()
@@ -616,6 +630,17 @@ pub struct TickReport {
     /// cap deliberately smooths *how fast* new sweeps are admitted rather than
     /// how many may run concurrently. See [`WORK_FINDER_MAX_ADMISSIONS_PER_TICK_ENV`].
     pub deferred_ramp_cap: usize,
+    /// Issues deferred to a future tick because the **saturation admission
+    /// brake** (#4903, [`crate::admission_brake`]) held new admissions: the host
+    /// is already at/over the configured load-per-core hold threshold, so adding
+    /// work would only slow the sweeps already running.
+    ///
+    /// Deliberately its own counter, not folded into
+    /// [`deferred_capacity`](Self::deferred_capacity): the concurrency cap was
+    /// *not* reached — the host was. Conflating them would report a token/disk
+    /// shortage on a machine whose only problem is that it is already full, and
+    /// send an operator to raise a knob that is not binding.
+    pub deferred_saturation: usize,
     /// Issues skipped because they are quarantined for repeated insta-crashing
     /// (Issue #3939). Filtered out before the concurrency budget is allocated, so
     /// a quarantined candidate never consumes a shared dispatch slot.
@@ -662,6 +687,14 @@ pub struct TickReport {
     /// flags the gate writes (#3974 AC3), so this can never disagree with what
     /// the gate loop reports — including when a repo's forge query fails.
     pub halted: bool,
+    /// True when the saturation admission brake (#4903) was engaged for this
+    /// tick. Reported separately from
+    /// [`deferred_saturation`](Self::deferred_saturation) so "the host was
+    /// holding" is visible even when the backlog was empty and nothing was
+    /// deferred — otherwise a saturated host with no queued work is
+    /// indistinguishable from a healthy idle one, which is the exact reporting
+    /// gap #4903 was filed on.
+    pub saturation_held: bool,
 }
 
 /// Run one work-finder tick: fetch ready issues, filter, and dispatch up to the
@@ -723,9 +756,65 @@ pub fn tick_with_admission_cap(
     halted: bool,
     max_admissions_per_tick: usize,
 ) -> Result<TickReport> {
+    tick_with_saturation_brake(
+        source,
+        dispatcher,
+        max_concurrent,
+        halted,
+        max_admissions_per_tick,
+        false,
+    )
+}
+
+/// Like [`tick_with_admission_cap`], but additionally honors the **saturation
+/// admission brake** (#4903, [`crate::admission_brake`]): when
+/// `saturation_held` is `true` the host is already at/over its load-per-core
+/// hold threshold, so this tick admits **no new sweeps** and attributes every
+/// otherwise-eligible candidate to [`TickReport::deferred_saturation`].
+/// `false` (what [`tick_with_admission_cap`] passes) reduces to the pre-#4903
+/// behavior byte-for-byte.
+///
+/// Three properties are load-bearing, and each maps to an acceptance criterion
+/// of #4903:
+///
+/// 1. **In-flight sweeps are never touched.** The brake is applied *inside the
+///    candidate loop*, which only ever visits ready `loom:issue` rows that are
+///    not already in flight. There is no branch here — and no path from this
+///    module — that cancels, signals, or reaps a running sweep. A held tick
+///    simply dispatches nothing and returns, and the running sweeps drain
+///    normally, which is how the host recovers.
+/// 2. **The hold is re-evaluated every tick.** Nothing latches: the caller
+///    re-samples load each tick and passes a fresh `saturation_held`, so the
+///    moment the host drops back under the threshold admissions resume (the
+///    sticky, cool-down-bearing guard is the host breaker, #4235 — deliberately
+///    a different mechanism).
+/// 3. **A healthy host is unchanged.** With `saturation_held = false` this
+///    function is the pre-#4903 code path exactly, so an idle 8-core host still
+///    fills its configured cap — no re-introduction of the over-throttling
+///    #4512 removed.
+///
+/// The check sits **before** the concurrency-cap check so a saturated host
+/// reports `deferred-saturation`, not a misleading `deferred-capacity` (the cap
+/// was not reached; the host was).
+///
+/// # Errors
+///
+/// Same as [`tick`].
+pub fn tick_with_saturation_brake(
+    source: &mut impl WorkSource,
+    dispatcher: &mut impl WorkDispatcher,
+    max_concurrent: usize,
+    halted: bool,
+    max_admissions_per_tick: usize,
+    saturation_held: bool,
+) -> Result<TickReport> {
     let ready = source.list_ready_issues()?;
     let mut report = TickReport {
         seen: ready.len(),
+        // Record the brake's engagement even on a tick that defers nothing, so a
+        // saturated host with an empty backlog still reads as "holding" rather
+        // than "idle" (#4903).
+        saturation_held,
         ..TickReport::default()
     };
 
@@ -788,6 +877,16 @@ pub fn tick_with_admission_cap(
                  over safehouse (#4028)",
                 item.number
             );
+            continue;
+        }
+        // 2d. Saturation admission brake (#4903) — the host is already at/over
+        //     its load-per-core hold threshold, so hold this candidate and
+        //     re-check next tick. Checked BEFORE the concurrency cap so the
+        //     deferral is attributed to the host, not to a cap that is not
+        //     actually binding. Running sweeps are untouched: this loop only
+        //     ever sees candidates that are NOT in flight.
+        if saturation_held {
+            report.deferred_saturation += 1;
             continue;
         }
         // 3. Fixed concurrency cap — defer the rest to a future tick.
@@ -1009,9 +1108,45 @@ pub fn tick_multi_with_admission_cap<S: WorkSource, D: WorkDispatcher>(
     halted: &[bool],
     max_admissions_per_tick: usize,
 ) -> TickReport {
+    tick_multi_with_saturation_brake(
+        workspaces,
+        priorities,
+        max_concurrent,
+        halted,
+        max_admissions_per_tick,
+        false,
+    )
+}
+
+/// Like [`tick_multi_with_admission_cap`], but additionally honors the
+/// **saturation admission brake** (#4903) — the multi-workspace analogue of
+/// [`tick_with_saturation_brake`]; see it for the full rationale and the three
+/// load-bearing properties.
+///
+/// The brake is **daemon-global**, not per-root: it measures the *host*, and
+/// every workspace's sweeps run on that one host, so a single `saturation_held`
+/// flag holds admissions across every repo at once (the same shape the
+/// host-distress breaker and the scheduled drain already use). Unlike those two,
+/// it is applied in pass 2 rather than folded into the per-root `halted` slice,
+/// so its deferrals stay attributable to saturation instead of disappearing into
+/// the main-health halt.
+///
+/// `false` (what [`tick_multi_with_admission_cap`] passes) reduces to the
+/// pre-#4903 behavior byte-for-byte.
+pub fn tick_multi_with_saturation_brake<S: WorkSource, D: WorkDispatcher>(
+    workspaces: &mut [(S, D)],
+    priorities: &[u32],
+    max_concurrent: usize,
+    halted: &[bool],
+    max_admissions_per_tick: usize,
+    saturation_held: bool,
+) -> TickReport {
     use crate::workspace_registry::DEFAULT_WORKSPACE_PRIORITY;
 
-    let mut report = TickReport::default();
+    let mut report = TickReport {
+        saturation_held,
+        ..TickReport::default()
+    };
 
     // Snapshot per-workspace in-flight sets *first* (immutable borrow) so the
     // dedup filtering below always has the full in-flight view.
@@ -1147,6 +1282,13 @@ pub fn tick_multi_with_admission_cap<S: WorkSource, D: WorkDispatcher>(
     // budget in the sorted global order, routing each candidate back to its
     // owning workspace's dispatcher.
     for cand in candidates {
+        // Saturation admission brake (#4903) — daemon-global, checked before the
+        // shared cap so the deferral names the host rather than a cap that is
+        // not binding. In-flight sweeps across every workspace are untouched.
+        if saturation_held {
+            report.deferred_saturation += 1;
+            continue;
+        }
         // Shared global cap across all workspaces — defer once the combined
         // occupancy hits the budget, regardless of which workspace still has
         // ready items.
@@ -1716,12 +1858,26 @@ where
             // suppressor alongside the main-health halt flag and the gate
             // in-flight hold. See the multi-workspace loop for the full
             // rationale; when no breaker is registered these are no-ops.
+            //
+            // ONE load reading serves both the breaker and the saturation
+            // admission brake (#4903) this tick: sampling twice would let the
+            // two disagree about the host within a single tick, which is exactly
+            // the race a load-aware admission decision must not have.
+            let ncpu = crate::cpu_headroom::logical_cpu_count();
+            let loadavg_1m = crate::cpu_headroom::read_loadavg_1m();
             if let Some(breaker) = crate::host_breaker::global() {
-                let load_per_core = crate::cpu_headroom::load_per_core();
+                let load_per_core = crate::cpu_headroom::load_per_core_from(loadavg_1m, ncpu);
                 if let Some(transition) = breaker.observe(load_per_core, chrono::Utc::now()) {
                     crate::host_breaker::emit_transition_event(&event_bus, &transition);
                 }
             }
+            // Saturation admission brake (#4903): a point-in-time hold on NEW
+            // admissions while the host is already saturated. Deliberately NOT
+            // folded into `halted` — a held tick must report `deferred-saturation`
+            // (and `SATURATION-HELD` on the status surface) rather than claim the
+            // main-health gate stopped it.
+            let saturation_held =
+                crate::admission_brake::global_observe(loadavg_1m, ncpu, chrono::Utc::now());
             let halted = health_state.is_halted()
                 || (suppress_dispatch_during_gate && health_state.is_gate_in_flight())
                 || crate::host_breaker::global_is_suppressed();
@@ -1753,6 +1909,7 @@ where
                  healthy_tokens={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
                  configured_max={configured_max}, \
                  max_admissions_per_tick={max_admissions_per_tick}, halted={halted}, \
+                 saturation_held={saturation_held}, \
                  observed_idle={})",
                 format_idle(idle)
             );
@@ -1762,12 +1919,13 @@ where
             } else {
                 log::debug!("{axis_line}");
             }
-            match tick_with_admission_cap(
+            match tick_with_saturation_brake(
                 &mut source,
                 &mut dispatcher,
                 max_concurrent,
                 halted,
                 max_admissions_per_tick,
+                saturation_held,
             ) {
                 Ok(report) => {
                     // Publish before any logging so `loom-daemon health` sees the
@@ -1790,6 +1948,7 @@ where
                         || report.skipped_pr_open > 0
                         || report.skipped_peer_claim > 0
                         || report.deferred_ramp_cap > 0
+                        || report.deferred_saturation > 0
                     {
                         log::info!(
                             "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
@@ -1798,7 +1957,8 @@ where
                              {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, \
                              {} quarantine-skip, {} backoff-skip, {} pr-open-skip, \
                              {} peer-claim-skip, \
-                             {} deferred (capacity), {} deferred (ramp), {} error(s), \
+                             {} deferred (capacity), {} deferred (ramp), \
+                             {} deferred (host saturated), {} error(s), \
                              {} cross-host-collision(s)",
                             report.seen,
                             report.dispatched,
@@ -1810,6 +1970,7 @@ where
                             report.skipped_peer_claim,
                             report.deferred_capacity,
                             report.deferred_ramp_cap,
+                            report.deferred_saturation,
                             report.errors,
                             report.collisions
                         );
@@ -2034,13 +2195,24 @@ pub fn spawn_multi_work_finder_task(
             // below. The load sample uses the fast, non-sleeping loadavg read (no
             // `iostat`), safe to call inline. When no breaker is registered the
             // helpers are no-ops returning `false` (zero behavior change).
+            //
+            // ONE load reading serves both the breaker and the saturation
+            // admission brake (#4903) — see the single-workspace loop for why
+            // the two must never sample separately within a tick.
+            let ncpu = crate::cpu_headroom::logical_cpu_count();
+            let loadavg_1m = crate::cpu_headroom::read_loadavg_1m();
             if let Some(breaker) = crate::host_breaker::global() {
-                let load_per_core = crate::cpu_headroom::load_per_core();
+                let load_per_core = crate::cpu_headroom::load_per_core_from(loadavg_1m, ncpu);
                 if let Some(transition) = breaker.observe(load_per_core, chrono::Utc::now()) {
                     crate::host_breaker::emit_transition_event(&event_bus, &transition);
                 }
             }
             let breaker_suppressed = crate::host_breaker::global_is_suppressed();
+            // Saturation admission brake (#4903): daemon-global (it measures the
+            // one host every workspace's sweeps run on), passed to the tick
+            // rather than OR'd into `halted` so its deferrals stay attributable.
+            let saturation_held =
+                crate::admission_brake::global_observe(loadavg_1m, ncpu, chrono::Utc::now());
             let halted: Vec<bool> = dispatch_held_per_root_with_drain(
                 &health_states,
                 &roots,
@@ -2065,6 +2237,7 @@ pub fn spawn_multi_work_finder_task(
                  healthy_tokens={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
                  configured_max={configured_max}, \
                  max_admissions_per_tick={max_admissions_per_tick}, any_halted={any_halted}, \
+                 saturation_held={saturation_held}, \
                  observed_idle={}, workspaces={}, priorities={priorities:?})",
                 format_idle(idle),
                 pairs.len()
@@ -2076,12 +2249,13 @@ pub fn spawn_multi_work_finder_task(
                 log::debug!("{axis_line}");
             }
 
-            let report = tick_multi_with_admission_cap(
+            let report = tick_multi_with_saturation_brake(
                 &mut pairs,
                 &priorities,
                 max_concurrent,
                 &halted,
                 max_admissions_per_tick,
+                saturation_held,
             );
 
             // Publish before any logging so `loom-daemon health` sees the same
@@ -2107,6 +2281,7 @@ pub fn spawn_multi_work_finder_task(
                 || report.skipped_pr_open > 0
                 || report.skipped_peer_claim > 0
                 || report.deferred_ramp_cap > 0
+                || report.deferred_saturation > 0
             {
                 log::info!(
                     "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
@@ -2116,7 +2291,8 @@ pub fn spawn_multi_work_finder_task(
                      {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, \
                      {} quarantine-skip, {} backoff-skip, {} pr-open-skip, \
                      {} peer-claim-skip, \
-                     {} deferred (capacity), {} deferred (ramp), {} error(s), \
+                     {} deferred (capacity), {} deferred (ramp), \
+                     {} deferred (host saturated), {} error(s), \
                      {} cross-host-collision(s)",
                     pairs.len(),
                     report.seen,
@@ -2129,6 +2305,7 @@ pub fn spawn_multi_work_finder_task(
                     report.skipped_peer_claim,
                     report.deferred_capacity,
                     report.deferred_ramp_cap,
+                    report.deferred_saturation,
                     report.errors,
                     report.collisions
                 );
@@ -2987,6 +3164,274 @@ exit 0
         assert_eq!(report.dispatched, 0);
         assert_eq!(report.deferred_ramp_cap, 3);
         assert!(disp.dispatched.is_empty());
+    }
+
+    // ========================================================================
+    // Saturation admission brake (#4903)
+    // ========================================================================
+
+    #[test]
+    fn test_saturated_host_admits_no_new_sweeps() {
+        // AC1: a host at/over the load-per-core hold threshold admits nothing.
+        // The cap is generous (12, the value the reported worker ran with) and
+        // the backlog is deep — only the brake stops it.
+        let mut source = FakeSource::once((1..=5).map(issue).collect());
+        let mut disp = RecordingDispatcher::default();
+
+        let report =
+            tick_with_saturation_brake(&mut source, &mut disp, 12, false, usize::MAX, true)
+                .unwrap();
+
+        assert_eq!(report.dispatched, 0, "a saturated host must admit nothing");
+        assert!(disp.dispatched.is_empty());
+        assert_eq!(report.deferred_saturation, 5);
+        // Attributed to the HOST, not to a cap that was nowhere near binding —
+        // the whole point of a separate counter.
+        assert_eq!(report.deferred_capacity, 0);
+        assert_eq!(report.deferred_ramp_cap, 0);
+        assert!(report.saturation_held);
+        // Not a main-health halt: `halted` stays false so the operator log/status
+        // never blames a red main for a load hold.
+        assert!(!report.halted);
+        assert_eq!(report.seen, 5, "the backlog is still observed and reported");
+    }
+
+    #[test]
+    fn test_brake_never_preempts_in_flight_sweeps() {
+        // AC2: in-flight sweeps are neither killed nor counted against the brake.
+        // Three sweeps are already running (the reported incident's shape); the
+        // brake holds new admissions and leaves the running set exactly as it was.
+        let in_flight = HashSet::from([101, 102, 103]);
+        let mut source = FakeSource::once(vec![issue(1), issue(2)]);
+        let mut disp = RecordingDispatcher {
+            in_flight: in_flight.clone(),
+            ..Default::default()
+        };
+
+        let report =
+            tick_with_saturation_brake(&mut source, &mut disp, 12, false, usize::MAX, true)
+                .unwrap();
+
+        assert_eq!(report.dispatched, 0);
+        assert_eq!(report.deferred_saturation, 2);
+        // The running set is untouched — the brake has no path to it at all.
+        assert_eq!(
+            disp.in_flight, in_flight,
+            "the brake must never preempt or drop a running sweep"
+        );
+        // And a running sweep is never mistaken for a deferred candidate.
+        assert_eq!(report.skipped_in_flight, 0);
+    }
+
+    #[test]
+    fn test_brake_holds_an_in_flight_candidate_as_in_flight_not_saturation() {
+        // A ready row that is ALSO already in flight (label-flip lag) must be
+        // attributed to the in-flight dedup, not swept into the brake's counter —
+        // otherwise "held by saturation" would over-report on a busy host.
+        let mut source = FakeSource::once(vec![issue(7), issue(8)]);
+        let mut disp = RecordingDispatcher {
+            in_flight: HashSet::from([7]),
+            ..Default::default()
+        };
+
+        let report =
+            tick_with_saturation_brake(&mut source, &mut disp, 12, false, usize::MAX, true)
+                .unwrap();
+
+        assert_eq!(report.skipped_in_flight, 1);
+        assert_eq!(report.deferred_saturation, 1);
+    }
+
+    #[test]
+    fn test_healthy_host_still_reaches_its_configured_cap() {
+        // AC3 (regression guard for #4512): with the brake NOT engaged, an idle
+        // host fills its configured cap exactly as before. If this ever fails,
+        // the brake has re-introduced the over-throttling #4512 removed.
+        let mut source = FakeSource::once((1..=8).map(issue).collect());
+        let mut disp = RecordingDispatcher::default();
+
+        let report =
+            tick_with_saturation_brake(&mut source, &mut disp, 8, false, usize::MAX, false)
+                .unwrap();
+
+        assert_eq!(report.dispatched, 8, "an idle 8-core host must reach its cap");
+        assert_eq!(report.deferred_saturation, 0);
+        assert!(!report.saturation_held);
+    }
+
+    #[test]
+    fn test_brake_disengaged_is_byte_for_byte_the_pre_brake_path() {
+        // The `false` path must be indistinguishable from the pre-#4903 wrapper,
+        // so the brake can never change a healthy host's schedule.
+        let ready: Vec<WorkItem> = (1..=6).map(issue).collect();
+
+        let mut source_a = FakeSource::once(ready.clone());
+        let mut disp_a = RecordingDispatcher::default();
+        let before = tick_with_admission_cap(&mut source_a, &mut disp_a, 4, false, 3).unwrap();
+
+        let mut source_b = FakeSource::once(ready);
+        let mut disp_b = RecordingDispatcher::default();
+        let after =
+            tick_with_saturation_brake(&mut source_b, &mut disp_b, 4, false, 3, false).unwrap();
+
+        assert_eq!(before, after);
+        assert_eq!(disp_a.dispatched, disp_b.dispatched);
+    }
+
+    #[test]
+    fn test_brake_releases_the_moment_the_host_recovers() {
+        // The hold is re-evaluated every tick and nothing latches (that is the
+        // host breaker's cool-down, deliberately a different mechanism): tick 1
+        // saturated holds everything, tick 2 recovered dispatches everything.
+        let ready: Vec<WorkItem> = (1..=3).map(issue).collect();
+        let mut disp = RecordingDispatcher::default();
+
+        let mut hot = FakeSource::once(ready.clone());
+        let held =
+            tick_with_saturation_brake(&mut hot, &mut disp, 10, false, usize::MAX, true).unwrap();
+        assert_eq!(held.dispatched, 0);
+        assert_eq!(held.deferred_saturation, 3);
+
+        let mut cool = FakeSource::once(ready);
+        let resumed =
+            tick_with_saturation_brake(&mut cool, &mut disp, 10, false, usize::MAX, false).unwrap();
+        assert_eq!(resumed.dispatched, 3, "admissions resume with no cool-down");
+        assert_eq!(resumed.deferred_saturation, 0);
+        assert!(!resumed.saturation_held);
+        assert_eq!(disp.dispatched, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_brake_engaged_with_empty_backlog_still_reports_held() {
+        // A saturated host with nothing queued must not read as idle-healthy —
+        // that indistinguishability is the reporting half of #4903.
+        let mut source = FakeSource::once(vec![]);
+        let mut disp = RecordingDispatcher::default();
+
+        let report =
+            tick_with_saturation_brake(&mut source, &mut disp, 12, false, usize::MAX, true)
+                .unwrap();
+
+        assert_eq!(report.deferred_saturation, 0);
+        assert!(report.saturation_held, "held state must survive an empty backlog");
+    }
+
+    #[test]
+    fn test_brake_and_main_health_halt_compose_halt_wins_early_return() {
+        // A red main short-circuits before the candidate loop, so nothing is
+        // attributed to the brake — but the brake's engagement is still recorded
+        // so status does not claim the host is fine.
+        let mut source = FakeSource::once((1..=3).map(issue).collect());
+        let mut disp = RecordingDispatcher::default();
+
+        let report =
+            tick_with_saturation_brake(&mut source, &mut disp, 12, true, usize::MAX, true).unwrap();
+
+        assert!(report.halted);
+        assert!(report.saturation_held);
+        assert_eq!(report.dispatched, 0);
+        assert_eq!(report.deferred_saturation, 0);
+    }
+
+    #[test]
+    fn test_tick_multi_brake_holds_every_workspace() {
+        // The brake is daemon-global: it measures the one host every workspace's
+        // sweeps run on, so a hold applies across repos at once.
+        let source_a = FakeSource::once(vec![issue(1), issue(2)]);
+        let disp_a = RecordingDispatcher::default();
+        let source_b = FakeSource::once(vec![issue(3), issue(4)]);
+        let disp_b = RecordingDispatcher::default();
+        let mut multi = vec![(source_a, disp_a), (source_b, disp_b)];
+
+        let report = tick_multi_with_saturation_brake(
+            &mut multi,
+            &[],
+            10,
+            &[false, false],
+            usize::MAX,
+            true,
+        );
+
+        assert_eq!(report.dispatched, 0);
+        assert_eq!(report.deferred_saturation, 4);
+        assert_eq!(report.deferred_capacity, 0);
+        assert!(report.saturation_held);
+        assert!(multi.iter().all(|(_, d)| d.dispatched.is_empty()));
+    }
+
+    #[test]
+    fn test_tick_multi_healthy_host_unchanged_by_the_brake() {
+        // AC3 for the production (multi-workspace) path: disengaged ⇒ the
+        // pre-#4903 schedule, cap and all.
+        let source_a = FakeSource::once(vec![issue(1), issue(2)]);
+        let disp_a = RecordingDispatcher::default();
+        let source_b = FakeSource::once(vec![issue(3), issue(4)]);
+        let disp_b = RecordingDispatcher::default();
+        let mut multi = vec![(source_a, disp_a), (source_b, disp_b)];
+
+        let report = tick_multi_with_saturation_brake(
+            &mut multi,
+            &[],
+            10,
+            &[false, false],
+            usize::MAX,
+            false,
+        );
+
+        assert_eq!(report.dispatched, 4);
+        assert_eq!(report.deferred_saturation, 0);
+        assert!(!report.saturation_held);
+    }
+
+    #[test]
+    fn test_tick_multi_brake_does_not_disturb_in_flight_across_workspaces() {
+        // AC2 on the multi path: every workspace's running set is preserved and
+        // its occupancy is never re-attributed to the brake.
+        let source_a = FakeSource::once(vec![issue(1)]);
+        let disp_a = RecordingDispatcher {
+            in_flight: HashSet::from([900]),
+            ..Default::default()
+        };
+        let source_b = FakeSource::once(vec![issue(2)]);
+        let disp_b = RecordingDispatcher {
+            in_flight: HashSet::from([901, 902]),
+            ..Default::default()
+        };
+        let mut multi = vec![(source_a, disp_a), (source_b, disp_b)];
+
+        let report = tick_multi_with_saturation_brake(
+            &mut multi,
+            &[],
+            10,
+            &[false, false],
+            usize::MAX,
+            true,
+        );
+
+        assert_eq!(report.deferred_saturation, 2);
+        assert_eq!(multi[0].1.in_flight, HashSet::from([900]));
+        assert_eq!(multi[1].1.in_flight, HashSet::from([901, 902]));
+    }
+
+    #[test]
+    fn test_saturation_deferrals_reach_the_published_tick_summary() {
+        // AC4's plumbing: the counter must survive into the process-global
+        // summary `loom-daemon health` / `status` read back, and the summary
+        // line must NAME it rather than hide it among the zeros.
+        let report = TickReport {
+            seen: 4,
+            deferred_saturation: 4,
+            saturation_held: true,
+            ..TickReport::default()
+        };
+        publish_tick_summary(&report, 12);
+        let summary = last_tick_summary().expect("a tick was just published");
+        assert_eq!(summary.deferred_saturation, 4);
+        assert!(summary.saturation_held);
+        let line = summary.reason_summary();
+        assert!(line.contains("4 deferred-saturation"), "got: {line}");
+        assert!(line.contains("SATURATION-HELD"), "got: {line}");
+        reset_last_tick_summary();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`loom-worker-1` (8 vCPU) was observed at load average 95 (11.9 load/core, 12x
overcommit, 0.07% idle) from only 3 in-flight sweeps, because all three were
analog-simulation repos (`gf180-*`) running sustained `ngspice` processes.
#4512 deliberately removed the CPU term from admission for the (correct, for
API-bound sweeps) reason that pricing every sweep as a build over-throttles
the common case — but that left admission with **no term that reads the host
at all**, so a CPU-heavy workload could walk straight past a nominal cap of
12 while the daemon reported `capacity_bound: false`.

This adds a **saturation admission brake**, not a return to CPU-based sizing:
once per work-finder tick, if `cpu_headroom::is_host_saturated(...)` says the
host is at/over a generous load-per-core threshold (default `4.0` — well
above a healthy burst, far below the 12x incident), **new** sweep admissions
are held and re-checked next tick. Existing sweeps are never touched.

## What changed

- `loom-daemon/src/admission_brake.rs` (new): the pure decision (`decide`),
  the shared runtime handle (`SharedAdmissionBrake`) tracking hold
  streaks/transitions, config resolution (env > config > default), and a
  process-global registration mirroring `host_breaker`.
- `work_finder.rs`: `tick_with_saturation_brake` /
  `tick_multi_with_saturation_brake` gate the *candidate* loop — checked
  before the concurrency-cap check so a held tick is attributed to the new
  `deferred_saturation` counter, not a cap that isn't actually binding. The
  brake has no path to the reaper or any running child; a held tick simply
  dispatches nothing. `tick_with_admission_cap` / `tick_multi_with_admission_cap`
  are unchanged wrappers (`saturation_held = false`), so a healthy host's
  schedule is byte-for-byte the pre-#4903 path.
- `types.rs` / `ipc.rs` / `status.rs` / `status_render.rs`: the brake's
  snapshot is threaded into `DaemonStatusReport.admission_brake` and rendered
  in both the human and `--json` `loom-daemon status` output — an
  `Admission brake: HOLDING/OK/disabled` line, and while holding, the
  capacity block's misleading "not capacity-bound ... limiter is work
  availability" line is replaced with an explicit `⚠ ADMISSION BRAKE HOLDING`
  note naming the host as the limiter.
- `daemon_service.rs`: registers the process-global brake at startup
  alongside the host breaker.
- `defaults/docs/daemon-reference.md`: documents the brake (config/env
  knobs, comparison table against the host-distress breaker #4235), and adds
  a "Sizing `maxConcurrent`" section documenting the knob as per-machine and
  workload-dependent, with the analog-vs-software contrast as the worked
  example.

## Acceptance criteria

- [x] A host at sustained load/core >= threshold admits no new sweeps until
      it recovers (`test_saturated_host_admits_no_new_sweeps`,
      `test_tick_multi_brake_holds_every_workspace`)
- [x] In-flight sweeps are never killed or preempted by the brake
      (`test_brake_never_preempts_in_flight_sweeps`,
      `test_tick_multi_brake_does_not_disturb_in_flight_across_workspaces`)
- [x] A healthy host's admission behaviour is unchanged — an idle 8-core host
      still reaches its configured cap
      (`test_healthy_host_still_reaches_its_configured_cap`,
      `test_tick_multi_healthy_host_unchanged_by_the_brake`,
      `test_brake_disengaged_is_byte_for_byte_the_pre_brake_path`)
- [x] The brake's state is visible in `loom-daemon status`
      (`admission_brake_render_tests::*` — human line, `--json` field, and
      the capacity-block substitution)
- [x] `maxConcurrent` documented as per-machine and workload-dependent, with
      the analog-vs-software contrast (`defaults/docs/daemon-reference.md`)

## Test plan

- `cargo build --lib --bins`: clean
- `cargo clippy --lib --bins --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo test --lib` / `cargo test --bin loom-daemon`: all admission-brake
  and saturation-brake tests pass (35 new tests total: 13 in
  `admission_brake`, 14 in `work_finder`, 8 in `status_render`). 10 unrelated
  pre-existing failures (`auto_update`/`work_finder` config-default tests)
  reproduce identically on `main` without this branch's changes — caused by
  this host's machine-tier `~/.local/share/loom/config/defaults.json`
  bleeding into config-resolution tests that assume no ambient config; not
  introduced by this PR.

Closes #4903