### PR TITLE
fix(hooks): fail closed on unresolvable $VAR write targets from a linked-worktree cwd

### DIFF
--- a/defaults/docs/guard-hooks.md
+++ b/defaults/docs/guard-hooks.md
@@ -392,6 +392,41 @@ attempt to catch every conceivable write vector (an interpreter one-liner like
 fallback an agent reaches for after an Edit/Write denial, not building a full
 security boundary.
 
+**Unresolvable `$…` targets fail closed, in every cwd (issue #4921).** The
+tokenizer never expands variables, so a target it cannot resolve is emitted as
+the raw token (`$A/evil`) and the resolution then cwd-prefixes it as if it
+were a relative path. From a **main-checkout** cwd that fabricated path landed
+inside the main checkout and denied, so the fallback looked fail-closed; from
+a **linked-worktree** cwd — the canonical builder setup and the only mode
+#4178 actually protects — the same fabricated path walked back up into the
+acting worktree's own `.loom-managed` sentinel and was **allowed**, whatever
+the variable would expand to at runtime. The write-confinement check therefore
+decides on the target's *shape* before trusting either containment test.
+
+**Denied** (the write's *location*, not merely its filename, is unknowable):
+
+| Shape | Example | Why |
+|-------|---------|-----|
+| Variable from the root down | `> $DEST`, `tee "${OUT}"`, `> $(mktemp)`, `> /$X`, `> /$X/evil` | The path root itself is unknown — the value may be (or complete) an absolute path into the main checkout, so the cwd prefix is pure invention. |
+| Expandable `$` in a **directory** component, known prefix inside the repo/worktree area | `> $A/evil`, `> ./$A/evil`, `cd $A && > f`, `> <worktree>/$A/f` | The value may contain `..` or an absolute path, so neither the sentinel walk-up nor the containment test can see where it lands. |
+| …or no usable known prefix (it collapses to `/`) | `> /tmp/../$A/evil` | The known prefix is normalized *before* it is judged, so a `..` traversal cannot manufacture a benign-looking prefix. |
+
+**Not denied**, so the fix adds no new false positives: a `$` only in the final
+filename (`> out-$STAMP.log` — the directory is fully known, so the ordinary
+containment test still runs and still denies a main-checkout directory), a
+known prefix outside the protected area (`> /tmp/$D/f.log`), and a `$` a real
+shell would never expand — single-quoted or backslash-escaped (`> '$A/evil'`),
+mirroring the quoted-tilde rule of #4382. As always, the deny only fires when a
+managed worktree actually exists for the repo, and the category toggle below
+switches it off with the rest of the check.
+
+The workaround when an agent legitimately needs a variable-derived target is to
+spell the path out literally — inside its own issue worktree for repo files, or
+as an explicit `/tmp/...` path for scratch. This deliberately also denies a
+target derived from a variable that would land *outside* the repo entirely
+(`> $HOME/x`, `> $TMPDIR/f`): the guard cannot know that at scan time, and
+fail-closed on an unknowable location is the whole point of the rule.
+
 The guard is **on by default**. It is resolved in this order (highest precedence first):
 
 1. **`LOOM_GUARD_WORKTREE_ISOLATION` env var** — `0`/`false`/`no` disables the guard; `1`/`true`/`yes` forces it on. Overrides the config value.

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -962,6 +962,62 @@ _any_managed_worktree_exists() {
 }
 
 # =============================================================================
+# mark_expandable_dollars() — rewrite a raw write-target token into its
+# "effective path shape" (#4921).
+#
+# extract_write_targets() is a TOKENIZER, not a shell evaluator: a token is
+# emitted with its quote characters copied verbatim (qsplit's contract) and
+# with every `$…` reference unexpanded. Before the write-confinement block can
+# reason about WHERE a token lands, it needs to know which `$` characters the
+# real shell would actually expand — a `$` inside a SINGLE-quoted span, or one
+# preceded by a backslash, is literal data (a file really named `$X`), while a
+# bare or DOUBLE-quoted `$` is an expansion the guard cannot resolve.
+#
+# Emits (in the global _MARKED_TOKEN) the token with:
+#   - quote characters removed (so `"$A"/x`, `"$A/x"` and `$A/x` all normalize
+#     to the same shape and quoting cannot be used to dodge the shape tests),
+#   - backslash escapes applied (the backslash dropped, the escaped character
+#     kept literal),
+#   - every EXPANDABLE `$` replaced by SOH (0x01) — a character no real path
+#     produced by this tokenizer contains — while a LITERAL `$` stays a `$`.
+#
+# A global rather than a subshell echo: this runs per write target and the
+# callers are already in a `while read` loop.
+# =============================================================================
+_MARKED_TOKEN=""
+mark_expandable_dollars() {
+    local tok="$1"
+    local out="" c
+    local n=${#tok}
+    local i=0 in_s=0 in_d=0
+    while [[ $i -lt $n ]]; do
+        c="${tok:i:1}"
+        if [[ $in_s -eq 1 ]]; then
+            # Inside '…': nothing expands; only the closing quote is special.
+            if [[ "$c" == "'" ]]; then in_s=0; else out+="$c"; fi
+            i=$((i + 1))
+            continue
+        fi
+        case "$c" in
+            "'")
+                if [[ $in_d -eq 1 ]]; then out+="$c"; else in_s=1; fi ;;
+            '"')
+                if [[ $in_d -eq 1 ]]; then in_d=0; else in_d=1; fi ;;
+            '\')
+                # Escapes the NEXT character (a trailing backslash is dropped).
+                i=$((i + 1))
+                [[ $i -lt $n ]] && out+="${tok:i:1}" ;;
+            '$')
+                out+=$'\001' ;;
+            *)
+                out+="$c" ;;
+        esac
+        i=$((i + 1))
+    done
+    _MARKED_TOKEN="$out"
+}
+
+# =============================================================================
 # force-op branch-scope toggle — default ALL (preserve current behaviour).
 #
 # The three generic force-op ASK patterns (git push --force / -f /
