### PR TITLE
ci: include install.sh and tests/install/** in scripts paths-filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
               - 'scripts/**'
               - 'defaults/**'
               - 'tests/hooks/**'
+              - 'tests/install/**'
+              - 'install.sh'
               # .loom/hooks/** is git-tracked (self-install dogfooding) and
               # several defaults/hooks/tests/*.sh + tests/hooks/*.sh suites
               # assert it's byte-identical to defaults/hooks/** (#4451) — a


### PR DESCRIPTION
## Summary

CI's `scripts` paths-filter in `.github/workflows/ci.yml` never matched
root-level `install.sh` or anything under `tests/install/**`, even though
the `installer-tests` and `shell-test-suites` jobs (both gated on
`needs.changes.outputs.scripts == 'true'`) specifically exercise
`install.sh` (via `scripts/test-installer.sh`) and fixtures under
`tests/install/`. PRs touching only those paths got zero CI signal from
either job.

## Changes

- `.github/workflows/ci.yml`: added `'tests/install/**'` and `'install.sh'`
  to the `scripts` paths-filter list, alongside the existing
  `scripts/**`, `defaults/**`, `tests/hooks/**`, and `.loom/hooks/**`
  entries.
- The existing `.loom/hooks/**` explanatory comment (dogfooding parity
  with `defaults/hooks/**`, #4451) is left unchanged — only inserted the
  two new list entries above it.

## Acceptance Criteria Verification

- [x] `scripts` path filter includes `'tests/install/**'` — added
- [x] `scripts` path filter includes `'install.sh'` — added
- [x] Existing `.loom/hooks/**` explanatory comment preserved unchanged —
      confirmed via `git diff`, only 2 lines inserted above it, comment
      text untouched
- [x] A PR touching only `install.sh` now runs `installer-tests` and
      `shell-test-suites` — `install.sh` now matches the `scripts` filter
      pattern directly
- [x] A PR touching only a file under `tests/install/**` now runs the
      same two jobs — `tests/install/**` now matches the `scripts` filter
      pattern directly
- [x] No other `changes` output (`backend`, `mcp`, `dashboard`) is
      affected — diff is scoped to the `scripts:` filter block only

## Test Plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML parses cleanly after the edit
- `git diff .github/workflows/ci.yml` reviewed — 2-line addition only, no reflow of the surrounding comment
- Reasoned through `dorny/paths-filter` semantics: `install.sh` (root-relative glob, no `**`) matches the top-level file exactly; `tests/install/**` matches any path under that directory, matching the same convention used by the existing `tests/hooks/**` entry

Closes #4924