### PR TITLE
fix(hooks): strip quotes before classifying a Bash write target as absolute

### DIFF
--- a/defaults/docs/guard-hooks.md
+++ b/defaults/docs/guard-hooks.md
@@ -427,6 +427,27 @@ target derived from a variable that would land *outside* the repo entirely
 (`> $HOME/x`, `> $TMPDIR/f`): the guard cannot know that at scan time, and
 fail-closed on an unknowable location is the whole point of the rule.
 
+**Quoted targets are still absolute (issue #4926).** The same classification had
+a second way to be fooled, reached without any `$` at all: the tokenizer copies
+a token's quote characters **verbatim** (`qsplit()`'s contract, #3755 — the `rm`
+and force-op consumers depend on that raw form), so a quoted absolute path
+arrived as `'/main/evil'` / `"/main/evil"`, failed the `== /*` test because it
+starts with a quote rather than a `/`, and was treated as **relative** and
+cwd-prefixed. From a main-checkout cwd the fabricated path happened to stay
+inside the main checkout and denied by accident; from a **linked-worktree** cwd
+it walked back into the acting worktree's own sentinel and was **allowed** —
+i.e. one pair of quotes defeated the whole #4178 check, for every idiom (`>`,
+`>>`, `tee`, `sed -i`, `cp`, `mv`). The write-confinement consumer now applies
+shell-accurate quote removal and backslash unescaping to a **copy** of the token
+before deciding absolute-vs-relative (`strip_target_quoting()`, sharing its
+scanner with `mark_expandable_dollars()` so the two can never disagree about the
+quoting grammar). Scope and fallbacks: `extract_rm_targets()` / `parse_force_ops()`
+keep their verbatim tokens and the deny message still quotes what the operator
+typed; `$`/`~` are copied through untouched, so a file genuinely named `$X` or
+`~` (single-quoted or escaped) is still a plain relative literal (#4382 / #4921
+unchanged); and an **unterminated** quote falls back to the raw token — today's
+verdict in both directions, never widening a deny into an allow.
+
 The guard is **on by default**. It is resolved in this order (highest precedence first):
 
 1. **`LOOM_GUARD_WORKTREE_ISOLATION` env var** — `0`/`false`/`no` disables the guard; `1`/`true`/`yes` forces it on. Overrides the config value.

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -983,10 +983,72 @@ _any_managed_worktree_exists() {
 #
 # A global rather than a subshell echo: this runs per write target and the
 # callers are already in a `while read` loop.
+#
+# Implemented on top of the shared scanner below so the write-confinement
+# block has exactly ONE definition of "what the shell would do to these
+# quotes" — a second, hand-copied quote parser is precisely how the two
+# consumers would drift apart, and a drift in this grammar IS a guard bypass.
 # =============================================================================
 _MARKED_TOKEN=""
 mark_expandable_dollars() {
-    local tok="$1"
+    _scan_token_quoting "$1" $'\001'
+    _MARKED_TOKEN="$_SCANNED_TOKEN"
+}
+
+# =============================================================================
+# strip_target_quoting() — shell-accurate quote removal + backslash
+# unescaping for the write-confinement absolute/relative classification
+# (#4926).
+#
+# extract_write_targets() emits tokens with their quote characters preserved
+# VERBATIM (qsplit's contract, #3755) — extract_rm_targets() and
+# parse_force_ops() depend on that raw form and MUST keep receiving it
+# unchanged, so this is called ONLY from the write-confinement classification
+# below, never from qsplit()/extract_write_targets() themselves. Without it a
+# quoted absolute path (`'/main/evil'`, `"/main/evil"`) starts with a quote
+# character rather than `/`, so the `[[ … == /* ]]` check misclassifies it as
+# RELATIVE and cwd-prefixes it into a location the write will never have.
+# From a LINKED-WORKTREE cwd — the canonical builder setup — that fabrication
+# walks straight back into the acting worktree's own `.loom-managed` sentinel
+# and is silently ALLOWED, defeating the #4178 confinement check by simply
+# quoting the target (the same masked-allow shape as the unresolved-`$`
+# bypass fixed by #4921/#4927, reached here through quoting instead).
+#
+# Emits (in the global _UNQUOTED_TARGET) the token with quote characters
+# removed and backslash escapes applied, and every other character —
+# INCLUDING `$` — copied through unchanged: any expandable-`$` shape was
+# already judged by the dedicated unresolved-`$` block above, so a file
+# genuinely named `$X` or `~` (single-quoted or backslash-escaped) unquotes
+# to the literal `$X`/`~` and still resolves as a plain relative path,
+# exactly as today (#4382 / #4921 contracts preserved).
+#
+# Returns 0 when every quote in the token is balanced (the caller may use
+# _UNQUOTED_TARGET). Returns 1 on an unterminated quote — the caller MUST
+# then fall back to the raw, quote-preserved token, so an unbalanced quote
+# can only ever keep today's verdict, never widen a deny into an allow.
+# =============================================================================
+_UNQUOTED_TARGET=""
+strip_target_quoting() {
+    local rc=0
+    _scan_token_quoting "$1" "" || rc=1
+    _UNQUOTED_TARGET="$_SCANNED_TOKEN"
+    return "$rc"
+}
+
+# =============================================================================
+# _scan_token_quoting() — the single shell-accurate quote-removal /
+# backslash-unescaping pass shared by the two helpers above.
+#
+#   $1  raw token (quote characters preserved verbatim, per qsplit's contract)
+#   $2  text substituted for each EXPANDABLE `$`; empty keeps the `$` literal
+#
+# Sets _SCANNED_TOKEN. Returns 0 when every quote was closed, 1 when the token
+# ended inside an unterminated quote (callers decide the fallback; no caller
+# may treat an unterminated quote as license to widen an allow).
+# =============================================================================
+_SCANNED_TOKEN=""
+_scan_token_quoting() {
+    local tok="$1" dollar="$2"
     local out="" c
     local n=${#tok}
     local i=0 in_s=0 in_d=0
@@ -1008,13 +1070,14 @@ mark_expandable_dollars() {
                 i=$((i + 1))
                 [[ $i -lt $n ]] && out+="${tok:i:1}" ;;
             '$')
-                out+=$'\001' ;;
+                if [[ -n "$dollar" ]]; then out+="$dollar"; else out+="$c"; fi ;;
             *)
                 out+="$c" ;;
         esac
         i=$((i + 1))
     done
-    _MARKED_TOKEN="$out"
+    _SCANNED_TOKEN="$out"
+    [[ $in_s -eq 0 && $in_d -eq 0 ]]
 }
 
 # =============================================================================
@@ -2591,13 +2654,25 @@ if worktree_isolation_guard_enabled && \
             fi
         fi
 
+        # Shell-accurate quote removal, for the classification only (#4926):
+        # `'/main/evil'` / `"/main/evil"` reach here with their quote
+        # characters intact (qsplit's contract), so they start with a quote
+        # rather than `/` and the test below would call an ABSOLUTE path
+        # relative and cwd-prefix it into a location the write never has.
+        # Unquote a COPY: extract_rm_targets()/parse_force_ops() keep their
+        # verbatim tokens, and the deny message below still quotes the raw
+        # `$_wtarget` the operator actually typed. An unterminated quote keeps
+        # the raw token (today's verdict) rather than risk widening a deny.
+        _wclassify="$_wtarget"
+        strip_target_quoting "$_wtarget" && _wclassify="$_UNQUOTED_TARGET"
+
         # Resolve to absolute; a relative target with no resolvable cwd is
         # ambiguous — skip it (allow on uncertainty, never deny on it).
         _wabs=""
-        if [[ "$_wtarget" == /* ]]; then
-            _wabs="$_wtarget"
+        if [[ "$_wclassify" == /* ]]; then
+            _wabs="$_wclassify"
         elif [[ -n "$_wcwd" ]]; then
-            _wabs="$_wcwd/$_wtarget"
+            _wabs="$_wcwd/$_wclassify"
         else
             continue
         fi

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -2791,6 +2791,89 @@ assert_deny "write-confinement (#4382): non-leading tilde ('backup~/f.sh') is no
 assert_deny "write-confinement (#4382): unresolvable '~nonexistentuser/' falls back to literal repo-relative path, still denies" \
     "cp /tmp/a.sh ~nonexistentloomuser999/defaults/hooks/f.sh" "$WT_REPO"
 
+# -------------------------------------------------------------------------
+# Quoted write targets are still classified as ABSOLUTE (#4926).
+#
+# extract_write_targets() emits a token with its quote characters preserved
+# VERBATIM (qsplit's contract, #3755). A quoted absolute path -- '/main/evil'
+# or "/main/evil" -- therefore starts with a quote character, not `/`, so the
+# `[[ … == /* ]]` classification called it RELATIVE and cwd-prefixed it into a
+# location the write will never actually have. From a MAIN-CHECKOUT cwd that
+# fabrication still happened to land inside the main checkout, so the deny
+# fired by accident. From a LINKED-WORKTREE cwd -- the canonical builder setup
+# -- the very same fabrication instead walked back into the acting worktree's
+# OWN `.loom-managed` sentinel and was silently ALLOWED, defeating the headline
+# #4178 protection with one pair of quotes (the same masked-allow shape as the
+# unresolved-`$` bypass fixed by #4921/#4927, reached through quoting instead).
+#
+# Every write idiom the unquoted fixtures above cover, in BOTH quote styles,
+# from BOTH cwd modes.
+for _q4926 in "'" '"'; do
+    assert_deny "write-confinement (#4926): CWD=main checkout, ${_q4926}-quoted echo > main-checkout path denies" \
+        "echo x > ${_q4926}$WT_REPO/defaults/hooks/f.sh${_q4926}" "$WT_REPO"
+    assert_deny "write-confinement (#4926): CWD=main checkout, ${_q4926}-quoted echo >> main-checkout path denies" \
+        "echo x >> ${_q4926}$WT_REPO/defaults/hooks/f.sh${_q4926}" "$WT_REPO"
+    assert_deny "write-confinement (#4926): CWD=main checkout, ${_q4926}-quoted tee main-checkout path denies" \
+        "echo x | tee ${_q4926}$WT_REPO/defaults/hooks/f.sh${_q4926}" "$WT_REPO"
+    assert_deny "write-confinement (#4926): CWD=main checkout, ${_q4926}-quoted sed -i on main-checkout path denies" \
+        "sed -i 's/a/b/' ${_q4926}$WT_REPO/defaults/hooks/f.sh${_q4926}" "$WT_REPO"
+    assert_deny "write-confinement (#4926): CWD=main checkout, ${_q4926}-quoted cp destination in main checkout denies" \
+        "cp /tmp/a.sh ${_q4926}$WT_REPO/defaults/hooks/f.sh${_q4926}" "$WT_REPO"
+    assert_deny "write-confinement (#4926): CWD=main checkout, ${_q4926}-quoted mv destination in main checkout denies" \
+        "mv /tmp/a.sh ${_q4926}$WT_REPO/defaults/hooks/f.sh${_q4926}" "$WT_REPO"
+
+    # These twelve are the actual bypass: every one of them ALLOWED pre-#4926.
+    assert_deny "write-confinement (#4926): CWD=linked worktree, ${_q4926}-quoted echo > main-checkout path denies" \
+        "echo x > ${_q4926}$WT_REPO_LINKED/defaults/hooks/f.sh${_q4926}" "$WT_LINKED_DIR"
+    assert_deny "write-confinement (#4926): CWD=linked worktree, ${_q4926}-quoted echo >> main-checkout path denies" \
+        "echo x >> ${_q4926}$WT_REPO_LINKED/defaults/hooks/f.sh${_q4926}" "$WT_LINKED_DIR"
+    assert_deny "write-confinement (#4926): CWD=linked worktree, ${_q4926}-quoted tee main-checkout path denies" \
+        "echo x | tee ${_q4926}$WT_REPO_LINKED/defaults/hooks/f.sh${_q4926}" "$WT_LINKED_DIR"
+    assert_deny "write-confinement (#4926): CWD=linked worktree, ${_q4926}-quoted sed -i on main-checkout path denies" \
+        "sed -i 's/a/b/' ${_q4926}$WT_REPO_LINKED/defaults/hooks/f.sh${_q4926}" "$WT_LINKED_DIR"
+    assert_deny "write-confinement (#4926): CWD=linked worktree, ${_q4926}-quoted cp destination in main checkout denies" \
+        "cp /tmp/a.sh ${_q4926}$WT_REPO_LINKED/defaults/hooks/f.sh${_q4926}" "$WT_LINKED_DIR"
+    assert_deny "write-confinement (#4926): CWD=linked worktree, ${_q4926}-quoted mv destination in main checkout denies" \
+        "mv /tmp/a.sh ${_q4926}$WT_REPO_LINKED/defaults/hooks/f.sh${_q4926}" "$WT_LINKED_DIR"
+done
+unset _q4926
+
+# Sibling-allow checks: quote removal changes only the absolute/relative
+# CLASSIFICATION -- it must never widen the containment test itself, so a
+# quoted target genuinely inside the worktree, or in /tmp, still allows.
+assert_allow "write-confinement (#4926): CWD=linked worktree, double-quoted write inside the worktree allows" \
+    "echo x > \"$WT_LINKED_DIR/src/f.sh\"" "$WT_LINKED_DIR"
+assert_allow "write-confinement (#4926): CWD=linked worktree, single-quoted write to /tmp allows" \
+    "echo x > '/tmp/loom-test-$$-quoted.sh'" "$WT_LINKED_DIR"
+
+# Regression guard for the #4382 / #4921 contracts: a file genuinely named
+# literally `$X` or `~` (single-quoted or backslash-escaped) is NOT an
+# expansion -- strip_target_quoting() removes the quote characters but leaves
+# `$`/`~` untouched, so these keep resolving as plain relative literals
+# (allowed here, since they land inside the worktree the write runs from) and
+# still deny when that relative literal sits under the main checkout.
+assert_allow "write-confinement (#4926): CWD=linked worktree, single-quoted literal '\$X' filename allows (not a \$-expansion)" \
+    "echo x > '\$X'" "$WT_LINKED_DIR"
+assert_allow "write-confinement (#4926): CWD=linked worktree, backslash-escaped literal \\\$X filename allows (not a \$-expansion)" \
+    "echo x > \\\$X" "$WT_LINKED_DIR"
+assert_allow "write-confinement (#4926): CWD=linked worktree, single-quoted literal '~evil' filename allows (not tilde-expanded)" \
+    "echo x > '~evil'" "$WT_LINKED_DIR"
+assert_deny "write-confinement (#4926): CWD=linked worktree, single-quoted literal '\$X' filename UNDER the main checkout still denies" \
+    "echo x > '$WT_REPO_LINKED/defaults/hooks/\$X'" "$WT_LINKED_DIR"
+
+# Unbalanced/unterminated quote: strip_target_quoting() reports failure and the
+# caller falls back to the raw, quote-preserved token -- i.e. today's verdict,
+# unchanged in BOTH directions. From a main-checkout cwd the raw token is still
+# read as relative and cwd-joined back inside the main checkout (deny); from a
+# linked-worktree cwd the same fabrication still lands in the worktree's own
+# sentinel (allow). The second case is NOT a regression -- it was already an
+# allow pre-#4926; it pins that the fallback never widens a deny into an allow
+# and never narrows an allow into a deny.
+assert_deny "write-confinement (#4926): CWD=main checkout, unbalanced leading single-quote keeps today's deny" \
+    "echo x > '$WT_REPO/defaults/hooks/f.sh" "$WT_REPO"
+assert_allow "write-confinement (#4926): CWD=linked worktree, unbalanced leading single-quote keeps today's allow" \
+    "echo x > '$WT_REPO_LINKED/defaults/hooks/f.sh" "$WT_LINKED_DIR"
+
 rm -rf "$HOME_FIXTURE_OUTSIDE"
 rm -rf "$WT_REPO" "$WT_REPO_NOWT" "$WT_REPO_OFF" "$WT_REPO_LINKED"
 


### PR DESCRIPTION
## Summary

`guard-destructive-generic.sh`'s Bash-tool write-confinement check (#4178) was
defeated by one pair of quotes. `extract_write_targets()` emits tokens with their
quote characters preserved **verbatim** (`qsplit()`'s contract, #3755 — `extract_rm_targets()`
and `parse_force_ops()` depend on that raw form), so a quoted absolute path reached
the classification as `'/main/evil'` / `"/main/evil"` — starting with a quote, not a
`/`. The `[[ "$_wtarget" == /* ]]` test therefore called an **absolute** path
**relative** and cwd-prefixed it into a location the write never has.

From a **main-checkout** cwd that fabrication happened to stay inside the main
checkout, so it denied by accident. From a **linked-worktree** cwd — the canonical
builder setup, and the only mode #4178 exists to protect — the same fabrication
walked back into the acting worktree's own `.loom-managed` sentinel and was
silently **ALLOWED**, for every write idiom (`>`, `>>`, `tee`, `sed -i`, `cp`, `mv`).
Verified against `origin/main`: all 12 linked-worktree quoted forms allow pre-fix,
all deny post-fix (see Test Plan).

This is the same masked-allow shape as the unresolved-`$` bypass fixed by #4921 /
PR #4927, reached through quoting instead of through `$`.

## Changes

- **`defaults/hooks/guard-destructive-generic.sh`**
  - New `strip_target_quoting()` — shell-accurate quote removal + backslash
    unescaping, applied to a **copy** of the token (`_wclassify`) used only for the
    absolute/relative decision and to build `_wabs`. `extract_rm_targets()` /
    `parse_force_ops()` keep their verbatim tokens, and the deny message still
    quotes the raw `$_wtarget` the operator typed.
  - `mark_expandable_dollars()` (#4927) and `strip_target_quoting()` now share a
    single scanner, `_scan_token_quoting()` (`$2` = the substitution for an
    expandable `$`; empty keeps it literal). A second hand-copied quote parser is
    exactly how the two consumers would drift apart, and a drift in this grammar is
    itself a guard bypass — so there is now one definition of the quoting rules.
    `mark_expandable_dollars()`'s behavior is unchanged (all pre-existing #4921
    fixtures pass).
  - `$` and `~` are copied through untouched: any expandable-`$` shape was already
    judged by the dedicated unresolved-`$` block that runs first, so a file
    genuinely named `$X` or `~` stays a plain relative literal.
- **`tests/hooks/test-guard-destructive.sh`** — 32 new fixtures (below).
- **`defaults/docs/guard-hooks.md`** — a short paragraph documenting the quoted-target
  classification, alongside the existing #4178 / #4921 write-confinement writeups.

## Acceptance Criteria Verification

- [x] A quoted absolute write target (single- or double-quoted, e.g. `'/main/evil'` or
      `"/main/evil"`) is correctly classified as **absolute**, not cwd-relative, before
      the `[[ … == /* ]]` check.
      — `strip_target_quoting()` runs immediately before the classification and feeds
      it `_wclassify`; verified by the 24 quoted-idiom fixtures.
- [x] `DENY` fires for the quoted forms of every write idiom already covered unquoted
      (`>`, `>>`, `tee`, `cp`, `mv`, `sed -i`) when the resolved target is inside the
      main checkout, from BOTH a main-checkout cwd and a linked-worktree cwd.
      — 2 quote styles x 6 idioms x 2 cwd modes = 24 `assert_deny` fixtures, all
      passing; the 12 linked-worktree ones all **allowed** on `origin/main`.
- [x] A file genuinely named literally `$X` or `~` (single-quoted or backslash-escaped)
      still resolves as a relative literal, not an expansion.
      — 3 `assert_allow` fixtures (`'$X'`, `\$X`, `'~evil'`) plus one `assert_deny`
      proving the same literal **under** the main checkout still denies; the
      pre-existing #4382 quoted/escaped-tilde and #4921 literal-`$` fixtures also
      still pass.
- [x] Unbalanced/unterminated quotes fall back to today's behavior (never widen an
      existing deny into an allow).
      — `strip_target_quoting()` returns 1 on an unterminated quote and the caller
      keeps the raw token. Pinned in **both** directions: unbalanced quote from a
      main-checkout cwd still denies, and from a linked-worktree cwd still allows
      (it was already an allow pre-#4926 — the fixture asserts the fallback changes
      neither verdict).
- [x] `extract_rm_targets()` and `parse_force_ops()` continue to receive verbatim
      (quote-preserved) tokens — fix is scoped to the write-confinement consumer only.
      — Neither function nor `qsplit()` is touched; `strip_target_quoting()` has
      exactly one call site, in the write-confinement classification. The full
      `rm`-scope and force-op fixture blocks pass unchanged.
- [x] New fixtures added to `tests/hooks/test-guard-destructive.sh` asserting `DENY`
      for the quoted forms of each write idiom above, from both cwd modes, alongside
      the existing unquoted write-confinement fixtures.

## Test Plan

- [x] `./tests/hooks/test-guard-destructive.sh` — **624 passed, 0 failed** (exit 0),
      up from 592, including all pre-existing unquoted / `~` (#4382) / `$VAR` (#4921)
      write-confinement fixtures.
- [x] `./tests/hooks/test-guard-destructive-dispatcher.sh` — 12 passed, 0 failed
      (the `worktree-write-confinement` capability-probe tag is unchanged).
- [x] `./tests/hooks/test-guard-loom-workflow.sh` — all passed.
- [x] Manual repro from the issue body, run against **both** the `origin/main` guard
      and the fixed guard on the same throwaway fixture repo (real `git worktree` +
      `.loom-managed` sentinel), 34 probes each:
      - `origin/main`: all 12 main-checkout-cwd quoted forms deny; **all 12
        linked-worktree-cwd quoted forms ALLOW** (the bypass), and the literal-`$X`-under-
        main-root case allows.
      - fixed: all 24 deny; the unquoted control still denies; quoted in-worktree and
        quoted `/tmp` writes still allow; literal `$X` / `\$X` / `~evil` still allow;
        unbalanced-quote verdicts unchanged in both cwd modes.
- [x] `bash -n` on both changed shell files; `shellcheck -S warning` reports only the
      pre-existing `SC2034` at `tests/hooks/test-guard-destructive.sh` (present
      identically on `origin/main`, and outside the `defaults/scripts/**` scope CI lints).

## Notes for the reviewer (out of scope, not regressions)

Two adjacent bypasses of the *same* classification exist **both before and after** this
PR — I probed each against `origin/main` and the fixed guard and got an identical
`allow` in both, so neither is introduced or widened here, and neither is in this
issue's acceptance criteria. Filing them as their own issues rather than widening this
security-critical diff (the same convention #4926 itself followed from #4921):

1. **Quoted `cd` argument** — `cd '/main' && echo x > defaults/hooks/f.sh` from a
   worktree cwd. The absolute/relative decision for the `cd` argument is made inside
   `extract_write_targets()`'s awk (`toks[2] ~ /^\//`), before any shell-side
   unquoting can reach it, so a shell-layer fix cannot close it.
2. **Quoted path containing whitespace** — `echo x > '/main/defaults/hooks/f g.sh'`.
   `extract_write_targets()` splits tokens on whitespace, so a path with a space is
   never one token regardless of quoting; this is the tokenizer's pre-existing
   documented limitation, not a quoting bug.

Closes #4926