@@ -2361,6 +2417,46 @@ if worktree_isolation_guard_enabled && \
     [[ -n "$_WT_MAIN_ROOT" ]] || _WT_MAIN_ROOT="$REPO_ROOT"
     [[ -n "$_WT_MAIN_ROOT_LOGICAL" ]] || _WT_MAIN_ROOT_LOGICAL="$_WT_MAIN_ROOT"
 
+    # "Worktree isolation is actually in play for this repo/session" — a
+    # managed worktree exists somewhere under the worktree base derived from
+    # the SAME main-checkout root the containment tests use. Resolved lazily
+    # and cached, so a command with no confinement-relevant target never pays
+    # for the find(1). Defined here (inside the block) because it reads the
+    # block-local _WT_MAIN_ROOT / _WT_WRITE_BASE* state.
+    _wt_isolation_in_play() {
+        if [[ -z "$_WT_WRITE_BASE_DONE" ]]; then
+            _WT_WRITE_BASE=$(resolve_worktree_root "$_WT_MAIN_ROOT")
+            _WT_WRITE_BASE_DONE=1
+        fi
+        _any_managed_worktree_exists "$_WT_WRITE_BASE"
+    }
+
+    # True if $1 (an absolute, normalized path) sits anywhere in the area this
+    # guard protects: inside a managed worktree, inside the main checkout
+    # (either spelling), or under the configured worktree base (which may live
+    # on an external volume, outside the main checkout entirely).
+    _wt_in_protected_area() {
+        local _p="$1"
+        [[ -n "$_p" ]] || return 1
+        _in_any_managed_worktree "$_p" && return 0
+        if [[ -n "$_WT_MAIN_ROOT" ]]; then
+            case "$_p" in
+                "$_WT_MAIN_ROOT"|"$_WT_MAIN_ROOT"/*) return 0 ;;
+                "$_WT_MAIN_ROOT_LOGICAL"|"$_WT_MAIN_ROOT_LOGICAL"/*) return 0 ;;
+            esac
+        fi
+        if [[ -z "$_WT_WRITE_BASE_DONE" ]]; then
+            _WT_WRITE_BASE=$(resolve_worktree_root "$_WT_MAIN_ROOT")
+            _WT_WRITE_BASE_DONE=1
+        fi
+        if [[ -n "$_WT_WRITE_BASE" ]]; then
+            case "$_p" in
+                "$_WT_WRITE_BASE"|"$_WT_WRITE_BASE"/*) return 0 ;;
+            esac
+        fi
+        return 1
+    }
+
     WRITE_TARGETS=$(extract_write_targets "$COMMAND_ASK_SCAN" "$CWD" | head -20)
     while IFS=$'\037' read -r _wcwd _wtarget; do
         [[ -z "$_wtarget" ]] && continue
@@ -2373,6 +2469,127 @@ if worktree_isolation_guard_enabled && \
         # expand_leading_tilde()'s doc comment) — no change to their
         # existing repo-relative treatment.
         _wtarget=$(expand_leading_tilde "$_wtarget")
+
+        # -------------------------------------------------------------
+        # Unresolved `$…` write targets must fail CLOSED, in every cwd (#4921)
+        #
+        # extract_write_targets() never expands variables; a target it cannot
+        # resolve is emitted as the RAW token (`$A/evil.sh`). The resolution
+        # below then treats that literal as a relative path and cwd-prefixes
+        # it — which fabricates a location the write will not actually have.
+        # From a MAIN-CHECKOUT cwd that fabrication happened to land inside
+        # the main checkout, so the containment test denied and the token was
+        # (accidentally) fail-closed. From a LINKED-WORKTREE cwd — the
+        # canonical builder setup, `cd .loom/worktrees/issue-N` — the very
+        # same fabrication instead walks straight back up into the acting
+        # worktree's own `.loom-managed` sentinel, so check (a) below ALLOWED
+        # it before the main-root containment test ever ran, no matter what
+        # the variable would expand to at runtime (#4921). That silently
+        # defeated the fail-closed backstop for every unresolvable `$` shape
+        # (`$(...)`, `${VAR:-x}`, an inherited env var, a chained or
+        # conflicting same-command assignment) in the ONE operating mode the
+        # #4178 guard exists to protect.
+        #
+        # So: decide on the token's SHAPE before trusting either test. A
+        # target is denial-worthy when the unexpanded `$` makes its LOCATION
+        # (not merely its filename) unknowable:
+        #
+        #   (1) the token IS a variable from the root down — it either starts
+        #       with an expandable `$` (`> $DEST`, `tee "${OUT}"`,
+        #       `> $(mktemp)`) or starts with `/$` (`> /$X`, `> /$X/evil`).
+        #       The path root itself is unknown, so the variable may hold (or
+        #       complete) an absolute path into the main checkout and the cwd
+        #       prefix is pure invention. Denied regardless of where cwd is.
+        #   (2) an expandable `$` appears in a DIRECTORY component of the
+        #       resolved path (`> $A/evil`, `> ./$A/evil`, `cd $A && > f`)
+        #       AND the known prefix — everything before the first `$`, i.e.
+        #       the only part that is a real path — is inside the area this
+        #       guard protects, or there is no usable known prefix at all
+        #       (it is relative, or it normalizes to `/` as in
+        #       `> /tmp/../$A/evil`). An unknown directory component under the
+        #       repo can resolve into the main checkout (directly, or via
+        #       `..`), and neither the sentinel walk-up nor the containment
+        #       test can see it.
+        #
+        # Deliberately NOT denied (no new false positives — these keep their
+        # existing treatment):
+        #   - a `$` only in the FINAL component (`> out-$STAMP.log`,
+        #     `sed -i s/a/b/ src/$f`): the directory is fully known and really
+        #     is cwd-relative, so the sentinel check (a) and the main-root
+        #     containment test below are meaningful again.
+        #   - a known prefix OUTSIDE the protected area (`> /tmp/$D/f.log`):
+        #     the write lands where this guard protects nothing.
+        #   - a LITERAL `$` the shell would never expand — inside a
+        #     single-quoted span or backslash-escaped (`> '$A/evil'`) — which
+        #     really is a relative path to a file named `$A` (mirrors the
+        #     quoted-tilde treatment in expand_leading_tilde, #4382).
+        #
+        # Fail-open contract is preserved: like every other deny in this
+        # block, it only fires when a managed worktree actually exists for
+        # this repo (_wt_isolation_in_play).
+        # -------------------------------------------------------------
+        if [[ "$_wtarget" == *'$'* || "$_wcwd" == *'$'* ]]; then
+            mark_expandable_dollars "$_wtarget"
+            _wmarked="$_MARKED_TOKEN"
+            # The cwd itself can carry the unexpanded `$` instead of the
+            # target (`cd $A && echo x > f.sh` — extract_write_targets threads
+            # the unresolved `cd` argument into curcwd), so mark it too and
+            # judge the JOINED path. A cwd that is absolute and `$`-free
+            # marks to itself, leaving every existing case byte-identical.
+            _wmarkedcwd=""
+            if [[ -n "$_wcwd" ]]; then
+                mark_expandable_dollars "$_wcwd"
+                _wmarkedcwd="$_MARKED_TOKEN"
+            fi
+            if [[ "$_wmarked" == *$'\001'* || ( "$_wmarked" != /* && "$_wmarkedcwd" == *$'\001'* ) ]]; then
+                # (1) Root unknown — the token is a variable from the root
+                # down (`$DEST`, `$(mktemp)`) or is root + a variable
+                # (`/$X`, `/$X/evil`, whose runtime value picks the top-level
+                # directory — the main checkout's own included).
+                if [[ "$_wmarked" == $'\001'* || "$_wmarked" == /$'\001'* ]]; then
+                    if _wt_isolation_in_play; then
+                        deny "BLOCKED: Bash-tool write target '${_wtarget}' is an unexpanded shell variable from the path root down, so this guard cannot tell where the write lands — it may resolve to an absolute path inside the main repository checkout ('${_WT_MAIN_ROOT}'), and a Loom-managed worktree exists in this repository. Unresolvable write targets fail closed (#4921). Write to an explicit literal path — inside your issue worktree (.loom/worktrees/issue-<N>) for repo files, or a spelled-out /tmp path for scratch. (#4178)" "worktree-write-confinement-unresolved-var"
+                    fi
+                    continue
+                fi
+                # (2) Unknown DIRECTORY component. Build the effective path
+                # the same way the resolution below does (cwd-joined when
+                # relative), then test only the KNOWN prefix — everything
+                # before the first unexpanded `$`, trimmed to its directory.
+                _weff=""
+                if [[ "$_wmarked" == /* ]]; then
+                    _weff="$_wmarked"
+                elif [[ -n "$_wmarkedcwd" ]]; then
+                    _weff="$_wmarkedcwd/$_wmarked"
+                fi
+                _wdirpart=""
+                [[ "$_weff" == */* ]] && _wdirpart="${_weff%/*}"
+                if [[ "$_wdirpart" == *$'\001'* ]]; then
+                    _wknown="${_weff%%$'\001'*}"
+                    _wknown="${_wknown%/*}"
+                    # Normalize BEFORE judging: a `..` traversal in the known
+                    # prefix (`> /tmp/../$A/evil`) otherwise hands the test a
+                    # prefix that is not where the write actually starts.
+                    [[ "$_wknown" == /* ]] && _wknown=$(normalize_abs_path "$_wknown")
+                    if [[ "$_wknown" != /* || "$_wknown" == "/" ]]; then
+                        # No usable known prefix — either it is relative (no
+                        # cwd to join against) or it collapses to `/`, i.e.
+                        # the first real path component IS the variable
+                        # (`> /$A/evil`, `> /tmp/../$A/evil`), whose runtime
+                        # value picks a top-level directory, the main
+                        # checkout's own included. Same verdict as (1).
+                        if _wt_isolation_in_play; then
+                            deny "BLOCKED: Bash-tool write target '${_wtarget}' has an unexpanded shell variable as its first real path component, so this guard cannot tell where the write lands — it may resolve inside the main repository checkout ('${_WT_MAIN_ROOT}'), and a Loom-managed worktree exists in this repository. Unresolvable write targets fail closed (#4921). Write to an explicit literal path — inside your issue worktree (.loom/worktrees/issue-<N>) for repo files, or a spelled-out /tmp path for scratch. (#4178)" "worktree-write-confinement-unresolved-var"
+                        fi
+                    elif _wt_in_protected_area "$_wknown"; then
+                        if _wt_isolation_in_play; then
+                            deny "BLOCKED: Bash-tool write target '${_wtarget}' contains an unexpanded shell variable in a directory component, and its known prefix ('${_wknown}') is inside this repository's worktree/checkout area — this guard cannot tell whether the expanded path stays in your worktree or lands in the main repository checkout ('${_WT_MAIN_ROOT}'). Unresolvable write targets fail closed (#4921). Write to an explicit literal path — inside your issue worktree (.loom/worktrees/issue-<N>) for repo files, or a spelled-out /tmp path for scratch. (#4178)" "worktree-write-confinement-unresolved-var"
+                        fi
+                    fi
+                    continue
+                fi
+            fi
+        fi
 
         # Resolve to absolute; a relative target with no resolvable cwd is
         # ambiguous — skip it (allow on uncertainty, never deny on it).
@@ -2406,11 +2623,7 @@ if worktree_isolation_guard_enabled && \
         # unaffected, mirroring guard-worktree-paths.sh exactly. The worktree
         # base is resolved off the same main-checkout root so the "a managed
         # worktree exists" gate stays consistent with the containment test.
-        if [[ -z "$_WT_WRITE_BASE_DONE" ]]; then
-            _WT_WRITE_BASE=$(resolve_worktree_root "$_WT_MAIN_ROOT")
-            _WT_WRITE_BASE_DONE=1
-        fi
-        if _any_managed_worktree_exists "$_WT_WRITE_BASE"; then
+        if _wt_isolation_in_play; then
             deny "BLOCKED: Bash-tool write to '${_wabs}' resolves to the main repository checkout ('${_WT_MAIN_ROOT}'), but a Loom-managed worktree exists elsewhere in this repository (this check cannot verify it belongs to the acting session — see #4245). This is a worktree-isolation bypass via Bash redirection/tee/sed -i/cp/mv — do NOT retry the write through Bash. cd into your issue worktree (.loom/worktrees/issue-<N>) and write there instead. (#4178)" "worktree-write-confinement"
         fi
     done <<< "$WRITE_TARGETS"

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -2617,6 +2617,127 @@ assert_allow "write-confinement: CWD=linked worktree, write to /tmp allows (#421
     "echo x > /tmp/loom-test-$$-linked.sh" "$WT_LINKED_DIR"
 
 # -------------------------------------------------------------------------
+# Unresolvable `$…` write targets fail CLOSED from a LINKED-WORKTREE cwd
+# (#4921).
+#
+# extract_write_targets() emits a target it cannot resolve as the RAW token
+# (`$A/evil`), which the resolution then cwd-prefixes as if it were a relative
+# path. From a MAIN-CHECKOUT cwd that fabricated path landed inside the main
+# checkout, so the containment test denied it and the "unresolvable -> fail
+# closed" backstop appeared to hold. From a LINKED-WORKTREE cwd — the
+# canonical builder setup, and the only mode #4178 actually protects — the
+# very same fabricated path walked straight back up into the acting worktree's
+# own `.loom-managed` sentinel and was ALLOWED before the main-root
+# containment test ever ran, whatever the variable would expand to at runtime.
+#
+# Every fixture below therefore uses cwd == WT_LINKED_DIR (a genuine `git
+# worktree add` linked worktree), which is exactly what the pre-#4921 suite
+# never exercised for these shapes — all of its `$`-target coverage ran with
+# cwd == the main checkout, where the bug is invisible.
+UNRESOLVED_MAIN_TARGET="$WT_REPO_LINKED/defaults/hooks"
+
+# Headline repro: a variable that is never assigned anywhere in the command.
+assert_deny "write-confinement (#4921): CWD=linked worktree, unresolvable \$VAR target denies" \
+    "echo x > \$SNEAK_NOT_ASSIGNED_ANYWHERE/evil" "$WT_LINKED_DIR"
+# Same-command CONFLICTING assignment (the shape #4914's record_assign()
+# poisons to unresolvable on purpose) must reach the same fail-closed answer.
+assert_deny "write-confinement (#4921): CWD=linked worktree, conflicting same-command assignment denies" \
+    "A=/tmp/outside
+A=$UNRESOLVED_MAIN_TARGET
+echo x > \$A/evil" "$WT_LINKED_DIR"
+# Shape variants: a leading `./`, surrounding quotes, or `${}` braces must not
+# buy an allow the bare form does not get.
+assert_deny "write-confinement (#4921): CWD=linked worktree, './\$VAR/…' target denies" \
+    "echo x > ./\$SNEAK/evil" "$WT_LINKED_DIR"
+assert_deny "write-confinement (#4921): CWD=linked worktree, double-quoted \"\$VAR\"/… target denies" \
+    "echo x > \"\$SNEAK\"/evil" "$WT_LINKED_DIR"
+assert_deny "write-confinement (#4921): CWD=linked worktree, \${BRACED} target denies" \
+    "echo x > \${SNEAK}/evil" "$WT_LINKED_DIR"
+# A bare `$VAR` with no path separator at all: the variable may itself hold an
+# absolute path into the main checkout, so the root is unknown -> fail closed.
+assert_deny "write-confinement (#4921): CWD=linked worktree, bare '\$VAR' target (no slash) denies" \
+    "cat > \$DEST" "$WT_LINKED_DIR"
+# `$(...)` command substitution is unresolvable in the same way.
+assert_deny "write-confinement (#4921): CWD=linked worktree, \$(...) command-substitution target denies" \
+    "cat > \$(mktemp)" "$WT_LINKED_DIR"
+# Every write idiom, not just `>` redirection.
+assert_deny "write-confinement (#4921): CWD=linked worktree, tee with an unresolvable \$VAR denies" \
+    "echo x | tee \$OUT/f" "$WT_LINKED_DIR"
+assert_deny "write-confinement (#4921): CWD=linked worktree, cp destination \$VAR denies" \
+    "cp /tmp/a.sh \$DEST" "$WT_LINKED_DIR"
+assert_deny "write-confinement (#4921): CWD=linked worktree, sed -i on an unresolvable \$VAR denies" \
+    "sed -i 's/a/b/' \$DEST" "$WT_LINKED_DIR"
+# The unexpanded `$` can arrive through the CWD channel instead of the target
+# (`cd $A` threads an unresolved curcwd into extract_write_targets()).
+assert_deny "write-confinement (#4921): CWD=linked worktree, 'cd \$VAR && relative write' denies" \
+    "cd \$A && echo y > f.sh" "$WT_LINKED_DIR"
+# An absolute prefix INSIDE the worktree plus an unknown directory component:
+# the variable can hold `../..`, so the sentinel walk-up proves nothing.
+assert_deny "write-confinement (#4921): CWD=linked worktree, worktree-absolute path with a \$VAR directory component denies" \
+    "echo x > $WT_LINKED_DIR/\$X/f.sh" "$WT_LINKED_DIR"
+# `/$A/evil` looks absolute but its FIRST component is the variable, so there
+# is no known prefix to judge — the runtime value picks the top-level
+# directory, the main checkout's own included.
+assert_deny "write-confinement (#4921): CWD=linked worktree, '/\$VAR/…' (variable as first component) denies" \
+    "echo x > /\$SNEAK/evil" "$WT_LINKED_DIR"
+# `/$A` with NO further slash is the same shape — a shell variable's value can
+# contain `/`, so "the final component" is a fiction when that component is
+# everything below the root.
+assert_deny "write-confinement (#4921): CWD=linked worktree, '/\$VAR' (whole path below root is the variable) denies" \
+    "echo x > /\$SNEAK" "$WT_LINKED_DIR"
+# A `..` traversal inside the KNOWN prefix must be normalized before the
+# prefix is judged, or `/tmp/../\$A/evil` hands the test a prefix (`/tmp`) that
+# is not where the write actually starts — it collapses to `/`, i.e. the first
+# real component is the variable again.
+assert_deny "write-confinement (#4921): CWD=linked worktree, known prefix that collapses to '/' via '..' denies" \
+    "echo x > /tmp/../\$SNEAK/evil" "$WT_LINKED_DIR"
+
+# --- No new false positives (all from the same linked-worktree cwd) ---
+# A `$` only in the FINAL path component leaves the directory fully known and
+# genuinely cwd-relative -> the ordinary worktree/main-root logic still applies.
+assert_allow "write-confinement (#4921): CWD=linked worktree, \$VAR only in the filename allows" \
+    "echo x > out-\$STAMP.log" "$WT_LINKED_DIR"
+assert_allow "write-confinement (#4921): CWD=linked worktree, known worktree subdir + \$VAR filename allows" \
+    "echo x > src/\$f.txt" "$WT_LINKED_DIR"
+# A known prefix OUTSIDE the protected area (e.g. /tmp) protects nothing.
+assert_allow "write-confinement (#4921): CWD=linked worktree, /tmp prefix with a \$VAR directory component allows" \
+    "echo x > /tmp/loom-test-\$STAMP/f.log" "$WT_LINKED_DIR"
+# A `$` a real shell would NEVER expand is literal data, not an unknown path:
+# single-quoted and backslash-escaped forms keep their existing treatment
+# (mirrors the quoted-tilde rule of #4382).
+assert_allow "write-confinement (#4921): CWD=linked worktree, single-quoted '\$A/…' is literal (shell never expands it) and allows" \
+    "echo x > '\$A/evil'" "$WT_LINKED_DIR"
+assert_allow "write-confinement (#4921): CWD=linked worktree, backslash-escaped \\\$A/… is literal and allows" \
+    "echo x > \\\$A/evil" "$WT_LINKED_DIR"
+# The filename-only exemption must NOT become a hole into the main checkout:
+# the directory is fully known there, so the ordinary containment test still
+# runs and still denies.
+assert_deny "write-confinement (#4921): CWD=linked worktree, \$VAR filename under a MAIN-checkout dir still denies" \
+    "echo x > $UNRESOLVED_MAIN_TARGET/out-\$STAMP.log" "$WT_LINKED_DIR"
+# A `$` that is only quoted DATA in a message argument (never a write target)
+# must not manufacture a deny — the quote-aware `>` scan of #4245/#4289 and the
+# literal-text redaction still decide that, unchanged.
+assert_allow "write-confinement (#4921): CWD=linked worktree, quoted '>' and '\$' inside a commit message allows" \
+    "git commit -m \"price > \$5 total\"" "$WT_LINKED_DIR"
+# Regression: ordinary in-worktree and /tmp writes are untouched.
+assert_allow "write-confinement (#4921): CWD=linked worktree, plain in-worktree write still allows" \
+    "echo x > $WT_LINKED_DIR/src/plain.sh" "$WT_LINKED_DIR"
+
+# The pre-existing MAIN-checkout-cwd behaviour for the same command must not
+# change (it was already fail-closed there -- #4921 makes the two cwds agree,
+# it does not relax either one).
+assert_deny "write-confinement (#4921): CWD=main checkout, unresolvable \$VAR target still denies" \
+    "echo x > \$SNEAK_NOT_ASSIGNED_ANYWHERE/evil" "$WT_REPO_LINKED"
+
+# Fail-open contract: with no managed worktree anywhere, an unresolvable
+# target is allowed exactly like every other write in that repo.
+assert_allow "write-confinement (#4921): no managed worktree anywhere -> unresolvable \$VAR allows (fail-open)" \
+    "echo x > \$SNEAK/evil" "$WT_REPO_NOWT"
+# And the category toggle still switches the whole check off.
+assert_allow_env "write-confinement (#4921): LOOM_GUARD_WORKTREE_ISOLATION=0 -> unresolvable \$VAR allows" \
+    "LOOM_GUARD_WORKTREE_ISOLATION=0" "echo x > \$SNEAK/evil" "$WT_LINKED_DIR"
+
+# -------------------------------------------------------------------------
 # Tilde expansion for write targets (#4382, same fix family as #4245/#4289's
 # quote-aware `>` scanning). Reported incident: `cp <built-binary>
 # ~/.local/bin/loom-daemon` from a main-checkout cwd was denied because the


### PR DESCRIPTION
## Summary

The Bash-tool write-confinement guard's "unresolvable `$VAR` → fail closed"
backstop was silently defeated whenever the acting cwd was a genuine **linked
worktree** — i.e. the canonical builder operating mode (`cd
.loom/worktrees/issue-N`) and the only mode #4178 exists to protect.

`extract_write_targets()` is a tokenizer, not a shell evaluator: a target it
cannot resolve is emitted as the **raw token** (`$A/evil`), and the
confinement block then treated that literal as a *relative path* and
cwd-prefixed it. From a **main-checkout** cwd the fabricated path landed inside
the main checkout, so the containment test denied and the backstop looked
intact. From a **linked-worktree** cwd the very same fabricated path walked
straight back up into the acting worktree's own `.loom-managed` sentinel
(`_in_any_managed_worktree`) and was **allowed** before the main-root
containment test ever ran — whatever the variable would expand to at runtime.

Pre-existing on `main`; confirmed reproducing on the isolated fixture from the
issue body before the fix (all `$`-shape cases ALLOW) and denying after it.

## Changes

- **`mark_expandable_dollars()`** (new helper): normalizes a raw write-target
  token to its *effective path shape* — quote characters removed, backslash
  escapes applied, and every **expandable** `$` marked with SOH. A `$` inside a
  single-quoted span or backslash-escaped is literal data and stays a `$`,
  mirroring the quoted-tilde rule of `expand_leading_tilde()` (#4382).
- **Shape decision before containment.** A target is denied when its
  *location* (not merely its filename) is unknowable:
  - the token is a variable from the root down — `> $DEST`, `tee "${OUT}"`,
    `> $(mktemp)`, `> /$X`, `> /$X/evil`;
  - an expandable `$` sits in a **directory component** and the known prefix is
    inside the repo/worktree area (`> $A/evil`, `> ./$A/evil`, `cd $A && > f`,
    `> <worktree>/$A/f`), or there is no usable known prefix because it
    collapses to `/` (`> /tmp/../$A/evil` — the prefix is normalized *before*
    it is judged, so a `..` traversal cannot manufacture a benign prefix).
- **No new false positives** for shapes that lose no information: a `$` only in
  the final filename (`> out-$STAMP.log` — the directory is fully known, so the
  ordinary containment test still runs and still denies a main-checkout
  directory), a known prefix outside the protected area (`> /tmp/$D/f.log`),
  and a `$` a real shell would never expand (`> '$A/evil'`, `> \$A/evil`).
- **Fail-open contract preserved**: the new deny fires only when a managed
  worktree actually exists (`_wt_isolation_in_play`, factored out of the
  existing inline `_WT_WRITE_BASE` resolution and reused), and the
  `guards.worktreeIsolation` / `LOOM_GUARD_WORKTREE_ISOLATION` toggle still
  switches the whole check off.
- **26 new assertions** in `tests/hooks/test-guard-destructive.sh`, every one
  with `cwd` set to a genuine `git worktree add` linked worktree — the shape no
  existing fixture in the suite used for these commands, which is exactly why
  the gap was untested.
- `defaults/docs/guard-hooks.md`: documents the denied/not-denied shape table
  and the workaround (spell the path literally).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Unresolvable `$VAR` (or #4914's poisoned-to-unresolvable shape) from a linked-worktree cwd is **denied**, not silently allowed | ✅ | Both repro scripts from the issue body run against the isolated fixture: ALLOW on `origin/main`, DENY after the fix (`worktree-write-confinement-unresolved-var`). Also covered by new assertions. |
| Does not weaken the legitimate case (a) — genuine writes inside a managed worktree still allowed, no false-positive deny | ✅ | `echo x > <worktree>/src/f.sh`, `cd <worktree> && echo x > src/f.sh`, `> out-$STAMP.log`, `> src/$f.txt`, `> /tmp/…-$STAMP/f.log`, `> '$A/evil'`, `> \$A/evil`, `git commit -m "price > $5"` all still ALLOW (asserted). |
| Suite gains ≥1 fixture with `cwd` set to a linked worktree covering the exact repro | ✅ | 26 new assertions, all `cwd == WT_LINKED_DIR` (`make_wt_repo_linked`), including the verbatim `echo x > $SNEAK_NOT_ASSIGNED_ANYWHERE/evil` and the conflicting-assignment shape. |
| All existing assertions continue to pass | ✅ | `tests/hooks/test-guard-destructive.sh`: **592 / 592 passed, 0 failed** (566 pre-existing + 26 new). Includes the #4178 / #4210 / #4245 / #4382 / #4495 write-confinement cases and the #3679 command-substitution smuggling floor. |

## Test Plan

- `bash tests/hooks/test-guard-destructive.sh` → **Total 592, Passed 592,
  Failed 0**.
- `bash tests/hooks/test-guard-destructive-dispatcher.sh` → **12 passed, 0
  failed**.
- `shellcheck -S warning` on both changed shell files → clean (one pre-existing
  SC2034 in the unrelated perf loop).
- Manual, against the isolated fixture from the issue body (throwaway repo +
  registered `.loom/worktrees/wt1` managed worktree), `origin/main` vs. this
  branch:

  | Case (cwd = linked worktree) | `origin/main` | this branch |
  |---|---|---|
  | literal write to main checkout (sanity) | DENY | DENY |
  | `echo x > $SNEAK_NOT_ASSIGNED_ANYWHERE/evil` | **ALLOW** | DENY |
  | conflicting same-command assignment → `$A/evil` | **ALLOW** | DENY |
  | `cat > $DEST` / `cat > $(mktemp)` | **ALLOW** | DENY |
  | `cd $A && echo y > f.sh` | **ALLOW** | DENY |
  | `echo x > /$SNEAK/evil` | **ALLOW** | DENY |
  | `> out-$STAMP.log`, `> /tmp/$D/f.log`, `> '$A/evil'`, `> \$A/evil` | ALLOW | ALLOW |
  | same unresolvable target from a **main-checkout** cwd | DENY | DENY |
  | same target in a repo with **no** managed worktree (fail-open) | ALLOW | ALLOW |

## Note for the reviewer (out of scope, filed separately)

While building the fixture I found a **separate, larger pre-existing bypass in
the same block**: simply **quoting** the target defeats write-confinement
entirely — `echo x > "/abs/path/into/main/checkout/evil"` is ALLOWED from any
cwd (including the main checkout), because `qsplit()` preserves quote
characters verbatim so `[[ "$_wtarget" == /* ]]` is false and the absolute path
is misclassified as relative. Verified on `origin/main` and against the real
repo. It is independent of the `$`-shape logic here, so I filed it as **#4926**
rather than widening this PR's blast radius on a security-critical file.

Closes #4921
