### PR TITLE
fix(install): skip daemon rebuild when installed binary already matches source HEAD

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -383,6 +383,107 @@ loom_daemon_binary_stale() {
   [[ -n "$newer_file" ]]
 }
 
+# Issue #4897: `loom_daemon_binary_stale` above only ever compares the
+# *source tree's own build artifact* (`$loom_root/target/release/loom-daemon`)
+# against source mtimes -- it has no idea a machine-level binary already
+# installed at the destination (`provision_machine_daemon`'s target,
+# scripts/install/provision-daemon.sh) was already rebuilt from the exact
+# commit we're about to build, e.g. by a fleet-mate's install/sweep that ran
+# moments ago. Both call sites unconditionally ran `pnpm daemon:build` --
+# i.e. `cargo build --package loom-daemon --release` -- whenever the source
+# artifact looked stale, even when that build would just block for minutes on
+# `target/.cargo-lock` (held by an unrelated `cargo test`/`clippy` in the same
+# tree) and then produce a binary identical to one already on disk.
+#
+# Returns 0 ("current -- skip the build") when a machine-level installed
+# binary exists AND its embedded build commit (`--version`, see
+# loom-daemon/build.rs / loom_daemon::self_update::BUILD_IDENTITY) matches
+# source HEAD. This is the SAME comparison `provision_machine_daemon()`
+# already performs (scripts/install/provision-daemon.sh ~line 268, the
+# "already current at $dest_bin" short-circuit) -- reused here so install.sh
+# can skip the build BEFORE paying for the lock wait, not just discover after
+# the fact that the rebuild wasn't needed. On a match it also copies the
+# installed binary into `$loom_root/target/release/loom-daemon` (creating
+# target/release/ if missing) so the unmodified downstream call sites that
+# reference that in-repo path directly (`loom-daemon init`,
+# `provision_machine_daemon` itself) keep working without further changes.
+#
+# Returns 1 (build still needed) when there is no installed binary, its
+# `--version` can't be read, its embedded commit is "unknown"/unparsable, or
+# it does not match source HEAD.
+loom_daemon_dest_binary_current() {
+  local loom_root="$1"
+  local dest_dir="${LOOM_DAEMON_BIN_DIR:-$HOME/.local/bin}"
+  local dest_bin="$dest_dir/loom-daemon"
+
+  [[ -x "$dest_bin" ]] || return 1
+
+  local head_commit
+  head_commit="$(git -C "$loom_root" rev-parse --short HEAD 2>/dev/null)" || return 1
+  [[ -n "$head_commit" ]] || return 1
+
+  local dest_version dest_commit
+  dest_version="$("$dest_bin" --version 2>/dev/null)" || return 1
+  # `--version` embeds "... (commit <sha>, built <ts>)" -- see
+  # loom-daemon/build.rs and loom_daemon::self_update::BUILD_IDENTITY.
+  case "$dest_version" in
+    *"(commit "*)
+      dest_commit="${dest_version#*"(commit "}"
+      dest_commit="${dest_commit%%,*}"
+      ;;
+    *) return 1 ;;
+  esac
+  [[ -n "$dest_commit" && "$dest_commit" != "unknown" ]] || return 1
+  [[ "$dest_commit" == "$head_commit" ]] || return 1
+
+  mkdir -p "$loom_root/target/release" 2>/dev/null || return 1
+  cp -f "$dest_bin" "$loom_root/target/release/loom-daemon" 2>/dev/null || return 1
+  chmod 755 "$loom_root/target/release/loom-daemon" 2>/dev/null || true
+  return 0
+}
+
+# Issue #4897: runs `pnpm daemon:build` (a `cargo build --package loom-daemon
+# --release` under the hood) in the background and emits a periodic progress
+# line while it is running, so a wait contended on `target/.cargo-lock` (held
+# by an unrelated `cargo test`/`clippy` elsewhere in the same source tree) is
+# visibly distinguishable from a hung installer instead of producing zero
+# output for 10+ minutes. Best-effort: if `lsof` is unavailable or the lock
+# file can't be inspected, the progress line still fires, just without naming
+# the competing PID.
+run_daemon_build_with_progress() {
+  local loom_root="$1"
+  local lockfile="$loom_root/target/.cargo-lock"
+  local log
+  log="$(mktemp 2>/dev/null || echo "/tmp/loom-daemon-build.$$.log")"
+
+  ( cd "$loom_root" && pnpm daemon:build >"$log" 2>&1 ) &
+  local build_pid=$!
+
+  local elapsed=0
+  local interval=15
+  while kill -0 "$build_pid" 2>/dev/null; do
+    sleep "$interval"
+    elapsed=$((elapsed + interval))
+    kill -0 "$build_pid" 2>/dev/null || break
+
+    local holder=""
+    if [[ -f "$lockfile" ]] && command -v lsof >/dev/null 2>&1; then
+      holder="$(lsof -t "$lockfile" 2>/dev/null | head -n1 || true)"
+    fi
+    if [[ -n "$holder" ]]; then
+      info "  ... still building loom-daemon (${elapsed}s elapsed; waiting on cargo build-dir lock, held by pid $holder)"
+    else
+      info "  ... still building loom-daemon (${elapsed}s elapsed)"
+    fi
+  done
+
+  wait "$build_pid"
+  local status=$?
+  cat "$log" 2>/dev/null || true
+  rm -f "$log" 2>/dev/null || true
+  return $status
+}
+
 # Issue #3588: re-append the current Loom ephemeral .gitignore patterns after a
 # --quick reinstall stash pop that was performed against a HEAD-reset .gitignore.
 #
