### PR TITLE
fix(tests): unset LOOM_DAEMON_BIN in loom-daemon-update test sandbox

### DIFF
--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -574,7 +574,17 @@ export LOOM_WATCHDOG_LABEL="${LOOM_LAUNCHD_LABEL}-watchdog"
 # current call site AND any future one that forgets to set LOOM_DAEMON_BIN —
 # belt-and-braces with the checksum guard at both the top and bottom of this
 # file, which would otherwise be the only thing catching a regression.
+#
+# `unset LOOM_DAEMON_BIN` closes the other half of the hole (#4902): every
+# live Loom agent session (Builder/Judge/Doctor, ...) inherits an ambient
+# LOOM_DAEMON_BIN pointing at the real production binary, and
+# loom-daemon-update.sh's `PROVISION_TARGET="${LOOM_DAEMON_BIN:-$DEST_DIR/...}"`
+# lets that ambient value win over the LOOM_DAEMON_BIN_DIR sandbox above,
+# silently defeating it. Tests below that need LOOM_DAEMON_BIN pin it inline
+# on their own invocation (e.g. `LOOM_DAEMON_BIN="$W1/..." bash ...`), which
+# still applies regardless of this ambient unset.
 export LOOM_DAEMON_BIN_DIR="$BASE_WORKDIR/machine-level-bin-sandbox"
+unset LOOM_DAEMON_BIN
 
 # Binary-format sanity gate bypass (#4397, deferred from #4381's incident
 # review): provision_machine_daemon now refuses to install anything that


### PR DESCRIPTION
## Summary

`test-loom-daemon-update.sh` exports `LOOM_DAEMON_BIN_DIR` suite-wide as a sandbox (the #4381 fix) to keep tests from writing to the operator's real `~/.local/bin/loom-daemon`. But `loom-daemon-update.sh` resolves its provisioning destination as `PROVISION_TARGET="${LOOM_DAEMON_BIN:-$DEST_DIR/loom-daemon}"` — `LOOM_DAEMON_BIN` wins whenever it's set, and every live Loom agent session (Builder/Judge/Doctor) has it pre-exported to the real production path. Tests 37/39/43 deliberately exercise the no-`LOOM_DAEMON_BIN` path relying solely on the `LOOM_DAEMON_BIN_DIR` sandbox — which is silently defeated by the ambient env var, corrupting the real running daemon's binary on disk.

## Fix

Add `unset LOOM_DAEMON_BIN` immediately after the `LOOM_DAEMON_BIN_DIR` sandbox export (line 577), mirroring the pattern already used elsewhere in the suite. Every other test that needs `LOOM_DAEMON_BIN` pins it inline on its own invocation (`LOOM_DAEMON_BIN="$W1/..." bash ...`), which still applies regardless of this ambient unset.

## Test plan

- [x] Ran the full suite with `LOOM_DAEMON_BIN` pre-exported to a stand-in "real binary" (simulating a live agent shell) — 120/120 tests passed, and the stand-in binary's checksum was unchanged before/after (sandbox held).
- [x] Confirmed tests 37 (ff-first), 39 (`--allow-stale`), and 43 (no-origin-remote) all pass under the ambient-`LOOM_DAEMON_BIN` condition.
- [x] Confirmed the suite's own #4381 regression guard ("real binary is byte-identical before/after") still passes.
- [x] Syntax-checked the modified script (`bash -n`).

Closes #4902