### PR TITLE
fix(install): migrate legacy AGENTS.md placeholders + defer target mutation on full reinstall

### DIFF
--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -54,6 +54,7 @@ test-gitignore-guard.sh
 test-guard-codex-bridge.sh
 test-guard-hook-schema.sh
 test-install-active-session.sh
+test-install-full-reinstall-no-target-mutation.sh
 test-install-pr-markers.sh
 test-install-source-guard.sh
 test-install-stash-scope.sh

--- a/defaults/scripts/tests/test-install-full-reinstall-no-target-mutation.sh
+++ b/defaults/scripts/tests/test-install-full-reinstall-no-target-mutation.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# test-install-full-reinstall-no-target-mutation.sh — regression test for
+# issue #4888 defect 2.
+#
+# Before the fix, `install.sh`'s `--confirm-reinstall` flow ran a chained
+# `uninstall-loom.sh --yes --local "$TARGET_PATH"` directly against the
+# TARGET's main checkout for BOTH the --quick and --full reinstall paths,
+# unconditionally -- staging deletions and stripping the Loom sections out of
+# CLAUDE.md / .gitignore in place -- before delegating the --full path via
+# `exec "$LOOM_ROOT/scripts/install-loom.sh" ...`. Because `exec` replaces the
+# current process, nothing in install.sh could roll that mutation back if the
+# delegated install-loom.sh run failed downstream (e.g. at `loom-daemon
+# init`), leaving the target's main checkout half-uninstalled with no
+# automatic recovery (the reported symptom: manual `git reset --hard HEAD`
+# required).
+#
+# The fix scopes that chained uninstall to the --quick path only (where the
+# fresh install runs synchronously in the same working tree and unstages/
+# restores as part of its own completion) -- the --full path never mutates
+# the target's main checkout at all before delegating, so a downstream
+# failure has nothing to roll back.
+#
+# Strategy: build a throwaway "fake LOOM_ROOT" whose install.sh is the REAL
+# script (symlinked) but whose scripts/install-loom.sh is a stub that always
+# fails -- deterministically simulating "the delegated Full Install workflow
+# failed" without needing a built loom-daemon binary, gh auth, or network
+# access. Run it against a scratch target repo seeded with an existing
+# (older) Loom install, and assert the scratch repo's tracked tree is
+# byte-for-byte unchanged afterward.
+#
+# Usage:
+#   bash defaults/scripts/tests/test-install-full-reinstall-no-target-mutation.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_PASSED=$((TESTS_PASSED + 1)); TESTS_RUN=$((TESTS_RUN + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() {
+  TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_RUN=$((TESTS_RUN + 1))
+  echo -e "  ${RED}FAIL${NC}: $1"
+  [[ -n "${2:-}" ]] && echo "$2" | sed 's/^/      /'
+}
+
+if [[ ! -f "$INSTALL_SH" ]]; then
+  echo "ERROR: $INSTALL_SH not found" >&2
+  exit 1
+fi
+
+if ! command -v git &> /dev/null; then
+  echo -e "${YELLOW}SKIP${NC}: missing required dependency 'git'"
+  exit 0
+fi
+
+echo "================================================================"
+echo "Full-reinstall no-target-mutation-on-failure (issue #4888)"
+echo "================================================================"
+echo ""
+
+# --- 1. Build a fake LOOM_ROOT: real install.sh, stubbed install-loom.sh ---
+#
+# scripts/install/ (provision-daemon.sh, provision-hooks.sh, stash-scope.sh,
+# ...) and the real uninstall-loom.sh are symlinked in so the reinstall gate
+# behaves identically to a real checkout, regardless of which code path
+# (pre- or post-fix) this test happens to be pointed at. Only
+# scripts/install-loom.sh -- the Full Install delegate -- is replaced with a
+# stub that always fails, deterministically simulating "the delegated
+# workflow failed downstream" without needing a built loom-daemon binary, gh
+# auth, or network access.
+FAKE_ROOT="$(mktemp -d /tmp/loom-full-reinstall-fakeroot.XXXXXX)"
+mkdir -p "$FAKE_ROOT/scripts"
+ln -s "$REPO_ROOT/scripts/install" "$FAKE_ROOT/scripts/install"
+ln -s "$REPO_ROOT/scripts/uninstall-loom.sh" "$FAKE_ROOT/scripts/uninstall-loom.sh"
+ln -s "$REPO_ROOT/install.sh" "$FAKE_ROOT/install.sh"
+
+STUB_MARKER="STUB install-loom.sh: simulating a downstream Full Install failure"
+cat > "$FAKE_ROOT/scripts/install-loom.sh" <<EOF
+#!/usr/bin/env bash
+echo "$STUB_MARKER" >&2
+exit 1
+EOF
+chmod +x "$FAKE_ROOT/scripts/install-loom.sh"
+
+# --- 2. Seed a scratch target repo with an existing ("older") Loom install ---
+TARGET="$(mktemp -d /tmp/loom-full-reinstall-target.XXXXXX)"
+git -C "$TARGET" init --quiet
+git -C "$TARGET" config user.email "test@test.com"
+git -C "$TARGET" config user.name "Test"
+
+mkdir -p "$TARGET/.loom/roles" "$TARGET/.claude"
+echo '{"loom_version": "0.1.0"}' > "$TARGET/.loom/install-metadata.json"
+echo '{}' > "$TARGET/.loom/config.json"
+echo '{}' > "$TARGET/.claude/settings.json"
+cat > "$TARGET/CLAUDE.md" <<'EOF'
+<!-- BEGIN LOOM ORCHESTRATION -->
+This repository uses Loom.
+<!-- END LOOM ORCHESTRATION -->
+
+# My Project
+
+Hand-written project docs.
+EOF
+cat > "$TARGET/.gitignore" <<'EOF'
+node_modules/
+
+# BEGIN LOOM
+.loom/tokens/
+.loom/*.log
+# END LOOM
+EOF
+git -C "$TARGET" add -A
+git -C "$TARGET" commit -m "Initial commit with an older Loom install" --quiet
+
+PRE_INSTALL_SHA="$(git -C "$TARGET" rev-parse HEAD)"
+
+# --- 3. Run the (fake-rooted) installer's --full --confirm-reinstall path ---
+OUTPUT="$("$FAKE_ROOT/install.sh" --full --confirm-reinstall -y "$TARGET" < /dev/null 2>&1)"
+EXIT_CODE=$?
+
+if [[ $EXIT_CODE -ne 0 ]]; then
+  pass "install run exited non-zero (downstream failure propagated)"
+else
+  fail "install run exited 0 (expected the stub failure to propagate)" "$OUTPUT"
+fi
+
+if [[ "$OUTPUT" == *"$STUB_MARKER"* ]]; then
+  pass "run actually reached the Full Install delegation (stub marker seen)"
+else
+  fail "run never reached the Full Install delegation -- test setup is broken" "$OUTPUT"
+fi
+
+# --- 4. Assert the target's tracked tree is completely untouched ---
+POST_SHA="$(git -C "$TARGET" rev-parse HEAD)"
+if [[ "$POST_SHA" == "$PRE_INSTALL_SHA" ]]; then
+  pass "HEAD is unchanged"
+else
+  fail "HEAD moved (expected $PRE_INSTALL_SHA, got $POST_SHA)"
+fi
+
+STATUS_AFTER="$(git -C "$TARGET" status --porcelain)"
+if [[ -z "$STATUS_AFTER" ]]; then
+  pass "git status is clean -- no staged/unstaged diff from the pre-install HEAD"
+else
+  fail "git status is NOT clean after the failed full reinstall" "$STATUS_AFTER"
+fi
+
+# Belt-and-suspenders: the specific files the reported bug showed as
+# half-uninstalled must still carry their original committed content.
+for f in .claude/settings.json .loom/install-metadata.json CLAUDE.md .gitignore; do
+  if [[ -f "$TARGET/$f" ]] && git -C "$TARGET" diff --quiet -- "$f"; then
+    pass "$f present and unmodified"
+  else
+    fail "$f missing or modified" "$(git -C "$TARGET" status --short -- "$f")"
+  fi
+done
+
+rm -rf "$FAKE_ROOT" "$TARGET"
+
+echo ""
+echo "================================================================"
+echo "Tests run:    $TESTS_RUN"
+echo -e "Tests passed: ${GREEN}$TESTS_PASSED${NC}"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+  echo -e "Tests failed: ${RED}$TESTS_FAILED${NC}"
+  exit 1
+fi
+echo "================================================================"
+echo "All tests passed."

--- a/defaults/scripts/tests/test-install-full-reinstall-no-target-mutation.sh
+++ b/defaults/scripts/tests/test-install-full-reinstall-no-target-mutation.sh
@@ -92,6 +92,38 @@ exit 1
 EOF
 chmod +x "$FAKE_ROOT/scripts/install-loom.sh"
 
+# --- 1b. Stub the toolchain deps install.sh gates on, so this suite is
+# host-independent ---
+#
+# install.sh runs a "Checking System Dependencies" gate (node / pnpm / cargo /
+# git) BEFORE it reaches any of the reinstall logic under test. A host missing
+# any one of them aborts the run early, and the "stub marker seen" assertion
+# below fails for a reason that has nothing to do with the behavior this suite
+# exists to pin. That is exactly what happened on the hermetic CI runner, which
+# has node/cargo/git but no pnpm -- the suite only passed on developer machines
+# that happened to have pnpm installed.
+#
+# On the --full path under test, install.sh only ever runs `<tool> --version`
+# on these before `exec`ing the (stubbed) Full Install delegate, so trivially
+# satisfying the gate with version-printing stubs is sound and keeps the suite
+# genuinely exercising the reinstall control flow on every host -- strictly
+# better than skipping the whole suite wherever pnpm is absent, which would
+# have left the #4888 regression uncovered in CI.
+#
+# `git` is deliberately NOT stubbed: it is used for real (fixture repo, HEAD
+# and `git status --porcelain` assertions), which is why it keeps the hard
+# `command -v git` skip-guard above instead.
+STUB_BIN="$FAKE_ROOT/stub-bin"
+mkdir -p "$STUB_BIN"
+for _tool in node pnpm cargo; do
+  cat > "$STUB_BIN/$_tool" <<EOF
+#!/usr/bin/env bash
+# Test stub: install.sh's dependency gate only calls \`$_tool --version\`.
+echo "$_tool (loom test stub) 0.0.0"
+EOF
+  chmod +x "$STUB_BIN/$_tool"
+done
+
 # --- 2. Seed a scratch target repo with an existing ("older") Loom install ---
 TARGET="$(mktemp -d /tmp/loom-full-reinstall-target.XXXXXX)"
 git -C "$TARGET" init --quiet
@@ -125,7 +157,7 @@ git -C "$TARGET" commit -m "Initial commit with an older Loom install" --quiet
 PRE_INSTALL_SHA="$(git -C "$TARGET" rev-parse HEAD)"
 
 # --- 3. Run the (fake-rooted) installer's --full --confirm-reinstall path ---
-OUTPUT="$("$FAKE_ROOT/install.sh" --full --confirm-reinstall -y "$TARGET" < /dev/null 2>&1)"
+OUTPUT="$(PATH="$STUB_BIN:$PATH" "$FAKE_ROOT/install.sh" --full --confirm-reinstall -y "$TARGET" < /dev/null 2>&1)"
 EXIT_CODE=$?
 
 if [[ $EXIT_CODE -ne 0 ]]; then

--- a/install.sh
+++ b/install.sh
@@ -836,6 +836,19 @@ if [[ ${#MISSING_DEPS[@]} -gt 0 ]]; then
   echo -e "$INSTALL_INSTRUCTIONS"
   echo ""
 
+  # Issue #4888: this gate used to `read` unconditionally, even under
+  # --yes/--quick/--full. On a non-interactive run stdin is not a terminal, so
+  # the read returns immediately at EOF with an empty reply, which then fell
+  # into the "exit to install" default below and aborted -- after printing a
+  # prompt nobody was there to answer, and (when stdin is a pipe rather than
+  # /dev/null) after silently eating a byte of whatever else was on it. Honor
+  # NON_INTERACTIVE explicitly instead: same outcome (a missing required
+  # dependency is still fatal), but as a direct, greppable error rather than a
+  # phantom prompt.
+  if [[ "$NON_INTERACTIVE" == true ]]; then
+    error "Missing required dependencies: ${MISSING_DEPS[*]} -- cannot continue a non-interactive install.\n       Install them (see above) and re-run, or drop --yes/--quick/--full to get an interactive prompt that lets you continue anyway."
+  fi
+
   read -r -p "Exit to install dependencies? [Y/n] " -n 1 INSTALL_DEPS
   echo ""
   if [[ ! $INSTALL_DEPS =~ ^[Nn]$ ]]; then

--- a/install.sh
+++ b/install.sh
@@ -884,8 +884,9 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
     info "Reinstall will uninstall the existing installation first, then perform"
     info "a fresh Quick Install."
   else
-    info "Reinstall will uninstall the existing installation first, then perform"
-    info "a fresh install and create a PR with the changes."
+    info "Reinstall will upgrade the existing installation in an isolated worktree"
+    info "and open a PR with the changes -- your working directory is not touched"
+    info "until you merge it."
   fi
   echo ""
 
@@ -908,22 +909,41 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
     error "Existing Loom installation detected at $TARGET_PATH/.loom -- refusing to run a non-interactive reinstall without explicit acknowledgement.\n       Reinstalling uninstalls the existing Loom payload before writing the new version; inventory and back up any project-owned Loom hooks, scripts, and agent configuration first.\n       Re-run with --confirm-reinstall once you have done so, or omit --quick/--yes/--full to get an interactive y/N prompt instead."
   fi
 
-  # Issue #3545: for a --quick reinstall, guard uncommitted user changes across
-  # the uninstall→reinstall cycle (mirrors the stash guard in the sibling
-  # scripts/install-loom.sh --clean path). The uninstall runs `git add` in the
-  # target tree and the reinstall reconciles the index afterwards; stashing
-  # first keeps a user's pre-existing staged/working changes from being caught
-  # up in either step. The non-quick reinstall delegates to install-loom.sh,
-  # which performs its own guarding, so it is intentionally left unstashed here.
-  #
-  # Issue #3597: scope the stash to Loom-owned paths. The original unscoped
-  # `git stash push` swept sibling installers' uncommitted tracked changes
-  # (.anvil/*, .claude/skills/repo/*, non-Loom CLAUDE.md sections, …) into the
-  # stash and left a half-old/half-new hybrid tree. Restrict the stash to the
-  # dirty ∩ (Loom ownership set + .gitignore) intersection so sibling changes
-  # are never touched. Empty intersection → no stash at all.
-  REINSTALL_STASHED_USER_CHANGES=false
+  # Issue #4888: the chained uninstall below (`uninstall-loom.sh --yes --local`)
+  # mutates $TARGET_PATH's MAIN checkout directly -- it stages deletions and
+  # strips the Loom sections out of CLAUDE.md / .gitignore in place. That is
+  # necessary and safe for a --quick reinstall (the fresh install runs
+  # synchronously in that same working tree right after -- see the
+  # INSTALL_TYPE=="1" branch below, which unstages/restores as part of its own
+  # completion). It is NOT safe for the non-quick (Full Install) path: that
+  # path `exec`s into scripts/install-loom.sh, which does all of its real work
+  # in an isolated worktree branched from `origin/main` (see
+  # scripts/install/create-worktree.sh) and opens a PR -- it never reads or
+  # needs a pre-uninstalled main checkout. Once `exec` replaces this process,
+  # nothing here can roll back a downstream failure (a trap in *this* script
+  # will never fire), so any failure inside the delegated install-loom.sh run
+  # left the chained uninstall's staged deletions stranded on $TARGET_PATH's
+  # main checkout with no automatic recovery (the reported half-uninstalled
+  # target). `loom-daemon init` already performs a careful merge/upgrade of an
+  # existing install (including legacy-content migration) from inside that
+  # worktree, so the Full Install path needs no pre-mutation at all --
+  # install-loom.sh's own idempotency check detects the older installed
+  # version and proceeds with a normal upgrade (see the delegation site below).
   if [[ "$INSTALL_TYPE" == "1" ]]; then
+    # Issue #3545: for a --quick reinstall, guard uncommitted user changes across
+    # the uninstall→reinstall cycle (mirrors the stash guard in the sibling
+    # scripts/install-loom.sh --clean path). The uninstall runs `git add` in the
+    # target tree and the reinstall reconciles the index afterwards; stashing
+    # first keeps a user's pre-existing staged/working changes from being caught
+    # up in either step.
+    #
+    # Issue #3597: scope the stash to Loom-owned paths. The original unscoped
+    # `git stash push` swept sibling installers' uncommitted tracked changes
+    # (.anvil/*, .claude/skills/repo/*, non-Loom CLAUDE.md sections, …) into the
+    # stash and left a half-old/half-new hybrid tree. Restrict the stash to the
+    # dirty ∩ (Loom ownership set + .gitignore) intersection so sibling changes
+    # are never touched. Empty intersection → no stash at all.
+    REINSTALL_STASHED_USER_CHANGES=false
     # shellcheck source=scripts/install/stash-scope.sh
     source "$LOOM_ROOT/scripts/install/stash-scope.sh"
     REINSTALL_OWNED_DIRTY=()
@@ -946,35 +966,32 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
         warning "Uncommitted changes may appear alongside the reinstall diff"
       fi
     fi
-  fi
 
-  # Issue #3598: snapshot the committed .loom/config.json before the chained
-  # uninstall deletes it. `config.json` is listed in uninstall-loom.sh's
-  # RUNTIME_ARTIFACTS and is removed from disk, but it is consumer configuration
-  # (e.g. a load-bearing `worktree.root` override), not a runtime artifact.
-  # Restoring the snapshot before `loom-daemon init` (below) lets the daemon's
-  # merge-aware config copy preserve consumer keys instead of regenerating the
-  # file from the template. Mirrors the #3588 .gitignore snapshot pattern.
-  # Standalone uninstall behavior is intentionally unchanged.
-  REINSTALL_CONFIG_SNAPSHOT=""
-  if [[ -f "$TARGET_PATH/.loom/config.json" ]]; then
-    REINSTALL_CONFIG_SNAPSHOT="$(mktemp 2>/dev/null || true)"
-    if [[ -n "$REINSTALL_CONFIG_SNAPSHOT" ]]; then
-      cp "$TARGET_PATH/.loom/config.json" "$REINSTALL_CONFIG_SNAPSHOT" 2>/dev/null || \
-        REINSTALL_CONFIG_SNAPSHOT=""
+    # Issue #3598: snapshot the committed .loom/config.json before the chained
+    # uninstall deletes it. `config.json` is listed in uninstall-loom.sh's
+    # RUNTIME_ARTIFACTS and is removed from disk, but it is consumer configuration
+    # (e.g. a load-bearing `worktree.root` override), not a runtime artifact.
+    # Restoring the snapshot before `loom-daemon init` (below) lets the daemon's
+    # merge-aware config copy preserve consumer keys instead of regenerating the
+    # file from the template. Mirrors the #3588 .gitignore snapshot pattern.
+    # Standalone uninstall behavior is intentionally unchanged.
+    REINSTALL_CONFIG_SNAPSHOT=""
+    if [[ -f "$TARGET_PATH/.loom/config.json" ]]; then
+      REINSTALL_CONFIG_SNAPSHOT="$(mktemp 2>/dev/null || true)"
+      if [[ -n "$REINSTALL_CONFIG_SNAPSHOT" ]]; then
+        cp "$TARGET_PATH/.loom/config.json" "$REINSTALL_CONFIG_SNAPSHOT" 2>/dev/null || \
+          REINSTALL_CONFIG_SNAPSHOT=""
+      fi
     fi
-  fi
 
-  # Uninstall existing installation (local mode, no separate PR)
-  info "Uninstalling existing Loom installation..."
-  "$LOOM_ROOT/scripts/uninstall-loom.sh" --yes --local "$TARGET_PATH" || \
-    error "Uninstall failed - aborting reinstall"
-  echo ""
-  success "Existing installation removed"
-  echo ""
+    # Uninstall existing installation (local mode, no separate PR)
+    info "Uninstalling existing Loom installation..."
+    "$LOOM_ROOT/scripts/uninstall-loom.sh" --yes --local "$TARGET_PATH" || \
+      error "Uninstall failed - aborting reinstall"
+    echo ""
+    success "Existing installation removed"
+    echo ""
 
-  # If --quick was specified, do a quick reinstall instead of full workflow
-  if [[ "$INSTALL_TYPE" == "1" ]]; then
     info "Running fresh Quick Install..."
     echo ""
 
@@ -1253,7 +1270,19 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
     exit 0
   fi
 
-  # Default: delegate to Full Install (creates worktree + PR)
+  # Default: delegate to Full Install (creates worktree + PR). Issue #4888: no
+  # uninstall runs against $TARGET_PATH's main checkout above for this path --
+  # the delegated install-loom.sh does all of its work in an isolated worktree
+  # (scripts/install/create-worktree.sh branches from `origin/main`) and never
+  # touches the live main checkout, so there is nothing to roll back on
+  # failure. install-loom.sh's own idempotency check will detect the existing
+  # (older) installed version from $TARGET_PATH/.loom/install-metadata.json
+  # and proceed with a normal merge-mode upgrade inside its worktree -- the
+  # same careful preserve/migrate logic (loom-daemon init) that a plain
+  # `install-loom.sh` upgrade already relies on. Deliberately NOT passing
+  # --force here: that flag also flips FORCE_AUTO_MERGE on for the resulting
+  # PR (scripts/install-loom.sh's create-pr.sh call), which is a bigger
+  # behavior change (skips human review) than this fix's scope.
   info "Running fresh install via Full Install workflow..."
   echo ""
   INSTALL_FLAGS=()

--- a/loom-daemon/src/init/scaffolding.rs
+++ b/loom-daemon/src/init/scaffolding.rs
@@ -925,8 +925,13 @@ pub fn setup_repository_scaffolding(
     // (AGENTS_SECTION_START/END) so the two files' Loom-managed sections are
     // independently detectable. AGENTS.md has no historical "legacy
     // full-guide-in-root" layout to migrate away from (unlike CLAUDE.md's
-    // pre-#3000 layout), so no `is_legacy_loom_managed_root`-style heuristic is
-    // needed for it.
+    // pre-#3000 layout) — but it still needs the same
+    // `is_legacy_loom_managed_root` / `slice_is_discardable_legacy` heuristics
+    // (issue #4888): a broken or interrupted prior install can leave a root
+    // AGENTS.md carrying stale, unsubstituted Loom template text with missing
+    // or malformed markers, and preserving that verbatim would reintroduce the
+    // placeholders and trip `assert_no_placeholders` below. See the marker /
+    // markerless branches further down.
     //
     // `defaults/.loom/AGENTS.md` is itself a generated artifact
     // (defaults/scripts/generate-agents-md.sh, kept in sync by

--- a/loom-daemon/src/init/scaffolding.rs
+++ b/loom-daemon/src/init/scaffolding.rs
@@ -987,13 +987,44 @@ pub fn setup_repository_scaffolding(
                     } else {
                         ""
                     };
-                    format!("{}{}{}", before.trim_end(), wrapped_agents_pointer, after)
+                    // Same hybrid-legacy hazard CLAUDE.md guards against
+                    // (issue #3476/#3527): if the slice outside the marker
+                    // block is itself leftover Loom-managed cruft — e.g. from
+                    // a previously interrupted install that left unsubstituted
+                    // `{{LOOM_VERSION}}` text lying around — preserving it
+                    // verbatim reintroduces the placeholders and trips the
+                    // `assert_no_placeholders` guard below (issue #4888).
+                    if slice_is_discardable_legacy(before) || slice_is_discardable_legacy(after) {
+                        wrapped_agents_pointer.clone()
+                    } else {
+                        format!("{}{}{}", before.trim_end(), wrapped_agents_pointer, after)
+                    }
                 } else {
-                    // Malformed markers - append pointer at end.
-                    format!("{}\n\n{}", existing_content.trim(), wrapped_agents_pointer)
+                    // Malformed markers (only one of START/END present) - this
+                    // is exactly the shape a broken/interrupted prior install
+                    // can leave behind. Treat it the same as the no-markers
+                    // case below rather than blindly preserving it (issue
+                    // #4888): discard if it looks like leftover Loom-managed
+                    // content, otherwise preserve and append.
+                    if is_legacy_loom_managed_root(&existing_content) {
+                        wrapped_agents_pointer.clone()
+                    } else {
+                        format!("{}\n\n{}", existing_content.trim(), wrapped_agents_pointer)
+                    }
                 }
+            } else if is_legacy_loom_managed_root(&existing_content) {
+                // No markers, but the content matches a known Loom-managed
+                // legacy/leftover signature (most tellingly, unsubstituted
+                // `{{LOOM_VERSION}}`-style placeholders — real users don't
+                // type those into hand-authored docs). This can happen even
+                // though AGENTS.md itself has no historical full-guide-in-root
+                // layout: a broken or interrupted prior install can leave a
+                // markerless root AGENTS.md carrying stale Loom template text
+                // (issue #4888). Discard rather than preserve-and-leak.
+                wrapped_agents_pointer.clone()
             } else {
-                // No markers — preserve genuine user-authored content, append at end.
+                // No markers, no legacy signature — preserve genuine
+                // user-authored content, append at end.
                 format!("{}\n\n{}", existing_content.trim(), wrapped_agents_pointer)
             }
         } else {
@@ -1879,9 +1910,13 @@ WARNING: Never run `lake build` inside Docker - causes memory corruption.
     // AGENTS.md tests (issue #4479, epic #4167 — dual-runtime instruction
     // anchor; seeded by gpeyton/loom fork PR #8). These mirror the CLAUDE.md
     // marker-injection tests above, exercised against `defaults/.loom/AGENTS.md`
-    // and the AGENTS-specific marker pair. No legacy-layout heuristic tests are
-    // needed (unlike CLAUDE.md's pre-#3000 migration tests) since AGENTS.md has
-    // no historical full-guide-in-root layout to migrate away from.
+    // and the AGENTS-specific marker pair. AGENTS.md has no historical
+    // full-guide-in-root layout of its own to migrate away from, but issue
+    // #4888 showed a broken/interrupted prior install can still leave a root
+    // AGENTS.md carrying leaked, unsubstituted `{{LOOM_VERSION}}`-style
+    // placeholder text (with or without markers) — the legacy-migration tests
+    // below (reusing the same `is_legacy_loom_managed_root` /
+    // `slice_is_discardable_legacy` heuristics as CLAUDE.md) cover that case.
     // =========================================================================
 
     /// Helper to create a standard test setup with an AGENTS.md template in defaults.
@@ -2164,6 +2199,143 @@ WARNING: Never run `lake build` inside Docker - causes memory corruption.",
         assert!(loom_content.contains("Updated content v2"));
         assert!(!loom_content.contains("Old content v1"));
         assert!(report.updated.contains(&".loom/AGENTS.md".to_string()));
+    }
+
+    // ---------- #4888 AGENTS.md legacy-placeholder migration tests ----------
+
+    #[test]
+    fn test_setup_scaffolding_discards_markerless_legacy_root_agents_md() {
+        // Regression test for #4888 defect 1. A broken/interrupted prior
+        // install (or an old pre-marker layout) can leave a markerless root
+        // AGENTS.md carrying leaked, unsubstituted `{{LOOM_VERSION}}` text.
+        // Before the fix, the "no markers" branch preserved this verbatim,
+        // which reintroduced the placeholders and tripped
+        // `assert_no_placeholders`, aborting the whole install.
+        let temp_dir = TempDir::new().unwrap();
+        let (workspace, defaults) = setup_test_with_agents_template(
+            &temp_dir,
+            "# Loom Orchestration - Repository Guide (AGENTS.md)\n\nFull guide content (new).",
+        );
+        fs::create_dir_all(workspace.join(".loom")).unwrap();
+
+        // Markerless legacy content with leaked template placeholders.
+        fs::write(
+            workspace.join("AGENTS.md"),
+            "# Loom Orchestration - Repository Guide\n\n\
+             **Loom Version**: {{LOOM_VERSION}}\n\
+             **Installation Date**: {{INSTALL_DATE}}\n\n\
+             Generated by Loom Installation Process\n",
+        )
+        .unwrap();
+
+        let mut report = InitReport::default();
+        let result = setup_repository_scaffolding(&workspace, &defaults, false, &mut report);
+        assert!(result.is_ok(), "install must not fail on legacy AGENTS.md: {result:?}");
+
+        let content = fs::read_to_string(workspace.join("AGENTS.md")).unwrap();
+        assert!(content.contains(AGENTS_SECTION_START));
+        assert!(content.contains(AGENTS_SECTION_END));
+        assert!(content.contains(AGENTS_ROOT_POINTER));
+        assert!(!content.contains("{{LOOM_VERSION}}"), "leaked placeholder: {content}");
+        assert!(!content.contains("{{INSTALL_DATE}}"));
+        assert!(!content.contains("Generated by Loom Installation Process"));
+    }
+
+    #[test]
+    fn test_setup_scaffolding_discards_hybrid_legacy_root_agents_md() {
+        // Regression test for #4888 defect 1, hybrid variant (mirrors
+        // CLAUDE.md's #3476 hybrid test): a markered root AGENTS.md whose
+        // slice OUTSIDE the marker block is itself leftover legacy content
+        // with unsubstituted placeholders. Before the fix the marker-replace
+        // branch preserved `before`/`after` verbatim regardless of content,
+        // leaking the placeholders through and tripping the guard.
+        let temp_dir = TempDir::new().unwrap();
+        let (workspace, defaults) = setup_test_with_agents_template(
+            &temp_dir,
+            "# Loom Orchestration - Repository Guide (AGENTS.md)\n\nFull guide content (new).",
+        );
+        fs::create_dir_all(workspace.join(".loom")).unwrap();
+
+        let legacy_fragment = "# Loom Orchestration - Repository Guide\n\n\
+             **Loom Version**: {{LOOM_VERSION}}\n\
+             **Installation Date**: {{INSTALL_DATE}}\n\n\
+             Generated by Loom Installation Process\n";
+        let hybrid = format!("{}\n{}\n", legacy_fragment, wrap_agents_content("Old pointer text"));
+        fs::write(workspace.join("AGENTS.md"), &hybrid).unwrap();
+
+        let mut report = InitReport::default();
+        let result = setup_repository_scaffolding(&workspace, &defaults, false, &mut report);
+        assert!(result.is_ok(), "install must not fail on hybrid legacy AGENTS.md: {result:?}");
+
+        let content = fs::read_to_string(workspace.join("AGENTS.md")).unwrap();
+        assert_eq!(
+            content,
+            wrap_agents_content(AGENTS_ROOT_POINTER),
+            "hybrid legacy AGENTS.md should be fully replaced with the wrapped pointer"
+        );
+        assert!(!content.contains("{{LOOM_VERSION}}"));
+        assert!(!content.contains("{{INSTALL_DATE}}"));
+        assert!(!content.contains("Generated by Loom Installation Process"));
+        assert!(!content.contains("Old pointer text"));
+    }
+
+    #[test]
+    fn test_setup_scaffolding_discards_malformed_marker_legacy_root_agents_md() {
+        // Regression test for #4888 defect 1, malformed-marker variant: only
+        // the START marker is present (no END), which used to fall into the
+        // "append pointer at end" branch and preserve the entire file
+        // (including leaked placeholders) verbatim.
+        let temp_dir = TempDir::new().unwrap();
+        let (workspace, defaults) = setup_test_with_agents_template(
+            &temp_dir,
+            "# Loom Orchestration - Repository Guide (AGENTS.md)\n\nFull guide content (new).",
+        );
+        fs::create_dir_all(workspace.join(".loom")).unwrap();
+
+        let malformed = format!(
+            "{AGENTS_SECTION_START}\n**Loom Version**: {{{{LOOM_VERSION}}}}\nno end marker here\n"
+        );
+        fs::write(workspace.join("AGENTS.md"), &malformed).unwrap();
+
+        let mut report = InitReport::default();
+        let result = setup_repository_scaffolding(&workspace, &defaults, false, &mut report);
+        assert!(
+            result.is_ok(),
+            "install must not fail on malformed-marker AGENTS.md: {result:?}"
+        );
+
+        let content = fs::read_to_string(workspace.join("AGENTS.md")).unwrap();
+        assert!(content.contains(AGENTS_SECTION_START));
+        assert!(content.contains(AGENTS_SECTION_END));
+        assert!(content.contains(AGENTS_ROOT_POINTER));
+        assert!(!content.contains("{{LOOM_VERSION}}"), "leaked placeholder: {content}");
+    }
+
+    #[test]
+    fn test_setup_scaffolding_preserves_markerless_user_root_agents_md() {
+        // Negative control: markerless content with NO legacy signature must
+        // still be preserved and appended-to, not discarded. Guards against
+        // the new legacy check being overly aggressive.
+        let temp_dir = TempDir::new().unwrap();
+        let (workspace, defaults) = setup_test_with_agents_template(
+            &temp_dir,
+            "# Loom Orchestration - Repository Guide (AGENTS.md)\n\nFull guide content (new).",
+        );
+        fs::create_dir_all(workspace.join(".loom")).unwrap();
+
+        fs::write(
+            workspace.join("AGENTS.md"),
+            "# My Project\n\nHand-written Codex instructions, no Loom signatures here.",
+        )
+        .unwrap();
+
+        let mut report = InitReport::default();
+        setup_repository_scaffolding(&workspace, &defaults, false, &mut report).unwrap();
+
+        let content = fs::read_to_string(workspace.join("AGENTS.md")).unwrap();
+        assert!(content.contains("Hand-written Codex instructions"));
+        assert!(content.contains(AGENTS_SECTION_START));
+        assert!(content.contains(AGENTS_ROOT_POINTER));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes two installer defects reported in #4888 from a real-world `--full --confirm-reinstall` run against a target with an older install.

## Changes

- **`loom-daemon/src/init/scaffolding.rs`** (defect 1 — AGENTS.md placeholder refusal): the root `AGENTS.md` handling had no legacy-content protection analogous to `CLAUDE.md`'s `is_legacy_loom_managed_root` / `slice_is_discardable_legacy` migration. A broken/interrupted prior install (or malformed markers) could leave a root `AGENTS.md` carrying leaked, unsubstituted `{{LOOM_VERSION}}`-style placeholders. All three handling branches (well-formed markers, malformed markers, no markers) preserved that content verbatim, reintroducing the placeholders and tripping `assert_no_placeholders` — aborting the whole install with a misleading "bug in the installer" message. All three branches now reuse the same legacy-detection heuristics `CLAUDE.md` already relies on and discard the leaked content instead of preserving it.
- **`install.sh`** (defect 2 — no rollback on target mutation): the `--confirm-reinstall` flow ran a chained `uninstall-loom.sh --yes --local "$TARGET_PATH"` directly against the target's **main checkout** unconditionally, before delegating the `--full` path via `exec scripts/install-loom.sh`. Since `exec` replaces the process, nothing in `install.sh` could roll that mutation back if the delegated run failed downstream (e.g. at `loom-daemon init`), leaving the target half-uninstalled with no automatic recovery (the reported symptom — manual `git reset --hard HEAD` required). Root cause: `install-loom.sh`'s own Full Install workflow does all its real work in an isolated worktree branched from `origin/main` (`scripts/install/create-worktree.sh`) and never reads the pre-uninstalled main checkout — the chained uninstall served no purpose for that path. It is now scoped to the `--quick` path only (where it runs synchronously in the same tree and is unstaged/restored as part of that path's own completion); the `--full` path never mutates the target before delegating, so a downstream failure has nothing to roll back.
- **`defaults/scripts/tests/test-install-full-reinstall-no-target-mutation.sh`** (new): builds a throwaway "fake LOOM_ROOT" (real `install.sh`, real `scripts/install/*` + `uninstall-loom.sh`, but a stub `scripts/install-loom.sh` that always fails) and runs it against a scratch target seeded with an older install. Asserts the scratch target's tracked tree (HEAD, `git status --porcelain`, and the specific files the bug report showed as half-uninstalled) is completely unchanged after the simulated downstream failure. Verified this test fails against the pre-fix `install.sh` (reproducing the exact `D .loom/install-metadata.json` / `M CLAUDE.md` / `M .gitignore` pattern from the report) and passes against the fix.
- Added 4 new Rust unit tests in `scaffolding.rs` covering the AGENTS.md legacy-migration paths (markerless legacy, hybrid markered+legacy, malformed-marker, and a negative control for genuine user content).
- Wired the new bash suite into `defaults/scripts/tests/ci-wired.txt`.

## Not addressed (noted, out of scope)

- The cosmetic skills-provisioning path-mismatch warning (`~/.local/share/loom` checkout-layout disagreement) mentioned in the issue is lower priority and left as a follow-up — it didn't block the install and is unrelated to either fix above.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--full` install from a clean main source completes on a target with an existing older install, or fails BEFORE mutating the target | ✅ | The `--full` path no longer runs any uninstall/mutation against the target's main checkout before delegating; verified via the new regression test (simulated downstream failure leaves the target's tracked tree byte-for-byte unchanged) |
| AGENTS.md template substitution happens (or the daemon substitutes) — no placeholder refusal on the happy path | ✅ | All three AGENTS.md handling branches now discard leaked-placeholder legacy content instead of preserving it; covered by 3 new positive regression tests + 1 negative control |
| Any failure after target mutation restores the target's tracked files (git reset of the staged uninstall) as part of cleanup | ✅ | Achieved via the stronger guarantee of never mutating the target for the `--full` path in the first place (nothing to roll back); the `--quick` path's existing synchronous uninstall+restore is unchanged |
| Regression test: install-over-existing in a scratch repo, killed at the init step, leaves the scratch repo's tracked tree unchanged | ✅ | `test-install-full-reinstall-no-target-mutation.sh`, wired into CI |

## Test Plan

- `cargo test -p loom-daemon --lib init::scaffolding` — 62/62 passed, including the 4 new AGENTS.md legacy-migration tests
- `cargo fmt --check` / `cargo clippy -p loom-daemon --lib --tests -- -D warnings` — clean
- `bash defaults/scripts/tests/test-install-full-reinstall-no-target-mutation.sh` — 8/8 passed; manually verified it FAILS against the pre-fix `install.sh` (reproducing the exact half-uninstalled diff from the bug report) and PASSES against the fix
- `bash defaults/scripts/tests/test-install-reinstall-safety.sh`, `test-install-stash-scope.sh`, `test-install-source-guard.sh`, `test-install-pr-markers.sh`, `test-install-active-session.sh` — all still pass (no regressions in the adjacent reinstall/install-safety suites)
- `bash defaults/scripts/tests/check-ci-suite-manifest.sh` — clean (new suite wired)
- `bash -n install.sh` / `bash -n` on the new test file — clean

Closes #4888