@@ -982,15 +1083,23 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
     # tree (issue #4188 -- a bare existence check reuses a binary built from
     # an older commit after `git pull` landed a newer one).
     if loom_daemon_binary_stale "$LOOM_ROOT"; then
-      if [[ -f "$LOOM_ROOT/target/release/loom-daemon" ]]; then
-        warning "loom-daemon binary is stale (source tree updated since last build)"
+      # Issue #4897: before paying for a `cargo build` (and its
+      # `target/.cargo-lock` wait), check whether the ALREADY-INSTALLED
+      # machine-level binary was already rebuilt from this exact commit --
+      # e.g. by a fleet-mate's install/sweep moments ago -- and reuse it
+      # instead of rebuilding.
+      if loom_daemon_dest_binary_current "$LOOM_ROOT"; then
+        info "loom-daemon already current at ${LOOM_DAEMON_BIN_DIR:-$HOME/.local/bin}/loom-daemon (matches source HEAD) -- skipping rebuild"
       else
-        warning "loom-daemon binary not found"
+        if [[ -f "$LOOM_ROOT/target/release/loom-daemon" ]]; then
+          warning "loom-daemon binary is stale (source tree updated since last build)"
+        else
+          warning "loom-daemon binary not found"
+        fi
+        info "Building loom-daemon (this may take a minute)..."
+        run_daemon_build_with_progress "$LOOM_ROOT" || error "Failed to build loom-daemon"
+        echo ""
       fi
-      info "Building loom-daemon (this may take a minute)..."
-      cd "$LOOM_ROOT"
-      pnpm daemon:build || error "Failed to build loom-daemon"
-      echo ""
     fi
 
     # Export LOOM_VERSION / LOOM_COMMIT so the daemon's template substituter
@@ -1366,15 +1475,23 @@ case "$METHOD" in
     # tree (issue #4188 -- a bare existence check reuses a binary built from
     # an older commit after `git pull` landed a newer one).
     if loom_daemon_binary_stale "$LOOM_ROOT"; then
-      if [[ -f "$LOOM_ROOT/target/release/loom-daemon" ]]; then
-        warning "loom-daemon binary is stale (source tree updated since last build)"
+      # Issue #4897: before paying for a `cargo build` (and its
+      # `target/.cargo-lock` wait), check whether the ALREADY-INSTALLED
+      # machine-level binary was already rebuilt from this exact commit --
+      # e.g. by a fleet-mate's install/sweep moments ago -- and reuse it
+      # instead of rebuilding.
+      if loom_daemon_dest_binary_current "$LOOM_ROOT"; then
+        info "loom-daemon already current at ${LOOM_DAEMON_BIN_DIR:-$HOME/.local/bin}/loom-daemon (matches source HEAD) -- skipping rebuild"
       else
-        warning "loom-daemon binary not found"
+        if [[ -f "$LOOM_ROOT/target/release/loom-daemon" ]]; then
+          warning "loom-daemon binary is stale (source tree updated since last build)"
+        else
+          warning "loom-daemon binary not found"
+        fi
+        info "Building loom-daemon (this may take a minute)..."
+        run_daemon_build_with_progress "$LOOM_ROOT" || error "Failed to build loom-daemon"
+        echo ""
       fi
-      info "Building loom-daemon (this may take a minute)..."
-      cd "$LOOM_ROOT"
-      pnpm daemon:build || error "Failed to build loom-daemon"
-      echo ""
     fi
 
     # Export LOOM_VERSION / LOOM_COMMIT so the daemon's template substituter

--- a/tests/install/test-daemon-build-shortcut.sh
+++ b/tests/install/test-daemon-build-shortcut.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Test suite for install.sh::loom_daemon_dest_binary_current() (issue #4897).
+#
+# Usage: ./tests/install/test-daemon-build-shortcut.sh
+#
+# install.sh runs top-level installer logic when sourced, so we extract just
+# the loom_daemon_dest_binary_current() function definition (the pre-build
+# short-circuit that lets a `--quick`/Quick Install skip `pnpm daemon:build`
+# -- and the `target/.cargo-lock` wait it can trigger -- when a machine-level
+# installed binary is already built from source HEAD) and eval it in
+# isolation, mirroring the extraction pattern in test-hooks-preserve.sh.
+#
+# Uses a FAKE loom-daemon binary that prints a settable `--version` string;
+# no real cargo build or network access needed.
+#
+# Exit code 0 = all tests pass, 1 = failures detected.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "${RED}FAIL${NC}: $desc"
+    echo "  expected: '$expected'"
+    echo "  actual:   '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Extract the loom_daemon_dest_binary_current() function body from install.sh
+# and define it here. awk grabs from the function header to the first
+# closing brace at column 0 (same technique as test-hooks-preserve.sh).
+_FN_SRC="$(awk '/^loom_daemon_dest_binary_current\(\) \{/{f=1} f{print} f&&/^}$/{exit}' "$INSTALL_SH")"
+if [[ -z "$_FN_SRC" ]]; then
+  echo -e "${RED}FATAL${NC}: could not extract loom_daemon_dest_binary_current() from $INSTALL_SH"
+  exit 1
+fi
+eval "$_FN_SRC"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# Build a fake loom-daemon binary that prints $2 as its --version output.
+make_fake_bin() {
+  local path="$1" version_output="$2"
+  cat > "$path" <<EOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "--version" ]]; then echo "$version_output"; fi
+EOF
+  chmod +x "$path"
+}
+
+# Build a minimal git repo standing in for LOOM_ROOT, and echo its HEAD short
+# commit so tests can construct a matching / mismatching fake --version.
+make_loom_root() {
+  local root="$1"
+  mkdir -p "$root"
+  git -C "$root" init -q
+  git -C "$root" config user.email "test@example.com"
+  git -C "$root" config user.name "Test"
+  echo "placeholder" > "$root/placeholder.txt"
+  git -C "$root" add placeholder.txt
+  git -C "$root" commit -q -m "initial commit"
+  git -C "$root" rev-parse --short HEAD
+}
+
+# ---------- test 1: no installed binary at the destination -> build still needed ----------
+ROOT1="$WORKDIR/root1"
+make_loom_root "$ROOT1" >/dev/null
+DEST1="$WORKDIR/dest1"
+mkdir -p "$DEST1"
+rc1=0
+LOOM_DAEMON_BIN_DIR="$DEST1" loom_daemon_dest_binary_current "$ROOT1" || rc1=$?
+assert_eq "missing dest binary returns 1 (build needed)" "1" "$rc1"
+assert_eq "missing dest binary: no target/release copy made" "0" \
+  "$( [[ -e "$ROOT1/target/release/loom-daemon" ]] && echo 1 || echo 0 )"
+
+# ---------- test 2: dest binary present but commit MISMATCHES source HEAD ----------
+ROOT2="$WORKDIR/root2"
+make_loom_root "$ROOT2" >/dev/null
+DEST2="$WORKDIR/dest2"
+mkdir -p "$DEST2"
+make_fake_bin "$DEST2/loom-daemon" "0.17.0 (commit deadbee, built 2026-01-01T00:00:00Z)"
+rc2=0
+LOOM_DAEMON_BIN_DIR="$DEST2" loom_daemon_dest_binary_current "$ROOT2" || rc2=$?
+assert_eq "mismatched commit returns 1 (build needed)" "1" "$rc2"
+assert_eq "mismatched commit: no target/release copy made" "0" \
+  "$( [[ -e "$ROOT2/target/release/loom-daemon" ]] && echo 1 || echo 0 )"
+
+# ---------- test 3: dest binary present with commit "unknown" (no git at build time) ----------
+ROOT3="$WORKDIR/root3"
+make_loom_root "$ROOT3" >/dev/null
+DEST3="$WORKDIR/dest3"
+mkdir -p "$DEST3"
+make_fake_bin "$DEST3/loom-daemon" "0.17.0 (commit unknown, built 2026-01-01T00:00:00Z)"
+rc3=0
+LOOM_DAEMON_BIN_DIR="$DEST3" loom_daemon_dest_binary_current "$ROOT3" || rc3=$?
+assert_eq "unknown commit returns 1 (build needed)" "1" "$rc3"
+
+# ---------- test 4: dest binary present but --version output unparsable ----------
+ROOT4="$WORKDIR/root4"
+make_loom_root "$ROOT4" >/dev/null
+DEST4="$WORKDIR/dest4"
+mkdir -p "$DEST4"
+make_fake_bin "$DEST4/loom-daemon" "0.17.0"
+rc4=0
+LOOM_DAEMON_BIN_DIR="$DEST4" loom_daemon_dest_binary_current "$ROOT4" || rc4=$?
+assert_eq "unparsable --version returns 1 (build needed)" "1" "$rc4"
+
+# ---------- test 5: dest binary present and commit MATCHES source HEAD -> skip the build ----------
+ROOT5="$WORKDIR/root5"
+HEAD5="$(make_loom_root "$ROOT5")"
+DEST5="$WORKDIR/dest5"
+mkdir -p "$DEST5"
+make_fake_bin "$DEST5/loom-daemon" "0.17.0 (commit $HEAD5, built 2026-01-01T00:00:00Z)"
+rc5=0
+LOOM_DAEMON_BIN_DIR="$DEST5" loom_daemon_dest_binary_current "$ROOT5" || rc5=$?
+assert_eq "matching commit returns 0 (build skipped)" "0" "$rc5"
+assert_eq "matching commit: copies dest binary into target/release/loom-daemon" "1" \
+  "$( [[ -x "$ROOT5/target/release/loom-daemon" ]] && echo 1 || echo 0 )"
+assert_eq "matching commit: copied binary reports the same --version" \
+  "0.17.0 (commit $HEAD5, built 2026-01-01T00:00:00Z)" \
+  "$("$ROOT5/target/release/loom-daemon" --version)"
+
+# ---------- test 6: LOOM_DAEMON_BIN_DIR unset falls back to $HOME/.local/bin ----------
+# Point HOME at a throwaway dir with no installed binary; must still return 1
+# (no crash resolving the default dest dir).
+ROOT6="$WORKDIR/root6"
+make_loom_root "$ROOT6" >/dev/null
+FAKE_HOME6="$WORKDIR/home6"
+mkdir -p "$FAKE_HOME6"
+rc6=0
+( unset LOOM_DAEMON_BIN_DIR; HOME="$FAKE_HOME6" loom_daemon_dest_binary_current "$ROOT6" ) || rc6=$?
+assert_eq "default dest dir (no LOOM_DAEMON_BIN_DIR) with nothing installed returns 1" "1" "$rc6"
+
+# ---------- summary ----------
+echo ""
+echo "-----------------------------------------"
+echo "Total: $TOTAL  Passed: $PASS  Failed: $FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Fixes #4897: `install.sh` unconditionally ran `pnpm daemon:build` (`cargo build --package loom-daemon --release`) whenever `loom_daemon_binary_stale()` reported the source-tree's own `target/release/loom-daemon` as stale-by-mtime — even when a machine-level binary was already installed and built from the exact commit in question. The build then blocked for 10+ minutes on a contended `target/.cargo-lock` (held by an unrelated `cargo test`/`clippy` in the same source tree) with zero output, only to print `[loom-daemon] already current at ~/.local/bin/loom-daemon` *after* the wait — the rebuild was never needed.

## Changes

- `install.sh`: adds `loom_daemon_dest_binary_current()`, which hoists the version-aware comparison `provision_machine_daemon()` already performs *after* a build (`scripts/install/provision-daemon.sh`'s "already current at `$dest_bin`" short-circuit, ~line 271) so it can run **before** the build instead. It compares the installed binary's embedded commit (`<dest_bin> --version`, baked in by `loom-daemon/build.rs`) against source `HEAD` (`git rev-parse --short HEAD`), and on a match copies the installed binary into `$LOOM_ROOT/target/release/loom-daemon` so the unmodified downstream call sites (`loom-daemon init`, `provision_machine_daemon`) keep working without further changes.
- Both call sites that acted on `loom_daemon_binary_stale()` — the `--quick` reinstall path and the main Quick Install method — now check `loom_daemon_dest_binary_current()` first and skip `pnpm daemon:build` entirely on a match.
- Adds `run_daemon_build_with_progress()`: when a build genuinely is needed, it now runs in the background with a periodic (15s) progress line, naming the elapsed time and — when `lsof` is available — the PID currently holding `target/.cargo-lock`, so a lock-contended wait is distinguishable from a hang.
- Adds `tests/install/test-daemon-build-shortcut.sh`, extending the existing extract-and-eval test pattern (`tests/install/test-hooks-preserve.sh`) to unit-test `loom_daemon_dest_binary_current()`: missing dest binary, mismatched commit, `unknown` commit, unparsable `--version`, matching commit (skip + copy), and the default `$HOME/.local/bin` dest-dir resolution. 10/10 pass.

## Test plan

- [x] `bash tests/install/test-daemon-build-shortcut.sh` — 10/10 pass
- [x] All existing `tests/install/*.sh` suites still pass (`test-forge-detect.sh`, `test-git-repo-detection.sh`, `test-hooks-preserve.sh`, `test-provision-daemon.sh`, `test-uninstall-labels-block.sh`, `test-uninstall-preserve-siblings.sh`)
- [x] `bash scripts/test-installer.sh` — full install/uninstall/reinstall integration suite passes end-to-end (exit 0)
- [x] `shellcheck install.sh tests/install/test-daemon-build-shortcut.sh` — no new warnings
- [x] `bash -n install.sh` — syntax OK
- [ ] Manual verification (not run in this sandbox — no second host/shell available to hold a real `target/.cargo-lock`): hold the lock in a second shell, run `install.sh --quick` against a repo whose installed `~/.local/bin/loom-daemon` matches source HEAD, confirm the rebuild is skipped with no lock wait; repeat with the installed binary behind HEAD and confirm the build runs with periodic progress output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)